### PR TITLE
Bug fixes for Interstitial creation with  no valence dictionary

### DIFF
--- a/pymatgen/analysis/defects/point_defects.py
+++ b/pymatgen/analysis/defects/point_defects.py
@@ -688,9 +688,10 @@ class Interstitial(Defect):
         coord_sites = filter(no_inter, coord_sites)
 
         coord_chrg = 0
-        for site, weight in coord_finder.get_voronoi_polyhedra(-1).items():
-            if not site.specie.symbol == 'X':
-                coord_chrg += weight * self._valence_dict.get(site.species_string, 0)
+        if self._valence_dict:
+            for site, weight in coord_finder.get_voronoi_polyhedra(-1).items():
+                if not site.specie.symbol == 'X':
+                    coord_chrg += weight * self._valence_dict.get[site.species_string]
 
         return coord_no, coord_sites, coord_chrg
 


### PR DESCRIPTION
## Summary

<When interstitial is created with no valences dictionary, ignore charge assignment>

* When interstitial is created with no valences dictionary, ignore charge assignment

## Additional dependencies introduced (if any)

## TODO (if any)

<Merge the Zeo++ python 3 changes and debug spglib errors>

