### PR TITLE
Add override_from_prev_calc to VASP input sets

### DIFF
--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -387,6 +387,33 @@ class MPStaticSetTest(PymatgenTest):
                                                   lcalcpol=True)
         self.assertTrue(lcalcpol_vis.incar["LCALCPOL"])
 
+    def test_override_from_prev_calc(self):
+        # test override_from_prev
+        prev_run = self.TEST_FILES_DIR / "relaxation"
+
+        vis = MPStaticSet(_dummy_structure)
+        vis.override_from_prev_calc(prev_calc_dir=prev_run)
+        self.assertEqual(vis.incar["NSW"], 0)
+        self.assertEqual(vis.incar["ENCUT"], 600)
+        self.assertEqual(vis.kpoints.style, Kpoints.supported_modes.Monkhorst)
+
+        # Check LCALCPOL flag
+        lcalcpol_vis = MPStaticSet(_dummy_structure, lcalcpol=True)
+        lcalcpol_vis = lcalcpol_vis.override_from_prev_calc(
+            prev_calc_dir=prev_run)
+        self.assertTrue(lcalcpol_vis.incar["LCALCPOL"])
+
+    def test_standardize_structure(self):
+        sga = SpacegroupAnalyzer(self.get_structure("Si"))
+        original_structure = sga.get_conventional_standard_structure()
+        sm = StructureMatcher(primitive_cell=False, scale=False)
+
+        vis = MPStaticSet(original_structure)
+        self.assertTrue(sm.fit(vis.structure, original_structure))
+
+        vis = MPStaticSet(original_structure, standardize=True)
+        self.assertFalse(sm.fit(vis.structure, original_structure))
+
     def tearDown(self):
         shutil.rmtree(self.tmp)
         warnings.simplefilter("default")
@@ -441,6 +468,41 @@ class MPNonSCFSetTest(PymatgenTest):
         vis = MPNonSCFSet.from_prev_calc(prev_calc_dir=prev_run,
                                          standardize=True,
                                          mode="Line", copy_chgcar=True)
+        vis.write_input(self.tmp)
+        self.assertFalse(os.path.exists(os.path.join(self.tmp, "CHGCAR")))
+
+    def test_override_from_prev(self):
+        prev_run = self.TEST_FILES_DIR / "relaxation"
+
+        # test override_from_prev
+        vis = MPNonSCFSet(_dummy_structure, mode="Boltztrap")
+        vis.override_from_prev_calc(prev_calc_dir=prev_run)
+        self.assertEqual(vis.incar["ISMEAR"], 0)
+
+        vis = MPNonSCFSet(_dummy_structure, mode="Uniform")
+        vis.override_from_prev_calc(prev_calc_dir=prev_run)
+        self.assertEqual(vis.incar["ISMEAR"], -5)
+
+        # test line mode
+        vis = MPNonSCFSet(_dummy_structure, mode="Line", copy_chgcar=False,
+                          user_incar_settings={"SIGMA": 0.025})
+        vis.override_from_prev_calc(prev_calc_dir=prev_run)
+
+        self.assertEqual(vis.incar["NSW"], 0)
+        self.assertEqual(vis.incar["ENCUT"], 600)
+        self.assertEqual(vis.incar["SIGMA"], 0.025)
+        self.assertEqual(vis.kpoints.style, Kpoints.supported_modes.Reciprocal)
+
+        vis = MPNonSCFSet(_dummy_structure, mode="Line", copy_chgcar=True)
+        vis.override_from_prev_calc(prev_calc_dir=prev_run)
+        self.assertEqual(vis.incar["ISMEAR"], 0)
+        vis.write_input(self.tmp)
+        self.assertTrue(os.path.exists(os.path.join(self.tmp, "CHGCAR")))
+        os.remove(os.path.join(self.tmp, "CHGCAR"))
+
+        vis = MPNonSCFSet(_dummy_structure, standardize=True, mode="Line",
+                          copy_chgcar=True)
+        vis.override_from_prev_calc(prev_calc_dir=prev_run)
         vis.write_input(self.tmp)
         self.assertFalse(os.path.exists(os.path.join(self.tmp, "CHGCAR")))
 
@@ -684,6 +746,19 @@ class MPSOCSetTest(PymatgenTest):
         self.assertEqual(vis.incar["MAGMOM"], [[0, 0, 3]])
         self.assertEqual(vis.incar['SIGMA'], 0.025)
 
