### PR TITLE
Added ability to make Gaussian input file without a geometry

### DIFF
--- a/pymatgen/io/gaussian.py
+++ b/pymatgen/io/gaussian.py
@@ -100,16 +100,20 @@ class GaussianInput:
                  gen_basis=None):
         """
         Args:
-            mol: Input molecule. If molecule is a single string, it is used as a
-                direct input to the geometry section of the Gaussian input
-                file.
+            mol: Input molecule. It can either be a Molecule object,
+                a string giving the geometry in a format supported by Guassian,
+                or ``None``. If the molecule is ``None``, you will need to use
+                read it in from a checkpoint. Consider adding ``CHK`` to the
+                ``link0_parameters``.
             charge: Charge of the molecule. If None, charge on molecule is used.
                 Defaults to None. This allows the input file to be set a
                 charge independently from the molecule itself.
+                If ``mol`` is not a Molecule object, then you must specify a charge.
             spin_multiplicity: Spin multiplicity of molecule. Defaults to None,
                 which means that the spin multiplicity is set to 1 if the
                 molecule has no unpaired electrons and to 2 if there are
-                unpaired electrons.
+                unpaired electrons. If ``mol`` is not a Molecule object, then you
+                 must specify the multiplicity
             title: Title for run. Defaults to formula of molecule if None.
             functional: Functional for run.
             basis_set: Basis set for run.
@@ -124,23 +128,38 @@ class GaussianInput:
                 be set to "Gen".
         """
         self._mol = mol
-        self.charge = charge if charge is not None else mol.charge
-        nelectrons = - self.charge + mol.charge + mol.nelectrons
-        if spin_multiplicity is not None:
-            self.spin_multiplicity = spin_multiplicity
-            if (nelectrons + spin_multiplicity) % 2 != 1:
-                raise ValueError(
-                    "Charge of {} and spin multiplicity of {} is"
-                    " not possible for this molecule".format(
-                        self.charge, spin_multiplicity))
+
+        # Determine multiplicity and charge settings
+        if isinstance(mol, Molecule):
+            self.charge = charge if charge is not None else mol.charge
+            nelectrons = - self.charge + mol.charge + mol.nelectrons
+            if spin_multiplicity is not None:
+                self.spin_multiplicity = spin_multiplicity
+                if (nelectrons + spin_multiplicity) % 2 != 1:
+                    raise ValueError(
+                        "Charge of {} and spin multiplicity of {} is"
+                        " not possible for this molecule".format(
+                            self.charge, spin_multiplicity))
+            else:
+                self.spin_multiplicity = 1 if nelectrons % 2 == 0 else 2
+
+            # Get a title from the molecule name
+            self.title = title if title else self._mol.composition.formula
         else:
-            self.spin_multiplicity = 1 if nelectrons % 2 == 0 else 2
+            if charge is None or spin_multiplicity is None:
+                raise ValueError('`charge` and `spin_multiplicity` must be specified')
+            self.charge = charge
+            self.spin_multiplicity = spin_multiplicity
+
+            # Set a title
+            self.title = title if title else 'Restart'
+
+        # Store the remaining settings
         self.functional = functional
         self.basis_set = basis_set
         self.link0_parameters = link0_parameters if link0_parameters else {}
         self.route_parameters = route_parameters if route_parameters else {}
         self.input_parameters = input_parameters if input_parameters else {}
-        self.title = title if title else self._mol.composition.formula
         self.dieze_tag = dieze_tag if dieze_tag[0] == "#" else "#" + dieze_tag
         self.gen_basis = gen_basis
         if gen_basis is not None:
@@ -443,7 +462,7 @@ class GaussianInput:
                 output.append(self.get_cart_coords())
             else:
                 output.append(self.get_zmatrix())
-        else:
+        elif self._mol is not None:
             output.append(str(self._mol))
         output.append("")
         if self.gen_basis is not None:

--- a/pymatgen/io/tests/test_gaussian.py
+++ b/pymatgen/io/tests/test_gaussian.py
@@ -193,6 +193,18 @@ H 0
         self.assertEqual(gin.charge, 0)
         self.assertEqual(gin.spin_multiplicity, 1)
 
+    def test_no_molecule(self):
+        """Test that we can write output files without a geometry"""
+
+        # Note that we must manually specify charge
+        with self.assertRaises(ValueError):
+            GaussianInput(None)
+
+        # Makes a file without geometry
+        input_file = GaussianInput(None, charge=0, spin_multiplicity=2)
+        input_str = input_file.to_string().strip()
+        self.assertTrue(input_str.endswith('0 2'))
+
 
 class GaussianOutputTest(unittest.TestCase):
     # todo: Add unittest for PCM type output.


### PR DESCRIPTION
## Summary

This change makes it possible to write Gaussian input files without needing a geometry, 
which is useful in writing input files for restarting runs. 

## Additional dependencies introduced (if any)

None

## TODO (if any)

None

## Checklist

Before a pull request can be merged, the following items must be checked:

- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). 
      Run [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/) and [flake8](http://flake8.pycqa.org/en/latest/)
      on your local machine.
- [x] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [x] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) 
      to type check your code.
- [x] Tests have been added for any new functionality or bug fixes.
- [x] All existing tests pass.

Note that the CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR. It is
highly recommended that you use the pre-commit hook provided in the pymatgen 
repository. Simply `cp pre-commit .git/hooks` and a check will be run prior to
allowing commits.
