### PR TITLE
SpaceGroup.get_orbit avoids duplicated positions

### DIFF
--- a/pymatgen/symmetry/groups.py
+++ b/pymatgen/symmetry/groups.py
@@ -224,7 +224,7 @@ class SpaceGroup(object):
         orbit = []
         for o in self.symmetry_ops:
             pp = o.operate(p)
-            pp = np.mod(pp, 1)
+            pp = np.mod(np.round(pp, decimals=10), 1)
             if not in_array_list(orbit, pp, tol=tol):
                 orbit.append(pp)
         return orbit


### PR DESCRIPTION
A fractional position such as [0.99999999, 0, 0] might not be recognized as equivalent to [0., 0., 0.].
Solved it with np.round(a, decimals=10).