### PR TITLE
adding parse_intrans method to BoltztrapAnalyzer to obtain scissor value, etc

### DIFF
--- a/pymatgen/electronic_structure/boltztrap.py
+++ b/pymatgen/electronic_structure/boltztrap.py
@@ -1787,14 +1787,14 @@ class BoltztrapAnalyzer(object):
                 path_dir, efermi, dos_spin=dos_spin, trim_dos=False)
 
             mu_steps, cond, seebeck, kappa, hall, pn_doping_levels, mu_doping,\
-            seebeck_doping, cond_doping, kappa_doping, hall_doping, \
+            seebeck_doping, cond_doping, kappa_doping, hall_doping,\
             carrier_conc = BoltztrapAnalyzer.\
                 parse_cond_and_hall(path_dir, doping_levels)
 
             return BoltztrapAnalyzer(
                 gap, mu_steps, cond, seebeck, kappa, hall, pn_doping_levels,
                 mu_doping, seebeck_doping, cond_doping, kappa_doping,
-                hall_doping, dos, pdos, carrier_conc, vol, warning)
+                hall_doping, intrans, dos, pdos, carrier_conc, vol, warning)
 
         elif run_type == "DOS":
             dos, pdos = BoltztrapAnalyzer.parse_transdos(

--- a/pymatgen/electronic_structure/tests/test_boltztrap.py
+++ b/pymatgen/electronic_structure/tests/test_boltztrap.py
@@ -59,6 +59,7 @@ class BoltztrapAnalyzerTest(unittest.TestCase):
                                    1]/1e-23, 3.2860613, 4)
         self.assertAlmostEqual(self.bz._carrier_conc[500][67], 38.22832002)
         self.assertAlmostEqual(self.bz.vol, 612.97557323964838, 4)
+        self.assertAlmostEqual(self.bz.intrans["scissor"], 0.0, 1)
         self.assertAlmostEqual(self.bz._hall_doping['n'][700][-1][2][2][2], 5.0136483e-26)
         self.assertAlmostEqual(self.bz.dos.efermi, -0.0300005507057)
         self.assertAlmostEqual(self.bz.dos.energies[0], -2.4497049391830448, 4)


### PR DESCRIPTION
## Summary

a few things are added to BoltztrapAnalyzer:

intrans as an input: it is a dictionary of inputs with which the boltztrap had been run before; it can be obtained via parse_intrans method from boltztrap.intrans file if BoltztrapAnalyzer is called via "from_files" method.

Justification:
when I call BoltztrapAnalyzer on a bunch of files that belong to a boltztrap run, I want to know if the run was on a normal band structure that was untouched or it was on a scissored band structure. In this way, we can also differentiate later in the database between the data from these two types of results.