### PR TITLE
adding the option "gap" to mode in MPHSEBSSet.from_prev_calc

### DIFF
--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -656,12 +656,12 @@ class MPHSEBSSet(MPHSERelaxSet):
                        labels=all_labels)
 
     @classmethod
-    def from_prev_calc(cls, prev_calc_dir, mode="uniform",
+    def from_prev_calc(cls, prev_calc_dir, mode="gap",
                        reciprocal_density=50, copy_chgcar=True, **kwargs):
         """
         Generate a set of Vasp input files for HSE calculations from a
-        directory of previous Vasp run. if mode=="gap" it, explicitly adds VBM and CBM
-        of prev. run to the k-point list of this run.
+        directory of previous Vasp run. if mode=="gap", it explicitly adds VBM and CBM
+        of the prev. run to the k-point list of this run.
 
         Args:
             prev_calc_dir (str): Directory containing the outputs
@@ -688,8 +688,6 @@ class MPHSEBSSet(MPHSERelaxSet):
                 added_kpoints.append(vbm.frac_coords)
             if cbm:
                 added_kpoints.append(cbm.frac_coords)
-        elif mode.lower() == "line":
-            added_kpoints += bs.as_dict()["kpoints"]
 
         files_to_transfer = {}
         if copy_chgcar:

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -636,7 +636,7 @@ class MPHSEBSSet(MPHSERelaxSet):
             all_labels.append("user-defined")
 
         # for line mode only, add the symmetry lines w/zero weight
-        if self.mode == "Line":
+        if self.mode.lower() == "line":
             kpath = HighSymmKpath(self.structure)
             frac_k_points, labels = kpath.get_kpoints(
                 line_density=self.kpoints_line_density,
@@ -647,7 +647,7 @@ class MPHSEBSSet(MPHSERelaxSet):
                 weights.append(0.0)
                 all_labels.append(labels[k])
 
-        comment = "HSE run along symmetry lines" if self.mode == "Line" \
+        comment = "HSE run along symmetry lines" if self.mode.lower() == "line" \
             else "HSE run on uniform grid"
 
         return Kpoints(comment=comment,

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -656,17 +656,17 @@ class MPHSEBSSet(MPHSERelaxSet):
                        labels=all_labels)
 
     @classmethod
-    def from_prev_calc(cls, prev_calc_dir, mode="Uniform",
+    def from_prev_calc(cls, prev_calc_dir, mode="uniform",
                        reciprocal_density=50, copy_chgcar=True, **kwargs):
         """
         Generate a set of Vasp input files for HSE calculations from a
-        directory of previous Vasp run. Explicitly adds VBM and CBM of prev.
-        run to the k-point list of this run.
+        directory of previous Vasp run. if mode=="gap" it, explicitly adds VBM and CBM
+        of prev. run to the k-point list of this run.
 
         Args:
             prev_calc_dir (str): Directory containing the outputs
                 (vasprun.xml and OUTCAR) of previous vasp run.
-            mode (str): Either "Uniform" or "Line"
+            mode (str): Either "uniform", "gap" or "line"
             reciprocal_density (int): density of k-mesh
             copy_chgcar (bool): whether to copy CHGCAR of previous run
             \*\*kwargs: All kwargs supported by MPHSEBSStaticSet,
@@ -682,7 +682,7 @@ class MPHSEBSSet(MPHSERelaxSet):
 
         added_kpoints = []
         bs = vasprun.get_band_structure()
-        if mode.lower() == "uniform":
+        if mode.lower() == "gap":
             vbm, cbm = bs.get_vbm()["kpoint"], bs.get_cbm()["kpoint"]
             if vbm:
                 added_kpoints.append(vbm.frac_coords)

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -528,11 +528,15 @@ class MPHSEBSTest(PymatgenTest):
 
     def test_init(self):
         prev_run = os.path.join(test_dir, "static_silicon")
-        vis = MPHSEBSSet.from_prev_calc(prev_calc_dir=prev_run, mode="Uniform")
+        vis = MPHSEBSSet.from_prev_calc(prev_calc_dir=prev_run, mode="uniform")
+        self.assertTrue(vis.incar["LHFCALC"])
+        self.assertEqual(len(vis.kpoints.kpts), 29)
+
+        vis = MPHSEBSSet.from_prev_calc(prev_calc_dir=prev_run, mode="gap")
         self.assertTrue(vis.incar["LHFCALC"])
         self.assertEqual(len(vis.kpoints.kpts), 31)
 
-        vis = MPHSEBSSet.from_prev_calc(prev_calc_dir=prev_run, mode="Line")
+        vis = MPHSEBSSet.from_prev_calc(prev_calc_dir=prev_run, mode="line")
         self.assertTrue(vis.incar["LHFCALC"])
         self.assertEqual(vis.incar['HFSCREEN'], 0.2)
         self.assertEqual(vis.incar['NSW'], 0)

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -541,7 +541,7 @@ class MPHSEBSTest(PymatgenTest):
         self.assertEqual(vis.incar['HFSCREEN'], 0.2)
         self.assertEqual(vis.incar['NSW'], 0)
         self.assertEqual(vis.incar['ISYM'], 3)
-        self.assertEqual(len(vis.kpoints.kpts), 203)
+        self.assertEqual(len(vis.kpoints.kpts), 193)
 
 
 class FuncTest(PymatgenTest):


### PR DESCRIPTION
## Summary

adding the option "gap" to the argument mode in MPHSEBSSet to distinguish between "uniform" and "gap" modes when ran from previous calculations. Also a test was added for the "gap" mode. Sometimes we want just to run the uniform k-points and don't need the CBM and VBM but the previous implementation didn't allow that.