### PR TITLE
Structure component enhancements

### DIFF
--- a/pymatgen/analysis/dimensionality.py
+++ b/pymatgen/analysis/dimensionality.py
@@ -80,7 +80,7 @@ def get_structure_components(bonded_structure, inc_orientation=False,
     Requires a StructureGraph object as input. This can be generated using one
     of the NearNeighbor classes. For example, using the CrystalNN class::
 
-        Bonded_structure = CrystalNN().get_bonded_structure(structure)
+        bonded_structure = CrystalNN().get_bonded_structure(structure)
 
     Based on the modified breadth-first-search algorithm described in:
 

--- a/pymatgen/analysis/dimensionality.py
+++ b/pymatgen/analysis/dimensionality.py
@@ -67,7 +67,8 @@ def get_dimensionality_larsen(bonded_structure):
                 get_structure_component_info(bonded_structure)])
 
 
-def get_structure_component_info(bonded_structure, inc_orientation=False):
+def get_structure_component_info(bonded_structure, inc_orientation=False,
+                                 inc_site_ids=False):
     """
     Gets information on the components in a bonded structure.
 
@@ -90,6 +91,8 @@ def get_structure_component_info(bonded_structure, inc_orientation=False):
         inc_orientation (bool, optional): Whether to include the orientation
             of the structure component. For surfaces, the miller index is given,
             for one-dimensional structures, the direction of the chain is given.
+        inc_site_ids (bool, optional): Whether to include the site indices
+            of the sites in the structure component.
 
     Returns:
         (list of dict): Information on the components in a structure as a list
@@ -101,6 +104,8 @@ def get_structure_component_info(bonded_structure, inc_orientation=False):
             int.
         - "orientation": If inc_orientation is `True`, the orientation of the
             component as a tuple. E.g. (1, 1, 1)
+        - "site_ids": If inc_site_ids is `True`, the site indices of the
+            sites in the component as a tuple.
     """
     import networkx as nx  # optional dependency therefore not top level import
 
@@ -135,6 +140,9 @@ def get_structure_component_info(bonded_structure, inc_orientation=False):
                 orientation = None
 
             component['orientation'] = orientation
+
+        if inc_site_ids:
+            component['site_ids'] = tuple(graph.nodes())
 
         components.append(component)
     return components

--- a/pymatgen/analysis/dimensionality.py
+++ b/pymatgen/analysis/dimensionality.py
@@ -22,12 +22,14 @@ from __future__ import division, unicode_literals
 
 import itertools
 import copy
+
 import numpy as np
 
 from collections import defaultdict
 
+from pymatgen.analysis.graphs import MoleculeGraph
 from pymatgen.core.lattice import get_integer_index
-from pymatgen.core.structure import Structure
+from pymatgen.core.structure import Structure, Molecule
 from pymatgen.core.periodic_table import Specie
 from pymatgen.core.surface import SlabGenerator
 from pymatgen.analysis.local_env import JmolNN
@@ -68,7 +70,7 @@ def get_dimensionality_larsen(bonded_structure):
 
 
 def get_structure_component_info(bonded_structure, inc_orientation=False,
-                                 inc_site_ids=False):
+                                 inc_site_ids=False, inc_molecule_graph=False):
     """
     Gets information on the components in a bonded structure.
 
@@ -78,7 +80,7 @@ def get_structure_component_info(bonded_structure, inc_orientation=False,
     Requires a StructureGraph object as input. This can be generated using one
     of the NearNeighbor classes. For example, using the CrystalNN class::
 
-        bonded_structure = CrystalNN().get_bonded_structure(structure)
+        Bonded_structure = CrystalNN().get_bonded_structure(structure)
 
     Based on the modified breadth-first-search algorithm described in:
 
@@ -93,6 +95,8 @@ def get_structure_component_info(bonded_structure, inc_orientation=False,
             for one-dimensional structures, the direction of the chain is given.
         inc_site_ids (bool, optional): Whether to include the site indices
             of the sites in the structure component.
+        inc_molecule_graph (bool, optional): Whether to include MoleculeGraph
+            objects for zero-dimensional components.
 
     Returns:
         (list of dict): Information on the components in a structure as a list
@@ -106,6 +110,8 @@ def get_structure_component_info(bonded_structure, inc_orientation=False,
             component as a tuple. E.g. (1, 1, 1)
         - "site_ids": If inc_site_ids is `True`, the site indices of the
             sites in the component as a tuple.
+        - "molecule_graph": If inc_molecule_graph is `True`, the site a
+            MoleculeGraph object for zero-dimensional components.
     """
     import networkx as nx  # optional dependency therefore not top level import
 
