### PR TITLE
Reaction Balancing

### DIFF
--- a/pymatgen/analysis/reaction_calculator.py
+++ b/pymatgen/analysis/reaction_calculator.py
@@ -222,15 +222,15 @@ class BalancedReaction(MSONable):
 
     @classmethod
     def _str_from_comp(cls, coeffs, compositions, reduce=False):
-        r_coeffs = []
+        r_coeffs = np.zeros(len(coeffs))
         r_formulas = []
-        for amt, comp in zip(coeffs, compositions):
+        for i, (amt, comp) in enumerate(zip(coeffs, compositions)):
             formula, factor = comp.get_reduced_formula_and_factor()
-            r_coeffs.append(amt * factor)
+            r_coeffs[i] = amt * factor
             r_formulas.append(formula)
         if reduce:
-            factor = gcd_float(np.abs(r_coeffs))
-            r_coeffs /= factor
+            factor = 1 / gcd_float(np.abs(r_coeffs))
+            r_coeffs *= factor
         else:
             factor = 1
         return cls._str_from_formulas(r_coeffs, r_formulas), factor

--- a/pymatgen/analysis/reaction_calculator.py
+++ b/pymatgen/analysis/reaction_calculator.py
@@ -214,9 +214,9 @@ class BalancedReaction(MSONable):
             elif abs(amt - 1) < cls.TOLERANCE:
                 product_str.append(formula)
             elif amt < -cls.TOLERANCE:
-                reactant_str.append("{:.3g} {}".format(-amt, formula))
+                reactant_str.append("{:.4g} {}".format(-amt, formula))
             elif amt > cls.TOLERANCE:
-                product_str.append("{:.3g} {}".format(amt, formula))
+                product_str.append("{:.4g} {}".format(amt, formula))
 
         return " + ".join(reactant_str) + " -> " + " + ".join(product_str)
 

