### PR TITLE
Improved performance of dumps parsing

### DIFF
--- a/pymatgen/io/lammps/outputs.py
+++ b/pymatgen/io/lammps/outputs.py
@@ -120,10 +120,15 @@ def parse_lammps_dumps(file_pattern):
 
     for fname in files:
         with zopen(fname, "rt") as f:
-            run = f.read()
-        dumps = run.split("ITEM: TIMESTEP")[1:]
-        for d in dumps:
-            yield LammpsDump.from_string(d)
+            dump_cache = []
+            for line in f:
+                if line.startswith("ITEM: TIMESTEP"):
+                    if len(dump_cache) > 0:
+                        yield LammpsDump.from_string("".join(dump_cache))
+                    dump_cache = [line]
+                else:
+                    dump_cache.append(line)
+            yield LammpsDump.from_string("".join(dump_cache))
 
 
 def parse_lammps_log(filename="log.lammps"):

--- a/pymatgen/io/lammps/tests/test_outputs.py
+++ b/pymatgen/io/lammps/tests/test_outputs.py
@@ -67,18 +67,19 @@ class LammpsDumpTest(unittest.TestCase):
 
 class FuncTest(unittest.TestCase):
 
-    @staticmethod
-    def test_parse_lammps_dumps():
+    def test_parse_lammps_dumps(self):
         # gzipped
         rdx_10_pattern = os.path.join(test_dir, "dump.rdx.gz")
         rdx_10 = list(parse_lammps_dumps(file_pattern=rdx_10_pattern))
         timesteps_10 = [d.timestep for d in rdx_10]
         np.testing.assert_array_equal(timesteps_10, np.arange(0, 101, 10))
+        self.assertTupleEqual(rdx_10[-1].data.shape, (21, 5))
         # wildcard
         rdx_25_pattern = os.path.join(test_dir, "dump.rdx_wc.*")
         rdx_25 = list(parse_lammps_dumps(file_pattern=rdx_25_pattern))
         timesteps_25 = [d.timestep for d in rdx_25]
         np.testing.assert_array_equal(timesteps_25, np.arange(0, 101, 25))
+        self.assertTupleEqual(rdx_25[-1].data.shape, (21, 5))
 
     def test_parse_lammps_log(self):
         comb_file = "log.5Oct16.comb.Si.elastic.g++.1"


### PR DESCRIPTION
## Summary

A memory friendly version of dump parser, reading a file line by line instead of reading the entire file into memory. Computers used to hang when dealing with GB size file, now parsing can be done in a few minutes w/ `pandas.read_csv`, tested to be faster than `numpy.loadtxt`.

## Additional dependencies introduced (if any)

None

## TODO (if any)

None