### PR TITLE
Add Haven ratio-related attributes to DiffusionAnalyzer

### DIFF
--- a/pymatgen/analysis/diffusion_analyzer.py
+++ b/pymatgen/analysis/diffusion_analyzer.py
@@ -48,9 +48,18 @@ class DiffusionAnalyzer(MSONable):
 
         Diffusivity in cm^2 / s
 
+    .. attribute: chg_diffusivity
+
+        Charge diffusivity in cm^2 / s
+
     .. attribute: conductivity
 
         Conductivity in mS / cm
+
+    .. attribute: chg_conductivity
+
+        Conductivity derived from Nernst-Einstein equation using charge
+        diffusivity, in mS / cm
 
     .. attribute: diffusivity_components
 
@@ -60,22 +69,27 @@ class DiffusionAnalyzer(MSONable):
 
         A vector with conductivity in the a, b and c directions in mS / cm
 
-    .. attribute: diffusivity_sigma
+    .. attribute: diffusivity_std_dev
 
         Std dev in diffusivity in cm^2 / s. Note that this makes sense only
         for non-smoothed analyses.
 
-    .. attribute: conductivity_sigma
+    .. attribute: chg_diffusivity_std_dev
+
+        Std dev in charge diffusivity in cm^2 / s. Note that this makes sense only
+        for non-smoothed analyses.
+
+    .. attribute: conductivity_std_dev
 
         Std dev in conductivity in mS / cm. Note that this makes sense only
         for non-smoothed analyses.
 
-    .. attribute: diffusivity_components_sigma
+    .. attribute: diffusivity_components_std_dev
 
         A vector with std dev. in diffusivity in the a, b and c directions in
         cm^2 / cm. Note that this makes sense only for non-smoothed analyses.
 
-    .. attribute: conductivity_components_sigma
+    .. attribute: conductivity_components_std_dev
 
         A vector with std dev. in conductivity in the a, b and c directions
         in mS / cm. Note that this makes sense only for non-smoothed analyses.
@@ -93,6 +107,10 @@ class DiffusionAnalyzer(MSONable):
 
         nsteps x 1 array of the mean square displacement of specie.
 
+    .. attribute: mscd
+
+        nsteps x 1 array of the mean square charge displacement of specie.
+
     .. attribute: msd_components
 
         nsteps x 3 array of the MSD in each lattice direction of specie.
@@ -105,6 +123,9 @@ class DiffusionAnalyzer(MSONable):
     .. attribute: dt
 
         Time coordinate array.
