### PR TITLE
Fix the rgb_label of 2 elements band structure

### DIFF
--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -2539,7 +2539,7 @@ class BSDOSPlotter:
                           [1 - (i / 1000) ** 2, 0, (i / 1000) ** 2]])
 
         # plot the bar
-        inset_ax.scatter(x, y, s=250., marker='s', edgecolor=color)
+        inset_ax.scatter(x, y, s=250., marker='s', c=color)
         inset_ax.set_xlim([-0.1, 1.7])
         inset_ax.text(1.35, 0, b_label, fontsize=13,
                       family='Times New Roman', color=(0, 0, 0),


### PR DESCRIPTION
## Summary

* Fix the rgb_label of 2 elements band structure

After fix: 
<img src="https://user-images.githubusercontent.com/18021558/58139835-969e8880-7c0a-11e9-8164-ef6039859383.png" width=150/>

Before fix:
<img src="https://user-images.githubusercontent.com/18021558/58139864-b9c93800-7c0a-11e9-9b08-27f80630a767.png" width=150/>
