### PR TITLE
Add fast `Structure.get_neighbor_list` method

### DIFF
--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -1230,8 +1230,8 @@ class IStructure(SiteCollection, MSONable):
                               numerical_tol: float = 1e-8,
                               exclude_self: bool = True) -> Tuple[np.ndarray, ...]:
         """
-        A python version of getting neighbor_list. The returned values are a list of
-        numpy arrays [center_indices, points_indices, offset_vectors, distances].
+        A python version of getting neighbor_list. The returned values are a tuple of
+        numpy arrays (center_indices, points_indices, offset_vectors, distances).
         Atom `center_indices[i]` has neighbor atom `points_indices[i]` that is
         translated by `offset_vectors[i]` lattice vectors, and the distance is
         `distances[i]`.
@@ -1249,7 +1249,7 @@ class IStructure(SiteCollection, MSONable):
                 ok in most instances.
             exclude_self (bool): whether to exclude atom neighboring with itself within
                 numerical tolerance distance, default to True
-        Returns: [center_indices, points_indices, offset_vectors, distances]
+        Returns: (center_indices, points_indices, offset_vectors, distances)
         """
         neighbors = self.get_all_neighbors_py(r=r, include_index=True, include_image=True,
                                               sites=sites, numerical_tol=1e-8)
@@ -1277,8 +1277,8 @@ class IStructure(SiteCollection, MSONable):
         Get neighbor lists using numpy array representations without constructing
         Neighbor objects. If the cython extension is installed,  this method will
         be orders of magnitude faster than `get_all_neighbors`.
-        The returned values are a list of numpy arrays
-        [center_indices, points_indices, offset_vectors, distances].
+        The returned values are a tuple of numpy arrays
+        (center_indices, points_indices, offset_vectors, distances).
         Atom `center_indices[i]` has neighbor atom `points_indices[i]` that is
         translated by `offset_vectors[i]` lattice vectors, and the distance is
         `distances[i]`.
@@ -1296,7 +1296,7 @@ class IStructure(SiteCollection, MSONable):
                 ok in most instances.
             exclude_self (bool): whether to exclude atom neighboring with itself within
                 numerical tolerance distance, default to True
-        Returns: [center_indices, points_indices, offset_vectors, distances]
+        Returns: (center_indices, points_indices, offset_vectors, distances)
 
         """
         try:

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -1225,6 +1225,102 @@ class IStructure(SiteCollection, MSONable):
                                       include_image=include_image)
         return [d for d in nn if site != d[0]]
 
+    def _get_neighbor_list_py(self, r: float,
+                              sites: List[PeriodicSite] = None,
+                              numerical_tol: float = 1e-8,
+                              exclude_self: bool = True) -> Tuple[np.ndarray, ...]:
+        """
+        A python version of getting neighbor_list. The returned values are a list of
+        numpy arrays [center_indices, points_indices, offset_vectors, distances].
+        Atom `center_indices[i]` has neighbor atom `points_indices[i]` that is
+        translated by `offset_vectors[i]` lattice vectors, and the distance is
+        `distances[i]`.
+
+        Args:
+            r (float): Radius of sphere
+            sites (list of Sites or None): sites for getting all neighbors,
+                default is None, which means neighbors will be obtained for all
+                sites. This is useful in the situation where you are interested
+                only in one subspecies type, and makes it a lot faster.
+            numerical_tol (float): This is a numerical tolerance for distances.
+                Sites which are < numerical_tol are determined to be conincident
+                with the site. Sites which are r + numerical_tol away is deemed
+                to be within r from the site. The default of 1e-8 should be
+                ok in most instances.
+            exclude_self (bool): whether to exclude atom neighboring with itself within
+                numerical tolerance distance, default to True
+        Returns: [center_indices, points_indices, offset_vectors, distances]
+        """
+        neighbors = self.get_all_neighbors_py(r=r, include_index=True, include_image=True,
+                                              sites=sites, numerical_tol=1e-8)
+        center_indices = []
+        points_indices = []
+        offsets = []
+        distances = []
+        for i, nns in enumerate(neighbors):
+            if len(nns) > 0:
+                for n in nns:
+                    if exclude_self and (i == n.index) and (n.nn_distance <= numerical_tol):
+                        continue
+                    center_indices.append(i)
+                    points_indices.append(n.index)
+                    offsets.append(n.image)
+                    distances.append(n.nn_distance)
+        return tuple((np.array(center_indices), np.array(points_indices),
+                     np.array(offsets), np.array(distances)))
+
+    def get_neighbor_list(self, r: float,
+                          sites: List[PeriodicSite] = None,
+                          numerical_tol: float = 1e-8,
+                          exclude_self: bool = True) -> Tuple[np.ndarray, ...]:
+        """
+        Get neighbor lists using numpy array representations without constructing
+        Neighbor objects. If the cython extension is installed,  this method will
+        be orders of magnitude faster than `get_all_neighbors`.
+        The returned values are a list of numpy arrays
+        [center_indices, points_indices, offset_vectors, distances].
+        Atom `center_indices[i]` has neighbor atom `points_indices[i]` that is
+        translated by `offset_vectors[i]` lattice vectors, and the distance is
+        `distances[i]`.
+
+        Args:
+            r (float): Radius of sphere
+            sites (list of Sites or None): sites for getting all neighbors,
+                default is None, which means neighbors will be obtained for all
+                sites. This is useful in the situation where you are interested
+                only in one subspecies type, and makes it a lot faster.
+            numerical_tol (float): This is a numerical tolerance for distances.
+                Sites which are < numerical_tol are determined to be conincident
+                with the site. Sites which are r + numerical_tol away is deemed
+                to be within r from the site. The default of 1e-8 should be
+                ok in most instances.
+            exclude_self (bool): whether to exclude atom neighboring with itself within
+                numerical tolerance distance, default to True
+        Returns: [center_indices, points_indices, offset_vectors, distances]
+
+        """
+        try:
+            from pymatgen.optimization.neighbors import find_points_in_spheres  # type: ignore
+        except ImportError:
+            return self._get_neighbor_list_py(r, sites, exclude_self=exclude_self)
+        else:
+            if sites is None:
+                sites = self.sites
+            site_coords = np.array([site.coords for site in sites], dtype=float)
+            cart_coords = np.ascontiguousarray(np.array(self.cart_coords), dtype=float)
+            lattice_matrix = np.ascontiguousarray(np.array(self.lattice.matrix), dtype=float)
+            r = float(r)
+            center_indices, points_indices, images, distances = \
+                find_points_in_spheres(cart_coords, site_coords, r=r,
+                                       pbc=np.array([1, 1, 1], dtype=int),
+                                       lattice=lattice_matrix, tol=numerical_tol)
+            cond = np.array([True] * len(center_indices))
+            if exclude_self:
+                self_pair = (center_indices == points_indices) & (distances <= numerical_tol)
+                cond = ~self_pair
+            return tuple((center_indices[cond], points_indices[cond],
+                         images[cond], distances[cond]))
+
     def get_all_neighbors(self, r: float,
                           include_index: bool = False,
                           include_image: bool = False,
@@ -1269,53 +1365,41 @@ class IStructure(SiteCollection, MSONable):
             [PeriodicNeighbor] where PeriodicNeighbor is a namedtuple containing
             (site, distance, index, image).
         """
