### PR TITLE
Make FermiDos MSONable

### DIFF
--- a/pymatgen/analysis/defects/thermodynamics.py
+++ b/pymatgen/analysis/defects/thermodynamics.py
@@ -416,7 +416,7 @@ class DefectPhaseDiagram(MSONable):
                 for d in self.defect_concentrations(
                     chemical_potentials=chemical_potentials, temperature=temperature, fermi_level=ef)
             ])
-            qd_tot += fdos.get_doping(fermi=ef + fdos_vbm, T=temperature)
+            qd_tot += fdos.get_doping(fermi_level=ef + fdos_vbm, temperature=temperature)
             return qd_tot
 
         return bisect(_get_total_q, -1., self.band_gap + 1.)
@@ -453,7 +453,7 @@ class DefectPhaseDiagram(MSONable):
         def _get_total_q(ef):
 
             qd_tot = fixed_defect_charge
-            qd_tot += fdos.get_doping(fermi=ef + fdos_vbm, T=temperature)
+            qd_tot += fdos.get_doping(fermi_level=ef + fdos_vbm, temperature=temperature)
             return qd_tot
 
         return bisect(_get_total_q, -1., self.band_gap + 1.)

--- a/pymatgen/electronic_structure/dos.py
+++ b/pymatgen/electronic_structure/dos.py
@@ -415,147 +415,196 @@ class Dos(MSONable):
 
 class FermiDos(Dos):
     """
-    This wrapper class helps relates the density of states, doping levels
+    This wrapper class helps relate the density of states, doping levels
     (i.e. carrier concentrations) and corresponding fermi levels. A negative
-    doping concentration (c) means that the majority carriers are electrons
-    (n-type doping) and positive c represents holes or p-type doping.
+    doping concentration indicates the majority carriers are electrons
+    (n-type doping); a positive doping concentration indicates holes are the
+    majority carriers (p-type doping).
 
     Args:
-        dos (pymatgen Dos class): density of states at corresponding energy levels
-        structure (pymatgen Structure class): provided either as input or
-            inside Dos (e.g. if CompleteDos used)
-        nelecs (float): the number of electrons included in the energy range of
+        dos: Pymatgen Dos object.
+        structure: A structure. If not provided, the structure
+            of the dos object will be used. If the dos does not have an
+            associated structure object, an error will be thrown.
+        nelecs: The number of electrons included in the energy range of
             dos. It is used for normalizing the densities. Default is the total
             number of electrons in the structure.
-        bandgap (float): if set, the energy values are scissored so that the
-            electronic band gap matches this value.
+        bandgap: If set, the energy values are scissored so that the electronic
+            band gap matches this value.
     """
 
-    def __init__(self, dos, structure=None, nelecs=None, bandgap=None):
-        super().__init__(
-            dos.efermi, energies=dos.energies,
-            densities={k: np.array(d) for k, d in dos.densities.items()})
+    def __init__(self, dos: Dos, structure: Structure = None,
+                 nelecs: float = None, bandgap: float = None):
+        super().__init__(dos.efermi, energies=dos.energies,
+                         densities={k: np.array(d) for k, d in
+                                    dos.densities.items()})
+
         if structure is None:
-            try:
-                self.structure = dos.structure
-            except:
-                raise ValueError('"structure" not provided!')
-        else:
-            self.structure = structure
+            if hasattr(self.structure, "structure"):
+                structure = dos.structure
+            else:
+                raise ValueError("Structure object is not provided and not "
+                                 "present in dos")
+
+        self.structure = structure
+        self.nelecs = nelecs or self.structure.composition.total_electrons
+        self.bandgap = bandgap
+        self._dos = dos
+
         self.volume = self.structure.volume
         self.energies = np.array(dos.energies)
-        self.de = np.hstack((self.energies[1:], self.energies[-1])) - self.energies
-        tdos = np.array(self.get_densities())
-        nelecs = nelecs or self.structure.composition.total_electrons
+        self.de = np.hstack(
+            (self.energies[1:], self.energies[-1])) - self.energies
+
         # normalize total density of states based on integral at 0K
-        self.tdos = tdos * nelecs / (tdos * self.de)[self.energies <= self.efermi].sum()
+        tdos = np.array(self.get_densities())
+        self.tdos = tdos * nelecs / (tdos * self.de)[self.energies <=
+                                                     self.efermi].sum()
+
         ecbm, evbm = self.get_cbm_vbm()
         self.idx_vbm = np.argmin(abs(self.energies - evbm))
         self.idx_cbm = np.argmin(abs(self.energies - ecbm))
         self.A_to_cm = 1e-8
