### PR TITLE
Added to Outcar and MPStaticSet to support LCALCPOL VASP flag

### DIFF
--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -2221,6 +2221,9 @@ class Outcar(MSONable):
         if self.lcalcpol:
             d.update({'p_elec': self.p_elec,
                       'p_ion': self.p_ion})
+            if self.spin and not self.noncollinear:
+                d.update({'p_sp1': self.p_sp1,
+                          'p_sp2': self.p_sp2})
 
         return d
 

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -434,7 +434,7 @@ class MPHSERelaxSet(DictSet):
 class MPStaticSet(MPRelaxSet):
 
     def __init__(self, structure, prev_incar=None, prev_kpoints=None,
-                 lepsilon=False, reciprocal_density=100, **kwargs):
+                 lepsilon=False, lcalcpol=False, reciprocal_density=100, **kwargs):
         """
         Run a static calculation.
 
@@ -456,6 +456,7 @@ class MPStaticSet(MPRelaxSet):
         self.structure = structure
         self.kwargs = kwargs
         self.lepsilon = lepsilon
+        self.lcalcpol = lcalcpol
 
     @property
     def incar(self):
@@ -475,6 +476,9 @@ class MPStaticSet(MPRelaxSet):
             # to output ionic.
             incar.pop("NSW", None)
             incar.pop("NPAR", None)
+
+        if self.lcalcpol:
+            incar["LCALCPOL"] = True
 
         for k in ["MAGMOM", "NUPDOWN"] + list(self.kwargs.get(
                 "user_incar_settings", {}).keys()):

--- a/pymatgen/io/vasp/tests/test_outputs.py
+++ b/pymatgen/io/vasp/tests/test_outputs.py
@@ -455,6 +455,20 @@ class OutcarTest(unittest.TestCase):
             self.assertAlmostEqual(outcar.born[0][1][2], -0.385)
             self.assertAlmostEqual(outcar.born[1][2][0], 0.36465)
 
+    def test_polarization(self):
+        filepath = os.path.join(test_dir, "OUTCAR.BaTiO3.polar")
+        outcar = Outcar(filepath)
+        self.assertEqual(outcar.spin, True)
+        self.assertEqual(outcar.noncollinear, False)
+        self.assertAlmostEqual(outcar.p_ion[0], 0.0)
+        self.assertAlmostEqual(outcar.p_ion[1],0.0)
+        self.assertAlmostEqual(outcar.p_ion[2], -5.56684)
+        self.assertAlmostEqual(outcar.p_sp1[0], 2.00068)
+        self.assertAlmostEqual(outcar.p_sp2[0], -2.00044)
+        self.assertAlmostEqual(outcar.p_elec[0], 0.00024)
+        self.assertAlmostEqual(outcar.p_elec[1], 0.00019)
+        self.assertAlmostEqual(outcar.p_elec[2], 3.61674)
+
     def test_dielectric(self):
         filepath = os.path.join(test_dir, "OUTCAR.dielectric")
         outcar = Outcar(filepath)

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -283,6 +283,10 @@ class MPStaticSetTest(PymatgenTest):
         self.assertEqual(non_prev_vis.kpoints.kpts, [[13, 11, 11]])
         non_prev_vis = MPStaticSet(vis.structure, reciprocal_density=200)
         self.assertEqual(non_prev_vis.kpoints.kpts, [[15, 13, 13]])
+        # Check LCALCPOL flag
+        lcalcpol_vis = MPStaticSet.from_prev_calc(prev_calc_dir=prev_run,
+                                                  lcalcpol=True)
+        self.assertTrue(lcalcpol_vis.incar["LCALCPOL"])
 
     def tearDown(self):
         shutil.rmtree(self.tmp)

--- a/test_files/OUTCAR.BaTiO3.polar
+++ b/test_files/OUTCAR.BaTiO3.polar
@@ -1,0 +1,6005 @@
+ vasp.5.3.5 31Mar14 (build Oct 24 2014 12:38:34) complex                        
+  
+ executed on             LinuxIFC date 2016.10.20  19:12:51
+ running on    8 total cores
+ distrk:  each k-point on    8 cores,    1 groups
+ distr:  one band on NCORES_PER_BAND=   1 cores,    8 groups
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ INCAR:
+ POTCAR:    PAW_PBE Ba_sv 06Sep2000               
+ POTCAR:    PAW_PBE Ti_pv 07Sep2000               
+ POTCAR:    PAW_PBE O 08Apr2002                   
+
+ ----------------------------------------------------------------------------- 
+|                                                                             |
+|           W    W    AA    RRRRR   N    N  II  N    N   GGGG   !!!           |
+|           W    W   A  A   R    R  NN   N  II  NN   N  G    G  !!!           |
+|           W    W  A    A  R    R  N N  N  II  N N  N  G       !!!           |
+|           W WW W  AAAAAA  RRRRR   N  N N  II  N  N N  G  GGG   !            |
+|           WW  WW  A    A  R   R   N   NN  II  N   NN  G    G                |
+|           W    W  A    A  R    R  N    N  II  N    N   GGGG   !!!           |
+|                                                                             |
+|      For optimal performance we recommend to set                            |
+|        NCORE= 4 - approx SQRT( number of cores)                             |
+|      NCORE specifies how many cores store one orbital (NPAR=cpu/NCORE).     |
+|      This setting can  greatly improve the performance of VASP for DFT.     |
+|      The default, NPAR=number of cores might be grossly inefficient         |
+|      on modern multi-core architectures or massively parallel machines.     |
+|      Do your own testing !!!!                                               |
+|      Unfortunately you need to use the default for GW and RPA calculations. |
+|      (for HF NCORE is supported but not extensively tested yet)             |
+|                                                                             |
+ ----------------------------------------------------------------------------- 
+
+ POTCAR:    PAW_PBE Ba_sv 06Sep2000               
+   VRHFIN =Ba: 5s5p6s                                                           
+   LEXCH  = PE                                                                  
+   EATOM  =   700.8560 eV,   51.5115 Ry                                         
+                                                                                
+   TITEL  = PAW_PBE Ba_sv 06Sep2000                                             
+   LULTRA =        F    use ultrasoft PP ?                                      
+   IUNSCR =        1    unscreen: 0-lin 1-nonlin 2-no                           
+   RPACOR =    2.400    partial core radius                                     
+   POMASS =  137.327; ZVAL   =   10.000    mass and valenz                      
+   RCORE  =    2.800    outmost cutoff radius                                   
+   RWIGS  =    3.740; RWIGS  =    1.979    wigner-seitz radius (au A)           
+   ENMAX  =  187.181; ENMIN  =  140.386 eV                                      
+   RCLOC  =    2.516    cutoff for local pot                                    
+   LCOR   =        T    correct aug charges                                     
+   LPAW   =        T    paw PP                                                  
+   EAUG   =  351.165                                                            
+   DEXC   =    0.000                                                            
+   RMAX   =    2.865    core radius for proj-oper                               
+   RAUG   =    1.300    factor for augmentation sphere                          
+   RDEP   =    2.976    radius for radial grids                                 
+   RDEPT  =    2.289    core radius for aug-charge                              
+                                                                                
+   Atomic configuration                                                         
+   13 entries                                                                   
+     n  l   j            E        occ.                                          
+     1  0  0.50    -37249.5946   2.0000                                         
+     2  0  0.50     -5887.1925   2.0000                                         
+     2  1  1.50     -5278.3977   6.0000                                         
+     3  0  0.50     -1242.7293   2.0000                                         
+     3  1  1.50     -1047.6609   6.0000                                         
+     3  2  2.50      -764.6158  10.0000                                         
+     4  0  0.50      -243.8228   2.0000                                         
+     4  1  1.50      -180.9218   6.0000                                         
+     4  2  2.50       -89.6477  10.0000                                         
+     5  0  0.50       -33.6549   2.0000                                         
+     6  0  0.50        -3.2247   1.9900                                         
+     5  1  1.50       -18.7193   6.0000                                         
+     5  2  2.50        -2.0115   0.0100                                         
+   Description                                                                  
+     l       E           TYP  RCUT    TYP  RCUT                                 
+     0    -33.6549039     23  2.800                                             
+     0     -3.2246942     23  2.800                                             
+     1    -18.7193050     23  2.700                                             
+     1     27.2116520     23  2.700                                             
+     2     -2.0115002     23  2.700                                             
+     2      0.3057420     23  2.700                                             
+  local pseudopotential read in
+  partial core-charges read in
+  partial kinetic energy density read in
+  atomic valenz-charges read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+    PAW grid and wavefunctions read in
+ 
+   number of l-projection  operators is LMAX  =           6
+   number of lm-projection operators is LMMAX =          18
+ 
+ POTCAR:    PAW_PBE Ti_pv 07Sep2000               
+   VRHFIN =Ti: d3 s1                                                            
+   LEXCH  = PE                                                                  
+   EATOM  =  1042.5995 eV,   76.6289 Ry                                         
+                                                                                
+   TITEL  = PAW_PBE Ti_pv 07Sep2000                                             
+   LULTRA =        F    use ultrasoft PP ?                                      
+   IUNSCR =        1    unscreen: 0-lin 1-nonlin 2-no                           
+   RPACOR =    2.200    partial core radius                                     
+   POMASS =   47.880; ZVAL   =   10.000    mass and valenz                      
+   RCORE  =    2.500    outmost cutoff radius                                   
+   RWIGS  =    2.500; RWIGS  =    1.323    wigner-seitz radius (au A)           
+   ENMAX  =  222.335; ENMIN  =  166.751 eV                                      
+   RCLOC  =    1.701    cutoff for local pot                                    
+   LCOR   =        T    correct aug charges                                     
+   LPAW   =        T    paw PP                                                  
+   EAUG   =  482.848                                                            
+   DEXC   =    0.000                                                            
+   RMAX   =    2.564    core radius for proj-oper                               
+   RAUG   =    1.300    factor for augmentation sphere                          
+   RDEP   =    2.538    radius for radial grids                                 
+   RDEPT  =    1.952    core radius for aug-charge                              
+                                                                                
+   Atomic configuration                                                         
+    8 entries                                                                   
+     n  l   j            E        occ.                                          
+     1  0  0.50     -4865.3608   2.0000                                         
+     2  0  0.50      -533.1368   2.0000                                         
+     2  1  1.50      -440.5031   6.0000                                         
+     3  0  0.50       -59.3186   2.0000                                         
+     3  1  1.50       -35.7012   6.0000                                         
+     3  2  2.50        -1.9157   3.0000                                         
+     4  0  0.50        -3.7291   1.0000                                         
+     4  3  2.50        -1.3606   0.0000                                         
+   Description                                                                  
+     l       E           TYP  RCUT    TYP  RCUT                                 
+     1    -35.7012140     23  2.300                                             
+     1     -1.3605826     23  2.300                                             
+     2     -1.9156996     23  2.500                                             
+     2     -0.4063033     23  2.500                                             
+     0     -3.7290856     23  2.500                                             
+     0     20.4087390     23  2.500                                             
+  local pseudopotential read in
+  partial core-charges read in
+  partial kinetic energy density read in
+  atomic valenz-charges read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+    PAW grid and wavefunctions read in
+ 
+   number of l-projection  operators is LMAX  =           6
+   number of lm-projection operators is LMMAX =          18
+ 
+ POTCAR:    PAW_PBE O 08Apr2002                   
+   VRHFIN =O: s2p4                                                              
+   LEXCH  = PE                                                                  
+   EATOM  =   432.3788 eV,   31.7789 Ry                                         
+                                                                                
+   TITEL  = PAW_PBE O 08Apr2002                                                 
+   LULTRA =        F    use ultrasoft PP ?                                      
+   IUNSCR =        1    unscreen: 0-lin 1-nonlin 2-no                           
+   RPACOR =    1.200    partial core radius                                     
+   POMASS =   16.000; ZVAL   =    6.000    mass and valenz                      
+   RCORE  =    1.520    outmost cutoff radius                                   
+   RWIGS  =    1.550; RWIGS  =    0.820    wigner-seitz radius (au A)           
+   ENMAX  =  400.000; ENMIN  =  300.000 eV                                      
+   ICORE  =        2    local potential                                         
+   LCOR   =        T    correct aug charges                                     
+   LPAW   =        T    paw PP                                                  
+   EAUG   =  605.392                                                            
+   DEXC   =    0.000                                                            
+   RMAX   =    1.553    core radius for proj-oper                               
+   RAUG   =    1.300    factor for augmentation sphere                          
+   RDEP   =    1.550    radius for radial grids                                 
+   RDEPT  =    1.329    core radius for aug-charge                              
+                                                                                
+   Atomic configuration                                                         
+    4 entries                                                                   
+     n  l   j            E        occ.                                          
+     1  0  0.50      -514.6923   2.0000                                         
+     2  0  0.50       -23.9615   2.0000                                         
+     2  1  0.50        -9.0305   4.0000                                         
+     3  2  1.50        -9.5241   0.0000                                         
+   Description                                                                  
+     l       E           TYP  RCUT    TYP  RCUT                                 
+     0    -23.9615318     23  1.200                                             
+     0     -9.5240782     23  1.200                                             
+     1     -9.0304911     23  1.520                                             
+     1      8.1634956     23  1.520                                             
+     2     -9.5240782      7  1.500                                             
+  local pseudopotential read in
+  partial core-charges read in
+  partial kinetic energy density read in
+  kinetic energy density of atom read in
+  atomic valenz-charges read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+    PAW grid and wavefunctions read in
+ 
+   number of l-projection  operators is LMAX  =           4
+   number of lm-projection operators is LMMAX =           8
+ 
+
+ ----------------------------------------------------------------------------- 
+|                                                                             |
+|  ADVICE TO THIS USER RUNNING 'VASP/VAMP'   (HEAR YOUR MASTER'S VOICE ...):  |
+|                                                                             |
+|      You have a (more or less) 'small supercell' and for smaller cells      |
+|      it is recommended  to use the reciprocal-space projection scheme!      |
+|      The real space optimization is not  efficient for small cells and it   |
+|      is also less accurate ...                                              |
+|      Therefore set LREAL=.FALSE. in the  INCAR file                         |
+|                                                                             |
+ ----------------------------------------------------------------------------- 
+
+ Optimization of the real space projectors (new method)
+
+ maximal supplied QI-value         = 13.42
+ optimisation between [QCUT,QGAM] = [ 11.67, 23.35] = [ 38.16,152.62] Ry 
+ Optimized for a Real-space Cutoff    1.68 Angstroem
+
+   l    n(q)    QCUT    max X(q) W(low)/X(q) W(high)/X(q)  e(spline) 
+   0     12    11.673    13.244    0.27E-04    0.53E-05    0.55E-07
+   0     12    11.673    14.240    0.39E-04    0.74E-05    0.11E-06
+   1     11    11.673     4.828    0.65E-05    0.14E-04    0.51E-07
+   1     11    11.673     3.934    0.16E-04    0.58E-04    0.38E-06
+   2     11    11.673    87.714    0.23E-03    0.16E-03    0.84E-06
+   2     11    11.673    59.874    0.22E-03    0.15E-03    0.81E-06
+ Optimization of the real space projectors (new method)
+
+ maximal supplied QI-value         = 15.12
+ optimisation between [QCUT,QGAM] = [ 11.64, 23.28] = [ 37.95,151.78] Ry 
+ Optimized for a Real-space Cutoff    1.49 Angstroem
+
+   l    n(q)    QCUT    max X(q) W(low)/X(q) W(high)/X(q)  e(spline) 
+   1     10    11.641     4.216    0.17E-04    0.40E-04    0.50E-07
+   1     10    11.641     5.422    0.66E-04    0.10E-03    0.13E-06
+   2      9    11.641    72.084    0.68E-04    0.13E-03    0.50E-06
+   2      9    11.641    65.965    0.66E-04    0.13E-03    0.50E-06
+   0     10    11.641    41.531    0.10E-03    0.87E-04    0.31E-06
+   0     10    11.641    16.290    0.75E-04    0.66E-04    0.24E-06
+ Optimization of the real space projectors (new method)
+
+ maximal supplied QI-value         = 24.76
+ optimisation between [QCUT,QGAM] = [ 11.64, 23.27] = [ 37.91,151.63] Ry 
+ Optimized for a Real-space Cutoff    1.14 Angstroem
+
+   l    n(q)    QCUT    max X(q) W(low)/X(q) W(high)/X(q)  e(spline) 
+   0      8    11.635    20.381    0.10E-03    0.33E-03    0.24E-06
+   0      8    11.635    15.268    0.11E-03    0.35E-03    0.26E-06
+   1      7    11.635     5.964    0.24E-03    0.31E-03    0.30E-06
+   1      7    11.635     5.382    0.22E-03    0.25E-03    0.26E-06
+  PAW_PBE Ba_sv 06Sep2000               :
+ energy of atom  1       EATOM= -700.8560
+ kinetic energy error for atom=    0.0005 (will be added to EATOM!!)
+  PAW_PBE Ti_pv 07Sep2000               :
+ energy of atom  2       EATOM=-1042.5995
+ kinetic energy error for atom=    0.0019 (will be added to EATOM!!)
+  PAW_PBE O 08Apr2002                   :
+ energy of atom  3       EATOM= -432.3788
+ kinetic energy error for atom=    0.0208 (will be added to EATOM!!)
+ 
+ 
+ POSCAR: Ba1 Ti1 O3                              
+  positions in direct lattice
+  No initial velocities read in
+ exchange correlation table for  LEXCH =        8
+   RHO(1)=    0.500       N(1)  =     2000
+   RHO(2)=  100.500       N(2)  =     4000
+ 
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ ion  position               nearest neighbor table
+   1  0.000  0.000  0.020-   3 2.82   4 2.82   3 2.82   4 2.82   5 2.84   5 2.84   5 2.84   5 2.84
+                             3 2.99   4 2.99   4 2.99   3 2.99   2 3.48   2 3.48   2 3.48   2 3.48
+   2  0.500  0.500  0.539-   5 1.82   4 2.01   3 2.01   4 2.01   3 2.01   5 2.39   1 3.48   1 3.48
+                             1 3.48   1 3.48   1 3.58   1 3.58   1 3.58   1 3.58
+   3  0.000  0.500  0.492-   2 2.01   2 2.01   1 2.82   1 2.82   1 2.99   1 2.99
+   4  0.500  0.000  0.492-   2 2.01   2 2.01   1 2.82   1 2.82   1 2.99   1 2.99
+   5  0.500  0.500  0.971-   2 1.82   2 2.39   1 2.84   1 2.84   1 2.84   1 2.84
+ 
+  LATTYP: Found a simple tetragonal cell.
+ ALAT       =     4.0013680000
+ C/A-ratio  =     1.0535756771
+  
+  Lattice vectors:
+  
+ A1 = (   4.0013680000,   0.0000000000,   0.0000000000)
+ A2 = (   0.0000000000,   4.0013680000,   0.0000000000)
+ A3 = (   0.0000000000,   0.0000000000,   4.2157440000)
+
+
+Analysis of symmetry for initial positions (statically):
+=====================================================================
+ Subroutine PRICEL returns:
+ Original cell was already a primitive cell.
+ 
+
+ Routine SETGRP: Setting up the symmetry group for a 
+ simple tetragonal supercell.
+
+
+ Subroutine GETGRP returns: Found  8 space group operations
+ (whereof  8 operations were pure point group operations)
+ out of a pool of 16 trial point group operations.
+
+
+The static configuration has the point symmetry C_4v.
+
+
+Analysis of symmetry for dynamics (positions and initial velocities):
+=====================================================================
+ Subroutine PRICEL returns:
+ Original cell was already a primitive cell.
+ 
+
+ Routine SETGRP: Setting up the symmetry group for a 
+ simple tetragonal supercell.
+
+
+ Subroutine GETGRP returns: Found  8 space group operations
+ (whereof  8 operations were pure point group operations)
+ out of a pool of 16 trial point group operations.
+
+
+The dynamic configuration has the point symmetry C_4v.
+
+
+Analysis of magnetic symmetry:
+=====================================================================
+ Subroutine PRICEL returns:
+ Original cell was already a primitive cell.
+ 
+
+ Subroutine MAGSYM returns: Found  8 space group operations
+ (whereof  8 operations were pure point group operations)
+ out of a pool of  8 trial space group operations
+ (whereof  8 operations were pure point group operations)
+ and found also     1 'primitive' translations
+
+
+The magnetic configuration has the point symmetry C_4v.
+ 
+ 
+ KPOINTS: Automatic kpoint scheme                 
+
+Automatic generation of k-mesh.
+Space group operators:
+ irot       det(A)        alpha          n_x          n_y          n_z        tau_x        tau_y        tau_z
+    1     1.000000     0.000001     1.000000     0.000000     0.000000     0.000000     0.000000     0.000000
+    2     1.000000    90.000000     0.000000     0.000000    -1.000000     0.000000     0.000000     0.000000
+    3     1.000000   179.999999     0.000000     0.000000     1.000000     0.000000     0.000000     0.000000
+    4     1.000000    90.000000     0.000000     0.000000     1.000000     0.000000     0.000000     0.000000
+    5    -1.000000   180.000000     0.000000     1.000000     0.000000     0.000000     0.000000     0.000000
+    6    -1.000000   180.000000     0.707107     0.707107     0.000000     0.000000     0.000000     0.000000
+    7    -1.000000   180.000000     1.000000     0.000000     0.000000     0.000000     0.000000     0.000000
+    8    -1.000000   180.000000     0.707107    -0.707107     0.000000     0.000000     0.000000     0.000000
+ 
+ Subroutine IBZKPT returns following result:
+ ===========================================
+ 
+ Found     75 irreducible k-points:
+ 
+ Following reciprocal coordinates:
+            Coordinates               Weight
+  0.000000  0.000000  0.000000      1.000000
+  0.125000  0.000000  0.000000      4.000000
+  0.250000  0.000000  0.000000      4.000000
+  0.375000  0.000000  0.000000      4.000000
+  0.500000  0.000000  0.000000      2.000000
+  0.125000  0.125000  0.000000      4.000000
+  0.250000  0.125000  0.000000      8.000000
+  0.375000  0.125000  0.000000      8.000000
+  0.500000  0.125000  0.000000      4.000000
+  0.250000  0.250000  0.000000      4.000000
+  0.375000  0.250000  0.000000      8.000000
+  0.500000  0.250000  0.000000      4.000000
+  0.375000  0.375000  0.000000      4.000000
+  0.500000  0.375000  0.000000      4.000000
+  0.500000  0.500000  0.000000      1.000000
+  0.000000  0.000000  0.125000      2.000000
+  0.125000  0.000000  0.125000      8.000000
+  0.250000  0.000000  0.125000      8.000000
+  0.375000  0.000000  0.125000      8.000000
+  0.500000  0.000000  0.125000      4.000000
+  0.125000  0.125000  0.125000      8.000000
+  0.250000  0.125000  0.125000     16.000000
+  0.375000  0.125000  0.125000     16.000000
+  0.500000  0.125000  0.125000      8.000000
+  0.250000  0.250000  0.125000      8.000000
+  0.375000  0.250000  0.125000     16.000000
+  0.500000  0.250000  0.125000      8.000000
+  0.375000  0.375000  0.125000      8.000000
+  0.500000  0.375000  0.125000      8.000000
+  0.500000  0.500000  0.125000      2.000000
+  0.000000  0.000000  0.250000      2.000000
+  0.125000  0.000000  0.250000      8.000000
+  0.250000  0.000000  0.250000      8.000000
+  0.375000  0.000000  0.250000      8.000000
+  0.500000  0.000000  0.250000      4.000000
+  0.125000  0.125000  0.250000      8.000000
+  0.250000  0.125000  0.250000     16.000000
+  0.375000  0.125000  0.250000     16.000000
+  0.500000  0.125000  0.250000      8.000000
+  0.250000  0.250000  0.250000      8.000000
+  0.375000  0.250000  0.250000     16.000000
+  0.500000  0.250000  0.250000      8.000000
+  0.375000  0.375000  0.250000      8.000000
+  0.500000  0.375000  0.250000      8.000000
+  0.500000  0.500000  0.250000      2.000000
+  0.000000  0.000000  0.375000      2.000000
+  0.125000  0.000000  0.375000      8.000000
+  0.250000  0.000000  0.375000      8.000000
+  0.375000  0.000000  0.375000      8.000000
+  0.500000  0.000000  0.375000      4.000000
+  0.125000  0.125000  0.375000      8.000000
+  0.250000  0.125000  0.375000     16.000000
+  0.375000  0.125000  0.375000     16.000000
+  0.500000  0.125000  0.375000      8.000000
+  0.250000  0.250000  0.375000      8.000000
+  0.375000  0.250000  0.375000     16.000000
+  0.500000  0.250000  0.375000      8.000000
+  0.375000  0.375000  0.375000      8.000000
+  0.500000  0.375000  0.375000      8.000000
+  0.500000  0.500000  0.375000      2.000000
+  0.000000  0.000000  0.500000      1.000000
+  0.125000  0.000000  0.500000      4.000000
+  0.250000  0.000000  0.500000      4.000000
+  0.375000  0.000000  0.500000      4.000000
+  0.500000  0.000000  0.500000      2.000000
+  0.125000  0.125000  0.500000      4.000000
+  0.250000  0.125000  0.500000      8.000000
+  0.375000  0.125000  0.500000      8.000000
+  0.500000  0.125000  0.500000      4.000000
+  0.250000  0.250000  0.500000      4.000000
+  0.375000  0.250000  0.500000      8.000000
+  0.500000  0.250000  0.500000      4.000000
+  0.375000  0.375000  0.500000      4.000000
+  0.500000  0.375000  0.500000      4.000000
+  0.500000  0.500000  0.500000      1.000000
+ 
+ Following cartesian coordinates:
+            Coordinates               Weight
+  0.000000  0.000000  0.000000      1.000000
+  0.031239  0.000000  0.000000      4.000000
+  0.062479  0.000000  0.000000      4.000000
+  0.093718  0.000000  0.000000      4.000000
+  0.124957  0.000000  0.000000      2.000000
+  0.031239  0.031239  0.000000      4.000000
+  0.062479  0.031239  0.000000      8.000000
+  0.093718  0.031239  0.000000      8.000000
+  0.124957  0.031239  0.000000      4.000000
+  0.062479  0.062479  0.000000      4.000000
+  0.093718  0.062479  0.000000      8.000000
+  0.124957  0.062479  0.000000      4.000000
+  0.093718  0.093718  0.000000      4.000000
+  0.124957  0.093718  0.000000      4.000000
+  0.124957  0.124957  0.000000      1.000000
+  0.000000  0.000000  0.029651      2.000000
+  0.031239  0.000000  0.029651      8.000000
+  0.062479  0.000000  0.029651      8.000000
+  0.093718  0.000000  0.029651      8.000000
+  0.124957  0.000000  0.029651      4.000000
+  0.031239  0.031239  0.029651      8.000000
+  0.062479  0.031239  0.029651     16.000000
+  0.093718  0.031239  0.029651     16.000000
+  0.124957  0.031239  0.029651      8.000000
+  0.062479  0.062479  0.029651      8.000000
+  0.093718  0.062479  0.029651     16.000000
+  0.124957  0.062479  0.029651      8.000000
+  0.093718  0.093718  0.029651      8.000000
+  0.124957  0.093718  0.029651      8.000000
+  0.124957  0.124957  0.029651      2.000000
+  0.000000  0.000000  0.059302      2.000000
+  0.031239  0.000000  0.059302      8.000000
+  0.062479  0.000000  0.059302      8.000000
+  0.093718  0.000000  0.059302      8.000000
+  0.124957  0.000000  0.059302      4.000000
+  0.031239  0.031239  0.059302      8.000000
+  0.062479  0.031239  0.059302     16.000000
+  0.093718  0.031239  0.059302     16.000000
+  0.124957  0.031239  0.059302      8.000000
+  0.062479  0.062479  0.059302      8.000000
+  0.093718  0.062479  0.059302     16.000000
+  0.124957  0.062479  0.059302      8.000000
+  0.093718  0.093718  0.059302      8.000000
+  0.124957  0.093718  0.059302      8.000000
+  0.124957  0.124957  0.059302      2.000000
+  0.000000  0.000000  0.088952      2.000000
+  0.031239  0.000000  0.088952      8.000000
+  0.062479  0.000000  0.088952      8.000000
+  0.093718  0.000000  0.088952      8.000000
+  0.124957  0.000000  0.088952      4.000000
+  0.031239  0.031239  0.088952      8.000000
+  0.062479  0.031239  0.088952     16.000000
+  0.093718  0.031239  0.088952     16.000000
+  0.124957  0.031239  0.088952      8.000000
+  0.062479  0.062479  0.088952      8.000000
+  0.093718  0.062479  0.088952     16.000000
+  0.124957  0.062479  0.088952      8.000000
+  0.093718  0.093718  0.088952      8.000000
+  0.124957  0.093718  0.088952      8.000000
+  0.124957  0.124957  0.088952      2.000000
+  0.000000  0.000000  0.118603      1.000000
+  0.031239  0.000000  0.118603      4.000000
+  0.062479  0.000000  0.118603      4.000000
+  0.093718  0.000000  0.118603      4.000000
+  0.124957  0.000000  0.118603      2.000000
+  0.031239  0.031239  0.118603      4.000000
+  0.062479  0.031239  0.118603      8.000000
+  0.093718  0.031239  0.118603      8.000000
+  0.124957  0.031239  0.118603      4.000000
+  0.062479  0.062479  0.118603      4.000000
+  0.093718  0.062479  0.118603      8.000000
+  0.124957  0.062479  0.118603      4.000000
+  0.093718  0.093718  0.118603      4.000000
+  0.124957  0.093718  0.118603      4.000000
+  0.124957  0.124957  0.118603      1.000000
+ 
+ TETIRR: Found    768 inequivalent tetrahedra from     3072
+ 
+ Subroutine IBZKPT_HF returns following result:
+ ==============================================
+ 
+ Found    512 k-points in 1st BZ
+ the following    512 k-points will be used (e.g. in the exchange kernel)
+ Following reciprocal coordinates:   # in IRBZ
+  0.000000  0.000000  0.000000       1 t-inv F
+  0.125000  0.000000  0.000000       2 t-inv F
+  0.250000  0.000000  0.000000       3 t-inv F
+  0.375000  0.000000  0.000000       4 t-inv F
+  0.500000  0.000000  0.000000       5 t-inv F
+  0.125000  0.125000  0.000000       6 t-inv F
+  0.250000  0.125000  0.000000       7 t-inv F
+  0.375000  0.125000  0.000000       8 t-inv F
+  0.500000  0.125000  0.000000       9 t-inv F
+  0.250000  0.250000  0.000000      10 t-inv F
+  0.375000  0.250000  0.000000      11 t-inv F
+  0.500000  0.250000  0.000000      12 t-inv F
+  0.375000  0.375000  0.000000      13 t-inv F
+  0.500000  0.375000  0.000000      14 t-inv F
+  0.500000  0.500000  0.000000      15 t-inv F
+  0.000000  0.000000  0.125000      16 t-inv F
+  0.125000  0.000000  0.125000      17 t-inv F
+  0.250000  0.000000  0.125000      18 t-inv F
+  0.375000  0.000000  0.125000      19 t-inv F
+  0.500000  0.000000  0.125000      20 t-inv F
+  0.125000  0.125000  0.125000      21 t-inv F
+  0.250000  0.125000  0.125000      22 t-inv F
+  0.375000  0.125000  0.125000      23 t-inv F
+  0.500000  0.125000  0.125000      24 t-inv F
+  0.250000  0.250000  0.125000      25 t-inv F
+  0.375000  0.250000  0.125000      26 t-inv F
+  0.500000  0.250000  0.125000      27 t-inv F
+  0.375000  0.375000  0.125000      28 t-inv F
+  0.500000  0.375000  0.125000      29 t-inv F
+  0.500000  0.500000  0.125000      30 t-inv F
+  0.000000  0.000000  0.250000      31 t-inv F
+  0.125000  0.000000  0.250000      32 t-inv F
+  0.250000  0.000000  0.250000      33 t-inv F
+  0.375000  0.000000  0.250000      34 t-inv F
+  0.500000  0.000000  0.250000      35 t-inv F
+  0.125000  0.125000  0.250000      36 t-inv F
+  0.250000  0.125000  0.250000      37 t-inv F
+  0.375000  0.125000  0.250000      38 t-inv F
+  0.500000  0.125000  0.250000      39 t-inv F
+  0.250000  0.250000  0.250000      40 t-inv F
+  0.375000  0.250000  0.250000      41 t-inv F
+  0.500000  0.250000  0.250000      42 t-inv F
+  0.375000  0.375000  0.250000      43 t-inv F
+  0.500000  0.375000  0.250000      44 t-inv F
+  0.500000  0.500000  0.250000      45 t-inv F
+  0.000000  0.000000  0.375000      46 t-inv F
+  0.125000  0.000000  0.375000      47 t-inv F
+  0.250000  0.000000  0.375000      48 t-inv F
+  0.375000  0.000000  0.375000      49 t-inv F
+  0.500000  0.000000  0.375000      50 t-inv F
+  0.125000  0.125000  0.375000      51 t-inv F
+  0.250000  0.125000  0.375000      52 t-inv F
+  0.375000  0.125000  0.375000      53 t-inv F
+  0.500000  0.125000  0.375000      54 t-inv F
+  0.250000  0.250000  0.375000      55 t-inv F
+  0.375000  0.250000  0.375000      56 t-inv F
+  0.500000  0.250000  0.375000      57 t-inv F
+  0.375000  0.375000  0.375000      58 t-inv F
+  0.500000  0.375000  0.375000      59 t-inv F
+  0.500000  0.500000  0.375000      60 t-inv F
+  0.000000  0.000000  0.500000      61 t-inv F
+  0.125000  0.000000  0.500000      62 t-inv F
+  0.250000  0.000000  0.500000      63 t-inv F
+  0.375000  0.000000  0.500000      64 t-inv F
+  0.500000  0.000000  0.500000      65 t-inv F
+  0.125000  0.125000  0.500000      66 t-inv F
+  0.250000  0.125000  0.500000      67 t-inv F
+  0.375000  0.125000  0.500000      68 t-inv F
+  0.500000  0.125000  0.500000      69 t-inv F
+  0.250000  0.250000  0.500000      70 t-inv F
+  0.375000  0.250000  0.500000      71 t-inv F
+  0.500000  0.250000  0.500000      72 t-inv F
+  0.375000  0.375000  0.500000      73 t-inv F
+  0.500000  0.375000  0.500000      74 t-inv F
+  0.500000  0.500000  0.500000      75 t-inv F
+  0.000000  0.125000  0.000000       2 t-inv F
+ -0.125000  0.000000  0.000000       2 t-inv F
+  0.000000 -0.125000  0.000000       2 t-inv F
+  0.000000  0.250000  0.000000       3 t-inv F
+ -0.250000  0.000000  0.000000       3 t-inv F
+  0.000000 -0.250000  0.000000       3 t-inv F
+  0.000000  0.375000  0.000000       4 t-inv F
+ -0.375000  0.000000  0.000000       4 t-inv F
+  0.000000 -0.375000  0.000000       4 t-inv F
+  0.000000  0.500000  0.000000       5 t-inv F
+ -0.125000  0.125000  0.000000       6 t-inv F
+ -0.125000 -0.125000  0.000000       6 t-inv F
+  0.125000 -0.125000  0.000000       6 t-inv F
+ -0.125000  0.250000  0.000000       7 t-inv F
+ -0.250000 -0.125000  0.000000       7 t-inv F
+  0.125000 -0.250000  0.000000       7 t-inv F
+  0.250000 -0.125000  0.000000       7 t-inv F
+ -0.125000 -0.250000  0.000000       7 t-inv F
+ -0.250000  0.125000  0.000000       7 t-inv F
+  0.125000  0.250000  0.000000       7 t-inv F
+ -0.125000  0.375000  0.000000       8 t-inv F
+ -0.375000 -0.125000  0.000000       8 t-inv F
+  0.125000 -0.375000  0.000000       8 t-inv F
+  0.375000 -0.125000  0.000000       8 t-inv F
+ -0.125000 -0.375000  0.000000       8 t-inv F
+ -0.375000  0.125000  0.000000       8 t-inv F
+  0.125000  0.375000  0.000000       8 t-inv F
+ -0.125000  0.500000  0.000000       9 t-inv F
+ -0.500000 -0.125000  0.000000       9 t-inv F
+  0.125000 -0.500000  0.000000       9 t-inv F
+ -0.250000  0.250000  0.000000      10 t-inv F
+ -0.250000 -0.250000  0.000000      10 t-inv F
+  0.250000 -0.250000  0.000000      10 t-inv F
+ -0.250000  0.375000  0.000000      11 t-inv F
+ -0.375000 -0.250000  0.000000      11 t-inv F
+  0.250000 -0.375000  0.000000      11 t-inv F
+  0.375000 -0.250000  0.000000      11 t-inv F
+ -0.250000 -0.375000  0.000000      11 t-inv F
+ -0.375000  0.250000  0.000000      11 t-inv F
+  0.250000  0.375000  0.000000      11 t-inv F
+ -0.250000  0.500000  0.000000      12 t-inv F
+ -0.500000 -0.250000  0.000000      12 t-inv F
+  0.250000 -0.500000  0.000000      12 t-inv F
+ -0.375000  0.375000  0.000000      13 t-inv F
+ -0.375000 -0.375000  0.000000      13 t-inv F
+  0.375000 -0.375000  0.000000      13 t-inv F
+ -0.375000  0.500000  0.000000      14 t-inv F
+ -0.500000 -0.375000  0.000000      14 t-inv F
+  0.375000 -0.500000  0.000000      14 t-inv F
+  0.000000  0.125000  0.125000      17 t-inv F
+ -0.125000  0.000000  0.125000      17 t-inv F
+  0.000000 -0.125000  0.125000      17 t-inv F
+  0.000000  0.250000  0.125000      18 t-inv F
+ -0.250000  0.000000  0.125000      18 t-inv F
+  0.000000 -0.250000  0.125000      18 t-inv F
+  0.000000  0.375000  0.125000      19 t-inv F
+ -0.375000  0.000000  0.125000      19 t-inv F
+  0.000000 -0.375000  0.125000      19 t-inv F
+  0.000000  0.500000  0.125000      20 t-inv F
+ -0.125000  0.125000  0.125000      21 t-inv F
+ -0.125000 -0.125000  0.125000      21 t-inv F
+  0.125000 -0.125000  0.125000      21 t-inv F
+ -0.125000  0.250000  0.125000      22 t-inv F
+ -0.250000 -0.125000  0.125000      22 t-inv F
+  0.125000 -0.250000  0.125000      22 t-inv F
+  0.250000 -0.125000  0.125000      22 t-inv F
+ -0.125000 -0.250000  0.125000      22 t-inv F
+ -0.250000  0.125000  0.125000      22 t-inv F
+  0.125000  0.250000  0.125000      22 t-inv F
+ -0.125000  0.375000  0.125000      23 t-inv F
+ -0.375000 -0.125000  0.125000      23 t-inv F
+  0.125000 -0.375000  0.125000      23 t-inv F
+  0.375000 -0.125000  0.125000      23 t-inv F
+ -0.125000 -0.375000  0.125000      23 t-inv F
+ -0.375000  0.125000  0.125000      23 t-inv F
+  0.125000  0.375000  0.125000      23 t-inv F
+ -0.125000  0.500000  0.125000      24 t-inv F
+ -0.500000 -0.125000  0.125000      24 t-inv F
+  0.125000 -0.500000  0.125000      24 t-inv F
+ -0.250000  0.250000  0.125000      25 t-inv F
+ -0.250000 -0.250000  0.125000      25 t-inv F
+  0.250000 -0.250000  0.125000      25 t-inv F
+ -0.250000  0.375000  0.125000      26 t-inv F
+ -0.375000 -0.250000  0.125000      26 t-inv F
+  0.250000 -0.375000  0.125000      26 t-inv F
+  0.375000 -0.250000  0.125000      26 t-inv F
+ -0.250000 -0.375000  0.125000      26 t-inv F
+ -0.375000  0.250000  0.125000      26 t-inv F
+  0.250000  0.375000  0.125000      26 t-inv F
+ -0.250000  0.500000  0.125000      27 t-inv F
+ -0.500000 -0.250000  0.125000      27 t-inv F
+  0.250000 -0.500000  0.125000      27 t-inv F
+ -0.375000  0.375000  0.125000      28 t-inv F
+ -0.375000 -0.375000  0.125000      28 t-inv F
+  0.375000 -0.375000  0.125000      28 t-inv F
+ -0.375000  0.500000  0.125000      29 t-inv F
+ -0.500000 -0.375000  0.125000      29 t-inv F
+  0.375000 -0.500000  0.125000      29 t-inv F
+  0.000000  0.125000  0.250000      32 t-inv F
+ -0.125000  0.000000  0.250000      32 t-inv F
+  0.000000 -0.125000  0.250000      32 t-inv F
+  0.000000  0.250000  0.250000      33 t-inv F
+ -0.250000  0.000000  0.250000      33 t-inv F
+  0.000000 -0.250000  0.250000      33 t-inv F
+  0.000000  0.375000  0.250000      34 t-inv F
+ -0.375000  0.000000  0.250000      34 t-inv F
+  0.000000 -0.375000  0.250000      34 t-inv F
+  0.000000  0.500000  0.250000      35 t-inv F
+ -0.125000  0.125000  0.250000      36 t-inv F
+ -0.125000 -0.125000  0.250000      36 t-inv F
+  0.125000 -0.125000  0.250000      36 t-inv F
+ -0.125000  0.250000  0.250000      37 t-inv F
+ -0.250000 -0.125000  0.250000      37 t-inv F
+  0.125000 -0.250000  0.250000      37 t-inv F
+  0.250000 -0.125000  0.250000      37 t-inv F
+ -0.125000 -0.250000  0.250000      37 t-inv F
+ -0.250000  0.125000  0.250000      37 t-inv F
+  0.125000  0.250000  0.250000      37 t-inv F
+ -0.125000  0.375000  0.250000      38 t-inv F
+ -0.375000 -0.125000  0.250000      38 t-inv F
+  0.125000 -0.375000  0.250000      38 t-inv F
+  0.375000 -0.125000  0.250000      38 t-inv F
+ -0.125000 -0.375000  0.250000      38 t-inv F
+ -0.375000  0.125000  0.250000      38 t-inv F
+  0.125000  0.375000  0.250000      38 t-inv F
+ -0.125000  0.500000  0.250000      39 t-inv F
+ -0.500000 -0.125000  0.250000      39 t-inv F
+  0.125000 -0.500000  0.250000      39 t-inv F
+ -0.250000  0.250000  0.250000      40 t-inv F
+ -0.250000 -0.250000  0.250000      40 t-inv F
+  0.250000 -0.250000  0.250000      40 t-inv F
+ -0.250000  0.375000  0.250000      41 t-inv F
+ -0.375000 -0.250000  0.250000      41 t-inv F
+  0.250000 -0.375000  0.250000      41 t-inv F
+  0.375000 -0.250000  0.250000      41 t-inv F
+ -0.250000 -0.375000  0.250000      41 t-inv F
+ -0.375000  0.250000  0.250000      41 t-inv F
+  0.250000  0.375000  0.250000      41 t-inv F
+ -0.250000  0.500000  0.250000      42 t-inv F
+ -0.500000 -0.250000  0.250000      42 t-inv F
+  0.250000 -0.500000  0.250000      42 t-inv F
+ -0.375000  0.375000  0.250000      43 t-inv F
+ -0.375000 -0.375000  0.250000      43 t-inv F
+  0.375000 -0.375000  0.250000      43 t-inv F
+ -0.375000  0.500000  0.250000      44 t-inv F
+ -0.500000 -0.375000  0.250000      44 t-inv F
+  0.375000 -0.500000  0.250000      44 t-inv F
+  0.000000  0.125000  0.375000      47 t-inv F
+ -0.125000  0.000000  0.375000      47 t-inv F
+  0.000000 -0.125000  0.375000      47 t-inv F
+  0.000000  0.250000  0.375000      48 t-inv F
+ -0.250000  0.000000  0.375000      48 t-inv F
+  0.000000 -0.250000  0.375000      48 t-inv F
+  0.000000  0.375000  0.375000      49 t-inv F
+ -0.375000  0.000000  0.375000      49 t-inv F
+  0.000000 -0.375000  0.375000      49 t-inv F
+  0.000000  0.500000  0.375000      50 t-inv F
+ -0.125000  0.125000  0.375000      51 t-inv F
+ -0.125000 -0.125000  0.375000      51 t-inv F
+  0.125000 -0.125000  0.375000      51 t-inv F
+ -0.125000  0.250000  0.375000      52 t-inv F
+ -0.250000 -0.125000  0.375000      52 t-inv F
+  0.125000 -0.250000  0.375000      52 t-inv F
+  0.250000 -0.125000  0.375000      52 t-inv F
+ -0.125000 -0.250000  0.375000      52 t-inv F
+ -0.250000  0.125000  0.375000      52 t-inv F
+  0.125000  0.250000  0.375000      52 t-inv F
+ -0.125000  0.375000  0.375000      53 t-inv F
+ -0.375000 -0.125000  0.375000      53 t-inv F
+  0.125000 -0.375000  0.375000      53 t-inv F
+  0.375000 -0.125000  0.375000      53 t-inv F
+ -0.125000 -0.375000  0.375000      53 t-inv F
+ -0.375000  0.125000  0.375000      53 t-inv F
+  0.125000  0.375000  0.375000      53 t-inv F
+ -0.125000  0.500000  0.375000      54 t-inv F
+ -0.500000 -0.125000  0.375000      54 t-inv F
+  0.125000 -0.500000  0.375000      54 t-inv F
+ -0.250000  0.250000  0.375000      55 t-inv F
+ -0.250000 -0.250000  0.375000      55 t-inv F
+  0.250000 -0.250000  0.375000      55 t-inv F
+ -0.250000  0.375000  0.375000      56 t-inv F
+ -0.375000 -0.250000  0.375000      56 t-inv F
+  0.250000 -0.375000  0.375000      56 t-inv F
+  0.375000 -0.250000  0.375000      56 t-inv F
+ -0.250000 -0.375000  0.375000      56 t-inv F
+ -0.375000  0.250000  0.375000      56 t-inv F
+  0.250000  0.375000  0.375000      56 t-inv F
+ -0.250000  0.500000  0.375000      57 t-inv F
+ -0.500000 -0.250000  0.375000      57 t-inv F
+  0.250000 -0.500000  0.375000      57 t-inv F
+ -0.375000  0.375000  0.375000      58 t-inv F
+ -0.375000 -0.375000  0.375000      58 t-inv F
+  0.375000 -0.375000  0.375000      58 t-inv F
+ -0.375000  0.500000  0.375000      59 t-inv F
+ -0.500000 -0.375000  0.375000      59 t-inv F
+  0.375000 -0.500000  0.375000      59 t-inv F
+  0.000000  0.125000  0.500000      62 t-inv F
+ -0.125000  0.000000  0.500000      62 t-inv F
+  0.000000 -0.125000  0.500000      62 t-inv F
+  0.000000  0.250000  0.500000      63 t-inv F
+ -0.250000  0.000000  0.500000      63 t-inv F
+  0.000000 -0.250000  0.500000      63 t-inv F
+  0.000000  0.375000  0.500000      64 t-inv F
+ -0.375000  0.000000  0.500000      64 t-inv F
+  0.000000 -0.375000  0.500000      64 t-inv F
+  0.000000  0.500000  0.500000      65 t-inv F
+ -0.125000  0.125000  0.500000      66 t-inv F
+ -0.125000 -0.125000  0.500000      66 t-inv F
+  0.125000 -0.125000  0.500000      66 t-inv F
+ -0.125000  0.250000  0.500000      67 t-inv F
+ -0.250000 -0.125000  0.500000      67 t-inv F
+  0.125000 -0.250000  0.500000      67 t-inv F
+  0.250000 -0.125000  0.500000      67 t-inv F
+ -0.125000 -0.250000  0.500000      67 t-inv F
+ -0.250000  0.125000  0.500000      67 t-inv F
+  0.125000  0.250000  0.500000      67 t-inv F
+ -0.125000  0.375000  0.500000      68 t-inv F
+ -0.375000 -0.125000  0.500000      68 t-inv F
+  0.125000 -0.375000  0.500000      68 t-inv F
+  0.375000 -0.125000  0.500000      68 t-inv F
+ -0.125000 -0.375000  0.500000      68 t-inv F
+ -0.375000  0.125000  0.500000      68 t-inv F
+  0.125000  0.375000  0.500000      68 t-inv F
+ -0.125000  0.500000  0.500000      69 t-inv F
+ -0.500000 -0.125000  0.500000      69 t-inv F
+  0.125000 -0.500000  0.500000      69 t-inv F
+ -0.250000  0.250000  0.500000      70 t-inv F
+ -0.250000 -0.250000  0.500000      70 t-inv F
+  0.250000 -0.250000  0.500000      70 t-inv F
+ -0.250000  0.375000  0.500000      71 t-inv F
+ -0.375000 -0.250000  0.500000      71 t-inv F
+  0.250000 -0.375000  0.500000      71 t-inv F
+  0.375000 -0.250000  0.500000      71 t-inv F
+ -0.250000 -0.375000  0.500000      71 t-inv F
+ -0.375000  0.250000  0.500000      71 t-inv F
+  0.250000  0.375000  0.500000      71 t-inv F
+ -0.250000  0.500000  0.500000      72 t-inv F
+ -0.500000 -0.250000  0.500000      72 t-inv F
+  0.250000 -0.500000  0.500000      72 t-inv F
+ -0.375000  0.375000  0.500000      73 t-inv F
+ -0.375000 -0.375000  0.500000      73 t-inv F
+  0.375000 -0.375000  0.500000      73 t-inv F
+ -0.375000  0.500000  0.500000      74 t-inv F
+ -0.500000 -0.375000  0.500000      74 t-inv F
+  0.375000 -0.500000  0.500000      74 t-inv F
+  0.000000  0.000000 -0.125000      16 t-inv T
+ -0.125000  0.000000 -0.125000      17 t-inv T
+  0.000000 -0.125000 -0.125000      17 t-inv T
+  0.125000  0.000000 -0.125000      17 t-inv T
+  0.000000  0.125000 -0.125000      17 t-inv T
+ -0.250000  0.000000 -0.125000      18 t-inv T
+  0.000000 -0.250000 -0.125000      18 t-inv T
+  0.250000  0.000000 -0.125000      18 t-inv T
+  0.000000  0.250000 -0.125000      18 t-inv T
+ -0.375000  0.000000 -0.125000      19 t-inv T
+  0.000000 -0.375000 -0.125000      19 t-inv T
+  0.375000  0.000000 -0.125000      19 t-inv T
+  0.000000  0.375000 -0.125000      19 t-inv T
+ -0.500000  0.000000 -0.125000      20 t-inv T
+  0.000000 -0.500000 -0.125000      20 t-inv T
+ -0.125000 -0.125000 -0.125000      21 t-inv T
+  0.125000 -0.125000 -0.125000      21 t-inv T
+  0.125000  0.125000 -0.125000      21 t-inv T
+ -0.125000  0.125000 -0.125000      21 t-inv T
+ -0.250000 -0.125000 -0.125000      22 t-inv T
+  0.125000 -0.250000 -0.125000      22 t-inv T
+  0.250000  0.125000 -0.125000      22 t-inv T
+ -0.125000  0.250000 -0.125000      22 t-inv T
+ -0.250000  0.125000 -0.125000      22 t-inv T
+  0.125000  0.250000 -0.125000      22 t-inv T
+  0.250000 -0.125000 -0.125000      22 t-inv T
+ -0.125000 -0.250000 -0.125000      22 t-inv T
+ -0.375000 -0.125000 -0.125000      23 t-inv T
+  0.125000 -0.375000 -0.125000      23 t-inv T
+  0.375000  0.125000 -0.125000      23 t-inv T
+ -0.125000  0.375000 -0.125000      23 t-inv T
+ -0.375000  0.125000 -0.125000      23 t-inv T
+  0.125000  0.375000 -0.125000      23 t-inv T
+  0.375000 -0.125000 -0.125000      23 t-inv T
+ -0.125000 -0.375000 -0.125000      23 t-inv T
+ -0.500000 -0.125000 -0.125000      24 t-inv T
+  0.125000 -0.500000 -0.125000      24 t-inv T
+  0.500000  0.125000 -0.125000      24 t-inv T
+ -0.125000  0.500000 -0.125000      24 t-inv T
+ -0.250000 -0.250000 -0.125000      25 t-inv T
+  0.250000 -0.250000 -0.125000      25 t-inv T
+  0.250000  0.250000 -0.125000      25 t-inv T
+ -0.250000  0.250000 -0.125000      25 t-inv T
+ -0.375000 -0.250000 -0.125000      26 t-inv T
+  0.250000 -0.375000 -0.125000      26 t-inv T
+  0.375000  0.250000 -0.125000      26 t-inv T
+ -0.250000  0.375000 -0.125000      26 t-inv T
+ -0.375000  0.250000 -0.125000      26 t-inv T
+  0.250000  0.375000 -0.125000      26 t-inv T
+  0.375000 -0.250000 -0.125000      26 t-inv T
+ -0.250000 -0.375000 -0.125000      26 t-inv T
+ -0.500000 -0.250000 -0.125000      27 t-inv T
+  0.250000 -0.500000 -0.125000      27 t-inv T
+  0.500000  0.250000 -0.125000      27 t-inv T
+ -0.250000  0.500000 -0.125000      27 t-inv T
+ -0.375000 -0.375000 -0.125000      28 t-inv T
+  0.375000 -0.375000 -0.125000      28 t-inv T
+  0.375000  0.375000 -0.125000      28 t-inv T
+ -0.375000  0.375000 -0.125000      28 t-inv T
+ -0.500000 -0.375000 -0.125000      29 t-inv T
+  0.375000 -0.500000 -0.125000      29 t-inv T
+  0.500000  0.375000 -0.125000      29 t-inv T
+ -0.375000  0.500000 -0.125000      29 t-inv T
+ -0.500000 -0.500000 -0.125000      30 t-inv T
+  0.000000  0.000000 -0.250000      31 t-inv T
+ -0.125000  0.000000 -0.250000      32 t-inv T
+  0.000000 -0.125000 -0.250000      32 t-inv T
+  0.125000  0.000000 -0.250000      32 t-inv T
+  0.000000  0.125000 -0.250000      32 t-inv T
+ -0.250000  0.000000 -0.250000      33 t-inv T
+  0.000000 -0.250000 -0.250000      33 t-inv T
+  0.250000  0.000000 -0.250000      33 t-inv T
+  0.000000  0.250000 -0.250000      33 t-inv T
+ -0.375000  0.000000 -0.250000      34 t-inv T
+  0.000000 -0.375000 -0.250000      34 t-inv T
+  0.375000  0.000000 -0.250000      34 t-inv T
+  0.000000  0.375000 -0.250000      34 t-inv T
+ -0.500000  0.000000 -0.250000      35 t-inv T
+  0.000000 -0.500000 -0.250000      35 t-inv T
+ -0.125000 -0.125000 -0.250000      36 t-inv T
+  0.125000 -0.125000 -0.250000      36 t-inv T
+  0.125000  0.125000 -0.250000      36 t-inv T
+ -0.125000  0.125000 -0.250000      36 t-inv T
+ -0.250000 -0.125000 -0.250000      37 t-inv T
+  0.125000 -0.250000 -0.250000      37 t-inv T
+  0.250000  0.125000 -0.250000      37 t-inv T
+ -0.125000  0.250000 -0.250000      37 t-inv T
+ -0.250000  0.125000 -0.250000      37 t-inv T
+  0.125000  0.250000 -0.250000      37 t-inv T
+  0.250000 -0.125000 -0.250000      37 t-inv T
+ -0.125000 -0.250000 -0.250000      37 t-inv T
+ -0.375000 -0.125000 -0.250000      38 t-inv T
+  0.125000 -0.375000 -0.250000      38 t-inv T
+  0.375000  0.125000 -0.250000      38 t-inv T
+ -0.125000  0.375000 -0.250000      38 t-inv T
+ -0.375000  0.125000 -0.250000      38 t-inv T
+  0.125000  0.375000 -0.250000      38 t-inv T
+  0.375000 -0.125000 -0.250000      38 t-inv T
+ -0.125000 -0.375000 -0.250000      38 t-inv T
+ -0.500000 -0.125000 -0.250000      39 t-inv T
+  0.125000 -0.500000 -0.250000      39 t-inv T
+  0.500000  0.125000 -0.250000      39 t-inv T
+ -0.125000  0.500000 -0.250000      39 t-inv T
+ -0.250000 -0.250000 -0.250000      40 t-inv T
+  0.250000 -0.250000 -0.250000      40 t-inv T
+  0.250000  0.250000 -0.250000      40 t-inv T
+ -0.250000  0.250000 -0.250000      40 t-inv T
+ -0.375000 -0.250000 -0.250000      41 t-inv T
+  0.250000 -0.375000 -0.250000      41 t-inv T
+  0.375000  0.250000 -0.250000      41 t-inv T
+ -0.250000  0.375000 -0.250000      41 t-inv T
+ -0.375000  0.250000 -0.250000      41 t-inv T
+  0.250000  0.375000 -0.250000      41 t-inv T
+  0.375000 -0.250000 -0.250000      41 t-inv T
+ -0.250000 -0.375000 -0.250000      41 t-inv T
+ -0.500000 -0.250000 -0.250000      42 t-inv T
+  0.250000 -0.500000 -0.250000      42 t-inv T
+  0.500000  0.250000 -0.250000      42 t-inv T
+ -0.250000  0.500000 -0.250000      42 t-inv T
+ -0.375000 -0.375000 -0.250000      43 t-inv T
+  0.375000 -0.375000 -0.250000      43 t-inv T
+  0.375000  0.375000 -0.250000      43 t-inv T
+ -0.375000  0.375000 -0.250000      43 t-inv T
+ -0.500000 -0.375000 -0.250000      44 t-inv T
+  0.375000 -0.500000 -0.250000      44 t-inv T
+  0.500000  0.375000 -0.250000      44 t-inv T
+ -0.375000  0.500000 -0.250000      44 t-inv T
+ -0.500000 -0.500000 -0.250000      45 t-inv T
+  0.000000  0.000000 -0.375000      46 t-inv T
+ -0.125000  0.000000 -0.375000      47 t-inv T
+  0.000000 -0.125000 -0.375000      47 t-inv T
+  0.125000  0.000000 -0.375000      47 t-inv T
+  0.000000  0.125000 -0.375000      47 t-inv T
+ -0.250000  0.000000 -0.375000      48 t-inv T
+  0.000000 -0.250000 -0.375000      48 t-inv T
+  0.250000  0.000000 -0.375000      48 t-inv T
+  0.000000  0.250000 -0.375000      48 t-inv T
+ -0.375000  0.000000 -0.375000      49 t-inv T
+  0.000000 -0.375000 -0.375000      49 t-inv T
+  0.375000  0.000000 -0.375000      49 t-inv T
+  0.000000  0.375000 -0.375000      49 t-inv T
+ -0.500000  0.000000 -0.375000      50 t-inv T
+  0.000000 -0.500000 -0.375000      50 t-inv T
+ -0.125000 -0.125000 -0.375000      51 t-inv T
+  0.125000 -0.125000 -0.375000      51 t-inv T
+  0.125000  0.125000 -0.375000      51 t-inv T
+ -0.125000  0.125000 -0.375000      51 t-inv T
+ -0.250000 -0.125000 -0.375000      52 t-inv T
+  0.125000 -0.250000 -0.375000      52 t-inv T
+  0.250000  0.125000 -0.375000      52 t-inv T
+ -0.125000  0.250000 -0.375000      52 t-inv T
+ -0.250000  0.125000 -0.375000      52 t-inv T
+  0.125000  0.250000 -0.375000      52 t-inv T
+  0.250000 -0.125000 -0.375000      52 t-inv T
+ -0.125000 -0.250000 -0.375000      52 t-inv T
+ -0.375000 -0.125000 -0.375000      53 t-inv T
+  0.125000 -0.375000 -0.375000      53 t-inv T
+  0.375000  0.125000 -0.375000      53 t-inv T
+ -0.125000  0.375000 -0.375000      53 t-inv T
+ -0.375000  0.125000 -0.375000      53 t-inv T
+  0.125000  0.375000 -0.375000      53 t-inv T
+  0.375000 -0.125000 -0.375000      53 t-inv T
+ -0.125000 -0.375000 -0.375000      53 t-inv T
+ -0.500000 -0.125000 -0.375000      54 t-inv T
+  0.125000 -0.500000 -0.375000      54 t-inv T
+  0.500000  0.125000 -0.375000      54 t-inv T
+ -0.125000  0.500000 -0.375000      54 t-inv T
+ -0.250000 -0.250000 -0.375000      55 t-inv T
+  0.250000 -0.250000 -0.375000      55 t-inv T
+  0.250000  0.250000 -0.375000      55 t-inv T
+ -0.250000  0.250000 -0.375000      55 t-inv T
+ -0.375000 -0.250000 -0.375000      56 t-inv T
+  0.250000 -0.375000 -0.375000      56 t-inv T
+  0.375000  0.250000 -0.375000      56 t-inv T
+ -0.250000  0.375000 -0.375000      56 t-inv T
+ -0.375000  0.250000 -0.375000      56 t-inv T
+  0.250000  0.375000 -0.375000      56 t-inv T
+  0.375000 -0.250000 -0.375000      56 t-inv T
+ -0.250000 -0.375000 -0.375000      56 t-inv T
+ -0.500000 -0.250000 -0.375000      57 t-inv T
+  0.250000 -0.500000 -0.375000      57 t-inv T
+  0.500000  0.250000 -0.375000      57 t-inv T
+ -0.250000  0.500000 -0.375000      57 t-inv T
+ -0.375000 -0.375000 -0.375000      58 t-inv T
+  0.375000 -0.375000 -0.375000      58 t-inv T
+  0.375000  0.375000 -0.375000      58 t-inv T
+ -0.375000  0.375000 -0.375000      58 t-inv T
+ -0.500000 -0.375000 -0.375000      59 t-inv T
+  0.375000 -0.500000 -0.375000      59 t-inv T
+  0.500000  0.375000 -0.375000      59 t-inv T
+ -0.375000  0.500000 -0.375000      59 t-inv T
+ -0.500000 -0.500000 -0.375000      60 t-inv T
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+ Dimension of arrays:
+   k-points           NKPTS =     75   k-points in BZ     NKDIM =     75   number of bands    NBANDS=     24
+   number of dos      NEDOS =    301   number of ions     NIONS =      5
+   non local maximal  LDIM  =      6   non local SUM 2l+1 LMDIM =     18
+   total plane-waves  NPLWV =  28800
+   max r-space proj   IRMAX =   8464   max aug-charges    IRDMAX=  26905
+   dimension x,y,z NGX =    30 NGY =   30 NGZ =   32
+   dimension x,y,z NGXF=    60 NGYF=   60 NGZF=   64
+   support grid    NGXF=    60 NGYF=   60 NGZF=   64
+   ions per type =               1   1   3
+ NGX,Y,Z   is equivalent  to a cutoff of  12.46, 12.46, 12.62 a.u.
+ NGXF,Y,Z  is equivalent  to a cutoff of  24.93, 24.93, 25.24 a.u.
+
+
+ I would recommend the setting:
+   dimension x,y,z NGX =    30 NGY =   30 NGZ =   31
+ SYSTEM =  unknown system                          
+ POSCAR =  Ba1 Ti1 O3                              
+
+ Startparameter for this run:
+   NWRITE =      2    write-flag & timer
+   PREC   = accura    normal or accurate (medium, high low for compatibility)
+   ISTART =      1    job   : 0-new  1-cont  2-samecut
+   ICHARG =      0    charge: 1-file 2-atom 10-const
+   ISPIN  =      2    spin polarized calculation?
+   LNONCOLLINEAR =      F non collinear calculations
+   LSORBIT =      F    spin-orbit coupling
+   INIWAV =      1    electr: 0-lowe 1-rand  2-diag
+   LASPH  =      F    aspherical Exc in radial PAW
+   METAGGA=      F    non-selfconsistent MetaGGA calc.
+
+ Electronic Relaxation 1
+   ENCUT  =  520.0 eV  38.22 Ry    6.18 a.u.   7.44  7.44  7.84*2*pi/ulx,y,z
+   ENINI  =  520.0     initial cutoff
+   ENAUG  =  605.4 eV  augmentation charge cutoff
+   NELM   =    100;   NELMIN=  2; NELMDL=  0     # of ELM steps 
+   EDIFF  = 0.3E-03   stopping-criterion for ELM
+   LREAL  =      T    real-space projection
+   NLSPLINE    = F    spline interpolate recip. space projectors
+   LCOMPAT=      F    compatible to vasp.4.4
+   GGA_COMPAT  = T    GGA compatible to vasp.4.4-vasp.4.6
+   LMAXPAW     = -100 max onsite density
+   LMAXMIX     =    2 max onsite mixed and CHGCAR
+   VOSKOWN=      0    Vosko Wilk Nusair interpolation
+   ROPT   =   -0.00025  -0.00025  -0.00025
+ Ionic relaxation
+   EDIFFG = 0.3E-02   stopping-criterion for IOM
+   NSW    =      0    number of steps for IOM
+   NBLOCK =      1;   KBLOCK =      1    inner block; outer block 
+   IBRION =     -1    ionic relax: 0-MD 1-quasi-New 2-CG
+   NFREE  =      0    steps in history (QN), initial steepest desc. (CG)
+   ISIF   =      3    stress and relaxation
+   IWAVPR =     10    prediction:  0-non 1-charg 2-wave 3-comb
+   ISYM   =      2    0-nonsym 1-usesym 2-fastsym
+   LCORR  =      T    Harris-Foulkes like correction to forces
+
+   POTIM  = 0.5000    time-step for ionic-motion
+   TEIN   =    0.0    initial temperature
+   TEBEG  =    0.0;   TEEND  =   0.0 temperature during run
+   SMASS  =  -3.00    Nose mass-parameter (am)
+   estimated Nose-frequenzy (Omega)   =  0.10E-29 period in steps =****** mass=  -0.366E-27a.u.
+   SCALEE = 1.0000    scale energy and forces
+   NPACO  =    256;   APACO  = 16.0  distance and # of slots for P.C.
+   PSTRESS=    0.0 pullay stress
+
+  Mass of Ions in am
+   POMASS = 137.33 47.88 16.00
+  Ionic Valenz
+   ZVAL   =  10.00 10.00  6.00
+  Atomic Wigner-Seitz radii
+   RWIGS  =  -1.00 -1.00 -1.00
+  virtual crystal weights 
+   VCA    =   1.00  1.00  1.00
+   NELECT =      38.0000    total number of electrons
+   NUPDOWN=      -1.0000    fix difference up-down
+
+ DOS related values:
+   EMIN   =  10.00;   EMAX   =-10.00  energy-range for DOS
+   EFERMI =   0.00
+   ISMEAR =    -5;   SIGMA  =   0.05  broadening in eV -4-tet -1-fermi 0-gaus
+
+ Electronic relaxation 2 (details)
+   IALGO  =     38    algorithm
+   LDIAG  =      T    sub-space diagonalisation (order eigenvalues)
+   LSUBROT=      F    optimize rotation matrix (better conditioning)
+   TURBO    =      0    0=normal 1=particle mesh
+   IRESTART =      0    0=no restart 2=restart with 2 vectors
+   NREBOOT  =      0    no. of reboots
+   NMIN     =      0    reboot dimension
+   EREF     =   0.00    reference energy to select bands
+   IMIX   =      4    mixing-type and parameters
+     AMIX     =   0.40;   BMIX     =  1.00
+     AMIX_MAG =   1.60;   BMIX_MAG =  1.00
+     AMIN     =   0.10
+     WC   =   100.;   INIMIX=   1;  MIXPRE=   1;  MAXMIX= -45
+
+ Intra band minimization:
+   WEIMIN = 0.0000     energy-eigenvalue tresh-hold
+   EBREAK =  0.26E-05  absolut break condition
+   DEPER  =   0.30     relativ break condition  
+
+   TIME   =   0.40     timestep for ELM
+
+  volume/ion in A,a.u.               =      13.50        91.10
+  Fermi-wavevector in a.u.,A,eV,Ry     =   1.351779  2.554491 24.862006  1.827306
+  Thomas-Fermi vector in A             =   2.479172
+ 
+ Write flags
+   LWAVE  =      F    write WAVECAR
+   LCHARG =      T    write CHGCAR
+   LVTOT  =      F    write LOCPOT, total local potential
+   LVHAR  =      T    write LOCPOT, Hartree potential only
+   LELF   =      F    write electronic localiz. function (ELF)
+   LORBIT =     11    0 simple, 1 ext, 2 COOP (PROOUT)
+
+
+ Dipole corrections
+   LMONO  =      F    monopole corrections only (constant potential shift)
+   LDIPOL =      F    correct potential (dipole corrections)
+   IDIPOL =      0    1-x, 2-y, 3-z, 4-all directions 
+   EPSILON=  1.0000000 bulk dielectric constant
+
+ Exchange correlation treatment:
+   GGA     =    --    GGA type
+   LEXCH   =     8    internal setting for exchange type
+   VOSKOWN=      0    Vosko Wilk Nusair interpolation
+   LHFCALC =     F    Hartree Fock is set to
+   LHFONE  =     F    Hartree Fock one center treatment
+   AEXX    =    0.0000 exact exchange contribution
+
+ Linear response parameters
+   LEPSILON=     F    determine dielectric tensor
+   LRPA    =     F    only Hartree local field effects (RPA)
+   LNABLA  =     F    use nabla operator in PAW spheres
+   LVEL    =     F    velocity operator in full k-point grid
+   LINTERFAST=   F  fast interpolation
+   KINTER  =     0    interpolate to denser k-point grid
+   CSHIFT  =0.1000    complex shift for real part using Kramers Kronig
+   OMEGAMAX=  -1.0    maximum frequency
+   DEG_THRESHOLD= 0.2000000E-02 threshold for treating states as degnerate
+   RTIME   =    0.100 relaxation time in fs
+
+ Orbital magnetization related:
+   ORBITALMAG=     F  switch on orbital magnetization
+   LCHIMAG   =     F  perturbation theory with respect to B field
+   DQ        =  0.001000  dq finite difference perturbation B field
+
+ PEAD related settings:
+   LPEAD      =     T    switch on PEAD
+   IPEAD      =     4    finite difference order for dpsi/dk
+   LCALCPOL   =     T    calculate macroscopic polarization
+   LCALCEPS   =     F    calculate dielectric tensor
+   EFIELD_PEAD=    0.0000    0.0000    0.0000
+   SKIP_EDOTP =     F
+   LRPA       =     F
+   SKIP_SCF   =     F
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ Static calculation
+ charge density and potential will be updated during run
+ spin polarized calculation
+ Variant of blocked Davidson
+ Davidson routine will perform the subspace rotation
+ perform sub-space diagonalisation
+    after iterative eigenvector-optimisation
+ modified Broyden-mixing scheme, WC =      100.0
+ initial mixing is a Kerker type mixing with AMIX =  0.4000 and BMIX =      1.0000
+ Hartree-type preconditioning will be used
+ using additional bands            5
+ real space projection scheme for non local part
+ use partial core corrections
+ calculate Harris-corrections to forces 
+   (improved forces if not selfconsistent)
+ use gradient corrections 
+ use of overlap-Matrix (Vanderbilt PP)
+ Fermi weights with tetrahedron method with Bloechl corrections
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+  energy-cutoff  :      520.00
+  volume of cell :       67.50
+      direct lattice vectors                 reciprocal lattice vectors
+     4.001368000  0.000000000  0.000000000     0.249914529  0.000000000  0.000000000
+     0.000000000  4.001368000  0.000000000     0.000000000  0.249914529  0.000000000
+     0.000000000  0.000000000  4.215744000     0.000000000  0.000000000  0.237206054
+
+  length of vectors
+     4.001368000  4.001368000  4.215744000     0.249914529  0.249914529  0.237206054
+
+
+ 
+ old parameters found on file WAVECAR:
+  energy-cutoff  :      520.00
+  volume of cell :       67.50
+      direct lattice vectors                 reciprocal lattice vectors
+     4.001368000  0.000000000  0.000000000     0.249914529  0.000000000  0.000000000
+     0.000000000  4.001368000  0.000000000     0.000000000  0.249914529  0.000000000
+     0.000000000  0.000000000  4.215744000     0.000000000  0.000000000  0.237206054
+
+  length of vectors
+
+ 
+ k-points in units of 2pi/SCALE and weight: Automatic kpoint scheme                 
+   0.00000000  0.00000000  0.00000000       0.002
+   0.03123932  0.00000000  0.00000000       0.008
+   0.06247863  0.00000000  0.00000000       0.008
+   0.09371795  0.00000000  0.00000000       0.008
+   0.12495726  0.00000000  0.00000000       0.004
+   0.03123932  0.03123932  0.00000000       0.008
+   0.06247863  0.03123932  0.00000000       0.016
+   0.09371795  0.03123932  0.00000000       0.016
+   0.12495726  0.03123932  0.00000000       0.008
+   0.06247863  0.06247863  0.00000000       0.008
+   0.09371795  0.06247863  0.00000000       0.016
+   0.12495726  0.06247863  0.00000000       0.008
+   0.09371795  0.09371795  0.00000000       0.008
+   0.12495726  0.09371795  0.00000000       0.008
+   0.12495726  0.12495726  0.00000000       0.002
+   0.00000000  0.00000000  0.02965076       0.004
+   0.03123932  0.00000000  0.02965076       0.016
+   0.06247863  0.00000000  0.02965076       0.016
+   0.09371795  0.00000000  0.02965076       0.016
+   0.12495726  0.00000000  0.02965076       0.008
+   0.03123932  0.03123932  0.02965076       0.016
+   0.06247863  0.03123932  0.02965076       0.031
+   0.09371795  0.03123932  0.02965076       0.031
+   0.12495726  0.03123932  0.02965076       0.016
+   0.06247863  0.06247863  0.02965076       0.016
+   0.09371795  0.06247863  0.02965076       0.031
+   0.12495726  0.06247863  0.02965076       0.016
+   0.09371795  0.09371795  0.02965076       0.016
+   0.12495726  0.09371795  0.02965076       0.016
+   0.12495726  0.12495726  0.02965076       0.004
+   0.00000000  0.00000000  0.05930151       0.004
+   0.03123932  0.00000000  0.05930151       0.016
+   0.06247863  0.00000000  0.05930151       0.016
+   0.09371795  0.00000000  0.05930151       0.016
+   0.12495726  0.00000000  0.05930151       0.008
+   0.03123932  0.03123932  0.05930151       0.016
+   0.06247863  0.03123932  0.05930151       0.031
+   0.09371795  0.03123932  0.05930151       0.031
+   0.12495726  0.03123932  0.05930151       0.016
+   0.06247863  0.06247863  0.05930151       0.016
+   0.09371795  0.06247863  0.05930151       0.031
+   0.12495726  0.06247863  0.05930151       0.016
+   0.09371795  0.09371795  0.05930151       0.016
+   0.12495726  0.09371795  0.05930151       0.016
+   0.12495726  0.12495726  0.05930151       0.004
+   0.00000000  0.00000000  0.08895227       0.004
+   0.03123932  0.00000000  0.08895227       0.016
+   0.06247863  0.00000000  0.08895227       0.016
+   0.09371795  0.00000000  0.08895227       0.016
+   0.12495726  0.00000000  0.08895227       0.008
+   0.03123932  0.03123932  0.08895227       0.016
+   0.06247863  0.03123932  0.08895227       0.031
+   0.09371795  0.03123932  0.08895227       0.031
+   0.12495726  0.03123932  0.08895227       0.016
+   0.06247863  0.06247863  0.08895227       0.016
+   0.09371795  0.06247863  0.08895227       0.031
+   0.12495726  0.06247863  0.08895227       0.016
+   0.09371795  0.09371795  0.08895227       0.016
+   0.12495726  0.09371795  0.08895227       0.016
+   0.12495726  0.12495726  0.08895227       0.004
+   0.00000000  0.00000000  0.11860303       0.002
+   0.03123932  0.00000000  0.11860303       0.008
+   0.06247863  0.00000000  0.11860303       0.008
+   0.09371795  0.00000000  0.11860303       0.008
+   0.12495726  0.00000000  0.11860303       0.004
+   0.03123932  0.03123932  0.11860303       0.008
+   0.06247863  0.03123932  0.11860303       0.016
+   0.09371795  0.03123932  0.11860303       0.016
+   0.12495726  0.03123932  0.11860303       0.008
+   0.06247863  0.06247863  0.11860303       0.008
+   0.09371795  0.06247863  0.11860303       0.016
+   0.12495726  0.06247863  0.11860303       0.008
+   0.09371795  0.09371795  0.11860303       0.008
+   0.12495726  0.09371795  0.11860303       0.008
+   0.12495726  0.12495726  0.11860303       0.002
+ 
+ k-points in reciprocal lattice and weights: Automatic kpoint scheme                 
+   0.00000000  0.00000000  0.00000000       0.002
+   0.12500000  0.00000000  0.00000000       0.008
+   0.25000000  0.00000000  0.00000000       0.008
+   0.37500000  0.00000000  0.00000000       0.008
+   0.50000000  0.00000000  0.00000000       0.004
+   0.12500000  0.12500000  0.00000000       0.008
+   0.25000000  0.12500000  0.00000000       0.016
+   0.37500000  0.12500000  0.00000000       0.016
+   0.50000000  0.12500000  0.00000000       0.008
+   0.25000000  0.25000000  0.00000000       0.008
+   0.37500000  0.25000000  0.00000000       0.016
+   0.50000000  0.25000000  0.00000000       0.008
+   0.37500000  0.37500000  0.00000000       0.008
+   0.50000000  0.37500000  0.00000000       0.008
+   0.50000000  0.50000000  0.00000000       0.002
+   0.00000000  0.00000000  0.12500000       0.004
+   0.12500000  0.00000000  0.12500000       0.016
+   0.25000000  0.00000000  0.12500000       0.016
+   0.37500000  0.00000000  0.12500000       0.016
+   0.50000000  0.00000000  0.12500000       0.008
+   0.12500000  0.12500000  0.12500000       0.016
+   0.25000000  0.12500000  0.12500000       0.031
+   0.37500000  0.12500000  0.12500000       0.031
+   0.50000000  0.12500000  0.12500000       0.016
+   0.25000000  0.25000000  0.12500000       0.016
+   0.37500000  0.25000000  0.12500000       0.031
+   0.50000000  0.25000000  0.12500000       0.016
+   0.37500000  0.37500000  0.12500000       0.016
+   0.50000000  0.37500000  0.12500000       0.016
+   0.50000000  0.50000000  0.12500000       0.004
+   0.00000000  0.00000000  0.25000000       0.004
+   0.12500000  0.00000000  0.25000000       0.016
+   0.25000000  0.00000000  0.25000000       0.016
+   0.37500000  0.00000000  0.25000000       0.016
+   0.50000000  0.00000000  0.25000000       0.008
+   0.12500000  0.12500000  0.25000000       0.016
+   0.25000000  0.12500000  0.25000000       0.031
+   0.37500000  0.12500000  0.25000000       0.031
+   0.50000000  0.12500000  0.25000000       0.016
+   0.25000000  0.25000000  0.25000000       0.016
+   0.37500000  0.25000000  0.25000000       0.031
+   0.50000000  0.25000000  0.25000000       0.016
+   0.37500000  0.37500000  0.25000000       0.016
+   0.50000000  0.37500000  0.25000000       0.016
+   0.50000000  0.50000000  0.25000000       0.004
+   0.00000000  0.00000000  0.37500000       0.004
+   0.12500000  0.00000000  0.37500000       0.016
+   0.25000000  0.00000000  0.37500000       0.016
+   0.37500000  0.00000000  0.37500000       0.016
+   0.50000000  0.00000000  0.37500000       0.008
+   0.12500000  0.12500000  0.37500000       0.016
+   0.25000000  0.12500000  0.37500000       0.031
+   0.37500000  0.12500000  0.37500000       0.031
+   0.50000000  0.12500000  0.37500000       0.016
+   0.25000000  0.25000000  0.37500000       0.016
+   0.37500000  0.25000000  0.37500000       0.031
+   0.50000000  0.25000000  0.37500000       0.016
+   0.37500000  0.37500000  0.37500000       0.016
+   0.50000000  0.37500000  0.37500000       0.016
+   0.50000000  0.50000000  0.37500000       0.004
+   0.00000000  0.00000000  0.50000000       0.002
+   0.12500000  0.00000000  0.50000000       0.008
+   0.25000000  0.00000000  0.50000000       0.008
+   0.37500000  0.00000000  0.50000000       0.008
+   0.50000000  0.00000000  0.50000000       0.004
+   0.12500000  0.12500000  0.50000000       0.008
+   0.25000000  0.12500000  0.50000000       0.016
+   0.37500000  0.12500000  0.50000000       0.016
+   0.50000000  0.12500000  0.50000000       0.008
+   0.25000000  0.25000000  0.50000000       0.008
+   0.37500000  0.25000000  0.50000000       0.016
+   0.50000000  0.25000000  0.50000000       0.008
+   0.37500000  0.37500000  0.50000000       0.008
+   0.50000000  0.37500000  0.50000000       0.008
+   0.50000000  0.50000000  0.50000000       0.002
+ 
+ position of ions in fractional coordinates (direct lattice) 
+   0.00000000  0.00000000  0.02027300
+   0.50000000  0.50000000  0.53885200
+   0.00000000  0.50000000  0.49202200
+   0.50000000  0.00000000  0.49202200
+   0.50000000  0.50000000  0.97082900
+ 
+ position of ions in cartesian coordinates  (Angst):
+   0.00000000  0.00000000  0.08546578
+   2.00068400  2.00068400  2.27166209
+   0.00000000  2.00068400  2.07423879
+   2.00068400  0.00000000  2.07423879
+   2.00068400  2.00068400  4.09276653
+ 
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ k-point  1 :   0.0000 0.0000 0.0000  plane waves:    1815
+ k-point  2 :   0.1250 0.0000 0.0000  plane waves:    1823
+ k-point  3 :   0.2500 0.0000 0.0000  plane waves:    1813
+ k-point  4 :   0.3750 0.0000 0.0000  plane waves:    1817
+ k-point  5 :   0.5000 0.0000 0.0000  plane waves:    1818
+ k-point  6 :   0.1250 0.1250 0.0000  plane waves:    1811
+ k-point  7 :   0.2500 0.1250 0.0000  plane waves:    1817
+ k-point  8 :   0.3750 0.1250 0.0000  plane waves:    1815
+ k-point  9 :   0.5000 0.1250 0.0000  plane waves:    1820
+ k-point 10 :   0.2500 0.2500 0.0000  plane waves:    1827
+ k-point 11 :   0.3750 0.2500 0.0000  plane waves:    1811
+ k-point 12 :   0.5000 0.2500 0.0000  plane waves:    1804
+ k-point 13 :   0.3750 0.3750 0.0000  plane waves:    1810
+ k-point 14 :   0.5000 0.3750 0.0000  plane waves:    1798
+ k-point 15 :   0.5000 0.5000 0.0000  plane waves:    1812
+ k-point 16 :   0.0000 0.0000 0.1250  plane waves:    1819
+ k-point 17 :   0.1250 0.0000 0.1250  plane waves:    1828
+ k-point 18 :   0.2500 0.0000 0.1250  plane waves:    1820
+ k-point 19 :   0.3750 0.0000 0.1250  plane waves:    1814
+ k-point 20 :   0.5000 0.0000 0.1250  plane waves:    1820
+ k-point 21 :   0.1250 0.1250 0.1250  plane waves:    1816
+ k-point 22 :   0.2500 0.1250 0.1250  plane waves:    1814
+ k-point 23 :   0.3750 0.1250 0.1250  plane waves:    1817
+ k-point 24 :   0.5000 0.1250 0.1250  plane waves:    1820
+ k-point 25 :   0.2500 0.2500 0.1250  plane waves:    1818
+ k-point 26 :   0.3750 0.2500 0.1250  plane waves:    1814
+ k-point 27 :   0.5000 0.2500 0.1250  plane waves:    1810
+ k-point 28 :   0.3750 0.3750 0.1250  plane waves:    1812
+ k-point 29 :   0.5000 0.3750 0.1250  plane waves:    1814
+ k-point 30 :   0.5000 0.5000 0.1250  plane waves:    1804
+ k-point 31 :   0.0000 0.0000 0.2500  plane waves:    1836
+ k-point 32 :   0.1250 0.0000 0.2500  plane waves:    1828
+ k-point 33 :   0.2500 0.0000 0.2500  plane waves:    1824
+ k-point 34 :   0.3750 0.0000 0.2500  plane waves:    1813
+ k-point 35 :   0.5000 0.0000 0.2500  plane waves:    1802
+ k-point 36 :   0.1250 0.1250 0.2500  plane waves:    1832
+ k-point 37 :   0.2500 0.1250 0.2500  plane waves:    1819
+ k-point 38 :   0.3750 0.1250 0.2500  plane waves:    1810
+ k-point 39 :   0.5000 0.1250 0.2500  plane waves:    1812
+ k-point 40 :   0.2500 0.2500 0.2500  plane waves:    1811
+ k-point 41 :   0.3750 0.2500 0.2500  plane waves:    1821
+ k-point 42 :   0.5000 0.2500 0.2500  plane waves:    1818
+ k-point 43 :   0.3750 0.3750 0.2500  plane waves:    1823
+ k-point 44 :   0.5000 0.3750 0.2500  plane waves:    1810
+ k-point 45 :   0.5000 0.5000 0.2500  plane waves:    1820
+ k-point 46 :   0.0000 0.0000 0.3750  plane waves:    1848
+ k-point 47 :   0.1250 0.0000 0.3750  plane waves:    1832
+ k-point 48 :   0.2500 0.0000 0.3750  plane waves:    1828
+ k-point 49 :   0.3750 0.0000 0.3750  plane waves:    1815
+ k-point 50 :   0.5000 0.0000 0.3750  plane waves:    1794
+ k-point 51 :   0.1250 0.1250 0.3750  plane waves:    1833
+ k-point 52 :   0.2500 0.1250 0.3750  plane waves:    1830
+ k-point 53 :   0.3750 0.1250 0.3750  plane waves:    1811
+ k-point 54 :   0.5000 0.1250 0.3750  plane waves:    1808
+ k-point 55 :   0.2500 0.2500 0.3750  plane waves:    1811
+ k-point 56 :   0.3750 0.2500 0.3750  plane waves:    1815
+ k-point 57 :   0.5000 0.2500 0.3750  plane waves:    1818
+ k-point 58 :   0.3750 0.3750 0.3750  plane waves:    1814
+ k-point 59 :   0.5000 0.3750 0.3750  plane waves:    1822
+ k-point 60 :   0.5000 0.5000 0.3750  plane waves:    1820
+ k-point 61 :   0.0000 0.0000 0.5000  plane waves:    1840
+ k-point 62 :   0.1250 0.0000 0.5000  plane waves:    1840
+ k-point 63 :   0.2500 0.0000 0.5000  plane waves:    1844
+ k-point 64 :   0.3750 0.0000 0.5000  plane waves:    1822
+ k-point 65 :   0.5000 0.0000 0.5000  plane waves:    1804
+ k-point 66 :   0.1250 0.1250 0.5000  plane waves:    1832
+ k-point 67 :   0.2500 0.1250 0.5000  plane waves:    1816
+ k-point 68 :   0.3750 0.1250 0.5000  plane waves:    1808
+ k-point 69 :   0.5000 0.1250 0.5000  plane waves:    1816
+ k-point 70 :   0.2500 0.2500 0.5000  plane waves:    1822
+ k-point 71 :   0.3750 0.2500 0.5000  plane waves:    1816
+ k-point 72 :   0.5000 0.2500 0.5000  plane waves:    1820
+ k-point 73 :   0.3750 0.3750 0.5000  plane waves:    1814
+ k-point 74 :   0.5000 0.3750 0.5000  plane waves:    1816
+ k-point 75 :   0.5000 0.5000 0.5000  plane waves:    1816
+
+ maximum and minimum number of plane-waves per node :      1848     1794
+
+ maximum number of plane-waves:      1848
+ maximum index in each direction: 
+   IXMAX=    7   IYMAX=    7   IZMAX=    7
+   IXMIN=   -7   IYMIN=   -7   IZMIN=   -8
+
+ NGX is ok and might be reduce to  30
+ NGY is ok and might be reduce to  30
+ NGZ is ok and might be reduce to  32
+
+ serial   3D FFT for wavefunctions
+ parallel 3D FFT for charge:
+    minimum data exchange during FFTs selected (reduces bandwidth)
+
+
+ total amount of memory used by VASP on root node    53643. kBytes
+========================================================================
+
+   base      :      30000. kBytes
+   nonlr-proj:       3455. kBytes
+   fftplans  :       1162. kBytes
+   grid      :       5105. kBytes
+   one-center:        155. kBytes
+   wavefun   :      13766. kBytes
+ 
+     INWAV:  cpu time    0.49: real time    0.49
+ Broyden mixing: mesh for mixing (old mesh)
+   NGX = 15   NGY = 15   NGZ = 15
+  (NGX  = 60   NGY  = 60   NGZ  = 64)
+  gives a total of   3375 points
+
+ charge density for first step will be calculated from the start-wavefunctions
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ Maximum index for non-local projection operator         8157
+ Maximum index for augmentation-charges         3792 (set IRDMAX)
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ initial charge from wavefunction
+ First call to EWALD:  gamma=   0.435
+ Maximum number of real-space cells 3x 3x 3
+ Maximum number of reciprocal cells 3x 3x 3
+
+ FEWALD executed in parallel
+    FEWALD:  cpu time    0.00: real time    0.00
+
+
+----------------------------------------- Iteration    1(   1)  ---------------------------------------
+
+
+    POTLOK:  cpu time    0.09: real time    0.09
+    SETDIJ:  cpu time    0.02: real time    0.02
+     EDDAV:  cpu time   11.77: real time   11.77
+ BZINTS: Fermi energy:  3.100253; 38.000000 electrons
+         Band energy:-335.069097;  BLOECHL correction:  0.000000
+       DOS:  cpu time    0.01: real time    0.01
+    CHARGE:  cpu time    0.84: real time    0.84
+    MIXING:  cpu time    0.00: real time    0.00
+    --------------------------------------------
+      LOOP:  cpu time   12.74: real time   12.74
+
+ eigenvalue-minimisations  :  6968
+ total energy-change (2. order) :-0.3994315E+02  (-0.1016676E-03)
+ number of electron      37.9999981 magnetization       0.0000000
+ augmentation part        4.8162523 magnetization      -0.0000014
+
+ Broyden mixing:
+  rms(total) = 0.94743E-02    rms(broyden)= 0.94722E-02
+  rms(prec ) = 0.20051E-01
+  weight for this iteration     100.00
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =       248.24775878
+  Ewald energy   TEWEN  =     -2470.23209786
+  -Hartree energ DENC   =      -660.71449030
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =       146.52873351
+  PAW double counting   =      3650.09740159    -3659.32837723
+  entropy T*S    EENTRO =         0.00000000
+  eigenvalues    EBANDS =      -335.06909747
+  atomic energy  EATOM  =      3040.52701931
+  ---------------------------------------------------
+  free energy    TOTEN  =       -39.94314969 eV
+
+  energy without entropy =      -39.94314969  energy(sigma->0) =      -39.94314969
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+----------------------------------------- Iteration    1(   2)  ---------------------------------------
+
+
+    POTLOK:  cpu time    0.09: real time    0.09
+    SETDIJ:  cpu time    0.02: real time    0.02
+     EDDAV:  cpu time   14.32: real time   14.33
+ BZINTS: Fermi energy:  3.098148; 38.000000 electrons
+         Band energy:-334.969667;  BLOECHL correction:  0.000000
+       DOS:  cpu time    0.01: real time    0.01
+    --------------------------------------------
+      LOOP:  cpu time   14.45: real time   14.45
+
+ eigenvalue-minimisations  :  8944
+ total energy-change (2. order) : 0.4380918E-04  (-0.1266543E-03)
+ number of electron      37.9999981 magnetization       0.0000000
+ augmentation part        4.8162523 magnetization      -0.0000014
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =       248.24775878
+  Ewald energy   TEWEN  =     -2470.23209786
+  -Hartree energ DENC   =      -660.81347064
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =       146.53966289
+  PAW double counting   =      3650.21658282    -3659.45889429
+  entropy T*S    EENTRO =         0.00000000
+  eigenvalues    EBANDS =      -334.96966688
+  atomic energy  EATOM  =      3040.52701931
+  ---------------------------------------------------
+  free energy    TOTEN  =       -39.94310588 eV
+
+  energy without entropy =      -39.94310588  energy(sigma->0) =      -39.94310588
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+ average (electrostatic) potential at core
+  the test charge radii are     1.2192  1.0397  0.7215
+  (the norm of the test charge is              1.0000)
+       1 -34.1238       2 -54.1195       3 -70.5835       4 -70.5835       5 -70.9142
+ 
+ 
+ 
+ E-fermi :   3.0981     XC(G=0): -10.9401     alpha+bet :-13.1747
+
+
+ spin component 1
+
+ k-point     1 :       0.0000    0.0000    0.0000
+  band No.  band energies     occupation 
+      1     -30.0580      1.00000
+      2     -29.9237      1.00000
+      3     -29.9237      1.00000
+      4     -22.1870      1.00000
+      5     -13.9656      1.00000
+      6     -13.3689      1.00000
+      7     -13.1998      1.00000
+      8      -7.3835      1.00000
+      9      -7.3123      1.00000
+     10      -7.3123      1.00000
+     11       0.4503      1.00000
+     12       0.5787      1.00000
+     13       0.5787      1.00000
+     14       1.3310      1.00000
+     15       1.3310      1.00000
+     16       1.7382      1.00000
+     17       2.1183      1.00000
+     18       2.4834      1.00000
+     19       2.4834      1.00000
+     20       4.7550      0.00000
+     21       5.3785      0.00000
+     22       5.3785      0.00000
+     23       6.9084      0.00000
+     24       7.1125      0.00000
+
+ k-point     2 :       0.1250    0.0000    0.0000
+  band No.  band energies     occupation 
+      1     -30.0577      1.00000
+      2     -29.9310      1.00000
+      3     -29.9234      1.00000
+      4     -22.1721      1.00000
+      5     -13.9682      1.00000
+      6     -13.3585      1.00000
+      7     -13.1920      1.00000
+      8      -7.3648      1.00000
+      9      -7.2892      1.00000
+     10      -7.2743      1.00000
+     11       0.3112      1.00000
+     12       0.4412      1.00000
+     13       0.5572      1.00000
+     14       1.1068      1.00000
+     15       1.2333      1.00000
+     16       1.6912      1.00000
+     17       1.9794      1.00000
+     18       2.2871      1.00000
+     19       2.3700      1.00000
+     20       5.0448      0.00000
+     21       5.3690      0.00000
+     22       5.3938      0.00000
+     23       7.0538      0.00000
+     24       7.3666      0.00000
+
+ k-point     3 :       0.2500    0.0000    0.0000
+  band No.  band energies     occupation 
+      1     -30.0570      1.00000
+      2     -29.9485      1.00000
+      3     -29.9228      1.00000
+      4     -22.1359      1.00000
+      5     -14.0124      1.00000
+      6     -13.3225      1.00000
+      7     -13.1380      1.00000
+      8      -7.3166      1.00000
+      9      -7.2320      1.00000
+     10      -7.1858      1.00000
+     11      -0.2518      1.00000
+     12       0.3459      1.00000
+     13       0.4486      1.00000
+     14       0.7516      1.00000
+     15       1.0763      1.00000
+     16       1.4655      1.00000
+     17       1.6705      1.00000
+     18       1.9258      1.00000
+     19       2.0610      1.00000
+     20       5.3836      0.00000
+     21       5.6731      0.00000
+     22       5.6979      0.00000
+     23       7.0551      0.00000
+     24       7.9536      0.00000
+
+ k-point     4 :       0.3750    0.0000    0.0000
+  band No.  band energies     occupation 
+      1     -30.0562      1.00000
+      2     -29.9660      1.00000
+      3     -29.9221      1.00000
+      4     -22.0991      1.00000
+      5     -14.0937      1.00000
+      6     -13.2917      1.00000
+      7     -13.0314      1.00000
+      8      -7.2651      1.00000
+      9      -7.1727      1.00000
+     10      -7.1000      1.00000
+     11      -0.7833      1.00000
+     12       0.2202      1.00000
+     13       0.2581      1.00000
+     14       0.4808      1.00000
+     15       1.0497      1.00000
+     16       1.1985      1.00000
+     17       1.4145      1.00000
+     18       1.6166      1.00000
+     19       1.8072      1.00000
+     20       5.4304      0.00000
+     21       6.1650      0.00000
+     22       6.2021      0.00000
+     23       7.0222      0.00000
+     24       8.2922      0.00000
+
+ k-point     5 :       0.5000    0.0000    0.0000
+  band No.  band energies     occupation 
+      1     -30.0559      1.00000
+      2     -29.9732      1.00000
+      3     -29.9218      1.00000
+      4     -22.0837      1.00000
+      5     -14.1336      1.00000
+      6     -13.2820      1.00000
+      7     -12.9746      1.00000
+      8      -7.2428      1.00000
+      9      -7.1475      1.00000
+     10      -7.0653      1.00000
+     11      -0.9963      1.00000
+     12       0.1650      1.00000
+     13       0.1684      1.00000
+     14       0.3656      1.00000
+     15       1.0814      1.00000
+     16       1.0852      1.00000
+     17       1.3334      1.00000
+     18       1.4782      1.00000
+     19       1.7161      1.00000
+     20       5.4481      0.00000
+     21       6.3577      0.00000
+     22       6.4594      0.00000
+     23       6.9825      0.00000
+     24       8.3791      0.00000
+
+ k-point     6 :       0.1250    0.1250    0.0000
+  band No.  band energies     occupation 
+      1     -30.0574      1.00000
+      2     -29.9308      1.00000
+      3     -29.9305      1.00000
+      4     -22.1580      1.00000
+      5     -13.9610      1.00000
+      6     -13.3427      1.00000
+      7     -13.1914      1.00000
+      8      -7.3437      1.00000
+      9      -7.3429      1.00000
+     10      -7.1881      1.00000
+     11       0.1836      1.00000
+     12       0.4093      1.00000
+     13       0.4191      1.00000
+     14       0.9734      1.00000
+     15       1.0768      1.00000
+     16       1.5840      1.00000
+     17       1.7526      1.00000
+     18       2.2269      1.00000
+     19       2.4433      1.00000
+     20       5.1949      0.00000
+     21       5.3826      0.00000
+     22       5.4340      0.00000
+     23       7.2447      0.00000
+     24       7.5895      0.00000
+
+ k-point     7 :       0.2500    0.1250    0.0000
+  band No.  band energies     occupation 
+      1     -30.0567      1.00000
+      2     -29.9482      1.00000
+      3     -29.9300      1.00000
+      4     -22.1235      1.00000
+      5     -13.9803      1.00000
+      6     -13.2990      1.00000
+      7     -13.1534      1.00000
+      8      -7.3395      1.00000
+      9      -7.2902      1.00000
+     10      -7.1162      1.00000
+     11      -0.3138      1.00000
+     12       0.2411      1.00000
+     13       0.3512      1.00000
+     14       0.7408      1.00000
+     15       0.8084      1.00000
+     16       1.1037      1.00000
+     17       1.6801      1.00000
+     18       2.0510      1.00000
+     19       2.2679      1.00000
+     20       5.3582      0.00000
+     21       5.7244      0.00000
+     22       5.7575      0.00000
+     23       7.2608      0.00000
+     24       8.1976      0.00000
+
+ k-point     8 :       0.3750    0.1250    0.0000
+  band No.  band energies     occupation 
+      1     -30.0559      1.00000
+      2     -29.9656      1.00000
+      3     -29.9293      1.00000
+      4     -22.0884      1.00000
+      5     -14.0389      1.00000
+      6     -13.2684      1.00000
+      7     -13.0532      1.00000
+      8      -7.2849      1.00000
+      9      -7.2284      1.00000
+     10      -7.1050      1.00000
+     11      -0.8190      1.00000
+     12       0.1188      1.00000
+     13       0.2152      1.00000
+     14       0.4307      1.00000
+     15       0.5789      1.00000
+     16       1.0267      1.00000
+     17       1.4729      1.00000
+     18       1.8846      1.00000
+     19       2.0314      1.00000
+     20       5.4165      0.00000
+     21       6.1921      0.00000
+     22       6.2249      0.00000
+     23       7.2116      0.00000
+     24       8.5783      0.00000
+
+ k-point     9 :       0.5000    0.1250    0.0000
+  band No.  band energies     occupation 
+      1     -30.0556      1.00000
+      2     -29.9727      1.00000
+      3     -29.9290      1.00000
+      4     -22.0737      1.00000
+      5     -14.0708      1.00000
+      6     -13.2596      1.00000
+      7     -12.9974      1.00000
+      8      -7.2478      1.00000
+      9      -7.1816      1.00000
+     10      -7.1364      1.00000
+     11      -1.0251      1.00000
+     12       0.0850      1.00000
+     13       0.1912      1.00000
+     14       0.2178      1.00000
+     15       0.5063      1.00000
+     16       1.1171      1.00000
+     17       1.3047      1.00000
+     18       1.8708      1.00000
+     19       1.8908      1.00000
+     20       5.4362      0.00000
+     21       6.3864      0.00000
+     22       6.4672      0.00000
+     23       7.1600      0.00000
+     24       8.6865      0.00000
+
+ k-point    10 :       0.2500    0.2500    0.0000
+  band No.  band energies     occupation 
+      1     -30.0560      1.00000
+      2     -29.9476      1.00000
+      3     -29.9470      1.00000
+      4     -22.0930      1.00000
+      5     -13.9264      1.00000
+      6     -13.2346      1.00000
+      7     -13.1700      1.00000
+      8      -7.4170      1.00000
+      9      -7.2429      1.00000
+     10      -7.1139      1.00000
+     11      -0.5374      1.00000
+     12      -0.1007      1.00000
+     13       0.2704      1.00000
+     14       0.3080      1.00000
+     15       0.6597      1.00000
+     16       0.7488      1.00000
+     17       1.8004      1.00000
+     18       1.9013      1.00000
+     19       2.4720      1.00000
+     20       5.5533      0.00000
+     21       5.8673      0.00000
+     22       6.0147      0.00000
+     23       7.3681      0.00000
+     24       8.8150      0.00000
+
+ k-point    11 :       0.3750    0.2500    0.0000
+  band No.  band energies     occupation 
+      1     -30.0552      1.00000
+      2     -29.9646      1.00000
+      3     -29.9465      1.00000
+      4     -22.0622      1.00000
+      5     -13.9099      1.00000
+      6     -13.2088      1.00000
+      7     -13.1028      1.00000
+      8      -7.4148      1.00000
+      9      -7.2264      1.00000
+     10      -7.1595      1.00000
+     11      -0.9085      1.00000
+     12      -0.3149      1.00000
+     13      -0.1417      1.00000
+     14       0.1638      1.00000
+     15       0.4549      1.00000
+     16       0.9068      1.00000
+     17       1.6298      1.00000
+     18       1.8184      1.00000
+     19       2.5180      1.00000
+     20       5.6885      0.00000
+     21       6.2383      0.00000
+     22       6.3600      0.00000
+     23       7.3196      0.00000
+     24       9.2839      0.00000
+
+ k-point    12 :       0.5000    0.2500    0.0000
+  band No.  band energies     occupation 
+      1     -30.0549      1.00000
+      2     -29.9717      1.00000
+      3     -29.9461      1.00000
+      4     -22.0493      1.00000
+      5     -13.9137      1.00000
+      6     -13.2064      1.00000
+      7     -13.0537      1.00000
+      8      -7.3603      1.00000
+      9      -7.3016      1.00000
+     10      -7.1494      1.00000
+     11      -1.0912      1.00000
+     12      -0.4380      1.00000
+     13      -0.2116      1.00000
+     14       0.0867      1.00000
+     15       0.3792      1.00000
+     16       1.0557      1.00000
+     17       1.4751      1.00000
+     18       1.7900      1.00000
+     19       2.5131      1.00000
+     20       5.7165      0.00000
+     21       6.4638      0.00000
+     22       6.5273      0.00000
+     23       7.2548      0.00000
+     24       9.4336      0.00000
+
+ k-point    13 :       0.3750    0.3750    0.0000
+  band No.  band energies     occupation 
+      1     -30.0545      1.00000
+      2     -29.9638      1.00000
+      3     -29.9635      1.00000
+      4     -22.0357      1.00000
+      5     -13.7910      1.00000
+      6     -13.1468      1.00000
+      7     -13.1393      1.00000
+      8      -7.4899      1.00000
+      9      -7.3574      1.00000
+     10      -7.1186      1.00000
+     11      -1.0867      1.00000
+     12      -0.7002      1.00000
+     13      -0.5861      1.00000
+     14       0.1184      1.00000
+     15       0.2513      1.00000
+     16       1.0298      1.00000
+     17       1.6507      1.00000
+     18       1.8413      1.00000
+     19       2.7932      1.00000
+     20       6.0995      0.00000
+     21       6.3197      0.00000
+     22       6.5944      0.00000
+     23       7.2466      0.00000
+     24       9.8786      0.00000
+
+ k-point    14 :       0.5000    0.3750    0.0000
+  band No.  band energies     occupation 
+      1     -30.0542      1.00000
+      2     -29.9707      1.00000
+      3     -29.9632      1.00000
+      4     -22.0246      1.00000
+      5     -13.7472      1.00000
+      6     -13.1559      1.00000
+      7     -13.1121      1.00000
+      8      -7.4755      1.00000
+      9      -7.4576      1.00000
+     10      -7.0964      1.00000
+     11      -1.2208      1.00000
+     12      -0.8780      1.00000
+     13      -0.6559      1.00000
+     14       0.0810      1.00000
+     15       0.1766      1.00000
+     16       1.0500      1.00000
+     17       1.7502      1.00000
+     18       1.8023      1.00000
+     19       2.8704      1.00000
+     20       6.2001      0.00000
+     21       6.4869      0.00000
+     22       6.7174      0.00000
+     23       7.1536      0.00000
+     24      10.0848      0.00000
+
+ k-point    15 :       0.5000    0.5000    0.0000
+  band No.  band energies     occupation 
+      1     -30.0540      1.00000
+      2     -29.9703      1.00000
+      3     -29.9703      1.00000
+      4     -22.0143      1.00000
+      5     -13.6744      1.00000
+      6     -13.1369      1.00000
+      7     -13.1369      1.00000
+      8      -7.5194      1.00000
+      9      -7.5194      1.00000
+     10      -7.0734      1.00000
+     11      -1.3340      1.00000
+     12      -1.0318      1.00000
+     13      -0.7744      1.00000
+     14       0.0826      1.00000
+     15       0.0826      1.00000
+     16       0.9944      1.00000
+     17       1.8718      1.00000
+     18       1.8718      1.00000
+     19       2.9783      1.00000
+     20       6.4939      0.00000
+     21       6.4939      0.00000
+     22       6.8221      0.00000
+     23       7.0186      0.00000
+     24      10.3863      0.00000
+
+ k-point    16 :       0.0000    0.0000    0.1250
+  band No.  band energies     occupation 
+      1     -30.0619      1.00000
+      2     -29.9235      1.00000
+      3     -29.9235      1.00000
+      4     -22.1769      1.00000
+      5     -13.9656      1.00000
+      6     -13.3762      1.00000
+      7     -13.1965      1.00000
+      8      -7.3202      1.00000
+      9      -7.2987      1.00000
+     10      -7.2987      1.00000
+     11       0.2242      1.00000
+     12       0.5371      1.00000
+     13       0.5371      1.00000
+     14       1.2371      1.00000
+     15       1.2371      1.00000
+     16       1.6264      1.00000
+     17       1.9076      1.00000
+     18       2.4592      1.00000
+     19       2.4592      1.00000
+     20       4.7716      0.00000
+     21       5.5298      0.00000
+     22       5.5298      0.00000
+     23       6.9072      0.00000
+     24       7.4073      0.00000
+
+ k-point    17 :       0.1250    0.0000    0.1250
+  band No.  band energies     occupation 
+      1     -30.0616      1.00000
+      2     -29.9308      1.00000
+      3     -29.9233      1.00000
+      4     -22.1627      1.00000
+      5     -13.9571      1.00000
+      6     -13.3721      1.00000
+      7     -13.1884      1.00000
+      8      -7.3503      1.00000
+      9      -7.2751      1.00000
+     10      -7.2315      1.00000
+     11       0.1449      1.00000
+     12       0.3326      1.00000
+     13       0.5238      1.00000
+     14       0.9730      1.00000
+     15       1.1341      1.00000
+     16       1.6769      1.00000
+     17       1.8484      1.00000
+     18       2.2606      1.00000
+     19       2.3284      1.00000
+     20       5.0602      0.00000
+     21       5.4947      0.00000
+     22       5.5408      0.00000
+     23       7.1570      0.00000
+     24       7.5651      0.00000
+
+ k-point    18 :       0.2500    0.0000    0.1250
+  band No.  band energies     occupation 
+      1     -30.0608      1.00000
+      2     -29.9483      1.00000
+      3     -29.9226      1.00000
+      4     -22.1279      1.00000
+      5     -13.9772      1.00000
+      6     -13.3412      1.00000
+      7     -13.1419      1.00000
+      8      -7.3350      1.00000
+      9      -7.2166      1.00000
+     10      -7.1584      1.00000
+     11      -0.3047      1.00000
+     12       0.1221      1.00000
+     13       0.4327      1.00000
+     14       0.5962      1.00000
+     15       0.9678      1.00000
+     16       1.5122      1.00000
+     17       1.6752      1.00000
+     18       1.8887      1.00000
+     19       2.0909      1.00000
+     20       5.5131      0.00000
+     21       5.6975      0.00000
+     22       5.7614      0.00000
+     23       7.2514      0.00000
+     24       8.0836      0.00000
+
+ k-point    19 :       0.3750    0.0000    0.1250
+  band No.  band energies     occupation 
+      1     -30.0601      1.00000
+      2     -29.9657      1.00000
+      3     -29.9220      1.00000
+      4     -22.0925      1.00000
+      5     -14.0411      1.00000
+      6     -13.3009      1.00000
+      7     -13.0512      1.00000
+      8      -7.2837      1.00000
+      9      -7.1559      1.00000
+     10      -7.1226      1.00000
+     11      -0.8106      1.00000
+     12       0.0121      1.00000
+     13       0.2452      1.00000
+     14       0.2652      1.00000
+     15       0.9467      1.00000
+     16       1.2958      1.00000
+     17       1.5670      1.00000
+     18       1.5685      1.00000
+     19       1.8479      1.00000
+     20       5.5705      0.00000
+     21       6.1730      0.00000
+     22       6.2242      0.00000
+     23       7.2429      0.00000
+     24       8.4229      0.00000
+
+ k-point    20 :       0.5000    0.0000    0.1250
+  band No.  band energies     occupation 
+      1     -30.0597      1.00000
+      2     -29.9729      1.00000
+      3     -29.9217      1.00000
+      4     -22.0777      1.00000
+      5     -14.0755      1.00000
+      6     -13.2864      1.00000
+      7     -13.0006      1.00000
+      8      -7.2511      1.00000
+      9      -7.1302      1.00000
+     10      -7.1195      1.00000
+     11      -1.0169      1.00000
+     12      -0.0002      1.00000
+     13       0.1028      1.00000
+     14       0.1511      1.00000
+     15       0.9829      1.00000
+     16       1.2029      1.00000
+     17       1.4234      1.00000
+     18       1.6073      1.00000
+     19       1.6854      1.00000
+     20       5.5864      0.00000
+     21       6.3657      0.00000
+     22       6.4595      0.00000
+     23       7.2217      0.00000
+     24       8.5100      0.00000
+
+ k-point    21 :       0.1250    0.1250    0.1250
+  band No.  band energies     occupation 
+      1     -30.0613      1.00000
+      2     -29.9307      1.00000
+      3     -29.9304      1.00000
+      4     -22.1490      1.00000
+      5     -13.9417      1.00000
+      6     -13.3608      1.00000
+      7     -13.1861      1.00000
+      8      -7.3440      1.00000
+      9      -7.3431      1.00000
+     10      -7.1367      1.00000
+     11       0.0314      1.00000
+     12       0.2902      1.00000
+     13       0.3757      1.00000
+     14       0.8895      1.00000
+     15       0.9517      1.00000
+     16       1.5432      1.00000
+     17       1.7900      1.00000
+     18       2.1424      1.00000
+     19       2.3924      1.00000
+     20       5.2391      0.00000
+     21       5.5143      0.00000
+     22       5.5364      0.00000
+     23       7.5593      0.00000
+     24       7.5815      0.00000
+
+ k-point    22 :       0.2500    0.1250    0.1250
+  band No.  band energies     occupation 
+      1     -30.0605      1.00000
+      2     -29.9480      1.00000
+      3     -29.9298      1.00000
+      4     -22.1158      1.00000
+      5     -13.9421      1.00000
+      6     -13.3189      1.00000
+      7     -13.1524      1.00000
+      8      -7.3564      1.00000
+      9      -7.3258      1.00000
+     10      -7.0637      1.00000
+     11      -0.3806      1.00000
+     12       0.0730      1.00000
+     13       0.2907      1.00000
+     14       0.6341      1.00000
+     15       0.7495      1.00000
+     16       1.1024      1.00000
+     17       1.7828      1.00000
+     18       1.9921      1.00000
+     19       2.2392      1.00000
+     20       5.5027      0.00000
+     21       5.7657      0.00000
+     22       5.8043      0.00000
+     23       7.5442      0.00000
+     24       8.2372      0.00000
+
+ k-point    23 :       0.3750    0.1250    0.1250
+  band No.  band energies     occupation 
+      1     -30.0598      1.00000
+      2     -29.9653      1.00000
+      3     -29.9291      1.00000
+      4     -22.0820      1.00000
+      5     -13.9863      1.00000
+      6     -13.2760      1.00000
+      7     -13.0673      1.00000
+      8      -7.3261      1.00000
+      9      -7.2731      1.00000
+     10      -7.0724      1.00000
+     11      -0.8449      1.00000
+     12      -0.0752      1.00000
+     13       0.1889      1.00000
+     14       0.3376      1.00000
+     15       0.5486      1.00000
+     16       0.9973      1.00000
+     17       1.6871      1.00000
+     18       1.8189      1.00000
+     19       2.0136      1.00000
+     20       5.5650      0.00000
+     21       6.2110      0.00000
+     22       6.2500      0.00000
+     23       7.4980      0.00000
+     24       8.6355      0.00000
+
+ k-point    24 :       0.5000    0.1250    0.1250
+  band No.  band energies     occupation 
+      1     -30.0594      1.00000
+      2     -29.9725      1.00000
+      3     -29.9288      1.00000
+      4     -22.0678      1.00000
+      5     -14.0134      1.00000
+      6     -13.2620      1.00000
+      7     -13.0168      1.00000
+      8      -7.3174      1.00000
+      9      -7.1936      1.00000
+     10      -7.1312      1.00000
+     11      -1.0422      1.00000
+     12      -0.0548      1.00000
+     13       0.0387      1.00000
+     14       0.2177      1.00000
+     15       0.4915      1.00000
+     16       1.0171      1.00000
+     17       1.6288      1.00000
+     18       1.7723      1.00000
+     19       1.8856      1.00000
+     20       5.5840      0.00000
+     21       6.4005      0.00000
+     22       6.4757      0.00000
+     23       7.4599      0.00000
+     24       8.7470      0.00000
+
+ k-point    25 :       0.2500    0.2500    0.1250
+  band No.  band energies     occupation 
+      1     -30.0598      1.00000
+      2     -29.9474      1.00000
+      3     -29.9469      1.00000
+      4     -22.0862      1.00000
+      5     -13.8811      1.00000
+      6     -13.2558      1.00000
+      7     -13.1596      1.00000
+      8      -7.4489      1.00000
+      9      -7.3463      1.00000
+     10      -7.0395      1.00000
+     11      -0.6067      1.00000
+     12      -0.1115      1.00000
+     13       0.0712      1.00000
+     14       0.4200      1.00000
+     15       0.6036      1.00000
+     16       0.6693      1.00000
+     17       1.8622      1.00000
+     18       1.8987      1.00000
+     19       2.4400      1.00000
+     20       5.7000      0.00000
+     21       5.9203      0.00000
+     22       6.0430      0.00000
+     23       7.7052      0.00000
+     24       8.8028      0.00000
+
+ k-point    26 :       0.3750    0.2500    0.1250
+  band No.  band energies     occupation 
+      1     -30.0590      1.00000
+      2     -29.9644      1.00000
+      3     -29.9463      1.00000
+      4     -22.0562      1.00000
+      5     -13.8578      1.00000
+      6     -13.2109      1.00000
+      7     -13.1039      1.00000
+      8      -7.4661      1.00000
+      9      -7.3602      1.00000
+     10      -7.0998      1.00000
+     11      -0.9278      1.00000
+     12      -0.3518      1.00000
+     13      -0.1261      1.00000
+     14       0.1796      1.00000
+     15       0.4008      1.00000
+     16       0.7723      1.00000
+     17       1.7206      1.00000
+     18       1.8448      1.00000
+     19       2.4993      1.00000
+     20       5.8258      0.00000
+     21       6.2827      0.00000
+     22       6.3826      0.00000
+     23       7.6613      0.00000
+     24       9.2766      0.00000
+
+ k-point    27 :       0.5000    0.2500    0.1250
+  band No.  band energies     occupation 
+      1     -30.0587      1.00000
+      2     -29.9715      1.00000
+      3     -29.9460      1.00000
+      4     -22.0437      1.00000
+      5     -13.8588      1.00000
+      6     -13.2027      1.00000
+      7     -13.0576      1.00000
+      8      -7.4494      1.00000
+      9      -7.3656      1.00000
+     10      -7.1495      1.00000
+     11      -1.1002      1.00000
+     12      -0.4151      1.00000
+     13      -0.2084      1.00000
+     14       0.0865      1.00000
+     15       0.3376      1.00000
+     16       0.8579      1.00000
+     17       1.6898      1.00000
+     18       1.7583      1.00000
+     19       2.4993      1.00000
+     20       5.8528      0.00000
+     21       6.4934      0.00000
+     22       6.5460      0.00000
+     23       7.6077      0.00000
+     24       9.4288      0.00000
+
+ k-point    28 :       0.3750    0.3750    0.1250
+  band No.  band energies     occupation 
+      1     -30.0583      1.00000
+      2     -29.9636      1.00000
+      3     -29.9633      1.00000
+      4     -22.0302      1.00000
+      5     -13.7401      1.00000
+      6     -13.1387      1.00000
+      7     -13.1316      1.00000
+      8      -7.5518      1.00000
+      9      -7.4610      1.00000
+     10      -7.1544      1.00000
+     11      -1.0888      1.00000
+     12      -0.5962      1.00000
+     13      -0.5848      1.00000
+     14       0.1412      1.00000
+     15       0.2818      1.00000
+     16       0.7694      1.00000
+     17       1.7162      1.00000
+     18       1.9240      1.00000
+     19       2.7889      1.00000
+     20       6.2167      0.00000
+     21       6.3693      0.00000
+     22       6.6163      0.00000
+     23       7.5972      0.00000
+     24       9.8656      0.00000
+
+ k-point    29 :       0.5000    0.3750    0.1250
+  band No.  band energies     occupation 
+      1     -30.0580      1.00000
+      2     -29.9705      1.00000
+      3     -29.9631      1.00000
+      4     -22.0193      1.00000
+      5     -13.6970      1.00000
+      6     -13.1436      1.00000
+      7     -13.1009      1.00000
+      8      -7.5557      1.00000
+      9      -7.5285      1.00000
+     10      -7.1791      1.00000
+     11      -1.2220      1.00000
+     12      -0.7243      1.00000
+     13      -0.6529      1.00000
+     14       0.1170      1.00000
+     15       0.2196      1.00000
+     16       0.7592      1.00000
+     17       1.8541      1.00000
+     18       1.8551      1.00000
+     19       2.8722      1.00000
+     20       6.2991      0.00000
+     21       6.5325      0.00000
+     22       6.7383      0.00000
+     23       7.5184      0.00000
+     24      10.0748      0.00000
+
+ k-point    30 :       0.5000    0.5000    0.1250
+  band No.  band energies     occupation 
+      1     -30.0577      1.00000
+      2     -29.9701      1.00000
+      3     -29.9701      1.00000
+      4     -22.0091      1.00000
+      5     -13.6271      1.00000
+      6     -13.1196      1.00000
+      7     -13.1196      1.00000
+      8      -7.5932      1.00000
+      9      -7.5932      1.00000
+     10      -7.1943      1.00000
+     11      -1.3337      1.00000
+     12      -0.8277      1.00000
+     13      -0.7728      1.00000
+     14       0.1499      1.00000
+     15       0.1499      1.00000
+     16       0.6694      1.00000
+     17       1.9425      1.00000
+     18       1.9425      1.00000
+     19       2.9871      1.00000
+     20       6.5455      0.00000
+     21       6.5455      0.00000
+     22       6.8439      0.00000
+     23       7.4127      0.00000
+     24      10.3229      0.00000
+
+ k-point    31 :       0.0000    0.0000    0.2500
+  band No.  band energies     occupation 
+      1     -30.0715      1.00000
+      2     -29.9232      1.00000
+      3     -29.9232      1.00000
+      4     -22.1525      1.00000
+      5     -13.9932      1.00000
+      6     -13.3613      1.00000
+      7     -13.1886      1.00000
+      8      -7.2654      1.00000
+      9      -7.2654      1.00000
+     10      -7.1684      1.00000
+     11      -0.2892      1.00000
+     12       0.4196      1.00000
+     13       0.4196      1.00000
+     14       1.0556      1.00000
+     15       1.0556      1.00000
+     16       1.3811      1.00000
+     17       1.4789      1.00000
+     18       2.3961      1.00000
+     19       2.3961      1.00000
+     20       4.8122      0.00000
+     21       5.8818      0.00000
+     22       5.8818      0.00000
+     23       6.9067      0.00000
+     24       8.0124      0.00000
+
+ k-point    32 :       0.1250    0.0000    0.2500
+  band No.  band energies     occupation 
+      1     -30.0711      1.00000
+      2     -29.9304      1.00000
+      3     -29.9229      1.00000
+      4     -22.1396      1.00000
+      5     -13.9561      1.00000
+      6     -13.3750      1.00000
+      7     -13.1791      1.00000
+      8      -7.3114      1.00000
+      9      -7.2405      1.00000
+     10      -7.1342      1.00000
+     11      -0.3348      1.00000
+     12       0.1887      1.00000
+     13       0.4241      1.00000
+     14       0.6984      1.00000
+     15       0.9407      1.00000
+     16       1.4652      1.00000
+     17       1.7194      1.00000
+     18       2.1923      1.00000
+     19       2.2446      1.00000
+     20       5.0954      0.00000
+     21       5.8096      0.00000
+     22       5.8865      0.00000
+     23       7.1982      0.00000
+     24       8.1556      0.00000
+
+ k-point    33 :       0.2500    0.0000    0.2500
+  band No.  band energies     occupation 
+      1     -30.0702      1.00000
+      2     -29.9478      1.00000
+      3     -29.9223      1.00000
+      4     -22.1083      1.00000
+      5     -13.9002      1.00000
+      6     -13.3815      1.00000
+      7     -13.1444      1.00000
+      8      -7.3478      1.00000
+      9      -7.1789      1.00000
+     10      -7.1265      1.00000
+     11      -0.4932      1.00000
+     12      -0.2770      1.00000
+     13       0.2810      1.00000
+     14       0.3859      1.00000
+     15       0.7358      1.00000
+     16       1.4058      1.00000
+     17       1.8001      1.00000
+     18       1.8091      1.00000
+     19       2.1850      1.00000
+     20       5.6631      0.00000
+     21       5.9093      0.00000
+     22       5.9517      0.00000
+     23       7.4633      0.00000
+     24       8.5728      0.00000
+
+ k-point    34 :       0.3750    0.0000    0.2500
+  band No.  band energies     occupation 
+      1     -30.0693      1.00000
+      2     -29.9651      1.00000
+      3     -29.9216      1.00000
+      4     -22.0766      1.00000
+      5     -13.9033      1.00000
+      6     -13.3386      1.00000
+      7     -13.0923      1.00000
+      8      -7.3265      1.00000
+      9      -7.1763      1.00000
+     10      -7.1148      1.00000
+     11      -0.8803      1.00000
+     12      -0.4694      1.00000
+     13      -0.0823      1.00000
+     14       0.2110      1.00000
+     15       0.7138      1.00000
+     16       1.4105      1.00000
+     17       1.4575      1.00000
+     18       1.7179      1.00000
+     19       2.1749      1.00000
+     20       5.9004      0.00000
+     21       6.1914      0.00000
+     22       6.3044      0.00000
+     23       7.5339      0.00000
+     24       8.9001      0.00000
+
+ k-point    35 :       0.5000    0.0000    0.2500
+  band No.  band energies     occupation 
+      1     -30.0689      1.00000
+      2     -29.9722      1.00000
+      3     -29.9214      1.00000
+      4     -22.0632      1.00000
+      5     -13.9196      1.00000
+      6     -13.3107      1.00000
+      7     -13.0632      1.00000
+      8      -7.2680      1.00000
+      9      -7.2462      1.00000
+     10      -7.0876      1.00000
+     11      -1.0672      1.00000
+     12      -0.5341      1.00000
+     13      -0.2056      1.00000
+     14       0.1143      1.00000
+     15       0.7545      1.00000
+     16       1.3078      1.00000
+     17       1.5056      1.00000
+     18       1.5966      1.00000
+     19       2.1525      1.00000
+     20       5.9135      0.00000
+     21       6.3825      0.00000
+     22       6.4962      0.00000
+     23       7.5419      0.00000
+     24       8.9885      0.00000
+
+ k-point    36 :       0.1250    0.1250    0.2500
+  band No.  band energies     occupation 
+      1     -30.0707      1.00000
+      2     -29.9303      1.00000
+      3     -29.9300      1.00000
+      4     -22.1272      1.00000
+      5     -13.9172      1.00000
+      6     -13.3785      1.00000
+      7     -13.1731      1.00000
+      8      -7.3437      1.00000
+      9      -7.3018      1.00000
+     10      -7.0590      1.00000
+     11      -0.3873      1.00000
+     12       0.0789      1.00000
+     13       0.2858      1.00000
+     14       0.6495      1.00000
+     15       0.7569      1.00000
+     16       1.4617      1.00000
+     17       1.7746      1.00000
+     18       2.0235      1.00000
+     19       2.2753      1.00000
+     20       5.2957      0.00000
+     21       5.8168      0.00000
+     22       5.8535      0.00000
+     23       7.5709      0.00000
+     24       8.2163      0.00000
+
+ k-point    37 :       0.2500    0.1250    0.2500
+  band No.  band energies     occupation 
+      1     -30.0698      1.00000
+      2     -29.9475      1.00000
+      3     -29.9295      1.00000
+      4     -22.0971      1.00000
+      5     -13.8548      1.00000
+      6     -13.3648      1.00000
+      7     -13.1445      1.00000
+      8      -7.3987      1.00000
+      9      -7.3323      1.00000
+     10      -7.0196      1.00000
+     11      -0.5709      1.00000
+     12      -0.2594      1.00000
+     13       0.1355      1.00000
+     14       0.4221      1.00000
+     15       0.6266      1.00000
+     16       1.0816      1.00000
+     17       1.8166      1.00000
+     18       2.0420      1.00000
+     19       2.1962      1.00000
+     20       5.7413      0.00000
+     21       5.9056      0.00000
+     22       5.9938      0.00000
+     23       7.9127      0.00000
+     24       8.5679      0.00000
+
+ k-point    38 :       0.3750    0.1250    0.2500
+  band No.  band energies     occupation 
+      1     -30.0689      1.00000
+      2     -29.9647      1.00000
+      3     -29.9288      1.00000
+      4     -22.0664      1.00000
+      5     -13.8481      1.00000
+      6     -13.3105      1.00000
+      7     -13.0942      1.00000
+      8      -7.3858      1.00000
+      9      -7.3505      1.00000
+     10      -7.0633      1.00000
+     11      -0.9077      1.00000
+     12      -0.4370      1.00000
+     13      -0.0884      1.00000
+     14       0.2329      1.00000
+     15       0.5263      1.00000
+     16       0.9321      1.00000
+     17       1.7300      1.00000
+     18       1.9889      1.00000
+     19       2.1516      1.00000
+     20       5.8944      0.00000
+     21       6.2475      0.00000
+     22       6.3407      0.00000
+     23       7.9484      0.00000
+     24       8.9414      0.00000
+
+ k-point    39 :       0.5000    0.1250    0.2500
+  band No.  band energies     occupation 
+      1     -30.0686      1.00000
+      2     -29.9718      1.00000
+      3     -29.9285      1.00000
+      4     -22.0536      1.00000
+      5     -13.8597      1.00000
+      6     -13.2808      1.00000
+      7     -13.0641      1.00000
+      8      -7.3802      1.00000
+      9      -7.3270      1.00000
+     10      -7.1135      1.00000
+     11      -1.0835      1.00000
+     12      -0.4579      1.00000
+     13      -0.2085      1.00000
+     14       0.1461      1.00000
+     15       0.5103      1.00000
+     16       0.9082      1.00000
+     17       1.7340      1.00000
+     18       1.9024      1.00000
+     19       2.1288      1.00000
+     20       5.9136      0.00000
+     21       6.4308      0.00000
+     22       6.5259      0.00000
+     23       7.9396      0.00000
+     24       9.0510      0.00000
+
+ k-point    40 :       0.2500    0.2500    0.2500
+  band No.  band energies     occupation 
+      1     -30.0690      1.00000
+      2     -29.9469      1.00000
+      3     -29.9465      1.00000
+      4     -22.0696      1.00000
+      5     -13.7674      1.00000
+      6     -13.3095      1.00000
+      7     -13.1343      1.00000
+      8      -7.5260      1.00000
+      9      -7.4343      1.00000
+     10      -7.0279      1.00000
+     11      -0.7353      1.00000
+     12      -0.2271      1.00000
+     13      -0.1341      1.00000
+     14       0.3400      1.00000
+     15       0.5170      1.00000
+     16       0.5292      1.00000
+     17       1.9525      1.00000
+     18       2.0583      1.00000
+     19       2.3685      1.00000
+     20       5.9768      0.00000
+     21       6.0811      0.00000
+     22       6.1360      0.00000
+     23       8.4515      0.00000
+     24       8.7696      0.00000
+
+ k-point    41 :       0.3750    0.2500    0.2500
+  band No.  band energies     occupation 
+      1     -30.0682      1.00000
+      2     -29.9639      1.00000
+      3     -29.9459      1.00000
+      4     -22.0418      1.00000
+      5     -13.7214      1.00000
+      6     -13.2336      1.00000
+      7     -13.0980      1.00000
+      8      -7.5757      1.00000
+      9      -7.5064      1.00000
+     10      -7.1453      1.00000
+     11      -0.9641      1.00000
+     12      -0.4136      1.00000
+     13      -0.1701      1.00000
+     14       0.0610      1.00000
+     15       0.3495      1.00000
+     16       0.5255      1.00000
+     17       1.8793      1.00000
+     18       2.1106      1.00000
+     19       2.4662      1.00000
+     20       6.1054      0.00000
+     21       6.3906      0.00000
+     22       6.4492      0.00000
+     23       8.4054      0.00000
+     24       9.2697      0.00000
+
+ k-point    42 :       0.5000    0.2500    0.2500
+  band No.  band energies     occupation 
+      1     -30.0678      1.00000
+      2     -29.9709      1.00000
+      3     -29.9456      1.00000
+      4     -22.0301      1.00000
+      5     -13.7143      1.00000
+      6     -13.2033      1.00000
+      7     -13.0677      1.00000
+      8      -7.5813      1.00000
+      9      -7.5153      1.00000
+     10      -7.2300      1.00000
+     11      -1.1240      1.00000
+     12      -0.3673      1.00000
+     13      -0.2513      1.00000
+     14      -0.0833      1.00000
+     15       0.3261      1.00000
+     16       0.5643      1.00000
+     17       1.8509      1.00000
+     18       2.1016      1.00000
+     19       2.4820      1.00000
+     20       6.1343      0.00000
+     21       6.5646      0.00000
+     22       6.6067      0.00000
+     23       8.3602      0.00000
+     24       9.4290      0.00000
+
+ k-point    43 :       0.3750    0.3750    0.2500
+  band No.  band energies     occupation 
+      1     -30.0674      1.00000
+      2     -29.9631      1.00000
+      3     -29.9629      1.00000
+      4     -22.0168      1.00000
+      5     -13.6096      1.00000
+      6     -13.1433      1.00000
+      7     -13.0941      1.00000
+      8      -7.6983      1.00000
+      9      -7.6391      1.00000
+     10      -7.3015      1.00000
+     11      -1.0979      1.00000
+     12      -0.5814      1.00000
+     13      -0.3597      1.00000
+     14      -0.0073      1.00000
+     15       0.3413      1.00000
+     16       0.3764      1.00000
+     17       1.9754      1.00000
+     18       2.1406      1.00000
+     19       2.7792      1.00000
+     20       6.4330      0.00000
+     21       6.4973      0.00000
+     22       6.6725      0.00000
+     23       8.3840      0.00000
+     24       9.8034      0.00000
+
+ k-point    44 :       0.5000    0.3750    0.2500
+  band No.  band energies     occupation 
+      1     -30.0670      1.00000
+      2     -29.9700      1.00000
+      3     -29.9626      1.00000
+      4     -22.0064      1.00000
+      5     -13.5696      1.00000
+      6     -13.1164      1.00000
+      7     -13.0736      1.00000
+      8      -7.7243      1.00000
+      9      -7.6948      1.00000
+     10      -7.3853      1.00000
+     11      -1.2334      1.00000
+     12      -0.6479      1.00000
+     13      -0.3572      1.00000
+     14      -0.0623      1.00000
+     15       0.2941      1.00000
+     16       0.3969      1.00000
+     17       2.0492      1.00000
+     18       2.1304      1.00000
+     19       2.8776      1.00000
+     20       6.4906      0.00000
+     21       6.6477      0.00000
+     22       6.7919      0.00000
+     23       8.3116      0.00000
+     24      10.0079      0.00000
+
+ k-point    45 :       0.5000    0.5000    0.2500
+  band No.  band energies     occupation 
+      1     -30.0667      1.00000
+      2     -29.9697      1.00000
+      3     -29.9697      1.00000
+      4     -21.9965      1.00000
+      5     -13.5105      1.00000
+      6     -13.0768      1.00000
+      7     -13.0768      1.00000
+      8      -7.7667      1.00000
+      9      -7.7667      1.00000
+     10      -7.4616      1.00000
+     11      -1.3432      1.00000
+     12      -0.7691      1.00000
+     13      -0.3548      1.00000
+     14       0.0091      1.00000
+     15       0.2804      1.00000
+     16       0.2804      1.00000
+     17       2.1596      1.00000
+     18       2.1596      1.00000
+     19       3.0084      1.00000
+     20       6.6736      0.00000
+     21       6.6736      0.00000
+     22       6.8983      0.00000
+     23       8.2112      0.00000
+     24      10.2390      0.00000
+
+ k-point    46 :       0.0000    0.0000    0.3750
+  band No.  band energies     occupation 
+      1     -30.0810      1.00000
+      2     -29.9229      1.00000
+      3     -29.9229      1.00000
+      4     -22.1277      1.00000
+      5     -14.0523      1.00000
+      6     -13.3078      1.00000
+      7     -13.1805      1.00000
+      8      -7.2314      1.00000
+      9      -7.2314      1.00000
+     10      -7.0173      1.00000
+     11      -0.7638      1.00000
+     12       0.2811      1.00000
+     13       0.2811      1.00000
+     14       0.9225      1.00000
+     15       0.9225      1.00000
+     16       1.1167      1.00000
+     17       1.1625      1.00000
+     18       2.3329      1.00000
+     19       2.3329      1.00000
+     20       4.8539      0.00000
+     21       6.2210      0.00000
+     22       6.2210      0.00000
+     23       6.9072      0.00000
+     24       8.5173      0.00000
+
+ k-point    47 :       0.1250    0.0000    0.3750
+  band No.  band energies     occupation 
+      1     -30.0805      1.00000
+      2     -29.9300      1.00000
+      3     -29.9226      1.00000
+      4     -22.1163      1.00000
+      5     -13.9908      1.00000
+      6     -13.3361      1.00000
+      7     -13.1697      1.00000
+      8      -7.2697      1.00000
+      9      -7.2052      1.00000
+     10      -7.0427      1.00000
+     11      -0.7878      1.00000
+     12       0.0561      1.00000
+     13       0.2960      1.00000
+     14       0.4549      1.00000
+     15       0.8016      1.00000
+     16       1.2503      1.00000
+     17       1.6580      1.00000
+     18       2.1248      1.00000
+     19       2.1425      1.00000
+     20       5.1303      0.00000
+     21       6.1369      0.00000
+     22       6.2224      0.00000
+     23       7.2069      0.00000
+     24       8.6761      0.00000
+
+ k-point    48 :       0.2500    0.0000    0.3750
+  band No.  band energies     occupation 
+      1     -30.0795      1.00000
+      2     -29.9473      1.00000
+      3     -29.9219      1.00000
+      4     -22.0886      1.00000
+      5     -13.8467      1.00000
+      6     -13.3964      1.00000
+      7     -13.1441      1.00000
+      8      -7.3373      1.00000
+      9      -7.1402      1.00000
+     10      -7.1215      1.00000
+     11      -0.8430      1.00000
+     12      -0.4911      1.00000
+     13       0.0291      1.00000
+     14       0.3150      1.00000
+     15       0.5484      1.00000
+     16       1.4187      1.00000
+     17       1.7173      1.00000
+     18       1.8721      1.00000
+     19       2.1921      1.00000
+     20       5.6982      0.00000
+     21       6.1996      0.00000
+     22       6.2282      0.00000
+     23       7.5236      0.00000
+     24       9.1135      0.00000
+
+ k-point    49 :       0.3750    0.0000    0.3750
+  band No.  band energies     occupation 
+      1     -30.0784      1.00000
+      2     -29.9645      1.00000
+      3     -29.9213      1.00000
+      4     -22.0604      1.00000
+      5     -13.7351      1.00000
+      6     -13.4101      1.00000
+      7     -13.1267      1.00000
+      8      -7.3712      1.00000
+      9      -7.2235      1.00000
+     10      -7.0726      1.00000
+     11      -0.9904      1.00000
+     12      -0.8507      1.00000
+     13      -0.4122      1.00000
+     14       0.1728      1.00000
+     15       0.4972      1.00000
+     16       1.3622      1.00000
+     17       1.6023      1.00000
+     18       1.8838      1.00000
+     19       2.3856      1.00000
+     20       6.1880      0.00000
+     21       6.2451      0.00000
+     22       6.4411      0.00000
+     23       7.6319      0.00000
+     24       9.4929      0.00000
+
+ k-point    50 :       0.5000    0.0000    0.3750
+  band No.  band energies     occupation 
+      1     -30.0780      1.00000
+      2     -29.9715      1.00000
+      3     -29.9210      1.00000
+      4     -22.0487      1.00000
+      5     -13.7151      1.00000
+      6     -13.3812      1.00000
+      7     -13.1258      1.00000
+      8      -7.3671      1.00000
+      9      -7.2807      1.00000
+     10      -7.0438      1.00000
+     11      -1.1443      1.00000
+     12      -0.9153      1.00000
+     13      -0.5721      1.00000
+     14       0.0732      1.00000
+     15       0.5375      1.00000
+     16       1.2119      1.00000
+     17       1.7661      1.00000
+     18       1.8167      1.00000
+     19       2.4366      1.00000
+     20       6.2359      0.00000
+     21       6.3969      0.00000
+     22       6.5839      0.00000
+     23       7.6508      0.00000
+     24       9.6034      0.00000
+
+ k-point    51 :       0.1250    0.1250    0.3750
+  band No.  band energies     occupation 
+      1     -30.0801      1.00000
+      2     -29.9298      1.00000
+      3     -29.9297      1.00000
+      4     -22.1052      1.00000
+      5     -13.9290      1.00000
+      6     -13.3544      1.00000
+      7     -13.1598      1.00000
+      8      -7.3449      1.00000
+      9      -7.2112      1.00000
+     10      -7.0348      1.00000
+     11      -0.8028      1.00000
+     12      -0.0853      1.00000
+     13       0.1950      1.00000
+     14       0.3817      1.00000
+     15       0.6277      1.00000
+     16       1.5055      1.00000
+     17       1.6919      1.00000
+     18       1.8610      1.00000
+     19       2.1681      1.00000
+     20       5.3388      0.00000
+     21       6.1299      0.00000
+     22       6.1882      0.00000
+     23       7.5622      0.00000
+     24       8.7668      0.00000
+
+ k-point    52 :       0.2500    0.1250    0.3750
+  band No.  band energies     occupation 
+      1     -30.0791      1.00000
+      2     -29.9470      1.00000
+      3     -29.9291      1.00000
+      4     -22.0782      1.00000
+      5     -13.7846      1.00000
+      6     -13.3922      1.00000
+      7     -13.1344      1.00000
+      8      -7.4349      1.00000
+      9      -7.2740      1.00000
+     10      -7.0535      1.00000
+     11      -0.8403      1.00000
+     12      -0.5046      1.00000
+     13      -0.0188      1.00000
+     14       0.2486      1.00000
+     15       0.5158      1.00000
+     16       1.1806      1.00000
+     17       1.7500      1.00000
+     18       2.0612      1.00000
+     19       2.1703      1.00000
+     20       5.8129      0.00000
+     21       6.1849      0.00000
+     22       6.2517      0.00000
+     23       7.9759      0.00000
+     24       9.1033      0.00000
+
+ k-point    53 :       0.3750    0.1250    0.3750
+  band No.  band energies     occupation 
+      1     -30.0781      1.00000
+      2     -29.9641      1.00000
+      3     -29.9284      1.00000
+      4     -22.0508      1.00000
+      5     -13.6770      1.00000
+      6     -13.3821      1.00000
+      7     -13.1144      1.00000
+      8      -7.4635      1.00000
+      9      -7.3504      1.00000
+     10      -7.1124      1.00000
+     11      -1.0011      1.00000
+     12      -0.7353      1.00000
+     13      -0.4023      1.00000
+     14       0.1797      1.00000
+     15       0.4361      1.00000
+     16       0.9551      1.00000
+     17       1.7915      1.00000
+     18       2.0664      1.00000
+     19       2.3775      1.00000
+     20       6.2037      0.00000
+     21       6.2887      0.00000
+     22       6.4817      0.00000
+     23       8.0898      0.00000
+     24       9.4724      0.00000
+
+ k-point    54 :       0.5000    0.1250    0.3750
+  band No.  band energies     occupation 
+      1     -30.0777      1.00000
+      2     -29.9712      1.00000
+      3     -29.9281      1.00000
+      4     -22.0393      1.00000
+      5     -13.6594      1.00000
+      6     -13.3433      1.00000
+      7     -13.1122      1.00000
+      8      -7.4544      1.00000
+      9      -7.3876      1.00000
+     10      -7.1500      1.00000
+     11      -1.1513      1.00000
+     12      -0.7261      1.00000
+     13      -0.5744      1.00000
+     14       0.1098      1.00000
+     15       0.4598      1.00000
+     16       0.8506      1.00000
+     17       1.8722      1.00000
+     18       2.0340      1.00000
+     19       2.4340      1.00000
+     20       6.2311      0.00000
+     21       6.4590      0.00000
+     22       6.6203      0.00000
+     23       8.0987      0.00000
+     24       9.5900      0.00000
+
+ k-point    55 :       0.2500    0.2500    0.3750
+  band No.  band energies     occupation 
+      1     -30.0782      1.00000
+      2     -29.9464      1.00000
+      3     -29.9461      1.00000
+      4     -22.0528      1.00000
+      5     -13.6443      1.00000
+      6     -13.3704      1.00000
+      7     -13.1086      1.00000
+      8      -7.6030      1.00000
+      9      -7.4206      1.00000
+     10      -7.1256      1.00000
+     11      -0.8705      1.00000
+     12      -0.5192      1.00000
+     13      -0.1502      1.00000
+     14       0.0641      1.00000
+     15       0.4686      1.00000
+     16       0.6654      1.00000
+     17       2.0448      1.00000
+     18       2.1490      1.00000
+     19       2.2930      1.00000
+     20       6.1150      0.00000
+     21       6.2974      0.00000
+     22       6.3447      0.00000
+     23       8.7293      0.00000
+     24       9.0953      0.00000
+
+ k-point    56 :       0.3750    0.2500    0.3750
+  band No.  band energies     occupation 
+      1     -30.0773      1.00000
+      2     -29.9633      1.00000
+      3     -29.9455      1.00000
+      4     -22.0272      1.00000
+      5     -13.5517      1.00000
+      6     -13.2944      1.00000
+      7     -13.0846      1.00000
+      8      -7.6810      1.00000
+      9      -7.5557      1.00000
+     10      -7.2884      1.00000
+     11      -1.0317      1.00000
+     12      -0.5663      1.00000
+     13      -0.3154      1.00000
+     14      -0.0461      1.00000
+     15       0.3747      1.00000
+     16       0.4849      1.00000
+     17       2.0595      1.00000
+     18       2.3470      1.00000
+     19       2.4514      1.00000
+     20       6.3640      0.00000
+     21       6.4785      0.00000
+     22       6.5752      0.00000
+     23       8.8637      0.00000
+     24       9.4168      0.00000
+
+ k-point    57 :       0.5000    0.2500    0.3750
+  band No.  band energies     occupation 
+      1     -30.0769      1.00000
+      2     -29.9704      1.00000
+      3     -29.9452      1.00000
+      4     -22.0165      1.00000
+      5     -13.5352      1.00000
+      6     -13.2346      1.00000
+      7     -13.0792      1.00000
+      8      -7.6588      1.00000
+      9      -7.6345      1.00000
+     10      -7.3840      1.00000
+     11      -1.1784      1.00000
+     12      -0.5757      1.00000
+     13      -0.3139      1.00000
+     14      -0.1208      1.00000
+     15       0.3516      1.00000
+     16       0.4500      1.00000
+     17       2.0682      1.00000
+     18       2.4132      1.00000
+     19       2.5032      1.00000
+     20       6.3995      0.00000
+     21       6.6253      0.00000
+     22       6.7086      0.00000
+     23       8.8097      0.00000
+     24       9.5718      0.00000
+
+ k-point    58 :       0.3750    0.3750    0.3750
+  band No.  band energies     occupation 
+      1     -30.0764      1.00000
+      2     -29.9626      1.00000
+      3     -29.9624      1.00000
+      4     -22.0034      1.00000
+      5     -13.4585      1.00000
+      6     -13.1655      1.00000
+      7     -13.0552      1.00000
+      8      -7.8412      1.00000
+      9      -7.7430      1.00000
+     10      -7.5070      1.00000
+     11      -1.1532      1.00000
+     12      -0.5775      1.00000
+     13      -0.5010      1.00000
+     14      -0.0132      1.00000
+     15       0.3247      1.00000
+     16       0.3845      1.00000
+     17       2.2710      1.00000
+     18       2.3885      1.00000
+     19       2.7600      1.00000
+     20       6.6243      0.00000
+     21       6.6463      0.00000
+     22       6.7392      0.00000
+     23       9.0023      0.00000
+     24       9.6147      0.00000
+
+ k-point    59 :       0.5000    0.3750    0.3750
+  band No.  band energies     occupation 
+      1     -30.0761      1.00000
+      2     -29.9696      1.00000
+      3     -29.9622      1.00000
+      4     -21.9934      1.00000
+      5     -13.4291      1.00000
+      6     -13.0973      1.00000
+      7     -13.0461      1.00000
+      8      -7.8552      1.00000
+      9      -7.8539      1.00000
+     10      -7.6078      1.00000
+     11      -1.2810      1.00000
+     12      -0.6587      1.00000
+     13      -0.4967      1.00000
+     14       0.0151      1.00000
+     15       0.3291      1.00000
+     16       0.3906      1.00000
+     17       2.3216      1.00000
+     18       2.4377      1.00000
+     19       2.8806      1.00000
+     20       6.6726      0.00000
+     21       6.7734      0.00000
+     22       6.8525      0.00000
+     23       8.8939      0.00000
+     24       9.6560      0.00000
+
+ k-point    60 :       0.5000    0.5000    0.3750
+  band No.  band energies     occupation 
+      1     -30.0757      1.00000
+      2     -29.9692      1.00000
+      3     -29.9692      1.00000
+      4     -21.9838      1.00000
+      5     -13.3898      1.00000
+      6     -13.0324      1.00000
+      7     -13.0324      1.00000
+      8      -7.9345      1.00000
+      9      -7.9345      1.00000
+     10      -7.7018      1.00000
+     11      -1.3861      1.00000
+     12      -0.7654      1.00000
+     13      -0.5173      1.00000
+     14       0.0977      1.00000
+     15       0.3691      1.00000
+     16       0.3691      1.00000
+     17       2.4471      1.00000
+     18       2.4471      1.00000
+     19       3.0300      1.00000
+     20       6.8100      0.00000
+     21       6.8100      0.00000
+     22       6.9556      0.00000
+     23       8.7674      0.00000
+     24       9.6582      0.00000
+
+ k-point    61 :       0.0000    0.0000    0.5000
+  band No.  band energies     occupation 
+      1     -30.0849      1.00000
+      2     -29.9227      1.00000
+      3     -29.9227      1.00000
+      4     -22.1174      1.00000
+      5     -14.0829      1.00000
+      6     -13.2773      1.00000
+      7     -13.1770      1.00000
+      8      -7.2171      1.00000
+      9      -7.2171      1.00000
+     10      -6.9547      1.00000
+     11      -0.9510      1.00000
+     12       0.2194      1.00000
+     13       0.2194      1.00000
+     14       0.8775      1.00000
+     15       0.8775      1.00000
+     16       0.9789      1.00000
+     17       1.0782      1.00000
+     18       2.3076      1.00000
+     19       2.3076      1.00000
+     20       4.8716      0.00000
+     21       6.3592      0.00000
+     22       6.3592      0.00000
+     23       6.9075      0.00000
+     24       9.2330      0.00000
+
+ k-point    62 :       0.1250    0.0000    0.5000
+  band No.  band energies     occupation 
+      1     -30.0844      1.00000
+      2     -29.9299      1.00000
+      3     -29.9225      1.00000
+      4     -22.1066      1.00000
+      5     -14.0134      1.00000
+      6     -13.3096      1.00000
+      7     -13.1661      1.00000
+      8      -7.2518      1.00000
+      9      -7.1903      1.00000
+     10      -7.0062      1.00000
+     11      -0.9673      1.00000
+     12       0.0003      1.00000
+     13       0.2360      1.00000
+     14       0.3636      1.00000
+     15       0.7563      1.00000
+     16       1.1694      1.00000
+     17       1.6404      1.00000
+     18       2.0929      1.00000
+     19       2.0979      1.00000
+     20       5.1449      0.00000
+     21       6.2753      0.00000
+     22       6.3599      0.00000
+     23       7.2088      0.00000
+     24       8.8705      0.00000
+
+ k-point    63 :       0.2500    0.0000    0.5000
+  band No.  band energies     occupation 
+      1     -30.0834      1.00000
+      2     -29.9471      1.00000
+      3     -29.9218      1.00000
+      4     -22.0804      1.00000
+      5     -13.8355      1.00000
+      6     -13.3892      1.00000
+      7     -13.1452      1.00000
+      8      -7.3271      1.00000
+      9      -7.1262      1.00000
+     10      -7.1240      1.00000
+     11      -1.0027      1.00000
+     12      -0.5731      1.00000
+     13      -0.0459      1.00000
+     14       0.2720      1.00000
+     15       0.4886      1.00000
+     16       1.4614      1.00000
+     17       1.6852      1.00000
+     18       1.8744      1.00000
+     19       2.1681      1.00000
+     20       5.7093      0.00000
+     21       6.3184      0.00000
+     22       6.3628      0.00000
+     23       7.5345      0.00000
+     24       9.3262      0.00000
+
+ k-point    64 :       0.3750    0.0000    0.5000
+  band No.  band energies     occupation 
+      1     -30.0822      1.00000
+      2     -29.9642      1.00000
+      3     -29.9212      1.00000
+      4     -22.0537      1.00000
+      5     -13.6345      1.00000
+      6     -13.4695      1.00000
+      7     -13.1413      1.00000
+      8      -7.3917      1.00000
+      9      -7.2397      1.00000
+     10      -7.0548      1.00000
+     11      -1.0730      1.00000
+     12      -0.9839      1.00000
+     13      -0.5170      1.00000
+     14       0.1558      1.00000
+     15       0.4110      1.00000
+     16       1.3268      1.00000
+     17       1.7428      1.00000
+     18       1.9076      1.00000
+     19       2.4443      1.00000
+     20       6.2065      0.00000
+     21       6.3674      0.00000
+     22       6.5163      0.00000
+     23       7.6483      0.00000
+     24       9.7568      0.00000
+
+ k-point    65 :       0.5000    0.0000    0.5000
+  band No.  band energies     occupation 
+      1     -30.0818      1.00000
+      2     -29.9713      1.00000
+      3     -29.9209      1.00000
+      4     -22.0426      1.00000
+      5     -13.5399      1.00000
+      6     -13.5002      1.00000
+      7     -13.1518      1.00000
+      8      -7.4155      1.00000
+      9      -7.2847      1.00000
+     10      -7.0253      1.00000
+     11      -1.2012      1.00000
+     12      -1.0514      1.00000
+     13      -0.7020      1.00000
+     14       0.0549      1.00000
+     15       0.4504      1.00000
+     16       1.1771      1.00000
+     17       1.8596      1.00000
+     18       1.9493      1.00000
+     19       2.5221      1.00000
+     20       6.3694      0.00000
+     21       6.4022      0.00000
+     22       6.6353      0.00000
+     23       7.6672      0.00000
+     24       9.9060      0.00000
+
+ k-point    66 :       0.1250    0.1250    0.5000
+  band No.  band energies     occupation 
+      1     -30.0840      1.00000
+      2     -29.9297      1.00000
+      3     -29.9295      1.00000
+      4     -22.0961      1.00000
+      5     -13.9437      1.00000
+      6     -13.3330      1.00000
+      7     -13.1543      1.00000
+      8      -7.3455      1.00000
+      9      -7.1388      1.00000
+     10      -7.0612      1.00000
+     11      -0.9713      1.00000
+     12      -0.1394      1.00000
+     13       0.1606      1.00000
+     14       0.2661      1.00000
+     15       0.5815      1.00000
+     16       1.6266      1.00000
+     17       1.6474      1.00000
+     18       1.6997      1.00000
+     19       2.1269      1.00000
+     20       5.3555      0.00000
+     21       6.2668      0.00000
+     22       6.3262      0.00000
+     23       7.5580      0.00000
+     24       8.9706      0.00000
+
+ k-point    67 :       0.2500    0.1250    0.5000
+  band No.  band energies     occupation 
+      1     -30.0829      1.00000
+      2     -29.9468      1.00000
+      3     -29.9289      1.00000
+      4     -22.0703      1.00000
+      5     -13.7651      1.00000
+      6     -13.3921      1.00000
+      7     -13.1304      1.00000
+      8      -7.4498      1.00000
+      9      -7.1956      1.00000
+     10      -7.1237      1.00000
+     11      -0.9792      1.00000
+     12      -0.5789      1.00000
+     13      -0.0700      1.00000
+     14       0.1789      1.00000
+     15       0.4783      1.00000
+     16       1.2583      1.00000
+     17       1.7108      1.00000
+     18       2.0292      1.00000
+     19       2.1627      1.00000
+     20       5.8324      0.00000
+     21       6.3125      0.00000
+     22       6.3725      0.00000
+     23       7.9793      0.00000
+     24       9.3195      0.00000
+
+ k-point    68 :       0.3750    0.1250    0.5000
+  band No.  band energies     occupation 
+      1     -30.0819      1.00000
+      2     -29.9639      1.00000
+      3     -29.9283      1.00000
+      4     -22.0442      1.00000
+      5     -13.5631      1.00000
+      6     -13.4539      1.00000
+      7     -13.1228      1.00000
+      8      -7.4992      1.00000
+      9      -7.3204      1.00000
+     10      -7.1587      1.00000
+     11      -1.0745      1.00000
+     12      -0.8395      1.00000
+     13      -0.4987      1.00000
+     14       0.1583      1.00000
+     15       0.3884      1.00000
+     16       0.9640      1.00000
+     17       1.8759      1.00000
+     18       2.0664      1.00000
+     19       2.4494      1.00000
+     20       6.2798      0.00000
+     21       6.3588      0.00000
+     22       6.5566      0.00000
+     23       8.1027      0.00000
+     24       9.7182      0.00000
+
+ k-point    69 :       0.5000    0.1250    0.5000
+  band No.  band energies     occupation 
+      1     -30.0814      1.00000
+      2     -29.9709      1.00000
+      3     -29.9280      1.00000
+      4     -22.0333      1.00000
+      5     -13.4824      1.00000
+      6     -13.4625      1.00000
+      7     -13.1324      1.00000
+      8      -7.5055      1.00000
+      9      -7.3720      1.00000
+     10      -7.1835      1.00000
+     11      -1.2058      1.00000
+     12      -0.8146      1.00000
+     13      -0.7062      1.00000
+     14       0.0992      1.00000
+     15       0.4203      1.00000
+     16       0.8227      1.00000
+     17       1.9612      1.00000
+     18       2.1080      1.00000
+     19       2.5323      1.00000
+     20       6.3637      0.00000
+     21       6.4705      0.00000
+     22       6.6735      0.00000
+     23       8.1087      0.00000
+     24       9.8650      0.00000
+
+ k-point    70 :       0.2500    0.2500    0.5000
+  band No.  band energies     occupation 
+      1     -30.0820      1.00000
+      2     -29.9462      1.00000
+      3     -29.9459      1.00000
+      4     -22.0459      1.00000
+      5     -13.5862      1.00000
+      6     -13.4021      1.00000
+      7     -13.0979      1.00000
+      8      -7.6350      1.00000
+      9      -7.3537      1.00000
+     10      -7.2292      1.00000
+     11      -0.9767      1.00000
+     12      -0.5761      1.00000
+     13      -0.1547      1.00000
+     14      -0.0471      1.00000
+     15       0.4555      1.00000
+     16       0.7402      1.00000
+     17       2.0606      1.00000
+     18       2.1931      1.00000
+     19       2.2381      1.00000
+     20       6.1475      0.00000
+     21       6.4059      0.00000
+     22       6.4556      0.00000
+     23       8.7093      0.00000
+     24       9.3232      0.00000
+
+ k-point    71 :       0.3750    0.2500    0.5000
+  band No.  band energies     occupation 
+      1     -30.0810      1.00000
+      2     -29.9631      1.00000
+      3     -29.9454      1.00000
+      4     -22.0211      1.00000
+      5     -13.4171      1.00000
+      6     -13.3838      1.00000
+      7     -13.0784      1.00000
+      8      -7.7271      1.00000
+      9      -7.5163      1.00000
+     10      -7.4036      1.00000
+     11      -1.1044      1.00000
+     12      -0.6456      1.00000
+     13      -0.3246      1.00000
+     14      -0.0923      1.00000
+     15       0.3826      1.00000
+     16       0.5035      1.00000
+     17       2.1508      1.00000
+     18       2.3852      1.00000
+     19       2.4780      1.00000
+     20       6.4632      0.00000
+     21       6.5197      0.00000
+     22       6.6482      0.00000
+     23       8.8912      0.00000
+     24       9.5682      0.00000
+
+ k-point    72 :       0.5000    0.2500    0.5000
+  band No.  band energies     occupation 
+      1     -30.0806      1.00000
+      2     -29.9702      1.00000
+      3     -29.9451      1.00000
+      4     -22.0108      1.00000
+      5     -13.4230      1.00000
+      6     -13.2846      1.00000
+      7     -13.0844      1.00000
+      8      -7.7166      1.00000
+      9      -7.6093      1.00000
+     10      -7.4934      1.00000
+     11      -1.2306      1.00000
+     12      -0.7107      1.00000
+     13      -0.2863      1.00000
+     14      -0.1094      1.00000
+     15       0.3603      1.00000
+     16       0.4089      1.00000
+     17       2.1827      1.00000
+     18       2.4763      1.00000
+     19       2.5673      1.00000
+     20       6.5127      0.00000
+     21       6.6491      0.00000
+     22       6.7644      0.00000
+     23       8.8131      0.00000
+     24       9.7307      0.00000
+
+ k-point    73 :       0.3750    0.3750    0.5000
+  band No.  band energies     occupation 
+      1     -30.0801      1.00000
+      2     -29.9624      1.00000
+      3     -29.9623      1.00000
+      4     -21.9978      1.00000
+      5     -13.3792      1.00000
+      6     -13.1905      1.00000
+      7     -13.0389      1.00000
+      8      -7.8994      1.00000
+      9      -7.7439      1.00000
+     10      -7.6298      1.00000
+     11      -1.2154      1.00000
+     12      -0.6218      1.00000
+     13      -0.5758      1.00000
+     14       0.0601      1.00000
+     15       0.3461      1.00000
+     16       0.3985      1.00000
+     17       2.3940      1.00000
+     18       2.5133      1.00000
+     19       2.7355      1.00000
+     20       6.6983      0.00000
+     21       6.7185      0.00000
+     22       6.7769      0.00000
+     23       9.1352      0.00000
+     24       9.4700      0.00000
+
+ k-point    74 :       0.5000    0.3750    0.5000
+  band No.  band energies     occupation 
+      1     -30.0798      1.00000
+      2     -29.9694      1.00000
+      3     -29.9620      1.00000
+      4     -21.9881      1.00000
+      5     -13.3637      1.00000
+      6     -13.0949      1.00000
+      7     -13.0346      1.00000
+      8      -7.9202      1.00000
+      9      -7.8887      1.00000
+     10      -7.7130      1.00000
+     11      -1.3288      1.00000
+     12      -0.7161      1.00000
+     13      -0.5943      1.00000
+     14       0.1899      1.00000
+     15       0.3163      1.00000
+     16       0.3948      1.00000
+     17       2.4564      1.00000
+     18       2.5760      1.00000
+     19       2.8768      1.00000
+     20       6.7523      0.00000
+     21       6.8285      0.00000
+     22       6.8833      0.00000
+     23       8.9687      0.00000
+     24       9.4968      0.00000
+
+ k-point    75 :       0.5000    0.5000    0.5000
+  band No.  band energies     occupation 
+      1     -30.0794      1.00000
+      2     -29.9690      1.00000
+      3     -29.9690      1.00000
+      4     -21.9786      1.00000
+      5     -13.3384      1.00000
+      6     -13.0135      1.00000
+      7     -13.0135      1.00000
+      8      -8.0027      1.00000
+      9      -8.0027      1.00000
+     10      -7.7949      1.00000
+     11      -1.4270      1.00000
+     12      -0.7638      1.00000
+     13      -0.6926      1.00000
+     14       0.2808      1.00000
+     15       0.3954      1.00000
+     16       0.3954      1.00000
+     17       2.5882      1.00000
+     18       2.5882      1.00000
+     19       3.0390      1.00000
+     20       6.8708      0.00000
+     21       6.8708      0.00000
+     22       6.9803      0.00000
+     23       8.9029      0.00000
+     24       9.3307      0.00000
+
+ spin component 2
+
+ k-point     1 :       0.0000    0.0000    0.0000
+  band No.  band energies     occupation 
+      1     -30.0580      1.00000
+      2     -29.9237      1.00000
+      3     -29.9237      1.00000
+      4     -22.1870      1.00000
+      5     -13.9656      1.00000
+      6     -13.3689      1.00000
+      7     -13.1998      1.00000
+      8      -7.3835      1.00000
+      9      -7.3123      1.00000
+     10      -7.3123      1.00000
+     11       0.4503      1.00000
+     12       0.5787      1.00000
+     13       0.5787      1.00000
+     14       1.3310      1.00000
+     15       1.3310      1.00000
+     16       1.7382      1.00000
+     17       2.1183      1.00000
+     18       2.4834      1.00000
+     19       2.4834      1.00000
+     20       4.7550      0.00000
+     21       5.3785      0.00000
+     22       5.3785      0.00000
+     23       6.9084      0.00000
+     24       7.1126      0.00000
+
+ k-point     2 :       0.1250    0.0000    0.0000
+  band No.  band energies     occupation 
+      1     -30.0577      1.00000
+      2     -29.9310      1.00000
+      3     -29.9234      1.00000
+      4     -22.1721      1.00000
+      5     -13.9682      1.00000
+      6     -13.3585      1.00000
+      7     -13.1920      1.00000
+      8      -7.3648      1.00000
+      9      -7.2892      1.00000
+     10      -7.2743      1.00000
+     11       0.3112      1.00000
+     12       0.4412      1.00000
+     13       0.5572      1.00000
+     14       1.1068      1.00000
+     15       1.2333      1.00000
+     16       1.6912      1.00000
+     17       1.9794      1.00000
+     18       2.2871      1.00000
+     19       2.3700      1.00000
+     20       5.0448      0.00000
+     21       5.3690      0.00000
+     22       5.3938      0.00000
+     23       7.0538      0.00000
+     24       7.3666      0.00000
+
+ k-point     3 :       0.2500    0.0000    0.0000
+  band No.  band energies     occupation 
+      1     -30.0569      1.00000
+      2     -29.9485      1.00000
+      3     -29.9228      1.00000
+      4     -22.1359      1.00000
+      5     -14.0124      1.00000
+      6     -13.3225      1.00000
+      7     -13.1380      1.00000
+      8      -7.3166      1.00000
+      9      -7.2320      1.00000
+     10      -7.1858      1.00000
+     11      -0.2518      1.00000
+     12       0.3459      1.00000
+     13       0.4486      1.00000
+     14       0.7516      1.00000
+     15       1.0763      1.00000
+     16       1.4656      1.00000
+     17       1.6705      1.00000
+     18       1.9258      1.00000
+     19       2.0610      1.00000
+     20       5.3836      0.00000
+     21       5.6731      0.00000
+     22       5.6979      0.00000
+     23       7.0551      0.00000
+     24       7.9536      0.00000
+
+ k-point     4 :       0.3750    0.0000    0.0000
+  band No.  band energies     occupation 
+      1     -30.0562      1.00000
+      2     -29.9660      1.00000
+      3     -29.9221      1.00000
+      4     -22.0991      1.00000
+      5     -14.0937      1.00000
+      6     -13.2917      1.00000
+      7     -13.0314      1.00000
+      8      -7.2651      1.00000
+      9      -7.1727      1.00000
+     10      -7.1001      1.00000
+     11      -0.7833      1.00000
+     12       0.2202      1.00000
+     13       0.2581      1.00000
+     14       0.4808      1.00000
+     15       1.0497      1.00000
+     16       1.1985      1.00000
+     17       1.4145      1.00000
+     18       1.6166      1.00000
+     19       1.8072      1.00000
+     20       5.4304      0.00000
+     21       6.1650      0.00000
+     22       6.2021      0.00000
+     23       7.0222      0.00000
+     24       8.2922      0.00000
+
+ k-point     5 :       0.5000    0.0000    0.0000
+  band No.  band energies     occupation 
+      1     -30.0559      1.00000
+      2     -29.9732      1.00000
+      3     -29.9218      1.00000
+      4     -22.0837      1.00000
+      5     -14.1336      1.00000
+      6     -13.2820      1.00000
+      7     -12.9746      1.00000
+      8      -7.2428      1.00000
+      9      -7.1475      1.00000
+     10      -7.0653      1.00000
+     11      -0.9963      1.00000
+     12       0.1650      1.00000
+     13       0.1684      1.00000
+     14       0.3656      1.00000
+     15       1.0814      1.00000
+     16       1.0852      1.00000
+     17       1.3334      1.00000
+     18       1.4782      1.00000
+     19       1.7161      1.00000
+     20       5.4481      0.00000
+     21       6.3577      0.00000
+     22       6.4594      0.00000
+     23       6.9825      0.00000
+     24       8.3791      0.00000
+
+ k-point     6 :       0.1250    0.1250    0.0000
+  band No.  band energies     occupation 
+      1     -30.0574      1.00000
+      2     -29.9308      1.00000
+      3     -29.9305      1.00000
+      4     -22.1580      1.00000
+      5     -13.9610      1.00000
+      6     -13.3427      1.00000
+      7     -13.1914      1.00000
+      8      -7.3437      1.00000
+      9      -7.3429      1.00000
+     10      -7.1881      1.00000
+     11       0.1836      1.00000
+     12       0.4093      1.00000
+     13       0.4191      1.00000
+     14       0.9734      1.00000
+     15       1.0768      1.00000
+     16       1.5840      1.00000
+     17       1.7526      1.00000
+     18       2.2269      1.00000
+     19       2.4433      1.00000
+     20       5.1949      0.00000
+     21       5.3825      0.00000
+     22       5.4340      0.00000
+     23       7.2447      0.00000
+     24       7.5895      0.00000
+
+ k-point     7 :       0.2500    0.1250    0.0000
+  band No.  band energies     occupation 
+      1     -30.0567      1.00000
+      2     -29.9482      1.00000
+      3     -29.9300      1.00000
+      4     -22.1235      1.00000
+      5     -13.9803      1.00000
+      6     -13.2990      1.00000
+      7     -13.1534      1.00000
+      8      -7.3395      1.00000
+      9      -7.2902      1.00000
+     10      -7.1162      1.00000
+     11      -0.3138      1.00000
+     12       0.2411      1.00000
+     13       0.3512      1.00000
+     14       0.7408      1.00000
+     15       0.8084      1.00000
+     16       1.1037      1.00000
+     17       1.6801      1.00000
+     18       2.0510      1.00000
+     19       2.2679      1.00000
+     20       5.3582      0.00000
+     21       5.7244      0.00000
+     22       5.7575      0.00000
+     23       7.2609      0.00000
+     24       8.1976      0.00000
+
+ k-point     8 :       0.3750    0.1250    0.0000
+  band No.  band energies     occupation 
+      1     -30.0559      1.00000
+      2     -29.9656      1.00000
+      3     -29.9293      1.00000
+      4     -22.0884      1.00000
+      5     -14.0389      1.00000
+      6     -13.2684      1.00000
+      7     -13.0532      1.00000
+      8      -7.2849      1.00000
+      9      -7.2284      1.00000
+     10      -7.1050      1.00000
+     11      -0.8190      1.00000
+     12       0.1188      1.00000
+     13       0.2152      1.00000
+     14       0.4307      1.00000
+     15       0.5789      1.00000
+     16       1.0267      1.00000
+     17       1.4729      1.00000
+     18       1.8846      1.00000
+     19       2.0314      1.00000
+     20       5.4165      0.00000
+     21       6.1921      0.00000
+     22       6.2249      0.00000
+     23       7.2116      0.00000
+     24       8.5783      0.00000
+
+ k-point     9 :       0.5000    0.1250    0.0000
+  band No.  band energies     occupation 
+      1     -30.0556      1.00000
+      2     -29.9727      1.00000
+      3     -29.9290      1.00000
+      4     -22.0737      1.00000
+      5     -14.0708      1.00000
+      6     -13.2596      1.00000
+      7     -12.9974      1.00000
+      8      -7.2478      1.00000
+      9      -7.1816      1.00000
+     10      -7.1364      1.00000
+     11      -1.0251      1.00000
+     12       0.0850      1.00000
+     13       0.1912      1.00000
+     14       0.2178      1.00000
+     15       0.5063      1.00000
+     16       1.1171      1.00000
+     17       1.3047      1.00000
+     18       1.8708      1.00000
+     19       1.8908      1.00000
+     20       5.4362      0.00000
+     21       6.3864      0.00000
+     22       6.4672      0.00000
+     23       7.1600      0.00000
+     24       8.6865      0.00000
+
+ k-point    10 :       0.2500    0.2500    0.0000
+  band No.  band energies     occupation 
+      1     -30.0560      1.00000
+      2     -29.9476      1.00000
+      3     -29.9470      1.00000
+      4     -22.0930      1.00000
+      5     -13.9264      1.00000
+      6     -13.2346      1.00000
+      7     -13.1700      1.00000
+      8      -7.4170      1.00000
+      9      -7.2429      1.00000
+     10      -7.1139      1.00000
+     11      -0.5374      1.00000
+     12      -0.1007      1.00000
+     13       0.2704      1.00000
+     14       0.3080      1.00000
+     15       0.6597      1.00000
+     16       0.7488      1.00000
+     17       1.8004      1.00000
+     18       1.9013      1.00000
+     19       2.4720      1.00000
+     20       5.5533      0.00000
+     21       5.8673      0.00000
+     22       6.0147      0.00000
+     23       7.3681      0.00000
+     24       8.8150      0.00000
+
+ k-point    11 :       0.3750    0.2500    0.0000
+  band No.  band energies     occupation 
+      1     -30.0552      1.00000
+      2     -29.9646      1.00000
+      3     -29.9465      1.00000
+      4     -22.0622      1.00000
+      5     -13.9099      1.00000
+      6     -13.2088      1.00000
+      7     -13.1028      1.00000
+      8      -7.4148      1.00000
+      9      -7.2264      1.00000
+     10      -7.1595      1.00000
+     11      -0.9085      1.00000
+     12      -0.3149      1.00000
+     13      -0.1417      1.00000
+     14       0.1638      1.00000
+     15       0.4549      1.00000
+     16       0.9068      1.00000
+     17       1.6298      1.00000
+     18       1.8184      1.00000
+     19       2.5180      1.00000
+     20       5.6885      0.00000
+     21       6.2383      0.00000
+     22       6.3600      0.00000
+     23       7.3196      0.00000
+     24       9.2839      0.00000
+
+ k-point    12 :       0.5000    0.2500    0.0000
+  band No.  band energies     occupation 
+      1     -30.0549      1.00000
+      2     -29.9717      1.00000
+      3     -29.9461      1.00000
+      4     -22.0493      1.00000
+      5     -13.9137      1.00000
+      6     -13.2064      1.00000
+      7     -13.0537      1.00000
+      8      -7.3603      1.00000
+      9      -7.3016      1.00000
+     10      -7.1494      1.00000
+     11      -1.0912      1.00000
+     12      -0.4380      1.00000
+     13      -0.2116      1.00000
+     14       0.0867      1.00000
+     15       0.3792      1.00000
+     16       1.0557      1.00000
+     17       1.4751      1.00000
+     18       1.7900      1.00000
+     19       2.5131      1.00000
+     20       5.7165      0.00000
+     21       6.4638      0.00000
+     22       6.5273      0.00000
+     23       7.2548      0.00000
+     24       9.4336      0.00000
+
+ k-point    13 :       0.3750    0.3750    0.0000
+  band No.  band energies     occupation 
+      1     -30.0545      1.00000
+      2     -29.9638      1.00000
+      3     -29.9635      1.00000
+      4     -22.0357      1.00000
+      5     -13.7910      1.00000
+      6     -13.1468      1.00000
+      7     -13.1393      1.00000
+      8      -7.4899      1.00000
+      9      -7.3574      1.00000
+     10      -7.1186      1.00000
+     11      -1.0867      1.00000
+     12      -0.7002      1.00000
+     13      -0.5861      1.00000
+     14       0.1184      1.00000
+     15       0.2513      1.00000
+     16       1.0298      1.00000
+     17       1.6507      1.00000
+     18       1.8413      1.00000
+     19       2.7932      1.00000
+     20       6.0995      0.00000
+     21       6.3197      0.00000
+     22       6.5944      0.00000
+     23       7.2466      0.00000
+     24       9.8787      0.00000
+
+ k-point    14 :       0.5000    0.3750    0.0000
+  band No.  band energies     occupation 
+      1     -30.0542      1.00000
+      2     -29.9707      1.00000
+      3     -29.9632      1.00000
+      4     -22.0246      1.00000
+      5     -13.7472      1.00000
+      6     -13.1559      1.00000
+      7     -13.1121      1.00000
+      8      -7.4755      1.00000
+      9      -7.4576      1.00000
+     10      -7.0964      1.00000
+     11      -1.2208      1.00000
+     12      -0.8780      1.00000
+     13      -0.6559      1.00000
+     14       0.0810      1.00000
+     15       0.1766      1.00000
+     16       1.0500      1.00000
+     17       1.7502      1.00000
+     18       1.8023      1.00000
+     19       2.8704      1.00000
+     20       6.2001      0.00000
+     21       6.4869      0.00000
+     22       6.7174      0.00000
+     23       7.1536      0.00000
+     24      10.0848      0.00000
+
+ k-point    15 :       0.5000    0.5000    0.0000
+  band No.  band energies     occupation 
+      1     -30.0540      1.00000
+      2     -29.9703      1.00000
+      3     -29.9703      1.00000
+      4     -22.0143      1.00000
+      5     -13.6744      1.00000
+      6     -13.1369      1.00000
+      7     -13.1369      1.00000
+      8      -7.5194      1.00000
+      9      -7.5194      1.00000
+     10      -7.0734      1.00000
+     11      -1.3340      1.00000
+     12      -1.0318      1.00000
+     13      -0.7744      1.00000
+     14       0.0826      1.00000
+     15       0.0826      1.00000
+     16       0.9944      1.00000
+     17       1.8718      1.00000
+     18       1.8718      1.00000
+     19       2.9783      1.00000
+     20       6.4939      0.00000
+     21       6.4939      0.00000
+     22       6.8221      0.00000
+     23       7.0186      0.00000
+     24      10.3863      0.00000
+
+ k-point    16 :       0.0000    0.0000    0.1250
+  band No.  band energies     occupation 
+      1     -30.0619      1.00000
+      2     -29.9235      1.00000
+      3     -29.9235      1.00000
+      4     -22.1769      1.00000
+      5     -13.9656      1.00000
+      6     -13.3762      1.00000
+      7     -13.1965      1.00000
+      8      -7.3202      1.00000
+      9      -7.2987      1.00000
+     10      -7.2987      1.00000
+     11       0.2242      1.00000
+     12       0.5371      1.00000
+     13       0.5371      1.00000
+     14       1.2371      1.00000
+     15       1.2371      1.00000
+     16       1.6264      1.00000
+     17       1.9076      1.00000
+     18       2.4592      1.00000
+     19       2.4592      1.00000
+     20       4.7716      0.00000
+     21       5.5298      0.00000
+     22       5.5298      0.00000
+     23       6.9072      0.00000
+     24       7.4073      0.00000
+
+ k-point    17 :       0.1250    0.0000    0.1250
+  band No.  band energies     occupation 
+      1     -30.0616      1.00000
+      2     -29.9308      1.00000
+      3     -29.9233      1.00000
+      4     -22.1627      1.00000
+      5     -13.9571      1.00000
+      6     -13.3721      1.00000
+      7     -13.1884      1.00000
+      8      -7.3503      1.00000
+      9      -7.2751      1.00000
+     10      -7.2315      1.00000
+     11       0.1449      1.00000
+     12       0.3326      1.00000
+     13       0.5238      1.00000
+     14       0.9730      1.00000
+     15       1.1341      1.00000
+     16       1.6769      1.00000
+     17       1.8484      1.00000
+     18       2.2606      1.00000
+     19       2.3284      1.00000
+     20       5.0602      0.00000
+     21       5.4947      0.00000
+     22       5.5408      0.00000
+     23       7.1570      0.00000
+     24       7.5651      0.00000
+
+ k-point    18 :       0.2500    0.0000    0.1250
+  band No.  band energies     occupation 
+      1     -30.0608      1.00000
+      2     -29.9483      1.00000
+      3     -29.9226      1.00000
+      4     -22.1279      1.00000
+      5     -13.9772      1.00000
+      6     -13.3412      1.00000
+      7     -13.1419      1.00000
+      8      -7.3350      1.00000
+      9      -7.2166      1.00000
+     10      -7.1584      1.00000
+     11      -0.3047      1.00000
+     12       0.1221      1.00000
+     13       0.4327      1.00000
+     14       0.5962      1.00000
+     15       0.9678      1.00000
+     16       1.5122      1.00000
+     17       1.6752      1.00000
+     18       1.8887      1.00000
+     19       2.0909      1.00000
+     20       5.5131      0.00000
+     21       5.6975      0.00000
+     22       5.7614      0.00000
+     23       7.2514      0.00000
+     24       8.0836      0.00000
+
+ k-point    19 :       0.3750    0.0000    0.1250
+  band No.  band energies     occupation 
+      1     -30.0600      1.00000
+      2     -29.9657      1.00000
+      3     -29.9220      1.00000
+      4     -22.0925      1.00000
+      5     -14.0411      1.00000
+      6     -13.3009      1.00000
+      7     -13.0512      1.00000
+      8      -7.2837      1.00000
+      9      -7.1559      1.00000
+     10      -7.1226      1.00000
+     11      -0.8106      1.00000
+     12       0.0121      1.00000
+     13       0.2452      1.00000
+     14       0.2652      1.00000
+     15       0.9467      1.00000
+     16       1.2958      1.00000
+     17       1.5670      1.00000
+     18       1.5685      1.00000
+     19       1.8479      1.00000
+     20       5.5705      0.00000
+     21       6.1730      0.00000
+     22       6.2242      0.00000
+     23       7.2429      0.00000
+     24       8.4229      0.00000
+
+ k-point    20 :       0.5000    0.0000    0.1250
+  band No.  band energies     occupation 
+      1     -30.0597      1.00000
+      2     -29.9729      1.00000
+      3     -29.9217      1.00000
+      4     -22.0777      1.00000
+      5     -14.0755      1.00000
+      6     -13.2864      1.00000
+      7     -13.0006      1.00000
+      8      -7.2511      1.00000
+      9      -7.1302      1.00000
+     10      -7.1195      1.00000
+     11      -1.0169      1.00000
+     12      -0.0002      1.00000
+     13       0.1028      1.00000
+     14       0.1511      1.00000
+     15       0.9829      1.00000
+     16       1.2029      1.00000
+     17       1.4234      1.00000
+     18       1.6073      1.00000
+     19       1.6854      1.00000
+     20       5.5864      0.00000
+     21       6.3657      0.00000
+     22       6.4595      0.00000
+     23       7.2217      0.00000
+     24       8.5100      0.00000
+
+ k-point    21 :       0.1250    0.1250    0.1250
+  band No.  band energies     occupation 
+      1     -30.0613      1.00000
+      2     -29.9307      1.00000
+      3     -29.9304      1.00000
+      4     -22.1490      1.00000
+      5     -13.9417      1.00000
+      6     -13.3608      1.00000
+      7     -13.1861      1.00000
+      8      -7.3440      1.00000
+      9      -7.3431      1.00000
+     10      -7.1367      1.00000
+     11       0.0314      1.00000
+     12       0.2902      1.00000
+     13       0.3757      1.00000
+     14       0.8895      1.00000
+     15       0.9517      1.00000
+     16       1.5432      1.00000
+     17       1.7900      1.00000
+     18       2.1424      1.00000
+     19       2.3924      1.00000
+     20       5.2391      0.00000
+     21       5.5143      0.00000
+     22       5.5364      0.00000
+     23       7.5593      0.00000
+     24       7.5815      0.00000
+
+ k-point    22 :       0.2500    0.1250    0.1250
+  band No.  band energies     occupation 
+      1     -30.0605      1.00000
+      2     -29.9480      1.00000
+      3     -29.9298      1.00000
+      4     -22.1158      1.00000
+      5     -13.9421      1.00000
+      6     -13.3189      1.00000
+      7     -13.1524      1.00000
+      8      -7.3564      1.00000
+      9      -7.3258      1.00000
+     10      -7.0637      1.00000
+     11      -0.3806      1.00000
+     12       0.0730      1.00000
+     13       0.2907      1.00000
+     14       0.6341      1.00000
+     15       0.7495      1.00000
+     16       1.1024      1.00000
+     17       1.7828      1.00000
+     18       1.9921      1.00000
+     19       2.2392      1.00000
+     20       5.5027      0.00000
+     21       5.7657      0.00000
+     22       5.8042      0.00000
+     23       7.5442      0.00000
+     24       8.2372      0.00000
+
+ k-point    23 :       0.3750    0.1250    0.1250
+  band No.  band energies     occupation 
+      1     -30.0597      1.00000
+      2     -29.9653      1.00000
+      3     -29.9291      1.00000
+      4     -22.0820      1.00000
+      5     -13.9863      1.00000
+      6     -13.2760      1.00000
+      7     -13.0673      1.00000
+      8      -7.3261      1.00000
+      9      -7.2731      1.00000
+     10      -7.0724      1.00000
+     11      -0.8449      1.00000
+     12      -0.0752      1.00000
+     13       0.1889      1.00000
+     14       0.3376      1.00000
+     15       0.5486      1.00000
+     16       0.9973      1.00000
+     17       1.6871      1.00000
+     18       1.8189      1.00000
+     19       2.0136      1.00000
+     20       5.5650      0.00000
+     21       6.2110      0.00000
+     22       6.2500      0.00000
+     23       7.4980      0.00000
+     24       8.6355      0.00000
+
+ k-point    24 :       0.5000    0.1250    0.1250
+  band No.  band energies     occupation 
+      1     -30.0594      1.00000
+      2     -29.9725      1.00000
+      3     -29.9288      1.00000
+      4     -22.0678      1.00000
+      5     -14.0134      1.00000
+      6     -13.2620      1.00000
+      7     -13.0168      1.00000
+      8      -7.3174      1.00000
+      9      -7.1936      1.00000
+     10      -7.1312      1.00000
+     11      -1.0422      1.00000
+     12      -0.0548      1.00000
+     13       0.0387      1.00000
+     14       0.2177      1.00000
+     15       0.4915      1.00000
+     16       1.0171      1.00000
+     17       1.6288      1.00000
+     18       1.7723      1.00000
+     19       1.8856      1.00000
+     20       5.5840      0.00000
+     21       6.4005      0.00000
+     22       6.4757      0.00000
+     23       7.4599      0.00000
+     24       8.7470      0.00000
+
+ k-point    25 :       0.2500    0.2500    0.1250
+  band No.  band energies     occupation 
+      1     -30.0598      1.00000
+      2     -29.9474      1.00000
+      3     -29.9469      1.00000
+      4     -22.0862      1.00000
+      5     -13.8811      1.00000
+      6     -13.2558      1.00000
+      7     -13.1596      1.00000
+      8      -7.4489      1.00000
+      9      -7.3463      1.00000
+     10      -7.0395      1.00000
+     11      -0.6067      1.00000
+     12      -0.1115      1.00000
+     13       0.0712      1.00000
+     14       0.4200      1.00000
+     15       0.6036      1.00000
+     16       0.6693      1.00000
+     17       1.8622      1.00000
+     18       1.8987      1.00000
+     19       2.4400      1.00000
+     20       5.7000      0.00000
+     21       5.9203      0.00000
+     22       6.0430      0.00000
+     23       7.7052      0.00000
+     24       8.8029      0.00000
+
+ k-point    26 :       0.3750    0.2500    0.1250
+  band No.  band energies     occupation 
+      1     -30.0590      1.00000
+      2     -29.9644      1.00000
+      3     -29.9463      1.00000
+      4     -22.0562      1.00000
+      5     -13.8578      1.00000
+      6     -13.2109      1.00000
+      7     -13.1039      1.00000
+      8      -7.4661      1.00000
+      9      -7.3602      1.00000
+     10      -7.0998      1.00000
+     11      -0.9278      1.00000
+     12      -0.3518      1.00000
+     13      -0.1261      1.00000
+     14       0.1796      1.00000
+     15       0.4008      1.00000
+     16       0.7723      1.00000
+     17       1.7206      1.00000
+     18       1.8448      1.00000
+     19       2.4993      1.00000
+     20       5.8258      0.00000
+     21       6.2827      0.00000
+     22       6.3826      0.00000
+     23       7.6613      0.00000
+     24       9.2766      0.00000
+
+ k-point    27 :       0.5000    0.2500    0.1250
+  band No.  band energies     occupation 
+      1     -30.0587      1.00000
+      2     -29.9715      1.00000
+      3     -29.9460      1.00000
+      4     -22.0437      1.00000
+      5     -13.8588      1.00000
+      6     -13.2027      1.00000
+      7     -13.0576      1.00000
+      8      -7.4494      1.00000
+      9      -7.3656      1.00000
+     10      -7.1495      1.00000
+     11      -1.1002      1.00000
+     12      -0.4151      1.00000
+     13      -0.2084      1.00000
+     14       0.0865      1.00000
+     15       0.3377      1.00000
+     16       0.8579      1.00000
+     17       1.6898      1.00000
+     18       1.7583      1.00000
+     19       2.4993      1.00000
+     20       5.8528      0.00000
+     21       6.4934      0.00000
+     22       6.5460      0.00000
+     23       7.6077      0.00000
+     24       9.4288      0.00000
+
+ k-point    28 :       0.3750    0.3750    0.1250
+  band No.  band energies     occupation 
+      1     -30.0583      1.00000
+      2     -29.9636      1.00000
+      3     -29.9633      1.00000
+      4     -22.0302      1.00000
+      5     -13.7401      1.00000
+      6     -13.1387      1.00000
+      7     -13.1316      1.00000
+      8      -7.5518      1.00000
+      9      -7.4610      1.00000
+     10      -7.1544      1.00000
+     11      -1.0888      1.00000
+     12      -0.5962      1.00000
+     13      -0.5848      1.00000
+     14       0.1412      1.00000
+     15       0.2818      1.00000
+     16       0.7694      1.00000
+     17       1.7162      1.00000
+     18       1.9240      1.00000
+     19       2.7889      1.00000
+     20       6.2167      0.00000
+     21       6.3693      0.00000
+     22       6.6163      0.00000
+     23       7.5973      0.00000
+     24       9.8656      0.00000
+
+ k-point    29 :       0.5000    0.3750    0.1250
+  band No.  band energies     occupation 
+      1     -30.0580      1.00000
+      2     -29.9705      1.00000
+      3     -29.9631      1.00000
+      4     -22.0193      1.00000
+      5     -13.6970      1.00000
+      6     -13.1436      1.00000
+      7     -13.1009      1.00000
+      8      -7.5557      1.00000
+      9      -7.5285      1.00000
+     10      -7.1791      1.00000
+     11      -1.2220      1.00000
+     12      -0.7243      1.00000
+     13      -0.6529      1.00000
+     14       0.1170      1.00000
+     15       0.2196      1.00000
+     16       0.7592      1.00000
+     17       1.8541      1.00000
+     18       1.8551      1.00000
+     19       2.8722      1.00000
+     20       6.2991      0.00000
+     21       6.5325      0.00000
+     22       6.7383      0.00000
+     23       7.5184      0.00000
+     24      10.0748      0.00000
+
+ k-point    30 :       0.5000    0.5000    0.1250
+  band No.  band energies     occupation 
+      1     -30.0577      1.00000
+      2     -29.9701      1.00000
+      3     -29.9701      1.00000
+      4     -22.0091      1.00000
+      5     -13.6271      1.00000
+      6     -13.1196      1.00000
+      7     -13.1196      1.00000
+      8      -7.5932      1.00000
+      9      -7.5932      1.00000
+     10      -7.1943      1.00000
+     11      -1.3337      1.00000
+     12      -0.8277      1.00000
+     13      -0.7728      1.00000
+     14       0.1499      1.00000
+     15       0.1499      1.00000
+     16       0.6694      1.00000
+     17       1.9425      1.00000
+     18       1.9425      1.00000
+     19       2.9871      1.00000
+     20       6.5455      0.00000
+     21       6.5455      0.00000
+     22       6.8439      0.00000
+     23       7.4127      0.00000
+     24      10.3229      0.00000
+
+ k-point    31 :       0.0000    0.0000    0.2500
+  band No.  band energies     occupation 
+      1     -30.0714      1.00000
+      2     -29.9232      1.00000
+      3     -29.9232      1.00000
+      4     -22.1525      1.00000
+      5     -13.9932      1.00000
+      6     -13.3613      1.00000
+      7     -13.1886      1.00000
+      8      -7.2654      1.00000
+      9      -7.2654      1.00000
+     10      -7.1684      1.00000
+     11      -0.2892      1.00000
+     12       0.4196      1.00000
+     13       0.4196      1.00000
+     14       1.0556      1.00000
+     15       1.0556      1.00000
+     16       1.3811      1.00000
+     17       1.4789      1.00000
+     18       2.3961      1.00000
+     19       2.3961      1.00000
+     20       4.8122      0.00000
+     21       5.8818      0.00000
+     22       5.8818      0.00000
+     23       6.9067      0.00000
+     24       8.0124      0.00000
+
+ k-point    32 :       0.1250    0.0000    0.2500
+  band No.  band energies     occupation 
+      1     -30.0711      1.00000
+      2     -29.9304      1.00000
+      3     -29.9229      1.00000
+      4     -22.1396      1.00000
+      5     -13.9561      1.00000
+      6     -13.3750      1.00000
+      7     -13.1791      1.00000
+      8      -7.3114      1.00000
+      9      -7.2405      1.00000
+     10      -7.1343      1.00000
+     11      -0.3348      1.00000
+     12       0.1887      1.00000
+     13       0.4241      1.00000
+     14       0.6984      1.00000
+     15       0.9407      1.00000
+     16       1.4652      1.00000
+     17       1.7194      1.00000
+     18       2.1923      1.00000
+     19       2.2446      1.00000
+     20       5.0954      0.00000
+     21       5.8096      0.00000
+     22       5.8865      0.00000
+     23       7.1982      0.00000
+     24       8.1556      0.00000
+
+ k-point    33 :       0.2500    0.0000    0.2500
+  band No.  band energies     occupation 
+      1     -30.0702      1.00000
+      2     -29.9478      1.00000
+      3     -29.9223      1.00000
+      4     -22.1083      1.00000
+      5     -13.9002      1.00000
+      6     -13.3815      1.00000
+      7     -13.1444      1.00000
+      8      -7.3478      1.00000
+      9      -7.1789      1.00000
+     10      -7.1265      1.00000
+     11      -0.4932      1.00000
+     12      -0.2770      1.00000
+     13       0.2810      1.00000
+     14       0.3859      1.00000
+     15       0.7358      1.00000
+     16       1.4058      1.00000
+     17       1.8001      1.00000
+     18       1.8091      1.00000
+     19       2.1850      1.00000
+     20       5.6631      0.00000
+     21       5.9093      0.00000
+     22       5.9517      0.00000
+     23       7.4633      0.00000
+     24       8.5729      0.00000
+
+ k-point    34 :       0.3750    0.0000    0.2500
+  band No.  band energies     occupation 
+      1     -30.0692      1.00000
+      2     -29.9651      1.00000
+      3     -29.9216      1.00000
+      4     -22.0766      1.00000
+      5     -13.9033      1.00000
+      6     -13.3386      1.00000
+      7     -13.0923      1.00000
+      8      -7.3265      1.00000
+      9      -7.1763      1.00000
+     10      -7.1148      1.00000
+     11      -0.8803      1.00000
+     12      -0.4694      1.00000
+     13      -0.0823      1.00000
+     14       0.2110      1.00000
+     15       0.7138      1.00000
+     16       1.4105      1.00000
+     17       1.4575      1.00000
+     18       1.7179      1.00000
+     19       2.1749      1.00000
+     20       5.9004      0.00000
+     21       6.1914      0.00000
+     22       6.3044      0.00000
+     23       7.5339      0.00000
+     24       8.9001      0.00000
+
+ k-point    35 :       0.5000    0.0000    0.2500
+  band No.  band energies     occupation 
+      1     -30.0689      1.00000
+      2     -29.9722      1.00000
+      3     -29.9214      1.00000
+      4     -22.0632      1.00000
+      5     -13.9196      1.00000
+      6     -13.3107      1.00000
+      7     -13.0632      1.00000
+      8      -7.2681      1.00000
+      9      -7.2462      1.00000
+     10      -7.0876      1.00000
+     11      -1.0672      1.00000
+     12      -0.5341      1.00000
+     13      -0.2056      1.00000
+     14       0.1143      1.00000
+     15       0.7545      1.00000
+     16       1.3078      1.00000
+     17       1.5056      1.00000
+     18       1.5966      1.00000
+     19       2.1525      1.00000
+     20       5.9135      0.00000
+     21       6.3825      0.00000
+     22       6.4962      0.00000
+     23       7.5419      0.00000
+     24       8.9885      0.00000
+
+ k-point    36 :       0.1250    0.1250    0.2500
+  band No.  band energies     occupation 
+      1     -30.0707      1.00000
+      2     -29.9303      1.00000
+      3     -29.9300      1.00000
+      4     -22.1272      1.00000
+      5     -13.9172      1.00000
+      6     -13.3785      1.00000
+      7     -13.1731      1.00000
+      8      -7.3437      1.00000
+      9      -7.3018      1.00000
+     10      -7.0590      1.00000
+     11      -0.3873      1.00000
+     12       0.0789      1.00000
+     13       0.2858      1.00000
+     14       0.6495      1.00000
+     15       0.7569      1.00000
+     16       1.4617      1.00000
+     17       1.7746      1.00000
+     18       2.0235      1.00000
+     19       2.2753      1.00000
+     20       5.2957      0.00000
+     21       5.8167      0.00000
+     22       5.8535      0.00000
+     23       7.5709      0.00000
+     24       8.2163      0.00000
+
+ k-point    37 :       0.2500    0.1250    0.2500
+  band No.  band energies     occupation 
+      1     -30.0698      1.00000
+      2     -29.9475      1.00000
+      3     -29.9295      1.00000
+      4     -22.0971      1.00000
+      5     -13.8548      1.00000
+      6     -13.3648      1.00000
+      7     -13.1445      1.00000
+      8      -7.3987      1.00000
+      9      -7.3323      1.00000
+     10      -7.0196      1.00000
+     11      -0.5709      1.00000
+     12      -0.2594      1.00000
+     13       0.1355      1.00000
+     14       0.4221      1.00000
+     15       0.6266      1.00000
+     16       1.0816      1.00000
+     17       1.8166      1.00000
+     18       2.0420      1.00000
+     19       2.1962      1.00000
+     20       5.7413      0.00000
+     21       5.9056      0.00000
+     22       5.9938      0.00000
+     23       7.9127      0.00000
+     24       8.5679      0.00000
+
+ k-point    38 :       0.3750    0.1250    0.2500
+  band No.  band energies     occupation 
+      1     -30.0689      1.00000
+      2     -29.9647      1.00000
+      3     -29.9288      1.00000
+      4     -22.0664      1.00000
+      5     -13.8481      1.00000
+      6     -13.3105      1.00000
+      7     -13.0942      1.00000
+      8      -7.3858      1.00000
+      9      -7.3505      1.00000
+     10      -7.0633      1.00000
+     11      -0.9077      1.00000
+     12      -0.4370      1.00000
+     13      -0.0884      1.00000
+     14       0.2329      1.00000
+     15       0.5263      1.00000
+     16       0.9321      1.00000
+     17       1.7300      1.00000
+     18       1.9889      1.00000
+     19       2.1516      1.00000
+     20       5.8944      0.00000
+     21       6.2475      0.00000
+     22       6.3407      0.00000
+     23       7.9484      0.00000
+     24       8.9414      0.00000
+
+ k-point    39 :       0.5000    0.1250    0.2500
+  band No.  band energies     occupation 
+      1     -30.0686      1.00000
+      2     -29.9718      1.00000
+      3     -29.9285      1.00000
+      4     -22.0536      1.00000
+      5     -13.8597      1.00000
+      6     -13.2808      1.00000
+      7     -13.0641      1.00000
+      8      -7.3802      1.00000
+      9      -7.3270      1.00000
+     10      -7.1135      1.00000
+     11      -1.0835      1.00000
+     12      -0.4579      1.00000
+     13      -0.2085      1.00000
+     14       0.1461      1.00000
+     15       0.5103      1.00000
+     16       0.9082      1.00000
+     17       1.7340      1.00000
+     18       1.9024      1.00000
+     19       2.1288      1.00000
+     20       5.9136      0.00000
+     21       6.4308      0.00000
+     22       6.5259      0.00000
+     23       7.9396      0.00000
+     24       9.0510      0.00000
+
+ k-point    40 :       0.2500    0.2500    0.2500
+  band No.  band energies     occupation 
+      1     -30.0690      1.00000
+      2     -29.9469      1.00000
+      3     -29.9465      1.00000
+      4     -22.0696      1.00000
+      5     -13.7674      1.00000
+      6     -13.3095      1.00000
+      7     -13.1343      1.00000
+      8      -7.5260      1.00000
+      9      -7.4343      1.00000
+     10      -7.0279      1.00000
+     11      -0.7353      1.00000
+     12      -0.2271      1.00000
+     13      -0.1341      1.00000
+     14       0.3400      1.00000
+     15       0.5170      1.00000
+     16       0.5292      1.00000
+     17       1.9525      1.00000
+     18       2.0583      1.00000
+     19       2.3685      1.00000
+     20       5.9768      0.00000
+     21       6.0811      0.00000
+     22       6.1360      0.00000
+     23       8.4516      0.00000
+     24       8.7696      0.00000
+
+ k-point    41 :       0.3750    0.2500    0.2500
+  band No.  band energies     occupation 
+      1     -30.0682      1.00000
+      2     -29.9639      1.00000
+      3     -29.9459      1.00000
+      4     -22.0418      1.00000
+      5     -13.7214      1.00000
+      6     -13.2336      1.00000
+      7     -13.0980      1.00000
+      8      -7.5757      1.00000
+      9      -7.5064      1.00000
+     10      -7.1453      1.00000
+     11      -0.9641      1.00000
+     12      -0.4136      1.00000
+     13      -0.1701      1.00000
+     14       0.0610      1.00000
+     15       0.3495      1.00000
+     16       0.5255      1.00000
+     17       1.8793      1.00000
+     18       2.1106      1.00000
+     19       2.4662      1.00000
+     20       6.1054      0.00000
+     21       6.3906      0.00000
+     22       6.4492      0.00000
+     23       8.4054      0.00000
+     24       9.2697      0.00000
+
+ k-point    42 :       0.5000    0.2500    0.2500
+  band No.  band energies     occupation 
+      1     -30.0678      1.00000
+      2     -29.9709      1.00000
+      3     -29.9456      1.00000
+      4     -22.0301      1.00000
+      5     -13.7143      1.00000
+      6     -13.2033      1.00000
+      7     -13.0677      1.00000
+      8      -7.5813      1.00000
+      9      -7.5153      1.00000
+     10      -7.2300      1.00000
+     11      -1.1240      1.00000
+     12      -0.3673      1.00000
+     13      -0.2513      1.00000
+     14      -0.0833      1.00000
+     15       0.3261      1.00000
+     16       0.5643      1.00000
+     17       1.8509      1.00000
+     18       2.1016      1.00000
+     19       2.4820      1.00000
+     20       6.1342      0.00000
+     21       6.5646      0.00000
+     22       6.6067      0.00000
+     23       8.3602      0.00000
+     24       9.4290      0.00000
+
+ k-point    43 :       0.3750    0.3750    0.2500
+  band No.  band energies     occupation 
+      1     -30.0674      1.00000
+      2     -29.9631      1.00000
+      3     -29.9629      1.00000
+      4     -22.0168      1.00000
+      5     -13.6096      1.00000
+      6     -13.1433      1.00000
+      7     -13.0941      1.00000
+      8      -7.6983      1.00000
+      9      -7.6391      1.00000
+     10      -7.3015      1.00000
+     11      -1.0979      1.00000
+     12      -0.5814      1.00000
+     13      -0.3597      1.00000
+     14      -0.0073      1.00000
+     15       0.3413      1.00000
+     16       0.3764      1.00000
+     17       1.9754      1.00000
+     18       2.1406      1.00000
+     19       2.7792      1.00000
+     20       6.4330      0.00000
+     21       6.4973      0.00000
+     22       6.6725      0.00000
+     23       8.3840      0.00000
+     24       9.8033      0.00000
+
+ k-point    44 :       0.5000    0.3750    0.2500
+  band No.  band energies     occupation 
+      1     -30.0670      1.00000
+      2     -29.9700      1.00000
+      3     -29.9626      1.00000
+      4     -22.0064      1.00000
+      5     -13.5696      1.00000
+      6     -13.1164      1.00000
+      7     -13.0736      1.00000
+      8      -7.7243      1.00000
+      9      -7.6948      1.00000
+     10      -7.3853      1.00000
+     11      -1.2334      1.00000
+     12      -0.6479      1.00000
+     13      -0.3571      1.00000
+     14      -0.0623      1.00000
+     15       0.2941      1.00000
+     16       0.3969      1.00000
+     17       2.0492      1.00000
+     18       2.1304      1.00000
+     19       2.8776      1.00000
+     20       6.4906      0.00000
+     21       6.6477      0.00000
+     22       6.7919      0.00000
+     23       8.3116      0.00000
+     24      10.0079      0.00000
+
+ k-point    45 :       0.5000    0.5000    0.2500
+  band No.  band energies     occupation 
+      1     -30.0667      1.00000
+      2     -29.9697      1.00000
+      3     -29.9697      1.00000
+      4     -21.9965      1.00000
+      5     -13.5105      1.00000
+      6     -13.0768      1.00000
+      7     -13.0768      1.00000
+      8      -7.7667      1.00000
+      9      -7.7667      1.00000
+     10      -7.4616      1.00000
+     11      -1.3432      1.00000
+     12      -0.7691      1.00000
+     13      -0.3548      1.00000
+     14       0.0091      1.00000
+     15       0.2804      1.00000
+     16       0.2804      1.00000
+     17       2.1596      1.00000
+     18       2.1596      1.00000
+     19       3.0084      1.00000
+     20       6.6736      0.00000
+     21       6.6736      0.00000
+     22       6.8983      0.00000
+     23       8.2112      0.00000
+     24      10.2390      0.00000
+
+ k-point    46 :       0.0000    0.0000    0.3750
+  band No.  band energies     occupation 
+      1     -30.0810      1.00000
+      2     -29.9229      1.00000
+      3     -29.9229      1.00000
+      4     -22.1277      1.00000
+      5     -14.0523      1.00000
+      6     -13.3078      1.00000
+      7     -13.1805      1.00000
+      8      -7.2314      1.00000
+      9      -7.2314      1.00000
+     10      -7.0173      1.00000
+     11      -0.7638      1.00000
+     12       0.2811      1.00000
+     13       0.2811      1.00000
+     14       0.9225      1.00000
+     15       0.9225      1.00000
+     16       1.1167      1.00000
+     17       1.1625      1.00000
+     18       2.3329      1.00000
+     19       2.3329      1.00000
+     20       4.8539      0.00000
+     21       6.2210      0.00000
+     22       6.2210      0.00000
+     23       6.9072      0.00000
+     24       8.6846      0.00000
+
+ k-point    47 :       0.1250    0.0000    0.3750
+  band No.  band energies     occupation 
+      1     -30.0805      1.00000
+      2     -29.9300      1.00000
+      3     -29.9226      1.00000
+      4     -22.1163      1.00000
+      5     -13.9908      1.00000
+      6     -13.3361      1.00000
+      7     -13.1697      1.00000
+      8      -7.2697      1.00000
+      9      -7.2052      1.00000
+     10      -7.0427      1.00000
+     11      -0.7878      1.00000
+     12       0.0561      1.00000
+     13       0.2960      1.00000
+     14       0.4549      1.00000
+     15       0.8016      1.00000
+     16       1.2503      1.00000
+     17       1.6580      1.00000
+     18       2.1248      1.00000
+     19       2.1425      1.00000
+     20       5.1303      0.00000
+     21       6.1369      0.00000
+     22       6.2224      0.00000
+     23       7.2069      0.00000
+     24       8.6761      0.00000
+
+ k-point    48 :       0.2500    0.0000    0.3750
+  band No.  band energies     occupation 
+      1     -30.0795      1.00000
+      2     -29.9473      1.00000
+      3     -29.9219      1.00000
+      4     -22.0886      1.00000
+      5     -13.8467      1.00000
+      6     -13.3964      1.00000
+      7     -13.1441      1.00000
+      8      -7.3373      1.00000
+      9      -7.1402      1.00000
+     10      -7.1215      1.00000
+     11      -0.8430      1.00000
+     12      -0.4911      1.00000
+     13       0.0291      1.00000
+     14       0.3150      1.00000
+     15       0.5484      1.00000
+     16       1.4187      1.00000
+     17       1.7173      1.00000
+     18       1.8721      1.00000
+     19       2.1921      1.00000
+     20       5.6982      0.00000
+     21       6.1996      0.00000
+     22       6.2282      0.00000
+     23       7.5236      0.00000
+     24       9.1135      0.00000
+
+ k-point    49 :       0.3750    0.0000    0.3750
+  band No.  band energies     occupation 
+      1     -30.0784      1.00000
+      2     -29.9645      1.00000
+      3     -29.9213      1.00000
+      4     -22.0604      1.00000
+      5     -13.7351      1.00000
+      6     -13.4101      1.00000
+      7     -13.1267      1.00000
+      8      -7.3712      1.00000
+      9      -7.2235      1.00000
+     10      -7.0726      1.00000
+     11      -0.9904      1.00000
+     12      -0.8507      1.00000
+     13      -0.4122      1.00000
+     14       0.1728      1.00000
+     15       0.4972      1.00000
+     16       1.3622      1.00000
+     17       1.6023      1.00000
+     18       1.8838      1.00000
+     19       2.3856      1.00000
+     20       6.1880      0.00000
+     21       6.2451      0.00000
+     22       6.4411      0.00000
+     23       7.6319      0.00000
+     24       9.4929      0.00000
+
+ k-point    50 :       0.5000    0.0000    0.3750
+  band No.  band energies     occupation 
+      1     -30.0780      1.00000
+      2     -29.9715      1.00000
+      3     -29.9210      1.00000
+      4     -22.0487      1.00000
+      5     -13.7151      1.00000
+      6     -13.3812      1.00000
+      7     -13.1258      1.00000
+      8      -7.3671      1.00000
+      9      -7.2807      1.00000
+     10      -7.0438      1.00000
+     11      -1.1443      1.00000
+     12      -0.9153      1.00000
+     13      -0.5721      1.00000
+     14       0.0732      1.00000
+     15       0.5375      1.00000
+     16       1.2119      1.00000
+     17       1.7661      1.00000
+     18       1.8167      1.00000
+     19       2.4366      1.00000
+     20       6.2359      0.00000
+     21       6.3969      0.00000
+     22       6.5838      0.00000
+     23       7.6508      0.00000
+     24       9.6034      0.00000
+
+ k-point    51 :       0.1250    0.1250    0.3750
+  band No.  band energies     occupation 
+      1     -30.0801      1.00000
+      2     -29.9298      1.00000
+      3     -29.9297      1.00000
+      4     -22.1052      1.00000
+      5     -13.9290      1.00000
+      6     -13.3544      1.00000
+      7     -13.1598      1.00000
+      8      -7.3449      1.00000
+      9      -7.2112      1.00000
+     10      -7.0348      1.00000
+     11      -0.8028      1.00000
+     12      -0.0853      1.00000
+     13       0.1950      1.00000
+     14       0.3817      1.00000
+     15       0.6277      1.00000
+     16       1.5055      1.00000
+     17       1.6919      1.00000
+     18       1.8610      1.00000
+     19       2.1681      1.00000
+     20       5.3388      0.00000
+     21       6.1299      0.00000
+     22       6.1882      0.00000
+     23       7.5622      0.00000
+     24       8.7669      0.00000
+
+ k-point    52 :       0.2500    0.1250    0.3750
+  band No.  band energies     occupation 
+      1     -30.0791      1.00000
+      2     -29.9470      1.00000
+      3     -29.9291      1.00000
+      4     -22.0782      1.00000
+      5     -13.7846      1.00000
+      6     -13.3922      1.00000
+      7     -13.1344      1.00000
+      8      -7.4349      1.00000
+      9      -7.2740      1.00000
+     10      -7.0535      1.00000
+     11      -0.8403      1.00000
+     12      -0.5046      1.00000
+     13      -0.0188      1.00000
+     14       0.2486      1.00000
+     15       0.5158      1.00000
+     16       1.1806      1.00000
+     17       1.7500      1.00000
+     18       2.0612      1.00000
+     19       2.1703      1.00000
+     20       5.8129      0.00000
+     21       6.1849      0.00000
+     22       6.2517      0.00000
+     23       7.9759      0.00000
+     24       9.1034      0.00000
+
+ k-point    53 :       0.3750    0.1250    0.3750
+  band No.  band energies     occupation 
+      1     -30.0781      1.00000
+      2     -29.9641      1.00000
+      3     -29.9284      1.00000
+      4     -22.0508      1.00000
+      5     -13.6770      1.00000
+      6     -13.3821      1.00000
+      7     -13.1144      1.00000
+      8      -7.4635      1.00000
+      9      -7.3504      1.00000
+     10      -7.1124      1.00000
+     11      -1.0011      1.00000
+     12      -0.7353      1.00000
+     13      -0.4023      1.00000
+     14       0.1797      1.00000
+     15       0.4361      1.00000
+     16       0.9551      1.00000
+     17       1.7915      1.00000
+     18       2.0664      1.00000
+     19       2.3776      1.00000
+     20       6.2037      0.00000
+     21       6.2887      0.00000
+     22       6.4817      0.00000
+     23       8.0898      0.00000
+     24       9.4724      0.00000
+
+ k-point    54 :       0.5000    0.1250    0.3750
+  band No.  band energies     occupation 
+      1     -30.0777      1.00000
+      2     -29.9712      1.00000
+      3     -29.9281      1.00000
+      4     -22.0393      1.00000
+      5     -13.6594      1.00000
+      6     -13.3433      1.00000
+      7     -13.1122      1.00000
+      8      -7.4544      1.00000
+      9      -7.3876      1.00000
+     10      -7.1500      1.00000
+     11      -1.1513      1.00000
+     12      -0.7261      1.00000
+     13      -0.5744      1.00000
+     14       0.1098      1.00000
+     15       0.4598      1.00000
+     16       0.8506      1.00000
+     17       1.8722      1.00000
+     18       2.0340      1.00000
+     19       2.4340      1.00000
+     20       6.2311      0.00000
+     21       6.4590      0.00000
+     22       6.6203      0.00000
+     23       8.0987      0.00000
+     24       9.5901      0.00000
+
+ k-point    55 :       0.2500    0.2500    0.3750
+  band No.  band energies     occupation 
+      1     -30.0782      1.00000
+      2     -29.9464      1.00000
+      3     -29.9461      1.00000
+      4     -22.0528      1.00000
+      5     -13.6443      1.00000
+      6     -13.3704      1.00000
+      7     -13.1086      1.00000
+      8      -7.6030      1.00000
+      9      -7.4206      1.00000
+     10      -7.1257      1.00000
+     11      -0.8705      1.00000
+     12      -0.5192      1.00000
+     13      -0.1502      1.00000
+     14       0.0641      1.00000
+     15       0.4686      1.00000
+     16       0.6654      1.00000
+     17       2.0448      1.00000
+     18       2.1490      1.00000
+     19       2.2930      1.00000
+     20       6.1150      0.00000
+     21       6.2974      0.00000
+     22       6.3447      0.00000
+     23       8.7293      0.00000
+     24       9.0953      0.00000
+
+ k-point    56 :       0.3750    0.2500    0.3750
+  band No.  band energies     occupation 
+      1     -30.0772      1.00000
+      2     -29.9633      1.00000
+      3     -29.9455      1.00000
+      4     -22.0272      1.00000
+      5     -13.5517      1.00000
+      6     -13.2944      1.00000
+      7     -13.0846      1.00000
+      8      -7.6810      1.00000
+      9      -7.5557      1.00000
+     10      -7.2884      1.00000
+     11      -1.0317      1.00000
+     12      -0.5663      1.00000
+     13      -0.3154      1.00000
+     14      -0.0461      1.00000
+     15       0.3747      1.00000
+     16       0.4849      1.00000
+     17       2.0595      1.00000
+     18       2.3470      1.00000
+     19       2.4514      1.00000
+     20       6.3640      0.00000
+     21       6.4785      0.00000
+     22       6.5752      0.00000
+     23       8.8637      0.00000
+     24       9.4168      0.00000
+
+ k-point    57 :       0.5000    0.2500    0.3750
+  band No.  band energies     occupation 
+      1     -30.0769      1.00000
+      2     -29.9704      1.00000
+      3     -29.9452      1.00000
+      4     -22.0165      1.00000
+      5     -13.5352      1.00000
+      6     -13.2346      1.00000
+      7     -13.0792      1.00000
+      8      -7.6588      1.00000
+      9      -7.6345      1.00000
+     10      -7.3840      1.00000
+     11      -1.1784      1.00000
+     12      -0.5757      1.00000
+     13      -0.3139      1.00000
+     14      -0.1208      1.00000
+     15       0.3516      1.00000
+     16       0.4500      1.00000
+     17       2.0682      1.00000
+     18       2.4132      1.00000
+     19       2.5032      1.00000
+     20       6.3995      0.00000
+     21       6.6253      0.00000
+     22       6.7086      0.00000
+     23       8.8097      0.00000
+     24       9.5718      0.00000
+
+ k-point    58 :       0.3750    0.3750    0.3750
+  band No.  band energies     occupation 
+      1     -30.0764      1.00000
+      2     -29.9626      1.00000
+      3     -29.9624      1.00000
+      4     -22.0034      1.00000
+      5     -13.4585      1.00000
+      6     -13.1655      1.00000
+      7     -13.0552      1.00000
+      8      -7.8412      1.00000
+      9      -7.7430      1.00000
+     10      -7.5070      1.00000
+     11      -1.1532      1.00000
+     12      -0.5775      1.00000
+     13      -0.5010      1.00000
+     14      -0.0132      1.00000
+     15       0.3247      1.00000
+     16       0.3845      1.00000
+     17       2.2710      1.00000
+     18       2.3885      1.00000
+     19       2.7600      1.00000
+     20       6.6243      0.00000
+     21       6.6463      0.00000
+     22       6.7392      0.00000
+     23       9.0023      0.00000
+     24       9.6147      0.00000
+
+ k-point    59 :       0.5000    0.3750    0.3750
+  band No.  band energies     occupation 
+      1     -30.0760      1.00000
+      2     -29.9696      1.00000
+      3     -29.9622      1.00000
+      4     -21.9934      1.00000
+      5     -13.4291      1.00000
+      6     -13.0973      1.00000
+      7     -13.0461      1.00000
+      8      -7.8552      1.00000
+      9      -7.8539      1.00000
+     10      -7.6078      1.00000
+     11      -1.2810      1.00000
+     12      -0.6587      1.00000
+     13      -0.4967      1.00000
+     14       0.0151      1.00000
+     15       0.3291      1.00000
+     16       0.3906      1.00000
+     17       2.3216      1.00000
+     18       2.4377      1.00000
+     19       2.8806      1.00000
+     20       6.6726      0.00000
+     21       6.7734      0.00000
+     22       6.8525      0.00000
+     23       8.8939      0.00000
+     24       9.6560      0.00000
+
+ k-point    60 :       0.5000    0.5000    0.3750
+  band No.  band energies     occupation 
+      1     -30.0757      1.00000
+      2     -29.9692      1.00000
+      3     -29.9692      1.00000
+      4     -21.9838      1.00000
+      5     -13.3898      1.00000
+      6     -13.0324      1.00000
+      7     -13.0324      1.00000
+      8      -7.9345      1.00000
+      9      -7.9345      1.00000
+     10      -7.7018      1.00000
+     11      -1.3861      1.00000
+     12      -0.7654      1.00000
+     13      -0.5173      1.00000
+     14       0.0977      1.00000
+     15       0.3691      1.00000
+     16       0.3691      1.00000
+     17       2.4471      1.00000
+     18       2.4471      1.00000
+     19       3.0300      1.00000
+     20       6.8100      0.00000
+     21       6.8100      0.00000
+     22       6.9556      0.00000
+     23       8.7674      0.00000
+     24       9.6582      0.00000
+
+ k-point    61 :       0.0000    0.0000    0.5000
+  band No.  band energies     occupation 
+      1     -30.0849      1.00000
+      2     -29.9227      1.00000
+      3     -29.9227      1.00000
+      4     -22.1174      1.00000
+      5     -14.0829      1.00000
+      6     -13.2773      1.00000
+      7     -13.1770      1.00000
+      8      -7.2171      1.00000
+      9      -7.2171      1.00000
+     10      -6.9547      1.00000
+     11      -0.9510      1.00000
+     12       0.2194      1.00000
+     13       0.2194      1.00000
+     14       0.8775      1.00000
+     15       0.8775      1.00000
+     16       0.9790      1.00000
+     17       1.0782      1.00000
+     18       2.3076      1.00000
+     19       2.3076      1.00000
+     20       4.8716      0.00000
+     21       6.3592      0.00000
+     22       6.3592      0.00000
+     23       6.9075      0.00000
+     24       8.7054      0.00000
+
+ k-point    62 :       0.1250    0.0000    0.5000
+  band No.  band energies     occupation 
+      1     -30.0844      1.00000
+      2     -29.9299      1.00000
+      3     -29.9225      1.00000
+      4     -22.1066      1.00000
+      5     -14.0134      1.00000
+      6     -13.3096      1.00000
+      7     -13.1661      1.00000
+      8      -7.2518      1.00000
+      9      -7.1903      1.00000
+     10      -7.0062      1.00000
+     11      -0.9673      1.00000
+     12       0.0003      1.00000
+     13       0.2360      1.00000
+     14       0.3636      1.00000
+     15       0.7563      1.00000
+     16       1.1694      1.00000
+     17       1.6404      1.00000
+     18       2.0929      1.00000
+     19       2.0979      1.00000
+     20       5.1449      0.00000
+     21       6.2753      0.00000
+     22       6.3599      0.00000
+     23       7.2088      0.00000
+     24       8.8705      0.00000
+
+ k-point    63 :       0.2500    0.0000    0.5000
+  band No.  band energies     occupation 
+      1     -30.0833      1.00000
+      2     -29.9471      1.00000
+      3     -29.9218      1.00000
+      4     -22.0804      1.00000
+      5     -13.8355      1.00000
+      6     -13.3892      1.00000
+      7     -13.1452      1.00000
+      8      -7.3271      1.00000
+      9      -7.1262      1.00000
+     10      -7.1240      1.00000
+     11      -1.0027      1.00000
+     12      -0.5731      1.00000
+     13      -0.0459      1.00000
+     14       0.2720      1.00000
+     15       0.4886      1.00000
+     16       1.4614      1.00000
+     17       1.6852      1.00000
+     18       1.8744      1.00000
+     19       2.1681      1.00000
+     20       5.7093      0.00000
+     21       6.3184      0.00000
+     22       6.3628      0.00000
+     23       7.5345      0.00000
+     24       9.3262      0.00000
+
+ k-point    64 :       0.3750    0.0000    0.5000
+  band No.  band energies     occupation 
+      1     -30.0822      1.00000
+      2     -29.9642      1.00000
+      3     -29.9212      1.00000
+      4     -22.0537      1.00000
+      5     -13.6345      1.00000
+      6     -13.4695      1.00000
+      7     -13.1413      1.00000
+      8      -7.3917      1.00000
+      9      -7.2397      1.00000
+     10      -7.0548      1.00000
+     11      -1.0730      1.00000
+     12      -0.9839      1.00000
+     13      -0.5170      1.00000
+     14       0.1558      1.00000
+     15       0.4110      1.00000
+     16       1.3268      1.00000
+     17       1.7428      1.00000
+     18       1.9076      1.00000
+     19       2.4443      1.00000
+     20       6.2065      0.00000
+     21       6.3674      0.00000
+     22       6.5163      0.00000
+     23       7.6483      0.00000
+     24       9.7568      0.00000
+
+ k-point    65 :       0.5000    0.0000    0.5000
+  band No.  band energies     occupation 
+      1     -30.0818      1.00000
+      2     -29.9713      1.00000
+      3     -29.9209      1.00000
+      4     -22.0426      1.00000
+      5     -13.5399      1.00000
+      6     -13.5002      1.00000
+      7     -13.1518      1.00000
+      8      -7.4155      1.00000
+      9      -7.2847      1.00000
+     10      -7.0253      1.00000
+     11      -1.2012      1.00000
+     12      -1.0514      1.00000
+     13      -0.7019      1.00000
+     14       0.0549      1.00000
+     15       0.4504      1.00000
+     16       1.1771      1.00000
+     17       1.8596      1.00000
+     18       1.9493      1.00000
+     19       2.5221      1.00000
+     20       6.3694      0.00000
+     21       6.4022      0.00000
+     22       6.6353      0.00000
+     23       7.6672      0.00000
+     24       9.9060      0.00000
+
+ k-point    66 :       0.1250    0.1250    0.5000
+  band No.  band energies     occupation 
+      1     -30.0840      1.00000
+      2     -29.9297      1.00000
+      3     -29.9295      1.00000
+      4     -22.0961      1.00000
+      5     -13.9437      1.00000
+      6     -13.3330      1.00000
+      7     -13.1543      1.00000
+      8      -7.3455      1.00000
+      9      -7.1388      1.00000
+     10      -7.0612      1.00000
+     11      -0.9713      1.00000
+     12      -0.1394      1.00000
+     13       0.1606      1.00000
+     14       0.2661      1.00000
+     15       0.5815      1.00000
+     16       1.6266      1.00000
+     17       1.6474      1.00000
+     18       1.6997      1.00000
+     19       2.1269      1.00000
+     20       5.3555      0.00000
+     21       6.2668      0.00000
+     22       6.3262      0.00000
+     23       7.5580      0.00000
+     24       8.9706      0.00000
+
+ k-point    67 :       0.2500    0.1250    0.5000
+  band No.  band energies     occupation 
+      1     -30.0829      1.00000
+      2     -29.9468      1.00000
+      3     -29.9289      1.00000
+      4     -22.0703      1.00000
+      5     -13.7651      1.00000
+      6     -13.3921      1.00000
+      7     -13.1304      1.00000
+      8      -7.4498      1.00000
+      9      -7.1956      1.00000
+     10      -7.1237      1.00000
+     11      -0.9792      1.00000
+     12      -0.5789      1.00000
+     13      -0.0700      1.00000
+     14       0.1789      1.00000
+     15       0.4783      1.00000
+     16       1.2583      1.00000
+     17       1.7108      1.00000
+     18       2.0292      1.00000
+     19       2.1627      1.00000
+     20       5.8324      0.00000
+     21       6.3125      0.00000
+     22       6.3725      0.00000
+     23       7.9793      0.00000
+     24       9.3196      0.00000
+
+ k-point    68 :       0.3750    0.1250    0.5000
+  band No.  band energies     occupation 
+      1     -30.0819      1.00000
+      2     -29.9639      1.00000
+      3     -29.9283      1.00000
+      4     -22.0442      1.00000
+      5     -13.5631      1.00000
+      6     -13.4539      1.00000
+      7     -13.1228      1.00000
+      8      -7.4992      1.00000
+      9      -7.3205      1.00000
+     10      -7.1587      1.00000
+     11      -1.0745      1.00000
+     12      -0.8395      1.00000
+     13      -0.4987      1.00000
+     14       0.1583      1.00000
+     15       0.3884      1.00000
+     16       0.9640      1.00000
+     17       1.8759      1.00000
+     18       2.0664      1.00000
+     19       2.4494      1.00000
+     20       6.2798      0.00000
+     21       6.3588      0.00000
+     22       6.5566      0.00000
+     23       8.1027      0.00000
+     24       9.7182      0.00000
+
+ k-point    69 :       0.5000    0.1250    0.5000
+  band No.  band energies     occupation 
+      1     -30.0814      1.00000
+      2     -29.9709      1.00000
+      3     -29.9280      1.00000
+      4     -22.0333      1.00000
+      5     -13.4824      1.00000
+      6     -13.4625      1.00000
+      7     -13.1324      1.00000
+      8      -7.5055      1.00000
+      9      -7.3720      1.00000
+     10      -7.1835      1.00000
+     11      -1.2058      1.00000
+     12      -0.8146      1.00000
+     13      -0.7062      1.00000
+     14       0.0992      1.00000
+     15       0.4203      1.00000
+     16       0.8227      1.00000
+     17       1.9612      1.00000
+     18       2.1080      1.00000
+     19       2.5323      1.00000
+     20       6.3637      0.00000
+     21       6.4705      0.00000
+     22       6.6735      0.00000
+     23       8.1087      0.00000
+     24       9.8650      0.00000
+
+ k-point    70 :       0.2500    0.2500    0.5000
+  band No.  band energies     occupation 
+      1     -30.0820      1.00000
+      2     -29.9462      1.00000
+      3     -29.9459      1.00000
+      4     -22.0459      1.00000
+      5     -13.5862      1.00000
+      6     -13.4021      1.00000
+      7     -13.0979      1.00000
+      8      -7.6350      1.00000
+      9      -7.3537      1.00000
+     10      -7.2292      1.00000
+     11      -0.9767      1.00000
+     12      -0.5761      1.00000
+     13      -0.1547      1.00000
+     14      -0.0471      1.00000
+     15       0.4555      1.00000
+     16       0.7402      1.00000
+     17       2.0606      1.00000
+     18       2.1931      1.00000
+     19       2.2381      1.00000
+     20       6.1475      0.00000
+     21       6.4059      0.00000
+     22       6.4556      0.00000
+     23       8.7094      0.00000
+     24       9.3232      0.00000
+
+ k-point    71 :       0.3750    0.2500    0.5000
+  band No.  band energies     occupation 
+      1     -30.0810      1.00000
+      2     -29.9631      1.00000
+      3     -29.9453      1.00000
+      4     -22.0211      1.00000
+      5     -13.4171      1.00000
+      6     -13.3838      1.00000
+      7     -13.0784      1.00000
+      8      -7.7271      1.00000
+      9      -7.5163      1.00000
+     10      -7.4036      1.00000
+     11      -1.1044      1.00000
+     12      -0.6456      1.00000
+     13      -0.3246      1.00000
+     14      -0.0923      1.00000
+     15       0.3826      1.00000
+     16       0.5035      1.00000
+     17       2.1508      1.00000
+     18       2.3852      1.00000
+     19       2.4780      1.00000
+     20       6.4632      0.00000
+     21       6.5197      0.00000
+     22       6.6482      0.00000
+     23       8.8912      0.00000
+     24       9.5682      0.00000
+
+ k-point    72 :       0.5000    0.2500    0.5000
+  band No.  band energies     occupation 
+      1     -30.0806      1.00000
+      2     -29.9702      1.00000
+      3     -29.9451      1.00000
+      4     -22.0108      1.00000
+      5     -13.4230      1.00000
+      6     -13.2846      1.00000
+      7     -13.0844      1.00000
+      8      -7.7166      1.00000
+      9      -7.6093      1.00000
+     10      -7.4934      1.00000
+     11      -1.2306      1.00000
+     12      -0.7107      1.00000
+     13      -0.2863      1.00000
+     14      -0.1094      1.00000
+     15       0.3603      1.00000
+     16       0.4089      1.00000
+     17       2.1827      1.00000
+     18       2.4763      1.00000
+     19       2.5673      1.00000
+     20       6.5127      0.00000
+     21       6.6491      0.00000
+     22       6.7644      0.00000
+     23       8.8131      0.00000
+     24       9.7307      0.00000
+
+ k-point    73 :       0.3750    0.3750    0.5000
+  band No.  band energies     occupation 
+      1     -30.0801      1.00000
+      2     -29.9624      1.00000
+      3     -29.9623      1.00000
+      4     -21.9978      1.00000
+      5     -13.3792      1.00000
+      6     -13.1905      1.00000
+      7     -13.0389      1.00000
+      8      -7.8994      1.00000
+      9      -7.7439      1.00000
+     10      -7.6298      1.00000
+     11      -1.2154      1.00000
+     12      -0.6218      1.00000
+     13      -0.5758      1.00000
+     14       0.0601      1.00000
+     15       0.3461      1.00000
+     16       0.3985      1.00000
+     17       2.3940      1.00000
+     18       2.5133      1.00000
+     19       2.7355      1.00000
+     20       6.6983      0.00000
+     21       6.7185      0.00000
+     22       6.7769      0.00000
+     23       9.1352      0.00000
+     24       9.4700      0.00000
+
+ k-point    74 :       0.5000    0.3750    0.5000
+  band No.  band energies     occupation 
+      1     -30.0798      1.00000
+      2     -29.9694      1.00000
+      3     -29.9620      1.00000
+      4     -21.9881      1.00000
+      5     -13.3637      1.00000
+      6     -13.0949      1.00000
+      7     -13.0346      1.00000
+      8      -7.9202      1.00000
+      9      -7.8888      1.00000
+     10      -7.7130      1.00000
+     11      -1.3288      1.00000
+     12      -0.7161      1.00000
+     13      -0.5943      1.00000
+     14       0.1899      1.00000
+     15       0.3163      1.00000
+     16       0.3948      1.00000
+     17       2.4564      1.00000
+     18       2.5760      1.00000
+     19       2.8768      1.00000
+     20       6.7523      0.00000
+     21       6.8284      0.00000
+     22       6.8833      0.00000
+     23       8.9687      0.00000
+     24       9.4968      0.00000
+
+ k-point    75 :       0.5000    0.5000    0.5000
+  band No.  band energies     occupation 
+      1     -30.0794      1.00000
+      2     -29.9690      1.00000
+      3     -29.9690      1.00000
+      4     -21.9786      1.00000
+      5     -13.3384      1.00000
+      6     -13.0135      1.00000
+      7     -13.0135      1.00000
+      8      -8.0027      1.00000
+      9      -8.0027      1.00000
+     10      -7.7949      1.00000
+     11      -1.4270      1.00000
+     12      -0.7638      1.00000
+     13      -0.6926      1.00000
+     14       0.2808      1.00000
+     15       0.3954      1.00000
+     16       0.3954      1.00000
+     17       2.5882      1.00000
+     18       2.5882      1.00000
+     19       3.0390      1.00000
+     20       6.8708      0.00000
+     21       6.8708      0.00000
+     22       6.9803      0.00000
+     23       8.9029      0.00000
+     24       9.3307      0.00000
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ soft charge-density along one line, spin component           1
+         0         1         2         3         4         5         6         7         8         9
+ total charge-density along one line
+ 
+ soft charge-density along one line, spin component           2
+         0         1         2         3         4         5         6         7         8         9
+ total charge-density along one line
+ 
+ pseudopotential strength for first ion, spin component:           1
+  1.307  -5.118   0.000  -0.008   0.000   0.000   0.001   0.000
+ -5.118   0.738  -0.000   0.005  -0.000   0.000  -0.002   0.000
+  0.000  -0.000  -7.657   0.000   0.000   4.478   0.000   0.000
+ -0.008   0.005   0.000  -7.659   0.000   0.000   4.476   0.000
+  0.000  -0.000   0.000   0.000  -7.657   0.000   0.000   4.478
+  0.000   0.000   4.478   0.000   0.000   6.736  -0.000  -0.000
+  0.001  -0.002   0.000   4.476   0.000  -0.000   6.738  -0.000
+  0.000   0.000   0.000   0.000   4.478  -0.000  -0.000   6.736
+  0.000  -0.000  -0.000  -0.000   0.000  -0.000  -0.000   0.000
+  0.000  -0.000  -0.003   0.000  -0.000  -0.001   0.000  -0.000
+ -0.001   0.001  -0.000  -0.003  -0.000  -0.000  -0.000  -0.000
+  0.000  -0.000  -0.000   0.000  -0.003  -0.000   0.000  -0.001
+ -0.000   0.000  -0.000   0.000   0.000  -0.000   0.000   0.000
+  0.000  -0.000   0.000  -0.000   0.000  -0.000  -0.000   0.000
+  0.000  -0.000  -0.004   0.000  -0.000  -0.001   0.000  -0.000
+ -0.002   0.001  -0.000  -0.004  -0.000  -0.000  -0.001  -0.000
+  0.000  -0.000  -0.000   0.000  -0.004  -0.000   0.000  -0.001
+ -0.000   0.000  -0.000   0.000   0.000  -0.000   0.000   0.000
+ pseudopotential strength for first ion, spin component:           2
+  1.307  -5.118   0.000  -0.008   0.000   0.000   0.001   0.000
+ -5.118   0.738  -0.000   0.005  -0.000   0.000  -0.002   0.000
+  0.000  -0.000  -7.657   0.000  -0.000   4.478   0.000  -0.000
+ -0.008   0.005   0.000  -7.659   0.000   0.000   4.476   0.000
+  0.000  -0.000  -0.000   0.000  -7.657  -0.000   0.000   4.478
+  0.000   0.000   4.478   0.000  -0.000   6.736  -0.000   0.000
+  0.001  -0.002   0.000   4.476   0.000  -0.000   6.738  -0.000
+  0.000   0.000  -0.000   0.000   4.478   0.000  -0.000   6.736
+ -0.000   0.000  -0.000   0.000   0.000  -0.000   0.000   0.000
+  0.000  -0.000  -0.003   0.000   0.000  -0.001   0.000   0.000
+ -0.001   0.001  -0.000  -0.003  -0.000  -0.000  -0.000  -0.000
+  0.000  -0.000   0.000   0.000  -0.003   0.000   0.000  -0.001
+ -0.000   0.000  -0.000   0.000   0.000  -0.000   0.000   0.000
+ -0.000   0.000  -0.000   0.000   0.000  -0.000   0.000   0.000
+  0.000  -0.000  -0.004   0.000   0.000  -0.001   0.000   0.000
+ -0.002   0.001  -0.000  -0.004  -0.000  -0.000  -0.001  -0.000
+  0.000  -0.000   0.000   0.000  -0.004   0.000   0.000  -0.001
+ -0.000   0.000  -0.000   0.000   0.000  -0.000   0.000   0.000
+ total augmentation occupancy for first ion, spin component:           1
+  2.004  -0.005   0.000  -0.001   0.000   0.000  -0.001   0.000   0.000   0.000  -0.003   0.000   0.000   0.000   0.000   0.000
+ -0.005   0.386   0.000  -0.027   0.000   0.000   0.006   0.000   0.000   0.000  -0.026   0.000   0.000   0.000  -0.000   0.015
+  0.000   0.000   2.020  -0.000   0.000  -0.008   0.000   0.000   0.000  -0.042  -0.000   0.000   0.000   0.000   0.017   0.000
+ -0.001  -0.027  -0.000   2.021   0.000   0.000  -0.010   0.000   0.000   0.000  -0.027   0.000   0.000   0.000   0.000   0.010
+  0.000   0.000   0.000   0.000   2.020   0.000   0.000  -0.008   0.000   0.000   0.000  -0.042   0.000  -0.000   0.000   0.000
+  0.000   0.000  -0.008   0.000   0.000   0.010  -0.000   0.000   0.000   0.013   0.000   0.000   0.000   0.000  -0.007   0.000
+ -0.001   0.006   0.000  -0.010   0.000  -0.000   0.009   0.000   0.000  -0.000   0.010   0.000   0.000   0.000   0.000  -0.006
+  0.000   0.000   0.000   0.000  -0.008   0.000   0.000   0.010  -0.000   0.000   0.000   0.013   0.000  -0.000   0.000   0.000
+  0.000   0.000   0.000   0.000   0.000   0.000   0.000  -0.000   2.835   0.000   0.000   0.000   0.000  -1.509   0.000   0.000
+  0.000   0.000  -0.042   0.000   0.000   0.013  -0.000   0.000   0.000   2.591  -0.000   0.000   0.000   0.000  -1.368   0.000
+ -0.003  -0.026   0.000  -0.027   0.000   0.000   0.010   0.000   0.000  -0.000   1.747   0.000   0.000   0.000   0.000  -0.920
+  0.000   0.000   0.000   0.000  -0.042   0.000   0.000   0.013  -0.000   0.000   0.000   2.591   0.000   0.000   0.000   0.000
+  0.000   0.000   0.000   0.000   0.000   0.000   0.000   0.000   0.000   0.000   0.000   0.000   1.639   0.000   0.000   0.000
+  0.000   0.000   0.000   0.000  -0.000   0.000   0.000  -0.000  -1.509   0.000   0.000  -0.000   0.000   0.804   0.000   0.000
+  0.000   0.000   0.017  -0.000   0.000  -0.007   0.000   0.000   0.000  -1.368   0.000   0.000   0.000   0.000   0.724   0.000
+  0.000   0.015  -0.000   0.010   0.000   0.000  -0.006   0.000   0.000  -0.000  -0.920   0.000   0.000   0.000   0.000   0.485
+  0.000   0.000   0.000   0.000   0.017   0.000   0.000  -0.007   0.000   0.000   0.000  -1.368   0.000   0.000   0.000   0.000
+  0.000   0.000   0.000   0.000   0.000   0.000   0.000   0.000  -0.000   0.000   0.000   0.000  -0.859   0.000   0.000   0.000
+ total augmentation occupancy for first ion, spin component:           2
+ -0.000  -0.000   0.000  -0.000   0.000   0.000  -0.000   0.000   0.000   0.000   0.000   0.000   0.000   0.000   0.000  -0.000
+ -0.000   0.000   0.000  -0.000   0.000   0.000   0.000   0.000   0.000   0.000   0.000   0.000   0.000   0.000   0.000  -0.000
+  0.000   0.000  -0.000   0.000   0.000   0.000   0.000   0.000   0.000   0.000   0.000   0.000   0.000   0.000  -0.000   0.000
+ -0.000  -0.000   0.000  -0.000   0.000   0.000   0.000   0.000   0.000  -0.000   0.000   0.000   0.000   0.000   0.000  -0.000
+  0.000   0.000   0.000   0.000  -0.000   0.000   0.000   0.000   0.000   0.000   0.000   0.000   0.000   0.000   0.000   0.000
+  0.000   0.000   0.000   0.000   0.000  -0.000   0.000   0.000   0.000  -0.000  -0.000   0.000   0.000   0.000   0.000   0.000
+ -0.000   0.000   0.000   0.000   0.000   0.000  -0.000   0.000   0.000   0.000   0.000   0.000   0.000   0.000   0.000  -0.000
+  0.000   0.000   0.000   0.000   0.000   0.000   0.000  -0.000   0.000  -0.000   0.000  -0.000   0.000  -0.000   0.000   0.000
+  0.000   0.000   0.000   0.000   0.000   0.000   0.000   0.000   0.000   0.000   0.000   0.000   0.000  -0.000  -0.000   0.000
+  0.000   0.000   0.000  -0.000   0.000  -0.000   0.000  -0.000   0.000   0.000  -0.000   0.000   0.000   0.000  -0.000   0.000
+  0.000   0.000   0.000   0.000   0.000  -0.000   0.000   0.000   0.000  -0.000   0.000   0.000   0.000   0.000   0.000  -0.000
+  0.000   0.000   0.000   0.000   0.000   0.000   0.000  -0.000   0.000   0.000   0.000   0.000  -0.000   0.000   0.000   0.000
+  0.000   0.000   0.000   0.000   0.000   0.000   0.000   0.000   0.000   0.000   0.000  -0.000   0.000   0.000   0.000   0.000
+  0.000   0.000   0.000   0.000   0.000   0.000   0.000  -0.000  -0.000   0.000   0.000   0.000   0.000   0.000   0.000   0.000
+  0.000   0.000  -0.000   0.000   0.000   0.000   0.000   0.000  -0.000  -0.000   0.000   0.000   0.000   0.000   0.000   0.000
+ -0.000  -0.000   0.000  -0.000   0.000   0.000  -0.000   0.000   0.000   0.000  -0.000   0.000   0.000   0.000   0.000   0.000
+  0.000   0.000   0.000   0.000  -0.000   0.000   0.000   0.000   0.000   0.000   0.000  -0.000   0.000  -0.000   0.000   0.000
+  0.000   0.000  -0.000   0.000   0.000   0.000   0.000  -0.000   0.000   0.000   0.000   0.000  -0.000  -0.000   0.000   0.000
+
+
+------------------------ aborting loop because EDIFF is reached ----------------------------------------
+
+
+     CALCP:  cpu time  156.40: real time  156.35
+ 
+            Ionic dipole moment: p[ion]=(     0.00000     0.00000    -5.56684 ) electrons Angst
+ 
+    Spin resolved dipole moment: p[sp1]=(     2.00068    -2.00068     1.80837 ) electrons Angst
+                                 p[sp2]=(    -2.00044     2.00087     1.80837 ) electrons Angst
+ 
+ Total electronic dipole moment: p[elc]=(     0.00024     0.00019     3.61674 ) electrons Angst
+ 
+ 
+ 
+
+
+ total charge     
+ 
+# of ion     s       p       d       tot
+----------------------------------------
+  1        2.005   5.644   0.300   7.949
+  2        0.310   6.416   1.970   8.696
+  3        1.573   3.331   0.000   4.904
+  4        1.551   3.573   0.000   5.124
+  5        1.570   3.447   0.000   5.017
+------------------------------------------------
+tot        7.009  22.411   2.270  31.690
+ 
+
+
+ magnetization (x)
+ 
+# of ion     s       p       d       tot
+----------------------------------------
+  1       -0.000  -0.000  -0.000  -0.000
+  2       -0.000  -0.000  -0.000  -0.000
+  3       -0.000   0.000   0.000   0.000
+  4       -0.000   0.000   0.000  -0.000
+  5        0.000   0.000   0.000   0.000
+------------------------------------------------
+tot        0.000   0.000  -0.000   0.000
+ 
+    CHARGE:  cpu time    0.84: real time    0.85
+    FORLOC:  cpu time    0.00: real time    0.00
+    FORNL :  cpu time    3.70: real time    3.70
+    STRESS:  cpu time   10.85: real time   10.85
+    FORCOR:  cpu time    0.09: real time    0.09
+    FORHAR:  cpu time    0.01: real time    0.01
+    MIXING:  cpu time    0.00: real time    0.00
+    OFIELD:  cpu time    0.00: real time    0.00
+
+  FORCE on cell =-STRESS in cart. coord.  units (eV):
+  Direction    XX          YY          ZZ          XY          YZ          ZX
+  --------------------------------------------------------------------------------------
+  Alpha Z   248.24776   248.24776   248.24776
+  Ewald    -811.55432  -811.55432  -847.12548     0.00000     0.00000     0.00000
+  Hartree   230.75080   230.75080   199.44558    -0.00000    -0.00000    -0.00000
+  E(xc)    -171.32311  -171.32311  -171.41044     0.00000    -0.00000     0.00000
+  Local     -58.33309   -58.33309     9.35290    -0.00000    -0.00000     0.00000
+  n-local  -129.00210  -126.90702  -128.44621    -0.30807    -0.26838    -0.23975
+  augment    63.20085    63.20085    62.84554     0.00000     0.00000     0.00000
+  Kinetic   621.31788   632.59296   627.06673    -2.47476    -2.32032    -2.08777
+  Fock        0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+  -------------------------------------------------------------------------------------
+  Total      -0.01025    -0.01025    -0.02363     0.00000     0.00000     0.00000
+  in kB      -0.24322    -0.24322    -0.56084     0.00000     0.00000     0.00000
+  external pressure =       -0.35 kB  Pullay stress =        0.00 kB
+
+
+ VOLUME and BASIS-vectors are now :
+ -----------------------------------------------------------------------------
+  energy-cutoff  :      520.00
+  volume of cell :       67.50
+      direct lattice vectors                 reciprocal lattice vectors
+     4.001368000  0.000000000  0.000000000     0.249914529  0.000000000  0.000000000
+     0.000000000  4.001368000  0.000000000     0.000000000  0.249914529  0.000000000
+     0.000000000  0.000000000  4.215744000     0.000000000  0.000000000  0.237206054
+
+  length of vectors
+     4.001368000  4.001368000  4.215744000     0.249914529  0.249914529  0.237206054
+
+
+ FORCES acting on ions
+    electron-ion (+dipol)            ewald-force                    non-local-force                 convergence-correction
+ -----------------------------------------------------------------------------------------------
+   -.127E-13 -.134E-13 0.686E+01   0.443E-14 -.106E-13 -.594E+01   0.000E+00 -.867E-18 -.935E+00   -.167E-13 -.268E-14 0.105E-01
+   0.148E-12 0.114E-11 0.669E+02   0.559E-16 -.974E-14 -.664E+02   0.000E+00 -.694E-17 -.508E+00   -.235E-14 -.119E-13 0.279E-01
+   -.553E-14 0.191E-12 0.213E+02   -.187E-14 0.903E-14 -.223E+02   0.000E+00 0.000E+00 0.101E+01   -.491E-14 -.130E-13 -.241E-01
+   0.122E-12 -.217E-12 0.213E+02   0.636E-14 0.119E-13 -.223E+02   -.217E-18 0.217E-18 0.101E+01   -.147E-13 -.449E-14 -.241E-01
+   0.129E-12 0.170E-11 -.107E+03   -.771E-14 -.433E-16 0.117E+03   0.000E+00 0.000E+00 -.104E+02   -.818E-14 -.231E-13 0.949E-01
+ -----------------------------------------------------------------------------------------------
+   0.381E-12 0.279E-11 0.977E+01   0.127E-14 0.537E-15 0.000E+00   -.217E-18 -.759E-17 -.985E+01   -.469E-13 -.553E-13 0.852E-01
+ 
+ 
+ POSITION                                       TOTAL-FORCE (eV/Angst)
+ -----------------------------------------------------------------------------------
+      0.00000      0.00000      0.08547         0.000000      0.000000      0.000789
+      2.00068      2.00068      2.27166         0.000000     -0.000000      0.021834
+      0.00000      2.00068      2.07424         0.000000      0.000000      0.003339
+      2.00068      0.00000      2.07424         0.000000      0.000000      0.003339
+      2.00068      2.00068      4.09277         0.000000      0.000000     -0.029300
+ -----------------------------------------------------------------------------------
+    total drift:                                0.000000      0.000000      0.002964
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+  FREE ENERGIE OF THE ION-ELECTRON SYSTEM (eV)
+  ---------------------------------------------------
+  free  energy   TOTEN  =       -39.94310588 eV
+
+  energy  without entropy=      -39.94310588  energy(sigma->0) =      -39.94310588
+ 
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+    POTLOK:  cpu time    0.11: real time    0.11
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+     LOOP+:  cpu time  200.53: real time  200.52
+    4ORBIT:  cpu time    0.00: real time    0.00
+ 
+
+
+ total charge     
+ 
+# of ion     s       p       d       tot
+----------------------------------------
+  1        2.005   5.644   0.300   7.949
+  2        0.310   6.416   1.970   8.696
+  3        1.573   3.331   0.000   4.904
+  4        1.551   3.573   0.000   5.124
+  5        1.570   3.447   0.000   5.017
+------------------------------------------------
+tot        7.009  22.411   2.270  31.690
+ 
+
+
+ magnetization (x)
+ 
+# of ion     s       p       d       tot
+----------------------------------------
+  1       -0.000  -0.000  -0.000  -0.000
+  2       -0.000  -0.000  -0.000  -0.000
+  3       -0.000   0.000   0.000   0.000
+  4       -0.000   0.000   0.000  -0.000
+  5        0.000   0.000   0.000   0.000
+------------------------------------------------
+tot        0.000   0.000  -0.000   0.000
+ 
+ BZINTS: Fermi energy:  3.098148; 38.000000 electrons
+         Band energy:-334.969667;  BLOECHL correction:  0.000000
+
+ total amount of memory used by VASP on root node    53643. kBytes
+========================================================================
+
+   base      :      30000. kBytes
+   nonlr-proj:       3455. kBytes
+   fftplans  :       1162. kBytes
+   grid      :       5105. kBytes
+   one-center:        155. kBytes
+   wavefun   :      13766. kBytes
+ 
+  
+  
+ General timing and accounting informations for this job:
+ ========================================================
+  
+                  Total CPU time used (sec):      212.408
+                            User time (sec):      199.087
+                          System time (sec):       13.321
+                         Elapsed time (sec):      213.551
+  
+                   Maximum memory used (kb):      122636.
+                   Average memory used (kb):           0.
+  
+                          Minor page faults:      4144763
+                          Major page faults:            7
+                 Voluntary context switches:          729


### PR DESCRIPTION
Modified Outcar __init__ method:
* Check for ISPIN = 2 and if so set self.spin = True
* Check for LNONCOLLINEAR = T and if so set self.noncollinear = True
* Check for LCALCPOL = T and if so run read_lcalcpol

Modified Outcar read_lcalcpol method:
* If self.spin = True, read spin polarized dipole moment to properties p_sp1 and p_sp2

Added tests to vasp.tests.test_outputs for changes to Outcar under test_polarization
Added tests to MPStaticSet for LCALCPOL flag.
Added test_files/OUTCAR.BaTiO3.polar for Outcar polarization test

More polarization related pull requests that use these functions coming soon.