### PR TITLE
Add rgb_legend style to BSDOSPlotter

### DIFF
--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -1047,7 +1047,7 @@ class BSDOSPlotter():
             bs_projection = None
 
         if rgb_legend and (not bs_projection or bs_projection.lower() != "elements" or len(elements) not in [2, 3]):
-            warnings.warn("Cannot create rgb_legend; requires projection data and exactly 2 or 3 unique elements")
+            warnings.warn("Cannot create rgb_legend; requires projection data and exactly 2 or 3 unique elements.")
             rgb_legend = None
 
 
@@ -1228,7 +1228,7 @@ class BSDOSPlotter():
 
         elif self.bs_legend and rgb_legend:
             if len(elements) == 2:
-                pass
+                self._rb_line(bs_ax, elements[1], elements[0])
             elif len(elements) == 3:
                 self._rgb_triangle(bs_ax, elements[1], elements[2], elements[0])
 
@@ -1317,14 +1317,13 @@ class BSDOSPlotter():
     @staticmethod
     def _rgb_triangle(ax, r_label, g_label, b_label):
         """
-        Draw an RGB triangle on the band structure axis with element
-        labels red, green, and blues
+        Draw an RGB triangle legend on the desired axis
         """
 
         MESH = 35
         x = []
         y = []
-        z = []
+        color = []
         for r in range(0, MESH):
             for g in range(0, MESH):
                 for b in range(0, MESH):
@@ -1332,69 +1331,35 @@ class BSDOSPlotter():
                         r1 = r / (r + g + b)
                         g1 = g / (r + g + b)
                         b1 = b / (r + g + b)
-                        colour = []
                         x.append(0.33 * (2. * g1 + r1) / (r1 + b1 + g1))
                         y.append(0.33 * np.sqrt(3) * r1 / (r1 + b1 + g1))
-                        colour.append(r1)
-                        colour.append(g1)
-                        colour.append(b1)
-                        z.append(colour)
+                        color.append([r1, g1, b1])
 
         max_y = ax.get_ylim()[1]
+        x = [n + 0.25 for n in x]  # nudge x coordinates
         y = [n + (max_y - 1) for n in y]  # shift y coordinates to top
-        x = [n + 0.25 for n in x]  # nudge x coordinates to right
-        ax.scatter(x, y, s=7, marker='.', edgecolor=z)
+        ax.scatter(x, y, s=7, marker='.', edgecolor=color)
         ax.text(0.95, max_y - 1.25, g_label, fontsize=16, family='Times New Roman', color=(0, 1, 0))
         ax.text(0.45, max_y - 0.3, r_label, fontsize=16, family='Times New Roman', color=(1, 0, 0))
         ax.text(0.05, max_y - 1.25, b_label, fontsize=16, family='Times New Roman', color=(0, 0, 1))
 
+    @staticmethod
+    def _rb_line(ax, r_label, b_label):
+        # Draw an rb line legend on the desired axis
 
-    def rb_line(self, ax, red, blue):
-        # Add a rb line with atoms
-        # Only for two atoms
+        max_y = ax.get_ylim()[1]
+
         x = []
         y = []
-        z = []
+        color = []
         for i in range(0, 1000):
-            x.append(i / 1800. + 0.3)
-            y.append(0)
-            colour = []
-            colour.append(1. - i / 1000.)
-            colour.append(0)
-            colour.append(i / 1000.)
-            z.append(colour)
-        ax.scatter(x, y, s=500., marker='s', edgecolor=z)
-        ax.text(1.05, -0.15, blue, fontsize=32, family='Times New Roman', color=(0, 0, 1))
-        if len(red) == 2:
-            ax.text(-0.6, -0.15, red, fontsize=32, family='Times New Roman', color=(1, 0, 0))
-        if len(red) == 1:
-            ax.text(-0.2, -0.15, red, fontsize=32, family='Times New Roman', color=(1, 0, 0))
+            x.append(i / 1800. + 0.55)
+            y.append(max_y - 0.5)
+            color.append([1 - i/1000, 0, i / 1000])
+        ax.scatter(x, y, s=250., marker='s', edgecolor=color)
+        ax.text(1.3, max_y - 0.6, b_label, fontsize=16, family='Times New Roman', color=(0, 0, 1))
+        ax.text(0, max_y - 0.6, r_label, fontsize=16, family='Times New Roman', color=(1, 0, 0))
 
