### PR TITLE
Update composition parser able to handle "@" #1268

### DIFF
--- a/pymatgen/core/composition.py
+++ b/pymatgen/core/composition.py
@@ -26,7 +26,6 @@ from pymatgen.util.string import formula_double_format
 from monty.json import MSONable
 from pymatgen.core.units import unitized
 
-
 """
 This module implements a Composition class to represent compositions,
 and a ChemicalPotential class to represent potentials.
@@ -94,7 +93,7 @@ class Composition(collections.Hashable, collections.Mapping, MSONable):
     """
     special_formulas = {"LiO": "Li2O2", "NaO": "Na2O2", "KO": "K2O2",
                         "HO": "H2O2", "CsO": "Cs2O2", "RbO": "Rb2O2",
-                        "O": "O2",  "N": "N2", "F": "F2", "Cl": "Cl2",
+                        "O": "O2", "N": "N2", "F": "F2", "Cl": "Cl2",
                         "H": "H2"}
 
     oxi_prob = None  # prior probability of oxidation used by oxi_state_guesses
@@ -254,7 +253,7 @@ class Composition(collections.Hashable, collections.Mapping, MSONable):
     @property
     def average_electroneg(self):
         return sum((el.X * abs(amt) for el, amt in self.items())) / \
-            self.num_atoms
+               self.num_atoms
 
     @property
     def total_electrons(self):
@@ -468,11 +467,17 @@ class Composition(collections.Hashable, collections.Mapping, MSONable):
     def _parse_formula(self, formula):
         """
         Args:
-            formula (str): A string formula, e.g. Fe2O3, Li3Fe2(PO4)3
+            formula (str): A string formula, e.g. Fe2O3, Li3Fe2(PO4)3, Y3N@C80
 
         Returns:
             Composition with that formula.
+
+        Notes:
+            In the case of Metallofullerene formula (e.g. Y3N@C80),
+            the @ mark will be dropped and passed to parser.
+
         """
+
         def get_sym_dict(f, factor):
             sym_dict = collections.defaultdict(float)
             for m in re.finditer(r"([A-Z][a-z]*)\s*([-*\.\d]*)", f):
@@ -485,6 +490,10 @@ class Composition(collections.Hashable, collections.Mapping, MSONable):
             if f.strip():
                 raise CompositionError("{} is an invalid formula!".format(f))
             return sym_dict
+
+        # for Metallofullerene like "Y3N@C80"
+        if "@" in formula:
+            formula = formula.replace("@", "")
 
         m = re.search(r"\(([^\(\)]+)\)\s*([\.\d]*)", formula)
         if m:
@@ -618,7 +627,7 @@ class Composition(collections.Hashable, collections.Mapping, MSONable):
         return self._get_oxid_state_guesses(all_oxi_states, max_sites, oxi_states_override, target_charge)[0]
 
     def add_charges_from_oxi_state_guesses(self, oxi_states_override=None, target_charge=0,
-                          all_oxi_states=False, max_sites=None):
+                                           all_oxi_states=False, max_sites=None):
         """
         Assign oxidation states basedon guessed oxidation states.
 
@@ -646,16 +655,17 @@ class Composition(collections.Hashable, collections.Mapping, MSONable):
                 returns a Composition where all oxidation states are 0
         """
 
-        _, oxidation_states = self._get_oxid_state_guesses(all_oxi_states, max_sites, oxi_states_override, target_charge)
+        _, oxidation_states = self._get_oxid_state_guesses(all_oxi_states, max_sites, oxi_states_override,
+                                                           target_charge)
 
         # Special case: No charged compound is possible
         if len(oxidation_states) == 0:
-            return Composition(dict((Specie(e,0),f) for e,f in self.items()))
+            return Composition(dict((Specie(e, 0), f) for e, f in self.items()))
 
         # Generate the species
         species = []
         for el, charges in oxidation_states[0].items():
-            species.extend([Specie(el,c) for c in charges])
+            species.extend([Specie(el, c) for c in charges])
 
         # Return the new object
         return Composition(collections.Counter(species))
