### PR TITLE
Force GrainBoundaryGenerator.gb_from_parameters to return fractional coords within unit cell

### DIFF
--- a/pymatgen/analysis/gb/grain.py
+++ b/pymatgen/analysis/gb/grain.py
@@ -658,6 +658,8 @@ class GrainBoundaryGenerator:
             all_sites = sites_away_gb + s_near_gb.sites
             gb_with_vac = Structure.from_sites(all_sites)
 
+        # move coordinates into the periodic cell.
+        gb_with_vac = fix_pbc(gb_with_vac, whole_lat.matrix)
         return GrainBoundary(whole_lat, gb_with_vac.species, gb_with_vac.cart_coords, rotation_axis,
                              rotation_angle, plane, join_plane, self.initial_structure,
                              vacuum_thickness, ab_shift, site_properties=gb_with_vac.site_properties,

--- a/pymatgen/analysis/gb/tests/test_grain.py
+++ b/pymatgen/analysis/gb/tests/test_grain.py
@@ -160,6 +160,20 @@ class GrainBoundaryGeneratorTest(PymatgenTest):
         ab_len3 = np.linalg.norm(np.cross(lat_mat3[2], c_vec3))
         self.assertAlmostEqual(ab_len3, 0)
 
+        # test normal in tilt boundary
+        # The 'finfo(np.float32).eps' is the smallest representable positive number in float32,
+        # which has been introduced because comparing to just zero or one failed the test by rounding errors.
+        gb_cu_010_conv1 = self.GB_Cu_conv.gb_from_parameters(rotation_axis=[0, 1, 0],
+                                                             rotation_angle=36.8698976458,
+                                                             expand_times=1,
+                                                             vacuum_thickness=1.0,
+                                                             ab_shift=[0.0, 0.0],
+                                                             rm_ratio=0.0,
+                                                             plane=[0, 0, 1],
+                                                             normal=True)
+        self.assertTrue(np.all(-np.finfo(np.float32).eps <= gb_cu_010_conv1.frac_coords))
+        self.assertTrue(np.all(1 + np.finfo(np.float32).eps >= gb_cu_010_conv1.frac_coords))
+
         # from fcc conventional cell,axis [1,2,3], siamg 9
         gb_cu_123_conv1 = self.GB_Cu_conv.gb_from_parameters([1, 2, 3],
                                                              123.74898859588858,


### PR DESCRIPTION
## Summary

Current implementation sometimes returns a structure with fractional coordinates whose absolute value are greater than one. It is not wrong but inconvenient when it is used in external calculation modules (and also it seems many users think it as unexpected behavior).
(related to [#1693](https://github.com/materialsproject/pymatgen/issues/1693))

* `pymatgen.analysis.gb.grain.gb_from_parameters()` now returns a structure with fractional coordinates in [0, 1).
* A Test for fractional coordinates has been added to `test_gb_from_parameters()` to check the fractional coords within [0, 1).

## Checklist

Before a pull request can be merged, the following items must be checked:

- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). 
      Run [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/) and [flake8](http://flake8.pycqa.org/en/latest/)
      on your local machine.
- [ ] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
      - I have not modified Docstrings in this PR.
- [ ] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) 
      to type check your code.
      - I have not added any functions.
- [x] Tests have been added for any new functionality or bug fixes.
- [ ] All existing tests pass.
  - [x] A test `pymatgen.analysis.gb.tests.test_grain` passes.
