### PR TITLE
Frequency and hessian matrix from gaussian output files

### DIFF
--- a/pymatgen/io/gaussian.py
+++ b/pymatgen/io/gaussian.py
@@ -498,15 +498,23 @@ class GaussianOutput(object):
 
     .. attribute:: frequencies
 
-        A dict with {"frequency": freq in cm-1, "masse": Reduce mass,
-                     "frc": force constant, "intensity": IR Intensity,
-                     "mode": normal mode}
+        A list for each freq calculation and for each mode of a dict with
+        {
+            "frequency": freq in cm-1,
+            "symmetry": symmetry tag
+            "r_mass": Reduce mass,
+            "f_constant": force constant,
+            "IR_intensity": IR Intensity,
+            "mode": normal mode
+         }
+
         The normal mode is a 1D vector of dx, dy dz of each atom.
 
     .. attribute:: hessian
 
         Matrix of second derivatives of the energy with respect to cartesian
-        coordinates in the **input orientation** frame.
+        coordinates in the **input orientation** frame. Need #P in the
+        route section in order to be in the output.
 
     .. attribute:: properly_terminated
 

--- a/pymatgen/io/gaussian.py
+++ b/pymatgen/io/gaussian.py
@@ -723,6 +723,7 @@ class GaussianOutput(object):
                         self.functional = params[0]
                         self.basis_set = params[1]
                         self.route = params[2]
+                        route_lower = {k.lower(): v for k, v in self.route.items()}
                         self.dieze_tag = params[3]
                         parse_stage = 1
                 elif parse_stage == 1:
@@ -736,7 +737,7 @@ class GaussianOutput(object):
                     if self.is_pcm:
                         self._check_pcm(line)
 
-                    if "FREQ" in self.route and thermo_patt.search(line):
+                    if "freq" in route_lower and thermo_patt.search(line):
                         m = thermo_patt.search(line)
                         if m.group(1) == "Zero-point":
                             self.corrections["Zero-point"] = float(m.group(3))
@@ -939,7 +940,7 @@ class GaussianOutput(object):
                     elif (not self.is_pcm) and pcm_patt.search(line):
                         self.is_pcm = True
                         self.pcm = {}
-                    elif "FREQ" in self.route and "OPT" in self.route and \
+                    elif "freq" in route_lower and "opt" in route_lower and \
                             stat_type_patt.search(line):
                         self.stationary_type = "Saddle"
                     elif mp2_patt.search(line):

--- a/pymatgen/io/tests/test_gaussian.py
+++ b/pymatgen/io/tests/test_gaussian.py
@@ -202,7 +202,7 @@ class GaussianOutputTest(unittest.TestCase):
         self.assertEqual(d["input"]["functional"], "hf")
         self.assertAlmostEqual(d["output"]["final_energy"], -39.9768775602)
         self.assertEqual(len(gau.cart_forces), 3)
-        self.assertEqual(gau.cart_forces[0][ 5],  0.009791094)
+        self.assertEqual(gau.cart_forces[0][5],  0.009791094)
         self.assertEqual(gau.cart_forces[0][-1], -0.003263698)
         self.assertEqual(gau.cart_forces[2][-1], -0.000000032)
         self.assertEqual(gau.eigenvalues[Spin.up][-1], 1.95586)
@@ -211,14 +211,19 @@ class GaussianOutputTest(unittest.TestCase):
 
         ch2o_co2 = GaussianOutput(os.path.join(test_dir, "CH2O_CO2.log"))
         self.assertEqual(len(ch2o_co2.frequencies), 2)
-        self.assertEqual(ch2o_co2.frequencies[0][0][0], 1203.1940)
-        self.assertListEqual(ch2o_co2.frequencies[0][1][1], [ 0.15, 0.00, 0.00,
-                                                             -0.26, 0.65, 0.00,
-                                                             -0.26,-0.65, 0.00,
-                                                             -0.08, 0.00, 0.00])
-        self.assertListEqual(ch2o_co2.frequencies[1][3][1], [ 0.00, 0.00, 0.88,
-                                                              0.00, 0.00,-0.33,
-                                                              0.00, 0.00,-0.33])
+        self.assertEqual(len(ch2o_co2.frequencies[0]), 6)
+        self.assertEqual(len(ch2o_co2.frequencies[1]), 4)
+        self.assertEqual(ch2o_co2.frequencies[0][0]["frequency"], 1203.1940)
+        self.assertEqual(ch2o_co2.frequencies[0][3]["IR_intensity"], 60.9575)
+        self.assertEqual(ch2o_co2.frequencies[0][3]["r_mass"], 3.7543)
+        self.assertEqual(ch2o_co2.frequencies[0][4]["f_constant"], 5.4175)
+        self.assertListEqual(ch2o_co2.frequencies[0][1]["mode"], [0.15, 0.00, 0.00,
+                                                                  -0.26, 0.65, 0.00,
+                                                                  -0.26, -0.65, 0.00,
+                                                                  -0.08, 0.00, 0.00])
+        self.assertListEqual(ch2o_co2.frequencies[1][3]["mode"], [0.00, 0.00, 0.88,
+                                                                  0.00, 0.00, -0.33,
+                                                                  0.00, 0.00, -0.33])
         self.assertEqual(ch2o_co2.eigenvalues[Spin.up][3], -1.18394)
 
     def test_pop(self):
@@ -227,26 +232,26 @@ class GaussianOutputTest(unittest.TestCase):
         self.assertEqual(gau.electrons, (5, 5))
         self.assertEqual(gau.is_spin, True)
         self.assertListEqual(gau.eigenvalues[Spin.down], [-20.55343,  -1.35264,
-                                                           -0.72655,  -0.54824,
-                                                           -0.49831,   0.20705,
-                                                            0.30297,   1.10569,
-                                                            1.16144,   1.16717,
-                                                            1.20460,   1.38903,
-                                                            1.67608])
+                                                          -0.72655,  -0.54824,
+                                                          -0.49831,   0.20705,
+                                                          0.30297,   1.10569,
+                                                          1.16144,   1.16717,
+                                                          1.20460,   1.38903,
+                                                          1.67608])
         mo = gau.molecular_orbital
