### PR TITLE
Add option to choose alternative settings for SpacegroupAnalyzer

### DIFF
--- a/pymatgen/symmetry/tests/test_analyzer.py
+++ b/pymatgen/symmetry/tests/test_analyzer.py
@@ -18,6 +18,7 @@ from pymatgen.symmetry.analyzer import SpacegroupAnalyzer, \
 from pymatgen.io.cif import CifParser
 from pymatgen.util.testing import PymatgenTest
 from pymatgen.core.structure import Molecule, Structure
+from pymatgen.core.lattice import Lattice
 
 """
 Created on Mar 9, 2012
@@ -63,6 +64,15 @@ class SpacegroupAnalyzerTest(PymatgenTest):
         a = SpacegroupAnalyzer(s)
         self.assertEqual(len(s), 4)
         self.assertEqual(len(a.find_primitive()), 1)
+        
+    def test_choices(self):
+        s = Structure.from_spacegroup("R-3m", Lattice.hexagonal(3.0, 5.0), ["Cu"],
+                                      [[0, 0, 0]])
+        a = SpacegroupAnalyzer(s)
+        self.assertListEqual(a.get_available_choices(), ['H', 'R'])
+        self.assertEqual(a.get_symmetry_dataset()['choice'], 'H')
+        a = SpacegroupAnalyzer(s, choice='R')
+        self.assertEqual(a.get_symmetry_dataset()['choice'], 'R')
 
     def test_is_laue(self):
         s = Structure.from_spacegroup("Fm-3m", np.eye(3) * 3, ["Cu"],


### PR DESCRIPTION
## Summary

Adds a `choice` kwarg to select alternative origin, axes settings.

Due to how spglib's python interface works, the easiest way to use this functionality is to use SpacegroupAnalyzer to do an initial analysis, use `.get_available_choices()` to list out other choices that are supported by spglib, and then run SpacegroupAnalyzer again with one of those choices as appropriate.

This functionality is important if interested in e.g. Wyckoff co-ordinates in specific settings.

## Additional dependencies introduced (if any)

* None

## TODO (if any)

* None