### PR TITLE
Xdatcar class did not read last configuration

### DIFF
--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -2333,6 +2333,9 @@ class Xdatcar(object):
                     coords_str = []
                 else:
                     coords_str.append(l)
+            p = Poscar.from_string("\n".join(preamble +
+                                             ["Direct"] + coords_str))
+            structures.append(p.structure)
         self.structures = structures
 
 class Dynmat(object):

--- a/pymatgen/io/vasp/tests/test_outputs.py
+++ b/pymatgen/io/vasp/tests/test_outputs.py
@@ -472,14 +472,14 @@ class XdatcarTest(unittest.TestCase):
         filepath = os.path.join(test_dir, 'XDATCAR_4')
         x = Xdatcar(filepath)
         structures = x.structures
-        self.assertEqual(len(structures), 3)
+        self.assertEqual(len(structures), 4)
         for s in structures:
             self.assertEqual(s.formula, "Li2 O1")
 
         filepath = os.path.join(test_dir, 'XDATCAR_5')
         x = Xdatcar(filepath)
         structures = x.structures
-        self.assertEqual(len(structures), 3)
+        self.assertEqual(len(structures), 4)
         for s in structures:
             self.assertEqual(s.formula, "Li2 O1")
 


### PR DESCRIPTION
Changed Xdatcar class and unit test so that last configuration in XDATCAR is also read. The expected number of configurations read from the test files was incorrect (3); each XDATCAR test file contains 4 configurations