### PR TITLE
Enable NPT-AIMD simulation

### DIFF
--- a/pymatgen/analysis/diffusion_analyzer.py
+++ b/pymatgen/analysis/diffusion_analyzer.py
@@ -766,7 +766,8 @@ class DiffusionAnalyzer(MSONable):
                    step_skip=d["step_skip"], min_obs=d["min_obs"],
                    smoothed=d.get("smoothed", "max"),
                    avg_nsteps=d.get("avg_nsteps", 1000),
-                   lattices=d.get("lattices"))
+                   lattices=np.array(d.get("lattices",
+                                           [d["structure"]["lattice"]["matrix"]])))
 
 
 def get_conversion_factor(structure, species, temperature):

--- a/pymatgen/analysis/diffusion_analyzer.py
+++ b/pymatgen/analysis/diffusion_analyzer.py
@@ -318,7 +318,6 @@ class DiffusionAnalyzer(MSONable):
         coords = np.array(self.structure.cart_coords)
         species = self.structure.species_and_occu
         lattices = self.lattices
-
         nsites, nsteps, dim = self.corrected_displacements.shape
 
         for i in range(start or 0, stop or nsteps, step or 1):
@@ -767,7 +766,7 @@ class DiffusionAnalyzer(MSONable):
                    step_skip=d["step_skip"], min_obs=d["min_obs"],
                    smoothed=d.get("smoothed", "max"),
                    avg_nsteps=d.get("avg_nsteps", 1000),
-                   lattices=np.array(d.get("lattices")))
+                   lattices=d.get("lattices"))
 
 
 def get_conversion_factor(structure, species, temperature):

--- a/pymatgen/analysis/diffusion_analyzer.py
+++ b/pymatgen/analysis/diffusion_analyzer.py
@@ -172,7 +172,10 @@ class DiffusionAnalyzer(MSONable):
         self.min_obs = min_obs
         self.smoothed = smoothed
         self.avg_nsteps = avg_nsteps
-        self.lattices = lattices or [structure.lattice.matrix]
+        self.lattices = lattices
+
+        if lattices is None:
+            self.lattices = np.array([structure.lattice.matrix.tolist()])
 
         indices = []
         framework_indices = []
@@ -559,7 +562,9 @@ class DiffusionAnalyzer(MSONable):
 
         # If is NVT-AIMD, clear lattice data.
         if np.array_equal(l[0], l[-1]):
-            l = [l[0]]
+            l = np.array([l[0]])
+        else:
+            l = np.array(l)
         p = np.concatenate(p, axis=1)
         dp = p[:, 1:] - p[:, :-1]
         dp = dp - np.round(dp)
@@ -751,7 +756,7 @@ class DiffusionAnalyzer(MSONable):
             "min_obs": self.min_obs,
             "smoothed": self.smoothed,
             "avg_nsteps": self.avg_nsteps,
-            "lattices": self.lattices
+            "lattices": self.lattices.tolist()
         }
 
     @classmethod
@@ -762,7 +767,7 @@ class DiffusionAnalyzer(MSONable):
                    step_skip=d["step_skip"], min_obs=d["min_obs"],
                    smoothed=d.get("smoothed", "max"),
                    avg_nsteps=d.get("avg_nsteps", 1000),
-                   lattices=d.get("lattices"))
+                   lattices=np.array(d.get("lattices")))
 
 
 def get_conversion_factor(structure, species, temperature):

--- a/pymatgen/analysis/diffusion_analyzer.py
+++ b/pymatgen/analysis/diffusion_analyzer.py
@@ -4,6 +4,7 @@
 
 from __future__ import division, unicode_literals
 import numpy as np
+import warnings
 import scipy.constants as const
 
 from monty.json import MSONable
@@ -45,7 +46,7 @@ class DiffusionAnalyzer(MSONable):
 
     .. attribute: diffusivity
 
-        Diffusivity in cm^2 / cm
+        Diffusivity in cm^2 / s
 
     .. attribute: conductivity
 
@@ -53,7 +54,7 @@ class DiffusionAnalyzer(MSONable):
 
     .. attribute: diffusivity_components
 
-        A vector with diffusivity in the a, b and c directions in cm^2 / cm
+        A vector with diffusivity in the a, b and c directions in cm^2 / s
 
     .. attribute: conductivity_components
 
@@ -61,7 +62,7 @@ class DiffusionAnalyzer(MSONable):
 
     .. attribute: diffusivity_sigma
 
