### PR TITLE
Respect KSPACING setting in the INCAR

### DIFF
--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -2040,8 +2040,9 @@ class VaspInput(dict, MSONable):
         if make_dir_if_not_present and not os.path.exists(output_dir):
             os.makedirs(output_dir)
         for k, v in self.items():
-            with zopen(os.path.join(output_dir, k), "wt") as f:
-                f.write(v.__str__())
+            if v is not None:
+                with zopen(os.path.join(output_dir, k), "wt") as f:
+                    f.write(v.__str__())
 
     @staticmethod
     def from_directory(input_dir, optional_files=None):

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -2064,6 +2064,7 @@ class VaspInput(dict, MSONable):
                 fullzpath = zpath(os.path.join(input_dir, fname))
                 sub_d[fname.lower()] = ftype.from_file(fullzpath)
             except FileNotFoundError: #handle the case where there is no KPOINTS file
+                sub_d[fname.lower()] = None
                 pass
 
         sub_d["optional_files"] = {}

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -2063,7 +2063,7 @@ class VaspInput(dict, MSONable):
             try:
                 fullzpath = zpath(os.path.join(input_dir, fname))
                 sub_d[fname.lower()] = ftype.from_file(fullzpath)
-            except FileNotFoundError: #handle the case where there is no KPOINTS file
+            except FileNotFoundError:  # handle the case where there is no KPOINTS file
                 sub_d[fname.lower()] = None
                 pass
 

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -2060,8 +2060,12 @@ class VaspInput(dict, MSONable):
         sub_d = {}
         for fname, ftype in [("INCAR", Incar), ("KPOINTS", Kpoints),
                              ("POSCAR", Poscar), ("POTCAR", Potcar)]:
-            fullzpath = zpath(os.path.join(input_dir, fname))
-            sub_d[fname.lower()] = ftype.from_file(fullzpath)
+            try:
+                fullzpath = zpath(os.path.join(input_dir, fname))
+                sub_d[fname.lower()] = ftype.from_file(fullzpath)
+            except FileNotFoundError: #handle the case where there is no KPOINTS file
+                pass
+
         sub_d["optional_files"] = {}
         if optional_files is not None:
             for fname, ftype in optional_files.items():

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -517,7 +517,7 @@ class DictSet(VaspInputSet):
         
         # Return None if KSPACING is present in the INCAR, because this will
         # cause VASP to generate the KPOINTS file automatically
-        if incar.get("KSPACING",None) is not None:
+        if self.incar.get("KSPACING",None) is not None:
             return None
 
         # If grid_density is in the kpoints_settings use

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -1110,6 +1110,11 @@ class MPNonSCFSet(MPRelaxSet):
         """
         :return: Kpoints
         """
