### PR TITLE
Bug fix for `calculate_vol`

### DIFF
--- a/pymatgen/analysis/defects/tests/test_utils.py
+++ b/pymatgen/analysis/defects/tests/test_utils.py
@@ -12,7 +12,7 @@ import random
 from pymatgen.analysis.defects.utils import QModel, eV_to_k, \
     generate_reciprocal_vectors_squared, \
     closestsites, StructureMotifInterstitial, TopographyAnalyzer, \
-    ChargeDensityAnalyzer, converge
+    ChargeDensityAnalyzer, converge, calculate_vol
 from pymatgen.util.testing import PymatgenTest
 
 from pymatgen.core import PeriodicSite
@@ -233,6 +233,15 @@ class TopographyAnalyzerTest(unittest.TestCase):
                 else:
                     continue
             self.assertTrue(is_site_matched)
+
+    def test_calculate_vol(self):
+        s = Structure.from_file(os.path.join(test_dir, "LiFePO4.cif"))
+        a = TopographyAnalyzer(s, framework_ions=["O"],
+                               cations=["P", "Fe"], check_volume=False)
+        coords = [s[i].coords for i in [20, 23, 25, 17, 24, 19]]
+        vol = calculate_vol(coords=coords)
+        vol_expected = 12.8884  # LiO6 volume calculated by VESTA
+        self.assertAlmostEqual(vol, vol_expected, 4)
 
 
 @unittest.skipIf(not peak_local_max,

--- a/pymatgen/analysis/defects/tests/test_utils.py
+++ b/pymatgen/analysis/defects/tests/test_utils.py
@@ -9,8 +9,10 @@ import os
 import numpy as np
 import random
 
-from pymatgen.analysis.defects.utils import QModel, eV_to_k, generate_reciprocal_vectors_squared, \
-    closestsites, StructureMotifInterstitial, TopographyAnalyzer, ChargeDensityAnalyzer, converge
+from pymatgen.analysis.defects.utils import QModel, eV_to_k, \
+    generate_reciprocal_vectors_squared, \
+    closestsites, StructureMotifInterstitial, TopographyAnalyzer, \
+    ChargeDensityAnalyzer, converge
 from pymatgen.util.testing import PymatgenTest
 
 from pymatgen.core import PeriodicSite
@@ -24,7 +26,8 @@ try:
 except ImportError:
     peak_local_max = None
 
-test_dir = os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", 'test_files', "chgden")
+test_dir = os.path.join(os.path.dirname(__file__), "..", "..", "..", "..",
+                        'test_files', "chgden")
 
 
 class DefectsUtilsTest(PymatgenTest):
@@ -50,25 +53,36 @@ class DefectsUtilsTest(PymatgenTest):
     def test_generate_reciprocal_vectors_squared(self):
         # test cubic case
         a = 6.
-        lattvectors = [[a if i == j else 0. for j in range(3)] for i in range(3)]
+        lattvectors = [[a if i == j else 0. for j in range(3)] for i in
+                       range(3)]
         brecip = [1.0966227112321507 for i in range(6)]
         self.assertAlmostEqual(
-            list(generate_reciprocal_vectors_squared(lattvectors[0], lattvectors[1], lattvectors[2], 1.3)), brecip)
+            list(generate_reciprocal_vectors_squared(lattvectors[0],
+                                                     lattvectors[1],
+                                                     lattvectors[2], 1.3)),
+            brecip)
 
         # test orthorhombic case
         lattconsts = [a, a / 2., 3. * a]
