### PR TITLE
incorporate capabilities in CifParser to handle various errors faced while parsing CIFs from the Springer materials/Pauling file DBs

### DIFF
--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -248,6 +248,12 @@ class CifFile(object):
         d = OrderedDict()
         for x in re.split("^\s*data_", "x\n"+string,
                           flags=re.MULTILINE | re.DOTALL)[1:]:
+
+            # Skip over Cif block that contains powder diffraction data.
+            # Some elements in this block were missing from CIF files in Springer materials/Pauling file DBs.
+            # This block anyway does not contain any structure information, and CifParser was also not parsing it.
+            if 'powder_pattern' in re.split("\n", x, 1)[0]:
+                continue
             c = CifBlock.from_string("data_"+x)
             d[c.header] = c
         return cls(d, string)
@@ -487,6 +493,7 @@ class CifParser(object):
             idxs_to_remove = []
 
             for idx, el_row in enumerate(data["_atom_site_label"]):
+
                 # CIF files from the Springer Materials/Pauling File have switched the label and symbol. Thus, in the
                 # above shown example row, '0.8Nb + 0.2Zr' is the symbol. Below, we split the strings on ' + ' to
                 # check if the length (or number of elements) in the label and symbol are equal.

--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -461,6 +461,9 @@ class CifParser(object):
 
             if substitution_dictionary:
                 return substitution_dictionary.get(sym)
+            elif sym in ['OH', 'OH2']:
+                warnings.warn("Symbol '{}' not recognized".format(sym))
+                return ""
             else:
                 m = re.findall(r"w?[A-Z][a-z]*", sym)
                 if m and m != "?":

--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -527,9 +527,9 @@ class CifParser(object):
                     for et in els_occu:
                         match = get_matching_coord(coord)
                         if not match:
-                            coord_to_species[coord] = Composition({et: els_occu[et]})
+                            coord_to_species[coord] = Composition({parse_symbol(et): els_occu[parse_symbol(et)]})
                         else:
-                            coord_to_species[match] += {et: els_occu[et]}
+                            coord_to_species[match] += {parse_symbol(et): els_occu[parse_symbol(et)]}
                     idxs_to_remove.append(idx)
 
             # Remove the original row by iterating over all keys in the CIF data looking for lists, which indicates

--- a/pymatgen/io/tests/test_cif.py
+++ b/pymatgen/io/tests/test_cif.py
@@ -277,6 +277,63 @@ loop_
         parser = CifParser(os.path.join(test_dir, "Fe.cif"))
         self.assertEqual(len(parser.get_structures(primitive=False)[0]), 2)
 
+        # Below are 10 tests for CIFs from the Springer Materials/Pauling file DBs.
+
+        # Partial occupancy on sites, incorrect label, previously unparsable
+        parser = CifParser(os.path.join(test_dir, 'PF_sd_1928405.cif'))
+        for s in parser.get_structures(True):
+            self.assertEqual(s.formula, "Er1 Mn3.888 Fe2.112 Sn6")
+
+        # Partial occupancy on sites, previously parsed as an ordered structure
+        parser = CifParser(os.path.join(test_dir, 'PF_sd_1011081.cif'))
+        for s in parser.get_structures(True):
+            self.assertEqual(s.formula, "Zr0.2 Nb0.8")
+
+        # Partial occupancy on sites, incorrect label, previously unparsable
+        parser = CifParser(os.path.join(test_dir, 'PF_sd_1615854.cif'))
+        for s in parser.get_structures(True):
+            self.assertEqual(s.formula, "Na2 Al2 Si6 O16")
+
+        # Partial occupancy on sites, incorrect label, previously unparsable
+        parser = CifParser(os.path.join(test_dir, 'PF_sd_1622133.cif'))
+        for s in parser.get_structures(True):
+            self.assertEqual(s.formula, "Ca0.184 Mg13.016 Fe2.8 Si16 O48")
+
+        # Partial occupancy on sites, previously parsed as an ordered structure
+        parser = CifParser(os.path.join(test_dir, 'PF_sd_1908491.cif'))
+        for s in parser.get_structures(True):
+            self.assertEqual(s.formula, "Mn0.48 Zn0.52 Ga2 Se4")
+
+        # Partial occupancy on sites, incorrect label, previously unparsable
+        parser = CifParser(os.path.join(test_dir, 'PF_sd_1811457.cif'))
+        for s in parser.get_structures(True):
+            self.assertEqual(s.formula, "Ba2 Mg0.6 Zr0.2 Ta1.2 O6")
+
+        # Incomplete powder diffraction data, previously unparsable
+        # This CIF file contains the molecular species "NH3" which is
+        # parsed as "N" because the label is "N{x}" (x = 1,2,..) and the
+        # corresponding symbol is "NH3". Since, the label and symbol are switched
+        # in CIFs from Springer Materials/Pauling file DBs, CifParser parses the
+        # element as "N".
+        parser = CifParser(os.path.join(test_dir, 'PF_sd_1002871.cif'))
+        self.assertEqual(parser.get_structures(True)[0].formula, "Cu1 Br2 N6")
+        self.assertEqual(parser.get_structures(True)[1].formula, "Cu1 Br4 N6")
+
+        # Incomplete powder diffraction data, previously unparsable
+        parser = CifParser(os.path.join(test_dir, 'PF_sd_1704003.cif'))
+        for s in parser.get_structures():
+            self.assertEqual(s.formula, "Rb4 Mn2 F12")
+
+        # Unparsable species 'OH/OH2', previously parsed as "O"
+        parser = CifParser(os.path.join(test_dir, 'PF_sd_1500382.cif'))
+        for s in parser.get_structures():
+            self.assertEqual(s.formula, "Mg6 B2 O6 F1.764")
+
+        # Unparsable species 'OH/OH2', previously parsed as "O"
+        parser = CifParser(os.path.join(test_dir, 'PF_sd_1601634.cif'))
+        for s in parser.get_structures():
+            self.assertEqual(s.formula, "Zn1.29 Fe0.69 As2 Pb1.02 O8")
+
     def test_CifWriter(self):
         filepath = os.path.join(test_dir, 'POSCAR')
         poscar = Poscar.from_file(filepath)

--- a/test_files/PF_sd_1002871.cif
+++ b/test_files/PF_sd_1002871.cif
@@ -1,0 +1,214 @@
+##CIF_1.1
+
+data_sm_global
+#Used dictionaries
+loop_
+_audit_conform_dict_name
+_audit_conform_dict_version
+_audit_conform_dict_location
+cif_core.dic 	2.4.2 	.
+cif_pd.dic 		1.0.1 	.
+cif_sm.dic 		0.1 	'redaktion.landolt-boernstein(at)springer.com'
+
+#About this content and reference
+_sm_credits_copyright
+;PAULING FILE Multinaries Edition - 2012. SpringerMaterials Release 2014.
+http://www.paulingfile.com
+Unique LPF ID Number SD1002871
+Project Coordinator: Shuichi Iwata
+Section-Editors: Karin Cenzual (Crystal Structures), Hiroaki Okamoto (Phase
+Diagrams), Fritz Hulliger (Physical Properties)
+(c) Springer & Material Phases Data System (MPDS), Switzerland & National
+Institute for Materials Science (NIMS), Japan 2014.
+(Data generated pre-2002: (c) Springer & MPDS & NIMS;
+post-2001: (c) Springer & MPDS)
+All Rights Reserved. Version 2014.06.
+;
+
+_audit_creation_method
+;This data have been compiled from the crystallographic datasheet for
+"Cu(NH3)6Br2 (CuBr2[NH3]6 rt) Crystal Structure"
+taken from SpringerMaterials (sm_isp_sd_1002871).
+;
+
+_publ_section_references
+;Distler T., Vaughan P.A.: <i>The crystal structures of the hexaamminecopper(II) halides</i>. Inorganic Chemistry <b>6</b> (1967) 126-129.
+;
+
+#Phase classification
+_sm_phase_labels				'CuBr2[NH3]6 rt'
+_chemical_name_mineral			''
+_sm_chemical_compound_class		'bromide'
+_sm_phase_prototype				'CuCl2 [NH3 ]6 '
+_sm_pearson_symbol				'tI18'
+_symmetry_Int_Tables_number		139
+_sm_sample_details
+;powder (determination of cell and structural parameters)
+;
+_sm_measurement_details
+;automatic diffractometer (determination of cell parameters),
+automatic diffractometer; Philips (determination of structural parameters),
+X-rays, Cu K&#x03b1;; &#x03bb; = 0.15418 nm (determination of cell and structural parameters)
+;
+_sm_interpretation_details
+;positions of non-H atoms determined,
+least-squares refinement,
+<i>R</i> = 0.130
+;
+
+data_sm_isp_SD1002871-standardized_unitcell
+#Cell Parameters
+_cell_length_a					7.5986
+_cell_length_b					7.5986
+_cell_length_c					9.675
+_cell_angle_alpha				90
+_cell_angle_beta				90
+_cell_angle_gamma				90
+_sm_length_ratio_ab				1.000
+_sm_length_ratio_bc				0.785
+_sm_length_ratio_ca				1.273
+_cell_volume 					558.6
+_symmetry_space_group_name_H-M	'I4/mmm'
+_symmetry_Int_Tables_number		139
+_cell_formula_units_Z			2
+_sm_cell_transformation
+;new axes a/2-b/2,a/2+b/2,c
+;
+
+#Atom Coordinates
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_Wyckoff_symbol
+_sm_site_symmetry
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+_sm_coordination_number
+_sm_atomic_environment_type
+N1 'NH3' .8h .m.2m 0.2 0.2 0 1 1 'single atom, Cu'
+N2 'NH3' .4e .4mm 0 0 0.253 1 1 'single atom, Cu'
+Br 'Br' .4d .-4m2 0 0.5 0.25 1 12 'cuboctahedron, (NH<sub>3</sub>)<sub>12</sub>'
+Cu 'Cu' .2a .4/mmm 0 0 0 1 6 'octahedron, (NH<sub>3</sub>)<sub>6</sub>'
+
+_sm_atom_site_transformation
+;new axes a/2-b/2,a/2+b/2,c
+;
+
+#Isotropic Displacement Parameters
+loop_
+_atom_site_label_1
+_atom_site_B_iso_or_equiv
+_sm_atom_site_isotropic_displacement_parameter_type
+_atom_site_B_equiv_geom_mean
+Cu 0.047(30) 'Biso' ?
+Br 0.033(13) 'Biso' ?
+N1 -0.017(21) 'Biso' ?
+N2 -0.017(21) 'Biso' ?
+
+data_sm_isp_SD1002871-published_cell
+#Cell Parameters
+_cell_length_a					10.746(2)
+_cell_length_b					10.746(2)
+_cell_length_c					9.675(1)
+_cell_angle_alpha				90
+_cell_angle_beta				90
+_cell_angle_gamma				90
+_sm_length_ratio_ab				1.000
+_sm_length_ratio_bc				1.111
+_sm_length_ratio_ca				0.900
+_cell_volume 					1117.24
+_symmetry_space_group_name_H-M	'F4/mmm'
+_symmetry_Int_Tables_number		139
+_cell_formula_units_Z			2
+
+#Atom Coordinates
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_Wyckoff_symbol
+_sm_site_symmetry
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+_sm_coordination_number
+_sm_atomic_environment_type
+Cu 'Cu' .4a .4/mmm 0 0 0 1 ? '?'
+Br 'Br' .8d .-4m2 0.25 0.25 0.25 1 ? '?'
+N1 'NH3' .16h .m.2m 0.2(7) 0 0 1 ? '?'
+N2 'NH3' .8e .4mm 0 0 0.253(29) 1 ? '?'
+
+#Isotropic Displacement Parameters
+loop_
+_atom_site_label_1
+_atom_site_B_iso_or_equiv
+_sm_atom_site_isotropic_displacement_parameter_type
+_atom_site_B_equiv_geom_mean
+Cu 0.047(30) 'Biso' ?
+Br 0.033(13) 'Biso' ?
+N1 -0.017(21) 'Biso' ?
+N2 -0.017(21) 'Biso' ?
+
+data_sm_isp_SD1002871-niggli_reduced_cell
+#Cell Parameters
+_cell_length_a					7.2299
+_cell_length_b					7.2299
+_cell_length_c					7.2299
+_cell_angle_alpha				96.005
+_cell_angle_beta				116.596
+_cell_angle_gamma				116.596
+_sm_length_ratio_ab				1.000
+_sm_length_ratio_bc				1.000
+_sm_length_ratio_ca				1.000
+_cell_volume 					279.31
+_symmetry_space_group_name_H-M	''
+_symmetry_Int_Tables_number		?
+_cell_formula_units_Z			2
+
+#Atom Coordinates
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_Wyckoff_symbol
+_sm_site_symmetry
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+_sm_coordination_number
+_sm_atomic_environment_type
+? ? ? ? ? ? ? ? ? ?
+
+data_sm_isp_SD1002871-powder_pattern
+#Powder Pattern
+#Note: Powder patterns are provided using custom cif-fields!
+loop_
+_sm_powderpattern_unit_published_line
+_sm_powderpattern_value_published_line
+_sm_powderpattern_unit_computed_line
+_sm_powderpattern_value_computed_line
+_sm_powderpattern_intensity
+_sm_powderpattern_miller_indices_h
+_sm_powderpattern_miller_indices_k
+_sm_powderpattern_miller_indices_l
+_sm_powderpattern_radiation
+_sm_powderpattern_remark
+'d' 5.9786 'd' 0.5979 14.7 1 1 1 'Cu K&#x03b1;' ''
+'d' 5.3742 'd' 0.5374 2.8 2 0 0 'Cu K&#x03b1;' ''
+'d' 4.8410 'd' 0.4841 1.4 0 0 2 'Cu K&#x03b1;' ''
+'d' 3.8016 'd' 0.3802 33.5 2 2 0 'Cu K&#x03b1;' ''
+'d' 3.5960 'd' 0.3596 59.7 2 0 2 'Cu K&#x03b1;' ''
+'d' 3.2076 'd' 0.3208 5.8 3 1 1 'Cu K&#x03b1;' ''
+'d' 2.9888 'd' 0.2989 65.7 2 2 2 'Cu K&#x03b1;' 'additional indices 1 1 3'
+'d' 2.6859 'd' 0.2686 46.9 4 0 0 'Cu K&#x03b1;' ''
+'d' 2.4174 'd' 0.2417 39.2 0 0 4 'Cu K&#x03b1;' ''
+'d' 2.3486 'd' 0.2349 16.0 4 0 2 'Cu K&#x03b1;' 'intensity includes next line(s)'
+'d' 2.3396 'd' 0.2340  3 1 3 'Cu K&#x03b1;' ''
+'d' 2.1520 'd' 0.2152 64.8 4 2 2 'Cu K&#x03b1;' ''
+'d' 2.0593 'd' 0.2059 65.3 5 1 1 'Cu K&#x03b1;' 'intensity includes next line(s)'
+'d' 2.0402 'd' 0.2040  2 2 4 'Cu K&#x03b1;' ''
+'d' 1.8994 'd' 0.1899 18.1 4 4 0 'Cu K&#x03b1;' ''
+'d' 1.7973 'd' 0.1797 67.8 4 0 4 'Cu K&#x03b1;' 'additional indices 6 0 0'
+'d' 1.6994 'd' 0.1699 44.2 2 6 0 'Cu K&#x03b1;' 'additional indices 2 4 4'

