### PR TITLE
Bug fix for get_all_neighbors

### DIFF
--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -1360,7 +1360,6 @@ class IStructure(SiteCollection, MSONable):
             nn_indices = list(itertools.chain(*[cube_to_indices[k] for k in ks]))
             dist = np.linalg.norm(nn_coords - i[None, :], axis=1)
             nns = []
-            is_filtered = False
             for coord, m, n, d in zip(nn_coords, nn_indices, nn_images, dist):
                 if d < r + 1e-10:
                     item = []
@@ -1370,8 +1369,7 @@ class IStructure(SiteCollection, MSONable):
 
                     # filtering out centering atom, if two identical sites exists
                     # only filter the first one
-                    if (site_temp.specie == site.specie) and (d < 1e-8) and (not is_filtered):
-                        is_filtered = True
+                    if (site_temp.specie == site.specie) and (d < 1e-8):
                         continue
                     if include_site:
                         item += [site_temp]

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -1367,8 +1367,7 @@ class IStructure(SiteCollection, MSONable):
                                              properties=self[m].properties,
                                              coords_are_cartesian=True)
 
-                    # filtering out centering atom, if two identical sites exists
-                    # only filter the first one
+                    # filtering out all sites that are identical to centering site
                     if (site_temp.specie == site.specie) and (d < 1e-8):
                         continue
                     if include_site:

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -1290,14 +1290,12 @@ class IStructure(SiteCollection, MSONable):
                 filtered_labels.append(labels[ind])
             return filtered_labels
 
-        # radius too small
-        if r < 1e-10:
-            return [[]]
+        if r == 0:
+            return [[]] * len(self)
         latt = self.lattice
         if sites is None:
             sites = self.sites
         site_coords = np.array([site.coords for site in sites])
-
         recp_len = np.array(latt.reciprocal_lattice.abc)
         maxr = np.ceil((r + 0.15) * recp_len / (2 * math.pi))
         frac_coords = latt.get_fractional_coords(site_coords)
@@ -1307,7 +1305,6 @@ class IStructure(SiteCollection, MSONable):
         matrix = latt.matrix
         all_fcoords = np.mod(self.frac_coords, 1)
         coords_in_cell = np.dot(all_fcoords, matrix)
-
         coords_min = np.min(site_coords, axis=0)
         coords_max = np.max(site_coords, axis=0)
         # The lower bound of all considered atom coords
@@ -1341,7 +1338,6 @@ class IStructure(SiteCollection, MSONable):
             cube_to_coords[i].append(j)
             cube_to_images[i].append(k)
             cube_to_indices[i].append(l)
-
         for i in cube_to_coords:
             cube_to_coords[i] = np.array(cube_to_coords[i])
 
@@ -1350,19 +1346,22 @@ class IStructure(SiteCollection, MSONable):
         neighbors = []
         # if no neighbors were found, return list of empty list
         if np.all([len(i) == 0 for i in site_neighbors]):
-            return [[]]
+            return [[]] * len(self)
         for sp, i, j in zip(self.species_and_occu, site_coords, site_neighbors):
             l1 = np.array(three_to_one(j, ny, nz), dtype=int).ravel()
             # use the cube index map to find the all the neighboring
             # coords, images, and indices
             ks = [k for k in l1 if k in cube_to_coords]
+            if not ks:
+                neighbors.append([])
+                continue
             nn_coords = np.concatenate([cube_to_coords[k] for k in ks], axis=0)
             nn_images = list(itertools.chain(*[cube_to_images[k] for k in ks]))
             nn_indices = list(itertools.chain(*[cube_to_indices[k] for k in ks]))
             dist = np.linalg.norm(nn_coords - i[None, :], axis=1)
             nns = []
             for coord, m, n, d in zip(nn_coords, nn_indices, nn_images, dist):
