### PR TITLE
Fix multi-line :param: and :return: directives in docstrings

### DIFF
--- a/pymatgen/analysis/chemenv/coordination_environments/chemenv_strategies.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/chemenv_strategies.py
@@ -158,7 +158,7 @@ class AbstractChemenvStrategy(MSONable, metaclass=abc.ABCMeta):
         """
         Abstract constructor for the all chemenv strategies.
         :param structure_environments: StructureEnvironments object containing all the information on the
-        coordination of the sites in a structure
+            coordination of the sites in a structure
         """
         self.structure_environments = None
         if structure_environments is not None:
@@ -239,9 +239,9 @@ class AbstractChemenvStrategy(MSONable, metaclass=abc.ABCMeta):
         Applies the strategy to the structure_environments object in order to get the neighbors of a given site.
         :param site: Site for which the neighbors are looked for
         :param structure_environments: StructureEnvironments object containing all the information needed to get the
-        neighbors of the site
+            neighbors of the site
         :return: The list of neighbors of the site. For complex strategies, where one allows multiple solutions, this
-        can return a list of list of neighbors
+            can return a list of list of neighbors
         """
         raise NotImplementedError()
 
@@ -260,7 +260,7 @@ class AbstractChemenvStrategy(MSONable, metaclass=abc.ABCMeta):
         a given site.
         :param site: Site for which the coordination environment is looked for
         :return: The coordination environment of the site. For complex strategies, where one allows multiple
-        solutions, this can return a list of coordination environments for the site
+            solutions, this can return a list of coordination environments for the site
         """
         raise NotImplementedError()
 
@@ -271,7 +271,7 @@ class AbstractChemenvStrategy(MSONable, metaclass=abc.ABCMeta):
         a given site.
         :param site: Site for which the coordination environment is looked for
         :return: The coordination environment of the site. For complex strategies, where one allows multiple
-        solutions, this can return a list of coordination environments for the site
+            solutions, this can return a list of coordination environments for the site
         """
         raise NotImplementedError()
 
@@ -284,7 +284,7 @@ class AbstractChemenvStrategy(MSONable, metaclass=abc.ABCMeta):
         a given site.
         :param site: Site for which the coordination environment is looked for
         :return: The coordination environment of the site. For complex strategies, where one allows multiple
-        solutions, this can return a list of coordination environments for the site
+            solutions, this can return a list of coordination environments for the site
         """
         raise NotImplementedError()
 
@@ -610,7 +610,7 @@ class SimpleAbundanceChemenvStrategy(AbstractChemenvStrategy):
         """
         Constructor for the SimpleAbundanceChemenvStrategy.
         :param structure_environments: StructureEnvironments object containing all the information on the
-        coordination of the sites in a structure
+            coordination of the sites in a structure
         """
         raise NotImplementedError('SimpleAbundanceChemenvStrategy not yet implemented')
         AbstractChemenvStrategy.__init__(self, structure_environments, symmetry_measure_type=symmetry_measure_type)
@@ -1606,7 +1606,7 @@ class WeightedNbSetChemenvStrategy(AbstractChemenvStrategy):
         """
         Constructor for the WeightedNbSetChemenvStrategy.
         :param structure_environments: StructureEnvironments object containing all the information on the
-        coordination of the sites in a structure
+            coordination of the sites in a structure
         """
         AbstractChemenvStrategy.__init__(self, structure_environments, symmetry_measure_type=symmetry_measure_type)
         self._additional_condition = additional_condition
@@ -1828,7 +1828,7 @@ class MultiWeightsChemenvStrategy(WeightedNbSetChemenvStrategy):
         """
         Constructor for the MultiWeightsChemenvStrategy.
         :param structure_environments: StructureEnvironments object containing all the information on the
-        coordination of the sites in a structure
+            coordination of the sites in a structure
         """
         self._additional_condition = additional_condition
         self.dist_ang_area_weight = dist_ang_area_weight

--- a/pymatgen/analysis/chemenv/coordination_environments/coordination_geometries.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/coordination_geometries.py
@@ -103,21 +103,21 @@ class SeparationPlane(AbstractChemenvAlgorithm):
             Initializes a separation plane for a given perfect coordination geometry
 
             :param mirror_plane: True if the separation plane is a mirror plane, in which case there is a correspondence
-            of the points in each point_group (can reduce the number of permutations)
+                of the points in each point_group (can reduce the number of permutations)
             :param ordered_plane : True if the order of the points in the plane can be taken into account to reduce the
-            number of permutations
+                number of permutations
             :param plane_points: Indices of the points that are in the plane in the perfect structure (and should be
-            found in the defective one as well)
+                found in the defective one as well)
             :param point_groups: The two groups of points separated by the plane
             :param plane_type: can be "MIRROR", if the plane is a mirror plane going through the central site,
-             'BASAL_THROUGH_CENTER', if the plane is a basal plane (no point on the "left" side) going through the central
-             site, 'BASAL', if the is a basal plane not going through the central site, 'UNEQUILIBRATED_THROUGH_CENTER', if
-             the plane cuts the geometry in two groups of points with different numbers of points on each side, and is going
-             through the centre, 'UNEQUILIBRATED', if the plane cuts the geometry in two groups of points with different
-             numbers of points on each side, and is not going through the centre, 'EQUILIBRATED_THROUGH_CENTER', if the
-             plane cuts the geometry in two groups of points of the same size, is going through the centre but is not a
-             mirror plane, 'EQUILIBRATED', if the plane cuts the geometry in two groups of points of the same size, is not
-             going through the centre but is not a mirror plane.
+                'BASAL_THROUGH_CENTER', if the plane is a basal plane (no point on the "left" side) going through the central
+                site, 'BASAL', if the is a basal plane not going through the central site, 'UNEQUILIBRATED_THROUGH_CENTER', if
+                the plane cuts the geometry in two groups of points with different numbers of points on each side, and is going
+                through the centre, 'UNEQUILIBRATED', if the plane cuts the geometry in two groups of points with different
+                numbers of points on each side, and is not going through the centre, 'EQUILIBRATED_THROUGH_CENTER', if the
+                plane cuts the geometry in two groups of points of the same size, is going through the centre but is not a
+                mirror plane, 'EQUILIBRATED', if the plane cuts the geometry in two groups of points of the same size, is not
+                going through the centre but is not a mirror plane.
             """
         super().__init__(algorithm_type=SEPARATION_PLANE)
         self.mirror_plane = mirror_plane
@@ -426,12 +426,12 @@ class CoordinationGeometry:
         :param points: The list of the coordinates of all the points of this coordination geometry.
         :param separation_planes: List of separation facets to help set up the permutations
         :param permutation_safe_override: Computes all the permutations if set to True (overrides the plane separation
-        algorithms or any other algorithm, for testing purposes)
+            algorithms or any other algorithm, for testing purposes)
         :param plane_ordering_override: Computes all the permutations of the plane separation algorithm if set to False
-        otherwise, uses the anticlockwise ordering of the separation facets (for testing purposes)
+            otherwise, uses the anticlockwise ordering of the separation facets (for testing purposes)
         :param deactivate: deactivates this coordination geometry in the search
         :param faces : list of the faces with their vertices given in a clockwise or anticlockwise order, for drawing
-        purposes
+            purposes
         :param : list of edges, for drawing purposes
         """
         self._mp_symbol = mp_symbol

--- a/pymatgen/analysis/chemenv/coordination_environments/coordination_geometry_finder.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/coordination_geometry_finder.py
@@ -79,7 +79,7 @@ class AbstractGeometry:
         :param bare_coords: Coordinates of the neighbors of the central site
         :param centering_type: How to center the abstract geometry
         :param include_central_site_in_centroid: When the centering is on the centroid, the central site is included
