### PR TITLE
fix DeformStructureTransformation serialization

### DIFF
--- a/pymatgen/transformations/standard_transformations.py
+++ b/pymatgen/transformations/standard_transformations.py
@@ -654,22 +654,23 @@ class DeformStructureTransformation(AbstractTransformation):
         deformation (array): deformation gradient for the transformation
     """
 
-    def __init__(self, deformation):
-        self.deformation = Deformation(deformation)
+    def __init__(self, deformation=((1, 0, 0), (0, 1, 0), (0, 0, 1))):
+        self._deform = Deformation(deformation)
+        self.deformation = self._deform.tolist()
 
     def apply_transformation(self, structure):
-        return self.deformation.apply_to_structure(structure)
+        return self._deform.apply_to_structure(structure)
 
     def __str__(self):
         return "DeformStructureTransformation : " + \
-            "Deformation = {}".format(str(self.deformation.tolist()))
+            "Deformation = {}".format(str(self.deformation))
 
     def __repr__(self):
         return self.__str__()
 
     @property
     def inverse(self):
-        return DeformStructureTransformation(self.deformation.inv())
+        return DeformStructureTransformation(self._deform.inv())
 
     @property
     def is_one_to_many(self):

--- a/pymatgen/transformations/tests/test_standard_transformations.py
+++ b/pymatgen/transformations/tests/test_standard_transformations.py
@@ -444,7 +444,7 @@ class DeformStructureTransformationTest(unittest.TestCase):
         self.assertAlmostEqual(transformed_s.lattice.b, 3.84379750)
         self.assertAlmostEqual(transformed_s.lattice.c, 3.75022981)
 
-        d = t.as_dict()
+        d = json.loads(json.dumps(t.as_dict()))
         self.assertEqual(type(DeformStructureTransformation.from_dict(d)),
                          DeformStructureTransformation)
 


### PR DESCRIPTION
## Summary

Fixed serialization issue as `Deformation` is not `MSONable`, with a proper test.

## Additional dependencies introduced (if any)

None

## TODO (if any)

None