--- a/pymatgen/analysis/reaction_calculator.py
+++ b/pymatgen/analysis/reaction_calculator.py
@@ -285,9 +285,8 @@ class BalancedReaction(MSONable):
 
         def get_comp_amt(comp_str):
             return {Composition(m.group(2)): float(m.group(1) or 1)
-                    for m in re.finditer(r"([\d\.]*)\s*([A-Z][\w\.\(\)]*)",
+                    for m in re.finditer(r"([\d\.]*(?:[eE]-?[\d\.]+)?)\s*([A-Z][\w\.\(\)]*)",
                                          comp_str)}
-
         return BalancedReaction(get_comp_amt(rct_str), get_comp_amt(prod_str))
 
 

--- a/pymatgen/analysis/reaction_calculator.py
+++ b/pymatgen/analysis/reaction_calculator.py
@@ -311,7 +311,9 @@ class BalancedReaction(MSONable):
 class Reaction(BalancedReaction):
     """
     A more flexible class representing a Reaction. The reaction amounts will
-    be automatically balanced.
+    be automatically balanced. Reactants and products can swap sides so that
+    all coefficients are positive. Normalizes so that the last product defined
+    has a coefficient of one (and remains on the products side)
     """
 
     def __init__(self, reactants, products):
@@ -355,7 +357,7 @@ class Reaction(BalancedReaction):
             raise ReactionError("Reaction cannot be balanced.")
 
         # normalizing to last non-zero product
-        coeffs /= coeffs[coeffs > self.TOLERANCE][-1]
+        coeffs /= coeffs[np.abs(coeffs) > self.TOLERANCE][-1]
         # Reactants have negative coefficients
         coeffs[:len(reactants)] *= -1
 

--- a/pymatgen/analysis/tests/test_reaction_calculator.py
+++ b/pymatgen/analysis/tests/test_reaction_calculator.py
@@ -24,7 +24,9 @@ class ReactionTest(unittest.TestCase):
 
         d = rxn.as_dict()
         rxn = Reaction.from_dict(d)
-        self.assertEqual(rxn.normalized_repr, "4 Fe + 3 O2 -> 2 Fe2O3")
+        repr, factor = rxn.normalized_repr_and_factor()
+        self.assertEqual(repr, "4 Fe + 3 O2 -> 2 Fe2O3")
+        self.assertAlmostEqual(factor, 2)
 
         reactants = [Composition("FePO4"), Composition('Mn')]
         products = [Composition("FePO4"), Composition('Xe')]

--- a/pymatgen/analysis/tests/test_reaction_calculator.py
+++ b/pymatgen/analysis/tests/test_reaction_calculator.py
@@ -29,19 +29,8 @@ class ReactionTest(unittest.TestCase):
         self.assertEqual(rxn.normalized_repr, "4 Fe + 3 O2 -> 2 Fe2O3",
                          "Wrong normalized reaction obtained!")
 
-        reactants = [Composition("Fe"), Composition("O"), Composition("Mn"),
-                     Composition("P")]
-        products = [Composition("FeP"), Composition("MnO")]
-        rxn = Reaction(reactants, products)
-        self.assertEqual(str(rxn),
-                         "1.000 Fe + 0.500 O2 + 1.000 Mn + 1.000 P -> 1.000 FeP + 1.000 MnO",
-                         "Wrong reaction obtained!")
-        self.assertEqual(rxn.normalized_repr,
-                         "2 Fe + O2 + 2 Mn + 2 P -> 2 FeP + 2 MnO",
-                         "Wrong normalized reaction obtained!")
-        reactants = [Composition("FePO4")]
-        products = [Composition("FePO4")]
-
+        reactants = [Composition("FePO4"), Composition('Mn')]
+        products = [Composition("FePO4"), Composition('Xe')]
         rxn = Reaction(reactants, products)
         self.assertEqual(str(rxn), "1.000 FePO4 -> 1.000 FePO4",
                          "Wrong reaction obtained!")
@@ -149,7 +138,7 @@ class ReactionTest(unittest.TestCase):
         energies = {Composition("Fe"): 0, Composition("O2"): 0,
                     Composition("Fe2O3"): 0.5}
         entry = rxn.as_entry(energies)
-        self.assertEqual(entry.composition.formula, "Fe1.33333333 O2")
+        self.assertEqual(entry.composition, Composition("Fe1.33333333 O2"))
         self.assertAlmostEqual(entry.energy, -0.333333, 5)
 
     def test_products_reactants(self):
@@ -178,6 +167,11 @@ class ReactionTest(unittest.TestCase):
         d = rxn.as_dict()
         rxn = Reaction.from_dict(d)
         self.assertEqual(rxn.normalized_repr, "4 Fe + 3 O2 -> 2 Fe2O3")
+
+    def test_underdetermined(self):
+        reactants = [Composition("Fe"), Composition("O2")]
+        products = [Composition("Fe"), Composition("O2")]
+        self.assertRaises(ReactionError, Reaction, reactants, products)
 
 
 class BalancedReactionTest(unittest.TestCase):

--- a/pymatgen/analysis/tests/test_reaction_calculator.py
+++ b/pymatgen/analysis/tests/test_reaction_calculator.py
@@ -82,6 +82,16 @@ class ReactionTest(unittest.TestCase):
         self.assertEqual(str(rxn),
                          "LiLa3Ti3CrO12 -> 1.5 La2Ti2O3 + 2.75 O2 + LiCrO2")
 
+    def test_singular_case(self):
+        rxn = Reaction([Composition('XeMn'), Composition("Li")],
+                       [Composition("LiS2"), Composition("S"),
+                        Composition('FeCl')])
+        self.assertEqual(str(rxn), '0.5 LiS2 -> 0.5 Li + S')
+
+    def test_overdetermined(self):
+        self.assertRaises(ReactionError, Reaction, [Composition("Li")],
+                          [Composition("LiO2")])
+
     def test_scientific_notation(self):
         products = [Composition("O2"), Composition("FePO3.9999")]
         reactants = [Composition("FePO4")]

--- a/pymatgen/analysis/tests/test_reaction_calculator.py
+++ b/pymatgen/analysis/tests/test_reaction_calculator.py
@@ -152,7 +152,7 @@ class ReactionTest(unittest.TestCase):
         self.assertIn(Composition("Li3Fe2(PO4)3"), rxn.reactants,
                       "Li3Fe2(PO4)4 not in reactants!")
         self.assertEqual(str(rxn),
-                         "0.333 Li3Fe2(PO4)3 + 0.167 Fe2O3 -> 0.25 O2 + LiFePO4")
+                         "0.3333 Li3Fe2(PO4)3 + 0.1667 Fe2O3 -> 0.25 O2 + LiFePO4")
         self.assertEqual(rxn.normalized_repr,
                          "4 Li3Fe2(PO4)3 + 2 Fe2O3 -> 3 O2 + 12 LiFePO4")
         self.assertAlmostEqual(rxn.calculate_energy(energies), -0.48333333, 5)

