### PR TITLE
small update of boltztrap.py

### DIFF
--- a/pymatgen/electronic_structure/boltztrap.py
+++ b/pymatgen/electronic_structure/boltztrap.py
@@ -535,6 +535,8 @@ class BoltztrapRunner(object):
 
         if self.run_type in ("BANDS", "DOS", "FERMI"):
             convergence = False
+            if self.lpfac > max_lpfac:
+                max_lpfac = self.lpfac 
 
         if self.run_type == "BANDS" and self.bs.is_spin_polarized:
             print("Reminder: for run_type " + str(

--- a/pymatgen/electronic_structure/boltztrap.py
+++ b/pymatgen/electronic_structure/boltztrap.py
@@ -122,9 +122,9 @@ class BoltztrapRunner(object):
                 shape. This is useful to correct the often underestimated band
                 gap in DFT. Default is 0.0 (no scissor)
             kpt_line:
-                list/array of kpoints in fractional coordinates for BANDS mode
-                calculation (standard path of high symmetry k-points is
-                automatically set as default)
+                list/array of kpoints in fractional coordinates or list of 
+                Kpoint objects for BANDS mode calculation (standard path of 
+                high symmetry k-points is automatically set as default)
             tmax:
                 Maximum temperature (K) for calculation (default=1300)
             tgrid:
@@ -457,10 +457,9 @@ class BoltztrapRunner(object):
                                  in
                                  kpath.get_kpoints(coords_are_cartesian=False)[
                                      0]]
-                self.kpt_line = np.array(
-                    [kp.frac_coords for kp in self.kpt_line])
-            else:
-                 self.kpt_line = [kp.frac_coords for kp in self.kpt_line]
+                self.kpt_line = [kp.frac_coords for kp in self.kpt_line]
+            elif type(self.kpt_line[0]) == Kpoint:
+                self.kpt_line = [kp.frac_coords for kp in self.kpt_line]
 
             with open(output_file, 'w') as fout:
                 fout.write("GENE          # use generic interface\n")

--- a/pymatgen/electronic_structure/boltztrap.py
+++ b/pymatgen/electronic_structure/boltztrap.py
@@ -220,7 +220,7 @@ class BoltztrapRunner(object):
             f.write("{}\n".format(len(self._bs.kpoints)))
 
             if self.run_type == "FERMI":
-                sign = 1.0 if self.cond_band else -1.0
+                sign = -1.0 if self.cond_band else 1.0
                 for i in range(len(self._bs.kpoints)):
                     eigs = []
                     eigs.append(Energy(
@@ -317,11 +317,11 @@ class BoltztrapRunner(object):
     def write_proj(self, output_file_proj, output_file_def):
         # This function is useless in std version of BoltzTraP code
         # because x_trans script overwrite BoltzTraP.def
-        for o in Orbital:
+        for oi,o in enumerate(Orbital):
             for site_nb in range(0, len(self._bs.structure.sites)):
-                if o in self._bs._projections[Spin.up][0][0]:
+                if oi < len(self._bs.projections[Spin.up][0][0]):
                     with open(output_file_proj + "_" + str(site_nb) + "_" + str(o),
-                              'w') as f:
+                                'w') as f:
                         f.write(self._bs.structure.composition.formula + "\n")
                         f.write(str(len(self._bs.kpoints)) + "\n")
                         for i in range(len(self._bs.kpoints)):
@@ -329,8 +329,8 @@ class BoltztrapRunner(object):
                             for j in range(
                                     int(math.floor(self._bs.nb_bands * 0.9))):
                                 tmp_proj.append(
-                                    self._bs._projections[Spin(self.spin)][j][
-                                        i][o][site_nb])
+                                    self._bs.projections[Spin(self.spin)][j][
+                                        i][oi][site_nb])
                             # TODO deal with the sorting going on at
                             # the energy level!!!
                             # tmp_proj.sort()
@@ -342,9 +342,9 @@ class BoltztrapRunner(object):
 
                             f.write("%12.8f %12.8f %12.8f %d\n"
                                     % (self._bs.kpoints[i].frac_coords[0],
-                                       self._bs.kpoints[i].frac_coords[1],
-                                       self._bs.kpoints[i].frac_coords[2],
-                                       len(tmp_proj)))
+                                        self._bs.kpoints[i].frac_coords[1],
+                                        self._bs.kpoints[i].frac_coords[2],
+                                        len(tmp_proj)))
                             for j in range(len(tmp_proj)):
                                 f.write("%18.8f\n" % float(tmp_proj[j]))
         with open(output_file_def, 'w') as f:
@@ -374,9 +374,9 @@ class BoltztrapRunner(object):
                     "30,'boltztrap_BZ.cube',           'unknown',    "
                     "'formatted',0\n")
             i = 1000
-            for o in Orbital:
+            for oi,o in enumerate(Orbital):
                 for site_nb in range(0, len(self._bs.structure.sites)):
-                    if o in self._bs._projections[Spin.up][0][0]:
+                    if oi < len(self._bs.projections[Spin.up][0][0]):
                         f.write(str(i) + ",\'" + "boltztrap.proj_" + str(
                             site_nb) + "_" + str(o.name) +
                                 "\' \'old\', \'formatted\',0\n")
@@ -601,7 +601,10 @@ class BoltztrapRunner(object):
                             if "WARNING" in l:
                                 warning = l
                                 break
-
+                            if "Error - Fermi level was not found" in l:
+                                warning = l
+                                break
+                            
                     if not warning and convergence:
                         # check convergence for warning
                         analyzer = BoltztrapAnalyzer.from_files(path_dir)
@@ -844,37 +847,69 @@ class BoltztrapAnalyzer(object):
                 "be run with run_type=BANDS")
 
     @staticmethod
-    def check_acc_bzt_bands(sbs_bz, sbs_ref):
+    def check_acc_bzt_bands(sbs_bz, sbs_ref, warn_thr=(0.03,0.03)):
         """
             Compare sbs_bz BandStructureSymmLine calculated with boltztrap with
             the sbs_ref BandStructureSymmLine as reference (from MP for
-            instance), using correlation.
-            See compare_sym_bands function doc
-            Return a list of correlation values of the eigth bands with index
-            that ranges from vbm_idx-3 to cbm_idx +3
-            Return also two list of sum of relative errors for each branch of
-            vbm and cbm and a boolean variable to signal the presence of not
-            accurate bands around the gap. warn_thr is a threshold to get a
-            warning in the accuracy of Boltztap interpolated bands.
+            instance), computing correlation and energy difference for eight bands
+            around the gap (semiconductors) or fermi level (metals).
+            warn_thr is a threshold to get a warning in the accuracy of Boltztap
+            interpolated bands.
+            Return a dictionary with these keys:
+            - "N": the index of the band compared; inside each there are:
+                - "Corr": correlation coefficient for the 8 compared bands
+                - "Dist": energy distance for the 8 compared bands
+                - "branch_name": energy distance for that branch
+            - "avg_corr": average of correlation coefficient over the 8 bands
+            - "avg_dist": average of energy distance over the 8 bands
+            - "nb_list": list of indexes of the 8 compared bands
+            - "acc_thr": list of two float corresponing to the two warning 
+                         thresholds in input
+            - "acc_err": list of two bools: 
+                         True if the avg_corr > warn_thr[0], and
+                         True if the avg_dist > warn_thr[1]
+            See also compare_sym_bands function doc
         """
-        if not sbs_ref.is_metal():
-            vbm_idx = sbs_ref.get_vbm()['band_index'][Spin.up][-1]
-            cbm_idx = sbs_ref.get_cbm()['band_index'][Spin.up][0]
-            corr, werr_vbm = compare_sym_bands(sbs_bz, sbs_ref, vbm_idx)
-            corr, werr_cbm = compare_sym_bands(sbs_bz, sbs_ref, cbm_idx)
-
-            acc_err = False
-            warn_thr = 0.01
-            if any(corr[vbm_idx - 3:vbm_idx + 1] > warn_thr) or any(
-                            corr[cbm_idx:cbm_idx + 4] > warn_thr):
-                print("Warning! some bands around gap are not accurate")
-                acc_err = True
-
-            return corr, werr_vbm, werr_cbm, acc_err
+        if not sbs_ref.is_metal() and not sbs_bz.is_metal():
+            vbm_idx = sbs_bz.get_vbm()['band_index'][Spin.up][-1]
+            cbm_idx = sbs_bz.get_cbm()['band_index'][Spin.up][0]
+            nb_list = range(vbm_idx-3,cbm_idx+4)
 
         else:
