### PR TITLE
Fix reading the SC K-Point set when LVEL flag is set.

### DIFF
--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -414,9 +414,10 @@ class Vasprun(MSONable):
                     elif tag == "incar":
                         self.incar = self._parse_params(elem)
                     elif tag == "kpoints":
-                        self.kpoints, self.actual_kpoints, \
-                        self.actual_kpoints_weights = self._parse_kpoints(
-                            elem)
+                        if not hasattr(self, 'kpoints'):
+                            self.kpoints, self.actual_kpoints, \
+                            self.actual_kpoints_weights = self._parse_kpoints(
+                                elem)
                     elif tag == "parameters":
                         self.parameters = self._parse_params(elem)
                     elif tag == "structure" and elem.attrib.get("name") == \

--- a/pymatgen/io/vasp/tests/test_outputs.py
+++ b/pymatgen/io/vasp/tests/test_outputs.py
@@ -561,6 +561,10 @@ class VasprunTest(PymatgenTest):
         self.assertEqual(vasprun.parameters.get('NELECT', 0), 7)
         self.assertEqual(vasprun.structures[-1].charge, 1)
 
+    def test_kpointset_electronvelocities(self):
+        vpath = self.TEST_FILES_DIR / 'vasprun.lvel.Si2H.xml'
+        vasprun = Vasprun(vpath, parse_potcar_file=False)
+        self.assertEqual(vasprun.eigenvalues[Spin.up].shape[0], len(vasprun.actual_kpoints))
 
 class OutcarTest(PymatgenTest):
     _multiprocess_shared_ = True


### PR DESCRIPTION
## Summary
This PR tries to fix the issue of #1513.
When running vasp with the LVEL flag enabled, two kpoint sets are written to the vasprun.xml file.
One quite far up in the file, containing the kpoints in the irreducible Brillouin zone, and one after the self-consistent calculation inside the electronvelocities tag which contains points in the full Brillouin zone.
Here, I only prevent that the kpoint variables read for the first set in Vasprun are overwritten by the second set. 

Also added a test that ensures that the kpoint dimension of the eigenvalues array is equal to the number of kpoints.


Short few sentences, and summary of the major changes in bullet 
points

* Recover default behaviour, when LVEL flag in vasp calculation is set

## For a later PR

A later feature PR should introduce new variables for the second kpoint set in vasprun.xml, as well as for any quantities calculated due to the LVEL flag (if any).