### PR TITLE
Structure transform

### DIFF
--- a/pymatgen/analysis/elasticity/tensors.py
+++ b/pymatgen/analysis/elasticity/tensors.py
@@ -14,6 +14,7 @@ import string
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.core.operations import SymmOp
 from pymatgen.core.lattice import Lattice
+from pymatgen.analysis.structure_matcher import StructureMatcher
 
 """
 This module provides a base class for tensor-like objects and methods for
@@ -387,6 +388,33 @@ class Tensor(np.ndarray):
         if initial_fit:
             result = result.fit_to_structure(structure)
         return result.rotate(rotation, tol=1e-2)
+
+    def structure_transform(self, original_structure, new_structure):
+        """
+        Transforms a tensor from one basis for an original structure
+        into a new basis defined by a new structure.
+
+        Args:
+            original_structure (Structure): structure corresponding
+                to the basis of the current tensor
+            new_structure (Structure): structure corresponding to the
+                desired basis
+
+        Returns:
+            Tensor that has been transformed such that its basis
+            corresponds to the new_structure's basis
+        """
+        sm = StructureMatcher()
+        if not sm.fit(original_structure, new_structure):
+            warnings.warn("original and new structures do not match!")
+        ieee_trans_1 = self.get_ieee_rotation(original_structure)
+        ieee_trans_2 = self.get_ieee_rotation(new_structure)
+        # Get the ieee format tensor
+        new = self.rotate(ieee_trans_1)
+        # Reverse the ieee format rotation for the second structure
+        new = new.rotate(np.transpose(ieee_trans_2))
+        import nose; nose.tools.set_trace()
+        return new
 
     @classmethod
     def from_values_indices(cls, values, indices, populate=False,

--- a/pymatgen/analysis/elasticity/tensors.py
+++ b/pymatgen/analysis/elasticity/tensors.py
@@ -294,7 +294,7 @@ class Tensor(np.ndarray):
         return cls(t)
 
     @staticmethod
-    def get_ieee_rotation(structure):
+    def get_ieee_rotation(structure, refine_rotation=True):
         """
         Given a structure associated with a tensor, determines
         the rotation matrix for IEEE conversion according to
@@ -303,8 +303,9 @@ class Tensor(np.ndarray):
         Args:
             structure (Structure): a structure associated with the
                 tensor to be converted to the IEEE standard
+            refine_rotation (bool): whether to refine the rotation
+                using SquareTensor.refine_rotation
         """
-
         # Check conventional setting:
         sga = SpacegroupAnalyzer(structure)
         dataset = sga.get_symmetry_dataset()
@@ -365,9 +366,14 @@ class Tensor(np.ndarray):
             rotation[1] = get_uvec(np.cross(rotation[2], rotation[1]))
             rotation[0] = np.cross(rotation[1], rotation[2])
 
+        rotation = SquareTensor(rotation)
+        if refine_rotation:
+            rotation = rotation.refine_rotation()
+
         return rotation
 
-    def convert_to_ieee(self, structure, initial_fit=True):
+    def convert_to_ieee(self, structure, initial_fit=True,
+                        refine_rotation=True):
         """
         Given a structure associated with a tensor, attempts a
         calculation of the tensor in IEEE format according to
@@ -382,14 +388,17 @@ class Tensor(np.ndarray):
                 results may be obtained due to symmetrically
                 equivalent, but distinct transformations
                 being used in different versions of spglib.
+            refine_rotation (bool): whether to refine the rotation
+                produced by the ieee transform generator, default True
         """
-        rotation = self.get_ieee_rotation(structure)
+        rotation = self.get_ieee_rotation(structure, refine_rotation)
         result = self.copy()
         if initial_fit:
             result = result.fit_to_structure(structure)
         return result.rotate(rotation, tol=1e-2)
 
-    def structure_transform(self, original_structure, new_structure):
+    def structure_transform(self, original_structure, new_structure,
+                            refine_rotation=True):
         """
         Transforms a tensor from one basis for an original structure
         into a new basis defined by a new structure.
@@ -399,6 +408,8 @@ class Tensor(np.ndarray):
                 to the basis of the current tensor
             new_structure (Structure): structure corresponding to the
                 desired basis
+            refine_rotation (bool): whether to refine the rotations
+                generated in get_ieee_rotation
 
         Returns:
             Tensor that has been transformed such that its basis
@@ -407,13 +418,12 @@ class Tensor(np.ndarray):
         sm = StructureMatcher()
         if not sm.fit(original_structure, new_structure):
             warnings.warn("original and new structures do not match!")
-        ieee_trans_1 = self.get_ieee_rotation(original_structure)
-        ieee_trans_2 = self.get_ieee_rotation(new_structure)
+        trans_1 = self.get_ieee_rotation(original_structure, refine_rotation)
+        trans_2 = self.get_ieee_rotation(new_structure, refine_rotation)
         # Get the ieee format tensor
