### PR TITLE
Add grain boundary generator

### DIFF
--- a/pymatgen/core/grain_boundary_generator.py
+++ b/pymatgen/core/grain_boundary_generator.py
@@ -10,6 +10,12 @@ from pymatgen import Structure, Lattice
 from monty.fractions import lcm
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 
+__author__ = "Xiang-Guo Li"
+__copyright__ = "Copyright 2018, The Materials Virtual Lab"
+__version__ = "0.1"
+__maintainer__ = "Xiang-Guo Li"
+__email__ = "xil110@ucsd.edu"
+__date__ = "7/10/18"
 
 class GBGenerator(object):
     """
@@ -31,12 +37,6 @@ class GBGenerator(object):
     multiple rotation angles.
     Users can use structure matcher in pymatgen to get rid of the redundant structures.
     """
-__author__ = "Xiang-Guo Li"
-__copyright__ = "Copyright 2018, The Materials Virtual Lab"
-__version__ = "0.1"
-__maintainer__ = "Xiang-Guo Li"
-__email__ = "xil110@ucsd.edu"
-__date__ = "7/10/18"
 
     def __init__(self, initial_structure):
 

--- a/pymatgen/core/grain_boundary_generator.py
+++ b/pymatgen/core/grain_boundary_generator.py
@@ -1570,26 +1570,26 @@ class GBGenerator(object):
                                         c_norm = c_norm_temp
 
         # find the best a, b vectors with their formed area smallest and average norm of a,b smallest.
-        for i in range(len(ab_vector)):
-            for j in range(i + 1, len(ab_vector)):
-                area_temp = np.linalg.norm(np.cross(np.matmul(ab_vector[i], trans),
-                                                    np.matmul(ab_vector[j], trans)))
+        for i, vali in enumerate(ab_vector):
+            for j, valj in enumerate(ab_vector, start = i + 1):
+                area_temp = np.linalg.norm(np.cross(np.matmul(vali, trans),
+                                                    np.matmul(valj, trans)))
                 if abs(area_temp - 0) > 1.e-8:
-                    ab_norm_temp = np.linalg.norm(np.matmul(ab_vector[i], trans)) + \
-                                   np.linalg.norm(np.matmul(ab_vector[j], trans))
+                    ab_norm_temp = np.linalg.norm(np.matmul(vali, trans)) + \
+                                   np.linalg.norm(np.matmul(valj, trans))
                     if area is None:
                         area = area_temp
                         ab_norm = ab_norm_temp
-                        t_matrix[0] = ab_vector[i]
-                        t_matrix[1] = ab_vector[j]
+                        t_matrix[0] = vali
+                        t_matrix[1] = valj
                     elif area_temp < area:
-                        t_matrix[0] = ab_vector[i]
-                        t_matrix[1] = ab_vector[j]
+                        t_matrix[0] = vali
+                        t_matrix[1] = valj
                         area = area_temp
                         ab_norm = ab_norm_temp
                     elif abs(area - area_temp) < 1.e-8 and ab_norm_temp < ab_norm:
-                        t_matrix[0] = ab_vector[i]
-                        t_matrix[1] = ab_vector[j]
+                        t_matrix[0] = vali
+                        t_matrix[1] = valj
                         area = area_temp
                         ab_norm = ab_norm_temp
         # make sure we have a left-handed crystallographic system

