### PR TITLE
Bug fix min_freq() in phonon/bandstructure.py

### DIFF
--- a/pymatgen/phonon/bandstructure.py
+++ b/pymatgen/phonon/bandstructure.py
@@ -103,7 +103,7 @@ class PhononBandStructure(MSONable):
         """
         i = np.unravel_index(np.argmin(self.bands), self.bands.shape)
 
-        return self.qpoints[i[0]], self.bands[i]
+        return self.qpoints[i[1]], self.bands[i]
 
     def has_imaginary_freq(self, tol=1e-5):
         """


### PR DESCRIPTION
## Summary

The method min_freq in the PhononBandStructure object returns the wrong q-point. In its current form, the method would return the q-point with the index of the band that contains the minimum instead of using the index of the minimum frequency.

Fix: Change self.qpoints[i[0]] in line 106 to self.qpoints[i[1]]