-            raise BoltztrapError(
-                "band check implemented only for bandstructure with gap")
+            bnd_around_efermi=[]
+            delta=0
+            spin=sbs_bz.bands.keys()[0]
+            while len(bnd_around_efermi)<8:
+                delta+=0.1
+                bnd_around_efermi=[]
+                for nb in range(len(sbs_bz.bands[spin])):
+                    for kp in range(len(sbs_bz.bands[spin][nb])):
+                        if abs(sbs_bz.bands[spin][nb][kp]-sbs_bz.efermi)<delta:
+                            bnd_around_efermi.append(nb)
+                            break
+            nb_list = bnd_around_efermi[:8]
+        
+        #print(nb_list)
+        bcheck = compare_sym_bands(sbs_bz, sbs_ref, nb_list)
+        #print(bcheck)
+        acc_err = [False,False]
+        avg_corr = sum([item[1]['Corr'] for item in bcheck.iteritems()])/8
+        avg_distance = sum([item[1]['Dist'] for item in bcheck.iteritems()])/8
+        
+        if avg_corr > warn_thr[0]: acc_err[0] = True
+        if avg_distance > warn_thr[0]: acc_err[1] = True
+        
+        bcheck['avg_corr'] = avg_corr
+        bcheck['avg_distance'] = avg_distance
+        bcheck['acc_err'] = acc_err
+        bcheck['acc_thr'] = warn_thr
+        bcheck['nb_list'] = nb_list
+        
+        if True in acc_err:
+            print("Warning! some bands around gap are not accurate")
+            
+        return bcheck
+
 
     def get_seebeck(self, output='eigs', doping_levels=True):
         """
@@ -1015,7 +1050,7 @@ class BoltztrapAnalyzer(object):
                                                    multi=1e6 * relaxation_time)
 
     def get_thermal_conductivity(self, output='eigs', doping_levels=True,
-                                 relaxation_time=1e-14):
+                                 k_el=True, relaxation_time=1e-14):
         """
         Gives the electronic part of the thermal conductivity in either a
         full 3x3 tensor form,
@@ -1032,6 +1067,7 @@ class BoltztrapAnalyzer(object):
             doping_levels (boolean): True for the results to be given at
             different doping levels, False for results
             at different electron chemical potentials
+            k_el (boolean): True for k_0-PF*T, False for k_0
             relaxation_time (float): constant relaxation time in secs
 
         Returns:
@@ -1057,24 +1093,26 @@ class BoltztrapAnalyzer(object):
             for doping in result_doping:
                 for t in result_doping[doping]:
                     for i in range(len(self.doping[doping])):
-                        pf_tensor = np.dot(self._cond_doping[doping][t][i],
-                                           np.dot(
-                                               self._seebeck_doping[doping][t][
-                                                   i],
-                                               self._seebeck_doping[doping][t][
-                                                   i]))
-                        result_doping[doping][t].append((self._kappa_doping[
-                                                                doping][t][
-                                                                i] -
-                                                         pf_tensor * t))
+                        if k_el:
+                            pf_tensor = np.dot(self._cond_doping[doping][t][i],
+                                        np.dot(self._seebeck_doping[doping][t][i],
+                                            self._seebeck_doping[doping][t][i]))
+                            result_doping[doping][t].append((
+                                self._kappa_doping[doping][t][i] - pf_tensor * t))
+                        else:
+                            result_doping[doping][t].append((
+                                self._kappa_doping[doping][t][i]))
         else:
             result = {t: [] for t in self._seebeck}
             for t in result:
                 for i in range(len(self.mu_steps)):
