### PR TITLE
Bug fix in core.composition

### DIFF
--- a/pymatgen/core/composition.py
+++ b/pymatgen/core/composition.py
@@ -588,7 +588,7 @@ class Composition(collections.Hashable, collections.Mapping, MSONable):
         return {"reduced_cell_composition": self.to_reduced_dict,
                 "unit_cell_composition": self.as_dict(),
                 "reduced_cell_formula": self.reduced_formula,
-                "elements": self.as_dict().keys(),
+                "elements": list(self.as_dict().keys()),
                 "nelements": len(self.as_dict().keys())}
 
     def oxi_state_guesses(self, oxi_states_override=None, target_charge=0,

--- a/pymatgen/core/tests/test_composition.py
+++ b/pymatgen/core/tests/test_composition.py
@@ -257,6 +257,7 @@ class CompositionTest(PymatgenTest):
     def test_pickle(self):
         for c in self.comp:
             self.serialize_with_pickle(c, test_eq=True)
+            self.serialize_with_pickle(c.to_data_dict, test_eq=True)
 
     def test_add(self):
         self.assertEqual((self.comp[0] + self.comp[2]).formula,


### PR DESCRIPTION
to_data_dict['element'] returned <dict_keys> which is a generator and cannot be pickled