### PR TITLE
Final energy contributions Outcar attribute

### DIFF
--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -1443,6 +1443,14 @@ class Outcar(object):
         Average electrostatic potential at each atomic position in order
         of the atoms in POSCAR.
 
+    ..attribute: final_energy_contribs
+        Individual contributions to the total final energy as a dictionary.
+        Include contirbutions from keys, e.g.:
+        {'DENC': -505778.5184347, 'EATOM': 15561.06492564, 'EBANDS': -804.53201231,
+        'EENTRO': -0.08932659, 'EXHF': 0.0, 'Ediel_sol': 0.0,
+        'PAW double counting': 664.6726974100002, 'PSCENC': 742.48691646,
+        'TEWEN': 489742.86847338, 'XCENC': -169.64189814}
+
     One can then call a specific reader depending on the type of run being
     performed. These are currently: read_igpar(), read_lepsilon() and
     read_lcalcpol(), read_core_state_eign(), read_avg_core_pot().

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -1657,6 +1657,19 @@ class Outcar(object):
             self.read_nmr_efg()
             self.read_nmr_efg_tensor()
 
+        # Store the individual contributions to the final total energy
+        final_energy_contribs = {}
+        for k in ["PSCENC", "TEWEN", "DENC", "EXHF", "XCENC", "PAW double counting",
+                  "EENTRO", "EBANDS", "EATOM", "Ediel_sol"]:
+            if k == "PAW double counting":
+                self.read_pattern({k: r"%s\s+=\s+([\.\-\d]+)\s+([\.\-\d]+)" % (k)})
+            else:
+                self.read_pattern({k: r"%s\s+=\s+([\d\-\.]+)" % (k)})
+            if not self.data[k]:
+                continue
+            final_energy_contribs[k] = sum([float(f) for f in self.data[k][-1]])
+        self.final_energy_contribs = final_energy_contribs
+
     def read_pattern(self, patterns, reverse=False, terminate_on_match=False,
                      postprocess=str):
         """

--- a/pymatgen/io/vasp/tests/test_outputs.py
+++ b/pymatgen/io/vasp/tests/test_outputs.py
@@ -601,6 +601,11 @@ class OutcarTest(PymatgenTest):
 
             self.assertFalse(outcar.lepsilon)
 
+            toten = 0
+            for k in outcar.final_energy_contribs.keys():
+                toten += outcar.final_energy_contribs[k]
+            self.assertAlmostEqual(toten, outcar.final_energy, 6)
+
     def test_stopped(self):
         filepath = os.path.join(test_dir, 'OUTCAR.stopped')
         outcar = Outcar(filepath)


### PR DESCRIPTION
The total energy stored in an OUTCAR file is the sum of individual contributions (e.g. contributions from alpha Z, Ewald energy, Hartree energy, exchange, V(xc)+E(xc), PAW double counting entropy T*S, eigenvalues, atomic energy and Solvation). 

Having this information stored as an attribute of the Outcar class (as a dictionary) would be useful if one wanted to compare the effects of different parameters or what might be contributing to the difference in energy between two similar but different systems.

Features:
-Outcar attribute "final_energy_contribs"
-Additional unittest for test_outputs.py