### PR TITLE
Turning back on fragmenter tests

### DIFF
--- a/pymatgen/analysis/tests/test_fragmenter.py
+++ b/pymatgen/analysis/tests/test_fragmenter.py
@@ -43,17 +43,17 @@ class TestFragmentMolecule(PymatgenTest):
         cls.LiEC = Molecule.from_file(
             os.path.join(test_dir, "LiEC.xyz"))
 
-    def _test_edges_given_PC_frag1(self):
+    def test_edges_given_PC_frag1(self):
         fragmenter = Fragmenter(molecule=self.pc_frag1, edges=self.pc_frag1_edges, depth=0)
         self.assertEqual(fragmenter.total_unique_fragments, 12)
 
     @unittest.skipIf(not ob, "OpenBabel not present. Skipping...")
-    def _test_babel_PC_frag1(self):
+    def test_babel_PC_frag1(self):
         fragmenter = Fragmenter(molecule=self.pc_frag1, depth=0)
         self.assertEqual(fragmenter.total_unique_fragments, 12)
 
     @unittest.skipIf(not ob, "OpenBabel not present. Skipping...")
-    def _test_babel_PC_old_defaults(self):
+    def test_babel_PC_old_defaults(self):
         fragmenter = Fragmenter(molecule=self.pc,open_rings=True)
         self.assertEqual(fragmenter.open_rings,True)
         self.assertEqual(fragmenter.opt_steps,10000)
@@ -63,7 +63,7 @@ class TestFragmentMolecule(PymatgenTest):
         self.assertEqual(fragmenter.total_unique_fragments, 13)
 
     @unittest.skipIf(not ob, "OpenBabel not present. Skipping...")
-    def _test_babel_PC_defaults(self):
+    def test_babel_PC_defaults(self):
         fragmenter = Fragmenter(molecule=self.pc)
         self.assertEqual(fragmenter.open_rings,False)
         self.assertEqual(fragmenter.opt_steps,10000)
@@ -72,7 +72,7 @@ class TestFragmentMolecule(PymatgenTest):
         self.assertEqual(fragmenter.mol_graph,default_mol_graph)
         self.assertEqual(fragmenter.total_unique_fragments, 8)
 
-    def _test_edges_given_PC_not_defaults(self):
+    def test_edges_given_PC_not_defaults(self):
         fragmenter = Fragmenter(molecule=self.pc, edges=self.pc_edges, depth=2, open_rings=False, opt_steps=0)
         self.assertEqual(fragmenter.open_rings, False)
         self.assertEqual(fragmenter.opt_steps, 0)
@@ -81,17 +81,17 @@ class TestFragmentMolecule(PymatgenTest):
         self.assertEqual(fragmenter.mol_graph,default_mol_graph)
         self.assertEqual(fragmenter.total_unique_fragments, 20)
 
-    def _test_edges_given_TFSI(self):
+    def test_edges_given_TFSI(self):
         fragmenter = Fragmenter(molecule=self.tfsi, edges=self.tfsi_edges, depth=0)
         self.assertEqual(fragmenter.total_unique_fragments, 156)
 
     @unittest.skipIf(not ob, "OpenBabel not present. Skipping...")
-    def _test_babel_TFSI(self):
+    def test_babel_TFSI(self):
         fragmenter = Fragmenter(molecule=self.tfsi, depth=0)
         self.assertEqual(fragmenter.total_unique_fragments, 156)
 
     @unittest.skipIf(not ob, "OpenBabel not present. Skipping...")
-    def _test_babel_PC_with_RO_depth_0_vs_depth_10(self):
+    def test_babel_PC_with_RO_depth_0_vs_depth_10(self):
         fragmenter0 = Fragmenter(molecule=self.pc, depth=0, open_rings=True, opt_steps=1000)
         self.assertEqual(fragmenter0.total_unique_fragments, 509)
 
@@ -106,7 +106,7 @@ class TestFragmentMolecule(PymatgenTest):
                 num_frags += len(fragments_by_level[str(ii)][key])
             self.assertEqual(num_frags,num_frags_by_level[ii])
 
-    def _test_PC_depth_0_vs_depth_10(self):
+    def test_PC_depth_0_vs_depth_10(self):
         fragmenter0 = Fragmenter(molecule=self.pc, edges=self.pc_edges, depth=0, open_rings=False)
         self.assertEqual(fragmenter0.total_unique_fragments, 295)
 
@@ -121,21 +121,21 @@ class TestFragmentMolecule(PymatgenTest):
                 num_frags += len(fragments_by_level[str(ii)][key])
             self.assertEqual(num_frags,num_frags_by_level[ii])
 
-    def _test_PC_frag1_then_PC(self):
+    def test_PC_frag1_then_PC(self):
         frag1 = Fragmenter(molecule=self.pc_frag1, edges=self.pc_frag1_edges, depth=0)
         self.assertEqual(frag1.new_unique_fragments,frag1.total_unique_fragments)
         frag2 = Fragmenter(molecule=self.pc, edges=self.pc_edges, depth=0, open_rings=False, prev_unique_frag_dict=frag1.unique_frag_dict)
         self.assertEqual(frag2.new_unique_fragments,295-12)
 
     @unittest.skipIf(not ob, "OpenBabel not present. Skipping...")
-    def _test_PC_then_EC_depth_0(self):
+    def test_PC_then_EC_depth_0(self):
         fragPC = Fragmenter(molecule=self.pc, depth=0, open_rings=True)
         fragEC = Fragmenter(molecule=self.ec, depth=0, open_rings=True, prev_unique_frag_dict=fragPC.unique_frag_dict)
         self.assertEqual(fragEC.new_unique_fragments,11)
         self.assertEqual(fragEC.total_unique_fragments,509+11)
 
     @unittest.skipIf(not ob, "OpenBabel not present. Skipping...")
-    def _test_PC_then_EC_depth_10(self):
+    def test_PC_then_EC_depth_10(self):
         fragPC = Fragmenter(molecule=self.pc, depth=10, open_rings=True)
         fragEC = Fragmenter(molecule=self.ec, depth=10, open_rings=True, prev_unique_frag_dict=fragPC.unique_frag_dict)
         self.assertEqual(fragEC.new_unique_fragments,11)


### PR DESCRIPTION
## Summary

When fixing the metal_edge_extender test to not use babel, I turned off the other fragmenter tests and forgot to turn them back on. This fixes that. 