### PR TITLE
Bug fix in lammps data

### DIFF
--- a/pymatgen/io/lammps/data.py
+++ b/pymatgen/io/lammps/data.py
@@ -163,7 +163,7 @@ class LammpsData(MSONable):
 
         """
         masses = self.masses
-        atoms = self.atoms
+        atoms = self.atoms.copy()
         atoms["molecule-ID"] = 1
         box_bounds = np.array(self.box_bounds)
         box_tilt = self.box_tilt if self.box_tilt else [0.0] * 3

--- a/pymatgen/io/lammps/tests/test_data.py
+++ b/pymatgen/io/lammps/tests/test_data.py
@@ -46,6 +46,7 @@ class LammpsDataTest(unittest.TestCase):
                                        [-2.456700, 4.255129, 0],
                                        [0, 0, 5.405200]])
         self.assertEqual(quartz_box.formula, "Si3 O6")
+        self.assertNotIn("molecule-ID", self.quartz.atoms.columns)
 
         ethane_box = self.ethane.structure
         np.testing.assert_array_equal(ethane_box.lattice.matrix,


### PR DESCRIPTION
## Summary

Fix a bug where the molecule-ID column is edited when calling `LammpsData.structure` attribute. 

