### PR TITLE
Update OpenBabel; Fix NN classes, graph classes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   # - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
-  - conda create -q -n test-environment python=3.7 numpy scipy matplotlib sympy cython pandas networkx pytest h5py git
+  - conda create -q -n test-environment python=3.7 numpy scipy matplotlib sympy cython pandas<1.0 networkx pytest h5py git
   - source activate test-environment
   - conda update --quiet --yes numpy scipy matplotlib sympy cython pandas networkx pytest pip h5py
   - pip install --quiet --ignore-installed -r requirements.txt -r requirements-optional.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   # - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
-  - conda create -q -n test-environment python=3.7 numpy scipy matplotlib sympy cython pandas<1.0 networkx pytest h5py git
+  - conda create -q -n test-environment python=3.7 numpy scipy matplotlib sympy cython pandas==0.25.3 networkx pytest h5py git
   - source activate test-environment
   - conda update --quiet --yes numpy scipy matplotlib sympy cython pandas networkx pytest pip h5py
   - pip install --quiet --ignore-installed -r requirements.txt -r requirements-optional.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
   - conda info -a
   - conda create -q -n test-environment python=3.7 numpy scipy matplotlib sympy cython pandas==0.25.3 networkx pytest h5py git
   - source activate test-environment
-  - conda update --quiet --yes numpy scipy matplotlib sympy cython pandas networkx pytest pip h5py
+  - conda update --quiet --yes numpy scipy matplotlib sympy cython networkx pytest pip h5py
   - pip install --quiet --ignore-installed -r requirements.txt -r requirements-optional.txt
   - >-
     echo "backend: Agg" > matplotlibrc

--- a/pymatgen/analysis/bond_dissociation.py
+++ b/pymatgen/analysis/bond_dissociation.py
@@ -98,9 +98,7 @@ class BondDissociationEnergies(MSONable):
 
         # Build principle molecule graph
         self.mol_graph = MoleculeGraph.with_local_env_strategy(Molecule.from_dict(molecule_entry["final_molecule"]),
-                                                               OpenBabelNN(),
-                                                               reorder=False,
-                                                               extend_structure=False)
+                                                               OpenBabelNN())
         # Loop through bonds, aka graph edges, and fragment and process:
         for bond in self.mol_graph.graph.edges:
             bonds = [(bond[0], bond[1])]
@@ -290,13 +288,9 @@ class BondDissociationEnergies(MSONable):
             # Build initial and final molgraphs:
             entry["initial_molgraph"] = MoleculeGraph.with_local_env_strategy(
                 Molecule.from_dict(entry["initial_molecule"]),
-                OpenBabelNN(),
-                reorder=False,
-                extend_structure=False)
+                OpenBabelNN())
             entry["final_molgraph"] = MoleculeGraph.with_local_env_strategy(Molecule.from_dict(entry["final_molecule"]),
-                                                                            OpenBabelNN(),
-                                                                            reorder=False,
-                                                                            extend_structure=False)
+                                                                            OpenBabelNN())
             # Classify any potential structural change that occured during optimization:
             if entry["initial_molgraph"].isomorphic_to(entry["final_molgraph"]):
                 entry["structure_change"] = "no_change"

--- a/pymatgen/analysis/fragmenter.py
+++ b/pymatgen/analysis/fragmenter.py
@@ -71,9 +71,7 @@ class Fragmenter(MSONable):
         self.opt_steps = opt_steps
 
         if edges is None:
-            self.mol_graph = MoleculeGraph.with_local_env_strategy(molecule, OpenBabelNN(),
-                                                                   reorder=False,
-                                                                   extend_structure=False)
+            self.mol_graph = MoleculeGraph.with_local_env_strategy(molecule, OpenBabelNN())
         else:
             edges = {(e[0], e[1]): None for e in edges}
             self.mol_graph = MoleculeGraph.with_edges(molecule, edges)
@@ -296,8 +294,7 @@ def open_ring(mol_graph, bond, opt_steps):
     obmol = BabelMolAdaptor.from_molecule_graph(mol_graph)
     obmol.remove_bond(bond[0][0] + 1, bond[0][1] + 1)
     obmol.localopt(steps=opt_steps, forcefield='uff')
-    return MoleculeGraph.with_local_env_strategy(obmol.pymatgen_mol, OpenBabelNN(), reorder=False,
-                                                 extend_structure=False)
+    return MoleculeGraph.with_local_env_strategy(obmol.pymatgen_mol, OpenBabelNN())
 
 
 def metal_edge_extender(mol_graph):

