### PR TITLE
Fixes bug in VoronoiNN where atoms in unit cell are not bonded

### DIFF
--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -702,8 +702,13 @@ class VoronoiNN(NearNeighbors):
         else:
             targets = self.targets
 
-        sites = []
-        indices = []
+        # Initialize the list of sites with the atoms in the origin unit cell
+        #  The `get_all_neighbors` function returns neighbors for each site's image in the
+        #   original unit cell. We start off with these central atoms to ensure they are
+        #   included in the tessellation
+        sites = [x.to_unit_cell for x in structure]
+        indices = [(i, 0, 0, 0) for i, _ in enumerate(structure)]
+
         # Get all neighbors within a certain cutoff
         #   Record both the list of these neighbors, and the site indices
         all_neighs = structure.get_all_neighbors(self.cutoff,
@@ -722,6 +727,7 @@ class VoronoiNN(NearNeighbors):
         #   Exploit the fact that the array is sorted by the unique operation such that
         #   the images associated with atom 0 are first, followed by atom 1, etc.
         root_images, = np.nonzero(np.abs(indices[:, 1:]).max(axis=1) == 0)
+
         del indices  # Save memory (tessellations can be costly)
 
         # Run the tessellation

--- a/pymatgen/analysis/tests/test_local_env.py
+++ b/pymatgen/analysis/tests/test_local_env.py
@@ -184,6 +184,18 @@ class VoronoiNNTest(PymatgenTest):
 
             self.assertArrayAlmostEqual(all_weights, by_one_weights)
 
+    def test_Cs2O(self):
+        """A problematic structure in the Materials Project"""
+        strc = Structure([[4.358219, 0.192833, 6.406960], [2.114414, 3.815824, 6.406960],
+                          [0.311360, 0.192833, 7.742498]],
+                         ['O', 'Cs', 'Cs'],
+                         [[0, 0, 0], [0.264318, 0.264318, 0.264318], [0.735682, 0.735682, 0.735682]],
+                         coords_are_cartesian=False)
+
+        # Compute the voronoi tessellation
+        result = VoronoiNN().get_all_voronoi_polyhedra(strc)
+        self.assertEqual(3, len(result))
+
     def test_filtered(self):
         nn = VoronoiNN(weight='area')
 


### PR DESCRIPTION


## Summary

Fixes a bug with VoronoiNN. Under cases where an atom is not bonded to any other atoms in its own image of a unit cell, VoronoiNN will fail to analyze the NN environment of that atom. To fix this problem, we ensure that all sites are in the list of atoms to include in a tessellation

- Added a unit test that fails before this fix, and now passes

## Additional dependencies introduced (if any)

None

## TODO (if any)

None