### PR TITLE
Modified run_type in outputs.py.

### DIFF
--- a/pymatgen/apps/borg/hive.py
+++ b/pymatgen/apps/borg/hive.py
@@ -244,14 +244,14 @@ class SimpleVaspToComputedEntryDrone(VaspToComputedEntryDrone):
                 param["hubbards"] = dict(zip(poscar.site_symbols,
                                              incar["LDAUU"]))
             param["is_hubbard"] = (
-                incar.get("LDAU", False) and sum(param["hubbards"].values()) > 0
+                incar.get("LDAU", True) and sum(param["hubbards"].values()) > 0
             ) if incar is not None else False
             param["run_type"] = None
             if incar is not None:
-                param["run_type"] = "GGA+U" if param["is_hubbard"] else "GGA"
+                param["run_type"] = Vasprun.run_type
             # param["history"] = _get_transformation_history(path)
             param["potcar_spec"] = potcar.spec if potcar is not None else None
-            energy = oszicar.final_energy if oszicar is not None else 1e10
+            energy = oszicar.final_energy if oszicar is not None else Vasprun.final_energy
             structure = contcar.structure if contcar is not None\
                 else poscar.structure
             initial_vol = poscar.structure.volume if poscar is not None else \

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -649,24 +649,39 @@ class Vasprun(MSONable):
 
         TODO: Fix for other functional types like PW91, other vdW types, etc.
         """
+        GGA_TYPES = {"RE": "revPBE", "PE": "PBE", "PS": "PBESol", "RP": "RevPBE+PADE", "AM": "AM05", "OR": "optPBE",
+                     "BO": "optB88", "MK": "optB86b", "--": "None or LDA"}
 
-        METAGGA_TYPES = {"TPSS", "RTPSS", "M06L", "MBJL", "SCAN", "MS0", "MS1", "MS2"}
+        METAGGA_TYPES = {"TPSS": "TPSS", "RTPSS": "revTPSS", "M06L": "M06-L", "MBJ": "modified Becke-Johnson",
+                         "SCAN": "SCAN", "MS0": "MadeSimple0", "MS1": "MadeSimple1", "MS2": "MadeSimple2"}
 
-        if self.parameters.get("LHFCALC", False):
+        if self.parameters.get("AEXX", 1.00) == 1.00:
             rt = "HF"
-        elif self.parameters.get("METAGGA", "").strip().upper() in METAGGA_TYPES:
-            rt = self.parameters["METAGGA"].strip().upper()
-        elif self.parameters.get("LUSE_VDW", False):
-            vdw_gga = {"RE": "DF", "OR": "optPBE", "BO": "optB88",
-                       "MK": "optB86b", "ML": "DF2"}
-            gga = self.parameters.get("GGA").upper()
-            rt = "vdW-" + vdw_gga[gga]
+        elif self.parameters.get("HFSCREEN", 0.30) == 0.30:
+            rt = "HSE03"
+        elif self.parameters.get("HFSCREEN", 0.20) == 0.20:
+            rt = "HSE06"
+        elif self.parameters.get("AEXX", 0.20) == 0.20:
+            rt = "B3LYP"
+        elif self.parameters.get("LHFCALC", True):
+            rt = "PBEO or other Hybrid Functional"
+        elif self.parameters.get("BPARAM", 15.70) == 15.70 and self.parameters.get("LUSE_VDW", True):
+            if self.incar.get("METAGGA", "").strip().upper() in METAGGA_TYPES:
+                rt = GGA_TYPES[self.parameters.get("GGA", "").strip().upper()]+"+"+\
+                     METAGGA_TYPES[self.incar.get("METAGGA", "").strip().upper()]+"+rVV10"
+            else:
+                rt = GGA_TYPES[self.parameters.get("GGA", "").strip().upper()]+"+rVV10"
+        elif self.incar.get("METAGGA", "").strip().upper() in METAGGA_TYPES:
+            rt = GGA_TYPES[self.parameters.get("GGA", "").strip().upper()]+"+"+\
+                 METAGGA_TYPES[self.incar.get("METAGGA", "").strip().upper()]
+            if self.is_hubbard or self.parameters.get("LDAU", True):
+                rt += "+U"
         elif self.potcar_symbols[0].split()[0] == 'PAW':
             rt = "LDA"
-        else:
-            rt = "GGA"
-        if self.is_hubbard:
-            rt += "+U"
+        elif self.parameters.get("GGA", "").strip().upper() in GGA_TYPES:
+            rt = GGA_TYPES[self.parameters.get("GGA", "").strip().upper()]
+            if self.is_hubbard or self.parameters.get("LDAU", True):
+                rt += "+U"
         return rt
 
     @property

--- a/pymatgen/io/vasp/tests/test_outputs.py
+++ b/pymatgen/io/vasp/tests/test_outputs.py
@@ -90,6 +90,10 @@ class VasprunTest(PymatgenTest):
             self.assertTrue(issubclass(w[-1].category,
                                        UserWarning))
 
+    def test_runtype(self):
+        v = Vasprun(self.TEST_FILES_DIR / "vasprun.xml.hse06")
+        self.assertIn(v.run_type, "HSE06")
+
     def test_vdw(self):
         v = Vasprun(self.TEST_FILES_DIR / "vasprun.xml.vdw")
         self.assertAlmostEqual(v.final_energy, -9.78310677)


### PR DESCRIPTION
## Summary
Updated run_type_method but phonoopy test giving error which is independent of my changes.

* Modified run_type_method in Vasprun class within outputs.py script to account for wider range of functionals/levels of theory.
   
* Added tests within test_outputs.py script in io/vasp/tests directory and new test files relevant to various functionals/levels of theory.

## TODO (if any)

If this is a work-in-progress, write something about what else needs 
to be done

* Add functionality to account for Many-Body perturbation theory (GW, GoWo, scGW, etc.), the Random Phase Approximation (ACDFT/RPA), Time-Dependent DFT (TD-DFT) and Time-Dependent Hartree-Fock equations (TDHF) via the Bethe Salpeter and Casida equations (BSE), and other higher levels of theory.
