### PR TITLE
Add bond order property of a CovalentBond

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
 before_script:
   - python setup.py --quiet develop
 # command to run tests, e.g. python setup.py test
-script: travis_wait 18000 "nosetests -v pymatgen"
+script: travis_wait 14400 "nosetests -v pymatgen"
 notifications:
   email:
     recipients:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
 before_script:
   - python setup.py --quiet develop
 # command to run tests, e.g. python setup.py test
-script: travis_wait 14400 "nosetests -v pymatgen"
+script: travis_wait 18000 "nosetests -v pymatgen"
 notifications:
   email:
     recipients:

--- a/pymatgen/core/bond_lengths.json
+++ b/pymatgen/core/bond_lengths.json
@@ -1,1 +1,389 @@
-[{"ref": "", "length": 1.54, "elements": ["C", "C"], "bond_order": 1.0}, {"ref": "", "length": 1.34, "elements": ["C", "C"], "bond_order": 2.0}, {"ref": "", "length": 1.2, "elements": ["C", "C"], "bond_order": 3.0}, {"ref": "", "length": 1.08, "elements": ["C", "H"], "bond_order": 1.0}, {"ref": "", "length": 1.47, "elements": ["C", "N"], "bond_order": 1.0}, {"ref": "", "length": 1.3, "elements": ["C", "N"], "bond_order": 2.0}, {"ref": "", "length": 1.16, "elements": ["C", "N"], "bond_order": 3.0}, {"ref": "", "length": 1.23, "elements": ["C", "O"], "bond_order": 2.0}, {"ref": "", "length": 1.43, "elements": ["C", "O"], "bond_order": 1.0}, {"ref": "", "length": 1.82, "elements": ["C", "S"], "bond_order": 1.0}, {"ref": "", "length": 1.84, "elements": ["C", "P"], "bond_order": 1.0}, {"ref": "", "length": 1.76, "elements": ["C", "Cl"], "bond_order": 1.0}, {"ref": "", "length": 1.35, "elements": ["C", "F"], "bond_order": 1.0}, {"ref": "", "length": 1.66, "elements": ["B", "C"], "bond_order": 1.0}, {"ref": "", "length": 1.01, "elements": ["H", "N"], "bond_order": 1.0}, {"ref": "", "length": 1.69, "elements": ["Cl", "N"], "bond_order": 1.0}, {"ref": "", "length": 1.28, "elements": ["F", "N"], "bond_order": 1.0}, {"ref": "", "length": 1.45, "elements": ["N", "N"], "bond_order": 1.0}, {"ref": "", "length": 1.1, "elements": ["N", "N"], "bond_order": 3.0}, {"ref": "", "length": 1.07, "elements": ["H", "H"], "bond_order": 1.0}, {"ref": "", "length": 1.27, "elements": ["Cl", "H"], "bond_order": 1.0}, {"ref": "", "length": 0.92, "elements": ["F", "H"], "bond_order": 1.0}, {"ref": "", "length": 0.96, "elements": ["H", "O"], "bond_order": 1.0}, {"ref": "", "length": 1.48, "elements": ["O", "O"], "bond_order": 1.0}, {"ref": "", "length": 1.37, "elements": ["N", "O"], "bond_order": 1.0}, {"ref": "Based on HOF", "length": 1.45, "elements": ["F", "O"], "bond_order": 1.0}, {"ref": "Based on H2SO4 CCBDB", "length": 1.57, "elements": ["O", "S"], "bond_order": 1.0}, {"ref": "", "length": 1.65, "elements": ["F", "P"], "bond_order": 1.0}, {"ref": "", "length": 1.4, "elements": ["H", "P"], "bond_order": 1.0}, {"ref": "Estimate", "length": 1.5, "elements": ["N", "P"], "bond_order": 1.0}, {"ref": "Based on Pcl5 Axial Length (longest)", "length": 2.2, "elements": ["Cl", "P"], "bond_order": 1.0}, {"ref": "Based on P=O", "length": 1.51, "elements": ["O", "P"], "bond_order": 1.0}, {"ref": "Based on F-F.", "length": 1.41, "elements": ["F", "F"], "bond_order": 1.0}, {"ref": "Based on SF4 (axial)", "length": 1.65, "elements": ["F", "S"], "bond_order": 1.0}, {"ref": "Based on Optimized Structure.", "length": 1.62, "elements": ["N", "S"], "bond_order": 1.0}, {"ref": "Based on max NO in CCBDB", "length": 1.51, "elements": ["N", "O"], "bond_order": 1.0}, {"ref": "Based on S8 CCBDB", "length": 2.06, "elements": ["S", "S"], "bond_order": 1.0}, {"ref": "Based on SH CCBDB", "length": 1.35, "elements": ["H", "S"], "bond_order": 1.0}, {"ref": "Based on calculated value", "length": 1.41, "elements": ["B", "F"], "bond_order": 1.0}, {"ref": "Based on max No in CCBDB", "length": 1.25, "elements": ["B", "O"], "bond_order": 1.0}, {"ref": "Based on max BH in CCBDB", "length": 1.232, "elements": ["B", "H"], "bond_order": 1.0}, {"ref": "Based on CCCBDB", "length": 1.6, "elements": ["B", "N"], "bond_order": 1.0}, {"ref": "Based on CCCBDB", "length": 1.887, "elements": ["Na", "H"], "bond_order": 1.0}]
+[
+  {
+    "ref": "",
+    "length": 1.54,
+    "elements": [
+      "C",
+      "C"
+    ],
+    "bond_order": 1.0
+  },
+  {
+    "ref": "",
+    "length": 1.34,
+    "elements": [
+      "C",
+      "C"
+    ],
+    "bond_order": 2.0
+  },
+  {
+    "ref": "",
+    "length": 1.2,
+    "elements": [
+      "C",
+      "C"
+    ],
+    "bond_order": 3.0
+  },
+  {
+    "ref": "",
+    "length": 1.08,
+    "elements": [
+      "C",
+      "H"
+    ],
+    "bond_order": 1.0
+  },
+  {
+    "ref": "",
+    "length": 1.47,
+    "elements": [
+      "C",
+      "N"
+    ],
+    "bond_order": 1.0
+  },
+  {
+    "ref": "",
+    "length": 1.3,
+    "elements": [
+      "C",
+      "N"
+    ],
+    "bond_order": 2.0
+  },
+  {
+    "ref": "",
+    "length": 1.16,
+    "elements": [
+      "C",
+      "N"
+    ],
+    "bond_order": 3.0
+  },
+  {
+    "ref": "",
+    "length": 1.23,
+    "elements": [
+      "C",
+      "O"
+    ],
+    "bond_order": 2.0
+  },
+  {
+    "ref": "",
+    "length": 1.43,
+    "elements": [
+      "C",
+      "O"
+    ],
+    "bond_order": 1.0
+  },
+  {
+    "ref": "",
+    "length": 1.82,
+    "elements": [
+      "C",
+      "S"
+    ],
+    "bond_order": 1.0
+  },
+  {
+    "ref": "",
+    "length": 1.84,
+    "elements": [
+      "C",
+      "P"
+    ],
+    "bond_order": 1.0
+  },
+  {
+    "ref": "",
+    "length": 1.76,
+    "elements": [
+      "C",
+      "Cl"
+    ],
+    "bond_order": 1.0
+  },
+  {
+    "ref": "",
+    "length": 1.35,
+    "elements": [
+      "C",
+      "F"
+    ],
+    "bond_order": 1.0
+  },
+  {
+    "ref": "",
+    "length": 1.66,
+    "elements": [
+      "B",
+      "C"
+    ],
+    "bond_order": 1.0
+  },
+  {
+    "ref": "",
+    "length": 1.01,
+    "elements": [
+      "H",
+      "N"
+    ],
+    "bond_order": 1.0
+  },
+  {
+    "ref": "",
+    "length": 1.69,
+    "elements": [
+      "Cl",
+      "N"
+    ],
+    "bond_order": 1.0
+  },
+  {
+    "ref": "",
+    "length": 1.28,
+    "elements": [
+      "F",
+      "N"
+    ],
+    "bond_order": 1.0
+  },
+  {
+    "ref": "",
+    "length": 1.45,
+    "elements": [
+      "N",
+      "N"
+    ],
+    "bond_order": 1.0
+  },
+  {
+    "ref": "",
+    "length": 1.1,
+    "elements": [
+      "N",
+      "N"
+    ],
+    "bond_order": 3.0
+  },
+  {
+    "ref": "",
+    "length": 1.07,
+    "elements": [
+      "H",
+      "H"
+    ],
+    "bond_order": 1.0
+  },
+  {
+    "ref": "",
+    "length": 1.27,
+    "elements": [
+      "Cl",
+      "H"
+    ],
+    "bond_order": 1.0
+  },
+  {
+    "ref": "",
+    "length": 0.92,
+    "elements": [
+      "F",
+      "H"
+    ],
+    "bond_order": 1.0
+  },
+  {
+    "ref": "",
+    "length": 0.96,
+    "elements": [
+      "H",
+      "O"
+    ],
+    "bond_order": 1.0
+  },
+  {
+    "ref": "",
+    "length": 1.48,
+    "elements": [
+      "O",
+      "O"
+    ],
+    "bond_order": 1.0
+  },
+  {
+    "ref": "",
+    "length": 1.37,
+    "elements": [
+      "N",
+      "O"
+    ],
+    "bond_order": 1.0
+  },
+  {
+    "ref": "Based on HOF",
+    "length": 1.45,
+    "elements": [
+      "F",
+      "O"
+    ],
+    "bond_order": 1.0
+  },
+  {
+    "ref": "Based on H2SO4 CCBDB",
+    "length": 1.57,
+    "elements": [
+      "O",
+      "S"
+    ],
+    "bond_order": 1.0
+  },
+  {
+    "ref": "",
+    "length": 1.65,
+    "elements": [
+      "F",
+      "P"
+    ],
+    "bond_order": 1.0
+  },
+  {
+    "ref": "",
+    "length": 1.4,
+    "elements": [
+      "H",
+      "P"
+    ],
+    "bond_order": 1.0
+  },
+  {
+    "ref": "Estimate",
+    "length": 1.5,
+    "elements": [
+      "N",
+      "P"
+    ],
+    "bond_order": 1.0
+  },
+  {
+    "ref": "Based on Pcl5 Axial Length (longest)",
+    "length": 2.2,
+    "elements": [
+      "Cl",
+      "P"
+    ],
+    "bond_order": 1.0
+  },
+  {
+    "ref": "Based on P=O",
+    "length": 1.51,
+    "elements": [
+      "O",
+      "P"
+    ],
+    "bond_order": 1.0
+  },
+  {
+    "ref": "Based on F-F.",
+    "length": 1.41,
+    "elements": [
+      "F",
+      "F"
+    ],
+    "bond_order": 1.0
+  },
+  {
+    "ref": "Based on SF4 (axial)",
+    "length": 1.65,
+    "elements": [
+      "F",
+      "S"
+    ],
+    "bond_order": 1.0
+  },
+  {
+    "ref": "Based on Optimized Structure.",
+    "length": 1.62,
+    "elements": [
+      "N",
+      "S"
+    ],
+    "bond_order": 1.0
+  },
+  {
+    "ref": "Based on max NO in CCBDB",
+    "length": 1.51,
+    "elements": [
+      "N",
+      "O"
+    ],
+    "bond_order": 1.0
+  },
+  {
+    "ref": "Based on S8 CCBDB",
+    "length": 2.06,
+    "elements": [
+      "S",
+      "S"
+    ],
+    "bond_order": 1.0
+  },
+  {
+    "ref": "Based on SH CCBDB",
+    "length": 1.35,
+    "elements": [
+      "H",
+      "S"
+    ],
+    "bond_order": 1.0
+  },
+  {
+    "ref": "Based on calculated value",
+    "length": 1.41,
+    "elements": [
+      "B",
+      "F"
+    ],
+    "bond_order": 1.0
+  },
+  {
+    "ref": "Based on max No in CCBDB",
+    "length": 1.25,
+    "elements": [
+      "B",
+      "O"
+    ],
+    "bond_order": 1.0
+  },
+  {
+    "ref": "Based on max BH in CCBDB",
+    "length": 1.232,
+    "elements": [
+      "B",
+      "H"
+    ],
+    "bond_order": 1.0
+  },
+  {
+    "ref": "Based on CCCBDB",
+    "length": 1.6,
+    "elements": [
+      "B",
+      "N"
+    ],
+    "bond_order": 1.0
+  },
+  {
+    "ref": "Based on CCCBDB",
+    "length": 1.887,
+    "elements": [
+      "Na",
+      "H"
+    ],
+    "bond_order": 1.0
+  }
+]

