### PR TITLE
Interface

### DIFF
--- a/pymatgen/analysis/interface_reactions.py
+++ b/pymatgen/analysis/interface_reactions.py
@@ -1,0 +1,337 @@
+from __future__ import division
+
+"""
+This module provides InterfacialReactivity class for analyzing interfacial reactions 
+and plotting reaction energy vs. mixing ratio between two reactants.
+
+Class Methods:
+
+    -- get_kinks: Gets information on critical reactions: [indices of kinks, critical
+                  mixing ratio x, critical energy, balanced reaction].
+    
+    -- get_products: Gets all potential potential products in interfacial reactions.
+    
+    -- labels: Dictionary version of class method get_kinks.
+
+    -- plot: Plots the reaction energy as a function of mixing ratios of reaction 
+             between electrolyte and cathode. Kinks are labeled.
+
+    -- minimum: Gets the minimum reaction energy E_min and corresponding mixing ratio
+                X_min: (x_min, energy_min).
+
+    -- get_no_mixing_energy: Gets only the reaction energies of reactants from 
+                             equilibration with the external reservoir.
+
+"""
+
+__author__ = "Yihan Xiao"
+__copyright__ = "Copyright 2011, The Materials Project"
+__version__ = "1.0"
+__maintainer__ = "Yihan Xiao"
+__email__ = "eric.xyh2011@gmail.com"
+__status__ = "Production"
+__date__ = "Mar 16 2017"
+
+import numpy as np
+import matplotlib.pylab as plt
+
+from pymatgen.phasediagram.maker import GrandPotentialPhaseDiagram
+from pymatgen.phasediagram.analyzer import PDAnalyzer
+from pymatgen.analysis.reaction_calculator import Reaction
+from pymatgen import Composition
+
+PDAnalyzer.numerical_tol = 1e-12
+
+class InterfacialReactivity:
+    """
+    A class for analyzing interfacial reactions and plotting reaction energy vs.
+    mixing ratio between two reactants.
+    """
+
+    def __init__(self, c1, c2, pd, norm=1, include_no_mixing_energy=0,
+                 pd_non_grand=None):
+        '''
+        Initiates the class.
+
+        :param c1, c2: Composition objects.
+        :param pd: PhaseDiagram object or GrandPotentialPhaseDiagram object built
+                from elements in c1 and c2.
+        :param norm: Whether or not the total number of atoms in each reactant
+                will be normalized to 1. If norm = 0, no normalization would
+                be performed.
+        :param include_no_mixing_energy: No_mixing_energy is the opposite number
+                of energy above grand potential convex hull, for a reactant. In
+                cases where reactions involve external reservoir, this param
+                determines whether no_mixing_energy of reactants will be included
+                in the final reaction energy calculation. By definition, if pd
+                is not GrandPotentialPhaseDiagram object, this param is 0.
+        :param pd_non_grand: PhaseDiagram object but not GrandPotentialPhaseDiagram
+                object, built from elements in c1 and c2.
+        '''
+        # Checks if pd is a GrandPotentialPhaseDiagram object.
+        self.grand = isinstance(pd,GrandPotentialPhaseDiagram)
+        assert not (include_no_mixing_energy and not self.grand), \
+            'Please provide grand phase diagram to compute no_mixing_energy for reactants!'
+        assert not (include_no_mixing_energy and not pd_non_grand),\
+            'Please also provide non-grand phase diagram to compute no_mixing_energy for reactants!'
+
+        # Keeps copy of original compositions.
+        self.c1_original = c1
+        self.c2_original = c2
+
+        # Two sets of composition attributes for different processing conditions:
+        # normalization with and without exluding element(s) from reservoir.
+        self.c1 = c1
+        self.c2 = c2
+        self.comp1 = c1
+        self.comp2 = c2
+
+        self.norm = norm
+        self.pd = pd
+        self.pda = PDAnalyzer(pd)
+        if pd_non_grand:
+            self.pd_non_grand = pd_non_grand
+
+        # Factor is the compositional ratio between composition self.c1 and processed
+        #  composition self.comp1. E.g., factor for Composition('SiO2') and Composition('O')
+        # is 2. This factor will be used to convert mixing ratio in self.comp1 - self.comp2
+        # tie line to that in self.c1 - self.c2 tie line.
+        self.factor1, self.factor2 = 1, 1
+
+        if self.grand:
+            # Excludes element(s) from reservoir.
+            self.comp1 = Composition({k:v for k,v in c1.items() if k not in pd.chempots})
+            self.comp2 = Composition({k:v for k,v in c2.items() if k not in pd.chempots})
+            # Calculate the factor for in case where self.grand =1 and self.norm =1.
+            factor1 = self.comp1.num_atoms / c1.num_atoms
+            factor2 = self.comp2.num_atoms / c2.num_atoms
+
+        if self.norm:
+                self.c1 = c1.fractional_composition
+                self.c2 = c2.fractional_composition
+                self.comp1 = self.comp1.fractional_composition
+                self.comp2 = self.comp2.fractional_composition
+                if self.grand:
+                    # Only when self.grand =1 and self.norm =1 will self.factor be updated.
+                    self.factor1 = factor1
+                    self.factor2 = factor2
+
+        # Computes energies for reactants in different scenarios.
+        if not self.grand:
+            # Use entry energy as reactant energy if no reservoir is present.
+            self.e1 = self._get_entry_energy(self.pd, self.comp1)
+            self.e2 = self._get_entry_energy(self.pd, self.comp2)
+        else:
+            if include_no_mixing_energy:
+                # Computing grand potentials needs compositions containing element(s)
+                # from reservoir, so self.c1 and self.c2 are used.
+                self.e1 = self._get_grand_potential(self.c1)
+                self.e2 = self._get_grand_potential(self.c2)
+            else:
+                self.e1 = self.pda.get_hull_energy(self.comp1)
+                self.e2 = self.pda.get_hull_energy(self.comp2)
+
+
+    def _get_entry_energy(self,pd,composition):
+        """
+        Returns the lowest entry energy for entries matching the COMPOSITION. Entries
+        with non-negative formation energies are excluded.
+        :param pd: PhaseDiagram object.
+        :param composition: Composition object that the target entry should match.
+        :return: The lowest entry energy among entries matching the COMPOSITION.
+        """
+        candidate = [i.energy_per_atom for i in pd.qhull_entries if
+                     i.composition.fractional_composition == composition.fractional_composition]
+        assert candidate != [], 'The reactant {} has no matching entry with negative' \
+                                ' formation energy!'.format(composition.reduced_formula)
+        min_entry_energy = min(candidate)
+        return min_entry_energy * composition.num_atoms
+
+    def _get_grand_potential(self,composition):
+        '''
+        Returns the grand potential Phi at a given composition and chemical potential(s).
+         E.g., Phi[c, mu_{Li}]= E_{hull}[c] - n_{Li}[c]mu_{Li}.
+        :param composition: Composition object.
+        :return: Grand potential at a given composition and chemical potential(s).
+        '''
+        grand_potential = self._get_entry_energy(self.pd_non_grand, composition) - \
+                          sum([composition[e] * mu for e, mu in self.pd.chempots.items()])
+        if self.norm:
+            # Normalizes energy to the composition excluding element(s) from reservoir.
+            grand_potential /= (1 - sum([composition.get_atomic_fraction(e.symbol)
+                                         for e, mu in self.pd.chempots.items()]))
+        return grand_potential
+
+
+    def _get_energy(self, x):
+        '''
+        Returns reaction energy at mixing ratio x:(1-x) for self.comp1:self.comp2.
+        :param x: Mixing ratio x.
+        :return: Reaction energy.
+        '''
+        return self.pda.get_hull_energy(self.comp1 * x + self.comp2 * (1-x)) - \
+               self.e1 * x - self.e2 * (1-x)
+
+    def _get_reaction(self, x, normalize=0):
+        '''
+        Returns balanced reaction at mixing ratio X:(1-X) for self.comp1:self.comp2.
+        :param x: Mixing ratio x.
+        :param normalize: Whether or not to normalize the sum of coefficients of reactants to 1.
+        :return: Reaction object.
+        '''
+        mix_comp = self.comp1 * x + self.comp2 * (1-x)
+        decomp = self.pda.get_decomposition(mix_comp)
+
+        if normalize:
+            reactant = list(set([self.c1, self.c2]))
+        else:
+            # Uses original composition for reactants.
+            reactant = list(set([self.c1_original, self.c2_original]))
+
+        if self.grand:
+            reactant += [Composition(e.symbol) for e, v in self.pd.chempots.items()]
+
+        product = [Composition(k.name) for k, v in decomp.items()]
+        reaction = Reaction(reactant, product)
+
+        if normalize:
+            x = self._convert(x,self.factor1,self.factor2)
+            if x == 1:
+                reaction.normalize_to(self.c1, x)
+            else:
+                reaction.normalize_to(self.c2, 1-x)
+        return reaction
+
+    def get_products(self):
+        """
+        Returns all potential products in interfacial reactions.
+        :return: List of product formulas. E.g., ['Li', 'O2','Mn'].
+        """
+        products = set()
+        for _,_,_,react in self.get_kinks():
+            products = products.union(set([k.reduced_formula for k in react.products]))
+        return list(products)
+
+    def _convert(self,x, factor1,factor2):
+        """
+        Converts mixing ratio x in comp1 - comp2 tie line to that in c1 - c2 tie line.
+        :param x: Mixing ratio x in comp1 - comp2 tie line.
+        :param factor1: Compositional ratio between composition c1 and processed composition comp1.
+                E.g., factor for Composition('SiO2') and Composition('O') is 2.
+        :param factor2: Compositional ratio between composition c2 and processed composition comp2.
+        :return: Mixing ratio in c1 - c2 tieline.
+        """
+        return x * factor2 / ((1-x) * factor1 + x * factor2)
+
+    def _reverse_convert(self,x, factor1,factor2):
+        """
+        Converts mixing ratio x in c1 - c2 tie line to that in comp1 - comp2 tie line.
+        :param x: Mixing ratio x in c1 - c2 tie line.
+        :param factor1: Compositional ratio between composition c1 and processed composition comp1.
+                E.g., factor for Composition('SiO2') and Composition('O') is 2.
+        :param factor2: Compositional ratio between composition c2 and processed composition comp2.
+        :return: Mixing ratio in comp1 - comp2 tie line.
+        """
+        return x * factor1 / ((1-x) * factor2 + x * factor1)
+
+    def get_kinks(self):
+        '''
+        Finds all the kinks in mixing ratio where reaction products changes along the tie line of
+        composition self.c1 and composition self.c2.
+        :return: Zip object of tuples (index, mixing ratio, reaction energy, reaction).
+        '''
+        c1_coord = self.pd.pd_coords(self.comp1)
+        c2_coord = self.pd.pd_coords(self.comp2)
+        n1 = self.comp1.num_atoms
+        n2 = self.comp2.num_atoms
+        critical_comp = self.pda.get_critical_compositions(self.comp1,self.comp2)
+        x_kink, energy_kink, react_kink = [], [], []
+        if all(c1_coord == c2_coord):
+            x_kink = [0,1]
+            energy_kink = [self._get_energy(x) for x in x_kink]
+            react_kink = [self._get_reaction(x) for x in x_kink]
+        else:
+            for i in reversed(critical_comp):
+                # Gets mixing ratio x at kinks.
+                c = self.pd.pd_coords(i)
+                x = np.linalg.norm(c-c2_coord) / np.linalg.norm(c1_coord-c2_coord)
+                # Modifies mixing ratio in case compositions self.comp1 and self.comp2 are not normalized.
+                x = x * n2 / (n1 + x * (n2 - n1))
+                # Converts mixing ratio in comp1 - comp2 tie line to that in c1 - c2 tie line.
+                x_converted = self._convert(x,self.factor1,self.factor2)
+                x_kink.append(x_converted)
+                # Gets reaction energy at kinks
+                energy_kink.append(self._get_energy(x))
+                # Gets balanced reaction at kinks
+                react_kink.append(self._get_reaction(x))
+        index_kink = range(1, len(critical_comp)+1)
+        return zip(index_kink, x_kink, energy_kink, react_kink)
+
+    def labels(self):
+        '''
+        Returns a dictionary containing kink information:
+        {index: 'x= mixing_ratio energy= reaction_energy reaction_equation'}.
+        :return: Dictionary object. E.g., {1: 'x= 0.0 energy = 0.0 Mn -> Mn',
+        2: 'x= 0.5 energy = -15.0 O2 + Mn -> MnO2', 3: 'x= 1.0 energy = 0.0 O2 -> O2'}.
+        '''
+        return {j:'x= '+str(round(x,4))+' energy = '+str(round(energy,4))+' '+str(reaction)
+                for j, x, energy, reaction in self.get_kinks()}
+
+    def plot(self):
+        '''
+        Plots reaction energy as a function of mixing ratio x in self.c1 - self.c2 tie line using pylab.
+        :return: Plot of reaction energy as a function of mixing ratio x.
+        '''
+        plt.rcParams['xtick.major.pad'] = '6'
+        plt.rcParams['ytick.major.pad'] = '6'
+        plt.rcParams['axes.linewidth'] = 2
+        npoint = 1000
+        xs = np.linspace(0, 1, npoint)
+
+        # Converts sampling points in self.c1 - self.c2 tie line to those in self.comp1 - self.comp2 tie line.
+        xs_reverse_converted = self._reverse_convert(xs, self.factor1,self.factor2)
+        energies = [self._get_energy(x) for x in xs_reverse_converted]
+        plt.plot(xs, energies, 'k-')
+
+        # Marks kinks and minimum energy point.
+        kinks = self.get_kinks()
+        _, x_kink, energy_kink, _, = zip(*kinks)
+        plt.scatter(x_kink, energy_kink, marker='o', c='blue', s=20)
+        plt.scatter(self.minimum()[0], self.minimum()[1], marker='*', c='red', s=300)
+
+        # Labels kinks with indices. Labels are made draggable in case of overlapping.
+        for index, x, energy, reaction in kinks:
+            plt.annotate(
+                index,
+                xy=(x, energy), xytext=(5, 30),
+                textcoords='offset points', ha='right', va='bottom',
+                arrowprops= dict(arrowstyle = '->', connectionstyle='arc3,rad=0')).draggable()
+        plt.xlim([-0.05,1.05])
+        if self.norm:
+            plt.ylabel('Energy (eV/atom)')
+        else:
+            plt.ylabel('Energy (eV/f.u.)')
+        plt.xlabel('$x$ in $x$ {} + $(1-x)$ {}'.format(self.c1.reduced_formula,self.c2.reduced_formula))
+        return plt
+
+    def minimum(self):
+        '''
+        Returns the minimum reaction energy E_min and corresponding mixing ratio X_min.
+        :return: Tuple (x_min, E_min).
+        '''
+        return min([(x,energy) for _,x,energy,_ in self.get_kinks()],key=lambda i:i[1])
+
+    def get_no_mixing_energy(self):
+        '''
+        Returns the opposite number of energy above grand potential convex hull for both reactants.
+        :return: [(reactant1, no_mixing_energy1),(reactant2,no_mixing_energy2)].
+        '''
+        assert self.grand == 1, 'Please provide grand potential phase diagram for computing no_mixing_energy!'
+
+        energy1 = self.pda.get_hull_energy(self.comp1) - self._get_grand_potential(self.c1)
+        energy2 = self.pda.get_hull_energy(self.comp2) - self._get_grand_potential(self.c2)
+        unit = 'eV/f.u.'
+        if self.norm:
+            unit = 'eV/atom'
+        return [(self.c1_original.reduced_formula + ' ({0})'.format(unit), energy1),
+                (self.c2_original.reduced_formula + ' ({0})'.format(unit), energy2)]

