### PR TITLE
Add return_all_molecules option to BabelMolAdaptor

### DIFF
--- a/pymatgen/io/babel.py
+++ b/pymatgen/io/babel.py
@@ -145,7 +145,7 @@ class BabelMolAdaptor:
 
         Args:
             idx1: The atom index of one of the atoms participating the in bond
-            idx2: The atom index of the other atom participating in the bond 
+            idx2: The atom index of the other atom participating in the bond
         """
         for obbond in ob.OBMolBondIter(self._obmol):
             if (obbond.GetBeginAtomIdx() == idx1 and obbond.GetEndAtomIdx() == idx2) or (obbond.GetBeginAtomIdx() == idx2 and obbond.GetEndAtomIdx() == idx1):
@@ -300,19 +300,25 @@ class BabelMolAdaptor:
         return mol.write(file_format, filename, overwrite=True)
 
     @staticmethod
-    def from_file(filename, file_format="xyz"):
+    def from_file(filename, file_format="xyz", return_all_molecules=False):
         """
         Uses OpenBabel to read a molecule from a file in all supported formats.
 
         Args:
             filename: Filename of input file
             file_format: String specifying any OpenBabel supported formats.
+            return_all_molecules: If ``True``, will return a list of
+                ``BabelMolAdaptor`` instances, one for each molecule found in
+                the file. If ``False``, will return only the first molecule.
 
         Returns:
-            BabelMolAdaptor object
+            BabelMolAdaptor object or list thereof
         """
-        mols = list(pb.readfile(str(file_format), str(filename)))
-        return BabelMolAdaptor(mols[0].OBMol)
+        mols = pb.readfile(str(file_format), str(filename))
+        if return_all_molecules:
+            return [ BabelMolAdaptor(mol.OBMol) for mol in mols ]
+        else:
+            return BabelMolAdaptor(next(mols).OBMol)
 
     @staticmethod
     def from_molecule_graph(mol):

--- a/pymatgen/io/tests/test_babel.py
+++ b/pymatgen/io/tests/test_babel.py
@@ -26,7 +26,7 @@ from pymatgen.analysis.graphs import MoleculeGraph
 from pymatgen.io.babel import BabelMolAdaptor
 
 test_dir = os.path.join(os.path.dirname(__file__), "..", "..", "..",
-                        "test_files", "molecules")
+                        "test_files")
 
 try:
     import openbabel as ob
@@ -61,9 +61,15 @@ class BabelMolAdaptorTest(unittest.TestCase):
 
     def test_from_file(self):
         adaptor = BabelMolAdaptor.from_file(
-            os.path.join(test_dir, "Ethane_e.pdb"), "pdb")
+            os.path.join(test_dir, "molecules/Ethane_e.pdb"), "pdb")
         mol = adaptor.pymatgen_mol
         self.assertEqual(mol.formula, "H6 C2")
+
+    def test_from_file_return_all_molecules(self):
+        adaptors = BabelMolAdaptor.from_file(
+            os.path.join(test_dir, "multiple_frame_xyz.xyz"), "xyz",
+            return_all_molecules=True)
+        self.assertEqual(len(adaptors), 302)
 
     def test_from_molecule_graph(self):
         graph = MoleculeGraph.with_empty_graph(self.mol)


### PR DESCRIPTION
## Summary

As suggested in https://github.com/materialsproject/pymatgen/issues/1512#issuecomment-506859409, this PR adds a ``return_all_molecules`` option to ``BabelMolAdaptor``, which, when set to ``True``, will return one instance of the adaptor for each molecule found in a file. The previous behavior was to always return just the first molecule found and discard the rest, which this PR leaves as the default behavior for backwards-compatibility.

Fixes #1512.