-        new = self.rotate(ieee_trans_1)
+        new = self.rotate(trans_1)
         # Reverse the ieee format rotation for the second structure
-        new = new.rotate(np.transpose(ieee_trans_2))
-        import nose; nose.tools.set_trace()
+        new = new.rotate(np.transpose(trans_2))
         return new
 
     @classmethod
@@ -593,8 +603,11 @@ class TensorCollection(collections.Sequence):
     def from_voigt(cls, voigt_input_list, base_class=Tensor):
         return cls([base_class.from_voigt(v) for v in voigt_input_list])
 
-    def convert_to_ieee(self, structure):
-        return self.__class__([t.convert_to_ieee(structure) for t in self])
+    def convert_to_ieee(self, structure, initial_fit=True,
+                        refine_rotation=True):
+        return self.__class__(
+            [t.convert_to_ieee(structure, initial_fit, refine_rotation)
+             for t in self])
 
 
 class SquareTensor(Tensor):

--- a/pymatgen/analysis/elasticity/tensors.py
+++ b/pymatgen/analysis/elasticity/tensors.py
@@ -664,6 +664,25 @@ class SquareTensor(Tensor):
         return (np.abs(self.inv - self.trans) < tol).all() \
             and (np.abs(det - 1.) < tol)
 
+    def refine_rotation(self):
+        """
+        Helper method for refining rotation matrix by ensuring
+        that second and third rows are perpindicular to the first.
+        Gets new y vector from an orthogonal projection of x onto y
+        and the new z vector from a cross product of the new x and y
+
+        Args:
+            tol to test for rotation
+
+        Returns:
+            new rotation matrix
+        """
+        new_x, y = get_uvec(self[0]), get_uvec(self[1])
+        # Get a projection on y
+        new_y = y - np.dot(new_x, y) * new_x
+        new_z = np.cross(new_x, new_y)
+        return SquareTensor([new_x, new_y, new_z])
+
     def get_scaled(self, scale_factor):
         """
         Scales the tensor by a certain multiplicative scale factor

--- a/pymatgen/analysis/elasticity/tests/test_tensors.py
+++ b/pymatgen/analysis/elasticity/tests/test_tensors.py
@@ -536,11 +536,11 @@ class SquareTensorTest(PymatgenTest):
 
     def test_refine_rotation(self):
         self.assertArrayAlmostEqual(self.rotation, self.rotation.refine_rotation())
-        new = np.copy(self.rotation)
-        new[3, 3] += 0.02
+        new = self.rotation.copy()
+        new[2, 2] += 0.02
         self.assertFalse(new.is_rotation())
         self.assertArrayAlmostEqual(self.rotation, new.refine_rotation())
-        new[2, 3] += 0.05
+        new[1] *= 1.05
         self.assertArrayAlmostEqual(self.rotation, new.refine_rotation())
 
     def test_get_scaled(self):

--- a/pymatgen/analysis/elasticity/tests/test_tensors.py
+++ b/pymatgen/analysis/elasticity/tests/test_tensors.py
@@ -108,7 +108,7 @@ class TensorTest(PymatgenTest):
                                    [[29.4, 0., 0.],
                                     [0., 29.4, 0.],
                                     [0., 0., 207.6]]]])
-        
+
         self.unfit4 = Tensor([[[[161.26, 0., 0.],
                                     [0., 62.76, 0.],
                                     [0., 0., 30.18]],
@@ -184,7 +184,7 @@ class TensorTest(PymatgenTest):
                                       [9.268, 38.321, 29.919],
                                       [8.285, 33.651, 26.000]]], 3)
 
-    
+
     def test_rotate(self):
         self.assertArrayEqual(self.vec.rotate([[0, -1, 0],
                                                [1, 0, 0],
@@ -195,7 +195,7 @@ class TensorTest(PymatgenTest):
                                                   [0.700, 0.5, 0.172],
                                                   [0.171, 0.233, 0.068]]),
                                     decimal=3)
-        self.assertRaises(ValueError, self.non_symm.rotate, 
+        self.assertRaises(ValueError, self.non_symm.rotate,
                           self.symm_rank2)
 
     def test_einsum_sequence(self):
@@ -209,7 +209,7 @@ class TensorTest(PymatgenTest):
         self.assertTrue(self.rand_rank2.symmetrized.is_symmetric())
         self.assertTrue(self.rand_rank3.symmetrized.is_symmetric())
         self.assertTrue(self.rand_rank4.symmetrized.is_symmetric())
-    
+
     def test_is_symmetric(self):
         self.assertTrue(self.symm_rank2.is_symmetric())
         self.assertTrue(self.symm_rank3.is_symmetric())
@@ -313,7 +313,7 @@ class TensorTest(PymatgenTest):
     def test_populate(self):
         test_data = loadfn(os.path.join(test_dir, 'test_toec_data.json'))
 
-        sn = self.get_structure("Sn") 
+        sn = self.get_structure("Sn")
         vtens = np.zeros((6, 6))
         vtens[0, 0] = 259.31
         vtens[0, 1] = 160.71
@@ -328,7 +328,7 @@ class TensorTest(PymatgenTest):
         self.assertAlmostEqual(populated[5, 5], 73.48)
         # test a rank 6 example
         vtens = np.zeros([6]*3)
-        indices = [(0, 0, 0), (0, 0, 1), (0, 1, 2), 
+        indices = [(0, 0, 0), (0, 0, 1), (0, 1, 2),
                    (0, 3, 3), (0, 5, 5), (3, 4, 5)]
         values = [-1271., -814., -50., -3., -780., -95.]
         for v, idx in zip(values, indices):
@@ -342,7 +342,7 @@ class TensorTest(PymatgenTest):
         self.assertAlmostEqual(toec.voigt[2, 5, 5], -3)
         self.assertAlmostEqual(toec.voigt[1, 2, 0], -50)
         self.assertAlmostEqual(toec.voigt[4, 5, 3], -95)
-        
+
         et = Tensor.from_voigt(test_data["C3_raw"]).fit_to_structure(sn)
         new = np.zeros(et.voigt.shape)
         for idx in indices:
@@ -354,7 +354,7 @@ class TensorTest(PymatgenTest):
         sn = self.get_structure("Sn")
         indices = [(0, 0), (0, 1), (3, 3)]
         values = [259.31, 160.71, 73.48]
-        et = Tensor.from_values_indices(values, indices, structure=sn, 
+        et = Tensor.from_values_indices(values, indices, structure=sn,
                                         populate=True).voigt.round(4)
         self.assertAlmostEqual(et[1, 1], 259.31)
         self.assertAlmostEqual(et[2, 2], 259.31)
@@ -405,7 +405,7 @@ class TensorCollectionTest(PymatgenTest):
         symm_op = SymmOp.from_axis_angle_and_translation([0, 0, 1], 30,
                                                          False, [0, 0, 1])
         self.list_based_function_check("transform", self.seq_tc, symm_op=symm_op)
-        
+
         # symmetrized
         self.list_based_function_check("symmetrized", self.seq_tc)
 
@@ -422,7 +422,7 @@ class TensorCollectionTest(PymatgenTest):
         # fit_to_structure
         self.list_based_function_check("fit_to_structure", self.diff_rank, self.struct)
         self.list_based_function_check("fit_to_structure", self.seq_tc, self.struct)
-        
+
         # fit_to_structure
         self.list_based_function_check("fit_to_structure", self.diff_rank, self.struct)
         self.list_based_function_check("fit_to_structure", self.seq_tc, self.struct)
@@ -469,7 +469,7 @@ class SquareTensorTest(PymatgenTest):
         self.rotation = SquareTensor([[math.cos(a), 0, math.sin(a)],
                                       [0, 1, 0],
                                       [-math.sin(a), 0, math.cos(a)]])
-        
+
     def test_new(self):
         non_sq_matrix = [[0.1, 0.2, 0.1],
                          [0.1, 0.2, 0.3],
@@ -485,7 +485,7 @@ class SquareTensorTest(PymatgenTest):
 
     def test_properties(self):
         # transpose
-        self.assertArrayEqual(self.non_symm.trans, 
+        self.assertArrayEqual(self.non_symm.trans,
                               SquareTensor([[0.1, 0.4, 0.2],
                                             [0.2, 0.5, 0.5],
                                             [0.3, 0.6, 0.5]]))

--- a/pymatgen/analysis/elasticity/tests/test_tensors.py
+++ b/pymatgen/analysis/elasticity/tests/test_tensors.py
@@ -534,6 +534,15 @@ class SquareTensorTest(PymatgenTest):
         self.assertTrue(self.low_val_2.is_rotation())
         self.assertFalse(self.low_val_2.is_rotation(tol=1e-8))
 
+    def test_refine_rotation(self):
+        self.assertArrayAlmostEqual(self.rotation, self.rotation.refine_rotation())
+        new = np.copy(self.rotation)
+        new[3, 3] += 0.02
+        self.assertFalse(new.is_rotation())
+        self.assertArrayAlmostEqual(self.rotation, new.refine_rotation())
+        new[2, 3] += 0.05
+        self.assertArrayAlmostEqual(self.rotation, new.refine_rotation())
+
     def test_get_scaled(self):
         self.assertArrayEqual(self.non_symm.get_scaled(10.),
                               SquareTensor([[1, 2, 3], [4, 5, 6], [2, 5, 5]]))


### PR DESCRIPTION
## Summary
Additional functionality to Tensor class to allow for transformations corresponding to changes in structure basis.

* adds a method to the Tensor class that allows one to transform from the implicit basis of one structure to that of a second structure.
* added a method to refine rotation matrices generated for ieee standards, in cases the lattice vectors used to generate new bases are slightly non-orthogonal.  This ensures, for example, that invariants won't change upon applying the tensor transformation.
* Tests for both methods