--- a/pymatgen/analysis/functional_groups.py
+++ b/pymatgen/analysis/functional_groups.py
@@ -92,9 +92,7 @@ class FunctionalGroupExtractor:
 
         if self.molgraph is None:
             self.molgraph = MoleculeGraph.with_local_env_strategy(self.molecule,
-                                                                  OpenBabelNN(),
-                                                                  reorder=False,
-                                                                  extend_structure=False)
+                                                                  OpenBabelNN())
 
         # Assign a specie and coordinates to each node in the graph,
         # corresponding to the Site in the Molecule object

--- a/pymatgen/analysis/graphs.py
+++ b/pymatgen/analysis/graphs.py
@@ -1666,8 +1666,7 @@ class MoleculeGraph(MSONable):
         return mg
 
     @staticmethod
-    def with_local_env_strategy(molecule, strategy, reorder=True,
-                                extend_structure=True):
+    def with_local_env_strategy(molecule, strategy):
         """
         Constructor for MoleculeGraph, using a strategy
         from :Class: `pymatgen.analysis.local_env`.
@@ -1675,13 +1674,16 @@ class MoleculeGraph(MSONable):
         :param molecule: Molecule object
         :param strategy: an instance of a
             :Class: `pymatgen.analysis.local_env.NearNeighbors` object
-        :param reorder: bool, representing if graph nodes need to be reordered
-            following the application of the local_env strategy
-        :param extend_structure: If True (default), then a large artificial box
-            will be placed around the Molecule, because some strategies assume
-            periodic boundary conditions.
         :return: mg, a MoleculeGraph
         """
+
+        if not strategy.molecules_allowed:
+            raise ValueError("Chosen strategy is not designed for use with molecules! "
+                             "Please choose another strategy.")
+        if strategy.extend_structure_molecules:
+            extend_structure = True
+        else:
+            extend_structure = False
 
         mg = MoleculeGraph.with_empty_graph(molecule, name="bonds",
                                             edge_weight_name="weight",
@@ -1696,10 +1698,16 @@ class MoleculeGraph(MSONable):
             b = max(coords[:, 1]) - min(coords[:, 1]) + 100
             c = max(coords[:, 2]) - min(coords[:, 2]) + 100
 
-            molecule = molecule.get_boxed_structure(a, b, c, no_cross=True)
+            structure = molecule.get_boxed_structure(a, b, c, no_cross=True)
+        else:
+            structure = None
 
         for n in range(len(molecule)):
-            neighbors = strategy.get_nn_info(molecule, n)
+
+            if structure is None:
+                neighbors = strategy.get_nn_info(molecule, n)
+            else:
+                neighbors = strategy.get_nn_info(structure, n)
             for neighbor in neighbors:
 
                 # all bonds in molecules should not cross
@@ -1707,20 +1715,36 @@ class MoleculeGraph(MSONable):
                 if not np.array_equal(neighbor['image'], [0, 0, 0]):
                     continue
 
-                # local_env will always try to add two edges
-                # for any one bond, one from site u to site v
-                # and another form site v to site u: this is
-                # harmless, so warn_duplicates=False
-                mg.add_edge(from_index=n,
-                            to_index=neighbor['site_index'],
+                if n > neighbor['site_index']:
+                    from_index = neighbor['site_index']
+                    to_index = n
+                else:
+                    from_index = n
+                    to_index = neighbor['site_index']
+
+                mg.add_edge(from_index=from_index,
+                            to_index=to_index,
                             weight=neighbor['weight'],
                             warn_duplicates=False)
 
-        if reorder:
-            # Reverse order of nodes to match with molecule
-            n = len(mg.molecule)
-            mapping = {i: (n - i) for i in range(n)}
-            mapping = {i: (j - 1) for i, j in mapping.items()}
+        if extend_structure:
+            # Structure has different ordering than Molecule, generally
+            # Map back from one ordering to another
+            centered = molecule.get_centered_molecule()
+
+            mapping = {}
+            for s, ssite in enumerate(structure):
+                x = ssite.coords[0] - structure.lattice.a/2
+                y = ssite.coords[1] - structure.lattice.b/2
+                z = ssite.coords[2] - structure.lattice.c/2
+                scoords = (x, y, z)
+                for m, msite in enumerate(centered):
+                    match = True
+                    for i in range(3):
+                        if abs(scoords[i] - msite.coords[i]) > 0.001:
+                            match = False
+                    if match:
+                        mapping[s] = m
 
             mg.graph = nx.relabel_nodes(mg.graph, mapping)
 
@@ -2145,8 +2169,7 @@ class MoleculeGraph(MSONable):
         return unique_mol_graph_dict
 
     def substitute_group(self, index, func_grp, strategy, bond_order=1,
-                         graph_dict=None, strategy_params=None, reorder=True,
-                         extend_structure=True):
+                         graph_dict=None, strategy_params=None):
         """
         Builds off of Molecule.substitute to replace an atom in self.molecule
         with a functional group. This method also amends self.graph to
@@ -2154,8 +2177,6 @@ class MoleculeGraph(MSONable):
 
         NOTE: using a MoleculeGraph will generally produce a different graph
         compared with using a Molecule or str (when not using graph_dict).
-        This is because of the reordering that occurs when using some of the
-        local_env strategies.
 
         :param index: Index of atom to substitute.
         :param func_grp: Substituent molecule. There are three options:
@@ -2183,11 +2204,6 @@ class MoleculeGraph(MSONable):
                 a list of strategies defined in pymatgen.analysis.local_env.
         :param strategy_params: dictionary of keyword arguments for strategy.
                 If None, default parameters will be used.
-        :param reorder: bool, representing if graph nodes need to be reordered
-                following the application of the local_env strategy
-        :param extend_structure: If True (default), then a large artificial box
-                will be placed around the Molecule, because some strategies assume
-                periodic boundary conditions.
         :return:
         """
 
@@ -2251,8 +2267,7 @@ class MoleculeGraph(MSONable):
                 if strategy_params is None:
                     strategy_params = {}
                 strat = strategy(**strategy_params)
-                graph = self.with_local_env_strategy(func_grp, strat, reorder=reorder,
-                                                     extend_structure=extend_structure)
+                graph = self.with_local_env_strategy(func_grp, strat)
 
                 for (u, v) in list(graph.graph.edges()):
                     edge_props = graph.graph.get_edge_data(u, v)[0]
@@ -2269,8 +2284,7 @@ class MoleculeGraph(MSONable):
                                   weight=weight, edge_properties=edge_props)
 
     def replace_group(self, index, func_grp, strategy, bond_order=1,
-                      graph_dict=None, strategy_params=None, reorder=True,
-                      extend_structure=True):
+                      graph_dict=None, strategy_params=None):
         """
         Builds off of Molecule.substitute and MoleculeGraph.substitute_group
         to replace a functional group in self.molecule with a functional group.
@@ -2305,11 +2319,6 @@ class MoleculeGraph(MSONable):
             a list of strategies defined in pymatgen.analysis.local_env.
         :param strategy_params: dictionary of keyword arguments for strategy.
             If None, default parameters will be used.
-        :param reorder: bool, representing if graph nodes need to be reordered
-            following the application of the local_env strategy
-        :param extend_structure: If True (default), then a large artificial box
-            will be placed around the Molecule, because some strategies assume
-            periodic boundary conditions.
         :return:
         """
 
