### PR TITLE
Fix broken plotting of fatbands from lobster and extension of Doscar class for lobster

### DIFF
--- a/pymatgen/electronic_structure/bandstructure.py
+++ b/pymatgen/electronic_structure/bandstructure.py
@@ -14,7 +14,7 @@ import collections
 import warnings
 
 from monty.json import MSONable
-from pymatgen.core.periodic_table import get_el_sp, Specie, Element
+from pymatgen.core.periodic_table import get_el_sp, Element
 from pymatgen.core.structure import Structure
 from pymatgen.core.lattice import Lattice
 from pymatgen.electronic_structure.core import Spin, Orbital

--- a/pymatgen/electronic_structure/bandstructure.py
+++ b/pymatgen/electronic_structure/bandstructure.py
@@ -14,7 +14,7 @@ import collections
 import warnings
 
 from monty.json import MSONable
-from pymatgen.core.periodic_table import get_el_sp, Specie
+from pymatgen.core.periodic_table import get_el_sp, Specie, Element
 from pymatgen.core.structure import Structure
 from pymatgen.core.lattice import Lattice
 from pymatgen.electronic_structure.core import Spin, Orbital
@@ -1095,7 +1095,6 @@ class LobsterBandStructureSymmLine(BandStructureSymmLine):
                 structure = Structure.from_dict(d['structure'])
                 projections = {Spin(int(spin)): np.array(v)
                                for spin, v in d["projections"].items()}
-                print(projections)
 
             return LobsterBandStructureSymmLine(
                 d['kpoints'], {Spin(int(k)): d['bands'][k]
@@ -1160,7 +1159,7 @@ class LobsterBandStructureSymmLine(BandStructureSymmLine):
                                           range(len(self.kpoints))):
                 for key, item in v[i][j].items():
                     for key2, item2 in item.items():
-                        specie = str(Specie(re.split(r"[0-9]+", key)[0]))
+                        specie = str(Element(re.split(r"[0-9]+", key)[0]))
                         result[spin][i][j][specie] += item2
         return result
 
@@ -1193,7 +1192,7 @@ class LobsterBandStructureSymmLine(BandStructureSymmLine):
                                           range(len(self.kpoints))):
                 for key, item in v[i][j].items():
                     for key2, item2 in item.items():
-                        specie = str(Specie(re.split(r"[0-9]+", key)[0]))
+                        specie = str(Element(re.split(r"[0-9]+", key)[0]))
                         if get_el_sp(str(specie)) in el_orb_spec:
                             if key2 in el_orb_spec[get_el_sp(str(specie))]:
                                 result[spin][i][j][specie][key2] += item2

--- a/pymatgen/electronic_structure/tests/test_bandstructure.py
+++ b/pymatgen/electronic_structure/tests/test_bandstructure.py
@@ -10,6 +10,7 @@ from io import open
 import warnings
 
 from pymatgen.electronic_structure.bandstructure import Kpoint
+from pymatgen.electronic_structure.plotter import BSPlotterProjected
 from pymatgen import Lattice
 from pymatgen.electronic_structure.core import Spin, Orbital
 from pymatgen.io.vasp import BSVasprun
@@ -285,50 +286,54 @@ class LobsterBandStructureSymmLine_test(PymatgenTest):
         self.assertAlmostEqual(bs_p.distance[30], 0.49251552363382556)
         self.assertTrue(bs_p.branches[0]["name"], '\\Gamma-K')
         self.assertAlmostEqual(bs_p.get_band_gap()["energy"], 5.6739999999999995)
-        print(bs_p.get_projection_on_elements()[Spin.up][0][0].keys())
-        self.assertAlmostEqual(bs_p.get_projection_on_elements()[Spin.up][0][0]["Si0+"], 3 * (0.001 + 0.064))
+        self.assertAlmostEqual(bs_p.get_projection_on_elements()[Spin.up][0][0]["Si"], 3 * (0.001 + 0.064))
         self.assertAlmostEqual(
-            bs_p.get_projections_on_elements_and_orbitals({"Si0+": ["3p"]})[Spin.up][0][0]["Si0+"]["3p"],
+            bs_p.get_projections_on_elements_and_orbitals({"Si": ["3p"]})[Spin.up][0][0]["Si"]["3p"],
             0.003)
         self.assertAlmostEqual(
-            bs_p.get_projections_on_elements_and_orbitals({"O0+": ["2p"]})[Spin.up][0][0]["O0+"]["2p"],
+            bs_p.get_projections_on_elements_and_orbitals({"O": ["2p"]})[Spin.up][0][0]["O"]["2p"],
             0.002 * 3 + 0.003 * 3)
         dict_here = \
