### PR TITLE
Fix bug of missing sp2 N-N bond data

### DIFF
--- a/pymatgen/core/bond_lengths.json
+++ b/pymatgen/core/bond_lengths.json
@@ -162,7 +162,7 @@
     "bond_order": 1.0
   },
   {
-    "ref": "",
+    "ref": "http://www.wiredchemist.com/chemistry/data/bond_energies_lengths.html",
     "length": 1.25,
     "elements": [
       "N",

--- a/pymatgen/core/bond_lengths.json
+++ b/pymatgen/core/bond_lengths.json
@@ -162,7 +162,7 @@
     "bond_order": 1.0
   },
   {
-    "ref": "http://www.wiredchemist.com/chemistry/data/bond_energies_lengths.html",
+    "ref": "M. Carlotti, J. W. C. Johns, A. Trombetti, Canadian Journal of Physics, 1974, 52:340-344",
     "length": 1.25,
     "elements": [
       "N",

--- a/pymatgen/core/bond_lengths.json
+++ b/pymatgen/core/bond_lengths.json
@@ -163,6 +163,15 @@
   },
   {
     "ref": "",
+    "length": 1.25,
+    "elements": [
+      "N",
+      "N"
+    ],
+    "bond_order": 2.0
+  },
+  {
+    "ref": "",
     "length": 1.1,
     "elements": [
       "N",

--- a/pymatgen/core/tests/test_bonds.py
+++ b/pymatgen/core/tests/test_bonds.py
@@ -105,6 +105,8 @@ class FuncTest(unittest.TestCase):
         self.assertAlmostEqual(get_bond_order(
             'C', 'Br', 2, tol=0.5, default_bl=1.9), 0.894736842105263)
         self.assertRaises(ValueError, get_bond_order, 'C', 'Br', 1.9)
+        self.assertAlmostEqual(get_bond_order(
+            'N', 'N', 1.25), 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added data for an sp2 N-N bonds in bond_lengths.json
Use value of 1.25 from the following source
http://www.wiredchemist.com/chemistry/data/bond_energies_lengths.html
