### PR TITLE
BSDOSPlotter bug fix

### DIFF
--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -2296,7 +2296,7 @@ class BSDOSPlotter(object):
                     label = "total" if spin == Spin.up else None
                     dos_ax.plot(dos_densities, dos_energies,
                                 color=(0.6, 0.6, 0.6), label=label)
-                    dos_ax.fill_between(dos_densities, 0, dos_energies,
+                    dos_ax.fill_betweenx(dos_energies, 0,dos_densities,
                                         color=(0.7, 0.7, 0.7),
                                         facecolor=(0.7, 0.7, 0.7))
 


### PR DESCRIPTION
I found a bug in plotting the dos.
In case the densities array have zeros 
in the first and last elements, the fill_between()
function fill the outer part of the dos and not the
inner one as it should.
In any case, since the dos plot has densities in the 
x-axis, the proper function to use should be fill_betweenx().