### PR TITLE
Make it easier for user to submit custom LDAUU

### DIFF
--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -201,6 +201,12 @@ class DictSet(VaspInputSet):
             scales with # of atoms, the latter does not. If both are
             present, EDIFF is preferred. To force such settings, just supply
             user_incar_settings={"EDIFF": 1e-5, "LDAU": False} for example.
+            The keys 'LDAUU', 'LDAUJ', 'LDAUL' are special cases since
+            pymatgen defines different values depending on what anions are
+            present in the structure, so these keys can be defined in one
+            of two ways, e.g. either {"LDAUU":{"O":{"Fe":5}}} to set LDAUU
+            for Fe to 5 in an oxide, or {"LDAUU":{"Fe":5}} to set LDAUU to
+            5 regardless of the input structure.
         user_kpoints_settings (dict): Allow user to override kpoints setting by
             supplying a dict. E.g., {"reciprocal_density": 1000}. Default is
             None.
@@ -283,7 +289,7 @@ class DictSet(VaspInputSet):
                                        for sym in poscar.site_symbols]
                     # else, use fallback LDAU value if it exists
                     else:
-                        incar[k] = [v[sym] if (sym in v.keys()) else 0 for sym in poscar.site_symbols]
+                        incar[k] = [v.get(sym, 0) for sym in poscar.site_symbols]
             elif k.startswith("EDIFF") and k != "EDIFFG":
                 if "EDIFF" not in settings and k == "EDIFF_PER_ATOM":
                     incar["EDIFF"] = float(v) * structure.num_sites

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -276,11 +276,14 @@ class DictSet(VaspInputSet):
                         m = dict([(site.specie.symbol, getattr(site, k.lower()))
                                   for site in structure])
                         incar[k] = [m[sym] for sym in poscar.site_symbols]
+                    # lookup specific LDAU if specified for most_electroneg atom
                     elif most_electroneg in v.keys():
-                        incar[k] = [v[most_electroneg].get(sym, 0)
-                                    for sym in poscar.site_symbols]
+                        if isinstance(v[most_electroneg], dict):
+                           incar[k] = [v[most_electroneg].get(sym, 0)
+                                       for sym in poscar.site_symbols]
+                    # else, use fallback LDAU value if it exists
                     else:
-                        incar[k] = [0] * len(poscar.site_symbols)
+                        incar[k] = [v[sym] if (sym in v.keys()) else 0 for sym in poscar.site_symbols]
             elif k.startswith("EDIFF") and k != "EDIFFG":
                 if "EDIFF" not in settings and k == "EDIFF_PER_ATOM":
                     incar["EDIFF"] = float(v) * structure.num_sites

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -169,6 +169,13 @@ class MITMPRelaxSetTest(unittest.TestCase):
 
         #Make sure Matproject sulfates are ok.
         self.assertEqual(MPRelaxSet(struct).incar['LDAUU'], [5.3, 0, 0])
+        
+        #test for default LDAUU value
+        
+        userset_ldauu_fallback = MPRelaxSet(struct,
+            user_incar_settings={'LDAUU': {'Fe': 5.0}}
+        )
+        self.assertEqual(userset_ldauu_fallback.incar['LDAUU'], [5.0, 0, 0])
 
     def test_get_kpoints(self):
         kpoints = MPRelaxSet(self.structure).kpoints


### PR DESCRIPTION
## Summary

Currently, it's non-obvious how a user would add a custom `LDAUU` value to their `user_incar_settings` that would be used in the general case (regardless of what anions are in the input structure).

From my reading of `sets.py` it seems like if a user wants to set (e.g.) a custom `LDAUU` value for Fe, they would need to see if their structure is (e.g.) an oxide and then supply `user_incar_settings={'LDAUU':{'O':{'Fe':5}}}`. This seems non-obvious, and also would mean that `user_incar_settings` needs to be customized for every structure. The only other way I can see to do this is to add a `LDAUU` site_property but, again, this would require modification of every input structure.

This PR would add a fallback option, so that e.g. `user_incar_settings={'LDAUU':{'Fe':5}}` would work as expected in the general case.

## Additional dependencies introduced (if any)

None

## TODO (if any)

I'm not sure the best way to fix this, PR has my suggestion which should work.