### PR TITLE
Added shortcut if structures is equal to self

### DIFF
--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -722,6 +722,8 @@ class IStructure(SiteCollection, MSONable):
         return m.fit(Structure.from_sites(self), Structure.from_sites(other))
 
     def __eq__(self, other):
+        if other is self:
+            return True
         if other is None:
             return False
         if len(self) != len(other):


### PR DESCRIPTION
## Summary

Determining whether a structure is equal to itself can be very expensive for large structures. A structure with 100 atoms can take seconds to verify, and the cost scales with the square of the number of atoms. This change adds a check in the equality operation if the "other" class refers to the same object in memory to drastically lower the cost of "x == x"

This problem has implications for the caching methods we use in matminer.

## Additional dependencies introduced (if any)

None

## TODO (if any)

None