### PR TITLE
[WIP] Add user-agent header to MPRester session requests

### DIFF
--- a/pymatgen/ext/matproj.py
+++ b/pymatgen/ext/matproj.py
@@ -14,7 +14,7 @@ from monty.json import MontyDecoder, MontyEncoder
 
 from copy import deepcopy
 
-from pymatgen import SETTINGS
+from pymatgen import SETTINGS, __version__
 
 from pymatgen.core.composition import Composition
 from pymatgen.core.periodic_table import Element
@@ -115,7 +115,7 @@ class MPRester:
                               "you should install dependencies via "
                               "`pip install pymatgen[matproj.snl]`.")
         self.session = requests.Session()
-        self.session.headers = {"x-api-key": self.api_key}
+        self.session.headers = {"x-api-key": self.api_key, "user-agent": "pymatgen/"+__version__}
 
     def __enter__(self):
         """

--- a/pymatgen/ext/matproj.py
+++ b/pymatgen/ext/matproj.py
@@ -77,7 +77,9 @@ class MPRester:
             can be changed to other urls implementing a similar interface.
         include_user_agent (bool): If True, will include a user agent with the
             HTTP request including information on pymatgen and system version
-            making the API request. Set to False to disable the user agent.
+            making the API request. This helps MP support pymatgen users, and
+            is similar to what most web browsers send with each page request.
+            Set to False to disable the user agent.
     """
 
     supported_properties = ("energy", "energy_per_atom", "volume",

--- a/pymatgen/ext/matproj.py
+++ b/pymatgen/ext/matproj.py
@@ -6,16 +6,16 @@
 import sys
 import itertools
 import json
+import platform
 import re
 import warnings
-import platform
 from time import sleep
 
 from monty.json import MontyDecoder, MontyEncoder
 
 from copy import deepcopy
 
-from pymatgen import SETTINGS, __version__
+from pymatgen import SETTINGS, __version__ as pmg_version
 
 from pymatgen.core.composition import Composition
 from pymatgen.core.periodic_table import Element
@@ -123,12 +123,12 @@ class MPRester:
         self.session = requests.Session()
         self.session.headers = {"x-api-key": self.api_key}
         if include_user_agent:
-            pymatgen_version = "pymatgen/"+__version__
-            python_version = "Python {}.{}.{}".format(sys.version_info.major, sys.version_info.minor,
-                                                      sys.version_info.micro)
-            platform = "{} {}".format(platform.system(), platform.release())
-            self.session.headers["user-agent"] = "{} ({} {})".format(pymatgen_version, python_version,
-                                                                     platform)
+            pymatgen_info = "pymatgen/"+pmg_version
+            python_info = "Python/{}.{}.{}".format(
+                sys.version_info.major, sys.version_info.minor, sys.version_info.micro)
+            platform_info = "{}/{}".format(platform.system(), platform.release())
+            self.session.headers["user-agent"] = "{} ({} {})".format(
+                pymatgen_info, python_info, platform_info)
 
     def __enter__(self):
         """

--- a/pymatgen/ext/matproj.py
+++ b/pymatgen/ext/matproj.py
@@ -8,6 +8,7 @@ import itertools
 import json
 import re
 import warnings
+import platform
 from time import sleep
 
 from monty.json import MontyDecoder, MontyEncoder
@@ -74,6 +75,9 @@ class MPRester:
             interface. Defaults to the standard Materials Project REST
             address at "https://materialsproject.org/rest/v2", but
             can be changed to other urls implementing a similar interface.
+        include_user_agent (bool): If True, will include a user agent with the
+            HTTP request including information on pymatgen and system version
+            making the API request. Set to False to disable the user agent.
     """
 
     supported_properties = ("energy", "energy_per_atom", "volume",
@@ -94,7 +98,7 @@ class MPRester:
                                  "is_compatible", "spacegroup",
                                  "band_gap", "density", "icsd_id", "cif")
 
-    def __init__(self, api_key=None, endpoint=None):
+    def __init__(self, api_key=None, endpoint=None, include_user_agent=True):
         if api_key is not None:
             self.api_key = api_key
         else:
@@ -115,7 +119,14 @@ class MPRester:
                               "you should install dependencies via "
                               "`pip install pymatgen[matproj.snl]`.")
         self.session = requests.Session()
-        self.session.headers = {"x-api-key": self.api_key, "user-agent": "pymatgen/"+__version__}
+        self.session.headers = {"x-api-key": self.api_key}
+        if include_user_agent:
+            pymatgen_version = "pymatgen/"+__version__
+            python_version = "Python {}.{}.{}".format(sys.version_info.major, sys.version_info.minor,
+                                                      sys.version_info.micro)
+            platform = "{} {}".format(platform.system(), platform.release())
+            self.session.headers["user-agent"] = "{} ({} {})".format(pymatgen_version, python_version,
+                                                                     platform)
 
     def __enter__(self):
         """

--- a/pymatgen/ext/tests/test_matproj.py
+++ b/pymatgen/ext/tests/test_matproj.py
@@ -1,12 +1,13 @@
 # coding: utf-8
 # Copyright (c) Pymatgen Development Team.
 # Distributed under the terms of the MIT License.
-
-
+import platform
+import re
 import unittest
 import warnings
 import random
-from pymatgen import SETTINGS
+import sys
+from pymatgen import SETTINGS, __version__ as pmg_version
 from pymatgen.ext.matproj import MPRester, MPRestError
 from pymatgen.core.periodic_table import Element
 from pymatgen.core.structure import Structure, Composition
@@ -403,6 +404,21 @@ class MPResterTest(PymatgenTest):
 
         crit = MPRester.parse_criteria("POPO2")
         self.assertIn("P2O3", crit["pretty_formula"]["$in"])
+
+    def test_include_user_agent(self):
+        headers = self.rester.session.headers
+        self.assertIn("user-agent", headers, msg="Include user-agent header by default")
+        m = re.match(
+            r"pymatgen/(\d+)\.(\d+)\.(\d+) \(Python/(\d+)\.(\d)+\.(\d+) ([^\/]*)/([^\)]*)\)",
+            headers['user-agent'])
+        self.assertIsNotNone(m, msg="Unexpected user-agent value {}".format(headers['user-agent']))
+        self.assertEqual(m.groups()[:3], tuple(pmg_version.split(".")))
+        self.assertEqual(
+            m.groups()[3:6],
+            tuple(str(n) for n in (sys.version_info.major, sys.version_info.minor, sys.version_info.micro))
+        )
+        self.rester = MPRester(include_user_agent=False)
+        self.assertNotIn("user-agent", self.rester.session.headers, msg="user-agent header unwanted")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add a user-agent header of [conventional syntax](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent) to identify pymatgen and its version to the MP server.

* Allows server, if it is running a later version of pymatgen than the user, to suggest upgrading (e.g. through adding a note in the response "warning" field).
* Allows server to collect statistics on pymatgen versions in active use for gathering MP data, and on what proportion of API use is via pymatgen.