-         if this parameter is set to True.
+            if this parameter is set to True.
         :raise: ValueError if the parameters are not consistent
         """
         bcoords = np.array(bare_coords)
@@ -234,8 +234,8 @@ def symmetry_measure(points_distorted, points_perfect):
     Computes the continuous symmetry measure of the (distorted) set of points "points_distorted" with respect to the
     (perfect) set of points "points_perfect".
     :param points_distorted: List of points describing a given (distorted) polyhedron for which the symmetry measure
-                             has to be computed with respect to the model polyhedron described by the list of points
-                             "points_perfect".
+        has to be computed with respect to the model polyhedron described by the list of points
+        "points_perfect".
     :param points_perfect: List of "perfect" points describing a given model polyhedron.
     :return: The continuous symmetry measure of the distorted polyhedron with respect to the perfect polyhedron
     """
@@ -262,7 +262,7 @@ def find_rotation(points_distorted, points_perfect):
     This finds the rotation matrix that aligns the (distorted) set of points "points_distorted" with respect to the
     (perfect) set of points "points_perfect" in a least-square sense.
     :param points_distorted: List of points describing a given (distorted) polyhedron for which the rotation that
-                             aligns these points in a least-square sense to the set of perfect points "points_perfect"
+        aligns these points in a least-square sense to the set of perfect points "points_perfect"
     :param points_perfect: List of "perfect" points describing a given model polyhedron.
     :return: The rotation matrix
     """
@@ -315,7 +315,7 @@ class LocalGeometryFinder:
         """
         Constructor for the LocalGeometryFinder, initializes the list of coordination geometries
         :param permutations_safe_override: If set to True, all permutations are tested (very time-consuming for large
-        coordination numbers!)
+            coordination numbers!)
         :param plane_ordering_override: If set to False, the ordering of the points in the plane is disabled
         """
         self.allcg = AllCoordinationGeometries(
@@ -342,14 +342,13 @@ class LocalGeometryFinder:
         atom for coordination numbers 1, 2, 3 and 4 and the centroid for coordination numbers > 4.
         :param centering_type: Type of the reference point (centering) 'standard', 'centroid' or 'central_site'
         :param include_central_site_in_centroid: In case centering_type is 'centroid', the central site is included if
-                                                 this value is set to True.
+            this value is set to True.
         :param bva_distance_scale_factor: Scaling factor for the bond valence analyzer (this might be different whether
-                                          the structure is an experimental one, an LDA or a GGA relaxed one, or any
-                                          other relaxation scheme (where under- or over-estimation of bond lengths
-                                          is known).
+            the structure is an experimental one, an LDA or a GGA relaxed one, or any other relaxation scheme (where 
+            under- or over-estimation of bond lengths is known).
         :param structure_refinement: Refinement of the structure. Can be "none", "refined" or "symmetrized".
         :param spg_analyzer_options: Options for the SpaceGroupAnalyzer (dictionary specifying "symprec"
-                                     and "angle_tolerance". See pymatgen's SpaceGroupAnalyzer for more information.
+            and "angle_tolerance". See pymatgen's SpaceGroupAnalyzer for more information.
         """
         self.centering_type = centering_type
         self.include_central_site_in_centroid = include_central_site_in_centroid
@@ -377,7 +376,6 @@ class LocalGeometryFinder:
         Sets up the structure for which the coordination geometries have to be identified. The structure is analyzed
         with the space group analyzer and a refined structure is used
         :param structure: A pymatgen Structure
-        :param
         """
         self.initial_structure = structure.copy()
         if self.structure_refinement == self.STRUCTURE_REFINEMENT_NONE:
@@ -480,29 +478,29 @@ class LocalGeometryFinder:
         :param only_cations: If set to True, will only compute environments for cations
         :param only_indices: If not set to None, will only compute environments the atoms of the given indices
         :param maximum_distance_factor: If not set to None, neighbors beyond
-                                        maximum_distance_factor*closest_neighbor_distance are not considered
+            maximum_distance_factor*closest_neighbor_distance are not considered
         :param minimum_angle_factor: If not set to None, neighbors for which the angle is lower than
-                                     minimum_angle_factor*largest_angle_neighbor are not considered
+            minimum_angle_factor*largest_angle_neighbor are not considered
         :param max_cn: maximum coordination number to be considered
         :param min_cn: minimum coordination number to be considered
         :param only_symbols: if not set to None, consider only coordination environments with the given symbols
         :param valences: valences of the atoms
         :param additional_conditions: additional conditions to be considered in the bonds (example : only bonds
-                                      between cation and anion
+            between cation and anion
         :param info: additional info about the calculation
         :param timelimit: time limit (in secs) after which the calculation of the StructureEnvironments object stops
         :param initial_structure_environments: initial StructureEnvironments object (most probably incomplete)
         :param get_from_hints: whether to add neighbors sets from "hints" (e.g. capped environment => test the
-                               neighbors without the cap)
+            neighbors without the cap)
         :param voronoi_normalized_distance_tolerance: tolerance for the normalized distance used to distinguish
-                                                      neighbors sets
+            neighbors sets
         :param voronoi_normalized_angle_tolerance: tolerance for the normalized angle used to distinguish
-                                                   neighbors sets
+            neighbors sets
         :param recompute: whether to recompute the sites already computed (when initial_structure_environments
-                          is not None)
+            is not None)
         :param optimization: optimization algorithm
         :return: The StructureEnvironments object containing all the information about the coordination
-        environments in the structure
+            environments in the structure
         """
         time_init = time.clock()
         if info is None:

--- a/pymatgen/analysis/chemenv/coordination_environments/structure_environments.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/structure_environments.py
@@ -340,7 +340,7 @@ class StructureEnvironments(MSONable):
         :param sites_map: Mapping of equivalent sites to the unequivalent sites that have been computed.
         :param equivalent_sites: List of list of equivalent sites of the structure
         :param struct_sites_to_irreducible_site_list_map: Maps the index of a site to the index of the item in the
-        list of equivalent sites to which the site belongs.
+            list of equivalent sites to which the site belongs.
         :param ce_list: List of chemical environments
         :param structure: Structure object
         """
@@ -495,9 +495,9 @@ class StructureEnvironments(MSONable):
         :param plot_type: How to plot the coordinations
         :param title: Title for the figure
         :param max_dist: Maximum distance to be plotted when the plotting of the distance is set to 'initial_normalized'
-                         or 'initial_real' (Warning: this is not the same meaning in both cases! In the first case,
-                         the closest atom lies at a "normalized" distance of 1.0 so that 2.0 means refers to this
-                         normalized distance while in the second case, the real distance is used)
+            or 'initial_real' (Warning: this is not the same meaning in both cases! In the first case, the closest atom 
+            lies at a "normalized" distance of 1.0 so that 2.0 means refers to this normalized distance while in the 
+            second case, the real distance is used)
         :param figsize: Size of the figure to be plotted
         :return: Nothing returned, just plot the figure
         """
@@ -650,9 +650,9 @@ class StructureEnvironments(MSONable):
         :param plot_type: How to plot the coordinations
         :param title: Title for the figure
         :param max_dist: Maximum distance to be plotted when the plotting of the distance is set to 'initial_normalized'
