### PR TITLE
miller_index_from_sites now supports more than 3 sites

### DIFF
--- a/pymatgen/core/lattice.py
+++ b/pymatgen/core/lattice.py
@@ -5,6 +5,17 @@
 from __future__ import division, unicode_literals
 import math
 import itertools
+import warnings
+
+from functools import reduce
+try:
+    # New Py>=3.5 import
+    from math import gcd
+except ImportError:
+    # Deprecated import from Py3.5 onwards.
+    from fractions import gcd
+
+from fractions import Fraction
 
 from six.moves import map, zip
 
@@ -30,7 +41,6 @@ __status__ = "Production"
 __date__ = "Sep 23, 2011"
 
 
-
 class Lattice(MSONable):
     """
     A lattice object.  Essentially a matrix with conversion matrices. In
@@ -39,7 +49,6 @@ class Lattice(MSONable):
     """
 
     # Properties lazily generated for efficiency.
-
 
     def __init__(self, matrix):
         """
@@ -1117,3 +1126,93 @@ class Lattice(MSONable):
         mapped_vec = self.get_cartesian_coords(jimage + frac_coords2
                                                - frac_coords1)
         return np.linalg.norm(mapped_vec), jimage
+
+    def get_miller_index_from_sites(self, coords, coords_are_cartesian=True,
+                                    round_dp=4, verbose=True):
+        """
+        Get the Miller index of a plane from a set of sites.
+
+        A minimum of 3 sites are required. If more than 3 sites are given
+        the best plane that minimises the distance to all points will be
+        calculated.
+
+        Args:
+            coords (iterable): A list or numpy array of site coordinates. Can be
+                cartesian or fractional coordinates. If more than three sites
+                are provided, the best plane that minimises the distance to all
+                sites will be calculated.
+            coords_are_cartesian (bool, optional): Whether the coordinates are
+                in cartesian space. If using fractional coordinates set to
+                False.
+            round_dp (int, optional): The number of decimal places to round the
+                miller index to.
+            verbose (bool, optional): Whether to print warnings.
+
+        Returns:
+            (tuple): The Miller index.
+        """
+        if coords_are_cartesian:
+            coords = [self.get_fractional_coords(c) for c in coords]
+
+        coords = np.asarray(coords)
+        g = coords.sum(axis=0) / coords.shape[0]
+
+        # run singular value decomposition
+        _, _, vh = np.linalg.svd(coords - g)
+
+        # get unitary normal vector
+        u_norm = vh[2, :]
+        return get_integer_index(u_norm, round_dp=round_dp, verbose=verbose)
+
+
+def get_integer_index(miller_index, round_dp=4, verbose=True):
+    """
+    Attempt to convert a vector of floats to whole numbers.
+
+    Args:
+        miller_index (list of float): A list miller indexes.
+        round_dp (int, optional): The number of decimal places to round the
+            miller index to.
+        verbose (bool, optional): Whether to print warnings.
+
+    Returns:
+        (tuple): The Miller index.
+    """
+    miller_index = np.asarray(miller_index)
+
+    # deal with the case we have small irregular floats
+    # that are all equal or factors of each other
+    miller_index /= min([m for m in miller_index if m != 0])
+    miller_index /= np.max(np.abs(miller_index))
+
+    # deal with the case we have nice fractions
+    md = [Fraction(n).limit_denominator(12).denominator for n in miller_index]
+    miller_index *= reduce(lambda x, y: x * y, md)
+    round_miller_index = np.int_(np.round(miller_index, 1))
+    miller_index /= np.abs(reduce(gcd, round_miller_index))
+
+    # round to a reasonable precision
+    miller_index = np.array([round(h, round_dp) for h in miller_index])
+
+    # need to recalculate this after rounding as values may have changed
+    round_miller_index = np.int_(np.round(miller_index, 1))
+    if (np.any(np.abs(miller_index - round_miller_index) > 1e-6) and
+            verbose):
+        warnings.warn("Non-integer encountered in Miller index")
+
+    # minimise the number of negative indexes
+    miller_index += 0  # converts -0 to 0
+
+    def n_minus(index):
+        return len([h for h in index if h < 0])
+
+    if n_minus(miller_index) > n_minus(miller_index * -1):
+        miller_index *= -1
+
+    # if only one index is negative, make sure it is the smallest
+    # e.g. (-2 1 0) -> (2 -1 0)
+    if (sum(miller_index != 0) == 2 and n_minus(miller_index) == 1
+            and abs(min(miller_index)) > max(miller_index)):
+        miller_index *= -1
+
+    return tuple(miller_index)

--- a/pymatgen/core/lattice.py
+++ b/pymatgen/core/lattice.py
@@ -1127,20 +1127,20 @@ class Lattice(MSONable):
                                                - frac_coords1)
         return np.linalg.norm(mapped_vec), jimage
 
-    def get_miller_index_from_sites(self, coords, coords_are_cartesian=True,
-                                    round_dp=4, verbose=True):
+    def get_miller_index_from_coords(self, coords, coords_are_cartesian=True,
+                                     round_dp=4, verbose=True):
         """
