### PR TITLE
revert list of specific keys back to original list:

### DIFF
--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -769,10 +769,16 @@ class Incar(dict, MSONable):
             key: INCAR parameter key
             val: Actual value of INCAR parameter.
         """
-        list_keys = tuple([k for k in incar_params.keys() if incar_params[k] == 'list'])
-        bool_keys = tuple([k for k in incar_params.keys() if incar_params[k] == 'bool'])
-        float_keys = tuple([k for k in incar_params.keys() if incar_params[k] == 'float'])
-        int_keys = tuple([k for k in incar_params.keys() if incar_params[k] == 'int'])
+        list_keys = ("LDAUU", "LDAUL", "LDAUJ", "MAGMOM", "DIPOL",
+                     "LANGEVIN_GAMMA", "QUAD_EFG", "EINT")
+        bool_keys = ("LDAU", "LWAVE", "LSCALU", "LCHARG", "LPLANE", "LUSE_VDW",
+                     "LHFCALC", "ADDGRID", "LSORBIT", "LNONCOLLINEAR")
+        float_keys = ("EDIFF", "SIGMA", "TIME", "ENCUTFOCK", "HFSCREEN",
+                      "POTIM", "EDIFFG", "AGGAC", "PARAM1", "PARAM2")
+        int_keys = ("NSW", "NBANDS", "NELMIN", "ISIF", "IBRION", "ISPIN",
+                    "ICHARG", "NELM", "ISMEAR", "NPAR", "LDAUPRINT", "LMAXMIX",
+                    "ENCUT", "NSIM", "NKRED", "NUPDOWN", "ISPIND", "LDAUTYPE",
+                    "IVDW")
 
         def smart_int_or_float(numstr):
             if numstr.find(".") != -1 or numstr.lower().find("e") != -1:


### PR DESCRIPTION
Change the list of specific parameters to handle in the Incar class method proc_val back to its original lists as this method can only read specific parameter types as certain objects.