### PR TITLE
Fix parsing of vasprun containing *

### DIFF
--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -1070,10 +1070,10 @@ class Vasprun(MSONable):
         return struct
 
     def _parse_diel(self, elem):
-        imag = [[float(l) for l in r.text.split()]
+        imag = [[_vasprun_float(l) for l in r.text.split()]
                 for r in elem.find("imag").find("array")
                 .find("set").findall("r")]
-        real = [[float(l) for l in r.text.split()]
+        real = [[_vasprun_float(l) for l in r.text.split()]
                 for r in elem.find("real")
                 .find("array").find("set").findall("r")]
         elem.clear()


### PR DESCRIPTION
VASP 5.4.4 introduced calculation of the dielectric constant based on the current-current response.

When using small values of the `CSHIFT` parameter (necessary to produce optical spectra with no broadening), this can result in anomalously large values of the current-current response, which VASP writes to the vasprun.xml files as `***********`.

I've updated the `Vasprun` parser to use the specific parsing method that can detect this bad behaviour.