### PR TITLE
Refactor piezo

### DIFF
--- a/pymatgen/analysis/elasticity/elastic.py
+++ b/pymatgen/analysis/elasticity/elastic.py
@@ -46,7 +46,7 @@ class ElasticTensor(TensorBase):
         subclassing numpy ndarrays.
 
         Args:
-            input_array (3x3x3x3 array-like): the Voigt-notation 6x6 array-like
+            input_array (3x3x3x3 array-like): the 3x3x3x3 array-like
                 representing the elastic tensor
 
             tol (float): tolerance for initial symmetry test of tensor

--- a/pymatgen/analysis/elasticity/elastic.py
+++ b/pymatgen/analysis/elasticity/elastic.py
@@ -39,11 +39,11 @@ class ElasticTensor(TensorBase):
     def __new__(cls, input_array, tol=1e-3):
         """
         Create an ElasticTensor object.  The constructor throws an error if
-        the shape of the input_matrix argument is not 6x6, i. e. in Voigt-
-        notation.  Also issues a warning if the input_matrix argument is
-        not symmetric.  Note that the constructor uses __new__ rather than
-        __init__ according to the standard method of subclassing numpy
-        ndarrays.
+        the shape of the input_matrix argument is not 3x3x3x3, i. e. in true
+        tensor notation.  Issues a warning if the input_matrix argument does
+        not satisfy standard symmetries.  Note that the constructor uses
+        __new__ rather than __init__ according to the standard method of
+        subclassing numpy ndarrays.
 
         Args:
             input_array (3x3x3x3 array-like): the Voigt-notation 6x6 array-like

--- a/pymatgen/analysis/piezo.py
+++ b/pymatgen/analysis/piezo.py
@@ -67,6 +67,9 @@ class PiezoTensor(TensorBase):
                 representing the piezo tensor
         """
         voigt_matrix = np.array(voigt_matrix)
+        if voigt_matrix.shape != (3, 6):
+            raise ValueError("PiezoTensor.from_voigt takes "
+                             "a 3x6 array-like as input.")
         c = np.zeros((3, 3, 3))
         for i in range(3):
             for p in range(6):
@@ -85,11 +88,6 @@ class PiezoTensor(TensorBase):
                 to the piezo tensor
             tol (float): tolerance for the symmetry test of the tensor
         """
-        # Test symmetry of piezo tensor
-        c_ijk = np.array(c_ijk)
-        if not (c_ijk - np.transpose(c_ijk, (0, 2, 1)) < tol).all():
-            raise ValueError("Input piezo tensor does "
-                             "not satisfy necessary symmetries")
         # Construct piezo tensor
         c_ip = np.zeros((3, 6))
         for i in range(3):

--- a/pymatgen/analysis/piezo.py
+++ b/pymatgen/analysis/piezo.py
@@ -93,6 +93,6 @@ class PiezoTensor(TensorBase):
         for i in range(3):
             for p in range(6):
                 j, k = voigt_map[p]
-                c_ip[i, p] = c_ijk[i, j, k]
+                c_ip[i, p] = self[i, j, k]
 
         return c_ip

--- a/pymatgen/analysis/piezo.py
+++ b/pymatgen/analysis/piezo.py
@@ -10,6 +10,8 @@ This module provides classes for the Piezoelectric tensor
 """
 from pymatgen.core.operations import SymmOp
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
+from pymatgen.analysis.elasticity.tensors import TensorBase
+from pymatgen.analysis.elasticity import voigt_map
 import numpy as np
 import warnings
 from six.moves import range
@@ -22,151 +24,77 @@ __email__ = "shyamd@lbl.gov"
 __status__ = "Development"
 __date__ = "Feb, 2016"
 
-voigt_map = [(0, 0), (1, 1), (2, 2), (1, 2), (2, 0), (0, 1)]
 
-
-class PiezoTensor(np.ndarray):
+class PiezoTensor(TensorBase):
     """
-    This class describes the 3 x 6 piezo tensor in Voigt-notation
+    This class describes the 3x6 piezo tensor in Voigt-notation
     """
 
