### PR TITLE
added more unittests for reconstruction

### DIFF
--- a/pymatgen/core/reconstructions_archive.json
+++ b/pymatgen/core/reconstructions_archive.json
@@ -176,7 +176,7 @@
   "name": "fcc_111_adatom_h_1x1",
   "description": "This is the (1x1) reconstruction for the fcc (111)                     slab on the hcp (h) site.",
   "reference": "Crljen, Z., Lazic, P., Sokcevic, D., & Brako, R. (2003).                     Relaxation and reconstruction on (111) surfaces of Au, Pt, and Cu.                     Physical Review B, 68(19), 195411.",
-  "base_reconstruction": "fcc_111_adatom_1x1_t",
+  "base_reconstruction": "fcc_111_adatom_t_1x1",
   "points_to_remove": [
    [
     0.0,
@@ -196,7 +196,7 @@
   "name": "fcc_111_adatom_ft_1x1",
   "description": "This is the (1x1) reconstruction for the fcc (111)                     slab with an adatom between the fcc and top (ft) site.",
   "reference": "Crljen, Z., Lazic, P., Sokcevic, D., & Brako, R. (2003).                     Relaxation and reconstruction on (111) surfaces of Au, Pt, and Cu.                     Physical Review B, 68(19), 195411.",
-  "base_reconstruction": "fcc_111_adatom_1x1_t",
+  "base_reconstruction": "fcc_111_adatom_t_1x1",
   "points_to_remove": [
    [
     0.0,
@@ -216,7 +216,7 @@
   "name": "fcc_111_adatom_ht_1x1",
   "description": "This is the (1x1) reconstruction for the fcc (111)                     slab with an adatom between the hcp and top (ht) site.",
   "reference": "Crljen, Z., Lazic, P., Sokcevic, D., & Brako, R. (2003).                     Relaxation and reconstruction on (111) surfaces of Au, Pt, and Cu.                     Physical Review B, 68(19), 195411.",
-  "base_reconstruction": "fcc_111_adatom_1x1_t",
+  "base_reconstruction": "fcc_111_adatom_t_1x1",
   "points_to_remove": [
    [
     0.0,
@@ -236,7 +236,7 @@
   "name": "fcc_111_adatom_bridge_1x1",
   "description": "This is the (1x1) reconstruction for the fcc (111)                     slab with an adatom on the bridge site.",
   "reference": "Crljen, Z., Lazic, P., Sokcevic, D., & Brako, R. (2003).                     Relaxation and reconstruction on (111) surfaces of Au, Pt, and Cu.                     Physical Review B, 68(19), 195411.",
-  "base_reconstruction": "fcc_111_adatom_1x1_t",
+  "base_reconstruction": "fcc_111_adatom_t_1x1",
   "points_to_remove": [
    [
     0.0,

--- a/pymatgen/core/tests/test_surface.py
+++ b/pymatgen/core/tests/test_surface.py
@@ -411,6 +411,7 @@ class ReconstructionGeneratorTests(PymatgenTest):
                                         "fcc_110_missing_row_1x2")
         slab = recon.get_unreconstructed_slab()
         recon_slab = recon.build_slab()
+        self.assertTrue(recon_slab.is_reconstructed)
         self.assertEqual(len(slab), len(recon_slab)+2)
         self.assertTrue(recon_slab.is_symmetric())
 
@@ -430,6 +431,13 @@ class ReconstructionGeneratorTests(PymatgenTest):
         recon_slab = recon.build_slab()
         self.assertEqual(len(slab), len(recon_slab)-8)
         self.assertTrue(recon_slab.is_symmetric())
+
+        # If a slab references another slab,
+        # make sure it is properly generated
+        recon = ReconstructionGenerator(self.Ni, 10, 10,
+                                        "fcc_111_adatom_ft_1x1")
+        slab = recon.build_slab()
+        self.assertTrue(slab.is_symmetric)
 
         # Test a reconstruction where terminations give
         # different reconstructions with a non-elemental system
@@ -452,6 +460,10 @@ class MillerIndexFinderTests(PymatgenTest):
         self.cscl = Structure.from_spacegroup(
             "Pm-3m", Lattice.cubic(4.2), ["Cs", "Cl"],
             [[0, 0, 0], [0.5, 0.5, 0.5]])
+
+        self.Fe = Structure.from_spacegroup(
+            "Im-3m", Lattice.cubic(2.82), ["Fe"],
+            [[0,0,0]])
 
         self.lifepo4 = self.get_structure("LiFePO4")
         self.tei = Structure.from_file(get_path("icsd_TeI.cif"),
@@ -493,6 +505,14 @@ class MillerIndexFinderTests(PymatgenTest):
 
         # Only three possible slabs, one each in (100), (110) and (111).
         self.assertEqual(len(slabs), 3)
+
+        # make sure it generates reconstructions
+        slabs = generate_all_slabs(self.Fe, 1, 10, 10,
+                                   include_reconstructions=True)
+        # Four possible slabs, (100), (110), (111) and the zigzag (100).
+        for slab in slabs:
+            print(slab.is_reconstructed)
+        self.assertEqual(len(slabs), 4)
 
         slabs = generate_all_slabs(self.cscl, 1, 10, 10,
                                    bonds={("Cs", "Cl"): 4})


### PR DESCRIPTION
## Summary

* Added option to include reconstructions when using generate_all_slabs
* Slab class has property called is_reconstructed. Can be a bool or a str (i.e. the name of the reconstruction).
* Made sure reconstructions that inherit from another base_reconstruction will properly be built.
* Added unittest for generate_all_slabs to make sure it includes existing reconstructions.