### PR TITLE
Kpath fix with on-the-fly structures for tests and some comments

### DIFF
--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -1193,7 +1193,7 @@ class PDPlotter(object):
             ehull < show_unstable will be shown.
     """
 
-    def __init__(self, phasediagram, show_unstable=0):
+    def __init__(self, phasediagram, show_unstable=0, **plotkwargs):
         self._pd = phasediagram
         self._dim = len(self._pd.elements)
         if self._dim > 4:
@@ -1201,6 +1201,7 @@ class PDPlotter(object):
         self.lines = uniquelines(self._pd.facets) if self._dim > 1 else \
             [[self._pd.facets[0][0], self._pd.facets[0][0]]]
         self.show_unstable = show_unstable
+        self.plotkwargs = plotkwargs
 
     @property
     def pd_plot_data(self):
@@ -1314,15 +1315,13 @@ class PDPlotter(object):
                 for x, y in labels.keys():
                     if labels[(x, y)].attribute is None or \
                                     labels[(x, y)].attribute == "existing":
-                        plt.plot(x, y, "ko", linewidth=3, markeredgecolor="k",
-                                 markerfacecolor="b", markersize=12)
+                        plt.plot(x, y, "ko", linewidth=3,
+                                 **self.plotkwargs)
                     else:
-                        plt.plot(x, y, "k*", linewidth=3, markeredgecolor="k",
-                                 markerfacecolor="g", markersize=18)
+                        plt.plot(x, y, "k*", linewidth=3, **self.plotkwargs)
             else:
                 for x, y in lines:
-                    plt.plot(x, y, "ko-", linewidth=3, markeredgecolor="k",
-                             markerfacecolor="b", markersize=15)
+                    plt.plot(x, y, "ko-", linewidth=3, **self.plotkwargs)
         else:
             from matplotlib.colors import Normalize, LinearSegmentedColormap
             from matplotlib.cm import ScalarMappable

--- a/pymatgen/analysis/tests/test_phase_diagram.py
+++ b/pymatgen/analysis/tests/test_phase_diagram.py
@@ -454,10 +454,10 @@ class PDPlotterTest(unittest.TestCase):
                    if len(e.composition) < 3 and ("Fe" not in e.composition)]
 
         self.pd_formation = PhaseDiagram(entrieslio)
-        self.plotter_formation = PDPlotter(self.pd_formation, show_unstable=True)
+        self.plotter_formation = PDPlotter(self.pd_formation, show_unstable=0.1)
         entries.append(PDEntry("C", 0))
         self.pd3d = PhaseDiagram(entries)
-        self.plotter3d = PDPlotter(self.pd3d, show_unstable=True)
+        self.plotter3d = PDPlotter(self.pd3d, show_unstable=0.1)
 
     def test_pd_plot_data(self):
         (lines, labels, unstable_entries) = self.plotter.pd_plot_data

--- a/pymatgen/symmetry/analyzer.py
+++ b/pymatgen/symmetry/analyzer.py
@@ -439,7 +439,7 @@ class SpacegroupAnalyzer(object):
         elif "F" in self.get_space_group_symbol():
             transf = np.array([[0, 1, 1], [1, 0, 1], [1, 1, 0]],
                               dtype=np.float) / 2
-        elif "C" in self.get_space_group_symbol():
+        elif "C" in self.get_space_group_symbol() or "A" in self.get_space_group_symbol():
             if self.get_crystal_system() == "monoclinic":
                 transf = np.array([[1, 1, 0], [-1, 1, 0], [0, 0, 2]],
                                   dtype=np.float) / 2
@@ -519,6 +519,16 @@ class SpacegroupAnalyzer(object):
                 for i in range(2):
                     transf[i][sorted_dic[i]['orig_index']] = 1
                 c = latt.abc[2]
+            elif self.get_space_group_symbol().startswith("A"): #change to C-centering to match Setyawan/Curtarolo convention             
+                transf[2] = [1, 0, 0]
+                a, b = sorted(latt.abc[1:])
+                sorted_dic = sorted([{'vec': latt.matrix[i],
+                                      'length': latt.abc[i],
+                                      'orig_index': i} for i in [1, 2]],
+                                    key=lambda k: k['length'])
+                for i in range(2):
+                    transf[i][sorted_dic[i]['orig_index']] = 1
+                c = latt.abc[0]
             else:
                 for i in range(len(sorted_dic)):
                     transf[i][sorted_dic[i]['orig_index']] = 1

--- a/pymatgen/symmetry/bandstructure.py
+++ b/pymatgen/symmetry/bandstructure.py
@@ -56,6 +56,9 @@ class HighSymmKpath(object):
         self._prim_rec = self._prim.lattice.reciprocal_lattice
         self._kpath = None
 
+        #Note: this warning will be issued for space groups 38-41, since the primitive cell must be 
+        #reformatted to match Setyawan/Curtarolo convention in order to work with the current k-path 
+        #generation scheme.
         if not np.allclose(self._structure.lattice.matrix, self._prim.lattice.matrix, atol=atol):
             warnings.warn("The input structure does not match the expected standard primitive! "
                           "The path can be incorrect. Use at your own risk.")
@@ -105,7 +108,7 @@ class HighSymmKpath(object):
             elif "I" in spg_symbol:
                 self._kpath = self.orci(a, b, c)
 
-            elif "C" in spg_symbol:
+            elif "C" in spg_symbol or "A" in spg_symbol:
                 self._kpath = self.orcc(a, b, c)
             else:
                 warn("Unexpected value for spg_symbol: %s" % spg_symbol)

--- a/pymatgen/symmetry/tests/test_analyzer.py
+++ b/pymatgen/symmetry/tests/test_analyzer.py
@@ -246,6 +246,17 @@ class SpacegroupAnalyzerTest(PymatgenTest):
         self.assertAlmostEqual(conv.lattice.b, 31.437979757624728)
         self.assertAlmostEqual(conv.lattice.c, 3.99648651)
 
+        parser = CifParser(os.path.join(test_dir, 'orac_632475.cif'))
+        structure = parser.get_structures(False)[0]
+        s = SpacegroupAnalyzer(structure, symprec=1e-2)
+        conv = s.get_conventional_standard_structure()
+        self.assertAlmostEqual(conv.lattice.alpha, 90)
+        self.assertAlmostEqual(conv.lattice.beta, 90)
+        self.assertAlmostEqual(conv.lattice.gamma, 90)
+        self.assertAlmostEqual(conv.lattice.a, 3.1790663399999999)
+        self.assertAlmostEqual(conv.lattice.b, 9.9032878699999998)
+        self.assertAlmostEqual(conv.lattice.c, 3.5372412099999999)
+
         parser = CifParser(os.path.join(test_dir, 'monoc_1028.cif'))
         structure = parser.get_structures(False)[0]
         s = SpacegroupAnalyzer(structure, symprec=1e-2)
@@ -312,6 +323,17 @@ class SpacegroupAnalyzerTest(PymatgenTest):
         self.assertAlmostEqual(prim.lattice.a, 15.854897098324196)
         self.assertAlmostEqual(prim.lattice.b, 15.854897098324196)
         self.assertAlmostEqual(prim.lattice.c, 3.99648651)
+
+        parser = CifParser(os.path.join(test_dir, 'orac_632475.cif'))
+        structure = parser.get_structures(False)[0]
+        s = SpacegroupAnalyzer(structure, symprec=1e-2)
+        prim = s.get_primitive_standard_structure()
+        self.assertAlmostEqual(prim.lattice.alpha, 90)
+        self.assertAlmostEqual(prim.lattice.beta, 90)
+        self.assertAlmostEqual(prim.lattice.gamma, 144.40557588533386)
+        self.assertAlmostEqual(prim.lattice.a, 5.2005185662155391)
+        self.assertAlmostEqual(prim.lattice.b, 5.2005185662155391)
+        self.assertAlmostEqual(prim.lattice.c, 3.5372412099999999)
 
         parser = CifParser(os.path.join(test_dir, 'monoc_1028.cif'))
         structure = parser.get_structures(False)[0]

--- a/pymatgen/symmetry/tests/test_kpaths.py
+++ b/pymatgen/symmetry/tests/test_kpaths.py
@@ -21,6 +21,7 @@ import os
 
 from pymatgen.util.testing import PymatgenTest
 from pymatgen.core.structure import Structure
+from pymatgen.core.lattice import Lattice
 from pymatgen.symmetry.bandstructure import HighSymmKpath
 
 test_dir_structs = os.path.join(os.path.dirname(__file__), "..", "..", "..",
@@ -29,6 +30,14 @@ test_dir_structs = os.path.join(os.path.dirname(__file__), "..", "..", "..",
 class HighSymmKpathTest(PymatgenTest):
 
     def test_kpath_generation(self):
+        triclinic = [1, 2]
+        monoclinic = range(3, 16)
+        orthorhombic = range(16, 75)
+        tetragonal = range(75, 143)
+        rhombohedral = range(143, 168)
+        hexagonal = range(168, 195)
+        cubic = range(195, 231)
+        
         species = ['K', 'La', 'Ti']
         coords = [[.345, 5, .77298], [.1345, 5.1, .77298], [.7, .8, .9]]
         for i in range(230):

--- a/pymatgen/symmetry/tests/test_kpaths.py
+++ b/pymatgen/symmetry/tests/test_kpaths.py
@@ -1,0 +1,107 @@
+# coding: utf-8
+# Copyright (c) Pymatgen Development Team.
+# Distributed under the terms of the MIT License.
+
+from __future__ import division, unicode_literals
+
+"""
+Created on Aug 23, 2017
+"""
+
+
+__author__ = "Katie Latimer"
+__copyright__ = "Copyright 2012, The Materials Project"
+__version__ = "0.1"
+__maintainer__ = "Katie Latimer"
+__email__ = "klatimer@berkeley.edu"
+__date__ = "Aug 23, 2017"
+
+import unittest
+import os
+
+from pymatgen.util.testing import PymatgenTest
+from pymatgen.core.structure import Structure
+from pymatgen.symmetry.bandstructure import HighSymmKpath
+
+test_dir_structs = os.path.join(os.path.dirname(__file__), "..", "..", "..",
+                            'test_files', 'space_group_structs')
+
+class HighSymmKpathTest(PymatgenTest):
+
+    def test_kpath_generation(self):
+        species = ['K', 'La', 'Ti']
+        coords = [[.345, 5, .77298], [.1345, 5.1, .77298], [.7, .8, .9]]
+        for i in range(230):
+            sg_num = i + 1
+            if sg_num in triclinic:
+                lattice = Lattice([[3.0233057319441246,0,0], [0,7.9850357844548681,0], [0,0,8.1136762279561818]])
+            elif sg_num in monoclinic:
+                lattice = Lattice.monoclinic(2, 9, 1, 99)
+            elif sg_num in orthorhombic:
+                lattice = Lattice.orthorhombic(2, 9, 1)
+            elif sg_num in tetragonal:
+                lattice = Lattice.tetragonal(2, 9)
+            elif sg_num in rhombohedral:
+                lattice = Lattice.hexagonal(2, 95)
+            elif sg_num in hexagonal:
+                lattice = Lattice.hexagonal(2, 9)
+            elif sg_num in cubic:
+                lattice = Lattice.cubic(2)
+        
+            struct = Structure.from_spacegroup(sg_num, lattice, species, coords)
+            kpath = HighSymmKpath(struct) #Throws error if something doesn't work, causing test to fail.
+
+    def test_kpath_acentered(self):
+        species = ['K', 'La', 'Ti']
+        coords = [[.345, 5, .77298], [.1345, 5.1, .77298], [.7, .8, .9]]
+        lattice = Lattice.orthorhombic(2, 9, 1)
+        struct = Structure.from_spacegroup(sg_num, lattice, species, coords)
+        kpath = HighSymmKpath(struct)
+        
+        kpoints = kpath._kpath['kpoints']
+        labels = list(kpoints.keys())
+
+        self.assertEqual(labels, ['\\Gamma', 'A', 'A_1', 'R', 'S', 'T', 'X', 'X_1', 'Y', 'Z'])
+
+        self.assertEqual(kpoints['\\Gamma'][0], 0.00000000)
+        self.assertAlmostEqual(kpoints['\\Gamma'][1], 0.00000000)
+        self.assertAlmostEqual(kpoints['\\Gamma'][2], 0.00000000)
+
+        self.assertAlmostEqual(kpoints['A'][0], 0.25308642)
+        self.assertAlmostEqual(kpoints['A'][1], 0.25308642)
+        self.assertAlmostEqual(kpoints['A'][2], 0.50000000)
+
+        self.assertAlmostEqual(kpoints['A_1'][0], -0.25308642)
+        self.assertAlmostEqual(kpoints['A_1'][1], 0.74691358)
+        self.assertAlmostEqual(kpoints['A_1'][2], 0.50000000)
+
+        self.assertAlmostEqual(kpoints['R'][0], 0.00000000)
+        self.assertAlmostEqual(kpoints['R'][1], 0.50000000)
+        self.assertAlmostEqual(kpoints['R'][2], 0.50000000)
+
+        self.assertAlmostEqual(kpoints['S'][0], 0.00000000)
+        self.assertAlmostEqual(kpoints['S'][1], 0.50000000)
+        self.assertAlmostEqual(kpoints['S'][2], 0.00000000)
+
+        self.assertAlmostEqual(kpoints['T'][0], -0.50000000)
+        self.assertAlmostEqual(kpoints['T'][1], 0.50000000)
+        self.assertAlmostEqual(kpoints['T'][2], 0.50000000)
+
+        self.assertAlmostEqual(kpoints['X'][0], 0.25308642)
+        self.assertAlmostEqual(kpoints['X'][1], 0.25308642)
+        self.assertAlmostEqual(kpoints['X'][2], 0.00000000)
+
+        self.assertAlmostEqual(kpoints['X_1'][0], -0.25308642)
+        self.assertAlmostEqual(kpoints['X_1'][1], 0.74691358)
+        self.assertAlmostEqual(kpoints['X_1'][2], 0.00000000)
+
+        self.assertAlmostEqual(kpoints['Y'][0], -0.50000000)
+        self.assertAlmostEqual(kpoints['Y'][1], 0.50000000)
+        self.assertAlmostEqual(kpoints['Y'][2], 0.00000000)
+
+        self.assertAlmostEqual(kpoints['Z'][0], 0.00000000)
+        self.assertAlmostEqual(kpoints['Z'][1], 0.00000000)
+        self.assertAlmostEqual(kpoints['Z'][2], 0.50000000)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pymatgen/symmetry/tests/test_kpaths.py
+++ b/pymatgen/symmetry/tests/test_kpaths.py
@@ -65,7 +65,7 @@ class HighSymmKpathTest(PymatgenTest):
         species = ['K', 'La', 'Ti']
         coords = [[.345, 5, .77298], [.1345, 5.1, .77298], [.7, .8, .9]]
         lattice = Lattice.orthorhombic(2, 9, 1)
-        struct = Structure.from_spacegroup(sg_num, lattice, species, coords)
+        struct = Structure.from_spacegroup(38, lattice, species, coords)
         kpath = HighSymmKpath(struct)
         
         kpoints = kpath._kpath['kpoints']

--- a/test_files/orac_632475.cif
+++ b/test_files/orac_632475.cif
@@ -1,0 +1,36 @@
+# generated using pymatgen
+data_NbS2
+_symmetry_space_group_name_H-M   Amm2
+_cell_length_a   3.53724121
+_cell_length_b   3.17906634
+_cell_length_c   9.90328787
+_cell_angle_alpha   90.00000000
+_cell_angle_beta   90.00000000
+_cell_angle_gamma   90.00000000
+_symmetry_Int_Tables_number   38
+_chemical_formula_structural   NbS2
+_chemical_formula_sum   'Nb2 S4'
+_cell_volume   111.363704602
+_cell_formula_units_Z   2
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+  2  '-x, -y, z'
+  3  '-x, y, z'
+  4  'x, -y, z'
+  5  'x, y+1/2, z+1/2'
+  6  '-x, -y+1/2, z+1/2'
+  7  '-x, y+1/2, z+1/2'
+  8  'x, -y+1/2, z+1/2'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  Nb  Nb1  2  0.500000  0.000000  0.030965  1
+  S  S2  2  0.000000  0.000000  0.626327  1
+  S  S3  2  0.500000  0.000000  0.348960  1


### PR DESCRIPTION
## Summary

Modifications to account for space group naming conventions changes in spglib.

* Fix in pymatgen.symmetry.bandstructure.HighSymmKpath class
* Fix in pymatgen.symmetry.analyzer.SpacegroupAnalyzer class
* Tests for both modifications, this time generating structures within tests
* A few comments to explain modifications

## Centering convention fix
```
from pymatgen import MPRester
from pymatgen.symmetry.analyzer import SpacegroupAnalyzer

struct = MPRester().get_structure_by_material_id('mp-4587')

print len(struct)
#out: 4

sga = SpacegroupAnalyzer(struct, symprec=1e-2)

print sga.get_space_group_number()
# out: 38

print sga.get_space_group_symbol()
#out: Amm2

std_prim = sga.get_primitive_standard_structure()

print len(std_prim)
#out: 4 

print(std_prim.lattice.abc)
#out:  (3.7566910450291151, 3.7566910450291155, 3.5941917999999999)
#Shows that it has been converted to Setyawan/Curtarolo convention with C-centering.

print len(std_prim.get_primitive_structure())
#out: 4
```