### PR TITLE
Predictor-corrector parsing and storage

### DIFF
--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -443,9 +443,9 @@ class Poscar(MSONable):
 
         if self.predictor_corrector:
             lines.append("")
-            try:
+            if self.predictor_corrector_preamble:
                 lines.append(self.predictor_corrector_preamble)
-            except:
+            else:
                 raise ValueError("Preamble information missing or corrupt.")
             pred = np.array(self.predictor_corrector)
             for col in range(3):

--- a/pymatgen/io/vasp/tests/test_inputs.py
+++ b/pymatgen/io/vasp/tests/test_inputs.py
@@ -181,12 +181,32 @@ direct
         self.assertEqual(str(poscar), expected)
 
     def test_from_md_run(self):
-        #Parsing from an MD type run with velocities
+        # Parsing from an MD type run with velocities and predictor corrector data
         p = Poscar.from_file(os.path.join(test_dir, "CONTCAR.MD"),
                              check_for_POTCAR=False)
         self.assertAlmostEqual(np.sum(np.array(p.velocities)), 0.0065417961324)
-        self.assertEqual(p.predictor_corrector[0][0], 1)
-        self.assertEqual(p.predictor_corrector[1][0], 2)
+        self.assertEqual(p.predictor_corrector[0][0][0], 0.33387820E+00)
+        self.assertEqual(p.predictor_corrector[0][1][1], -0.10583589E-02)
+
+    def test_write_MD_poscar(self):
+        # Parsing from an MD type run with velocities and predictor corrector data
+        # And writing a new POSCAR from the new structure
+        p = Poscar.from_file(os.path.join(test_dir, "CONTCAR.MD"),
+                             check_for_POTCAR=False)
+
+        tempfname = "POSCAR.testing"
+        p.write_file(tempfname)
+        p3 = Poscar.from_file(tempfname)
+
+        self.assertArrayAlmostEqual(p.structure.lattice.abc,
+                                    p3.structure.lattice.abc, 5)
+        self.assertArrayAlmostEqual(p.velocities,
+                                    p3.velocities, 5)
+        self.assertArrayAlmostEqual(p.predictor_corrector,
+                                    p3.predictor_corrector, 5)
+        self.assertEqual(p.predictor_corrector_preamble,
+                                    p3.predictor_corrector_preamble)
+        os.remove(tempfname)
 
     def test_setattr(self):
         filepath = os.path.join(test_dir, 'POSCAR')


### PR DESCRIPTION
## Summary
This pull request addresses [Issue #325](https://github.com/materialsproject/pymatgen/issues/325).
- Fixed the parsing of predictor-corrector data from an MD CONTCAR.
- Preamble (key, POTIM, thermostat parameters) for the predictor-corrector data is stored in Poscar.