### PR TITLE
solved problem with test_netcdf

### DIFF
--- a/pymatgen/io/abinitio/tests/test_netcdf.py
+++ b/pymatgen/io/abinitio/tests/test_netcdf.py
@@ -12,7 +12,7 @@ import numpy.testing.utils as nptu
 
 test_dir = os.path.join(os.path.dirname(__file__))
 
-def netcdf_version():
+def get_netcdf_version():
     """
     Returns the Netcdf version we can read with the available libraries. 
     0 if not library is found.
@@ -27,6 +27,8 @@ def netcdf_version():
         except ImportError:
             return 0
 
+NC_VERSION = get_netcdf_version()
+
 def filepath(basename):
     return os.path.join(test_dir, basename)
 
@@ -38,7 +40,7 @@ class GSR_Reader_TestCase(PymatgenTest):
         for formula in formulas:
             d[formula] = filepath(formula + "_GSR.nc")
 
-    @unittest.skipIf(netcdf_version == 0, "Requires Netcdf IO-library")
+    @unittest.skipIf(NC_VERSION==4, "Requires Netcdf4")
     def test_read_Si2(self):
         path = self.GSR_paths["Si2"]
 
@@ -57,7 +59,6 @@ class GSR_Reader_TestCase(PymatgenTest):
             self.assertEqual(data.ngroups, 1)
 
             print(data.get_varnames())
-            data.print_tree()
 
             # Test int variables
             for (varname, int_ref) in ref_int_values.items():
@@ -71,6 +72,7 @@ class GSR_Reader_TestCase(PymatgenTest):
                                                                     
                 self.assert_almost_equal(value, float_ref)
 
+            data.print_tree()
             for group in data.walk_tree():
                 print("group: " + str(group))
 


### PR DESCRIPTION
Hi Shyue, 

the problem with the netcdf test is hopefully solved in this revision. I was trying to support both scipy.io.netcdf as well as netcdf4 although the two APIs are not 100% compatible. netcdf4 is more flexible that the interface provided by scipy that only supports netcdf3. Now the test is skipped if netcdf4 is not available. Future versions of abinitio will require netcdf4  
