### PR TITLE
Included parsing of the static dielectric constant without local field effects

### DIFF
--- a/pymatgen/io/vaspio/tests/test_vasp_output.py
+++ b/pymatgen/io/vaspio/tests/test_vasp_output.py
@@ -132,6 +132,9 @@ class VasprunTest(unittest.TestCase):
         self.assertAlmostEqual(vasprun_dfpt.epsilon_static[0][0], 3.26105533)
         self.assertAlmostEqual(vasprun_dfpt.epsilon_static[0][1], -0.00459066)
         self.assertAlmostEqual(vasprun_dfpt.epsilon_static[2][2], 3.24330517)
+        self.assertAlmostEqual(vasprun_dfpt.epsilon_static_wolfe[0][0], 3.33402531)
+        self.assertAlmostEqual(vasprun_dfpt.epsilon_static_wolfe[0][1], -0.00559998)
+        self.assertAlmostEqual(vasprun_dfpt.epsilon_static_wolfe[2][2], 3.31237357)
         self.assertTrue(vasprun_dfpt.converged)
 
         entry = vasprun_dfpt.get_computed_entry()

--- a/pymatgen/io/vaspio/vasp_output.py
+++ b/pymatgen/io/vaspio/vasp_output.py
@@ -245,6 +245,11 @@ class Vasprun(PMGSONable):
         The static part of the dielectric constant. Present when it's a DFPT run
         (LEPSILON=TRUE)
 
+    .. attribute:: epsilon_static_wolfe
+
+        The static part of the dielectric constant without any local field effects. 
+        Present when it's a DFPT run (LEPSILON=TRUE)
+
     .. attribute:: epsilon_ionic
 
         The ionic part of the static dielectric constant. Present when it's a DFPT run
@@ -381,6 +386,13 @@ class Vasprun(PMGSONable):
         Property only available for DFPT calculations.
         """
         return self.ionic_steps[-1].get("epsilon", [])
+
+    @property
+    def epsilon_static_wolfe(self):
+        """
+        Property only available for DFPT calculations.
+        """
+        return self.ionic_steps[-1].get("epsilon_rpa", [])
 
     @property
     def epsilon_ionic(self):
@@ -781,6 +793,7 @@ class Vasprun(PMGSONable):
                 vout['projected_eigenvalues'] = peigen
 
         vout['epsilon_static'] = self.epsilon_static
+        vout['epsilon_static_wolfe'] = self.epsilon_static_wolfe
         vout['epsilon_ionic'] = self.epsilon_ionic
         d['output'] = vout
         return jsanitize(d, strict=True)


### PR DESCRIPTION
Changed files: 
vasp_output.py in pymategen/io/vaspio/
test_vasp_output.py in pymategen/io/vaspio/tests
