### PR TITLE
Minor CIF Parser Fixes

### DIFF
--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -1113,11 +1113,12 @@ class CifParser(object):
             # convert to bibtex author format ('and' delimited)
             if 'author' in bibtex_entry:
                 # separate out semicolon authors
-                if isinstance(bibtex_entry["author"],str):
+                if isinstance(bibtex_entry["author"], str):
                     if ";" in bibtex_entry["author"]:
                         bibtex_entry["author"] = bibtex_entry["author"].split(";")
-                        
-                bibtex_entry['author'] = ' and '.join(bibtex_entry['author'])
+
+                if isinstance(bibtex_entry['author'], list):
+                    bibtex_entry['author'] = ' and '.join(bibtex_entry['author'])
 
             # convert to bibtex page range format, use empty string if not specified
             if ('page_first' in bibtex_entry) or ('page_last' in bibtex_entry):

--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -1112,6 +1112,11 @@ class CifParser(object):
 
             # convert to bibtex author format ('and' delimited)
             if 'author' in bibtex_entry:
+                # separate out semicolon authors
+                if isinstance(bibtex_entry["author"],str):
+                    if ";" in bibtex_entry["author"]:
+                        bibtex_entry["author"] = bibtex_entry["author"].split(";")
+                        
                 bibtex_entry['author'] = ' and '.join(bibtex_entry['author'])
 
             # convert to bibtex page range format, use empty string if not specified

--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -1105,7 +1105,10 @@ class CifParser(object):
             for field, tags in bibtex_keys.items():
                 for tag in tags:
                     if tag in data:
-                        bibtex_entry[field] = data[tag]
+                        if isinstance(data[tag], list):
+                            bibtex_entry[field] = data[tag][0]
+                        else:
+                            bibtex_entry[field] = data[tag]
 
             # convert to bibtex author format ('and' delimited)
             if 'author' in bibtex_entry:

--- a/pymatgen/io/tests/test_cif.py
+++ b/pymatgen/io/tests/test_cif.py
@@ -177,7 +177,7 @@ class CifIOTest(PymatgenTest):
         for s in parser.get_structures(True):
             self.assertEqual(s.formula, "V4 O6")
 
-        bibtex_str = """      
+        bibtex_str = """
 @article{cif-reference-0,
     author = "Andersson, G.",
     title = "Studies on vanadium oxides. I. Phase analysis",

--- a/pymatgen/io/tests/test_cif.py
+++ b/pymatgen/io/tests/test_cif.py
@@ -177,6 +177,18 @@ class CifIOTest(PymatgenTest):
         for s in parser.get_structures(True):
             self.assertEqual(s.formula, "V4 O6")
 
+        bibtex_str = """      
+@article{cif-reference-0,
+    author = "Andersson, G.",
+    title = "Studies on vanadium oxides. I. Phase analysis",
+    journal = "Acta Chemica Scandinavica (1-27,1973-42,1988)",
+    volume = "8",
+    year = "1954",
+    pages = "1599--1606"
+}
+        """
+        self.assertEqual(parser.get_bibtex_string().strip(), bibtex_str.strip())
+
         parser = CifParser(os.path.join(test_dir, 'Li2O.cif'))
         prim = parser.get_structures(True)[0]
         self.assertEqual(prim.formula, "Li2 O1")


### PR DESCRIPTION
Fixes some minor issues with CIF Parser's get_bibtex_string when dealing with ICSD CIFs

- ensure bibtex gets single strings and not arrays when dealing with _loop fields
- properly formats author field when not supplied via _loop
- simple test for get_bibtex_string so we can monitor incase it breaks