### PR TITLE
Add converters to and from dictionary

### DIFF
--- a/pymatgen/io/pwscf.py
+++ b/pymatgen/io/pwscf.py
@@ -172,6 +172,44 @@ class PWInput(object):
         for vec in self.structure.lattice.matrix:
             out.append("  %f %f %f" % (vec[0], vec[1], vec[2]))
         return "\n".join(out)
+    
+    def as_dict(self):
+        """
+        Create a dictionary representation of a PWInput object
+        
+        Returns:
+            dict
+        """
+        pwinput_dict = {'structure': self.structure.as_dict(),
+                        'pseudo': self.pseudo,
+                        'sections': self.sections,
+                        'kpoints_mode': self.kpoints_mode,
+                        'kpoints_grid': self.kpoints_grid,
+                        'kpoints_shift': self.kpoints_shift}
+        return pwinput_dict
+    
+    @classmethod
+    def from_dict(cls, pwinput_dict):
+        """
+        Load a PWInput object from a dictionary.
+        
+        Args:
+            pwinput_dict (dict): dictionary with PWInput data
+            
+        Returns:
+            PWInput object
+        """
+        pwinput = cls(structure=Structure.from_dict(pwinput_dict['structure']),
+                          pseudo=pwinput_dict['pseudo'],
+                          control=pwinput_dict['sections']['control'],
+                          system=pwinput_dict['sections']['system'],
+                          electrons=pwinput_dict['sections']['electrons'],
+                          ions=pwinput_dict['sections']['ions'],
+                          cell=pwinput_dict['sections']['cell'],
+                          kpoints_mode=pwinput_dict['kpoints_mode'],
+                          kpoints_grid=pwinput_dict['kpoints_grid'],
+                          kpoints_shift=pwinput_dict['kpoints_shift'])
+        return pwinput
 
     def write_file(self, filename):
         """


### PR DESCRIPTION
Implement PWInput.as_dict() and PWInput.from_dict(pwinput_dict) methods to the PWInput class.

## Summary

* as_dict method returns a dictionary with a dictionary-encoded Structure object, pseudopotential dictionary, input sections, and k points information
* from_dict method takes a dictionary from as_dict and returns a PWInput object