### PR TITLE
Misc fixes for lammps data

### DIFF
--- a/pymatgen/io/lammps/data.py
+++ b/pymatgen/io/lammps/data.py
@@ -920,13 +920,13 @@ class Topology(MSONable):
         else:
             angle_list, dihedral_list = [], []
             dests, freq = np.unique(bond_list, return_counts=True)
-            hubs = dests[np.where(freq > 1)]
+            hubs = dests[np.where(freq > 1)].tolist()
             bond_arr = np.array(bond_list)
             if len(hubs) > 0:
                 hub_spokes = {}
                 for hub in hubs:
                     ix = np.any(np.isin(bond_arr, hub), axis=1)
-                    bonds = list(np.unique(bond_arr[ix]))
+                    bonds = np.unique(bond_arr[ix]).tolist()
                     bonds.remove(hub)
                     hub_spokes[hub] = bonds
             # skip angle or dihedral searching if too few bonds or hubs
@@ -940,7 +940,7 @@ class Topology(MSONable):
                                        itertools.combinations(v, 2)])
             if dihedral:
                 hub_cons = bond_arr[np.all(np.isin(bond_arr, hubs), axis=1)]
-                for i, j in hub_cons:
+                for i, j in hub_cons.tolist():
                     ks = [k for k in hub_spokes[i] if k != j]
                     ls = [l for l in hub_spokes[j] if l != i]
                     dihedral_list.extend([[k, i, j, l] for k, l in

--- a/pymatgen/io/lammps/data.py
+++ b/pymatgen/io/lammps/data.py
@@ -193,22 +193,16 @@ def lattice_2_lmpbox(lattice, origin=(0, 0, 0)):
     a, b, c = lattice.abc
     xlo, ylo, zlo = origin
     xhi = a + xlo
-    if lattice.is_orthogonal:
-        yhi = b + ylo
-        zhi = c + zlo
-        tilt = None
-        rot_matrix = np.eye(3)
-    else:
-        m = lattice.matrix
-        xy = np.dot(m[1], m[0] / a)
-        yhi = np.sqrt(b ** 2 - xy ** 2) + ylo
-        xz = np.dot(m[2], m[0] / a)
-        yz = (np.dot(m[1], m[2]) - xy * xz) / (yhi - ylo)
-        zhi = np.sqrt(c ** 2 - xz ** 2 - yz ** 2) + zlo
-        tilt = [xy, xz, yz]
-        rot_matrix = np.linalg.solve([[xhi - xlo, 0, 0],
-                                      [xy, yhi - ylo, 0],
-                                      [xz, yz, zhi - zlo]], m)
+    m = lattice.matrix
+    xy = np.dot(m[1], m[0] / a)
+    yhi = np.sqrt(b ** 2 - xy ** 2) + ylo
+    xz = np.dot(m[2], m[0] / a)
+    yz = (np.dot(m[1], m[2]) - xy * xz) / (yhi - ylo)
+    zhi = np.sqrt(c ** 2 - xz ** 2 - yz ** 2) + zlo
+    tilt = None if lattice.is_orthogonal else [xy, xz, yz]
+    rot_matrix = np.linalg.solve([[xhi - xlo, 0, 0],
+                                  [xy, yhi - ylo, 0],
+                                  [xz, yz, zhi - zlo]], m)
     bounds = [[xlo, xhi], [ylo, yhi], [zlo, zhi]]
     symmop = SymmOp.from_rotation_and_translation(rot_matrix, origin)
     return LammpsBox(bounds, tilt), symmop
@@ -949,7 +943,7 @@ class Topology(MSONable):
                 for i, j in hub_cons:
                     ks = [k for k in hub_spokes[i] if k != j]
                     ls = [l for l in hub_spokes[j] if l != i]
-                    dihedral_list.extend([[k, i, j, l] for k,l in
+                    dihedral_list.extend([[k, i, j, l] for k, l in
                                           itertools.product(ks, ls)
                                           if k != l])
 

--- a/pymatgen/io/lammps/tests/test_data.py
+++ b/pymatgen/io/lammps/tests/test_data.py
@@ -741,9 +741,16 @@ class FuncTest(unittest.TestCase):
         tetra_latt = Lattice.tetragonal(5, 5)
         tetra_box, _ = lattice_2_lmpbox(tetra_latt)
         self.assertIsNone(tetra_box.tilt)
-        orthorhombic_latt = Lattice.orthorhombic(5, 5, 5)
-        orthorhombic_box, _ = lattice_2_lmpbox(orthorhombic_latt)
-        self.assertIsNone(orthorhombic_box.tilt)
+        ortho_latt = Lattice.orthorhombic(5, 5, 5)
+        ortho_box, _ = lattice_2_lmpbox(ortho_latt)
+        self.assertIsNone(ortho_box.tilt)
+        rot_tetra_latt = Lattice([[5, 0, 0], [0, 2, 2], [0, -2, 2]])
+        _, rotop = lattice_2_lmpbox(rot_tetra_latt)
+        np.testing.\
+            assert_array_almost_equal(rotop.rotation_matrix,
+                                      [[1, 0, 0],
+                                       [0, 2 ** 0.5 / 2, 2 ** 0.5 / 2],
+                                       [0, -2 ** 0.5 / 2, 2 ** 0.5 / 2]])
 
     @unittest.skip("The function is deprecated")
     def test_structure_2_lmpdata(self):

--- a/pymatgen/io/lammps/tests/test_data.py
+++ b/pymatgen/io/lammps/tests/test_data.py
@@ -595,6 +595,7 @@ class TopologyTest(unittest.TestCase):
                           [6, 0, 1, 2], [6, 0, 1, 7], [6, 0, 1, 8],
                           [0, 1, 2, 3], [7, 1, 2, 3], [8, 1, 2, 3]]
         np.testing.assert_array_equal(tp_etoh["Dihedrals"], etoh_dihedrals)
+        self.assertIsNotNone(json.dumps(topo_etoh.as_dict()))
         # bond flag to off
         topo_etoh0 = Topology.from_bonding(molecule=etoh, bond=False,
                                            angle=True, dihedral=True)


### PR DESCRIPTION
## Summary

* Fix rotation operation for orthogonal box **not** originally aligned with Cartesian axes. 
* Fix `Topology` serialization caused by numpy data type.

## Additional dependencies introduced (if any)

None