### PR TITLE
Minor fix in vaso.io.inputs

### DIFF
--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -445,12 +445,13 @@ class Poscar(MSONable):
             lines.append("")
             if self.predictor_corrector_preamble:
                 lines.append(self.predictor_corrector_preamble)
+                pred = np.array(self.predictor_corrector)
+                for col in range(3):
+                    for z in pred[:,col]:
+                        lines.append(" ".join([format_str.format(i) for i in z]))
             else:
-                raise ValueError("Preamble information missing or corrupt.")
-            pred = np.array(self.predictor_corrector)
-            for col in range(3):
-                for z in pred[:,col]:
-                    lines.append(" ".join([format_str.format(i) for i in z]))
+                warnings.warn("Preamble information missing or corrupt.\n \
+                               Not able to write predictor corrector data.")
 
         return "\n".join(lines) + "\n"
 

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -451,7 +451,7 @@ class Poscar(MSONable):
                         lines.append(" ".join([format_str.format(i) for i in z]))
             else:
                 warnings.warn("Preamble information missing or corrupt.\n \
-                               Not able to write predictor corrector data.")
+                               Writing Poscar with no predictor corrector data.")
 
         return "\n".join(lines) + "\n"
 

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -450,8 +450,8 @@ class Poscar(MSONable):
                     for z in pred[:,col]:
                         lines.append(" ".join([format_str.format(i) for i in z]))
             else:
-                warnings.warn("Preamble information missing or corrupt.\n \
-                               Writing Poscar with no predictor corrector data.")
+                warnings.warn("Preamble information missing or corrupt. " +
+                              "Writing Poscar with no predictor corrector data.")
 
         return "\n".join(lines) + "\n"
 


### PR DESCRIPTION
## Summary
Revision to properly handle the specific case when a _Structure_ that has predictor_corrector site_properties (e.g. obtained from a _Poscar_ parsed from MD CONTCAR) is reused to generate a new _Poscar_ and write inputs.
* Fix: Rather than raising a ValueError for missing predictor_corrector_preamble, a warning is raised and POSCAR is properly written excluding the entire predictor corrector chunk.
* This fix ensures that; for example, the existing MITMDVasp input sets work as before, with a Structure obtained from a previous MD run, without raising a "No predictor corrector preamble" error.