### PR TITLE
feff updates

### DIFF
--- a/pymatgen/io/feff/outputs.py
+++ b/pymatgen/io/feff/outputs.py
@@ -193,7 +193,7 @@ class Xmu(MSONable):
     Args:
         header: Header object
         parameters: Tags object
-        absorbing_atom (str): absorbing atom symbol
+        absorbing_atom (str/int): absorbing atom symbol or index
         data (numpy.ndarray, Nx6): cross_sections
 
     Default attributes:
@@ -233,7 +233,12 @@ class Xmu(MSONable):
         header = Header.from_file(feff_inp_file)
         parameters = Tags.from_file(feff_inp_file)
         pots = Potential.pot_string_from_file(feff_inp_file)
-        absorbing_atom = pots.splitlines()[1].split()[2]
+        # site index (Note: in feff it starts from 1)
+        if "RECIPROCAL" in parameters:
+            absorbing_atom = parameters["TARGET"]
+        # species symbol
+        else:
+            absorbing_atom = pots.splitlines()[1].split()[2]
         return Xmu(header, parameters, absorbing_atom, data)
 
     @property

--- a/pymatgen/io/feff/sets.py
+++ b/pymatgen/io/feff/sets.py
@@ -249,7 +249,7 @@ class MPXANESSet(FEFFDictSet):
     CONFIG = loadfn(os.path.join(MODULE_DIR, "MPXANESSet.yaml"))
 
     def __init__(self, absorbing_atom, structure, edge="K", radius=10.,
-                 nkpts=1000, **kwargs):
+                 nkpts=1000, user_tag_settings=None):
         """
         Args:
             absorbing_atom (str/int): absorbing atom symbol or site index
@@ -258,12 +258,12 @@ class MPXANESSet(FEFFDictSet):
             radius (float): cluster radius in Angstroms.
             nkpts (int): Total number of kpoints in the brillouin zone. Used
                 only when feff is run in the reciprocal space mode.
-            **kwargs
+            user_tag_settings (dict): override default tag settings
         """
         super(MPXANESSet, self).__init__(absorbing_atom, structure, radius,
                                          MPXANESSet.CONFIG, edge=edge,
-                                         spectrum="XANES", nkpts=nkpts, **kwargs)
-        self.kwargs = kwargs
+                                         spectrum="XANES", nkpts=nkpts,
+                                         user_tag_settings=user_tag_settings)
 
 
 class MPEXAFSSet(FEFFDictSet):
@@ -274,7 +274,7 @@ class MPEXAFSSet(FEFFDictSet):
     CONFIG = loadfn(os.path.join(MODULE_DIR, "MPEXAFSSet.yaml"))
 
     def __init__(self, absorbing_atom, structure, edge="K", radius=10.,
-                 nkpts=1000, **kwargs):
+                 nkpts=1000, user_tag_settings=None):
         """
         Args:
             absorbing_atom (str/int): absorbing atom symbol or site index
@@ -283,12 +283,12 @@ class MPEXAFSSet(FEFFDictSet):
             radius (float): cluster radius in Angstroms.
             nkpts (int): Total number of kpoints in the brillouin zone. Used
                 only when feff is run in the reciprocal space mode.
-            **kwargs
+            user_tag_settings (dict): override default tag settings
         """
         super(MPEXAFSSet, self).__init__(absorbing_atom, structure, radius,
                                          MPEXAFSSet.CONFIG, edge=edge,
-                                         spectrum="EXAFS", nkpts=nkpts, **kwargs)
-        self.kwargs = kwargs
+                                         spectrum="EXAFS", nkpts=nkpts,
+                                         user_tag_settings=user_tag_settings)
 
 
 class MPEELSDictSet(FEFFDictSet):
