### PR TITLE
Refactor write_input() when potcar_spec=True

### DIFF
--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -180,20 +180,22 @@ class VaspInputSet(MSONable, metaclass=abc.ABCMeta):
             zip_output (bool): If True, output will be zipped into a file with the
                 same name as the InputSet (e.g., MPStaticSet.zip)
         """
-        vinput = self.get_vasp_input()
-
         if potcar_spec:
             if make_dir_if_not_present and not os.path.exists(output_dir):
                 os.makedirs(output_dir)
 
-            for k, v in vinput.items():
-                if k == "POTCAR":
-                    with zopen(os.path.join(output_dir, "POTCAR.spec"), "wt") as f:
-                        f.write("\n".join(self.potcar_symbols))
-                elif v is not None:
+            with zopen(os.path.join(output_dir, "POTCAR.spec"), "wt") as f:
+                f.write("\n".join(self.potcar_symbols))
+
+            for k, v in {"INCAR": self.incar,
+                         "POSCAR": self.poscar,
+                         "KPOINTS": self.kpoints
+                         }.items():
+                if k is not None:
                     with zopen(os.path.join(output_dir, k), "wt") as f:
                         f.write(v.__str__())
         else:
+            vinput = self.get_vasp_input()
             vinput.write_input(output_dir, make_dir_if_not_present=make_dir_if_not_present)
 
         cifname = ""


### PR DESCRIPTION
## Summary

This commit refactors 'write_input' so that 'get_vasp_input' is not called when `write_spec` is True. Avoiding the call to `get_vasp_input` is important for testing in systems where no POTCARs are installed. @utf was consulted on this fix as well. See https://github.com/hackingmaterials/atomate/pull/345