### PR TITLE
Minor bug fix in wulff.py

### DIFF
--- a/pymatgen/analysis/wulff.py
+++ b/pymatgen/analysis/wulff.py
@@ -430,7 +430,7 @@ class WulffShape(object):
             # assign the color for on_wulff facets according to its
             # index and the color_list for on_wulff
             plane_color = color_list[plane.index]
-            pt = self.get_lines_in_facet(plane)
+            pt = self.get_line_in_facet(plane)
             # plot from the sorted pts from [simpx]
             tri = mpl3.art3d.Poly3DCollection([pt])
             tri.set_color(plane_color)


### PR DESCRIPTION
Got an error when trying to plot wulff shapes today.  I think there's a typo in one of the method calls in the get_plot method, this should fix.  Not sure why the unit test isn't throwing an error.