### PR TITLE
Fixed bug in boltztrap runner with alternate dopings

### DIFF
--- a/pymatgen/electronic_structure/boltztrap.py
+++ b/pymatgen/electronic_structure/boltztrap.py
@@ -162,7 +162,7 @@ class BoltztrapRunner(object):
         self.tauen = tauen
         self.soc = soc
         self.kpt_line = kpt_line
-        if doping:
+        if isinstance(doping, list) and len(doping) > 0:
             self.doping = doping
         else:
             self.doping = []


### PR DESCRIPTION
Boltztrap runner tried to evaluate truth of doping variable to test if None or array.
Can't evaluate truth of an array in py2 directly
Fixed by testing if list and ensuring list size greater than 0