-        Get the Miller index of a plane from a set of sites.
+        Get the Miller index of a plane from a list of site coordinates.
 
-        A minimum of 3 sites are required. If more than 3 sites are given
-        the best plane that minimises the distance to all points will be
-        calculated.
+        A minimum of 3 sets of coordinates are required. If more than 3 sets of
+        coordinates are given, the best plane that minimises the distance to all
+        points will be calculated.
 
         Args:
-            coords (iterable): A list or numpy array of site coordinates. Can be
-                cartesian or fractional coordinates. If more than three sites
-                are provided, the best plane that minimises the distance to all
-                sites will be calculated.
+            coords (iterable): A list or numpy array of coordinates. Can be
+                cartesian or fractional coordinates. If more than three sets of
+                coordinates are provided, the best plane that minimises the
+                distance to all sites will be calculated.
             coords_are_cartesian (bool, optional): Whether the coordinates are
                 in cartesian space. If using fractional coordinates set to
                 False.

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -1220,7 +1220,7 @@ class IStructure(SiteCollection, MSONable):
         Returns:
             (tuple): The Miller index.
         """
-        return self.lattice.get_miller_index_from_sites(
+        return self.lattice.get_miller_index_from_coords(
             self.frac_coords[site_ids], coords_are_cartesian=False,
             round_dp=round_dp, verbose=verbose)
 

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -1199,9 +1199,33 @@ class IStructure(SiteCollection, MSONable):
                                           site_properties=self.site_properties))
         return structs
 
+    def get_miller_index_from_site_indexes(self, site_ids, round_dp=4,
+                                           verbose=True):
+        """
+        Get the Miller index of a plane from a set of sites indexes.
+
+        A minimum of 3 sites are required. If more than 3 sites are given
+        the best plane that minimises the distance to all points will be
+        calculated.
+
+        Args:
+            site_ids (list of int): A list of site indexes to consider. A
+                minimum of three site indexes are required. If more than three
+                sites are provided, the best plane that minimises the distance
+                to all sites will be calculated.
+            round_dp (int, optional): The number of decimal places to round the
+                miller index to.
+            verbose (bool, optional): Whether to print warnings.
+
+        Returns:
+            (tuple): The Miller index.
+        """
+        return self.lattice.get_miller_index_from_sites(
+            self.frac_coords[site_ids], coords_are_cartesian=False,
+            round_dp=round_dp, verbose=verbose)
+
     def get_primitive_structure(self, tolerance=0.25, use_site_props=False,
-                                constrain_latt=[False, False, False, False,
-                                                False, False]):
+                                constrain_latt=None):
         """
         This finds a smaller unit cell than the input. Sometimes it doesn"t
         find the smallest possible one, so this method is recursively called
