### PR TITLE
Add OccupancyComparator

### DIFF
--- a/pymatgen/analysis/structure_matcher.py
+++ b/pymatgen/analysis/structure_matcher.py
@@ -257,6 +257,33 @@ class OrderDisorderElementComparator(AbstractComparator):
         """
         return 1
 
+class OccupancyComparator(AbstractComparator):
+    """
+    A Comparator that matches occupancies on sites,
+    irrespective of the species of those sites.
+    """
+
+    def are_equal(self, sp1, sp2):
+        """
+        Args:
+            sp1: First species. A dict of {specie/element: amt} as per the
+                definition in Site and PeriodicSite.
+            sp2: Second species. A dict of {specie/element: amt} as per the
+                definition in Site and PeriodicSite.
+
+        Returns:
+            True if sets of occupancies (amt) are equal on both sites.
+        """
+        set1 = set(sp1.element_composition.values())
+        set2 = set(sp2.element_composition.values())
+        if set1 == set2:
+            return True
+        else:
+            return False
+
+    def get_hash(self, composition):
+        # Difficult to define sensible hash
+        return 1
 
 class StructureMatcher(MSONable):
     """

--- a/pymatgen/analysis/tests/test_structure_matcher.py
+++ b/pymatgen/analysis/tests/test_structure_matcher.py
@@ -10,7 +10,8 @@ import json
 import numpy as np
 
 from pymatgen.analysis.structure_matcher import StructureMatcher, \
-    ElementComparator, FrameworkComparator, OrderDisorderElementComparator
+    ElementComparator, FrameworkComparator, OrderDisorderElementComparator, \
+    OccupancyComparator
 from monty.json import MontyDecoder
 from pymatgen.core.operations import SymmOp
 from pymatgen import Structure, Element, Lattice
@@ -659,6 +660,25 @@ class StructureMatcherTest(PymatgenTest):
 
         self.assertTrue(sm_sites.fit(s1, s2))
         self.assertFalse(sm_atoms.fit(s1, s2))
+
+    def test_occupancy_comparator(self):
+
+        lp = Lattice.orthorhombic(10, 20, 30)
+        pcoords = [[0, 0, 0],
+                   [0.5, 0.5, 0.5]]
+        s1 = Structure(lp, [{'Na':0.6, 'K':0.4}, 'Cl'], pcoords)
+        s2 = Structure(lp, [{'Xa':0.4, 'Xb':0.6}, 'Cl'], pcoords)
+        s3 = Structure(lp, [{'Xa':0.5, 'Xb':0.5}, 'Cl'], pcoords)
+
+        sm_sites = StructureMatcher(ltol=0.2, stol=0.3, angle_tol=5,
+                                    primitive_cell=False, scale=True,
+                                    attempt_supercell=True,
+                                    allow_subset=True,
+                                    supercell_size = 'num_sites',
+                                    comparator=OccupancyComparator())
+
+        self.assertTrue(sm_sites.fit(s1, s2))
+        self.assertFalse(sm_sites.fit(s1, s3))
 
     def test_electronegativity(self):
         sm = StructureMatcher(ltol=0.2, stol=0.3, angle_tol=5)

--- a/pymatgen/command_line/critic2_caller.py
+++ b/pymatgen/command_line/critic2_caller.py
@@ -505,9 +505,6 @@ class Critic2Output(MSONable):
                 if l[2] == "n":
                     critic2_idx = int(l[0]) - 1
                     frac_coord = np.array([float(l[3]), float(l[4]), float(l[5])]) % 1
-                    if critic2_idx != kd.query(frac_coord)[1]:
-                        print(critic2_idx)
-                        print(frac_coord)
                     node_mapping[critic2_idx] = kd.query(frac_coord)[1]
 
         if len(node_mapping) != len(self.structure):


### PR DESCRIPTION
## Summary

Couldn't find this in pymatgen already. Patch to add a comparator which matches occupancies in StructureMatcher. Used for SQS generation, to match a disordered pymatgen Structure to its appropriate SQS template file.

(Also included another commit to delete a stray print statement in my previous PR...)

## Additional dependencies introduced (if any)

None

## TODO (if any)

None