### PR TITLE
fixes in the get_environment script

### DIFF
--- a/pymatgen/analysis/chemenv/coordination_environments/chemenv_strategies.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/chemenv_strategies.py
@@ -128,7 +128,7 @@ class AdditionalConditionInt(int, StrategyOption):
         allowed_values += ' - {:d} for "{}"\n'.format(integer, description)
 
     def __new__(cls, integer):
-        if int(integer) != integer:
+        if str(int(integer)) != str(integer):
             raise ValueError("Additional condition {} is not an integer".format(str(integer)))
         intger = int.__new__(cls, integer)
         if intger not in AdditionalConditions.ALL:

--- a/pymatgen/analysis/chemenv/utils/chemenv_config.py
+++ b/pymatgen/analysis/chemenv/utils/chemenv_config.py
@@ -8,6 +8,7 @@ from os.path import expanduser, exists
 from os import makedirs
 import json
 from six.moves import input
+from pymatgen import SETTINGS
 
 """
 This module contains the classes for configuration of the chemenv package.
@@ -38,8 +39,13 @@ class ChemEnvConfig():
                                'default_max_distance_factor': 1.5
                                }
 
-    def __init__(self, materials_project_configuration=None, package_options=None):
-        self.materials_project_configuration = materials_project_configuration
+    def __init__(self, package_options=None):
+        if SETTINGS.get("PMG_MAPI_KEY", "") != "": 
+            self.materials_project_configuration = SETTINGS.get("PMG_MAPI_KEY", "")
+        else:
+            self.materials_project_configuration = None
+
+
         if package_options is None:
             self.package_options = self.DEFAULT_PACKAGE_OPTIONS
         else:
@@ -122,8 +128,7 @@ class ChemEnvConfig():
             root_dir = '{}/.chemenv'.format(home)
         if not exists(root_dir):
             makedirs(root_dir)
-        config_dict = {'materials_project_configuration': self.materials_project_configuration,
-                       'package_options': self.package_options}
+        config_dict = {'package_options': self.package_options}  
         config_file = '{}/config.json'.format(root_dir)
         if exists(config_file):
             test = input('Overwrite existing configuration ? (<Y> + <ENTER> to confirm)')
@@ -146,8 +151,8 @@ class ChemEnvConfig():
             f = open(config_file, 'r')
             config_dict = json.load(f)
             f.close()
-            return ChemEnvConfig(materials_project_configuration=config_dict['materials_project_configuration'],
-                                 package_options=config_dict['package_options'])
+            return ChemEnvConfig(package_options=config_dict['package_options']) 
+            
         except IOError:
             print('Unable to load configuration from file "{}" ...'.format(config_file))
             print(' ... loading default configuration')

--- a/pymatgen/analysis/chemenv/utils/tests/test_chemenv_config.py
+++ b/pymatgen/analysis/chemenv/utils/tests/test_chemenv_config.py
@@ -24,7 +24,7 @@ class ChemenvConfigTest(unittest.TestCase):
         if SETTINGS.get("PMG_MAPI_KEY", "") != "":
              self.assertTrue(config.has_materials_project_access)
         else:
-	     self.assertFalse(config.has_materials_project_access)
+             self.assertFalse(config.has_materials_project_access)
 
         package_options = ChemEnvConfig.DEFAULT_PACKAGE_OPTIONS
         package_options['default_max_distance_factor'] = 1.8

--- a/pymatgen/analysis/chemenv/utils/tests/test_chemenv_config.py
+++ b/pymatgen/analysis/chemenv/utils/tests/test_chemenv_config.py
@@ -7,7 +7,7 @@ import unittest
 import os
 import shutil
 from pymatgen.analysis.chemenv.utils.chemenv_config import ChemEnvConfig
-
+from pymatgen import SETTINGS
 
 config_file_dir = os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", "..",
                                'test_files', "chemenv", "config")
@@ -20,7 +20,11 @@ class ChemenvConfigTest(unittest.TestCase):
 
     def test_chemenv_config(self):
         config = ChemEnvConfig()
-        self.assertFalse(config.has_materials_project_access)
+
+        if SETTINGS.get("PMG_MAPI_KEY", "") != "":
+             self.assertTrue(config.has_materials_project_access)
+        else:
+	     self.assertFalse(config.has_materials_project_access)
 
         package_options = ChemEnvConfig.DEFAULT_PACKAGE_OPTIONS
         package_options['default_max_distance_factor'] = 1.8


### PR DESCRIPTION
Fixed the access to the materials project in a more thorough way and adapted the test accordingly. Moreover, a small bug in the reading in of the chemenv strategy was fixed. 

I introduced an additional dependency on SETTINGS in chemenv_strategies.py and its test test_chemenv_config.py. 