### PR TITLE
Converter between AiiDA StructureData object and pymatgen Molecule/Structure objects

### DIFF
--- a/pymatgen/io/aiida.py
+++ b/pymatgen/io/aiida.py
@@ -1,0 +1,72 @@
+# coding: utf-8
+# Copyright (c) AiiDA Development Team.
+# Distributed under the terms of the MIT License.
+
+"""
+This module provides conversion between AiiDA StructureData object and
+pymatgen Molecule/Structure objects.
+"""
+
+
+__author__ = "Andrius Merkys"
+__copyright__ = "Copyright 2015, AiiDA Development Team"
+__version__ = "1.0"
+__maintainer__ = "Andrius Merkys"
+__email__ = "andrius.merkys@gmail.com"
+__date__ = "Oct 9, 2015"
+
+from pymatgen.core.structure import Molecule, Structure
+
+try:
+    from aiida.orm.data.structure import StructureData
+    aiida_loaded = True
+except ImportError:
+    aiida_loaded = False
+
+
+class AiidaStructureAdaptor(object):
+    """
+    Adaptor serves as a bridge between AiiDA StructureData and pymatgen
+    Molecule/Structure objects.
+    """
+
+    @staticmethod
+    def get_structuredata(structure):
+        """
+        Returns AiiDA StructureData object from pymatgen structure or
+        molecule.
+
+        Args:
+            structure: pymatgen.core.structure.Structure or
+                       pymatgen.core.structure.Molecule
+
+        Returns:
+            AiiDA StructureData object
+        """
+        return StructureData(pymatgen=structure);
+
+    @staticmethod
+    def get_molecule(structuredata):
+        """
+        Returns pymatgen molecule from AiiDA StructureData.
+
+        Args:
+            structuredata: AiiDA StructureData object
+
+        Returns:
+            pymatgen.core.structure.Molecule
+        """
+        return structuredata.get_pymatgen_molecule()
+
+    @staticmethod
+    def get_structure(structuredata):
+        """
+        Returns pymatgen structure from AiiDA StructureData.
+
+        Args:
+            structuredata: AiiDA StructureData object
+
+        Returns:
+            pymatgen.core.structure.Structure
+        """
+        return structuredata.get_pymatgen_structure()

--- a/pymatgen/io/aiida.py
+++ b/pymatgen/io/aiida.py
@@ -18,8 +18,13 @@ __date__ = "Oct 9, 2015"
 from pymatgen.core.structure import Molecule, Structure
 
 try:
-    from aiida.orm.data.structure import StructureData
+    from aiida.orm import DataFactory
+    from aiida.common.exceptions import MissingPluginError
     aiida_loaded = True
+    try:
+        StructureData = DataFactory('structure')
+    except MissingPluginError:
+        raise ImportError
 except ImportError:
     aiida_loaded = False
 
@@ -43,7 +48,7 @@ class AiidaStructureAdaptor(object):
         Returns:
             AiiDA StructureData object
         """
-        return StructureData(pymatgen=structure);
+        return StructureData(pymatgen=structure)
 
     @staticmethod
     def get_molecule(structuredata):

--- a/pymatgen/io/aiida.py
+++ b/pymatgen/io/aiida.py
@@ -2,6 +2,8 @@
 # Copyright (c) AiiDA Development Team.
 # Distributed under the terms of the MIT License.
 
+from __future__ import absolute_import
+
 """
 This module provides conversion between AiiDA StructureData object and
 pymatgen Molecule/Structure objects.
@@ -20,11 +22,11 @@ from pymatgen.core.structure import Molecule, Structure
 try:
     from aiida.orm import DataFactory
     from aiida.common.exceptions import MissingPluginError
-    aiida_loaded = True
     try:
         StructureData = DataFactory('structure')
     except MissingPluginError:
         raise ImportError
+    aiida_loaded = True
 except ImportError:
     aiida_loaded = False
 


### PR DESCRIPTION
I present a converter between AiiDA StructureData and pymatgen Molecule/Structure objects. Since testing requires a sophisticated environment, it is done at AiiDA side.

Please check whether the method names comply with the pymatgen's style.