### PR TITLE
Added charged cell correction to EwaldSummation

### DIFF
--- a/pymatgen/analysis/ewald.py
+++ b/pymatgen/analysis/ewald.py
@@ -112,6 +112,10 @@ class EwaldSummation(object):
         if self._compute_forces:
             self._forces = recip_forces + real_point_forces
 
+        # Compute the correction for a charged cell
+        self._charged_cell_energy = - EwaldSummation.CONV_FACT / 2 * np.pi / \
+                                    structure.volume / self._eta * structure.charge ** 2
+
     def compute_partial_energy(self, removed_indices):
         """
         Gives total ewald energy for certain sites being removed, i.e. zeroed
@@ -221,17 +225,16 @@ class EwaldSummation(object):
         """
         The total energy.
         """
-        if self._charged:
-            warn('Charged structures not supported in EwaldSummation, but '
-                 'charged input structures can be used for '
-                 'EwaldSummation.compute_sub_structure')
-        return sum(sum(self._recip)) + sum(sum(self._real)) + sum(self._point)
+        return sum(sum(self._recip)) + sum(sum(self._real)) + sum(self._point) + self._charged_cell_energy
 
     @property
     def total_energy_matrix(self):
         """
         The total energy matrix. Each matrix element (i, j) corresponds to the
         total interaction energy between site i and site j.
+
+        Note that this does not include the charged-cell energy, which is only important
+        when the simulation cell is not charge balanced.
         """
         totalenergy = self._recip + self._real
         for i in range(len(self._point)):
@@ -256,7 +259,8 @@ class EwaldSummation(object):
             site_index (int): Index of site
         ReturnS:
             (float) - Energy of that site"""
-        
+        if self._charged:
+            warn('Per atom energies for charged structures not supported in EwaldSummation')
         return np.sum(self._recip[:,site_index]) + np.sum(self._real[:,site_index]) \
             + self._point[site_index]
 
@@ -320,8 +324,6 @@ class EwaldSummation(object):
     def _calc_real_and_point(self):
         """
         Determines the self energy -(eta/pi)**(1/2) * sum_{i=1}^{N} q_i**2
-
-        If cell is charged a compensating background is added (i.e. a G=0 term)
         """
         fcoords = self._s.frac_coords
         forcepf = 2.0 * self._sqrt_eta / sqrt(pi)

--- a/pymatgen/analysis/tests/test_energy_models.py
+++ b/pymatgen/analysis/tests/test_energy_models.py
@@ -50,7 +50,7 @@ class EwaldElectrostaticModelTest(unittest.TestCase):
 
         m = EwaldElectrostaticModel()
         # large tolerance because scipy constants changed between 0.16.1 and 0.17
-        self.assertAlmostEqual(m.get_energy(s), -59.322817600353616, 4)
+        self.assertAlmostEqual(m.get_energy(s), -264.66364858, 2)  # Result from GULP
         s2 = Structure.from_file(os.path.join(test_dir, "Li2O.cif"))
         self.assertAlmostEqual(m.get_energy(s2), -145.39050015844839, 4)
 

--- a/pymatgen/analysis/tests/test_ewald.py
+++ b/pymatgen/analysis/tests/test_ewald.py
@@ -36,7 +36,7 @@ class EwaldSummationTest(unittest.TestCase):
         self.assertAlmostEqual(ham.real_space_energy, -502.23549897772602, 4)
         self.assertAlmostEqual(ham.reciprocal_space_energy,  6.1541071599534654, 4)
         self.assertAlmostEqual(ham.point_energy, -620.22598358035918, 4)
-        self.assertAlmostEqual(ham.total_energy, -1116.30737539811, 2)
+        self.assertAlmostEqual(ham.total_energy, -1123.00766, 1)
         self.assertAlmostEqual(ham.forces[0, 0], -1.98818620e-01, 4)
         self.assertAlmostEqual(sum(sum(abs(ham.forces))), 915.925354346, 4,
                                "Forces incorrect")
@@ -46,11 +46,8 @@ class EwaldSummationTest(unittest.TestCase):
                                ham.reciprocal_space_energy, 4)
         self.assertAlmostEqual(sum(ham.point_energy_matrix), ham.point_energy,
                                4)
-        self.assertAlmostEqual(sum(sum(ham.total_energy_matrix)),
+        self.assertAlmostEqual(sum(sum(ham.total_energy_matrix)) + ham._charged_cell_energy,
                                ham.total_energy, 2)
-        # note that forces are not individually tested, but should work fine.
-        self.assertAlmostEqual(ham.get_site_energy(0), ham.get_site_energy(2))  # The Fe atoms should all be the same
-        self.assertAlmostEqual(ham.get_site_energy(0), -24.457, 2)
 
         self.assertRaises(ValueError, EwaldSummation, original_s)
         # try sites with charge.


### PR DESCRIPTION
## Summary

Added charge cell correction to Ewald summation method. Ewald summation now exactly matches results for Ewald calculations from LAMMPS and GULP.

See discussion in #972 

## Additional dependencies introduced 

None