### PR TITLE
I modified two lines in "get_projected_plots_dots_patom_pmorb" method…

### DIFF
--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -1366,13 +1366,13 @@ class BSPlotterProjected(BSPlotter):
                     for b in branches:
                         br += 1
                         for i in range(self._nb_bands):
-                            plt.plot(map(lambda x: x-shift[br], data['distances'][b]),
+                            plt.plot(list(map(lambda x: x-shift[br], data['distances'][b])),
                                  [data['energy'][b][str(Spin.up)][i][j]
                                   for j in range(len(data['distances'][b]))],
                                  'b-', linewidth=band_linewidth)
 
                             if self._bs.is_spin_polarized:
-                                plt.plot(map(lambda x: x-shift[br], data['distances'][b]),
+                                plt.plot(list(map(lambda x: x-shift[br], data['distances'][b])),
                                      [data['energy'][b][str(Spin.down)][i][j]
                                       for j in range(len(data['distances'][b]))],
                                      'r--', linewidth=band_linewidth)


### PR DESCRIPTION
… in plotter.py file.

These changes make the usage of "map" function suitable with both python 2.x and python 3.x

## Summary

Short few sentences, and summary of the major changes in bullet 
points

* Feature 1
* Feature 2
* Fix 1
* Fix 2

## Additional dependencies introduced (if any)

* List all new dependencies needed. While adding dependencies that bring
significantly useful functionality is perfectly fine, adding ones that 
add trivial functionality, e.g., to use one single easily implementable
function, is frowned upon. Provide a justification why that dependency is needed. 
Especially frowned upon are circular dependencies, e.g., depending on derivative
modules of pymatgen such as custodian or Fireworks.

## TODO (if any)

If this is a work-in-progress, write something about what else needs 
to be done

* Feature 1 supports a, but not b.