### PR TITLE
Fix the color issue of segmented drawing different branches of band s…

### DIFF
--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -2291,13 +2291,14 @@ class BSDOSPlotter:
                     current_pos = 0
                     for x_distances in x_distances_list:
                         sub_band = band[current_pos: current_pos + len(x_distances)]
-                        current_pos += len(x_distances)
 
                         self._rgbline(bs_ax, x_distances, sub_band,
-                                      colordata[spin][band_idx, :, 0],
-                                      colordata[spin][band_idx, :, 1],
-                                      colordata[spin][band_idx, :, 2],
+                                      colordata[spin][band_idx, :, 0][current_pos: current_pos + len(x_distances)],
+                                      colordata[spin][band_idx, :, 1][current_pos: current_pos + len(x_distances)],
+                                      colordata[spin][band_idx, :, 2][current_pos: current_pos + len(x_distances)],
                                       linestyles=linestyles)
+
+                        current_pos += len(x_distances)
 
         if dos:
             # Plot the DOS and projected DOS


### PR DESCRIPTION
## Summary
Fix the color issue of segmented drawing different branches of the band structure in BSDOSPlotter.

* After fix
![image](https://user-images.githubusercontent.com/18021558/58363740-1892e980-7e77-11e9-8af3-1b8fbd0f1e84.png)

* Before fix
![image](https://user-images.githubusercontent.com/18021558/58363715-bfc35100-7e76-11e9-8ade-4a31de333236.png)

This bug was introduced in PR: https://github.com/materialsproject/pymatgen/pull/1470