+
         if bandgap:
-            if self.efermi < ecbm and self.efermi > evbm:
+            if evbm < self.efermi < ecbm:
                 eref = self.efermi
             else:
                 eref = (evbm + ecbm) / 2.0
+
             idx_fermi = np.argmin(abs(self.energies - eref))
-            if idx_fermi == self.idx_vbm: #need fermi level and vbm to be different indices
+
+            if idx_fermi == self.idx_vbm:
+                # Fermi level and vbm should be different indices
                 idx_fermi += 1
+
             self.energies[:idx_fermi] -= (bandgap - (ecbm - evbm)) / 2.0
             self.energies[idx_fermi:] += (bandgap - (ecbm - evbm)) / 2.0
 
-    def get_doping(self, fermi, T):
+    def get_doping(self, fermi_level: float, temperature: float) -> float:
         """
-        Calculate the doping (majority carrier concentration) at a given fermi
-        level and temperature. A simple Left Riemann sum is used for integrating
-        the density of states over energy & equilibrium Fermi-Dirac distribution
+        Calculate the doping (majority carrier concentration) at a given
+        fermi level  and temperature. A simple Left Riemann sum is used for
+        integrating the density of states over energy & equilibrium Fermi-Dirac
+        distribution.
 
         Args:
-            fermi (float): the fermi level in eV
-            T (float): the temperature in Kelvin
+            fermi_level: The fermi_level level in eV.
+            temperature: The temperature in Kelvin.
 
-        Returns (float): in units 1/cm3. If negative it means that the majority
-            carriers are electrons (n-type doping) and if positive holes/p-type
+        Returns:
+            The doping concentration in units of 1/cm^3. Negative values
+            indicate that the majority carriers are electrons (n-type doping)
+            whereas positivie values indicates the majority carriers are holes
+            (p-type doping).
         """
-        cb_integral = np.sum(self.tdos[self.idx_cbm:]
-                             * f0(self.energies[self.idx_cbm:], fermi, T)
-                             * self.de[self.idx_cbm:], axis=0)
-        vb_integral = np.sum(self.tdos[:self.idx_vbm + 1]
-                             * (1 - f0(self.energies[:self.idx_vbm + 1], fermi, T))
-                             * self.de[:self.idx_vbm + 1], axis=0)
+        cb_integral = np.sum(
+            self.tdos[self.idx_cbm:]
+            * f0(self.energies[self.idx_cbm:], fermi_level, temperature)
+            * self.de[self.idx_cbm:], axis=0)
+        vb_integral = np.sum(
+            self.tdos[:self.idx_vbm + 1] *
+            (1 - f0(self.energies[:self.idx_vbm + 1], fermi_level, temperature))
+            * self.de[:self.idx_vbm + 1], axis=0)
         return (vb_integral - cb_integral) / (self.volume * self.A_to_cm ** 3)
 
-    def get_fermi_interextrapolated(self, c, T, warn=True, c_ref=1e10, **kwargs):
+    def get_fermi_interextrapolated(self, concentration: float,
+                                    temperature: float, warn: bool = True,
+                                    c_ref: float = 1e10, **kwargs) -> float:
         """
         Similar to get_fermi except that when get_fermi fails to converge,
-        an interpolated or extrapolated fermi (depending on c) is returned with
-        the assumption that the fermi level changes linearly with log(abs(c)).
+        an interpolated or extrapolated fermi is returned with the assumption
+        that the fermi level changes linearly with log(abs(concentration)).
 
         Args:
-            c (float): doping concentration in 1/cm3. c<0 represents n-type
-                doping and c>0 p-type doping (i.e. majority carriers are holes)
-            T (float): absolute temperature in Kelvin
-            warn (bool): whether to warn for the first time when no fermi can
-                be found.
-            c_ref (float): a doping concentration where get_fermi returns a
-                value without error for both c_ref and -c_ref
-            **kwargs: see keyword arguments of the get_fermi function
+            concentration: The doping concentration in 1/cm^3. Negative values
+                represent n-type doping and positive values represent p-type
+                doping.
+            temperature: The temperature in Kelvin.
+            warn: Whether to give a warning the first time the fermi cannot be
+                found.
+            c_ref: A doping concentration where get_fermi returns a
+                value without error for both c_ref and -c_ref.
+            **kwargs: Keyword arguments passed to the get_fermi function.
 
-        Returns (float): the fermi level that is possibly interapolated or
+        Returns:
+            The Fermi level. Note, the value is possibly interpolated or
             extrapolated and must be used with caution.
         """
         try:
-            return self.get_fermi(c, T, **kwargs)
+            return self.get_fermi(concentration, temperature, **kwargs)
         except ValueError as e:
             if warn:
                 warnings.warn(str(e))
-            if abs(c) < c_ref:
-                if abs(c) < 1e-10:
-                    c = 1e-10
-                # max(10, ) is to avoid log(0<x<1) and log(1+x) both of which are slow
-                f2 = self.get_fermi_interextrapolated(max(10, abs(c) * 10.), T, warn=False, **kwargs)
-                f1 = self.get_fermi_interextrapolated(-max(10, abs(c) * 10.), T, warn=False, **kwargs)
-                c2 = np.log(abs(1 + self.get_doping(f2, T)))
-                c1 = -np.log(abs(1 + self.get_doping(f1, T)))
+
+            if abs(concentration) < c_ref:
+                if abs(concentration) < 1e-10:
+                    concentration = 1e-10
+
+                # max(10, ) is to avoid log(0<x<1) and log(1+x) both of which
+                # are slow
+                f2 = self.get_fermi_interextrapolated(
+                    max(10, abs(concentration) * 10.), temperature, warn=False,
+                    **kwargs)
+                f1 = self.get_fermi_interextrapolated(
+                    -max(10, abs(concentration) * 10.), temperature, warn=False,
+                    **kwargs)
+                c2 = np.log(abs(1 + self.get_doping(f2, temperature)))
+                c1 = -np.log(abs(1 + self.get_doping(f1, temperature)))
                 slope = (f2 - f1) / (c2 - c1)
-                return f2 + slope * (np.sign(c) * np.log(abs(1 + c)) - c2)
+                return f2 + slope * (np.sign(concentration) *
+                                     np.log(abs(1 + concentration)) - c2)
+
             else:
-                f_ref = self.get_fermi_interextrapolated(np.sign(c) * c_ref, T, warn=False, **kwargs)
-                f_new = self.get_fermi_interextrapolated(c / 10., T, warn=False, **kwargs)
-                clog = np.sign(c) * np.log(abs(c))
-                c_newlog = np.sign(c) * np.log(abs(self.get_doping(f_new, T)))
-                slope = (f_new - f_ref) / (c_newlog - np.sign(c) * 10.)
+                f_ref = self.get_fermi_interextrapolated(
+                    np.sign(concentration) * c_ref, temperature, warn=False,
+                    **kwargs)
+                f_new = self.get_fermi_interextrapolated(
+                    concentration / 10., temperature, warn=False, **kwargs)
+                clog = np.sign(concentration) * np.log(abs(concentration))
+                c_newlog = np.sign(concentration) * np.log(
+                    abs(self.get_doping(f_new, temperature)))
+                slope = (f_new - f_ref) / (c_newlog - np.sign(concentration)
+                                           * 10.)
                 return f_new + slope * (clog - c_newlog)
 
-    def get_fermi(self, c, T, rtol=0.01, nstep=50, step=0.1, precision=8):
+    def get_fermi(self, concentration: float, temperature: float,
+                  rtol: float = 0.01, nstep: int = 50, step: float = 0.1,
+                  precision: int = 8):
         """
         Finds the fermi level at which the doping concentration at the given
-        temperature (T) is equal to c. A greedy algorithm is used where the
-        relative error is minimized by calculating the doping at a grid which
-        is continuously become finer.
+        temperature (T) is equal to concentration. A greedy algorithm is used
+        where the relative error is minimized by calculating the doping at a
+        grid which continually becomes finer.
 
         Args:
-            c (float): doping concentration. c<0 represents n-type doping and
-                c>0 represents p-type doping (i.e. majority carriers are holes)
-            T (float): absolute temperature in Kelvin
-            rtol (float): maximum acceptable relative error
-            nstep (int): number of steps checked around a given fermi level
-            step (float): initial step in fermi level when searching
-            precision (int): essentially the decimal places of calculated fermi
+            concentration: The doping concentration in 1/cm^3. Negative values
+                represent n-type doping and positive values represent p-type
+                doping.
+            temperature: The temperature in Kelvin.
+            rtol: The maximum acceptable relative error.
+            nstep: THe number of steps checked around a given fermi level.
+            step: Initial step in energy when searching for the Fermi level.
+            precision: Essentially the decimal places of calculated Fermi level.
 
-        Returns (float): the fermi level. Note that this is different from the
-            default dos.efermi.
+        Returns:
+            The fermi level in eV.. Note that this is different from the default
+            dos.efermi.
         """
         fermi = self.efermi  # initialize target fermi