@@ -779,7 +789,7 @@ class Composition(collections.Hashable, collections.Mapping, MSONable):
                 all_scores.append(score)
 
                 # collect the combination of oxidation states for each site
-                all_oxid_combo.append(dict((e,el_best_oxid_combo[idx][v]) for idx, (e,v) in enumerate(zip(els,x))))
+                all_oxid_combo.append(dict((e, el_best_oxid_combo[idx][v]) for idx, (e, v) in enumerate(zip(els, x))))
 
         # sort the solutions by highest to lowest score
         if len(all_scores) > 0:
@@ -808,11 +818,11 @@ class Composition(collections.Hashable, collections.Mapping, MSONable):
             A ranked list of potential Composition matches
         """
 
-        #if we have an exact match and the user specifies lock_if_strict, just
-        #return the exact match!
+        # if we have an exact match and the user specifies lock_if_strict, just
+        # return the exact match!
         if lock_if_strict:
-            #the strict composition parsing might throw an error, we can ignore
-            #it and just get on with fuzzy matching
+            # the strict composition parsing might throw an error, we can ignore
+            # it and just get on with fuzzy matching
             try:
                 comp = Composition(fuzzy_formula)
                 return [comp]
@@ -820,9 +830,9 @@ class Composition(collections.Hashable, collections.Mapping, MSONable):
                 pass
 
         all_matches = Composition._comps_from_fuzzy_formula(fuzzy_formula)
-        #remove duplicates
+        # remove duplicates
         all_matches = list(set(all_matches))
-        #sort matches by rank descending
+        # sort matches by rank descending
         all_matches = sorted(all_matches,
                              key=lambda match: match[1], reverse=True)
         all_matches = [m[0] for m in all_matches]
@@ -883,14 +893,14 @@ class Composition(collections.Hashable, collections.Mapping, MSONable):
             # specified as lowercase
             points_second_lowercase = 100
 
-            #get element and amount from regex match
+            # get element and amount from regex match
             el = m.group(1)
             if len(el) > 2 or len(el) < 1:
                 raise CompositionError("Invalid element symbol entered!")
             amt = float(m.group(2)) if m.group(2).strip() != "" else 1
 
-            #convert the element string to proper [uppercase,lowercase] format
-            #and award points if it is already in that format
+            # convert the element string to proper [uppercase,lowercase] format
+            # and award points if it is already in that format
             char1 = el[0]
             char2 = el[1] if len(el) > 1 else ""
 
@@ -901,7 +911,7 @@ class Composition(collections.Hashable, collections.Mapping, MSONable):
 
             el = char1.upper() + char2.lower()
 
-            #if it's a valid element, chomp and add to the points
+            # if it's a valid element, chomp and add to the points
             if Element.is_valid_symbol(el):
                 if el in m_dict:
                     m_dict[el] += amt * factor
@@ -909,7 +919,7 @@ class Composition(collections.Hashable, collections.Mapping, MSONable):
                     m_dict[el] = amt * factor
                 return f.replace(m.group(), "", 1), m_dict, m_points + points
 
-            #else return None
+            # else return None
             return None, None, None
 
         fuzzy_formula = fuzzy_formula.strip()
@@ -930,19 +940,19 @@ class Composition(collections.Hashable, collections.Mapping, MSONable):
                 # Match the stuff inside the parenthesis with the appropriate
                 # factor
                 for match in \
-                    Composition._comps_from_fuzzy_formula(mp.group(1),
-                                                          mp_dict,
-                                                          mp_points,
-                                                          factor=mp_factor):
+                        Composition._comps_from_fuzzy_formula(mp.group(1),
+                                                              mp_dict,
+                                                              mp_points,
+                                                              factor=mp_factor):
                     only_me = True
                     # Match the stuff outside the parentheses and return the
                     # sum.
 
                     for match2 in \
-                        Composition._comps_from_fuzzy_formula(mp_form,
-                                                              mp_dict,
-                                                              mp_points,
-                                                              factor=1):
+                            Composition._comps_from_fuzzy_formula(mp_form,
+                                                                  mp_dict,
+                                                                  mp_points,
+                                                                  factor=1):
                         only_me = False
                         yield (match[0] + match2[0], match[1] + match2[1])
                     # if the stuff inside the parenthesis is nothing, then just
@@ -960,15 +970,15 @@ class Composition(collections.Hashable, collections.Mapping, MSONable):
                 (m_form1, m_dict1, m_points1) = \
                     _parse_chomp_and_rank(m1, m_form1, m_dict1, m_points1)
                 if m_dict1:
-                    #there was a real match
+                    # there was a real match
                     for match in \
-                        Composition._comps_from_fuzzy_formula(m_form1,
-                                                              m_dict1,
-                                                              m_points1,
-                                                              factor):
+                            Composition._comps_from_fuzzy_formula(m_form1,
+                                                                  m_dict1,
+                                                                  m_points1,
+                                                                  factor):
                         yield match
 
-            #try to match two-letter elements
+            # try to match two-letter elements
             m2 = re.match(r"([A-z]{2})([\.\d]*)", fuzzy_formula)
             if m2:
                 m_points2 = m_points
@@ -977,11 +987,11 @@ class Composition(collections.Hashable, collections.Mapping, MSONable):
                 (m_form2, m_dict2, m_points2) = \
                     _parse_chomp_and_rank(m2, m_form2, m_dict2, m_points2)
                 if m_dict2:
-                    #there was a real match
+                    # there was a real match
                     for match in \
-                        Composition._comps_from_fuzzy_formula(m_form2, m_dict2,
-                                                              m_points2,
-                                                              factor):
+                            Composition._comps_from_fuzzy_formula(m_form2, m_dict2,
+                                                                  m_points2,
+                                                                  factor):
                         yield match
 
 
@@ -999,7 +1009,7 @@ def reduce_formula(sym_amt):
                   key=lambda s: [get_el_sp(s).X, s])
 
     syms = list(filter(lambda s: abs(sym_amt[s]) >
-                       Composition.amount_tolerance, syms))
+                                 Composition.amount_tolerance, syms))
     num_el = len(syms)
     contains_polyanion = (num_el >= 3 and
                           get_el_sp(syms[num_el - 1]).X
@@ -1108,4 +1118,5 @@ class ChemicalPotential(dict, MSONable):
 
 if __name__ == "__main__":
     import doctest
+
     doctest.testmod()

--- a/pymatgen/core/composition.py
+++ b/pymatgen/core/composition.py
@@ -477,6 +477,13 @@ class Composition(collections.Hashable, collections.Mapping, MSONable):
             In the case of Metallofullerene formula (e.g. Y3N@C80),
             the @ mark will be dropped and passed to parser.
         """