-        Std dev in diffusivity in cm^2 / cm. Note that this makes sense only
+        Std dev in diffusivity in cm^2 / s. Note that this makes sense only
         for non-smoothed analyses.
 
     .. attribute: conductivity_sigma
@@ -108,7 +109,7 @@ class DiffusionAnalyzer(MSONable):
 
     def __init__(self, structure, displacements, specie, temperature,
                  time_step, step_skip, smoothed="max", min_obs=30,
-                 avg_nsteps=1000):
+                 avg_nsteps=1000, lattices=None):
         """
         This constructor is meant to be used with pre-processed data.
         Other convenient constructors are provided as class methods (see
@@ -159,6 +160,8 @@ class DiffusionAnalyzer(MSONable):
             avg_nsteps (int): Used with smoothed="constant". Determines the
                 number of time steps to average over to get the msd for each
                 timestep. Default of 1000 is usually pretty good.
+            lattices (array): Numpy array of lattice matrix of every step
+                in NPT-AIMD. For NVT-AIMD, lattices has only one item.
         """
         self.structure = structure
         self.disp = displacements
@@ -169,6 +172,7 @@ class DiffusionAnalyzer(MSONable):
         self.min_obs = min_obs
         self.smoothed = smoothed
         self.avg_nsteps = avg_nsteps
+        self.lattices = lattices or [structure.lattice.matrix]
 
         indices = []
         framework_indices = []
@@ -189,7 +193,6 @@ class DiffusionAnalyzer(MSONable):
 
             #drift corrected position
             dc = self.disp - drift
-            df = structure.lattice.get_fractional_coords(dc)
 
             nions, nsteps, dim = dc.shape
 
@@ -215,19 +218,17 @@ class DiffusionAnalyzer(MSONable):
             sq_disp_ions = np.zeros((len(dc), len(dt)), dtype=np.double)
             msd_components = np.zeros(dt.shape + (3,))
 
-            lengths = np.array(self.structure.lattice.abc)[None, None, :]
-
             for i, n in enumerate(timesteps):
                 if not smoothed:
                     dx = dc[:, i:i + 1, :]
-                    dcomponents = df[:, i:i + 1, :] * lengths
+                    dcomponents = dc[:, i:i + 1, :]
                 elif smoothed == "constant":
                     dx = dc[:, i:i + avg_nsteps, :] - dc[:, 0:avg_nsteps, :]
-                    dcomponents = (df[:, i:i + avg_nsteps, :]
-                                   - df[:, 0:avg_nsteps, :]) * lengths
+                    dcomponents = dc[:, i:i + avg_nsteps, :] \
+                        - dc[:, 0:avg_nsteps, :]
                 else:
                     dx = dc[:, n:, :] - dc[:, :-n, :]
-                    dcomponents = (df[:, n:, :] - df[:, :-n, :]) * lengths
+                    dcomponents = dc[:, n:, :] - dc[:, :-n, :]
                 sq_disp = dx ** 2
                 sq_disp_ions[:, i] = np.average(np.sum(sq_disp, axis=2), axis=1)
                 msd[i] = np.average(sq_disp_ions[:, i][indices])
@@ -313,9 +314,12 @@ class DiffusionAnalyzer(MSONable):
         """
         coords = np.array(self.structure.cart_coords)
         species = self.structure.species_and_occu
-        latt = self.structure.lattice
+        lattices = self.lattices
+
         nsites, nsteps, dim = self.corrected_displacements.shape
+
         for i in range(start or 0, stop or nsteps, step or 1):
+            latt = lattices[0] if len(lattices) == 1 else lattices[i]
             yield Structure(
                     latt, species,
                     coords + self.corrected_displacements[:, i, :],
@@ -361,12 +365,20 @@ class DiffusionAnalyzer(MSONable):
         but doesn't constitute melting).
 
         Args:
+            plt (matplotlib.pyplot): If plt is supplied, changes will be made to an
+                existing plot. Otherwise, a new plot will be created.
             granularity (int): Number of structures to match
             matching_s (Structure): Optionally match to a disordered structure
                 instead of the first structure in the analyzer. Required when
                 a secondary mobile ion is present.
+        Notes:
+            The method doesn't apply to NPT-AIMD simulation analysis.
         """
         from pymatgen.util.plotting_utils import get_publication_quality_plot
+        if self.lattices is not None and len(self.lattices) > 1:
+            warnings.warn("Note the method doesn't apply to NPT-AIMD "
+                          "simulation analysis!")
+
         plt = get_publication_quality_plot(12, 8, plt=plt)
         step = (self.corrected_displacements.shape[1] - 1) // (granularity - 1)
         f = (matching_s or self.structure).copy()