--- a/pymatgen/core/grain_boundary_generator.py
+++ b/pymatgen/core/grain_boundary_generator.py
@@ -1,0 +1,1647 @@
+# coding: utf-8
+# !/usr/bin/env python
+
+from __future__ import division, unicode_literals
+import numpy as np
+from fractions import Fraction
+from math import gcd, floor
+from functools import reduce
+from pymatgen import Structure, Lattice
+from monty.fractions import lcm
+from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
+
+
+class GBGenerator(object):
+    """
+    This class provides two methods to generate grain boundaries (GBs) from bulk
+    conventional cell (fcc, bcc can from the primitive cell), and works for Cubic,
+    Tetragonal, Orthorhombic, Rhombohedral, and Hexagonal systems.
+    The first one is to generate GBs from given parameters, which includes
+    GB plane, rotation axis, rotation angle.
+    The second one is to generate GBs from given transformation matrices for each
+    grain.
+
+    This class works for any general GB, including both twist and tilt GBs.
+    The three parameters, rotation axis, GB plane and rotation angle, are
+    sufficient to identify one unique GB. While sometimes, users may not be able
+    to tell what exactly rotation angle is but prefer to use sigma as an parameter,
+    this class also provides the function that is able to return all possible
+    rotation angles for a specific sigma value.
+    The same sigma value (with rotation axis fixed) can correspond to
+    multiple rotation angles.
+    Users can use structure matcher in pymatgen to get rid of the redundant structures.
+    """
+__author__ = "Xiang-Guo Li"
+__copyright__ = "Copyright 2018, The Materials Virtual Lab"
+__version__ = "0.1"
+__maintainer__ = "Xiang-Guo Li"
+__email__ = "xil110@ucsd.edu"
+__date__ = "7/10/18"
+
+    def __init__(self, initial_structure):
+
+        """
+        initial_structure (Structure): Initial input structure. It can
+               be conventional or primitive cell (primitive cell works for bcc and fcc).
+               For fcc and bcc, using conventional cell can lead to a non-primitive
+               grain boundary structure.
+               This code supplies Cubic, Tetragonal, Orthorhombic, Rhombohedral, and
+               Hexagonal systems.
+               For Tetragonal and Hexagonal systems, keep the structure's third direction
+               as c axis, the first two axis as a axis.
+        """
+
+        self.initial_structure = initial_structure
+
+    def gb_from_parameters(self, rotation_axis, rotation_angle, expand_times=4, vacuum_thickness=0.0,
+                           normal=False, ratio=None, plane=None, tol=1.e-4):
+
+        """
+        Args:
+           rotation_axis (list): Rotation axis of GB in the form of a list of integer
+                e.g.: [1, 1, 0]
+           rotation_angle (float, in unit of degree): rotation angle used to generate GB.
+                Make sure the angle is accurate enough. You can use the enum* functions
+                in this class to extract the accurate angle.
+                e.g.: The rotation angle of sigma 3 twist GB with the rotation axis
+                [1, 1, 1] and GB plane (1, 1, 1) can be 60.000000000 degree.
+                If you do not know the rotation angle, but know the sigma value, we have
+                provide the function get_rotation_angle_from_sigma which is able to return
+                all the rotation angles of sigma value you provided.
+           expand_times (int): The multiple times used to expand one unit grain to larger grain.
+                This is used to tune the grain length of GB to warrant that the two GBs in one
+                cell do not interact with each other. Default set to 4.
+           vacuum_thickness (float): The thickness of vacuum that you want to insert between
+                two grains of the GB. Default to 0.
+            normal (logic):
+                determine if need to require the c axis of top grain (first transformation matrix)
+                perperdicular to the surface or not.
+                default to false.
+            ratio (list of integers):
+                    lattice axial ratio.
+                    For cubic system, ratio is not needed.
+                    For tetragonal system, ratio = [mu, mv], list of two integers,
+                    that is, mu/mv = c2/a2. If it is irrational, set it to none.
+                    For orthorhombic system, ratio = [mu, lam, mv], list of three integers,
+                    that is, mu:lam:mv = c2:b2:a2. If irrational for one axis, set it to None.
+                    e.g. mu:lam:mv = c2,None,a2, means b2 is irrational.
+                    For rhombohedral system, ratio = [mu, mv], list of two integers,
+                    that is, mu/mv is the ratio of (1+2*cos(alpha))/cos(alpha).
+                    If irrational, set it to None.
+                    For hexagonal system, ratio = [mu, mv], list of two integers,
+                    that is, mu/mv = c2/a2. If it is irrational, set it to none.
+            plane (list): Grain boundary plane in the form of a list of integers
+                e.g.: [1, 2, 3]. If none, we set it as twist GB. The plane will be perpendicular
+                to the rotation axis.
+            tol (float): tolerance to determine the type of inital structure.
+        Returns:
+           Grain boundary structure (structure object).
+               """
+        # angle tolerance should be looser.
+        tol_angle = 100 * tol
+        # if the initial structure is primitive cell in cubic system,
+        # calculate the transformation matrix from its conventional cell
+        # to primitive cell, basically for bcc and fcc systems.
+        init_str = self.initial_structure
+        alpha, beta, gamma = init_str.lattice.angles
+        a, b, c = init_str.lattice.abc
+        analyzer = SpacegroupAnalyzer(init_str)
+        convention_cell = analyzer.get_conventional_standard_structure()
+        vol_ratio = init_str.volume / convention_cell.volume
+        # bcc primitive cell, belong to cubic system
+        if abs(vol_ratio - 0.5) < tol * vol_ratio:
+            trans_cry = np.array([[0.5, 0.5, -0.5], [-0.5, 0.5, 0.5], [0.5, -0.5, 0.5]])
+            lat_type = 'c'
+            print('Make sure this is for cubic system with bcc primitive cell')
+        # fcc primitive cell, belong to cubic system
+        elif abs(vol_ratio - 0.25) < tol * vol_ratio:
+            trans_cry = np.array([[0.5, 0.5, 0], [0, 0.5, 0.5], [0.5, 0, 0.5]])
+            lat_type = 'c'
+            print('Make sure this is for cubic system with fcc primitive cell')
+        else:
+            trans_cry = np.eye(3)
+            if abs(alpha - 90) < tol_angle and (abs(beta - 90) < tol_angle) and \
+                    (abs(gamma - 90) < tol_angle):
+                if abs(a - b) < tol and (abs(a - c) < tol):
+                    lat_type = 'c'
+                    print('Make sure this is for cubic system with conventional cell')
+                elif abs(a - b) < tol:
+                    lat_type = 't'
+                    print('Make sure this is for tetragonal system')
+                    if ratio is None:
+                        print('Make sure this is for irrational c2/a2')
+                    elif len(ratio) != 2:
+                        raise RuntimeError('Tetragonal system needs correct c2/a2 ratio')
+                else:
+                    lat_type = 'o'
+                    print('Make sure this is for orthorhombic system')
+                    if ratio is None:
+                        raise RuntimeError('CSL donot exist if all axial ratios are irrational'
+                                           'for orthorhombic system')
+                    elif len(ratio) != 3:
+                        raise RuntimeError('Orthorhombic system needs correct c2:b2:a2 ratio')
+            elif abs(alpha - 90) < tol_angle and ((beta - 90) < tol_angle) and \
+                    (abs(gamma - 120) < tol_angle or abs(gamma - 60) < tol_angle) and \
+                            abs(a - b) < tol:
+                lat_type = 'h'
+                print('Make sure this is for hexagonal system')
+                if ratio is None:
+                    print('Make sure this is for irrational c2/a2')
+                elif len(ratio) != 2:
+                    raise RuntimeError('Hexagonal system needs correct c2/a2 ratio')
+            elif abs(alpha - beta) < tol_angle and ((alpha - gamma) < tol_angle) and \
+                    (abs(a - b) < tol) and abs(a - c) < tol:
+                lat_type = 'r'
+                print('Make sure this is for rhombohedral system')
+                if ratio is None:
+                    print('Make sure this is for irrational (1+2*cos(alpha)/cos(alpha) ratio')
+                elif len(ratio) != 2:
+                    raise RuntimeError('Rhombohedral system needs correct '
+                                       '(1+2*cos(alpha)/cos(alpha) ratio')
+            else:
+                raise RuntimeError('Lattice type not implemented. This code works for cubic, '
+                                   'tetragonal, orthorhombic, rhombehedral, hexagonal systems')
+
+        t1, t2 = self.get_trans_mat(r_axis=rotation_axis, angle=rotation_angle, normal=normal,
+                                    trans_cry=trans_cry, lat_type=lat_type, ratio=ratio, surface=plane)
+
+        gb_with_vac = self.gb_from_matrices(top_grain_matrix=t1,
+                                            bottom_grain_matrix=t2,
+                                            expand_times=expand_times,
+                                            vacuum_thickness=vacuum_thickness)
+
+        return gb_with_vac
+
+    def gb_from_matrices(self, top_grain_matrix, bottom_grain_matrix, expand_times, vacuum_thickness):
+
+        """
+        This function is used to generate GB structures from the given transformation matrices.
+        The idea here is to use a generic descriptor for a specific type of GB define by
+        spacegroup and the matrix only. This descriptor will then work for any material of
+        a particular spacegroup.
+        E.g. for sigma 5 (001) fcc GB, we know beforehand matrix to describe the two
+        grains of this GB, which can be used to generate GB structure for all kinds of systems
+        with fcc lattice. To be used for the high throughput effort.
+
+        Args:
+           top_grain_matrix (3 by 3 array): The transformation matrix used to operate on top grain.
+           bottom_grain_matrix (3 by 3 array): The transformation matrix used to operate on bottom grain.
+           expand_times (int): The multiple times used to expand one unit grain to larger grain.
+               This is used to tune the grain length of GB to warrant that the two GBs in one cell do
+               not interact with each other.
+           vacuum_thickness (float): The thickness of vacuum that you want to insert between
+                two grains of the GB.
+        Returns:
+           Grain boundary structure.
+        """
+
+        parent_structure = self.initial_structure.copy()
+        # top grain
+        top_grain = fix_pbc(parent_structure * top_grain_matrix)
+        top_grain_init = top_grain.lattice.matrix
+        top_grain.make_supercell([1, 1, expand_times])
+        top_grain = fix_pbc(top_grain)
+
+        # bottom grain, using top grain's lattice matrix
+        bottom_grain = fix_pbc(parent_structure * bottom_grain_matrix, top_grain_init)
+        bottom_grain.make_supercell([1, 1, expand_times])
+        bottom_grain = fix_pbc(bottom_grain, top_grain.lattice.matrix)
+
+        # construct all species
+        all_species = []
+        all_species.extend([site.specie for site in bottom_grain])
+        all_species.extend([site.specie for site in top_grain])
+
+        half_lattice = top_grain.lattice
+        # calculate translation vector, perpendicular to the plane
+        normal_v_plane = np.cross(half_lattice.matrix[0], half_lattice.matrix[1])
+        unit_normal_v = normal_v_plane / np.linalg.norm(normal_v_plane)
+        translation_v = unit_normal_v * vacuum_thickness
+
+        # construct the final lattice
+        whole_matrix_no_vac = half_lattice.matrix
+        whole_matrix_no_vac[2] = half_lattice.matrix[2] * 2
+        whole_matrix_with_vac = whole_matrix_no_vac.copy()
+        whole_matrix_with_vac[2] = whole_matrix_no_vac[2] + translation_v * 2
+        whole_lat = Lattice(whole_matrix_with_vac)
+
+        # construct the coords, move top grain with translation_v
+        all_coords = []
+        for site in bottom_grain:
+            all_coords.append(site.coords)
+        for site in top_grain:
+            all_coords.append(site.coords + half_lattice.matrix[2] + translation_v)
+
+        gb_with_vac = Structure(whole_lat, all_species, all_coords,
+                                coords_are_cartesian=True)
+
+        return gb_with_vac
+
+    @staticmethod
+    def enum_sigma_cubic(cutoff, r_axis):
+        """
+        Find all possible sigma values and corresponding rotation angles
+        within a sigma value cutoff with known rotation axis in cubic system.
+        The algorithm for this code is from reference, Acta Cryst, A40,108(1984)
+        Args:
+            cutoff (integer): the cutoff of sigma values.
+            r_axis (list of three integers, e.g. u, v, w):
+                    the rotation axis of the grain boundary, with the format of [u,v,w].
+        Returns:
+            sigmas (dict):
+                    dictionary with keys as the possible integer sigma values
+                    and values as list of the possible rotation angles to the
+                    corresponding sigma values.
+                    e.g. the format as
+                    {sigma1: [angle11,angle12,...], sigma2: [angle21, angle22,...],...}
+                    Note: the angles are the rotation angles of one grain respect to
+                    the other grain.
+                    When generate the microstructures of the grain boundary using these angles,
+                    you need to analyze the symmetry of the structure. Different angles may
+                    result in equivalent microstructures.
+
+        """
+        sigmas = {}
+        # make sure gcd(r_axis)==1
+        if reduce(gcd, r_axis) != 1:
+            r_axis = [int(round(x / reduce(gcd, r_axis))) for x in r_axis]
+
+        # count the number of odds in r_axis
+        odd_r = len(list(filter(lambda x: x % 2 == 1, r_axis)))
+        # Compute the max n we need to enumerate.
+        if odd_r == 3:
+            a_max = 4
+        elif odd_r == 0:
+            a_max = 1
+        else:
+            a_max = 2
+        n_max = int(np.sqrt(cutoff * a_max / sum(np.array(r_axis) ** 2)))
+        # enumerate all possible n, m to give possible sigmas within the cutoff.
+        for n_loop in range(1, n_max + 1):
+            n = n_loop
+            m_max = int(np.sqrt(cutoff * a_max - n ** 2 * sum(np.array(r_axis) ** 2)))
+            for m in range(0, m_max + 1):
+                if gcd(m, n) == 1 or m == 0:
+                    if m == 0:
+                        n = 1
+                    else:
+                        n = n_loop
+                    # construct the quadruple [m, U,V,W], count the number of odds in
+                    # quadruple to determine the parameter a, refer to the reference
+                    quadruple = [m] + [x * n for x in r_axis]
+                    odd_qua = len(list(filter(lambda x: x % 2 == 1, quadruple)))
+                    if odd_qua == 4:
+                        a = 4
+                    elif odd_qua == 2:
+                        a = 2
+                    else:
+                        a = 1
+                    sigma = int(round((m ** 2 + n ** 2 * sum(np.array(r_axis) ** 2)) / a))
+                    if (sigma <= cutoff) and (sigma > 1):
+                        if sigma not in list(sigmas.keys()):
+                            if m == 0:
+                                angle = 180.0
+                            else:
+                                angle = 2 * np.arctan(n * np.sqrt(sum(np.array(r_axis) ** 2)) / m) \
+                                        / np.pi * 180
+                            sigmas[sigma] = [angle]
+                        else:
+                            if m == 0:
+                                angle = 180.0
+                            else:
+                                angle = 2 * np.arctan(n * np.sqrt(sum(np.array(r_axis) ** 2)) / m) \
+                                        / np.pi * 180
+                            if angle not in sigmas[sigma]:
+                                sigmas[sigma].append(angle)
+        return sigmas
+
+    @staticmethod
+    def enum_sigma_hex(cutoff, r_axis, c2_a2_ratio):
+        """
+        Find all possible sigma values and corresponding rotation angles
+        within a sigma value cutoff with known rotation axis in hexagonal system.
+        The algorithm for this code is from reference, Acta Cryst, A38,550(1982)
+
+        Args:
+            cutoff (integer): the cutoff of sigma values.
+            r_axis (list of three integers, e.g. u, v, w
+                    or four integers, e.g. u, v, t, w):
+                    the rotation axis of the grain boundary.
+            c2_a2_ratio (list of two integers, e.g. mu, mv):
+                    mu/mv is the square of the hexagonal axial ratio, which is rational
+                    number. If irrational, set c2_a2_ratio = None
+        Returns:
+            sigmas (dict):
+                    dictionary with keys as the possible integer sigma values
+                    and values as list of the possible rotation angles to the
+                    corresponding sigma values.
+                    e.g. the format as
+                    {sigma1: [angle11,angle12,...], sigma2: [angle21, angle22,...],...}
+                    Note: the angles are the rotation angle of one grain respect to the
+                    other grain.
+                    When generate the microstructure of the grain boundary using these
+                    angles, you need to analyze the symmetry of the structure. Different
+                    angles may result in equivalent microstructures.
+
+        """
+        sigmas = {}
+        # make sure gcd(r_axis)==1
+        if reduce(gcd, r_axis) != 1:
+            r_axis = [int(round(x / reduce(gcd, r_axis))) for x in r_axis]
+        # transform four index notation to three index notation
+        if len(r_axis) == 4:
+            u1, v1, t1, w1 = r_axis
+            u = 2 * u1 + v1
+            v = 2 * v1 + u1
+            w = w1
+        else:
+            u, v, w = r_axis
+
+        # make sure mu, mv are coprime integers.
+        if c2_a2_ratio is None:
+            mu, mv = [1, 1]
+            if w != 0:
+                if u != 0 or (v != 0):
+                    raise RuntimeError('For irrational c2/a2, CSL only exist for [0,0,1] '
+                                       'or [u,v,0] and m = 0')
+        else:
+            mu, mv = c2_a2_ratio
+            if gcd(mu, mv) != 1:
+                temp = gcd(mu, mv)
+                mu = int(round(mu / temp))
+                mv = int(round(mv / temp))
+
+        # refer to the meaning of d in reference
+        d = (u ** 2 + v ** 2 - u * v) * mv + w ** 2 * mu
+
+        # Compute the max n we need to enumerate.
+        n_max = int(np.sqrt((cutoff * 12 * mu * mv) / abs(d)))
+
+        # Enumerate all possible n, m to give possible sigmas within the cutoff.
+        for n in range(1, n_max + 1):
+            if (c2_a2_ratio is None) and w == 0:
+                m_max = 0
+            else:
+                m_max = int(np.sqrt((cutoff * 12 * mu * mv - n ** 2 * d) / (3 * mu)))
+            for m in range(0, m_max + 1):
+                if gcd(m, n) == 1 or m == 0:
+                    # construct the rotation matrix, refer to the reference
+                    R_list = [(u ** 2 * mv - v ** 2 * mv - w ** 2 * mu) * n ** 2 +
+                              2 * w * mu * m * n + 3 * mu * m ** 2,
+                              (2 * v - u) * u * mv * n ** 2 - 4 * w * mu * m * n,
+                              2 * u * w * mu * n ** 2 + 2 * (2 * v - u) * mu * m * n,
+                              (2 * u - v) * v * mv * n ** 2 + 4 * w * mu * m * n,
+                              (v ** 2 * mv - u ** 2 * mv - w ** 2 * mu) * n ** 2 -
+                              2 * w * mu * m * n + 3 * mu * m ** 2,
+                              2 * v * w * mu * n ** 2 - 2 * (2 * u - v) * mu * m * n,
+                              (2 * u - v) * w * mv * n ** 2 - 3 * v * mv * m * n,
+                              (2 * v - u) * w * mv * n ** 2 + 3 * u * mv * m * n,
+                              (w ** 2 * mu - u ** 2 * mv - v ** 2 * mv + u * v * mv) *
+                              n ** 2 + 3 * mu * m ** 2]
+                    m = -1 * m
+                    # inverse of the rotation matrix
+                    R_list_inv = [(u ** 2 * mv - v ** 2 * mv - w ** 2 * mu) * n ** 2 +
+                                  2 * w * mu * m * n + 3 * mu * m ** 2,
+                                  (2 * v - u) * u * mv * n ** 2 - 4 * w * mu * m * n,
+                                  2 * u * w * mu * n ** 2 + 2 * (2 * v - u) * mu * m * n,
+                                  (2 * u - v) * v * mv * n ** 2 + 4 * w * mu * m * n,
+                                  (v ** 2 * mv - u ** 2 * mv - w ** 2 * mu) * n ** 2 -
+                                  2 * w * mu * m * n + 3 * mu * m ** 2,
+                                  2 * v * w * mu * n ** 2 - 2 * (2 * u - v) * mu * m * n,
+                                  (2 * u - v) * w * mv * n ** 2 - 3 * v * mv * m * n,
+                                  (2 * v - u) * w * mv * n ** 2 + 3 * u * mv * m * n,
+                                  (w ** 2 * mu - u ** 2 * mv - v ** 2 * mv + u * v * mv) *
+                                  n ** 2 + 3 * mu * m ** 2]
+                    m = -1 * m
+                    F = 3 * mu * m ** 2 + d * n ** 2
+                    all_list = R_list_inv + R_list + [F]
+                    # Compute the max common factors for the elements of the rotation matrix
+                    # and its inverse.
+                    com_fac = reduce(gcd, all_list)
+                    sigma = int(round((3 * mu * m ** 2 + d * n ** 2) / com_fac))
+                    if (sigma <= cutoff) and (sigma > 1):
+                        if sigma not in list(sigmas.keys()):
+                            if m == 0:
+                                angle = 180.0
+                            else:
+                                angle = 2 * np.arctan(n / m * np.sqrt(d / 3.0 / mu)) \
+                                        / np.pi * 180
+                            sigmas[sigma] = [angle]
+                        else:
+                            if m == 0:
+                                angle = 180.0
+                            else:
+                                angle = 2 * np.arctan(n / m * np.sqrt(d / 3.0 / mu)) \
+                                        / np.pi * 180
+                            if angle not in sigmas[sigma]:
+                                sigmas[sigma].append(angle)
+            if m_max == 0:
+                break
+        return sigmas
+
+    @staticmethod
+    def enum_sigma_rho(cutoff, r_axis, ratio_alpha):
+        """
+        Find all possible sigma values and corresponding rotation angles
+        within a sigma value cutoff with known rotation axis in rhombohedral system.
+        The algorithm for this code is from reference, Acta Cryst, A45,505(1989).
+
+        Args:
+            cutoff (integer): the cutoff of sigma values.
+            r_axis (list of three integers, e.g. u, v, w
+                    or four integers, e.g. u, v, t, w):
+                    the rotation axis of the grain boundary, with the format of [u,v,w]
+                    or Weber indices [u, v, t, w].
+            ratio_alpha (list of two integers, e.g. mu, mv):
+                    mu/mv is the ratio of (1+2*cos(alpha))/cos(alpha) with rational number.
+                    If irrational, set ratio_alpha = None.
+        Returns:
+            sigmas (dict):
+                    dictionary with keys as the possible integer sigma values
+                    and values as list of the possible rotation angles to the
+                    corresponding sigma values.
+                    e.g. the format as
+                    {sigma1: [angle11,angle12,...], sigma2: [angle21, angle22,...],...}
+                    Note: the angles are the rotation angle of one grain respect to the
+                    other grain.
+                    When generate the microstructure of the grain boundary using these
+                    angles, you need to analyze the symmetry of the structure. Different
+                    angles may result in equivalent microstructures.
+
+        """
+        sigmas = {}
+        # transform four index notation to three index notation
+        if len(r_axis) == 4:
+            u1, v1, t1, w1 = r_axis
+            u = 2 * u1 + v1 + w1
+            v = v1 + w1 - u1
+            w = w1 - 2 * v1 - u1
+            r_axis = [u, v, w]
+        # make sure gcd(r_axis)==1
+        if reduce(gcd, r_axis) != 1:
+            r_axis = [int(round(x / reduce(gcd, r_axis))) for x in r_axis]
+        u, v, w = r_axis
+        # make sure mu, mv are coprime integers.
+        if ratio_alpha is None:
+            mu, mv = [1, 1]
+            if u + v + w != 0:
+                if u != v or u != w:
+                    raise RuntimeError('For irrational ratio_alpha, CSL only exist for [1,1,1]'
+                                       'or [u, v, -(u+v)] and m =0')
+        else:
+            mu, mv = ratio_alpha
+            if gcd(mu, mv) != 1:
+                temp = gcd(mu, mv)
+                mu = int(round(mu / temp))
+                mv = int(round(mv / temp))
+
+        # refer to the meaning of d in reference
+        d = (u ** 2 + v ** 2 + w ** 2) * (mu - 2 * mv) + \
+            2 * mv * (v * w + w * u + u * v)
+        # Compute the max n we need to enumerate.
+        n_max = int(np.sqrt((cutoff * abs(4 * mu * (mu - 3 * mv))) / abs(d)))
+
+        # Enumerate all possible n, m to give possible sigmas within the cutoff.
+        for n in range(1, n_max + 1):
+            if ratio_alpha is None and u + v + w == 0:
+                m_max = 0
+            else:
+                m_max = int(np.sqrt((cutoff * abs(4 * mu * (mu - 3 * mv)) - n ** 2 * d) / (mu)))
+            for m in range(0, m_max + 1):
+                if gcd(m, n) == 1 or m == 0:
+                    # construct the rotation matrix, refer to the reference
+                    R_list = [(mu - 2 * mv) * (u ** 2 - v ** 2 - w ** 2) * n ** 2 +
+                              2 * mv * (v - w) * m * n - 2 * mv * v * w * n ** 2 +
+                              mu * m ** 2,
+                              2 * (mv * u * n * (w * n + u * n - m) - (mu - mv) *
+                                   m * w * n + (mu - 2 * mv) * u * v * n ** 2),
+                              2 * (mv * u * n * (v * n + u * n + m) + (mu - mv) *
+                                   m * v * n + (mu - 2 * mv) * w * u * n ** 2),
+                              2 * (mv * v * n * (w * n + v * n + m) + (mu - mv) *
+                                   m * w * n + (mu - 2 * mv) * u * v * n ** 2),
+                              (mu - 2 * mv) * (v ** 2 - w ** 2 - u ** 2) * n ** 2 +
+                              2 * mv * (w - u) * m * n - 2 * mv * u * w * n ** 2 +
+                              mu * m ** 2,
+                              2 * (mv * v * n * (v * n + u * n - m) - (mu - mv) *
+                                   m * u * n + (mu - 2 * mv) * w * v * n ** 2),
+                              2 * (mv * w * n * (w * n + v * n - m) - (mu - mv) *
+                                   m * v * n + (mu - 2 * mv) * w * u * n ** 2),
+                              2 * (mv * w * n * (w * n + u * n + m) + (mu - mv) *
+                                   m * u * n + (mu - 2 * mv) * w * v * n ** 2),
+                              (mu - 2 * mv) * (w ** 2 - u ** 2 - v ** 2) * n ** 2 +
+                              2 * mv * (u - v) * m * n - 2 * mv * u * v * n ** 2 +
+                              mu * m ** 2]
+                    m = -1 * m
+                    # inverse of the rotation matrix
+                    R_list_inv = [(mu - 2 * mv) * (u ** 2 - v ** 2 - w ** 2) * n ** 2 +
+                                  2 * mv * (v - w) * m * n - 2 * mv * v * w * n ** 2 +
+                                  mu * m ** 2,
+                                  2 * (mv * u * n * (w * n + u * n - m) - (mu - mv) *
+                                       m * w * n + (mu - 2 * mv) * u * v * n ** 2),
+                                  2 * (mv * u * n * (v * n + u * n + m) + (mu - mv) *
+                                       m * v * n + (mu - 2 * mv) * w * u * n ** 2),
+                                  2 * (mv * v * n * (w * n + v * n + m) + (mu - mv) *
+                                       m * w * n + (mu - 2 * mv) * u * v * n ** 2),
+                                  (mu - 2 * mv) * (v ** 2 - w ** 2 - u ** 2) * n ** 2 +
+                                  2 * mv * (w - u) * m * n - 2 * mv * u * w * n ** 2 +
+                                  mu * m ** 2,
+                                  2 * (mv * v * n * (v * n + u * n - m) - (mu - mv) *
+                                       m * u * n + (mu - 2 * mv) * w * v * n ** 2),
+                                  2 * (mv * w * n * (w * n + v * n - m) - (mu - mv) *
+                                       m * v * n + (mu - 2 * mv) * w * u * n ** 2),
+                                  2 * (mv * w * n * (w * n + u * n + m) + (mu - mv) *
+                                       m * u * n + (mu - 2 * mv) * w * v * n ** 2),
+                                  (mu - 2 * mv) * (w ** 2 - u ** 2 - v ** 2) * n ** 2 +
+                                  2 * mv * (u - v) * m * n - 2 * mv * u * v * n ** 2 +
+                                  mu * m ** 2]
+                    m = -1 * m
+                    F = mu * m ** 2 + d * n ** 2
+                    all_list = R_list_inv + R_list + [F]
+                    # Compute the max common factors for the elements of the rotation matrix
+                    #  and its inverse.
+                    com_fac = reduce(gcd, all_list)
+                    sigma = int(round(abs(F / com_fac)))
+                    if (sigma <= cutoff) and (sigma > 1):
+                        if sigma not in list(sigmas.keys()):
+                            if m == 0:
+                                angle = 180.0
+                            else:
+                                angle = 2 * np.arctan(n / m * np.sqrt(d / mu)) \
+                                        / np.pi * 180
+                            sigmas[sigma] = [angle]
+                        else:
+                            if m == 0:
+                                angle = 180
+                            else:
+                                angle = 2 * np.arctan(n / m * np.sqrt(d / mu)) \
+                                        / np.pi * 180.0
+                            if angle not in sigmas[sigma]:
+                                sigmas[sigma].append(angle)
+            if m_max == 0:
+                break
+        return sigmas
+
+    @staticmethod
+    def enum_sigma_tet(cutoff, r_axis, c2_a2_ratio):
+        """
+        Find all possible sigma values and corresponding rotation angles
+        within a sigma value cutoff with known rotation axis in tetragonal system.
+        The algorithm for this code is from reference, Acta Cryst, B46,117(1990)
+
+        Args:
+            cutoff (integer): the cutoff of sigma values.
+            r_axis (list of three integers, e.g. u, v, w):
+                    the rotation axis of the grain boundary, with the format of [u,v,w].
+            c2_a2_ratio (list of two integers, e.g. mu, mv):
+                    mu/mv is the square of the tetragonal axial ratio with rational number.
+                    if irrational, set c2_a2_ratio = None
+        Returns:
+            sigmas (dict):
+                    dictionary with keys as the possible integer sigma values
+                    and values as list of the possible rotation angles to the
+                    corresponding sigma values.
+                    e.g. the format as
+                    {sigma1: [angle11,angle12,...], sigma2: [angle21, angle22,...],...}
+                    Note: the angles are the rotation angle of one grain respect to the
+                    other grain.
+                    When generate the microstructure of the grain boundary using these
+                    angles, you need to analyze the symmetry of the structure. Different
+                    angles may result in equivalent microstructures.
+
+        """
+        sigmas = {}
+        # make sure gcd(r_axis)==1
+        if reduce(gcd, r_axis) != 1:
+            r_axis = [int(round(x / reduce(gcd, r_axis))) for x in r_axis]
+
+        u, v, w = r_axis
+
+        # make sure mu, mv are coprime integers.
+        if c2_a2_ratio is None:
+            mu, mv = [1, 1]
+            if w != 0:
+                if u != 0 or (v != 0):
+                    raise RuntimeError('For irrational c2/a2, CSL only exist for [0,0,1] '
+                                       'or [u,v,0] and m = 0')
+        else:
+            mu, mv = c2_a2_ratio
+            if gcd(mu, mv) != 1:
+                temp = gcd(mu, mv)
+                mu = int(round(mu / temp))
+                mv = int(round(mv / temp))
+
+        # refer to the meaning of d in reference
+        d = (u ** 2 + v ** 2) * mv + w ** 2 * mu
+
+        # Compute the max n we need to enumerate.
+        n_max = int(np.sqrt((cutoff * 4 * mu * mv) / d))
+
+        # Enumerate all possible n, m to give possible sigmas within the cutoff.
+        for n in range(1, n_max + 1):
+            if c2_a2_ratio is None and w == 0:
+                m_max = 0
+            else:
+                m_max = int(np.sqrt((cutoff * 4 * mu * mv - n ** 2 * d) / mu))
+            for m in range(0, m_max + 1):
+                if gcd(m, n) == 1 or m == 0:
+                    # construct the rotation matrix, refer to the reference
+                    R_list = [(u ** 2 * mv - v ** 2 * mv - w ** 2 * mu) * n ** 2 +
+                              mu * m ** 2,
+                              2 * v * u * mv * n ** 2 - 2 * w * mu * m * n,
+                              2 * u * w * mu * n ** 2 + 2 * v * mu * m * n,
+                              2 * u * v * mv * n ** 2 + 2 * w * mu * m * n,
+                              (v ** 2 * mv - u ** 2 * mv - w ** 2 * mu) * n ** 2 +
+                              mu * m ** 2,
+                              2 * v * w * mu * n ** 2 - 2 * u * mu * m * n,
+                              2 * u * w * mv * n ** 2 - 2 * v * mv * m * n,
+                              2 * v * w * mv * n ** 2 + 2 * u * mv * m * n,
+                              (w ** 2 * mu - u ** 2 * mv - v ** 2 * mv) * n ** 2 +
+                              mu * m ** 2]
+                    m = -1 * m
+                    # inverse of rotation matrix
+                    R_list_inv = [(u ** 2 * mv - v ** 2 * mv - w ** 2 * mu) * n ** 2 +
+                                  mu * m ** 2,
+                                  2 * v * u * mv * n ** 2 - 2 * w * mu * m * n,
+                                  2 * u * w * mu * n ** 2 + 2 * v * mu * m * n,
+                                  2 * u * v * mv * n ** 2 + 2 * w * mu * m * n,
+                                  (v ** 2 * mv - u ** 2 * mv - w ** 2 * mu) * n ** 2 +
+                                  mu * m ** 2,
+                                  2 * v * w * mu * n ** 2 - 2 * u * mu * m * n,
+                                  2 * u * w * mv * n ** 2 - 2 * v * mv * m * n,
+                                  2 * v * w * mv * n ** 2 + 2 * u * mv * m * n,
+                                  (w ** 2 * mu - u ** 2 * mv - v ** 2 * mv) * n ** 2 +
+                                  mu * m ** 2]
+                    m = -1 * m
+                    F = mu * m ** 2 + d * n ** 2
+                    all_list = R_list + R_list_inv + [F]
+                    # Compute the max common factors for the elements of the rotation matrix
+                    #  and its inverse.
+                    com_fac = reduce(gcd, all_list)
+                    sigma = int(round((mu * m ** 2 + d * n ** 2) / com_fac))
+                    if (sigma <= cutoff) and (sigma > 1):
+                        if sigma not in list(sigmas.keys()):
+                            if m == 0:
+                                angle = 180.0
+                            else:
+                                angle = 2 * np.arctan(n / m * np.sqrt(d / mu)) \
+                                        / np.pi * 180
+                            sigmas[sigma] = [angle]
+                        else:
+                            if m == 0:
+                                angle = 180.0
+                            else:
+                                angle = 2 * np.arctan(n / m * np.sqrt(d / mu)) \
+                                        / np.pi * 180
+                            if angle not in sigmas[sigma]:
+                                sigmas[sigma].append(angle)
+            if m_max == 0:
+                break
+
+        return sigmas
+
+    @staticmethod
+    def enum_sigma_ort(cutoff, r_axis, c2_b2_a2_ratio):
+        """
+        Find all possible sigma values and corresponding rotation angles
+        within a sigma value cutoff with known rotation axis in orthorhombic system.
+        The algorithm for this code is from reference, Scipta Metallurgica 27, 291(1992)
+
+        Args:
+            cutoff (integer): the cutoff of sigma values.
+            r_axis (list of three integers, e.g. u, v, w):
+                    the rotation axis of the grain boundary, with the format of [u,v,w].
+            c2_b2_a2_ratio (list of three integers, e.g. mu,lamda, mv):
+                    mu:lam:mv is the square of the orthorhombic axial ratio with rational
+                    numbers. If irrational for one axis, set it to None.
+                    e.g. mu:lam:mv = c2,None,a2, means b2 is irrational.
+        Returns:
+            sigmas (dict):
+                    dictionary with keys as the possible integer sigma values
+                    and values as list of the possible rotation angles to the
+                    corresponding sigma values.
+                    e.g. the format as
+                    {sigma1: [angle11,angle12,...], sigma2: [angle21, angle22,...],...}
+                    Note: the angles are the rotation angle of one grain respect to the
+                    other grain.
+                    When generate the microstructure of the grain boundary using these
+                    angles, you need to analyze the symmetry of the structure. Different
+                    angles may result in equivalent microstructures.
+
+        """
+        sigmas = {}
+        # make sure gcd(r_axis)==1
+        if reduce(gcd, r_axis) != 1:
+            r_axis = [int(round(x / reduce(gcd, r_axis))) for x in r_axis]
+
+        u, v, w = r_axis
+        # make sure mu, lambda, mv are coprime integers.
+        if None in c2_b2_a2_ratio:
+            mu, lam, mv = c2_b2_a2_ratio
+            non_none = [i for i in c2_b2_a2_ratio if i is not None]
+            if len(non_none) < 2:
+                raise RuntimeError('No CSL exist for two irrational numbers')
+            non1, non2 = non_none
+            if reduce(gcd, non_none) != 1:
+                temp = reduce(gcd, non_none)
+                non1 = int(round(non1 / temp))
+                non2 = int(round(non2 / temp))
+            if mu is None:
+                lam = non1
+                mv = non2
+                mu = 1
+                if w != 0:
+                    if u != 0 or (v != 0):
+                        raise RuntimeError('For irrational c2, CSL only exist for [0,0,1] '
+                                           'or [u,v,0] and m = 0')
+            elif lam is None:
+                mu = non1
+                mv = non2
+                lam = 1
+                if v != 0:
+                    if u != 0 or (w != 0):
+                        raise RuntimeError('For irrational b2, CSL only exist for [0,1,0] '
+                                           'or [u,0,w] and m = 0')
+            elif mv is None:
+                mu = non1
+                lam = non2
+                mv = 1
+                if u != 0:
+                    if w != 0 or (v != 0):
+                        raise RuntimeError('For irrational a2, CSL only exist for [1,0,0] '
+                                           'or [0,v,w] and m = 0')
+        else:
+            mu, lam, mv = c2_b2_a2_ratio
+            if reduce(gcd, c2_b2_a2_ratio) != 1:
+                temp = reduce(gcd, c2_b2_a2_ratio)
+                mu = int(round(mu / temp))
+                mv = int(round(mv / temp))
+                lam = int(round(lam / temp))
+            if u == 0 and v == 0:
+                mu = 1
+            if u == 0 and w == 0:
+                lam = 1
+            if v == 0 and w == 0:
+                mv = 1
+        # refer to the meaning of d in reference
+        d = (mv * u ** 2 + lam * v ** 2) * mv + w ** 2 * mu * mv
+
+        # Compute the max n we need to enumerate.
+        n_max = int(np.sqrt((cutoff * 4 * mu * mv * mv * lam) / d))
+        # Enumerate all possible n, m to give possible sigmas within the cutoff.
+        for n in range(1, n_max + 1):
+            mu_temp, lam_temp, mv_temp = c2_b2_a2_ratio
+            if (mu_temp is None and w == 0) or (lam_temp is None and v == 0) \
+                    or (mv_temp is None and u == 0):
+                m_max = 0
+            else:
+                m_max = int(np.sqrt((cutoff * 4 * mu * mv * lam * mv -
+                                     n ** 2 * d) / mu / lam))
+            for m in range(0, m_max + 1):
+
+                if gcd(m, n) == 1 or m == 0:
+                    # construct the rotation matrix, refer to the reference
+                    R_list = [(u ** 2 * mv * mv - lam * v ** 2 * mv -
+                               w ** 2 * mu * mv) * n ** 2 + lam * mu * m ** 2,
+                              2 * lam * (v * u * mv * n ** 2 - w * mu * m * n),
+                              2 * mu * (u * w * mv * n ** 2 + v * lam * m * n),
+                              2 * mv * (u * v * mv * n ** 2 + w * mu * m * n),
+                              (v ** 2 * mv * lam - u ** 2 * mv * mv -
+                               w ** 2 * mu * mv) * n ** 2 + lam * mu * m ** 2,
+                              2 * mv * mu * (v * w * n ** 2 - u * m * n),
+                              2 * mv * (u * w * mv * n ** 2 - v * lam * m * n),
+                              2 * lam * mv * (v * w * n ** 2 + u * m * n),
+                              (w ** 2 * mu * mv - u ** 2 * mv * mv -
+                               v ** 2 * mv * lam) * n ** 2 + lam * mu * m ** 2]
+                    m = -1 * m
+                    # inverse of rotation matrix
+                    R_list_inv = [(u ** 2 * mv * mv - lam * v ** 2 * mv -
+                                   w ** 2 * mu * mv) * n ** 2 + lam * mu * m ** 2,
+                                  2 * lam * (v * u * mv * n ** 2 - w * mu * m * n),
+                                  2 * mu * (u * w * mv * n ** 2 + v * lam * m * n),
+                                  2 * mv * (u * v * mv * n ** 2 + w * mu * m * n),
+                                  (v ** 2 * mv * lam - u ** 2 * mv * mv -
+                                   w ** 2 * mu * mv) * n ** 2 + lam * mu * m ** 2,
+                                  2 * mv * mu * (v * w * n ** 2 - u * m * n),
+                                  2 * mv * (u * w * mv * n ** 2 - v * lam * m * n),
+                                  2 * lam * mv * (v * w * n ** 2 + u * m * n),
+                                  (w ** 2 * mu * mv - u ** 2 * mv * mv -
+                                   v ** 2 * mv * lam) * n ** 2 + lam * mu * m ** 2]
+                    m = -1 * m
+                    F = mu * lam * m ** 2 + d * n ** 2
+                    all_list = R_list + R_list_inv + [F]
+                    # Compute the max common factors for the elements of the rotation matrix
+                    #  and its inverse.
+                    com_fac = reduce(gcd, all_list)
+                    sigma = int(round((mu * lam * m ** 2 + d * n ** 2) / com_fac))
+                    if (sigma <= cutoff) and (sigma > 1):
+                        if sigma not in list(sigmas.keys()):
+                            if m == 0:
+                                angle = 180.0
+                            else:
+                                angle = 2 * np.arctan(n / m * np.sqrt(d / mu / lam)) \
+                                        / np.pi * 180
+                            sigmas[sigma] = [angle]
+                        else:
+                            if m == 0:
+                                angle = 180.0
+                            else:
+                                angle = 2 * np.arctan(n / m * np.sqrt(d / mu / lam)) \
+                                        / np.pi * 180
+                            if angle not in sigmas[sigma]:
+                                sigmas[sigma].append(angle)
+            if m_max == 0:
+                break
+
+        return sigmas
+
+    @staticmethod
+    def get_trans_mat(r_axis, angle, normal=False, trans_cry=np.eye(3), lat_type='c',
+                      ratio=None, surface=None):
+        """
+        Find the two transformation matrix for each grain from given rotation axis,
+        GB plane, rotation angle and corresponding ratio (see explanation for ratio
+        below).
+        The structure of each grain can be obtained by applying the corresponding
+        transformation matrix to the conventional cell.
+        The algorithm for this code is from reference, Acta Cryst, A32,783(1976).
+
+        Args:
+            r_axis (list of three integers, e.g. u, v, w
+                    or four integers, e.g. u, v, t, w for hex/rho system only):
+                    the rotation axis of the grain boundary.
+            angle (float, in unit of degree) :
+                    the rotation angle of the grain boundary
+            normal (logic):
+                    determine if need to require the c axis of one grain associated with
+                    the first transformation matrix perperdicular to the surface or not.
+                    default to false.
+            trans_cry (3 by 3 array):
+                    if the structure given are primitive cell in cubic system, e.g.
+                    bcc or fcc system, trans_cry is the transformation matrix from its
+                    conventional cell to the primitive cell.
+            lat_type ( one character):
+                    'c' or 'C': cubic system
+                     't' or 'T': tetragonal system
+                     'o' or 'O': orthorhombic system
+                     'h' or 'H': hexagonal system
+                     'r' or 'R': rhombohedral system
+                     default to cubic system
+            ratio (list of integers):
+                    lattice axial ratio.
+                    For cubic system, ratio is not needed.
+                    For tetragonal system, ratio = [mu, mv], list of two integers,
+                    that is, mu/mv = c2/a2. If it is irrational, set it to none.
+                    For orthorhombic system, ratio = [mu, lam, mv], list of three integers,
+                    that is, mu:lam:mv = c2:b2:a2. If irrational for one axis, set it to None.
+                    e.g. mu:lam:mv = c2,None,a2, means b2 is irrational.
+                    For rhombohedral system, ratio = [mu, mv], list of two integers,
+                    that is, mu/mv is the ratio of (1+2*cos(alpha)/cos(alpha).
+                    If irrational, set it to None.
+                    For hexagonal system, ratio = [mu, mv], list of two integers,
+                    that is, mu/mv = c2/a2. If it is irrational, set it to none.
+            surface (list of three integers, e.g. h, k, l
+                     or four integers, e.g. h, k, i, l for hex/rho system only):
+                    the miller index of grain boundary plane, with the format of [h,k,l]
+                    if surface is not given, the default is perpendicular to r_axis, which is
+                    a twist grain boundary.
+
+        Returns:
+            t1 (3 by 3 integer array):
+                    The transformation array for one grain.
+            t2 (3 by 3 integer array):
+                    The transformation array for the other grain
+        """
+
+        # transform four index notation to three index notation
+        if len(r_axis) == 4:
+            u1, v1, t_temp, w1 = r_axis
+            if lat_type.lower() == 'h':
+                u = 2 * u1 + v1
+                v = 2 * v1 + u1
+                w = w1
+                r_axis = [u, v, w]
+            elif lat_type.lower() == 'r':
+                u = 2 * u1 + v1 + w1
+                v = v1 + w1 - u1
+                w = w1 - 2 * v1 - u1
+                r_axis = [u, v, w]
+
+        # make sure gcd(r_axis)==1
+        if reduce(gcd, r_axis) != 1:
+            r_axis = [int(round(x / reduce(gcd, r_axis))) for x in r_axis]
+
+        if surface is not None:
+            if len(surface) == 4:
+                u1, v1, t_temp, w1 = surface
+                surface = [u1, v1, w1]
+        # set the surface for grain boundary.
+        if surface is None:
+            if lat_type.lower() == 'c':
+                surface = r_axis
+            else:
+                if lat_type.lower() == 'h':
+                    if ratio is None:
+                        c2_a2_ratio = 1
+                    else:
+                        c2_a2_ratio = ratio[0] / ratio[1]
+                    metric = np.array([[1, -0.5, 0], [-0.5, 1, 0], [0, 0, c2_a2_ratio]])
+                elif lat_type.lower() == 'r':
+                    if ratio is None:
+                        cos_alpha = 0.5
+                    else:
+                        cos_alpha = 1.0 / (ratio[0] / ratio[1] - 2)
+                    metric = np.array([[1, cos_alpha, cos_alpha], [cos_alpha, 1, cos_alpha],
+                                       [cos_alpha, cos_alpha, 1]])
+                    print('metric', metric)
+                elif lat_type.lower() == 't':
+                    if ratio is None:
+                        c2_a2_ratio = 1
+                    else:
+                        c2_a2_ratio = ratio[0] / ratio[1]
+                    metric = np.array([[1, 0, 0], [0, 1, 0], [0, 0, c2_a2_ratio]])
+                elif lat_type.lower() == 'o':
+                    for i in range(3):
+                        if ratio[i] is None:
+                            ratio[i] = 1
+                    metric = np.array([[1, 0, 0], [0, ratio[1] / ratio[2], 0],
+                                       [0, 0, ratio[0] / ratio[2]]])
+                else:
+                    raise RuntimeError('Lattice type has not implemented.')
+
+                surface = np.matmul(r_axis, metric)
+                fractions = [Fraction(x).limit_denominator() for x in surface]
+                least_mul = reduce(lcm, [f.denominator for f in fractions])
+                surface = [int(round(x * least_mul)) for x in surface]
+
+        if reduce(gcd, surface) != 1:
+            index = reduce(gcd, surface)
+            surface = [int(round(x / index)) for x in surface]
+
+        if lat_type.lower() == 'h':
+            # set the value for u,v,w,mu,mv,m,n,d,x
+            # check the reference for the meaning of these parameters
+            u, v, w = r_axis
+            # make sure mu, mv are coprime integers.
+            if ratio is None:
+                mu, mv = [1, 1]
+                if w != 0:
+                    if u != 0 or (v != 0):
+                        raise RuntimeError('For irrational c2/a2, CSL only exist for [0,0,1] '
+                                           'or [u,v,0] and m = 0')
+            else:
+                mu, mv = ratio
+            if gcd(mu, mv) != 1:
+                temp = gcd(mu, mv)
+                mu = int(round(mu / temp))
+                mv = int(round(mv / temp))
+            d = (u ** 2 + v ** 2 - u * v) * mv + w ** 2 * mu
+            if abs(angle - 180.0) < 1.e-2:
+                m = 0
+                n = 1
+            else:
+                fraction = Fraction(np.tan(angle / 2 / 180.0 * np.pi) /
+                                    np.sqrt(float(d) / 3.0 / mu)).limit_denominator()
+                m = fraction.denominator
+                n = fraction.numerator
+
+            # construct the rotation matrix, check reference for details
+            r_list = [(u ** 2 * mv - v ** 2 * mv - w ** 2 * mu) * n ** 2 +
+                      2 * w * mu * m * n + 3 * mu * m ** 2,
+                      (2 * v - u) * u * mv * n ** 2 - 4 * w * mu * m * n,
+                      2 * u * w * mu * n ** 2 + 2 * (2 * v - u) * mu * m * n,
+                      (2 * u - v) * v * mv * n ** 2 + 4 * w * mu * m * n,
+                      (v ** 2 * mv - u ** 2 * mv - w ** 2 * mu) * n ** 2 -
+                      2 * w * mu * m * n + 3 * mu * m ** 2,
+                      2 * v * w * mu * n ** 2 - 2 * (2 * u - v) * mu * m * n,
+                      (2 * u - v) * w * mv * n ** 2 - 3 * v * mv * m * n,
+                      (2 * v - u) * w * mv * n ** 2 + 3 * u * mv * m * n,
+                      (w ** 2 * mu - u ** 2 * mv - v ** 2 * mv + u * v * mv) *
+                      n ** 2 + 3 * mu * m ** 2]
+            m = -1 * m
+            r_list_inv = [(u ** 2 * mv - v ** 2 * mv - w ** 2 * mu) * n ** 2 +
+                          2 * w * mu * m * n + 3 * mu * m ** 2,
+                          (2 * v - u) * u * mv * n ** 2 - 4 * w * mu * m * n,
+                          2 * u * w * mu * n ** 2 + 2 * (2 * v - u) * mu * m * n,
+                          (2 * u - v) * v * mv * n ** 2 + 4 * w * mu * m * n,
+                          (v ** 2 * mv - u ** 2 * mv - w ** 2 * mu) * n ** 2 -
+                          2 * w * mu * m * n + 3 * mu * m ** 2,
+                          2 * v * w * mu * n ** 2 - 2 * (2 * u - v) * mu * m * n,
+                          (2 * u - v) * w * mv * n ** 2 - 3 * v * mv * m * n,
+                          (2 * v - u) * w * mv * n ** 2 + 3 * u * mv * m * n,
+                          (w ** 2 * mu - u ** 2 * mv - v ** 2 * mv + u * v * mv) *
+                          n ** 2 + 3 * mu * m ** 2]
+            m = -1 * m
+            F = 3 * mu * m ** 2 + d * n ** 2
+            all_list = r_list + r_list_inv + [F]
+            com_fac = reduce(gcd, all_list)
+            sigma = F / com_fac
+            r_matrix = np.matrix(np.array(np.array(r_list) / com_fac
+                                          / sigma).reshape(3, 3))
+        elif lat_type.lower() == 'r':
+            # set the value for u,v,w,mu,mv,m,n,d
+            # check the reference for the meaning of these parameters
+            u, v, w = r_axis
+            # make sure mu, mv are coprime integers.
+            if ratio is None:
+                mu, mv = [1, 1]
+                if u + v + w != 0:
+                    if u != v or u != w:
+                        raise RuntimeError('For irrational ratio_alpha, CSL only exist for [1,1,1]'
+                                           'or [u, v, -(u+v)] and m =0')
+            else:
+                mu, mv = ratio
+            if gcd(mu, mv) != 1:
+                temp = gcd(mu, mv)
+                mu = int(round(mu / temp))
+                mv = int(round(mv / temp))
+            d = (u ** 2 + v ** 2 + w ** 2) * (mu - 2 * mv) + \
+                2 * mv * (v * w + w * u + u * v)
+            if abs(angle - 180.0) < 1.e-2:
+                m = 0
+                n = 1
+            else:
+                fraction = Fraction(np.tan(angle / 2 / 180.0 * np.pi) /
+                                    np.sqrt(float(d) / mu)).limit_denominator()
+                m = fraction.denominator
+                n = fraction.numerator
+
+            # construct the rotation matrix, check reference for details
+            r_list = [(mu - 2 * mv) * (u ** 2 - v ** 2 - w ** 2) * n ** 2 +
+                      2 * mv * (v - w) * m * n - 2 * mv * v * w * n ** 2 +
+                      mu * m ** 2,
+                      2 * (mv * u * n * (w * n + u * n - m) - (mu - mv) *
+                           m * w * n + (mu - 2 * mv) * u * v * n ** 2),
+                      2 * (mv * u * n * (v * n + u * n + m) + (mu - mv) *
+                           m * v * n + (mu - 2 * mv) * w * u * n ** 2),
+                      2 * (mv * v * n * (w * n + v * n + m) + (mu - mv) *
+                           m * w * n + (mu - 2 * mv) * u * v * n ** 2),
+                      (mu - 2 * mv) * (v ** 2 - w ** 2 - u ** 2) * n ** 2 +
+                      2 * mv * (w - u) * m * n - 2 * mv * u * w * n ** 2 +
+                      mu * m ** 2,
+                      2 * (mv * v * n * (v * n + u * n - m) - (mu - mv) *
+                           m * u * n + (mu - 2 * mv) * w * v * n ** 2),
+                      2 * (mv * w * n * (w * n + v * n - m) - (mu - mv) *
+                           m * v * n + (mu - 2 * mv) * w * u * n ** 2),
+                      2 * (mv * w * n * (w * n + u * n + m) + (mu - mv) *
+                           m * u * n + (mu - 2 * mv) * w * v * n ** 2),
+                      (mu - 2 * mv) * (w ** 2 - u ** 2 - v ** 2) * n ** 2 +
+                      2 * mv * (u - v) * m * n - 2 * mv * u * v * n ** 2 +
+                      mu * m ** 2]
+            m = -1 * m
+            r_list_inv = [(mu - 2 * mv) * (u ** 2 - v ** 2 - w ** 2) * n ** 2 +
+                          2 * mv * (v - w) * m * n - 2 * mv * v * w * n ** 2 +
+                          mu * m ** 2,
+                          2 * (mv * u * n * (w * n + u * n - m) - (mu - mv) *
+                               m * w * n + (mu - 2 * mv) * u * v * n ** 2),
+                          2 * (mv * u * n * (v * n + u * n + m) + (mu - mv) *
+                               m * v * n + (mu - 2 * mv) * w * u * n ** 2),
+                          2 * (mv * v * n * (w * n + v * n + m) + (mu - mv) *
+                               m * w * n + (mu - 2 * mv) * u * v * n ** 2),
+                          (mu - 2 * mv) * (v ** 2 - w ** 2 - u ** 2) * n ** 2 +
+                          2 * mv * (w - u) * m * n - 2 * mv * u * w * n ** 2 +
+                          mu * m ** 2,
+                          2 * (mv * v * n * (v * n + u * n - m) - (mu - mv) *
+                               m * u * n + (mu - 2 * mv) * w * v * n ** 2),
+                          2 * (mv * w * n * (w * n + v * n - m) - (mu - mv) *
+                               m * v * n + (mu - 2 * mv) * w * u * n ** 2),
+                          2 * (mv * w * n * (w * n + u * n + m) + (mu - mv) *
+                               m * u * n + (mu - 2 * mv) * w * v * n ** 2),
+                          (mu - 2 * mv) * (w ** 2 - u ** 2 - v ** 2) * n ** 2 +
+                          2 * mv * (u - v) * m * n - 2 * mv * u * v * n ** 2 +
+                          mu * m ** 2]
+            m = -1 * m
+            F = mu * m ** 2 + d * n ** 2
+            all_list = r_list_inv + r_list + [F]
+            com_fac = reduce(gcd, all_list)
+            sigma = F / com_fac
+            r_matrix = np.matrix(np.array(np.array(r_list) / com_fac
+                                          / sigma).reshape(3, 3))
+
+        else:
+            u, v, w = r_axis
+            if lat_type.lower() == 'c':
+                mu = 1
+                lam = 1
+                mv = 1
+            elif lat_type.lower() == 't':
+                if ratio is None:
+                    mu, mv = [1, 1]
+                    if w != 0:
+                        if u != 0 or (v != 0):
+                            raise RuntimeError('For irrational c2/a2, CSL only exist for [0,0,1] '
+                                               'or [u,v,0] and m = 0')
+                else:
+                    mu, mv = ratio
+                lam = mv
+            elif lat_type.lower() == 'o':
+                if None in ratio:
+                    mu, lam, mv = ratio
+                    non_none = [i for i in ratio if i is not None]
+                    if len(non_none) < 2:
+                        raise RuntimeError('No CSL exist for two irrational numbers')
+                    non1, non2 = non_none
+                    if mu is None:
+                        lam = non1
+                        mv = non2
+                        mu = 1
+                        if w != 0:
+                            if u != 0 or (v != 0):
+                                raise RuntimeError('For irrational c2, CSL only exist for [0,0,1] '
+                                                   'or [u,v,0] and m = 0')
+                    elif lam is None:
+                        mu = non1
+                        mv = non2
+                        lam = 1
+                        if v != 0:
+                            if u != 0 or (w != 0):
+                                raise RuntimeError('For irrational b2, CSL only exist for [0,1,0] '
+                                                   'or [u,0,w] and m = 0')
+                    elif mv is None:
+                        mu = non1
+                        lam = non2
+                        mv = 1
+                        if u != 0:
+                            if w != 0 or (v != 0):
+                                raise RuntimeError('For irrational a2, CSL only exist for [1,0,0] '
+                                                   'or [0,v,w] and m = 0')
+                else:
+                    mu, lam, mv = ratio
+                    if u == 0 and v == 0:
+                        mu = 1
+                    if u == 0 and w == 0:
+                        lam = 1
+                    if v == 0 and w == 0:
+                        mv = 1
+
+            # make sure mu, lambda, mv are coprime integers.
+            if reduce(gcd, [mu, lam, mv]) != 1:
+                temp = reduce(gcd, [mu, lam, mv])
+                mu = int(round(mu / temp))
+                mv = int(round(mv / temp))
+                lam = int(round(lam / temp))
+            d = (mv * u ** 2 + lam * v ** 2) * mv + w ** 2 * mu * mv
+            if abs(angle - 180.0) < 1.e-2:
+                m = 0
+                n = 1
+            else:
+                fraction = Fraction(np.tan(angle / 2 / 180.0 * np.pi) /
+                                    np.sqrt(d / mu / lam)).limit_denominator()
+                m = fraction.denominator
+                n = fraction.numerator
+            r_list = [(u ** 2 * mv * mv - lam * v ** 2 * mv -
+                       w ** 2 * mu * mv) * n ** 2 + lam * mu * m ** 2,
+                      2 * lam * (v * u * mv * n ** 2 - w * mu * m * n),
+                      2 * mu * (u * w * mv * n ** 2 + v * lam * m * n),
+                      2 * mv * (u * v * mv * n ** 2 + w * mu * m * n),
+                      (v ** 2 * mv * lam - u ** 2 * mv * mv -
+                       w ** 2 * mu * mv) * n ** 2 + lam * mu * m ** 2,
+                      2 * mv * mu * (v * w * n ** 2 - u * m * n),
+                      2 * mv * (u * w * mv * n ** 2 - v * lam * m * n),
+                      2 * lam * mv * (v * w * n ** 2 + u * m * n),
+                      (w ** 2 * mu * mv - u ** 2 * mv * mv -
+                       v ** 2 * mv * lam) * n ** 2 + lam * mu * m ** 2]
+            m = -1 * m
+            r_list_inv = [(u ** 2 * mv * mv - lam * v ** 2 * mv -
+                           w ** 2 * mu * mv) * n ** 2 + lam * mu * m ** 2,
+                          2 * lam * (v * u * mv * n ** 2 - w * mu * m * n),
+                          2 * mu * (u * w * mv * n ** 2 + v * lam * m * n),
+                          2 * mv * (u * v * mv * n ** 2 + w * mu * m * n),
+                          (v ** 2 * mv * lam - u ** 2 * mv * mv -
+                           w ** 2 * mu * mv) * n ** 2 + lam * mu * m ** 2,
+                          2 * mv * mu * (v * w * n ** 2 - u * m * n),
+                          2 * mv * (u * w * mv * n ** 2 - v * lam * m * n),
+                          2 * lam * mv * (v * w * n ** 2 + u * m * n),
+                          (w ** 2 * mu * mv - u ** 2 * mv * mv -
+                           v ** 2 * mv * lam) * n ** 2 + lam * mu * m ** 2]
+            m = -1 * m
+            F = mu * lam * m ** 2 + d * n ** 2
+            all_list = r_list + r_list_inv + [F]
+            com_fac = reduce(gcd, all_list)
+            sigma = F / com_fac
+            r_matrix = np.matrix(np.array(np.array(r_list) / com_fac
+                                          / sigma).reshape(3, 3))
+
+        if (sigma > 1000):
+            raise RuntimeError('Sigma >1000 too large. Are you sure what you are doing, '
+                               'Please check the GB if exist')
+        # transform surface, r_axis, r_matrix in terms of primitive lattice
+        surface = np.matmul(surface, np.transpose(trans_cry))
+        fractions = [Fraction(x).limit_denominator() for x in surface]
+        least_mul = reduce(lcm, [f.denominator for f in fractions])
+        surface = [int(round(x * least_mul)) for x in surface]
+        if reduce(gcd, surface) != 1:
+            index = reduce(gcd, surface)
+            surface = [int(round(x / index)) for x in surface]
+        r_axis = np.rint(np.matmul(r_axis, np.linalg.inv(trans_cry))).astype(int)
+        if reduce(gcd, r_axis) != 1:
+            r_axis = [int(round(x / reduce(gcd, r_axis))) for x in r_axis]
+        r_matrix = np.matrix(trans_cry).T.I * r_matrix * np.matrix(trans_cry).T
+
+        # set one vector of the basis to the rotation axis direction, and
+        # obtain the corresponding transform matrix
+        I_mat = np.matrix(np.identity(3))
+        for h in range(3):
+            if abs(r_axis[h]) != 0:
+                I_mat[h] = np.array(r_axis)
+                k = h + 1 if h + 1 < 3 else abs(2 - h)
+                l = h + 2 if h + 2 < 3 else abs(1 - h)
+                break
+        trans = I_mat.T
+        new_rot = np.array(r_matrix)
+
+        # with the rotation matrix to construct the CSL lattice, check reference for details
+        fractions = [Fraction(x).limit_denominator() for x in new_rot[:, k]]
+        least_mul = reduce(lcm, [f.denominator for f in fractions])
+        scale = np.zeros((3, 3))
+        scale[h, h] = 1
+        scale[k, k] = least_mul
+        scale[l, l] = sigma / least_mul
+        for i in range(least_mul):
+            check_int = i * new_rot[:, k] + (sigma / least_mul) * new_rot[:, l]
+            if all([np.round(x, 5).is_integer() for x in list(check_int)]):
+                n_final = i
+                break
+        try:
+            n_final
+        except NameError:
+            raise RuntimeError('Something is wrong. Check if this GB exists or not')
+        scale[k, l] = n_final
+        # each row of mat_csl is the CSL lattice vector
+        csl_init = np.rint(r_matrix * trans * np.matrix(scale)).astype(int).T
+        if abs(r_axis[h]) > 1:
+            csl_init = GBGenerator.reduce_mat(np.array(csl_init), r_axis[h])
+        csl = np.rint(Lattice(csl_init).get_niggli_reduced_lattice().matrix).astype(int)
+
+        # find the best slab supercell in terms of the conventional cell from the csl lattice,
+        # which is the transformation matrix
+
+        # now trans_cry is the transformation matrix from crystal to cartesian coordinates.
+        # for cubic, do not need to change.
+        if lat_type.lower() != 'c':
+            if lat_type.lower() == 'h':
+                trans_cry = np.array([[1, 0, 0], [-0.5, np.sqrt(3.0) / 2.0, 0],
+                                      [0, 0, np.sqrt(mu / mv)]])
+            elif lat_type.lower() == 'r':
+                if ratio is None:
+                    c2_a2_ratio = 1
+                else:
+                    c2_a2_ratio = 3.0 / (2 - 6 * mv / mu)
+                trans_cry = np.array([[0.5, np.sqrt(3.0) / 6.0, 1.0 / 3 * np.sqrt(c2_a2_ratio)],
+                                      [-0.5, np.sqrt(3.0) / 6.0, 1.0 / 3 * np.sqrt(c2_a2_ratio)],
+                                      [0, -1 * np.sqrt(3.0) / 3.0, 1.0 / 3 * np.sqrt(c2_a2_ratio)]])
+            else:
+                trans_cry = np.array([[1, 0, 0], [0, np.sqrt(lam / mv), 0], [0, 0, np.sqrt(mu / mv)]])
+        t1_final = GBGenerator.slab_from_csl(csl, surface, normal, trans_cry)
+        t2_final = np.array(np.rint(np.matrix(t1_final) * (r_matrix).T.I)).astype(int)
+        return t1_final, t2_final
+
+    @staticmethod
+    def get_rotation_angle_from_sigma(sigma, r_axis, lat_type='C', ratio=None):
+        """
+        Find all possible rotation angle for the given sigma value.
+
+        Args:
+            sigma (integer):
+                    sigma value provided
+            r_axis (list of three integers, e.g. u, v, w
+                    or four integers, e.g. u, v, t, w for hex/rho system only):
+                    the rotation axis of the grain boundary.
+            lat_type ( one character):
+                    'c' or 'C': cubic system
+                     't' or 'T': tetragonal system
+                     'o' or 'O': orthorhombic system
+                     'h' or 'H': hexagonal system
+                     'r' or 'R': rhombohedral system
+                     default to cubic system
+            ratio (list of integers):
+                    lattice axial ratio.
+                    For cubic system, ratio is not needed.
+                    For tetragonal system, ratio = [mu, mv], list of two integers,
+                    that is, mu/mv = c2/a2. If it is irrational, set it to none.
+                    For orthorhombic system, ratio = [mu, lam, mv], list of three integers,
+                    that is, mu:lam:mv = c2:b2:a2. If irrational for one axis, set it to None.
+                    e.g. mu:lam:mv = c2,None,a2, means b2 is irrational.
+                    For rhombohedral system, ratio = [mu, mv], list of two integers,
+                    that is, mu/mv is the ratio of (1+2*cos(alpha)/cos(alpha).
+                    If irrational, set it to None.
+                    For hexagonal system, ratio = [mu, mv], list of two integers,
+                    that is, mu/mv = c2/a2. If it is irrational, set it to none.
+
+        Returns:
+            rotation_angles corresponding to the provided sigma value.
+            If the sigma value is not correct, return the rotation angle corresponding
+            to the correct possible sigma value right smaller than the wrong sigma value provided.
+        """
+        if lat_type.lower() == 'c':
+            print('Make sure this is for cubic system')
+            sigma_dict = GBGenerator.enum_sigma_cubic(cutoff=sigma, r_axis=r_axis)
+        elif lat_type.lower() == 't':
+            print('Make sure this is for tetragonal system')
+            if ratio is None:
+                print('Make sure this is for irrational c2/a2 ratio')
+            elif len(ratio) != 2:
+                raise RuntimeError('Tetragonal system needs correct c2/a2 ratio')
+            sigma_dict = GBGenerator.enum_sigma_tet(cutoff=sigma, r_axis=r_axis, c2_a2_ratio=ratio)
+        elif lat_type.lower() == 'o':
+            print('Make sure this is for orthorhombic system')
+            if len(ratio) != 3:
+                raise RuntimeError('Orthorhombic system needs correct c2:b2:a2 ratio')
+            sigma_dict = GBGenerator.enum_sigma_ort(cutoff=sigma, r_axis=r_axis, c2_b2_a2_ratio=ratio)
+        elif lat_type.lower() == 'h':
+            print('Make sure this is for hexagonal system')
+            if ratio is None:
+                print('Make sure this is for irrational c2/a2 ratio')
+            elif len(ratio) != 2:
+                raise RuntimeError('Hexagonal system needs correct c2/a2 ratio')
+            sigma_dict = GBGenerator.enum_sigma_hex(cutoff=sigma, r_axis=r_axis, c2_a2_ratio=ratio)
+        elif lat_type.lower() == 'r':
+            print('Make sure this is for rhombohedral system')
+            if ratio is None:
+                print('Make sure this is for irrational (1+2*cos(alpha)/cos(alpha) ratio')
+            elif len(ratio) != 2:
+                raise RuntimeError('Rhombohedral system needs correct '
+                                   '(1+2*cos(alpha)/cos(alpha) ratio')
+            sigma_dict = GBGenerator.enum_sigma_rho(cutoff=sigma, r_axis=r_axis, ratio_alpha=ratio)
+        else:
+            raise RuntimeError('Lattice type not implemented')
+
+        sigmas = list(sigma_dict.keys())
+        if not sigmas:
+            print('This is a wriong sigma value, and no sigma exists smaller than this value.')
+            return None
+        if sigma in sigmas:
+            rotation_angles = sigma_dict[sigma]
+        else:
+            sigmas.sort()
+            print("This is not the possible sigma value according to the rotation axis!")
+            print("The possible sigma values that are smaller than the given "
+                  "sigma values include:", "\n", sigmas)
+            print("The nearest neighbor sigma is:", "\n", sigmas[-1],
+                  "and the corresponding angles are returned")
+            rotation_angles = sigma_dict[sigmas[-1]]
+        rotation_angles.sort()
+        return rotation_angles
+
+    @staticmethod
+    def slab_from_csl(csl, surface, normal, trans_cry):
+        """
+        By linear operation of csl lattice vectors to get the best corresponding
+        slab lattice. That is the area of a,b vectors (within the surface plane)
+        is the smallest, the c vector first, has shortest length perpendicular
+        to surface [h,k,l], second, has shortest length itself.
+
+        Args:
+            csl (3 by 3 integer array):
+                    input csl lattice.
+            surface (list of three integers, e.g. h, k, l):
+                    the miller index of the surface, with the format of [h,k,l]
+            normal (logic):
+                    determine if the c vector needs to perpendicular to surface
+            trans_cry (3 by 3 array):
+                    transform matrix from crystal system to orthogonal system
+            lat_type ( one character):
+                    'c' or 'C': cubic system
+                     't' or 'T': tetragonal system
+                     'o' or 'O': orthorhombic system
+                     'h' or 'H': hexagonal system
+                     'r' or 'R': rhombohedral system
+                     default to cubic system
+            ratio (list of integers):
+                    lattice axial ratio.
+                    For cubic system, ratio is not needed.
+                    For tetragonal system, ratio = [mu, mv], list of two integers,
+                    that is, mu/mv = c2/a2. If it is irrational, set it to none.
+                    For orthorhombic system, ratio = [mu, lam, mv], list of three integers,
+                    that is, mu:lam:mv = c2:b2:a2. If irrational for one axis, set it to None.
+                    e.g. mu:lam:mv = c2,None,a2, means b2 is irrational.
+                    For rhombohedral system, ratio = [mu, mv], list of two integers,
+                    that is, mu/mv is the ratio of (1+2*cos(alpha)/cos(alpha).
+                    If irrational, set it to None.
+                    For hexagonal system, ratio = [mu, mv], list of two integers,
+                    that is, mu/mv = c2/a2. If it is irrational, set it to none.
+
+        Returns:
+            t_matrix: a slab lattice ( 3 by 3 integer array):
+        """
+
+        # set the transform matrix in real space
+        trans = trans_cry
+        # transform matrix in reciprocal space
+        ctrans = np.array(np.matrix(trans).T.I)
+
+        t_matrix = csl.copy()
+        # vectors constructed from csl that perpendicular to surface
+        ab_vector = []
+        # obtain the miller index of surface in terms of csl.
+        miller = np.matmul(surface, csl.T)
+        if reduce(gcd, miller) != 1:
+            miller = [int(round(x / reduce(gcd, miller))) for x in miller]
+        miller_nonzero = []
+        for i, j in enumerate(miller):
+            if j == 0:
+                ab_vector.append(csl[i])
+            else:
+                c_index = i
+                miller_nonzero.append(j)
+
+        if len(miller_nonzero) > 1:
+            index_len = len(miller_nonzero)
+            lcm_miller = []
+            for i in range(index_len):
+                for j in range(i + 1, index_len):
+                    com_gcd = gcd(miller_nonzero[i], miller_nonzero[j])
+                    mil1 = int(round(miller_nonzero[i] / com_gcd))
+                    mil2 = int(round(miller_nonzero[j] / com_gcd))
+                    lcm_miller.append(max(abs(mil1), abs(mil2)))
+            lcm_sorted = sorted(lcm_miller)
+            if index_len == 2:
+                max_j = lcm_sorted[0]
+            else:
+                max_j = lcm_sorted[1]
+        else:
+            if not normal:
+                t_matrix[0] = ab_vector[0]
+                t_matrix[1] = ab_vector[1]
+                t_matrix[2] = csl[c_index]
+                return t_matrix
+            else:
+                max_j = abs(miller_nonzero[0])
+
+        # area of a, b vectors
+        area = None
+        # length of c vector
+        c_norm = None
+        for j1 in range(-max_j, max_j + 1):
+            for j2 in range(-max_j, max_j + 1):
+                for j3 in range(-max_j, max_j + 1):
+                    temp = j1 * csl[0] + j2 * csl[1] + j3 * csl[2]
+                    if abs(np.dot(temp, surface) - 0) < 1.e-8:
+                        if np.linalg.norm(np.matmul(temp, trans)) > 0:
+                            ab_vector.append(temp)
+                    else:
+                        # c vector length along the direction perpendicular to surface
+                        c_len_temp = np.abs(np.dot(temp, surface))
+                        # c vector length itself
+                        c_norm_temp = np.linalg.norm(np.matmul(temp, trans))
+                        if c_norm is None:
+                            c_norm = c_norm_temp
+                            c_length = c_len_temp
+                            # check if the init c vector perpendicular to the surface
+                            if normal:
+                                c_cross = np.cross(np.matmul(temp, trans), np.matmul(surface, ctrans))
+                                if np.linalg.norm(c_cross) < 1.e-8:
+                                    normal_init = True
+                                    t_matrix[2] = temp
+                                else:
+                                    normal_init = False
+                        elif normal:
+                            c_cross = np.cross(np.matmul(temp, trans), np.matmul(surface, ctrans))
+                            if np.linalg.norm(c_cross) < 1.e-8:
+                                if normal_init:
+                                    if c_norm_temp < c_norm:
+                                        t_matrix[2] = temp
+                                        c_norm = c_norm_temp
+                                else:
+                                    c_norm = c_norm_temp
+                                    normal_init = True
+                                    t_matrix[2] = temp
+                        else:
+                            if c_len_temp < c_length or \
+                                    (abs(c_len_temp - c_length) < 1.e-8 and c_norm_temp < c_norm):
+                                t_matrix[2] = temp
+                                c_norm = c_norm_temp
+                                c_length = c_len_temp
+
+        if normal and (not normal_init):
+            print('Warning: did not find the perpendicular c vector, increase max_j')
+            while (not normal_init):
+                max_j = 3 * max_j
+                c_norm = None
+                for j1 in range(-max_j, max_j + 1):
+                    for j2 in range(-max_j, max_j + 1):
+                        for j3 in range(-max_j, max_j + 1):
+                            temp = j1 * csl[0] + j2 * csl[1] + j3 * csl[2]
+                            if abs(np.dot(temp, surface) - 0) > 1.e-8:
+                                c_cross = np.cross(np.matmul(temp, trans), np.matmul(surface, ctrans))
+                                if np.linalg.norm(c_cross) < 1.e-8:
+                                    # c vetor length itself
+                                    c_norm_temp = np.linalg.norm(np.matmul(temp, trans))
+                                    if c_norm is None:
+                                        c_norm = c_norm_temp
+                                        normal_init = True
+                                        t_matrix[2] = temp
+                                    elif c_norm_temp < c_norm:
+                                        t_matrix[2] = temp
+                                        c_norm = c_norm_temp
+
+        # find the best a, b vectors with their formed area smallest and average norm of a,b smallest.
+        for i in range(len(ab_vector)):
+            for j in range(i + 1, len(ab_vector)):
+                area_temp = np.linalg.norm(np.cross(np.matmul(ab_vector[i], trans),
+                                                    np.matmul(ab_vector[j], trans)))
+                if abs(area_temp - 0) > 1.e-8:
+                    ab_norm_temp = np.linalg.norm(np.matmul(ab_vector[i], trans)) + \
+                                   np.linalg.norm(np.matmul(ab_vector[j], trans))
+                    if area is None:
+                        area = area_temp
+                        ab_norm = ab_norm_temp
+                        t_matrix[0] = ab_vector[i]
+                        t_matrix[1] = ab_vector[j]
+                    elif area_temp < area:
+                        t_matrix[0] = ab_vector[i]
+                        t_matrix[1] = ab_vector[j]
+                        area = area_temp
+                        ab_norm = ab_norm_temp
+                    elif abs(area - area_temp) < 1.e-8 and ab_norm_temp < ab_norm:
+                        t_matrix[0] = ab_vector[i]
+                        t_matrix[1] = ab_vector[j]
+                        area = area_temp
+                        ab_norm = ab_norm_temp
+        # make sure we have a left-handed crystallographic system
+        if np.linalg.det(np.matmul(t_matrix, trans)) < 0:
+            t_matrix *= -1
+        return t_matrix
+
+    @staticmethod
+    def reduce_mat(mat, mag):
+        """
+        Reduce integer array mat's determinant mag times by linear combination
+        of its row vectors
+
+        Args:
+            mat (3 by 3 array): input matrix
+            mag (integer): reduce times for the determinant
+        Return:
+            the reduced integer array
+        """
+        max_j = abs(int(round(np.linalg.det(mat) / mag)))
+        reduced = False
+        for h in range(3):
+            k = h + 1 if h + 1 < 3 else abs(2 - h)
+            l = h + 2 if h + 2 < 3 else abs(1 - h)
+            for j1 in range(-max_j, max_j + 1):
+                for j2 in range(-max_j, max_j + 1):
+                    temp = mat[h] + j1 * mat[k] + j2 * mat[l]
+                    if all([np.round(x, 5).is_integer() for x in list(temp / mag)]):
+                        mat[h] = np.array([int(round(ele / mag)) for ele in temp])
+                        reduced = True
+                        break
+                if reduced:
+                    break
+            if reduced:
+                break
+
+        if not reduced:
+            print('Warning: Matrix reduction not performed.')
+        return mat
+
+
+def factors(n):
+    """
+    Compute the factors of a integer.
+    Args:
+        n: the input integer
+
+    Returns:
+        a set of integers that are the factors of the input integer.
+    """
+    return set(reduce(list.__add__,
+                      ([i, n // i] for i in range(1, int(np.sqrt(n)) + 1) if n % i == 0)))
+
+
+def fix_pbc(structure, matrix=None):
+    """
+    Set all frac_coords of the input structure within [0,1].
+
+    Args:
+        structure (pymatgen structure object):
+            input structure
+        matrix (lattice matrix, 3 by 3 array/matrix)
+            new structure's lattice matrix, if none, use
+            input structure's matrix
+
+    Return:
+        new structure with fixed frac_coords and lattice matrix
+    """
+
+    spec = []
+    coords = []
+    if matrix is None:
+        latte = Lattice(structure.lattice.matrix)
+    else:
+        latte = Lattice(matrix)
+
+    for site in structure:
+        spec.append(site.specie)
+        coord = site.frac_coords
+        for i in range(3):
+            coord[i] -= floor(coord[i])
+            if np.allclose(coord[i], 1):
+                coord[i] = 0
+            elif np.allclose(coord[i], 0):
+                coord[i] = 0
+            else:
+                coord[i] = round(coord[i], 7)
+        coords.append(coord)
+
+    return Structure(latte, spec, coords)

--- a/pymatgen/core/grain_boundary_generator.py
+++ b/pymatgen/core/grain_boundary_generator.py
@@ -17,6 +17,7 @@ __maintainer__ = "Xiang-Guo Li"
 __email__ = "xil110@ucsd.edu"
 __date__ = "7/10/18"
 
+
 class GBGenerator(object):
     """
     This class provides two methods to generate grain boundaries (GBs) from bulk
@@ -227,13 +228,17 @@ class GBGenerator(object):
 
         # construct the coords, move top grain with translation_v
         all_coords = []
+        grain_labels = []
         for site in bottom_grain:
             all_coords.append(site.coords)
+            grain_labels.append('bottom_grain')
         for site in top_grain:
             all_coords.append(site.coords + half_lattice.matrix[2] + translation_v)
+            grain_labels.append('top_grain')
 
         gb_with_vac = Structure(whole_lat, all_species, all_coords,
-                                coords_are_cartesian=True)
+                                coords_are_cartesian=True,
+                                site_properties={'grain_label': grain_labels})
 
         return gb_with_vac
 

--- a/pymatgen/core/tests/test_grain_boundary_generator.py
+++ b/pymatgen/core/tests/test_grain_boundary_generator.py
@@ -9,7 +9,7 @@ import unittest
 import os
 import numpy as np
 from pymatgen import Structure
-from pymacy.grain_boundary.grain_boundary_generator import GBGenerator
+from pymatgen.core.grain_boundary_generator import GBGenerator
 
 test_dir = os.path.join(os.path.dirname(__file__), "..", "..", "..",
                         "test_files", "grain_boundary")
@@ -212,6 +212,7 @@ class Test_grain_boundary_generator(unittest.TestCase):
                                                surface=[21, 20, 10], normal=True)
         self.assertAlmostEqual(np.dot(mat1[0], [21, 20, 10]), 0)
         self.assertAlmostEqual(np.dot(mat1[1], [21, 20, 10]), 0)
+        self.assertAlmostEqual(np.linalg.det(mat1), np.linalg.det(mat2))
         ab_len1 = np.linalg.norm(np.cross(mat1[2], [1, 1, 1]))
         self.assertAlmostEqual(ab_len1, 0)
 

--- a/pymatgen/core/tests/test_grain_boundary_generator.py
+++ b/pymatgen/core/tests/test_grain_boundary_generator.py
@@ -6,6 +6,7 @@ __email__ = 'xil110@eng.ucsd.edu'
 __date__ = '05/18/18'
 
 import unittest
+from pymatgen.util.testing import PymatgenTest
 import os
 import numpy as np
 from pymatgen import Structure
@@ -15,7 +16,7 @@ test_dir = os.path.join(os.path.dirname(__file__), "..", "..", "..",
                         "test_files", "grain_boundary")
 
 
-class Test_grain_boundary_generator(unittest.TestCase):
+class Test_grain_boundary_generator(PymatgenTest):
     @classmethod
     def setUpClass(cls):
         cls.Cu_prim = Structure.from_file(os.path.join(test_dir, "Cu_mp-30_primitive.cif"))
@@ -219,7 +220,7 @@ class Test_grain_boundary_generator(unittest.TestCase):
     def test_get_rotation_angle_from_sigma(self):
         true_angle = [12.680383491819821, 167.3196165081802]
         angle = GBGenerator.get_rotation_angle_from_sigma(41, [1, 0, 0], lat_type='o', ratio=[270, 30, 29])
-        np.testing.assert_almost_equal(true_angle, angle)
+        self.assertArrayAlmostEqual(true_angle, angle)
         close_angle = [36.86989764584403, 143.13010235415598]
         angle = GBGenerator.get_rotation_angle_from_sigma(6, [1, 0, 0], lat_type='o', ratio=[270, 30, 29])
-        np.testing.assert_almost_equal(close_angle, angle)
+        self.assertArrayAlmostEqual(close_angle, angle)

--- a/pymatgen/core/tests/test_grain_boundary_generator.py
+++ b/pymatgen/core/tests/test_grain_boundary_generator.py
@@ -1,0 +1,224 @@
+from __future__ import division, unicode_literals
+
+__author__ = 'Xiang-Guo Li'
+__copyright__ = 'Copyright 2018, The Materials Virtual Lab'
+__email__ = 'xil110@eng.ucsd.edu'
+__date__ = '05/18/18'
+
+import unittest
+import os
+import numpy as np
+from pymatgen import Structure
+from pymacy.grain_boundary.grain_boundary_generator import GBGenerator
+
+test_dir = os.path.join(os.path.dirname(__file__), "..", "..", "..",
+                        "test_files", "grain_boundary")
+
+
+class Test_grain_boundary_generator(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.Cu_prim = Structure.from_file(os.path.join(test_dir, "Cu_mp-30_primitive.cif"))
+        cls.GB_Cu_prim = GBGenerator(cls.Cu_prim)
+        cls.Cu_conv = Structure.from_file(os.path.join(test_dir,
+                                                       "Cu_mp-30_conventional_standard.cif"))
+        cls.GB_Cu_conv = GBGenerator(cls.Cu_conv)
+        cls.Be = Structure.from_file(os.path.join(test_dir,
+                                                  "Be_mp-87_conventional_standard.cif"))
+        cls.GB_Be = GBGenerator(cls.Be)
+        cls.Pa = Structure.from_file(os.path.join(test_dir,
+                                                  "Pa_mp-62_conventional_standard.cif"))
+        cls.GB_Pa = GBGenerator(cls.Pa)
+        cls.Br = Structure.from_file(os.path.join(test_dir,
+                                                  "Br_mp-23154_conventional_standard.cif"))
+        cls.GB_Br = GBGenerator(cls.Br)
+        cls.Bi = Structure.from_file(os.path.join(test_dir,
+                                                  "Bi_mp-23152_primitive.cif"))
+        cls.GB_Bi = GBGenerator(cls.Bi)
+
+    def test_gb_from_parameters(self):
+        # from fcc primitive cell,axis[1,2,3],sigma 9.
+        gb_cu_123_prim1 = self.GB_Cu_prim.gb_from_parameters([1, 2, 3],
+                                                             123.74898859588858,
+                                                             expand_times=2)
+        lat_mat1 = gb_cu_123_prim1.lattice.matrix
+        c_vec1 = np.cross(lat_mat1[0], lat_mat1[1]) / np.linalg.norm(np.cross(lat_mat1[0], lat_mat1[1]))
+        c_len1 = np.dot(lat_mat1[2], c_vec1)
+        vol_ratio = gb_cu_123_prim1.volume / self.Cu_prim.volume
+        self.assertAlmostEqual(vol_ratio, 9 * 2 * 2, 8)
+        # test expand_times
+        gb_cu_123_prim2 = self.GB_Cu_prim.gb_from_parameters([1, 2, 3],
+                                                             123.74898859588858,
+                                                             expand_times=4)
+        lat_mat2 = gb_cu_123_prim2.lattice.matrix
+        c_vec2 = np.cross(lat_mat2[0], lat_mat2[1]) / np.linalg.norm(np.cross(lat_mat2[0], lat_mat2[1]))
+        c_len2 = np.dot(lat_mat2[2], c_vec2)
+        self.assertAlmostEqual(c_len2 / c_len1, 2)
+        # test vacuum layer
+        gb_cu_123_prim3 = self.GB_Cu_prim.gb_from_parameters([1, 2, 3],
+                                                             123.74898859588858,
+                                                             expand_times=4,
+                                                             vacuum_thickness=1.5)
+        lat_mat3 = gb_cu_123_prim3.lattice.matrix
+        c_vec3 = np.cross(lat_mat3[0], lat_mat3[1]) / np.linalg.norm(np.cross(lat_mat3[0], lat_mat3[1]))
+        c_len3 = np.dot(lat_mat3[2], c_vec3)
+        self.assertAlmostEqual(c_len3 - c_len2, 1.5 * 2)
+
+        # from fcc conventional cell,axis [1,2,3], siamg 9
+        gb_cu_123_conv1 = self.GB_Cu_conv.gb_from_parameters([1, 2, 3],
+                                                             123.74898859588858,
+                                                             expand_times=4,
+                                                             vacuum_thickness=1.5)
+        lat_mat1 = gb_cu_123_conv1.lattice.matrix
+        self.assertAlmostEqual(np.dot(lat_mat1[0], [1, 2, 3]), 0)
+        self.assertAlmostEqual(np.dot(lat_mat1[1], [1, 2, 3]), 0)
+        # test normal
+        gb_cu_123_conv2 = self.GB_Cu_conv.gb_from_parameters([1, 2, 3],
+                                                             123.74898859588858,
+                                                             expand_times=4,
+                                                             vacuum_thickness=1.5,
+                                                             normal=True)
+        lat_mat2 = gb_cu_123_conv2.lattice.matrix
+        c_vec2 = np.cross(lat_mat2[0], lat_mat2[1]) / np.linalg.norm(np.cross(lat_mat2[0], lat_mat2[1]))
+        ab_len2 = np.linalg.norm(np.cross(lat_mat2[2], c_vec2))
+        self.assertAlmostEqual(ab_len2, 0)
+        # test plane
+        gb_cu_123_conv3 = self.GB_Cu_conv.gb_from_parameters([1, 2, 3],
+                                                             123.74898859588858,
+                                                             expand_times=4,
+                                                             vacuum_thickness=1.5,
+                                                             plane=[1, 3, 1])
+        lat_mat3 = gb_cu_123_conv3.lattice.matrix
+        self.assertAlmostEqual(np.dot(lat_mat3[0], [1, 3, 1]), 0)
+        self.assertAlmostEqual(np.dot(lat_mat3[1], [1, 3, 1]), 0)
+
+        # from hex cell,axis [1,1,1], sigma 21
+        gb_Be_111_1 = self.GB_Be.gb_from_parameters([1, 1, 1],
+                                                    128.246619878345,
+                                                    ratio=[12, 5],
+                                                    expand_times=4,
+                                                    vacuum_thickness=1.5,
+                                                    plane=[1, 2, 1])
+        lat_priv = self.Be.lattice.matrix
+        lat_mat1 = np.matmul(gb_Be_111_1.lattice.matrix, np.linalg.inv(lat_priv))
+        self.assertAlmostEqual(np.dot(lat_mat1[0], [1, 2, 1]), 0)
+        self.assertAlmostEqual(np.dot(lat_mat1[1], [1, 2, 1]), 0)
+        # test volume associated with sigma value
+        gb_Be_111_2 = self.GB_Be.gb_from_parameters([1, 1, 1], 128.246619878345, ratio=[12, 5],
+                                                    expand_times=4)
+        vol_ratio = gb_Be_111_2.volume / self.Be.volume
+        self.assertAlmostEqual(vol_ratio, 21 * 2 * 4)
+        # test ratio = None, axis [0,0,1], sigma 7
+        gb_Be_111_3 = self.GB_Be.gb_from_parameters([0, 0, 1], 21.786789298261812,
+                                                    ratio=[12, 5],
+                                                    expand_times=4)
+        gb_Be_111_4 = self.GB_Be.gb_from_parameters([0, 0, 1], 21.786789298261812, ratio=None,
+                                                    expand_times=4)
+        self.assertTupleEqual(gb_Be_111_3.lattice.abc, gb_Be_111_4.lattice.abc)
+        self.assertTupleEqual(gb_Be_111_3.lattice.angles, gb_Be_111_4.lattice.angles)
+        gb_Be_111_5 = self.GB_Be.gb_from_parameters([3, 1, 0], 180.0, ratio=[12, 5],
+                                                    expand_times=4)
+        ouc_supercell_gb_Be_111_6 = self.GB_Be.gb_from_parameters([3, 1, 0], 180.0, ratio=None,
+                                                                  expand_times=4)
+        gb_Be_111_6 = ouc_supercell_gb_Be_111_6[2]
+        self.assertTupleEqual(gb_Be_111_5.lattice.abc, gb_Be_111_6.lattice.abc)
+        self.assertTupleEqual(gb_Be_111_5.lattice.angles, gb_Be_111_6.lattice.angles)
+
+        # gb from tetragonal cell, axis[1,1,1], sigma 15
+        gb_Pa_111_1 = self.GB_Pa.gb_from_parameters([1, 1, 1], 86.17744627072565, ratio=[4, 5],
+                                                    expand_times=4)
+        vol_ratio = gb_Pa_111_1.volume / self.Pa.volume
+        self.assertAlmostEqual(vol_ratio, 15 * 2 * 4)
+
+        # gb from orthorhombic cell, axis[1,1,1], sigma 93
+        gb_Br_111_1 = self.GB_Br.gb_from_parameters([1, 1, 1], 95.55344419565849,
+                                                    ratio=[10, 20, 21],
+                                                    expand_times=4)
+        vol_ratio = gb_Br_111_1.volume / self.Br.volume
+        self.assertAlmostEqual(vol_ratio, 93 * 2 * 4)
+
+        # gb from rhombohedra cell, axis[1,2,0], sigma 81
+        gb_Bi_120_1 = self.GB_Bi.gb_from_parameters([1, 2, 0], 63.612200038756995,
+                                                    ratio=[39, 10],
+                                                    expand_times=4)
+        vol_ratio = gb_Bi_120_1.volume / self.Bi.volume
+        self.assertAlmostEqual(vol_ratio, 81 * 2 * 4)
+
+    def test_gb_from_matrices(self):
+        mat1 = np.array([[30, -11, -41], [20, 3, -48], [-7, -1, 17]])
+        mat2 = np.array([[10, -31, 41], [20, -31, 20], [-7, 11, -7]])
+        gb_Br_111_1 = self.GB_Br.gb_from_matrices(mat1, mat2, expand_times=4,
+                                                  vacuum_thickness=3)
+        lat_conv = self.Br.lattice.matrix
+        lat_mat1 = np.rint(np.matmul(gb_Br_111_1.lattice.matrix, np.linalg.inv(lat_conv))).astype(int)
+        self.assertListEqual(list(lat_mat1[0]), list(mat1[0]))
+        self.assertListEqual(list(lat_mat1[1]), list(mat1[1]))
+
+    def test_enum_sigma_cubic(self):
+        true_100 = [5, 13, 17, 25, 29, 37, 41]
+        true_110 = [3, 9, 11, 17, 19, 27, 33, 41, 43]
+        true_111 = [3, 7, 13, 19, 21, 31, 37, 39, 43, 49]
+        sigma_100 = list(GBGenerator.enum_sigma_cubic(50, [1, 0, 0]).keys())
+        sigma_110 = list(GBGenerator.enum_sigma_cubic(50, [1, 1, 0]).keys())
+        sigma_111 = list(GBGenerator.enum_sigma_cubic(50, [1, 1, 1]).keys())
+        sigma_222 = list(GBGenerator.enum_sigma_cubic(50, [2, 2, 2]).keys())
+        sigma_888 = list(GBGenerator.enum_sigma_cubic(50, [8, 8, 8]).keys())
+
+        self.assertListEqual(sorted(true_100), sorted(sigma_100))
+        self.assertListEqual(sorted(true_110), sorted(sigma_110))
+        self.assertListEqual(sorted(true_111), sorted(sigma_111))
+        self.assertListEqual(sorted(true_111), sorted(sigma_222))
+        self.assertListEqual(sorted(true_111), sorted(sigma_888))
+
+    def test_enum_sigma_hex(self):
+        true_100 = [17, 18, 22, 27, 38, 41]
+        true_001 = [7, 13, 19, 31, 37, 43, 49]
+        true_210 = [10, 11, 14, 25, 35, 49]
+        sigma_100 = list(GBGenerator.enum_sigma_hex(50, [1, 0, 0], [8, 3]).keys())
+        sigma_001 = list(GBGenerator.enum_sigma_hex(50, [0, 0, 1], [8, 3]).keys())
+        sigma_210 = list(GBGenerator.enum_sigma_hex(50, [2, 1, 0], [8, 3]).keys())
+        sigma_420 = list(GBGenerator.enum_sigma_hex(50, [4, 2, 0], [8, 3]).keys())
+        sigma_840 = list(GBGenerator.enum_sigma_hex(50, [8, 4, 0], [8, 3]).keys())
+
+        self.assertListEqual(sorted(true_100), sorted(sigma_100))
+        self.assertListEqual(sorted(true_001), sorted(sigma_001))
+        self.assertListEqual(sorted(true_210), sorted(sigma_210))
+        self.assertListEqual(sorted(true_210), sorted(sigma_420))
+        self.assertListEqual(sorted(true_210), sorted(sigma_840))
+
+    def test_enum_sigma_tet(self):
+        true_100 = [5, 37, 41, 13, 3, 15, 39, 25, 17, 29]
+        true_331 = [9, 3, 21, 39, 7, 31, 43, 13, 19, 37, 49]
+        sigma_100 = list(GBGenerator.enum_sigma_tet(50, [1, 0, 0], [9, 1]).keys())
+        sigma_331 = list(GBGenerator.enum_sigma_tet(50, [3, 3, 1], [9, 1]).keys())
+
+        self.assertListEqual(sorted(true_100), sorted(sigma_100))
+        self.assertListEqual(sorted(true_331), sorted(sigma_331))
+
+    def test_enum_sigma_ort(self):
+        true_100 = [41, 37, 39, 5, 15, 17, 13, 3, 25, 29]
+        sigma_100 = list(GBGenerator.enum_sigma_ort(50, [1, 0, 0], [270, 30, 29]).keys())
+
+        self.assertListEqual(sorted(true_100), sorted(sigma_100))
+
+    def test_enum_sigma_rho(self):
+        true_100 = [7, 11, 43, 13, 41, 19, 47, 31]
+        sigma_100 = list(GBGenerator.enum_sigma_rho(50, [1, 0, 0], [15, 4]).keys())
+
+        self.assertListEqual(sorted(true_100), sorted(sigma_100))
+
+    def test_get_trans_mat(self):
+        mat1, mat2 = GBGenerator.get_trans_mat([1, 1, 1], 95.55344419565849, lat_type='o', ratio=[10, 20, 21],
+                                               surface=[21, 20, 10], normal=True)
+        self.assertAlmostEqual(np.dot(mat1[0], [21, 20, 10]), 0)
+        self.assertAlmostEqual(np.dot(mat1[1], [21, 20, 10]), 0)
+        ab_len1 = np.linalg.norm(np.cross(mat1[2], [1, 1, 1]))
+        self.assertAlmostEqual(ab_len1, 0)
+
+    def test_get_rotation_angle_from_sigma(self):
+        true_angle = [12.680383491819821, 167.3196165081802]
+        angle = GBGenerator.get_rotation_angle_from_sigma(41, [1, 0, 0], lat_type='o', ratio=[270, 30, 29])
+        np.testing.assert_almost_equal(true_angle, angle)
+        close_angle = [36.86989764584403, 143.13010235415598]
+        angle = GBGenerator.get_rotation_angle_from_sigma(6, [1, 0, 0], lat_type='o', ratio=[270, 30, 29])
+        np.testing.assert_almost_equal(close_angle, angle)

--- a/pymatgen/core/tests/test_grain_boundary_generator.py
+++ b/pymatgen/core/tests/test_grain_boundary_generator.py
@@ -5,7 +5,6 @@ __copyright__ = 'Copyright 2018, The Materials Virtual Lab'
 __email__ = 'xil110@eng.ucsd.edu'
 __date__ = '05/18/18'
 
-import unittest
 from pymatgen.util.testing import PymatgenTest
 import os
 import numpy as np

--- a/test_files/grain_boundary/Be_mp-87_conventional_standard.cif
+++ b/test_files/grain_boundary/Be_mp-87_conventional_standard.cif
@@ -1,0 +1,28 @@
+# generated using pymatgen
+data_Be
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.27983889
+_cell_length_b   2.27983889
+_cell_length_c   3.52777283
+_cell_angle_alpha   90.00000000
+_cell_angle_beta   90.00000000
+_cell_angle_gamma   120.00000000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   Be
+_chemical_formula_sum   Be2
+_cell_volume   15.8795999213
+_cell_formula_units_Z   2
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  Be  Be1  1  0.333333  0.666667  0.750000  1
+  Be  Be2  1  0.666667  0.333333  0.250000  1

--- a/test_files/grain_boundary/Bi_mp-23152_primitive.cif
+++ b/test_files/grain_boundary/Bi_mp-23152_primitive.cif
@@ -1,0 +1,28 @@
+# generated using pymatgen
+data_Bi
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.79829946
+_cell_length_b   4.79829946
+_cell_length_c   4.79829946
+_cell_angle_alpha   57.26305593
+_cell_angle_beta   57.26305593
+_cell_angle_gamma   57.26305593
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   Bi
+_chemical_formula_sum   Bi2
+_cell_volume   73.1939584902
+_cell_formula_units_Z   2
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  Bi  Bi1  1  0.765615  0.765615  0.765615  1
+  Bi  Bi2  1  0.234385  0.234385  0.234385  1

--- a/test_files/grain_boundary/Br_mp-23154_conventional_standard.cif
+++ b/test_files/grain_boundary/Br_mp-23154_conventional_standard.cif
@@ -1,0 +1,34 @@
+# generated using pymatgen
+data_Br
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.25864728
+_cell_length_b   8.45219038
+_cell_length_c   8.74379641
+_cell_angle_alpha   90.00000000
+_cell_angle_beta   90.00000000
+_cell_angle_gamma   90.00000000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   Br
+_chemical_formula_sum   Br8
+_cell_volume   314.732056167
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  Br  Br1  1  0.857527  0.000000  0.617751  1
+  Br  Br2  1  0.142473  0.000000  0.382249  1
+  Br  Br3  1  0.642473  0.000000  0.117751  1
+  Br  Br4  1  0.357527  0.000000  0.882249  1
+  Br  Br5  1  0.357527  0.500000  0.617751  1
+  Br  Br6  1  0.642473  0.500000  0.382249  1
+  Br  Br7  1  0.142473  0.500000  0.117751  1
+  Br  Br8  1  0.857527  0.500000  0.882249  1

--- a/test_files/grain_boundary/Cu_mp-30_conventional_standard.cif
+++ b/test_files/grain_boundary/Cu_mp-30_conventional_standard.cif
@@ -1,0 +1,30 @@
+# generated using pymatgen
+data_Cu
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.61640724
+_cell_length_b   3.61640724
+_cell_length_c   3.61640724
+_cell_angle_alpha   90.00000000
+_cell_angle_beta   90.00000000
+_cell_angle_gamma   90.00000000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   Cu
+_chemical_formula_sum   Cu4
+_cell_volume   47.2968251068
+_cell_formula_units_Z   4
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  Cu  Cu1  1  0.000000  0.000000  0.000000  1
+  Cu  Cu2  1  0.000000  0.500000  0.500000  1
+  Cu  Cu3  1  0.500000  0.000000  0.500000  1
+  Cu  Cu4  1  0.500000  0.500000  0.000000  1

--- a/test_files/grain_boundary/Cu_mp-30_primitive.cif
+++ b/test_files/grain_boundary/Cu_mp-30_primitive.cif
@@ -1,0 +1,27 @@
+# generated using pymatgen
+data_Cu
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.55718608
+_cell_length_b   2.55718608
+_cell_length_c   2.55718608
+_cell_angle_alpha   60.00000000
+_cell_angle_beta   60.00000000
+_cell_angle_gamma   60.00000000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   Cu
+_chemical_formula_sum   Cu1
+_cell_volume   11.8242062767
+_cell_formula_units_Z   1
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  Cu  Cu1  1  0.000000  0.000000  0.000000  1

--- a/test_files/grain_boundary/Pa_mp-62_conventional_standard.cif
+++ b/test_files/grain_boundary/Pa_mp-62_conventional_standard.cif
@@ -1,0 +1,28 @@
+# generated using pymatgen
+data_Pa
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.93092144
+_cell_length_b   3.93092144
+_cell_length_c   3.19113993
+_cell_angle_alpha   90.00000000
+_cell_angle_beta   90.00000000
+_cell_angle_gamma   90.00000000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   Pa
+_chemical_formula_sum   Pa2
+_cell_volume   49.3099515892
+_cell_formula_units_Z   2
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  Pa  Pa1  1  0.000000  0.000000  0.000000  1
+  Pa  Pa2  1  0.500000  0.500000  0.500000  1


### PR DESCRIPTION
## Summary

This generator provides two methods to generate grain boundaries (GBs) from bulk conventional cell (fcc, bcc can from the primitive cell), and works for Cubic, Tetragonal, Orthorhombic, Rhombohedral, and Hexagonal systems. The first one is to generate GBs from given parameters, which includes
GB plane, rotation axis, rotation angle. The second one is to generate GBs from given transformation matrices for each grain. It works for any general GB, including both twist, tilt GBs, etc.

It also contains functions that can generate all possible sigma values and from sigma value to generate rotation angles needed for the GB generator.