### PR TITLE
method to symmetrically edit both sides of a slab

### DIFF
--- a/pymatgen/analysis/adsorption.py
+++ b/pymatgen/analysis/adsorption.py
@@ -62,6 +62,7 @@ class AdsorbateSiteFinder(object):
     """
 
     def __init__(self, slab, selective_dynamics=False,
+                 selective_dynamics_dict={},
                  height=0.9, mi_vec=None):
         """
         Create an AdsorbateSiteFinder object.
@@ -86,6 +87,7 @@ class AdsorbateSiteFinder(object):
         else:
             self.mvec = get_mi_vec(slab)
         slab = self.assign_site_properties(slab, height)
+        self.selective_dynamics_dict = selective_dynamics_dict
         if selective_dynamics:
             slab = self.assign_selective_dynamics(slab)
         self.slab = slab
@@ -422,9 +424,11 @@ class AdsorbateSiteFinder(object):
         Args:
             slab (Slab): slab for which to assign selective dynamics
         """
-        sd_list = []
-        sd_list = [[False, False, False] if site.properties['surface_properties'] == 'subsurface'
+
+        sd_list = [self.selective_dynamics_dict[site.properties['surface_properties']] if
+                   site.properties['surface_properties'] in self.selective_dynamics_dict.keys()
                    else [True, True, True] for site in slab.sites]
+
         new_sp = slab.site_properties
         new_sp['selective_dynamics'] = sd_list
         return slab.copy(site_properties=new_sp)
@@ -458,12 +462,12 @@ class AdsorbateSiteFinder(object):
         return structs
 
     def adsorb_both_surfaces(self, molecule, repeat=None, min_lw=5.0,
-                             reorient=True, find_args={}, ltol=0.1,
-                             stol=0.1, angle_tol=0.01):
-
+                             reorient=True, find_args={}):
         """
         Function that generates all adsorption structures for a given
-        molecular adsorbate on both surfaces of a slab.
+        molecular adsorbate on both surfaces of a slab. This is useful
+        for calculating surface energy where both surfaces need to be
+        equivalent or if we want to calculate nonpolar systems.
 
         Args:
             molecule (Molecule): molecule corresponding to adsorbate
@@ -474,82 +478,58 @@ class AdsorbateSiteFinder(object):
                 along the miller index
             find_args (dict): dictionary of arguments to be passed to the
                 call to self.find_adsorption_sites, e.g. {"distance":2.0}
