### PR TITLE
Allow fractional NELECT

### DIFF
--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -904,8 +904,8 @@ class Vasprun(MSONable):
 
         if potcar and self.incar.get("ALGO", "") not in ["GW0", "G0W0", "GW", "BSE"]:
             nelect = self.parameters["NELECT"]
-            potcar_nelect = int(round(sum([self.initial_structure.composition.element_composition[
-                                ps.element] * ps.ZVAL for ps in potcar])))
+            potcar_nelect = sum([self.initial_structure.composition.element_composition[
+                                ps.element] * ps.ZVAL for ps in potcar])
             charge = nelect - potcar_nelect
 
             if charge:

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -394,9 +394,9 @@ class DictSet(VaspInputSet):
                 nelect += self.structure.composition.element_composition[ps.element] * ps.ZVAL
 
         if self.use_structure_charge:
-            return int(round(nelect)) - self.structure.charge
+            return nelect - self.structure.charge
         else:
-            return int(round(nelect))
+            return nelect
 
     @property
     def kpoints(self):


### PR DESCRIPTION
## Summary

Removed unnecessary int(round(...)) from two locations when computing the NELECT value. While for most cases this should be an integer, there are some cases where a fractional value is expected; one use case is pseudo-hydrogen, which has a fractional charge for passivating bonds.

## Additional dependencies introduced (if any)

None

## TODO (if any)

- Possibly add a flag to turn this on/off
- An alternative would be to add some code which checks if nelect is close to an integer value before rounding: `if abs(round(nelect) - nelect) < 0.001: nelect = int(round(nelect))`