### PR TITLE
QuasiharmonicDebyeApprox: Consider anaharmonic contribution to Debye temperature.

### DIFF
--- a/pymatgen/analysis/quasiharmonic.py
+++ b/pymatgen/analysis/quasiharmonic.py
@@ -26,7 +26,7 @@ from scipy.optimize import minimize
 from pymatgen.core.units import FloatWithUnit
 from pymatgen.analysis.eos import EOS, PolynomialEOS
 
-__author__ = "Kiran Mathew"
+__author__ = "Kiran Mathew, Brandon Bocklund"
 __credits__ = "Cormac Toher"
 
 
@@ -49,10 +49,13 @@ class QuasiharmonicDebyeApprox(object):
         use_mie_gruneisen (bool): whether or not to use the mie-gruneisen
             formulation to compute the gruneisen parameter.
             The default is the slater-gamma formulation.
+        anharmonic_contribution (bool): whether or not to consider the anharmonic
+            contribution to the Debye temperature. Cannot be used with
+            use_mie_gruneisen. Defaults to True.
     """
     def __init__(self, energies, volumes, structure, t_min=300.0, t_step=100,
                  t_max=300.0, eos="vinet", pressure=0.0, poisson=0.25,
-                 use_mie_gruneisen=False):
+                 use_mie_gruneisen=False, anharmonic_contribution=True):
         self.energies = energies
         self.volumes = volumes
         self.structure = structure
@@ -63,6 +66,9 @@ class QuasiharmonicDebyeApprox(object):
         self.pressure = pressure
         self.poisson = poisson
         self.use_mie_gruneisen = use_mie_gruneisen
+        self.anharmonic_contribution = anharmonic_contribution
+        if self.use_mie_gruneisen and self.anharmonic_contribution:
+            raise ValueError('The Mie-Gruneisen formulation and anharmonic contribution are circular referenced and cannot be used together.')
         self.mass = sum([e.atomic_mass for e in self.structure.species])
         self.natoms = self.structure.composition.num_atoms
         self.avg_mass = physical_constants["atomic mass constant"][0] \
@@ -182,6 +188,15 @@ class QuasiharmonicDebyeApprox(object):
         Calculates the debye temperature.
         Eq(6) in doi.org/10.1016/j.comphy.2003.12.001. Thanks to Joey.
 
+        Eq(6) above is equivalent to Eq(3) in doi.org/10.1103/PhysRevB.37.790
+        which does not consider anharmonic effects. Eq(20) in the same paper
+        and Eq(18) in doi.org/10.1016/j.commatsci.2009.12.006 both consider
+        anharmonic contributions to the Debye temperature through the Gruneisen
+        parameter at 0K (Gruneisen constant).
+
+        The anharmonic contribution is toggled by setting the anharmonic_contribution
+        to True or False in the QuasiharmonicDebyeApprox constructor.
+
         Args:
             volume (float): in Ang^3
 
@@ -191,8 +206,12 @@ class QuasiharmonicDebyeApprox(object):
         term1 = (2./3. * (1. + self.poisson) / (1. - 2. * self.poisson))**1.5
         term2 = (1./3. * (1. + self.poisson) / (1. - self.poisson))**1.5
         f = (3. / (2. * term1 + term2))**(1. / 3.)
-        return 2.9772e-11 * (volume / self.natoms) ** (-1. / 6.) * f * \
+        debye = 2.9772e-11 * (volume / self.natoms) ** (-1. / 6.) * f * \
                np.sqrt(self.bulk_modulus/self.avg_mass)
+        if self.anharmonic_contribution:
+            return debye * (self.ev_eos_fit.v0 / volume) ** (self.gruneisen_parameter(0, volume))
+        else:
+            return debye
 
     @staticmethod
     def debye_integral(y):

--- a/pymatgen/analysis/quasiharmonic.py
+++ b/pymatgen/analysis/quasiharmonic.py
@@ -51,11 +51,11 @@ class QuasiharmonicDebyeApprox(object):
             The default is the slater-gamma formulation.
         anharmonic_contribution (bool): whether or not to consider the anharmonic
             contribution to the Debye temperature. Cannot be used with
-            use_mie_gruneisen. Defaults to True.
+            use_mie_gruneisen. Defaults to False.
     """
     def __init__(self, energies, volumes, structure, t_min=300.0, t_step=100,
                  t_max=300.0, eos="vinet", pressure=0.0, poisson=0.25,
-                 use_mie_gruneisen=False, anharmonic_contribution=True):
+                 use_mie_gruneisen=False, anharmonic_contribution=False):
         self.energies = energies
         self.volumes = volumes
         self.structure = structure
@@ -209,9 +209,11 @@ class QuasiharmonicDebyeApprox(object):
         debye = 2.9772e-11 * (volume / self.natoms) ** (-1. / 6.) * f * \
                np.sqrt(self.bulk_modulus/self.avg_mass)
         if self.anharmonic_contribution:
-            return debye * (self.ev_eos_fit.v0 / volume) ** (self.gruneisen_parameter(0, volume))
+            gamma = self.gruneisen_parameter(0, self.ev_eos_fit.v0)  # 0K equilibrium Gruneisen parameter
+            return debye * (self.ev_eos_fit.v0 / volume) ** (gamma)
         else:
             return debye
