### PR TITLE
Add option to translate molecule to origin in add_adsorbate

### DIFF
--- a/pymatgen/analysis/adsorption.py
+++ b/pymatgen/analysis/adsorption.py
@@ -400,7 +400,7 @@ class AdsorbateSiteFinder:
                                   if s.coords[2] == min([s.coords[2]
                                   for s in molecule.sites])]
             x, y, z = front_atoms.center_of_mass
-            molecule.translate_sites(vector = [-x, -y, -z])
+            molecule.translate_sites(vector=[-x, -y, -z])
         if reorient:    
             # Reorient the molecule along slab m_index
             sop = get_rot(self.slab)

--- a/pymatgen/analysis/adsorption.py
+++ b/pymatgen/analysis/adsorption.py
@@ -386,36 +386,35 @@ class AdsorbateSiteFinder:
             ads_coord (array): coordinate of adsorbate position
             repeat (3-tuple or list): input for making a supercell of slab
                 prior to placing the adsorbate
-            translate (bool): flag on whether to translate the molecule to
-                the origin prior to adding it to the surface
+            translate (bool): flag on whether to translate the molecule so
+                that its CoM is at the origin prior to adding it to the surface
             reorient (bool): flag on whether to reorient the molecule to
                 have its z-axis concurrent with miller index
         """
-        adsorbate = molecule.copy()
+        molecule = molecule.copy()
         if translate:
             # Translate the molecule so that the center of mass of the atoms
             # that have the most negative z coordinate is at (0, 0, 0)
-            front_atoms = adsorbate.copy()
-            front_atoms._sites = [s for s in adsorbate.sites
-                                       if s.coords[2]==min([s.coords[2]
-                                       for s in adsorbate.sites])]
-            [x,y,z]=front_atoms.center_of_mass
-            sop = SymmOp.from_rotation_and_translation(translation_vec=(-x,-y,-z))
-            adsorbate.apply_operation(sop)
+            front_atoms = molecule.copy()
+            front_atoms._sites = [s for s in molecule.sites
+                                  if s.coords[2] == min([s.coords[2]
+                                  for s in molecule.sites])]
+            x, y, z = front_atoms.center_of_mass
+            molecule.translate_sites(vector = [-x, -y, -z])
         if reorient:    
             # Reorient the molecule along slab m_index
             sop = get_rot(self.slab)
-            adsorbate.apply_operation(sop.inverse)
+            molecule.apply_operation(sop.inverse)
         struct = self.slab.copy()
         if repeat:
             struct.make_supercell(repeat)
         if 'surface_properties' in struct.site_properties.keys():
-            adsorbate.add_site_property("surface_properties",
-                                       ["adsorbate"] * adsorbate.num_sites)
+            molecule.add_site_property("surface_properties",
+                                       ["adsorbate"] * molecule.num_sites)
         if 'selective_dynamics' in struct.site_properties.keys():
-            adsorbate.add_site_property("selective_dynamics",
-                                       [[True, True, True]] * adsorbate.num_sites)
-        for site in adsorbate:
+            molecule.add_site_property("selective_dynamics",
+                                       [[True, True, True]] * molecule.num_sites)
+        for site in molecule:
             struct.append(site.specie, ads_coord + site.coords, coords_are_cartesian=True,
                           properties=site.properties)
         return struct

--- a/pymatgen/analysis/adsorption.py
+++ b/pymatgen/analysis/adsorption.py
@@ -373,34 +373,49 @@ class AdsorbateSiteFinder:
             return np.average([site_list[i].frac_coords for i in indices],
                               axis=0)
 
-    def add_adsorbate(self, molecule, ads_coord, repeat=None, reorient=True):
+    def add_adsorbate(self, molecule, ads_coord, repeat=None, translate=True,
+                      reorient=True):
         """
         Adds an adsorbate at a particular coordinate.  Adsorbate
