### PR TITLE
internal pmg4 compat: use scipy.constants

### DIFF
--- a/pymatgen/io/gaussian.py
+++ b/pymatgen/io/gaussian.py
@@ -25,8 +25,9 @@ from pymatgen.core.operations import SymmOp
 from pymatgen.core import Element, Molecule, Composition
 from monty.io import zopen
 from pymatgen.util.coord_utils import get_angle
-import pymatgen.core.physical_constants as cst
+import scipy.constants as cst
 
+HARTREE_TO_ELECTRON_VOLT = 1/cst.physical_constants["electron volt-hartree relationship"][0]
 
 def read_route_line(route):
     """
@@ -940,7 +941,7 @@ class GaussianOutput(object):
         plt.ylabel("Energy   /   eV")
         
         e_min = min(d["energies"])
-        y = [(e - e_min) * cst.HARTREE_TO_ELECTRON_VOLT for e in d["energies"]]
+        y = [(e - e_min) * HARTREE_TO_ELECTRON_VOLT for e in d["energies"]]
         
         plt.plot(x, y, "ro--")
         return plt


### PR DESCRIPTION
## Summary

If the `core.physical_constants` module will be removed in pmg 4.0 as the module warns, this change or similar is necessary. Currently, a deprecation warning is given with as little as `from pymatgen import __version__`.

* `pymatgen.core.physical_constants` --> `scipy.constants`
* define `HARTREE_TO_ELECTRON_VOLT` locally
* Other constants (`h`, `c`, and `e`) used in file are already members of `scipy.constants`
