### PR TITLE
Fix MagneticSpaceGroup for Python 2.7

### DIFF
--- a/pymatgen/symmetry/maggroups.py
+++ b/pymatgen/symmetry/maggroups.py
@@ -235,7 +235,11 @@ class MagneticSpaceGroup(SymmetryGroup):
             return P_string + ";" + p_string
 
         for i in range(8, 15):
-            raw_data[i] = array('b', raw_data[i])  # construct array from sql binary blobs
+            try:
+                raw_data[i] = array('b', raw_data[i])  # construct array from sql binary blobs
+            except:
+                # array() behavior changed, need to explicitly convert buffer to str in earlier Python
+                raw_data[i] = array('b', str(raw_data[i]))
 
         self._data['og_bns_transform'] = _parse_transformation(raw_data[8])
         self._data['bns_operators'] = _parse_operators(raw_data[9])


### PR DESCRIPTION
Class retrieves a binary blob from the sqlite database and converts it to a byte `array`. At some point, the `array` constructors changed from accepting a string to accepting a buffer.

At present, I can't find a constructor that works in both Python 2.7 and Python 3.6, so have wrapped it in a try/except.

Apologies for this! Have set up proper Python 2.7 testing locally to catch this in future.