### PR TITLE
Remove logging.basicConfig call in graphs.py

### DIFF
--- a/pymatgen/analysis/graphs.py
+++ b/pymatgen/analysis/graphs.py
@@ -29,7 +29,7 @@ from networkx.readwrite import json_graph
 from networkx.drawing.nx_agraph import write_dot
 
 import logging
-logging.basicConfig(level=logging.INFO)
+
 logger = logging.getLogger(__name__)
 
 __author__ = "Matthew Horton, Evan Spotte-Smith"

--- a/pymatgen/analysis/graphs.py
+++ b/pymatgen/analysis/graphs.py
@@ -31,6 +31,7 @@ from networkx.drawing.nx_agraph import write_dot
 import logging
 
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 __author__ = "Matthew Horton, Evan Spotte-Smith"
 __version__ = "0.1"
@@ -58,6 +59,7 @@ class StructureGraph(MSONable):
 
         This class that contains connection information:
         relationships between sites represented by a Graph structure,
+
         and an associated structure object.
 
         This class uses the NetworkX package to store and operate

--- a/pymatgen/analysis/graphs.py
+++ b/pymatgen/analysis/graphs.py
@@ -59,7 +59,6 @@ class StructureGraph(MSONable):
 
         This class that contains connection information:
         relationships between sites represented by a Graph structure,
-
         and an associated structure object.
 
         This class uses the NetworkX package to store and operate


### PR DESCRIPTION
## Summary

`graphs.py` currently has a call to `logging.basicConfig` to set the logging level. This will affect the top level logger rather than the module level logger. The code now sets the logging level of the module level logger.