### PR TITLE
handle bracketed data in attribute data for Elememt

### DIFF
--- a/pymatgen/core/periodic_table.py
+++ b/pymatgen/core/periodic_table.py
@@ -399,7 +399,8 @@ class Element(Enum):
                 try:
                     val = float(val)
                 except ValueError:
-                    toks = val.replace("about", "").strip().split(" ", 1)
+                    toks_nobrackets = re.sub(r'\(.*\)', "", val)
+                    toks = toks_nobrackets.replace("about", "").strip().split(" ", 1)
                     if len(toks) == 2:
                         try:
                             unit = toks[1].replace("<sup>", "^").replace(

--- a/pymatgen/core/periodic_table.py
+++ b/pymatgen/core/periodic_table.py
@@ -399,8 +399,8 @@ class Element(Enum):
                 try:
                     val = float(val)
                 except ValueError:
-                    toks_nobrackets = re.sub(r'\(.*\)', "", val)
-                    toks = toks_nobrackets.replace("about", "").strip().split(" ", 1)
+                    toks_nobracket = re.sub(r'\(.*\)', "", val)
+                    toks = toks_nobracket.replace("about", "").strip().split(" ", 1)
                     if len(toks) == 2:
                         try:
                             unit = toks[1].replace("<sup>", "^").replace(


### PR DESCRIPTION
## Summary

Some attribute data contains brackets, which raises an error when converting to a FloatWithUnit. 

* Fix: remove bracketed data

## Example:

Element('P').melting_point = "(white P) 317.3 K"