### PR TITLE
updates

### DIFF
--- a/pymatgen/electronic_structure/bandstructure.py
+++ b/pymatgen/electronic_structure/bandstructure.py
@@ -506,23 +506,15 @@ class BandStructure(object):
                     "kpoint_index": vbm["kpoint_index"],
                     "band_index": {str(int(spin)): vbm["band_index"][spin]
                                    for spin in vbm["band_index"]},
-                    'projections': {str(spin): {str(orb):
-                                                    vbm['projections'][spin][
-                                                        orb]
-                                                for orb in
-                                                vbm['projections'][spin]}
-                                    for spin in vbm['projections']}}
+                    'projections': {str(spin): v.tolist() for spin, v in vbm[
+                        'projections'].items()}}
         cbm = self.get_cbm()
         d['cbm'] = {'energy': cbm['energy'],
                     'kpoint_index': cbm['kpoint_index'],
                     'band_index': {str(int(spin)): cbm['band_index'][spin]
                                    for spin in cbm['band_index']},
-                    'projections': {str(spin): {str(orb):
-                                                    cbm['projections'][spin][
-                                                        orb]
-                                                for orb in
-                                                cbm['projections'][spin]}
-                                    for spin in cbm['projections']}}
+                    'projections': {str(spin): v.tolist() for spin, v in cbm[
+                        'projections'].items()}}
         d['band_gap'] = self.get_band_gap()
         d['labels_dict'] = {}
         d['is_spin_polarized'] = self.is_spin_polarized

--- a/pymatgen/io/feff/sets.py
+++ b/pymatgen/io/feff/sets.py
@@ -136,7 +136,7 @@ class FEFFDictSet(AbstractFeffInputSet):
         """
 
         Args:
-            absorbing_atom (str): absorbing atom symbol
+            absorbing_atom (str/int): absorbing atom symbol or site index
             structure (Structure): input structure
             radius (float): cluster radius
             config_dict (dict): control tag settings dict
@@ -252,7 +252,7 @@ class MPXANESSet(FEFFDictSet):
                  nkpts=1000, **kwargs):
         """
         Args:
-            absorbing_atom (str): absorbing atom symbol
+            absorbing_atom (str/int): absorbing atom symbol or site index
             structure (Structure): input
             edge (str): absorption edge
             radius (float): cluster radius in Angstroms.
@@ -277,7 +277,7 @@ class MPEXAFSSet(FEFFDictSet):
                  nkpts=1000, **kwargs):
         """
         Args:
-            absorbing_atom (str): absorbing atom symbol
+            absorbing_atom (str/int): absorbing atom symbol or site index
             structure (Structure): input structure
             edge (str): absorption edge
             radius (float): cluster radius in Angstroms.
@@ -302,7 +302,7 @@ class MPEELSDictSet(FEFFDictSet):
                  nkpts=1000, **kwargs):
         """
         Args:
-            absorbing_atom (str): absorbing atom symbol
+            absorbing_atom (str/int): absorbing atom symbol or site index
             structure (Structure): input structure
             edge (str): absorption edge
             spectrum (str): ELNES or EXELFS
@@ -358,7 +358,7 @@ class MPELNESSet(MPEELSDictSet):
                  **kwargs):
         """
         Args:
-            absorbing_atom (str): absorbing atom symbol
+            absorbing_atom (str/int): absorbing atom symbol or site index
             structure (Structure): input structure
             edge (str): absorption edge
             radius (float): cluster radius in Angstroms.
@@ -396,7 +396,7 @@ class MPEXELFSSet(MPEELSDictSet):
                  **kwargs):
         """
         Args:
-            absorbing_atom (str): absorbing atom symbol
+            absorbing_atom (str/int): absorbing atom symbol or site index
             structure (Structure): input structure
             edge (str): absorption edge
             radius (float): cluster radius in Angstroms.

--- a/pymatgen/io/feff/tests/test_inputs.py
+++ b/pymatgen/io/feff/tests/test_inputs.py
@@ -71,8 +71,14 @@ class FeffAtomsTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         r = CifParser(os.path.join(test_dir, "CoO19128.cif"))
-        structure = r.get_structures()[0]
-        cls.atoms = Atoms(structure, "O", 10.0)
+        cls.structure = r.get_structures()[0]
+        cls.atoms = Atoms(cls.structure, "O", 10.0)
+
+    def test_absorbing_atom(self):
+        atoms_1 = Atoms(self.structure, 0, 10.0)
+        atoms_2 = Atoms(self.structure, 2, 10.0)
+        self.assertEqual(atoms_1.absorbing_atom, "Co")
+        self.assertEqual(atoms_2.absorbing_atom, "O")
 
     def test_absorber_line(self):
         atoms_lines = self.atoms.get_lines()


### PR DESCRIPTION
* feff: the absorbing atom can be specified by either its symbol or the site index. added test

* Bandstructure serialization fix: make the vbm and cbm projections consistent with the latest refactoring. The stray old style serialization in the Bandstructure class causes trouble if the projections are read in and the line mode is set to false in  the get_bandstructure call(this is why i was getting the error( issue #500))