### PR TITLE
fix inversed oxidation state decoration from bader

### DIFF
--- a/pymatgen/command_line/bader_caller.py
+++ b/pymatgen/command_line/bader_caller.py
@@ -189,6 +189,7 @@ class BaderAnalysis(object):
             to be supplied.
         """
         structure = self.chgcar.structure
-        charges = [self.get_charge_transfer(i) for i in range(len(structure))]
+        charges = [-self.get_charge_transfer(i)
+                   for i in range(len(structure))]
         structure.add_oxidation_state_by_site(charges)
         return structure

--- a/pymatgen/command_line/tests/test_bader_caller.py
+++ b/pymatgen/command_line/tests/test_bader_caller.py
@@ -39,7 +39,7 @@ class BaderAnalysisTest(unittest.TestCase):
         for i in range(14):
             self.assertAlmostEqual(ans[i], analysis.get_charge_transfer(i), 3)
         s = analysis.get_oxidation_state_decorated_structure()
-        self.assertAlmostEqual(s[0].specie.oxi_state, -1.3863218, 3)
+        self.assertAlmostEqual(s[0].specie.oxi_state, 1.3863218, 3)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

Previously, the method used # of electrons as oxidation state, but the two should be opposite to each other. 
