### PR TITLE
Simplification of COHP Plotting

### DIFF
--- a/pymatgen/electronic_structure/cohp.py
+++ b/pymatgen/electronic_structure/cohp.py
@@ -327,38 +327,32 @@ class CompleteCohp(Cohp):
 
         return d
 
-    def get_cohp(self, label, spin=None, integrated=False):
+    def get_cohp(self, label):
         """
-        Get specific COHP or ICOHP. If label is not in the COHP labels,
+        Get specific COHP object. For older lobster versions: If label is not in the COHP labels,
         try reversing the order of the sites.
 
         Args:
-            spin: Spin. Can be parsed as spin object, integer (-1/1)
-                or str ("up"/"down")
-            integrated: Return COHP (False) or ICOHP (True)
+            label: string (for newer Lobster versions: a number)
 
         Returns:
-            Returns the CHOP or ICOHP for the input spin. If Spin is
-            None and both spins are present, both spins will be returned
-            as a dictionary.
+            Returns the COHP object to simplify plotting
         """
         if label.lower() == "average":
-            return self.cohp.get_cohp(spin=spin, integrated=integrated)
+            return Cohp(efermi=self.efermi,energies=self.energies,cohp= self.cohp.get_cohp(spin=None, integrated=False),are_coops=self.are_coops,icohp=self.cohp.get_icohp(spin=None))
         else:
             try:
-                return self.all_cohps[label].get_cohp(spin=spin,
-                                                      integrated=integrated)
+                return Cohp(efermi=self.efermi, energies=self.energies,
+                            cohp=self.all_cohps[label].get_cohp(spin=None, integrated=False), are_coops=self.are_coops,
+                            icohp=self.all_cohps[label].get_icohp(spin=None))
+
             except KeyError:
                 atoms = label.split("-")
                 label = atoms[1] + "-" + atoms[0]
-                return self.all_cohps[label].get_cohp(spin=spin,
-                                                      integrated=integrated)
+                return Cohp(efermi=self.efermi, energies=self.energies,
+                            cohp=self.all_cohps[label].get_cohp(spin=None, integrated=False), are_coops=self.are_coops,
+                            icohp=self.all_cohps[label].get_icohp(spin=None))
 
-    def get_icohp(self, label, spin=None):
-        """
-        Convenient alternative to get a specific ICOHP.
-        """
-        return self.get_cohp(label, spin=spin, integrated=True)
 
     def get_orbital_resolved_cohp(self, label, orbitals):
         """

--- a/pymatgen/electronic_structure/cohp.py
+++ b/pymatgen/electronic_structure/cohp.py
@@ -329,8 +329,7 @@ class CompleteCohp(Cohp):
 
     def get_cohp_by_label(self, label):
         """
-        Get specific COHP object. For older lobster versions: If label is not in the COHP labels,
-        try reversing the order of the sites.
+        Get specific COHP object. 
 
         Args:
             label: string (for newer Lobster versions: a number)

--- a/pymatgen/electronic_structure/cohp.py
+++ b/pymatgen/electronic_structure/cohp.py
@@ -329,7 +329,7 @@ class CompleteCohp(Cohp):
 
     def get_cohp_by_label(self, label):
         """
-        Get specific COHP object. 
+        Get specific COHP object.
 
         Args:
             label: string (for newer Lobster versions: a number)

--- a/pymatgen/electronic_structure/cohp.py
+++ b/pymatgen/electronic_structure/cohp.py
@@ -327,7 +327,7 @@ class CompleteCohp(Cohp):
 
         return d
 
-    def get_cohp(self, label):
+    def get_cohp_by_label(self, label):
         """
         Get specific COHP object. For older lobster versions: If label is not in the COHP labels,
         try reversing the order of the sites.
