### PR TITLE
Remove old function

### DIFF
--- a/pymatgen/analysis/elasticity/strain.py
+++ b/pymatgen/analysis/elasticity/strain.py
@@ -153,16 +153,6 @@ class DeformedStructureSet(collections.Sequence):
     def __getitem__(self, ind):
         return self.def_structs[ind]
 
-    def as_strain_dict(self):
-        """
-        Returns dictionary of deformed structures indexed by independent
-        strain objects in accordance with legacy behavior of elasticity
-        package
-        """
-        strains = [IndependentStrain(defo) for defo in self.deformations]
-        return dict(zip(strains, self.def_structs))
-
-
 class Strain(SquareTensor):
     """
     Subclass of SquareTensor that describes the Green-Lagrange strain tensor.


### PR DESCRIPTION
## Summary

Deletes legacy as_strain_dict method.  Should resolve #716 .