### PR TITLE
New function to plot fermi surfaces using Mayavi tool 

### DIFF
--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -1542,67 +1542,135 @@ class BoltztrapPlotter(object):
         plt.yticks(fontsize=25)
         return plt
 
-    def plot_fermi_surface(self, structure=None, isolevel=None):
-        """
-        Plot the Fermi surface at a aspecific energy value
+def plot_fermi_surface(data, structure, cbm, energy_levels=[], multiple_figure=True,
+                       mlab_figure = None, kpoints_dict={}, color=(0,0,1), 
+                       transparency_factor=[], labels_scale_factor=0.05, 
+                       points_scale_factor=0.02, interative=True):
+    """
+    Plot the Fermi surface at specific energy value.
 
-        Args:
-            bz_lattice: structure object of the material
-            isolevel: energy value fo fermi surface, Default: max energy value + 0.1eV
+    Args:
+        data: energy values in a 3D grid from a CUBE file 
+              via read_cube_file function, or from a 
+              BoltztrapAnalyzer.fermi_surface_data
+        structure: structure object of the material
+        energy_levels: list of energy value of the fermi surface. 
+                        Default: max energy value + 0.01 eV
+        cbm: Boolean value to specify if the considered band is 
+                a conduction band or not
+        multiple_figure: if True a figure for each energy level will be shown.
+                         If False all the surfaces will be shown in the same figure.
+                         In this las case, tune the transparency factor.
+        mlab_figure: provide a previous figure to plot a new surface on it.
+        kpoints_dict: dictionary of kpoints to show in the plot.
+                        example: {"K":[0.5,0.0,0.5]}, 
+                        where the coords are fractional.
+        color: tuple (r,g,b) of integers to define the color of the surface.
+        transparency_factor: list of values in the range [0,1] to tune
+                             the opacity of the surfaces.
+        labels_scale_factor: factor to tune the size of the kpoint labels
+        points_scale_factor: factor to tune the size of the kpoint points
+        interative: if True an interactive figure will be shown.
+                    If False a non interactive figure will be shown, but
+                    it is possible to plot other surfaces on the same figure.
+                    To make it interactive, run mlab.show().
+        
+    Returns:
+        a Mayavi figure and a mlab module to control the plot.
 
-        Returns:
-            a matplotlib object
+    Note: Experimental. 
+          Please, double check the surface shown by using some 
+          other software and report issues.
+    """
+    
+    try:
+        from mayavi import mlab
+    except ImportError:
+        raise BoltztrapError(
+            "Mayavi package should be installed to use this function")
 
-        Note: Experimental
-        """
-        import matplotlib.pyplot as plt
-        from mpl_toolkits.mplot3d import Axes3D
-        from pymatgen.electronic_structure.plotter import plot_brillouin_zone
-        try:
-            from skimage import measure
-        except ImportError:
-            raise BoltztrapError(
-                "skimage package should be installed to use this function")
+    bz = structure.lattice.reciprocal_lattice.get_wigner_seitz_cell()
+    cell = structure.lattice.reciprocal_lattice.matrix
 
-        fig = None
+    fact = 1 if cbm == False else -1
+    en_min = np.min(fact*data.ravel())
+    en_max = np.max(fact*data.ravel())
+    
+    if energy_levels == []:
+        energy_levels = [en_min + 0.01] if cbm == True else \
+                        [en_max - 0.01]
+        print("Energy level set to: " + str(energy_levels[0])+" eV")
+    
+    else:
+        for e in energy_levels:
+            if e > en_max or e < en_min:
+                raise BoltztrapError("energy level " + str(e) + 
+                                     " not in the range of possible energies: [" +
+                                     str(en_min) + ", " + str(en_max) + "]")
+    
+    if transparency_factor == []:
+        transparency_factor = [1]*len(energy_levels)
+    
+    if mlab_figure:
+        fig=mlab_figure
+        
+    if mlab_figure == None and not multiple_figure:
+        fig = mlab.figure(size = (1024,768),bgcolor = (1,1,1))
+        for iface in range(len(bz)):
+            for line in itertools.combinations(bz[iface], 2):
+                for jface in range(len(bz)):
+                    if iface < jface and any(np.all(line[0] == x) 
+                                                for x in bz[jface]) and \
+                                            any(np.all(line[1] == x) 
+                                                for x in bz[jface]):
+                        mlab.plot3d(*zip(line[0], line[1]),color=(0,0,0),
+                                    tube_radius=None, figure = fig)
+        for label,coords in kpoints_dict.iteritems():
+            label_coords = structure.lattice.reciprocal_lattice \
+                        .get_cartesian_coords(coords)
+            mlab.points3d(*label_coords, scale_factor=points_scale_factor, color=(0,0,0), figure = fig)
+            mlab.text3d(*label_coords, text=label, scale=labels_scale_factor, color=(0,0,0), figure = fig)
 
