### PR TITLE
Bug fixes in Interstitial class and Zeo++ python 3 compatibility

### DIFF
--- a/pymatgen/io/zeopp.py
+++ b/pymatgen/io/zeopp.py
@@ -29,14 +29,51 @@ except ImportError:
 
 """
 Module implementing classes and functions to use Zeo++.
-Zeo++ can be obtained from http://www.maciejharanczyk.info/Zeopp/
+
+Zeo++ Installation Steps:
+========================
+1) Zeo++ requires Voro++. Download Voro++ from code.lbl.gov using
+   subversion:
+   "svn checkout --username anonsvn https://code.lbl.gov/svn/voro/trunk
+   Password is anonsvn.
+2) Stable version of Zeo++ can be obtained from
+   http://www.maciejharanczyk.info/Zeopp/
+   Alternatively it can be obtained from code.lbl.gov. Replace voro
+   with zeo.
+3) (Optional) Install cython from pip
+Mac OS X:
+4) (a) Edit the Voro++/voro/trunk/config.mk file to suit your environment
+   (compiler, linker).
+   (b) Run make command
+5) (a) Edit the Zeo++/trunk/cython_wrapper/setup.py to correctly point to
+   Voro++ directory.
+   (b) Run "python setup.py develop" to install Zeo++ python bindings.
+   Be patient, it will take a while.
+Linux:
+4) (a) Edit the Voro++/voro/trunk/config.mk file to suit your environment.
+   (b) Also add -fPIC option to CFLAGS variable in config.mk file.
+   (c) Run make command
+5) (a) Go to Zeo++/zeo/trunk folder and compile zeo++ library using the
+   command "make dylib".
+   (b) Edit the Zeo++/trunk/cython_wrapper/setup_alt.py to correctly
+   point to Voro++ directory.
+   (c) Run "python setup_alt.py develop" to install Zeo++ python bindings.
+
+Zeo++ Post-Installation Checking:
+==============================
+1) Go to pymatgen/io/tests and run "python test_zeoio.py"
+   If Zeo++ python bindings are properly installed, the tests should
+   pass. One or two tests will be skipped.
+b) Go to pymatgen/analysis/defects/tests and run
+   "python test_point_defects.py". Lots of tests will be skipped if GULP
+   is not installed. But there should be no errors.
 """
 
 __author__ = "Bharat Medasani"
 __copyright = "Copyright 2013, The Materials Project"
 __version__ = "0.1"
 __maintainer__ = "Bharat Medasani"
-__email__ = "bkmedasani@lbl.gov"
+__email__ = "mbkumar@gmail.com"
 __data__ = "Aug 2, 2013"
 
 


### PR DESCRIPTION
## Summary

Long pending modifications with respect to Zeo++ implemented.

* python3 compatibility for Zeo++ python bindings  
* SpagegroupAnalyzer.get_symmetrized_structure fails for dense voronoi points. Voronoi points are pruned if close before passing to SpgA
* Zeo++ installation instructions added 

## Additional dependencies introduced (if any):
<Zeo++>

