### PR TITLE
Polarization cartesian fix

### DIFF
--- a/pymatgen/analysis/ferroelectricity/polarization.py
+++ b/pymatgen/analysis/ferroelectricity/polarization.py
@@ -29,19 +29,25 @@ the distortion.
 See Nicola Spaldin's "A beginner's guide to the modern theory of polarization"
 (https://arxiv.org/abs/1202.1831) for an introduction to crystal polarization.
 
+VASP reports dipole moment values (used to derive polarization) along Cartesian 
+directions (see pead.F around line 970 in the VASP source to confirm this).
+However, it is most convenient to perform the adjustments necessary to recover
+a same branch polarization by expressing the polarization along lattice directions.
+For this reason, calc_ionic calculates ionic contributions to the polarization
+along lattice directions. We provide the means to convert Cartesian direction 
+polarizations to lattice direction polarizations in the Polarization class. 
+
 We recommend using our calc_ionic function for calculating the ionic
-polarization rather than the values from OUTCAR.
-
-We find that the ionic dipole moment reported in OUTCAR differ from
-the naive calculation of \\sum_i Z_i r_i where i is the index of the
-atom, Z_i is the ZVAL from the pseudopotential file, and r is the distance
-in Angstroms along the lattice vectors.
-
-Compare calc_ionic to VASP dipol.F. SUBROUTINE POINT_CHARGE_DIPOL.
-
-We are able to recover a smooth same branch polarization more frequently
-using the naive calculation in calc_ionic than using the ionic dipole
-moment reported in the OUTCAR.
+polarization rather than the values from OUTCAR. We find that the ionic
+dipole moment reported in OUTCAR differ from the naive calculation of 
+\\sum_i Z_i r_i where i is the index of the atom, Z_i is the ZVAL from the 
+pseudopotential file, and r is the distance in Angstroms along the lattice vectors.
+Note, this difference is not simply due to VASP using Cartesian directions and
+calc_ionic using lattice direction but rather how the ionic polarization is 
+computed. Compare calc_ionic to VASP SUBROUTINE POINT_CHARGE_DIPOL in dipol.F in
+the VASP source to see the differences. We are able to recover a smooth same 
+branch polarization more frequently using the naive calculation in calc_ionic
+than using the ionic dipole moment reported in the OUTCAR.
 
 Some defintions of terms used in the comments below:
 
@@ -103,6 +109,20 @@ def get_total_ionic_dipole(structure, zval_dict):
     return np.sum(tot_ionic, axis=0)
 
 
+def convert_cart_to_latt(vector, structure):
+    """
+    Convert a vector along Cartesian directions to be along
+    lattice directions.
+
+    vector: np.array along Cartesian directions of shape [3]
+    structure: pymatgen Structure with desired lattice directions
+    """
+    M = structure.lattice.matrix
+    cart_to_direct = np.linalg.inv(M.T).dot(vector)
+    direct_to_latt = structure.lattice.lengths_and_angles[0] * cart_to_direct
+    return direct_to_latt
+
+
 class PolarizationLattice(Structure):
     def get_nearest_site(self, coords, site, r=None):
         """
@@ -144,10 +164,25 @@ class Polarization:
 
     """
 
-    def __init__(self, p_elecs, p_ions, structures):
+    def __init__(self, p_elecs, p_ions, structures, p_elecs_in_cartesian=True, p_ions_in_cartesian=False):
+        """
+        p_elecs: np.array of electronic contribution to the polarization with shape [N, 3]
+        p_ions: np.array of ionic contribution to the polarization with shape [N, 3]
+        p_elecs_in_cartesian: whether p_elecs is along Cartesian directions (rather than lattice directions).
+            Default is True because that is the convention for VASP.
+        p_ions_in_cartesian: whether p_ions is along Cartesian directions (rather than lattice directions).
+            Default is False because calc_ionic (which we recommend using for calculating the ionic
+            contribution to the polarization) uses lattice directions.
+        """
         if len(p_elecs) != len(p_ions) or len(p_elecs) != len(structures):
             raise ValueError(
                 "The number of electronic polarization and ionic polarization values must be equal.")
+        if p_elecs_in_cartesian:
+            p_elecs = np.array(
+                [convert_cart_to_latt(p_elecs[i], struct) for i, struct in enumerate(structures)])
+        if p_ions_in_cartesian:
+            p_ions = np.array(
+                [convert_cart_to_latt(p_ions[i], struct) for i, struct in enumerate(structures)])
         self.p_elecs = np.array(p_elecs)
         self.p_ions = np.array(p_ions)
         self.structures = structures

--- a/pymatgen/analysis/ferroelectricity/tests/test_polarization.py
+++ b/pymatgen/analysis/ferroelectricity/tests/test_polarization.py
@@ -7,6 +7,7 @@ from pymatgen.core.structure import Structure
 from pymatgen.io.vasp.outputs import Outcar
 from pymatgen.io.vasp.inputs import Potcar
 from pymatgen.util.testing import PymatgenTest
+import numpy as np
 
 test_dir = os.path.join(os.path.dirname(__file__), "..", "..", "..", "..",
                         'test_files/BTO_221_99_polarization')
@@ -26,6 +27,20 @@ ions = np.array([[-44.363484, -44.363484, -44.79259988],
                   [-44.092477, -44.092477, -72.1168782 ],
                   [-44.053768, -44.053768, -72.56736141],
                   [-44.015048, -44.015048, -73.01874336]])
+
+
+class CartToLatt(PymatgenTest):
+   def SetUp(self):
+       lattice_mat = np.array([[0.5, 0., 0.],
+                               [0.5, np.sqrt(3) / 2., 0.],
+                               [0., 0., 1.0]])
+       cart_coord = np.array([0.5, np.sqrt(3)/4., 0.5])
+       direct_coord = np.array([0.5, 0.5, 0.5])
+       latt_coord = np.array([0.25, 0.5, 0.5])
+       test_struct_direct = Structure(lattice_mat, ["C"], [direct_coord])
+       from_direct = (test_struct_direct.frac_coords * test_struct_direct.lattice.lengths_and_angles[0])[0]
+       self.assertArrayAlmostEqual(convert_cart_to_latt(cart_coord, test_struct_direct), latt_coord)
+       self.assertArrayAlmostEqual(convert_cart_to_latt(cart_coord, test_struct_direct), from_direct)
 
 
 class UtilsTest(PymatgenTest):


### PR DESCRIPTION
VASP reports dipole moments in along Cartesian directions. This pull requests adds the ability to specify when creating a Polarization object whether ionic and electronic contributions to the polarization are given in Cartesian or lattice directions. The default for ionic contributions is lattice directions (since it is recommended to use the calc_ionic function as described in the documentation) and the default for electronic contributions is Cartesian (since these are read directly from VASP). I have added a test checking that the conversion between Cartesian to lattice directions is computed correctly and added additional documentation detailing these conventions.