### PR TITLE
fix to actually use search_cutoff

### DIFF
--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -2587,7 +2587,8 @@ class CrystalNN(NearNeighbors):
                     "No valid targets for site within cation_anion constraint!")
 
         # get base VoronoiNN targets
-        vnn = VoronoiNN(weight="solid_angle", targets=target, cutoff=6)
+        vnn = VoronoiNN(weight="solid_angle", targets=target,
+                        cutoff=self.search_cutoff)
         nn = vnn.get_nn_info(structure, n)
 
         # adjust solid angle weights based on distance

--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -2490,7 +2490,7 @@ class CrystalNN(NearNeighbors):
 
     def __init__(self, weighted_cn=False, cation_anion=False,
                  distance_cutoffs=(1.25, 2.5), x_diff_weight=1.0,
-                 search_cutoff=6.0, fingerprint_length=None):
+                 search_cutoff=7.0, fingerprint_length=None):
         """
         Initialize CrystalNN with desired paramters.
 


### PR DESCRIPTION
A very minor fix - the parameter search_cutoff in the constructor of CrystalNN wasn't being used, this actually makes use of it.