### PR TITLE
fix CovalentBondNN.get_bonded_structure

### DIFF
--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -1378,7 +1378,7 @@ class CovalentBondNN(NearNeighbors):
                                 for n in range(len(structure))]
             structure.add_site_property('order_parameters', order_parameters)
 
-        mg = MoleculeGraph.with_local_env_strategy(structure, self)
+        mg = MoleculeGraph.with_local_env_strategy(structure, self, extend_structure=False)
 
         return mg
 

--- a/pymatgen/analysis/tests/test_local_env.py
+++ b/pymatgen/analysis/tests/test_local_env.py
@@ -335,6 +335,15 @@ class CovalentBondNNTest(PymatgenTest):
         acetylene = strat.get_nn_info(self.acetylene, 0)
         self.assertAlmostEqual(acetylene[0]["weight"], 1.19, places=2)
 
+    def test_bonded_structure(self):
+        strat = CovalentBondNN()
+
+        benzene = strat.get_bonded_structure(self.benzene)
+        self.assertEqual(len(benzene.find_rings()), 1)
+
+        acetylene = strat.get_bonded_structure(self.acetylene)
+        self.assertEqual(len(acetylene.graph.nodes), 4)
+
     def tearDown(self):
         del self.benzene
         del self.acetylene


### PR DESCRIPTION
## Summary
In the current master branch, `pymatgen.analysis.local_env.CovalentBondNN` returns AttributeError with the following code:
```
from pymatgen.core import Molecule
from pymatgen.analysis.local_env import CovalentBondNN

H2 = Molecule(['H', 'H'], [[0, 0, 0], [0, 0, 1.0]])
bonds = H2.get_covalent_bonds()
assert(len(bonds) == 1)

cbnn = CovalentBondNN()
mg = cbnn.get_bonded_structure(H2)
# -> AttributeError: 'Structure' object has no attribute 'get_covalent_bonds'
```

I find `CovalentBondNN.get_bonded_structure` calls `pymatgen.analysis.graphs.with_local_env_strategy` with defalut flag, and the latter returns not Molecule object but Structure object.

I fix a corresponding part and add test for `CovalentBondNN.get_bonded_structure`.