+
+    .. attribute: haven_ratio
+        Haven ratio defined as diffusivity / chg_diffusivity.
     """
 
     def __init__(self, structure, displacements, specie, temperature,
@@ -222,6 +243,9 @@ class DiffusionAnalyzer(MSONable):
             sq_disp_ions = np.zeros((len(dc), len(dt)), dtype=np.double)
             msd_components = np.zeros(dt.shape + (3,))
 
+            # calculate mean square charge displacement
+            mscd = np.zeros_like(msd, dtype=np.double)
+
             for i, n in enumerate(timesteps):
                 if not smoothed:
                     dx = dc[:, i:i + 1, :]
@@ -233,12 +257,18 @@ class DiffusionAnalyzer(MSONable):
                 else:
                     dx = dc[:, n:, :] - dc[:, :-n, :]
                     dcomponents = dc[:, n:, :] - dc[:, :-n, :]
+
+                # Get msd
                 sq_disp = dx ** 2
                 sq_disp_ions[:, i] = np.average(np.sum(sq_disp, axis=2), axis=1)
                 msd[i] = np.average(sq_disp_ions[:, i][indices])
 
                 msd_components[i] = np.average(dcomponents[indices] ** 2,
                                                axis=(0, 1))
+
+                # Get mscd
+                sq_chg_disp = np.sum(dx[indices, :, :], axis=0) ** 2
+                mscd[i] = np.average(np.sum(sq_chg_disp, axis=1), axis=0) / len(indices)
 
             def weighted_lstsq(a, b):
                 if smoothed == "max":
@@ -248,6 +278,7 @@ class DiffusionAnalyzer(MSONable):
                 else:
                     return np.linalg.lstsq(a, b)
 
+            # Get self diffusivity
             m_components = np.zeros(3)
             m_components_res = np.zeros(3)
             a = np.ones((len(dt), 2))
@@ -261,11 +292,17 @@ class DiffusionAnalyzer(MSONable):
             # m shouldn't be negative
             m = max(m, 1e-15)
 
+            # Get also the charge diffusivity
+            (m_chg, c_chg), res_chg, _, _ = weighted_lstsq(a, mscd)
+            # m shouldn't be negative
+            m_chg = max(m_chg, 1e-15)
+
             # factor of 10 is to convert from A^2/fs to cm^2/s
             # factor of 6 is for dimensionality
             conv_factor = get_conversion_factor(self.structure, self.specie,
                                                 self.temperature)
             self.diffusivity = m / 60
+            self.chg_diffusivity = m_chg / 60
 
             # Calculate the error in the diffusivity using the error in the
             # slope from the lst sq.
@@ -279,7 +316,9 @@ class DiffusionAnalyzer(MSONable):
             denom = (n * np.sum((dt / 1000) ** 2) - np.sum(dt / 1000) ** 2) * (
                 n - 2)
             self.diffusivity_std_dev = np.sqrt(n * res[0] / denom) / 60 / 1000
+            self.chg_diffusivity_std_dev = np.sqrt(n * res_chg[0] / denom) / 60 / 1000
             self.conductivity = self.diffusivity * conv_factor
+            self.chg_conductivity = self.chg_diffusivity * conv_factor
             self.conductivity_std_dev = self.diffusivity_std_dev * conv_factor
 
             self.diffusivity_components = m_components / 20
@@ -297,8 +336,9 @@ class DiffusionAnalyzer(MSONable):
                 dc ** 2, axis=-1) ** 0.5, axis=1)
             self.max_framework_displacement = \
                 np.max(self.max_ion_displacements[framework_indices])
-
             self.msd = msd
+            self.mscd = mscd
+            self.haven_ratio = self.diffusivity / self.chg_diffusivity
             self.sq_disp_ions = sq_disp_ions
             self.msd_components = msd_components
             self.dt = dt
@@ -328,12 +368,14 @@ class DiffusionAnalyzer(MSONable):
                 coords + self.corrected_displacements[:, i, :],
                 coords_are_cartesian=True)
 
-    def get_summary_dict(self, include_msd_t=False):
+    def get_summary_dict(self, include_msd_t=False, include_mscd_t=False):
         """
         Provides a summary of diffusion information.
 
         Args:
             include_msd_t (bool): Whether to include mean square displace and
+                time data with the data.
+            include_msd_t (bool): Whether to include mean square charge displace and
                 time data with the data.
 
         Returns:
@@ -342,8 +384,11 @@ class DiffusionAnalyzer(MSONable):
         d = {
             "D": self.diffusivity,
             "D_sigma": self.diffusivity_std_dev,
+            "D_charge": self.chg_diffusivity,
+            "D_charge_sigma": self.chg_diffusivity_std_dev,
             "S": self.conductivity,
             "S_sigma": self.conductivity_std_dev,
+            "S_charge": self.chg_conductivity,
             "D_components": self.diffusivity_components.tolist(),
             "S_components": self.conductivity_components.tolist(),
             "D_components_sigma": self.diffusivity_components_std_dev.tolist(),
@@ -352,12 +397,15 @@ class DiffusionAnalyzer(MSONable):
             "step_skip": self.step_skip,
             "time_step": self.time_step,
             "temperature": self.temperature,
-            "max_framework_displacement": self.max_framework_displacement
+            "max_framework_displacement": self.max_framework_displacement,
+            "Haven_ratio": self.haven_ratio
         }
         if include_msd_t:
             d["msd"] = self.msd.tolist()
             d["msd_components"] = self.msd_components.tolist()
             d["dt"] = self.dt.tolist()
