### PR TITLE
Removed glitch 

### DIFF
--- a/pymatgen/core/lattice.py
+++ b/pymatgen/core/lattice.py
@@ -906,7 +906,7 @@ class Lattice(MSONable):
                 fcoords, dists, inds
         """
         recp_len = np.array(self.reciprocal_lattice_crystallographic.abc)
-        nmax = r * recp_len + 0.01
+        nmax = float(r) * recp_len + 0.01
 
         pcoords = self.get_fractional_coords(center)
         center = np.array(center)


### PR DESCRIPTION
Removed glitch when attempting to (unsuccessfully) multiply a float carrying a length unit with a non-units carrying matrix in lattice.py.
The weird part was that for some structures that I'm currently testing the issue resulted in a true error and sometimes not.