-        self.assertEqual(len(mo), 2) # la 6
+        self.assertEqual(len(mo), 2)  # la 6
         self.assertEqual(len(mo[Spin.down]), 13)
         self.assertEqual(len(mo[Spin.down][0]), 3)
         self.assertEqual(mo[Spin.down][5][0]["1S"], -0.08771)
         self.assertEqual(mo[Spin.down][5][0]["2PZ"], -0.21625)
         self.assertListEqual(gau.eigenvectors[Spin.up][:, 5].tolist(), [-0.08771,
-                                                                         0.10840,
-                                                                         0.00000,
-                                                                         0.00000,
+                                                                        0.10840,
+                                                                        0.00000,
+                                                                        0.00000,
                                                                         -0.21625,
-                                                                         1.21165,
-                                                                         0.00000,
-                                                                         0.00000,
+                                                                        1.21165,
+                                                                        0.00000,
+                                                                        0.00000,
                                                                         -0.44481,
                                                                         -0.06348,
                                                                         -1.00532,

--- a/pymatgen/io/tests/test_gaussian.py
+++ b/pymatgen/io/tests/test_gaussian.py
@@ -214,6 +214,7 @@ class GaussianOutputTest(unittest.TestCase):
         self.assertEqual(len(ch2o_co2.frequencies[0]), 6)
         self.assertEqual(len(ch2o_co2.frequencies[1]), 4)
         self.assertEqual(ch2o_co2.frequencies[0][0]["frequency"], 1203.1940)
+        self.assertEqual(ch2o_co2.frequencies[0][0]["symmetry"], "A\"")
         self.assertEqual(ch2o_co2.frequencies[0][3]["IR_intensity"], 60.9575)
         self.assertEqual(ch2o_co2.frequencies[0][3]["r_mass"], 3.7543)
         self.assertEqual(ch2o_co2.frequencies[0][4]["f_constant"], 5.4175)
@@ -224,7 +225,20 @@ class GaussianOutputTest(unittest.TestCase):
         self.assertListEqual(ch2o_co2.frequencies[1][3]["mode"], [0.00, 0.00, 0.88,
                                                                   0.00, 0.00, -0.33,
                                                                   0.00, 0.00, -0.33])
+        self.assertEqual(ch2o_co2.frequencies[1][3]["symmetry"], "SGU")
         self.assertEqual(ch2o_co2.eigenvalues[Spin.up][3], -1.18394)
+
+        h2o = GaussianOutput(os.path.join(test_dir, "H2O_gau_vib.out"))
+        self.assertEqual(len(h2o.frequencies[0]), 3)
+        self.assertEqual(h2o.frequencies[0][0]["frequency"], 1662.8033)
+        self.assertEqual(h2o.frequencies[0][1]["symmetry"], "A'")
+        self.assertEqual(h2o.hessian[0, 0], 0.356872)
+        self.assertEqual(h2o.hessian.shape, (9, 9))
+        self.assertEqual(h2o.hessian[8, :].tolist(), [-0.143692e-01,  0.780136e-01,
+                                                      -0.362637e-01, -0.176193e-01,
+                                                      0.277304e-01, -0.583237e-02,
+                                                      0.319885e-01, -0.105744e+00,
+                                                      0.420960e-01])
 
     def test_pop(self):
         gau = GaussianOutput(os.path.join(test_dir, "H2O_gau.out"))

--- a/test_files/molecules/H2O_gau_vib.out
+++ b/test_files/molecules/H2O_gau_vib.out
@@ -1,0 +1,3975 @@
+===============================================
+Execution sur noeud     : dnas-node31.univ-pau.fr
+Job id = 853327
+Fichiers temporaire sur :  /scratch/853327
+===============================================
+Debut execution du job  : jeu. nov. 17 12:10:42 CET 2016
+ Entering Gaussian System, Link 0=g09
+ Initial command:
+ /opt/g09-d01/g09/l1.exe "/scratch/853327/Gau-20518.inp" -scrdir="/scratch/853327/"
+ Entering Link 1 = /opt/g09-d01/g09/l1.exe PID=     20519.
+  
+ Copyright (c) 1988,1990,1992,1993,1995,1998,2003,2009,2013,
+            Gaussian, Inc.  All Rights Reserved.
+  
+ This is part of the Gaussian(R) 09 program.  It is based on
+ the Gaussian(R) 03 system (copyright 2003, Gaussian, Inc.),
+ the Gaussian(R) 98 system (copyright 1998, Gaussian, Inc.),
+ the Gaussian(R) 94 system (copyright 1995, Gaussian, Inc.),
+ the Gaussian 92(TM) system (copyright 1992, Gaussian, Inc.),
+ the Gaussian 90(TM) system (copyright 1990, Gaussian, Inc.),
+ the Gaussian 88(TM) system (copyright 1988, Gaussian, Inc.),
+ the Gaussian 86(TM) system (copyright 1986, Carnegie Mellon
+ University), and the Gaussian 82(TM) system (copyright 1983,
+ Carnegie Mellon University). Gaussian is a federally registered
+ trademark of Gaussian, Inc.
+  
+ This software contains proprietary and confidential information,
+ including trade secrets, belonging to Gaussian, Inc.
+  
+ This software is provided under written license and may be
+ used, copied, transmitted, or stored only in accord with that
+ written license.
+  
+ The following legend is applicable only to US Government
+ contracts under FAR:
+  
+                    RESTRICTED RIGHTS LEGEND
+  
+ Use, reproduction and disclosure by the US Government is
+ subject to restrictions as set forth in subparagraphs (a)
+ and (c) of the Commercial Computer Software - Restricted
+ Rights clause in FAR 52.227-19.
+  
+ Gaussian, Inc.
+ 340 Quinnipiac St., Bldg. 40, Wallingford CT 06492
+  
+  
+ ---------------------------------------------------------------
+ Warning -- This program may not be used in any manner that
+ competes with the business of Gaussian, Inc. or will provide
+ assistance to any competitor of Gaussian, Inc.  The licensee
+ of this program is prohibited from giving any competitor of
+ Gaussian, Inc. access to this program.  By using this program,
+ the user acknowledges that Gaussian, Inc. is engaged in the
+ business of creating and licensing software in the field of
+ computational chemistry and represents and warrants to the
+ licensee that it is not a competitor of Gaussian, Inc. and that
+ it will not use this program in any manner prohibited above.
+ ---------------------------------------------------------------
+  
+
+ Cite this work as:
+ Gaussian 09, Revision D.01,
+ M. J. Frisch, G. W. Trucks, H. B. Schlegel, G. E. Scuseria, 
+ M. A. Robb, J. R. Cheeseman, G. Scalmani, V. Barone, B. Mennucci, 
+ G. A. Petersson, H. Nakatsuji, M. Caricato, X. Li, H. P. Hratchian, 
+ A. F. Izmaylov, J. Bloino, G. Zheng, J. L. Sonnenberg, M. Hada, 
+ M. Ehara, K. Toyota, R. Fukuda, J. Hasegawa, M. Ishida, T. Nakajima, 
+ Y. Honda, O. Kitao, H. Nakai, T. Vreven, J. A. Montgomery, Jr., 
+ J. E. Peralta, F. Ogliaro, M. Bearpark, J. J. Heyd, E. Brothers, 
+ K. N. Kudin, V. N. Staroverov, T. Keith, R. Kobayashi, J. Normand, 
+ K. Raghavachari, A. Rendell, J. C. Burant, S. S. Iyengar, J. Tomasi, 
+ M. Cossi, N. Rega, J. M. Millam, M. Klene, J. E. Knox, J. B. Cross, 
+ V. Bakken, C. Adamo, J. Jaramillo, R. Gomperts, R. E. Stratmann, 
+ O. Yazyev, A. J. Austin, R. Cammi, C. Pomelli, J. W. Ochterski, 
+ R. L. Martin, K. Morokuma, V. G. Zakrzewski, G. A. Voth, 
+ P. Salvador, J. J. Dannenberg, S. Dapprich, A. D. Daniels, 
+ O. Farkas, J. B. Foresman, J. V. Ortiz, J. Cioslowski, 
+ and D. J. Fox, Gaussian, Inc., Wallingford CT, 2013.
+ 
+ ******************************************
+ Gaussian 09:  EM64L-G09RevD.01 24-Apr-2013
+                17-Nov-2016 
+ ******************************************
+ %chk=h2o.chk
+ --------------------------------------
+ #P B3LYP / 6-31+G* opt=tight freq form
+ --------------------------------------
+ 1/7=10,14=-1,18=20,19=15,26=3,38=1/1,3;
+ 2/9=110,12=2,17=6,18=5,40=1/2;
+ 3/5=1,6=6,7=11,11=2,16=1,25=1,30=1,71=1,74=-5/1,2,3;
+ 4//1;
+ 5/5=2,38=5/2;
+ 6/7=2,8=2,9=2,10=2,28=1/1;
+ 7//1,2,3,16;
+ 1/7=10,14=-1,18=20,19=15,26=3/3(2);
+ 2/9=110/2;
+ 99//99;
+ 2/9=110/2;
+ 3/5=1,6=6,7=11,11=2,16=1,25=1,30=1,71=1,74=-5/1,2,3;
+ 4/5=5,16=3,69=1/1;
+ 5/5=2,38=5/2;
+ 7//1,2,3,16;
+ 1/7=10,14=-1,18=20,19=15,26=3/3(-5);
+ 2/9=110/2;
+ 6/7=2,8=2,9=2,10=2,19=2,28=1/1;
+ 99/9=1/99;
+ Leave Link    1 at Thu Nov 17 12:10:42 2016, MaxMem=           0 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l101.exe)
+ -------
+ vib H2O
+ -------
+ Symbolic Z-matrix:
+ Charge =  0 Multiplicity = 1
+ O                    -0.11106   0.0339    0.04317 
+ H                     0.96606   0.95915  -1.08909 
+ H                     0.79663  -1.49716   0.40399 
+ 
+ Add virtual bond connecting atoms H3         and O1         Dist= 3.43D+00.
+ Add virtual bond connecting atoms H2         and O1         Dist= 3.43D+00.
+ NAtoms=      3 NQM=        3 NQMF=       0 NMMI=      0 NMMIF=      0
+                NMic=       0 NMicF=      0.
+                    Isotopes and Nuclear Properties:
+ (Nuclear quadrupole moments (NQMom) in fm**2, nuclear magnetic moments (NMagM)
+  in nuclear magnetons)
+
+  Atom         1           2           3
+ IAtWgt=          16           1           1
+ AtmWgt=  15.9949146   1.0078250   1.0078250
+ NucSpn=           0           1           1
+ AtZEff=   0.0000000   0.0000000   0.0000000
+ NQMom=    0.0000000   0.0000000   0.0000000
+ NMagM=    0.0000000   2.7928460   2.7928460
+ AtZNuc=   8.0000000   1.0000000   1.0000000
+ Leave Link  101 at Thu Nov 17 12:10:42 2016, MaxMem=    33554432 cpu:         0.1
+ (Enter /opt/g09-d01/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Initialization pass.
+                           ----------------------------
+                           !    Initial Parameters    !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  1.8161         estimate D2E/DX2                !
+ ! R2    R(1,3)                  1.8161         estimate D2E/DX2                !
+ ! A1    A(2,1,3)              104.889          estimate D2E/DX2                !
+ --------------------------------------------------------------------------------
+ Trust Radius=3.00D-01 FncErr=1.00D-07 GrdErr=1.00D-06
+ Number of steps in this run=     20 maximum allowed number of steps=    100.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Thu Nov 17 12:10:42 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0       -0.111056    0.033897    0.043165
+      2          1           0        0.966057    0.959148   -1.089095
+      3          1           0        0.796629   -1.497157    0.403985
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    1.816115   0.000000
+     3  H    1.816097   2.879484   0.000000
+ Stoichiometry    H2O
+ Framework group  CS[SG(H2O)]
+ Deg. of freedom     3
+ Full point group                 CS      NOp   2
+ Largest Abelian subgroup         CS      NOp   2
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.000000    0.221394    0.000000
+      2          1           0        1.439742   -0.885592    0.000000
+      3          1           0       -1.439742   -0.885562    0.000000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):    230.3959797    120.9574758     79.3164709
+ Leave Link  202 at Thu Nov 17 12:10:42 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l301.exe)
+ Standard basis: 6-31+G(d) (6D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are    18 symmetry adapted cartesian basis functions of A'  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A"  symmetry.
+ There are    18 symmetry adapted basis functions of A'  symmetry.
+ There are     5 symmetry adapted basis functions of A"  symmetry.
+    23 basis functions,    40 primitive gaussians,    23 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         4.8458564381 Hartrees.
+ IExCor=  402 DFT=T Ex+Corr=B3LYP ExCW=0 ScaHFX=  0.200000
+ ScaDFX=  0.800000  0.720000  1.000000  0.810000 ScalE2=  1.000000  1.000000
+ IRadAn=      0 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=  4
+ NAtoms=    3 NActive=    3 NUniq=    3 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ Leave Link  301 at Thu Nov 17 12:10:42 2016, MaxMem=    33554432 cpu:         0.1
+ (Enter /opt/g09-d01/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+ NBasis=    23 RedAO= T EigKep=  3.03D-02  NBF=    18     5
+ NBsUse=    23 1.00D-06 EigRej= -1.00D+00 NBFU=    18     5
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           0 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=    23    23    23    23    23 MxSgAt=     3 MxSgA2=     3.
+ Leave Link  302 at Thu Nov 17 12:10:42 2016, MaxMem=    33554432 cpu:         0.2
+ (Enter /opt/g09-d01/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Thu Nov 17 12:10:42 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l401.exe)
+ ExpMin= 8.45D-02 ExpMax= 5.48D+03 ExpMxC= 8.25D+02 IAcc=2 IRadAn=         4 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       4 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         4 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Harris En= -76.1845027436366    
+ JPrj=0 DoOrth=F DoCkMO=F.
+ Initial guess orbital symmetries:
+       Occupied  (A') (A') (A') (A') (A")
+       Virtual   (A') (A') (A') (A") (A') (A') (A') (A') (A") (A')
+                 (A') (A') (A') (A") (A") (A') (A') (A')
+ The electronic state of the initial guess is 1-A'.
+ Leave Link  401 at Thu Nov 17 12:10:43 2016, MaxMem=    33554432 cpu:         0.2
+ (Enter /opt/g09-d01/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ Integral symmetry usage will be decided dynamically.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=919005.
+ IVT=       20464 IEndB=       20464 NGot=    33554432 MDV=    33511632
+ LenX=    33511632 LenY=    33510662
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=    276 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+
+ Cycle   1  Pass 0  IDiag  1:
+ E= -75.9356103046487    
+ DIIS: error= 1.06D-01 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -75.9356103046487     IErMin= 1 ErrMin= 1.06D-01
+ ErrMax= 1.06D-01  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.57D-01 BMatP= 1.57D-01
+ IDIUse=3 WtCom= 0.00D+00 WtEn= 1.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff-En:   0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.046 Goal=   None    Shift=    0.000
+ GapD=    0.046 DampG=0.250 DampE=0.250 DampFc=0.2500 IDamp=-1.
+ Damping current iteration by 2.50D-01
+ RMSDP=5.06D-02 MaxDP=3.64D-01              OVMax= 6.85D-01
+
+ Cycle   2  Pass 0  IDiag  1:
+ E= -75.9954437767750     Delta-E=       -0.059833472126 Rises=F Damp=T
+ DIIS: error= 2.35D-02 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -75.9954437767750     IErMin= 2 ErrMin= 2.35D-02
+ ErrMax= 2.35D-02  0.00D+00 EMaxC= 1.00D-01 BMatC= 6.62D-03 BMatP= 1.57D-01
+ IDIUse=3 WtCom= 7.65D-01 WtEn= 2.35D-01
+ Coeff-Com:  0.114D+00 0.886D+00
+ Coeff-En:   0.332D+00 0.668D+00
+ Coeff:      0.165D+00 0.835D+00
+ Gap=     0.056 Goal=   None    Shift=    0.000
+ RMSDP=1.07D-02 MaxDP=7.25D-02 DE=-5.98D-02 OVMax= 5.28D-01
+
+ Cycle   3  Pass 0  IDiag  1:
+ E= -76.0840875979956     Delta-E=       -0.088643821221 Rises=F Damp=F
+ DIIS: error= 5.17D-02 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -76.0840875979956     IErMin= 2 ErrMin= 2.35D-02
+ ErrMax= 5.17D-02  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.14D-02 BMatP= 6.62D-03
+ IDIUse=2 WtCom= 0.00D+00 WtEn= 1.00D+00
+ Coeff-En:   0.274D+00 0.000D+00 0.726D+00
+ Coeff:      0.274D+00 0.000D+00 0.726D+00
+ Gap=     0.148 Goal=   None    Shift=    0.000
+ RMSDP=9.28D-03 MaxDP=8.48D-02 DE=-8.86D-02 OVMax= 1.63D-01
+
+ Cycle   4  Pass 0  IDiag  1:
+ E= -76.1009425706340     Delta-E=       -0.016854972638 Rises=F Damp=F
+ DIIS: error= 3.97D-02 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -76.1009425706340     IErMin= 2 ErrMin= 2.35D-02
+ ErrMax= 3.97D-02  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.49D-02 BMatP= 6.62D-03
+ IDIUse=2 WtCom= 0.00D+00 WtEn= 1.00D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.421D+00 0.579D+00
+ Coeff:      0.000D+00 0.000D+00 0.421D+00 0.579D+00
+ Gap=     0.133 Goal=   None    Shift=    0.000
+ RMSDP=4.55D-03 MaxDP=4.44D-02 DE=-1.69D-02 OVMax= 8.13D-02
+
+ Cycle   5  Pass 0  IDiag  1:
+ E= -76.1246996510674     Delta-E=       -0.023757080433 Rises=F Damp=F
+ DIIS: error= 5.30D-03 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -76.1246996510674     IErMin= 5 ErrMin= 5.30D-03
+ ErrMax= 5.30D-03  0.00D+00 EMaxC= 1.00D-01 BMatC= 5.27D-04 BMatP= 6.62D-03
+ IDIUse=3 WtCom= 9.47D-01 WtEn= 5.30D-02
+ Coeff-Com: -0.108D-01-0.150D-01 0.168D-01 0.166D+00 0.843D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.000D+00 0.426D-01 0.957D+00
+ Coeff:     -0.102D-01-0.142D-01 0.159D-01 0.159D+00 0.849D+00
+ Gap=     0.137 Goal=   None    Shift=    0.000
+ RMSDP=5.79D-04 MaxDP=5.59D-03 DE=-2.38D-02 OVMax= 9.54D-03
+
+ Cycle   6  Pass 0  IDiag  1:
+ E= -76.1251567380065     Delta-E=       -0.000457086939 Rises=F Damp=F
+ DIIS: error= 5.38D-04 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -76.1251567380065     IErMin= 6 ErrMin= 5.38D-04
+ ErrMax= 5.38D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 6.13D-06 BMatP= 5.27D-04
+ IDIUse=3 WtCom= 9.95D-01 WtEn= 5.38D-03
+ Coeff-Com:  0.166D-02-0.142D-02-0.427D-02 0.302D-03 0.161D+00 0.843D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.000D+00 0.000D+00 0.609D-02 0.994D+00
+ Coeff:      0.165D-02-0.141D-02-0.425D-02 0.301D-03 0.160D+00 0.844D+00
+ Gap=     0.137 Goal=   None    Shift=    0.000
+ RMSDP=6.63D-05 MaxDP=6.53D-04 DE=-4.57D-04 OVMax= 1.09D-03
+
+ Cycle   7  Pass 0  IDiag  1:
+ E= -76.1251615377783     Delta-E=       -0.000004799772 Rises=F Damp=F
+ DIIS: error= 1.35D-04 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -76.1251615377783     IErMin= 7 ErrMin= 1.35D-04
+ ErrMax= 1.35D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.72D-07 BMatP= 6.13D-06
+ IDIUse=3 WtCom= 9.99D-01 WtEn= 1.35D-03
+ Coeff-Com:  0.400D-04 0.344D-03-0.167D-02 0.969D-03 0.355D-02 0.375D-01
+ Coeff-Com:  0.959D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.000D+00 0.000D+00 0.000D+00 0.117D+00
+ Coeff-En:   0.883D+00
+ Coeff:      0.399D-04 0.343D-03-0.166D-02 0.968D-03 0.355D-02 0.376D-01
+ Coeff:      0.959D+00
+ Gap=     0.137 Goal=   None    Shift=    0.000
+ RMSDP=1.55D-05 MaxDP=1.46D-04 DE=-4.80D-06 OVMax= 2.92D-04
+
+ Cycle   8  Pass 0  IDiag  1:
+ E= -76.1251618175152     Delta-E=       -0.000000279737 Rises=F Damp=F
+ DIIS: error= 1.25D-05 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -76.1251618175152     IErMin= 8 ErrMin= 1.25D-05
+ ErrMax= 1.25D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.10D-09 BMatP= 2.72D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.773D-05-0.627D-05-0.387D-04 0.114D-03-0.294D-03-0.363D-02
+ Coeff-Com:  0.118D+00 0.886D+00
+ Coeff:     -0.773D-05-0.627D-05-0.387D-04 0.114D-03-0.294D-03-0.363D-02
+ Coeff:      0.118D+00 0.886D+00
+ Gap=     0.137 Goal=   None    Shift=    0.000
+ RMSDP=1.30D-06 MaxDP=1.15D-05 DE=-2.80D-07 OVMax= 2.26D-05
+
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ Cycle   9  Pass 1  IDiag  1:
+ E= -76.1251855597237     Delta-E=       -0.000023742209 Rises=F Damp=F
+ DIIS: error= 6.13D-06 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -76.1251855597237     IErMin= 1 ErrMin= 6.13D-06
+ ErrMax= 6.13D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 9.39D-10 BMatP= 9.39D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.137 Goal=   None    Shift=    0.000
+ RMSDP=1.30D-06 MaxDP=1.15D-05 DE=-2.37D-05 OVMax= 2.36D-05
+
+ Cycle  10  Pass 1  IDiag  1:
+ E= -76.1251855599622     Delta-E=       -0.000000000238 Rises=F Damp=F
+ DIIS: error= 7.92D-06 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -76.1251855599622     IErMin= 1 ErrMin= 6.13D-06
+ ErrMax= 7.92D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 9.32D-10 BMatP= 9.39D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.499D+00 0.501D+00
+ Coeff:      0.499D+00 0.501D+00
+ Gap=     0.137 Goal=   None    Shift=    0.000
+ RMSDP=2.44D-06 MaxDP=2.29D-05 DE=-2.38D-10 OVMax= 4.36D-05
+
+ Cycle  11  Pass 1  IDiag  1:
+ E= -76.1251855570714     Delta-E=        0.000000002891 Rises=F Damp=F
+ DIIS: error= 1.60D-05 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 2 EnMin= -76.1251855599622     IErMin= 1 ErrMin= 6.13D-06
+ ErrMax= 1.60D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.07D-09 BMatP= 9.32D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.182D-01 0.688D+00 0.330D+00
+ Coeff:     -0.182D-01 0.688D+00 0.330D+00
+ Gap=     0.137 Goal=   None    Shift=    0.000
+ RMSDP=1.44D-06 MaxDP=1.41D-05 DE= 2.89D-09 OVMax= 2.54D-05
+
+ Cycle  12  Pass 1  IDiag  1:
+ E= -76.1251855609171     Delta-E=       -0.000000003846 Rises=F Damp=F
+ DIIS: error= 1.28D-06 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -76.1251855609171     IErMin= 4 ErrMin= 1.28D-06
+ ErrMax= 1.28D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.07D-11 BMatP= 9.32D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.112D-01 0.169D+00 0.241D-01 0.818D+00
+ Coeff:     -0.112D-01 0.169D+00 0.241D-01 0.818D+00
+ Gap=     0.137 Goal=   None    Shift=    0.000
+ RMSDP=1.40D-07 MaxDP=1.14D-06 DE=-3.85D-09 OVMax= 2.41D-06
+
+ Cycle  13  Pass 1  IDiag  1:
+ E= -76.1251855609402     Delta-E=       -0.000000000023 Rises=F Damp=F
+ DIIS: error= 5.48D-08 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -76.1251855609402     IErMin= 5 ErrMin= 5.48D-08
+ ErrMax= 5.48D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 6.10D-14 BMatP= 2.07D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.113D-02 0.745D-02-0.143D-02 0.115D+00 0.880D+00
+ Coeff:     -0.113D-02 0.745D-02-0.143D-02 0.115D+00 0.880D+00
+ Gap=     0.137 Goal=   None    Shift=    0.000
+ RMSDP=9.88D-09 MaxDP=7.50D-08 DE=-2.31D-11 OVMax= 1.67D-07
+
+ SCF Done:  E(RB3LYP) =  -76.1251855609     A.U. after   13 cycles
+            NFock= 13  Conv=0.99D-08     -V/T= 2.0169
+ KE= 7.485901897578D+01 PE=-1.893264342216D+02 EE= 3.349637324671D+01
+ Leave Link  502 at Thu Nov 17 12:10:44 2016, MaxMem=    33554432 cpu:         0.9
+ (Enter /opt/g09-d01/g09/l601.exe)
+ Copying SCF densities to generalized density rwf, IOpCl= 0 IROHF=0.
+
+ **********************************************************************
+
+            Population analysis using the SCF density.
+
+ **********************************************************************
+
+ Orbital symmetries:
+       Occupied  (A') (A') (A') (A') (A")
+       Virtual   (A') (A') (A') (A") (A') (A') (A') (A') (A") (A')
+                 (A') (A') (A') (A") (A") (A') (A') (A')
+ The electronic state is 1-A'.
+ Alpha  occ. eigenvalues --  -19.23987  -0.89317  -0.36289  -0.34243  -0.30301
+ Alpha virt. eigenvalues --   -0.16598  -0.13658   0.14648   0.16009   0.19528
+ Alpha virt. eigenvalues --    0.20883   0.75927   0.78950   1.12890   1.14267
+ Alpha virt. eigenvalues --    1.16046   1.22846   1.78656   1.80340   1.80743
+ Alpha virt. eigenvalues --    1.82214   1.83843   3.66540
+          Condensed to atoms (all electrons):
+               1          2          3
+     1  O    8.142208   0.175070   0.175071
+     2  H    0.175070   0.579320  -0.000564
+     3  H    0.175071  -0.000564   0.579318
+ Mulliken charges:
+               1
+     1  O   -0.492349
+     2  H    0.246174
+     3  H    0.246175
+ Sum of Mulliken charges =   0.00000
+ Mulliken charges with hydrogens summed into heavy atoms:
+               1
+     1  O    0.000000
+ Electronic spatial extent (au):  <R**2>=             34.9425
+ Charge=              0.0000 electrons
+ Dipole moment (field-independent basis, Debye):
+    X=              0.0000    Y=             -2.2007    Z=              0.0000  Tot=              2.2007
+ Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=             -2.5240   YY=             -6.0775   ZZ=             -9.0675
+   XY=              0.0000   XZ=              0.0000   YZ=              0.0000
+ Traceless Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=              3.3656   YY=             -0.1878   ZZ=             -3.1778
+   XY=              0.0000   XZ=              0.0000   YZ=              0.0000
+ Octapole moment (field-independent basis, Debye-Ang**2):
+  XXX=              0.0000  YYY=             -0.4565  ZZZ=              0.0000  XYY=              0.0001
+  XXY=             -4.8852  XXZ=              0.0000  XZZ=              0.0000  YZZ=              0.3393
+  YYZ=              0.0000  XYZ=              0.0000
+ Hexadecapole moment (field-independent basis, Debye-Ang**3):
+ XXXX=            -16.4230 YYYY=            -16.1516 ZZZZ=             -9.7026 XXXY=              0.0000
+ XXXZ=              0.0000 YYYX=              0.0000 YYYZ=              0.0000 ZZZX=              0.0000
+ ZZZY=              0.0000 XXYY=             -2.7102 XXZZ=             -6.6911 YYZZ=             -4.7072
+ XXYZ=              0.0000 YYXZ=              0.0000 ZZXY=              0.0000
+ N-N= 4.845856438139D+00 E-N=-1.893264333241D+02  KE= 7.485901897578D+01
+ Symmetry A'   KE= 7.012882137039D+01
+ Symmetry A"   KE= 4.730197605395D+00
+ No NMR shielding tensors so no spin-rotation constants.
+ Leave Link  601 at Thu Nov 17 12:10:44 2016, MaxMem=    33554432 cpu:         0.2
+ (Enter /opt/g09-d01/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ Leave Link  701 at Thu Nov 17 12:10:44 2016, MaxMem=    33554432 cpu:         0.2
+ (Enter /opt/g09-d01/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Thu Nov 17 12:10:44 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=F KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         0 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2127 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Thu Nov 17 12:10:44 2016, MaxMem=    33554432 cpu:         0.3
+ (Enter /opt/g09-d01/g09/l716.exe)
+ Dipole        =-4.17459808D-06-8.65831885D-01 8.91029224D-17
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8           0.083799259   -0.025578822   -0.032569773
+      2        1          -0.045936997   -0.045751578    0.051869047
+      3        1          -0.037862261    0.071330400   -0.019299274
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.083799259 RMS     0.050028029
+ Leave Link  716 at Thu Nov 17 12:10:44 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.082892730 RMS     0.068340145
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .68340D-01 SwitMx=.10000D-02 MixMth= 1
+ Mixed Optimization -- RFO/linear search
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.05935
+           R2           0.00000   0.05935
+           A1           0.00000   0.00000   0.16000
+ ITU=  0
+     Eigenvalues ---    0.05935   0.05935   0.16000
+ RFO step:  Lambda=-9.19156082D-02 EMin= 5.93490387D-02
+ Linear search not attempted -- first point.
+ Maximum step size (   0.300) exceeded in Quadratic search.
+    -- Step size scaled by   0.386
+ Iteration  1 RMS(Cart)=  0.15646966 RMS(Int)=  0.00957448
+ Iteration  2 RMS(Cart)=  0.00757538 RMS(Int)=  0.00000335
+ Iteration  3 RMS(Cart)=  0.00000605 RMS(Int)=  0.00000000
+ Iteration  4 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ITry= 1 IFail=0 DXMaxC= 1.73D-01 DCOld= 1.00D+10 DXMaxT= 3.00D-01 DXLimC= 3.00D+00 Rises=F
+ ClnCor:  largest displacement from symmetrization is 3.65D-15 for atom     2.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        3.43196  -0.08289   0.00000  -0.21139  -0.21139   3.22057
+    R2        3.43193  -0.08289   0.00000  -0.21139  -0.21139   3.22054
+    A1        1.83066  -0.01640   0.00000  -0.02511  -0.02511   1.80555
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.082893     0.000015     NO 
+ RMS     Force            0.068340     0.000010     NO 
+ Maximum Displacement     0.172992     0.000060     NO 
+ RMS     Displacement     0.163629     0.000040     NO 
+ Predicted change in Energy=-3.275403D-02
+ Lowest energy point so far.  Saving SCF results.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Thu Nov 17 12:10:44 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0       -0.080395    0.024538    0.031248
+      2          1           0        0.944735    0.876964   -1.030336
+      3          1           0        0.787290   -1.405614    0.357143
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    1.704254   0.000000
+     3  H    1.704236   2.675826   0.000000
+ Stoichiometry    H2O
+ Framework group  CS[SG(H2O)]
+ Deg. of freedom     3
+ Full point group                 CS      NOp   2
+ RotChk:  IX=0 Diff= 9.82D-07
+ Largest Abelian subgroup         CS      NOp   2
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.000000    0.211134    0.000000
+      2          1           0        1.337913   -0.844551    0.000000
+      3          1           0       -1.337913   -0.844521    0.000000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):    253.3327068    140.0703470     90.1985885
+ Leave Link  202 at Thu Nov 17 12:10:45 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l301.exe)
+ Standard basis: 6-31+G(d) (6D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are    18 symmetry adapted cartesian basis functions of A'  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A"  symmetry.
+ There are    18 symmetry adapted basis functions of A'  symmetry.
+ There are     5 symmetry adapted basis functions of A"  symmetry.
+    23 basis functions,    40 primitive gaussians,    23 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         5.1658485017 Hartrees.
+ IExCor=  402 DFT=T Ex+Corr=B3LYP ExCW=0 ScaHFX=  0.200000
+ ScaDFX=  0.800000  0.720000  1.000000  0.810000 ScalE2=  1.000000  1.000000
+ IRadAn=      0 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=  4
+ NAtoms=    3 NActive=    3 NUniq=    3 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ Leave Link  301 at Thu Nov 17 12:10:45 2016, MaxMem=    33554432 cpu:         0.1
+ (Enter /opt/g09-d01/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+ NBasis=    23 RedAO= T EigKep=  3.00D-02  NBF=    18     5
+ NBsUse=    23 1.00D-06 EigRej= -1.00D+00 NBFU=    18     5
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           0 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=    23    23    23    23    23 MxSgAt=     3 MxSgA2=     3.
+ Leave Link  302 at Thu Nov 17 12:10:45 2016, MaxMem=    33554432 cpu:         0.2
+ (Enter /opt/g09-d01/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Thu Nov 17 12:10:45 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l401.exe)
+ Initial guess from the checkpoint file:  "h2o.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess orbital symmetries:
+       Occupied  (A') (A') (A') (A') (A")
+       Virtual   (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A") (A") (A") (A")
+ The electronic state of the initial guess is 1-A'.
+ Generating alternative initial guess.
+ ExpMin= 8.45D-02 ExpMax= 5.48D+03 ExpMxC= 8.25D+02 IAcc=2 IRadAn=         4 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       4 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         4 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Harris En= -76.2137829489675    
+ Leave Link  401 at Thu Nov 17 12:10:45 2016, MaxMem=    33554432 cpu:         0.3
+ (Enter /opt/g09-d01/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ Integral symmetry usage will be decided dynamically.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=919005.
+ IVT=       20464 IEndB=       20464 NGot=    33554432 MDV=    33511632
+ LenX=    33511632 LenY=    33510662
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=    276 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+
+ Cycle   1  Pass 0  IDiag  1:
+ E= -76.1617398639271    
+ DIIS: error= 5.09D-03 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -76.1617398639271     IErMin= 1 ErrMin= 5.09D-03
+ ErrMax= 5.09D-03  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.74D-04 BMatP= 4.74D-04
+ IDIUse=3 WtCom= 9.49D-01 WtEn= 5.09D-02
+ Coeff-Com:  0.100D+01
+ Coeff-En:   0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.681 Goal=   None    Shift=    0.000
+ GapD=    0.681 DampG=2.000 DampE=1.000 DampFc=2.0000 IDamp=-1.
+ RMSDP=2.54D-03 MaxDP=2.32D-02              OVMax= 4.42D-02
+
+ Cycle   2  Pass 0  IDiag  1:
+ E= -76.1577996917329     Delta-E=        0.003940172194 Rises=F Damp=F
+ DIIS: error= 1.71D-02 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 1 EnMin= -76.1617398639271     IErMin= 1 ErrMin= 5.09D-03
+ ErrMax= 1.71D-02  0.00D+00 EMaxC= 1.00D-01 BMatC= 5.05D-03 BMatP= 4.74D-04
+ IDIUse=2 WtCom= 0.00D+00 WtEn= 1.00D+00
+ Coeff-En:   0.840D+00 0.160D+00
+ Coeff:      0.840D+00 0.160D+00
+ Gap=     0.156 Goal=   None    Shift=    0.000
+ RMSDP=1.49D-03 MaxDP=1.41D-02 DE= 3.94D-03 OVMax= 2.52D-02
+
+ Cycle   3  Pass 0  IDiag  1:
+ E= -76.1623777794042     Delta-E=       -0.004578087671 Rises=F Damp=F
+ DIIS: error= 2.72D-03 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -76.1623777794042     IErMin= 3 ErrMin= 2.72D-03
+ ErrMax= 2.72D-03  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.36D-04 BMatP= 4.74D-04
+ IDIUse=3 WtCom= 9.73D-01 WtEn= 2.72D-02
+ Coeff-Com:  0.257D-01-0.182D+00 0.116D+01
+ Coeff-En:   0.000D+00 0.000D+00 0.100D+01
+ Coeff:      0.250D-01-0.178D+00 0.115D+01
+ Gap=     0.155 Goal=   None    Shift=    0.000
+ RMSDP=3.28D-04 MaxDP=2.48D-03 DE=-4.58D-03 OVMax= 4.85D-03
+
+ Cycle   4  Pass 0  IDiag  1:
+ E= -76.1625057816154     Delta-E=       -0.000128002211 Rises=F Damp=F
+ DIIS: error= 2.42D-04 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -76.1625057816154     IErMin= 4 ErrMin= 2.42D-04
+ ErrMax= 2.42D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.58D-06 BMatP= 1.36D-04
+ IDIUse=3 WtCom= 9.98D-01 WtEn= 2.42D-03
+ Coeff-Com: -0.156D-01-0.305D-01 0.243D+00 0.803D+00
+ Coeff-En:   0.000D+00 0.000D+00 0.000D+00 0.100D+01
+ Coeff:     -0.155D-01-0.305D-01 0.242D+00 0.804D+00
+ Gap=     0.155 Goal=   None    Shift=    0.000
+ RMSDP=3.03D-05 MaxDP=2.89D-04 DE=-1.28D-04 OVMax= 5.19D-04
+
+ Cycle   5  Pass 0  IDiag  1:
+ E= -76.1625072120574     Delta-E=       -0.000001430442 Rises=F Damp=F
+ DIIS: error= 5.73D-05 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -76.1625072120574     IErMin= 5 ErrMin= 5.73D-05
+ ErrMax= 5.73D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 5.83D-08 BMatP= 1.58D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.598D-03 0.549D-02-0.113D-01 0.399D-01 0.966D+00
+ Coeff:     -0.598D-03 0.549D-02-0.113D-01 0.399D-01 0.966D+00
+ Gap=     0.155 Goal=   None    Shift=    0.000
+ RMSDP=1.09D-05 MaxDP=1.21D-04 DE=-1.43D-06 OVMax= 2.33D-04
+
+ Cycle   6  Pass 0  IDiag  1:
+ E= -76.1625072766675     Delta-E=       -0.000000064610 Rises=F Damp=F
+ DIIS: error= 1.99D-05 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -76.1625072766675     IErMin= 6 ErrMin= 1.99D-05
+ ErrMax= 1.99D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.69D-09 BMatP= 5.83D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.251D-03-0.930D-04-0.607D-02-0.211D-01 0.365D-01 0.991D+00
+ Coeff:      0.251D-03-0.930D-04-0.607D-02-0.211D-01 0.365D-01 0.991D+00
+ Gap=     0.155 Goal=   None    Shift=    0.000
+ RMSDP=2.48D-06 MaxDP=2.58D-05 DE=-6.46D-08 OVMax= 5.15D-05
+
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ Cycle   7  Pass 1  IDiag  1:
+ E= -76.1625055117898     Delta-E=        0.000001764878 Rises=F Damp=F
+ DIIS: error= 6.18D-06 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -76.1625055117898     IErMin= 1 ErrMin= 6.18D-06
+ ErrMax= 6.18D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 6.10D-10 BMatP= 6.10D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.155 Goal=   None    Shift=    0.000
+ RMSDP=2.48D-06 MaxDP=2.58D-05 DE= 1.76D-06 OVMax= 1.98D-05
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -76.1625055121185     Delta-E=       -0.000000000329 Rises=F Damp=F
+ DIIS: error= 5.96D-06 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -76.1625055121185     IErMin= 2 ErrMin= 5.96D-06
+ ErrMax= 5.96D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.70D-10 BMatP= 6.10D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.441D+00 0.559D+00
+ Coeff:      0.441D+00 0.559D+00
+ Gap=     0.155 Goal=   None    Shift=    0.000
+ RMSDP=1.69D-06 MaxDP=1.51D-05 DE=-3.29D-10 OVMax= 2.78D-05
+
+ Cycle   9  Pass 1  IDiag  1:
+ E= -76.1625055108791     Delta-E=        0.000000001239 Rises=F Damp=F
+ DIIS: error= 1.02D-05 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 2 EnMin= -76.1625055121185     IErMin= 2 ErrMin= 5.96D-06
+ ErrMax= 1.02D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.86D-09 BMatP= 4.70D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.704D-01 0.622D+00 0.307D+00
+ Coeff:      0.704D-01 0.622D+00 0.307D+00
+ Gap=     0.155 Goal=   None    Shift=    0.000
+ RMSDP=1.04D-06 MaxDP=1.03D-05 DE= 1.24D-09 OVMax= 1.83D-05
+
+ Cycle  10  Pass 1  IDiag  1:
+ E= -76.1625055126028     Delta-E=       -0.000000001724 Rises=F Damp=F
+ DIIS: error= 3.37D-07 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -76.1625055126028     IErMin= 4 ErrMin= 3.37D-07
+ ErrMax= 3.37D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.90D-12 BMatP= 4.70D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.173D-01 0.139D+00 0.600D-01 0.818D+00
+ Coeff:     -0.173D-01 0.139D+00 0.600D-01 0.818D+00
+ Gap=     0.155 Goal=   None    Shift=    0.000
+ RMSDP=5.02D-08 MaxDP=3.37D-07 DE=-1.72D-09 OVMax= 8.14D-07
+
+ Cycle  11  Pass 1  IDiag  1:
+ E= -76.1625055126049     Delta-E=       -0.000000000002 Rises=F Damp=F
+ DIIS: error= 4.83D-08 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -76.1625055126049     IErMin= 5 ErrMin= 4.83D-08
+ ErrMax= 4.83D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 3.20D-14 BMatP= 1.90D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.998D-03-0.199D-01-0.131D-01-0.882D-01 0.112D+01
+ Coeff:      0.998D-03-0.199D-01-0.131D-01-0.882D-01 0.112D+01
+ Gap=     0.155 Goal=   None    Shift=    0.000
+ RMSDP=1.42D-08 MaxDP=1.58D-07 DE=-2.10D-12 OVMax= 3.12D-07
+
+ Cycle  12  Pass 1  IDiag  1:
+ E= -76.1625055126051     Delta-E=        0.000000000000 Rises=F Damp=F
+ DIIS: error= 2.82D-08 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -76.1625055126051     IErMin= 6 ErrMin= 2.82D-08
+ ErrMax= 2.82D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.01D-14 BMatP= 3.20D-14
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.807D-03-0.765D-02-0.202D-02-0.370D-01 0.167D+00 0.878D+00
+ Coeff:      0.807D-03-0.765D-02-0.202D-02-0.370D-01 0.167D+00 0.878D+00
+ Gap=     0.155 Goal=   None    Shift=    0.000
+ RMSDP=3.44D-09 MaxDP=3.31D-08 DE=-2.70D-13 OVMax= 6.96D-08
+
+ SCF Done:  E(RB3LYP) =  -76.1625055126     A.U. after   12 cycles
+            NFock= 12  Conv=0.34D-08     -V/T= 2.0172
+ KE= 7.487432186164D+01 PE=-1.900035995517D+02 EE= 3.380092367579D+01
+ Leave Link  502 at Thu Nov 17 12:10:46 2016, MaxMem=    33554432 cpu:         0.9
+ (Enter /opt/g09-d01/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ Leave Link  701 at Thu Nov 17 12:10:46 2016, MaxMem=    33554432 cpu:         0.2
+ (Enter /opt/g09-d01/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Thu Nov 17 12:10:46 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=F KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         0 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2127 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Thu Nov 17 12:10:47 2016, MaxMem=    33554432 cpu:         0.3
+ (Enter /opt/g09-d01/g09/l716.exe)
+ Dipole        =-5.33692804D-06-8.77416550D-01-1.76979879D-16
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8           0.094616451   -0.028880511   -0.036774109
+      2        1          -0.051729914   -0.049673242    0.057358468
+      3        1          -0.042886537    0.078553753   -0.020584359
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.094616451 RMS     0.055783076
+ Leave Link  716 at Thu Nov 17 12:10:47 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.091691628 RMS     0.075470354
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .75470D-01 SwitMx=.10000D-02 MixMth= 1
+ Mixed Optimization -- RFO/linear search
+ Update second derivatives using D2CorX and points    1    2
+ DE= -3.73D-02 DEPred=-3.28D-02 R= 1.14D+00
+ TightC=F SS=  1.41D+00  RLast= 3.00D-01 DXNew= 5.0454D-01 9.0000D-01
+ Trust test= 1.14D+00 RLast= 3.00D-01 DXMaxT set to 5.05D-01
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.00943
+           R2          -0.04992   0.00943
+           A1          -0.00961  -0.00961   0.15701
+ ITU=  1  0
+ Use linear search instead of GDIIS.
+     Eigenvalues ---   -0.04141   0.05935   0.15794
+ Eigenvalue     1 is  -4.14D-02 should be greater than     0.000000 Eigenvector:
+                          R2        R1        A1
+   1                    0.70546   0.70545   0.06832
+ RFO step:  Lambda=-1.52914346D-01 EMin=-4.14135227D-02
+ Skip linear search -- no minimum in search direction.
+ Maximum step size (   0.505) exceeded in Quadratic search.
+    -- Step size scaled by   0.504
+ Iteration  1 RMS(Cart)=  0.16908595 RMS(Int)=  0.12751989
+ Iteration  2 RMS(Cart)=  0.10735646 RMS(Int)=  0.00009722
+ Iteration  3 RMS(Cart)=  0.00015437 RMS(Int)=  0.00000001
+ Iteration  4 RMS(Cart)=  0.00000001 RMS(Int)=  0.00000000
+ ITry= 1 IFail=0 DXMaxC= 2.89D-01 DCOld= 1.00D+10 DXMaxT= 5.05D-01 DXLimC= 3.00D+00 Rises=F
+ ClnCor:  largest displacement from symmetrization is 1.33D-15 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        3.22057  -0.09169   0.00000  -0.35522  -0.35522   2.86535
+    R2        3.22054  -0.09169   0.00000  -0.35523  -0.35523   2.86531
+    A1        1.80555  -0.01652   0.00000  -0.04680  -0.04680   1.75875
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.091692     0.000015     NO 
+ RMS     Force            0.075470     0.000010     NO 
+ Maximum Displacement     0.289148     0.000060     NO 
+ RMS     Displacement     0.273792     0.000040     NO 
+ Predicted change in Energy=-7.117054D-02
+ Lowest energy point so far.  Saving SCF results.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Thu Nov 17 12:10:47 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0       -0.027294    0.008329    0.010610
+      2          1           0        0.908190    0.740162   -0.931935
+      3          1           0        0.770734   -1.252603    0.279380
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    1.516278   0.000000
+     3  H    1.516258   2.336085   0.000000
+ Stoichiometry    H2O
+ Framework group  CS[SG(H2O)]
+ Deg. of freedom     3
+ Full point group                 CS      NOp   2
+ RotChk:  IX=0 Diff= 2.96D-06
+ Largest Abelian subgroup         CS      NOp   2
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.000000    0.193365    0.000000
+      2          1           0        1.168043   -0.773474    0.000000
+      3          1           0       -1.168043   -0.773442    0.000000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):    302.0326252    183.7742853    114.2549203
+ Leave Link  202 at Thu Nov 17 12:10:47 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l301.exe)
+ Standard basis: 6-31+G(d) (6D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are    18 symmetry adapted cartesian basis functions of A'  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A"  symmetry.
+ There are    18 symmetry adapted basis functions of A'  symmetry.
+ There are     5 symmetry adapted basis functions of A"  symmetry.
+    23 basis functions,    40 primitive gaussians,    23 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         5.8105188470 Hartrees.
+ IExCor=  402 DFT=T Ex+Corr=B3LYP ExCW=0 ScaHFX=  0.200000
+ ScaDFX=  0.800000  0.720000  1.000000  0.810000 ScalE2=  1.000000  1.000000
+ IRadAn=      0 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=  4
+ NAtoms=    3 NActive=    3 NUniq=    3 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ Leave Link  301 at Thu Nov 17 12:10:47 2016, MaxMem=    33554432 cpu:         0.1
+ (Enter /opt/g09-d01/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+ NBasis=    23 RedAO= T EigKep=  2.97D-02  NBF=    18     5
+ NBsUse=    23 1.00D-06 EigRej= -1.00D+00 NBFU=    18     5
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           0 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=    23    23    23    23    23 MxSgAt=     3 MxSgA2=     3.
+ Leave Link  302 at Thu Nov 17 12:10:47 2016, MaxMem=    33554432 cpu:         0.2
+ (Enter /opt/g09-d01/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Thu Nov 17 12:10:47 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l401.exe)
+ Initial guess from the checkpoint file:  "h2o.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000001 Ang=   0.00 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess orbital symmetries:
+       Occupied  (A') (A') (A') (A') (A")
+       Virtual   (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A") (A") (A") (A")
+ The electronic state of the initial guess is 1-A'.
+ Generating alternative initial guess.
+ ExpMin= 8.45D-02 ExpMax= 5.48D+03 ExpMxC= 8.25D+02 IAcc=2 IRadAn=         4 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       4 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         4 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Harris En= -76.2730102303595    
+ Leave Link  401 at Thu Nov 17 12:10:48 2016, MaxMem=    33554432 cpu:         0.3
+ (Enter /opt/g09-d01/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ Integral symmetry usage will be decided dynamically.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=919005.
+ IVT=       20464 IEndB=       20464 NGot=    33554432 MDV=    33511632
+ LenX=    33511632 LenY=    33510662
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=    276 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+
+ Cycle   1  Pass 0  IDiag  1:
+ E= -76.2300560607013    
+ DIIS: error= 1.19D-02 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -76.2300560607013     IErMin= 1 ErrMin= 1.19D-02
+ ErrMax= 1.19D-02  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.07D-03 BMatP= 2.07D-03
+ IDIUse=3 WtCom= 8.81D-01 WtEn= 1.19D-01
+ Coeff-Com:  0.100D+01
+ Coeff-En:   0.100D+01
+ Coeff:      0.100D+01
+ Recover alternate guess density for next cycle.
+ RMSDP=1.11D-02 MaxDP=9.80D-02              OVMax= 0.00D+00
+
+ Cycle   2  Pass 0  IDiag  1:
+ E= -76.1355233053296     Delta-E=        0.094532755372 Rises=F Damp=F
+ Switch densities from cycles 1 and 2 for lowest energy.
+ DIIS: error= 7.50D-02 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 1 EnMin= -76.2300560607013     IErMin= 1 ErrMin= 1.19D-02
+ ErrMax= 7.50D-02  0.00D+00 EMaxC= 1.00D+00 BMatC= 9.23D-02 BMatP= 2.07D-03
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.923D+00 0.770D-01
+ Coeff:      0.923D+00 0.770D-01
+ Gap=     0.676 Goal=   None    Shift=    0.000
+ RMSDP=2.54D-03 MaxDP=1.65D-02 DE= 9.45D-02 OVMax= 3.84D-02
+
+ Cycle   3  Pass 0  IDiag  1:
+ E= -76.2331545897060     Delta-E=       -0.097631284376 Rises=F Damp=F
+ DIIS: error= 3.70D-03 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -76.2331545897060     IErMin= 3 ErrMin= 3.70D-03
+ ErrMax= 3.70D-03  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.70D-04 BMatP= 2.07D-03
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.117D+00-0.326D-01 0.916D+00
+ Coeff:      0.117D+00-0.326D-01 0.916D+00
+ Gap=     0.194 Goal=   None    Shift=    0.000
+ RMSDP=4.04D-04 MaxDP=2.98D-03 DE=-9.76D-02 OVMax= 4.66D-03
+
+ Cycle   4  Pass 0  IDiag  1:
+ E= -76.2333886756238     Delta-E=       -0.000234085918 Rises=F Damp=F
+ DIIS: error= 9.12D-04 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -76.2333886756238     IErMin= 4 ErrMin= 9.12D-04
+ ErrMax= 9.12D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.29D-05 BMatP= 2.70D-04
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.187D-01-0.158D-01 0.160D+00 0.875D+00
+ Coeff:     -0.187D-01-0.158D-01 0.160D+00 0.875D+00
+ Gap=     0.193 Goal=   None    Shift=    0.000
+ RMSDP=1.28D-04 MaxDP=5.85D-04 DE=-2.34D-04 OVMax= 1.73D-03
+
+ Cycle   5  Pass 0  IDiag  1:
+ E= -76.2334012915885     Delta-E=       -0.000012615965 Rises=F Damp=F
+ DIIS: error= 6.03D-05 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -76.2334012915885     IErMin= 5 ErrMin= 6.03D-05
+ ErrMax= 6.03D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 4.74D-08 BMatP= 1.29D-05
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.752D-03 0.795D-03-0.919D-02 0.125D-01 0.997D+00
+ Coeff:     -0.752D-03 0.795D-03-0.919D-02 0.125D-01 0.997D+00
+ Gap=     0.193 Goal=   None    Shift=    0.000
+ RMSDP=1.67D-05 MaxDP=1.68D-04 DE=-1.26D-05 OVMax= 3.16D-04
+
+ Cycle   6  Pass 0  IDiag  1:
+ E= -76.2334013854786     Delta-E=       -0.000000093890 Rises=F Damp=F
+ DIIS: error= 1.65D-05 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -76.2334013854786     IErMin= 6 ErrMin= 1.65D-05
+ ErrMax= 1.65D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.42D-09 BMatP= 4.74D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.157D-03-0.434D-04-0.200D-02-0.977D-02-0.622D-01 0.107D+01
+ Coeff:      0.157D-03-0.434D-04-0.200D-02-0.977D-02-0.622D-01 0.107D+01
+ Gap=     0.193 Goal=   None    Shift=    0.000
+ RMSDP=2.87D-06 MaxDP=2.73D-05 DE=-9.39D-08 OVMax= 5.34D-05
+
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ Cycle   7  Pass 1  IDiag  1:
+ E= -76.2333914439929     Delta-E=        0.000009941486 Rises=F Damp=F
+ DIIS: error= 3.84D-06 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -76.2333914439929     IErMin= 1 ErrMin= 3.84D-06
+ ErrMax= 3.84D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.36D-10 BMatP= 2.36D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.193 Goal=   None    Shift=    0.000
+ RMSDP=2.87D-06 MaxDP=2.73D-05 DE= 9.94D-06 OVMax= 1.50D-05
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -76.2333914435364     Delta-E=        0.000000000457 Rises=F Damp=F
+ DIIS: error= 6.49D-06 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 1 EnMin= -76.2333914439929     IErMin= 1 ErrMin= 3.84D-06
+ ErrMax= 6.49D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 9.68D-10 BMatP= 2.36D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.706D+00 0.294D+00
+ Coeff:      0.706D+00 0.294D+00
+ Gap=     0.193 Goal=   None    Shift=    0.000
+ RMSDP=9.86D-07 MaxDP=9.04D-06 DE= 4.57D-10 OVMax= 1.51D-05
+
+ Cycle   9  Pass 1  IDiag  1:
+ E= -76.2333914443205     Delta-E=       -0.000000000784 Rises=F Damp=F
+ DIIS: error= 1.75D-06 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -76.2333914443205     IErMin= 3 ErrMin= 1.75D-06
+ ErrMax= 1.75D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 6.55D-11 BMatP= 2.36D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.429D-01 0.204D+00 0.839D+00
+ Coeff:     -0.429D-01 0.204D+00 0.839D+00
+ Gap=     0.193 Goal=   None    Shift=    0.000
+ RMSDP=2.35D-07 MaxDP=1.85D-06 DE=-7.84D-10 OVMax= 3.22D-06
+
+ Cycle  10  Pass 1  IDiag  1:
+ E= -76.2333914443811     Delta-E=       -0.000000000061 Rises=F Damp=F
+ DIIS: error= 1.27D-07 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -76.2333914443811     IErMin= 4 ErrMin= 1.27D-07
+ ErrMax= 1.27D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 4.08D-13 BMatP= 6.55D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.837D-02 0.191D-01 0.148D+00 0.842D+00
+ Coeff:     -0.837D-02 0.191D-01 0.148D+00 0.842D+00
+ Gap=     0.193 Goal=   None    Shift=    0.000
+ RMSDP=1.85D-08 MaxDP=1.63D-07 DE=-6.06D-11 OVMax= 3.11D-07
+
+ Cycle  11  Pass 1  IDiag  1:
+ E= -76.2333914443815     Delta-E=        0.000000000000 Rises=F Damp=F
+ DIIS: error= 6.20D-09 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -76.2333914443815     IErMin= 5 ErrMin= 6.20D-09
+ ErrMax= 6.20D-09  0.00D+00 EMaxC= 1.00D+00 BMatC= 8.23D-16 BMatP= 4.08D-13
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.188D-03-0.256D-02-0.342D-02 0.961D-01 0.910D+00
+ Coeff:      0.188D-03-0.256D-02-0.342D-02 0.961D-01 0.910D+00
+ Gap=     0.193 Goal=   None    Shift=    0.000
+ RMSDP=1.80D-09 MaxDP=1.48D-08 DE=-4.26D-13 OVMax= 2.90D-08
+
+ SCF Done:  E(RB3LYP) =  -76.2333914444     A.U. after   11 cycles
+            NFock= 11  Conv=0.18D-08     -V/T= 2.0174
+ KE= 7.493280646087D+01 PE=-1.913798182059D+02 EE= 3.440310145356D+01
+ Leave Link  502 at Thu Nov 17 12:10:48 2016, MaxMem=    33554432 cpu:         0.8
+ (Enter /opt/g09-d01/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ Leave Link  701 at Thu Nov 17 12:10:49 2016, MaxMem=    33554432 cpu:         0.2
+ (Enter /opt/g09-d01/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Thu Nov 17 12:10:49 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=F KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         0 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2127 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Thu Nov 17 12:10:49 2016, MaxMem=    33554432 cpu:         0.3
+ (Enter /opt/g09-d01/g09/l716.exe)
+ Dipole        =-7.29381242D-06-9.07708814D-01 3.65642728D-17
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8           0.113763206   -0.034724387   -0.044216032
+      2        1          -0.061836620   -0.054483981    0.065779758
+      3        1          -0.051926586    0.089208368   -0.021563726
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.113763206 RMS     0.065270083
+ Leave Link  716 at Thu Nov 17 12:10:49 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.105338496 RMS     0.086377913
+ Search for a local minimum.
+ Step number   3 out of a maximum of   20
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .86378D-01 SwitMx=.10000D-02 MixMth= 1
+ Mixed Optimization -- RFO/linear search
+ Update second derivatives using D2CorX and points    2    3
+ DE= -7.09D-02 DEPred=-7.12D-02 R= 9.96D-01
+ TightC=F SS=  1.41D+00  RLast= 5.05D-01 DXNew= 8.4853D-01 1.5136D+00
+ Trust test= 9.96D-01 RLast= 5.05D-01 DXMaxT set to 8.49D-01
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.01089
+           R2          -0.04846   0.01089
+           A1          -0.00651  -0.00651   0.15628
+ ITU=  1  1  0
+ Use linear search instead of GDIIS.
+     Eigenvalues ---   -0.03800   0.05935   0.15672
+ Eigenvalue     1 is  -3.80D-02 should be greater than     0.000000 Eigenvector:
+                          R2        R1        A1
+   1                   -0.70631  -0.70631  -0.04734
+ RFO step:  Lambda=-1.69720159D-01 EMin=-3.79965762D-02
+ Skip linear search -- no minimum in search direction.
+ Maximum step size (   0.849) exceeded in Quadratic search.
+    -- Step size scaled by   0.848
+ Iteration  1 RMS(Cart)=  0.17150446 RMS(Int)=  0.32652054
+ Iteration  2 RMS(Cart)=  0.13565058 RMS(Int)=  0.16321733
+ Iteration  3 RMS(Cart)=  0.13767454 RMS(Int)=  0.00001780
+ Iteration  4 RMS(Cart)=  0.00002251 RMS(Int)=  0.00000000
+ Iteration  5 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ITry= 1 IFail=0 DXMaxC= 4.60D-01 DCOld= 1.00D+10 DXMaxT= 8.49D-01 DXLimC= 3.00D+00 Rises=F
+ ClnCor:  largest displacement from symmetrization is 7.77D-16 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.86535  -0.10534   0.00000  -0.59861  -0.59861   2.26674
+    R2        2.86531  -0.10534   0.00000  -0.59861  -0.59861   2.26670
+    A1        1.75875  -0.01383   0.00000  -0.05771  -0.05771   1.70103
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.105338     0.000015     NO 
+ RMS     Force            0.086378     0.000010     NO 
+ Maximum Displacement     0.459834     0.000060     NO 
+ RMS     Displacement     0.439923     0.000040     NO 
+ Predicted change in Energy=-1.405597D-01
+ Lowest energy point so far.  Saving SCF results.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Thu Nov 17 12:10:49 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.077681   -0.023713   -0.030190
+      2          1           0        0.840024    0.528871   -0.773362
+      3          1           0        0.733925   -1.009270    0.161607
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    1.199509   0.000000
+     3  H    1.199486   1.803137   0.000000
+ Stoichiometry    H2O
+ Framework group  CS[SG(H2O)]
+ Deg. of freedom     3
+ Full point group                 CS      NOp   2
+ RotChk:  IX=0 Diff= 6.10D-06
+ Largest Abelian subgroup         CS      NOp   2
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.000000    0.158236    0.000000
+      2          1           0        0.901568   -0.632962    0.000000
+      3          1           0       -0.901568   -0.632928    0.000000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):    451.0193647    308.4642451    183.1815013
+ Leave Link  202 at Thu Nov 17 12:10:49 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l301.exe)
+ Standard basis: 6-31+G(d) (6D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are    18 symmetry adapted cartesian basis functions of A'  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A"  symmetry.
+ There are    18 symmetry adapted basis functions of A'  symmetry.
+ There are     5 symmetry adapted basis functions of A"  symmetry.
+    23 basis functions,    40 primitive gaussians,    23 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         7.3521296625 Hartrees.
+ IExCor=  402 DFT=T Ex+Corr=B3LYP ExCW=0 ScaHFX=  0.200000
+ ScaDFX=  0.800000  0.720000  1.000000  0.810000 ScalE2=  1.000000  1.000000
+ IRadAn=      0 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=  4
+ NAtoms=    3 NActive=    3 NUniq=    3 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ Leave Link  301 at Thu Nov 17 12:10:49 2016, MaxMem=    33554432 cpu:         0.1
+ (Enter /opt/g09-d01/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+ NBasis=    23 RedAO= T EigKep=  3.16D-02  NBF=    18     5
+ NBsUse=    23 1.00D-06 EigRej= -1.00D+00 NBFU=    18     5
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           0 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=    23    23    23    23    23 MxSgAt=     3 MxSgA2=     3.
+ Leave Link  302 at Thu Nov 17 12:10:49 2016, MaxMem=    33554432 cpu:         0.2
+ (Enter /opt/g09-d01/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Thu Nov 17 12:10:49 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l401.exe)
+ Initial guess from the checkpoint file:  "h2o.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000002 Ang=   0.00 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess orbital symmetries:
+       Occupied  (A') (A') (A') (A') (A")
+       Virtual   (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A") (A") (A") (A")
+ The electronic state of the initial guess is 1-A'.
+ Generating alternative initial guess.
+ ExpMin= 8.45D-02 ExpMax= 5.48D+03 ExpMxC= 8.25D+02 IAcc=2 IRadAn=         4 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       4 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         4 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Harris En= -76.3910432572044    
+ Leave Link  401 at Thu Nov 17 12:10:50 2016, MaxMem=    33554432 cpu:         0.3
+ (Enter /opt/g09-d01/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ Integral symmetry usage will be decided dynamically.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=919005.
+ IVT=       20464 IEndB=       20464 NGot=    33554432 MDV=    33511632
+ LenX=    33511632 LenY=    33510662
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=    276 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+
+ Cycle   1  Pass 0  IDiag  1:
+ E= -76.3439358070536    
+ DIIS: error= 2.84D-02 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -76.3439358070536     IErMin= 1 ErrMin= 2.84D-02
+ ErrMax= 2.84D-02  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.42D-02 BMatP= 1.42D-02
+ IDIUse=3 WtCom= 7.16D-01 WtEn= 2.84D-01
+ Coeff-Com:  0.100D+01
+ Coeff-En:   0.100D+01
+ Coeff:      0.100D+01
+ Recover alternate guess density for next cycle.
+ RMSDP=1.25D-02 MaxDP=1.04D-01              OVMax= 0.00D+00
+
+ Cycle   2  Pass 0  IDiag  1:
+ E= -76.2996637629292     Delta-E=        0.044272044124 Rises=F Damp=F
+ Switch densities from cycles 1 and 2 for lowest energy.
+ DIIS: error= 5.74D-02 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 1 EnMin= -76.3439358070536     IErMin= 1 ErrMin= 2.84D-02
+ ErrMax= 5.74D-02  0.00D+00 EMaxC= 1.00D+00 BMatC= 7.36D-02 BMatP= 1.42D-02
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.773D+00 0.227D+00
+ Coeff:      0.773D+00 0.227D+00
+ Gap=     0.675 Goal=   None    Shift=    0.000
+ RMSDP=6.08D-03 MaxDP=2.99D-02 DE= 4.43D-02 OVMax= 7.90D-02
+
+ Cycle   3  Pass 0  IDiag  1:
+ E= -76.3639679705540     Delta-E=       -0.064304207625 Rises=F Damp=F
+ DIIS: error= 5.66D-03 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -76.3639679705540     IErMin= 3 ErrMin= 5.66D-03
+ ErrMax= 5.66D-03  0.00D+00 EMaxC= 1.00D+00 BMatC= 7.37D-04 BMatP= 1.42D-02
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.588D-01 0.801D-01 0.861D+00
+ Coeff:      0.588D-01 0.801D-01 0.861D+00
+ Gap=     0.282 Goal=   None    Shift=    0.000
+ RMSDP=8.91D-04 MaxDP=7.49D-03 DE=-6.43D-02 OVMax= 1.22D-02
+
+ Cycle   4  Pass 0  IDiag  1:
+ E= -76.3646175939487     Delta-E=       -0.000649623395 Rises=F Damp=F
+ DIIS: error= 9.28D-04 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -76.3646175939487     IErMin= 4 ErrMin= 9.28D-04
+ ErrMax= 9.28D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.33D-05 BMatP= 7.37D-04
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.115D-01 0.173D-01 0.165D+00 0.829D+00
+ Coeff:     -0.115D-01 0.173D-01 0.165D+00 0.829D+00
+ Gap=     0.282 Goal=   None    Shift=    0.000
+ RMSDP=1.29D-04 MaxDP=8.41D-04 DE=-6.50D-04 OVMax= 1.30D-03
+
+ Cycle   5  Pass 0  IDiag  1:
+ E= -76.3646360907396     Delta-E=       -0.000018496791 Rises=F Damp=F
+ DIIS: error= 1.46D-04 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -76.3646360907396     IErMin= 5 ErrMin= 1.46D-04
+ ErrMax= 1.46D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 5.47D-07 BMatP= 2.33D-05
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.750D-04 0.197D-02-0.733D-02-0.234D-01 0.103D+01
+ Coeff:     -0.750D-04 0.197D-02-0.733D-02-0.234D-01 0.103D+01
+ Gap=     0.282 Goal=   None    Shift=    0.000
+ RMSDP=3.18D-05 MaxDP=2.99D-04 DE=-1.85D-05 OVMax= 4.93D-04
+
+ Cycle   6  Pass 0  IDiag  1:
+ E= -76.3646366366179     Delta-E=       -0.000000545878 Rises=F Damp=F
+ DIIS: error= 1.63D-05 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -76.3646366366179     IErMin= 6 ErrMin= 1.63D-05
+ ErrMax= 1.63D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 4.01D-09 BMatP= 5.47D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.245D-04-0.309D-03-0.604D-03-0.200D-02-0.886D-02 0.101D+01
+ Coeff:      0.245D-04-0.309D-03-0.604D-03-0.200D-02-0.886D-02 0.101D+01
+ Gap=     0.282 Goal=   None    Shift=    0.000
+ RMSDP=2.54D-06 MaxDP=2.30D-05 DE=-5.46D-07 OVMax= 3.80D-05
+
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ Cycle   7  Pass 1  IDiag  1:
+ E= -76.3646431393427     Delta-E=       -0.000006502725 Rises=F Damp=F
+ DIIS: error= 3.24D-06 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -76.3646431393427     IErMin= 1 ErrMin= 3.24D-06
+ ErrMax= 3.24D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.02D-10 BMatP= 2.02D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.282 Goal=   None    Shift=    0.000
+ RMSDP=2.54D-06 MaxDP=2.30D-05 DE=-6.50D-06 OVMax= 1.65D-05
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -76.3646431397149     Delta-E=       -0.000000000372 Rises=F Damp=F
+ DIIS: error= 2.52D-06 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -76.3646431397149     IErMin= 2 ErrMin= 2.52D-06
+ ErrMax= 2.52D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 9.53D-11 BMatP= 2.02D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.341D+00 0.659D+00
+ Coeff:      0.341D+00 0.659D+00
+ Gap=     0.282 Goal=   None    Shift=    0.000
+ RMSDP=5.09D-07 MaxDP=4.39D-06 DE=-3.72D-10 OVMax= 6.26D-06
+
+ Cycle   9  Pass 1  IDiag  1:
+ E= -76.3646431397098     Delta-E=        0.000000000005 Rises=F Damp=F
+ DIIS: error= 2.28D-06 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 2 EnMin= -76.3646431397149     IErMin= 3 ErrMin= 2.28D-06
+ ErrMax= 2.28D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.06D-10 BMatP= 9.53D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.465D-01 0.530D+00 0.516D+00
+ Coeff:     -0.465D-01 0.530D+00 0.516D+00
+ Gap=     0.282 Goal=   None    Shift=    0.000
+ RMSDP=2.60D-07 MaxDP=2.43D-06 DE= 5.10D-12 OVMax= 3.33D-06
+
+ Cycle  10  Pass 1  IDiag  1:
+ E= -76.3646431397935     Delta-E=       -0.000000000084 Rises=F Damp=F
+ DIIS: error= 7.96D-08 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -76.3646431397935     IErMin= 4 ErrMin= 7.96D-08
+ ErrMax= 7.96D-08  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.13D-13 BMatP= 9.53D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.143D-01 0.114D+00 0.114D+00 0.787D+00
+ Coeff:     -0.143D-01 0.114D+00 0.114D+00 0.787D+00
+ Gap=     0.282 Goal=   None    Shift=    0.000
+ RMSDP=1.18D-08 MaxDP=7.47D-08 DE=-8.37D-11 OVMax= 1.48D-07
+
+ Cycle  11  Pass 1  IDiag  1:
+ E= -76.3646431397937     Delta-E=        0.000000000000 Rises=F Damp=F
+ DIIS: error= 1.04D-08 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -76.3646431397937     IErMin= 5 ErrMin= 1.04D-08
+ ErrMax= 1.04D-08  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.34D-15 BMatP= 1.13D-13
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.133D-02-0.160D-01-0.187D-01-0.999D-03 0.103D+01
+ Coeff:      0.133D-02-0.160D-01-0.187D-01-0.999D-03 0.103D+01
+ Gap=     0.282 Goal=   None    Shift=    0.000
+ RMSDP=3.49D-09 MaxDP=2.62D-08 DE=-1.56D-13 OVMax= 4.84D-08
+
+ SCF Done:  E(RB3LYP) =  -76.3646431398     A.U. after   11 cycles
+            NFock= 11  Conv=0.35D-08     -V/T= 2.0154
+ KE= 7.520504562451D+01 PE=-1.946950079533D+02 EE= 3.577318952653D+01
+ Leave Link  502 at Thu Nov 17 12:10:51 2016, MaxMem=    33554432 cpu:         0.8
+ (Enter /opt/g09-d01/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ Leave Link  701 at Thu Nov 17 12:10:51 2016, MaxMem=    33554432 cpu:         0.1
+ (Enter /opt/g09-d01/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Thu Nov 17 12:10:51 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=F KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         0 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2127 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Thu Nov 17 12:10:51 2016, MaxMem=    33554432 cpu:         0.3
+ (Enter /opt/g09-d01/g09/l716.exe)
+ Dipole        =-9.18556644D-06-9.54442001D-01 1.16692680D-16
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8           0.123159034   -0.037588877   -0.047869838
+      2        1          -0.066068673   -0.046278891    0.063490482
+      3        1          -0.057090361    0.083867768   -0.015620643
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.123159034 RMS     0.066622949
+ Leave Link  716 at Thu Nov 17 12:10:51 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.102645641 RMS     0.083825926
+ Search for a local minimum.
+ Step number   4 out of a maximum of   20
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .83826D-01 SwitMx=.10000D-02 MixMth= 1
+ Mixed Optimization -- RFO/linear search
+ Update second derivatives using D2CorX and points    3    4
+ DE= -1.31D-01 DEPred=-1.41D-01 R= 9.34D-01
+ TightC=F SS=  1.41D+00  RLast= 8.49D-01 DXNew= 1.4270D+00 2.5456D+00
+ Trust test= 9.34D-01 RLast= 8.49D-01 DXMaxT set to 1.43D+00
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.03177
+           R2          -0.02758   0.03177
+           A1           0.00324   0.00326   0.22363
+ ITU=  1  1  1  0
+ Use linear search instead of GDIIS.
+     Eigenvalues ---    0.00409   0.05935   0.22373
+ RFO step:  Lambda=-1.43159986D-01 EMin= 4.09032776D-03
+ Skip linear search -- no minimum in search direction.
+ Iteration  1 RMS(Cart)=  0.13080947 RMS(Int)=  0.40596088
+ Iteration  2 RMS(Cart)=  0.13896481 RMS(Int)=  0.24266094
+ Iteration  3 RMS(Cart)=  0.13817777 RMS(Int)=  0.07936161
+ Iteration  4 RMS(Cart)=  0.06719379 RMS(Int)=  0.00000091
+ Iteration  5 RMS(Cart)=  0.00000079 RMS(Int)=  0.00000000
+ ITry= 1 IFail=0 DXMaxC= 4.81D-01 DCOld= 1.00D+10 DXMaxT= 1.43D+00 DXLimC= 3.00D+00 Rises=F
+ ClnCor:  largest displacement from symmetrization is 7.02D-16 for atom     2.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.26674  -0.10265   0.00000  -0.69708  -0.69708   1.56966
+    R2        2.26670  -0.10264   0.00000  -0.69705  -0.69705   1.56965
+    A1        1.70103   0.00297   0.00000   0.02047   0.02047   1.72150
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.102646     0.000015     NO 
+ RMS     Force            0.083826     0.000010     NO 
+ Maximum Displacement     0.480983     0.000060     NO 
+ RMS     Displacement     0.474558     0.000040     NO 
+ Predicted change in Energy=-1.411716D-01
+ Lowest energy point so far.  Saving SCF results.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Thu Nov 17 12:10:51 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.226933   -0.069263   -0.088203
+      2          1           0        0.749411    0.319896   -0.603484
+      3          1           0        0.675287   -0.754745    0.049742
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.830628   0.000000
+     3  H    0.830624   1.259782   0.000000
+ Stoichiometry    H2O
+ Framework group  CS[SG(H2O)]
+ Deg. of freedom     3
+ Full point group                 CS      NOp   2
+ RotChk:  IX=0 Diff= 1.61D-05
+ Largest Abelian subgroup         CS      NOp   2
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.000000    0.108291    0.000000
+      2          1           0        0.629891   -0.433169    0.000000
+      3          1           0       -0.629891   -0.433163    0.000000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):    962.9834343    631.9332609    381.5504996
+ Leave Link  202 at Thu Nov 17 12:10:51 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l301.exe)
+ Standard basis: 6-31+G(d) (6D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are    18 symmetry adapted cartesian basis functions of A'  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A"  symmetry.
+ There are    18 symmetry adapted basis functions of A'  symmetry.
+ There are     5 symmetry adapted basis functions of A"  symmetry.
+    23 basis functions,    40 primitive gaussians,    23 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy        10.6133781391 Hartrees.
+ IExCor=  402 DFT=T Ex+Corr=B3LYP ExCW=0 ScaHFX=  0.200000
+ ScaDFX=  0.800000  0.720000  1.000000  0.810000 ScalE2=  1.000000  1.000000
+ IRadAn=      0 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=  4
+ NAtoms=    3 NActive=    3 NUniq=    3 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ Leave Link  301 at Thu Nov 17 12:10:51 2016, MaxMem=    33554432 cpu:         0.1
+ (Enter /opt/g09-d01/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+ NBasis=    23 RedAO= T EigKep=  1.60D-02  NBF=    18     5
+ NBsUse=    23 1.00D-06 EigRej= -1.00D+00 NBFU=    18     5
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           0 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=    23    23    23    23    23 MxSgAt=     3 MxSgA2=     3.
+ Leave Link  302 at Thu Nov 17 12:10:52 2016, MaxMem=    33554432 cpu:         0.2
+ (Enter /opt/g09-d01/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Thu Nov 17 12:10:52 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l401.exe)
+ Initial guess from the checkpoint file:  "h2o.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000   -0.000004 Ang=   0.00 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess orbital symmetries:
+       Occupied  (A') (A') (A') (A') (A")
+       Virtual   (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A") (A") (A") (A")
+ The electronic state of the initial guess is 1-A'.
+ Generating alternative initial guess.
+ ExpMin= 8.45D-02 ExpMax= 5.48D+03 ExpMxC= 8.25D+02 IAcc=2 IRadAn=         4 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       4 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         4 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Harris En= -76.4184023793543    
+ Leave Link  401 at Thu Nov 17 12:10:52 2016, MaxMem=    33554432 cpu:         0.3
+ (Enter /opt/g09-d01/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ Integral symmetry usage will be decided dynamically.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=919005.
+ IVT=       20464 IEndB=       20464 NGot=    33554432 MDV=    33511632
+ LenX=    33511632 LenY=    33510662
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=    276 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+
+ Cycle   1  Pass 0  IDiag  1:
+ E= -76.2950674257670    
+ DIIS: error= 5.16D-02 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -76.2950674257670     IErMin= 1 ErrMin= 5.16D-02
+ ErrMax= 5.16D-02  0.00D+00 EMaxC= 1.00D-01 BMatC= 6.83D-02 BMatP= 6.83D-02
+ IDIUse=3 WtCom= 4.84D-01 WtEn= 5.16D-01
+ Coeff-Com:  0.100D+01
+ Coeff-En:   0.100D+01
+ Coeff:      0.100D+01
+ Recover alternate guess density for next cycle.
+ RMSDP=1.84D-02 MaxDP=1.43D-01              OVMax= 0.00D+00
+
+ Cycle   2  Pass 0  IDiag  1:
+ E= -76.2720931906524     Delta-E=        0.022974235115 Rises=F Damp=F
+ Switch densities from cycles 1 and 2 for lowest energy.
+ DIIS: error= 7.70D-02 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 1 EnMin= -76.2950674257670     IErMin= 1 ErrMin= 5.16D-02
+ ErrMax= 7.70D-02  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.36D-01 BMatP= 6.83D-02
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.613D+00 0.387D+00
+ Coeff:      0.613D+00 0.387D+00
+ Gap=     0.678 Goal=   None    Shift=    0.000
+ RMSDP=1.19D-02 MaxDP=6.04D-02 DE= 2.30D-02 OVMax= 1.23D-01
+
+ Cycle   3  Pass 0  IDiag  1:
+ E= -76.3661987002954     Delta-E=       -0.094105509643 Rises=F Damp=F
+ DIIS: error= 1.52D-02 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -76.3661987002954     IErMin= 3 ErrMin= 1.52D-02
+ ErrMax= 1.52D-02  0.00D+00 EMaxC= 1.00D+00 BMatC= 5.43D-03 BMatP= 6.83D-02
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.604D-01 0.165D+00 0.775D+00
+ Coeff:      0.604D-01 0.165D+00 0.775D+00
+ Gap=     0.367 Goal=   None    Shift=    0.000
+ RMSDP=1.76D-03 MaxDP=1.61D-02 DE=-9.41D-02 OVMax= 1.81D-02
+
+ Cycle   4  Pass 0  IDiag  1:
+ E= -76.3698923538567     Delta-E=       -0.003693653561 Rises=F Damp=F
+ DIIS: error= 1.25D-03 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -76.3698923538567     IErMin= 4 ErrMin= 1.25D-03
+ ErrMax= 1.25D-03  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.59D-05 BMatP= 5.43D-03
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.469D-02 0.206D-01 0.107D+00 0.877D+00
+ Coeff:     -0.469D-02 0.206D-01 0.107D+00 0.877D+00
+ Gap=     0.367 Goal=   None    Shift=    0.000
+ RMSDP=1.72D-04 MaxDP=7.80D-04 DE=-3.69D-03 OVMax= 1.41D-03
+
+ Cycle   5  Pass 0  IDiag  1:
+ E= -76.3699128365085     Delta-E=       -0.000020482652 Rises=F Damp=F
+ DIIS: error= 1.26D-04 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -76.3699128365085     IErMin= 5 ErrMin= 1.26D-04
+ ErrMax= 1.26D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.64D-07 BMatP= 2.59D-05
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.461D-04 0.413D-03-0.602D-02 0.837D-02 0.997D+00
+ Coeff:     -0.461D-04 0.413D-03-0.602D-02 0.837D-02 0.997D+00
+ Gap=     0.367 Goal=   None    Shift=    0.000
+ RMSDP=1.88D-05 MaxDP=1.89D-04 DE=-2.05D-05 OVMax= 2.46D-04
+
+ Cycle   6  Pass 0  IDiag  1:
+ E= -76.3699131213246     Delta-E=       -0.000000284816 Rises=F Damp=F
+ DIIS: error= 4.02D-06 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -76.3699131213246     IErMin= 6 ErrMin= 4.02D-06
+ ErrMax= 4.02D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.19D-10 BMatP= 3.64D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.704D-05-0.785D-04 0.159D-03-0.425D-02-0.758D-01 0.108D+01
+ Coeff:      0.704D-05-0.785D-04 0.159D-03-0.425D-02-0.758D-01 0.108D+01
+ Gap=     0.367 Goal=   None    Shift=    0.000
+ RMSDP=1.28D-06 MaxDP=1.04D-05 DE=-2.85D-07 OVMax= 1.71D-05
+
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ Cycle   7  Pass 1  IDiag  1:
+ E= -76.3698975228838     Delta-E=        0.000015598441 Rises=F Damp=F
+ DIIS: error= 3.64D-06 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -76.3698975228838     IErMin= 1 ErrMin= 3.64D-06
+ ErrMax= 3.64D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.98D-10 BMatP= 2.98D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.367 Goal=   None    Shift=    0.000
+ RMSDP=1.28D-06 MaxDP=1.04D-05 DE= 1.56D-05 OVMax= 1.02D-05
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -76.3698975232454     Delta-E=       -0.000000000362 Rises=F Damp=F
+ DIIS: error= 6.76D-07 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -76.3698975232454     IErMin= 2 ErrMin= 6.76D-07
+ ErrMax= 6.76D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.12D-11 BMatP= 2.98D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.115D-01 0.101D+01
+ Coeff:     -0.115D-01 0.101D+01
+ Gap=     0.367 Goal=   None    Shift=    0.000
+ RMSDP=2.09D-07 MaxDP=2.29D-06 DE=-3.62D-10 OVMax= 2.60D-06
+
+ Cycle   9  Pass 1  IDiag  1:
+ E= -76.3698975232415     Delta-E=        0.000000000004 Rises=F Damp=F
+ DIIS: error= 9.76D-07 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 2 EnMin= -76.3698975232454     IErMin= 2 ErrMin= 6.76D-07
+ ErrMax= 9.76D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.01D-11 BMatP= 1.12D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.308D-01 0.600D+00 0.431D+00
+ Coeff:     -0.308D-01 0.600D+00 0.431D+00
+ Gap=     0.367 Goal=   None    Shift=    0.000
+ RMSDP=1.04D-07 MaxDP=1.06D-06 DE= 3.87D-12 OVMax= 1.18D-06
+
+ Cycle  10  Pass 1  IDiag  1:
+ E= -76.3698975232552     Delta-E=       -0.000000000014 Rises=F Damp=F
+ DIIS: error= 1.61D-08 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -76.3698975232552     IErMin= 4 ErrMin= 1.61D-08
+ ErrMax= 1.61D-08  0.00D+00 EMaxC= 1.00D+00 BMatC= 4.36D-15 BMatP= 1.12D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.634D-03-0.195D-01-0.187D-01 0.104D+01
+ Coeff:     -0.634D-03-0.195D-01-0.187D-01 0.104D+01
+ Gap=     0.367 Goal=   None    Shift=    0.000
+ RMSDP=4.56D-09 MaxDP=3.50D-08 DE=-1.37D-11 OVMax= 5.43D-08
+
+ SCF Done:  E(RB3LYP) =  -76.3698975233     A.U. after   10 cycles
+            NFock= 10  Conv=0.46D-08     -V/T= 1.9998
+ KE= 7.638360933111D+01 PE=-2.016932544413D+02 EE= 3.832636944789D+01
+ Leave Link  502 at Thu Nov 17 12:10:53 2016, MaxMem=    33554432 cpu:         0.7
+ (Enter /opt/g09-d01/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ Leave Link  701 at Thu Nov 17 12:10:53 2016, MaxMem=    33554432 cpu:         0.1
+ (Enter /opt/g09-d01/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Thu Nov 17 12:10:53 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=F KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         0 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2127 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Thu Nov 17 12:10:53 2016, MaxMem=    33554432 cpu:         0.3
+ (Enter /opt/g09-d01/g09/l716.exe)
+ Dipole        =-1.26280078D-06-8.84714896D-01-6.02496677D-17
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8          -0.231755329    0.070744974    0.090072639
+      2        1           0.127019353    0.126206171   -0.143250933
+      3        1           0.104735976   -0.196951145    0.053178295
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.231755329 RMS     0.138242346
+ Leave Link  716 at Thu Nov 17 12:10:53 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.227902169 RMS     0.187501612
+ Search for a local minimum.
+ Step number   5 out of a maximum of   20
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .18750D+00 SwitMx=.10000D-02 MixMth= 1
+ Mixed Optimization -- RFO/linear search
+ Update second derivatives using D2CorX and points    4    5
+ DE= -5.25D-03 DEPred=-1.41D-01 R= 3.72D-02
+ Trust test= 3.72D-02 RLast= 9.86D-01 DXMaxT set to 7.14D-01
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.26720
+           R2           0.20786   0.26721
+           A1           0.02984   0.02986   0.22661
+ ITU= -1  1  1  1
+ Use linear search instead of GDIIS.
+     Eigenvalues ---    0.05935   0.21963   0.48204
+ RFO step:  Lambda=-3.57256032D-03 EMin= 5.93500183D-02
+ Quartic linear search produced a step of -0.38857.
+ Iteration  1 RMS(Cart)=  0.17529932 RMS(Int)=  0.05079794
+ Iteration  2 RMS(Cart)=  0.04754733 RMS(Int)=  0.00026124
+ Iteration  3 RMS(Cart)=  0.00024366 RMS(Int)=  0.00000004
+ Iteration  4 RMS(Cart)=  0.00000004 RMS(Int)=  0.00000000
+ ITry= 1 IFail=0 DXMaxC= 2.37D-01 DCOld= 1.00D+10 DXMaxT= 7.14D-01 DXLimC= 3.00D+00 Rises=F
+ ClnCor:  largest displacement from symmetrization is 3.30D-15 for atom     2.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.56966   0.22789   0.27086  -0.00704   0.26382   1.83348
+    R2        1.56965   0.22790   0.27085  -0.00688   0.26397   1.83362
+    A1        1.72150   0.03995  -0.00795   0.12559   0.11764   1.83914
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.227902     0.000015     NO 
+ RMS     Force            0.187502     0.000010     NO 
+ Maximum Displacement     0.236670     0.000060     NO 
+ RMS     Displacement     0.222720     0.000040     NO 
+ Predicted change in Energy=-8.847688D-02
+ Lowest energy point so far.  Saving SCF results.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Thu Nov 17 12:10:53 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.199032   -0.060723   -0.077373
+      2          1           0        0.771695    0.436596   -0.682426
+      3          1           0        0.680903   -0.879985    0.117854
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.970236   0.000000
+     3  H    0.970311   1.543398   0.000000
+ Stoichiometry    H2O
+ Framework group  CS[SG(H2O)]
+ Deg. of freedom     3
+ Full point group                 CS      NOp   2
+ RotChk:  IX=0 Diff= 9.98D-05
+ Largest Abelian subgroup         CS      NOp   2
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.000000    0.117629    0.000000
+      2          1           0        0.771699   -0.470453    0.000000
+      3          1           0       -0.771699   -0.470576    0.000000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):    816.1724708    421.0236074    277.7473062
+ Leave Link  202 at Thu Nov 17 12:10:53 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l301.exe)
+ Standard basis: 6-31+G(d) (6D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are    18 symmetry adapted cartesian basis functions of A'  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A"  symmetry.
+ There are    18 symmetry adapted basis functions of A'  symmetry.
+ There are     5 symmetry adapted basis functions of A"  symmetry.
+    23 basis functions,    40 primitive gaussians,    23 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.0690998775 Hartrees.
+ IExCor=  402 DFT=T Ex+Corr=B3LYP ExCW=0 ScaHFX=  0.200000
+ ScaDFX=  0.800000  0.720000  1.000000  0.810000 ScalE2=  1.000000  1.000000
+ IRadAn=      0 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=  4
+ NAtoms=    3 NActive=    3 NUniq=    3 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ Leave Link  301 at Thu Nov 17 12:10:54 2016, MaxMem=    33554432 cpu:         0.1
+ (Enter /opt/g09-d01/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+ NBasis=    23 RedAO= T EigKep=  2.58D-02  NBF=    18     5
+ NBsUse=    23 1.00D-06 EigRej= -1.00D+00 NBFU=    18     5
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           0 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=    23    23    23    23    23 MxSgAt=     3 MxSgA2=     3.
+ Leave Link  302 at Thu Nov 17 12:10:54 2016, MaxMem=    33554432 cpu:         0.2
+ (Enter /opt/g09-d01/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Thu Nov 17 12:10:54 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l401.exe)
+ Initial guess from the checkpoint file:  "h2o.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000   -0.000028 Ang=   0.00 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess orbital symmetries:
+       Occupied  (A') (A') (A') (A') (A")
+       Virtual   (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A") (A") (A") (A")
+ The electronic state of the initial guess is 1-A'.
+ Generating alternative initial guess.
+ ExpMin= 8.45D-02 ExpMax= 5.48D+03 ExpMxC= 8.25D+02 IAcc=2 IRadAn=         4 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       4 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         4 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Harris En= -76.4522031393319    
+ Leave Link  401 at Thu Nov 17 12:10:54 2016, MaxMem=    33554432 cpu:         0.3
+ (Enter /opt/g09-d01/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ Integral symmetry usage will be decided dynamically.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=919005.
+ IVT=       20464 IEndB=       20464 NGot=    33554432 MDV=    33511632
+ LenX=    33511632 LenY=    33510662
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=    276 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+
+ Cycle   1  Pass 0  IDiag  1:
+ E= -76.4086877629378    
+ DIIS: error= 2.70D-02 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -76.4086877629378     IErMin= 1 ErrMin= 2.70D-02
+ ErrMax= 2.70D-02  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.44D-02 BMatP= 1.44D-02
+ IDIUse=3 WtCom= 7.30D-01 WtEn= 2.70D-01
+ Coeff-Com:  0.100D+01
+ Coeff-En:   0.100D+01
+ Coeff:      0.100D+01
+ Recover alternate guess density for next cycle.
+ RMSDP=8.00D-03 MaxDP=6.29D-02              OVMax= 0.00D+00
+
+ Cycle   2  Pass 0  IDiag  1:
+ E= -76.3492810286539     Delta-E=        0.059406734284 Rises=F Damp=F
+ Switch densities from cycles 1 and 2 for lowest energy.
+ DIIS: error= 6.93D-02 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 1 EnMin= -76.4086877629378     IErMin= 1 ErrMin= 2.70D-02
+ ErrMax= 6.93D-02  0.00D+00 EMaxC= 1.00D+00 BMatC= 9.57D-02 BMatP= 1.44D-02
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.107D+01-0.714D-01
+ Coeff:      0.107D+01-0.714D-01
+ Gap=     0.642 Goal=   None    Shift=    0.000
+ RMSDP=5.95D-03 MaxDP=4.38D-02 DE= 5.94D-02 OVMax= 6.39D-02
+
+ Cycle   3  Pass 0  IDiag  1:
+ E= -76.4164203952662     Delta-E=       -0.067139366612 Rises=F Damp=F
+ DIIS: error= 2.10D-02 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -76.4164203952662     IErMin= 3 ErrMin= 2.10D-02
+ ErrMax= 2.10D-02  0.00D+00 EMaxC= 1.00D+00 BMatC= 8.48D-03 BMatP= 1.44D-02
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.138D+00 0.168D+00 0.694D+00
+ Coeff:      0.138D+00 0.168D+00 0.694D+00
+ Gap=     0.343 Goal=   None    Shift=    0.000
+ RMSDP=2.18D-03 MaxDP=2.21D-02 DE=-6.71D-02 OVMax= 2.61D-02
+
+ Cycle   4  Pass 0  IDiag  1:
+ E= -76.4225520319030     Delta-E=       -0.006131636637 Rises=F Damp=F
+ DIIS: error= 1.33D-03 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -76.4225520319030     IErMin= 4 ErrMin= 1.33D-03
+ ErrMax= 1.33D-03  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.44D-05 BMatP= 8.48D-03
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.177D-01 0.293D-01 0.823D-01 0.906D+00
+ Coeff:     -0.177D-01 0.293D-01 0.823D-01 0.906D+00
+ Gap=     0.344 Goal=   None    Shift=    0.000
+ RMSDP=1.45D-04 MaxDP=6.76D-04 DE=-6.13D-03 OVMax= 1.40D-03
+
+ Cycle   5  Pass 0  IDiag  1:
+ E= -76.4225720834035     Delta-E=       -0.000020051500 Rises=F Damp=F
+ DIIS: error= 7.05D-05 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -76.4225720834035     IErMin= 5 ErrMin= 7.05D-05
+ ErrMax= 7.05D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.13D-07 BMatP= 2.44D-05
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.557D-04-0.599D-03-0.473D-02 0.180D-01 0.987D+00
+ Coeff:     -0.557D-04-0.599D-03-0.473D-02 0.180D-01 0.987D+00
+ Gap=     0.344 Goal=   None    Shift=    0.000
+ RMSDP=1.14D-05 MaxDP=9.99D-05 DE=-2.01D-05 OVMax= 1.17D-04
+
+ Cycle   6  Pass 0  IDiag  1:
+ E= -76.4225721766522     Delta-E=       -0.000000093249 Rises=F Damp=F
+ DIIS: error= 1.14D-05 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -76.4225721766522     IErMin= 6 ErrMin= 1.14D-05
+ ErrMax= 1.14D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.77D-09 BMatP= 1.13D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.390D-04-0.494D-05-0.352D-03-0.455D-02-0.287D-01 0.103D+01
+ Coeff:      0.390D-04-0.494D-05-0.352D-03-0.455D-02-0.287D-01 0.103D+01
+ Gap=     0.344 Goal=   None    Shift=    0.000
+ RMSDP=1.70D-06 MaxDP=1.57D-05 DE=-9.32D-08 OVMax= 2.15D-05
+
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ Cycle   7  Pass 1  IDiag  1:
+ E= -76.4225690221549     Delta-E=        0.000003154497 Rises=F Damp=F
+ DIIS: error= 2.94D-06 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -76.4225690221549     IErMin= 1 ErrMin= 2.94D-06
+ ErrMax= 2.94D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 9.03D-11 BMatP= 9.03D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.344 Goal=   None    Shift=    0.000
+ RMSDP=1.70D-06 MaxDP=1.57D-05 DE= 3.15D-06 OVMax= 1.33D-05
+
+ Cycle   8  Pass 1  IDiag  1:
+ E= -76.4225690223858     Delta-E=       -0.000000000231 Rises=F Damp=F
+ DIIS: error= 8.87D-07 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -76.4225690223858     IErMin= 2 ErrMin= 8.87D-07
+ ErrMax= 8.87D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.53D-11 BMatP= 9.03D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.132D+00 0.868D+00
+ Coeff:      0.132D+00 0.868D+00
+ Gap=     0.344 Goal=   None    Shift=    0.000
+ RMSDP=2.33D-07 MaxDP=2.11D-06 DE=-2.31D-10 OVMax= 2.68D-06
+
+ Cycle   9  Pass 1  IDiag  1:
+ E= -76.4225690223832     Delta-E=        0.000000000003 Rises=F Damp=F
+ DIIS: error= 1.07D-06 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 2 EnMin= -76.4225690223858     IErMin= 2 ErrMin= 8.87D-07
+ ErrMax= 1.07D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.17D-11 BMatP= 1.53D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.268D-01 0.559D+00 0.468D+00
+ Coeff:     -0.268D-01 0.559D+00 0.468D+00
+ Gap=     0.344 Goal=   None    Shift=    0.000
+ RMSDP=1.13D-07 MaxDP=1.17D-06 DE= 2.59D-12 OVMax= 1.41D-06
+
+ Cycle  10  Pass 1  IDiag  1:
+ E= -76.4225690223991     Delta-E=       -0.000000000016 Rises=F Damp=F
+ DIIS: error= 4.36D-08 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -76.4225690223991     IErMin= 4 ErrMin= 4.36D-08
+ ErrMax= 4.36D-08  0.00D+00 EMaxC= 1.00D+00 BMatC= 4.62D-14 BMatP= 1.53D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.116D-01 0.774D-01 0.841D-01 0.850D+00
+ Coeff:     -0.116D-01 0.774D-01 0.841D-01 0.850D+00
+ Gap=     0.344 Goal=   None    Shift=    0.000
+ RMSDP=7.09D-09 MaxDP=5.65D-08 DE=-1.58D-11 OVMax= 7.20D-08
+
+ SCF Done:  E(RB3LYP) =  -76.4225690224     A.U. after   10 cycles
+            NFock= 10  Conv=0.71D-08     -V/T= 2.0093
+ KE= 7.571963457347D+01 PE=-1.984040532410D+02 EE= 3.719274976772D+01
+ Leave Link  502 at Thu Nov 17 12:10:55 2016, MaxMem=    33554432 cpu:         0.7
+ (Enter /opt/g09-d01/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ Leave Link  701 at Thu Nov 17 12:10:55 2016, MaxMem=    33554432 cpu:         0.2
+ (Enter /opt/g09-d01/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Thu Nov 17 12:10:55 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=F KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         0 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2127 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Thu Nov 17 12:10:56 2016, MaxMem=    33554432 cpu:         0.3
+ (Enter /opt/g09-d01/g09/l716.exe)
+ Dipole        = 2.43203945D-05-8.86037705D-01-1.13432382D-16
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8           0.001487457   -0.000504914   -0.000549165
+      2        1          -0.000777833   -0.000537182    0.000743118
+      3        1          -0.000709624    0.001042096   -0.000193953
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.001487457 RMS     0.000805675
+ Leave Link  716 at Thu Nov 17 12:10:56 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.001271304 RMS     0.001014535
+ Search for a local minimum.
+ Step number   6 out of a maximum of   20
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .10145D-02 SwitMx=.10000D-02 MixMth= 1
+ Mixed Optimization -- RFO/linear search
+ Update second derivatives using D2CorX and points    5    6
+ DE= -5.27D-02 DEPred=-8.85D-02 R= 5.95D-01
+ TightC=F SS=  1.41D+00  RLast= 3.91D-01 DXNew= 1.2000D+00 1.1739D+00
+ Trust test= 5.95D-01 RLast= 3.91D-01 DXMaxT set to 1.17D+00
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.45754
+           R2           0.39832   0.45781
+           A1           0.02750   0.02754   0.21455
+ ITU=  1 -1  1  1
+ Use linear search instead of GDIIS.
+     Eigenvalues ---    0.05935   0.21220   0.85835
+ RFO step:  Lambda=-2.20773782D-07 EMin= 5.93500209D-02
+ Quartic linear search produced a step of -0.00858.
+ Iteration  1 RMS(Cart)=  0.00172531 RMS(Int)=  0.00000014
+ Iteration  2 RMS(Cart)=  0.00000013 RMS(Int)=  0.00000000
+ ITry= 1 IFail=0 DXMaxC= 1.99D-03 DCOld= 1.00D+10 DXMaxT= 1.17D+00 DXLimC= 3.00D+00 Rises=F
+ ClnCor:  largest displacement from symmetrization is 1.68D-15 for atom     2.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.83348  -0.00120  -0.00226   0.00054  -0.00172   1.83176
+    R2        1.83362  -0.00127  -0.00226  -0.00069  -0.00296   1.83066
+    A1        1.83914   0.00019  -0.00101   0.00090  -0.00011   1.83903
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.001271     0.000015     NO 
+ RMS     Force            0.001015     0.000010     NO 
+ Maximum Displacement     0.001993     0.000060     NO 
+ RMS     Displacement     0.001725     0.000040     NO 
+ Predicted change in Energy=-1.074625D-06
+ Lowest energy point so far.  Saving SCF results.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Thu Nov 17 12:10:56 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.199442   -0.061048   -0.077418
+      2          1           0        0.771509    0.435866   -0.681906
+      3          1           0        0.680679   -0.878930    0.117379
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.969324   0.000000
+     3  H    0.968746   1.541362   0.000000
+ Stoichiometry    H2O
+ Framework group  CS[SG(H2O)]
+ Deg. of freedom     3
+ Full point group                 CS      NOp   2
+ RotChk:  IX=0 Diff= 8.28D-04
+ Largest Abelian subgroup         CS      NOp   2
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.000000    0.117487    0.000000
+      2          1           0        0.770681   -0.470425    0.000000
+      3          1           0       -0.770681   -0.469471    0.000000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):    818.1421005    422.1362625    278.4596255
+ Leave Link  202 at Thu Nov 17 12:10:56 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l301.exe)
+ Standard basis: 6-31+G(d) (6D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are    18 symmetry adapted cartesian basis functions of A'  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A"  symmetry.
+ There are    18 symmetry adapted basis functions of A'  symmetry.
+ There are     5 symmetry adapted basis functions of A"  symmetry.
+    23 basis functions,    40 primitive gaussians,    23 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.0807091994 Hartrees.
+ IExCor=  402 DFT=T Ex+Corr=B3LYP ExCW=0 ScaHFX=  0.200000
+ ScaDFX=  0.800000  0.720000  1.000000  0.810000 ScalE2=  1.000000  1.000000
+ IRadAn=      0 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=  4
+ NAtoms=    3 NActive=    3 NUniq=    3 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ Leave Link  301 at Thu Nov 17 12:10:56 2016, MaxMem=    33554432 cpu:         0.1
+ (Enter /opt/g09-d01/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+ NBasis=    23 RedAO= T EigKep=  2.57D-02  NBF=    18     5
+ NBsUse=    23 1.00D-06 EigRej= -1.00D+00 NBFU=    18     5
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           0 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=    23    23    23    23    23 MxSgAt=     3 MxSgA2=     3.
+ Leave Link  302 at Thu Nov 17 12:10:56 2016, MaxMem=    33554432 cpu:         0.2
+ (Enter /opt/g09-d01/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Thu Nov 17 12:10:56 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l401.exe)
+ Initial guess from the checkpoint file:  "h2o.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000239 Ang=   0.03 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess orbital symmetries:
+       Occupied  (A') (A') (A') (A') (A")
+       Virtual   (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A") (A") (A") (A")
+ The electronic state of the initial guess is 1-A'.
+ Leave Link  401 at Thu Nov 17 12:10:56 2016, MaxMem=    33554432 cpu:         0.1
+ (Enter /opt/g09-d01/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ Integral symmetry usage will be decided dynamically.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=919005.
+ IVT=       20464 IEndB=       20464 NGot=    33554432 MDV=    33511632
+ LenX=    33511632 LenY=    33510662
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=    276 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+
+ Cycle   1  Pass 1  IDiag  1:
+ E= -76.4225708692243    
+ DIIS: error= 1.94D-04 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -76.4225708692243     IErMin= 1 ErrMin= 1.94D-04
+ ErrMax= 1.94D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 8.75D-07 BMatP= 8.75D-07
+ IDIUse=3 WtCom= 9.98D-01 WtEn= 1.94D-03
+ Coeff-Com:  0.100D+01
+ Coeff-En:   0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.663 Goal=   None    Shift=    0.000
+ RMSDP=5.73D-05 MaxDP=3.94D-04              OVMax= 5.91D-04
+
+ Cycle   2  Pass 1  IDiag  1:
+ E= -76.4225711845880     Delta-E=       -0.000000315364 Rises=F Damp=F
+ DIIS: error= 2.11D-04 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -76.4225711845880     IErMin= 1 ErrMin= 1.94D-04
+ ErrMax= 2.11D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 8.96D-07 BMatP= 8.75D-07
+ IDIUse=3 WtCom= 9.98D-01 WtEn= 2.11D-03
+ Coeff-Com:  0.504D+00 0.496D+00
+ Coeff-En:   0.349D+00 0.651D+00
+ Coeff:      0.503D+00 0.497D+00
+ Gap=     0.344 Goal=   None    Shift=    0.000
+ RMSDP=2.84D-05 MaxDP=2.75D-04 DE=-3.15D-07 OVMax= 3.11D-04
+
+ Cycle   3  Pass 1  IDiag  1:
+ E= -76.4225717728778     Delta-E=       -0.000000588290 Rises=F Damp=F
+ DIIS: error= 6.28D-05 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -76.4225717728778     IErMin= 3 ErrMin= 6.28D-05
+ ErrMax= 6.28D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 8.03D-08 BMatP= 8.75D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.258D-01 0.230D+00 0.744D+00
+ Coeff:      0.258D-01 0.230D+00 0.744D+00
+ Gap=     0.344 Goal=   None    Shift=    0.000
+ RMSDP=7.27D-06 MaxDP=6.95D-05 DE=-5.88D-07 OVMax= 8.34D-05
+
+ Cycle   4  Pass 1  IDiag  1:
+ E= -76.4225718306873     Delta-E=       -0.000000057810 Rises=F Damp=F
+ DIIS: error= 5.50D-06 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -76.4225718306873     IErMin= 4 ErrMin= 5.50D-06
+ ErrMax= 5.50D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 5.62D-10 BMatP= 8.03D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.809D-02 0.337D-01 0.161D+00 0.814D+00
+ Coeff:     -0.809D-02 0.337D-01 0.161D+00 0.814D+00
+ Gap=     0.344 Goal=   None    Shift=    0.000
+ RMSDP=7.21D-07 MaxDP=3.22D-06 DE=-5.78D-08 OVMax= 6.99D-06
+
+ Cycle   5  Pass 1  IDiag  1:
+ E= -76.4225718311343     Delta-E=       -0.000000000447 Rises=F Damp=F
+ DIIS: error= 3.43D-07 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -76.4225718311343     IErMin= 5 ErrMin= 3.43D-07
+ ErrMax= 3.43D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.32D-12 BMatP= 5.62D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.188D-03-0.907D-03-0.635D-02 0.954D-02 0.998D+00
+ Coeff:     -0.188D-03-0.907D-03-0.635D-02 0.954D-02 0.998D+00
+ Gap=     0.344 Goal=   None    Shift=    0.000
+ RMSDP=8.68D-08 MaxDP=6.64D-07 DE=-4.47D-10 OVMax= 1.14D-06
+
+ Cycle   6  Pass 1  IDiag  1:
+ E= -76.4225718311371     Delta-E=       -0.000000000003 Rises=F Damp=F
+ DIIS: error= 7.75D-08 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -76.4225718311371     IErMin= 6 ErrMin= 7.75D-08
+ ErrMax= 7.75D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.18D-13 BMatP= 2.32D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.528D-04-0.741D-03-0.374D-02-0.961D-02 0.256D+00 0.759D+00
+ Coeff:      0.528D-04-0.741D-03-0.374D-02-0.961D-02 0.256D+00 0.759D+00
+ Gap=     0.344 Goal=   None    Shift=    0.000
+ RMSDP=1.58D-08 MaxDP=7.83D-08 DE=-2.79D-12 OVMax= 1.44D-07
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -76.4225718311372     Delta-E=        0.000000000000 Rises=F Damp=F
+ DIIS: error= 1.10D-08 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -76.4225718311372     IErMin= 7 ErrMin= 1.10D-08
+ ErrMax= 1.10D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.27D-15 BMatP= 1.18D-13
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.101D-04-0.431D-04-0.785D-05-0.133D-02-0.148D-01 0.403D-01
+ Coeff-Com:  0.976D+00
+ Coeff:      0.101D-04-0.431D-04-0.785D-05-0.133D-02-0.148D-01 0.403D-01
+ Coeff:      0.976D+00
+ Gap=     0.344 Goal=   None    Shift=    0.000
+ RMSDP=1.99D-09 MaxDP=1.49D-08 DE=-8.53D-14 OVMax= 2.17D-08
+
+ SCF Done:  E(RB3LYP) =  -76.4225718311     A.U. after    7 cycles
+            NFock=  7  Conv=0.20D-08     -V/T= 2.0092
+ KE= 7.572399712167D+01 PE=-1.984289819306D+02 EE= 3.720170377843D+01
+ Leave Link  502 at Thu Nov 17 12:10:57 2016, MaxMem=    33554432 cpu:         0.7
+ (Enter /opt/g09-d01/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ Leave Link  701 at Thu Nov 17 12:10:57 2016, MaxMem=    33554432 cpu:         0.2
+ (Enter /opt/g09-d01/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Thu Nov 17 12:10:57 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=F KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         0 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2127 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Thu Nov 17 12:10:58 2016, MaxMem=    33554432 cpu:         0.3
+ (Enter /opt/g09-d01/g09/l716.exe)
+ Dipole        =-1.88640130D-04-8.85820578D-01 2.10110289D-16
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8           0.000338452    0.000295161   -0.000358300
+      2        1          -0.000320798   -0.000031803    0.000198504
+      3        1          -0.000017654   -0.000263358    0.000159796
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.000358300 RMS     0.000251347
+ Leave Link  716 at Thu Nov 17 12:10:58 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.000341708 RMS     0.000308567
+ Search for a local minimum.
+ Step number   7 out of a maximum of   20
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .30857D-03 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Update second derivatives using D2CorX and points    5    6    7
+ DE= -2.81D-06 DEPred=-1.07D-06 R= 2.61D+00
+ TightC=F SS=  1.41D+00  RLast= 3.43D-03 DXNew= 1.9743D+00 1.0277D-02
+ Trust test= 2.61D+00 RLast= 3.43D-03 DXMaxT set to 1.17D+00
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.17294
+           R2           0.19214   0.39963
+           A1           0.01748   0.03244   0.21581
+ ITU=  1  1 -1  1
+ Use linear search instead of GDIIS.
+     Eigenvalues ---    0.06320   0.21126   0.51392
+ RFO step:  Lambda=-3.14886719D-06 EMin= 6.31974740D-02
+ Quartic linear search produced a step of -0.03264.
+ Iteration  1 RMS(Cart)=  0.00253710 RMS(Int)=  0.00000279
+ Iteration  2 RMS(Cart)=  0.00000206 RMS(Int)=  0.00000000
+ Iteration  3 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ITry= 1 IFail=0 DXMaxC= 2.28D-03 DCOld= 1.00D+10 DXMaxT= 1.17D+00 DXLimC= 3.00D+00 Rises=F
+ ClnCor:  largest displacement from symmetrization is 1.64D-15 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.83176  -0.00033   0.00006  -0.00565  -0.00559   1.82617
+    R2        1.83066   0.00025   0.00010   0.00308   0.00318   1.83384
+    A1        1.83903   0.00034   0.00000   0.00156   0.00156   1.84059
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000342     0.000015     NO 
+ RMS     Force            0.000309     0.000010     NO 
+ Maximum Displacement     0.002284     0.000060     NO 
+ RMS     Displacement     0.002537     0.000040     NO 
+ Predicted change in Energy=-1.577624D-06
+ Lowest energy point so far.  Saving SCF results.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Thu Nov 17 12:10:58 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.200129   -0.059839   -0.078493
+      2          1           0        0.770606    0.435389   -0.681126
+      3          1           0        0.680895   -0.879662    0.117674
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.966365   0.000000
+     3  H    0.970426   1.541262   0.000000
+ Stoichiometry    H2O
+ Framework group  CS[SG(H2O)]
+ Deg. of freedom     3
+ Full point group                 CS      NOp   2
+ RotChk:  IX=0 Diff= 5.89D-03
+ Largest Abelian subgroup         CS      NOp   2
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.000000    0.117290    0.000000
+      2          1           0        0.770624   -0.465806    0.000000
+      3          1           0       -0.770624   -0.472512    0.000000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):    820.9261913    422.1827970    278.8017132
+ Leave Link  202 at Thu Nov 17 12:10:58 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l301.exe)
+ Standard basis: 6-31+G(d) (6D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are    18 symmetry adapted cartesian basis functions of A'  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A"  symmetry.
+ There are    18 symmetry adapted basis functions of A'  symmetry.
+ There are     5 symmetry adapted basis functions of A"  symmetry.
+    23 basis functions,    40 primitive gaussians,    23 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.0865360638 Hartrees.
+ IExCor=  402 DFT=T Ex+Corr=B3LYP ExCW=0 ScaHFX=  0.200000
+ ScaDFX=  0.800000  0.720000  1.000000  0.810000 ScalE2=  1.000000  1.000000
+ IRadAn=      0 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=  4
+ NAtoms=    3 NActive=    3 NUniq=    3 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ Leave Link  301 at Thu Nov 17 12:10:58 2016, MaxMem=    33554432 cpu:         0.1
+ (Enter /opt/g09-d01/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+ NBasis=    23 RedAO= T EigKep=  2.56D-02  NBF=    18     5
+ NBsUse=    23 1.00D-06 EigRej= -1.00D+00 NBFU=    18     5
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           0 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=    23    23    23    23    23 MxSgAt=     3 MxSgA2=     3.
+ Leave Link  302 at Thu Nov 17 12:10:58 2016, MaxMem=    33554432 cpu:         0.2
+ (Enter /opt/g09-d01/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Thu Nov 17 12:10:58 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l401.exe)
+ Initial guess from the checkpoint file:  "h2o.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    0.999999    0.000000    0.000000   -0.001698 Ang=  -0.19 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess orbital symmetries:
+       Occupied  (A') (A') (A') (A') (A")
+       Virtual   (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A") (A") (A") (A")
+ The electronic state of the initial guess is 1-A'.
+ Leave Link  401 at Thu Nov 17 12:10:58 2016, MaxMem=    33554432 cpu:         0.1
+ (Enter /opt/g09-d01/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ Integral symmetry usage will be decided dynamically.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=919005.
+ IVT=       20464 IEndB=       20464 NGot=    33554432 MDV=    33511632
+ LenX=    33511632 LenY=    33510662
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=    276 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+
+ Cycle   1  Pass 1  IDiag  1:
+ E= -76.4225606410797    
+ DIIS: error= 2.82D-04 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -76.4225606410797     IErMin= 1 ErrMin= 2.82D-04
+ ErrMax= 2.82D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.71D-06 BMatP= 2.71D-06
+ IDIUse=3 WtCom= 9.97D-01 WtEn= 2.82D-03
+ Coeff-Com:  0.100D+01
+ Coeff-En:   0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.663 Goal=   None    Shift=    0.000
+ RMSDP=8.75D-05 MaxDP=4.55D-04              OVMax= 9.21D-04
+
+ Cycle   2  Pass 1  IDiag  1:
+ E= -76.4225637401638     Delta-E=       -0.000003099084 Rises=F Damp=F
+ DIIS: error= 1.13D-04 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -76.4225637401638     IErMin= 2 ErrMin= 1.13D-04
+ ErrMax= 1.13D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 3.40D-07 BMatP= 2.71D-06
+ IDIUse=3 WtCom= 9.99D-01 WtEn= 1.13D-03
+ Coeff-Com:  0.163D+00 0.837D+00
+ Coeff-En:   0.000D+00 0.100D+01
+ Coeff:      0.163D+00 0.837D+00
+ Gap=     0.344 Goal=   None    Shift=    0.000
+ RMSDP=2.79D-05 MaxDP=2.49D-04 DE=-3.10D-06 OVMax= 2.86D-04
+
+ Cycle   3  Pass 1  IDiag  1:
+ E= -76.4225637326680     Delta-E=        0.000000007496 Rises=F Damp=F
+ DIIS: error= 1.31D-04 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 2 EnMin= -76.4225637401638     IErMin= 2 ErrMin= 1.13D-04
+ ErrMax= 1.31D-04  0.00D+00 EMaxC= 1.00D-01 BMatC= 3.67D-07 BMatP= 3.40D-07
+ IDIUse=3 WtCom= 9.99D-01 WtEn= 1.31D-03
+ Coeff-Com:  0.106D-01 0.508D+00 0.481D+00
+ Coeff-En:   0.000D+00 0.507D+00 0.493D+00
+ Coeff:      0.105D-01 0.508D+00 0.481D+00
+ Gap=     0.344 Goal=   None    Shift=    0.000
+ RMSDP=1.56D-05 MaxDP=1.41D-04 DE= 7.50D-09 OVMax= 1.59D-04
+
+ Cycle   4  Pass 1  IDiag  1:
+ E= -76.4225639935221     Delta-E=       -0.000000260854 Rises=F Damp=F
+ DIIS: error= 1.23D-05 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -76.4225639935221     IErMin= 4 ErrMin= 1.23D-05
+ ErrMax= 1.23D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 5.36D-09 BMatP= 3.40D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.986D-02 0.117D+00 0.170D+00 0.722D+00
+ Coeff:     -0.986D-02 0.117D+00 0.170D+00 0.722D+00
+ Gap=     0.344 Goal=   None    Shift=    0.000
+ RMSDP=2.48D-06 MaxDP=1.30D-05 DE=-2.61D-07 OVMax= 2.16D-05
+
+ Cycle   5  Pass 1  IDiag  1:
+ E= -76.4225639976496     Delta-E=       -0.000000004128 Rises=F Damp=F
+ DIIS: error= 6.84D-07 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -76.4225639976496     IErMin= 5 ErrMin= 6.84D-07
+ ErrMax= 6.84D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.25D-11 BMatP= 5.36D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.268D-03-0.198D-02 0.111D-02 0.504D-01 0.951D+00
+ Coeff:     -0.268D-03-0.198D-02 0.111D-02 0.504D-01 0.951D+00
+ Gap=     0.344 Goal=   None    Shift=    0.000
+ RMSDP=1.83D-07 MaxDP=1.07D-06 DE=-4.13D-09 OVMax= 2.12D-06
+
+ Cycle   6  Pass 1  IDiag  1:
+ E= -76.4225639976643     Delta-E=       -0.000000000015 Rises=F Damp=F
+ DIIS: error= 7.21D-08 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -76.4225639976643     IErMin= 6 ErrMin= 7.21D-08
+ ErrMax= 7.21D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.33D-13 BMatP= 1.25D-11
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.254D-04-0.109D-02-0.138D-02-0.410D-02 0.859D-01 0.921D+00
+ Coeff:      0.254D-04-0.109D-02-0.138D-02-0.410D-02 0.859D-01 0.921D+00
+ Gap=     0.344 Goal=   None    Shift=    0.000
+ RMSDP=2.19D-08 MaxDP=9.69D-08 DE=-1.47D-11 OVMax= 1.67D-07
+
+ Cycle   7  Pass 1  IDiag  1:
+ E= -76.4225639976646     Delta-E=        0.000000000000 Rises=F Damp=F
+ DIIS: error= 1.36D-08 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -76.4225639976646     IErMin= 7 ErrMin= 1.36D-08
+ ErrMax= 1.36D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.93D-15 BMatP= 1.33D-13
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.770D-05-0.142D-03-0.236D-03-0.164D-02 0.377D-03 0.155D+00
+ Coeff-Com:  0.847D+00
+ Coeff:      0.770D-05-0.142D-03-0.236D-03-0.164D-02 0.377D-03 0.155D+00
+ Coeff:      0.847D+00
+ Gap=     0.344 Goal=   None    Shift=    0.000
+ RMSDP=1.79D-09 MaxDP=8.19D-09 DE=-2.98D-13 OVMax= 1.72D-08
+
+ SCF Done:  E(RB3LYP) =  -76.4225639977     A.U. after    7 cycles
+            NFock=  7  Conv=0.18D-08     -V/T= 2.0092
+ KE= 7.572606281941D+01 PE=-1.984415628498D+02 EE= 3.720639996900D+01
+ Leave Link  502 at Thu Nov 17 12:10:59 2016, MaxMem=    33554432 cpu:         0.7
+ (Enter /opt/g09-d01/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ Leave Link  701 at Thu Nov 17 12:10:59 2016, MaxMem=    33554432 cpu:         0.2
+ (Enter /opt/g09-d01/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Thu Nov 17 12:10:59 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=F KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         0 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2127 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Thu Nov 17 12:11:00 2016, MaxMem=    33554432 cpu:         0.3
+ (Enter /opt/g09-d01/g09/l716.exe)
+ Dipole        = 1.32184619D-03-8.85079313D-01-4.72884514D-17
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8          -0.000669068   -0.002606467    0.001859513
+      2        1           0.001464245    0.001378690   -0.001608007
+      3        1          -0.000795177    0.001227777   -0.000251506
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.002606467 RMS     0.001473190
+ Leave Link  716 at Thu Nov 17 12:11:00 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.002573616 RMS     0.001716763
+ Search for a local minimum.
+ Step number   8 out of a maximum of   20
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .17168D-02 SwitMx=.10000D-02 MixMth= 1
+ Mixed Optimization -- RFO/linear search
+ Update second derivatives using D2CorX and points    5    6    8    7
+ DE=  7.83D-06 DEPred=-1.58D-06 R=-4.97D+00
+ Trust test=-4.97D+00 RLast= 6.62D-03 DXMaxT set to 5.87D-01
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.52202
+           R2          -0.01013   0.51588
+           A1           0.03096   0.02082   0.19238
+ ITU= -1  1  1 -1
+ Use linear search instead of GDIIS.
+ Energy rises -- skip Quadratic/GDIIS search.
+ Quartic linear search produced a step of -0.85598.
+ Iteration  1 RMS(Cart)=  0.00217159 RMS(Int)=  0.00000205
+ Iteration  2 RMS(Cart)=  0.00000151 RMS(Int)=  0.00000000
+ Iteration  3 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ITry= 1 IFail=0 DXMaxC= 1.96D-03 DCOld= 1.00D+10 DXMaxT= 5.87D-01 DXLimC= 3.00D+00 Rises=T
+ ClnCor:  largest displacement from symmetrization is 5.00D-16 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.82617   0.00257   0.00479   0.00000   0.00479   1.83095
+    R2        1.83384  -0.00148  -0.00272   0.00000  -0.00272   1.83112
+    A1        1.84059   0.00015  -0.00133   0.00000  -0.00133   1.83925
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.002574     0.000015     NO 
+ RMS     Force            0.001717     0.000010     NO 
+ Maximum Displacement     0.001955     0.000060     NO 
+ RMS     Displacement     0.002172     0.000040     NO 
+ Predicted change in Energy=-2.482836D-07
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Thu Nov 17 12:11:00 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.199541   -0.060874   -0.077573
+      2          1           0        0.771379    0.435797   -0.681794
+      3          1           0        0.680711   -0.879036    0.117422
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.968898   0.000000
+     3  H    0.968988   1.541347   0.000000
+ Stoichiometry    H2O
+ Framework group  CS[SG(H2O)]
+ Deg. of freedom     3
+ Full point group                 CS      NOp   2
+ RotChk:  IX=0 Diff= 5.04D-03
+ Largest Abelian subgroup         CS      NOp   2
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.000000    0.117458    0.000000
+      2          1           0        0.770674   -0.469760    0.000000
+      3          1           0       -0.770674   -0.469908    0.000000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):    818.5381373    422.1444269    278.5090424
+ Leave Link  202 at Thu Nov 17 12:11:00 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l301.exe)
+ Standard basis: 6-31+G(d) (6D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are    18 symmetry adapted cartesian basis functions of A'  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A"  symmetry.
+ There are    18 symmetry adapted basis functions of A'  symmetry.
+ There are     5 symmetry adapted basis functions of A"  symmetry.
+    23 basis functions,    40 primitive gaussians,    23 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.0815417734 Hartrees.
+ IExCor=  402 DFT=T Ex+Corr=B3LYP ExCW=0 ScaHFX=  0.200000
+ ScaDFX=  0.800000  0.720000  1.000000  0.810000 ScalE2=  1.000000  1.000000
+ IRadAn=      0 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=  4
+ NAtoms=    3 NActive=    3 NUniq=    3 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ Leave Link  301 at Thu Nov 17 12:11:00 2016, MaxMem=    33554432 cpu:         0.1
+ (Enter /opt/g09-d01/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+ NBasis=    23 RedAO= T EigKep=  2.57D-02  NBF=    18     5
+ NBsUse=    23 1.00D-06 EigRej= -1.00D+00 NBFU=    18     5
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           0 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=    23    23    23    23    23 MxSgAt=     3 MxSgA2=     3.
+ Leave Link  302 at Thu Nov 17 12:11:00 2016, MaxMem=    33554432 cpu:         0.2
+ (Enter /opt/g09-d01/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Thu Nov 17 12:11:00 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l401.exe)
+ Lowest energy guess from the checkpoint file:  "h2o.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000   -0.000244 Ang=  -0.03 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    0.999999    0.000000    0.000000    0.001453 Ang=   0.17 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ CkInt1:  FT= 1.44D-01
+ Max alpha theta=  0.060 degrees.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess orbital symmetries:
+       Occupied  (A') (A') (A') (A") (A')
+       Virtual   (A') (A') (A') (A") (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A") (A") (A") (A")
+ The electronic state of the initial guess is 1-A'.
+ Leave Link  401 at Thu Nov 17 12:11:00 2016, MaxMem=    33554432 cpu:         0.1
+ (Enter /opt/g09-d01/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ Integral symmetry usage will be decided dynamically.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=919005.
+ IVT=       20464 IEndB=       20464 NGot=    33554432 MDV=    33511632
+ LenX=    33511632 LenY=    33510662
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=    276 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ An orbital has undefined symmetry, so N**3 symmetry is turned off.
+
+ Cycle   1  Pass 1  IDiag  1:
+ E= -76.4225720584867    
+ DIIS: error= 1.57D-07 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -76.4225720584867     IErMin= 1 ErrMin= 1.57D-07
+ ErrMax= 1.57D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 5.12D-13 BMatP= 5.12D-13
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=    19.607 Goal=   None    Shift=    0.000
+ RMSDP=3.24D-08 MaxDP=2.69D-07              OVMax= 2.82D-07
+
+ Cycle   2  Pass 1  IDiag  1:
+ E= -76.4225720584866     Delta-E=        0.000000000000 Rises=F Damp=F
+ DIIS: error= 1.41D-07 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 1 EnMin= -76.4225720584867     IErMin= 2 ErrMin= 1.41D-07
+ ErrMax= 1.41D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 4.27D-13 BMatP= 5.12D-13
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.472D+00 0.528D+00
+ Coeff:      0.472D+00 0.528D+00
+ Gap=     0.344 Goal=   None    Shift=    0.000
+ RMSDP=2.09D-08 MaxDP=1.98D-07 DE= 7.11D-14 OVMax= 2.19D-07
+
+ Cycle   3  Pass 1  IDiag  1:
+ E= -76.4225720584871     Delta-E=        0.000000000000 Rises=F Damp=F
+ DIIS: error= 5.39D-08 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -76.4225720584871     IErMin= 3 ErrMin= 5.39D-08
+ ErrMax= 5.39D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 5.97D-14 BMatP= 4.27D-13
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.386D-02 0.270D+00 0.734D+00
+ Coeff:     -0.386D-02 0.270D+00 0.734D+00
+ Gap=     0.344 Goal=   None    Shift=    0.000
+ RMSDP=6.12D-09 MaxDP=5.43D-08 DE=-4.97D-13 OVMax= 6.51D-08
+
+ SCF Done:  E(RB3LYP) =  -76.4225720585     A.U. after    3 cycles
+            NFock=  3  Conv=0.61D-08     -V/T= 2.0092
+ KE= 7.572428980238D+01 PE=-1.984307811796D+02 EE= 3.720237754537D+01
+ Leave Link  502 at Thu Nov 17 12:11:01 2016, MaxMem=    33554432 cpu:         0.4
+ (Enter /opt/g09-d01/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ Leave Link  701 at Thu Nov 17 12:11:01 2016, MaxMem=    33554432 cpu:         0.2
+ (Enter /opt/g09-d01/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Thu Nov 17 12:11:01 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=F KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         0 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2127 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Thu Nov 17 12:11:01 2016, MaxMem=    33554432 cpu:         0.3
+ (Enter /opt/g09-d01/g09/l716.exe)
+ Dipole        = 2.92190990D-05-8.85713990D-01 7.55791377D-17
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8           0.000196520   -0.000121817   -0.000041194
+      2        1          -0.000066011    0.000169540   -0.000059357
+      3        1          -0.000130509   -0.000047723    0.000100551
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.000196520 RMS     0.000116047
+ Leave Link  716 at Thu Nov 17 12:11:01 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.000313978 RMS     0.000187811
+ Search for a local minimum.
+ Step number   9 out of a maximum of   20
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .18781D-03 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Update second derivatives using D2CorX and points    6    8    7    9
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.51823
+           R2          -0.00966   0.51766
+           A1           0.03300   0.02402   0.19296
+ ITU=  0 -1  1  1
+ Use linear search instead of GDIIS.
+     Eigenvalues ---    0.18777   0.51327   0.52780
+ RFO step:  Lambda=-5.16316195D-07 EMin= 1.87771054D-01
+ Quartic linear search produced a step of  0.00024.
+ Iteration  1 RMS(Cart)=  0.00092177 RMS(Int)=  0.00000050
+ Iteration  2 RMS(Cart)=  0.00000043 RMS(Int)=  0.00000000
+ ITry= 1 IFail=0 DXMaxC= 8.87D-04 DCOld= 1.00D+10 DXMaxT= 5.87D-01 DXLimC= 3.00D+00 Rises=F
+ ClnCor:  largest displacement from symmetrization is 1.51D-15 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.83095   0.00008   0.00000   0.00006   0.00006   1.83101
+    R2        1.83112   0.00000   0.00000  -0.00008  -0.00008   1.83104
+    A1        1.83925   0.00031   0.00000   0.00163   0.00163   1.84088
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000314     0.000015     NO 
+ RMS     Force            0.000188     0.000010     NO 
+ Maximum Displacement     0.000887     0.000060     NO 
+ RMS     Displacement     0.000922     0.000040     NO 
+ Predicted change in Energy=-2.581582D-07
+ Lowest energy point so far.  Saving SCF results.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Thu Nov 17 12:11:01 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.199916   -0.061011   -0.077706
+      2          1           0        0.771228    0.436266   -0.681976
+      3          1           0        0.680486   -0.879367    0.117737
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.968929   0.000000
+     3  H    0.968944   1.542292   0.000000
+ Stoichiometry    H2O
+ Framework group  CS[SG(H2O)]
+ Deg. of freedom     3
+ Full point group                 CS      NOp   2
+ RotChk:  IX=0 Diff= 9.49D-05
+ Largest Abelian subgroup         CS      NOp   2
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.000000    0.117332    0.000000
+      2          1           0        0.771146   -0.469317    0.000000
+      3          1           0       -0.771146   -0.469341    0.000000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):    820.3002057    421.6271708    278.4871817
+ Leave Link  202 at Thu Nov 17 12:11:01 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l301.exe)
+ Standard basis: 6-31+G(d) (6D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are    18 symmetry adapted cartesian basis functions of A'  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A"  symmetry.
+ There are    18 symmetry adapted basis functions of A'  symmetry.
+ There are     5 symmetry adapted basis functions of A"  symmetry.
+    23 basis functions,    40 primitive gaussians,    23 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.0813883534 Hartrees.
+ IExCor=  402 DFT=T Ex+Corr=B3LYP ExCW=0 ScaHFX=  0.200000
+ ScaDFX=  0.800000  0.720000  1.000000  0.810000 ScalE2=  1.000000  1.000000
+ IRadAn=      0 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=  4
+ NAtoms=    3 NActive=    3 NUniq=    3 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ Leave Link  301 at Thu Nov 17 12:11:02 2016, MaxMem=    33554432 cpu:         0.1
+ (Enter /opt/g09-d01/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+ NBasis=    23 RedAO= T EigKep=  2.57D-02  NBF=    18     5
+ NBsUse=    23 1.00D-06 EigRej= -1.00D+00 NBFU=    18     5
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           0 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=    23    23    23    23    23 MxSgAt=     3 MxSgA2=     3.
+ Leave Link  302 at Thu Nov 17 12:11:02 2016, MaxMem=    33554432 cpu:         0.2
+ (Enter /opt/g09-d01/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Thu Nov 17 12:11:02 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l401.exe)
+ Initial guess from the checkpoint file:  "h2o.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000027 Ang=   0.00 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess orbital symmetries:
+       Occupied  (A') (A') (A') (A') (A")
+       Virtual   (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A") (A") (A") (A")
+ The electronic state of the initial guess is 1-A'.
+ Leave Link  401 at Thu Nov 17 12:11:02 2016, MaxMem=    33554432 cpu:         0.1
+ (Enter /opt/g09-d01/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ Integral symmetry usage will be decided dynamically.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=919005.
+ IVT=       20464 IEndB=       20464 NGot=    33554432 MDV=    33511632
+ LenX=    33511632 LenY=    33510662
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=    276 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+
+ Cycle   1  Pass 1  IDiag  1:
+ E= -76.4225722566716    
+ DIIS: error= 5.41D-05 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -76.4225722566716     IErMin= 1 ErrMin= 5.41D-05
+ ErrMax= 5.41D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 7.53D-08 BMatP= 7.53D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.663 Goal=   None    Shift=    0.000
+ RMSDP=2.27D-05 MaxDP=1.39D-04              OVMax= 1.67D-04
+
+ Cycle   2  Pass 1  IDiag  1:
+ E= -76.4225723501027     Delta-E=       -0.000000093431 Rises=F Damp=F
+ DIIS: error= 1.11D-05 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -76.4225723501027     IErMin= 2 ErrMin= 1.11D-05
+ ErrMax= 1.11D-05  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.00D-09 BMatP= 7.53D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.343D-01 0.966D+00
+ Coeff:      0.343D-01 0.966D+00
+ Gap=     0.344 Goal=   None    Shift=    0.000
+ RMSDP=2.47D-06 MaxDP=1.41D-05 DE=-9.34D-08 OVMax= 2.50D-05
+
+ Cycle   3  Pass 1  IDiag  1:
+ E= -76.4225723507048     Delta-E=       -0.000000000602 Rises=F Damp=F
+ DIIS: error= 8.99D-06 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -76.4225723507048     IErMin= 3 ErrMin= 8.99D-06
+ ErrMax= 8.99D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.80D-09 BMatP= 2.00D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.526D-02 0.485D+00 0.520D+00
+ Coeff:     -0.526D-02 0.485D+00 0.520D+00
+ Gap=     0.344 Goal=   None    Shift=    0.000
+ RMSDP=1.38D-06 MaxDP=1.17D-05 DE=-6.02D-10 OVMax= 1.35D-05
+
+ Cycle   4  Pass 1  IDiag  1:
+ E= -76.4225723518765     Delta-E=       -0.000000001172 Rises=F Damp=F
+ DIIS: error= 2.98D-06 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -76.4225723518765     IErMin= 4 ErrMin= 2.98D-06
+ ErrMax= 2.98D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.97D-10 BMatP= 1.80D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.985D-02 0.127D+00 0.280D+00 0.603D+00
+ Coeff:     -0.985D-02 0.127D+00 0.280D+00 0.603D+00
+ Gap=     0.344 Goal=   None    Shift=    0.000
+ RMSDP=3.15D-07 MaxDP=3.13D-06 DE=-1.17D-09 OVMax= 3.58D-06
+
+ Cycle   5  Pass 1  IDiag  1:
+ E= -76.4225723520172     Delta-E=       -0.000000000141 Rises=F Damp=F
+ DIIS: error= 3.66D-08 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -76.4225723520172     IErMin= 5 ErrMin= 3.66D-08
+ ErrMax= 3.66D-08  0.00D+00 EMaxC= 1.00D-01 BMatC= 3.86D-14 BMatP= 1.97D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.167D-03-0.524D-02-0.782D-02-0.556D-02 0.102D+01
+ Coeff:      0.167D-03-0.524D-02-0.782D-02-0.556D-02 0.102D+01
+ Gap=     0.344 Goal=   None    Shift=    0.000
+ RMSDP=2.79D-08 MaxDP=1.76D-07 DE=-1.41D-10 OVMax= 2.08D-07
+
+ Cycle   6  Pass 1  IDiag  1:
+ E= -76.4225723520174     Delta-E=        0.000000000000 Rises=F Damp=F
+ DIIS: error= 9.90D-09 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -76.4225723520174     IErMin= 6 ErrMin= 9.90D-09
+ ErrMax= 9.90D-09  0.00D+00 EMaxC= 1.00D-01 BMatC= 3.07D-15 BMatP= 3.86D-14
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.933D-04-0.192D-02-0.292D-02-0.560D-02 0.200D+00 0.810D+00
+ Coeff:      0.933D-04-0.192D-02-0.292D-02-0.560D-02 0.200D+00 0.810D+00
+ Gap=     0.344 Goal=   None    Shift=    0.000
+ RMSDP=2.46D-09 MaxDP=1.29D-08 DE=-2.13D-13 OVMax= 2.03D-08
+
+ SCF Done:  E(RB3LYP) =  -76.4225723520     A.U. after    6 cycles
+            NFock=  6  Conv=0.25D-08     -V/T= 2.0092
+ KE= 7.572409036076D+01 PE=-1.984305213311D+02 EE= 3.720247026489D+01
+ Leave Link  502 at Thu Nov 17 12:11:03 2016, MaxMem=    33554432 cpu:         0.7
+ (Enter /opt/g09-d01/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ Leave Link  701 at Thu Nov 17 12:11:03 2016, MaxMem=    33554432 cpu:         0.2
+ (Enter /opt/g09-d01/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Thu Nov 17 12:11:03 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=F KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         0 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2127 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Thu Nov 17 12:11:03 2016, MaxMem=    33554432 cpu:         0.3
+ (Enter /opt/g09-d01/g09/l716.exe)
+ Dipole        = 4.85518482D-06-8.85080307D-01-6.31633179D-17
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8           0.000031994   -0.000020010   -0.000006605
+      2        1          -0.000011118    0.000021359   -0.000005902
+      3        1          -0.000020876   -0.000001350    0.000012508
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.000031994 RMS     0.000017244
+ Leave Link  716 at Thu Nov 17 12:11:03 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.000042913 RMS     0.000025506
+ Search for a local minimum.
+ Step number  10 out of a maximum of   20
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .25506D-04 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Swapping is turned off.
+ Update second derivatives using D2CorX and points    8    7    9   10
+ DE= -2.94D-07 DEPred=-2.58D-07 R= 1.14D+00
+ Trust test= 1.14D+00 RLast= 1.63D-03 DXMaxT set to 5.87D-01
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.52596
+           R2          -0.01473   0.52203
+           A1           0.02749   0.02853   0.16702
+ ITU=  0  0 -1  1
+     Eigenvalues ---    0.16249   0.51365   0.53887
+ En-DIIS/RFO-DIIS IScMMF=        0 using points:    10    9
+ RFO step:  Lambda= 0.00000000D+00.
+ NNeg= 0 NP= 2 Switch=  2.50D-03 Rises=F DC=  2.94D-07 SmlDif=  1.00D-05
+ RMS Error=  0.6166155203D-04 NUsed= 2 EDIIS=F
+ DidBck=F Rises=F RFO-DIIS coefs:    1.15909   -0.15909
+ Iteration  1 RMS(Cart)=  0.00014444 RMS(Int)=  0.00000001
+ Iteration  2 RMS(Cart)=  0.00000001 RMS(Int)=  0.00000000
+ ITry= 1 IFail=0 DXMaxC= 1.36D-04 DCOld= 1.00D+10 DXMaxT= 5.87D-01 DXLimC= 3.00D+00 Rises=F
+ ClnCor:  largest displacement from symmetrization is 1.11D-15 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.83101   0.00001   0.00001  -0.00001   0.00000   1.83101
+    R2        1.83104  -0.00001  -0.00001  -0.00001  -0.00003   1.83101
+    A1        1.84088   0.00004   0.00026   0.00000   0.00026   1.84114
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000043     0.000015     NO 
+ RMS     Force            0.000026     0.000010     NO 
+ Maximum Displacement     0.000136     0.000060     NO 
+ RMS     Displacement     0.000144     0.000040     NO 
+ Predicted change in Energy=-5.703220D-09
+ Lowest energy point so far.  Saving SCF results.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Thu Nov 17 12:11:03 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.199979   -0.061035   -0.077728
+      2          1           0        0.771202    0.436338   -0.682002
+      3          1           0        0.680449   -0.879416    0.117785
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.968929   0.000000
+     3  H    0.968930   1.542435   0.000000
+ Stoichiometry    H2O
+ Framework group  CS[SG(H2O)]
+ Deg. of freedom     3
+ Full point group                 CS      NOp   2
+ RotChk:  IX=0 Diff= 1.88D-05
+ Largest Abelian subgroup         CS      NOp   2
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.000000    0.117311    0.000000
+      2          1           0        0.771217   -0.469245    0.000000
+      3          1           0       -0.771217   -0.469245    0.000000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):    820.5938589    421.5493578    278.4870614
+ Leave Link  202 at Thu Nov 17 12:11:03 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l301.exe)
+ Standard basis: 6-31+G(d) (6D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are    18 symmetry adapted cartesian basis functions of A'  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A"  symmetry.
+ There are    18 symmetry adapted basis functions of A'  symmetry.
+ There are     5 symmetry adapted basis functions of A"  symmetry.
+    23 basis functions,    40 primitive gaussians,    23 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.0814190272 Hartrees.
+ IExCor=  402 DFT=T Ex+Corr=B3LYP ExCW=0 ScaHFX=  0.200000
+ ScaDFX=  0.800000  0.720000  1.000000  0.810000 ScalE2=  1.000000  1.000000
+ IRadAn=      0 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=  4
+ NAtoms=    3 NActive=    3 NUniq=    3 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ Leave Link  301 at Thu Nov 17 12:11:03 2016, MaxMem=    33554432 cpu:         0.1
+ (Enter /opt/g09-d01/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+ NBasis=    23 RedAO= T EigKep=  2.57D-02  NBF=    18     5
+ NBsUse=    23 1.00D-06 EigRej= -1.00D+00 NBFU=    18     5
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           0 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=    23    23    23    23    23 MxSgAt=     3 MxSgA2=     3.
+ Leave Link  302 at Thu Nov 17 12:11:04 2016, MaxMem=    33554432 cpu:         0.2
+ (Enter /opt/g09-d01/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Thu Nov 17 12:11:04 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l401.exe)
+ Initial guess from the checkpoint file:  "h2o.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000005 Ang=   0.00 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess orbital symmetries:
+       Occupied  (A') (A') (A') (A') (A")
+       Virtual   (A') (A') (A') (A') (A') (A') (A') (A') (A') (A')
+                 (A') (A') (A') (A') (A") (A") (A") (A")
+ The electronic state of the initial guess is 1-A'.
+ Leave Link  401 at Thu Nov 17 12:11:04 2016, MaxMem=    33554432 cpu:         0.1
+ (Enter /opt/g09-d01/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ Integral symmetry usage will be decided dynamically.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=919005.
+ IVT=       20464 IEndB=       20464 NGot=    33554432 MDV=    33511632
+ LenX=    33511632 LenY=    33510662
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=    276 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+
+ Cycle   1  Pass 1  IDiag  1:
+ E= -76.4225723551482    
+ DIIS: error= 8.60D-06 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -76.4225723551482     IErMin= 1 ErrMin= 8.60D-06
+ ErrMax= 8.60D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.97D-09 BMatP= 1.97D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.663 Goal=   None    Shift=    0.000
+ RMSDP=3.76D-06 MaxDP=2.37D-05              OVMax= 2.78D-05
+
+ Cycle   2  Pass 1  IDiag  1:
+ E= -76.4225723576378     Delta-E=       -0.000000002490 Rises=F Damp=F
+ DIIS: error= 1.85D-06 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -76.4225723576378     IErMin= 2 ErrMin= 1.85D-06
+ ErrMax= 1.85D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.04D-10 BMatP= 1.97D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.587D-01 0.941D+00
+ Coeff:      0.587D-01 0.941D+00
+ Gap=     0.344 Goal=   None    Shift=    0.000
+ RMSDP=5.59D-07 MaxDP=4.39D-06 DE=-2.49D-09 OVMax= 5.74D-06
+
+ Cycle   3  Pass 1  IDiag  1:
+ E= -76.4225723576055     Delta-E=        0.000000000032 Rises=F Damp=F
+ DIIS: error= 2.78D-06 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 2 EnMin= -76.4225723576378     IErMin= 2 ErrMin= 1.85D-06
+ ErrMax= 2.78D-06  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.66D-10 BMatP= 1.04D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.861D-02 0.564D+00 0.445D+00
+ Coeff:     -0.861D-02 0.564D+00 0.445D+00
+ Gap=     0.344 Goal=   None    Shift=    0.000
+ RMSDP=3.41D-07 MaxDP=2.99D-06 DE= 3.23D-11 OVMax= 3.40D-06
+
+ Cycle   4  Pass 1  IDiag  1:
+ E= -76.4225723577238     Delta-E=       -0.000000000118 Rises=F Damp=F
+ DIIS: error= 2.72D-07 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -76.4225723577238     IErMin= 4 ErrMin= 2.72D-07
+ ErrMax= 2.72D-07  0.00D+00 EMaxC= 1.00D-01 BMatC= 2.03D-12 BMatP= 1.04D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.984D-02 0.127D+00 0.155D+00 0.728D+00
+ Coeff:     -0.984D-02 0.127D+00 0.155D+00 0.728D+00
+ Gap=     0.344 Goal=   None    Shift=    0.000
+ RMSDP=3.60D-08 MaxDP=2.99D-07 DE=-1.18D-10 OVMax= 3.51D-07
+
+ Cycle   5  Pass 1  IDiag  1:
+ E= -76.4225723577254     Delta-E=       -0.000000000002 Rises=F Damp=F
+ DIIS: error= 6.16D-09 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -76.4225723577254     IErMin= 5 ErrMin= 6.16D-09
+ ErrMax= 6.16D-09  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.30D-15 BMatP= 2.03D-12
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.132D-03-0.509D-02-0.464D-02 0.702D-03 0.101D+01
+ Coeff:      0.132D-03-0.509D-02-0.464D-02 0.702D-03 0.101D+01
+ Gap=     0.344 Goal=   None    Shift=    0.000
+ RMSDP=4.53D-09 MaxDP=2.92D-08 DE=-1.59D-12 OVMax= 3.57D-08
+
+ SCF Done:  E(RB3LYP) =  -76.4225723577     A.U. after    5 cycles
+            NFock=  5  Conv=0.45D-08     -V/T= 2.0092
+ KE= 7.572407905456D+01 PE=-1.984305981894D+02 EE= 3.720252774992D+01
+ Leave Link  502 at Thu Nov 17 12:11:04 2016, MaxMem=    33554432 cpu:         0.6
+ (Enter /opt/g09-d01/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ Leave Link  701 at Thu Nov 17 12:11:05 2016, MaxMem=    33554432 cpu:         0.2
+ (Enter /opt/g09-d01/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Thu Nov 17 12:11:05 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=F KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         0 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2127 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Thu Nov 17 12:11:05 2016, MaxMem=    33554432 cpu:         0.3
+ (Enter /opt/g09-d01/g09/l716.exe)
+ Dipole        =-1.17660657D-08-8.84977190D-01-1.93844906D-16
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8           0.000000001   -0.000000022    0.000000012
+      2        1           0.000000010    0.000000038   -0.000000027
+      3        1          -0.000000011   -0.000000016    0.000000015
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.000000038 RMS     0.000000020
+ Leave Link  716 at Thu Nov 17 12:11:05 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.000000043 RMS     0.000000035
+ Search for a local minimum.
+ Step number  11 out of a maximum of   20
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .34712D-07 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Swapping is turned off.
+ Update second derivatives using D2CorX and points    7    9   10   11
+ DE= -5.71D-09 DEPred=-5.70D-09 R= 1.00D+00
+ Trust test= 1.00D+00 RLast= 2.63D-04 DXMaxT set to 5.87D-01
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.51995
+           R2          -0.01063   0.51928
+           A1           0.02778   0.02819   0.16683
+ ITU=  0  0  0 -1
+     Eigenvalues ---    0.16231   0.51349   0.53025
+ En-DIIS/RFO-DIIS IScMMF=        0 using points:    11   10    9
+ RFO step:  Lambda= 0.00000000D+00.
+ NNeg= 0 NP= 3 Switch=  2.50D-03 Rises=F DC=  2.94D-07 SmlDif=  1.00D-05
+ RMS Error=  0.6472991120D-07 NUsed= 3 EDIIS=F
+ DidBck=F Rises=F RFO-DIIS coefs:    0.99692    0.00373   -0.00064
+ Iteration  1 RMS(Cart)=  0.00000015 RMS(Int)=  0.00000000
+ ITry= 1 IFail=0 DXMaxC= 1.56D-07 DCOld= 1.00D+10 DXMaxT= 5.87D-01 DXLimC= 3.00D+00 Rises=F
+ ClnCor:  largest displacement from symmetrization is 1.96D-15 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.83101   0.00000   0.00000   0.00000   0.00000   1.83101
+    R2        1.83101   0.00000   0.00000   0.00000   0.00000   1.83101
+    A1        1.84114   0.00000   0.00000   0.00000   0.00000   1.84114
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000000     0.000015     YES
+ RMS     Force            0.000000     0.000010     YES
+ Maximum Displacement     0.000000     0.000060     YES
+ RMS     Displacement     0.000000     0.000040     YES
+ Predicted change in Energy=-6.284837D-15
+ Optimization completed.
+    -- Stationary point found.
+                           ----------------------------
+                           !   Optimized Parameters   !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  0.9689         -DE/DX =    0.0                 !
+ ! R2    R(1,3)                  0.9689         -DE/DX =    0.0                 !
+ ! A1    A(2,1,3)              105.4898         -DE/DX =    0.0                 !
+ --------------------------------------------------------------------------------
+ Lowest energy point so far.  Saving SCF results.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Largest change from initial coordinates is atom    2       0.788 Angstoms.
+ Leave Link  103 at Thu Nov 17 12:11:05 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.199979   -0.061035   -0.077728
+      2          1           0        0.771202    0.436338   -0.682002
+      3          1           0        0.680449   -0.879416    0.117785
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.968929   0.000000
+     3  H    0.968930   1.542435   0.000000
+ Stoichiometry    H2O
+ Framework group  CS[SG(H2O)]
+ Deg. of freedom     3
+ Full point group                 CS      NOp   2
+ RotChk:  IX=0 Diff= 1.34D-15
+ Largest Abelian subgroup         CS      NOp   2
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.000000    0.117311    0.000000
+      2          1           0        0.771217   -0.469245    0.000000
+      3          1           0       -0.771217   -0.469245    0.000000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):    820.5938589    421.5493578    278.4870614
+ Leave Link  202 at Thu Nov 17 12:11:05 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l601.exe)
+ Copying SCF densities to generalized density rwf, IOpCl= 0 IROHF=0.
+
+ **********************************************************************
+
+            Population analysis using the SCF density.
+
+ **********************************************************************
+
+ Orbital symmetries:
+       Occupied  (A') (A') (A') (A') (A")
+       Virtual   (A') (A') (A") (A') (A') (A') (A') (A') (A') (A")
+                 (A') (A') (A') (A") (A") (A') (A') (A')
+ The electronic state is 1-A'.
+ Alpha  occ. eigenvalues --  -19.16895  -1.02228  -0.54352  -0.39492  -0.31926
+ Alpha virt. eigenvalues --    0.02489   0.11344   0.15548   0.15557   0.20365
+ Alpha virt. eigenvalues --    0.23946   0.94700   1.03188   1.11169   1.11382
+ Alpha virt. eigenvalues --    1.14378   1.24356   1.71230   1.72086   1.75827
+ Alpha virt. eigenvalues --    2.27092   2.63639   3.67481
+          Condensed to atoms (all electrons):
+               1          2          3
+     1  O    8.472006   0.227769   0.227769
+     2  H    0.227769   0.330867  -0.022408
+     3  H    0.227769  -0.022408   0.330867
+ Mulliken charges:
+               1
+     1  O   -0.927545
+     2  H    0.463772
+     3  H    0.463772
+ Sum of Mulliken charges =   0.00000
+ Mulliken charges with hydrogens summed into heavy atoms:
+               1
+     1  O    0.000000
+ Electronic spatial extent (au):  <R**2>=             20.2151
+ Charge=              0.0000 electrons
+ Dipole moment (field-independent basis, Debye):
+    X=              0.0000    Y=             -2.2494    Z=              0.0000  Tot=              2.2494
+ Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=             -4.3540   YY=             -6.5331   ZZ=             -7.9451
+   XY=              0.0000   XZ=              0.0000   YZ=              0.0000
+ Traceless Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=              1.9234   YY=             -0.2557   ZZ=             -1.6677
+   XY=              0.0000   XZ=              0.0000   YZ=              0.0000
+ Octapole moment (field-independent basis, Debye-Ang**2):
+  XXX=              0.0000  YYY=             -1.6505  ZZZ=              0.0000  XYY=              0.0000
+  XXY=             -1.4312  XXZ=              0.0000  XZZ=              0.0000  YZZ=             -0.4920
+  YYZ=              0.0000  XYZ=              0.0000
+ Hexadecapole moment (field-independent basis, Debye-Ang**3):
+ XXXX=             -6.4207 YYYY=             -8.1090 ZZZZ=             -7.9817 XXXY=              0.0000
+ XXXZ=              0.0000 YYYX=              0.0000 YYYZ=              0.0000 ZZZX=              0.0000
+ ZZZY=              0.0000 XXYY=             -2.1125 XXZZ=             -2.6730 YYZZ=             -2.7312
+ XXYZ=              0.0000 YYXZ=              0.0000 ZZXY=              0.0000
+ N-N= 9.081419027242D+00 E-N=-1.984305983523D+02  KE= 7.572407905456D+01
+ Symmetry A'   KE= 7.124773759684D+01
+ Symmetry A"   KE= 4.476341457720D+00
+ No NMR shielding tensors so no spin-rotation constants.
+ Leave Link  601 at Thu Nov 17 12:11:05 2016, MaxMem=    33554432 cpu:         0.2
+ (Enter /opt/g09-d01/g09/l9999.exe)
+ 1\1\GINC-DNAS-NODE31\FOpt\RB3LYP\6-31+G(d)\H2O1\GVALLVER\17-Nov-2016\0
+ \\#P B3LYP / 6-31+G* opt=tight freq form\\vib H2O\\0,1\O,0.1999786654,
+ -0.0610346817,-0.0777277681\H,0.7712024465,0.4363383751,-0.6820023705\
+ H,0.6804488881,-0.8794156935,0.1177851386\\Version=EM64L-G09RevD.01\St
+ ate=1-A'\HF=-76.4225724\RMSD=4.527e-09\RMSF=1.995e-08\Dipole=0.7933812
+ ,-0.2421633,-0.3083633\Quadrupole=-0.3869134,0.7815015,-0.3945881,-0.1
+ 235254,-0.4093805,-1.0808286\PG=CS [SG(H2O1)]\\@
+
+
+ When cryptography is outlawed, bayl bhgynjf jvyy unir cevinpl.
+ FChkPn:  Coordinates translated and rotated.
+ FChkPn:  Coordinates match /B/ after translation and rotation.
+ Leave Link 9999 at Thu Nov 17 12:11:05 2016, MaxMem=    33554432 cpu:         0.1
+ Job cpu time:       0 days  0 hours  0 minutes 22.6 seconds.
+ File lengths (MBytes):  RWF=      5 Int=      0 D2E=      0 Chk=      1 Scr=      1
+ Normal termination of Gaussian 09 at Thu Nov 17 12:11:06 2016.
+ (Enter /opt/g09-d01/g09/l1.exe)
+ Link1:  Proceeding to internal job step number  2.
+ ---------------------------------------------------------------------
+ #P Geom=AllCheck Guess=TCheck SCRF=Check GenChk RB3LYP/6-31+G(d) Freq
+ ---------------------------------------------------------------------
+ 1/7=10,10=4,29=7,30=1,38=1,40=1/1,3;
+ 2/12=2,40=1/2;
+ 3/5=1,6=6,7=11,11=2,14=-4,16=1,25=1,30=1,70=2,71=2,74=-5,116=1,140=1/1,2,3;
+ 4/5=101/1;
+ 5/5=2,98=1/2;
+ 8/6=4,10=90,11=11/1;
+ 11/6=1,8=1,9=11,15=111,16=1/1,2,10;
+ 10/6=1/2;
+ 6/7=2,8=2,9=2,10=2,18=1,28=1/1;
+ 7/8=1,10=1,25=1/1,2,3,16;
+ 1/7=10,10=4,30=1/3;
+ 99//99;
+ Leave Link    1 at Thu Nov 17 12:11:06 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l101.exe)
+ Structure from the checkpoint file:  "h2o.chk"
+ -------
+ vib H2O
+ -------
+ Charge =  0 Multiplicity = 1
+ Redundant internal coordinates found in file.
+ O,0,0.1999786654,-0.0610346817,-0.0777277681
+ H,0,0.7712024465,0.4363383751,-0.6820023705
+ H,0,0.6804488881,-0.8794156935,0.1177851386
+ Recover connectivity data from disk.
+ NAtoms=      3 NQM=        3 NQMF=       0 NMMI=      0 NMMIF=      0
+                NMic=       0 NMicF=      0.
+                    Isotopes and Nuclear Properties:
+ (Nuclear quadrupole moments (NQMom) in fm**2, nuclear magnetic moments (NMagM)
+  in nuclear magnetons)
+
+  Atom         1           2           3
+ IAtWgt=          16           1           1
+ AtmWgt=  15.9949146   1.0078250   1.0078250
+ NucSpn=           0           1           1
+ AtZEff=  -5.6000000  -1.0000000  -1.0000000
+ NQMom=    0.0000000   0.0000000   0.0000000
+ NMagM=    0.0000000   2.7928460   2.7928460
+ AtZNuc=   8.0000000   1.0000000   1.0000000
+ Leave Link  101 at Thu Nov 17 12:11:06 2016, MaxMem=    33554432 cpu:         0.1
+ (Enter /opt/g09-d01/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Initialization pass.
+                           ----------------------------
+                           !    Initial Parameters    !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  0.9689         calculate D2E/DX2 analytically  !
+ ! R2    R(1,3)                  0.9689         calculate D2E/DX2 analytically  !
+ ! A1    A(2,1,3)              105.4898         calculate D2E/DX2 analytically  !
+ --------------------------------------------------------------------------------
+ Trust Radius=3.00D-01 FncErr=1.00D-07 GrdErr=1.00D-07
+ Number of steps in this run=      2 maximum allowed number of steps=      2.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Thu Nov 17 12:11:06 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l202.exe)
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.199979   -0.061035   -0.077728
+      2          1           0        0.771202    0.436338   -0.682002
+      3          1           0        0.680449   -0.879416    0.117785
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.968929   0.000000
+     3  H    0.968930   1.542435   0.000000
+ Stoichiometry    H2O
+ Framework group  CS[SG(H2O)]
+ Deg. of freedom     3
+ Full point group                 CS      NOp   2
+ RotChk:  IX=0 Diff= 1.23D-15
+ Largest Abelian subgroup         CS      NOp   2
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.000000    0.117311    0.000000
+      2          1           0        0.771217   -0.469245    0.000000
+      3          1           0       -0.771217   -0.469245    0.000000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):    820.5938589    421.5493578    278.4870614
+ Leave Link  202 at Thu Nov 17 12:11:06 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l301.exe)
+ Standard basis: 6-31+G(d) (6D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are    18 symmetry adapted cartesian basis functions of A'  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A"  symmetry.
+ There are    18 symmetry adapted basis functions of A'  symmetry.
+ There are     5 symmetry adapted basis functions of A"  symmetry.
+    23 basis functions,    40 primitive gaussians,    23 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.0814190272 Hartrees.
+ IExCor=  402 DFT=T Ex+Corr=B3LYP ExCW=0 ScaHFX=  0.200000
+ ScaDFX=  0.800000  0.720000  1.000000  0.810000 ScalE2=  1.000000  1.000000
+ IRadAn=      0 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=  4
+ NAtoms=    3 NActive=    3 NUniq=    3 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ Leave Link  301 at Thu Nov 17 12:11:06 2016, MaxMem=    33554432 cpu:         0.1
+ (Enter /opt/g09-d01/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+ NBasis=    23 RedAO= T EigKep=  2.57D-02  NBF=    18     5
+ NBsUse=    23 1.00D-06 EigRej= -1.00D+00 NBFU=    18     5
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           0 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=    23    23    23    23    23 MxSgAt=     3 MxSgA2=     3.
+ Leave Link  302 at Thu Nov 17 12:11:06 2016, MaxMem=    33554432 cpu:         0.2
+ (Enter /opt/g09-d01/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Thu Nov 17 12:11:06 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l401.exe)
+ Initial guess from the checkpoint file:  "h2o.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess orbital symmetries:
+       Occupied  (A') (A') (A') (A') (A")
+       Virtual   (A') (A') (A") (A') (A') (A') (A') (A') (A') (A")
+                 (A') (A') (A') (A") (A") (A') (A') (A')
+ The electronic state of the initial guess is 1-A'.
+ Leave Link  401 at Thu Nov 17 12:11:06 2016, MaxMem=    33554432 cpu:         0.1
+ (Enter /opt/g09-d01/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=  1040.
+ Integral symmetry usage will be decided dynamically.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=919005.
+ IVT=       20464 IEndB=       20464 NGot=    33554432 MDV=    33511632
+ LenX=    33511632 LenY=    33510662
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=    276 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+
+ Cycle   1  Pass 1  IDiag  1:
+ E= -76.4225723577254    
+ DIIS: error= 1.90D-09 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -76.4225723577254     IErMin= 1 ErrMin= 1.90D-09
+ ErrMax= 1.90D-09  0.00D+00 EMaxC= 1.00D-01 BMatC= 1.08D-16 BMatP= 1.08D-16
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.344 Goal=   None    Shift=    0.000
+ RMSDP=6.51D-10 MaxDP=3.65D-09              OVMax= 5.68D-09
+
+ SCF Done:  E(RB3LYP) =  -76.4225723577     A.U. after    1 cycles
+            NFock=  1  Conv=0.65D-09     -V/T= 2.0092
+ KE= 7.572407896604D+01 PE=-1.984305982638D+02 EE= 3.720252791277D+01
+ Leave Link  502 at Thu Nov 17 12:11:07 2016, MaxMem=    33554432 cpu:         0.2
+ (Enter /opt/g09-d01/g09/l801.exe)
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1    23
+ NBasis=    23 NAE=     5 NBE=     5 NFC=     0 NFV=     0
+ NROrb=     23 NOA=     5 NOB=     5 NVA=    18 NVB=    18
+ Leave Link  801 at Thu Nov 17 12:11:07 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l1101.exe)
+ Using compressed storage, NAtomX=     3.
+ Will process      4 centers per pass.
+ Leave Link 1101 at Thu Nov 17 12:11:07 2016, MaxMem=    33554432 cpu:         0.2
+ (Enter /opt/g09-d01/g09/l1102.exe)
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+ Leave Link 1102 at Thu Nov 17 12:11:07 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l1110.exe)
+ Forming Gx(P) for the SCF density, NAtomX=     3.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Do as many integral derivatives as possible in FoFJK.
+ G2DrvN: MDV=      33554304.
+ G2DrvN: will do     4 centers at a time, making    1 passes.
+ Calling FoFCou, ICntrl=  3107 FMM=F I1Cent=   0 AccDes= 0.00D+00.
+ FoFJK:  IHMeth= 1 ICntrl=    3107 DoSepK=F KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         0 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    3107 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ End of G2Drv F.D. properties file   721 does not exist.
+ End of G2Drv F.D. properties file   722 does not exist.
+ End of G2Drv F.D. properties file   788 does not exist.
+ Leave Link 1110 at Thu Nov 17 12:11:07 2016, MaxMem=    33554432 cpu:         0.6
+ (Enter /opt/g09-d01/g09/l1002.exe)
+ Minotr:  Closed shell wavefunction.
+          IDoAtm=111
+          Direct CPHF calculation.
+          Differentiating once with respect to electric field.
+                with respect to dipole field.
+          Differentiating once with respect to nuclear coordinates.
+          Using symmetry in CPHF.
+          Requested convergence is 1.0D-08 RMS, and 1.0D-07 maximum.
+          Secondary convergence is 1.0D-12 RMS, and 1.0D-12 maximum.
+          NewPWx=T KeepS1=F KeepF1=F KeepIn=T MapXYZ=F SortEE=F KeepMc=T.
+          MDV=      33554375 using IRadAn=       2.
+ Generate precomputed XC quadrature information.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=897942.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=           0 FMFlg1=           0
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=     600 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=    276 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+          Solving linear equations simultaneously, MaxMat=       0.
+          There are    12 degrees of freedom in the 1st order CPHF.  IDoFFX=6 NUNeed=     3.
+      9 vectors produced by pass  0 Test12= 7.50D-16 8.33D-09 XBig12= 3.46D+00 1.36D+00.
+ AX will form     9 AO Fock derivatives at one time.
+      9 vectors produced by pass  1 Test12= 7.50D-16 8.33D-09 XBig12= 4.01D-01 2.33D-01.
+      9 vectors produced by pass  2 Test12= 7.50D-16 8.33D-09 XBig12= 3.59D-03 2.75D-02.
+      9 vectors produced by pass  3 Test12= 7.50D-16 8.33D-09 XBig12= 7.23D-06 1.35D-03.
+      8 vectors produced by pass  4 Test12= 7.50D-16 8.33D-09 XBig12= 8.94D-09 3.74D-05.
+      4 vectors produced by pass  5 Test12= 7.50D-16 8.33D-09 XBig12= 5.00D-12 1.04D-06.
+      1 vectors produced by pass  6 Test12= 7.50D-16 8.33D-09 XBig12= 2.55D-15 2.03D-08.
+ InvSVY:  IOpt=1 It=  1 EMax= 2.22D-16
+ Solved reduced A of dimension    49 with     9 vectors.
+ FullF1:  Do perturbations    1 to     3.
+ Isotropic polarizability for W=    0.000000        6.91 Bohr**3.
+ End of Minotr F.D. properties file   721 does not exist.
+ End of Minotr F.D. properties file   722 does not exist.
+ End of Minotr F.D. properties file   788 does not exist.
+ Leave Link 1002 at Thu Nov 17 12:11:08 2016, MaxMem=    33554432 cpu:         0.9
+ (Enter /opt/g09-d01/g09/l601.exe)
+ Copying SCF densities to generalized density rwf, IOpCl= 0 IROHF=0.
+
+ **********************************************************************
+
+            Population analysis using the SCF density.
+
+ **********************************************************************
+
+ Orbital symmetries:
+       Occupied  (A') (A') (A') (A') (A")
+       Virtual   (A') (A') (A") (A') (A') (A') (A') (A') (A') (A")
+                 (A') (A') (A') (A") (A") (A') (A') (A')
+ The electronic state is 1-A'.
+ Alpha  occ. eigenvalues --  -19.16895  -1.02228  -0.54352  -0.39492  -0.31926
+ Alpha virt. eigenvalues --    0.02489   0.11344   0.15548   0.15557   0.20365
+ Alpha virt. eigenvalues --    0.23946   0.94700   1.03188   1.11169   1.11382
+ Alpha virt. eigenvalues --    1.14378   1.24356   1.71230   1.72086   1.75827
+ Alpha virt. eigenvalues --    2.27092   2.63639   3.67481
+          Condensed to atoms (all electrons):
+               1          2          3
+     1  O    8.472006   0.227769   0.227769
+     2  H    0.227769   0.330867  -0.022408
+     3  H    0.227769  -0.022408   0.330867
+ Mulliken charges:
+               1
+     1  O   -0.927545
+     2  H    0.463772
+     3  H    0.463772
+ Sum of Mulliken charges =   0.00000
+ Mulliken charges with hydrogens summed into heavy atoms:
+               1
+     1  O    0.000000
+ APT charges:
+               1
+     1  O   -0.576118
+     2  H    0.288059
+     3  H    0.288059
+ Sum of APT charges =   0.00000
+ APT charges with hydrogens summed into heavy atoms:
+               1
+     1  O    0.000000
+ Electronic spatial extent (au):  <R**2>=             20.2151
+ Charge=              0.0000 electrons
+ Dipole moment (field-independent basis, Debye):
+    X=              0.0000    Y=             -2.2494    Z=              0.0000  Tot=              2.2494
+ Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=             -4.3540   YY=             -6.5331   ZZ=             -7.9451
+   XY=              0.0000   XZ=              0.0000   YZ=              0.0000
+ Traceless Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=              1.9234   YY=             -0.2557   ZZ=             -1.6677
+   XY=              0.0000   XZ=              0.0000   YZ=              0.0000
+ Octapole moment (field-independent basis, Debye-Ang**2):
+  XXX=              0.0000  YYY=             -1.6505  ZZZ=              0.0000  XYY=              0.0000
+  XXY=             -1.4312  XXZ=              0.0000  XZZ=              0.0000  YZZ=             -0.4920
+  YYZ=              0.0000  XYZ=              0.0000
+ Hexadecapole moment (field-independent basis, Debye-Ang**3):
+ XXXX=             -6.4207 YYYY=             -8.1090 ZZZZ=             -7.9817 XXXY=              0.0000
+ XXXZ=              0.0000 YYYX=              0.0000 YYYZ=              0.0000 ZZZX=              0.0000
+ ZZZY=              0.0000 XXYY=             -2.1125 XXZZ=             -2.6730 YYZZ=             -2.7312
+ XXYZ=              0.0000 YYXZ=              0.0000 ZZXY=              0.0000
+ N-N= 9.081419027242D+00 E-N=-1.984305981652D+02  KE= 7.572407896604D+01
+ Symmetry A'   KE= 7.124773753490D+01
+ Symmetry A"   KE= 4.476341431139D+00
+  Exact polarizability:   7.749   0.000   6.456   0.000   0.000   6.515
+ Approx polarizability:   9.509   0.000   7.457   0.000   0.000   6.602
+ No NMR shielding tensors so no spin-rotation constants.
+ Leave Link  601 at Thu Nov 17 12:11:09 2016, MaxMem=    33554432 cpu:         0.2
+ (Enter /opt/g09-d01/g09/l701.exe)
+ Compute integral second derivatives.
+ ... and contract with generalized density number  0.
+ Leave Link  701 at Thu Nov 17 12:11:09 2016, MaxMem=    33554432 cpu:         0.2
+ (Enter /opt/g09-d01/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Thu Nov 17 12:11:09 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l703.exe)
+ Compute integral second derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=    100127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=  100127 DoSepK=F KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         0 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=         800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=  100127 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Thu Nov 17 12:11:10 2016, MaxMem=    33554432 cpu:         1.0
+ (Enter /opt/g09-d01/g09/l716.exe)
+ Dipole        = 1.80038814D-08-8.84977177D-01 2.37367968D-16
+ Polarizability= 7.74873478D+00 2.05562571D-07 6.45582419D+00
+                 1.23827388D-09 7.61998072D-11 6.51486896D+00
+ Full mass-weighted force constant matrix:
+ Low frequencies ---  -58.2948  -38.6065  -18.1970   -0.0008    0.0006    0.0007
+ Low frequencies --- 1662.8033 3736.2607 3860.5869
+ Diagonal vibrational polarizability:
+        0.0954903       0.9587349       0.0000000
+ Harmonic frequencies (cm**-1), IR intensities (KM/Mole), Raman scattering
+ activities (A**4/AMU), depolarization ratios for plane and unpolarized
+ incident light, reduced masses (AMU), force constants (mDyne/A),
+ and normal coordinates:
+                      1                      2                      3
+                     A'                     A'                     A'
+ Frequencies --   1662.8033              3736.2607              3860.5869
+ Red. masses --      1.0834                 1.0445                 1.0828
+ Frc consts  --      1.7649                 8.5907                 9.5087
+ IR Inten    --     97.3057                 6.0426                52.8850
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   8     0.00   0.07   0.00     0.00   0.05   0.00     0.07   0.00   0.00
+     2   1    -0.42  -0.56   0.00     0.59  -0.39   0.00    -0.56   0.43   0.00
+     3   1     0.42  -0.56   0.00    -0.59  -0.39   0.00    -0.56  -0.43   0.00
+
+ -------------------
+ - Thermochemistry -
+ -------------------
+ Temperature   298.150 Kelvin.  Pressure   1.00000 Atm.
+ Atom     1 has atomic number  8 and mass  15.99491
+ Atom     2 has atomic number  1 and mass   1.00783
+ Atom     3 has atomic number  1 and mass   1.00783
+ Molecular mass:    18.01056 amu.
+ Principal axes and moments of inertia in atomic units:
+                           1         2         3
+     Eigenvalues --     2.19931   4.28121   6.48052
+           X            1.00000   0.00000   0.00000
+           Y            0.00000   1.00000   0.00000
+           Z            0.00000   0.00000   1.00000
+ This molecule is an asymmetric top.
+ Rotational symmetry number  1.
+ Rotational temperatures (Kelvin)     39.38225    20.23115    13.36526
+ Rotational constants (GHZ):         820.59386   421.54936   278.48706
+ Zero-point vibrational energy      55385.0 (Joules/Mol)
+                                   13.23734 (Kcal/Mol)
+ Vibrational temperatures:   2392.40  5375.64  5554.52
+          (Kelvin)
+ 
+ Zero-point correction=                           0.021095 (Hartree/Particle)
+ Thermal correction to Energy=                    0.023930
+ Thermal correction to Enthalpy=                  0.024874
+ Thermal correction to Gibbs Free Energy=         0.002780
+ Sum of electronic and zero-point Energies=            -76.401477
+ Sum of electronic and thermal Energies=               -76.398642
+ Sum of electronic and thermal Enthalpies=             -76.397698
+ Sum of electronic and thermal Free Energies=          -76.419793
+ 
+                     E (Thermal)             CV                S
+                      KCal/Mol        Cal/Mol-Kelvin    Cal/Mol-Kelvin
+ Total                   15.016              6.004             46.502
+ Electronic               0.000              0.000              0.000
+ Translational            0.889              2.981             34.608
+ Rotational               0.889              2.981             11.888
+ Vibrational             13.239              0.042              0.006
+                       Q            Log10(Q)             Ln(Q)
+ Total Bot       0.526555D-01         -1.278556         -2.943985
+ Total V=0       0.265746D+09          8.424466         19.398051
+ Vib (Bot)       0.198207D-09         -9.702880        -22.341708
+ Vib (V=0)       0.100033D+01          0.000142          0.000328
+ Electronic      0.100000D+01          0.000000          0.000000
+ Translational   0.300432D+07          6.477746         14.915562
+ Rotational      0.884256D+02          1.946578          4.482161
+ 
+                                                               vib H2O
+                                                             IR Spectrum
+ 
+     3    3                                                                   1                                                      
+     8    7                                                                   6                                                      
+     6    3                                                                   6                                                      
+     1    6                                                                   3                                                      
+ 
+     X    X                                                                   X                                                      
+     X                                                                        X                                                      
+     X                                                                        X                                                      
+     X                                                                        X                                                      
+     X                                                                        X                                                      
+     X                                                                        X                                                      
+     X                                                                        X                                                      
+     X                                                                        X                                                      
+     X                                                                        X                                                      
+     X                                                                        X                                                      
+     X                                                                        X                                                      
+                                                                              X                                                      
+                                                                              X                                                      
+                                                                              X                                                      
+                                                                              X                                                      
+                                                                              X                                                      
+                                                                              X                                                      
+                                                                              X                                                      
+                                                                              X                                                      
+                                                                              X                                                      
+ 
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8           0.000000000   -0.000000016    0.000000009
+      2        1           0.000000009    0.000000037   -0.000000026
+      3        1          -0.000000008   -0.000000020    0.000000016
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.000000037 RMS     0.000000019
+ Force constants in Cartesian coordinates: 
+                1             2             3             4             5 
+      1  0.356872D+00
+      2 -0.747774D-01  0.518285D+00
+      3 -0.158196D+00 -0.252943D+00  0.232804D+00
+      4 -0.201832D+00 -0.153548D+00  0.200911D+00  0.190821D+00
+      5 -0.103737D+00 -0.155607D+00  0.146918D+00  0.133430D+00  0.174954D+00
+      6  0.172565D+00  0.174930D+00 -0.196541D+00 -0.183292D+00 -0.174648D+00
+      7 -0.155040D+00  0.228326D+00 -0.427151D-01  0.110119D-01 -0.296927D-01
+      8  0.178514D+00 -0.362677D+00  0.106026D+00  0.201186D-01 -0.193470D-01
+      9 -0.143692D-01  0.780136D-01 -0.362637D-01 -0.176193D-01  0.277304D-01
+                6             7             8             9 
+      6  0.202373D+00
+      7  0.107266D-01  0.144028D+00
+      8 -0.281797D-03 -0.198633D+00  0.382024D+00
+      9 -0.583237D-02  0.319885D-01 -0.105744D+00  0.420960D-01
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Force constants in internal coordinates: 
+                1             2             3 
+      1  0.518467D+00
+      2 -0.789699D-02  0.518467D+00
+      3  0.280753D-01  0.280753D-01  0.166792D+00
+ Leave Link  716 at Thu Nov 17 12:11:10 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Red2BG is reusing G-inverse.
+ Internal  Forces:  Max     0.000000040 RMS     0.000000034
+ Search for a local minimum.
+ Step number   1 out of a maximum of    2
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Second derivative matrix not updated -- analytic derivatives used.
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.51847
+           R2          -0.00790   0.51847
+           A1           0.02808   0.02808   0.16679
+ ITU=  0
+     Eigenvalues ---    0.16227   0.51510   0.52636
+ Angle between quadratic step and forces=  90.00 degrees.
+ Linear search not attempted -- first point.
+ Iteration  1 RMS(Cart)=  0.00000015 RMS(Int)=  0.00000000
+ ITry= 1 IFail=0 DXMaxC= 1.54D-07 DCOld= 1.00D+10 DXMaxT= 3.00D-01 DXLimC= 3.00D+00 Rises=F
+ ClnCor:  largest displacement from symmetrization is 1.24D-15 for atom     2.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.83101   0.00000   0.00000   0.00000   0.00000   1.83101
+    R2        1.83101   0.00000   0.00000   0.00000   0.00000   1.83101
+    A1        1.84114   0.00000   0.00000   0.00000   0.00000   1.84114
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000000     0.000015     YES
+ RMS     Force            0.000000     0.000010     YES
+ Maximum Displacement     0.000000     0.000060     YES
+ RMS     Displacement     0.000000     0.000040     YES
+ Predicted change in Energy=-6.006225D-15
+ Optimization completed.
+    -- Stationary point found.
+                           ----------------------------
+                           !   Optimized Parameters   !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  0.9689         -DE/DX =    0.0                 !
+ ! R2    R(1,3)                  0.9689         -DE/DX =    0.0                 !
+ ! A1    A(2,1,3)              105.4898         -DE/DX =    0.0                 !
+ --------------------------------------------------------------------------------
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Thu Nov 17 12:11:10 2016, MaxMem=    33554432 cpu:         0.0
+ (Enter /opt/g09-d01/g09/l9999.exe)
+ 1\1\GINC-DNAS-NODE31\Freq\RB3LYP\6-31+G(d)\H2O1\GVALLVER\17-Nov-2016\0
+ \\#P Geom=AllCheck Guess=TCheck SCRF=Check GenChk RB3LYP/6-31+G(d) Fre
+ q\\vib H2O\\0,1\O,0.1999786654,-0.0610346817,-0.0777277681\H,0.7712024
+ 465,0.4363383751,-0.6820023705\H,0.6804488881,-0.8794156935,0.11778513
+ 86\\Version=EM64L-G09RevD.01\State=1-A'\HF=-76.4225724\RMSD=6.507e-10\
+ RMSF=1.879e-08\ZeroPoint=0.021095\Thermal=0.0239301\Dipole=0.7933811,-
+ 0.2421633,-0.3083633\DipoleDeriv=-0.4818386,-0.0825772,-0.1310392,-0.0
+ 825772,-0.5694975,-0.08383,-0.1310392,-0.08383,-0.6770173,0.2309796,-0
+ .0370875,0.1157105,-0.021409,0.3287346,0.0521431,0.1067884,0.0609601,0
+ .3044625,0.2508591,0.1196647,0.0153287,0.1039862,0.2407628,0.0316869,0
+ .0242507,0.0228699,0.3725547\Polar=6.4716856,0.0764133,7.4082979,-0.01
+ 91994,-0.5513922,6.8394445\PG=CS [SG(H2O1)]\NImag=0\\0.35687194,-0.074
+ 77744,0.51828484,-0.15819594,-0.25294346,0.23280448,-0.20183243,-0.153
+ 54828,0.20091108,0.19082053,-0.10373698,-0.15560741,0.14691771,0.13342
+ 966,0.17495438,0.17256516,0.17492986,-0.19654083,-0.18329180,-0.174648
+ 06,0.20237319,-0.15503951,0.22832572,-0.04271514,0.01101189,-0.0296926
+ 9,0.01072664,0.14402761,0.17851442,-0.36267743,0.10602576,0.02011861,-
+ 0.01934697,-0.00028180,-0.19863303,0.38202440,-0.01436922,0.07801360,-
+ 0.03626365,-0.01761928,0.02773036,-0.00583237,0.03198850,-0.10574396,0
+ .04209602\\0.,0.00000002,0.,0.,-0.00000004,0.00000003,0.,0.00000002,-0
+ .00000002\\\@
+
+
+ IF NO USE IS MADE OF THE LABOR OF PAST AGES,
+ THE WORLD MUST REMAIN ALWAYS IN THE INFANCY OF KNOWLEDGE.
+
+                          -- CICERO
+ FChkPn:  Coordinates translated and rotated.
+ FChkPn:  Coordinates match /B/ after translation and rotation.
+ Job cpu time:       0 days  0 hours  0 minutes  4.5 seconds.
+ File lengths (MBytes):  RWF=      5 Int=      0 D2E=      0 Chk=      1 Scr=      1
+ Normal termination of Gaussian 09 at Thu Nov 17 12:11:10 2016.
+ Fin  execution du job  : jeu. nov. 17 12:11:10 CET 2016


### PR DESCRIPTION
## Summary

* read in hessian matrix : need #P in route line
* read IR intensity, force constant and reduce mass
* compatibility break on frequency attributes of GaussianOutput object. Frequency is still a list for each frequency calculations and for each mode. But for each mode it contains a dictionary such as :

```py
{'IR_intensity': 97.3057,
  'f_constant': 1.7649,
  'frequency': 1662.8033,
  'mode': [0.0, 0.07, 0.0, -0.42, -0.56, 0.0, 0.42, -0.56, 0.0],
  'r_mass': 1.0834,
  'symmetry': "A'"},
```