### PR TITLE
Fix bug in POSCAR parsing

### DIFF
--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -228,7 +228,7 @@ class Poscar(MSONable):
         names = None
         if check_for_POTCAR:
             for f in os.listdir(dirname):
-                if f == "POTCAR":
+                if "POTCAR" in f:
                     try:
                         potcar = Potcar.from_file(os.path.join(dirname, f))
                         names = [sym.split("_")[0] for sym in potcar.symbols]


### PR DESCRIPTION
Bug in POSCAR parsing from file looking for POTCAR by name only
Misses extensions such as .gz .orig, .relax1.gz , etc. 
Fixed by looking for POTCAR in filename