### PR TITLE
Suggested fix for the parsing issues related with the predictor-corrector data in VASP output

### DIFF
--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -949,7 +949,7 @@ class IStructure(SiteCollection, MSONable):
                                               to_unit_cell=True,
                                               properties=site_props))
             new_sites = sorted(new_sites)
-            return self.__class__.from_sites(new_sites)
+            return self.__class__.from_sites(new_sites, structure_properties=struct_props)
 
     def interpolate(self, end_structure, nimages=10,
                     interpolate_lattices=False, pbc=True, autosort_tol=0):

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -909,7 +909,7 @@ class IStructure(SiteCollection, MSONable):
             optionally sanitized.
         """
         props = self.site_properties
-        struct_props = self.structure_properties
+        struct_props = self._struct_props
         if site_properties:
             props.update(site_properties)
         if structure_properties:

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -913,7 +913,10 @@ class IStructure(SiteCollection, MSONable):
         if site_properties:
             props.update(site_properties)
         if structure_properties:
-            struct_props.update(structure_properties)
+            if struct_props:
+                struct_props.update(structure_properties)
+            else:
+                struct_props = structure_properties
         if not sanitize:
             return self.__class__(self._lattice,
                                   self.species_and_occu,

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -417,6 +417,9 @@ class IStructure(SiteCollection, MSONable):
                 that are less than 0.01 Ang apart. Defaults to False.
             to_unit_cell (bool): Whether to translate sites into the unit
                 cell.
+            structure_properties (dict): Arbitrary properties associated with the
+                entire structure that are not site specific: e.g., thermostat
+                information to be written to Poscar to continue VASP MD.
 
         Returns:
             (Structure) Note that missing properties are set as None.
@@ -487,6 +490,9 @@ class IStructure(SiteCollection, MSONable):
                 fractional_coords. Defaults to None for no properties.
             tol (float): A fractional tolerance to deal with numerical
                precision issues in determining if orbits are the same.
+            structure_properties (dict): Arbitrary properties associated with the
+                entire structure that are not site specific: e.g., thermostat
+                information to be written to Poscar to continue VASP MD.
         """
         try:
             i = int(sg)
@@ -562,6 +568,13 @@ class IStructure(SiteCollection, MSONable):
         Reciprocal lattice of the structure.
         """
         return self._lattice.reciprocal_lattice
+
+    @property
+    def structure_properties(self):
+        """
+        Structure properties stored as a part of the Structure
+        """
+        return self._struct_props
 
     def lattice_vectors(self, space="r"):
         """
@@ -2128,6 +2141,9 @@ class Structure(IStructure, collections.MutableSequence):
                 dict of sequences, e.g., {"magmom":[5,5,5,5]}. The sequences
                 have to be the same length as the atomic species and
                 fractional_coords. Defaults to None for no properties.
+            structure_properties (dict): Arbitrary properties associated with the
+                entire structure that are not site specific: e.g., thermostat
+                information to be written to Poscar to continue VASP MD.
         """
         super(Structure, self).__init__(lattice, species, coords,
             validate_proximity=validate_proximity, to_unit_cell=to_unit_cell,
@@ -2263,7 +2279,7 @@ class Structure(IStructure, collections.MutableSequence):
 
         Args:
             property_name (str): The name of the property to add.
-            value: can be of any type.
+            value: can be of any type depending on the property.
         """
         if not self._struct_props:
             self._struct_props = {}

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -2279,7 +2279,8 @@ class Structure(IStructure, collections.MutableSequence):
 
         Args:
             property_name (str): The name of the property to add.