--- a/pymatgen/analysis/tests/test_reaction_calculator.py
+++ b/pymatgen/analysis/tests/test_reaction_calculator.py
@@ -66,7 +66,7 @@ class ReactionTest(unittest.TestCase):
         products = [Composition("Na2O"), Composition("K")]
         rxn = Reaction(reactants, products)
         self.assertEqual(str(rxn),
-                         "Na + 0.5 K2O -> 0.5 Na2O + K")
+                         "2 Na + K2O -> Na2O + 2 K")
 
         # Test for an old bug which has a problem when excess product is
         # defined.
@@ -76,15 +76,15 @@ class ReactionTest(unittest.TestCase):
 
         self.assertEqual(str(rxn), "FePO4 -> FePO4")
 
-        products = list(map(Composition, ['La8Ti8O12', 'O2', 'LiCrO2']))
+        products = list(map(Composition, ['LiCrO2', 'La8Ti8O12', 'O2']))
         reactants = [Composition('LiLa3Ti3CrO12')]
         rxn = Reaction(reactants, products)
         self.assertEqual(str(rxn),
-                         "LiLa3Ti3CrO12 -> 1.5 La2Ti2O3 + 2.75 O2 + LiCrO2")
+                         "LiLa3Ti3CrO12 -> LiCrO2 + 1.5 La2Ti2O3 + 2.75 O2")
 
     def test_singular_case(self):
         rxn = Reaction([Composition('XeMn'), Composition("Li")],
-                       [Composition("LiS2"), Composition("S"),
+                       [Composition("S"), Composition("LiS2"),
                         Composition('FeCl')])
         self.assertEqual(str(rxn), '0.5 LiS2 -> 0.5 Li + S')
 
@@ -93,10 +93,10 @@ class ReactionTest(unittest.TestCase):
                           [Composition("LiO2")])
 
     def test_scientific_notation(self):
-        products = [Composition("O2"), Composition("FePO3.9999")]
+        products = [Composition("FePO3.9999"), Composition("O2")]
         reactants = [Composition("FePO4")]
         rxn = Reaction(reactants, products)
-        self.assertEqual(str(rxn), "FePO4 -> 5e-05 O2 + Fe1P1O3.9999")
+        self.assertEqual(str(rxn), "FePO4 -> Fe1P1O3.9999 + 5e-05 O2")
         self.assertEqual(rxn, Reaction.from_string(str(rxn)))
 
         rxn2 = Reaction.from_string("FePO4 + 20 CO -> 1e1 O2 + Fe1P1O4 + 20 C")
@@ -147,8 +147,8 @@ class ReactionTest(unittest.TestCase):
         energies = {Composition("Fe"): 0, Composition("O2"): 0,
                     Composition("Fe2O3"): 0.5}
         entry = rxn.as_entry(energies)
-        self.assertEqual(entry.composition, Composition("Fe1.33333333 O2"))
-        self.assertAlmostEqual(entry.energy, -0.333333, 5)
+        self.assertEqual(entry.composition, Composition("Fe1.0 O1.5"))
+        self.assertAlmostEqual(entry.energy, -0.25, 5)
 
     def test_products_reactants(self):
         reactants = [Composition("Li3Fe2(PO4)3"), Composition("Fe2O3"),
@@ -196,10 +196,11 @@ class ReactionTest(unittest.TestCase):
                      Composition("Na"),
                      Composition("Li2O"),
                      Composition("Cl")]
-        products = [Composition("FeCl"), Composition("Na2O"),
-                    Composition("Xe"), Composition("LiCl"), Composition("Mn")]
+        products = [Composition("LiCl"), Composition("Na2O"),
+                    Composition("Xe"), Composition("FeCl"), Composition("Mn")]
         rxn = Reaction(reactants, products)
-        self.assertEqual(str(rxn), "Fe + Na + 0.5 Li2O + Cl2 -> FeCl + 0.5 Na2O + LiCl")
+        # this cant normalize to 1 LiCl + 1 Na2O (not enough O), so chooses LiCl and FeCl
+        self.assertEqual(str(rxn), "Fe + Na + 0.5 Li2O + Cl2 -> LiCl + 0.5 Na2O + FeCl")
 
 class BalancedReactionTest(unittest.TestCase):
     def test_init(self):

