### PR TITLE
Added additional statistics to VoronoiNN calculation

### DIFF
--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -513,29 +513,16 @@ class VoronoiNN(NearNeighbors):
         return siw
 
 
-class VoronoiNN_modified(NearNeighbors):
+class VoronoiNN_modified(VoronoiNN):
     """
     Modified VoronoiNN that only considers neighbors
     with at least 50% weight of max(weight).
     """
 
-    def __init__(self):
-        self._cns = {}
-
     def get_nn_info(self, structure, n):
-
-        vor = VoronoiNN(structure).get_voronoi_polyhedra(structure, n).items()
-        weights = VoronoiNN(structure).get_voronoi_polyhedra(structure, n).values()
-        max_weight = max(weights)
-
-        siw = []
-        for site, weight in vor:
-            if weight > 0.5 * max_weight:
-                siw.append({'site': site,
-                            'image': self._get_image(site.frac_coords),
-                            'weight': weight,
-                            'site_index': self._get_original_site(structure, site)})
-        return siw
+        result = super(VoronoiNN_modified, self).get_nn_info(structure, n)
+        max_weight = max(i['weight'] for i in result)
+        return [i for i in result if i['weight'] > 0.5 * max_weight]
 
 
 class JMolNN(NearNeighbors):

--- a/pymatgen/analysis/tests/test_local_env.py
+++ b/pymatgen/analysis/tests/test_local_env.py
@@ -63,6 +63,22 @@ class VoronoiNNTest(PymatgenTest):
     def test_get_coordinated_sites(self):
         self.assertEqual(len(self.nn.get_nn(self.s, 0)), 8)
 
+    def test_volume(self):
+        self.nn.targets = None
+        volume = 0
+        for n in range(len(self.s)):
+            for nn in self.nn.get_voronoi_polyhedra(self.s, n).values():
+                volume += nn['volume']
+        self.assertAlmostEquals(self.s.volume, volume)
+
+    def test_solid_angle(self):
+        self.nn.targets = None
+        for n in range(len(self.s)):
+            angle = 0
+            for nn in self.nn.get_voronoi_polyhedra(self.s, n).values():
+                angle += nn['solid_angle']
+            self.assertAlmostEquals(4 * np.pi, angle)
+
     def tearDown(self):
         del self.s
         del self.nn


### PR DESCRIPTION
## Summary

Adds additional information about each facet to the `get_voronoi_polyhedra` method of `VoronoiNN`.

- Altered `get_voronoi_polyhedra` to compute a few other statistics
- Added option to `VoronoiNN` that changes whether solid angle is used to weigh neighbors, or one of these other statistics

## Additional dependencies introduced (if any)

None

## TODO (if any)

I'm not sure whether these changes make the most sense here, or in one of the other Voronoi-related classes. It was just easiest for me to build it here.

PS. Borrowed code from @qi-max, who wrote similar methods into matminer.