### PR TITLE
handle disordered species

### DIFF
--- a/pymatgen/analysis/structure_analyzer.py
+++ b/pymatgen/analysis/structure_analyzer.py
@@ -89,8 +89,14 @@ class VoronoiCoordFinder(object):
 
         resultweighted = {}
         for nn, angle in results.items():
-            if nn.specie in localtarget:
-                resultweighted[nn] = angle / maxangle
+            # is nn site is ordered use "nn.specie" to get species, else use "nn.species_and_occu" to get species
+            if nn.is_ordered:
+                if nn.specie in localtarget:
+                    resultweighted[nn] = angle / maxangle
+            else:  # is nn site is disordered
+                for disordered_sp in nn.species_and_occu.keys():
+                    if disordered_sp in localtarget:
+                        resultweighted[nn] = angle / maxangle
 
         return resultweighted
 


### PR DESCRIPTION
## Summary

- Error faced: "AttributeError: specie" when running get_voronoi_polyhedra() for a site that has as its nearest neighbor (nn) a disorderd site. 
- Proposed fix: separate handling of disordered nn, get elements contained on the site, check if present in structure, and update the weighted polyhedra. 
- Attachment: example structure (as a dictionary) tested with

[structure_sd_1615854.json.zip](https://github.com/materialsproject/pymatgen/files/210750/structure_sd_1615854.json.zip)
