### PR TITLE
Reverted slab argument to structure in MVLSlabSet

### DIFF
--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -1252,11 +1252,10 @@ class MVLSlabSet(MPRelaxSet):
         **kwargs:
             Other kwargs supported by :class:`DictSet`.
     """
-    def __init__(self, slab, k_product=50, bulk=False,
+    def __init__(self, structure, k_product=50, bulk=False,
                  auto_dipole=False, **kwargs):
-        super(MVLSlabSet, self).__init__(slab, **kwargs)
-        self.structure = slab
-        self.slab = slab
+        super(MVLSlabSet, self).__init__(structure, **kwargs)
+        self.structure = structure
         self.k_product = k_product
         self.bulk = bulk
         self.auto_dipole = auto_dipole
@@ -1273,7 +1272,7 @@ class MVLSlabSet(MPRelaxSet):
             if self.auto_dipole:
                 slab_incar["IDIPOL"] = 3
                 slab_incar["LDIPOL"] = True
-                slab_incar["DIPOL"] = slab.center_of_mass
+                slab_incar["DIPOL"] = structure.center_of_mass
 
         self._config_dict["INCAR"].update(slab_incar)
 


### PR DESCRIPTION
Can we revert the constructor syntax of MVLSlabSet such that it takes a "structure" kwarg instead of a "slab"?  My reasoning for this is twofold:

* Input structures to MVLSlabSet aren't always slabs, e.g. when doing reference bulk calculations, but they are always structures
* Having "slab" as the input argument name changes the structure of the dictionary resultant from as_dict() such that it's different from every other input set, which makes it unwieldy when trying to do some db operations or modifications on the serialized object, for example.