-                         or 'initial_real' (Warning: this is not the same meaning in both cases! In the first case,
-                         the closest atom lies at a "normalized" distance of 1.0 so that 2.0 means refers to this
-                         normalized distance while in the second case, the real distance is used)
+            or 'initial_real' (Warning: this is not the same meaning in both cases! In the first case, the closest atom 
+            lies at a "normalized" distance of 1.0 so that 2.0 means refers to this normalized distance while in the 
+            second case, the real distance is used)
         :param figsize: Size of the figure to be plotted
         :return: The figure object to be plotted or saved to file
         """
@@ -791,9 +791,9 @@ class StructureEnvironments(MSONable):
         :param plot_type: How to plot the coordinations
         :param title: Title for the figure
         :param max_dist: Maximum distance to be plotted when the plotting of the distance is set to 'initial_normalized'
-                         or 'initial_real' (Warning: this is not the same meaning in both cases! In the first case,
-                         the closest atom lies at a "normalized" distance of 1.0 so that 2.0 means refers to this
-                         normalized distance while in the second case, the real distance is used)
+            or 'initial_real' (Warning: this is not the same meaning in both cases! In the first case, the closest atom 
+            lies at a "normalized" distance of 1.0 so that 2.0 means refers to this normalized distance while in the 
+            second case, the real distance is used)
         :param figsize: Size of the figure to be plotted
         :return: Nothing returned, just plot the figure
         """

--- a/pymatgen/analysis/chemenv/coordination_environments/voronoi.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/voronoi.py
@@ -37,7 +37,7 @@ def from_bson_voronoi_list(bson_nb_voro_list, structure):
     :param vlist: List of voronoi objects
     :param bson_nb_voro_list: List of periodic sites involved in the Voronoi
     :return: The voronoi_list needed for the VoronoiContainer (with PeriodicSites as keys of the dictionary - not
-    allowed in the BSON format)
+        allowed in the BSON format)
     """
     voronoi_list = [None] * len(bson_nb_voro_list)
     for isite, voro in enumerate(bson_nb_voro_list):
@@ -58,7 +58,7 @@ def from_bson_voronoi_list2(bson_nb_voro_list2, structure):
     :param vlist: List of voronoi objects
     :param bson_nb_voro_list: List of periodic sites involved in the Voronoi
     :return: The voronoi_list needed for the VoronoiContainer (with PeriodicSites as keys of the dictionary - not
-    allowed in the BSON format)
+        allowed in the BSON format)
     """
     voronoi_list = [None] * len(bson_nb_voro_list2)
     for isite, voro in enumerate(bson_nb_voro_list2):

--- a/pymatgen/analysis/chemenv/utils/coordination_geometry_utils.py
+++ b/pymatgen/analysis/chemenv/utils/coordination_geometry_utils.py
@@ -666,9 +666,9 @@ class Plane:
         is considered to lie on the plane or not (distance to the plane)
         :param points: list of points
         :param dist_tolerance: tolerance to which a point is considered to lie on the plane
-        or not (distance to the plane)
+            or not (distance to the plane)
         :return: The lists of indices of the points on one side of the plane, on the plane and
-        on the other side of the plane
+            on the other side of the plane
         """
         side1 = list()
         inplane = list()
@@ -697,7 +697,7 @@ class Plane:
         normal of the plane while negative distances are on the other side
         :param points: Points for which distances are computed
         :return: Distances from the plane to the points (positive values on the side of the normal to the plane,
-                 negative values on the other side)
+            negative values on the other side)
         """
         return [np.dot(self.normal_vector, pp) + self.d for pp in points]
 
@@ -709,9 +709,8 @@ class Plane:
         :param points: Points for which distances are computed
         :param sign: Whether to add sign information in the indices sorting the points distances
         :return: Distances from the plane to the points (positive values on the side of the normal to the plane,
-                 negative values on the other side), as well as indices of the points from closest to furthest. For
-                 the latter, when the sign parameter is True, items of the sorting list are given as tuples of
-                 (index, sign).
+            negative values on the other side), as well as indices of the points from closest to furthest. For the 
+            latter, when the sign parameter is True, items of the sorting list are given as tuples of (index, sign).
         """
         distances = [np.dot(self.normal_vector, pp) + self.d for pp in points]
         indices = sorted(range(len(distances)), key=lambda k: np.abs(distances[k]))
@@ -729,12 +728,12 @@ class Plane:
         :param points: Points for which distances are computed
         :param delta: Distance interval for which two points are considered in the same group.
         :param delta_factor: If delta is None, the distance interval is taken as delta_factor times the maximal
-                             point distance.
-                             :param sign: Whether to add sign information in the indices sorting the points distances
+            point distance.
+        :param sign: Whether to add sign information in the indices sorting the points distances
         :return: Distances from the plane to the points (positive values on the side of the normal to the plane,
-                 negative values on the other side), as well as indices of the points from closest to furthest and
-                 grouped indices of distances separated by less than delta. For the sorting list and the grouped
-                 indices, when the sign parameter is True, items are given as tuples of (index, sign).
+            negative values on the other side), as well as indices of the points from closest to furthest and
+            grouped indices of distances separated by less than delta. For the sorting list and the grouped
+            indices, when the sign parameter is True, items are given as tuples of (index, sign).
         """
         distances, indices = self.distances_indices_sorted(points=points)
         if delta is None:

--- a/pymatgen/analysis/diffraction/neutron.py
+++ b/pymatgen/analysis/diffraction/neutron.py
@@ -37,6 +37,7 @@ class NDCalculator(AbstractDiffractionPatternCalculator):
     This code is a slight modification of XRDCalculator in
     pymatgen.analysis.diffraction.xrd. See it for details of the algorithm.
     Main changes by using neutron instead of X-ray are as follows:
+    
     1. Atomic scattering length is a constant.
     2. Polarization correction term of Lorentz factor is unnecessary.
 

--- a/pymatgen/analysis/graphs.py
+++ b/pymatgen/analysis/graphs.py
@@ -74,7 +74,7 @@ class StructureGraph(MSONable):
         :param structure: a Structure object
 
         :param graph_data: dict containing graph information in