@@ -2320,9 +2329,7 @@ class MoleculeGraph(MSONable):
         if len(neighbors) == 1:
             self.substitute_group(index, func_grp, strategy,
                                   bond_order=bond_order, graph_dict=graph_dict,
-                                  strategy_params=strategy_params,
-                                  reorder=reorder,
-                                  extend_structure=extend_structure)
+                                  strategy_params=strategy_params)
 
         else:
             rings = self.find_rings(including=[index])
@@ -2345,11 +2352,10 @@ class MoleculeGraph(MSONable):
 
             self.remove_nodes(list(to_remove))
 
-            self.substitute_group(index, func_grp, strategy,
-                                  bond_order=bond_order, graph_dict=graph_dict,
-                                  strategy_params=strategy_params,
-                                  reorder=reorder,
-                                  extend_structure=extend_structure)
+            self.group = self.substitute_group(index, func_grp, strategy,
+                                               bond_order=bond_order,
+                                               graph_dict=graph_dict,
+                                               strategy_params=strategy_params)
 
     def find_rings(self, including=None):
         """

--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -1228,8 +1228,9 @@ class OpenBabelNN(NearNeighbors):
     """
 
     @requires(ob,
-              "OpenBabelNN requires openbabel to be installed with "
-              "Python bindings. Please get it at http://openbabel.org.")
+              "BabelMolAdaptor requires openbabel to be installed with "
+              "Python bindings. Please get it at http://openbabel.org "
+              "(version >=3.0.0).")
     def __init__(self, order=True):
         """
         Args:

--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -38,10 +38,8 @@ from math import pow, pi, asin, sqrt, exp, sin, cos, acos, fabs, atan2
 import numpy as np
 
 try:
-    import openbabel as ob
-    import pybel as pb
+    from openbabel import openbabel as ob
 except Exception:
-    pb = None
     ob = None
 
 from monty.dev import requires
@@ -1182,7 +1180,7 @@ class OpenBabelNN(NearNeighbors):
     structures.
     """
 
