### PR TITLE
You can supply max bond distances to recognize dimensionality of NaCl

### DIFF
--- a/pymatgen/analysis/structure_analyzer.py
+++ b/pymatgen/analysis/structure_analyzer.py
@@ -605,7 +605,7 @@ def get_max_bond_lengths(structure, el_radius_updates=None):
 
 def get_dimensionality(structure, max_hkl=2, el_radius_updates=None,
                        min_slab_size=5, min_vacuum_size=5,
-                       standardize=True):
+                       standardize=True, bonds=None):
 
     """
     This method returns whether a structure is 3D, 2D (layered), or 1D (linear 
@@ -626,6 +626,11 @@ def get_dimensionality(structure, max_hkl=2, el_radius_updates=None,
         standardize (bool): whether to standardize the structure before 
             analysis. Set to False only if you already have the structure in a 
             convention where layers / chains will be along low <hkl> indexes.
+        bonds ({(specie1, specie2): max_bond_dist}: bonds are
+                specified as a dict of tuples: float of specie1, specie2
+                and the max bonding distance. For example, PO4 groups may be
+                defined as {("P", "O"): 3}. Otherwise, JMolCoordFinder is
+                used.
 
     Returns: (int) the dimensionality of the structure - 1 (molecules/chains), 
         2 (layered), or 3 (3D)
@@ -635,7 +640,8 @@ def get_dimensionality(structure, max_hkl=2, el_radius_updates=None,
         structure = SpacegroupAnalyzer(structure).\
             get_conventional_standard_structure()
 
-    bonds = get_max_bond_lengths(structure)
+    if not bonds:
+        bonds = get_max_bond_lengths(structure)
 
     num_surfaces = 0
     for h in range(max_hkl):

--- a/pymatgen/analysis/structure_analyzer.py
+++ b/pymatgen/analysis/structure_analyzer.py
@@ -617,6 +617,11 @@ def get_dimensionality(structure, max_hkl=2, el_radius_updates=None,
     Note that a 1D structure detection might indicate problems in the bonding
     algorithm, particularly for ionic crystals (e.g., NaCl)
     
+    Users can change the behavior of bonds detection by passing either
+    el_radius_updates to update atomic radii for auto-detection of max bond 
+    distances, or bonds to explicitly specify max bond distances for atom pairs.
+    Note that if you pass both, el_radius_updates are ignored.
+    
     Args:
         structure: (Structure) structure to analyze dimensionality for 
         max_hkl: (int) max index of planes to look for layers
@@ -629,8 +634,7 @@ def get_dimensionality(structure, max_hkl=2, el_radius_updates=None,
         bonds ({(specie1, specie2): max_bond_dist}: bonds are
                 specified as a dict of tuples: float of specie1, specie2
                 and the max bonding distance. For example, PO4 groups may be
-                defined as {("P", "O"): 3}. Otherwise, JMolCoordFinder is
-                used.
+                defined as {("P", "O"): 3}.
 
     Returns: (int) the dimensionality of the structure - 1 (molecules/chains), 
         2 (layered), or 3 (3D)

--- a/pymatgen/analysis/tests/test_structure_analyzer.py
+++ b/pymatgen/analysis/tests/test_structure_analyzer.py
@@ -96,6 +96,10 @@ class GetDimensionalityTest(PymatgenTest):
         s = self.get_structure('Graphite')
         self.assertEqual(get_dimensionality(s), 2)
 
+    def test_get_dimensionality_with_bonds(self):
+        s = self.get_structure('CsCl')
+        self.assertEqual(get_dimensionality(s), 1)
+        self.assertEqual(get_dimensionality(s, bonds={("Cs", "Cl"): 3.7}), 3)
 
 class RelaxationAnalyzerTest(unittest.TestCase):
     def setUp(self):
@@ -362,7 +366,7 @@ class OrderParametersTest(PymatgenTest):
             [[15, 15, 15.707], [14.75, 14.75, 15], [14.75, 15.25, 15], \
             [15.25, 14.75, 15], [15.25, 15.25, 15]],
             validate_proximity=False, to_unit_cell=False,
-            coords_are_cartesian=True, site_properties=None) 
+            coords_are_cartesian=True, site_properties=None)
         self.square_pyramid = Structure(
             Lattice.from_lengths_and_angles(
             [30, 30, 30], [90, 90, 90]), ["H", "H", "H", "H", "H", "H"],


### PR DESCRIPTION
## Summary

* This PR extends the `get_dimensionality` method in `strucuture_analyzer.py`.
* Users can optionally pass max bond distances to correctly recognize the dimensionality of NaCl, which is problematic by default as commented in `get_dimensionality` by the original author.
* If the max bond distances are not supplied, original `get_max_bond_lengths` method works to detect them.
* This can be helpful if users want to ignore specific types of bonds.
* Unit tests are added to verify that
    * CsCl is recognized as 1D using `get_max_bond_lengths` (default)
    * CsCl is recognized as 3D by passing the max bond distance of Cs-Cl.
* Hope this helps!

## Additional dependencies introduced (if any)

None

## TODO (if any)

None