### PR TITLE
Fix small bug in MinimumVIRENN get_nn_info

### DIFF
--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -677,7 +677,7 @@ class MinimumVIRENN(NearNeighbors):
                 siw.append({'site': s,
                             'image': self._get_image(s.frac_coords),
                             'weight': w,
-                            'site_index': self._get_original_site(structure, s)})
+                            'site_index': self._get_original_site(vire.structure, s)})
 
         return siw
 


### PR DESCRIPTION
## Summary

VIRENN adds oxidation states to the input structure, causing a subtle bug in .get_periodic_image which was referencing the input structure instead of the oxi-state decorated structure.

## Additional dependencies introduced (if any)

None

## TODO (if any)

None