-    @requires(pb and ob,
+    @requires(ob,
               "OpenBabelNN requires openbabel to be installed with "
               "Python bindings. Please get it at http://openbabel.org.")
     def __init__(self, order=True):

--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -233,6 +233,21 @@ class NearNeighbors:
     def __hash__(self):
         return len(self.__dict__.items())
 
+    @property
+    def structures_allowed(self):
+        raise NotImplementedError("structures_allowed"
+                                  " is not defined!")
+
+    @property
+    def molecules_allowed(self):
+        raise NotImplementedError("molecules_allowed"
+                                  " is not defined!")
+
+    @property
+    def extend_structure_molecules(self):
+        raise NotImplementedError("extend_structures_molecule"
+                                  " is not defined!")
+
     def get_cn(self, structure, n, use_weights=False):
         """
         Get coordination number, CN, of site with index n in structure.
@@ -623,6 +638,14 @@ class VoronoiNN(NearNeighbors):
         self.weight = weight
         self.extra_nn_info = extra_nn_info
         self.compute_adj_neighbors = compute_adj_neighbors
+
+    @property
+    def structures_allowed(self):
+        return True
+
+    @property
+    def molecules_allowed(self):
+        return False
 
     def get_voronoi_polyhedra(self, structure, n):
         """
@@ -1050,6 +1073,18 @@ class JmolNN(NearNeighbors):
         if el_radius_updates:
             self.el_radius.update(el_radius_updates)
 
+    @property
+    def structures_allowed(self):
+        return True
+
+    @property
+    def molecules_allowed(self):
+        return True
+
+    @property
+    def extend_structure_molecules(self):
+        return True
+
     def get_max_bond_distance(self, el1_sym, el2_sym):
         """
         Use Jmol algorithm to determine bond length from atomic parameters
@@ -1129,6 +1164,18 @@ class MinimumDistanceNN(NearNeighbors):
         self.cutoff = cutoff
         self.get_all_sites = get_all_sites
 
+    @property
+    def structures_allowed(self):
+        return True
+
+    @property
+    def molecules_allowed(self):
+        return True
+
+    @property
+    def extend_structure_molecules(self):
+        return True
+
     def get_nn_info(self, structure, n):
         """
         Get all near-neighbor sites as well as the associated image locations
@@ -1190,6 +1237,18 @@ class OpenBabelNN(NearNeighbors):
             if bond length should be used as a weight.
         """
         self.order = order
+
+    @property
+    def structures_allowed(self):
+        return False
+
+    @property
+    def molecules_allowed(self):
+        return True
+
+    @property
+    def extend_structure_molecules(self):
+        return False
 
     def get_nn_info(self, structure, n):
         """
@@ -1327,6 +1386,18 @@ class CovalentBondNN(NearNeighbors):
 
         self.bonds = None
 
+    @property
+    def structures_allowed(self):
+        return False
+
+    @property
+    def molecules_allowed(self):
+        return True
+
+    @property
+    def extend_structure_molecules(self):
+        return False
+
     def get_nn_info(self, structure, n):
         """
         Get all near-neighbor sites and weights (orders) of bonds for a given
@@ -1393,7 +1464,7 @@ class CovalentBondNN(NearNeighbors):
                                 for n in range(len(structure))]
             structure.add_site_property('order_parameters', order_parameters)
 
-        mg = MoleculeGraph.with_local_env_strategy(structure, self, extend_structure=False)
+        mg = MoleculeGraph.with_local_env_strategy(structure, self)
 
         return mg
 
@@ -1458,6 +1529,18 @@ class MinimumOKeeffeNN(NearNeighbors):
         """
         self.tol = tol
         self.cutoff = cutoff
+
+    @property
+    def structures_allowed(self):
+        return True
+
+    @property
+    def molecules_allowed(self):
+        return True
+
+    @property
+    def extend_structure_molecules(self):
+        return True
 
     def get_nn_info(self, structure, n):
         """
@@ -1527,6 +1610,14 @@ class MinimumVIRENN(NearNeighbors):
         """
         self.tol = tol
         self.cutoff = cutoff
+
+    @property
+    def structures_allowed(self):
+        return True
+
+    @property
+    def molecules_allowed(self):
+        return False
 
     def get_nn_info(self, structure, n):
         """
@@ -3003,6 +3094,14 @@ class BrunnerNN_reciprocal(NearNeighbors):
         self.tol = tol
         self.cutoff = cutoff
 
+    @property
+    def structures_allowed(self):
+        return True
+
+    @property
+    def molecules_allowed(self):
+        return False
+
     def get_nn_info(self, structure, n):
         """
         Get all near-neighbor sites as well as the associated image locations
@@ -3058,6 +3157,14 @@ class BrunnerNN_relative(NearNeighbors):
         self.tol = tol
         self.cutoff = cutoff
 
+    @property
+    def structures_allowed(self):
+        return True
+
+    @property
+    def molecules_allowed(self):
+        return False
+
     def get_nn_info(self, structure, n):
         """
         Get all near-neighbor sites as well as the associated image locations
@@ -3112,6 +3219,14 @@ class BrunnerNN_real(NearNeighbors):
         """
         self.tol = tol
         self.cutoff = cutoff
+
+    @property
+    def structures_allowed(self):
+        return True
+
+    @property
+    def molecules_allowed(self):
+        return False
 
     def get_nn_info(self, structure, n):
         """
@@ -3171,6 +3286,18 @@ class EconNN(NearNeighbors):
         """
         self.tol = tol
         self.cutoff = cutoff
+
+    @property
+    def structures_allowed(self):
+        return True
+
+    @property
+    def molecules_allowed(self):
+        return True
+
+    @property
+    def extend_structure_molecules(self):
+        return True
 
     def get_nn_info(self, structure, n):
         """
@@ -3258,6 +3385,14 @@ class CrystalNN(NearNeighbors):
         self.search_cutoff = search_cutoff
         self.porous_adjustment = porous_adjustment
         self.fingerprint_length = fingerprint_length
+
+    @property
+    def structures_allowed(self):
+        return True
+
+    @property
+    def molecules_allowed(self):
+        return False
 
     def get_nn_info(self, structure, n):
         """
@@ -3636,6 +3771,18 @@ class CutOffDictNN(NearNeighbors):
                 self._max_dist = dist
         self._lookup_dict = lookup_dict
 
+    @property
+    def structures_allowed(self):
+        return True
+
+    @property
+    def molecules_allowed(self):
+        return True
+
+    @property
+    def extend_structure_molecules(self):
+        return True
+
     @staticmethod
     def from_preset(preset):
         """
@@ -3713,6 +3860,18 @@ class Critic2NN(NearNeighbors):
         # computations
         self.__last_structure = None
         self.__last_bonded_structure = None
+
+    @property
+    def structures_allowed(self):
+        return True
+
+    @property
+    def molecules_allowed(self):
+        return True
+
+    @property
+    def extend_structure_molecules(self):
+        return True
 
     def get_bonded_structure(self, structure, decorate=False):
         """

--- a/pymatgen/analysis/molecule_matcher.py
+++ b/pymatgen/analysis/molecule_matcher.py
@@ -30,7 +30,7 @@ from monty.dev import requires
 from pymatgen.io.babel import BabelMolAdaptor
 
 try:
-    import openbabel as ob
+    from openbabel import openbabel as ob
 except ImportError:
     ob = None
 

--- a/pymatgen/analysis/molecule_matcher.py
+++ b/pymatgen/analysis/molecule_matcher.py
@@ -559,7 +559,8 @@ class MoleculeMatcher(MSONable):
 
     @requires(ob,
               "BabelMolAdaptor requires openbabel to be installed with "
-              "Python bindings. Please get it at http://openbabel.org.")
+              "Python bindings. Please get it at http://openbabel.org "
+              "(version >=3.0.0).")
     def __init__(self, tolerance=0.01, mapper=InchiMolAtomMapper()):
         self._tolerance = tolerance
         self._mapper = mapper

