### PR TITLE
Make Kpoints init convert style string to enum

### DIFF
--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -843,7 +843,7 @@ class Kpoints(MSONable):
         self.comment = comment
         self.num_kpts = num_kpts
         self.kpts = kpts
-        self._style = style
+        self.style = style
         self.coord_type = coord_type
         self.kpts_weights = kpts_weights
         self.kpts_shift = kpts_shift
@@ -1251,9 +1251,6 @@ class Kpoints(MSONable):
     def from_dict(cls, d):
         comment = d.get("comment", "")
         generation_style = d.get("generation_style")
-        if generation_style is not None:
-            generation_style = Kpoints.supported_modes[generation_style]
-
         kpts = d.get("kpoints", [[1, 1, 1]])
         kpts_shift = d.get("usershift", [0, 0, 0])
         num_kpts = d.get("nkpoints", 0)


### PR DESCRIPTION
## Summary

`Kpoints.__init__`  now sets `self.style`, thus using a setter method to automatically convert a given string `style` to the proper enum type if possible.

* `Kpoints.__init__` is more lenient about its input `style`
* `Kpoints.from_dict` is shortened

Alternative solution:
In `Kpoints.from_dict`, could change `Kpoints.supported_modes[generation_style]` to `Kpoints.supported_modes.from_string(generation_style)`, but it seems cleaner to remove that spot conversion entirely and delegate to `Kpoints.__init__`.