### PR TITLE
Minor improvements to plot_fermi_surface

### DIFF
--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -3740,7 +3740,8 @@ def plot_fermi_surface(data, structure, cbm, energy_levels=None,
             run mlab.show().
         
     Returns:
-        a Mayavi figure and a mlab module to control the plot.
+        ((mayavi.mlab.figure, mayavi.mlab)): The mlab plotter and an interactive
+            figure to control the plot.
 
     Note: Experimental. 
           Please, double check the surface shown by using some 

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -3689,6 +3689,7 @@ class CohpPlotter:
         plt = self.get_plot(xlim, ylim)
         plt.show()
 
+
 @requires(mlab is not None, "MayAvi mlab not imported! Please install mayavi.")
 def plot_fermi_surface(data, structure, cbm, energy_levels=[],
                        multiple_figure=True,
@@ -3696,19 +3697,26 @@ def plot_fermi_surface(data, structure, cbm, energy_levels=[],
                        transparency_factor=[], labels_scale_factor=0.05,
                        points_scale_factor=0.02, interative=True):
     """
-    Plot the Fermi surface at specific energy value.
+    Plot the Fermi surface at specific energy value using Boltztrap 1 FERMI
+    mode.
+
+    The easiest way to use this plotter is:
+
+        1. Run boltztrap in 'FERMI' mode using BoltztrapRunner,
+        2. Load BoltztrapAnalyzer using your method of choice (e.g., from_files)
+        3. Pass in your BoltztrapAnalyzer's fermi_surface_data as this
+            function's data argument.
 
     Args:
-        data: energy values in a 3D grid from a CUBE file 
-              via read_cube_file function, or from a 
-              BoltztrapAnalyzer.fermi_surface_data
+        data: energy values in a 3D grid from a CUBE file via read_cube_file
+            function, or from a BoltztrapAnalyzer.fermi_surface_data
         structure: structure object of the material
-        energy_levels: list of energy value of the fermi surface. 
-                       By default 0 eV correspond to the VBM, as in 
-                       the plot of band structure along symmetry line.
-                       Default: max energy value + 0.01 eV
-        cbm: Boolean value to specify if the considered band is 
-             a conduction band or not
+        energy_levels ([float]): Energy values for plotting the fermi surface(s)
+            By default 0 eV correspond to the VBM, as in the plot of band
+            structure along symmetry line.
+            Default: max energy value + 0.01 eV
+        cbm (bool): Boolean value to specify if the considered band is a
+            conduction band or not
         multiple_figure: if True a figure for each energy level will be shown.
                          If False all the surfaces will be shown in the same figure.
                          In this last case, tune the transparency factor.
@@ -3757,8 +3765,7 @@ def plot_fermi_surface(data, structure, cbm, energy_levels=[],
                                      " not in the range of possible energies: [" +
                                      str(en_min) + ", " + str(en_max) + "]")
 
-    if colors is None:
-        colors = [(0, 0, 1)] * len(energy_levels)
+    colors = [(0, 0, 1)] * len(energy_levels) if colors is None else colors
 
     if transparency_factor == []:
         transparency_factor = [1] * len(energy_levels)

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -3751,8 +3751,9 @@ def plot_fermi_surface(data, structure, cbm, energy_levels=None,
     cell = structure.lattice.reciprocal_lattice.matrix
 
     fact = 1 if cbm == False else -1
-    en_min = np.min(fact * data.ravel())
-    en_max = np.max(fact * data.ravel())
+    data_1d = data.ravel()
+    en_min = np.min(fact * data_1d)
+    en_max = np.max(fact * data_1d)
 
     if energy_levels is None:
         energy_levels = [en_min + 0.01] if cbm == True else \

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -3693,8 +3693,8 @@ class CohpPlotter:
 @requires(mlab is not None, "MayAvi mlab not imported! Please install mayavi.")
 def plot_fermi_surface(data, structure, cbm, energy_levels=None,
                        multiple_figure=True,
-                       mlab_figure=None, kpoints_dict={}, colors=None,
-                       transparency_factor=[], labels_scale_factor=0.05,
+                       mlab_figure=None, kpoints_dict=None, colors=None,
+                       transparency_factor=None, labels_scale_factor=0.05,
                        points_scale_factor=0.02, interative=True):
     """
     Plot the Fermi surface at specific energy value using Boltztrap 1 FERMI
@@ -3761,19 +3761,26 @@ def plot_fermi_surface(data, structure, cbm, energy_levels=None,
     else:
         for e in energy_levels:
             if e > en_max or e < en_min:
-                raise BoltztrapError("energy level " + str(e) +
-                                     " not in the range of possible energies: [" +
-                                     str(en_min) + ", " + str(en_max) + "]")
+                raise BoltztrapError(
+                    "energy level " + str(e) +
+                    " not in the range of possible energies: [" +
+                    str(en_min) + ", " + str(en_max) + "]"
+                )
 
-    colors = [(0, 0, 1)] * len(energy_levels) if colors is None else colors
+    n_surfaces = len(energy_levels)
+    if colors is None:
+        colors = [(0, 0, 1)] * n_surfaces
 
-    if transparency_factor == []:
-        transparency_factor = [1] * len(energy_levels)
+    if transparency_factor is None:
+        transparency_factor = [1] * n_surfaces
 
     if mlab_figure:
         fig = mlab_figure
 
-    if mlab_figure == None and not multiple_figure:
+    if kpoints_dict is None:
+        kpoints_dict = {}
+
+    if mlab_figure is None and not multiple_figure:
         fig = mlab.figure(size=(1024, 768), bgcolor=(1, 1, 1))
         for iface in range(len(bz)):
             for line in itertools.combinations(bz[iface], 2):
@@ -3832,8 +3839,9 @@ def plot_fermi_surface(data, structure, cbm, energy_levels=None,
         polydata.points = (np.array(polydata.points) - [cx, cy, cz]) * 2
 
         #mlab.view(distance='auto')
-        fig.scene.isometric_view() 
-    if interative == True:
+        fig.scene.isometric_view()
+
+    if interative:
         mlab.show()
 
     return fig, mlab

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -3691,7 +3691,7 @@ class CohpPlotter:
 
 
 @requires(mlab is not None, "MayAvi mlab not imported! Please install mayavi.")
-def plot_fermi_surface(data, structure, cbm, energy_levels=[],
+def plot_fermi_surface(data, structure, cbm, energy_levels=None,
                        multiple_figure=True,
                        mlab_figure=None, kpoints_dict={}, colors=None,
                        transparency_factor=[], labels_scale_factor=0.05,
@@ -3714,30 +3714,30 @@ def plot_fermi_surface(data, structure, cbm, energy_levels=[],
         energy_levels ([float]): Energy values for plotting the fermi surface(s)
             By default 0 eV correspond to the VBM, as in the plot of band
             structure along symmetry line.
-            Default: max energy value + 0.01 eV
+            Default: One surface, with max energy value + 0.01 eV
         cbm (bool): Boolean value to specify if the considered band is a
             conduction band or not
-        multiple_figure: if True a figure for each energy level will be shown.
-                         If False all the surfaces will be shown in the same figure.
-                         In this last case, tune the transparency factor.
-        mlab_figure: provide a previous figure to plot a new surface on it.
-        kpoints_dict: dictionary of kpoints to show in the plot.
-                      example: {"K":[0.5,0.0,0.5]}, 
-                      where the coords are fractional.
-        colors: list of 3-tuple (r,g,b) of integers to define the colors of each
-                surface (one per energy level). Should be the same length as the
-                number of surfaces being plotted.
-                Example: colors=[(1,0,0), (0,1,0), (0,0,1)]
-                Example: colors=[(0, 0.5, 0.5)]
-        transparency_factor: list of values in the range [0,1] to tune
-                             the opacity of the surfaces. Should be one
-                             transparency_factor per surface.
-        labels_scale_factor: factor to tune the size of the kpoint labels
-        points_scale_factor: factor to tune the size of the kpoint points
-        interative: if True an interactive figure will be shown.
-                    If False a non interactive figure will be shown, but
-                    it is possible to plot other surfaces on the same figure.
-                    To make it interactive, run mlab.show().
+        multiple_figure (bool): If True a figure for each energy level will be
+            shown.  If False all the surfaces will be shown in the same figure.
+            In this last case, tune the transparency factor.
+        mlab_figure (mayavi.mlab.figure): A previous figure to plot a new
+            surface on.
+        kpoints_dict (dict): dictionary of kpoints to label in the plot.
+            Example: {"K":[0.5,0.0,0.5]}, coords are fractional
+        colors ([tuple]): Iterable of 3-tuples (r,g,b) of integers to define
+            the colors of each surface (one per energy level).
+            Should be the same length as the number of surfaces being plotted.
+            Example (3 surfaces): colors=[(1,0,0), (0,1,0), (0,0,1)]
+            Example (2 surfaces): colors=[(0, 0.5, 0.5)]
+        transparency_factor [float]: Values in the range [0,1] to tune the
+            opacity of each surface. Should be one transparency_factor per
+            surface.
+        labels_scale_factor (float): factor to tune size of the kpoint labels
+        points_scale_factor (float): factor to tune size of the kpoint points
+        interative (bool): if True an interactive figure will be shown.
+            If False a non interactive figure will be shown, but it is possible
+            to plot other surfaces on the same figure. To make it interactive,
+            run mlab.show().
         
     Returns:
         a Mayavi figure and a mlab module to control the plot.
@@ -3753,7 +3753,7 @@ def plot_fermi_surface(data, structure, cbm, energy_levels=[],
     en_min = np.min(fact * data.ravel())
     en_max = np.max(fact * data.ravel())
 
-    if energy_levels == []:
+    if energy_levels is None:
         energy_levels = [en_min + 0.01] if cbm == True else \
             [en_max - 0.01]
         print("Energy level set to: " + str(energy_levels[0]) + " eV")

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -3692,10 +3692,10 @@ class CohpPlotter:
 
 @requires(mlab is not None, "MayAvi mlab not imported! Please install mayavi.")
 def plot_fermi_surface(data, structure, cbm, energy_levels=None,
-                       multiple_figure=True,
-                       mlab_figure=None, kpoints_dict=None, colors=None,
-                       transparency_factor=None, labels_scale_factor=0.05,
-                       points_scale_factor=0.02, interative=True):
+                       multiple_figure=True, mlab_figure=None,
+                       kpoints_dict=None, colors=None, transparency_factor=None,
+                       labels_scale_factor=0.05, points_scale_factor=0.02,
+                       interative=True):
     """
     Plot the Fermi surface at specific energy value using Boltztrap 1 FERMI
     mode.

--- a/pymatgen/symmetry/analyzer.py
+++ b/pymatgen/symmetry/analyzer.py
@@ -770,7 +770,6 @@ class SpacegroupAnalyzer:
             List of weights, in the SAME order as kpoints.
         """
         kpts = np.array(kpoints)
-        print("KPOINTS ARE", kpts)
         shift = []
         mesh = []
         for i in range(3):

--- a/pymatgen/symmetry/analyzer.py
+++ b/pymatgen/symmetry/analyzer.py
@@ -770,6 +770,7 @@ class SpacegroupAnalyzer:
             List of weights, in the SAME order as kpoints.
         """
         kpts = np.array(kpoints)
+        print("KPOINTS ARE", kpts)
         shift = []
         mesh = []
         for i in range(3):

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -12,3 +12,4 @@ phonopy==1.11.12.121
 h5py==2.9.0
 #BoltzTraP2==18.9.1
 f90nml==1.1.2
+mayavi==4.7.1


### PR DESCRIPTION
## Summary

1. `plot_fermi_surface` did not easily work with multiple transparency factors and colors at the same time. This PR makes plotting multiple energy levels with plot_fermi_surface easier by accepting a list of colors and transparencies, one for each desired surface. The core plotting code is identical to previous versions. No features were added. 

2. Some formatting and removal of the most obvious anti-patterns (imports in functions, mutable default kwargs). Docs are changed to be a bit clearer and more PEP8 compliant.

3. Added mayavi as an optional requirement (it was used but not optionally required before)


## Additional dependencies introduced (if any)

Technically `mayavi`, but this was already implicitly "required" by the module and would just throw a boltztrap error every time if mayavi wasn't installed.