### PR TITLE
updated debye temperature formulation

### DIFF
--- a/pymatgen/analysis/elasticity/elastic.py
+++ b/pymatgen/analysis/elasticity/elastic.py
@@ -614,7 +614,8 @@ class ElasticTensorExpansion(TensorCollection):
             n (3x1 array-like): direction for Cv determination
             u (3x1 array-like): polarization direction, note that
                 no attempt for verification of eigenvectors is made
-            overflow_cutoff (float)
+            cutoff (float): cutoff for scale of kt / (hbar * omega)
+                if lower than this value, returns 0
         """
         k = 1.38065e-23
         kt = k*temperature
@@ -788,7 +789,7 @@ class ElasticTensorExpansion(TensorCollection):
         return (comp.x, tens.x)
 
 
-#TODO: abstract this for other tensor fitting procedures
+# TODO: abstract this for other tensor fitting procedures
 def diff_fit(strains, stresses, eq_stress=None, order=2, tol=1e-10):
     """
     nth order elastic constant fitting function based on

--- a/pymatgen/analysis/elasticity/elastic.py
+++ b/pymatgen/analysis/elasticity/elastic.py
@@ -15,6 +15,7 @@ from scipy.integrate import quad
 from scipy.optimize import root
 from monty.serialization import loadfn
 from collections import OrderedDict
+from monty.dev import deprecated
 import numpy as np
 import warnings
 import itertools
@@ -42,7 +43,7 @@ __date__ = "March 22, 2012"
 
 class NthOrderElasticTensor(Tensor):
     """
-    An object representing an nth-order tensor expansion 
+    An object representing an nth-order tensor expansion
     of the stress-strain constitutive equations
     """
     GPa_to_eV_A3 = Unit("GPa").get_conversion_factor(Unit("eV ang^-3"))
@@ -126,7 +127,7 @@ class ElasticTensor(NthOrderElasticTensor):
     @property
     def compliance_tensor(self):
         """
-        returns the Voigt-notation compliance tensor, 
+        returns the Voigt-notation compliance tensor,
         which is the matrix inverse of the
         Voigt-notation elastic tensor
         """
@@ -182,14 +183,14 @@ class ElasticTensor(NthOrderElasticTensor):
     @property
     def y_mod(self):
         """
-        Calculates Young's modulus (in SI units) using the 
+        Calculates Young's modulus (in SI units) using the
         Voigt-Reuss-Hill averages of bulk and shear moduli
         """
         return 9.e9 * self.k_vrh * self.g_vrh / (3. * self.k_vrh + self.g_vrh)
 
     def directional_poisson_ratio(self, n, m, tol=1e-8):
         """
-        Calculates the poisson ratio for a specific direction 
+        Calculates the poisson ratio for a specific direction
         relative to a second, orthogonal direction
 
         Args:
@@ -213,7 +214,7 @@ class ElasticTensor(NthOrderElasticTensor):
 
     def trans_v(self, structure):
         """
-        Calculates transverse sound velocity (in SI units) using the 
+        Calculates transverse sound velocity (in SI units) using the
         Voigt-Reuss-Hill average bulk modulus
 
         Args:
@@ -334,54 +335,28 @@ class ElasticTensor(NthOrderElasticTensor):
 
     def debye_temperature(self, structure):
         """
-        Calculates the debye temperature (in SI units)
+        Estimates the debye temperature from longitudinal and
+        transverse sound velocities
 
         Args:
             structure: pymatgen structure object
 
         Returns: debye temperature (in SI units)
 
-        """
-        nsites = structure.num_sites
-        volume = structure.volume
-        tot_mass = sum([e.atomic_mass for e in structure.species])
-        natoms = structure.composition.num_atoms
-        weight = structure.composition.weight
-        avg_mass = 1.6605e-27 * tot_mass / natoms
-        mass_density = 1.6605e3 * nsites * weight / (natoms * volume)
-        return 2.589e-11 * avg_mass**(-1./3.) * mass_density**(-1./6.) \
-            * self.y_mod**0.5
-
-    def debye_temperature_gibbs(self, structure):
-        """
-        Calculates the debye temperature accordings to the GIBBS
-        formulation (in SI units)
-
-        Args:
-            structure: pymatgen structure object
-
-        Returns: debye temperature (in SI units)
-
-        """
-        volume = structure.volume
-        tot_mass = sum([e.atomic_mass for e in structure.species])
-        natoms = structure.composition.num_atoms
-        avg_mass = 1.6605e-27 * tot_mass / natoms
-        t = self.homogeneous_poisson
-        f = (3.*(2.*(2./3.*(1. + t)/(1. - 2.*t))**1.5 +
-                 (1./3.*(1. + t)/(1. - t))**1.5)**-1) ** (1./3.)
-        return 2.9772e-11 * avg_mass**(-1./2.) * (volume / natoms) ** (-1./6.) \
-            * f * self.k_vrh ** 0.5
-
-    def debye_temperature_from_sound_velocities(self, structure):
-        """
-        Estimates Debye temperature from sound velocities
         """
         v0 = (structure.volume * 1e-30 / structure.num_sites)
         vl, vt = self.long_v(structure), self.trans_v(structure)
         vm = 3**(1./3.) * (1 / vl**3 + 2 / vt**3)**(-1./3.)
         td = 1.05457e-34 / 1.38065e-23 * vm * (6 * np.pi**2 / v0) ** (1./3.)
         return td
+
+    @deprecated("debye_temperature_from_sound_velocities is now the default"
+                "debye_temperature function, this one will be removed.")
+    def debye_temperature_from_sound_velocities(self, structure):
+        """
+        Estimates Debye temperature from sound velocities
+        """
+        return self.debye_temperature(structure)
 
     @property
     def universal_anisotropy(self):
@@ -421,7 +396,7 @@ class ElasticTensor(NthOrderElasticTensor):
         """
         s_props = ["trans_v", "long_v", "snyder_ac", "snyder_opt",
                    "snyder_total", "clarke_thermalcond", "cahill_thermalcond",
-                   "debye_temperature", "debye_temperature_gibbs"]
+                   "debye_temperature"]
         sp_dict = {prop: getattr(self, prop)(structure) for prop in s_props}
         sp_dict["structure"] = structure
         if include_base_props:
@@ -431,9 +406,9 @@ class ElasticTensor(NthOrderElasticTensor):
     @classmethod
     def from_pseudoinverse(cls, strains, stresses):
         """
-        Class method to fit an elastic tensor from stress/strain 
-        data.  Method uses Moore-Penrose pseudoinverse to invert 
-        the s = C*e equation with elastic tensor, stress, and 
+        Class method to fit an elastic tensor from stress/strain
+        data.  Method uses Moore-Penrose pseudoinverse to invert
+        the s = C*e equation with elastic tensor, stress, and
         strain in voigt notation
 
         Args:
@@ -504,7 +479,7 @@ class ComplianceTensor(Tensor):
 class ElasticTensorExpansion(TensorCollection):
     """
     This class is a sequence of elastic tensors corresponding
-    to an elastic tensor expansion, which can be used to 
+    to an elastic tensor expansion, which can be used to
     calculate stress and energy density and inherits all
     of the list-based properties of TensorCollection
     (e. g. symmetrization, voigt conversion, etc.)
@@ -515,7 +490,7 @@ class ElasticTensorExpansion(TensorCollection):
 
         Args:
             c_list (list or tuple): sequence of Tensor inputs
-                or tensors from which the elastic tensor 
+                or tensors from which the elastic tensor
                 expansion is constructed.
         """
         c_list = [NthOrderElasticTensor(c, check_rank=4+i*2)
@@ -573,7 +548,7 @@ class ElasticTensorExpansion(TensorCollection):
         Gets the thermodynamic Gruneisen tensor (TGT) by via an
         integration of the GGT weighted by the directional heat
         capacity.
-        
+
         See refs:
             R. N. Thurston and K. Brugger, Phys. Rev. 113, A1604 (1964).
             K. Brugger Phys. Rev. 137, A1826 (1965).
@@ -585,7 +560,7 @@ class ElasticTensorExpansion(TensorCollection):
                 capacity determination, only necessary if temperature
                 is specified
             quad (dict): quadrature for integration, should be
-                dictionary with "points" and "weights" keys defaults 
+                dictionary with "points" and "weights" keys defaults
                 to quadpy.sphere.Lebedev(19) as read from file
         """
         if temperature and not structure:
@@ -603,7 +578,7 @@ class ElasticTensorExpansion(TensorCollection):
             rho_wsquareds, us = np.linalg.eigh(gk)
             us = [u / np.linalg.norm(u) for u in np.transpose(us)]
             for u in us:
-                # TODO: this should be benchmarked 
+                # TODO: this should be benchmarked
                 if temperature:
                     c = self.get_heat_capacity(temperature, structure, p, u)
                 num += c*self.get_ggt(p, u) * w
@@ -622,7 +597,7 @@ class ElasticTensorExpansion(TensorCollection):
                 capacity determination, only necessary if temperature
                 is specified
             quad (dict): quadrature for integration, should be
-                dictionary with "points" and "weights" keys defaults 
+                dictionary with "points" and "weights" keys defaults
                 to quadpy.sphere.Lebedev(19) as read from file
         """
         return np.trace(self.get_tgt(temperature, structure, quad)) / 3.
@@ -673,7 +648,7 @@ class ElasticTensorExpansion(TensorCollection):
     def thermal_expansion_coeff(self, structure, temperature, mode="debye"):
         """
         Gets thermal expansion coefficient from third-order constants.
-        
+
         Args:
             temperature (float): Temperature in kelvin, if not specified
                 will return non-cv-normalized value
@@ -777,7 +752,7 @@ class ElasticTensorExpansion(TensorCollection):
 
         Args:
             tau (3x3 array-like): stress at which to evaluate
-                the wallace tensor. 
+                the wallace tensor.
         """
         wallace = self.get_wallace_tensor(tau)
         return Tensor(0.5 * (wallace + np.transpose(wallace, [2, 3, 0, 1])))
@@ -816,11 +791,11 @@ class ElasticTensorExpansion(TensorCollection):
 #TODO: abstract this for other tensor fitting procedures
 def diff_fit(strains, stresses, eq_stress=None, order=2, tol=1e-10):
     """
-    nth order elastic constant fitting function based on 
+    nth order elastic constant fitting function based on
     central-difference derivatives with respect to distinct
     strain states.  The algorithm is summarized as follows:
 
-    1. Identify distinct strain states as sets of indices 
+    1. Identify distinct strain states as sets of indices
        for which nonzero strain values exist, typically
        [(0), (1), (2), (3), (4), (5), (0, 1) etc.]
     2. For each strain state, find and sort strains and
@@ -828,12 +803,12 @@ def diff_fit(strains, stresses, eq_stress=None, order=2, tol=1e-10):
     3. Find first, second .. nth derivatives of each stress
        with respect to scalar variable corresponding to
        the smallest perturbation in the strain.
-    4. Use the pseudoinverse of a matrix-vector expression 
+    4. Use the pseudoinverse of a matrix-vector expression
        corresponding to the parameterized stress-strain
-       relationship and multiply that matrix by the respective 
+       relationship and multiply that matrix by the respective
        calculated first or second derivatives from the
        previous step.
-    5. Place the calculated nth-order elastic 
+    5. Place the calculated nth-order elastic
        constants appropriately.
 
     Args:
@@ -905,9 +880,9 @@ def find_eq_stress(strains, stresses, tol=1e-10):
 def get_strain_state_dict(strains, stresses, eq_stress=None,
                           tol=1e-10, add_eq=True, sort=True):
     """
-    Creates a dictionary of voigt-notation stress-strain sets 
-    keyed by "strain state", i. e. a tuple corresponding to 
-    the non-zero entries in ratios to the lowest nonzero value, 
+    Creates a dictionary of voigt-notation stress-strain sets
+    keyed by "strain state", i. e. a tuple corresponding to
+    the non-zero entries in ratios to the lowest nonzero value,
     e.g. [0, 0.1, 0, 0.2, 0, 0] -> (0,1,0,2,0,0)
     This allows strains to be collected in stencils as to
     evaluate parameterized finite difference derivatives
@@ -923,7 +898,7 @@ def get_strain_state_dict(strains, stresses, eq_stress=None,
 
     Returns:
         OrderedDict with strain state keys and dictionaries
-        with stress-strain data corresponding to strain state 
+        with stress-strain data corresponding to strain state
     """
     # Recast stress/strains
     vstrains = np.array([Strain(s).zeroed(tol).voigt for s in strains])
@@ -966,16 +941,16 @@ def get_strain_state_dict(strains, stresses, eq_stress=None,
 def generate_pseudo(strain_states, order=3):
     """
     Generates the pseudoinverse for a given set of strains.
-    
+
     Args:
-        strain_states (6xN array like): a list of voigt-notation 
+        strain_states (6xN array like): a list of voigt-notation
             "strain-states", i. e. perturbed indices of the strain
             as a function of the smallest strain e. g. (0, 1, 0, 0, 1, 0)
         order (int): order of pseudoinverse to calculate
-    
+
     Returns:
-        mis: pseudo inverses for each order tensor, these can 
-            be multiplied by the central difference derivative 
+        mis: pseudo inverses for each order tensor, these can
+            be multiplied by the central difference derivative
             of the stress with respect to the strain state
         absent_syms: symbols of the tensor absent from the PI
             expression

--- a/pymatgen/analysis/elasticity/tensors.py
+++ b/pymatgen/analysis/elasticity/tensors.py
@@ -116,7 +116,7 @@ class Tensor(np.ndarray):
 
     def transform(self, symm_op):
         """
-        Applies a transformation (via a symmetry operation) to a tensor. 
+        Applies a transformation (via a symmetry operation) to a tensor.
 
         Args:
             symm_op (SymmOp): a symmetry operation to apply to the tensor
@@ -163,8 +163,8 @@ class Tensor(np.ndarray):
     @property
     def symmetrized(self):
         """
-        Returns a generally symmetrized tensor, calculated by taking 
-        the sum of the tensor and its transpose with respect to all 
+        Returns a generally symmetrized tensor, calculated by taking
+        the sum of the tensor and its transpose with respect to all
         possible permutations of indices
         """
         perms = list(itertools.permutations(range(self.rank)))
@@ -199,8 +199,8 @@ class Tensor(np.ndarray):
         Returns a tensor that is invariant with respect to symmetry
         operations corresponding to a structure
 
-        Args: 
-            structure (Structure): structure from which to generate 
+        Args:
+            structure (Structure): structure from which to generate
                 symmetry operations
             symprec (float): symmetry tolerance for the Spacegroup Analyzer
                 used to generate the symmetry operations
@@ -214,9 +214,9 @@ class Tensor(np.ndarray):
         """
         Tests whether a tensor is invariant with respect to the
         symmetry operations of a particular structure by testing
-        whether the residual of the symmetric portion is below a 
+        whether the residual of the symmetric portion is below a
         tolerance
-        
+
         Args:
             structure (Structure): structure to be fit to
             tol (float): tolerance for symmetry testing
@@ -278,7 +278,7 @@ class Tensor(np.ndarray):
         """
         Constructor based on the voigt notation vector or matrix.
 
-        Args: 
+        Args:
             voigt_input (array-like): voigt input for a given tensor
         """
         voigt_input = np.array(voigt_input)
@@ -390,12 +390,12 @@ class Tensor(np.ndarray):
 
     @classmethod
     def from_values_indices(cls, values, indices, populate=False,
-                            structure=None, voigt_rank=None, 
+                            structure=None, voigt_rank=None,
                             vsym=True, verbose=False):
         """
         Creates a tensor from values and indices, with options
         for populating the remainder of the tensor.
-        
+
         Args:
             values (floats): numbers to place at indices
             indices (array-likes): indices to place values at
@@ -405,7 +405,7 @@ class Tensor(np.ndarray):
             voigt_rank (int): full tensor rank to indicate the
                 shape of the resulting tensor.  This is necessary
                 if one provides a set of indices more minimal than
-                the shape of the tensor they want, e.g. 
+                the shape of the tensor they want, e.g.
                 Tensor.from_values_indices((0, 0), 100)
             vsym (bool): whether to voigt symmetrize during the
                 optimization procedure
@@ -443,7 +443,7 @@ class Tensor(np.ndarray):
         2. Symmetrize the tensor with respect to crystal symmetry and
            (optionally) voigt symmetry
         3. Reset the non-zero entries of the original tensor
-        
+
         Args:
             structure (structure object)
             prec (float): precision for determining a non-zero value
@@ -494,7 +494,7 @@ class Tensor(np.ndarray):
             test_new = test_old.fit_to_structure(structure)
             if vsym:
                 test_new = test_new.voigt_symmetrized
-            diff = np.abs(test_old - test_new) 
+            diff = np.abs(test_old - test_new)
             converged = (diff < prec).all()
             if converged:
                 break
@@ -544,16 +544,16 @@ class TensorCollection(collections.Sequence):
         return all([t.is_symmetric(tol) for t in self])
 
     def fit_to_structure(self, structure, symprec=0.1):
-        return self.__class__([t.fit_to_structure(structure, symprec) 
+        return self.__class__([t.fit_to_structure(structure, symprec)
                                for t in self])
-    
+
     def is_fit_to_structure(self, structure, tol=1e-2):
         return all([t.is_fit_to_structure(structure, tol) for t in self])
 
     @property
     def voigt(self):
         return [t.voigt for t in self]
-    
+
     @property
     def ranks(self):
         return [t.rank for t in self]
@@ -704,7 +704,7 @@ def symmetry_reduce(tensors, structure, tol=1e-8, **kwargs):
     return unique_tdict
 
 
-def get_tkd_value(tensor_keyed_dict, tensor, allclose_kwargs={}):
+def get_tkd_value(tensor_keyed_dict, tensor, allclose_kwargs=None):
     """
     Helper function to find a value in a tensor-keyed-
     dictionary using an approximation to the key.  This
@@ -713,13 +713,15 @@ def get_tkd_value(tensor_keyed_dict, tensor, allclose_kwargs={}):
     (e. g. from symmetry_reduce).  Resolves most
     hashing issues, and is preferable to redefining
     eq methods in the base tensor class.
-    
+
     Args:
         tensor_keyed_dict (dict): dict with Tensor keys
         tensor (Tensor): tensor to find value of in the dict
         allclose_kwargs (dict): dict of keyword-args
             to pass to allclose.
     """
+    if allclose_kwargs is None:
+        allclose_kwargs = {}
     for tkey, value in tensor_keyed_dict.items():
         if np.allclose(tensor, tkey, **allclose_kwargs):
             return value

--- a/pymatgen/analysis/elasticity/tests/test_elastic.py
+++ b/pymatgen/analysis/elasticity/tests/test_elastic.py
@@ -139,10 +139,8 @@ class ElasticTensorTest(PymatgenTest):
         self.assertAlmostEqual(0.37896275,
                                self.elastic_tensor_1.cahill_thermalcond(self.structure))
         # Debye
-        self.assertAlmostEqual(247.3058931,
+        self.assertAlmostEqual(198.8037985019,
                                self.elastic_tensor_1.debye_temperature(self.structure))
-        self.assertAlmostEqual(189.05670205,
-                               self.elastic_tensor_1.debye_temperature_gibbs(self.structure))
 
         # structure-property dict
         sprop_dict = self.elastic_tensor_1.get_structure_property_dict(self.structure)


### PR DESCRIPTION
## Summary

I've found that estimating the debye temperature of solids from the elastic tensor using the formulation from the longitudinal and transverse speed of sound is significantly more accurate than that of the isotropic young's modulus, so I've moved that to the default function and deleted both the old one and the GIBBS formulation, which is both somewhat unstable and very inaccurate as implemented.  Also cleaned up some trailing whitespace and codacy issues in the elasticity module.