@@ -299,7 +299,7 @@ class MPEELSDictSet(FEFFDictSet):
     def __init__(self, absorbing_atom, structure, edge, spectrum, radius,
                  beam_energy, beam_direction, collection_angle,
                  convergence_angle, config_dict, user_eels_settings=None,
-                 nkpts=1000, **kwargs):
+                 nkpts=1000, user_tag_settings=None):
         """
         Args:
             absorbing_atom (str/int): absorbing atom symbol or site index
@@ -316,7 +316,7 @@ class MPEELSDictSet(FEFFDictSet):
                 See MPELNESSet.yaml for supported keys.
             nkpts (int): Total number of kpoints in the brillouin zone. Used
                 only when feff is run in the reciprocal space mode.
-            **kwargs
+            user_tag_settings (dict): override default tag settings
         """
         self.beam_energy = beam_energy
         self.beam_direction = beam_direction
@@ -341,8 +341,7 @@ class MPEELSDictSet(FEFFDictSet):
         super(MPEELSDictSet, self).__init__(absorbing_atom, structure, radius,
                                             eels_config_dict, edge=edge,
                                             spectrum=spectrum, nkpts=nkpts,
-                                            **kwargs)
-        self.kwargs = kwargs
+                                            user_tag_settings=user_tag_settings)
 
 
 class MPELNESSet(MPEELSDictSet):
@@ -355,7 +354,7 @@ class MPELNESSet(MPEELSDictSet):
     def __init__(self, absorbing_atom, structure, edge="K", radius=10.,
                  beam_energy=100, beam_direction=None, collection_angle=1,
                  convergence_angle=1, user_eels_settings=None, nkpts=1000,
-                 **kwargs):
+                 user_tag_settings=None):
         """
         Args:
             absorbing_atom (str/int): absorbing atom symbol or site index
@@ -371,7 +370,7 @@ class MPELNESSet(MPEELSDictSet):
                 See MPELNESSet.yaml for supported keys.
             nkpts (int): Total number of kpoints in the brillouin zone. Used
                 only when feff is run in the reciprocal space mode.
-            **kwargs
+            user_tag_settings (dict): override default tag settings
         """
 
         super(MPELNESSet, self).__init__(absorbing_atom, structure, edge,
@@ -379,8 +378,7 @@ class MPELNESSet(MPEELSDictSet):
                                          beam_direction, collection_angle,
                                          convergence_angle, MPELNESSet.CONFIG,
                                          user_eels_settings=user_eels_settings,
-                                         nkpts=nkpts, **kwargs)
-        self.kwargs = kwargs
+                                         nkpts=nkpts, user_tag_settings=user_tag_settings)
 
 
 class MPEXELFSSet(MPEELSDictSet):
@@ -393,7 +391,7 @@ class MPEXELFSSet(MPEELSDictSet):
     def __init__(self, absorbing_atom, structure, edge="K", radius=10.,
                  beam_energy=100, beam_direction=None, collection_angle=1,
                  convergence_angle=1, user_eels_settings=None, nkpts=1000,
-                 **kwargs):
+                 user_tag_settings=None):
         """
         Args:
             absorbing_atom (str/int): absorbing atom symbol or site index
@@ -409,7 +407,7 @@ class MPEXELFSSet(MPEELSDictSet):
                 See MPEXELFSSet.yaml for supported keys.
             nkpts (int): Total number of kpoints in the brillouin zone. Used
                 only when feff is run in the reciprocal space mode.
-            **kwargs
+            user_tag_settings (dict): override default tag settings
         """
 
         super(MPEXELFSSet, self).__init__(absorbing_atom, structure, edge,
@@ -417,5 +415,4 @@ class MPEXELFSSet(MPEELSDictSet):
                                           beam_direction, collection_angle,
                                           convergence_angle, MPEXELFSSet.CONFIG,
                                           user_eels_settings=user_eels_settings,
-                                          nkpts=nkpts, **kwargs)
-        self.kwargs = kwargs
+                                          nkpts=nkpts, user_tag_settings=user_tag_settings)


### PR DESCRIPTION
* remove kwargs in inputsets: keep it simple
* fix parsing of the absorbing atom from the reciprocal space calculation outputs