-            ltol (float): Fractional length tolerance. Default is 0.2.
-            stol (float): Site tolerance. Defined as the fraction of the
-                average free length per atom := ( V / Nsites ) ** (1/3)
-                Default is 0.3.
-            angle_tol (float): Angle tolerance in degrees. Default is 5 degrees.
         """
 
-        # First get all possible adsorption configurations for this surface
-        adslabs = self.generate_adsorption_structures(molecule, repeat=repeat, min_lw=min_lw,
-                                                      reorient=reorient, find_args=find_args)
+        # Get the adsorbed surfaces first
+        adslabs = self.generate_adsorption_structures(molecule, repeat=repeat,
+                                                      min_lw=min_lw,
+                                                      reorient=reorient,
+                                                      find_args=find_args)
 
-        # Now we need to sort the sites by their position along
-        # c as well as whether or not they are adsorbate
-        single_ads = []
-        for i, slab in enumerate(adslabs):
-            sorted_sites = sorted(slab, key=lambda site: site.frac_coords[2])
-            ads_indices = [site_index for site_index, site in enumerate(sorted_sites) \
-                           if site.surface_properties == "adsorbate"]
-            non_ads_indices = [site_index for site_index, site in enumerate(sorted_sites) \
-                               if site.surface_properties != "adsorbate"]
+        new_adslabs = []
+        for i, adslab in enumerate(adslabs):
 
-            species, fcoords, props = [], [], {"surface_properties": []}
-            for site in sorted_sites:
-                species.append(site.specie)
-                fcoords.append(site.frac_coords)
-                props["surface_properties"].append(site.surface_properties)
+            # Find the adsorbate sites and indices in each slab
+            symmetric, adsorbates, indices = False, [], []
+            for i, site in enumerate(adslab.sites):
+                if site.surface_properties == "adsorbate":
+                    adsorbates.append(site)
+                    indices.append(i)
 
-            slab_other_side = Structure(slab.lattice, species,
-                                        fcoords, site_properties=props)
+            # Start with the clean slab
+            adslab.remove_sites(indices)
+            slab = adslab.copy()
+            sg = SpacegroupAnalyzer(slab)
+            ops = sg.get_symmetry_operations()
 
-            # For each adsorbate, get its distance from the surface and move it
-            # to the other side with the same distance from the other surface
-            for ads_index in ads_indices:
-                props["surface_properties"].append("adsorbate")
-                adsite = sorted_sites[ads_index]
-                diff = abs(adsite.frac_coords[2] - \
-                           sorted_sites[non_ads_indices[-1]].frac_coords[2])
-                slab_other_side.append(adsite.specie, [adsite.frac_coords[0],
-                                                       adsite.frac_coords[1],
-                                                       sorted_sites[0].frac_coords[2] - diff],
-                                       properties={"surface_properties": "adsorbate"})
-                # slab_other_side[-1].add
-
-            # Remove the adsorbates on the original side of the slab
-            # to create a slab with one adsorbate on the other side
-            slab_other_side.remove_sites(ads_indices)
-
-            # Put both slabs with adsorption on one side
-            # and the other in a list of slabs for grouping
-            single_ads.extend([slab, slab_other_side])
-
-        # Now group the slabs.
-        matcher = StructureMatcher(ltol=ltol, stol=stol,
-                                   angle_tol=angle_tol)
-        groups = matcher.group_structures(single_ads)
-
-        # Each group should be a pair with adsorbate on one side and the other.
-        # If a slab has no equivalent adsorbed slab on the other side, skip.
-        adsorb_both_sides = []
-        for i, group in enumerate(groups):
-            if len(group) != 2:
-                continue
-            ads1 = [site for site in group[0] if \
-                    site.surface_properties == "adsorbate"][0]
-            group[1].append(ads1.specie, ads1.frac_coords,
+            # For each site, we add it back to the slab along with a
+            # symmetrically equivalent position on the other side of
+            # the slab using symmetry operations
+            for adsorbate in adsorbates:
+                site = adsorbate.frac_coords
+                slab.append(adsorbate.specie, site,
                             properties={"surface_properties": "adsorbate"})
-            # Build the slab object
-            species, fcoords, props = [], [], {"surface_properties": []}
-            for site in group[1]:
-                species.append(site.specie)
-                fcoords.append(site.frac_coords)
-                props["surface_properties"].append(site.surface_properties)
-            s = Structure(group[1].lattice, species, fcoords, site_properties=props)
-            adsorb_both_sides.append(s)
 
-        return adsorb_both_sides
+                for op in ops:
+                    site2 = op.operate(site)
+                    if "%.6f" % (site2[2]) == "%.6f" % (site[2]):
+                        continue
+
+                    slab.append(adsorbate.specie, site2,
+                                properties={"surface_properties": "adsorbate"})
+                    sg = SpacegroupAnalyzer(slab)
+                    if sg.is_laue():
+                        break
+                    else:
+                        slab.remove_sites([len(slab) - 1])
+
+            # Only return symmetrically equivalent slabs because
+            # when working with molecules, we do not know if the op
+            # corresponds to the molecule, only to the given site.
+            if sg.is_laue():
+                new_adslabs.append(slab)
+
+        return new_adslabs
 
 
 def get_mi_vec(slab):

--- a/pymatgen/analysis/adsorption.py
+++ b/pymatgen/analysis/adsorption.py
@@ -495,35 +495,16 @@ class AdsorbateSiteFinder(object):
             # Start with the clean slab
             adslab.remove_sites(indices)
             slab = adslab.copy()
-            sg = SpacegroupAnalyzer(slab)
-            ops = sg.get_symmetry_operations()
 
             # For each site, we add it back to the slab along with a
             # symmetrically equivalent position on the other side of
             # the slab using symmetry operations
             for adsorbate in adsorbates:
-                site = adsorbate.frac_coords
-                slab.append(adsorbate.specie, site,
+                p2 = adslab.get_symmetric_site(adsorbate.frac_coords)
+                slab.append(adsorbate.specie, p2,
                             properties={"surface_properties": "adsorbate"})
-
-                for op in ops:
-                    site2 = op.operate(site)
-                    if "%.6f" % (site2[2]) == "%.6f" % (site[2]):
-                        continue
-
-                    slab.append(adsorbate.specie, site2,
-                                properties={"surface_properties": "adsorbate"})
-                    sg = SpacegroupAnalyzer(slab)
-                    if sg.is_laue():
-                        break
-                    else:
-                        slab.remove_sites([len(slab) - 1])
-
-            # Only return symmetrically equivalent slabs because
-            # when working with molecules, we do not know if the op
-            # corresponds to the molecule, only to the given site.
-            if sg.is_laue():
-                new_adslabs.append(slab)
+                slab.append(adsorbate.specie, adsorbate.frac_coords,
+                            properties={"surface_properties": "adsorbate"})
 
         return new_adslabs
 

--- a/pymatgen/analysis/adsorption.py
+++ b/pymatgen/analysis/adsorption.py
@@ -87,7 +87,6 @@ class AdsorbateSiteFinder(object):
         else:
             self.mvec = get_mi_vec(slab)
         slab = self.assign_site_properties(slab, height)
-        self.selective_dynamics_dict = selective_dynamics_dict
         if selective_dynamics:
             slab = self.assign_selective_dynamics(slab)
         self.slab = slab
@@ -424,15 +423,13 @@ class AdsorbateSiteFinder(object):
         Args:
             slab (Slab): slab for which to assign selective dynamics
         """
