### PR TITLE
fix parsing BSE vasprun error

### DIFF
--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -389,7 +389,7 @@ class Vasprun(MSONable):
         try:
             if "BSE" in self.incar["ALGO"]:
                 pass
-            if not self.converged:
+            elif not self.converged:
                 msg = "%s is an unconverged VASP run.\n" % filename
                 msg += "Electronic convergence reached: %s.\n" % \
                        self.converged_electronic

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -386,7 +386,9 @@ class Vasprun(MSONable):
             if parse_potcar_file:
                 self.update_potcar_spec(parse_potcar_file)
 
-        if not self.converged:
+        if self.incar["ALGO"] == "BSE":
+            pass
+        elif not self.converged:
             msg = "%s is an unconverged VASP run.\n" % filename
             msg += "Electronic convergence reached: %s.\n" % \
                    self.converged_electronic

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -386,14 +386,17 @@ class Vasprun(MSONable):
             if parse_potcar_file:
                 self.update_potcar_spec(parse_potcar_file)
 
-        if self.incar["ALGO"] == "BSE":
+        try:
+            if "BSE" in self.incar["ALGO"]:
+                pass
+            if not self.converged:
+                msg = "%s is an unconverged VASP run.\n" % filename
+                msg += "Electronic convergence reached: %s.\n" % \
+                       self.converged_electronic
+                msg += "Ionic convergence reached: %s." % self.converged_ionic
+                warnings.warn(msg, UnconvergedVASPWarning)
+        except:
             pass
-        elif not self.converged:
-            msg = "%s is an unconverged VASP run.\n" % filename
-            msg += "Electronic convergence reached: %s.\n" % \
-                   self.converged_electronic
-            msg += "Ionic convergence reached: %s." % self.converged_ionic
-            warnings.warn(msg, UnconvergedVASPWarning)
 
     def _parse(self, stream, parse_dos, parse_eigen, parse_projected_eigen):
         self.efermi = None


### PR DESCRIPTION
## Summary

When Vasprun() parses vasprun.xml , it generally first checks the convergence status (electronic and ionic). However, there is no electronic or ionic step in BSE calc. This fix is to ignore the convergence checking of BSE vasprun.xml.