### PR TITLE
MPRester: add get_materials_id_references()

### DIFF
--- a/pymatgen/matproj/rest.py
+++ b/pymatgen/matproj/rest.py
@@ -157,6 +157,18 @@ class MPRester(object):
         """
         return self._make_request("/materials/mid_from_tid/%s" % task_id)
 
+    def get_materials_id_references(self, material_id):
+        """
+        Returns all references for a materials id.
+
+        Args:
+            material_id (str): A material id.
+
+        Returns:
+            BibTeX (str)
+        """
+        return self._make_request("/materials/%s/refs" % material_id)
+
     def get_data(self, chemsys_formula_id, data_type="vasp", prop=""):
         """
         Flexible method to get any data using the Materials Project REST

--- a/pymatgen/matproj/rest.py
+++ b/pymatgen/matproj/rest.py
@@ -68,7 +68,7 @@ class MPRester(object):
             variable. This makes easier for heavy users to simply add
             this environment variable to their setups and MPRester can
             then be called without any arguments.
-        host (str): Url of host to access the MaterialsProject REST interface.
+        endpoint (str): Url of endpoint to access the MaterialsProject REST interface.
             Defaults to the standard Materials Project REST address, but
             can be changed to other urls implementing a similar interface.
     """
@@ -91,12 +91,12 @@ class MPRester(object):
                                  "is_compatible", "spacegroup",
                                  "band_gap", "density", "icsd_id", "cif")
 
-    def __init__(self, api_key=None, host="www.materialsproject.org"):
+    def __init__(self, api_key=None, endpoint="https://www.materialsproject.org/rest/v2"):
         if api_key is not None:
             self.api_key = api_key
         else:
             self.api_key = os.environ.get("MAPI_KEY", "")
-        self.preamble = "https://{}/rest/v2".format(host)
+        self.preamble = endpoint
         self.session = requests.Session()
         self.session.headers = {"x-api-key": self.api_key}
 

--- a/pymatgen/matproj/tests/test_rest.py
+++ b/pymatgen/matproj/tests/test_rest.py
@@ -97,6 +97,12 @@ class MPResterTest(unittest.TestCase):
         self.assertEqual(self.rester.get_materials_id_from_task_id(
             "mp-540081"), "mp-19017")
 
+    def test_get_materials_id_references(self):
+        # nosetests pymatgen/matproj/tests/test_rest.py:MPResterTest.test_get_materials_id_references
+        self.rester.preamble = "http://www.materialsproject.org:8080/rest" # TODO rm when in prod
+        data = self.rester.get_materials_id_references('mp-123')
+        self.assertTrue(len(data) > 1000)
+
     def test_get_entries_in_chemsys(self):
         syms = ["Li", "Fe", "O"]
         all_entries = self.rester.get_entries_in_chemsys(syms, False)

--- a/pymatgen/matproj/tests/test_rest.py
+++ b/pymatgen/matproj/tests/test_rest.py
@@ -99,8 +99,9 @@ class MPResterTest(unittest.TestCase):
 
     def test_get_materials_id_references(self):
         # nosetests pymatgen/matproj/tests/test_rest.py:MPResterTest.test_get_materials_id_references
-        self.rester.preamble = "http://www.materialsproject.org:8080/rest" # TODO rm when in prod
-        data = self.rester.get_materials_id_references('mp-123')
+        # TODO use self.rester when in prod
+        m = MPRester(os.environ.get('MAPI_KEY_DEV'), endpoint="http://www.materialsproject.org:8080/rest")
+        data = m.get_materials_id_references('mp-123')
         self.assertTrue(len(data) > 1000)
 
     def test_get_entries_in_chemsys(self):


### PR DESCRIPTION
This pull request adds the convenience function `get_materials_id_references(<mp-id>)` and the according test in MPRester to make use of the new MP REST API [endpoint](https://github.com/materialsproject/materials_django/compare/89710d0bf172319455baa47419d7658010523465~1...master) `materials/mp-123/refs`. For the purpose of [pre](https://github.com/materialsproject/pymatgen/compare/master...tschaume:master#diff-6821d60ec5218f73aefdd5318abfbc7eR102)-release [testing](https://gist.github.com/tschaume/fa8d0fc7ed29fe972d2c) (dev or local), MPRester can now be initialized with the more general `endpoint` instead of `host`. Please advise if you can think of a better solution for the latter.