### PR TITLE
matproj.snl: set pybtex strict mode False (>=0.18)

### DIFF
--- a/pymatgen/matproj/snl.py
+++ b/pymatgen/matproj/snl.py
@@ -28,6 +28,7 @@ from monty.string import remove_non_ascii
 
 from pymatgen.core.structure import Structure, Molecule
 from pybtex.database.input import bibtex
+from pybtex import errors
 
 
 MAX_HNODE_SIZE = 64000  # maximum size (bytes) of SNL HistoryNode
@@ -50,6 +51,7 @@ def is_valid_bibtex(reference):
     # filter expression removes all non-ASCII characters.
     sio = cStringIO(remove_non_ascii(reference))
     parser = bibtex.Parser()
+    errors.set_strict_mode(False)
     bib_data = parser.parse_stream(sio)
     return len(bib_data.entries) > 0
 


### PR DESCRIPTION
With the latest version of pybtex (0.18) the [strict mode has been made default](http://pybtex.sourceforge.net/history.html). This means that all former warnings will now cause error exceptions to be raised since the pybtex version has been fixed in pymatgen (see a69eaaeb93191c47aee3d240f41bded0624ac2f7). Hence, the conversion from database dicts to pymatgen objects via `MPStructureNL.from_dict(snl_dict)`, for instance, now won't result in a usable `Structure` object anymore. This pull request adds a call to `pybtex.errors.set_strict_mode(False)` in `matproj.snl.is_valid_bibtex()` to keep treating pybtex _typos_ as warnings in the future (backward-compatibilty)
