### PR TITLE
Avoid force calculation error when printing

### DIFF
--- a/pymatgen/analysis/ewald.py
+++ b/pymatgen/analysis/ewald.py
@@ -364,11 +364,19 @@ class EwaldSummation(object):
         return self._eta
 
     def __str__(self):
-        output = ["Real = " + str(self.real_space_energy),
+        if self._compute_forces:
+            output = ["Real = " + str(self.real_space_energy),
                   "Reciprocal = " + str(self.reciprocal_space_energy),
                   "Point = " + str(self.point_energy),
                   "Total = " + str(self.total_energy),
-                  "Forces:\n" + str(self.forces)]
+                  "Forces:\n" + str(self.forces)
+                  ]           
+        else:
+            output = ["Real = " + str(self.real_space_energy),
+                  "Reciprocal = " + str(self.reciprocal_space_energy),
+                  "Point = " + str(self.point_energy),
+                  "Total = " + str(self.total_energy),
+                  "Forces were not computed"]
         return "\n".join(output)
 
 


### PR DESCRIPTION
Now if compute_forces is set to False, will allow __str__ method to print without error from trying to calculate self.forces.

## Summary

- Bug fix with printing the EwaldSummation object with default value of compute_force

## Additional dependencies introduced (if any)

N/A

## TODO (if any)

N/A