### PR TITLE
Change the implementation of Structure.interpolate_lattices.

### DIFF
--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -972,9 +972,9 @@ class IStructure(SiteCollection, MSONable):
             raise ValueError("Structures have different lengths!")
 
         if interpolate_lattices:
-            # interpolate lattices
-            lstart = np.array(self.lattice.lengths_and_angles)
-            lend = np.array(end_structure.lattice.lengths_and_angles)
+            # interpolate lattice matricies
+            lstart = self.lattice.matrix
+            lend = end_structure.lattice.matrix
             lvec = lend - lstart
 
         # Check that both structures have the same lattice
@@ -1033,7 +1033,7 @@ class IStructure(SiteCollection, MSONable):
         for x in range(nimages + 1):
             if interpolate_lattices:
                 l_a = lstart + x / nimages * lvec
-                l = Lattice.from_lengths_and_angles(*l_a)
+                l = Lattice(l_a)
             else:
                 l = self.lattice
             fcoords = start_coords + x / nimages * vec

--- a/pymatgen/core/tests/test_structure.py
+++ b/pymatgen/core/tests/test_structure.py
@@ -267,10 +267,14 @@ class IStructureTest(PymatgenTest):
                                     int_s[2].lattice.abc)
         self.assertArrayAlmostEqual(struct2.lattice.angles,
                                     int_s[2].lattice.angles)
-        int_angles = [(a + struct2.lattice.angles[i]) / 2
-                      for i, a in enumerate(struct.lattice.angles)]
+        int_angles = [110.7734367, 94.1864814, 65.4423028]
         self.assertArrayAlmostEqual(int_angles,
                                     int_s[1].lattice.angles)
+
+        # Assert that volume is monotonic
+        self.assertTrue(struct2.lattice.volume >=
+                        int_s[1].lattice.volume >=
+                        struct.lattice.volume)
 
     def test_get_primitive_structure(self):
         coords = [[0, 0, 0], [0.5, 0.5, 0], [0, 0.5, 0.5], [0.5, 0, 0.5]]


### PR DESCRIPTION
## Summary

Change the implementation of interpolate_lattices. Previously, the
parameters for the lattice (a, b, c, alpha, beta, gamma) were all
linearly interpolated to the parameters of the second structure. 
However, this can lead to various issues, including
that the interpolated volumes are not guarenteed monotonic. This is
resolved via interpolating the lattice matrices directly.