+        print(formula)
+        # for Metallofullerene like "Y3N@C80"
+        if "@" in formula:
+            print(formula)
+            formula = formula.replace("@", "")
+            print(formula)
+
         def get_sym_dict(f, factor):
             sym_dict = collections.defaultdict(float)
             for m in re.finditer(r"([A-Z][a-z]*)\s*([-*\.\d]*)", f):
@@ -489,10 +496,6 @@ class Composition(collections.Hashable, collections.Mapping, MSONable):
             if f.strip():
                 raise CompositionError("{} is an invalid formula!".format(f))
             return sym_dict
-
-        # for Metallofullerene like "Y3N@C80"
-        if "@" in formula:
-            formula = formula.replace("@", "")
 
         m = re.search(r"\(([^\(\)]+)\)\s*([\.\d]*)", formula)
         if m:

--- a/pymatgen/core/composition.py
+++ b/pymatgen/core/composition.py
@@ -26,6 +26,7 @@ from pymatgen.util.string import formula_double_format
 from monty.json import MSONable
 from pymatgen.core.units import unitized
 
+
 """
 This module implements a Composition class to represent compositions,
 and a ChemicalPotential class to represent potentials.
@@ -93,7 +94,7 @@ class Composition(collections.Hashable, collections.Mapping, MSONable):
     """
     special_formulas = {"LiO": "Li2O2", "NaO": "Na2O2", "KO": "K2O2",
                         "HO": "H2O2", "CsO": "Cs2O2", "RbO": "Rb2O2",
-                        "O": "O2", "N": "N2", "F": "F2", "Cl": "Cl2",
+                        "O": "O2",  "N": "N2", "F": "F2", "Cl": "Cl2",
                         "H": "H2"}
 
     oxi_prob = None  # prior probability of oxidation used by oxi_state_guesses
