### PR TITLE
Automatic setting for NEDOS in MPNonSCFSet

### DIFF
--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -1360,7 +1360,7 @@ class MPNonSCFSet(MPRelaxSet):
 
         if self.mode.lower() == "uniform":
             # use tetrahedron method for DOS and optics calculations
-            incar.update({"ISMEAR": -5, "ISYM": 1})
+            incar.update({"ISMEAR": -5})
         else:
             # if line mode, can't use ISMEAR=-5; also use small sigma to avoid
             # partial occupancies for small band gap materials.

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -1277,6 +1277,7 @@ class MPNonSCFSet(MPRelaxSet):
         prev_incar=None,
         mode="line",
         nedos=2001,
+        dedos=0.005,
         reciprocal_density=100,
         sym_prec=0.1,
         kpoints_line_density=20,
@@ -1316,6 +1317,7 @@ class MPNonSCFSet(MPRelaxSet):
         self.prev_incar = prev_incar
         self.kwargs = kwargs
         self.nedos = nedos
+        self.dedos = dedos
         self.reciprocal_density = reciprocal_density
         self.sym_prec = sym_prec
         self.kpoints_line_density = kpoints_line_density
@@ -1361,8 +1363,7 @@ class MPNonSCFSet(MPRelaxSet):
 
         if self.mode.lower() == "uniform":
             # use tetrahedron method for DOS and optics calculations
-
-            incar.update({"ISMEAR": -5, "ISYM": 2})
+            incar.update({"ISMEAR": -5})
         else:
             # if line mode, can't use ISMEAR=-5; also use small sigma to avoid
             # partial occupancies for small band gap materials.

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -1293,6 +1293,9 @@ class MPNonSCFSet(MPRelaxSet):
             prev_incar (Incar/string): Incar file from previous run.
             mode (str): Line, Uniform or Boltztrap mode supported.
             nedos (int): nedos parameter. Default to 2001.
+            dedos (float): setting nedos=0 and uniform mode in from_prev_calc,
+                an automatic nedos will be calculated using the total energy range
+                divided by the energy step dedos
             reciprocal_density (int): density of k-mesh by reciprocal
                 volume (defaults to 100)
             sym_prec (float): Symmetry precision (for Uniform mode).
@@ -1491,7 +1494,7 @@ class MPNonSCFSet(MPRelaxSet):
                     self.kpoints_line_density * self.small_gap_multiply[1]
                 )
 
-        # automatic setting of nedos using total energy range and energy step dedos
+        # automatic setting of nedos using the total energy range and the energy step dedos
         if self.nedos == 0:
             emax = max([eigs.max() for eigs in vasprun.eigenvalues.values()])
             emin = min([eigs.min() for eigs in vasprun.eigenvalues.values()])

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -1496,7 +1496,7 @@ class MPNonSCFSet(MPRelaxSet):
             emax = max([eigs.max() for eigs in vasprun.eigenvalues.values()])
             emin = min([eigs.min() for eigs in vasprun.eigenvalues.values()])
             self.nedos = int((emax - emin) / self.dedos) 
-            
+
         return self
 
     @classmethod

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -1363,7 +1363,7 @@ class MPNonSCFSet(MPRelaxSet):
 
         if self.mode.lower() == "uniform":
             # use tetrahedron method for DOS and optics calculations
-            incar.update({"ISMEAR": -5})
+            incar.update({"ISMEAR": -5, "ISYM": 2})
         else:
             # if line mode, can't use ISMEAR=-5; also use small sigma to avoid
             # partial occupancies for small band gap materials.

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -604,7 +604,7 @@ class MPNonSCFSetTest(PymatgenTest):
         self.assertEqual(vis.incar["ISMEAR"], -5)
 
         # check uniform mode with automatic nedos
-        vis = MPNonSCFSet.from_prev_calc(prev_calc_dir=prev_run, mode="Uniform"
+        vis = MPNonSCFSet.from_prev_calc(prev_calc_dir=prev_run, mode="Uniform",
                                          nedos=0)
         self.assertEqual(vis.incar["NEDOS"], 12217)
 

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -603,6 +603,11 @@ class MPNonSCFSetTest(PymatgenTest):
         vis = MPNonSCFSet.from_prev_calc(prev_calc_dir=prev_run, mode="Uniform")
         self.assertEqual(vis.incar["ISMEAR"], -5)
 
+        # check uniform mode with automatic nedos
+        vis = MPNonSCFSet.from_prev_calc(prev_calc_dir=prev_run, mode="Uniform"
+                                         nedos=0)
+        self.assertEqual(vis.incar["NEDOS"], 12217)
+
         # test line mode
         vis = MPNonSCFSet.from_prev_calc(
             prev_calc_dir=prev_run,
@@ -655,6 +660,10 @@ class MPNonSCFSetTest(PymatgenTest):
         vis.override_from_prev_calc(prev_calc_dir=prev_run)
         self.assertEqual(vis.incar["ISMEAR"], -5)
 
+        vis = MPNonSCFSet(_dummy_structure, mode="Uniform",nedos=0)
+        vis.override_from_prev_calc(prev_calc_dir=prev_run)
+        self.assertEqual(vis.incar["NEDOS"], 12217)
+        
         # test line mode
         vis = MPNonSCFSet(
             _dummy_structure,

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -660,7 +660,7 @@ class MPNonSCFSetTest(PymatgenTest):
         vis.override_from_prev_calc(prev_calc_dir=prev_run)
         self.assertEqual(vis.incar["ISMEAR"], -5)
 
-        vis = MPNonSCFSet(_dummy_structure, mode="Uniform",nedos=0)
+        vis = MPNonSCFSet(_dummy_structure, mode="Uniform", nedos=0)
         vis.override_from_prev_calc(prev_calc_dir=prev_run)
         self.assertEqual(vis.incar["NEDOS"], 12217)
         


### PR DESCRIPTION
As discussed with @mkhorton, here an implemention of
an automatic setting for NEDOS for "uniform" mode in MPNonSCFSet.
It reads the max and min of eigenvalues from previous vasprun and use
a default energy step, called dedos, set at 0.005eV.

It works setting nedos=0 in from_prev_calc() method:
mpset = MPNonSCFSet.from_prev_calc(prev_static_dir,mode="uniform",nedos=0)  

Let me know if it's ok or it need to be implemented differently.