### PR TITLE
Amend API method to specify use of hull energy for interface rxn calc

### DIFF
--- a/pymatgen/ext/matproj.py
+++ b/pymatgen/ext/matproj.py
@@ -1017,7 +1017,8 @@ class MPRester(object):
         return WulffShape(lattice, millers, energies)
 
     def get_interface_reactions(self, reactant1, reactant2,
-                                open_el=None, relative_mu=None):
+                                open_el=None, relative_mu=None,
+                                use_hull_energy=False):
         """
         Gets critical reactions between two reactants.
 
@@ -1031,6 +1032,11 @@ class MPRester(object):
             open_el (str): Element in reservoir available to system
             relative_mu (float): Relative chemical potential of element in
                 reservoir with respect to pure substance. Must be non-positive.
+            use_hull_energy (bool): Whether to use the convex hull energy for a
+            given composition for the reaction energy calculation. If false,
+            the energy of the ground state structure will be preferred; if a
+            ground state can not be found for a composition, the convex hull
+            energy will be used with a warning message.
 
         Returns:
             list: list of dicts of form {ratio,energy,rxn} where `ratio` is the
@@ -1041,7 +1047,8 @@ class MPRester(object):
         """
         payload = {"reactants": " ".join([reactant1, reactant2]),
                    "open_el": open_el,
-                   "relative_mu": relative_mu}
+                   "relative_mu": relative_mu,
+                   "use_hull_energy": use_hull_energy}
         return self._make_request("/interface_reactions",
                                   payload=payload, method="POST")
 

--- a/pymatgen/ext/tests/test_matproj.py
+++ b/pymatgen/ext/tests/test_matproj.py
@@ -310,6 +310,10 @@ class MPResterTest(unittest.TestCase):
         kinks_open_O = self.rester.get_interface_reactions(
             "LiCoO2", "Li3PS4", open_el="O", relative_mu=-1)
         self.assertTrue(len(kinks_open_O) > 0)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings("always", message="The reactant.+")
+            self.rester.get_interface_reactions("LiCoO2", "MnO3")
+            self.assertTrue("The reactant" in str(w[-1].message))
 
     def test_parse_criteria(self):
         crit = MPRester.parse_criteria("mp-1234 Li-*")


### PR DESCRIPTION
## Summary

For `MPRester.get_interface_reactions`, extend method signature to allow toggling of whether to use the convex hull energy for a given composition for the reaction energy calculation. If false (default), the energy of the ground state structure will be preferred; if a ground state cannot be found for a composition, the convex hull energy will be used with a warning message. Add a test for this.

## TODO

@yihanxiao92 will amend [the example `matgenb` notebook](https://github.com/materialsvirtuallab/matgenb/blob/eb5b67bc1064cd96211117b23403c27fc36b7f6b/notebooks/2018-01-29-Interface%20Reactions.ipynb) to include this functionality. However, this does not block merging -- this is only to notify Yihan that this PR is done and that the notebook no longer lives in the pymatgen repo).