@@ -1224,6 +1248,8 @@ class IStructure(SiteCollection, MSONable):
         Returns:
             The most primitive structure found.
         """
+        if constrain_latt is None:
+            constrain_latt = [False, False, False, False, False, False]
 
         def site_label(site):
             if not use_site_props:

--- a/pymatgen/core/surface.py
+++ b/pymatgen/core/surface.py
@@ -1682,24 +1682,19 @@ def generate_all_slabs(structure, max_index, min_slab_size, min_vacuum_size,
 def miller_index_from_sites(lattice, coords, coords_are_cartesian=True,
                             round_dp=4, verbose=True):
     """
-    Get the Miller index of a plane from a set of sites.
+    Get the Miller index of a plane from a list of site coordinates.
 
-    A minimum of 3 sites are required. If more than 3 sites are given
-    the best plane that minimises the distance to all points will be
-    calculated.
-
-    If you use this module, please consider citing the following work::
-        Sun, W., & Ceder, G. (2018). A topological screening heuristic
-        for low-energy , high-index surfaces. Surface Science, 669(October
-        2017), 50–56. https://doi.org/10.1016/j.susc.2017.11.007
+    A minimum of 3 sets of coordinates are required. If more than 3 sets of
+    coordinates are given, the best plane that minimises the distance to all
+    points will be calculated.
 
     Args:
-        lattice (Lattice): A `Lattice` object for the structure. For example
-            obtained from Structure.lattice
-        coords (np.ndarray): A numpy array of site coordinates. Can be cartesian
-            or fractional coordinates. If more than three sites are provided,
-            the best plane that minimises the distance to all sites will be
-            calculated.
+        lattice (list or Lattice): A 3x3 lattice matrix or `Lattice` object (for
+            example obtained from Structure.lattice).
+        coords (iterable): A list or numpy array of coordinates. Can be
+            cartesian or fractional coordinates. If more than three sets of
+            coordinates are provided, the best plane that minimises the
+            distance to all sites will be calculated.
         coords_are_cartesian (bool, optional): Whether the coordinates are
             in cartesian space. If using fractional coordinates set to False.
         round_dp (int, optional): The number of decimal places to round the