-        data = self._bz.fermi_surface_data
+    for isolevel,alpha in zip(energy_levels,transparency_factor):
+        if multiple_figure:
+            fig = mlab.figure(size = (1024,768),bgcolor = (1,1,1))
+        
+            for iface in range(len(bz)):
+                for line in itertools.combinations(bz[iface], 2):
+                    for jface in range(len(bz)):
+                        if iface < jface and any(np.all(line[0] == x) 
+                                                    for x in bz[jface]) and \
+                                                any(np.all(line[1] == x) 
+                                                    for x in bz[jface]):
+                            mlab.plot3d(*zip(line[0], line[1]),color=(0,0,0),
+                                        tube_radius=None, figure = fig)
+                            
+            for label,coords in kpoints_dict.iteritems():
+                label_coords = structure.lattice.reciprocal_lattice \
+                            .get_cartesian_coords(coords)
+                mlab.points3d(*label_coords, scale_factor=points_scale_factor, color=(0,0,0), figure = fig)
+                mlab.text3d(*label_coords, text=label, scale=labels_scale_factor, color=(0,0,0), figure = fig)
+            
+            
+        cp = mlab.contour3d(fact*data,contours=[isolevel], transparent=True,
+                            colormap='hot', color=color, opacity=alpha, figure = fig)
 
-        if not isolevel:
-            isolevel = max(data[0].flat) - Energy(0.1, "eV").to("Ry")
+        polydata = cp.actor.actors[0].mapper.input
+        pts = np.array(polydata.points) #- 1
+        polydata.points = np.dot(pts, 
+                                    cell / np.array(data.shape)[:, np.newaxis])
 
-        verts, faces = measure.marching_cubes(data[0], isolevel)
-        verts -= 1
-        verts2 = np.dot(verts,
-                        data[1].cell / np.array(data[0].shape)[:, np.newaxis])
-        verts2 /= max(verts2.flat) / 1.5
+        cx,cy,cz = [np.mean(np.array(polydata.points)[:, i]) 
+                    for i in range(3)]
 
-        cx, cy, cz = [
-            (max(verts2[:, i]) - min(verts2[:, i])) / 2 + min(verts2[:, i]) for
-            i in range(3)]
+        polydata.points = (np.array(polydata.points) - [cx,cy,cz]) * 2
+    
+        
+        mlab.view(distance='auto')
+    if interative == True:
+        mlab.show()
 
-        if structure is not None:
-            kpath = HighSymmKpath(structure).kpath
-            lines = [[kpath['kpoints'][k] for k in p] for p in kpath['path']]
-            fig = plot_brillouin_zone(bz_lattice=structure.reciprocal_lattice,
-                                      lines=lines, labels=kpath['kpoints'])
-
-        if fig:
-            ax = fig.gca()
-            ax.plot_trisurf(verts2[:, 0] - cx, verts2[:, 1] - cy, faces,
-                            verts2[:, 2] - cz, lw=0)
-        else:
-            fig = plt.figure()
-            ax = fig.add_subplot(111, projection='3d')
-            ax.plot_trisurf(verts2[:, 0] - cx, verts2[:, 1] - cy, faces,
-                            verts2[:, 2] - cz, lw=0)
-            ax.set_xlim3d(-1, 1)
-            ax.set_ylim3d(-1, 1)
-            ax.set_zlim3d(-1, 1)
-            ax.set_aspect('equal')
-            ax.axis("off")
-
-        return fig, ax
+    return fig, mlab
 
 
 def plot_wigner_seitz(lattice, ax=None, **kwargs):