-            bs_p.get_projections_on_elements_and_orbitals({"Si0+": ["3s", "3p"], "O0+": ["2s", "2p"]})[Spin.up][0][
+            bs_p.get_projections_on_elements_and_orbitals({"Si": ["3s", "3p"], "O": ["2s", "2p"]})[Spin.up][0][
                 0]
-        self.assertAlmostEqual(dict_here["Si0+"]["3s"], 0.192)
-        self.assertAlmostEqual(dict_here["Si0+"]["3p"], 0.003)
-        self.assertAlmostEqual(dict_here["O0+"]["2s"], 0.792)
-        self.assertAlmostEqual(dict_here["O0+"]["2p"], 0.015)
+        self.assertAlmostEqual(dict_here["Si"]["3s"], 0.192)
+        self.assertAlmostEqual(dict_here["Si"]["3p"], 0.003)
+        self.assertAlmostEqual(dict_here["O"]["2s"], 0.792)
+        self.assertAlmostEqual(dict_here["O"]["2p"], 0.015)
 
-        self.assertAlmostEqual(bs_spin.get_projection_on_elements()[Spin.up][0][0]["Si0+"], 3 * (0.001 + 0.064))
+        self.assertAlmostEqual(bs_spin.get_projection_on_elements()[Spin.up][0][0]["Si"], 3 * (0.001 + 0.064))
         self.assertAlmostEqual(
-            bs_spin.get_projections_on_elements_and_orbitals({"Si0+": ["3p"]})[Spin.up][0][0]["Si0+"]["3p"],
+            bs_spin.get_projections_on_elements_and_orbitals({"Si": ["3p"]})[Spin.up][0][0]["Si"]["3p"],
             0.003)
         self.assertAlmostEqual(
-            bs_spin.get_projections_on_elements_and_orbitals({"O0+": ["2p"]})[Spin.up][0][0]["O0+"]["2p"],
+            bs_spin.get_projections_on_elements_and_orbitals({"O": ["2p"]})[Spin.up][0][0]["O"]["2p"],
             0.002 * 3 + 0.003 * 3)
 
         dict_here = \
-            bs_spin.get_projections_on_elements_and_orbitals({"Si0+": ["3s", "3p"], "O0+": ["2s", "2p"]})[Spin.up][0][0]
-        self.assertAlmostEqual(dict_here["Si0+"]["3s"], 0.192)
-        self.assertAlmostEqual(dict_here["Si0+"]["3p"], 0.003)
-        self.assertAlmostEqual(dict_here["O0+"]["2s"], 0.792)
-        self.assertAlmostEqual(dict_here["O0+"]["2p"], 0.015)
-        self.assertAlmostEqual(bs_spin.get_projection_on_elements()[Spin.up][0][0]["Si0+"], 3 * (0.001 + 0.064))
+            bs_spin.get_projections_on_elements_and_orbitals({"Si": ["3s", "3p"], "O": ["2s", "2p"]})[Spin.up][0][0]
+        self.assertAlmostEqual(dict_here["Si"]["3s"], 0.192)
+        self.assertAlmostEqual(dict_here["Si"]["3p"], 0.003)
+        self.assertAlmostEqual(dict_here["O"]["2s"], 0.792)
+        self.assertAlmostEqual(dict_here["O"]["2p"], 0.015)
+        self.assertAlmostEqual(bs_spin.get_projection_on_elements()[Spin.up][0][0]["Si"], 3 * (0.001 + 0.064))
         self.assertAlmostEqual(
-            bs_spin.get_projections_on_elements_and_orbitals({"Si0+": ["3p"]})[Spin.down][0][0]["Si0+"]["3p"],
+            bs_spin.get_projections_on_elements_and_orbitals({"Si": ["3p"]})[Spin.down][0][0]["Si"]["3p"],
             0.003)
         self.assertAlmostEqual(
-            bs_spin.get_projections_on_elements_and_orbitals({"O0+": ["2p"]})[Spin.down][0][0]["O0+"]["2p"],
+            bs_spin.get_projections_on_elements_and_orbitals({"O": ["2p"]})[Spin.down][0][0]["O"]["2p"],
             0.002 * 3 + 0.003 * 3)
         dict_here = \
-            bs_spin.get_projections_on_elements_and_orbitals({"Si0+": ["3s", "3p"], "O0+": ["2s", "2p"]})[Spin.down][0][
+            bs_spin.get_projections_on_elements_and_orbitals({"Si": ["3s", "3p"], "O": ["2s", "2p"]})[Spin.down][0][
                 0]
-        self.assertAlmostEqual(dict_here["Si0+"]["3s"], 0.192)
-        self.assertAlmostEqual(dict_here["Si0+"]["3p"], 0.003)
-        self.assertAlmostEqual(dict_here["O0+"]["2s"], 0.792)
-        self.assertAlmostEqual(dict_here["O0+"]["2p"], 0.015)
+        self.assertAlmostEqual(dict_here["Si"]["3s"], 0.192)
+        self.assertAlmostEqual(dict_here["Si"]["3p"], 0.003)
+        self.assertAlmostEqual(dict_here["O"]["2s"], 0.792)
+        self.assertAlmostEqual(dict_here["O"]["2p"], 0.015)
+
+    def test_proj_bandstructure_plot(self):
+        # make sure that it can be plotted!
+        BSPlotterProjected(self.bs_spin).get_elt_projected_plots()
+        BSPlotterProjected(self.bs_spin).get_projected_plots_dots({"Si": ["3s"]})
 
     def test_get_branch(self):
         branch = self.bs_p.get_branch(0)[0]

--- a/pymatgen/io/lobster.py
+++ b/pymatgen/io/lobster.py
@@ -372,6 +372,17 @@ class Doscar:
         if is_spin_polarized=False:
         tdensities[Spin.up]: numpy array of the total density of states
 
+
+    .. attribute:: itdensities:
+        itdensities[Spin.up]: numpy array of the total density of states for the Spin.up contribution at each of the
+            energies
+        itdensities[Spin.down]: numpy array of the total density of states for the Spin.down contribution at each of the
+            energies
+
+        if is_spin_polarized=False:
+        itdensities[Spin.up]: numpy array of the total density of states
+
+
     .. attribute:: is_spin_polarized
         Boolean. Tells if the system is spin polarized
 
@@ -395,6 +406,7 @@ class Doscar:
         doscar = self._doscar
 
         tdensities = {}
+        itdensities = {}
         f = open(doscar)
         natoms = int(f.readline().split()[0])
         efermi = float([f.readline() for nn in range(4)][3].split()[17])
@@ -422,6 +434,7 @@ class Doscar:
         energies = doshere[:, 0]
         if not self._is_spin_polarized:
             tdensities[Spin.up] = doshere[:, 1]
+            itdensities[Spin.up] = doshere[:, 2]
             pdoss = []
             spin = Spin.up
             for atom in range(natoms):
@@ -437,6 +450,8 @@ class Doscar:
         else:
             tdensities[Spin.up] = doshere[:, 1]
             tdensities[Spin.down] = doshere[:, 2]
+            itdensities[Spin.up] = doshere[:, 3]
+            itdensities[Spin.down] = doshere[:, 4]
             pdoss = []
             for atom in range(natoms):
                 pdos = defaultdict(dict)
@@ -453,11 +468,13 @@ class Doscar:
                     if j % 2 == 0:
                         orbnumber = orbnumber + 1
                 pdoss.append(pdos)
+
         self._efermi = efermi
         self._pdos = pdoss
         self._tdos = Dos(efermi, energies, tdensities)
         self._energies = energies
         self._tdensities = tdensities
+        self._itdensities = itdensities
         final_struct = self._final_structure
 
         pdossneu = {final_struct[i]: pdos for i, pdos in enumerate(self._pdos)}
@@ -498,6 +515,13 @@ class Doscar:
         :return: total densities as a list
         """
         return self._tdensities
+
+    @property
+    def itdensities(self) -> list:
+        """
+        :return: integrated total densities as a list
+        """
+        return self._itdensities
 
     @property
     def is_spin_polarized(self) -> bool:

--- a/pymatgen/io/lobster.py
+++ b/pymatgen/io/lobster.py
@@ -503,23 +503,23 @@ class Doscar:
         return self._tdos
 
     @property
-    def energies(self) -> list:
+    def energies(self) -> np.array:
         """
         :return: Energies
         """
         return self._energies
 
     @property
-    def tdensities(self) -> list:
+    def tdensities(self) -> np.array:
         """
-        :return: total densities as a list
+        :return: total densities as a np.array
         """
         return self._tdensities
 
     @property
-    def itdensities(self) -> list:
+    def itdensities(self) -> np.array:
         """
-        :return: integrated total densities as a list
+        :return: integrated total densities as a np.array
         """
         return self._itdensities
 

--- a/pymatgen/io/tests/test_lobster.py
+++ b/pymatgen/io/tests/test_lobster.py
@@ -1007,51 +1007,51 @@ class FatbandTest(PymatgenTest):
         self.assertAlmostEqual(bs_p.kpoints[50].cart_coords[1], self.bs_symmline2.kpoints[50].cart_coords[1])
         self.assertAlmostEqual(bs_p.kpoints[50].cart_coords[2], self.bs_symmline2.kpoints[50].cart_coords[2])
         self.assertAlmostEqual(bs_p.get_band_gap()["energy"], self.bs_symmline2.get_band_gap()["energy"], places=2)
-        self.assertAlmostEqual(bs_p.get_projection_on_elements()[Spin.up][0][0]["Si0+"], 3 * (0.001 + 0.064))
+        self.assertAlmostEqual(bs_p.get_projection_on_elements()[Spin.up][0][0]["Si"], 3 * (0.001 + 0.064))
         self.assertAlmostEqual(
-            bs_p.get_projections_on_elements_and_orbitals({"Si0+": ["3p"]})[Spin.up][0][0]["Si0+"]["3p"],
+            bs_p.get_projections_on_elements_and_orbitals({"Si": ["3p"]})[Spin.up][0][0]["Si"]["3p"],
             0.003)
         self.assertAlmostEqual(
-            bs_p.get_projections_on_elements_and_orbitals({"O0+": ["2p"]})[Spin.up][0][0]["O0+"]["2p"],
+            bs_p.get_projections_on_elements_and_orbitals({"O": ["2p"]})[Spin.up][0][0]["O"]["2p"],
             0.002 * 3 + 0.003 * 3)
         dict_here = bs_p.get_projections_on_elements_and_orbitals({
-            "Si0+": ["3s", "3p"], "O0+": ["2s", "2p"]})[Spin.up][0][0]
-        self.assertAlmostEqual(dict_here["Si0+"]["3s"], 0.192)
-        self.assertAlmostEqual(dict_here["Si0+"]["3p"], 0.003)
-        self.assertAlmostEqual(dict_here["O0+"]["2s"], 0.792)
-        self.assertAlmostEqual(dict_here["O0+"]["2p"], 0.015)
+            "Si": ["3s", "3p"], "O": ["2s", "2p"]})[Spin.up][0][0]
+        self.assertAlmostEqual(dict_here["Si"]["3s"], 0.192)
+        self.assertAlmostEqual(dict_here["Si"]["3p"], 0.003)
+        self.assertAlmostEqual(dict_here["O"]["2s"], 0.792)
+        self.assertAlmostEqual(dict_here["O"]["2p"], 0.015)
 
         bs_spin = self.fatband_SiO2_spin.get_bandstructure()
-        self.assertAlmostEqual(bs_spin.get_projection_on_elements()[Spin.up][0][0]["Si0+"], 3 * (0.001 + 0.064))
+        self.assertAlmostEqual(bs_spin.get_projection_on_elements()[Spin.up][0][0]["Si"], 3 * (0.001 + 0.064))
         self.assertAlmostEqual(
-            bs_spin.get_projections_on_elements_and_orbitals({"Si0+": ["3p"]})[Spin.up][0][0]["Si0+"]["3p"],
+            bs_spin.get_projections_on_elements_and_orbitals({"Si": ["3p"]})[Spin.up][0][0]["Si"]["3p"],
             0.003)
         self.assertAlmostEqual(
-            bs_spin.get_projections_on_elements_and_orbitals({"O0+": ["2p"]})[Spin.up][0][0]["O0+"]["2p"],
+            bs_spin.get_projections_on_elements_and_orbitals({"O": ["2p"]})[Spin.up][0][0]["O"]["2p"],
             0.002 * 3 + 0.003 * 3)
         dict_here = \
-            bs_spin.get_projections_on_elements_and_orbitals({"Si0+": ["3s", "3p"], "O0+": ["2s", "2p"]})[Spin.up][0][0]
-        self.assertAlmostEqual(dict_here["Si0+"]["3s"], 0.192)
-        self.assertAlmostEqual(dict_here["Si0+"]["3p"], 0.003)
-        self.assertAlmostEqual(dict_here["O0+"]["2s"], 0.792)
-        self.assertAlmostEqual(dict_here["O0+"]["2p"], 0.015)
+            bs_spin.get_projections_on_elements_and_orbitals({"Si": ["3s", "3p"], "O": ["2s", "2p"]})[Spin.up][0][0]
+        self.assertAlmostEqual(dict_here["Si"]["3s"], 0.192)
+        self.assertAlmostEqual(dict_here["Si"]["3p"], 0.003)
+        self.assertAlmostEqual(dict_here["O"]["2s"], 0.792)
+        self.assertAlmostEqual(dict_here["O"]["2p"], 0.015)
 
-        self.assertAlmostEqual(bs_spin.get_projection_on_elements()[Spin.up][0][0]["Si0+"], 3 * (0.001 + 0.064))
+        self.assertAlmostEqual(bs_spin.get_projection_on_elements()[Spin.up][0][0]["Si"], 3 * (0.001 + 0.064))
         self.assertAlmostEqual(
-            bs_spin.get_projections_on_elements_and_orbitals({"Si0+": ["3p"]})[Spin.down][0][0]["Si0+"]["3p"],
+            bs_spin.get_projections_on_elements_and_orbitals({"Si": ["3p"]})[Spin.down][0][0]["Si"]["3p"],
             0.003)
         self.assertAlmostEqual(
-            bs_spin.get_projections_on_elements_and_orbitals({"O0+": ["2p"]})[Spin.down][0][0]["O0+"]["2p"],
+            bs_spin.get_projections_on_elements_and_orbitals({"O": ["2p"]})[Spin.down][0][0]["O"]["2p"],
             0.002 * 3 + 0.003 * 3)
         dict_here = \
-            bs_spin.get_projections_on_elements_and_orbitals({"Si0+": ["3s", "3p"], "O0+": ["2s", "2p"]})[Spin.down][0][
+            bs_spin.get_projections_on_elements_and_orbitals({"Si": ["3s", "3p"], "O": ["2s", "2p"]})[Spin.down][0][
                 0]
-        self.assertAlmostEqual(dict_here["Si0+"]["3s"], 0.192)
-        self.assertAlmostEqual(dict_here["Si0+"]["3p"], 0.003)
-        self.assertAlmostEqual(dict_here["O0+"]["2s"], 0.792)
-        self.assertAlmostEqual(dict_here["O0+"]["2p"], 0.015)
+        self.assertAlmostEqual(dict_here["Si"]["3s"], 0.192)
+        self.assertAlmostEqual(dict_here["Si"]["3p"], 0.003)
+        self.assertAlmostEqual(dict_here["O"]["2s"], 0.792)
+        self.assertAlmostEqual(dict_here["O"]["2p"], 0.015)
         bs_p_x = self.fatband_SiO2_p_x.get_bandstructure()
-        self.assertAlmostEqual(bs_p_x.get_projection_on_elements()[Spin.up][0][0]["Si0+"], 3 * (0.001 + 0.064), 2)
+        self.assertAlmostEqual(bs_p_x.get_projection_on_elements()[Spin.up][0][0]["Si"], 3 * (0.001 + 0.064), 2)
 
 
 class LobsterinTest(unittest.TestCase):

--- a/pymatgen/io/tests/test_lobster.py
+++ b/pymatgen/io/tests/test_lobster.py
@@ -483,11 +483,12 @@ class DoscarTest(unittest.TestCase):
         pass
         itdos_up = [1.99997, 4.99992, 4.99992, 7.99987, 7.99987, 8.09650]
         itdos_down = [1.99997, 4.99992, 4.99992, 7.99987, 7.99987, 8.09685]
-        self.assertListEqual(itdos_up,self.DOSCAR_spin_pol.itdensities[Spin.up].tolist())
-        self.assertListEqual(itdos_down,self.DOSCAR_spin_pol.itdensities[Spin.down].tolist())
+        self.assertListEqual(itdos_up, self.DOSCAR_spin_pol.itdensities[Spin.up].tolist())
+        self.assertListEqual(itdos_down, self.DOSCAR_spin_pol.itdensities[Spin.down].tolist())
 
-        itdos_nonspin=[   4.00000,   10.00000,  10.00000,  16.00000,  16.00000,  16.09067]
+        itdos_nonspin = [4.00000, 10.00000, 10.00000, 16.00000, 16.00000, 16.09067]
         self.assertListEqual(itdos_nonspin, self.DOSCAR_nonspin_pol.itdensities[Spin.up].tolist())
+
     def test_is_spin_polarized(self):
         # first for spin polarized version
         self.assertTrue(self.DOSCAR_spin_pol.is_spin_polarized)

--- a/pymatgen/io/tests/test_lobster.py
+++ b/pymatgen/io/tests/test_lobster.py
@@ -479,6 +479,15 @@ class DoscarTest(unittest.TestCase):
         tdos_nonspin = [0.00000, 1.60000, 0.00000, 1.60000, 0.00000, 0.02418]
         self.assertListEqual(tdos_nonspin, self.DOSCAR_nonspin_pol.tdensities[Spin.up].tolist())
 
+    def test_itdensities(self):
+        pass
+        itdos_up = [1.99997, 4.99992, 4.99992, 7.99987, 7.99987, 8.09650]
+        itdos_down = [1.99997, 4.99992, 4.99992, 7.99987, 7.99987, 8.09685]
+        self.assertListEqual(itdos_up,self.DOSCAR_spin_pol.itdensities[Spin.up].tolist())
+        self.assertListEqual(itdos_down,self.DOSCAR_spin_pol.itdensities[Spin.down].tolist())
+
+        itdos_nonspin=[   4.00000,   10.00000,  10.00000,  16.00000,  16.00000,  16.09067]
+        self.assertListEqual(itdos_nonspin, self.DOSCAR_nonspin_pol.itdensities[Spin.up].tolist())
     def test_is_spin_polarized(self):
         # first for spin polarized version
         self.assertTrue(self.DOSCAR_spin_pol.is_spin_polarized)


### PR DESCRIPTION
## Summary

Hello, 

There was a problem in LobsterBandStructureSymmLine due to the use of "Species". I have fixed this and reverted some changes in the tests that were done to account for this problem. Without the current pull request, plotting fatbands from Lobster isn't possible anymore. I have also included an additional test that might help to avoid such changes of tests in the future. 
I have also extended the Doscar class to also read in the integrated total density of states from Lobster. Tests have been added as well.

Best, 
JG

## Checklist

Before a pull request can be merged, the following items must be checked:

- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). 
      Run [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/) and [flake8](http://flake8.pycqa.org/en/latest/)
      on your local machine.
- [x] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [x] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) 
      to type check your code.
- [x] Tests have been added for any new functionality or bug fixes.
- [x] All existing tests pass.

Note that the CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR. It is
highly recommended that you use the pre-commit hook provided in the pymatgen 
repository. Simply `cp pre-commit .git/hooks` and a check will be run prior to
allowing commits.
