### PR TITLE
add BSDOS plotter

### DIFF
--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -10,10 +10,6 @@ import warnings
 from collections import OrderedDict
 
 import numpy as np
-from matplotlib.collections import LineCollection
-import matplotlib.lines as mlines
-from matplotlib.gridspec import GridSpec
-import matplotlib.pyplot as mplt
 
 from monty.json import jsanitize
 
@@ -1027,6 +1023,9 @@ class BSDOSPlotter():
             a matplotlib plt object on which you can call commands like show() and savefig()
 
         """
+        import matplotlib.lines as mlines
+        from matplotlib.gridspec import GridSpec
+        import matplotlib.pyplot as mplt
 
         # make sure the user-specified band structure projection is valid
         elements = [e.symbol for e in dos.structure.composition.elements]
@@ -1237,6 +1236,8 @@ class BSDOSPlotter():
             alpha: alpha values data
             linestyles: linestyle for plot (e.g., "solid" or "dotted")
         """
+        from matplotlib.collections import LineCollection
+
         pts = np.array([k, e]).T.reshape(-1, 1, 2)
         seg = np.concatenate([pts[:-1], pts[1:]], axis=1)
 

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -1019,7 +1019,7 @@ class BSDOSPlotter():
         Get a matplotlib plot object.
         Args:
             bs (BandStructure): the bandstructure to plot. Projection data must exist for projected plots.
-            dos (Dos): the bandstructure to plot. Projection data must exist (i.e., CompleteDos) for projected plots.
+            dos (Dos): the Dos to plot. Projection data must exist (i.e., CompleteDos) for projected plots.
 
         Returns:
             a matplotlib plt object on which you can call commands like show() and savefig()

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -980,9 +980,10 @@ class BSDOSPlotter():
     """
 
     def __init__(self, bs_projection="elements", dos_projection="elements",
-                 vb_energy_range=4, cb_energy_range=4, egrid_interval=1,
-                 font="Times New Roman", axis_fontsize=20, tick_fontsize=15,
-                 legend_fontsize=14, bs_legend="best", dos_legend="best"):
+                 vb_energy_range=4, cb_energy_range=4, fixed_cb_energy=False,
+                 egrid_interval=1, font="Times New Roman", axis_fontsize=20,
+                 tick_fontsize=15, legend_fontsize=14, bs_legend="best",
+                 dos_legend="best"):
 
         """
         Instantiate plotter settings.
@@ -992,6 +993,8 @@ class BSDOSPlotter():
             dos_projection (str): "elements", "orbitals", or None
             vb_energy_range (float): energy in eV to show of valence bands
             cb_energy_range (float): energy in eV to show of conduction bands
+            fixed_cb_energy (bool): If true, the cb_energy_range will be interpreted
+                as constant (i.e., no gap correction for cb energy)
             egrid_interval (float): interval for grid marks
             font (str): font family
             axis_fontsize (float): font size for axis
@@ -1004,6 +1007,7 @@ class BSDOSPlotter():
         self.dos_projection = dos_projection
         self.vb_energy_range = vb_energy_range
         self.cb_energy_range = cb_energy_range
+        self.fixed_cb_energy = fixed_cb_energy
         self.egrid_interval = egrid_interval
         self.font = font
         self.axis_fontsize = axis_fontsize
@@ -1040,7 +1044,8 @@ class BSDOSPlotter():
 
         # specify energy range of plot
         emin = -self.vb_energy_range
-        emax = bs.get_band_gap()["energy"] + self.cb_energy_range
+        emax = self.cb_energy_range if self.fixed_cb_energy else \
+            self.cb_energy_range + bs.get_band_gap()["energy"]
 
         # initialize all the k-point labels and k-point x-distances for bs plot
         xlabels = []  # all symmetry point labels on x-axis
@@ -1102,10 +1107,10 @@ class BSDOSPlotter():
 
         # add BS fermi level line at E=0 and gridlines
         bs_ax.hlines(y=0, xmin=0, xmax=x_distances[-1], color="k", lw=2)
-        bs_ax.set_yticks(np.arange(emin, emax, self.egrid_interval))
-        bs_ax.set_yticklabels(np.arange(emin, emax, self.egrid_interval),
+        bs_ax.set_yticks(np.arange(emin, emax+1E-5, self.egrid_interval))
+        bs_ax.set_yticklabels(np.arange(emin, emax+1E-5, self.egrid_interval),
                               size=self.tick_fontsize)
-        dos_ax.set_yticks(np.arange(emin, emax, self.egrid_interval))
+        dos_ax.set_yticks(np.arange(emin, emax+1E-5, self.egrid_interval))
         bs_ax.grid(color=[0.5, 0.5, 0.5], linestyle='dotted', linewidth=1)
         dos_ax.set_yticklabels([])
         dos_ax.grid(color=[0.5, 0.5, 0.5], linestyle='dotted', linewidth=1)

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -1184,9 +1184,11 @@ class BSDOSPlotter():
 
         # determine DOS x-axis range
         dos_xmin = 0 if Spin.down not in dos.densities else -max(
-            dos.densities[Spin.down][emin_idx:emax_idx] * 1.05)
+            dos.densities[Spin.down][emin_idx:emax_idx+1] * 1.05)
         dos_xmax = max([max(dos.densities[Spin.up][emin_idx:emax_idx]) *
                         1.05, abs(dos_xmin)])
