### PR TITLE
ce_symbol in chemenv and fix of piecewise polynomial in nebanalysis for scipy > 0.18

### DIFF
--- a/pymatgen/analysis/chemenv/coordination_environments/coordination_geometries.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/coordination_geometries.py
@@ -567,6 +567,13 @@ class CoordinationGeometry(object):
         """
         return self._mp_symbol
 
+    @property
+    def ce_symbol(self):
+        """
+        Returns the symbol of this coordination geometry.
+        """
+        return self._mp_symbol
+
     def get_coordination_number(self):
         """
         Returns the coordination number of this coordination geometry.

--- a/pymatgen/analysis/transition_state.py
+++ b/pymatgen/analysis/transition_state.py
@@ -12,7 +12,7 @@ scipy_old_piecewisepolynomial = True
 try:
     from scipy.interpolate import PiecewisePolynomial
 except ImportError:
-    from scipy.interpolate import splmake, PPoly
+    from scipy.interpolate import CubicSpline
     scipy_old_piecewisepolynomial = False
 
 from pymatgen.util.plotting_utils import get_publication_quality_plot
@@ -97,10 +97,7 @@ class NEBAnalysis(object):
                 orders=interpolation_order)
         else:
             # New scipy implementation for scipy > 0.18.0
-            xk, coefs, order = splmake(
-                self.r, np.array([self.energies, -self.forces]).T,
-                order=interpolation_order)
-            self.spline = PPoly(c=coefs, x=xk)
+            self.spline = CubicSpline(x=self.r, y=self.energies, bc_type=((1, 0.0), (1, 0.0)))
 
     def get_extrema(self, normalize_rxn_coordinate=True):
         """


### PR DESCRIPTION
## Summary

* Added property ce_symbol in CoordinationGeometry (same as mp_symbol) in chemenv
* Fixed NEBAnalysis's piecewise polynomial construction for scipy versions > 0.18.