### PR TITLE
Cast spacegroup_number to int

### DIFF
--- a/pymatgen/symmetry/analyzer.py
+++ b/pymatgen/symmetry/analyzer.py
@@ -126,7 +126,7 @@ class SpacegroupAnalyzer(object):
         Returns:
             (int): International spacegroup number for structure.
         """
-        return self._spacegroup_data["number"]
+        return int(self._spacegroup_data["number"])
 
     def get_hall(self):
         """


### PR DESCRIPTION
## Summary

_spacegroup_data["number"] is `long`. Can safely cast to `int` and match method signature.

Closes #421