### PR TITLE
allow the MimimumDistanceNN class to only use the cutoff distance as …

### DIFF
--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -1105,14 +1105,17 @@ class MinimumDistanceNN(NearNeighbors):
     Args:
         tol (float): tolerance parameter for neighbor identification
             (default: 0.1).
-            If this is set to None then the neighbor sites are only determined by the cutoff radius
         cutoff (float): cutoff radius in Angstrom to look for trial
             near-neighbor sites (default: 10.0).
+        get_all_sites (boolean): If this is set to True then the neighbor
+            sites are only determined by the cutoff radius, tol is ignored
+
     """
 
-    def __init__(self, tol=0.1, cutoff=10.0):
+    def __init__(self, tol=0.1, cutoff=10.0, get_all_sites=False):
         self.tol = tol
         self.cutoff = cutoff
+        self.get_all_sites = get_all_sites
 
     def get_nn_info(self, structure, n):
         """
@@ -1136,13 +1139,22 @@ class MinimumDistanceNN(NearNeighbors):
         min_dist = min([dist for neigh, dist in neighs_dists])
 
         siw = []
-        for s, dist in neighs_dists:
-            if self.tol is None or dist < (1.0 + self.tol) * min_dist:
-                w = min_dist / dist
-                siw.append({'site': s,
-                            'image': self._get_image(structure, s),
-                            'weight': w,
-                            'site_index': self._get_original_site(structure,
+        if self.get_all_sites == True:
+            for s, dist in neighs_dists:
+                    w = dist
+                    siw.append({'site': s,
+                                'image': self._get_image(structure, s),
+                                'weight': w,
+                                'site_index': self._get_original_site(structure,
+                                                                  s)})
+        else:
+            for s, dist in neighs_dists:
+                if dist < (1.0 + self.tol) * min_dist:
+                    w = min_dist / dist
+                    siw.append({'site': s,
+                                'image': self._get_image(structure, s),
+                                'weight': w,
+                                'site_index': self._get_original_site(structure,
                                                                   s)})
         return siw
 

--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -1099,7 +1099,7 @@ class MinimumDistanceNN(NearNeighbors):
     """
     Determine near-neighbor sites and coordination number using the
     nearest neighbor(s) at distance, d_min, plus all neighbors
-    within a distance (1 + delta) * d_min, where delta is a
+    within a distance (1 + tol) * d_min, where tol is a
     (relative) distance tolerance parameter.
 
     Args:
@@ -1137,7 +1137,7 @@ class MinimumDistanceNN(NearNeighbors):
 
         siw = []
         for s, dist in neighs_dists:
-            if self.tol == None or dist < (1.0 + self.tol) * min_dist:
+            if self.tol is None or dist < (1.0 + self.tol) * min_dist:
                 w = min_dist / dist
                 siw.append({'site': s,
                             'image': self._get_image(structure, s),

--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -1136,7 +1136,6 @@ class MinimumDistanceNN(NearNeighbors):
 
         site = structure[n]
         neighs_dists = structure.get_neighbors(site, self.cutoff)
-        min_dist = min([dist for neigh, dist in neighs_dists])
 
         siw = []
         if self.get_all_sites == True:
@@ -1148,6 +1147,7 @@ class MinimumDistanceNN(NearNeighbors):
                                 'site_index': self._get_original_site(structure,
                                                                   s)})
         else:
+            min_dist = min([dist for neigh, dist in neighs_dists])
             for s, dist in neighs_dists:
                 if dist < (1.0 + self.tol) * min_dist:
                     w = min_dist / dist

--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -1105,6 +1105,7 @@ class MinimumDistanceNN(NearNeighbors):
     Args:
         tol (float): tolerance parameter for neighbor identification
             (default: 0.1).
+            If this is set to None then the neighbor sites are only determined by the cutoff radius
         cutoff (float): cutoff radius in Angstrom to look for trial
             near-neighbor sites (default: 10.0).
     """
@@ -1136,7 +1137,7 @@ class MinimumDistanceNN(NearNeighbors):
 
         siw = []
         for s, dist in neighs_dists:
-            if dist < (1.0 + self.tol) * min_dist:
+            if self.tol == None or dist < (1.0 + self.tol) * min_dist:
                 w = min_dist / dist
                 siw.append({'site': s,
                             'image': self._get_image(structure, s),

--- a/pymatgen/analysis/tests/test_local_env.py
+++ b/pymatgen/analysis/tests/test_local_env.py
@@ -368,7 +368,7 @@ class MiniDistNNTest(PymatgenTest):
             [1.595, 0.92, 2.155]], coords_are_cartesian=True)
 
     def test_all_nn_classes(self):
-        self.assertAlmostEqual(MinimumDistanceNN(tol=None, cutoff=5).get_cn(
+        self.assertAlmostEqual(MinimumDistanceNN(cutoff=5, get_all_sites=True).get_cn(
             self.cscl, 0), 14)
         self.assertAlmostEqual(MinimumDistanceNN().get_cn(
             self.diamond, 0), 4)

--- a/pymatgen/analysis/tests/test_local_env.py
+++ b/pymatgen/analysis/tests/test_local_env.py
@@ -368,6 +368,8 @@ class MiniDistNNTest(PymatgenTest):
             [1.595, 0.92, 2.155]], coords_are_cartesian=True)
 
     def test_all_nn_classes(self):
+        self.assertAlmostEqual(MinimumDistanceNN(tol=None, cutoff=5).get_cn(
+            self.cscl, 0), 14)
         self.assertAlmostEqual(MinimumDistanceNN().get_cn(
             self.diamond, 0), 4)
         self.assertAlmostEqual(MinimumDistanceNN().get_cn(


### PR DESCRIPTION
## New option in MimimumDistanceNN
Allow the MimimumDistanceNN class to only use the cutoff distance as the filter.
So you can ignore the tolerance value.

