### PR TITLE
Overall charge for structures

### DIFF
--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -425,7 +425,7 @@ class IStructure(SiteCollection, MSONable):
             for s in sites[1:]:
                 if s.lattice != lattice:
                     raise ValueError("Sites must belong to the same lattice")
-            s_copy = cls(lattice=lattice,charge=charge, species=[], coords=[])
+            s_copy = cls(lattice=lattice, charge=charge, species=[], coords=[])
             s_copy._sites = list(sites)
             return s_copy
         prop_keys = []
@@ -648,7 +648,7 @@ class IStructure(SiteCollection, MSONable):
         Overall charge of the structure
         """
         if self._charge is None:
-            return super(IStructure,self).charge
+            return super(IStructure, self).charge
         else:
             return self._charge
 
@@ -1443,8 +1443,8 @@ class IStructure(SiteCollection, MSONable):
 
         lattice = Lattice.from_dict(d["lattice"])
         sites = [PeriodicSite.from_dict(sd, lattice) for sd in d["sites"]]
-        charge = d.get("charge",None)
-        return cls.from_sites(sites,charge=charge)
+        charge = d.get("charge", None)
+        return cls.from_sites(sites, charge=charge)
 
     def to(self, fmt=None, filename=None, **kwargs):
         """

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -980,7 +980,7 @@ class IStructure(SiteCollection, MSONable):
                 as if each comparison were reversed.
         """
         sites = sorted(self, key=key, reverse=reverse)
-        return self.__class__.from_sites(sites)
+        return self.__class__.from_sites(sites, charge=self._charge)
 
     def get_reduced_structure(self, reduction_algo="niggli"):
         """
@@ -1002,7 +1002,7 @@ class IStructure(SiteCollection, MSONable):
             return self.__class__(reduced_latt, self.species_and_occu,
                                   self.cart_coords,
                                   coords_are_cartesian=True, to_unit_cell=True,
-                                  site_properties=self.site_properties)
+                                  site_properties=self.site_properties, charge=self._charge)
         else:
             return self.copy()
 

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -335,7 +335,7 @@ class IStructure(SiteCollection, MSONable):
     structure is equivalent to going through the sites in sequence.
     """
 
-    def __init__(self, lattice, species, coords, validate_proximity=False,
+    def __init__(self, lattice, species, coords, charge=None, validate_proximity=False,
                  to_unit_cell=False, coords_are_cartesian=False,
                  site_properties=None):
         """
@@ -359,6 +359,7 @@ class IStructure(SiteCollection, MSONable):
                     disordered structures.
             coords (Nx3 array): list of fractional/cartesian coordinates of
                 each species.
+            charge (int): overall charge of the structure. Defaults to behavior in SiteCollection where total charge is the sum of the oxidation states
             validate_proximity (bool): Whether to check if there are sites
                 that are less than 0.01 Ang apart. Defaults to False.
             coords_are_cartesian (bool): Set to True if you are providing
@@ -394,9 +395,10 @@ class IStructure(SiteCollection, MSONable):
         if validate_proximity and not self.is_valid():
             raise StructureError(("Structure contains sites that are ",
                                   "less than 0.01 Angstrom apart!"))
+        self._charge = charge
 
     @classmethod
-    def from_sites(cls, sites, validate_proximity=False,
+    def from_sites(cls, sites, charge=None, validate_proximity=False,
                    to_unit_cell=False):
         """
         Convenience constructor to make a Structure from a list of sites.
@@ -423,7 +425,7 @@ class IStructure(SiteCollection, MSONable):
             for s in sites[1:]:
                 if s.lattice != lattice:
                     raise ValueError("Sites must belong to the same lattice")
-            s_copy = cls(lattice=lattice, species=[], coords=[])
+            s_copy = cls(lattice=lattice,charge=charge, species=[], coords=[])
             s_copy._sites = list(sites)
             return s_copy
         prop_keys = []
@@ -445,6 +447,7 @@ class IStructure(SiteCollection, MSONable):
                               "are set to None." % k)
         return cls(lattice, [site.species_and_occu for site in sites],
                    [site.frac_coords for site in sites],
+                   charge=charge,
                    site_properties=props,
                    validate_proximity=validate_proximity,
                    to_unit_cell=to_unit_cell)
@@ -640,6 +643,16 @@ class IStructure(SiteCollection, MSONable):
                     site_properties=all_site_properties)
 
     @property
+    def charge(self):
+        """
+        Overall charge of the structure
+        """
+        if self._charge is None:
+            return super(IStructure,self).charge
+        else:
+            return self._charge
+
+    @property
     def distance_matrix(self):
         """
         Returns the distance matrix between all sites in the structure. For
@@ -768,7 +781,8 @@ class IStructure(SiteCollection, MSONable):
                                  coords_are_cartesian=True, to_unit_cell=False)
                 new_sites.append(s)
 
-        return Structure.from_sites(new_sites)
+        new_charge = self._charge * np.linalg.det(scale_matrix) if self._charge else None
+        return Structure.from_sites(new_sites,charge=new_charge)
 
     def __rmul__(self, scaling_matrix):
         """
@@ -1019,7 +1033,7 @@ class IStructure(SiteCollection, MSONable):
             # the site_properties or sanitizing, initializing an empty
             # structure and setting _sites to be sites is much faster (~100x)
             # than doing the full initialization.
-            s_copy = self.__class__(lattice=self._lattice, species=[],
+            s_copy = self.__class__(lattice=self._lattice, species=[], charge=self._charge,
                                     coords=[])
             s_copy._sites = list(self._sites)
             return s_copy
@@ -1030,6 +1044,7 @@ class IStructure(SiteCollection, MSONable):
             return self.__class__(self._lattice,
                                   self.species_and_occu,
                                   self.frac_coords,
+                                  charge=self._charge,
                                   site_properties=props)
         else:
             reduced_latt = self._lattice.get_lll_reduced_lattice()
@@ -1044,7 +1059,7 @@ class IStructure(SiteCollection, MSONable):
                                               to_unit_cell=True,
                                               properties=site_props))
             new_sites = sorted(new_sites)
-            return self.__class__.from_sites(new_sites)
+            return self.__class__.from_sites(new_sites, charge=self._charge)
 
     def interpolate(self, end_structure, nimages=10,
                     interpolate_lattices=False, pbc=True, autosort_tol=0):
@@ -1331,6 +1346,11 @@ class IStructure(SiteCollection, MSONable):
 
     def __repr__(self):
         outs = ["Structure Summary", repr(self.lattice)]
+        if self._charge:
+            if self._charge >= 0:
+                outs.append("Overall Charge: +{}".format(self._charge))
+            else:
+                outs.append("Overall Charge: -{}".format(self._charge))
         for s in self:
             outs.append(repr(s))
         return "\n".join(outs)
@@ -1344,6 +1364,11 @@ class IStructure(SiteCollection, MSONable):
                                            for i in self.lattice.abc]))
         outs.append("angles: " + " ".join([to_s(i).rjust(10)
                                            for i in self.lattice.angles]))
+        if self._charge:
+            if self._charge >= 0:
+                outs.append("Overall Charge: +{}".format(self._charge))
+            else:
+                outs.append("Overall Charge: -{}".format(self._charge))
         outs.append("Sites ({i})".format(i=len(self)))
         data = []
         props = self.site_properties
@@ -1390,6 +1415,7 @@ class IStructure(SiteCollection, MSONable):
 
         d = {"@module": self.__class__.__module__,
              "@class": self.__class__.__name__,
+             "charge": self._charge,
              "lattice": latt_dict, "sites": []}
         for site in self:
             site_dict = site.as_dict(verbosity=verbosity)
@@ -1417,7 +1443,8 @@ class IStructure(SiteCollection, MSONable):
 
         lattice = Lattice.from_dict(d["lattice"])
         sites = [PeriodicSite.from_dict(sd, lattice) for sd in d["sites"]]
-        return cls.from_sites(sites)
+        charge = d.get("charge",None)
+        return cls.from_sites(sites,charge=charge)
 
     def to(self, fmt=None, filename=None, **kwargs):
         """
@@ -2249,7 +2276,7 @@ class Structure(IStructure, collections.MutableSequence):
     """
     __hash__ = None
 
-    def __init__(self, lattice, species, coords, validate_proximity=False,
+    def __init__(self, lattice, species, coords, charge=None, validate_proximity=False,
                  to_unit_cell=False, coords_are_cartesian=False,
                  site_properties=None):
         """
@@ -2281,6 +2308,7 @@ class Structure(IStructure, collections.MutableSequence):
                 fractional_coords. Defaults to None for no properties.
         """
         super(Structure, self).__init__(lattice, species, coords,
+                                        charge=charge,
                                         validate_proximity=validate_proximity,
                                         to_unit_cell=to_unit_cell,
                                         coords_are_cartesian=coords_are_cartesian,

--- a/pymatgen/core/tests/test_structure.py
+++ b/pymatgen/core/tests/test_structure.py
@@ -878,7 +878,7 @@ class StructureTest(PymatgenTest):
         super_cell = s*3
         self.assertEqual(super_cell.charge,27,"Overall charge is not being properly multiplied in IStructure __mul__")
         self.assertIn("Overall Charge: +1", str(s),"String representation not adding charge")
-        sorted_s = s.get_sorted_structure()
+        sorted_s = super_cell.get_sorted_structure()
         self.assertEqual(sorted_s.charge,27,"Overall charge is not properly copied during structure sorting")
 
 

--- a/pymatgen/core/tests/test_structure.py
+++ b/pymatgen/core/tests/test_structure.py
@@ -33,7 +33,7 @@ class IStructureTest(PymatgenTest):
         coords.append([0, 0, 0])
         coords.append([0., 0, 0.0000001])
         self.assertRaises(StructureError, IStructure, self.lattice,
-                          ["Si"] * 2, coords, True)
+                          ["Si"] * 2, coords, validate_proximity=True)
         self.propertied_structure = IStructure(
             self.lattice, ["Si"] * 2, coords,
             site_properties={'magmom': [5, -5]})

--- a/pymatgen/core/tests/test_structure.py
+++ b/pymatgen/core/tests/test_structure.py
@@ -878,6 +878,8 @@ class StructureTest(PymatgenTest):
         super_cell = s*3
         self.assertEqual(super_cell.charge,27,"Overall charge is not being properly multiplied in IStructure __mul__")
         self.assertIn("Overall Charge: +1", str(s),"String representation not adding charge")
+        sorted_s = s.get_sorted_structure()
+        self.assertEqual(sorted_s.charge,27,"Overall charge is not properly copied during structure sorting")
 
 
 class IMoleculeTest(PymatgenTest):

--- a/pymatgen/core/tests/test_structure.py
+++ b/pymatgen/core/tests/test_structure.py
@@ -864,6 +864,21 @@ class StructureTest(PymatgenTest):
         self.assertNotEqual(s, self.structure)
         self.assertNotEqual(self.structure * 2, self.structure)
 
+    def test_charge(self):
+        s = Structure.from_sites(self.structure)
+        self.assertEqual(s.charge,0,"Initial Structure not defaulting to behavior in SiteCollection")
+        s.add_oxidation_state_by_site([1,1])
+        self.assertEqual(s.charge,2,"Initial Structure not defaulting to behavior in SiteCollection")
+        s = Structure.from_sites(s,charge=1)
+        self.assertEqual(s.charge,1,"Overall charge not being stored in seperate property")
+        s = s.copy()
+        self.assertEqual(s.charge,1,"Overall charge not being copied properly with no sanitization")
+        s = s.copy(sanitize=True)
+        self.assertEqual(s.charge,1,"Overall charge not being copied properly with sanitization")
+        super_cell = s*3
+        self.assertEqual(super_cell.charge,27,"Overall charge is not being properly multiplied in IStructure __mul__")
+        self.assertIn("Overall Charge: +1", str(s),"String representation not adding charge")
+
 
 class IMoleculeTest(PymatgenTest):
 

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -385,6 +385,7 @@ class Vasprun(MSONable):
 
             if parse_potcar_file:
                 self.update_potcar_spec(parse_potcar_file)
+                self.update_charge_from_potcar(parse_potcar_file)
 
         if self.incar.get("ALGO", "") != "BSE" and (not self.converged):
             msg = "%s is an unconverged VASP run.\n" % filename
@@ -820,7 +821,8 @@ class Vasprun(MSONable):
                         cbm_kpoint = k
         return max(cbm - vbm, 0), cbm, vbm, vbm_kpoint == cbm_kpoint
 
-    def update_potcar_spec(self, path):
+
+    def get_potcars(self,path):
         def get_potcar_in_path(p):
             for fn in os.listdir(os.path.abspath(p)):
                 if fn.startswith('POTCAR'):
@@ -844,11 +846,27 @@ class Vasprun(MSONable):
         else:
             potcar = None
 
+        return potcar
+
+    def update_potcar_spec(self, path):
+        potcar = self.get_potcars(path)
         if potcar:
             self.potcar_spec = [{"titel": sym, "hash": ps.get_potcar_hash()}
                                 for sym in self.potcar_symbols
                                 for ps in potcar if
                                 ps.symbol == sym.split()[1]]
+
+    def update_charge_from_potcar(self,path):
+        potcar = self.get_potcars(path)
+
+        if potcar:
+            nelect = self.parameters["NELECT"]
+            potcar_nelect = int(round(sum([self.structures[0].composition.element_composition[ps.element]* ps.ZVAL for ps in potcar])))
+            charge = nelect - potcar_nelect
+
+            if charge:
+                for s in self.structures:
+                    s._charge = charge
 
     def as_dict(self):
         """

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -821,8 +821,7 @@ class Vasprun(MSONable):
                         cbm_kpoint = k
         return max(cbm - vbm, 0), cbm, vbm, vbm_kpoint == cbm_kpoint
 
-
-    def get_potcars(self,path):
+    def get_potcars(self, path):
         def get_potcar_in_path(p):
             for fn in os.listdir(os.path.abspath(p)):
                 if fn.startswith('POTCAR'):
@@ -856,12 +855,13 @@ class Vasprun(MSONable):
                                 for ps in potcar if
                                 ps.symbol == sym.split()[1]]
 
-    def update_charge_from_potcar(self,path):
+    def update_charge_from_potcar(self, path):
         potcar = self.get_potcars(path)
 
         if potcar:
             nelect = self.parameters["NELECT"]
-            potcar_nelect = int(round(sum([self.structures[0].composition.element_composition[ps.element]* ps.ZVAL for ps in potcar])))
+            potcar_nelect = int(round(sum([self.structures[0].composition.element_composition[
+                                ps.element] * ps.ZVAL for ps in potcar])))
             charge = nelect - potcar_nelect
 
             if charge:

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -360,6 +360,9 @@ class DictSet(VaspInputSet):
                            for mag in incar['MAGMOM']])
             incar['NUPDOWN'] = nupdown
 
+        if self.structure._charge:
+            incar["NELECT"] = self.nelect + self.structure._charge
+
         return incar
 
     @property

--- a/pymatgen/io/vasp/tests/test_outputs.py
+++ b/pymatgen/io/vasp/tests/test_outputs.py
@@ -424,12 +424,13 @@ class VasprunTest(unittest.TestCase):
             self.assertTrue(vasprun.converged)
 
     def test_charged_structure(self):
-      vpath = os.path.join(test_dir, 'vasprun.charged.xml')
-      potcar_path = os.path.join(test_dir, 'POT_GGA_PAW_PBE','POTCAR.Si.gz')
-      vasprun = Vasprun(vpath, parse_potcar_file=False)
-      vasprun.update_charge_from_potcar(potcar_path)
-      self.assertEqual(vasprun.parameters.get("NELECT",8),9)
-      self.assertEqual(vasprun.structures[0].charge,1)
+        vpath = os.path.join(test_dir, 'vasprun.charged.xml')
+        potcar_path = os.path.join(test_dir, 'POT_GGA_PAW_PBE', 'POTCAR.Si.gz')
+        vasprun = Vasprun(vpath, parse_potcar_file=False)
+        vasprun.update_charge_from_potcar(potcar_path)
+        self.assertEqual(vasprun.parameters.get("NELECT", 8), 9)
+        self.assertEqual(vasprun.structures[0].charge, 1)
+
 
 class OutcarTest(unittest.TestCase):
 

