### PR TITLE
Add methods for getting phonon BS, DOS, and DDB output

### DIFF
--- a/pymatgen/ext/matproj.py
+++ b/pymatgen/ext/matproj.py
@@ -548,7 +548,7 @@ class MPRester(object):
         Get a BandStructure corresponding to a material_id.
 
         Args:
-            material_id (str): Materials Project material_id (an int).
+            material_id (str): Materials Project material_id.
             line_mode (bool): If True, fetch a BandStructureSymmLine object
                 (default). If False, return the uniform band structure.
 
@@ -558,6 +558,43 @@ class MPRester(object):
         prop = "bandstructure" if line_mode else "bandstructure_uniform"
         data = self.get_data(material_id, prop=prop)
         return data[0][prop]
+
+    def get_phonon_dos_by_material_id(self, material_id):
+        """
+        Get phonon density of states data corresponding to a material_id.
+
+        Args:
+            material_id (str): Materials Project material_id.
+
+        Returns:
+            ﻿CompletePhononDos: A phonon DOS object.
+        """
+        return self._make_request("/materials/{}/phonondos".format(material_id))
+
+    def get_phonon_bandstructure_by_material_id(self, material_id):
+        """
+        Get phonon dispersion data corresponding to a material_id.
+
+        Args:
+            material_id (str): Materials Project material_id.
+
+        Returns:
+            PhononBandStructureSymmLine: A phonon band structure.
+        """
+        return self._make_request("/materials/{}/phononbs".format(material_id))
+
+    def get_phonon_ddb_by_material_id(self, material_id):
+        """
+        Get ABINIT Derivative Data Base (DDB) output for phonon calculations.
+
+        Args:
+            material_id (str): Materials Project material_id.
+
+        Returns:
+            str: ABINIT DDB file as a string.
+        """
+        return self._make_request("/materials/{}/abinit_ddb"
+                                  .format(material_id))
 
     def get_entries_in_chemsys(self, elements, compatible_only=True,
                                inc_structure=None, property_data=None,

--- a/pymatgen/ext/tests/test_matproj.py
+++ b/pymatgen/ext/tests/test_matproj.py
@@ -22,6 +22,8 @@ from pymatgen.analysis.pourbaix_diagram import PourbaixEntry, PourbaixDiagram
 from pymatgen.analysis.wulff import WulffShape
 from pymatgen.analysis.reaction_calculator import Reaction
 from pymatgen.io.cif import CifParser
+from pymatgen.phonon.bandstructure import PhononBandStructureSymmLine
+from pymatgen.phonon.dos import CompletePhononDos
 
 """
 Created on Jun 9, 2012
@@ -174,6 +176,14 @@ class MPResterTest(unittest.TestCase):
             "mp-2254", line_mode=False)
         self.assertIsInstance(bs_unif, BandStructure)
         self.assertNotIsInstance(bs_unif, BandStructureSymmLine)
+
+    def test_get_phonon_data_by_material_id(self):
+        bs = self.rester.get_phonon_bandstructure_by_material_id("mp-661")
+        self.assertIsInstance(bs, PhononBandStructureSymmLine)
+        dos = self.rester.get_phonon_dos_by_material_id("mp-661")
+        self.assertIsInstance(dos, CompletePhononDos)
+        ddb_str = self.rester.get_phonon_ddb_by_material_id("mp-661")
+        self.assertIsInstance(ddb_str, str)
 
     def test_get_structures(self):
         structs = self.rester.get_structures("Mn3O4")


### PR DESCRIPTION
## Summary

Add `MPRester` methods to get phonon dispersion, density of states, and ABINIT Derivative Data Base (DDB) output. Add unit test.