-            # Change the gridSpec for the subplots to
-            gs1 = GridSpec(1, 2, width_ratios=[2, 1, ])
-            gs1.update(left=0.15, right=1.3, wspace=0.05)
-            fig = plt.figure(figsize=(11.69, 8.27))
-            ax1 = plt.subplot(gs1[0])
-            ax2 = plt.subplot(gs1[1])
-
-            gs2 = GridSpec(2, 1, height_ratios=[1, 8, ])
-            gs2.update(left=0.0, right=0.1)
-            ax3 = plt.subplot(gs2[0])
-            ax3.axis('off')
-
-            '''below
-            if len(atoms) == 3:
-                contrib,band_energy,atoms=plot_3atoms(data,atoms)
-            add'''
-            rgb_triangle(ax3, str(atoms[0]), str(atoms[1]), str(atoms[2]))
-            # I would use it only for publication as it is time consumind
-            # and there should be on/off option
-
-        '''below
-        if len(atoms) == 2:
-            contrib,band_energy,atoms=plot_2atoms(data,atoms)
-        add'''
-        rb_line(ax3, str(atoms[0]), str(atoms[1]))
 
 class BoltztrapPlotter(object):
     """

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -1046,8 +1046,10 @@ class BSDOSPlotter():
                           " unique elements.")
             bs_projection = None
 
-        if rgb_legend and (not bs_projection or bs_projection.lower() != "elements" or len(elements) not in [2, 3]):
-            warnings.warn("Cannot create rgb_legend; requires projection data and exactly 2 or 3 unique elements.")
+        if rgb_legend and (not bs_projection or bs_projection.lower() != "elements" or
+                                   len(elements) not in [2, 3]):
+            warnings.warn("Cannot create rgb_legend; requires projection data and "
+                          "exactly 2 or 3 unique elements.")
             rgb_legend = None
 
 
@@ -1320,13 +1322,13 @@ class BSDOSPlotter():
         Draw an RGB triangle legend on the desired axis
         """
 
-        MESH = 35
+        mesh = 35
         x = []
         y = []
         color = []
-        for r in range(0, MESH):
-            for g in range(0, MESH):
-                for b in range(0, MESH):
+        for r in range(0, mesh):
+            for g in range(0, mesh):
+                for b in range(0, mesh):
                     if not (r == 0 and b == 0 and g == 0):
                         r1 = r / (r + g + b)
                         g1 = g / (r + g + b)
@@ -1338,14 +1340,20 @@ class BSDOSPlotter():
         max_y = ax.get_ylim()[1]
         x = [n + 0.25 for n in x]  # nudge x coordinates
         y = [n + (max_y - 1) for n in y]  # shift y coordinates to top
+        # plot the triangle
         ax.scatter(x, y, s=7, marker='.', edgecolor=color)
-        ax.text(0.95, max_y - 1.25, g_label, fontsize=16, family='Times New Roman', color=(0, 1, 0))
-        ax.text(0.45, max_y - 0.3, r_label, fontsize=16, family='Times New Roman', color=(1, 0, 0))
-        ax.text(0.05, max_y - 1.25, b_label, fontsize=16, family='Times New Roman', color=(0, 0, 1))
+
+        # add the labels
+        ax.text(0.95, max_y - 1.25, g_label, fontsize=16,
+                family='Times New Roman', color=(0, 1, 0))
+        ax.text(0.45, max_y - 0.3, r_label, fontsize=16,
+                family='Times New Roman', color=(1, 0, 0))
+        ax.text(0.05, max_y - 1.25, b_label, fontsize=16,
+                family='Times New Roman', color=(0, 0, 1))
 
     @staticmethod
     def _rb_line(ax, r_label, b_label):
-        # Draw an rb line legend on the desired axis
+        # Draw an rb bar legend on the desired axis
 
         max_y = ax.get_ylim()[1]
 
@@ -1356,9 +1364,13 @@ class BSDOSPlotter():
             x.append(i / 1800. + 0.55)
             y.append(max_y - 0.5)
             color.append([1 - i/1000, 0, i / 1000])
