### PR TITLE
fix json serialization for Molecule with DummySpecie

### DIFF
--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -1996,23 +1996,10 @@ class IMolecule(SiteCollection, MSONable):
         Returns:
             Molecule object
         """
-        species = []
-        coords = []
-        props = collections.defaultdict(list)
-
-        for site_dict in d["sites"]:
-            species.append({Specie(sp["element"], sp["oxidation_state"])
-                            if "oxidation_state" in sp else
-                            Element(sp["element"]): sp["occu"]
-                            for sp in site_dict["species"]})
-            coords.append(site_dict["xyz"])
-            siteprops = site_dict.get("properties", {})
-            for k, v in siteprops.items():
-                props[k].append(v)
-
-        return cls(species, coords, charge=d.get("charge", 0),
-                   spin_multiplicity=d.get("spin_multiplicity"),
-                   site_properties=props)
+        sites = [Site.from_dict(sd) for sd in d["sites"]]
+        charge = d.get("charge", 0)
+        spin_multiplicity = d.get("spin_multiplicity")
+        return cls.from_sites(sites, charge=charge, spin_multiplicity=spin_multiplicity)
 
     def get_distance(self, i, j):
         """

--- a/pymatgen/core/tests/test_structure.py
+++ b/pymatgen/core/tests/test_structure.py
@@ -1253,9 +1253,11 @@ class MoleculeTest(PymatgenTest):
         self.assertRaises(AttributeError, getattr, self.mol[0], "magmom")
 
     def test_to_from_dict(self):
+        self.mol.append("X", [2,0,0])
         d = self.mol.as_dict()
         mol2 = Molecule.from_dict(d)
         self.assertEqual(type(mol2), Molecule)
+        self.assertMSONable(self.mol)
 
     def test_apply_operation(self):
         op = SymmOp.from_axis_angle_and_translation([0, 0, 1], 90)


### PR DESCRIPTION
## Summary
The current implementation of `from_dict` in `Molecule` fails if a `DummySpecie` is present: 
```
from pymatgen import Molecule
m = Molecule(species=["X"], coords=[[0,0,0]])
Molecule.from_dict(m.as_dict())
```
leads to the following error:

> 
> /pymatgen/pymatgen/core/structure.py in from_dict(cls, d)
>    2005                             if "oxidation_state" in sp else
>    2006                             Element(sp["element"]): sp["occu"]
> -> 2007                             for sp in site_dict["species"]})
>    2008             coords.append(site_dict["xyz"])
>    2009             siteprops = site_dict.get("properties", {})
> 
> /pymatgen/pymatgen/core/structure.py in <dictcomp>(.0)
>    2005                             if "oxidation_state" in sp else
>    2006                             Element(sp["element"]): sp["occu"]
> -> 2007                             for sp in site_dict["species"]})
>    2008             coords.append(site_dict["xyz"])
>    2009             siteprops = site_dict.get("properties", {})
> 
> /pymatgen/pymatgen/core/periodic_table.py in __init__(self, symbol, oxidation_state, properties)
>    1060 
>    1061     def __init__(self, symbol, oxidation_state=None, properties=None):
> -> 1062         self._el = Element(symbol)
>    1063         self._oxi_state = oxidation_state
>    1064         self._properties = properties if properties else {}
> 
> /python3.6/enum.py in __call__(cls, value, names, module, qualname, type, start)
>     289         """
>     290         if names is None:  # simple value lookup
> --> 291             return cls.__new__(cls, value)
>     292         # otherwise, functional API: we're creating a new Enum type
>     293         return cls._create_(value, names, module=module, qualname=qualname, type=type, start=start)
> 
> /python3.6/enum.py in __new__(cls, value)
>     531                     return member
>     532         # still not found -- try _missing_ hook
> --> 533         return cls._missing_(value)
>     534 
>     535     def _generate_next_value_(name, start, count, last_values):
> 
> /python3.6/enum.py in _missing_(cls, value)
>     544     @classmethod
>     545     def _missing_(cls, value):
> --> 546         raise ValueError("%r is not a valid %s" % (value, cls.__name__))
>     547 
>     548     def __repr__(self):
> 
> ValueError: 'X' is not a valid Element
> 

I updated the `from_dict` method making it similar to the one in `Structure`, that does not suffer from the same problem.
