### PR TITLE
Fix integer miller indices

### DIFF
--- a/pymatgen/core/lattice.py
+++ b/pymatgen/core/lattice.py
@@ -1189,17 +1189,19 @@ def get_integer_index(miller_index, round_dp=4, verbose=True):
     # deal with the case we have nice fractions
     md = [Fraction(n).limit_denominator(12).denominator for n in miller_index]
     miller_index *= reduce(lambda x, y: x * y, md)
-    round_miller_index = np.int_(np.round(miller_index, 1))
-    miller_index /= np.abs(reduce(gcd, round_miller_index))
+    int_miller_index = np.int_(np.round(miller_index, 1))
+    miller_index /= np.abs(reduce(gcd, int_miller_index))
 
     # round to a reasonable precision
     miller_index = np.array([round(h, round_dp) for h in miller_index])
 
     # need to recalculate this after rounding as values may have changed
-    round_miller_index = np.int_(np.round(miller_index, 1))
-    if (np.any(np.abs(miller_index - round_miller_index) > 1e-6) and
+    int_miller_index = np.int_(np.round(miller_index, 1))
+    if (np.any(np.abs(miller_index - int_miller_index) > 1e-6) and
             verbose):
         warnings.warn("Non-integer encountered in Miller index")
+    else:
+        miller_index = int_miller_index
 
     # minimise the number of negative indexes
     miller_index += 0  # converts -0 to 0


### PR DESCRIPTION
## Summary

The `get_integer_index` function for miller indices now correctly returns integer indices when possible (if an integer index cannot be determined a floating point index is given).

E.g. `get_integer_index((2, 2, 0))` now gives `(1, 1, 0)` rather than `(1.0, 1.0, 0)`.