-        lattvectors = [[lattconsts[i] if i == j else 0. for j in range(3)] for i in range(3)]
+        lattvectors = [[lattconsts[i] if i == j else 0. for j in range(3)] for i
+                       in range(3)]
         brval = 0.4873878716587337
         brecip = [brval, brval / 4., brval / 4., brval]
         self.assertAlmostEqual(
-            list(generate_reciprocal_vectors_squared(lattvectors[0], lattvectors[1], lattvectors[2], 1.)), brecip)
+            list(generate_reciprocal_vectors_squared(lattvectors[0],
+                                                     lattvectors[1],
+                                                     lattvectors[2], 1.)),
+            brecip)
 
         # test triclinic case
         lattvectors = [[1.5, 0.2, 0.3], [0.3, 1.2, .2], [0.5, 0.4, 1.3]]
         brval = 24.28330561545568
         brecip = [brval, brval]
         self.assertAlmostEqual(
-            list(generate_reciprocal_vectors_squared(lattvectors[0], lattvectors[1], lattvectors[2], 30.)), brecip)
+            list(generate_reciprocal_vectors_squared(lattvectors[0],
+                                                     lattvectors[1],
+                                                     lattvectors[2], 30.)),
+            brecip)
 
     def test_closest_sites(self):
         struct = PymatgenTest.get_structure("VO2")
@@ -90,16 +104,20 @@ class DefectsUtilsTest(PymatgenTest):
         self.assertEqual(dsite[2], 1)
 
     def test_converges(self):