-
-        sd_list = [self.selective_dynamics_dict[site.properties['surface_properties']] if
-                   site.properties['surface_properties'] in self.selective_dynamics_dict.keys()
+        sd_list = []
+        sd_list = [[False, False, False] if site.properties['surface_properties'] == 'subsurface'
                    else [True, True, True] for site in slab.sites]
-
         new_sp = slab.site_properties
         new_sp['selective_dynamics'] = sd_list
         return slab.copy(site_properties=new_sp)
-
+    
     def generate_adsorption_structures(self, molecule, repeat=None, min_lw=5.0,
                                        reorient=True, find_args={}):
         """

--- a/pymatgen/analysis/adsorption.py
+++ b/pymatgen/analysis/adsorption.py
@@ -62,7 +62,6 @@ class AdsorbateSiteFinder(object):
     """
 
     def __init__(self, slab, selective_dynamics=False,
-                 selective_dynamics_dict={},
                  height=0.9, mi_vec=None):
         """
         Create an AdsorbateSiteFinder object.
@@ -429,7 +428,7 @@ class AdsorbateSiteFinder(object):
         new_sp = slab.site_properties
         new_sp['selective_dynamics'] = sd_list
         return slab.copy(site_properties=new_sp)
-    
+
     def generate_adsorption_structures(self, molecule, repeat=None, min_lw=5.0,
                                        reorient=True, find_args={}):
         """

--- a/pymatgen/analysis/tests/test_adsorption.py
+++ b/pymatgen/analysis/tests/test_adsorption.py
@@ -21,23 +21,23 @@ test_dir = os.path.join(os.path.dirname(__file__), "..", "..", "..", "..",
 class AdsorbateSiteFinderTest(PymatgenTest):
     def setUp(self):
         self.structure = Structure.from_spacegroup("Fm-3m", Lattice.cubic(3.5),
-                                                ["Ni"], [[0, 0, 0]])
+                                                   ["Ni"], [[0, 0, 0]])
         slabs = generate_all_slabs(self.structure, max_index=2,
                                    min_slab_size=6.0, min_vacuum_size=15.0,
                                    max_normal_search=1, center_slab=True)
         self.slab_dict = {''.join([str(i) for i in slab.miller_index]):
-                          slab for slab in slabs}
+                              slab for slab in slabs}
         self.asf_211 = AdsorbateSiteFinder(self.slab_dict["211"])
         self.asf_100 = AdsorbateSiteFinder(self.slab_dict["100"])
         self.asf_111 = AdsorbateSiteFinder(self.slab_dict["111"])
         self.asf_110 = AdsorbateSiteFinder(self.slab_dict["110"])
         self.asf_struct = AdsorbateSiteFinder(
-                Structure.from_sites(self.slab_dict["111"].sites))
+            Structure.from_sites(self.slab_dict["111"].sites))
 
     def test_init(self):
         asf_100 = AdsorbateSiteFinder(self.slab_dict["100"])
         asf_111 = AdsorbateSiteFinder(self.slab_dict["111"])
