### PR TITLE
Pass the user defined symprec to spglib.get_ir_reciprocal_mesh 

### DIFF
--- a/pymatgen/symmetry/analyzer.py
+++ b/pymatgen/symmetry/analyzer.py
@@ -389,7 +389,7 @@ class SpacegroupAnalyzer(object):
         """
         shift = np.array([1 if i else 0 for i in is_shift])
         mapping, grid = spglib.get_ir_reciprocal_mesh(
-            np.array(mesh), self._cell, is_shift=shift)
+            np.array(mesh), self._cell, is_shift=shift, symprec=self._symprec)
 
         results = []
         tmp_map = list(mapping)
@@ -777,7 +777,7 @@ class SpacegroupAnalyzer(object):
                 shift.append(1)
 
         mapping, grid = spglib.get_ir_reciprocal_mesh(
-            np.array(mesh), self._cell, is_shift=shift)
+            np.array(mesh), self._cell, is_shift=shift, symprec=self._symprec)
         mapping = list(mapping)
         grid = (np.array(grid) + np.array(shift) * (0.5, 0.5, 0.5)) / mesh
         weights = []


### PR DESCRIPTION

## Summary

In SpacegroupAnalyzer the defined value of symprec is not propagated to spglib when calling the get_ir_reciprocal_mesh function, that instead uses a default of 1e-5. This may lead to unexpected behaviours and inconsistencies between the obtained space group and the list of irreducible kpoints. This pull request fixes this problem passing self._symprec to the function. 
Notice that the get_ir_reciprocal_mesh function in spglib does not accept angle_tolerance as an argument.