### PR TITLE
add potcar_spec option to write_input

### DIFF
--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -177,7 +177,7 @@ class VaspInputSet(MSONable, metaclass=abc.ABCMeta):
                 not have a license to specific Potcar files. Given a "POTCAR.spec",
                 the specific POTCAR file can be re-generated using pymatgen with the
                 "generate_potcar" function in the pymatgen CLI.
-            zip_output (bool): If True, output will be zipped into a file with the 
+            zip_output (bool): If True, output will be zipped into a file with the
                 same name as the InputSet (e.g., MPStaticSet.zip)
         """
         vinput = self.get_vasp_input()
@@ -201,11 +201,11 @@ class VaspInputSet(MSONable, metaclass=abc.ABCMeta):
             s = vinput["POSCAR"].structure
             cifname = Path(output_dir) / ("%s.cif" % re.sub(r"\s", "", s.formula))
             s.to(filename=cifname)
-        
+
         if zip_output:
             filename = self.__class__.__name__ + ".zip"
             with ZipFile(filename, "w") as zip:
-                for file in ["INCAR","POSCAR","KPOINTS","POTCAR","POTCAR.spec",cifname]:
+                for file in ["INCAR", "POSCAR", "KPOINTS", "POTCAR", "POTCAR.spec", cifname]:
                     try:
                         zip.write(file)
                         os.remove(file)
@@ -2925,7 +2925,7 @@ def batch_write_input(
                 not have a license to specific Potcar files. Given a "POTCAR.spec",
                 the specific POTCAR file can be re-generated using pymatgen with the
                 "generate_potcar" function in the pymatgen CLI.
-        zip_output (bool): If True, output will be zipped into a file with the 
+        zip_output (bool): If True, output will be zipped into a file with the
             same name as the InputSet (e.g., MPStaticSet.zip)
         **kwargs: Additional kwargs are passed to the vasp_input_set class
             in addition to structure.

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -562,13 +562,13 @@ class MPStaticSetTest(PymatgenTest):
         vis = MPStaticSet(original_structure, standardize=True)
         self.assertFalse(sm.fit(vis.structure, original_structure))
 
-    def test_write_spec(self):
+    def test_write_input_zipped(self):
 
         vis = MPStaticSet(self.get_structure("Si"))
-        vis.write_spec()
+        vis.write_input(output_dir=".", potcar_spec=True, zip_output=True)
 
-        self.assertTrue(os.path.exists("MPStaticSet_spec.zip"))
-        with ZipFile("MPStaticSet_spec.zip", "r") as zip:
+        self.assertTrue(os.path.exists("MPStaticSet.zip"))
+        with ZipFile("MPStaticSet.zip", "r") as zip:
             contents = zip.namelist()
             self.assertSetEqual(
                 set(contents), {"INCAR", "POSCAR", "POTCAR.spec", "KPOINTS"}
@@ -576,7 +576,7 @@ class MPStaticSetTest(PymatgenTest):
             spec = zip.open("POTCAR.spec", "r").read().decode()
             self.assertEqual(spec, "Si")
 
-        os.remove("MPStaticSet_spec.zip")
+        os.remove("MPStaticSet.zip")
 
     def test_conflicting_arguments(self):
         with pytest.raises(ValueError, match="deprecated"):

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -448,9 +448,19 @@ class MITMPRelaxSetTest(PymatgenTest):
         for f in ["INCAR", "KPOINTS", "POSCAR", "POTCAR"]:
             self.assertTrue(os.path.exists(f))
         self.assertFalse(os.path.exists("Fe4P4O16.cif"))
+
         self.mitset.write_input(".", make_dir_if_not_present=True, include_cif=True)
         self.assertTrue(os.path.exists("Fe4P4O16.cif"))
         for f in ["INCAR", "KPOINTS", "POSCAR", "POTCAR", "Fe4P4O16.cif"]:
+            os.remove(f)
+
+        self.mitset.write_input(".", make_dir_if_not_present=True, potcar_spec=True)
+
+        for f in ["INCAR", "KPOINTS", "POSCAR"]:
+            self.assertTrue(os.path.exists(f))
+        self.assertFalse(os.path.exists("POTCAR"))
+        self.assertTrue(os.path.exists("POTCAR.spec"))
+        for f in ["INCAR", "KPOINTS", "POSCAR", "POTCAR.spec"]:
             os.remove(f)
 
     def test_user_potcar_settings(self):


### PR DESCRIPTION
## Summary

Adds a boolean `potcar_spec` option to the `write_input` method of a `VaspInputSet`. When this option is enabled, `write_input` generates a POTCAR.spec file rather than a POTCAR file (similar to the existing `write_spec` method, which outputs a .zip file containing all the inputs.) The purpose of this option is to facilitate sharing of inputs and automated testing in environments where POTCAR files are not available due to licensing. 

In this particular case, I developed some tests for a new atomate workflow in which the input set utilized POTCAR files that are not distributed with pymatgen (see https://github.com/hackingmaterials/atomate/pull/345). It was not possible for the CI testing to call `write_input` on my inputset because of the missing POTCARs. A similar issue affects some of the Ferroelectric workflow tests in atomate.

With this new option in pymatgen, a powerup can be added to atomate to enable the `potcar_spec` option in unittests and avoid problems with missing POTCARs. The existing `write_spec` method is less desirable for this because it outputs a zip file rather than just writing the files into a directory.

@utf and @computron were consulted on this solution.