### PR TITLE
Add GrainBoundaryTransformation and test in advanced_transformations

### DIFF
--- a/pymatgen/analysis/gb/gb.py
+++ b/pymatgen/analysis/gb/gb.py
@@ -14,8 +14,8 @@ from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 
 import logging
 
-#This module implements representations of grain boundaries, as well as
-#algorithms for generating them. 
+# This module implements representations of grain boundaries, as well as
+# algorithms for generating them.
 
 __author__ = "Xiang-Guo Li"
 __copyright__ = "Copyright 2018, The Materials Virtual Lab"
@@ -113,6 +113,26 @@ class Gb(Structure):
             optionally sanitized.
         """
         return Gb(self.lattice, self.species_and_occu, self.frac_coords,
+                  self.rotation_axis, self.rotation_angle, self.gb_plane,
+                  self.init_cell, self.vacuum_thickness, self.ab_shift,
+                  self.site_properties, self.oriented_unit_cell)
+
+    def get_sorted_structure(self, key=None, reverse=False):
+        """
+        Get a sorted copy of the structure. The parameters have the same
+        meaning as in list.sort. By default, sites are sorted by the
+        electronegativity of the species. Note that Slab has to override this
+        because of the different __init__ args.
+        Args:
+            key: Specifies a function of one argument that is used to extract
+                a comparison key from each list element: key=str.lower. The
+                default value is None (compare the elements directly).
+            reverse (bool): If set to True, then the list elements are sorted
+                as if each comparison were reversed.
+        """
+        sites = sorted(self, key=key, reverse=reverse)
+        s = Structure.from_sites(sites)
+        return Gb(s.lattice, s.species_and_occu, s.frac_coords,
                   self.rotation_axis, self.rotation_angle, self.gb_plane,
                   self.init_cell, self.vacuum_thickness, self.ab_shift,
                   self.site_properties, self.oriented_unit_cell)

--- a/pymatgen/analysis/gb/test/test_gb.py
+++ b/pymatgen/analysis/gb/test/test_gb.py
@@ -9,7 +9,7 @@ from pymatgen.util.testing import PymatgenTest
 import os
 import numpy as np
 from pymatgen import Structure
-from pymatgen.io.gb.gb import Gb, GBGenerator
+from pymatgen.analysis.gb.gb import Gb, GBGenerator
 
 test_dir = os.path.join(os.path.dirname(__file__), "..", "..", "..", "..",
                         "test_files", "grain_boundary")

--- a/pymatgen/transformations/advanced_transformations.py
+++ b/pymatgen/transformations/advanced_transformations.py
@@ -37,7 +37,7 @@ from pymatgen.analysis.energy_models import SymmetryModel
 from pymatgen.analysis.bond_valence import BVAnalyzer
 from pymatgen.core.surface import SlabGenerator
 from pymatgen.electronic_structure.core import Spin
-from pymatgen.analysis.gb.gb import Gb, GBGenerator
+from pymatgen.analysis.gb.gb import GBGenerator
 
 """
 This module implements more advanced transformations.

--- a/pymatgen/transformations/advanced_transformations.py
+++ b/pymatgen/transformations/advanced_transformations.py
@@ -6,6 +6,7 @@ from __future__ import division, unicode_literals
 
 import numpy as np
 from fractions import Fraction
+
 try:
     from math import gcd
 except ImportError:
@@ -36,6 +37,7 @@ from pymatgen.analysis.energy_models import SymmetryModel
 from pymatgen.analysis.bond_valence import BVAnalyzer
 from pymatgen.core.surface import SlabGenerator
 from pymatgen.electronic_structure.core import Spin
+from pymatgen.analysis.gb.gb import Gb, GBGenerator
 
 """
 This module implements more advanced transformations.
@@ -47,7 +49,6 @@ __version__ = "1.0"
 __maintainer__ = "Shyue Ping Ong"
 __email__ = "shyuep@gmail.com"
 __date__ = "Jul 24, 2012"
-
 
 logger = logging.getLogger(__name__)
 
@@ -61,6 +62,7 @@ class ChargeBalanceTransformation(AbstractTransformation):
         charge_balance_sp: specie to add or remove. Currently only removal
             is supported
     """
+
     def __init__(self, charge_balance_sp):
         self.charge_balance_sp = str(charge_balance_sp)
 
@@ -353,7 +355,7 @@ class EnumerateStructureTransformation(AbstractTransformation):
                     "Too many disordered sites! ({} > {})".format(
                         ndisordered, self.max_disordered_sites))
             max_cell_sizes = range(self.min_cell_size, int(
-                    math.floor(self.max_disordered_sites / ndisordered)) + 1)
+                math.floor(self.max_disordered_sites / ndisordered)) + 1)
 
         else:
             max_cell_sizes = [self.max_cell_size]
