### PR TITLE
Add Supercell Image to Neighbor-Finding Routines

### DIFF
--- a/pymatgen/analysis/diffraction/neutron.py
+++ b/pymatgen/analysis/diffraction/neutron.py
@@ -133,7 +133,7 @@ class NDCalculator(DiffractionPatternCalculator):
         peaks = {}
         two_thetas = []
 
-        for hkl, g_hkl, ind in sorted(
+        for hkl, g_hkl, ind, img in sorted(
                 recip_pts, key=lambda i: (i[1], -i[0][0], -i[0][1], -i[0][2])):
             # Force miller indices to be integers.
             hkl = [int(round(i)) for i in hkl]

--- a/pymatgen/analysis/diffraction/neutron.py
+++ b/pymatgen/analysis/diffraction/neutron.py
@@ -133,7 +133,7 @@ class NDCalculator(DiffractionPatternCalculator):
         peaks = {}
         two_thetas = []
 
-        for hkl, g_hkl, ind, img in sorted(
+        for hkl, g_hkl, ind, _ in sorted(
                 recip_pts, key=lambda i: (i[1], -i[0][0], -i[0][1], -i[0][2])):
             # Force miller indices to be integers.
             hkl = [int(round(i)) for i in hkl]

--- a/pymatgen/analysis/diffraction/xrd.py
+++ b/pymatgen/analysis/diffraction/xrd.py
@@ -214,7 +214,7 @@ class XRDCalculator(DiffractionPatternCalculator):
         peaks = {}
         two_thetas = []
 
-        for hkl, g_hkl, ind, img in sorted(
+        for hkl, g_hkl, ind, _ in sorted(
                 recip_pts, key=lambda i: (i[1], -i[0][0], -i[0][1], -i[0][2])):
             # Force miller indices to be integers.
             hkl = [int(round(i)) for i in hkl]

--- a/pymatgen/analysis/diffraction/xrd.py
+++ b/pymatgen/analysis/diffraction/xrd.py
@@ -214,7 +214,7 @@ class XRDCalculator(DiffractionPatternCalculator):
         peaks = {}
         two_thetas = []
 
-        for hkl, g_hkl, ind in sorted(
+        for hkl, g_hkl, ind, img in sorted(
                 recip_pts, key=lambda i: (i[1], -i[0][0], -i[0][1], -i[0][2])):
             # Force miller indices to be integers.
             hkl = [int(round(i)) for i in hkl]

--- a/pymatgen/analysis/ewald.py
+++ b/pymatgen/analysis/ewald.py
@@ -284,7 +284,7 @@ class EwaldSummation(object):
         recip_nn = rcp_latt.get_points_in_sphere([[0, 0, 0]], [0, 0, 0],
                                                  self._gmax)
 
-        frac_coords = [fcoords for (fcoords, dist, i) in recip_nn if dist != 0]
+        frac_coords = [fcoords for (fcoords, dist, i, img) in recip_nn if dist != 0]
 
         gs = rcp_latt.get_cartesian_coords(frac_coords)
         g2s = np.sum(gs ** 2, 1)
@@ -338,7 +338,7 @@ class EwaldSummation(object):
         epoint = - qs ** 2 * sqrt(self._eta / pi)
 
         for i in range(numsites):
-            nfcoords, rij, js = self._s.lattice.get_points_in_sphere(fcoords,
+            nfcoords, rij, js, _ = self._s.lattice.get_points_in_sphere(fcoords,
                                     coords[i], self._rmax, zip_results=False)
 
             # remove the rii term

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -856,7 +856,7 @@ class IStructure(SiteCollection, MSONable):
         """
         site_fcoords = np.mod(self.frac_coords, 1)
         neighbors = []
-        for fcoord, dist, i, img in self._lattice.get_points_in_sphere(
+        for fcoord, dist, i, _ in self._lattice.get_points_in_sphere(
                 site_fcoords, pt, r):
             nnsite = PeriodicSite(self[i].species_and_occu,
                                   fcoord, self._lattice,

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -825,7 +825,7 @@ class IStructure(SiteCollection, MSONable):
         """
         return self[i].distance(self[j], jimage)
 
-    def get_sites_in_sphere(self, pt, r, include_index=False):
+    def get_sites_in_sphere(self, pt, r, include_index=False, include_image=False):
         """
         Find all sites within a sphere from the point. This includes sites
         in other periodic images.
@@ -847,6 +847,8 @@ class IStructure(SiteCollection, MSONable):
             r (float): Radius of sphere.
             include_index (bool): Whether the non-supercell site index
                 is included in the returned data
+            include_image (bool): Whether to include the supercell image
+                is included in the returned data
 
         Returns:
             [(site, dist) ...] since most of the time, subsequent processing
@@ -859,30 +861,38 @@ class IStructure(SiteCollection, MSONable):
             nnsite = PeriodicSite(self[i].species_and_occu,
                                   fcoord, self._lattice,
                                   properties=self[i].properties)
-            neighbors.append((nnsite, dist) if not include_index
-                             else (nnsite, dist, i))
+
+            # Get the neighbor data
+            nn_data = (nnsite, dist) if not include_index else (nnsite, dist, i)
+            if include_image:
+                nn_data += (img,)
+            neighbors.append(nn_data)
         return neighbors
 
-    def get_neighbors(self, site, r, include_index=False):
+    def get_neighbors(self, site, r, include_index=False, include_image=False):
         """
         Get all neighbors to a site within a sphere of radius r.  Excludes the
         site itself.
 
         Args:
-            site:
-                site, which is the center of the sphere.
-            r:
-                radius of sphere.
-            include_index:
-                boolean that determines whether the non-supercell site index
+            site (Site): Which is the center of the sphere.
+            r (float): Radius of sphere.
+            include_index (bool): Whether the non-supercell site index
+                is included in the returned data
+            include_image (bool): Whether to include the supercell image
                 is included in the returned data
 
         Returns:
             [(site, dist) ...] since most of the time, subsequent processing
             requires the distance.
+            If include_index == True, the tuple for each neighbor also includes
+            the index of the neighbor.
+            If include_supercell == True, the tuple for each neighbor also includes
+            the index of supercell.
         """
         nn = self.get_sites_in_sphere(site.coords, r,
-                                      include_index=include_index)
+                                      include_index=include_index,
+                                      include_image=include_image)
         return [d for d in nn if site != d[0]]
 
     def get_all_neighbors(self, r, include_index=False, include_image=False):
@@ -954,7 +964,7 @@ class IStructure(SiteCollection, MSONable):
                     neighbors[i].append(item)
         return neighbors
 
-    def get_neighbors_in_shell(self, origin, r, dr, include_index=False):
+    def get_neighbors_in_shell(self, origin, r, dr, include_index=False, include_image=False):
         """
         Returns all sites in a shell centered on origin (coords) between radii
         r-dr and r+dr.
@@ -965,6 +975,8 @@ class IStructure(SiteCollection, MSONable):
             dr (float): Width of shell.
             include_index (bool): Whether to include the non-supercell site
                 in the returned data
+            include_image (bool): Whether to include the supercell image
+                in the returned data
 
         Returns:
             [(site, dist, index) ...] since most of the time, subsequent
@@ -973,9 +985,11 @@ class IStructure(SiteCollection, MSONable):
             The index is the index of the site in the original (non-supercell)
             structure. This is needed for ewaldmatrix by keeping track of which
             sites contribute to the ewald sum.
+            Image only supplied if include_image = True
         """
         outer = self.get_sites_in_sphere(origin, r + dr,
-                                         include_index=include_index)
+                                         include_index=include_index,
+                                         include_image=include_image)
         inner = r - dr
         return [t for t in outer if t[1] > inner]
 

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -854,7 +854,7 @@ class IStructure(SiteCollection, MSONable):
         """
         site_fcoords = np.mod(self.frac_coords, 1)
         neighbors = []
-        for fcoord, dist, i in self._lattice.get_points_in_sphere(
+        for fcoord, dist, i, img in self._lattice.get_points_in_sphere(
                 site_fcoords, pt, r):
             nnsite = PeriodicSite(self[i].species_and_occu,
                                   fcoord, self._lattice,

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -856,7 +856,7 @@ class IStructure(SiteCollection, MSONable):
         """
         site_fcoords = np.mod(self.frac_coords, 1)
         neighbors = []
-        for fcoord, dist, i, _ in self._lattice.get_points_in_sphere(
+        for fcoord, dist, i, img in self._lattice.get_points_in_sphere(
                 site_fcoords, pt, r):
             nnsite = PeriodicSite(self[i].species_and_occu,
                                   fcoord, self._lattice,

--- a/pymatgen/core/tests/test_structure.py
+++ b/pymatgen/core/tests/test_structure.py
@@ -358,9 +358,9 @@ class IStructureTest(PymatgenTest):
     def test_get_all_neighbors_and_get_neighbors(self):
         s = self.struct
         nn = s.get_neighbors_in_shell(s[0].frac_coords, 2, 4,
-                                       include_index=True)
+                                      include_index=True, include_image=True)
         self.assertEqual(len(nn), 47)
-        self.assertEqual(nn[0][-1], 0)
+        self.assertEqual(nn[0][-2], 0)
 
         r = random.uniform(3, 6)
         all_nn = s.get_all_neighbors(r, True, True)


### PR DESCRIPTION
## Summary

Adding the ability to output to all routines that determine nearest neighbors. Detecting which image a neighbor comes from given its coordinates (Cartesian or fraction) can be complicated for neighbors near the edges of cells, and this change allows algorithms to avoid needing to perform such operations.

## Additional dependencies introduced (if any)

None

## TODO (if any)

~~Need to add the image outputs to neighbor finding routines in Structure. I'll be working on those shortly, but wanted to open a PR to run unit tests because changing Lattice touches many parts of pymatgen.~~