### PR TITLE
Moved some functions as a Lattice object method.

### DIFF
--- a/pymatgen/analysis/wulff.py
+++ b/pymatgen/analysis/wulff.py
@@ -19,7 +19,6 @@ Tran, R.; Xu, Z.; Radhakrishnan, B.; Winston, D.; Persson, K. A.; Ong, S. P.
 """
 
 from pymatgen.core.structure import Structure
-from pymatgen.core.surface import get_recp_symmetry_operation
 from pymatgen.util.coord import get_angle
 import numpy as np
 import scipy as sp
@@ -232,7 +231,7 @@ class WulffShape:
         color_ind = self.color_ind
         planes = []
         recp = self.structure.lattice.reciprocal_lattice_crystallographic
-        recp_symmops = get_recp_symmetry_operation(self.structure, self.symprec)
+        recp_symmops = self.structure.get_recp_symmetry_operation(self.symprec)
 
         for i, (hkl, energy) in enumerate(zip(self.hkl_list,
                                               self.e_surf_list)):

--- a/pymatgen/analysis/wulff.py
+++ b/pymatgen/analysis/wulff.py
@@ -231,7 +231,7 @@ class WulffShape:
         color_ind = self.color_ind
         planes = []
         recp = self.structure.lattice.reciprocal_lattice_crystallographic
-        recp_symmops = self.structure.get_recp_symmetry_operation(self.symprec)
+        recp_symmops = self.lattice.get_recp_symmetry_operation(self.symprec)
 
         for i, (hkl, energy) in enumerate(zip(self.hkl_list,
                                               self.e_surf_list)):

--- a/pymatgen/core/lattice.py
+++ b/pymatgen/core/lattice.py
@@ -1297,26 +1297,6 @@ class Lattice(MSONable):
         return recp_symmops
 
 
-def is_already_analyzed(
-        miller_index: tuple, miller_list: list, symm_ops: list)-> bool:
-    """
-    Helper function to check if a given Miller index is
-    part of the family of indices of any index in a list
-
-    Args:
-        miller_index (tuple): The Miller index to analyze
-        miller_list (list): List of Miller indices. If the given
-            Miller index belongs in the same family as any of the
-            indices in this list, return True, else return False
-        symm_ops (list): Symmetry operations of a
-            lattice, used to define family of indices
-    """
-    for op in symm_ops:
-        if in_coord_list(miller_list, op.operate(miller_index)):
-            return True
-    return False
-
-
 def get_integer_index(
     miller_index: bool, round_dp: int = 4, verbose: bool = True
 ) -> Tuple[int, int, int]:

--- a/pymatgen/core/lattice.py
+++ b/pymatgen/core/lattice.py
@@ -19,9 +19,9 @@ from numpy.linalg import inv
 from numpy import pi, dot, transpose, radians
 
 from monty.json import MSONable
-from pymatgen.util.coord import pbc_shortest_vectors
+from pymatgen.util.coord import pbc_shortest_vectors, in_coord_list
 from pymatgen.util.num import abs_cap
-from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
+
 
 """
 This module defines the classes relating to 3D lattices.
@@ -1287,6 +1287,7 @@ class Lattice(MSONable):
         # need a localized import of structure to build a
         # pseudo empty lattice for SpacegroupAnalyzer
         from pymatgen import Structure
+        from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
         recp = Structure(recp_lattice, ["H"], [[0, 0, 0]])
         # Creates a function that uses the symmetry operations in the
         # structure to find Miller indices that might give repetitive slabs
@@ -1297,7 +1298,7 @@ class Lattice(MSONable):
 
 
 def is_already_analyzed(
-        miller_index: tuple, miller_list: list, symm_ops: list)-> Bool:
+        miller_index: tuple, miller_list: list, symm_ops: list)-> bool:
     """
     Helper function to check if a given Miller index is
     part of the family of indices of any index in a list

--- a/pymatgen/core/lattice.py
+++ b/pymatgen/core/lattice.py
@@ -1271,6 +1271,26 @@ class Lattice(MSONable):
         return get_integer_index(u_norm, round_dp=round_dp, verbose=verbose)
 
 
+def is_already_analyzed(
+        miller_index: tuple, miller_list: list, symm_ops: list):
+    """
+    Helper function to check if a given Miller index is
+    part of the family of indices of any index in a list
+
+    Args:
+        miller_index (tuple): The Miller index to analyze
+        miller_list (list): List of Miller indices. If the given
+            Miller index belongs in the same family as any of the
+            indices in this list, return True, else return False
+        symm_ops (list): Symmetry operations of a
+            lattice, used to define family of indices
+    """
+    for op in symm_ops:
+        if in_coord_list(miller_list, op.operate(miller_index)):
+            return True
+    return False
+
+
 def get_integer_index(
     miller_index: bool, round_dp: int = 4, verbose: bool = True
 ) -> Tuple[int, int, int]:

--- a/pymatgen/core/surface.py
+++ b/pymatgen/core/surface.py
@@ -20,7 +20,7 @@ from monty.fractions import lcm
 
 from pymatgen.core.periodic_table import get_el_sp
 from pymatgen.core.structure import Structure
-from pymatgen.core.lattice import Lattice, is_already_analyzed
+from pymatgen.core.lattice import Lattice
 from pymatgen.core.sites import PeriodicSite
 
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer

--- a/pymatgen/core/surface.py
+++ b/pymatgen/core/surface.py
@@ -1566,11 +1566,15 @@ def get_symmetrically_equivalent_miller_indices(structure, miller_index, return_
     is based on the symmetry of the reciprocal lattice of the structure.
 
     Args:
-        miller_index (tuple): Designates the family of Miller indices to find.
+        miller_index (tuple): Designates the family of Miller indices
+            to find. Can be hkl or hkil for hexagonal systems
         return_hkil (bool): If true, return hkil form of Miller
             index for hexagonal systems, otherwise return hkl
     """
 