--- a/pymatgen/analysis/tests/test_reaction_calculator.py
+++ b/pymatgen/analysis/tests/test_reaction_calculator.py
@@ -19,62 +19,52 @@ class ReactionTest(unittest.TestCase):
                      Composition("O2")]
         products = [Composition("Fe2O3")]
         rxn = Reaction(reactants, products)
-        self.assertEqual(str(rxn), "2.000 Fe + 1.500 O2 -> 1.000 Fe2O3",
-                         "Wrong reaction obtained!")
-        self.assertEqual(rxn.normalized_repr, "4 Fe + 3 O2 -> 2 Fe2O3",
-                         "Wrong normalized reaction obtained!")
+        self.assertEqual(str(rxn), "2 Fe + 1.5 O2 -> Fe2O3")
+        self.assertEqual(rxn.normalized_repr, "4 Fe + 3 O2 -> 2 Fe2O3")
 
         d = rxn.as_dict()
         rxn = Reaction.from_dict(d)
-        self.assertEqual(rxn.normalized_repr, "4 Fe + 3 O2 -> 2 Fe2O3",
-                         "Wrong normalized reaction obtained!")
+        self.assertEqual(rxn.normalized_repr, "4 Fe + 3 O2 -> 2 Fe2O3")
 
         reactants = [Composition("FePO4"), Composition('Mn')]
         products = [Composition("FePO4"), Composition('Xe')]
         rxn = Reaction(reactants, products)
-        self.assertEqual(str(rxn), "1.000 FePO4 -> 1.000 FePO4",
-                         "Wrong reaction obtained!")
+        self.assertEqual(str(rxn), "FePO4 -> FePO4")
 
         products = [Composition("Ti2 O4"), Composition("O1")]
         reactants = [Composition("Ti1 O2")]
         rxn = Reaction(reactants, products)
-        self.assertEqual(str(rxn), "2.000 TiO2 -> 2.000 TiO2",
-                         "Wrong reaction obtained!")
+        self.assertEqual(str(rxn), "2 TiO2 -> 2 TiO2")
 
         reactants = [Composition("FePO4"), Composition("Li")]
         products = [Composition("LiFePO4")]
         rxn = Reaction(reactants, products)
-        self.assertEqual(str(rxn), "1.000 FePO4 + 1.000 Li -> 1.000 LiFePO4",
-                         "Wrong reaction obtained!")
+        self.assertEqual(str(rxn), "FePO4 + Li -> LiFePO4")
 
         reactants = [Composition("MgO")]
         products = [Composition("MgO")]
 
         rxn = Reaction(reactants, products)
-        self.assertEqual(str(rxn), "1.000 MgO -> 1.000 MgO",
-                         "Wrong reaction obtained!")
+        self.assertEqual(str(rxn), "MgO -> MgO")
 
         reactants = [Composition("Mg")]
         products = [Composition("Mg")]
 
         rxn = Reaction(reactants, products)
-        self.assertEqual(str(rxn), "1.000 Mg -> 1.000 Mg",
-                         "Wrong reaction obtained!")
+        self.assertEqual(str(rxn), "Mg -> Mg")
 
         reactants = [Composition("FePO4"), Composition("LiPO3")]
         products = [Composition("LiFeP2O7")]
 
         rxn = Reaction(reactants, products)
         self.assertEqual(str(rxn),
-                         "1.000 FePO4 + 1.000 LiPO3 -> 1.000 LiFeP2O7",
-                         "Wrong reaction obtained!")
+                         "FePO4 + LiPO3 -> LiFeP2O7")
 
         reactants = [Composition("Na"), Composition("K2O")]
         products = [Composition("Na2O"), Composition("K")]
         rxn = Reaction(reactants, products)
         self.assertEqual(str(rxn),
-                         "1.000 Na + 0.500 K2O -> 0.500 Na2O + 1.000 K",
-                         "Wrong reaction obtained!")
+                         "Na + 0.5 K2O -> 0.5 Na2O + K")
 
         # Test for an old bug which has a problem when excess product is
         # defined.
@@ -82,15 +72,13 @@ class ReactionTest(unittest.TestCase):
         reactants = [Composition("FePO4")]
         rxn = Reaction(reactants, products)
 
