### PR TITLE
Patch 3

### DIFF
--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -1541,7 +1541,7 @@ class MITMDSet(MITRelaxSet):
                     'NELMIN': 4, 'LREAL': True, 'BMIX': 1,
                     'MAXMIX': 20, 'NELM': 500, 'NSIM': 4, 'ISYM': 0,
                     'ISIF': 0, 'IBRION': 0, 'NBLOCK': 1, 'KBLOCK': 100,
-                    'SMASS': 0, 'POTIM': time_step, 'PREC': 'Normal',
+                    'SMASS': 0, 'POTIM': time_step, 'PREC': 'Low',
                     'ISPIN': 2 if spin_polarized else 1,
                     "LDAU": False}
 

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -462,6 +462,7 @@ class MITMDSetTest(unittest.TestCase):
         v = dec.process_decoded(d)
         self.assertEqual(type(v), MITMDSet)
         self.assertEqual(v._config_dict["INCAR"]["TEBEG"], 300)
+        self.assertEqual(v._config_dict["INCAR"]["PREC"], "Low")
 
 
 class MVLNPTMDSetTest(unittest.TestCase):
@@ -494,6 +495,7 @@ class MVLNPTMDSetTest(unittest.TestCase):
         self.assertEqual(incar["ISIF"], 3)
         self.assertEqual(incar["MDALGO"], 3)
         self.assertEqual(incar["SMASS"], 0)
+        self.assertEqual(incar["PREC"], "Low")
 
         kpoints = npt_set.kpoints
         self.assertEqual(kpoints.kpts, [(1, 1, 1)])


### PR DESCRIPTION
## Summary

Changed `MITMDSet` and `MVLNPTMDSet` default "PREC" from "Normal" to "Low". 

Note that we already set "ENCUT" = 1.5*"ENMAX" in `MVLNPTMDSet`, which address the main concern that not using "PREC" = "Low" for NPT-MD (more details can be found in [VASP-MDALGO](https://cms.mpi.univie.ac.at/wiki/index.php/MDALGO)).

* Changed "PREC" for both `MITMDSet` and `MVLNPTMDSet`.
* Update the unittest.