### PR TITLE
Get symmetrically equivalent Miller indices

### DIFF
--- a/pymatgen/core/surface.py
+++ b/pymatgen/core/surface.py
@@ -1542,7 +1542,6 @@ def get_d(slab):
     return slab.lattice.get_cartesian_coords([0, 0, d])[2]
 
 
-
 def get_recp_symmetry_operation(structure, symprec=0.01):
     """
     Find the symmetric operations of the reciprocal lattice,
@@ -1659,45 +1658,6 @@ def get_symmetrically_distinct_miller_indices(structure, max_index):
                 unique_millers_conv.append(miller)
 
     return unique_millers_conv
-
-
-def get_symmetrically_equivalent_miller_indices(structure, miller_index):
-    """
-    Returns all symmetrically equivalent indices for a given structure. Analysis
-    is based on the symmetry of the reciprocal lattice of the structure.
-
-    Args:
-        miller_index (tuple): Designates the family of Miller indices to find.
-    """
-    equivalent_millers = [miller_index]
-    r = list(range(-max(np.abs(miller_index)), max(np.abs(miller_index)) + 1))
-    r.reverse()
-
-    sg = SpacegroupAnalyzer(structure)
-    # Get distinct hkl planes from the rhombohedral setting if trigonal
-    if sg.get_crystal_system() == "trigonal":
-        prim_structure = SpacegroupAnalyzer(structure).get_primitive_standard_structure()
-        symm_ops = get_recp_symmetry_operation(prim_structure)
-    else:
-        symm_ops = get_recp_symmetry_operation(structure)
-
-    for miller in itertools.product(r, r, r):
-
-        if miller[0] == miller_index[0] and \
-                        miller[1] == miller_index[1] and \
-                        miller[2] == miller_index[2]:
-            continue
-
-        if any([i != 0 for i in miller]):
-            d = abs(reduce(gcd, miller))
-            miller = tuple([int(i / d) for i in miller])
-            if in_coord_list(equivalent_millers, miller):
-                # equivalent_millers.append(miller)
-                continue
-            if is_already_analyzed(miller, equivalent_millers, symm_ops):
-                equivalent_millers.append(miller)
-
-    return equivalent_millers
 
 
 def hkl_transformation(transf, miller_index):

--- a/pymatgen/core/surface.py
+++ b/pymatgen/core/surface.py
@@ -1566,6 +1566,13 @@ def get_recp_symmetry_operation(structure, symprec=0.01):
     return recp_symmops
 
 
+def is_already_analyzed(miller_index, miller_list):
+    for op in symm_ops:
+        if in_coord_list(miller_list, op.operate(miller_index)):
+            return True
+    return False
+
+
 def get_symmetrically_distinct_miller_indices(structure, max_index):
     """
     Returns all symmetrically distinct indices below a certain max-index for
@@ -1597,16 +1604,10 @@ def get_symmetrically_distinct_miller_indices(structure, max_index):
 
     unique_millers, unique_millers_conv = [], []
 
-    def is_already_analyzed(miller_index):
-        for op in symm_ops:
-            if in_coord_list(unique_millers, op.operate(miller_index)):
-                return True
-        return False
-
     for i, miller in enumerate(miller_list):
         d = abs(reduce(gcd, miller))
         miller = tuple([int(i / d) for i in miller])
-        if not is_already_analyzed(miller):
+        if not is_already_analyzed(miller, miller_list):
             if sg.get_crystal_system() == "trigonal":
                 # Now we find the distinct primitive hkls using
                 # the primitive symmetry operations and their

--- a/pymatgen/core/surface.py
+++ b/pymatgen/core/surface.py
@@ -1600,6 +1600,7 @@ def get_symmetrically_equivalent_miller_indices(structure, miller_index):
         if any([i != 0 for i in miller]):
             if is_already_analyzed(miller, equivalent_millers, symm_ops):
                 equivalent_millers.append(miller)
+                
             # include larger Miller indices in the family of planes
             if all([mmi > i for i in np.abs(miller)]) and \
                     not in_coord_list(equivalent_millers, miller):

--- a/pymatgen/core/surface.py
+++ b/pymatgen/core/surface.py
@@ -1645,7 +1645,7 @@ def get_symmetrically_distinct_miller_indices(structure, max_index):
     for i, miller in enumerate(miller_list):
         d = abs(reduce(gcd, miller))
         miller = tuple([int(i / d) for i in miller])
-        if not is_already_analyzed(miller, miller_list, symm_ops):
+        if not is_already_analyzed(miller, unique_millers, symm_ops):
             if sg.get_crystal_system() == "trigonal":
                 # Now we find the distinct primitive hkls using
                 # the primitive symmetry operations and their

--- a/pymatgen/core/tests/test_surface.py
+++ b/pymatgen/core/tests/test_surface.py
@@ -629,9 +629,10 @@ class MillerIndexFinderTests(PymatgenTest):
         self.Fe = Structure.from_spacegroup( \
             "Im-3m", Lattice.cubic(2.82), ["Fe"],
             [[0, 0, 0]])
