### PR TITLE
Fix PDEntry.from_dict to accommodate no-name dicts

### DIFF
--- a/pymatgen/phasediagram/entries.py
+++ b/pymatgen/phasediagram/entries.py
@@ -89,7 +89,8 @@ class PDEntry(MSONable):
 
     @classmethod
     def from_dict(cls, d):
-        return cls(Composition(d["composition"]), d["energy"], d["name"],
+        return cls(Composition(d["composition"]), d["energy"],
+                   d["name"] if "name" in d else None,
                    d["attribute"] if "attribute" in d else None)
 
 

--- a/pymatgen/phasediagram/tests/test_entries.py
+++ b/pymatgen/phasediagram/tests/test_entries.py
@@ -59,6 +59,13 @@ class PDEntryTest(unittest.TestCase):
         self.assertEqual(gpentry.name, 'LiFeO2', "Wrong name!")
         self.assertEqual(gpentry.energy_per_atom, 50.0 / 2)
 
+        d_anon = d.copy()
+        del d_anon['name']
+        try:
+            entry = PDEntry.from_dict(d_anon)
+        except KeyError:
+            self.fail("Should not need to supply name!")
+
     def test_str(self):
         self.assertIsNotNone(str(self.entry))
 


### PR DESCRIPTION
## Summary

Fix PDEntry.from_dict to accommodate no-name entry dicts. Add a test for this.

I encountered this issue when using `monty.json.MontyEncoder` to `json.dumps` Pourbaix entries. I could ensure this dumps 'name's for each entry, but `PDEntry.from_dict` should also just accommodate no-name entries as `PDEntry.__init__` specifies.
