### PR TITLE
Fix bug in `pmg potcar` command

### DIFF
--- a/pymatgen/cli/pmg.py
+++ b/pymatgen/cli/pmg.py
@@ -272,7 +272,7 @@ def main():
                        help="List of POTCAR symbols. Use -f to set "
                             "functional. Defaults to PBE.")
     group.add_argument("-r", "--recursive", dest="recursive",
-                       type=str, nargs="+",
+                       type=str,
                        help="Dirname to find and generate from POTCAR.spec.")
     parser_potcar.set_defaults(func=generate_potcar)
 

--- a/pymatgen/cli/pmg_potcar.py
+++ b/pymatgen/cli/pmg_potcar.py
@@ -27,7 +27,7 @@ def gen_potcar(dirname, filename):
 
 def generate_potcar(args):
     if args.recursive:
-        proc_dir(args.spec, gen_potcar)
+        proc_dir(args.recursive, gen_potcar)
     elif args.symbols:
         try:
             p = Potcar(args.symbols, functional=args.functional)


### PR DESCRIPTION
## Summary

Prompted by [user post](https://discuss.materialsproject.org/t/cli-error-occur-using-mpg-potcar-r/2429) to MP's forum.

There is no `spec` arg destination. Fixes this. Also, argparser help text indicates one directory only should be given, and `cli.pmg_potcar.proc_dir` appears to expect only one as well, so removes `nargs="+"` in the arg parsing.

## TODO (if any)

Test? I ran with a mock `POTCAR.spec` file with just the symbol `Ag` in it and got the error
> ValueError: No POTCAR for Ag with functional PBE found

so I think it's getting to the right point in the application logic. I have no interest in writing a proper test for this.