### PR TITLE
Remove pyhull

### DIFF
--- a/pymatgen/analysis/pourbaix/analyzer.py
+++ b/pymatgen/analysis/pourbaix/analyzer.py
@@ -69,15 +69,13 @@ class PourbaixAnalyzer(object):
         Returns a chemical potential range map for each stable entry.
 
         Args:
-            elements: Sequence of elements to be considered as independent
-                variables. E.g., if you want to show the stability ranges of
-                all Li-Co-O phases wrt to uLi and uO, you will supply
-                [Element("Li"), Element("O")]
+            limits ([[float]]): limits in which to do the pourbaix
+                analysis
 
         Returns:
-            Returns a dict of the form {entry: [simplices]}. The list of
-            simplices are the sides of the N-1 dim polytope bounding the
-            allowable chemical potential range of each entry.
+            Returns a dict of the form {entry: [boundary_points]}. 
+            The list of boundary points are the sides of the N-1 
+            dim polytope bounding the allowable ph-V range of each entry.
         """
         tol = PourbaixAnalyzer.numerical_tol
         all_chempots = []
@@ -89,6 +87,7 @@ class PourbaixAnalyzer(object):
             chempots["1"] = chempots["1"]
             all_chempots.append([chempots[el] for el in self._keys])
 
+        # This works by 
         halfspaces = []
         qhull_data = np.array(self._pd._qhull_data)
         stable_entries = self._pd.stable_entries

--- a/pymatgen/analysis/pourbaix/analyzer.py
+++ b/pymatgen/analysis/pourbaix/analyzer.py
@@ -134,23 +134,20 @@ class PourbaixAnalyzer(object):
         # Post-process boundary points, sorting isn't strictly necessary
         # but useful for some plotting tools (e.g. highcharts)
         for entry, points in pourbaix_domains.items():
-            if points:
-                points = np.array(points)[:, :2]
-                center = np.average(points, axis=0)
-                points_centered = points - center
+            points = np.array(points)[:, :2]
+            center = np.average(points, axis=0)
+            points_centered = points - center
 
-                # Sort points by cross product of centered points
-                point_comparator = lambda x, y: x[0]*y[1] - x[1]*y[0]
-                points_centered = sorted(points_centered,
-                                         key=cmp_to_key(point_comparator))
-                points = points_centered + center
+            # Sort points by cross product of centered points
+            point_comparator = lambda x, y: x[0]*y[1] - x[1]*y[0]
+            points_centered = sorted(points_centered,
+                                     key=cmp_to_key(point_comparator))
+            points = points_centered + center
 
-                # Create simplices corresponding to pourbaix boundary
-                simplices = [Simplex(points[indices]) 
-                             for indices in ConvexHull(points).simplices]
-                pourbaix_domains[entry] = simplices
-            else:
-                pourbaix_domains.pop(entry)
+            # Create simplices corresponding to pourbaix boundary
+            simplices = [Simplex(points[indices]) 
+                         for indices in ConvexHull(points).simplices]
+            pourbaix_domains[entry] = simplices
 
 
         self.pourbaix_domains = pourbaix_domains

--- a/pymatgen/analysis/pourbaix/analyzer.py
+++ b/pymatgen/analysis/pourbaix/analyzer.py
@@ -96,7 +96,7 @@ class PourbaixAnalyzer(object):
             chempots["1"] = chempots["1"]
             all_chempots.append([chempots[el] for el in self._keys])
 
-        # This works by 
+        # Get hyperplanes corresponding to G as function of pH and V
         halfspaces = []
         qhull_data = np.array(self._pd._qhull_data)
         stable_entries = self._pd.stable_entries
@@ -108,6 +108,8 @@ class PourbaixAnalyzer(object):
         hyperplanes = np.transpose(hyperplanes)
         max_contribs = np.max(np.abs(hyperplanes), axis=0)
         g_max = np.dot(-max_contribs, [limits[0][1], limits[1][1], 0, 1])
+
+        # Add border hyperplanes and generate HalfspaceIntersection
         border_hyperplanes = [[-1, 0, 0, limits[0][0]],
                               [1, 0, 0, -limits[0][1]],
                               [0, -1, 0, limits[1][0]],
@@ -117,6 +119,7 @@ class PourbaixAnalyzer(object):
                                     border_hyperplanes])
         interior_point = np.average(limits, axis=1).tolist() + [g_max]
         hs_int = HalfspaceIntersection(hs_hyperplanes, np.array(interior_point))
+
         # organize the boundary points by entry
         pourbaix_domains = {entry: [] for entry in stable_entries}
         for intersection, facet in zip(hs_int.intersections, 

--- a/pymatgen/analysis/pourbaix/tests/test_analyzer.py
+++ b/pymatgen/analysis/pourbaix/tests/test_analyzer.py
@@ -10,11 +10,7 @@ import os
 from pymatgen.analysis.pourbaix.maker import PourbaixDiagram
 from pymatgen.analysis.pourbaix.entry import PourbaixEntryIO, PourbaixEntry
 from monty.serialization import loadfn
-
-try:
-    from pymatgen.analysis.pourbaix.analyzer import PourbaixAnalyzer
-except ImportError:
-    PourbaixAnalyzer = None
+from pymatgen.analysis.pourbaix.analyzer import PourbaixAnalyzer
 
 test_dir = os.path.join(os.path.dirname(__file__), '..', '..', '..', '..', 'test_files')
 

--- a/pymatgen/analysis/pourbaix/tests/test_analyzer.py
+++ b/pymatgen/analysis/pourbaix/tests/test_analyzer.py
@@ -18,7 +18,6 @@ except ImportError:
 
 test_dir = os.path.join(os.path.dirname(__file__), '..', '..', '..', '..', 'test_files')
 
-@unittest.skipIf(PourbaixAnalyzer is None, "ImportError while importing PourbaixAnalyzer")
 class TestPourbaixAnalyzer(unittest.TestCase):
 
     def setUp(self):

--- a/pymatgen/analysis/pourbaix/tests/test_plotter.py
+++ b/pymatgen/analysis/pourbaix/tests/test_plotter.py
@@ -18,7 +18,6 @@ except ImportError:
 
 test_dir = os.path.join(os.path.dirname(__file__), '..', '..', '..', '..', 'test_files')
 
-@unittest.skipIf(PourbaixAnalyzer is None, "ImportError while importing PourbaixAnalyzer")
 class TestPourbaixPlotter(unittest.TestCase):
 
     def setUp(self):
@@ -32,7 +31,14 @@ class TestPourbaixPlotter(unittest.TestCase):
         self.plotter = PourbaixPlotter(self.pd)
 
     def test_plot_pourbaix(self):
-        plt = self.plotter.get_pourbaix_plot(limits=[[-2, 14], [-3, 3]])
+        # Default limits
+        plt = self.plotter.get_pourbaix_plot()
+        # Non-standard limits
+        plt = self.plotter.get_pourbaix_plot(limits=[[-5, 4], [-2, 2]])
+        
+        # Try 3-D plot
+        plot_3d = self.plotter._get_plot()
+        plot_3d_unstable = self.plotter._get_plot(label_unstable=True)
 
     def test_get_entry_stability(self):
         entry = self.pd.all_entries[0]

--- a/pymatgen/analysis/pourbaix/tests/test_plotter.py
+++ b/pymatgen/analysis/pourbaix/tests/test_plotter.py
@@ -9,12 +9,8 @@ import os
 
 from pymatgen.analysis.pourbaix.maker import PourbaixDiagram
 from pymatgen.analysis.pourbaix.entry import PourbaixEntryIO
-
-try:
-    from pymatgen.analysis.pourbaix.plotter import PourbaixPlotter
-    from pymatgen.analysis.pourbaix.analyzer import PourbaixAnalyzer
-except ImportError:
-    PourbaixAnalyzer = None
+from pymatgen.analysis.pourbaix.plotter import PourbaixPlotter
+from pymatgen.analysis.pourbaix.analyzer import PourbaixAnalyzer
 
 test_dir = os.path.join(os.path.dirname(__file__), '..', '..', '..', '..', 'test_files')
 


### PR DESCRIPTION
## Remove pyhull dependency in PourbaixAnalyzer

Replaces pyhull halfspace usage with scipy.spatial.HalfspaceIntersection usage in pourbaix analysis module.  Also adds a few more unittests to the plotter and fleshes out the docstring in PourbaixAnalyzer.

Addresses #283.