### PR TITLE
fix pmg plot --xrd

### DIFF
--- a/pymatgen/cli/pmg_plot.py
+++ b/pymatgen/cli/pmg_plot.py
@@ -68,7 +68,7 @@ def get_chgint_plot(args):
 
 
 def get_xrd_plot(args):
-    s = Structure.from_file(args.xrd)
+    s = Structure.from_file(args.xrd_structure_file)
     c = XRDCalculator()
     return c.get_xrd_plot(s)
 


### PR DESCRIPTION
## Summary

fix `pmg plot --xrd POSCAR`

error message:

```plain
AttributeError: 'Namespace' object has no attribute 'xrd'
```