@@ -459,7 +461,7 @@ class SubstitutionPredictorTransformation(AbstractTransformation):
             output = {'structure': st.apply_transformation(structure),
                       'probability': pred['probability'],
                       'threshold': self.threshold, 'substitutions': {}}
-            
+
             # dictionary keys have to be converted to strings for JSON
             for key, value in pred['substitutions'].items():
                 output['substitutions'][str(key)] = str(value)
@@ -482,7 +484,6 @@ class SubstitutionPredictorTransformation(AbstractTransformation):
 
 
 class MagOrderParameterConstraint(MSONable):
-
     def __init__(self, order_parameter,
                  species_constraints=None,
                  site_constraint_name=None,
@@ -508,7 +509,7 @@ class MagOrderParameterConstraint(MSONable):
         # validation
         if site_constraints and site_constraints != [None] \
                 and not site_constraint_name:
-                raise ValueError("Specify the name of the site constraint.")
+            raise ValueError("Specify the name of the site constraint.")
         elif not site_constraints and site_constraint_name:
             raise ValueError("Please specify some site constraints.")
         if not isinstance(species_constraints, list):
@@ -553,7 +554,6 @@ class MagOrderParameterConstraint(MSONable):
 
 
 class MagOrderingTransformation(AbstractTransformation):
-
     def __init__(self, mag_species_spin, order_parameter=0.5,
                  energy_model=SymmetryModel(), **kwargs):
         """
@@ -664,16 +664,17 @@ class MagOrderingTransformation(AbstractTransformation):
             subscript_length = 1
             while True:
                 for subscript in product(ascii_lowercase, repeat=subscript_length):
-                    yield "Mm"+"".join(subscript)
+                    yield "Mm" + "".join(subscript)
                 subscript_length += 1
+
         dummy_species_gen = generate_dummy_specie()
 
         # one dummy species for each order parameter constraint
         dummy_species_symbols = [next(dummy_species_gen) for i in range(len(order_parameters))]
         dummy_species = [{
-            DummySpecie(symbol, properties={'spin': Spin.up}): constraint.order_parameter,
-            DummySpecie(symbol, properties={'spin': Spin.down}): 1-constraint.order_parameter
-        } for symbol, constraint in zip(dummy_species_symbols, order_parameters)]
+                             DummySpecie(symbol, properties={'spin': Spin.up}): constraint.order_parameter,
+                             DummySpecie(symbol, properties={'spin': Spin.down}): 1 - constraint.order_parameter
+                         } for symbol, constraint in zip(dummy_species_symbols, order_parameters)]
 
         sites_to_add = []
 
@@ -712,7 +713,7 @@ class MagOrderingTransformation(AbstractTransformation):
                 spin = site.specie._properties.get('spin', None)
                 neighbors = structure.get_neighbors(
                     site,
-                    0.05, # arbitrary threshold, needs to be << any bond length
+                    0.05,  # arbitrary threshold, needs to be << any bond length
                     # but >> floating point precision issues
                     include_index=True
                 )
@@ -749,7 +750,7 @@ class MagOrderingTransformation(AbstractTransformation):
                     # but have different spins, and this is comma-delimited
                     sp = str(site.specie).split(",")[0]
                     new_properties.update({
-                        'spin': sign*self.mag_species_spin.get(sp, 0)
+                        'spin': sign * self.mag_species_spin.get(sp, 0)
                     })
                     new_specie = Specie(site.specie.symbol,
                                         getattr(site.specie, 'oxi_state', None),
@@ -884,7 +885,7 @@ def _find_codopant(target, oxidation_state, allowed_elements=None):
                     candidates.append((r, sp))
         except:
             pass
-    return min(candidates, key=lambda l: abs(l[0]/ref_radius - 1))[1]
+    return min(candidates, key=lambda l: abs(l[0] / ref_radius - 1))[1]
 
 
 class DopingTransformation(AbstractTransformation):
@@ -976,7 +977,7 @@ class DopingTransformation(AbstractTransformation):
         logger.info("Compatible species: %s" % compatible_species)
 
         lengths = structure.lattice.abc
-        scaling = [max(1, int(round(math.ceil(self.min_length/x))))
+        scaling = [max(1, int(round(math.ceil(self.min_length / x))))
                    for x in lengths]
         logger.info("Lengths are %s" % str(lengths))
         logger.info("Scaling = %s" % str(scaling))
@@ -988,8 +989,8 @@ class DopingTransformation(AbstractTransformation):
             supercell = structure * scaling
             nsp = supercell.composition[sp]
             if sp.oxi_state == ox:
-                supercell.replace_species({sp: {sp: (nsp - 1)/nsp,
-                                                self.dopant: 1/nsp}})
+                supercell.replace_species({sp: {sp: (nsp - 1) / nsp,
+                                                self.dopant: 1 / nsp}})
                 logger.info("Doping %s for %s at level %.3f" % (
                     sp, self.dopant, 1 / nsp))
             elif self.codopant:
@@ -1006,7 +1007,7 @@ class DopingTransformation(AbstractTransformation):
                 # vacancy compensation species as it is likely to be lower in
                 # energy
                 sp_to_remove = min([s for s in comp if s.oxi_state * ox > 0],
-                                    key=lambda ss: abs(ss.oxi_state))
+                                   key=lambda ss: abs(ss.oxi_state))
 
                 if sp_to_remove == sp:
                     common_charge = lcm(int(abs(sp.oxi_state)), int(abs(ox)))
@@ -1056,7 +1057,7 @@ class DopingTransformation(AbstractTransformation):
                 supercell.replace_species(
                     {sp: {sp: (nsp - ndopant) / nsp,
                           self.dopant: ndopant / nsp},
-                     sp_to_remove: {sp_to_remove: (nx - nx_to_remove)/nx}})
+                     sp_to_remove: {sp_to_remove: (nx - nx_to_remove) / nx}})
 
             ss = t.apply_transformation(
                 supercell, return_ranked_list=self.max_structures_per_enum)
@@ -1083,6 +1084,7 @@ class SlabTransformation(AbstractTransformation):
     A transformation that creates a slab from a structure.
 
     """
+
     def __init__(self, miller_index, min_slab_size, min_vacuum_size,
                  lll_reduce=False, center_slab=False,
                  in_unit_planes=False, primitive=True,
@@ -1119,6 +1121,99 @@ class SlabTransformation(AbstractTransformation):
                            self.primitive, self.max_normal_search)
         slab = sg.get_slab(self.shift, self.tol)
         return slab
+
+    @property
+    def inverse(self):
+        return None
+
+    @property
+    def is_one_to_many(self):
+        return None
+
+
+class GrainBoundaryTransformation(AbstractTransformation):
+    """
+    A transformation that creates a gb from a bulk structure.
+    """
+
+    def __init__(self, rotation_axis, rotation_angle, expand_times=4, vacuum_thickness=0.0,
+                 ab_shift=[0, 0], normal=False, ratio=None, plane=None, max_search=50,
+                 tol_coi=1.e-3):
+        """
+        Args:
+            rotation_axis (list): Rotation axis of GB in the form of a list of integer
+                e.g.: [1, 1, 0]
+            rotation_angle (float, in unit of degree): rotation angle used to generate GB.
+                Make sure the angle is accurate enough. You can use the enum* functions
+                in this class to extract the accurate angle.
+                e.g.: The rotation angle of sigma 3 twist GB with the rotation axis
+                [1, 1, 1] and GB plane (1, 1, 1) can be 60.000000000 degree.
+                If you do not know the rotation angle, but know the sigma value, we have
+                provide the function get_rotation_angle_from_sigma which is able to return
+                all the rotation angles of sigma value you provided.
+            expand_times (int): The multiple times used to expand one unit grain to larger grain.
+                This is used to tune the grain length of GB to warrant that the two GBs in one
+                cell do not interact with each other. Default set to 4.
+            vacuum_thickness (float): The thickness of vacuum that you want to insert between
+                two grains of the GB. Default to 0.
+            ab_shift (list of float, in unit of a, b vectors of Gb): in plane shift of two grains
+            normal (logic):
+                determine if need to require the c axis of top grain (first transformation matrix)
+                perperdicular to the surface or not.
+                default to false.
+            ratio (list of integers):
+                    lattice axial ratio.
+                    For cubic system, ratio is not needed.
+                    For tetragonal system, ratio = [mu, mv], list of two integers,
+                    that is, mu/mv = c2/a2. If it is irrational, set it to none.
+                    For orthorhombic system, ratio = [mu, lam, mv], list of three integers,
+                    that is, mu:lam:mv = c2:b2:a2. If irrational for one axis, set it to None.
+                    e.g. mu:lam:mv = c2,None,a2, means b2 is irrational.
+                    For rhombohedral system, ratio = [mu, mv], list of two integers,
+                    that is, mu/mv is the ratio of (1+2*cos(alpha))/cos(alpha).
+                    If irrational, set it to None.
+                    For hexagonal system, ratio = [mu, mv], list of two integers,
+                    that is, mu/mv = c2/a2. If it is irrational, set it to none.
+            plane (list): Grain boundary plane in the form of a list of integers
+                e.g.: [1, 2, 3]. If none, we set it as twist GB. The plane will be perpendicular
+                to the rotation axis.
+            max_search (int): max search for the GB lattice vectors that give the smallest GB
+                lattice. If normal is true, also max search the GB c vector that perpendicular
+                to the plane. For complex GB, if you want to speed up, you can reduce this value.
+                But too small of this value may lead to error.
+            tol_coi (float): tolerance to find the coincidence sites. When making approximations to
+                the ratio needed to generate the GB, you probably need to increase this tolerance to
+                obtain the correct number of coincidence sites. To check the number of coincidence
+                sites are correct or not, you can compare the generated Gb object's sigma with enum*
+                sigma values (what user expected by input).
+        Returns:
+           Grain boundary structure (Gb (Structure) object).
+        """
+        self.rotation_axis = rotation_axis
+        self.rotation_angle = rotation_angle
+        self.expand_times = expand_times
+        self.vacuum_thickness = vacuum_thickness
+        self.ab_shift = ab_shift
+        self.normal = normal
+        self.ratio = ratio
+        self.plane = plane
+        self.max_search = max_search
+        self.tol_coi = tol_coi
+
+    def apply_transformation(self, structure):
+        gbg = GBGenerator(structure)
+        gb_struct = gbg.gb_from_parameters(
+            self.rotation_axis,
+            self.rotation_angle,
+            self.expand_times,
+            self.vacuum_thickness,
+            self.ab_shift,
+            self.normal,
+            self.ratio,
+            self.plane,
+            self.max_search,
+            self.tol_coi)
+        return gb_struct
 
     @property
     def inverse(self):

--- a/pymatgen/transformations/tests/test_advanced_transformations.py
+++ b/pymatgen/transformations/tests/test_advanced_transformations.py
@@ -24,7 +24,7 @@ from pymatgen.io.vasp.inputs import Poscar
 from pymatgen.io.cif import CifParser
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.analysis.energy_models import IsingModel
-from pymatgen.analysis.gb.gb import Gb, GBGenerator
+from pymatgen.analysis.gb.gb import GBGenerator
 from pymatgen.util.testing import PymatgenTest
 from pymatgen.core.surface import SlabGenerator
 

--- a/pymatgen/transformations/tests/test_advanced_transformations.py
+++ b/pymatgen/transformations/tests/test_advanced_transformations.py
@@ -24,6 +24,7 @@ from pymatgen.io.vasp.inputs import Poscar
 from pymatgen.io.cif import CifParser
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.analysis.energy_models import IsingModel
+from pymatgen.analysis.gb.gb import Gb, GBGenerator
 from pymatgen.util.testing import PymatgenTest
 from pymatgen.core.surface import SlabGenerator
 
@@ -574,6 +575,23 @@ class SlabTransformationTest(PymatgenTest):
         self.assertArrayAlmostEqual(slab_from_gen.cart_coords, 
                                     slab_from_trans.cart_coords)
 
+from pymatgen.transformations.advanced_transformations import GrainBoundaryTransformation
+
+class GrainBoundaryTransformationTest(PymatgenTest):
+    def test_apply_transformation(self):
+        Li_bulk = Structure.from_spacegroup("Im-3m", Lattice.cubic(2.96771),
+                                            ["Li"], [[0, 0, 0]])
+        gb_gen_params_s3 = {"rotation_axis": [1, 1, 1], "rotation_angle": 60.0,
+                            "expand_times": 2, "vacuum_thickness": 0.0, "normal": True,
+                            "ratio": None, "plane": None}
+        gbg = GBGenerator(Li_bulk)
+        gb_from_generator = gbg.gb_from_parameters(**gb_gen_params_s3)
+        gbt_s3 = GrainBoundaryTransformation(**gb_gen_params_s3)
+        gb_from_trans = gbt_s3.apply_transformation(Li_bulk)
+        self.assertArrayAlmostEqual(gb_from_generator.lattice.matrix,
+                                    gb_from_trans.lattice.matrix)
+        self.assertArrayAlmostEqual(gb_from_generator.cart_coords,
+                                    gb_from_trans.cart_coords)
 
 if __name__ == "__main__":
     import logging


### PR DESCRIPTION
## Summary

GrainBoundaryTransformation is used to generate grain boundary structure, which will be used in atomate grain boundary workflow.