### PR TITLE
Updated parameter that throws NoneType error when checking if structure is valid

### DIFF
--- a/pymatgen/core/lattice.py
+++ b/pymatgen/core/lattice.py
@@ -708,7 +708,7 @@ class Lattice(MSONable):
                     # We have to do p/q, so do lstsq(q.T, p.T).T instead.
                     p = dot(a[:, k:3].T, b[:, (k - 2):k])
                     q = np.diag(m[(k - 2):k])
-                    result = np.linalg.lstsq(q.T, p.T, rcond=None)[0].T
+                    result = np.linalg.lstsq(q.T, p.T, rcond=-1)[0].T
                     u[k:3, (k - 2):k] = result
 
         return a.T, mapping.T


### PR DESCRIPTION
## Summary

* Updated parameter that throws NoneType error when checking if structure is valid

Fixes the following error:

  File "/home/sivonxay/.conda-envs/cms/code/pymatgen/pymatgen/core/structure.py", line 299, in is_valid
    all_dists = self.distance_matrix[np.triu_indices(len(self), 1)]
  File "/home/sivonxay/.conda-envs/cms/code/pymatgen/pymatgen/core/structure.py", line 663, in distance_matrix
    self.frac_coords)
  File "/home/sivonxay/.conda-envs/cms/code/pymatgen/pymatgen/core/lattice.py", line 1057, in get_all_distances
    v, d2 = pbc_shortest_vectors(self, fcoords1, fcoords2, return_d2=True)
  File "/home/sivonxay/.conda-envs/cms/code/pymatgen/pymatgen/util/coord.py", line 213, in pbc_shortest_vectors
    return_d2)
  File "coord_cython.pyx", line 96, in pymatgen.util.coord_cython.pbc_shortest_vectors
  File "/home/sivonxay/.conda-envs/cms/code/pymatgen/pymatgen/core/lattice.py", line 721, in get_lll_frac_coords
    return np.dot(frac_coords, self.lll_inverse)
  File "/home/sivonxay/.conda-envs/cms/code/pymatgen/pymatgen/core/lattice.py", line 462, in lll_inverse
    self._lll_inverse = np.linalg.inv(self.lll_mapping)
  File "/home/sivonxay/.conda-envs/cms/code/pymatgen/pymatgen/core/lattice.py", line 454, in lll_mapping
    self._lll_matrix_mappings[0.75] = self._calculate_lll()
  File "/home/sivonxay/.conda-envs/cms/code/pymatgen/pymatgen/core/lattice.py", line 711, in _calculate_lll
    result = np.linalg.lstsq(q.T, p.T, rcond=None)[0].T
  File "/home/sivonxay/.conda-envs/cms/lib/python3.6/site-packages/numpy/linalg/linalg.py", line 1953, in lstsq
    0, work, -1, iwork, 0)
TypeError: must be real number, not NoneType

## Additional dependencies introduced (if any)

## TODO (if any)