@@ -253,7 +254,7 @@ class Composition(collections.Hashable, collections.Mapping, MSONable):
     @property
     def average_electroneg(self):
         return sum((el.X * abs(amt) for el, amt in self.items())) / \
-               self.num_atoms
+            self.num_atoms
 
     @property
     def total_electrons(self):
@@ -467,7 +468,7 @@ class Composition(collections.Hashable, collections.Mapping, MSONable):
     def _parse_formula(self, formula):
         """
         Args:
-            formula (str): A string formula, e.g. Fe2O3, Li3Fe2(PO4)3, Y3N@C80
+            formula (str): A string formula, e.g. Fe2O3, Li3Fe2(PO4)3
 
         Returns:
             Composition with that formula.
@@ -475,9 +476,7 @@ class Composition(collections.Hashable, collections.Mapping, MSONable):
         Notes:
             In the case of Metallofullerene formula (e.g. Y3N@C80),
             the @ mark will be dropped and passed to parser.
-
         """
-
         def get_sym_dict(f, factor):
             sym_dict = collections.defaultdict(float)
             for m in re.finditer(r"([A-Z][a-z]*)\s*([-*\.\d]*)", f):
@@ -627,7 +626,7 @@ class Composition(collections.Hashable, collections.Mapping, MSONable):
         return self._get_oxid_state_guesses(all_oxi_states, max_sites, oxi_states_override, target_charge)[0]
 
     def add_charges_from_oxi_state_guesses(self, oxi_states_override=None, target_charge=0,
-                                           all_oxi_states=False, max_sites=None):
+                          all_oxi_states=False, max_sites=None):
         """
         Assign oxidation states basedon guessed oxidation states.
 
@@ -655,17 +654,16 @@ class Composition(collections.Hashable, collections.Mapping, MSONable):
                 returns a Composition where all oxidation states are 0
         """
 
-        _, oxidation_states = self._get_oxid_state_guesses(all_oxi_states, max_sites, oxi_states_override,
-                                                           target_charge)
+        _, oxidation_states = self._get_oxid_state_guesses(all_oxi_states, max_sites, oxi_states_override, target_charge)
 
         # Special case: No charged compound is possible
         if len(oxidation_states) == 0:
-            return Composition(dict((Specie(e, 0), f) for e, f in self.items()))
+            return Composition(dict((Specie(e,0),f) for e,f in self.items()))
 
         # Generate the species
         species = []
         for el, charges in oxidation_states[0].items():
-            species.extend([Specie(el, c) for c in charges])
+            species.extend([Specie(el,c) for c in charges])
 
         # Return the new object
         return Composition(collections.Counter(species))
@@ -789,7 +787,7 @@ class Composition(collections.Hashable, collections.Mapping, MSONable):
                 all_scores.append(score)
 
                 # collect the combination of oxidation states for each site
-                all_oxid_combo.append(dict((e, el_best_oxid_combo[idx][v]) for idx, (e, v) in enumerate(zip(els, x))))
+                all_oxid_combo.append(dict((e,el_best_oxid_combo[idx][v]) for idx, (e,v) in enumerate(zip(els,x))))
 
         # sort the solutions by highest to lowest score
         if len(all_scores) > 0:
