### PR TITLE
handle NoneType entries

### DIFF
--- a/pymatgen/ext/matproj.py
+++ b/pymatgen/ext/matproj.py
@@ -326,8 +326,10 @@ class MPRester(object):
                 criteria = MPRester.parse_criteria(chemsys_formula_id_criteria)
             else:
                 criteria = chemsys_formula_id_criteria
-
-            data = self.query(criteria, props)
+            try:
+                data = self.query(criteria, props)
+            except MPRestError:
+                return []
 
             entries = []
             for d in data:


### PR DESCRIPTION
## Summary

Mute MPRestError if the given criteria have no corresponding entries. 

* `rester.get_entries_in_chemsys` throws MPRestError if no entry matches the given criteria. For example, a query in chemical system C-O-N:

```python
from pymatgen.ext.matproj import MPRester

rester = MPRester()
mp_entries = rester.get_entries_in_chemsys(["C", "O", "N"])
```

Error message:

`MPRestError: local variable 'first' referenced before assignment. Content: b'{"valid_response": false, "version": {"pymatgen": "2017.11.9", "db": "2.0.0", "rest": "2.0"}, "traceback": "Traceback (most recent call last):\\n  File \\"/var/www/python/matgen/materials_django/rest/rest.py\\", line 91, in wrapped\\n    d = func(*args, **kwargs)\\n  File \\"/var/www/python/matgen/materials_django/rest/rest.py\\", line 182, in query\\n    raise RESTError(str(ex))\\nRESTError: local variable \'first\' referenced before assignment\\n", "created_at": "2017-11-10T23:40:33.356887", "error": "local variable \'first\' referenced before assignment"}'`