--- a/pymatgen/analysis/tests/test_bond_dissociation.py
+++ b/pymatgen/analysis/tests/test_bond_dissociation.py
@@ -10,7 +10,7 @@ from monty.serialization import loadfn
 from pymatgen.analysis.bond_dissociation import BondDissociationEnergies
 
 try:
-    import openbabel as ob
+    from openbabel import openbabel as ob
 except ImportError:
     ob = None
 

--- a/pymatgen/analysis/tests/test_fragmenter.py
+++ b/pymatgen/analysis/tests/test_fragmenter.py
@@ -11,7 +11,7 @@ from pymatgen.util.testing import PymatgenTest
 from pymatgen.analysis.fragmenter import Fragmenter, metal_edge_extender
 
 try:
-    import openbabel as ob
+    from openbabel import openbabel as ob
 except ImportError:
     ob = None
 
@@ -56,8 +56,7 @@ class TestFragmentMolecule(PymatgenTest):
         fragmenter = Fragmenter(molecule=self.pc, open_rings=True)
         self.assertEqual(fragmenter.open_rings, True)
         self.assertEqual(fragmenter.opt_steps, 10000)
-        default_mol_graph = MoleculeGraph.with_local_env_strategy(self.pc, OpenBabelNN(),
-                                                                  reorder=False, extend_structure=False)
+        default_mol_graph = MoleculeGraph.with_local_env_strategy(self.pc, OpenBabelNN())
         self.assertEqual(fragmenter.mol_graph, default_mol_graph)
         self.assertEqual(fragmenter.total_unique_fragments, 13)
 
@@ -66,8 +65,7 @@ class TestFragmentMolecule(PymatgenTest):
         fragmenter = Fragmenter(molecule=self.pc)
         self.assertEqual(fragmenter.open_rings, False)
         self.assertEqual(fragmenter.opt_steps, 10000)