+
+        # plot the bar
         ax.scatter(x, y, s=250., marker='s', edgecolor=color)
-        ax.text(1.3, max_y - 0.6, b_label, fontsize=16, family='Times New Roman', color=(0, 0, 1))
-        ax.text(0, max_y - 0.6, r_label, fontsize=16, family='Times New Roman', color=(1, 0, 0))
+        ax.text(1.3, max_y - 0.6, b_label, fontsize=16,
+                family='Times New Roman', color=(0, 0, 1))
+        ax.text(0, max_y - 0.6, r_label, fontsize=16,
+                family='Times New Roman', color=(1, 0, 0))
 
 
 class BoltztrapPlotter(object):

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -1205,16 +1205,24 @@ class BSDOSPlotter():
                                          color='b', linestyle="dotted",
                                          label='spin down')]
 
-            elif bs_projection.lower() == "elements":
-                colors = ['b', 'r', 'g']
-                for idx, el in enumerate(elements):
-                    handles.append(mlines.Line2D([], [],
-                                                 linewidth=2,
-                                                 color=colors[idx], label=el))
+                bs_ax.legend(handles=handles, fancybox=True,
+                             prop={'size': self.legend_fontsize,
+                                   'family': self.font}, loc=self.bs_legend)
 
-            bs_ax.legend(handles=handles, fancybox=True,
-                         prop={'size': self.legend_fontsize,
-                               'family': self.font}, loc=self.bs_legend)
+            elif bs_projection.lower() == "elements":
+                # colors = ['b', 'r', 'g']
+                # for idx, el in enumerate(elements):
+                #     handles.append(mlines.Line2D([], [],
+                #                                  linewidth=2,
+                #                                  color=colors[idx], label=el))
+                # bs_ax.legend(handles=handles, fancybox=True,
+                #              prop={'size': self.legend_fontsize,
+                #                    'family': self.font}, loc=self.bs_legend)
+
+                bs_ax.legend()
+                self.rgb_triangle(bs_ax, elements[1], elements[2], elements[0])
+
+
 
         # add legend for DOS
         if self.dos_legend:
@@ -1297,6 +1305,84 @@ class BSDOSPlotter():
                 contribs[spin] = np.array(contribs[spin])
 
         return contribs
