### PR TITLE
Fractional NELECT

### DIFF
--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -261,7 +261,7 @@ class DictSet(VaspInputSet):
                  constrain_total_magmom=False, sort_structure=True,
                  potcar_functional="PBE", force_gamma=False,
                  reduce_structure=None, vdw=None,
-                 use_structure_charge=False):
+                 use_structure_charge=False, allow_fractional_nelect=False):
         if reduce_structure:
             structure = structure.get_reduced_structure(reduce_structure)
         if sort_structure:
@@ -279,6 +279,7 @@ class DictSet(VaspInputSet):
         self.user_potcar_settings = user_potcar_settings
         self.vdw = vdw.lower() if vdw is not None else None
         self.use_structure_charge = use_structure_charge
+        self.allow_fractional_nelect = allow_fractional_nelect
         if self.vdw:
             vdw_par = loadfn(os.path.join(MODULE_DIR, "vdW_parameters.yaml"))
             try:
@@ -393,10 +394,13 @@ class DictSet(VaspInputSet):
                 site_symbols.remove(ps.element)
                 nelect += self.structure.composition.element_composition[ps.element] * ps.ZVAL
 
+        if not self.allow_fractional_nelect:
+            nelect = int(round(nelect))
+
         if self.use_structure_charge:
-            return int(round(nelect)) - self.structure.charge
+            return nelect - self.structure.charge
         else:
-            return int(round(nelect))
+            return nelect
 
     @property
     def kpoints(self):

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -92,6 +92,11 @@ class MITMPRelaxSetTest(unittest.TestCase):
         self.assertAlmostEqual(MITRelaxSet(s).nelect, 16)
         self.assertAlmostEqual(MPRelaxSet(s).nelect, 22)
 
+        s = Structure(lattice, ['H']*3, coords)
+        mprs = MPRelaxSet(s, allow_fractional_nelect=True)
+        mprs._config_dict['POTCAR']['H'] = 'H1.25'
+        self.assertAlmostEqual(mprs.nelect, 3.75)
+
     def test_get_incar(self):
 
         incar = self.mpset.incar


### PR DESCRIPTION
## Summary

In the DictSet provided in pymatgen.io.vasp.sets, fractional NELECT values are not allowed. For almost all purposes, this is not a problem. However, I am using the DictSet to prepare calculations that use the fractional hydrogen pseudopotentials, giving an incorrect NELECT value. I added a flag 'allow_fractional_nelect', which defaults to False, to the DictSet class.

I added relevant code to MITMPRelaxSetTest.test_nelect for code coverage.

## Additional dependencies introduced (if any)

None.

## TODO (if any)

None.