### PR TITLE
avoid importing palettable

### DIFF
--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -28,7 +28,6 @@ from pymatgen.util.string import latexify
 from pymatgen.util.plotting import pretty_plot
 from pymatgen.analysis.reaction_calculator import Reaction, \
             ReactionError
-from palettable.colorbrewer.qualitative import Set1_3
 
 
 """
@@ -1204,6 +1203,9 @@ class PDPlotter(object):
     """
 
     def __init__(self, phasediagram, show_unstable=0, **plotkwargs):
+        # note: palettable imports matplotlib
+        from palettable.colorbrewer.qualitative import Set1_3
+
         self._pd = phasediagram
         self._dim = len(self._pd.elements)
         if self._dim > 4:


### PR DESCRIPTION
## Summary

Fixes a performance regression that has caused the time taken by `import pymatgen` to rise by about 50%.

In short, palettable imports matplotlib, undoing all of pymatgen's hard work to avoid exactly that.
