### PR TITLE
Add uniform bandstructure fetching to MPRester

### DIFF
--- a/pymatgen/ext/matproj.py
+++ b/pymatgen/ext/matproj.py
@@ -543,18 +543,21 @@ class MPRester(object):
         data = self.get_data(material_id, prop="dos")
         return data[0]["dos"]
 
-    def get_bandstructure_by_material_id(self, material_id):
+    def get_bandstructure_by_material_id(self, material_id, line_mode=True):
         """
         Get a BandStructure corresponding to a material_id.
 
         Args:
             material_id (str): Materials Project material_id (an int).
+            line_mode (bool): If True, fetch a BandStructureSymmLine object
+                (default). If False, return the uniform band structure.
 
         Returns:
             A BandStructure object.
         """
-        data = self.get_data(material_id, prop="bandstructure")
-        return data[0]["bandstructure"]
+        prop = "bandstructure" if line_mode else "bandstructure_uniform"
+        data = self.get_data(material_id, prop=prop)
+        return data[0][prop]
 
     def get_entries_in_chemsys(self, elements, compatible_only=True,
                                inc_structure=None, property_data=None,

--- a/pymatgen/ext/tests/test_matproj.py
+++ b/pymatgen/ext/tests/test_matproj.py
@@ -14,7 +14,8 @@ from pymatgen.core.periodic_table import Element
 from pymatgen.core.structure import Structure, Composition
 from pymatgen.entries.computed_entries import ComputedEntry
 from pymatgen.electronic_structure.dos import CompleteDos
-from pymatgen.electronic_structure.bandstructure import BandStructureSymmLine
+from pymatgen.electronic_structure.bandstructure import (
+    BandStructureSymmLine, BandStructure)
 from pymatgen.entries.compatibility import MaterialsProjectCompatibility
 from pymatgen.analysis.phase_diagram import PhaseDiagram
 from pymatgen.analysis.pourbaix_diagram import PourbaixEntry, PourbaixDiagram
@@ -169,6 +170,10 @@ class MPResterTest(unittest.TestCase):
     def test_get_bandstructure_by_material_id(self):
         bs = self.rester.get_bandstructure_by_material_id("mp-2254")
         self.assertIsInstance(bs, BandStructureSymmLine)
+        bs_unif = self.rester.get_bandstructure_by_material_id(
+            "mp-2254", line_mode=False)
+        self.assertIsInstance(bs_unif, BandStructure)
+        self.assertNotIsInstance(bs_unif, BandStructureSymmLine)
 
     def test_get_structures(self):
         structs = self.rester.get_structures("Mn3O4")


### PR DESCRIPTION
## Summary

Adds `line_mode=True` kwarg to `MPRester.get_bandstructure_by_material_id`. If false, returns uniform bandstructure if available. Adds test.