-    def __new__(cls, input_array):
+    def __new__(cls, input_array, tol=1e-3):
         """
         Create an PiezoTensor object.  The constructor throws an error if
-        the shape of the input_matrix argument is not 3x6, i. e. in Voigt-
-        notation. Note that the constructor uses __new__ rather than
+        the shape of the input_matrix argument is not 3x3x3, i. e. in true
+        tensor notation. Note that the constructor uses __new__ rather than
         __init__ according to the standard method of subclassing numpy
         ndarrays.
 
         Args:
-            input_matrix (3x6 array-like): the Voigt-notation 3x6 array-like
+            input_matrix (3x3x3 array-like): the 3x6 array-like
                 representing the piezo tensor
         """
-        obj = np.asarray(input_array).view(cls)
-        if obj.shape != (3, 6):
+        obj = TensorBase(input_array).view(cls)
+        if obj.shape != (3, 3, 3):
             raise ValueError("Default piezo tensor constructor requires "
-                             "input argument to be the Voigt-notation 3x6 "
-                             "array.  To construct from a 3x3x3 array, use "
-                             "PiezoTensor.from_full_tensor")
+                             "input argument to be the true 3x3x3 "
+                             "array.  To construct from a 3x6 array, use "
+                             "PiezoTensor.from_voigt")
+        if not (obj - np.transpose(obj, (0, 2, 1)) < tol).all():
+            warnings.warn("Input piezo tensor does "
+                          "not satisfy standard symmetries")
         return obj
 
     def __array_finalize__(self, obj):
         if obj is None:
             return
 
-    @property
-    def full_tensor(self):
+    @classmethod
+    def from_voigt(cls, voigt_matrix, tol=1e-2):
         """
-        Returns the tensor in standard notation (i. e.
-        a 3th order 3-dimensional tensor, C_{ijk}), which
-        is represented in a np.array with shape (3,3,3)
+        Constructor based on 3x6 voigt-notation tensor
+
+        Args:
+            voigt_matrix: (3x6 array-like): The Voigt notation 3x6 array-like
+                representing the piezo tensor
         """
+        voigt_matrix = np.array(voigt_matrix)
         c = np.zeros((3, 3, 3))
         for i in range(3):
             for p in range(6):
                 j, k = voigt_map[p]
-                c[i, j, k] = c[i, k, j] = self[i, p]
-        return c
+                c[i, j, k] = c[i, k, j] = voigt_matrix[i, p]
+        return cls(c)
 
-    @classmethod
-    def from_full_tensor(cls, c_ijk, tol=1e-5):
+    @property
+    def voigt(self):
         """
-        Factory method to construct piezo tensor from third order
-        tensor C_ijk.  First tests for appropriate symmetries and then
-        constructs the 3x6 voigt notation tensor.
+        Returns the 3x6 voigt notation tensor corresponding 
+        to the piezo tensor.
 
         Args:
             c_ijkl (3x3x3 array-like): third order tensor corresponding
                 to the piezo tensor
             tol (float): tolerance for the symmetry test of the tensor
         """
-        # Test symmetry of elastic tensor
+        # Test symmetry of piezo tensor
         c_ijk = np.array(c_ijk)
         if not (c_ijk - np.transpose(c_ijk, (0, 2, 1)) < tol).all():
             raise ValueError("Input piezo tensor does "
                              "not satisfy necessary symmetries")
-        # Construct elastic tensor
+        # Construct piezo tensor
         c_ip = np.zeros((3, 6))
         for i in range(3):
             for p in range(6):
                 j, k = voigt_map[p]
                 c_ip[i, p] = c_ijk[i, j, k]
 
