### PR TITLE
Allowing CIF data_* header to be prefixed with spaces and tabulations.

### DIFF
--- a/pymatgen/io/cifio.py
+++ b/pymatgen/io/cifio.py
@@ -238,7 +238,7 @@ class CifFile(object):
     @classmethod
     def from_string(cls, string):
         d = OrderedDict()
-        for x in re.split("^data_", "x\n"+string,
+        for x in re.split("^[ \t]*data_", "x\n"+string,
                           flags=re.MULTILINE | re.DOTALL)[1:]:
             c = CifBlock.from_string("data_"+x)
             d[c.header] = c


### PR DESCRIPTION
Current parser for CIF format files forbids CIF data_* header to be prefixed with space, what is completely normal, according to IUCr's CIF syntax specification (http://www.iucr.org/resources/cif/spec/version1.1/cifsyntax).

MWE (test.cif):
```
    data_test_1
    data_test_2
```
MWE (python script):
```python
from pymatgen.io.cifio import CifParser
c = CifParser("test.cif")
c.as_dict()
```
should produce:
```python
OrderedDict([(u'test_1', {}), (u'test_2', {})])
```