@@ -339,7 +339,8 @@ class CompleteCohp(Cohp):
             Returns the COHP object to simplify plotting
         """
         if label.lower() == "average":
-            return Cohp(efermi=self.efermi,energies=self.energies,cohp= self.cohp.get_cohp(spin=None, integrated=False),are_coops=self.are_coops,icohp=self.cohp.get_icohp(spin=None))
+            return Cohp(efermi=self.efermi, energies=self.energies,
+                        cohp=self.cohp, are_coops=self.are_coops, icohp=self.icohp)
         else:
             try:
                 return Cohp(efermi=self.efermi, energies=self.energies,
@@ -347,12 +348,7 @@ class CompleteCohp(Cohp):
                             icohp=self.all_cohps[label].get_icohp(spin=None))
 
             except KeyError:
-                atoms = label.split("-")
-                label = atoms[1] + "-" + atoms[0]
-                return Cohp(efermi=self.efermi, energies=self.energies,
-                            cohp=self.all_cohps[label].get_cohp(spin=None, integrated=False), are_coops=self.are_coops,
-                            icohp=self.all_cohps[label].get_icohp(spin=None))
-
+                print("The label does not exist")
 
     def get_orbital_resolved_cohp(self, label, orbitals):
         """

--- a/pymatgen/electronic_structure/tests/test_cohp.py
+++ b/pymatgen/electronic_structure/tests/test_cohp.py
@@ -518,7 +518,7 @@ class CompleteCohpTest(PymatgenTest):
                     if bond != "average":
                         self.assertEqual(self.cohp_lmto.as_dict()[key][bond],
                                          self.cohp_lmto_dict.as_dict()[key][bond])
-
+    
     def test_icohp_values(self):
         # icohp_ef are the ICHOP(Ef) values taken from
         # the ICOHPLIST.lobster file.
@@ -546,6 +546,11 @@ class CompleteCohpTest(PymatgenTest):
             icoop_ef = all_coops_lobster[bond].get_interpolated_value(
                 self.coop_lobster.efermi, integrated=True)
             self.assertEqual(icoop_ef_dict[bond], icoop_ef)
+
+    def test_get_cohp(self):
+        #TODO: include test
+        self.assertArrayAlmotEqual([0],[0])
+        print(self.cohp_orb.get_cohp())
 
     def test_orbital_resolved_cohp(self):
         # When read from a COHPCAR file, total COHPs are calculated from

--- a/pymatgen/electronic_structure/tests/test_cohp.py
+++ b/pymatgen/electronic_structure/tests/test_cohp.py
@@ -518,7 +518,7 @@ class CompleteCohpTest(PymatgenTest):
                     if bond != "average":
                         self.assertEqual(self.cohp_lmto.as_dict()[key][bond],
                                          self.cohp_lmto_dict.as_dict()[key][bond])
-    
+
     def test_icohp_values(self):
         # icohp_ef are the ICHOP(Ef) values taken from
         # the ICOHPLIST.lobster file.
@@ -548,9 +548,17 @@ class CompleteCohpTest(PymatgenTest):
             self.assertEqual(icoop_ef_dict[bond], icoop_ef)
 
     def test_get_cohp(self):
-        #TODO: include test
-        self.assertArrayAlmotEqual([0],[0])
-        print(self.cohp_orb.get_cohp())
+        self.assertEqual(self.cohp_orb.get_cohp_by_label("1").energies[0], -11.7225)
+        self.assertEqual(self.cohp_orb.get_cohp_by_label("1").energies[5], -11.47187)
+        self.assertFalse(self.cohp_orb.get_cohp_by_label("1").are_coops)
+        self.assertEqual(self.cohp_orb.get_cohp_by_label("1").cohp[Spin.up][0], 0.0)
+        self.assertEqual(self.cohp_orb.get_cohp_by_label("1").cohp[Spin.up][300], 0.03392)
+        self.assertEqual(self.cohp_orb.get_cohp_by_label("average").cohp[Spin.up][230], -0.08792)
+        self.assertEqual(self.cohp_orb.get_cohp_by_label("average").energies[230], -0.19368000000000007)
+        self.assertFalse(self.cohp_orb.get_cohp_by_label("average").are_coops)
+        # test methods from super class that could be overwritten
+        self.assertEqual(self.cohp_orb.get_icohp()[Spin.up][3], 0.0)
+        self.assertEqual(self.cohp_orb.get_cohp()[Spin.up][3], 0.0)
 
     def test_orbital_resolved_cohp(self):
         # When read from a COHPCAR file, total COHPs are calculated from


### PR DESCRIPTION
## Summary

I have removed the methods get_cohp and get_icohp in CompleteCohp. They are now inherited from Cohp and give an array with the average cohp. Instead, I included get_cohp_by_label which gives a Cohp object that can now be easily plotted with CohpPlotter. Furthermore, I included tests. I am also planning to update the tutorial on how to plot COHP from Lobster.