-                if 1e-8 < d <= r:
+                if d < r + 1e-10:
                     item = []
                     if include_site:
                         item += [PeriodicSite(self[m].species, coord, latt,
@@ -1374,6 +1373,12 @@ class IStructure(SiteCollection, MSONable):
                     if include_image:
                         item += [tuple(n)]
                     nns.append(item)
+
+            # filtering the centering atom
+            dist_index = 1 if include_site else 0
+            n_dist = [nn[dist_index] for nn in nns]
+            ind_min = np.argmin(n_dist)
+            nns.pop(ind_min)
             neighbors.append(nns)
         return neighbors
 

--- a/pymatgen/core/tests/test_structure.py
+++ b/pymatgen/core/tests/test_structure.py
@@ -461,7 +461,7 @@ class IStructureTest(PymatgenTest):
                       [[0.1, 0.1, 0.1], [0.1, 0.1, 0.1], [3, 3, 3]],
                       coords_are_cartesian=True)
         all_nn = s.get_all_neighbors(1e-5, True)
-        self.assertEqual([len(i) for i in all_nn], [1, 1, 0])
+        self.assertEqual([len(i) for i in all_nn], [0, 0, 0])
 
     def test_get_all_neighbors_old(self):
         s = self.struct

--- a/pymatgen/core/tests/test_structure.py
+++ b/pymatgen/core/tests/test_structure.py
@@ -389,7 +389,6 @@ class IStructureTest(PymatgenTest):
                                       include_index=True, include_image=True)
         self.assertEqual(len(nn), 47)
         self.assertEqual(nn[0][-2], 0)
-
         r = random.uniform(3, 6)
         all_nn = s.get_all_neighbors(r, True, True)
         for i in range(len(s)):
@@ -446,6 +445,24 @@ class IStructureTest(PymatgenTest):
                 self.assertAlmostEqual(d, nn[1])
         self.assertEqual(list(map(len, all_nn)), [2, 2, 2, 0])
 
+    def test_get_all_neighbors_small_cutoff(self):
+        s = Structure(Lattice.cubic(2), ['Li', 'Li', 'Li', 'Si'],
+                      [[3.1] * 3, [0.11] * 3, [-1.91] * 3, [0.5] * 3])
+        all_nn = s.get_all_neighbors(1e-5, True)
+        self.assertEqual(len(all_nn), len(s))
+        self.assertEqual([], all_nn[0])
+
+        all_nn = s.get_all_neighbors(0, True)
+        self.assertEqual(len(all_nn), len(s))
+        self.assertEqual([], all_nn[0])
+
+    def test_coincide_sites(self):
+        s = Structure(Lattice.cubic(5), ['Li', 'Li', 'Li'],
+                      [[0.1, 0.1, 0.1], [0.1, 0.1, 0.1], [3, 3, 3]],
+                      coords_are_cartesian=True)
+        all_nn = s.get_all_neighbors(1e-5, True)
+        self.assertEqual([len(i) for i in all_nn], [1, 1, 0])
+
     def test_get_all_neighbors_old(self):
         s = self.struct
 
@@ -453,7 +470,7 @@ class IStructureTest(PymatgenTest):
         all_nn = s.get_all_neighbors_old(r, True, True)
         for i in range(len(s)):
             self.assertEqual(4, len(all_nn[i][0]))
-            self.assertEqual(len(all_nn[i]), len(s.get_neighbors(s[i], r)))
+            self.assertEqual(len(all_nn[i]), len(s.get_neighbors_old(s[i], r)))
 
         for site, nns in zip(s, all_nn):
             for nn in nns:


### PR DESCRIPTION
## Summary

1. Fixed the return type of `get_all_neighbors` when no neighbors are found. It should return a list of length n, where each item is `[]` and n is the number of atoms
2. Fixed the `magnetism` test problem. It is an issue with coincide sites. The site with DummySpecie coincides with a normal site and now the `get_neighbors` can find the correct neighbors from the Dummy site. 

## Possible issue
In the case where two identical sites exist in a structure, the `get_neighbors_old` will not find any neighbors using one of the site (small cutoff). However, if one site has a different specie, then the algorithm will be able to find neighbors. It does not seem to be physical since neighboring relationship is only spatial information and should have nothing to do with the Specie. Now I set `get_neighbors` to have the same behavior as `get_neighbors_old`. If this needs to change, it can be easily fixed. 

## Comparisons between `get_all_neighbors_old` and `get_all_neighbors`
The `get_all_neighbors_old` may give different results compared to `get_neighbors_old`, for example, in structures with coincide sites. For comparisons, always compare `get_all_neighbors` and `get_neighbors` to `get_neighbors_old`. 