-        self.Mg = Structure.from_spacegroup( \
-            "P6_3/mmc", Lattice.hexagonal(3.2, 5.13), ["Mg", "Mg"],
-            [[0.3333, 0.6667, 0.2500], [0.6667, 0.3333, 0.7500]])
+        mglatt = Lattice.from_parameters(3.2, 3.2, 5.13, 90, 90, 120)
+        self.Mg = Structure(mglatt, ["Mg", "Mg"],
+                            [[1 / 3, 2 / 3, 1 / 4],
+                             [2 / 3, 1 / 3, 3 / 4]])
         self.lifepo4 = self.get_structure("LiFePO4")
         self.tei = Structure.from_file(get_path("icsd_TeI.cif"),
                                        primitive=False)

--- a/pymatgen/core/tests/test_surface.py
+++ b/pymatgen/core/tests/test_surface.py
@@ -11,8 +11,8 @@ import numpy as np
 from pymatgen.core.structure import Structure
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.surface import Slab, SlabGenerator, generate_all_slabs, \
-    get_symmetrically_distinct_miller_indices, ReconstructionGenerator, \
-    miller_index_from_sites, get_d, get_slab_regions
+    get_symmetrically_distinct_miller_indices, get_symmetrically_equivalent_miller_indices, \
+    ReconstructionGenerator, miller_index_from_sites, get_d, get_slab_regions
 from pymatgen.symmetry.groups import SpaceGroup
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.util.testing import PymatgenTest
@@ -629,6 +629,9 @@ class MillerIndexFinderTests(PymatgenTest):
         self.Fe = Structure.from_spacegroup( \
             "Im-3m", Lattice.cubic(2.82), ["Fe"],
             [[0, 0, 0]])
+        self.Mg = Structure.from_spacegroup( \
+            "P6_3/mmc", Lattice.hexagonal(3.2, 5.13), ["Mg", "Mg"],
+            [[0.3333, 0.6667, 0.2500], [0.6667, 0.3333, 0.7500]])
         self.lifepo4 = self.get_structure("LiFePO4")
         self.tei = Structure.from_file(get_path("icsd_TeI.cif"),
                                        primitive=False)
@@ -675,6 +678,20 @@ class MillerIndexFinderTests(PymatgenTest):
         # Now try a trigonal system.
         indices = get_symmetrically_distinct_miller_indices(self.trigBi, 2)
         self.assertEqual(len(indices), 17)
+
+    def test_get_symmetrically_equivalent_miller_indices(self):
+
+        # Tests to see if the function obtains all equivalent hkl for cubic (100)
+        indices001 = [(1, 0, 0), (0, 1, 0), (0, 0, 1), (0, 0, -1), (0, -1, 0), (-1, 0, 0)]
+        indices = get_symmetrically_equivalent_miller_indices(self.cscl, (1,0,0))
+        self.assertTrue(all([hkl in indices for hkl in indices001]))
+
+        # Tests to see if it captures expanded Miller indices in the family e.g. (001) == (002)
+        hcp_indices_100 = get_symmetrically_equivalent_miller_indices(self.Mg, (1,0,0))
+        hcp_indices_200 = get_symmetrically_equivalent_miller_indices(self.Mg, (2,0,0))
+        self.assertEqual(len(hcp_indices_100)*2, len(hcp_indices_200))
+        self.assertEqual(len(hcp_indices_100), 6)
+
 
     def test_generate_all_slabs(self):
 

--- a/pymatgen/ext/matproj.py
+++ b/pymatgen/ext/matproj.py
@@ -20,6 +20,7 @@ from pymatgen import SETTINGS, __version__ as pmg_version
 from pymatgen.core.composition import Composition
 from pymatgen.core.periodic_table import Element
 from pymatgen.core.structure import Structure
+from pymatgen.core.surface import get_symmetrically_equivalent_miller_indices
 
 from pymatgen.entries.computed_entries import ComputedEntry, \
     ComputedStructureEntry
@@ -1183,12 +1184,13 @@ class MPRester:
             req += "?include_structures=true"
 
         if miller_index:
-            abs_miller_index = [abs(i) for i in miller_index]
-            sorted_miller_index = sorted(abs_miller_index, key=int, reverse=True)
             surf_data_dict = self._make_request(req)
             surf_list = surf_data_dict['surfaces']
+            ucell = self.get_structure_by_material_id(material_id,
+                                                      conventional_unit_cell=True)
+            eq_indices = get_symmetrically_equivalent_miller_indices(ucell, miller_index)
             for one_surf in surf_list:
-                if one_surf['miller_index'] == sorted_miller_index:
+                if tuple(one_surf['miller_index']) in eq_indices:
                     return one_surf
         else:
             return self._make_request(req)


### PR DESCRIPTION
## Summary

Added a new function in surface.py called get_symmetrically_equivalent_miller_indices which takes in a structure and Miller index and returns a list for the family of hkl. Useful for searching for Miller index specific entries on MPRester (surface data, GB data, Wsep) as the user does not need to enter the exact same Miller index as the one associated with an entry. Modified get_surface_data using this function to make it easier to obtain work of separation from GB data.

* Feature 1 get_equivalent_miller_indices(structure, miller_index)
* Fix 1: Can now get specific surfaces without needing the exact same Miller index

## TODO (if any):
Some overlap between get_symmetrically_equivalent_miller_indices and get_symmetrically_distinct_miller_indices. 
