### PR TITLE
PARCHG from WAVECAR

### DIFF
--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -4175,8 +4175,8 @@ class Wavecar:
         of this function can be passed directly to numpy's fft function. For
         example:
 
-            mesh = Wavecar().fft_mesh(kpoint, band)
-            evals = np.fft.fft(mesh)
+            mesh = Wavecar('WAVECAR').fft_mesh(kpoint, band)
+            evals = np.fft.ifftn(mesh)
 
         Args:
             kpoint (int): the index of the kpoint where the wavefunction
@@ -4200,6 +4200,78 @@ class Wavecar:
             return np.fft.ifftshift(mesh)
         else:
             return mesh
+
+    def get_parchg(self, poscar, kpoint, band, spin=None, phase=False,
+                   scale=2):
+        """
+        Generates a Chgcar object, which is the charge density of the specified
+        wavefunction.
+
+        This function generates a Chgcar object with the charge density of the
+        wavefunction specified by band and kpoint (and spin, if the WAVECAR
+        corresponds to a spin-polarized calculation). The phase tag is a
+        feature that is not present in VASP. For a real wavefunction, the phase
+        tag being turn on means that the charge density is multiplied by the
+        sign of the wavefunction at that point in space. A warning is generated
+        if the phase tag is on and the chosen kpoint is not Gamma.
+
+        Note: Augmentation from the PAWs is NOT included in this function.
+
+        Args:
+            poscar (pymatgen.io.vasp.inputs.Poscar): Poscar object that has the
+                                structure associated with the WAVECAR file
+            kpoint (int):   the index of the kpoint for the wavefunction
+            band (int):     the index of the band for the wavefunction
+            spin (int):     optional argument to specify the spin. If the
+                                Wavecar has ISPIN = 2, spin == None generates a
+                                Chgcar with total spin and magnetization, and
+                                spin == {0, 1} specifies just the spin up or
+                                down component.
+            phase (bool):   flag to determine if the charge density is
+                                multiplied by the sign of the wavefunction.
+                                Only valid for real wavefunctions.
+            scale (int):    scaling for the FFT grid. The default value of 2 is
+                                at least as fine as the VASP default.
+        Returns:
+            a pymatgen.io.vasp.outputs.Chgcar object
+        """
+        # check to make sure poscar is valid
+        if True:
+            pass
+
+        if phase and not np.all(self.kpoints[kpoint] == 0.):
+            warnings.warn('phase == True should only be used for the Gamma '
+                          'kpoint! I hope you know what you\'re doing!')
+
+        # scaling of ng for the fft grid, need to restore value at the end
+        temp_ng = self.ng
+        self.ng = self.ng * scale
+        N = np.prod(self.ng)
+
+        data = {}
+        if self.spin == 2:
+            if spin is not None:
+                wfr = np.fft.ifftn(self.fft_mesh(kpoint, band, spin=spin)) * N
+                den = np.abs(np.conj(wfr) * wfr)
+                if phase:
+                    den = np.sign(np.real(wfr)) * den
+                data['total'] = den
+            else:
+                wfr = np.fft.ifftn(self.fft_mesh(kpoint, band, spin=0)) * N
+                denup = np.abs(np.conj(wfr) * wfr)
+                wfr = np.fft.ifftn(self.fft_mesh(kpoint, band, spin=1)) * N
+                dendn = np.abs(np.conj(wfr) * wfr)
+                data['total'] = denup + dendn
+                data['diff'] = denup - dendn
+        else:
+            wfr = np.fft.ifftn(self.fft_mesh(kpoint, band)) * N
+            den = np.abs(np.conj(wfr) * wfr)
+            if phase:
+                den = np.sign(np.real(wfr)) * den
+            data['total'] = den
+
+        self.ng = temp_ng
+        return Chgcar(poscar, data)
 
 
 class Wavederf:

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -4211,11 +4211,13 @@ class Wavecar:
         wavefunction specified by band and kpoint (and spin, if the WAVECAR
         corresponds to a spin-polarized calculation). The phase tag is a
         feature that is not present in VASP. For a real wavefunction, the phase
-        tag being turn on means that the charge density is multiplied by the
+        tag being turned on means that the charge density is multiplied by the
         sign of the wavefunction at that point in space. A warning is generated
         if the phase tag is on and the chosen kpoint is not Gamma.
 
-        Note: Augmentation from the PAWs is NOT included in this function.
+        Note: Augmentation from the PAWs is NOT included in this function. The
+        maximal charge density will differ from the PARCHG from VASP, but the
+        qualitative shape of the charge density will match.
 
         Args:
             poscar (pymatgen.io.vasp.inputs.Poscar): Poscar object that has the