+    # Change to hkl if hkil because in_coord_list only handles tuples of 3
+    miller_index = (miller_index[0], miller_index[1], miller_index[3]) \
+        if len(miller_index) == 4 else miller_index
     mmi = max(np.abs(miller_index))
     r = list(range(-mmi, mmi + 1))
     r.reverse()
@@ -1598,7 +1602,7 @@ def get_symmetrically_equivalent_miller_indices(structure, miller_index, return_
                                        equivalent_millers, symm_ops):
                     equivalent_millers.append(miller)
 
-    if return_hkil and sg.crystal_system in ["trigonal", "hexagonal"]:
+    if return_hkil and sg.get_crystal_system() in ["trigonal", "hexagonal"]:
         return [(hkl[0], hkl[1], -1*hkl[0]-hkl[1],
                  hkl[2]) for hkl in equivalent_millers]
     return equivalent_millers
@@ -1653,7 +1657,7 @@ def get_symmetrically_distinct_miller_indices(structure, max_index, return_hkil=
                 unique_millers.append(miller)
                 unique_millers_conv.append(miller)
 
-    if return_hkil and sg.crystal_system in ["trigonal", "hexagonal"]:
+    if return_hkil and sg.get_crystal_system() in ["trigonal", "hexagonal"]:
         return [(hkl[0], hkl[1], -1*hkl[0]-hkl[1],
                  hkl[2]) for hkl in unique_millers_conv]
     return unique_millers_conv

--- a/pymatgen/core/surface.py
+++ b/pymatgen/core/surface.py
@@ -1541,14 +1541,34 @@ def get_d(slab):
             break
     return slab.lattice.get_cartesian_coords([0, 0, d])[2]
 
+def is_already_analyzed(
+        miller_index: tuple, miller_list: list, symm_ops: list)-> bool:
+    """
+    Helper function to check if a given Miller index is
+    part of the family of indices of any index in a list
 
-def get_symmetrically_equivalent_miller_indices(structure, miller_index):
+    Args:
+        miller_index (tuple): The Miller index to analyze
+        miller_list (list): List of Miller indices. If the given
+            Miller index belongs in the same family as any of the
+            indices in this list, return True, else return False
+        symm_ops (list): Symmetry operations of a
+            lattice, used to define family of indices
+    """
+    for op in symm_ops:
+        if in_coord_list(miller_list, op.operate(miller_index)):
+            return True
+    return False
+
+def get_symmetrically_equivalent_miller_indices(structure, miller_index, return_hkil=True):
     """
     Returns all symmetrically equivalent indices for a given structure. Analysis
     is based on the symmetry of the reciprocal lattice of the structure.
 
     Args:
         miller_index (tuple): Designates the family of Miller indices to find.
+        return_hkil (bool): If true, return hkil form of Miller
+            index for hexagonal systems, otherwise return hkl
     """
 
     mmi = max(np.abs(miller_index))
@@ -1578,10 +1598,13 @@ def get_symmetrically_equivalent_miller_indices(structure, miller_index):
                                        equivalent_millers, symm_ops):
                     equivalent_millers.append(miller)
 
+    if return_hkil and sg.crystal_system in ["trigonal", "hexagonal"]:
+        return [(hkl[0], hkl[1], -1*hkl[0]-hkl[1],
+                 hkl[2]) for hkl in equivalent_millers]
     return equivalent_millers
 
 