-        self.assertAlmostEqual(converge(np.sqrt, 0.1, 0.1, 1.0), 0.6324555320336759)
+        self.assertAlmostEqual(converge(np.sqrt, 0.1, 0.1, 1.0),
+                               0.6324555320336759)
 
 
 class StructureMotifInterstitialTest(PymatgenTest):
     def setUp(self):
         self.silicon = Structure(
             Lattice.from_lengths_and_angles([5.47, 5.47, 5.47],
-                                            [90.0, 90.0, 90.0]), ["Si", "Si", "Si", "Si", "Si", "Si", "Si", "Si"],
-            [[0.000000, 0.000000, 0.500000], [0.750000, 0.750000, 0.750000], [0.000000, 0.500000, 1.000000],
-             [0.750000, 0.250000, 0.250000], [0.500000, 0.000000, 1.000000], [0.250000, 0.750000, 0.250000],
+                                            [90.0, 90.0, 90.0]),
+            ["Si", "Si", "Si", "Si", "Si", "Si", "Si", "Si"],
+            [[0.000000, 0.000000, 0.500000], [0.750000, 0.750000, 0.750000],
+             [0.000000, 0.500000, 1.000000],
+             [0.750000, 0.250000, 0.250000], [0.500000, 0.000000, 1.000000],
+             [0.250000, 0.750000, 0.250000],
              [0.500000, 0.500000, 0.500000], [0.250000, 0.250000, 0.750000]],
             validate_proximity=False,
             to_unit_cell=False,
@@ -114,36 +132,43 @@ class StructureMotifInterstitialTest(PymatgenTest):
             doverlap=1.0,
             facmaxdl=1.51)
         self.diamond = Structure(
-            Lattice([[2.189, 0, 1.264], [0.73, 2.064, 1.264], [0, 0, 2.528]]), ["C0+", "C0+"],
+            Lattice([[2.189, 0, 1.264], [0.73, 2.064, 1.264], [0, 0, 2.528]]),
+            ["C0+", "C0+"],
             [[2.554, 1.806, 4.423], [0.365, 0.258, 0.632]],
             validate_proximity=False,
             to_unit_cell=False,
             coords_are_cartesian=True,
             site_properties=None)
         self.nacl = Structure(
-            Lattice([[3.485, 0, 2.012], [1.162, 3.286, 2.012], [0, 0, 4.025]]), ["Na1+", "Cl1-"],
+            Lattice([[3.485, 0, 2.012], [1.162, 3.286, 2.012], [0, 0, 4.025]]),
+            ["Na1+", "Cl1-"],
             [[0, 0, 0], [2.324, 1.643, 4.025]],
             validate_proximity=False,
             to_unit_cell=False,
             coords_are_cartesian=True,
             site_properties=None)
         self.cscl = Structure(
-            Lattice([[4.209, 0, 0], [0, 4.209, 0], [0, 0, 4.209]]), ["Cl1-", "Cs1+"],
+            Lattice([[4.209, 0, 0], [0, 4.209, 0], [0, 0, 4.209]]),
+            ["Cl1-", "Cs1+"],
             [[2.105, 2.105, 2.105], [0, 0, 0]],
             validate_proximity=False,
             to_unit_cell=False,
             coords_are_cartesian=True,
             site_properties=None)
         self.square_pyramid = Structure(
-            Lattice([[100, 0, 0], [0, 100, 0], [0, 0, 100]]), ["C", "C", "C", "C", "C", "C"],
-            [[0, 0, 0], [1, 0, 0], [-1, 0, 0], [0, 1, 0], [0, -1, 0], [0, 0, 1]],
+            Lattice([[100, 0, 0], [0, 100, 0], [0, 0, 100]]),
+            ["C", "C", "C", "C", "C", "C"],
+            [[0, 0, 0], [1, 0, 0], [-1, 0, 0], [0, 1, 0], [0, -1, 0],
+             [0, 0, 1]],
             validate_proximity=False,
             to_unit_cell=False,
             coords_are_cartesian=True,
             site_properties=None)
         self.trigonal_bipyramid = Structure(
-            Lattice([[100, 0, 0], [0, 100, 0], [0, 0, 100]]), ["P", "Cl", "Cl", "Cl", "Cl", "Cl"],
-            [[0, 0, 0], [0, 0, 2.14], [0, 2.02, 0], [1.74937, -1.01, 0], [-1.74937, -1.01, 0], [0, 0, -2.14]],
+            Lattice([[100, 0, 0], [0, 100, 0], [0, 0, 100]]),
+            ["P", "Cl", "Cl", "Cl", "Cl", "Cl"],
+            [[0, 0, 0], [0, 0, 2.14], [0, 2.02, 0], [1.74937, -1.01, 0],
+             [-1.74937, -1.01, 0], [0, 0, -2.14]],
             validate_proximity=False,
             to_unit_cell=False,
             coords_are_cartesian=True,
@@ -153,7 +178,8 @@ class StructureMotifInterstitialTest(PymatgenTest):
         self.assertIsInstance(self.smi, StructureMotifInterstitial)
         self.assertEqual(len(self.smi.enumerate_defectsites()), 1)
         self.assertIsInstance(self.smi.enumerate_defectsites()[0], PeriodicSite)
-        self.assertEqual("Si", self.smi.enumerate_defectsites()[0].species_string)
+        self.assertEqual("Si",
+                         self.smi.enumerate_defectsites()[0].species_string)
         self.assertEqual("tetrahedral", self.smi.get_motif_type(0))
 
         elem_cn_dict = self.smi.get_coordinating_elements_cns(0)
@@ -182,17 +208,21 @@ class TopographyAnalyzerTest(unittest.TestCase):
 
     def test_topography_analyzer(self):
         # check interstitial sites for FePO4 using Voronoi Tessellation
-        vor_feo4 = TopographyAnalyzer(self.feo4, framework_ions=["O"], cations=["P", "Fe"], check_volume=False)
+        vor_feo4 = TopographyAnalyzer(self.feo4, framework_ions=["O"],
+                                      cations=["P", "Fe"], check_volume=False)
         vor_feo4.cluster_nodes(tol=1.2)
         vor_feo4.remove_collisions(1.2)
         s_feo4 = vor_feo4.get_structure_with_nodes()
-        sites_feo4 = np.array([s_feo4[i].frac_coords for i in range(len(s_feo4)) if s_feo4[i].species_string == "X0+"])
+        sites_feo4 = np.array(
+            [s_feo4[i].frac_coords for i in range(len(s_feo4)) if
+             s_feo4[i].species_string == "X0+"])
 
         # check total number of vnodes
         self.assertAlmostEqual(len(vor_feo4.vnodes), 24)
 
         # check four sites that match Li sites in LiFePO4(mp-19017)
-        site_predicted = [[0, 0, 0], [0.5, 0.5, 0.5], [0.5, 0, 0.5], [0, 0.5, 0]]
+        site_predicted = [[0, 0, 0], [0.5, 0.5, 0.5], [0.5, 0, 0.5],
+                          [0, 0.5, 0]]
         for i in range(0, 4):
             is_site_matched = False
             for site in sites_feo4:
@@ -205,7 +235,8 @@ class TopographyAnalyzerTest(unittest.TestCase):
             self.assertTrue(is_site_matched)
 
 
-@unittest.skipIf(not peak_local_max, "skimage.feature.peak_local_max module not present.")
+@unittest.skipIf(not peak_local_max,
+                 "skimage.feature.peak_local_max module not present.")
 class ChgDenAnalyzerTest(unittest.TestCase):
     def setUp(self):
         # This is a CHGCAR_sum file with reduced grid size
@@ -214,7 +245,8 @@ class ChgDenAnalyzerTest(unittest.TestCase):
         self.chgcar_path = chgcar_path
         self.chg_FePO4 = chg_FePO4
         self.ca_FePO4 = ChargeDensityAnalyzer(chg_FePO4)
-        self.s_LiFePO4 = Structure.from_file(os.path.join(test_dir, "LiFePO4.cif"))
+        self.s_LiFePO4 = Structure.from_file(
+            os.path.join(test_dir, "LiFePO4.cif"))
 
     def test_get_local_extrema(self):
         ca = ChargeDensityAnalyzer.from_file(self.chgcar_path)
@@ -223,28 +255,38 @@ class ChgDenAnalyzerTest(unittest.TestCase):
         threshold_abs_max = random.randrange(27e2, 28e4)
 
         # Minima test
-        full_list_min = self.ca_FePO4.get_local_extrema(find_min=True, threshold_frac=1.0)
-        frac_list_min_frac = self.ca_FePO4.get_local_extrema(find_min=True, threshold_frac=threshold_frac)
-        frac_list_min_abs = self.ca_FePO4.get_local_extrema(find_min=True, threshold_abs=threshold_abs_min)
+        full_list_min = self.ca_FePO4.get_local_extrema(find_min=True,
+                                                        threshold_frac=1.0)
+        frac_list_min_frac = self.ca_FePO4.get_local_extrema(find_min=True,
+                                                             threshold_frac=threshold_frac)
+        frac_list_min_abs = self.ca_FePO4.get_local_extrema(find_min=True,
+                                                            threshold_abs=threshold_abs_min)
 
-        self.assertAlmostEqual(len(full_list_min) * threshold_frac, len(frac_list_min_frac), delta=1)
+        self.assertAlmostEqual(len(full_list_min) * threshold_frac,
+                               len(frac_list_min_frac), delta=1)
 
         ca.get_local_extrema(find_min=True)
-        df_expected = ca.extrema_df[ca.extrema_df["Charge Density"] <= threshold_abs_min]
+        df_expected = ca.extrema_df[
+            ca.extrema_df["Charge Density"] <= threshold_abs_min]
         self.assertEqual(len(frac_list_min_abs), len(df_expected))
 
         # Maxima test
-        full_list_max = self.ca_FePO4.get_local_extrema(find_min=False, threshold_frac=1.0)
-        frac_list_max = self.ca_FePO4.get_local_extrema(find_min=False, threshold_frac=threshold_frac)
-        frac_list_max_abs = self.ca_FePO4.get_local_extrema(find_min=False, threshold_abs=threshold_abs_max)
+        full_list_max = self.ca_FePO4.get_local_extrema(find_min=False,
+                                                        threshold_frac=1.0)
+        frac_list_max = self.ca_FePO4.get_local_extrema(find_min=False,
+                                                        threshold_frac=threshold_frac)
+        frac_list_max_abs = self.ca_FePO4.get_local_extrema(find_min=False,
+                                                            threshold_abs=threshold_abs_max)
 
-        self.assertAlmostEqual(len(full_list_max) * threshold_frac, len(frac_list_max), delta=1)
+        self.assertAlmostEqual(len(full_list_max) * threshold_frac,
+                               len(frac_list_max), delta=1)
 
         # Local maxima should finds all center of atoms
         self.assertEqual(len(self.ca_FePO4.structure), len(full_list_max))
 
         ca.get_local_extrema(find_min=False)
-        df_expected = ca.extrema_df[ca.extrema_df["Charge Density"] >= threshold_abs_max]
+        df_expected = ca.extrema_df[
+            ca.extrema_df["Charge Density"] >= threshold_abs_max]
         self.assertEqual(len(frac_list_max_abs), len(df_expected))
 
     def test_remove_collisions(self):
@@ -272,8 +314,10 @@ class ChgDenAnalyzerTest(unittest.TestCase):
             if self.s_LiFePO4[i].species_string == "Li"
         ])
         sites_guess = np.array(
-            [s_FePO4[i].frac_coords for i in range(len(s_FePO4)) if s_FePO4[i].species_string == "X0+"])
-        distances = s_FePO4.lattice.get_all_distances(sites_predicted, sites_guess).flatten()
+            [s_FePO4[i].frac_coords for i in range(len(s_FePO4)) if
+             s_FePO4[i].species_string == "X0+"])
+        distances = s_FePO4.lattice.get_all_distances(sites_predicted,
+                                                      sites_guess).flatten()
         distances = [d for d in distances if d < 0.1]
         self.assertEqual(len(distances), len(sites_predicted))
 
