### PR TITLE
Substrate analyzer refactor

### DIFF
--- a/pymatgen/analysis/elasticity/elastic.py
+++ b/pymatgen/analysis/elasticity/elastic.py
@@ -9,6 +9,7 @@ from pymatgen.analysis.elasticity.tensors import Tensor, \
     TensorCollection, get_uvec
 from pymatgen.analysis.elasticity.stress import Stress
 from pymatgen.analysis.elasticity.strain import Strain
+from pymatgen.core.units import Unit
 from scipy.misc import factorial
 from scipy.integrate import quad
 from scipy.optimize import root
@@ -44,6 +45,8 @@ class NthOrderElasticTensor(Tensor):
     An object representing an nth-order tensor expansion 
     of the stress-strain constitutive equations
     """
+    GPa_to_eV_A3 = Unit("GPa").get_conversion_factor(Unit("eV ang^-3"))
+
     def __new__(cls, input_array, check_rank=None, tol=1e-4):
         obj = super(NthOrderElasticTensor, cls).__new__(
             cls, input_array, check_rank=check_rank)
@@ -83,7 +86,7 @@ class NthOrderElasticTensor(Tensor):
         """
         e_density = np.sum(self.calculate_stress(strain)*strain) / self.order
         if convert_GPa_to_eV:
-            e_density *= 0.000624151  # Conversion factor for GPa to eV/A^3
+            e_density *= self.GPa_to_eV_A3  # Conversion factor for GPa to eV/A^3
         return e_density
 
     @classmethod