--- a/pymatgen/core/bonds.py
+++ b/pymatgen/core/bonds.py
@@ -8,7 +8,7 @@ import json
 import collections
 import warnings
 
-from pymatgen.core.periodic_table import get_el_sp
+from pymatgen.core.periodic_table import Element
 
 """
 This class implements definitions for various kinds of bonds. Typically used in
@@ -33,6 +33,7 @@ def _load_bond_length_data():
             els = sorted(row['elements'])
             data[tuple(els)][row['bond_order']] = row['length']
         return data
+
 
 bond_lengths = _load_bond_length_data()
 
@@ -60,6 +61,28 @@ class CovalentBond(object):
         """
         return self.site1.distance(self.site2)
 
+    def get_bond_order(self, tol=0.2, default_bl=None):
+        """
+        The bond order according the distance between the two sites
+        Args:
+            tol (float): Relative tolerance to test.
+                (1 + tol) * the longest bond distance is considered
+                to be the threshold length for a bond to exist.
+                (1 - tol) * the shortest bond distance is considered
+                to be the shortest possible bond length
+                Defaults to 0.2.
+            default_bl: If a particular type of bond does not exist, 
+                use this bond length as a default value
+                (bond order = 1). If None, a ValueError will be thrown.
+        Returns:
+            Float value of bond order. For example, for C-C bond in
+            benzene, return 1.7.
+        """
+        sp1 = list(self.site1.species_and_occu.keys())[0]
+        sp2 = list(self.site2.species_and_occu.keys())[0]
+        dist = self.site1.distance(self.site2)
+        return get_bond_order(sp1, sp2, dist, tol, default_bl)
+
     @staticmethod
     def is_bonded(site1, site2, tol=0.2, bond_order=None, default_bl=None):
         """
@@ -69,9 +92,11 @@ class CovalentBond(object):
             site1 (Site): First site
             site2 (Site): Second site
             tol (float): Relative tolerance to test. Basically, the code
-                checks if the distance between the sites is less than (1 +
-                tol) * typical bond distances. Defaults to 0.2, i.e.,
-                20% longer.
+                checks if the distance between the sites is larger than
+                (1 + tol) * the longest bond distance or smaller than
+                (1 - tol) * the shortest bond distance to determine if
+                they are bonded or the distance is too short.
+                Defaults to 0.2.
             bond_order: Bond order to test. If None, the code simply checks
                 against all possible bond data. Defaults to None.
             default_bl: If a particular type of bond does not exist, use this
@@ -80,21 +105,12 @@ class CovalentBond(object):
         Returns:
             Boolean indicating whether two sites are bonded.
         """
