### PR TITLE
How best to handle PointGroupAnalyzer error when list from `_get_smallest_set_not_on_axis` is empty.

### DIFF
--- a/pymatgen/symmetry/analyzer.py
+++ b/pymatgen/symmetry/analyzer.py
@@ -1076,7 +1076,7 @@ class PointGroupAnalyzer:
             if len(valid_set) > 0:
                 valid_sets.append(valid_set)
 
-        return min(valid_sets, key=lambda s: len(s))
+        return min(valid_sets, key=lambda s: len(s)) if len(valid_sets) > 0 else []
 
     def _check_rot_sym(self, axis):
         """

--- a/pymatgen/symmetry/tests/test_analyzer.py
+++ b/pymatgen/symmetry/tests/test_analyzer.py
@@ -478,6 +478,23 @@ class PointGroupAnalyzerTest(PymatgenTest):
         mol = Molecule(["C", "H", "N"], coords)
         a = PointGroupAnalyzer(mol)
         self.assertEqual(a.sch_symbol, "C*v")
+        coords = [[ 7.19818282e-02, -5.13850399e+00,-2.78587036e-02],
+                  [ 5.43328572e-02, -3.92940670e+00,-1.66248333e-02],
+                  [ 3.58450624e-02, -2.57656810e+00,-7.91702010e-03],
+                  [ 1.97902488e-02, -1.35920654e+00,-8.21484300e-04],
+                  [ 2.15564240e-03, -6.33514200e-03, 3.49187570e-03],
+                  [-1.37242873e-02,  1.20283596e+00, 6.03167840e-03],
+                  [ 8.86138290e-02, -6.19975876e+00,-4.19759731e-02],
+                  [-2.73483707e-02,  2.26422268e+00, 5.41551030e-03]]
+        species = [6, 6, 6, 6, 6, 6, 1, 1]
+        mol = Molecule(species, coords)
+        # This molecule is classified as linear only with increased tolerance
+        a = PointGroupAnalyzer(mol, eigen_tolerance=2e-2)
+        self.assertEqual(a.sch_symbol, "D*h")
+        # This molecule is classified as only having inversion symmetry if the zero eigenvalue check fails
+        a = PointGroupAnalyzer(mol, eigen_tolerance=1e-2)
+        self.assertEqual(a.sch_symbol, "Ci")
+
 
     def test_asym_top(self):
         coords = [[0.000000, 0.000000, 0.000000],


### PR DESCRIPTION
This pull request has a question at the bottom of the post.

For the following Molecule, with the default parameters, PointGroupAnalyzer throws an error from the list returned [`self._get_smallest_set_not_on_axis(axis)` being empty](https://github.com/materialsproject/pymatgen/blob/master/pymatgen/symmetry/analyzer.py#L1079) but gives the correct point group when increasing `eigen_value` to `2e-2`.

```
8
H2 C6
C 0.043026 -3.170664 -0.017826
C 0.025377 -1.961567 -0.006592
C 0.006889 -0.608728 0.002115
C -0.009166 0.608634 0.009211
C -0.026800 1.961505 0.013524
C -0.042680 3.170676 0.016064
H 0.059658 -4.231919 -0.031944
H -0.056304 4.232063 0.015448
```

```
mol = Molecule.from_file('mol.xyz')
pga = PointGroupAnalyzer(mol, tolerance=0.3, eigen_tolerance=1e-2)
pga.sch_symbol
>> ValueError: min() arg is an empty sequence 
```

```
mol = Molecule.from_file('mol.xyz')
pga = PointGroupAnalyzer(mol, tolerance=0.3, eigen_tolerance=2e-2)
pga.sch_symbol
>> "D*h"
```

This molecule should be classified as "D*h" (a linear molecule with inversion symmetry). The reason why it fails the linear check is that the eigenvalues fail the `eigen_zero` check [in line 896](https://github.com/materialsproject/pymatgen/blob/master/pymatgen/symmetry/analyzer.py#L896) for default parameters because the eigenvalue closest to zero is ~2e-6. If `eigen_tolerance=2e-2`, the molecule's point group is resolved correctly without error.

It seems that the case where the `eigen_zero` check fails and proceeds to check `self._get_smallest_set_not_on_axis(axis)` should be handled with at least a warning. 

One approach is to simply return an empty list when `min` will fail. This would then result in this molecule being classified in the "Ci" point group. This is the fix I have implemented. However, it might be good to also implement a warning that says something like -- "possible linear molecule resolved to lower symmetry due to eigen_tolerance being too small". 

Which is better? An error with an updated warning message, or a fix with a warning message but a possibly lower symmetry point group?