-        return cls(c_ip)
-
-    def __array_wrap__(self, obj):
-        """
-        Overrides __array_wrap__ methods in ndarray superclass to avoid errors
-        associated with functions that return scalar values
-        """
-
-        if len(obj.shape) == 0:
-            return obj[()]
-        else:
-            return np.ndarray.__array_wrap__(self, obj)
-
-    def __hash__(self):
-        """
-        define a hash function, since numpy arrays
-        have their own __eq__ method
-        """
-        return hash(self.tostring())
-
-    def __repr__(cls):
-        return "{}({})".format(cls.__class__.__name__,
-                               cls.__str__())
-
-    def transform(self, sym):
-        """
-        Returns a transformed tensor based on input of symmetry operation
-
-        Args:
-            symp (SymmOp): symmetry operation
-        """
-        return PiezoTensor.from_full_tensor(sym.transform_tensor(self.full_tensor))
-
-    def is_valid(self, structure, symprec=0.1, tol=1e-3):
-        """
-        Checks the piezo tensor against the symmetries of the structure and
-        determine if the piezoelectric tensor is valid for that structure
-
-        Args:
-            structure (Structure): structure to check against
-            symprec (float): Tolerance for symmetry finding, default good for
-                             as-made structures. Set to 0.1 for MP structures
-            tol (float): tolerance for equality
-        """
-
-        sg = SpacegroupAnalyzer(structure, symprec)
-
-        # Check every symmetry operation in the space group
-        for symm in sg.get_symmetry_operations(cartesian=True):
-            # does it produce the same tensor?
-            diff = self.transform(symm) - self
-            if not (np.abs(diff) < tol).all():
-                print(diff)
-                return False
-
-        return True
-
-    def symmeterize(self, structure, symprec=0.1, tol=1e-3):
-        """
-        Averages the piezo tensor based on the symmetries of the structure
-
-        Args:
-            structure (Structure): structure to check against
-            symprec (float): Tolerance for symmetry finding, default good for
-                             as-made structures. Set to 0.1 for MP structures
-            tol (float): tolerance for zero'ing out indicies. The average procedure produces very small numbers rather then 0. This tolerance is used to zero out those values to make the tensor less messy.
-        """
-
-        sg = SpacegroupAnalyzer(structure, symprec)
-        new_pt = PiezoTensor(self)
-
-        for symm in sg.get_symmetry_operations(cartesian=True):
-            new_pt = (new_pt + new_pt.transform(symm)) / 2
-
-        low_values_indices = np.abs(new_pt) < tol
-        new_pt [low_values_indices] = 0
-
-        return new_pt
+        return c_ip

--- a/pymatgen/analysis/tests/test_piezo.py
+++ b/pymatgen/analysis/tests/test_piezo.py
@@ -27,37 +27,42 @@ test_dir = os.path.join(os.path.dirname(__file__), "..", "..", "..",
 
 
 class PiezoTest(PymatgenTest):
+    def setUp(self):
+        self.piezo_struc = self.get_structure('BaNiO3')
+        self.voigt_matrix = np.array([[0., 0., 0., 0., 0.03839, 0.],
+                                      [0., 0., 0., 0.03839, 0., 0.],
+                                      [6.89822, 6.89822, 27.46280, 0., 0., 0.]])
+        self.full_tensor_array = [[[0., 0., 0.03839],
+                                   [0., 0., 0.],
+                                   [0.03839, 0., 0.]],
+                                  [[0., 0., 0.],
+                                   [0., 0., 0.03839],
+                                   [0.,  0.03839,  0.]],
+                                  [[6.89822, 0., 0.],
+                                   [0.,  6.89822, 0.],
+                                   [0.,  0.,  27.4628]]]
+    def test_new(self):
+        pt = PiezoTensor(self.full_tensor_array)
+        self.assertArrayAlmostEqual(pt, self.full_tensor_array)
+        bad_dim_array = np.zeros((3, 3))
+        self.assertRaises(ValueError, PiezoTensor, bad_dim_array)
 
-    def runTest(self):
+        bad_pt = PiezoTensor.from_voigt([[0., 0., 1., 0., 0.03839, 2.],
+                                         [0., 0., 0., 0.03839, 0., 0.],
+                                         [6.89822, 6.89822, 27.4628, 0., 0., 0.]])
 
-        piezo_struc = self.get_structure('BaNiO3')
-        tensor = np.asarray([[0., 0., 0., 0., 0.03839, 0.],
-                             [0., 0., 0., 0.03839, 0., 0.],
-                             [6.89822, 6.89822, 27.46280, 0., 0., 0.]]).reshape(3, 6)
-        pt = PiezoTensor(tensor)
-        full_tensor = [[[0., 0., 0.03839],
-                        [0., 0., 0.],
-                        [0.03839, 0., 0.]],
-                       [[0., 0., 0.],
-                        [0., 0., 0.03839],
-                        [0.,  0.03839,  0.]],
-                       [[6.89822, 0., 0.],
-                        [0.,  6.89822, 0.],
-                        [0.,  0.,  27.4628]]]
-        bad_pt = PiezoTensor([[0., 0., 1., 0., 0.03839, 2.],
-                              [0., 0., 0., 0.03839, 0., 0.],
-                              [6.89822, 6.89822, 27.4628, 0., 0., 0.]])
+        sym_pt = bad_pt.symmeterized(piezo_struc)
+        alt_tensor = pt(full_tensor)
 
-        sym_pt = bad_pt.symmeterize(piezo_struc)
-        alt_tensor = pt.from_full_tensor(full_tensor)
-
-        self.assertArrayAlmostEqual(pt.full_tensor, full_tensor)
+        self.assertArrayAlmostEqual(pt.voigt, full_tensor)
         self.assertArrayEqual(pt, alt_tensor)
         #TODO Recheck this test. Commented out for now to enable Py3k testing.
-        self.assertTrue(pt.is_valid(piezo_struc))
+        self.assertTrue(pt.is_fit_to_structure(piezo_struc))
 
-        self.assertTrue(sym_pt.is_valid(piezo_struc))
+        self.assertTrue(sym_pt.is_fit_to_structure(piezo_struc))
         self.assertArrayAlmostEqual(sym_pt, pt)
+
+    def test_from_voigt(self):
 
 if __name__ == '__main__':
     unittest.main()

--- a/pymatgen/analysis/tests/test_piezo.py
+++ b/pymatgen/analysis/tests/test_piezo.py
@@ -41,28 +41,18 @@ class PiezoTest(PymatgenTest):
                                   [[6.89822, 0., 0.],
                                    [0.,  6.89822, 0.],
                                    [0.,  0.,  27.4628]]]