-        sp1 = list(site1.species_and_occu.keys())[0]
-        sp2 = list(site2.species_and_occu.keys())[0]
-        dist = site1.distance(site2)
-        syms = tuple(sorted([sp1.symbol, sp2.symbol]))
-        if syms in bond_lengths:
-            all_lengths = bond_lengths[syms]
-            if bond_order:
-                return dist < (1 + tol) * all_lengths[bond_order]
-            for v in all_lengths.values():
-                if dist < (1 + tol) * v:
-                    return True
-            return False
-        elif default_bl:
-            return dist < (1 + tol) * default_bl
-        raise ValueError("No bond data for elements {} - {}".format(*syms))
+        bond = CovalentBond(site1, site2)
+        estimate_bond_order = bond.get_bond_order(tol, default_bl)
+        if bond_order:
+            return estimate_bond_order < (1 + tol) * bond_order
+        else:
+            return bool(estimate_bond_order)
 
     def __repr__(self):
         return "Covalent bond between {} and {}".format(self.site1,
@@ -102,6 +118,78 @@ class CovalentBond(object):
 
     def __str__(self):
         return self.__repr__()
+
+
+def obtain_all_bond_lengths(sp1, sp2, default_bl=None):
+    """
+    Obtain bond lengths for all bond orders from bond length database
+
+    Args:
+        sp1 (Specie): First specie.
+        sp2 (Specie): Second specie.
+        default_bl: If a particular type of bond does not exist, use this
+            bond length as a default value (bond order = 1).
+            If None, a ValueError will be thrown.
+
+    Return:
+        A dict mapping bond order to bond length in angstrom
+    """
+    if isinstance(sp1, Element):
+        sp1 = sp1.symbol
+    if isinstance(sp2, Element):
+        sp2 = sp2.symbol
+    syms = tuple(sorted([sp1, sp2]))
+    if syms in bond_lengths:
+        return bond_lengths[syms].copy()
+    elif default_bl is not None:
+        return {1: default_bl}
+    else:
+        raise ValueError("No bond data for elements {} - {}".format(*syms))
+
+
+def get_bond_order(sp1, sp2, dist, tol=0.2, default_bl=None):
+    """
+    Calculate the bond order given the distance of 2 species
+
+    Args:
+        sp1 (Specie): First specie.
+        sp2 (Specie): Second specie.
+        dist: Their distance in angstrom
+        tol (float): Relative tolerance to test. Basically, the code
+            checks if the distance between the sites is larger than
+            (1 + tol) * the longest bond distance or smaller than
+            (1 - tol) * the shortest bond distance to determine if
+            they are bonded or the distance is too short.
+            Defaults to 0.2.
+        default_bl: If a particular type of bond does not exist, use this
+            bond length (bond order = 1). If None, a ValueError will be thrown.
+
+    Returns:
+        Float value of bond order. For example, for C-C bond in benzene,
+        return 1.7.
+    """
+    all_lengths = obtain_all_bond_lengths(sp1, sp2, default_bl)
+    # Transform bond lengths dict to list assuming bond data is successive
+    # and add an imaginary bond 0 length
+    lengths_list = [all_lengths[1] * (1 + tol)] \
+                   + [all_lengths[idx+1] for idx in range(len(all_lengths))]
+    trial_bond_order = 0
+    while trial_bond_order < len(lengths_list):
+        if lengths_list[trial_bond_order] < dist:
+            if trial_bond_order == 0:
+                return trial_bond_order
+            else:
+                low_bl = lengths_list[trial_bond_order]
+                high_bl = lengths_list[trial_bond_order - 1]
+                return trial_bond_order - (dist - low_bl) / (high_bl - low_bl)
+        trial_bond_order += 1
+    # Distance shorter than the shortest bond length stored,
+    # check if the distance is too short
+    if dist < lengths_list[-1] * (1 - tol): # too short
+        warnings.warn('%.2f angstrom distance is too short for %s and %s'
+                      % (dist, sp1, sp2))
+    # return the highest bond order
+    return trial_bond_order - 1
 
 
 def get_bond_length(sp1, sp2, bond_order=1):
@@ -118,17 +206,20 @@ def get_bond_length(sp1, sp2, bond_order=1):
 
     Returns:
         Bond length in Angstrom. If no data is available, the sum of the atomic
-        radii is used.
+        radius is used.
     """
-    sp1 = get_el_sp(sp1)
-    sp2 = get_el_sp(sp2)
-    syms = tuple(sorted([sp1.symbol, sp2.symbol]))
-    if syms in bond_lengths:
-        all_lengths = bond_lengths[syms]
-        if bond_order:
-            return all_lengths.get(bond_order)
-        else:
-            return all_lengths.get(1)
-    warnings.warn("No bond lengths for %s-%s found in database. Returning sum"
-                  "of atomic radius." % (sp1, sp2))
-    return sp1.atomic_radius + sp2.atomic_radius
+    sp1 = Element(sp1) if isinstance(sp1, str) else sp1
+    sp2 = Element(sp2) if isinstance(sp2, str) else sp2
+    try:
+        all_lengths = obtain_all_bond_lengths(sp1, sp2)
+        return all_lengths[bond_order]
+    # The ValueError is raised in `obtain_all_bond_lengths` where no bond
+    # data for both elements is found. The KeyError is raised in
+    # `__getitem__` method of `dict` builtin class where although bond data
+    # for both elements is found, the data for specified bond order does
+    # not exist. In both cases, sum of atomic radius is returned.
+    except (ValueError, KeyError):
+        warnings.warn("No order %d bond lengths between %s and %s found in "
+                      "database. Returning sum of atomic radius."
+                      % (bond_order, sp1, sp2))
+        return sp1.atomic_radius + sp2.atomic_radius

--- a/pymatgen/core/bonds.py
+++ b/pymatgen/core/bonds.py
@@ -71,7 +71,7 @@ class CovalentBond(object):
                 (1 - tol) * the shortest bond distance is considered
                 to be the shortest possible bond length
                 Defaults to 0.2.
-            default_bl: If a particular type of bond does not exist, 
+            default_bl: If a particular type of bond does not exist,
                 use this bond length as a default value
                 (bond order = 1). If None, a ValueError will be thrown.
         Returns:
@@ -185,7 +185,7 @@ def get_bond_order(sp1, sp2, dist, tol=0.2, default_bl=None):
         trial_bond_order += 1
     # Distance shorter than the shortest bond length stored,
     # check if the distance is too short
-    if dist < lengths_list[-1] * (1 - tol): # too short
+    if dist < lengths_list[-1] * (1 - tol):  # too short
         warnings.warn('%.2f angstrom distance is too short for %s and %s'
                       % (dist, sp1, sp2))
     # return the highest bond order

--- a/pymatgen/core/tests/test_bonds.py
+++ b/pymatgen/core/tests/test_bonds.py
@@ -6,8 +6,10 @@ from __future__ import division, unicode_literals
 
 import unittest
 import warnings
-from pymatgen.core.bonds import CovalentBond, get_bond_length
+from pymatgen.core.bonds import CovalentBond, get_bond_length, \
+    obtain_all_bond_lengths, get_bond_order
 from pymatgen.core.sites import Site
+from pymatgen.core.periodic_table import Element
 
 
 __author__ = "Shyue Ping Ong"
@@ -32,6 +34,15 @@ class CovalentBondTest(unittest.TestCase):
         self.assertAlmostEqual(CovalentBond(site1, site2).length,
                                0.92195444572928864)
 
+    def test_get_bond_order(self):
+        site1 = Site("C", [0, 0, 0])
+        site2 = Site("H", [0, 0, 1.08])
+        self.assertAlmostEqual(
+            CovalentBond(site1, site2).get_bond_order(), 1)
+        bond = CovalentBond(Site("C", [0, 0, 0]), Site("Br", [0, 0, 2]))
+        self.assertAlmostEqual(
+            bond.get_bond_order(0.5, 1.9), 0.894736842105263)
+
     def test_is_bonded(self):
         site1 = Site("C", [0, 0, 0])
         site2 = Site("H", [0, 0, 1])
@@ -54,8 +65,48 @@ class FuncTest(unittest.TestCase):
         self.assertAlmostEqual(get_bond_length("C", "C", 1), 1.54)
         self.assertAlmostEqual(get_bond_length("C", "C", 2), 1.34)
         self.assertAlmostEqual(get_bond_length("C", "H", 1), 1.08)
-        self.assertEqual(get_bond_length("C", "H", 2), None)
+        self.assertEqual(get_bond_length("C", "H", 2), 0.95)
         self.assertAlmostEqual(get_bond_length("C", "Br", 1), 1.85)
+
+    def test_obtain_all_bond_lengths(self):
+        self.assertDictEqual(obtain_all_bond_lengths('C', 'C'),
+                             {1.0: 1.54, 2.0: 1.34, 3.0: 1.2})
+        self.assertRaises(ValueError, obtain_all_bond_lengths,
+                          'Br', Element('C'))
+        self.assertDictEqual(obtain_all_bond_lengths(
+            'C', Element('Br'), 1.76), {1: 1.76})
+        bond_lengths_dict = obtain_all_bond_lengths('C', 'N')
+        bond_lengths_dict[4] = 999
+        self.assertDictEqual(obtain_all_bond_lengths('C', 'N'),
+                             {1.0: 1.47, 2.0: 1.3, 3.0: 1.16})
+
+    def test_get_bond_order(self):
+        self.assertAlmostEqual(get_bond_order(
+            'C', 'C', 1), 3)
+        self.assertAlmostEqual(get_bond_order(
+            'C', 'C', 1.2), 3)
+        self.assertAlmostEqual(get_bond_order(
+            'C', 'C', 1.25), 2.642857142857143)
+        self.assertAlmostEqual(get_bond_order(
+            'C', 'C', 1.34), 2)
+        self.assertAlmostEqual(get_bond_order(
+            'C', 'C', 1.4), 1.7)  # bond length in benzene
+        self.assertAlmostEqual(get_bond_order(
+            'C', 'C', 1.54), 1)
+        self.assertAlmostEqual(get_bond_order(
+            'C', 'C', 2.5), 0)
+        self.assertAlmostEqual(get_bond_order(
+            'C', 'C', 9999), 0)
+        self.assertAlmostEqual(get_bond_order(
+            'C', 'Br', 1.9, default_bl=1.9), 1)
+        self.assertAlmostEqual(get_bond_order(
+            'C', 'Br', 2, default_bl=1.9), 0.7368421052631575)
+        self.assertAlmostEqual(get_bond_order(
+            'C', 'Br', 1.9, tol=0.5, default_bl=1.9), 1)
+        self.assertAlmostEqual(get_bond_order(
+            'C', 'Br', 2, tol=0.5, default_bl=1.9), 0.894736842105263)
+        self.assertRaises(ValueError, get_bond_order, 'C', 'Br', 1.9)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Add bond order property of a CovalentBond (Issue #1126) . Initially I plan to change `is_bonded` to return an int indicating bond order. After some reflection I think this is a bad idea:
* According to the semantics, `is_bonded` should return a Boolean instead of an int.
* In some cases, like in benzene, the bond order can not be described by an int.

So what I finally do is to build another function `get_bond_order` which returns a float indicating the bond order. The bond order is calculated by the ideal bond lengths of different bond orders and the actual site distance. For example, if C-C bond is 1.54 A and C=C bond is 1.34 A and we have a distance of 1.4 A (benzene). Then the bond order is 2 - (1.4 - 1.34) / (1.54 - 1.34) = 1.7. I think this is enough to provide some qualitative information.

What I did is listed below in detail:
* Add a function `obtain_all_bond_lengths` as a wrapper of the bond length database. 
* Add a function `get_bond_order` to calculate bond order
* Add a member method `get_bond_order` for class `CovalentBond` to indicate the bond order of the covalent bond.
* Refractor `get_bond_length` and `is_bonded` to make them more concise using new functions.
* Improve the behavior of `get_bond_length`. If data for the bond order requested is not available, a warning will be shown and the radius sum will be returned, instead of `None`, which is the same as the behavior when no bond order data is available for the species.
* Make bond lengths json file indented to provide convenience for inspection.
* Add tests for the bond order related functions.
