### PR TITLE
Pourbaix patch 1

### DIFF
--- a/pymatgen/analysis/pourbaix_diagram.py
+++ b/pymatgen/analysis/pourbaix_diagram.py
@@ -434,7 +434,6 @@ class PourbaixDiagram(object):
             entries_HO = [ComputedEntry('H', 0), ComputedEntry('O', 2.46)]
             solid_pd = PhaseDiagram(solid_entries + entries_HO)
             solid_entries = list(set(solid_pd.stable_entries) - set(entries_HO))
-            # import nose; nose.tools.set_trace()
 
         if len(comp_dict) > 1:
             self._multielement = True
@@ -604,7 +603,6 @@ class PourbaixDiagram(object):
                          for indices in ConvexHull(points).simplices]
             pourbaix_domains[entry] = simplices
             pourbaix_domain_vertices[entry] = points
-        # import nose; nose.tools.set_trace()
 
         return pourbaix_domains, pourbaix_domain_vertices
 

--- a/pymatgen/analysis/pourbaix_diagram.py
+++ b/pymatgen/analysis/pourbaix_diagram.py
@@ -485,7 +485,7 @@ class PourbaixDiagram(object):
         return processed_entries
 
     @staticmethod
-    def process_multientry(entry_list, prod_comp):
+    def process_multientry(entry_list, prod_comp, coeff_threshold=1e-4):
         """
         Static method for finding a multientry based on
         a list of entries and a product composition.
@@ -497,8 +497,11 @@ class PourbaixDiagram(object):
         Args:
             entry_list ([Entry]): list of entries from which to
                 create a MultiEntry
-            comp (Composition): composition constraint for setting
+            prod_comp (Composition): composition constraint for setting
                 weights of MultiEntry
+            coeff_threshold (float): threshold of stoichiometric
+                coefficients to filter, if weights are lower than
+                this value, the entry is not returned
         """
         dummy_oh = [Composition("H"), Composition("O")]
         try:
@@ -508,11 +511,12 @@ class PourbaixDiagram(object):
             # their charge state.
             entry_comps = [e.composition for e in entry_list]
             rxn = Reaction(entry_comps + dummy_oh, [prod_comp])
-            thresh = np.array([pe.concentration if pe.phase_type == "Ion"
-                               else 1e-3 for pe in entry_list])
+            # thresh = np.array([pe.concentration if pe.phase_type == "Ion"
+            #                    else 1e-3 for pe in entry_list])
             coeffs = -np.array([rxn.get_coeff(comp) for comp in entry_comps])
-            if (coeffs > thresh).all():
-                # import nose; nose.tools.set_trace()
+            # Return None if reaction coeff threshold is not met
+            # TODO: this filtration step might be put somewhere else
+            if (coeffs > coeff_threshold).all():
                 return MultiEntry(entry_list, weights=coeffs.tolist())
             else:
                 return None

--- a/pymatgen/analysis/pourbaix_diagram.py
+++ b/pymatgen/analysis/pourbaix_diagram.py
@@ -510,8 +510,6 @@ class PourbaixDiagram(object):
             # their charge state.
             entry_comps = [e.composition for e in entry_list]
             rxn = Reaction(entry_comps + dummy_oh, [prod_comp])
-            # thresh = np.array([pe.concentration if pe.phase_type == "Ion"
-            #                    else 1e-3 for pe in entry_list])
             coeffs = -np.array([rxn.get_coeff(comp) for comp in entry_comps])
             # Return None if reaction coeff threshold is not met
             # TODO: this filtration step might be put somewhere else

--- a/pymatgen/analysis/tests/test_pourbaix_diagram.py
+++ b/pymatgen/analysis/tests/test_pourbaix_diagram.py
@@ -109,6 +109,14 @@ class PourbaixDiagramTest(unittest.TestCase):
                          {"Zn(HO)2(aq)", "Zn[2+]", "ZnHO2[-]", "ZnO2[2-]", "Zn(s)"})
 
     def test_multicomponent(self):
+        # Assure no ions get filtered at high concentration
+        ag_n = [e for e in self.test_data['Ag-Te-N']
+                if not "Te" in e.composition]
+        highconc = PourbaixDiagram(ag_n, filter_solids=True,
+                                   conc_dict={"Ag": 1e-5, "N": 1})
+        entry_sets = [set(e.entry_id) for e in highconc.stable_entries]
+        self.assertIn({"mp-124", "ion-17"}, entry_sets)
+
         # Binary system
         pd_binary = PourbaixDiagram(self.test_data['Ag-Te'], filter_solids=True,
                                     comp_dict={"Ag": 0.5, "Te": 0.5},


### PR DESCRIPTION
A legacy portion of the pourbaix code filtered ion-including MultiEntries from pourbaix diagrams when their reaction coefficients were lower than their attached concentration attribute, which I can't think of a good reason to do.  This resulted in pourbaix diagrams with high ion concentrations (e. g. > 0.5) filtering out ion entries.

* Changes pourbaix processing of multi-entries to filter ion entries based on reaction coefficient weights that are fixed, rather than concentration-based.
* Adds associated unit test to ensure that high concentration ion entries are not filtered arbitrarily