### PR TITLE
Add magCIF support to CifParser and CifWriter

### DIFF
--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -277,7 +277,7 @@ class CifFile(object):
 
     @classmethod
     def from_file(cls, filename):
-        with zopen(filename, "rt") as f:
+        with zopen(filename, "rt", errors="replace") as f:
             return cls.from_string(f.read())
 
 

--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -16,6 +16,7 @@ from six.moves import zip, cStringIO
 
 import numpy as np
 from functools import partial
+
 try:
     from inspect import getfullargspec as getargspec
 except ImportError:
@@ -32,6 +33,9 @@ from pymatgen.core.composition import Composition
 from pymatgen.core.operations import SymmOp
 from pymatgen.symmetry.groups import SpaceGroup, SYMM_DATA
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
+from pymatgen.electronic_structure.core import Magmom
+from pymatgen.core.operations import MagSymmOp
+from pymatgen.symmetry.maggroups import MagneticSpaceGroup
 
 """
 Wrapper classes for Cif input and output from Structures.
@@ -242,7 +246,7 @@ class CifBlock(object):
 
 class CifFile(object):
     """
-    Reads and parses CifBlocks from a .cif file
+    Reads and parses CifBlocks from a .cif file or string
     """
 
     def __init__(self, data, orig_string=None, comment=None):
@@ -280,7 +284,6 @@ class CifFile(object):
         with zopen(filename, "rt", errors="replace") as f:
             return cls.from_string(f.read())
 
-
 class CifParser(object):
     """
     Parses a cif file
@@ -302,6 +305,50 @@ class CifParser(object):
         else:
             self._cif = CifFile.from_string(filename.read())
 
+        # store if CIF contains features from non-core CIF dictionaries
+        # e.g. magCIF
+        self.feature_flags = {}
+
+        def is_magcif():
+            """
+            Checks to see if file appears to be a magCIF file (heuristic).
+            """
+            # Doesn't seem to be a canonical way to test if file is magCIF or
+            # not, so instead check for magnetic symmetry datanames
+            prefixes = ['_space_group_magn', '_atom_site_moment', '_space_group_symop_magn']
+            for d in self._cif.data.values():
+                for k in d.data.keys():
+                    for prefix in prefixes:
+                        if prefix in k:
+                            return True
+            return False
+
+        self.feature_flags['magcif'] = is_magcif()
+
+        def is_magcif_incommensurate():
+            """
+            Checks to see if file contains an incommensurate magnetic
+            structure (heuristic).
+            """
+            # Doesn't seem to be a canonical way to test if magCIF file
+            # describes incommensurate strucure or not, so instead check
+            # for common datanames
+            if not self.feature_flags["magcif"]:
+                return False
+            prefixes = ['_cell_modulation_dimension', '_cell_wave_vector']
+            for d in self._cif.data.values():
+                for k in d.data.keys():
+                    for prefix in prefixes:
+                        if prefix in k:
+                            return True
+            return False
+
+        self.feature_flags['magcif_incommensurate'] = is_magcif_incommensurate()
+
+        for k in self._cif.data.keys():
+            # pass individual CifBlocks to _sanitize_data
+            self._cif.data[k] = self._sanitize_data(self._cif.data[k])
+
     @staticmethod
     def from_string(cif_string, occupancy_tolerance=1.):
         """
@@ -319,19 +366,189 @@ class CifParser(object):
         stream = cStringIO(cif_string)
         return CifParser(stream, occupancy_tolerance)
 
-    def _unique_coords(self, coords_in):
+    def _sanitize_data(self, data):
         """
