### PR TITLE
MPScanRelaxSet: fix bug and add write_input test

### DIFF
--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -191,7 +191,7 @@ class VaspInputSet(MSONable, metaclass=abc.ABCMeta):
                          "POSCAR": self.poscar,
                          "KPOINTS": self.kpoints
                          }.items():
-                if k is not None:
+                if v is not None:
                     with zopen(os.path.join(output_dir, k), "wt") as f:
                         f.write(v.__str__())
         else:

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -1327,6 +1327,18 @@ class MPScanRelaxSetTest(PymatgenTest):
         self.assertEqual(type(v), MPScanRelaxSet)
         self.assertEqual(v._config_dict["INCAR"]["METAGGA"], "SCAN")
         self.assertEqual(v.user_incar_settings["NSW"], 500)
+    
+    def test_write_input(self):
+        self.mp_scan_set.write_input(
+            "."
+        )
+        self.assertTrue(os.path.exists("INCAR"))
+        self.assertFalse(os.path.exists("KPOINTS"))
+        self.assertTrue(os.path.exists("POTCAR"))
+        self.assertTrue(os.path.exists("POSCAR"))
+
+        for f in ["INCAR", "POSCAR", "POTCAR"]:
+            os.remove(f)
 
 
 class FuncTest(PymatgenTest):


### PR DESCRIPTION
Recent changes to `write_input` contained a bug regarding cases in which there was no KPOINTS file. In such cases, `write_input` would still write an empty file, causing problems with downstream logic.