@@ -290,8 +334,10 @@ class ChgDenAnalyzerTest(unittest.TestCase):
         self.assertAlmostEqual(ca._extrema_df.iloc[0]['a'], 0.0)
         self.assertAlmostEqual(ca._extrema_df.iloc[0]['b'], 0.5)
         self.assertAlmostEqual(ca._extrema_df.iloc[0]['c'], 0.0)
-        self.assertAlmostEqual(ca._extrema_df.iloc[0]['Charge Density'], 1.65288944124)
-        self.assertAlmostEqual(ca._extrema_df.iloc[0]['Int. Charge Density'], 0.0018375161626331743)
+        self.assertAlmostEqual(ca._extrema_df.iloc[0]['Charge Density'],
+                               1.65288944124)
+        self.assertAlmostEqual(ca._extrema_df.iloc[0]['Int. Charge Density'],
+                               0.0018375161626331743)
 
 
 if __name__ == "__main__":

--- a/pymatgen/analysis/defects/utils.py
+++ b/pymatgen/analysis/defects/utils.py
@@ -1200,7 +1200,7 @@ def calculate_vol(coords):
         center = np.average(coords, axis=0)
         vol = 0
         for s in simplices:
-            c = list(s.coords)
+            c = list(coords[i] for i in s)
             c.append(center)
             vol += calculate_vol(c)
         return vol


### PR DESCRIPTION
## Summary

Hi @mkhorton, I have fixed the unittest, where I commited the wrong file. This PR fixes bug in `calculate_vol` and corresponding test has been added.

This bug can be reproduced as:
```python
>>> from pymatgen.analysis.defects.utils import TopographyAnalyzer, calculate_vol
>>> from pymatgen.core import Structure

>>> s = Structure.from_file("pymatgen/test_files/chgden/LiFePO4.cif")
>>> a = TopographyAnalyzer(s, ["P", "O"], ["Fe"], check_volume=False, tol=0.1)
>>> a.remove_collisions(1.5)
>>> print([v.volume for v in a.vnodes])
...
AttributeError: 'numpy.ndarray' object has no attribute 'coords'
```

* Fixed a minor bug in `calculate_vol`
* Added unittests
* formatting