### PR TITLE
Add in some additional Parsing logic for DFPT into Outcar

### DIFF
--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -2571,12 +2571,16 @@ class Outcar(MSONable):
              "electrostatic_potential": self.electrostatic_potential}
 
         if self.lepsilon:
-            d.update({'piezo_tensor': self.piezo_tensor,
-                      'piezo_ionic_tensor': self.piezo_ionic_tensor,
-                      'dielectric_tensor': self.dielectric_tensor,
-                      'dielectric_ionic_tensor': self.dielectric_ionic_tensor,
-                      'born_ion': self.born_ion,
-                      'born': self.born})
+            d.update({"piezo_tensor": self.piezo_tensor,
+                      "dielectric_tensor": self.dielectric_tensor,
+                      "born": self.born})
+
+        if self.dfpt:
+            d.update({"internal_strain_tensor": self.interna_strain_tensor})
+
+        if self.dfpt and self.lepsilon:
+            d.update({"piezo_ionic_tensor": self.piezo_ionic_tensor,
+                      "dielectric_ionic_tensor": self.dielectric_ionic_tensor})
 
         if self.lcalcpol:
             d.update({'p_elec': self.p_elec,

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -2146,7 +2146,7 @@ class Outcar(MSONable):
     def read_internal_strain_tensor(self):
         """
         Reads the internal strain tensor and populates self.interna_strain_tensor with an array of voigt notation
-            tensors for each site. 
+            tensors for each site.
         """
         search = []
 

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -1596,6 +1596,12 @@ class Outcar(MSONable):
         if self.data.get('noncollinear', []):
             self.noncollinear = False
 
+        # Check if the calculation type is DFPT
+        self.dfpt = False
+        self.read_pattern({'ibrion': "IBRION =\s+([\-\d]+)"}, terminate_on_match=True,
+                          postprocess=int)
+        if self.data.get("ibrion", [[0]])[0][0] > 6:
+            self.dfpt = True
         # Check to see if LEPSILON is true and read piezo data if so
         self.lepsilon = False
         self.read_pattern({'epsilon': 'LEPSILON=     T'})

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -1610,7 +1610,10 @@ class Outcar(MSONable):
         if self.data.get('epsilon', []):
             self.lepsilon = True
             self.read_lepsilon()
-            self.read_lepsilon_ionic()
+            # only read ionic contribution if DFPT is turned on
+            if self.dfpt:
+                self.read_lepsilon_ionic()
+
 
         # Check to see if LCALCPOL is true and read polarization data if so
         self.lcalcpol = False

--- a/pymatgen/io/vasp/tests/test_outputs.py
+++ b/pymatgen/io/vasp/tests/test_outputs.py
@@ -548,6 +548,12 @@ class OutcarTest(PymatgenTest):
             self.assertAlmostEqual(outcar.piezo_ionic_tensor[2][5], 0.06242)
             self.assertAlmostEqual(outcar.born[0][1][2], -0.385)
             self.assertAlmostEqual(outcar.born[1][2][0], 0.36465)
+            self.assertAlmostEqual(outcar.internal_strain_tensor[0][0][0], -572.5437,places=4)
+            self.assertAlmostEqual(outcar.internal_strain_tensor[0][1][0], 683.2985,places=4)
+            self.assertAlmostEqual(outcar.internal_strain_tensor[0][1][3], 73.07059,places=4)
+            self.assertAlmostEqual(outcar.internal_strain_tensor[1][0][0], 570.98927,places=4)
+            self.assertAlmostEqual(outcar.internal_strain_tensor[1][1][0], -683.68519,places=4)
+            self.assertAlmostEqual(outcar.internal_strain_tensor[1][2][2], 570.98927,places=4)
 
         filepath = os.path.join(test_dir, 'OUTCAR.NiO_SOC.gz')
         outcar = Outcar(filepath)


### PR DESCRIPTION
## Summary

Modifying OUTCAR's parsing logic. The big change is the addition of parsing of internal strain tensors from DFPT calcs. There is some additional logic for parsing the ionic portion of the dielectric and piezoelectric tensor if DFPT is on.