-        self.assertEqual(str(rxn), "1.000 FePO4 -> 1.000 FePO4",
-                         "Wrong reaction obtained!")
+        self.assertEqual(str(rxn), "FePO4 -> FePO4")
 
         products = list(map(Composition, ['La8Ti8O12', 'O2', 'LiCrO2']))
         reactants = [Composition('LiLa3Ti3CrO12')]
         rxn = Reaction(reactants, products)
         self.assertEqual(str(rxn),
-                         "1.000 LiLa3Ti3CrO12 -> 1.500 La2Ti2O3 + 2.750 O2 + 1.000 LiCrO2",
-                         "Wrong reaction obtained!")
+                         "LiLa3Ti3CrO12 -> 1.5 La2Ti2O3 + 2.75 O2 + LiCrO2")
 
     def test_equals(self):
         reactants = [Composition("Fe"),
@@ -107,8 +95,7 @@ class ReactionTest(unittest.TestCase):
         reactants = [Composition("Fe2O3")]
         rxn = Reaction(reactants, products)
         rxn.normalize_to(Composition("Fe"), 3)
-        self.assertEqual(str(rxn), "1.500 Fe2O3 -> 3.000 Fe + 2.250 O2",
-                         "Wrong reaction obtained!")
+        self.assertEqual(str(rxn), "1.5 Fe2O3 -> 3 Fe + 2.25 O2")
 
     def test_calculate_energy(self):
         reactants = [Composition("MgO"), Composition("Al2O3")]
@@ -117,7 +104,7 @@ class ReactionTest(unittest.TestCase):
                     Composition("MgAl2O4"): -0.5}
         rxn = Reaction(reactants, products)
         self.assertEqual(str(rxn),
-                         "1.000 MgO + 1.000 Al2O3 -> 1.000 MgAl2O4")
+                         "MgO + Al2O3 -> MgAl2O4")
         self.assertEqual(rxn.normalized_repr, "MgO + Al2O3 -> MgAl2O4")
         self.assertAlmostEqual(rxn.calculate_energy(energies), -0.2, 5)
 
@@ -129,7 +116,7 @@ class ReactionTest(unittest.TestCase):
         rxn = Reaction(reactants, products)
         entry = rxn.as_entry(energies)
         self.assertEqual(entry.name,
-                         "1.000 MgO + 1.000 Al2O3 -> 1.000 MgAl2O4")
+                         "MgO + Al2O3 -> MgAl2O4")
         self.assertAlmostEqual(entry.energy, -0.2, 5)
 
         products = [Composition("Fe"), Composition("O2")]
@@ -155,7 +142,7 @@ class ReactionTest(unittest.TestCase):
         self.assertIn(Composition("Li3Fe2(PO4)3"), rxn.reactants,
                       "Li3Fe2(PO4)4 not in reactants!")
         self.assertEqual(str(rxn),
-                         "0.333 Li3Fe2(PO4)3 + 0.167 Fe2O3 -> 0.250 O2 + 1.000 LiFePO4")
+                         "0.333 Li3Fe2(PO4)3 + 0.167 Fe2O3 -> 0.25 O2 + LiFePO4")
         self.assertEqual(rxn.normalized_repr,
                          "4 Li3Fe2(PO4)3 + 2 Fe2O3 -> 3 O2 + 12 LiFePO4")
         self.assertAlmostEqual(rxn.calculate_energy(energies), -0.48333333, 5)
@@ -246,12 +233,12 @@ class ComputedReactionTest(unittest.TestCase):
                                - 5.60748821935)
 
     def test_init(self):
-        self.assertEqual(str(self.rxn), "1.000 O2 + 2.000 Li -> 1.000 Li2O2")
+        self.assertEqual(str(self.rxn), "O2 + 2 Li -> Li2O2")
 
     def test_to_from_dict(self):
         d = self.rxn.as_dict()
         new_rxn = ComputedReaction.from_dict(d)
-        self.assertEqual(str(new_rxn), "1.000 O2 + 2.000 Li -> 1.000 Li2O2")
+        self.assertEqual(str(new_rxn), "O2 + 2 Li -> Li2O2")
 
     def test_all_entries(self):
         for c, e in zip(self.rxn.coeffs, self.rxn.all_entries):

