### PR TITLE
correct unit test of periodic_table.py

### DIFF
--- a/pymatgen/core/tests/test_periodic_table.py
+++ b/pymatgen/core/tests/test_periodic_table.py
@@ -119,7 +119,7 @@ class ElementTestCase(unittest.TestCase):
         self.assertEqual(val, 235)
         self.assertEqual(str(val.unit), "W K^-1 m^-1")
         val = al.electrical_resistivity
-        self.assertEqual(val, 2.7)
+        self.assertEqual(val, 2.7e-08)
         self.assertEqual(str(val.unit), "m ohm")
 
     def test_sort(self):


### PR DESCRIPTION
## Summary

Correct unit test of Al's electrical resistivity which should be 2.7e^-8 ohm m, and not 2.7 ohm m.