@@ -818,11 +816,11 @@ class Composition(collections.Hashable, collections.Mapping, MSONable):
             A ranked list of potential Composition matches
         """
 
-        # if we have an exact match and the user specifies lock_if_strict, just
-        # return the exact match!
+        #if we have an exact match and the user specifies lock_if_strict, just
+        #return the exact match!
         if lock_if_strict:
-            # the strict composition parsing might throw an error, we can ignore
-            # it and just get on with fuzzy matching
+            #the strict composition parsing might throw an error, we can ignore
+            #it and just get on with fuzzy matching
             try:
                 comp = Composition(fuzzy_formula)
                 return [comp]
@@ -830,9 +828,9 @@ class Composition(collections.Hashable, collections.Mapping, MSONable):
                 pass
 
         all_matches = Composition._comps_from_fuzzy_formula(fuzzy_formula)
-        # remove duplicates
+        #remove duplicates
         all_matches = list(set(all_matches))
-        # sort matches by rank descending
+        #sort matches by rank descending
         all_matches = sorted(all_matches,
                              key=lambda match: match[1], reverse=True)
         all_matches = [m[0] for m in all_matches]
@@ -893,14 +891,14 @@ class Composition(collections.Hashable, collections.Mapping, MSONable):
             # specified as lowercase
             points_second_lowercase = 100
 
-            # get element and amount from regex match
+            #get element and amount from regex match
             el = m.group(1)
             if len(el) > 2 or len(el) < 1:
                 raise CompositionError("Invalid element symbol entered!")
             amt = float(m.group(2)) if m.group(2).strip() != "" else 1
 
-            # convert the element string to proper [uppercase,lowercase] format
-            # and award points if it is already in that format
+            #convert the element string to proper [uppercase,lowercase] format
+            #and award points if it is already in that format
             char1 = el[0]
             char2 = el[1] if len(el) > 1 else ""
 
@@ -911,7 +909,7 @@ class Composition(collections.Hashable, collections.Mapping, MSONable):
 
             el = char1.upper() + char2.lower()
 
-            # if it's a valid element, chomp and add to the points
+            #if it's a valid element, chomp and add to the points
             if Element.is_valid_symbol(el):
                 if el in m_dict:
                     m_dict[el] += amt * factor
@@ -919,7 +917,7 @@ class Composition(collections.Hashable, collections.Mapping, MSONable):
                     m_dict[el] = amt * factor
                 return f.replace(m.group(), "", 1), m_dict, m_points + points
 
-            # else return None
+            #else return None
             return None, None, None
 
         fuzzy_formula = fuzzy_formula.strip()
@@ -940,19 +938,19 @@ class Composition(collections.Hashable, collections.Mapping, MSONable):
                 # Match the stuff inside the parenthesis with the appropriate
                 # factor
                 for match in \
-                        Composition._comps_from_fuzzy_formula(mp.group(1),
-                                                              mp_dict,
-                                                              mp_points,
-                                                              factor=mp_factor):
+                    Composition._comps_from_fuzzy_formula(mp.group(1),
+                                                          mp_dict,
+                                                          mp_points,
+                                                          factor=mp_factor):
                     only_me = True
                     # Match the stuff outside the parentheses and return the
                     # sum.
 
                     for match2 in \
-                            Composition._comps_from_fuzzy_formula(mp_form,
-                                                                  mp_dict,
-                                                                  mp_points,
-                                                                  factor=1):
+                        Composition._comps_from_fuzzy_formula(mp_form,
+                                                              mp_dict,
+                                                              mp_points,
+                                                              factor=1):
                         only_me = False
                         yield (match[0] + match2[0], match[1] + match2[1])
                     # if the stuff inside the parenthesis is nothing, then just
@@ -970,15 +968,15 @@ class Composition(collections.Hashable, collections.Mapping, MSONable):
                 (m_form1, m_dict1, m_points1) = \
                     _parse_chomp_and_rank(m1, m_form1, m_dict1, m_points1)
                 if m_dict1:
-                    # there was a real match
+                    #there was a real match
                     for match in \
-                            Composition._comps_from_fuzzy_formula(m_form1,
-                                                                  m_dict1,
-                                                                  m_points1,
-                                                                  factor):
+                        Composition._comps_from_fuzzy_formula(m_form1,
+                                                              m_dict1,
+                                                              m_points1,
+                                                              factor):
                         yield match
 
-            # try to match two-letter elements
+            #try to match two-letter elements
             m2 = re.match(r"([A-z]{2})([\.\d]*)", fuzzy_formula)
             if m2:
                 m_points2 = m_points
@@ -987,11 +985,11 @@ class Composition(collections.Hashable, collections.Mapping, MSONable):
                 (m_form2, m_dict2, m_points2) = \
                     _parse_chomp_and_rank(m2, m_form2, m_dict2, m_points2)
                 if m_dict2:
-                    # there was a real match
+                    #there was a real match
                     for match in \
-                            Composition._comps_from_fuzzy_formula(m_form2, m_dict2,
-                                                                  m_points2,
-                                                                  factor):
+                        Composition._comps_from_fuzzy_formula(m_form2, m_dict2,
+                                                              m_points2,
+                                                              factor):
                         yield match
 
 
@@ -1009,7 +1007,7 @@ def reduce_formula(sym_amt):
                   key=lambda s: [get_el_sp(s).X, s])
 
     syms = list(filter(lambda s: abs(sym_amt[s]) >
-                                 Composition.amount_tolerance, syms))
+                       Composition.amount_tolerance, syms))
     num_el = len(syms)
     contains_polyanion = (num_el >= 3 and
                           get_el_sp(syms[num_el - 1]).X
@@ -1118,5 +1116,4 @@ class ChemicalPotential(dict, MSONable):
 
 if __name__ == "__main__":
     import doctest
-
     doctest.testmod()

--- a/pymatgen/core/composition.py
+++ b/pymatgen/core/composition.py
@@ -477,12 +477,8 @@ class Composition(collections.Hashable, collections.Mapping, MSONable):
             In the case of Metallofullerene formula (e.g. Y3N@C80),
             the @ mark will be dropped and passed to parser.
         """
