### PR TITLE
Minor elastic fix

### DIFF
--- a/pymatgen/analysis/elasticity/__init__.py
+++ b/pymatgen/analysis/elasticity/__init__.py
@@ -4,7 +4,7 @@
 
 import numpy as np
 
-voigt_map = [(0, 0), (1, 1), (2, 2), (1, 2), (0, 2), (0, 1)]
-reverse_voigt_map = np.array([[0, 5, 4],
-                              [5, 1, 3],
-                              [4, 3, 2]])
+from .elastic import *
+from .tensors import *
+from .stress import *
+from .strain import *

--- a/pymatgen/analysis/elasticity/elastic.py
+++ b/pymatgen/analysis/elasticity/elastic.py
@@ -11,8 +11,8 @@ including methods used to fit the elastic tensor from linear response
 stress-strain data
 """
 
-from pymatgen.analysis.elasticity import voigt_map as vmap
-from pymatgen.analysis.elasticity.tensors import TensorBase
+from pymatgen.analysis.elasticity.tensors import TensorBase, \
+        voigt_map as vmap, reverse_voigt_map
 from pymatgen.analysis.elasticity.stress import Stress
 from pymatgen.analysis.elasticity.strain import Strain
 import numpy as np

--- a/pymatgen/analysis/elasticity/strain.py
+++ b/pymatgen/analysis/elasticity/strain.py
@@ -323,7 +323,7 @@ class IndependentStrain(Strain):
     def j(self):
         return self._j
 
-def convert_strain_to_deformation(strain):
+def convert_strain_to_deformation(strain, tol=1e-5):
     strain = SquareTensor(strain)
     ftdotf = 2*strain + np.eye(3)
     eigs, eigvecs = np.linalg.eig(ftdotf)
@@ -331,4 +331,8 @@ def convert_strain_to_deformation(strain):
     rotated = rotated.round(14)
     defo = Deformation(np.sqrt(rotated))
     result = defo.rotate(eigvecs)
+    rd = np.abs(strain - 0.5*(np.dot(np.transpose(result),result) - np.eye(3)))
+    assert (rd < tol).all(), "Strain-generated deformation is not valid!"
     return result
+
+

--- a/pymatgen/analysis/elasticity/strain.py
+++ b/pymatgen/analysis/elasticity/strain.py
@@ -12,9 +12,8 @@ generating deformed structure sets for further calculations.
 """
 
 from pymatgen.core.lattice import Lattice
-from pymatgen.analysis.elasticity.tensors import SquareTensor
+from pymatgen.analysis.elasticity.tensors import SquareTensor, voigt_map
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
-from pymatgen.analysis.elasticity import voigt_map
 import warnings
 import numpy as np
 from six.moves import zip

--- a/pymatgen/analysis/elasticity/stress.py
+++ b/pymatgen/analysis/elasticity/stress.py
@@ -10,8 +10,7 @@ This module provides the Stress class used to create, manipulate, and
 calculate relevant properties of the stress tensor.
 """
 
-from pymatgen.analysis.elasticity import voigt_map
-from pymatgen.analysis.elasticity.tensors import SquareTensor
+from pymatgen.analysis.elasticity.tensors import SquareTensor, voigt_map
 import math
 import numpy as np
 import warnings

--- a/pymatgen/analysis/elasticity/tensors.py
+++ b/pymatgen/analysis/elasticity/tensors.py
@@ -32,7 +32,11 @@ from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.core.operations import SymmOp
 from pymatgen.core.lattice import Lattice
 from numpy.linalg import norm
-from pymatgen.analysis.elasticity import reverse_voigt_map
+
+voigt_map = [(0, 0), (1, 1), (2, 2), (1, 2), (0, 2), (0, 1)]
+reverse_voigt_map = np.array([[0, 5, 4],
+                              [5, 1, 3],
+                              [4, 3, 2]])
 
 class TensorBase(np.ndarray):
     """
@@ -184,9 +188,9 @@ class TensorBase(np.ndarray):
         Returns the tensor in Voigt notation
         """
         if self.rank > 4:
-            raise ValueError("Voigt notation not standardized "
-                             "for tensor ranks higher than 4.")
-        v_matrix = np.zeros(self._vscale.shape)
+            warnings.warn("Voigt notation not standardized "
+                          "for tensor ranks higher than 4.")
+        v_matrix = np.zeros(self._vscale.shape, dtype=self.dtype)
         voigt_map = self.get_voigt_dict(self.rank)
         for ind in voigt_map:
             v_matrix[voigt_map[ind]] = self[ind]
@@ -377,7 +381,7 @@ class SquareTensor(TensorBase):
         """
         return np.linalg.det(self)
 
-    def is_rotation(self, tol=1e-3):
+    def is_rotation(self, tol=1e-5, include_improper=True):
         """
         Test to see if tensor is a valid rotation matrix, performs a
         test to check whether the inverse is equal to the transpose
@@ -389,9 +393,11 @@ class SquareTensor(TensorBase):
                 the determinant is one and the inverse is equal
                 to the transpose
         """
-
+        det = np.abs(np.linalg.det(self))
+        if include_improper:
+            det = np.abs(det)
         return (np.abs(self.inv - self.trans) < tol).all() \
-            and (np.linalg.det(self) - 1. < tol)
+            and (np.abs(det - 1.) < tol)
 
     def get_scaled(self, scale_factor):
         """


### PR DESCRIPTION
## Changes to elasticity module

Minor reorganization and bug fixes.

* elasticity classes/functions can now be imported from the top-level module, i. e. `from pymatgen.analysis.elasticity import ElasticTensor`. 
* Minor bug fix concerning improper rotations with the option to exclude for TensorBase
* Added a test to deformation/strain conversion function