+        # override pymatgen kpoints if provided
+        user_kpoints = self.kwargs.get("user_kpoints_settings", None)
+        if isinstance(user_kpoints, Kpoints):
+            return user_kpoints
+
         if self.mode.lower() == "line":
             kpath = HighSymmKpath(self.structure)
             frac_k_points, k_points_labels = kpath.get_kpoints(
@@ -1140,12 +1145,7 @@ class MPNonSCFSet(MPRelaxSet):
         else:
             self._config_dict["KPOINTS"]["reciprocal_density"] = \
                 self.reciprocal_density
-            kpoints = super().kpoints
-
-        # override pymatgen kpoints if provided
-        user_kpoints = self.kwargs.get("user_kpoints_settings", None)
-        if isinstance(user_kpoints, Kpoints):
-            kpoints = user_kpoints
+            return super().kpoints
 
         return kpoints
 

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -511,7 +511,7 @@ class DictSet(VaspInputSet):
             return nelect
 
     @property
-    def kpoints(self) -> Kpoints or None:
+    def kpoints(self) -> Union[Kpoints,None]:
         """
         Returns a KPOINTS file using the fully automated grid method. Uses
         Gamma centered meshes for hexagonal cells and Monk grids otherwise.
@@ -527,7 +527,7 @@ class DictSet(VaspInputSet):
 
         # Return None if KSPACING is present in the INCAR, because this will
         # cause VASP to generate the KPOINTS file automatically
-        if self.user_incar_settings.get("KSPACING", None) is not None:
+        if self.user_incar_settings.get("KSPACING"):
             return None
 
         # If grid_density is in the kpoints_settings use

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -429,7 +429,7 @@ class DictSet(VaspInputSet):
                 if "EDIFF" not in settings and k == "EDIFF_PER_ATOM":
                     incar["EDIFF"] = float(v) * structure.num_sites
                 else:
-                    incar["EDIFF"] = float(settings["EDIFF"])   
+                    incar["EDIFF"] = float(settings["EDIFF"])
             else:
                 incar[k] = v
 
@@ -464,15 +464,15 @@ class DictSet(VaspInputSet):
         # when the KSPACING value is > 0.5 (2 reciprocal Angstrom).
         # An error handler in Custodian is available to
         # correct overly large KSPACING values (small number of kpoints)
-        # if necessary. 
+        # if necessary.
         if "KSPACING" not in self.user_incar_settings.keys():
             if np.product(self.kpoints.kpts) < 4 and incar.get("ISMEAR", 0) == -5:
                 incar["ISMEAR"] = 0
-        
+
         if self.user_incar_settings.get("KSPACING", 0) > 0.5 and incar.get("ISMEAR", 0 == -5):
             warnings.warn("Large KSPACING value detected with ISMEAR = -5. Ensure that VASP "
-                            "generates an adequate number of KPOINTS, lower KSPACING, or "
-                            "set ISMEAR = 0", BadInputSetWarning)
+                          "generates an adequate number of KPOINTS, lower KSPACING, or "
+                          "set ISMEAR = 0", BadInputSetWarning)
 
         if all([k.is_metal for k in structure.composition.keys()]):
             if incar.get("NSW", 0) > 0 and incar.get("ISMEAR", 1) < 1:
@@ -524,7 +524,7 @@ class DictSet(VaspInputSet):
 
         if isinstance(settings, Kpoints):
             return settings
-        
+
         # Return None if KSPACING is present in the INCAR, because this will
         # cause VASP to generate the KPOINTS file automatically
         if self.user_incar_settings.get("KSPACING", None) is not None:

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -47,7 +47,7 @@ import warnings
 from itertools import chain
 from copy import deepcopy
 from pathlib import Path
-from typing import List, Union
+from typing import List, Union, Optional
 import numpy as np
 from monty.serialization import loadfn
 from monty.io import zopen
@@ -777,7 +777,7 @@ class MPStaticSet(MPRelaxSet):
         return incar
 
     @property
-    def kpoints(self) -> Union[Kpoints, None]:
+    def kpoints(self) -> Optional[Kpoints]:
         """
         :return: Kpoints
         """
@@ -1106,7 +1106,7 @@ class MPNonSCFSet(MPRelaxSet):
         return incar
 
     @property
-    def kpoints(self) -> Union[Kpoints, None]:
+    def kpoints(self) -> Optional[Kpoints]:
         """
         :return: Kpoints
         """

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -511,7 +511,7 @@ class DictSet(VaspInputSet):
             return nelect
 
     @property
-    def kpoints(self) -> Union[Kpoints,None]:
+    def kpoints(self) -> Union[Kpoints, None]:
         """
         Returns a KPOINTS file using the fully automated grid method. Uses
         Gamma centered meshes for hexagonal cells and Monk grids otherwise.
@@ -762,7 +762,7 @@ class MPStaticSet(MPRelaxSet):
         return incar
 
     @property
-    def kpoints(self) -> Kpoints:
+    def kpoints(self) -> Union[Kpoints, None]:
         """
         :return: Kpoints
         """

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -469,10 +469,10 @@ class DictSet(VaspInputSet):
             if np.product(self.kpoints.kpts) < 4 and incar.get("ISMEAR", 0) == -5:
                 incar["ISMEAR"] = 0
         
-        if self.user_incar_settings.get("KSPACING",0) > 0.5 and incar.get("ISMEAR",0 == -5):
+        if self.user_incar_settings.get("KSPACING", 0) > 0.5 and incar.get("ISMEAR", 0 == -5):
             warnings.warn("Large KSPACING value detected with ISMEAR = -5. Ensure that VASP "
-                              "generates an adequate number of KPOINTS, lower KSPACING, or "
-                              "set ISMEAR = 0", BadInputSetWarning)
+                            "generates an adequate number of KPOINTS, lower KSPACING, or "
+                            "set ISMEAR = 0", BadInputSetWarning)
 
         if all([k.is_metal for k in structure.composition.keys()]):
             if incar.get("NSW", 0) > 0 and incar.get("ISMEAR", 1) < 1:
@@ -527,7 +527,7 @@ class DictSet(VaspInputSet):
         
         # Return None if KSPACING is present in the INCAR, because this will
         # cause VASP to generate the KPOINTS file automatically
-        if self.user_incar_settings.get("KSPACING",None) is not None:
+        if self.user_incar_settings.get("KSPACING", None) is not None:
             return None
 
         # If grid_density is in the kpoints_settings use

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -396,7 +396,7 @@ class MPStaticSetTest(PymatgenTest):
         self.assertEqual(vis.incar["KSPACING"], 0.22)
         self.assertEqual(vis.kpoints, None)
 
-    def test_kspacing_overridce(self):
+    def test_kspacing_override(self):
         # If KSPACING is set and user_kpoints_settings are given,
         # make sure the user_kpoints_settings override KSPACING
         si = self.get_structure('Si')

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -276,8 +276,8 @@ class MITMPRelaxSetTest(PymatgenTest):
         self.assertEqual(kpoints.kpts, [[2, 4, 5]])
         self.assertEqual(kpoints.style, Kpoints.supported_modes.Gamma)
 
-        kpoints = MPRelaxSet(self.structure,user_incar_settings={"KSPACING":0.22}).kpoints
-        self.assertEqual(kpoints,None)
+        kpoints = MPRelaxSet(self.structure, user_incar_settings={"KSPACING": 0.22}).kpoints
+        self.assertEqual(kpoints, None)
 
     def test_get_vasp_input(self):
         d = self.mitset.get_vasp_input()

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -276,6 +276,9 @@ class MITMPRelaxSetTest(PymatgenTest):
         self.assertEqual(kpoints.kpts, [[2, 4, 5]])
         self.assertEqual(kpoints.style, Kpoints.supported_modes.Gamma)
 
+        kpoints = MPRelaxSet(self.structure,user_incar_settings={"KSPACING":0.22}).kpoints
+        self.assertEqual(kpoints,None)
+
     def test_get_vasp_input(self):
         d = self.mitset.get_vasp_input()
         self.assertEqual(d["INCAR"]["ISMEAR"], -5)
@@ -826,6 +829,12 @@ class MVLSlabSetTest(PymatgenTest):
         si = self.get_structure('Si')
         vis = MVLSlabSet(si, user_incar_settings={"AMIX": 0.1})
         self.assertEqual(vis.incar["AMIX"], 0.1)
+
+    def test_user_incar_kspacing(self):
+        # Make sure user KSPACING settings properly overrides KPOINTS.
+        si = self.get_structure('Si')
+        vis = MVLSlabSet(si, user_incar_settings={"KSPACING": 0.22})
+        self.assertEqual(vis.incar["KSPACING"], 0.22)
 
     def test_bulk(self):
         incar_bulk = self.d_bulk["INCAR"]

--- a/pymatgen/util/typing.py
+++ b/pymatgen/util/typing.py
@@ -2,7 +2,7 @@
 # Copyright (c) Pymatgen Development Team.
 # Distributed under the terms of the MIT License.
 
-from typing import Union, List
+from typing import Union, List, Optional
 from pathlib import Path
 import numpy as np
 

--- a/pymatgen/util/typing.py
+++ b/pymatgen/util/typing.py
@@ -2,7 +2,7 @@
 # Copyright (c) Pymatgen Development Team.
 # Distributed under the terms of the MIT License.
 
-from typing import Union, List, Optional
+from typing import Union, List
 from pathlib import Path
 import numpy as np
 


### PR DESCRIPTION
## Summary

VASP now [recommends](https://www.vasp.at/wiki/index.php/KSPACING) setting KSPACING in the INCAR file rather than supplying KPOINTS manually. This PR updates the teterror handler to accommodate calculations that use KSPACING instead of an explicit KPOINTS file.

Currently, if a user adds KSPACING to user_incar_settings when initializing a VaspInputSet, the setting will be ignored and a KPOINTS file generated anyway. This PR ensures that the KSPACING setting passed to VASP as expected.

See also Custodian [#139](https://github.com/materialsproject/custodian/pull/139)

See also a [similar issue](https://gitlab.com/ase/ase/merge_requests/226/commits) recently fixed in ASE.
