### PR TITLE
ENH: Implemented get_symmetrised_molecule + helper functions; Improved performance of generate_full_symmops

### DIFF
--- a/pymatgen/symmetry/analyzer.py
+++ b/pymatgen/symmetry/analyzer.py
@@ -16,10 +16,6 @@ from fractions import Fraction
 import numpy as np
 from numpy.linalg import matrix_power, multi_dot
 
-from numba import jit
-import numba as nb
-
-
 from six.moves import filter, map, zip
 from monty.dev import deprecated
 import spglib

--- a/pymatgen/symmetry/analyzer.py
+++ b/pymatgen/symmetry/analyzer.py
@@ -1307,8 +1307,8 @@ class PointGroupAnalyzer(object):
         """
         return self._combine_eq_sets(*self._get_eq_sets())
 
-    def get_symmetrized_molecule(self):
-        """Returns a symmetrised molecule
+    def symmetrize_molecule(self):
+        """Returns a symmetrized molecule
 
         The equivalent atoms obtained via
         :meth:`~pymatgen.symmetry.analyzer.PointGroupAnalyzer.get_equivalent_atoms`

--- a/pymatgen/symmetry/analyzer.py
+++ b/pymatgen/symmetry/analyzer.py
@@ -1226,13 +1226,13 @@ class PointGroupAnalyzer(object):
 
         for index in get_clustered_indices():
             sites = self.centered_mol.cart_coords[index]
-            rename = dict(enumerate(index))
             for i, reference in zip(index, sites):
                 for op in symm_ops:
                     rotated = np.dot(op, sites.T).T
                     matched_indices = find_in_coord_list(rotated, reference,
                                                          self.tol)
-                    matched_indices = {rename[i] for i in matched_indices}
+                    matched_indices = {
+                        dict(enumerate(index))[i] for i in matched_indices}
                     eq_sets[i] |= matched_indices
 
                     operations[i].update({j: op.T for j in matched_indices})
@@ -1269,7 +1269,7 @@ class PointGroupAnalyzer(object):
                     visited.add(j)
                     for k in tmp_eq_sets[j]:
                         new_tmp_eq_sets[k] = eq_sets[k] - visited
-                        ops[k][i] = np.dot(ops[k][j], ops[j][i])
+                        ops[k][i] = np.dot(ops[j][i], ops[k][j])
                         ops[i][k] = ops[k][i].T
                 tmp_eq_sets = new_tmp_eq_sets
             return visited, ops

--- a/pymatgen/symmetry/tests/test_analyzer.py
+++ b/pymatgen/symmetry/tests/test_analyzer.py
@@ -497,7 +497,6 @@ class PointGroupAnalyzerTest(PymatgenTest):
         eq_sets, ops = a.get_equivalent_atoms()
         self.assertTrue({0, 1} in eq_sets.values())
         self.assertTrue({2, 3, 4, 5} eq_sets.values())
-        self.assertTrue(np.allclose(np.dot(ops[2][3], ops[3][4]), ops[2][4]))
         sym_mol = a.symmetrize_molecule()
         coords = sym_mol.cart_coords
         for i, eq_set in eq_sets.items():

--- a/pymatgen/symmetry/tests/test_analyzer.py
+++ b/pymatgen/symmetry/tests/test_analyzer.py
@@ -493,8 +493,8 @@ class PointGroupAnalyzerTest(PymatgenTest):
         distortion = np.random.randn(len(C2H4), 3) / 10
         dist_mol = mg.Molecule(C2H4.species, C2H4.cart_coords + distortion)
 
-        sym_mol, eq_sets, ops = iterative_symmetrize(dist_mol, max_n=100,
-                                                     tol=1e-7)
+        eq = iterative_symmetrize(dist_mol, max_n=100, tol=1e-7)
+        sym_mol, eq_sets, ops = eq['sym_mol'], eq['eq_sets'], eq['sym_ops']
 
         self.assertTrue({0, 1} in eq_sets.values())
         self.assertTrue({2, 3, 4, 5} in eq_sets.values())

--- a/pymatgen/symmetry/tests/test_analyzer.py
+++ b/pymatgen/symmetry/tests/test_analyzer.py
@@ -491,7 +491,7 @@ class PointGroupAnalyzerTest(PymatgenTest):
     def test_symmetrize_molecule(self):
         np.random.seed(77)
         distortion = np.random.randn(len(C2H4), 3) / 10
-        dist_mol = mg.Molecule(C2H4.species, C2H4.cart_coords + distortion)
+        dist_mol = Molecule(C2H4.species, C2H4.cart_coords + distortion)
 
         eq = iterative_symmetrize(dist_mol, max_n=100, tol=1e-7)
         sym_mol, eq_sets, ops = eq['sym_mol'], eq['eq_sets'], eq['sym_ops']

--- a/pymatgen/symmetry/tests/test_analyzer.py
+++ b/pymatgen/symmetry/tests/test_analyzer.py
@@ -496,14 +496,15 @@ class PointGroupAnalyzerTest(PymatgenTest):
         sym_mol, eq_sets, ops = iterative_symmetrize(dist_mol, max_n=100,
                                                      tol=1e-7)
 
-        assert ({0, 1} in eq_sets.values())
-        assert ({2, 3, 4, 5} in eq_sets.values())
+        self.assertTrue({0, 1} in eq_sets.values())
+        self.assertTrue({2, 3, 4, 5} in eq_sets.values())
 
         coords = sym_mol.cart_coords
         for i, eq_set in eq_sets.items():
             for j in eq_set:
                 rotated = np.dot(ops[i][j], coords[i])
-                assert np.allclose(np.dot(ops[i][j], coords[i]), coords[j])
+                self.assertTrue(
+                    np.allclose(np.dot(ops[i][j], coords[i]), coords[j]))
 
     def test_tricky_structure(self):
         # for some reason this structure kills spglib1.9

--- a/pymatgen/symmetry/tests/test_analyzer.py
+++ b/pymatgen/symmetry/tests/test_analyzer.py
@@ -13,7 +13,7 @@ from pymatgen.core.sites import PeriodicSite
 from pymatgen.io.vasp.inputs import Poscar
 from pymatgen.io.vasp.outputs import Vasprun
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer, \
-    PointGroupAnalyzer, cluster_sites
+    PointGroupAnalyzer, cluster_sites, iterative_symmetrize
 from pymatgen.io.cif import CifParser
 from pymatgen.util.testing import PymatgenTest
 from pymatgen.core.structure import Molecule, Structure


### PR DESCRIPTION
# Summary
Closes materialsproject/pymatgen#746

New public functions:
* ``PointGroupAnalyzer.symmetrize_molecule``
* ``PointGroupAnalyzer.get_equivalent_atoms``

Changes in public functions:
* ``analyzer.cluster_sites`` now supports an optional boolean keyword argument ``give_only_index``, which defaults to ``False`` (previous behaviour)
* ``analyze.generate_full_symmops`` was optimised numerically and does not use recursion anymore. In the case of icosahedral point groups (tested on fullerene) the new implementation is 72 times faster.

New private functions (helper functions for ``PointGroupAnalyzer.get_equivalent_atoms``)
* ``PointGroupAnalyzer._get_eq_sets``
* ``PointGroupAnalyzer._combine_eq_sets``