### PR TITLE
add read_velocities option in Poscar

### DIFF
--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -446,9 +446,12 @@ class Poscar(MSONable):
             lines.append(line)
 
         if self.velocities:
-            lines.append("")
-            for v in self.velocities:
-                lines.append(" ".join([format_str.format(i) for i in v]))
+            try:
+                lines.append("")
+                for v in self.velocities:
+                    lines.append(" ".join([format_str.format(i) for i in v]))
+            except:
+                warnings.warn("Velocities are missing or corrupted.")
 
         if self.predictor_corrector:
             lines.append("")

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -189,7 +189,7 @@ class Poscar(MSONable):
         super(Poscar, self).__setattr__(name, value)
 
     @staticmethod
-    def from_file(filename, check_for_POTCAR=True):
+    def from_file(filename, check_for_POTCAR=True, read_velocities=True):
         """
         Reads a Poscar from a file.
 
@@ -214,6 +214,8 @@ class Poscar(MSONable):
             filename (str): File name containing Poscar data.
             check_for_POTCAR (bool): Whether to check if a POTCAR is present
                 in the same directory as the POSCAR. Defaults to True.
+            read_velocities (bool): Whether to read or not velocities if they
+                are present in the POSCAR. Default is True.
 
         Returns:
             Poscar object.
@@ -230,10 +232,10 @@ class Poscar(MSONable):
                     except:
                         names = None
         with zopen(filename, "rt") as f:
-            return Poscar.from_string(f.read(), names)
+            return Poscar.from_string(f.read(), names, read_velocities=read_velocities)
 
     @staticmethod
-    def from_string(data, default_names=None):
+    def from_string(data, default_names=None, read_velocities=True):
         """
         Reads a Poscar from a string.
 
@@ -257,6 +259,8 @@ class Poscar(MSONable):
             data (str): String containing Poscar data.
             default_names ([str]): Default symbols for the POSCAR file,
                 usually coming from a POTCAR in the same directory.
+            read_velocities (bool): Whether to read or not velocities if they
+                are present in the POSCAR. Default is True.
 
         Returns:
             Poscar object.
@@ -356,33 +360,38 @@ class Poscar(MSONable):
                            to_unit_cell=False, validate_proximity=False,
                            coords_are_cartesian=cart)
 
-        # Parse velocities if any
-        velocities = []
-        if len(chunks) > 1:
-            for line in chunks[1].strip().split("\n"):
-                velocities.append([float(tok) for tok in line.split()])
+        if read_velocities:
+            # Parse velocities if any
+            velocities = []
+            if len(chunks) > 1:
+                for line in chunks[1].strip().split("\n"):
+                    velocities.append([float(tok) for tok in line.split()])
 
-        # Parse the predictor-corrector data
-        predictor_corrector = []
-        predictor_corrector_preamble = None
+            # Parse the predictor-corrector data
+            predictor_corrector = []
+            predictor_corrector_preamble = None
 
-        if len(chunks) > 2:
-            lines = chunks[2].strip().split("\n")
-            # There are 3 sets of 3xN Predictor corrector parameters
-            # So can't be stored as a single set of "site_property"
+            if len(chunks) > 2:
+                lines = chunks[2].strip().split("\n")
+                # There are 3 sets of 3xN Predictor corrector parameters
+                # So can't be stored as a single set of "site_property"
 
-            # First line in chunk is a key in CONTCAR
-            # Second line is POTIM
-            # Third line is the thermostat parameters
-            predictor_corrector_preamble = lines[0] + "\n" + lines[1]+"\n" + lines[2]
-            # Rest is three sets of parameters, each set contains
-            # x, y, z predictor-corrector parameters for every atom in orde
-            lines = lines[3:]
-            for st in range(nsites):
-                d1 = [float(tok) for tok in lines[st].split()]
-                d2 = [float(tok) for tok in lines[st+nsites].split()]
-                d3 = [float(tok) for tok in lines[st+2*nsites].split()]
-                predictor_corrector.append([d1,d2,d3])
+                # First line in chunk is a key in CONTCAR
+                # Second line is POTIM
+                # Third line is the thermostat parameters
+                predictor_corrector_preamble = lines[0] + "\n" + lines[1]+"\n" + lines[2]
+                # Rest is three sets of parameters, each set contains
+                # x, y, z predictor-corrector parameters for every atom in orde
+                lines = lines[3:]
+                for st in range(nsites):
+                    d1 = [float(tok) for tok in lines[st].split()]
+                    d2 = [float(tok) for tok in lines[st+nsites].split()]
+                    d3 = [float(tok) for tok in lines[st+2*nsites].split()]
+                    predictor_corrector.append([d1,d2,d3])
+        else:
+            velocities = None
+            predictor_corrector = None
+            predictor_corrector_preamble = None
 
         return Poscar(struct, comment, selective_dynamics, vasp5_symbols,
                       velocities=velocities,


### PR DESCRIPTION
## Summary

* add read_velocities option in Poscar class method from_file
* check velocities when write a POSCAR file

## Comment

I write a comment in case of there is a better way to solve the problem. The pull request solve the error of the example at the end of this message.

Actually, the problem comes from the site_properties property of the Structure class (see below). 

```py
@property
def site_properties(self):
    """
    Returns the site properties as a dict of sequences. E.g.,
    {"magmom": (5,-5), "charge": (-4,4)}.
    """
    props = {}
    prop_keys = set()
    for site in self:
        prop_keys.update(site.properties.keys())

    for k in prop_keys:
        props[k] = [site.properties.get(k, None) for site in self]
    return props
```

That property returns the value None if you ask for a property which does not exist for the given site of the structure. Thus if you are working on a structure where sites have specific properties, you have to manually update them. For example in the case of POSCAR files, if you add or remove atoms and velocities is a property of the site of the strucutre, when you try to write the POSCAR file, velocities of added atom is None and thus you obtain an error message.

Maybe the follwing exampel is clearer : 
```
In [1]: import pymatgen as mg

In [2]: poscar = mg.io.vasp.inputs.Poscar.from_file("CONTCAR")

In [3]: poscar.structure.insert(0, "O", [0.2, 0.3, 0.4])

In [4]: poscar.velocities
Out[4]: [None, [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]

In [5]: poscar.write_file("test.vasp")
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-5-5972e896ad38> in <module>()
----> 1 poscar.write_file("test.vasp")

/home/r/user/g/gvallver/git/pymatgen/pymatgen/io/vasp/inputs.py in write_file(self, filename, **kwargs)
    443         """
    444         with zopen(filename, "wt") as f:
--> 445             f.write(self.get_string(**kwargs))
    446 
    447     def as_dict(self):

/home/r/user/g/gvallver/git/pymatgen/pymatgen/io/vasp/inputs.py in get_string(self, direct, vasp4_compatible, significant_figures)
    417             lines.append("")
    418             for v in self.velocities:
--> 419                 lines.append(" ".join([format_str.format(i) for i in v]))
    420 
    421         if self.predictor_corrector:

TypeError: 'NoneType' object is not iterable
```