### PR TITLE
Fix MagneticSymmteryGroup for unicode arguments in Python 2.7

### DIFF
--- a/pymatgen/symmetry/maggroups.py
+++ b/pymatgen/symmetry/maggroups.py
@@ -105,7 +105,7 @@ class MagneticSpaceGroup(SymmetryGroup):
         # retrieve raw data
         db = sqlite3.connect(MAGSYMM_DATA)
         c = db.cursor()
-        if isinstance(id, str):
+        if isinstance(id, basestring):
             id = "".join(id.split())  # remove any white space
             c.execute('SELECT * FROM space_groups WHERE BNS_label=?;', (id, ))
         elif isinstance(id, list):


### PR DESCRIPTION
Nosetests supply label string as `unicode` type, which wasn’t being
caught by `if isinstance(…, str)` statement leading to no SQL query
being generated.