### PR TITLE
enable setting 3d MAGMOM in incar for spin-orbit coupling calculations

### DIFF
--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -608,10 +608,10 @@ class Incar(dict, MSONable):
         for k in keys:
             if k == "MAGMOM" and isinstance(self[k], list):
                 value = []
-                if isinstance(self[k][0], list) and "LSORBIT" in keys or \
-                        "LNONCOLLINEAR" in keys:
+                if isinstance(self[k][0], list) and self.get("LSORBIT") or \
+                        self.get("LNONCOLLINEAR"):
                     value.append(" ".join(str(i) for j in self[k] for i in j))
-                elif "LSORBIT" in keys or "LNONCOLLINEAR" in keys:
+                elif self.get("LSORBIT") or self.get("LNONCOLLINEAR"):
                     for m, g in itertools.groupby(self[k]):
                         value.append("3*{}*{}".format(len(tuple(g)), m))
                 else:

--- a/pymatgen/io/vasp/tests/test_inputs.py
+++ b/pymatgen/io/vasp/tests/test_inputs.py
@@ -432,6 +432,37 @@ SYSTEM     =  Id=[0] dblock_code=[97763-icsd] formula=[li mn (p o4)] sg_name=[p 
 TIME       =  0.4"""
         self.assertEqual(s, ans)
 
+    def test_lsorbit_magmom(self):
+        magmom1 = [[0.0, 0.0, 3.0], [0, 1, 0], [2, 1, 2]]
+        magmom2 = [-1,-1,-1, 0, 0, 0, 0 ,0 ]
+
+        ans_string1 = "LSORBIT = True\nMAGMOM = 0.0 0.0 3.0 0 1 0 2 1 2\n"
+        ans_string2 = "LSORBIT = True\nMAGMOM = 3*3*-1 3*5*0\n"
+        ans_string3 = "LSORBIT = False\nMAGMOM = 2*-1 2*9\n"
+
+        incar = Incar({})
+        incar["MAGMOM"] = magmom1
+        incar["LSORBIT"] = "T"
+        self.assertEqual(ans_string1, str(incar))
+
+        incar["MAGMOM"] = magmom2
+        incar["LSORBIT"] = "T"
+        self.assertEqual(ans_string2, str(incar))
+
+        incar = Incar.from_string(ans_string1)
+        self.assertEqual(incar["MAGMOM"], [[0.0, 0.0, 3.0], [0, 1, 0], [2, 1, 2]])
+
+        incar = Incar.from_string(ans_string2)
+        self.assertEqual(incar["MAGMOM"], [[-1, -1, -1], [-1, -1, -1],
+                                           [-1, -1, -1], [0, 0, 0],
+                                           [0, 0, 0], [0, 0, 0],
+                                           [0, 0, 0], [0, 0, 0]])
+
+        incar = Incar.from_string(ans_string3)
+        self.assertFalse(incar["LSORBIT"])
+        self.assertEqual(incar["MAGMOM"], [-1, -1, 9, 9])
+
+
 class KpointsTest(unittest.TestCase):
 
     def test_init(self):


### PR DESCRIPTION
## Summary

Allow [x,y,z] values for each ion in MAGMOM when LSORBIT or LNONCOLLINEAR is set.
This makes the "MAGMOM" value a list of lists for spin-orbit coupling calculations. Please see the tests.
