### PR TITLE
Refactoring of PDAnalyzer.get_element_profile

### DIFF
--- a/pymatgen/analysis/tests/test_reaction_calculator.py
+++ b/pymatgen/analysis/tests/test_reaction_calculator.py
@@ -202,6 +202,14 @@ class ReactionTest(unittest.TestCase):
         # this cant normalize to 1 LiCl + 1 Na2O (not enough O), so chooses LiCl and FeCl
         self.assertEqual(str(rxn), "Fe + Na + 0.5 Li2O + Cl2 -> LiCl + 0.5 Na2O + FeCl")
 
+    def test_underdetermined_reactants(self):
+        reactants = [Composition("Li"),
+                     Composition("Cl"),
+                     Composition("Cl")]
+        products = [Composition("LiCl")]
+        self.assertRaisesRegexp(ReactionError, "underdetermined", Reaction,
+                                reactants, products)
+
 class BalancedReactionTest(unittest.TestCase):
     def test_init(self):
         rct = {Composition('K2SO4'): 3, Composition('Na2S'): 1,

--- a/pymatgen/phasediagram/analyzer.py
+++ b/pymatgen/phasediagram/analyzer.py
@@ -308,7 +308,7 @@ class PDAnalyzer(object):
         for cc in self.get_critical_compositions(elcomp, gccomp)[1:]:
             decomp_entries = self.get_decomposition(cc).keys()
             decomp = [k.composition for k in decomp_entries]
-            rxn = Reaction([comp, elcomp], decomp)
+            rxn = Reaction([comp], decomp + [elcomp])
             rxn.normalize_to(comp)
             c = self.get_composition_chempots(cc + elcomp * 1e-5)[element]
             amt = -rxn.coeffs[rxn.all_comp.index(elcomp)]

--- a/pymatgen/phasediagram/analyzer.py
+++ b/pymatgen/phasediagram/analyzer.py
@@ -299,45 +299,23 @@ class PDAnalyzer(object):
         if element not in self._pd.elements:
             raise ValueError("get_transition_chempots can only be called with"
                              " elements in the phase diagram.")
-        chempots = self.get_transition_chempots(element)
-        stable_entries = self._pd.stable_entries
         gccomp = Composition({el: amt for el, amt in comp.items()
                               if el != element})
         elref = self._pd.el_refs[element]
         elcomp = Composition(element.symbol)
-        prev_decomp = []
         evolution = []
 
-        def are_same_decomp(decomp1, decomp2):
-            for comp in decomp2:
-                if comp not in decomp1:
-                    return False
-            return True
-
-        for c in chempots:
-            gcpd = GrandPotentialPhaseDiagram(
-                stable_entries, {element: c - 1e-5}, self._pd.elements
-            )
-            analyzer = PDAnalyzer(gcpd)
-            gcdecomp = analyzer.get_decomposition(gccomp)
-            decomp = [gcentry.original_entry.composition
-                      for gcentry, amt in gcdecomp.items()
-                      if amt > comp_tol]
-            decomp_entries = [gcentry.original_entry
-                              for gcentry, amt in gcdecomp.items()
-                              if amt > comp_tol]
-
-            if not are_same_decomp(prev_decomp, decomp):
-                if elcomp not in decomp:
-                    decomp.append(elcomp)
-                rxn = Reaction([comp], decomp)
-                rxn.normalize_to(comp)
-                prev_decomp = decomp
-                amt = -rxn.coeffs[rxn.all_comp.index(elcomp)]
-                evolution.append({'chempot': c,
-                                  'evolution': amt,
-                                  'element_reference': elref,
-                                  'reaction': rxn, 'entries': decomp_entries})
+        for cc in self.get_critical_compositions(elcomp, gccomp)[1:]:
+            decomp_entries = self.get_decomposition(cc).keys()
+            decomp = [k.composition for k in decomp_entries]
+            rxn = Reaction([comp, elcomp], decomp)
+            rxn.normalize_to(comp)
+            c = self.get_composition_chempots(cc + elcomp * 1e-5)[element]
+            amt = -rxn.coeffs[rxn.all_comp.index(elcomp)]
+            evolution.append({'chempot': c,
+                              'evolution': amt,
+                              'element_reference': elref,
+                              'reaction': rxn, 'entries': decomp_entries})
         return evolution
 
     def get_chempot_range_map(self, elements, referenced=True, joggle=True):

--- a/pymatgen/phasediagram/tests/test_pdanalyzer.py
+++ b/pymatgen/phasediagram/tests/test_pdanalyzer.py
@@ -73,6 +73,17 @@ class PDAnalyzerTest(unittest.TestCase):
                     self.assertLessEqual(len(self.analyzer.get_element_profile(el, entry.composition)),
                                          len(self.pd.facets))
 
+        expected = [{'evolution': 1.0,
+                     'chempot': -4.2582781416666666},
+                    {'evolution': 0,
+                     'chempot': -5.0885906699999968},
+                    {'evolution': -1.0,
+                     'chempot': -10.487582010000001}]
+        result = self.analyzer.get_element_profile(Element('O'), Composition('Li2O'))
+        for d1, d2 in zip(expected, result):
+            self.assertAlmostEqual(d1['evolution'], d2['evolution'])
+            self.assertAlmostEqual(d1['chempot'], d2['chempot'])
+
     def test_get_get_chempot_range_map(self):
         elements = [el for el in self.pd.elements if el.symbol != "Fe"]
         self.assertEqual(len(self.analyzer.get_chempot_range_map(elements)), 10)

--- a/pymatgen/phasediagram/tests/test_pdanalyzer.py
+++ b/pymatgen/phasediagram/tests/test_pdanalyzer.py
@@ -74,15 +74,19 @@ class PDAnalyzerTest(unittest.TestCase):
                                          len(self.pd.facets))
 
         expected = [{'evolution': 1.0,
-                     'chempot': -4.2582781416666666},
+                     'chempot': -4.2582781416666666,
+                     'reaction': 'Li2O + 0.5 O2 -> Li2O2'},
                     {'evolution': 0,
-                     'chempot': -5.0885906699999968},
+                     'chempot': -5.0885906699999968,
+                     'reaction': 'Li2O -> Li2O'},
                     {'evolution': -1.0,
-                     'chempot': -10.487582010000001}]
+                     'chempot': -10.487582010000001,
+                     'reaction': 'Li2O -> 2 Li + 0.5 O2'}]
         result = self.analyzer.get_element_profile(Element('O'), Composition('Li2O'))
         for d1, d2 in zip(expected, result):
             self.assertAlmostEqual(d1['evolution'], d2['evolution'])
             self.assertAlmostEqual(d1['chempot'], d2['chempot'])
+            self.assertEqual(d1['reaction'], str(d2['reaction']))
 
     def test_get_get_chempot_range_map(self):
         elements = [el for el in self.pd.elements if el.symbol != "Fe"]


### PR DESCRIPTION
## Summary
* Refactor PDAnalyzer.get_element_profile to use get_critical_compositions instead of generating new PDs
* More helpful error message in Reaction for underdetermined reactants. I don't think there's a useful result to return in these cases.
* Better unittests for get_element_profile