### PR TITLE
Implement new OrderDisorderElementComparator

### DIFF
--- a/pymatgen/analysis/structure_matcher.py
+++ b/pymatgen/analysis/structure_matcher.py
@@ -242,17 +242,16 @@ class OrderDisorderElementComparator(AbstractComparator):
         Returns:
             True always
         """
-        set1 = set(sp1.element_composition.keys())
-        set2 = set(sp2.element_composition.keys())
-        if set1.intersection(set2):
-            return True
-        return False
+        set1 = set(sp1.elements)
+        set2 = set(sp2.elements)
+        return set1.issubset(set2) or set2.issubset(set1)
 
     def get_hash(self, composition):
-        """"
-        No hash possible
         """
-        return 1
+        Returns: Fractional composition
+        """
+        return composition.fractional_composition
+
 
 class OccupancyComparator(AbstractComparator):
     """

--- a/pymatgen/analysis/tests/test_structure_matcher.py
+++ b/pymatgen/analysis/tests/test_structure_matcher.py
@@ -667,6 +667,21 @@ class StructureMatcherTest(PymatgenTest):
         self.assertTrue(sm_sites.fit(s1, s2))
         self.assertFalse(sm_atoms.fit(s1, s2))
 
+    def test_disordered_to_disordered(self):
+        sm_atoms = StructureMatcher(ltol=0.2, stol=0.3, angle_tol=5,
+                                    primitive_cell=False, scale=True,
+                                    attempt_supercell=True,
+                                    allow_subset=False,
+                                    comparator=OrderDisorderElementComparator())
+        lp = Lattice.orthorhombic(10, 20, 30)
+        coords = [[0., 0., 0.], [0.5, 0.5, 0.5]]
+        s1 = Structure(lp, [{'Na': 0.5, "Cl": 0.5}, {'Na': 0.5, "Cl": 0.5}],
+                       coords)
+        s2 = Structure(lp, [{'Na': 0.5, "Cl": 0.5}, {'Na': 0.5, "Br": 0.5}],
+                       coords)
+
+        self.assertFalse(sm_atoms.fit(s1, s2))
+
     def test_occupancy_comparator(self):
 
         lp = Lattice.orthorhombic(10, 20, 30)


### PR DESCRIPTION
## Summary

The current OrderDisorderElementComparator will match in unexpected cases. E.g.,
1.  A structure with the fractional composition Sn0.2 O0.8 will match a structure with the composition Sn0.5 O0.5.
2.  A structure with a 50:50 Sn:Pb site would match with a structure with a 50:50 Sn:O site.

This PR fixes both scenarios and should allow proper matching of disordered structures to their ordered counterparts.