-        dict format (not intended to be constructed manually,
+            dict format (not intended to be constructed manually,
         see as_dict method for format)
         """
 
@@ -112,9 +112,9 @@ class StructureGraph(MSONable):
         :param structure (Structure):
         :param name (str): name of graph, e.g. "bonds"
         :param edge_weight_name (str): name of edge weights,
-        e.g. "bond_length" or "exchange_constant"
+            e.g. "bond_length" or "exchange_constant"
         :param edge_weight_units (str): name of edge weight units
-        e.g. "Å" or "eV"
+            e.g. "Å" or "eV"
         :return (StructureGraph):
         """
 
@@ -144,10 +144,10 @@ class StructureGraph(MSONable):
 
         :param molecule: Molecule object
         :param edges: dict representing the bonds of the functional
-                group (format: {(from_index, to_index, from_image, to_image): props},
-                where props is a dictionary of properties, including weight.
-                Props should be None if no additional properties are to be
-                specified.
+            group (format: {(from_index, to_index, from_image, to_image): props},
+            where props is a dictionary of properties, including weight.
+            Props should be None if no additional properties are to be
+            specified.
         :return: sg, a StructureGraph
         """
 
@@ -201,7 +201,7 @@ class StructureGraph(MSONable):
         :param strategy: an instance of a
             :Class: `pymatgen.analysis.local_env.NearNeighbors` object
         :param weights: if True, use weights from local_env class
-        (consult relevant class for their meaning)
+            (consult relevant class for their meaning)
         :return:
         """
 
@@ -261,14 +261,14 @@ class StructureGraph(MSONable):
         :param from_index: index of site connecting from
         :param to_index: index of site connecting to
         :param from_jimage (tuple of ints): lattice vector of periodic
-        image, e.g. (1, 0, 0) for periodic image in +x direction
+            image, e.g. (1, 0, 0) for periodic image in +x direction
         :param to_jimage (tuple of ints): lattice vector of image
         :param weight (float): e.g. bond length
         :param warn_duplicates (bool): if True, will warn if
-        trying to add duplicate edges (duplicate edges will not
-        be added in either case)
+            trying to add duplicate edges (duplicate edges will not
+            be added in either case)
         :param edge_properties (dict): any other information to
-        store on graph edges, similar to Structure's site_properties
+            store on graph edges, similar to Structure's site_properties
         :return:
         """
 
@@ -360,7 +360,7 @@ class StructureGraph(MSONable):
         :param species: Species for the new site
         :param coords: 3x1 array representing coordinates of the new site
         :param coords_are_cartesian: Whether coordinates are cartesian.
-                Defaults to False.
+            Defaults to False.
         :param validate_proximity: For Molecule.insert(); if True (default
             False), distance will be checked to ensure that site can be safely
             added.
@@ -431,13 +431,13 @@ class StructureGraph(MSONable):
         :param to_index: int
         :param to_jimage: tuple
         :param new_weight: alter_edge does not require
-        that weight be altered. As such, by default, this
-        is None. If weight is to be changed, it should be a
-        float.
+            that weight be altered. As such, by default, this
+            is None. If weight is to be changed, it should be a
+            float.
         :param new_edge_properties: alter_edge does not require
-        that edge_properties be altered. As such, by default,
-        this is None. If any edge properties are to be changed,
-        it should be a dictionary of edge properties to be changed.
+            that edge_properties be altered. As such, by default,
+            this is None. If any edge properties are to be changed,
+            it should be a dictionary of edge properties to be changed.
         :return:
         """
 
@@ -472,8 +472,8 @@ class StructureGraph(MSONable):
         :param to_index: int
         :param to_jimage: tuple
         :param allow_reverse: If allow_reverse is True, then break_edge will
-        attempt to break both (from_index, to_index) and, failing that,
-        will attempt to break (to_index, from_index).
+            attempt to break both (from_index, to_index) and, failing that,
+            will attempt to break (to_index, from_index).
         :return:
         """
 
@@ -540,28 +540,28 @@ class StructureGraph(MSONable):
         :param index: Index of atom to substitute.
         :param func_grp: Substituent molecule. There are two options:
 
-                1. Providing an actual Molecule as the input. The first atom
-                   must be a DummySpecie X, indicating the position of
-                   nearest neighbor. The second atom must be the next
-                   nearest atom. For example, for a methyl group
-                   substitution, func_grp should be X-CH3, where X is the
-                   first site and C is the second site. What the code will
-                   do is to remove the index site, and connect the nearest
-                   neighbor to the C atom in CH3. The X-C bond indicates the
-                   directionality to connect the atoms.
-                2. A string name. The molecule will be obtained from the
-                   relevant template in func_groups.json.
+            1. Providing an actual Molecule as the input. The first atom
+                must be a DummySpecie X, indicating the position of
+                nearest neighbor. The second atom must be the next
+                nearest atom. For example, for a methyl group
+                substitution, func_grp should be X-CH3, where X is the
+                first site and C is the second site. What the code will
+                do is to remove the index site, and connect the nearest
+                neighbor to the C atom in CH3. The X-C bond indicates the
+                directionality to connect the atoms.
+            2. A string name. The molecule will be obtained from the
+                relevant template in func_groups.json.
         :param strategy: Class from pymatgen.analysis.local_env.
         :param bond_order: A specified bond order to calculate the bond
-                length between the attached functional group and the nearest
-                neighbor site. Defaults to 1.
+            length between the attached functional group and the nearest
+            neighbor site. Defaults to 1.
         :param graph_dict: Dictionary representing the bonds of the functional
-                group (format: {(u, v): props}, where props is a dictionary of
-                properties, including weight. If None, then the algorithm
-                will attempt to automatically determine bonds using one of
-                a list of strategies defined in pymatgen.analysis.local_env.
+            group (format: {(u, v): props}, where props is a dictionary of
+            properties, including weight. If None, then the algorithm
+            will attempt to automatically determine bonds using one of
+            a list of strategies defined in pymatgen.analysis.local_env.
         :param strategy_params: dictionary of keyword arguments for strategy.
-                If None, default parameters will be used.
+            If None, default parameters will be used.
         :return:
         """
 
@@ -636,7 +636,7 @@ class StructureGraph(MSONable):
         :param n: index of Site in Structure
         :param jimage: lattice vector of site
         :return: list of ConnectedSite tuples,
-        sorted by closest first
+            sorted by closest first
         """
 
         connected_sites = set()
@@ -716,30 +716,30 @@ class StructureGraph(MSONable):
         graphs.
 
         :param filename: filename to output, will detect filetype
-        from extension (any graphviz filetype supported, such as
-        pdf or png)
+            from extension (any graphviz filetype supported, such as
+            pdf or png)
         :param diff (StructureGraph): an additional graph to
-        compare with, will color edges red that do not exist in diff
-        and edges green that are in diff graph but not in the
-        reference graph
+            compare with, will color edges red that do not exist in diff
+            and edges green that are in diff graph but not in the
+            reference graph
         :param hide_unconnected_nodes: if True, hide unconnected
-        nodes
+            nodes
         :param hide_image_edges: if True, do not draw edges that
-        go through periodic boundaries
+            go through periodic boundaries
         :param edge_colors (bool): if True, use node colors to
-        color edges
+            color edges
         :param node_labels (bool): if True, label nodes with
-        species and site index
+            species and site index
         :param weight_labels (bool): if True, label edges with
-        weights
+            weights
         :param image_labels (bool): if True, label edges with
-        their periodic images (usually only used for debugging,
-        edges to periodic images always appear as dashed lines)
+            their periodic images (usually only used for debugging,
+            edges to periodic images always appear as dashed lines)
         :param color_scheme (str): "VESTA" or "JMOL"
         :param keep_dot (bool): keep GraphViz .dot file for later
-        visualization
+            visualization
         :param algo: any graphviz algo, "neato" (for simple graphs)
-        or "fdp" (for more crowded graphs) usually give good outputs
+            or "fdp" (for more crowded graphs) usually give good outputs
         :return:
         """
 
@@ -868,9 +868,9 @@ class StructureGraph(MSONable):
         of edges in the graph.
 
         :return: A dictionary with keys specifying the
-        species involved in a connection in alphabetical order
-        (e.g. string 'Fe-O') and values which are a list of
-        weights for those connections (e.g. bond lengths).
+            species involved in a connection in alphabetical order
+            (e.g. string 'Fe-O') and values which are a list of
+            weights for those connections (e.g. bond lengths).
         """
         def get_label(u, v):
             u_label = self.structure[u].species_string
@@ -891,7 +891,7 @@ class StructureGraph(MSONable):
         the graph.
 
         :return: A dict with an 'all_weights' list, 'minimum',
-        'maximum', 'median', 'mean', 'std_dev'
+            'maximum', 'median', 'mean', 'std_dev'
         """
 
         all_weights = [d.get('weight', None) for u, v, d
@@ -912,9 +912,9 @@ class StructureGraph(MSONable):
         present in the graph.
 
         :param anonymous: if anonymous, will replace specie names
-        with A, B, C, etc.
+            with A, B, C, etc.
         :return: a list of co-ordination environments,
-        e.g. ['Mo-S(6)', 'S-Mo(3)']
+            e.g. ['Mo-S(6)', 'S-Mo(3)']
         """
 
         motifs = set()
@@ -1321,9 +1321,9 @@ class StructureGraph(MSONable):
 
         :param other: StructureGraph
         :param strict: if False, will compare bonds
-        from different Structures, with node indices
-        replaced by Specie strings, will not count
-        number of occurrences of bonds
+            from different Structures, with node indices
+            replaced by Specie strings, will not count
+            number of occurrences of bonds
         :return:
         """
 
@@ -1378,11 +1378,11 @@ class StructureGraph(MSONable):
         isomorphic subgraph).
 
         :param use_weights (bool): If True, only treat subgraphs
-        as isomorphic if edges have the same weights. Typically,
-        this means molecules will need to have the same bond
-        lengths to be defined as duplicates, otherwise bond
-        lengths can differ. This is a fairly robust approach,
-        but will treat e.g. enantiomers as being duplicates.
+            as isomorphic if edges have the same weights. Typically,
+            this means molecules will need to have the same bond
+            lengths to be defined as duplicates, otherwise bond
+            lengths can differ. This is a fairly robust approach,
+            but will treat e.g. enantiomers as being duplicates.
 
         :return: list of unique Molecules in Structure
         """
@@ -1487,8 +1487,8 @@ class MoleculeGraph(MSONable):
         :param molecule: Molecule object
 
         :param graph_data: dict containing graph information in
-        dict format (not intended to be constructed manually,
-        see as_dict method for format)
+            dict format (not intended to be constructed manually,
+            see as_dict method for format)
         """
 
         if isinstance(molecule, MoleculeGraph):
@@ -1527,9 +1527,9 @@ class MoleculeGraph(MSONable):
         :param molecule (Molecule):
         :param name (str): name of graph, e.g. "bonds"
         :param edge_weight_name (str): name of edge weights,
-        e.g. "bond_length" or "exchange_constant"
+            e.g. "bond_length" or "exchange_constant"
         :param edge_weight_units (str): name of edge weight units
-        e.g. "Å" or "eV"
+            e.g. "Å" or "eV"
         :return (MoleculeGraph):
         """
 
@@ -1559,9 +1559,9 @@ class MoleculeGraph(MSONable):
 
         :param molecule: Molecule object
         :param edges: dict representing the bonds of the functional
-                group (format: {(u, v): props}, where props is a dictionary of
-                properties, including weight. Props should be None if no
-                additional properties are to be specified.
+            group (format: {(u, v): props}, where props is a dictionary of
+            properties, including weight. Props should be None if no
+            additional properties are to be specified.
         :return: mg, a MoleculeGraph
         """
 
@@ -1710,10 +1710,10 @@ class MoleculeGraph(MSONable):
         :param to_index: index of site connecting to
         :param weight (float): e.g. bond length
         :param warn_duplicates (bool): if True, will warn if
-        trying to add duplicate edges (duplicate edges will not
-        be added in either case)
+            trying to add duplicate edges (duplicate edges will not
+            be added in either case)
         :param edge_properties (dict): any other information to
-        store on graph edges, similar to Structure's site_properties
+            store on graph edges, similar to Structure's site_properties
         :return:
         """
 
@@ -1822,13 +1822,13 @@ class MoleculeGraph(MSONable):
         :param from_index: int
         :param to_index: int
         :param new_weight: alter_edge does not require
-        that weight be altered. As such, by default, this
-        is None. If weight is to be changed, it should be a
-        float.
+            that weight be altered. As such, by default, this
+            is None. If weight is to be changed, it should be a
+            float.
         :param new_edge_properties: alter_edge does not require
-        that edge_properties be altered. As such, by default,
-        this is None. If any edge properties are to be changed,
-        it should be a dictionary of edge properties to be changed.
+            that edge_properties be altered. As such, by default,
+            this is None. If any edge properties are to be changed,
+            it should be a dictionary of edge properties to be changed.
         :return:
         """
 
@@ -1856,8 +1856,8 @@ class MoleculeGraph(MSONable):
         :param from_index: int
         :param to_index: int
         :param allow_reverse: If allow_reverse is True, then break_edge will
-        attempt to break both (from_index, to_index) and, failing that,
-        will attempt to break (to_index, from_index).
+            attempt to break both (from_index, to_index) and, failing that,
+            will attempt to break (to_index, from_index).
         :return:
         """
 
@@ -1922,13 +1922,13 @@ class MoleculeGraph(MSONable):
         returns two or more new MoleculeGraph objects.
 
         :param bonds: list of tuples (from_index, to_index)
-        representing bonds to be broken to split the MoleculeGraph.
+            representing bonds to be broken to split the MoleculeGraph.
         :param alterations: a dict {(from_index, to_index): alt},
-        where alt is a dictionary including weight and/or edge
-        properties to be changed following the split.
+            where alt is a dictionary including weight and/or edge
+            properties to be changed following the split.
         :param allow_reverse: If allow_reverse is True, then break_edge will
-        attempt to break both (from_index, to_index) and, failing that,
-        will attempt to break (to_index, from_index).
+            attempt to break both (from_index, to_index) and, failing that,
+            will attempt to break (to_index, from_index).
         :return: list of MoleculeGraphs
         """
 
@@ -2078,18 +2078,18 @@ class MoleculeGraph(MSONable):
         :param index: Index of atom to substitute.
         :param func_grp: Substituent molecule. There are three options:
 
-                1. Providing an actual molecule as the input. The first atom
-                   must be a DummySpecie X, indicating the position of
-                   nearest neighbor. The second atom must be the next
-                   nearest atom. For example, for a methyl group
-                   substitution, func_grp should be X-CH3, where X is the
-                   first site and C is the second site. What the code will
-                   do is to remove the index site, and connect the nearest
-                   neighbor to the C atom in CH3. The X-C bond indicates the
-                   directionality to connect the atoms.
-                2. A string name. The molecule will be obtained from the
-                   relevant template in func_groups.json.
-                3. A MoleculeGraph object.
+            1. Providing an actual molecule as the input. The first atom
+                must be a DummySpecie X, indicating the position of
+                nearest neighbor. The second atom must be the next
+                nearest atom. For example, for a methyl group
+                substitution, func_grp should be X-CH3, where X is the
+                first site and C is the second site. What the code will
+                do is to remove the index site, and connect the nearest
+                neighbor to the C atom in CH3. The X-C bond indicates the
+                directionality to connect the atoms.
+            2. A string name. The molecule will be obtained from the
+                relevant template in func_groups.json.
+            3. A MoleculeGraph object.
         :param strategy: Class from pymatgen.analysis.local_env.
         :param bond_order: A specified bond order to calculate the bond
                 length between the attached functional group and the nearest
@@ -2199,35 +2199,35 @@ class MoleculeGraph(MSONable):
 
         :param index: Index of atom to substitute.
         :param func_grp: Substituent molecule. There are three options:
-
-                1. Providing an actual molecule as the input. The first atom
-                   must be a DummySpecie X, indicating the position of
-                   nearest neighbor. The second atom must be the next
-                   nearest atom. For example, for a methyl group
-                   substitution, func_grp should be X-CH3, where X is the
-                   first site and C is the second site. What the code will
-                   do is to remove the index site, and connect the nearest
-                   neighbor to the C atom in CH3. The X-C bond indicates the
-                   directionality to connect the atoms.
-                2. A string name. The molecule will be obtained from the
-                   relevant template in func_groups.json.
-                3. A MoleculeGraph object.
+        
+            1. Providing an actual molecule as the input. The first atom
+               must be a DummySpecie X, indicating the position of
+               nearest neighbor. The second atom must be the next
+               nearest atom. For example, for a methyl group
+               substitution, func_grp should be X-CH3, where X is the
+               first site and C is the second site. What the code will
+               do is to remove the index site, and connect the nearest
+               neighbor to the C atom in CH3. The X-C bond indicates the
+               directionality to connect the atoms.
+            2. A string name. The molecule will be obtained from the
+               relevant template in func_groups.json.
+            3. A MoleculeGraph object.
         :param strategy: Class from pymatgen.analysis.local_env.
         :param bond_order: A specified bond order to calculate the bond
-                length between the attached functional group and the nearest
-                neighbor site. Defaults to 1.
+            length between the attached functional group and the nearest
+            neighbor site. Defaults to 1.
         :param graph_dict: Dictionary representing the bonds of the functional
-                group (format: {(u, v): props}, where props is a dictionary of
-                properties, including weight. If None, then the algorithm
-                will attempt to automatically determine bonds using one of
-                a list of strategies defined in pymatgen.analysis.local_env.
+            group (format: {(u, v): props}, where props is a dictionary of
+            properties, including weight. If None, then the algorithm
+            will attempt to automatically determine bonds using one of
+            a list of strategies defined in pymatgen.analysis.local_env.
         :param strategy_params: dictionary of keyword arguments for strategy.
-                If None, default parameters will be used.
+            If None, default parameters will be used.
         :param reorder: bool, representing if graph nodes need to be reordered
-                following the application of the local_env strategy
+            following the application of the local_env strategy
         :param extend_structure: If True (default), then a large artificial box
-                will be placed around the Molecule, because some strategies assume
-                periodic boundary conditions.
+            will be placed around the Molecule, because some strategies assume
+            periodic boundary conditions.
         :return:
         """
 
@@ -2274,14 +2274,14 @@ class MoleculeGraph(MSONable):
         Find ring structures in the MoleculeGraph.
 
         :param including: list of site indices. If
-        including is not None, then find_rings will
-        only return those rings including the specified
-        sites. By default, this parameter is None, and
-        all rings will be returned.
+            including is not None, then find_rings will
+            only return those rings including the specified
+            sites. By default, this parameter is None, and
+            all rings will be returned.
         :return: dict {index:cycle}. Each
-        entry will be a ring (cycle, in graph theory terms) including the index
-        found in the Molecule. If there is no cycle including an index, the
-        value will be an empty list.
+            entry will be a ring (cycle, in graph theory terms) including the index
+            found in the Molecule. If there is no cycle including an index, the
+            value will be an empty list.
         """
 
         # Copies self.graph such that all edges (u, v) matched by edges (v, u)
@@ -2329,7 +2329,7 @@ class MoleculeGraph(MSONable):
         :param n: index of Site in Molecule
         :param jimage: lattice vector of site
         :return: list of ConnectedSite tuples,
-        sorted by closest first
+            sorted by closest first
         """
 
         connected_sites = set()
@@ -2403,30 +2403,30 @@ class MoleculeGraph(MSONable):
         graphs.
 
         :param filename: filename to output, will detect filetype
-        from extension (any graphviz filetype supported, such as
-        pdf or png)
+            from extension (any graphviz filetype supported, such as
+            pdf or png)
         :param diff (StructureGraph): an additional graph to
-        compare with, will color edges red that do not exist in diff
-        and edges green that are in diff graph but not in the
-        reference graph
+            compare with, will color edges red that do not exist in diff
+            and edges green that are in diff graph but not in the
+            reference graph
         :param hide_unconnected_nodes: if True, hide unconnected
-        nodes
+            nodes
         :param hide_image_edges: if True, do not draw edges that
-        go through periodic boundaries
+            go through periodic boundaries
         :param edge_colors (bool): if True, use node colors to
-        color edges
+            color edges
         :param node_labels (bool): if True, label nodes with
-        species and site index
+            species and site index
         :param weight_labels (bool): if True, label edges with
-        weights
+            weights
         :param image_labels (bool): if True, label edges with
-        their periodic images (usually only used for debugging,
-        edges to periodic images always appear as dashed lines)
+            their periodic images (usually only used for debugging,
+            edges to periodic images always appear as dashed lines)
         :param color_scheme (str): "VESTA" or "JMOL"
         :param keep_dot (bool): keep GraphViz .dot file for later
-        visualization
+            visualization
         :param algo: any graphviz algo, "neato" (for simple graphs)
-        or "fdp" (for more crowded graphs) usually give good outputs
+            or "fdp" (for more crowded graphs) usually give good outputs
         :return:
         """
 
@@ -2733,9 +2733,9 @@ class MoleculeGraph(MSONable):
 
         :param other: MoleculeGraph
         :param strict: if False, will compare bonds
-        from different Molecules, with node indices
-        replaced by Specie strings, will not count
-        number of occurrences of bonds
+            from different Molecules, with node indices
+            replaced by Specie strings, will not count
+            number of occurrences of bonds
         :return:
         """
 

--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -1189,7 +1189,7 @@ class OpenBabelNN(NearNeighbors):
         :param molecule: input Molecule.
         :param n: index of site for which to determine near neighbors.
         :return: [dict] representing a neighboring site and the type of
-        bond present between site n and the neighboring site.
+            bond present between site n and the neighboring site.
         """
 
         from pymatgen.io.babel import BabelMolAdaptor
@@ -1324,7 +1324,7 @@ class CovalentBondNN(NearNeighbors):
         :param structure: input Molecule.
         :param n: index of site for which to determine near neighbors.
         :return: [dict] representing a neighboring site and the type of
-        bond present between site n and the neighboring site.
+            bond present between site n and the neighboring site.
         """
 
         # This is unfortunately inefficient, but is the best way to fit the

--- a/pymatgen/analysis/magnetism/analyzer.py
+++ b/pymatgen/analysis/magnetism/analyzer.py
@@ -120,22 +120,22 @@ class CollinearMagneticStructureAnalyzer:
         :param structure: Structure object
         :param overwrite_magmom_mode (str): default "none"
         :param round_magmoms (int or bool): will round input magmoms to
-        specified number of decimal places if integer is supplied, if set
-        to a float will try and group magmoms together using a kernel density
-        estimator of provided width, and extracting peaks of the estimator
+            specified number of decimal places if integer is supplied, if set
+            to a float will try and group magmoms together using a kernel density
+            estimator of provided width, and extracting peaks of the estimator
         :param detect_valences (bool): if True, will attempt to assign valences
-        to input structure
+            to input structure
         :param make_primitive (bool): if True, will transform to primitive
-        magnetic cell
+            magnetic cell
         :param default_magmoms (dict): (optional) dict specifying default magmoms
         :param set_net_positive (bool): if True, will change sign of magnetic
-        moments such that the net magnetization is positive. Argument will be
-        ignored if mode "respect_sign" is used.
+            moments such that the net magnetization is positive. Argument will be
+            ignored if mode "respect_sign" is used.
         :param threshold (float): number (in Bohr magnetons) below which magmoms
-        will be rounded to zero,
+            will be rounded to zero,
         :param threshold_nonmag (float): number (in Bohr magneton) 
-        below which nonmagnetic ions (with no magmom specified 
-        in default_magmoms) will be rounded to zero
+            below which nonmagnetic ions (with no magmom specified 
+            in default_magmoms) will be rounded to zero
         """
 
         if default_magmoms:
@@ -402,7 +402,7 @@ class CollinearMagneticStructureAnalyzer:
         """
         Returns a Structure without magnetic moments defined.
         :param make_primitive (bool): Return a primitive
-        structure, defaults to True.
+            structure, defaults to True.
         :return: Structure
         """
 
@@ -419,7 +419,7 @@ class CollinearMagneticStructureAnalyzer:
         Returns a Structure with all magnetic moments positive
         or zero.
         :param make_primitive (bool): Return a primitive
-        structure, defaults to True.
+            structure, defaults to True.
         :return: Structure
         """
 
@@ -504,7 +504,7 @@ class CollinearMagneticStructureAnalyzer:
         :param symprec (float): same as in SpacegroupAnalyzer
         :param angle_tolerance (float): same as in SpacegroupAnalyzer
         :return (int): Number of symmetrically-distinct magnetic sites present
-        in structure.
+            in structure.
         """
 
         structure = self.get_nonmagnetic_structure()

--- a/pymatgen/analysis/magnetism/jahnteller.py
+++ b/pymatgen/analysis/magnetism/jahnteller.py
@@ -77,14 +77,14 @@ class JahnTellerAnalyzer:
 
         :param structure: input structure
         :param calculate_valences (bool): whether to attempt to calculate valences or not, structure
-        should have oxidation states to perform analysis
+            should have oxidation states to perform analysis
         :param guesstimate_spin (bool): whether to guesstimate spin state from magnetic moments
-        or not, use with caution
+            or not, use with caution
         :param op_threshold (float): threshold for order parameter above which to consider site
-        to match an octahedral or tetrahedral motif, since Jahn-Teller structures can often be
-        quite distorted, this threshold is smaller than one might expect
+            to match an octahedral or tetrahedral motif, since Jahn-Teller structures can often be
+            quite distorted, this threshold is smaller than one might expect
         :return (dict): analysis of structure, with key 'strength' which may be 'none', 'strong',
-        'weak', or 'unknown'
+            'weak', or 'unknown'
         """
 
         structure = structure.get_primitive_structure()
@@ -289,7 +289,7 @@ class JahnTellerAnalyzer:
         * in tetrahedral environments always weaker
         :param motif (str): "oct" or "tet"
         :param spin_config (dict): dict of 'e' (e_g) and 't' (t2_g)
-        with number of electrons in each state
+            with number of electrons in each state
         """
         magnitude = "none"
         if motif == "oct":

--- a/pymatgen/command_line/critic2_caller.py
+++ b/pymatgen/command_line/critic2_caller.py
@@ -116,13 +116,13 @@ class Critic2Caller:
 
         :param structure: Structure to analyze
         :param chgcar: Charge density to use for analysis. If None, will
-        use promolecular density.
+            use promolecular density.
         :param chgcar_ref: Reference charge density. If None, will use
-        chgcar as reference.
+            chgcar as reference.
         :param user_input_settings (dict):
         :param write_cml (bool): Useful for debug, if True will write all
-        critical points to a file 'table.cml' in the working directory
-        useful for visualization
+            critical points to a file 'table.cml' in the working directory
+            useful for visualization
         """
 
         settings = {'CPEPS': 0.1, 'SEED': ["WS", "PAIR DIST 10"]}
@@ -198,15 +198,19 @@ class Critic2Caller:
         Convenience method to run critic2 analysis on a folder containing
         typical VASP output files.
         This method will:
+
         1. Look for files CHGCAR, AECAR0, AECAR2, POTCAR or their gzipped
         counterparts.
+
         2. If AECCAR* files are present, constructs a temporary reference
-        file as AECCAR0 + AECCAR2
+        file as AECCAR0 + AECCAR2.
+        
         3. Runs critic2 analysis twice: once for charge, and a second time
         for the charge difference (magnetization density).
+
         :param path: path to folder to search in
         :param suffix: specific suffix to look for (e.g. '.relax1' for
-        'CHGCAR.relax1.gz')
+            'CHGCAR.relax1.gz')
         :return:
         """
 
@@ -331,7 +335,7 @@ class Critic2Output(MSONable):
 
         :param structure: associated Structure
         :param critic2_stdout: stdout from running critic2 in automatic
-        mode
+            mode
         """
 
         self.structure = structure
@@ -349,8 +353,8 @@ class Critic2Output(MSONable):
         in the crystal. Lazily constructed.
 
         :param edge_weight: a value to store on the Graph edges,
-        by default this is "bond_length" but other supported
-        values are any of the attributes of CriticalPoint
+            by default this is "bond_length" but other supported
+            values are any of the attributes of CriticalPoint
         :return:
         """
 
@@ -532,7 +536,7 @@ class Critic2Output(MSONable):
 
         :param idx: unique index
         :param unique_idx: index of unique CriticalPoint,
-        used to look up more information of point (field etc.)
+            used to look up more information of point (field etc.)
         :param frac_coord: fractional co-ordinates of point
         :return:
         """
@@ -555,10 +559,10 @@ class Critic2Output(MSONable):
         :param idx: index of node
         :param from_idx: from index of node
         :param from_lvec: vector of lattice image the from node is in
-        as tuple of ints
+            as tuple of ints
         :param to_idx: to index of node
         :param to_lvec:  vector of lattice image the to node is in as
-        tuple of ints
+            tuple of ints
         :return:
         """
         self.edges[idx] = {'from_idx': from_idx, 'from_lvec': from_lvec,

--- a/pymatgen/core/surface.py
+++ b/pymatgen/core/surface.py
@@ -1886,17 +1886,21 @@ def center_slab(slab):
         find the surface sites and apply operations like doping.
 
     There are three cases where the slab in not centered:
+
     1. The slab region is completely between two vacuums in the
-        box but not necessarily centered. We simply shift the
-        slab by the difference in its center of mass and 0.5
-        along the c direction.
+    box but not necessarily centered. We simply shift the
+    slab by the difference in its center of mass and 0.5
+    along the c direction.
+
     2. The slab completely spills outside the box from the bottom
-        and into the top. This makes it incredibly difficult to
-        locate surface sites. We iterate through all sites that
-        spill over (z>c) and shift all sites such that this specific
-        site is now on the other side. Repeat for all sites with z>c.
+    and into the top. This makes it incredibly difficult to
+    locate surface sites. We iterate through all sites that
+    spill over (z>c) and shift all sites such that this specific
+    site is now on the other side. Repeat for all sites with z>c.
+
     3. This is a simpler case of scenario 2. Either the top or bottom
-        slab sites are at c=0 or c=1. Treat as scenario 2.
+    slab sites are at c=0 or c=1. Treat as scenario 2.
+    
     Args:
         slab (Slab): Slab structure to center
     Returns:

--- a/pymatgen/electronic_structure/core.py
+++ b/pymatgen/electronic_structure/core.py
@@ -141,7 +141,7 @@ class Magmom(MSONable):
         """
         :param moment: magnetic moment, supplied as float or list/np.ndarray
         :param saxis: spin axis, supplied as list/np.ndarray, parameter will
-        be converted to unit vector (default is [0, 0, 1])
+            be converted to unit vector (default is [0, 0, 1])
         :return: Magmom object
         """
         # to init from another Magmom instance

--- a/pymatgen/io/babel.py
+++ b/pymatgen/io/babel.py
@@ -202,6 +202,7 @@ class BabelMolAdaptor:
         """
         A combined method to first generate 3D structures from 0D or 2D
         structures and then find the minimum energy conformer:
+        
         1. Use OBBuilder to create a 3D structure using rules and ring templates
         2. Do 250 steps of a steepest descent geometry optimization with the
            MMFF94 forcefield

--- a/pymatgen/io/nwchem.py
+++ b/pymatgen/io/nwchem.py
@@ -24,6 +24,7 @@ This module implements input and output processing from Nwchem.
 2015/09/21 - Xin Chen (chenxin13@mails.tsinghua.edu.cn):
 
     NwOutput will read new kinds of data:
+
         1. normal hessian matrix.       ["hessian"]
         2. projected hessian matrix.    ["projected_hessian"]
         3. normal frequencies.          ["normal_frequencies"]
@@ -33,6 +34,7 @@ This module implements input and output processing from Nwchem.
 
 2015/10/12 - Xin Chen
     NwOutput will read new kinds of data:
+    
         1. forces.                      ["forces"]
 
 """

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -202,6 +202,7 @@ class Poscar(MSONable):
 
         The code will try its best to determine the elements in the POSCAR in
         the following order:
+
         1. If check_for_POTCAR is True, the code will try to check if a POTCAR
         is in the same directory as the POSCAR and use elements from that by
         default. (This is the VASP default sequence of priority).
@@ -249,11 +250,14 @@ class Poscar(MSONable):
 
         The code will try its best to determine the elements in the POSCAR in
         the following order:
+
         1. If default_names are supplied and valid, it will use those. Usually,
         default names comes from an external source, such as a POTCAR in the
         same directory.
+
         2. If there are no valid default names but the input file is Vasp5-like
         and contains element symbols in the 6th line, the code will use that.
+        
         3. Failing (2), the code will check if a symbol is provided at the end
         of each coordinate.
 

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -26,6 +26,7 @@ Read the following carefully before implementing new input sets:
    MPStaticSet or MPNonSCFSets are constructed.
 
 The above are recommendations. The following are UNBREAKABLE rules:
+
 1. All input sets must take in a structure or list of structures as the first
    argument.
 2. user_incar_settings, user_kpoints_settings and user_<whatever>_settings are

--- a/pymatgen/symmetry/maggroups.py
+++ b/pymatgen/symmetry/maggroups.py
@@ -92,7 +92,7 @@ class MagneticSpaceGroup(SymmetryGroup):
         information on magnetic symmetry.
         
         :param id: BNS number supplied as list of 2 ints or BNS label as
-        str or index as int (1-1651) to iterate over all space groups"""
+            str or index as int (1-1651) to iterate over all space groups"""
 
         self._data = {}
 
@@ -258,7 +258,7 @@ class MagneticSpaceGroup(SymmetryGroup):
         Initialize from Opechowski and Guccione (OG) label or number.
         
         :param id: OG number supplied as list of 3 ints or
-        or OG label as str
+            or OG label as str
         :return: 
         """
 

--- a/pymatgen/transformations/advanced_transformations.py
+++ b/pymatgen/transformations/advanced_transformations.py
@@ -493,13 +493,13 @@ class MagOrderParameterConstraint(MSONable):
         dependent on how many sites satisfy that motif.
 
         :param order_parameter (float): any number from 0.0 to 1.0,
-        typically 0.5 (antiferromagnetic) or 1.0 (ferromagnetic)
+            typically 0.5 (antiferromagnetic) or 1.0 (ferromagnetic)
         :param species_constraint (list): str or list of strings
-        of Specie symbols that the constraint should apply to
+            of Specie symbols that the constraint should apply to
         :param site_constraint_name (str): name of the site property
-        that the constraint should apply to, e.g. "coordination_no"
+            that the constraint should apply to, e.g. "coordination_no"
         :param site_constraints (list): list of values of the site
-        property that the constraints should apply to
+            property that the constraints should apply to
         """
 
         # validation
@@ -558,19 +558,19 @@ class MagOrderingTransformation(AbstractTransformation):
         approximation first.
 
         :param mag_species_spin: A mapping of elements/species to their
-        spin magnitudes, e.g. {"Fe3+": 5, "Mn3+": 4}
+            spin magnitudes, e.g. {"Fe3+": 5, "Mn3+": 4}
         :param order_parameter (float or list): if float, a specifies a
-        global order parameter and can take values from 0.0 to 1.0
-        (e.g. 0.5 for antiferromagnetic or 1.0 for ferromagnetic), if
-        list has to be a list of
-        :class: `pymatgen.transformations.advanced_transformations.MagOrderParameterConstraint`
-        to specify more complicated orderings, see documentation for
-        MagOrderParameterConstraint more details on usage
+            global order parameter and can take values from 0.0 to 1.0
+            (e.g. 0.5 for antiferromagnetic or 1.0 for ferromagnetic), if
+            list has to be a list of
+            :class: `pymatgen.transformations.advanced_transformations.MagOrderParameterConstraint`
+            to specify more complicated orderings, see documentation for
+            MagOrderParameterConstraint more details on usage
         :param energy_model: Energy model to rank the returned structures,
-        see :mod: `pymatgen.analysis.energy_models` for more information (note
-        that this is not necessarily a physical energy). By default, returned
-        structures use SymmetryModel() which ranks structures from most
-        symmetric to least.
+            see :mod: `pymatgen.analysis.energy_models` for more information (note
+            that this is not necessarily a physical energy). By default, returned
+            structures use SymmetryModel() which ranks structures from most
+            symmetric to least.
         :param kwargs: Additional kwargs that are passed to
         :class:`EnumerateStructureTransformation` such as min_cell_size etc.
         """
@@ -640,15 +640,15 @@ class MagOrderingTransformation(AbstractTransformation):
         :param structure: ordered Structure
         :param order_parameters: list of MagOrderParameterConstraints
         :return: A structure decorated with disordered
-        DummySpecies on which to perform the enumeration.
-        Note that the DummySpecies are super-imposed on
-        to the original sites, to make it easier to
-        retrieve the original site after enumeration is
-        performed (this approach is preferred over a simple
-        mapping since multiple species may have the same
-        DummySpecie, depending on the constraints specified).
-        This approach can also preserve site properties even after
-        enumeration.
+            DummySpecies on which to perform the enumeration.
+            Note that the DummySpecies are super-imposed on
+            to the original sites, to make it easier to
+            retrieve the original site after enumeration is
+            performed (this approach is preferred over a simple
+            mapping since multiple species may have the same
+            DummySpecie, depending on the constraints specified).
+            This approach can also preserve site properties even after
+            enumeration.
         """
 
         dummy_struct = structure.copy()

--- a/pymatgen/transformations/defect_transformations.py
+++ b/pymatgen/transformations/defect_transformations.py
@@ -25,16 +25,15 @@ class DefectTransformation(AbstractTransformation):
         """
         :param scaling_matrix: Supercell scaling matrix
         :param defect: Defect pymatgen object
-                NOTE: defect.bulk_structure should be same as provided structure in the apply_transformation step
+            NOTE: defect.bulk_structure should be same as provided structure in the apply_transformation step
         """
         self.scaling_matrix = scaling_matrix
         self.defect = defect
 
     def apply_transformation(self, structure):
         """
-        :param structure (bulk structure to be scaled up - typically conventional unit cell)
-        :return:
-            defect_structure, with charge applied
+        :param structure: (bulk structure to be scaled up - typically conventional unit cell)
+        :return: defect_structure, with charge applied
         """
         if structure != self.defect.bulk_structure:
             raise ValueError("Defect bulk_structure is not the same as input structure.")


### PR DESCRIPTION
## Summary

* Fix docstrings with multi-line :param: and :return: directives not being rendered correctly. This was due to an (undocumented) quirk in sphinx discussed [here](https://stackoverflow.com/questions/32566466/multi-line-description-of-a-parameter-description-in-python-docstring). 

* I also fixed a few issues with the display of some numbered lists.

See screenshots of the incorrect rendering attached.

@shyuep - I've tested this with ```invoke make-docs```. Do you want me to commit the built docs as well, or just the code?

![image](https://user-images.githubusercontent.com/1908695/62742960-7a360f00-b9f5-11e9-8ae0-ceef777716e8.png)

![image](https://user-images.githubusercontent.com/1908695/62743003-a81b5380-b9f5-11e9-9a5f-a8340201f94c.png)
