### PR TITLE
Refactor outcar

### DIFF
--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -1517,7 +1517,6 @@ class Outcar(MSONable):
                 table_contents.append(processed_line)
             tables.append(table_contents)
         if last_one_only:
-            import pdb; pdb.set_trace()
             retained_data = tables[-1]
         else:
             retained_data = tables
@@ -1592,7 +1591,14 @@ class Outcar(MSONable):
         """
         Parse the piezo tensor data
         """
-        pass
+        header_pattern = "PIEZOELECTRIC TENSOR  for field in x, y, z\s+\(C/m\^2\)\s+" \
+                         "([X-Z][X-Z]\s+)+" \
+                         "\-+"
+        row_pattern = "[x-z]\s+"+"\s+".join(["(\-*[\.\d]+)"] * 6)
+        footer_pattern = "BORN EFFECTIVE"
+        pt_table = self.read_table_pattern(header_pattern, row_pattern,
+                                           footer_pattern, postprocess=float)
+        self.data["piezo_tensor"] = pt_table
 
     def read_corrections(self, reverse=True, terminate_on_match=True):
         patterns = {

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -1320,7 +1320,6 @@ class Outcar(MSONable):
         total_mag = None
         nelect = None
         efermi = None
-        elastic_tensor = None
         total_energy = None
 
         time_patt = re.compile("\((sec|kb)\)")
@@ -1404,28 +1403,12 @@ class Outcar(MSONable):
                     run_stats['cores'] = line.split()[2]
                     break
 
-        # 6x6 tensor matrix for TOTAL ELASTIC MODULI
-        tensor_matrix = []
-        tag = "TOTAL ELASTIC MODULI (kBar)"
-        if tag in all_lines:
-            for clean in all_lines:
-                if etensor_patt.search(clean):
-                    tok = clean.strip().split()
-                    tok.pop(0)
-                    tok = [float(i) for i in tok]
-                    tensor_matrix.append(tok)
-            total_elm = [tensor_matrix[i] for i in range(18, 24)]
-            elastic_tensor = np.asarray(total_elm).reshape(6, 6)
-        else:
-            pass
-
         self.run_stats = run_stats
         self.magnetization = tuple(mag)
         self.charge = tuple(charge)
         self.efermi = efermi
         self.nelect = nelect
         self.total_mag = total_mag
-        self.elastic_tensor = elastic_tensor
         self.final_energy = total_energy
         self.data = {}
 

--- a/pymatgen/io/vasp/tests/test_outputs.py
+++ b/pymatgen/io/vasp/tests/test_outputs.py
@@ -451,15 +451,24 @@ class OutcarTest(unittest.TestCase):
         self.assertAlmostEqual(outcar.data["dipol_quadrupol_correction"], 0.03565)
         self.assertAlmostEqual(outcar.final_energy, -797.46760559)
 
-    def test_elastic_tensor(self):
+    def test_read_elastic_tensor(self):
         filepath = os.path.join(test_dir, "OUTCAR.total_tensor.Li2O.gz")
         outcar = Outcar(filepath)
 
-        elastic_tensor = outcar.elastic_tensor
+        outcar.read_elastic_tensor()
 
-        self.assertAlmostEqual(elastic_tensor[0][0], 1986.3391)
-        self.assertAlmostEqual(elastic_tensor[0][1], 187.8324)
-        self.assertAlmostEqual(elastic_tensor[3][3], 586.3034)
+        self.assertAlmostEqual(outcar.data["elastic_tensor"][0][0], 1986.3391)
+        self.assertAlmostEqual(outcar.data["elastic_tensor"][0][1], 187.8324)
+        self.assertAlmostEqual(outcar.data["elastic_tensor"][3][3], 586.3034)
+
+    def test_read_piezo_tensor(self):
+        filepath = os.path.join(test_dir, "OUTCAR.lepsilon.gz")
+        outcar = Outcar(filepath)
+
+        outcar.read_piezo_tensor()
+        self.assertAlmostEqual(outcar.data["piezo_tensor"][0][0], 0.52799)
+        self.assertAlmostEqual(outcar.data["piezo_tensor"][1][3], 0.35998)
+        self.assertAlmostEqual(outcar.data["piezo_tensor"][2][5], 0.35997)
 
     def test_core_state_eigen(self):
         filepath = os.path.join(test_dir, "OUTCAR.CL")


### PR DESCRIPTION
## Summary

Uses @xhqu1981's table parser for the elastic and piezo tensors.

* Elastic and piezo tensors read in separate methods using read_table_pattern
* Elastic and piezo tensors are stored in outcar.data, rather than as attributes of outcar

## TODO (if any)

It looks like some parts of the lepsilon parsing methods should be refactored as well using the table_parsing method.  I can go ahead and refactor these as seems prudent from the code, but I don't know much about how these methods are used.