### PR TITLE
Add query-chunking capability to MPRester.query

### DIFF
--- a/pymatgen/ext/matproj.py
+++ b/pymatgen/ext/matproj.py
@@ -671,25 +671,29 @@ class MPRester(object):
         return ExpEntry(Composition(formula),
                         self.get_exp_thermo_data(formula))
 
-    def query(self, criteria, properties, mp_decode=True):
+    def query(self, criteria, properties, chunk_size=500, max_tries_per_chunk=5,
+              mp_decode=True):
         """
-        Performs an advanced query, which is a Mongo-like syntax for directly
-        querying the Materials Project database via the query rest interface.
-        Please refer to the Materials Project REST wiki
-        https://materialsproject.org/wiki/index.php/The_Materials_API#query
-        on the query language and supported criteria and properties.
-        Essentially, any supported properties within MPRester should be
-        supported in query.
 
-        Query allows an advanced developer to perform queries which are
-        otherwise too cumbersome to perform using the standard convenience
-        methods.
+        Performs an advanced query using MongoDB-like syntax for directly
+        querying the Materials Project database. This allows one to perform
+        queries which are otherwise too cumbersome to perform using the standard
+        convenience methods.
 
-        It is highly recommended that you consult the Materials API
-        documentation at http://bit.ly/materialsapi, which provides a
-        comprehensive explanation of the document schema used in the
-        Materials Project and how best to query for the relevant information
-        you need.
+        Please consult the Materials API documentation at
+        https://github.com/materialsproject/mapidoc, which provides a
+        comprehensive explanation of the document schema used in the Materials
+        Project (supported criteria and properties) and guidance on how best to
+        query for the relevant information you need.
+
+        For queries that request data on more than CHUNK_SIZE materials at once,
+        this method will chunk a query by first retrieving a list of material
+        IDs that satisfy CRITERIA, and then merging the criteria with a
+        restriction to one chunk of materials at a time of size CHUNK_SIZE. You
+        can opt out of this behavior by setting CHUNK_SIZE=0. To guard against
+        intermittent server errors in the case of many chunks per query,
+        possibly-transient server errors will result in re-trying a give chunk
+        up to MAX_TRIES_PER_CHUNK times.
 
         Args:
             criteria (str/dict): Criteria of the query as a string or
@@ -718,6 +722,12 @@ class MPRester(object):
             properties (list): Properties to request for as a list. For
                 example, ["formula", "formation_energy_per_atom"] returns
                 the formula and formation energy per atom.
+            chunk_size (int): Number of materials for which to fetch data at a
+                time. More data-intensive properties may require smaller chunk
+                sizes. Use chunk_size=0 to force no chunking -- this is useful
+                when fetching only properties such as 'material_id'.
+            max_tries_per_chunk (int): How many times to re-try fetching a given
+                chunk when the server gives a 5xx error (e.g. a timeout error).
             mp_decode (bool): Whether to do a decoding to a Pymatgen object
                 where possible. In some cases, it might be useful to just get
                 the raw python dict, i.e., set to False.
@@ -730,53 +740,34 @@ class MPRester(object):
             ...]
         """
         if not isinstance(criteria, dict):
-            criteria = MPRester.parse_criteria(criteria)
+            criteria = self.parse_criteria(criteria)
         payload = {"criteria": json.dumps(criteria),
                    "properties": json.dumps(properties)}
-        return self._make_request("/query", payload=payload, method="POST",
-                                  mp_decode=mp_decode)
+        if chunk_size == 0:
+            return self._make_request(
+                "/query", payload=payload, method="POST", mp_decode=mp_decode)
 
