### PR TITLE
Fix a typo in Outcar.read_lepsilon()

### DIFF
--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -2235,7 +2235,7 @@ class Outcar(MSONable):
                  born_data])
 
             def born_section_stop(results, match):
-                results.born_index = None
+                results.born_ion = None
 
             search.append(
                 [r"-------------------------------------",


### PR DESCRIPTION
`Outcar.read_lepsilon()` had a typo.