### PR TITLE
Use caching in MinimumVIRENN class

### DIFF
--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -1582,7 +1582,7 @@ def _get_vire(structure: Union[Structure, IStructure]):
         Output of `ValenceIonicRadiusEvaluator(structure)`
     """
     # pymatgen does not hash Structure objects, so we need
-    #  to convert from Structure to the immutable IStructure method
+    # to cast from Structure to the immutable IStructure
     if isinstance(structure, Structure):
         structure = IStructure.from_sites(structure)
 

--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -11,6 +11,8 @@ of single sites in molecules and structures.
 import math
 import warnings
 from collections import namedtuple, defaultdict
+from functools import lru_cache
+from typing import Union
 
 import ruamel.yaml as yaml
 import os
@@ -48,7 +50,7 @@ from monty.serialization import loadfn
 from bisect import bisect_left
 from scipy.spatial import Voronoi
 
-from pymatgen import Element
+from pymatgen import Element, Structure, IStructure
 from pymatgen.analysis.bond_valence import BV_PARAMS, BVAnalyzer
 
 _directory = os.path.join(os.path.dirname(__file__))
@@ -1527,6 +1529,8 @@ class MinimumVIRENN(NearNeighbors):
         """
         self.tol = tol
         self.cutoff = cutoff
+        self._structure_hash = None
+        self._vire_cache = None
 
     def get_nn_info(self, structure, n):
         """
@@ -1544,8 +1548,7 @@ class MinimumVIRENN(NearNeighbors):
                 of which represents a neighbor site, its image location,
                 and its weight.
         """
-
-        vire = ValenceIonicRadiusEvaluator(structure)
+        vire = _get_vire(structure)
         site = vire.structure[n]
         neighs_dists = vire.structure.get_neighbors(site, self.cutoff)
         rn = vire.radii[vire.structure[n].species_string]
@@ -1568,6 +1571,38 @@ class MinimumVIRENN(NearNeighbors):
                                 vire.structure, s)})
 
         return siw
+
+
+def _get_vire(structure: Union[Structure, IStructure]):
+    """Get the ValenceIonicRadiusEvaluator object for an structure taking
+    advantage of caching.
+
+    Args:
+        structure: A structure.
+
+    Returns:
+        Output of `ValenceIonicRadiusEvaluator(structure)`
+    """
+    # pymatgen does not hash Structure objects, so we need
+    #  to convert from Structure to the immutable IStructure method
+    if isinstance(structure, Structure):
+        structure = IStructure.from_sites(structure)
+
+    return _get_vire_istructure(structure)
+
+
+@lru_cache(maxsize=1)
+def _get_vire_istructure(structure: IStructure):
+    """Get the ValenceIonicRadiusEvaluator object for an immutable structure
+    taking advantage of caching.
+
+    Args:
+        structure: A structure.
+
+    Returns:
+        Output of `ValenceIonicRadiusEvaluator(structure)`
+    """
+    return ValenceIonicRadiusEvaluator(structure)
 
 
 def solid_angle(center, coords):

--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -1529,8 +1529,6 @@ class MinimumVIRENN(NearNeighbors):
         """
         self.tol = tol
         self.cutoff = cutoff
-        self._structure_hash = None
-        self._vire_cache = None
 
     def get_nn_info(self, structure, n):
         """


### PR DESCRIPTION
## Summary

The `MinimumVIRENN` near neighbors class relies on the `ValenceIonicRadiusEvaluator` which is extremely slow.

If using `MinimumVIRENN` to get the coordination of all sites in a structure, the `ValenceIonicRadiusEvaluator` class will be initialized once per site. This is very inefficient as `ValenceIonicRadiusEvaluator` calculates ionic radii for the whole structure simultaneously.

I've therefore enabled caching of the `ValenceIonicRadiusEvaluator` class using the `lru_cache` functionality in `functools`. In my testing, for some structures this result in a 10x speedup.