### PR TITLE
Mprest final struct

### DIFF
--- a/pymatgen/ext/matproj.py
+++ b/pymatgen/ext/matproj.py
@@ -329,9 +329,9 @@ class MPRester(object):
                 calculations for more accurate phase diagrams and reaction
                 energies.
             inc_structure (str): If None, entries returned are
-                ComputedEntries. If inc_structure="final",
-                ComputedStructureEntries with final structures are returned.
-                Otherwise, ComputedStructureEntries with initial structures
+                ComputedEntries. If inc_structure="initial",
+                ComputedStructureEntries with initial structures are returned.
+                Otherwise, ComputedStructureEntries with final structures
                 are returned.
             property_data (list): Specify additional properties to include in
                 entry.data. If None, no data. Should be a subset of
@@ -350,10 +350,10 @@ class MPRester(object):
         if property_data:
             props += property_data
         if inc_structure:
-            if inc_structure == "final":
-                props.append("structure")
-            else:
+            if inc_structure == "initial":
                 props.append("initial_structure")
+            else:
+                props.append("structure")
 
         if not isinstance(chemsys_formula_id_criteria, dict):
             criteria = MPRester.parse_criteria(chemsys_formula_id_criteria)
@@ -379,8 +379,8 @@ class MPRester(object):
                                   entry_id=d["task_id"])
 
             else:
-                prim = d["structure"] if inc_structure == "final" else d[
-                    "initial_structure"]
+                prim = d["initial_structure"] if inc_structure == "initial"\
+                    else d["structure"]
                 if conventional_unit_cell:
                     s = SpacegroupAnalyzer(prim).get_conventional_standard_structure()
                     energy = d["energy"]*(len(s)/len(prim))

--- a/pymatgen/ext/tests/test_matproj.py
+++ b/pymatgen/ext/tests/test_matproj.py
@@ -180,7 +180,7 @@ class MPResterTest(unittest.TestCase):
         for e in entries:
             self.assertEqual(e.composition.reduced_formula, "TiO2")
 
-        entries = self.rester.get_entries("TiO2", inc_structure="final")
+        entries = self.rester.get_entries("TiO2", inc_structure=True)
         self.assertTrue(len(entries) > 1)
         for e in entries:
             self.assertEqual(e.structure.composition.reduced_formula, "TiO2")
@@ -197,8 +197,8 @@ class MPResterTest(unittest.TestCase):
             self.assertIsNotNone(e.data["oxide_type"])
 
         # test if it will retrieve the conventional unit cell of Ni
-        entry = self.rester.get_entry_by_material_id("mp-23", inc_structure="Final",
-                                                     conventional_unit_cell=True)
+        entry = self.rester.get_entry_by_material_id(
+            "mp-23", inc_structure=True, conventional_unit_cell=True)
         Ni = entry.structure
         self.assertEqual(Ni.lattice.a, Ni.lattice.b)
         self.assertEqual(Ni.lattice.a, Ni.lattice.c)
@@ -207,17 +207,28 @@ class MPResterTest(unittest.TestCase):
         self.assertEqual(Ni.lattice.gamma, 90)
 
         # Ensure energy per atom is same
-        primNi = self.rester.get_entry_by_material_id("mp-23", inc_structure="Final",
-                                                      conventional_unit_cell=False)
+        primNi = self.rester.get_entry_by_material_id(
+            "mp-23", inc_structure=True, conventional_unit_cell=False)
         self.assertEqual(primNi.energy_per_atom, entry.energy_per_atom)
 
-        Ni = self.rester.get_structure_by_material_id("mp-23",
-                                                      conventional_unit_cell=True)
+        Ni = self.rester.get_structure_by_material_id(
+            "mp-23", conventional_unit_cell=True)
         self.assertEqual(Ni.lattice.a, Ni.lattice.b)
         self.assertEqual(Ni.lattice.a, Ni.lattice.c)
         self.assertEqual(Ni.lattice.alpha, 90)
         self.assertEqual(Ni.lattice.beta, 90)
         self.assertEqual(Ni.lattice.gamma, 90)
+
+        # Test case where convs are different from initial and final
+        th = self.rester.get_structure_by_material_id(
+            "mp-37", conventional_unit_cell=True)
+        th_entry = self.rester.get_entry_by_material_id(
+            "mp-37", inc_structure=True, conventional_unit_cell=True)
+        th_entry_initial = self.rester.get_entry_by_material_id(
+            "mp-37", inc_structure="initial", conventional_unit_cell=True)
+        self.assertEqual(th, th_entry.structure)
+        self.assertEqual(len(th_entry.structure), 4)
+        self.assertEqual(len(th_entry_initial.structure), 2)
 
 
     def test_get_pourbaix_entries(self):


### PR DESCRIPTION
## Change default behavior of MPRester.get_entries with inc_structure

Someone pointed out on the forum that the rester was returning different structures with `MPRester.get_entry_by_material_id` and `MPRester.get_structure_by_material_id`.  This is because `get_entry_by_material_id` will include the initial structure if `inc_structure=True` and only return the final structure if `inc_structure="Final"`.  This seems counterintuitive to me, since the final structure is the one that actually corresponds to the calculated energy, and the rest of the MPRester uses the final structure by default, so this PR changes the default `inc_structure=True` behavior to include the final structure and allows for initial structures to be requested by `inc_structure="initial"`.  Also added a test.