### PR TITLE
Element sorting in Phase Diagram

### DIFF
--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -339,6 +339,7 @@ class PhaseDiagram(MSONable):
                 elements.update(entry.composition.elements)
             elements = sorted(list(elements))
 
+        elements = list(elements)
         dim = len(elements)
 
         entries = sorted(entries, key=lambda e: e.composition.reduced_composition)

--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -329,7 +329,9 @@ class PhaseDiagram(MSONable):
                 energy, energy_per_atom and composition.
             elements ([Element]): Optional list of elements in the phase
                 diagram. If set to None, the elements are determined from
-                the the entries themselves.
+                the the entries themselves and are sorted alphabetically.
+                If specified, element ordering (e.g. for pd coordinates)
+                is preserved.
         """
         if elements is None:
             elements = set()

--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -335,7 +335,8 @@ class PhaseDiagram(MSONable):
             elements = set()
             for entry in entries:
                 elements.update(entry.composition.elements)
-        elements = list(elements)
+            elements = sorted(list(elements))
+
         dim = len(elements)
 
         entries = sorted(entries, key=lambda e: e.composition.reduced_composition)

--- a/pymatgen/analysis/tests/test_phase_diagram.py
+++ b/pymatgen/analysis/tests/test_phase_diagram.py
@@ -147,6 +147,24 @@ class PhaseDiagramTest(unittest.TestCase):
             lines, stable_entries, unstable_entries = plotter.pd_plot_data
             self.assertEqual(lines[0][1], [0, 0])
 
+    def test_ordering(self):
+        # Test sorting of elements
+        entries = [ComputedEntry(Composition(formula), 0)
+                   for formula in ['O', 'N', 'Fe']]
+        pd = PhaseDiagram(entries)
+        sorted_elements = (Element('Fe'), Element('N'), Element('O'))
+        self.assertEqual(tuple(pd.elements), sorted_elements)
+
+        entries.reverse()
+        pd = PhaseDiagram(entries)
+        self.assertEqual(tuple(pd.elements), sorted_elements)
+
+        # Test manual specification of order
+        ordering = [Element(elt_string)
+                    for elt_string in ['O', 'N', 'Fe']]
+        pd = PhaseDiagram(entries, elements=ordering)
+        self.assertEqual(tuple(pd.elements), tuple(ordering))
+
     def test_stable_entries(self):
         stable_formulas = [ent.composition.reduced_formula
                            for ent in self.pd.stable_entries]

--- a/pymatgen/analysis/tests/test_phase_diagram.py
+++ b/pymatgen/analysis/tests/test_phase_diagram.py
@@ -392,7 +392,7 @@ class PhaseDiagramTest(unittest.TestCase):
                     Element("O"): -6.969907375000003}
 
         for elem, energy in cpresult.items():
-            self.assertAlmostEqual(cp1['FeO-LiFeO2-Fe3O4'][elem], energy)
+            self.assertAlmostEqual(cp1['Fe3O4-FeO-LiFeO2'][elem], energy)
 
         cp2 = self.pd.get_all_chempots(c2)
         cpresult = {Element("O"): -7.115354140000001,


### PR DESCRIPTION
## Summary

Sorts elements determined from entries, if elements are not explicitly specified.  Adds test for to ensure that specified element order is respected and that unspecified element orderings result in the same ordering.  Addresses #1721 .