+        relative_error = float("inf")
         for _ in range(precision):
             frange = np.arange(-nstep, nstep + 1) * step + fermi
-            calc_doping = np.array([self.get_doping(f, T) for f in frange])
-            relative_error = abs(calc_doping / c - 1.0)
+            calc_doping = np.array([self.get_doping(f, temperature)
+                                    for f in frange])
+            relative_error = abs(calc_doping / concentration - 1.0)
             fermi = frange[np.argmin(relative_error)]
             step /= 10.0
+
         if min(relative_error) > rtol:
-            raise ValueError('Could not find fermi within {}% of c={}'.format(
-                rtol * 100, c))
+            raise ValueError(
+                "Could not find fermi within {}% of concentration={}".format(
+                    rtol * 100, concentration))
         return fermi
 
 

--- a/pymatgen/electronic_structure/dos.py
+++ b/pymatgen/electronic_structure/dos.py
@@ -440,7 +440,7 @@ class FermiDos(Dos, MSONable):
                                     dos.densities.items()})
 
         if structure is None:
-            if hasattr(self.structure, "structure"):
+            if hasattr(dos, "structure"):
                 structure = dos.structure
             else:
                 raise ValueError("Structure object is not provided and not "

--- a/pymatgen/electronic_structure/dos.py
+++ b/pymatgen/electronic_structure/dos.py
@@ -456,8 +456,8 @@ class FermiDos(Dos, MSONable):
 
         # normalize total density of states based on integral at 0K
         tdos = np.array(self.get_densities())
-        self.tdos = tdos * nelecs / (tdos * self.de)[self.energies <=
-                                                     self.efermi].sum()
+        self.tdos = tdos * self.nelecs / (tdos * self.de)[self.energies <=
+                                                          self.efermi].sum()
 
         ecbm, evbm = self.get_cbm_vbm()
         self.idx_vbm = np.argmin(abs(self.energies - evbm))

--- a/pymatgen/electronic_structure/tests/test_dos.py
+++ b/pymatgen/electronic_structure/tests/test_dos.py
@@ -60,12 +60,12 @@ class FermiDosTest(unittest.TestCase):
         T = 300
         fermi0 = self.dos.efermi
         frange = [fermi0 - 0.5, fermi0, fermi0 + 2.0, fermi0 + 2.2]
-        dopings = [self.dos.get_doping(fermi=f, T=T) for f in frange]
+        dopings = [self.dos.get_doping(fermi_level=f, temperature=T) for f in frange]
         ref_dopings = [3.48077e+21, 1.9235e+18, -2.6909e+16, -4.8723e+19]
         for i, c_ref in enumerate(ref_dopings):
             self.assertLessEqual(abs(dopings[i] / c_ref - 1.0), 0.01)
 
-        calc_fermis = [self.dos.get_fermi(c=c, T=T) for c in ref_dopings]
+        calc_fermis = [self.dos.get_fermi(concentration=c, temperature=T) for c in ref_dopings]
         for j, f_ref in enumerate(frange):
             self.assertAlmostEqual(calc_fermis[j], f_ref, 4)
 
@@ -79,10 +79,10 @@ class FermiDosTest(unittest.TestCase):
         for i, c_ref in enumerate(ref_dopings):
             if c_ref < 0:
                 self.assertAlmostEqual(
-                    sci_dos.get_fermi(c_ref, T=T) - frange[i], 0.47, places=2)
+                    sci_dos.get_fermi(c_ref, temperature=T) - frange[i], 0.47, places=2)
             else:
                 self.assertAlmostEqual(
-                    sci_dos.get_fermi(c_ref, T=T) - frange[i], -0.47, places=2)
+                    sci_dos.get_fermi(c_ref, temperature=T) - frange[i], -0.47, places=2)
 
         self.assertAlmostEqual(sci_dos.get_fermi_interextrapolated(-1e26, 300),
                                7.5108, 4)


### PR DESCRIPTION
## Summary

Currently, FermiDos objects are not MSONable for two reasons:
1. They have a strange constructor that requires a Dos object rather than energies, densities and a Fermi level like other Dos subclasses.
2. The nelecs variable is not stored, even as a private variable.

Ideally I'd correct the constructor but I don't want to break other peoples code. Instead, I've added custom to_dict and from_dict methods and fixed point 2.

I've also tied up the class, made it pep8 compliant and added type hinting. 