### PR TITLE
Ensure SNL references is a string rather than any falsy value

### DIFF
--- a/pymatgen/matproj/snl.py
+++ b/pymatgen/matproj/snl.py
@@ -219,6 +219,9 @@ class StructureNL(object):
             if isinstance(projects, string_types) else projects
 
         # check that references are valid BibTeX
+        if not isinstance(references, string_types):
+            raise ValueError("Invalid format for SNL reference! Should be "
+                             "empty string or BibTeX string.")
         if references and not is_valid_bibtex(references):
             raise ValueError("Invalid format for SNL reference! Should be "
                              "BibTeX string.")

--- a/pymatgen/matproj/tests/test_snl.py
+++ b/pymatgen/matproj/tests/test_snl.py
@@ -93,6 +93,13 @@ class StructureNLCase(unittest.TestCase):
         StructureNL(self.s, self.hulk, references=self.pmg)
 
     def test_references(self):
+        # An empty string should be OK
+        StructureNL(self.s, self.hulk, references="")
+
+        # An empty list should not work
+        self.assertRaises(ValueError, StructureNL, self.s, self.hulk,
+                          references=[])
+
         # junk reference should not work
         self.assertRaises(ValueError, StructureNL, self.s, self.hulk,
                           references=self.junk)


### PR DESCRIPTION
Ensure SNL references is a string rather than any falsy value. Prevents downstream surprises for users who e.g. submit SNLs in bulk to Materials Project. Thank you @shyamd for discovering this.

* Type-check on SNL construction
* Add unit tests for "empty" references