-        represented by a Molecule object, and is positioned relative
-        to the input adsorbate coordinate.
+        represented by a Molecule object and is translated to (0, 0, 0) if 
+        translate is True, or positioned relative to the input adsorbate
+        coordinate if translate is False.
 
         Args:
             molecule (Molecule): molecule object representing the adsorbate
             ads_coord (array): coordinate of adsorbate position
             repeat (3-tuple or list): input for making a supercell of slab
                 prior to placing the adsorbate
+            translate (bool): flag on whether to translate the molecule to
+                the origin prior to adding it to the surface
             reorient (bool): flag on whether to reorient the molecule to
                 have its z-axis concurrent with miller index
         """
-        if reorient:
+        adsorbate = molecule.copy()
+        if translate:
+            # Translate the molecule so that the center of mass of the atoms
+            # that have the most negative z coordinate is at (0, 0, 0)
+            front_atoms = adsorbate.copy()
+            front_atoms._sites = [s for s in adsorbate.sites
+                                       if s.coords[2]==min([s.coords[2]
+                                       for s in adsorbate.sites])]
+            [x,y,z]=front_atoms.center_of_mass
+            sop = SymmOp.from_rotation_and_translation(translation_vec=(-x,-y,-z))
+            adsorbate.apply_operation(sop)
+        if reorient:    
             # Reorient the molecule along slab m_index
             sop = get_rot(self.slab)
-            molecule.apply_operation(sop.inverse)
+            adsorbate.apply_operation(sop.inverse)
         struct = self.slab.copy()
         if repeat:
             struct.make_supercell(repeat)
         if 'surface_properties' in struct.site_properties.keys():
-            molecule.add_site_property("surface_properties",
-                                       ["adsorbate"] * molecule.num_sites)
+            adsorbate.add_site_property("surface_properties",
+                                       ["adsorbate"] * adsorbate.num_sites)
         if 'selective_dynamics' in struct.site_properties.keys():
-            molecule.add_site_property("selective_dynamics",
-                                       [[True, True, True]] * molecule.num_sites)
-        for site in molecule:
+            adsorbate.add_site_property("selective_dynamics",
+                                       [[True, True, True]] * adsorbate.num_sites)
+        for site in adsorbate:
             struct.append(site.specie, ads_coord + site.coords, coords_are_cartesian=True,
                           properties=site.properties)
         return struct
@@ -421,7 +436,7 @@ class AdsorbateSiteFinder:
         return slab.copy(site_properties=new_sp)
 
     def generate_adsorption_structures(self, molecule, repeat=None, min_lw=5.0,
-                                       reorient=True, find_args={}):
+                                       translate=True, reorient=True, find_args={}):
         """
         Function that generates all adsorption structures for a given
         molecular adsorbate.  Can take repeat argument or minimum
@@ -444,12 +459,12 @@ class AdsorbateSiteFinder:
         structs = []
 
         for coords in self.find_adsorption_sites(**find_args)['all']:
-            structs.append(self.add_adsorbate(
-                molecule, coords, repeat=repeat, reorient=reorient))
+            structs.append(self.add_adsorbate(molecule, coords, 
+                repeat=repeat, translate=translate, reorient=reorient))
         return structs
 
     def adsorb_both_surfaces(self, molecule, repeat=None, min_lw=5.0,
-                             reorient=True, find_args={}):
+                             translate=True, reorient=True, find_args={}):
         """
         Function that generates all adsorption structures for a given
         molecular adsorbate on both surfaces of a slab. This is useful
@@ -470,6 +485,7 @@ class AdsorbateSiteFinder:
         # Get the adsorbed surfaces first
         adslabs = self.generate_adsorption_structures(molecule, repeat=repeat,
                                                       min_lw=min_lw,
+                                                      translate=translate,
                                                       reorient=reorient,
                                                       find_args=find_args)
 

--- a/pymatgen/analysis/tests/test_adsorption.py
+++ b/pymatgen/analysis/tests/test_adsorption.py
@@ -95,6 +95,23 @@ class AdsorbateSiteFinderTest(PymatgenTest):
         self.assertEqual(len(structures_hollow), len(sites['hollow']))
         for n, structure in enumerate(structures_hollow):
             self.assertTrue(in_coord_list(sites['hollow'], structure[-2].coords))
+        # Check molecule not changed after run
+        co = Molecule("CO", [[1.0, -0.5, 3], [0.8, 0.46, 3.75]])
+        structures = self.asf_211.generate_adsorption_structures(co)
+        self.assertEqual(co, Molecule("CO", [[1.0, -0.5, 3], [0.8, 0.46, 3.75]]))
+        # Check translation
+        sites = self.asf_211.find_adsorption_sites()
+        ads_site_coords = sites['all'][0]
+        c_site = structures[0].sites[-2]
+        self.assertEqual(str(c_site.specie), 'C')
+        self.assertArrayAlmostEqual(c_site.coords, sites['all'][0])
+        # Check no translation
+        structures = self.asf_111.generate_adsorption_structures(co, translate = False)
+        self.assertEqual(co, Molecule("CO", [[1.0, -0.5, 3], [0.8, 0.46, 3.75]]))
+        sites = self.asf_111.find_adsorption_sites()
+        ads_site_coords = sites['all'][0]
+        c_site = structures[0].sites[-2]
+        self.assertArrayAlmostEqual(c_site.coords, ads_site_coords+np.array([1.0, -0.5, 3]))
 
     def test_adsorb_both_surfaces(self):
 

--- a/pymatgen/analysis/tests/test_adsorption.py
+++ b/pymatgen/analysis/tests/test_adsorption.py
@@ -106,7 +106,7 @@ class AdsorbateSiteFinderTest(PymatgenTest):
         self.assertEqual(str(c_site.specie), 'C')
         self.assertArrayAlmostEqual(c_site.coords, sites['all'][0])
         # Check no translation
-        structures = self.asf_111.generate_adsorption_structures(co, translate = False)
+        structures = self.asf_111.generate_adsorption_structures(co, translate=False)
         self.assertEqual(co, Molecule("CO", [[1.0, -0.5, 3], [0.8, 0.46, 3.75]]))
         sites = self.asf_111.find_adsorption_sites()
         ads_site_coords = sites['all'][0]

--- a/pymatgen/analysis/tests/test_adsorption.py
+++ b/pymatgen/analysis/tests/test_adsorption.py
@@ -95,7 +95,7 @@ class AdsorbateSiteFinderTest(PymatgenTest):
         self.assertEqual(len(structures_hollow), len(sites['hollow']))
         for n, structure in enumerate(structures_hollow):
             self.assertTrue(in_coord_list(sites['hollow'], structure[-2].coords))
-        # Check molecule not changed after run
+        # Check molecule not changed after rotation when added to surface
         co = Molecule("CO", [[1.0, -0.5, 3], [0.8, 0.46, 3.75]])
         structures = self.asf_211.generate_adsorption_structures(co)
         self.assertEqual(co, Molecule("CO", [[1.0, -0.5, 3], [0.8, 0.46, 3.75]]))


### PR DESCRIPTION
## Summary

Updated _add_adsorbate_ to work with a copy of the adsorbate molecule and added the _translate_ keyword - if _True_, the molecule is translated to the origin before being added to the surface.

* Updated _add_adsorbate_ to work with a copy of the molecule passed as an argument. Previously, if _reorient_ was _True_ (it is by default), the molecule would be rotated in place. In the case of consecutive structure generation (such as in the adsorption workflow from atomate), the adsorbate would keep rotating after each structure generation.
* Added the option to translate the molecule to the origin before adding it to the surface. Previously, the position of the adsorbate was fully dependent on the position of the input molecule - which could lead to structures with adsorbates that are positioned too close to surface, or too far from the actual adsorption site. If _translate_ is _True_, the molecule is first translated so that the center of mass of the substructure made up of the atoms that have the most negative z coordinates is placed at the origin (and hence on the adsorption site). This allows for both head-on and side-on adsorbate placement while ensuring that no atoms are placed closer to the surface than the actual adsorption site.
* Added tests for both changes.