### PR TITLE
Fix Outcar's MSONable pattern

### DIFF
--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -2569,8 +2569,7 @@ class Outcar(MSONable):
         return aps
 
     def as_dict(self):
-        d = {"@module": self.__class__.__module__,
-             "@class": self.__class__.__name__, "efermi": self.efermi,
+        d = {"efermi": self.efermi,
              "run_stats": self.run_stats, "magnetization": self.magnetization,
              "charge": self.charge, "total_magnetization": self.total_mag,
              "nelect": self.nelect, "is_stopped": self.is_stopped,
@@ -2610,6 +2609,14 @@ class Outcar(MSONable):
                                   "parameters":   self.data["efg"]}})
 
         return d
+
+    @classmethod
+    def from_dict(cls, outcar_dict):
+        """
+        Outcar does not support being generated from a dictionary.
+        This object is only designed to parse Outcar files
+        """
+        raise NotImplementedError("Outcar class is not designed to be instantiated from a dictionary. This class is only designed to parse a file")
 
     def read_fermi_contact_shift(self):
         '''

--- a/pymatgen/io/vasp/tests/test_outputs.py
+++ b/pymatgen/io/vasp/tests/test_outputs.py
@@ -593,6 +593,17 @@ class OutcarTest(PymatgenTest):
         self.assertEqual(outcar.magnetization, expected_mag,
                          "Wrong vector magnetization read from Outcar for SOC calculation")
 
+    def test_msonable(self):
+        filepath = os.path.join(test_dir, "OUTCAR")
+        outcar = Outcar(filepath)
+
+        outcar_dict = outcar.as_dict()
+        self.assertIsNotNone(outcar_dict)
+        self.assertNotIn("@class",outcar_dict)
+        self.assertNotIn("@module",outcar_dict)
+        with self.assertRaises(NotImplementedError):
+            Outcar.from_dict(outcar_dict)
+
     def test_polarization(self):
         filepath = os.path.join(test_dir, "OUTCAR.BaTiO3.polar")
         outcar = Outcar(filepath)


### PR DESCRIPTION
## Summary

Outcar is subclassed from MSONable, but is not intended to fully implement this pattern as its not designed to instantiated from the dictionary it generates. This ensures that Monty doesn't try to auto convert the dictionary into an Outcar object, for instance when using loadfn from a jsonified Outcar or task document. 

- Ensures Outcar as_dict dictionaries don't have "@class" or "@module" keys
- Ensures Outcar from_dict throws an error