-        print(formula)
         # for Metallofullerene like "Y3N@C80"
-        if "@" in formula:
-            print(formula)
-            formula = formula.replace("@", "")
-            print(formula)
+        formula = formula.replace("@", "")
 
         def get_sym_dict(f, factor):
             sym_dict = collections.defaultdict(float)

--- a/pymatgen/core/tests/test_composition.py
+++ b/pymatgen/core/tests/test_composition.py
@@ -10,7 +10,6 @@ from __future__ import division, unicode_literals
 
 from pymatgen.util.testing import PymatgenTest
 
-
 __author__ = "Shyue Ping Ong"
 __copyright__ = "Copyright 2011, The Materials Project"
 __version__ = "0.1"
@@ -275,7 +274,7 @@ class CompositionTest(PymatgenTest):
         self.assertRaises(CompositionError, Composition('O').__sub__,
                           Composition('H'))
 
-        #check that S is completely removed by subtraction
+        # check that S is completely removed by subtraction
         c1 = Composition({'S': 1 + Composition.amount_tolerance / 2, 'O': 1})
         c2 = Composition({'S': 1})
         self.assertEqual(len((c1 - c2).elements), 1)
@@ -318,7 +317,7 @@ class CompositionTest(PymatgenTest):
         self.assertTrue(c3 < c1)
         self.assertTrue(c4 > c1)
         self.assertEqual(sorted([c1, c1_1, c2, c4, c3]),
-                        [c3, c1, c1_1, c4, c2])
+                         [c3, c1, c1_1, c4, c2])
 
     def test_almost_equals(self):
         c1 = Composition({'Fe': 2.0, 'O': 3.0, 'Mn': 0})
@@ -341,7 +340,7 @@ class CompositionTest(PymatgenTest):
             self.assertAlmostEqual(c.fractional_composition.num_atoms, 1)
 
     def test_init_numerical_tolerance(self):
