### PR TITLE
extend the XYZ class

### DIFF
--- a/pymatgen/io/tests/test_xyz.py
+++ b/pymatgen/io/tests/test_xyz.py
@@ -97,6 +97,21 @@ C 1.16730636786 -1.38166622735 -2.77112970359e-06
         self.assertTrue(abs(mol[0].z) < 1e-5)
         self.assertTrue(abs(mol[1].z) < 1e-5)
 
+        mol_str = """3
+Random
+C   0.000000000000E+00  2.232615992397E+01  0.000000000000E+00
+C  -2.383225420567E-31  1.116307996198E+01  1.933502166311E+01
+C  -4.440892098501D-01 -1.116307996198d+01  1.933502166311E+01
+"""
+        xyz = XYZ.from_string(mol_str)
+        mol = xyz.molecule
+        self.assertAlmostEqual(mol[0].x, 0)
+        self.assertAlmostEqual(mol[1].y, 11.16307996198)
+        self.assertAlmostEqual(mol[2].x, -0.4440892098501)
+        self.assertAlmostEqual(mol[2].y, -11.16307996198)
+        # self.assertTrue(abs(mol[1].z) < 1e-5)
+
+
     def test_from_file(self):
         filepath = os.path.join(test_dir, 'multiple_frame_xyz.xyz')
         mxyz = XYZ.from_file(filepath)

--- a/pymatgen/io/xyz.py
+++ b/pymatgen/io/xyz.py
@@ -73,7 +73,10 @@ class XYZ(object):
             if m:
                 sp.append(m.group(1))  # this is 1-indexed
                 # this is 0-indexed
-                coords.append([float(j) for j in m.groups()[1:4]])
+                # in case of 0.0D+00 or 0.00d+01 old double precision writing
+                # replace d or D by e for ten power exponent
+                xyz = [val.lower().replace("d", "e") for val in m.groups()[1:4]]
+                coords.append([float(val) for val in xyz])
         return Molecule(sp, coords)
 
     @staticmethod

--- a/pymatgen/io/xyz.py
+++ b/pymatgen/io/xyz.py
@@ -66,7 +66,7 @@ class XYZ(object):
         coords = []
         sp = []
         coord_patt = re.compile(
-            r"(\w+)\s+([0-9\-\.e]+)\s+([0-9\-\.e]+)\s+([0-9\-\.e]+)"
+            r"(\w+)\s+([0-9\-\+\.eEdD]+)\s+([0-9\-\+\.eEdD]+)\s+([0-9\-\+\.eEdD]+)"
         )
         for i in range(2, 2 + num_sites):
             m = coord_patt.search(lines[i])
@@ -92,7 +92,7 @@ class XYZ(object):
         white_space = r"[ \t\r\f\v]"
         natoms_line = white_space + r"*\d+" + white_space + r"*\n"
         comment_line = r"[^\n]*\n"
-        coord_lines = r"(\s*\w+\s+[0-9\-\.e]+\s+[0-9\-\.e]+\s+[0-9\-\.e]+\s*\n)+"
+        coord_lines = r"(\s*\w+\s+[0-9\-\+\.eEdD]+\s+[0-9\-\+\.eEdD]+\s+[0-9\-\+\.eEdD]+\s*\n)+"
         frame_pattern_text = natoms_line + comment_line + coord_lines
         pat = re.compile(frame_pattern_text, re.MULTILINE)
         mols = []


### PR DESCRIPTION
## Summary

some float formats were not recognized when reading an xyz file. Only this one was read: 0.500e-09 and 0.7766e3. That floats were not recognized by the regex and are now read correctly: 

* 0.100E+01
* 0.100D+02
* 0.100d+2
