### PR TITLE
add a reciprocal density parameter to vasp sets

### DIFF
--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -385,6 +385,12 @@ class DictVaspInputSet(AbstractVaspInputSet):
                 structure, int(self.kpoints_settings['grid_density']),
                 self.force_gamma)
 
+        # If reciprocal_density is in the kpoints_settings use Kpoints.automatic_density_by_vol
+        elif self.kpoints_settings.get('reciprocal_density'):
+            return Kpoints.automatic_density_by_vol(
+                structure, int(self.kpoints_settings['reciprocal_density']),
+                self.force_gamma)
+
         # If length is in the kpoints_settings use Kpoints.automatic
         elif self.kpoints_settings.get('length'):
             return Kpoints.automatic(self.kpoints_settings['length'])

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -303,6 +303,12 @@ class MITMPVaspInputSetTest(unittest.TestCase):
         self.assertAlmostEqual(kpoints.kpts[-1][1], 0.5)
         self.assertAlmostEqual(kpoints.kpts[-1][2], 0.0)
 
+        recip_paramset = MPVaspInputSet(force_gamma=True)
+        recip_paramset.kpoints_settings = {"reciprocal_density": 40}
+        kpoints = recip_paramset.get_kpoints(self.struct)
+        self.assertEqual(kpoints.kpts, [[2, 4, 6]])
+        self.assertEqual(kpoints.style, Kpoints.supported_modes.Gamma)
+
     def test_get_all_vasp_input(self):
         d = self.mitparamset.get_all_vasp_input(self.struct)
         self.assertEqual(d["INCAR"]["ISMEAR"], -5)


### PR DESCRIPTION
## Summary

Add a "reciprocal_volume" setting for kpoints_settings in vasp sets. This supplements "grid_density" and "length" settings and allows one to set the k-point density using spacing in reciprocal space.

Note that I would suggest also making "force_gamma" one of the kpoints_settings (instead of a constructor to VaspInputSets). I am not sure why this aspect of selecting the kpoint mesh is treated differently than the others.