@@ -529,31 +541,35 @@ class DiffusionAnalyzer(MSONable):
             initial_structure (Structure): Like initial_disp, this is used
                 for iterative computations of estimates of the diffusivity. You
                 typically need to supply both variables. This stipulates the
-                initial strcture from which the current set of displacements
+                initial structure from which the current set of displacements
                 are computed.
         """
-        p = []
+        p, l = [], []
         for i, s in enumerate(structures):
             if i == 0:
                 structure = s
-            p.append(np.array(s.frac_coords)[:, None])
-
+            p.append(np.array(s.cart_coords)[:, None])
+            l.append(s.lattice.matrix)
         if initial_structure is not None:
-            p.insert(0, np.array(initial_structure.frac_coords)[:, None])
+            p.insert(0, np.array(initial_structure.cart_coords)[:, None])
+            l.insert(0, initial_structure.lattice.matrix)
         else:
             p.insert(0, p[0])
+            l.insert(0, l[0])
+
+        # If is NVT-AIMD, clear lattice data.
+        if np.array_equal(l[0], l[-1]):
+            l = [l[0]]
         p = np.concatenate(p, axis=1)
         dp = p[:, 1:] - p[:, :-1]
         dp = dp - np.round(dp)
-        f_disp = np.cumsum(dp, axis=1)
+        disp = np.cumsum(dp, axis=1)
         if initial_disp is not None:
-            f_disp += structure.lattice.get_fractional_coords(initial_disp)[:,
-                                                              None, :]
-        disp = structure.lattice.get_cartesian_coords(f_disp)
+            disp += initial_disp[:, None, :]
 
-        return cls(structure, disp, specie, temperature,
-                   time_step, step_skip=step_skip, smoothed=smoothed,
-                   min_obs=min_obs, avg_nsteps=avg_nsteps)
+        return cls(structure, disp, specie, temperature, time_step,
+                   step_skip=step_skip, smoothed=smoothed,
+                   min_obs=min_obs, avg_nsteps=avg_nsteps, lattices=l)
 
     @classmethod
     def from_vaspruns(cls, vaspruns, specie, smoothed="max", min_obs=30,
@@ -605,7 +621,7 @@ class DiffusionAnalyzer(MSONable):
             initial_structure (Structure): Like initial_disp, this is used
                 for iterative computations of estimates of the diffusivity. You
                 typically need to supply both variables. This stipulates the
-                initial strcture from which the current set of displacements
+                initial stricture from which the current set of displacements
                 are computed.
         """
 
@@ -694,7 +710,7 @@ class DiffusionAnalyzer(MSONable):
             initial_structure (Structure): Like initial_disp, this is used
                 for iterative computations of estimates of the diffusivity. You
                 typically need to supply both variables. This stipulates the
