### PR TITLE
Include additional check to avoid problems for summed cohps

### DIFF
--- a/pymatgen/electronic_structure/cohp.py
+++ b/pymatgen/electronic_structure/cohp.py
@@ -416,6 +416,9 @@ class CompleteCohp(Cohp):
         Returns:
             Returns a COHP object including a summed COHP
         """
+        # check length of label_list and orbital_list:
+        if not len(label_list) == len(orbital_list):
+            raise ValueError("label_list and orbital_list don't have the same length!")
         # check if cohps are spinpolarized or not
         first_cohpobject = self.get_orbital_resolved_cohp(label_list[0], orbital_list[0])
         summed_cohp = first_cohpobject.cohp.copy()

--- a/pymatgen/electronic_structure/tests/test_cohp.py
+++ b/pymatgen/electronic_structure/tests/test_cohp.py
@@ -625,6 +625,10 @@ class CompleteCohpTest(PymatgenTest):
         self.assertArrayEqual(cohp_label2.icohp[Spin.up], ref["ICOHP"][Spin.up] * 2.0)
         self.assertArrayEqual(cohp_label2x.icohp[Spin.up], ref["ICOHP"][Spin.up])
         self.assertArrayEqual(cohp_label3.icohp[Spin.up], ref["ICOHP"][Spin.up] + ref2["ICOHP"][Spin.up])
+        with self.assertRaises(ValueError):
+            self.cohp_orb.get_summed_cohp_by_label_and_orbital_list(["1"], ["4px-4pz", "4s-4px"])
+        with self.assertRaises(ValueError):
+            self.cohp_orb.get_summed_cohp_by_label_and_orbital_list(["1", "2"], ["4s-4px"])
 
     def test_orbital_resolved_cohp(self):
         # When read from a COHPCAR file, total COHPs are calculated from


### PR DESCRIPTION
Hello!

I included an additional test to make sure that two lists that should have the same length actually have the same lengths. These lists are parameters for "get_summed_icohp_by_label_and_orbital_list". I have also included a test to make sure an error will be raised if they have different lengths. 

Best, 
JG