### PR TITLE
Add MPRester method to get interface reaction kinks

### DIFF
--- a/pymatgen/ext/matproj.py
+++ b/pymatgen/ext/matproj.py
@@ -963,6 +963,35 @@ class MPRester(object):
         millers, energies = zip(*miller_energy_map.items())
         return WulffShape(lattice, millers, energies)
 
+    def get_interface_reactions(self, reactant1, reactant2,
+                                open_el=None, relative_mu=None):
+        """
+        Gets critical reactions between two reactants.
+
+        Get critical reactions ("kinks" in the mixing ratio where
+        reaction products change) between two reactants. See the
+        `pymatgen.analysis.interface_reactions` module for more info.
+
+        Args:
+            reactant1 (str): Chemical formula for reactant
+            reactant2 (str): Chemical formula for reactant
+            open_el (str): Element in reservoir available to system
+            relative_mu (float): Relative chemical potential of element in
+                reservoir with respect to pure substance. Must be non-positive.
+
+        Returns:
+            list: list of dicts of form {ratio,energy,rxn} where `ratio` is the
+                reactant mixing ratio, `energy` is the reaction energy
+                in eV/atom, and `rxn` is a
+                `pymatgen.analysis.reaction_calculator.Reaction`.
+
+        """
+        payload = {"reactants": " ".join([reactant1, reactant2]),
+                   "open_el": open_el,
+                   "relative_mu": relative_mu}
+        return self._make_request("/interface_reactions",
+                                  payload=payload, method="POST")
+
     @staticmethod
     def parse_criteria(criteria_string):
         """

--- a/pymatgen/ext/tests/test_matproj.py
+++ b/pymatgen/ext/tests/test_matproj.py
@@ -19,6 +19,7 @@ from pymatgen.analysis.phase_diagram import PhaseDiagram
 from pymatgen.analysis.pourbaix.entry import PourbaixEntry
 from pymatgen.analysis.pourbaix.maker import PourbaixDiagram
 from pymatgen.analysis.wulff import WulffShape
+from pymatgen.analysis.reaction_calculator import Reaction
 from pymatgen.io.cif import CifParser
 
 """
@@ -262,6 +263,18 @@ class MPResterTest(unittest.TestCase):
     def test_get_wulff_shape(self):
         ws = self.rester.get_wulff_shape("mp-126")
         self.assertTrue(isinstance(ws, WulffShape))
+
+    def test_get_interface_reactions(self):
+        kinks = self.rester.get_interface_reactions("LiCoO2", "Li3PS4")
+        self.assertTrue(len(kinks) > 0)
+        kink = kinks[0]
+        self.assertIn("energy", kink)
+        self.assertIn("ratio", kink)
+        self.assertIn("rxn", kink)
+        self.assertTrue(isinstance(kink['rxn'], Reaction))
+        kinks_open_O = self.rester.get_interface_reactions(
+            "LiCoO2", "Li3PS4", open_el="O", relative_mu=-1)
+        self.assertTrue(len(kinks_open_O) > 0)
 
     def test_parse_criteria(self):
         crit = MPRester.parse_criteria("mp-1234 Li-*")


### PR DESCRIPTION
## Summary

Get critical reactions ("kinks" in the mixing ratio where reaction products change) between two reactants. See the `pymatgen.analysis.interface_reactions` module for more info. Useful to generate pseudo-binary phase diagrams of two reactants. Also allows elemental reservoir open to system with _relative_ chemical potential with respect to pure substance. Work done with @yihanxiao92.