-def get_symmetrically_distinct_miller_indices(structure, max_index):
+def get_symmetrically_distinct_miller_indices(structure, max_index, return_hkil=False):
     """
     Returns all symmetrically distinct indices below a certain max-index for
     a given structure. Analysis is based on the symmetry of the reciprocal
@@ -1591,6 +1614,8 @@ def get_symmetrically_distinct_miller_indices(structure, max_index):
         max_index (int): The maximum index. For example, a max_index of 1
             means that (100), (110), and (111) are returned for the cubic
             structure. All other indices are equivalent to one of these.
+        return_hkil (bool): If true, return hkil form of Miller
+            index for hexagonal systems, otherwise return hkl
     """
 
     r = list(range(-max_index, max_index + 1))
@@ -1628,6 +1653,9 @@ def get_symmetrically_distinct_miller_indices(structure, max_index):
                 unique_millers.append(miller)
                 unique_millers_conv.append(miller)
 
+    if return_hkil and sg.crystal_system in ["trigonal", "hexagonal"]:
+        return [(hkl[0], hkl[1], -1*hkl[0]-hkl[1],
+                 hkl[2]) for hkl in unique_millers_conv]
     return unique_millers_conv
 
 

--- a/pymatgen/core/surface.py
+++ b/pymatgen/core/surface.py
@@ -20,7 +20,7 @@ from monty.fractions import lcm
 
 from pymatgen.core.periodic_table import get_el_sp
 from pymatgen.core.structure import Structure
-from pymatgen.core.lattice import Lattice
+from pymatgen.core.lattice import Lattice, is_already_analyzed
 from pymatgen.core.sites import PeriodicSite
 
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
@@ -1563,13 +1563,6 @@ def get_recp_symmetry_operation(structure, symprec=0.01):
     recp_symmops = analyzer.get_symmetry_operations()
 
     return recp_symmops
-
-
-def is_already_analyzed(miller_index, miller_list, symm_ops):
-    for op in symm_ops:
-        if in_coord_list(miller_list, op.operate(miller_index)):
-            return True
-    return False
 
 
 def get_symmetrically_equivalent_miller_indices(structure, miller_index):

--- a/pymatgen/core/tests/test_surface.py
+++ b/pymatgen/core/tests/test_surface.py
@@ -677,8 +677,9 @@ class MillerIndexFinderTests(PymatgenTest):
         self.assertEqual(len(indices), 12)
 
         # Now try a trigonal system.
-        indices = get_symmetrically_distinct_miller_indices(self.trigBi, 2)
+        indices = get_symmetrically_distinct_miller_indices(self.trigBi, 2, return_hkil=True)
         self.assertEqual(len(indices), 17)
+        self.assertTrue(all([len(hkl) == 4 for hkl in indices]))
 
     def test_get_symmetrically_equivalent_miller_indices(self):
 
@@ -692,7 +693,7 @@ class MillerIndexFinderTests(PymatgenTest):
         hcp_indices_200 = get_symmetrically_equivalent_miller_indices(self.Mg, (2,0,0))
         self.assertEqual(len(hcp_indices_100)*2, len(hcp_indices_200))
         self.assertEqual(len(hcp_indices_100), 6)
-
+        self.assertTrue(all([len(hkl) == 4 for hkl in hcp_indices_100]))
 
     def test_generate_all_slabs(self):
 

--- a/pymatgen/ext/tests/test_matproj.py
+++ b/pymatgen/ext/tests/test_matproj.py
@@ -383,6 +383,11 @@ class MPResterTest(PymatgenTest):
         self.assertAlmostEqual(mo_s3_112[0]['gb_energy'], 0.47965, places=2)
         self.assertAlmostEqual(mo_s3_112[0]['work_of_separation'], 6.318144, places=2)
         self.assertIn("Mo24", gb_f.formula)
+        hcp_s7 = self.rester.get_gb_data(material_id='mp-87', gb_plane=[0, 0, 0, 1],
+                                         include_work_of_separation=True)
+        self.assertAlmostEqual(hcp_s7[0]['gb_energy'], 1.12, places=2)
+        self.assertAlmostEqual(hcp_s7[0]['work_of_separation'], 2.46, places=2)
+
 
     def test_get_interface_reactions(self):
         kinks = self.rester.get_interface_reactions("LiCoO2", "Li3PS4")


### PR DESCRIPTION
## Summary

Added unit testing for querying work of separation. Also moved get_recp_symmetry_operation function as a Lattice method. 

## TODO (if any)

* I would prefer to have get_recp_symmetry_operation as a Lattice method since its more related to lattices and not just surfaces, however at the moment it requires a local import of Structure and SpacegroupAnalyzer to work which may be unwieldy?

* I want to make get_symmetrically_equivalent_miller_indices and get_symmetrically_distinct_miller_indices as a Lattice method as well, however there is the issue of getting Miller indices for trigonal systems which at the moment requires searching through the rhombohedral basis instead of the hexagonal basis to identify all the Miller indices. This is an issue because a lattice object won't know to look at a rhombohedral setting when given a hexagonal setting when looking for Miller indices. Will need to think of a more elegant way to refactor all these Miller index operations.