### PR TITLE
Change default VoronoiNN cutoff

### DIFF
--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -590,7 +590,7 @@ class VoronoiNN(NearNeighbors):
             (default: 0).
         targets (Element or list of Elements): target element(s).
         cutoff (float): cutoff radius in Angstrom to look for near-neighbor
-            atoms. Defaults to 10.0.
+            atoms. Defaults to 13.0.
         allow_pathological (bool): whether to allow infinite vertices in
             determination of Voronoi coordination.
         weight (string) - Statistic used to weigh neighbors (see the statistics
@@ -600,7 +600,7 @@ class VoronoiNN(NearNeighbors):
             for faster performance
     """
 
-    def __init__(self, tol=0, targets=None, cutoff=10.0,
+    def __init__(self, tol=0, targets=None, cutoff=13.0,
                  allow_pathological=False, weight='solid_angle',
                  extra_nn_info=True, compute_adj_neighbors=True):
         super(VoronoiNN, self).__init__()
@@ -645,8 +645,12 @@ class VoronoiNN(NearNeighbors):
         center = structure[n]
 
         cutoff = self.cutoff
-        max_cutoff = np.linalg.norm(
-            structure.lattice.lengths_and_angles[0]) + 0.01  # diagonal of cell
+
+        # max cutoff is the longest diagonal of the cell + room for noise
+        corners = [[1, 1, 1], [-1, 1, 1], [1, -1, 1], [1, 1, -1]]
+        d_corners = [np.linalg.norm(structure.lattice.get_cartesian_coords(c))
+                     for c in corners]
+        max_cutoff = max(d_corners) + 0.01
 
         while True:
             try:
@@ -657,19 +661,27 @@ class VoronoiNN(NearNeighbors):
 
                 # Run the Voronoi tessellation
                 qvoronoi_input = [s.coords for s in neighbors]
+
                 voro = Voronoi(
                     qvoronoi_input)  # can give seg fault if cutoff is too small
+
+                # Extract data about the site in question
+                cell_info = self._extract_cell_info(
+                    structure, 0, neighbors, targets, voro,
+                    self.compute_adj_neighbors)
                 break
 
-            except RuntimeError:
+            except RuntimeError as e:
                 if cutoff >= max_cutoff:
-                    raise RuntimeError("Error in Voronoi neighbor finding; max "
-                                       "cutoff exceeded")
+                    if e.args and "vertex" in e.args[0]:
+                        # pass through the error raised by _extract_cell_info
+                        raise e
+                    else:
+                        raise RuntimeError("Error in Voronoi neighbor finding; "
+                                           "max cutoff exceeded")
                 cutoff = min(cutoff * 2, max_cutoff + 0.001)
+        return cell_info
 
-        # Extract data about the site in question
-        return self._extract_cell_info(structure, 0, neighbors, targets, voro,
-                                       self.compute_adj_neighbors)
 
     def get_all_voronoi_polyhedra(self, structure):
         """Get the Voronoi polyhedra for all site in a simulation cell


### PR DESCRIPTION
## Summary

Change default cutoff of `VoronoiNN` from 10.0 to 13.0. This fixes #1281 for all 85,000 materials currently in the materials project database.

I have also changed the way the max_cutoff is calculated. Previously, the max cutoff was incorrect for cells with angles not equal to 90 deg (e.g. for the example in #1281). The max cutoff is now set to the largest of the 4 cell diagonals. I'm not confident that my implementation is the cleanest way to do this but it works.

Lastly, I moved the `self._extract_cell_info()` call to within the try-catch block, as I found that just increasing the cutoff fixed this error in most cases (maybe all cases). Just to be sure, I altered the error handling to make sure the right error message is thrown.