### PR TITLE
fix slab set as_dict issue and add unittest

### DIFF
--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -1235,6 +1235,7 @@ class MVLSlabSet(MPRelaxSet):
                  auto_dipole=False, **kwargs):
         super(MVLSlabSet, self).__init__(slab, **kwargs)
         self.structure = slab
+        self.slab = slab
         self.k_product = k_product
         self.bulk = bulk
         self.auto_dipole = auto_dipole

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -40,7 +40,6 @@ class MITMPRelaxSetTest(unittest.TestCase):
         self.mpset = MPRelaxSet(self.structure)
 
     def test_poscar(self):
-
         structure = Structure(self.lattice, ["Fe", "Mn"], self.coords)
         mitparamset = MITRelaxSet(structure, sort_structure=False)
         s_unsorted = mitparamset.poscar.structure
@@ -494,6 +493,7 @@ class MVLSlabSetTest(PymatgenTest):
         self.d_bulk = vis_bulk.all_input
         self.d_slab = vis.all_input
         self.d_dipole = vis_dipole.all_input
+        self.vis = vis
 
     def test_user_incar_settings(self):
         # Make sure user incar settings properly override AMIX.
@@ -546,6 +546,10 @@ class MVLSlabSetTest(PymatgenTest):
         self.assertEqual(kpoints_bulk[2], 15)
         # The last kpoint in a slab should always be 1
         self.assertEqual(kpoints_slab[2], 1)
+    
+    def test_as_dict(self):
+        vis_dict = self.vis.as_dict()
+        new = MVLSlabSet.from_dict(vis_dict)
 
 
 class MVLElasticSetTest(PymatgenTest):


### PR DESCRIPTION
## Summary

MVLSlabSet.as_dict was failing due to a change in __init__ argument name without the corresponding assignment of attribute.  I'm not sure this is the best way to do it, but this seems to fix the issue.  Might want to check, @richardtran415.  Also added a unittest.