### PR TITLE
Fix access to materials project

### DIFF
--- a/pymatgen/analysis/chemenv/utils/chemenv_config.py
+++ b/pymatgen/analysis/chemenv/utils/chemenv_config.py
@@ -57,13 +57,10 @@ class ChemEnvConfig():
             for key, val in self.package_options.items():
                 print('     {}   :   {}'.format(str(key), str(val)))
             print('\nChoose in the following :')
-            print(' <1> + <ENTER> : setup of the access to the materials project database')
-            print(' <2> + <ENTER> : configuration of the package options (strategy, ...)')
+            print(' <1> + <ENTER> : configuration of the package options (strategy, ...)')
             print(' <q> + <ENTER> : quit without saving configuration')
             test = input(' <S> + <ENTER> : save configuration and quit\n ... ')
-            if test == '1':
-                self.setup_materials_project_configuration()
-            elif test == '2':
+	    if test == '1':
                 self.setup_package_options()
             elif test == 'q':
                 break

--- a/pymatgen/analysis/chemenv/utils/chemenv_config.py
+++ b/pymatgen/analysis/chemenv/utils/chemenv_config.py
@@ -60,7 +60,7 @@ class ChemEnvConfig():
             print(' <1> + <ENTER> : configuration of the package options (strategy, ...)')
             print(' <q> + <ENTER> : quit without saving configuration')
             test = input(' <S> + <ENTER> : save configuration and quit\n ... ')
-	    if test == '1':
+        if test == '1':
                 self.setup_package_options()
             elif test == 'q':
                 break

--- a/pymatgen/analysis/chemenv/utils/chemenv_config.py
+++ b/pymatgen/analysis/chemenv/utils/chemenv_config.py
@@ -60,7 +60,7 @@ class ChemEnvConfig():
             print(' <1> + <ENTER> : configuration of the package options (strategy, ...)')
             print(' <q> + <ENTER> : quit without saving configuration')
             test = input(' <S> + <ENTER> : save configuration and quit\n ... ')
-        if test == '1':
+            if test == '1':
                 self.setup_package_options()
             elif test == 'q':
                 break

--- a/pymatgen/analysis/chemenv/utils/scripts_utils.py
+++ b/pymatgen/analysis/chemenv/utils/scripts_utils.py
@@ -170,8 +170,7 @@ def compute_environments(chemenv_configuration):
                       'mp': {'string': 'the Materials Project database',
                              'regexp': r'mp-[0-9]+$'}}
     questions = {'c': 'cif'}
-    if chemenv_configuration.has_materials_project_access:
-        questions['m'] = 'mp'
+    questions['m'] = 'mp'
     lgf = LocalGeometryFinder()
     lgf.setup_parameters()
     allcg = AllCoordinationGeometries()


### PR DESCRIPTION
## Summary

Fixed access to materials project for get_environment. 

* Excluded the setup of the access to the materials project data base (not necessary)
* removed chemenv_configuration.has_materials_project_access because it is not defined

## TODO

If the API_KEY is not supplied it raises an error. A treatment might be necessary. 