+
+        print(dos_xmin)
 
         # set up the DOS x-axis and add Fermi level line
         dos_ax.set_xlim(dos_xmin, dos_xmax)

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -31,7 +31,7 @@ from pymatgen.symmetry.bandstructure import HighSymmKpath
 This module implements plotter for DOS and band structure.
 """
 
-__author__ = "Shyue Ping Ong, Geoffroy Hautier"
+__author__ = "Shyue Ping Ong, Geoffroy Hautier, Anubhav Jain"
 __copyright__ = "Copyright 2012, The Materials Project"
 __version__ = "0.1"
 __maintainer__ = "Shyue Ping Ong"

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -1054,9 +1054,9 @@ class BSDOSPlotter():
             left_k, right_k = l["name"].split("-")
 
             # add $ notation for LaTeX kpoint labels
-            if left_k[0] == "\\":
+            if left_k[0] == "\\" or "_" in left_k:
                 left_k = "$"+left_k+"$"
-            if right_k[0] == "\\":
+            if right_k[0] == "\\" or "_" in right_k:
                 right_k = "$"+right_k+"$"
 
             # add left k label to list of labels

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -985,8 +985,8 @@ class BSDOSPlotter():
 
     def __init__(self, bs_projection="elements", dos_projection="elements",
                  vb_energy_range=4, cb_energy_range=4, egrid_interval=1,
-                 font="Times New Roman", axis_fontsize=20, legend_fontsize=13,
-                 bs_legend="best", dos_legend="best"):
+                 font="Times New Roman", axis_fontsize=20, tick_fontsize=15,
+                 legend_fontsize=14, bs_legend="best", dos_legend="best"):
 
         """
         Instantiate plotter settings.
@@ -999,6 +999,7 @@ class BSDOSPlotter():
             egrid_interval (float): interval for grid marks
             font (str): font family
             axis_fontsize (float): font size for axis
+            tick_fontsize (float): font size for axis tick labels
             legend_fontsize (float): font size for legends
             bs_legend (str): matplotlib string location for legend or None
             dos_legend (str): matplotlib string location for legend or None
@@ -1010,6 +1011,7 @@ class BSDOSPlotter():
         self.egrid_interval = egrid_interval
         self.font = font
         self.axis_fontsize = axis_fontsize
+        self.tick_fontsize = tick_fontsize
         self.legend_fontsize = legend_fontsize
         self.bs_legend = bs_legend
         self.dos_legend = dos_legend
@@ -1095,13 +1097,15 @@ class BSDOSPlotter():
 
         # add BS xticks, labels, etc.
         bs_ax.set_xticks(xlabel_distances)
-        bs_ax.set_xticklabels(xlabels)
+        bs_ax.set_xticklabels(xlabels, size=self.tick_fontsize)
         bs_ax.set_xlabel('Wavevector $k$', fontsize=self.axis_fontsize, family=self.font)
         bs_ax.set_ylabel('$E-E_F$ / eV', fontsize=self.axis_fontsize, family=self.font)
 
         # add BS fermi level line at E=0 and gridlines
         bs_ax.hlines(y=0, xmin=0, xmax=x_distances[-1], color="k", lw=2)
         bs_ax.set_yticks(np.arange(emin, emax, self.egrid_interval))
+        bs_ax.set_yticklabels(np.arange(emin, emax, self.egrid_interval),
+                              size=self.tick_fontsize)
         dos_ax.set_yticks(np.arange(emin, emax, self.egrid_interval))
         bs_ax.grid(color=[0.5, 0.5, 0.5], linestyle='dotted', linewidth=1)
         dos_ax.set_yticklabels([])

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -1188,8 +1188,6 @@ class BSDOSPlotter():
         dos_xmax = max([max(dos.densities[Spin.up][emin_idx:emax_idx]) *
                         1.05, abs(dos_xmin)])
 
-        print(dos_xmin)
-
         # set up the DOS x-axis and add Fermi level line
         dos_ax.set_xlim(dos_xmin, dos_xmax)
         dos_ax.set_xticklabels([])


### PR DESCRIPTION
## Summary

A new band structure plotter that puts band structure and DOS on the same plot, aligned.

* Band structures include spin polarization
* Element projections on band structures supported
* Element and orbital projections on DOS supported
* Code is relatively straightforward to use, understand and modify as needed

## Additional dependencies introduced (if any)

None

## TODO (if any)

Things that could be done:
- support element projections for band structures with 4 or more elements (only 3 of those elements would actually be projected, the remaining elements ignored)
- support element+orbital projections for band structures

## Example images

![example1](https://cloud.githubusercontent.com/assets/986759/21196895/4adcefdc-c1ee-11e6-8271-3e80111f2db6.png)

![example2](https://cloud.githubusercontent.com/assets/986759/21196898/4e149db2-c1ee-11e6-86e6-9630b9972f47.png)

