### PR TITLE
fix a bug of Element.valence of noble gases, and add tests

### DIFF
--- a/pymatgen/core/periodic_table.py
+++ b/pymatgen/core/periodic_table.py
@@ -612,6 +612,10 @@ class Element(Enum):
         # angular moment (L) and number of valence e- (v_e)
 
         """
+        # the number of valence of noble gas is 0
+        if self.group == 18:
+            return (np.nan, 0)
+
         L_symbols = 'SPDFGHIKLMNOQRTUVWXYZ'
         valence = []
         full_electron_config = self.full_electronic_structure

--- a/pymatgen/core/tests/test_periodic_table.py
+++ b/pymatgen/core/tests/test_periodic_table.py
@@ -67,6 +67,10 @@ class ElementTestCase(PymatgenTest):
         with self.assertRaises(ValueError):
             Element("U").valence
 
+        valence = Element("He").valence
+        self.assertTrue(np.isnan(valence[0]))
+        self.assertEqual(valence[1], 0)
+
     def test_term_symbols(self):
         testsets = {"Li": [['2S0.5']],  # s1
                     "C": [['1D2.0'],


### PR DESCRIPTION
# Summary

Fix a bug of [Element valence](https://github.com/materialsproject/pymatgen/blob/master/pymatgen/core/periodic_table.py#L609) with noble gases.

# bug
```Python
import pymatgen as mg
he=mg.Element("He")
he.valence
```
causes an error:
```
--> 585                 valence.append((l, ne))
IndexError: list index out of range
```

# How to fix
return `(np.nan, 0)` if element is noble gas.






