### PR TITLE
NearNeighbors + StructureGraphs: some bug fixes, convenience methods + tests

### DIFF
--- a/pymatgen/analysis/graphs.py
+++ b/pymatgen/analysis/graphs.py
@@ -9,7 +9,6 @@ import subprocess
 import numpy as np
 import os.path
 
-from pymatgen.analysis.local_env import LocalStructOrderParams
 from pymatgen.core import Structure, Lattice, PeriodicSite, Molecule
 from pymatgen.util.coord import lattice_points_in_supercell
 from pymatgen.vis.structure_vtk import EL_COLORS
@@ -40,17 +39,19 @@ __email__ = "mkhorton@lbl.gov"
 __status__ = "Beta"
 __date__ = "August 2017"
 
-ConnectedSite = namedtuple('ConnectedSite', 'periodic_site, jimage, index, weight, dist')
+ConnectedSite = namedtuple('ConnectedSite', 'site, jimage, index, weight, dist')
 
-cn_opt_params = {}
-with open(os.path.join(os.path.dirname(
-        __file__), 'cn_opt_params.yaml'), 'r') as f:
-    cn_opt_params = yaml.safe_load(f)
-    f.close()
 
+# TODO: split into separate class for Molecules
 class StructureGraph(MSONable):
+    """
+    This is a class for annotating a Structure (or Molecule) with
+    bond information, stored in the form of a graph. A "bond" does
+    not necessarily have to be a chemical bond, but can store any
+    kind of information that connects two Sites.
+    """
 
-    def __init__(self, structure, graph_data):
+    def __init__(self, structure_or_molecule, graph_data=None):
         """
         If constructing this class manually, use the `with_empty_graph`
         method or `with_local_env_strategy` method (using an algorithm
@@ -71,12 +72,21 @@ class StructureGraph(MSONable):
         For periodic graphs, class stores information on the graph
         edges of what lattice image the edge belongs to.
 
-        :param *args: same as in :class: `pymatgen.core.Structure`
+        :param structure_or_molecule: a Structure object or a
+        Molecule object (molecules are supported, but some
+        methods are for structures only, such as __mul__, in
+        future this may be broken into two separate classes)
+
         :param graph_data: dict containing graph information in
-        dict format, not intended to be constructed manually
+        dict format (not intended to be constructed manually,
+        see as_dict method for format)
         """
 
-        self.structure = structure
+        if isinstance(structure_or_molecule, StructureGraph):
+            # just make a copy from input
+            graph_data = structure_or_molecule.as_dict()['graphs']
+
+        self.structure = structure_or_molecule
         self.graph = nx.readwrite.json_graph.adjacency_graph(graph_data)
 
         # tidy up edge attr dicts, reading to/from json duplicates
@@ -95,15 +105,15 @@ class StructureGraph(MSONable):
                 d['from_jimage'] = tuple(d['from_jimage'])
 
     @classmethod
