### PR TITLE
Bug fix: remove occasional blank line that makes CHGCAR unreadable

### DIFF
--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -3120,7 +3120,8 @@ class VolumetricData(MSONable):
                         lines = []
                     else:
                         lines.append(" ")
-                f.write(" " + "".join(lines) + " \n")
+                if count % 5 != 0:
+                    f.write(" " + "".join(lines) + " \n")
                 f.write("".join(self.data_aug.get(data_type, [])))
 
             write_spin("total")


### PR DESCRIPTION
## Summary

* Fix 1: When writing CHGCAR files, if a full line is already output in the last step of the for loop, additional blank line is no longer added.