### PR TITLE
DLS predictor - add limits

### DIFF
--- a/pymatgen/analysis/structure_prediction/tests/test_volume_predictor.py
+++ b/pymatgen/analysis/structure_prediction/tests/test_volume_predictor.py
@@ -90,19 +90,29 @@ class DLSVolumePredictorTest(PymatgenTest):
     def test_predict(self):
         p = DLSVolumePredictor()
         p_fast = DLSVolumePredictor(cutoff=0.0)  # for speed on compressed cells
+        p_nolimit = DLSVolumePredictor(min_scaling=None, max_scaling=None)  # no limits on scaling
 
         fen = Structure.from_file(os.path.join(dir_path, "FeN_mp-6988.cif"))
+
         self.assertAlmostEqual(p.predict(fen), 18.2252568873)
-        fen.scale_lattice(3.0)
-        self.assertAlmostEqual(p.predict(fen), 18.2252568873)
-        fen.scale_lattice(0.24)
-        self.assertAlmostEqual(p.predict(fen), 18.2252568873)
+        fen.scale_lattice(fen.volume * 3.0)
+        self.assertAlmostEqual(p_nolimit.predict(fen), 18.2252568873)
+        self.assertAlmostEqual(p.predict(fen), fen.volume * 0.5)
+        fen.scale_lattice(fen.volume * 0.1)
+        self.assertAlmostEqual(p_nolimit.predict(fen), 18.2252568873)
+        self.assertAlmostEqual(p.predict(fen), fen.volume * 1.5)
+        self.assertAlmostEqual(p_fast.predict(fen), fen.volume * 1.5)
 
         lfpo = PymatgenTest.get_structure("LiFePO4")
-        lfpo.scale_lattice(10.1)
-        self.assertAlmostEqual(p.predict(lfpo), 291.62094410192924)
-        lfpo.scale_lattice(0.2)
-        self.assertAlmostEqual(p_fast.predict(lfpo), 291.62094410192924)
+
+        lfpo.scale_lattice(lfpo.volume * 3.0)
+        self.assertAlmostEqual(p_nolimit.predict(lfpo), 291.62094410192924)
+        self.assertAlmostEqual(p.predict(lfpo), lfpo.volume * 0.5)
+        lfpo.scale_lattice(lfpo.volume * 0.1)
+        self.assertAlmostEqual(p_nolimit.predict(lfpo), 291.62094410192924)
+        self.assertAlmostEqual(p.predict(lfpo), lfpo.volume * 1.5)
+        self.assertAlmostEqual(p_fast.predict(lfpo), lfpo.volume * 1.5)
+
         lmpo = PymatgenTest.get_structure("LiFePO4")
         lmpo.replace_species({"Fe": "Mn"})
         self.assertAlmostEqual(p.predict(lmpo), 290.795329052)


### PR DESCRIPTION
## Summary

Issue #1295 mentions that DLSVolumePredictor can have very large errors in rare (but important) instances.

As no long-term solution is likely forthcoming, this PR allows the user to set bounds on how much the volume can change from the initial structure, with defaults of 50% to 150% of the original cell volume.

Unit tests have been updated.