### PR TITLE
updated analyzer to restore pourbaix_domain_vertices and added unittest

### DIFF
--- a/pymatgen/analysis/pourbaix/tests/test_analyzer.py
+++ b/pymatgen/analysis/pourbaix/tests/test_analyzer.py
@@ -4,18 +4,19 @@
 
 from __future__ import unicode_literals
 
-import unittest
 import os
 
 from pymatgen.analysis.pourbaix.maker import PourbaixDiagram
 from pymatgen.analysis.pourbaix.entry import PourbaixEntryIO, PourbaixEntry
-from monty.serialization import loadfn
 from pymatgen.analysis.pourbaix.analyzer import PourbaixAnalyzer
+from pymatgen.util.testing import PymatgenTest
+
+from monty.serialization import loadfn
 
 test_dir = os.path.join(os.path.dirname(__file__), '..', '..', '..', '..', 'test_files')
 
 # TODO: refactor with more sensible binary/ternary test data
-class TestPourbaixAnalyzer(unittest.TestCase):
+class TestPourbaixAnalyzer(PymatgenTest):
 
     def setUp(self):
         module_dir = os.path.dirname(os.path.abspath(__file__))
@@ -28,13 +29,21 @@ class TestPourbaixAnalyzer(unittest.TestCase):
         self.analyzer = PourbaixAnalyzer(self.pd)
         self.multi_data = loadfn(os.path.join(test_dir, 'multicomp_pbx.json'))
         
-    def test_get_facet_chempots(self):
+    def test_chempot_range_map(self):
         range_map = self.analyzer.get_chempot_range_map()
         range_map_dict = {}
         for PourEntry in range_map.keys():
             range_map_dict[PourEntry.name] = range_map[PourEntry]
         for entry in self.num_simplices.keys():
             self.assertEqual(len(range_map_dict[entry]), self.num_simplices[entry])
+        ZnO2_entry = [e for e in self.pd.all_entries if e.name == "ZnO2(s)"][0]
+        test_vertices = self.analyzer.pourbaix_domain_vertices[ZnO2_entry]
+        self.assertArrayAlmostEqual(test_vertices[0], [13.13028765, 1.5378])
+
+        # ensure consistent sorting
+        for vertices in self.analyzer.pourbaix_domain_vertices.values():
+            sorted_vertices = sorted(vertices, key=lambda x: (x[1], x[0]))
+            self.assertArrayEqual(sorted_vertices[0], vertices[0])
 
     def test_get_decomp(self):
         for entry in [entry for entry in self.pd.all_entries


### PR DESCRIPTION
## Summary

Returns pourbaix_domain_vertices attribute to PourbaixAnalyzer.  Addresses #964.

* Adds the pourbaix_domain_vertices attribute back
* provides a more stable sort of the points bounding the pourbaix region to ensure consistency
* Adds test of functionality