@@ -4235,9 +4237,6 @@ class Wavecar:
         Returns:
             a pymatgen.io.vasp.outputs.Chgcar object
         """
-        # check to make sure poscar is valid
-        if True:
-            pass
 
         if phase and not np.all(self.kpoints[kpoint] == 0.):
             warnings.warn('phase == True should only be used for the Gamma '

--- a/pymatgen/io/vasp/tests/test_outputs.py
+++ b/pymatgen/io/vasp/tests/test_outputs.py
@@ -1290,6 +1290,13 @@ class WavecarTest(unittest.TestCase):
         self.assertTrue('diff' not in c.data)
         self.assertEqual(np.prod(c.data['total'].shape), np.prod(w.ng * 2))
         self.assertFalse(np.all(c.data['total'] > 0.))
+        w.kpoints.append([0.2, 0.2, 0.2])
+        with warnings.catch_warnings(record=True) as wrns:
+            try:
+                c = w.get_parchg(poscar, 1, 0, spin=0, phase=True)
+            except IndexError:
+                pass
+            self.assertEqual(len(wrns), 1)
         w = Wavecar(os.path.join(test_dir, 'WAVECAR.N2.spin'))
         c = w.get_parchg(poscar, 0, 0, phase=False, scale=1)
         self.assertTrue('total' in c.data)

--- a/pymatgen/io/vasp/tests/test_outputs.py
+++ b/pymatgen/io/vasp/tests/test_outputs.py
@@ -1277,6 +1277,9 @@ class WavecarTest(unittest.TestCase):
         self.assertEqual(np.unravel_index(ind, mesh.shape), (6, 8, 8))
         self.assertEqual(mesh[0, 0, 0], 0j)
 
+    def test_get_parchg(self):
+        pass
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/pymatgen/io/vasp/tests/test_outputs.py
+++ b/pymatgen/io/vasp/tests/test_outputs.py
@@ -17,7 +17,7 @@ import xml.etree.cElementTree as ET
 
 from pymatgen.core.periodic_table import Element
 from pymatgen.electronic_structure.core import OrbitalType
-from pymatgen.io.vasp.inputs import Kpoints
+from pymatgen.io.vasp.inputs import Kpoints, Poscar
 from pymatgen.io.vasp.outputs import Chgcar, Locpot, Oszicar, Outcar, \
     Vasprun, Procar, Xdatcar, Dynmat, BSVasprun, UnconvergedVASPWarning, \
     VaspParserError, Wavecar
@@ -1278,7 +1278,35 @@ class WavecarTest(unittest.TestCase):
         self.assertEqual(mesh[0, 0, 0], 0j)
 
     def test_get_parchg(self):
-        pass
+        poscar = Poscar.from_file(os.path.join(test_dir, 'POSCAR'))
+        w = self.w
+        c = w.get_parchg(poscar, 0, 0, spin=0, phase=False)
+        self.assertTrue('total' in c.data)
+        self.assertTrue('diff' not in c.data)
+        self.assertEqual(np.prod(c.data['total'].shape), np.prod(w.ng * 2))
+        self.assertTrue(np.all(c.data['total'] > 0.))
+        c = w.get_parchg(poscar, 0, 0, spin=0, phase=True)
+        self.assertTrue('total' in c.data)
+        self.assertTrue('diff' not in c.data)
+        self.assertEqual(np.prod(c.data['total'].shape), np.prod(w.ng * 2))
+        self.assertFalse(np.all(c.data['total'] > 0.))
+        w = Wavecar(os.path.join(test_dir, 'WAVECAR.N2.spin'))
+        c = w.get_parchg(poscar, 0, 0, phase=False, scale=1)
+        self.assertTrue('total' in c.data)
+        self.assertTrue('diff' in c.data)
+        self.assertEqual(np.prod(c.data['total'].shape), np.prod(w.ng))
+        self.assertTrue(np.all(c.data['total'] > 0.))
+        self.assertFalse(np.all(c.data['diff'] > 0.))
+        c = w.get_parchg(poscar, 0, 0, spin=0, phase=False)
+        self.assertTrue('total' in c.data)
+        self.assertTrue('diff' not in c.data)
+        self.assertEqual(np.prod(c.data['total'].shape), np.prod(w.ng * 2))
+        self.assertTrue(np.all(c.data['total'] > 0.))
+        c = w.get_parchg(poscar, 0, 0, spin=0, phase=True)
+        self.assertTrue('total' in c.data)
+        self.assertTrue('diff' not in c.data)
+        self.assertEqual(np.prod(c.data['total'].shape), np.prod(w.ng * 2))
+        self.assertFalse(np.all(c.data['total'] > 0.))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds the function "get_parchg" to the Wavecar class. This function outputs a Chgcar object that corresponds to the charge density of the specified wavefunction. This emulates the PARCHG output from VASP, but it does not include augmentation from the PAWs.

* PARCHG from a Wavecar object
* For real wavefunctions, adds the ability to visualize the phase of the wavefunction.

## Additional dependencies introduced (if any)

N/A

## TODO (if any)

N/A