### PR TITLE
add get_fermi_interextrapolated method to FermiDos

### DIFF
--- a/pymatgen/electronic_structure/dos.py
+++ b/pymatgen/electronic_structure/dos.py
@@ -5,6 +5,7 @@
 from __future__ import division, unicode_literals
 import numpy as np
 import six
+import warnings
 from monty.json import MSONable
 from pymatgen.electronic_structure.core import Spin, Orbital
 from pymatgen.core.periodic_table import get_el_sp
@@ -454,7 +455,11 @@ class FermiDos(Dos):
         self.idx_cbm = np.argmin(abs(self.energies - ecbm))
         self.A_to_cm = 1e-8
         if bandgap:
-            idx_fermi = np.argmin(abs(self.energies - self.efermi))
+            if self.efermi < ecbm and self.efermi > evbm:
+                eref = self.efermi
+            else:
+                eref = (evbm + ecbm) / 2.0
+            idx_fermi = np.argmin(abs(self.energies - eref))
             self.energies[:idx_fermi] -= (bandgap - (ecbm - evbm)) / 2.0
             self.energies[idx_fermi:] += (bandgap - (ecbm - evbm)) / 2.0
 
@@ -478,6 +483,48 @@ class FermiDos(Dos):
                              * (1-f0(self.energies[:self.idx_vbm+1], fermi, T))\
                              * self.de[:self.idx_vbm + 1],axis=0)
         return (vb_integral-cb_integral) / (self.volume*self.A_to_cm**3)
+
+    def get_fermi_interextrapolated(self, c, T, warn=True, c_ref=1e10, **kwargs):
+        """
+        Similar to get_fermi except that when get_fermi fails to converge,
+        an interpolated or extrapolated fermi (depending on c) is returned with
+        the assumption that the fermi level changes linearly with log(abs(c)).
+
+        Args:
+            c (float): doping concentration in 1/cm3. c<0 represents n-type
+                doping and c>0 p-type doping (i.e. majority carriers are holes)
+            T (float): absolute temperature in Kelvin
+            warn (bool): whether to warn for the first time when no fermi can
+                be found.
+            c_ref (float): a doping concentration where get_fermi returns a
+                value without error for both c_ref and -c_ref
+            **kwargs: see keyword arguments of the get_fermi function
+
+        Returns (float): the fermi level that is possibly interapolated or
+            extrapolated and must be used with caution.
+        """
+        try:
+            return self.get_fermi(c, T, **kwargs)
+        except ValueError as e:
+            if warn:
+                warnings.warn(str(e))
+            if abs(c) < c_ref:
+                if abs(c) < 1e-10:
+                    c = 1e-10
+                # max(10, ) is to avoid log(0<x<1) and log(1+x) both of which are slow
+                f2 = self.get_fermi_interextrapolated(max(10, abs(c)*10.), T, warn=False, **kwargs)
+                f1  = self.get_fermi_interextrapolated(-max(10, abs(c)*10.), T, warn=False, **kwargs)
+                c2 = np.log(abs(1+self.get_doping(f2, T)))
+                c1 = -np.log(abs(1+self.get_doping(f1, T)))
+                slope = (f2-f1)/(c2-c1)
+                return f2 + slope * (np.sign(c)*np.log(abs(1+c)) - c2)
+            else:
+                f_ref = self.get_fermi_interextrapolated(np.sign(c)*c_ref, T, warn=False, **kwargs)
+                f_new = self.get_fermi_interextrapolated(c/10., T, warn=False, **kwargs)
+                clog = np.sign(c)*np.log(abs(c))
+                c_newlog = np.sign(c)*np.log(abs(self.get_doping(f_new, T)))
+                slope = (f_new - f_ref) / (c_newlog - np.sign(c)*10.)
+                return f_new + slope * (clog - c_newlog)
 
     def get_fermi(self, c, T, rtol=0.01, nstep=50, step=0.1, precision=8):
         """

--- a/pymatgen/electronic_structure/tests/test_dos.py
+++ b/pymatgen/electronic_structure/tests/test_dos.py
@@ -76,6 +76,12 @@ class FermiDosTest(unittest.TestCase):
                 self.assertAlmostEqual(
                     sci_dos.get_fermi(c_ref, T=T) - frange[i], -0.47, places=2)
 
+        self.assertAlmostEqual(sci_dos.get_fermi_interextrapolated(-1e26, 300),
+                               7.5108, 4)
+        self.assertAlmostEqual(sci_dos.get_fermi_interextrapolated(1e26, 300),
+                               -1.6884, 4)
+        self.assertAlmostEqual(sci_dos.get_fermi_interextrapolated(0.0, 300),
+                               3.2382, 4)
 
 class CompleteDosTest(unittest.TestCase):
 


### PR DESCRIPTION
## Summary

when the value of doping concentration, c, is too low or too high, the get_fermi method may not converge in which case it raises error which is expected. To support a wider range of c even for a coarse CompleteDos with an energy range that is not wide enough, get_fermi_interextrapolated is introduced that supports c=0 or c=1e26 or c=-1e24, etc (all in 1/cm3).