### PR TITLE
More boltztrap fixes

### DIFF
--- a/pymatgen/electronic_structure/boltztrap.py
+++ b/pymatgen/electronic_structure/boltztrap.py
@@ -1988,10 +1988,23 @@ class BoltztrapAnalyzer(object):
         vol = data.get('vol')
         warning = data.get('warning')
 
-        return BoltztrapAnalyzer(gap, mu_steps, cond, seebeck, kappa, hall,
-                                 doping, mu_doping, seebeck_doping,
-                                 cond_doping, kappa_doping, hall_doping, dos,
-                                 dos_partial, carrier_conc, vol, warning)
+        return BoltztrapAnalyzer(gap=gap,
+                                 mu_steps=mu_steps,
+                                 cond=cond,
+                                 seebeck=seebeck,
+                                 kappa=kappa,
+                                 hall=hall,
+                                 doping=doping,
+                                 mu_doping=mu_doping,
+                                 seebeck_doping=seebeck_doping,
+                                 cond_doping=cond_doping,
+                                 kappa_doping=kappa_doping,
+                                 hall_doping=hall_doping,
+                                 dos=dos,
+                                 dos_partial=dos_partial,
+                                 carrier_conc=carrier_conc,
+                                 vol=vol,
+                                 warning=warning)
 
 
 def read_cube_file(filename):

--- a/pymatgen/electronic_structure/boltztrap.py
+++ b/pymatgen/electronic_structure/boltztrap.py
@@ -1275,10 +1275,13 @@ class BoltztrapAnalyzer(object):
             for doping in result_doping:
                 for temp in result_doping[doping]:
                     for i in range(len(self.doping[doping])):
-                        result_doping[doping][temp].append(np.linalg.inv(
-                            np.array(self._cond_doping[doping][temp][i])) * \
-                                                           self.doping[doping][
-                                                               i] * 10 ** 6 * e ** 2 / m_e)
+                        try:
+                            result_doping[doping][temp].append(np.linalg.inv(
+                                np.array(self._cond_doping[doping][temp][i])) * \
+                                                               self.doping[doping][
+                                                                   i] * 10 ** 6 * e ** 2 / m_e)
+                        except np.linalg.LinAlgError:
+                            pass
         else:
             result = {t: [] for t in self._seebeck}
             for temp in result:


### PR DESCRIPTION
Fixed the from_dict function which was previously passing variables to the constructor in order and was garbling up variables after DOS due to intrans being in the middle.

Fixed the linalg inversion in get_average_eff_mass to try and catch the linalg exception. This can be caused by a matrix of zeros, which can't be inverted. Why boltztrap spits this out, I don't know. 