### PR TITLE
MPRester: add find_structure()

### DIFF
--- a/pymatgen/matproj/rest.py
+++ b/pymatgen/matproj/rest.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
 from __future__ import division, unicode_literals
+from six import string_types
 
 """
 This module provides classes to interface with the Materials Project REST
@@ -249,7 +250,7 @@ class MPRester(object):
             MPRestError
         """
         try:
-            if isinstance(filename_or_structure, str):
+            if isinstance(filename_or_structure, string_types):
                 s = Structure.from_file(filename_or_structure)
             elif isinstance(filename_or_structure, Structure):
                 s = filename_or_structure

--- a/pymatgen/matproj/rest.py
+++ b/pymatgen/matproj/rest.py
@@ -39,7 +39,7 @@ from pymatgen.io.vaspio_set import DictVaspInputSet
 from pymatgen.apps.borg.hive import VaspToComputedEntryDrone
 from pymatgen.apps.borg.queen import BorgQueen
 from pymatgen.matproj.snl import StructureNL
-
+from pymatgen.core.structure import Structure
 
 class MPRester(object):
     """
@@ -234,6 +234,41 @@ class MPRester(object):
         prop = "final_structure" if final else "initial_structure"
         data = self.get_data(chemsys_formula_id, prop=prop)
         return [d[prop] for d in data]
+
+    def find_structure(self, filename_or_structure):
+        """
+        Finds matching structures on the Materials Project site.
+
+        Args:
+            filename_or_structure: filename or Structure object
+
+        Returns:
+            A list of matching structures.
+
+        Raises:
+            MPRestError
+        """
+        try:
+            if isinstance(filename_or_structure, str):
+                s = Structure.from_file(filename_or_structure)
+            elif isinstance(filename_or_structure, Structure):
+                s = filename_or_structure
+            else:
+                raise MPRestError("Provide filename or Structure object.")
+            payload = {'structure': json.dumps(s.as_dict(), cls=MontyEncoder)}
+            response = self.session.post(
+                '{}/find_structure'.format(self.preamble), data=payload
+            )
+            if response.status_code in [200, 400]:
+                resp = json.loads(response.text, cls=MPDecoder)
+                if resp['valid_response']:
+                    return resp['response']
+                else:
+                    raise MPRestError(resp["error"])
+            raise MPRestError("REST error with status code {} and error {}"
+                              .format(response.status_code, response.text))
+        except Exception as ex:
+            raise MPRestError(str(ex))
 
     def get_entries(self, chemsys_formula_id, compatible_only=True,
                     inc_structure=None):

--- a/pymatgen/matproj/tests/test_rest.py
+++ b/pymatgen/matproj/tests/test_rest.py
@@ -26,6 +26,7 @@ from pymatgen.electronic_structure.bandstructure import BandStructureSymmLine
 from pymatgen.entries.compatibility import MaterialsProjectCompatibility
 from pymatgen.phasediagram.pdmaker import PhaseDiagram
 from pymatgen.phasediagram.pdanalyzer import PDAnalyzer
+from pymatgen.io.cifio import CifParser
 
 
 test_dir = os.path.join(os.path.dirname(__file__), "..", "..", "..",
@@ -103,6 +104,17 @@ class MPResterTest(unittest.TestCase):
         m = MPRester(os.environ.get('MAPI_KEY_DEV'), endpoint="http://www.materialsproject.org:8080/rest")
         data = m.get_materials_id_references('mp-123')
         self.assertTrue(len(data) > 1000)
+
+    def test_find_structure(self):
+        # nosetests pymatgen/matproj/tests/test_rest.py:MPResterTest.test_find_structure
+        # TODO use self.rester when in prod
+        m = MPRester(os.environ.get('MAPI_KEY_DEV'), endpoint="http://www.materialsproject.org:8080/rest")
+        ciffile = 'test_files/Fe3O4.cif'
+        data = m.find_structure(ciffile)
+        self.assertTrue(len(data) > 1)
+        s = CifParser(ciffile).get_structures()[0]
+        data = m.find_structure(s)
+        self.assertTrue(len(data) > 1)
 
     def test_get_entries_in_chemsys(self):
         syms = ["Li", "Fe", "O"]


### PR DESCRIPTION
This pull request adds the convenience function `find_structure()` and according unit test to MPRester making use of the respective MP REST API [endpoint](https://github.com/materialsproject/materials_django/compare/materialsproject:00ec866...materialsproject:c368a32) ([Usage](https://gist.github.com/tschaume/fa8d0fc7ed29fe972d2c)).