### PR TITLE
Problem with multiple preambles in XDATCAR

### DIFF
--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -2324,6 +2324,13 @@ class Xdatcar(object):
                 elif not preamble_done:
                     if l == "" or "Direct configuration=" in l:
                         preamble_done = True
+                        tmp_preamble = [preamble[0]]
+                        for i in range(1, len(preamble)):
+                            if preamble[0] != preamble[i]:
+                                tmp_preamble.append(preamble[i])
+                            else:
+                                break
+                        preamble = tmp_preamble
                     else:
                         preamble.append(l)
                 elif l == "" or "Direct configuration=" in l:


### PR DESCRIPTION
I've extended the constructor of Xdatcar to enable successful treatment of multiple consecutive preambles in XDATCAR. That case seems rare, but I've just encountered it.