--- a/test_files/PF_sd_1011081.cif
+++ b/test_files/PF_sd_1011081.cif
@@ -1,0 +1,150 @@
+##CIF_1.1
+
+data_sm_global
+#Used dictionaries
+loop_
+_audit_conform_dict_name
+_audit_conform_dict_version
+_audit_conform_dict_location
+cif_core.dic 	2.4.2 	.
+cif_pd.dic 		1.0.1 	.
+cif_sm.dic 		0.1 	'redaktion.landolt-boernstein(at)springer.com'
+
+#About this content and reference
+_sm_credits_copyright
+;PAULING FILE Multinaries Edition - 2012. SpringerMaterials Release 2014.
+http://www.paulingfile.com
+Unique LPF ID Number SD1011081
+Project Coordinator: Shuichi Iwata
+Section-Editors: Karin Cenzual (Crystal Structures), Hiroaki Okamoto (Phase
+Diagrams), Fritz Hulliger (Physical Properties)
+(c) Springer & Material Phases Data System (MPDS), Switzerland & National
+Institute for Materials Science (NIMS), Japan 2014.
+(Data generated pre-2002: (c) Springer & MPDS & NIMS;
+post-2001: (c) Springer & MPDS)
+All Rights Reserved. Version 2014.06.
+;
+
+_audit_creation_method
+;This data have been compiled from the crystallographic datasheet for
+"Zr0.2Nb0.8 (Zr0.5Nb0.5 ht) Crystal Structure"
+taken from SpringerMaterials (sm_isp_sd_1011081).
+;
+
+_publ_section_references
+;Svechnikov V.N., Spektor A.T.: <i>Phase diagram of the Zr-Mo-Nb system in the solid state (up to 1800 &#x00b0;C)</i>. Russian Metallurgy (translated from Izvestiya Akademii Nauk SSSR, Metally) <b>4</b> (1968) 118-121.
+;
+
+#Phase classification
+_sm_phase_labels				'Zr0.5Nb0.5 ht'
+_chemical_name_mineral			''
+_sm_chemical_compound_class		'intermetallic'
+_sm_phase_prototype				'W'
+_sm_pearson_symbol				'cI2'
+_symmetry_Int_Tables_number		229
+_sm_sample_details
+;powder (determination of cell parameters)
+;
+_sm_measurement_details
+;X-rays (determination of cell parameters)
+;
+_sm_interpretation_details
+;cell parameters determined and type with fixed coordinates assigned
+;
+
+data_sm_isp_SD1011081-standardized_unitcell
+#Cell Parameters
+_cell_length_a					3.363
+_cell_length_b					3.363
+_cell_length_c					3.363
+_cell_angle_alpha				90
+_cell_angle_beta				90
+_cell_angle_gamma				90
+_sm_length_ratio_ab				1.000
+_sm_length_ratio_bc				1.000
+_sm_length_ratio_ca				1.000
+_cell_volume 					38
+_symmetry_space_group_name_H-M	'Im-3m'
+_symmetry_Int_Tables_number		229
+_cell_formula_units_Z			2
+_sm_cell_transformation
+;No transformation from published to standardized cell parameters necessary.
+;
+
+#Atom Coordinates
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_Wyckoff_symbol
+_sm_site_symmetry
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+_sm_coordination_number
+_sm_atomic_environment_type
+Nb,Zr '0.8Nb + 0.2Zr' .2a .m-3m 0 0 0 1 14 'rhombic dodecahedron, Nb<sub>14</sub>'
+
+_sm_atom_site_transformation
+;No transformation from published to standardized cell parameters necessary.
+;
+
+data_sm_isp_SD1011081-published_cell
+#Cell Parameters
+_cell_length_a					3.363
+_cell_length_b					3.363
+_cell_length_c					3.363
+_cell_angle_alpha				90
+_cell_angle_beta				90
+_cell_angle_gamma				90
+_sm_length_ratio_ab				1.000
+_sm_length_ratio_bc				1.000
+_sm_length_ratio_ca				1.000
+_cell_volume 					38.03
+_symmetry_space_group_name_H-M	'Im-3m'
+_symmetry_Int_Tables_number		229
+_cell_formula_units_Z			2
+
+#Atom Coordinates
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_Wyckoff_symbol
+_sm_site_symmetry
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+_sm_coordination_number
+_sm_atomic_environment_type
+Nb,Zr '0.8Nb + 0.2Zr' .2a .m-3m 0 0 0 1 ? '?'
+
+data_sm_isp_SD1011081-niggli_reduced_cell
+#Cell Parameters
+_cell_length_a					2.9124
+_cell_length_b					2.9124
+_cell_length_c					2.9124
+_cell_angle_alpha				109.471
+_cell_angle_beta				109.471
+_cell_angle_gamma				109.471
+_sm_length_ratio_ab				1.000
+_sm_length_ratio_bc				1.000
+_sm_length_ratio_ca				1.000
+_cell_volume 					19.02
+_symmetry_space_group_name_H-M	''
+_symmetry_Int_Tables_number		?
+_cell_formula_units_Z			2
+
+#Atom Coordinates
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_Wyckoff_symbol
+_sm_site_symmetry
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+_sm_coordination_number
+_sm_atomic_environment_type
+? ? ? ? ? ? ? ? ? ?

--- a/test_files/PF_sd_1500382.cif
+++ b/test_files/PF_sd_1500382.cif
@@ -1,0 +1,164 @@
+##CIF_1.1
+
+data_sm_global
+#Used dictionaries
+loop_
+_audit_conform_dict_name
+_audit_conform_dict_version
+_audit_conform_dict_location
+cif_core.dic 	2.4.2 	.
+cif_pd.dic 		1.0.1 	.
+cif_sm.dic 		0.1 	'redaktion.landolt-boernstein(at)springer.com'
+
+#About this content and reference
+_sm_credits_copyright
+;PAULING FILE Multinaries Edition - 2012. SpringerMaterials Release 2014.
+http://www.paulingfile.com
+Unique LPF ID Number SD1500382
+Project Coordinator: Shuichi Iwata
+Section-Editors: Karin Cenzual (Crystal Structures), Hiroaki Okamoto (Phase
+Diagrams), Fritz Hulliger (Physical Properties)
+(c) Springer & Material Phases Data System (MPDS), Switzerland & National
+Institute for Materials Science (NIMS), Japan 2014.
+(Data generated pre-2002: (c) Springer & MPDS & NIMS;
+post-2001: (c) Springer & MPDS)
+All Rights Reserved. Version 2014.06.
+;
+
+_audit_creation_method
+;This data have been compiled from the crystallographic datasheet for
+"3Mg(OH,F)&#x00b7;BO3 (Mg3[BO3][OH]1.5F1.5) Crystal Structure"
+taken from SpringerMaterials (sm_isp_sd_1500382).
+;
+
+_publ_section_references
+;Tak&#x00e9;uchi Y.: <i>The Structure of Fluoborite</i>. Acta Crystallographica <b>3</b> (1950) 208-210.
+;
+
+#Phase classification
+_sm_phase_labels				'Mg3[BO3][OH]1.5F1.5'
+_chemical_name_mineral			'fluoborite/hydroxylborite'
+_sm_chemical_compound_class		'orthoborate, hydroxide, fluoride'
+_sm_phase_prototype				'Mg3 [BO3 ]([OH]0.71 F0.29 )3 '
+_sm_pearson_symbol				'hP20'
+_symmetry_Int_Tables_number		176
+_sm_sample_details
+;fluoborite sample from Sweden, V&#x00e4;stmanland, Norberg, Tallgruvan,
+sample prepared from fluoborite,
+single crystal (determination of cell and structural parameters)
+;
+_sm_measurement_details
+;rotation and Weissenberg photographs (determination of cell and structural parameters),
+X-rays, Mo K&#x03b1;; &#x03bb; = 0.0710 nm (determination of cell and structural parameters)
+;
+_sm_interpretation_details
+;positions of non-H atoms determined,
+trial-and-error
+;
+
+data_sm_isp_SD1500382-standardized_unitcell
+#Cell Parameters
+_cell_length_a					9.06
+_cell_length_b					9.06
+_cell_length_c					3.06
+_cell_angle_alpha				90
+_cell_angle_beta				90
+_cell_angle_gamma				120
+_sm_length_ratio_ab				1.000
+_sm_length_ratio_bc				2.961
+_sm_length_ratio_ca				0.338
+_cell_volume 					217.52
+_symmetry_space_group_name_H-M	'P63/m'
+_symmetry_Int_Tables_number		176
+_cell_formula_units_Z			2
+_sm_cell_transformation
+;No transformation from published to standardized cell parameters necessary.
+;
+
+#Atom Coordinates
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_Wyckoff_symbol
+_sm_site_symmetry
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+_sm_coordination_number
+_sm_atomic_environment_type
+O 'O' .6h .m.. 0.156 0.619 0.25 1 1 'single atom, B'
+#M '0.706OH + 0.294F' .6h .m.. 0.31 0.218 0.25 1 3 'non-coplanar triangle , Mg<sub>3</sub>'
+OH 'OH' .6h .m.. 0.31 0.218 0.25 0.706 3 'non-coplanar triangle , Mg<sub>3</sub>'
+F 'F' .6h .m.. 0.31 0.218 0.25 0.294 3 'non-coplanar triangle , Mg<sub>3</sub>'
+Mg 'Mg' .6h .m.. 0.381 0.038 0.25 1 6 'octahedron, O<sub>3</sub>(OH)<sub>3</sub>'
+B 'B' .2c .-6.. 0.333333333333333 0.666666666666667 0.25 1 3 'coplanar triangle, O<sub>3</sub>'
+
+_sm_atom_site_transformation
+;No transformation from published to standardized cell parameters necessary.
+;
+
+data_sm_isp_SD1500382-published_cell
+#Cell Parameters
+_cell_length_a					9.06(2)
+_cell_length_b					9.06(2)
+_cell_length_c					3.06(1)
+_cell_angle_alpha				90
+_cell_angle_beta				90
+_cell_angle_gamma				120
+_sm_length_ratio_ab				1.000
+_sm_length_ratio_bc				2.961
+_sm_length_ratio_ca				0.338
+_cell_volume 					217.52
+_symmetry_space_group_name_H-M	'P63/m'
+_symmetry_Int_Tables_number		176
+_cell_formula_units_Z			2
+
+#Atom Coordinates
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_Wyckoff_symbol
+_sm_site_symmetry
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+_sm_coordination_number
+_sm_atomic_environment_type
+#M '0.706OH + 0.294F' .6h .m.. 0.31 0.218 0.25 1 ? '?'
+OH 'OH' .6h .m.. 0.31 0.218 0.25 0.706 ? '?'
+F 'F' .6h .m.. 0.31 0.218 0.25 0.294 ? '?'
+O 'O' .6h .m.. 0.537 0.156 0.75 1 ? '?'
+Mg 'Mg' .6h .m.. 0.381 0.038 0.25 1 ? '?'
+B 'B' .2c .-6.. 0.666666666666667 0.333333333333333 0.75 1 ? '?'
+
+data_sm_isp_SD1500382-niggli_reduced_cell
+#Cell Parameters
+_cell_length_a					3.06
+_cell_length_b					9.06
+_cell_length_c					9.06
+_cell_angle_alpha				120
+_cell_angle_beta				90
+_cell_angle_gamma				90
+_sm_length_ratio_ab				0.338
+_sm_length_ratio_bc				1.000
+_sm_length_ratio_ca				2.961
+_cell_volume 					217.52
+_symmetry_space_group_name_H-M	''
+_symmetry_Int_Tables_number		?
+_cell_formula_units_Z			2
+
+#Atom Coordinates
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_Wyckoff_symbol
+_sm_site_symmetry
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+_sm_coordination_number
+_sm_atomic_environment_type
+? ? ? ? ? ? ? ? ? ?

--- a/test_files/PF_sd_1601634.cif
+++ b/test_files/PF_sd_1601634.cif
@@ -1,0 +1,166 @@
+##CIF_1.1
+
+data_sm_global
+#Used dictionaries
+loop_
+_audit_conform_dict_name
+_audit_conform_dict_version
+_audit_conform_dict_location
+cif_core.dic 	2.4.2 	.
+cif_pd.dic 		1.0.1 	.
+cif_sm.dic 		0.1 	'redaktion.landolt-boernstein(at)springer.com'
+
+#About this content and reference
+_sm_credits_copyright
+;PAULING FILE Multinaries Edition - 2012. SpringerMaterials Release 2014.
+http://www.paulingfile.com
+Unique LPF ID Number SD1601634
+Project Coordinator: Shuichi Iwata
+Section-Editors: Karin Cenzual (Crystal Structures), Hiroaki Okamoto (Phase
+Diagrams), Fritz Hulliger (Physical Properties)
+(c) Springer & Material Phases Data System (MPDS), Switzerland & National
+Institute for Materials Science (NIMS), Japan 2014.
+(Data generated pre-2002: (c) Springer & MPDS & NIMS;
+post-2001: (c) Springer & MPDS)
+All Rights Reserved. Version 2014.06.
+;
+
+_audit_creation_method
+;This data have been compiled from the crystallographic datasheet for
+"tsumcorite (ZnFePb[AsO4]2[OH][H2O]) Crystal Structure"
+taken from SpringerMaterials (sm_isp_sd_1601634).
+;
+
+_publ_section_references
+;Krause W., Belendorff K., Bernhardt H.J., McCammon C.A., Effenberger H.S., Mikenda W.: <i>Crystal chemistry of the tsumcorite-group minerals. New data on ferrilotharmeyerite, tsumcorite, thometzekite, mounanaite, helmutwinklerite, and a redefinition of gartrellite</i>. European Journal of Mineralogy <b>10</b> (1998) 179-206.
+;
+
+#Phase classification
+_sm_phase_labels				'ZnFePb[AsO4]2[OH][H2O]'
+_chemical_name_mineral			'tsumcorite'
+_sm_chemical_compound_class		'arsenate, hydroxide, hydrate'
+_sm_phase_prototype				'NaCu2 [SO4 ]2 [OH][H2 O]'
+_sm_pearson_symbol				'mS30'
+_symmetry_Int_Tables_number		12
+_sm_sample_details
+;tsumcorite sample from Namibia, Tsumeb, Tsumeb mine,
+sample prepared from tsumcorite,
+electron microprobe analysis; Pb<sub>1.02</sub>Fe<sup>3+</sup><sub>0.69</sub>Zn<sub>1.30</sub>[AsO<sub>4</sub>]<sub>1.99</sub>[OH]<sub>0.74</sub>[H<sub>2</sub>O]<sub>1.29</sub>,
+powder (determination of cell parameters)
+;
+_sm_measurement_details
+;automatic diffractometer (determination of cell parameters),
+X-rays, Cu K&#x03b1; (determination of cell parameters)
+;
+_sm_interpretation_details
+;cell parameters determined and structure type assigned
+;
+
+data_sm_isp_SD1601634-standardized_unitcell
+#Cell Parameters
+_cell_length_a					9.143
+_cell_length_b					6.335
+_cell_length_c					7.598
+_cell_angle_alpha				90
+_cell_angle_beta				115.07
+_cell_angle_gamma				90
+_sm_length_ratio_ab				1.443
+_sm_length_ratio_bc				0.834
+_sm_length_ratio_ca				0.831
+_cell_volume 					398.6
+_symmetry_space_group_name_H-M	'C12/m1'
+_symmetry_Int_Tables_number		12
+_cell_formula_units_Z			2
+_sm_cell_transformation
+;No transformation from published to standardized cell parameters necessary.
+;
+
+#Atom Coordinates
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_Wyckoff_symbol
+_sm_site_symmetry
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+_sm_coordination_number
+_sm_atomic_environment_type
+O1 'O' .8j .1 0.0201 0.3033 0.256 1 ? '?'
+#M1 '0.655OH2 + 0.345OH' .4i .m 0.1576 0 0.5754 1 ? '?'
+OH2 'OH2' .4i .m 0.1576 0 0.5754 0.655 ? '?'
+OH 'OH' .4i .m 0.1576 0 0.5754 0.345 ? '?'
+O2 'O' .4i .m 0.3069 0 0.3081 1 ? '?'
+As1 'As' .4i .m 0.4091 0 0.1987 1 ? '?'
+O3 'O' .4i .m 0.7091 0 0.0177 1 ? '?'
+#M2 '0.645Zn + 0.345Fe + 0.010Pb' .4f .-1 0.25 0.25 0.5 1 ? '?'
+Zn 'Zn' .4f .-1 0.25 0.25 0.5 0.645 ? '?'
+Fe 'Fe' .4f .-1 0.25 0.25 0.5 0.345 ? '?'
+Pb 'Pb' .4f .-1 0.25 0.25 0.5 0.010 ? '?'
+Pb1 'Pb' .2a .2/m 0 0 0 1 ? '?'
+
+_sm_atom_site_transformation
+;No transformation from published to standardized cell parameters necessary.
+Atom coordinates assigned by editor.
+;
+
+data_sm_isp_SD1601634-published_cell
+#Cell Parameters
+_cell_length_a					9.143(2)
+_cell_length_b					6.335(1)
+_cell_length_c					7.598(2)
+_cell_angle_alpha				90
+_cell_angle_beta				115.07(2)
+_cell_angle_gamma				90
+_sm_length_ratio_ab				1.443
+_sm_length_ratio_bc				0.834
+_sm_length_ratio_ca				0.831
+_cell_volume 					398.62
+_symmetry_space_group_name_H-M	'C12/m1'
+_symmetry_Int_Tables_number		12
+_cell_formula_units_Z			2
+
+#Atom Coordinates
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_Wyckoff_symbol
+_sm_site_symmetry
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+_sm_coordination_number
+_sm_atomic_environment_type
+? ? ? ? ? ? ? ? ? ?
+
+data_sm_isp_SD1601634-niggli_reduced_cell
+#Cell Parameters
+_cell_length_a					5.5616
+_cell_length_b					5.5616
+_cell_length_c					7.598
+_cell_angle_alpha				69.617
+_cell_angle_beta				69.617
+_cell_angle_gamma				69.435
+_sm_length_ratio_ab				1.000
+_sm_length_ratio_bc				0.732
+_sm_length_ratio_ca				1.366
+_cell_volume 					199.31
+_symmetry_space_group_name_H-M	''
+_symmetry_Int_Tables_number		?
+_cell_formula_units_Z			2
+
+#Atom Coordinates
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_Wyckoff_symbol
+_sm_site_symmetry
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+_sm_coordination_number
+_sm_atomic_environment_type
+? ? ? ? ? ? ? ? ? ?

--- a/test_files/PF_sd_1615854.cif
+++ b/test_files/PF_sd_1615854.cif
@@ -1,0 +1,227 @@
+##CIF_1.1
+
+data_sm_global
+#Used dictionaries
+loop_
+_audit_conform_dict_name
+_audit_conform_dict_version
+_audit_conform_dict_location
+cif_core.dic 	2.4.2 	.
+cif_pd.dic 		1.0.1 	.
+cif_sm.dic 		0.1 	'redaktion.landolt-boernstein(at)springer.com'
+
+#About this content and reference
+_sm_credits_copyright
+;PAULING FILE Multinaries Edition - 2012. SpringerMaterials Release 2014.
+http://www.paulingfile.com
+Unique LPF ID Number SD1615854
+Project Coordinator: Shuichi Iwata
+Section-Editors: Karin Cenzual (Crystal Structures), Hiroaki Okamoto (Phase
+Diagrams), Fritz Hulliger (Physical Properties)
+(c) Springer & Material Phases Data System (MPDS), Switzerland & National
+Institute for Materials Science (NIMS), Japan 2014.
+(Data generated pre-2002: (c) Springer & MPDS & NIMS;
+post-2001: (c) Springer & MPDS)
+All Rights Reserved. Version 2014.06.
+;
+
+_audit_creation_method
+;This data have been compiled from the crystallographic datasheet for
+"Ab99.75Or0.25 (NaAlSi3O8 alb, <i>T</i> = 1243 K) Crystal Structure"
+taken from SpringerMaterials (sm_isp_sd_1615854).
+;
+
+_publ_section_references
+;Winter J.K., Ghose S., Okamura F.P.: <i>A high-temperature study of the thermal expansion and the anisotropy of the sodium atom in low albite</i>. American Mineralogist <b>62</b> (1977) 921-931.
+;
+
+#Phase classification
+_sm_phase_labels				'NaAlSi3O8 alb'
+_chemical_name_mineral			'albite'
+_sm_chemical_compound_class		'silicate'
+_sm_phase_prototype				'NaAlSi3 O8 '
+_sm_pearson_symbol				'aP26'
+_symmetry_Int_Tables_number		2
+_sm_sample_details
+;albite low sample from U.S.A. California, Marin County, Tiburon Peninsula,
+single crystal (determination of cell parameters),
+single crystal, 0.25 mm diameter (determination of structural parameters)
+;
+_sm_measurement_details
+;automatic diffractometer (determination of cell parameters),
+automatic diffractometer; Syntex P1 (determination of structural parameters),
+X-rays, Mo K&#x03b1; (determination of cell and structural parameters),
+<i>T</i> = 1243 K (determination of cell and structural parameters)
+;
+_sm_interpretation_details
+;complete structure determined; temperature dependence studied,
+least-squares refinement; 2002 reflections,
+<i>R</i> = 0.039
+;
+
+data_sm_isp_SD1615854-standardized_unitcell
+#Cell Parameters
+_cell_length_a					7.181
+_cell_length_b					7.4971
+_cell_length_c					7.7934
+_cell_angle_alpha				114.487
+_cell_angle_beta				106.377
+_cell_angle_gamma				101.155
+_sm_length_ratio_ab				0.958
+_sm_length_ratio_bc				0.962
+_sm_length_ratio_ca				1.085
+_cell_volume 					342.42
+_symmetry_space_group_name_H-M	'P-1'
+_symmetry_Int_Tables_number		2
+_cell_formula_units_Z			2
+_sm_cell_transformation
+;new axes c,a/2-b/2,a/2+b/2; origin shift 0 1/2 1/2
+;
+
+#Atom Coordinates
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_Wyckoff_symbol
+_sm_site_symmetry
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+_sm_coordination_number
+_sm_atomic_environment_type
+Oa1 'O' .2i .1 0.0283 0.6326 0.3584 1 2 'non-collinear, Si<sub>2</sub>'
+Obo 'O' .2i .1 0.2012 0.1932 0.4378 1 2 'non-collinear, Si<sub>2</sub>'
+T1(o) '0.75Si + 0.25Al' .2i .1 0.2113 0.3351 0.6845 1 4 'tetrahedron, O<sub>4</sub>'
+Ocm 'O' .2i .1 0.2466 0.8351 0.2245 1 2 'non-collinear, Si<sub>2</sub>'
+T1(m) '0.75Si + 0.25Al' .2i .1 0.237 0.6858 0.3258 1 4 'tetrahedron, O<sub>4</sub>'
+Obm 'O' .2i .1 0.2549 0.4721 0.1783 1 2 'non-collinear, Si<sub>2</sub>'
+Oco 'O' .2i .1 0.2679 0.2145 0.8305 1 2 'non-collinear, Si<sub>2</sub>'
+Oa2 'O' .2i .1 0.2841 0.1077 0.1079 1 2 'non-collinear, Si<sub>2</sub>'
+T2(o) '0.75Si + 0.25Al' .2i .1 0.3252 0.0862 0.3132 1 4 'tetrahedron, O<sub>4</sub>'
+T2(m) '0.75Si + 0.25Al' .2i .1 0.3596 0.3081 0.0741 1 4 'tetrahedron, O<sub>4</sub>'
+Odm 'O' .2i .1 0.572 0.1911 0.4499 1 2 'non-collinear, Si<sub>2</sub>'
+Odo 'O' .2i .1 0.6066 0.4122 0.185 1 2 'non-collinear, Si<sub>2</sub>'
+Na 'Na' .2i .1 0.8532 0.2101 0.2335 1 5 'trigonal bipyramid, O<sub>5</sub>'
+
+_sm_atom_site_transformation
+;new axes c,a/2-b/2,a/2+b/2; origin shift 0 1/2 1/2
+;
+
+#Anisotropic Displacement Parameters
+loop_
+_atom_site_aniso_label
+_atom_site_aniso_U_11
+_atom_site_aniso_U_12
+_atom_site_aniso_U_13
+_atom_site_aniso_U_22
+_atom_site_aniso_U_23
+_atom_site_aniso_U_33
+Na 2.36(5) -0.2(3) 1.37(5) 2.03(3) -1.24(4) 6.12(9)
+T1(o) 1.11(1) -0.1(1) 0.5(1) 0.32(1) 0.02(1) 1.13(2)
+T1(m) 1.01(1) 0.08(1) 0.47(1) 0.3(1) 0.05(1) 1.02(1)
+T2(o) 0.92(1) -0.05(1) 0.4(1) 0.25(1) 0.02(1) 1.36(1)
+T2(m) 0.91(1) 0.02(1) 0.44(1) 0.25(1) 0.06(1) 1.39(1)
+Oa1 2.42(1) -0.02(2) 1.06(4) 0.61(1) 0.11(2) 1.33(4)
+Oa2 1.17(3) -0.02(1) 0.43(3) 0.25(1) 0.12(2) 2.3(5)
+Obo 1.64(4) -0.34(2) 1.37(4) 0.73(2) -0.05(3) 2.82(6)
+Obm 1.78(5) 0.31(2) 1.75(5) 0.81(2) 0.09(3) 3.59(8)
+Oco 1.51(4) -0.19(2) 0.74(4) 0.36(1) -0.07(2) 2.85(6)
+Ocm 1.52(4) 0.21(2) 0.74(4) 0.33(1) 0.18(2) 2.9(6)
+Odo 1.75(4) 0.15(2) 0.23(4) 0.61(1) 0.16(2) 1.52(5)
+Odm 1.9(5) -0.23(2) 0.06(4) 0.68(2) -0.07(2) 1.53(5)
+
+data_sm_isp_SD1615854-published_cell
+#Cell Parameters
+_cell_length_a					8.277(1)
+_cell_length_b					12.86(2)
+_cell_length_c					7.181(1)
+_cell_angle_alpha				93.33(1)
+_cell_angle_beta				116.15(1)
+_cell_angle_gamma				87.56(1)
+_sm_length_ratio_ab				0.644
+_sm_length_ratio_bc				1.791
+_sm_length_ratio_ca				0.868
+_cell_volume 					684.84
+_symmetry_space_group_name_H-M	'C-1'
+_symmetry_Int_Tables_number		2
+_cell_formula_units_Z			2
+
+#Atom Coordinates
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_Wyckoff_symbol
+_sm_site_symmetry
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+_sm_coordination_number
+_sm_atomic_environment_type
+Na 'Na' .4i .1 0.2782(3) 0.9883(2) 0.1468(4) 1 ? '?'
+T1(o) '0.75Si + 0.25Al' .4i .1 0.0098(1) 0.1747(1) 0.2113(1) 1 ? '?'
+T1(m) '0.75Si + 0.25Al' .4i .1 0.0058(1) 0.82(1) 0.237(1) 1 ? '?'
+T2(o) '0.75Si + 0.25Al' .4i .1 0.6997(1) 0.1135(1) 0.3252(1) 1 ? '?'
+T2(m) '0.75Si + 0.25Al' .4i .1 0.6911(1) 0.883(1) 0.3596(1) 1 ? '?'
+Oa1 'O' .4i .1 0.0045(3) 0.1371(2) 0.9717(3) 1 ? '?'
+Oa2 'O' .4i .1 0.6078(2) 0.0001(3) 0.2841(3) 1 ? '?'
+Obo 'O' .4i .1 0.8155(3) 0.1223(2) 0.2012(4) 1 ? '?'
+Obm 'O' .4i .1 0.8252(3) 0.8531(3) 0.2549(4) 1 ? '?'
+Oco 'O' .4i .1 0.0225(3) 0.308(1) 0.2679(3) 1 ? '?'
+Ocm 'O' .4i .1 0.0298(3) 0.6947(1) 0.2466(3) 1 ? '?'
+Odo 'O' .4i .1 0.2014(3) 0.1136(2) 0.3934(3) 1 ? '?'
+Odm 'O' .4i .1 0.1795(3) 0.8706(2) 0.428(3) 1 ? '?'
+
+#Anisotropic Displacement Parameters
+loop_
+_atom_site_aniso_label
+_atom_site_aniso_U_11
+_atom_site_aniso_U_12
+_atom_site_aniso_U_13
+_atom_site_aniso_U_22
+_atom_site_aniso_U_23
+_atom_site_aniso_U_33
+Na 2.36(5) -0.2(3) 1.37(5) 2.03(3) -1.24(4) 6.12(9)
+T1(o) 1.11(1) -0.1(1) 0.5(1) 0.32(1) 0.02(1) 1.13(2)
+T1(m) 1.01(1) 0.08(1) 0.47(1) 0.3(1) 0.05(1) 1.02(1)
+T2(o) 0.92(1) -0.05(1) 0.4(1) 0.25(1) 0.02(1) 1.36(1)
+T2(m) 0.91(1) 0.02(1) 0.44(1) 0.25(1) 0.06(1) 1.39(1)
+Oa1 2.42(1) -0.02(2) 1.06(4) 0.61(1) 0.11(2) 1.33(4)
+Oa2 1.17(3) -0.02(1) 0.43(3) 0.25(1) 0.12(2) 2.3(5)
+Obo 1.64(4) -0.34(2) 1.37(4) 0.73(2) -0.05(3) 2.82(6)
+Obm 1.78(5) 0.31(2) 1.75(5) 0.81(2) 0.09(3) 3.59(8)
+Oco 1.51(4) -0.19(2) 0.74(4) 0.36(1) -0.07(2) 2.85(6)
+Ocm 1.52(4) 0.21(2) 0.74(4) 0.33(1) 0.18(2) 2.9(6)
+Odo 1.75(4) 0.15(2) 0.23(4) 0.61(1) 0.16(2) 1.52(5)
+Odm 1.9(5) -0.23(2) 0.06(4) 0.68(2) -0.07(2) 1.53(5)
+
+data_sm_isp_SD1615854-niggli_reduced_cell
+#Cell Parameters
+_cell_length_a					7.181
+_cell_length_b					7.4971
+_cell_length_c					7.7934
+_cell_angle_alpha				114.487
+_cell_angle_beta				106.377
+_cell_angle_gamma				101.155
+_sm_length_ratio_ab				0.958
+_sm_length_ratio_bc				0.962
+_sm_length_ratio_ca				1.085
+_cell_volume 					342.42
+_symmetry_space_group_name_H-M	''
+_symmetry_Int_Tables_number		?
+_cell_formula_units_Z			2
+
+#Atom Coordinates
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_Wyckoff_symbol
+_sm_site_symmetry
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+_sm_coordination_number
+_sm_atomic_environment_type
+? ? ? ? ? ? ? ? ? ?

--- a/test_files/PF_sd_1622133.cif
+++ b/test_files/PF_sd_1622133.cif
@@ -1,0 +1,208 @@
+##CIF_1.1
+
+data_sm_global
+#Used dictionaries
+loop_
+_audit_conform_dict_name
+_audit_conform_dict_version
+_audit_conform_dict_location
+cif_core.dic 	2.4.2 	.
+cif_pd.dic 		1.0.1 	.
+cif_sm.dic 		0.1 	'redaktion.landolt-boernstein(at)springer.com'
+
+#About this content and reference
+_sm_credits_copyright
+;PAULING FILE Multinaries Edition - 2012. SpringerMaterials Release 2014.
+http://www.paulingfile.com
+Unique LPF ID Number SD1622133
+Project Coordinator: Shuichi Iwata
+Section-Editors: Karin Cenzual (Crystal Structures), Hiroaki Okamoto (Phase
+Diagrams), Fritz Hulliger (Physical Properties)
+(c) Springer & Material Phases Data System (MPDS), Switzerland & National
+Institute for Materials Science (NIMS), Japan 2014.
+(Data generated pre-2002: (c) Springer & MPDS & NIMS;
+post-2001: (c) Springer & MPDS)
+All Rights Reserved. Version 2014.06.
+;
+
+_audit_creation_method
+;This data have been compiled from the crystallographic datasheet for
+"Low-Ca orthopyroxene (Ca0.02Mg0.49Fe0.49SiO3) Crystal Structure"
+taken from SpringerMaterials (sm_isp_sd_1622133).
+;
+
+_publ_section_references
+;Dodd R.T., Grover J.E., Brown G.E. Jr.: <i>Pyroxenes in the Shaw (L-7) chondrite</i>. Geochimica et Cosmochimica Acta <b>39</b> (1975) 1585-1594.
+;
+
+#Phase classification
+_sm_phase_labels				'Ca0.02Mg0.49Fe0.49SiO3'
+_chemical_name_mineral			'enstatite/ferrosilite'
+_sm_chemical_compound_class		'silicate'
+_sm_phase_prototype				'MgSiO3 '
+_sm_pearson_symbol				'oP80'
+_symmetry_Int_Tables_number		61
+_sm_sample_details
+;orthopyroxene group sample from,
+electron microprobe analysis; 55.7 wt.% SiO<sub>2</sub>, 11.3 wt.% FeO, 30.7 wt.% MgO,
+single crystal (determination of cell parameters),
+single crystal, 60 &#x03bc;m (determination of structural parameters)
+;
+_sm_measurement_details
+;precession photographs (determination of cell parameters),
+automatic diffractometer; Picker FACS-1 (determination of structural parameters),
+X-rays, Mo K&#x03b1; (determination of cell and structural parameters)
+;
+_sm_interpretation_details
+;complete structure determined,
+least-squares refinement; 1028 reflections
+;
+
+data_sm_isp_SD1622133-standardized_unitcell
+#Cell Parameters
+_cell_length_a					5.194
+_cell_length_b					18.233
+_cell_length_c					8.836
+_cell_angle_alpha				90
+_cell_angle_beta				90
+_cell_angle_gamma				90
+_sm_length_ratio_ab				0.285
+_sm_length_ratio_bc				2.063
+_sm_length_ratio_ca				1.701
+_cell_volume 					836.8
+_symmetry_space_group_name_H-M	'Pbca'
+_symmetry_Int_Tables_number		61
+_cell_formula_units_Z			16
+_sm_cell_transformation
+;new axes c,a,b; origin shift 0 0 1/2
+;
+
+#Atom Coordinates
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_Wyckoff_symbol
+_sm_site_symmetry
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+_sm_coordination_number
+_sm_atomic_environment_type
+O1A 'O' .8c .1 0.0382 0.3171 0.3387 1 4 'tetrahedron, SiMg<sub>3</sub>'
+O2A 'O' .8c .1 0.0477 0.31 0.0021 1 1 'single atom, Si'
+SiA 'Si' .8c .1 0.0513 0.2287 0.342 1 4 'tetrahedron, O<sub>4</sub>'
+O3B 'O' .8c .1 0.1006 0.0526 0.3013 1 2 'non-collinear, Si<sub>2</sub>'
+O2B 'O' .8c .1 0.1933 0.0667 0.0151 1 3 'non-coplanar triangle , SiMg<sub>2</sub>'
+O1B 'O' .8c .1 0.2016 0.4377 0.1609 1 4 'tetrahedron, SiMg<sub>3</sub>'
+SiB 'Si' .8c .1 0.296 0.0262 0.1633 1 4 'tetrahedron, O<sub>4</sub>'
+O3A 'O' .8c .1 0.328 0.197 0.2734 1 2 'non-collinear, Si<sub>2</sub>'
+M2 '0.660Mg + 0.317Fe + 0.023Ca' .8c .1 0.3635 0.1226 0.4842 1 6 'octahedron, O<sub>6</sub>'
+M1 '0.967(4)Mg + 0.033(4)Fe' .8c .1 0.3693 0.3756 0.346 1 6 'octahedron, O<sub>6</sub>'
+
+_sm_atom_site_transformation
+;new axes c,a,b; origin shift 0 0 1/2
+;
+
+#Isotropic Displacement Parameters
+loop_
+_atom_site_label_1
+_atom_site_B_iso_or_equiv
+_sm_atom_site_isotropic_displacement_parameter_type
+_atom_site_B_equiv_geom_mean
+M1 0.0059(5) 'Biso' ?
+M2 0.0063(3) 'Biso' ?
+SiA 0.0042(3) 'Biso' ?
+SiB 0.0046(3) 'Biso' ?
+O1A 0.004(7) 'Biso' ?
+O2A 0.0056(8) 'Biso' ?
+O3A 0.0067(8) 'Biso' ?
+O1B 0.0067(8) 'Biso' ?
+O2B 0.0048(8) 'Biso' ?
+O3B 0.0024(8) 'Biso' ?
+
+data_sm_isp_SD1622133-published_cell
+#Cell Parameters
+_cell_length_a					18.233(4)
+_cell_length_b					8.836(3)
+_cell_length_c					5.194(2)
+_cell_angle_alpha				90
+_cell_angle_beta				90
+_cell_angle_gamma				90
+_sm_length_ratio_ab				2.063
+_sm_length_ratio_bc				1.701
+_sm_length_ratio_ca				0.285
+_cell_volume 					836.79
+_symmetry_space_group_name_H-M	'Pbca'
+_symmetry_Int_Tables_number		61
+_cell_formula_units_Z			16
+
+#Atom Coordinates
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_Wyckoff_symbol
+_sm_site_symmetry
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+_sm_coordination_number
+_sm_atomic_environment_type
+M1 '0.967(4)Mg + 0.033(4)Fe' .8c .1 0.3756(1) 0.654(2) 0.8693(4) 1 ? '?'
+M2 '0.660Mg + 0.317Fe + 0.023Ca' .8c .1 0.3774(1) 0.4842(2) 0.3635(3) 1 ? '?'
+SiA 'Si' .8c .1 0.2713(1) 0.342(2) 0.0513(3) 1 ? '?'
+SiB 'Si' .8c .1 0.4738(1) 0.3367(2) 0.796(3) 1 ? '?'
+O1A 'O' .8c .1 0.1829(2) 0.3387(5) 0.0382(8) 1 ? '?'
+O2A 'O' .8c .1 0.31(2) 0.5021(5) 0.0477(8) 1 ? '?'
+O3A 'O' .8c .1 0.303(2) 0.2266(5) -0.172(9) 1 ? '?'
+O1B 'O' .8c .1 0.5623(2) 0.3391(5) 0.7984(9) 1 ? '?'
+O2B 'O' .8c .1 0.4333(2) 0.4849(5) 0.6933(9) 1 ? '?'
+O3B 'O' .8c .1 0.4474(2) 0.1987(4) 0.6006(8) 1 ? '?'
+
+#Isotropic Displacement Parameters
+loop_
+_atom_site_label_1
+_atom_site_B_iso_or_equiv
+_sm_atom_site_isotropic_displacement_parameter_type
+_atom_site_B_equiv_geom_mean
+M1 0.0059(5) 'Biso' ?
+M2 0.0063(3) 'Biso' ?
+SiA 0.0042(3) 'Biso' ?
+SiB 0.0046(3) 'Biso' ?
+O1A 0.004(7) 'Biso' ?
+O2A 0.0056(8) 'Biso' ?
+O3A 0.0067(8) 'Biso' ?
+O1B 0.0067(8) 'Biso' ?
+O2B 0.0048(8) 'Biso' ?
+O3B 0.0024(8) 'Biso' ?
+
+data_sm_isp_SD1622133-niggli_reduced_cell
+#Cell Parameters
+_cell_length_a					5.194
+_cell_length_b					8.836
+_cell_length_c					18.233
+_cell_angle_alpha				90
+_cell_angle_beta				90
+_cell_angle_gamma				90
+_sm_length_ratio_ab				0.588
+_sm_length_ratio_bc				0.485
+_sm_length_ratio_ca				3.510
+_cell_volume 					836.79
+_symmetry_space_group_name_H-M	''
+_symmetry_Int_Tables_number		?
+_cell_formula_units_Z			16
+
+#Atom Coordinates
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_Wyckoff_symbol
+_sm_site_symmetry
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+_sm_coordination_number
+_sm_atomic_environment_type
+? ? ? ? ? ? ? ? ? ?

--- a/test_files/PF_sd_1704003.cif
+++ b/test_files/PF_sd_1704003.cif
@@ -1,0 +1,210 @@
+##CIF_1.1
+
+data_sm_global
+#Used dictionaries
+loop_
+_audit_conform_dict_name
+_audit_conform_dict_version
+_audit_conform_dict_location
+cif_core.dic 	2.4.2 	.
+cif_pd.dic 		1.0.1 	.
+cif_sm.dic 		0.1 	'redaktion.landolt-boernstein(at)springer.com'
+
+#About this content and reference
+_sm_credits_copyright
+;PAULING FILE Multinaries Edition - 2012. SpringerMaterials Release 2014.
+http://www.paulingfile.com
+Unique LPF ID Number SD1704003
+Project Coordinator: Shuichi Iwata
+Section-Editors: Karin Cenzual (Crystal Structures), Hiroaki Okamoto (Phase
+Diagrams), Fritz Hulliger (Physical Properties)
+(c) Springer & Material Phases Data System (MPDS), Switzerland & National
+Institute for Materials Science (NIMS), Japan 2014.
+(Data generated pre-2002: (c) Springer & MPDS & NIMS;
+post-2001: (c) Springer & MPDS)
+All Rights Reserved. Version 2014.06.
+;
+
+_audit_creation_method
+;This data have been compiled from the crystallographic datasheet for
+"Rb2MnF6 Crystal Structure"
+taken from SpringerMaterials (sm_isp_sd_1704003).
+;
+
+_publ_section_references
+;Bode H., Wendt W.: <i>&#x00dc;ber die Struktur von Hexafluoromanganaten(IV)</i>. Zeitschrift f&#x00fc;r Anorganische und Allgemeine Chemie <b>269</b> (1952) 165-172 (in German).
+;
+
+#Phase classification
+_sm_phase_labels				'Rb2MnF6 hex'
+_chemical_name_mineral			''
+_sm_chemical_compound_class		'fluoride'
+_sm_phase_prototype				'Rb2 MnF6 '
+_sm_pearson_symbol				'hP18'
+_symmetry_Int_Tables_number		186
+_sm_sample_details
+;powder (determination of cell and structural parameters)
+;
+_sm_measurement_details
+;Debye-Scherrer film (determination of cell and structural parameters),
+X-rays, Cu K&#x03b1; (determination of cell and structural parameters)
+;
+_sm_interpretation_details
+;complete structure determined,
+trial-and-error
+;
+
+data_sm_isp_SD1704003-standardized_unitcell
+#Cell Parameters
+_cell_length_a					5.855
+_cell_length_b					5.855
+_cell_length_c					9.503
+_cell_angle_alpha				90
+_cell_angle_beta				90
+_cell_angle_gamma				120
+_sm_length_ratio_ab				1.000
+_sm_length_ratio_bc				0.616
+_sm_length_ratio_ca				1.623
+_cell_volume 					282.1
+_symmetry_space_group_name_H-M	'P63mc'
+_symmetry_Int_Tables_number		186
+_cell_formula_units_Z			2
+_sm_cell_transformation
+;origin shift 0 0 0.605
+;
+
+#Atom Coordinates
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_Wyckoff_symbol
+_sm_site_symmetry
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+_sm_coordination_number
+_sm_atomic_environment_type
+F2 'F' .6c ..m. 0.528 0.472 0.04 1 1 'single atom, Mn'
+F1 'F' .6c ..m. 0.805 0.195 0.25 1 1 'single atom, Mn'
+Rb1 'Rb' .2b .3m. 0.333333333333333 0.666666666666667 0.29 1 12 'anticuboctahedron, F<sub>12</sub>'
+Mn 'Mn' .2b .3m. 0.333333333333333 0.666666666666667 0.645 1 6 'octahedron, F<sub>6</sub>'
+Rb2 'Rb' .2a .3m. 0 0 0 1 12 'cuboctahedron, F<sub>12</sub>'
+
+_sm_atom_site_transformation
+;origin shift 0 0 0.605
+;
+
+data_sm_isp_SD1704003-published_cell
+#Cell Parameters
+_cell_length_a					5.855
+_cell_length_b					5.855
+_cell_length_c					9.503
+_cell_angle_alpha				90
+_cell_angle_beta				90
+_cell_angle_gamma				120
+_sm_length_ratio_ab				1.000
+_sm_length_ratio_bc				0.616
+_sm_length_ratio_ca				1.623
+_cell_volume 					282.13
+_symmetry_space_group_name_H-M	'P63mc'
+_symmetry_Int_Tables_number		186
+_cell_formula_units_Z			2
+
+#Atom Coordinates
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_Wyckoff_symbol
+_sm_site_symmetry
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+_sm_coordination_number
+_sm_atomic_environment_type
+Mn 'Mn' .2b .3m. 0.333333333333333 0.666666666666667 0.25 1 ? '?'
+Rb1 'Rb' .2b .3m. 0.333333333333333 0.666666666666667 0.895 1 ? '?'
+Rb2 'Rb' .2a .3m. 0 0 0.605 1 ? '?'
+F1 'F' .6c ..m. 0.195 -0.195 0.355 1 ? '?'
+F2 'F' .6c ..m. 0.472 -0.472 0.145 1 ? '?'
+
+data_sm_isp_SD1704003-niggli_reduced_cell
+#Cell Parameters
+_cell_length_a					5.855
+_cell_length_b					5.855
+_cell_length_c					9.503
+_cell_angle_alpha				90
+_cell_angle_beta				90
+_cell_angle_gamma				120
+_sm_length_ratio_ab				1.000
+_sm_length_ratio_bc				0.616
+_sm_length_ratio_ca				1.623
+_cell_volume 					282.13
+_symmetry_space_group_name_H-M	''
+_symmetry_Int_Tables_number		?
+_cell_formula_units_Z			2
+
+#Atom Coordinates
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_Wyckoff_symbol
+_sm_site_symmetry
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+_sm_coordination_number
+_sm_atomic_environment_type
+? ? ? ? ? ? ? ? ? ?
+
+data_sm_isp_SD1704003-powder_pattern
+#Powder Pattern
+#Note: Powder patterns are provided using custom cif-fields!
+loop_
+_sm_powderpattern_unit_published_line
+_sm_powderpattern_value_published_line
+_sm_powderpattern_unit_computed_line
+_sm_powderpattern_value_computed_line
+_sm_powderpattern_intensity
+_sm_powderpattern_miller_indices_h
+_sm_powderpattern_miller_indices_k
+_sm_powderpattern_miller_indices_l
+_sm_powderpattern_radiation
+_sm_powderpattern_remark
+'sin<sup>2</sup>(&#x03b8;)' 26.3 'd' 0.4754 89 0 0 2 'Cu K&#x03b1;' ''
+'sin<sup>2</sup>(&#x03b8;)' 29.6 'd' 0.4481 132 1 0 1 'Cu K&#x03b1;' ''
+'sin<sup>2</sup>(&#x03b8;)' 49.4 'd' 0.3469 640 1 0 2 'Cu K&#x03b1;' ''
+'sin<sup>2</sup>(&#x03b8;)' 69.6 'd' 0.2922 490 1 1 0 'Cu K&#x03b1;' ''
+'sin<sup>2</sup>(&#x03b8;)' 82.2 'd' 0.2689 375 1 0 3 'Cu K&#x03b1;' ''
+'sin<sup>2</sup>(&#x03b8;)' 92.4 'd' 0.2536 20 2 0 0 'Cu K&#x03b1;' ''
+'sin<sup>2</sup>(&#x03b8;)' 99.1 'd' 0.2449 207 2 0 1 'Cu K&#x03b1;' ''
+'sin<sup>2</sup>(&#x03b8;)' 105.0 'd' 0.2379 190 0 0 4 'Cu K&#x03b1;' ''
+'sin<sup>2</sup>(&#x03b8;)' 118.5 'd' 0.2239 810 2 0 2 'Cu K&#x03b1;' ''
+'sin<sup>2</sup>(&#x03b8;)' 127.8 'd' 0.2156 115 1 0 4 'Cu K&#x03b1;' ''
+'sin<sup>2</sup>(&#x03b8;)' 151.4 'd' 0.1981 320 2 0 3 'Cu K&#x03b1;' ''
+'sin<sup>2</sup>(&#x03b8;)' 161.6 'd' 0.1918 38 2 1 0 'Cu K&#x03b1;' ''
+'sin<sup>2</sup>(&#x03b8;)' 167.3 'd' 0.1885 38 2 1 1 'Cu K&#x03b1;' ''
+'sin<sup>2</sup>(&#x03b8;)' 174.4 'd' 0.1846 94 1 1 4 'Cu K&#x03b1;' ''
+'sin<sup>2</sup>(&#x03b8;)' 186.8 'd' 0.1784 240 1 0 5 'Cu K&#x03b1;' 'intensity includes next line(s)'
+'sin<sup>2</sup>(&#x03b8;)' 188.0 'd' 0.1778  2 1 2 'Cu K&#x03b1;' ''
+'sin<sup>2</sup>(&#x03b8;)' 196.4 'd' 0.1740 20 2 0 4 'Cu K&#x03b1;' ''
+'sin<sup>2</sup>(&#x03b8;)' 207.5 'd' 0.1692 95 3 0 0 'Cu K&#x03b1;' ''
+'sin<sup>2</sup>(&#x03b8;)' 212.5 'd' 0.1672 20 3 0 1 'Cu K&#x03b1;' ''
+'sin<sup>2</sup>(&#x03b8;)' 219.9 'd' 0.1644 130 2 1 3 'Cu K&#x03b1;' ''
+'sin<sup>2</sup>(&#x03b8;)' 233.6 'd' 0.1595 26 3 0 2 'Cu K&#x03b1;' ''
+'sin<sup>2</sup>(&#x03b8;)' 236.9 'd' 0.1584 10 0 0 6 'Cu K&#x03b1;' ''
+'sin<sup>2</sup>(&#x03b8;)' 256.1 'd' 0.1523 170 2 0 5 'Cu K&#x03b1;' 'intensity includes next line(s)'
+'sin<sup>2</sup>(&#x03b8;)' 258.6 'd' 0.1516  1 0 6 'Cu K&#x03b1;' ''
+'sin<sup>2</sup>(&#x03b8;)' 265.5 'd' 0.1496 150 3 0 3 'Cu K&#x03b1;' 'intensity includes next line(s)'
+'sin<sup>2</sup>(&#x03b8;)' 266.0 'd' 0.1495  2 1 4 'Cu K&#x03b1;' ''
+'sin<sup>2</sup>(&#x03b8;)' 275.6 'd' 0.1468 190 2 2 0 'Cu K&#x03b1;' ''
+'sin<sup>2</sup>(&#x03b8;)' 303.0 'd' 0.1401 130 2 2 2 'Cu K&#x03b1;' 'intensity includes next line(s)'
+'sin<sup>2</sup>(&#x03b8;)' 303.8 'd' 0.1399  1 1 6 'Cu K&#x03b1;' ''
+'sin<sup>2</sup>(&#x03b8;)' 305.5 'd' 0.1395  3 1 1 'Cu K&#x03b1;' ''
+'sin<sup>2</sup>(&#x03b8;)' 311.1 'd' 0.1382 38 3 0 4 'Cu K&#x03b1;' ''
+'sin<sup>2</sup>(&#x03b8;)' 323.3 'd' 0.1356 225 2 1 5 'Cu K&#x03b1;' 'intensity includes next line(s)'
+'sin<sup>2</sup>(&#x03b8;)' 325.7 'd' 0.1351  3 1 2 'Cu K&#x03b1;' ''
+'sin<sup>2</sup>(&#x03b8;)' 328.3 'd' 0.1345  2 0 6 'Cu K&#x03b1;' ''
+'sin<sup>2</sup>(&#x03b8;)' 343.8 'd' 0.1315 38 1 0 7 'Cu K&#x03b1;' ''

--- a/test_files/PF_sd_1811457.cif
+++ b/test_files/PF_sd_1811457.cif
@@ -1,0 +1,185 @@
+##CIF_1.1
+
+data_sm_global
+#Used dictionaries
+loop_
+_audit_conform_dict_name
+_audit_conform_dict_version
+_audit_conform_dict_location
+cif_core.dic 	2.4.2 	.
+cif_pd.dic 		1.0.1 	.
+cif_sm.dic 		0.1 	'redaktion.landolt-boernstein(at)springer.com'
+
+#About this content and reference
+_sm_credits_copyright
+;PAULING FILE Multinaries Edition - 2012. SpringerMaterials Release 2014.
+http://www.paulingfile.com
+Unique LPF ID Number SD1811457
+Project Coordinator: Shuichi Iwata
+Section-Editors: Karin Cenzual (Crystal Structures), Hiroaki Okamoto (Phase
+Diagrams), Fritz Hulliger (Physical Properties)
+(c) Springer & Material Phases Data System (MPDS), Switzerland & National
+Institute for Materials Science (NIMS), Japan 2014.
+(Data generated pre-2002: (c) Springer & MPDS & NIMS;
+post-2001: (c) Springer & MPDS)
+All Rights Reserved. Version 2014.06.
+;
+
+_audit_creation_method
+;This data have been compiled from the crystallographic datasheet for
+"1-x(BaMg1/3Ta2/3O3)-x(BaZrO3), x= 0.1 (BaMg0.3Zr0.1Ta0.6O3) Crystal Structure"
+taken from SpringerMaterials (sm_isp_sd_1811457).
+;
+
+_publ_section_references
+;Chai L., Akbas M.A., Davies P.K., Parise J.B.: <i>Cation ordering transformations in Ba(Mg<sub>1/3</sub>Ta<sub>2/3</sub>)O<sub>3</sub>-BaZrO<sub>3</sub> perovskite solid solutions</i>. Materials Research Bulletin <b>32</b> (1997) 1261-1269.
+;
+
+#Phase classification
+_sm_phase_labels				'BaMg0.3Zr0.1Ta0.6O3'
+_chemical_name_mineral			''
+_sm_chemical_compound_class		'oxide'
+_sm_phase_prototype				'BaBiO3 '
+_sm_pearson_symbol				'cF40'
+_symmetry_Int_Tables_number		225
+_sm_sample_details
+;sample prepared from BaCO<sub>3</sub>, MgO, Ta<sub>2</sub>O<sub>5</sub>, ZrO<sub>2</sub>,
+powder (determination of cell and structural parameters)
+;
+_sm_measurement_details
+;automatic diffractometer (determination of cell parameters),
+automatic diffractometer; U.S.A. New York, Brookhaven, Brookhaven National Laboratory, HFBR reactor, H1A (determination of structural parameters),
+neutrons (determination of cell parameters),
+neutrons; &#x03bb; = 0.18857 nm (determination of structural parameters),
+<i>T</i> = 293 K (determination of cell and structural parameters)
+;
+_sm_interpretation_details
+;complete structure determined; composition dependence studied,
+Rietveld refinement,
+<i>R</i><sub>P</sub> = 0.061; <i>wR</i><sub>P</sub> = 0.082
+;
+
+data_sm_isp_SD1811457-standardized_unitcell
+#Cell Parameters
+_cell_length_a					8.2023
+_cell_length_b					8.2023
+_cell_length_c					8.2023
+_cell_angle_alpha				90
+_cell_angle_beta				90
+_cell_angle_gamma				90
+_sm_length_ratio_ab				1.000
+_sm_length_ratio_bc				1.000
+_sm_length_ratio_ca				1.000
+_cell_volume 					551.8
+_symmetry_space_group_name_H-M	'Fm-3m'
+_symmetry_Int_Tables_number		225
+_cell_formula_units_Z			8
+_sm_cell_transformation
+;origin shift 1/2 1/2 1/2
+;
+
+#Atom Coordinates
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_Wyckoff_symbol
+_sm_site_symmetry
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+_sm_coordination_number
+_sm_atomic_environment_type
+O 'O' .24e .4m.m 0.246 0 0 1 2 'collinear, TaMg'
+Ba 'Ba' .8c .-43m 0.25 0.25 0.25 1 12 'cuboctahedron, O<sub>12</sub>'
+M1 '0.56(4)Mg + 0.29(3)Ta + 0.15(5)Zr' .4b .m-3m 0.5 0.5 0.5 1 6 'octahedron, O<sub>6</sub>'
+M2 '0.91(3)Ta + 0.05(5)Zr + 0.04(4)Mg' .4a .m-3m 0 0 0 1 6 'octahedron, O<sub>6</sub>'
+
+_sm_atom_site_transformation
+;origin shift 1/2 1/2 1/2
+;
+
+#Isotropic Displacement Parameters
+loop_
+_atom_site_label_1
+_atom_site_B_iso_or_equiv
+_sm_atom_site_isotropic_displacement_parameter_type
+_atom_site_B_equiv_geom_mean
+Ba 0.0058(20) 'Biso' ?
+M1 0.0032(69) 'Biso' ?
+M2 0.0047(62) 'Biso' ?
+O 0.0072(16) 'Biso' ?
+
+data_sm_isp_SD1811457-published_cell
+#Cell Parameters
+_cell_length_a					8.2023(1)
+_cell_length_b					8.2023(1)
+_cell_length_c					8.2023(1)
+_cell_angle_alpha				90
+_cell_angle_beta				90
+_cell_angle_gamma				90
+_sm_length_ratio_ab				1.000
+_sm_length_ratio_bc				1.000
+_sm_length_ratio_ca				1.000
+_cell_volume 					551.83
+_symmetry_space_group_name_H-M	'Fm-3m'
+_symmetry_Int_Tables_number		225
+_cell_formula_units_Z			8
+
+#Atom Coordinates
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_Wyckoff_symbol
+_sm_site_symmetry
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+_sm_coordination_number
+_sm_atomic_environment_type
+Ba 'Ba' .8c .-43m 0.25 0.25 0.25 1 ? '?'
+M1 '0.56(4)Mg + 0.29(3)Ta + 0.15(5)Zr' .4a .m-3m 0 0 0 1 ? '?'
+M2 '0.91(3)Ta + 0.05(5)Zr + 0.04(4)Mg' .4b .m-3m 0.5 0.5 0.5 1 ? '?'
+O 'O' .24e .4m.m 0.254(1) 0 0 1 ? '?'
+
+#Isotropic Displacement Parameters
+loop_
+_atom_site_label_1
+_atom_site_B_iso_or_equiv
+_sm_atom_site_isotropic_displacement_parameter_type
+_atom_site_B_equiv_geom_mean
+Ba 0.0058(20) 'Biso' ?
+M1 0.0032(69) 'Biso' ?
+M2 0.0047(62) 'Biso' ?
+O 0.0072(16) 'Biso' ?
+
+data_sm_isp_SD1811457-niggli_reduced_cell
+#Cell Parameters
+_cell_length_a					5.7999
+_cell_length_b					5.7999
+_cell_length_c					5.7999
+_cell_angle_alpha				60
+_cell_angle_beta				60
+_cell_angle_gamma				60
+_sm_length_ratio_ab				1.000
+_sm_length_ratio_bc				1.000
+_sm_length_ratio_ca				1.000
+_cell_volume 					137.96
+_symmetry_space_group_name_H-M	''
+_symmetry_Int_Tables_number		?
+_cell_formula_units_Z			8
+
+#Atom Coordinates
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_Wyckoff_symbol
+_sm_site_symmetry
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+_sm_coordination_number
+_sm_atomic_environment_type
+? ? ? ? ? ? ? ? ? ?

--- a/test_files/PF_sd_1908491.cif
+++ b/test_files/PF_sd_1908491.cif
@@ -1,0 +1,179 @@
+##CIF_1.1
+
+data_sm_global
+#Used dictionaries
+loop_
+_audit_conform_dict_name
+_audit_conform_dict_version
+_audit_conform_dict_location
+cif_core.dic 	2.4.2 	.
+cif_pd.dic 		1.0.1 	.
+cif_sm.dic 		0.1 	'redaktion.landolt-boernstein(at)springer.com'
+
+#About this content and reference
+_sm_credits_copyright
+;PAULING FILE Multinaries Edition - 2012. SpringerMaterials Release 2014.
+http://www.paulingfile.com
+Unique LPF ID Number SD1908491
+Project Coordinator: Shuichi Iwata
+Section-Editors: Karin Cenzual (Crystal Structures), Hiroaki Okamoto (Phase
+Diagrams), Fritz Hulliger (Physical Properties)
+(c) Springer & Material Phases Data System (MPDS), Switzerland & National
+Institute for Materials Science (NIMS), Japan 2014.
+(Data generated pre-2002: (c) Springer & MPDS & NIMS;
+post-2001: (c) Springer & MPDS)
+All Rights Reserved. Version 2014.06.
+;
+
+_audit_creation_method
+;This data have been compiled from the crystallographic datasheet for
+"Zn0.52Mn0.48Ga2Se4 (Zn0.5Mn0.5Ga2Se4 rt, <i>T</i> = 300 K) Crystal Structure"
+taken from SpringerMaterials (sm_isp_sd_1908491).
+;
+
+_publ_section_references
+;Moron M.C., Hull S.: <i>Effect of magnetic dilution in Zn<sub>1&#x2212;x</sub>Mn<sub>x</sub>Ga<sub>2</sub>Se<sub>4</sub> (0 &#x003c; x &#x003c; 0.5)</i>. Journal of Applied Physics <b>98:013904</b> (2005) 1-6.
+;
+
+#Phase classification
+_sm_phase_labels				'Zn0.5Mn0.5Ga2Se4 rt'
+_chemical_name_mineral			''
+_sm_chemical_compound_class		'selenide'
+_sm_phase_prototype				'(Mn0.33 In0.67 )3 Te4 '
+_sm_pearson_symbol				'tI14'
+_symmetry_Int_Tables_number		121
+_sm_sample_details
+;magnetic measurements; Mn content confirmed,
+powder (determination of structural parameters)
+;
+_sm_measurement_details
+;automatic diffractometer; United Kingdom, Chilton, Rutherford Appleton Laboratory, ISIS Facility, POLARIS (determination of structural parameters),
+neutrons, time-of-flight (determination of structural parameters),
+<i>T</i> = 300 K (determination of structural parameters)
+;
+_sm_interpretation_details
+;complete structure determined; composition dependence studied,
+Rietveld refinement,
+<i>wR</i><sub>P</sub> = 0.021; <i>R</i><sub>B</sub> = 0.088
+;
+
+data_sm_isp_SD1908491-standardized_unitcell
+#Cell Parameters
+_cell_length_a					5.5665
+_cell_length_b					5.5665
+_cell_length_c					10.9439
+_cell_angle_alpha				90
+_cell_angle_beta				90
+_cell_angle_gamma				90
+_sm_length_ratio_ab				1.000
+_sm_length_ratio_bc				0.509
+_sm_length_ratio_ca				1.966
+_cell_volume 					339.1
+_symmetry_space_group_name_H-M	'I-42m'
+_symmetry_Int_Tables_number		121
+_cell_formula_units_Z			2
+_sm_cell_transformation
+;No transformation from published to standardized cell parameters necessary.
+;
+
+#Atom Coordinates
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_Wyckoff_symbol
+_sm_site_symmetry
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+_sm_coordination_number
+_sm_atomic_environment_type
+Se 'Se' .8i ...m 0.26304 0.26304 0.11591 1 3 'non-coplanar triangle , Ga<sub>3</sub>'
+Zn,Ga,Mn '0.5Ga + 0.26Zn + 0.24Mn' .4d .-4.. 0 0.5 0.25 1 4 'tetrahedron, Se<sub>4</sub>'
+Ga2 'Ga' .2a .-42m 0 0 0 1 4 'tetrahedron, Se<sub>4</sub>'
+
+_sm_atom_site_transformation
+;No transformation from published to standardized cell parameters necessary.
+;
+
+#Isotropic Displacement Parameters
+loop_
+_atom_site_label_1
+_atom_site_B_iso_or_equiv
+_sm_atom_site_isotropic_displacement_parameter_type
+_atom_site_B_equiv_geom_mean
+Se 0.003835(79) 'Biso' ?
+Zn,Ga,Mn 0.0033(3) 'Biso' ?
+Ga2 0.0084(4) 'Biso' ?
+
+data_sm_isp_SD1908491-published_cell
+#Cell Parameters
+_cell_length_a					5.56647(1)
+_cell_length_b					5.56647(1)
+_cell_length_c					10.94394(3)
+_cell_angle_alpha				90
+_cell_angle_beta				90
+_cell_angle_gamma				90
+_sm_length_ratio_ab				1.000
+_sm_length_ratio_bc				0.509
+_sm_length_ratio_ca				1.966
+_cell_volume 					339.1
+_symmetry_space_group_name_H-M	'I-42m'
+_symmetry_Int_Tables_number		121
+_cell_formula_units_Z			2
+
+#Atom Coordinates
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_Wyckoff_symbol
+_sm_site_symmetry
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+_sm_coordination_number
+_sm_atomic_environment_type
+Se 'Se' .8i ...m 0.26304(10) 0.26304(10) 0.11591(6) 1 ? '?'
+Zn,Ga,Mn '0.5Ga + 0.26Zn + 0.24Mn' .4d .-4.. 0 0.5 0.25 1 ? '?'
+Ga2 'Ga' .2a .-42m 0 0 0 1 ? '?'
+
+#Isotropic Displacement Parameters
+loop_
+_atom_site_label_1
+_atom_site_B_iso_or_equiv
+_sm_atom_site_isotropic_displacement_parameter_type
+_atom_site_B_equiv_geom_mean
+Se 0.003835(79) 'Biso' ?
+Zn,Ga,Mn 0.0033(3) 'Biso' ?
+Ga2 0.0084(4) 'Biso' ?
+
+data_sm_isp_SD1908491-niggli_reduced_cell
+#Cell Parameters
+_cell_length_a					5.5665
+_cell_length_b					5.5665
+_cell_length_c					6.7406
+_cell_angle_alpha				114.388
+_cell_angle_beta				114.388
+_cell_angle_gamma				90
+_sm_length_ratio_ab				1.000
+_sm_length_ratio_bc				0.826
+_sm_length_ratio_ca				1.211
+_cell_volume 					169.55
+_symmetry_space_group_name_H-M	''
+_symmetry_Int_Tables_number		?
+_cell_formula_units_Z			2
+
+#Atom Coordinates
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_Wyckoff_symbol
+_sm_site_symmetry
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+_sm_coordination_number
+_sm_atomic_environment_type
+? ? ? ? ? ? ? ? ? ?

--- a/test_files/PF_sd_1928405.cif
+++ b/test_files/PF_sd_1928405.cif
@@ -1,0 +1,165 @@
+##CIF_1.1
+
+data_sm_global
+#Used dictionaries
+loop_
+_audit_conform_dict_name
+_audit_conform_dict_version
+_audit_conform_dict_location
+cif_core.dic 	2.4.2 	.
+cif_pd.dic 		1.0.1 	.
+cif_sm.dic 		0.1 	'redaktion.landolt-boernstein(at)springer.com'
+
+#About this content and reference
+_sm_credits_copyright
+;PAULING FILE Multinaries Edition - 2012. SpringerMaterials Release 2014.
+http://www.paulingfile.com
+Unique LPF ID Number SD1928405
+Project Coordinator: Shuichi Iwata
+Section-Editors: Karin Cenzual (Crystal Structures), Hiroaki Okamoto (Phase
+Diagrams), Fritz Hulliger (Physical Properties)
+(c) Springer & Material Phases Data System (MPDS), Switzerland & National
+Institute for Materials Science (NIMS), Japan 2014.
+(Data generated pre-2002: (c) Springer & MPDS & NIMS;
+post-2001: (c) Springer & MPDS)
+All Rights Reserved. Version 2014.06.
+;
+
+_audit_creation_method
+;This data have been compiled from the crystallographic datasheet for
+"ErMn6&#x2212;xFexSn6, x= 2 (ErMn3Fe3Sn6, <i>T</i> = 300 K) Crystal Structure"
+taken from SpringerMaterials (sm_isp_sd_1928405).
+;
+
+_publ_section_references
+;Bourgeois J., Venturini G., Malaman B.: <i>A neutron diffraction study of the hexagonal pseudo-ternary compounds ErMn<sub>6&#x2212;x</sub>Fe<sub>x</sub>Sn<sub>6</sub> (x= 0.2, 0.4, 0.6, 0.8, 1.0, 2.0, 3.0, 4.0)</i>. Journal of Alloys and Compounds <b>480</b> (2009) 171-183.
+;
+
+#Phase classification
+_sm_phase_labels				'ErMn3Fe3Sn6'
+_chemical_name_mineral			''
+_sm_chemical_compound_class		'intermetallic'
+_sm_phase_prototype				'MgFe6 Ge6 '
+_sm_pearson_symbol				'hP13'
+_symmetry_Int_Tables_number		191
+_sm_sample_details
+;sample prepared from Er, Mn, Fe, Sn,
+amounts of Sn and TSn<sub>2</sub> phases,
+powder (determination of cell and structural parameters)
+;
+_sm_measurement_details
+;automatic diffractometer (determination of cell parameters),
+automatic diffractometer; France, Grenoble, Institute Laue-Langevin ILL, D1B (determination of structural parameters),
+neutrons; &#x03bb; = 0.2520 nm (determination of cell and structural parameters),
+<i>T</i> = 300 K (determination of cell and structural parameters)
+;
+_sm_interpretation_details
+;complete structure determined; composition dependence studied; magnetic structure determined; temperature dependence studied,
+Rietveld refinement, multiphase,
+<i>wR</i><sub>P</sub> = 0.103; <i>R</i><sub>B</sub> = 0.0502
+;
+
+data_sm_isp_SD1928405-standardized_unitcell
+#Cell Parameters
+_cell_length_a					5.469
+_cell_length_b					5.469
+_cell_length_c					8.968
+_cell_angle_alpha				90
+_cell_angle_beta				90
+_cell_angle_gamma				120
+_sm_length_ratio_ab				1.000
+_sm_length_ratio_bc				0.610
+_sm_length_ratio_ca				1.640
+_cell_volume 					232.3
+_symmetry_space_group_name_H-M	'P6/mmm'
+_symmetry_Int_Tables_number		191
+_cell_formula_units_Z			1
+_sm_cell_transformation
+;No transformation from published to standardized cell parameters necessary.
+;
+
+#Atom Coordinates
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_Wyckoff_symbol
+_sm_site_symmetry
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+_sm_coordination_number
+_sm_atomic_environment_type
+T '0.648(4)Mn + 0.352(4)Fe' .6i .2mm 0.5 0 0.246 1 12 'icosahedron, Sn<sub>6</sub>Mn<sub>4</sub>Er<sub>2</sub>'
+Sn3 'Sn' .2e .6mm 0 0 0.338 1 14 '14-vertex Frank-Kasper, Mn<sub>6</sub>Sn<sub>7</sub>Er'
+Sn2 'Sn' .2d .-6m2 0.333333333333333 0.666666666666667 0.5 1 15 '15-vertex Frank-Kasper, Mn<sub>6</sub>Sn<sub>9</sub>'
+Sn1 'Sn' .2c .-6m2 0.333333333333333 0.666666666666667 0 1 12 'icosahedron, Mn<sub>6</sub>Er<sub>3</sub>Sn<sub>3</sub>'
+Er 'Er' .1a .6/mmm 0 0 0 1 20 'pseudo Frank-Kasper (20), Sn<sub>8</sub>Mn<sub>12</sub>'
+
+_sm_atom_site_transformation
+;No transformation from published to standardized cell parameters necessary.
+;
+
+data_sm_isp_SD1928405-published_cell
+#Cell Parameters
+_cell_length_a					5.469(1)
+_cell_length_b					5.469(1)
+_cell_length_c					8.968(2)
+_cell_angle_alpha				90
+_cell_angle_beta				90
+_cell_angle_gamma				120
+_sm_length_ratio_ab				1.000
+_sm_length_ratio_bc				0.610
+_sm_length_ratio_ca				1.640
+_cell_volume 					232.3
+_symmetry_space_group_name_H-M	'P6/mmm'
+_symmetry_Int_Tables_number		191
+_cell_formula_units_Z			1
+
+#Atom Coordinates
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_Wyckoff_symbol
+_sm_site_symmetry
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+_sm_coordination_number
+_sm_atomic_environment_type
+Er 'Er' .1a .6/mmm 0 0 0 1 ? '?'
+T '0.648(4)Mn + 0.352(4)Fe' .6i .2mm 0.5 0 0.246 1 ? '?'
+Sn1 'Sn' .2c .-6m2 0.333333333333333 0.666666666666667 0 1 ? '?'
+Sn2 'Sn' .2d .-6m2 0.333333333333333 0.666666666666667 0.5 1 ? '?'
+Sn3 'Sn' .2e .6mm 0 0 0.338(1) 1 ? '?'
+
+data_sm_isp_SD1928405-niggli_reduced_cell
+#Cell Parameters
+_cell_length_a					5.469
+_cell_length_b					5.469
+_cell_length_c					8.968
+_cell_angle_alpha				90
+_cell_angle_beta				90
+_cell_angle_gamma				120
+_sm_length_ratio_ab				1.000
+_sm_length_ratio_bc				0.610
+_sm_length_ratio_ca				1.640
+_cell_volume 					232.3
+_symmetry_space_group_name_H-M	''
+_symmetry_Int_Tables_number		?
+_cell_formula_units_Z			1
+
+#Atom Coordinates
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_Wyckoff_symbol
+_sm_site_symmetry
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+_sm_coordination_number
+_sm_atomic_environment_type
+? ? ? ? ? ? ? ? ? ?


### PR DESCRIPTION
## Summary

While parsing 225k CIF files from the Springer materials/Pauling file DBs using CifParser, numerous errors were faced, which were earlier fixed at my end, but now I have tried to introduce those capabilities directly in CifParser. 

Here's a summary of changes made. They passed all the tests in test_cif.py (including the new ones added in this request) so hopefully that shouldn't throw any errors. Also, I am of course open to discussing if some of these changes should be implemented in a different/better way. 

* Feature: the following line in a CIF file,

T1(o) '0.75Si + 0.25Al' .4i .1 0.0098(1) 0.1747(1) 0.2113(1) 1 ? '?'

made the file unparsable due to unrecognizable label and symbol. The fix recognizes this as a disordered site with occupancies parsed from the symbol string "0.75Si + 0.25Al". 

* Feature: the following line in a CIF file,

Nb,Zr '0.8Nb + 0.2Zr' .2a .m-3m 0 0 0 1 ? '?'

event though didn't throw an error while parsing, was previously recognized as an ordered site containing Nb with occupancy=1. The fix recognizes this as a disordered site with occupancies parsed from the symbol string "0.8Nb + 0.2Zr". 

* Feature: parse the structures from CIFs that contain incomplete powder diffraction data by skipping over that data block (previously threw an error). 

* Feature: print user warnings for CIFs that contain molecular species OH, OH2. 

* Add unit tests and example CIF files.