-        self.assertEqual(Composition({'B':1, 'C':-1e-12}), Composition('B'))
+        self.assertEqual(Composition({'B': 1, 'C': -1e-12}), Composition('B'))
 
     def test_negative_compositions(self):
         self.assertEqual(Composition('Li-1(PO-1)4', allow_negative=True).formula,
@@ -353,7 +352,7 @@ class CompositionTest(PymatgenTest):
         self.assertEqual(Composition('Li-2.5Mg4', allow_negative=True).reduced_composition,
                          Composition('Li-2.5Mg4', allow_negative=True))
 
-        #test math
+        # test math
         c1 = Composition('LiCl', allow_negative=True)
         c2 = Composition('Li')
         self.assertEqual(c1 - 2 * c2, Composition({'Li': -1, 'Cl': 1},
@@ -361,7 +360,7 @@ class CompositionTest(PymatgenTest):
         self.assertEqual((c1 + c2).allow_negative, True)
         self.assertEqual(c1 / -1, Composition('Li-1Cl-1', allow_negative=True))
 
-        #test num_atoms
+        # test num_atoms
         c1 = Composition('Mg-1Li', allow_negative=True)
         self.assertEqual(c1.num_atoms, 2)
         self.assertEqual(c1.get_atomic_fraction('Mg'), 0.5)
@@ -369,11 +368,11 @@ class CompositionTest(PymatgenTest):
         self.assertEqual(c1.fractional_composition,
                          Composition('Mg-0.5Li0.5', allow_negative=True))
 
-        #test copy
+        # test copy
         self.assertEqual(c1.copy(), c1)
 
-        #test species
-        c1 = Composition({'Mg':1, 'Mg2+':-1}, allow_negative=True)
+        # test species
+        c1 = Composition({'Mg': 1, 'Mg2+': -1}, allow_negative=True)
         self.assertEqual(c1.num_atoms, 2)
         self.assertEqual(c1.element_composition, Composition())
         self.assertEqual(c1.average_electroneg, 1.31)
@@ -381,7 +380,7 @@ class CompositionTest(PymatgenTest):
     def test_special_formulas(self):
         special_formulas = {"LiO": "Li2O2", "NaO": "Na2O2", "KO": "K2O2",
                             "HO": "H2O2", "CsO": "Cs2O2", "RbO": "Rb2O2",
-                            "O": "O2",  "N": "N2", "F": "F2", "Cl": "Cl2",
+                            "O": "O2", "N": "N2", "F": "F2", "Cl": "Cl2",
                             "H": "H2"}
         for k, v in special_formulas.items():
             self.assertEqual(Composition(k).reduced_formula, v)
@@ -453,6 +452,14 @@ class CompositionTest(PymatgenTest):
         self.assertEqual(1, decorated.get(Specie("Ni", 0)))
         self.assertEqual(1, decorated.get(Specie("Al", 0)))
 
+    def test_Metallofullerene(self):
+        # Test: Parse Metallofullerene formula (e.g. Y3N@C80)
+        formula = "Y3N@C80"
+        sym_dict = {"Y": 3, "N": 1, "C": 80}
+        cmp = Composition(formula)
+        cmp2 = Composition.from_dict(sym_dict)
+        self.assertEqual(cmp, cmp2)
+
 
 class ChemicalPotentialTest(unittest.TestCase):
 
@@ -492,5 +499,5 @@ class ChemicalPotentialTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    #import sys;sys.argv = ['', 'Test.testName']
+    # import sys;sys.argv = ['', 'Test.testName']
     unittest.main()

--- a/pymatgen/core/tests/test_composition.py
+++ b/pymatgen/core/tests/test_composition.py
@@ -10,6 +10,7 @@ from __future__ import division, unicode_literals
 
 from pymatgen.util.testing import PymatgenTest
 
+
 __author__ = "Shyue Ping Ong"
 __copyright__ = "Copyright 2011, The Materials Project"
 __version__ = "0.1"
@@ -274,7 +275,7 @@ class CompositionTest(PymatgenTest):
         self.assertRaises(CompositionError, Composition('O').__sub__,
                           Composition('H'))
 
-        # check that S is completely removed by subtraction
+        #check that S is completely removed by subtraction
         c1 = Composition({'S': 1 + Composition.amount_tolerance / 2, 'O': 1})
         c2 = Composition({'S': 1})
         self.assertEqual(len((c1 - c2).elements), 1)
@@ -317,7 +318,7 @@ class CompositionTest(PymatgenTest):
         self.assertTrue(c3 < c1)
         self.assertTrue(c4 > c1)
         self.assertEqual(sorted([c1, c1_1, c2, c4, c3]),
-                         [c3, c1, c1_1, c4, c2])
+                        [c3, c1, c1_1, c4, c2])
 
     def test_almost_equals(self):
         c1 = Composition({'Fe': 2.0, 'O': 3.0, 'Mn': 0})
@@ -340,7 +341,7 @@ class CompositionTest(PymatgenTest):
             self.assertAlmostEqual(c.fractional_composition.num_atoms, 1)
 
     def test_init_numerical_tolerance(self):
-        self.assertEqual(Composition({'B': 1, 'C': -1e-12}), Composition('B'))
+        self.assertEqual(Composition({'B':1, 'C':-1e-12}), Composition('B'))
 
     def test_negative_compositions(self):
         self.assertEqual(Composition('Li-1(PO-1)4', allow_negative=True).formula,
@@ -352,7 +353,7 @@ class CompositionTest(PymatgenTest):
         self.assertEqual(Composition('Li-2.5Mg4', allow_negative=True).reduced_composition,
                          Composition('Li-2.5Mg4', allow_negative=True))
 
-        # test math
+        #test math
         c1 = Composition('LiCl', allow_negative=True)
         c2 = Composition('Li')
         self.assertEqual(c1 - 2 * c2, Composition({'Li': -1, 'Cl': 1},
@@ -360,7 +361,7 @@ class CompositionTest(PymatgenTest):
         self.assertEqual((c1 + c2).allow_negative, True)
         self.assertEqual(c1 / -1, Composition('Li-1Cl-1', allow_negative=True))
 
-        # test num_atoms
+        #test num_atoms
         c1 = Composition('Mg-1Li', allow_negative=True)
         self.assertEqual(c1.num_atoms, 2)
         self.assertEqual(c1.get_atomic_fraction('Mg'), 0.5)
@@ -368,11 +369,11 @@ class CompositionTest(PymatgenTest):
         self.assertEqual(c1.fractional_composition,
                          Composition('Mg-0.5Li0.5', allow_negative=True))
 
-        # test copy
+        #test copy
         self.assertEqual(c1.copy(), c1)
 
-        # test species
-        c1 = Composition({'Mg': 1, 'Mg2+': -1}, allow_negative=True)
+        #test species
+        c1 = Composition({'Mg':1, 'Mg2+':-1}, allow_negative=True)
         self.assertEqual(c1.num_atoms, 2)
         self.assertEqual(c1.element_composition, Composition())
         self.assertEqual(c1.average_electroneg, 1.31)
@@ -380,7 +381,7 @@ class CompositionTest(PymatgenTest):
     def test_special_formulas(self):
         special_formulas = {"LiO": "Li2O2", "NaO": "Na2O2", "KO": "K2O2",
                             "HO": "H2O2", "CsO": "Cs2O2", "RbO": "Rb2O2",
-                            "O": "O2", "N": "N2", "F": "F2", "Cl": "Cl2",
+                            "O": "O2",  "N": "N2", "F": "F2", "Cl": "Cl2",
                             "H": "H2"}
         for k, v in special_formulas.items():
             self.assertEqual(Composition(k).reduced_formula, v)
@@ -499,5 +500,5 @@ class ChemicalPotentialTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    # import sys;sys.argv = ['', 'Test.testName']
+    #import sys;sys.argv = ['', 'Test.testName']
     unittest.main()

--- a/pymatgen/core/tests/test_composition.py
+++ b/pymatgen/core/tests/test_composition.py
@@ -24,6 +24,7 @@ import unittest
 from pymatgen.core.periodic_table import Element, Specie
 from pymatgen.core.composition import Composition, CompositionError, \
     ChemicalPotential
+
 import random
 
 


### PR DESCRIPTION
## Summary

See the issue #1268

* Update Composition._parse_formula able to handle "@", that is usually used in Metallofullerene formula (e.g. Y3N@C80)
* Add test_Metallofullerene to test the updated parser