### PR TITLE
update cbm module to make 0eV cbm discoverable

### DIFF
--- a/pymatgen/electronic_structure/bandstructure.py
+++ b/pymatgen/electronic_structure/bandstructure.py
@@ -391,7 +391,7 @@ class BandStructure(object):
         index = None
         kpointcbm = None
         for spin, v in self.bands.items():
-            for i, j in zip(*np.where(v > self.efermi)):
+            for i, j in zip(*np.where(v >= self.efermi)):
                 if v[i, j] < max_tmp:
                     max_tmp = float(v[i, j])
                     index = j


### PR DESCRIPTION
previously, if the conduction band minimum is equal to Fermi level, the code excludes it and return a neighbor data point.