-        Generate unique coordinates using coord and symmetry positions.
+        Some CIF files do not conform to spec. This function corrects
+        known issues, particular in regards to Springer materials/
+        Pauling files.
+
+        This function is here so that CifParser can assume its
+        input conforms to spec, simplifying its implementation.
+        :param data: CifBlock
+        :return: data CifBlock
+        """
+
+        """
+        This part of the code deals with handling formats of data as found in
+        CIF files extracted from the Springer Materials/Pauling File
+        databases, and that are different from standard ICSD formats.
+        """
+
+        # Check to see if "_atom_site_type_symbol" exists, as some test CIFs do
+        # not contain this key.
+        if "_atom_site_type_symbol" in data.data.keys():
+
+            # Keep a track of which data row needs to be removed.
+            # Example of a row: Nb,Zr '0.8Nb + 0.2Zr' .2a .m-3m 0 0 0 1 14
+            # 'rhombic dodecahedron, Nb<sub>14</sub>'
+            # Without this code, the above row in a structure would be parsed
+            # as an ordered site with only Nb (since
+            # CifParser would try to parse the first two characters of the
+            # label "Nb,Zr") and occupancy=1.
+            # However, this site is meant to be a disordered site with 0.8 of
+            # Nb and 0.2 of Zr.
+            idxs_to_remove = []
+
+            new_atom_site_label = []
+            new_atom_site_type_symbol = []
+            new_atom_site_occupancy = []
+            new_fract_x = []
+            new_fract_y = []
+            new_fract_z = []
+
+            for idx, el_row in enumerate(data["_atom_site_label"]):
+
+                # CIF files from the Springer Materials/Pauling File have
+                # switched the label and symbol. Thus, in the
+                # above shown example row, '0.8Nb + 0.2Zr' is the symbol.
+                # Below, we split the strings on ' + ' to
+                # check if the length (or number of elements) in the label and
+                # symbol are equal.
+                if len(data["_atom_site_type_symbol"][idx].split(' + ')) > \
+                        len(data["_atom_site_label"][idx].split(' + ')):
+
+                    # Dictionary to hold extracted elements and occupancies
+                    els_occu = {}
+
+                    # parse symbol to get element names and occupancy and store
+                    # in "els_occu"
+                    symbol_str = data["_atom_site_type_symbol"][idx]
+                    symbol_str_lst = symbol_str.split(' + ')
+                    for elocc_idx in range(len(symbol_str_lst)):
+                        # Remove any bracketed items in the string
+                        symbol_str_lst[elocc_idx] = re.sub(r'\([0-9]*\)', '',
+                                                           symbol_str_lst[elocc_idx].strip())
+
+                        # Extract element name and its occupancy from the
+                        # string, and store it as a
+                        # key-value pair in "els_occ".
+                        els_occu[str(re.findall(r'\D+', symbol_str_lst[
+                            elocc_idx].strip())[1]).replace('<sup>', '')] = \
+                            float('0' + re.findall(r'\.?\d+', symbol_str_lst[
+                                elocc_idx].strip())[1])
+
+                    x = str2float(data["_atom_site_fract_x"][idx])
+                    y = str2float(data["_atom_site_fract_y"][idx])
+                    z = str2float(data["_atom_site_fract_z"][idx])
+
+                    for et, occu in els_occu.items():
+                        # new atom site labels have 'fix' appended
+                        new_atom_site_label.append(et + '_fix' + str(len(new_atom_site_label)))
+                        new_atom_site_type_symbol.append(et)
+                        new_atom_site_occupancy.append(str(occu))
+                        new_fract_x.append(str(x))
+                        new_fract_y.append(str(y))
+                        new_fract_z.append(str(z))
+
+                    idxs_to_remove.append(idx)
+
+            # Remove the original row by iterating over all keys in the CIF
+            # data looking for lists, which indicates
+            # multiple data items, one for each row, and remove items from the
+            # list that corresponds to the removed row,
+            # so that it's not processed by the rest of this function (which
+            # would result in an error).
+            for original_key in data.data:
+                if isinstance(data.data[original_key], list):
+                    for id in sorted(idxs_to_remove, reverse=True):
+                        del data.data[original_key][id]
+
+            if len(idxs_to_remove) > 0:
+                data.data["_atom_site_label"] += new_atom_site_label
+                data.data["_atom_site_type_symbol"] += new_atom_site_type_symbol
+                data.data["_atom_site_occupancy"] += new_atom_site_occupancy
+                data.data["_atom_site_fract_x"] += new_fract_x
+                data.data["_atom_site_fract_y"] += new_fract_y
+                data.data["_atom_site_fract_z"] += new_fract_z
+
+        """
+        This fixes inconsistencies in naming of several magCIF tags
+        as a result of magCIF being in widespread use prior to
+        specification being finalized (on advice of Branton Campbell).
+        """
+
+        if self.feature_flags["magcif"]:
+
+            # CIF-1 style has all underscores, interim standard
+            # had period before magn instead of before the final
+            # component (e.g. xyz)
+            correct_keys = ["_space_group_symop_magn_operation.xyz",
+                            "_space_group_symop_magn_centering.xyz",
+                            "_space_group_magn.name_BNS",
+                            "_space_group_magn.number_BNS"]
+
+            # cannot mutate OrderedDict during enumeration,
+            # so store changes we want to make
+            changes_to_make = {}
+
+            for original_key in data.data:
+                for correct_key in correct_keys:
+                    # convert to all underscore
+                    trial_key = "_".join(correct_key.split("."))
+                    test_key = "_".join(original_key.split("."))
+                    if trial_key == test_key:
+                        changes_to_make[correct_key] = original_key
+
+            # make changes
+            for correct_key, original_key in changes_to_make.items():
+                data.data[correct_key] = data.data[original_key]
+
+            # some keys have been renamed, renamed_keys maps interim_keys to final_keys
+            renamed_keys = {"_magnetic_space_group.transform_to_standard_Pp_abc":
+                            "_space_group_magn.transform_BNS_Pp_abc"}
+            changes_to_make = {}
+
+            for interim_key, final_key in renamed_keys.items():
+                if data.data.get(interim_key):
+                    changes_to_make[final_key] = interim_key
+            for final_key, interim_key in changes_to_make.items():
+                data.data[final_key] = data.data[interim_key]
+
+        return data
+
+    def _unique_coords(self, coords_in, magmoms_in=None):
+        """
+        Generate unique coordinates using coord and symmetry positions
+        and also their corresponding magnetic moments, if supplied.
         """
         coords = []
-        for tmp_coord in coords_in:
-            for op in self.symmetry_operations:
-                coord = op.operate(tmp_coord)
-                coord = np.array([i - math.floor(i) for i in coord])
-                if not in_coord_list_pbc(coords, coord,
-                                         atol=self._site_tolerance):
-                    coords.append(coord)
-        return coords
+        if magmoms_in:
+            magmoms = []
+            magmoms_in = [Magmom(magmom) for magmom in magmoms_in]
+            if len(magmoms_in) != len(coords_in):
+                raise ValueError
+            for tmp_coord, tmp_magmom in zip(coords_in, magmoms_in):
+                for op in self.symmetry_operations:
+                    coord = op.operate(tmp_coord)
+                    coord = np.array([i - math.floor(i) for i in coord])
+                    if isinstance(op, MagSymmOp):
+                        magmom = Magmom(op.operate_magmom(tmp_magmom.moment))
+                    else:
+                        magmom = tmp_magmom
+                    if not in_coord_list_pbc(coords, coord,
+                                             atol=self._site_tolerance):
+                        coords.append(coord)
+                        magmoms.append(magmom)
+            return coords, magmoms
+        else:
+            for tmp_coord in coords_in:
+                for op in self.symmetry_operations:
+                    coord = op.operate(tmp_coord)
+                    coord = np.array([i - math.floor(i) for i in coord])
+                    if not in_coord_list_pbc(coords, coord,
+                                             atol=self._site_tolerance):
+                        coords.append(coord)
+            return coords, [Magmom(0)]*len(coords)  # return dummy magmoms
 
     def get_lattice(self, data, length_strings=("a", "b", "c"),
                     angle_strings=("alpha", "beta", "gamma"),
@@ -431,7 +648,7 @@ class CifParser(object):
                     try:
                         for d in _get_cod_data():
                             if sg == re.sub(r"\s+", "",
-                                            d["hermann_mauguin"]) :
+                                            d["hermann_mauguin"]):
                                 xyz = d["symops"]
                                 symops = [SymmOp.from_xyz_string(s)
                                           for s in xyz]
@@ -465,6 +682,67 @@ class CifParser(object):
 
         return symops
 
+    def get_magsymops(self, data):
+        """
+        Equivalent to get_symops except for magnetic symmetry groups.
+        Separate function since additional operation for time reversal symmetry
+        (which changes magnetic moments on sites) needs to be returned.
+        """
+        magsymmops = []
+
+        # check to see if magCIF file explicitly contains magnetic symmetry operations
+        if data.data.get("_space_group_symop_magn_operation.xyz"):
+
+            xyzt = data.data.get("_space_group_symop_magn_operation.xyz")
+            if isinstance(xyzt, six.string_types):
+                xyzt = [xyzt]
+            magsymmops = [MagSymmOp.from_xyzt_string(s) for s in xyzt]
+
+            if data.data.get("_space_group_symop_magn_centering.xyz"):
+
+                xyzt = data.data.get("_space_group_symop_magn_centering.xyz")
+                if isinstance(xyzt, six.string_types):
+                    xyzt = [xyzt]
+                centering_symops = [MagSymmOp.from_xyzt_string(s) for s in xyzt]
+
+                all_ops = []
+                for op in magsymmops:
+                    for centering_op in centering_symops:
+                        new_translation = [i - np.floor(i) for i
+                                           in op.translation_vector + centering_op.translation_vector]
+                        new_time_reversal = op.time_reversal * centering_op.time_reversal
+                        all_ops.append(MagSymmOp.from_rotation_and_translation_and_time_reversal(
+                            rotation_matrix=op.rotation_matrix, translation_vec=new_translation,
+                            time_reversal=new_time_reversal))
+                magsymmops = all_ops
+
+        # else check to see if it specifies a magnetic space group
+        elif data.data.get("_space_group_magn.name_BNS") or data.data.get("_space_group_magn.number_BNS"):
+
+            if data.data.get("_space_group_magn.name_BNS"):
+                # get BNS label for MagneticSpaceGroup()
+                id = data.data.get("_space_group_magn.name_BNS")
+            else:
+                # get BNS number for MagneticSpaceGroup()
+                # by converting string to list of ints
+                id = list(map(int, (data.data.get("_space_group_magn.number_BNS").split("."))))
+
+            msg = MagneticSpaceGroup(id)
+
+            if data.data.get("_space_group_magn.transform_BNS_Pp_abc"):
+                if data.data.get("_space_group_magn.transform_BNS_Pp_abc") != "a,b,c;0,0,0":
+                    return NotImplementedError("Non-standard settings not currently supported.")
+            elif data.data.get("_space_group_magn.transform_BNS_Pp"):
+                return NotImplementedError("Incomplete specification to implement.")
+
+            magsymmops = msg.symmetry_ops
+
+        if not magsymmops:
+            warnings.warn("No magnetic symmetry detected, using primitive symmetry.")
+            magsymmops = [MagSymmOp.from_xyzt_string("x, y, z, 1")]
+
+        return magsymmops
+
     def parse_oxi_states(self, data):
         """
         Parse oxidation states from data dictionary