-    def with_empty_graph(cls, structure, name="bonds",
-                        edge_weight_name=None,
+    def with_empty_graph(cls, structure_or_molecule, name="bonds",
+                         edge_weight_name=None,
                          edge_weight_units=None):
         """
         Constructor for StructureGraph, returns a StructureGraph
         object with an empty graph (no edges, only nodes defined
         that correspond to Sites in Structure).
 
-        :param structure (Structure):
+        :param structure_or_molecule (Structure):
         :param name (str): name of graph, e.g. "bonds"
         :param edge_weight_name (str): name of edge weights,
         e.g. "bond_length" or "exchange_constant"
@@ -124,34 +134,54 @@ class StructureGraph(MSONable):
         graph = nx.MultiDiGraph(edge_weight_name=edge_weight_name,
                                 edge_weight_units=edge_weight_units,
                                 name=name)
-        graph.add_nodes_from(range(len(structure)))
+        graph.add_nodes_from(range(len(structure_or_molecule)))
 
         graph_data = json_graph.adjacency_data(graph)
 
-        return cls(structure, graph_data=graph_data)
+        return cls(structure_or_molecule, graph_data=graph_data)
 
     @staticmethod
-    def with_local_env_strategy(structure, strategy, decorate=True):
+    def with_local_env_strategy(structure_or_molecule, strategy):
         """
         Constructor for StructureGraph, using a strategy
-        from  :Class: `pymatgen.analysis.local_env`.
+        from :Class: `pymatgen.analysis.local_env`.
 
-        :param structure: Structure object
+        Molecules will be put into a large artificial box for calculation
+        of bonds using a NearNeighbor strategy, since some strategies
+        assume periodic boundary conditions.
+
+        :param structure_or_molecule: Structure object
         :param strategy: an instance of a
-         :Class: `pymatgen.analysis.local_env.NearNeighbors`
-         object
-        :param decorate: flag to indicate whether or not to decorate
-         all sites with coordination environment information.
+            :Class: `pymatgen.analysis.local_env.NearNeighbors` object
         :return:
         """
 
-        sg = StructureGraph.with_empty_graph(structure, name="bonds",
+        is_molecule = isinstance(structure_or_molecule, Molecule)
+
+        sg = StructureGraph.with_empty_graph(structure_or_molecule, name="bonds",
                                              edge_weight_name="weight",
                                              edge_weight_units="")
 
-        for n in range(len(structure)):
-            neighbors = strategy.get_nn_info(structure, n)
+        if is_molecule:
+            # NearNeighbor classes only (generally) work with structures
+            # molecules have to be boxed first
+            coords = structure_or_molecule.cart_coords
+
+            a = max(coords[:, 0]) - min(coords[:, 0]) + 100
+            b = max(coords[:, 1]) - min(coords[:, 1]) + 100
+            c = max(coords[:, 2]) - min(coords[:, 2]) + 100
+
+            structure_or_molecule = structure_or_molecule.get_boxed_structure(a, b, c,
+                                                                              no_cross=True)
+
+        for n in range(len(structure_or_molecule)):
+            neighbors = strategy.get_nn_info(structure_or_molecule, n)
             for neighbor in neighbors:
+
+                # all bonds in molecules should not cross
+                # (artificial) periodic boundaries
+                if is_molecule and not np.array_equal(neighbor['image'], [0, 0, 0]):
+                    continue
 
                 # local_env will always try to add two edges
                 # for any one bond, one from site u to site v
@@ -163,8 +193,6 @@ class StructureGraph(MSONable):
                             to_jimage=neighbor['image'],
                             weight=neighbor['weight'],
                             warn_duplicates=False)
-        if decorate:
-            sg.decorate_structure_with_ce_info()
 
         return sg
 
@@ -191,7 +219,8 @@ class StructureGraph(MSONable):
 
     def add_edge(self, from_index, to_index,
                  from_jimage=(0, 0, 0), to_jimage=None,
-                 weight=None, warn_duplicates=True):
+                 weight=None, warn_duplicates=True,
+                 edge_properties=None):
         """
         Add edge to graph.
 
@@ -211,6 +240,8 @@ class StructureGraph(MSONable):
         :param warn_duplicates (bool): if True, will warn if
         trying to add duplicate edges (duplicate edges will not
         be added in either case)
+        :param edge_properties (dict): any other information to
+        store on graph edges, similar to Structure's site_properties
         :return:
         """
 
@@ -232,18 +263,20 @@ class StructureGraph(MSONable):
         # automatic detection of to_jimage if user doesn't specify
         # will try and detect all equivalent images and add multiple
         # edges if appropriate
-        if to_jimage is None:
+        if to_jimage is None and not isinstance(self.structure, Molecule):
             # assume we want the closest site
             warnings.warn("Please specify to_jimage to be unambiguous, "
                           "trying to automatically detect.")
-            dist, to_jimage = self.structure[from_index].distance_and_image(self.structure[to_index])
+            dist, to_jimage = self.structure[from_index]\
+                .distance_and_image(self.structure[to_index])
             if dist == 0:
                 # this will happen when from_index == to_index,
                 # typically in primitive single-atom lattices
                 images = [1, 0, 0], [0, 1, 0], [0, 0, 1]
                 dists = []
                 for image in images:
-                    dists.append(self.structure[from_index].distance_and_image(self.structure[from_index],
+                    dists.append(self.structure[from_index]
+                                 .distance_and_image(self.structure[from_index],
                                                                                jimage=image)[0])
                 dist = min(dists)
             equiv_sites = self.structure.get_neighbors_in_shell(self.structure[from_index].coords,
@@ -257,7 +290,9 @@ class StructureGraph(MSONable):
                               to_jimage=to_jimage, to_index=to_index)
             return
 
-        from_jimage, to_jimage = tuple(from_jimage), tuple(to_jimage)
+        # sanitize types
+        from_jimage, to_jimage = tuple(map(int, from_jimage)), tuple(map(int, to_jimage))
+        from_index, to_index = int(from_index), int(to_index)
 
         # check we're not trying to add a duplicate edge
         # there should only ever be at most one edge
@@ -274,13 +309,19 @@ class StructureGraph(MSONable):
                                                                          to_jimage))
                     return
 
+        # generic container for additional edge properties,
+        # similar to site properties
+        edge_properties = edge_properties or {}
+
         if weight:
             self.graph.add_edge(from_index, to_index,
                                 to_jimage=to_jimage,
-                                weight=weight)
+                                weight=weight,
+                                **edge_properties)
         else:
             self.graph.add_edge(from_index, to_index,
-                                to_jimage=to_jimage)
+                                to_jimage=to_jimage,
+                                **edge_properties)
 
     def get_connected_sites(self, n, jimage=(0, 0, 0)):
         """
@@ -302,24 +343,33 @@ class StructureGraph(MSONable):
 
         for u, v, d, dir in out_edges + in_edges:
 
-            to_jimage = d['to_jimage']
+            if not isinstance(self.structure, Molecule):
 
-            if dir == 'in':
-                u, v = v, u
-                to_jimage = np.multiply(-1, to_jimage)
+                to_jimage = d['to_jimage']
 
-            site_d = self.structure[v].as_dict()
-            site_d['abc'] = np.add(site_d['abc'], to_jimage).tolist()
-            to_jimage = tuple(map(int, np.add(to_jimage, jimage)))
-            periodic_site = PeriodicSite.from_dict(site_d)
+                if dir == 'in':
+                    u, v = v, u
+                    to_jimage = np.multiply(-1, to_jimage)
+
+                site_d = self.structure[v].as_dict()
+                site_d['abc'] = np.add(site_d['abc'], to_jimage).tolist()
+                to_jimage = tuple(map(int, np.add(to_jimage, jimage)))
+                site = PeriodicSite.from_dict(site_d)
+
+                # from_site if jimage arg != (0, 0, 0)
+                relative_jimage = np.subtract(to_jimage, jimage)
+                dist = self.structure[u].distance(self.structure[v], jimage=relative_jimage)
+
+            else:
+
+                # simpler case for molecules
+                site = self.structure[v]
+                dist = self.structure[u].distance(self.structure[v])
+                to_jimage = (0, 0, 0)
 
             weight = d.get('weight', None)
 
-            # from_site if jimage arg != (0, 0, 0)
-            relative_jimage = np.subtract(to_jimage, jimage)
-            dist = self.structure[u].distance(self.structure[v], jimage=relative_jimage)
-
-            connected_site = ConnectedSite(periodic_site=periodic_site,
+            connected_site = ConnectedSite(site=site,
                                            jimage=to_jimage,
                                            index=v,
                                            weight=weight,
@@ -343,57 +393,6 @@ class StructureGraph(MSONable):
         """
         number_of_self_loops = sum([1 for n, v in self.graph.edges(n) if n == v])
         return self.graph.degree(n) - number_of_self_loops
-
-    def get_local_order_parameters(self, n):
-        """
-        Calculate those local structure order parameters for 
-        the given site whose ideal CN corresponds to the
-        underlying motif (e.g., CN=4, then calculate the
-        square planar, tetrahedral, see-saw-like,
-        rectangular see-saw-like order paramters).
-
-        Args:
-            n (integer): site index.
-
-        Returns:
-            A dict of order parameters (values) and the
-            underlying motif type (keys; for example, tetrahedral).
-
-        """
-        cn = self.get_coordination_of_site(n)
-        if cn in [int(k_cn) for k_cn in cn_opt_params.keys()]:
-            names = [k for k in cn_opt_params[cn].keys()]
-            types = []
-            params = []
-            for name in names:
-                types.append(cn_opt_params[cn][name][0])
-                tmp = cn_opt_params[cn][name][1] \
-                    if len(cn_opt_params[cn][name]) > 1 else None
-                params.append(tmp)
-            lostops = LocalStructOrderParams(types, parameters=params)
-            sites = [self.structure[n]]
-            for s in self.get_connected_sites(n):
-                sites.append(s.periodic_site)
-            lostop_vals = lostops.get_order_parameters(
-                    sites, 0, indices_neighs=[i for i in range(1, cn+1)])
-            d = {}
-            for i, lostop in enumerate(lostop_vals):
-                d[names[i]] = lostop
-            return d
-        else:
-            return None
-
-    def decorate_structure_with_ce_info(self):
-        """
-        Decorate all sites in the underlying structure
-        with site properties that provides information on the
-        coordination number and coordination pattern based
-        on the (current) structure of this graph.
-        """
-        l = []
-        for i in range(len(self.structure.sites)):
-            l.append(self.get_local_order_parameters(i))
-        self.structure.add_site_property('ce_info', l)
 
     def draw_graph_to_file(self, filename="graph",
                            diff=None,
@@ -620,6 +619,11 @@ class StructureGraph(MSONable):
         # which new lattice images present, but should hopefully be
         # easier to extend to a general 3x3 scaling matrix.
 
+        if isinstance(self.structure, Molecule):
+            raise ValueError("Multiplying graphs is only-welled defined for "
+                             "structures not molecules or other objects without "
+                             "a well-defined periodic lattice.")
+
         # code adapted from Structure.__mul__
         scale_matrix = np.array(scaling_matrix, np.int16)
         if scale_matrix.shape != (3, 3):
@@ -702,7 +706,7 @@ class StructureGraph(MSONable):
                 v_rel = np.subtract(v_image_cart, u_cart)
 
                 # now retrieve position of node v in
-                # new supercell, and get absolute Cartesian
+                # new supercell, and get asgolute Cartesian
                 # co-ordinates of where atoms defined by edge
                 # are expected to be
                 v_expec = new_structure[u].coords + v_rel
@@ -823,7 +827,7 @@ class StructureGraph(MSONable):
 
         if print_weights:
             for u, v, data in edges:
-                s += "{:4}  {:4}  {:12}  {:.12E}\n".format(u, v, str(data.get("to_jimage", (0, 0, 0))),
+                s += "{:4}  {:4}  {:12}  {:.3e}\n".format(u, v, str(data.get("to_jimage", (0, 0, 0))),
                                                            data.get("weight", 0))
         else:
             for u, v, data in edges:
@@ -876,7 +880,7 @@ class StructureGraph(MSONable):
             if v < u:
                 new_v, new_u, new_d = u, v, d.copy()
                 new_d['to_jimage'] = tuple(np.multiply(-1, d['to_jimage']).astype(int))
-                edges_to_remove.append((u,v,k))
+                edges_to_remove.append((u, v, k))
                 edges_to_add.append((new_u, new_v, new_d))
 
         # add/delete marked edges

--- a/pymatgen/analysis/tests/test_graphs.py
+++ b/pymatgen/analysis/tests/test_graphs.py
@@ -24,6 +24,7 @@ __email__ = "mkhorton@lbl.gov"
 __status__ = "Beta"
 __date__ = "August 2017"
 
+
 class StructureGraphTest(unittest.TestCase):
 
     def setUp(self):
@@ -89,7 +90,6 @@ class StructureGraphTest(unittest.TestCase):
     def tearDown(self):
         warnings.resetwarnings()
 
-
     def test_properties(self):
 
         self.assertEqual(self.mos2_sg.name, "bonds")
@@ -97,8 +97,8 @@ class StructureGraphTest(unittest.TestCase):
         self.assertEqual(self.mos2_sg.edge_weight_unit, "Å")
         self.assertEqual(self.mos2_sg.get_coordination_of_site(0), 6)
         self.assertEqual(len(self.mos2_sg.get_connected_sites(0)), 6)
-        self.assertTrue(isinstance(self.mos2_sg.get_connected_sites(0)[0].periodic_site, PeriodicSite))
-        self.assertEqual(str(self.mos2_sg.get_connected_sites(0)[0].periodic_site.specie), 'S')
+        self.assertTrue(isinstance(self.mos2_sg.get_connected_sites(0)[0].site, PeriodicSite))
+        self.assertEqual(str(self.mos2_sg.get_connected_sites(0)[0].site.specie), 'S')
 
         # these two graphs should be equivalent
         for n in range(len(self.bc_square_sg)):
@@ -154,12 +154,12 @@ Sites (3)
 Graph: bonds
 from    to  to_image      bond_length (A)
 ----  ----  ------------  ------------------
-   0     1  (-1, 0, 0)    2.416930006299E+00
-   0     1  (0, 0, 0)     2.416930006299E+00
-   0     1  (0, 1, 0)     2.416930006299E+00
-   0     2  (0, 1, 0)     2.416941297830E+00
-   0     2  (-1, 0, 0)    2.416941297830E+00
-   0     2  (0, 0, 0)     2.416941297830E+00
+   0     1  (-1, 0, 0)    2.417e+00
+   0     1  (0, 0, 0)     2.417e+00
+   0     1  (0, 1, 0)     2.417e+00
+   0     2  (0, 1, 0)     2.417e+00
+   0     2  (-1, 0, 0)    2.417e+00
+   0     2  (0, 0, 0)     2.417e+00
 """
 
         # don't care about testing Py 2.7 unicode support,
@@ -215,45 +215,25 @@ from    to  to_image
         for idx in mos2_sg_mul.structure.indices_from_symbol("Mo"):
             self.assertEqual(mos2_sg_mul.get_coordination_of_site(idx), 6)
 
-        mos2_sg_premul = StructureGraph.with_local_env_strategy(self.structure*(3, 3, 1), MinimumDistanceNN(), decorate=False)
+        mos2_sg_premul = StructureGraph.with_local_env_strategy(self.structure*(3, 3, 1),
+                                                                MinimumDistanceNN())
         self.assertTrue(mos2_sg_mul == mos2_sg_premul)
 
         # test 3D Structure
 
-        nio_sg = StructureGraph.with_local_env_strategy(self.NiO, MinimumDistanceNN(), decorate=False)
+        nio_sg = StructureGraph.with_local_env_strategy(self.NiO, MinimumDistanceNN())
         nio_sg = nio_sg*3
 
         for n in range(len(nio_sg)):
             self.assertEqual(nio_sg.get_coordination_of_site(n), 6)
-            ops = nio_sg.get_local_order_parameters(n)
 
-        # BCC
-        bcc_sg = StructureGraph.with_local_env_strategy(
-                self.bcc, MinimumDistanceNN(), decorate=False)
-        bcc_sg_dec = StructureGraph.with_local_env_strategy(
-                self.bcc, MinimumDistanceNN())
-        for n in range(len(bcc_sg)):
-            self.assertEqual(bcc_sg.get_coordination_of_site(n), 8)
-            self.assertEqual(bcc_sg.get_coordination_of_site(n), \
-                             bcc_sg_dec.get_coordination_of_site(n))
-            ops = bcc_sg.get_local_order_parameters(n)
-            self.assertTrue(any(t in list(ops.keys()) for t in (
-                    'body-centered cubic', 'hexagonal bipyramidal')))
-            sprops = bcc_sg_dec.structure.sites[n].properties['ce_info']
-            self.assertTrue(any(t in list(sprops) \
-                    for t in ('body-centered cubic', 'hexagonal bipyramidal')))
-            self.assertAlmostEqual(ops['body-centered cubic'], 1)
-            self.assertAlmostEqual(sprops['body-centered cubic'], 1)
-            self.assertAlmostEqual(ops['hexagonal bipyramidal'], \
-                    0.43331263572418355)
-            self.assertAlmostEqual(sprops['hexagonal bipyramidal'], \
-                    0.43331263572418355)
 
     @unittest.skipIf(not (which('neato') and which('fdp')), "graphviz executables not present")
     def test_draw(self):
 
         # draw MoS2 graph
-        self.mos2_sg.draw_graph_to_file('MoS2_single.pdf', image_labels=True, hide_image_edges=False)
+        self.mos2_sg.draw_graph_to_file('MoS2_single.pdf', image_labels=True,
+                                        hide_image_edges=False)
         mos2_sg = self.mos2_sg * (9, 9, 1)
         mos2_sg.draw_graph_to_file('MoS2.pdf', algo='neato')
 
@@ -263,13 +243,15 @@ from    to  to_image
         mos2_sg_2.draw_graph_to_file('MoS2_twice_mul.pdf', algo='neato', hide_image_edges=True)
 
         # draw MoS2 graph that's generated from a pre-multiplied Structure
-        mos2_sg_premul = StructureGraph.with_local_env_strategy(self.structure*(3, 3, 1), MinimumDistanceNN(), decorate=False)
+        mos2_sg_premul = StructureGraph.with_local_env_strategy(self.structure*(3, 3, 1),
+                                                                MinimumDistanceNN())
         mos2_sg_premul.draw_graph_to_file('MoS2_premul.pdf', algo='neato', hide_image_edges=True)
 
         # draw graph for a square lattice
         self.square_sg.draw_graph_to_file('square_single.pdf', hide_image_edges=False)
         square_sg = self.square_sg * (5, 5, 1)
-        square_sg.draw_graph_to_file('square.pdf', algo='neato', image_labels=True, node_labels=False)
+        square_sg.draw_graph_to_file('square.pdf', algo='neato', image_labels=True,
+                                     node_labels=False)
 
         # draw graph for a body-centered square lattice
         self.bc_square_sg.draw_graph_to_file('bc_square_single.pdf', hide_image_edges=False)
@@ -281,6 +263,13 @@ from    to  to_image
         bc_square_sg_r = self.bc_square_sg_r * (9, 9, 1)
         bc_square_sg_r.draw_graph_to_file('bc_square_r.pdf', algo='neato', image_labels=False)
 
+        # delete generated test files
+        test_files = ('bc_square_r_single.pdf', 'bc_square_r.pdf', 'bc_square_single.pdf',
+                      'bc_square.pdf', 'MoS2_premul.pdf', 'MOS2_single.pdf', 'MoS2_twice_mul.pdf',
+                      'MoS2.pdf', 'square_single.pdf', 'square.pdf')
+        for test_file in test_files:
+            os.remove(test_file)
+
     def test_to_from_dict(self):
         d = self.mos2_sg.as_dict()
         sg = StructureGraph.from_dict(d)
@@ -289,12 +278,12 @@ from    to  to_image
 
     def test_from_local_env_and_equality_and_diff(self):
         nn = MinimumDistanceNN()
-        sg = StructureGraph.with_local_env_strategy(self.structure, nn, decorate=False)
+        sg = StructureGraph.with_local_env_strategy(self.structure, nn)
         
         self.assertEqual(sg.graph.number_of_edges(), 6)
 
         nn2 = MinimumOKeeffeNN()
-        sg2 = StructureGraph.with_local_env_strategy(self.structure, nn2, decorate=False)
+        sg2 = StructureGraph.with_local_env_strategy(self.structure, nn2)
 
         self.assertTrue(sg == sg2)
         self.assertTrue(sg == self.mos2_sg)
@@ -313,7 +302,7 @@ from    to  to_image
         s = Structure.from_file(structure_file)
 
         nn = MinimumOKeeffeNN()
-        sg = StructureGraph.with_local_env_strategy(s, nn, decorate=False)
+        sg = StructureGraph.with_local_env_strategy(s, nn)
 
         molecules = sg.get_subgraphs_as_molecules()
 
@@ -322,6 +311,16 @@ from    to  to_image
 
         molecules = self.mos2_sg.get_subgraphs_as_molecules()
         self.assertEqual(len(molecules), 0)
+
+    def test_from_molecule(self):
+
+        molecule = Molecule(['C', 'C'], [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
+
+        sg = StructureGraph.with_empty_graph(molecule)
+        self.assertEqual(sg.get_coordination_of_site(0), 0)
+
+        sg = StructureGraph.with_local_env_strategy(molecule, MinimumDistanceNN())
+        self.assertEqual(sg.get_coordination_of_site(0), 1)
 
 
 if __name__ == "__main__":

--- a/pymatgen/command_line/critic2_caller.py
+++ b/pymatgen/command_line/critic2_caller.py
@@ -399,8 +399,10 @@ class Critic2Output(MSONable):
                 from_lvec = edge['from_lvec']
                 to_lvec = edge['to_lvec']
 
+                relative_lvec = np.subtract(to_lvec, from_lvec)
+
                 if edge_weight == "bond_length":
-                    weight = self.structure.get_distance(from_idx, to_idx)
+                    weight = self.structure.get_distance(from_idx, to_idx, jimage=relative_lvec)
                 else:
                     weight = getattr(self.critical_points[unique_idx],
                                      edge_weight, None)

--- a/pymatgen/command_line/tests/test_critic2_caller.py
+++ b/pymatgen/command_line/tests/test_critic2_caller.py
@@ -5,7 +5,6 @@
 from __future__ import division, unicode_literals
 import unittest
 
-from pymatgen import Structure
 from pymatgen.command_line.critic2_caller import *
 from monty.os.path import which
 


### PR DESCRIPTION
## Summary

Fixed a few minor bugs in pymatgen.analysis.graphs, now supports molecules too (including via NearNeighbor class; will box them first).

Added `get_local_order_parameters` and `get_bonded_structure` convenience methods to NearNeighbor base class. The former is adapted from Nils' code, moved here from analysis.graphs to avoid a circular import.

Added two new NearNeighbor classes:

* Critic2NN -- this uses sum of atomic charge densities (to calculate bonds from Chgcars, you still need to use Critic2Caller directly)

* CutoffDictNN -- a very basic NN I've found useful for testing

## Additional dependencies introduced (if any)

* None

## TODO (if any)

* None