### PR TITLE
add as_base_units for FloatWithUnit and ArrayWithUnit. This is helps …

### DIFF
--- a/pymatgen/core/tests/test_units.py
+++ b/pymatgen/core/tests/test_units.py
@@ -118,6 +118,10 @@ class FloatWithUnitTest(PymatgenTest):
         self.assertAlmostEqual(b, 1556.8929672799854)
         self.assertEqual(str(b.unit), "J m^-2")
 
+    def test_as_base_units(self):
+        x = FloatWithUnit(5, "MPa")
+        self.assert_equal(FloatWithUnit(5000000, "Pa"), x.as_base_units)
+
 
 class ArrayWithFloatWithUnitTest(PymatgenTest):
 
@@ -225,6 +229,10 @@ class ArrayWithFloatWithUnitTest(PymatgenTest):
         self.assertTrue(str(l) == "[ 1.88972612] bohr")
         v = ArrayWithUnit([1, 2, 3], "bohr^3").to("ang^3")
         self.assertTrue(str(v) == '[ 0.14818471  0.29636942  0.44455413] ang^3')
+
+    def test_as_base_units(self):
+        x = ArrayWithUnit([5, 10], "MPa")
+        self.assert_equal(ArrayWithUnit([5000000, 10000000], "Pa"), x.as_base_units)
 
 
 class DataPersistenceTest(PymatgenTest):

--- a/pymatgen/core/units.py
+++ b/pymatgen/core/units.py
@@ -493,6 +493,17 @@ class FloatWithUnit(float):
             unit=new_unit)
 
     @property
+    def as_base_units(self):
+        """
+        Returns this FloatWithUnit in base SI units, including derived units.
+
+        Returns:
+            A FloatWithUnit object in base SI units
+        """
+        return self.to(self.unit.as_base_units[0])
+
+
+    @property
     def supported_units(self):
         """
         Supported units for specific unit type.
@@ -663,6 +674,16 @@ class ArrayWithUnit(np.ndarray):
         return self.__class__(
             np.array(self) * self.unit.get_conversion_factor(new_unit),
             unit_type=self.unit_type, unit=new_unit)
+
+    @property
+    def as_base_units(self):
+        """
+        Returns this ArrayWithUnit in base SI units, including derived units.
+
+        Returns:
+            An ArrayWithUnit object in base SI units
+        """
+        return self.to(self.unit.as_base_units[0])
 
     #TODO abstract base class property?
     @property

--- a/pymatgen/core/units.py
+++ b/pymatgen/core/units.py
@@ -810,10 +810,12 @@ def obj_with_unit(obj, unit):
 
 def unitized(unit):
     """
-    Useful decorator to assign units to the output of a function. For
-    sequences, all values in the sequences are assigned the same unit. It
-    works with Python sequences only. The creation of numpy arrays loses all
-    unit information. For mapping types, the values are assigned units.
+    Useful decorator to assign units to the output of a function. You can also
+    use it to standardize the output units of a function that already returns
+    a FloatWithUnit or ArrayWithUnit. For sequences, all values in the sequences
+    are assigned the same unit. It works with Python sequences only. The creation
+    of numpy arrays loses all unit information. For mapping types, the values
+    are assigned units.
 
     Args:
         unit: Specific unit (eV, Ha, m, ang, etc.).
@@ -828,9 +830,12 @@ def unitized(unit):
     def wrap(f):
         def wrapped_f(*args, **kwargs):
             val = f(*args, **kwargs)
-            #print(val)
             unit_type = _UNAME2UTYPE[unit]
-            if isinstance(val, collections.Sequence):
+
+            if isinstance(val, FloatWithUnit) or isinstance(val, ArrayWithUnit):
+                return val.to(unit)
+
+            elif isinstance(val, collections.Sequence):
                 # TODO: why don't we return a ArrayWithUnit?
                 # This complicated way is to ensure the sequence type is
                 # preserved (list or tuple).


### PR DESCRIPTION
This adds an ``as_base_units`` functionality to FloatWithUnit and ArrayWithUnit. When I have these two objects, I often want to quickly convert them to base units and would find this function a handy shortcut.