### PR TITLE
Enable molecule-like rotations for structures.

### DIFF
--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -2726,6 +2726,50 @@ class Structure(IStructure, collections.MutableSequence):
                                     properties=site.properties)
             self._sites[i] = new_site
 
+    def rotate_sites(self, indices=None, theta=0, axis=None, anchor=None,
+                     to_unit_cell=True):
+        """
+        Rotate specific sites by some angle around vector at anchor.
+
+        Args:
+            indices (list): List of site indices on which to perform the
+                translation.
+            angle (float): Angle in radians
+            axis (3x1 array): Rotation axis vector.
+            anchor (3x1 array): Point of rotation.
+            to_unit_cell (bool): Whether new sites are transformed to unit
+                cell
+        """
+
+        from numpy.linalg import norm
+        from numpy import cross, eye
+        from scipy.linalg import expm
+
+        if indices is None:
+            indices = range(len(self))
+
+        if axis is None:
+            axis = [0, 0, 1]
+
+        if anchor is None:
+            anchor = [0, 0, 0]
+
+        anchor = np.array(anchor)
+        axis = np.array(axis)
+
+        theta %= 2 * np.pi
+
+        rm = expm(cross(eye(3), axis / norm(axis)) * theta)
+
+        for i in indices:
+            site = self._sites[i]
+            s = ((rm * np.matrix(site.coords - anchor).T).T + anchor).A1
+            new_site = PeriodicSite(site.species_and_occu, s,
+                            self._lattice, to_unit_cell=to_unit_cell,
+                            coords_are_cartesian=True,
+                            properties=site.properties)
+            self._sites[i] = new_site
+
     def perturb(self, distance):
         """
         Performs a random perturbation of the sites in a structure to break

--- a/pymatgen/core/tests/test_structure.py
+++ b/pymatgen/core/tests/test_structure.py
@@ -667,6 +667,22 @@ class StructureTest(PymatgenTest):
         self.assertArrayAlmostEqual(self.structure.frac_coords[0],
                                     [1.00187517, 1.25665291, 1.15946374])
 
+    def test_rotate_sites(self):
+        self.structure.rotate_sites(indices=[1],
+                                    theta=2.*np.pi/3.,
+                                    anchor=self.structure.sites[0].coords,
+                                    to_unit_cell=False)
+        self.assertArrayAlmostEqual(self.structure.frac_coords[1],
+                                    [-1.25, 1.5, 0.75],
+                                    decimal=6)
+        self.structure.rotate_sites(indices=[1],
+                                    theta=2.*np.pi/3.,
+                                    anchor=self.structure.sites[0].coords,
+                                    to_unit_cell=True)
+        self.assertArrayAlmostEqual(self.structure.frac_coords[1],
+                                    [0.75, 0.5, 0.75],
+                                    decimal=6)
+
     def test_mul(self):
         self.structure *= [2, 1, 1]
         self.assertEqual(self.structure.formula, "Si4")


### PR DESCRIPTION
## Summary

* enable molecule-like rotations of arbitrary sites by some angle around some axis at some anchor for pymatgen.core.Structure.

## Additional dependencies introduced

None

## TODO

Nothing