--- a/pymatgen/analysis/tests/test_reaction_calculator.py
+++ b/pymatgen/analysis/tests/test_reaction_calculator.py
@@ -180,8 +180,26 @@ class ReactionTest(unittest.TestCase):
     def test_underdetermined(self):
         reactants = [Composition("Fe"), Composition("O2")]
         products = [Composition("Fe"), Composition("O2")]
-        self.assertRaises(ReactionError, Reaction, reactants, products)
+        rxn = Reaction(reactants, products)
+        self.assertEqual(str(rxn), "Fe + O2 -> Fe + O2")
 
+        reactants = [Composition("Fe"),
+                     Composition("O2"),
+                     Composition("Na"),
+                     Composition("Li"),
+                     Composition("Cl")]
+        products = [Composition("FeO2"), Composition("NaCl"), Composition("Li2Cl2")]
+        rxn = Reaction(reactants, products)
+        self.assertEqual(str(rxn), "Fe + O2 + Na + 2 Li + 1.5 Cl2 -> FeO2 + NaCl + 2 LiCl")
+
+        reactants = [Composition("Fe"),
+                     Composition("Na"),
+                     Composition("Li2O"),
+                     Composition("Cl")]
+        products = [Composition("FeCl"), Composition("Na2O"),
+                    Composition("Xe"), Composition("LiCl"), Composition("Mn")]
+        rxn = Reaction(reactants, products)
+        self.assertEqual(str(rxn), "Fe + Na + 0.5 Li2O + Cl2 -> FeCl + 0.5 Na2O + LiCl")
 
 class BalancedReactionTest(unittest.TestCase):
     def test_init(self):

--- a/pymatgen/analysis/tests/test_reaction_calculator.py
+++ b/pymatgen/analysis/tests/test_reaction_calculator.py
@@ -80,6 +80,16 @@ class ReactionTest(unittest.TestCase):
         self.assertEqual(str(rxn),
                          "LiLa3Ti3CrO12 -> 1.5 La2Ti2O3 + 2.75 O2 + LiCrO2")
 
+    def test_scientific_notation(self):
+        products = [Composition("O2"), Composition("FePO3.9999")]
+        reactants = [Composition("FePO4")]
+        rxn = Reaction(reactants, products)
+        self.assertEqual(str(rxn), "FePO4 -> 5e-05 O2 + Fe1P1O3.9999")
+        self.assertEqual(rxn, Reaction.from_string(str(rxn)))
+
+        rxn2 = Reaction.from_string("FePO4 + 20 CO -> 1e1 O2 + Fe1P1O4 + 20 C")
+        self.assertEqual(str(rxn2), "20 CO -> 10 O2 + 20 C")
+
     def test_equals(self):
         reactants = [Composition("Fe"),
                      Composition("O2")]

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -653,7 +653,6 @@ class Vasprun(MSONable):
                                  self.final_energy, parameters=params,
                                  data=data)
 
-    #@profile
     def get_band_structure(self, kpoints_filename=None, efermi=None,
                            line_mode=False):
         """

--- a/pymatgen/phasediagram/analyzer.py
+++ b/pymatgen/phasediagram/analyzer.py
@@ -329,7 +329,7 @@ class PDAnalyzer(object):
 
             if not are_same_decomp(prev_decomp, decomp):
                 if elcomp not in decomp:
-                    decomp.insert(0, elcomp)
+                    decomp.append(elcomp)
                 rxn = Reaction([comp], decomp)
                 rxn.normalize_to(comp)
                 prev_decomp = decomp


### PR DESCRIPTION
## Summary

Cleaned up the reaction balancing.

Changed string formatting of reactions to avoid superfluous zeros and decimals. Also made the reaction strings consistent with each other (the formatting of different methods was slightly different).

Redefined and documented how Reactions are balanced by default. This is backwards incompatible, but the previous default was not documented or intuitive.

Fixed some weird balancing issues, for example, balancing
Fe + Na + Li2O + Cl -> FeCl2 + Na2O + Xe + LiCl + Mn
used to return
2 Na + Li2O + 5 FeCl2 -> 5 Fe + 4 Cl2 + Na2O + 2 LiCl
now it returns
Fe + 2 Na + Li2O + 2 Cl2 -> FeCl2 + Na2O + 2 LiCl
which is more reasonable. (Though this is obviously a contrived example.)