### PR TITLE
Non-integer subscripts in MolecularOrbitals class

### DIFF
--- a/pymatgen/core/molecular_orbitals.py
+++ b/pymatgen/core/molecular_orbitals.py
@@ -36,7 +36,7 @@ class MolecularOrbitals(object):
     def __init__(self, formula):
         '''
         Args:
-            A chemical formula as a string
+            chemical formula as a string. formula must have integer subscripts
             Ex: 'SrTiO3'
 
         Attributes:
@@ -53,6 +53,10 @@ class MolecularOrbitals(object):
         '''
         self.composition = Composition(formula).as_dict()
         self.elements = self.composition.keys()
+        for subscript in self.composition.values():
+            if not float(subscript).is_integer():
+                raise ValueError('composition subscripts must be integers')
+
         self.elec_neg = self.max_electronegativity()
         self.aos = {str(el): [[str(el), k, v]
                               for k, v in Element(el).atomic_orbitals.items()]

--- a/pymatgen/core/tests/test_molecular_orbitals.py
+++ b/pymatgen/core/tests/test_molecular_orbitals.py
@@ -33,6 +33,10 @@ class MolecularOrbitalTestCase(PymatgenTest):
         for k in test_edges.keys():
             self.assertEqual(test_edges[k], test_case.obtain_band_edges()[k])
 
+    # test for raising ValueError for fractional composition
+    def test_fractional_compositions(self):
+        self.assertRaises(ValueError, lambda: MolecularOrbitals('Na0.5Cl0.5'))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION

## Summary

* Semantically, `MolecularOrbitals` should only handle compositions with integer-valued subscripts.
* The doc strings for this class have been updated to reflect the intended use.
* A feature has been added that raises a `ValueError` when non-integer subscripts are used.

(the issue of non-integer subscripts propagated into _matminer_, where this issue was first identified)