-                    pf_tensor = np.dot(self._cond[t][i],
+                    if k_el:
+                        pf_tensor = np.dot(self._cond[t][i],
                                        np.dot(self._seebeck[t][i],
                                               self._seebeck[t][i]))
-                    result[t].append((self._kappa[t][i] - pf_tensor * t))
+                        result[t].append((self._kappa[t][i] - pf_tensor * t))
+                    else:
+                        result[t].append((self._kappa[t][i]))
 
         return BoltztrapAnalyzer._format_to_output(result, result_doping,
                                                    output, doping_levels,
@@ -1964,18 +2002,38 @@ def compare_sym_bands(bands_obj, bands_ref_obj, nb=None):
         [distance.correlation(arr_bands[idx], arr_bands_ref[idx]) for idx in
          range(nbands)])
 
-    if type(nb) == int and nb < nbands:
+    if type(nb) == int: nb = [nb]
+    
+    bcheck={}
+    
+    if max(nb) < nbands:
         branches = [[s['start_index'], s['end_index'], s['name']] for s in
-                    bands_ref_obj._branches]
-        werr = {}
-        for start, end, name in branches:
-            # werr.append((sum((arr_bands_corr[nb][start:end+1] -
-            # arr_bands_ref_corr[nb][start:end+1])**2)/(end+1-start)*100,name))
-            werr[name] = np.sum(abs(
-                arr_bands[nb][start:end + 1] - arr_bands_ref[nb][
-                                               start:end + 1]) / abs(
-                arr_bands_ref[nb][start:end + 1])) / (end + 1 - start) * 100
+                    bands_ref_obj.branches]
+        
+        if not bands_obj.is_metal() and not bands_ref_obj.is_metal():
+            zero_ref = bands_ref_obj.get_vbm()['energy']
+            zero = bands_obj.get_vbm()['energy']
+            if not zero:
+                vbm = bands_ref_obj.get_vbm()['band_index'][Spin.up][-1]
+                zero = max(arr_bands[vbm])
+        else:
+            zero_ref = 0#bands_ref_obj.efermi
+            zero = 0#bands_obj.efermi
+            print(zero,zero_ref)
+            
+        for nbi in nb:
+            bcheck[nbi]={}
+            
+            bcheck[nbi]['Dist'] = np.mean(abs(arr_bands[nbi] - zero - arr_bands_ref[nbi] + zero_ref))
+            bcheck[nbi]['Corr'] = corr[nbi]
+            
+            for start, end, name in branches:
+                # werr.append((sum((arr_bands_corr[nb][start:end+1] -
+                # arr_bands_ref_corr[nb][start:end+1])**2)/(end+1-start)*100,name))
+                bcheck[nbi][name] = np.mean(abs(arr_bands[nbi][start:end + 1] - zero -
+                                        arr_bands_ref[nbi][start:end + 1] + zero_ref))
+    #                                abs(arr_bands_ref[nb][start:end + 1])) / (end + 1 - start) * 100
     else:
-        werr = "No nb given"
+        bcheck = "No nb given"
 
-    return corr, werr
+    return bcheck

--- a/pymatgen/electronic_structure/boltztrap.py
+++ b/pymatgen/electronic_structure/boltztrap.py
@@ -804,9 +804,9 @@ class BoltztrapAnalyzer(object):
                             kpath.get_kpoints(coords_are_cartesian=False)[0]]
                 labels_dict = {l: k for k, l in zip(
                     *kpath.get_kpoints(coords_are_cartesian=False)) if l}
-                kpoints = [kp.frac_coords for kp in kpt_line]
-            else:
-                kpoints = [kp.frac_coords for kp in kpt_line]
+                kpt_line = [kp.frac_coords for kp in kpt_line]
+            elif type(kpt_line[0]) == Kpoint:
+                kpt_line = [kp.frac_coords for kp in kpt_line]
                 labels_dict = {k: labels_dict[k].frac_coords for k in
                                labels_dict}
 
@@ -817,7 +817,7 @@ class BoltztrapAnalyzer(object):
                 prec = 1e-05
                 while len(w) == 0:
                     w = np.where(np.all(
-                        np.abs(kp.frac_coords - self._bz_kpoints) < [prec] * 3,
+                        np.abs(kp - self._bz_kpoints) < [prec] * 3,
                         axis=1))[0]
                     prec *= 10
 
@@ -838,7 +838,7 @@ class BoltztrapAnalyzer(object):
                 "eV") + efermi).T[:, idx_list[:, 1]].tolist()}
             # bz_kpoints = bz_kpoints[idx_list[:,1]].tolist()
 