--- a/pymatgen/analysis/elasticity/tests/test_elastic.py
+++ b/pymatgen/analysis/elasticity/tests/test_elastic.py
@@ -207,7 +207,7 @@ class ElasticTensorTest(PymatgenTest):
                            [ -6.12323400e-17,-6.12323400e-17,1.00000000e+00]])
 
         self.assertAlmostEqual(film_elac.energy_density(dfm.green_lagrange_strain),
-            0.000125664672793)
+            0.00125664672793)
 
         film_elac.energy_density(Strain.from_deformation([[ 0.99774738,  0.11520994, -0.        ],
                                         [-0.11520994,  0.99774738,  0.        ],
@@ -254,7 +254,7 @@ class ElasticTensorExpansionTest(PymatgenTest):
 
     def test_energy_density(self):
         edensity = self.exp.energy_density(self.strains[0])
-        self.assertAlmostEqual(edensity, 1.36363099e-5)
+        self.assertAlmostEqual(edensity, 1.36363099e-4)
 
     def test_gruneisen(self):
         # Get GGT

--- a/pymatgen/analysis/substrate_analyzer.py
+++ b/pymatgen/analysis/substrate_analyzer.py
@@ -317,12 +317,16 @@ class SubstrateAnalyzer:
         if elasticity_tensor is None:
             return 9999
 
+        # Get the appropriate surface structure
+        struc = SlabGenerator(self.film, match['film_miller'], 20, 15,
+                                      primitive=False).get_slab().oriented_unit_cell
+
         # Generate 3D lattice vectors for film super lattice
         film_matrix = list(match['film_sl_vecs'])
         film_matrix.append(np.cross(film_matrix[0], film_matrix[1]))
 
         # Generate 3D lattice vectors for substrate super lattice
-        # Out of place substrate super lattice has to be same length as
+        # Out of plane substrate super lattice has to be same length as
         # Film out of plane vector to ensure no extra deformation in that
         # direction
         substrate_matrix = list(match['sub_sl_vecs'])
@@ -335,7 +339,7 @@ class SubstrateAnalyzer:
 
         dfm = Deformation(transform_matrix)
 
-        strain = dfm.green_lagrange_strain.von_mises_strain
+        strain = dfm.green_lagrange_strain.von_mises_strain.convert_to_ieee(struc,initial_fit=False)
 
         energy_density = elasticity_tensor.energy_density(
             dfm.green_lagrange_strain)

--- a/pymatgen/analysis/substrate_analyzer.py
+++ b/pymatgen/analysis/substrate_analyzer.py
@@ -144,9 +144,9 @@ class ZSLGenerator(object):
         for (film_transformations, substrate_transformations) in \
                 transformation_sets:
             # Apply transformations and reduce using Zur reduce methodology
-            films = [reduce_vectors(*np.dot(f, film_vectors).tolist()) for f in film_transformations]
+            films = [reduce_vectors(*np.dot(f, film_vectors)) for f in film_transformations]
 
-            substrates = [reduce_vectors(*np.dot(s, substrate_vectors).tolist()) for s in substrate_transformations]
+            substrates = [reduce_vectors(*np.dot(s, substrate_vectors)) for s in substrate_transformations]
 
             # Check if equivelant super lattices
             for f, s in product(films, substrates):
@@ -186,11 +186,11 @@ class ZSLGenerator(object):
             substrate_miller(array)
         """
         d = {}
-        d["film_sl_vecs"] = np.asarray(film_sl_vectors).tolist()
-        d["sub_sl_vecs"] = np.asarray(substrate_sl_vectors).tolist()
+        d["film_sl_vecs"] = np.asarray(film_sl_vectors)
+        d["sub_sl_vecs"] = np.asarray(substrate_sl_vectors)
         d["match_area"] = match_area
-        d["film_vecs"] = np.asarray(film_vectors).tolist()
-        d["sub_vecs"] = np.asarray(substrate_vectors).tolist()
+        d["film_vecs"] = np.asarray(film_vectors)
+        d["sub_vecs"] = np.asarray(substrate_vectors)
 
         return d
 
@@ -367,7 +367,7 @@ def gen_sl_transform_matricies(area_multiple):
         matrix_list: transformation matricies to covert unit vectors to
         super lattice vectors
     """
-    return [np.matrix(((i, j), (0, area_multiple / i)))
+    return [np.array(((i, j), (0, area_multiple / i)))
             for i in get_factors(area_multiple)
             for j in range(area_multiple // i)]
 

--- a/pymatgen/analysis/substrate_analyzer.py
+++ b/pymatgen/analysis/substrate_analyzer.py
@@ -339,13 +339,13 @@ class SubstrateAnalyzer:
 
         dfm = Deformation(transform_matrix)
 
-        strain = dfm.green_lagrange_strain.von_mises_strain.convert_to_ieee(struc,initial_fit=False)
+        strain = dfm.green_lagrange_strain.convert_to_ieee(struc,initial_fit=False)
 
         energy_density = elasticity_tensor.energy_density(
-            dfm.green_lagrange_strain)
+            strain)
 
         if include_strain:
-            return (film.volume * energy_density / len(film.sites), strain)
+            return (film.volume * energy_density / len(film.sites), strain.von_mises_strain)
         else:
             return film.volume * energy_density / len(film.sites)
 

--- a/pymatgen/analysis/substrate_analyzer.py
+++ b/pymatgen/analysis/substrate_analyzer.py
@@ -32,26 +32,29 @@ __date__ = "Feb, 2016"
 
 class ZSLGenerator(object):
     """
-    This class generate matching interface super lattices based on the methodology
+    This class generate interface super lattices based on the methodology
     of lattice vector matching for heterostructural interfaces proposed by
     Zur and McGill:
     Journal of Applied Physics 55 (1984), 378 ; doi: 10.1063/1.333084
 
-    The process of generating all possible matching super lattices is:
+    The process of generating all possible interaces is as such:
 
-    1.) Reduce the surface lattice vectors and calculate area for the surfaces
-    2.) Generate all super lattice transformations within a maximum allowed area
-        limit that give nearly equal area super-lattices for the two
-        surfaces - generate_sl_transformation_sets
-    3.) For each superlattice set:
-        1.) Reduce super lattice vectors
-        2.) Check length and angle between film and substrate super lattice
-            vectors to determine if the super lattices are the nearly same
-            and therefore coincident - get_equiv_transformations
+    1.) Generate all slabs for the film and substrate for different orientations
+        given by maximum miller limitations - generate_surface_vectors
+    2.) For each film/substrate orientation pair:
+        1.) Reduce lattice vectors and calculate area
+        2.) Generate all super lattice transformations within a maximum area
+            limit that give nearly equal area super-lattices for the two
+            surfaces - generate_sl_transformation_sets
+        3.) For each superlattice set:
+            1.) Reduce super lattice vectors
+            2.) Check length and angle between film and substrate super lattice
+                vectors to determine if the super lattices are the nearly same
+                and therefore coincident - get_equiv_transformations
     """
 
     def __init__(self, max_area_ratio_tol=0.09,
-                 max_area=400,
+                 max_area=400, film_max_miller=1, substrate_max_miller=1,
                  max_length_tol=0.03, max_angle_tol=0.01):
         """
         Intialize a Zur Super Lattice Generator for a specific film and
@@ -61,6 +64,10 @@ class ZSLGenerator(object):
             max_area_ratio_tol(float): Max tolerance on ratio of
                 super-lattices to consider equal
             max_area(float): max super lattice area to generate in search
+            film_max_miller(int): maximum miller index to generate for film
+                surfaces
+            substrate_max_miller(int): maximum miller index to generate for
+                substrate surfaces
             max_length_tol: maximum length tolerance in checking if two
                 vectors are of nearly the same length
             max_angle_tol: maximum angle tolerance in checking of two sets
@@ -68,6 +75,8 @@ class ZSLGenerator(object):
         """
         self.max_area_ratio_tol = max_area_ratio_tol
         self.max_area = max_area
+        self.film_max_miller = film_max_miller
+        self.substrate_max_miller = substrate_max_miller
         self.max_length_tol = max_length_tol
         self.max_angle_tol = max_angle_tol
 
@@ -111,9 +120,9 @@ class ZSLGenerator(object):
                 a super lattice of area j*film area
         """
         transformation_indicies = [(i, j)
-                                   for i in range(1, int(self.max_area / film_area))
-                                   for j in range(1, int(self.max_area / substrate_area))
-                                   if np.absolute(film_area / substrate_area - float(j) / i) < self.max_area_ratio_tol]
+                               for i in range(1, int(self.max_area / film_area))
+                               for j in range(1, int(self.max_area / substrate_area))
+                               if np.absolute(film_area / substrate_area - float(j) / i) < self.max_area_ratio_tol]
 
         # Sort sets by the square of the matching area and yield in order
         # from smallest to largest
@@ -122,7 +131,7 @@ class ZSLGenerator(object):
                    gen_sl_transform_matricies(x[1]))
 
     def get_equiv_transformations(self, transformation_sets, film_vectors,
-                                  substrate_vectors):
+                              substrate_vectors):
         """
         Applies the transformation_sets to the film and substrate vectors
         to generate super-lattices and checks if they matches.
@@ -144,40 +153,100 @@ class ZSLGenerator(object):
         for (film_transformations, substrate_transformations) in \
                 transformation_sets:
             # Apply transformations and reduce using Zur reduce methodology
-            films = [reduce_vectors(*np.dot(f, film_vectors).tolist()) for f in film_transformations]
+            films = [reduce_vectors(*np.dot(f,film_vectors).tolist())for f in film_transformations]
 
-            substrates = [reduce_vectors(*np.dot(s, substrate_vectors).tolist()) for s in substrate_transformations]
+            substrates = [reduce_vectors(*np.dot(s,substrate_vectors).tolist())for s in substrate_transformations]
 
             # Check if equivelant super lattices
-            for f, s in product(films, substrates):
+            for f,s in product(films,substrates):
                 if self.is_same_vectors(f, s):
                     yield [f, s]
 
-    def __call__(self, film_vectors, substrate_vectors, lowest=False):
+    def generate_surface_vectors(self, film_millers, substrate_millers):
         """
-        Runs the ZSL algorithm to generate all possible matching
-        :return:
+        Generates the film/substrate slab combinations for a set of given
+        miller indicies
+
+        Args:
+            film_millers(array): all miller indices to generate slabs for
+                film
+            substrate_millers(array): all miller indicies to generate slabs
+                for substrate
         """
 
-        film_area = vec_area(*film_vectors)
-        substrate_area = vec_area(*substrate_vectors)
+        for f in film_millers:
+            film_slab = SlabGenerator(self.film, f, 20, 15,
+                                      primitive=False).get_slab()
+            film_vectors = reduce_vectors(film_slab.lattice.matrix[0],
+                                          film_slab.lattice.matrix[1])
+            film_area = vec_area(*film_vectors)
 
-        # Generate all super lattice comnbinations for a given set of miller
-        # indicies
-        transformation_sets = self.generate_sl_transformation_sets(film_area, substrate_area)
+            for s in substrate_millers:
+                substrate_slab = SlabGenerator(self.substrate, s, 20, 15,
+                                               primitive=False).get_slab()
+                substrate_vectors = reduce_vectors(
+                    substrate_slab.lattice.matrix[0],
+                    substrate_slab.lattice.matrix[1])
+                substrate_area = vec_area(*substrate_vectors)
 
-        # Check each super-lattice pair to see if they match
-        for match in self.get_equiv_transformations(transformation_sets,
+                yield [film_area, substrate_area, film_vectors,
+                       substrate_vectors, f, s]
+
+    def generate(self, film, substrate, film_millers=None, substrate_millers=None,
+                 lowest=False):
+        """
+        Generates the film/substrate combinations for either set miller
+        indicies or all possible miller indices up to a max miller index
+
+        Args:
+            film(Structure):  Conventional standard pymatgen structure for
+                the film
+            substrate(Struture): Conventional standard pymatgen Structure
+                for the substrate
+            film_millers(array): array of film miller indicies to consider
+                in the matching algorithm
+            substrate_millers(array): array of substrate miller indicies to
+                consider in the matching algorithm
+        """
+
+        # Sets film and substrate for search
+        self.substrate = substrate
+        self.film = film
+
+        # Generate miller indicies if none specified for film
+        if film_millers is None:
+            film_millers = sorted(get_symmetrically_distinct_miller_indices(
+                self.film, self.film_max_miller))
+
+        # Generate miller indicies if none specified for substrate
+        if substrate_millers is None:
+            substrate_millers = sorted(
+                get_symmetrically_distinct_miller_indices(self.substrate,
+                                                          self.substrate_max_miller))
+
+        # Check each miller index combination
+        for [film_area, substrate_area, film_vectors, substrate_vectors,
+             film_miller, substrate_miller] in self.generate_surface_vectors(film_millers,
+                                                                             substrate_millers):
+            # Generate all super lattice comnbinations for a given set of miller
+            # indicies
+            transformation_sets = self.generate_sl_transformation_sets(film_area, substrate_area)
+
+            # Check each super-lattice pair to see if they match
+            for match in self.get_equiv_transformations(transformation_sets,
                                                     film_vectors,
                                                     substrate_vectors):
-            # Yield the match area, the miller indicies,
-            yield self.match_as_dict(match[0], match[1], film_vectors, substrate_vectors, vec_area(*match[0]))
+                # Yield the match area, the miller indicies,
+                yield self.match_as_dict(film_miller, substrate_miller, match[0],
+                                         match[1], film_vectors, substrate_vectors, vec_area(*match[0]))
 
-            # Just want lowest match per direction
-            if (lowest):
-                break
+                # Just want lowest match per direction
+                if (lowest):
+                    break
 
-    def match_as_dict(self, film_sl_vectors, substrate_sl_vectors, film_vectors, substrate_vectors, match_area):
+    def match_as_dict(self, film_miller, substrate_miller, film_sl_vectors,
+                      substrate_sl_vectors, film_vectors, substrate_vectors,
+                      match_area):
         """
         Returns dict which contains ZSL match
 
@@ -186,6 +255,9 @@ class ZSLGenerator(object):
             substrate_miller(array)
         """
         d = {}
+
+        d["film_miller"] = np.asarray(film_miller).tolist()
+        d["sub_miller"] = np.asarray(substrate_miller).tolist()
         d["film_sl_vecs"] = np.asarray(film_sl_vectors).tolist()
         d["sub_sl_vecs"] = np.asarray(substrate_sl_vectors).tolist()
         d["match_area"] = match_area
@@ -193,7 +265,6 @@ class ZSLGenerator(object):
         d["sub_vecs"] = np.asarray(substrate_vectors).tolist()
 
         return d
-
 
 class SubstrateAnalyzer:
     """
@@ -205,50 +276,14 @@ class SubstrateAnalyzer:
     elastic strain energy of the super-lattices
     """
 
-    def __init__(self, zslgen=ZSLGenerator(), film_max_miller=1, substrate_max_miller=1):
+    def __init__(self, zslgen=ZSLGenerator()):
         """
             Initializes the substrate analyzer
             Args:
                 zslgen(ZSLGenerator): Defaults to a ZSLGenerator with standard
                     tolerances, but can be fed one with custom tolerances
-                film_max_miller(int): maximum miller index to generate for film
-                    surfaces
-                substrate_max_miller(int): maximum miller index to generate for
-                    substrate surfaces
         """
         self.zsl = zslgen
-        self.film_max_miller = film_max_miller
-        self.substrate_max_miller = substrate_max_miller
-
-    def generate_surface_vectors(self,film_millers, substrate_millers):
-        """
-        Generates the film/substrate slab combinations for a set of given
-        miller indicies
-
-        Args:
-            film_millers(array): all miller indices to generate slabs for
-                film
-            substrate_millers(array): all miller indicies to generate slabs
-                for substrate
-        """
-        vector_sets = []
-
-        for f in film_millers:
-            film_slab = SlabGenerator(self.film, f, 20, 15,
-                                      primitive=False).get_slab()
-            film_vectors = reduce_vectors(film_slab.lattice.matrix[0],
-                                          film_slab.lattice.matrix[1])
-
-            for s in substrate_millers:
-                substrate_slab = SlabGenerator(self.substrate, s, 20, 15,
-                                               primitive=False).get_slab()
-                substrate_vectors = reduce_vectors(
-                    substrate_slab.lattice.matrix[0],
-                    substrate_slab.lattice.matrix[1])
-
-                vector_sets.append((film_vectors, substrate_vectors, f, s))
-
-        return vector_sets
 
     def calculate(self, film, substrate, elasticity_tensor=None,
                   film_millers=None, substrate_millers=None,
@@ -270,35 +305,17 @@ class SubstrateAnalyzer:
             ground_state_energy(float): ground state energy for the film
             lowest(bool): only consider lowest matching area for each surface
         """
-        self.film = film
-        self.substrate = substrate
 
-        # Generate miller indicies if none specified for film
-        if film_millers is None:
-            film_millers = sorted(get_symmetrically_distinct_miller_indices(
-                self.film, self.film_max_miller))
+        for match in self.zsl.generate(film, substrate, film_millers, substrate_millers, lowest):
+            if (elasticity_tensor is not None):
+                energy, strain = self.calculate_3D_elastic_energy(
+                    film, match, elasticity_tensor, include_strain=True)
+                match["elastic_energy"] = energy
+                match["strain"] = strain
+            if (ground_state_energy is not 0):
+                match['total_energy'] = match.get('elastic_energy', 0) + ground_state_energy
 
-        # Generate miller indicies if none specified for substrate
-        if substrate_millers is None:
-            substrate_millers = sorted(
-                get_symmetrically_distinct_miller_indices(self.substrate,
-                                                          self.substrate_max_miller))
-
-        # Check each miller index combination
-        surface_vector_sets =  self.generate_surface_vectors(film_millers,substrate_millers)
-        for [film_vectors, substrate_vectors,film_miller, substrate_miller] in surface_vector_sets:
-            for match in self.zsl(film_vectors, substrate_vectors, lowest):
-                match['film_miller'] = film_miller
-                match['sub_miller'] = substrate_miller
-                if (elasticity_tensor is not None):
-                    energy, strain = self.calculate_3D_elastic_energy(
-                        film, match, elasticity_tensor, include_strain=True)
-                    match["elastic_energy"] = energy
-                    match["strain"] = strain
-                if (ground_state_energy is not 0):
-                    match['total_energy'] = match.get('elastic_energy', 0) + ground_state_energy
-
-                yield match
+            yield match
 
     def calculate_3D_elastic_energy(self, film, match, elasticity_tensor=None,
                                     include_strain=False):
@@ -317,16 +334,12 @@ class SubstrateAnalyzer:
         if elasticity_tensor is None:
             return 9999
 
-        # Get the appropriate surface structure
-        struc = SlabGenerator(self.film, match['film_miller'], 20, 15,
-                                      primitive=False).get_slab().oriented_unit_cell
-
         # Generate 3D lattice vectors for film super lattice
         film_matrix = list(match['film_sl_vecs'])
         film_matrix.append(np.cross(film_matrix[0], film_matrix[1]))
 
         # Generate 3D lattice vectors for substrate super lattice
-        # Out of plane substrate super lattice has to be same length as
+        # Out of place substrate super lattice has to be same length as
         # Film out of plane vector to ensure no extra deformation in that
         # direction
         substrate_matrix = list(match['sub_sl_vecs'])
@@ -339,16 +352,15 @@ class SubstrateAnalyzer:
 
         dfm = Deformation(transform_matrix)
 
-        strain = dfm.green_lagrange_strain.convert_to_ieee(struc,initial_fit=False)
+        strain = dfm.green_lagrange_strain.von_mises_strain
 
         energy_density = elasticity_tensor.energy_density(
-            strain)
+            dfm.green_lagrange_strain)
 
         if include_strain:
-            return (film.volume * energy_density / len(film.sites), strain.von_mises_strain)
+            return (film.volume * energy_density / len(film.sites), strain)
         else:
             return film.volume * energy_density / len(film.sites)
-
 
 def gen_sl_transform_matricies(area_multiple):
     """
@@ -371,13 +383,11 @@ def gen_sl_transform_matricies(area_multiple):
             for i in get_factors(area_multiple)
             for j in range(area_multiple // i)]
 
-
 def rel_strain(vec1, vec2):
     """
     Calculate relative strain between two vectors
     """
     return fast_norm(vec2) / fast_norm(vec1) - 1
-
 
 def rel_angle(vec_set1, vec_set2):
     """
@@ -390,13 +400,11 @@ def rel_angle(vec_set1, vec_set2):
     return vec_angle(vec_set2[0], vec_set2[1]) / vec_angle(
         vec_set1[0], vec_set1[1]) - 1
 
-
 def fast_norm(a):
     """
     Much faster variant of numpy linalg norm
     """
     return np.sqrt(np.dot(a, a))
-
 
 def vec_angle(a, b):
     """
@@ -406,13 +414,11 @@ def vec_angle(a, b):
     sinang = fast_norm(np.cross(a, b))
     return np.arctan2(sinang, cosang)
 
-
 def vec_area(a, b):
     """
     Area of lattice plane defined by two vectors
     """
     return fast_norm(np.cross(a, b))
-
 
 def reduce_vectors(a, b):
     """
@@ -432,7 +438,6 @@ def reduce_vectors(a, b):
         return reduce_vectors(a, np.subtract(b, a))
 
     return [a, b]
-
 
 def get_factors(n):
     """

--- a/pymatgen/analysis/substrate_analyzer.py
+++ b/pymatgen/analysis/substrate_analyzer.py
@@ -220,7 +220,7 @@ class SubstrateAnalyzer:
         self.film_max_miller = film_max_miller
         self.substrate_max_miller = substrate_max_miller
 
-    def generate_surface_vectors(self,film_millers, substrate_millers):
+    def generate_surface_vectors(self, film_millers, substrate_millers):
         """
         Generates the film/substrate slab combinations for a set of given
         miller indicies
@@ -285,8 +285,8 @@ class SubstrateAnalyzer:
                                                           self.substrate_max_miller))
 
         # Check each miller index combination
-        surface_vector_sets =  self.generate_surface_vectors(film_millers,substrate_millers)
-        for [film_vectors, substrate_vectors,film_miller, substrate_miller] in surface_vector_sets:
+        surface_vector_sets = self.generate_surface_vectors(film_millers, substrate_millers)
+        for [film_vectors, substrate_vectors, film_miller, substrate_miller] in surface_vector_sets:
             for match in self.zsl(film_vectors, substrate_vectors, lowest):
                 match['film_miller'] = film_miller
                 match['sub_miller'] = substrate_miller
@@ -319,7 +319,7 @@ class SubstrateAnalyzer:
 
         # Get the appropriate surface structure
         struc = SlabGenerator(self.film, match['film_miller'], 20, 15,
-                                      primitive=False).get_slab().oriented_unit_cell
+                              primitive=False).get_slab().oriented_unit_cell
 
         # Generate 3D lattice vectors for film super lattice
         film_matrix = list(match['film_sl_vecs'])
@@ -339,7 +339,7 @@ class SubstrateAnalyzer:
 
         dfm = Deformation(transform_matrix)
 
-        strain = dfm.green_lagrange_strain.convert_to_ieee(struc,initial_fit=False)
+        strain = dfm.green_lagrange_strain.convert_to_ieee(struc, initial_fit=False)
 
         energy_density = elasticity_tensor.energy_density(
             strain)

--- a/pymatgen/analysis/substrate_analyzer.py
+++ b/pymatgen/analysis/substrate_analyzer.py
@@ -263,6 +263,7 @@ class SubstrateAnalyzer:
             substrate(Structure): conventional standard structure for the
                 substrate
             elasticity_tensor(ElasticTensor): elasticity tensor for the film
+                in the IEEE orientation
             film_millers(array): film facets to consider in search as defined by
                 miller indicies
             substrate_millers(array): substrate facets to consider in search as

--- a/pymatgen/analysis/tests/test_substrate_analyzer.py
+++ b/pymatgen/analysis/tests/test_substrate_analyzer.py
@@ -48,9 +48,9 @@ class ZSLGenTest(PymatgenTest):
         self.assertFalse(z.is_same_vectors([[1.01, 2, 0], [0, 2, 0]],
                                            [[1, 0, 0], [0, 2.01, 0]]))
 
-        matches = list(z.generate(film, substrate))
+        matches = list(z(film.lattice.matrix[:2], substrate.lattice.matrix[:2]))
 
-        self.assertEqual(len(matches), 82)
+        self.assertEqual(len(matches), 8)
 
 
 class SubstrateAnalyzerTest(PymatgenTest):

--- a/pymatgen/analysis/tests/test_substrate_analyzer.py
+++ b/pymatgen/analysis/tests/test_substrate_analyzer.py
@@ -76,7 +76,7 @@ class SubstrateAnalyzerTest(PymatgenTest):
         s = SubstrateAnalyzer()
 
         matches = list(s.calculate(film,substrate,film_elac))
-        self.assertEqual(len(matches), 82)
+        self.assertEqual(len(matches), 192)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

Refactored the substrate analyzer code to be clearer and fixed some bugs along the way.
* ZSLGenerator now only implements the ZSL algorithm. It can be used for any sort of topological matching
* SubstrateAnalyzer takes on the brunt of generating different slabs of various miller indicies and feeding them to ZSLGenerator
* Fixed elastic energy being off by a factor of 10 due to units by using the units class
Note this still assumes the elastic tensor is in units of GPa.
* Fixed bug where the elastic tensor and the strain orientation might have been different by putting the strain in the IEEE orientation. Docs have been updated to state the elastic tensor should already be in the IEEE orientation. 