### PR TITLE
Optical add vasprun

### DIFF
--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -448,6 +448,8 @@ class Vasprun(MSONable):
                     else:
                         comment = elem.attrib["comment"]
                         self.other_dielectric[comment] = self._parse_diel(elem)
+                elif tag == 'varray' and elem.attrib.get("name") == 'opticaltransitions':
+                    self.optical_transition = np.array(_parse_varray(elem))
                 elif tag == "structure" and elem.attrib.get("name") == \
                         "finalpos":
                     self.final_structure = self._parse_structure(elem)
@@ -1015,6 +1017,15 @@ class Vasprun(MSONable):
         elem.clear()
         return [e[0] for e in imag], \
                [e[1:] for e in real], [e[1:] for e in imag]
+
+    def _parse_optical_transition(self, elem):
+        for va in elem.findall("varray"):
+            if va.attrib.get("name") == "opticaltransitions":
+                # opticaltransitions array contains oscillator strength and probability of transition
+                oscillator_strength = np.array(_parse_varray(va))[0:,]
+                probability_transition = np.array(_parse_varray(va))[0:,1]
+        return oscillator_strength, probability_transition
+
 
     def _parse_chemical_shift_calculation(self, elem):
         calculation = []

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -448,7 +448,7 @@ class Vasprun(MSONable):
                     else:
                         comment = elem.attrib["comment"]
                         self.other_dielectric[comment] = self._parse_diel(elem)
-                elif tag == 'varray' and elem.attrib.get("name") == 'opticaltransitions':
+                elif tag == "varray" and elem.attrib.get("name") == 'opticaltransitions':
                     self.optical_transition = np.array(_parse_varray(elem))
                 elif tag == "structure" and elem.attrib.get("name") == \
                         "finalpos":

--- a/pymatgen/io/vasp/tests/test_outputs.py
+++ b/pymatgen/io/vasp/tests/test_outputs.py
@@ -234,6 +234,24 @@ class VasprunTest(unittest.TestCase):
         (gap, cbm, vbm, direct) = v.eigenvalue_band_properties
         self.assertFalse(direct)
 
+        vasprun_optical = Vasprun(os.path.join(test_dir, "vasprun.xml.opticaltransitions"),
+                                  parse_potcar_file=False)
+        self.assertAlmostEqual(3.084, vasprun_optical.optical_transition[0][0])
+        self.assertAlmostEqual(3.087, vasprun_optical.optical_transition[3][0])
+        self.assertAlmostEqual(0.001, vasprun_optical.optical_transition[0][1])
+        self.assertAlmostEqual(0.001, vasprun_optical.optical_transition[1][1])
+        self.assertAlmostEqual(0.001, vasprun_optical.optical_transition[7][1])
+        self.assertAlmostEqual(0.001, vasprun_optical.optical_transition[19][1])
+        self.assertAlmostEqual(3.3799999999, vasprun_optical.optical_transition[54][0])
+        self.assertAlmostEqual(3.381, vasprun_optical.optical_transition[55][0])
+        self.assertAlmostEqual(3.381, vasprun_optical.optical_transition[56][0])
+        self.assertAlmostEqual(10554.9860, vasprun_optical.optical_transition[54][1])
+        self.assertAlmostEqual(0.0, vasprun_optical.optical_transition[55][1])
+        self.assertAlmostEqual(0.001,vasprun_optical.optical_transition[56][1])
+
+
+
+
     def test_force_constants(self):
         vasprun_fc = Vasprun(os.path.join(test_dir, "vasprun.xml.dfpt.phonon"),
                              parse_potcar_file=False)

--- a/pymatgen/io/vasp/tests/test_outputs.py
+++ b/pymatgen/io/vasp/tests/test_outputs.py
@@ -247,7 +247,7 @@ class VasprunTest(unittest.TestCase):
         self.assertAlmostEqual(3.381, vasprun_optical.optical_transition[56][0])
         self.assertAlmostEqual(10554.9860, vasprun_optical.optical_transition[54][1])
         self.assertAlmostEqual(0.0, vasprun_optical.optical_transition[55][1])
-        self.assertAlmostEqual(0.001,vasprun_optical.optical_transition[56][1])
+        self.assertAlmostEqual(0.001, vasprun_optical.optical_transition[56][1])
 
 
 

--- a/test_files/vasprun.xml.opticaltransitions
+++ b/test_files/vasprun.xml.opticaltransitions
@@ -1,0 +1,9089 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<modeling>
+ <generator>
+  <i name="program" type="string">vasp </i>
+  <i name="version" type="string">5.4.4.18Apr17-6-g9f103f2a35  </i>
+  <i name="subversion" type="string">(build Apr 25 2017 00:43:00) complex            parallel </i>
+  <i name="platform" type="string">LinuxIFC </i>
+  <i name="date" type="string">2017 09 29 </i>
+  <i name="time" type="string">11:34:32 </i>
+ </generator>
+ <incar>
+  <i type="string" name="SYSTEM"> Si</i>
+  <i type="string" name="PREC">normal</i>
+  <i type="string" name="ALGO"> BSE</i>
+  <i name="EDIFF">      0.00000001</i>
+  <i name="ENCUT">    250.00000000</i>
+  <i type="int" name="NBANDS">   128</i>
+  <i type="int" name="ISMEAR">     0</i>
+  <i name="SIGMA">      0.01000000</i>
+  <v type="int" name="KPOINT_BSE">    -1     0     0     0</v>
+  <i type="int" name="ANTIRES">     0</i>
+  <i type="int" name="NBANDSO">     4</i>
+  <i type="int" name="NBANDSV">     8</i>
+  <i name="OMEGAMAX">     20.00000000</i>
+  <i name="ENCUTGW">    150.00000000</i>
+  <i type="string" name="PRECFOCK">normal</i>
+  <i name="OMEGAMAX">     20.00000000</i>
+ </incar>
+ <structure name="primitive_cell" >
+  <crystal>
+   <varray name="basis" >
+    <v>       2.71500000       2.71500000       0.00000000 </v>
+    <v>       0.00000000       2.71500000       2.71500000 </v>
+    <v>       2.71500000       0.00000000       2.71500000 </v>
+   </varray>
+   <i name="volume">     40.02575175 </i>
+   <varray name="rec_basis" >
+    <v>       0.18416206       0.18416206      -0.18416206 </v>
+    <v>      -0.18416206       0.18416206       0.18416206 </v>
+    <v>       0.18416206      -0.18416206       0.18416206 </v>
+   </varray>
+  </crystal>
+  <varray name="positions" >
+   <v>       0.00000000       0.00000000       0.00000000 </v>
+   <v>       0.25000000       0.25000000       0.25000000 </v>
+  </varray>
+ </structure>
+ <varray name="primitive_index" >
+  <v type="int" >        1 </v>
+  <v type="int" >        2 </v>
+ </varray>
+ <kpoints>
+  <generation param="Gamma">
+   <v type="int" name="divisions">       6        6        6 </v>
+   <v name="usershift">      0.00000000       0.00000000       0.00000000 </v>
+   <v name="genvec1">      0.16666667       0.00000000       0.00000000 </v>
+   <v name="genvec2">      0.00000000       0.16666667       0.00000000 </v>
+   <v name="genvec3">      0.00000000       0.00000000       0.16666667 </v>
+   <v name="shift">      0.00000000       0.00000000       0.00000000 </v>
+  </generation>
+  <varray name="kpointlist" >
+   <v>       0.00000000       0.00000000       0.00000000 </v>
+   <v>       0.16666667       0.00000000       0.00000000 </v>
+   <v>       0.33333333       0.00000000       0.00000000 </v>
+   <v>       0.50000000       0.00000000       0.00000000 </v>
+   <v>       0.16666667       0.16666667       0.00000000 </v>
+   <v>       0.33333333       0.16666667       0.00000000 </v>
+   <v>       0.50000000       0.16666667       0.00000000 </v>
+   <v>      -0.33333333       0.16666667       0.00000000 </v>
+   <v>      -0.16666667       0.16666667       0.00000000 </v>
+   <v>       0.33333333       0.33333333       0.00000000 </v>
+   <v>       0.50000000       0.33333333       0.00000000 </v>
+   <v>      -0.33333333       0.33333333       0.00000000 </v>
+   <v>       0.50000000       0.50000000       0.00000000 </v>
+   <v>       0.50000000       0.33333333       0.16666667 </v>
+   <v>      -0.33333333       0.33333333       0.16666667 </v>
+   <v>      -0.33333333       0.50000000       0.16666667 </v>
+  </varray>
+  <varray name="weights" >
+   <v>       0.00462963 </v>
+   <v>       0.03703704 </v>
+   <v>       0.03703704 </v>
+   <v>       0.01851852 </v>
+   <v>       0.02777778 </v>
+   <v>       0.11111111 </v>
+   <v>       0.11111111 </v>
+   <v>       0.11111111 </v>
+   <v>       0.05555556 </v>
+   <v>       0.02777778 </v>
+   <v>       0.11111111 </v>
+   <v>       0.05555556 </v>
+   <v>       0.01388889 </v>
+   <v>       0.11111111 </v>
+   <v>       0.11111111 </v>
+   <v>       0.05555556 </v>
+  </varray>
+ </kpoints>
+ <parameters>
+  <separator name="general" >
+   <i type="string" name="SYSTEM">Si</i>
+   <i type="logical" name="LCOMPAT"> F  </i>
+  </separator>
+  <separator name="electronic" >
+   <i type="string" name="PREC">normal</i>
+   <i name="ENMAX">    250.00000000</i>
+   <i name="ENAUG">    322.06900000</i>
+   <i name="EDIFF">      0.00000001</i>
+   <i type="int" name="IALGO">    38</i>
+   <i type="int" name="IWAVPR">    10</i>
+   <i type="int" name="NBANDS">   128</i>
+   <i name="NELECT">      8.00000000</i>
+   <i type="int" name="TURBO">     0</i>
+   <i type="int" name="IRESTART">     0</i>
+   <i type="int" name="NREBOOT">     0</i>
+   <i type="int" name="NMIN">     0</i>
+   <i name="EREF">      0.00000000</i>
+   <separator name="electronic smearing" >
+    <i type="int" name="ISMEAR">     0</i>
+    <i name="SIGMA">      0.01000000</i>
+    <i name="KSPACING">      0.50000000</i>
+    <i type="logical" name="KGAMMA"> T  </i>
+   </separator>
+   <separator name="electronic projectors" >
+    <i type="logical" name="LREAL"> F  </i>
+    <v name="ROPT">      0.00000000</v>
+    <i type="int" name="LMAXPAW">  -100</i>
+    <i type="int" name="LMAXMIX">     2</i>
+    <i type="logical" name="NLSPLINE"> F  </i>
+   </separator>
+   <separator name="electronic startup" >
+    <i type="int" name="ISTART">     1</i>
+    <i type="int" name="ICHARG">     0</i>
+    <i type="int" name="INIWAV">     1</i>
+   </separator>
+   <separator name="electronic spin" >
+    <i type="int" name="ISPIN">     1</i>
+    <i type="logical" name="LNONCOLLINEAR"> F  </i>
+    <v name="MAGMOM">      1.00000000      1.00000000</v>
+    <i name="NUPDOWN">     -1.00000000</i>
+    <i type="logical" name="LSORBIT"> F  </i>
+    <v name="SAXIS">      0.00000000      0.00000000      1.00000000</v>
+    <i type="logical" name="LSPIRAL"> F  </i>
+    <v name="QSPIRAL">      0.00000000      0.00000000      0.00000000</v>
+    <i type="logical" name="LZEROZ"> F  </i>
+   </separator>
+   <separator name="electronic exchange-correlation" >
+    <i type="logical" name="LASPH"> F  </i>
+    <i type="logical" name="LMETAGGA"> F  </i>
+   </separator>
+   <separator name="electronic convergence" >
+    <i type="int" name="NELM">    60</i>
+    <i type="int" name="NELMDL">     0</i>
+    <i type="int" name="NELMIN">     2</i>
+    <i name="ENINI">    250.00000000</i>
+    <separator name="electronic convergence detail" >
+     <i type="logical" name="LDIAG"> T  </i>
+     <i type="logical" name="LSUBROT"> F  </i>
+     <i name="WEIMIN">      0.00000000</i>
+     <i name="EBREAK">      0.00000000</i>
+     <i name="DEPER">      0.30000000</i>
+     <i type="int" name="NRMM">     4</i>
+     <i name="TIME">      0.40000000</i>
+    </separator>
+   </separator>
+   <separator name="electronic mixer" >
+    <i name="AMIX">      0.40000000</i>
+    <i name="BMIX">      1.00000000</i>
+    <i name="AMIN">      0.10000000</i>
+    <i name="AMIX_MAG">      1.60000000</i>
+    <i name="BMIX_MAG">      1.00000000</i>
+    <separator name="electronic mixer details" >
+     <i type="int" name="IMIX">     1</i>
+     <i type="logical" name="MIXFIRST"> F  </i>
+     <i type="int" name="MAXMIX">   -45</i>
+     <i name="WC">    100.00000000</i>
+     <i type="int" name="INIMIX">     1</i>
+     <i type="int" name="MIXPRE">     1</i>
+     <i type="int" name="MREMOVE">     5</i>
+    </separator>
+   </separator>
+   <separator name="electronic dipolcorrection" >
+    <i type="logical" name="LDIPOL"> F  </i>
+    <i type="logical" name="LMONO"> F  </i>
+    <i type="int" name="IDIPOL">     0</i>
+    <i name="EPSILON">      1.00000000</i>
+    <v name="DIPOL">   -100.00000000   -100.00000000   -100.00000000</v>
+    <i name="EFIELD">      0.00000000</i>
+   </separator>
+  </separator>
+  <separator name="grids" >
+   <i type="int" name="NGX">    16</i>
+   <i type="int" name="NGY">    16</i>
+   <i type="int" name="NGZ">    16</i>
+   <i type="int" name="NGXF">    32</i>
+   <i type="int" name="NGYF">    32</i>
+   <i type="int" name="NGZF">    32</i>
+   <i type="logical" name="ADDGRID"> F  </i>
+  </separator>
+  <separator name="ionic" >
+   <i type="int" name="NSW">     0</i>
+   <i type="int" name="IBRION">    -1</i>
+   <i type="int" name="MDALGO">     0</i>
+   <i type="int" name="ISIF">     0</i>
+   <i name="PSTRESS">      0.00000000</i>
+   <i name="EDIFFG">      0.00000010</i>
+   <i type="int" name="NFREE">     0</i>
+   <i name="POTIM">      0.50000000</i>
+   <i name="SMASS">     -3.00000000</i>
+   <i name="SCALEE">      1.00000000</i>
+  </separator>
+  <separator name="ionic md" >
+   <i name="TEBEG">      0.00010000</i>
+   <i name="TEEND">      0.00010000</i>
+   <i type="int" name="NBLOCK">     1</i>
+   <i type="int" name="KBLOCK">     1</i>
+   <i type="int" name="NPACO">   256</i>
+   <i name="APACO">     16.00000000</i>
+  </separator>
+  <separator name="symmetry" >
+   <i type="int" name="ISYM">     3</i>
+   <i name="SYMPREC">      0.00001000</i>
+  </separator>
+  <separator name="dos" >
+   <i type="int" name="LORBIT">     0</i>
+   <v name="RWIGS">     -1.00000000</v>
+   <i type="int" name="NEDOS">   301</i>
+   <i name="EMIN">     10.00000000</i>
+   <i name="EMAX">    -10.00000000</i>
+   <i name="EFERMI">      0.00000000</i>
+  </separator>
+  <separator name="writing" >
+   <i type="int" name="NWRITE">     2</i>
+   <i type="logical" name="LWAVE"> T  </i>
+   <i type="logical" name="LDOWNSAMPLE"> F  </i>
+   <i type="logical" name="LCHARG"> T  </i>
+   <i type="logical" name="LPARD"> F  </i>
+   <i type="logical" name="LVTOT"> F  </i>
+   <i type="logical" name="LVHAR"> F  </i>
+   <i type="logical" name="LELF"> F  </i>
+   <i type="logical" name="LOPTICS"> F  </i>
+   <v name="STM">      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000</v>
+  </separator>
+  <separator name="performance" >
+   <i type="int" name="NPAR">    16</i>
+   <i type="int" name="NSIM">     4</i>
+   <i type="int" name="NBLK">    -1</i>
+   <i type="logical" name="LPLANE"> T  </i>
+   <i type="logical" name="LSCALAPACK"> T  </i>
+   <i type="logical" name="LSCAAWARE"> T  </i>
+   <i type="logical" name="LSCALU"> F  </i>
+   <i type="logical" name="LASYNC"> F  </i>
+   <i type="logical" name="LORBITALREAL"> F  </i>
+  </separator>
+  <separator name="miscellaneous" >
+   <i type="int" name="IDIOT">     3</i>
+   <i type="int" name="ISPECIAL">     0</i>
+   <i type="logical" name="LMUSIC"> F  </i>
+   <v name="POMASS">     28.08500000</v>
+   <v name="DARWINR">      0.00000000</v>
+   <v name="DARWINV">      1.00000000</v>
+   <i type="logical" name="LCORR"> T  </i>
+  </separator>
+  <i type="logical" name="GGA_COMPAT"> T  </i>
+  <i type="logical" name="LBERRY"> F  </i>
+  <i type="int" name="ICORELEVEL">     0</i>
+  <i type="logical" name="LDAU"> F  </i>
+  <i type="int" name="I_CONSTRAINED_M">     0</i>
+  <separator name="electronic exchange-correlation" >
+   <i type="string" name="GGA">--</i>
+   <i type="int" name="VOSKOWN">     0</i>
+   <i type="logical" name="LHFCALC"> T  </i>
+   <i type="string" name="PRECFOCK">normal</i>
+   <i type="logical" name="LSYMGRAD"> F  </i>
+   <i type="logical" name="LHFONE"> F  </i>
+   <i type="logical" name="LRHFCALC"> F  </i>
+   <i type="logical" name="LTHOMAS"> F  </i>
+   <i type="logical" name="LMODELHF"> F  </i>
+   <i name="ENCUT4O">     -1.00000000</i>
+   <i type="int" name="EXXOEP">     0</i>
+   <i type="int" name="FOURORBIT">     0</i>
+   <i name="AEXX">      1.00000000</i>
+   <i name="HFALPHA">     -1.00000000</i>
+   <i name="MCALPHA">      0.00000000</i>
+   <i name="ALDAX">      0.00000000</i>
+   <i name="AGGAX">      0.00000000</i>
+   <i name="ALDAC">      0.00000000</i>
+   <i name="AGGAC">      0.00000000</i>
+   <i type="int" name="NKREDX">     1</i>
+   <i type="int" name="NKREDY">     1</i>
+   <i type="int" name="NKREDZ">     1</i>
+   <i type="logical" name="SHIFTRED"> F  </i>
+   <i type="logical" name="ODDONLY"> F  </i>
+   <i type="logical" name="EVENONLY"> F  </i>
+   <i type="int" name="LMAXFOCK">     4</i>
+   <i type="int" name="NMAXFOCKAE">     1</i>
+   <i type="logical" name="LFOCKAEDFT"> F  </i>
+   <i name="HFSCREEN">      0.00000000</i>
+   <i name="HFSCREENC">      0.00000000</i>
+   <i type="int" name="NBANDSGWLOW">     1</i>
+  </separator>
+  <separator name="vdW DFT" >
+   <i type="logical" name="LUSE_VDW"> F  </i>
+   <i name="Zab_VDW">     -0.84910000</i>
+   <i name="PARAM1">      0.12340000</i>
+   <i name="PARAM2">      1.00000000</i>
+   <i name="PARAM3">      0.00000000</i>
+  </separator>
+  <separator name="model GW" >
+   <i type="int" name="MODEL_GW">     0</i>
+   <i name="MODEL_EPS0">     12.00772552</i>
+   <i name="MODEL_ALPHA">      1.00000000</i>
+  </separator>
+  <separator name="linear response parameters" >
+   <i type="logical" name="LEPSILON"> F  </i>
+   <i type="logical" name="LRPA"> F  </i>
+   <i type="logical" name="LNABLA"> F  </i>
+   <i type="logical" name="LVEL"> F  </i>
+   <i type="int" name="KINTER">     0</i>
+   <i name="CSHIFT">      0.10000000</i>
+   <i name="OMEGAMAX">     20.00000000</i>
+   <i name="DEG_THRESHOLD">      0.00200000</i>
+   <i name="RTIME">     -0.10000000</i>
+   <i name="WPLASMAI">      0.00000000</i>
+   <v name="DFIELD">      0.00000000      0.00000000      0.00000000</v>
+   <v name="WPLASMA">      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000</v>
+  </separator>
+  <separator name="orbital magnetization" >
+   <i type="logical" name="NUCIND"> F  </i>
+   <v name="MAGPOS">      0.00000000      0.00000000      0.00000000</v>
+   <i type="logical" name="LNICSALL"> T  </i>
+   <i type="logical" name="ORBITALMAG"> F  </i>
+   <i type="logical" name="LMAGBLOCH"> F  </i>
+   <i type="logical" name="LCHIMAG"> F  </i>
+   <i type="logical" name="LGAUGE"> T  </i>
+   <i type="int" name="MAGATOM">     0</i>
+   <v name="MAGDIPOL">      0.00000000      0.00000000      0.00000000</v>
+   <v name="AVECCONST">      0.00000000      0.00000000      0.00000000</v>
+  </separator>
+  <separator name="response functions" >
+   <i type="logical" name="LADDER"> T  </i>
+   <i type="logical" name="LRPAFORCE"> F  </i>
+   <i type="logical" name="LFXC"> F  </i>
+   <i type="logical" name="LHARTREE"> T  </i>
+   <i type="int" name="IBSE">     0</i>
+   <v type="int" name="KPOINT">    -1     0     0     0</v>
+   <i type="logical" name="LTCTE"> F  </i>
+   <i type="logical" name="LTETE"> F  </i>
+   <i type="logical" name="LTRIPLET"> F  </i>
+   <i type="logical" name="LFXCEPS"> F  </i>
+   <i type="logical" name="LFXHEG"> F  </i>
+   <i type="int" name="NATURALO">     2</i>
+   <i type="logical" name="L2ORDER"> F  </i>
+   <i type="logical" name="LMP2LT"> F  </i>
+   <i type="logical" name="LUSEW"> T  </i>
+   <i name="ENCUTGW">    150.00000000</i>
+   <i name="ENCUTGWSOFT">    150.00000000</i>
+   <i name="ENCUTLF">     -1.00000000</i>
+   <i type="int" name="LMAXMP2">    -1</i>
+   <i name="SCISSOR">      0.00000000</i>
+   <i type="int" name="NOMEGA">     0</i>
+   <i type="int" name="NOMEGAR">     0</i>
+   <i type="int" name="NBANDSGW">    -1</i>
+   <i type="int" name="NBANDSO">     4</i>
+   <i type="int" name="NBANDSV">     8</i>
+   <i type="int" name="NELM">     1</i>
+   <i type="int" name="NELMHF">     1</i>
+   <i type="int" name="DIM">     3</i>
+   <i type="int" name="ANTIRES">     0</i>
+   <i name="OMEGAMAX">     20.00000000</i>
+   <i name="OMEGAMIN">    -30.00000000</i>
+   <i name="OMEGATL">   -200.00000000</i>
+   <i type="int" name="OMEGAGRID">   140</i>
+   <i name="CSHIFT">     -0.10000000</i>
+   <i type="logical" name="SELFENERGY"> F  </i>
+   <i type="logical" name="LSPECTRAL"> F  </i>
+   <i type="logical" name="LSPECTRALGW"> F  </i>
+   <i type="logical" name="LSINGLES"> F  </i>
+   <i type="logical" name="LFERMIGW"> F  </i>
+   <i type="logical" name="ODDONLYGW"> F  </i>
+   <i type="logical" name="EVENONLYGW"> F  </i>
+   <i type="int" name="NKREDLFX">     1</i>
+   <i type="int" name="NKREDLFY">     1</i>
+   <i type="int" name="NKREDLFZ">     1</i>
+   <i type="int" name="MAXMEM">  2800</i>
+   <i type="int" name="TELESCOPE">     0</i>
+   <i type="int" name="TAUPAR">     1</i>
+   <i type="int" name="OMEGAPAR">    -1</i>
+   <i name="LAMBDA">      1.00000000</i>
+  </separator>
+  <separator name="External order field" >
+   <i name="OFIELD_KAPPA">      0.00000000</i>
+   <v name="OFIELD_K">      0.00000000      0.00000000      0.00000000</v>
+   <i name="OFIELD_Q6_NEAR">      0.00000000</i>
+   <i name="OFIELD_Q6_FAR">      0.00000000</i>
+   <i name="OFIELD_A">      0.00000000</i>
+  </separator>
+ </parameters>
+ <atominfo>
+  <atoms>       2 </atoms>
+  <types>       1 </types>
+  <array name="atoms" >
+   <dimension dim="1">ion</dimension>
+   <field type="string">element</field>
+   <field type="int">atomtype</field>
+   <set>
+    <rc><c>Si</c><c>   1</c></rc>
+    <rc><c>Si</c><c>   1</c></rc>
+   </set>
+  </array>
+  <array name="atomtypes" >
+   <dimension dim="1">type</dimension>
+   <field type="int">atomspertype</field>
+   <field type="string">element</field>
+   <field>mass</field>
+   <field>valence</field>
+   <field type="string">pseudopotential</field>
+   <set>
+    <rc><c>   2</c><c>Si</c><c>     28.08500000</c><c>      4.00000000</c><c>  PAW_PBE Si 05Jan2001                  </c></rc>
+   </set>
+  </array>
+ </atominfo>
+ <structure name="initialpos" >
+  <crystal>
+   <varray name="basis" >
+    <v>       2.71500000       2.71500000       0.00000000 </v>
+    <v>       0.00000000       2.71500000       2.71500000 </v>
+    <v>       2.71500000       0.00000000       2.71500000 </v>
+   </varray>
+   <i name="volume">     40.02575175 </i>
+   <varray name="rec_basis" >
+    <v>       0.18416206       0.18416206      -0.18416206 </v>
+    <v>      -0.18416206       0.18416206       0.18416206 </v>
+    <v>       0.18416206      -0.18416206       0.18416206 </v>
+   </varray>
+  </crystal>
+  <varray name="positions" >
+   <v>       0.00000000       0.00000000       0.00000000 </v>
+   <v>       0.25000000       0.25000000       0.25000000 </v>
+  </varray>
+ </structure>
+ <kpoints>
+  <generation param="Gamma">
+   <v type="int" name="divisions">       6        6        6 </v>
+   <v name="usershift">      0.00000000       0.00000000       0.00000000 </v>
+   <v name="genvec1">      0.16666667       0.00000000       0.00000000 </v>
+   <v name="genvec2">      0.00000000       0.16666667       0.00000000 </v>
+   <v name="genvec3">      0.00000000       0.00000000       0.16666667 </v>
+   <v name="shift">      0.00000000       0.00000000       0.00000000 </v>
+  </generation>
+  <varray name="kpointlist" >
+   <v>       0.00000000       0.00000000       0.00000000 </v>
+   <v>       0.16666667       0.00000000       0.00000000 </v>
+   <v>       0.33333333       0.00000000       0.00000000 </v>
+   <v>       0.50000000       0.00000000       0.00000000 </v>
+   <v>      -0.33333333       0.00000000       0.00000000 </v>
+   <v>      -0.16666667       0.00000000       0.00000000 </v>
+   <v>       0.00000000       0.16666667       0.00000000 </v>
+   <v>       0.16666667       0.16666667       0.00000000 </v>
+   <v>       0.33333333       0.16666667       0.00000000 </v>
+   <v>       0.50000000       0.16666667       0.00000000 </v>
+   <v>      -0.33333333       0.16666667       0.00000000 </v>
+   <v>      -0.16666667       0.16666667       0.00000000 </v>
+   <v>       0.00000000       0.33333333       0.00000000 </v>
+   <v>       0.16666667       0.33333333       0.00000000 </v>
+   <v>       0.33333333       0.33333333       0.00000000 </v>
+   <v>       0.50000000       0.33333333       0.00000000 </v>
+   <v>      -0.33333333       0.33333333       0.00000000 </v>
+   <v>      -0.16666667       0.33333333       0.00000000 </v>
+   <v>       0.00000000       0.50000000       0.00000000 </v>
+   <v>       0.16666667       0.50000000       0.00000000 </v>
+   <v>       0.33333333       0.50000000       0.00000000 </v>
+   <v>       0.50000000       0.50000000       0.00000000 </v>
+   <v>      -0.33333333       0.50000000       0.00000000 </v>
+   <v>      -0.16666667       0.50000000       0.00000000 </v>
+   <v>       0.00000000      -0.33333333       0.00000000 </v>
+   <v>       0.16666667      -0.33333333       0.00000000 </v>
+   <v>       0.33333333      -0.33333333       0.00000000 </v>
+   <v>       0.50000000      -0.33333333       0.00000000 </v>
+   <v>      -0.33333333      -0.33333333       0.00000000 </v>
+   <v>      -0.16666667      -0.33333333       0.00000000 </v>
+   <v>       0.00000000      -0.16666667       0.00000000 </v>
+   <v>       0.16666667      -0.16666667       0.00000000 </v>
+   <v>       0.33333333      -0.16666667       0.00000000 </v>
+   <v>       0.50000000      -0.16666667       0.00000000 </v>
+   <v>      -0.33333333      -0.16666667       0.00000000 </v>
+   <v>      -0.16666667      -0.16666667       0.00000000 </v>
+   <v>       0.00000000       0.00000000       0.16666667 </v>
+   <v>       0.16666667       0.00000000       0.16666667 </v>
+   <v>       0.33333333       0.00000000       0.16666667 </v>
+   <v>       0.50000000       0.00000000       0.16666667 </v>
+   <v>      -0.33333333       0.00000000       0.16666667 </v>
+   <v>      -0.16666667       0.00000000       0.16666667 </v>
+   <v>       0.00000000       0.16666667       0.16666667 </v>
+   <v>       0.16666667       0.16666667       0.16666667 </v>
+   <v>       0.33333333       0.16666667       0.16666667 </v>
+   <v>       0.50000000       0.16666667       0.16666667 </v>
+   <v>      -0.33333333       0.16666667       0.16666667 </v>
+   <v>      -0.16666667       0.16666667       0.16666667 </v>
+   <v>       0.00000000       0.33333333       0.16666667 </v>
+   <v>       0.16666667       0.33333333       0.16666667 </v>
+   <v>       0.33333333       0.33333333       0.16666667 </v>
+   <v>       0.50000000       0.33333333       0.16666667 </v>
+   <v>      -0.33333333       0.33333333       0.16666667 </v>
+   <v>      -0.16666667       0.33333333       0.16666667 </v>
+   <v>       0.00000000       0.50000000       0.16666667 </v>
+   <v>       0.16666667       0.50000000       0.16666667 </v>
+   <v>       0.33333333       0.50000000       0.16666667 </v>
+   <v>       0.50000000       0.50000000       0.16666667 </v>
+   <v>      -0.33333333       0.50000000       0.16666667 </v>
+   <v>      -0.16666667       0.50000000       0.16666667 </v>
+   <v>       0.00000000      -0.33333333       0.16666667 </v>
+   <v>       0.16666667      -0.33333333       0.16666667 </v>
+   <v>       0.33333333      -0.33333333       0.16666667 </v>
+   <v>       0.50000000      -0.33333333       0.16666667 </v>
+   <v>      -0.33333333      -0.33333333       0.16666667 </v>
+   <v>      -0.16666667      -0.33333333       0.16666667 </v>
+   <v>       0.00000000      -0.16666667       0.16666667 </v>
+   <v>       0.16666667      -0.16666667       0.16666667 </v>
+   <v>       0.33333333      -0.16666667       0.16666667 </v>
+   <v>       0.50000000      -0.16666667       0.16666667 </v>
+   <v>      -0.33333333      -0.16666667       0.16666667 </v>
+   <v>      -0.16666667      -0.16666667       0.16666667 </v>
+   <v>       0.00000000       0.00000000       0.33333333 </v>
+   <v>       0.16666667       0.00000000       0.33333333 </v>
+   <v>       0.33333333       0.00000000       0.33333333 </v>
+   <v>       0.50000000       0.00000000       0.33333333 </v>
+   <v>      -0.33333333       0.00000000       0.33333333 </v>
+   <v>      -0.16666667       0.00000000       0.33333333 </v>
+   <v>       0.00000000       0.16666667       0.33333333 </v>
+   <v>       0.16666667       0.16666667       0.33333333 </v>
+   <v>       0.33333333       0.16666667       0.33333333 </v>
+   <v>       0.50000000       0.16666667       0.33333333 </v>
+   <v>      -0.33333333       0.16666667       0.33333333 </v>
+   <v>      -0.16666667       0.16666667       0.33333333 </v>
+   <v>       0.00000000       0.33333333       0.33333333 </v>
+   <v>       0.16666667       0.33333333       0.33333333 </v>
+   <v>       0.33333333       0.33333333       0.33333333 </v>
+   <v>       0.50000000       0.33333333       0.33333333 </v>
+   <v>      -0.33333333       0.33333333       0.33333333 </v>
+   <v>      -0.16666667       0.33333333       0.33333333 </v>
+   <v>       0.00000000       0.50000000       0.33333333 </v>
+   <v>       0.16666667       0.50000000       0.33333333 </v>
+   <v>       0.33333333       0.50000000       0.33333333 </v>
+   <v>       0.50000000       0.50000000       0.33333333 </v>
+   <v>      -0.33333333       0.50000000       0.33333333 </v>
+   <v>      -0.16666667       0.50000000       0.33333333 </v>
+   <v>       0.00000000      -0.33333333       0.33333333 </v>
+   <v>       0.16666667      -0.33333333       0.33333333 </v>
+   <v>       0.33333333      -0.33333333       0.33333333 </v>
+   <v>       0.50000000      -0.33333333       0.33333333 </v>
+   <v>      -0.33333333      -0.33333333       0.33333333 </v>
+   <v>      -0.16666667      -0.33333333       0.33333333 </v>
+   <v>       0.00000000      -0.16666667       0.33333333 </v>
+   <v>       0.16666667      -0.16666667       0.33333333 </v>
+   <v>       0.33333333      -0.16666667       0.33333333 </v>
+   <v>       0.50000000      -0.16666667       0.33333333 </v>
+   <v>      -0.33333333      -0.16666667       0.33333333 </v>
+   <v>      -0.16666667      -0.16666667       0.33333333 </v>
+   <v>       0.00000000       0.00000000       0.50000000 </v>
+   <v>       0.16666667       0.00000000       0.50000000 </v>
+   <v>       0.33333333       0.00000000       0.50000000 </v>
+   <v>       0.50000000       0.00000000       0.50000000 </v>
+   <v>      -0.33333333       0.00000000       0.50000000 </v>
+   <v>      -0.16666667       0.00000000       0.50000000 </v>
+   <v>       0.00000000       0.16666667       0.50000000 </v>
+   <v>       0.16666667       0.16666667       0.50000000 </v>
+   <v>       0.33333333       0.16666667       0.50000000 </v>
+   <v>       0.50000000       0.16666667       0.50000000 </v>
+   <v>      -0.33333333       0.16666667       0.50000000 </v>
+   <v>      -0.16666667       0.16666667       0.50000000 </v>
+   <v>       0.00000000       0.33333333       0.50000000 </v>
+   <v>       0.16666667       0.33333333       0.50000000 </v>
+   <v>       0.33333333       0.33333333       0.50000000 </v>
+   <v>       0.50000000       0.33333333       0.50000000 </v>
+   <v>      -0.33333333       0.33333333       0.50000000 </v>
+   <v>      -0.16666667       0.33333333       0.50000000 </v>
+   <v>       0.00000000       0.50000000       0.50000000 </v>
+   <v>       0.16666667       0.50000000       0.50000000 </v>
+   <v>       0.33333333       0.50000000       0.50000000 </v>
+   <v>       0.50000000       0.50000000       0.50000000 </v>
+   <v>      -0.33333333       0.50000000       0.50000000 </v>
+   <v>      -0.16666667       0.50000000       0.50000000 </v>
+   <v>       0.00000000      -0.33333333       0.50000000 </v>
+   <v>       0.16666667      -0.33333333       0.50000000 </v>
+   <v>       0.33333333      -0.33333333       0.50000000 </v>
+   <v>       0.50000000      -0.33333333       0.50000000 </v>
+   <v>      -0.33333333      -0.33333333       0.50000000 </v>
+   <v>      -0.16666667      -0.33333333       0.50000000 </v>
+   <v>       0.00000000      -0.16666667       0.50000000 </v>
+   <v>       0.16666667      -0.16666667       0.50000000 </v>
+   <v>       0.33333333      -0.16666667       0.50000000 </v>
+   <v>       0.50000000      -0.16666667       0.50000000 </v>
+   <v>      -0.33333333      -0.16666667       0.50000000 </v>
+   <v>      -0.16666667      -0.16666667       0.50000000 </v>
+   <v>       0.00000000       0.00000000      -0.33333333 </v>
+   <v>       0.16666667       0.00000000      -0.33333333 </v>
+   <v>       0.33333333       0.00000000      -0.33333333 </v>
+   <v>       0.50000000       0.00000000      -0.33333333 </v>
+   <v>      -0.33333333       0.00000000      -0.33333333 </v>
+   <v>      -0.16666667       0.00000000      -0.33333333 </v>
+   <v>       0.00000000       0.16666667      -0.33333333 </v>
+   <v>       0.16666667       0.16666667      -0.33333333 </v>
+   <v>       0.33333333       0.16666667      -0.33333333 </v>
+   <v>       0.50000000       0.16666667      -0.33333333 </v>
+   <v>      -0.33333333       0.16666667      -0.33333333 </v>
+   <v>      -0.16666667       0.16666667      -0.33333333 </v>
+   <v>       0.00000000       0.33333333      -0.33333333 </v>
+   <v>       0.16666667       0.33333333      -0.33333333 </v>
+   <v>       0.33333333       0.33333333      -0.33333333 </v>
+   <v>       0.50000000       0.33333333      -0.33333333 </v>
+   <v>      -0.33333333       0.33333333      -0.33333333 </v>
+   <v>      -0.16666667       0.33333333      -0.33333333 </v>
+   <v>       0.00000000       0.50000000      -0.33333333 </v>
+   <v>       0.16666667       0.50000000      -0.33333333 </v>
+   <v>       0.33333333       0.50000000      -0.33333333 </v>
+   <v>       0.50000000       0.50000000      -0.33333333 </v>
+   <v>      -0.33333333       0.50000000      -0.33333333 </v>
+   <v>      -0.16666667       0.50000000      -0.33333333 </v>
+   <v>       0.00000000      -0.33333333      -0.33333333 </v>
+   <v>       0.16666667      -0.33333333      -0.33333333 </v>
+   <v>       0.33333333      -0.33333333      -0.33333333 </v>
+   <v>       0.50000000      -0.33333333      -0.33333333 </v>
+   <v>      -0.33333333      -0.33333333      -0.33333333 </v>
+   <v>      -0.16666667      -0.33333333      -0.33333333 </v>
+   <v>       0.00000000      -0.16666667      -0.33333333 </v>
+   <v>       0.16666667      -0.16666667      -0.33333333 </v>
+   <v>       0.33333333      -0.16666667      -0.33333333 </v>
+   <v>       0.50000000      -0.16666667      -0.33333333 </v>
+   <v>      -0.33333333      -0.16666667      -0.33333333 </v>
+   <v>      -0.16666667      -0.16666667      -0.33333333 </v>
+   <v>       0.00000000       0.00000000      -0.16666667 </v>
+   <v>       0.16666667       0.00000000      -0.16666667 </v>
+   <v>       0.33333333       0.00000000      -0.16666667 </v>
+   <v>       0.50000000       0.00000000      -0.16666667 </v>
+   <v>      -0.33333333       0.00000000      -0.16666667 </v>
+   <v>      -0.16666667       0.00000000      -0.16666667 </v>
+   <v>       0.00000000       0.16666667      -0.16666667 </v>
+   <v>       0.16666667       0.16666667      -0.16666667 </v>
+   <v>       0.33333333       0.16666667      -0.16666667 </v>
+   <v>       0.50000000       0.16666667      -0.16666667 </v>
+   <v>      -0.33333333       0.16666667      -0.16666667 </v>
+   <v>      -0.16666667       0.16666667      -0.16666667 </v>
+   <v>       0.00000000       0.33333333      -0.16666667 </v>
+   <v>       0.16666667       0.33333333      -0.16666667 </v>
+   <v>       0.33333333       0.33333333      -0.16666667 </v>
+   <v>       0.50000000       0.33333333      -0.16666667 </v>
+   <v>      -0.33333333       0.33333333      -0.16666667 </v>
+   <v>      -0.16666667       0.33333333      -0.16666667 </v>
+   <v>       0.00000000       0.50000000      -0.16666667 </v>
+   <v>       0.16666667       0.50000000      -0.16666667 </v>
+   <v>       0.33333333       0.50000000      -0.16666667 </v>
+   <v>       0.50000000       0.50000000      -0.16666667 </v>
+   <v>      -0.33333333       0.50000000      -0.16666667 </v>
+   <v>      -0.16666667       0.50000000      -0.16666667 </v>
+   <v>       0.00000000      -0.33333333      -0.16666667 </v>
+   <v>       0.16666667      -0.33333333      -0.16666667 </v>
+   <v>       0.33333333      -0.33333333      -0.16666667 </v>
+   <v>       0.50000000      -0.33333333      -0.16666667 </v>
+   <v>      -0.33333333      -0.33333333      -0.16666667 </v>
+   <v>      -0.16666667      -0.33333333      -0.16666667 </v>
+   <v>       0.00000000      -0.16666667      -0.16666667 </v>
+   <v>       0.16666667      -0.16666667      -0.16666667 </v>
+   <v>       0.33333333      -0.16666667      -0.16666667 </v>
+   <v>       0.50000000      -0.16666667      -0.16666667 </v>
+   <v>      -0.33333333      -0.16666667      -0.16666667 </v>
+   <v>      -0.16666667      -0.16666667      -0.16666667 </v>
+  </varray>
+  <varray name="weights" >
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+   <v>       0.00462963 </v>
+  </varray>
+ </kpoints>
+ <varray name="opticaltransitions" >
+  <v>      3.084      0.001 </v>
+  <v>      3.084      0.001 </v>
+  <v>      3.084      0.000 </v>
+  <v>      3.087  27781.944 </v>
+  <v>      3.087  27801.690 </v>
+  <v>      3.087  27764.719 </v>
+  <v>      3.097      0.000 </v>
+  <v>      3.097      0.001 </v>
+  <v>      3.101   1061.068 </v>
+  <v>      3.216  97571.194 </v>
+  <v>      3.216  97546.735 </v>
+  <v>      3.216  97568.968 </v>
+  <v>      3.237      0.006 </v>
+  <v>      3.237      0.009 </v>
+  <v>      3.237      0.008 </v>
+  <v>      3.244      0.017 </v>
+  <v>      3.244      0.003 </v>
+  <v>      3.283      0.005 </v>
+  <v>      3.283      0.007 </v>
+  <v>      3.283      0.001 </v>
+  <v>      3.289      0.000 </v>
+  <v>      3.289      0.000 </v>
+  <v>      3.289      0.000 </v>
+  <v>      3.289      0.000 </v>
+  <v>      3.289      0.000 </v>
+  <v>      3.294   6462.171 </v>
+  <v>      3.294   6461.701 </v>
+  <v>      3.294   6462.308 </v>
+  <v>      3.295      0.000 </v>
+  <v>      3.295      0.000 </v>
+  <v>      3.295      0.000 </v>
+  <v>      3.299      0.000 </v>
+  <v>      3.299      0.001 </v>
+  <v>      3.322   1613.046 </v>
+  <v>      3.322   1612.293 </v>
+  <v>      3.322   1614.642 </v>
+  <v>      3.322      0.000 </v>
+  <v>      3.322      0.000 </v>
+  <v>      3.322      0.000 </v>
+  <v>      3.322      0.003 </v>
+  <v>      3.322      0.001 </v>
+  <v>      3.322      0.000 </v>
+  <v>      3.326      0.000 </v>
+  <v>      3.326      0.001 </v>
+  <v>      3.326      0.000 </v>
+  <v>      3.326      0.000 </v>
+  <v>      3.326      0.000 </v>
+  <v>      3.326      0.000 </v>
+  <v>      3.326      0.000 </v>
+  <v>      3.379      0.000 </v>
+  <v>      3.379      0.001 </v>
+  <v>      3.379      0.000 </v>
+  <v>      3.380  10540.930 </v>
+  <v>      3.380  10528.912 </v>
+  <v>      3.380  10554.986 </v>
+  <v>      3.381      0.000 </v>
+  <v>      3.381      0.001 </v>
+  <v>      3.381      0.000 </v>
+  <v>      3.387      0.001 </v>
+  <v>      3.387      0.000 </v>
+  <v>      3.387      0.001 </v>
+  <v>      3.620  22848.092 </v>
+  <v>      3.620  22845.712 </v>
+  <v>      3.620  22850.807 </v>
+  <v>      3.621      0.000 </v>
+  <v>      3.621      0.006 </v>
+  <v>      3.621      0.002 </v>
+  <v>      3.623      0.000 </v>
+  <v>      3.623      0.000 </v>
+  <v>      3.623      0.000 </v>
+  <v>      3.630      0.002 </v>
+  <v>      3.630      0.001 </v>
+  <v>      3.630      0.002 </v>
+  <v>      3.950  23181.486 </v>
+  <v>      3.950  23171.747 </v>
+  <v>      3.950  23182.700 </v>
+  <v>      3.999      0.005 </v>
+  <v>      3.999      0.001 </v>
+  <v>      3.999      0.007 </v>
+  <v>      4.010 101264.301 </v>
+  <v>      4.010 101319.740 </v>
+  <v>      4.010 101321.814 </v>
+  <v>      4.054      0.000 </v>
+  <v>      4.054      0.000 </v>
+  <v>      4.054      0.001 </v>
+  <v>      4.062      0.002 </v>
+  <v>      4.062      0.005 </v>
+  <v>      4.062      0.015 </v>
+  <v>      4.096      0.001 </v>
+  <v>      4.096      0.002 </v>
+  <v>      4.096      0.002 </v>
+  <v>      4.098  47866.245 </v>
+  <v>      4.098  47819.854 </v>
+  <v>      4.098  47825.405 </v>
+  <v>      4.110      0.000 </v>
+  <v>      4.110      0.000 </v>
+  <v>      4.112      0.000 </v>
+  <v>      4.112      0.000 </v>
+  <v>      4.112      0.000 </v>
+  <v>      4.114      0.000 </v>
+  <v>      4.129      0.001 </v>
+  <v>      4.129      0.000 </v>
+  <v>      4.129      0.000 </v>
+  <v>      4.131      0.008 </v>
+  <v>      4.131      0.006 </v>
+  <v>      4.131      0.005 </v>
+  <v>      4.132      0.000 </v>
+  <v>      4.132      0.000 </v>
+  <v>      4.132      0.000 </v>
+  <v>      4.132      0.000 </v>
+  <v>      4.133      0.017 </v>
+  <v>      4.133      0.010 </v>
+  <v>      4.140  21437.787 </v>
+  <v>      4.140  21391.485 </v>
+  <v>      4.140  21542.740 </v>
+  <v>      4.144      0.002 </v>
+  <v>      4.144      0.000 </v>
+  <v>      4.144      0.001 </v>
+  <v>      4.162      0.001 </v>
+  <v>      4.162      0.001 </v>
+  <v>      4.162      0.010 </v>
+  <v>      4.164      0.000 </v>
+  <v>      4.164      0.000 </v>
+  <v>      4.164      0.000 </v>
+  <v>      4.190      3.295 </v>
+  <v>      4.190      4.640 </v>
+  <v>      4.190      0.107 </v>
+  <v>      4.190     22.783 </v>
+  <v>      4.190      2.475 </v>
+  <v>      4.190      4.023 </v>
+  <v>      4.191      0.001 </v>
+  <v>      4.191      0.012 </v>
+  <v>      4.191      0.007 </v>
+  <v>      4.194      4.256 </v>
+  <v>      4.194      0.152 </v>
+  <v>      4.197      0.000 </v>
+  <v>      4.197      0.000 </v>
+  <v>      4.197      0.000 </v>
+  <v>      4.202      0.000 </v>
+  <v>      4.202      0.000 </v>
+  <v>      4.202      0.000 </v>
+  <v>      4.202      0.000 </v>
+  <v>      4.202      0.000 </v>
+  <v>      4.203   6899.587 </v>
+  <v>      4.203   6974.844 </v>
+  <v>      4.203   6902.633 </v>
+  <v>      4.203      0.004 </v>
+  <v>      4.203      0.002 </v>
+  <v>      4.203      0.005 </v>
+  <v>      4.203      0.000 </v>
+  <v>      4.205      0.000 </v>
+  <v>      4.205      0.000 </v>
+  <v>      4.205      1.088 </v>
+  <v>      4.206      0.000 </v>
+  <v>      4.206      0.000 </v>
+  <v>      4.207      0.000 </v>
+  <v>      4.207      0.000 </v>
+  <v>      4.207      0.000 </v>
+  <v>      4.207      0.003 </v>
+  <v>      4.207      0.002 </v>
+  <v>      4.207      0.019 </v>
+  <v>      4.207   1489.453 </v>
+  <v>      4.207   1396.102 </v>
+  <v>      4.207   1449.311 </v>
+  <v>      4.209      0.000 </v>
+  <v>      4.210      7.567 </v>
+  <v>      4.210      0.892 </v>
+  <v>      4.210      1.163 </v>
+  <v>      4.212      7.438 </v>
+  <v>      4.212      1.512 </v>
+  <v>      4.212      0.818 </v>
+  <v>      4.215      0.297 </v>
+  <v>      4.215      2.477 </v>
+  <v>      4.217    922.130 </v>
+  <v>      4.217    926.920 </v>
+  <v>      4.217    938.167 </v>
+  <v>      4.218      0.002 </v>
+  <v>      4.218      0.000 </v>
+  <v>      4.218      0.002 </v>
+  <v>      4.218      0.000 </v>
+  <v>      4.218      0.000 </v>
+  <v>      4.218      0.000 </v>
+  <v>      4.219      0.000 </v>
+  <v>      4.219      0.000 </v>
+  <v>      4.219      0.000 </v>
+  <v>      4.219      0.000 </v>
+  <v>      4.219      0.000 </v>
+  <v>      4.220      0.000 </v>
+  <v>      4.221      0.000 </v>
+  <v>      4.221      0.000 </v>
+  <v>      4.221      0.000 </v>
+  <v>      4.222      0.000 </v>
+  <v>      4.226     46.900 </v>
+  <v>      4.226     13.959 </v>
+  <v>      4.226     12.914 </v>
+  <v>      4.227     18.597 </v>
+  <v>      4.227      1.799 </v>
+  <v>      4.229     40.724 </v>
+  <v>      4.292  11116.383 </v>
+  <v>      4.292  11116.787 </v>
+  <v>      4.292  11122.673 </v>
+  <v>      4.295      0.000 </v>
+  <v>      4.295      0.001 </v>
+  <v>      4.295      0.002 </v>
+  <v>      4.299      0.000 </v>
+  <v>      4.299      0.000 </v>
+  <v>      4.300      0.000 </v>
+  <v>      4.300      0.000 </v>
+  <v>      4.300      0.001 </v>
+  <v>      4.301      0.000 </v>
+  <v>      4.304      0.002 </v>
+  <v>      4.304      0.004 </v>
+  <v>      4.306      0.004 </v>
+  <v>      4.306      0.001 </v>
+  <v>      4.306      0.002 </v>
+  <v>      4.309      0.000 </v>
+  <v>      4.311      0.000 </v>
+  <v>      4.311      0.000 </v>
+  <v>      4.311      0.000 </v>
+  <v>      4.311      0.009 </v>
+  <v>      4.311      0.008 </v>
+  <v>      4.311      0.009 </v>
+  <v>      4.356      0.000 </v>
+  <v>      4.356      0.000 </v>
+  <v>      4.356      0.000 </v>
+  <v>      4.357   4797.822 </v>
+  <v>      4.357   4797.264 </v>
+  <v>      4.357   4799.915 </v>
+  <v>      4.358      0.000 </v>
+  <v>      4.358      0.001 </v>
+  <v>      4.358      0.001 </v>
+  <v>      4.358      0.000 </v>
+  <v>      4.358      0.000 </v>
+  <v>      4.358      0.000 </v>
+  <v>      4.362      0.000 </v>
+  <v>      4.362      0.000 </v>
+  <v>      4.362      0.000 </v>
+  <v>      4.362      0.000 </v>
+  <v>      4.362      0.000 </v>
+  <v>      4.363      0.001 </v>
+  <v>      4.363      0.001 </v>
+  <v>      4.363      0.002 </v>
+  <v>      4.363      0.000 </v>
+  <v>      4.363      0.000 </v>
+  <v>      4.363      0.000 </v>
+  <v>      4.364      0.000 </v>
+  <v>      4.426      0.343 </v>
+  <v>      4.426      0.410 </v>
+  <v>      4.426      0.674 </v>
+  <v>      4.431      0.026 </v>
+  <v>      4.431      0.071 </v>
+  <v>      4.432      0.003 </v>
+  <v>      4.432      0.002 </v>
+  <v>      4.432      0.027 </v>
+  <v>      4.433    332.514 </v>
+  <v>      4.433    332.021 </v>
+  <v>      4.433    316.046 </v>
+  <v>      4.433      0.149 </v>
+  <v>      4.433      0.247 </v>
+  <v>      4.433      0.090 </v>
+  <v>      4.437      0.000 </v>
+  <v>      4.437      0.000 </v>
+  <v>      4.438      0.034 </v>
+  <v>      4.438      0.015 </v>
+  <v>      4.438      0.042 </v>
+  <v>      4.439      0.000 </v>
+  <v>      4.441   1037.452 </v>
+  <v>      4.441   1036.242 </v>
+  <v>      4.441   1046.853 </v>
+  <v>      4.449      0.142 </v>
+  <v>      4.693   4288.379 </v>
+  <v>      4.693   4129.304 </v>
+  <v>      4.693   4379.168 </v>
+  <v>      4.696      3.913 </v>
+  <v>      4.696      2.425 </v>
+  <v>      4.696     12.198 </v>
+  <v>      4.696      1.441 </v>
+  <v>      4.696      6.761 </v>
+  <v>      4.696     15.996 </v>
+  <v>      4.699      4.639 </v>
+  <v>      4.699      4.689 </v>
+  <v>      4.710      1.690 </v>
+  <v>      4.896      0.009 </v>
+  <v>      4.896      0.009 </v>
+  <v>      4.897      0.042 </v>
+  <v>      4.897      0.025 </v>
+  <v>      4.897      0.030 </v>
+  <v>      4.898      0.006 </v>
+  <v>      4.898      0.006 </v>
+  <v>      4.898      0.008 </v>
+  <v>      4.899      0.000 </v>
+  <v>      4.899      0.001 </v>
+  <v>      4.899      0.000 </v>
+  <v>      4.906      0.000 </v>
+  <v>      4.932      0.000 </v>
+  <v>      4.932      0.000 </v>
+  <v>      4.932      0.000 </v>
+  <v>      4.936      0.009 </v>
+  <v>      4.936      0.022 </v>
+  <v>      4.936      0.026 </v>
+  <v>      4.938   4927.039 </v>
+  <v>      4.938   4948.214 </v>
+  <v>      4.938   4962.124 </v>
+  <v>      4.941      0.000 </v>
+  <v>      4.941      0.001 </v>
+  <v>      4.941      0.005 </v>
+  <v>      5.078      0.008 </v>
+  <v>      5.078      0.001 </v>
+  <v>      5.078      0.003 </v>
+  <v>      5.078    180.675 </v>
+  <v>      5.078    155.413 </v>
+  <v>      5.078     13.825 </v>
+  <v>      5.085      0.015 </v>
+  <v>      5.085      0.068 </v>
+  <v>      5.085      0.014 </v>
+  <v>      5.089      0.143 </v>
+  <v>      5.089      0.030 </v>
+  <v>      5.090      0.000 </v>
+  <v>      5.100  15688.584 </v>
+  <v>      5.100  15531.089 </v>
+  <v>      5.100  15310.883 </v>
+  <v>      5.108      0.000 </v>
+  <v>      5.108      0.000 </v>
+  <v>      5.108      0.000 </v>
+  <v>      5.108      0.000 </v>
+  <v>      5.108      0.000 </v>
+  <v>      5.108      0.015 </v>
+  <v>      5.108      0.008 </v>
+  <v>      5.108      0.003 </v>
+  <v>      5.109      0.000 </v>
+  <v>      5.109      0.000 </v>
+  <v>      5.109      0.002 </v>
+  <v>      5.109      0.000 </v>
+  <v>      5.109      0.000 </v>
+  <v>      5.111      0.005 </v>
+  <v>      5.111      0.005 </v>
+  <v>      5.111      0.005 </v>
+  <v>      5.119    148.925 </v>
+  <v>      5.159     78.877 </v>
+  <v>      5.159     73.749 </v>
+  <v>      5.159     89.505 </v>
+  <v>      5.159      0.501 </v>
+  <v>      5.159      0.179 </v>
+  <v>      5.159      0.000 </v>
+  <v>      5.159      0.000 </v>
+  <v>      5.159      0.002 </v>
+  <v>      5.159      0.227 </v>
+  <v>      5.159      0.049 </v>
+  <v>      5.159      0.022 </v>
+  <v>      5.160      0.003 </v>
+  <v>      5.160      0.004 </v>
+  <v>      5.160      0.001 </v>
+  <v>      5.161      0.000 </v>
+  <v>      5.162   1844.620 </v>
+  <v>      5.162   1834.538 </v>
+  <v>      5.162   1818.009 </v>
+  <v>      5.163     15.864 </v>
+  <v>      5.178      1.576 </v>
+  <v>      5.178     10.529 </v>
+  <v>      5.180      0.000 </v>
+  <v>      5.180      0.022 </v>
+  <v>      5.180      0.005 </v>
+  <v>      5.181   1154.215 </v>
+  <v>      5.181   1157.700 </v>
+  <v>      5.181   1284.626 </v>
+  <v>      5.187      8.688 </v>
+  <v>      5.196      0.045 </v>
+  <v>      5.196      0.035 </v>
+  <v>      5.196      0.043 </v>
+  <v>      5.197      4.089 </v>
+  <v>      5.197     12.225 </v>
+  <v>      5.197     13.809 </v>
+  <v>      5.198    409.475 </v>
+  <v>      5.198    346.282 </v>
+  <v>      5.198    340.406 </v>
+  <v>      5.198      0.000 </v>
+  <v>      5.198      0.000 </v>
+  <v>      5.198      0.000 </v>
+  <v>      5.264    335.863 </v>
+  <v>      5.264    296.092 </v>
+  <v>      5.264    264.237 </v>
+  <v>      5.267      0.016 </v>
+  <v>      5.267      0.014 </v>
+  <v>      5.267      0.005 </v>
+  <v>      5.269      0.000 </v>
+  <v>      5.278     15.475 </v>
+  <v>      5.335      8.097 </v>
+  <v>      5.335      1.985 </v>
+  <v>      5.337      1.595 </v>
+  <v>      5.337     23.311 </v>
+  <v>      5.337      3.427 </v>
+  <v>      5.337      0.019 </v>
+  <v>      5.337      0.024 </v>
+  <v>      5.337      0.020 </v>
+  <v>      5.337      0.000 </v>
+  <v>      5.337      0.000 </v>
+  <v>      5.337      0.000 </v>
+  <v>      5.338      0.000 </v>
+  <v>      5.338      0.000 </v>
+  <v>      5.339    494.904 </v>
+  <v>      5.339    559.708 </v>
+  <v>      5.339    555.920 </v>
+  <v>      5.339      0.000 </v>
+  <v>      5.343      0.014 </v>
+  <v>      5.343      0.020 </v>
+  <v>      5.343      0.015 </v>
+  <v>      5.345    461.527 </v>
+  <v>      5.345    362.663 </v>
+  <v>      5.345    419.875 </v>
+  <v>      5.355      2.087 </v>
+  <v>      5.665      0.041 </v>
+  <v>      5.665      0.021 </v>
+  <v>      5.665     14.498 </v>
+  <v>      5.665     14.589 </v>
+  <v>      5.665     14.505 </v>
+  <v>      5.667      0.002 </v>
+  <v>      5.667      0.000 </v>
+  <v>      5.667      0.005 </v>
+  <v>      5.670      0.006 </v>
+  <v>      5.670      0.050 </v>
+  <v>      5.670      0.008 </v>
+  <v>      5.673   6122.153 </v>
+  <v>      5.673   6107.690 </v>
+  <v>      5.673   6127.126 </v>
+  <v>      5.674      0.001 </v>
+  <v>      5.675     63.692 </v>
+  <v>      5.675     63.368 </v>
+  <v>      5.675     63.120 </v>
+  <v>      5.676      0.000 </v>
+  <v>      5.676      0.000 </v>
+  <v>      5.676      0.000 </v>
+  <v>      5.679      0.004 </v>
+  <v>      5.679      0.003 </v>
+  <v>      5.684      0.711 </v>
+  <v>      5.786      0.002 </v>
+  <v>      5.786      0.002 </v>
+  <v>      5.786      0.006 </v>
+  <v>      5.801      0.000 </v>
+  <v>      5.801      0.000 </v>
+  <v>      5.801      0.000 </v>
+  <v>      5.806      0.973 </v>
+  <v>      5.806      0.576 </v>
+  <v>      5.806      0.162 </v>
+  <v>      5.806      0.004 </v>
+  <v>      5.812      0.028 </v>
+  <v>      5.812      0.062 </v>
+  <v>      5.823      0.010 </v>
+  <v>      5.823      0.001 </v>
+  <v>      5.823      0.004 </v>
+  <v>      5.823    760.617 </v>
+  <v>      5.823    760.220 </v>
+  <v>      5.823    758.050 </v>
+  <v>      5.824      0.000 </v>
+  <v>      5.824      0.000 </v>
+  <v>      5.825      0.000 </v>
+  <v>      5.825      0.000 </v>
+  <v>      5.825      0.000 </v>
+  <v>      5.825      0.000 </v>
+  <v>      5.949      0.054 </v>
+  <v>      5.949      0.023 </v>
+  <v>      5.951      0.007 </v>
+  <v>      5.951      0.007 </v>
+  <v>      5.951      0.117 </v>
+  <v>      5.952      0.001 </v>
+  <v>      5.952      0.002 </v>
+  <v>      5.952      0.001 </v>
+  <v>      5.955      0.065 </v>
+  <v>      5.955      0.038 </v>
+  <v>      5.955      0.058 </v>
+  <v>      5.956      0.000 </v>
+  <v>      5.956      0.000 </v>
+  <v>      5.959      0.004 </v>
+  <v>      5.959      0.004 </v>
+  <v>      5.959      0.056 </v>
+  <v>      5.960      0.002 </v>
+  <v>      5.960      0.008 </v>
+  <v>      5.960      0.002 </v>
+  <v>      5.960      0.000 </v>
+  <v>      5.961      0.000 </v>
+  <v>      5.964    383.095 </v>
+  <v>      5.964    381.894 </v>
+  <v>      5.964    382.727 </v>
+  <v>      6.006      1.183 </v>
+  <v>      6.006      1.174 </v>
+  <v>      6.006     18.477 </v>
+  <v>      6.019      1.972 </v>
+  <v>      6.019      3.263 </v>
+  <v>      6.022   3369.122 </v>
+  <v>      6.022   3312.880 </v>
+  <v>      6.022   3226.228 </v>
+  <v>      6.024      3.354 </v>
+  <v>      6.024      7.710 </v>
+  <v>      6.024      7.941 </v>
+  <v>      6.039   4057.714 </v>
+  <v>      6.039   4024.913 </v>
+  <v>      6.039   4050.846 </v>
+  <v>      6.043      0.014 </v>
+  <v>      6.043      0.021 </v>
+  <v>      6.043      0.185 </v>
+  <v>      6.044      8.805 </v>
+  <v>      6.045      0.171 </v>
+  <v>      6.045      0.161 </v>
+  <v>      6.045      2.654 </v>
+  <v>      6.047      0.580 </v>
+  <v>      6.047      0.126 </v>
+  <v>      6.047      0.033 </v>
+  <v>      6.057      4.562 </v>
+  <v>      6.057      0.719 </v>
+  <v>      6.057      0.442 </v>
+  <v>      6.058      0.000 </v>
+  <v>      6.058      0.000 </v>
+  <v>      6.059      0.000 </v>
+  <v>      6.059      2.717 </v>
+  <v>      6.059      1.931 </v>
+  <v>      6.059      0.526 </v>
+  <v>      6.061      0.863 </v>
+  <v>      6.061      0.246 </v>
+  <v>      6.061      0.264 </v>
+  <v>      6.063      7.545 </v>
+  <v>      6.063     12.649 </v>
+  <v>      6.064      1.900 </v>
+  <v>      6.064     12.816 </v>
+  <v>      6.064      1.498 </v>
+  <v>      6.065      6.300 </v>
+  <v>      6.065      1.923 </v>
+  <v>      6.065      5.294 </v>
+  <v>      6.065      6.848 </v>
+  <v>      6.065     81.237 </v>
+  <v>      6.065     81.435 </v>
+  <v>      6.065     49.124 </v>
+  <v>      6.086      0.000 </v>
+  <v>      6.086      0.000 </v>
+  <v>      6.089      0.213 </v>
+  <v>      6.089      0.053 </v>
+  <v>      6.089      0.018 </v>
+  <v>      6.090      0.345 </v>
+  <v>      6.090      1.167 </v>
+  <v>      6.094      2.161 </v>
+  <v>      6.094      0.636 </v>
+  <v>      6.094      0.269 </v>
+  <v>      6.097   2658.212 </v>
+  <v>      6.097   2630.985 </v>
+  <v>      6.097   2656.852 </v>
+  <v>      6.098      0.000 </v>
+  <v>      6.101      0.000 </v>
+  <v>      6.101      0.000 </v>
+  <v>      6.105      0.000 </v>
+  <v>      6.108      0.000 </v>
+  <v>      6.109     27.591 </v>
+  <v>      6.109    151.148 </v>
+  <v>      6.109    486.803 </v>
+  <v>      6.109     43.904 </v>
+  <v>      6.109    211.447 </v>
+  <v>      6.111    154.439 </v>
+  <v>      6.127     66.476 </v>
+  <v>      6.127    102.836 </v>
+  <v>      6.127     78.505 </v>
+  <v>      6.130      0.001 </v>
+  <v>      6.130      0.000 </v>
+  <v>      6.130      0.000 </v>
+  <v>      6.132      3.271 </v>
+  <v>      6.132      4.493 </v>
+  <v>      6.134     13.776 </v>
+  <v>      6.134      3.431 </v>
+  <v>      6.134      5.749 </v>
+  <v>      6.139      6.550 </v>
+  <v>      6.139     11.744 </v>
+  <v>      6.139      8.348 </v>
+  <v>      6.141      0.000 </v>
+  <v>      6.141      0.000 </v>
+  <v>      6.142      0.000 </v>
+  <v>      6.143   5714.107 </v>
+  <v>      6.143   5876.701 </v>
+  <v>      6.143   6050.132 </v>
+  <v>      6.144      0.395 </v>
+  <v>      6.144      1.229 </v>
+  <v>      6.144      0.541 </v>
+  <v>      6.150     11.870 </v>
+  <v>      6.150      5.922 </v>
+  <v>      6.150      1.193 </v>
+  <v>      6.151      0.001 </v>
+  <v>      6.151      0.005 </v>
+  <v>      6.151      0.001 </v>
+  <v>      6.157    155.585 </v>
+  <v>      6.157    149.557 </v>
+  <v>      6.157    143.334 </v>
+  <v>      6.157      1.471 </v>
+  <v>      6.158      0.027 </v>
+  <v>      6.158      0.025 </v>
+  <v>      6.158      0.392 </v>
+  <v>      6.159      2.510 </v>
+  <v>      6.159      0.709 </v>
+  <v>      6.160      0.000 </v>
+  <v>      6.160      0.000 </v>
+  <v>      6.173     58.778 </v>
+  <v>      6.173     37.721 </v>
+  <v>      6.173     76.146 </v>
+  <v>      6.175      0.016 </v>
+  <v>      6.175     25.487 </v>
+  <v>      6.208     91.240 </v>
+  <v>      6.379   6753.163 </v>
+  <v>      6.379   6757.260 </v>
+  <v>      6.379   6746.660 </v>
+  <v>      6.382      0.014 </v>
+  <v>      6.382      0.015 </v>
+  <v>      6.382      0.261 </v>
+  <v>      6.390      0.000 </v>
+  <v>      6.390      0.002 </v>
+  <v>      6.390      0.000 </v>
+  <v>      6.392      0.001 </v>
+  <v>      6.392      0.000 </v>
+  <v>      6.392      0.000 </v>
+  <v>      6.394      0.000 </v>
+  <v>      6.396      0.000 </v>
+  <v>      6.396      0.000 </v>
+  <v>      6.398      0.001 </v>
+  <v>      6.398      0.013 </v>
+  <v>      6.398      0.026 </v>
+  <v>      6.398      0.011 </v>
+  <v>      6.398      0.049 </v>
+  <v>      6.398      0.018 </v>
+  <v>      6.398      0.035 </v>
+  <v>      6.405      0.002 </v>
+  <v>      6.405      0.001 </v>
+  <v>      6.432    878.456 </v>
+  <v>      6.432    881.750 </v>
+  <v>      6.432    883.587 </v>
+  <v>      6.433      0.000 </v>
+  <v>      6.433      0.000 </v>
+  <v>      6.439      0.002 </v>
+  <v>      6.439      0.002 </v>
+  <v>      6.439      0.027 </v>
+  <v>      6.447      0.011 </v>
+  <v>      6.447      0.089 </v>
+  <v>      6.449      0.000 </v>
+  <v>      6.449      0.000 </v>
+  <v>      6.449      0.000 </v>
+  <v>      6.450      0.028 </v>
+  <v>      6.450      0.021 </v>
+  <v>      6.450      0.004 </v>
+  <v>      6.457      0.004 </v>
+  <v>      6.457      0.004 </v>
+  <v>      6.457      0.001 </v>
+  <v>      6.458      0.000 </v>
+  <v>      6.458      0.000 </v>
+  <v>      6.459      0.036 </v>
+  <v>      6.459      0.043 </v>
+  <v>      6.460      0.008 </v>
+  <v>      6.460      0.009 </v>
+  <v>      6.460      0.152 </v>
+  <v>      6.461      0.001 </v>
+  <v>      6.461      0.000 </v>
+  <v>      6.461      0.000 </v>
+  <v>      6.461      0.062 </v>
+  <v>      6.461      0.066 </v>
+  <v>      6.461      0.925 </v>
+  <v>      6.462      0.000 </v>
+  <v>      6.462    422.970 </v>
+  <v>      6.462    422.384 </v>
+  <v>      6.462    420.159 </v>
+  <v>      6.463      0.165 </v>
+  <v>      6.463      0.037 </v>
+  <v>      6.463      0.020 </v>
+  <v>      6.465      0.000 </v>
+  <v>      6.494      1.588 </v>
+  <v>      6.494      1.454 </v>
+  <v>      6.494     24.953 </v>
+  <v>      6.500      5.592 </v>
+  <v>      6.500      4.569 </v>
+  <v>      6.501    251.750 </v>
+  <v>      6.501    220.107 </v>
+  <v>      6.501    263.779 </v>
+  <v>      6.503      4.978 </v>
+  <v>      6.503      8.242 </v>
+  <v>      6.503     11.271 </v>
+  <v>      6.506      3.827 </v>
+  <v>      6.508      0.000 </v>
+  <v>      6.508      0.000 </v>
+  <v>      6.520      0.000 </v>
+  <v>      6.520      0.001 </v>
+  <v>      6.520      0.000 </v>
+  <v>      6.526    868.026 </v>
+  <v>      6.526    842.812 </v>
+  <v>      6.526    852.100 </v>
+  <v>      6.530      0.097 </v>
+  <v>      6.530      0.096 </v>
+  <v>      6.530      1.516 </v>
+  <v>      6.537      0.039 </v>
+  <v>      6.537      0.056 </v>
+  <v>      6.537      0.029 </v>
+  <v>      6.539      0.000 </v>
+  <v>      6.539      0.000 </v>
+  <v>      6.539      0.001 </v>
+  <v>      6.539      0.000 </v>
+  <v>      6.539      0.000 </v>
+  <v>      6.544      0.000 </v>
+  <v>      6.544    726.931 </v>
+  <v>      6.544    720.929 </v>
+  <v>      6.544    720.367 </v>
+  <v>      6.545      0.000 </v>
+  <v>      6.548      0.000 </v>
+  <v>      6.548      0.000 </v>
+  <v>      6.549   7202.094 </v>
+  <v>      6.549   7196.696 </v>
+  <v>      6.549   7214.308 </v>
+  <v>      6.549      0.143 </v>
+  <v>      6.549      0.065 </v>
+  <v>      6.549      0.110 </v>
+  <v>      6.551      0.004 </v>
+  <v>      6.551      0.011 </v>
+  <v>      6.551      0.003 </v>
+  <v>      6.558      0.000 </v>
+  <v>      6.609   4935.051 </v>
+  <v>      6.609   4970.020 </v>
+  <v>      6.609   4954.069 </v>
+  <v>      6.612      0.000 </v>
+  <v>      6.612      0.000 </v>
+  <v>      6.617      0.000 </v>
+  <v>      6.619      0.000 </v>
+  <v>      6.619      0.000 </v>
+  <v>      6.619      0.002 </v>
+  <v>      6.621      0.113 </v>
+  <v>      6.621      0.145 </v>
+  <v>      6.621      0.840 </v>
+  <v>      6.623      0.535 </v>
+  <v>      6.623      0.303 </v>
+  <v>      6.625      0.042 </v>
+  <v>      6.625      0.143 </v>
+  <v>      6.625      0.075 </v>
+  <v>      6.626      0.015 </v>
+  <v>      6.626      0.034 </v>
+  <v>      6.626      0.013 </v>
+  <v>      6.626      0.004 </v>
+  <v>      6.626    927.352 </v>
+  <v>      6.626    922.463 </v>
+  <v>      6.626    935.181 </v>
+  <v>      6.630      0.134 </v>
+  <v>      6.630      0.031 </v>
+  <v>      6.630      0.075 </v>
+  <v>      6.632      0.000 </v>
+  <v>      6.632      0.000 </v>
+  <v>      6.638      0.010 </v>
+  <v>      6.638      0.011 </v>
+  <v>      6.638      0.023 </v>
+  <v>      6.639      0.003 </v>
+  <v>      6.639      0.003 </v>
+  <v>      6.639      0.040 </v>
+  <v>      6.640      0.000 </v>
+  <v>      6.640      0.000 </v>
+  <v>      6.640      0.000 </v>
+  <v>      6.647   5951.532 </v>
+  <v>      6.647   5961.036 </v>
+  <v>      6.647   5967.849 </v>
+  <v>      6.647      0.026 </v>
+  <v>      6.647      0.043 </v>
+  <v>      6.648      0.047 </v>
+  <v>      6.648      0.026 </v>
+  <v>      6.648      0.027 </v>
+  <v>      6.648      0.005 </v>
+  <v>      6.651      0.000 </v>
+  <v>      6.752      0.000 </v>
+  <v>      6.752      0.000 </v>
+  <v>      6.752   2078.562 </v>
+  <v>      6.752   2078.147 </v>
+  <v>      6.752   2086.120 </v>
+  <v>      6.754      0.009 </v>
+  <v>      6.754      0.010 </v>
+  <v>      6.754      0.062 </v>
+  <v>      6.759      0.000 </v>
+  <v>      6.759      0.000 </v>
+  <v>      6.759      0.000 </v>
+  <v>      6.760      0.000 </v>
+  <v>      6.760      0.000 </v>
+  <v>      6.760      0.000 </v>
+  <v>      6.760      0.000 </v>
+  <v>      6.760      0.000 </v>
+  <v>      6.761      0.013 </v>
+  <v>      6.761      0.044 </v>
+  <v>      6.761      0.006 </v>
+  <v>      6.762      0.000 </v>
+  <v>      6.763      0.000 </v>
+  <v>      6.764      0.105 </v>
+  <v>      6.764      0.130 </v>
+  <v>      6.764      0.131 </v>
+  <v>      6.822      0.010 </v>
+  <v>      6.822      0.013 </v>
+  <v>      6.827  10757.117 </v>
+  <v>      6.827  10740.813 </v>
+  <v>      6.827  10727.565 </v>
+  <v>      6.828      0.001 </v>
+  <v>      6.828      0.001 </v>
+  <v>      6.828      0.008 </v>
+  <v>      6.828      0.000 </v>
+  <v>      6.828      0.000 </v>
+  <v>      6.828      0.000 </v>
+  <v>      6.828      0.004 </v>
+  <v>      6.828      0.001 </v>
+  <v>      6.830      0.028 </v>
+  <v>      6.830      0.001 </v>
+  <v>      6.830      0.044 </v>
+  <v>      6.832      0.003 </v>
+  <v>      6.832      0.002 </v>
+  <v>      6.832      0.009 </v>
+  <v>      6.833      0.039 </v>
+  <v>      6.833      0.043 </v>
+  <v>      6.833      0.053 </v>
+  <v>      6.834      0.000 </v>
+  <v>      6.834      0.001 </v>
+  <v>      6.838      0.000 </v>
+  <v>      6.838      0.000 </v>
+  <v>      6.842      0.003 </v>
+  <v>      6.842      0.002 </v>
+  <v>      6.842      0.016 </v>
+  <v>      6.843   6082.800 </v>
+  <v>      6.843   6059.655 </v>
+  <v>      6.843   6072.793 </v>
+  <v>      6.848      0.156 </v>
+  <v>      6.848      0.142 </v>
+  <v>      6.848      0.104 </v>
+  <v>      6.871      0.000 </v>
+  <v>      6.877      0.000 </v>
+  <v>      6.879      0.000 </v>
+  <v>      6.879      0.000 </v>
+  <v>      6.882      0.522 </v>
+  <v>      6.882      0.303 </v>
+  <v>      6.882      0.637 </v>
+  <v>      6.882      0.039 </v>
+  <v>      6.882      0.085 </v>
+  <v>      6.882      0.046 </v>
+  <v>      6.884      0.718 </v>
+  <v>      6.884      0.401 </v>
+  <v>      6.886      0.000 </v>
+  <v>      6.886   1237.017 </v>
+  <v>      6.886   1251.905 </v>
+  <v>      6.886   1246.513 </v>
+  <v>      6.887     48.416 </v>
+  <v>      6.887     50.379 </v>
+  <v>      6.887     47.667 </v>
+  <v>      6.887      0.059 </v>
+  <v>      6.888      0.035 </v>
+  <v>      6.888      0.015 </v>
+  <v>      6.888      0.050 </v>
+  <v>      6.888      0.001 </v>
+  <v>      6.888      0.004 </v>
+  <v>      6.888      0.001 </v>
+  <v>      6.889     35.768 </v>
+  <v>      6.889     33.599 </v>
+  <v>      6.889     30.565 </v>
+  <v>      6.890      0.023 </v>
+  <v>      6.890      0.106 </v>
+  <v>      6.890      0.001 </v>
+  <v>      6.892      1.596 </v>
+  <v>      6.892      0.486 </v>
+  <v>      6.892      0.303 </v>
+  <v>      6.894      0.001 </v>
+  <v>      6.894      0.008 </v>
+  <v>      6.894      0.006 </v>
+  <v>      6.894      0.000 </v>
+  <v>      6.894      0.000 </v>
+  <v>      6.894     36.667 </v>
+  <v>      6.894     34.882 </v>
+  <v>      6.894     37.616 </v>
+  <v>      6.897      1.003 </v>
+  <v>      6.897      0.792 </v>
+  <v>      6.897      0.753 </v>
+  <v>      6.898      0.014 </v>
+  <v>      6.898      0.112 </v>
+  <v>      6.898      0.036 </v>
+  <v>      6.898      1.697 </v>
+  <v>      6.898      1.434 </v>
+  <v>      6.898      1.648 </v>
+  <v>      6.901   1521.089 </v>
+  <v>      6.901   1528.960 </v>
+  <v>      6.901   1537.092 </v>
+  <v>      6.903      0.230 </v>
+  <v>      6.903      0.419 </v>
+  <v>      6.904      0.000 </v>
+  <v>      6.904      0.000 </v>
+  <v>      6.904   1549.690 </v>
+  <v>      6.904   1514.502 </v>
+  <v>      6.904   1534.345 </v>
+  <v>      6.905      0.000 </v>
+  <v>      6.906      2.650 </v>
+  <v>      6.906      3.078 </v>
+  <v>      6.906      2.774 </v>
+  <v>      6.917      0.008 </v>
+  <v>      6.917      0.002 </v>
+  <v>      6.917      0.001 </v>
+  <v>      6.918      0.239 </v>
+  <v>      6.918      0.093 </v>
+  <v>      6.918      0.580 </v>
+  <v>      6.919      0.064 </v>
+  <v>      6.925      0.382 </v>
+  <v>      6.925      0.230 </v>
+  <v>      6.925      0.298 </v>
+  <v>      6.927   1560.459 </v>
+  <v>      6.927   1556.103 </v>
+  <v>      6.927   1567.453 </v>
+  <v>      6.927      7.701 </v>
+  <v>      6.928      2.880 </v>
+  <v>      6.928      0.573 </v>
+  <v>      6.931      0.000 </v>
+  <v>      6.931      0.000 </v>
+  <v>      6.931      0.999 </v>
+  <v>      6.932      3.170 </v>
+  <v>      6.932      4.778 </v>
+  <v>      6.932      4.197 </v>
+  <v>      6.932      3.270 </v>
+  <v>      6.932      0.133 </v>
+  <v>      6.932      4.859 </v>
+  <v>      6.933      0.101 </v>
+  <v>      6.933      0.025 </v>
+  <v>      6.933      0.017 </v>
+  <v>      6.933    733.170 </v>
+  <v>      6.933    727.034 </v>
+  <v>      6.933    730.356 </v>
+  <v>      6.934      1.310 </v>
+  <v>      6.934      0.421 </v>
+  <v>      6.936      0.004 </v>
+  <v>      6.936      0.006 </v>
+  <v>      6.936      0.012 </v>
+  <v>      6.937      2.501 </v>
+  <v>      6.937      0.856 </v>
+  <v>      6.937      1.869 </v>
+  <v>      6.937      0.029 </v>
+  <v>      6.937      0.009 </v>
+  <v>      6.937      0.057 </v>
+  <v>      6.939      0.001 </v>
+  <v>      6.939      0.011 </v>
+  <v>      6.939      0.023 </v>
+  <v>      6.939    220.156 </v>
+  <v>      6.939    220.758 </v>
+  <v>      6.939    220.898 </v>
+  <v>      6.940      0.000 </v>
+  <v>      6.940      0.005 </v>
+  <v>      6.940      0.000 </v>
+  <v>      6.940      0.001 </v>
+  <v>      6.940      0.000 </v>
+  <v>      6.942      0.336 </v>
+  <v>      6.942      0.400 </v>
+  <v>      6.942      0.357 </v>
+  <v>      6.942    148.839 </v>
+  <v>      6.942    149.357 </v>
+  <v>      6.942    150.884 </v>
+  <v>      6.943      0.000 </v>
+  <v>      6.943      0.000 </v>
+  <v>      6.961      0.000 </v>
+  <v>      6.961      0.000 </v>
+  <v>      6.961      0.005 </v>
+  <v>      6.961      0.067 </v>
+  <v>      6.961      0.012 </v>
+  <v>      6.962      0.017 </v>
+  <v>      6.962      0.055 </v>
+  <v>      6.962      0.063 </v>
+  <v>      6.962      0.000 </v>
+  <v>      6.962      0.000 </v>
+  <v>      6.962      0.000 </v>
+  <v>      6.962      0.001 </v>
+  <v>      6.962    267.521 </v>
+  <v>      6.962    267.848 </v>
+  <v>      6.962    267.197 </v>
+  <v>      6.963      0.000 </v>
+  <v>      6.963      0.000 </v>
+  <v>      6.963     20.332 </v>
+  <v>      6.963     20.128 </v>
+  <v>      6.963     19.815 </v>
+  <v>      6.963      0.092 </v>
+  <v>      6.963      0.113 </v>
+  <v>      6.963      0.125 </v>
+  <v>      6.964      0.000 </v>
+  <v>      7.010    107.000 </v>
+  <v>      7.010     85.658 </v>
+  <v>      7.010    107.487 </v>
+  <v>      7.021     11.109 </v>
+  <v>      7.021     12.557 </v>
+  <v>      7.021      4.282 </v>
+  <v>      7.022      4.827 </v>
+  <v>      7.022      5.208 </v>
+  <v>      7.024      0.000 </v>
+  <v>      7.024      0.000 </v>
+  <v>      7.024      0.002 </v>
+  <v>      7.024      0.002 </v>
+  <v>      7.024      0.000 </v>
+  <v>      7.024      0.020 </v>
+  <v>      7.024      0.009 </v>
+  <v>      7.024      0.040 </v>
+  <v>      7.030      0.000 </v>
+  <v>      7.031   3973.192 </v>
+  <v>      7.031   3871.929 </v>
+  <v>      7.031   3697.058 </v>
+  <v>      7.034      0.128 </v>
+  <v>      7.034      0.081 </v>
+  <v>      7.034      0.047 </v>
+  <v>      7.042      3.130 </v>
+  <v>      7.049      0.000 </v>
+  <v>      7.049      0.000 </v>
+  <v>      7.050   4250.520 </v>
+  <v>      7.050   4212.520 </v>
+  <v>      7.050   4192.424 </v>
+  <v>      7.051      7.114 </v>
+  <v>      7.051      0.511 </v>
+  <v>      7.051      1.479 </v>
+  <v>      7.052      0.002 </v>
+  <v>      7.052      0.002 </v>
+  <v>      7.052      0.007 </v>
+  <v>      7.053      0.000 </v>
+  <v>      7.053      0.001 </v>
+  <v>      7.053      0.003 </v>
+  <v>      7.053      0.005 </v>
+  <v>      7.059      0.051 </v>
+  <v>      7.059      0.020 </v>
+  <v>      7.059      0.003 </v>
+  <v>      7.060      3.102 </v>
+  <v>      7.060      1.276 </v>
+  <v>      7.062   2606.644 </v>
+  <v>      7.062   2578.294 </v>
+  <v>      7.062   2680.640 </v>
+  <v>      7.087      0.004 </v>
+  <v>      7.127      0.000 </v>
+  <v>      7.127      0.065 </v>
+  <v>      7.127      0.036 </v>
+  <v>      7.127      0.020 </v>
+  <v>      7.128      0.000 </v>
+  <v>      7.128      0.000 </v>
+  <v>      7.128      0.000 </v>
+  <v>      7.128      0.000 </v>
+  <v>      7.128      0.000 </v>
+  <v>      7.128   4004.683 </v>
+  <v>      7.128   4017.432 </v>
+  <v>      7.128   4019.039 </v>
+  <v>      7.130      0.000 </v>
+  <v>      7.130      0.000 </v>
+  <v>      7.130     85.760 </v>
+  <v>      7.130     82.963 </v>
+  <v>      7.130     78.910 </v>
+  <v>      7.131      0.026 </v>
+  <v>      7.131      0.191 </v>
+  <v>      7.131      0.074 </v>
+  <v>      7.132      0.137 </v>
+  <v>      7.132      0.107 </v>
+  <v>      7.132      0.078 </v>
+  <v>      7.135      0.000 </v>
+  <v>      7.283      0.000 </v>
+  <v>      7.290      0.007 </v>
+  <v>      7.290      0.010 </v>
+  <v>      7.290      0.003 </v>
+  <v>      7.290      0.000 </v>
+  <v>      7.290      0.000 </v>
+  <v>      7.292   3413.828 </v>
+  <v>      7.292   3417.285 </v>
+  <v>      7.292   3389.535 </v>
+  <v>      7.293      0.023 </v>
+  <v>      7.293      0.009 </v>
+  <v>      7.293      0.002 </v>
+  <v>      7.345     18.523 </v>
+  <v>      7.345     20.093 </v>
+  <v>      7.345     20.312 </v>
+  <v>      7.346      0.004 </v>
+  <v>      7.346      0.005 </v>
+  <v>      7.346      0.001 </v>
+  <v>      7.347      0.000 </v>
+  <v>      7.347      0.054 </v>
+  <v>      7.347      0.011 </v>
+  <v>      7.347      0.004 </v>
+  <v>      7.348      0.000 </v>
+  <v>      7.348      0.000 </v>
+  <v>      7.432   1118.250 </v>
+  <v>      7.432   1193.447 </v>
+  <v>      7.432   1093.682 </v>
+  <v>      7.436      0.000 </v>
+  <v>      7.436      0.000 </v>
+  <v>      7.437      0.078 </v>
+  <v>      7.437      0.055 </v>
+  <v>      7.437      0.030 </v>
+  <v>      7.438      0.000 </v>
+  <v>      7.439      5.463 </v>
+  <v>      7.439      1.973 </v>
+  <v>      7.440   3896.045 </v>
+  <v>      7.440   3961.014 </v>
+  <v>      7.440   3798.351 </v>
+  <v>      7.441      6.242 </v>
+  <v>      7.441     12.103 </v>
+  <v>      7.441      3.159 </v>
+  <v>      7.441      0.002 </v>
+  <v>      7.441      0.000 </v>
+  <v>      7.441      0.000 </v>
+  <v>      7.445      0.000 </v>
+  <v>      7.445      0.000 </v>
+  <v>      7.445      0.000 </v>
+  <v>      7.446      0.000 </v>
+  <v>      7.446      0.001 </v>
+  <v>      7.446      0.000 </v>
+  <v>      7.447     25.896 </v>
+  <v>      7.447     23.697 </v>
+  <v>      7.447     26.322 </v>
+  <v>      7.447      0.000 </v>
+  <v>      7.448      0.384 </v>
+  <v>      7.448      0.056 </v>
+  <v>      7.449      0.004 </v>
+  <v>      7.449      0.011 </v>
+  <v>      7.449      0.032 </v>
+  <v>      7.450      0.000 </v>
+  <v>      7.450      0.000 </v>
+  <v>      7.450      0.000 </v>
+  <v>      7.450      0.000 </v>
+  <v>      7.450      0.000 </v>
+  <v>      7.452      1.537 </v>
+  <v>      7.455      0.034 </v>
+  <v>      7.455      0.030 </v>
+  <v>      7.455      0.022 </v>
+  <v>      7.456    358.341 </v>
+  <v>      7.456    309.460 </v>
+  <v>      7.456    324.453 </v>
+  <v>      7.481      0.000 </v>
+  <v>      7.481      0.000 </v>
+  <v>      7.486      0.000 </v>
+  <v>      7.491      0.665 </v>
+  <v>      7.494   1351.560 </v>
+  <v>      7.494   1363.232 </v>
+  <v>      7.494   1342.044 </v>
+  <v>      7.622      0.007 </v>
+  <v>      7.622      0.013 </v>
+  <v>      7.622      0.007 </v>
+  <v>      7.625    126.069 </v>
+  <v>      7.625     60.650 </v>
+  <v>      7.625     62.183 </v>
+  <v>      7.627      0.000 </v>
+  <v>      7.633     22.405 </v>
+  <v>      7.649      0.008 </v>
+  <v>      7.649      0.001 </v>
+  <v>      7.649      0.001 </v>
+  <v>      7.653      0.000 </v>
+  <v>      7.653      0.003 </v>
+  <v>      7.653      0.000 </v>
+  <v>      7.655      0.001 </v>
+  <v>      7.655      0.001 </v>
+  <v>      7.656      0.148 </v>
+  <v>      7.656      0.100 </v>
+  <v>      7.656      0.113 </v>
+  <v>      7.656      0.000 </v>
+  <v>      7.656      0.000 </v>
+  <v>      7.657      0.000 </v>
+  <v>      7.657      0.000 </v>
+  <v>      7.657      0.008 </v>
+  <v>      7.658      0.004 </v>
+  <v>      7.658      0.006 </v>
+  <v>      7.658      0.023 </v>
+  <v>      7.659      0.000 </v>
+  <v>      7.661   2348.527 </v>
+  <v>      7.661   2347.985 </v>
+  <v>      7.661   2355.452 </v>
+  <v>      7.661      0.000 </v>
+  <v>      7.710   2117.591 </v>
+  <v>      7.710   2032.082 </v>
+  <v>      7.710   2093.582 </v>
+  <v>      7.711      0.003 </v>
+  <v>      7.711      0.003 </v>
+  <v>      7.711      0.036 </v>
+  <v>      7.711      1.443 </v>
+  <v>      7.711      2.046 </v>
+  <v>      7.711      0.207 </v>
+  <v>      7.713      0.000 </v>
+  <v>      7.713      0.000 </v>
+  <v>      7.713      0.420 </v>
+  <v>      7.713      0.303 </v>
+  <v>      7.713      0.363 </v>
+  <v>      7.713      0.303 </v>
+  <v>      7.713      1.453 </v>
+  <v>      7.714      0.010 </v>
+  <v>      7.714      0.004 </v>
+  <v>      7.714      0.005 </v>
+  <v>      7.714    787.529 </v>
+  <v>      7.714    843.969 </v>
+  <v>      7.714    860.098 </v>
+  <v>      7.718      0.000 </v>
+  <v>      7.731      0.311 </v>
+  <v>      7.807      0.004 </v>
+  <v>      7.807      0.002 </v>
+  <v>      7.807      0.012 </v>
+  <v>      7.813      0.042 </v>
+  <v>      7.813      0.043 </v>
+  <v>      7.813      0.002 </v>
+  <v>      7.813      0.019 </v>
+  <v>      7.813      0.004 </v>
+  <v>      7.814      4.202 </v>
+  <v>      7.814      4.558 </v>
+  <v>      7.814      4.327 </v>
+  <v>      7.821      0.085 </v>
+  <v>      7.821      0.002 </v>
+  <v>      7.821      0.017 </v>
+  <v>      7.821      0.009 </v>
+  <v>      7.822      0.003 </v>
+  <v>      7.822      0.047 </v>
+  <v>      7.822      0.062 </v>
+  <v>      7.823   2280.551 </v>
+  <v>      7.823   2258.326 </v>
+  <v>      7.823   2259.861 </v>
+  <v>      7.825      4.296 </v>
+  <v>      7.825      4.260 </v>
+  <v>      7.825      4.272 </v>
+  <v>      7.853      0.012 </v>
+  <v>      7.853      0.005 </v>
+  <v>      7.853      0.003 </v>
+  <v>      7.861      0.029 </v>
+  <v>      7.861      0.010 </v>
+  <v>      7.861      0.003 </v>
+  <v>      7.864      1.341 </v>
+  <v>      7.864      1.411 </v>
+  <v>      7.864      1.259 </v>
+  <v>      7.864      0.000 </v>
+  <v>      7.869      0.029 </v>
+  <v>      7.869      0.014 </v>
+  <v>      7.873      0.003 </v>
+  <v>      7.873      0.004 </v>
+  <v>      7.873      0.005 </v>
+  <v>      7.874      0.014 </v>
+  <v>      7.874      0.019 </v>
+  <v>      7.874      0.018 </v>
+  <v>      7.874      0.000 </v>
+  <v>      7.874      0.000 </v>
+  <v>      7.881   2313.372 </v>
+  <v>      7.881   2306.205 </v>
+  <v>      7.881   2298.449 </v>
+  <v>      7.881      0.000 </v>
+  <v>      7.886      0.011 </v>
+  <v>      7.886      0.012 </v>
+  <v>      7.888      0.000 </v>
+  <v>      7.888      0.001 </v>
+  <v>      7.888      0.005 </v>
+  <v>      7.888      0.004 </v>
+  <v>      7.888      0.019 </v>
+  <v>      7.888      0.004 </v>
+  <v>      7.889      4.260 </v>
+  <v>      7.889      4.254 </v>
+  <v>      7.889      4.285 </v>
+  <v>      7.889      0.000 </v>
+  <v>      7.892    621.798 </v>
+  <v>      7.892    617.124 </v>
+  <v>      7.892    624.976 </v>
+  <v>      7.893      0.001 </v>
+  <v>      7.893      0.000 </v>
+  <v>      7.893      0.003 </v>
+  <v>      7.897      0.000 </v>
+  <v>      7.897      0.000 </v>
+  <v>      7.897      0.000 </v>
+  <v>      7.897      0.000 </v>
+  <v>      7.898      0.001 </v>
+  <v>      7.898      0.001 </v>
+  <v>      7.898      0.000 </v>
+  <v>      7.898      0.000 </v>
+  <v>      7.898      0.000 </v>
+  <v>      7.898      0.001 </v>
+  <v>      7.899      1.253 </v>
+  <v>      7.899      1.205 </v>
+  <v>      7.899      1.210 </v>
+  <v>      7.899      0.000 </v>
+  <v>      7.901      7.983 </v>
+  <v>      7.901      8.126 </v>
+  <v>      7.901      7.685 </v>
+  <v>      7.903      0.200 </v>
+  <v>      8.004      0.001 </v>
+  <v>      8.004      0.000 </v>
+  <v>      8.004      0.000 </v>
+  <v>      8.008      0.000 </v>
+  <v>      8.010      0.003 </v>
+  <v>      8.010      0.000 </v>
+  <v>      8.010      0.001 </v>
+  <v>      8.010      0.000 </v>
+  <v>      8.010      0.000 </v>
+  <v>      8.011      0.229 </v>
+  <v>      8.011      0.203 </v>
+  <v>      8.011      0.177 </v>
+  <v>      8.012      0.011 </v>
+  <v>      8.012      0.005 </v>
+  <v>      8.012      0.006 </v>
+  <v>      8.013      0.016 </v>
+  <v>      8.013      0.041 </v>
+  <v>      8.015      0.000 </v>
+  <v>      8.016      0.009 </v>
+  <v>      8.016      0.005 </v>
+  <v>      8.016      0.072 </v>
+  <v>      8.016   1028.630 </v>
+  <v>      8.016   1032.846 </v>
+  <v>      8.016   1021.915 </v>
+  <v>      8.051      0.096 </v>
+  <v>      8.051      0.027 </v>
+  <v>      8.051      0.239 </v>
+  <v>      8.054      0.000 </v>
+  <v>      8.054      0.000 </v>
+  <v>      8.059      5.669 </v>
+  <v>      8.059      2.550 </v>
+  <v>      8.066      0.000 </v>
+  <v>      8.067    202.871 </v>
+  <v>      8.067    244.490 </v>
+  <v>      8.067    186.361 </v>
+  <v>      8.068      3.938 </v>
+  <v>      8.069      1.058 </v>
+  <v>      8.069      1.352 </v>
+  <v>      8.069     16.163 </v>
+  <v>      8.071      1.678 </v>
+  <v>      8.071      1.705 </v>
+  <v>      8.071      4.332 </v>
+  <v>      8.071      0.742 </v>
+  <v>      8.071      0.134 </v>
+  <v>      8.071      0.698 </v>
+  <v>      8.072     44.024 </v>
+  <v>      8.072     19.993 </v>
+  <v>      8.072     30.073 </v>
+  <v>      8.074      6.804 </v>
+  <v>      8.074     41.826 </v>
+  <v>      8.074     26.162 </v>
+  <v>      8.075     17.882 </v>
+  <v>      8.075      7.842 </v>
+  <v>      8.077    344.823 </v>
+  <v>      8.077    268.108 </v>
+  <v>      8.077    319.657 </v>
+  <v>      8.079     30.328 </v>
+  <v>      8.079     26.109 </v>
+  <v>      8.079      6.967 </v>
+  <v>      8.103      2.848 </v>
+  <v>      8.143      0.000 </v>
+  <v>      8.143      0.000 </v>
+  <v>      8.143      0.004 </v>
+  <v>      8.146      0.074 </v>
+  <v>      8.146      0.048 </v>
+  <v>      8.148      0.007 </v>
+  <v>      8.148      0.006 </v>
+  <v>      8.148      0.106 </v>
+  <v>      8.149      0.024 </v>
+  <v>      8.149      0.023 </v>
+  <v>      8.149      0.033 </v>
+  <v>      8.149    183.127 </v>
+  <v>      8.149    266.971 </v>
+  <v>      8.149    258.399 </v>
+  <v>      8.151      0.000 </v>
+  <v>      8.153      0.001 </v>
+  <v>      8.153      0.005 </v>
+  <v>      8.153      0.001 </v>
+  <v>      8.155      0.011 </v>
+  <v>      8.155      0.009 </v>
+  <v>      8.155      0.001 </v>
+  <v>      8.156      0.000 </v>
+  <v>      8.156      0.098 </v>
+  <v>      8.156      0.076 </v>
+  <v>      8.156      0.256 </v>
+  <v>      8.156      0.000 </v>
+  <v>      8.156      0.000 </v>
+  <v>      8.164      0.009 </v>
+  <v>      8.164      0.011 </v>
+  <v>      8.164      0.004 </v>
+  <v>      8.178      0.000 </v>
+  <v>      8.181   3668.581 </v>
+  <v>      8.181   4503.850 </v>
+  <v>      8.181   4623.130 </v>
+  <v>      8.181      0.000 </v>
+  <v>      8.181      0.000 </v>
+  <v>      8.182      0.001 </v>
+  <v>      8.182      0.001 </v>
+  <v>      8.182      0.012 </v>
+  <v>      8.184      0.016 </v>
+  <v>      8.184      0.024 </v>
+  <v>      8.184      0.021 </v>
+  <v>      8.186      0.000 </v>
+  <v>      8.190      0.000 </v>
+  <v>      8.190      0.000 </v>
+  <v>      8.190      0.001 </v>
+  <v>      8.193      0.000 </v>
+  <v>      8.193      0.001 </v>
+  <v>      8.193      0.000 </v>
+  <v>      8.193      0.000 </v>
+  <v>      8.193     41.559 </v>
+  <v>      8.193     43.392 </v>
+  <v>      8.193    165.614 </v>
+  <v>      8.194    121.860 </v>
+  <v>      8.195      0.000 </v>
+  <v>      8.195      0.000 </v>
+  <v>      8.197      0.076 </v>
+  <v>      8.197      0.123 </v>
+  <v>      8.197      0.015 </v>
+  <v>      8.388      0.000 </v>
+  <v>      8.389    455.369 </v>
+  <v>      8.389    526.698 </v>
+  <v>      8.389    519.033 </v>
+  <v>      8.393      0.101 </v>
+  <v>      8.393      0.142 </v>
+  <v>      8.393      0.087 </v>
+  <v>      8.404      4.791 </v>
+  <v>      8.406      0.001 </v>
+  <v>      8.406      0.000 </v>
+  <v>      8.406      0.009 </v>
+  <v>      8.409      0.016 </v>
+  <v>      8.409      0.006 </v>
+  <v>      8.411      4.563 </v>
+  <v>      8.411      4.515 </v>
+  <v>      8.411      4.436 </v>
+  <v>      8.412      0.000 </v>
+  <v>      8.412      0.000 </v>
+  <v>      8.412      0.000 </v>
+  <v>      8.413      0.003 </v>
+  <v>      8.413      0.001 </v>
+  <v>      8.413      0.006 </v>
+  <v>      8.413      0.000 </v>
+  <v>      8.414      0.000 </v>
+  <v>      8.414      0.002 </v>
+  <v>      8.415    224.620 </v>
+  <v>      8.415    225.679 </v>
+  <v>      8.415    220.474 </v>
+  <v>      8.422      0.786 </v>
+  <v>      8.422      0.877 </v>
+  <v>      8.422      0.747 </v>
+  <v>      8.430      0.001 </v>
+  <v>      8.430      0.001 </v>
+  <v>      8.430      0.015 </v>
+  <v>      8.431      0.000 </v>
+  <v>      8.431      0.000 </v>
+  <v>      8.431      0.000 </v>
+  <v>      8.436      0.078 </v>
+  <v>      8.436      0.089 </v>
+  <v>      8.436      0.080 </v>
+  <v>      8.437      0.502 </v>
+  <v>      8.438     27.050 </v>
+  <v>      8.438     35.632 </v>
+  <v>      8.438     35.044 </v>
+  <v>      8.467      0.000 </v>
+  <v>      8.467      0.000 </v>
+  <v>      8.467      0.000 </v>
+  <v>      8.469    531.533 </v>
+  <v>      8.469    535.501 </v>
+  <v>      8.469    570.497 </v>
+  <v>      8.475      0.001 </v>
+  <v>      8.475      0.000 </v>
+  <v>      8.475      0.000 </v>
+  <v>      8.477      0.001 </v>
+  <v>      8.477      0.001 </v>
+  <v>      8.477      0.000 </v>
+  <v>      8.481      0.001 </v>
+  <v>      8.481      0.000 </v>
+  <v>      8.481      0.000 </v>
+  <v>      8.487      0.024 </v>
+  <v>      8.487      0.057 </v>
+  <v>      8.487      0.036 </v>
+  <v>      8.617      0.009 </v>
+  <v>      8.617      0.008 </v>
+  <v>      8.617      0.126 </v>
+  <v>      8.620   1301.884 </v>
+  <v>      8.620   1307.843 </v>
+  <v>      8.620   1333.723 </v>
+  <v>      8.620      0.020 </v>
+  <v>      8.620      0.062 </v>
+  <v>      8.620      0.092 </v>
+  <v>      8.621      0.027 </v>
+  <v>      8.621      0.069 </v>
+  <v>      8.622      0.182 </v>
+  <v>      8.757      0.000 </v>
+  <v>      8.757      0.000 </v>
+  <v>      8.757      0.001 </v>
+  <v>      8.761      0.000 </v>
+  <v>      8.761      0.001 </v>
+  <v>      8.761      0.001 </v>
+  <v>      8.764      0.000 </v>
+  <v>      8.767      0.000 </v>
+  <v>      8.767      0.000 </v>
+  <v>      8.768      0.000 </v>
+  <v>      8.768      0.000 </v>
+  <v>      8.768      0.000 </v>
+  <v>      8.768      0.002 </v>
+  <v>      8.769     91.224 </v>
+  <v>      8.769     90.141 </v>
+  <v>      8.769     90.825 </v>
+  <v>      8.769      0.000 </v>
+  <v>      8.769      0.000 </v>
+  <v>      8.769      0.003 </v>
+  <v>      8.773      0.000 </v>
+  <v>      8.773      0.001 </v>
+  <v>      8.773      0.001 </v>
+  <v>      8.774      0.000 </v>
+  <v>      8.774      0.000 </v>
+  <v>      8.791      0.000 </v>
+  <v>      8.791      0.000 </v>
+  <v>      8.803      0.002 </v>
+  <v>      8.803      0.005 </v>
+  <v>      8.803      0.013 </v>
+  <v>      8.803      0.003 </v>
+  <v>      8.803      0.002 </v>
+  <v>      8.803      0.001 </v>
+  <v>      8.805      0.001 </v>
+  <v>      8.805      0.009 </v>
+  <v>      8.805      0.004 </v>
+  <v>      8.812      0.000 </v>
+  <v>      8.936      0.000 </v>
+  <v>      8.936      0.000 </v>
+  <v>      8.939      0.345 </v>
+  <v>      8.939      0.313 </v>
+  <v>      8.939      0.292 </v>
+  <v>      8.942      0.000 </v>
+  <v>      8.942      0.015 </v>
+  <v>      8.944      0.000 </v>
+  <v>      8.947    395.641 </v>
+  <v>      8.947    394.417 </v>
+  <v>      8.947    396.754 </v>
+  <v>      8.950     19.161 </v>
+  <v>      8.968      0.740 </v>
+  <v>      8.968      0.681 </v>
+  <v>      8.968      0.688 </v>
+  <v>      8.982      0.000 </v>
+  <v>      8.982      0.000 </v>
+  <v>      8.984      0.000 </v>
+  <v>      8.987     19.442 </v>
+  <v>      8.987     19.572 </v>
+  <v>      8.987     18.976 </v>
+  <v>      8.987      0.044 </v>
+  <v>      8.987      0.051 </v>
+  <v>      8.987      0.008 </v>
+  <v>      8.988      0.006 </v>
+  <v>      8.988      0.057 </v>
+  <v>      8.990    164.236 </v>
+  <v>      8.990    161.192 </v>
+  <v>      8.990    159.325 </v>
+  <v>      8.990      0.000 </v>
+  <v>      8.990      0.002 </v>
+  <v>      8.990      0.005 </v>
+  <v>      8.990      0.015 </v>
+  <v>      8.990      0.114 </v>
+  <v>      8.990      0.098 </v>
+  <v>      8.991      9.200 </v>
+  <v>      8.991      8.941 </v>
+  <v>      8.991      9.054 </v>
+  <v>      8.995      0.000 </v>
+  <v>      8.995      0.001 </v>
+  <v>      8.995      0.003 </v>
+  <v>      8.999      1.291 </v>
+  <v>      8.999      1.228 </v>
+  <v>      8.999      1.209 </v>
+  <v>      9.000      0.000 </v>
+  <v>      9.000      0.018 </v>
+  <v>      9.003      0.000 </v>
+  <v>      9.003      0.001 </v>
+  <v>      9.003      0.000 </v>
+  <v>      9.003      0.007 </v>
+  <v>      9.003      0.026 </v>
+  <v>      9.003      0.002 </v>
+  <v>      9.003      0.012 </v>
+  <v>      9.003      0.012 </v>
+  <v>      9.004      0.011 </v>
+  <v>      9.004      0.028 </v>
+  <v>      9.009     11.932 </v>
+  <v>      9.009     12.458 </v>
+  <v>      9.009     12.660 </v>
+  <v>      9.012      0.164 </v>
+  <v>      9.020      0.000 </v>
+  <v>      9.021      0.023 </v>
+  <v>      9.021      0.027 </v>
+  <v>      9.021      0.019 </v>
+  <v>      9.056      0.000 </v>
+  <v>      9.056      0.000 </v>
+  <v>      9.056      0.000 </v>
+  <v>      9.070      0.571 </v>
+  <v>      9.070      1.051 </v>
+  <v>      9.070      0.889 </v>
+  <v>      9.074      7.376 </v>
+  <v>      9.074      7.377 </v>
+  <v>      9.074      9.526 </v>
+  <v>      9.075      0.006 </v>
+  <v>      9.075      0.017 </v>
+  <v>      9.075      0.008 </v>
+  <v>      9.076      0.000 </v>
+  <v>      9.076      0.000 </v>
+  <v>      9.076      0.000 </v>
+  <v>      9.081      0.196 </v>
+  <v>      9.081      0.736 </v>
+  <v>      9.084    562.547 </v>
+  <v>      9.084    537.184 </v>
+  <v>      9.084    544.436 </v>
+  <v>      9.084      0.986 </v>
+  <v>      9.084      1.037 </v>
+  <v>      9.084      1.001 </v>
+  <v>      9.085      0.177 </v>
+  <v>      9.096      0.000 </v>
+  <v>      9.096      0.000 </v>
+  <v>      9.098      0.000 </v>
+  <v>      9.098      0.000 </v>
+  <v>      9.098      0.003 </v>
+  <v>      9.107     17.733 </v>
+  <v>      9.107     17.883 </v>
+  <v>      9.107     18.742 </v>
+  <v>      9.113      0.025 </v>
+  <v>      9.113      0.009 </v>
+  <v>      9.113      0.003 </v>
+  <v>      9.117      0.000 </v>
+  <v>      9.118      0.003 </v>
+  <v>      9.118      0.002 </v>
+  <v>      9.119      0.059 </v>
+  <v>      9.119      0.067 </v>
+  <v>      9.119      0.069 </v>
+  <v>      9.122      0.000 </v>
+  <v>      9.122      0.000 </v>
+  <v>      9.122      0.002 </v>
+  <v>      9.123      0.000 </v>
+  <v>      9.123      0.000 </v>
+  <v>      9.123      0.000 </v>
+  <v>      9.126      0.000 </v>
+  <v>      9.141      0.000 </v>
+  <v>      9.141      0.000 </v>
+  <v>      9.141      0.001 </v>
+  <v>      9.144      0.000 </v>
+  <v>      9.144      0.000 </v>
+  <v>      9.145      0.001 </v>
+  <v>      9.145      0.002 </v>
+  <v>      9.145      0.005 </v>
+  <v>      9.150      0.012 </v>
+  <v>      9.150      0.015 </v>
+  <v>      9.150      0.018 </v>
+  <v>      9.150      0.000 </v>
+  <v>      9.150      0.000 </v>
+  <v>      9.150      0.001 </v>
+  <v>      9.151      0.028 </v>
+  <v>      9.151      0.003 </v>
+  <v>      9.151      0.004 </v>
+  <v>      9.151      0.004 </v>
+  <v>      9.151      0.002 </v>
+  <v>      9.152      0.000 </v>
+  <v>      9.152     19.514 </v>
+  <v>      9.152     14.331 </v>
+  <v>      9.152     16.764 </v>
+  <v>      9.152      0.242 </v>
+  <v>      9.153      0.061 </v>
+  <v>      9.153      0.053 </v>
+  <v>      9.153      0.041 </v>
+  <v>      9.154      0.000 </v>
+  <v>      9.156      0.896 </v>
+  <v>      9.156      0.195 </v>
+  <v>      9.156      1.174 </v>
+  <v>      9.156      0.337 </v>
+  <v>      9.156      1.640 </v>
+  <v>      9.157     26.621 </v>
+  <v>      9.157     28.096 </v>
+  <v>      9.157     23.017 </v>
+  <v>      9.185      0.000 </v>
+  <v>      9.185      0.000 </v>
+  <v>      9.187      0.000 </v>
+  <v>      9.187      0.000 </v>
+  <v>      9.187      0.000 </v>
+  <v>      9.190      0.000 </v>
+  <v>      9.190      0.001 </v>
+  <v>      9.190      0.001 </v>
+  <v>      9.210      0.064 </v>
+  <v>      9.210      0.011 </v>
+  <v>      9.210      0.101 </v>
+  <v>      9.212     33.336 </v>
+  <v>      9.212     33.297 </v>
+  <v>      9.212     32.119 </v>
+  <v>      9.214      0.001 </v>
+  <v>      9.214      0.000 </v>
+  <v>      9.217      0.035 </v>
+  <v>      9.217      0.068 </v>
+  <v>      9.217      0.015 </v>
+  <v>      9.234    102.483 </v>
+  <v>      9.234    101.404 </v>
+  <v>      9.234    102.343 </v>
+  <v>      9.237      0.000 </v>
+  <v>      9.237      0.000 </v>
+  <v>      9.237      0.000 </v>
+  <v>      9.237      0.000 </v>
+  <v>      9.237      0.000 </v>
+  <v>      9.240      0.000 </v>
+  <v>      9.240      0.000 </v>
+  <v>      9.240      0.001 </v>
+  <v>      9.241      0.000 </v>
+  <v>      9.241      0.000 </v>
+  <v>      9.243      0.001 </v>
+  <v>      9.243      0.000 </v>
+  <v>      9.243      0.000 </v>
+  <v>      9.246      0.206 </v>
+  <v>      9.248      0.000 </v>
+  <v>      9.248      0.000 </v>
+  <v>      9.250      0.000 </v>
+  <v>      9.252      1.077 </v>
+  <v>      9.252      0.161 </v>
+  <v>      9.252      0.974 </v>
+  <v>      9.262   2711.833 </v>
+  <v>      9.262   2675.218 </v>
+  <v>      9.262   2694.634 </v>
+  <v>      9.265      0.025 </v>
+  <v>      9.265      0.009 </v>
+  <v>      9.265      0.031 </v>
+  <v>      9.266      0.000 </v>
+  <v>      9.266      0.000 </v>
+  <v>      9.268     15.875 </v>
+  <v>      9.268     18.467 </v>
+  <v>      9.268     13.147 </v>
+  <v>      9.268      0.002 </v>
+  <v>      9.268      0.002 </v>
+  <v>      9.268      0.010 </v>
+  <v>      9.269      0.000 </v>
+  <v>      9.269    413.812 </v>
+  <v>      9.269    396.804 </v>
+  <v>      9.269    389.116 </v>
+  <v>      9.270      0.646 </v>
+  <v>      9.270      0.209 </v>
+  <v>      9.272      0.022 </v>
+  <v>      9.272      0.003 </v>
+  <v>      9.272      0.001 </v>
+  <v>      9.283      0.092 </v>
+  <v>      9.423      0.000 </v>
+  <v>      9.423      0.000 </v>
+  <v>      9.424      0.001 </v>
+  <v>      9.424      0.000 </v>
+  <v>      9.424      0.000 </v>
+  <v>      9.432      0.008 </v>
+  <v>      9.432      0.082 </v>
+  <v>      9.432      0.021 </v>
+  <v>      9.433      0.001 </v>
+  <v>      9.433      0.001 </v>
+  <v>      9.434      1.113 </v>
+  <v>      9.434      1.145 </v>
+  <v>      9.434      1.140 </v>
+  <v>      9.435      0.001 </v>
+  <v>      9.435      0.002 </v>
+  <v>      9.435      0.000 </v>
+  <v>      9.435     31.050 </v>
+  <v>      9.435     30.848 </v>
+  <v>      9.435     30.225 </v>
+  <v>      9.437      0.001 </v>
+  <v>      9.437      0.002 </v>
+  <v>      9.437      0.007 </v>
+  <v>      9.441      0.000 </v>
+  <v>      9.441      0.000 </v>
+  <v>      9.441      0.000 </v>
+  <v>      9.443      0.000 </v>
+  <v>      9.443      0.000 </v>
+  <v>      9.444     14.359 </v>
+  <v>      9.444     14.323 </v>
+  <v>      9.444     14.445 </v>
+  <v>      9.445      0.002 </v>
+  <v>      9.445      0.000 </v>
+  <v>      9.445      9.667 </v>
+  <v>      9.445      9.839 </v>
+  <v>      9.445     10.088 </v>
+  <v>      9.447      0.000 </v>
+  <v>      9.449      0.040 </v>
+  <v>      9.453    423.549 </v>
+  <v>      9.453    423.547 </v>
+  <v>      9.453    422.725 </v>
+  <v>      9.503     22.997 </v>
+  <v>      9.503     21.274 </v>
+  <v>      9.503     27.051 </v>
+  <v>      9.504      0.000 </v>
+  <v>      9.504      0.000 </v>
+  <v>      9.504    596.612 </v>
+  <v>      9.504    568.374 </v>
+  <v>      9.504    545.410 </v>
+  <v>      9.508      0.001 </v>
+  <v>      9.508      0.001 </v>
+  <v>      9.508      0.009 </v>
+  <v>      9.511      0.003 </v>
+  <v>      9.511      0.003 </v>
+  <v>      9.511      0.003 </v>
+  <v>      9.511      0.555 </v>
+  <v>      9.511      2.173 </v>
+  <v>      9.511      2.371 </v>
+  <v>      9.512      0.000 </v>
+  <v>      9.520      1.980 </v>
+  <v>      9.520      0.213 </v>
+  <v>      9.521      0.023 </v>
+  <v>      9.521      0.008 </v>
+  <v>      9.521      0.018 </v>
+  <v>      9.528      0.317 </v>
+  <v>      9.619      0.005 </v>
+  <v>      9.619      0.000 </v>
+  <v>      9.619      0.001 </v>
+  <v>      9.620      0.000 </v>
+  <v>      9.620      0.000 </v>
+  <v>      9.620      0.000 </v>
+  <v>      9.620      0.000 </v>
+  <v>      9.620      0.000 </v>
+  <v>      9.622      0.001 </v>
+  <v>      9.622      0.005 </v>
+  <v>      9.622      0.009 </v>
+  <v>      9.622     40.935 </v>
+  <v>      9.622     47.823 </v>
+  <v>      9.622     42.516 </v>
+  <v>      9.622      0.000 </v>
+  <v>      9.622      0.000 </v>
+  <v>      9.622      0.000 </v>
+  <v>      9.622      0.000 </v>
+  <v>      9.623      0.000 </v>
+  <v>      9.624      0.000 </v>
+  <v>      9.626      0.005 </v>
+  <v>      9.626      0.006 </v>
+  <v>      9.626      0.006 </v>
+  <v>      9.630    536.234 </v>
+  <v>      9.630    585.121 </v>
+  <v>      9.630    579.818 </v>
+  <v>      9.631      0.004 </v>
+  <v>      9.631      0.001 </v>
+  <v>      9.633      1.995 </v>
+  <v>      9.635      0.000 </v>
+  <v>      9.635      0.001 </v>
+  <v>      9.635      0.010 </v>
+  <v>      9.721      0.000 </v>
+  <v>      9.721      0.000 </v>
+  <v>      9.734    162.196 </v>
+  <v>      9.734    168.063 </v>
+  <v>      9.734    162.598 </v>
+  <v>      9.740      0.000 </v>
+  <v>      9.741      0.000 </v>
+  <v>      9.741      0.000 </v>
+  <v>      9.741      0.000 </v>
+  <v>      9.742      0.093 </v>
+  <v>      9.742      0.006 </v>
+  <v>      9.742      0.006 </v>
+  <v>      9.744      0.015 </v>
+  <v>      9.744      0.005 </v>
+  <v>      9.744      0.007 </v>
+  <v>      9.751      0.020 </v>
+  <v>      9.751      0.006 </v>
+  <v>      9.752      0.001 </v>
+  <v>      9.752      0.002 </v>
+  <v>      9.752      0.000 </v>
+  <v>      9.759      0.000 </v>
+  <v>      9.759      0.000 </v>
+  <v>      9.759     25.389 </v>
+  <v>      9.759     28.839 </v>
+  <v>      9.759     35.477 </v>
+  <v>      9.761     13.627 </v>
+  <v>      9.761     20.885 </v>
+  <v>      9.761     18.893 </v>
+  <v>      9.762      0.595 </v>
+  <v>      9.762      0.673 </v>
+  <v>      9.762      8.256 </v>
+  <v>      9.763      0.592 </v>
+  <v>      9.765      0.000 </v>
+  <v>      9.765      0.000 </v>
+  <v>      9.765      0.000 </v>
+  <v>      9.765      0.001 </v>
+  <v>      9.765      0.001 </v>
+  <v>      9.765      0.001 </v>
+  <v>      9.765      0.889 </v>
+  <v>      9.765      2.801 </v>
+  <v>      9.766      0.026 </v>
+  <v>      9.766      0.021 </v>
+  <v>      9.766      0.022 </v>
+  <v>      9.768      0.000 </v>
+  <v>      9.773      0.120 </v>
+  <v>      9.776   1346.097 </v>
+  <v>      9.776   1353.850 </v>
+  <v>      9.776   1316.476 </v>
+  <v>      9.778      0.089 </v>
+  <v>      9.778      0.014 </v>
+  <v>      9.778      0.045 </v>
+  <v>      9.786      0.001 </v>
+  <v>      9.786      0.004 </v>
+  <v>      9.786      0.001 </v>
+  <v>      9.787      0.001 </v>
+  <v>      9.787      0.000 </v>
+  <v>      9.789      0.000 </v>
+  <v>      9.789      0.000 </v>
+  <v>      9.789      0.001 </v>
+  <v>      9.789      0.000 </v>
+  <v>      9.789      0.000 </v>
+  <v>      9.791      4.684 </v>
+  <v>      9.791      4.792 </v>
+  <v>      9.791      4.807 </v>
+  <v>      9.793      0.001 </v>
+  <v>      9.795      0.046 </v>
+  <v>      9.795      0.011 </v>
+  <v>      9.795      0.046 </v>
+  <v>      9.797      0.000 </v>
+  <v>      9.797      0.000 </v>
+  <v>      9.797      0.001 </v>
+  <v>      9.797      0.036 </v>
+  <v>      9.797      0.035 </v>
+  <v>      9.797      0.041 </v>
+  <v>      9.798      0.001 </v>
+  <v>      9.798      0.001 </v>
+  <v>      9.851      0.000 </v>
+  <v>      9.851      0.000 </v>
+  <v>      9.856      0.000 </v>
+  <v>      9.858     79.059 </v>
+  <v>      9.858     81.666 </v>
+  <v>      9.858     80.516 </v>
+  <v>      9.859      0.043 </v>
+  <v>      9.859      0.005 </v>
+  <v>      9.859      0.006 </v>
+  <v>      9.860      0.000 </v>
+  <v>      9.860      0.000 </v>
+  <v>      9.860      0.000 </v>
+  <v>      9.861      0.004 </v>
+  <v>      9.861      0.002 </v>
+  <v>      9.861      0.002 </v>
+  <v>      9.863      0.027 </v>
+  <v>      9.863      0.020 </v>
+  <v>      9.863      0.071 </v>
+  <v>      9.864      0.000 </v>
+  <v>      9.864      0.001 </v>
+  <v>      9.865      0.000 </v>
+  <v>      9.865      0.000 </v>
+  <v>      9.866    337.334 </v>
+  <v>      9.866    347.559 </v>
+  <v>      9.866    339.717 </v>
+  <v>      9.866      0.000 </v>
+  <v>      9.866      0.000 </v>
+  <v>      9.870      0.000 </v>
+  <v>      9.870      0.000 </v>
+  <v>      9.870      0.001 </v>
+  <v>      9.872      0.001 </v>
+  <v>      9.872      0.006 </v>
+  <v>      9.872      0.000 </v>
+  <v>      9.872     94.365 </v>
+  <v>      9.872     93.035 </v>
+  <v>      9.872     93.094 </v>
+  <v>      9.873      0.009 </v>
+  <v>      9.873      0.007 </v>
+  <v>      9.873      0.009 </v>
+  <v>      9.878      0.000 </v>
+  <v>      9.878      0.000 </v>
+  <v>      9.879      0.006 </v>
+  <v>      9.879      0.002 </v>
+  <v>      9.879      0.009 </v>
+  <v>      9.883      0.254 </v>
+  <v>      9.883      0.212 </v>
+  <v>      9.883      0.116 </v>
+  <v>      9.884      0.000 </v>
+  <v>      9.928      0.000 </v>
+  <v>      9.930      0.000 </v>
+  <v>      9.930      0.000 </v>
+  <v>      9.930      0.000 </v>
+  <v>      9.930      0.000 </v>
+  <v>      9.930      0.000 </v>
+  <v>      9.934     21.277 </v>
+  <v>      9.934     20.591 </v>
+  <v>      9.934     20.642 </v>
+  <v>      9.936      0.124 </v>
+  <v>      9.936      0.093 </v>
+  <v>      9.936      0.095 </v>
+  <v>      9.966      0.001 </v>
+  <v>      9.966      0.000 </v>
+  <v>      9.968      0.000 </v>
+  <v>      9.968      0.000 </v>
+  <v>      9.968      0.001 </v>
+  <v>      9.970      0.000 </v>
+  <v>      9.970      0.000 </v>
+  <v>      9.970      0.001 </v>
+  <v>      9.974      0.000 </v>
+  <v>      9.974      0.000 </v>
+  <v>      9.974      0.000 </v>
+  <v>      9.976      0.618 </v>
+  <v>      9.976      0.688 </v>
+  <v>      9.976      0.719 </v>
+  <v>      9.979      5.529 </v>
+  <v>      9.979      5.547 </v>
+  <v>      9.979      5.484 </v>
+  <v>      9.980      0.000 </v>
+  <v>      9.981      0.001 </v>
+  <v>      9.981      0.002 </v>
+  <v>      9.988     18.119 </v>
+  <v>      9.988     18.382 </v>
+  <v>      9.988     18.113 </v>
+  <v>     10.011      0.054 </v>
+  <v>     10.094      0.000 </v>
+  <v>     10.094      0.000 </v>
+  <v>     10.103      0.001 </v>
+  <v>     10.103      0.001 </v>
+  <v>     10.103      0.001 </v>
+  <v>     10.103      0.000 </v>
+  <v>     10.103      0.000 </v>
+  <v>     10.103      0.003 </v>
+  <v>     10.107      0.000 </v>
+  <v>     10.108     68.633 </v>
+  <v>     10.108     69.558 </v>
+  <v>     10.108     69.140 </v>
+  <v>     10.112      0.000 </v>
+  <v>     10.112      0.000 </v>
+  <v>     10.112      0.001 </v>
+  <v>     10.112      0.000 </v>
+  <v>     10.112      0.000 </v>
+  <v>     10.112      0.001 </v>
+  <v>     10.113      0.000 </v>
+  <v>     10.113      0.000 </v>
+  <v>     10.115      4.438 </v>
+  <v>     10.115      4.453 </v>
+  <v>     10.115      4.186 </v>
+  <v>     10.115      0.001 </v>
+  <v>     10.115      0.000 </v>
+  <v>     10.116      0.000 </v>
+  <v>     10.116      0.000 </v>
+  <v>     10.116      0.000 </v>
+  <v>     10.116      0.007 </v>
+  <v>     10.116      0.012 </v>
+  <v>     10.116      0.008 </v>
+  <v>     10.119      0.000 </v>
+  <v>     10.121      0.000 </v>
+  <v>     10.121      0.000 </v>
+  <v>     10.121      0.001 </v>
+  <v>     10.121      0.000 </v>
+  <v>     10.131      0.000 </v>
+  <v>     10.131      0.000 </v>
+  <v>     10.132      0.002 </v>
+  <v>     10.132      0.000 </v>
+  <v>     10.132      0.000 </v>
+  <v>     10.134      0.001 </v>
+  <v>     10.134      0.001 </v>
+  <v>     10.134      0.008 </v>
+  <v>     10.138    803.744 </v>
+  <v>     10.138    801.536 </v>
+  <v>     10.138    803.123 </v>
+  <v>     10.141      0.009 </v>
+  <v>     10.141      0.045 </v>
+  <v>     10.141      0.020 </v>
+  <v>     10.145      0.000 </v>
+  <v>     10.145      0.000 </v>
+  <v>     10.214      0.000 </v>
+  <v>     10.214      0.000 </v>
+  <v>     10.214      0.000 </v>
+  <v>     10.214    321.671 </v>
+  <v>     10.214    322.441 </v>
+  <v>     10.214    324.088 </v>
+  <v>     10.214      0.000 </v>
+  <v>     10.214      0.002 </v>
+  <v>     10.214      0.000 </v>
+  <v>     10.217      0.032 </v>
+  <v>     10.217      0.014 </v>
+  <v>     10.217      0.003 </v>
+  <v>     10.315      0.000 </v>
+  <v>     10.315      0.000 </v>
+  <v>     10.316      0.125 </v>
+  <v>     10.316      0.074 </v>
+  <v>     10.316      0.000 </v>
+  <v>     10.316      0.000 </v>
+  <v>     10.316      0.001 </v>
+  <v>     10.316      0.000 </v>
+  <v>     10.316      0.000 </v>
+  <v>     10.317      0.001 </v>
+  <v>     10.317      0.001 </v>
+  <v>     10.317      0.001 </v>
+  <v>     10.317     48.007 </v>
+  <v>     10.317     48.115 </v>
+  <v>     10.317     47.533 </v>
+  <v>     10.319      0.000 </v>
+  <v>     10.320      0.001 </v>
+  <v>     10.321      3.855 </v>
+  <v>     10.321      0.845 </v>
+  <v>     10.322      0.000 </v>
+  <v>     10.328     17.134 </v>
+  <v>     10.328      0.366 </v>
+  <v>     10.328      4.499 </v>
+  <v>     10.337      5.568 </v>
+  <v>     10.369      0.000 </v>
+  <v>     10.369      0.000 </v>
+  <v>     10.383      0.000 </v>
+  <v>     10.385      0.231 </v>
+  <v>     10.385      0.817 </v>
+  <v>     10.385    411.577 </v>
+  <v>     10.385    397.494 </v>
+  <v>     10.385    405.309 </v>
+  <v>     10.388      0.001 </v>
+  <v>     10.388      0.002 </v>
+  <v>     10.388      0.001 </v>
+  <v>     10.392      0.007 </v>
+  <v>     10.392      0.002 </v>
+  <v>     10.392      0.002 </v>
+  <v>     10.393     45.181 </v>
+  <v>     10.393     44.409 </v>
+  <v>     10.393     41.755 </v>
+  <v>     10.393      0.078 </v>
+  <v>     10.393      0.558 </v>
+  <v>     10.393      0.675 </v>
+  <v>     10.393      0.000 </v>
+  <v>     10.393      0.000 </v>
+  <v>     10.393      0.001 </v>
+  <v>     10.409      0.619 </v>
+  <v>     10.440      0.000 </v>
+  <v>     10.440      0.000 </v>
+  <v>     10.440      0.001 </v>
+  <v>     10.440      0.002 </v>
+  <v>     10.440      0.016 </v>
+  <v>     10.442     39.237 </v>
+  <v>     10.442     39.337 </v>
+  <v>     10.442     39.110 </v>
+  <v>     10.443      0.000 </v>
+  <v>     10.443      0.001 </v>
+  <v>     10.443      0.000 </v>
+  <v>     10.443      0.002 </v>
+  <v>     10.444      0.000 </v>
+  <v>     10.444      0.000 </v>
+  <v>     10.444      0.000 </v>
+  <v>     10.445      0.000 </v>
+  <v>     10.445      0.000 </v>
+  <v>     10.447      0.000 </v>
+  <v>     10.447      0.000 </v>
+  <v>     10.447      0.000 </v>
+  <v>     10.450      0.000 </v>
+  <v>     10.450     84.324 </v>
+  <v>     10.450     83.961 </v>
+  <v>     10.450     83.798 </v>
+  <v>     10.452      0.000 </v>
+  <v>     10.452      0.000 </v>
+  <v>     10.452      0.000 </v>
+  <v>     10.453      0.000 </v>
+  <v>     10.453      0.000 </v>
+  <v>     10.456      1.438 </v>
+  <v>     10.456      1.406 </v>
+  <v>     10.456      1.398 </v>
+  <v>     10.460      0.000 </v>
+  <v>     10.460      0.000 </v>
+  <v>     10.460      0.002 </v>
+  <v>     10.460      0.000 </v>
+  <v>     10.460      0.000 </v>
+  <v>     10.460      0.000 </v>
+  <v>     10.460      0.002 </v>
+  <v>     10.460      0.001 </v>
+  <v>     10.462      0.000 </v>
+  <v>     10.465      0.000 </v>
+  <v>     10.465      0.002 </v>
+  <v>     10.465      0.006 </v>
+  <v>     10.468      0.000 </v>
+  <v>     10.477   1158.725 </v>
+  <v>     10.477   1163.383 </v>
+  <v>     10.477   1163.617 </v>
+  <v>     10.551      0.008 </v>
+  <v>     10.551      0.001 </v>
+  <v>     10.551      0.001 </v>
+  <v>     10.552     36.918 </v>
+  <v>     10.552     37.633 </v>
+  <v>     10.552     38.555 </v>
+  <v>     10.552      0.001 </v>
+  <v>     10.552      0.001 </v>
+  <v>     10.552      0.010 </v>
+  <v>     10.553      0.000 </v>
+  <v>     10.553      0.000 </v>
+  <v>     10.556      0.001 </v>
+  <v>     10.556      0.004 </v>
+  <v>     10.556      0.006 </v>
+  <v>     10.557      0.001 </v>
+  <v>     10.557      0.014 </v>
+  <v>     10.606    147.405 </v>
+  <v>     10.606    149.329 </v>
+  <v>     10.606    147.203 </v>
+  <v>     10.607      0.000 </v>
+  <v>     10.607      0.000 </v>
+  <v>     10.608      0.000 </v>
+  <v>     10.608      0.000 </v>
+  <v>     10.608      0.001 </v>
+  <v>     10.608      0.000 </v>
+  <v>     10.608      0.003 </v>
+  <v>     10.608      0.000 </v>
+  <v>     10.611      0.000 </v>
+  <v>     10.631      0.000 </v>
+  <v>     10.631      0.000 </v>
+  <v>     10.638      0.002 </v>
+  <v>     10.638      0.002 </v>
+  <v>     10.639      0.017 </v>
+  <v>     10.639      2.784 </v>
+  <v>     10.639      1.892 </v>
+  <v>     10.639      1.872 </v>
+  <v>     10.639     22.699 </v>
+  <v>     10.639     23.576 </v>
+  <v>     10.639     19.075 </v>
+  <v>     10.640      1.347 </v>
+  <v>     10.640      2.132 </v>
+  <v>     10.645     56.800 </v>
+  <v>     10.645     67.734 </v>
+  <v>     10.645     52.776 </v>
+  <v>     10.645      0.589 </v>
+  <v>     10.646      0.015 </v>
+  <v>     10.646      0.022 </v>
+  <v>     10.646      0.023 </v>
+  <v>     10.649      0.010 </v>
+  <v>     10.649      0.009 </v>
+  <v>     10.650      0.000 </v>
+  <v>     10.652      0.011 </v>
+  <v>     10.652      0.004 </v>
+  <v>     10.652      0.006 </v>
+  <v>     10.653      0.003 </v>
+  <v>     10.653      0.003 </v>
+  <v>     10.653      0.003 </v>
+  <v>     10.653     44.854 </v>
+  <v>     10.653     45.555 </v>
+  <v>     10.653     49.838 </v>
+  <v>     10.656      0.162 </v>
+  <v>     10.656      1.034 </v>
+  <v>     10.656      0.678 </v>
+  <v>     10.657      0.069 </v>
+  <v>     10.657      0.005 </v>
+  <v>     10.657      0.029 </v>
+  <v>     10.657      0.000 </v>
+  <v>     10.657      0.000 </v>
+  <v>     10.657      0.001 </v>
+  <v>     10.657      0.000 </v>
+  <v>     10.657      0.000 </v>
+  <v>     10.657      0.000 </v>
+  <v>     10.658      0.000 </v>
+  <v>     10.658      0.000 </v>
+  <v>     10.659      0.285 </v>
+  <v>     10.659      0.605 </v>
+  <v>     10.659      0.049 </v>
+  <v>     10.659      0.037 </v>
+  <v>     10.659      0.042 </v>
+  <v>     10.661      0.059 </v>
+  <v>     10.661      0.030 </v>
+  <v>     10.661      0.031 </v>
+  <v>     10.661      0.013 </v>
+  <v>     10.661     74.145 </v>
+  <v>     10.661     73.732 </v>
+  <v>     10.661     72.679 </v>
+  <v>     10.662      0.000 </v>
+  <v>     10.663      0.002 </v>
+  <v>     10.663      0.004 </v>
+  <v>     10.663      0.000 </v>
+  <v>     10.664      0.056 </v>
+  <v>     10.664      0.083 </v>
+  <v>     10.664      0.076 </v>
+  <v>     10.670      0.009 </v>
+  <v>     10.670      0.011 </v>
+  <v>     10.670      0.013 </v>
+  <v>     10.671    153.823 </v>
+  <v>     10.671    149.975 </v>
+  <v>     10.671    147.650 </v>
+  <v>     10.672      0.000 </v>
+  <v>     10.672      0.000 </v>
+  <v>     10.673      0.470 </v>
+  <v>     10.673      0.074 </v>
+  <v>     10.673      0.576 </v>
+  <v>     10.675     19.853 </v>
+  <v>     10.675     23.131 </v>
+  <v>     10.675     25.976 </v>
+  <v>     10.676     11.232 </v>
+  <v>     10.676     10.553 </v>
+  <v>     10.676     11.065 </v>
+  <v>     10.677      0.021 </v>
+  <v>     10.677      0.019 </v>
+  <v>     10.677      0.011 </v>
+  <v>     10.678      0.219 </v>
+  <v>     10.678      0.208 </v>
+  <v>     10.678      0.139 </v>
+  <v>     10.678      0.126 </v>
+  <v>     10.679      0.000 </v>
+  <v>     10.679      0.037 </v>
+  <v>     10.679      0.343 </v>
+  <v>     10.679      0.278 </v>
+  <v>     10.683      0.003 </v>
+  <v>     10.683      0.012 </v>
+  <v>     10.683      0.003 </v>
+  <v>     10.687      0.000 </v>
+  <v>     10.687      0.000 </v>
+  <v>     10.688      0.007 </v>
+  <v>     10.688      0.019 </v>
+  <v>     10.688      0.020 </v>
+  <v>     10.689      0.024 </v>
+  <v>     10.689      0.053 </v>
+  <v>     10.689    144.232 </v>
+  <v>     10.689    146.912 </v>
+  <v>     10.689    146.018 </v>
+  <v>     10.691      0.000 </v>
+  <v>     10.692      0.004 </v>
+  <v>     10.692      0.010 </v>
+  <v>     10.695      0.000 </v>
+  <v>     10.695      0.000 </v>
+  <v>     10.695      0.001 </v>
+  <v>     10.696      0.001 </v>
+  <v>     10.696      0.000 </v>
+  <v>     10.696      0.004 </v>
+  <v>     10.696      0.041 </v>
+  <v>     10.706      0.061 </v>
+  <v>     10.706      0.045 </v>
+  <v>     10.706      0.054 </v>
+  <v>     10.708      0.000 </v>
+  <v>     10.728      0.414 </v>
+  <v>     10.728      0.452 </v>
+  <v>     10.728      1.180 </v>
+  <v>     10.729      0.819 </v>
+  <v>     10.729      0.069 </v>
+  <v>     10.731      1.985 </v>
+  <v>     10.731      0.208 </v>
+  <v>     10.731      0.139 </v>
+  <v>     10.741    347.494 </v>
+  <v>     10.741    363.458 </v>
+  <v>     10.741    356.180 </v>
+  <v>     10.755      0.144 </v>
+  <v>     10.782      0.000 </v>
+  <v>     10.782      0.000 </v>
+  <v>     10.784      0.006 </v>
+  <v>     10.784      0.001 </v>
+  <v>     10.784      0.001 </v>
+  <v>     10.784      0.002 </v>
+  <v>     10.784      0.001 </v>
+  <v>     10.784      0.001 </v>
+  <v>     10.789    180.956 </v>
+  <v>     10.789    177.815 </v>
+  <v>     10.789    178.097 </v>
+  <v>     10.794      0.000 </v>
+  <v>     10.810      0.004 </v>
+  <v>     10.810      0.010 </v>
+  <v>     10.810      0.040 </v>
+  <v>     10.815      0.000 </v>
+  <v>     10.815      0.000 </v>
+  <v>     10.820      0.000 </v>
+  <v>     10.820      0.000 </v>
+  <v>     10.820      0.000 </v>
+  <v>     10.820      0.000 </v>
+  <v>     10.820      0.001 </v>
+  <v>     10.820      0.002 </v>
+  <v>     10.823      0.000 </v>
+  <v>     10.828      0.000 </v>
+  <v>     10.828      0.000 </v>
+  <v>     10.828      0.001 </v>
+  <v>     10.828     24.287 </v>
+  <v>     10.828     24.397 </v>
+  <v>     10.828     24.660 </v>
+  <v>     10.832      0.003 </v>
+  <v>     10.832      0.002 </v>
+  <v>     10.832      0.000 </v>
+  <v>     10.833      0.004 </v>
+  <v>     10.833      0.003 </v>
+  <v>     10.836      0.000 </v>
+  <v>     10.866      0.007 </v>
+  <v>     10.866      0.007 </v>
+  <v>     10.866      0.022 </v>
+  <v>     10.869    140.009 </v>
+  <v>     10.869    143.528 </v>
+  <v>     10.869    141.033 </v>
+  <v>     10.870      0.283 </v>
+  <v>     10.870      0.259 </v>
+  <v>     10.872      0.027 </v>
+  <v>     10.872      0.000 </v>
+  <v>     10.872      0.000 </v>
+  <v>     10.872      0.038 </v>
+  <v>     10.872      0.074 </v>
+  <v>     10.872      0.472 </v>
+  <v>     10.874      0.017 </v>
+  <v>     10.874      0.019 </v>
+  <v>     10.874      0.046 </v>
+  <v>     10.879      0.578 </v>
+  <v>     10.879      0.950 </v>
+  <v>     10.879      0.495 </v>
+  <v>     10.879     63.912 </v>
+  <v>     10.879     66.457 </v>
+  <v>     10.879     69.761 </v>
+  <v>     10.880      0.000 </v>
+  <v>     10.892      0.000 </v>
+  <v>     10.892      0.000 </v>
+  <v>     10.894      0.016 </v>
+  <v>     10.894      0.002 </v>
+  <v>     10.894      0.027 </v>
+  <v>     10.897      0.009 </v>
+  <v>     10.897      0.006 </v>
+  <v>     10.897      0.012 </v>
+  <v>     10.901      0.620 </v>
+  <v>     10.901      1.011 </v>
+  <v>     10.901      0.514 </v>
+  <v>     10.905     82.575 </v>
+  <v>     10.905     83.016 </v>
+  <v>     10.905     82.772 </v>
+  <v>     10.905      0.000 </v>
+  <v>     10.905      0.000 </v>
+  <v>     10.905      0.000 </v>
+  <v>     10.905      0.000 </v>
+  <v>     10.905      0.000 </v>
+  <v>     10.908      1.649 </v>
+  <v>     10.908      1.689 </v>
+  <v>     10.908      0.000 </v>
+  <v>     10.912      0.877 </v>
+  <v>     10.912      0.911 </v>
+  <v>     10.912      2.616 </v>
+  <v>     10.913      0.001 </v>
+  <v>     10.913      0.007 </v>
+  <v>     10.913      0.001 </v>
+  <v>     10.919      0.024 </v>
+  <v>     10.919      0.027 </v>
+  <v>     10.919      0.070 </v>
+  <v>     10.919      3.456 </v>
+  <v>     10.919      3.453 </v>
+  <v>     10.919      3.474 </v>
+  <v>     10.919      0.000 </v>
+  <v>     10.919      0.000 </v>
+  <v>     10.920      7.003 </v>
+  <v>     10.920      1.710 </v>
+  <v>     10.920      2.670 </v>
+  <v>     10.920      1.089 </v>
+  <v>     10.924      4.739 </v>
+  <v>     10.924      2.445 </v>
+  <v>     10.924      0.722 </v>
+  <v>     10.924      0.000 </v>
+  <v>     10.924      0.000 </v>
+  <v>     10.924      0.000 </v>
+  <v>     10.925      0.000 </v>
+  <v>     10.925      0.725 </v>
+  <v>     10.926      0.870 </v>
+  <v>     10.926      0.987 </v>
+  <v>     10.930      0.208 </v>
+  <v>     10.930      0.501 </v>
+  <v>     10.930      0.532 </v>
+  <v>     10.933    305.158 </v>
+  <v>     10.933    306.525 </v>
+  <v>     10.933    305.907 </v>
+  <v>     10.942      0.131 </v>
+  <v>     10.942      0.004 </v>
+  <v>     10.943      0.000 </v>
+  <v>     10.943      0.000 </v>
+  <v>     10.943      0.001 </v>
+  <v>     10.946      0.000 </v>
+  <v>     10.946      0.000 </v>
+  <v>     10.946      0.001 </v>
+  <v>     10.947      2.797 </v>
+  <v>     10.947      2.685 </v>
+  <v>     10.947      2.903 </v>
+  <v>     10.948     12.251 </v>
+  <v>     10.948     12.089 </v>
+  <v>     10.948     12.086 </v>
+  <v>     10.948      0.634 </v>
+  <v>     10.948      0.296 </v>
+  <v>     10.948      1.781 </v>
+  <v>     10.948      0.046 </v>
+  <v>     10.948      0.010 </v>
+  <v>     10.948      0.089 </v>
+  <v>     10.949      0.002 </v>
+  <v>     10.949      0.002 </v>
+  <v>     10.949      0.009 </v>
+  <v>     10.949      0.000 </v>
+  <v>     10.949      0.000 </v>
+  <v>     10.949      0.000 </v>
+  <v>     10.949      0.000 </v>
+  <v>     10.949      0.000 </v>
+  <v>     10.950      0.000 </v>
+  <v>     10.950      2.207 </v>
+  <v>     10.950      2.535 </v>
+  <v>     10.950      1.908 </v>
+  <v>     10.950      0.000 </v>
+  <v>     10.950      0.000 </v>
+  <v>     10.950      0.000 </v>
+  <v>     10.952     16.662 </v>
+  <v>     10.952     16.329 </v>
+  <v>     10.952     16.494 </v>
+  <v>     10.954      0.000 </v>
+  <v>     10.957      0.000 </v>
+  <v>     10.957      0.000 </v>
+  <v>     10.962    108.380 </v>
+  <v>     10.962    109.229 </v>
+  <v>     10.962    109.001 </v>
+  <v>     10.970      9.953 </v>
+  <v>     10.970     11.029 </v>
+  <v>     10.970      9.489 </v>
+  <v>     10.986      0.723 </v>
+  <v>     10.997      0.106 </v>
+  <v>     10.997      0.109 </v>
+  <v>     10.997      0.340 </v>
+  <v>     10.998      0.000 </v>
+  <v>     10.998      0.000 </v>
+  <v>     11.001      0.000 </v>
+  <v>     11.001      0.000 </v>
+  <v>     11.001      0.000 </v>
+  <v>     11.004      1.243 </v>
+  <v>     11.006      0.006 </v>
+  <v>     11.006      0.003 </v>
+  <v>     11.006      0.000 </v>
+  <v>     11.008    109.017 </v>
+  <v>     11.008    108.848 </v>
+  <v>     11.008    107.891 </v>
+  <v>     11.010      0.483 </v>
+  <v>     11.010      0.134 </v>
+  <v>     11.010      0.299 </v>
+  <v>     11.010      0.000 </v>
+  <v>     11.012      0.092 </v>
+  <v>     11.012      0.063 </v>
+  <v>     11.012      0.003 </v>
+  <v>     11.012      1.227 </v>
+  <v>     11.012      0.906 </v>
+  <v>     11.013      3.191 </v>
+  <v>     11.013      3.202 </v>
+  <v>     11.013      3.231 </v>
+  <v>     11.014      0.951 </v>
+  <v>     11.014      0.675 </v>
+  <v>     11.014      1.757 </v>
+  <v>     11.015      0.000 </v>
+  <v>     11.016     49.578 </v>
+  <v>     11.016     49.406 </v>
+  <v>     11.016     49.639 </v>
+  <v>     11.018      0.728 </v>
+  <v>     11.018      0.686 </v>
+  <v>     11.018      0.000 </v>
+  <v>     11.018      0.001 </v>
+  <v>     11.018      0.001 </v>
+  <v>     11.018      0.017 </v>
+  <v>     11.018      0.167 </v>
+  <v>     11.018      0.274 </v>
+  <v>     11.019      0.000 </v>
+  <v>     11.019      0.000 </v>
+  <v>     11.019      0.000 </v>
+  <v>     11.019      0.000 </v>
+  <v>     11.019      0.150 </v>
+  <v>     11.019      0.194 </v>
+  <v>     11.019      0.092 </v>
+  <v>     11.019      4.770 </v>
+  <v>     11.020      0.000 </v>
+  <v>     11.020      0.000 </v>
+  <v>     11.020      0.000 </v>
+  <v>     11.020      4.349 </v>
+  <v>     11.020      0.277 </v>
+  <v>     11.020      3.081 </v>
+  <v>     11.021      0.000 </v>
+  <v>     11.021      0.000 </v>
+  <v>     11.021      0.000 </v>
+  <v>     11.022      3.406 </v>
+  <v>     11.022      2.216 </v>
+  <v>     11.022      4.574 </v>
+  <v>     11.026      1.172 </v>
+  <v>     11.027      0.934 </v>
+  <v>     11.034      0.000 </v>
+  <v>     11.036      2.146 </v>
+  <v>     11.036      1.671 </v>
+  <v>     11.036      2.791 </v>
+  <v>     11.040    856.826 </v>
+  <v>     11.040    853.357 </v>
+  <v>     11.040    860.030 </v>
+  <v>     11.044      0.000 </v>
+  <v>     11.044      0.000 </v>
+  <v>     11.044      0.000 </v>
+  <v>     11.047      0.000 </v>
+  <v>     11.047      0.000 </v>
+  <v>     11.051      0.000 </v>
+  <v>     11.056      0.283 </v>
+  <v>     11.115      0.000 </v>
+  <v>     11.115      0.000 </v>
+  <v>     11.120      1.355 </v>
+  <v>     11.120      1.455 </v>
+  <v>     11.120      1.309 </v>
+  <v>     11.121      0.000 </v>
+  <v>     11.121      0.000 </v>
+  <v>     11.121      0.000 </v>
+  <v>     11.124      0.009 </v>
+  <v>     11.124      0.017 </v>
+  <v>     11.124      0.037 </v>
+  <v>     11.125     79.551 </v>
+  <v>     11.125     79.246 </v>
+  <v>     11.125     79.142 </v>
+  <v>     11.126      0.004 </v>
+  <v>     11.126      0.004 </v>
+  <v>     11.126      0.012 </v>
+  <v>     11.127      0.000 </v>
+  <v>     11.132    453.339 </v>
+  <v>     11.132    450.646 </v>
+  <v>     11.132    449.046 </v>
+  <v>     11.132      0.011 </v>
+  <v>     11.132      0.005 </v>
+  <v>     11.132      0.015 </v>
+  <v>     11.175      0.005 </v>
+  <v>     11.175      0.001 </v>
+  <v>     11.175      0.006 </v>
+  <v>     11.177      0.001 </v>
+  <v>     11.177      0.001 </v>
+  <v>     11.177      0.002 </v>
+  <v>     11.178      0.024 </v>
+  <v>     11.178      0.013 </v>
+  <v>     11.178      0.015 </v>
+  <v>     11.181      0.002 </v>
+  <v>     11.184      0.007 </v>
+  <v>     11.184      0.023 </v>
+  <v>     11.192      0.000 </v>
+  <v>     11.192      0.000 </v>
+  <v>     11.194      0.000 </v>
+  <v>     11.196      0.000 </v>
+  <v>     11.196      0.000 </v>
+  <v>     11.197    166.651 </v>
+  <v>     11.197    165.475 </v>
+  <v>     11.197    167.626 </v>
+  <v>     11.199      0.000 </v>
+  <v>     11.199      0.000 </v>
+  <v>     11.199      0.000 </v>
+  <v>     11.200      0.001 </v>
+  <v>     11.200      0.000 </v>
+  <v>     11.200      0.000 </v>
+  <v>     11.201      0.000 </v>
+  <v>     11.205    197.492 </v>
+  <v>     11.205    199.747 </v>
+  <v>     11.205    197.098 </v>
+  <v>     11.224      0.053 </v>
+  <v>     11.224      0.025 </v>
+  <v>     11.224      0.049 </v>
+  <v>     11.229     16.096 </v>
+  <v>     11.229     15.692 </v>
+  <v>     11.229     16.522 </v>
+  <v>     11.239      0.017 </v>
+  <v>     11.239      0.068 </v>
+  <v>     11.239      0.030 </v>
+  <v>     11.243      0.000 </v>
+  <v>     11.243      0.000 </v>
+  <v>     11.243      0.000 </v>
+  <v>     11.247      0.709 </v>
+  <v>     11.247      0.097 </v>
+  <v>     11.247      0.832 </v>
+  <v>     11.250      0.000 </v>
+  <v>     11.250      0.000 </v>
+  <v>     11.252      0.026 </v>
+  <v>     11.252      0.019 </v>
+  <v>     11.252      0.046 </v>
+  <v>     11.256      0.001 </v>
+  <v>     11.256      0.001 </v>
+  <v>     11.256      0.002 </v>
+  <v>     11.256     73.048 </v>
+  <v>     11.256     75.771 </v>
+  <v>     11.256     69.989 </v>
+  <v>     11.257      0.064 </v>
+  <v>     11.257      0.004 </v>
+  <v>     11.257      0.008 </v>
+  <v>     11.258      0.000 </v>
+  <v>     11.258      0.000 </v>
+  <v>     11.258      0.000 </v>
+  <v>     11.260    184.677 </v>
+  <v>     11.260    183.339 </v>
+  <v>     11.260    180.523 </v>
+  <v>     11.262      0.048 </v>
+  <v>     11.262      0.057 </v>
+  <v>     11.262      0.052 </v>
+  <v>     11.263      0.000 </v>
+  <v>     11.264      2.025 </v>
+  <v>     11.264      0.147 </v>
+  <v>     11.264      0.181 </v>
+  <v>     11.265      0.205 </v>
+  <v>     11.265      1.195 </v>
+  <v>     11.265      5.707 </v>
+  <v>     11.265      8.939 </v>
+  <v>     11.265      7.436 </v>
+  <v>     11.268      0.000 </v>
+  <v>     11.268      0.000 </v>
+  <v>     11.268      0.000 </v>
+  <v>     11.268      3.225 </v>
+  <v>     11.268      4.873 </v>
+  <v>     11.268      6.909 </v>
+  <v>     11.269      0.000 </v>
+  <v>     11.269      0.000 </v>
+  <v>     11.270      0.010 </v>
+  <v>     11.270      0.019 </v>
+  <v>     11.270      0.017 </v>
+  <v>     11.270      0.003 </v>
+  <v>     11.272      0.385 </v>
+  <v>     11.365      0.046 </v>
+  <v>     11.365      0.025 </v>
+  <v>     11.365      0.024 </v>
+  <v>     11.365      0.001 </v>
+  <v>     11.365      0.002 </v>
+  <v>     11.370      0.001 </v>
+  <v>     11.370      0.000 </v>
+  <v>     11.370      0.000 </v>
+  <v>     11.373      0.000 </v>
+  <v>     11.373      0.000 </v>
+  <v>     11.373      0.000 </v>
+  <v>     11.376      0.000 </v>
+  <v>     11.400      0.000 </v>
+  <v>     11.400      0.000 </v>
+  <v>     11.404      0.000 </v>
+  <v>     11.404      0.000 </v>
+  <v>     11.404      0.011 </v>
+  <v>     11.412     14.343 </v>
+  <v>     11.412     13.979 </v>
+  <v>     11.412     14.663 </v>
+  <v>     11.415      0.012 </v>
+  <v>     11.416      0.005 </v>
+  <v>     11.416      0.005 </v>
+  <v>     11.417      0.001 </v>
+  <v>     11.417      0.000 </v>
+  <v>     11.418      0.001 </v>
+  <v>     11.418      0.000 </v>
+  <v>     11.418      0.000 </v>
+  <v>     11.507      0.000 </v>
+  <v>     11.507      0.000 </v>
+  <v>     11.507     60.541 </v>
+  <v>     11.507     53.479 </v>
+  <v>     11.507     56.986 </v>
+  <v>     11.507      0.002 </v>
+  <v>     11.507      0.002 </v>
+  <v>     11.507      0.036 </v>
+  <v>     11.508      0.319 </v>
+  <v>     11.508      0.468 </v>
+  <v>     11.508      0.048 </v>
+  <v>     11.509      0.004 </v>
+  <v>     11.509      0.013 </v>
+  <v>     11.509      0.009 </v>
+  <v>     11.510      0.001 </v>
+  <v>     11.510      0.001 </v>
+  <v>     11.510      0.021 </v>
+  <v>     11.515      1.321 </v>
+  <v>     11.515      0.206 </v>
+  <v>     11.515      0.240 </v>
+  <v>     11.517      8.027 </v>
+  <v>     11.517      5.060 </v>
+  <v>     11.517      3.439 </v>
+  <v>     11.517      0.000 </v>
+  <v>     11.520      0.025 </v>
+  <v>     11.520      0.037 </v>
+  <v>     11.520      0.000 </v>
+  <v>     11.520      0.000 </v>
+  <v>     11.522      0.000 </v>
+  <v>     11.522      0.000 </v>
+  <v>     11.522      0.000 </v>
+  <v>     11.522      0.003 </v>
+  <v>     11.523      1.043 </v>
+  <v>     11.523      0.950 </v>
+  <v>     11.523      0.152 </v>
+  <v>     11.525     10.529 </v>
+  <v>     11.525      7.213 </v>
+  <v>     11.525      1.049 </v>
+  <v>     11.525      0.001 </v>
+  <v>     11.525      0.001 </v>
+  <v>     11.525      0.002 </v>
+  <v>     11.526      0.000 </v>
+  <v>     11.526      0.000 </v>
+  <v>     11.527      2.498 </v>
+  <v>     11.527      4.483 </v>
+  <v>     11.527      9.882 </v>
+  <v>     11.529      0.000 </v>
+  <v>     11.529      0.000 </v>
+  <v>     11.529      2.204 </v>
+  <v>     11.530      0.002 </v>
+  <v>     11.530      0.003 </v>
+  <v>     11.530      0.004 </v>
+  <v>     11.533      4.122 </v>
+  <v>     11.533      5.085 </v>
+  <v>     11.538    656.847 </v>
+  <v>     11.538    756.453 </v>
+  <v>     11.538    707.685 </v>
+  <v>     11.539      1.134 </v>
+  <v>     11.539      0.914 </v>
+  <v>     11.539      1.076 </v>
+  <v>     11.569      0.001 </v>
+  <v>     11.570      0.000 </v>
+  <v>     11.570      0.000 </v>
+  <v>     11.616      0.000 </v>
+  <v>     11.616      0.000 </v>
+  <v>     11.620      0.000 </v>
+  <v>     11.621      0.000 </v>
+  <v>     11.621      0.000 </v>
+  <v>     11.629      0.008 </v>
+  <v>     11.629      0.004 </v>
+  <v>     11.629      0.005 </v>
+  <v>     11.630      0.418 </v>
+  <v>     11.630      0.400 </v>
+  <v>     11.630      0.513 </v>
+  <v>     11.632      0.020 </v>
+  <v>     11.632      0.001 </v>
+  <v>     11.632      0.003 </v>
+  <v>     11.634      0.000 </v>
+  <v>     11.634      0.000 </v>
+  <v>     11.635      0.000 </v>
+  <v>     11.635      0.003 </v>
+  <v>     11.635      0.001 </v>
+  <v>     11.635      0.009 </v>
+  <v>     11.638      0.000 </v>
+  <v>     11.638      0.000 </v>
+  <v>     11.638      0.000 </v>
+  <v>     11.638      0.000 </v>
+  <v>     11.655    101.288 </v>
+  <v>     11.655     93.306 </v>
+  <v>     11.655     87.999 </v>
+  <v>     11.664      3.271 </v>
+  <v>     11.714      0.002 </v>
+  <v>     11.714      0.000 </v>
+  <v>     11.714      0.000 </v>
+  <v>     11.714      0.000 </v>
+  <v>     11.714      0.000 </v>
+  <v>     11.719      0.000 </v>
+  <v>     11.719      0.000 </v>
+  <v>     11.719      0.000 </v>
+  <v>     11.719      0.000 </v>
+  <v>     11.720      0.110 </v>
+  <v>     11.720      0.023 </v>
+  <v>     11.722      0.040 </v>
+  <v>     11.722      0.127 </v>
+  <v>     11.722      0.037 </v>
+  <v>     11.722      0.003 </v>
+  <v>     11.722      0.000 </v>
+  <v>     11.722      0.000 </v>
+  <v>     11.724      0.252 </v>
+  <v>     11.724    190.946 </v>
+  <v>     11.724    173.939 </v>
+  <v>     11.724    207.701 </v>
+  <v>     11.724      0.006 </v>
+  <v>     11.724      0.001 </v>
+  <v>     11.724      0.014 </v>
+  <v>     11.725     34.705 </v>
+  <v>     11.725     30.842 </v>
+  <v>     11.725     31.460 </v>
+  <v>     11.726      0.010 </v>
+  <v>     11.726      0.014 </v>
+  <v>     11.726      0.002 </v>
+  <v>     11.727      0.000 </v>
+  <v>     11.727      0.000 </v>
+  <v>     11.727      0.005 </v>
+  <v>     11.727      0.003 </v>
+  <v>     11.727      0.015 </v>
+  <v>     11.729      0.002 </v>
+  <v>     11.729      0.000 </v>
+  <v>     11.729      0.000 </v>
+  <v>     11.729      0.000 </v>
+  <v>     11.729      0.000 </v>
+  <v>     11.729    452.211 </v>
+  <v>     11.729    382.224 </v>
+  <v>     11.729    392.378 </v>
+  <v>     11.729      3.870 </v>
+  <v>     11.731      0.081 </v>
+  <v>     11.731      0.041 </v>
+  <v>     11.733      0.002 </v>
+  <v>     11.733      0.012 </v>
+  <v>     11.733      0.042 </v>
+  <v>     11.734      8.894 </v>
+  <v>     11.734      1.164 </v>
+  <v>     11.734      0.693 </v>
+  <v>     11.734      0.000 </v>
+  <v>     11.735      1.624 </v>
+  <v>     11.735      3.066 </v>
+  <v>     11.735      5.708 </v>
+  <v>     11.735      0.000 </v>
+  <v>     11.736      0.018 </v>
+  <v>     11.736      0.008 </v>
+  <v>     11.736      0.016 </v>
+  <v>     11.738      0.032 </v>
+  <v>     11.738      0.012 </v>
+  <v>     11.738      0.021 </v>
+  <v>     11.739     11.927 </v>
+  <v>     11.739     13.200 </v>
+  <v>     11.739      9.222 </v>
+  <v>     11.740      2.522 </v>
+  <v>     11.740    177.471 </v>
+  <v>     11.740    179.298 </v>
+  <v>     11.740    139.615 </v>
+  <v>     11.742      0.000 </v>
+  <v>     11.742      0.006 </v>
+  <v>     11.742      0.004 </v>
+  <v>     11.742      0.005 </v>
+  <v>     11.743      0.030 </v>
+  <v>     11.743      0.002 </v>
+  <v>     11.743      0.003 </v>
+  <v>     11.743      0.000 </v>
+  <v>     11.743      0.000 </v>
+  <v>     11.743      0.000 </v>
+  <v>     11.745      3.524 </v>
+  <v>     11.745      3.341 </v>
+  <v>     11.745     11.653 </v>
+  <v>     11.745      9.337 </v>
+  <v>     11.745     11.484 </v>
+  <v>     11.749      0.003 </v>
+  <v>     11.749      0.002 </v>
+  <v>     11.749      0.001 </v>
+  <v>     11.750      2.294 </v>
+  <v>     11.750      1.094 </v>
+  <v>     11.750      1.957 </v>
+  <v>     11.752      0.003 </v>
+  <v>     11.752      0.000 </v>
+  <v>     11.752      0.000 </v>
+  <v>     11.753      4.859 </v>
+  <v>     11.753      4.668 </v>
+  <v>     11.755      0.000 </v>
+  <v>     11.755    445.692 </v>
+  <v>     11.755    477.408 </v>
+  <v>     11.755    468.084 </v>
+  <v>     11.761      0.021 </v>
+  <v>     11.761      0.030 </v>
+  <v>     11.761      0.010 </v>
+  <v>     11.769      0.610 </v>
+  <v>     11.808      0.000 </v>
+  <v>     11.808      0.000 </v>
+  <v>     11.810      0.000 </v>
+  <v>     11.810      0.000 </v>
+  <v>     11.810      0.000 </v>
+  <v>     11.818      0.000 </v>
+  <v>     11.818      0.001 </v>
+  <v>     11.818      0.000 </v>
+  <v>     11.819      0.003 </v>
+  <v>     11.819      0.003 </v>
+  <v>     11.819      0.000 </v>
+  <v>     11.820      0.000 </v>
+  <v>     11.823      0.000 </v>
+  <v>     11.823      0.000 </v>
+  <v>     11.823      0.000 </v>
+  <v>     11.824      0.004 </v>
+  <v>     11.824      0.003 </v>
+  <v>     11.828     31.695 </v>
+  <v>     11.828     32.902 </v>
+  <v>     11.828     30.413 </v>
+  <v>     11.829      0.000 </v>
+  <v>     11.830      0.000 </v>
+  <v>     11.830      0.000 </v>
+  <v>     11.830      0.000 </v>
+  <v>     11.950      0.000 </v>
+  <v>     11.952      0.010 </v>
+  <v>     11.952      0.001 </v>
+  <v>     11.952      0.001 </v>
+  <v>     11.952      0.000 </v>
+  <v>     11.952      0.000 </v>
+  <v>     11.953     35.190 </v>
+  <v>     11.953     33.489 </v>
+  <v>     11.953     33.985 </v>
+  <v>     11.954      0.000 </v>
+  <v>     11.954      0.000 </v>
+  <v>     11.954      0.000 </v>
+  <v>     11.955     21.744 </v>
+  <v>     11.955     22.431 </v>
+  <v>     11.955     23.245 </v>
+  <v>     11.956      0.000 </v>
+  <v>     11.956      0.000 </v>
+  <v>     11.957      0.028 </v>
+  <v>     11.957      0.067 </v>
+  <v>     11.957      0.096 </v>
+  <v>     11.957      0.000 </v>
+  <v>     11.960      0.003 </v>
+  <v>     11.960      0.002 </v>
+  <v>     11.960      0.014 </v>
+  <v>     11.991      4.085 </v>
+  <v>     11.991      3.915 </v>
+  <v>     11.991      3.669 </v>
+  <v>     11.992      0.009 </v>
+  <v>     11.992      0.006 </v>
+  <v>     11.992      0.023 </v>
+  <v>     11.996      0.000 </v>
+  <v>     11.996      0.000 </v>
+  <v>     11.996      0.000 </v>
+  <v>     11.997      0.001 </v>
+  <v>     11.997      0.005 </v>
+  <v>     11.998      0.000 </v>
+  <v>     11.998      0.000 </v>
+  <v>     12.000      0.000 </v>
+  <v>     12.000      0.005 </v>
+  <v>     12.000      0.007 </v>
+  <v>     12.000      0.006 </v>
+  <v>     12.000      0.000 </v>
+  <v>     12.000      0.000 </v>
+  <v>     12.000      0.000 </v>
+  <v>     12.016    504.162 </v>
+  <v>     12.016    512.848 </v>
+  <v>     12.016    511.301 </v>
+  <v>     12.021      0.026 </v>
+  <v>     12.068      0.002 </v>
+  <v>     12.068      0.002 </v>
+  <v>     12.068      0.004 </v>
+  <v>     12.069      7.052 </v>
+  <v>     12.072      2.196 </v>
+  <v>     12.072      0.098 </v>
+  <v>     12.073      0.094 </v>
+  <v>     12.073      4.936 </v>
+  <v>     12.073     17.315 </v>
+  <v>     12.077      0.000 </v>
+  <v>     12.077      0.000 </v>
+  <v>     12.079      1.583 </v>
+  <v>     12.079      2.634 </v>
+  <v>     12.079      2.001 </v>
+  <v>     12.080      0.595 </v>
+  <v>     12.080      0.172 </v>
+  <v>     12.080      0.281 </v>
+  <v>     12.080      0.000 </v>
+  <v>     12.080      1.269 </v>
+  <v>     12.080      2.100 </v>
+  <v>     12.081      0.004 </v>
+  <v>     12.081      0.000 </v>
+  <v>     12.081      0.002 </v>
+  <v>     12.089      0.227 </v>
+  <v>     12.089      0.010 </v>
+  <v>     12.089      0.706 </v>
+  <v>     12.091     39.245 </v>
+  <v>     12.091     39.630 </v>
+  <v>     12.091     39.027 </v>
+  <v>     12.095      0.002 </v>
+  <v>     12.095      0.014 </v>
+  <v>     12.095      0.001 </v>
+  <v>     12.098      0.061 </v>
+  <v>     12.098      0.000 </v>
+  <v>     12.098      0.000 </v>
+  <v>     12.107    478.280 </v>
+  <v>     12.107    478.886 </v>
+  <v>     12.107    479.279 </v>
+  <v>     12.107      0.001 </v>
+  <v>     12.108      0.357 </v>
+  <v>     12.108      0.031 </v>
+  <v>     12.108      0.940 </v>
+  <v>     12.200      0.001 </v>
+  <v>     12.200      0.002 </v>
+  <v>     12.200      0.000 </v>
+  <v>     12.200      0.000 </v>
+  <v>     12.200      0.000 </v>
+  <v>     12.201      0.001 </v>
+  <v>     12.201      0.000 </v>
+  <v>     12.201      0.000 </v>
+  <v>     12.202      0.000 </v>
+  <v>     12.202      0.000 </v>
+  <v>     12.202      0.000 </v>
+  <v>     12.203    137.520 </v>
+  <v>     12.203    136.103 </v>
+  <v>     12.203    137.255 </v>
+  <v>     12.204      0.000 </v>
+  <v>     12.204      0.000 </v>
+  <v>     12.204      0.002 </v>
+  <v>     12.204      0.000 </v>
+  <v>     12.204      0.001 </v>
+  <v>     12.205      0.001 </v>
+  <v>     12.205      0.000 </v>
+  <v>     12.205      0.004 </v>
+  <v>     12.205      0.000 </v>
+  <v>     12.209      0.000 </v>
+  <v>     12.410      2.057 </v>
+  <v>     12.410      0.128 </v>
+  <v>     12.410      0.125 </v>
+  <v>     12.411    104.140 </v>
+  <v>     12.411    106.738 </v>
+  <v>     12.411    103.321 </v>
+  <v>     12.412      0.544 </v>
+  <v>     12.412      0.185 </v>
+  <v>     12.412      0.078 </v>
+  <v>     12.412      0.092 </v>
+  <v>     12.412      0.057 </v>
+  <v>     12.416      0.123 </v>
+  <v>     12.451      2.687 </v>
+  <v>     12.451      0.167 </v>
+  <v>     12.451      0.166 </v>
+  <v>     12.452      0.000 </v>
+  <v>     12.452      0.000 </v>
+  <v>     12.453      0.574 </v>
+  <v>     12.453      0.064 </v>
+  <v>     12.453      0.039 </v>
+  <v>     12.455      0.061 </v>
+  <v>     12.455      0.069 </v>
+  <v>     12.455      0.039 </v>
+  <v>     12.456      0.000 </v>
+  <v>     12.457      0.000 </v>
+  <v>     12.464      0.616 </v>
+  <v>     12.464      1.348 </v>
+  <v>     12.464      2.773 </v>
+  <v>     12.467     80.231 </v>
+  <v>     12.467      4.178 </v>
+  <v>     12.467      5.537 </v>
+  <v>     12.467     14.686 </v>
+  <v>     12.467     42.664 </v>
+  <v>     12.467     13.573 </v>
+  <v>     12.468      3.828 </v>
+  <v>     12.468     33.735 </v>
+  <v>     12.468      7.756 </v>
+  <v>     12.471    283.978 </v>
+  <v>     12.471    292.227 </v>
+  <v>     12.471    250.295 </v>
+  <v>     12.482      0.000 </v>
+  <v>     12.482      0.001 </v>
+  <v>     12.493      2.826 </v>
+  <v>     12.493      0.175 </v>
+  <v>     12.493      0.174 </v>
+  <v>     12.497      0.004 </v>
+  <v>     12.497      0.000 </v>
+  <v>     12.497      0.000 </v>
+  <v>     12.497     52.613 </v>
+  <v>     12.497     49.897 </v>
+  <v>     12.497     52.602 </v>
+  <v>     12.502      0.202 </v>
+  <v>     12.502      0.080 </v>
+  <v>     12.503      0.455 </v>
+  <v>     12.503      0.239 </v>
+  <v>     12.503      2.412 </v>
+  <v>     12.503      0.000 </v>
+  <v>     12.510      0.181 </v>
+  <v>     12.510      0.379 </v>
+  <v>     12.510      0.151 </v>
+  <v>     12.511      0.465 </v>
+  <v>     12.511      0.001 </v>
+  <v>     12.511      0.012 </v>
+  <v>     12.511      0.001 </v>
+  <v>     12.511      0.001 </v>
+  <v>     12.512      0.001 </v>
+  <v>     12.512      0.578 </v>
+  <v>     12.516      0.000 </v>
+  <v>     12.516      0.000 </v>
+  <v>     12.516      0.000 </v>
+  <v>     12.518      0.078 </v>
+  <v>     12.518      0.098 </v>
+  <v>     12.518      0.074 </v>
+  <v>     12.519    207.396 </v>
+  <v>     12.519    210.320 </v>
+  <v>     12.519    211.240 </v>
+  <v>     12.520      0.000 </v>
+  <v>     12.520      0.000 </v>
+  <v>     12.521      0.000 </v>
+  <v>     12.521      0.000 </v>
+  <v>     12.521      0.002 </v>
+  <v>     12.524      0.000 </v>
+  <v>     12.524    146.226 </v>
+  <v>     12.524    137.225 </v>
+  <v>     12.524    145.681 </v>
+  <v>     12.527      0.003 </v>
+  <v>     12.527      0.000 </v>
+  <v>     12.527      0.000 </v>
+  <v>     12.527      0.163 </v>
+  <v>     12.527      0.011 </v>
+  <v>     12.527      0.010 </v>
+  <v>     12.528      0.001 </v>
+  <v>     12.528      0.001 </v>
+  <v>     12.530      0.152 </v>
+  <v>     12.530      0.082 </v>
+  <v>     12.535      0.000 </v>
+  <v>     12.535      0.048 </v>
+  <v>     12.535      0.003 </v>
+  <v>     12.535      0.003 </v>
+  <v>     12.536      0.003 </v>
+  <v>     12.536      0.008 </v>
+  <v>     12.536      0.001 </v>
+  <v>     12.537      0.000 </v>
+  <v>     12.542      0.454 </v>
+  <v>     12.542      1.180 </v>
+  <v>     12.542      0.341 </v>
+  <v>     12.609      0.017 </v>
+  <v>     12.609      0.001 </v>
+  <v>     12.609      0.001 </v>
+  <v>     12.610     29.679 </v>
+  <v>     12.610     39.404 </v>
+  <v>     12.610     33.832 </v>
+  <v>     12.611      0.000 </v>
+  <v>     12.611      0.000 </v>
+  <v>     12.612      0.285 </v>
+  <v>     12.613      0.001 </v>
+  <v>     12.613      0.001 </v>
+  <v>     12.613      0.001 </v>
+  <v>     12.617      0.725 </v>
+  <v>     12.617      0.335 </v>
+  <v>     12.618      0.284 </v>
+  <v>     12.618      1.295 </v>
+  <v>     12.618      1.434 </v>
+  <v>     12.622     10.573 </v>
+  <v>     12.622     13.867 </v>
+  <v>     12.622     12.010 </v>
+  <v>     12.628      0.000 </v>
+  <v>     12.630      0.045 </v>
+  <v>     12.630      0.016 </v>
+  <v>     12.630      0.014 </v>
+  <v>     12.743      0.081 </v>
+  <v>     12.743      0.214 </v>
+  <v>     12.744      0.045 </v>
+  <v>     12.744      0.047 </v>
+  <v>     12.744      0.076 </v>
+  <v>     12.744      0.001 </v>
+  <v>     12.746     68.030 </v>
+  <v>     12.746     63.421 </v>
+  <v>     12.746     67.141 </v>
+  <v>     12.746      0.468 </v>
+  <v>     12.746      0.030 </v>
+  <v>     12.746      0.079 </v>
+  <v>     12.746      0.001 </v>
+  <v>     12.746      0.000 </v>
+  <v>     12.746      0.000 </v>
+  <v>     12.749      0.016 </v>
+  <v>     12.749      0.065 </v>
+  <v>     12.749      0.064 </v>
+  <v>     12.749      0.003 </v>
+  <v>     12.749      0.002 </v>
+  <v>     12.749      0.003 </v>
+  <v>     12.750      0.005 </v>
+  <v>     12.750      0.006 </v>
+  <v>     12.750      0.083 </v>
+  <v>     12.751      0.000 </v>
+  <v>     12.751      0.000 </v>
+  <v>     12.751      0.000 </v>
+  <v>     12.753      0.000 </v>
+  <v>     12.753      0.000 </v>
+  <v>     12.753      0.038 </v>
+  <v>     12.753      0.042 </v>
+  <v>     12.753      0.047 </v>
+  <v>     12.754      0.000 </v>
+  <v>     12.756     15.475 </v>
+  <v>     12.756     15.129 </v>
+  <v>     12.756     16.875 </v>
+  <v>     12.761      0.001 </v>
+  <v>     12.761      0.000 </v>
+  <v>     12.761      0.000 </v>
+  <v>     12.764      0.000 </v>
+  <v>     12.766      0.000 </v>
+  <v>     12.766      0.000 </v>
+  <v>     12.766      0.000 </v>
+  <v>     12.766     33.951 </v>
+  <v>     12.766     32.377 </v>
+  <v>     12.766     36.249 </v>
+  <v>     12.767      0.034 </v>
+  <v>     12.767      0.159 </v>
+  <v>     12.767      0.453 </v>
+  <v>     12.768      0.002 </v>
+  <v>     12.768      0.008 </v>
+  <v>     12.769      0.081 </v>
+  <v>     12.769      1.191 </v>
+  <v>     12.769      1.209 </v>
+  <v>     12.769      1.249 </v>
+  <v>     12.770      0.000 </v>
+  <v>     12.770      0.000 </v>
+  <v>     12.770      0.000 </v>
+  <v>     12.771      0.019 </v>
+  <v>     12.771      0.093 </v>
+  <v>     12.771     13.368 </v>
+  <v>     12.771     12.658 </v>
+  <v>     12.771     13.793 </v>
+  <v>     12.772      0.000 </v>
+  <v>     12.772      0.000 </v>
+  <v>     12.772      0.000 </v>
+  <v>     12.773      0.000 </v>
+  <v>     12.773      0.000 </v>
+  <v>     12.773      0.000 </v>
+  <v>     12.776      0.000 </v>
+  <v>     12.776      0.000 </v>
+  <v>     12.777      0.025 </v>
+  <v>     12.777      0.005 </v>
+  <v>     12.777      0.005 </v>
+  <v>     12.780      1.265 </v>
+  <v>     12.780      1.377 </v>
+  <v>     12.780      1.350 </v>
+  <v>     12.781      0.000 </v>
+  <v>     12.785      0.001 </v>
+  <v>     12.785      0.000 </v>
+  <v>     12.794      0.363 </v>
+  <v>     12.794     69.220 </v>
+  <v>     12.794     73.674 </v>
+  <v>     12.794     73.686 </v>
+  <v>     12.804      0.647 </v>
+  <v>     12.804      0.678 </v>
+  <v>     12.804      0.679 </v>
+  <v>     12.812    211.568 </v>
+  <v>     12.812    189.947 </v>
+  <v>     12.812    205.333 </v>
+  <v>     12.814      0.654 </v>
+  <v>     12.814      0.272 </v>
+  <v>     12.814      0.000 </v>
+  <v>     12.815      0.000 </v>
+  <v>     12.815      0.000 </v>
+  <v>     12.815      0.000 </v>
+  <v>     12.824    132.205 </v>
+  <v>     12.824    126.300 </v>
+  <v>     12.824    130.871 </v>
+  <v>     12.827      0.115 </v>
+  <v>     12.828      0.026 </v>
+  <v>     12.828      0.030 </v>
+  <v>     12.828      0.021 </v>
+  <v>     12.828      0.803 </v>
+  <v>     12.828      0.749 </v>
+  <v>     12.828      1.451 </v>
+  <v>     12.830      0.000 </v>
+  <v>     12.830      0.000 </v>
+  <v>     12.844      0.000 </v>
+  <v>     12.844      0.001 </v>
+  <v>     12.844      0.000 </v>
+  <v>     12.844      0.793 </v>
+  <v>     12.844      0.000 </v>
+  <v>     12.844      3.311 </v>
+  <v>     12.844      4.997 </v>
+  <v>     12.844      8.343 </v>
+  <v>     12.863      7.318 </v>
+  <v>     12.863      6.961 </v>
+  <v>     12.863      7.092 </v>
+  <v>     12.863      0.000 </v>
+  <v>     12.863      0.000 </v>
+  <v>     12.863      0.000 </v>
+  <v>     12.864      0.000 </v>
+  <v>     12.864      0.000 </v>
+  <v>     12.864      0.000 </v>
+  <v>     12.865      0.000 </v>
+  <v>     12.865      0.000 </v>
+  <v>     12.865      0.000 </v>
+  <v>     12.914     55.914 </v>
+  <v>     12.914     59.010 </v>
+  <v>     12.914     56.754 </v>
+  <v>     12.916      0.010 </v>
+  <v>     12.916      0.005 </v>
+  <v>     12.916      0.005 </v>
+  <v>     12.917      0.000 </v>
+  <v>     12.917      0.000 </v>
+  <v>     12.917      0.001 </v>
+  <v>     12.917      0.001 </v>
+  <v>     12.917      0.014 </v>
+  <v>     12.918      0.022 </v>
+  <v>     12.918      0.002 </v>
+  <v>     12.918      0.001 </v>
+  <v>     12.921      0.004 </v>
+  <v>     12.921      0.003 </v>
+  <v>     12.921      0.005 </v>
+  <v>     12.924      0.213 </v>
+  <v>     12.924      0.017 </v>
+  <v>     12.924      0.015 </v>
+  <v>     12.924      0.920 </v>
+  <v>     12.924      0.739 </v>
+  <v>     12.924      0.785 </v>
+  <v>     12.925      0.000 </v>
+  <v>     12.925      0.000 </v>
+  <v>     12.925      0.000 </v>
+  <v>     12.926      0.000 </v>
+  <v>     12.929      0.000 </v>
+  <v>     12.929      0.000 </v>
+  <v>     12.934    169.453 </v>
+  <v>     12.934    180.957 </v>
+  <v>     12.934    177.112 </v>
+  <v>     12.940      0.000 </v>
+  <v>     12.940      0.000 </v>
+  <v>     12.941      0.138 </v>
+  <v>     12.941      0.138 </v>
+  <v>     12.941      2.178 </v>
+  <v>     12.941      0.053 </v>
+  <v>     12.941      0.053 </v>
+  <v>     12.941      0.062 </v>
+  <v>     12.944      0.007 </v>
+  <v>     12.944      0.010 </v>
+  <v>     12.944      0.008 </v>
+  <v>     12.944      5.891 </v>
+  <v>     12.944      5.753 </v>
+  <v>     12.944      5.680 </v>
+  <v>     12.949      0.000 </v>
+  <v>     12.950      0.001 </v>
+  <v>     12.950      0.000 </v>
+  <v>     12.950      0.000 </v>
+  <v>     12.950      0.309 </v>
+  <v>     12.950      0.652 </v>
+  <v>     12.952      1.413 </v>
+  <v>     12.952      2.840 </v>
+  <v>     12.952      2.493 </v>
+  <v>     12.955      0.127 </v>
+  <v>     12.958      0.022 </v>
+  <v>     12.958      0.019 </v>
+  <v>     12.958      0.022 </v>
+  <v>     12.963      0.042 </v>
+  <v>     12.974      0.000 </v>
+  <v>     12.974      0.000 </v>
+  <v>     12.995     65.938 </v>
+  <v>     12.995     66.288 </v>
+  <v>     12.995     67.883 </v>
+  <v>     12.996      0.000 </v>
+  <v>     12.996      0.006 </v>
+  <v>     12.996      0.001 </v>
+  <v>     12.996      0.001 </v>
+  <v>     12.999      0.019 </v>
+  <v>     12.999      0.002 </v>
+  <v>     12.999      0.001 </v>
+  <v>     13.009      0.000 </v>
+  <v>     13.009      0.000 </v>
+  <v>     13.009      0.000 </v>
+  <v>     13.010      0.000 </v>
+  <v>     13.010      0.000 </v>
+  <v>     13.010      0.002 </v>
+  <v>     13.012      0.025 </v>
+  <v>     13.012      0.023 </v>
+  <v>     13.012      0.029 </v>
+  <v>     13.016    263.206 </v>
+  <v>     13.016    272.025 </v>
+  <v>     13.016    274.395 </v>
+  <v>     13.062      9.386 </v>
+  <v>     13.062      9.254 </v>
+  <v>     13.062      9.665 </v>
+  <v>     13.065      0.001 </v>
+  <v>     13.065      0.000 </v>
+  <v>     13.065      0.011 </v>
+  <v>     13.065      0.001 </v>
+  <v>     13.065      0.002 </v>
+  <v>     13.065      0.000 </v>
+  <v>     13.066      0.000 </v>
+  <v>     13.066      0.000 </v>
+  <v>     13.067      0.000 </v>
+  <v>     13.069      0.039 </v>
+  <v>     13.069      0.050 </v>
+  <v>     13.069      0.020 </v>
+  <v>     13.076      0.002 </v>
+  <v>     13.076      0.009 </v>
+  <v>     13.077      0.174 </v>
+  <v>     13.077      0.006 </v>
+  <v>     13.077      0.037 </v>
+  <v>     13.077      0.096 </v>
+  <v>     13.077      0.162 </v>
+  <v>     13.077      0.099 </v>
+  <v>     13.077     33.930 </v>
+  <v>     13.077     36.334 </v>
+  <v>     13.077     36.237 </v>
+  <v>     13.078      0.018 </v>
+  <v>     13.078      0.034 </v>
+  <v>     13.078      0.004 </v>
+  <v>     13.078      0.000 </v>
+  <v>     13.078      0.000 </v>
+  <v>     13.078      0.002 </v>
+  <v>     13.078     34.596 </v>
+  <v>     13.078     39.053 </v>
+  <v>     13.078     35.897 </v>
+  <v>     13.079      0.003 </v>
+  <v>     13.082      0.357 </v>
+  <v>     13.082      0.131 </v>
+  <v>     13.086      0.002 </v>
+  <v>     13.086      0.002 </v>
+  <v>     13.086      0.000 </v>
+  <v>     13.087      0.000 </v>
+  <v>     13.088      0.163 </v>
+  <v>     13.088      0.975 </v>
+  <v>     13.088      0.073 </v>
+  <v>     13.089      4.395 </v>
+  <v>     13.089      4.142 </v>
+  <v>     13.089      4.334 </v>
+  <v>     13.090      0.000 </v>
+  <v>     13.090      0.003 </v>
+  <v>     13.090      0.001 </v>
+  <v>     13.090      0.626 </v>
+  <v>     13.091      0.590 </v>
+  <v>     13.091      0.309 </v>
+  <v>     13.092      0.060 </v>
+  <v>     13.102      0.020 </v>
+  <v>     13.102      0.044 </v>
+  <v>     13.118      0.365 </v>
+  <v>     13.118      1.018 </v>
+  <v>     13.118      0.457 </v>
+  <v>     13.131      0.488 </v>
+  <v>     13.135   1525.323 </v>
+  <v>     13.135   1506.020 </v>
+  <v>     13.135   1506.106 </v>
+  <v>     13.225      0.000 </v>
+  <v>     13.226      0.267 </v>
+  <v>     13.226      0.298 </v>
+  <v>     13.226      0.271 </v>
+  <v>     13.228     27.705 </v>
+  <v>     13.228     27.640 </v>
+  <v>     13.228     27.024 </v>
+  <v>     13.228      0.000 </v>
+  <v>     13.228      0.000 </v>
+  <v>     13.231      0.000 </v>
+  <v>     13.231      0.000 </v>
+  <v>     13.231      0.001 </v>
+  <v>     13.232      0.000 </v>
+  <v>     13.234      0.006 </v>
+  <v>     13.234      0.000 </v>
+  <v>     13.234      0.000 </v>
+  <v>     13.234      0.005 </v>
+  <v>     13.234      0.000 </v>
+  <v>     13.234      0.002 </v>
+  <v>     13.235      0.002 </v>
+  <v>     13.235      0.001 </v>
+  <v>     13.235      0.000 </v>
+  <v>     13.235      0.000 </v>
+  <v>     13.235      0.000 </v>
+  <v>     13.235      2.414 </v>
+  <v>     13.235      2.418 </v>
+  <v>     13.235      2.438 </v>
+  <v>     13.236      0.000 </v>
+  <v>     13.236      0.023 </v>
+  <v>     13.236      0.009 </v>
+  <v>     13.237    229.201 </v>
+  <v>     13.237    230.204 </v>
+  <v>     13.237    228.774 </v>
+  <v>     13.237      0.000 </v>
+  <v>     13.237      0.000 </v>
+  <v>     13.237      0.000 </v>
+  <v>     13.238      0.017 </v>
+  <v>     13.238      0.009 </v>
+  <v>     13.238      0.007 </v>
+  <v>     13.239      0.000 </v>
+  <v>     13.239      0.000 </v>
+  <v>     13.239      0.000 </v>
+  <v>     13.239      0.000 </v>
+  <v>     13.239      0.001 </v>
+  <v>     13.239      0.000 </v>
+  <v>     13.242      0.000 </v>
+  <v>     13.242      0.000 </v>
+  <v>     13.242      0.000 </v>
+  <v>     13.244      0.000 </v>
+  <v>     13.244      0.000 </v>
+  <v>     13.244      0.000 </v>
+  <v>     13.245      0.000 </v>
+  <v>     13.245      0.000 </v>
+  <v>     13.245      0.000 </v>
+  <v>     13.246      3.642 </v>
+  <v>     13.246      3.422 </v>
+  <v>     13.246      3.454 </v>
+  <v>     13.248    137.046 </v>
+  <v>     13.248    139.759 </v>
+  <v>     13.248    135.798 </v>
+  <v>     13.292      0.007 </v>
+  <v>     13.292      0.003 </v>
+  <v>     13.292      0.033 </v>
+  <v>     13.292      0.044 </v>
+  <v>     13.292      0.118 </v>
+  <v>     13.293      0.647 </v>
+  <v>     13.293      0.643 </v>
+  <v>     13.293      0.646 </v>
+  <v>     13.293      0.008 </v>
+  <v>     13.293      0.001 </v>
+  <v>     13.293      0.001 </v>
+  <v>     13.295      0.001 </v>
+  <v>     13.295      0.000 </v>
+  <v>     13.295      0.000 </v>
+  <v>     13.296      0.000 </v>
+  <v>     13.300      0.000 </v>
+  <v>     13.300      0.000 </v>
+  <v>     13.300      0.000 </v>
+  <v>     13.305      0.000 </v>
+  <v>     13.305      0.001 </v>
+  <v>     13.310      1.060 </v>
+  <v>     13.310      0.945 </v>
+  <v>     13.310      0.948 </v>
+  <v>     13.312      0.095 </v>
+  <v>     13.361     82.880 </v>
+  <v>     13.361     84.239 </v>
+  <v>     13.361    228.810 </v>
+  <v>     13.363      5.636 </v>
+  <v>     13.363      5.724 </v>
+  <v>     13.363     14.964 </v>
+  <v>     13.365      4.853 </v>
+  <v>     13.367     42.255 </v>
+  <v>     13.465      0.000 </v>
+  <v>     13.471      0.212 </v>
+  <v>     13.471      0.014 </v>
+  <v>     13.471      0.014 </v>
+  <v>     13.472      0.006 </v>
+  <v>     13.472      0.017 </v>
+  <v>     13.477      0.000 </v>
+  <v>     13.477      0.002 </v>
+  <v>     13.477      0.005 </v>
+  <v>     13.478      0.004 </v>
+  <v>     13.478      0.006 </v>
+  <v>     13.478      0.004 </v>
+  <v>     13.482      0.000 </v>
+  <v>     13.482      0.000 </v>
+  <v>     13.485      0.000 </v>
+  <v>     13.486      0.000 </v>
+  <v>     13.486      0.001 </v>
+  <v>     13.486      0.000 </v>
+  <v>     13.490    226.672 </v>
+  <v>     13.490    223.664 </v>
+  <v>     13.490    226.324 </v>
+  <v>     13.500      0.010 </v>
+  <v>     13.500      0.025 </v>
+  <v>     13.500      0.005 </v>
+  <v>     13.532      0.000 </v>
+  <v>     13.532      0.000 </v>
+  <v>     13.532      0.000 </v>
+  <v>     13.536      0.003 </v>
+  <v>     13.536      0.006 </v>
+  <v>     13.537     23.739 </v>
+  <v>     13.537     27.269 </v>
+  <v>     13.537     26.636 </v>
+  <v>     13.539    130.294 </v>
+  <v>     13.539    122.629 </v>
+  <v>     13.539    131.015 </v>
+  <v>     13.541      0.002 </v>
+  <v>     13.541      0.000 </v>
+  <v>     13.541      0.000 </v>
+  <v>     13.542      0.000 </v>
+  <v>     13.542      0.000 </v>
+  <v>     13.545      0.000 </v>
+  <v>     13.550      0.004 </v>
+  <v>     13.550      0.002 </v>
+  <v>     13.551      0.169 </v>
+  <v>     13.555     44.419 </v>
+  <v>     13.555     49.249 </v>
+  <v>     13.555     47.144 </v>
+  <v>     13.557      0.000 </v>
+  <v>     13.558      0.000 </v>
+  <v>     13.558      0.000 </v>
+  <v>     13.558      0.000 </v>
+  <v>     13.562      0.000 </v>
+  <v>     13.562      0.000 </v>
+  <v>     13.564      0.000 </v>
+  <v>     13.564      0.000 </v>
+  <v>     13.564      0.000 </v>
+  <v>     13.564      0.432 </v>
+  <v>     13.564      1.057 </v>
+  <v>     13.564      2.136 </v>
+  <v>     13.568      0.187 </v>
+  <v>     13.568      1.188 </v>
+  <v>     13.569      0.060 </v>
+  <v>     13.569      0.075 </v>
+  <v>     13.569      0.045 </v>
+  <v>     13.572     27.222 </v>
+  <v>     13.572     38.391 </v>
+  <v>     13.572     31.920 </v>
+  <v>     13.572      0.525 </v>
+  <v>     13.575      0.001 </v>
+  <v>     13.577      0.017 </v>
+  <v>     13.577      0.011 </v>
+  <v>     13.577      0.014 </v>
+  <v>     13.580    187.260 </v>
+  <v>     13.580    196.034 </v>
+  <v>     13.580    186.992 </v>
+  <v>     13.595      0.933 </v>
+  <v>     13.617      0.005 </v>
+  <v>     13.620      0.000 </v>
+  <v>     13.620      0.000 </v>
+  <v>     13.626    193.117 </v>
+  <v>     13.626    198.317 </v>
+  <v>     13.626    189.013 </v>
+  <v>     13.635      0.048 </v>
+  <v>     13.635      0.022 </v>
+  <v>     13.640      0.000 </v>
+  <v>     13.640      0.001 </v>
+  <v>     13.640      0.001 </v>
+  <v>     13.641      0.884 </v>
+  <v>     13.646      0.211 </v>
+  <v>     13.646      0.294 </v>
+  <v>     13.647    109.695 </v>
+  <v>     13.647    115.218 </v>
+  <v>     13.647    128.231 </v>
+  <v>     13.648      0.000 </v>
+  <v>     13.768      0.001 </v>
+  <v>     13.771      0.000 </v>
+  <v>     13.771      0.000 </v>
+  <v>     13.772      0.003 </v>
+  <v>     13.772      0.000 </v>
+  <v>     13.772      0.000 </v>
+  <v>     13.773     15.808 </v>
+  <v>     13.773     14.690 </v>
+  <v>     13.773     14.429 </v>
+  <v>     13.774      0.015 </v>
+  <v>     13.774      0.010 </v>
+  <v>     13.775      0.018 </v>
+  <v>     13.775      0.014 </v>
+  <v>     13.775      0.080 </v>
+  <v>     13.776      0.009 </v>
+  <v>     13.776      0.006 </v>
+  <v>     13.776      0.008 </v>
+  <v>     13.777      0.009 </v>
+  <v>     13.777      0.015 </v>
+  <v>     13.777      0.016 </v>
+  <v>     13.777      0.000 </v>
+  <v>     13.778      0.000 </v>
+  <v>     13.778      0.000 </v>
+  <v>     13.779      0.000 </v>
+  <v>     13.780      0.001 </v>
+  <v>     13.780      0.001 </v>
+  <v>     13.780      0.001 </v>
+  <v>     13.781      0.277 </v>
+  <v>     13.781      0.304 </v>
+  <v>     13.781      0.255 </v>
+  <v>     13.781      0.000 </v>
+  <v>     13.781      0.000 </v>
+  <v>     13.781      0.000 </v>
+  <v>     13.782      0.000 </v>
+  <v>     13.782      0.000 </v>
+  <v>     13.782      0.001 </v>
+  <v>     13.805      0.000 </v>
+  <v>     13.806     28.765 </v>
+  <v>     13.806     30.208 </v>
+  <v>     13.806     35.449 </v>
+  <v>     13.808      0.922 </v>
+  <v>     13.808      0.567 </v>
+  <v>     13.808      0.909 </v>
+  <v>     13.810      0.000 </v>
+  <v>     13.810      0.000 </v>
+  <v>     13.811      0.002 </v>
+  <v>     13.811      0.003 </v>
+  <v>     13.811      0.002 </v>
+  <v>     13.812      0.000 </v>
+  <v>     13.812      0.000 </v>
+  <v>     13.812      0.000 </v>
+  <v>     13.814      0.012 </v>
+  <v>     13.814      0.013 </v>
+  <v>     13.814      0.016 </v>
+  <v>     13.815      0.818 </v>
+  <v>     13.815      0.332 </v>
+  <v>     13.817     62.090 </v>
+  <v>     13.817     69.321 </v>
+  <v>     13.817     75.463 </v>
+  <v>     13.818      0.199 </v>
+  <v>     13.818      0.204 </v>
+  <v>     13.818      0.150 </v>
+  <v>     13.818      0.000 </v>
+  <v>     13.818      0.001 </v>
+  <v>     13.818      0.000 </v>
+  <v>     13.819      0.000 </v>
+  <v>     13.820      0.183 </v>
+  <v>     13.826      0.002 </v>
+  <v>     13.826      0.005 </v>
+  <v>     13.826      0.004 </v>
+  <v>     13.828      0.000 </v>
+  <v>     13.828      0.000 </v>
+  <v>     13.856      1.068 </v>
+  <v>     13.856      1.062 </v>
+  <v>     13.856      1.082 </v>
+  <v>     13.859      0.000 </v>
+  <v>     13.859      0.002 </v>
+  <v>     13.864      0.790 </v>
+  <v>     13.864      0.791 </v>
+  <v>     13.864      0.765 </v>
+  <v>     13.865      0.000 </v>
+  <v>     13.865      0.000 </v>
+  <v>     13.865      0.000 </v>
+  <v>     13.865      0.000 </v>
+  <v>     13.865      0.000 </v>
+  <v>     13.865      0.000 </v>
+  <v>     13.871      0.007 </v>
+  <v>     13.872      0.000 </v>
+  <v>     13.872      0.000 </v>
+  <v>     13.872      0.000 </v>
+  <v>     13.872      0.000 </v>
+  <v>     13.873      0.076 </v>
+  <v>     13.873      0.054 </v>
+  <v>     13.873      0.066 </v>
+  <v>     13.873      0.001 </v>
+  <v>     13.873      0.000 </v>
+  <v>     13.896      0.000 </v>
+  <v>     13.896      0.000 </v>
+  <v>     13.896      0.000 </v>
+  <v>     13.901      0.001 </v>
+  <v>     13.901      0.000 </v>
+  <v>     13.901      0.000 </v>
+  <v>     13.906      0.062 </v>
+  <v>     13.906      0.036 </v>
+  <v>     13.906      0.109 </v>
+  <v>     13.907      0.000 </v>
+  <v>     13.907      0.000 </v>
+  <v>     13.908      0.000 </v>
+  <v>     13.908      0.000 </v>
+  <v>     13.908      0.000 </v>
+  <v>     13.910     43.757 </v>
+  <v>     13.910     44.510 </v>
+  <v>     13.910     45.346 </v>
+  <v>     13.911      0.000 </v>
+  <v>     13.912      0.000 </v>
+  <v>     13.912      0.000 </v>
+  <v>     13.912      0.000 </v>
+  <v>     13.912      0.000 </v>
+  <v>     13.912      0.000 </v>
+  <v>     13.913      0.000 </v>
+  <v>     13.913      0.000 </v>
+  <v>     13.914      3.158 </v>
+  <v>     13.914      3.302 </v>
+  <v>     13.914      3.260 </v>
+  <v>     13.915      0.000 </v>
+  <v>     13.917      0.000 </v>
+  <v>     13.917      0.000 </v>
+  <v>     13.917      0.000 </v>
+  <v>     13.918      0.000 </v>
+  <v>     13.918      0.000 </v>
+  <v>     13.918      0.000 </v>
+  <v>     13.918      0.000 </v>
+  <v>     13.918      0.000 </v>
+  <v>     13.918      0.000 </v>
+  <v>     13.919      0.000 </v>
+  <v>     13.922      0.501 </v>
+  <v>     13.922      0.535 </v>
+  <v>     13.922      0.501 </v>
+  <v>     13.922     23.167 </v>
+  <v>     13.922     23.081 </v>
+  <v>     13.922     22.585 </v>
+  <v>     13.923      0.006 </v>
+  <v>     13.923      0.007 </v>
+  <v>     13.927      0.006 </v>
+  <v>     13.927      0.001 </v>
+  <v>     13.927      0.002 </v>
+  <v>     13.928      0.007 </v>
+  <v>     13.928      0.000 </v>
+  <v>     13.928      0.000 </v>
+  <v>     13.931      0.015 </v>
+  <v>     13.931      0.002 </v>
+  <v>     13.931      0.015 </v>
+  <v>     13.934     37.588 </v>
+  <v>     13.934     37.946 </v>
+  <v>     13.934     38.447 </v>
+  <v>     13.935      0.059 </v>
+  <v>     13.935      0.054 </v>
+  <v>     13.935      0.054 </v>
+  <v>     13.936      0.004 </v>
+  <v>     13.936      0.004 </v>
+  <v>     13.940      0.000 </v>
+  <v>     13.940      0.000 </v>
+  <v>     13.947      0.000 </v>
+  <v>     13.947      0.002 </v>
+  <v>     13.947      0.004 </v>
+  <v>     13.948      2.775 </v>
+  <v>     13.948      2.898 </v>
+  <v>     13.948      2.799 </v>
+  <v>     13.951      0.006 </v>
+  <v>     13.951      0.007 </v>
+  <v>     13.951      0.003 </v>
+  <v>     13.953      0.000 </v>
+  <v>     13.953      0.000 </v>
+  <v>     13.954      0.000 </v>
+  <v>     13.954      0.000 </v>
+  <v>     13.954      0.000 </v>
+  <v>     13.955      0.000 </v>
+  <v>     13.956      0.001 </v>
+  <v>     13.956      0.000 </v>
+  <v>     13.956      0.000 </v>
+  <v>     13.959      0.001 </v>
+  <v>     13.959      0.000 </v>
+  <v>     13.959      0.000 </v>
+  <v>     13.959      0.000 </v>
+  <v>     13.961      0.000 </v>
+  <v>     13.969    454.041 </v>
+  <v>     13.969    451.674 </v>
+  <v>     13.969    448.077 </v>
+  <v>     13.971      0.041 </v>
+  <v>     13.971      0.089 </v>
+  <v>     13.971      0.028 </v>
+  <v>     13.973      0.000 </v>
+  <v>     13.973      0.000 </v>
+  <v>     13.973      1.650 </v>
+  <v>     13.973      1.725 </v>
+  <v>     13.973      1.548 </v>
+  <v>     13.973      0.000 </v>
+  <v>     13.973      0.000 </v>
+  <v>     13.973      0.000 </v>
+  <v>     13.974      0.006 </v>
+  <v>     13.974      0.003 </v>
+  <v>     13.974      0.006 </v>
+  <v>     13.974      0.004 </v>
+  <v>     13.974      0.004 </v>
+  <v>     13.975      0.003 </v>
+  <v>     13.975      0.005 </v>
+  <v>     13.975      0.004 </v>
+  <v>     13.986      0.036 </v>
+  <v>     14.037      0.000 </v>
+  <v>     14.037      0.000 </v>
+  <v>     14.037      0.000 </v>
+  <v>     14.039      0.000 </v>
+  <v>     14.039      0.000 </v>
+  <v>     14.040     74.213 </v>
+  <v>     14.040     74.082 </v>
+  <v>     14.040     74.333 </v>
+  <v>     14.044      0.007 </v>
+  <v>     14.044      0.009 </v>
+  <v>     14.044      0.014 </v>
+  <v>     14.048      0.000 </v>
+  <v>     14.048      0.000 </v>
+  <v>     14.052      0.000 </v>
+  <v>     14.052      0.000 </v>
+  <v>     14.052      0.000 </v>
+  <v>     14.054      0.000 </v>
+  <v>     14.054      0.000 </v>
+  <v>     14.054      0.000 </v>
+  <v>     14.054      0.000 </v>
+  <v>     14.054      0.000 </v>
+  <v>     14.055      0.000 </v>
+  <v>     14.055      0.000 </v>
+  <v>     14.055      0.001 </v>
+  <v>     14.056      4.647 </v>
+  <v>     14.056      4.664 </v>
+  <v>     14.056      4.626 </v>
+  <v>     14.056      0.000 </v>
+  <v>     14.056      0.000 </v>
+  <v>     14.057      0.001 </v>
+  <v>     14.057      0.002 </v>
+  <v>     14.057      0.002 </v>
+  <v>     14.058      0.002 </v>
+  <v>     14.058      0.000 </v>
+  <v>     14.058      0.000 </v>
+  <v>     14.058      0.000 </v>
+  <v>     14.058      0.000 </v>
+  <v>     14.058      0.000 </v>
+  <v>     14.060      0.000 </v>
+  <v>     14.060      0.000 </v>
+  <v>     14.061      0.000 </v>
+  <v>     14.061      0.001 </v>
+  <v>     14.061      0.000 </v>
+  <v>     14.062      0.000 </v>
+  <v>     14.062     11.653 </v>
+  <v>     14.062     11.950 </v>
+  <v>     14.062     11.717 </v>
+  <v>     14.062      0.000 </v>
+  <v>     14.099     59.234 </v>
+  <v>     14.099     56.296 </v>
+  <v>     14.099     63.306 </v>
+  <v>     14.101      0.001 </v>
+  <v>     14.101      0.001 </v>
+  <v>     14.101      0.000 </v>
+  <v>     14.102      0.000 </v>
+  <v>     14.102      0.000 </v>
+  <v>     14.110      0.620 </v>
+  <v>     14.110      0.081 </v>
+  <v>     14.110      0.673 </v>
+  <v>     14.110      0.159 </v>
+  <v>     14.110      0.254 </v>
+  <v>     14.111      0.005 </v>
+  <v>     14.111      0.005 </v>
+  <v>     14.111      0.003 </v>
+  <v>     14.115      0.000 </v>
+  <v>     14.128      0.744 </v>
+  <v>     14.128      0.635 </v>
+  <v>     14.128      0.657 </v>
+  <v>     14.129    334.606 </v>
+  <v>     14.129    337.581 </v>
+  <v>     14.129    345.565 </v>
+  <v>     14.132      0.033 </v>
+  <v>     14.170      0.000 </v>
+  <v>     14.182     54.474 </v>
+  <v>     14.182     63.500 </v>
+  <v>     14.182     68.615 </v>
+  <v>     14.189      0.000 </v>
+  <v>     14.189      0.000 </v>
+  <v>     14.190      0.222 </v>
+  <v>     14.190      0.163 </v>
+  <v>     14.190      0.173 </v>
+  <v>     14.195      0.000 </v>
+  <v>     14.195      0.000 </v>
+  <v>     14.195      0.000 </v>
+  <v>     14.197      0.000 </v>
+  <v>     14.197      0.000 </v>
+  <v>     14.202      0.026 </v>
+  <v>     14.202      0.003 </v>
+  <v>     14.202      0.002 </v>
+  <v>     14.202      6.395 </v>
+  <v>     14.202      5.963 </v>
+  <v>     14.202      2.824 </v>
+  <v>     14.203      1.473 </v>
+  <v>     14.203      1.871 </v>
+  <v>     14.203      0.544 </v>
+  <v>     14.203      0.000 </v>
+  <v>     14.207      0.003 </v>
+  <v>     14.207      0.003 </v>
+  <v>     14.207      0.002 </v>
+  <v>     14.208      0.750 </v>
+  <v>     14.208      0.743 </v>
+  <v>     14.208      0.325 </v>
+  <v>     14.208      0.005 </v>
+  <v>     14.208      0.001 </v>
+  <v>     14.208      0.004 </v>
+  <v>     14.209      0.000 </v>
+  <v>     14.209      0.001 </v>
+  <v>     14.209      0.000 </v>
+  <v>     14.209      0.000 </v>
+  <v>     14.209      0.000 </v>
+  <v>     14.209      0.000 </v>
+  <v>     14.212      0.110 </v>
+  <v>     14.212      0.071 </v>
+  <v>     14.212     56.421 </v>
+  <v>     14.212     61.120 </v>
+  <v>     14.212     58.562 </v>
+  <v>     14.214      0.000 </v>
+  <v>     14.214      0.006 </v>
+  <v>     14.214      0.001 </v>
+  <v>     14.215      0.000 </v>
+  <v>     14.265     37.364 </v>
+  <v>     14.265     37.912 </v>
+  <v>     14.265     37.840 </v>
+  <v>     14.267      0.010 </v>
+  <v>     14.267      0.001 </v>
+  <v>     14.267      0.004 </v>
+  <v>     14.268      0.000 </v>
+  <v>     14.270      0.000 </v>
+  <v>     14.270      0.000 </v>
+  <v>     14.272      0.004 </v>
+  <v>     14.272      0.003 </v>
+  <v>     14.272      0.005 </v>
+  <v>     14.273      1.127 </v>
+  <v>     14.273      1.154 </v>
+  <v>     14.273      1.121 </v>
+  <v>     14.274    258.001 </v>
+  <v>     14.274    258.005 </v>
+  <v>     14.274    257.426 </v>
+  <v>     14.277      0.002 </v>
+  <v>     14.277      0.001 </v>
+  <v>     14.282      0.080 </v>
+  <v>     14.282      0.042 </v>
+  <v>     14.282      0.012 </v>
+  <v>     14.290      0.039 </v>
+  <v>     14.354      3.475 </v>
+  <v>     14.354      3.278 </v>
+  <v>     14.354      2.617 </v>
+  <v>     14.357     10.683 </v>
+  <v>     14.358      0.665 </v>
+  <v>     14.358      0.668 </v>
+  <v>     14.360      4.210 </v>
+  <v>     14.360      2.324 </v>
+  <v>     14.360      1.521 </v>
+  <v>     14.361      1.666 </v>
+  <v>     14.361      2.758 </v>
+  <v>     14.363      0.773 </v>
+  <v>     14.403      1.750 </v>
+  <v>     14.403      0.163 </v>
+  <v>     14.403      0.185 </v>
+  <v>     14.405     59.503 </v>
+  <v>     14.405     50.856 </v>
+  <v>     14.405     60.517 </v>
+  <v>     14.407      0.300 </v>
+  <v>     14.407      0.568 </v>
+  <v>     14.408      0.164 </v>
+  <v>     14.408      0.774 </v>
+  <v>     14.408      0.759 </v>
+  <v>     14.408      0.393 </v>
+  <v>     14.427      0.018 </v>
+  <v>     14.427      0.017 </v>
+  <v>     14.427      0.047 </v>
+  <v>     14.428      0.000 </v>
+  <v>     14.430     35.773 </v>
+  <v>     14.430     37.749 </v>
+  <v>     14.430     45.770 </v>
+  <v>     14.440      0.742 </v>
+  <v>     14.447      0.065 </v>
+  <v>     14.447      0.007 </v>
+  <v>     14.447      0.072 </v>
+  <v>     14.451      0.031 </v>
+  <v>     14.451      0.014 </v>
+  <v>     14.451      0.005 </v>
+  <v>     14.453      0.167 </v>
+  <v>     14.453      0.199 </v>
+  <v>     14.453      0.148 </v>
+  <v>     14.453      0.002 </v>
+  <v>     14.453      0.006 </v>
+  <v>     14.453      0.003 </v>
+  <v>     14.458      0.009 </v>
+  <v>     14.458      0.003 </v>
+  <v>     14.459      0.000 </v>
+  <v>     14.462      0.003 </v>
+  <v>     14.462      0.000 </v>
+  <v>     14.463      1.129 </v>
+  <v>     14.463      0.802 </v>
+  <v>     14.463      0.920 </v>
+  <v>     14.468     38.892 </v>
+  <v>     14.468     38.769 </v>
+  <v>     14.468     40.691 </v>
+  <v>     14.470      0.000 </v>
+  <v>     14.470      0.000 </v>
+  <v>     14.470      0.099 </v>
+  <v>     14.470      0.013 </v>
+  <v>     14.470      0.102 </v>
+  <v>     14.471      0.189 </v>
+  <v>     14.472     65.759 </v>
+  <v>     14.472     59.658 </v>
+  <v>     14.472     61.818 </v>
+  <v>     14.476      0.000 </v>
+  <v>     14.477      0.276 </v>
+  <v>     14.477      0.239 </v>
+  <v>     14.477      0.109 </v>
+  <v>     14.477      0.191 </v>
+  <v>     14.477      0.009 </v>
+  <v>     14.477      0.015 </v>
+  <v>     14.477      3.669 </v>
+  <v>     14.477      3.484 </v>
+  <v>     14.477      3.367 </v>
+  <v>     14.478      0.075 </v>
+  <v>     14.478      0.003 </v>
+  <v>     14.478      0.008 </v>
+  <v>     14.482     56.750 </v>
+  <v>     14.482     58.420 </v>
+  <v>     14.482     57.288 </v>
+  <v>     14.483      0.018 </v>
+  <v>     14.483      0.041 </v>
+  <v>     14.486    157.927 </v>
+  <v>     14.486    158.661 </v>
+  <v>     14.486    162.008 </v>
+  <v>     14.507      0.000 </v>
+  <v>     14.507      0.000 </v>
+  <v>     14.511      0.000 </v>
+  <v>     14.511      0.000 </v>
+  <v>     14.511      0.000 </v>
+  <v>     14.514      2.256 </v>
+  <v>     14.516      0.691 </v>
+  <v>     14.516      0.044 </v>
+  <v>     14.516      0.047 </v>
+  <v>     14.519      0.000 </v>
+  <v>     14.519      0.000 </v>
+  <v>     14.519      0.000 </v>
+  <v>     14.520      0.000 </v>
+  <v>     14.521      8.560 </v>
+  <v>     14.521      8.453 </v>
+  <v>     14.521      8.381 </v>
+  <v>     14.526      3.870 </v>
+  <v>     14.526      3.380 </v>
+  <v>     14.526      1.290 </v>
+  <v>     14.528      0.000 </v>
+  <v>     14.529      2.566 </v>
+  <v>     14.529      5.257 </v>
+  <v>     14.529      5.801 </v>
+  <v>     14.530      0.034 </v>
+  <v>     14.530      0.103 </v>
+  <v>     14.537    223.453 </v>
+  <v>     14.537    171.842 </v>
+  <v>     14.537    160.089 </v>
+  <v>     14.542     33.192 </v>
+  <v>     14.542      2.071 </v>
+  <v>     14.542      2.075 </v>
+  <v>     14.543      2.077 </v>
+  <v>     14.543     12.147 </v>
+  <v>     14.554      0.700 </v>
+  <v>     14.554      3.586 </v>
+  <v>     14.554      1.522 </v>
+  <v>     14.554      3.284 </v>
+  <v>     14.575      0.074 </v>
+  <v>     14.575      0.234 </v>
+  <v>     14.575      0.091 </v>
+  <v>     14.580     45.202 </v>
+  <v>     14.580     43.112 </v>
+  <v>     14.580     41.693 </v>
+  <v>     14.582      0.104 </v>
+  <v>     14.582      0.049 </v>
+  <v>     14.582      0.065 </v>
+  <v>     14.584      0.015 </v>
+  <v>     14.584      0.088 </v>
+  <v>     14.584      0.035 </v>
+  <v>     14.585      0.093 </v>
+  <v>     14.585      0.075 </v>
+  <v>     14.585      0.110 </v>
+  <v>     14.585      0.000 </v>
+  <v>     14.585      0.000 </v>
+  <v>     14.586      0.000 </v>
+  <v>     14.586      0.000 </v>
+  <v>     14.586      0.000 </v>
+  <v>     14.586      0.000 </v>
+  <v>     14.586      0.000 </v>
+  <v>     14.589      0.010 </v>
+  <v>     14.589      0.004 </v>
+  <v>     14.589      0.004 </v>
+  <v>     14.592      0.000 </v>
+  <v>     14.593      0.000 </v>
+  <v>     14.594     36.810 </v>
+  <v>     14.594     39.487 </v>
+  <v>     14.594     38.328 </v>
+  <v>     14.597      0.000 </v>
+  <v>     14.597      0.000 </v>
+  <v>     14.599      0.004 </v>
+  <v>     14.599      0.004 </v>
+  <v>     14.602      0.000 </v>
+  <v>     14.602      4.278 </v>
+  <v>     14.602      5.485 </v>
+  <v>     14.602      4.866 </v>
+  <v>     14.605      0.014 </v>
+  <v>     14.605      0.024 </v>
+  <v>     14.605      0.006 </v>
+  <v>     14.608      0.200 </v>
+  <v>     14.610      0.011 </v>
+  <v>     14.610      0.002 </v>
+  <v>     14.610      0.010 </v>
+  <v>     14.612      0.000 </v>
+  <v>     14.612      0.000 </v>
+  <v>     14.612      0.000 </v>
+  <v>     14.612      0.000 </v>
+  <v>     14.612      0.000 </v>
+  <v>     14.613      0.113 </v>
+  <v>     14.613      0.121 </v>
+  <v>     14.613      0.124 </v>
+  <v>     14.613      0.158 </v>
+  <v>     14.613      0.109 </v>
+  <v>     14.614      0.000 </v>
+  <v>     14.614      0.000 </v>
+  <v>     14.615      0.029 </v>
+  <v>     14.615      0.015 </v>
+  <v>     14.615      0.135 </v>
+  <v>     14.615      0.000 </v>
+  <v>     14.615      0.003 </v>
+  <v>     14.615      0.000 </v>
+  <v>     14.615      0.002 </v>
+  <v>     14.615      0.000 </v>
+  <v>     14.615      0.000 </v>
+  <v>     14.615      0.000 </v>
+  <v>     14.616      0.906 </v>
+  <v>     14.616      1.118 </v>
+  <v>     14.616      1.501 </v>
+  <v>     14.620      0.000 </v>
+  <v>     14.624      0.000 </v>
+  <v>     14.624      0.000 </v>
+  <v>     14.625      0.111 </v>
+  <v>     14.625      0.122 </v>
+  <v>     14.625      0.190 </v>
+  <v>     14.625      0.001 </v>
+  <v>     14.625      0.011 </v>
+  <v>     14.625      0.001 </v>
+  <v>     14.625      0.016 </v>
+  <v>     14.629      0.000 </v>
+  <v>     14.633      0.007 </v>
+  <v>     14.633      0.001 </v>
+  <v>     14.636      0.012 </v>
+  <v>     14.636      0.007 </v>
+  <v>     14.636      0.009 </v>
+  <v>     14.637      0.000 </v>
+  <v>     14.637      0.000 </v>
+  <v>     14.637      0.000 </v>
+  <v>     14.654     92.872 </v>
+  <v>     14.654     91.142 </v>
+  <v>     14.654     92.767 </v>
+  <v>     14.655      0.000 </v>
+  <v>     14.655      0.000 </v>
+  <v>     14.655      0.000 </v>
+  <v>     14.656      0.000 </v>
+  <v>     14.656      0.000 </v>
+  <v>     14.657      0.000 </v>
+  <v>     14.657      0.000 </v>
+  <v>     14.657      0.000 </v>
+  <v>     14.660      0.000 </v>
+  <v>     14.660      0.000 </v>
+  <v>     14.660      0.000 </v>
+  <v>     14.661      0.000 </v>
+  <v>     14.661      0.000 </v>
+  <v>     14.662      0.000 </v>
+  <v>     14.671      0.014 </v>
+  <v>     14.671      0.114 </v>
+  <v>     14.671      0.046 </v>
+  <v>     14.675    189.051 </v>
+  <v>     14.675    191.818 </v>
+  <v>     14.675    190.593 </v>
+  <v>     14.675      0.000 </v>
+  <v>     14.676      0.000 </v>
+  <v>     14.676      0.000 </v>
+  <v>     14.676      0.000 </v>
+  <v>     14.677      0.000 </v>
+  <v>     14.677      0.000 </v>
+  <v>     14.677      0.000 </v>
+  <v>     14.677      0.000 </v>
+  <v>     14.677      0.000 </v>
+  <v>     14.679      0.000 </v>
+  <v>     14.679      0.000 </v>
+  <v>     14.679      0.000 </v>
+  <v>     14.681    447.404 </v>
+  <v>     14.681    455.514 </v>
+  <v>     14.681    456.805 </v>
+  <v>     14.681      0.000 </v>
+  <v>     14.681      0.000 </v>
+  <v>     14.683      1.113 </v>
+  <v>     14.683      0.929 </v>
+  <v>     14.683      0.827 </v>
+  <v>     14.683      0.000 </v>
+  <v>     14.684      0.000 </v>
+  <v>     14.684      0.000 </v>
+  <v>     14.684      0.000 </v>
+  <v>     14.714      0.000 </v>
+  <v>     14.717      0.023 </v>
+  <v>     14.717      0.003 </v>
+  <v>     14.717      0.002 </v>
+  <v>     14.720      0.000 </v>
+  <v>     14.720      0.000 </v>
+  <v>     14.720      0.003 </v>
+  <v>     14.720      0.008 </v>
+  <v>     14.720      0.005 </v>
+  <v>     14.733    216.706 </v>
+  <v>     14.733    221.278 </v>
+  <v>     14.733    220.692 </v>
+  <v>     14.748      0.000 </v>
+  <v>     14.748      0.000 </v>
+  <v>     14.748      0.000 </v>
+  <v>     14.748      0.000 </v>
+  <v>     14.748      0.000 </v>
+  <v>     14.748     10.256 </v>
+  <v>     14.748      9.714 </v>
+  <v>     14.748      9.944 </v>
+  <v>     14.749      0.004 </v>
+  <v>     14.749      0.000 </v>
+  <v>     14.749      0.000 </v>
+  <v>     14.753      0.000 </v>
+  <v>     14.771      0.001 </v>
+  <v>     14.771      0.000 </v>
+  <v>     14.771      0.001 </v>
+  <v>     14.771      0.000 </v>
+  <v>     14.771      0.000 </v>
+  <v>     14.771      0.001 </v>
+  <v>     14.772      0.000 </v>
+  <v>     14.772      0.000 </v>
+  <v>     14.773      0.002 </v>
+  <v>     14.773      0.002 </v>
+  <v>     14.773      0.001 </v>
+  <v>     14.773      0.000 </v>
+  <v>     14.829      0.006 </v>
+  <v>     14.829      0.061 </v>
+  <v>     14.829      0.004 </v>
+  <v>     14.840      0.000 </v>
+  <v>     14.840      0.000 </v>
+  <v>     14.842      0.003 </v>
+  <v>     14.842      0.002 </v>
+  <v>     14.842      0.001 </v>
+  <v>     14.843     40.107 </v>
+  <v>     14.843     38.452 </v>
+  <v>     14.843     40.603 </v>
+  <v>     14.844      0.021 </v>
+  <v>     14.844      0.015 </v>
+  <v>     14.844      0.016 </v>
+  <v>     14.844      0.023 </v>
+  <v>     14.844      0.021 </v>
+  <v>     14.854    267.813 </v>
+  <v>     14.854    264.236 </v>
+  <v>     14.854    257.099 </v>
+  <v>     14.857      0.024 </v>
+  <v>     14.857      0.019 </v>
+  <v>     14.857      0.020 </v>
+  <v>     14.860      0.003 </v>
+  <v>     14.863      0.000 </v>
+  <v>     14.864      0.004 </v>
+  <v>     14.864      0.003 </v>
+  <v>     14.865      0.000 </v>
+  <v>     14.865      0.000 </v>
+  <v>     14.865      0.000 </v>
+  <v>     14.869      0.000 </v>
+  <v>     14.869      0.000 </v>
+  <v>     14.869      0.000 </v>
+  <v>     14.870      0.008 </v>
+  <v>     14.870      0.000 </v>
+  <v>     14.870      0.008 </v>
+  <v>     14.871      0.000 </v>
+  <v>     14.871      0.000 </v>
+  <v>     14.878     81.948 </v>
+  <v>     14.878     82.330 </v>
+  <v>     14.878     86.732 </v>
+  <v>     14.879      0.018 </v>
+  <v>     14.879      0.030 </v>
+  <v>     14.879      0.005 </v>
+  <v>     14.883      0.012 </v>
+  <v>     14.883      0.013 </v>
+  <v>     14.883      0.012 </v>
+  <v>     14.884      4.257 </v>
+  <v>     14.884      3.677 </v>
+  <v>     14.884      4.125 </v>
+  <v>     14.885      0.377 </v>
+  <v>     14.886      0.000 </v>
+  <v>     14.889      0.000 </v>
+  <v>     14.889      0.007 </v>
+  <v>     14.890      0.000 </v>
+  <v>     14.891      0.000 </v>
+  <v>     14.891      0.000 </v>
+  <v>     14.891      0.000 </v>
+  <v>     14.891      0.001 </v>
+  <v>     14.891      0.001 </v>
+  <v>     14.891      0.000 </v>
+  <v>     14.892      0.009 </v>
+  <v>     14.892      0.001 </v>
+  <v>     14.892      0.001 </v>
+  <v>     14.892      0.000 </v>
+  <v>     14.892      0.000 </v>
+  <v>     14.892      0.312 </v>
+  <v>     14.892      0.316 </v>
+  <v>     14.892      0.360 </v>
+  <v>     14.893      0.004 </v>
+  <v>     14.893      0.007 </v>
+  <v>     14.893      0.003 </v>
+  <v>     14.894      0.000 </v>
+  <v>     14.894      0.000 </v>
+  <v>     14.895      5.144 </v>
+  <v>     14.895      5.044 </v>
+  <v>     14.895      4.913 </v>
+  <v>     14.902      0.003 </v>
+  <v>     14.902      0.003 </v>
+  <v>     14.902      0.010 </v>
+  <v>     14.911      0.063 </v>
+  <v>     14.943      0.028 </v>
+  <v>     14.943      0.423 </v>
+  <v>     14.943      0.031 </v>
+  <v>     14.948      0.286 </v>
+  <v>     14.967      0.004 </v>
+  <v>     14.967      0.003 </v>
+  <v>     14.967      0.001 </v>
+  <v>     14.968      0.000 </v>
+  <v>     14.968      0.000 </v>
+  <v>     14.969      0.028 </v>
+  <v>     14.969      0.023 </v>
+  <v>     14.969      0.023 </v>
+  <v>     14.969    139.383 </v>
+  <v>     14.969    136.080 </v>
+  <v>     14.969    141.660 </v>
+  <v>     14.970      0.233 </v>
+  <v>     14.970      0.105 </v>
+  <v>     14.972      0.029 </v>
+  <v>     14.972      0.024 </v>
+  <v>     14.972      0.383 </v>
+  <v>     14.976      0.016 </v>
+  <v>     14.976      0.009 </v>
+  <v>     14.976      0.026 </v>
+  <v>     14.979      0.000 </v>
+  <v>     14.979      0.000 </v>
+  <v>     14.981      0.018 </v>
+  <v>     14.981      0.022 </v>
+  <v>     14.981      0.285 </v>
+  <v>     14.982     43.376 </v>
+  <v>     14.982     47.439 </v>
+  <v>     14.982     36.675 </v>
+  <v>     14.984      0.003 </v>
+  <v>     14.984      0.004 </v>
+  <v>     14.984      0.011 </v>
+  <v>     14.984      0.044 </v>
+  <v>     14.984      0.005 </v>
+  <v>     14.984      0.021 </v>
+  <v>     14.987      0.003 </v>
+  <v>     14.987      0.007 </v>
+  <v>     14.987      0.032 </v>
+  <v>     14.987      0.029 </v>
+  <v>     14.987      0.007 </v>
+  <v>     14.987      1.845 </v>
+  <v>     14.987      0.124 </v>
+  <v>     14.987      0.119 </v>
+  <v>     14.988      0.031 </v>
+  <v>     14.990      0.000 </v>
+  <v>     14.990      0.000 </v>
+  <v>     14.991      0.008 </v>
+  <v>     14.991      0.007 </v>
+  <v>     14.991      0.003 </v>
+  <v>     14.992      0.000 </v>
+  <v>     14.992      0.141 </v>
+  <v>     14.993     21.519 </v>
+  <v>     14.993     21.381 </v>
+  <v>     14.993     23.622 </v>
+  <v>     14.995      0.204 </v>
+  <v>     14.995      0.985 </v>
+  <v>     14.995      0.730 </v>
+  <v>     14.996      0.020 </v>
+  <v>     14.996      0.007 </v>
+  <v>     14.996      0.016 </v>
+  <v>     14.997      0.000 </v>
+  <v>     14.998      0.013 </v>
+  <v>     14.998      0.003 </v>
+  <v>     14.998      0.006 </v>
+  <v>     15.000      0.210 </v>
+  <v>     15.000      0.699 </v>
+  <v>     15.000      1.542 </v>
+  <v>     15.000      1.521 </v>
+  <v>     15.000      1.525 </v>
+  <v>     15.001      0.187 </v>
+  <v>     15.001      0.022 </v>
+  <v>     15.001      0.330 </v>
+  <v>     15.002      0.000 </v>
+  <v>     15.002      0.000 </v>
+  <v>     15.002      0.000 </v>
+  <v>     15.002      0.002 </v>
+  <v>     15.002      0.000 </v>
+  <v>     15.003     11.051 </v>
+  <v>     15.003     10.723 </v>
+  <v>     15.003     11.679 </v>
+  <v>     15.003      0.003 </v>
+  <v>     15.003      0.026 </v>
+  <v>     15.003      0.023 </v>
+  <v>     15.003      0.000 </v>
+  <v>     15.006      0.272 </v>
+  <v>     15.006      0.086 </v>
+  <v>     15.006      0.137 </v>
+  <v>     15.006      0.001 </v>
+  <v>     15.006      0.017 </v>
+  <v>     15.006      0.005 </v>
+  <v>     15.008      0.000 </v>
+  <v>     15.008      0.000 </v>
+  <v>     15.008      0.015 </v>
+  <v>     15.008      0.008 </v>
+  <v>     15.008      0.001 </v>
+  <v>     15.009      0.457 </v>
+  <v>     15.009      0.001 </v>
+  <v>     15.010      0.252 </v>
+  <v>     15.010      0.083 </v>
+  <v>     15.010      0.125 </v>
+  <v>     15.010      0.187 </v>
+  <v>     15.010      0.217 </v>
+  <v>     15.010      0.032 </v>
+  <v>     15.010      0.041 </v>
+  <v>     15.010      0.040 </v>
+  <v>     15.010      0.377 </v>
+  <v>     15.010      0.363 </v>
+  <v>     15.010      0.333 </v>
+  <v>     15.010      0.000 </v>
+  <v>     15.010      0.000 </v>
+  <v>     15.010      0.000 </v>
+  <v>     15.011      0.000 </v>
+  <v>     15.011      0.005 </v>
+  <v>     15.011      0.002 </v>
+  <v>     15.012      0.034 </v>
+  <v>     15.012      0.028 </v>
+  <v>     15.014      0.021 </v>
+  <v>     15.015      0.024 </v>
+  <v>     15.015      0.056 </v>
+  <v>     15.015      0.029 </v>
+  <v>     15.015      0.000 </v>
+  <v>     15.015      0.000 </v>
+  <v>     15.015      0.020 </v>
+  <v>     15.015      0.016 </v>
+  <v>     15.015      0.009 </v>
+  <v>     15.015      5.233 </v>
+  <v>     15.015      5.307 </v>
+  <v>     15.015      5.282 </v>
+  <v>     15.016      0.245 </v>
+  <v>     15.017      0.018 </v>
+  <v>     15.017      0.091 </v>
+  <v>     15.017      0.007 </v>
+  <v>     15.017      0.000 </v>
+  <v>     15.017      0.001 </v>
+  <v>     15.017      0.001 </v>
+  <v>     15.017      0.000 </v>
+  <v>     15.017      0.000 </v>
+  <v>     15.018      0.052 </v>
+  <v>     15.018      0.105 </v>
+  <v>     15.018      0.061 </v>
+  <v>     15.018      0.066 </v>
+  <v>     15.018      0.036 </v>
+  <v>     15.018      0.057 </v>
+  <v>     15.019      0.164 </v>
+  <v>     15.019      0.180 </v>
+  <v>     15.019      2.810 </v>
+  <v>     15.019      3.049 </v>
+  <v>     15.019      3.031 </v>
+  <v>     15.020      0.002 </v>
+  <v>     15.020      0.002 </v>
+  <v>     15.020      0.004 </v>
+  <v>     15.020      0.044 </v>
+  <v>     15.020      0.064 </v>
+  <v>     15.020      0.030 </v>
+  <v>     15.020      0.000 </v>
+  <v>     15.020      0.000 </v>
+  <v>     15.021      0.054 </v>
+  <v>     15.021      0.004 </v>
+  <v>     15.021      0.004 </v>
+  <v>     15.021      0.000 </v>
+  <v>     15.021      0.000 </v>
+  <v>     15.021      0.000 </v>
+  <v>     15.022      0.004 </v>
+  <v>     15.022      0.008 </v>
+  <v>     15.022      0.003 </v>
+  <v>     15.022      0.000 </v>
+  <v>     15.022      0.000 </v>
+  <v>     15.023      0.000 </v>
+  <v>     15.023      0.032 </v>
+  <v>     15.023      0.028 </v>
+  <v>     15.038      0.106 </v>
+  <v>     15.038      0.189 </v>
+  <v>     15.038      0.164 </v>
+  <v>     15.041      0.253 </v>
+  <v>     15.041      0.175 </v>
+  <v>     15.041      0.147 </v>
+  <v>     15.041      0.460 </v>
+  <v>     15.041      0.056 </v>
+  <v>     15.041      0.032 </v>
+  <v>     15.042     99.510 </v>
+  <v>     15.042     98.147 </v>
+  <v>     15.042     97.066 </v>
+  <v>     15.044      0.054 </v>
+  <v>     15.046      0.011 </v>
+  <v>     15.046      0.020 </v>
+  <v>     15.046      0.014 </v>
+  <v>     15.047      0.000 </v>
+  <v>     15.047      0.000 </v>
+  <v>     15.048      0.002 </v>
+  <v>     15.048      0.002 </v>
+  <v>     15.048      0.000 </v>
+  <v>     15.048      0.000 </v>
+  <v>     15.050      0.362 </v>
+  <v>     15.050      0.429 </v>
+  <v>     15.052     38.742 </v>
+  <v>     15.052     39.328 </v>
+  <v>     15.052     37.563 </v>
+  <v>     15.062      0.000 </v>
+  <v>     15.062      0.000 </v>
+  <v>     15.062      0.000 </v>
+  <v>     15.063      0.000 </v>
+  <v>     15.063      0.000 </v>
+  <v>     15.063      0.000 </v>
+  <v>     15.063      0.000 </v>
+  <v>     15.063      0.003 </v>
+  <v>     15.063      0.000 </v>
+  <v>     15.068     69.215 </v>
+  <v>     15.068     68.949 </v>
+  <v>     15.068     68.893 </v>
+  <v>     15.069      0.414 </v>
+  <v>     15.069      0.704 </v>
+  <v>     15.069      0.519 </v>
+  <v>     15.086      0.511 </v>
+  <v>     15.094      0.000 </v>
+  <v>     15.094      0.000 </v>
+  <v>     15.098      0.001 </v>
+  <v>     15.098      0.000 </v>
+  <v>     15.098      0.001 </v>
+  <v>     15.107      0.003 </v>
+  <v>     15.107      0.000 </v>
+  <v>     15.107      0.001 </v>
+  <v>     15.110      0.000 </v>
+  <v>     15.133    601.716 </v>
+  <v>     15.133    607.280 </v>
+  <v>     15.133    610.998 </v>
+  <v>     15.197      1.091 </v>
+  <v>     15.197      1.019 </v>
+  <v>     15.197      3.039 </v>
+  <v>     15.200      0.000 </v>
+  <v>     15.201      0.298 </v>
+  <v>     15.206      0.259 </v>
+  <v>     15.206      2.188 </v>
+  <v>     15.207      0.011 </v>
+  <v>     15.207      0.012 </v>
+  <v>     15.207      0.009 </v>
+  <v>     15.209      0.009 </v>
+  <v>     15.209      0.010 </v>
+  <v>     15.209      0.019 </v>
+  <v>     15.210      0.001 </v>
+  <v>     15.210      0.000 </v>
+  <v>     15.210      0.000 </v>
+  <v>     15.211      0.000 </v>
+  <v>     15.211      0.000 </v>
+  <v>     15.213      0.372 </v>
+  <v>     15.213      1.341 </v>
+  <v>     15.213      4.308 </v>
+  <v>     15.216      1.238 </v>
+  <v>     15.216      3.084 </v>
+  <v>     15.216      4.106 </v>
+  <v>     15.227      0.184 </v>
+  <v>     15.227      1.534 </v>
+  <v>     15.227      0.128 </v>
+  <v>     15.227     72.983 </v>
+  <v>     15.227     78.125 </v>
+  <v>     15.227     85.371 </v>
+  <v>     15.227      0.006 </v>
+  <v>     15.227      0.007 </v>
+  <v>     15.227      0.007 </v>
+  <v>     15.230      0.059 </v>
+  <v>     15.230      0.233 </v>
+  <v>     15.231      0.002 </v>
+  <v>     15.231      0.000 </v>
+  <v>     15.231      0.000 </v>
+  <v>     15.231      0.002 </v>
+  <v>     15.231      0.003 </v>
+  <v>     15.231      0.006 </v>
+  <v>     15.232      0.000 </v>
+  <v>     15.232      0.000 </v>
+  <v>     15.233     21.808 </v>
+  <v>     15.233     22.085 </v>
+  <v>     15.233     22.116 </v>
+  <v>     15.234      0.000 </v>
+  <v>     15.235      0.003 </v>
+  <v>     15.235      0.002 </v>
+  <v>     15.235      0.003 </v>
+  <v>     15.235      0.003 </v>
+  <v>     15.245      0.000 </v>
+  <v>     15.245      0.000 </v>
+  <v>     15.245      0.000 </v>
+  <v>     15.246      0.130 </v>
+  <v>     15.246      0.144 </v>
+  <v>     15.250      0.000 </v>
+  <v>     15.250      0.000 </v>
+  <v>     15.250      0.000 </v>
+  <v>     15.250      0.000 </v>
+  <v>     15.250      0.569 </v>
+  <v>     15.250      0.755 </v>
+  <v>     15.250      0.547 </v>
+  <v>     15.251      0.000 </v>
+  <v>     15.251      0.000 </v>
+  <v>     15.252      0.000 </v>
+  <v>     15.252      0.000 </v>
+  <v>     15.252      0.000 </v>
+  <v>     15.252      0.000 </v>
+  <v>     15.252      0.007 </v>
+  <v>     15.252      0.004 </v>
+  <v>     15.252      0.004 </v>
+  <v>     15.254      0.023 </v>
+  <v>     15.254      0.019 </v>
+  <v>     15.254      0.021 </v>
+  <v>     15.256      0.158 </v>
+  <v>     15.256      0.414 </v>
+  <v>     15.256      0.146 </v>
+  <v>     15.257      0.000 </v>
+  <v>     15.257      0.000 </v>
+  <v>     15.257      0.000 </v>
+  <v>     15.258      0.003 </v>
+  <v>     15.258      0.002 </v>
+  <v>     15.258      0.002 </v>
+  <v>     15.260     14.175 </v>
+  <v>     15.260     15.969 </v>
+  <v>     15.260     15.447 </v>
+  <v>     15.261      0.081 </v>
+  <v>     15.261      0.053 </v>
+  <v>     15.261      0.000 </v>
+  <v>     15.261      0.000 </v>
+  <v>     15.265     37.676 </v>
+  <v>     15.265     36.966 </v>
+  <v>     15.265     35.047 </v>
+  <v>     15.265      0.000 </v>
+  <v>     15.269      0.000 </v>
+  <v>     15.274     22.405 </v>
+  <v>     15.274     22.531 </v>
+  <v>     15.274     21.795 </v>
+  <v>     15.274      0.000 </v>
+  <v>     15.274      0.000 </v>
+  <v>     15.274      0.000 </v>
+  <v>     15.274      0.001 </v>
+  <v>     15.274      0.000 </v>
+  <v>     15.276      0.000 </v>
+  <v>     15.276      0.000 </v>
+  <v>     15.276      0.000 </v>
+  <v>     15.276      0.000 </v>
+  <v>     15.276      0.000 </v>
+  <v>     15.277      0.007 </v>
+  <v>     15.277      0.007 </v>
+  <v>     15.277      0.042 </v>
+  <v>     15.277      0.001 </v>
+  <v>     15.277      0.001 </v>
+  <v>     15.277      0.002 </v>
+  <v>     15.279      0.000 </v>
+  <v>     15.281      1.859 </v>
+  <v>     15.281      1.819 </v>
+  <v>     15.281      2.015 </v>
+  <v>     15.283      0.038 </v>
+  <v>     15.302     69.994 </v>
+  <v>     15.302     71.034 </v>
+  <v>     15.302     70.918 </v>
+  <v>     15.303      0.000 </v>
+  <v>     15.303      0.000 </v>
+  <v>     15.306      0.001 </v>
+  <v>     15.306      0.013 </v>
+  <v>     15.306      0.001 </v>
+  <v>     15.308      0.000 </v>
+  <v>     15.310      6.589 </v>
+  <v>     15.310      6.482 </v>
+  <v>     15.310      6.532 </v>
+  <v>     15.311      0.000 </v>
+  <v>     15.311      0.000 </v>
+  <v>     15.312      0.149 </v>
+  <v>     15.312      0.145 </v>
+  <v>     15.312      0.141 </v>
+  <v>     15.314      0.000 </v>
+  <v>     15.314      0.000 </v>
+  <v>     15.314      0.000 </v>
+  <v>     15.316      1.206 </v>
+  <v>     15.316      1.174 </v>
+  <v>     15.316      1.183 </v>
+  <v>     15.319      0.001 </v>
+  <v>     15.319      0.000 </v>
+  <v>     15.319      0.000 </v>
+  <v>     15.319      0.007 </v>
+  <v>     15.319      0.001 </v>
+  <v>     15.319      0.000 </v>
+  <v>     15.320      0.000 </v>
+  <v>     15.320      0.000 </v>
+  <v>     15.320      0.240 </v>
+  <v>     15.320      0.241 </v>
+  <v>     15.320      0.212 </v>
+  <v>     15.322      0.000 </v>
+  <v>     15.324      0.000 </v>
+  <v>     15.324      0.000 </v>
+  <v>     15.324      0.001 </v>
+  <v>     15.326      0.000 </v>
+  <v>     15.326      0.000 </v>
+  <v>     15.326      0.000 </v>
+  <v>     15.326      0.000 </v>
+  <v>     15.327      0.000 </v>
+  <v>     15.327      0.000 </v>
+  <v>     15.327      0.000 </v>
+  <v>     15.328      0.000 </v>
+  <v>     15.328      0.001 </v>
+  <v>     15.328      0.001 </v>
+  <v>     15.328      0.001 </v>
+  <v>     15.330      0.000 </v>
+  <v>     15.330      0.000 </v>
+  <v>     15.330      0.000 </v>
+  <v>     15.330     32.435 </v>
+  <v>     15.330     32.608 </v>
+  <v>     15.330     32.484 </v>
+  <v>     15.333      0.001 </v>
+  <v>     15.333      0.000 </v>
+  <v>     15.333      0.000 </v>
+  <v>     15.333      0.000 </v>
+  <v>     15.333      0.000 </v>
+  <v>     15.333      0.000 </v>
+  <v>     15.337      0.516 </v>
+  <v>     15.337      0.504 </v>
+  <v>     15.337      0.493 </v>
+  <v>     15.339      0.198 </v>
+  <v>     15.339      0.222 </v>
+  <v>     15.339      0.221 </v>
+  <v>     15.340      0.000 </v>
+  <v>     15.340      0.000 </v>
+  <v>     15.340      0.000 </v>
+  <v>     15.342      0.002 </v>
+  <v>     15.342      0.001 </v>
+  <v>     15.399   1185.193 </v>
+  <v>     15.399   1185.444 </v>
+  <v>     15.399   1184.744 </v>
+  <v>     15.446      0.012 </v>
+  <v>     15.462      0.000 </v>
+  <v>     15.466      0.000 </v>
+  <v>     15.466      0.000 </v>
+  <v>     15.467      0.922 </v>
+  <v>     15.467      0.892 </v>
+  <v>     15.467      0.864 </v>
+  <v>     15.611      0.000 </v>
+  <v>     15.611      0.000 </v>
+  <v>     15.611      0.000 </v>
+  <v>     15.612      0.000 </v>
+  <v>     15.612      0.000 </v>
+  <v>     15.613      0.000 </v>
+  <v>     15.632      0.022 </v>
+  <v>     15.632      0.306 </v>
+  <v>     15.632      0.036 </v>
+  <v>     15.635      0.000 </v>
+  <v>     15.635      0.000 </v>
+  <v>     15.635      0.000 </v>
+  <v>     15.638      0.000 </v>
+  <v>     15.638      0.000 </v>
+  <v>     15.638      0.000 </v>
+  <v>     15.639      1.618 </v>
+  <v>     15.639      1.812 </v>
+  <v>     15.639      1.601 </v>
+  <v>     15.639      0.001 </v>
+  <v>     15.639      0.001 </v>
+  <v>     15.639      0.001 </v>
+  <v>     15.643      0.070 </v>
+  <v>     15.643      0.161 </v>
+  <v>     15.645    149.537 </v>
+  <v>     15.645    148.299 </v>
+  <v>     15.645    149.526 </v>
+  <v>     15.647      0.004 </v>
+  <v>     15.647      0.006 </v>
+  <v>     15.647      0.005 </v>
+  <v>     15.662      0.163 </v>
+  <v>     15.669     38.406 </v>
+  <v>     15.669     37.350 </v>
+  <v>     15.669     36.127 </v>
+  <v>     15.671      0.015 </v>
+  <v>     15.671      0.016 </v>
+  <v>     15.671      0.015 </v>
+  <v>     15.673      0.000 </v>
+  <v>     15.673      0.000 </v>
+  <v>     15.673      0.015 </v>
+  <v>     15.673      0.019 </v>
+  <v>     15.673      0.002 </v>
+  <v>     15.675      0.000 </v>
+  <v>     15.683      0.002 </v>
+  <v>     15.683      0.002 </v>
+  <v>     15.683      0.002 </v>
+  <v>     15.683      0.175 </v>
+  <v>     15.683      0.687 </v>
+  <v>     15.687      0.988 </v>
+  <v>     15.687      0.927 </v>
+  <v>     15.687      0.654 </v>
+  <v>     15.688      0.000 </v>
+  <v>     15.688      0.000 </v>
+  <v>     15.688      0.000 </v>
+  <v>     15.692     65.107 </v>
+  <v>     15.692     67.920 </v>
+  <v>     15.692     75.076 </v>
+  <v>     15.693      0.062 </v>
+  <v>     15.696      0.000 </v>
+  <v>     15.697      0.000 </v>
+  <v>     15.697      0.000 </v>
+  <v>     15.699     58.051 </v>
+  <v>     15.699     63.160 </v>
+  <v>     15.699     65.357 </v>
+  <v>     15.709      0.043 </v>
+  <v>     15.709      0.039 </v>
+  <v>     15.709      0.035 </v>
+  <v>     15.723      0.000 </v>
+  <v>     15.723      0.000 </v>
+  <v>     15.725      0.003 </v>
+  <v>     15.725      0.001 </v>
+  <v>     15.725      0.006 </v>
+  <v>     15.729      0.000 </v>
+  <v>     15.729      0.000 </v>
+  <v>     15.729      0.000 </v>
+  <v>     15.729      0.000 </v>
+  <v>     15.741      0.000 </v>
+  <v>     15.741      0.001 </v>
+  <v>     15.741      0.000 </v>
+  <v>     15.741      0.000 </v>
+  <v>     15.742      0.040 </v>
+  <v>     15.742      0.036 </v>
+  <v>     15.742      0.035 </v>
+  <v>     15.752      0.003 </v>
+  <v>     15.752      0.003 </v>
+  <v>     15.753      6.104 </v>
+  <v>     15.753      6.060 </v>
+  <v>     15.753      6.020 </v>
+  <v>     15.757      0.000 </v>
+  <v>     15.758      0.000 </v>
+  <v>     15.758      0.000 </v>
+  <v>     15.758      0.000 </v>
+  <v>     15.759      0.065 </v>
+  <v>     15.759      0.071 </v>
+  <v>     15.759      0.064 </v>
+  <v>     15.759      0.000 </v>
+  <v>     15.759      0.000 </v>
+  <v>     15.760      0.000 </v>
+  <v>     15.760      0.000 </v>
+  <v>     15.760      0.000 </v>
+  <v>     15.762     58.977 </v>
+  <v>     15.762     59.736 </v>
+  <v>     15.762     59.701 </v>
+  <v>     15.764      0.000 </v>
+  <v>     15.764      0.000 </v>
+  <v>     15.766      0.000 </v>
+  <v>     15.766      0.000 </v>
+  <v>     15.766      0.000 </v>
+  <v>     15.771      0.000 </v>
+  <v>     15.771      0.000 </v>
+  <v>     15.771      0.000 </v>
+  <v>     15.772      0.000 </v>
+  <v>     15.772      0.001 </v>
+  <v>     15.772      0.000 </v>
+  <v>     15.774      0.000 </v>
+  <v>     15.774      0.000 </v>
+  <v>     15.775      4.419 </v>
+  <v>     15.775      4.472 </v>
+  <v>     15.775      4.381 </v>
+  <v>     15.776      0.000 </v>
+  <v>     15.785      0.755 </v>
+  <v>     15.785      0.738 </v>
+  <v>     15.785      0.726 </v>
+  <v>     15.786      0.004 </v>
+  <v>     15.797    422.744 </v>
+  <v>     15.797    426.714 </v>
+  <v>     15.797    430.298 </v>
+  <v>     15.863     51.080 </v>
+  <v>     15.863     52.287 </v>
+  <v>     15.863     50.837 </v>
+  <v>     15.866      0.001 </v>
+  <v>     15.866      0.000 </v>
+  <v>     15.866      0.000 </v>
+  <v>     15.866      0.179 </v>
+  <v>     15.867      0.000 </v>
+  <v>     15.867      0.000 </v>
+  <v>     15.867      0.000 </v>
+  <v>     15.868      0.007 </v>
+  <v>     15.868      0.007 </v>
+  <v>     15.868      0.008 </v>
+  <v>     15.873      0.001 </v>
+  <v>     15.873      0.000 </v>
+  <v>     15.873      0.000 </v>
+  <v>     15.877      3.694 </v>
+  <v>     15.877      3.039 </v>
+  <v>     15.877      2.790 </v>
+  <v>     15.877      0.134 </v>
+  <v>     15.877      0.029 </v>
+  <v>     15.886      0.002 </v>
+  <v>     15.886      0.003 </v>
+  <v>     15.886      0.002 </v>
+  <v>     15.886      0.000 </v>
+  <v>     15.887      0.000 </v>
+  <v>     15.887      0.000 </v>
+  <v>     15.889      0.048 </v>
+  <v>     15.889      0.041 </v>
+  <v>     15.889      0.405 </v>
+  <v>     15.900      0.025 </v>
+  <v>     15.900      0.024 </v>
+  <v>     15.900      0.020 </v>
+  <v>     15.918    659.475 </v>
+  <v>     15.918    665.749 </v>
+  <v>     15.918    670.890 </v>
+  <v>     15.935      0.087 </v>
+  <v>     15.944      0.000 </v>
+  <v>     15.944      0.000 </v>
+  <v>     15.944      0.000 </v>
+  <v>     15.944      0.000 </v>
+  <v>     15.944      0.000 </v>
+  <v>     15.946      0.001 </v>
+  <v>     15.946      0.000 </v>
+  <v>     15.946      0.000 </v>
+  <v>     15.948      0.080 </v>
+  <v>     15.948      0.074 </v>
+  <v>     15.948      0.033 </v>
+  <v>     15.951     12.231 </v>
+  <v>     15.951     11.874 </v>
+  <v>     15.951     12.219 </v>
+  <v>     15.951      0.000 </v>
+  <v>     15.952      0.000 </v>
+  <v>     15.952      0.016 </v>
+  <v>     15.952      0.018 </v>
+  <v>     15.952      0.017 </v>
+  <v>     15.952      0.001 </v>
+  <v>     15.952      0.000 </v>
+  <v>     15.952      0.000 </v>
+  <v>     15.953      0.000 </v>
+  <v>     15.953      0.000 </v>
+  <v>     16.042      0.000 </v>
+  <v>     16.042      0.000 </v>
+  <v>     16.044      0.000 </v>
+  <v>     16.044      0.000 </v>
+  <v>     16.044      0.000 </v>
+  <v>     16.048      0.001 </v>
+  <v>     16.048      0.000 </v>
+  <v>     16.048      0.000 </v>
+  <v>     16.050      9.203 </v>
+  <v>     16.050      9.230 </v>
+  <v>     16.050      9.086 </v>
+  <v>     16.052      0.000 </v>
+  <v>     16.053      0.000 </v>
+  <v>     16.054      0.008 </v>
+  <v>     16.054      0.009 </v>
+  <v>     16.054      0.008 </v>
+  <v>     16.055      0.000 </v>
+  <v>     16.055      0.000 </v>
+  <v>     16.055      0.000 </v>
+  <v>     16.058      0.000 </v>
+  <v>     16.058      0.000 </v>
+  <v>     16.059     19.620 </v>
+  <v>     16.059     19.718 </v>
+  <v>     16.059     19.606 </v>
+  <v>     16.068      0.000 </v>
+  <v>     16.068      0.000 </v>
+  <v>     16.068      0.000 </v>
+  <v>     16.074      1.739 </v>
+  <v>     16.074      1.761 </v>
+  <v>     16.074      1.677 </v>
+  <v>     16.075      0.000 </v>
+  <v>     16.075      0.000 </v>
+  <v>     16.075      0.000 </v>
+  <v>     16.081      0.001 </v>
+  <v>     16.081      0.000 </v>
+  <v>     16.081      0.001 </v>
+  <v>     16.082      0.000 </v>
+  <v>     16.082      0.000 </v>
+  <v>     16.082      0.000 </v>
+  <v>     16.082      0.000 </v>
+  <v>     16.082      0.000 </v>
+  <v>     16.083      0.000 </v>
+  <v>     16.084      0.000 </v>
+  <v>     16.084      0.000 </v>
+  <v>     16.084      0.000 </v>
+  <v>     16.084      0.002 </v>
+  <v>     16.084      0.000 </v>
+  <v>     16.087      0.000 </v>
+  <v>     16.088      0.003 </v>
+  <v>     16.088      0.001 </v>
+  <v>     16.088      0.000 </v>
+  <v>     16.088      0.000 </v>
+  <v>     16.088      0.000 </v>
+  <v>     16.092      0.031 </v>
+  <v>     16.092      0.029 </v>
+  <v>     16.092      0.028 </v>
+  <v>     16.093      0.000 </v>
+  <v>     16.093      0.000 </v>
+  <v>     16.093      0.000 </v>
+  <v>     16.093      0.000 </v>
+  <v>     16.093      0.000 </v>
+  <v>     16.093      0.000 </v>
+  <v>     16.094      0.000 </v>
+  <v>     16.095      0.001 </v>
+  <v>     16.095      0.000 </v>
+  <v>     16.108      9.195 </v>
+  <v>     16.108      9.278 </v>
+  <v>     16.108      9.383 </v>
+  <v>     16.108    123.302 </v>
+  <v>     16.108    122.412 </v>
+  <v>     16.108    121.469 </v>
+  <v>     16.136      0.028 </v>
+  <v>     16.150      0.000 </v>
+  <v>     16.150      0.000 </v>
+  <v>     16.150      0.000 </v>
+  <v>     16.150      0.000 </v>
+  <v>     16.150      0.000 </v>
+  <v>     16.150      0.000 </v>
+  <v>     16.162      0.140 </v>
+  <v>     16.162      0.142 </v>
+  <v>     16.162      0.154 </v>
+  <v>     16.168    270.650 </v>
+  <v>     16.168    272.039 </v>
+  <v>     16.168    274.345 </v>
+  <v>     16.282      0.000 </v>
+  <v>     16.282      0.000 </v>
+  <v>     16.282      0.000 </v>
+  <v>     16.286      0.003 </v>
+  <v>     16.286      0.002 </v>
+  <v>     16.286      0.014 </v>
+  <v>     16.287      0.001 </v>
+  <v>     16.287      0.001 </v>
+  <v>     16.287      0.001 </v>
+  <v>     16.287      0.000 </v>
+  <v>     16.287      0.008 </v>
+  <v>     16.292      0.000 </v>
+  <v>     16.292      0.000 </v>
+  <v>     16.292      0.000 </v>
+  <v>     16.296      0.000 </v>
+  <v>     16.296      0.000 </v>
+  <v>     16.297      0.000 </v>
+  <v>     16.299      0.167 </v>
+  <v>     16.299      0.160 </v>
+  <v>     16.299      0.173 </v>
+  <v>     16.299      0.000 </v>
+  <v>     16.299      0.000 </v>
+  <v>     16.300      0.000 </v>
+  <v>     16.300      0.001 </v>
+  <v>     16.300      0.000 </v>
+  <v>     16.301      0.005 </v>
+  <v>     16.301      0.000 </v>
+  <v>     16.308    174.108 </v>
+  <v>     16.308    174.918 </v>
+  <v>     16.308    174.656 </v>
+  <v>     16.327      0.001 </v>
+  <v>     16.327      0.001 </v>
+  <v>     16.327      0.004 </v>
+  <v>     16.327      0.000 </v>
+  <v>     16.327      0.000 </v>
+  <v>     16.329      0.000 </v>
+  <v>     16.337     88.900 </v>
+  <v>     16.337     89.950 </v>
+  <v>     16.337     89.501 </v>
+  <v>     16.340      0.039 </v>
+  <v>     16.340      0.041 </v>
+  <v>     16.340      0.035 </v>
+  <v>     16.348      0.000 </v>
+  <v>     16.348      0.000 </v>
+  <v>     16.348      0.000 </v>
+  <v>     16.350      0.000 </v>
+  <v>     16.350      0.000 </v>
+  <v>     16.350      0.000 </v>
+  <v>     16.352     14.344 </v>
+  <v>     16.352     14.124 </v>
+  <v>     16.352     14.426 </v>
+  <v>     16.354    341.422 </v>
+  <v>     16.354    341.408 </v>
+  <v>     16.354    343.987 </v>
+  <v>     16.405      9.459 </v>
+  <v>     16.405     10.625 </v>
+  <v>     16.405     12.404 </v>
+  <v>     16.409      0.000 </v>
+  <v>     16.409      0.000 </v>
+  <v>     16.409      0.000 </v>
+  <v>     16.409      0.000 </v>
+  <v>     16.409      0.000 </v>
+  <v>     16.410      0.001 </v>
+  <v>     16.410      0.001 </v>
+  <v>     16.410      0.000 </v>
+  <v>     16.412      0.082 </v>
+  <v>     16.412      0.024 </v>
+  <v>     16.412      0.030 </v>
+  <v>     16.413      0.000 </v>
+  <v>     16.414      0.009 </v>
+  <v>     16.414      0.077 </v>
+  <v>     16.415     10.277 </v>
+  <v>     16.415      8.641 </v>
+  <v>     16.415      9.289 </v>
+  <v>     16.419      0.097 </v>
+  <v>     16.421      0.155 </v>
+  <v>     16.421      0.152 </v>
+  <v>     16.421      0.165 </v>
+  <v>     16.425     50.757 </v>
+  <v>     16.425     52.181 </v>
+  <v>     16.425     54.689 </v>
+  <v>     16.430      0.000 </v>
+  <v>     16.430      0.000 </v>
+  <v>     16.430      0.000 </v>
+  <v>     16.430      0.000 </v>
+  <v>     16.430      0.000 </v>
+  <v>     16.431      0.002 </v>
+  <v>     16.431      0.002 </v>
+  <v>     16.431      0.001 </v>
+  <v>     16.437      0.472 </v>
+  <v>     16.437      0.406 </v>
+  <v>     16.437      1.130 </v>
+  <v>     16.437      0.186 </v>
+  <v>     16.437      1.223 </v>
+  <v>     16.438      0.000 </v>
+  <v>     16.443      0.087 </v>
+  <v>     16.445      0.079 </v>
+  <v>     16.445      0.068 </v>
+  <v>     16.445      0.076 </v>
+  <v>     16.457    301.497 </v>
+  <v>     16.457    307.884 </v>
+  <v>     16.457    294.859 </v>
+  <v>     16.504      0.000 </v>
+  <v>     16.504      0.000 </v>
+  <v>     16.504      0.002 </v>
+  <v>     16.507      0.002 </v>
+  <v>     16.507      0.003 </v>
+  <v>     16.513      0.127 </v>
+  <v>     16.513      0.124 </v>
+  <v>     16.513      0.113 </v>
+  <v>     16.518      0.000 </v>
+  <v>     16.519     55.038 </v>
+  <v>     16.519     54.601 </v>
+  <v>     16.519     54.384 </v>
+  <v>     16.520      0.001 </v>
+  <v>     16.520      0.015 </v>
+  <v>     16.520      0.001 </v>
+  <v>     16.520      0.000 </v>
+  <v>     16.520      0.000 </v>
+  <v>     16.521      0.000 </v>
+  <v>     16.521      0.001 </v>
+  <v>     16.521      0.001 </v>
+  <v>     16.526    194.410 </v>
+  <v>     16.526    195.430 </v>
+  <v>     16.526    195.096 </v>
+  <v>     16.528      0.012 </v>
+  <v>     16.553      0.000 </v>
+  <v>     16.553      0.000 </v>
+  <v>     16.555      0.001 </v>
+  <v>     16.555      0.000 </v>
+  <v>     16.555      0.000 </v>
+  <v>     16.556      0.007 </v>
+  <v>     16.556      0.002 </v>
+  <v>     16.558      0.000 </v>
+  <v>     16.567    112.262 </v>
+  <v>     16.567    113.981 </v>
+  <v>     16.567    115.280 </v>
+  <v>     16.570      0.009 </v>
+  <v>     16.575      0.000 </v>
+  <v>     16.578      0.000 </v>
+  <v>     16.578      0.000 </v>
+  <v>     16.578      0.000 </v>
+  <v>     16.578      0.000 </v>
+  <v>     16.578      0.000 </v>
+  <v>     16.578      0.000 </v>
+  <v>     16.580     49.427 </v>
+  <v>     16.580     49.331 </v>
+  <v>     16.580     49.335 </v>
+  <v>     16.582     10.268 </v>
+  <v>     16.582     10.365 </v>
+  <v>     16.582     10.232 </v>
+  <v>     16.583      0.001 </v>
+  <v>     16.583      0.002 </v>
+  <v>     16.583      0.000 </v>
+  <v>     16.583      0.001 </v>
+  <v>     16.583      0.002 </v>
+  <v>     16.586      0.000 </v>
+  <v>     16.586      0.000 </v>
+  <v>     16.588      5.370 </v>
+  <v>     16.588      5.322 </v>
+  <v>     16.588      5.252 </v>
+  <v>     16.590      0.000 </v>
+  <v>     16.633      0.043 </v>
+  <v>     16.633      0.003 </v>
+  <v>     16.633      0.003 </v>
+  <v>     16.636      0.000 </v>
+  <v>     16.636      0.000 </v>
+  <v>     16.636      0.000 </v>
+  <v>     16.637      0.000 </v>
+  <v>     16.637      0.000 </v>
+  <v>     16.638      0.003 </v>
+  <v>     16.638      0.000 </v>
+  <v>     16.638      0.000 </v>
+  <v>     16.638     27.144 </v>
+  <v>     16.638     27.238 </v>
+  <v>     16.638     27.612 </v>
+  <v>     16.640      0.030 </v>
+  <v>     16.640      0.003 </v>
+  <v>     16.640      0.057 </v>
+  <v>     16.640      0.059 </v>
+  <v>     16.640      0.083 </v>
+  <v>     16.641      0.000 </v>
+  <v>     16.641      0.000 </v>
+  <v>     16.641      0.000 </v>
+  <v>     16.641      0.000 </v>
+  <v>     16.641      0.001 </v>
+  <v>     16.641      0.001 </v>
+  <v>     16.643      8.948 </v>
+  <v>     16.643      8.475 </v>
+  <v>     16.643      8.391 </v>
+  <v>     16.645      0.000 </v>
+  <v>     16.646      0.001 </v>
+  <v>     16.646      0.003 </v>
+  <v>     16.648      0.000 </v>
+  <v>     16.650      0.264 </v>
+  <v>     16.650      0.301 </v>
+  <v>     16.650      0.290 </v>
+  <v>     16.700      0.000 </v>
+  <v>     16.700      0.000 </v>
+  <v>     16.700      0.000 </v>
+  <v>     16.700      0.000 </v>
+  <v>     16.702      0.000 </v>
+  <v>     16.702      0.000 </v>
+  <v>     16.702      0.000 </v>
+  <v>     16.702      0.000 </v>
+  <v>     16.702      0.000 </v>
+  <v>     16.705      0.000 </v>
+  <v>     16.705      0.000 </v>
+  <v>     16.705      0.000 </v>
+  <v>     16.705      0.000 </v>
+  <v>     16.705      0.000 </v>
+  <v>     16.706      0.000 </v>
+  <v>     16.706      0.000 </v>
+  <v>     16.706      0.000 </v>
+  <v>     16.706      0.000 </v>
+  <v>     16.713     97.361 </v>
+  <v>     16.713     98.902 </v>
+  <v>     16.713     94.284 </v>
+  <v>     16.713      5.570 </v>
+  <v>     16.714     20.470 </v>
+  <v>     16.714     20.293 </v>
+  <v>     16.714     20.475 </v>
+  <v>     16.815      0.000 </v>
+  <v>     16.815      0.000 </v>
+  <v>     16.819      0.000 </v>
+  <v>     16.819      0.001 </v>
+  <v>     16.819      0.000 </v>
+  <v>     16.821      0.000 </v>
+  <v>     16.823     20.390 </v>
+  <v>     16.823     20.277 </v>
+  <v>     16.823     20.097 </v>
+  <v>     16.823      0.000 </v>
+  <v>     16.823      0.000 </v>
+  <v>     16.823      0.000 </v>
+  <v>     16.831      0.000 </v>
+  <v>     16.831      0.000 </v>
+  <v>     16.831      0.000 </v>
+  <v>     16.837      0.001 </v>
+  <v>     16.837      0.001 </v>
+  <v>     16.851      2.048 </v>
+  <v>     16.851      2.051 </v>
+  <v>     16.851      2.076 </v>
+  <v>     16.853    272.841 </v>
+  <v>     16.853    273.266 </v>
+  <v>     16.853    272.521 </v>
+  <v>     16.856      0.005 </v>
+  <v>     16.902      0.000 </v>
+  <v>     16.902      0.000 </v>
+  <v>     16.902      0.000 </v>
+  <v>     16.903      0.120 </v>
+  <v>     16.903      0.189 </v>
+  <v>     16.903      0.031 </v>
+  <v>     16.916      0.000 </v>
+  <v>     16.916      0.000 </v>
+  <v>     16.916      0.000 </v>
+  <v>     16.917      0.000 </v>
+  <v>     16.920     51.616 </v>
+  <v>     16.920     51.980 </v>
+  <v>     16.920     50.690 </v>
+  <v>     16.923      0.000 </v>
+  <v>     16.923      0.000 </v>
+  <v>     16.923      0.000 </v>
+  <v>     16.923      0.000 </v>
+  <v>     16.923      0.000 </v>
+  <v>     16.923      0.000 </v>
+  <v>     16.923      0.000 </v>
+  <v>     16.923      0.000 </v>
+  <v>     16.923      0.000 </v>
+  <v>     16.924      0.016 </v>
+  <v>     16.924      0.016 </v>
+  <v>     16.924      0.015 </v>
+  <v>     16.926      0.142 </v>
+  <v>     16.926      0.126 </v>
+  <v>     16.929      0.000 </v>
+  <v>     16.929      0.000 </v>
+  <v>     16.929      0.000 </v>
+  <v>     16.930      0.000 </v>
+  <v>     16.930      0.000 </v>
+  <v>     16.930      0.000 </v>
+  <v>     16.931      0.026 </v>
+  <v>     16.931      0.024 </v>
+  <v>     16.936      0.000 </v>
+  <v>     16.936      0.000 </v>
+  <v>     16.936      5.539 </v>
+  <v>     16.936      6.155 </v>
+  <v>     16.936      5.038 </v>
+  <v>     16.936      0.000 </v>
+  <v>     16.938      3.418 </v>
+  <v>     16.938      3.898 </v>
+  <v>     16.938      4.521 </v>
+  <v>     16.938      0.000 </v>
+  <v>     16.938      0.000 </v>
+  <v>     16.938      0.000 </v>
+  <v>     16.939      0.000 </v>
+  <v>     16.939      0.000 </v>
+  <v>     16.939      0.000 </v>
+  <v>     16.939      0.164 </v>
+  <v>     16.939      0.301 </v>
+  <v>     16.939      0.052 </v>
+  <v>     16.958      3.046 </v>
+  <v>     16.958      3.029 </v>
+  <v>     16.958      2.957 </v>
+  <v>     16.967    684.793 </v>
+  <v>     16.967    687.511 </v>
+  <v>     16.967    686.759 </v>
+  <v>     16.968      0.047 </v>
+  <v>     16.978      0.000 </v>
+  <v>     16.978      0.000 </v>
+  <v>     16.978      0.001 </v>
+  <v>     16.980      0.000 </v>
+  <v>     16.980      0.000 </v>
+  <v>     16.980      0.000 </v>
+  <v>     16.983      0.000 </v>
+  <v>     16.986      0.000 </v>
+  <v>     16.986      0.001 </v>
+  <v>     17.007      0.724 </v>
+  <v>     17.007      0.723 </v>
+  <v>     17.007      0.744 </v>
+  <v>     17.128      0.000 </v>
+  <v>     17.128      0.000 </v>
+  <v>     17.128      0.000 </v>
+  <v>     17.135      0.016 </v>
+  <v>     17.135      0.015 </v>
+  <v>     17.135      0.017 </v>
+  <v>     17.137      0.030 </v>
+  <v>     17.140      0.087 </v>
+  <v>     17.140      0.087 </v>
+  <v>     17.141      0.470 </v>
+  <v>     17.141      0.290 </v>
+  <v>     17.141      0.153 </v>
+  <v>     17.148      0.000 </v>
+  <v>     17.148      0.000 </v>
+  <v>     17.148      0.001 </v>
+  <v>     17.148      0.001 </v>
+  <v>     17.148      0.001 </v>
+  <v>     17.148      0.033 </v>
+  <v>     17.148      0.358 </v>
+  <v>     17.148      0.149 </v>
+  <v>     17.149      7.843 </v>
+  <v>     17.149      8.614 </v>
+  <v>     17.149      9.606 </v>
+  <v>     17.152      0.000 </v>
+  <v>     17.166      0.008 </v>
+  <v>     17.166      0.009 </v>
+  <v>     17.166      0.007 </v>
+  <v>     17.170      2.887 </v>
+  <v>     17.170      2.972 </v>
+  <v>     17.170      2.952 </v>
+  <v>     17.171      0.003 </v>
+  <v>     17.171      0.005 </v>
+  <v>     17.171      0.006 </v>
+  <v>     17.173      0.001 </v>
+  <v>     17.173      0.001 </v>
+  <v>     17.212      0.040 </v>
+  <v>     17.228      0.000 </v>
+  <v>     17.228      0.000 </v>
+  <v>     17.228      0.001 </v>
+  <v>     17.230      0.008 </v>
+  <v>     17.230      0.001 </v>
+  <v>     17.231      0.062 </v>
+  <v>     17.231      0.053 </v>
+  <v>     17.231      0.057 </v>
+  <v>     17.233      5.618 </v>
+  <v>     17.233      5.812 </v>
+  <v>     17.233      5.652 </v>
+  <v>     17.241      0.006 </v>
+  <v>     17.241      0.017 </v>
+  <v>     17.241      0.001 </v>
+  <v>     17.241      0.000 </v>
+  <v>     17.241      0.000 </v>
+  <v>     17.241      0.000 </v>
+  <v>     17.241      0.000 </v>
+  <v>     17.242      0.001 </v>
+  <v>     17.242      0.001 </v>
+  <v>     17.242      0.001 </v>
+  <v>     17.242      0.013 </v>
+  <v>     17.242      0.002 </v>
+  <v>     17.252      0.000 </v>
+  <v>     17.252      0.000 </v>
+  <v>     17.252      0.000 </v>
+  <v>     17.254      0.000 </v>
+  <v>     17.254      0.000 </v>
+  <v>     17.254      0.004 </v>
+  <v>     17.254      0.002 </v>
+  <v>     17.257     28.281 </v>
+  <v>     17.257     28.091 </v>
+  <v>     17.257     28.180 </v>
+  <v>     17.257      0.004 </v>
+  <v>     17.257      0.000 </v>
+  <v>     17.257      0.000 </v>
+  <v>     17.259      0.012 </v>
+  <v>     17.259      0.009 </v>
+  <v>     17.259      0.009 </v>
+  <v>     17.263      0.003 </v>
+  <v>     17.263      0.002 </v>
+  <v>     17.264      0.018 </v>
+  <v>     17.268      0.066 </v>
+  <v>     17.268      0.070 </v>
+  <v>     17.268      0.068 </v>
+  <v>     17.271    118.813 </v>
+  <v>     17.271    118.781 </v>
+  <v>     17.271    118.653 </v>
+  <v>     17.273      0.000 </v>
+  <v>     17.273      0.000 </v>
+  <v>     17.273      0.000 </v>
+  <v>     17.274      0.003 </v>
+  <v>     17.274      0.002 </v>
+  <v>     17.274      0.000 </v>
+  <v>     17.275      0.002 </v>
+  <v>     17.275      0.002 </v>
+  <v>     17.275      0.004 </v>
+  <v>     17.275      0.001 </v>
+  <v>     17.275      0.001 </v>
+  <v>     17.275      0.002 </v>
+  <v>     17.275      0.001 </v>
+  <v>     17.275      0.001 </v>
+  <v>     17.275      0.001 </v>
+  <v>     17.275      0.001 </v>
+  <v>     17.275      0.001 </v>
+  <v>     17.275      0.000 </v>
+  <v>     17.275      0.000 </v>
+  <v>     17.277      0.000 </v>
+  <v>     17.278      0.005 </v>
+  <v>     17.278      0.005 </v>
+  <v>     17.278      0.005 </v>
+  <v>     17.285      0.014 </v>
+  <v>     17.303      0.000 </v>
+  <v>     17.303      0.000 </v>
+  <v>     17.303      0.000 </v>
+  <v>     17.303      0.000 </v>
+  <v>     17.303      0.000 </v>
+  <v>     17.304      8.256 </v>
+  <v>     17.304      8.315 </v>
+  <v>     17.304      8.296 </v>
+  <v>     17.306      0.000 </v>
+  <v>     17.306      0.000 </v>
+  <v>     17.306      0.000 </v>
+  <v>     17.306      0.000 </v>
+  <v>     17.309      0.000 </v>
+  <v>     17.309      0.000 </v>
+  <v>     17.309      0.000 </v>
+  <v>     17.310      0.000 </v>
+  <v>     17.310      0.000 </v>
+  <v>     17.310      0.000 </v>
+  <v>     17.325      3.604 </v>
+  <v>     17.325      3.608 </v>
+  <v>     17.325      3.578 </v>
+  <v>     17.326     14.902 </v>
+  <v>     17.326     14.696 </v>
+  <v>     17.326     14.448 </v>
+  <v>     17.326      0.000 </v>
+  <v>     17.326      0.000 </v>
+  <v>     17.326      0.000 </v>
+  <v>     17.333      0.000 </v>
+  <v>     17.333      0.000 </v>
+  <v>     17.340      0.000 </v>
+  <v>     17.340      0.000 </v>
+  <v>     17.340      0.000 </v>
+  <v>     17.341      0.001 </v>
+  <v>     17.341      0.002 </v>
+  <v>     17.341      0.772 </v>
+  <v>     17.341      0.773 </v>
+  <v>     17.341      0.778 </v>
+  <v>     17.342      0.003 </v>
+  <v>     17.342      0.002 </v>
+  <v>     17.342      0.001 </v>
+  <v>     17.344      0.000 </v>
+  <v>     17.355      5.237 </v>
+  <v>     17.355      5.232 </v>
+  <v>     17.355      5.219 </v>
+  <v>     17.359    666.527 </v>
+  <v>     17.359    667.204 </v>
+  <v>     17.359    667.235 </v>
+  <v>     17.378      0.000 </v>
+  <v>     17.378      0.000 </v>
+  <v>     17.378      0.000 </v>
+  <v>     17.378      0.001 </v>
+  <v>     17.378      0.000 </v>
+  <v>     17.379      0.000 </v>
+  <v>     17.379      0.000 </v>
+  <v>     17.379      0.000 </v>
+  <v>     17.379      0.000 </v>
+  <v>     17.380      0.212 </v>
+  <v>     17.380      0.210 </v>
+  <v>     17.380      0.218 </v>
+  <v>     17.383      0.104 </v>
+  <v>     17.560      0.006 </v>
+  <v>     17.560      0.007 </v>
+  <v>     17.560      0.005 </v>
+  <v>     17.566      0.172 </v>
+  <v>     17.566      3.679 </v>
+  <v>     17.566      3.708 </v>
+  <v>     17.566      5.147 </v>
+  <v>     17.572      0.000 </v>
+  <v>     17.583      0.002 </v>
+  <v>     17.583      0.002 </v>
+  <v>     17.583      0.002 </v>
+  <v>     17.585      0.000 </v>
+  <v>     17.631      0.002 </v>
+  <v>     17.631      0.002 </v>
+  <v>     17.631      0.002 </v>
+  <v>     17.631      2.877 </v>
+  <v>     17.631      2.267 </v>
+  <v>     17.631      1.960 </v>
+  <v>     17.631      0.000 </v>
+  <v>     17.631      0.000 </v>
+  <v>     17.631      0.000 </v>
+  <v>     17.636      0.060 </v>
+  <v>     17.636      0.053 </v>
+  <v>     17.639      0.000 </v>
+  <v>     17.642      0.035 </v>
+  <v>     17.642      0.022 </v>
+  <v>     17.642      0.035 </v>
+  <v>     17.642      0.000 </v>
+  <v>     17.642      0.000 </v>
+  <v>     17.644     20.306 </v>
+  <v>     17.644     19.433 </v>
+  <v>     17.644     21.510 </v>
+  <v>     17.646      0.005 </v>
+  <v>     17.646      0.006 </v>
+  <v>     17.646      0.006 </v>
+  <v>     17.652      0.837 </v>
+  <v>     17.668      0.004 </v>
+  <v>     17.668      0.002 </v>
+  <v>     17.668      0.005 </v>
+  <v>     17.673     45.797 </v>
+  <v>     17.673     53.831 </v>
+  <v>     17.673     49.270 </v>
+  <v>     17.684      5.120 </v>
+  <v>     17.684      4.330 </v>
+  <v>     17.686      1.033 </v>
+  <v>     17.688     19.115 </v>
+  <v>     17.688     22.187 </v>
+  <v>     17.688      4.847 </v>
+  <v>     17.689      0.000 </v>
+  <v>     17.689      0.000 </v>
+  <v>     17.689      0.000 </v>
+  <v>     17.689      0.000 </v>
+  <v>     17.689      0.000 </v>
+  <v>     17.689      1.281 </v>
+  <v>     17.689      2.541 </v>
+  <v>     17.689      1.211 </v>
+  <v>     17.690      0.000 </v>
+  <v>     17.690      0.000 </v>
+  <v>     17.690      0.000 </v>
+  <v>     17.691      0.001 </v>
+  <v>     17.692      7.397 </v>
+  <v>     17.692     10.848 </v>
+  <v>     17.692      5.861 </v>
+  <v>     17.692      0.081 </v>
+  <v>     17.692      0.704 </v>
+  <v>     17.694      0.000 </v>
+  <v>     17.694      0.001 </v>
+  <v>     17.694      0.001 </v>
+  <v>     17.695      0.000 </v>
+  <v>     17.695      0.000 </v>
+  <v>     17.695      0.000 </v>
+  <v>     17.703      0.000 </v>
+  <v>     17.709      0.000 </v>
+  <v>     17.709      0.000 </v>
+  <v>     17.709      0.000 </v>
+  <v>     17.713      0.001 </v>
+  <v>     17.713      0.005 </v>
+  <v>     17.713      0.002 </v>
+  <v>     17.715      0.232 </v>
+  <v>     17.715      0.308 </v>
+  <v>     17.722      0.019 </v>
+  <v>     17.722      0.082 </v>
+  <v>     17.722      0.023 </v>
+  <v>     17.722     15.873 </v>
+  <v>     17.722     15.180 </v>
+  <v>     17.722     15.002 </v>
+  <v>     17.723      0.623 </v>
+  <v>     17.723      0.631 </v>
+  <v>     17.723      0.636 </v>
+  <v>     17.723      0.000 </v>
+  <v>     17.723      0.000 </v>
+  <v>     17.725      0.000 </v>
+  <v>     17.725      0.000 </v>
+  <v>     17.725      0.000 </v>
+  <v>     17.727      0.000 </v>
+  <v>     17.728      0.000 </v>
+  <v>     17.728      0.000 </v>
+  <v>     17.728      0.000 </v>
+  <v>     17.729      0.001 </v>
+  <v>     17.729      0.001 </v>
+  <v>     17.729      0.001 </v>
+  <v>     17.730      0.015 </v>
+  <v>     17.730      0.025 </v>
+  <v>     17.732      0.000 </v>
+  <v>     17.732      0.000 </v>
+  <v>     17.732      5.456 </v>
+  <v>     17.732      5.512 </v>
+  <v>     17.732      5.414 </v>
+  <v>     17.733      0.000 </v>
+  <v>     17.733      0.000 </v>
+  <v>     17.733      0.000 </v>
+  <v>     17.733      0.000 </v>
+  <v>     17.735      0.000 </v>
+  <v>     17.764      0.060 </v>
+  <v>     17.764      0.056 </v>
+  <v>     17.764      0.065 </v>
+  <v>     17.770    219.258 </v>
+  <v>     17.770    217.065 </v>
+  <v>     17.770    215.081 </v>
+  <v>     17.774      0.001 </v>
+  <v>     17.774      0.000 </v>
+  <v>     17.774      0.001 </v>
+  <v>     17.776      0.000 </v>
+  <v>     17.776      0.000 </v>
+  <v>     17.776      0.000 </v>
+  <v>     17.778      0.005 </v>
+  <v>     17.778      0.002 </v>
+  <v>     17.779      0.000 </v>
+  <v>     17.779      0.000 </v>
+  <v>     17.780      0.000 </v>
+  <v>     17.784      0.000 </v>
+  <v>     17.784      0.000 </v>
+  <v>     17.784      0.000 </v>
+  <v>     17.785      0.000 </v>
+  <v>     17.785      0.000 </v>
+  <v>     17.785      0.000 </v>
+  <v>     17.787      0.000 </v>
+  <v>     17.801      1.487 </v>
+  <v>     17.801      1.501 </v>
+  <v>     17.801      1.473 </v>
+  <v>     17.806    489.935 </v>
+  <v>     17.806    497.473 </v>
+  <v>     17.806    504.573 </v>
+  <v>     17.857      0.151 </v>
+  <v>     17.880      3.893 </v>
+  <v>     17.880      4.234 </v>
+  <v>     17.880      4.279 </v>
+  <v>     17.882      0.000 </v>
+  <v>     17.882      0.000 </v>
+  <v>     17.882      0.000 </v>
+  <v>     17.884      0.000 </v>
+  <v>     17.884      0.000 </v>
+  <v>     17.884      0.000 </v>
+  <v>     17.884      0.000 </v>
+  <v>     17.884      0.000 </v>
+  <v>     17.884      0.000 </v>
+  <v>     17.887      0.000 </v>
+  <v>     17.887      0.000 </v>
+  <v>     17.887      0.000 </v>
+  <v>     17.888      0.727 </v>
+  <v>     17.888      0.721 </v>
+  <v>     17.888      0.729 </v>
+  <v>     17.890      0.000 </v>
+  <v>     17.890      0.000 </v>
+  <v>     17.890      7.479 </v>
+  <v>     17.890      7.558 </v>
+  <v>     17.890      7.643 </v>
+  <v>     17.892      0.000 </v>
+  <v>     17.894      1.159 </v>
+  <v>     17.894      1.161 </v>
+  <v>     17.894      1.156 </v>
+  <v>     17.894      0.008 </v>
+  <v>     17.894      0.001 </v>
+  <v>     17.894      9.971 </v>
+  <v>     17.894      9.859 </v>
+  <v>     17.894      9.766 </v>
+  <v>     17.895      0.000 </v>
+  <v>     17.895      0.001 </v>
+  <v>     17.895      0.000 </v>
+  <v>     17.895      0.000 </v>
+  <v>     17.895      0.000 </v>
+  <v>     17.895      0.000 </v>
+  <v>     17.896      0.000 </v>
+  <v>     17.896      0.000 </v>
+  <v>     17.896      0.000 </v>
+  <v>     17.898      0.050 </v>
+  <v>     17.898      0.000 </v>
+  <v>     17.898      0.000 </v>
+  <v>     17.898      0.000 </v>
+  <v>     17.899      0.000 </v>
+  <v>     17.902      0.000 </v>
+  <v>     17.903      0.000 </v>
+  <v>     17.903      0.000 </v>
+  <v>     17.903      0.000 </v>
+  <v>     17.903      0.002 </v>
+  <v>     17.903      0.000 </v>
+  <v>     17.906      0.005 </v>
+  <v>     17.906      0.005 </v>
+  <v>     17.916    136.098 </v>
+  <v>     17.916    132.309 </v>
+  <v>     17.916    132.629 </v>
+  <v>     17.924      0.156 </v>
+  <v>     17.924      0.167 </v>
+  <v>     17.924      0.168 </v>
+  <v>     17.930      0.000 </v>
+  <v>     17.930      0.000 </v>
+  <v>     17.930      0.000 </v>
+  <v>     17.932      0.000 </v>
+  <v>     17.932      0.000 </v>
+  <v>     17.933      0.000 </v>
+  <v>     17.933      0.000 </v>
+  <v>     17.933      0.000 </v>
+  <v>     17.935      7.507 </v>
+  <v>     17.935     10.205 </v>
+  <v>     17.935      8.981 </v>
+  <v>     17.935      0.762 </v>
+  <v>     17.935      0.413 </v>
+  <v>     17.935      0.548 </v>
+  <v>     17.937      0.259 </v>
+  <v>     17.937      0.391 </v>
+  <v>     17.939      0.000 </v>
+  <v>     17.983   1204.793 </v>
+  <v>     17.983   1209.331 </v>
+  <v>     17.983   1207.964 </v>
+  <v>     18.010      4.171 </v>
+  <v>     18.010      4.230 </v>
+  <v>     18.010      4.254 </v>
+  <v>     18.054      0.027 </v>
+  <v>     18.198      0.000 </v>
+  <v>     18.198      0.000 </v>
+  <v>     18.198      0.000 </v>
+  <v>     18.200      0.000 </v>
+  <v>     18.200      0.000 </v>
+  <v>     18.222    488.734 </v>
+  <v>     18.222    488.907 </v>
+  <v>     18.222    488.345 </v>
+  <v>     18.415      0.020 </v>
+  <v>     18.415      0.340 </v>
+  <v>     18.417      0.252 </v>
+  <v>     18.417      0.264 </v>
+  <v>     18.417      1.644 </v>
+  <v>     18.421      0.429 </v>
+  <v>     18.430      0.000 </v>
+  <v>     18.430      0.000 </v>
+  <v>     18.430      0.000 </v>
+  <v>     18.430      0.000 </v>
+  <v>     18.430      0.000 </v>
+  <v>     18.430      0.000 </v>
+  <v>     18.438     24.112 </v>
+  <v>     18.438     24.225 </v>
+  <v>     18.438     24.228 </v>
+  <v>     18.441      0.101 </v>
+  <v>     18.441      0.119 </v>
+  <v>     18.441      0.346 </v>
+  <v>     18.554      0.000 </v>
+  <v>     18.554      0.000 </v>
+  <v>     18.555     59.742 </v>
+  <v>     18.555     59.803 </v>
+  <v>     18.555     59.732 </v>
+  <v>     18.558      0.000 </v>
+  <v>     18.558      0.000 </v>
+  <v>     18.558      0.000 </v>
+  <v>     18.558      0.000 </v>
+  <v>     18.560      0.000 </v>
+  <v>     18.560      0.000 </v>
+  <v>     18.560      0.000 </v>
+  <v>     18.562      0.064 </v>
+  <v>     18.562      0.079 </v>
+  <v>     18.562      0.051 </v>
+  <v>     18.566      0.000 </v>
+  <v>     18.566      0.000 </v>
+  <v>     18.566      0.000 </v>
+  <v>     18.569      0.001 </v>
+  <v>     18.569      0.000 </v>
+  <v>     18.591    533.377 </v>
+  <v>     18.591    533.136 </v>
+  <v>     18.591    532.869 </v>
+  <v>     18.601      0.016 </v>
+  <v>     18.668      0.209 </v>
+  <v>     18.668      0.007 </v>
+  <v>     18.669      0.019 </v>
+  <v>     18.669      0.135 </v>
+  <v>     18.669      0.517 </v>
+  <v>     18.706      0.455 </v>
+  <v>     18.767      0.012 </v>
+  <v>     18.767      0.009 </v>
+  <v>     18.767      0.011 </v>
+  <v>     18.769      0.000 </v>
+  <v>     18.772      1.457 </v>
+  <v>     18.772      1.392 </v>
+  <v>     18.772      0.822 </v>
+  <v>     18.786      0.014 </v>
+  <v>     18.810      0.000 </v>
+  <v>     18.810      0.000 </v>
+  <v>     18.810      0.000 </v>
+  <v>     18.817      0.000 </v>
+  <v>     18.817      0.000 </v>
+  <v>     18.823      0.069 </v>
+  <v>     18.824      0.042 </v>
+  <v>     18.824      0.064 </v>
+  <v>     18.850     16.583 </v>
+  <v>     18.850     18.197 </v>
+  <v>     18.850     17.761 </v>
+  <v>     18.854      0.088 </v>
+  <v>     18.854      0.062 </v>
+  <v>     18.854      0.094 </v>
+  <v>     18.855     36.703 </v>
+  <v>     18.855     35.167 </v>
+  <v>     18.855     34.464 </v>
+  <v>     18.855      0.008 </v>
+  <v>     18.855      0.006 </v>
+  <v>     18.857      0.179 </v>
+  <v>     18.857      0.152 </v>
+  <v>     18.857      0.034 </v>
+  <v>     18.861      0.001 </v>
+  <v>     18.861      0.000 </v>
+  <v>     18.861      0.001 </v>
+  <v>     18.862      0.191 </v>
+  <v>     18.862      0.173 </v>
+  <v>     18.862      0.402 </v>
+  <v>     18.862     40.431 </v>
+  <v>     18.862     41.379 </v>
+  <v>     18.862     39.510 </v>
+  <v>     18.862      0.010 </v>
+  <v>     18.863      0.000 </v>
+  <v>     18.863      0.004 </v>
+  <v>     18.863      0.003 </v>
+  <v>     18.863      0.005 </v>
+  <v>     18.863      0.000 </v>
+  <v>     18.865      0.000 </v>
+  <v>     18.865      0.000 </v>
+  <v>     18.865      0.000 </v>
+  <v>     18.866      0.246 </v>
+  <v>     18.866      0.260 </v>
+  <v>     18.866      0.608 </v>
+  <v>     18.867      0.227 </v>
+  <v>     18.867      0.120 </v>
+  <v>     18.867      0.170 </v>
+  <v>     18.867      0.000 </v>
+  <v>     18.867      0.000 </v>
+  <v>     18.869      0.000 </v>
+  <v>     18.882      0.094 </v>
+  <v>     18.882      0.363 </v>
+  <v>     18.882      0.524 </v>
+  <v>     18.882      0.049 </v>
+  <v>     18.882      0.000 </v>
+  <v>     18.882      0.000 </v>
+  <v>     18.882      0.000 </v>
+  <v>     18.883      0.026 </v>
+  <v>     18.883      0.036 </v>
+  <v>     18.883      0.038 </v>
+  <v>     18.883      0.567 </v>
+  <v>     18.883      0.561 </v>
+  <v>     18.883      0.569 </v>
+  <v>     18.884      0.000 </v>
+  <v>     18.884      0.000 </v>
+  <v>     18.884      0.000 </v>
+  <v>     18.884      0.010 </v>
+  <v>     18.884      0.012 </v>
+  <v>     18.884      0.003 </v>
+  <v>     18.884      0.000 </v>
+  <v>     18.885      0.042 </v>
+  <v>     18.885      0.092 </v>
+  <v>     18.885      0.000 </v>
+  <v>     18.885      0.000 </v>
+  <v>     18.895    319.566 </v>
+  <v>     18.895    320.011 </v>
+  <v>     18.895    321.923 </v>
+  <v>     18.907      0.042 </v>
+  <v>     18.928      1.315 </v>
+  <v>     18.929      1.328 </v>
+  <v>     18.929      1.312 </v>
+  <v>     19.057      0.000 </v>
+  <v>     19.057      0.000 </v>
+  <v>     19.057      0.000 </v>
+  <v>     19.057      0.000 </v>
+  <v>     19.057      0.000 </v>
+  <v>     19.063      0.007 </v>
+  <v>     19.063      0.003 </v>
+  <v>     19.063      0.007 </v>
+  <v>     19.067      0.001 </v>
+  <v>     19.067      0.001 </v>
+  <v>     19.068      0.000 </v>
+  <v>     19.068      0.000 </v>
+  <v>     19.068      0.000 </v>
+  <v>     19.069      0.001 </v>
+  <v>     19.072     97.078 </v>
+  <v>     19.072     97.418 </v>
+  <v>     19.072     97.650 </v>
+  <v>     19.075      0.000 </v>
+  <v>     19.075      0.000 </v>
+  <v>     19.075      0.001 </v>
+  <v>     19.075      0.001 </v>
+  <v>     19.076     61.971 </v>
+  <v>     19.076     61.988 </v>
+  <v>     19.076     62.104 </v>
+  <v>     19.102      0.000 </v>
+  <v>     19.102      0.000 </v>
+  <v>     19.102      0.000 </v>
+  <v>     19.117     52.795 </v>
+  <v>     19.117     52.309 </v>
+  <v>     19.117     52.528 </v>
+  <v>     19.156      0.000 </v>
+  <v>     19.156      0.000 </v>
+  <v>     19.156      0.000 </v>
+  <v>     19.159      0.000 </v>
+  <v>     19.159      0.000 </v>
+  <v>     19.159      0.000 </v>
+  <v>     19.161      0.000 </v>
+  <v>     19.161      0.000 </v>
+  <v>     19.165      0.000 </v>
+  <v>     19.165      0.001 </v>
+  <v>     19.170     41.144 </v>
+  <v>     19.170     40.544 </v>
+  <v>     19.170     40.848 </v>
+  <v>     19.172     91.774 </v>
+  <v>     19.172     91.037 </v>
+  <v>     19.172     91.390 </v>
+  <v>     19.216      0.001 </v>
+  <v>     19.216      0.001 </v>
+  <v>     19.216      0.000 </v>
+  <v>     19.219     14.001 </v>
+  <v>     19.219     13.182 </v>
+  <v>     19.219     12.973 </v>
+  <v>     19.221      0.002 </v>
+  <v>     19.224      0.000 </v>
+  <v>     19.224      0.001 </v>
+  <v>     19.225      0.214 </v>
+  <v>     19.225      0.199 </v>
+  <v>     19.225      0.214 </v>
+  <v>     19.247      0.000 </v>
+  <v>     19.257      0.018 </v>
+  <v>     19.257      0.017 </v>
+  <v>     19.257      0.015 </v>
+  <v>     19.261     51.417 </v>
+  <v>     19.261     50.297 </v>
+  <v>     19.261     50.407 </v>
+  <v>     19.263      0.000 </v>
+  <v>     19.263      0.000 </v>
+  <v>     19.264      0.000 </v>
+  <v>     19.265      0.004 </v>
+  <v>     19.265      0.017 </v>
+  <v>     19.265      0.020 </v>
+  <v>     19.265      0.050 </v>
+  <v>     19.265      0.049 </v>
+  <v>     19.265      0.054 </v>
+  <v>     19.271      0.002 </v>
+  <v>     19.271      0.001 </v>
+  <v>     19.272      0.000 </v>
+  <v>     19.272      0.000 </v>
+  <v>     19.272      0.000 </v>
+  <v>     19.274      0.000 </v>
+  <v>     19.274      0.000 </v>
+  <v>     19.275      0.000 </v>
+  <v>     19.275      0.000 </v>
+  <v>     19.275      0.000 </v>
+  <v>     19.276      0.644 </v>
+  <v>     19.276      0.622 </v>
+  <v>     19.276      0.659 </v>
+  <v>     19.277      0.000 </v>
+  <v>     19.277      0.000 </v>
+  <v>     19.277      0.000 </v>
+  <v>     19.277      0.000 </v>
+  <v>     19.277      0.000 </v>
+  <v>     19.279      0.002 </v>
+  <v>     19.279      0.000 </v>
+  <v>     19.279      0.000 </v>
+  <v>     19.279     10.806 </v>
+  <v>     19.279     11.049 </v>
+  <v>     19.279     11.140 </v>
+  <v>     19.280      0.000 </v>
+  <v>     19.280      0.000 </v>
+  <v>     19.280      0.000 </v>
+  <v>     19.280      0.000 </v>
+  <v>     19.282      0.456 </v>
+  <v>     19.282      0.460 </v>
+  <v>     19.282      0.455 </v>
+  <v>     19.283      0.012 </v>
+  <v>     19.283      0.000 </v>
+  <v>     19.283      0.000 </v>
+  <v>     19.283      9.787 </v>
+  <v>     19.283      9.776 </v>
+  <v>     19.283      9.681 </v>
+  <v>     19.285      0.000 </v>
+  <v>     19.286      0.001 </v>
+  <v>     19.286      0.001 </v>
+  <v>     19.286      0.001 </v>
+  <v>     19.286      0.003 </v>
+  <v>     19.286      0.000 </v>
+  <v>     19.286      0.000 </v>
+  <v>     19.286      0.000 </v>
+  <v>     19.286      0.000 </v>
+  <v>     19.288      1.659 </v>
+  <v>     19.288      1.584 </v>
+  <v>     19.288      1.600 </v>
+  <v>     19.289     33.418 </v>
+  <v>     19.289     35.722 </v>
+  <v>     19.289     33.163 </v>
+  <v>     19.294      0.025 </v>
+  <v>     19.294      0.022 </v>
+  <v>     19.294      0.028 </v>
+  <v>     19.298      0.000 </v>
+  <v>     19.298      0.000 </v>
+  <v>     19.300      0.008 </v>
+  <v>     19.300      0.011 </v>
+  <v>     19.300      0.008 </v>
+  <v>     19.300      0.000 </v>
+  <v>     19.300      0.000 </v>
+  <v>     19.300      0.000 </v>
+  <v>     19.308      0.000 </v>
+  <v>     19.308      0.000 </v>
+  <v>     19.308      0.000 </v>
+  <v>     19.310     10.578 </v>
+  <v>     19.310     10.465 </v>
+  <v>     19.310     11.307 </v>
+  <v>     19.317      0.000 </v>
+  <v>     19.317      0.000 </v>
+  <v>     19.318      3.841 </v>
+  <v>     19.329      0.022 </v>
+  <v>     19.329      0.009 </v>
+  <v>     19.329      0.033 </v>
+  <v>     19.330      0.834 </v>
+  <v>     19.330      1.960 </v>
+  <v>     19.330      2.953 </v>
+  <v>     19.335      0.000 </v>
+  <v>     19.358      0.000 </v>
+  <v>     19.358      0.000 </v>
+  <v>     19.362      0.007 </v>
+  <v>     19.362      0.015 </v>
+  <v>     19.362      0.032 </v>
+  <v>     19.364     76.249 </v>
+  <v>     19.364     75.615 </v>
+  <v>     19.364     76.411 </v>
+  <v>     19.367      0.000 </v>
+  <v>     19.368      0.001 </v>
+  <v>     19.368      0.006 </v>
+  <v>     19.368      0.001 </v>
+  <v>     19.369      0.000 </v>
+  <v>     19.369      0.000 </v>
+  <v>     19.369      0.000 </v>
+  <v>     19.370      0.030 </v>
+  <v>     19.370      0.029 </v>
+  <v>     19.370      0.031 </v>
+  <v>     19.371      0.000 </v>
+  <v>     19.371      0.000 </v>
+  <v>     19.374      0.001 </v>
+  <v>     19.374      0.001 </v>
+  <v>     19.374      0.002 </v>
+  <v>     19.376      0.000 </v>
+  <v>     19.377      0.001 </v>
+  <v>     19.377      0.016 </v>
+  <v>     19.377      0.002 </v>
+  <v>     19.378      0.000 </v>
+  <v>     19.378      0.000 </v>
+  <v>     19.378      0.000 </v>
+  <v>     19.378      0.000 </v>
+  <v>     19.378      0.000 </v>
+  <v>     19.378      0.000 </v>
+  <v>     19.380      0.000 </v>
+  <v>     19.380      0.000 </v>
+  <v>     19.380      0.000 </v>
+  <v>     19.381      0.000 </v>
+  <v>     19.382      0.005 </v>
+  <v>     19.382      0.000 </v>
+  <v>     19.382      0.001 </v>
+  <v>     19.382      0.000 </v>
+  <v>     19.382      0.000 </v>
+  <v>     19.386     84.763 </v>
+  <v>     19.386     84.005 </v>
+  <v>     19.386     84.850 </v>
+  <v>     19.397      1.327 </v>
+  <v>     19.415      0.185 </v>
+  <v>     19.415      0.215 </v>
+  <v>     19.415      0.204 </v>
+  <v>     19.454      0.000 </v>
+  <v>     19.454     60.089 </v>
+  <v>     19.454     58.077 </v>
+  <v>     19.454     62.807 </v>
+  <v>     19.456      0.360 </v>
+  <v>     19.456      0.544 </v>
+  <v>     19.456      1.740 </v>
+  <v>     19.457      0.000 </v>
+  <v>     19.457      0.000 </v>
+  <v>     19.457      0.000 </v>
+  <v>     19.458      0.000 </v>
+  <v>     19.458      0.000 </v>
+  <v>     19.461      0.289 </v>
+  <v>     19.461      0.767 </v>
+  <v>     19.461      0.000 </v>
+  <v>     19.461      0.000 </v>
+  <v>     19.461      0.000 </v>
+  <v>     19.465      0.035 </v>
+  <v>     19.465      0.029 </v>
+  <v>     19.465      0.029 </v>
+  <v>     19.467     20.174 </v>
+  <v>     19.467     21.402 </v>
+  <v>     19.467     20.868 </v>
+  <v>     19.493      0.000 </v>
+  <v>     19.493      0.002 </v>
+  <v>     19.493      0.000 </v>
+  <v>     19.493      0.002 </v>
+  <v>     19.493      0.002 </v>
+  <v>     19.493      0.001 </v>
+  <v>     19.503    214.502 </v>
+  <v>     19.503    212.338 </v>
+  <v>     19.503    214.985 </v>
+  <v>     19.509      0.566 </v>
+  <v>     19.526      0.055 </v>
+  <v>     19.526      0.080 </v>
+  <v>     19.526      0.066 </v>
+  <v>     19.569      0.001 </v>
+  <v>     19.569      0.001 </v>
+  <v>     19.569      0.008 </v>
+  <v>     19.570      0.000 </v>
+  <v>     19.570      0.000 </v>
+  <v>     19.571      0.000 </v>
+  <v>     19.585      0.002 </v>
+  <v>     19.585      0.000 </v>
+  <v>     19.585      0.000 </v>
+  <v>     19.586      0.000 </v>
+  <v>     19.586      0.000 </v>
+  <v>     19.586      0.000 </v>
+  <v>     19.588      0.048 </v>
+  <v>     19.588      0.045 </v>
+  <v>     19.588      0.044 </v>
+  <v>     19.588     77.753 </v>
+  <v>     19.588     78.164 </v>
+  <v>     19.588     78.097 </v>
+  <v>     19.594      0.000 </v>
+  <v>     19.594      0.000 </v>
+  <v>     19.594      0.000 </v>
+  <v>     19.594      0.000 </v>
+  <v>     19.595      0.000 </v>
+  <v>     19.595      0.000 </v>
+  <v>     19.672      0.167 </v>
+  <v>     19.672      0.171 </v>
+  <v>     19.672      0.157 </v>
+  <v>     19.673      0.000 </v>
+  <v>     19.673      0.000 </v>
+  <v>     19.679      0.000 </v>
+  <v>     19.679      0.000 </v>
+  <v>     19.679      0.000 </v>
+  <v>     19.680      0.000 </v>
+  <v>     19.684      0.004 </v>
+  <v>     19.684      0.005 </v>
+  <v>     19.684      0.005 </v>
+  <v>     19.698      0.341 </v>
+  <v>     19.698      0.032 </v>
+  <v>     19.698      0.048 </v>
+  <v>     19.699      0.000 </v>
+  <v>     19.699      0.000 </v>
+  <v>     19.700      0.000 </v>
+  <v>     19.701      7.310 </v>
+  <v>     19.701      6.833 </v>
+  <v>     19.701      8.345 </v>
+  <v>     19.702      0.002 </v>
+  <v>     19.702      0.002 </v>
+  <v>     19.702      0.001 </v>
+  <v>     19.714      0.000 </v>
+  <v>     19.714      0.000 </v>
+  <v>     19.714      0.000 </v>
+  <v>     19.716      0.000 </v>
+  <v>     19.716      0.000 </v>
+  <v>     19.716      0.000 </v>
+  <v>     19.717      0.018 </v>
+  <v>     19.717      0.129 </v>
+  <v>     19.717      7.297 </v>
+  <v>     19.717      7.369 </v>
+  <v>     19.717      7.139 </v>
+  <v>     19.728      0.083 </v>
+ </varray>
+ <dielectricfunction>
+  <imag>
+   <array>
+    <dimension dim="1">gridpoints</dimension>
+    <field>energy</field>
+    <field>xx</field>
+    <field>yy</field>
+    <field>zz</field>
+    <field>xy</field>
+    <field>yz</field>
+    <field>zx</field>
+    <set>
+     <r>     0.0000     0.0000     0.0000     0.0000    -0.0000    -0.0000    -0.0000 </r>
+     <r>     0.0200     0.0030     0.0030     0.0030    -0.0000    -0.0000    -0.0000 </r>
+     <r>     0.0400     0.0059     0.0059     0.0059    -0.0000    -0.0000    -0.0000 </r>
+     <r>     0.0601     0.0089     0.0089     0.0089    -0.0000    -0.0000    -0.0000 </r>
+     <r>     0.0801     0.0118     0.0118     0.0118    -0.0000    -0.0000    -0.0000 </r>
+     <r>     0.1001     0.0148     0.0148     0.0148    -0.0000    -0.0000    -0.0000 </r>
+     <r>     0.1201     0.0177     0.0177     0.0177    -0.0000    -0.0000    -0.0000 </r>
+     <r>     0.1401     0.0207     0.0207     0.0207    -0.0000    -0.0000    -0.0000 </r>
+     <r>     0.1602     0.0237     0.0237     0.0237    -0.0000    -0.0000    -0.0000 </r>
+     <r>     0.1802     0.0267     0.0267     0.0267    -0.0000    -0.0000    -0.0000 </r>
+     <r>     0.2002     0.0297     0.0297     0.0297    -0.0000    -0.0001    -0.0000 </r>
+     <r>     0.2202     0.0327     0.0327     0.0327    -0.0000    -0.0001    -0.0000 </r>
+     <r>     0.2402     0.0357     0.0357     0.0357    -0.0000    -0.0001    -0.0001 </r>
+     <r>     0.2603     0.0388     0.0388     0.0388    -0.0001    -0.0001    -0.0001 </r>
+     <r>     0.2803     0.0418     0.0418     0.0418    -0.0001    -0.0001    -0.0001 </r>
+     <r>     0.3003     0.0449     0.0449     0.0449    -0.0001    -0.0001    -0.0001 </r>
+     <r>     0.3203     0.0480     0.0480     0.0480    -0.0001    -0.0001    -0.0001 </r>
+     <r>     0.3403     0.0511     0.0511     0.0511    -0.0001    -0.0001    -0.0001 </r>
+     <r>     0.3604     0.0542     0.0542     0.0542    -0.0001    -0.0001    -0.0001 </r>
+     <r>     0.3804     0.0573     0.0573     0.0574    -0.0001    -0.0001    -0.0001 </r>
+     <r>     0.4004     0.0605     0.0605     0.0605    -0.0001    -0.0001    -0.0001 </r>
+     <r>     0.4204     0.0637     0.0637     0.0637    -0.0001    -0.0001    -0.0001 </r>
+     <r>     0.4404     0.0669     0.0669     0.0669    -0.0001    -0.0001    -0.0001 </r>
+     <r>     0.4605     0.0701     0.0702     0.0702    -0.0001    -0.0001    -0.0001 </r>
+     <r>     0.4805     0.0734     0.0734     0.0734    -0.0001    -0.0001    -0.0001 </r>
+     <r>     0.5005     0.0767     0.0767     0.0767    -0.0001    -0.0001    -0.0001 </r>
+     <r>     0.5205     0.0800     0.0800     0.0801    -0.0001    -0.0001    -0.0001 </r>
+     <r>     0.5405     0.0834     0.0834     0.0834    -0.0001    -0.0002    -0.0001 </r>
+     <r>     0.5606     0.0868     0.0868     0.0868    -0.0001    -0.0002    -0.0001 </r>
+     <r>     0.5806     0.0902     0.0902     0.0902    -0.0001    -0.0002    -0.0001 </r>
+     <r>     0.6006     0.0937     0.0937     0.0937    -0.0001    -0.0002    -0.0001 </r>
+     <r>     0.6206     0.0972     0.0972     0.0972    -0.0001    -0.0002    -0.0002 </r>
+     <r>     0.6406     0.1007     0.1007     0.1008    -0.0001    -0.0002    -0.0002 </r>
+     <r>     0.6607     0.1043     0.1043     0.1043    -0.0001    -0.0002    -0.0002 </r>
+     <r>     0.6807     0.1079     0.1080     0.1080    -0.0001    -0.0002    -0.0002 </r>
+     <r>     0.7007     0.1116     0.1116     0.1117    -0.0001    -0.0002    -0.0002 </r>
+     <r>     0.7207     0.1153     0.1154     0.1154    -0.0002    -0.0002    -0.0002 </r>
+     <r>     0.7407     0.1191     0.1191     0.1191    -0.0002    -0.0002    -0.0002 </r>
+     <r>     0.7608     0.1229     0.1229     0.1230    -0.0002    -0.0002    -0.0002 </r>
+     <r>     0.7808     0.1268     0.1268     0.1268    -0.0002    -0.0002    -0.0002 </r>
+     <r>     0.8008     0.1307     0.1308     0.1308    -0.0002    -0.0002    -0.0002 </r>
+     <r>     0.8208     0.1347     0.1347     0.1348    -0.0002    -0.0002    -0.0002 </r>
+     <r>     0.8408     0.1388     0.1388     0.1388    -0.0002    -0.0003    -0.0002 </r>
+     <r>     0.8609     0.1429     0.1429     0.1429    -0.0002    -0.0003    -0.0002 </r>
+     <r>     0.8809     0.1471     0.1471     0.1471    -0.0002    -0.0003    -0.0002 </r>
+     <r>     0.9009     0.1513     0.1513     0.1514    -0.0002    -0.0003    -0.0002 </r>
+     <r>     0.9209     0.1556     0.1556     0.1557    -0.0002    -0.0003    -0.0002 </r>
+     <r>     0.9409     0.1600     0.1600     0.1601    -0.0002    -0.0003    -0.0003 </r>
+     <r>     0.9610     0.1645     0.1645     0.1645    -0.0002    -0.0003    -0.0003 </r>
+     <r>     0.9810     0.1690     0.1690     0.1691    -0.0002    -0.0003    -0.0003 </r>
+     <r>     1.0010     0.1736     0.1737     0.1737    -0.0002    -0.0003    -0.0003 </r>
+     <r>     1.0210     0.1783     0.1784     0.1784    -0.0002    -0.0003    -0.0003 </r>
+     <r>     1.0410     0.1831     0.1832     0.1832    -0.0003    -0.0003    -0.0003 </r>
+     <r>     1.0611     0.1880     0.1881     0.1881    -0.0003    -0.0004    -0.0003 </r>
+     <r>     1.0811     0.1930     0.1930     0.1931    -0.0003    -0.0004    -0.0003 </r>
+     <r>     1.1011     0.1981     0.1981     0.1982    -0.0003    -0.0004    -0.0003 </r>
+     <r>     1.1211     0.2033     0.2033     0.2033    -0.0003    -0.0004    -0.0003 </r>
+     <r>     1.1411     0.2086     0.2086     0.2086    -0.0003    -0.0004    -0.0003 </r>
+     <r>     1.1612     0.2140     0.2140     0.2140    -0.0003    -0.0004    -0.0003 </r>
+     <r>     1.1812     0.2195     0.2195     0.2196    -0.0003    -0.0004    -0.0004 </r>
+     <r>     1.2012     0.2251     0.2252     0.2252    -0.0003    -0.0004    -0.0004 </r>
+     <r>     1.2212     0.2309     0.2309     0.2310    -0.0003    -0.0004    -0.0004 </r>
+     <r>     1.2412     0.2368     0.2368     0.2369    -0.0003    -0.0005    -0.0004 </r>
+     <r>     1.2613     0.2428     0.2428     0.2429    -0.0003    -0.0005    -0.0004 </r>
+     <r>     1.2813     0.2490     0.2490     0.2491    -0.0004    -0.0005    -0.0004 </r>
+     <r>     1.3013     0.2553     0.2553     0.2554    -0.0004    -0.0005    -0.0004 </r>
+     <r>     1.3213     0.2618     0.2618     0.2618    -0.0004    -0.0005    -0.0004 </r>
+     <r>     1.3413     0.2684     0.2684     0.2685    -0.0004    -0.0005    -0.0004 </r>
+     <r>     1.3614     0.2752     0.2752     0.2753    -0.0004    -0.0005    -0.0005 </r>
+     <r>     1.3814     0.2821     0.2822     0.2822    -0.0004    -0.0006    -0.0005 </r>
+     <r>     1.4014     0.2893     0.2893     0.2894    -0.0004    -0.0006    -0.0005 </r>
+     <r>     1.4214     0.2966     0.2967     0.2967    -0.0004    -0.0006    -0.0005 </r>
+     <r>     1.4414     0.3042     0.3042     0.3042    -0.0005    -0.0006    -0.0005 </r>
+     <r>     1.4615     0.3119     0.3119     0.3120    -0.0005    -0.0006    -0.0005 </r>
+     <r>     1.4815     0.3198     0.3199     0.3199    -0.0005    -0.0006    -0.0005 </r>
+     <r>     1.5015     0.3280     0.3281     0.3281    -0.0005    -0.0007    -0.0006 </r>
+     <r>     1.5215     0.3364     0.3365     0.3365    -0.0005    -0.0007    -0.0006 </r>
+     <r>     1.5415     0.3451     0.3451     0.3452    -0.0005    -0.0007    -0.0006 </r>
+     <r>     1.5616     0.3540     0.3540     0.3541    -0.0005    -0.0007    -0.0006 </r>
+     <r>     1.5816     0.3631     0.3632     0.3632    -0.0006    -0.0007    -0.0006 </r>
+     <r>     1.6016     0.3726     0.3727     0.3727    -0.0006    -0.0008    -0.0007 </r>
+     <r>     1.6216     0.3823     0.3824     0.3824    -0.0006    -0.0008    -0.0007 </r>
+     <r>     1.6416     0.3924     0.3925     0.3925    -0.0006    -0.0008    -0.0007 </r>
+     <r>     1.6617     0.4028     0.4028     0.4029    -0.0006    -0.0008    -0.0007 </r>
+     <r>     1.6817     0.4135     0.4135     0.4136    -0.0007    -0.0009    -0.0007 </r>
+     <r>     1.7017     0.4245     0.4246     0.4246    -0.0007    -0.0009    -0.0008 </r>
+     <r>     1.7217     0.4360     0.4360     0.4361    -0.0007    -0.0009    -0.0008 </r>
+     <r>     1.7417     0.4478     0.4479     0.4479    -0.0007    -0.0009    -0.0008 </r>
+     <r>     1.7618     0.4601     0.4601     0.4602    -0.0007    -0.0010    -0.0008 </r>
+     <r>     1.7818     0.4727     0.4728     0.4728    -0.0008    -0.0010    -0.0009 </r>
+     <r>     1.8018     0.4859     0.4859     0.4860    -0.0008    -0.0010    -0.0009 </r>
+     <r>     1.8218     0.4995     0.4996     0.4996    -0.0008    -0.0011    -0.0009 </r>
+     <r>     1.8418     0.5136     0.5137     0.5137    -0.0009    -0.0011    -0.0010 </r>
+     <r>     1.8619     0.5283     0.5283     0.5284    -0.0009    -0.0011    -0.0010 </r>
+     <r>     1.8819     0.5435     0.5436     0.5436    -0.0009    -0.0012    -0.0010 </r>
+     <r>     1.9019     0.5593     0.5594     0.5594    -0.0009    -0.0012    -0.0011 </r>
+     <r>     1.9219     0.5758     0.5759     0.5759    -0.0010    -0.0013    -0.0011 </r>
+     <r>     1.9419     0.5929     0.5930     0.5930    -0.0010    -0.0013    -0.0011 </r>
+     <r>     1.9620     0.6108     0.6109     0.6109    -0.0011    -0.0013    -0.0012 </r>
+     <r>     1.9820     0.6294     0.6295     0.6295    -0.0011    -0.0014    -0.0012 </r>
+     <r>     2.0020     0.6488     0.6489     0.6489    -0.0011    -0.0014    -0.0013 </r>
+     <r>     2.0220     0.6691     0.6692     0.6692    -0.0012    -0.0015    -0.0013 </r>
+     <r>     2.0420     0.6903     0.6904     0.6904    -0.0012    -0.0016    -0.0014 </r>
+     <r>     2.0621     0.7124     0.7125     0.7125    -0.0013    -0.0016    -0.0014 </r>
+     <r>     2.0821     0.7356     0.7357     0.7357    -0.0013    -0.0017    -0.0015 </r>
+     <r>     2.1021     0.7599     0.7600     0.7600    -0.0014    -0.0017    -0.0015 </r>
+     <r>     2.1221     0.7854     0.7855     0.7855    -0.0015    -0.0018    -0.0016 </r>
+     <r>     2.1421     0.8122     0.8123     0.8123    -0.0015    -0.0019    -0.0017 </r>
+     <r>     2.1622     0.8403     0.8404     0.8404    -0.0016    -0.0020    -0.0017 </r>
+     <r>     2.1822     0.8699     0.8700     0.8700    -0.0017    -0.0021    -0.0018 </r>
+     <r>     2.2022     0.9010     0.9011     0.9011    -0.0017    -0.0021    -0.0019 </r>
+     <r>     2.2222     0.9339     0.9340     0.9340    -0.0018    -0.0022    -0.0020 </r>
+     <r>     2.2422     0.9686     0.9687     0.9687    -0.0019    -0.0023    -0.0021 </r>
+     <r>     2.2623     1.0052     1.0054     1.0053    -0.0020    -0.0025    -0.0022 </r>
+     <r>     2.2823     1.0441     1.0442     1.0442    -0.0021    -0.0026    -0.0023 </r>
+     <r>     2.3023     1.0852     1.0853     1.0853    -0.0022    -0.0027    -0.0024 </r>
+     <r>     2.3223     1.1289     1.1290     1.1290    -0.0023    -0.0028    -0.0025 </r>
+     <r>     2.3423     1.1753     1.1755     1.1754    -0.0025    -0.0030    -0.0027 </r>
+     <r>     2.3624     1.2248     1.2249     1.2249    -0.0026    -0.0031    -0.0028 </r>
+     <r>     2.3824     1.2775     1.2777     1.2776    -0.0027    -0.0033    -0.0030 </r>
+     <r>     2.4024     1.3339     1.3340     1.3339    -0.0029    -0.0035    -0.0031 </r>
+     <r>     2.4224     1.3942     1.3943     1.3943    -0.0031    -0.0037    -0.0033 </r>
+     <r>     2.4424     1.4589     1.4590     1.4590    -0.0033    -0.0039    -0.0035 </r>
+     <r>     2.4625     1.5284     1.5286     1.5285    -0.0035    -0.0041    -0.0037 </r>
+     <r>     2.4825     1.6033     1.6035     1.6034    -0.0037    -0.0044    -0.0040 </r>
+     <r>     2.5025     1.6842     1.6844     1.6842    -0.0040    -0.0047    -0.0042 </r>
+     <r>     2.5225     1.7717     1.7719     1.7718    -0.0042    -0.0050    -0.0045 </r>
+     <r>     2.5425     1.8667     1.8669     1.8667    -0.0045    -0.0053    -0.0048 </r>
+     <r>     2.5626     1.9700     1.9702     1.9700    -0.0049    -0.0057    -0.0052 </r>
+     <r>     2.5826     2.0828     2.0830     2.0828    -0.0053    -0.0061    -0.0056 </r>
+     <r>     2.6026     2.2063     2.2065     2.2062    -0.0057    -0.0066    -0.0060 </r>
+     <r>     2.6226     2.3419     2.3421     2.3418    -0.0062    -0.0071    -0.0065 </r>
+     <r>     2.6426     2.4914     2.4916     2.4913    -0.0067    -0.0077    -0.0071 </r>
+     <r>     2.6627     2.6568     2.6571     2.6568    -0.0073    -0.0084    -0.0077 </r>
+     <r>     2.6827     2.8407     2.8410     2.8406    -0.0080    -0.0092    -0.0084 </r>
+     <r>     2.7027     3.0460     3.0463     3.0459    -0.0088    -0.0100    -0.0092 </r>
+     <r>     2.7227     3.2763     3.2766     3.2762    -0.0097    -0.0110    -0.0101 </r>
+     <r>     2.7427     3.5361     3.5364     3.5359    -0.0107    -0.0121    -0.0112 </r>
+     <r>     2.7628     3.8307     3.8310     3.8304    -0.0119    -0.0135    -0.0125 </r>
+     <r>     2.7828     4.1670     4.1673     4.1666    -0.0133    -0.0150    -0.0139 </r>
+     <r>     2.8028     4.5534     4.5537     4.5530    -0.0150    -0.0168    -0.0156 </r>
+     <r>     2.8228     5.0006     5.0010     5.0001    -0.0170    -0.0190    -0.0177 </r>
+     <r>     2.8428     5.5225     5.5229     5.5219    -0.0194    -0.0216    -0.0202 </r>
+     <r>     2.8629     6.1366     6.1370     6.1359    -0.0224    -0.0248    -0.0231 </r>
+     <r>     2.8829     6.8658     6.8663     6.8649    -0.0260    -0.0286    -0.0268 </r>
+     <r>     2.9029     7.7400     7.7406     7.7389    -0.0304    -0.0333    -0.0313 </r>
+     <r>     2.9229     8.7980     8.7985     8.7966    -0.0359    -0.0393    -0.0369 </r>
+     <r>     2.9429    10.0893    10.0900    10.0876    -0.0429    -0.0467    -0.0440 </r>
+     <r>     2.9630    11.6758    11.6765    11.6737    -0.0517    -0.0561    -0.0530 </r>
+     <r>     2.9830    13.6280    13.6288    13.6253    -0.0629    -0.0679    -0.0643 </r>
+     <r>     3.0030    16.0121    16.0131    16.0088    -0.0768    -0.0826    -0.0784 </r>
+     <r>     3.0230    18.8564    18.8574    18.8523    -0.0937    -0.1005    -0.0955 </r>
+     <r>     3.0430    22.0927    22.0940    22.0879    -0.1127    -0.1206    -0.1148 </r>
+     <r>     3.0631    25.5109    25.5124    25.5057    -0.1313    -0.1406    -0.1339 </r>
+     <r>     3.0831    28.8304    28.8322    28.8253    -0.1450    -0.1555    -0.1481 </r>
+     <r>     3.1031    31.9449    31.9471    31.9408    -0.1486    -0.1606    -0.1525 </r>
+     <r>     3.1231    35.1012    35.1039    35.0988    -0.1405    -0.1540    -0.1452 </r>
+     <r>     3.1431    38.6999    38.7033    38.6997    -0.1234    -0.1387    -0.1293 </r>
+     <r>     3.1632    42.8395    42.8436    42.8415    -0.1028    -0.1201    -0.1099 </r>
+     <r>     3.1832    46.9487    46.9534    46.9526    -0.0829    -0.1022    -0.0912 </r>
+     <r>     3.2032    49.7909    49.7961    49.7962    -0.0660    -0.0866    -0.0750 </r>
+     <r>     3.2232    50.1201    50.1253    50.1256    -0.0527    -0.0734    -0.0619 </r>
+     <r>     3.2432    47.6770    47.6817    47.6816    -0.0429    -0.0625    -0.0515 </r>
+     <r>     3.2633    43.3906    43.3945    43.3936    -0.0358    -0.0534    -0.0434 </r>
+     <r>     3.2833    38.5367    38.5398    38.5376    -0.0307    -0.0460    -0.0370 </r>
+     <r>     3.3033    33.9783    33.9806    33.9773    -0.0268    -0.0401    -0.0320 </r>
+     <r>     3.3233    30.0707    30.0723    30.0678    -0.0239    -0.0354    -0.0281 </r>
+     <r>     3.3433    26.8540    26.8549    26.8495    -0.0215    -0.0316    -0.0249 </r>
+     <r>     3.3634    24.1965    24.1970    24.1909    -0.0195    -0.0285    -0.0223 </r>
+     <r>     3.3834    21.9033    21.9036    21.8972    -0.0176    -0.0258    -0.0200 </r>
+     <r>     3.4034    19.8487    19.8487    19.8424    -0.0159    -0.0233    -0.0180 </r>
+     <r>     3.4234    18.0416    18.0415    18.0357    -0.0143    -0.0210    -0.0162 </r>
+     <r>     3.4434    16.5637    16.5636    16.5582    -0.0128    -0.0190    -0.0145 </r>
+     <r>     3.4635    15.4812    15.4810    15.4760    -0.0115    -0.0173    -0.0132 </r>
+     <r>     3.4835    14.8193    14.8190    14.8143    -0.0103    -0.0160    -0.0120 </r>
+     <r>     3.5035    14.5780    14.5776    14.5730    -0.0094    -0.0150    -0.0111 </r>
+     <r>     3.5235    14.7465    14.7459    14.7412    -0.0086    -0.0142    -0.0103 </r>
+     <r>     3.5435    15.2970    15.2963    15.2913    -0.0079    -0.0137    -0.0097 </r>
+     <r>     3.5636    16.1518    16.1509    16.1455    -0.0073    -0.0135    -0.0092 </r>
+     <r>     3.5836    17.1297    17.1285    17.1226    -0.0068    -0.0133    -0.0088 </r>
+     <r>     3.6036    17.9251    17.9238    17.9176    -0.0064    -0.0132    -0.0085 </r>
+     <r>     3.6236    18.2175    18.2161    18.2097    -0.0060    -0.0130    -0.0082 </r>
+     <r>     3.6436    17.8970    17.8958    17.8895    -0.0057    -0.0125    -0.0078 </r>
+     <r>     3.6637    17.1615    17.1604    17.1546    -0.0054    -0.0120    -0.0074 </r>
+     <r>     3.6837    16.3479    16.3471    16.3417    -0.0051    -0.0115    -0.0071 </r>
+     <r>     3.7037    15.7257    15.7251    15.7200    -0.0048    -0.0111    -0.0068 </r>
+     <r>     3.7237    15.4371    15.4368    15.4319    -0.0046    -0.0109    -0.0065 </r>
+     <r>     3.7437    15.5395    15.5394    15.5347    -0.0044    -0.0108    -0.0064 </r>
+     <r>     3.7638    16.0589    16.0590    16.0542    -0.0043    -0.0110    -0.0063 </r>
+     <r>     3.7838    17.0240    17.0242    17.0193    -0.0042    -0.0113    -0.0064 </r>
+     <r>     3.8038    18.4837    18.4840    18.4788    -0.0040    -0.0118    -0.0065 </r>
+     <r>     3.8238    20.5157    20.5162    20.5105    -0.0039    -0.0126    -0.0066 </r>
+     <r>     3.8438    23.2287    23.2295    23.2232    -0.0038    -0.0137    -0.0069 </r>
+     <r>     3.8639    26.7555    26.7564    26.7494    -0.0038    -0.0151    -0.0074 </r>
+     <r>     3.8839    31.2245    31.2256    31.2175    -0.0037    -0.0170    -0.0080 </r>
+     <r>     3.9039    36.6977    36.6991    36.6895    -0.0038    -0.0194    -0.0088 </r>
+     <r>     3.9239    43.0740    43.0756    43.0641    -0.0042    -0.0224    -0.0099 </r>
+     <r>     3.9439    50.0070    50.0088    49.9944    -0.0050    -0.0260    -0.0114 </r>
+     <r>     3.9640    56.8825    56.8843    56.8663    -0.0066    -0.0301    -0.0133 </r>
+     <r>     3.9840    62.8091    62.8109    62.7886    -0.0090    -0.0344    -0.0155 </r>
+     <r>     4.0040    66.7218    66.7235    66.6965    -0.0120    -0.0385    -0.0180 </r>
+     <r>     4.0240    67.9551    67.9567    67.9249    -0.0158    -0.0421    -0.0205 </r>
+     <r>     4.0440    66.8735    66.8748    66.8384    -0.0201    -0.0451    -0.0230 </r>
+     <r>     4.0641    64.5048    64.5060    64.4649    -0.0248    -0.0478    -0.0256 </r>
+     <r>     4.0841    61.5357    61.5366    61.4913    -0.0295    -0.0501    -0.0281 </r>
+     <r>     4.1041    57.9783    57.9790    57.9310    -0.0334    -0.0512    -0.0299 </r>
+     <r>     4.1241    53.6742    53.6746    53.6268    -0.0356    -0.0503    -0.0306 </r>
+     <r>     4.1441    48.7608    48.7611    48.7167    -0.0354    -0.0470    -0.0297 </r>
+     <r>     4.1642    43.6483    43.6486    43.6109    -0.0330    -0.0417    -0.0275 </r>
+     <r>     4.1842    38.7748    38.7752    38.7459    -0.0290    -0.0355    -0.0244 </r>
+     <r>     4.2042    34.4174    34.4180    34.3971    -0.0245    -0.0298    -0.0211 </r>
+     <r>     4.2242    30.6770    30.6780    30.6639    -0.0201    -0.0251    -0.0181 </r>
+     <r>     4.2442    27.5579    27.5592    27.5500    -0.0161    -0.0215    -0.0154 </r>
+     <r>     4.2643    24.9840    24.9854    24.9793    -0.0124    -0.0189    -0.0130 </r>
+     <r>     4.2843    22.7856    22.7868    22.7825    -0.0092    -0.0170    -0.0109 </r>
+     <r>     4.3043    20.7722    20.7731    20.7696    -0.0066    -0.0155    -0.0092 </r>
+     <r>     4.3243    18.8424    18.8429    18.8396    -0.0046    -0.0143    -0.0079 </r>
+     <r>     4.3443    16.9917    16.9915    16.9880    -0.0032    -0.0134    -0.0069 </r>
+     <r>     4.3644    15.2435    15.2426    15.2387    -0.0021    -0.0127    -0.0061 </r>
+     <r>     4.3844    13.6243    13.6227    13.6182    -0.0013    -0.0122    -0.0056 </r>
+     <r>     4.4044    12.1657    12.1634    12.1584    -0.0006    -0.0118    -0.0051 </r>
+     <r>     4.4244    10.8854    10.8826    10.8773     0.0002    -0.0117    -0.0047 </r>
+     <r>     4.4444     9.7753     9.7724     9.7672     0.0012    -0.0117    -0.0043 </r>
+     <r>     4.4645     8.8173     8.8145     8.8099     0.0025    -0.0120    -0.0039 </r>
+     <r>     4.4845     7.9999     7.9976     7.9938     0.0042    -0.0127    -0.0035 </r>
+     <r>     4.5045     7.3174     7.3156     7.3126     0.0061    -0.0137    -0.0032 </r>
+     <r>     4.5245     6.7629     6.7615     6.7593     0.0083    -0.0152    -0.0029 </r>
+     <r>     4.5445     6.3269     6.3259     6.3244     0.0110    -0.0173    -0.0027 </r>
+     <r>     4.5646     6.0002     5.9995     5.9985     0.0141    -0.0201    -0.0026 </r>
+     <r>     4.5846     5.7752     5.7748     5.7740     0.0178    -0.0238    -0.0025 </r>
+     <r>     4.6046     5.6451     5.6450     5.6442     0.0224    -0.0284    -0.0026 </r>
+     <r>     4.6246     5.5993     5.5993     5.5985     0.0276    -0.0340    -0.0027 </r>
+     <r>     4.6446     5.6142     5.6144     5.6134     0.0332    -0.0400    -0.0029 </r>
+     <r>     4.6647     5.6439     5.6443     5.6433     0.0383    -0.0453    -0.0029 </r>
+     <r>     4.6847     5.6246     5.6251     5.6247     0.0416    -0.0482    -0.0028 </r>
+     <r>     4.7047     5.5073     5.5079     5.5087     0.0420    -0.0473    -0.0023 </r>
+     <r>     4.7247     5.2970     5.2978     5.3004     0.0397    -0.0427    -0.0015 </r>
+     <r>     4.7447     5.0480     5.0489     5.0540     0.0358    -0.0360    -0.0005 </r>
+     <r>     4.7648     4.8222     4.8233     4.8310     0.0318    -0.0288     0.0007 </r>
+     <r>     4.7848     4.6611     4.6624     4.6730     0.0284    -0.0220     0.0019 </r>
+     <r>     4.8048     4.5851     4.5866     4.6003     0.0259    -0.0160     0.0031 </r>
+     <r>     4.8248     4.6029     4.6047     4.6218     0.0246    -0.0108     0.0045 </r>
+     <r>     4.8448     4.7186     4.7208     4.7416     0.0242    -0.0062     0.0060 </r>
+     <r>     4.8649     4.9312     4.9338     4.9591     0.0249    -0.0019     0.0077 </r>
+     <r>     4.8849     5.2281     5.2312     5.2615     0.0265     0.0022     0.0097 </r>
+     <r>     4.9049     5.5741     5.5776     5.6139     0.0290     0.0063     0.0121 </r>
+     <r>     4.9249     5.9114     5.9152     5.9582     0.0324     0.0106     0.0148 </r>
+     <r>     4.9449     6.1898     6.1935     6.2441     0.0367     0.0154     0.0181 </r>
+     <r>     4.9650     6.4153     6.4188     6.4783     0.0422     0.0209     0.0221 </r>
+     <r>     4.9850     6.6602     6.6632     6.7337     0.0493     0.0273     0.0270 </r>
+     <r>     5.0050     7.0155     7.0178     7.1020     0.0584     0.0349     0.0330 </r>
+     <r>     5.0250     7.5364     7.5380     7.6388     0.0694     0.0436     0.0398 </r>
+     <r>     5.0450     8.2076     8.2085     8.3276     0.0811     0.0526     0.0468 </r>
+     <r>     5.0651     8.9163     8.9163     9.0527     0.0910     0.0604     0.0522 </r>
+     <r>     5.0851     9.4545     9.4534     9.6011     0.0949     0.0652     0.0538 </r>
+     <r>     5.1051     9.6088     9.6061     9.7548     0.0895     0.0659     0.0505 </r>
+     <r>     5.1251     9.3095     9.3048     9.4426     0.0746     0.0632     0.0430 </r>
+     <r>     5.1451     8.6692     8.6622     8.7797     0.0538     0.0586     0.0335 </r>
+     <r>     5.1652     7.8620     7.8529     7.9459     0.0315     0.0530     0.0239 </r>
+     <r>     5.1852     7.0171     7.0068     7.0755     0.0112     0.0462     0.0151 </r>
+     <r>     5.2052     6.2110     6.2010     6.2486    -0.0057     0.0385     0.0075 </r>
+     <r>     5.2252     5.4908     5.4830     5.5140    -0.0192     0.0305     0.0010 </r>
+     <r>     5.2452     4.8812     4.8771     4.8961    -0.0298     0.0235    -0.0043 </r>
+     <r>     5.2653     4.3846     4.3851     4.3965    -0.0375     0.0186    -0.0081 </r>
+     <r>     5.2853     3.9885     3.9935     4.0014    -0.0426     0.0160    -0.0104 </r>
+     <r>     5.3053     3.6729     3.6821     3.6892    -0.0452     0.0152    -0.0113 </r>
+     <r>     5.3253     3.4144     3.4266     3.4341    -0.0456     0.0154    -0.0113 </r>
+     <r>     5.3453     3.1900     3.2037     3.2118    -0.0437     0.0154    -0.0104 </r>
+     <r>     5.3654     2.9866     3.0001     3.0087    -0.0396     0.0148    -0.0092 </r>
+     <r>     5.3854     2.8045     2.8168     2.8256    -0.0341     0.0134    -0.0077 </r>
+     <r>     5.4054     2.6509     2.6617     2.6705    -0.0283     0.0117    -0.0064 </r>
+     <r>     5.4254     2.5320     2.5413     2.5502    -0.0232     0.0100    -0.0052 </r>
+     <r>     5.4454     2.4504     2.4584     2.4673    -0.0188     0.0085    -0.0042 </r>
+     <r>     5.4655     2.4063     2.4134     2.4223    -0.0153     0.0072    -0.0035 </r>
+     <r>     5.4855     2.4003     2.4068     2.4157    -0.0126     0.0062    -0.0030 </r>
+     <r>     5.5055     2.4342     2.4402     2.4494    -0.0104     0.0054    -0.0025 </r>
+     <r>     5.5255     2.5117     2.5176     2.5270    -0.0087     0.0048    -0.0022 </r>
+     <r>     5.5455     2.6388     2.6446     2.6544    -0.0073     0.0043    -0.0019 </r>
+     <r>     5.5656     2.8225     2.8283     2.8387    -0.0061     0.0040    -0.0016 </r>
+     <r>     5.5856     3.0677     3.0738     3.0850    -0.0050     0.0038    -0.0014 </r>
+     <r>     5.6056     3.3707     3.3771     3.3893    -0.0040     0.0036    -0.0012 </r>
+     <r>     5.6256     3.7053     3.7122     3.7254    -0.0032     0.0036    -0.0010 </r>
+     <r>     5.6456     4.0105     4.0179     4.0320    -0.0026     0.0036    -0.0009 </r>
+     <r>     5.6657     4.1989     4.2067     4.2214    -0.0024     0.0035    -0.0009 </r>
+     <r>     5.6857     4.2069     4.2148     4.2295    -0.0028     0.0033    -0.0012 </r>
+     <r>     5.7057     4.0484     4.0563     4.0705    -0.0037     0.0030    -0.0017 </r>
+     <r>     5.7257     3.8041     3.8120     3.8254    -0.0050     0.0027    -0.0024 </r>
+     <r>     5.7457     3.5599     3.5677     3.5803    -0.0065     0.0024    -0.0031 </r>
+     <r>     5.7658     3.3670     3.3749     3.3868    -0.0081     0.0022    -0.0039 </r>
+     <r>     5.7858     3.2411     3.2493     3.2608    -0.0098     0.0020    -0.0047 </r>
+     <r>     5.8058     3.1762     3.1849     3.1962    -0.0116     0.0020    -0.0056 </r>
+     <r>     5.8258     3.1599     3.1692     3.1808    -0.0136     0.0020    -0.0066 </r>
+     <r>     5.8458     3.1866     3.1969     3.2090    -0.0159     0.0021    -0.0076 </r>
+     <r>     5.8659     3.2640     3.2756     3.2886    -0.0186     0.0024    -0.0089 </r>
+     <r>     5.8859     3.4078     3.4210     3.4352    -0.0218     0.0028    -0.0103 </r>
+     <r>     5.9059     3.6342     3.6494     3.6653    -0.0259     0.0034    -0.0121 </r>
+     <r>     5.9259     3.9561     3.9737     3.9916    -0.0309     0.0043    -0.0143 </r>
+     <r>     5.9459     4.3791     4.3998     4.4201    -0.0371     0.0053    -0.0170 </r>
+     <r>     5.9660     4.8968     4.9211     4.9443    -0.0446     0.0064    -0.0204 </r>
+     <r>     5.9860     5.4796     5.5081     5.5344    -0.0532     0.0072    -0.0247 </r>
+     <r>     6.0060     6.0642     6.0973     6.1270    -0.0627     0.0072    -0.0299 </r>
+     <r>     6.0260     6.5635     6.6014     6.6342    -0.0725     0.0056    -0.0363 </r>
+     <r>     6.0460     6.9131     6.9559     6.9918    -0.0823     0.0022    -0.0438 </r>
+     <r>     6.0661     7.1115     7.1592     7.1985    -0.0913    -0.0027    -0.0517 </r>
+     <r>     6.0861     7.1950     7.2480     7.2917    -0.0981    -0.0088    -0.0586 </r>
+     <r>     6.1061     7.1802     7.2383     7.2875    -0.1002    -0.0155    -0.0629 </r>
+     <r>     6.1261     7.0461     7.1081     7.1628    -0.0966    -0.0216    -0.0631 </r>
+     <r>     6.1461     6.7656     6.8285     6.8870    -0.0883    -0.0260    -0.0595 </r>
+     <r>     6.1662     6.3540     6.4141     6.4734    -0.0779    -0.0281    -0.0532 </r>
+     <r>     6.1862     5.8854     5.9398     5.9972    -0.0669    -0.0280    -0.0458 </r>
+     <r>     6.2062     5.4545     5.5021     5.5555    -0.0564    -0.0264    -0.0382 </r>
+     <r>     6.2262     5.1310     5.1717     5.2198    -0.0469    -0.0238    -0.0315 </r>
+     <r>     6.2462     4.9489     4.9834     5.0255    -0.0387    -0.0206    -0.0258 </r>
+     <r>     6.2663     4.9190     4.9482     4.9843    -0.0321    -0.0174    -0.0213 </r>
+     <r>     6.2863     5.0413     5.0662     5.0970    -0.0267    -0.0145    -0.0178 </r>
+     <r>     6.3063     5.3075     5.3291     5.3554    -0.0225    -0.0120    -0.0150 </r>
+     <r>     6.3263     5.6923     5.7111     5.7340    -0.0192    -0.0100    -0.0127 </r>
+     <r>     6.3463     6.1382     6.1551     6.1752    -0.0167    -0.0083    -0.0110 </r>
+     <r>     6.3664     6.5548     6.5703     6.5885    -0.0149    -0.0067    -0.0095 </r>
+     <r>     6.3864     6.8588     6.8733     6.8903    -0.0139    -0.0049    -0.0083 </r>
+     <r>     6.4064     7.0377     7.0518     7.0681    -0.0135    -0.0030    -0.0073 </r>
+     <r>     6.4264     7.1624     7.1764     7.1926    -0.0137    -0.0008    -0.0064 </r>
+     <r>     6.4464     7.3320     7.3464     7.3628    -0.0141     0.0013    -0.0056 </r>
+     <r>     6.4665     7.6226     7.6376     7.6548    -0.0146     0.0031    -0.0049 </r>
+     <r>     6.4865     8.0661     8.0821     8.1003    -0.0146     0.0044    -0.0042 </r>
+     <r>     6.5065     8.6389     8.6563     8.6760    -0.0136     0.0047    -0.0036 </r>
+     <r>     6.5265     9.2581     9.2774     9.2988    -0.0116     0.0037    -0.0031 </r>
+     <r>     6.5465     9.8116     9.8330     9.8566    -0.0088     0.0020    -0.0027 </r>
+     <r>     6.5666    10.2228    10.2465    10.2723    -0.0058     0.0000    -0.0024 </r>
+     <r>     6.5866    10.4804    10.5061    10.5340    -0.0032    -0.0016    -0.0022 </r>
+     <r>     6.6066    10.5907    10.6176    10.6467    -0.0014    -0.0027    -0.0019 </r>
+     <r>     6.6266    10.5388    10.5659    10.5951    -0.0003    -0.0033    -0.0018 </r>
+     <r>     6.6466    10.3229    10.3489    10.3770     0.0005    -0.0037    -0.0017 </r>
+     <r>     6.6667    10.0047    10.0291    10.0555     0.0013    -0.0043    -0.0016 </r>
+     <r>     6.6867     9.7098     9.7325     9.7572     0.0024    -0.0051    -0.0015 </r>
+     <r>     6.7067     9.5697     9.5912     9.6145     0.0036    -0.0061    -0.0014 </r>
+     <r>     6.7267     9.6651     9.6859     9.7086     0.0049    -0.0072    -0.0013 </r>
+     <r>     6.7467    10.0128    10.0338    10.0566     0.0061    -0.0083    -0.0012 </r>
+     <r>     6.7668    10.5814    10.6033    10.6270     0.0072    -0.0095    -0.0012 </r>
+     <r>     6.7868    11.2917    11.3152    11.3402     0.0082    -0.0107    -0.0013 </r>
+     <r>     6.8068    11.9910    12.0165    12.0431     0.0092    -0.0121    -0.0014 </r>
+     <r>     6.8268    12.4672    12.4946    12.5230     0.0105    -0.0137    -0.0015 </r>
+     <r>     6.8468    12.5621    12.5912    12.6213     0.0123    -0.0156    -0.0016 </r>
+     <r>     6.8669    12.2834    12.3144    12.3462     0.0147    -0.0181    -0.0015 </r>
+     <r>     6.8869    11.7660    11.7993    11.8336     0.0180    -0.0213    -0.0015 </r>
+     <r>     6.9069    11.1503    11.1870    11.2244     0.0223    -0.0254    -0.0014 </r>
+     <r>     6.9269    10.5342    10.5749    10.6166     0.0275    -0.0304    -0.0013 </r>
+     <r>     6.9469     9.9954    10.0412    10.0879     0.0337    -0.0364    -0.0012 </r>
+     <r>     6.9670     9.6032     9.6547     9.7070     0.0411    -0.0436    -0.0011 </r>
+     <r>     6.9870     9.3914     9.4485     9.5063     0.0494    -0.0518    -0.0011 </r>
+     <r>     7.0070     9.3234     9.3844     9.4461     0.0577    -0.0599    -0.0010 </r>
+     <r>     7.0270     9.2869     9.3481     9.4100     0.0644    -0.0662    -0.0009 </r>
+     <r>     7.0470     9.1449     9.2016     9.2590     0.0674    -0.0686    -0.0007 </r>
+     <r>     7.0671     8.8212     8.8697     8.9192     0.0655    -0.0663    -0.0005 </r>
+     <r>     7.0871     8.3385     8.3776     8.4179     0.0598    -0.0600    -0.0003 </r>
+     <r>     7.1071     7.7669     7.7975     7.8296     0.0521    -0.0518    -0.0002 </r>
+     <r>     7.1271     7.1564     7.1805     7.2065     0.0444    -0.0437     0.0000 </r>
+     <r>     7.1471     6.5367     6.5563     6.5782     0.0379    -0.0366     0.0002 </r>
+     <r>     7.1672     5.9500     5.9669     5.9865     0.0329    -0.0310     0.0004 </r>
+     <r>     7.1872     5.4499     5.4653     5.4840     0.0292    -0.0266     0.0007 </r>
+     <r>     7.2072     5.0744     5.0892     5.1077     0.0268    -0.0234     0.0009 </r>
+     <r>     7.2272     4.8323     4.8468     4.8658     0.0254    -0.0211     0.0012 </r>
+     <r>     7.2472     4.7029     4.7177     4.7376     0.0249    -0.0197     0.0015 </r>
+     <r>     7.2673     4.6405     4.6559     4.6770     0.0250    -0.0191     0.0018 </r>
+     <r>     7.2873     4.5879     4.6044     4.6268     0.0257    -0.0194     0.0019 </r>
+     <r>     7.3073     4.5094     4.5274     4.5512     0.0268    -0.0208     0.0018 </r>
+     <r>     7.3273     4.4168     4.4370     4.4625     0.0285    -0.0232     0.0016 </r>
+     <r>     7.3473     4.3559     4.3789     4.4067     0.0310    -0.0267     0.0013 </r>
+     <r>     7.3674     4.3667     4.3933     4.4239     0.0342    -0.0310     0.0009 </r>
+     <r>     7.3874     4.4560     4.4865     4.5205     0.0380    -0.0358     0.0006 </r>
+     <r>     7.4074     4.5861     4.6203     4.6575     0.0416    -0.0405     0.0003 </r>
+     <r>     7.4274     4.6828     4.7193     4.7582     0.0438    -0.0439    -0.0001 </r>
+     <r>     7.4474     4.6714     4.7079     4.7462     0.0435    -0.0451    -0.0005 </r>
+     <r>     7.4675     4.5266     4.5608     4.5960     0.0406    -0.0439    -0.0010 </r>
+     <r>     7.4875     4.2826     4.3130     4.3435     0.0358    -0.0411    -0.0016 </r>
+     <r>     7.5075     3.9992     4.0255     4.0509     0.0301    -0.0376    -0.0024 </r>
+     <r>     7.5275     3.7332     3.7558     3.7762     0.0245    -0.0344    -0.0032 </r>
+     <r>     7.5475     3.5277     3.5472     3.5632     0.0193    -0.0321    -0.0041 </r>
+     <r>     7.5676     3.4087     3.4256     3.4378     0.0148    -0.0308    -0.0052 </r>
+     <r>     7.5876     3.3846     3.3997     3.4088     0.0113    -0.0304    -0.0062 </r>
+     <r>     7.6076     3.4483     3.4622     3.4690     0.0093    -0.0307    -0.0070 </r>
+     <r>     7.6276     3.5759     3.5888     3.5947     0.0092    -0.0313    -0.0073 </r>
+     <r>     7.6476     3.7268     3.7390     3.7450     0.0110    -0.0318    -0.0069 </r>
+     <r>     7.6677     3.8538     3.8652     3.8719     0.0140    -0.0320    -0.0060 </r>
+     <r>     7.6877     3.9206     3.9313     3.9386     0.0169    -0.0318    -0.0050 </r>
+     <r>     7.7077     3.9129     3.9226     3.9300     0.0188    -0.0308    -0.0040 </r>
+     <r>     7.7277     3.8421     3.8505     3.8578     0.0191    -0.0286    -0.0032 </r>
+     <r>     7.7477     3.7467     3.7537     3.7605     0.0182    -0.0257    -0.0026 </r>
+     <r>     7.7678     3.6726     3.6783     3.6845     0.0165    -0.0224    -0.0020 </r>
+     <r>     7.7878     3.6438     3.6483     3.6540     0.0147    -0.0194    -0.0016 </r>
+     <r>     7.8078     3.6488     3.6523     3.6577     0.0134    -0.0168    -0.0012 </r>
+     <r>     7.8278     3.6535     3.6560     3.6616     0.0128    -0.0147    -0.0007 </r>
+     <r>     7.8478     3.6247     3.6266     3.6328     0.0130    -0.0129     0.0000 </r>
+     <r>     7.8679     3.5413     3.5427     3.5505     0.0141    -0.0112     0.0009 </r>
+     <r>     7.8879     3.3935     3.3947     3.4047     0.0158    -0.0094     0.0021 </r>
+     <r>     7.9079     3.1925     3.1935     3.2066     0.0182    -0.0073     0.0036 </r>
+     <r>     7.9279     2.9744     2.9753     2.9922     0.0211    -0.0052     0.0053 </r>
+     <r>     7.9479     2.7812     2.7820     2.8033     0.0247    -0.0029     0.0072 </r>
+     <r>     7.9680     2.6383     2.6391     2.6653     0.0290    -0.0005     0.0094 </r>
+     <r>     7.9880     2.5483     2.5490     2.5811     0.0341     0.0021     0.0120 </r>
+     <r>     8.0080     2.4979     2.4985     2.5379     0.0402     0.0053     0.0151 </r>
+     <r>     8.0280     2.4716     2.4720     2.5206     0.0477     0.0095     0.0191 </r>
+     <r>     8.0480     2.4633     2.4633     2.5239     0.0570     0.0154     0.0244 </r>
+     <r>     8.0681     2.4771     2.4769     2.5528     0.0687     0.0232     0.0312 </r>
+     <r>     8.0881     2.5214     2.5208     2.6162     0.0836     0.0331     0.0397 </r>
+     <r>     8.1081     2.6023     2.6015     2.7199     0.1015     0.0445     0.0497 </r>
+     <r>     8.1281     2.7138     2.7129     2.8563     0.1211     0.0564     0.0602 </r>
+     <r>     8.1481     2.8248     2.8240     2.9901     0.1387     0.0666     0.0693 </r>
+     <r>     8.1682     2.8787     2.8780     3.0590     0.1492     0.0727     0.0744 </r>
+     <r>     8.1882     2.8218     2.8213     3.0042     0.1486     0.0727     0.0738 </r>
+     <r>     8.2082     2.6458     2.6454     2.8167     0.1373     0.0670     0.0678 </r>
+     <r>     8.2282     2.3950     2.3948     2.5458     0.1199     0.0581     0.0588 </r>
+     <r>     8.2482     2.1303     2.1302     2.2585     0.1012     0.0488     0.0494 </r>
+     <r>     8.2683     1.8945     1.8945     2.0017     0.0844     0.0405     0.0411 </r>
+     <r>     8.2883     1.7059     1.7059     1.7957     0.0707     0.0339     0.0343 </r>
+     <r>     8.3083     1.5671     1.5672     1.6432     0.0600     0.0288     0.0292 </r>
+     <r>     8.3283     1.4734     1.4735     1.5389     0.0520     0.0250     0.0253 </r>
+     <r>     8.3483     1.4159     1.4160     1.4734     0.0458     0.0222     0.0223 </r>
+     <r>     8.3684     1.3828     1.3828     1.4337     0.0407     0.0199     0.0199 </r>
+     <r>     8.3884     1.3603     1.3602     1.4053     0.0359     0.0177     0.0175 </r>
+     <r>     8.4084     1.3373     1.3372     1.3763     0.0309     0.0153     0.0151 </r>
+     <r>     8.4284     1.3088     1.3088     1.3417     0.0257     0.0127     0.0125 </r>
+     <r>     8.4484     1.2742     1.2742     1.3012     0.0206     0.0102     0.0100 </r>
+     <r>     8.4685     1.2343     1.2343     1.2562     0.0162     0.0081     0.0079 </r>
+     <r>     8.4885     1.1919     1.1919     1.2097     0.0127     0.0065     0.0062 </r>
+     <r>     8.5085     1.1543     1.1542     1.1689     0.0100     0.0053     0.0049 </r>
+     <r>     8.5285     1.1306     1.1305     1.1426     0.0078     0.0046     0.0040 </r>
+     <r>     8.5485     1.1263     1.1260     1.1361     0.0059     0.0040     0.0032 </r>
+     <r>     8.5686     1.1391     1.1387     1.1469     0.0042     0.0036     0.0025 </r>
+     <r>     8.5886     1.1573     1.1568     1.1633     0.0026     0.0032     0.0018 </r>
+     <r>     8.6086     1.1614     1.1608     1.1660     0.0014     0.0029     0.0013 </r>
+     <r>     8.6286     1.1340     1.1334     1.1378     0.0007     0.0026     0.0010 </r>
+     <r>     8.6486     1.0729     1.0724     1.0764     0.0006     0.0024     0.0008 </r>
+     <r>     8.6687     0.9922     0.9917     0.9957     0.0007     0.0022     0.0008 </r>
+     <r>     8.6887     0.9097     0.9094     0.9135     0.0010     0.0020     0.0008 </r>
+     <r>     8.7087     0.8374     0.8372     0.8413     0.0012     0.0018     0.0008 </r>
+     <r>     8.7287     0.7793     0.7792     0.7834     0.0014     0.0017     0.0008 </r>
+     <r>     8.7487     0.7349     0.7348     0.7390     0.0014     0.0015     0.0008 </r>
+     <r>     8.7688     0.7016     0.7015     0.7056     0.0013     0.0014     0.0007 </r>
+     <r>     8.7888     0.6773     0.6773     0.6813     0.0012     0.0013     0.0005 </r>
+     <r>     8.8088     0.6616     0.6616     0.6655     0.0010     0.0012     0.0004 </r>
+     <r>     8.8288     0.6552     0.6552     0.6590     0.0007     0.0011     0.0002 </r>
+     <r>     8.8488     0.6591     0.6591     0.6628     0.0003     0.0009    -0.0001 </r>
+     <r>     8.8689     0.6739     0.6738     0.6774    -0.0002     0.0008    -0.0004 </r>
+     <r>     8.8889     0.6989     0.6988     0.7023    -0.0008     0.0007    -0.0007 </r>
+     <r>     8.9089     0.7318     0.7316     0.7350    -0.0014     0.0006    -0.0010 </r>
+     <r>     8.9289     0.7676     0.7673     0.7705    -0.0020     0.0006    -0.0013 </r>
+     <r>     8.9489     0.8003     0.7999     0.8028    -0.0026     0.0009    -0.0014 </r>
+     <r>     8.9690     0.8262     0.8256     0.8283    -0.0031     0.0015    -0.0014 </r>
+     <r>     8.9890     0.8467     0.8459     0.8482    -0.0034     0.0023    -0.0011 </r>
+     <r>     9.0090     0.8670     0.8658     0.8677    -0.0038     0.0032    -0.0009 </r>
+     <r>     9.0290     0.8922     0.8907     0.8921    -0.0042     0.0041    -0.0006 </r>
+     <r>     9.0490     0.9246     0.9227     0.9238    -0.0047     0.0050    -0.0003 </r>
+     <r>     9.0691     0.9613     0.9593     0.9602    -0.0051     0.0058    -0.0001 </r>
+     <r>     9.0891     0.9980     0.9964     0.9974    -0.0054     0.0063     0.0000 </r>
+     <r>     9.1091     1.0354     1.0345     1.0360    -0.0055     0.0065     0.0001 </r>
+     <r>     9.1291     1.0815     1.0816     1.0839    -0.0054     0.0065     0.0001 </r>
+     <r>     9.1491     1.1476     1.1490     1.1524    -0.0053     0.0063     0.0001 </r>
+     <r>     9.1692     1.2424     1.2453     1.2499    -0.0052     0.0060     0.0001 </r>
+     <r>     9.1892     1.3679     1.3725     1.3785    -0.0052     0.0057     0.0000 </r>
+     <r>     9.2092     1.5150     1.5213     1.5287    -0.0052     0.0055    -0.0001 </r>
+     <r>     9.2292     1.6571     1.6650     1.6738    -0.0054     0.0053    -0.0002 </r>
+     <r>     9.2492     1.7518     1.7608     1.7706    -0.0054     0.0053    -0.0002 </r>
+     <r>     9.2693     1.7603     1.7696     1.7795    -0.0053     0.0052    -0.0002 </r>
+     <r>     9.2893     1.6773     1.6859     1.6952    -0.0049     0.0051    -0.0001 </r>
+     <r>     9.3093     1.5362     1.5434     1.5516    -0.0044     0.0049     0.0000 </r>
+     <r>     9.3293     1.3825     1.3881     1.3948    -0.0039     0.0048     0.0002 </r>
+     <r>     9.3493     1.2484     1.2523     1.2575    -0.0035     0.0047     0.0003 </r>
+     <r>     9.3694     1.1482     1.1504     1.1543    -0.0033     0.0048     0.0004 </r>
+     <r>     9.3894     1.0838     1.0846     1.0872    -0.0032     0.0051     0.0006 </r>
+     <r>     9.4094     1.0504     1.0497     1.0511    -0.0033     0.0056     0.0007 </r>
+     <r>     9.4294     1.0386     1.0365     1.0367    -0.0035     0.0062     0.0008 </r>
+     <r>     9.4494     1.0366     1.0330     1.0320    -0.0038     0.0070     0.0010 </r>
+     <r>     9.4695     1.0332     1.0283     1.0264    -0.0041     0.0078     0.0012 </r>
+     <r>     9.4895     1.0214     1.0155     1.0130    -0.0040     0.0084     0.0014 </r>
+     <r>     9.5095     0.9988     0.9924     0.9900    -0.0034     0.0087     0.0017 </r>
+     <r>     9.5295     0.9692     0.9629     0.9613    -0.0023     0.0087     0.0021 </r>
+     <r>     9.5495     0.9418     0.9359     0.9358    -0.0006     0.0085     0.0025 </r>
+     <r>     9.5696     0.9252     0.9198     0.9214     0.0012     0.0082     0.0031 </r>
+     <r>     9.5896     0.9224     0.9174     0.9207     0.0030     0.0081     0.0036 </r>
+     <r>     9.6096     0.9291     0.9244     0.9289     0.0045     0.0081     0.0041 </r>
+     <r>     9.6296     0.9382     0.9336     0.9387     0.0052     0.0081     0.0043 </r>
+     <r>     9.6496     0.9466     0.9418     0.9467     0.0051     0.0081     0.0043 </r>
+     <r>     9.6697     0.9592     0.9540     0.9578     0.0043     0.0081     0.0041 </r>
+     <r>     9.6897     0.9840     0.9781     0.9804     0.0031     0.0082     0.0037 </r>
+     <r>     9.7097     1.0248     1.0179     1.0186     0.0019     0.0084     0.0034 </r>
+     <r>     9.7297     1.0762     1.0683     1.0672     0.0008     0.0087     0.0031 </r>
+     <r>     9.7497     1.1233     1.1144     1.1118    -0.0000     0.0088     0.0028 </r>
+     <r>     9.7698     1.1465     1.1370     1.1333    -0.0004     0.0085     0.0026 </r>
+     <r>     9.7898     1.1331     1.1237     1.1196    -0.0003     0.0077     0.0024 </r>
+     <r>     9.8098     1.0869     1.0783     1.0746     0.0001     0.0066     0.0021 </r>
+     <r>     9.8298     1.0232     1.0157     1.0126     0.0006     0.0053     0.0019 </r>
+     <r>     9.8498     0.9539     0.9475     0.9451     0.0011     0.0041     0.0017 </r>
+     <r>     9.8699     0.8828     0.8776     0.8757     0.0014     0.0031     0.0015 </r>
+     <r>     9.8899     0.8115     0.8071     0.8057     0.0015     0.0024     0.0013 </r>
+     <r>     9.9099     0.7437     0.7401     0.7390     0.0014     0.0019     0.0011 </r>
+     <r>     9.9299     0.6850     0.6819     0.6811     0.0012     0.0016     0.0009 </r>
+     <r>     9.9499     0.6388     0.6362     0.6356     0.0010     0.0014     0.0007 </r>
+     <r>     9.9700     0.6063     0.6041     0.6037     0.0008     0.0012     0.0006 </r>
+     <r>     9.9900     0.5877     0.5858     0.5854     0.0005     0.0011     0.0005 </r>
+     <r>    10.0100     0.5827     0.5811     0.5807     0.0003     0.0009     0.0003 </r>
+     <r>    10.0300     0.5915     0.5901     0.5898     0.0001     0.0008     0.0002 </r>
+     <r>    10.0501     0.6143     0.6131     0.6127    -0.0001     0.0006     0.0001 </r>
+     <r>    10.0701     0.6498     0.6488     0.6483    -0.0003     0.0004    -0.0000 </r>
+     <r>    10.0901     0.6938     0.6929     0.6924    -0.0004     0.0002    -0.0002 </r>
+     <r>    10.1101     0.7377     0.7369     0.7362    -0.0006     0.0001    -0.0003 </r>
+     <r>    10.1301     0.7695     0.7688     0.7681    -0.0008    -0.0001    -0.0004 </r>
+     <r>    10.1502     0.7805     0.7799     0.7791    -0.0011    -0.0001    -0.0006 </r>
+     <r>    10.1702     0.7712     0.7707     0.7699    -0.0014    -0.0001    -0.0007 </r>
+     <r>    10.1902     0.7491     0.7486     0.7478    -0.0017     0.0001    -0.0008 </r>
+     <r>    10.2102     0.7215     0.7210     0.7202    -0.0021     0.0003    -0.0009 </r>
+     <r>    10.2302     0.6931     0.6927     0.6920    -0.0025     0.0005    -0.0010 </r>
+     <r>    10.2503     0.6689     0.6685     0.6679    -0.0029     0.0009    -0.0011 </r>
+     <r>    10.2703     0.6541     0.6536     0.6532    -0.0034     0.0012    -0.0012 </r>
+     <r>    10.2903     0.6527     0.6522     0.6519    -0.0040     0.0016    -0.0013 </r>
+     <r>    10.3103     0.6662     0.6657     0.6655    -0.0044     0.0021    -0.0014 </r>
+     <r>    10.3303     0.6939     0.6934     0.6934    -0.0048     0.0025    -0.0014 </r>
+     <r>    10.3504     0.7334     0.7328     0.7329    -0.0049     0.0028    -0.0013 </r>
+     <r>    10.3704     0.7801     0.7795     0.7796    -0.0048     0.0031    -0.0011 </r>
+     <r>    10.3904     0.8291     0.8284     0.8285    -0.0044     0.0031    -0.0009 </r>
+     <r>    10.4104     0.8772     0.8765     0.8765    -0.0039     0.0030    -0.0007 </r>
+     <r>    10.4304     0.9220     0.9212     0.9213    -0.0033     0.0028    -0.0005 </r>
+     <r>    10.4505     0.9566     0.9558     0.9558    -0.0027     0.0025    -0.0003 </r>
+     <r>    10.4705     0.9689     0.9680     0.9679    -0.0022     0.0023    -0.0002 </r>
+     <r>    10.4905     0.9504     0.9493     0.9490    -0.0020     0.0022    -0.0001 </r>
+     <r>    10.5105     0.9062     0.9049     0.9043    -0.0019     0.0022    -0.0001 </r>
+     <r>    10.5305     0.8525     0.8508     0.8499    -0.0019     0.0023    -0.0001 </r>
+     <r>    10.5506     0.8050     0.8029     0.8015    -0.0021     0.0024    -0.0001 </r>
+     <r>    10.5706     0.7721     0.7695     0.7676    -0.0022     0.0026    -0.0000 </r>
+     <r>    10.5906     0.7553     0.7522     0.7496    -0.0024     0.0028    -0.0000 </r>
+     <r>    10.6106     0.7518     0.7479     0.7446    -0.0026     0.0032     0.0000 </r>
+     <r>    10.6306     0.7566     0.7519     0.7479    -0.0029     0.0037     0.0001 </r>
+     <r>    10.6507     0.7643     0.7588     0.7541    -0.0034     0.0044     0.0002 </r>
+     <r>    10.6707     0.7697     0.7636     0.7586    -0.0040     0.0052     0.0004 </r>
+     <r>    10.6907     0.7702     0.7639     0.7588    -0.0047     0.0060     0.0004 </r>
+     <r>    10.7107     0.7659     0.7598     0.7548    -0.0053     0.0067     0.0005 </r>
+     <r>    10.7307     0.7578     0.7520     0.7474    -0.0058     0.0072     0.0005 </r>
+     <r>    10.7508     0.7462     0.7410     0.7369    -0.0059     0.0074     0.0005 </r>
+     <r>    10.7708     0.7325     0.7278     0.7243    -0.0058     0.0072     0.0005 </r>
+     <r>    10.7908     0.7197     0.7156     0.7126    -0.0055     0.0069     0.0005 </r>
+     <r>    10.8108     0.7118     0.7082     0.7057    -0.0051     0.0065     0.0004 </r>
+     <r>    10.8308     0.7122     0.7091     0.7071    -0.0049     0.0062     0.0004 </r>
+     <r>    10.8509     0.7223     0.7197     0.7181    -0.0046     0.0060     0.0004 </r>
+     <r>    10.8709     0.7409     0.7386     0.7374    -0.0044     0.0058     0.0004 </r>
+     <r>    10.8909     0.7650     0.7629     0.7619    -0.0042     0.0056     0.0005 </r>
+     <r>    10.9109     0.7916     0.7895     0.7887    -0.0039     0.0054     0.0006 </r>
+     <r>    10.9309     0.8181     0.8159     0.8153    -0.0036     0.0052     0.0007 </r>
+     <r>    10.9510     0.8437     0.8414     0.8408    -0.0033     0.0050     0.0007 </r>
+     <r>    10.9710     0.8697     0.8672     0.8668    -0.0031     0.0049     0.0008 </r>
+     <r>    10.9910     0.8970     0.8943     0.8939    -0.0028     0.0048     0.0008 </r>
+     <r>    11.0110     0.9215     0.9186     0.9182    -0.0025     0.0047     0.0009 </r>
+     <r>    11.0310     0.9346     0.9316     0.9313    -0.0023     0.0046     0.0009 </r>
+     <r>    11.0511     0.9297     0.9267     0.9264    -0.0021     0.0043     0.0009 </r>
+     <r>    11.0711     0.9093     0.9065     0.9062    -0.0018     0.0041     0.0008 </r>
+     <r>    11.0911     0.8824     0.8798     0.8796    -0.0017     0.0038     0.0008 </r>
+     <r>    11.1111     0.8553     0.8530     0.8528    -0.0016     0.0036     0.0007 </r>
+     <r>    11.1311     0.8279     0.8259     0.8258    -0.0016     0.0034     0.0007 </r>
+     <r>    11.1512     0.7981     0.7964     0.7964    -0.0016     0.0032     0.0006 </r>
+     <r>    11.1712     0.7658     0.7645     0.7647    -0.0018     0.0032     0.0005 </r>
+     <r>    11.1912     0.7318     0.7309     0.7315    -0.0021     0.0032     0.0004 </r>
+     <r>    11.2112     0.6952     0.6949     0.6958    -0.0025     0.0034     0.0004 </r>
+     <r>    11.2312     0.6550     0.6554     0.6568    -0.0029     0.0036     0.0003 </r>
+     <r>    11.2513     0.6115     0.6125     0.6145    -0.0033     0.0037     0.0002 </r>
+     <r>    11.2713     0.5658     0.5676     0.5701    -0.0035     0.0037     0.0001 </r>
+     <r>    11.2913     0.5208     0.5233     0.5264    -0.0036     0.0036     0.0001 </r>
+     <r>    11.3113     0.4804     0.4836     0.4873    -0.0036     0.0034    -0.0000 </r>
+     <r>    11.3313     0.4479     0.4520     0.4562    -0.0037     0.0031    -0.0002 </r>
+     <r>    11.3514     0.4250     0.4300     0.4350    -0.0037     0.0029    -0.0003 </r>
+     <r>    11.3714     0.4120     0.4181     0.4240    -0.0039     0.0028    -0.0004 </r>
+     <r>    11.3914     0.4088     0.4162     0.4234    -0.0041     0.0027    -0.0005 </r>
+     <r>    11.4114     0.4151     0.4243     0.4330    -0.0044     0.0028    -0.0006 </r>
+     <r>    11.4314     0.4312     0.4424     0.4531    -0.0048     0.0029    -0.0007 </r>
+     <r>    11.4515     0.4570     0.4708     0.4838    -0.0053     0.0031    -0.0008 </r>
+     <r>    11.4715     0.4916     0.5084     0.5241    -0.0059     0.0033    -0.0010 </r>
+     <r>    11.4915     0.5316     0.5513     0.5699    -0.0065     0.0036    -0.0011 </r>
+     <r>    11.5115     0.5695     0.5918     0.6126    -0.0073     0.0038    -0.0012 </r>
+     <r>    11.5315     0.5961     0.6197     0.6412    -0.0082     0.0040    -0.0014 </r>
+     <r>    11.5516     0.6060     0.6290     0.6493    -0.0094     0.0041    -0.0017 </r>
+     <r>    11.5716     0.6024     0.6233     0.6405    -0.0112     0.0042    -0.0022 </r>
+     <r>    11.5916     0.5960     0.6138     0.6268    -0.0135     0.0043    -0.0029 </r>
+     <r>    11.6116     0.5969     0.6116     0.6200    -0.0163     0.0046    -0.0037 </r>
+     <r>    11.6316     0.6112     0.6229     0.6271    -0.0194     0.0052    -0.0045 </r>
+     <r>    11.6517     0.6402     0.6494     0.6499    -0.0227     0.0063    -0.0052 </r>
+     <r>    11.6717     0.6816     0.6888     0.6864    -0.0259     0.0078    -0.0057 </r>
+     <r>    11.6917     0.7289     0.7347     0.7303    -0.0286     0.0094    -0.0061 </r>
+     <r>    11.7117     0.7698     0.7748     0.7694    -0.0302     0.0104    -0.0063 </r>
+     <r>    11.7317     0.7884     0.7933     0.7879    -0.0301     0.0104    -0.0064 </r>
+     <r>    11.7518     0.7739     0.7790     0.7743    -0.0280     0.0093    -0.0061 </r>
+     <r>    11.7718     0.7284     0.7336     0.7300    -0.0246     0.0078    -0.0056 </r>
+     <r>    11.7918     0.6652     0.6703     0.6678    -0.0207     0.0063    -0.0049 </r>
+     <r>    11.8118     0.5999     0.6045     0.6029    -0.0172     0.0051    -0.0042 </r>
+     <r>    11.8318     0.5427     0.5469     0.5459    -0.0142     0.0042    -0.0035 </r>
+     <r>    11.8519     0.4985     0.5021     0.5016    -0.0119     0.0035    -0.0029 </r>
+     <r>    11.8719     0.4684     0.4716     0.4714    -0.0100     0.0030    -0.0025 </r>
+     <r>    11.8919     0.4525     0.4552     0.4553    -0.0086     0.0026    -0.0021 </r>
+     <r>    11.9119     0.4498     0.4521     0.4524    -0.0075     0.0023    -0.0019 </r>
+     <r>    11.9319     0.4590     0.4611     0.4616    -0.0066     0.0020    -0.0017 </r>
+     <r>    11.9520     0.4779     0.4799     0.4807    -0.0060     0.0019    -0.0016 </r>
+     <r>    11.9720     0.5031     0.5050     0.5063    -0.0056     0.0018    -0.0015 </r>
+     <r>    11.9920     0.5292     0.5312     0.5327    -0.0054     0.0018    -0.0015 </r>
+     <r>    12.0120     0.5497     0.5517     0.5536    -0.0055     0.0019    -0.0016 </r>
+     <r>    12.0320     0.5607     0.5626     0.5645    -0.0059     0.0021    -0.0018 </r>
+     <r>    12.0521     0.5630     0.5647     0.5665    -0.0064     0.0024    -0.0019 </r>
+     <r>    12.0721     0.5591     0.5606     0.5623    -0.0067     0.0027    -0.0019 </r>
+     <r>    12.0921     0.5486     0.5499     0.5514    -0.0069     0.0030    -0.0019 </r>
+     <r>    12.1121     0.5286     0.5297     0.5309    -0.0067     0.0033    -0.0017 </r>
+     <r>    12.1321     0.4988     0.4998     0.5008    -0.0065     0.0034    -0.0015 </r>
+     <r>    12.1522     0.4639     0.4648     0.4657    -0.0062     0.0036    -0.0013 </r>
+     <r>    12.1722     0.4295     0.4303     0.4311    -0.0061     0.0037    -0.0011 </r>
+     <r>    12.1922     0.3983     0.3991     0.3998    -0.0060     0.0039    -0.0010 </r>
+     <r>    12.2122     0.3704     0.3712     0.3718    -0.0061     0.0042    -0.0009 </r>
+     <r>    12.2322     0.3459     0.3466     0.3471    -0.0065     0.0047    -0.0008 </r>
+     <r>    12.2523     0.3258     0.3264     0.3268    -0.0069     0.0053    -0.0007 </r>
+     <r>    12.2723     0.3112     0.3118     0.3121    -0.0076     0.0060    -0.0007 </r>
+     <r>    12.2923     0.3032     0.3038     0.3040    -0.0085     0.0070    -0.0007 </r>
+     <r>    12.3123     0.3023     0.3027     0.3029    -0.0097     0.0082    -0.0006 </r>
+     <r>    12.3323     0.3085     0.3089     0.3090    -0.0112     0.0097    -0.0006 </r>
+     <r>    12.3524     0.3219     0.3223     0.3223    -0.0132     0.0116    -0.0006 </r>
+     <r>    12.3724     0.3424     0.3426     0.3425    -0.0156     0.0140    -0.0007 </r>
+     <r>    12.3924     0.3688     0.3689     0.3687    -0.0185     0.0169    -0.0007 </r>
+     <r>    12.4124     0.3992     0.3992     0.3988    -0.0217     0.0201    -0.0006 </r>
+     <r>    12.4324     0.4307     0.4306     0.4300    -0.0249     0.0235    -0.0006 </r>
+     <r>    12.4525     0.4594     0.4592     0.4583    -0.0275     0.0262    -0.0006 </r>
+     <r>    12.4725     0.4798     0.4796     0.4785    -0.0286     0.0276    -0.0005 </r>
+     <r>    12.4925     0.4875     0.4872     0.4861    -0.0281     0.0272    -0.0005 </r>
+     <r>    12.5125     0.4804     0.4801     0.4791    -0.0261     0.0253    -0.0004 </r>
+     <r>    12.5325     0.4599     0.4598     0.4590    -0.0235     0.0226    -0.0004 </r>
+     <r>    12.5526     0.4310     0.4311     0.4306    -0.0207     0.0198    -0.0004 </r>
+     <r>    12.5726     0.4004     0.4008     0.4005    -0.0182     0.0171    -0.0004 </r>
+     <r>    12.5926     0.3735     0.3740     0.3740    -0.0161     0.0148    -0.0004 </r>
+     <r>    12.6126     0.3527     0.3534     0.3535    -0.0144     0.0129    -0.0005 </r>
+     <r>    12.6326     0.3390     0.3398     0.3397    -0.0130     0.0113    -0.0006 </r>
+     <r>    12.6527     0.3326     0.3334     0.3332    -0.0120     0.0100    -0.0006 </r>
+     <r>    12.6727     0.3340     0.3347     0.3343    -0.0112     0.0090    -0.0007 </r>
+     <r>    12.6927     0.3432     0.3439     0.3433    -0.0108     0.0083    -0.0009 </r>
+     <r>    12.7127     0.3597     0.3604     0.3597    -0.0107     0.0078    -0.0010 </r>
+     <r>    12.7327     0.3819     0.3829     0.3821    -0.0109     0.0076    -0.0011 </r>
+     <r>    12.7528     0.4072     0.4085     0.4078    -0.0114     0.0076    -0.0013 </r>
+     <r>    12.7728     0.4320     0.4338     0.4333    -0.0119     0.0077    -0.0014 </r>
+     <r>    12.7928     0.4527     0.4550     0.4548    -0.0124     0.0078    -0.0016 </r>
+     <r>    12.8128     0.4661     0.4688     0.4689    -0.0127     0.0078    -0.0016 </r>
+     <r>    12.8328     0.4718     0.4748     0.4752    -0.0126     0.0077    -0.0017 </r>
+     <r>    12.8529     0.4735     0.4768     0.4776    -0.0122     0.0074    -0.0016 </r>
+     <r>    12.8729     0.4766     0.4802     0.4817    -0.0116     0.0071    -0.0015 </r>
+     <r>    12.8929     0.4850     0.4891     0.4912    -0.0111     0.0068    -0.0015 </r>
+     <r>    12.9129     0.4995     0.5041     0.5068    -0.0108     0.0067    -0.0014 </r>
+     <r>    12.9329     0.5187     0.5237     0.5269    -0.0105     0.0066    -0.0013 </r>
+     <r>    12.9530     0.5420     0.5472     0.5508    -0.0102     0.0066    -0.0013 </r>
+     <r>    12.9730     0.5697     0.5751     0.5791    -0.0100     0.0066    -0.0012 </r>
+     <r>    12.9930     0.6025     0.6080     0.6123    -0.0099     0.0065    -0.0011 </r>
+     <r>    13.0130     0.6400     0.6457     0.6501    -0.0097     0.0064    -0.0011 </r>
+     <r>    13.0330     0.6831     0.6887     0.6933    -0.0096     0.0062    -0.0011 </r>
+     <r>    13.0531     0.7341     0.7398     0.7444    -0.0096     0.0060    -0.0012 </r>
+     <r>    13.0731     0.7943     0.8000     0.8047    -0.0096     0.0057    -0.0012 </r>
+     <r>    13.0931     0.8581     0.8639     0.8686    -0.0096     0.0054    -0.0013 </r>
+     <r>    13.1131     0.9107     0.9165     0.9211    -0.0098     0.0050    -0.0015 </r>
+     <r>    13.1331     0.9326     0.9382     0.9422    -0.0101     0.0043    -0.0018 </r>
+     <r>    13.1532     0.9133     0.9186     0.9216    -0.0107     0.0033    -0.0023 </r>
+     <r>    13.1732     0.8613     0.8663     0.8679    -0.0115     0.0022    -0.0030 </r>
+     <r>    13.1932     0.7958     0.8004     0.8002    -0.0126     0.0008    -0.0038 </r>
+     <r>    13.2132     0.7311     0.7352     0.7332    -0.0142    -0.0007    -0.0048 </r>
+     <r>    13.2332     0.6712     0.6750     0.6709    -0.0163    -0.0023    -0.0061 </r>
+     <r>    13.2533     0.6150     0.6185     0.6121    -0.0191    -0.0042    -0.0076 </r>
+     <r>    13.2733     0.5625     0.5657     0.5566    -0.0225    -0.0064    -0.0095 </r>
+     <r>    13.2933     0.5166     0.5196     0.5073    -0.0267    -0.0089    -0.0117 </r>
+     <r>    13.3133     0.4799     0.4827     0.4673    -0.0312    -0.0116    -0.0141 </r>
+     <r>    13.3333     0.4525     0.4553     0.4372    -0.0353    -0.0140    -0.0163 </r>
+     <r>    13.3534     0.4322     0.4350     0.4154    -0.0377    -0.0155    -0.0177 </r>
+     <r>    13.3734     0.4167     0.4195     0.4003    -0.0375    -0.0158    -0.0178 </r>
+     <r>    13.3934     0.4055     0.4085     0.3913    -0.0348    -0.0148    -0.0166 </r>
+     <r>    13.4134     0.4003     0.4035     0.3892    -0.0307    -0.0129    -0.0146 </r>
+     <r>    13.4334     0.4026     0.4063     0.3950    -0.0262    -0.0108    -0.0124 </r>
+     <r>    13.4535     0.4124     0.4165     0.4080    -0.0222    -0.0089    -0.0105 </r>
+     <r>    13.4735     0.4271     0.4317     0.4257    -0.0189    -0.0073    -0.0088 </r>
+     <r>    13.4935     0.4432     0.4483     0.4444    -0.0162    -0.0061    -0.0075 </r>
+     <r>    13.5135     0.4575     0.4630     0.4608    -0.0140    -0.0053    -0.0065 </r>
+     <r>    13.5335     0.4682     0.4740     0.4730    -0.0121    -0.0048    -0.0057 </r>
+     <r>    13.5536     0.4738     0.4796     0.4796    -0.0105    -0.0045    -0.0051 </r>
+     <r>    13.5736     0.4729     0.4785     0.4792    -0.0091    -0.0043    -0.0047 </r>
+     <r>    13.5936     0.4647     0.4700     0.4709    -0.0082    -0.0041    -0.0044 </r>
+     <r>    13.6136     0.4492     0.4540     0.4551    -0.0077    -0.0037    -0.0042 </r>
+     <r>    13.6336     0.4267     0.4310     0.4321    -0.0074    -0.0032    -0.0040 </r>
+     <r>    13.6537     0.3990     0.4027     0.4037    -0.0073    -0.0025    -0.0038 </r>
+     <r>    13.6737     0.3693     0.3724     0.3732    -0.0070    -0.0019    -0.0035 </r>
+     <r>    13.6937     0.3420     0.3445     0.3450    -0.0066    -0.0013    -0.0031 </r>
+     <r>    13.7137     0.3203     0.3223     0.3225    -0.0063    -0.0007    -0.0028 </r>
+     <r>    13.7337     0.3056     0.3072     0.3072    -0.0060    -0.0002    -0.0024 </r>
+     <r>    13.7538     0.2979     0.2992     0.2989    -0.0058     0.0004    -0.0022 </r>
+     <r>    13.7738     0.2961     0.2971     0.2966    -0.0056     0.0009    -0.0019 </r>
+     <r>    13.7938     0.2986     0.2994     0.2987    -0.0055     0.0013    -0.0017 </r>
+     <r>    13.8138     0.3041     0.3046     0.3039    -0.0052     0.0015    -0.0015 </r>
+     <r>    13.8338     0.3122     0.3126     0.3118    -0.0049     0.0015    -0.0014 </r>
+     <r>    13.8539     0.3240     0.3243     0.3236    -0.0045     0.0014    -0.0012 </r>
+     <r>    13.8739     0.3409     0.3413     0.3406    -0.0040     0.0012    -0.0011 </r>
+     <r>    13.8939     0.3633     0.3637     0.3631    -0.0037     0.0009    -0.0011 </r>
+     <r>    13.9139     0.3892     0.3897     0.3893    -0.0033     0.0007    -0.0010 </r>
+     <r>    13.9339     0.4148     0.4153     0.4150    -0.0031     0.0006    -0.0009 </r>
+     <r>    13.9540     0.4345     0.4350     0.4347    -0.0028     0.0005    -0.0009 </r>
+     <r>    13.9740     0.4439     0.4442     0.4438    -0.0026     0.0004    -0.0008 </r>
+     <r>    13.9940     0.4428     0.4428     0.4421    -0.0024     0.0003    -0.0008 </r>
+     <r>    14.0140     0.4360     0.4355     0.4344    -0.0021     0.0002    -0.0007 </r>
+     <r>    14.0340     0.4296     0.4285     0.4269    -0.0019     0.0001    -0.0007 </r>
+     <r>    14.0541     0.4275     0.4257     0.4235    -0.0016     0.0000    -0.0006 </r>
+     <r>    14.0741     0.4305     0.4280     0.4250    -0.0015    -0.0000    -0.0006 </r>
+     <r>    14.0941     0.4366     0.4334     0.4298    -0.0013    -0.0001    -0.0005 </r>
+     <r>    14.1141     0.4416     0.4380     0.4340    -0.0012    -0.0001    -0.0005 </r>
+     <r>    14.1341     0.4414     0.4377     0.4336    -0.0011    -0.0002    -0.0005 </r>
+     <r>    14.1542     0.4349     0.4314     0.4276    -0.0009    -0.0004    -0.0005 </r>
+     <r>    14.1742     0.4247     0.4218     0.4185    -0.0008    -0.0005    -0.0005 </r>
+     <r>    14.1942     0.4146     0.4124     0.4097    -0.0009    -0.0005    -0.0006 </r>
+     <r>    14.2142     0.4069     0.4053     0.4032    -0.0012    -0.0003    -0.0006 </r>
+     <r>    14.2342     0.4016     0.4005     0.3988    -0.0016     0.0000    -0.0006 </r>
+     <r>    14.2543     0.3966     0.3960     0.3945    -0.0021     0.0004    -0.0007 </r>
+     <r>    14.2743     0.3892     0.3888     0.3874    -0.0028     0.0008    -0.0008 </r>
+     <r>    14.2943     0.3783     0.3781     0.3765    -0.0035     0.0011    -0.0009 </r>
+     <r>    14.3143     0.3663     0.3662     0.3645    -0.0043     0.0014    -0.0011 </r>
+     <r>    14.3343     0.3573     0.3573     0.3553    -0.0052     0.0017    -0.0013 </r>
+     <r>    14.3544     0.3546     0.3547     0.3524    -0.0061     0.0020    -0.0015 </r>
+     <r>    14.3744     0.3594     0.3596     0.3569    -0.0071     0.0023    -0.0018 </r>
+     <r>    14.3944     0.3715     0.3717     0.3687    -0.0081     0.0025    -0.0019 </r>
+     <r>    14.4144     0.3893     0.3897     0.3865    -0.0089     0.0029    -0.0020 </r>
+     <r>    14.4344     0.4111     0.4116     0.4085    -0.0097     0.0034    -0.0021 </r>
+     <r>    14.4545     0.4341     0.4347     0.4318    -0.0105     0.0044    -0.0020 </r>
+     <r>    14.4745     0.4549     0.4556     0.4532    -0.0115     0.0058    -0.0019 </r>
+     <r>    14.4945     0.4707     0.4717     0.4697    -0.0127     0.0074    -0.0017 </r>
+     <r>    14.5145     0.4811     0.4823     0.4808    -0.0137     0.0089    -0.0017 </r>
+     <r>    14.5345     0.4877     0.4893     0.4882    -0.0142     0.0099    -0.0016 </r>
+     <r>    14.5546     0.4934     0.4952     0.4945    -0.0139     0.0100    -0.0016 </r>
+     <r>    14.5746     0.5014     0.5035     0.5032    -0.0129     0.0094    -0.0015 </r>
+     <r>    14.5946     0.5154     0.5176     0.5177    -0.0117     0.0084    -0.0014 </r>
+     <r>    14.6146     0.5368     0.5391     0.5395    -0.0107     0.0074    -0.0013 </r>
+     <r>    14.6346     0.5636     0.5661     0.5668    -0.0099     0.0066    -0.0013 </r>
+     <r>    14.6547     0.5891     0.5918     0.5926    -0.0093     0.0060    -0.0012 </r>
+     <r>    14.6747     0.6038     0.6066     0.6075    -0.0087     0.0054    -0.0012 </r>
+     <r>    14.6947     0.6011     0.6040     0.6049    -0.0082     0.0048    -0.0012 </r>
+     <r>    14.7147     0.5822     0.5849     0.5859    -0.0076     0.0043    -0.0012 </r>
+     <r>    14.7347     0.5535     0.5561     0.5569    -0.0070     0.0038    -0.0011 </r>
+     <r>    14.7548     0.5228     0.5252     0.5257    -0.0065     0.0033    -0.0011 </r>
+     <r>    14.7748     0.4966     0.4986     0.4989    -0.0061     0.0029    -0.0011 </r>
+     <r>    14.7948     0.4789     0.4806     0.4806    -0.0058     0.0026    -0.0011 </r>
+     <r>    14.8148     0.4700     0.4715     0.4712    -0.0056     0.0024    -0.0011 </r>
+     <r>    14.8348     0.4665     0.4676     0.4669    -0.0054     0.0021    -0.0011 </r>
+     <r>    14.8549     0.4629     0.4637     0.4626    -0.0052     0.0018    -0.0011 </r>
+     <r>    14.8749     0.4562     0.4563     0.4548    -0.0047     0.0015    -0.0011 </r>
+     <r>    14.8949     0.4472     0.4467     0.4446    -0.0041     0.0011    -0.0010 </r>
+     <r>    14.9149     0.4399     0.4386     0.4360    -0.0034     0.0007    -0.0009 </r>
+     <r>    14.9349     0.4375     0.4354     0.4323    -0.0028     0.0003    -0.0008 </r>
+     <r>    14.9550     0.4405     0.4377     0.4340    -0.0022     0.0001    -0.0007 </r>
+     <r>    14.9750     0.4471     0.4438     0.4398    -0.0018    -0.0001    -0.0006 </r>
+     <r>    14.9950     0.4559     0.4524     0.4481    -0.0015    -0.0001    -0.0006 </r>
+     <r>    15.0150     0.4667     0.4632     0.4590    -0.0013    -0.0001    -0.0005 </r>
+     <r>    15.0350     0.4802     0.4768     0.4729    -0.0012     0.0000    -0.0004 </r>
+     <r>    15.0551     0.4963     0.4931     0.4895    -0.0012     0.0001    -0.0004 </r>
+     <r>    15.0751     0.5145     0.5115     0.5081    -0.0013     0.0003    -0.0003 </r>
+     <r>    15.0951     0.5326     0.5298     0.5266    -0.0013     0.0004    -0.0003 </r>
+     <r>    15.1151     0.5458     0.5431     0.5401    -0.0012     0.0004    -0.0002 </r>
+     <r>    15.1351     0.5481     0.5455     0.5427    -0.0010     0.0003    -0.0002 </r>
+     <r>    15.1552     0.5374     0.5351     0.5325    -0.0007     0.0000    -0.0002 </r>
+     <r>    15.1752     0.5193     0.5171     0.5148    -0.0002    -0.0004    -0.0002 </r>
+     <r>    15.1952     0.5017     0.4997     0.4976     0.0004    -0.0008    -0.0002 </r>
+     <r>    15.2152     0.4902     0.4883     0.4863     0.0008    -0.0012    -0.0002 </r>
+     <r>    15.2352     0.4867     0.4849     0.4829     0.0010    -0.0013    -0.0002 </r>
+     <r>    15.2553     0.4912     0.4895     0.4875     0.0010    -0.0013    -0.0002 </r>
+     <r>    15.2753     0.5039     0.5023     0.5005     0.0008    -0.0012    -0.0002 </r>
+     <r>    15.2953     0.5256     0.5240     0.5223     0.0007    -0.0010    -0.0002 </r>
+     <r>    15.3153     0.5567     0.5554     0.5538     0.0005    -0.0009    -0.0002 </r>
+     <r>    15.3353     0.5968     0.5956     0.5942     0.0004    -0.0008    -0.0002 </r>
+     <r>    15.3554     0.6408     0.6398     0.6385     0.0002    -0.0008    -0.0003 </r>
+     <r>    15.3754     0.6773     0.6763     0.6752     0.0002    -0.0008    -0.0003 </r>
+     <r>    15.3954     0.6898     0.6890     0.6879     0.0001    -0.0007    -0.0003 </r>
+     <r>    15.4154     0.6681     0.6673     0.6662     0.0000    -0.0006    -0.0003 </r>
+     <r>    15.4354     0.6168     0.6159     0.6149    -0.0000    -0.0006    -0.0003 </r>
+     <r>    15.4555     0.5517     0.5508     0.5498    -0.0001    -0.0005    -0.0002 </r>
+     <r>    15.4755     0.4881     0.4871     0.4860    -0.0001    -0.0004    -0.0002 </r>
+     <r>    15.4955     0.4344     0.4334     0.4321    -0.0002    -0.0003    -0.0002 </r>
+     <r>    15.5155     0.3937     0.3925     0.3911    -0.0002    -0.0002    -0.0002 </r>
+     <r>    15.5355     0.3658     0.3645     0.3629    -0.0002    -0.0002    -0.0002 </r>
+     <r>    15.5556     0.3498     0.3482     0.3464    -0.0002    -0.0002    -0.0002 </r>
+     <r>    15.5756     0.3442     0.3423     0.3403    -0.0003    -0.0001    -0.0002 </r>
+     <r>    15.5956     0.3477     0.3454     0.3430    -0.0003    -0.0001    -0.0002 </r>
+     <r>    15.6156     0.3580     0.3553     0.3525    -0.0003    -0.0001    -0.0002 </r>
+     <r>    15.6356     0.3722     0.3690     0.3657    -0.0003    -0.0001    -0.0002 </r>
+     <r>    15.6557     0.3872     0.3835     0.3797    -0.0003    -0.0001    -0.0002 </r>
+     <r>    15.6757     0.4015     0.3972     0.3929    -0.0003    -0.0000    -0.0002 </r>
+     <r>    15.6957     0.4150     0.4104     0.4058    -0.0003     0.0000    -0.0001 </r>
+     <r>    15.7157     0.4296     0.4248     0.4200    -0.0004     0.0001    -0.0001 </r>
+     <r>    15.7357     0.4470     0.4422     0.4374    -0.0004     0.0002    -0.0001 </r>
+     <r>    15.7558     0.4671     0.4623     0.4576    -0.0005     0.0002    -0.0001 </r>
+     <r>    15.7758     0.4867     0.4820     0.4773    -0.0006     0.0003    -0.0001 </r>
+     <r>    15.7958     0.5013     0.4967     0.4921    -0.0007     0.0004    -0.0001 </r>
+     <r>    15.8158     0.5092     0.5048     0.5003    -0.0009     0.0006    -0.0001 </r>
+     <r>    15.8358     0.5138     0.5094     0.5050    -0.0012     0.0009    -0.0001 </r>
+     <r>    15.8559     0.5196     0.5152     0.5108    -0.0015     0.0012    -0.0001 </r>
+     <r>    15.8759     0.5276     0.5231     0.5186    -0.0018     0.0015    -0.0001 </r>
+     <r>    15.8959     0.5328     0.5282     0.5236    -0.0021     0.0018    -0.0001 </r>
+     <r>    15.9159     0.5268     0.5222     0.5176    -0.0022     0.0019    -0.0001 </r>
+     <r>    15.9359     0.5046     0.5001     0.4957    -0.0021     0.0019    -0.0001 </r>
+     <r>    15.9560     0.4694     0.4653     0.4613    -0.0020     0.0017    -0.0001 </r>
+     <r>    15.9760     0.4303     0.4267     0.4232    -0.0017     0.0015    -0.0001 </r>
+     <r>    15.9960     0.3958     0.3926     0.3895    -0.0015     0.0013    -0.0001 </r>
+     <r>    16.0160     0.3702     0.3675     0.3647    -0.0013     0.0011    -0.0001 </r>
+     <r>    16.0360     0.3548     0.3523     0.3498    -0.0012     0.0010    -0.0001 </r>
+     <r>    16.0561     0.3484     0.3461     0.3438    -0.0011     0.0009    -0.0001 </r>
+     <r>    16.0761     0.3493     0.3471     0.3449    -0.0010     0.0008    -0.0001 </r>
+     <r>    16.0961     0.3549     0.3527     0.3506    -0.0010     0.0008    -0.0001 </r>
+     <r>    16.1161     0.3624     0.3603     0.3582    -0.0010     0.0007    -0.0001 </r>
+     <r>    16.1361     0.3692     0.3672     0.3651    -0.0010     0.0007    -0.0001 </r>
+     <r>    16.1562     0.3732     0.3713     0.3693    -0.0010     0.0007    -0.0001 </r>
+     <r>    16.1762     0.3732     0.3713     0.3694    -0.0009     0.0007    -0.0001 </r>
+     <r>    16.1962     0.3704     0.3686     0.3668    -0.0009     0.0007    -0.0001 </r>
+     <r>    16.2162     0.3690     0.3673     0.3657    -0.0009     0.0007    -0.0001 </r>
+     <r>    16.2362     0.3735     0.3719     0.3704    -0.0009     0.0007    -0.0001 </r>
+     <r>    16.2563     0.3866     0.3850     0.3835    -0.0009     0.0007    -0.0001 </r>
+     <r>    16.2763     0.4078     0.4063     0.4048    -0.0009     0.0007    -0.0001 </r>
+     <r>    16.2963     0.4339     0.4324     0.4310    -0.0009     0.0007    -0.0001 </r>
+     <r>    16.3163     0.4594     0.4578     0.4564    -0.0008     0.0007    -0.0001 </r>
+     <r>    16.3363     0.4783     0.4768     0.4754    -0.0007     0.0005    -0.0001 </r>
+     <r>    16.3564     0.4871     0.4857     0.4845    -0.0004     0.0002    -0.0001 </r>
+     <r>    16.3764     0.4868     0.4857     0.4846     0.0001    -0.0002    -0.0001 </r>
+     <r>    16.3964     0.4822     0.4814     0.4807     0.0006    -0.0008    -0.0001 </r>
+     <r>    16.4164     0.4777     0.4774     0.4771     0.0012    -0.0013    -0.0001 </r>
+     <r>    16.4364     0.4741     0.4743     0.4745     0.0017    -0.0018    -0.0001 </r>
+     <r>    16.4565     0.4695     0.4700     0.4706     0.0020    -0.0021    -0.0001 </r>
+     <r>    16.4765     0.4620     0.4629     0.4637     0.0021    -0.0021    -0.0000 </r>
+     <r>    16.4965     0.4518     0.4527     0.4537     0.0021    -0.0020    -0.0000 </r>
+     <r>    16.5165     0.4389     0.4398     0.4407     0.0019    -0.0018     0.0000 </r>
+     <r>    16.5365     0.4225     0.4233     0.4241     0.0017    -0.0015     0.0001 </r>
+     <r>    16.5566     0.4021     0.4028     0.4035     0.0015    -0.0012     0.0001 </r>
+     <r>    16.5766     0.3786     0.3792     0.3799     0.0013    -0.0009     0.0002 </r>
+     <r>    16.5966     0.3542     0.3548     0.3553     0.0011    -0.0007     0.0002 </r>
+     <r>    16.6166     0.3317     0.3322     0.3326     0.0008    -0.0005     0.0001 </r>
+     <r>    16.6366     0.3133     0.3137     0.3141     0.0006    -0.0003     0.0001 </r>
+     <r>    16.6567     0.3001     0.3005     0.3008     0.0004    -0.0002     0.0001 </r>
+     <r>    16.6767     0.2920     0.2923     0.2926     0.0003    -0.0001     0.0001 </r>
+     <r>    16.6967     0.2877     0.2880     0.2883     0.0002    -0.0001     0.0001 </r>
+     <r>    16.7167     0.2862     0.2865     0.2868     0.0001    -0.0000     0.0000 </r>
+     <r>    16.7367     0.2870     0.2873     0.2877     0.0001    -0.0000     0.0000 </r>
+     <r>    16.7568     0.2914     0.2918     0.2923     0.0001     0.0000     0.0000 </r>
+     <r>    16.7768     0.3012     0.3017     0.3023     0.0000     0.0000     0.0000 </r>
+     <r>    16.7968     0.3170     0.3177     0.3183     0.0000     0.0001     0.0000 </r>
+     <r>    16.8168     0.3376     0.3384     0.3393    -0.0000     0.0001     0.0000 </r>
+     <r>    16.8368     0.3600     0.3610     0.3621    -0.0000     0.0001     0.0000 </r>
+     <r>    16.8569     0.3811     0.3824     0.3838    -0.0000     0.0001     0.0000 </r>
+     <r>    16.8769     0.4003     0.4020     0.4038    -0.0000     0.0001     0.0000 </r>
+     <r>    16.8969     0.4193     0.4215     0.4238     0.0000     0.0001     0.0000 </r>
+     <r>    16.9169     0.4390     0.4417     0.4445     0.0000     0.0001     0.0000 </r>
+     <r>    16.9369     0.4555     0.4586     0.4618     0.0001     0.0001     0.0000 </r>
+     <r>    16.9570     0.4607     0.4641     0.4676     0.0001     0.0000     0.0000 </r>
+     <r>    16.9770     0.4476     0.4510     0.4545     0.0001     0.0000     0.0000 </r>
+     <r>    16.9970     0.4165     0.4197     0.4229     0.0001     0.0000     0.0000 </r>
+     <r>    17.0170     0.3755     0.3782     0.3811     0.0001     0.0000     0.0000 </r>
+     <r>    17.0370     0.3339     0.3362     0.3386     0.0000     0.0000     0.0000 </r>
+     <r>    17.0571     0.2980     0.2998     0.3018    -0.0000     0.0001     0.0000 </r>
+     <r>    17.0771     0.2699     0.2714     0.2729    -0.0001     0.0001     0.0000 </r>
+     <r>    17.0971     0.2499     0.2511     0.2523    -0.0001     0.0001     0.0000 </r>
+     <r>    17.1171     0.2373     0.2382     0.2392    -0.0001     0.0001     0.0000 </r>
+     <r>    17.1371     0.2312     0.2319     0.2327    -0.0002     0.0002     0.0000 </r>
+     <r>    17.1572     0.2311     0.2317     0.2324    -0.0002     0.0002     0.0000 </r>
+     <r>    17.1772     0.2367     0.2373     0.2379    -0.0002     0.0002     0.0000 </r>
+     <r>    17.1972     0.2482     0.2487     0.2494    -0.0003     0.0003     0.0000 </r>
+     <r>    17.2172     0.2654     0.2659     0.2666    -0.0003     0.0003     0.0000 </r>
+     <r>    17.2372     0.2877     0.2882     0.2889    -0.0003     0.0003     0.0000 </r>
+     <r>    17.2573     0.3137     0.3143     0.3150    -0.0004     0.0003     0.0000 </r>
+     <r>    17.2773     0.3420     0.3426     0.3433    -0.0004     0.0004     0.0000 </r>
+     <r>    17.2973     0.3711     0.3717     0.3724    -0.0004     0.0004     0.0000 </r>
+     <r>    17.3173     0.3983     0.3989     0.3997    -0.0004     0.0004     0.0000 </r>
+     <r>    17.3373     0.4176     0.4182     0.4190    -0.0005     0.0005     0.0000 </r>
+     <r>    17.3574     0.4209     0.4215     0.4223    -0.0005     0.0005     0.0000 </r>
+     <r>    17.3774     0.4040     0.4047     0.4055    -0.0006     0.0006     0.0000 </r>
+     <r>    17.3974     0.3713     0.3721     0.3730    -0.0007     0.0006     0.0000 </r>
+     <r>    17.4174     0.3323     0.3332     0.3342    -0.0008     0.0007    -0.0000 </r>
+     <r>    17.4374     0.2951     0.2962     0.2973    -0.0009     0.0008    -0.0000 </r>
+     <r>    17.4575     0.2641     0.2653     0.2665    -0.0011     0.0009    -0.0000 </r>
+     <r>    17.4775     0.2403     0.2417     0.2431    -0.0012     0.0010    -0.0000 </r>
+     <r>    17.4975     0.2235     0.2252     0.2268    -0.0014     0.0012    -0.0000 </r>
+     <r>    17.5175     0.2130     0.2149     0.2168    -0.0017     0.0014    -0.0000 </r>
+     <r>    17.5375     0.2079     0.2102     0.2125    -0.0019     0.0016    -0.0000 </r>
+     <r>    17.5576     0.2077     0.2105     0.2134    -0.0023     0.0020     0.0000 </r>
+     <r>    17.5776     0.2123     0.2157     0.2192    -0.0026     0.0024     0.0001 </r>
+     <r>    17.5976     0.2214     0.2256     0.2299    -0.0031     0.0029     0.0001 </r>
+     <r>    17.6176     0.2352     0.2401     0.2453    -0.0036     0.0036     0.0002 </r>
+     <r>    17.6376     0.2535     0.2592     0.2651    -0.0042     0.0042     0.0002 </r>
+     <r>    17.6577     0.2760     0.2823     0.2888    -0.0047     0.0048     0.0001 </r>
+     <r>    17.6777     0.3029     0.3095     0.3160    -0.0052     0.0052    -0.0001 </r>
+     <r>    17.6977     0.3345     0.3410     0.3472    -0.0055     0.0054    -0.0002 </r>
+     <r>    17.7177     0.3712     0.3773     0.3829    -0.0056     0.0054    -0.0004 </r>
+     <r>    17.7377     0.4121     0.4177     0.4228    -0.0057     0.0054    -0.0004 </r>
+     <r>    17.7578     0.4538     0.4589     0.4636    -0.0057     0.0054    -0.0004 </r>
+     <r>    17.7778     0.4902     0.4950     0.4992    -0.0057     0.0054    -0.0003 </r>
+     <r>    17.7978     0.5155     0.5198     0.5238    -0.0055     0.0052    -0.0003 </r>
+     <r>    17.8178     0.5277     0.5317     0.5354    -0.0053     0.0050    -0.0002 </r>
+     <r>    17.8378     0.5318     0.5355     0.5389    -0.0049     0.0046    -0.0002 </r>
+     <r>    17.8579     0.5369     0.5404     0.5436    -0.0045     0.0043    -0.0001 </r>
+     <r>    17.8779     0.5513     0.5544     0.5574    -0.0041     0.0039    -0.0001 </r>
+     <r>    17.8979     0.5781     0.5810     0.5837    -0.0037     0.0034    -0.0001 </r>
+     <r>    17.9179     0.6159     0.6183     0.6206    -0.0032     0.0029    -0.0001 </r>
+     <r>    17.9379     0.6579     0.6598     0.6617    -0.0026     0.0024    -0.0001 </r>
+     <r>    17.9580     0.6919     0.6932     0.6945    -0.0020     0.0017    -0.0001 </r>
+     <r>    17.9780     0.7017     0.7026     0.7034    -0.0014     0.0012    -0.0001 </r>
+     <r>    17.9980     0.6769     0.6774     0.6780    -0.0010     0.0008    -0.0001 </r>
+     <r>    18.0180     0.6221     0.6225     0.6228    -0.0008     0.0006    -0.0001 </r>
+     <r>    18.0380     0.5534     0.5537     0.5540    -0.0007     0.0005    -0.0001 </r>
+     <r>    18.0581     0.4867     0.4871     0.4874    -0.0007     0.0005    -0.0001 </r>
+     <r>    18.0781     0.4313     0.4317     0.4320    -0.0007     0.0005    -0.0001 </r>
+     <r>    18.0981     0.3905     0.3908     0.3911    -0.0007     0.0005    -0.0001 </r>
+     <r>    18.1181     0.3642     0.3645     0.3648    -0.0007     0.0005    -0.0001 </r>
+     <r>    18.1381     0.3511     0.3515     0.3518    -0.0007     0.0005    -0.0001 </r>
+     <r>    18.1582     0.3490     0.3493     0.3496    -0.0007     0.0005    -0.0001 </r>
+     <r>    18.1782     0.3537     0.3541     0.3544    -0.0008     0.0006    -0.0001 </r>
+     <r>    18.1982     0.3587     0.3590     0.3593    -0.0008     0.0006    -0.0001 </r>
+     <r>    18.2182     0.3560     0.3563     0.3566    -0.0008     0.0006    -0.0001 </r>
+     <r>    18.2382     0.3406     0.3410     0.3412    -0.0008     0.0006    -0.0001 </r>
+     <r>    18.2583     0.3143     0.3146     0.3148    -0.0008     0.0005    -0.0001 </r>
+     <r>    18.2783     0.2833     0.2836     0.2838    -0.0008     0.0005    -0.0001 </r>
+     <r>    18.2983     0.2537     0.2540     0.2542    -0.0007     0.0004    -0.0001 </r>
+     <r>    18.3183     0.2289     0.2292     0.2294    -0.0007     0.0004    -0.0001 </r>
+     <r>    18.3383     0.2100     0.2102     0.2104    -0.0007     0.0004    -0.0002 </r>
+     <r>    18.3584     0.1968     0.1970     0.1972    -0.0007     0.0004    -0.0002 </r>
+     <r>    18.3784     0.1889     0.1891     0.1893    -0.0008     0.0004    -0.0002 </r>
+     <r>    18.3984     0.1857     0.1859     0.1861    -0.0008     0.0003    -0.0002 </r>
+     <r>    18.4184     0.1867     0.1869     0.1871    -0.0008     0.0003    -0.0002 </r>
+     <r>    18.4384     0.1917     0.1919     0.1921    -0.0008     0.0003    -0.0002 </r>
+     <r>    18.4585     0.2009     0.2011     0.2013    -0.0008     0.0003    -0.0002 </r>
+     <r>    18.4785     0.2149     0.2151     0.2152    -0.0008     0.0004    -0.0002 </r>
+     <r>    18.4985     0.2343     0.2345     0.2347    -0.0008     0.0004    -0.0002 </r>
+     <r>    18.5185     0.2588     0.2591     0.2593    -0.0008     0.0004    -0.0002 </r>
+     <r>    18.5385     0.2862     0.2865     0.2867    -0.0008     0.0004    -0.0002 </r>
+     <r>    18.5586     0.3113     0.3115     0.3117    -0.0009     0.0005    -0.0002 </r>
+     <r>    18.5786     0.3263     0.3266     0.3268    -0.0009     0.0005    -0.0002 </r>
+     <r>    18.5986     0.3251     0.3254     0.3256    -0.0009     0.0005    -0.0002 </r>
+     <r>    18.6186     0.3077     0.3079     0.3081    -0.0008     0.0005    -0.0002 </r>
+     <r>    18.6386     0.2804     0.2806     0.2808    -0.0008     0.0004    -0.0001 </r>
+     <r>    18.6587     0.2513     0.2515     0.2516    -0.0007     0.0004    -0.0001 </r>
+     <r>    18.6787     0.2257     0.2259     0.2260    -0.0006     0.0004    -0.0001 </r>
+     <r>    18.6987     0.2062     0.2062     0.2064    -0.0006     0.0003    -0.0001 </r>
+     <r>    18.7187     0.1931     0.1931     0.1932    -0.0005     0.0003    -0.0001 </r>
+     <r>    18.7387     0.1863     0.1863     0.1864    -0.0005     0.0003    -0.0001 </r>
+     <r>    18.7588     0.1856     0.1855     0.1855    -0.0005     0.0004    -0.0001 </r>
+     <r>    18.7788     0.1907     0.1905     0.1904    -0.0005     0.0004    -0.0000 </r>
+     <r>    18.7988     0.2012     0.2009     0.2008    -0.0005     0.0004    -0.0000 </r>
+     <r>    18.8188     0.2162     0.2159     0.2156    -0.0006     0.0004    -0.0001 </r>
+     <r>    18.8388     0.2336     0.2332     0.2329    -0.0006     0.0005    -0.0001 </r>
+     <r>    18.8589     0.2497     0.2492     0.2488    -0.0007     0.0005    -0.0001 </r>
+     <r>    18.8789     0.2595     0.2591     0.2586    -0.0007     0.0005    -0.0001 </r>
+     <r>    18.8989     0.2596     0.2592     0.2588    -0.0008     0.0005    -0.0001 </r>
+     <r>    18.9189     0.2499     0.2496     0.2493    -0.0007     0.0004    -0.0001 </r>
+     <r>    18.9389     0.2346     0.2344     0.2341    -0.0007     0.0004    -0.0001 </r>
+     <r>    18.9590     0.2191     0.2190     0.2188    -0.0007     0.0003    -0.0001 </r>
+     <r>    18.9790     0.2074     0.2074     0.2073    -0.0007     0.0002    -0.0002 </r>
+     <r>    18.9990     0.2013     0.2014     0.2014    -0.0007     0.0002    -0.0002 </r>
+     <r>    19.0190     0.2008     0.2010     0.2010    -0.0007     0.0001    -0.0002 </r>
+     <r>    19.0390     0.2044     0.2047     0.2048    -0.0007     0.0001    -0.0002 </r>
+     <r>    19.0591     0.2098     0.2101     0.2102    -0.0008     0.0000    -0.0003 </r>
+     <r>    19.0791     0.2141     0.2145     0.2146    -0.0008    -0.0000    -0.0003 </r>
+     <r>    19.0991     0.2160     0.2164     0.2166    -0.0009    -0.0000    -0.0003 </r>
+     <r>    19.1191     0.2157     0.2162     0.2163    -0.0010    -0.0000    -0.0003 </r>
+     <r>    19.1391     0.2140     0.2146     0.2147    -0.0011    -0.0001    -0.0004 </r>
+     <r>    19.1592     0.2113     0.2119     0.2121    -0.0012    -0.0001    -0.0004 </r>
+     <r>    19.1792     0.2074     0.2081     0.2083    -0.0013    -0.0001    -0.0005 </r>
+     <r>    19.1992     0.2027     0.2035     0.2038    -0.0014    -0.0002    -0.0005 </r>
+     <r>    19.2192     0.1986     0.1994     0.1998    -0.0015    -0.0002    -0.0006 </r>
+     <r>    19.2392     0.1958     0.1968     0.1973    -0.0016    -0.0003    -0.0006 </r>
+     <r>    19.2593     0.1946     0.1957     0.1965    -0.0016    -0.0003    -0.0006 </r>
+     <r>    19.2793     0.1944     0.1956     0.1967    -0.0016    -0.0003    -0.0006 </r>
+     <r>    19.2993     0.1949     0.1962     0.1977    -0.0014    -0.0002    -0.0005 </r>
+     <r>    19.3193     0.1962     0.1977     0.1997    -0.0012    -0.0002    -0.0004 </r>
+     <r>    19.3393     0.1986     0.2004     0.2027    -0.0009    -0.0002    -0.0003 </r>
+     <r>    19.3594     0.2015     0.2035     0.2063    -0.0005    -0.0002    -0.0002 </r>
+     <r>    19.3794     0.2037     0.2059     0.2092    -0.0002    -0.0002    -0.0001 </r>
+     <r>    19.3994     0.2050     0.2075     0.2111     0.0002    -0.0003    -0.0001 </r>
+     <r>    19.4194     0.2062     0.2090     0.2128     0.0006    -0.0005    -0.0000 </r>
+     <r>    19.4394     0.2081     0.2110     0.2150     0.0009    -0.0007     0.0000 </r>
+     <r>    19.4595     0.2100     0.2130     0.2169     0.0012    -0.0009     0.0001 </r>
+     <r>    19.4795     0.2101     0.2128     0.2164     0.0014    -0.0010     0.0001 </r>
+     <r>    19.4995     0.2058     0.2082     0.2114     0.0015    -0.0010     0.0001 </r>
+     <r>    19.5195     0.1962     0.1982     0.2010     0.0014    -0.0010     0.0001 </r>
+     <r>    19.5395     0.1825     0.1841     0.1865     0.0012    -0.0008     0.0001 </r>
+     <r>    19.5596     0.1670     0.1683     0.1703     0.0011    -0.0007     0.0001 </r>
+     <r>    19.5796     0.1512     0.1524     0.1541     0.0009    -0.0006     0.0001 </r>
+     <r>    19.5996     0.1357     0.1367     0.1382     0.0008    -0.0005     0.0001 </r>
+     <r>    19.6196     0.1206     0.1215     0.1229     0.0006    -0.0004     0.0001 </r>
+     <r>    19.6396     0.1068     0.1076     0.1089     0.0006    -0.0004     0.0001 </r>
+     <r>    19.6597     0.0947     0.0955     0.0967     0.0005    -0.0004     0.0001 </r>
+     <r>    19.6797     0.0845     0.0853     0.0864     0.0005    -0.0003     0.0000 </r>
+     <r>    19.6997     0.0759     0.0767     0.0778     0.0004    -0.0003     0.0000 </r>
+     <r>    19.7197     0.0686     0.0693     0.0703     0.0004    -0.0003     0.0000 </r>
+     <r>    19.7397     0.0621     0.0628     0.0637     0.0004    -0.0003     0.0000 </r>
+     <r>    19.7598     0.0564     0.0570     0.0578     0.0003    -0.0002     0.0000 </r>
+     <r>    19.7798     0.0515     0.0520     0.0527     0.0003    -0.0002     0.0000 </r>
+     <r>    19.7998     0.0473     0.0478     0.0483     0.0002    -0.0002     0.0000 </r>
+     <r>    19.8198     0.0437     0.0441     0.0446     0.0002    -0.0001     0.0000 </r>
+     <r>    19.8398     0.0407     0.0410     0.0415     0.0001    -0.0001     0.0000 </r>
+     <r>    19.8599     0.0381     0.0384     0.0388     0.0001    -0.0001     0.0000 </r>
+     <r>    19.8799     0.0358     0.0361     0.0365     0.0001    -0.0001    -0.0000 </r>
+     <r>    19.8999     0.0339     0.0341     0.0344     0.0001    -0.0001    -0.0000 </r>
+     <r>    19.9199     0.0322     0.0324     0.0327     0.0001    -0.0001    -0.0000 </r>
+     <r>    19.9399     0.0307     0.0309     0.0311     0.0000    -0.0001    -0.0000 </r>
+     <r>    19.9600     0.0293     0.0295     0.0297     0.0000    -0.0000    -0.0000 </r>
+     <r>    19.9800     0.0281     0.0283     0.0285     0.0000    -0.0000    -0.0000 </r>
+     <r>    20.0000     0.0270     0.0272     0.0274     0.0000    -0.0000    -0.0000 </r>
+    </set>
+   </array>
+  </imag>
+  <real>
+   <array>
+    <dimension dim="1">gridpoints</dimension>
+    <field>energy</field>
+    <field>xx</field>
+    <field>yy</field>
+    <field>zz</field>
+    <field>xy</field>
+    <field>yz</field>
+    <field>zx</field>
+    <set>
+     <r>     0.0000    12.1144    12.1206    12.1319    -0.0079    -0.0138    -0.0114 </r>
+     <r>     0.0200    12.1147    12.1209    12.1322    -0.0079    -0.0138    -0.0114 </r>
+     <r>     0.0400    12.1156    12.1217    12.1331    -0.0079    -0.0138    -0.0114 </r>
+     <r>     0.0601    12.1171    12.1232    12.1345    -0.0079    -0.0138    -0.0114 </r>
+     <r>     0.0801    12.1191    12.1253    12.1366    -0.0079    -0.0139    -0.0114 </r>
+     <r>     0.1001    12.1218    12.1279    12.1393    -0.0079    -0.0139    -0.0114 </r>
+     <r>     0.1201    12.1250    12.1312    12.1425    -0.0080    -0.0139    -0.0114 </r>
+     <r>     0.1401    12.1289    12.1350    12.1463    -0.0080    -0.0139    -0.0114 </r>
+     <r>     0.1602    12.1333    12.1395    12.1508    -0.0080    -0.0139    -0.0114 </r>
+     <r>     0.1802    12.1383    12.1445    12.1558    -0.0080    -0.0139    -0.0114 </r>
+     <r>     0.2002    12.1440    12.1501    12.1614    -0.0080    -0.0139    -0.0114 </r>
+     <r>     0.2202    12.1502    12.1563    12.1677    -0.0080    -0.0139    -0.0114 </r>
+     <r>     0.2402    12.1570    12.1632    12.1745    -0.0080    -0.0139    -0.0114 </r>
+     <r>     0.2603    12.1644    12.1706    12.1819    -0.0080    -0.0139    -0.0114 </r>
+     <r>     0.2803    12.1725    12.1786    12.1900    -0.0080    -0.0139    -0.0114 </r>
+     <r>     0.3003    12.1811    12.1873    12.1986    -0.0080    -0.0140    -0.0115 </r>
+     <r>     0.3203    12.1904    12.1966    12.2079    -0.0080    -0.0140    -0.0115 </r>
+     <r>     0.3403    12.2003    12.2064    12.2178    -0.0080    -0.0140    -0.0115 </r>
+     <r>     0.3604    12.2108    12.2169    12.2283    -0.0081    -0.0140    -0.0115 </r>
+     <r>     0.3804    12.2219    12.2281    12.2394    -0.0081    -0.0140    -0.0115 </r>
+     <r>     0.4004    12.2337    12.2398    12.2512    -0.0081    -0.0141    -0.0115 </r>
+     <r>     0.4204    12.2461    12.2522    12.2636    -0.0081    -0.0141    -0.0116 </r>
+     <r>     0.4404    12.2591    12.2653    12.2766    -0.0081    -0.0141    -0.0116 </r>
+     <r>     0.4605    12.2728    12.2789    12.2903    -0.0081    -0.0141    -0.0116 </r>
+     <r>     0.4805    12.2871    12.2933    12.3046    -0.0082    -0.0142    -0.0116 </r>
+     <r>     0.5005    12.3020    12.3082    12.3196    -0.0082    -0.0142    -0.0116 </r>
+     <r>     0.5205    12.3177    12.3239    12.3352    -0.0082    -0.0142    -0.0117 </r>
+     <r>     0.5405    12.3340    12.3402    12.3515    -0.0082    -0.0142    -0.0117 </r>
+     <r>     0.5606    12.3510    12.3572    12.3685    -0.0082    -0.0143    -0.0117 </r>
+     <r>     0.5806    12.3686    12.3748    12.3862    -0.0083    -0.0143    -0.0117 </r>
+     <r>     0.6006    12.3870    12.3932    12.4045    -0.0083    -0.0143    -0.0118 </r>
+     <r>     0.6206    12.4060    12.4122    12.4236    -0.0083    -0.0144    -0.0118 </r>
+     <r>     0.6406    12.4257    12.4320    12.4433    -0.0083    -0.0144    -0.0118 </r>
+     <r>     0.6607    12.4462    12.4524    12.4638    -0.0084    -0.0144    -0.0119 </r>
+     <r>     0.6807    12.4674    12.4736    12.4850    -0.0084    -0.0145    -0.0119 </r>
+     <r>     0.7007    12.4893    12.4955    12.5069    -0.0084    -0.0145    -0.0119 </r>
+     <r>     0.7207    12.5119    12.5181    12.5295    -0.0085    -0.0146    -0.0120 </r>
+     <r>     0.7407    12.5353    12.5415    12.5529    -0.0085    -0.0146    -0.0120 </r>
+     <r>     0.7608    12.5594    12.5657    12.5771    -0.0085    -0.0147    -0.0120 </r>
+     <r>     0.7808    12.5843    12.5906    12.6020    -0.0086    -0.0147    -0.0121 </r>
+     <r>     0.8008    12.6100    12.6163    12.6277    -0.0086    -0.0147    -0.0121 </r>
+     <r>     0.8208    12.6365    12.6427    12.6542    -0.0086    -0.0148    -0.0122 </r>
+     <r>     0.8408    12.6638    12.6700    12.6814    -0.0087    -0.0148    -0.0122 </r>
+     <r>     0.8609    12.6918    12.6981    12.7095    -0.0087    -0.0149    -0.0123 </r>
+     <r>     0.8809    12.7208    12.7270    12.7385    -0.0087    -0.0150    -0.0123 </r>
+     <r>     0.9009    12.7505    12.7568    12.7682    -0.0088    -0.0150    -0.0123 </r>
+     <r>     0.9209    12.7811    12.7874    12.7988    -0.0088    -0.0151    -0.0124 </r>
+     <r>     0.9409    12.8126    12.8189    12.8303    -0.0089    -0.0151    -0.0124 </r>
+     <r>     0.9610    12.8449    12.8512    12.8627    -0.0089    -0.0152    -0.0125 </r>
+     <r>     0.9810    12.8782    12.8845    12.8959    -0.0090    -0.0152    -0.0125 </r>
+     <r>     1.0010    12.9123    12.9186    12.9301    -0.0090    -0.0153    -0.0126 </r>
+     <r>     1.0210    12.9474    12.9537    12.9652    -0.0090    -0.0154    -0.0127 </r>
+     <r>     1.0410    12.9834    12.9898    13.0012    -0.0091    -0.0154    -0.0127 </r>
+     <r>     1.0611    13.0204    13.0268    13.0382    -0.0091    -0.0155    -0.0128 </r>
+     <r>     1.0811    13.0584    13.0647    13.0762    -0.0092    -0.0156    -0.0128 </r>
+     <r>     1.1011    13.0974    13.1037    13.1152    -0.0093    -0.0157    -0.0129 </r>
+     <r>     1.1211    13.1374    13.1437    13.1552    -0.0093    -0.0157    -0.0130 </r>
+     <r>     1.1411    13.1784    13.1848    13.1963    -0.0094    -0.0158    -0.0130 </r>
+     <r>     1.1612    13.2205    13.2269    13.2384    -0.0094    -0.0159    -0.0131 </r>
+     <r>     1.1812    13.2637    13.2701    13.2816    -0.0095    -0.0160    -0.0132 </r>
+     <r>     1.2012    13.3080    13.3144    13.3259    -0.0095    -0.0161    -0.0132 </r>
+     <r>     1.2212    13.3534    13.3598    13.3714    -0.0096    -0.0161    -0.0133 </r>
+     <r>     1.2412    13.4000    13.4064    13.4180    -0.0097    -0.0162    -0.0134 </r>
+     <r>     1.2613    13.4478    13.4542    13.4658    -0.0097    -0.0163    -0.0135 </r>
+     <r>     1.2813    13.4968    13.5032    13.5148    -0.0098    -0.0164    -0.0135 </r>
+     <r>     1.3013    13.5470    13.5534    13.5650    -0.0099    -0.0165    -0.0136 </r>
+     <r>     1.3213    13.5985    13.6049    13.6165    -0.0100    -0.0166    -0.0137 </r>
+     <r>     1.3413    13.6513    13.6577    13.6693    -0.0100    -0.0167    -0.0138 </r>
+     <r>     1.3614    13.7054    13.7119    13.7235    -0.0101    -0.0168    -0.0139 </r>
+     <r>     1.3814    13.7609    13.7674    13.7790    -0.0102    -0.0169    -0.0140 </r>
+     <r>     1.4014    13.8178    13.8243    13.8359    -0.0103    -0.0170    -0.0141 </r>
+     <r>     1.4214    13.8761    13.8826    13.8942    -0.0104    -0.0172    -0.0142 </r>
+     <r>     1.4414    13.9359    13.9424    13.9540    -0.0105    -0.0173    -0.0143 </r>
+     <r>     1.4615    13.9973    14.0037    14.0154    -0.0105    -0.0174    -0.0144 </r>
+     <r>     1.4815    14.0601    14.0666    14.0783    -0.0106    -0.0175    -0.0145 </r>
+     <r>     1.5015    14.1246    14.1311    14.1428    -0.0107    -0.0177    -0.0146 </r>
+     <r>     1.5215    14.1907    14.1972    14.2089    -0.0108    -0.0178    -0.0147 </r>
+     <r>     1.5415    14.2585    14.2650    14.2767    -0.0109    -0.0179    -0.0148 </r>
+     <r>     1.5616    14.3280    14.3346    14.3462    -0.0110    -0.0181    -0.0149 </r>
+     <r>     1.5816    14.3993    14.4059    14.4176    -0.0112    -0.0182    -0.0151 </r>
+     <r>     1.6016    14.4725    14.4791    14.4908    -0.0113    -0.0183    -0.0152 </r>
+     <r>     1.6216    14.5476    14.5542    14.5659    -0.0114    -0.0185    -0.0153 </r>
+     <r>     1.6416    14.6246    14.6312    14.6429    -0.0115    -0.0187    -0.0155 </r>
+     <r>     1.6617    14.7036    14.7102    14.7220    -0.0116    -0.0188    -0.0156 </r>
+     <r>     1.6817    14.7848    14.7914    14.8031    -0.0117    -0.0190    -0.0157 </r>
+     <r>     1.7017    14.8680    14.8747    14.8864    -0.0119    -0.0192    -0.0159 </r>
+     <r>     1.7217    14.9535    14.9602    14.9719    -0.0120    -0.0193    -0.0160 </r>
+     <r>     1.7417    15.0413    15.0480    15.0597    -0.0122    -0.0195    -0.0162 </r>
+     <r>     1.7618    15.1315    15.1381    15.1499    -0.0123    -0.0197    -0.0164 </r>
+     <r>     1.7818    15.2241    15.2308    15.2425    -0.0124    -0.0199    -0.0165 </r>
+     <r>     1.8018    15.3192    15.3260    15.3377    -0.0126    -0.0201    -0.0167 </r>
+     <r>     1.8218    15.4170    15.4238    15.4355    -0.0128    -0.0203    -0.0169 </r>
+     <r>     1.8418    15.5176    15.5243    15.5361    -0.0129    -0.0205    -0.0171 </r>
+     <r>     1.8619    15.6209    15.6277    15.6395    -0.0131    -0.0207    -0.0173 </r>
+     <r>     1.8819    15.7272    15.7340    15.7458    -0.0133    -0.0210    -0.0175 </r>
+     <r>     1.9019    15.8366    15.8434    15.8552    -0.0135    -0.0212    -0.0177 </r>
+     <r>     1.9219    15.9491    15.9559    15.9677    -0.0136    -0.0214    -0.0179 </r>
+     <r>     1.9419    16.0649    16.0717    16.0835    -0.0138    -0.0217    -0.0181 </r>
+     <r>     1.9620    16.1842    16.1910    16.2028    -0.0141    -0.0220    -0.0183 </r>
+     <r>     1.9820    16.3070    16.3138    16.3256    -0.0143    -0.0222    -0.0186 </r>
+     <r>     2.0020    16.4335    16.4404    16.4522    -0.0145    -0.0225    -0.0188 </r>
+     <r>     2.0220    16.5639    16.5708    16.5826    -0.0147    -0.0228    -0.0191 </r>
+     <r>     2.0420    16.6984    16.7053    16.7171    -0.0150    -0.0231    -0.0193 </r>
+     <r>     2.0621    16.8371    16.8440    16.8559    -0.0152    -0.0234    -0.0196 </r>
+     <r>     2.0821    16.9802    16.9872    16.9990    -0.0155    -0.0237    -0.0199 </r>
+     <r>     2.1021    17.1280    17.1350    17.1468    -0.0157    -0.0241    -0.0202 </r>
+     <r>     2.1221    17.2806    17.2876    17.2994    -0.0160    -0.0244    -0.0205 </r>
+     <r>     2.1421    17.4383    17.4453    17.4571    -0.0163    -0.0248    -0.0208 </r>
+     <r>     2.1622    17.6013    17.6083    17.6201    -0.0166    -0.0252    -0.0211 </r>
+     <r>     2.1822    17.7699    17.7769    17.7888    -0.0169    -0.0256    -0.0215 </r>
+     <r>     2.2022    17.9444    17.9514    17.9633    -0.0172    -0.0260    -0.0218 </r>
+     <r>     2.2222    18.1250    18.1321    18.1440    -0.0176    -0.0264    -0.0222 </r>
+     <r>     2.2422    18.3122    18.3193    18.3312    -0.0180    -0.0268    -0.0226 </r>
+     <r>     2.2623    18.5063    18.5134    18.5253    -0.0183    -0.0273    -0.0230 </r>
+     <r>     2.2823    18.7076    18.7148    18.7266    -0.0187    -0.0278    -0.0235 </r>
+     <r>     2.3023    18.9166    18.9238    18.9356    -0.0192    -0.0283    -0.0239 </r>
+     <r>     2.3223    19.1337    19.1409    19.1528    -0.0196    -0.0289    -0.0244 </r>
+     <r>     2.3423    19.3595    19.3667    19.3785    -0.0201    -0.0294    -0.0249 </r>
+     <r>     2.3624    19.5943    19.6016    19.6134    -0.0206    -0.0300    -0.0254 </r>
+     <r>     2.3824    19.8389    19.8462    19.8580    -0.0211    -0.0306    -0.0260 </r>
+     <r>     2.4024    20.0938    20.1011    20.1129    -0.0216    -0.0313    -0.0266 </r>
+     <r>     2.4224    20.3597    20.3671    20.3788    -0.0222    -0.0320    -0.0272 </r>
+     <r>     2.4424    20.6374    20.6448    20.6565    -0.0228    -0.0327    -0.0279 </r>
+     <r>     2.4625    20.9277    20.9351    20.9468    -0.0234    -0.0335    -0.0285 </r>
+     <r>     2.4825    21.2314    21.2389    21.2506    -0.0241    -0.0343    -0.0293 </r>
+     <r>     2.5025    21.5496    21.5571    21.5688    -0.0248    -0.0352    -0.0301 </r>
+     <r>     2.5225    21.8834    21.8909    21.9026    -0.0256    -0.0361    -0.0309 </r>
+     <r>     2.5425    22.2339    22.2415    22.2531    -0.0264    -0.0371    -0.0318 </r>
+     <r>     2.5626    22.6026    22.6101    22.6217    -0.0273    -0.0381    -0.0327 </r>
+     <r>     2.5826    22.9908    22.9984    23.0099    -0.0283    -0.0392    -0.0337 </r>
+     <r>     2.6026    23.4002    23.4078    23.4194    -0.0293    -0.0404    -0.0348 </r>
+     <r>     2.6226    23.8327    23.8404    23.8519    -0.0304    -0.0417    -0.0359 </r>
+     <r>     2.6426    24.2903    24.2981    24.3095    -0.0315    -0.0430    -0.0372 </r>
+     <r>     2.6627    24.7754    24.7832    24.7946    -0.0328    -0.0445    -0.0385 </r>
+     <r>     2.6827    25.2905    25.2983    25.3097    -0.0342    -0.0461    -0.0400 </r>
+     <r>     2.7027    25.8385    25.8464    25.8577    -0.0356    -0.0478    -0.0415 </r>
+     <r>     2.7227    26.4227    26.4306    26.4418    -0.0373    -0.0496    -0.0432 </r>
+     <r>     2.7427    27.0467    27.0547    27.0658    -0.0390    -0.0516    -0.0451 </r>
+     <r>     2.7628    27.7147    27.7227    27.7337    -0.0409    -0.0538    -0.0471 </r>
+     <r>     2.7828    28.4310    28.4391    28.4501    -0.0430    -0.0562    -0.0493 </r>
+     <r>     2.8028    29.2009    29.2090    29.2198    -0.0453    -0.0588    -0.0517 </r>
+     <r>     2.8228    30.0295    30.0377    30.0484    -0.0478    -0.0616    -0.0543 </r>
+     <r>     2.8428    30.9226    30.9309    30.9414    -0.0505    -0.0647    -0.0571 </r>
+     <r>     2.8629    31.8855    31.8939    31.9043    -0.0535    -0.0681    -0.0603 </r>
+     <r>     2.8829    32.9230    32.9314    32.9417    -0.0568    -0.0718    -0.0636 </r>
+     <r>     2.9029    34.0372    34.0457    34.0559    -0.0602    -0.0757    -0.0673 </r>
+     <r>     2.9229    35.2259    35.2345    35.2444    -0.0639    -0.0798    -0.0711 </r>
+     <r>     2.9429    36.4771    36.4858    36.4956    -0.0675    -0.0839    -0.0749 </r>
+     <r>     2.9630    37.7619    37.7707    37.7804    -0.0709    -0.0879    -0.0785 </r>
+     <r>     2.9830    39.0219    39.0308    39.0404    -0.0735    -0.0909    -0.0813 </r>
+     <r>     3.0030    40.1524    40.1615    40.1712    -0.0742    -0.0922    -0.0823 </r>
+     <r>     3.0230    40.9908    41.0000    41.0101    -0.0716    -0.0901    -0.0799 </r>
+     <r>     3.0430    41.3343    41.3437    41.3545    -0.0634    -0.0822    -0.0720 </r>
+     <r>     3.0631    41.0319    41.0414    41.0534    -0.0474    -0.0663    -0.0564 </r>
+     <r>     3.0831    40.1311    40.1408    40.1543    -0.0230    -0.0418    -0.0322 </r>
+     <r>     3.1031    38.8994    38.9092    38.9242     0.0068    -0.0119    -0.0027 </r>
+     <r>     3.1231    37.5419    37.5517    37.5679     0.0356     0.0171     0.0259 </r>
+     <r>     3.1431    35.8470    35.8567    35.8735     0.0574     0.0396     0.0479 </r>
+     <r>     3.1632    33.1523    33.1616    33.1783     0.0703     0.0536     0.0613 </r>
+     <r>     3.1832    28.7060    28.7147    28.7306     0.0755     0.0607     0.0674 </r>
+     <r>     3.2032    22.3080    22.3158    22.3304     0.0751     0.0632     0.0686 </r>
+     <r>     3.2232    14.8411    14.8477    14.8609     0.0717     0.0631     0.0669 </r>
+     <r>     3.2432     7.9416     7.9472     7.9590     0.0669     0.0614     0.0638 </r>
+     <r>     3.2633     2.8741     2.8790     2.8897     0.0620     0.0587     0.0601 </r>
+     <r>     3.2833    -0.1117    -0.1072    -0.0970     0.0575     0.0554     0.0563 </r>
+     <r>     3.3033    -1.4497    -1.4453    -1.4353     0.0536     0.0519     0.0526 </r>
+     <r>     3.3233    -1.7151    -1.7106    -1.7003     0.0503     0.0484     0.0492 </r>
+     <r>     3.3433    -1.3813    -1.3766    -1.3657     0.0475     0.0453     0.0461 </r>
+     <r>     3.3634    -0.7645    -0.7595    -0.7478     0.0451     0.0425     0.0434 </r>
+     <r>     3.3834     0.0075     0.0128     0.0255     0.0431     0.0399     0.0410 </r>
+     <r>     3.4034     0.9669     0.9726     0.9862     0.0413     0.0376     0.0387 </r>
+     <r>     3.4234     2.1797     2.1856     2.1998     0.0395     0.0352     0.0366 </r>
+     <r>     3.4434     3.6403     3.6465     3.6610     0.0378     0.0328     0.0346 </r>
+     <r>     3.4635     5.2747     5.2810     5.2955     0.0361     0.0304     0.0325 </r>
+     <r>     3.4835     6.9870     6.9935     7.0078     0.0345     0.0281     0.0306 </r>
+     <r>     3.5035     8.6846     8.6912     8.7053     0.0329     0.0258     0.0288 </r>
+     <r>     3.5235    10.2725    10.2791    10.2929     0.0314     0.0237     0.0271 </r>
+     <r>     3.5435    11.6357    11.6425    11.6561     0.0301     0.0217     0.0255 </r>
+     <r>     3.5636    12.6319    12.6389    12.6525     0.0288     0.0199     0.0241 </r>
+     <r>     3.5836    13.1232    13.1304    13.1442     0.0276     0.0184     0.0228 </r>
+     <r>     3.6036    13.0815    13.0891    13.1032     0.0264     0.0172     0.0216 </r>
+     <r>     3.6236    12.7147    12.7228    12.7374     0.0254     0.0161     0.0205 </r>
+     <r>     3.6436    12.4350    12.4435    12.4586     0.0244     0.0151     0.0195 </r>
+     <r>     3.6637    12.6113    12.6202    12.6355     0.0235     0.0139     0.0185 </r>
+     <r>     3.6837    13.3728    13.3819    13.3972     0.0225     0.0126     0.0175 </r>
+     <r>     3.7037    14.6477    14.6569    14.6720     0.0217     0.0111     0.0164 </r>
+     <r>     3.7237    16.2995    16.3088    16.3235     0.0208     0.0095     0.0153 </r>
+     <r>     3.7437    18.2110    18.2205    18.2346     0.0199     0.0078     0.0142 </r>
+     <r>     3.7638    20.3040    20.3135    20.3271     0.0191     0.0061     0.0131 </r>
+     <r>     3.7838    22.5292    22.5388    22.5516     0.0182     0.0043     0.0120 </r>
+     <r>     3.8038    24.8487    24.8583    24.8704     0.0174     0.0024     0.0109 </r>
+     <r>     3.8238    27.2164    27.2261    27.2373     0.0165     0.0006     0.0097 </r>
+     <r>     3.8438    29.5549    29.5646    29.5749     0.0156    -0.0013     0.0086 </r>
+     <r>     3.8639    31.7251    31.7349    31.7441     0.0145    -0.0032     0.0074 </r>
+     <r>     3.8839    33.4898    33.4995    33.5076     0.0133    -0.0051     0.0062 </r>
+     <r>     3.9039    34.4861    34.4958    34.5025     0.0119    -0.0068     0.0049 </r>
+     <r>     3.9239    34.2435    34.2530    34.2584     0.0101    -0.0083     0.0036 </r>
+     <r>     3.9439    32.2752    32.2845    32.2885     0.0081    -0.0092     0.0025 </r>
+     <r>     3.9640    28.2033    28.2124    28.2156     0.0060    -0.0093     0.0016 </r>
+     <r>     3.9840    21.9055    21.9143    21.9175     0.0042    -0.0083     0.0011 </r>
+     <r>     4.0040    13.8185    13.8271    13.8315     0.0028    -0.0062     0.0011 </r>
+     <r>     4.0240     5.1336     5.1420     5.1486     0.0021    -0.0033     0.0017 </r>
+     <r>     4.0440    -2.8149    -2.8066    -2.7968     0.0023     0.0002     0.0027 </r>
+     <r>     4.0641    -9.5057    -9.4975    -9.4831     0.0038     0.0042     0.0044 </r>
+     <r>     4.0841   -15.2468   -15.2385   -15.2178     0.0070     0.0093     0.0070 </r>
+     <r>     4.1041   -20.3724   -20.3641   -20.3351     0.0119     0.0156     0.0106 </r>
+     <r>     4.1241   -24.7674   -24.7590   -24.7203     0.0183     0.0225     0.0149 </r>
+     <r>     4.1441   -28.0982   -28.0895   -28.0413     0.0253     0.0290     0.0194 </r>
+     <r>     4.1642   -30.1884   -30.1794   -30.1235     0.0316     0.0339     0.0232 </r>
+     <r>     4.1842   -31.1405   -31.1312   -31.0709     0.0364     0.0365     0.0259 </r>
+     <r>     4.2042   -31.2354   -31.2259   -31.1646     0.0395     0.0368     0.0274 </r>
+     <r>     4.2242   -30.7695   -30.7600   -30.7001     0.0413     0.0358     0.0281 </r>
+     <r>     4.2442   -29.9990   -29.9898   -29.9326     0.0422     0.0342     0.0282 </r>
+     <r>     4.2643   -29.1525   -29.1436   -29.0894     0.0423     0.0324     0.0279 </r>
+     <r>     4.2843   -28.3832   -28.3748   -28.3233     0.0418     0.0306     0.0273 </r>
+     <r>     4.3043   -27.7046   -27.6966   -27.6473     0.0410     0.0290     0.0264 </r>
+     <r>     4.3243   -27.0320   -27.0242   -26.9767     0.0400     0.0274     0.0255 </r>
+     <r>     4.3443   -26.2917   -26.2841   -26.2379     0.0391     0.0259     0.0246 </r>
+     <r>     4.3644   -25.4552   -25.4475   -25.4019     0.0385     0.0244     0.0238 </r>
+     <r>     4.3844   -24.5141   -24.5061   -24.4607     0.0382     0.0229     0.0231 </r>
+     <r>     4.4044   -23.4805   -23.4720   -23.4261     0.0383     0.0215     0.0225 </r>
+     <r>     4.4244   -22.3900   -22.3806   -22.3339     0.0387     0.0201     0.0220 </r>
+     <r>     4.4444   -21.2784   -21.2681   -21.2202     0.0394     0.0186     0.0216 </r>
+     <r>     4.4645   -20.1645   -20.1532   -20.1042     0.0403     0.0170     0.0212 </r>
+     <r>     4.4845   -19.0567   -19.0447   -18.9947     0.0412     0.0154     0.0209 </r>
+     <r>     4.5045   -17.9647   -17.9523   -17.9016     0.0421     0.0137     0.0205 </r>
+     <r>     4.5245   -16.9012   -16.8884   -16.8373     0.0430     0.0121     0.0202 </r>
+     <r>     4.5445   -15.8774   -15.8644   -15.8129     0.0438     0.0106     0.0198 </r>
+     <r>     4.5646   -14.9026   -14.8895   -14.8375     0.0446     0.0093     0.0196 </r>
+     <r>     4.5846   -13.9860   -13.9728   -13.9202     0.0451     0.0084     0.0194 </r>
+     <r>     4.6046   -13.1401   -13.1269   -13.0735     0.0451     0.0085     0.0193 </r>
+     <r>     4.6246   -12.3841   -12.3708   -12.3163     0.0440     0.0100     0.0194 </r>
+     <r>     4.6446   -11.7419   -11.7286   -11.6725     0.0412     0.0138     0.0197 </r>
+     <r>     4.6647   -11.2309   -11.2175   -11.1593     0.0364     0.0205     0.0203 </r>
+     <r>     4.6847   -10.8370   -10.8235   -10.7626     0.0296     0.0298     0.0211 </r>
+     <r>     4.7047   -10.4993   -10.4857   -10.4218     0.0222     0.0401     0.0220 </r>
+     <r>     4.7247   -10.1359   -10.1222   -10.0554     0.0159     0.0492     0.0230 </r>
+     <r>     4.7447    -9.6945    -9.6806    -9.6111     0.0118     0.0558     0.0237 </r>
+     <r>     4.7648    -9.1701    -9.1561    -9.0841     0.0100     0.0597     0.0244 </r>
+     <r>     4.7848    -8.5859    -8.5718    -8.4976     0.0099     0.0616     0.0249 </r>
+     <r>     4.8048    -7.9711    -7.9568    -7.8803     0.0109     0.0624     0.0255 </r>
+     <r>     4.8248    -7.3519    -7.3375    -7.2587     0.0125     0.0626     0.0260 </r>
+     <r>     4.8448    -6.7537    -6.7393    -6.6580     0.0145     0.0625     0.0266 </r>
+     <r>     4.8649    -6.2051    -6.1906    -6.1069     0.0166     0.0625     0.0272 </r>
+     <r>     4.8849    -5.7397    -5.7254    -5.6392     0.0186     0.0625     0.0279 </r>
+     <r>     4.9049    -5.3881    -5.3742    -5.2858     0.0205     0.0626     0.0285 </r>
+     <r>     4.9249    -5.1537    -5.1405    -5.0501     0.0220     0.0628     0.0290 </r>
+     <r>     4.9449    -4.9905    -4.9779    -4.8858     0.0232     0.0630     0.0293 </r>
+     <r>     4.9650    -4.8219    -4.8100    -4.7165     0.0239     0.0631     0.0294 </r>
+     <r>     4.9850    -4.6032    -4.5919    -4.4976     0.0238     0.0628     0.0290 </r>
+     <r>     5.0050    -4.3635    -4.3525    -4.2591     0.0219     0.0615     0.0274 </r>
+     <r>     5.0250    -4.1980    -4.1873    -4.0983     0.0170     0.0584     0.0239 </r>
+     <r>     5.0450    -4.2396    -4.2291    -4.1504     0.0070     0.0525     0.0175 </r>
+     <r>     5.0651    -4.6134    -4.6031    -4.5428    -0.0093     0.0434     0.0077 </r>
+     <r>     5.0851    -5.3569    -5.3467    -5.3128    -0.0314     0.0315    -0.0047 </r>
+     <r>     5.1051    -6.3420    -6.3317    -6.3289    -0.0557     0.0190    -0.0173 </r>
+     <r>     5.1251    -7.3160    -7.3052    -7.3320    -0.0766     0.0079    -0.0274 </r>
+     <r>     5.1451    -8.0684    -8.0562    -8.1055    -0.0900    -0.0012    -0.0337 </r>
+     <r>     5.1652    -8.5292    -8.5144    -8.5766    -0.0952    -0.0087    -0.0366 </r>
+     <r>     5.1852    -8.7225    -8.7039    -8.7699    -0.0936    -0.0147    -0.0370 </r>
+     <r>     5.2052    -8.6965    -8.6734    -8.7364    -0.0877    -0.0187    -0.0356 </r>
+     <r>     5.2252    -8.5032    -8.4758    -8.5314    -0.0795    -0.0202    -0.0330 </r>
+     <r>     5.2452    -8.1973    -8.1668    -8.2125    -0.0698    -0.0191    -0.0294 </r>
+     <r>     5.2653    -7.8290    -7.7969    -7.8319    -0.0592    -0.0163    -0.0250 </r>
+     <r>     5.2853    -7.4363    -7.4042    -7.4294    -0.0482    -0.0131    -0.0204 </r>
+     <r>     5.3053    -7.0447    -7.0142    -7.0315    -0.0374    -0.0106    -0.0161 </r>
+     <r>     5.3253    -6.6679    -6.6402    -6.6518    -0.0270    -0.0096    -0.0125 </r>
+     <r>     5.3453    -6.3057    -6.2816    -6.2891    -0.0173    -0.0099    -0.0095 </r>
+     <r>     5.3654    -5.9470    -5.9261    -5.9305    -0.0092    -0.0107    -0.0072 </r>
+     <r>     5.3854    -5.5798    -5.5612    -5.5632    -0.0034    -0.0116    -0.0058 </r>
+     <r>     5.4054    -5.2001    -5.1828    -5.1826    -0.0000    -0.0119    -0.0050 </r>
+     <r>     5.4254    -4.8109    -4.7940    -4.7919     0.0015    -0.0119    -0.0046 </r>
+     <r>     5.4454    -4.4172    -4.4002    -4.3963     0.0019    -0.0115    -0.0045 </r>
+     <r>     5.4655    -4.0229    -4.0056    -3.9999     0.0015    -0.0110    -0.0046 </r>
+     <r>     5.4855    -3.6310    -3.6131    -3.6058     0.0007    -0.0103    -0.0049 </r>
+     <r>     5.5055    -3.2438    -3.2253    -3.2163    -0.0002    -0.0097    -0.0051 </r>
+     <r>     5.5255    -2.8647    -2.8454    -2.8349    -0.0013    -0.0091    -0.0054 </r>
+     <r>     5.5455    -2.4999    -2.4799    -2.4679    -0.0024    -0.0086    -0.0058 </r>
+     <r>     5.5656    -2.1610    -2.1403    -2.1269    -0.0035    -0.0081    -0.0062 </r>
+     <r>     5.5856    -1.8684    -1.8469    -1.8323    -0.0047    -0.0077    -0.0066 </r>
+     <r>     5.6056    -1.6534    -1.6313    -1.6157    -0.0061    -0.0073    -0.0072 </r>
+     <r>     5.6256    -1.5555    -1.5329    -1.5167    -0.0077    -0.0072    -0.0078 </r>
+     <r>     5.6456    -1.6029    -1.5800    -1.5636    -0.0097    -0.0071    -0.0087 </r>
+     <r>     5.6657    -1.7767    -1.7535    -1.7374    -0.0119    -0.0072    -0.0097 </r>
+     <r>     5.6857    -1.9906    -1.9671    -1.9515    -0.0142    -0.0074    -0.0108 </r>
+     <r>     5.7057    -2.1320    -2.1082    -2.0927    -0.0165    -0.0075    -0.0118 </r>
+     <r>     5.7257    -2.1344    -2.1100    -2.0942    -0.0185    -0.0076    -0.0128 </r>
+     <r>     5.7457    -1.9990    -1.9738    -1.9571    -0.0203    -0.0075    -0.0137 </r>
+     <r>     5.7658    -1.7647    -1.7385    -1.7206    -0.0220    -0.0075    -0.0145 </r>
+     <r>     5.7858    -1.4745    -1.4471    -1.4276    -0.0236    -0.0074    -0.0153 </r>
+     <r>     5.8058    -1.1580    -1.1292    -1.1080    -0.0252    -0.0073    -0.0162 </r>
+     <r>     5.8258    -0.8269    -0.7966    -0.7735    -0.0269    -0.0072    -0.0172 </r>
+     <r>     5.8458    -0.4790    -0.4472    -0.4221    -0.0288    -0.0072    -0.0182 </r>
+     <r>     5.8659    -0.1103    -0.0769    -0.0498    -0.0308    -0.0072    -0.0193 </r>
+     <r>     5.8859     0.2749     0.3099     0.3390    -0.0330    -0.0073    -0.0206 </r>
+     <r>     5.9059     0.6618     0.6986     0.7295    -0.0352    -0.0076    -0.0220 </r>
+     <r>     5.9259     1.0267     1.0651     1.0978    -0.0373    -0.0081    -0.0235 </r>
+     <r>     5.9459     1.3366     1.3764     1.4107    -0.0390    -0.0091    -0.0250 </r>
+     <r>     5.9660     1.5490     1.5900     1.6255    -0.0398    -0.0108    -0.0264 </r>
+     <r>     5.9860     1.6160     1.6575     1.6937    -0.0392    -0.0135    -0.0276 </r>
+     <r>     6.0060     1.5014     1.5428     1.5791    -0.0367    -0.0171    -0.0283 </r>
+     <r>     6.0260     1.2135     1.2539     1.2898    -0.0319    -0.0212    -0.0280 </r>
+     <r>     6.0460     0.8180     0.8564     0.8919    -0.0245    -0.0251    -0.0259 </r>
+     <r>     6.0661     0.3945     0.4303     0.4654    -0.0140    -0.0280    -0.0212 </r>
+     <r>     6.0861    -0.0195     0.0125     0.0469     0.0001    -0.0292    -0.0134 </r>
+     <r>     6.1061    -0.4270    -0.4008    -0.3686     0.0169    -0.0283    -0.0027 </r>
+     <r>     6.1261    -0.8237    -0.8056    -0.7781     0.0336    -0.0248     0.0090 </r>
+     <r>     6.1461    -1.1629    -1.1546    -1.1344     0.0473    -0.0194     0.0197 </r>
+     <r>     6.1662    -1.3657    -1.3669    -1.3550     0.0570    -0.0131     0.0279 </r>
+     <r>     6.1862    -1.3722    -1.3809    -1.3768     0.0631    -0.0072     0.0333 </r>
+     <r>     6.2062    -1.1814    -1.1947    -1.1971     0.0662    -0.0022     0.0362 </r>
+     <r>     6.2262    -0.8379    -0.8535    -0.8606     0.0671     0.0017     0.0370 </r>
+     <r>     6.2462    -0.3994    -0.4154    -0.4255     0.0663     0.0044     0.0365 </r>
+     <r>     6.2663     0.0815     0.0662     0.0552     0.0645     0.0059     0.0353 </r>
+     <r>     6.2863     0.5578     0.5442     0.5337     0.0622     0.0065     0.0337 </r>
+     <r>     6.3063     0.9818     0.9702     0.9613     0.0597     0.0066     0.0322 </r>
+     <r>     6.3263     1.3011     1.2917     1.2851     0.0572     0.0064     0.0306 </r>
+     <r>     6.3463     1.4697     1.4627     1.4586     0.0547     0.0062     0.0292 </r>
+     <r>     6.3664     1.4807     1.4762     1.4747     0.0524     0.0060     0.0279 </r>
+     <r>     6.3864     1.3979     1.3957     1.3970     0.0503     0.0058     0.0267 </r>
+     <r>     6.4064     1.3315     1.3315     1.3355     0.0486     0.0053     0.0257 </r>
+     <r>     6.4264     1.3628     1.3651     1.3715     0.0476     0.0044     0.0247 </r>
+     <r>     6.4464     1.4997     1.5040     1.5128     0.0473     0.0029     0.0238 </r>
+     <r>     6.4665     1.6892     1.6954     1.7063     0.0479     0.0007     0.0230 </r>
+     <r>     6.4865     1.8450     1.8529     1.8658     0.0494    -0.0022     0.0222 </r>
+     <r>     6.5065     1.8717     1.8810     1.8955     0.0514    -0.0055     0.0214 </r>
+     <r>     6.5265     1.7004     1.7109     1.7266     0.0533    -0.0086     0.0206 </r>
+     <r>     6.5465     1.3315     1.3424     1.3587     0.0545    -0.0110     0.0199 </r>
+     <r>     6.5666     0.8336     0.8443     0.8605     0.0547    -0.0123     0.0192 </r>
+     <r>     6.5866     0.2815     0.2910     0.3062     0.0540    -0.0129     0.0186 </r>
+     <r>     6.6066    -0.2861    -0.2785    -0.2652     0.0530    -0.0131     0.0180 </r>
+     <r>     6.6266    -0.8298    -0.8244    -0.8132     0.0522    -0.0135     0.0175 </r>
+     <r>     6.6466    -1.2708    -1.2671    -1.2575     0.0518    -0.0142     0.0170 </r>
+     <r>     6.6667    -1.5167    -1.5139    -1.5049     0.0519    -0.0152     0.0166 </r>
+     <r>     6.6867    -1.5266    -1.5236    -1.5142     0.0522    -0.0164     0.0162 </r>
+     <r>     6.7067    -1.3466    -1.3424    -1.3317     0.0525    -0.0175     0.0158 </r>
+     <r>     6.7267    -1.0853    -1.0794    -1.0670     0.0527    -0.0185     0.0154 </r>
+     <r>     6.7467    -0.8682    -0.8604    -0.8459     0.0528    -0.0195     0.0151 </r>
+     <r>     6.7668    -0.8143    -0.8046    -0.7883     0.0531    -0.0205     0.0147 </r>
+     <r>     6.7868    -1.0364    -1.0253    -1.0074     0.0536    -0.0216     0.0144 </r>
+     <r>     6.8068    -1.6168    -1.6048    -1.5856     0.0544    -0.0228     0.0142 </r>
+     <r>     6.8268    -2.5284    -2.5160    -2.4961     0.0557    -0.0243     0.0141 </r>
+     <r>     6.8468    -3.5931    -3.5803    -3.5598     0.0574    -0.0259     0.0141 </r>
+     <r>     6.8669    -4.5789    -4.5657    -4.5442     0.0594    -0.0278     0.0140 </r>
+     <r>     6.8869    -5.3455    -5.3316    -5.3091     0.0613    -0.0296     0.0140 </r>
+     <r>     6.9069    -5.8670    -5.8526    -5.8293     0.0630    -0.0312     0.0140 </r>
+     <r>     6.9269    -6.1659    -6.1516    -6.1282     0.0643    -0.0324     0.0139 </r>
+     <r>     6.9469    -6.2784    -6.2655    -6.2430     0.0647    -0.0328     0.0138 </r>
+     <r>     6.9670    -6.2698    -6.2600    -6.2403     0.0639    -0.0319     0.0138 </r>
+     <r>     6.9870    -6.2444    -6.2402    -6.2259     0.0609    -0.0288     0.0138 </r>
+     <r>     7.0070    -6.3200    -6.3246    -6.3185     0.0550    -0.0226     0.0138 </r>
+     <r>     7.0270    -6.5700    -6.5853    -6.5895     0.0456    -0.0130     0.0139 </r>
+     <r>     7.0470    -6.9702    -6.9959    -7.0098     0.0336    -0.0009     0.0139 </r>
+     <r>     7.0671    -7.4105    -7.4433    -7.4639     0.0217     0.0112     0.0138 </r>
+     <r>     7.0871    -7.7767    -7.8126    -7.8357     0.0121     0.0207     0.0138 </r>
+     <r>     7.1071    -8.0194    -8.0548    -8.0769     0.0062     0.0266     0.0137 </r>
+     <r>     7.1271    -8.1361    -8.1688    -8.1877     0.0036     0.0292     0.0137 </r>
+     <r>     7.1471    -8.1225    -8.1515    -8.1664     0.0035     0.0293     0.0136 </r>
+     <r>     7.1672    -7.9712    -7.9965    -8.0073     0.0048     0.0279     0.0136 </r>
+     <r>     7.1872    -7.7003    -7.7221    -7.7291     0.0069     0.0257     0.0135 </r>
+     <r>     7.2072    -7.3567    -7.3755    -7.3793     0.0093     0.0231     0.0134 </r>
+     <r>     7.2272    -6.9990    -7.0151    -7.0163     0.0117     0.0203     0.0132 </r>
+     <r>     7.2472    -6.6809    -6.6947    -6.6936     0.0140     0.0173     0.0130 </r>
+     <r>     7.2673    -6.4371    -6.4486    -6.4458     0.0160     0.0142     0.0125 </r>
+     <r>     7.2873    -6.2658    -6.2753    -6.2710     0.0177     0.0110     0.0120 </r>
+     <r>     7.3073    -6.1258    -6.1335    -6.1281     0.0191     0.0080     0.0115 </r>
+     <r>     7.3273    -5.9682    -5.9744    -5.9680     0.0204     0.0055     0.0110 </r>
+     <r>     7.3473    -5.7783    -5.7835    -5.7763     0.0212     0.0037     0.0107 </r>
+     <r>     7.3674    -5.5854    -5.5905    -5.5833     0.0212     0.0031     0.0105 </r>
+     <r>     7.3874    -5.4448    -5.4513    -5.4453     0.0198     0.0040     0.0103 </r>
+     <r>     7.4074    -5.4096    -5.4193    -5.4163     0.0163     0.0071     0.0102 </r>
+     <r>     7.4274    -5.4975    -5.5122    -5.5140     0.0110     0.0120     0.0100 </r>
+     <r>     7.4474    -5.6664    -5.6868    -5.6942     0.0046     0.0181     0.0099 </r>
+     <r>     7.4675    -5.8322    -5.8577    -5.8699    -0.0012     0.0238     0.0098 </r>
+     <r>     7.4875    -5.9222    -5.9512    -5.9665    -0.0053     0.0281     0.0098 </r>
+     <r>     7.5075    -5.9044    -5.9353    -5.9518    -0.0074     0.0307     0.0099 </r>
+     <r>     7.5275    -5.7814    -5.8127    -5.8289    -0.0077     0.0317     0.0101 </r>
+     <r>     7.5475    -5.5774    -5.6084    -5.6231    -0.0063     0.0318     0.0105 </r>
+     <r>     7.5676    -5.3287    -5.3588    -5.3711    -0.0037     0.0314     0.0112 </r>
+     <r>     7.5876    -5.0756    -5.1048    -5.1139     0.0001     0.0312     0.0123 </r>
+     <r>     7.6076    -4.8582    -4.8865    -4.8918     0.0048     0.0316     0.0139 </r>
+     <r>     7.6276    -4.7115    -4.7390    -4.7405     0.0097     0.0326     0.0159 </r>
+     <r>     7.6476    -4.6565    -4.6836    -4.6815     0.0139     0.0344     0.0178 </r>
+     <r>     7.6677    -4.6891    -4.7160    -4.7111     0.0163     0.0367     0.0194 </r>
+     <r>     7.6877    -4.7803    -4.8072    -4.8003     0.0169     0.0396     0.0205 </r>
+     <r>     7.7077    -4.8880    -4.9149    -4.9063     0.0161     0.0429     0.0214 </r>
+     <r>     7.7277    -4.9683    -4.9951    -4.9849     0.0149     0.0462     0.0220 </r>
+     <r>     7.7477    -4.9941    -5.0207    -5.0084     0.0142     0.0487     0.0226 </r>
+     <r>     7.7678    -4.9735    -4.9996    -4.9850     0.0145     0.0503     0.0233 </r>
+     <r>     7.7878    -4.9445    -4.9698    -4.9523     0.0160     0.0512     0.0241 </r>
+     <r>     7.8078    -4.9473    -4.9718    -4.9508     0.0186     0.0516     0.0251 </r>
+     <r>     7.8278    -4.9998    -5.0233    -4.9983     0.0219     0.0519     0.0263 </r>
+     <r>     7.8478    -5.0936    -5.1161    -5.0866     0.0255     0.0524     0.0276 </r>
+     <r>     7.8679    -5.2065    -5.2279    -5.1936     0.0293     0.0532     0.0291 </r>
+     <r>     7.8879    -5.3070    -5.3274    -5.2882     0.0331     0.0542     0.0307 </r>
+     <r>     7.9079    -5.3575    -5.3771    -5.3330     0.0368     0.0554     0.0323 </r>
+     <r>     7.9279    -5.3340    -5.3529    -5.3040     0.0405     0.0565     0.0339 </r>
+     <r>     7.9479    -5.2424    -5.2607    -5.2071     0.0442     0.0577     0.0356 </r>
+     <r>     7.9680    -5.1103    -5.1282    -5.0697     0.0479     0.0592     0.0373 </r>
+     <r>     7.9880    -4.9689    -4.9864    -4.9227     0.0516     0.0610     0.0392 </r>
+     <r>     8.0080    -4.8382    -4.8553    -4.7860     0.0552     0.0633     0.0413 </r>
+     <r>     8.0280    -4.7221    -4.7389    -4.6638     0.0588     0.0661     0.0435 </r>
+     <r>     8.0480    -4.6155    -4.6319    -4.5513     0.0621     0.0688     0.0456 </r>
+     <r>     8.0681    -4.5157    -4.5317    -4.4469     0.0646     0.0709     0.0471 </r>
+     <r>     8.0881    -4.4287    -4.4441    -4.3579     0.0650     0.0713     0.0471 </r>
+     <r>     8.1081    -4.3710    -4.3858    -4.3035     0.0613     0.0688     0.0447 </r>
+     <r>     8.1281    -4.3705    -4.3847    -4.3144     0.0509     0.0622     0.0386 </r>
+     <r>     8.1481    -4.4554    -4.4690    -4.4209     0.0320     0.0511     0.0282 </r>
+     <r>     8.1682    -4.6286    -4.6417    -4.6252     0.0056     0.0360     0.0141 </r>
+     <r>     8.1882    -4.8463    -4.8590    -4.8786    -0.0237     0.0197    -0.0012 </r>
+     <r>     8.2082    -5.0335    -5.0458    -5.0981    -0.0493     0.0058    -0.0143 </r>
+     <r>     8.2282    -5.1326    -5.1447    -5.2207    -0.0670    -0.0038    -0.0231 </r>
+     <r>     8.2482    -5.1329    -5.1447    -5.2343    -0.0765    -0.0091    -0.0278 </r>
+     <r>     8.2683    -5.0559    -5.0676    -5.1628    -0.0800    -0.0113    -0.0295 </r>
+     <r>     8.2883    -4.9319    -4.9435    -5.0392    -0.0798    -0.0116    -0.0294 </r>
+     <r>     8.3083    -4.7865    -4.7979    -4.8915    -0.0777    -0.0110    -0.0285 </r>
+     <r>     8.3283    -4.6385    -4.6498    -4.7404    -0.0751    -0.0101    -0.0273 </r>
+     <r>     8.3483    -4.5020    -4.5130    -4.6006    -0.0728    -0.0095    -0.0263 </r>
+     <r>     8.3684    -4.3856    -4.3965    -4.4818    -0.0712    -0.0092    -0.0256 </r>
+     <r>     8.3884    -4.2919    -4.3027    -4.3863    -0.0702    -0.0092    -0.0253 </r>
+     <r>     8.4084    -4.2163    -4.2268    -4.3090    -0.0693    -0.0092    -0.0250 </r>
+     <r>     8.4284    -4.1508    -4.1612    -4.2415    -0.0680    -0.0089    -0.0244 </r>
+     <r>     8.4484    -4.0893    -4.0995    -4.1772    -0.0659    -0.0081    -0.0235 </r>
+     <r>     8.4685    -4.0268    -4.0369    -4.1112    -0.0631    -0.0069    -0.0221 </r>
+     <r>     8.4885    -3.9580    -3.9680    -4.0385    -0.0599    -0.0054    -0.0206 </r>
+     <r>     8.5085    -3.8797    -3.8896    -3.9563    -0.0569    -0.0040    -0.0192 </r>
+     <r>     8.5285    -3.7952    -3.8049    -3.8682    -0.0541    -0.0028    -0.0179 </r>
+     <r>     8.5485    -3.7143    -3.7239    -3.7841    -0.0515    -0.0018    -0.0167 </r>
+     <r>     8.5686    -3.6502    -3.6597    -3.7169    -0.0490    -0.0009    -0.0156 </r>
+     <r>     8.5886    -3.6140    -3.6233    -3.6775    -0.0465    -0.0001    -0.0145 </r>
+     <r>     8.6086    -3.6068    -3.6158    -3.6671    -0.0439     0.0006    -0.0134 </r>
+     <r>     8.6286    -3.6143    -3.6230    -3.6714    -0.0413     0.0012    -0.0124 </r>
+     <r>     8.6486    -3.6130    -3.6215    -3.6672    -0.0389     0.0018    -0.0114 </r>
+     <r>     8.6687    -3.5863    -3.5945    -3.6380    -0.0370     0.0023    -0.0106 </r>
+     <r>     8.6887    -3.5316    -3.5397    -3.5813    -0.0355     0.0028    -0.0100 </r>
+     <r>     8.7087    -3.4561    -3.4641    -3.5041    -0.0343     0.0032    -0.0095 </r>
+     <r>     8.7287    -3.3686    -3.3766    -3.4153    -0.0335     0.0036    -0.0091 </r>
+     <r>     8.7487    -3.2760    -3.2839    -3.3214    -0.0328     0.0040    -0.0088 </r>
+     <r>     8.7688    -3.1817    -3.1895    -3.2259    -0.0322     0.0044    -0.0085 </r>
+     <r>     8.7888    -3.0867    -3.0944    -3.1298    -0.0317     0.0048    -0.0082 </r>
+     <r>     8.8088    -2.9908    -2.9985    -3.0330    -0.0312     0.0052    -0.0080 </r>
+     <r>     8.8288    -2.8945    -2.9022    -2.9358    -0.0308     0.0055    -0.0078 </r>
+     <r>     8.8488    -2.7994    -2.8071    -2.8399    -0.0304     0.0059    -0.0075 </r>
+     <r>     8.8689    -2.7079    -2.7155    -2.7475    -0.0300     0.0063    -0.0073 </r>
+     <r>     8.8889    -2.6231    -2.6307    -2.6620    -0.0296     0.0068    -0.0069 </r>
+     <r>     8.9089    -2.5487    -2.5562    -2.5869    -0.0291     0.0075    -0.0065 </r>
+     <r>     8.9289    -2.4867    -2.4941    -2.5242    -0.0285     0.0082    -0.0059 </r>
+     <r>     8.9489    -2.4355    -2.4429    -2.4724    -0.0278     0.0090    -0.0052 </r>
+     <r>     8.9690    -2.3895    -2.3968    -2.4258    -0.0270     0.0097    -0.0046 </r>
+     <r>     8.9890    -2.3423    -2.3495    -2.3779    -0.0263     0.0103    -0.0040 </r>
+     <r>     9.0090    -2.2907    -2.2976    -2.3253    -0.0257     0.0106    -0.0036 </r>
+     <r>     9.0290    -2.2360    -2.2425    -2.2693    -0.0250     0.0106    -0.0034 </r>
+     <r>     9.0490    -2.1827    -2.1885    -2.2143    -0.0243     0.0104    -0.0032 </r>
+     <r>     9.0691    -2.1344    -2.1393    -2.1638    -0.0234     0.0098    -0.0031 </r>
+     <r>     9.0891    -2.0893    -2.0931    -2.1162    -0.0225     0.0091    -0.0031 </r>
+     <r>     9.1091    -2.0410    -2.0439    -2.0656    -0.0215     0.0084    -0.0031 </r>
+     <r>     9.1291    -1.9854    -1.9875    -2.0081    -0.0207     0.0077    -0.0030 </r>
+     <r>     9.1491    -1.9262    -1.9278    -1.9475    -0.0200     0.0072    -0.0030 </r>
+     <r>     9.1692    -1.8752    -1.8766    -1.8958    -0.0194     0.0069    -0.0029 </r>
+     <r>     9.1892    -1.8508    -1.8524    -1.8713    -0.0188     0.0067    -0.0028 </r>
+     <r>     9.2092    -1.8754    -1.8777    -1.8969    -0.0183     0.0067    -0.0027 </r>
+     <r>     9.2292    -1.9679    -1.9717    -1.9917    -0.0177     0.0067    -0.0025 </r>
+     <r>     9.2492    -2.1279    -2.1338    -2.1553    -0.0169     0.0067    -0.0023 </r>
+     <r>     9.2693    -2.3215    -2.3299    -2.3531    -0.0161     0.0067    -0.0020 </r>
+     <r>     9.2893    -2.4926    -2.5034    -2.5283    -0.0153     0.0067    -0.0018 </r>
+     <r>     9.3093    -2.5990    -2.6116    -2.6378    -0.0147     0.0068    -0.0015 </r>
+     <r>     9.3293    -2.6322    -2.6461    -2.6729    -0.0144     0.0069    -0.0014 </r>
+     <r>     9.3493    -2.6085    -2.6231    -2.6502    -0.0142     0.0072    -0.0012 </r>
+     <r>     9.3694    -2.5509    -2.5659    -2.5928    -0.0141     0.0076    -0.0011 </r>
+     <r>     9.3894    -2.4798    -2.4948    -2.5215    -0.0140     0.0080    -0.0010 </r>
+     <r>     9.4094    -2.4106    -2.4256    -2.4517    -0.0139     0.0083    -0.0009 </r>
+     <r>     9.4294    -2.3541    -2.3688    -2.3943    -0.0137     0.0085    -0.0007 </r>
+     <r>     9.4494    -2.3149    -2.3290    -2.3535    -0.0131     0.0084    -0.0006 </r>
+     <r>     9.4695    -2.2907    -2.3039    -2.3270    -0.0123     0.0081    -0.0005 </r>
+     <r>     9.4895    -2.2749    -2.2869    -2.3082    -0.0111     0.0074    -0.0003 </r>
+     <r>     9.5095    -2.2587    -2.2691    -2.2885    -0.0098     0.0066    -0.0002 </r>
+     <r>     9.5295    -2.2332    -2.2423    -2.2600    -0.0086     0.0058    -0.0001 </r>
+     <r>     9.5495    -2.1949    -2.2030    -2.2195    -0.0080     0.0052    -0.0000 </r>
+     <r>     9.5696    -2.1478    -2.1553    -2.1714    -0.0079     0.0048    -0.0001 </r>
+     <r>     9.5896    -2.1004    -2.1078    -2.1241    -0.0086     0.0046    -0.0004 </r>
+     <r>     9.6096    -2.0600    -2.0674    -2.0848    -0.0099     0.0044    -0.0009 </r>
+     <r>     9.6296    -2.0271    -2.0347    -2.0536    -0.0117     0.0041    -0.0016 </r>
+     <r>     9.6496    -1.9962    -2.0040    -2.0246    -0.0135     0.0038    -0.0023 </r>
+     <r>     9.6697    -1.9626    -1.9705    -1.9924    -0.0150     0.0036    -0.0029 </r>
+     <r>     9.6897    -1.9290    -1.9370    -1.9598    -0.0159     0.0033    -0.0033 </r>
+     <r>     9.7097    -1.9060    -1.9138    -1.9368    -0.0162     0.0030    -0.0035 </r>
+     <r>     9.7297    -1.9063    -1.9136    -1.9361    -0.0159     0.0023    -0.0037 </r>
+     <r>     9.7497    -1.9380    -1.9440    -1.9656    -0.0153     0.0014    -0.0038 </r>
+     <r>     9.7698    -1.9966    -2.0010    -2.0210    -0.0145     0.0002    -0.0039 </r>
+     <r>     9.7898    -2.0640    -2.0666    -2.0849    -0.0138    -0.0009    -0.0040 </r>
+     <r>     9.8098    -2.1188    -2.1199    -2.1366    -0.0133    -0.0016    -0.0041 </r>
+     <r>     9.8298    -2.1510    -2.1510    -2.1667    -0.0131    -0.0019    -0.0042 </r>
+     <r>     9.8498    -2.1628    -2.1623    -2.1773    -0.0133    -0.0017    -0.0042 </r>
+     <r>     9.8699    -2.1586    -2.1578    -2.1725    -0.0137    -0.0013    -0.0042 </r>
+     <r>     9.8899    -2.1386    -2.1378    -2.1523    -0.0141    -0.0008    -0.0042 </r>
+     <r>     9.9099    -2.1020    -2.1012    -2.1157    -0.0145    -0.0002    -0.0041 </r>
+     <r>     9.9299    -2.0506    -2.0500    -2.0644    -0.0148     0.0003    -0.0041 </r>
+     <r>     9.9499    -1.9886    -1.9881    -2.0025    -0.0150     0.0007    -0.0040 </r>
+     <r>     9.9700    -1.9203    -1.9201    -1.9344    -0.0151     0.0010    -0.0040 </r>
+     <r>     9.9900    -1.8494    -1.8493    -1.8635    -0.0152     0.0013    -0.0039 </r>
+     <r>    10.0100    -1.7783    -1.7784    -1.7927    -0.0153     0.0016    -0.0039 </r>
+     <r>    10.0300    -1.7100    -1.7103    -1.7245    -0.0154     0.0018    -0.0039 </r>
+     <r>    10.0501    -1.6482    -1.6487    -1.6628    -0.0154     0.0021    -0.0038 </r>
+     <r>    10.0701    -1.5981    -1.5987    -1.6127    -0.0155     0.0024    -0.0037 </r>
+     <r>    10.0901    -1.5655    -1.5663    -1.5802    -0.0155     0.0027    -0.0037 </r>
+     <r>    10.1101    -1.5546    -1.5555    -1.5693    -0.0156     0.0030    -0.0036 </r>
+     <r>    10.1301    -1.5635    -1.5645    -1.5780    -0.0157     0.0035    -0.0035 </r>
+     <r>    10.1502    -1.5818    -1.5829    -1.5963    -0.0158     0.0039    -0.0034 </r>
+     <r>    10.1702    -1.5964    -1.5977    -1.6109    -0.0159     0.0044    -0.0033 </r>
+     <r>    10.1902    -1.5995    -1.6009    -1.6138    -0.0159     0.0048    -0.0032 </r>
+     <r>    10.2102    -1.5894    -1.5910    -1.6036    -0.0159     0.0052    -0.0031 </r>
+     <r>    10.2302    -1.5663    -1.5679    -1.5803    -0.0159     0.0056    -0.0030 </r>
+     <r>    10.2503    -1.5303    -1.5320    -1.5443    -0.0159     0.0059    -0.0028 </r>
+     <r>    10.2703    -1.4836    -1.4855    -1.4976    -0.0157     0.0061    -0.0027 </r>
+     <r>    10.2903    -1.4310    -1.4329    -1.4450    -0.0154     0.0063    -0.0025 </r>
+     <r>    10.3103    -1.3780    -1.3800    -1.3920    -0.0150     0.0063    -0.0022 </r>
+     <r>    10.3303    -1.3302    -1.3324    -1.3443    -0.0143     0.0062    -0.0019 </r>
+     <r>    10.3504    -1.2926    -1.2949    -1.3069    -0.0136     0.0061    -0.0016 </r>
+     <r>    10.3704    -1.2689    -1.2712    -1.2833    -0.0128     0.0058    -0.0014 </r>
+     <r>    10.3904    -1.2598    -1.2622    -1.2743    -0.0122     0.0054    -0.0013 </r>
+     <r>    10.4104    -1.2648    -1.2673    -1.2794    -0.0118     0.0051    -0.0012 </r>
+     <r>    10.4304    -1.2854    -1.2880    -1.3003    -0.0116     0.0050    -0.0012 </r>
+     <r>    10.4505    -1.3245    -1.3273    -1.3397    -0.0117     0.0050    -0.0012 </r>
+     <r>    10.4705    -1.3785    -1.3815    -1.3940    -0.0120     0.0052    -0.0012 </r>
+     <r>    10.4905    -1.4326    -1.4358    -1.4485    -0.0123     0.0055    -0.0013 </r>
+     <r>    10.5105    -1.4684    -1.4717    -1.4846    -0.0127     0.0058    -0.0013 </r>
+     <r>    10.5305    -1.4766    -1.4801    -1.4932    -0.0131     0.0061    -0.0014 </r>
+     <r>    10.5506    -1.4606    -1.4643    -1.4774    -0.0134     0.0064    -0.0014 </r>
+     <r>    10.5706    -1.4302    -1.4339    -1.4470    -0.0136     0.0067    -0.0014 </r>
+     <r>    10.5906    -1.3952    -1.3990    -1.4120    -0.0139     0.0070    -0.0013 </r>
+     <r>    10.6106    -1.3633    -1.3670    -1.3797    -0.0141     0.0073    -0.0013 </r>
+     <r>    10.6306    -1.3388    -1.3421    -1.3543    -0.0144     0.0076    -0.0013 </r>
+     <r>    10.6507    -1.3231    -1.3258    -1.3372    -0.0146     0.0078    -0.0013 </r>
+     <r>    10.6707    -1.3148    -1.3166    -1.3270    -0.0147     0.0078    -0.0013 </r>
+     <r>    10.6907    -1.3102    -1.3109    -1.3202    -0.0145     0.0075    -0.0014 </r>
+     <r>    10.7107    -1.3059    -1.3055    -1.3139    -0.0141     0.0069    -0.0015 </r>
+     <r>    10.7307    -1.3001    -1.2988    -1.3064    -0.0134     0.0061    -0.0016 </r>
+     <r>    10.7508    -1.2913    -1.2893    -1.2962    -0.0127     0.0052    -0.0017 </r>
+     <r>    10.7708    -1.2772    -1.2747    -1.2810    -0.0121     0.0044    -0.0017 </r>
+     <r>    10.7908    -1.2560    -1.2532    -1.2592    -0.0116     0.0039    -0.0018 </r>
+     <r>    10.8108    -1.2283    -1.2253    -1.2311    -0.0113     0.0035    -0.0018 </r>
+     <r>    10.8308    -1.1968    -1.1937    -1.1993    -0.0112     0.0033    -0.0018 </r>
+     <r>    10.8509    -1.1657    -1.1627    -1.1682    -0.0110     0.0031    -0.0018 </r>
+     <r>    10.8709    -1.1393    -1.1364    -1.1420    -0.0109     0.0030    -0.0018 </r>
+     <r>    10.8909    -1.1202    -1.1175    -1.1230    -0.0108     0.0029    -0.0018 </r>
+     <r>    10.9109    -1.1090    -1.1064    -1.1120    -0.0107     0.0028    -0.0018 </r>
+     <r>    10.9309    -1.1049    -1.1024    -1.1080    -0.0107     0.0027    -0.0018 </r>
+     <r>    10.9510    -1.1061    -1.1036    -1.1092    -0.0107     0.0027    -0.0019 </r>
+     <r>    10.9710    -1.1124    -1.1097    -1.1153    -0.0108     0.0027    -0.0020 </r>
+     <r>    10.9910    -1.1266    -1.1238    -1.1292    -0.0110     0.0026    -0.0021 </r>
+     <r>    11.0110    -1.1533    -1.1500    -1.1554    -0.0111     0.0025    -0.0022 </r>
+     <r>    11.0310    -1.1921    -1.1883    -1.1936    -0.0113     0.0024    -0.0024 </r>
+     <r>    11.0511    -1.2347    -1.2303    -1.2354    -0.0116     0.0023    -0.0025 </r>
+     <r>    11.0711    -1.2701    -1.2652    -1.2701    -0.0119     0.0022    -0.0026 </r>
+     <r>    11.0911    -1.2944    -1.2890    -1.2936    -0.0123     0.0023    -0.0028 </r>
+     <r>    11.1111    -1.3113    -1.3054    -1.3097    -0.0128     0.0024    -0.0029 </r>
+     <r>    11.1311    -1.3253    -1.3189    -1.3229    -0.0133     0.0026    -0.0030 </r>
+     <r>    11.1512    -1.3369    -1.3300    -1.3337    -0.0138     0.0028    -0.0031 </r>
+     <r>    11.1712    -1.3450    -1.3376    -1.3408    -0.0143     0.0031    -0.0032 </r>
+     <r>    11.1912    -1.3498    -1.3419    -1.3447    -0.0147     0.0033    -0.0032 </r>
+     <r>    11.2112    -1.3517    -1.3433    -1.3456    -0.0151     0.0035    -0.0033 </r>
+     <r>    11.2312    -1.3495    -1.3406    -1.3425    -0.0153     0.0035    -0.0034 </r>
+     <r>    11.2513    -1.3411    -1.3317    -1.3334    -0.0154     0.0034    -0.0035 </r>
+     <r>    11.2713    -1.3242    -1.3146    -1.3160    -0.0155     0.0032    -0.0036 </r>
+     <r>    11.2913    -1.2972    -1.2872    -1.2884    -0.0155     0.0031    -0.0036 </r>
+     <r>    11.3113    -1.2599    -1.2496    -1.2505    -0.0157     0.0030    -0.0037 </r>
+     <r>    11.3313    -1.2144    -1.2038    -1.2044    -0.0160     0.0031    -0.0038 </r>
+     <r>    11.3514    -1.1639    -1.1528    -1.1530    -0.0164     0.0033    -0.0039 </r>
+     <r>    11.3714    -1.1109    -1.0993    -1.0991    -0.0169     0.0036    -0.0040 </r>
+     <r>    11.3914    -1.0576    -1.0456    -1.0450    -0.0174     0.0039    -0.0040 </r>
+     <r>    11.4114    -1.0056    -0.9932    -0.9923    -0.0180     0.0042    -0.0041 </r>
+     <r>    11.4314    -0.9568    -0.9443    -0.9433    -0.0185     0.0046    -0.0042 </r>
+     <r>    11.4515    -0.9137    -0.9015    -0.9010    -0.0191     0.0048    -0.0043 </r>
+     <r>    11.4715    -0.8802    -0.8690    -0.8697    -0.0197     0.0050    -0.0044 </r>
+     <r>    11.4915    -0.8607    -0.8515    -0.8546    -0.0204     0.0052    -0.0045 </r>
+     <r>    11.5115    -0.8576    -0.8519    -0.8587    -0.0211     0.0052    -0.0047 </r>
+     <r>    11.5315    -0.8679    -0.8666    -0.8784    -0.0220     0.0052    -0.0049 </r>
+     <r>    11.5516    -0.8814    -0.8849    -0.9018    -0.0229     0.0053    -0.0052 </r>
+     <r>    11.5716    -0.8866    -0.8940    -0.9152    -0.0239     0.0054    -0.0055 </r>
+     <r>    11.5916    -0.8778    -0.8879    -0.9118    -0.0246     0.0058    -0.0056 </r>
+     <r>    11.6116    -0.8577    -0.8691    -0.8941    -0.0247     0.0062    -0.0056 </r>
+     <r>    11.6316    -0.8335    -0.8453    -0.8701    -0.0242     0.0068    -0.0053 </r>
+     <r>    11.6517    -0.8139    -0.8254    -0.8488    -0.0228     0.0071    -0.0047 </r>
+     <r>    11.6717    -0.8072    -0.8179    -0.8391    -0.0204     0.0070    -0.0041 </r>
+     <r>    11.6917    -0.8214    -0.8310    -0.8496    -0.0168     0.0060    -0.0033 </r>
+     <r>    11.7117    -0.8614    -0.8697    -0.8855    -0.0121     0.0042    -0.0024 </r>
+     <r>    11.7317    -0.9228    -0.9301    -0.9432    -0.0068     0.0020    -0.0015 </r>
+     <r>    11.7518    -0.9902    -0.9971    -1.0080    -0.0020     0.0002    -0.0005 </r>
+     <r>    11.7718    -1.0442    -1.0510    -1.0606     0.0014    -0.0008     0.0003 </r>
+     <r>    11.7918    -1.0723    -1.0793    -1.0882     0.0032    -0.0011     0.0009 </r>
+     <r>    11.8118    -1.0732    -1.0805    -1.0889     0.0038    -0.0009     0.0011 </r>
+     <r>    11.8318    -1.0529    -1.0602    -1.0685     0.0034    -0.0005     0.0012 </r>
+     <r>    11.8519    -1.0188    -1.0259    -1.0342     0.0027    -0.0000     0.0011 </r>
+     <r>    11.8719    -0.9769    -0.9839    -0.9922     0.0017     0.0005     0.0010 </r>
+     <r>    11.8919    -0.9323    -0.9390    -0.9472     0.0006     0.0010     0.0008 </r>
+     <r>    11.9119    -0.8888    -0.8952    -0.9033    -0.0005     0.0015     0.0005 </r>
+     <r>    11.9319    -0.8502    -0.8562    -0.8642    -0.0016     0.0020     0.0003 </r>
+     <r>    11.9520    -0.8200    -0.8257    -0.8336    -0.0027     0.0026     0.0001 </r>
+     <r>    11.9720    -0.8014    -0.8068    -0.8147    -0.0039     0.0032    -0.0001 </r>
+     <r>    11.9920    -0.7965    -0.8017    -0.8098    -0.0050     0.0038    -0.0003 </r>
+     <r>    12.0120    -0.8037    -0.8089    -0.8173    -0.0061     0.0043    -0.0004 </r>
+     <r>    12.0320    -0.8179    -0.8230    -0.8318    -0.0069     0.0049    -0.0005 </r>
+     <r>    12.0521    -0.8336    -0.8388    -0.8478    -0.0074     0.0053    -0.0004 </r>
+     <r>    12.0721    -0.8498    -0.8548    -0.8641    -0.0076     0.0057    -0.0002 </r>
+     <r>    12.0921    -0.8672    -0.8721    -0.8815    -0.0077     0.0060    -0.0001 </r>
+     <r>    12.1121    -0.8839    -0.8886    -0.8981    -0.0078     0.0062     0.0001 </r>
+     <r>    12.1321    -0.8943    -0.8988    -0.9083    -0.0081     0.0065     0.0001 </r>
+     <r>    12.1522    -0.8940    -0.8984    -0.9078    -0.0086     0.0068     0.0001 </r>
+     <r>    12.1722    -0.8836    -0.8877    -0.8972    -0.0093     0.0073     0.0000 </r>
+     <r>    12.1922    -0.8658    -0.8698    -0.8792    -0.0102     0.0078    -0.0001 </r>
+     <r>    12.2122    -0.8429    -0.8467    -0.8561    -0.0111     0.0084    -0.0002 </r>
+     <r>    12.2322    -0.8151    -0.8189    -0.8282    -0.0121     0.0091    -0.0003 </r>
+     <r>    12.2523    -0.7828    -0.7864    -0.7956    -0.0131     0.0099    -0.0004 </r>
+     <r>    12.2723    -0.7466    -0.7501    -0.7593    -0.0141     0.0106    -0.0005 </r>
+     <r>    12.2923    -0.7082    -0.7116    -0.7208    -0.0152     0.0114    -0.0006 </r>
+     <r>    12.3123    -0.6690    -0.6723    -0.6814    -0.0162     0.0122    -0.0007 </r>
+     <r>    12.3323    -0.6306    -0.6338    -0.6429    -0.0172     0.0130    -0.0008 </r>
+     <r>    12.3524    -0.5946    -0.5977    -0.6068    -0.0180     0.0136    -0.0009 </r>
+     <r>    12.3724    -0.5631    -0.5662    -0.5752    -0.0185     0.0139    -0.0009 </r>
+     <r>    12.3924    -0.5385    -0.5414    -0.5504    -0.0184     0.0137    -0.0010 </r>
+     <r>    12.4124    -0.5228    -0.5255    -0.5345    -0.0175     0.0127    -0.0010 </r>
+     <r>    12.4324    -0.5178    -0.5203    -0.5292    -0.0154     0.0105    -0.0011 </r>
+     <r>    12.4525    -0.5245    -0.5268    -0.5355    -0.0120     0.0070    -0.0011 </r>
+     <r>    12.4725    -0.5418    -0.5439    -0.5523    -0.0077     0.0024    -0.0012 </r>
+     <r>    12.4925    -0.5656    -0.5673    -0.5754    -0.0033    -0.0023    -0.0013 </r>
+     <r>    12.5125    -0.5894    -0.5908    -0.5985     0.0003    -0.0063    -0.0014 </r>
+     <r>    12.5325    -0.6065    -0.6076    -0.6150     0.0027    -0.0092    -0.0015 </r>
+     <r>    12.5526    -0.6116    -0.6125    -0.6197     0.0039    -0.0108    -0.0017 </r>
+     <r>    12.5726    -0.6034    -0.6041    -0.6113     0.0043    -0.0116    -0.0018 </r>
+     <r>    12.5926    -0.5841    -0.5847    -0.5920     0.0041    -0.0118    -0.0019 </r>
+     <r>    12.6126    -0.5570    -0.5577    -0.5652     0.0036    -0.0116    -0.0021 </r>
+     <r>    12.6326    -0.5251    -0.5257    -0.5334     0.0029    -0.0113    -0.0022 </r>
+     <r>    12.6527    -0.4903    -0.4908    -0.4985     0.0021    -0.0107    -0.0023 </r>
+     <r>    12.6727    -0.4544    -0.4547    -0.4624     0.0011    -0.0101    -0.0025 </r>
+     <r>    12.6927    -0.4195    -0.4196    -0.4272     0.0002    -0.0094    -0.0026 </r>
+     <r>    12.7127    -0.3882    -0.3880    -0.3954    -0.0007    -0.0087    -0.0027 </r>
+     <r>    12.7327    -0.3629    -0.3624    -0.3693    -0.0015    -0.0082    -0.0027 </r>
+     <r>    12.7528    -0.3453    -0.3444    -0.3510    -0.0020    -0.0077    -0.0028 </r>
+     <r>    12.7728    -0.3359    -0.3348    -0.3411    -0.0022    -0.0075    -0.0028 </r>
+     <r>    12.7928    -0.3336    -0.3324    -0.3384    -0.0020    -0.0076    -0.0027 </r>
+     <r>    12.8128    -0.3347    -0.3336    -0.3394    -0.0016    -0.0078    -0.0026 </r>
+     <r>    12.8328    -0.3340    -0.3329    -0.3385    -0.0011    -0.0080    -0.0025 </r>
+     <r>    12.8529    -0.3268    -0.3258    -0.3312    -0.0007    -0.0082    -0.0025 </r>
+     <r>    12.8729    -0.3124    -0.3114    -0.3168    -0.0006    -0.0083    -0.0025 </r>
+     <r>    12.8929    -0.2938    -0.2929    -0.2984    -0.0007    -0.0083    -0.0025 </r>
+     <r>    12.9129    -0.2745    -0.2738    -0.2796    -0.0010    -0.0083    -0.0026 </r>
+     <r>    12.9329    -0.2566    -0.2563    -0.2625    -0.0012    -0.0084    -0.0027 </r>
+     <r>    12.9530    -0.2402    -0.2402    -0.2470    -0.0015    -0.0086    -0.0029 </r>
+     <r>    12.9730    -0.2255    -0.2260    -0.2333    -0.0019    -0.0088    -0.0031 </r>
+     <r>    12.9930    -0.2139    -0.2147    -0.2226    -0.0023    -0.0092    -0.0033 </r>
+     <r>    13.0130    -0.2064    -0.2076    -0.2162    -0.0027    -0.0096    -0.0036 </r>
+     <r>    13.0330    -0.2035    -0.2050    -0.2144    -0.0032    -0.0100    -0.0039 </r>
+     <r>    13.0531    -0.2077    -0.2096    -0.2197    -0.0037    -0.0105    -0.0042 </r>
+     <r>    13.0731    -0.2261    -0.2282    -0.2392    -0.0043    -0.0111    -0.0046 </r>
+     <r>    13.0931    -0.2685    -0.2710    -0.2830    -0.0050    -0.0118    -0.0051 </r>
+     <r>    13.1131    -0.3412    -0.3441    -0.3575    -0.0058    -0.0125    -0.0056 </r>
+     <r>    13.1331    -0.4372    -0.4405    -0.4554    -0.0068    -0.0134    -0.0063 </r>
+     <r>    13.1532    -0.5349    -0.5387    -0.5549    -0.0078    -0.0142    -0.0069 </r>
+     <r>    13.1732    -0.6119    -0.6161    -0.6335    -0.0090    -0.0149    -0.0076 </r>
+     <r>    13.1932    -0.6603    -0.6646    -0.6829    -0.0102    -0.0155    -0.0082 </r>
+     <r>    13.2132    -0.6855    -0.6898    -0.7089    -0.0114    -0.0159    -0.0087 </r>
+     <r>    13.2332    -0.6963    -0.7006    -0.7201    -0.0124    -0.0162    -0.0092 </r>
+     <r>    13.2533    -0.6967    -0.7010    -0.7207    -0.0132    -0.0163    -0.0095 </r>
+     <r>    13.2733    -0.6868    -0.6909    -0.7104    -0.0135    -0.0162    -0.0096 </r>
+     <r>    13.2933    -0.6670    -0.6709    -0.6895    -0.0127    -0.0155    -0.0092 </r>
+     <r>    13.3133    -0.6405    -0.6442    -0.6607    -0.0104    -0.0141    -0.0080 </r>
+     <r>    13.3333    -0.6115    -0.6149    -0.6282    -0.0061    -0.0116    -0.0058 </r>
+     <r>    13.3534    -0.5827    -0.5859    -0.5948    -0.0000    -0.0083    -0.0027 </r>
+     <r>    13.3734    -0.5544    -0.5573    -0.5615     0.0067    -0.0046     0.0008 </r>
+     <r>    13.3934    -0.5252    -0.5279    -0.5281     0.0126    -0.0012     0.0039 </r>
+     <r>    13.4134    -0.4951    -0.4976    -0.4951     0.0167     0.0012     0.0061 </r>
+     <r>    13.4334    -0.4662    -0.4685    -0.4645     0.0189     0.0026     0.0073 </r>
+     <r>    13.4535    -0.4417    -0.4440    -0.4394     0.0196     0.0033     0.0078 </r>
+     <r>    13.4735    -0.4246    -0.4271    -0.4226     0.0195     0.0034     0.0078 </r>
+     <r>    13.4935    -0.4161    -0.4189    -0.4149     0.0190     0.0033     0.0076 </r>
+     <r>    13.5135    -0.4151    -0.4185    -0.4153     0.0184     0.0030     0.0073 </r>
+     <r>    13.5335    -0.4202    -0.4242    -0.4220     0.0176     0.0028     0.0069 </r>
+     <r>    13.5536    -0.4301    -0.4349    -0.4337     0.0167     0.0027     0.0065 </r>
+     <r>    13.5736    -0.4430    -0.4484    -0.4483     0.0156     0.0028     0.0061 </r>
+     <r>    13.5936    -0.4565    -0.4626    -0.4635     0.0144     0.0031     0.0058 </r>
+     <r>    13.6136    -0.4683    -0.4749    -0.4767     0.0133     0.0035     0.0056 </r>
+     <r>    13.6336    -0.4758    -0.4828    -0.4853     0.0125     0.0038     0.0055 </r>
+     <r>    13.6537    -0.4761    -0.4833    -0.4865     0.0120     0.0040     0.0055 </r>
+     <r>    13.6737    -0.4670    -0.4744    -0.4781     0.0116     0.0041     0.0055 </r>
+     <r>    13.6937    -0.4487    -0.4560    -0.4602     0.0113     0.0041     0.0055 </r>
+     <r>    13.7137    -0.4233    -0.4306    -0.4350     0.0109     0.0040     0.0054 </r>
+     <r>    13.7337    -0.3940    -0.4012    -0.4058     0.0105     0.0038     0.0053 </r>
+     <r>    13.7538    -0.3637    -0.3707    -0.3754     0.0101     0.0036     0.0051 </r>
+     <r>    13.7738    -0.3343    -0.3411    -0.3458     0.0099     0.0033     0.0049 </r>
+     <r>    13.7938    -0.3070    -0.3135    -0.3183     0.0097     0.0028     0.0047 </r>
+     <r>    13.8138    -0.2815    -0.2878    -0.2925     0.0096     0.0022     0.0045 </r>
+     <r>    13.8338    -0.2571    -0.2631    -0.2678     0.0095     0.0017     0.0043 </r>
+     <r>    13.8539    -0.2333    -0.2392    -0.2437     0.0094     0.0013     0.0041 </r>
+     <r>    13.8739    -0.2116    -0.2173    -0.2219     0.0091     0.0010     0.0039 </r>
+     <r>    13.8939    -0.1947    -0.2003    -0.2049     0.0088     0.0008     0.0037 </r>
+     <r>    13.9139    -0.1858    -0.1913    -0.1961     0.0084     0.0007     0.0036 </r>
+     <r>    13.9339    -0.1868    -0.1925    -0.1975     0.0081     0.0007     0.0034 </r>
+     <r>    13.9540    -0.1973    -0.2031    -0.2085     0.0077     0.0007     0.0033 </r>
+     <r>    13.9740    -0.2124    -0.2185    -0.2242     0.0074     0.0008     0.0032 </r>
+     <r>    13.9940    -0.2251    -0.2314    -0.2375     0.0071     0.0008     0.0031 </r>
+     <r>    14.0140    -0.2304    -0.2370    -0.2434     0.0067     0.0008     0.0030 </r>
+     <r>    14.0340    -0.2284    -0.2350    -0.2416     0.0063     0.0009     0.0028 </r>
+     <r>    14.0541    -0.2223    -0.2287    -0.2353     0.0059     0.0010     0.0027 </r>
+     <r>    14.0741    -0.2163    -0.2225    -0.2289     0.0054     0.0011     0.0026 </r>
+     <r>    14.0941    -0.2144    -0.2199    -0.2259     0.0050     0.0012     0.0025 </r>
+     <r>    14.1141    -0.2181    -0.2227    -0.2279     0.0045     0.0013     0.0023 </r>
+     <r>    14.1341    -0.2251    -0.2287    -0.2331     0.0040     0.0014     0.0022 </r>
+     <r>    14.1542    -0.2309    -0.2335    -0.2372     0.0034     0.0016     0.0021 </r>
+     <r>    14.1742    -0.2320    -0.2339    -0.2369     0.0027     0.0019     0.0019 </r>
+     <r>    14.1942    -0.2281    -0.2295    -0.2323     0.0019     0.0024     0.0018 </r>
+     <r>    14.2142    -0.2213    -0.2225    -0.2254     0.0011     0.0028     0.0017 </r>
+     <r>    14.2342    -0.2142    -0.2155    -0.2185     0.0004     0.0032     0.0015 </r>
+     <r>    14.2543    -0.2085    -0.2099    -0.2133    -0.0003     0.0034     0.0014 </r>
+     <r>    14.2743    -0.2034    -0.2050    -0.2087    -0.0009     0.0036     0.0013 </r>
+     <r>    14.2943    -0.1955    -0.1971    -0.2011    -0.0014     0.0037     0.0011 </r>
+     <r>    14.3143    -0.1815    -0.1832    -0.1874    -0.0018     0.0038     0.0011 </r>
+     <r>    14.3343    -0.1609    -0.1626    -0.1669    -0.0020     0.0039     0.0010 </r>
+     <r>    14.3544    -0.1359    -0.1377    -0.1420    -0.0022     0.0039     0.0010 </r>
+     <r>    14.3744    -0.1099    -0.1117    -0.1158    -0.0021     0.0040     0.0011 </r>
+     <r>    14.3944    -0.0859    -0.0877    -0.0914    -0.0019     0.0042     0.0013 </r>
+     <r>    14.4144    -0.0661    -0.0679    -0.0712    -0.0016     0.0046     0.0015 </r>
+     <r>    14.4344    -0.0525    -0.0542    -0.0570    -0.0012     0.0050     0.0017 </r>
+     <r>    14.4545    -0.0461    -0.0478    -0.0500    -0.0008     0.0054     0.0019 </r>
+     <r>    14.4745    -0.0465    -0.0481    -0.0500    -0.0003     0.0056     0.0021 </r>
+     <r>    14.4945    -0.0512    -0.0528    -0.0544     0.0005     0.0051     0.0021 </r>
+     <r>    14.5145    -0.0565    -0.0581    -0.0596     0.0019     0.0039     0.0021 </r>
+     <r>    14.5345    -0.0596    -0.0612    -0.0627     0.0038     0.0021     0.0021 </r>
+     <r>    14.5546    -0.0588    -0.0606    -0.0622     0.0058     0.0001     0.0022 </r>
+     <r>    14.5746    -0.0543    -0.0563    -0.0580     0.0073    -0.0016     0.0023 </r>
+     <r>    14.5946    -0.0485    -0.0507    -0.0527     0.0082    -0.0028     0.0023 </r>
+     <r>    14.6146    -0.0462    -0.0487    -0.0510     0.0087    -0.0034     0.0023 </r>
+     <r>    14.6346    -0.0537    -0.0564    -0.0590     0.0089    -0.0038     0.0022 </r>
+     <r>    14.6547    -0.0751    -0.0782    -0.0811     0.0090    -0.0040     0.0022 </r>
+     <r>    14.6747    -0.1091    -0.1126    -0.1159     0.0092    -0.0042     0.0022 </r>
+     <r>    14.6947    -0.1472    -0.1511    -0.1549     0.0094    -0.0044     0.0022 </r>
+     <r>    14.7147    -0.1791    -0.1835    -0.1877     0.0096    -0.0045     0.0022 </r>
+     <r>    14.7347    -0.1983    -0.2031    -0.2077     0.0096    -0.0045     0.0022 </r>
+     <r>    14.7548    -0.2034    -0.2086    -0.2136     0.0096    -0.0045     0.0022 </r>
+     <r>    14.7748    -0.1966    -0.2022    -0.2075     0.0095    -0.0044     0.0021 </r>
+     <r>    14.7948    -0.1831    -0.1889    -0.1944     0.0094    -0.0043     0.0021 </r>
+     <r>    14.8148    -0.1689    -0.1750    -0.1807     0.0093    -0.0043     0.0021 </r>
+     <r>    14.8348    -0.1586    -0.1650    -0.1709     0.0095    -0.0043     0.0022 </r>
+     <r>    14.8549    -0.1527    -0.1594    -0.1655     0.0097    -0.0043     0.0022 </r>
+     <r>    14.8749    -0.1476    -0.1545    -0.1608     0.0100    -0.0043     0.0023 </r>
+     <r>    14.8949    -0.1389    -0.1460    -0.1523     0.0102    -0.0043     0.0024 </r>
+     <r>    14.9149    -0.1253    -0.1324    -0.1385     0.0102    -0.0041     0.0024 </r>
+     <r>    14.9349    -0.1087    -0.1156    -0.1215     0.0100    -0.0039     0.0024 </r>
+     <r>    14.9550    -0.0924    -0.0989    -0.1044     0.0096    -0.0035     0.0024 </r>
+     <r>    14.9750    -0.0785    -0.0842    -0.0891     0.0092    -0.0032     0.0024 </r>
+     <r>    14.9950    -0.0667    -0.0717    -0.0759     0.0088    -0.0028     0.0024 </r>
+     <r>    15.0150    -0.0565    -0.0608    -0.0644     0.0084    -0.0026     0.0023 </r>
+     <r>    15.0350    -0.0485    -0.0522    -0.0554     0.0080    -0.0024     0.0023 </r>
+     <r>    15.0551    -0.0439    -0.0473    -0.0501     0.0078    -0.0023     0.0022 </r>
+     <r>    15.0751    -0.0445    -0.0476    -0.0503     0.0076    -0.0022     0.0022 </r>
+     <r>    15.0951    -0.0526    -0.0556    -0.0580     0.0075    -0.0023     0.0021 </r>
+     <r>    15.1151    -0.0693    -0.0720    -0.0744     0.0076    -0.0025     0.0021 </r>
+     <r>    15.1351    -0.0909    -0.0934    -0.0956     0.0077    -0.0027     0.0020 </r>
+     <r>    15.1552    -0.1090    -0.1114    -0.1135     0.0078    -0.0029     0.0020 </r>
+     <r>    15.1752    -0.1163    -0.1185    -0.1206     0.0077    -0.0029     0.0019 </r>
+     <r>    15.1952    -0.1114    -0.1137    -0.1158     0.0074    -0.0027     0.0018 </r>
+     <r>    15.2152    -0.0981    -0.1003    -0.1025     0.0069    -0.0024     0.0018 </r>
+     <r>    15.2352    -0.0804    -0.0826    -0.0849     0.0063    -0.0019     0.0017 </r>
+     <r>    15.2553    -0.0614    -0.0636    -0.0658     0.0058    -0.0015     0.0017 </r>
+     <r>    15.2753    -0.0431    -0.0452    -0.0475     0.0053    -0.0012     0.0017 </r>
+     <r>    15.2953    -0.0279    -0.0300    -0.0321     0.0050    -0.0010     0.0017 </r>
+     <r>    15.3153    -0.0193    -0.0213    -0.0235     0.0048    -0.0009     0.0016 </r>
+     <r>    15.3353    -0.0230    -0.0251    -0.0273     0.0046    -0.0008     0.0016 </r>
+     <r>    15.3554    -0.0463    -0.0485    -0.0508     0.0045    -0.0007     0.0016 </r>
+     <r>    15.3754    -0.0942    -0.0965    -0.0990     0.0044    -0.0007     0.0016 </r>
+     <r>    15.3954    -0.1622    -0.1647    -0.1674     0.0043    -0.0005     0.0016 </r>
+     <r>    15.4154    -0.2331    -0.2358    -0.2386     0.0042    -0.0004     0.0016 </r>
+     <r>    15.4354    -0.2867    -0.2895    -0.2926     0.0041    -0.0003     0.0016 </r>
+     <r>    15.4555    -0.3125    -0.3155    -0.3187     0.0040    -0.0003     0.0016 </r>
+     <r>    15.4755    -0.3122    -0.3154    -0.3188     0.0039    -0.0002     0.0016 </r>
+     <r>    15.4955    -0.2932    -0.2966    -0.3002     0.0038    -0.0002     0.0016 </r>
+     <r>    15.5155    -0.2630    -0.2665    -0.2703     0.0038    -0.0002     0.0015 </r>
+     <r>    15.5355    -0.2271    -0.2308    -0.2348     0.0037    -0.0002     0.0015 </r>
+     <r>    15.5556    -0.1895    -0.1933    -0.1975     0.0037    -0.0002     0.0015 </r>
+     <r>    15.5756    -0.1529    -0.1569    -0.1612     0.0036    -0.0001     0.0015 </r>
+     <r>    15.5956    -0.1197    -0.1239    -0.1284     0.0035    -0.0001     0.0015 </r>
+     <r>    15.6156    -0.0922    -0.0965    -0.1010     0.0034    -0.0000     0.0015 </r>
+     <r>    15.6356    -0.0714    -0.0756    -0.0801     0.0033     0.0000     0.0015 </r>
+     <r>    15.6557    -0.0566    -0.0607    -0.0650     0.0032     0.0001     0.0015 </r>
+     <r>    15.6757    -0.0459    -0.0496    -0.0536     0.0031     0.0002     0.0015 </r>
+     <r>    15.6957    -0.0370    -0.0402    -0.0437     0.0030     0.0002     0.0015 </r>
+     <r>    15.7157    -0.0291    -0.0318    -0.0347     0.0029     0.0003     0.0014 </r>
+     <r>    15.7357    -0.0234    -0.0256    -0.0280     0.0028     0.0003     0.0014 </r>
+     <r>    15.7558    -0.0229    -0.0246    -0.0267     0.0027     0.0004     0.0014 </r>
+     <r>    15.7758    -0.0298    -0.0311    -0.0329     0.0025     0.0005     0.0014 </r>
+     <r>    15.7958    -0.0428    -0.0439    -0.0453     0.0024     0.0006     0.0014 </r>
+     <r>    15.8158    -0.0572    -0.0580    -0.0593     0.0022     0.0008     0.0014 </r>
+     <r>    15.8358    -0.0692    -0.0699    -0.0710     0.0022     0.0008     0.0013 </r>
+     <r>    15.8559    -0.0801    -0.0807    -0.0817     0.0022     0.0008     0.0013 </r>
+     <r>    15.8759    -0.0953    -0.0956    -0.0965     0.0023     0.0006     0.0013 </r>
+     <r>    15.8959    -0.1192    -0.1193    -0.1197     0.0026     0.0003     0.0013 </r>
+     <r>    15.9159    -0.1505    -0.1500    -0.1500     0.0030    -0.0001     0.0013 </r>
+     <r>    15.9359    -0.1802    -0.1792    -0.1787     0.0033    -0.0005     0.0013 </r>
+     <r>    15.9560    -0.1982    -0.1968    -0.1958     0.0036    -0.0008     0.0013 </r>
+     <r>    15.9760    -0.1999    -0.1982    -0.1970     0.0038    -0.0010     0.0013 </r>
+     <r>    15.9960    -0.1874    -0.1856    -0.1843     0.0038    -0.0011     0.0012 </r>
+     <r>    16.0160    -0.1658    -0.1640    -0.1628     0.0038    -0.0011     0.0012 </r>
+     <r>    16.0360    -0.1403    -0.1386    -0.1375     0.0038    -0.0011     0.0012 </r>
+     <r>    16.0561    -0.1150    -0.1134    -0.1124     0.0037    -0.0011     0.0012 </r>
+     <r>    16.0761    -0.0927    -0.0912    -0.0903     0.0037    -0.0010     0.0012 </r>
+     <r>    16.0961    -0.0753    -0.0738    -0.0730     0.0036    -0.0010     0.0012 </r>
+     <r>    16.1161    -0.0632    -0.0617    -0.0608     0.0036    -0.0010     0.0012 </r>
+     <r>    16.1361    -0.0558    -0.0543    -0.0534     0.0035    -0.0010     0.0012 </r>
+     <r>    16.1562    -0.0515    -0.0500    -0.0490     0.0035    -0.0010     0.0012 </r>
+     <r>    16.1762    -0.0473    -0.0457    -0.0447     0.0036    -0.0010     0.0012 </r>
+     <r>    16.1962    -0.0394    -0.0377    -0.0366     0.0036    -0.0010     0.0012 </r>
+     <r>    16.2162    -0.0258    -0.0241    -0.0230     0.0036    -0.0010     0.0012 </r>
+     <r>    16.2362    -0.0081    -0.0064    -0.0053     0.0036    -0.0011     0.0012 </r>
+     <r>    16.2563     0.0094     0.0111     0.0122     0.0037    -0.0011     0.0012 </r>
+     <r>    16.2763     0.0218     0.0235     0.0246     0.0038    -0.0012     0.0011 </r>
+     <r>    16.2963     0.0246     0.0264     0.0276     0.0039    -0.0014     0.0011 </r>
+     <r>    16.3163     0.0161     0.0180     0.0193     0.0041    -0.0016     0.0011 </r>
+     <r>    16.3363    -0.0019     0.0002     0.0017     0.0044    -0.0019     0.0011 </r>
+     <r>    16.3564    -0.0240    -0.0216    -0.0199     0.0046    -0.0022     0.0011 </r>
+     <r>    16.3764    -0.0440    -0.0414    -0.0394     0.0048    -0.0023     0.0011 </r>
+     <r>    16.3964    -0.0587    -0.0559    -0.0538     0.0048    -0.0023     0.0011 </r>
+     <r>    16.4164    -0.0698    -0.0669    -0.0646     0.0046    -0.0021     0.0011 </r>
+     <r>    16.4364    -0.0805    -0.0776    -0.0755     0.0042    -0.0017     0.0011 </r>
+     <r>    16.4565    -0.0926    -0.0900    -0.0881     0.0037    -0.0012     0.0012 </r>
+     <r>    16.4765    -0.1052    -0.1029    -0.1014     0.0031    -0.0006     0.0012 </r>
+     <r>    16.4965    -0.1171    -0.1152    -0.1141     0.0026    -0.0001     0.0012 </r>
+     <r>    16.5165    -0.1282    -0.1267    -0.1258     0.0022     0.0003     0.0012 </r>
+     <r>    16.5365    -0.1381    -0.1367    -0.1360     0.0018     0.0006     0.0012 </r>
+     <r>    16.5566    -0.1449    -0.1437    -0.1431     0.0016     0.0008     0.0011 </r>
+     <r>    16.5766    -0.1466    -0.1455    -0.1450     0.0014     0.0009     0.0011 </r>
+     <r>    16.5966    -0.1418    -0.1407    -0.1403     0.0012     0.0009     0.0010 </r>
+     <r>    16.6166    -0.1304    -0.1293    -0.1289     0.0011     0.0009     0.0010 </r>
+     <r>    16.6366    -0.1139    -0.1128    -0.1123     0.0011     0.0008     0.0009 </r>
+     <r>    16.6567    -0.0945    -0.0933    -0.0928     0.0011     0.0008     0.0009 </r>
+     <r>    16.6767    -0.0742    -0.0730    -0.0724     0.0011     0.0007     0.0009 </r>
+     <r>    16.6967    -0.0544    -0.0531    -0.0525     0.0012     0.0007     0.0009 </r>
+     <r>    16.7167    -0.0352    -0.0338    -0.0330     0.0012     0.0006     0.0009 </r>
+     <r>    16.7367    -0.0157    -0.0141    -0.0133     0.0012     0.0006     0.0009 </r>
+     <r>    16.7568     0.0047     0.0064     0.0074     0.0012     0.0006     0.0009 </r>
+     <r>    16.7768     0.0248     0.0266     0.0277     0.0013     0.0006     0.0009 </r>
+     <r>    16.7968     0.0421     0.0440     0.0453     0.0013     0.0006     0.0009 </r>
+     <r>    16.8168     0.0537     0.0558     0.0571     0.0013     0.0006     0.0009 </r>
+     <r>    16.8368     0.0580     0.0602     0.0617     0.0013     0.0006     0.0009 </r>
+     <r>    16.8569     0.0560     0.0583     0.0599     0.0012     0.0005     0.0009 </r>
+     <r>    16.8769     0.0501     0.0524     0.0541     0.0012     0.0005     0.0009 </r>
+     <r>    16.8969     0.0406     0.0429     0.0444     0.0012     0.0005     0.0009 </r>
+     <r>    16.9169     0.0245     0.0265     0.0279     0.0012     0.0005     0.0009 </r>
+     <r>    16.9369    -0.0022    -0.0006     0.0003     0.0012     0.0005     0.0009 </r>
+     <r>    16.9570    -0.0393    -0.0384    -0.0381     0.0011     0.0006     0.0008 </r>
+     <r>    16.9770    -0.0795    -0.0792    -0.0797     0.0010     0.0006     0.0008 </r>
+     <r>    16.9970    -0.1112    -0.1115    -0.1126     0.0009     0.0007     0.0008 </r>
+     <r>    17.0170    -0.1267    -0.1275    -0.1290     0.0008     0.0007     0.0008 </r>
+     <r>    17.0370    -0.1257    -0.1267    -0.1284     0.0008     0.0008     0.0008 </r>
+     <r>    17.0571    -0.1120    -0.1131    -0.1149     0.0007     0.0008     0.0008 </r>
+     <r>    17.0771    -0.0904    -0.0914    -0.0932     0.0007     0.0009     0.0008 </r>
+     <r>    17.0971    -0.0644    -0.0654    -0.0671     0.0006     0.0009     0.0008 </r>
+     <r>    17.1171    -0.0365    -0.0373    -0.0389     0.0006     0.0009     0.0008 </r>
+     <r>    17.1371    -0.0082    -0.0088    -0.0101     0.0005     0.0010     0.0008 </r>
+     <r>    17.1572     0.0199     0.0195     0.0183     0.0005     0.0010     0.0008 </r>
+     <r>    17.1772     0.0468     0.0466     0.0456     0.0004     0.0011     0.0008 </r>
+     <r>    17.1972     0.0717     0.0717     0.0708     0.0004     0.0011     0.0008 </r>
+     <r>    17.2172     0.0932     0.0933     0.0926     0.0003     0.0012     0.0007 </r>
+     <r>    17.2372     0.1094     0.1097     0.1091     0.0002     0.0012     0.0007 </r>
+     <r>    17.2573     0.1190     0.1194     0.1189     0.0002     0.0012     0.0007 </r>
+     <r>    17.2773     0.1209     0.1213     0.1209     0.0001     0.0013     0.0007 </r>
+     <r>    17.2973     0.1137     0.1142     0.1140     0.0000     0.0014     0.0007 </r>
+     <r>    17.3173     0.0953     0.0959     0.0957    -0.0001     0.0014     0.0007 </r>
+     <r>    17.3373     0.0642     0.0649     0.0648    -0.0002     0.0015     0.0007 </r>
+     <r>    17.3574     0.0243     0.0252     0.0252    -0.0003     0.0016     0.0007 </r>
+     <r>    17.3774    -0.0140    -0.0130    -0.0128    -0.0004     0.0017     0.0007 </r>
+     <r>    17.3974    -0.0401    -0.0388    -0.0385    -0.0005     0.0018     0.0007 </r>
+     <r>    17.4174    -0.0492    -0.0478    -0.0473    -0.0006     0.0019     0.0007 </r>
+     <r>    17.4374    -0.0434    -0.0419    -0.0412    -0.0008     0.0020     0.0007 </r>
+     <r>    17.4575    -0.0271    -0.0254    -0.0245    -0.0009     0.0021     0.0007 </r>
+     <r>    17.4775    -0.0045    -0.0025    -0.0015    -0.0011     0.0023     0.0007 </r>
+     <r>    17.4975     0.0217     0.0239     0.0251    -0.0012     0.0024     0.0007 </r>
+     <r>    17.5175     0.0497     0.0520     0.0535    -0.0013     0.0026     0.0007 </r>
+     <r>    17.5375     0.0785     0.0810     0.0826    -0.0015     0.0028     0.0007 </r>
+     <r>    17.5576     0.1074     0.1100     0.1119    -0.0016     0.0030     0.0007 </r>
+     <r>    17.5776     0.1360     0.1388     0.1407    -0.0017     0.0031     0.0007 </r>
+     <r>    17.5976     0.1640     0.1667     0.1686    -0.0017     0.0032     0.0006 </r>
+     <r>    17.6176     0.1908     0.1932     0.1947    -0.0017     0.0031     0.0006 </r>
+     <r>    17.6376     0.2157     0.2176     0.2183    -0.0015     0.0029     0.0004 </r>
+     <r>    17.6577     0.2382     0.2392     0.2390    -0.0011     0.0024     0.0003 </r>
+     <r>    17.6777     0.2579     0.2579     0.2565    -0.0006     0.0017     0.0002 </r>
+     <r>    17.6977     0.2739     0.2729     0.2705     0.0000     0.0010     0.0003 </r>
+     <r>    17.7177     0.2845     0.2826     0.2796     0.0006     0.0004     0.0004 </r>
+     <r>    17.7377     0.2866     0.2842     0.2807     0.0011    -0.0000     0.0005 </r>
+     <r>    17.7578     0.2773     0.2745     0.2708     0.0017    -0.0005     0.0006 </r>
+     <r>    17.7778     0.2562     0.2531     0.2493     0.0022    -0.0010     0.0007 </r>
+     <r>    17.7978     0.2276     0.2242     0.2202     0.0028    -0.0016     0.0007 </r>
+     <r>    17.8178     0.1996     0.1961     0.1920     0.0033    -0.0021     0.0007 </r>
+     <r>    17.8378     0.1803     0.1766     0.1724     0.0038    -0.0026     0.0007 </r>
+     <r>    17.8579     0.1716     0.1678     0.1634     0.0042    -0.0029     0.0007 </r>
+     <r>    17.8779     0.1689     0.1650     0.1604     0.0045    -0.0032     0.0007 </r>
+     <r>    17.8979     0.1639     0.1598     0.1550     0.0047    -0.0035     0.0007 </r>
+     <r>    17.9179     0.1474     0.1431     0.1381     0.0050    -0.0037     0.0007 </r>
+     <r>    17.9379     0.1113     0.1068     0.1018     0.0051    -0.0039     0.0007 </r>
+     <r>    17.9580     0.0509     0.0466     0.0416     0.0050    -0.0038     0.0007 </r>
+     <r>    17.9780    -0.0288    -0.0329    -0.0376     0.0048    -0.0036     0.0007 </r>
+     <r>    17.9980    -0.1110    -0.1147    -0.1191     0.0044    -0.0032     0.0006 </r>
+     <r>    18.0180    -0.1752    -0.1786    -0.1826     0.0041    -0.0029     0.0006 </r>
+     <r>    18.0380    -0.2105    -0.2137    -0.2174     0.0037    -0.0026     0.0006 </r>
+     <r>    18.0581    -0.2189    -0.2217    -0.2253     0.0035    -0.0023     0.0006 </r>
+     <r>    18.0781    -0.2080    -0.2107    -0.2141     0.0033    -0.0021     0.0006 </r>
+     <r>    18.0981    -0.1864    -0.1890    -0.1922     0.0031    -0.0020     0.0006 </r>
+     <r>    18.1181    -0.1606    -0.1631    -0.1662     0.0029    -0.0019     0.0006 </r>
+     <r>    18.1381    -0.1360    -0.1384    -0.1414     0.0028    -0.0018     0.0006 </r>
+     <r>    18.1582    -0.1172    -0.1195    -0.1225     0.0027    -0.0017     0.0006 </r>
+     <r>    18.1782    -0.1083    -0.1106    -0.1135     0.0027    -0.0016     0.0006 </r>
+     <r>    18.1982    -0.1118    -0.1140    -0.1169     0.0026    -0.0016     0.0006 </r>
+     <r>    18.2182    -0.1255    -0.1276    -0.1304     0.0026    -0.0016     0.0006 </r>
+     <r>    18.2382    -0.1417    -0.1438    -0.1465     0.0026    -0.0016     0.0006 </r>
+     <r>    18.2583    -0.1518    -0.1539    -0.1566     0.0026    -0.0016     0.0005 </r>
+     <r>    18.2783    -0.1514    -0.1534    -0.1560     0.0025    -0.0016     0.0005 </r>
+     <r>    18.2983    -0.1410    -0.1429    -0.1455     0.0025    -0.0015     0.0005 </r>
+     <r>    18.3183    -0.1235    -0.1254    -0.1280     0.0024    -0.0015     0.0005 </r>
+     <r>    18.3383    -0.1020    -0.1038    -0.1063     0.0024    -0.0014     0.0005 </r>
+     <r>    18.3584    -0.0784    -0.0802    -0.0827     0.0023    -0.0014     0.0005 </r>
+     <r>    18.3784    -0.0543    -0.0561    -0.0585     0.0023    -0.0013     0.0005 </r>
+     <r>    18.3984    -0.0306    -0.0323    -0.0347     0.0023    -0.0013     0.0005 </r>
+     <r>    18.4184    -0.0077    -0.0094    -0.0118     0.0023    -0.0012     0.0006 </r>
+     <r>    18.4384     0.0139     0.0123     0.0100     0.0023    -0.0012     0.0006 </r>
+     <r>    18.4585     0.0341     0.0325     0.0303     0.0023    -0.0012     0.0006 </r>
+     <r>    18.4785     0.0522     0.0506     0.0484     0.0023    -0.0011     0.0006 </r>
+     <r>    18.4985     0.0662     0.0647     0.0625     0.0022    -0.0011     0.0006 </r>
+     <r>    18.5185     0.0734     0.0719     0.0697     0.0022    -0.0011     0.0006 </r>
+     <r>    18.5385     0.0702     0.0687     0.0665     0.0022    -0.0011     0.0006 </r>
+     <r>    18.5586     0.0540     0.0525     0.0503     0.0022    -0.0011     0.0006 </r>
+     <r>    18.5786     0.0259     0.0244     0.0222     0.0023    -0.0011     0.0006 </r>
+     <r>    18.5986    -0.0071    -0.0087    -0.0108     0.0023    -0.0011     0.0006 </r>
+     <r>    18.6186    -0.0351    -0.0367    -0.0388     0.0023    -0.0012     0.0006 </r>
+     <r>    18.6386    -0.0510    -0.0525    -0.0546     0.0024    -0.0012     0.0006 </r>
+     <r>    18.6587    -0.0535    -0.0551    -0.0572     0.0024    -0.0012     0.0006 </r>
+     <r>    18.6787    -0.0457    -0.0473    -0.0494     0.0023    -0.0012     0.0006 </r>
+     <r>    18.6987    -0.0312    -0.0327    -0.0348     0.0023    -0.0011     0.0006 </r>
+     <r>    18.7187    -0.0131    -0.0146    -0.0167     0.0023    -0.0011     0.0006 </r>
+     <r>    18.7387     0.0066     0.0051     0.0030     0.0022    -0.0011     0.0006 </r>
+     <r>    18.7588     0.0261     0.0247     0.0225     0.0021    -0.0010     0.0006 </r>
+     <r>    18.7788     0.0442     0.0427     0.0406     0.0020    -0.0010     0.0006 </r>
+     <r>    18.7988     0.0589     0.0575     0.0555     0.0020    -0.0010     0.0006 </r>
+     <r>    18.8188     0.0683     0.0670     0.0651     0.0019    -0.0010     0.0005 </r>
+     <r>    18.8388     0.0702     0.0690     0.0671     0.0019    -0.0011     0.0005 </r>
+     <r>    18.8589     0.0632     0.0622     0.0605     0.0019    -0.0011     0.0005 </r>
+     <r>    18.8789     0.0487     0.0479     0.0464     0.0019    -0.0012     0.0005 </r>
+     <r>    18.8989     0.0311     0.0304     0.0291     0.0020    -0.0013     0.0005 </r>
+     <r>    18.9189     0.0166     0.0161     0.0148     0.0020    -0.0013     0.0005 </r>
+     <r>    18.9389     0.0098     0.0094     0.0082     0.0020    -0.0014     0.0005 </r>
+     <r>    18.9590     0.0115     0.0111     0.0100     0.0020    -0.0014     0.0004 </r>
+     <r>    18.9790     0.0192     0.0190     0.0179     0.0020    -0.0014     0.0004 </r>
+     <r>    18.9990     0.0299     0.0297     0.0287     0.0019    -0.0014     0.0004 </r>
+     <r>    19.0190     0.0403     0.0401     0.0391     0.0019    -0.0014     0.0004 </r>
+     <r>    19.0390     0.0479     0.0476     0.0467     0.0018    -0.0013     0.0004 </r>
+     <r>    19.0591     0.0511     0.0509     0.0500     0.0018    -0.0013     0.0004 </r>
+     <r>    19.0791     0.0505     0.0503     0.0494     0.0018    -0.0013     0.0004 </r>
+     <r>    19.0991     0.0479     0.0477     0.0469     0.0018    -0.0012     0.0004 </r>
+     <r>    19.1191     0.0451     0.0450     0.0442     0.0018    -0.0012     0.0004 </r>
+     <r>    19.1391     0.0428     0.0426     0.0420     0.0018    -0.0012     0.0004 </r>
+     <r>    19.1592     0.0408     0.0407     0.0401     0.0019    -0.0012     0.0004 </r>
+     <r>    19.1792     0.0396     0.0395     0.0391     0.0019    -0.0012     0.0005 </r>
+     <r>    19.1992     0.0399     0.0398     0.0396     0.0021    -0.0012     0.0005 </r>
+     <r>    19.2192     0.0421     0.0420     0.0420     0.0022    -0.0012     0.0006 </r>
+     <r>    19.2392     0.0453     0.0453     0.0454     0.0024    -0.0011     0.0007 </r>
+     <r>    19.2593     0.0485     0.0485     0.0489     0.0027    -0.0011     0.0008 </r>
+     <r>    19.2793     0.0512     0.0512     0.0517     0.0030    -0.0010     0.0009 </r>
+     <r>    19.2993     0.0534     0.0535     0.0541     0.0033    -0.0010     0.0010 </r>
+     <r>    19.3193     0.0553     0.0554     0.0560     0.0035    -0.0010     0.0010 </r>
+     <r>    19.3393     0.0560     0.0561     0.0566     0.0037    -0.0010     0.0011 </r>
+     <r>    19.3594     0.0550     0.0550     0.0553     0.0039    -0.0011     0.0011 </r>
+     <r>    19.3794     0.0524     0.0523     0.0522     0.0039    -0.0012     0.0011 </r>
+     <r>    19.3994     0.0491     0.0488     0.0483     0.0039    -0.0013     0.0010 </r>
+     <r>    19.4194     0.0455     0.0449     0.0439     0.0037    -0.0013     0.0010 </r>
+     <r>    19.4394     0.0409     0.0398     0.0382     0.0035    -0.0012     0.0010 </r>
+     <r>    19.4595     0.0336     0.0320     0.0298     0.0032    -0.0011     0.0009 </r>
+     <r>    19.4795     0.0229     0.0208     0.0180     0.0028    -0.0009     0.0009 </r>
+     <r>    19.4995     0.0099     0.0075     0.0043     0.0024    -0.0007     0.0008 </r>
+     <r>    19.5195    -0.0026    -0.0052    -0.0086     0.0021    -0.0005     0.0008 </r>
+     <r>    19.5395    -0.0119    -0.0146    -0.0182     0.0018    -0.0003     0.0007 </r>
+     <r>    19.5596    -0.0173    -0.0199    -0.0235     0.0016    -0.0002     0.0007 </r>
+     <r>    19.5796    -0.0195    -0.0219    -0.0255     0.0015    -0.0002     0.0007 </r>
+     <r>    19.5996    -0.0189    -0.0213    -0.0247     0.0015    -0.0002     0.0006 </r>
+     <r>    19.6196    -0.0159    -0.0182    -0.0215     0.0014    -0.0002     0.0006 </r>
+     <r>    19.6396    -0.0105    -0.0127    -0.0159     0.0014    -0.0002     0.0006 </r>
+     <r>    19.6597    -0.0034    -0.0055    -0.0087     0.0014    -0.0002     0.0006 </r>
+     <r>    19.6797     0.0046     0.0024    -0.0007     0.0014    -0.0002     0.0006 </r>
+     <r>    19.6997     0.0127     0.0106     0.0075     0.0014    -0.0002     0.0006 </r>
+     <r>    19.7197     0.0209     0.0187     0.0156     0.0014    -0.0002     0.0006 </r>
+     <r>    19.7397     0.0289     0.0268     0.0236     0.0013    -0.0002     0.0006 </r>
+     <r>    19.7598     0.0370     0.0348     0.0317     0.0013    -0.0002     0.0006 </r>
+     <r>    19.7798     0.0449     0.0428     0.0397     0.0013    -0.0002     0.0006 </r>
+     <r>    19.7998     0.0527     0.0506     0.0476     0.0013    -0.0002     0.0006 </r>
+     <r>    19.8198     0.0603     0.0583     0.0553     0.0013    -0.0002     0.0006 </r>
+     <r>    19.8398     0.0677     0.0656     0.0627     0.0013    -0.0002     0.0006 </r>
+     <r>    19.8599     0.0747     0.0727     0.0698     0.0013    -0.0002     0.0006 </r>
+     <r>    19.8799     0.0814     0.0795     0.0767     0.0013    -0.0002     0.0006 </r>
+     <r>    19.8999     0.0879     0.0860     0.0832     0.0013    -0.0002     0.0006 </r>
+     <r>    19.9199     0.0941     0.0922     0.0895     0.0013    -0.0002     0.0005 </r>
+     <r>    19.9399     0.1000     0.0982     0.0956     0.0013    -0.0002     0.0005 </r>
+     <r>    19.9600     0.1058     0.1040     0.1014     0.0013    -0.0002     0.0005 </r>
+     <r>    19.9800     0.1113     0.1095     0.1069     0.0013    -0.0002     0.0005 </r>
+     <r>    20.0000     0.1166     0.1149     0.1123     0.0013    -0.0002     0.0005 </r>
+    </set>
+   </array>
+  </real>
+ </dielectricfunction>
+</modeling>


### PR DESCRIPTION
## Summary

Added a new Vasprun parser to parse opticaltransitions tags printed in vasprun.xml after a BSE calculation. The new parser will output both the oscillator strength in (eV) and the probability of transition (dimensionless) 


## Additional dependencies introduced (if any)
None

## TODO (if any)

N/A

