### PR TITLE
Fix VaspInput.write_input (TypeError)

### DIFF
--- a/pymatgen/io/vaspio/tests/test_vasp_input.py
+++ b/pymatgen/io/vaspio/tests/test_vasp_input.py
@@ -560,6 +560,19 @@ class VaspInputTest(unittest.TestCase):
         comp = vinput["POSCAR"].structure.composition
         self.assertEqual(comp, Composition("Fe4P4O16"))
 
+    def test_write(self):
+        tmp_dir = "VaspInput.testing"
+        self.vinput.write_input(tmp_dir)
+
+        filepath = os.path.join(tmp_dir, "INCAR")
+        incar = Incar.from_file(filepath)
+        self.assertEqual(incar["NSW"], 99)
+
+        for name in ("INCAR", "POSCAR", "POTCAR", "KPOINTS"):
+            os.remove(os.path.join(tmp_dir, name))
+
+        os.rmdir(tmp_dir)
+
     def test_from_directory(self):
         vi = VaspInput.from_directory(test_dir,
                                       optional_files={"CONTCAR.Li2O": Poscar})

--- a/pymatgen/io/vaspio/vasp_input.py
+++ b/pymatgen/io/vaspio/vasp_input.py
@@ -1637,7 +1637,7 @@ class VaspInput(dict, PMGSONable):
             os.makedirs(output_dir)
         for k, v in self.items():
             with zopen(os.path.join(output_dir, k), "wt") as f:
-                f.write(v)
+                f.write(str(v))
 
     @staticmethod
     def from_directory(input_dir, optional_files=None):


### PR DESCRIPTION
It was producing TypeError when used due to it passing in Incar/Potcar/etc instances to the file.write method.

Also, none of the tests called this method, so I added one.