-        try:
-            from pymatgen.optimization.neighbors import find_points_in_spheres  # type: ignore
-        except ImportError:
-            return self.get_all_neighbors_py(r=r, include_index=include_index, include_image=include_image,
-                                             sites=sites, numerical_tol=numerical_tol)
-        else:
-            if sites is None:
-                sites = self.sites
-            site_coords = np.array([site.coords for site in sites], dtype=float)
-            cart_coords = np.ascontiguousarray(np.array(self.cart_coords), dtype=float)
-            lattice_matrix = np.ascontiguousarray(np.array(self.lattice.matrix), dtype=float)
-            r = float(r)
-            center_indices, points_indices, images, distances = \
-                find_points_in_spheres(cart_coords, site_coords, r=r,
-                                       pbc=np.array([1, 1, 1], dtype=int),
-                                       lattice=lattice_matrix, tol=numerical_tol)
-            if len(points_indices) < 1:
-                return [[]] * len(sites)
-            f_coords = self.frac_coords[points_indices] + images
-            neighbor_dict: Dict[int, List] = collections.defaultdict(list)
-            lattice = self.lattice
-            atol = Site.position_atol
-            all_sites = self.sites
-            for cindex, pindex, image, f_coord, d in zip(center_indices, points_indices, images, f_coords, distances):
-                psite = all_sites[pindex]
-                csite = sites[cindex]
-                if (d > numerical_tol or
-                        # This simply compares the psite and csite. The reason why manual comparison is done is
-                        # for speed. This does not check the lattice since they are always equal. Also, the or construct
-                        # returns True immediately once one of the conditions are satisfied.
-                        psite.species != csite.species or
-                        (not np.allclose(psite.coords, csite.coords, atol=atol)) or
-                        (not psite.properties == csite.properties)):
-                    neighbor_dict[cindex].append(PeriodicNeighbor(
-                        species=psite.species,
-                        coords=f_coord,
-                        lattice=lattice,
-                        properties=psite.properties,
-                        nn_distance=d,
-                        index=pindex,
-                        image=tuple(image)))
+        if sites is None:
+            sites = self.sites
+        center_indices, points_indices, images, distances = \
+            self.get_neighbor_list(r=r, sites=sites, numerical_tol=numerical_tol)
+        if len(points_indices) < 1:
+            return [[]] * len(sites)
+        f_coords = self.frac_coords[points_indices] + images
+        neighbor_dict: Dict[int, List] = collections.defaultdict(list)
+        lattice = self.lattice
+        atol = Site.position_atol
+        all_sites = self.sites
+        for cindex, pindex, image, f_coord, d in zip(center_indices, points_indices, images, f_coords, distances):
+            psite = all_sites[pindex]
+            csite = sites[cindex]
+            if (d > numerical_tol or
+                    # This simply compares the psite and csite. The reason why manual comparison is done is
+                    # for speed. This does not check the lattice since they are always equal. Also, the or construct
+                    # returns True immediately once one of the conditions are satisfied.
+                    psite.species != csite.species or
+                    (not np.allclose(psite.coords, csite.coords, atol=atol)) or
+                    (not psite.properties == csite.properties)):
+                neighbor_dict[cindex].append(PeriodicNeighbor(
+                    species=psite.species,
+                    coords=f_coord,
+                    lattice=lattice,
+                    properties=psite.properties,
+                    nn_distance=d,
+                    index=pindex,
+                    image=tuple(image)))
 