-            value: can be of any type depending on the property.
+            value: Depends on the property to be stored.
+                Can be of any JSON serializable object.
         """
         if not self._struct_props:
             self._struct_props = {}

--- a/pymatgen/core/tests/test_structure.py
+++ b/pymatgen/core/tests/test_structure.py
@@ -35,7 +35,9 @@ class IStructureTest(PymatgenTest):
                           ["Si"] * 2, coords, True)
         self.propertied_structure = IStructure(
             self.lattice, ["Si"] * 2, coords,
-            site_properties={'magmom': [5, -5]})
+            site_properties={'magmom': [5, -5]},
+            structure_properties={'thermostat_params': ["\nsome",
+                            "\nthermostat", "\nparameters"]})
 
     def test_bad_structure(self):
         coords = list()
@@ -168,6 +170,10 @@ class IStructureTest(PymatgenTest):
         self.assertEqual(site_props['magmom'], [5, -5])
         self.assertEqual(self.propertied_structure[0].magmom, 5)
         self.assertEqual(self.propertied_structure[1].magmom, -5)
+
+    def test_structure_properties(self):
+        struct_props = self.propertied_structure.structure_properties
+        self.assertEqual(struct_props['thermostat_params'][2], "\nparameters")
 
     def test_copy(self):
         new_struct = self.propertied_structure.copy(site_properties={'charge':
@@ -481,6 +487,15 @@ class StructureTest(PymatgenTest):
         s.add_site_property("magmom", [3, 2])
         self.assertEqual(s[0].charge, 4.1)
         self.assertEqual(s[0].magmom, 3)
+
+    def test_add_structure_property(self):
+        s = self.structure
+        preamble = "1\n2.\n0.56815805E+00  0.14857275E-02 -0.27337773E-18  0.00000000E+00\n"
+        print s.structure_properties
+        s.add_structure_property("predictor_corrector_preamble", preamble)
+        self.assertEqual(s.structure_properties['predictor_corrector_preamble'][0], "1")
+        self.assertEqual(s.structure_properties['predictor_corrector_preamble'][-1], "\n")
+        print s.structure_properties
 
     def test_propertied_structure(self):
         #Make sure that site properties are set to None for missing values.

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -366,7 +366,7 @@ class Poscar(MSONable):
             for line in chunks[1].strip().split("\n"):
                 velocities.append([float(tok) for tok in line.split()])
 
-        predictor_corrector = [[],[],[]]
+        predictor_corrector = []
         predictor_corrector_preamble = None
 
         if len(chunks) > 2:
@@ -380,11 +380,12 @@ class Poscar(MSONable):
             predictor_corrector_preamble = lines[0] + "\n" + lines[1]+"\n" + lines[2]+"\n"
             # Rest is three sets of parameters, each set contains
             # x, y, z predictor-corrector parameters for every atom in orde
-            chnk = 0
-            for pred in predictor_corrector:
-                for line in lines[chnk*nsites+3: (chnk+1)*nsites+3]:
-                    pred.append([float(tok) for tok in line.split()])
-                chnk+=1
+            lines = lines[3:]
+            for st in range(nsites):
+                d1 = [float(tok) for tok in lines[st].split()]
+                d2 = [float(tok) for tok in lines[st+nsites].split()]
+                d3 = [float(tok) for tok in lines[st+2*nsites].split()]
+                predictor_corrector.append([d1,d2,d3])
 
         return Poscar(struct, comment, selective_dynamics, vasp5_symbols,
                       velocities=velocities,

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -444,10 +444,13 @@ class Poscar(MSONable):
 
         if self.predictor_corrector:
             lines.append("")
-            lines.append(str(self.predictor_corrector[0][0]))
-            lines.append(str(self.predictor_corrector[1][0]))
-            for v in self.predictor_corrector[2:]:
-                lines.append(" ".join([format_str.format(i) for i in v]))
+            try:
+                lines.append(self.predictor_corrector_preamble)
+            except:
+                raise ValueError("Preamble information missing")
+            for v in self.predictor_corrector:
+                for z in v:
+                    lines.append(" ".join([format_str.format(i) for i in z]))
 
         return "\n".join(lines) + "\n"
 

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -355,7 +355,23 @@ class Poscar(MSONable):
                 velocities.append([float(tok) for tok in line.split()])
 
         predictor_corrector = []
+
         if len(chunks) > 2:
+            # There are 3x 3x N Predictor corrector parameters
+            # So can't be stored as a single set of "site_property"
+            # This is a key in CONTCAR
+            predictor_corrector.append([int(lines[0])])
+
+            # This is the POTIM
+            predictor_corrector.append([float(lines[1])])
+
+            # This is the NOSE Thermostat parameters
+            predictor_corrector.append([float(tok)
+                                            for tok in lines[2].split()])
+            # Rest is three sets of parameters, each set contains
+            # x, y, z predictor-corrector parameters for every atom in orde
+
+
             lines = chunks[2].strip().split("\n")
             predictor_corrector.append([int(lines[0])])
             predictor_corrector.append([int(lines[0])])

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -358,7 +358,10 @@ class Poscar(MSONable):
         if len(chunks) > 2:
             lines = chunks[2].strip().split("\n")
             predictor_corrector.append([int(lines[0])])
-            for line in lines[1:]:
+            predictor_corrector.append([int(lines[0])])
+            predictor_corrector.append([int(lines[0])])
+
+            for line in lines[3:]:
                 predictor_corrector.append([float(tok)
                                             for tok in line.split()])
 

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -367,6 +367,7 @@ class Poscar(MSONable):
                 velocities.append([float(tok) for tok in line.split()])
 
         predictor_corrector = [[],[],[]]
+        predictor_corrector_preamble = None
 
         if len(chunks) > 2:
             lines = chunks[2].strip().split("\n")

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -377,7 +377,7 @@ class Poscar(MSONable):
             # First line in chunk is a key in CONTCAR
             # Second line is POTIM
             # Third line is the thermostat parameters
-            predictor_corrector_preamble = lines[0] + "\n" + lines[1]+"\n" + lines[2]+"\n"
+            predictor_corrector_preamble = lines[0] + "\n" + lines[1]+"\n" + lines[2]
             # Rest is three sets of parameters, each set contains
             # x, y, z predictor-corrector parameters for every atom in orde
             lines = lines[3:]
@@ -449,9 +449,10 @@ class Poscar(MSONable):
             try:
                 lines.append(self.predictor_corrector_preamble)
             except:
-                raise ValueError("Preamble information missing")
-            for v in self.predictor_corrector:
-                for z in v:
+                raise ValueError("Preamble information missing or corrupt.")
+            pred = np.array(self.predictor_corrector)
+            for col in range(3):
+                for z in pred[:,col]:
                     lines.append(" ".join([format_str.format(i) for i in z]))
 
         return "\n".join(lines) + "\n"

--- a/pymatgen/io/vasp/tests/test_inputs.py
+++ b/pymatgen/io/vasp/tests/test_inputs.py
@@ -181,7 +181,7 @@ direct
         self.assertEqual(str(poscar), expected)
 
     def test_from_md_run(self):
-        #Parsing from an MD type run with velocities
+        #Parsing from an MD type run with velocities and predictor corrector
         p = Poscar.from_file(os.path.join(test_dir, "CONTCAR.MD"),
                              check_for_POTCAR=False)
         self.assertAlmostEqual(np.sum(np.array(p.velocities)), 0.0065417961324)
@@ -273,6 +273,28 @@ direct
         p = Poscar.from_file(tempfname)
         self.assertArrayAlmostEqual(poscar.structure.lattice.abc,
                                     p.structure.lattice.abc, 5)
+        os.remove(tempfname)
+
+    def test_write_MD_poscar(self):
+        # Parsing from an MD type run with velocities and predictor corrector
+        # And writing a new POSCAR from the new structure
+        p = Poscar.from_file(os.path.join(test_dir, "CONTCAR.MD"),
+                             check_for_POTCAR=False)
+
+        tempfname = "POSCAR.testing"
+        structure = p.structure
+        p2 = Poscar(structure)
+        p2.write_file(tempfname)
+        p3 = Poscar.from_file(tempfname)
+
+        self.assertArrayAlmostEqual(p.structure.lattice.abc,
+                                    p3.structure.lattice.abc, 5)
+        self.assertArrayAlmostEqual(p.velocities,
+                                    p3.velocities, 5)
+        self.assertArrayAlmostEqual(p.predictor_corrector,
+                                    p3.predictor_corrector, 5)
+        self.assertEqual(p.predictor_corrector_preamble,
+                                    p3.predictor_corrector_preamble)
         os.remove(tempfname)
 
 

--- a/pymatgen/io/vasp/tests/test_inputs.py
+++ b/pymatgen/io/vasp/tests/test_inputs.py
@@ -185,8 +185,8 @@ direct
         p = Poscar.from_file(os.path.join(test_dir, "CONTCAR.MD"),
                              check_for_POTCAR=False)
         self.assertAlmostEqual(np.sum(np.array(p.velocities)), 0.0065417961324)
-        self.assertEqual(p.predictor_corrector[0][0], 1)
-        self.assertEqual(p.predictor_corrector[1][0], 2)
+        self.assertEqual(p.predictor_corrector[0][0][0], 0.33387820E+00)
+        self.assertEqual(p.predictor_corrector[0][1][1], -0.10583589E-02)
 
     def test_setattr(self):
         filepath = os.path.join(test_dir, 'POSCAR')


### PR DESCRIPTION
## Summary

This is a suggested solution for the Issue #325, mostly for code review purposes. I can work on a new pull request based on the comments on this one.

* Predictor corrector data is now correctly parsed.
* These 3 sets of 3 xN parameters are stored properly for each site as a site_property.
* inputs.Poscar is modified to now generate the the correct string for POSCAR's with predictor_corrector information.
* A generic "structure_properties" attribute is added to Structure to store any arbitrary structure information that is not site-specific.
* Using that, predictor corrector preamble (key, potim, thermostat params...) is stored as a structure_property
* Structure and IStructure were modified to accommodate "structure_properties" (e.g. addition of properties, structure generation, copying etc.)
* Changes are tested, no errors generated.