### PR TITLE
Added horizontal line in DosPlotter

### DIFF
--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -211,6 +211,7 @@ class DosPlotter:
         plt.xlabel('Energies (eV)')
         plt.ylabel('Density of states')
 
+        plt.axhline(y=0,color='k',linestyle='--',linewidth=2)
         plt.legend()
         leg = plt.gca().get_legend()
         ltext = leg.get_texts()  # all the text.Text instance in the legend


### PR DESCRIPTION
## Summary

* Added a horizontal line in DosPlotter. This is helpful when we have spin polarized DOS. 
