### PR TITLE
BSDOS color interpolation update

### DIFF
--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -1298,6 +1298,8 @@ class BSDOSPlotter():
                         if bs_projection and bs_projection.lower() == "elements":
                             c = [0, 0, 0]
                             projs = projections[spin][band_idx][k_idx]
+                            # note: squared color interpolations are smoother
+                            # see: https://youtu.be/LKnqECcg6Gw
                             projs = dict([(k, v**2) for k, v in projs.items()])
                             total = sum(projs.values())
                             if total > 0:

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -1298,10 +1298,11 @@ class BSDOSPlotter():
                         if bs_projection and bs_projection.lower() == "elements":
                             c = [0, 0, 0]
                             projs = projections[spin][band_idx][k_idx]
+                            projs = dict([(k, v**2) for k, v in projs.items()])
                             total = sum(projs.values())
                             if total > 0:
                                 for idx, e in enumerate(elements):
-                                    c[idx] = projs[e]/total  # min is to handle round errors
+                                    c[idx] = math.sqrt(projs[e]/total)  # min is to handle round errors
 
                             c = [c[1], c[2], c[0]]  # prefer blue, then red, then green
 
@@ -1335,7 +1336,10 @@ class BSDOSPlotter():
                         b1 = b / (r + g + b)
                         x.append(0.33 * (2. * g1 + r1) / (r1 + b1 + g1))
                         y.append(0.33 * np.sqrt(3) * r1 / (r1 + b1 + g1))
-                        color.append([r1, g1, b1])
+                        rc = math.sqrt(r**2 / (r**2 + g**2 + b**2))
+                        gc = math.sqrt(g**2 / (r**2 + g**2 + b**2))
+                        bc = math.sqrt(b**2 / (r**2 + g**2 + b**2))
+                        color.append([rc, gc, bc])
 
         max_y = ax.get_ylim()[1]
         x = [n + 0.25 for n in x]  # nudge x coordinates
@@ -1363,7 +1367,8 @@ class BSDOSPlotter():
         for i in range(0, 1000):
             x.append(i / 1800. + 0.55)
             y.append(max_y - 0.5)
-            color.append([1 - i/1000, 0, i / 1000])
+            color.append([math.sqrt(c) for c in
+                          [1 - (i/1000)**2, 0, (i / 1000)**2]])
 
         # plot the bar
         ax.scatter(x, y, s=250., marker='s', edgecolor=color)


### PR DESCRIPTION
## Summary

This is just a subtle change to the BSDOS coloring (both in the plot as well as in the legend). RGB values are interpolated based on square values. The reasoning is explained in this video:

https://youtu.be/LKnqECcg6Gw

Thanks to Matt Horton for pointing this out.

The squared values indeed lead to more pleasing results as can be seen in the before/after shots below. A blind test of a colleague demonstrated that in the GaP plot in particular, more information was gleaned about the band structure projections using the new coloring. For the KTaO3 example it's clearest to see how the coloring changes in the legend, the actual plot looks similar.

Before:
![2_el](https://cloud.githubusercontent.com/assets/986759/23091470/c1ac9f44-f56b-11e6-857a-49ae73b0bbc5.png)
After:
![2_el_revised](https://cloud.githubusercontent.com/assets/986759/23091471/c7cec442-f56b-11e6-8a18-1e344c209507.png)

Before:
![3_el](https://cloud.githubusercontent.com/assets/986759/23091472/cd82b1aa-f56b-11e6-8961-dfc791e6d5dd.png)
After:
![3_el_revised](https://cloud.githubusercontent.com/assets/986759/23091476/d2166dd8-f56b-11e6-8314-5c4d89cd6f92.png)

