### PR TITLE
`BaderAnalysis.from_path`

### DIFF
--- a/pymatgen/command_line/bader_caller.py
+++ b/pymatgen/command_line/bader_caller.py
@@ -234,27 +234,28 @@ class BaderAnalysis(object):
             name_pattern = filename + suffix + '*' if filename != 'POTCAR' \
                 else filename + '*'
             paths = glob.glob(os.path.join(path, name_pattern))
-            if not paths:
-                if filename == "CHGCAR":
-                    raise IOError("Could not find CHGCAR!")
-                else:
-                    if filename == "POTCAR":
-                        warning_msg = "cannot calculate charge transfer."
-                    else:
-                        warning_msg = "interpret Bader results with caution."
-                    warnings.warn("Could not find %s, " % filename
-                                  + warning_msg)
-                    return None
-            if len(paths) > 1:
+            fpath = None
+            if len(paths) >= 1:
                 # using reverse=True because, if multiple files are present,
                 # they likely have suffixes 'static', 'relax', 'relax2', etc.
                 # and this would give 'static' over 'relax2' over 'relax'
                 # however, better to use 'suffix' kwarg to avoid this!
                 paths.sort(reverse=True)
                 warning_msg = "Multiple files detected, using %s" \
-                              % os.path.basename(paths[0])
+                              % os.path.basename(paths[0]) if len(paths) > 1\
+                    else None
+                fpath = paths[0]
+            else:
+                if filename == "CHGCAR":
+                    raise IOError("Could not find CHGCAR!")
+                else:
+                    warning_msg = "Could not find %s, " % filename
+                    if filename == "POTCAR":
+                        warning_msg += "cannot calculate charge transfer."
+                    else:
+                        warning_msg += "interpret Bader results with caution."
+            if warning_msg:
                 warnings.warn(warning_msg)
-            fpath = paths[0]
             return fpath
 
         chgcar_filename = _get_filepath("CHGCAR")

--- a/pymatgen/command_line/bader_caller.py
+++ b/pymatgen/command_line/bader_caller.py
@@ -40,10 +40,6 @@ __status__ = "Beta"
 __date__ = "4/5/13"
 
 
-@requires(which("bader") or which("bader.exe"),
-          "BaderAnalysis requires the executable bader to be in the path."
-          " Please download the library at http://theory.cm.utexas"
-          ".edu/vasp/bader/ and compile the executable.")
 class BaderAnalysis(object):
     """
     Bader analysis for a CHGCAR.
@@ -230,6 +226,49 @@ class BaderAnalysis(object):
             summary['charge_transfer'] = charge_transfer
 
         return summary
+
+    @classmethod
+    def from_path(cls, path, suffix=""):
+
+        def _get_filepath(filename):
+            name_pattern = filename + suffix + '*' if filename != 'POTCAR' \
+                else filename + '*'
+            paths = glob.glob(os.path.join(path, name_pattern))
+            if not paths:
+                if filename == "CHGCAR":
+                    raise IOError("Could not find CHGCAR!")
+                else:
+                    if filename == "POTCAR":
+                        warning_msg = "cannot calculate charge transfer."
+                    else:
+                        warning_msg = "interpret Bader results with caution."
+                    warnings.warn("Could not find %s, " % filename
+                                  + warning_msg)
+                    return None
+            if len(paths) > 1:
+                # using reverse=True because, if multiple files are present,
+                # they likely have suffixes 'static', 'relax', 'relax2', etc.
+                # and this would give 'static' over 'relax2' over 'relax'
+                # however, better to use 'suffix' kwarg to avoid this!
+                paths.sort(reverse=True)
+                warning_msg = "Multiple files detected, using %s" \
+                              % os.path.basename(paths[0])
+                warnings.warn(warning_msg)
+            fpath = paths[0]
+            return fpath
+
+        chgcar_filename = _get_filepath("CHGCAR")
+        potcar_filename = _get_filepath("POTCAR")
+        aeccar0 = _get_filepath("AECCAR0")
+        aeccar2 = _get_filepath("AECCAR2")
+        if (aeccar0 and aeccar2):
+            chgref = Chgcar.from_file(aeccar0) + Chgcar.from_file(aeccar2)
+            chgref_filename = "CHGCAR_ref"
+            chgref.write_file(chgref_filename)
+        else:
+            chgref_filename = None
+        return cls(chgcar_filename, potcar_filename=potcar_filename,
+                   chgref_filename=chgref_filename)
 
 
 def bader_analysis_from_path(path, suffix=''):

--- a/pymatgen/command_line/bader_caller.py
+++ b/pymatgen/command_line/bader_caller.py
@@ -261,19 +261,18 @@ class BaderAnalysis(object):
                     else None
                 fpath = paths[0]
             else:
-                if filename == "CHGCAR":
-                    raise IOError("Could not find CHGCAR!")
-                else:
-                    warning_msg = "Could not find %s, " % filename
-                    if filename == "POTCAR":
-                        warning_msg += "cannot calculate charge transfer."
-                    else:
-                        warning_msg += "interpret Bader results with caution."
+                warning_msg = "Could not find %s" % filename
+                if filename in ['AECCAR0', 'AECCAR2']:
+                    warning_msg += ", cannot calculate charge transfer."
+                elif filename == "POTCAR":
+                    warning_msg += ", interpret Bader results with caution."
             if warning_msg:
                 warnings.warn(warning_msg)
             return fpath
 
         chgcar_filename = _get_filepath("CHGCAR")
+        if chgcar_filename is None:
+            raise IOError("Could not find CHGCAR!")
         potcar_filename = _get_filepath("POTCAR")
         aeccar0 = _get_filepath("AECCAR0")
         aeccar2 = _get_filepath("AECCAR2")

--- a/pymatgen/command_line/bader_caller.py
+++ b/pymatgen/command_line/bader_caller.py
@@ -229,6 +229,17 @@ class BaderAnalysis(object):
 
     @classmethod
     def from_path(cls, path, suffix=""):
+        """
+        Convenient constructor that takes in the path name of VASP run
+        to perform Bader analysis.
+
+        Args:
+            path (str): Name of directory where VASP output files are
+                stored.
+            suffix (str): specific suffix to look for (e.g. '.relax1'
+                for 'CHGCAR.relax1.gz').
+
+        """
 
         def _get_filepath(filename):
             name_pattern = filename + suffix + '*' if filename != 'POTCAR' \
@@ -263,6 +274,7 @@ class BaderAnalysis(object):
         aeccar0 = _get_filepath("AECCAR0")
         aeccar2 = _get_filepath("AECCAR2")
         if (aeccar0 and aeccar2):
+            # `chgsum.pl AECCAR0 AECCAR2` equivalent to obtain chgref_file
             chgref = Chgcar.from_file(aeccar0) + Chgcar.from_file(aeccar2)
             chgref_filename = "CHGREF"
             chgref.write_file(chgref_filename)

--- a/pymatgen/command_line/bader_caller.py
+++ b/pymatgen/command_line/bader_caller.py
@@ -263,7 +263,7 @@ class BaderAnalysis(object):
         aeccar2 = _get_filepath("AECCAR2")
         if (aeccar0 and aeccar2):
             chgref = Chgcar.from_file(aeccar0) + Chgcar.from_file(aeccar2)
-            chgref_filename = "CHGCAR_ref"
+            chgref_filename = "CHGREF"
             chgref.write_file(chgref_filename)
         else:
             chgref_filename = None

--- a/pymatgen/command_line/bader_caller.py
+++ b/pymatgen/command_line/bader_caller.py
@@ -13,6 +13,8 @@ import glob
 from six.moves import map, zip
 from pymatgen.io.vasp.outputs import Chgcar
 from pymatgen.io.vasp.inputs import Potcar
+from monty.dev import requires
+from monty.os.path import which
 from monty.tempfile import ScratchDir
 from monty.io import zopen
 
@@ -86,6 +88,10 @@ class BaderAnalysis(object):
         (See http://theory.cm.utexas.edu/henkelman/code/bader/ for details.)
     """
 
