### PR TITLE
scrubbed units

### DIFF
--- a/pymatgen/analysis/elasticity/elastic.py
+++ b/pymatgen/analysis/elasticity/elastic.py
@@ -240,7 +240,7 @@ class ElasticTensor(NthOrderElasticTensor):
         nsites = structure.num_sites
         volume = structure.volume
         natoms = structure.composition.num_atoms
-        weight = structure.composition.weight
+        weight = float(structure.composition.weight)
         mass_density = 1.6605e3 * nsites * weight / (natoms * volume)
         if self.g_vrh < 0:
             raise ValueError("k_vrh or g_vrh is negative, "
@@ -262,7 +262,7 @@ class ElasticTensor(NthOrderElasticTensor):
         nsites = structure.num_sites
         volume = structure.volume
         natoms = structure.composition.num_atoms
-        weight = structure.composition.weight
+        weight = float(structure.composition.weight)
         mass_density = 1.6605e3 * nsites * weight / (natoms * volume)
         if self.g_vrh < 0:
             raise ValueError("k_vrh or g_vrh is negative, "
@@ -336,7 +336,7 @@ class ElasticTensor(NthOrderElasticTensor):
         volume = structure.volume
         tot_mass = sum([e.atomic_mass for e in structure.species])
         natoms = structure.composition.num_atoms
-        weight = structure.composition.weight
+        weight = float(structure.composition.weight)
         avg_mass = 1.6605e-27 * tot_mass / natoms
         mass_density = 1.6605e3 * nsites * weight / (natoms * volume)
         return 0.87 * 1.3806e-23 * avg_mass**(-2./3.) \
@@ -680,7 +680,7 @@ class ElasticTensorExpansion(TensorCollection):
         """
         l0 = np.dot(np.sum(structure.lattice.matrix, axis=0), n)
         l0 *= 1e-10 # in A
-        weight = structure.composition.weight * 1.66054e-27 # in kg
+        weight = float(structure.composition.weight) * 1.66054e-27 # in kg
         vol = structure.volume * 1e-30 # in m^3
         vel = (1e9 * self[0].einsum_sequence([n, u, n, u])
                / (weight / vol)) ** 0.5

--- a/pymatgen/analysis/elasticity/tests/test_elastic.py
+++ b/pymatgen/analysis/elasticity/tests/test_elastic.py
@@ -8,6 +8,7 @@ from pymatgen.analysis.elasticity.elastic import *
 from pymatgen.analysis.elasticity.strain import Strain, Deformation
 from pymatgen.analysis.elasticity.stress import Stress
 from pymatgen.util.testing import PymatgenTest
+from pymatgen.core.units import FloatWithUnit
 from pymatgen import Structure, Lattice
 from scipy.misc import central_diff_weights
 import warnings
@@ -143,6 +144,8 @@ class ElasticTensorTest(PymatgenTest):
         # structure-property dict
         sprop_dict = self.elastic_tensor_1.get_structure_property_dict(self.structure)
         self.assertAlmostEqual(sprop_dict["long_v"], 3534.68123832)
+        for val in sprop_dict.values():
+            self.assertFalse(isinstance(val, FloatWithUnit))
         for k, v in sprop_dict.items():
             if k=="structure":
                 self.assertEqual(v, self.structure)


### PR DESCRIPTION
## Summary

Some of the methods in the elastic tensor classes get (incorrectly) unitized, which can lead to problems in postprocessing.  In the long term, I think the elastic tensor classes should be refactored to better support units, but in the short term I think it's probably best to scrub the quantities which have units until a more holistic approach can be implemented.  This PR does that and adds a few tests to ensure no unitized floats are returned by the relevant methods.