### PR TITLE
Bug fix for DiffusionAnalyzer with NPT runs

### DIFF
--- a/pymatgen/analysis/diffusion_analyzer.py
+++ b/pymatgen/analysis/diffusion_analyzer.py
@@ -602,7 +602,9 @@ class DiffusionAnalyzer(MSONable):
         dp = p[:, 1:] - p[:, :-1]
         dp = dp - np.round(dp)
         f_disp = np.cumsum(dp, axis=1)
-        c_disp = [np.dot(d, m) for d, m in zip(f_disp, l)]
+        c_disp = []
+        for i in f_disp:
+            c_disp.append( [ np.dot(d, m) for d, m in zip(i, l[1:]) ] )
         disp = np.array(c_disp)
 
         # If is NVT-AIMD, clear lattice data.

--- a/pymatgen/analysis/tests/test_diffusion_analyzer.py
+++ b/pymatgen/analysis/tests/test_diffusion_analyzer.py
@@ -318,6 +318,22 @@ class DiffusionAnalyzerTest(PymatgenTest):
             self.assertArrayAlmostEqual(data[:, -1], d.mscd)
             os.remove("test.csv")
 
+    def test_from_structure_NPT( self ):
+        from pymatgen import Structure, Lattice
+        coords1 = np.array([[0.0, 0.0, 0.0], [0.5, 0.5, 0.5]] )
+        coords2 = np.array([[0.0, 0.0, 0.0], [0.6, 0.6, 0.6]] )
+        coords3 = np.array([[0.0, 0.0, 0.0], [0.7, 0.7, 0.7]] )
+        lattice1 = Lattice.from_parameters(a=2.0, b=2.0, c=2.0, alpha=90, beta=90, gamma=90)
+        lattice2 = Lattice.from_parameters(a=2.1, b=2.1, c=2.1, alpha=90, beta=90, gamma=90)
+        lattice3 = Lattice.from_parameters(a=2.0, b=2.0, c=2.0, alpha=90, beta=90, gamma=90)
+        s1 = Structure(coords=coords1, lattice=lattice1, species=['F', 'Li'])
+        s2 = Structure(coords=coords2, lattice=lattice2, species=['F', 'Li'])
+        s3 = Structure(coords=coords3, lattice=lattice3, species=['F', 'Li'])
+        structures = [s1, s2, s3]
+        d = DiffusionAnalyzer.from_structures( structures, specie='Li', temperature=500.0, time_step=2.0, step_skip=1, smoothed=None )    
+        self.assertArrayAlmostEqual(d.disp[1], np.array([[0.,    0.,    0.  ],
+                                                         [0.21,  0.21,  0.21],
+                                                         [0.40,  0.40,  0.40]]))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The `DiffusionAnalyzer` `from_structures()` method calculates cartesian displacements using

    c_disp = [np.dot(d, m) for d, m in zip(f_disp, l)]

`f_disp` has dimensions `[site, time step, axis]`.
`l` has dimensions `[time step, axis, axis]`

This means the lattice used for calculating the cartesian displacements is selected based on site number, not on time step.

Displacements calculated for NPT simulations therefore contain errors (equivalent to assuming NVT, and then taking a different lattice for each site).

This commit fixes this, by replacing the calculation of `c_disp` with

    c_disp = []
    for i in f_disp:
        c_disp.append([np.dot(d, m) for d, m in zip(i, l[1:])])

The new calculation also addresses an off-by-one error, where the displacement at time step t was calculated using the lattice at time step t-1.

This commit includes a test to check `self.disp` is correct after initialising using `from_structures()`.