### PR TITLE
Correct attribute used in example for generating a Structure object

### DIFF
--- a/docs_rst/usage.rst
+++ b/docs_rst/usage.rst
@@ -172,7 +172,7 @@ Another example, creating a Structure from a VASP POSCAR/CONTCAR file::
 
     from pymatgen.io.vasp import Poscar
     poscar = Poscar.from_file("POSCAR")
-    struct = poscar.struct
+    structure = poscar.structure
 
 Many of these io packages also provide the means to write a Structure to
 various output formats, e.g. the CifWriter in :mod:`pymatgen.io.cif`. In


### PR DESCRIPTION
from a VASP POSCAR

The docs previously had this example for generating a
Structure object from a VASP POSCAR file:

```python
from pymatgen.io.vasp import Poscar
poscar = Poscar.from_file("POSCAR")
struct = poscar.struct
```

The correct attribute is `poscar.structure`.

This pull request updates the `usage` documentation file to reflect this.
