### PR TITLE
bug fix for exporting structure out of LammpsData

### DIFF
--- a/pymatgen/io/lammps/data.py
+++ b/pymatgen/io/lammps/data.py
@@ -456,7 +456,7 @@ class LammpsData(MSONable):
         masses["label"] = atom_labels
         unique_masses = np.unique(masses["mass"])
         if guess_element:
-            ref_masses = sorted([el.atomic_mass.real for el in Element])
+            ref_masses = [el.atomic_mass.real for el in Element]
             diff = np.abs(np.array(ref_masses) - unique_masses[:, None])
             atomic_numbers = np.argmin(diff, axis=1) + 1
             symbols = [Element.from_Z(an).symbol for an in atomic_numbers]

--- a/pymatgen/io/lammps/tests/test_data.py
+++ b/pymatgen/io/lammps/tests/test_data.py
@@ -123,6 +123,16 @@ class LammpsDataTest(unittest.TestCase):
                                               0.71487872,
                                               0.14134139])
 
+        co = Structure.from_spacegroup(194,
+                                       Lattice.hexagonal(2.50078, 4.03333),
+                                       ["Co"], [[1/3, 2/3, 1/4]])
+        ld_co = LammpsData.from_structure(co)
+        self.assertEqual(ld_co.structure.composition.reduced_formula, "Co")
+        ni = Structure.from_spacegroup(225, Lattice.cubic(3.50804),
+                                       ["Ni"], [[0, 0, 0]])
+        ld_ni = LammpsData.from_structure(ni)
+        self.assertEqual(ld_ni.structure.composition.reduced_formula, "Ni")
+
     def test_get_string(self):
         pep = self.peptide.get_string(distance=7, velocity=5, charge=4)
         pep_lines = pep.split("\n")


### PR DESCRIPTION
## Summary

Fixed a bug where exported structure has Ni or Co in the composition. Thanks to the report by @ucsdlxg 

## Additional dependencies introduced (if any)

None

## TODO (if any)

None