-                initial strcture from which the current set of displacements
+                initial structure from which the current set of displacements
                 are computed.
         """
         if ncores is not None and len(filepaths) > 1:
@@ -717,6 +733,7 @@ class DiffusionAnalyzer(MSONable):
                     yield v
                     # Recompute offset.
                     offset = (-(v.nionic_steps - offset)) % step_skip
+
             return cls.from_vaspruns(vr(filepaths), min_obs=min_obs,
                 smoothed=smoothed, specie=specie, initial_disp=initial_disp,
                 initial_structure=initial_structure, avg_nsteps=avg_nsteps)
@@ -733,7 +750,8 @@ class DiffusionAnalyzer(MSONable):
             "step_skip": self.step_skip,
             "min_obs": self.min_obs,
             "smoothed": self.smoothed,
-            "avg_nsteps": self.avg_nsteps
+            "avg_nsteps": self.avg_nsteps,
+            "lattices": self.lattices
         }
 
     @classmethod
@@ -743,7 +761,8 @@ class DiffusionAnalyzer(MSONable):
                    temperature=d["temperature"], time_step=d["time_step"],
                    step_skip=d["step_skip"], min_obs=d["min_obs"],
                    smoothed=d.get("smoothed", "max"),
-                   avg_nsteps=d.get("avg_nsteps", 1000))
+                   avg_nsteps=d.get("avg_nsteps", 1000),
+                   lattices=d.get("lattices"))
 
 
 def get_conversion_factor(structure, species, temperature):

--- a/pymatgen/analysis/tests/test_diffusion_analyzer.py
+++ b/pymatgen/analysis/tests/test_diffusion_analyzer.py
@@ -117,6 +117,7 @@ class DiffusionAnalyzerTest(PymatgenTest):
                  0.713087091642237, 0.7621007695790749])
 
             self.assertEqual(d.sq_disp_ions.shape, (50, 206))
+            self.assertEqual(d.lattices.shape, (1, 3, 3))
 
             self.assertAlmostEqual(d.max_framework_displacement, 1.18656839605)
 

--- a/pymatgen/analysis/tests/test_diffusion_analyzer.py
+++ b/pymatgen/analysis/tests/test_diffusion_analyzer.py
@@ -84,13 +84,13 @@ class DiffusionAnalyzerTest(PymatgenTest):
             self.assertAlmostEqual(d.diffusivity_std_dev, 9.1013023085561779e-09, 7)
             self.assertArrayAlmostEqual(
                 d.conductivity_components,
-                [45.9109703,   26.2856302,  150.5405727], 3)
+                [45.7903694,   26.1651956,  150.5406140], 3)
             self.assertArrayAlmostEqual(
                 d.diffusivity_components,
                 [7.49601236e-07, 4.90254273e-07, 2.24649255e-06])
             self.assertArrayAlmostEqual(
                 d.conductivity_components_std_dev,
-                [0.0063579,  0.0180862,  0.0217917]
+                [0.0063566,  0.0180854,  0.0217918]
             )
             self.assertArrayAlmostEqual(
                 d.diffusivity_components_std_dev,

--- a/pymatgen/analysis/tests/test_diffusion_analyzer.py
+++ b/pymatgen/analysis/tests/test_diffusion_analyzer.py
@@ -31,7 +31,6 @@ __status__ = "Beta"
 __date__ = "5/2/13"
 
 
-
 test_dir = os.path.join(os.path.dirname(__file__), "..", "..", "..",
                         'test_files')
 
@@ -164,6 +163,117 @@ class DiffusionAnalyzerTest(PymatgenTest):
                 d.step_skip, d.smoothed, avg_nsteps=100)
             self.assertAlmostEqual(d.conductivity, 47.404056230438741, 4)
             self.assertAlmostEqual(d.diffusivity, 7.4226016496716148e-07, 7)
+
+            d.export_msdt("test.csv")
+            with open("test.csv") as f:
+                data = []
+                for row in csv.reader(f):
+                    if row:
+                        data.append(row)
+            data.pop(0)
+            data = np.array(data, dtype=np.float64)
+            self.assertArrayAlmostEqual(data[:, 1], d.msd)
+            os.remove("test.csv")
+
+    def test_init_npt(self):
+        # Diffusion vasprun.xmls are rather large. We are only going to use a
+        # very small preprocessed run for testing. Note that the results are
+        # unreliable for short runs.
+        with open(os.path.join(test_dir, "DiffusionAnalyzer_NPT.json"), 'r') as f:
+            dd = json.load(f)
+            d = DiffusionAnalyzer.from_dict(dd)
+            # large tolerance because scipy constants changed between 0.16.1 and 0.17
+            self.assertAlmostEqual(d.conductivity, 499.15058192970508, 4)
+            self.assertAlmostEqual(d.diffusivity,  8.40265434771e-06, 7)
+            self.assertAlmostEqual(d.conductivity_std_dev, 0.10368477696021029, 7)
+            self.assertAlmostEqual(d.diffusivity_std_dev, 9.1013023085561779e-09, 7)
+            self.assertArrayAlmostEqual(
+                d.conductivity_components,
+                [455.178101,   602.252644,  440.0210014], 3)
+            self.assertArrayAlmostEqual(
+                d.diffusivity_components,
+                [7.66242570e-06, 1.01382648e-05, 7.40727250e-06])
+            self.assertArrayAlmostEqual(
+                d.conductivity_components_std_dev,
+                [0.1196577,  0.0973347,  0.1525400]
+            )
+            self.assertArrayAlmostEqual(
+                d.diffusivity_components_std_dev,
+                [2.0143072e-09,   1.6385239e-09,   2.5678445e-09]
+            )
+
+            self.assertArrayAlmostEqual(
+                d.max_ion_displacements,
+                [1.13147881, 0.79899554, 1.04153733, 0.96061850,
+                 0.83039864, 0.70246715, 0.61365911, 0.67965179,
+                 1.91973907, 1.69127386, 1.60568746, 1.35587641,
+                 1.03280378, 0.99202692, 2.03359655, 1.03760269,
+                 1.40228350, 1.36315080, 1.27414979, 1.26742035,
+                 0.88199589, 0.97700804, 1.11323184, 1.00139511,
+                 2.94164403, 0.89438909, 1.41508334, 1.23660358,
+                 0.39322939, 0.54264064, 1.25291806, 0.62869809,
+                 0.40846708, 1.43415505, 0.88891241, 0.56259128,
+                 0.81712740, 0.52700441, 0.51011733, 0.55557882,
+                 0.49131002, 0.66740277, 0.57798671, 0.63521025,
+                 0.50277142, 0.52878021, 0.67803443, 0.81161269,
+                 0.46486345, 0.47132761, 0.74301293, 0.79285519,
+                 0.48789600, 0.61776836, 0.60695847, 0.67767756,
+                 0.70972268, 1.08232442, 0.87871177, 0.84674206,
+                 0.45694693, 0.60417985, 0.61652272, 0.66444583,
+                 0.52211986, 0.56544134, 0.43311443, 0.43027547,
+                 1.10730439, 0.59829728, 0.52270635, 0.72327608,
+                 1.02919775, 0.84423208, 0.61694764, 0.72795752,
+                 0.72957755, 0.55491631, 0.68507454, 0.76745343,
+                 0.96346584, 0.66672645, 1.06810107, 0.65705843])
+
+            self.assertEqual(d.sq_disp_ions.shape, (84, 217))
+            self.assertEqual(d.lattices.shape, (1001, 3, 3))
+
+            self.assertAlmostEqual(d.max_framework_displacement, 1.43415505156)
+
+            ss = list(d.get_drift_corrected_structures(10, 1000, 20))
+            self.assertEqual(len(ss), 50)
+            n = random.randint(0, 49)
+            n_orig = n * 20 + 10
+            self.assertArrayAlmostEqual(
+                ss[n].cart_coords - d.structure.cart_coords + d.drift[:, n_orig, :],
+                d.disp[:, n_orig, :])
+
+            d = DiffusionAnalyzer.from_dict(d.as_dict())
+            self.assertIsInstance(d, DiffusionAnalyzer)
+
+            # Ensure summary dict is json serializable.
+            json.dumps(d.get_summary_dict(include_msd_t=True))
+
+            d = DiffusionAnalyzer(d.structure, d.disp, d.specie, d.temperature,
+                                  d.time_step, d.step_skip, smoothed="max")
+            self.assertAlmostEqual(d.conductivity, 499.15058192970508, 4)
+            self.assertAlmostEqual(d.diffusivity, 8.40265434771e-06, 7)
+
+            d = DiffusionAnalyzer(d.structure, d.disp, d.specie, d.temperature,
+                                  d.time_step, d.step_skip, smoothed=False)
+            self.assertAlmostEqual(d.conductivity, 406.5965396, 4)
+            self.assertAlmostEqual(d.diffusivity, 6.8446082e-06, 7)
+
+            d = DiffusionAnalyzer(d.structure, d.disp, d.specie, d.temperature,
+                                  d.time_step, d.step_skip,
+                                  smoothed="constant", avg_nsteps=100)
+
+            self.assertAlmostEqual(d.conductivity, 425.7789898, 4)
+            self.assertAlmostEqual(d.diffusivity, 7.167523809142514e-06, 7)
+
+            # Can't average over 2000 steps because this is a 1000-step run.
+            self.assertRaises(ValueError, DiffusionAnalyzer,
+                              d.structure, d.disp, d.specie, d.temperature,
+                              d.time_step, d.step_skip, smoothed="constant",
+                              avg_nsteps=2000)
+
+            d = DiffusionAnalyzer.from_structures(
+                list(d.get_drift_corrected_structures()),
+                d.specie, d.temperature, d.time_step,
+                d.step_skip, d.smoothed, avg_nsteps=100)
+            self.assertAlmostEqual(d.conductivity, 425.77898986201302, 4)
+            self.assertAlmostEqual(d.diffusivity, 7.1675238091425148e-06, 7)
 
             d.export_msdt("test.csv")
             with open("test.csv") as f:


### PR DESCRIPTION
## Summary

Make DiffusionAnalyzer class compatible with NPT-AIMD diffusion analysis.

* Added a new attribute *lattices*. For NVT simulation, the attribute is a one-item list; for NPT simulation, the attribute includes all lattice matrix, which is used in *get_drift_corrected_structures()*.
* Use fractional coordinates instead of Cartesian coordinates.
* Minor change for the unit test
* Throw warning when *get_framework_rms_plot()* is called during NPT analysis.

## Additional dependencies introduced (if any)

None

## TODO (if any)

None
