### PR TITLE
Use future numpy default for rcond

### DIFF
--- a/pymatgen/analysis/diffusion_analyzer.py
+++ b/pymatgen/analysis/diffusion_analyzer.py
@@ -274,9 +274,10 @@ class DiffusionAnalyzer(MSONable):
                 if smoothed == "max":
                     # For max smoothing, we need to weight by variance.
                     w_root = (1 / dt) ** 0.5
-                    return np.linalg.lstsq(a * w_root[:, None], b * w_root)
+                    return np.linalg.lstsq(
+                        a * w_root[:, None], b * w_root, rcond=None)
                 else:
-                    return np.linalg.lstsq(a, b)
+                    return np.linalg.lstsq(a, b, rcond=None)
 
             # Get self diffusivity
             m_components = np.zeros(3)
@@ -817,7 +818,7 @@ def fit_arrhenius(temps, diffusivities):
     logd = np.log(diffusivities)
     # Do a least squares regression of log(D) vs 1/T
     a = np.array([t_1, np.ones(len(temps))]).T
-    w, res, _, _ = np.linalg.lstsq(a, logd)
+    w, res, _, _ = np.linalg.lstsq(a, logd, rcond=None)
     w = np.array(w)
     n = len(temps)
     if n > 2:

--- a/pymatgen/core/lattice.py
+++ b/pymatgen/core/lattice.py
@@ -709,7 +709,7 @@ class Lattice(MSONable):
                     # We have to do p/q, so do lstsq(q.T, p.T).T instead.
                     p = dot(a[:, k:3].T, b[:, (k - 2):k])
                     q = np.diag(m[(k - 2):k])
-                    result = np.linalg.lstsq(q.T, p.T)[0].T
+                    result = np.linalg.lstsq(q.T, p.T, rcond=None)[0].T
                     u[k:3, (k - 2):k] = result
 
         return a.T, mapping.T


### PR DESCRIPTION
Uses machine precision times the largest of the input array dimensions rather
than simply the machine precision as the `rcond` parameter to `numpy.linalg.lstsq`.

## Summary

Adds `rcond=None` to all calls to `numpy.linalg.lstsq`.

* This suppresses a `FutureWarning` for numpy>=1.14 (pmg dep)
* The future default is [apparently](https://stackoverflow.com/a/44678023) more consistent with `scipy` and is "a good and robust default threshold."

However, I don't know if any current code _depends_ on the old default. I would hope not, and that code would break anyway with numpy 1.15.