+
+    def rgb_triangle(self, ax, red, green, blue):
+        # To generate the rgb triangle and add the atoms
+        # Only for 3 atoms
+        MESH = 25
+        x = []
+        y = []
+        z = []
+        for r in range(0, MESH):
+            for g in range(0, MESH):
+                for b in range(0, MESH):
+                    r1 = r / MESH
+                    g1 = g / MESH
+                    b1 = b / MESH
+                    colour = []
+                    if math.sqrt(r1 ** 2 + g1 ** 2 + b1 ** 2) != 0:
+                        x.append(0.5 * (2. * g1 + r1) / (r1 + b1 + g1))
+                        y.append(0.5 * np.sqrt(3) * r1 / (r1 + b1 + g1))
+                        colour.append(r1)
+                        colour.append(g1)
+                        colour.append(b1)
+                        z.append(colour)
+
+        max_y = ax.get_ylim()[1]
+        y = [n + (max_y - 1.5) for n in y]  # shift y coordinates to top
+        x = [n + 0.25 for n in x]  # nudge x coordinates to right
+        ax.scatter(x, y, s=7, marker='.', edgecolor=z)
+        ax.text(1.25, max_y-1.5-0.25, green, fontsize=24, family='Times New Roman', color=(0, 1, 0))
+        ax.text(0.68, max_y-1.5+0.92, red, fontsize=24, family='Times New Roman', color=(1, 0, 0))
+        ax.text(0.05, max_y-1.5-0.25, blue, fontsize=24, family='Times New Roman', color=(0, 0, 1))
+
+
+    def rb_line(self, ax, red, blue):
+        # Add a rb line with atoms
+        # Only for two atoms
+        x = []
+        y = []
+        z = []
+        for i in range(0, 1000):
+            x.append(i / 1800. + 0.3)
+            y.append(0)
+            colour = []
+            colour.append(1. - i / 1000.)
+            colour.append(0)
+            colour.append(i / 1000.)
+            z.append(colour)
+        ax.scatter(x, y, s=500., marker='s', edgecolor=z)
+        ax.text(1.05, -0.15, blue, fontsize=32, family='Times New Roman', color=(0, 0, 1))
+        if len(red) == 2:
+            ax.text(-0.6, -0.15, red, fontsize=32, family='Times New Roman', color=(1, 0, 0))
+        if len(red) == 1:
+            ax.text(-0.2, -0.15, red, fontsize=32, family='Times New Roman', color=(1, 0, 0))
+
+            # Change the gridSpec for the subplots to
+            gs1 = GridSpec(1, 2, width_ratios=[2, 1, ])
+            gs1.update(left=0.15, right=1.3, wspace=0.05)
+            fig = plt.figure(figsize=(11.69, 8.27))
+            ax1 = plt.subplot(gs1[0])
+            ax2 = plt.subplot(gs1[1])
+
+            gs2 = GridSpec(2, 1, height_ratios=[1, 8, ])
+            gs2.update(left=0.0, right=0.1)
+            ax3 = plt.subplot(gs2[0])
+            ax3.axis('off')
+
+            '''below
+            if len(atoms) == 3:
+                contrib,band_energy,atoms=plot_3atoms(data,atoms)
+            add'''
+            rgb_triangle(ax3, str(atoms[0]), str(atoms[1]), str(atoms[2]))
+            # I would use it only for publication as it is time consumind
+            # and there should be on/off option
+
+        '''below
+        if len(atoms) == 2:
+            contrib,band_energy,atoms=plot_2atoms(data,atoms)
+        add'''
+        rb_line(ax3, str(atoms[0]), str(atoms[1]))
 
 class BoltztrapPlotter(object):
     """

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -1345,11 +1345,11 @@ class BSDOSPlotter():
 
         # add the labels
         ax.text(0.95, max_y - 1.25, g_label, fontsize=16,
-                family='Times New Roman', color=(0, 1, 0))
+                family='Times New Roman', color=(0, 0, 0))
         ax.text(0.45, max_y - 0.3, r_label, fontsize=16,
-                family='Times New Roman', color=(1, 0, 0))
+                family='Times New Roman', color=(0, 0, 0))
         ax.text(0.05, max_y - 1.25, b_label, fontsize=16,
-                family='Times New Roman', color=(0, 0, 1))
+                family='Times New Roman', color=(0, 0, 0))
 
     @staticmethod
     def _rb_line(ax, r_label, b_label):

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -1368,9 +1368,9 @@ class BSDOSPlotter():
         # plot the bar
         ax.scatter(x, y, s=250., marker='s', edgecolor=color)
         ax.text(1.3, max_y - 0.6, b_label, fontsize=16,
-                family='Times New Roman', color=(0, 0, 1))
+                family='Times New Roman', color=(0, 0, 0))
         ax.text(0, max_y - 0.6, r_label, fontsize=16,
-                family='Times New Roman', color=(1, 0, 0))
+                family='Times New Roman', color=(0, 0, 0))
 
 
 class BoltztrapPlotter(object):


### PR DESCRIPTION
## Summary

This PR adds a new style of legend to the BSDOSPlotter, the rgb_legend, which is by default False. If enabled, it can add a colored RGB triangle (ternaries) or RB bar (binaries) to show how the various colors on projected plots map to element ratios.

Note that the alternate (default) style is a more conventional style of legend.

Some examples of the rgb_legend style are shown below

![2_el](https://cloud.githubusercontent.com/assets/986759/23084330/a0da5428-f516-11e6-8872-5861d682bc2f.png)
![3_el](https://cloud.githubusercontent.com/assets/986759/23084332/a4403d30-f516-11e6-9a10-12f963e28723.png)

Also, thanks to Jan Pohls for sharing his code from which this was based.

## Additional dependencies introduced (if any)

None

## TODO (if any)

* Unfortunately, as can be seen in the above diagrams, the band structure plots can overlap the legend diagrams in some systems. In the limited time I had to develop this, I was not able to develop a fix. e.g., simply adding a matplotlib rectangle Patch object to try to cover up the band structure and create more of a "legend" style didn't work.  The overlap can cause things to look a little funny which is one reason the rgb_legend style is not default for now.

This branch can be safely deleted after merge.