### PR TITLE
Interpolate ximages

### DIFF
--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -1283,7 +1283,7 @@ class IStructure(SiteCollection, MSONable):
             new_sites = sorted(new_sites)
             return self.__class__.from_sites(new_sites, charge=self._charge)
 
-    def interpolate(self, end_structure, nimages=10,
+    def interpolate(self, end_structure, nimages=10, ximages=None,
                     interpolate_lattices=False, pbc=True, autosort_tol=0):
         """
         Interpolate between this structure and end_structure. Useful for
@@ -1293,6 +1293,8 @@ class IStructure(SiteCollection, MSONable):
             end_structure (Structure): structure to interpolate between this
                 structure and end.
             nimages (int): No. of interpolation images. Defaults to 10 images.
+            ximages (list): list of interpolation images
+                (e.g. ximages=np.linspace(0., 1., 20))
             interpolate_lattices (bool): Whether to interpolate the lattices.
                 Interpolates the lengths and angles (rather than the matrix)
                 so orientation may be affected.
@@ -1375,14 +1377,15 @@ class IStructure(SiteCollection, MSONable):
             lvec = p - np.identity(3)
             lstart = self.lattice.matrix.T
 
-        for x in range(nimages + 1):
+        for x in np.arange(nimages + 1) / nimages \
+                if ximages is None else ximages:
             if interpolate_lattices:
-                l_a = np.dot(np.identity(3) + x / nimages * lvec, lstart).T
-                l = Lattice(l_a)
+                l_a = np.dot(np.identity(3) + x * lvec, lstart).T
+                lat = Lattice(l_a)
             else:
-                l = self.lattice
-            fcoords = start_coords + x / nimages * vec
-            structs.append(self.__class__(l, sp, fcoords,
+                lat = self.lattice
+            fcoords = start_coords + x * vec
+            structs.append(self.__class__(lat, sp, fcoords,
                                           site_properties=self.site_properties))
         return structs
 

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -1283,7 +1283,7 @@ class IStructure(SiteCollection, MSONable):
             new_sites = sorted(new_sites)
             return self.__class__.from_sites(new_sites, charge=self._charge)
 
-    def interpolate(self, end_structure, nimages=10, ximages=None,
+    def interpolate(self, end_structure, nimages=10,
                     interpolate_lattices=False, pbc=True, autosort_tol=0):
         """
         Interpolate between this structure and end_structure. Useful for
@@ -1292,9 +1292,8 @@ class IStructure(SiteCollection, MSONable):
         Args:
             end_structure (Structure): structure to interpolate between this
                 structure and end.
-            nimages (int): No. of interpolation images. Defaults to 10 images.
-            ximages (list): list of interpolation images
-                (e.g. ximages=np.linspace(0., 1., 20))
+            nimages (int,list): No. of interpolation images or a list of
+                interpolation images. Defaults to 10 images.
             interpolate_lattices (bool): Whether to interpolate the lattices.
                 Interpolates the lengths and angles (rather than the matrix)
                 so orientation may be affected.
@@ -1317,6 +1316,9 @@ class IStructure(SiteCollection, MSONable):
 
         if not (interpolate_lattices or self.lattice == end_structure.lattice):
             raise ValueError("Structures with different lattices!")
+
+        if not isinstance(nimages, collections.abc.Iterable):
+            nimages = np.arange(nimages + 1) / nimages
 
         # Check that both structures have the same species
         for i in range(len(self)):
@@ -1377,8 +1379,7 @@ class IStructure(SiteCollection, MSONable):
             lvec = p - np.identity(3)
             lstart = self.lattice.matrix.T
 
-        for x in np.arange(nimages + 1) / nimages \
-                if ximages is None else ximages:
+        for x in nimages:
             if interpolate_lattices:
                 l_a = np.dot(np.identity(3) + x * lvec, lstart).T
                 lat = Lattice(l_a)

--- a/pymatgen/core/tests/test_structure.py
+++ b/pymatgen/core/tests/test_structure.py
@@ -212,6 +212,13 @@ class IStructureTest(PymatgenTest):
             self.assertEqual(int_s[0].lattice, s.lattice)
         self.assertArrayEqual(int_s[1][1].frac_coords, [0.725, 0.5, 0.725])
 
+        # test ximages
+        int_s = struct.interpolate(struct2, ximages=np.linspace(0., 1., 3))
+        for s in int_s:
+            self.assertIsNotNone(s, "Interpolation Failed!")
+            self.assertEqual(int_s[0].lattice, s.lattice)
+        self.assertArrayEqual(int_s[1][1].frac_coords, [0.625, 0.5, 0.625])
+
         badlattice = [[1, 0.00, 0.00], [0, 1, 0.00], [0.00, 0, 1]]
         struct2 = IStructure(badlattice, ["Si"] * 2, coords2)
         self.assertRaises(ValueError, struct.interpolate, struct2)

--- a/pymatgen/core/tests/test_structure.py
+++ b/pymatgen/core/tests/test_structure.py
@@ -213,7 +213,7 @@ class IStructureTest(PymatgenTest):
         self.assertArrayEqual(int_s[1][1].frac_coords, [0.725, 0.5, 0.725])
 
         # test ximages
-        int_s = struct.interpolate(struct2, ximages=np.linspace(0., 1., 3))
+        int_s = struct.interpolate(struct2, nimages=np.linspace(0., 1., 3))
         for s in int_s:
             self.assertIsNotNone(s, "Interpolation Failed!")
             self.assertEqual(int_s[0].lattice, s.lattice)


### PR DESCRIPTION
## Summary

Added the argument "ximages" to IStructure.interpolate. This allows you to define an arbitrary grid of interpolation points between the two lattices. This is useful for making configuration coordinate diagrams.

"nimages" was left intact to maintain backwards compatibility. "ximages" may not be the best name, feel free to change it to something more descriptive.

## Additional dependencies introduced (if any)

N/A

## TODO (if any)

N/A