### PR TITLE
handle base 10 powers that exist in two Element attributes

### DIFF
--- a/pymatgen/core/periodic_table.py
+++ b/pymatgen/core/periodic_table.py
@@ -407,6 +407,13 @@ class Element(Enum):
                                 base_power = re.findall(r'([+-]?\d+)', toks[1])
                                 factor = "e" + base_power[1]
                                 toks[0] += factor
+                                if a == "electrical_resistivity":
+                                    unit = "ohm m"
+                                elif a == "coefficient_of_linear_thermal_expansion":
+                                    unit = "K^-1"
+                                else:
+                                    unit = toks[1]
+                                val = FloatWithUnit(toks[0], unit)
                             else:
                                 unit = toks[1].replace("<sup>", "^").replace(
                                     "</sup>", "").replace("&Omega;",

--- a/pymatgen/core/periodic_table.py
+++ b/pymatgen/core/periodic_table.py
@@ -403,12 +403,17 @@ class Element(Enum):
                     toks = toks_nobracket.replace("about", "").strip().split(" ", 1)
                     if len(toks) == 2:
                         try:
-                            unit = toks[1].replace("<sup>", "^").replace(
-                                "</sup>", "").replace("&Omega;",
-                                                      "ohm")
-                            units = Unit(unit)
-                            if set(units.keys()).issubset(SUPPORTED_UNIT_NAMES):
-                                val = FloatWithUnit(toks[0], unit)
+                            if "10<sup>" in toks[1]:
+                                base_power = re.findall(r'([+-]?\d+)', toks[1])
+                                factor = "e" + base_power[1]
+                                toks[0] += factor
+                            else:
+                                unit = toks[1].replace("<sup>", "^").replace(
+                                    "</sup>", "").replace("&Omega;",
+                                                          "ohm")
+                                units = Unit(unit)
+                                if set(units.keys()).issubset(SUPPORTED_UNIT_NAMES):
+                                    val = FloatWithUnit(toks[0], unit)
                         except ValueError as ex:
                             # Ignore error. val will just remain a string.
                             pass


### PR DESCRIPTION
## Summary

Base 10 powers occur in "electrical_resistivity" and "coefficient_of_linear_thermal_expansion" which were not handled, thus returning a string instead of a FloatWithUnit object

* Fix: extract the factor and add it to the float, define the unit for the above two attributes (since such factors only seem to be present there), and return a FloatWithUnit object for these attributes. 

Example, the code,

from pymatgen import Element, FloatWithUnit

el = Element('Al')
print el.melting_point
print float(el.melting_point)
print el.melting_point.unit

print el.thermal_conductivity
print float(el.thermal_conductivity)
print el.thermal_conductivity.unit

print el.coefficient_of_linear_thermal_expansion
print float(el.coefficient_of_linear_thermal_expansion)
print el.coefficient_of_linear_thermal_expansion.unit

print el.electrical_resistivity
print float(el.electrical_resistivity)
print el.electrical_resistivity.unit

produces the following output,

933.47 K
933.47
K
235.0 W K^-1 m^-1
235.0
W K^-1 m^-1
2.31e-05 K^-1
2.31e-05
K^-1
2.7e-08 m ohm
2.7e-08
m ohm