### PR TITLE
Update structure_analyzer.py

### DIFF
--- a/pymatgen/analysis/structure_analyzer.py
+++ b/pymatgen/analysis/structure_analyzer.py
@@ -54,8 +54,8 @@ def average_coordination_number(structures, freq=10):
         Dictionary of elements as keys and average coordination numbers as values.
     """
     coordination_numbers = {}
-    for el in structures[0].composition.elements:
-        coordination_numbers[el.name] = 0.0
+    for spec in structures[0].composition.as_dict().keys():
+        coordination_numbers[spec] = 0.0
     count = 0
     for t in range(len(structures)):
         if t % freq != 0:


### PR DESCRIPTION
Change initialization of coordination number dictionary keys to species rather than elements to match with species_string use later on. This avoids a key error when dealing with ions like 'Ba2+'

## Summary

Short few sentences, and summary of the major changes in bullet 
points

* Feature 1
* Feature 2
* Fix 1
* Fix 2

## Additional dependencies introduced (if any)

* List all new dependencies needed. While adding dependencies that bring
significantly useful functionality is perfectly fine, adding ones that 
add trivial functionality, e.g., to use one single easily implementable
function, is frowned upon. Provide a justification why that dependency is needed. 
Especially frowned upon are circular dependencies, e.g., depending on derivative
modules of pymatgen such as custodian or Fireworks.

## TODO (if any)

If this is a work-in-progress, write something about what else needs 
to be done

* Feature 1 supports a, but not b.