@@ -143,6 +149,10 @@ def get_structure_component_info(bonded_structure, inc_orientation=False,
 
         if inc_site_ids:
             component['site_ids'] = tuple(graph.nodes())
+
+        if inc_molecule_graph and dimensionality == 0:
+            component['molecule_graph'] = zero_d_graph_to_molecule_graph(
+                bonded_structure, graph)
 
         components.append(component)
     return components
@@ -219,6 +229,55 @@ def calculate_dimensionality_of_site(bonded_structure, site_index,
                 list(seen_comp_vertices[site_index]))
     else:
         return rank(seen_comp_vertices[site_index])
+
+
+def zero_d_graph_to_molecule_graph(bonded_structure, graph):
+    """
+    Converts a zero-dimensional networkx Graph object into a MoleculeGraph.
+
+    Args:
+        bonded_structure (StructureGraph): A structure with bonds, represented
+            as a pymatgen structure graph. For example, generated using the
+            CrystalNN.get_bonded_structure() method.
+        graph (nx.Graph): A networkx `Graph` object for the component of
+            interest.
+
+    Returns:
+        (MoleculeGraph): A MoleculeGraph object of the component.
+    """
+    import networkx as nx
+    seen_indices = []
+    sites = []
+
+    start_index = list(graph.nodes())[0]
+    queue = [(start_index, (0, 0, 0),
+              bonded_structure.structure[start_index])]
+    while len(queue) > 0:
+        comp_i, image_i, site_i = queue.pop(0)
+
+        if comp_i in seen_indices:
+            raise ValueError("Graph component is not 0D")
+
+        seen_indices.append(comp_i)
+        sites.append(site_i)
+
+        for site_j in bonded_structure.get_connected_sites(
+                comp_i, jimage=image_i):
+
+            if site_j.index in seen_indices:
+                continue
+            else:
+                queue.append((site_j.index, site_j.jimage, site_j.site))
+
+    # sort the list of indices and the graph by index to make consistent
+    indices_ordering = np.argsort(seen_indices)
+    sorted_sites = np.array(sites, dtype=object)[indices_ordering]
+    sorted_graph = nx.convert_node_labels_to_integers(graph, ordering="sorted")
+    mol = Molecule([s.specie for s in sorted_sites],
+                   [s.coords for s in sorted_sites])
+    mol_graph = MoleculeGraph.with_edges(mol, nx.Graph(sorted_graph).edges())
+
+    return mol_graph
 
 
 def get_dimensionality_cheon(structure_raw, tolerance=0.45,

--- a/pymatgen/analysis/dimensionality.py
+++ b/pymatgen/analysis/dimensionality.py
@@ -66,11 +66,11 @@ def get_dimensionality_larsen(bonded_structure):
         (int): The dimensionality of the structure.
     """
     return max([c['dimensionality'] for c in
-                get_structure_component_info(bonded_structure)])
+                get_structure_components(bonded_structure)])
 
 
-def get_structure_component_info(bonded_structure, inc_orientation=False,
-                                 inc_site_ids=False, inc_molecule_graph=False):
+def get_structure_components(bonded_structure, inc_orientation=False,
+                             inc_site_ids=False, inc_molecule_graph=False):
     """
     Gets information on the components in a bonded structure.
 


### PR DESCRIPTION
## Summary

Added a number of features relating to structure components.

* `get_structure_component_info` renamed to `get_structure_components`
* `get_structure_components` can now return the indices of the corresponding sites in the original structure.
* Can also return `MoleculeGraph` objects for any zero dimensional components.

A future PR will use this functionality to replace the `Graph.get_subgraphs_as_molecules` implementation (will currently will fail for some systems).