@@ -484,10 +762,30 @@ class CifParser(object):
             oxi_states = None
         return oxi_states
 
+    def parse_magmoms(self, data, lattice=None):
+        """
+        Parse atomic magnetic moments from data dictionary
+        """
+        if lattice is None:
+            raise Exception('Magmoms given in terms of crystal axes in magCIF spec.')
+        try:
+            magmoms = {
+                data["_atom_site_moment_label"][i]:
+                    Magmom.from_moment_relative_to_crystal_axes([str2float(data["_atom_site_moment_crystalaxis_x"][i]),
+                                                                 str2float(data["_atom_site_moment_crystalaxis_y"][i]),
+                                                                 str2float(data["_atom_site_moment_crystalaxis_z"][i])],
+                                                                lattice)
+                for i in range(len(data["_atom_site_moment_label"]))
+                }
+        except (ValueError, KeyError):
+            return None
+        return magmoms
+
     def _get_structure(self, data, primitive):
         """
         Generate structure from part of the cif.
         """
+
         def parse_symbol(sym):
             # Common representations for elements/water in cif files
             # TODO: fix inconsistent handling of water
@@ -504,10 +802,22 @@ class CifParser(object):
                 return v
 
         lattice = self.get_lattice(data)
-        self.symmetry_operations = self.get_symops(data)
+
+        # if magCIF, get magnetic symmetry moments and magmoms
+        # else standard CIF, and use empty magmom dict
+        if self.feature_flags["magcif_incommensurate"]:
+            raise NotImplementedError("Incommensurate structures not currently supported.")
+        elif self.feature_flags["magcif"]:
+            self.symmetry_operations = self.get_magsymops(data)
+            magmoms = self.parse_magmoms(data, lattice=lattice)
+        else:
+            self.symmetry_operations = self.get_symops(data)
+            magmoms = {}
+
         oxi_states = self.parse_oxi_states(data)
 
         coord_to_species = OrderedDict()
+        coord_to_magmoms = OrderedDict()
 
         def get_matching_coord(coord):
             keys = list(coord_to_species.keys())
@@ -521,87 +831,6 @@ class CifParser(object):
                     return keys[inds[0]]
             return False
 
-        ############################################################
-        """
-        This part of the code deals with handling formats of data as found in
-        CIF files extracted from the Springer Materials/Pauling File
-        databases, and that are different from standard ICSD formats.
-        """
-
-        # Check to see if "_atom_site_type_symbol" exists, as some test CIFs do
-        # not contain this key.
-        if "_atom_site_type_symbol" in data.data.keys():
-
-            # Keep a track of which data row needs to be removed.
-            # Example of a row: Nb,Zr '0.8Nb + 0.2Zr' .2a .m-3m 0 0 0 1 14
-            # 'rhombic dodecahedron, Nb<sub>14</sub>'
-            # Without this code, the above row in a structure would be parsed
-            # as an ordered site with only Nb (since
-            # CifParser would try to parse the first two characters of the
-            # label "Nb,Zr") and occupancy=1.
-            # However, this site is meant to be a disordered site with 0.8 of
-            # Nb and 0.2 of Zr.
-            idxs_to_remove = []
-
-            for idx, el_row in enumerate(data["_atom_site_label"]):
-
-                # CIF files from the Springer Materials/Pauling File have
-                # switched the label and symbol. Thus, in the
-                # above shown example row, '0.8Nb + 0.2Zr' is the symbol.
-                # Below, we split the strings on ' + ' to
-                # check if the length (or number of elements) in the label and
-                # symbol are equal.
-                if len(data["_atom_site_type_symbol"][idx].split(' + ')) > \
-                        len(data["_atom_site_label"][idx].split(' + ')):
-
-                    # Dictionary to hold extracted elements and occupancies
-                    els_occu = {}
-
-                    # parse symbol to get element names and occupancy and store
-                    # in "els_occu"
-                    symbol_str = data["_atom_site_type_symbol"][idx]
-                    symbol_str_lst = symbol_str.split(' + ')
-                    for elocc_idx in range(len(symbol_str_lst)):
-                        # Remove any bracketed items in the string
-                        symbol_str_lst[elocc_idx] = re.sub(r'\([0-9]*\)', '',
-                            symbol_str_lst[elocc_idx].strip())
-
-                        # Extract element name and its occupancy from the
-                        # string, and store it as a
-                        # key-value pair in "els_occ".
-                        els_occu[str(re.findall(r'\D+', symbol_str_lst[
-                            elocc_idx].strip())[1]).replace('<sup>', '')] = \
-                            float('0' + re.findall(r'\.?\d+', symbol_str_lst[
-                                elocc_idx].strip())[1])
-
-                    x = str2float(data["_atom_site_fract_x"][idx])
-                    y = str2float(data["_atom_site_fract_y"][idx])
-                    z = str2float(data["_atom_site_fract_z"][idx])
-
-                    coord = (x, y, z)
-                    # Add each partially occupied element on the site coordinate
-                    for et in els_occu:
-                        match = get_matching_coord(coord)
-                        if not match:
-                            coord_to_species[coord] = Composition(
-                                {parse_symbol(et): els_occu[parse_symbol(et)]})
-                        else:
-                            coord_to_species[match] += {
-                                parse_symbol(et): els_occu[parse_symbol(et)]}
-                    idxs_to_remove.append(idx)
-
-            # Remove the original row by iterating over all keys in the CIF
-            # data looking for lists, which indicates
-            # multiple data items, one for each row, and remove items from the
-            # list that corresponds to the removed row,
-            # so that it's not processed by the rest of this function (which
-            # would result in an error).
-            for cif_key in data.data:
-                if type(data.data[cif_key]) == list:
-                    for id in sorted(idxs_to_remove, reverse=True):
-                        del data.data[cif_key][id]
-
-        ############################################################
         for i in range(len(data["_atom_site_label"])):
             try:
                 # If site type symbol exists, use it. Otherwise, we use the