@@ -1911,9 +1979,10 @@ def plot_ellipsoid(hessian, center, lattice=None, rescale=1.0, ax=None, coords_a
         rescale: factor for size scaling of the ellipsoid
         ax: matplotlib :class:`Axes` or None if a new figure should be created.
         coords_are_cartesian: Set to True if you are providing a center in
-            cartesian coordinates. Defaults to False.
-        kwargs: kwargs passed to the matplotlib function 'plot_wireframe'. Color defaults to blue, rstride and cstride
-            default to 4, alpha defaults to 0.2.
+                              cartesian coordinates. Defaults to False.
+        kwargs: kwargs passed to the matplotlib function 'plot_wireframe'. 
+                Color defaults to blue, rstride and cstride
+                default to 4, alpha defaults to 0.2.
     Returns:
         matplotlib figure and matplotlib ax
     Example of use:

--- a/pymatgen/electronic_structure/tests/test_boltztrap.py
+++ b/pymatgen/electronic_structure/tests/test_boltztrap.py
@@ -28,7 +28,7 @@ class BoltztrapAnalyzerTest(unittest.TestCase):
         cls.bz_bands = BoltztrapAnalyzer.from_files(os.path.join(test_dir, "boltztrap/bands/"))
         cls.bz_up = BoltztrapAnalyzer.from_files(os.path.join(test_dir, "boltztrap/dos_up/"),dos_spin=1)
         cls.bz_dw = BoltztrapAnalyzer.from_files(os.path.join(test_dir, "boltztrap/dos_dw/"),dos_spin=-1)
-        # cls.bz_fermi = BoltztrapAnalyzer.from_files(os.path.join(test_dir, "boltztrap/fermi/"))
+        cls.bz_fermi = BoltztrapAnalyzer.from_files(os.path.join(test_dir, "boltztrap/fermi/"))
         
     def test_properties(self):
         self.assertAlmostEqual(self.bz.gap, 1.6644932121620404, 4)
@@ -74,9 +74,8 @@ class BoltztrapAnalyzerTest(unittest.TestCase):
         self.assertAlmostEqual(self.bz_bands._bz_kpoints.shape, (1316, 3))
         self.assertAlmostEqual(self.bz_up._dos_partial['0']['pz'][2562],0.023862958)
         self.assertAlmostEqual(self.bz_dw._dos_partial['1']['px'][3120],5.0192891)
-        # self.assertAlmostEqual(self.bz_fermi.fermi_surface_data[0].shape,
-        #                        (121,121, 65))
-        # self.assertAlmostEqual(self.bz_fermi.fermi_surface_data[0][21][79][19],-0.138412)
+        self.assertAlmostEqual(self.bz_fermi.fermi_surface_data.shape, (121,121, 65))
+        self.assertAlmostEqual(self.bz_fermi.fermi_surface_data[21][79][19],-1.88319111)
 
     def test_get_seebeck(self):
         ref = [-768.99078999999995, -724.43919999999991, -686.84682999999973]


### PR DESCRIPTION
The function plot_fermi_surface of plotter module has been rewritten.
It now uses Mayavi package (mandatory) to calculate and potting the surface.
The dependency from ASE for reading CUBE files has been replaced with a new internal function.
It allows to plot fermi surfaces from cube file produces by both boltztrap (using BoltztrapAnalyzer.fermi_surface_data) or other softwares (reading the file with the read_cube_file function).
It plots different surfaces in different figures or all in one figure.
It returns both the last figure and the module mayavi in order to allow you to plot different data
in the same figure.
Color and transparency of surfaces are tunable.
Labels of kpoints will be shown in the Brillouin zone if a proper dictionary of kpoints coords is provided.
