### PR TITLE
Add MPRester methods for surface data and Wulff construction

### DIFF
--- a/pymatgen/ext/matproj.py
+++ b/pymatgen/ext/matproj.py
@@ -878,6 +878,54 @@ class MPRester(object):
 
         return self._make_request("/materials/all_substrate_ids")
 
+    def get_surface_data(self, material_id, inc_structures=False):
+        """
+        Gets surface data for a material. Useful for Wulff shapes.
+
+        Reference for surface data:
+
+        Tran, R., Xu, Z., Radhakrishnan, B., Winston, D., Sun, W., Persson, K.
+        A., & Ong, S. P. (2016). Data Descripter: Surface energies of elemental
+        crystals. Scientific Data, 3(160080), 1–13.
+        http://dx.doi.org/10.1038/sdata.2016.80
+
+        Args:
+            material_id (str): Materials Project material_id, e.g. 'mp-123'.
+            inc_structures (bool): Include final surface slab structures.
+                These are unnecessary for Wulff shape construction.
+        Returns:
+            Surface data for material. Energies are given in SI units (J/m^2).
+        """
+        req = "/materials/{}/surfaces".format(material_id)
+        if inc_structures:
+            req += "?include_structures=true"
+        return self._make_request(req)
+
+    def get_wulff_shape(self, material_id):
+        """
+        Constructs a Wulff shape for a material.
+
+        Args:
+            material_id (str): Materials Project material_id, e.g. 'mp-123'.
+        Returns:
+            pymatgen.analysis.wulff.WulffShape
+        """
+        from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
+        from pymatgen.analysis.wulff import WulffShape, hkl_tuple_to_str
+
+        structure = self.get_structure_by_material_id(material_id)
+        surfaces = self.get_surface_data(material_id)["surfaces"]
+        lattice = (SpacegroupAnalyzer(structure)
+                   .get_conventional_standard_structure().lattice)
+        miller_energy_map = {}
+        for surf in surfaces:
+            miller = tuple(surf["miller_index"])
+             # Prefer reconstructed surfaces, which have lower surface energies.
+            if (miller not in miller_energy_map) or surf["is_reconstructed"]:
+                miller_energy_map[miller] = surf["surface_energy"]
+        millers, energies = zip(*miller_energy_map.items())
+        return WulffShape(lattice, millers, energies)
+
     @staticmethod
     def parse_criteria(criteria_string):
         """

--- a/pymatgen/ext/tests/test_matproj.py
+++ b/pymatgen/ext/tests/test_matproj.py
@@ -16,6 +16,7 @@ from pymatgen.electronic_structure.dos import CompleteDos
 from pymatgen.electronic_structure.bandstructure import BandStructureSymmLine
 from pymatgen.entries.compatibility import MaterialsProjectCompatibility
 from pymatgen.analysis.phase_diagram import PhaseDiagram
+from pymatgen.analysis.wulff import WulffShape
 from pymatgen.io.cif import CifParser
 
 """
@@ -233,6 +234,22 @@ class MPResterTest(unittest.TestCase):
         substrate_data = self.rester.get_substrates('mp-123', 5, [1, 0, 0])
         substrates = [sub_dict['sub_id'] for sub_dict in substrate_data]
         self.assertIn("mp-2534", substrates)
+
+    def test_get_surface_data(self):
+        data = self.rester.get_surface_data("mp-126") # Pt
+        self.assertIn("surfaces", data)
+        surfaces = data["surfaces"]
+        self.assertTrue(len(surfaces) > 0)
+        surface = surfaces.pop()
+        self.assertIn("miller_index", surface)
+        self.assertIn("surface_energy", surface)
+        self.assertIn("is_reconstructed", surface)
+        data_inc = self.rester.get_surface_data("mp-126", inc_structures=True)
+        self.assertIn("structure", data_inc["surfaces"][0])
+
+    def test_get_wulff_shape(self):
+        ws = self.rester.get_wulff_shape("mp-126")
+        self.assertTrue(isinstance(ws, WulffShape))
 
     def test_parse_criteria(self):
         crit = MPRester.parse_criteria("mp-1234 Li-*")


### PR DESCRIPTION
## Summary

Provides methods to retrieve MP surface data and to construct a Wulff shape given a material ID. Addresses #768.