+    
     def test_new(self):
         pt = PiezoTensor(self.full_tensor_array)
         self.assertArrayAlmostEqual(pt, self.full_tensor_array)
         bad_dim_array = np.zeros((3, 3))
         self.assertRaises(ValueError, PiezoTensor, bad_dim_array)
 
-        bad_pt = PiezoTensor.from_voigt([[0., 0., 1., 0., 0.03839, 2.],
-                                         [0., 0., 0., 0.03839, 0., 0.],
-                                         [6.89822, 6.89822, 27.4628, 0., 0., 0.]])
-
-        sym_pt = bad_pt.symmeterized(piezo_struc)
-        alt_tensor = pt(full_tensor)
-
-        self.assertArrayAlmostEqual(pt.voigt, full_tensor)
-        self.assertArrayEqual(pt, alt_tensor)
-        #TODO Recheck this test. Commented out for now to enable Py3k testing.
-        self.assertTrue(pt.is_fit_to_structure(piezo_struc))
-
-        self.assertTrue(sym_pt.is_fit_to_structure(piezo_struc))
-        self.assertArrayAlmostEqual(sym_pt, pt)
-
     def test_from_voigt(self):
+        bad_voigt = np.zeros((3, 7))
+        pt = PiezoTensor.from_voigt(self.voigt_matrix)
+        self.assertArrayEqual(pt, self.full_tensor_array)
+        self.assertRaises(ValueError, PiezoTensor.from_voigt, bad_voigt)
 
 if __name__ == '__main__':
     unittest.main()

--- a/pymatgen/analysis/tests/test_piezo.py
+++ b/pymatgen/analysis/tests/test_piezo.py
@@ -53,6 +53,7 @@ class PiezoTest(PymatgenTest):
         pt = PiezoTensor.from_voigt(self.voigt_matrix)
         self.assertArrayEqual(pt, self.full_tensor_array)
         self.assertRaises(ValueError, PiezoTensor.from_voigt, bad_voigt)
+        self.assertArrayEqual(self.voigt_matrix, pt.voigt)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR refactors PiezoTensor to subclass TensorBase primarily so that it inherits the fit_to_structure and is_fit_to_structure methods, rather than implementing the symmetrization methods explicitly.  Note that, like ElasticTensor, PiezoTensor's default constructor now takes the 3x3x3 true tensor notation as input, and uses PiezoTensor.from_voigt to construct from the Voigt-notation 3x6 matrix.

* PiezoTensor subclasses TensorBase
* Removed PiezoTensor-specific symmetrization operations
* Fixed some typos in documentation of elasticity
* Updated Piezo unittests accordingly

## TODO (if any)

PiezoTensor needs a few more methods associated with calculations on the MP website, i. e. maximum piezoelectric modulus and direction.