### PR TITLE
Parsing Updates and Bug Squashing

### DIFF
--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -228,7 +228,7 @@ class Poscar(MSONable):
         names = None
         if check_for_POTCAR:
             for f in os.listdir(dirname):
-                if f == "POTCAR":
+                if "POTCAR" in f:
                     try:
                         potcar = Potcar.from_file(os.path.join(dirname, f))
                         names = [sym.split("_")[0] for sym in potcar.symbols]

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -1498,7 +1498,7 @@ class Outcar(MSONable):
         self.read_pattern({"drift":"total drift:\s+(\S+)\s+(\S+)\s+(\S+)"},
                           terminate_on_match=False,
                           postprocess=float)        
-         self.drift = self.data.get('drift',[])
+        self.drift = self.data.get('drift',[])
            
 
         # Check if calculation is spin polarized

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -1348,6 +1348,18 @@ class Outcar(MSONable):
     .. attribute:: drift
         Total drift for each step in eV/Atom
 
+    .. attribute:: ngf
+        Dimensions for the Augementation grid
+
+    .. attribute: sampling_radii
+        Size of the sampling radii in VASP for the test charges for 
+        the electrostatic potential at each atom. Total array size is the number
+        of elements present in the calculation
+
+    .. attribute: electrostatic_potential
+        Average electrostatic potential at each atomic position in order
+        of the atoms in POSCAR.
+
     One can then call a specific reader depending on the type of run being
     performed. These are currently: read_igpar(), read_lepsilon() and
     read_lcalcpol(), read_core_state_eign(), read_avg_core_pot().

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -1345,6 +1345,9 @@ class Outcar(MSONable):
     .. attribute:: elastic_tensor
         Total elastic moduli (Kbar) is given in a 6x6 array matrix.
 
+    .. attribute:: drift
+        Total drift for each step in eV/Atom
+
     One can then call a specific reader depending on the type of run being
     performed. These are currently: read_igpar(), read_lepsilon() and
     read_lcalcpol(), read_core_state_eign(), read_avg_core_pot().
@@ -1494,7 +1497,9 @@ class Outcar(MSONable):
         # Read the drift:
         self.read_pattern({"drift":"total drift:\s+(\S+)\s+(\S+)\s+(\S+)"},
                           terminate_on_match=False,
-                          postprocess=float)
+                          postprocess=float)        
+         self.drift = self.data.get('drift',[])
+           
 
         # Check if calculation is spin polarized
         self.spin = False
@@ -2372,7 +2377,8 @@ class Outcar(MSONable):
              "@class": self.__class__.__name__, "efermi": self.efermi,
              "run_stats": self.run_stats, "magnetization": self.magnetization,
              "charge": self.charge, "total_magnetization": self.total_mag,
-             "nelect": self.nelect, "is_stopped": self.is_stopped}
+             "nelect": self.nelect, "is_stopped": self.is_stopped,
+             "drift": self.drift}
 
         if self.lepsilon:
             d.update({'piezo_tensor': self.piezo_tensor,

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -1507,7 +1507,7 @@ class Outcar(MSONable):
         self.data = {}
 
         # Read the drift:
-        self.read_pattern({"drift":"total drift:\s+(\S+)\s+(\S+)\s+(\S+)"},
+        self.read_pattern({"drift":"total drift:\s+([\.\-\d]+)\s+([\.\-\d]+)\s+([\.\-\d]+)"},
                           terminate_on_match=False,
                           postprocess=float)        
         self.drift = self.data.get('drift',[])

--- a/pymatgen/io/vasp/tests/test_inputs.py
+++ b/pymatgen/io/vasp/tests/test_inputs.py
@@ -37,7 +37,7 @@ test_dir = os.path.join(os.path.dirname(__file__), "..", "..", "..", "..",
 class PoscarTest(PymatgenTest):
     def test_init(self):
         filepath = os.path.join(test_dir, 'POSCAR')
-        poscar = Poscar.from_file(filepath)
+        poscar = Poscar.from_file(filepath,check_for_POTCAR=False)
         comp = poscar.structure.composition
         self.assertEqual(comp, Composition("Fe4P4O16"))
 
@@ -256,7 +256,7 @@ direct
 
     def test_setattr(self):
         filepath = os.path.join(test_dir, 'POSCAR')
-        poscar = Poscar.from_file(filepath)
+        poscar = Poscar.from_file(filepath,check_for_POTCAR=False)
         self.assertRaises(ValueError, setattr, poscar, 'velocities',
                           [[0, 0, 0]])
         poscar.selective_dynamics = np.array([[True, False, False]] * 24)
@@ -828,7 +828,7 @@ class VaspInputTest(unittest.TestCase):
         filepath = os.path.join(test_dir, 'INCAR')
         incar = Incar.from_file(filepath)
         filepath = os.path.join(test_dir, 'POSCAR')
-        poscar = Poscar.from_file(filepath)
+        poscar = Poscar.from_file(filepath,check_for_POTCAR=False)
         if "PMG_VASP_PSP_DIR" not in os.environ:
             test_potcar_dir = os.path.abspath(
                 os.path.join(os.path.dirname(__file__), "..", "..", "..", "..",

--- a/pymatgen/io/vasp/tests/test_outputs.py
+++ b/pymatgen/io/vasp/tests/test_outputs.py
@@ -689,12 +689,12 @@ class OutcarTest(unittest.TestCase):
 
     def test_drift(self):
         outcar = Outcar(os.path.join(test_dir, "OUTCAR"))
-        self.assertEqual(len(outcar.data['drift']),5)
-        self.assertAlmostEqual(np.sum(outcar.data['drift']),0)
+        self.assertEqual(len(outcar.drift),5)
+        self.assertAlmostEqual(np.sum(outcar.drift),0)
 
         outcar = Outcar(os.path.join(test_dir, "OUTCAR.CL"))
-        self.assertEqual(len(outcar.data['drift']), 79)
-        self.assertAlmostEqual(np.sum(outcar.data['drift']),  0.448010)
+        self.assertEqual(len(outcar.drift), 79)
+        self.assertAlmostEqual(np.sum(outcar.drift),  0.448010)
 
 
 

--- a/pymatgen/io/vasp/tests/test_outputs.py
+++ b/pymatgen/io/vasp/tests/test_outputs.py
@@ -696,8 +696,13 @@ class OutcarTest(unittest.TestCase):
         self.assertEqual(len(outcar.drift), 79)
         self.assertAlmostEqual(np.sum(outcar.drift),  0.448010)
 
+    def test_electrostatic_potential(self):
 
-
+        outcar = Outcar(os.path.join(test_dir,"OUTCAR"))
+        self.assertEqual(outcar.ngf,[54,30,54])
+        self.assertTrue(np.allclose(outcar.sampling_radii,[0.9748, 0.9791, 0.7215]))
+        self.assertTrue(np.allclose(outcar.electrostatic_potential,
+          [-26.0704, -45.5046, -45.5046, -72.9539, -73.0621, -72.9539, -73.0621]))
 
 class BSVasprunTest(unittest.TestCase):
 


### PR DESCRIPTION
- Fixed the POTCAR parsing bug in POSCAR again
- Updated the tests so they are appropriate conditioned for a test folder with multiple POSCARs and POTCARs
- Added in electrostatic potential parsing at each atom in OUTCAR
- Moved drift to an Outcar attribute
- Used a more sensible regex for parsing the drift