### PR TITLE
use significant_digits in poscar lattice str

### DIFF
--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -466,15 +466,17 @@ class Poscar(MSONable):
         if np.linalg.det(latt.matrix) < 0:
             latt = Lattice(-latt.matrix)
 
-        lines = [self.comment, "1.0", str(latt)]
+        format_str = "{{:.{0}f}}".format(significant_figures)
+        lines = [self.comment, "1.0"]
+        for v in latt.matrix:
+            lines.append(" ".join([format_str.format(c) for c in v]))
+
         if self.true_names and not vasp4_compatible:
             lines.append(" ".join(self.site_symbols))
         lines.append(" ".join([str(x) for x in self.natoms]))
         if self.selective_dynamics:
             lines.append("Selective dynamics")
         lines.append("direct" if direct else "cartesian")
-
-        format_str = "{{:.{0}f}}".format(significant_figures)
 
         for (i, site) in enumerate(self.structure):
             coords = site.frac_coords if direct else site.coords

--- a/pymatgen/io/vasp/tests/test_inputs.py
+++ b/pymatgen/io/vasp/tests/test_inputs.py
@@ -146,6 +146,34 @@ cart
         self.assertArrayAlmostEqual(site.coords,
                                     np.array([3.840198, 1.5, 2.35163175]) * 1.1)
 
+    def test_significant_figures(self):
+        si = 14
+        coords = list()
+        coords.append([0, 0, 0])
+        coords.append([0.75, 0.5, 0.75])
+
+        # Silicon structure for testing.
+        latt = [[3.8401979337, 0.00, 0.00],
+                [1.9200989668, 3.3257101909, 0.00],
+                [0.00, -2.2171384943, 3.1355090603]]
+        struct = Structure(latt, [si, si], coords)
+        poscar = Poscar(struct)
+        expected_str = '''Si2
+1.0
+3.84 0.00 0.00
+1.92 3.33 0.00
+0.00 -2.22 3.14
+Si
+2
+direct
+0.00 0.00 0.00 Si
+0.75 0.50 0.75 Si
+'''
+
+        actual_str = poscar.get_string(significant_figures=2)
+        self.assertEqual(actual_str, expected_str, "Wrong POSCAR output!")
+
+
     def test_str(self):
         si = 14
         coords = list()


### PR DESCRIPTION
## Summary

* Fix formatting of lattice in `Poscar.get_string` to respect the `significant_digits` argument