-        
+
     def test_from_bulk_and_miller(self):
         # Standard site finding
         asf = AdsorbateSiteFinder.from_bulk_and_miller(self.structure, (1, 1, 1))
@@ -79,19 +79,21 @@ class AdsorbateSiteFinderTest(PymatgenTest):
         self.assertEqual(len(structures), 4)
         sites = self.asf_111.find_adsorption_sites()
         # Check repeat functionality
-        self.assertEqual(len([site for site in structures[0] if 
+        self.assertEqual(len([site for site in structures[0] if
                               site.properties['surface_properties'] != 'adsorbate']),
-                         4*len(self.asf_111.slab))
+                         4 * len(self.asf_111.slab))
         for n, structure in enumerate(structures):
             self.assertArrayAlmostEqual(structure[-2].coords, sites['all'][n])
-        find_args = {"positions":["hollow"]}
-        structures_hollow = self.asf_111.\
-                generate_adsorption_structures(co, find_args=find_args)
+        find_args = {"positions": ["hollow"]}
+        structures_hollow = self.asf_111. \
+            generate_adsorption_structures(co, find_args=find_args)
         self.assertEqual(len(structures_hollow), len(sites['hollow']))
         for n, structure in enumerate(structures_hollow):
             self.assertTrue(in_coord_list(sites['hollow'], structure[-2].coords))
 
     def test_adsorb_both_surfaces(self):
+
+        # Test out for monatomic adsorption
         o = Molecule("O", [[0, 0, 0]])
         adslabs = self.asf_100.adsorb_both_surfaces(o)
         for adslab in adslabs:
@@ -99,6 +101,17 @@ class AdsorbateSiteFinderTest(PymatgenTest):
             sites = sorted(adslab, key=lambda site: site.frac_coords[2])
             self.assertTrue(sites[0].species_string == "O")
             self.assertTrue(sites[-1].species_string == "O")
+            self.assertTrue(sg.is_laue())
+
+        # Test out for molecular adsorption
+        oh = Molecule(["O", "H"], [[0, 0, 0], [0, 0, 1]])
+        adslabs = self.asf_100.adsorb_both_surfaces(oh)
+        for adslab in adslabs:
+            sg = SpacegroupAnalyzer(adslab)
+            sites = sorted(adslab, key=lambda site: site.frac_coords[2])
+            self.assertTrue(sites[0].species_string in ["O", "H"])
+            self.assertTrue(sites[-1].species_string in ["O", "H"])
+            self.assertTrue(sg.is_laue())
 
     def test_functions(self):
         slab = self.slab_dict["111"]

--- a/pymatgen/core/surface.py
+++ b/pymatgen/core/surface.py
@@ -584,19 +584,23 @@ class Slab(Structure):
         sg = SpacegroupAnalyzer(self)
         ops = sg.get_symmetry_operations()
 
+        # Each operation on a point will return an equivalent point.
+        # We want to find the point on the other side of the slab.
         for op in ops:
             slab = self.copy()
             site2 = op.operate(point)
             if "%.6f" % (site2[2]) == "%.6f" % (point[2]):
                 continue
-            slab.append("O", point,
-                        properties={"surface_properties": "adsorbate"})
-            slab.append("O", site2,
-                        properties={"surface_properties": "adsorbate"})
+
+            # Add dummy site to check the overall structure is symmetric
+            slab.append("O", point)
+            slab.append("O", site2)
             sg = SpacegroupAnalyzer(slab)
             if sg.is_laue():
                 break
             else:
+                # If not symmetric, remove the two added
+                # sites and try another symmetry operator
                 slab.remove_sites([len(slab) - 1])
                 slab.remove_sites([len(slab) - 1])
 

--- a/pymatgen/core/surface.py
+++ b/pymatgen/core/surface.py
@@ -565,6 +565,43 @@ class Slab(Structure):
 
         return all(equal_surf_sites)
 
+    def get_symmetric_site(self, point):
+        """
+        This method uses symmetry operations to find equivalent sites on
+            both sides of the slab. Works mainly for slabs with Laue
+            symmetry. This is useful for retaining the non-polar and
+            symmetric properties of a slab when creating adsorbed
+            structures or symmetric reconstructions.
+
+        Arg:
+            point: Fractional coordinate.
+
+        Returns:
+            point: Fractional coordinate. A point equivalent to the
+                parameter point, but on the other side of the slab
+        """
+
+        sg = SpacegroupAnalyzer(self)
+        ops = sg.get_symmetry_operations()
+
+        for op in ops:
+            slab = self.copy()
+            site2 = op.operate(point)
+            if "%.6f" % (site2[2]) == "%.6f" % (point[2]):
+                continue
+            slab.append("O", point,
+                        properties={"surface_properties": "adsorbate"})
+            slab.append("O", site2,
+                        properties={"surface_properties": "adsorbate"})
+            sg = SpacegroupAnalyzer(slab)
+            if sg.is_laue():
+                break
+            else:
+                slab.remove_sites([len(slab) - 1])
+                slab.remove_sites([len(slab) - 1])
+
+        return site2
+
 
 class SlabGenerator(object):
 

--- a/pymatgen/core/tests/test_surface.py
+++ b/pymatgen/core/tests/test_surface.py
@@ -174,6 +174,30 @@ class SlabTest(PymatgenTest):
             self.assertEqual(assymetric_count, 0)
             self.assertEqual(symmetric_count, len(slabs))
 
+    def test_get_symmetric_sites(self):
+
+        # Check to see if we get an equivalent site on one
+        # surface if we add a new site to the other surface
+
+        all_Ti_slabs = generate_all_slabs(self.ti, 2, 10, 10, bonds=None,
+                                          tol=1e-3, max_broken_bonds=0,
+                                          lll_reduce=False, center_slab=False,
+                                          primitive=True, max_normal_search=2,
+                                          symmetrize=True)
+
+        for slab in all_Ti_slabs:
+            sorted_sites = sorted(slab, key=lambda site: site.frac_coords[2])
+            site = sorted_sites[-1]
+            point = site.frac_coords
+            point[2] = point[2]+0.1
+            point2 = slab.get_symmetric_site(point)
+            slab.append("O", point)
+            slab.append("O", point2)
+
+            # Check if slab is all symmetric
+            sg = SpacegroupAnalyzer(slab)
+            self.assertTrue(sg.is_laue())
+
 
 class SlabGeneratorTest(PymatgenTest):
 


### PR DESCRIPTION
## Summary

* class method of AdsorbateSiteFinder, adsorb_both_surfaces() now uses symmetry operators to find a position on the other side of the slab for an adsorbate. This more generalized method will allow for adsorption of molecules on both surfaces. The method is also much more simplified compared to the previous version. This is useful for anyone trying to calculate an adsorbed slab without having slab polarity or if one wants to calculate surface energy (where both surfaces must be equivalent).
* class method of Slab, get_symmetric_site() finds a symmetrically equivalent point on the other side of the slab given a point.