### PR TITLE
Multiple dielectricfunction elements in vasprun.xml

### DIFF
--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -388,7 +388,7 @@ class Vasprun(PMGSONable):
                 ionic_steps.append(self._parse_calculation(elem))
             if tag == "dielectricfunction":
                 if not elem.attrib.has_key("comment") or \
-                   elem.attrib["comment"] == "HEAD OF MICROSCOPIC DIELECTRIC TENSOR (INDEPENDENT PARTICLE)":
+                   elem.attrib["comment"] == "INVERSE MACROSCOPIC DIELECTRIC TENSOR (including local field effects in RPA (Hartree))":
                     self.dielectric = self._parse_diel(elem)
                 else:
                     self.other_dielectric[elem.attrib["comment"]] = self._parse_diel(elem)


### PR DESCRIPTION
When [using the GW routines for the determination of frequency dependent dielectric matrix](http://cms.mpi.univie.ac.at/vasp/vasp/Using_GW_routines_determination_frequency_dependent_dielectric_matrix.html), there are multiple dielectricfuction elements in vasprun.xml, distinguished by element comments, and the Vasprun class is keeping the last one, which is actually the 'screened Coulomb potential'.

This tries to add support for these additional dielectricfunction elements without breaking the default behaviour by 

1. if there is no comment (there is only one dielectricfunction element), keeping the previous behaviour

2. if an element with comment "INVERSE MACROSCOPIC DIELECTRIC TENSOR (including local field effects in RPA (Hartree))" exists, storing it in the default dielectric attribute and 

2. storing any others (e.g., comments "HEAD OF MICROSCOPIC DIELECTRIC TENSOR (INDEPENDENT PARTICLE)", "1 + v P,  with REDUCIBLE POLARIZABILTY P=P_0 (1 -(v+f) P_0)^-1", "screened Coulomb potential") in an other_dielectric dictionary using the comment as key.

For your consideration.