+        if include_mscd_t:
+            d["mscd"] = self.mscd.tolist()
         return d
 
     def get_framework_rms_plot(self, plt=None, granularity=200,
@@ -423,7 +471,8 @@ class DiffusionAnalyzer(MSONable):
             plt: A plot object. Defaults to None, which means one will be
                 generated.
             mode (str): Determines type of msd plot. By "species", "sites",
-                or direction (default).
+                or direction (default). If mode = "mscd", the smoothed mscd vs.
+                time will be plotted.
         """
         from pymatgen.util.plotting import pretty_plot
         plt = pretty_plot(12, 8, plt=plt)
@@ -447,6 +496,9 @@ class DiffusionAnalyzer(MSONable):
                 plt.plot(plot_dt, sd, label="%s - %d" % (
                     site.specie.__str__(), i))
             plt.legend(loc=2, prop={"size": 20})
+        elif mode == "mscd":
+            plt.plot(plot_dt, self.mscd, 'r')
+            plt.legend(["Overall"], loc=2, prop={"size": 20})
         else:
             # Handle default / invalid mode case
             plt.plot(plot_dt, self.msd, 'k')
@@ -454,8 +506,12 @@ class DiffusionAnalyzer(MSONable):
             plt.plot(plot_dt, self.msd_components[:, 1], 'g')
             plt.plot(plot_dt, self.msd_components[:, 2], 'b')
             plt.legend(["Overall", "a", "b", "c"], loc=2, prop={"size": 20})
+
         plt.xlabel("Timestep ({})".format(unit))
-        plt.ylabel("MSD ($\\AA^2$)")
+        if mode == "mscd":
+            plt.ylabel("MSCD ($\\AA^2$)")
+        else:
+            plt.ylabel("MSD ($\\AA^2$)")
         plt.tight_layout()
         return plt
 
@@ -464,10 +520,11 @@ class DiffusionAnalyzer(MSONable):
         Plot the smoothed msd vs time graph. Useful for checking convergence.
 
         Args:
-            mode (str): Either "default" (the default, shows only the MSD for
+            mode (str): Can be "default" (the default, shows only the MSD for
                 the diffusing specie, and its components), "ions" (individual
-                square displacements of all ions), or "species" (mean square
-                displacement by specie).
+                square displacements of all ions), "species" (mean square
+                displacement by specie), or "mscd" (overall mean square charge
+                displacement for diffusing specie).
         """
         self.get_msd_plot(mode=mode).show()
 
@@ -486,13 +543,15 @@ class DiffusionAnalyzer(MSONable):
         with open(filename, "wt") as f:
             if fmt == "dat":
                 f.write("# ")
-            f.write(delimiter.join(["t", "MSD", "MSD_a", "MSD_b", "MSD_c"]))
+            f.write(delimiter.join(["t", "MSD", "MSD_a", "MSD_b", "MSD_c",
+                                    "MSCD"]))
             f.write("\n")
-
-            for dt, msd, msdc in zip(self.dt, self.msd, self.msd_components):
+            for dt, msd, msdc, mscd in zip(self.dt, self.msd,
+                                           self.msd_components, self.mscd):
                 f.write(delimiter.join(["%s" % v for v in [dt, msd] + list(
-                    msdc)]))
+                    msdc) + [mscd]]))
                 f.write("\n")
