### PR TITLE
Debug plot_slab from adsorption module

### DIFF
--- a/pymatgen/analysis/adsorption.py
+++ b/pymatgen/analysis/adsorption.py
@@ -570,7 +570,9 @@ def plot_slab(slab, ax, scale=0.8, repeat=5, window=1.5,
     ax.set_aspect("equal")
     center = corner + lattsum / 2.
     extent = np.max(lattsum)
-    lim = zip(center-extent*window, center+extent*window)
-    ax.set_xlim(lim[0])
-    ax.set_ylim(lim[1])
+    lim_array = [center-extent*window, center+extent*window]
+    x_lim = [ele[0] for ele in lim_array]
+    y_lim = [ele[1] for ele in lim_array]
+    ax.set_xlim(x_lim)
+    ax.set_ylim(y_lim)
     return ax


### PR DESCRIPTION
From using plot_slab in the adsorption module, I was getting a 

`TypeError: 'zip' object is not subscriptable`

This error came from `lim[0]` where `lim` is a zip object. This was okay in Python 2, but in Python 3, the zip object cannot be indexed like this anymore.

Therefore, I have made a simple change by using putting them into a list and use list comprehensions instead. This change was tested and it works in my development environment.