### PR TITLE
Make the conversion battery module useful for multivalent cations

### DIFF
--- a/pymatgen/apps/battery/conversion_battery.py
+++ b/pymatgen/apps/battery/conversion_battery.py
@@ -359,9 +359,10 @@ class ConversionVoltagePair(AbstractVoltagePair):
         """
         working_ion_entry = step1["element_reference"]
         working_ion = working_ion_entry.composition.elements[0].symbol
-        voltage = -step1["chempot"] + working_ion_entry.energy_per_atom
+        working_ion_valence = max(Element(working_ion).oxidation_states)
+        voltage = -step1["chempot"] + working_ion_entry.energy_per_atom/working_ion_valence
         mAh = (step2["evolution"] - step1["evolution"]) \
-            * Charge(1, "e").to("C") * Time(1, "s").to("h") * N_A * 1000
+            * Charge(1, "e").to("C") * Time(1, "s").to("h") * N_A * 1000*working_ion_valence
         licomp = Composition(working_ion)
         prev_rxn = step1["reaction"]
         reactants = {comp: abs(prev_rxn.get_coeff(comp))


### PR DESCRIPTION
Applied the same treatment as we did for insertion electrodes. When the ion oxidation state is 2+, the voltage reduced to half, and the capacity multiplied by 2.

## Summary

* Previously, the code works for LIB. However, it ignores the valence state of multivalent cations such as Mg and Ca, and treat it like Li.  The fixed code, take the oxidation state of the working ion into account. 

## Additional dependencies introduced (if any)

* N/A

## TODO (if any)

* someone may add nosetest for it