### PR TITLE
add init to gb

### DIFF
--- a/pymatgen/analysis/gb/__init__.py
+++ b/pymatgen/analysis/gb/__init__.py
@@ -1,0 +1,7 @@
+# coding: utf-8
+# Copyright (c) Pymatgen Development Team.
+# Distributed under the terms of the MIT License.
+
+"""
+This package implements various grain boundary analyses
+"""


### PR DESCRIPTION
`__init__.py` is generally unnecessary for including packages in editable installs of pymatgen in python 3, but seems to be necessary for non-editable installs (e. g. with pip or `python setup.py install`).  I think this should fix the issue.  Currently the pip-installed release doesn't include the analysis.gb module, which breaks transformations.  Might want to re-release as well.