### PR TITLE
add bandgap option for FermiDos

### DIFF
--- a/pymatgen/electronic_structure/tests/test_dos.py
+++ b/pymatgen/electronic_structure/tests/test_dos.py
@@ -55,16 +55,26 @@ class FermiDosTest(unittest.TestCase):
         self.dos = FermiDos(self.dos)
 
     def test_doping_fermi(self):
+        T = 300
         fermi0 = self.dos.efermi
         frange = [fermi0-0.5, fermi0, fermi0+2.0, fermi0+2.2]
-        dopings = [self.dos.get_doping(fermi=f, T=300) for f in frange]
+        dopings = [self.dos.get_doping(fermi=f, T=T) for f in frange]
         ref_dopings = [3.48077e+21, 1.9235e+18, -2.6909e+16, -4.8723e+19]
         for i, c_ref in enumerate(ref_dopings):
             self.assertLessEqual(abs(dopings[i]/c_ref-1.0), 0.01)
 
-        calc_fermis = [self.dos.get_fermi(c=c, T=300) for c in ref_dopings]
+        calc_fermis = [self.dos.get_fermi(c=c, T=T) for c in ref_dopings]
         for j, f_ref in enumerate(frange):
             self.assertAlmostEqual(calc_fermis[j], f_ref, 4)
+
+        sci_dos = FermiDos(self.dos, bandgap=3.0)
+        for i, c_ref in enumerate(ref_dopings):
+            if c_ref < 0:
+                self.assertAlmostEqual(
+                    sci_dos.get_fermi(c_ref, T=T) - frange[i], 0.47, places=2)
+            else:
+                self.assertAlmostEqual(
+                    sci_dos.get_fermi(c_ref, T=T) - frange[i], -0.47, places=2)
 
 
 class CompleteDosTest(unittest.TestCase):


### PR DESCRIPTION
add bandgap option for FermiDos enabling scissoring of the gap + testing. No scissoring by default.