### PR TITLE
Computron

### DIFF
--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -643,7 +643,7 @@ class VoronoiNN(NearNeighbors):
 
         cutoff = self.cutoff
         max_cutoff = np.linalg.norm(
-            structure.lattice.lengths_and_angles[0])  # diagonal of cell
+            structure.lattice.lengths_and_angles[0]) + 0.01  # diagonal of cell
 
         while True:
             try:
@@ -659,10 +659,10 @@ class VoronoiNN(NearNeighbors):
                 break
 
             except RuntimeError:
-                if cutoff > max_cutoff:
+                if cutoff >= max_cutoff:
                     raise RuntimeError("Error in Voronoi neighbor finding; max "
                                        "cutoff exceeded")
-                cutoff *= 2
+                cutoff = min(cutoff * 2, max_cutoff)
 
         # Extract data about the site in question
         return self._extract_cell_info(structure, 0, neighbors, targets, voro)


### PR DESCRIPTION
## Summary

Currently, VoronoiNN takes in a static cutoff, and if neighbors are not found within that cutoff, it gives an error and quits.

Two problems:
- the default cutoff is very high to avoid such problems, making the default unnecessarily slow for most structures (which do not need a 10 Angstrom cutoff to find near neighbors)
- For some structures (e.g. mp-1096674), the cutoff is actually not enough and we hit the error.

This PR:

- sets a "maximum cutoff" equal to the length of the diagonal of the unit cell plus a small numerical tolerance
- if encountering a problem with the initial cutoff set by the user, it will double it until  hitting the max cutoff

## Additional dependencies introduced (if any)

None

## TODO (if any)

* I didn't change the default cutoff of 10.0. I do think this could be scaled back to 8.0 or so and the algorithm would go much faster and not change any real results. The only issue is that it is *possible* that there is a structure where including all sites within 8 Angstroms and all sites within 10 Angstroms for consideration result in different answers, but both give valid Voronoi constructions. In these (probably extremely rare) cases, changing the default might change the answer. Someone could in principle test all MP structures and ensure that the results were the same with both cutoffs.