@@ -1709,7 +1704,10 @@ def miller_index_from_sites(lattice, coords, coords_are_cartesian=True,
     Returns:
         (tuple): The Miller index.
     """
-    return lattice.get_miller_index_from_sites(
+    if not isinstance(lattice, Lattice):
+        lattice = Lattice(lattice)
+
+    return lattice.get_miller_index_from_coords(
         coords, coords_are_cartesian=coords_are_cartesian, round_dp=round_dp,
         verbose=verbose)
 

--- a/pymatgen/core/surface.py
+++ b/pymatgen/core/surface.py
@@ -1680,40 +1680,101 @@ def generate_all_slabs(structure, max_index, min_slab_size, min_vacuum_size,
     return all_slabs
 
 
-def get_integer_index(miller_index):
+def get_integer_index(miller_index, round_dp=4, verbose=True):
     """
-    Converts a vector of floats to whole numbers
+    Attempt to convert a vector of floats to whole numbers.
+
+    Args:
+        miller_index (list of float): A list miller indexes.
+        round_dp (int, optional): The number of decimal places to round the
+            miller index to.
+        verbose (bool, optional): Whether to print warnings.
+
+    Returns:
+        (tuple): The Miller index.
     """
+    miller_index = np.asarray(miller_index)
+
+    # deal with the case we have small irregular floats
+    # that are all equal or factors of each other
+    miller_index /= min([m for m in miller_index if m != 0])
+    miller_index /= np.max(np.abs(miller_index))
+
+    # deal with the case we have nice fractions
     md = [Fraction(n).limit_denominator(12).denominator for n in miller_index]
     miller_index *= reduce(lambda x, y: x * y, md)
     round_miller_index = np.int_(np.round(miller_index, 1))
-    if np.any(np.abs(miller_index - round_miller_index) > 1e-6):
+    miller_index /= np.abs(reduce(gcd, round_miller_index))
+
+    # round to a reasonable precision
+    miller_index = np.array([round(h, round_dp) for h in miller_index])
+
+    # need to recalculate this after rounding as values may have changed
+    round_miller_index = np.int_(np.round(miller_index, 1))
+    if (np.any(np.abs(miller_index - round_miller_index) > 1e-6) and
+            verbose):
         warnings.warn("Non-integer encountered in Miller index")
 
-    return miller_index / np.abs(reduce(gcd, round_miller_index))
+    # minimise the number of negative indexes
+    miller_index += 0  # converts -0 to 0
+
+    def n_minus(index):
+        return len([h for h in index if h < 0])
+
+    if n_minus(miller_index) > n_minus(miller_index * -1):
+        miller_index *= -1
+
+    # if only one index is negative, make sure it is the smallest
+    # e.g. (-2 1 0) -> (2 -1 0)
+    if (sum(miller_index != 0) == 2 and n_minus(miller_index) == 1
+            and abs(min(miller_index)) > max(miller_index)):
+        miller_index *= -1
+
+    return tuple(miller_index)
 
 
-def miller_index_from_sites(supercell_matrix, coords):
+def miller_index_from_sites(lattice, coords, coords_are_cartesian=True,
+                            round_dp=4, verbose=True):
     """
-    Get the Miller index of a plane from two vectors formed from three
-    cartesian coordinates. If you use this module, please consider
-    citing the following work::
+    Get the Miller index of a plane from a set of sites.
+
+    A minimum of 3 sites are required. If more than 3 sites are given
+    the best plane that minimises the distance to all points will be
+    calculated.
+
+    If you use this module, please consider citing the following work::
         Sun, W., & Ceder, G. (2018). A topological screening heuristic
         for low-energy , high-index surfaces. Surface Science, 669(October
         2017), 50–56. https://doi.org/10.1016/j.susc.2017.11.007
-    Args:
-        supercell_matrix: 3x3 matrix describing the supercell or unit cell
-        coords: List of three (numpy arrays) points as cartesian coordinates
-            in the corresponding cell
-    Returns:
-        The Miller index
-    """
 
-    v1 = np.dot(np.linalg.inv(np.transpose(supercell_matrix)),
-                coords[0] - coords[1])
-    v2 = np.dot(np.linalg.inv(np.transpose(supercell_matrix)),
-                coords[0] - coords[2])
-    return get_integer_index(np.transpose(np.cross(v1, v2)))
+    Args:
+        lattice (Lattice): A `Lattice` object for the structure. For example
+            obtained from Structure.lattice
+        coords (np.ndarray): A numpy array of site coordinates. Can be cartesian
+            or fractional coordinates. If more than three sites are provided,
+            the best plane that minimises the distance to all sites will be
+            calculated.
+        coords_are_cartesian (bool, optional): Whether the coordinates are
+            in cartesian space. If using fractional coordinates set to False.
+        round_dp (int, optional): The number of decimal places to round the
+            miller index to.
+        verbose (bool, optional): Whether to print warnings.
+
+    Returns:
+        (tuple): The Miller index.
+    """
+    if coords_are_cartesian:
+        coords = [lattice.get_fractional_coords(c) for c in coords]
+
+    coords = np.asarray(coords)
+    G = coords.sum(axis=0) / coords.shape[0]
+
+    # run singular value decomposition
+    u, s, vh = np.linalg.svd(coords - G)
+
+    # get unitary normal vector
+    u_norm = vh[2, :]
+    return get_integer_index(u_norm, round_dp=round_dp, verbose=verbose)
 
 
 def center_slab(slab):
@@ -1773,4 +1834,3 @@ def reduce_vector(vector):
     vector = tuple([int(i / d) for i in vector])
 
     return vector
-

--- a/pymatgen/core/tests/test_lattice.py
+++ b/pymatgen/core/tests/test_lattice.py
@@ -470,6 +470,40 @@ class LatticeTestCase(PymatgenTest):
         self.assertArrayAlmostEqual(l2.get_frac_coords_from_lll(lll_fcoords),
                                     l2_fcoords)
 
+    def test_get_miller_index_from_sites(self):
+        # test on a cubic system
+        m = Lattice.cubic(1)
+        s1 = np.array([0.5, -1.5, 3])
+        s2 = np.array([0.5, 3., -1.5])
+        s3 = np.array([2.5, 1.5, -4.])
+        self.assertEqual(m.get_miller_index_from_sites([s1, s2, s3]),
+                         (2, 1, 1))
+
+        # test on a hexagonal system
+        m = Lattice([[2.319, -4.01662582, 0.],
+                     [2.319, 4.01662582, 0.],
+                     [0., 0., 7.252]])
+
+        s1 = np.array([2.319, 1.33887527, 6.3455])
+        s2 = np.array([1.1595, 0.66943764, 4.5325])
+        s3 = np.array([1.1595, 0.66943764, 0.9065])
+        hkl = m.get_miller_index_from_sites([s1, s2, s3])
+        self.assertEqual(hkl, (2, -1, 0))
+
+        # test for previous failing structure
+        m = Lattice([10, 0, 0, 0, 10, 0, 0, 0, 10])
+        sites = [[0.5, 0.8, 0.8], [0.5, 0.4, 0.2], [0.5, 0.3, 0.7]]
+
+        hkl = m.get_miller_index_from_sites(sites, coords_are_cartesian=False)
+        self.assertEqual(hkl, (1, 0, 0))
+
+        # test for more than 3 sites
+        sites = [[0.5, 0.8, 0.8], [0.5, 0.4, 0.2], [0.5, 0.3, 0.7],
+                 [0.5, 0.1, 0.2]]
+
+        hkl = m.get_miller_index_from_sites(sites, coords_are_cartesian=False)
+        self.assertEqual(hkl, (1, 0, 0))
+
 
 if __name__ == '__main__':
     import unittest

--- a/pymatgen/core/tests/test_lattice.py
+++ b/pymatgen/core/tests/test_lattice.py
@@ -487,21 +487,21 @@ class LatticeTestCase(PymatgenTest):
         s1 = np.array([2.319, 1.33887527, 6.3455])
         s2 = np.array([1.1595, 0.66943764, 4.5325])
         s3 = np.array([1.1595, 0.66943764, 0.9065])
-        hkl = m.get_miller_index_from_sites([s1, s2, s3])
+        hkl = m.get_miller_index_from_coords([s1, s2, s3])
         self.assertEqual(hkl, (2, -1, 0))
 
         # test for previous failing structure
         m = Lattice([10, 0, 0, 0, 10, 0, 0, 0, 10])
         sites = [[0.5, 0.8, 0.8], [0.5, 0.4, 0.2], [0.5, 0.3, 0.7]]
 
-        hkl = m.get_miller_index_from_sites(sites, coords_are_cartesian=False)
+        hkl = m.get_miller_index_from_coords(sites, coords_are_cartesian=False)
         self.assertEqual(hkl, (1, 0, 0))
 
         # test for more than 3 sites
         sites = [[0.5, 0.8, 0.8], [0.5, 0.4, 0.2], [0.5, 0.3, 0.7],
                  [0.5, 0.1, 0.2]]
 
-        hkl = m.get_miller_index_from_sites(sites, coords_are_cartesian=False)
+        hkl = m.get_miller_index_from_coords(sites, coords_are_cartesian=False)
         self.assertEqual(hkl, (1, 0, 0))
 
 

--- a/pymatgen/core/tests/test_lattice.py
+++ b/pymatgen/core/tests/test_lattice.py
@@ -476,7 +476,7 @@ class LatticeTestCase(PymatgenTest):
         s1 = np.array([0.5, -1.5, 3])
         s2 = np.array([0.5, 3., -1.5])
         s3 = np.array([2.5, 1.5, -4.])
-        self.assertEqual(m.get_miller_index_from_sites([s1, s2, s3]),
+        self.assertEqual(m.get_miller_index_from_coords([s1, s2, s3]),
                          (2, 1, 1))
 
         # test on a hexagonal system

--- a/pymatgen/core/tests/test_structure.py
+++ b/pymatgen/core/tests/test_structure.py
@@ -364,6 +364,18 @@ class IStructureTest(PymatgenTest):
         sprim = s.get_primitive_structure(tolerance=0.1)
         self.assertEqual(len(sprim), 6)
 
+    def test_get_miller_index(self):
+        """Test for get miller index convenience method"""
+        struct = Structure(
+            [2.319, -4.01662582, 0., 2.319, 4.01662582, 0., 0., 0., 7.252],
+            ['Sn', 'Sn', 'Sn'],
+            [[2.319, 1.33887527, 6.3455], [1.1595, 0.66943764, 4.5325],
+             [1.1595, 0.66943764, 0.9065]],
+            coords_are_cartesian=True
+        )
+        hkl = struct.get_miller_index_from_site_indexes([0, 1, 2])
+        self.assertEqual(hkl, (2, -1, 0))
+
     def test_get_all_neighbors_and_get_neighbors(self):
         s = self.struct
         nn = s.get_neighbors_in_shell(s[0].frac_coords, 2, 4,

--- a/pymatgen/core/tests/test_surface.py
+++ b/pymatgen/core/tests/test_surface.py
@@ -677,23 +677,43 @@ class MillerIndexFinderTests(PymatgenTest):
 
     def test_miller_index_from_sites(self):
         # test on a cubic system
-        m = Lattice.cubic(1).matrix
+        m = Lattice.cubic(1)
         s1 = np.array([0.5, -1.5, 3])
         s2 = np.array([0.5, 3.,-1.5])
         s3 = np.array([2.5, 1.5,-4.])
-        self.assertEqual(tuple(miller_index_from_sites(m, [s1, s2, s3])),
-                         (-2,-1,-1))
+        self.assertEqual(miller_index_from_sites(m, [s1, s2, s3]),
+                         (2, 1, 1))
 
         # test on a hexagonal system
-        m = np.array([[2.319, -4.01662582, 0.],
-                      [2.319, 4.01662582, 0.],
-                      [0., 0., 7.252]])
+        m = Lattice([[2.319, -4.01662582, 0.],
+                     [2.319, 4.01662582, 0.],
+                     [0., 0., 7.252]])
 
         s1 = np.array([2.319, 1.33887527, 6.3455])
         s2 = np.array([1.1595, 0.66943764, 4.5325])
         s3 = np.array([1.1595, 0.66943764, 0.9065])
-        hkl = [np.round(i, 6) for i in miller_index_from_sites(m, [s1, s2, s3])]
-        self.assertEqual(tuple(hkl), (2, -1, 0))
+        hkl = miller_index_from_sites(m, [s1, s2, s3])
+        self.assertEqual(hkl, (2, -1, 0))
+
+        # test for previous failing structure
+        s = Structure(
+            [10, 0, 0, 0, 10, 0, 0, 0, 10],
+            ['Fe', 'Fe', 'Fe'],
+            [[0.5, 0.8, 0.8], [0.5, 0.4, 0.2], [0.5, 0.3, 0.7]]
+        )
+
+        hkl = miller_index_from_sites(s.lattice, s.cart_coords)
+        self.assertEqual(hkl, (1, 0, 0))
+
+        # test for more than 3 sites
+        s = Structure(
+            [10, 0, 0, 0, 10, 0, 0, 0, 10],
+            ['Fe', 'Fe', 'Fe', 'Fe'],
+            [[0.5, 0.8, 0.8], [0.5, 0.4, 0.2], [0.5, 0.3, 0.7], [0.5, 0.1, 0.2]]
+        )
+
+        hkl = miller_index_from_sites(s.lattice, s.cart_coords)
+        self.assertEqual(hkl, (1, 0, 0))
 
 
 if __name__ == "__main__":

--- a/pymatgen/core/tests/test_surface.py
+++ b/pymatgen/core/tests/test_surface.py
@@ -676,6 +676,8 @@ class MillerIndexFinderTests(PymatgenTest):
         self.assertEqual(len(miller_list), len(all_miller_list))
 
     def test_miller_index_from_sites(self):
+        """Test surface miller index convenience function"""
+
         # test on a cubic system
         m = Lattice.cubic(1)
         s1 = np.array([0.5, -1.5, 3])
@@ -683,37 +685,6 @@ class MillerIndexFinderTests(PymatgenTest):
         s3 = np.array([2.5, 1.5,-4.])
         self.assertEqual(miller_index_from_sites(m, [s1, s2, s3]),
                          (2, 1, 1))
-
-        # test on a hexagonal system
-        m = Lattice([[2.319, -4.01662582, 0.],
-                     [2.319, 4.01662582, 0.],
-                     [0., 0., 7.252]])
-
-        s1 = np.array([2.319, 1.33887527, 6.3455])
-        s2 = np.array([1.1595, 0.66943764, 4.5325])
-        s3 = np.array([1.1595, 0.66943764, 0.9065])
-        hkl = miller_index_from_sites(m, [s1, s2, s3])
-        self.assertEqual(hkl, (2, -1, 0))
-
-        # test for previous failing structure
-        s = Structure(
-            [10, 0, 0, 0, 10, 0, 0, 0, 10],
-            ['Fe', 'Fe', 'Fe'],
-            [[0.5, 0.8, 0.8], [0.5, 0.4, 0.2], [0.5, 0.3, 0.7]]
-        )
-
-        hkl = miller_index_from_sites(s.lattice, s.cart_coords)
-        self.assertEqual(hkl, (1, 0, 0))
-
-        # test for more than 3 sites
-        s = Structure(
-            [10, 0, 0, 0, 10, 0, 0, 0, 10],
-            ['Fe', 'Fe', 'Fe', 'Fe'],
-            [[0.5, 0.8, 0.8], [0.5, 0.4, 0.2], [0.5, 0.3, 0.7], [0.5, 0.1, 0.2]]
-        )
-
-        hkl = miller_index_from_sites(s.lattice, s.cart_coords)
-        self.assertEqual(hkl, (1, 0, 0))
 
 
 if __name__ == "__main__":

--- a/pymatgen/core/tests/test_surface.py
+++ b/pymatgen/core/tests/test_surface.py
@@ -686,6 +686,15 @@ class MillerIndexFinderTests(PymatgenTest):
         self.assertEqual(miller_index_from_sites(m, [s1, s2, s3]),
                          (2, 1, 1))
 
+        # test casting from matrix to Lattice
+        m = [[2.319, -4.01662582, 0.], [2.319, 4.01662582, 0.], [0., 0., 7.252]]
+
+        s1 = np.array([2.319, 1.33887527, 6.3455])
+        s2 = np.array([1.1595, 0.66943764, 4.5325])
+        s3 = np.array([1.1595, 0.66943764, 0.9065])
+        hkl = miller_index_from_sites(m, [s1, s2, s3])
+        self.assertEqual(hkl, (2, -1, 0))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Fixed bugs in `miller_index_from_sites` detailed in #1301. 

I also extended `miller_index_from_sites` to support passing more than 3 sites. In this case, the "best" plane that minimizes the distance from all atoms to the plane will be calculated using singular value decomposition. This behavior is the same as provided in the VESTA visualization tool.

Other changes include:
- Support for fractional or cartesian coordinates.
- Improvements in getting the integer miller index.
  - The number of negative indexes is minimized. E.g. `(-1 -1 1)` -> `(1 1 -1)`.
  - If there are negative indexes, the largest number should be possitivie. E.g. `(-2 1 0)` -> `(2 -1 0)`.
  - Other improvements to reliability.
- Tests for the failing case described in #1301.
- Tests for finding the plane with more than 3 sites.

One thing to note is that previously `miller_index_from_sites` required the lattice matrix as input, whereas now it requires a `Lattice` object. This is so I can calculate the fractional coordinates.