### PR TITLE
Fix for dielectric tensors read from OUTCAR not being symmetric

### DIFF
--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -1591,7 +1591,7 @@ class Outcar(MSONable):
                 if component == "IMAGINARY":
                     freq.append(float(toks[0]))
                 xx, yy, zz, xy, yz, xz = [float(t) for t in toks[1:]]
-                matrix = [[xx, xy, yz], [xy, yy, yz], [xz, yz, zz]]
+                matrix = [[xx, xy, xz], [xy, yy, yz], [xz, yz, zz]]
                 data[component].append(matrix)
             elif re.match(r"\s*\-+\s*", l):
                 count += 1

--- a/pymatgen/io/vasp/tests/test_outputs.py
+++ b/pymatgen/io/vasp/tests/test_outputs.py
@@ -490,6 +490,7 @@ class OutcarTest(unittest.TestCase):
         self.assertAlmostEqual(outcar.dielectric_tensor_function[0][0, 0], 8.96938800)
         self.assertAlmostEqual(outcar.dielectric_tensor_function[-1][0, 0], 7.36167000e-01 +1.53800000e-03j)
         self.assertEqual(len(outcar.frequencies), len(outcar.dielectric_tensor_function))
+        np.testing.assert_array_equal( outcar.dielectric_tensor_function[0], outcar.dielectric_tensor_function[0].transpose() )
 
     def test_read_elastic_tensor(self):
         filepath = os.path.join(test_dir, "OUTCAR.total_tensor.Li2O.gz")


### PR DESCRIPTION
## Summary

`Outcar.read_freq_dielectric()` had a typo when assigning the dielectic tensor components to full tensors, making the data stored in `self.dielectric_tensor_function` have asymmetric off-diagonal elements. This update fixes this.

* `read_freq_dielectric()` now generates symmetric dielectric tensors.