+
 
     @staticmethod
     def debye_integral(y):

--- a/pymatgen/analysis/tests/test_quasiharmonic_debye_approx.py
+++ b/pymatgen/analysis/tests/test_quasiharmonic_debye_approx.py
@@ -112,7 +112,7 @@ direct
 
     def test_debye_temperature(self):
         theta = self.qhda.debye_temperature(self.opt_vol)
-        np.testing.assert_almost_equal(theta, 601.239096, 3)
+        np.testing.assert_approx_equal(theta, 601.239096, 4 )
 
     def test_gruneisen_paramter(self):
         gamma = self.qhda.gruneisen_parameter(0, self.qhda.ev_eos_fit.v0)

--- a/pymatgen/analysis/tests/test_quasiharmonic_debye_approx.py
+++ b/pymatgen/analysis/tests/test_quasiharmonic_debye_approx.py
@@ -48,7 +48,7 @@ class TestQuasiharmociDebyeApprox(unittest.TestCase):
         self.eos = "vinet"
         self.T = 300
         self.qhda = QuasiharmonicDebyeApprox(self.energies, self.volumes, struct, t_min=self.T,
-                                             t_max=self.T, eos=self.eos)
+                                             t_max=self.T, eos=self.eos, anharmonic_contribution=False)
         self.opt_vol = 11.957803302392925
 
     def test_bulk_modulus(self):

--- a/pymatgen/analysis/tests/test_quasiharmonic_debye_approx.py
+++ b/pymatgen/analysis/tests/test_quasiharmonic_debye_approx.py
@@ -48,7 +48,7 @@ class TestQuasiharmociDebyeApprox(unittest.TestCase):
         self.eos = "vinet"
         self.T = 300
         self.qhda = QuasiharmonicDebyeApprox(self.energies, self.volumes, struct, t_min=self.T,
-                                             t_max=self.T, eos=self.eos, anharmonic_contribution=False)
+                                             t_max=self.T, eos=self.eos)
         self.opt_vol = 11.957803302392925
 
     def test_bulk_modulus(self):
@@ -81,3 +81,51 @@ class TestQuasiharmociDebyeApprox(unittest.TestCase):
     def test_vibrational_free_energy(self):
         A = self.qhda.vibrational_free_energy(self.T, self.opt_vol)
         np.testing.assert_almost_equal(A, 0.494687, 3)
+
+class TestAnharmonicQuasiharmociDebyeApprox(unittest.TestCase):
+
+    def setUp(self):
+        struct = Structure.from_str("""FCC Al
+1.0
+2.473329 0.000000 1.427977
+0.824443 2.331877 1.427977
+0.000000 0.000000 2.855955
+Al
+1
+direct
+0.000000 0.000000 0.000000 Al""", fmt='POSCAR')
+
+        self.energies = [-3.69150886, -3.70788383, -3.71997361, -3.72522301,
+                         -3.73569569, -3.73649743, -3.74054982]
+        self.volumes = [14.824542034870653, 18.118887714656875, 15.373596786943025,
+                        17.569833126580278, 15.92265868064787, 17.02077912220064,
+                        16.471717630914863]
+        self.eos = "vinet"
+        self.T = 500
+        self.qhda = QuasiharmonicDebyeApprox(self.energies, self.volumes, struct, t_min=self.T,
+                                             t_max=self.T, eos=self.eos, anharmonic_contribution=True)
+        self.opt_vol = 17.216094889116807
+
+    def test_optimum_volume(self):
+        opt_vol = self.qhda.optimum_volumes[0]
+        np.testing.assert_almost_equal(opt_vol, self.opt_vol, 3)
+
+    def test_debye_temperature(self):
+        theta = self.qhda.debye_temperature(self.opt_vol)
+        np.testing.assert_almost_equal(theta, 601.239096, 3)
+
+    def test_gruneisen_paramter(self):
+        gamma = self.qhda.gruneisen_parameter(0, self.qhda.ev_eos_fit.v0)
+        np.testing.assert_almost_equal(gamma, 2.188302, 3)
+
+    def test_thermal_conductivity(self):
+        kappa = self.qhda.thermal_conductivity(self.T, self.opt_vol)
+        np.testing.assert_almost_equal(kappa, 21.810997, 1)
+
+    def test_vibrational_internal_energy(self):
+        u = self.qhda.vibrational_internal_energy(self.T, self.opt_vol)
+        np.testing.assert_almost_equal(u, 0.13845, 3)
+
+    def test_vibrational_free_energy(self):
+        A = self.qhda.vibrational_free_energy(self.T, self.opt_vol)
+        np.testing.assert_almost_equal(A, -0.014620, 3)


### PR DESCRIPTION
The Debye temperature can have anharmonic contributions which can be calculated through the Gruneisen parameter.

This change implements the anharmonic contribution by default (can be turned off) with updates to documentation to reflect the change.

Previous tests were updated to reflect the anharmonic contribution option.

For theoretical details see:
Moruzzi et al. Phys. Rev. B 37, 790–799 (1988). (Eq 20)
Shang et al. Comput. Mater. Sci. 47, 1040–1048 (2010). (Eq 18)

Result: 

![image](https://user-images.githubusercontent.com/7681751/29290747-3a603638-810f-11e7-8bf4-a737a7948bb9.png)

@matk86 please take a look
