### PR TITLE
Add pymatgen.Molecule support to AseAtomsAdaptor

### DIFF
--- a/pymatgen/io/tests/test_ase.py
+++ b/pymatgen/io/tests/test_ase.py
@@ -6,7 +6,7 @@
 import unittest
 import os
 
-from pymatgen import Composition
+from pymatgen import Composition, Molecule
 from pymatgen.io.vasp.inputs import Poscar
 import pymatgen.io.ase as aio
 
@@ -17,12 +17,23 @@ test_dir = os.path.join(os.path.dirname(__file__), "..", "..", "..",
 class AseAtomsAdaptorTest(unittest.TestCase):
 
     @unittest.skipIf(not aio.ase_loaded, "ASE not loaded.")
-    def test_get_atoms(self):
+    def test_get_atoms_from_structure(self):
         p = Poscar.from_file(os.path.join(test_dir, 'POSCAR'))
         structure = p.structure
         atoms = aio.AseAtomsAdaptor.get_atoms(structure)
         ase_composition = Composition(atoms.get_chemical_formula())
         self.assertEqual(ase_composition, structure.composition)
+        self.assertTrue(atoms.cell is not None and atoms.cell.any())
+        self.assertTrue(atoms.get_pbc() is not None and atoms.get_pbc().all())
+
+    @unittest.skipIf(not aio.ase_loaded, "ASE not loaded.")
+    def test_get_atoms_from_molecule(self):
+        m = Molecule.from_file(os.path.join(test_dir, 'acetylene.xyz'))
+        atoms = aio.AseAtomsAdaptor.get_atoms(m)
+        ase_composition = Composition(atoms.get_chemical_formula())
+        self.assertEqual(ase_composition, m.composition)
+        self.assertTrue(atoms.cell is None or not atoms.cell.any())
+        self.assertTrue(atoms.get_pbc() is None or not atoms.get_pbc().any())
 
     @unittest.skipIf(not aio.ase_loaded, "ASE not loaded.")
     def test_get_structure(self):
@@ -30,6 +41,13 @@ class AseAtomsAdaptorTest(unittest.TestCase):
         atoms = aio.AseAtomsAdaptor.get_atoms(p.structure)
         self.assertEqual(aio.AseAtomsAdaptor.get_structure(atoms).formula,
                          "Fe4 P4 O16")
+
+    @unittest.skipIf(not aio.ase_loaded, "ASE not loaded.")
+    def test_get_molecule(self):
+        m = Molecule.from_file(os.path.join(test_dir, 'acetylene.xyz'))
+        atoms = aio.AseAtomsAdaptor.get_atoms(m)
+        self.assertEqual(aio.AseAtomsAdaptor.get_molecule(atoms).formula,
+                         "H2 C2")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

* Added ``pymatgen.Molecule`` support to ``AseAtomsAdaptor``:
  * ``AseAtomsAdaptor.get_atoms()``now also accepts ``Molecule``s (previously, it would only accept ``Structure``s)
  * New (static) method ``AseAtomsAdaptor.get_molecule()`` (analogous to the existing ``get_structure()``method, but returns ``Molecule``s instead of ``Structure``s)
* Slightly extended tests

## Checklist

- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). 
      Run [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/) and [flake8](http://flake8.pycqa.org/en/latest/) on your local machine.
- [x] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [ ] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) to type check your code.
  - [x] There weren't any before in the module this is about, so it should be fine if my stuff doesn't have any either. Probably better for a separate PR.
- [x] Tests have been added for any new functionality or bug fixes.
- [ ] All existing tests pass.
  - Only one way to find out for sure...
