### PR TITLE
Bond valence sum unordered function fix

### DIFF
--- a/pymatgen/analysis/bond_valence.py
+++ b/pymatgen/analysis/bond_valence.py
@@ -57,14 +57,12 @@ def calculate_bv_sum(site, nn_list, scale_factor=1.0):
     Calculates the BV sum of a site.
 
     Args:
-        site:
-            The site
-        nn_list:
-            List of nearest neighbors in the format [(nn_site, dist), ...].
-        scale_factor:
-            A scale factor to be applied. This is useful for scaling distance,
-            esp in the case of calculation-relaxed structures which may tend
-            to under (GGA) or over bind (LDA).
+        site (PeriodicSite): The central site to calculate the bond valence
+        nn_list ([Neighbor]): A list of namedtuple Neighbors having "distance"
+            and "site" attributes
+        scale_factor (float): A scale factor to be applied. This is useful for
+            scaling distance, esp in the case of calculation-relaxed structures
+            which may tend to under (GGA) or over bind (LDA).
     """
     el1 = Element(site.specie.symbol)
     bvsum = 0
@@ -87,14 +85,12 @@ def calculate_bv_sum_unordered(site, nn_list, scale_factor=1):
     Calculates the BV sum of a site for unordered structures.
 
     Args:
-        site:
-            The site
-        nn_list:
-            List of nearest neighbors in the format [(nn_site, dist), ...].
-        scale_factor:
-            A scale factor to be applied. This is useful for scaling distance,
-            esp in the case of calculation-relaxed structures which may tend
-            to under (GGA) or over bind (LDA).
+        site (PeriodicSite): The central site to calculate the bond valence
+        nn_list ([Neighbor]): A list of namedtuple Neighbors having "distance"
+            and "site" attributes
+        scale_factor (float): A scale factor to be applied. This is useful for
+            scaling distance, esp in the case of calculation-relaxed structures
+            which may tend to under (GGA) or over bind (LDA).
     """
     # If the site "site" has N partial occupations as : f_{site}_0,
     # f_{site}_1, ... f_{site}_N of elements

--- a/pymatgen/analysis/bond_valence.py
+++ b/pymatgen/analysis/bond_valence.py
@@ -107,8 +107,8 @@ def calculate_bv_sum_unordered(site, nn_list, scale_factor=1):
     bvsum = 0
     for specie1, occu1 in site.species.items():
         el1 = Element(specie1.symbol)
-        for (nn, dist) in nn_list:
-            for specie2, occu2 in nn.species.items():
+        for nn in nn_list:
+            for specie2, occu2 in nn.site.species.items():
                 el2 = Element(specie2.symbol)
                 if (el1 in ELECTRONEG or el2 in ELECTRONEG) and el1 != el2:
                     r1 = BV_PARAMS[el1]["r"]
@@ -117,7 +117,7 @@ def calculate_bv_sum_unordered(site, nn_list, scale_factor=1):
                     c2 = BV_PARAMS[el2]["c"]
                     R = r1 + r2 - r1 * r2 * (sqrt(c1) - sqrt(c2)) ** 2 / \
                         (c1 * r1 + c2 * r2)
-                    vij = exp((R - dist * scale_factor) / 0.31)
+                    vij = exp((R - nn.distance * scale_factor) / 0.31)
                     bvsum += occu1 * occu2 * vij * (1 if el1.X < el2.X else -1)
     return bvsum
 

--- a/pymatgen/analysis/tests/test_bond_valence.py
+++ b/pymatgen/analysis/tests/test_bond_valence.py
@@ -72,14 +72,14 @@ class BondValenceSumTest(PymatgenTest):
         s = Structure.from_file(os.path.join(test_dir, "LiMn2O4.json"))
         neighbors = s.get_neighbors(s[0], 3.0)
         bv_sum = calculate_bv_sum(s[0], neighbors)
-        self.assertAlmostEqual(bv_sum, 0.7723402182087497)
+        self.assertAlmostEqual(bv_sum, 0.7723402182087497, places=5)
 
     def test_calculate_bv_sum_unordered(self):
         s = Structure.from_file(os.path.join(test_dir, "LiMn2O4.json"))
         s[0].species = Composition("Li0.5Na0.5")
         neighbors = s.get_neighbors(s[0], 3.0)
         bv_sum = calculate_bv_sum_unordered(s[0], neighbors)
-        self.assertAlmostEqual(bv_sum, 1.5494662306918852)
+        self.assertAlmostEqual(bv_sum, 1.5494662306918852, places=5)
 
 if __name__ == "__main__":
     #import sys;sys.argv = ['', 'Test.testName']

--- a/pymatgen/analysis/tests/test_bond_valence.py
+++ b/pymatgen/analysis/tests/test_bond_valence.py
@@ -81,6 +81,7 @@ class BondValenceSumTest(PymatgenTest):
         bv_sum = calculate_bv_sum_unordered(s[0], neighbors)
         self.assertAlmostEqual(bv_sum, 1.5494662306918852, places=5)
 
+
 if __name__ == "__main__":
     #import sys;sys.argv = ['', 'Test.testName']
     unittest.main()

--- a/pymatgen/analysis/tests/test_bond_valence.py
+++ b/pymatgen/analysis/tests/test_bond_valence.py
@@ -21,9 +21,11 @@ __date__ = "Oct 24, 2012"
 import unittest
 import os
 
+from pymatgen.core.composition import Composition
 from pymatgen.core.structure import Structure
 from pymatgen.core.periodic_table import Specie
-from pymatgen.analysis.bond_valence import BVAnalyzer
+from pymatgen.analysis.bond_valence import BVAnalyzer, calculate_bv_sum, \
+    calculate_bv_sum_unordered
 from pymatgen.util.testing import PymatgenTest
 
 test_dir = os.path.join(os.path.dirname(__file__), "..", "..", "..",
@@ -62,6 +64,22 @@ class BVAnalyzerTest(PymatgenTest):
         news = self.analyzer.get_oxi_state_decorated_structure(s)
         self.assertIn(Specie("Mn", 3), news.composition.elements)
         self.assertIn(Specie("Mn", 4), news.composition.elements)
+
+
+class BondValenceSumTest(PymatgenTest):
+
+    def test_calculate_bv_sum(self):
+        s = Structure.from_file(os.path.join(test_dir, "LiMn2O4.json"))
+        neighbors = s.get_neighbors(s[0], 3.0)
+        bv_sum = calculate_bv_sum(s[0], neighbors)
+        self.assertAlmostEqual(bv_sum, 0.7723402182087497)
+
+    def test_calculate_bv_sum_unordered(self):
+        s = Structure.from_file(os.path.join(test_dir, "LiMn2O4.json"))
+        s[0].species = Composition("Li0.5Na0.5")
+        neighbors = s.get_neighbors(s[0], 3.0)
+        bv_sum = calculate_bv_sum_unordered(s[0], neighbors)
+        self.assertAlmostEqual(bv_sum, 1.5494662306918852)
 
 if __name__ == "__main__":
     #import sys;sys.argv = ['', 'Test.testName']


### PR DESCRIPTION
## Summary

New Structure `get_neighbors` returns namedtuples which breaks usage of `calculate_bv_sum_unordered`. It appears `calculate_bv_sum` was fixed previously though.

* Fix `test_calculate_bv_sum_unordered`
* Add tests for both bv_sum functions (previously missing, hence why this bug existed)
* Cleaned up the docstrings for these two functions to match the implementation


## TODO:
There is probably a way to combine these into one function for a little less boilerplate, but that's maybe something for a future PR. This is just a minimum changes necessary fix. 