### PR TITLE
Bug fix for DiffusionAnalyzer.from_vasprun()

### DIFF
--- a/pymatgen/analysis/diffusion_analyzer.py
+++ b/pymatgen/analysis/diffusion_analyzer.py
@@ -586,6 +586,8 @@ class DiffusionAnalyzer(MSONable):
         """
         p, l = [], []
         for i, s in enumerate(structures):
+            if i == 0:
+                structure = s
             p.append(np.array(s.frac_coords)[:, None])
             l.append(s.lattice.matrix)
         if initial_structure is not None:
@@ -612,7 +614,7 @@ class DiffusionAnalyzer(MSONable):
         if initial_disp is not None:
             disp += initial_disp[:, None, :]
 
-        return cls(structures[0], disp, specie, temperature, time_step,
+        return cls(structure, disp, specie, temperature, time_step,
                    step_skip=step_skip, lattices=l, **kwargs)
 
     @classmethod
@@ -666,7 +668,7 @@ class DiffusionAnalyzer(MSONable):
         step_skip, temperature, time_step = next(s)
 
         return cls.from_structures(
-            structures=s, specie=specie, temperature=temperature,
+            structures=list(s), specie=specie, temperature=temperature,
             time_step=time_step, step_skip=step_skip,
             initial_disp=initial_disp, initial_structure=initial_structure,
             **kwargs)


### PR DESCRIPTION
Commit c99dba04ebba648909ab5f71a7593f26cb388f11 introduces a bug in the `from_structures()` method if this is called from the `from_vaspruns()` method. This commit reverts this change.

In `from_vasprun()`, structures are collected as a generator function, using `get_structures()`. The `from_structures()` method, however, expects a list of structures, and tries to access `structures[0]`. This fails if a constructor has been passed in, instead of a list (as is the case with `from_vasprun()`).

This commit:

a) reverts the behaviour of `from_structures()` to explicitly store the first structure passed in.
b) generates a list of structures in `from_vaspruns()` before calling `from_structures()`, for 
consistency with the argument types in the `from_structures()` docstring.
