### PR TITLE
Minor bug fix in bandstructure

### DIFF
--- a/pymatgen/electronic_structure/bandstructure.py
+++ b/pymatgen/electronic_structure/bandstructure.py
@@ -205,7 +205,7 @@ class BandStructure(object):
         self.labels_dict = {}
         self.structure = structure
         self.projections = projections or {}
-        self.projections = {k: np.array(v) for k, v in projections.items()}
+        self.projections = {k: np.array(v) for k, v in self.projections.items()}
 
         if labels_dict is None:
             labels_dict = {}


### PR DESCRIPTION
Fixes a bug in the initialization of projections in bandstructure.py.  This was causing an error in the boltztrap module test.