### PR TITLE
Minor fix in lammps.output

### DIFF
--- a/pymatgen/io/lammps/output.py
+++ b/pymatgen/io/lammps/output.py
@@ -325,8 +325,7 @@ class LammpsRun(MSONable):
         end = (step + 1) * self.natoms
         mol_vector_structured = \
             self.trajectory[begin:end][self.mol_config[mol_id]][param]
-        new_shape = mol_vector_structured.shape + (-1,)
-        mol_vector = mol_vector_structured.view(np.float64).reshape(new_shape)
+        mol_vector = np.array(mol_vector_structured.tolist())
         return mol_vector.copy()
 
     # TODO: remove this and use only get_displacements(an order of magnitude faster)
@@ -350,9 +349,7 @@ class LammpsRun(MSONable):
             end = (step + 1) * self.natoms
             mol_vector_structured = \
                 self.trajectory[begin:end][:][["x", "y", "z"]]
-            new_shape = mol_vector_structured.shape + (-1,)
-            mol_vector = mol_vector_structured.view(np.float64).reshape(
-                new_shape)
+            mol_vector = np.array(mol_vector_structured.tolist())
             coords = mol_vector.copy()
             species = [mass_to_symbol[round(unique_atomic_masses[atype - 1], 1)]
                        for atype in self.trajectory[begin:end][:]["atom_type"]]
@@ -386,9 +383,7 @@ class LammpsRun(MSONable):
             end = (step + 1) * self.natoms
             mol_vector_structured = \
                 self.trajectory[begin:end][:][["x", "y", "z"]]
-            new_shape = mol_vector_structured.shape + (-1,)
-            mol_vector = mol_vector_structured.view(np.float64).reshape(
-                new_shape)
+            mol_vector = np.array(mol_vector_structured.tolist())
             coords = mol_vector.copy()
             if step == 0:
                 species = [

--- a/pymatgen/io/lammps/output.py
+++ b/pymatgen/io/lammps/output.py
@@ -344,7 +344,7 @@ class LammpsRun(MSONable):
         structures = []
         mass_to_symbol = dict(
             (round(y["Atomic mass"], 1), x) for x, y in _pt_data.items())
-        unique_atomic_masses = np.array([d["mass"] for d in self.lammps_data.masses])
+        unique_atomic_masses = self.lammps_data.masses["mass"].values
         for step in range(self.timesteps.size):
             begin = step * self.natoms
             end = (step + 1) * self.natoms
@@ -379,7 +379,7 @@ class LammpsRun(MSONable):
                            [0, 0, self.box_lengths[2]]])
         mass_to_symbol = dict(
             (round(y["Atomic mass"], 1), x) for x, y in _pt_data.items())
-        unique_atomic_masses = np.array([d["mass"] for d in self.lammps_data.masses])
+        unique_atomic_masses = self.lammps_data.masses["mass"].values
         frac_coords = []
         for step in range(self.timesteps.size):
             begin = step * self.natoms

--- a/pymatgen/io/lammps/tests/test_output.py
+++ b/pymatgen/io/lammps/tests/test_output.py
@@ -97,6 +97,17 @@ class TestLammpsRun(unittest.TestCase):
                                            trajectory_ans[:, i + 1],
                                            decimal=10)
 
+    def test_get_structures_from_trajectory(self):
+        structures = self.lammpsrun.get_structures_from_trajectory()
+        self.assertEqual(len(structures), len(self.lammpsrun.timesteps))
+
+    def test_get_displacements(self):
+        structure, disp = self.lammpsrun.get_displacements()
+        self.assertEqual(disp.shape[0], len(structure))
+        self.assertEqual(disp.shape[1], len(self.lammpsrun.timesteps) - 1)
+        self.assertEqual(disp.shape[2], 3)
+        self.assertAlmostEqual(disp[-1, -1, -1], 0.077079999999999788)
+
     def test_serialization(self):
         d = self.lammpsrun.as_dict()
         lmps_run = LammpsRun.from_dict(d)


### PR DESCRIPTION
## Summary

Fix `unique_atomic_masses` in two methods.

## Additional dependencies introduced (if any)

None

## TODO (if any)

This bug was reported in a user post in pmg google group. It was caused by rewriting `lammps.data`, but I would not take the blame because it would have been found if there were unit tests for those methods. So, if the developer/user is still using them, can you update your code and add comprehensive tests, please? Thank you. 