### PR TITLE
Small bug in tetragonal conventional structure method when a = c

### DIFF
--- a/pymatgen/symmetry/analyzer.py
+++ b/pymatgen/symmetry/analyzer.py
@@ -518,7 +518,7 @@ class SpacegroupAnalyzer(object):
             for d in range(len(sorted_dic)):
                 transf[d][sorted_dic[d]['orig_index']] = 1
 
-            if abs(b - c) < tol:
+            if abs(b - c) < tol and abs(a - c) > tol:
                 a, c = c, a
                 transf = np.dot([[0, 0, 1], [0, 1, 0], [1, 0, 0]], transf)
             latt = Lattice.tetragonal(a, c)


### PR DESCRIPTION
## Summary
The `get_conventional_standard_structure` method currently unexpectedly switches a and c for tetragonal space groups if a = b = c. This is obviously not desirable and so has been removed, while still allowing for switching a and c if a != b = c (the original intention). 

## Additional dependencies introduced (if any)
None

## TODO (if any)
This only removes unexpected behaviour for a = b = c, but doesn't determine which is the conventional c axis in that case.