@@ -628,6 +857,7 @@ class CifParser(object):
             x = str2float(data["_atom_site_fract_x"][i])
             y = str2float(data["_atom_site_fract_y"][i])
             z = str2float(data["_atom_site_fract_z"][i])
+            magmom = magmoms.get(data["_atom_site_label"][i], Magmom(0))
 
             try:
                 occu = str2float(data["_atom_site_occupancy"][i])
@@ -639,8 +869,10 @@ class CifParser(object):
                 match = get_matching_coord(coord)
                 if not match:
                     coord_to_species[coord] = Composition({el: occu})
+                    coord_to_magmoms[coord] = magmom
                 else:
                     coord_to_species[match] += {el: occu}
+                    coord_to_magmoms[match] = None  # disordered magnetic not currently supported
 
         sum_occu = [sum(c.values()) for c in coord_to_species.values()]
         if any([o > 1 for o in sum_occu]):
@@ -649,17 +881,33 @@ class CifParser(object):
 
         allspecies = []
         allcoords = []
+        allmagmoms = []
+
+        # check to see if magCIF file is disordered
+        if self.feature_flags["magcif"]:
+            for k, v in coord_to_magmoms.items():
+                if v is None:
+                    # Proposed solution to this is to instead store magnetic moments
+                    # as Specie 'spin' property, instead of site property, but this
+                    # introduces ambiguities for end user (such as unintended use of
+                    # `spin` and Specie will have fictious oxidation state).
+                    raise NotImplementedError('Disordered magnetic structures not currently supported.')
 
         if coord_to_species.items():
             for species, group in groupby(
                     sorted(list(coord_to_species.items()), key=lambda x: x[1]),
                     key=lambda x: x[1]):
                 tmp_coords = [site[0] for site in group]
+                tmp_magmom = [coord_to_magmoms[tmp_coord] for tmp_coord in tmp_coords]
 
-                coords = self._unique_coords(tmp_coords)
+                if self.feature_flags["magcif"]:
+                    coords, magmoms = self._unique_coords(tmp_coords, tmp_magmom)
+                else:
+                    coords, magmoms = self._unique_coords(tmp_coords)
 
                 allcoords.extend(coords)
                 allspecies.extend(len(coords) * [species])
+                allmagmoms.extend(magmoms)
 
             # rescale occupancies if necessary
             for i, species in enumerate(allspecies):
@@ -667,8 +915,14 @@ class CifParser(object):
                 if 1 < totaloccu <= self._occupancy_tolerance:
                     allspecies[i] = species / totaloccu
 
-        if allspecies and len(allspecies) == len(allcoords):
-            struct = Structure(lattice, allspecies, allcoords)
+        if allspecies and len(allspecies) == len(allcoords) and len(allspecies) == len(allmagmoms):
+
+            if self.feature_flags["magcif"]:
+                struct = Structure(lattice, allspecies, allcoords,
+                                   site_properties={"magmom": allmagmoms})
+            else:
+                struct = Structure(lattice, allspecies, allcoords)
+
             struct = struct.get_sorted_structure()
 
             if primitive:

--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -957,6 +957,57 @@ class CifParser(object):
             raise ValueError("Invalid cif file with no structures!")
         return structures
 
+    def get_bibtex_strings(self):
+        """
+        (Beta) Get BibTeX reference from CIF file.
+        :param data:
+        :return: BibTeX string
+        """
+
+        # TODO: CIF specification supports multiple citations.
+
+        bibtex_strs = []
+
+        for d in self._cif.data.values():
+
+            bibtex_entry = {'authors': '_citation_author_name',
+                            'title': '_citation_title',
+                            'journal': '_citation_journal_abbrev',
+                            'volume': '_citation_journal_volume',
+                            'year': '_citation_year',
+                            'number': '_citation_number',
+                            'page_first': '_citation_page_first',
+                            'page_last': '_citation_page_last',
+                            'doi': '_citation_DOI'}
+
+            for field, tag in bibtex_entry.items():
+                try:
+                    bibtex_entry[field] = d[tag]
+                except:
+                    bibtex_entry[field] = "?"
+
+            bibtex_entry['key'] = bibtex_entry['authors'][0].split(',')[0]+":"+bibtex_entry['year']
+            bibtex_entry['key'] = ''.join(bibtex_entry['key'].split())
+            bibtex_entry['authors'] = " and ".join(bibtex_entry['authors'])
+            bibtex_entry['pages'] = "{0}--{1}".format(bibtex_entry['page_first'], bibtex_entry['page_last'])
+
+            for field, entry in bibtex_entry.items():
+                if field is not 'key':
+                    bibtex_entry[field] = "{"+entry+"}"
+
+            bibtex_str = ("""{key},
+    author = {authors},
+    title = {title},
+    journal = {journal},
+    year = {year},
+    volume = {volume},
+    number = {number},
+    pages = {pages},
+    doi = {doi}""".format(**bibtex_entry))
+            bibtex_strs.append("@article{"+bibtex_str+"\n}")
+
+        return bibtex_strs
+
     def as_dict(self):
         d = OrderedDict()
         for k, v in self._cif.data.items():

--- a/pymatgen/io/tests/test_cif.py
+++ b/pymatgen/io/tests/test_cif.py
@@ -1039,5 +1039,68 @@ Gd1 5.05 5.05 0.0"""
 
         self.assertTrue(s_ncl.matches(s_ncl_from_msg))
 
+    def test_write(self):
+
+        s_ncl = self.mcif_ncl.get_structures(primitive=False)[0]
+        cw = CifWriter(s_ncl, write_magmoms=True)
+
+        cw_ref_string = """# generated using pymatgen
+data_GdB4
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   7.13160000
+_cell_length_b   7.13160000
+_cell_length_c   4.05050000
+_cell_angle_alpha   90.00000000
+_cell_angle_beta   90.00000000
+_cell_angle_gamma   90.00000000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   GdB4
+_chemical_formula_sum   'Gd4 B16'
+_cell_volume   206.007290027
+_cell_formula_units_Z   4
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  Gd  Gd1  1  0.317460  0.817460  0.000000  1.0
+  Gd  Gd2  1  0.182540  0.317460  0.000000  1.0
+  Gd  Gd3  1  0.817460  0.682540  0.000000  1.0
+  Gd  Gd4  1  0.682540  0.182540  0.000000  1.0
+  B  B5  1  0.000000  0.000000  0.202900  1.0
+  B  B6  1  0.500000  0.500000  0.797100  1.0
+  B  B7  1  0.000000  0.000000  0.797100  1.0
+  B  B8  1  0.500000  0.500000  0.202900  1.0
+  B  B9  1  0.175900  0.038000  0.500000  1.0
+  B  B10  1  0.962000  0.175900  0.500000  1.0
+  B  B11  1  0.038000  0.824100  0.500000  1.0
+  B  B12  1  0.675900  0.462000  0.500000  1.0
+  B  B13  1  0.324100  0.538000  0.500000  1.0
+  B  B14  1  0.824100  0.962000  0.500000  1.0
+  B  B15  1  0.538000  0.675900  0.500000  1.0
+  B  B16  1  0.462000  0.324100  0.500000  1.0
+  B  B17  1  0.086700  0.586700  0.500000  1.0
+  B  B18  1  0.413300  0.086700  0.500000  1.0
+  B  B19  1  0.586700  0.913300  0.500000  1.0
+  B  B20  1  0.913300  0.413300  0.500000  1.0
+loop_
+ _atom_site_moment_label
+ _atom_site_moment_crystalaxis_x
+ _atom_site_moment_crystalaxis_y
+ _atom_site_moment_crystalaxis_z
+  Gd1  5.05  5.05  0.0
+  Gd2  -5.05  5.05  0.0
+  Gd3  5.05  -5.05  0.0
+  Gd4  -5.05  -5.05  0.0
+"""
+
+        self.assertEqual(cw.__str__(), cw_ref_string)
 if __name__ == '__main__':
     unittest.main()

--- a/pymatgen/io/tests/test_cif.py
+++ b/pymatgen/io/tests/test_cif.py
@@ -1102,5 +1102,20 @@ loop_
 """
 
         self.assertEqual(cw.__str__(), cw_ref_string)
