### PR TITLE
Update MPNonSCFSet smearing parameters

### DIFF
--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -411,6 +411,11 @@ class MPNonSCFSetTest(PymatgenTest):
         self.assertEqual(vis.incar["NSW"], 0)
         # Check that the ENCUT has been inherited.
         self.assertEqual(vis.incar["ENCUT"], 600)
+
+        # check NEDOS and ISMEAR set correctly
+        self.assertEqual(vis.incar["NEDOS"], 2001)
+        self.assertEqual(vis.incar["ISMEAR"], -5)
+
         self.assertTrue(vis.incar["LOPTICS"])
         self.assertEqual(vis.kpoints.style, Kpoints.supported_modes.Reciprocal)
 


### PR DESCRIPTION
## Summary

Based on discussions with @shyamd, @mkhorton and @tschaume, I've updated the default smearing parameters for NonSCF uniform calculations.

The parameters I've modified are:
- NEDOS now 2001 for uniform calculations.
- ISMEAR now -5 (tetrahedron method with Blöchl corrections) for uniform calculations.

This should give nicer looking density of states/optics plots.

For consistency, I think it is best to keep the parameters the same for metals and insulators . Down the line, we could apply additional broadening to reproduce experimental spectra (UPS, XPS, etc) using [galore](https://github.com/SMTG-UCL/galore).