### PR TITLE
Warn MPRester user about need to install matproj.snl extras

### DIFF
--- a/pymatgen/matproj/rest.py
+++ b/pymatgen/matproj/rest.py
@@ -100,6 +100,14 @@ class MPRester(object):
             self.api_key = SETTINGS.get("PMG_MAPI_KEY", "")
         self.preamble = endpoint
         import requests
+        try:
+            from pybtex import __version__
+        except ImportError:
+            warnings.warn("If you query for structure data encoded using MP's "
+                          "Structure Notation Language (SNL) format and you use "
+                          "`mp_decode=True` (the default) for MPRester queries, "
+                          "you should install dependencies via "
+                          "`pip install pymatgen[matproj.snl]`.")
         self.session = requests.Session()
         self.session.headers = {"x-api-key": self.api_key}
 
@@ -946,4 +954,3 @@ class MPRestError(Exception):
     Raised when the query has problems, e.g., bad query format.
     """
     pass
-


### PR DESCRIPTION
MPRester users are having issues decoding SNL objects due to `pybtex` no longer being installed by default by pymatgen. This issue was raised before as #519. I would love to have `pybtex` required, but as an alternative, this PR adds a user warning to install extras.

* Emits `UserWarning` if cannot import `pybtex`
* Gives one-liner `pip install` command to ensure matproj.snl dependencies.