### PR TITLE
Changes to accelerate Voronoi-tessellation based features

### DIFF
--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -505,16 +505,19 @@ class VoronoiNN(NearNeighbors):
             determination of Voronoi coordination.
         weight (string) - Statistic used to weigh neighbors (see the statistics
             available in get_voronoi_polyhedra)
+        extra_nn_info (bool) - Add all polyhedron info to `get_nn_info`
     """
 
     def __init__(self, tol=0, targets=None, cutoff=10.0,
-                 allow_pathological=False, weight='solid_angle'):
+                 allow_pathological=False, weight='solid_angle',
+                 extra_nn_info=True):
         super(VoronoiNN, self).__init__()
         self.tol = tol
         self.cutoff = cutoff
         self.allow_pathological = allow_pathological
         self.targets = targets
         self.weight = weight
+        self.extra_nn_info = extra_nn_info
 
     def get_voronoi_polyhedra(self, structure, n):
         """
@@ -681,10 +684,18 @@ class VoronoiNN(NearNeighbors):
             site = nstats['site']
             if nstats[self.weight] > self.tol * max_weight \
                     and site.specie in targets:
-                siw.append({'site': site,
-                            'image': self._get_image(site.frac_coords),
-                            'weight': nstats[self.weight] / max_weight,
-                            'site_index': self._get_original_site(structure, site)})
+                nn_info = {'site': site,
+                           'image': self._get_image(site.frac_coords),
+                           'weight': nstats[self.weight] / max_weight,
+                           'site_index': self._get_original_site(
+                               structure, site)}
+
+                if self.extra_nn_info:
+                    # Add all the information about the site
+                    poly_info = nstats
+                    del poly_info['site']
+                    nn_info['poly_info'] = poly_info
+                siw.append(nn_info)
         return siw
 
 

--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -968,18 +968,27 @@ def solid_angle(center, coords):
     Returns:
         The solid angle.
     """
-    o = np.array(center)
-    r = [np.array(c) - o for c in coords]
-    r.append(r[0])
-    n = [np.cross(r[i + 1], r[i]) for i in range(len(r) - 1)]
-    n.append(np.cross(r[1], r[0]))
-    vals = []
-    for i in range(len(n) - 1):
-        v = -np.dot(n[i], n[i + 1]) \
-            / (np.linalg.norm(n[i]) * np.linalg.norm(n[i + 1]))
-        vals.append(acos(abs_cap(v)))
-    phi = sum(vals)
-    return phi + (3 - len(r)) * pi
+
+    # Compute the displacement from the center
+    r = [np.subtract(c, center) for c in coords]
+
+    # Compute the magnitude of each vector
+    r_norm = [np.linalg.norm(i) for i in r]
+
+    # Compute the solid angle for each tetrahedron that makes up the facet
+    #  Following: https://en.wikipedia.org/wiki/Solid_angle#Tetrahedron
+    angle = 0
+    for i in range(1, len(r)-1):
+        j = i + 1
+        tp = np.abs(np.dot(r[0], np.cross(r[i], r[j])))
+        de = r_norm[0] * r_norm[i] * r_norm[j] + \
+            r_norm[j] * np.dot(r[0], r[i]) + \
+            r_norm[i] * np.dot(r[0], r[j]) + \
+            r_norm[0] * np.dot(r[i], r[j])
+        my_angle = np.arctan(tp / de)
+        angle += (my_angle if my_angle > 0 else my_angle + np.pi) * 2
+
+    return angle
 
 
 def vol_tetra(vt1, vt2, vt3, vt4):

--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -208,8 +208,13 @@ class NearNeighbors(object):
     neighbors and others that are within some tolerable distance.
     """
 
-    def __init__(self):
-        pass
+    def __eq__(self, other):
+        if type(other) is type(self):
+            return self.__dict__ == other.__dict__
+        return False
+
+    def __hash__(self):
+        return hash(tuple(sorted(self.__dict__.items())))
 
     def get_cn(self, structure, n, use_weights=False):
         """
@@ -496,12 +501,11 @@ class VoronoiNN(NearNeighbors):
         self.allow_pathological = allow_pathological
         self.targets = targets
         self.weight = weight
-        self._cns = {}
 
     def get_voronoi_polyhedra(self, structure, n):
         """
-        Gives a weighted polyhedra around a site. This uses the Voronoi
-        construction with solid angle weights.
+        Gives a weighted polyhedra around a site.
+
         See ref: A Proposed Rigorous Definition of Coordination Number,
         M. O'Keeffe, Acta Cryst. (1979). A35, 772-775
 
@@ -689,9 +693,7 @@ class JMolNN(NearNeighbors):
     """
 
     def __init__(self, tol=1E-3, el_radius_updates=None):
-
         self.tol = tol
-        self._cns = {}
 
         # Load elemental radii table
         bonds_file = os.path.join(os.path.dirname(os.path.abspath(__file__)),
@@ -773,10 +775,8 @@ class MinimumDistanceNN(NearNeighbors):
     """
 
     def __init__(self, tol=0.1, cutoff=10.0):
