### PR TITLE
Fix incar list_key parse error

### DIFF
--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -330,7 +330,7 @@ class DictSet(VaspInputSet):
                     # else, use fallback LDAU value if it exists
                     else:
                         incar[k] = [v.get(sym, 0)
-                                    if isinstance(v.get(sym, 0), float)
+                                    if isinstance(v.get(sym, 0), (float, int))
                                     else 0 for sym in poscar.site_symbols]
             elif k.startswith("EDIFF") and k != "EDIFFG":
                 if "EDIFF" not in settings and k == "EDIFF_PER_ATOM":

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -329,7 +329,9 @@ class DictSet(VaspInputSet):
                                     for sym in poscar.site_symbols]
                     # else, use fallback LDAU value if it exists
                     else:
-                        incar[k] = [v.get(sym, 0) for sym in poscar.site_symbols]
+                        incar[k] = [v.get(sym, 0)
+                                    if isinstance(v.get(sym, 0), float)
+                                    else 0 for sym in poscar.site_symbols]
             elif k.startswith("EDIFF") and k != "EDIFFG":
                 if "EDIFF" not in settings and k == "EDIFF_PER_ATOM":
                     incar["EDIFF"] = float(v) * structure.num_sites

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -182,12 +182,29 @@ class MITMPRelaxSetTest(unittest.TestCase):
         self.assertEqual(MPRelaxSet(struct).incar['LDAUU'], [5.3, 0, 0])
 
         # test for default LDAUU value
-
         userset_ldauu_fallback = MPRelaxSet(struct,
                                             user_incar_settings={
                                                 'LDAUU': {'Fe': 5.0, 'S': 0}}
                                             )
         self.assertEqual(userset_ldauu_fallback.incar['LDAUU'], [5.0, 0, 0])
+        
+        # Expected to be oxide (O is the most electronegative atom)
+        s = Structure(lattice, ["Fe", "O", "S"], coords)
+        incar = MITRelaxSet(s).incar
+        self.assertEqual(incar["LDAUU"], [4.0, 0, 0])
+
+        # Expected to be chloride (Cl is the most electronegative atom)
+        s = Structure(lattice, ["Fe", "Cl", "S"], coords)
+        incar = MITRelaxSet(s, user_incar_settings={"LDAU": True}).incar
+        self.assertFalse("LDAUU" in incar)  # LDAU = False
+
+        # User set a compound to be sulfide by specifing values of "LDAUL" etc.
+        s = Structure(lattice, ["Fe", "Cl", "S"], coords)
+        incar = MITRelaxSet(s, user_incar_settings={"LDAU": True,
+                                                    "LDAUL": {"Fe": 3},
+                                                    "LDAUU": {"Fe": 1.8}}).incar
+        self.assertEqual(incar["LDAUL"], [3.0, 0, 0])
+        self.assertEqual(incar["LDAUU"], [1.8, 0, 0])
 
         # test that van-der-Waals parameters are parsed correctly
         incar = MITRelaxSet(struct, vdw='optB86b').incar
@@ -205,9 +222,10 @@ class MITMPRelaxSetTest(unittest.TestCase):
         latt = Lattice(np.array([[3.8401979337, 0.00, 0.00],
                                  [1.9200989668, 3.3257101909, 0.00],
                                  [0.00, -2.2171384943, 3.1355090603]]))
-        struct = Structure(latt, [si, si], coords,charge=1)
+        struct = Structure(latt, [si, si], coords, charge=1)
         mpr = MPRelaxSet(struct)
-        self.assertEqual(mpr.incar["NELECT"],mpr.nelect+1,"NELECT not properly set for nonzero charge")
+        self.assertEqual(mpr.incar["NELECT"], mpr.nelect+1,
+                         "NELECT not properly set for nonzero charge")
 
     def test_get_kpoints(self):
         kpoints = MPRelaxSet(self.structure).kpoints


### PR DESCRIPTION
## Summary

This commit fixes incar write error and one example is shown below. This error is triggered if a structure contains elements in ["F", "O", "S"] but the most electro-negative element is not within the list.

Example:
```python
>>> from pymatgen.ext.matproj import MPRester
>>> from pymatgen.io.vasp.sets import MITRelaxSet
>>> rest = MPRester()
>>> SCl = rest.get_structures("SCl")[0]
>>> vis = MITRelaxSet(SCl)
>>> print(vis.incar)

TypeError
~/repos/pymatgen/pymatgen/io/vasp/sets.py in incar(self)
--> 341         has_u = hubbard_u and sum(incar['LDAUU']) > 0
TypeError: unsupported operand type(s) for +: 'int' and 'dict'
```