### PR TITLE
add FermiDos for convenient fermi and doping calculations

### DIFF
--- a/pymatgen/electronic_structure/dos.py
+++ b/pymatgen/electronic_structure/dos.py
@@ -461,6 +461,7 @@ class FermiDos(Dos):
         Args:
             fermi (float): the fermi level in eV
             T (float): the temperature in Kelvin
+
         Returns (float): in units 1/cm3. If negative it means that the majority
             carriers are electrons (n-type doping) and if positive holes/p-type
         """
@@ -475,9 +476,9 @@ class FermiDos(Dos):
     def get_fermi(self, c, T, rtol=0.01, nstep=20, step=0.1, precision=8):
         """
         Finds the fermi level at which the doping concentration at the given
-        temperature (T) is equal to c using. A greedy algorithm is used where
-        the relative error is minimized by calculating the doping at a grid
-        that is continuously become finer.
+        temperature (T) is equal to c. A greedy algorithm is used where the
+        relative error is minimized by calculating the doping at a grid which
+        is continuously become finer.
 
         Args:
             c (float): doping concentration. c<0 represents n-type doping and
@@ -488,14 +489,14 @@ class FermiDos(Dos):
             step (float): initial step in fermi level when searching
             precision (int): essentially the decimal places of calculated fermi
 
-        Returns (float): the fermi level. Note that this is different than the
+        Returns (float): the fermi level. Note that this is different from the
             default dos.efermi.
         """
         fermi = self.efermi # initialize target fermi
         for i in range(precision):
             frange = np.arange(-nstep, nstep+1) * step + fermi
             calc_doping = np.array([self.get_doping(f, T) for f in frange])
-            relative_error = abs(calc_doping - c) / abs(c)
+            relative_error = abs(calc_doping/c - 1.0)
             fermi = frange[np.argmin(relative_error)]
             step /= 10.0
         if min(relative_error) > rtol:

--- a/pymatgen/electronic_structure/dos.py
+++ b/pymatgen/electronic_structure/dos.py
@@ -493,7 +493,7 @@ class FermiDos(Dos):
             default dos.efermi.
         """
         fermi = self.efermi # initialize target fermi
-        for i in range(precision):
+        for _ in range(precision):
             frange = np.arange(-nstep, nstep+1) * step + fermi
             calc_doping = np.array([self.get_doping(f, T) for f in frange])
             relative_error = abs(calc_doping/c - 1.0)

--- a/pymatgen/electronic_structure/dos.py
+++ b/pymatgen/electronic_structure/dos.py
@@ -4,15 +4,14 @@
 
 from __future__ import division, unicode_literals
 import numpy as np
-
 import six
-
+from monty.json import MSONable
 from pymatgen.electronic_structure.core import Spin, Orbital
 from pymatgen.core.periodic_table import get_el_sp
 from pymatgen.core.structure import Structure
 from pymatgen.core.spectrum import Spectrum
 from pymatgen.util.coord import get_linear_interpolated_value
-from monty.json import MSONable
+from scipy.constants.codata import value as _cd
 
 
 """
@@ -669,3 +668,14 @@ def _get_orb_type(orb):
         return orb.orbital_type
     except AttributeError:
         return orb
+
+
+def f0(E, fermi, T):
+    """
+    Returns the equilibrium fermi-dirac.
+    Args:
+        E (float): energy in eV
+        fermi (float): the fermi level in eV
+        T (float): the temperature in kelvin
+    """
+    return 1./ ( 1.+np.exp((E-fermi)/(_cd("Boltzmann constant in eV/K") * T)) )

--- a/pymatgen/electronic_structure/tests/test_dos.py
+++ b/pymatgen/electronic_structure/tests/test_dos.py
@@ -11,7 +11,7 @@ import json
 from monty.serialization import loadfn
 
 from pymatgen.electronic_structure.core import Spin, Orbital, OrbitalType
-from pymatgen.electronic_structure.dos import CompleteDos, DOS
+from pymatgen.electronic_structure.dos import CompleteDos, DOS, FermiDos
 from pymatgen.util.testing import PymatgenTest
 
 test_dir = os.path.join(os.path.dirname(__file__), "..", "..", "..",
@@ -46,6 +46,25 @@ class DosTest(unittest.TestCase):
         dens = dos.densities
         for spin in Spin:
             self.assertAlmostEqual(sum(dens[spin]), sum(smeared[spin]))
+
+
+class FermiDosTest(unittest.TestCase):
+    def setUp(self):
+        with open(os.path.join(test_dir, "complete_dos.json"), "r") as f:
+            self.dos = CompleteDos.from_dict(json.load(f))
+        self.dos = FermiDos(self.dos)
+
+    def test_doping_fermi(self):
+        fermi0 = self.dos.efermi
+        frange = [fermi0-0.5, fermi0, fermi0+2.0, fermi0+2.2]
+        dopings = [self.dos.get_doping(fermi=f, T=300) for f in frange]
+        ref_dopings = [3.48077e+21, 1.9235e+18, -2.6909e+16, -4.8723e+19]
+        for i, c_ref in enumerate(ref_dopings):
+            self.assertLessEqual(abs(dopings[i]/c_ref-1.0), 0.01)
+
+        calc_fermis = [self.dos.get_fermi(c=c, T=300) for c in ref_dopings]
+        for j, f_ref in enumerate(frange):
+            self.assertAlmostEqual(calc_fermis[j], f_ref, 4)
 
 
 class CompleteDosTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

added FermiDos class that makes it very easy to calculate the fermi level at a given concentration (get_fermi) or the concentration (doping) at a given fermi level (get_doping). Also added tests for both methods.