-        default_mol_graph = MoleculeGraph.with_local_env_strategy(self.pc, OpenBabelNN(),
-                                                                  reorder=False, extend_structure=False)
+        default_mol_graph = MoleculeGraph.with_local_env_strategy(self.pc, OpenBabelNN())
         self.assertEqual(fragmenter.mol_graph, default_mol_graph)
         self.assertEqual(fragmenter.total_unique_fragments, 8)
 

--- a/pymatgen/analysis/tests/test_functional_groups.py
+++ b/pymatgen/analysis/tests/test_functional_groups.py
@@ -15,8 +15,8 @@ test_dir = os.path.join(os.path.dirname(__file__), "..", "..", "..",
                         "test_files", "functional_groups")
 
 try:
-    import openbabel as ob
-    import pybel as pb
+    from openbabel import openbabel as ob
+    from openbabel import pybel as pb
     import networkx as nx
 except ImportError:
     pb = None
@@ -41,9 +41,7 @@ class FunctionalGroupExtractorTest(unittest.TestCase):
         self.file = os.path.join(test_dir, "func_group_test.mol")
         self.mol = Molecule.from_file(self.file)
         self.strat = OpenBabelNN()
-        self.mg = MoleculeGraph.with_local_env_strategy(self.mol, self.strat,
-                                                        reorder=False,
-                                                        extend_structure=False)
+        self.mg = MoleculeGraph.with_local_env_strategy(self.mol, self.strat)
         self.extractor = FunctionalGroupExtractor(self.mg)
 
     def tearDown(self):

--- a/pymatgen/analysis/tests/test_graphs.py
+++ b/pymatgen/analysis/tests/test_graphs.py
@@ -20,7 +20,7 @@ from pymatgen.analysis.local_env import (
 )
 from pymatgen.util.testing import PymatgenTest
 try:
-    import openbabel as ob
+    from openbabel import openbabel as ob
 except ImportError:
     ob = None
 try:
@@ -721,9 +721,7 @@ class MoleculeGraphTest(unittest.TestCase):
                 )
 
         mol_graph_edges = MoleculeGraph.with_edges(self.pc, edges=edges_pc)
-        mol_graph_strat = MoleculeGraph.with_local_env_strategy(
-            self.pc, OpenBabelNN(), reorder=False, extend_structure=False
-        )
+        mol_graph_strat = MoleculeGraph.with_local_env_strategy(self.pc, OpenBabelNN())
         self.assertTrue(mol_graph_edges.isomorphic_to(mol_graph_strat))
 
     def test_properties(self):

--- a/pymatgen/analysis/tests/test_graphs.py
+++ b/pymatgen/analysis/tests/test_graphs.py
@@ -17,6 +17,7 @@ from pymatgen.analysis.local_env import (
     MinimumOKeeffeNN,
     OpenBabelNN,
     CutOffDictNN,
+    VoronoiNN
 )
 from pymatgen.util.testing import PymatgenTest
 try:
@@ -130,6 +131,11 @@ class StructureGraphTest(PymatgenTest):
 
     def tearDown(self):
         warnings.simplefilter("default")
+
+    def test_inappropriate_construction(self):
+        # Check inappropriate strategy
+        with self.assertRaises(ValueError):
+            StructureGraph.with_local_env_strategy(self.NiO, OpenBabelNN())
 
     def test_properties(self):
 
@@ -722,7 +728,12 @@ class MoleculeGraphTest(unittest.TestCase):
 
         mol_graph_edges = MoleculeGraph.with_edges(self.pc, edges=edges_pc)
         mol_graph_strat = MoleculeGraph.with_local_env_strategy(self.pc, OpenBabelNN())
+
         self.assertTrue(mol_graph_edges.isomorphic_to(mol_graph_strat))
+
+        # Check inappropriate strategy
+        with self.assertRaises(ValueError):
+            MoleculeGraph.with_local_env_strategy(self.pc, VoronoiNN())
 
     def test_properties(self):
         self.assertEqual(self.cyclohexene.name, "bonds")

--- a/pymatgen/analysis/tests/test_graphs.py
+++ b/pymatgen/analysis/tests/test_graphs.py
@@ -17,7 +17,8 @@ from pymatgen.analysis.local_env import (
     MinimumOKeeffeNN,
     OpenBabelNN,
     CutOffDictNN,
-    VoronoiNN
+    VoronoiNN,
+    CovalentBondNN
 )
 from pymatgen.util.testing import PymatgenTest
 try:
@@ -135,7 +136,7 @@ class StructureGraphTest(PymatgenTest):
     def test_inappropriate_construction(self):
         # Check inappropriate strategy
         with self.assertRaises(ValueError):
-            StructureGraph.with_local_env_strategy(self.NiO, OpenBabelNN())
+            StructureGraph.with_local_env_strategy(self.NiO, CovalentBondNN())
 
     def test_properties(self):
 

