### PR TITLE
Bugfix for PointGroupAnalyzer get_symmetry_operations

### DIFF
--- a/pymatgen/symmetry/analyzer.py
+++ b/pymatgen/symmetry/analyzer.py
@@ -1205,7 +1205,7 @@ class PointGroupAnalyzer(object):
         Returns:
             ([SymmOp]): List of symmetry operations.
         """
-        return self.symmops
+        return generate_full_symmops(self.symmops, self.tol)
  
     def is_valid_op(self, symmop):
         """

--- a/pymatgen/symmetry/tests/test_analyzer.py
+++ b/pymatgen/symmetry/tests/test_analyzer.py
@@ -10,6 +10,7 @@ import os
 import numpy as np
 
 from pymatgen.core.sites import PeriodicSite
+from pymatgen.core.operations import SymmOp
 from pymatgen.io.vasp.inputs import Poscar
 from pymatgen.io.vasp.outputs import Vasprun
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer, \
@@ -103,7 +104,16 @@ class SpacegroupAnalyzerTest(PymatgenTest):
         self.assertEqual(self.disordered_sg.get_point_group_symbol(), '4/mmm')
 
     def test_get_symmetry_operations(self):
-        self.assertEqual(self.sg.get_symmetry_operations(), self.sg.symmops)
+        coordinates = np.array([[0.5, 0.0, 0.0],
+                                [0.0, 0.5, 0.0],
+                                [0.5, 1.0, 0.0],
+                                [1.0, 0.5, 0.0]])
+        species = ['H'] * len(coordinates)
+        molecule = Molecule(species,coordinates)
+        so = PointGroupAnalyzer(molecule, 0.3).get_symmetry_operations()
+        self.assertEqual(len(so), 16) # D4h contains 16 symmetry elements
+        for o in so:
+            self.assertEqual(isinstance(o,SymmOp), True)
  
     def test_get_symmetry_dataset(self):
         ds = self.sg.get_symmetry_dataset()


### PR DESCRIPTION
Commit 42df22fe0d2488c539914f58ed90961411eaec46 added a `get_symmetry_operations` method to the `PointGroupAnalyzer` class. 

It also introduced a bug, where the symmetry operations returned only included those found from the initial analysis of a molecule, instead of the complete set of symmetry operations for the corresponding point group. 

This commit fixes this bug, and adds a more detailed test that checks a full set of symmetry operations is returned.