-            neighbors: List[List[PeriodicNeighbor]] = []
+        neighbors: List[List[PeriodicNeighbor]] = []
 
-            for i in range(len(sites)):
-                neighbors.append(neighbor_dict[i])
-            return neighbors
+        for i in range(len(sites)):
+            neighbors.append(neighbor_dict[i])
+        return neighbors
 
     def get_all_neighbors_py(self, r: float,
                              include_index: bool = False,

--- a/pymatgen/core/tests/test_structure.py
+++ b/pymatgen/core/tests/test_structure.py
@@ -405,6 +405,12 @@ class IStructureTest(PymatgenTest):
         all_nn = s.get_all_neighbors(0.05)
         self.assertEqual([len(nn) for nn in all_nn], [0] * len(s))
 
+    def test_get_neighbor_list(self):
+        s = self.struct
+        c_indices1, c_indices2, c_offsets, c_distances = s.get_neighbor_list(3)
+        p_indices1, p_indices2, p_offsets, p_distances = s._get_neighbor_list_py(3)
+        self.assertArrayAlmostEqual(sorted(c_distances), sorted(p_distances))
+
     @unittest.skipIf(not os.environ.get("CI"), "Only run this in CI tests.")
     def test_get_all_neighbors_crosscheck_old(self):
         warnings.simplefilter("ignore")

--- a/setup.py
+++ b/setup.py
@@ -31,14 +31,14 @@ if sys.platform.startswith('win') and platform.machine().endswith('64'):
     extra_link_args.append('-Wl,--allow-multiple-definition')
 
 cpp_extra_link_args = extra_link_args
-cpp_extra_compile_args = ["-Wno-cpp", "-Wno-unused-function", "-O2", "-march=native", '-std=c++11']
+cpp_extra_compile_args = ["-Wno-cpp", "-Wno-unused-function", "-O2", "-march=native", '-std=c++0x']
 if sys.platform.startswith('darwin'):
     cpp_extra_compile_args.append("-stdlib=libc++")
     cpp_extra_link_args = ["-O2", "-march=native", '-stdlib=libc++']
 
 # https://docs.microsoft.com/en-us/cpp/build/reference/compiler-options-listed-alphabetically?view=vs-2017
 if sys.platform.startswith('win'):
-    cpp_extra_compile_args = ['/w', '/O2', '/std:c++14']
+    cpp_extra_compile_args = ['/w', '/O2', '/std:c++0x']
     cpp_extra_link_args = extra_link_args
 
 long_desc = """


### PR DESCRIPTION
## Summary

Added a Structure method to construct neighbor list without using Neighbor class. Previously this is achieved by using `get_all_neighbors` method, which is much slower than the proposed methods.  It may become a problem when the structure is very large, e.g., >10,000 atoms.

Here I am adding a new method `get_neighbor_list` to `Structure`, that returns the full information about neighbors without the use of many python native objects. This new method returns a tuple of numpy array `(center_indices, points_indices, offset_vectors, distances)` as the neighbors. Here atom `center_indices[i]` has neighbor atom index `points_indices[i]` that is translated by `offset_vectors[i]` lattice vectors, and the distance between them is `distances[i]`.  

For a Mo structure with atom numbers of `1000` ([10, 10, 10] supercell), `10,000` ([10, 10, 100] supercell) and `100,000 ` ([10, 10, 1000] supercells), constructing the neighbor list of radius 4 in this way takes about `0.04`, `0.24` and `2.37` seconds, respectively using 2.7 GHz Dual-Core Intel Core i5.  `get_all_neighbors` (not including the time it takes to convert neighbors to numpy format) is about five times slower.  I think this method is highly needed for high-performance materials computations, for example, in the construction of force fields, machine learning, etc. 

Before a pull request can be merged, the following items must be checked:

- [Y] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). 
      Run [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/) and [flake8](http://flake8.pycqa.org/en/latest/)
      on your local machine.
- [Y] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [Y ] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) 
      to type check your code.
- [ Y] Tests have been added for any new functionality or bug fixes.
- [ Y] All existing tests pass.

Note that the CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR. It is
highly recommended that you use the pre-commit hook provided in the pymatgen 
repository. Simply `cp pre-commit .git/hooks` and a check will be run prior to
allowing commits.
