### PR TITLE
Fix a bug in is_element in computed entry

### DIFF
--- a/pymatgen/entries/computed_entries.py
+++ b/pymatgen/entries/computed_entries.py
@@ -75,7 +75,7 @@ class ComputedEntry(MSONable):
 
     @property
     def is_element(self):
-        return self.composition.num_atoms == 1
+        return self.composition.is_element
 
     @property
     def energy(self):


### PR DESCRIPTION
This bug causes problems in evaluating if an elemental composition is an element. 
Fixed by switching to the logic used in PDEntry.