### PR TITLE
Glitch in BSPlotter.plot_compare

### DIFF
--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -637,7 +637,7 @@ class BSPlotter(object):
                 previous_branch = this_branch
         return {'distance': tick_distance, 'label': tick_labels}
 
-    def plot_compare(self, other_plotter):
+    def plot_compare(self, other_plotter, legend=True):
         """
         plot two band structure for comparison. One is in red the other in blue
         (no difference in spins). The two band structures need to be defined
@@ -652,6 +652,7 @@ class BSPlotter(object):
 
         """
         # TODO: add exception if the band structures are not compatible
+        import matplotlib.lines as mlines
         plt = self.get_plot()
         data_orig = self.bs_plot_data()
         data = other_plotter.bs_plot_data()
@@ -660,11 +661,23 @@ class BSPlotter(object):
             for d in range(len(data_orig['distances'])):
                 plt.plot(data_orig['distances'][d],
                          [e[str(Spin.up)][i] for e in data['energy']][d],
-                         'r-', linewidth=band_linewidth)
+                         'c-', linewidth=band_linewidth)
                 if other_plotter._bs.is_spin_polarized:
                     plt.plot(data_orig['distances'][d],
                              [e[str(Spin.down)][i] for e in data['energy']][d],
-                             'r-', linewidth=band_linewidth)
+                             'm--', linewidth=band_linewidth)
+        if legend:
+            handles = [mlines.Line2D([], [], linewidth=2,
+                                     color='b', label='bs 1 up'),
+                       mlines.Line2D([], [], linewidth=2,
+                                     color='r', label='bs 1 down', linestyle="--"),
+                       mlines.Line2D([], [], linewidth=2,
+                                     color='c', label='bs 2 up'),
+                       mlines.Line2D([], [], linewidth=2,
+                                     color='m', linestyle="--",
+                                     label='bs 2 down')]
+
+            plt.legend(handles=handles)
         return plt
 
     def plot_brillouin(self):

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -661,10 +661,10 @@ class BSPlotter(object):
                 plt.plot(data_orig['distances'][d],
                          [e[str(Spin.up)][i] for e in data['energy']][d],
                          'r-', linewidth=band_linewidth)
-        if other_plotter._bs.is_spin_polarized:
-            plt.plot(data_orig['distances'],
-                     [e for e in data['energy'][i][str(Spin.down)]],
-                     'r-', linewidth=band_linewidth)
+                if other_plotter._bs.is_spin_polarized:
+                plt.plot(data_orig['distances'][d],
+                         [e[str(Spin.down)][i] for e in data['energy']][d],
+                         'r-', linewidth=band_linewidth)
         return plt
 
     def plot_brillouin(self):


### PR DESCRIPTION
## Summary

Added color differentiation between plot_1 and plot_2 in plot_compare, an option to print a legend, and fixed a bug preventing plot_compare from ever succeeding. 

In BSPlotter.plot_compare(other_plotter), the indentation level of the block regarding the spin-down channel was incorrect, and the content of the block itself was incorrect, causing:

1. Spin-down BS to be evaluated only in one branch
2. The band number being used in-place of the k-point branch

Point 1 was merely incorrect, while point 2 would lead to an index-out-of-range error, and the plot to fail. This pull request fixes the syntax so that plot_compare works properly.