--- a/pymatgen/analysis/interface_reactions.py
+++ b/pymatgen/analysis/interface_reactions.py
@@ -6,15 +6,15 @@ and plotting reaction energy vs. mixing ratio between two reactants.
 
 Class Methods:
 
-    -- get_kinks: Gets information on critical reactions: [indices of kinks, critical
+    -- get_kinks: Gets information on critical reactions: [index of kink, critical
                   mixing ratio x, critical energy, balanced reaction].
     
-    -- get_products: Gets all potential potential products in interfacial reactions.
+    -- get_products: Gets all potential reaction products in interfacial reactions.
     
     -- labels: Dictionary version of class method get_kinks.
 
     -- plot: Plots the reaction energy as a function of mixing ratios of reaction 
-             between electrolyte and cathode. Kinks are labeled.
+             between reactants. Kinks are labeled with indices.
 
     -- minimum: Gets the minimum reaction energy E_min and corresponding mixing ratio
                 X_min: (x_min, energy_min).
@@ -25,12 +25,8 @@ Class Methods:
 """
 
 __author__ = "Yihan Xiao"
-__copyright__ = "Copyright 2011, The Materials Project"
-__version__ = "1.0"
-__maintainer__ = "Yihan Xiao"
 __email__ = "eric.xyh2011@gmail.com"
-__status__ = "Production"
-__date__ = "Mar 16 2017"
+__date__ = "Aug 15 2017"
 
 import numpy as np
 import matplotlib.pylab as plt
@@ -53,25 +49,27 @@ class InterfacialReactivity:
         '''
         Initiates the class.
 
-        :param c1, c2: Composition objects.
+        :param c1, c2: Composition objects for reactants.
         :param pd: PhaseDiagram object or GrandPotentialPhaseDiagram object built
                 from elements in c1 and c2.
         :param norm: Whether or not the total number of atoms in each reactant
-                will be normalized to 1. If norm = 0, no normalization would
-                be performed.
-        :param include_no_mixing_energy: No_mixing_energy is the opposite number
-                of energy above grand potential convex hull, for a reactant. In
-                cases where reactions involve external reservoir, this param
+                will be normalized to 1 for reaction energy calculations.
+        :param include_no_mixing_energy: No_mixing_energy for a reactant is the
+                opposite number of its energy above grand potential convex hull. In
+                cases where reactions involve elements reservoir, this param
                 determines whether no_mixing_energy of reactants will be included
-                in the final reaction energy calculation. By definition, if pd
-                is not GrandPotentialPhaseDiagram object, this param is 0.
+                in the final reaction energy calculation. By definition, if pd is
+                not a GrandPotentialPhaseDiagram object, this param is 0.
         :param pd_non_grand: PhaseDiagram object but not GrandPotentialPhaseDiagram
                 object, built from elements in c1 and c2.
         '''
-        # Checks if pd is a GrandPotentialPhaseDiagram object.
         self.grand = isinstance(pd,GrandPotentialPhaseDiagram)
+
+        # if pd is not a GrandPotentialPhaseDiagram object, include_no_mixing_energy should be 0.
         assert not (include_no_mixing_energy and not self.grand), \
             'Please provide grand phase diagram to compute no_mixing_energy for reactants!'
+        # if include_no_mixing_energy = 1, pd should be a GrandPotentialPhaseDiagram object,
+        # pd_non_grand should be a normal PhaseDiagram object.
         assert not (include_no_mixing_energy and not pd_non_grand),\
             'Please also provide non-grand phase diagram to compute no_mixing_energy for reactants!'
 
@@ -174,9 +172,10 @@ class InterfacialReactivity:
 
     def _get_reaction(self, x, normalize=0):
         '''
-        Returns balanced reaction at mixing ratio X:(1-X) for self.comp1:self.comp2.
+        Returns balanced reaction at mixing ratio x:(1-x) for self.comp1:self.comp2.
         :param x: Mixing ratio x.
         :param normalize: Whether or not to normalize the sum of coefficients of reactants to 1.
+                For unnormalized case, use original reactant compositions in reaction for clarity.
         :return: Reaction object.
         '''
         mix_comp = self.comp1 * x + self.comp2 * (1-x)
@@ -316,7 +315,7 @@ class InterfacialReactivity:
 
     def minimum(self):
         '''
-        Returns the minimum reaction energy E_min and corresponding mixing ratio X_min.
+        Returns the minimum reaction energy E_min and corresponding mixing ratio x_min.
         :return: Tuple (x_min, E_min).
         '''
         return min([(x,energy) for _,x,energy,_ in self.get_kinks()],key=lambda i:i[1])

--- a/pymatgen/analysis/tests/test_interface_reactions.py
+++ b/pymatgen/analysis/tests/test_interface_reactions.py
@@ -32,7 +32,6 @@ class InterfaceReactionTest(unittest.TestCase):
         self.ir.append(InterfacialReactivity(Composition('Mn'),Composition('Li2O'),self.gpd, norm=1, include_no_mixing_energy=1, pd_non_grand=self.pd))
 
     def test_get_entry_energy(self):
-        comp = Composition('MnO3')
         # Test normal functionality
         comp = Composition('MnO2')
         test2 = np.isclose(self.ir[0]._get_entry_energy(self.pd,comp), -30,atol=1e-03)

--- a/pymatgen/analysis/tests/test_interface_reactions.py
+++ b/pymatgen/analysis/tests/test_interface_reactions.py
@@ -1,5 +1,8 @@
 from __future__ import division, unicode_literals
 
+import matplotlib
+matplotlib.use('pdf')
+
 import unittest as unittest
 import numpy as np
 

--- a/pymatgen/analysis/tests/test_interface_reactions.py
+++ b/pymatgen/analysis/tests/test_interface_reactions.py
@@ -10,7 +10,6 @@ from pymatgen.analysis.interface_reactions import InterfacialReactivity
 
 class InterfaceReactionTest(unittest.TestCase):
 
-
     def setUp(self):
         self.entries = [ComputedEntry(Composition('Li'), 0),
                 ComputedEntry(Composition('Mn'), 0),
@@ -20,7 +19,6 @@ class InterfaceReactionTest(unittest.TestCase):
                 ComputedEntry(Composition('MnO3'), 20),
                 ComputedEntry(Composition('Li2O'), -10),
                 ComputedEntry(Composition('LiMnO2'), -30),
-                # ComputedEntry(Composition('LiMnO2'), -30),
                         ]
         self.pd = PhaseDiagram(self.entries)
         chempots = {'Li':-3}

--- a/pymatgen/analysis/tests/test_interface_reactions.py
+++ b/pymatgen/analysis/tests/test_interface_reactions.py
@@ -1,0 +1,168 @@
+from __future__ import division, unicode_literals
+
+import unittest as unittest
+import numpy as np
+
+from pymatgen import Composition
+from pymatgen.entries.computed_entries import ComputedEntry
+from pymatgen.phasediagram.maker import PhaseDiagram,GrandPotentialPhaseDiagram
+from pyabinitio.analysis.interface_reactions import InterfacialReactivity
+
+class InterfaceReactionTest(unittest.TestCase):
+
+
+    def setUp(self):
+        self.entries = [ComputedEntry(Composition('Li'), 0),
+                ComputedEntry(Composition('Mn'), 0),
+                ComputedEntry(Composition('O2'), 0),
+                ComputedEntry(Composition('MnO2'), -10),
+                ComputedEntry(Composition('Mn2O4'), -60),
+                ComputedEntry(Composition('MnO3'), 20),
+                ComputedEntry(Composition('Li2O'), -10),
+                ComputedEntry(Composition('LiMnO2'), -30),
+                # ComputedEntry(Composition('LiMnO2'), -30),
+                        ]
+        self.pd = PhaseDiagram(self.entries)
+        chempots = {'Li':-3}
+        self.gpd = GrandPotentialPhaseDiagram(self.entries, chempots)
+        self.ir = []
+        self.ir.append(InterfacialReactivity(Composition('O2'),Composition('Mn'),self.pd, norm=0, include_no_mixing_energy=0, pd_non_grand=None))
+        self.ir.append(InterfacialReactivity(Composition('MnO2'),Composition('Mn'),self.gpd, norm=0, include_no_mixing_energy=1, pd_non_grand=self.pd))
+        self.ir.append(InterfacialReactivity(Composition('Mn'),Composition('O2'),self.gpd, norm=1, include_no_mixing_energy=1, pd_non_grand=self.pd))
+        self.ir.append(InterfacialReactivity(Composition('Li2O'),Composition('Mn'),self.gpd, norm=0, include_no_mixing_energy=1, pd_non_grand=self.pd))
+        self.ir.append(InterfacialReactivity(Composition('Mn'),Composition('O2'),self.gpd, norm=1, include_no_mixing_energy=0, pd_non_grand=self.pd))
+        self.ir.append(InterfacialReactivity(Composition('Mn'),Composition('Li2O'),self.gpd, norm=1, include_no_mixing_energy=1, pd_non_grand=self.pd))
+
+        with self.assertRaises(Exception) as context1:
+            self.ir.append(InterfacialReactivity(Composition('O2'),Composition('Mn'),self.pd, norm=0, include_no_mixing_energy=1, pd_non_grand=None))
+        self.assertTrue('Please provide grand phase diagram to compute no_mixing_energy for reactants!' in context1.exception)
+
+        with self.assertRaises(Exception) as context2:
+            self.ir.append(InterfacialReactivity(Composition('O2'),Composition('Mn'),self.gpd, norm=0, include_no_mixing_energy=1, pd_non_grand=None))
+        self.assertTrue('Please also provide non-grand phase diagram to compute no_mixing_energy for reactants!' in context2.exception)
+
+    def test_get_entry_energy(self):
+        # Test AssertionError
+        comp = Composition('MnO3')
+        with self.assertRaises(Exception) as context1:
+            energy = self.ir[0]._get_entry_energy(self.pd,comp)
+        self.assertTrue('The reactant MnO3 has no matching entry with negative formation energy!' in context1.exception)
+        # Test normal functionality
+        comp = Composition('MnO2')
+        test2 = np.isclose(self.ir[0]._get_entry_energy(self.pd,comp), -30,atol=1e-03)
+        self.assertTrue(test2,'_get_entry_energy: energy for {} is wrong!'.format(comp.reduced_formula))
+
+    def test_get_grand_potential(self):
+        comp = Composition('LiMnO2')
+        # Test non-normalized case
+        test1 = np.isclose(self.ir[1]._get_grand_potential(comp), -27,atol=1e-03)
+        self.assertTrue(test1,'_get_grand_potential: Non-normalized case gets error!')
+
+        # Test normalized case
+        test2 = np.isclose(self.ir[2]._get_grand_potential(comp),-36,atol=1e-03)
+        self.assertTrue(test2, '_get_grand_potential: Normalized case gets error!')
+
+    def test_get_energy(self):
+        test1 = (np.isclose(self.ir[0]._get_energy(0.5),-15,atol=1e-03))
+        self.assertTrue(test1,'_get_energy: phase diagram gets error!')
+
+        test2 = (np.isclose(self.ir[3]._get_energy(0.6666666),-7.333333,atol=1e-03))
+        self.assertTrue(test2,'_get_energy: grand canonical phase diagram gets error!')
+
+    def test_get_reaction(self):
+        test1 = str(self.ir[0]._get_reaction(0.5))=='O2 + Mn -> MnO2'
+        self.assertTrue(test1,'_get_reaction: reaction not involving chempots species gets error!')
+
+        test2 = str(self.ir[0]._get_reaction(0.5,normalize=1))=='0.5 O2 + 0.5 Mn -> 0.5 MnO2'
+        self.assertTrue(test2,'_get_reaction: reaction not involving chempots species gets error!')
+
+        test3 = str(self.ir[3]._get_reaction(0.666666))=='2 Mn + 2 Li2O -> 4 Li + MnO2 + Mn'or '2 Mn + 2 Li2O -> 4 Li + Mn + MnO2'
+        self.assertTrue(test3,'_get_reaction: reaction involving chempots species gets error!')
+
+    def test_convert(self):
+        test_array = [(0.5,1,3),(0.4,2,3),(0,1,9),(1,2,7)]
+        result = [self.ir[0]._convert(x,f1,f2) for x,f1,f2 in test_array]
+        answer = [0.75,0.5,0,1]
+        self.assertTrue(np.allclose(result,answer), '_convert: conversion gets error! {0} expected, but gets {1}'.format(answer,result))
+
+    def test_reverse_convert(self):
+        test_array = [(0.5,1,3),(0.4,2,3),(0,1,9),(1,2,7)]
+        result = [self.ir[0]._reverse_convert(x,f1,f2) for x,f1,f2 in test_array]
+        answer = [0.25,0.3076923,0,1]
+        self.assertTrue(np.allclose(result,answer), '_convert: conversion gets error! {0} expected, but gets {1}'.format(answer,result))
+
+    def test_get_products(self):
+        test1 = sorted(self.ir[0].get_products())==sorted(['MnO2','O2','Mn'])
+        self.assertTrue(test1, 'get_products: decomposition products gets error for reaction not involving chempots species!')
+
+        test2 = sorted(self.ir[3].get_products())==sorted(['Li','MnO2','Mn','Li2O'])
+        self.assertTrue(test2, 'get_decomp: decomposition products gets error for reaction involving chempots species!')
+
+    def test_get_kinks(self):
+        ir = self.ir[0]
+        lst = list(self.ir[0].get_kinks())
+        index = [i[0] for i in lst]
+        x_kink = [i[1] for i in lst]
+        energy_kink = [i[2] for i in lst]
+        react_kink = [str(i[3]) for i in lst]
+        test1 = index == [1,2,3]
+        self.assertTrue(test1,'get_kinks:index gets error!')
+
+        test2 = np.allclose(x_kink,[0,0.5,1])
+        self.assertTrue(test2,'get_kinks:x kinks gets error!')
+
+        test3 = np.allclose(energy_kink,[0,-15,0])
+        self.assertTrue(test3,'get_kinks:energy kinks gets error!')
+
+        test4 = react_kink == ['Mn -> Mn','O2 + Mn -> MnO2','O2 -> O2']
+        self.assertTrue(test4,'get_kinks:reaction kinks gets error for {0} and {1} reaction!'.format(ir.c1_original.reduced_formula,ir.c2_original.reduced_formula))
+
+        ir = self.ir[4]
+
+    def test_labels(self):
+        ir = self.ir[0]
+        dict = ir.labels()
+        test1 = dict == {1: 'x= 0.0 energy = 0.0 Mn -> Mn', 2: 'x= 0.5 energy = -15.0 O2 + Mn -> MnO2', 3: 'x= 1.0 energy = 0.0 O2 -> O2'}
+        self.assertTrue(test1, 'labels:label does not match for interfacial system with {0} and {1}.'.format(ir.c1_original.reduced_formula,ir.c2_original.reduced_formula))
+
+    def test_plot(self):
+        # Test plot is hard. Here just to call the plot function to see if any error occurs.
+        for i in self.ir:
+            i.plot()
+
+    def test_minimum(self):
+        answer = [
+            (0.5, -15),
+            (0, 0),
+            (0.3333333, -10),
+            (0.6666666, -7.333333),
+            (0.3333333, -7.333333),
+            (0.1428571,-7.333333)
+        ]
+        for i,j in zip(self.ir,answer):
+            self.assertTrue(np.allclose(i.minimum(),j),'minimum: the system with {0} and {1} gets error!{2} expected, but gets {3}'.format(i.c1_original.reduced_formula,i.c2_original.reduced_formula,str(j),str(i.minimum())))
+
+    def test_get_no_mixing_energy(self):
+        with self.assertRaises(Exception) as context1:
+            self.ir[0].get_no_mixing_energy()
+        self.assertTrue('Please provide grand potential phase diagram for computing no_mixing_energy!' in context1.exception)
+
+        answer = [
+            [(u'MnO2 (eV/f.u.)', 0.0), (u'Mn (eV/f.u.)', 0.0)],
+            [(u'Mn (eV/atom)', 0.0), (u'O2 (eV/atom)', -4.0)],
+            [(u'Li2O (eV/f.u.)', 0.0), (u'Mn (eV/f.u.)', 0.0)],
+            [(u'Mn (eV/atom)', 0.0), (u'O2 (eV/atom)', -4.0)],
+            [(u'Mn (eV/atom)', 0.0), (u'Li2O (eV/atom)', 0.0)]
+        ]
+        def name_lst(lst):
+            return (lst[0][0],lst[1][0])
+        def energy_lst(lst):
+            return (lst[0][1],lst[1][1])
+        result_info = [i.get_no_mixing_energy() for i in self.ir if i.grand]
+        for i,j in zip(result_info,answer):
+            self.assertTrue(name_lst(i)==name_lst(j),'get_no_mixing_energy: names get error, {0} expected but gets {1}'.format(name_lst(j),name_lst(i)))
+            self.assertTrue(energy_lst(i)==energy_lst(j),'get_no_mixing_energy: no_mixing energies get error, {0} expected but gets {1}'.format(energy_lst(j),energy_lst(i)))
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/pymatgen/analysis/tests/test_interface_reactions.py
+++ b/pymatgen/analysis/tests/test_interface_reactions.py
@@ -31,20 +31,8 @@ class InterfaceReactionTest(unittest.TestCase):
         self.ir.append(InterfacialReactivity(Composition('Mn'),Composition('O2'),self.gpd, norm=1, include_no_mixing_energy=0, pd_non_grand=self.pd))
         self.ir.append(InterfacialReactivity(Composition('Mn'),Composition('Li2O'),self.gpd, norm=1, include_no_mixing_energy=1, pd_non_grand=self.pd))
 
-        with self.assertRaises(Exception) as context1:
-            self.ir.append(InterfacialReactivity(Composition('O2'),Composition('Mn'),self.pd, norm=0, include_no_mixing_energy=1, pd_non_grand=None))
-        self.assertTrue('Please provide grand phase diagram to compute no_mixing_energy for reactants!' in context1.exception)
-
-        with self.assertRaises(Exception) as context2:
-            self.ir.append(InterfacialReactivity(Composition('O2'),Composition('Mn'),self.gpd, norm=0, include_no_mixing_energy=1, pd_non_grand=None))
-        self.assertTrue('Please also provide non-grand phase diagram to compute no_mixing_energy for reactants!' in context2.exception)
-
     def test_get_entry_energy(self):
-        # Test AssertionError
         comp = Composition('MnO3')
-        with self.assertRaises(Exception) as context1:
-            energy = self.ir[0]._get_entry_energy(self.pd,comp)
-        self.assertTrue('The reactant MnO3 has no matching entry with negative formation energy!' in context1.exception)
         # Test normal functionality
         comp = Composition('MnO2')
         test2 = np.isclose(self.ir[0]._get_entry_energy(self.pd,comp), -30,atol=1e-03)
@@ -141,10 +129,6 @@ class InterfaceReactionTest(unittest.TestCase):
             self.assertTrue(np.allclose(i.minimum(),j),'minimum: the system with {0} and {1} gets error!{2} expected, but gets {3}'.format(i.c1_original.reduced_formula,i.c2_original.reduced_formula,str(j),str(i.minimum())))
 
     def test_get_no_mixing_energy(self):
-        with self.assertRaises(Exception) as context1:
-            self.ir[0].get_no_mixing_energy()
-        self.assertTrue('Please provide grand potential phase diagram for computing no_mixing_energy!' in context1.exception)
-
         answer = [
             [(u'MnO2 (eV/f.u.)', 0.0), (u'Mn (eV/f.u.)', 0.0)],
             [(u'Mn (eV/atom)', 0.0), (u'O2 (eV/atom)', -4.0)],

--- a/pymatgen/analysis/tests/test_interface_reactions.py
+++ b/pymatgen/analysis/tests/test_interface_reactions.py
@@ -33,8 +33,20 @@ class InterfaceReactionTest(unittest.TestCase):
         self.ir.append(InterfacialReactivity(Composition('Li2O'),Composition('Mn'),self.gpd, norm=0, include_no_mixing_energy=1, pd_non_grand=self.pd))
         self.ir.append(InterfacialReactivity(Composition('Mn'),Composition('O2'),self.gpd, norm=1, include_no_mixing_energy=0, pd_non_grand=self.pd))
         self.ir.append(InterfacialReactivity(Composition('Mn'),Composition('Li2O'),self.gpd, norm=1, include_no_mixing_energy=1, pd_non_grand=self.pd))
+        with self.assertRaises(Exception) as context1:
+            self.ir.append(InterfacialReactivity(Composition('O2'),Composition('Mn'),self.pd, norm=0, include_no_mixing_energy=1, pd_non_grand=None))
+        self.assertTrue('Please provide grand phase diagram to compute no_mixing_energy for reactants!' == str(context1.exception))
+
+        with self.assertRaises(Exception) as context2:
+             self.ir.append(InterfacialReactivity(Composition('O2'),Composition('Mn'),self.gpd, norm=0, include_no_mixing_energy=1, pd_non_grand=None))
+        self.assertTrue('Please also provide non-grand phase diagram to compute no_mixing_energy for reactants!' == str(context2.exception))
 
     def test_get_entry_energy(self):
+        # Test AssertionError
+        comp = Composition('MnO3')
+        with self.assertRaises(Exception) as context1:
+            energy = self.ir[0]._get_entry_energy(self.pd,comp)
+        self.assertTrue('The reactant MnO3 has no matching entry with negative formation energy!' == str(context1.exception))
         # Test normal functionality
         comp = Composition('MnO2')
         test2 = np.isclose(self.ir[0]._get_entry_energy(self.pd,comp), -30,atol=1e-03)
@@ -131,6 +143,9 @@ class InterfaceReactionTest(unittest.TestCase):
             self.assertTrue(np.allclose(i.minimum(),j),'minimum: the system with {0} and {1} gets error!{2} expected, but gets {3}'.format(i.c1_original.reduced_formula,i.c2_original.reduced_formula,str(j),str(i.minimum())))
 
     def test_get_no_mixing_energy(self):
+        with self.assertRaises(Exception) as context1:
+             self.ir[0].get_no_mixing_energy()
+        self.assertTrue('Please provide grand potential phase diagram for computing no_mixing_energy!' == str(context1.exception))
         answer = [
             [(u'MnO2 (eV/f.u.)', 0.0), (u'Mn (eV/f.u.)', 0.0)],
             [(u'Mn (eV/atom)', 0.0), (u'O2 (eV/atom)', -4.0)],

--- a/pymatgen/analysis/tests/test_interface_reactions.py
+++ b/pymatgen/analysis/tests/test_interface_reactions.py
@@ -6,7 +6,7 @@ import numpy as np
 from pymatgen import Composition
 from pymatgen.entries.computed_entries import ComputedEntry
 from pymatgen.phasediagram.maker import PhaseDiagram,GrandPotentialPhaseDiagram
-from pyabinitio.analysis.interface_reactions import InterfacialReactivity
+from pymatgen.analysis.interface_reactions import InterfacialReactivity
 
 class InterfaceReactionTest(unittest.TestCase):
 


### PR DESCRIPTION
## Summary

Add interface_reactions.py and its test file to pymatgen/analysis library. This module does analysis for interfacial reactions between two reactants, and plots reaction energy vs. mixing ratio x. The "Interfacial reaction" web app on Materials Project website will use this module for calculations.

* Gets critical mixing ratio where the composition tie lie intersects with phase diagram facets.
* Gets reaction energy and balanced reaction equation for each critical mixing ratio.
* Finds maximum driving force for interface reaction, which is a measure of the reactivity.
