### PR TITLE
Fix empty file for Structure.to(filename=) for fmt='mcsqs'

### DIFF
--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -1473,7 +1473,9 @@ class IStructure(SiteCollection, MSONable):
                 or fnmatch(fname, "*bestsqs*"):
             if filename:
                 with zopen(fname, "wt", encoding='ascii') as f:
-                    return Mcsqs(self).to_string()
+                    s = Mcsqs(self).to_string()
+                    f.write(s)
+                    return
             else:
                 return Mcsqs(self).to_string()
         else:


### PR DESCRIPTION
Was previously just returning the string instead of writing to file. Thanks @josuav1 for the report.