### PR TITLE
Fix bug in get_band_structure()

### DIFF
--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -755,16 +755,18 @@ class Vasprun(MSONable):
                 kpoints = kpoints[start_bs_index:nkpts]
                 up_eigen = [eigenvals[Spin.up][i][start_bs_index:nkpts]
                             for i in range(nbands)]
-                p_eigenvals[Spin.up] = [p_eigenvals[Spin.up][i][
-                                        start_bs_index:nkpts]
-                                        for i in range(nbands)]
+                if self.projected_eigenvalues:
+                    p_eigenvals[Spin.up] = [p_eigenvals[Spin.up][i][
+                                            start_bs_index:nkpts]
+                                            for i in range(nbands)]
                 if self.is_spin:
                     down_eigen = [eigenvals[Spin.down][i][start_bs_index:nkpts]
                                   for i in range(nbands)]
                     eigenvals = {Spin.up: up_eigen, Spin.down: down_eigen}
-                    p_eigenvals[Spin.down] = [p_eigenvals[Spin.down][i][
-                                              start_bs_index:nkpts]
-                                              for i in range(nbands)]
+                    if self.projected_eigenvalues:
+                        p_eigenvals[Spin.down] = [p_eigenvals[Spin.down][i][
+                                                start_bs_index:nkpts]
+                                                for i in range(nbands)]
                 else:
                     eigenvals = {Spin.up: up_eigen}
             else:


### PR DESCRIPTION
When fixing #602 I didn't check that the band structure had projections before discarding those corresponding to weighted k-points. As such trying to run `vr.get_band_structure()` when projections are not loaded results in an error.

This pull request fixes that bug.

However, this and #543 highlight the need for proper testing of the band structure functionality in pymatgen.