### PR TITLE
Add error throwing for negative max_sites in Composition.oxi_state_guesses

### DIFF
--- a/pymatgen/core/tests/test_composition.py
+++ b/pymatgen/core/tests/test_composition.py
@@ -433,6 +433,16 @@ class CompositionTest(PymatgenTest):
                          oxi_state_guesses(max_sites=-1)[0],
                          {"Li": 1, "Fe": 2, "P": 5, "O": -2})
 
+        # negative max_sites less than -1 - should throw error if cannot reduce
+        # to under the abs(max_sites) number of sites. Will also timeout if
+        # incorrect.
+        self.assertEqual(
+            Composition("Sb10000O10000F10000").oxi_state_guesses(
+                max_sites=-3)[0],
+            {"Sb": 3, "O": -2, "F": -1})
+        self.assertRaises(ValueError, Composition("LiOF").oxi_state_guesses,
+                          max_sites=-2)
+
         self.assertRaises(ValueError, Composition("V2O3").
                           oxi_state_guesses, max_sites=1)
 


### PR DESCRIPTION
## Summary

Composition.oxi_state_guesses currently has a `max_sites` option where, if possible, the composition will be reduced to at most this many sites to speed up oxidation state guesses. If the structure cannot be reduced to this many sites an error will be thrown. If `-1` is passed to `max_sites` the composition will be fully reduced. However, the current behavior does not indicate whether the composition has been reduced at all. This can lead to very long running times for large systems which cannot be reduced.

This PR allows setting `max_sites` to negative numbers less than -1. In this case, the structure will be fully reduced however an error will be thrown if the number of sites in the reduced structure is greater than `abs(max_sites)`. This allows one to fully reduce the composition but avoid calculating the oxidation states for very large structures.
