### PR TITLE
CrystalNN takes into account ionic radii

### DIFF
--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -3370,6 +3370,15 @@ class CrystalNN(NearNeighbors):
 
     @staticmethod
     def _get_default_radius(site):
+        """
+        An internal method to get a "default" covalent/element radius
+
+        Args:
+            site: (Site)
+
+        Returns:
+            Covalent radius of element on site, or Atomic radius if unavailable
+        """
         try:
             return CovalentRadius.radius[site.specie.symbol]
         except:
@@ -3379,22 +3388,26 @@ class CrystalNN(NearNeighbors):
     @staticmethod
     def _get_radius(site):
         """
-        An internal method to get the expected radius for a site.
+        An internal method to get the expected radius for a site with
+        oxidation state.
         Args:
             site: (Site)
 
         Returns:
-            Covalent radius of element on site, or Atomic radius if unavailable
+            Oxidation-state dependent radius: ionic, covalent, or atomic.
+            Returns 0 if no oxidation state or appropriate radius is found.
         """
         if hasattr(site.specie, 'oxi_state'):
             el = site.specie.element
             oxi = site.specie.oxi_state
+
             if oxi == 0:
                 return CrystalNN._get_default_radius(site)
 
             elif oxi in el.ionic_radii:
                 return el.ionic_radii[oxi]
 
+            # e.g., oxi = 2.667, average together 2+ and 3+ radii
             elif int(math.floor(oxi)) in el.ionic_radii and \
                     int(math.ceil(oxi)) in el.ionic_radii:
                 oxi_low = el.ionic_radii[int(math.floor(oxi))]
@@ -3409,10 +3422,9 @@ class CrystalNN(NearNeighbors):
                 return el.average_anionic_radius
 
         else:
-            warnings.warn("CrystalNN: distance cutoffs but no oxidation states "
-                          "set on sites! We strongly recommend you set "
-                          "oxidation states, especially if using default "
-                          "distance cutoff parameters.")
+            warnings.warn("CrystalNN: distance cutoffs set but no oxidation "
+                          "states specified on sites! For better results, set "
+                          "the site oxidation states in the structure.")
         return 0
 
     @staticmethod

--- a/pymatgen/analysis/tests/test_local_env.py
+++ b/pymatgen/analysis/tests/test_local_env.py
@@ -1036,13 +1036,28 @@ class CrystalNNTest(PymatgenTest):
         cnn = CrystalNN(weighted_cn=True)
         cn_array = []
 
+        expected_array = [5.863, 5.8716, 5.863 , 5.8716, 5.7182, 5.7182, 5.719,
+                          5.7181, 3.991 , 3.991 , 3.991 , 3.9907, 3.5997, 3.525,
+                          3.4133, 3.4714, 3.4727, 3.4133, 3.525 , 3.5997,
+                          3.5997, 3.525 , 3.4122, 3.4738, 3.4728, 3.4109,
+                          3.5259, 3.5997]
+        for idx, _ in enumerate(self.lifepo4):
+            cn_array.append(cnn.get_cn(self.lifepo4, idx, use_weights=True))
+
+        self.assertArrayAlmostEqual(expected_array, cn_array, 2)
+
+    def test_weighted_cn_no_oxid(self):
+        cnn = CrystalNN(weighted_cn=True)
+        cn_array = []
         expected_array = [5.8962, 5.8996, 5.8962, 5.8996, 5.7195, 5.7195,
                           5.7202, 5.7194, 4.0012, 4.0012, 4.0012, 4.0009,
                           3.3897, 3.2589, 3.1218, 3.1914, 3.1914, 3.1218,
                           3.2589, 3.3897, 3.3897, 3.2589, 3.1207, 3.1924,
                           3.1915, 3.1207, 3.2598, 3.3897]
-        for idx, _ in enumerate(self.lifepo4):
-            cn_array.append(cnn.get_cn(self.lifepo4, idx, use_weights=True))
+        s = self.lifepo4.copy()
+        s.remove_oxidation_states()
+        for idx, _ in enumerate(s):
+            cn_array.append(cnn.get_cn(s, idx, use_weights=True))
 
         self.assertArrayAlmostEqual(expected_array, cn_array, 2)
 
@@ -1060,7 +1075,7 @@ class CrystalNNTest(PymatgenTest):
     def test_x_diff_weight(self):
         cnn = CrystalNN(weighted_cn=True, x_diff_weight=0)
         self.assertAlmostEqual(cnn.get_cn(self.lifepo4, 0, use_weights=True),
-                               5.9522, 2)
+                               5.8630, 2)
 
     def test_noble_gas_material(self):
         cnn = CrystalNN()

--- a/pymatgen/core/periodic_table.py
+++ b/pymatgen/core/periodic_table.py
@@ -273,6 +273,16 @@ class Element(Enum):
         Average ionic radius for element in ang. The average is taken over all
         oxidation states of the element for which data is present.
 
+    .. attribute:: average_cationic_radius
+
+        Average cationic radius for element in ang. The average is taken over all
+        positive oxidation states of the element for which data is present.
+
+    .. attribute:: average_anionic_radius
+
+        Average ionic radius for element in ang. The average is taken over all
+        negative oxidation states of the element for which data is present.
+
     .. attribute:: ionic_radii
 
         All ionic radii of the element as a dict of
@@ -487,6 +497,36 @@ class Element(Enum):
             return sum(radii.values()) / len(radii)
         else:
             return 0
+
+    @property
+    @unitized("ang")
+    def average_cationic_radius(self):
+        """
+        Average cationic radius for element (with units). The average is
+        taken over all positive oxidation states of the element for which
+        data is present.
+        """
+        if "Ionic radii" in self._data:
+            radii = [v for k, v in self._data["Ionic radii"].items()
+                     if int(k) > 0]
+            if radii:
+                return sum(radii) / len(radii)
+        return 0
+
+    @property
+    @unitized("ang")
+    def average_anionic_radius(self):
+        """
+        Average anionic radius for element (with units). The average is
+        taken over all negative oxidation states of the element for which
+        data is present.
+        """
+        if "Ionic radii" in self._data:
+            radii = [v for k, v in self._data["Ionic radii"].items()
+                     if int(k) < 0]
+            if radii:
+                return sum(radii) / len(radii)
+        return 0
 
     @property
     @unitized("ang")

--- a/pymatgen/core/tests/test_periodic_table.py
+++ b/pymatgen/core/tests/test_periodic_table.py
@@ -135,6 +135,7 @@ class ElementTestCase(PymatgenTest):
                 "vickers_hardness", "density_of_solid", "atomic_orbitals"
                                                         "coefficient_of_linear_thermal_expansion", "oxidation_states",
                 "common_oxidation_states", "average_ionic_radius",
+                "average_cationic_radius", "average_anionic_radius",
                 "ionic_radii", "long_name", "metallic_radius"]
 
         # Test all elements up to Uranium


### PR DESCRIPTION
## Summary

If a structure has oxidation states set, CrystalNN will try to use ionic radii instead of covalent/atomic radii.

* PeriodicTable has two new attributes per element: ``average_cationic_radius`` and ``average_anionic_radius``. These are used in the new CrystalNN, and for elements like N, P, S etc that can act as both anions and cations, it is useful to have an average radius that doesn't mix together the positive and negative valence states.
* CrystalNN: if ``distance_cutoffs`` are set, CrystalNN will throw a warning if oxidation states are not set, although it will still work without oxidation states (just generally poorer results)
* CrystalNN: if ``distance_cutoffs`` are set, CrystalNN will use oxidation state data from the structure to set better ionic radii for those distance cutoffs.