### PR TITLE
Added Rotate_Tensor method to TensorBase class which rotates a tensor… 

### DIFF
--- a/pymatgen/analysis/elasticity/tensors.py
+++ b/pymatgen/analysis/elasticity/tensors.py
@@ -24,6 +24,7 @@ __date__ = "March 22, 2012"
 
 
 from scipy.linalg import polar
+from scipy.linalg import sqrtm
 import numpy as np
 import itertools
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
@@ -114,6 +115,25 @@ class TensorBase(np.ndarray):
         sop = SymmOp.from_rotation_and_translation(matrix,
                                                    [0., 0., 0.])
         return self.transform(sop)
+
+    def rotate_tensor(self, initial_struct, final_struct):
+        """ 
+        Applies a transformation on tensor and returns the tensor in the final
+        basis set given a initial and final structure files
+        """
+
+        initialsg = SpacegroupAnalyzer(initial_struct)
+        finalsg = SpacegroupAnalyzer(final_struct)
+
+        rotationintial = latticeobj.get_symmetry_dataset()['transformation_matrix']
+        rotationfinal = conventionalsg.get_symmetry_dataset()['transformation_matrix']
+
+        transmatrix = np.dot(rotationprim, np.linalg.inv(rotationconv)).T
+
+        U = scipy.linalg.sqrtm(np.dot(transmatrix.T, transmatrix))
+        R = np.dot(transmatrix, np.linalg.inv(U))
+
+        return self.rotate(R)
 
 
     @property


### PR DESCRIPTION
Added  a Rotate_Tensor method to the TensorBase class which rotates a tensor from a given initial structure's basis to the final structure's basis, useful for comparing tensors from the primitive unit cell to the conventional cell or whatever final reference from we look at. Associated unit tests also added.