--- a/pymatgen/io/vasp/tests/test_outputs.py
+++ b/pymatgen/io/vasp/tests/test_outputs.py
@@ -406,7 +406,7 @@ class VasprunTest(unittest.TestCase):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             vasprun = Vasprun(filepath, parse_potcar_file='.')
-            self.assertEqual(len(w), 1)
+            self.assertEqual(len(w), 2)
         self.assertEqual(vasprun.potcar_spec, [{"titel": "PAW_PBE Li 17Jan2003", "hash": None},
                                                {"titel": "PAW_PBE Fe 06Sep2000", "hash": None},
                                                {"titel": "PAW_PBE Fe 06Sep2000", "hash": None},
@@ -423,6 +423,13 @@ class VasprunTest(unittest.TestCase):
             self.assertEqual(nestep, 10)
             self.assertTrue(vasprun.converged)
 
+    def test_charged_structure(self):
+      vpath = os.path.join(test_dir, 'vasprun.charged.xml')
+      potcar_path = os.path.join(test_dir, 'POT_GGA_PAW_PBE','POTCAR.Si.gz')
+      vasprun = Vasprun(vpath, parse_potcar_file=False)
+      vasprun.update_charge_from_potcar(potcar_path)
+      self.assertEqual(vasprun.parameters.get("NELECT",8),9)
+      self.assertEqual(vasprun.structures[0].charge,1)
 
 class OutcarTest(unittest.TestCase):
 

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -188,6 +188,20 @@ class MITMPRelaxSetTest(unittest.TestCase):
         self.assertEqual(incar['LUSE_VDW'], True)
         self.assertEqual(incar['PARAM1'], 0.1234)
 
+        # Test that NELECT is updated when a charge is present
+        si = 14
+        coords = list()
+        coords.append(np.array([0, 0, 0]))
+        coords.append(np.array([0.75, 0.5, 0.75]))
+
+        # Silicon structure for testing.
+        latt = Lattice(np.array([[3.8401979337, 0.00, 0.00],
+                                 [1.9200989668, 3.3257101909, 0.00],
+                                 [0.00, -2.2171384943, 3.1355090603]]))
+        struct = Structure(latt, [si, si], coords,charge=1)
+        mpr = MPRelaxSet(struct)
+        self.assertEqual(mpr.incar["NELECT"],mpr.nelect+1,"NELECT not properly set for nonzero charge")
+
     def test_get_kpoints(self):
         kpoints = MPRelaxSet(self.structure).kpoints
         self.assertEqual(kpoints.kpts, [[2, 4, 5]])

--- a/test_files/vasprun.charged.xml
+++ b/test_files/vasprun.charged.xml
@@ -1,0 +1,5623 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<modeling>
+ <generator>
+  <i name="program" type="string">vasp </i>
+  <i name="version" type="string">5.4.1  </i>
+  <i name="subversion" type="string">24Jun15 (build Feb 01 2016 23:38:11) complex                          parallel </i>
+  <i name="platform" type="string">IFC91_impi </i>
+  <i name="date" type="string">2017 12 05 </i>
+  <i name="time" type="string">08:32:42 </i>
+ </generator>
+ <incar>
+  <i type="string" name="PREC">accurate</i>
+  <i type="string" name="ALGO"> Fast</i>
+  <i type="int" name="ISPIN">     2</i>
+  <i type="int" name="ICHARG">     1</i>
+  <i type="int" name="NELM">   100</i>
+  <i type="int" name="IBRION">     2</i>
+  <i name="EDIFF">      0.00010000</i>
+  <i type="int" name="NSW">    99</i>
+  <i type="int" name="ISIF">     3</i>
+  <i name="ENCUT">    520.00000000</i>
+  <v name="MAGMOM">      0.60000000      0.60000000</v>
+  <i name="NELECT">      9.00000000</i>
+  <i type="string" name="LREAL"> Auto</i>
+  <i type="int" name="ISMEAR">    -5</i>
+  <i name="SIGMA">      0.05000000</i>
+  <i type="logical" name="LWAVE"> F  </i>
+  <i type="logical" name="LORBIT"> F  </i>
+  <v type="int" name="KPOINT_BSE">    -1     0     0     0</v>
+  <i type="int" name="NELM">   100</i>
+ </incar>
+ <kpoints>
+  <generation param="Gamma">
+   <v type="int" name="divisions">       7        7        7 </v>
+   <v name="usershift">      0.00000000       0.00000000       0.00000000 </v>
+   <v name="genvec1">      0.14285714       0.00000000       0.00000000 </v>
+   <v name="genvec2">      0.00000000       0.14285714       0.00000000 </v>
+   <v name="genvec3">      0.00000000       0.00000000       0.14285714 </v>
+   <v name="shift">      0.00000000       0.00000000       0.00000000 </v>
+  </generation>
+  <varray name="kpointlist" >
+   <v>       0.00000000       0.00000000       0.00000000 </v>
+   <v>       0.14285714       0.00000000      -0.00000000 </v>
+   <v>       0.28571429       0.00000000      -0.00000000 </v>
+   <v>       0.42857143       0.00000000       0.00000000 </v>
+   <v>       0.00000000       0.14285714       0.00000000 </v>
+   <v>       0.28571429       0.14285714       0.00000000 </v>
+   <v>       0.42857143       0.14285714       0.00000000 </v>
+   <v>      -0.42857143       0.14285714      -0.00000000 </v>
+   <v>      -0.28571429       0.14285714       0.00000000 </v>
+   <v>      -0.14285714       0.14285714       0.00000000 </v>
+   <v>       0.00000000       0.28571429       0.00000000 </v>
+   <v>      -0.42857143       0.28571429       0.00000000 </v>
+   <v>      -0.28571429       0.28571429       0.00000000 </v>
+   <v>      -0.14285714       0.28571429       0.00000000 </v>
+   <v>       0.00000000       0.42857143      -0.00000000 </v>
+   <v>      -0.14285714       0.42857143      -0.00000000 </v>
+   <v>       0.42857143       0.14285714       0.14285714 </v>
+   <v>      -0.42857143       0.14285714       0.14285714 </v>
+   <v>      -0.28571429       0.28571429       0.14285714 </v>
+   <v>      -0.14285714       0.28571429       0.14285714 </v>
+  </varray>
+  <varray name="weights" >
+   <v>       0.00291545 </v>
+   <v>       0.02332362 </v>
+   <v>       0.02332362 </v>
+   <v>       0.02332362 </v>
+   <v>       0.01749271 </v>
+   <v>       0.03498542 </v>
+   <v>       0.06997085 </v>
+   <v>       0.06997085 </v>
+   <v>       0.06997085 </v>
+   <v>       0.06997085 </v>
+   <v>       0.01749271 </v>
+   <v>       0.03498542 </v>
+   <v>       0.06997085 </v>
+   <v>       0.06997085 </v>
+   <v>       0.01749271 </v>
+   <v>       0.03498542 </v>
+   <v>       0.06997085 </v>
+   <v>       0.13994169 </v>
+   <v>       0.06997085 </v>
+   <v>       0.06997085 </v>
+  </varray>
+  <varray name="tetrahedronlist"  type="int" >
+   <v type="int" >        4        1        2        2        2 </v>
+   <v type="int" >        8        1        2        2        5 </v>
+   <v type="int" >        8        2        2        5       10 </v>
+   <v type="int" >        4        2        2        2        5 </v>
+   <v type="int" >        8        2        2        5        6 </v>
+   <v type="int" >        8        2        2        6       10 </v>
+   <v type="int" >        8        2        3        5        6 </v>
+   <v type="int" >        4        2        5        6        6 </v>
+   <v type="int" >        8        3        5        6       10 </v>
+   <v type="int" >        8        5        6       10       10 </v>
+   <v type="int" >        4        5        6        6       10 </v>
+   <v type="int" >        8        3        4        7       10 </v>
+   <v type="int" >       16        3        6        7       10 </v>
+   <v type="int" >       12        6        7       10       10 </v>
+   <v type="int" >        8        4        7        9       10 </v>
+   <v type="int" >       16        7        9       10       17 </v>
+   <v type="int" >        8        7       10       10       17 </v>
+   <v type="int" >        8        4        4        8        9 </v>
+   <v type="int" >       24        4        7        8        9 </v>
+   <v type="int" >        8        7        8        9       17 </v>
+   <v type="int" >       28        4        8        8        9 </v>
+   <v type="int" >       24        8        8        9       18 </v>
+   <v type="int" >        8        8        9       17       18 </v>
+   <v type="int" >        8        3        4        8        9 </v>
+   <v type="int" >        8        3        7        8        9 </v>
+   <v type="int" >       24        7        8        9       18 </v>
+   <v type="int" >       12        8        9       18       18 </v>
+   <v type="int" >        8        2        3        7       10 </v>
+   <v type="int" >       16        3        7        9       10 </v>
+   <v type="int" >        8        7        9       10       18 </v>
+   <v type="int" >        8        2        6        7       10 </v>
+   <v type="int" >       16        6        7       10       17 </v>
+   <v type="int" >        8        7       10       17       18 </v>
+   <v type="int" >        8        1        2        5        6 </v>
+   <v type="int" >       16        2        5        6       10 </v>
+   <v type="int" >        8        5        6       10       17 </v>
+   <v type="int" >        8        2        5       10       10 </v>
+   <v type="int" >        8        5       10       10       11 </v>
+   <v type="int" >        8       10       10       11       14 </v>
+   <v type="int" >       12        2        6       10       10 </v>
+   <v type="int" >        8        6       10       10       17 </v>
+   <v type="int" >        8       10       10       14       17 </v>
+   <v type="int" >        4        2        3        6        6 </v>
+   <v type="int" >       16        2        3        6       10 </v>
+   <v type="int" >        8        3        6       10       17 </v>
+   <v type="int" >        4        3        6        6       10 </v>
+   <v type="int" >        8        3        6        7       17 </v>
+   <v type="int" >        8        6        7        7       10 </v>
+   <v type="int" >        4        3        7        7       10 </v>
+   <v type="int" >        8        7        7       10       17 </v>
+   <v type="int" >        4        7        7        9       10 </v>
+   <v type="int" >        8        7        8       12       17 </v>
+   <v type="int" >        8        7        7       12       17 </v>
+   <v type="int" >        8        7        9       12       17 </v>
+   <v type="int" >        8        8       12       17       18 </v>
+   <v type="int" >        8       12       17       18       18 </v>
+   <v type="int" >        8        9       12       17       18 </v>
+   <v type="int" >       32        8        9       13       18 </v>
+   <v type="int" >       24        8       12       13       18 </v>
+   <v type="int" >       12       12       13       18       18 </v>
+   <v type="int" >        8        9       13       18       18 </v>
+   <v type="int" >       32       13       18       18       19 </v>
+   <v type="int" >        8        9       10       14       18 </v>
+   <v type="int" >       16        9       13       14       18 </v>
+   <v type="int" >        8       13       14       18       19 </v>
+   <v type="int" >        8       10       14       17       18 </v>
+   <v type="int" >       16       14       17       18       20 </v>
+   <v type="int" >        8       14       18       19       20 </v>
+   <v type="int" >        8        5       10       11       17 </v>
+   <v type="int" >       16       10       11       14       17 </v>
+   <v type="int" >        8       11       14       17       20 </v>
+   <v type="int" >        8       10       11       14       14 </v>
+   <v type="int" >        8       11       14       14       15 </v>
+   <v type="int" >        8       14       14       15       16 </v>
+   <v type="int" >        8       10       14       14       17 </v>
+   <v type="int" >        8       14       14       17       20 </v>
+   <v type="int" >        8       14       14       16       20 </v>
+   <v type="int" >        8        3        9       10       17 </v>
+   <v type="int" >       16        9       10       14       17 </v>
+   <v type="int" >        8        9       14       17       20 </v>
+   <v type="int" >        8        3        7        9       17 </v>
+   <v type="int" >       16        7        9       17       18 </v>
+   <v type="int" >        8        9       17       18       20 </v>
+   <v type="int" >        4        3        4        7        7 </v>
+   <v type="int" >       16        3        4        7        9 </v>
+   <v type="int" >        8        4        7        9       18 </v>
+   <v type="int" >        4        4        7        7        9 </v>
+   <v type="int" >        8        4        7        8       18 </v>
+   <v type="int" >        8        7        8        9       12 </v>
+   <v type="int" >        8        8        9       12       18 </v>
+   <v type="int" >        4        8        8        8        9 </v>
+   <v type="int" >        8       12       13       13       18 </v>
+   <v type="int" >        8        8        8       13       18 </v>
+   <v type="int" >        8       13       13       18       19 </v>
+   <v type="int" >       32        8       13       18       18 </v>
+   <v type="int" >        8       13       14       16       19 </v>
+   <v type="int" >        8       13       13       16       19 </v>
+   <v type="int" >        8       13       16       18       19 </v>
+   <v type="int" >        8       14       16       19       20 </v>
+   <v type="int" >        8       16       19       20       20 </v>
+   <v type="int" >        8       16       18       19       20 </v>
+   <v type="int" >        8       11       14       15       20 </v>
+   <v type="int" >       16       14       15       16       20 </v>
+   <v type="int" >       12       15       16       20       20 </v>
+   <v type="int" >        8       14       15       16       16 </v>
+   <v type="int" >        4       15       15       16       16 </v>
+   <v type="int" >        8       14       16       16       20 </v>
+   <v type="int" >        4       16       16       20       20 </v>
+   <v type="int" >        8        9       13       14       20 </v>
+   <v type="int" >       16       13       14       16       20 </v>
+   <v type="int" >       12       13       16       20       20 </v>
+   <v type="int" >        8        9       13       18       20 </v>
+   <v type="int" >       32       13       18       19       20 </v>
+   <v type="int" >        8       13       19       20       20 </v>
+   <v type="int" >        8        4        8        9       18 </v>
+   <v type="int" >        8        8       13       18       19 </v>
+   <v type="int" >        8        4        8        8       18 </v>
+   <v type="int" >        8        8        8       18       18 </v>
+   <v type="int" >        8        8       18       18       19 </v>
+   <v type="int" >       12        4        4        8        8 </v>
+   <v type="int" >        4        4        8        8        8 </v>
+   <v type="int" >        8        8        8        9       13 </v>
+   <v type="int" >        4        4        8        9        9 </v>
+   <v type="int" >        4        7        8        9        9 </v>
+   <v type="int" >        8       13       14       16       18 </v>
+   <v type="int" >        8        7        9       14       18 </v>
+   <v type="int" >        8       14       16       18       20 </v>
+   <v type="int" >        8        7       14       17       18 </v>
+   <v type="int" >        8       15       15       16       20 </v>
+   <v type="int" >        8       14       15       17       20 </v>
+   <v type="int" >        8       13       13       16       20 </v>
+   <v type="int" >        8       13       14       17       20 </v>
+   <v type="int" >        8       13       13       19       20 </v>
+   <v type="int" >        8       13       17       18       20 </v>
+   <v type="int" >        8        8       12       13       19 </v>
+   <v type="int" >        8       12       13       13       19 </v>
+   <v type="int" >       24       12       13       18       19 </v>
+   <v type="int" >        8        8       12       18       19 </v>
+   <v type="int" >       16       12       18       18       19 </v>
+   <v type="int" >       16        7        8       12       18 </v>
+   <v type="int" >       12        7       12       18       18 </v>
+   <v type="int" >        8        7       17       18       18 </v>
+   <v type="int" >        4        3        4        9        9 </v>
+   <v type="int" >        4        3        7        9        9 </v>
+   <v type="int" >        8        7        9       10       14 </v>
+   <v type="int" >        4        3        7       10       10 </v>
+   <v type="int" >        8        7       10       14       17 </v>
+   <v type="int" >        8       11       14       15       17 </v>
+   <v type="int" >        8        6       10       11       17 </v>
+   <v type="int" >        8        9       13       14       17 </v>
+   <v type="int" >        8        6        9       10       17 </v>
+   <v type="int" >        8        9       13       17       18 </v>
+   <v type="int" >        8        6        7        9       17 </v>
+   <v type="int" >        8        8       12       18       18 </v>
+   <v type="int" >        8        7        8        8       18 </v>
+   <v type="int" >        8        7        7       12       18 </v>
+   <v type="int" >        8        7        7       17       18 </v>
+   <v type="int" >        8        6        7        7       17 </v>
+   <v type="int" >        4        2        3       10       10 </v>
+   <v type="int" >        8        5        6       10       11 </v>
+   <v type="int" >        4        2        5        5        6 </v>
+   <v type="int" >        8        3        6        9       10 </v>
+   <v type="int" >        8        3        6        7        9 </v>
+   <v type="int" >        8        4        7        8        8 </v>
+   <v type="int" >        4        1        2        5        5 </v>
+   <v type="int" >        4        5       10       10       10 </v>
+   <v type="int" >        4       10       10       10       11 </v>
+   <v type="int" >        8       10       10       11       17 </v>
+   <v type="int" >        8        9       10       11       17 </v>
+   <v type="int" >        4       10       11       17       17 </v>
+   <v type="int" >        8        9       11       14       17 </v>
+   <v type="int" >        8       11       14       14       17 </v>
+   <v type="int" >        4       11       14       17       17 </v>
+   <v type="int" >        8        8        9       14       18 </v>
+   <v type="int" >       16        9       14       17       18 </v>
+   <v type="int" >        8       14       14       17       18 </v>
+   <v type="int" >        8        8       13       14       18 </v>
+   <v type="int" >       16       13       14       18       20 </v>
+   <v type="int" >        8       14       14       18       20 </v>
+   <v type="int" >        8        7        8       13       18 </v>
+   <v type="int" >        8       13       18       18       20 </v>
+   <v type="int" >        8        7       12       13       18 </v>
+   <v type="int" >        8        6        7       12       17 </v>
+   <v type="int" >       16        7       12       17       18 </v>
+   <v type="int" >        8       12       17       18       19 </v>
+   <v type="int" >        4        9       10       17       17 </v>
+   <v type="int" >        4        9       14       17       17 </v>
+   <v type="int" >        8       14       17       18       18 </v>
+   <v type="int" >        4        9       14       18       18 </v>
+   <v type="int" >        8       14       18       18       20 </v>
+   <v type="int" >        4       13       14       18       18 </v>
+   <v type="int" >       24       18       18       19       20 </v>
+   <v type="int" >       32       18       19       19       20 </v>
+   <v type="int" >       16       19       19       19       20 </v>
+   <v type="int" >        8       13       19       19       20 </v>
+   <v type="int" >        8       17       18       19       20 </v>
+   <v type="int" >        8       17       18       18       20 </v>
+   <v type="int" >       16       18       18       19       19 </v>
+   <v type="int" >        8       13       18       19       19 </v>
+   <v type="int" >       12       19       19       20       20 </v>
+   <v type="int" >        8       12       18       19       20 </v>
+   <v type="int" >        8       18       19       19       19 </v>
+   <v type="int" >        2       19       19       19       19 </v>
+   <v type="int" >        4        7        8       18       18 </v>
+   <v type="int" >        8       12       17       18       20 </v>
+   <v type="int" >        4        7       12       17       17 </v>
+   <v type="int" >        4        6        7       17       17 </v>
+   <v type="int" >        4       11       14       14       14 </v>
+   <v type="int" >        4       14       14       14       15 </v>
+   <v type="int" >        8       14       14       15       20 </v>
+   <v type="int" >        8       13       14       15       20 </v>
+   <v type="int" >        4       14       15       20       20 </v>
+   <v type="int" >        8       13       15       16       20 </v>
+   <v type="int" >        8       15       16       16       20 </v>
+   <v type="int" >        8       12       13       16       19 </v>
+   <v type="int" >       16       13       16       19       20 </v>
+   <v type="int" >        8       16       16       19       20 </v>
+   <v type="int" >        4       13       14       20       20 </v>
+   <v type="int" >        8       16       19       19       20 </v>
+   <v type="int" >        4       13       16       19       19 </v>
+   <v type="int" >        4       12       13       19       19 </v>
+   <v type="int" >        4       15       16       16       16 </v>
+  </varray>
+  <i name="volumeweight">      0.00048591 </i>
+ </kpoints>
+ <parameters>
+  <separator name="general" >
+   <i type="string" name="SYSTEM">unknown system</i>
+   <i type="logical" name="LCOMPAT"> F  </i>
+  </separator>
+  <separator name="electronic" >
+   <i type="string" name="PREC">accura</i>
+   <i name="ENMAX">    520.00000000</i>
+   <i name="ENAUG">    322.06900000</i>
+   <i name="EDIFF">      0.00010000</i>
+   <i type="int" name="IALGO">    68</i>
+   <i type="int" name="IWAVPR">    11</i>
+   <i type="int" name="NBANDS">     9</i>
+   <i name="NELECT">      9.00000000</i>
+   <i type="int" name="TURBO">     0</i>
+   <i type="int" name="IRESTART">     0</i>
+   <i type="int" name="NREBOOT">     0</i>
+   <i type="int" name="NMIN">     0</i>
+   <i name="EREF">      0.00000000</i>
+   <separator name="electronic smearing" >
+    <i type="int" name="ISMEAR">    -5</i>
+    <i name="SIGMA">      0.05000000</i>
+    <i name="KSPACING">      0.50000000</i>
+    <i type="logical" name="KGAMMA"> T  </i>
+   </separator>
+   <separator name="electronic projectors" >
+    <i type="logical" name="LREAL"> T  </i>
+    <v name="ROPT">     -0.00025000</v>
+    <i type="int" name="LMAXPAW">  -100</i>
+    <i type="int" name="LMAXMIX">     2</i>
+    <i type="logical" name="NLSPLINE"> F  </i>
+   </separator>
+   <separator name="electronic startup" >
+    <i type="int" name="ISTART">     0</i>
+    <i type="int" name="ICHARG">     1</i>
+    <i type="int" name="INIWAV">     1</i>
+   </separator>
+   <separator name="electronic spin" >
+    <i type="int" name="ISPIN">     2</i>
+    <i type="logical" name="LNONCOLLINEAR"> F  </i>
+    <v name="MAGMOM">      0.60000000      0.60000000</v>
+    <i name="NUPDOWN">     -1.00000000</i>
+    <i type="logical" name="LSORBIT"> F  </i>
+    <v name="SAXIS">      0.00000000      0.00000000      1.00000000</v>
+    <i type="logical" name="LSPIRAL"> F  </i>
+    <v name="QSPIRAL">      0.00000000      0.00000000      0.00000000</v>
+    <i type="logical" name="LZEROZ"> F  </i>
+   </separator>
+   <separator name="electronic exchange-correlation" >
+    <i type="logical" name="LASPH"> F  </i>
+    <i type="logical" name="LMETAGGA"> F  </i>
+   </separator>
+   <separator name="electronic convergence" >
+    <i type="int" name="NELM">   100</i>
+    <i type="int" name="NELMDL">    -5</i>
+    <i type="int" name="NELMIN">     2</i>
+    <i name="ENINI">    520.00000000</i>
+    <separator name="electronic convergence detail" >
+     <i type="logical" name="LDIAG"> T  </i>
+     <i type="logical" name="LSUBROT"> F  </i>
+     <i name="WEIMIN">      0.00100000</i>
+     <i name="EBREAK">      0.00000278</i>
+     <i name="DEPER">      0.30000000</i>
+     <i type="int" name="NRMM">     4</i>
+     <i name="TIME">      0.40000000</i>
+    </separator>
+   </separator>
+   <separator name="electronic mixer" >
+    <i name="AMIX">      0.40000000</i>
+    <i name="BMIX">      1.00000000</i>
+    <i name="AMIN">      0.10000000</i>
+    <i name="AMIX_MAG">      1.60000000</i>
+    <i name="BMIX_MAG">      1.00000000</i>
+    <separator name="electronic mixer details" >
+     <i type="int" name="IMIX">     4</i>
+     <i type="logical" name="MIXFIRST"> F  </i>
+     <i type="int" name="MAXMIX">   -45</i>
+     <i name="WC">    100.00000000</i>
+     <i type="int" name="INIMIX">     1</i>
+     <i type="int" name="MIXPRE">     1</i>
+     <i type="int" name="MREMOVE">     5</i>
+    </separator>
+   </separator>
+   <separator name="electronic dipolcorrection" >
+    <i type="logical" name="LDIPOL"> F  </i>
+    <i type="logical" name="LMONO"> F  </i>
+    <i type="int" name="IDIPOL">     0</i>
+    <i name="EPSILON">      1.00000000</i>
+    <v name="DIPOL">   -100.00000000   -100.00000000   -100.00000000</v>
+    <i name="EFIELD">      0.00000000</i>
+   </separator>
+  </separator>
+  <separator name="grids" >
+   <i type="int" name="NGX">    30</i>
+   <i type="int" name="NGY">    30</i>
+   <i type="int" name="NGZ">    30</i>
+   <i type="int" name="NGXF">    60</i>
+   <i type="int" name="NGYF">    60</i>
+   <i type="int" name="NGZF">    60</i>
+   <i type="logical" name="ADDGRID"> F  </i>
+  </separator>
+  <separator name="ionic" >
+   <i type="int" name="NSW">    99</i>
+   <i type="int" name="IBRION">     2</i>
+   <i type="int" name="ISIF">     3</i>
+   <i name="PSTRESS">      0.00000000</i>
+   <i name="EDIFFG">      0.00100000</i>
+   <i type="int" name="NFREE">     1</i>
+   <i name="POTIM">      0.50000000</i>
+   <i name="SMASS">     -3.00000000</i>
+   <i name="SCALEE">      1.00000000</i>
+  </separator>
+  <separator name="ionic md" >
+   <i name="TEBEG">      0.00010000</i>
+   <i name="TEEND">      0.00010000</i>
+   <i type="int" name="NBLOCK">     1</i>
+   <i type="int" name="KBLOCK">    99</i>
+   <i type="int" name="NPACO">   256</i>
+   <i name="APACO">     16.00000000</i>
+  </separator>
+  <separator name="symmetry" >
+   <i type="int" name="ISYM">     2</i>
+   <i name="SYMPREC">      0.00001000</i>
+  </separator>
+  <separator name="dos" >
+   <i type="logical" name="LORBIT"> F  </i>
+   <v name="RWIGS">     -1.00000000</v>
+   <i type="int" name="NEDOS">   301</i>
+   <i name="EMIN">     10.00000000</i>
+   <i name="EMAX">    -10.00000000</i>
+   <i name="EFERMI">      0.00000000</i>
+  </separator>
+  <separator name="writing" >
+   <i type="int" name="NWRITE">     2</i>
+   <i type="logical" name="LWAVE"> F  </i>
+   <i type="logical" name="LCHARG"> T  </i>
+   <i type="logical" name="LPARD"> F  </i>
+   <i type="logical" name="LVTOT"> F  </i>
+   <i type="logical" name="LVHAR"> F  </i>
+   <i type="logical" name="LELF"> F  </i>
+   <i type="logical" name="LOPTICS"> F  </i>
+   <v name="STM">      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000</v>
+  </separator>
+  <separator name="performance" >
+   <i type="int" name="NPAR">     1</i>
+   <i type="int" name="NSIM">     4</i>
+   <i type="int" name="NBLK">    -1</i>
+   <i type="logical" name="LPLANE"> T  </i>
+   <i type="logical" name="LSCALAPACK"> F  </i>
+   <i type="logical" name="LSCAAWARE"> F  </i>
+   <i type="logical" name="LSCALU"> F  </i>
+   <i type="logical" name="LASYNC"> F  </i>
+   <i type="logical" name="LORBITALREAL"> F  </i>
+  </separator>
+  <separator name="miscellaneous" >
+   <i type="int" name="IDIOT">     3</i>
+   <i type="logical" name="LMUSIC"> F  </i>
+   <v name="POMASS">     28.08500000</v>
+   <v name="DARWINR">      0.00000000</v>
+   <v name="DARWINV">      1.00000000</v>
+   <i type="logical" name="LCORR"> T  </i>
+  </separator>
+  <i type="logical" name="GGA_COMPAT"> T  </i>
+  <i type="logical" name="LBERRY"> F  </i>
+  <i type="int" name="ICORELEVEL">     0</i>
+  <i type="logical" name="LDAU"> F  </i>
+  <i type="int" name="I_CONSTRAINED_M">     0</i>
+  <separator name="electronic exchange-correlation" >
+   <i type="string" name="GGA">--</i>
+   <i type="int" name="VOSKOWN">     0</i>
+   <i type="logical" name="LHFCALC"> F  </i>
+   <i type="string" name="PRECFOCK"></i>
+   <i type="logical" name="LSYMGRAD"> F  </i>
+   <i type="logical" name="LHFONE"> F  </i>
+   <i type="logical" name="LRHFCALC"> F  </i>
+   <i type="logical" name="LTHOMAS"> F  </i>
+   <i type="logical" name="LMODELHF"> F  </i>
+   <i name="ENCUT4O">     -1.00000000</i>
+   <i type="int" name="EXXOEP">     0</i>
+   <i type="int" name="FOURORBIT">     0</i>
+   <i name="AEXX">      0.00000000</i>
+   <i name="HFALPHA">      0.00000000</i>
+   <i name="MCALPHA">      0.00000000</i>
+   <i name="ALDAX">      1.00000000</i>
+   <i name="AGGAX">      1.00000000</i>
+   <i name="ALDAC">      1.00000000</i>
+   <i name="AGGAC">      1.00000000</i>
+   <i type="int" name="NKREDX">     1</i>
+   <i type="int" name="NKREDY">     1</i>
+   <i type="int" name="NKREDZ">     1</i>
+   <i type="logical" name="SHIFTRED"> F  </i>
+   <i type="logical" name="ODDONLY"> F  </i>
+   <i type="logical" name="EVENONLY"> F  </i>
+   <i type="int" name="LMAXFOCK">     0</i>
+   <i type="int" name="NMAXFOCKAE">     0</i>
+   <i type="logical" name="LFOCKAEDFT"> F  </i>
+   <i name="HFSCREEN">      0.00000000</i>
+   <i name="HFSCREENC">      0.00000000</i>
+   <i type="int" name="NBANDSGWLOW">     0</i>
+  </separator>
+  <separator name="vdW DFT" >
+   <i type="logical" name="LUSE_VDW"> F  </i>
+   <i name="Zab_VDW">     -0.84910000</i>
+   <i name="PARAM1">      0.12340000</i>
+   <i name="PARAM2">      1.00000000</i>
+   <i name="PARAM3">      0.00000000</i>
+  </separator>
+  <separator name="model GW" >
+   <i type="int" name="MODEL_GW">     0</i>
+   <i name="MODEL_EPS0">     12.01343768</i>
+   <i name="MODEL_ALPHA">      1.00000000</i>
+  </separator>
+  <separator name="linear response parameters" >
+   <i type="logical" name="LEPSILON"> F  </i>
+   <i type="logical" name="LRPA"> F  </i>
+   <i type="logical" name="LNABLA"> F  </i>
+   <i type="logical" name="LVEL"> F  </i>
+   <i type="int" name="KINTER">     0</i>
+   <i name="CSHIFT">      0.10000000</i>
+   <i name="OMEGAMAX">     -1.00000000</i>
+   <i name="DEG_THRESHOLD">      0.00200000</i>
+  </separator>
+  <separator name="orbital magnetization" >
+   <i type="logical" name="NUCIND"> F  </i>
+   <v name="MAGPOS">      0.00000000      0.00000000      0.00000000</v>
+   <i type="logical" name="LNICSALL"> T  </i>
+   <i type="logical" name="ORBITALMAG"> F  </i>
+   <i type="logical" name="LMAGBLOCH"> F  </i>
+   <i type="logical" name="LCHIMAG"> F  </i>
+   <i type="logical" name="LGAUGE"> T  </i>
+   <i type="int" name="MAGATOM">     0</i>
+   <v name="MAGDIPOL">      0.00000000      0.00000000      0.00000000</v>
+   <v name="AVECCONST">      0.00000000      0.00000000      0.00000000</v>
+  </separator>
+  <separator name="response functions" >
+   <i type="logical" name="LADDER"> F  </i>
+   <i type="logical" name="LFXC"> F  </i>
+   <i type="logical" name="LHARTREE"> T  </i>
+   <i type="int" name="IBSE">     0</i>
+   <v type="int" name="KPOINT">    -1     0     0     0</v>
+   <i type="logical" name="LTCTE"> F  </i>
+   <i type="logical" name="LTETE"> F  </i>
+   <i type="logical" name="LTRIPLET"> F  </i>
+   <i type="logical" name="LFXCEPS"> F  </i>
+   <i type="logical" name="LFXHEG"> F  </i>
+   <i type="int" name="NATURALO">     0</i>
+   <i type="logical" name="L2ORDER"> F  </i>
+   <i type="logical" name="LUSEW"> F  </i>
+   <i name="ENCUTGW">     -2.00000000</i>
+   <i name="ENCUTGWSOFT">     -2.00000000</i>
+   <i name="ENCUTLF">     -1.00000000</i>
+   <i type="int" name="LMAXMP2">    -1</i>
+   <i name="SCISSOR">      0.00000000</i>
+   <i type="int" name="NOMEGA">     0</i>
+   <i type="int" name="NOMEGAR">     0</i>
+   <i type="int" name="NBANDSGW">    -1</i>
+   <i type="int" name="NBANDSO">    -1</i>
+   <i type="int" name="NBANDSV">    -1</i>
+   <i type="int" name="NELM">   100</i>
+   <i type="int" name="NELMHF">     1</i>
+   <i type="int" name="DIM">     3</i>
+   <i type="int" name="ANTIRES">     0</i>
+   <i name="OMEGAMAX">    -30.00000000</i>
+   <i name="OMEGAMIN">    -30.00000000</i>
+   <i name="OMEGATL">   -200.00000000</i>
+   <i type="int" name="OMEGAGRID">     0</i>
+   <i name="CSHIFT">     -0.10000000</i>
+   <i type="logical" name="SELFENERGY"> F  </i>
+   <i type="logical" name="LSPECTRAL"> F  </i>
+   <i type="logical" name="LSPECTRALGW"> F  </i>
+   <i type="logical" name="LSINGLES"> F  </i>
+   <i type="logical" name="LFERMIGW"> F  </i>
+   <i type="logical" name="ODDONLYGW"> F  </i>
+   <i type="logical" name="EVENONLYGW"> F  </i>
+   <i type="int" name="NKREDLFX">     1</i>
+   <i type="int" name="NKREDLFY">     1</i>
+   <i type="int" name="NKREDLFZ">     1</i>
+   <i type="int" name="MAXMEM">  1800</i>
+   <i type="int" name="TELESCOPE">     0</i>
+   <i type="int" name="TAUPAR">     1</i>
+   <i type="int" name="OMEGAPAR">    -1</i>
+   <i name="LAMBDA">      1.00000000</i>
+  </separator>
+  <separator name="External order field" >
+   <i name="OFIELD_KAPPA">      0.00000000</i>
+   <v name="OFIELD_K">      0.00000000      0.00000000      0.00000000</v>
+   <i name="OFIELD_Q6_NEAR">      0.00000000</i>
+   <i name="OFIELD_Q6_FAR">      0.00000000</i>
+   <i name="OFIELD_A">      0.00000000</i>
+  </separator>
+ </parameters>
+ <atominfo>
+  <atoms>       2 </atoms>
+  <types>       1 </types>
+  <array name="atoms" >
+   <dimension dim="1">ion</dimension>
+   <field type="string">element</field>
+   <field type="int">atomtype</field>
+   <set>
+    <rc><c>Si</c><c>   1</c></rc>
+    <rc><c>Si</c><c>   1</c></rc>
+   </set>
+  </array>
+  <array name="atomtypes" >
+   <dimension dim="1">type</dimension>
+   <field type="int">atomspertype</field>
+   <field type="string">element</field>
+   <field>mass</field>
+   <field>valence</field>
+   <field type="string">pseudopotential</field>
+   <set>
+    <rc><c>   2</c><c>Si</c><c>     28.08500000</c><c>      4.00000000</c><c> PAW_PBE Si 05Jan2001                   </c></rc>
+   </set>
+  </array>
+ </atominfo>
+ <structure name="initialpos" >
+  <crystal>
+   <varray name="basis" >
+    <v>       3.84019800       0.00000000       0.00000000 </v>
+    <v>       1.92009900       3.32571000       0.00000000 </v>
+    <v>       0.00000000      -2.21713800       3.13550900 </v>
+   </varray>
+   <i name="volume">     40.04479227 </i>
+   <varray name="rec_basis" >
+    <v>       0.26040324      -0.15034384      -0.10630907 </v>
+    <v>       0.00000000       0.30068767       0.21261813 </v>
+    <v>       0.00000000       0.00000000       0.31892749 </v>
+   </varray>
+  </crystal>
+  <varray name="positions" >
+   <v>       0.00000000       0.00000000       0.00000000 </v>
+   <v>       0.75000000       0.50000000       0.75000000 </v>
+  </varray>
+ </structure>
+ <calculation>
+  <scstep>
+   <time name="dav">    1.13    1.16</time>
+   <time name="total">    1.40    1.46</time>
+   <energy>
+    <i name="alphaZ">      3.36254244 </i>
+    <i name="ewald">   -228.52729335 </i>
+    <i name="hartreedc">    -11.00822102 </i>
+    <i name="XCdc">    -18.52396975 </i>
+    <i name="pawpsdc">     65.91709927 </i>
+    <i name="pawaedc">    -30.72587073 </i>
+    <i name="eentropy">      0.00000000 </i>
+    <i name="bandstr">     30.68638099 </i>
+    <i name="atom">    206.13270273 </i>
+    <i name="e_fr_energy">     17.31337058 </i>
+    <i name="e_wo_entrp">     17.31337058 </i>
+    <i name="e_0_energy">     17.31337058 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    1.48    1.49</time>
+   <time name="total">    1.49    1.50</time>
+   <energy>
+    <i name="e_fr_energy">     -3.25280551 </i>
+    <i name="e_wo_entrp">     -3.25280551 </i>
+    <i name="e_0_energy">     -3.25280551 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    1.37    1.37</time>
+   <time name="total">    1.37    1.38</time>
+   <energy>
+    <i name="e_fr_energy">     -3.74049525 </i>
+    <i name="e_wo_entrp">     -3.74049525 </i>
+    <i name="e_0_energy">     -3.74049525 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    1.50    1.51</time>
+   <time name="total">    1.51    1.51</time>
+   <energy>
+    <i name="e_fr_energy">     -3.74341783 </i>
+    <i name="e_wo_entrp">     -3.74341783 </i>
+    <i name="e_0_energy">     -3.74341783 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    1.37    1.38</time>
+   <time name="total">    1.49    1.50</time>
+   <energy>
+    <i name="e_fr_energy">     -3.74342426 </i>
+    <i name="e_wo_entrp">     -3.74342426 </i>
+    <i name="e_0_energy">     -3.74342426 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="diag">    0.22    0.23</time>
+   <time name="diis">    0.92    0.92</time>
+   <time name="orth">    0.00    0.01</time>
+   <time name="total">    1.52    1.53</time>
+   <energy>
+    <i name="e_fr_energy">     -3.72289341 </i>
+    <i name="e_wo_entrp">     -3.72289341 </i>
+    <i name="e_0_energy">     -3.72289341 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="diag">    0.22    0.22</time>
+   <time name="diis">    0.92    0.92</time>
+   <time name="orth">    0.00    0.01</time>
+   <time name="total">    1.52    1.52</time>
+   <energy>
+    <i name="e_fr_energy">     -3.67794902 </i>
+    <i name="e_wo_entrp">     -3.67794902 </i>
+    <i name="e_0_energy">     -3.67794902 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="diag">    0.22    0.22</time>
+   <time name="diis">    0.92    0.92</time>
+   <time name="orth">    0.00    0.01</time>
+   <time name="total">    1.52    1.52</time>
+   <energy>
+    <i name="e_fr_energy">     -3.67680587 </i>
+    <i name="e_wo_entrp">     -3.67680587 </i>
+    <i name="e_0_energy">     -3.67680587 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="diag">    0.22    0.22</time>
+   <time name="diis">    0.90    0.91</time>
+   <time name="orth">    0.00    0.01</time>
+   <time name="total">    1.51    1.51</time>
+   <energy>
+    <i name="e_fr_energy">     -3.67540125 </i>
+    <i name="e_wo_entrp">     -3.67540125 </i>
+    <i name="e_0_energy">     -3.67540125 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="diag">    0.22    0.22</time>
+   <time name="diis">    0.77    0.77</time>
+   <time name="orth">    0.00    0.01</time>
+   <time name="total">    1.37    1.38</time>
+   <energy>
+    <i name="e_fr_energy">     -3.67503489 </i>
+    <i name="e_wo_entrp">     -3.67503489 </i>
+    <i name="e_0_energy">     -3.67503489 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="diag">    0.22    0.22</time>
+   <time name="diis">    0.61    0.61</time>
+   <time name="orth">    0.00    0.01</time>
+   <time name="total">    1.10    1.10</time>
+   <energy>
+    <i name="alphaZ">      3.36254244 </i>
+    <i name="ewald">   -228.52729335 </i>
+    <i name="hartreedc">    -14.79869946 </i>
+    <i name="XCdc">    -15.09721043 </i>
+    <i name="pawpsdc">     78.91273250 </i>
+    <i name="pawaedc">    -44.08008009 </i>
+    <i name="eentropy">      0.00000000 </i>
+    <i name="bandstr">     10.42027333 </i>
+    <i name="atom">    206.13270273 </i>
+    <i name="e_fr_energy">     -3.67503233 </i>
+    <i name="e_wo_entrp">     -3.67503233 </i>
+    <i name="e_0_energy">     -3.67503233 </i>
+   </energy>
+  </scstep>
+  <structure>
+   <crystal>
+    <varray name="basis" >
+     <v>       3.84019800       0.00000000       0.00000000 </v>
+     <v>       1.92009900       3.32571000       0.00000000 </v>
+     <v>       0.00000000      -2.21713800       3.13550900 </v>
+    </varray>
+    <i name="volume">     40.04479227 </i>
+    <varray name="rec_basis" >
+     <v>       0.26040324      -0.15034384      -0.10630907 </v>
+     <v>       0.00000000       0.30068767       0.21261813 </v>
+     <v>       0.00000000       0.00000000       0.31892749 </v>
+    </varray>
+   </crystal>
+   <varray name="positions" >
+    <v>       0.00000000       0.00000000       0.00000000 </v>
+    <v>       0.75000000       0.50000000       0.75000000 </v>
+   </varray>
+  </structure>
+  <varray name="forces" >
+   <v>       0.00000000       0.00000000       0.00000000 </v>
+   <v>      -0.00000000      -0.00000000      -0.00000000 </v>
+  </varray>
+  <varray name="stress" >
+   <v>     407.18374395      -0.00000000       0.00000000 </v>
+   <v>       0.00000000     407.18398305       0.00025972 </v>
+   <v>      -0.00000000       0.00025972     407.18386418 </v>
+  </varray>
+  <energy>
+   <i name="e_fr_energy">     -3.67503233 </i>
+   <i name="e_wo_entrp">     -3.67503233 </i>
+   <i name="e_0_energy">      0.00000000 </i>
+  </energy>
+  <time name="totalsc">   19.01   19.13</time>
+ </calculation>
+ <calculation>
+  <scstep>
+   <time name="dav">    1.13    1.13</time>
+   <time name="total">    1.48    1.49</time>
+   <energy>
+    <i name="alphaZ">      1.74040745 </i>
+    <i name="ewald">   -183.48439291 </i>
+    <i name="hartreedc">    -11.88622932 </i>
+    <i name="XCdc">    -18.79718943 </i>
+    <i name="pawpsdc">     78.92039529 </i>
+    <i name="pawaedc">    -44.08836002 </i>
+    <i name="eentropy">      0.00000000 </i>
+    <i name="bandstr">    -38.85374068 </i>
+    <i name="atom">    206.13270273 </i>
+    <i name="e_fr_energy">    -10.31640688 </i>
+    <i name="e_wo_entrp">    -10.31640688 </i>
+    <i name="e_0_energy">    -10.31640688 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="diag">    0.22    0.22</time>
+   <time name="diis">    0.85    0.85</time>
+   <time name="orth">    0.00    0.01</time>
+   <time name="total">    1.43    1.43</time>
+   <energy>
+    <i name="e_fr_energy">     -7.85413202 </i>
+    <i name="e_wo_entrp">     -7.85413202 </i>
+    <i name="e_0_energy">     -7.85413202 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="diag">    0.22    0.22</time>
+   <time name="diis">    0.85    0.85</time>
+   <time name="orth">    0.00    0.01</time>
+   <time name="total">    1.44    1.44</time>
+   <energy>
+    <i name="e_fr_energy">     -6.61305728 </i>
+    <i name="e_wo_entrp">     -6.61305728 </i>
+    <i name="e_0_energy">     -6.61305728 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="diag">    0.22    0.22</time>
+   <time name="diis">    0.85    0.85</time>
+   <time name="orth">    0.01    0.01</time>
+   <time name="total">    1.43    1.43</time>
+   <energy>
+    <i name="e_fr_energy">     -6.60938961 </i>
+    <i name="e_wo_entrp">     -6.60938961 </i>
+    <i name="e_0_energy">     -6.60938961 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="diag">    0.22    0.22</time>
+   <time name="diis">    0.85    0.85</time>
+   <time name="orth">    0.01    0.01</time>
+   <time name="total">    1.44    1.44</time>
+   <energy>
+    <i name="e_fr_energy">     -6.60892659 </i>
+    <i name="e_wo_entrp">     -6.60892659 </i>
+    <i name="e_0_energy">     -6.60892659 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="diag">    0.22    0.22</time>
+   <time name="diis">    0.85    0.85</time>
+   <time name="orth">    0.00    0.01</time>
+   <time name="total">    1.43    1.43</time>
+   <energy>
+    <i name="e_fr_energy">     -6.60909194 </i>
+    <i name="e_wo_entrp">     -6.60909194 </i>
+    <i name="e_0_energy">     -6.60909194 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="diag">    0.22    0.22</time>
+   <time name="diis">    0.69    0.69</time>
+   <time name="orth">    0.00    0.01</time>
+   <time name="total">    1.18    1.18</time>
+   <energy>
+    <i name="alphaZ">      1.74040745 </i>
+    <i name="ewald">   -183.48439291 </i>
+    <i name="hartreedc">    -26.71386298 </i>
+    <i name="XCdc">    -17.96821120 </i>
+    <i name="pawpsdc">     69.16327473 </i>
+    <i name="pawaedc">    -34.06269549 </i>
+    <i name="eentropy">      0.00000000 </i>
+    <i name="bandstr">    -21.41638003 </i>
+    <i name="atom">    206.13270273 </i>
+    <i name="e_fr_energy">     -6.60915769 </i>
+    <i name="e_wo_entrp">     -6.60915769 </i>
+    <i name="e_0_energy">     -6.60915769 </i>
+   </energy>
+  </scstep>
+  <structure>
+   <crystal>
+    <varray name="basis" >
+     <v>       4.78291363      -0.00000000       0.00000000 </v>
+     <v>       2.39145682       4.14212640       0.00000052 </v>
+     <v>      -0.00000000      -2.76141462       3.90523308 </v>
+    </varray>
+    <i name="volume">     77.36826984 </i>
+    <varray name="rec_basis" >
+     <v>       0.20907758      -0.12071094      -0.08535545 </v>
+     <v>       0.00000000       0.24142187       0.17071091 </v>
+     <v>      -0.00000000      -0.00000003       0.25606664 </v>
+    </varray>
+   </crystal>
+   <varray name="positions" >
+    <v>      -0.00000000       0.00000000       0.00000000 </v>
+    <v>       0.75000000       0.50000000       0.75000000 </v>
+   </varray>
+  </structure>
+  <varray name="forces" >
+   <v>       0.00000000      -0.00000000       0.00000000 </v>
+   <v>      -0.00000000       0.00000000      -0.00000000 </v>
+  </varray>
+  <varray name="stress" >
+   <v>      17.89589121       0.00000000      -0.00000000 </v>
+   <v>       0.00000000      17.89590586       0.00001591 </v>
+   <v>       0.00000000       0.00001591      17.89589858 </v>
+  </varray>
+  <energy>
+   <i name="e_fr_energy">     -6.60915769 </i>
+   <i name="e_wo_entrp">     -6.60915769 </i>
+   <i name="e_0_energy">      0.00000000 </i>
+  </energy>
+  <time name="totalsc">   12.24   12.25</time>
+ </calculation>
+ <calculation>
+  <scstep>
+   <time name="dav">    1.10    1.10</time>
+   <time name="total">    1.46    1.46</time>
+   <energy>
+    <i name="alphaZ">      1.64830245 </i>
+    <i name="ewald">   -180.18879680 </i>
+    <i name="hartreedc">    -26.20166012 </i>
+    <i name="XCdc">    -18.23407173 </i>
+    <i name="pawpsdc">     69.11794798 </i>
+    <i name="pawaedc">    -34.01568766 </i>
+    <i name="eentropy">      0.00000000 </i>
+    <i name="bandstr">    -24.92548165 </i>
+    <i name="atom">    206.13270273 </i>
+    <i name="e_fr_energy">     -6.66674481 </i>
+    <i name="e_wo_entrp">     -6.66674481 </i>
+    <i name="e_0_energy">     -6.66674481 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="diag">    0.22    0.22</time>
+   <time name="diis">    0.84    0.84</time>
+   <time name="orth">    0.00    0.01</time>
+   <time name="total">    1.43    1.43</time>
+   <energy>
+    <i name="e_fr_energy">     -6.64640599 </i>
+    <i name="e_wo_entrp">     -6.64640599 </i>
+    <i name="e_0_energy">     -6.64640599 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="diag">    0.22    0.22</time>
+   <time name="diis">    0.84    0.85</time>
+   <time name="orth">    0.00    0.01</time>
+   <time name="total">    1.43    1.43</time>
+   <energy>
+    <i name="e_fr_energy">     -6.63962065 </i>
+    <i name="e_wo_entrp">     -6.63962065 </i>
+    <i name="e_0_energy">     -6.63962065 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="diag">    0.22    0.22</time>
+   <time name="diis">    0.74    0.74</time>
+   <time name="orth">    0.01    0.01</time>
+   <time name="total">    1.32    1.33</time>
+   <energy>
+    <i name="e_fr_energy">     -6.63943941 </i>
+    <i name="e_wo_entrp">     -6.63943941 </i>
+    <i name="e_0_energy">     -6.63943941 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="diag">    0.22    0.22</time>
+   <time name="diis">    0.55    0.55</time>
+   <time name="orth">    0.00    0.01</time>
+   <time name="total">    1.13    1.14</time>
+   <energy>
+    <i name="e_fr_energy">     -6.63931743 </i>
+    <i name="e_wo_entrp">     -6.63931743 </i>
+    <i name="e_0_energy">     -6.63931743 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="diag">    0.22    0.22</time>
+   <time name="diis">    0.49    0.49</time>
+   <time name="orth">    0.01    0.01</time>
+   <time name="total">    0.98    0.98</time>
+   <energy>
+    <i name="alphaZ">      1.64830245 </i>
+    <i name="ewald">   -180.18879680 </i>
+    <i name="hartreedc">    -27.86212245 </i>
+    <i name="XCdc">    -18.14826582 </i>
+    <i name="pawpsdc">     68.70486840 </i>
+    <i name="pawaedc">    -33.59041907 </i>
+    <i name="eentropy">      0.00000000 </i>
+    <i name="bandstr">    -23.33560143 </i>
+    <i name="atom">    206.13270273 </i>
+    <i name="e_fr_energy">     -6.63933198 </i>
+    <i name="e_wo_entrp">     -6.63933198 </i>
+    <i name="e_0_energy">     -6.63933198 </i>
+   </energy>
+  </scstep>
+  <structure>
+   <crystal>
+    <varray name="basis" >
+     <v>       4.87039159      -0.00000000       0.00000000 </v>
+     <v>       2.43519579       4.21788460       0.00000057 </v>
+     <v>      -0.00000000      -2.81192000       3.97665854 </v>
+    </varray>
+    <i name="volume">     81.69150873 </i>
+    <varray name="rec_basis" >
+     <v>       0.20532230      -0.11854282      -0.08382237 </v>
+     <v>       0.00000000       0.23708565       0.16764474 </v>
+     <v>      -0.00000000      -0.00000003       0.25146738 </v>
+    </varray>
+   </crystal>
+   <varray name="positions" >
+    <v>      -0.00000000       0.00000000       0.00000000 </v>
+    <v>       0.75000000       0.50000000       0.75000000 </v>
+   </varray>
+  </structure>
+  <varray name="forces" >
+   <v>       0.00000000       0.00000000       0.00000000 </v>
+   <v>      -0.00000000      -0.00000000      -0.00000000 </v>
+  </varray>
+  <varray name="stress" >
+   <v>       9.79119873       0.00000000      -0.00000000 </v>
+   <v>      -0.00000000       9.79120691       0.00000889 </v>
+   <v>       0.00000000       0.00000889       9.79120284 </v>
+  </varray>
+  <energy>
+   <i name="e_fr_energy">     -6.63933198 </i>
+   <i name="e_wo_entrp">     -6.63933198 </i>
+   <i name="e_0_energy">      0.00000000 </i>
+  </energy>
+  <time name="totalsc">   10.14   10.20</time>
+ </calculation>
+ <calculation>
+  <scstep>
+   <time name="dav">    1.07    1.07</time>
+   <time name="total">    1.42    1.43</time>
+   <energy>
+    <i name="alphaZ">      1.48270681 </i>
+    <i name="ewald">   -173.94044567 </i>
+    <i name="hartreedc">    -26.90563017 </i>
+    <i name="XCdc">    -18.65377295 </i>
+    <i name="pawpsdc">     68.74389423 </i>
+    <i name="pawaedc">    -33.63026815 </i>
+    <i name="eentropy">      0.00000000 </i>
+    <i name="bandstr">    -29.98700395 </i>
+    <i name="atom">    206.13270273 </i>
+    <i name="e_fr_energy">     -6.75781712 </i>
+    <i name="e_wo_entrp">     -6.75781712 </i>
+    <i name="e_0_energy">     -6.75781712 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="diag">    0.22    0.22</time>
+   <time name="diis">    0.84    0.84</time>
+   <time name="orth">    0.00    0.01</time>
+   <time name="total">    1.42    1.42</time>
+   <energy>
+    <i name="e_fr_energy">     -6.67375315 </i>
+    <i name="e_wo_entrp">     -6.67375315 </i>
+    <i name="e_0_energy">     -6.67375315 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="diag">    0.22    0.22</time>
+   <time name="diis">    0.84    0.84</time>
+   <time name="orth">    0.01    0.01</time>
+   <time name="total">    1.42    1.42</time>
+   <energy>
+    <i name="e_fr_energy">     -6.63939901 </i>
+    <i name="e_wo_entrp">     -6.63939901 </i>
+    <i name="e_0_energy">     -6.63939901 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="diag">    0.22    0.22</time>
+   <time name="diis">    0.84    0.84</time>
+   <time name="orth">    0.00    0.01</time>
+   <time name="total">    1.42    1.43</time>
+   <energy>
+    <i name="e_fr_energy">     -6.63912394 </i>
+    <i name="e_wo_entrp">     -6.63912394 </i>
+    <i name="e_0_energy">     -6.63912394 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="diag">    0.22    0.22</time>
+   <time name="diis">    0.64    0.64</time>
+   <time name="orth">    0.01    0.01</time>
+   <time name="total">    1.23    1.23</time>
+   <energy>
+    <i name="e_fr_energy">     -6.63897824 </i>
+    <i name="e_wo_entrp">     -6.63897824 </i>
+    <i name="e_0_energy">     -6.63897824 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="diag">    0.22    0.22</time>
+   <time name="diis">    0.55    0.55</time>
+   <time name="orth">    0.00    0.01</time>
+   <time name="total">    1.04    1.04</time>
+   <energy>
+    <i name="alphaZ">      1.48270681 </i>
+    <i name="ewald">   -173.94044567 </i>
+    <i name="hartreedc">    -30.21655442 </i>
+    <i name="XCdc">    -18.47135067 </i>
+    <i name="pawpsdc">     68.12896395 </i>
+    <i name="pawaedc">    -32.99645010 </i>
+    <i name="eentropy">      0.00000000 </i>
+    <i name="bandstr">    -26.75861221 </i>
+    <i name="atom">    206.13270273 </i>
+    <i name="e_fr_energy">     -6.63903958 </i>
+    <i name="e_wo_entrp">     -6.63903958 </i>
+    <i name="e_0_energy">     -6.63903958 </i>
+   </energy>
+  </scstep>
+  <structure>
+   <crystal>
+    <varray name="basis" >
+     <v>       5.04534750      -0.00000000       0.00000000 </v>
+     <v>       2.52267375       4.36940100       0.00000067 </v>
+     <v>      -0.00000000      -2.91293075       4.11950944 </v>
+    </varray>
+    <i name="volume">     90.81519869 </i>
+    <varray name="rec_basis" >
+     <v>       0.19820240      -0.11443215      -0.08091568 </v>
+     <v>       0.00000000       0.22886430       0.16183137 </v>
+     <v>      -0.00000000      -0.00000004       0.24274732 </v>
+    </varray>
+   </crystal>
+   <varray name="positions" >
+    <v>      -0.00000000       0.00000000       0.00000000 </v>
+    <v>       0.75000000       0.50000000       0.75000000 </v>
+   </varray>
+  </structure>
+  <varray name="forces" >
+   <v>       0.00000000      -0.00000000       0.00000000 </v>
+   <v>      -0.00000000       0.00000000      -0.00000000 </v>
+  </varray>
+  <varray name="stress" >
+   <v>      -3.90647364       0.00000000      -0.00000000 </v>
+   <v>       0.00000000      -3.90647703      -0.00000368 </v>
+   <v>       0.00000000      -0.00000368      -3.90647534 </v>
+  </varray>
+  <energy>
+   <i name="e_fr_energy">     -6.63903958 </i>
+   <i name="e_wo_entrp">     -6.63903958 </i>
+   <i name="e_0_energy">      0.00000000 </i>
+  </energy>
+  <time name="totalsc">   10.31   10.32</time>
+ </calculation>
+ <calculation>
+  <scstep>
+   <time name="dav">    1.07    1.07</time>
+   <time name="total">    1.43    1.43</time>
+   <energy>
+    <i name="alphaZ">      1.53112822 </i>
+    <i name="ewald">   -175.81368301 </i>
+    <i name="hartreedc">    -30.53088465 </i>
+    <i name="XCdc">    -18.32186582 </i>
+    <i name="pawpsdc">     68.15255360 </i>
+    <i name="pawaedc">    -33.02071512 </i>
+    <i name="eentropy">      0.00000000 </i>
+    <i name="bandstr">    -24.79161996 </i>
+    <i name="atom">    206.13270273 </i>
+    <i name="e_fr_energy">     -6.66238400 </i>
+    <i name="e_wo_entrp">     -6.66238400 </i>
+    <i name="e_0_energy">     -6.66238400 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="diag">    0.22    0.22</time>
+   <time name="diis">    0.84    0.84</time>
+   <time name="orth">    0.00    0.01</time>
+   <time name="total">    1.42    1.42</time>
+   <energy>
+    <i name="e_fr_energy">     -6.65178092 </i>
+    <i name="e_wo_entrp">     -6.65178092 </i>
+    <i name="e_0_energy">     -6.65178092 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="diag">    0.22    0.22</time>
+   <time name="diis">    0.84    0.84</time>
+   <time name="orth">    0.00    0.01</time>
+   <time name="total">    1.42    1.42</time>
+   <energy>
+    <i name="e_fr_energy">     -6.64591420 </i>
+    <i name="e_wo_entrp">     -6.64591420 </i>
+    <i name="e_0_energy">     -6.64591420 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="diag">    0.22    0.22</time>
+   <time name="diis">    0.64    0.64</time>
+   <time name="orth">    0.00    0.01</time>
+   <time name="total">    1.23    1.23</time>
+   <energy>
+    <i name="e_fr_energy">     -6.64602230 </i>
+    <i name="e_wo_entrp">     -6.64602230 </i>
+    <i name="e_0_energy">     -6.64602230 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="diag">    0.22    0.22</time>
+   <time name="diis">    0.51    0.51</time>
+   <time name="orth">    0.00    0.01</time>
+   <time name="total">    1.09    1.09</time>
+   <energy>
+    <i name="e_fr_energy">     -6.64614453 </i>
+    <i name="e_wo_entrp">     -6.64614453 </i>
+    <i name="e_0_energy">     -6.64614453 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="diag">    0.22    0.22</time>
+   <time name="diis">    0.41    0.41</time>
+   <time name="orth">    0.00    0.01</time>
+   <time name="total">    0.90    0.90</time>
+   <energy>
+    <i name="alphaZ">      1.53112822 </i>
+    <i name="ewald">   -175.81368301 </i>
+    <i name="hartreedc">    -29.48977915 </i>
+    <i name="XCdc">    -18.37532748 </i>
+    <i name="pawpsdc">     68.33646379 </i>
+    <i name="pawaedc">    -33.21018034 </i>
+    <i name="eentropy">      0.00000000 </i>
+    <i name="bandstr">    -25.75747030 </i>
+    <i name="atom">    206.13270273 </i>
+    <i name="e_fr_energy">     -6.64614553 </i>
+    <i name="e_wo_entrp">     -6.64614553 </i>
+    <i name="e_0_energy">     -6.64614553 </i>
+   </energy>
+  </scstep>
+  <structure>
+   <crystal>
+    <varray name="basis" >
+     <v>       4.99159099      -0.00000000       0.00000000 </v>
+     <v>       2.49579549       4.32284645       0.00000064 </v>
+     <v>      -0.00000000      -2.88189444       4.07561743 </v>
+    </varray>
+    <i name="volume">     87.94319863 </i>
+    <varray name="rec_basis" >
+     <v>       0.20033693      -0.11566452      -0.08178710 </v>
+     <v>       0.00000000       0.23132903       0.16357420 </v>
+     <v>      -0.00000000      -0.00000004       0.24536157 </v>
+    </varray>
+   </crystal>
+   <varray name="positions" >
+    <v>      -0.00000000       0.00000000       0.00000000 </v>
+    <v>       0.75000000       0.50000000       0.75000000 </v>
+   </varray>
+  </structure>
+  <varray name="forces" >
+   <v>       0.00000000       0.00000000      -0.00000000 </v>
+   <v>      -0.00000000      -0.00000000       0.00000000 </v>
+  </varray>
+  <varray name="stress" >
+   <v>       0.14129697       0.00000000       0.00000000 </v>
+   <v>       0.00000000       0.14129709       0.00000013 </v>
+   <v>       0.00000000       0.00000013       0.14129703 </v>
+  </varray>
+  <energy>
+   <i name="e_fr_energy">     -6.64614553 </i>
+   <i name="e_wo_entrp">     -6.64614553 </i>
+   <i name="e_0_energy">      0.00000000 </i>
+  </energy>
+  <time name="totalsc">    9.70    9.71</time>
+  <eigenvalues>
+   <array>
+    <dimension dim="1">band</dimension>
+    <dimension dim="2">kpoint</dimension>
+    <dimension dim="3">spin</dimension>
+    <field>eigene</field>
+    <field>occ</field>
+    <set>
+     <set comment="spin 1">
+      <set comment="kpoint 1">
+       <r>   -7.8606    1.0000 </r>
+       <r>   -2.5809    1.0000 </r>
+       <r>    0.3711    1.0000 </r>
+       <r>    0.3711    1.0000 </r>
+       <r>    0.3711    1.0000 </r>
+       <r>    2.1323    0.0000 </r>
+       <r>    2.1323    0.0000 </r>
+       <r>    2.1323    0.0000 </r>
+       <r>    4.9292    0.0000 </r>
+      </set>
+      <set comment="kpoint 2">
+       <r>   -7.7345    1.0000 </r>
+       <r>   -3.0514    1.0000 </r>
+       <r>    0.2008    1.0000 </r>
+       <r>    0.2008    1.0000 </r>
+       <r>    0.3099    1.0000 </r>
+       <r>    2.3797    0.0000 </r>
+       <r>    2.3797    0.0000 </r>
+       <r>    2.4243    0.0000 </r>
+       <r>    5.5425    0.0000 </r>
+      </set>
+      <set comment="kpoint 3">
+       <r>   -7.3855    1.0000 </r>
+       <r>   -3.9878    1.0000 </r>
+       <r>   -0.0758    1.0000 </r>
+       <r>   -0.0758    1.0000 </r>
+       <r>    0.0091    1.0158 </r>
+       <r>    2.7614    0.0000 </r>
+       <r>    2.7614    0.0000 </r>
+       <r>    3.4433    0.0000 </r>
+       <r>    6.6369    0.0000 </r>
+      </set>
+      <set comment="kpoint 4">
+       <r>   -6.9717    1.0000 </r>
+       <r>   -4.7740    1.0000 </r>
+       <r>   -0.2434    1.0000 </r>
+       <r>   -0.2433    1.0000 </r>
+       <r>   -0.2244    1.0157 </r>
+       <r>    2.9237    0.0000 </r>
+       <r>    2.9237    0.0000 </r>
+       <r>    4.6557    0.0000 </r>
+       <r>    6.3955    0.0000 </r>
+      </set>
+      <set comment="kpoint 5">
+       <r>   -7.6909    1.0000 </r>
+       <r>   -3.1709    1.0000 </r>
+       <r>   -0.0607    1.0000 </r>
+       <r>   -0.0607    1.0000 </r>
+       <r>    0.8940    1.0150 </r>
+       <r>    1.7297    0.0000 </r>
+       <r>    2.7601    0.0000 </r>
+       <r>    2.7601    0.0000 </r>
+       <r>    5.9455    0.0000 </r>
+      </set>
+      <set comment="kpoint 6">
+       <r>   -7.5307    1.0000 </r>
+       <r>   -3.6161    1.0000 </r>
+       <r>   -0.5290    1.0000 </r>
+       <r>    0.1395    1.0000 </r>
+       <r>    0.6743    1.0333 </r>
+       <r>    2.4298    0.0000 </r>
+       <r>    2.5117    0.0000 </r>
+       <r>    3.1808    0.0000 </r>
+       <r>    6.1251    0.0000 </r>
+      </set>
+      <set comment="kpoint 7">
+       <r>   -7.1319    1.0000 </r>
+       <r>   -4.4394    1.0000 </r>
+       <r>   -1.0205    1.0000 </r>
+       <r>   -0.1502    1.0000 </r>
+       <r>    0.7486    1.0708 </r>
+       <r>    2.8917    0.0000 </r>
+       <r>    2.9400    0.0000 </r>
+       <r>    3.7588    0.0000 </r>
+       <r>    6.2499    0.0000 </r>
+      </set>
+      <set comment="kpoint 8">
+       <r>   -6.7826    1.0000 </r>
+       <r>   -5.0008    1.0000 </r>
+       <r>   -1.1570    1.0000 </r>
+       <r>   -0.3911    1.0000 </r>
+       <r>    0.7354    1.0803 </r>
+       <r>    2.8820    0.0000 </r>
+       <r>    3.2495    0.0000 </r>
+       <r>    4.5321    0.0000 </r>
+       <r>    6.2579    0.0000 </r>
+      </set>
+      <set comment="kpoint 9">
+       <r>   -6.9794    1.0000 </r>
+       <r>   -4.6981    1.0000 </r>
+       <r>   -0.9652    1.0000 </r>
+       <r>   -0.4652    1.0000 </r>
+       <r>    0.8423    1.0328 </r>
+       <r>    2.5610    0.0000 </r>
+       <r>    3.3803    0.0000 </r>
+       <r>    4.0187    0.0000 </r>
+       <r>    6.4141    0.0000 </r>
+      </set>
+      <set comment="kpoint 10">
+       <r>   -7.4087    1.0000 </r>
+       <r>   -3.8876    1.0000 </r>
+       <r>   -0.5132    1.0000 </r>
+       <r>   -0.3422    1.0000 </r>
+       <r>    1.0160    0.9770 </r>
+       <r>    1.9237    0.0000 </r>
+       <r>    3.2261    0.0000 </r>
+       <r>    3.3737    0.0000 </r>
+       <r>    5.7033    0.0000 </r>
+      </set>
+      <set comment="kpoint 11">
+       <r>   -7.1948    1.0000 </r>
+       <r>   -4.2789    1.0000 </r>
+       <r>   -0.6469    1.0000 </r>
+       <r>   -0.6469    1.0000 </r>
+       <r>    1.2147    0.3625 </r>
+       <r>    1.4550    0.0000 </r>
+       <r>    3.8936    0.0000 </r>
+       <r>    3.8936    0.0000 </r>
+       <r>    5.2682    0.0000 </r>
+      </set>
+      <set comment="kpoint 12">
+       <r>   -6.7112    1.0000 </r>
+       <r>   -5.0327    1.0000 </r>
+       <r>   -1.5458    1.0000 </r>
+       <r>   -0.4632    1.0000 </r>
+       <r>    1.1631    0.3931 </r>
+       <r>    3.3030    0.0000 </r>
+       <r>    3.5639    0.0000 </r>
+       <r>    3.7066    0.0000 </r>
+       <r>    6.4338    0.0000 </r>
+      </set>
+      <set comment="kpoint 13">
+       <r>   -6.4412    1.0000 </r>
+       <r>   -5.3709    1.0000 </r>
+       <r>   -1.5341    1.0000 </r>
+       <r>   -0.7204    1.0000 </r>
+       <r>    1.2015    0.1774 </r>
+       <r>    2.8244    0.0000 </r>
+       <r>    4.0138    0.0000 </r>
+       <r>    4.0862    0.0000 </r>
+       <r>    5.7042    0.0000 </r>
+      </set>
+      <set comment="kpoint 14">
+       <r>   -6.7889    1.0000 </r>
+       <r>   -4.9219    1.0000 </r>
+       <r>   -1.1048    1.0000 </r>
+       <r>   -0.7906    1.0000 </r>
+       <r>    1.2522    0.1173 </r>
+       <r>    1.8047    0.0000 </r>
+       <r>    4.0652    0.0000 </r>
+       <r>    4.2406    0.0000 </r>
+       <r>    6.0011    0.0000 </r>
+      </set>
+      <set comment="kpoint 15">
+       <r>   -6.4124    1.0000 </r>
+       <r>   -5.4102    1.0000 </r>
+       <r>   -0.9791    1.0000 </r>
+       <r>   -0.9791    1.0000 </r>
+       <r>    1.0567    0.6439 </r>
+       <r>    1.2765    0.0000 </r>
+       <r>    4.8939    0.0000 </r>
+       <r>    4.8939    0.0000 </r>
+       <r>    6.0805    0.0000 </r>
+      </set>
+      <set comment="kpoint 16">
+       <r>   -6.0251    1.0000 </r>
+       <r>   -5.8312    1.0000 </r>
+       <r>   -1.3152    1.0000 </r>
+       <r>   -0.9524    1.0000 </r>
+       <r>    1.1618    0.2150 </r>
+       <r>    1.7644    0.0000 </r>
+       <r>    4.6792    0.0000 </r>
+       <r>    4.8198    0.0000 </r>
+       <r>    6.1589    0.0000 </r>
+      </set>
+      <set comment="kpoint 17">
+       <r>   -7.0670    1.0000 </r>
+       <r>   -4.5098    1.0000 </r>
+       <r>   -1.0908    1.0000 </r>
+       <r>   -0.5078    1.0000 </r>
+       <r>    1.3789    0.2223 </r>
+       <r>    2.0258    0.0000 </r>
+       <r>    3.5667    0.0000 </r>
+       <r>    3.7560    0.0000 </r>
+       <r>    5.9038    0.0000 </r>
+      </set>
+      <set comment="kpoint 18">
+       <r>   -6.6382    1.0000 </r>
+       <r>   -5.1337    1.0000 </r>
+       <r>   -1.4343    1.0000 </r>
+       <r>   -0.7172    1.0000 </r>
+       <r>    1.4297    0.0995 </r>
+       <r>    2.6438    0.0000 </r>
+       <r>    3.6856    0.0000 </r>
+       <r>    4.0539    0.0000 </r>
+       <r>    5.9919    0.0000 </r>
+      </set>
+      <set comment="kpoint 19">
+       <r>   -6.2029    1.0000 </r>
+       <r>   -5.6258    1.0000 </r>
+       <r>   -1.5405    1.0000 </r>
+       <r>   -1.0522    1.0000 </r>
+       <r>    1.7790   -0.0260 </r>
+       <r>    2.7711    0.0000 </r>
+       <r>    3.7947    0.0000 </r>
+       <r>    3.9329    0.0000 </r>
+       <r>    5.9184    0.0000 </r>
+      </set>
+      <set comment="kpoint 20">
+       <r>   -6.3514    1.0000 </r>
+       <r>   -5.4667    1.0000 </r>
+       <r>   -1.3000    1.0000 </r>
+       <r>   -1.0877    1.0000 </r>
+       <r>    1.7704   -0.0833 </r>
+       <r>    1.8023    0.0000 </r>
+       <r>    3.9839    0.0000 </r>
+       <r>    4.5775    0.0000 </r>
+       <r>    6.5537    0.0000 </r>
+      </set>
+     </set>
+     <set comment="spin 2">
+      <set comment="kpoint 1">
+       <r>   -7.8606    1.0000 </r>
+       <r>   -2.5809    1.0000 </r>
+       <r>    0.3711    1.0000 </r>
+       <r>    0.3711    1.0000 </r>
+       <r>    0.3711    1.0000 </r>
+       <r>    2.1323    0.0000 </r>
+       <r>    2.1323    0.0000 </r>
+       <r>    2.1323    0.0000 </r>
+       <r>    4.9292    0.0000 </r>
+      </set>
+      <set comment="kpoint 2">
+       <r>   -7.7345    1.0000 </r>
+       <r>   -3.0514    1.0000 </r>
+       <r>    0.2008    1.0000 </r>
+       <r>    0.2008    1.0000 </r>
+       <r>    0.3099    1.0000 </r>
+       <r>    2.3797    0.0000 </r>
+       <r>    2.3797    0.0000 </r>
+       <r>    2.4243    0.0000 </r>
+       <r>    6.6766    0.0000 </r>
+      </set>
+      <set comment="kpoint 3">
+       <r>   -7.3855    1.0000 </r>
+       <r>   -3.9878    1.0000 </r>
+       <r>   -0.0758    1.0000 </r>
+       <r>   -0.0758    1.0000 </r>
+       <r>    0.0091    1.0158 </r>
+       <r>    2.7614    0.0000 </r>
+       <r>    2.7614    0.0000 </r>
+       <r>    3.4433    0.0000 </r>
+       <r>    6.6369    0.0000 </r>
+      </set>
+      <set comment="kpoint 4">
+       <r>   -6.9717    1.0000 </r>
+       <r>   -4.7740    1.0000 </r>
+       <r>   -0.2434    1.0000 </r>
+       <r>   -0.2433    1.0000 </r>
+       <r>   -0.2244    1.0157 </r>
+       <r>    2.9237    0.0000 </r>
+       <r>    2.9237    0.0000 </r>
+       <r>    4.6557    0.0000 </r>
+       <r>    6.3954    0.0000 </r>
+      </set>
+      <set comment="kpoint 5">
+       <r>   -7.6909    1.0000 </r>
+       <r>   -3.1709    1.0000 </r>
+       <r>   -0.0607    1.0000 </r>
+       <r>   -0.0607    1.0000 </r>
+       <r>    0.8940    1.0150 </r>
+       <r>    1.7297    0.0000 </r>
+       <r>    2.7601    0.0000 </r>
+       <r>    2.7601    0.0000 </r>
+       <r>    5.9455    0.0000 </r>
+      </set>
+      <set comment="kpoint 6">
+       <r>   -7.5307    1.0000 </r>
+       <r>   -3.6161    1.0000 </r>
+       <r>   -0.5290    1.0000 </r>
+       <r>    0.1395    1.0000 </r>
+       <r>    0.6743    1.0333 </r>
+       <r>    2.4298    0.0000 </r>
+       <r>    2.5117    0.0000 </r>
+       <r>    3.1808    0.0000 </r>
+       <r>    6.1251    0.0000 </r>
+      </set>
+      <set comment="kpoint 7">
+       <r>   -7.1319    1.0000 </r>
+       <r>   -4.4394    1.0000 </r>
+       <r>   -1.0205    1.0000 </r>
+       <r>   -0.1502    1.0000 </r>
+       <r>    0.7486    1.0708 </r>
+       <r>    2.8917    0.0000 </r>
+       <r>    2.9400    0.0000 </r>
+       <r>    3.7588    0.0000 </r>
+       <r>    6.2499    0.0000 </r>
+      </set>
+      <set comment="kpoint 8">
+       <r>   -6.7826    1.0000 </r>
+       <r>   -5.0008    1.0000 </r>
+       <r>   -1.1570    1.0000 </r>
+       <r>   -0.3911    1.0000 </r>
+       <r>    0.7354    1.0803 </r>
+       <r>    2.8820    0.0000 </r>
+       <r>    3.2495    0.0000 </r>
+       <r>    4.5321    0.0000 </r>
+       <r>    6.2579    0.0000 </r>
+      </set>
+      <set comment="kpoint 9">
+       <r>   -6.9794    1.0000 </r>
+       <r>   -4.6981    1.0000 </r>
+       <r>   -0.9652    1.0000 </r>
+       <r>   -0.4652    1.0000 </r>
+       <r>    0.8423    1.0328 </r>
+       <r>    2.5610    0.0000 </r>
+       <r>    3.3803    0.0000 </r>
+       <r>    4.0187    0.0000 </r>
+       <r>    6.4141    0.0000 </r>
+      </set>
+      <set comment="kpoint 10">
+       <r>   -7.4087    1.0000 </r>
+       <r>   -3.8876    1.0000 </r>
+       <r>   -0.5132    1.0000 </r>
+       <r>   -0.3422    1.0000 </r>
+       <r>    1.0160    0.9770 </r>
+       <r>    1.9237    0.0000 </r>
+       <r>    3.2261    0.0000 </r>
+       <r>    3.3737    0.0000 </r>
+       <r>    5.7033    0.0000 </r>
+      </set>
+      <set comment="kpoint 11">
+       <r>   -7.1948    1.0000 </r>
+       <r>   -4.2789    1.0000 </r>
+       <r>   -0.6469    1.0000 </r>
+       <r>   -0.6469    1.0000 </r>
+       <r>    1.2147    0.3625 </r>
+       <r>    1.4550    0.0000 </r>
+       <r>    3.8936    0.0000 </r>
+       <r>    3.8936    0.0000 </r>
+       <r>    5.2682    0.0000 </r>
+      </set>
+      <set comment="kpoint 12">
+       <r>   -6.7112    1.0000 </r>
+       <r>   -5.0327    1.0000 </r>
+       <r>   -1.5458    1.0000 </r>
+       <r>   -0.4632    1.0000 </r>
+       <r>    1.1631    0.3931 </r>
+       <r>    3.3030    0.0000 </r>
+       <r>    3.5639    0.0000 </r>
+       <r>    3.7066    0.0000 </r>
+       <r>    6.4343    0.0000 </r>
+      </set>
+      <set comment="kpoint 13">
+       <r>   -6.4412    1.0000 </r>
+       <r>   -5.3709    1.0000 </r>
+       <r>   -1.5341    1.0000 </r>
+       <r>   -0.7204    1.0000 </r>
+       <r>    1.2015    0.1774 </r>
+       <r>    2.8244    0.0000 </r>
+       <r>    4.0138    0.0000 </r>
+       <r>    4.0862    0.0000 </r>
+       <r>    5.7042    0.0000 </r>
+      </set>
+      <set comment="kpoint 14">
+       <r>   -6.7889    1.0000 </r>
+       <r>   -4.9219    1.0000 </r>
+       <r>   -1.1048    1.0000 </r>
+       <r>   -0.7906    1.0000 </r>
+       <r>    1.2522    0.1173 </r>
+       <r>    1.8047    0.0000 </r>
+       <r>    4.0652    0.0000 </r>
+       <r>    4.2406    0.0000 </r>
+       <r>    6.0011    0.0000 </r>
+      </set>
+      <set comment="kpoint 15">
+       <r>   -6.4124    1.0000 </r>
+       <r>   -5.4102    1.0000 </r>
+       <r>   -0.9791    1.0000 </r>
+       <r>   -0.9791    1.0000 </r>
+       <r>    1.0567    0.6439 </r>
+       <r>    1.2765    0.0000 </r>
+       <r>    4.8939    0.0000 </r>
+       <r>    4.8939    0.0000 </r>
+       <r>    6.0805    0.0000 </r>
+      </set>
+      <set comment="kpoint 16">
+       <r>   -6.0251    1.0000 </r>
+       <r>   -5.8312    1.0000 </r>
+       <r>   -1.3152    1.0000 </r>
+       <r>   -0.9524    1.0000 </r>
+       <r>    1.1618    0.2150 </r>
+       <r>    1.7644    0.0000 </r>
+       <r>    4.6792    0.0000 </r>
+       <r>    4.8198    0.0000 </r>
+       <r>    6.1589    0.0000 </r>
+      </set>
+      <set comment="kpoint 17">
+       <r>   -7.0670    1.0000 </r>
+       <r>   -4.5098    1.0000 </r>
+       <r>   -1.0908    1.0000 </r>
+       <r>   -0.5078    1.0000 </r>
+       <r>    1.3789    0.2223 </r>
+       <r>    2.0258    0.0000 </r>
+       <r>    3.5667    0.0000 </r>
+       <r>    3.7560    0.0000 </r>
+       <r>    5.9038    0.0000 </r>
+      </set>
+      <set comment="kpoint 18">
+       <r>   -6.6382    1.0000 </r>
+       <r>   -5.1337    1.0000 </r>
+       <r>   -1.4343    1.0000 </r>
+       <r>   -0.7172    1.0000 </r>
+       <r>    1.4297    0.0995 </r>
+       <r>    2.6438    0.0000 </r>
+       <r>    3.6856    0.0000 </r>
+       <r>    4.0539    0.0000 </r>
+       <r>    5.9919    0.0000 </r>
+      </set>
+      <set comment="kpoint 19">
+       <r>   -6.2029    1.0000 </r>
+       <r>   -5.6258    1.0000 </r>
+       <r>   -1.5405    1.0000 </r>
+       <r>   -1.0522    1.0000 </r>
+       <r>    1.7790   -0.0260 </r>
+       <r>    2.7711    0.0000 </r>
+       <r>    3.7947    0.0000 </r>
+       <r>    3.9329    0.0000 </r>
+       <r>    5.9184    0.0000 </r>
+      </set>
+      <set comment="kpoint 20">
+       <r>   -6.3514    1.0000 </r>
+       <r>   -5.4667    1.0000 </r>
+       <r>   -1.3000    1.0000 </r>
+       <r>   -1.0877    1.0000 </r>
+       <r>    1.7704   -0.0833 </r>
+       <r>    1.8023    0.0000 </r>
+       <r>    3.9839    0.0000 </r>
+       <r>    4.5775    0.0000 </r>
+       <r>    6.5537    0.0000 </r>
+      </set>
+     </set>
+    </set>
+   </array>
+  </eigenvalues>
+  <separator name="orbital magnetization" >
+   <v name="MAGDIPOLOUT">      0.00000000      0.00000000      0.00000000</v>
+  </separator>
+  <dos>
+   <i name="efermi">      1.17540521 </i>
+   <total>
+    <array>
+     <dimension dim="1">gridpoints</dimension>
+     <dimension dim="2">spin</dimension>
+     <field>energy</field>
+     <field>total</field>
+     <field>integrated</field>
+     <set>
+      <set comment="spin 1">
+       <r>    -8.5874     0.0000     0.0000 </r>
+       <r>    -8.5341     0.0000     0.0000 </r>
+       <r>    -8.4808     0.0000     0.0000 </r>
+       <r>    -8.4275     0.0000     0.0000 </r>
+       <r>    -8.3742     0.0000     0.0000 </r>
+       <r>    -8.3209     0.0000     0.0000 </r>
+       <r>    -8.2676     0.0000     0.0000 </r>
+       <r>    -8.2143     0.0000     0.0000 </r>
+       <r>    -8.1610     0.0000     0.0000 </r>
+       <r>    -8.1077     0.0000     0.0000 </r>
+       <r>    -8.0544     0.0000     0.0000 </r>
+       <r>    -8.0011     0.0000     0.0000 </r>
+       <r>    -7.9478     0.0000     0.0000 </r>
+       <r>    -7.8945     0.0000     0.0000 </r>
+       <r>    -7.8412     0.0039     0.0000 </r>
+       <r>    -7.7879     0.0554     0.0013 </r>
+       <r>    -7.7346     0.1665     0.0070 </r>
+       <r>    -7.6813     0.1890     0.0176 </r>
+       <r>    -7.6280     0.2232     0.0286 </r>
+       <r>    -7.5747     0.2668     0.0416 </r>
+       <r>    -7.5214     0.3194     0.0572 </r>
+       <r>    -7.4681     0.3584     0.0754 </r>
+       <r>    -7.4148     0.3703     0.0949 </r>
+       <r>    -7.3615     0.4046     0.1156 </r>
+       <r>    -7.3081     0.4402     0.1381 </r>
+       <r>    -7.2548     0.4781     0.1625 </r>
+       <r>    -7.2015     0.5183     0.1891 </r>
+       <r>    -7.1482     0.5619     0.2179 </r>
+       <r>    -7.0949     0.6080     0.2490 </r>
+       <r>    -7.0416     0.6721     0.2831 </r>
+       <r>    -6.9883     0.7430     0.3208 </r>
+       <r>    -6.9350     0.9145     0.3658 </r>
+       <r>    -6.8817     0.9835     0.4166 </r>
+       <r>    -6.8284     1.0095     0.4699 </r>
+       <r>    -6.7751     0.9337     0.5230 </r>
+       <r>    -6.7218     0.9387     0.5727 </r>
+       <r>    -6.6685     0.9545     0.6234 </r>
+       <r>    -6.6152     0.8974     0.6730 </r>
+       <r>    -6.5619     0.8299     0.7190 </r>
+       <r>    -6.5086     0.7692     0.7616 </r>
+       <r>    -6.4553     0.7155     0.8012 </r>
+       <r>    -6.4020     0.7303     0.8391 </r>
+       <r>    -6.3487     0.7810     0.8796 </r>
+       <r>    -6.2954     0.7062     0.9195 </r>
+       <r>    -6.2421     0.5901     0.9542 </r>
+       <r>    -6.1888     0.2633     0.9801 </r>
+       <r>    -6.1355     0.1592     0.9913 </r>
+       <r>    -6.0822     0.0775     0.9975 </r>
+       <r>    -6.0289     0.0184     0.9999 </r>
+       <r>    -5.9756     0.0000     1.0000 </r>
+       <r>    -5.9223     0.0000     1.0000 </r>
+       <r>    -5.8690     0.0000     1.0000 </r>
+       <r>    -5.8157     0.0251     1.0003 </r>
+       <r>    -5.7624     0.0738     1.0029 </r>
+       <r>    -5.7091     0.1380     1.0084 </r>
+       <r>    -5.6558     0.2178     1.0179 </r>
+       <r>    -5.6025     0.4957     1.0370 </r>
+       <r>    -5.5492     0.5997     1.0664 </r>
+       <r>    -5.4958     0.6704     1.1004 </r>
+       <r>    -5.4425     0.6663     1.1367 </r>
+       <r>    -5.3892     0.6084     1.1705 </r>
+       <r>    -5.3359     0.6185     1.2027 </r>
+       <r>    -5.2826     0.6561     1.2367 </r>
+       <r>    -5.2293     0.6984     1.2728 </r>
+       <r>    -5.1760     0.7451     1.3112 </r>
+       <r>    -5.1227     0.7959     1.3523 </r>
+       <r>    -5.0694     0.7974     1.3951 </r>
+       <r>    -5.0161     0.7289     1.4359 </r>
+       <r>    -4.9628     0.7753     1.4763 </r>
+       <r>    -4.9095     0.7610     1.5174 </r>
+       <r>    -4.8562     0.7264     1.5572 </r>
+       <r>    -4.8029     0.6683     1.5945 </r>
+       <r>    -4.7496     0.5776     1.6279 </r>
+       <r>    -4.6963     0.5040     1.6565 </r>
+       <r>    -4.6430     0.4639     1.6823 </r>
+       <r>    -4.5897     0.4259     1.7060 </r>
+       <r>    -4.5364     0.3901     1.7277 </r>
+       <r>    -4.4831     0.3541     1.7476 </r>
+       <r>    -4.4298     0.3253     1.7656 </r>
+       <r>    -4.3765     0.3077     1.7825 </r>
+       <r>    -4.3232     0.2916     1.7984 </r>
+       <r>    -4.2699     0.2768     1.8136 </r>
+       <r>    -4.2166     0.2627     1.8279 </r>
+       <r>    -4.1633     0.2490     1.8416 </r>
+       <r>    -4.1100     0.2357     1.8545 </r>
+       <r>    -4.0567     0.2228     1.8667 </r>
+       <r>    -4.0034     0.2103     1.8782 </r>
+       <r>    -3.9501     0.1979     1.8891 </r>
+       <r>    -3.8968     0.1847     1.8993 </r>
+       <r>    -3.8435     0.1680     1.9086 </r>
+       <r>    -3.7902     0.1587     1.9173 </r>
+       <r>    -3.7369     0.1492     1.9255 </r>
+       <r>    -3.6836     0.1395     1.9332 </r>
+       <r>    -3.6302     0.1295     1.9404 </r>
+       <r>    -3.5769     0.1200     1.9470 </r>
+       <r>    -3.5236     0.1112     1.9532 </r>
+       <r>    -3.4703     0.1029     1.9589 </r>
+       <r>    -3.4170     0.0952     1.9642 </r>
+       <r>    -3.3637     0.0881     1.9690 </r>
+       <r>    -3.3104     0.0816     1.9736 </r>
+       <r>    -3.2571     0.0756     1.9777 </r>
+       <r>    -3.2038     0.0702     1.9816 </r>
+       <r>    -3.1505     0.0653     1.9852 </r>
+       <r>    -3.0972     0.0701     1.9888 </r>
+       <r>    -3.0439     0.0475     1.9927 </r>
+       <r>    -2.9906     0.0372     1.9949 </r>
+       <r>    -2.9373     0.0281     1.9967 </r>
+       <r>    -2.8840     0.0203     1.9979 </r>
+       <r>    -2.8307     0.0138     1.9988 </r>
+       <r>    -2.7774     0.0086     1.9994 </r>
+       <r>    -2.7241     0.0045     1.9998 </r>
+       <r>    -2.6708     0.0018     1.9999 </r>
+       <r>    -2.6175     0.0003     2.0000 </r>
+       <r>    -2.5642     0.0000     2.0000 </r>
+       <r>    -2.5109     0.0000     2.0000 </r>
+       <r>    -2.4576     0.0000     2.0000 </r>
+       <r>    -2.4043     0.0000     2.0000 </r>
+       <r>    -2.3510     0.0000     2.0000 </r>
+       <r>    -2.2977     0.0000     2.0000 </r>
+       <r>    -2.2444     0.0000     2.0000 </r>
+       <r>    -2.1911     0.0000     2.0000 </r>
+       <r>    -2.1378     0.0000     2.0000 </r>
+       <r>    -2.0845     0.0000     2.0000 </r>
+       <r>    -2.0312     0.0000     2.0000 </r>
+       <r>    -1.9779     0.0000     2.0000 </r>
+       <r>    -1.9246     0.0000     2.0000 </r>
+       <r>    -1.8713     0.0000     2.0000 </r>
+       <r>    -1.8179     0.0000     2.0000 </r>
+       <r>    -1.7646     0.0000     2.0000 </r>
+       <r>    -1.7113     0.0000     2.0000 </r>
+       <r>    -1.6580     0.0000     2.0000 </r>
+       <r>    -1.6047     0.0000     2.0000 </r>
+       <r>    -1.5514     0.0000     2.0000 </r>
+       <r>    -1.4981     1.6633     2.0659 </r>
+       <r>    -1.4448     1.6059     2.1567 </r>
+       <r>    -1.3915     1.3658     2.2342 </r>
+       <r>    -1.3382     1.2554     2.3038 </r>
+       <r>    -1.2849     1.1836     2.3710 </r>
+       <r>    -1.2316     1.1473     2.4331 </r>
+       <r>    -1.1783     1.1152     2.4934 </r>
+       <r>    -1.1250     1.0797     2.5525 </r>
+       <r>    -1.0717     1.5479     2.6129 </r>
+       <r>    -1.0184     1.5259     2.7004 </r>
+       <r>    -0.9651     1.7208     2.7856 </r>
+       <r>    -0.9118     1.5233     2.8695 </r>
+       <r>    -0.8585     1.5008     2.9502 </r>
+       <r>    -0.8052     1.4461     3.0289 </r>
+       <r>    -0.7519     1.4311     3.1052 </r>
+       <r>    -0.6986     1.4822     3.1829 </r>
+       <r>    -0.6453     1.4750     3.2618 </r>
+       <r>    -0.5920     1.4572     3.3400 </r>
+       <r>    -0.5387     1.4301     3.4170 </r>
+       <r>    -0.4854     1.3817     3.4922 </r>
+       <r>    -0.4321     1.3466     3.5642 </r>
+       <r>    -0.3788     1.3498     3.6373 </r>
+       <r>    -0.3255     1.2176     3.7058 </r>
+       <r>    -0.2722     1.0246     3.7660 </r>
+       <r>    -0.2189     0.8174     3.8144 </r>
+       <r>    -0.1656     0.6861     3.8544 </r>
+       <r>    -0.1123     0.5295     3.8869 </r>
+       <r>    -0.0590     0.4431     3.9124 </r>
+       <r>    -0.0057     0.4029     3.9349 </r>
+       <r>     0.0477     0.3710     3.9555 </r>
+       <r>     0.1010     0.3482     3.9747 </r>
+       <r>     0.1543     0.3104     3.9926 </r>
+       <r>     0.2076     0.2385     4.0067 </r>
+       <r>     0.2609     0.1820     4.0178 </r>
+       <r>     0.3142     0.2554     4.0272 </r>
+       <r>     0.3675     0.2130     4.0390 </r>
+       <r>     0.4208     0.2525     4.0514 </r>
+       <r>     0.4741     0.2890     4.0659 </r>
+       <r>     0.5274     0.3222     4.0822 </r>
+       <r>     0.5807     0.3521     4.1001 </r>
+       <r>     0.6340     0.3787     4.1196 </r>
+       <r>     0.6873     0.4038     4.1405 </r>
+       <r>     0.7406     0.5213     4.1637 </r>
+       <r>     0.7939     0.6350     4.1951 </r>
+       <r>     0.8472     0.6498     4.2296 </r>
+       <r>     0.9005     0.6881     4.2653 </r>
+       <r>     0.9538     0.7326     4.3031 </r>
+       <r>     1.0071     0.7817     4.3434 </r>
+       <r>     1.0604     0.8198     4.3857 </r>
+       <r>     1.1137     0.9750     4.4333 </r>
+       <r>     1.1670     1.1282     4.4904 </r>
+       <r>     1.2203     1.4298     4.5591 </r>
+       <r>     1.2736     1.3130     4.6351 </r>
+       <r>     1.3269     1.1841     4.7017 </r>
+       <r>     1.3802     1.0407     4.7611 </r>
+       <r>     1.4335     0.8522     4.8120 </r>
+       <r>     1.4868     0.7937     4.8558 </r>
+       <r>     1.5401     0.7465     4.8968 </r>
+       <r>     1.5934     0.7109     4.9356 </r>
+       <r>     1.6467     0.6869     4.9728 </r>
+       <r>     1.7000     0.6746     5.0091 </r>
+       <r>     1.7533     0.6758     5.0450 </r>
+       <r>     1.8066     0.4233     5.0969 </r>
+       <r>     1.8599     0.4855     5.1211 </r>
+       <r>     1.9133     0.5476     5.1487 </r>
+       <r>     1.9666     0.5072     5.1763 </r>
+       <r>     2.0199     0.5234     5.2037 </r>
+       <r>     2.0732     0.5597     5.2325 </r>
+       <r>     2.1265     0.5952     5.2633 </r>
+       <r>     2.1798     0.6323     5.2960 </r>
+       <r>     2.2331     0.6749     5.3308 </r>
+       <r>     2.2864     0.7230     5.3680 </r>
+       <r>     2.3397     0.7767     5.4080 </r>
+       <r>     2.3930     0.7782     5.4503 </r>
+       <r>     2.4463     0.8179     5.4927 </r>
+       <r>     2.4996     0.8639     5.5375 </r>
+       <r>     2.5529     0.8885     5.5843 </r>
+       <r>     2.6062     0.9868     5.6336 </r>
+       <r>     2.6595     1.3374     5.6931 </r>
+       <r>     2.7128     1.7528     5.7770 </r>
+       <r>     2.7661     1.8271     5.8739 </r>
+       <r>     2.8194     1.5071     5.9615 </r>
+       <r>     2.8727     1.3050     6.0370 </r>
+       <r>     2.9260     0.7621     6.1013 </r>
+       <r>     2.9793     0.7526     6.1414 </r>
+       <r>     3.0326     0.7585     6.1817 </r>
+       <r>     3.0859     0.7649     6.2223 </r>
+       <r>     3.1392     0.7718     6.2633 </r>
+       <r>     3.1925     0.7799     6.3046 </r>
+       <r>     3.2458     0.7949     6.3465 </r>
+       <r>     3.2991     0.8217     6.3902 </r>
+       <r>     3.3524     0.8392     6.4344 </r>
+       <r>     3.4057     0.8846     6.4801 </r>
+       <r>     3.4590     0.9349     6.5286 </r>
+       <r>     3.5123     0.9832     6.5797 </r>
+       <r>     3.5656     1.0296     6.6335 </r>
+       <r>     3.6189     1.1234     6.6908 </r>
+       <r>     3.6722     1.2063     6.7529 </r>
+       <r>     3.7256     1.5161     6.8232 </r>
+       <r>     3.7789     1.7742     6.9170 </r>
+       <r>     3.8322     1.7538     7.0132 </r>
+       <r>     3.8855     1.6764     7.1045 </r>
+       <r>     3.9388     1.7696     7.1940 </r>
+       <r>     3.9921     1.9009     7.2917 </r>
+       <r>     4.0454     2.0814     7.3947 </r>
+       <r>     4.0987     1.6400     7.4962 </r>
+       <r>     4.1520     1.4131     7.5774 </r>
+       <r>     4.2053     1.2177     7.6474 </r>
+       <r>     4.2586     1.0464     7.7077 </r>
+       <r>     4.3119     0.9041     7.7596 </r>
+       <r>     4.3652     0.7766     7.8043 </r>
+       <r>     4.4185     0.6639     7.8426 </r>
+       <r>     4.4718     0.5660     7.8753 </r>
+       <r>     4.5251     0.4829     7.9032 </r>
+       <r>     4.5784     0.4382     7.9286 </r>
+       <r>     4.6317     0.3257     7.9492 </r>
+       <r>     4.6850     0.2656     7.9637 </r>
+       <r>     4.7383     0.2200     7.9766 </r>
+       <r>     4.7916     0.1693     7.9870 </r>
+       <r>     4.8449     0.1537     7.9961 </r>
+       <r>     4.8982     0.0000     8.0000 </r>
+       <r>     4.9515     0.0000     8.0000 </r>
+       <r>     5.0048     0.0005     8.0000 </r>
+       <r>     5.0581     0.0013     8.0001 </r>
+       <r>     5.1114     0.0027     8.0002 </r>
+       <r>     5.1647     0.0045     8.0004 </r>
+       <r>     5.2180     0.0067     8.0006 </r>
+       <r>     5.2713     0.0094     8.0011 </r>
+       <r>     5.3246     0.0155     8.0017 </r>
+       <r>     5.3779     0.0273     8.0028 </r>
+       <r>     5.4312     0.0447     8.0047 </r>
+       <r>     5.4845     0.0678     8.0077 </r>
+       <r>     5.5378     0.0966     8.0121 </r>
+       <r>     5.5912     0.1632     8.0190 </r>
+       <r>     5.6445     0.2383     8.0296 </r>
+       <r>     5.6978     0.3247     8.0446 </r>
+       <r>     5.7511     0.4630     8.0655 </r>
+       <r>     5.8044     0.6562     8.0950 </r>
+       <r>     5.8577     0.9134     8.1366 </r>
+       <r>     5.9110     1.2395     8.1935 </r>
+       <r>     5.9643     1.9257     8.2839 </r>
+       <r>     6.0176     1.8747     8.3871 </r>
+       <r>     6.0709     1.8431     8.4863 </r>
+       <r>     6.1242     1.8537     8.5850 </r>
+       <r>     6.1775     1.6535     8.6796 </r>
+       <r>     6.2308     1.4761     8.7632 </r>
+       <r>     6.2841     1.4419     8.8405 </r>
+       <r>     6.3374     1.1693     8.9111 </r>
+       <r>     6.3907     0.6852     8.9614 </r>
+       <r>     6.4440     0.2801     8.9837 </r>
+       <r>     6.4973     0.1360     8.9946 </r>
+       <r>     6.5506     0.0360     8.9990 </r>
+       <r>     6.6039     0.0050     8.9999 </r>
+       <r>     6.6572     0.0000     9.0000 </r>
+       <r>     6.7105     0.0000     9.0000 </r>
+       <r>     6.7638     0.0000     9.0000 </r>
+       <r>     6.8171     0.0000     9.0000 </r>
+       <r>     6.8704     0.0000     9.0000 </r>
+       <r>     6.9237     0.0000     9.0000 </r>
+       <r>     6.9770     0.0000     9.0000 </r>
+       <r>     7.0303     0.0000     9.0000 </r>
+       <r>     7.0836     0.0000     9.0000 </r>
+       <r>     7.1369     0.0000     9.0000 </r>
+       <r>     7.1902     0.0000     9.0000 </r>
+       <r>     7.2435     0.0000     9.0000 </r>
+       <r>     7.2968     0.0000     9.0000 </r>
+       <r>     7.3501     0.0000     9.0000 </r>
+       <r>     7.4035     0.0000     9.0000 </r>
+      </set>
+      <set comment="spin 2">
+       <r>    -8.5874     0.0000     0.0000 </r>
+       <r>    -8.5341     0.0000     0.0000 </r>
+       <r>    -8.4808     0.0000     0.0000 </r>
+       <r>    -8.4275     0.0000     0.0000 </r>
+       <r>    -8.3742     0.0000     0.0000 </r>
+       <r>    -8.3209     0.0000     0.0000 </r>
+       <r>    -8.2676     0.0000     0.0000 </r>
+       <r>    -8.2143     0.0000     0.0000 </r>
+       <r>    -8.1610     0.0000     0.0000 </r>
+       <r>    -8.1077     0.0000     0.0000 </r>
+       <r>    -8.0544     0.0000     0.0000 </r>
+       <r>    -8.0011     0.0000     0.0000 </r>
+       <r>    -7.9478     0.0000     0.0000 </r>
+       <r>    -7.8945     0.0000     0.0000 </r>
+       <r>    -7.8412     0.0039     0.0000 </r>
+       <r>    -7.7879     0.0554     0.0013 </r>
+       <r>    -7.7346     0.1665     0.0070 </r>
+       <r>    -7.6813     0.1890     0.0176 </r>
+       <r>    -7.6280     0.2232     0.0286 </r>
+       <r>    -7.5747     0.2668     0.0416 </r>
+       <r>    -7.5214     0.3194     0.0572 </r>
+       <r>    -7.4681     0.3584     0.0754 </r>
+       <r>    -7.4148     0.3703     0.0949 </r>
+       <r>    -7.3615     0.4046     0.1156 </r>
+       <r>    -7.3081     0.4402     0.1381 </r>
+       <r>    -7.2548     0.4781     0.1625 </r>
+       <r>    -7.2015     0.5183     0.1891 </r>
+       <r>    -7.1482     0.5619     0.2179 </r>
+       <r>    -7.0949     0.6080     0.2490 </r>
+       <r>    -7.0416     0.6722     0.2831 </r>
+       <r>    -6.9883     0.7430     0.3208 </r>
+       <r>    -6.9350     0.9145     0.3658 </r>
+       <r>    -6.8817     0.9835     0.4166 </r>
+       <r>    -6.8284     1.0095     0.4699 </r>
+       <r>    -6.7751     0.9337     0.5230 </r>
+       <r>    -6.7218     0.9387     0.5727 </r>
+       <r>    -6.6685     0.9545     0.6234 </r>
+       <r>    -6.6152     0.8974     0.6730 </r>
+       <r>    -6.5619     0.8299     0.7190 </r>
+       <r>    -6.5086     0.7692     0.7616 </r>
+       <r>    -6.4553     0.7155     0.8012 </r>
+       <r>    -6.4020     0.7303     0.8391 </r>
+       <r>    -6.3487     0.7810     0.8796 </r>
+       <r>    -6.2954     0.7062     0.9195 </r>
+       <r>    -6.2421     0.5901     0.9542 </r>
+       <r>    -6.1888     0.2633     0.9801 </r>
+       <r>    -6.1355     0.1591     0.9913 </r>
+       <r>    -6.0822     0.0775     0.9975 </r>
+       <r>    -6.0289     0.0184     0.9999 </r>
+       <r>    -5.9756     0.0000     1.0000 </r>
+       <r>    -5.9223     0.0000     1.0000 </r>
+       <r>    -5.8690     0.0000     1.0000 </r>
+       <r>    -5.8157     0.0251     1.0003 </r>
+       <r>    -5.7624     0.0738     1.0029 </r>
+       <r>    -5.7091     0.1380     1.0084 </r>
+       <r>    -5.6558     0.2178     1.0179 </r>
+       <r>    -5.6025     0.4957     1.0370 </r>
+       <r>    -5.5492     0.5997     1.0664 </r>
+       <r>    -5.4958     0.6704     1.1004 </r>
+       <r>    -5.4425     0.6663     1.1367 </r>
+       <r>    -5.3892     0.6084     1.1705 </r>
+       <r>    -5.3359     0.6185     1.2027 </r>
+       <r>    -5.2826     0.6561     1.2367 </r>
+       <r>    -5.2293     0.6984     1.2728 </r>
+       <r>    -5.1760     0.7451     1.3112 </r>
+       <r>    -5.1227     0.7959     1.3523 </r>
+       <r>    -5.0694     0.7974     1.3951 </r>
+       <r>    -5.0161     0.7289     1.4359 </r>
+       <r>    -4.9628     0.7753     1.4763 </r>
+       <r>    -4.9095     0.7610     1.5174 </r>
+       <r>    -4.8562     0.7264     1.5572 </r>
+       <r>    -4.8029     0.6683     1.5945 </r>
+       <r>    -4.7496     0.5776     1.6279 </r>
+       <r>    -4.6963     0.5040     1.6565 </r>
+       <r>    -4.6430     0.4639     1.6823 </r>
+       <r>    -4.5897     0.4259     1.7060 </r>
+       <r>    -4.5364     0.3901     1.7277 </r>
+       <r>    -4.4831     0.3541     1.7476 </r>
+       <r>    -4.4298     0.3253     1.7656 </r>
+       <r>    -4.3765     0.3077     1.7825 </r>
+       <r>    -4.3232     0.2916     1.7984 </r>
+       <r>    -4.2699     0.2768     1.8136 </r>
+       <r>    -4.2166     0.2627     1.8279 </r>
+       <r>    -4.1633     0.2490     1.8416 </r>
+       <r>    -4.1100     0.2357     1.8545 </r>
+       <r>    -4.0567     0.2228     1.8667 </r>
+       <r>    -4.0034     0.2103     1.8782 </r>
+       <r>    -3.9501     0.1979     1.8891 </r>
+       <r>    -3.8968     0.1847     1.8993 </r>
+       <r>    -3.8435     0.1680     1.9086 </r>
+       <r>    -3.7902     0.1587     1.9173 </r>
+       <r>    -3.7369     0.1492     1.9255 </r>
+       <r>    -3.6836     0.1395     1.9332 </r>
+       <r>    -3.6302     0.1295     1.9404 </r>
+       <r>    -3.5769     0.1200     1.9470 </r>
+       <r>    -3.5236     0.1112     1.9532 </r>
+       <r>    -3.4703     0.1029     1.9589 </r>
+       <r>    -3.4170     0.0952     1.9642 </r>
+       <r>    -3.3637     0.0881     1.9690 </r>
+       <r>    -3.3104     0.0816     1.9736 </r>
+       <r>    -3.2571     0.0756     1.9777 </r>
+       <r>    -3.2038     0.0702     1.9816 </r>
+       <r>    -3.1505     0.0653     1.9852 </r>
+       <r>    -3.0972     0.0701     1.9888 </r>
+       <r>    -3.0439     0.0475     1.9927 </r>
+       <r>    -2.9906     0.0372     1.9949 </r>
+       <r>    -2.9373     0.0281     1.9967 </r>
+       <r>    -2.8840     0.0203     1.9979 </r>
+       <r>    -2.8307     0.0138     1.9988 </r>
+       <r>    -2.7774     0.0086     1.9994 </r>
+       <r>    -2.7241     0.0045     1.9998 </r>
+       <r>    -2.6708     0.0018     1.9999 </r>
+       <r>    -2.6175     0.0003     2.0000 </r>
+       <r>    -2.5642     0.0000     2.0000 </r>
+       <r>    -2.5109     0.0000     2.0000 </r>
+       <r>    -2.4576     0.0000     2.0000 </r>
+       <r>    -2.4043     0.0000     2.0000 </r>
+       <r>    -2.3510     0.0000     2.0000 </r>
+       <r>    -2.2977     0.0000     2.0000 </r>
+       <r>    -2.2444     0.0000     2.0000 </r>
+       <r>    -2.1911     0.0000     2.0000 </r>
+       <r>    -2.1378     0.0000     2.0000 </r>
+       <r>    -2.0845     0.0000     2.0000 </r>
+       <r>    -2.0312     0.0000     2.0000 </r>
+       <r>    -1.9779     0.0000     2.0000 </r>
+       <r>    -1.9246     0.0000     2.0000 </r>
+       <r>    -1.8713     0.0000     2.0000 </r>
+       <r>    -1.8179     0.0000     2.0000 </r>
+       <r>    -1.7646     0.0000     2.0000 </r>
+       <r>    -1.7113     0.0000     2.0000 </r>
+       <r>    -1.6580     0.0000     2.0000 </r>
+       <r>    -1.6047     0.0000     2.0000 </r>
+       <r>    -1.5514     0.0000     2.0000 </r>
+       <r>    -1.4981     1.6633     2.0659 </r>
+       <r>    -1.4448     1.6059     2.1567 </r>
+       <r>    -1.3915     1.3658     2.2342 </r>
+       <r>    -1.3382     1.2554     2.3038 </r>
+       <r>    -1.2849     1.1836     2.3710 </r>
+       <r>    -1.2316     1.1473     2.4331 </r>
+       <r>    -1.1783     1.1152     2.4934 </r>
+       <r>    -1.1250     1.0797     2.5525 </r>
+       <r>    -1.0717     1.5479     2.6129 </r>
+       <r>    -1.0184     1.5259     2.7004 </r>
+       <r>    -0.9651     1.7208     2.7856 </r>
+       <r>    -0.9118     1.5233     2.8695 </r>
+       <r>    -0.8585     1.5008     2.9502 </r>
+       <r>    -0.8052     1.4461     3.0289 </r>
+       <r>    -0.7519     1.4311     3.1052 </r>
+       <r>    -0.6986     1.4822     3.1829 </r>
+       <r>    -0.6453     1.4750     3.2618 </r>
+       <r>    -0.5920     1.4572     3.3400 </r>
+       <r>    -0.5387     1.4301     3.4170 </r>
+       <r>    -0.4854     1.3817     3.4922 </r>
+       <r>    -0.4321     1.3466     3.5642 </r>
+       <r>    -0.3788     1.3498     3.6373 </r>
+       <r>    -0.3255     1.2176     3.7058 </r>
+       <r>    -0.2722     1.0246     3.7660 </r>
+       <r>    -0.2189     0.8174     3.8144 </r>
+       <r>    -0.1656     0.6861     3.8544 </r>
+       <r>    -0.1123     0.5295     3.8869 </r>
+       <r>    -0.0590     0.4431     3.9124 </r>
+       <r>    -0.0057     0.4029     3.9349 </r>
+       <r>     0.0477     0.3710     3.9555 </r>
+       <r>     0.1010     0.3482     3.9747 </r>
+       <r>     0.1543     0.3104     3.9926 </r>
+       <r>     0.2076     0.2385     4.0067 </r>
+       <r>     0.2609     0.1820     4.0178 </r>
+       <r>     0.3142     0.2554     4.0272 </r>
+       <r>     0.3675     0.2130     4.0390 </r>
+       <r>     0.4208     0.2525     4.0514 </r>
+       <r>     0.4741     0.2890     4.0659 </r>
+       <r>     0.5274     0.3222     4.0822 </r>
+       <r>     0.5807     0.3521     4.1001 </r>
+       <r>     0.6340     0.3787     4.1196 </r>
+       <r>     0.6873     0.4038     4.1405 </r>
+       <r>     0.7406     0.5213     4.1637 </r>
+       <r>     0.7939     0.6350     4.1951 </r>
+       <r>     0.8472     0.6498     4.2296 </r>
+       <r>     0.9005     0.6881     4.2653 </r>
+       <r>     0.9538     0.7326     4.3031 </r>
+       <r>     1.0071     0.7817     4.3434 </r>
+       <r>     1.0604     0.8198     4.3857 </r>
+       <r>     1.1137     0.9750     4.4333 </r>
+       <r>     1.1670     1.1282     4.4904 </r>
+       <r>     1.2203     1.4298     4.5591 </r>
+       <r>     1.2736     1.3130     4.6351 </r>
+       <r>     1.3269     1.1841     4.7017 </r>
+       <r>     1.3802     1.0407     4.7611 </r>
+       <r>     1.4335     0.8522     4.8120 </r>
+       <r>     1.4868     0.7937     4.8558 </r>
+       <r>     1.5401     0.7465     4.8968 </r>
+       <r>     1.5934     0.7109     4.9356 </r>
+       <r>     1.6467     0.6869     4.9728 </r>
+       <r>     1.7000     0.6746     5.0091 </r>
+       <r>     1.7533     0.6758     5.0450 </r>
+       <r>     1.8066     0.4233     5.0969 </r>
+       <r>     1.8599     0.4855     5.1211 </r>
+       <r>     1.9133     0.5476     5.1487 </r>
+       <r>     1.9666     0.5072     5.1763 </r>
+       <r>     2.0199     0.5234     5.2037 </r>
+       <r>     2.0732     0.5597     5.2325 </r>
+       <r>     2.1265     0.5952     5.2633 </r>
+       <r>     2.1798     0.6323     5.2960 </r>
+       <r>     2.2331     0.6749     5.3308 </r>
+       <r>     2.2864     0.7230     5.3680 </r>
+       <r>     2.3397     0.7767     5.4080 </r>
+       <r>     2.3930     0.7782     5.4503 </r>
+       <r>     2.4463     0.8179     5.4927 </r>
+       <r>     2.4996     0.8639     5.5375 </r>
+       <r>     2.5529     0.8885     5.5843 </r>
+       <r>     2.6062     0.9868     5.6336 </r>
+       <r>     2.6595     1.3374     5.6931 </r>
+       <r>     2.7128     1.7528     5.7770 </r>
+       <r>     2.7661     1.8271     5.8739 </r>
+       <r>     2.8194     1.5071     5.9615 </r>
+       <r>     2.8727     1.3050     6.0370 </r>
+       <r>     2.9260     0.7621     6.1013 </r>
+       <r>     2.9793     0.7526     6.1414 </r>
+       <r>     3.0326     0.7585     6.1817 </r>
+       <r>     3.0859     0.7649     6.2223 </r>
+       <r>     3.1392     0.7718     6.2633 </r>
+       <r>     3.1925     0.7799     6.3046 </r>
+       <r>     3.2458     0.7949     6.3465 </r>
+       <r>     3.2991     0.8217     6.3902 </r>
+       <r>     3.3524     0.8392     6.4344 </r>
+       <r>     3.4057     0.8846     6.4801 </r>
+       <r>     3.4590     0.9349     6.5286 </r>
+       <r>     3.5123     0.9832     6.5797 </r>
+       <r>     3.5656     1.0296     6.6335 </r>
+       <r>     3.6189     1.1234     6.6908 </r>
+       <r>     3.6722     1.2063     6.7529 </r>
+       <r>     3.7256     1.5161     6.8232 </r>
+       <r>     3.7789     1.7742     6.9170 </r>
+       <r>     3.8322     1.7538     7.0132 </r>
+       <r>     3.8855     1.6765     7.1045 </r>
+       <r>     3.9388     1.7696     7.1940 </r>
+       <r>     3.9921     1.9009     7.2917 </r>
+       <r>     4.0454     2.0814     7.3947 </r>
+       <r>     4.0987     1.6400     7.4962 </r>
+       <r>     4.1520     1.4131     7.5774 </r>
+       <r>     4.2053     1.2177     7.6474 </r>
+       <r>     4.2586     1.0464     7.7077 </r>
+       <r>     4.3119     0.9041     7.7596 </r>
+       <r>     4.3652     0.7766     7.8043 </r>
+       <r>     4.4185     0.6639     7.8426 </r>
+       <r>     4.4718     0.5660     7.8753 </r>
+       <r>     4.5251     0.4829     7.9032 </r>
+       <r>     4.5784     0.4382     7.9286 </r>
+       <r>     4.6317     0.3257     7.9492 </r>
+       <r>     4.6850     0.2656     7.9637 </r>
+       <r>     4.7383     0.2200     7.9766 </r>
+       <r>     4.7916     0.1693     7.9870 </r>
+       <r>     4.8449     0.1537     7.9961 </r>
+       <r>     4.8982     0.0000     8.0000 </r>
+       <r>     4.9515     0.0000     8.0000 </r>
+       <r>     5.0048     0.0001     8.0000 </r>
+       <r>     5.0581     0.0002     8.0000 </r>
+       <r>     5.1114     0.0005     8.0000 </r>
+       <r>     5.1647     0.0008     8.0001 </r>
+       <r>     5.2180     0.0011     8.0001 </r>
+       <r>     5.2713     0.0016     8.0002 </r>
+       <r>     5.3246     0.0050     8.0003 </r>
+       <r>     5.3779     0.0138     8.0008 </r>
+       <r>     5.4312     0.0278     8.0019 </r>
+       <r>     5.4845     0.0471     8.0039 </r>
+       <r>     5.5378     0.0718     8.0070 </r>
+       <r>     5.5912     0.1017     8.0116 </r>
+       <r>     5.6445     0.1369     8.0180 </r>
+       <r>     5.6978     0.1774     8.0263 </r>
+       <r>     5.7511     0.3330     8.0396 </r>
+       <r>     5.8044     0.5520     8.0629 </r>
+       <r>     5.8577     0.8355     8.0996 </r>
+       <r>     5.9110     1.1889     8.1532 </r>
+       <r>     5.9643     1.9065     8.2416 </r>
+       <r>     6.0176     1.8903     8.3447 </r>
+       <r>     6.0709     1.8885     8.4455 </r>
+       <r>     6.1242     1.9241     8.5474 </r>
+       <r>     6.1775     1.7357     8.6460 </r>
+       <r>     6.2308     1.5647     8.7342 </r>
+       <r>     6.2841     1.5322     8.8163 </r>
+       <r>     6.3374     1.2579     8.8917 </r>
+       <r>     6.3907     0.7685     8.9466 </r>
+       <r>     6.4440     0.3553     8.9732 </r>
+       <r>     6.4973     0.2003     8.9878 </r>
+       <r>     6.5506     0.0863     8.9953 </r>
+       <r>     6.6039     0.0383     8.9984 </r>
+       <r>     6.6572     0.0150     8.9997 </r>
+       <r>     6.7105     0.0000     9.0000 </r>
+       <r>     6.7638     0.0000     9.0000 </r>
+       <r>     6.8171     0.0000     9.0000 </r>
+       <r>     6.8704     0.0000     9.0000 </r>
+       <r>     6.9237     0.0000     9.0000 </r>
+       <r>     6.9770     0.0000     9.0000 </r>
+       <r>     7.0303     0.0000     9.0000 </r>
+       <r>     7.0836     0.0000     9.0000 </r>
+       <r>     7.1369     0.0000     9.0000 </r>
+       <r>     7.1902     0.0000     9.0000 </r>
+       <r>     7.2435     0.0000     9.0000 </r>
+       <r>     7.2968     0.0000     9.0000 </r>
+       <r>     7.3501     0.0000     9.0000 </r>
+       <r>     7.4035     0.0000     9.0000 </r>
+      </set>
+     </set>
+    </array>
+   </total>
+   <partial>
+    <array>
+     <dimension dim="1">gridpoints</dimension>
+     <dimension dim="2">spin</dimension>
+     <dimension dim="3">ion</dimension>
+     <field>energy</field>
+     <field>  s</field>
+     <field> py</field>
+     <field> pz</field>
+     <field> px</field>
+     <field>dxy</field>
+     <field>dyz</field>
+     <field>dz2</field>
+     <field>dxz</field>
+     <field>dx2</field>
+     <set>
+      <set comment="ion 1">
+       <set comment="spin 1">
+        <r>    -8.5874     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.5341     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.4808     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.4275     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.3742     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.3209     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.2676     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.2143     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.1610     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.1077     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.0544     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.0011     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.9478     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.8945     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.8412     0.0007     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.7879     0.0104     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.7346     0.0312     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.6813     0.0356     0.0001     0.0000     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.6280     0.0421     0.0001     0.0001     0.0002     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.5747     0.0504     0.0001     0.0001     0.0002     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.5214     0.0605     0.0002     0.0001     0.0003     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.4681     0.0680     0.0002     0.0001     0.0003     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.4148     0.0706     0.0003     0.0001     0.0004     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.3615     0.0775     0.0003     0.0002     0.0006     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.3081     0.0845     0.0004     0.0002     0.0007     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.2548     0.0920     0.0004     0.0002     0.0008     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.2015     0.1000     0.0005     0.0003     0.0009     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.1482     0.1087     0.0006     0.0003     0.0010     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.0949     0.1181     0.0007     0.0004     0.0011     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.0416     0.1312     0.0008     0.0005     0.0013     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.9883     0.1457     0.0009     0.0005     0.0016     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.9350     0.1801     0.0012     0.0007     0.0020     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.8817     0.1943     0.0013     0.0008     0.0022     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.8284     0.1999     0.0014     0.0009     0.0023     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.7751     0.1852     0.0015     0.0009     0.0021     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.7218     0.1868     0.0016     0.0010     0.0022     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.6685     0.1906     0.0018     0.0011     0.0022     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.6152     0.1797     0.0019     0.0012     0.0020     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.5619     0.1665     0.0019     0.0012     0.0018     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.5086     0.1547     0.0019     0.0012     0.0016     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.4553     0.1441     0.0019     0.0012     0.0014     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.4020     0.1475     0.0021     0.0013     0.0014     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.3487     0.1581     0.0025     0.0016     0.0013     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.2954     0.1432     0.0024     0.0015     0.0011     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.2421     0.1199     0.0021     0.0013     0.0009     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.1888     0.0535     0.0011     0.0006     0.0003     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.1355     0.0324     0.0007     0.0004     0.0002     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.0822     0.0158     0.0003     0.0002     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.0289     0.0038     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.9756     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.9223     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.8690     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.8157     0.0052     0.0002     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.7624     0.0154     0.0004     0.0003     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.7091     0.0288     0.0008     0.0005     0.0002     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.6558     0.0455     0.0013     0.0007     0.0004     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.6025     0.1036     0.0027     0.0016     0.0012     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.5492     0.1255     0.0033     0.0020     0.0016     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.4958     0.1404     0.0036     0.0022     0.0020     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.4425     0.1397     0.0036     0.0021     0.0022     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.3892     0.1278     0.0032     0.0019     0.0024     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.3359     0.1301     0.0032     0.0019     0.0027     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.2826     0.1381     0.0034     0.0020     0.0031     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.2293     0.1470     0.0035     0.0021     0.0036     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.1760     0.1568     0.0037     0.0021     0.0041     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.1227     0.1674     0.0039     0.0022     0.0049     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.0694     0.1678     0.0039     0.0022     0.0054     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.0161     0.1537     0.0035     0.0020     0.0052     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.9628     0.1631     0.0037     0.0020     0.0061     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.9095     0.1601     0.0036     0.0020     0.0062     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.8562     0.1531     0.0034     0.0019     0.0061     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.8029     0.1414     0.0032     0.0017     0.0056     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.7496     0.1231     0.0027     0.0015     0.0048     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.6963     0.1082     0.0024     0.0013     0.0041     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.6430     0.1001     0.0022     0.0012     0.0038     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.5897     0.0924     0.0021     0.0011     0.0035     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.5364     0.0852     0.0019     0.0010     0.0032     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.4831     0.0779     0.0017     0.0009     0.0029     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.4298     0.0722     0.0016     0.0008     0.0026     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.3765     0.0685     0.0015     0.0008     0.0025     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.3232     0.0652     0.0014     0.0008     0.0024     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.2699     0.0622     0.0013     0.0007     0.0022     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.2166     0.0593     0.0013     0.0007     0.0021     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.1633     0.0565     0.0012     0.0006     0.0020     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.1100     0.0537     0.0011     0.0006     0.0019     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.0567     0.0511     0.0011     0.0006     0.0018     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.0034     0.0485     0.0010     0.0005     0.0016     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.9501     0.0459     0.0010     0.0005     0.0015     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.8968     0.0432     0.0009     0.0005     0.0014     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.8435     0.0398     0.0008     0.0004     0.0012     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.7902     0.0380     0.0008     0.0004     0.0011     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.7369     0.0361     0.0007     0.0004     0.0010     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.6836     0.0340     0.0007     0.0003     0.0009     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.6302     0.0318     0.0006     0.0003     0.0008     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.5769     0.0296     0.0005     0.0003     0.0008     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.5236     0.0275     0.0005     0.0002     0.0007     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.4703     0.0256     0.0004     0.0002     0.0007     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.4170     0.0238     0.0004     0.0002     0.0006     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.3637     0.0222     0.0004     0.0002     0.0005     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.3104     0.0207     0.0003     0.0002     0.0005     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.2571     0.0193     0.0003     0.0001     0.0004     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.2038     0.0181     0.0003     0.0001     0.0004     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.1505     0.0171     0.0002     0.0001     0.0003     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.0972     0.0187     0.0002     0.0001     0.0003     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.0439     0.0131     0.0001     0.0001     0.0002     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.9906     0.0103     0.0001     0.0000     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.9373     0.0078     0.0001     0.0000     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.8840     0.0056     0.0001     0.0000     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.8307     0.0038     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.7774     0.0024     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.7241     0.0013     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.6708     0.0005     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.6175     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.5642     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.5109     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.4576     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.4043     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.3510     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.2977     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.2444     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.1911     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.1378     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.0845     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.0312     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.9779     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.9246     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.8713     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.8179     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.7646     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.7113     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.6580     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.6047     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.5514     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.4981     0.0048     0.0332     0.0385     0.1146     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.4448     0.0059     0.0313     0.0412     0.1083     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.3915     0.0060     0.0270     0.0350     0.0925     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.3382     0.0062     0.0254     0.0315     0.0860     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.2849     0.0065     0.0238     0.0272     0.0848     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.2316     0.0069     0.0240     0.0254     0.0828     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.1783     0.0073     0.0245     0.0238     0.0806     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.1250     0.0076     0.0256     0.0221     0.0777     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.0717     0.0071     0.0544     0.0509     0.0811     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.0184     0.0057     0.0625     0.0643     0.0624     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.9651     0.0046     0.0757     0.0895     0.0529     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.9118     0.0043     0.0690     0.0762     0.0484     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.8585     0.0040     0.0698     0.0767     0.0453     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.8052     0.0038     0.0690     0.0746     0.0422     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.7519     0.0035     0.0698     0.0758     0.0397     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.6986     0.0033     0.0743     0.0853     0.0355     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.6453     0.0030     0.0742     0.0885     0.0330     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.5920     0.0028     0.0731     0.0906     0.0312     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.5387     0.0026     0.0710     0.0914     0.0303     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.4854     0.0022     0.0690     0.0921     0.0270     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.4321     0.0018     0.0657     0.0961     0.0237     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.3788     0.0015     0.0636     0.1039     0.0205     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.3255     0.0012     0.0567     0.0963     0.0179     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.2722     0.0009     0.0473     0.0818     0.0153     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.2189     0.0007     0.0374     0.0653     0.0131     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.1656     0.0008     0.0311     0.0551     0.0116     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.1123     0.0010     0.0240     0.0408     0.0105     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.0590     0.0014     0.0199     0.0331     0.0099     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.0057     0.0019     0.0174     0.0292     0.0104     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.0477     0.0026     0.0155     0.0260     0.0107     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.1010     0.0034     0.0143     0.0235     0.0109     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.1543     0.0043     0.0129     0.0195     0.0105     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.2076     0.0054     0.0118     0.0119     0.0081     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.2609     0.0066     0.0084     0.0070     0.0071     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.3142     0.0104     0.0093     0.0054     0.0164     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.3675     0.0108     0.0091     0.0046     0.0110     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.4208     0.0127     0.0110     0.0056     0.0130     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.4741     0.0145     0.0128     0.0065     0.0148     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.5274     0.0161     0.0145     0.0074     0.0162     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.5807     0.0177     0.0161     0.0082     0.0174     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.6340     0.0191     0.0176     0.0090     0.0183     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.6873     0.0205     0.0192     0.0098     0.0190     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.7406     0.0266     0.0259     0.0135     0.0230     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.7939     0.0321     0.0330     0.0180     0.0260     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.8472     0.0327     0.0345     0.0195     0.0253     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.9005     0.0346     0.0370     0.0214     0.0255     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.9538     0.0366     0.0400     0.0236     0.0255     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.0071     0.0387     0.0436     0.0261     0.0250     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.0604     0.0403     0.0450     0.0275     0.0252     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.1137     0.0462     0.0534     0.0325     0.0259     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.1670     0.0521     0.0618     0.0378     0.0267     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.2203     0.0648     0.0786     0.0487     0.0295     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.2736     0.0605     0.0708     0.0465     0.0284     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.3269     0.0549     0.0631     0.0433     0.0254     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.3802     0.0481     0.0552     0.0393     0.0215     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.4335     0.0386     0.0458     0.0329     0.0157     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.4868     0.0357     0.0429     0.0308     0.0145     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.5401     0.0331     0.0408     0.0289     0.0134     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.5934     0.0309     0.0393     0.0274     0.0127     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.6467     0.0290     0.0386     0.0261     0.0121     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.7000     0.0274     0.0385     0.0251     0.0119     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.7533     0.0263     0.0392     0.0246     0.0119     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.8066     0.0133     0.0252     0.0142     0.0090     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.8599     0.0143     0.0279     0.0169     0.0109     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.9133     0.0149     0.0304     0.0198     0.0129     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.9666     0.0131     0.0271     0.0192     0.0128     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.0199     0.0128     0.0272     0.0206     0.0138     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.0732     0.0132     0.0286     0.0227     0.0151     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.1265     0.0137     0.0300     0.0248     0.0163     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.1798     0.0142     0.0315     0.0271     0.0176     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.2331     0.0147     0.0332     0.0295     0.0192     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.2864     0.0151     0.0353     0.0322     0.0212     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.3397     0.0156     0.0377     0.0352     0.0235     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.3930     0.0158     0.0381     0.0337     0.0253     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.4463     0.0160     0.0400     0.0357     0.0276     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.4996     0.0162     0.0427     0.0379     0.0297     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.5529     0.0165     0.0441     0.0393     0.0307     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.6062     0.0178     0.0486     0.0443     0.0344     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.6595     0.0247     0.0641     0.0624     0.0465     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.7128     0.0340     0.0834     0.0843     0.0607     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.7661     0.0343     0.0879     0.0866     0.0653     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.8194     0.0222     0.0727     0.0701     0.0553     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.8727     0.0164     0.0647     0.0615     0.0472     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.9260     0.0088     0.0410     0.0417     0.0234     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.9793     0.0068     0.0394     0.0442     0.0217     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.0326     0.0051     0.0387     0.0468     0.0209     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.0859     0.0038     0.0379     0.0489     0.0208     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.1392     0.0028     0.0370     0.0503     0.0215     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.1925     0.0021     0.0361     0.0511     0.0230     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.2458     0.0019     0.0355     0.0516     0.0255     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.2991     0.0022     0.0347     0.0507     0.0313     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.3524     0.0027     0.0337     0.0477     0.0380     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.4057     0.0034     0.0339     0.0462     0.0459     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.4590     0.0039     0.0348     0.0460     0.0523     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.5123     0.0044     0.0356     0.0456     0.0586     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.5656     0.0049     0.0363     0.0448     0.0652     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.6189     0.0057     0.0378     0.0440     0.0768     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.6722     0.0066     0.0384     0.0425     0.0886     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.7256     0.0092     0.0436     0.0431     0.1229     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.7789     0.0117     0.0484     0.0464     0.1496     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.8322     0.0120     0.0481     0.0489     0.1471     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.8855     0.0118     0.0483     0.0515     0.1379     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.9388     0.0121     0.0562     0.0665     0.1333     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.9921     0.0128     0.0677     0.0855     0.1302     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.0454     0.0143     0.0858     0.1131     0.1249     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.0987     0.0125     0.0666     0.0881     0.1071     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.1520     0.0108     0.0568     0.0763     0.0944     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.2053     0.0093     0.0484     0.0661     0.0832     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.2586     0.0081     0.0411     0.0569     0.0732     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.3119     0.0070     0.0352     0.0496     0.0646     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.3652     0.0060     0.0299     0.0430     0.0568     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.4185     0.0052     0.0253     0.0371     0.0498     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.4718     0.0044     0.0214     0.0320     0.0436     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.5251     0.0038     0.0181     0.0277     0.0382     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.5784     0.0039     0.0168     0.0250     0.0364     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.6317     0.0019     0.0125     0.0216     0.0252     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.6850     0.0007     0.0096     0.0192     0.0206     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.7383     0.0005     0.0080     0.0162     0.0174     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.7916     0.0004     0.0061     0.0124     0.0141     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.8449     0.0002     0.0057     0.0115     0.0133     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.8982     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.9515     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.0048     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.0581     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.1114     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.1647     0.0002     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.2180     0.0003     0.0000     0.0000     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.2713     0.0004     0.0000     0.0000     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.3246     0.0006     0.0001     0.0000     0.0002     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.3779     0.0009     0.0002     0.0001     0.0003     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.4312     0.0012     0.0004     0.0002     0.0006     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.4845     0.0016     0.0007     0.0003     0.0009     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.5378     0.0021     0.0010     0.0005     0.0014     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.5912     0.0032     0.0016     0.0008     0.0023     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.6445     0.0042     0.0022     0.0011     0.0032     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.6978     0.0053     0.0029     0.0015     0.0041     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.7511     0.0058     0.0055     0.0031     0.0071     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.8044     0.0064     0.0099     0.0058     0.0124     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.8577     0.0074     0.0157     0.0093     0.0200     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.9110     0.0087     0.0232     0.0138     0.0299     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.9643     0.0111     0.0401     0.0249     0.0507     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.0176     0.0115     0.0395     0.0224     0.0492     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.0709     0.0112     0.0390     0.0218     0.0470     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.1242     0.0121     0.0411     0.0225     0.0444     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.1775     0.0096     0.0329     0.0181     0.0408     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.2308     0.0084     0.0275     0.0151     0.0372     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.2841     0.0103     0.0232     0.0129     0.0379     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.3374     0.0098     0.0180     0.0101     0.0296     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.3907     0.0062     0.0117     0.0067     0.0151     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.4440     0.0022     0.0061     0.0035     0.0044     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.4973     0.0011     0.0028     0.0017     0.0020     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.5506     0.0003     0.0003     0.0002     0.0006     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.6039     0.0000     0.0000     0.0000     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.6572     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.7105     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.7638     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.8171     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.8704     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.9237     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.9770     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     7.0303     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     7.0836     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     7.1369     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     7.1902     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     7.2435     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     7.2968     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     7.3501     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     7.4035     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+       </set>
+       <set comment="spin 2">
+        <r>    -8.5874     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.5341     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.4808     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.4275     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.3742     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.3209     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.2676     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.2143     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.1610     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.1077     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.0544     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.0011     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.9478     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.8945     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.8412     0.0007     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.7879     0.0104     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.7346     0.0312     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.6813     0.0356     0.0001     0.0000     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.6280     0.0421     0.0001     0.0001     0.0002     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.5747     0.0504     0.0001     0.0001     0.0002     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.5214     0.0605     0.0002     0.0001     0.0003     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.4681     0.0680     0.0002     0.0001     0.0003     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.4148     0.0706     0.0003     0.0001     0.0004     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.3615     0.0775     0.0003     0.0002     0.0006     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.3081     0.0845     0.0004     0.0002     0.0007     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.2548     0.0920     0.0004     0.0002     0.0008     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.2015     0.1000     0.0005     0.0003     0.0009     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.1482     0.1087     0.0006     0.0003     0.0010     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.0949     0.1181     0.0007     0.0004     0.0011     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.0416     0.1312     0.0008     0.0005     0.0013     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.9883     0.1457     0.0009     0.0005     0.0016     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.9350     0.1801     0.0012     0.0007     0.0020     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.8817     0.1943     0.0013     0.0008     0.0022     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.8284     0.1999     0.0014     0.0009     0.0023     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.7751     0.1852     0.0015     0.0009     0.0021     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.7218     0.1868     0.0016     0.0010     0.0022     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.6685     0.1906     0.0018     0.0011     0.0022     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.6152     0.1797     0.0019     0.0012     0.0020     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.5619     0.1665     0.0019     0.0012     0.0018     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.5086     0.1547     0.0019     0.0012     0.0016     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.4553     0.1441     0.0019     0.0012     0.0014     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.4020     0.1475     0.0021     0.0013     0.0014     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.3487     0.1581     0.0025     0.0016     0.0013     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.2954     0.1432     0.0024     0.0015     0.0011     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.2421     0.1199     0.0021     0.0013     0.0009     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.1888     0.0535     0.0011     0.0006     0.0003     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.1355     0.0324     0.0007     0.0004     0.0002     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.0822     0.0158     0.0003     0.0002     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.0289     0.0038     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.9756     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.9223     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.8690     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.8157     0.0052     0.0002     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.7624     0.0154     0.0004     0.0003     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.7091     0.0288     0.0008     0.0005     0.0002     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.6558     0.0455     0.0013     0.0007     0.0004     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.6025     0.1036     0.0027     0.0016     0.0012     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.5492     0.1255     0.0033     0.0020     0.0016     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.4958     0.1404     0.0036     0.0022     0.0020     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.4425     0.1397     0.0036     0.0021     0.0022     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.3892     0.1278     0.0032     0.0019     0.0024     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.3359     0.1301     0.0032     0.0019     0.0027     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.2826     0.1381     0.0034     0.0020     0.0031     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.2293     0.1470     0.0035     0.0021     0.0036     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.1760     0.1568     0.0037     0.0021     0.0041     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.1227     0.1674     0.0039     0.0022     0.0049     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.0694     0.1678     0.0039     0.0022     0.0054     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.0161     0.1537     0.0035     0.0020     0.0052     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.9628     0.1631     0.0037     0.0020     0.0061     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.9095     0.1601     0.0036     0.0020     0.0062     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.8562     0.1531     0.0034     0.0019     0.0061     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.8029     0.1414     0.0032     0.0017     0.0056     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.7496     0.1231     0.0027     0.0015     0.0048     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.6963     0.1082     0.0024     0.0013     0.0041     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.6430     0.1001     0.0022     0.0012     0.0038     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.5897     0.0924     0.0021     0.0011     0.0035     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.5364     0.0852     0.0019     0.0010     0.0032     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.4831     0.0779     0.0017     0.0009     0.0029     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.4298     0.0722     0.0016     0.0008     0.0026     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.3765     0.0685     0.0015     0.0008     0.0025     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.3232     0.0652     0.0014     0.0008     0.0024     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.2699     0.0622     0.0013     0.0007     0.0022     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.2166     0.0593     0.0013     0.0007     0.0021     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.1633     0.0565     0.0012     0.0006     0.0020     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.1100     0.0537     0.0011     0.0006     0.0019     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.0567     0.0511     0.0011     0.0006     0.0018     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.0034     0.0485     0.0010     0.0005     0.0016     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.9501     0.0459     0.0010     0.0005     0.0015     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.8968     0.0432     0.0009     0.0005     0.0014     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.8435     0.0398     0.0008     0.0004     0.0012     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.7902     0.0380     0.0008     0.0004     0.0011     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.7369     0.0361     0.0007     0.0004     0.0010     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.6836     0.0340     0.0007     0.0003     0.0009     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.6302     0.0318     0.0006     0.0003     0.0008     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.5769     0.0296     0.0005     0.0003     0.0008     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.5236     0.0275     0.0005     0.0002     0.0007     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.4703     0.0256     0.0004     0.0002     0.0007     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.4170     0.0238     0.0004     0.0002     0.0006     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.3637     0.0222     0.0004     0.0002     0.0005     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.3104     0.0207     0.0003     0.0002     0.0005     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.2571     0.0193     0.0003     0.0001     0.0004     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.2038     0.0181     0.0003     0.0001     0.0004     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.1505     0.0171     0.0002     0.0001     0.0003     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.0972     0.0187     0.0002     0.0001     0.0003     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.0439     0.0131     0.0001     0.0001     0.0002     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.9906     0.0103     0.0001     0.0000     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.9373     0.0078     0.0001     0.0000     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.8840     0.0056     0.0001     0.0000     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.8307     0.0038     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.7774     0.0024     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.7241     0.0013     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.6708     0.0005     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.6175     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.5642     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.5109     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.4576     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.4043     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.3510     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.2977     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.2444     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.1911     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.1378     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.0845     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.0312     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.9779     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.9246     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.8713     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.8179     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.7646     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.7113     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.6580     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.6047     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.5514     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.4981     0.0048     0.0332     0.0385     0.1146     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.4448     0.0059     0.0313     0.0412     0.1083     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.3915     0.0060     0.0270     0.0350     0.0925     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.3382     0.0062     0.0254     0.0315     0.0860     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.2849     0.0065     0.0238     0.0272     0.0848     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.2316     0.0069     0.0240     0.0254     0.0828     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.1783     0.0073     0.0245     0.0238     0.0806     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.1250     0.0076     0.0256     0.0221     0.0777     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.0717     0.0071     0.0544     0.0509     0.0811     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.0184     0.0057     0.0625     0.0643     0.0624     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.9651     0.0046     0.0757     0.0895     0.0529     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.9118     0.0043     0.0690     0.0762     0.0484     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.8585     0.0040     0.0698     0.0767     0.0453     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.8052     0.0038     0.0690     0.0746     0.0422     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.7519     0.0035     0.0699     0.0758     0.0397     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.6986     0.0033     0.0743     0.0853     0.0355     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.6453     0.0030     0.0742     0.0885     0.0330     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.5920     0.0028     0.0731     0.0905     0.0312     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.5387     0.0026     0.0710     0.0914     0.0303     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.4854     0.0022     0.0690     0.0921     0.0270     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.4321     0.0018     0.0657     0.0961     0.0237     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.3788     0.0015     0.0636     0.1039     0.0205     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.3255     0.0012     0.0566     0.0963     0.0179     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.2722     0.0009     0.0473     0.0819     0.0153     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.2189     0.0007     0.0374     0.0653     0.0131     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.1656     0.0008     0.0310     0.0551     0.0116     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.1123     0.0010     0.0240     0.0408     0.0105     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.0590     0.0014     0.0199     0.0331     0.0099     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.0057     0.0019     0.0174     0.0292     0.0104     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.0477     0.0026     0.0155     0.0260     0.0107     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.1010     0.0034     0.0143     0.0236     0.0109     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.1543     0.0043     0.0129     0.0195     0.0105     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.2076     0.0054     0.0118     0.0119     0.0081     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.2609     0.0066     0.0084     0.0070     0.0071     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.3142     0.0104     0.0093     0.0054     0.0164     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.3675     0.0108     0.0091     0.0046     0.0110     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.4208     0.0127     0.0110     0.0056     0.0130     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.4741     0.0145     0.0128     0.0065     0.0148     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.5274     0.0161     0.0145     0.0074     0.0162     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.5807     0.0177     0.0161     0.0082     0.0174     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.6340     0.0191     0.0176     0.0090     0.0183     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.6873     0.0205     0.0192     0.0098     0.0190     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.7406     0.0266     0.0259     0.0135     0.0230     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.7939     0.0321     0.0330     0.0180     0.0260     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.8472     0.0327     0.0345     0.0195     0.0253     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.9005     0.0346     0.0370     0.0214     0.0255     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.9538     0.0366     0.0400     0.0236     0.0255     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.0071     0.0387     0.0436     0.0261     0.0250     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.0604     0.0403     0.0450     0.0275     0.0252     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.1137     0.0462     0.0534     0.0325     0.0259     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.1670     0.0521     0.0618     0.0378     0.0267     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.2203     0.0648     0.0786     0.0487     0.0295     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.2736     0.0605     0.0708     0.0465     0.0284     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.3269     0.0549     0.0631     0.0433     0.0254     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.3802     0.0481     0.0552     0.0393     0.0215     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.4335     0.0386     0.0458     0.0329     0.0157     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.4868     0.0357     0.0429     0.0308     0.0145     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.5401     0.0331     0.0408     0.0289     0.0134     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.5934     0.0309     0.0393     0.0274     0.0127     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.6467     0.0290     0.0386     0.0261     0.0121     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.7000     0.0274     0.0385     0.0251     0.0119     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.7533     0.0263     0.0392     0.0246     0.0119     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.8066     0.0133     0.0252     0.0142     0.0090     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.8599     0.0143     0.0279     0.0169     0.0109     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.9133     0.0149     0.0304     0.0198     0.0129     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.9666     0.0131     0.0271     0.0192     0.0128     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.0199     0.0128     0.0272     0.0206     0.0138     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.0732     0.0132     0.0286     0.0227     0.0150     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.1265     0.0137     0.0300     0.0248     0.0163     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.1798     0.0142     0.0315     0.0271     0.0176     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.2331     0.0147     0.0333     0.0295     0.0192     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.2864     0.0151     0.0353     0.0322     0.0212     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.3397     0.0156     0.0377     0.0352     0.0235     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.3930     0.0158     0.0381     0.0337     0.0253     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.4463     0.0160     0.0400     0.0357     0.0276     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.4996     0.0162     0.0427     0.0379     0.0296     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.5529     0.0165     0.0441     0.0394     0.0307     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.6062     0.0178     0.0486     0.0443     0.0344     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.6595     0.0247     0.0642     0.0623     0.0465     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.7128     0.0340     0.0835     0.0842     0.0607     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.7661     0.0343     0.0881     0.0864     0.0654     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.8194     0.0222     0.0730     0.0698     0.0554     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.8727     0.0164     0.0650     0.0611     0.0472     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.9260     0.0088     0.0409     0.0417     0.0234     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.9793     0.0068     0.0392     0.0443     0.0217     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.0326     0.0051     0.0385     0.0470     0.0209     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.0859     0.0038     0.0377     0.0491     0.0208     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.1392     0.0028     0.0368     0.0505     0.0215     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.1925     0.0021     0.0359     0.0513     0.0229     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.2458     0.0019     0.0353     0.0518     0.0254     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.2991     0.0022     0.0346     0.0508     0.0313     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.3524     0.0027     0.0336     0.0477     0.0380     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.4057     0.0034     0.0339     0.0462     0.0459     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.4590     0.0039     0.0348     0.0460     0.0523     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.5123     0.0044     0.0356     0.0456     0.0586     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.5656     0.0049     0.0362     0.0448     0.0652     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.6189     0.0057     0.0378     0.0440     0.0768     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.6722     0.0066     0.0384     0.0425     0.0886     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.7256     0.0092     0.0436     0.0431     0.1229     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.7789     0.0117     0.0484     0.0464     0.1496     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.8322     0.0120     0.0481     0.0489     0.1471     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.8855     0.0118     0.0483     0.0515     0.1379     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.9388     0.0121     0.0562     0.0665     0.1333     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.9921     0.0128     0.0677     0.0855     0.1302     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.0454     0.0143     0.0858     0.1131     0.1249     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.0987     0.0125     0.0666     0.0881     0.1071     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.1520     0.0108     0.0568     0.0763     0.0944     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.2053     0.0093     0.0484     0.0661     0.0832     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.2586     0.0081     0.0411     0.0569     0.0732     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.3119     0.0070     0.0352     0.0496     0.0646     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.3652     0.0060     0.0299     0.0430     0.0568     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.4185     0.0052     0.0253     0.0371     0.0498     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.4718     0.0044     0.0214     0.0320     0.0436     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.5251     0.0038     0.0181     0.0277     0.0382     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.5784     0.0039     0.0168     0.0250     0.0364     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.6317     0.0019     0.0125     0.0216     0.0252     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.6850     0.0007     0.0096     0.0192     0.0206     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.7383     0.0005     0.0080     0.0162     0.0174     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.7916     0.0004     0.0061     0.0124     0.0141     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.8449     0.0002     0.0057     0.0115     0.0133     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.8982     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.9515     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.0048     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.0581     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.1114     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.1647     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.2180     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.2713     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.3246     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.3779     0.0002     0.0001     0.0001     0.0002     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.4312     0.0003     0.0003     0.0002     0.0004     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.4845     0.0005     0.0006     0.0003     0.0007     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.5378     0.0008     0.0009     0.0005     0.0011     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.5912     0.0011     0.0013     0.0007     0.0015     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.6445     0.0015     0.0017     0.0009     0.0021     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.6978     0.0020     0.0023     0.0012     0.0027     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.7511     0.0028     0.0050     0.0028     0.0058     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.8044     0.0040     0.0094     0.0055     0.0113     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.8577     0.0055     0.0154     0.0090     0.0191     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.9110     0.0072     0.0230     0.0135     0.0292     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.9643     0.0100     0.0399     0.0246     0.0502     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.0176     0.0109     0.0394     0.0220     0.0489     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.0709     0.0109     0.0390     0.0215     0.0468     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.1242     0.0120     0.0411     0.0222     0.0443     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.1775     0.0096     0.0330     0.0179     0.0407     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.2308     0.0085     0.0277     0.0149     0.0372     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.2841     0.0103     0.0234     0.0127     0.0380     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.3374     0.0099     0.0183     0.0099     0.0298     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.3907     0.0063     0.0120     0.0065     0.0152     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.4440     0.0023     0.0063     0.0034     0.0045     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.4973     0.0012     0.0030     0.0016     0.0021     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.5506     0.0004     0.0005     0.0002     0.0006     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.6039     0.0002     0.0001     0.0000     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.6572     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.7105     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.7638     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.8171     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.8704     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.9237     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.9770     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     7.0303     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     7.0836     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     7.1369     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     7.1902     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     7.2435     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     7.2968     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     7.3501     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     7.4035     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+       </set>
+      </set>
+      <set comment="ion 2">
+       <set comment="spin 1">
+        <r>    -8.5874     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.5341     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.4808     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.4275     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.3742     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.3209     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.2676     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.2143     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.1610     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.1077     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.0544     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.0011     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.9478     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.8945     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.8412     0.0007     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.7879     0.0104     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.7346     0.0312     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.6813     0.0356     0.0001     0.0000     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.6280     0.0421     0.0001     0.0001     0.0002     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.5747     0.0504     0.0001     0.0001     0.0002     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.5214     0.0605     0.0002     0.0001     0.0003     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.4681     0.0680     0.0002     0.0001     0.0003     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.4148     0.0706     0.0003     0.0001     0.0004     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.3615     0.0775     0.0003     0.0002     0.0006     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.3081     0.0845     0.0004     0.0002     0.0007     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.2548     0.0920     0.0004     0.0002     0.0008     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.2015     0.1000     0.0005     0.0003     0.0009     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.1482     0.1087     0.0006     0.0003     0.0010     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.0949     0.1181     0.0007     0.0004     0.0011     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.0416     0.1312     0.0008     0.0005     0.0013     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.9883     0.1457     0.0009     0.0005     0.0016     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.9350     0.1801     0.0012     0.0007     0.0020     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.8817     0.1943     0.0013     0.0008     0.0022     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.8284     0.1999     0.0014     0.0009     0.0023     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.7751     0.1852     0.0015     0.0009     0.0021     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.7218     0.1868     0.0016     0.0010     0.0022     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.6685     0.1906     0.0018     0.0011     0.0022     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.6152     0.1797     0.0019     0.0012     0.0020     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.5619     0.1665     0.0019     0.0012     0.0018     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.5086     0.1547     0.0019     0.0012     0.0016     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.4553     0.1441     0.0019     0.0012     0.0014     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.4020     0.1475     0.0021     0.0013     0.0014     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.3487     0.1581     0.0025     0.0016     0.0013     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.2954     0.1432     0.0024     0.0015     0.0011     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.2421     0.1198     0.0021     0.0013     0.0009     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.1888     0.0535     0.0011     0.0006     0.0003     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.1355     0.0323     0.0007     0.0004     0.0002     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.0822     0.0158     0.0003     0.0002     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.0289     0.0038     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.9756     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.9223     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.8690     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.8157     0.0052     0.0002     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.7624     0.0154     0.0004     0.0003     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.7091     0.0288     0.0008     0.0005     0.0002     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.6558     0.0455     0.0013     0.0007     0.0004     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.6025     0.1036     0.0027     0.0016     0.0012     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.5492     0.1255     0.0033     0.0020     0.0016     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.4958     0.1404     0.0036     0.0022     0.0020     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.4425     0.1397     0.0036     0.0021     0.0022     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.3892     0.1278     0.0032     0.0019     0.0024     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.3359     0.1301     0.0032     0.0019     0.0027     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.2826     0.1381     0.0034     0.0020     0.0031     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.2293     0.1470     0.0035     0.0021     0.0036     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.1760     0.1568     0.0037     0.0021     0.0041     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.1227     0.1674     0.0039     0.0022     0.0049     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.0694     0.1678     0.0039     0.0022     0.0054     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.0161     0.1537     0.0035     0.0020     0.0052     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.9628     0.1631     0.0037     0.0020     0.0061     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.9095     0.1601     0.0036     0.0020     0.0062     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.8562     0.1531     0.0034     0.0019     0.0061     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.8029     0.1414     0.0032     0.0017     0.0056     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.7496     0.1231     0.0027     0.0015     0.0048     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.6963     0.1082     0.0024     0.0013     0.0041     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.6430     0.1001     0.0022     0.0012     0.0038     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.5897     0.0925     0.0021     0.0011     0.0035     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.5364     0.0852     0.0019     0.0010     0.0032     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.4831     0.0779     0.0017     0.0009     0.0029     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.4298     0.0722     0.0016     0.0008     0.0026     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.3765     0.0685     0.0015     0.0008     0.0025     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.3232     0.0652     0.0014     0.0008     0.0024     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.2699     0.0622     0.0013     0.0007     0.0022     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.2166     0.0593     0.0013     0.0007     0.0021     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.1633     0.0565     0.0012     0.0006     0.0020     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.1100     0.0537     0.0011     0.0006     0.0019     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.0567     0.0511     0.0011     0.0006     0.0018     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.0034     0.0485     0.0010     0.0005     0.0016     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.9501     0.0459     0.0010     0.0005     0.0015     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.8968     0.0432     0.0009     0.0005     0.0014     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.8435     0.0398     0.0008     0.0004     0.0012     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.7902     0.0380     0.0008     0.0004     0.0011     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.7369     0.0361     0.0007     0.0004     0.0010     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.6836     0.0340     0.0007     0.0003     0.0009     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.6302     0.0318     0.0006     0.0003     0.0008     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.5769     0.0296     0.0005     0.0003     0.0008     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.5236     0.0275     0.0005     0.0002     0.0007     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.4703     0.0256     0.0004     0.0002     0.0007     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.4170     0.0238     0.0004     0.0002     0.0006     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.3637     0.0222     0.0004     0.0002     0.0005     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.3104     0.0207     0.0003     0.0002     0.0005     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.2571     0.0194     0.0003     0.0001     0.0004     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.2038     0.0181     0.0003     0.0001     0.0004     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.1505     0.0171     0.0002     0.0001     0.0003     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.0972     0.0187     0.0002     0.0001     0.0003     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.0439     0.0131     0.0001     0.0001     0.0002     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.9906     0.0103     0.0001     0.0000     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.9373     0.0078     0.0001     0.0000     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.8840     0.0056     0.0001     0.0000     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.8307     0.0038     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.7774     0.0024     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.7241     0.0013     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.6708     0.0005     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.6175     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.5642     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.5109     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.4576     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.4043     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.3510     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.2977     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.2444     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.1911     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.1378     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.0845     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.0312     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.9779     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.9246     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.8713     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.8179     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.7646     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.7113     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.6580     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.6047     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.5514     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.4981     0.0048     0.0332     0.0385     0.1146     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.4448     0.0059     0.0313     0.0412     0.1083     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.3915     0.0060     0.0270     0.0350     0.0926     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.3382     0.0062     0.0254     0.0315     0.0860     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.2849     0.0065     0.0238     0.0272     0.0848     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.2316     0.0069     0.0240     0.0254     0.0828     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.1783     0.0073     0.0245     0.0238     0.0806     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.1250     0.0076     0.0256     0.0221     0.0777     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.0717     0.0071     0.0544     0.0509     0.0811     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.0184     0.0057     0.0625     0.0643     0.0624     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.9651     0.0046     0.0757     0.0895     0.0529     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.9118     0.0043     0.0690     0.0762     0.0484     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.8585     0.0040     0.0698     0.0767     0.0453     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.8052     0.0038     0.0690     0.0746     0.0422     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.7519     0.0035     0.0698     0.0758     0.0397     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.6986     0.0033     0.0743     0.0853     0.0355     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.6453     0.0030     0.0742     0.0885     0.0330     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.5920     0.0028     0.0731     0.0906     0.0312     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.5387     0.0026     0.0710     0.0914     0.0303     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.4854     0.0022     0.0690     0.0921     0.0270     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.4321     0.0018     0.0657     0.0961     0.0237     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.3788     0.0015     0.0636     0.1040     0.0205     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.3255     0.0012     0.0567     0.0963     0.0179     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.2722     0.0009     0.0473     0.0818     0.0153     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.2189     0.0007     0.0374     0.0653     0.0131     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.1656     0.0008     0.0311     0.0551     0.0116     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.1123     0.0010     0.0240     0.0408     0.0105     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.0590     0.0014     0.0199     0.0331     0.0099     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.0057     0.0019     0.0174     0.0292     0.0104     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.0477     0.0026     0.0155     0.0260     0.0107     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.1010     0.0034     0.0143     0.0235     0.0109     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.1543     0.0043     0.0129     0.0195     0.0105     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.2076     0.0054     0.0118     0.0119     0.0081     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.2609     0.0066     0.0084     0.0070     0.0071     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.3142     0.0104     0.0093     0.0054     0.0164     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.3675     0.0108     0.0091     0.0046     0.0110     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.4208     0.0127     0.0110     0.0056     0.0130     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.4741     0.0145     0.0128     0.0065     0.0148     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.5274     0.0161     0.0145     0.0074     0.0162     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.5807     0.0177     0.0161     0.0082     0.0174     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.6340     0.0191     0.0176     0.0090     0.0183     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.6873     0.0205     0.0192     0.0098     0.0190     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.7406     0.0266     0.0259     0.0135     0.0230     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.7939     0.0321     0.0330     0.0180     0.0260     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.8472     0.0327     0.0345     0.0195     0.0253     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.9005     0.0346     0.0370     0.0214     0.0255     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.9538     0.0366     0.0400     0.0236     0.0255     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.0071     0.0387     0.0436     0.0261     0.0250     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.0604     0.0403     0.0450     0.0275     0.0252     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.1137     0.0462     0.0534     0.0325     0.0259     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.1670     0.0521     0.0618     0.0378     0.0267     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.2203     0.0648     0.0786     0.0487     0.0295     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.2736     0.0605     0.0708     0.0465     0.0285     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.3269     0.0549     0.0631     0.0433     0.0254     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.3802     0.0481     0.0552     0.0393     0.0215     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.4335     0.0386     0.0458     0.0329     0.0157     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.4868     0.0357     0.0429     0.0308     0.0145     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.5401     0.0331     0.0408     0.0289     0.0134     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.5934     0.0309     0.0393     0.0274     0.0127     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.6467     0.0290     0.0386     0.0261     0.0121     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.7000     0.0274     0.0385     0.0251     0.0119     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.7533     0.0263     0.0392     0.0246     0.0119     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.8066     0.0133     0.0252     0.0142     0.0090     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.8599     0.0143     0.0279     0.0169     0.0109     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.9133     0.0149     0.0304     0.0198     0.0129     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.9666     0.0131     0.0271     0.0192     0.0128     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.0199     0.0128     0.0272     0.0206     0.0138     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.0732     0.0132     0.0286     0.0227     0.0151     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.1265     0.0137     0.0300     0.0248     0.0163     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.1798     0.0142     0.0315     0.0271     0.0176     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.2331     0.0147     0.0332     0.0295     0.0192     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.2864     0.0151     0.0353     0.0322     0.0212     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.3397     0.0156     0.0377     0.0352     0.0235     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.3930     0.0158     0.0381     0.0337     0.0253     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.4463     0.0160     0.0400     0.0357     0.0276     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.4996     0.0162     0.0427     0.0379     0.0297     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.5529     0.0165     0.0441     0.0393     0.0307     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.6062     0.0178     0.0486     0.0443     0.0344     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.6595     0.0247     0.0642     0.0624     0.0465     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.7128     0.0340     0.0834     0.0843     0.0607     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.7661     0.0343     0.0879     0.0866     0.0653     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.8194     0.0222     0.0727     0.0701     0.0553     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.8727     0.0164     0.0647     0.0615     0.0472     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.9260     0.0088     0.0410     0.0417     0.0234     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.9793     0.0068     0.0394     0.0442     0.0217     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.0326     0.0051     0.0387     0.0468     0.0209     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.0859     0.0038     0.0379     0.0489     0.0208     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.1392     0.0028     0.0370     0.0503     0.0215     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.1925     0.0021     0.0361     0.0511     0.0230     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.2458     0.0019     0.0355     0.0516     0.0255     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.2991     0.0022     0.0347     0.0507     0.0313     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.3524     0.0027     0.0337     0.0477     0.0380     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.4057     0.0034     0.0339     0.0462     0.0459     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.4590     0.0039     0.0348     0.0460     0.0523     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.5123     0.0044     0.0356     0.0456     0.0586     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.5656     0.0049     0.0363     0.0448     0.0652     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.6189     0.0057     0.0378     0.0440     0.0768     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.6722     0.0066     0.0384     0.0425     0.0886     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.7256     0.0092     0.0436     0.0431     0.1229     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.7789     0.0117     0.0484     0.0464     0.1496     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.8322     0.0120     0.0481     0.0489     0.1471     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.8855     0.0118     0.0483     0.0515     0.1379     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.9388     0.0121     0.0562     0.0665     0.1333     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.9921     0.0128     0.0677     0.0855     0.1302     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.0454     0.0143     0.0858     0.1131     0.1249     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.0987     0.0125     0.0666     0.0881     0.1071     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.1520     0.0108     0.0568     0.0763     0.0944     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.2053     0.0093     0.0484     0.0661     0.0832     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.2586     0.0081     0.0411     0.0569     0.0732     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.3119     0.0070     0.0352     0.0496     0.0646     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.3652     0.0060     0.0299     0.0430     0.0568     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.4185     0.0052     0.0253     0.0371     0.0498     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.4718     0.0044     0.0214     0.0320     0.0436     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.5251     0.0038     0.0181     0.0277     0.0382     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.5784     0.0039     0.0168     0.0250     0.0364     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.6317     0.0019     0.0125     0.0216     0.0252     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.6850     0.0007     0.0096     0.0192     0.0206     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.7383     0.0005     0.0080     0.0162     0.0174     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.7916     0.0004     0.0061     0.0124     0.0141     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.8449     0.0002     0.0057     0.0115     0.0133     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.8982     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.9515     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.0048     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.0581     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.1114     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.1647     0.0002     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.2180     0.0003     0.0000     0.0000     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.2713     0.0004     0.0000     0.0000     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.3246     0.0006     0.0001     0.0000     0.0002     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.3779     0.0009     0.0002     0.0001     0.0003     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.4312     0.0012     0.0004     0.0002     0.0006     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.4845     0.0016     0.0007     0.0003     0.0009     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.5378     0.0021     0.0010     0.0005     0.0014     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.5912     0.0032     0.0016     0.0008     0.0023     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.6445     0.0042     0.0022     0.0011     0.0032     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.6978     0.0053     0.0029     0.0015     0.0041     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.7511     0.0058     0.0055     0.0031     0.0071     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.8044     0.0064     0.0098     0.0057     0.0124     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.8577     0.0074     0.0157     0.0092     0.0199     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.9110     0.0087     0.0231     0.0137     0.0299     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.9643     0.0111     0.0399     0.0246     0.0507     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.0176     0.0116     0.0392     0.0220     0.0492     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.0709     0.0113     0.0386     0.0214     0.0470     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.1242     0.0121     0.0407     0.0221     0.0444     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.1775     0.0096     0.0325     0.0178     0.0407     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.2308     0.0085     0.0272     0.0148     0.0371     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.2841     0.0103     0.0230     0.0126     0.0379     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.3374     0.0099     0.0178     0.0099     0.0296     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.3907     0.0062     0.0116     0.0065     0.0150     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.4440     0.0022     0.0060     0.0034     0.0044     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.4973     0.0011     0.0028     0.0016     0.0020     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.5506     0.0003     0.0003     0.0002     0.0006     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.6039     0.0000     0.0000     0.0000     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.6572     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.7105     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.7638     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.8171     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.8704     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.9237     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.9770     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     7.0303     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     7.0836     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     7.1369     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     7.1902     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     7.2435     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     7.2968     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     7.3501     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     7.4035     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+       </set>
+       <set comment="spin 2">
+        <r>    -8.5874     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.5341     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.4808     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.4275     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.3742     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.3209     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.2676     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.2143     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.1610     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.1077     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.0544     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.0011     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.9478     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.8945     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.8412     0.0007     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.7879     0.0104     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.7346     0.0312     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.6813     0.0356     0.0001     0.0000     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.6280     0.0421     0.0001     0.0001     0.0002     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.5747     0.0504     0.0001     0.0001     0.0002     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.5214     0.0605     0.0002     0.0001     0.0003     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.4681     0.0680     0.0002     0.0001     0.0003     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.4148     0.0706     0.0003     0.0001     0.0004     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.3615     0.0775     0.0003     0.0002     0.0006     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.3081     0.0845     0.0004     0.0002     0.0007     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.2548     0.0920     0.0004     0.0002     0.0008     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.2015     0.1000     0.0005     0.0003     0.0009     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.1482     0.1087     0.0006     0.0003     0.0010     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.0949     0.1181     0.0007     0.0004     0.0011     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.0416     0.1312     0.0008     0.0005     0.0013     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.9883     0.1457     0.0009     0.0005     0.0016     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.9350     0.1801     0.0012     0.0007     0.0020     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.8817     0.1943     0.0013     0.0008     0.0022     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.8284     0.1999     0.0014     0.0009     0.0023     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.7751     0.1852     0.0015     0.0009     0.0021     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.7218     0.1868     0.0016     0.0010     0.0022     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.6685     0.1906     0.0018     0.0011     0.0022     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.6152     0.1797     0.0019     0.0012     0.0020     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.5619     0.1665     0.0019     0.0012     0.0018     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.5086     0.1547     0.0019     0.0012     0.0016     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.4553     0.1441     0.0019     0.0012     0.0014     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.4020     0.1475     0.0021     0.0013     0.0014     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.3487     0.1581     0.0025     0.0016     0.0013     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.2954     0.1432     0.0024     0.0015     0.0011     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.2421     0.1198     0.0021     0.0013     0.0009     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.1888     0.0535     0.0011     0.0006     0.0003     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.1355     0.0323     0.0007     0.0004     0.0002     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.0822     0.0158     0.0003     0.0002     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.0289     0.0038     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.9756     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.9223     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.8690     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.8157     0.0052     0.0002     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.7624     0.0154     0.0004     0.0003     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.7091     0.0288     0.0008     0.0005     0.0002     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.6558     0.0455     0.0013     0.0007     0.0004     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.6025     0.1036     0.0027     0.0016     0.0012     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.5492     0.1255     0.0033     0.0020     0.0016     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.4958     0.1404     0.0036     0.0022     0.0020     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.4425     0.1397     0.0036     0.0021     0.0022     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.3892     0.1278     0.0032     0.0019     0.0024     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.3359     0.1301     0.0032     0.0019     0.0027     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.2826     0.1381     0.0034     0.0020     0.0031     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.2293     0.1470     0.0035     0.0021     0.0036     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.1760     0.1568     0.0037     0.0021     0.0041     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.1227     0.1674     0.0039     0.0022     0.0049     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.0694     0.1678     0.0039     0.0022     0.0054     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.0161     0.1537     0.0035     0.0020     0.0052     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.9628     0.1631     0.0037     0.0020     0.0061     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.9095     0.1601     0.0036     0.0020     0.0062     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.8562     0.1531     0.0034     0.0019     0.0061     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.8029     0.1414     0.0032     0.0017     0.0056     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.7496     0.1231     0.0027     0.0015     0.0048     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.6963     0.1082     0.0024     0.0013     0.0041     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.6430     0.1001     0.0022     0.0012     0.0038     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.5897     0.0925     0.0021     0.0011     0.0035     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.5364     0.0852     0.0019     0.0010     0.0032     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.4831     0.0779     0.0017     0.0009     0.0029     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.4298     0.0722     0.0016     0.0008     0.0026     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.3765     0.0685     0.0015     0.0008     0.0025     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.3232     0.0652     0.0014     0.0008     0.0024     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.2699     0.0622     0.0013     0.0007     0.0022     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.2166     0.0593     0.0013     0.0007     0.0021     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.1633     0.0565     0.0012     0.0006     0.0020     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.1100     0.0537     0.0011     0.0006     0.0019     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.0567     0.0511     0.0011     0.0006     0.0018     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -4.0034     0.0485     0.0010     0.0005     0.0016     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.9501     0.0459     0.0010     0.0005     0.0015     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.8968     0.0432     0.0009     0.0005     0.0014     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.8435     0.0398     0.0008     0.0004     0.0012     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.7902     0.0380     0.0008     0.0004     0.0011     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.7369     0.0361     0.0007     0.0004     0.0010     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.6836     0.0340     0.0007     0.0003     0.0009     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.6302     0.0318     0.0006     0.0003     0.0008     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.5769     0.0296     0.0005     0.0003     0.0008     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.5236     0.0275     0.0005     0.0002     0.0007     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.4703     0.0256     0.0004     0.0002     0.0007     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.4170     0.0238     0.0004     0.0002     0.0006     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.3637     0.0222     0.0004     0.0002     0.0005     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.3104     0.0207     0.0003     0.0002     0.0005     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.2571     0.0194     0.0003     0.0001     0.0004     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.2038     0.0181     0.0003     0.0001     0.0004     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.1505     0.0171     0.0002     0.0001     0.0003     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.0972     0.0187     0.0002     0.0001     0.0003     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.0439     0.0131     0.0001     0.0001     0.0002     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.9906     0.0103     0.0001     0.0000     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.9373     0.0078     0.0001     0.0000     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.8840     0.0056     0.0001     0.0000     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.8307     0.0038     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.7774     0.0024     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.7241     0.0013     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.6708     0.0005     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.6175     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.5642     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.5109     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.4576     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.4043     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.3510     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.2977     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.2444     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.1911     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.1378     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.0845     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.0312     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.9779     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.9246     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.8713     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.8179     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.7646     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.7113     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.6580     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.6047     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.5514     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.4981     0.0048     0.0332     0.0385     0.1146     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.4448     0.0059     0.0313     0.0412     0.1083     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.3915     0.0060     0.0270     0.0350     0.0926     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.3382     0.0062     0.0254     0.0315     0.0860     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.2849     0.0065     0.0238     0.0272     0.0848     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.2316     0.0069     0.0240     0.0254     0.0828     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.1783     0.0073     0.0245     0.0238     0.0806     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.1250     0.0076     0.0256     0.0221     0.0777     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.0717     0.0071     0.0544     0.0509     0.0811     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.0184     0.0057     0.0625     0.0643     0.0624     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.9651     0.0046     0.0757     0.0895     0.0529     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.9118     0.0043     0.0690     0.0762     0.0484     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.8585     0.0040     0.0698     0.0767     0.0453     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.8052     0.0038     0.0690     0.0746     0.0422     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.7519     0.0035     0.0699     0.0758     0.0397     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.6986     0.0033     0.0743     0.0853     0.0355     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.6453     0.0030     0.0742     0.0885     0.0330     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.5920     0.0028     0.0731     0.0905     0.0312     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.5387     0.0026     0.0710     0.0914     0.0303     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.4854     0.0022     0.0690     0.0921     0.0270     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.4321     0.0018     0.0657     0.0961     0.0237     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.3788     0.0015     0.0636     0.1040     0.0205     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.3255     0.0012     0.0566     0.0963     0.0179     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.2722     0.0009     0.0473     0.0819     0.0153     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.2189     0.0007     0.0374     0.0653     0.0131     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.1656     0.0008     0.0310     0.0551     0.0116     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.1123     0.0010     0.0240     0.0408     0.0105     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.0590     0.0014     0.0199     0.0331     0.0099     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.0057     0.0019     0.0174     0.0292     0.0104     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.0477     0.0026     0.0155     0.0260     0.0107     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.1010     0.0034     0.0143     0.0236     0.0109     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.1543     0.0043     0.0129     0.0195     0.0105     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.2076     0.0054     0.0118     0.0119     0.0081     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.2609     0.0066     0.0084     0.0070     0.0071     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.3142     0.0104     0.0093     0.0054     0.0164     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.3675     0.0108     0.0091     0.0046     0.0110     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.4208     0.0127     0.0110     0.0056     0.0130     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.4741     0.0145     0.0128     0.0065     0.0148     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.5274     0.0161     0.0145     0.0074     0.0162     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.5807     0.0177     0.0161     0.0082     0.0174     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.6340     0.0191     0.0176     0.0090     0.0183     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.6873     0.0205     0.0192     0.0098     0.0190     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.7406     0.0266     0.0259     0.0135     0.0230     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.7939     0.0321     0.0330     0.0180     0.0260     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.8472     0.0327     0.0345     0.0195     0.0253     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.9005     0.0346     0.0370     0.0214     0.0255     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.9538     0.0366     0.0400     0.0236     0.0255     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.0071     0.0387     0.0436     0.0261     0.0250     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.0604     0.0403     0.0450     0.0275     0.0252     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.1137     0.0462     0.0534     0.0325     0.0259     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.1670     0.0521     0.0618     0.0378     0.0267     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.2203     0.0648     0.0786     0.0487     0.0295     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.2736     0.0605     0.0708     0.0465     0.0285     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.3269     0.0549     0.0631     0.0433     0.0254     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.3802     0.0481     0.0552     0.0393     0.0215     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.4335     0.0386     0.0458     0.0329     0.0157     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.4868     0.0357     0.0429     0.0308     0.0145     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.5401     0.0331     0.0408     0.0289     0.0134     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.5934     0.0309     0.0393     0.0274     0.0127     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.6467     0.0290     0.0386     0.0261     0.0121     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.7000     0.0274     0.0385     0.0251     0.0119     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.7533     0.0263     0.0392     0.0246     0.0119     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.8066     0.0133     0.0252     0.0142     0.0090     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.8599     0.0143     0.0279     0.0169     0.0109     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.9133     0.0149     0.0304     0.0198     0.0129     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     1.9666     0.0131     0.0271     0.0192     0.0128     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.0199     0.0128     0.0272     0.0206     0.0138     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.0732     0.0132     0.0287     0.0227     0.0150     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.1265     0.0137     0.0300     0.0248     0.0163     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.1798     0.0142     0.0315     0.0271     0.0176     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.2331     0.0147     0.0333     0.0295     0.0192     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.2864     0.0151     0.0353     0.0322     0.0212     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.3397     0.0156     0.0377     0.0352     0.0235     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.3930     0.0158     0.0381     0.0337     0.0253     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.4463     0.0160     0.0400     0.0357     0.0276     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.4996     0.0162     0.0427     0.0379     0.0296     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.5529     0.0165     0.0441     0.0394     0.0307     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.6062     0.0178     0.0486     0.0443     0.0344     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.6595     0.0247     0.0642     0.0623     0.0465     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.7128     0.0340     0.0835     0.0842     0.0607     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.7661     0.0343     0.0881     0.0864     0.0654     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.8194     0.0222     0.0730     0.0698     0.0554     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.8727     0.0164     0.0650     0.0611     0.0472     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.9260     0.0088     0.0409     0.0417     0.0234     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     2.9793     0.0068     0.0392     0.0443     0.0217     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.0326     0.0051     0.0385     0.0470     0.0209     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.0859     0.0038     0.0377     0.0491     0.0208     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.1392     0.0028     0.0368     0.0505     0.0215     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.1925     0.0021     0.0359     0.0513     0.0229     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.2458     0.0019     0.0353     0.0518     0.0254     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.2991     0.0022     0.0346     0.0508     0.0313     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.3524     0.0027     0.0336     0.0477     0.0380     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.4057     0.0034     0.0339     0.0462     0.0459     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.4590     0.0039     0.0348     0.0460     0.0523     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.5123     0.0044     0.0356     0.0456     0.0586     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.5656     0.0049     0.0363     0.0448     0.0652     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.6189     0.0057     0.0378     0.0440     0.0768     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.6722     0.0066     0.0384     0.0425     0.0886     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.7256     0.0092     0.0436     0.0431     0.1229     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.7789     0.0117     0.0484     0.0464     0.1496     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.8322     0.0120     0.0481     0.0489     0.1471     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.8855     0.0118     0.0483     0.0515     0.1379     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.9388     0.0121     0.0562     0.0665     0.1333     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     3.9921     0.0128     0.0677     0.0855     0.1302     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.0454     0.0143     0.0858     0.1131     0.1249     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.0987     0.0125     0.0666     0.0881     0.1071     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.1520     0.0108     0.0568     0.0763     0.0944     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.2053     0.0093     0.0484     0.0661     0.0832     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.2586     0.0081     0.0411     0.0569     0.0732     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.3119     0.0070     0.0352     0.0496     0.0646     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.3652     0.0060     0.0299     0.0430     0.0568     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.4185     0.0052     0.0253     0.0371     0.0498     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.4718     0.0044     0.0214     0.0320     0.0436     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.5251     0.0038     0.0181     0.0277     0.0382     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.5784     0.0039     0.0168     0.0250     0.0364     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.6317     0.0019     0.0125     0.0216     0.0252     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.6850     0.0007     0.0096     0.0192     0.0206     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.7383     0.0005     0.0080     0.0162     0.0174     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.7916     0.0004     0.0061     0.0124     0.0141     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.8449     0.0002     0.0057     0.0115     0.0133     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.8982     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.9515     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.0048     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.0581     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.1114     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.1647     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.2180     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.2713     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.3246     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.3779     0.0002     0.0001     0.0001     0.0002     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.4312     0.0003     0.0003     0.0002     0.0004     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.4845     0.0005     0.0006     0.0003     0.0007     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.5378     0.0008     0.0009     0.0005     0.0011     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.5912     0.0011     0.0013     0.0007     0.0015     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.6445     0.0015     0.0017     0.0009     0.0021     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.6978     0.0020     0.0023     0.0012     0.0027     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.7511     0.0028     0.0050     0.0028     0.0058     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.8044     0.0040     0.0094     0.0055     0.0113     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.8577     0.0055     0.0154     0.0090     0.0191     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.9110     0.0072     0.0230     0.0135     0.0292     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.9643     0.0100     0.0399     0.0245     0.0502     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.0176     0.0109     0.0393     0.0220     0.0489     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.0709     0.0109     0.0389     0.0214     0.0468     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.1242     0.0120     0.0410     0.0222     0.0443     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.1775     0.0096     0.0329     0.0178     0.0407     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.2308     0.0085     0.0276     0.0149     0.0372     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.2841     0.0103     0.0234     0.0127     0.0380     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.3374     0.0099     0.0182     0.0099     0.0298     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.3907     0.0063     0.0120     0.0064     0.0152     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.4440     0.0023     0.0063     0.0034     0.0045     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.4973     0.0012     0.0030     0.0016     0.0021     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.5506     0.0004     0.0005     0.0002     0.0006     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.6039     0.0002     0.0001     0.0000     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.6572     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.7105     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.7638     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.8171     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.8704     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.9237     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     6.9770     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     7.0303     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     7.0836     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     7.1369     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     7.1902     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     7.2435     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     7.2968     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     7.3501     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     7.4035     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+       </set>
+      </set>
+     </set>
+    </array>
+   </partial>
+  </dos>
+  <projected>
+   <eigenvalues>
+    <array>
+     <dimension dim="1">band</dimension>
+     <dimension dim="2">kpoint</dimension>
+     <dimension dim="3">spin</dimension>
+     <field>eigene</field>
+     <field>occ</field>
+     <set>
+      <set comment="spin 1">
+       <set comment="kpoint 1">
+        <r>   -7.8606    1.0000 </r>
+        <r>   -2.5809    1.0000 </r>
+        <r>    0.3711    1.0000 </r>
+        <r>    0.3711    1.0000 </r>
+        <r>    0.3711    1.0000 </r>
+        <r>    2.1323    0.0000 </r>
+        <r>    2.1323    0.0000 </r>
+        <r>    2.1323    0.0000 </r>
+        <r>    4.9292    0.0000 </r>
+       </set>
+       <set comment="kpoint 2">
+        <r>   -7.7345    1.0000 </r>
+        <r>   -3.0514    1.0000 </r>
+        <r>    0.2008    1.0000 </r>
+        <r>    0.2008    1.0000 </r>
+        <r>    0.3099    1.0000 </r>
+        <r>    2.3797    0.0000 </r>
+        <r>    2.3797    0.0000 </r>
+        <r>    2.4243    0.0000 </r>
+        <r>    5.5425    0.0000 </r>
+       </set>
+       <set comment="kpoint 3">
+        <r>   -7.3855    1.0000 </r>
+        <r>   -3.9878    1.0000 </r>
+        <r>   -0.0758    1.0000 </r>
+        <r>   -0.0758    1.0000 </r>
+        <r>    0.0091    1.0158 </r>
+        <r>    2.7614    0.0000 </r>
+        <r>    2.7614    0.0000 </r>
+        <r>    3.4433    0.0000 </r>
+        <r>    6.6369    0.0000 </r>
+       </set>
+       <set comment="kpoint 4">
+        <r>   -6.9717    1.0000 </r>
+        <r>   -4.7740    1.0000 </r>
+        <r>   -0.2434    1.0000 </r>
+        <r>   -0.2433    1.0000 </r>
+        <r>   -0.2244    1.0157 </r>
+        <r>    2.9237    0.0000 </r>
+        <r>    2.9237    0.0000 </r>
+        <r>    4.6557    0.0000 </r>
+        <r>    6.3955    0.0000 </r>
+       </set>
+       <set comment="kpoint 5">
+        <r>   -7.6909    1.0000 </r>
+        <r>   -3.1709    1.0000 </r>
+        <r>   -0.0607    1.0000 </r>
+        <r>   -0.0607    1.0000 </r>
+        <r>    0.8940    1.0150 </r>
+        <r>    1.7297    0.0000 </r>
+        <r>    2.7601    0.0000 </r>
+        <r>    2.7601    0.0000 </r>
+        <r>    5.9455    0.0000 </r>
+       </set>
+       <set comment="kpoint 6">
+        <r>   -7.5307    1.0000 </r>
+        <r>   -3.6161    1.0000 </r>
+        <r>   -0.5290    1.0000 </r>
+        <r>    0.1395    1.0000 </r>
+        <r>    0.6743    1.0333 </r>
+        <r>    2.4298    0.0000 </r>
+        <r>    2.5117    0.0000 </r>
+        <r>    3.1808    0.0000 </r>
+        <r>    6.1251    0.0000 </r>
+       </set>
+       <set comment="kpoint 7">
+        <r>   -7.1319    1.0000 </r>
+        <r>   -4.4394    1.0000 </r>
+        <r>   -1.0205    1.0000 </r>
+        <r>   -0.1502    1.0000 </r>
+        <r>    0.7486    1.0708 </r>
+        <r>    2.8917    0.0000 </r>
+        <r>    2.9400    0.0000 </r>
+        <r>    3.7588    0.0000 </r>
+        <r>    6.2499    0.0000 </r>
+       </set>
+       <set comment="kpoint 8">
+        <r>   -6.7826    1.0000 </r>
+        <r>   -5.0008    1.0000 </r>
+        <r>   -1.1570    1.0000 </r>
+        <r>   -0.3911    1.0000 </r>
+        <r>    0.7354    1.0803 </r>
+        <r>    2.8820    0.0000 </r>
+        <r>    3.2495    0.0000 </r>
+        <r>    4.5321    0.0000 </r>
+        <r>    6.2579    0.0000 </r>
+       </set>
+       <set comment="kpoint 9">
+        <r>   -6.9794    1.0000 </r>
+        <r>   -4.6981    1.0000 </r>
+        <r>   -0.9652    1.0000 </r>
+        <r>   -0.4652    1.0000 </r>
+        <r>    0.8423    1.0328 </r>
+        <r>    2.5610    0.0000 </r>
+        <r>    3.3803    0.0000 </r>
+        <r>    4.0187    0.0000 </r>
+        <r>    6.4141    0.0000 </r>
+       </set>
+       <set comment="kpoint 10">
+        <r>   -7.4087    1.0000 </r>
+        <r>   -3.8876    1.0000 </r>
+        <r>   -0.5132    1.0000 </r>
+        <r>   -0.3422    1.0000 </r>
+        <r>    1.0160    0.9770 </r>
+        <r>    1.9237    0.0000 </r>
+        <r>    3.2261    0.0000 </r>
+        <r>    3.3737    0.0000 </r>
+        <r>    5.7033    0.0000 </r>
+       </set>
+       <set comment="kpoint 11">
+        <r>   -7.1948    1.0000 </r>
+        <r>   -4.2789    1.0000 </r>
+        <r>   -0.6469    1.0000 </r>
+        <r>   -0.6469    1.0000 </r>
+        <r>    1.2147    0.3625 </r>
+        <r>    1.4550    0.0000 </r>
+        <r>    3.8936    0.0000 </r>
+        <r>    3.8936    0.0000 </r>
+        <r>    5.2682    0.0000 </r>
+       </set>
+       <set comment="kpoint 12">
+        <r>   -6.7112    1.0000 </r>
+        <r>   -5.0327    1.0000 </r>
+        <r>   -1.5458    1.0000 </r>
+        <r>   -0.4632    1.0000 </r>
+        <r>    1.1631    0.3931 </r>
+        <r>    3.3030    0.0000 </r>
+        <r>    3.5639    0.0000 </r>
+        <r>    3.7066    0.0000 </r>
+        <r>    6.4338    0.0000 </r>
+       </set>
+       <set comment="kpoint 13">
+        <r>   -6.4412    1.0000 </r>
+        <r>   -5.3709    1.0000 </r>
+        <r>   -1.5341    1.0000 </r>
+        <r>   -0.7204    1.0000 </r>
+        <r>    1.2015    0.1774 </r>
+        <r>    2.8244    0.0000 </r>
+        <r>    4.0138    0.0000 </r>
+        <r>    4.0862    0.0000 </r>
+        <r>    5.7042    0.0000 </r>
+       </set>
+       <set comment="kpoint 14">
+        <r>   -6.7889    1.0000 </r>
+        <r>   -4.9219    1.0000 </r>
+        <r>   -1.1048    1.0000 </r>
+        <r>   -0.7906    1.0000 </r>
+        <r>    1.2522    0.1173 </r>
+        <r>    1.8047    0.0000 </r>
+        <r>    4.0652    0.0000 </r>
+        <r>    4.2406    0.0000 </r>
+        <r>    6.0011    0.0000 </r>
+       </set>
+       <set comment="kpoint 15">
+        <r>   -6.4124    1.0000 </r>
+        <r>   -5.4102    1.0000 </r>
+        <r>   -0.9791    1.0000 </r>
+        <r>   -0.9791    1.0000 </r>
+        <r>    1.0567    0.6439 </r>
+        <r>    1.2765    0.0000 </r>
+        <r>    4.8939    0.0000 </r>
+        <r>    4.8939    0.0000 </r>
+        <r>    6.0805    0.0000 </r>
+       </set>
+       <set comment="kpoint 16">
+        <r>   -6.0251    1.0000 </r>
+        <r>   -5.8312    1.0000 </r>
+        <r>   -1.3152    1.0000 </r>
+        <r>   -0.9524    1.0000 </r>
+        <r>    1.1618    0.2150 </r>
+        <r>    1.7644    0.0000 </r>
+        <r>    4.6792    0.0000 </r>
+        <r>    4.8198    0.0000 </r>
+        <r>    6.1589    0.0000 </r>
+       </set>
+       <set comment="kpoint 17">
+        <r>   -7.0670    1.0000 </r>
+        <r>   -4.5098    1.0000 </r>
+        <r>   -1.0908    1.0000 </r>
+        <r>   -0.5078    1.0000 </r>
+        <r>    1.3789    0.2223 </r>
+        <r>    2.0258    0.0000 </r>
+        <r>    3.5667    0.0000 </r>
+        <r>    3.7560    0.0000 </r>
+        <r>    5.9038    0.0000 </r>
+       </set>
+       <set comment="kpoint 18">
+        <r>   -6.6382    1.0000 </r>
+        <r>   -5.1337    1.0000 </r>
+        <r>   -1.4343    1.0000 </r>
+        <r>   -0.7172    1.0000 </r>
+        <r>    1.4297    0.0995 </r>
+        <r>    2.6438    0.0000 </r>
+        <r>    3.6856    0.0000 </r>
+        <r>    4.0539    0.0000 </r>
+        <r>    5.9919    0.0000 </r>
+       </set>
+       <set comment="kpoint 19">
+        <r>   -6.2029    1.0000 </r>
+        <r>   -5.6258    1.0000 </r>
+        <r>   -1.5405    1.0000 </r>
+        <r>   -1.0522    1.0000 </r>
+        <r>    1.7790   -0.0260 </r>
+        <r>    2.7711    0.0000 </r>
+        <r>    3.7947    0.0000 </r>
+        <r>    3.9329    0.0000 </r>
+        <r>    5.9184    0.0000 </r>
+       </set>
+       <set comment="kpoint 20">
+        <r>   -6.3514    1.0000 </r>
+        <r>   -5.4667    1.0000 </r>
+        <r>   -1.3000    1.0000 </r>
+        <r>   -1.0877    1.0000 </r>
+        <r>    1.7704   -0.0833 </r>
+        <r>    1.8023    0.0000 </r>
+        <r>    3.9839    0.0000 </r>
+        <r>    4.5775    0.0000 </r>
+        <r>    6.5537    0.0000 </r>
+       </set>
+      </set>
+      <set comment="spin 2">
+       <set comment="kpoint 1">
+        <r>   -7.8606    1.0000 </r>
+        <r>   -2.5809    1.0000 </r>
+        <r>    0.3711    1.0000 </r>
+        <r>    0.3711    1.0000 </r>
+        <r>    0.3711    1.0000 </r>
+        <r>    2.1323    0.0000 </r>
+        <r>    2.1323    0.0000 </r>
+        <r>    2.1323    0.0000 </r>
+        <r>    4.9292    0.0000 </r>
+       </set>
+       <set comment="kpoint 2">
+        <r>   -7.7345    1.0000 </r>
+        <r>   -3.0514    1.0000 </r>
+        <r>    0.2008    1.0000 </r>
+        <r>    0.2008    1.0000 </r>
+        <r>    0.3099    1.0000 </r>
+        <r>    2.3797    0.0000 </r>
+        <r>    2.3797    0.0000 </r>
+        <r>    2.4243    0.0000 </r>
+        <r>    6.6766    0.0000 </r>
+       </set>
+       <set comment="kpoint 3">
+        <r>   -7.3855    1.0000 </r>
+        <r>   -3.9878    1.0000 </r>
+        <r>   -0.0758    1.0000 </r>
+        <r>   -0.0758    1.0000 </r>
+        <r>    0.0091    1.0158 </r>
+        <r>    2.7614    0.0000 </r>
+        <r>    2.7614    0.0000 </r>
+        <r>    3.4433    0.0000 </r>
+        <r>    6.6369    0.0000 </r>
+       </set>
+       <set comment="kpoint 4">
+        <r>   -6.9717    1.0000 </r>
+        <r>   -4.7740    1.0000 </r>
+        <r>   -0.2434    1.0000 </r>
+        <r>   -0.2433    1.0000 </r>
+        <r>   -0.2244    1.0157 </r>
+        <r>    2.9237    0.0000 </r>
+        <r>    2.9237    0.0000 </r>
+        <r>    4.6557    0.0000 </r>
+        <r>    6.3954    0.0000 </r>
+       </set>
+       <set comment="kpoint 5">
+        <r>   -7.6909    1.0000 </r>
+        <r>   -3.1709    1.0000 </r>
+        <r>   -0.0607    1.0000 </r>
+        <r>   -0.0607    1.0000 </r>
+        <r>    0.8940    1.0150 </r>
+        <r>    1.7297    0.0000 </r>
+        <r>    2.7601    0.0000 </r>
+        <r>    2.7601    0.0000 </r>
+        <r>    5.9455    0.0000 </r>
+       </set>
+       <set comment="kpoint 6">
+        <r>   -7.5307    1.0000 </r>
+        <r>   -3.6161    1.0000 </r>
+        <r>   -0.5290    1.0000 </r>
+        <r>    0.1395    1.0000 </r>
+        <r>    0.6743    1.0333 </r>
+        <r>    2.4298    0.0000 </r>
+        <r>    2.5117    0.0000 </r>
+        <r>    3.1808    0.0000 </r>
+        <r>    6.1251    0.0000 </r>
+       </set>
+       <set comment="kpoint 7">
+        <r>   -7.1319    1.0000 </r>
+        <r>   -4.4394    1.0000 </r>
+        <r>   -1.0205    1.0000 </r>
+        <r>   -0.1502    1.0000 </r>
+        <r>    0.7486    1.0708 </r>
+        <r>    2.8917    0.0000 </r>
+        <r>    2.9400    0.0000 </r>
+        <r>    3.7588    0.0000 </r>
+        <r>    6.2499    0.0000 </r>
+       </set>
+       <set comment="kpoint 8">
+        <r>   -6.7826    1.0000 </r>
+        <r>   -5.0008    1.0000 </r>
+        <r>   -1.1570    1.0000 </r>
+        <r>   -0.3911    1.0000 </r>
+        <r>    0.7354    1.0803 </r>
+        <r>    2.8820    0.0000 </r>
+        <r>    3.2495    0.0000 </r>
+        <r>    4.5321    0.0000 </r>
+        <r>    6.2579    0.0000 </r>
+       </set>
+       <set comment="kpoint 9">
+        <r>   -6.9794    1.0000 </r>
+        <r>   -4.6981    1.0000 </r>
+        <r>   -0.9652    1.0000 </r>
+        <r>   -0.4652    1.0000 </r>
+        <r>    0.8423    1.0328 </r>
+        <r>    2.5610    0.0000 </r>
+        <r>    3.3803    0.0000 </r>
+        <r>    4.0187    0.0000 </r>
+        <r>    6.4141    0.0000 </r>
+       </set>
+       <set comment="kpoint 10">
+        <r>   -7.4087    1.0000 </r>
+        <r>   -3.8876    1.0000 </r>
+        <r>   -0.5132    1.0000 </r>
+        <r>   -0.3422    1.0000 </r>
+        <r>    1.0160    0.9770 </r>
+        <r>    1.9237    0.0000 </r>
+        <r>    3.2261    0.0000 </r>
+        <r>    3.3737    0.0000 </r>
+        <r>    5.7033    0.0000 </r>
+       </set>
+       <set comment="kpoint 11">
+        <r>   -7.1948    1.0000 </r>
+        <r>   -4.2789    1.0000 </r>
+        <r>   -0.6469    1.0000 </r>
+        <r>   -0.6469    1.0000 </r>
+        <r>    1.2147    0.3625 </r>
+        <r>    1.4550    0.0000 </r>
+        <r>    3.8936    0.0000 </r>
+        <r>    3.8936    0.0000 </r>
+        <r>    5.2682    0.0000 </r>
+       </set>
+       <set comment="kpoint 12">
+        <r>   -6.7112    1.0000 </r>
+        <r>   -5.0327    1.0000 </r>
+        <r>   -1.5458    1.0000 </r>
+        <r>   -0.4632    1.0000 </r>
+        <r>    1.1631    0.3931 </r>
+        <r>    3.3030    0.0000 </r>
+        <r>    3.5639    0.0000 </r>
+        <r>    3.7066    0.0000 </r>
+        <r>    6.4343    0.0000 </r>
+       </set>
+       <set comment="kpoint 13">
+        <r>   -6.4412    1.0000 </r>
+        <r>   -5.3709    1.0000 </r>
+        <r>   -1.5341    1.0000 </r>
+        <r>   -0.7204    1.0000 </r>
+        <r>    1.2015    0.1774 </r>
+        <r>    2.8244    0.0000 </r>
+        <r>    4.0138    0.0000 </r>
+        <r>    4.0862    0.0000 </r>
+        <r>    5.7042    0.0000 </r>
+       </set>
+       <set comment="kpoint 14">
+        <r>   -6.7889    1.0000 </r>
+        <r>   -4.9219    1.0000 </r>
+        <r>   -1.1048    1.0000 </r>
+        <r>   -0.7906    1.0000 </r>
+        <r>    1.2522    0.1173 </r>
+        <r>    1.8047    0.0000 </r>
+        <r>    4.0652    0.0000 </r>
+        <r>    4.2406    0.0000 </r>
+        <r>    6.0011    0.0000 </r>
+       </set>
+       <set comment="kpoint 15">
+        <r>   -6.4124    1.0000 </r>
+        <r>   -5.4102    1.0000 </r>
+        <r>   -0.9791    1.0000 </r>
+        <r>   -0.9791    1.0000 </r>
+        <r>    1.0567    0.6439 </r>
+        <r>    1.2765    0.0000 </r>
+        <r>    4.8939    0.0000 </r>
+        <r>    4.8939    0.0000 </r>
+        <r>    6.0805    0.0000 </r>
+       </set>
+       <set comment="kpoint 16">
+        <r>   -6.0251    1.0000 </r>
+        <r>   -5.8312    1.0000 </r>
+        <r>   -1.3152    1.0000 </r>
+        <r>   -0.9524    1.0000 </r>
+        <r>    1.1618    0.2150 </r>
+        <r>    1.7644    0.0000 </r>
+        <r>    4.6792    0.0000 </r>
+        <r>    4.8198    0.0000 </r>
+        <r>    6.1589    0.0000 </r>
+       </set>
+       <set comment="kpoint 17">
+        <r>   -7.0670    1.0000 </r>
+        <r>   -4.5098    1.0000 </r>
+        <r>   -1.0908    1.0000 </r>
+        <r>   -0.5078    1.0000 </r>
+        <r>    1.3789    0.2223 </r>
+        <r>    2.0258    0.0000 </r>
+        <r>    3.5667    0.0000 </r>
+        <r>    3.7560    0.0000 </r>
+        <r>    5.9038    0.0000 </r>
+       </set>
+       <set comment="kpoint 18">
+        <r>   -6.6382    1.0000 </r>
+        <r>   -5.1337    1.0000 </r>
+        <r>   -1.4343    1.0000 </r>
+        <r>   -0.7172    1.0000 </r>
+        <r>    1.4297    0.0995 </r>
+        <r>    2.6438    0.0000 </r>
+        <r>    3.6856    0.0000 </r>
+        <r>    4.0539    0.0000 </r>
+        <r>    5.9919    0.0000 </r>
+       </set>
+       <set comment="kpoint 19">
+        <r>   -6.2029    1.0000 </r>
+        <r>   -5.6258    1.0000 </r>
+        <r>   -1.5405    1.0000 </r>
+        <r>   -1.0522    1.0000 </r>
+        <r>    1.7790   -0.0260 </r>
+        <r>    2.7711    0.0000 </r>
+        <r>    3.7947    0.0000 </r>
+        <r>    3.9329    0.0000 </r>
+        <r>    5.9184    0.0000 </r>
+       </set>
+       <set comment="kpoint 20">
+        <r>   -6.3514    1.0000 </r>
+        <r>   -5.4667    1.0000 </r>
+        <r>   -1.3000    1.0000 </r>
+        <r>   -1.0877    1.0000 </r>
+        <r>    1.7704   -0.0833 </r>
+        <r>    1.8023    0.0000 </r>
+        <r>    3.9839    0.0000 </r>
+        <r>    4.5775    0.0000 </r>
+        <r>    6.5537    0.0000 </r>
+       </set>
+      </set>
+     </set>
+    </array>
+   </eigenvalues>
+   <array>
+    <dimension dim="1">ion</dimension>
+    <dimension dim="2">band</dimension>
+    <dimension dim="3">kpoint</dimension>
+    <dimension dim="4">spin</dimension>
+    <field>  s</field>
+    <field> py</field>
+    <field> pz</field>
+    <field> px</field>
+    <field>dxy</field>
+    <field>dyz</field>
+    <field>dz2</field>
+    <field>dxz</field>
+    <field>dx2</field>
+    <set>
+     <set comment="spin1">
+      <set comment="kpoint 1">
+       <set comment="band 1">
+        <r>  0.1862  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1862  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.3051  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.3051  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.1225  0.0305  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.1225  0.0305  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0304  0.1225  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0304  0.1225  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0002  0.0001  0.1528  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0002  0.0001  0.1528  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0000  0.0001  0.0001  0.1348  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0001  0.0001  0.1348  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.0317  0.1032  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0317  0.1032  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.1032  0.0318  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.1032  0.0318  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0715  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0715  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 2">
+       <set comment="band 1">
+        <r>  0.1872  0.0001  0.0001  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1872  0.0001  0.0001  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.2687  0.0021  0.0011  0.0064  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2687  0.0021  0.0011  0.0064  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0866  0.0149  0.0483  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0866  0.0149  0.0483  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0299  0.1182  0.0016  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0299  0.1182  0.0016  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0320  0.0285  0.0142  0.0855  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0320  0.0285  0.0142  0.0855  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0000  0.0289  0.1093  0.0014  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0289  0.1093  0.0014  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.0797  0.0147  0.0452  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0797  0.0147  0.0452  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0149  0.0290  0.0145  0.0869  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0149  0.0290  0.0145  0.0869  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0536  0.0070  0.0035  0.0210  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0536  0.0070  0.0035  0.0210  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 3">
+       <set comment="band 1">
+        <r>  0.1910  0.0005  0.0003  0.0015  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1910  0.0005  0.0003  0.0015  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.2246  0.0039  0.0020  0.0117  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2246  0.0039  0.0020  0.0117  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0804  0.0182  0.0479  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0804  0.0182  0.0479  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0335  0.1119  0.0010  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0335  0.1119  0.0010  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0637  0.0210  0.0105  0.0629  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0637  0.0210  0.0105  0.0629  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0000  0.0001  0.1186  0.0205  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0001  0.1186  0.0205  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.1081  0.0051  0.0259  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.1082  0.0051  0.0259  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0309  0.0325  0.0162  0.0974  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0309  0.0325  0.0162  0.0974  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.0018  0.0060  0.0029  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0018  0.0060  0.0029  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 4">
+       <set comment="band 1">
+        <r>  0.1979  0.0008  0.0004  0.0023  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1979  0.0008  0.0004  0.0023  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.1997  0.0043  0.0022  0.0130  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1997  0.0043  0.0022  0.0130  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0782  0.0194  0.0477  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0782  0.0194  0.0477  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0348  0.1097  0.0008  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0348  0.1097  0.0008  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0778  0.0176  0.0088  0.0528  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0778  0.0176  0.0088  0.0528  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0000  0.0335  0.0554  0.0407  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0335  0.0554  0.0407  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.0672  0.0597  0.0025  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0672  0.0597  0.0025  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0255  0.0422  0.0211  0.1266  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0255  0.0422  0.0211  0.1267  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0280  0.0037  0.0018  0.0111  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0280  0.0037  0.0018  0.0111  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 5">
+       <set comment="band 1">
+        <r>  0.1876  0.0006  0.0003  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1876  0.0006  0.0003  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.2651  0.0067  0.0034  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2651  0.0067  0.0034  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0475  0.0951  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0475  0.0951  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0001  0.0003  0.1426  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0001  0.0003  0.1426  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0356  0.0975  0.0487  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0356  0.0975  0.0488  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0151  0.0710  0.0355  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0151  0.0710  0.0355  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.0001  0.0002  0.1490  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0001  0.0002  0.1490  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.0497  0.0993  0.0003  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0497  0.0993  0.0003  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0022  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0022  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 6">
+       <set comment="band 1">
+        <r>  0.1892  0.0001  0.0000  0.0016  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1892  0.0001  0.0000  0.0016  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.2433  0.0016  0.0008  0.0119  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2434  0.0016  0.0008  0.0119  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0033  0.0562  0.0281  0.0432  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0033  0.0562  0.0281  0.0432  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0503  0.1006  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0503  0.1006  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0484  0.0352  0.0176  0.0748  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0484  0.0352  0.0176  0.0748  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0194  0.0470  0.0235  0.0507  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0194  0.0470  0.0235  0.0508  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.0466  0.0932  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0466  0.0932  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0048  0.0485  0.0242  0.0790  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0048  0.0485  0.0242  0.0790  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 7">
+       <set comment="band 1">
+        <r>  0.1939  0.0004  0.0002  0.0028  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1940  0.0004  0.0002  0.0028  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.2177  0.0036  0.0018  0.0113  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2177  0.0036  0.0018  0.0113  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0103  0.0411  0.0205  0.0530  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0103  0.0411  0.0205  0.0530  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0488  0.0975  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0488  0.0975  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0546  0.0470  0.0235  0.0474  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0546  0.0470  0.0235  0.0474  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0150  0.0617  0.0308  0.0353  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0150  0.0617  0.0308  0.0353  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.0474  0.0949  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0474  0.0949  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0168  0.0261  0.0130  0.1053  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0168  0.0261  0.0130  0.1053  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.0027  0.0054  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0027  0.0054  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 8">
+       <set comment="band 1">
+        <r>  0.2003  0.0011  0.0006  0.0026  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2003  0.0011  0.0006  0.0026  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.2021  0.0046  0.0023  0.0103  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2021  0.0046  0.0023  0.0103  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0176  0.0327  0.0163  0.0598  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0176  0.0327  0.0163  0.0599  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0473  0.0947  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0473  0.0947  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0529  0.0533  0.0266  0.0353  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0529  0.0533  0.0267  0.0353  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0086  0.0488  0.0244  0.0474  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0086  0.0488  0.0244  0.0474  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.0462  0.0925  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0462  0.0925  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0207  0.0389  0.0195  0.1205  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0207  0.0389  0.0195  0.1205  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0039  0.0039  0.0019  0.0543  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0039  0.0039  0.0019  0.0543  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 9">
+       <set comment="band 1">
+        <r>  0.1962  0.0017  0.0008  0.0014  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1962  0.0017  0.0008  0.0014  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.2108  0.0054  0.0027  0.0087  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2108  0.0054  0.0027  0.0087  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0173  0.0259  0.0129  0.0733  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0173  0.0259  0.0129  0.0733  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0465  0.0930  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0465  0.0930  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0492  0.0612  0.0306  0.0286  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0492  0.0612  0.0306  0.0286  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0139  0.0485  0.0242  0.0512  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0139  0.0485  0.0242  0.0512  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.0482  0.0964  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0482  0.0964  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0149  0.0206  0.0103  0.1073  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0149  0.0206  0.0103  0.1073  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0119  0.0195  0.0097  0.0414  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0119  0.0195  0.0097  0.0414  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 10">
+       <set comment="band 1">
+        <r>  0.1903  0.0013  0.0006  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1903  0.0013  0.0006  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.2355  0.0071  0.0036  0.0042  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2355  0.0071  0.0036  0.0042  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0085  0.0144  0.0072  0.1048  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0085  0.0144  0.0072  0.1048  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0465  0.0930  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0465  0.0930  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0459  0.0774  0.0387  0.0172  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0459  0.0774  0.0387  0.0172  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0197  0.0551  0.0276  0.0294  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0197  0.0552  0.0276  0.0294  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.0514  0.1027  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0514  0.1027  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0068  0.0140  0.0070  0.1273  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0068  0.0140  0.0070  0.1273  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0067  0.0049  0.0024  0.0071  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0067  0.0049  0.0024  0.0071  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 11">
+       <set comment="band 1">
+        <r>  0.1920  0.0023  0.0012  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1920  0.0023  0.0012  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.2302  0.0093  0.0046  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2302  0.0093  0.0046  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0433  0.0866  0.0050  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0433  0.0866  0.0050  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0017  0.0033  0.1299  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0017  0.0033  0.1299  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0277  0.0554  0.0277  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0277  0.0554  0.0277  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0491  0.0857  0.0428  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0491  0.0857  0.0428  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.0570  0.1140  0.0013  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0570  0.1140  0.0013  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.0004  0.0008  0.1710  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0004  0.0008  0.1710  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0154  0.0139  0.0070  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0154  0.0139  0.0070  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 12">
+       <set comment="band 1">
+        <r>  0.1992  0.0012  0.0006  0.0034  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1992  0.0012  0.0006  0.0034  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.2126  0.0047  0.0023  0.0070  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2126  0.0047  0.0023  0.0070  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0024  0.0309  0.0154  0.0633  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0024  0.0309  0.0154  0.0633  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0468  0.0935  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0468  0.0935  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0524  0.0590  0.0295  0.0218  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0524  0.0590  0.0295  0.0218  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0339  0.0761  0.0381  0.0367  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0339  0.0761  0.0381  0.0367  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.0528  0.1057  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0528  0.1057  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0097  0.0026  0.0013  0.1229  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0097  0.0026  0.0013  0.1229  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.0019  0.0037  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0019  0.0037  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 13">
+       <set comment="band 1">
+        <r>  0.2027  0.0028  0.0014  0.0020  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2027  0.0028  0.0014  0.0020  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.2083  0.0056  0.0028  0.0044  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2083  0.0056  0.0028  0.0044  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0026  0.0222  0.0111  0.0773  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0026  0.0222  0.0111  0.0773  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0452  0.0905  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0452  0.0905  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0449  0.0606  0.0303  0.0088  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0449  0.0606  0.0303  0.0088  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0348  0.0575  0.0287  0.0551  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0348  0.0575  0.0287  0.0551  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0094  0.0015  0.0007  0.1261  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0094  0.0015  0.0007  0.1261  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.0560  0.1121  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0560  0.1121  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0064  0.0258  0.0129  0.0305  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0064  0.0258  0.0129  0.0305  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 14">
+       <set comment="band 1">
+        <r>  0.1965  0.0033  0.0016  0.0005  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1965  0.0033  0.0016  0.0005  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.2175  0.0076  0.0038  0.0020  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2175  0.0076  0.0038  0.0020  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0027  0.0114  0.0057  0.1037  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0027  0.0114  0.0057  0.1037  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0446  0.0892  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0446  0.0892  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0376  0.0612  0.0306  0.0047  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0376  0.0612  0.0306  0.0047  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0384  0.0575  0.0288  0.0286  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0384  0.0575  0.0288  0.0286  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0039  0.0006  0.0003  0.1347  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0039  0.0006  0.0003  0.1347  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.0585  0.1171  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0585  0.1171  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0159  0.0311  0.0156  0.0522  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0159  0.0311  0.0155  0.0522  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 15">
+       <set comment="band 1">
+        <r>  0.1997  0.0049  0.0024  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1997  0.0049  0.0024  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.2116  0.0076  0.0038  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2116  0.0076  0.0038  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0001  0.1312  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0001  0.1312  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0437  0.0875  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0437  0.0875  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0331  0.0515  0.0258  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0331  0.0515  0.0258  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0384  0.0607  0.0304  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0384  0.0607  0.0304  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.0685  0.1370  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0685  0.1370  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.0000  0.0000  0.2055  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.2055  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0264  0.0531  0.0265  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0264  0.0530  0.0265  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 16">
+       <set comment="band 1">
+        <r>  0.2056  0.0052  0.0026  0.0008  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2056  0.0052  0.0026  0.0008  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.2056  0.0061  0.0031  0.0009  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2057  0.0061  0.0031  0.0009  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0003  0.0104  0.0052  0.1036  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0003  0.0104  0.0052  0.1037  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0440  0.0880  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0440  0.0880  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0372  0.0557  0.0279  0.0011  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0372  0.0557  0.0279  0.0011  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0344  0.0493  0.0247  0.0283  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0344  0.0493  0.0247  0.0283  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0080  0.0026  0.0013  0.1769  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0080  0.0026  0.0013  0.1769  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.0671  0.1341  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0671  0.1341  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0146  0.0517  0.0259  0.0018  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0146  0.0517  0.0259  0.0018  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 17">
+       <set comment="band 1">
+        <r>  0.1940  0.0004  0.0005  0.0030  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1940  0.0004  0.0005  0.0030  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.2226  0.0028  0.0022  0.0097  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2226  0.0028  0.0022  0.0097  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0036  0.0430  0.0224  0.0527  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0036  0.0430  0.0224  0.0527  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0019  0.0515  0.0742  0.0097  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0019  0.0515  0.0742  0.0097  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0543  0.0400  0.0407  0.0520  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0543  0.0400  0.0407  0.0520  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0220  0.0413  0.0538  0.0145  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0220  0.0413  0.0538  0.0145  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0010  0.0303  0.0198  0.0724  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0010  0.0303  0.0198  0.0724  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0048  0.0697  0.0699  0.0260  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0048  0.0697  0.0699  0.0260  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0087  0.0107  0.0063  0.0307  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0087  0.0107  0.0063  0.0307  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 18">
+       <set comment="band 1">
+        <r>  0.2002  0.0012  0.0010  0.0032  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2002  0.0012  0.0010  0.0032  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.2104  0.0039  0.0025  0.0074  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2104  0.0039  0.0025  0.0074  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0054  0.0151  0.0378  0.0578  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0054  0.0151  0.0378  0.0578  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0005  0.0778  0.0463  0.0079  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0005  0.0778  0.0463  0.0079  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0527  0.0445  0.0437  0.0361  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0527  0.0445  0.0437  0.0362  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0214  0.0304  0.0797  0.0122  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0214  0.0304  0.0797  0.0122  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0041  0.0367  0.0115  0.0808  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0041  0.0367  0.0115  0.0808  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0102  0.0629  0.0552  0.0429  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0102  0.0629  0.0552  0.0429  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0008  0.0100  0.0006  0.0491  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0008  0.0100  0.0006  0.0491  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 19">
+       <set comment="band 1">
+        <r>  0.2048  0.0031  0.0019  0.0025  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2048  0.0031  0.0019  0.0025  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.2082  0.0048  0.0029  0.0032  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2083  0.0048  0.0029  0.0032  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0002  0.0226  0.0115  0.0780  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0002  0.0226  0.0115  0.0780  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0005  0.0471  0.0761  0.0008  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0005  0.0471  0.0761  0.0008  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0449  0.0612  0.0449  0.0118  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0449  0.0613  0.0449  0.0118  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0410  0.0620  0.0418  0.0412  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0410  0.0620  0.0418  0.0412  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0065  0.0012  0.0023  0.1169  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0065  0.0012  0.0023  0.1169  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.0396  0.0746  0.0174  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0396  0.0746  0.0174  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0016  0.0425  0.0439  0.0058  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0016  0.0425  0.0439  0.0058  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 20">
+       <set comment="band 1">
+        <r>  0.2016  0.0037  0.0029  0.0006  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2016  0.0037  0.0029  0.0006  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.2110  0.0056  0.0044  0.0012  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2110  0.0056  0.0044  0.0012  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0013  0.0089  0.0580  0.0510  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0013  0.0089  0.0580  0.0510  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0513  0.0194  0.0536  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0513  0.0194  0.0536  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0445  0.0497  0.0513  0.0147  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0445  0.0497  0.0513  0.0147  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0312  0.0698  0.0167  0.0164  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0312  0.0697  0.0167  0.0164  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0040  0.0279  0.0363  0.0631  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0040  0.0279  0.0363  0.0631  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0054  0.0279  0.0669  0.0944  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0054  0.0279  0.0669  0.0944  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0028  0.0577  0.0260  0.0049  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0031  0.0556  0.0236  0.0045  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+      </set>
+     </set>
+     <set comment="spin2">
+      <set comment="kpoint 1">
+       <set comment="band 1">
+        <r>  0.1862  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1862  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.3051  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.3051  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.1225  0.0305  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.1225  0.0305  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0304  0.1225  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0304  0.1225  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0002  0.0001  0.1528  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0002  0.0001  0.1528  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0000  0.0001  0.0001  0.1348  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0001  0.0001  0.1348  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.0316  0.1032  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0316  0.1032  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.1033  0.0317  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.1033  0.0317  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0715  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0715  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 2">
+       <set comment="band 1">
+        <r>  0.1872  0.0001  0.0001  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1872  0.0001  0.0001  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.2687  0.0021  0.0011  0.0064  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2687  0.0021  0.0011  0.0064  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0869  0.0147  0.0482  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0869  0.0147  0.0482  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0296  0.1185  0.0017  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0296  0.1185  0.0017  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0320  0.0285  0.0142  0.0855  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0320  0.0285  0.0142  0.0855  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0000  0.0293  0.1090  0.0013  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0293  0.1090  0.0013  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.0793  0.0151  0.0452  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0793  0.0151  0.0452  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0149  0.0290  0.0145  0.0869  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0149  0.0290  0.0145  0.0869  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.0008  0.0002  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0008  0.0002  0.0003  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 3">
+       <set comment="band 1">
+        <r>  0.1910  0.0005  0.0003  0.0015  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1910  0.0005  0.0003  0.0015  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.2246  0.0039  0.0020  0.0117  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2246  0.0039  0.0020  0.0117  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0806  0.0180  0.0478  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0806  0.0180  0.0478  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0333  0.1122  0.0010  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0333  0.1122  0.0010  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0637  0.0210  0.0105  0.0629  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0637  0.0210  0.0105  0.0629  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0000  0.0000  0.1193  0.0198  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.1193  0.0198  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.1082  0.0044  0.0266  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.1082  0.0044  0.0266  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0309  0.0325  0.0162  0.0974  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0309  0.0325  0.0162  0.0974  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.0057  0.0019  0.0032  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0057  0.0019  0.0032  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 4">
+       <set comment="band 1">
+        <r>  0.1979  0.0008  0.0004  0.0023  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1979  0.0008  0.0004  0.0023  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.1997  0.0043  0.0022  0.0130  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1997  0.0043  0.0022  0.0130  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0783  0.0193  0.0477  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0783  0.0193  0.0477  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0347  0.1098  0.0008  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0347  0.1099  0.0008  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0778  0.0176  0.0088  0.0528  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0778  0.0176  0.0088  0.0528  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0000  0.0366  0.0516  0.0413  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0366  0.0516  0.0413  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.0641  0.0635  0.0019  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0641  0.0635  0.0019  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0255  0.0422  0.0211  0.1266  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0255  0.0422  0.0211  0.1266  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0277  0.0039  0.0019  0.0116  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0277  0.0039  0.0019  0.0117  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 5">
+       <set comment="band 1">
+        <r>  0.1876  0.0006  0.0003  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1876  0.0006  0.0003  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.2651  0.0067  0.0034  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2651  0.0067  0.0034  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0475  0.0951  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0475  0.0951  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0001  0.0003  0.1426  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0001  0.0003  0.1426  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0356  0.0975  0.0487  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0356  0.0975  0.0488  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0151  0.0710  0.0355  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0151  0.0710  0.0355  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.0001  0.0002  0.1490  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0001  0.0002  0.1490  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.0497  0.0993  0.0003  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0497  0.0993  0.0003  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0022  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0022  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 6">
+       <set comment="band 1">
+        <r>  0.1892  0.0001  0.0000  0.0016  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1892  0.0001  0.0000  0.0016  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.2433  0.0016  0.0008  0.0119  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2434  0.0016  0.0008  0.0119  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0033  0.0562  0.0281  0.0432  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0033  0.0562  0.0281  0.0432  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0503  0.1006  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0503  0.1006  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0484  0.0352  0.0176  0.0748  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0484  0.0352  0.0176  0.0748  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0194  0.0470  0.0235  0.0507  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0194  0.0470  0.0235  0.0507  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.0466  0.0932  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0466  0.0932  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0048  0.0485  0.0242  0.0790  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0048  0.0485  0.0242  0.0790  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 7">
+       <set comment="band 1">
+        <r>  0.1940  0.0004  0.0002  0.0028  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1940  0.0004  0.0002  0.0028  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.2177  0.0036  0.0018  0.0113  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2177  0.0036  0.0018  0.0113  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0103  0.0411  0.0205  0.0530  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0103  0.0411  0.0205  0.0530  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0488  0.0975  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0488  0.0975  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0546  0.0470  0.0235  0.0474  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0546  0.0470  0.0235  0.0474  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0150  0.0617  0.0308  0.0353  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0150  0.0617  0.0308  0.0353  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.0474  0.0949  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0474  0.0949  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0168  0.0261  0.0130  0.1053  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0168  0.0261  0.0130  0.1053  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.0027  0.0054  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0027  0.0054  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 8">
+       <set comment="band 1">
+        <r>  0.2003  0.0011  0.0006  0.0026  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2003  0.0011  0.0006  0.0026  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.2021  0.0046  0.0023  0.0103  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2021  0.0046  0.0023  0.0103  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0176  0.0327  0.0163  0.0599  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0176  0.0327  0.0163  0.0599  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0473  0.0947  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0473  0.0947  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0529  0.0533  0.0266  0.0353  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0529  0.0533  0.0267  0.0353  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0086  0.0488  0.0244  0.0474  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0086  0.0488  0.0244  0.0474  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.0462  0.0925  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0462  0.0925  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0207  0.0389  0.0195  0.1205  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0207  0.0389  0.0195  0.1205  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0039  0.0039  0.0019  0.0543  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0039  0.0039  0.0019  0.0543  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 9">
+       <set comment="band 1">
+        <r>  0.1962  0.0017  0.0008  0.0014  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1962  0.0017  0.0008  0.0014  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.2108  0.0054  0.0027  0.0087  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2108  0.0054  0.0027  0.0087  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0173  0.0259  0.0129  0.0733  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0173  0.0259  0.0129  0.0733  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0465  0.0930  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0465  0.0930  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0492  0.0612  0.0306  0.0286  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0492  0.0612  0.0306  0.0286  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0139  0.0485  0.0242  0.0512  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0139  0.0485  0.0242  0.0512  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.0482  0.0964  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0482  0.0964  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0149  0.0206  0.0103  0.1073  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0149  0.0206  0.0103  0.1073  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0119  0.0195  0.0097  0.0415  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0119  0.0195  0.0097  0.0415  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 10">
+       <set comment="band 1">
+        <r>  0.1903  0.0013  0.0006  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1903  0.0013  0.0006  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.2355  0.0071  0.0036  0.0042  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2355  0.0071  0.0036  0.0042  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0085  0.0144  0.0072  0.1048  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0085  0.0144  0.0072  0.1048  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0465  0.0930  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0465  0.0930  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0459  0.0774  0.0387  0.0172  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0459  0.0774  0.0387  0.0172  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0197  0.0551  0.0276  0.0294  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0197  0.0552  0.0276  0.0294  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.0514  0.1027  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0514  0.1027  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0068  0.0140  0.0070  0.1273  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0068  0.0140  0.0070  0.1273  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0067  0.0049  0.0024  0.0071  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0067  0.0049  0.0024  0.0071  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 11">
+       <set comment="band 1">
+        <r>  0.1919  0.0023  0.0012  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1920  0.0023  0.0012  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.2302  0.0093  0.0046  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2302  0.0093  0.0046  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0433  0.0867  0.0049  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0433  0.0867  0.0049  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0016  0.0032  0.1300  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0016  0.0032  0.1300  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0277  0.0554  0.0277  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0277  0.0554  0.0277  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0491  0.0857  0.0428  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0491  0.0857  0.0428  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.0570  0.1141  0.0011  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0570  0.1141  0.0011  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.0004  0.0007  0.1711  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0004  0.0007  0.1711  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0154  0.0139  0.0070  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0154  0.0139  0.0070  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 12">
+       <set comment="band 1">
+        <r>  0.1992  0.0012  0.0006  0.0034  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1992  0.0012  0.0006  0.0034  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.2126  0.0047  0.0023  0.0070  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2126  0.0047  0.0023  0.0070  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0024  0.0309  0.0154  0.0633  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0024  0.0309  0.0154  0.0633  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0468  0.0935  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0468  0.0935  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0524  0.0590  0.0295  0.0218  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0524  0.0590  0.0295  0.0218  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0339  0.0761  0.0381  0.0367  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0339  0.0761  0.0381  0.0367  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.0528  0.1057  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0528  0.1057  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0097  0.0026  0.0013  0.1229  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0097  0.0026  0.0013  0.1229  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.0018  0.0037  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0018  0.0037  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 13">
+       <set comment="band 1">
+        <r>  0.2027  0.0028  0.0014  0.0020  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2027  0.0028  0.0014  0.0020  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.2083  0.0056  0.0028  0.0044  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2083  0.0056  0.0028  0.0044  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0026  0.0222  0.0111  0.0773  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0026  0.0222  0.0111  0.0773  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0452  0.0905  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0452  0.0905  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0449  0.0606  0.0303  0.0088  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0449  0.0606  0.0303  0.0088  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0348  0.0575  0.0287  0.0551  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0348  0.0575  0.0287  0.0551  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0094  0.0015  0.0007  0.1261  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0094  0.0015  0.0007  0.1261  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.0560  0.1121  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0560  0.1121  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0064  0.0258  0.0129  0.0305  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0064  0.0258  0.0129  0.0305  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 14">
+       <set comment="band 1">
+        <r>  0.1965  0.0033  0.0016  0.0005  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1965  0.0033  0.0016  0.0005  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.2175  0.0076  0.0038  0.0020  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2175  0.0076  0.0038  0.0020  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0027  0.0114  0.0057  0.1037  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0027  0.0114  0.0057  0.1037  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0446  0.0892  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0446  0.0892  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0376  0.0612  0.0306  0.0047  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0376  0.0612  0.0306  0.0047  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0384  0.0575  0.0288  0.0286  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0384  0.0575  0.0288  0.0286  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0039  0.0006  0.0003  0.1347  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0039  0.0006  0.0003  0.1347  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.0585  0.1171  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0585  0.1171  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0159  0.0311  0.0156  0.0522  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0159  0.0311  0.0155  0.0522  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 15">
+       <set comment="band 1">
+        <r>  0.1997  0.0049  0.0024  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1997  0.0049  0.0024  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.2116  0.0076  0.0038  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2116  0.0076  0.0038  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0001  0.1312  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0001  0.1312  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0437  0.0875  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0437  0.0875  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0331  0.0515  0.0258  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0331  0.0515  0.0258  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0384  0.0607  0.0304  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0384  0.0607  0.0304  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.0685  0.1370  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0685  0.1370  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.0000  0.0000  0.2055  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.2055  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0264  0.0530  0.0265  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0264  0.0531  0.0265  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 16">
+       <set comment="band 1">
+        <r>  0.2056  0.0052  0.0026  0.0008  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2056  0.0052  0.0026  0.0008  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.2056  0.0061  0.0031  0.0009  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2057  0.0061  0.0031  0.0009  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0003  0.0104  0.0052  0.1036  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0003  0.0104  0.0052  0.1037  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0440  0.0880  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0440  0.0880  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0372  0.0557  0.0279  0.0011  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0372  0.0557  0.0279  0.0011  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0344  0.0493  0.0247  0.0283  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0344  0.0493  0.0247  0.0283  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0080  0.0026  0.0013  0.1769  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0080  0.0026  0.0013  0.1769  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.0671  0.1341  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0671  0.1341  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0146  0.0517  0.0259  0.0018  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0146  0.0517  0.0259  0.0018  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 17">
+       <set comment="band 1">
+        <r>  0.1940  0.0004  0.0005  0.0030  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1940  0.0004  0.0005  0.0030  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.2226  0.0028  0.0022  0.0097  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2226  0.0028  0.0022  0.0097  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0036  0.0430  0.0224  0.0527  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0036  0.0430  0.0224  0.0527  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0019  0.0515  0.0742  0.0097  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0019  0.0515  0.0742  0.0097  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0543  0.0400  0.0407  0.0520  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0543  0.0400  0.0407  0.0520  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0220  0.0413  0.0538  0.0145  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0220  0.0413  0.0538  0.0145  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0010  0.0303  0.0198  0.0724  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0010  0.0303  0.0198  0.0724  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0048  0.0697  0.0699  0.0260  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0048  0.0697  0.0699  0.0260  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0087  0.0107  0.0063  0.0307  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0087  0.0107  0.0063  0.0307  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 18">
+       <set comment="band 1">
+        <r>  0.2002  0.0012  0.0010  0.0032  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2002  0.0012  0.0010  0.0032  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.2104  0.0039  0.0025  0.0074  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2104  0.0039  0.0025  0.0074  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0054  0.0151  0.0378  0.0578  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0054  0.0151  0.0378  0.0578  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0005  0.0778  0.0463  0.0079  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0005  0.0778  0.0463  0.0079  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0527  0.0445  0.0437  0.0361  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0527  0.0445  0.0437  0.0362  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0214  0.0304  0.0797  0.0122  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0214  0.0304  0.0797  0.0122  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0041  0.0367  0.0115  0.0808  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0041  0.0367  0.0115  0.0808  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0102  0.0629  0.0552  0.0429  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0102  0.0629  0.0552  0.0429  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0008  0.0100  0.0006  0.0491  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0008  0.0100  0.0006  0.0491  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 19">
+       <set comment="band 1">
+        <r>  0.2048  0.0031  0.0019  0.0025  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2048  0.0031  0.0019  0.0025  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.2082  0.0048  0.0029  0.0032  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2083  0.0048  0.0029  0.0032  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0002  0.0226  0.0115  0.0780  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0002  0.0226  0.0115  0.0780  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0005  0.0471  0.0761  0.0008  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0005  0.0471  0.0761  0.0008  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0449  0.0612  0.0449  0.0118  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0449  0.0613  0.0449  0.0118  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0410  0.0620  0.0418  0.0412  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0410  0.0620  0.0418  0.0412  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0065  0.0012  0.0023  0.1169  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0065  0.0012  0.0023  0.1169  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.0396  0.0746  0.0174  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0396  0.0746  0.0174  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0016  0.0425  0.0439  0.0058  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0016  0.0425  0.0439  0.0058  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 20">
+       <set comment="band 1">
+        <r>  0.2016  0.0037  0.0029  0.0006  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2016  0.0037  0.0029  0.0006  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.2110  0.0056  0.0044  0.0012  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.2110  0.0056  0.0044  0.0012  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0013  0.0089  0.0580  0.0510  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0013  0.0089  0.0580  0.0510  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0513  0.0194  0.0536  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0513  0.0194  0.0536  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0445  0.0497  0.0513  0.0147  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0445  0.0497  0.0513  0.0147  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0312  0.0698  0.0167  0.0164  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0312  0.0698  0.0167  0.0164  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0040  0.0279  0.0363  0.0631  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0040  0.0279  0.0363  0.0631  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0054  0.0279  0.0669  0.0944  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0054  0.0279  0.0669  0.0944  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0029  0.0571  0.0249  0.0046  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0030  0.0568  0.0246  0.0045  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+      </set>
+     </set>
+    </set>
+   </array>
+  </projected>
+ </calculation>
+ <structure name="finalpos" >
+  <crystal>
+   <varray name="basis" >
+    <v>       4.99159099      -0.00000000       0.00000000 </v>
+    <v>       2.49579549       4.32284645       0.00000064 </v>
+    <v>      -0.00000000      -2.88189444       4.07561743 </v>
+   </varray>
+   <i name="volume">     87.94319863 </i>
+   <varray name="rec_basis" >
+    <v>       0.20033693      -0.11566452      -0.08178710 </v>
+    <v>       0.00000000       0.23132903       0.16357420 </v>
+    <v>      -0.00000000      -0.00000004       0.24536157 </v>
+   </varray>
+  </crystal>
+  <varray name="positions" >
+   <v>      -0.00000000       0.00000000       0.00000000 </v>
+   <v>       0.75000000       0.50000000       0.75000000 </v>
+  </varray>
+ </structure>
+</modeling>


### PR DESCRIPTION
## Summary

Added the ability for a structure to have an overall charge. This will default to the behavior in SiteCollection when overall charge is not specified: the structure's charge is the sum of the oxidation state of its sites. 

- IStructure and Structure contain an overall charge
- The generator functions such as make_supercell/__mul__ properly account for overall charge
- Vasp input sets will modify NELECT in INCAR when an overall charge is specified. 
- Vasprun compares nelect against potcars when available and sets charge if they are different. 