### PR TITLE
Enhancements to ComputedEntry and MPRester

### DIFF
--- a/pymatgen/entries/computed_entries.py
+++ b/pymatgen/entries/computed_entries.py
@@ -87,6 +87,10 @@ class ComputedEntry(MSONable):
     def energy_per_atom(self):
         return self.energy / self.composition.num_atoms
 
+    @property
+    def energy_per_formula_unit(self):
+        return self.energy / self.composition.get_reduced_composition_and_factor()[1]
+
     def __repr__(self):
         output = ["ComputedEntry {} - {}".format(self.entry_id,
                                                  self.composition.formula),

--- a/pymatgen/ext/matproj.py
+++ b/pymatgen/ext/matproj.py
@@ -663,8 +663,9 @@ class MPRester:
         creating phase diagrams of entire chemical systems.
 
         Args:
-            elements ([str]): List of element symbols, e.g., ["Li", "Fe",
-                "O"].
+            elements (str or [str]): Chemical system string comprising element
+                symbols separated by dashes, e.g., "Li-Fe-O" or List of element 
+                symbols, e.g., ["Li", "Fe", "O"].
             compatible_only (bool): Whether to return only "compatible"
                 entries. Compatible entries are entries that have been
                 processed using the MaterialsProjectCompatibility class,
@@ -686,6 +687,9 @@ class MPRester:
             List of ComputedEntries.
         """
         entries = []
+        if isinstance(elements,str):
+            elements = elements.split('-')
+
         for i in range(len(elements)):
             for els in itertools.combinations(elements, i + 1):
                 entries.extend(

--- a/pymatgen/ext/matproj.py
+++ b/pymatgen/ext/matproj.py
@@ -687,7 +687,7 @@ class MPRester:
             List of ComputedEntries.
         """
         entries = []
-        if isinstance(elements,str):
+        if isinstance(elements, str):
             elements = elements.split('-')
 
         for i in range(len(elements)):


### PR DESCRIPTION
## Summary

* By analogy to the `energy_per_atom` property, it would be useful for ComputedEntry objects to have an energy per formula unit property to unambiguously return the energy associated with a single formuala unit or reduced formula. The first commit adds this property

* `get_entries_in_chemsys` currently requires a list input e.g. ['Li','O'], but the `chemical_system` attribute of Composition returns a str separated by dashes e.g. 'Li-O'. To improve interoperability, it should be possible to pass the dash-separated string into `get_entries_in_chemsys` in addition to lists. The second commit makes this possible