### PR TITLE
fixed the accidental overide of get_min_instability

### DIFF
--- a/pymatgen/apps/battery/insertion_battery.py
+++ b/pymatgen/apps/battery/insertion_battery.py
@@ -204,7 +204,7 @@ class InsertionElectrode(AbstractElectrode):
                 data.append(pair.decomp_e_charge)
             if pair.decomp_e_discharge is not None:
                 data.append(pair.decomp_e_discharge)
-        return min(data, key=lambda x: x['chempot']) if len(data) > 0 else None
+        return min(data) if len(data) > 0 else None
 
     def get_max_muO2(self, min_voltage=None, max_voltage=None):
         """
@@ -243,11 +243,11 @@ class InsertionElectrode(AbstractElectrode):
         """
         data = []
         for pair in self._select_in_voltage_range(min_voltage, max_voltage):
-            if pair.muO2_discharge is not None:
-                data.extend([d['chempot'] for d in pair.muO2_discharge])
-            if pair.muO2_charge is not None:
-                data.extend([d['chempot'] for d in pair.muO2_discharge])
-        return min(data) if len(data) > 0 else None
+            if pair.decomp_e_charge is not None:
+                data.append(pair.decomp_e_charge)
+            if pair.decomp_e_discharge is not None:
+                data.append(pair.decomp_e_discharge)
+        return min(data, key=lambda x: x['chempot']) if len(data) > 0 else None
 
     def get_sub_electrodes(self, adjacent_only=True, include_myself=True):
         """

--- a/pymatgen/apps/battery/insertion_battery.py
+++ b/pymatgen/apps/battery/insertion_battery.py
@@ -243,11 +243,11 @@ class InsertionElectrode(AbstractElectrode):
         """
         data = []
         for pair in self._select_in_voltage_range(min_voltage, max_voltage):
-            if pair.decomp_e_charge is not None:
-                data.append(pair.decomp_e_charge)
-            if pair.decomp_e_discharge is not None:
-                data.append(pair.decomp_e_discharge)
-        return min(data, key=lambda x: x['chempot']) if len(data) > 0 else None
+            if pair.muO2_discharge is not None:
+                data.extend([d['chempot'] for d in pair.muO2_discharge])
+            if pair.muO2_charge is not None:
+                data.extend([d['chempot'] for d in pair.muO2_discharge])
+        return min(data) if len(data) > 0 else None
 
     def get_sub_electrodes(self, adjacent_only=True, include_myself=True):
         """

--- a/pymatgen/apps/battery/tests/test_insertion_battery.py
+++ b/pymatgen/apps/battery/tests/test_insertion_battery.py
@@ -83,7 +83,10 @@ class InsertionElectrodeTest(unittest.TestCase):
         self.assertAlmostEqual(self.ie_MVO.get_capacity_grav(), 281.845548242, 3)
         self.assertAlmostEqual(self.ie_MVO.get_capacity_vol(), 1145.80087994, 3)
 
-
+    def test_get_instability(self):
+        self.assertIsNone(self.ie_LTO.get_max_instability())
+        self.assertAlmostEqual(self.ie_MVO.get_max_instability(), 0.7233711650000014)
+        self.assertAlmostEqual(self.ie_MVO.get_min_instability(), 0.4913575099999994)
 
     def test_get_muO2(self):
         self.assertIsNone(self.ie_LTO.get_max_muO2())


### PR DESCRIPTION
fixed the accidental override of get_min_instability
I also realized that there is no test for the get_min_instability and get_max_instability functions, and I will write them as part of this pull request, I just want to let you know that a typo was made on the last one that was not caught by the tests.