--- a/pymatgen/analysis/tests/test_local_env.py
+++ b/pymatgen/analysis/tests/test_local_env.py
@@ -21,8 +21,8 @@ from pymatgen import Element, Molecule, Structure, Lattice
 from pymatgen.util.testing import PymatgenTest
 
 try:
-    import openbabel as ob
-    import pybel as pb
+    from openbabel import openbabel as ob
+    from openbabel import pybel as pb
 except ImportError:
     pb = None
     ob = None

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -2610,7 +2610,7 @@ class IMolecule(SiteCollection, MSONable):
         Find all sites within a sphere from a point.
 
         Args:
-            pt (3x1 array): Cartesian coordinates of center of sphere.
+            pt (3x1 array): Cartesian coordinates of center of sphere
             r (float): Radius of sphere.
 
         Returns:

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -2661,7 +2661,7 @@ class IMolecule(SiteCollection, MSONable):
 
     def get_boxed_structure(self, a, b, c, images=(1, 1, 1),
                             random_rotation=False, min_dist=1, cls=None,
-                            offset=None, no_cross=False):
+                            offset=None, no_cross=False, reorder=True):
         """
         Creates a Structure from a Molecule by putting the Molecule in the
         center of a orthorhombic box. Useful for creating Structure for
@@ -2686,6 +2686,8 @@ class IMolecule(SiteCollection, MSONable):
             offset: Translation to offset molecule from center of mass coords
             no_cross: Whether to forbid molecule coords from extending beyond
                 boundary of box.
+            reorder: Whether to reorder the sites to be in electronegativity
+                order.
 
         Returns:
             Structure containing molecule in a box.
@@ -2746,9 +2748,14 @@ class IMolecule(SiteCollection, MSONable):
         if cls is None:
             cls = Structure
 
-        return cls(lattice, self.species * nimages, coords,
-                   coords_are_cartesian=True,
-                   site_properties=sprops).get_sorted_structure()
+        if reorder:
+            return cls(lattice, self.species * nimages, coords,
+                       coords_are_cartesian=True,
+                       site_properties=sprops).get_sorted_structure()
+        else:
+            return cls(lattice, self.species * nimages, coords,
+                       coords_are_cartesian=True,
+                       site_properties=sprops)
 
     def get_centered_molecule(self):
         """

--- a/pymatgen/core/tests/test_structure.py
+++ b/pymatgen/core/tests/test_structure.py
@@ -1220,6 +1220,11 @@ Site: H (-0.5134, 0.8892, -0.3630)"""
         self.assertRaises(ValueError, self.mol.get_boxed_structure,
                           5, 5, 5, offset=[10, 10, 10], no_cross=True)
 
+        # Test reorder option
+        no_reorder = self.mol.get_boxed_structure(10, 10, 10, reorder=False)
+        self.assertEqual(str(s3[0].specie), "H")
+        self.assertEqual(str(no_reorder[0].specie), "C")
+
     def test_get_distance(self):
         self.assertAlmostEqual(self.mol.get_distance(0, 1), 1.089)
 

--- a/pymatgen/io/babel.py
+++ b/pymatgen/io/babel.py
@@ -38,7 +38,8 @@ class BabelMolAdaptor:
 
     @requires(ob,
               "BabelMolAdaptor requires openbabel to be installed with "
-              "Python bindings. Please get it at http://openbabel.org.")
+              "Python bindings. Please get it at http://openbabel.org "
+              "(version >=3.0.0).")
     def __init__(self, mol):
         """
         Initializes with pymatgen Molecule or OpenBabel"s OBMol.

--- a/pymatgen/io/babel.py
+++ b/pymatgen/io/babel.py
@@ -10,10 +10,9 @@ from pymatgen.analysis.graphs import MoleculeGraph
 from monty.dev import requires
 
 try:
-    import openbabel as ob
+    from openbabel import openbabel as ob
     from openbabel import pybel as pb
 except Exception:
-    pb = None
     ob = None
 
 """
@@ -37,7 +36,7 @@ class BabelMolAdaptor:
     Molecule.
     """
 
