### PR TITLE
Add option to return graph for structure components

### DIFF
--- a/pymatgen/analysis/dimensionality.py
+++ b/pymatgen/analysis/dimensionality.py
@@ -70,7 +70,8 @@ def get_dimensionality_larsen(bonded_structure):
 
 
 def get_structure_components(bonded_structure, inc_orientation=False,
-                             inc_site_ids=False, inc_molecule_graph=False):
+                             inc_site_ids=False, inc_molecule_graph=False,
+                             inc_graph=False):
     """
     Gets information on the components in a bonded structure.
 
@@ -97,6 +98,8 @@ def get_structure_components(bonded_structure, inc_orientation=False,
             of the sites in the structure component.
         inc_molecule_graph (bool, optional): Whether to include MoleculeGraph
             objects for zero-dimensional components.
+        inc_graph (bool, optional): Whether to include the component Graph
+            object.
 
     Returns:
         (list of dict): Information on the components in a structure as a list
@@ -112,6 +115,9 @@ def get_structure_components(bonded_structure, inc_orientation=False,
             sites in the component as a tuple.
         - "molecule_graph": If inc_molecule_graph is `True`, the site a
             MoleculeGraph object for zero-dimensional components.
+        - "graph": If inc_graph is `True`, the networkx Graph for the component.
+            The node indices have been reordered to match the site indices
+            for the component structure rather than the initial structure.
     """
     import networkx as nx  # optional dependency therefore not top level import
 
@@ -120,7 +126,7 @@ def get_structure_components(bonded_structure, inc_orientation=False,
 
     components = []
     for graph in comp_graphs:
-        sites = [bonded_structure.structure[n] for n in graph.nodes()]
+        sites = [bonded_structure.structure[n] for n in sorted(graph.nodes())]
         component_structure = Structure.from_sites(sites)
 
         dimensionality, vertices = calculate_dimensionality_of_site(
@@ -153,6 +159,14 @@ def get_structure_components(bonded_structure, inc_orientation=False,
         if inc_molecule_graph and dimensionality == 0:
             component['molecule_graph'] = zero_d_graph_to_molecule_graph(
                 bonded_structure, graph)
+
+        if inc_graph:
+            # add specie names to graph to be able to identify sites
+            species = {n: {'specie': str(bonded_structure.structure[n].specie)}
+                       for n in graph}
+            nx.set_node_attributes(graph, species)
+            component['graph'] = nx.convert_node_labels_to_integers(
+                graph, ordering="sorted")
 
         components.append(component)
     return components

--- a/pymatgen/analysis/tests/test_dimensionality.py
+++ b/pymatgen/analysis/tests/test_dimensionality.py
@@ -68,6 +68,10 @@ class LarsenDimensionalityTest(PymatgenTest):
         self.assertEqual(components[0]['structure'].num_sites, 2)
         self.assertEqual(components[0]['orientation'], (0, 0, 1))
 
+        # test getting component graphs
+        components = get_structure_components(self.graphite, inc_graph=True)
+        self.assertEqual(list(components[0]['graph'].nodes()), [0, 1])
+
     def test_calculate_dimensionality_of_site(self):
         dimen = calculate_dimensionality_of_site(self.tricky_structure, 0)
         self.assertEqual(dimen, 3)

--- a/pymatgen/analysis/tests/test_dimensionality.py
+++ b/pymatgen/analysis/tests/test_dimensionality.py
@@ -1,6 +1,7 @@
 import os
 import networkx as nx
 
+from pymatgen.analysis.graphs import StructureGraph
 from pymatgen.core.structure import Structure
 from pymatgen.analysis.local_env import CrystalNN
 from pymatgen.analysis.dimensionality import (
@@ -56,21 +57,25 @@ class LarsenDimensionalityTest(PymatgenTest):
         components = get_structure_components(self.tricky_structure)
         self.assertEqual(len(components), 1)
         self.assertEqual(components[0]['dimensionality'], 3)
-        self.assertTrue(isinstance(components[0]['structure'], Structure))
-        self.assertEqual(components[0]['structure'].num_sites, 10)
+        self.assertTrue(
+            isinstance(components[0]['structure_graph'], StructureGraph))
+        self.assertEqual(components[0]['structure_graph'].structure.num_sites,
+                         10)
 
         # test 2D structure and get orientation information
         components = get_structure_components(
             self.graphite, inc_orientation=True)
         self.assertEqual(len(components), 2)
         self.assertEqual(components[0]['dimensionality'], 2)
-        self.assertTrue(isinstance(components[0]['structure'], Structure))
-        self.assertEqual(components[0]['structure'].num_sites, 2)
+        self.assertTrue(
+            isinstance(components[0]['structure_graph'], StructureGraph))
+        self.assertEqual(components[0]['structure_graph'].structure.num_sites,
+                         2)
         self.assertEqual(components[0]['orientation'], (0, 0, 1))
 
         # test getting component graphs
-        components = get_structure_components(self.graphite, inc_graph=True)
-        self.assertEqual(list(components[0]['graph'].nodes()), [0, 1])
+        self.assertEqual(list(components[0]['structure_graph'].graph.nodes()),
+                         [0, 1])
 
     def test_calculate_dimensionality_of_site(self):
         dimen = calculate_dimensionality_of_site(self.tricky_structure, 0)


### PR DESCRIPTION
## Summary

Added the `inc_graph` option to `get_structure_components()` to allow returning of networkx graphs for structure components.

The graphs have their nodes indexed to match the returned component `Structure` objects rather than initial structure passed to `get_structure_components`. 