-    def bulk_query(self, criteria, properties, chunk_size=50,
-                   max_tries_per_chunk=5, **kwargs):
-        """
-        A wrapper around `MPRester.query` to accommodate queries for a large
-        total amount of data across materials. For queries that request more
-        data than the server can handle per material, i.e. too many properties,
-        you will get an error message, as with `MPRester.query`. This method
-        chunks a query by first retrieving a list of material IDs that satisfy
-        CRITERIA, and then merging the criteria with a restriction to one chunk
-        of materials at a time of size CHUNK_SIZE. Because this can be a
-        long-running method, unclear server errors will result in re-trying a
-        give chunk up to MAX_TRIES_PER_CHUNK times. All other arguments and
-        keyword arguments are passed to `MPRester.query`.
+        count_payload = payload.copy()
+        count_payload["options"] = json.dumps({"count_only": True})
+        num_results = self._make_request(
+            "/query", payload=count_payload, method="POST")
+        if num_results <= chunk_size:
+            return self._make_request(
+                "/query", payload=payload, method="POST", mp_decode=mp_decode)
 
-        Args:
-            criteria (str/dict): passed to `MPRester.query`
-            properties (list): passed to `MPRester.query`
-            chunk_size (int): Number of materials for which to fetch data at a
-                time. More data-intensive properties may require smaller chunk
-                sizes.
-            max_tries_per_chunk (int): How many times to re-try fetching a given
-                chunk when the server gives a 5xx error (e.g. a timeout error).
-            **kwargs: passed to `MPRester.query`
-
-        Returns:
-
-        """
         data = []
-        mids = [d["material_id"] for d in self.query(criteria, ["material_id"])]
+        mids = [d["material_id"] for d in
+                self.query(criteria, ["material_id"], chunk_size=0)]
         chunks = get_chunks(mids, size=chunk_size)
         progress_bar = PBar(total=len(mids))
-        if not isinstance(criteria, dict):
-            criteria = self.parse_criteria(criteria)
         for chunk in chunks:
             chunk_criteria = criteria.copy()
             chunk_criteria.update({"material_id": {"$in": chunk}})
             num_tries = 0
             while num_tries < max_tries_per_chunk:
                 try:
-                    data.extend(
-                        self.query(chunk_criteria, properties, **kwargs))
+                    data.extend(self.query(chunk_criteria, properties,
+                                           chunk_size=0, mp_decode=mp_decode))
                     break
                 except MPRestError as e:
                     match = re.search("error status code (\d+)", e.message)
@@ -785,7 +776,10 @@ class MPRester(object):
                             raise e
                         else:  # 5xx error. Try again
                             num_tries += 1
-                            print("trying again")
+                            print(
+                                "Unknown server error. Trying again in five "
+                                "seconds (will try at most {} times)...".format(
+                                    max_tries_per_chunk))
                             sleep(5)
             progress_bar.update(len(chunk))
         return data

--- a/pymatgen/ext/tests/test_matproj.py
+++ b/pymatgen/ext/tests/test_matproj.py
@@ -167,6 +167,16 @@ class MPResterTest(unittest.TestCase):
         self.assertGreaterEqual(len(data), 52)
         self.assertIn("Li2O", (d["pretty_formula"] for d in data))
 
+    def test_bulk_query(self):
+        criteria = {"nelements": 2, "elements": "O"}
+        props = ['pretty_formula']
+        data1 = self.rester.query(criteria=criteria, properties=props)
+        data2 = self.rester.bulk_query(
+            criteria=criteria, properties=props, chunk_size=500)
+        self.assertEqual({d['pretty_formula'] for d in data1},
+                         {d['pretty_formula'] for d in data2})
+        self.assertIn("Al2O3", {d['pretty_formula'] for d in data1})
+
     def test_get_exp_thermo_data(self):
         data = self.rester.get_exp_thermo_data("Fe2O3")
         self.assertTrue(len(data) > 0)

--- a/pymatgen/ext/tests/test_matproj.py
+++ b/pymatgen/ext/tests/test_matproj.py
@@ -161,17 +161,20 @@ class MPResterTest(unittest.TestCase):
     def test_query(self):
         criteria = {'elements': {'$in': ['Li', 'Na', 'K'], '$all': ['O']}}
         props = ['pretty_formula', 'energy']
-        data = self.rester.query(criteria=criteria, properties=props)
+        data = self.rester.query(
+            criteria=criteria, properties=props, chunk_size=0)
         self.assertTrue(len(data) > 6)
