### PR TITLE
Fixed bug in XCrySDen parser failing to parse element symbols

### DIFF
--- a/pymatgen/io/tests/test_xcrysden.py
+++ b/pymatgen/io/tests/test_xcrysden.py
@@ -22,6 +22,39 @@ class XSFTest(PymatgenTest):
         self.assertTrue(structure, XSF.from_string(xsf.to_string()))
 
 
+    def test_xsf_symbolparse(self):
+        """
+        Ensure that the same structure is parsed
+        even if the atomic symbol / number convention
+        is different.
+        """
+
+        test_string = """
+CRYSTAL
+PRIMVEC
+       11.45191956     0.00000000     0.00000000
+        5.72596044     9.91765288     0.00000000
+      -14.31490370    -8.26471287    23.37613199
+PRIMCOORD
+1 1
+H     -0.71644986    -0.41364333     1.19898200     0.00181803     0.00084718     0.00804832
+"""
+        structure = XSF.from_string(test_string).structure
+        self.assertTrue(str(structure.species[0]) == 'H')
+        test_string2 = """
+CRYSTAL
+PRIMVEC
+       11.45191956     0.00000000     0.00000000
+        5.72596044     9.91765288     0.00000000
+      -14.31490370    -8.26471287    23.37613199
+PRIMCOORD
+1 1
+1     -0.71644986    -0.41364333     1.19898200     0.00181803     0.00084718     0.00804832
+"""
+
+        structure2 = XSF.from_string(test_string2).structure
+        self.assertTrue(structure == structure2)
+
 if __name__ == "__main__":
     import unittest
     unittest.main()

--- a/pymatgen/io/tests/test_xcrysden.py
+++ b/pymatgen/io/tests/test_xcrysden.py
@@ -40,7 +40,7 @@ PRIMCOORD
 H     -0.71644986    -0.41364333     1.19898200     0.00181803     0.00084718     0.00804832
 """
         structure = XSF.from_string(test_string).structure
-        self.assertTrue(str(structure.species[0]) == 'H')
+        self.assertEqual(str(structure.species[0]), 'H')
         test_string2 = """
 CRYSTAL
 PRIMVEC
@@ -53,7 +53,7 @@ PRIMCOORD
 """
 
         structure2 = XSF.from_string(test_string2).structure
-        self.assertTrue(structure == structure2)
+        self.assertEqual(structure, structure2)
 
 if __name__ == "__main__":
     import unittest

--- a/pymatgen/io/xcrysden.py
+++ b/pymatgen/io/xcrysden.py
@@ -2,6 +2,8 @@
 # Copyright (c) Pymatgen Development Team.
 # Distributed under the terms of the MIT License.
 
+from pymatgen.core.periodic_table import Element
+
 __author__ = "Matteo Giantomassi"
 __copyright__ = "Copyright 2013, The Materials Project"
 __version__ = "0.1"
@@ -85,7 +87,11 @@ class XSF:
 
                 for j in range(i+2, i+2+num_sites):
                     tokens = lines[j].split()
-                    species.append(int(tokens[0]))
+                    if tokens[0].isalpha():
+                        Z = Element(tokens[0]).Z
+                    else:
+                        Z = int(tokens[0])
+                    species.append(Z)
                     coords.append([float(j) for j in tokens[1:4]])
                 break
         else:


### PR DESCRIPTION
## Summary

Closes #1616 

## Additional dependencies introduced (if any)

The XCrySDen parser now imports from the `pymatgen.core.Element` module.