+
 
     @classmethod
     def from_structures(cls, structures, specie, temperature,

--- a/pymatgen/analysis/tests/test_diffusion_analyzer.py
+++ b/pymatgen/analysis/tests/test_diffusion_analyzer.py
@@ -78,9 +78,13 @@ class DiffusionAnalyzerTest(PymatgenTest):
             d = DiffusionAnalyzer.from_dict(dd)
             # large tolerance because scipy constants changed between 0.16.1 and 0.17
             self.assertAlmostEqual(d.conductivity, 74.165372613735684, 4)
+            self.assertAlmostEqual(d.chg_conductivity, 232.827958801, 4)
             self.assertAlmostEqual(d.diffusivity,  1.16083658794e-06, 7)
+            self.assertAlmostEqual(d.chg_diffusivity, 3.64565578208e-06, 7)
             self.assertAlmostEqual(d.conductivity_std_dev, 0.0097244677795984488, 7)
             self.assertAlmostEqual(d.diffusivity_std_dev, 9.1013023085561779e-09, 7)
+            self.assertAlmostEqual(d.chg_diffusivity_std_dev, 7.20911399729e-10, 5)
+            self.assertAlmostEqual(d.haven_ratio, 0.31854161048867402, 7)
             self.assertArrayAlmostEqual(
                 d.conductivity_components,
                 [45.7903694,   26.1651956,  150.5406140], 3)
@@ -94,6 +98,10 @@ class DiffusionAnalyzerTest(PymatgenTest):
             self.assertArrayAlmostEqual(
                 d.diffusivity_components_std_dev,
                 [8.9465670e-09,   2.4931224e-08,   2.2636384e-08]
+            )
+            self.assertArrayAlmostEqual(
+                d.mscd[0:4],
+                [0.69131064, 0.71794072, 0.74315283, 0.76703961]
             )
 
             self.assertArrayAlmostEqual(
@@ -118,7 +126,8 @@ class DiffusionAnalyzerTest(PymatgenTest):
 
             self.assertEqual(d.sq_disp_ions.shape, (50, 206))
             self.assertEqual(d.lattices.shape, (1, 3, 3))
-
+            self.assertEqual(d.mscd.shape, (206,))
+            self.assertEqual(d.mscd.shape, d.msd.shape)
             self.assertAlmostEqual(d.max_framework_displacement, 1.18656839605)
 
             ss = list(d.get_drift_corrected_structures(10, 1000, 20))
@@ -139,11 +148,15 @@ class DiffusionAnalyzerTest(PymatgenTest):
                                   d.time_step, d.step_skip, smoothed="max")
             self.assertAlmostEqual(d.conductivity, 74.165372613735684, 4)
             self.assertAlmostEqual(d.diffusivity, 1.14606446822e-06, 7)
+            self.assertAlmostEqual(d.haven_ratio, 0.318541610489, 6)
+            self.assertAlmostEqual(d.chg_conductivity, 232.827958801, 4)
+            self.assertAlmostEqual(d.chg_diffusivity, 3.64565578208e-06, 7)
 
             d = DiffusionAnalyzer(d.structure, d.disp, d.specie, d.temperature,
                                   d.time_step, d.step_skip, smoothed=False)
             self.assertAlmostEqual(d.conductivity, 27.20479170406027, 4)
             self.assertAlmostEqual(d.diffusivity, 4.25976905436e-07, 7)
+            self.assertAlmostEqual(d.chg_diffusivity, 1.6666666666666667e-17, 3)
 
             d = DiffusionAnalyzer(d.structure, d.disp, d.specie, d.temperature,
                                   d.time_step, d.step_skip,
@@ -151,6 +164,7 @@ class DiffusionAnalyzerTest(PymatgenTest):
 
             self.assertAlmostEqual(d.conductivity, 47.404056230438741, 4)
             self.assertAlmostEqual(d.diffusivity, 7.4226016496716148e-07, 7)
+            self.assertAlmostEqual(d.chg_conductivity, 1.06440821953e-09, 4)
 
             # Can't average over 2000 steps because this is a 1000-step run.
             self.assertRaises(ValueError, DiffusionAnalyzer,
@@ -174,6 +188,7 @@ class DiffusionAnalyzerTest(PymatgenTest):
             data.pop(0)
             data = np.array(data, dtype=np.float64)
             self.assertArrayAlmostEqual(data[:, 1], d.msd)
+            self.assertArrayAlmostEqual(data[:, -1], d.mscd)
             os.remove("test.csv")
 
     def test_init_npt(self):
@@ -185,9 +200,13 @@ class DiffusionAnalyzerTest(PymatgenTest):
             d = DiffusionAnalyzer.from_dict(dd)
             # large tolerance because scipy constants changed between 0.16.1 and 0.17
             self.assertAlmostEqual(d.conductivity, 499.15058192970508, 4)
+            self.assertAlmostEqual(d.chg_conductivity, 1219.59633107, 4)
             self.assertAlmostEqual(d.diffusivity,  8.40265434771e-06, 7)
+            self.assertAlmostEqual(d.chg_diffusivity, 2.05305709033e-05, 6)
             self.assertAlmostEqual(d.conductivity_std_dev, 0.10368477696021029, 7)
             self.assertAlmostEqual(d.diffusivity_std_dev, 9.1013023085561779e-09, 7)
+            self.assertAlmostEqual(d.chg_diffusivity_std_dev, 1.20834853646e-08, 6)
+            self.assertAlmostEqual(d.haven_ratio, 0.409275240679, 7)
             self.assertArrayAlmostEqual(
                 d.conductivity_components,
                 [455.178101,   602.252644,  440.0210014], 3)
@@ -229,6 +248,8 @@ class DiffusionAnalyzerTest(PymatgenTest):
 
             self.assertEqual(d.sq_disp_ions.shape, (84, 217))
             self.assertEqual(d.lattices.shape, (1001, 3, 3))
+            self.assertEqual(d.mscd.shape, (217,))
+            self.assertEqual(d.mscd.shape, d.msd.shape)
 
             self.assertAlmostEqual(d.max_framework_displacement, 1.43415505156)
 
@@ -250,11 +271,15 @@ class DiffusionAnalyzerTest(PymatgenTest):
                                   d.time_step, d.step_skip, smoothed="max")
             self.assertAlmostEqual(d.conductivity, 499.15058192970508, 4)
             self.assertAlmostEqual(d.diffusivity, 8.40265434771e-06, 7)
+            self.assertAlmostEqual(d.haven_ratio, 0.409275240679, 7)
+            self.assertAlmostEqual(d.chg_diffusivity, 2.05305709033e-05, 7)
 
             d = DiffusionAnalyzer(d.structure, d.disp, d.specie, d.temperature,
                                   d.time_step, d.step_skip, smoothed=False)
             self.assertAlmostEqual(d.conductivity, 406.5965396, 4)
             self.assertAlmostEqual(d.diffusivity, 6.8446082e-06, 7)
+            self.assertAlmostEqual(d.chg_diffusivity, 1.03585877962e-05, 6)
+            self.assertAlmostEqual(d.haven_ratio, 0.6607665413, 6)
 
             d = DiffusionAnalyzer(d.structure, d.disp, d.specie, d.temperature,
                                   d.time_step, d.step_skip,
@@ -262,6 +287,9 @@ class DiffusionAnalyzerTest(PymatgenTest):
 
             self.assertAlmostEqual(d.conductivity, 425.7789898, 4)
             self.assertAlmostEqual(d.diffusivity, 7.167523809142514e-06, 7)
+            self.assertAlmostEqual(d.chg_diffusivity, 9.33480892187e-06, 6)
+            self.assertAlmostEqual(d.haven_ratio, 0.767827586952, 6)
+            self.assertAlmostEqual(d.chg_conductivity, 554.524214937, 6)
 
             # Can't average over 2000 steps because this is a 1000-step run.
             self.assertRaises(ValueError, DiffusionAnalyzer,
@@ -275,6 +303,8 @@ class DiffusionAnalyzerTest(PymatgenTest):
                 d.step_skip, smoothed=d.smoothed, avg_nsteps=100)
             self.assertAlmostEqual(d.conductivity, 425.77898986201302, 4)
             self.assertAlmostEqual(d.diffusivity, 7.1675238091425148e-06, 7)
+            self.assertAlmostEqual(d.haven_ratio, 0.767827586952, 7)
+            self.assertAlmostEqual(d.chg_conductivity, 554.524214937, 6)
 
             d.export_msdt("test.csv")
             with open("test.csv") as f:
@@ -285,6 +315,7 @@ class DiffusionAnalyzerTest(PymatgenTest):
             data.pop(0)
             data = np.array(data, dtype=np.float64)
             self.assertArrayAlmostEqual(data[:, 1], d.msd)
+            self.assertArrayAlmostEqual(data[:, -1], d.mscd)
             os.remove("test.csv")
 
 

--- a/pymatgen/util/plotting.py
+++ b/pymatgen/util/plotting.py
@@ -190,7 +190,8 @@ def pretty_polyfit_plot(x, y, deg=1, xlabel=None, ylabel=None,
 
 
 def periodic_table_heatmap(elemental_data, cbar_label="",
-                           show_plot=False, cmap="YlOrRd", blank_color="grey"):
+                           show_plot=False, cmap="YlOrRd", blank_color="grey",
+                           show_value=True):
     """
     A static method that generates a heat map overlapped on a periodic table.
 
@@ -226,7 +227,7 @@ def periodic_table_heatmap(elemental_data, cbar_label="",
     # We set nan type values to masked values (ie blank spaces)
     data_mask = np.ma.masked_invalid(value_table.tolist())
     heatmap = ax.pcolor(data_mask, cmap=cmap, edgecolors='w', linewidths=1,
-                        vmin=min_val, vmax=max_val)
+                        vmin=min_val-0.001, vmax=max_val+0.001)
     cbar = fig.colorbar(heatmap)
 
     # Grey out missing elements in input data
@@ -246,7 +247,7 @@ def periodic_table_heatmap(elemental_data, cbar_label="",
                 plt.text(j + 0.5, i + 0.25, symbol,
                          horizontalalignment='center',
                          verticalalignment='center', fontsize=14)
-                if el != blank_value:
+                if el != blank_value and show_value:
                     plt.text(j + 0.5, i + 0.5, "%.2f" % (el),
                              horizontalalignment='center',
                              verticalalignment='center', fontsize=10)


### PR DESCRIPTION
## Summary

- Add Haven ratio, charge diffusivity, etc. as new attributes in DiffusionAnalyzer.
- Add unittests for the new additions (for both NpT and NVT simulations).
- Minor bugfix in periodic heatmap (when vmin = vmax).