+    @requires(which("bader") or which("bader.exe"),
+              "BaderAnalysis requires the executable bader to be in the path."
+              " Please download the library at http://theory.cm.utexas"
+              ".edu/vasp/bader/ and compile the executable.")
     def __init__(self, chgcar_filename, potcar_filename=None,
                  chgref_filename=None):
         """

--- a/pymatgen/command_line/bader_caller.py
+++ b/pymatgen/command_line/bader_caller.py
@@ -13,8 +13,6 @@ import glob
 from six.moves import map, zip
 from pymatgen.io.vasp.outputs import Chgcar
 from pymatgen.io.vasp.inputs import Potcar
-from monty.os.path import which
-from monty.dev import requires
 from monty.tempfile import ScratchDir
 from monty.io import zopen
 

--- a/pymatgen/command_line/tests/test_bader_caller.py
+++ b/pymatgen/command_line/tests/test_bader_caller.py
@@ -8,6 +8,7 @@ import os
 
 from pymatgen.command_line.bader_caller import *
 from monty.os.path import which
+import numpy as np
 
 """
 TODO: Change the module doc.
@@ -46,6 +47,20 @@ class BaderAnalysisTest(unittest.TestCase):
         # make sure bader still runs without reference file
         analysis = BaderAnalysis(os.path.join(test_dir, "CHGCAR.Fe3O4"))
         self.assertEqual(len(analysis.data), 14)
+
+    def test_from_path(self):
+        test_dir = os.path.join(os.path.dirname(__file__), "..", "..", "..",
+                                "test_files", "bader")
+        analysis = BaderAnalysis.from_path(test_dir)
+        chgcar = os.path.join(test_dir, "CHGCAR.gz")
+        chgref = os.path.join(test_dir, "_CHGCAR_sum.gz")
+        analysis0 = BaderAnalysis(chgcar_filename=chgcar,
+                                  chgref_filename=chgref)
+        charge = np.array(analysis.summary["charge"])
+        charge0 = np.array(analysis0.summary["charge"])
+        self.assertTrue(np.allclose(charge, charge0))
+        if os.path.exists("CHGREF"):
+            os.remove("CHGREF")
 
     def test_automatic_runner(self):
         test_dir = os.path.join(os.path.dirname(__file__), "..", "..", "..",


### PR DESCRIPTION
## Summary

Added a Convenient constructor that takes in the path name of VASP run to perform Bader analysis.

## TODO (if any)

code cleanup in `bader_caller.py`, I'll leave this for @mkhorton to decide. 