-
         self.tol = tol
         self.cutoff = cutoff
-        self._cns = {}
 
     def get_nn_info(self, structure, n):
         """
@@ -826,10 +826,8 @@ class MinimumOKeeffeNN(NearNeighbors):
     """
 
     def __init__(self, tol=0.1, cutoff=10.0):
-
         self.tol = tol
         self.cutoff = cutoff
-        self._cns = {}
 
     def get_nn_info(self, structure, n):
         """
@@ -893,10 +891,8 @@ class MinimumVIRENN(NearNeighbors):
     """
 
     def __init__(self, tol=0.1, cutoff=10.0):
-
         self.tol = tol
         self.cutoff = cutoff
-        self._cns = {}
 
     def get_nn_info(self, structure, n):
         """
@@ -2301,7 +2297,6 @@ class BrunnerNN(NearNeighbors):
         self.mode = mode
         self.tol = tol
         self.cutoff = cutoff
-        self._cns = {}
 
     def get_nn_info(self, structure, n):
 
@@ -2350,10 +2345,8 @@ class EconNN(NearNeighbors):
     """
 
     def __init__(self, tol=1.0e-4, cutoff=10.0):
-
         self.tol = tol
         self.cutoff = cutoff
-        self._cns = {}
 
     def get_nn_info(self, structure, n):
 

--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -214,7 +214,7 @@ class NearNeighbors(object):
         return False
 
     def __hash__(self):
-        return hash(tuple(sorted(self.__dict__.items())))
+        return len(self.__dict__.items())
 
     def get_cn(self, structure, n, use_weights=False):
         """

--- a/pymatgen/analysis/tests/test_local_env.py
+++ b/pymatgen/analysis/tests/test_local_env.py
@@ -99,6 +99,31 @@ class VoronoiNNTest(PymatgenTest):
                                     [x['weight'] for x in nns if
                                      max(np.abs(x['image'])) == 1])
 
+        # Test the 3rd NN shell
+        nns = self.nn.get_nn_shell_info(s, 0, 3)
+        for nn in nns:
+            #  Check that the coordinates were set correctly
+            self.assertArrayAlmostEqual(nn['site'].frac_coords, nn['image'])
+
+        # Test with a structure that has unequal faces
+        cscl = Structure(Lattice([[4.209, 0, 0], [0, 4.209, 0], [0, 0, 4.209]]),
+            ["Cl1-", "Cs1+"], [[2.1045, 2.1045, 2.1045], [0, 0, 0]],
+            validate_proximity=False, to_unit_cell=False,
+            coords_are_cartesian=True, site_properties=None)
+        self.nn.weight = 'area'
+        nns = self.nn.get_nn_shell_info(cscl, 0, 1)
+        self.assertEqual(14, len(nns))
+        self.assertEqual(6, np.isclose([x['weight'] for x in nns],
+                                       0.125/0.32476).sum())  # Square faces
+        self.assertEqual(8, np.isclose([x['weight'] for x in nns], 1).sum())
+
+        nns = self.nn.get_nn_shell_info(cscl, 0, 2)
+        # Weight of getting back on to own site
+        #  Square-square hop: 6*5 options times (0.125/0.32476)^2 weight each
+        #  Hex-hex hop: 8*7 options times 1 weight each
+        self.assertAlmostEqual(60.4444,
+                               np.sum([x['weight'] for x in nns if x['site_index'] == 0]),
+                               places=3)
 
     def tearDown(self):
         del self.s

--- a/pymatgen/analysis/tests/test_local_env.py
+++ b/pymatgen/analysis/tests/test_local_env.py
@@ -48,6 +48,7 @@ class ValenceIonicRadiusEvaluatorTest(PymatgenTest):
         del self._mgo_uc
         del self._mgo_valrad_evaluator
 
+
 class VoronoiNNTest(PymatgenTest):
     def setUp(self):
         self.s = self.get_structure('LiFePO4')


### PR DESCRIPTION
## Summary

A series of changes to make the calculation of Voronoi-tessellation-based features in matminer faster.

* Optimization of `get_nn_shell_info` 
* Optimization of `get_voronoi_polyhedra`. No longer returns a dict indexed by `PeriodicSite`, which is very slow to modify. 
* Implemented `__hash__` and `__eq__` for NearNeighbors. Makes it easier to use LRU caches with these tools
* Faster implementation of `solid_angle`
* VoronoiNN now can return all polyhedron information as part of `get_nn_info`. Used to improve usefulness of cached results in matminer

## Additional dependencies introduced (if any)

None

## TODO (if any)

Optional: Index output of `get_voronoi_polyhedron` by "site index" and "image". Right now, the key of the output dict is the facet number, which is not useful.