+    def test_override_from_prev_calc(self):
+        # test override_from_prev_calc
+        prev_run = self.TEST_FILES_DIR / "fe_monomer"
+        vis = MPSOCSet(_dummy_structure, magmom=[3], saxis=(1, 0, 0),
+                       user_incar_settings={"SIGMA": 0.025})
+        vis.override_from_prev_calc(prev_calc_dir=prev_run)
+        self.assertEqual(vis.incar["ISYM"], -1)
+        self.assertTrue(vis.incar["LSORBIT"])
+        self.assertEqual(vis.incar["ICHARG"], 11)
+        self.assertEqual(vis.incar["SAXIS"], [1, 0, 0])
+        self.assertEqual(vis.incar["MAGMOM"], [[0, 0, 3]])
+        self.assertEqual(vis.incar['SIGMA'], 0.025)
+
 
 class MPNMRSetTest(PymatgenTest):
     def setUp(self):
@@ -829,6 +904,15 @@ class MVLGWSetTest(PymatgenTest):
         self.assertEqual(mvlgwdiag.incar["ALGO"], "Exact")
         self.assertTrue(mvlgwdiag.incar["LOPTICS"])
 
+        # test override_from_prev_calc
+        mvlgwdiag = MVLGWSet(_dummy_structure, copy_wavecar=True, mode="diag")
+        mvlgwdiag.override_from_prev_calc(prev_calc_dir=prev_run)
+        mvlgwdiag.write_input(self.tmp)
+        self.assertTrue(os.path.exists(os.path.join(self.tmp, "WAVECAR")))
+        self.assertEqual(mvlgwdiag.incar["NBANDS"], 32)
+        self.assertEqual(mvlgwdiag.incar["ALGO"], "Exact")
+        self.assertTrue(mvlgwdiag.incar["LOPTICS"])
+
     def test_bse(self):
         prev_run = self.TEST_FILES_DIR / "relaxation"
         mvlgwgbse = MVLGWSet.from_prev_calc(prev_run, copy_wavecar=True,
@@ -845,6 +929,27 @@ class MVLGWSetTest(PymatgenTest):
         self.assertEqual(mvlgwgbse.incar["ALGO"], "GW0")
         mvlgwgbse1 = MVLGWSet.from_prev_calc(prev_run, copy_wavecar=False,
                                              mode="BSE")
+        self.assertEqual(mvlgwgbse1.incar["ANTIRES"], 0)
+        self.assertEqual(mvlgwgbse1.incar["NBANDSO"], 20)
+        self.assertEqual(mvlgwgbse1.incar["ALGO"], "BSE")
+
+        # test override_from_prev_calc
+        prev_run = self.TEST_FILES_DIR / "relaxation"
+        mvlgwgbse = MVLGWSet(_dummy_structure, copy_wavecar=True, mode="BSE")
+        mvlgwgbse.override_from_prev_calc(prev_calc_dir=prev_run)
+        mvlgwgbse.write_input(self.tmp)
+        self.assertTrue(os.path.exists(os.path.join(self.tmp, "WAVECAR")))
+        self.assertTrue(os.path.exists(os.path.join(self.tmp, "WAVEDER")))
+
+        prev_run = self.TEST_FILES_DIR / "relaxation"
+        mvlgwgbse = MVLGWSet(_dummy_structure, copy_wavecar=True, mode="GW")
+        mvlgwgbse.override_from_prev_calc(prev_calc_dir=prev_run)
+        self.assertEqual(mvlgwgbse.incar["NOMEGA"], 80)
+        self.assertEqual(mvlgwgbse.incar["ENCUTGW"], 250)
+        self.assertEqual(mvlgwgbse.incar["ALGO"], "GW0")
+
+        mvlgwgbse1 = MVLGWSet(_dummy_structure, copy_wavecar=False, mode="BSE")
+        mvlgwgbse1.override_from_prev_calc(prev_calc_dir=prev_run)
         self.assertEqual(mvlgwgbse1.incar["ANTIRES"], 0)
         self.assertEqual(mvlgwgbse1.incar["NBANDSO"], 20)
         self.assertEqual(mvlgwgbse1.incar["ALGO"], "BSE")
@@ -872,6 +977,26 @@ class MPHSEBSTest(PymatgenTest):
         self.assertEqual(len(vis.kpoints.kpts), 18)
 
         vis = MPHSEBSSet.from_prev_calc(prev_calc_dir=prev_run, mode="line")
+        self.assertTrue(vis.incar["LHFCALC"])
+        self.assertEqual(vis.incar['HFSCREEN'], 0.2)
+        self.assertEqual(vis.incar['NSW'], 0)
+        self.assertEqual(vis.incar['ISYM'], 3)
+        self.assertEqual(len(vis.kpoints.kpts), 180)
+
+    def test_override_from_prev_calc(self):
+        prev_run = self.TEST_FILES_DIR / "static_silicon"
+        vis = MPHSEBSSet(_dummy_structure, mode="uniform")
+        vis = vis.override_from_prev_calc(prev_calc_dir=prev_run)
+        self.assertTrue(vis.incar["LHFCALC"])
+        self.assertEqual(len(vis.kpoints.kpts), 16)
+
+        vis = MPHSEBSSet(_dummy_structure, mode="gap")
+        vis = vis.override_from_prev_calc(prev_calc_dir=prev_run)
+        self.assertTrue(vis.incar["LHFCALC"])
+        self.assertEqual(len(vis.kpoints.kpts), 18)
+
+        vis = MPHSEBSSet(_dummy_structure, mode="line")
+        vis = vis.override_from_prev_calc(prev_calc_dir=prev_run)
         self.assertTrue(vis.incar["LHFCALC"])
         self.assertEqual(vis.incar['HFSCREEN'], 0.2)
         self.assertEqual(vis.incar['NSW'], 0)
@@ -999,6 +1124,9 @@ class MVLRelax52SetTest(PymatgenTest):
         self.assertEqual(type(v), MVLRelax52Set)
         self.assertEqual(v.incar["NSW"], 500)
 
+
+_dummy_structure = Structure([1, 0, 0, 0, 1, 0, 0, 0, 1], ['I'], [[0, 0, 0]],
+                             site_properties={"magmom": [[0, 0, 1]]})
 
 if __name__ == '__main__':
     unittest.main()

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -504,7 +504,7 @@ class MagmomLdauTest(PymatgenTest):
         vrun = Vasprun(self.TEST_FILES_DIR / "vasprun.xml.magmom_ldau")
         structure = vrun.final_structure
         poscar = Poscar(structure)
-        structure_decorated = get_structure_from_prev_run(vrun, sym_prec=0)
+        structure_decorated = get_structure_from_prev_run(vrun)
         ldau_ans = {'LDAUU': [5.3, 0.0], 'LDAUL': [2, 0], 'LDAUJ': [0.0, 0.0]}
         magmom_ans = [5.0, 5.0, 5.0, 5.0, 0.6, 0.6, 0.6, 0.6, 0.6, 0.6]
         ldau_dict = {}


### PR DESCRIPTION
## Summary

Based on the discussion in #1464, I have added `override_from_prev_calc` methods to the VASP input sets that already define `from_prev_calc`. In each case, the old `from_prev_calc` method has been rewritten to use `override_from_prev_calc`. This new approach has several advantages, including:

- The `from_prev_calc` and `override_from_prev_calc` parameters are now consistent for every input set.
- There are now no duplicated parameters. Previously, some defaults were defined in both `__init__` and `from_prev_calc`, now they are all defined in `__init__`.
- The implementation in atomate should be significantly cleaner.

Some additional notes:
- Previously, some from_prev functions had a `standardize` keyword that would transform the structure to the standardized primitive cell. It seemed like this would be a very useful option for every input set, regardless of whether it was continuing from a previous calculation. E.g. at the start of your workflow, you might want to standardize your structure before relaxing. I have therefore added the `standardize` keyword argument to the base `DictSet`. By default this is set to False (which also matches the previous default behavior of standardize in the from_prev methods).
- `MPHSEBSSet` has a `mode` keyword that controls the type of calculation (line, uniform or gap). The gap option was only available in the from_prev method, where it was the default. The only difference between the gap and uniform modes is that the VBM and CBM of the previous calculation are explicitly added to the k-point list. I have changed the default value of mode in `__init__` to "Gap" because this gives the best compatibility with the previous behavior (it is reproduced exactly). If the user does not continue from a previous calculation, the behavior will be exactly the same as the "uniform" mode (the previous default for the init method). However, if the user continues from a previous calculation then the default will be to add the VBM and CBM k-points unless otherwise specified (again, the default for from_prev).
- `MVLGWSet` has different default values for they `mode` kwarg in the from_prev and init functions. I think this is due to the standard workflow for GW/BSE calculations. To avoid any issues here, I left the `mode` keyword as an option to the `from_prev_calc` method (so that the default behavior is not affected). As the main use of the `override_from_prev_calc` methods will be in atomate which does not use these input sets, the slightly different behavior of `override_from_prev_calc` (it does not use the same default mode as `from_prev_calc`) should not be an issue. I am open to other suggestions for fixing this, however.
- I fixed up the documentation if I noticed it was off.

One thing to note is, I had to introduce a dummy structure in the from_prev_calc methods, so that I could initialise the input set before calling override_from_prev_calc method. This is a bit ugly, but saves reading the vasprun twice to get the structure. 