### PR TITLE
Fix outrageous performance bug in Poscar.get_string

### DIFF
--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -478,11 +478,12 @@ class Poscar(MSONable):
             lines.append("Selective dynamics")
         lines.append("direct" if direct else "cartesian")
 
+        selective_dynamics = self.selective_dynamics
         for (i, site) in enumerate(self.structure):
             coords = site.frac_coords if direct else site.coords
             line = " ".join([format_str.format(c) for c in coords])
-            if self.selective_dynamics is not None:
-                sd = ["T" if j else "F" for j in self.selective_dynamics[i]]
+            if selective_dynamics is not None:
+                sd = ["T" if j else "F" for j in selective_dynamics[i]]
                 line += " %s %s %s" % (sd[0], sd[1], sd[2])
             line += " " + site.species_string
             lines.append(line)


### PR DESCRIPTION
```python
#!/usr/bin/env python3

import numpy as np
from pymatgen import Structure
from pymatgen.io.vasp import Poscar

N = 100000
s = Structure(np.array([[1,0,0],[0,1,0],[0,0,1]]), ['C']*N, np.zeros((N, 3)))
Poscar(s, velocities=np.zeros((N, 3)).tolist()).get_string()
```
Prepare to wait several millenia.

pymatgen has some bad cases of property abuse, but this takes the cake.  Writing a file had O(N^2) performance because `Poscar.selective_dynamics` is a property implemented in terms of another property that transposes a list of dicts for all atoms.

(and it *still* computes this transpose of dicts way more times than it should have to)