-        data = self.rester.query(criteria="*2O", properties=props)
+        data = self.rester.query(
+            criteria="*2O", properties=props, chunk_size=0)
         self.assertGreaterEqual(len(data), 52)
         self.assertIn("Li2O", (d["pretty_formula"] for d in data))
 
-    def test_bulk_query(self):
+    def test_query_chunk_size(self):
         criteria = {"nelements": 2, "elements": "O"}
         props = ['pretty_formula']
-        data1 = self.rester.query(criteria=criteria, properties=props)
-        data2 = self.rester.bulk_query(
+        data1 = self.rester.query(
+            criteria=criteria, properties=props, chunk_size=0)
+        data2 = self.rester.query(
             criteria=criteria, properties=props, chunk_size=500)
         self.assertEqual({d['pretty_formula'] for d in data1},
                          {d['pretty_formula'] for d in data2})

--- a/pymatgen/util/sequence.py
+++ b/pymatgen/util/sequence.py
@@ -1,0 +1,43 @@
+# coding: utf-8
+# Copyright (c) Pymatgen Development Team.
+# Distributed under the terms of the MIT License.
+
+from __future__ import unicode_literals, division, print_function
+
+import math
+
+"""
+This module provides utilities to chunk large sequences and display progress
+bars during processing.
+"""
+
+
+def get_chunks(sequence, size=1):
+    chunks = int(math.ceil(len(sequence) / float(size)))
+    return [sequence[i * size:(i + 1) * size]
+            for i in range(chunks)]
+
+class PBarSafe:
+    def __init__(self, total):
+        self.total = total
+        self.done = 0
+        self.report()
+
+    def update(self, amount):
+        self.done += amount
+        self.report()
+
+    def report(self):
+        print("{} of {} done {:.1%}".format(
+            self.done, self.total, self.done / self.total))
+
+try:
+    # noinspection PyUnresolvedReferences
+    if get_ipython().__class__.__name__ == 'ZMQInteractiveShell':
+        from tqdm import tqdm_notebook as PBar
+    else:  # likely 'TerminalInteractiveShell'
+        from tqdm import tqdm as PBar
+except NameError:
+    from tqdm import tqdm as PBar
+except ImportError:
+    PBar = PBarSafe

--- a/pymatgen/util/tests/test_sequence.py
+++ b/pymatgen/util/tests/test_sequence.py
@@ -1,0 +1,20 @@
+from unittest import TestCase
+
+from pymatgen.util.sequence import get_chunks, PBarSafe
+
+
+class SequenceUtilsTest(TestCase):
+    def setUp(self):
+        self.sequence = list(range(100))
+
+    def test_get_chunks(self):
+        lengths = [len(chunk) for chunk in get_chunks(self.sequence, 30)]
+        self.assertTrue(all(length == 30 for length in lengths[:-1]))
+        self.assertEqual(lengths[-1], 10)
+
+    def test_pbar_safe(self):
+        pbar = PBarSafe(len(self.sequence))
+        self.assertEqual(pbar.total, len(self.sequence))
+        self.assertEqual(pbar.done, 0)
+        pbar.update(10)
+        self.assertEqual(pbar.done, 10)


### PR DESCRIPTION
## Summary

Add a `bulk_query` method to `MPRester`, which wraps `query` to provide a better user experience for fetching a large sum of data across many materials. Fixes issue where user requests not too much data per material, but too much data overall in one query because the number of materials matching criteria is large.

* Chunk a query into multiple queries by first fetching a list of material ids satisfying the criteria.
* Re-try fetching chunks a configurable number of times in case of 5xx (e.g. timeout) errors.
* Improves user experience when fetching many material documents by providing a progress bar (uses `tqdm_notebook` if `tqdm` is installed and user is in Jupyter Notebook, falls back to plain `tqdm` if installed, and otherwise uses simple `print`-based progress indication.
* Puts general chunking and progress-bar sequence utilities in `pymatgen.util.sequence`.
* Adds unit tests for the above.