-            sbs = BandStructureSymmLine(kpoints, bands_dict,
+            sbs = BandStructureSymmLine(kpt_line, bands_dict,
                                         structure.lattice.reciprocal_lattice, efermi,
                                         labels_dict=labels_dict)
 

--- a/pymatgen/electronic_structure/boltztrap.py
+++ b/pymatgen/electronic_structure/boltztrap.py
@@ -459,6 +459,8 @@ class BoltztrapRunner(object):
                                      0]]
                 self.kpt_line = np.array(
                     [kp.frac_coords for kp in self.kpt_line])
+            else:
+                 self.kpt_line = [kp.frac_coords for kp in self.kpt_line]
 
             with open(output_file, 'w') as fout:
                 fout.write("GENE          # use generic interface\n")

--- a/pymatgen/electronic_structure/boltztrap.py
+++ b/pymatgen/electronic_structure/boltztrap.py
@@ -122,7 +122,7 @@ class BoltztrapRunner(object):
                 shape. This is useful to correct the often underestimated band
                 gap in DFT. Default is 0.0 (no scissor)
             kpt_line:
-                list/array of kpoints in fractional coordinates or list of 
+                list of fractional coordinates of kpoints as arrays or list of
                 Kpoint objects for BANDS mode calculation (standard path of 
                 high symmetry k-points is automatically set as default)
             tmax:

--- a/pymatgen/electronic_structure/tests/test_boltztrap.py
+++ b/pymatgen/electronic_structure/tests/test_boltztrap.py
@@ -114,6 +114,8 @@ class BoltztrapAnalyzerTest(unittest.TestCase):
                                8.08066254813)
         self.assertAlmostEqual(self.bz.get_thermal_conductivity(output='average', doping_levels=False)[200][32],  # TODO: this was originally "eigs"
                                0.0738961845832)
+        self.assertAlmostEqual(self.bz.get_thermal_conductivity(k_el=False,output='average', doping_levels=False)[200][32], 
+                               0.19429052)
 
     def test_get_zt(self):
         ref = [0.097408810215, 0.29335112354, 0.614673998089]
@@ -157,10 +159,15 @@ class BoltztrapAnalyzerTest(unittest.TestCase):
     
     def test_get_symm_bands(self):
         structure = loadfn(os.path.join(test_dir,'boltztrap/structure_mp-12103.json'))
-        sbs_bzt = self.bz_bands.get_symm_bands(structure,-5.25204548)
-        self.assertAlmostEqual(len(sbs_bzt.bands[Spin.up]),20)
-        self.assertAlmostEqual(len(sbs_bzt.bands[Spin.up][1]),143)
-
+        sbs = loadfn(os.path.join(test_dir,'boltztrap/dft_bs_sym_line.json'))
+        kpoints = [kp.frac_coords for kp in sbs.kpoints]
+        labels_dict = {k: sbs.labels_dict[k].frac_coords for k in sbs.labels_dict}
+        for kpt_line,labels_dict in zip([None,sbs.kpoints,kpoints],[None,sbs.labels_dict,labels_dict]):
+            print(kpt_line)
+            sbs_bzt = self.bz_bands.get_symm_bands(structure,-5.25204548,kpt_line=kpt_line,labels_dict=labels_dict)
+            self.assertAlmostEqual(len(sbs_bzt.bands[Spin.up]),20)
+            self.assertAlmostEqual(len(sbs_bzt.bands[Spin.up][1]),143)
+        
     # def test_check_acc_bzt_bands(self):
     #     structure = loadfn(os.path.join(test_dir,'boltztrap/structure_mp-12103.json'))
     #     sbs = loadfn(os.path.join(test_dir,'boltztrap/dft_bs_sym_line.json'))


### PR DESCRIPTION
## Summary
- bands check works for metals
- update the write_proj function to use properly the Orbital enum and new projections format
- added the k_el option to the get_thermal_conductivity function 
(k_el = True  is the default output k_0 -PF*T, as before. If False k_0 is returned)
- fixed a bug in the FERMI mode
- included a check of ERROR msg in the boltztrap output inside the convergence loop of BoltztrapRunner
- fix kpt_line option for bands mode. Now it works  for both a list of fractional coords as arrays or a list of Kpoint objects.
- fix case lpfac > max_lpfac in case of convergence=False (fermi,bands,dos cases)