### PR TITLE
Method to load the averaged core potentials from OUTCAR

### DIFF
--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -2130,7 +2130,7 @@ class Outcar(MSONable):
         def pairwise(iterable):
             "s -> (s0,s1), (s1,s2), (s2, s3), ..."
             a = iter(iterable)
-            return itertools.izip(a, a)
+            return zip(a, a)
 
         with zopen(self.filename, "rt") as foutcar:
             line = foutcar.readline()

--- a/pymatgen/io/vasp/tests/test_outputs.py
+++ b/pymatgen/io/vasp/tests/test_outputs.py
@@ -499,6 +499,14 @@ class OutcarTest(unittest.TestCase):
         cl = Outcar(filepath).read_core_state_eigen()
         self.assertAlmostEqual(cl[4]["3d"][-1], -31.4522)
 
+    def test_avg_core_poten(self):
+        filepath = os.path.join(test_dir, "OUTCAR.lepsilon")
+        cp = Outcar(filepath).read_avg_core_poten()
+        self.assertAlmostEqual(cp[-1][1], -90.0487)
+        filepath = os.path.join(test_dir, "OUTCAR")
+        cp = Outcar(filepath).read_avg_core_poten()
+        self.assertAlmostEqual(cp[0][6], -73.1068)
+
     def test_single_atom(self):
         filepath = os.path.join(test_dir, "OUTCAR.Al")
         outcar = Outcar(filepath)


### PR DESCRIPTION
## Summary

Added a new function to the `Outcar` class to load in the average core potentials of each atom at all ionic steps. A test for this method was also added and is passing.

Some blank spaces at the end of lines were removed by vim python-mode- apologies for cluttering the pull request.