-    @requires(pb and ob,
+    @requires(ob,
               "BabelMolAdaptor requires openbabel to be installed with "
               "Python bindings. Please get it at http://openbabel.org.")
     def __init__(self, mol):
@@ -72,7 +71,6 @@ class BabelMolAdaptor:
             obmol.SetTotalSpinMultiplicity(mol.spin_multiplicity)
             obmol.SetTotalCharge(int(mol.charge))
             obmol.Center()
-            obmol.Kekulize()
             obmol.EndModify()
             self._obmol = obmol
         elif isinstance(mol, ob.OBMol):

--- a/pymatgen/io/babel.py
+++ b/pymatgen/io/babel.py
@@ -11,7 +11,7 @@ from monty.dev import requires
 
 try:
     import openbabel as ob
-    import pybel as pb
+    from openbabel import pybel as pb
 except Exception:
     pb = None
     ob = None

--- a/pymatgen/io/qchem/outputs.py
+++ b/pymatgen/io/qchem/outputs.py
@@ -19,7 +19,7 @@ from pymatgen.analysis.local_env import OpenBabelNN
 import networkx as nx
 
 try:
-    import openbabel as ob
+    from openbabel import openbabel as ob
 
     have_babel = True
 except ImportError:
@@ -1185,14 +1185,10 @@ def check_for_structure_changes(mol1, mol2):
     # Can add logic to check the distances in the future if desired
 
     initial_mol_graph = MoleculeGraph.with_local_env_strategy(mol_list[0],
-                                                              OpenBabelNN(),
-                                                              reorder=False,
-                                                              extend_structure=False)
+                                                              OpenBabelNN())
     initial_graph = initial_mol_graph.graph
     last_mol_graph = MoleculeGraph.with_local_env_strategy(mol_list[1],
-                                                           OpenBabelNN(),
-                                                           reorder=False,
-                                                           extend_structure=False)
+                                                           OpenBabelNN())
     last_graph = last_mol_graph.graph
     if initial_mol_graph.isomorphic_to(last_mol_graph):
         return "no_change"

--- a/pymatgen/io/qchem/tests/test_outputs.py
+++ b/pymatgen/io/qchem/tests/test_outputs.py
@@ -11,7 +11,7 @@ from pymatgen.io.qchem.outputs import QCOutput
 from pymatgen.util.testing import PymatgenTest
 
 try:
-    import openbabel
+    from openbabel import openbabel
 
     have_babel = True
 except ImportError:

--- a/pymatgen/io/tests/test_babel.py
+++ b/pymatgen/io/tests/test_babel.py
@@ -32,11 +32,10 @@ try:
     from openbabel import openbabel as ob
     from openbabel import pybel as pb
 except ImportError:
-    pb = None
     ob = None
 
 
-@unittest.skipIf(not (pb and ob), "OpenBabel not present. Skipping...")
+@unittest.skipIf(not (ob), "OpenBabel not present. Skipping...")
 class BabelMolAdaptorTest(unittest.TestCase):
 
     def setUp(self):

--- a/pymatgen/io/tests/test_babel.py
+++ b/pymatgen/io/tests/test_babel.py
@@ -29,8 +29,8 @@ test_dir = os.path.join(os.path.dirname(__file__), "..", "..", "..",
                         "test_files")
 
 try:
-    import openbabel as ob
-    import pybel as pb
+    from openbabel import openbabel as ob
+    from openbabel import pybel as pb
 except ImportError:
     pb = None
     ob = None

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -17,4 +17,3 @@ mypy==0.761
 pydocstyle==5.0.1
 flake8==3.7.9
 pylint==2.4.4
-openbabel==3.0.0

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -17,3 +17,4 @@ mypy==0.761
 pydocstyle==5.0.1
 flake8==3.7.9
 pylint==2.4.4
+openbabel==3.0.0

--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ setup(
     install_requires=["numpy>=1.14.3", "requests", "ruamel.yaml>=0.15.6",
                       "monty>=3.0.2", "scipy>=1.0.1", "pydispatcher>=2.0.5",
                       "tabulate", "spglib>=1.9.9.44", "networkx>=2.2",
-                      "matplotlib>=1.5", "palettable>=3.1.1", "sympy", "pandas"],
+                      "matplotlib>=1.5", "palettable>=3.1.1", "sympy", "pandas<1.0"],
     extras_require={
         "provenance": ["pybtex"],
         "ase": ["ase>=3.3"],


### PR DESCRIPTION
## Summary

This PR addresses two major issues:

* The recent OpenBabel release 3.0.0 breaks the previous API in several ways, most notably in how the Python interface is imported
* A bug was found in which certain NearNeighbors classes failed to approrpriately detect bonds in molecules

With respect to the second change, all NearNeighbor classes now have properties describing if they can be used with Molecules, Structures, or both. MoleculeGraph and StructureGraph now prevent the user from using with_local_env_strategy with an inappropriate strategy.

Additionally, the bug which caused an automatic re-indexing of Molecules has been identified and fixed.

## Additional dependencies introduced (if any)

* openbabel 3.0.0

## Checklist

- [ ] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). 
      Run [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/) and [flake8](http://flake8.pycqa.org/en/latest/)
      on your local machine.
- [X] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html). (exceptions for some properties)
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [ ] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) 
      to type check your code.
- [X] Tests have been added for any new functionality or bug fixes.
- [x] All existing tests pass.