+
+    def test_bibtex(self):
+
+        ref_bibtex_string = """@article{Blanco:2006,
+    author = {Blanco, J.A.},
+    title = {?},
+    journal = {PHYSICAL REVIEW B},
+    year = {2006},
+    volume = {73},
+    number = {?},
+    pages = {?--?},
+    doi = {10.1103/PhysRevB.73.212411}
+}"""
+        self.assertEqual(self.mcif_ncl.get_bibtex_strings()[0], ref_bibtex_string)
+
 if __name__ == '__main__':
     unittest.main()

--- a/test_files/magnetic.disordered.example.CuMnO2.mcif
+++ b/test_files/magnetic.disordered.example.CuMnO2.mcif
@@ -1,0 +1,138 @@
+# Created by the Bilbao Crystallographic Server
+# http://www.cryst.ehu.es
+# Date: 08/22/2016 22:48:02
+# Database entry: 1.178 Cu1.07Mn0.93O2
+# Cif-like file for the case 1.178
+
+
+data_5yOhtAoR
+_audit_creation_date            2016-08-22
+_audit_creation_method          "Bilbao Crystallographic Server"
+
+_chemical_name_systematic
+;
+;
+_chemical_name_common                    ?
+_chemical_formula_moiety                 ?
+_chemical_formula_structural             ?
+_chemical_formula_analytical             ?
+_chemical_formula_iupac                  ?
+_chemical_formula_sum                    'Cu1 .07Mn0 .93O2'
+_chemical_formula_weight                 ?
+_chemical_melting_point                  ?
+_chemical_compound_source                ?
+_chemical_absolute_configuration         .
+
+
+_citation_journal_abbrev        "PHYSICAL REVIEW B"
+_citation_journal_volume        83
+_citation_page_first            ?
+_citation_page_last             ?
+_citation_article_id            172407
+_citation_year                  2011
+_citation_DOI                   10.1103/PhysRevB.83.172407
+
+loop_
+_citation_author_name
+"Garlea, V.O."
+
+_atomic_positions_source_database_code_ICSD  .
+_atomic_positions_source_other               .
+
+_transition_temperature     52
+_experiment_temperature     ?
+
+loop_
+_irrep_id
+_irrep_dimension
+_irrep_small_dimension
+_irrep_direction_type
+_irrep_action
+_irrep_modes_number
+_irrep_presence
+mV1- 2 1 . primary 3 .
+
+_exptl_crystal_magnetic_properties_details
+;
+NPD
+Compound with a 7% substitution of Mn by Cu, with formula Cu_1.07Mn_0.93O_2
+The pure compound MnCuO2 has a different magnetic phase with k=(-1/2,1/2,1/2)  (see entry #1.57)
+No triclinic strain is observed, in contrast with the pure compound.
+;
+
+_active_magnetic_irreps_details
+;
+1k magnetic structure
+k-maximal magnetic symmetry
+maximal k-symmetry (1 possible)
+twin related equivalent structure with k=(1/2,1/2,0), related by the lost twofold rotation.
+;
+
+_parent_space_group.name_H-M                        'C 2/m'
+_parent_space_group.IT_number                       12
+_parent_space_group.transform_to_standard_Pp_abc    'a,b,c;0,0,0'
+
+loop_
+_magnetic_propagation_vector_seq_id
+_magnetic_propagation_vector_kxkykz
+k1 -1/2,1/2,0
+
+_magnetic_space_group.standard_setting              'no'
+_magnetic_space_group.transform_from_parent_Pp_abc  '2a,2b,c;0,0,0'
+_magnetic_space_group.transform_to_standard_Pp_abc  'c,1/4a+1/4b,-1/2a+1/2b;0,0,0'
+
+loop_
+_magnetic_atom_site_moment_symmetry_constraints_label
+_atom_site_magnetic_moment_symmetry_constraints_mxmymz
+Mn1 mx,my,mz
+
+_space_group.magn_number_BNS   2.7
+_space_group.magn_name_BNS     "P_S -1"
+_space_group.magn_point_group "-11'"
+_space_group.magn_point_group_number "2.2.4"
+_cell_length_a                 11.0867
+_cell_length_b                 5.7640
+_cell_length_c                 5.8955
+_cell_angle_alpha              90.00
+_cell_angle_beta               104.2968
+_cell_angle_gamma              90.00
+
+loop_
+_space_group_symop.magn_id
+_space_group_symop.magn_operation_xyz
+_space_group_symop.magn_operation_mxmymz
+1 x,y,z,+1 mx,my,mz
+2 -x,-y,-z,+1 mx,my,mz
+
+loop_
+_space_group_symop.magn_centering_id
+_space_group_symop.magn_centering_xyz
+_space_group_symop.magn_centering_mxmymz
+1 x,y,z,+1 mx,my,mz
+2 x+1/4,y+1/4,z,+1 mx,my,mz
+3 x+1/2,y+1/2,z,+1 mx,my,mz
+4 x+3/4,y+3/4,z,+1 mx,my,mz
+5 x+3/4,y+1/4,z,-1 -mx,-my,-mz
+6 x,y+1/2,z,-1 -mx,-my,-mz
+7 x+1/4,y+3/4,z,-1 -mx,-my,-mz
+8 x+1/2,y,z,-1 -mx,-my,-mz
+
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+Cu1 Cu 0.00000 0.25000 0.50000 1.00
+Mn1 Mn 0.00000 0.00000 0.00000 0.932(5)
+Cu2 Cu 0.00000 0.00000 0.00000 0.068
+O1 O 0.20349 0.00000 0.1763 1.
+
+loop_
+_atom_site_moment_label
+_atom_site_moment_crystalaxis_x
+_atom_site_moment_crystalaxis_y
+_atom_site_moment_crystalaxis_z
+Mn1 1.8(2) 0.0 1.4(3)
+

--- a/test_files/magnetic.example.NiO.mcif
+++ b/test_files/magnetic.example.NiO.mcif
@@ -1,0 +1,160 @@
+# Created by the Bilbao Crystallographic Server
+# http://www.cryst.ehu.es
+# Date: 02/17/2016 21:26:10
+# Database entry: 1.6 NiO
+# Cif-like file for the case 1.6
+
+
+data_5yOhtAoR
+_audit_creation_date            2016-02-17
+_audit_creation_method          "Bilbao Crystallographic Server"
+
+_chemical_name_systematic
+;
+;
+_chemical_name_common                    ?
+_chemical_formula_moiety                 ?
+_chemical_formula_structural             ?
+_chemical_formula_analytical             ?
+_chemical_formula_iupac                  ?
+_chemical_formula_sum                    'Ni O'
+_chemical_formula_weight                 ?
+_chemical_melting_point                  ?
+_chemical_compound_source                ?
+_chemical_absolute_configuration         .
+
+
+_citation_journal_abbrev        "Physica B"
+_citation_journal_volume        385Ð386
+_citation_page_first            394
+_citation_page_last             ?
+_citation_article_id            .
+_citation_year                  2006
+_citation_DOI                   ?
+
+loop_
+_citation_author_name
+"Ressouche, E."
+
+_atomic_positions_source_database_code_ICSD  .
+_atomic_positions_source_other               .
+
+_transition_temperature     523
+_experiment_temperature     ?
+
+loop_
+_irrep_id
+_irrep_dimension
+_irrep_small_dimension
+_irrep_direction_type
+_irrep_action
+_irrep_modes_number
+_irrep_presence
+mL3+ 8 2 special primary . .
+
+_exptl_crystal_magnetic_properties_details
+;
+SNP
+arbitrary spin scale.
+spins along the (11-2) direction, perpendicular to the propagation vector
+monoclinic axis along (1,-1,0) direction, also perpendicular to k.
+;
+
+_active_magnetic_irreps_details
+;
+irrep mL3+, special direction.
+a secondary weak spin component (irrep mL2+, 1dim-irrep) along the propagation vector, direction (1,1,1), is allowed and sometimes reported. Not included here.
+;
+
+_parent_space_group.name_H-M                        'F m -3m'
+_parent_space_group.IT_number                       225
+_parent_space_group.transform_to_standard_Pp_abc    'a,b,c;0,0,0'
+
+loop_
+_magnetic_propagation_vector_seq_id
+_magnetic_propagation_vector_kxkykz
+k1 1/2,1/2,1/2
+
+_magnetic_space_group.standard_setting              'no'
+_magnetic_space_group.transform_from_parent_Pp_abc  '2a,2b,2c;0,0,0'
+_magnetic_space_group.transform_to_standard_Pp_abc  'a/4+b/4-c/2,a/4-b/4,-a/2-b/2;0,0,0'
+
+loop_
+_magnetic_atom_site_moment_symmetry_constraints_label
+_atom_site_magnetic_moment_symmetry_constraints_mxmymz
+Ni mx,mx,mz
+
+_space_group.magn_number_BNS   15.90
+_space_group.magn_name_BNS     "C_c 2/c"
+_space_group.magn_point_group "2/m1'"
+_space_group.magn_point_group_number "5.2.13"
+_cell_length_a                 8.3500
+_cell_length_b                 8.3500
+_cell_length_c                 8.3500
+_cell_angle_alpha              90.0000
+_cell_angle_beta               90.0000
+_cell_angle_gamma              90.0000
+
+loop_
+_space_group_symop.magn_id
+_space_group_symop.magn_operation_xyz
+_space_group_symop.magn_operation_mxmymz
+1 x,y,z,+1 mx,my,mz
+2 -y+3/4,-x+3/4,-z,+1 -my,-mx,-mz
+3 -x+1/4,-y+3/4,-z,+1 mx,my,mz
+4 y,x+1/2,z,+1 -my,-mx,-mz
+
+loop_
+_space_group_symop.magn_centering_id
+_space_group_symop.magn_centering_xyz
+_space_group_symop.magn_centering_mxmymz
+1 x,y,z,+1 mx,my,mz
+2 x,y+1/4,z+3/4,+1 mx,my,mz
+3 x,y+1/2,z+1/2,+1 mx,my,mz
+4 x,y+3/4,z+1/4,+1 mx,my,mz
+5 x+1/4,y,z+3/4,+1 mx,my,mz
+6 x+1/4,y+1/4,z+1/2,+1 mx,my,mz
+7 x+1/4,y+1/2,z+1/4,+1 mx,my,mz
+8 x+1/4,y+3/4,z,+1 mx,my,mz
+9 x+1/2,y,z+1/2,+1 mx,my,mz
+10 x+1/2,y+1/4,z+1/4,+1 mx,my,mz
+11 x+1/2,y+1/2,z,+1 mx,my,mz
+12 x+1/2,y+3/4,z+3/4,+1 mx,my,mz
+13 x+3/4,y,z+1/4,+1 mx,my,mz
+14 x+3/4,y+1/4,z,+1 mx,my,mz
+15 x+3/4,y+1/2,z+3/4,+1 mx,my,mz
+16 x+3/4,y+3/4,z+1/2,+1 mx,my,mz
+17 x+3/4,y+3/4,z,-1 -mx,-my,-mz
+18 x+3/4,y,z+3/4,-1 -mx,-my,-mz
+19 x+3/4,y+1/4,z+1/2,-1 -mx,-my,-mz
+20 x+3/4,y+1/2,z+1/4,-1 -mx,-my,-mz
+21 x,y+3/4,z+3/4,-1 -mx,-my,-mz
+22 x,y,z+1/2,-1 -mx,-my,-mz
+23 x,y+1/4,z+1/4,-1 -mx,-my,-mz
+24 x,y+1/2,z,-1 -mx,-my,-mz
+25 x+1/4,y+3/4,z+1/2,-1 -mx,-my,-mz
+26 x+1/4,y,z+1/4,-1 -mx,-my,-mz
+27 x+1/4,y+1/4,z,-1 -mx,-my,-mz
+28 x+1/4,y+1/2,z+3/4,-1 -mx,-my,-mz
+29 x+1/2,y+3/4,z+1/4,-1 -mx,-my,-mz
+30 x+1/2,y,z,-1 -mx,-my,-mz
+31 x+1/2,y+1/4,z+3/4,-1 -mx,-my,-mz
+32 x+1/2,y+1/2,z+1/2,-1 -mx,-my,-mz
+
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+Ni Ni 0.00000 0.00000 0.00000 1
+O O 0.75000 0.50000 0.00000 1
+
+loop_
+_atom_site_moment_label
+_atom_site_moment_crystalaxis_x
+_atom_site_moment_crystalaxis_y
+_atom_site_moment_crystalaxis_z
+Ni 1. 1. -2.
+

--- a/test_files/magnetic.incommensurate.example.Cr.mcif
+++ b/test_files/magnetic.incommensurate.example.Cr.mcif
@@ -1,0 +1,167 @@
+# Created by the Bilbao Crystallographic Server
+# http://www.cryst.ehu.es
+# Date: 03/23/2016 17:28:19
+# Database entry: 1.1.4 Cr
+# Cif-like file for the case 1.1.4
+
+
+data_5yOhtAoR
+_audit_creation_date            2016-03-23
+_audit_creation_method          "Bilbao Crystallographic Server"
+
+_chemical_name_systematic
+;
+;
+_chemical_name_common                    ?
+_chemical_formula_moiety                 ?
+_chemical_formula_structural             ?
+_chemical_formula_analytical             ?
+_chemical_formula_iupac                  ?
+_chemical_formula_sum                    'Cr'
+_chemical_formula_weight                 ?
+_chemical_melting_point                  ?
+_chemical_compound_source                ?
+_chemical_absolute_configuration         .
+
+
+_citation_journal_abbrev        "J. Phys.: Condens. Matter"
+_citation_journal_volume        24
+_citation_page_first            ?
+_citation_page_last             ?
+_citation_article_id            163201
+_citation_year                  2012
+_citation_DOI                   10.1088/0953-8984/24/16/163201
+
+loop_
+_citation_author_name
+"Perez-Mato, J.M."
+
+_atomic_positions_source_database_code_ICSD   625717
+_atomic_positions_source_other               .
+
+_transition_temperature     123
+_experiment_temperature     ?
+
+loop_
+_irrep_id
+_irrep_dimension
+_irrep_small_dimension
+_irrep_direction_type
+_irrep_action
+_irrep_modes_number
+_irrep_presence
+mDT4 6 1 . primary 1 .
+
+_exptl_crystal_magnetic_properties_details
+;
+Phase II
+only approximate modulation wave vector and moment values
+see also: Rev. Mod. Phys. 60, 209 (1988) and PHYSICAL REVIEW B 51, 10336 (1995).
+;
+
+_active_magnetic_irreps_details
+;
+1k incommensurate magnetic structure
+2-dim small irrep active (8 possible different ssgroups for this irrep)
+;
+
+_parent_space_group.name_H-M              'I m -3m'
+_parent_space_group.IT_number             229
+_parent_space_group.transform_to_standard_Pp_abc    'a,b,c;0,0,0'
+
+_cell_modulation_dimension               1
+
+loop_
+_cell_wave_vector_seq_id
+_cell_wave_vector_x
+_cell_wave_vector_y
+_cell_wave_vector_z
+1 0.000000 0.000000 0.950000
+
+
+_space_group.magn_ssg_transform_from_parent_Pp_abc   'a,b,c;0,0,0'
+
+_space_group.magn_ssg_name_BNS     "I4/mmm1'(00\g)00sss"
+_space_group.magn_point_group "4/mmm1'"
+_space_group.magn_point_group_number "15.2.54"
+_cell_length_a                 2.884
+_cell_length_b                 2.884
+_cell_length_c                 2.884
+_cell_angle_alpha              90
+_cell_angle_beta               90
+_cell_angle_gamma              90
+
+loop_
+_space_group_symop.magn_ssg_id
+_space_group_symop.magn_ssg_operation_algebraic
+1 x1,x2,x3,x4,+1
+2 -x1,-x2,x3,x4,+1
+3 -x2,x1,x3,x4,+1
+4 x2,-x1,x3,x4,+1
+5 -x1,x2,-x3,-x4+1/2,+1
+6 x1,-x2,-x3,-x4+1/2,+1
+7 x2,x1,-x3,-x4+1/2,+1
+8 -x2,-x1,-x3,-x4+1/2,+1
+9 -x1,-x2,-x3,-x4,+1
+10 x1,x2,-x3,-x4,+1
+11 x2,-x1,-x3,-x4,+1
+12 -x2,x1,-x3,-x4,+1
+13 x1,-x2,x3,x4+1/2,+1
+14 -x1,x2,x3,x4+1/2,+1
+15 -x2,-x1,x3,x4+1/2,+1
+16 x2,x1,x3,x4+1/2,+1
+
+loop_
+_space_group_symop.magn_ssg_centering_id
+_space_group_symop.magn_ssg_centering_algebraic
+1 x1,x2,x3,x4,+1
+2 x1+1/2,x2+1/2,x3+1/2,x4,+1
+3 x1,x2,x3,x4+1/2,-1
+4 x1+1/2,x2+1/2,x3+1/2,x4+1/2,-1
+
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+Cr1 Cr 0 0 0 1
+
+loop_
+_magnetic_atom_site_moment_symmetry_constraints_label
+_atom_site_magnetic_moment_symmetry_constraints_mxmymz
+Cr1 0,0,0
+
+loop_
+_atom_site_moment_label
+_atom_site_moment_crystalaxis_x
+_atom_site_moment_crystalaxis_y
+_atom_site_moment_crystalaxis_z
+Cr1 0 0 0
+
+loop_
+_atom_site_Fourier_wave_vector_seq_id
+_atom_site_Fourier_wave_vector_q1_coeff
+1 1
+
+loop_
+_atom_site_moment_Fourier_atom_site_label
+_atom_site_moment_Fourier_axis
+_atom_site_moment_Fourier_wave_vector_seq_id
+_atom_site_moment_Fourier_param_cos
+_atom_site_moment_Fourier_param_sin
+Cr1 x 1 0 0
+Cr1 y 1 0 0
+Cr1 z 1 0.6 0
+
+loop_
+_atom_site_moment_Fourier_atom_site_sym_constraints_label
+_atom_site_moment_Fourier_sym_constraints_axis
+_atom_site_moment_Fourier_wave_vector_sym_constraints_seq_id
+_atom_site_moment_Fourier_sym_constraints_param_cos
+_atom_site_moment_Fourier_sym_constraints_param_sin
+Cr1 x 1 0 0
+Cr1 y 1 0 0
+Cr1 z 1 Mzcos1 0
+

--- a/test_files/magnetic.ncl.example.GdB4.mcif
+++ b/test_files/magnetic.ncl.example.GdB4.mcif
@@ -1,0 +1,142 @@
+# Created by the Bilbao Crystallographic Server
+# http://www.cryst.ehu.es
+# Date: 02/17/2016 16:24:56
+# Database entry: 0.9 GdB4
+# Cif-like file for the case 0.9
+
+
+data_5yOhtAoR
+_audit_creation_date            2016-02-17
+_audit_creation_method          "Bilbao Crystallographic Server"
+
+_chemical_name_systematic
+;
+;
+_chemical_name_common                    ?
+_chemical_formula_moiety                 ?
+_chemical_formula_structural             ?
+_chemical_formula_analytical             ?
+_chemical_formula_iupac                  ?
+_chemical_formula_sum                    'Gd B4'
+_chemical_formula_weight                 ?
+_chemical_melting_point                  ?
+_chemical_compound_source                ?
+_chemical_absolute_configuration         .
+
+
+_citation_journal_abbrev        "PHYSICAL REVIEW B"
+_citation_journal_volume        73
+_citation_page_first            ?
+_citation_page_last             ?
+_citation_article_id            212411
+_citation_year                  2006
+_citation_DOI                   10.1103/PhysRevB.73.212411
+
+loop_
+_citation_author_name
+"Blanco, J.A."
+
+_atomic_positions_source_database_code_ICSD  .
+_atomic_positions_source_other               .
+
+_transition_temperature     42
+_experiment_temperature     2.2
+
+loop_
+_irrep_id
+_irrep_dimension
+_irrep_small_dimension
+_irrep_direction_type
+_irrep_action
+_irrep_modes_number
+_irrep_presence
+? ? ? ? ? ? ?
+
+_exptl_crystal_magnetic_properties_details
+;
+spherical neutron polarimetry (SNP)
+modulus Gd moment = 7.14(17)
+;
+
+_active_magnetic_irreps_details
+;
+1k magnetic structure
+k-maximal magnetic symmetry
+1-dim irrep active, i.e. equivalence between irrep and magnetic space group assignment.
+;
+
+_parent_space_group.name_H-M                        'P 4/m b m'
+_parent_space_group.IT_number                       127
+_parent_space_group.transform_to_standard_Pp_abc    'a,b,c;0,0,0'
+
+loop_
+_magnetic_propagation_vector_seq_id
+_magnetic_propagation_vector_kxkykz
+k1 0,0,0
+
+_magnetic_space_group.standard_setting              'yes'
+_magnetic_space_group.transform_from_parent_Pp_abc  'a,b,c;0,0,0'
+_magnetic_space_group.transform_to_standard_Pp_abc  'a,b,c;0,0,0'
+
+loop_
+_magnetic_atom_site_moment_symmetry_constraints_label
+_atom_site_magnetic_moment_symmetry_constraints_mxmymz
+Gd1 mx,mx,0
+
+_space_group.magn_number_BNS   127.395
+_space_group.magn_name_BNS     "P 4/m' b' m' "
+_space_group.magn_point_group "4/m'm'm'"
+_space_group.magn_point_group_number "15.7.59"
+_cell_length_a                 7.1316
+_cell_length_b                 7.1316
+_cell_length_c                 4.0505
+_cell_angle_alpha              90.00
+_cell_angle_beta               90.00
+_cell_angle_gamma              90.00
+
+loop_
+_space_group_symop.magn_id
+_space_group_symop.magn_operation_xyz
+_space_group_symop.magn_operation_mxmymz
+1 x,y,z,+1 mx,my,mz
+2 -y,x,z,+1 -my,mx,mz
+3 y,-x,z,+1 my,-mx,mz
+4 x+1/2,-y+1/2,-z,+1 mx,-my,-mz
+5 -x+1/2,y+1/2,-z,+1 -mx,my,-mz
+6 -x,-y,z,+1 -mx,-my,mz
+7 y+1/2,x+1/2,-z,+1 my,mx,-mz
+8 -y+1/2,-x+1/2,-z,+1 -my,-mx,-mz
+9 -x,-y,-z,-1 -mx,-my,-mz
+10 y,-x,-z,-1 my,-mx,-mz
+11 -y,x,-z,-1 -my,mx,-mz
+12 -x+1/2,y+1/2,z,-1 -mx,my,mz
+13 x+1/2,-y+1/2,z,-1 mx,-my,mz
+14 x,y,-z,-1 mx,my,-mz
+15 -y+1/2,-x+1/2,z,-1 -my,-mx,mz
+16 y+1/2,x+1/2,z,-1 my,mx,mz
+
+loop_
+_space_group_symop.magn_centering_id
+_space_group_symop.magn_centering_xyz
+_space_group_symop.magn_centering_mxmymz
+1 x,y,z,+1 mx,my,mz
+
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+Gd1 Gd 0.31746 0.81746 0.00000 1
+B1 B 0.00000 0.00000 0.20290 1
+B2 B 0.17590 0.03800 0.50000 1
+B3 B 0.08670 0.58670 0.50000 1
+
+loop_
+_atom_site_moment_label
+_atom_site_moment_crystalaxis_x
+_atom_site_moment_crystalaxis_y
+_atom_site_moment_crystalaxis_z
+Gd1 5.05 5.05 0.0
+


### PR DESCRIPTION
## Summary

* Adds read support and partial write support for the magCIF standard (preliminary v1 dictionary available [here](http://comcifs.github.io/magCIF.dic.html)).

* This was developed as a separate class based on `CifParser`, but given that `CifParser` itself has seen recent changes, it seemed sensible to combine them now before they diverge too much.

* CifParser changes:
	* Includes a new CIF `feature_flags` dictionary (extensible for other non-core CIF features), checks to see if a file is magCIF
	* If magCIF, will try to place atoms:
		* First by magnetic symmetry operations, if provided (most common case)
		* If not, then by BNS symmetry group, if provided
	* Will output a Structure with magnetic moments on site properties
		* Note that this means disordered magnetic structures not currently supported
	*  Includes refactor of Pauling/Springer correction code, putting it into a `_sanitize_data()` function – *all current tests pass, but I'm not familiar with the Pauling files, so I'm cautious about this.* The refactor was done to introduce a logical separation between correction code and parsing code, so that parsing code can assume the data conforms to specification, and will make it easier to make changes to the parser in the future
	* Adds simple `get_bibtex_strings()` function to extract reference from CIF file, I found it useful for constructing SNLs

* CifWriter changes:
	* Adds `write_magmoms` kwarg
	* If moments are written, will not perform symmetry analysis
	* Scalar moments are arbitrarily aligned along z (note that magnetic symmetry not well defined with scalar moments), this comes directly from the `Magmom` class
	* Useful for visualization of magnetic moments (works with VESTA, JMOL etc.)

* Tested on Py3.6 and Py2.7 locally

* Closes #508

## Additional dependencies introduced (if any)

None

## TODO (if any)

Core functionality is all present, but there are some features to add (these raise NotImplementedErrors for now):

* Add code to parse an arbitrary change of setting, which is included in the spec

* Add support for disordered magnetic structures
    * I don't think there's currently a good way to do this in pymatgen, was going to implement this by adding a `Magmom` to a `Specie` 'spin' property, but this would likely be confusing to the end user (would introduce a fictitious oxidation state, and misuses the spin property) ... open to suggestions here

additionally,

* More graceful handing of `get_primitive_structure()` for magnetic structures, which often gives the wrong results for complex magnetic structures. Will address this with `get_primitive_magnetic_structure()` in a `MagneticStructureAnalyzer` in a future PR, until then advise using `primitive=False` in `CifParser` for magCIF files.

* (Future) Add magnetic symmetry detection support to output full-featured magCIF files containing appropriate symmetry information