### PR TITLE
Parse NPLWV, NPLWVs at kpoints from OUTCAR-files into Outcar.data dictionary.

### DIFF
--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -1648,18 +1648,27 @@ class Outcar:
 
         # Read "total number of plane waves", NPLWV:
         self.read_pattern(
-            {"nplwv": r"total plane-waves  NPLWV =\s*(\d+)"},
-            terminate_on_match=True,
-            postprocess=int
+            {"nplwv": r"total plane-waves  NPLWV =\s+(\*{6}|\d+)"},
+            terminate_on_match=True
         )
+        try:
+            self.data["nplwv"] = [[int(self.data["nplwv"][0][0])]]
+        except ValueError:
+            self.data["nplwv"] = [[None]]
 
-        self.data["nplwvs_at_kpoints"] = [
-            int(n) for [n] in self.read_table_pattern(
-                r"\n+",
-                r".+plane waves:\s+(\d+)",
-                r"maximum and minimum number of plane-waves per node"
+        nplwvs_at_kpoints = [
+            n for [n] in self.read_table_pattern(
+                r"\n{3}-{104}\n{3}",
+                r".+plane waves:\s+(\*{6,}|\d+)",
+                r"maximum and minimum number of plane-waves"
             )
         ]
+        self.data["nplwvs_at_kpoints"] = [None for n in nplwvs_at_kpoints]
+        for (n, nplwv) in enumerate(nplwvs_at_kpoints):
+            try:
+                self.data["nplwvs_at_kpoints"][n] = int(nplwv)
+            except ValueError:
+                pass
 
         # Read the drift:
         self.read_pattern({

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -1648,7 +1648,7 @@ class Outcar:
 
         # Read "total number of plane waves", NPLWV:
         self.read_pattern(
-            {"nplwv" : r"total plane-waves  NPLWV =\s*(\d+)"},
+            {"nplwv": r"total plane-waves  NPLWV =\s*(\d+)"},
             terminate_on_match=True,
             postprocess=int
         )
@@ -1660,7 +1660,6 @@ class Outcar:
                 r"maximum and minimum number of plane-waves per node"
             )
         ]
-
 
         # Read the drift:
         self.read_pattern({

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -1646,6 +1646,22 @@ class Outcar:
         self.final_energy = total_energy
         self.data = {}
 
+        # Read "total number of plane waves", NPLWV:
+        self.read_pattern(
+            {"nplwv" : r"total plane-waves  NPLWV =\s*(\d+)"},
+            terminate_on_match=True,
+            postprocess=int
+        )
+
+        self.data["nplwvs_at_kpoints"] = [
+            int(n) for [n] in self.read_table_pattern(
+                r"\n+",
+                r".+plane waves:\s+(\d+)",
+                r"maximum and minimum number of plane-waves per node"
+            )
+        ]
+
+
         # Read the drift:
         self.read_pattern({
             "drift": r"total drift:\s+([\.\-\d]+)\s+([\.\-\d]+)\s+([\.\-\d]+)"},

--- a/pymatgen/io/vasp/tests/test_outputs.py
+++ b/pymatgen/io/vasp/tests/test_outputs.py
@@ -998,6 +998,20 @@ class OutcarTest(PymatgenTest):
         self.assertEqual(len(matrices[0][Spin.up][0]), 7)
         self.assertTrue("onsite_density_matrices" in outcar.as_dict())
 
+    def test_nplwvs(self):
+        outcar = Outcar(self.TEST_FILES_DIR / "OUTCAR")
+        self.assertEqual(outcar.data["nplwv"], [[34560]])
+        self.assertEqual(outcar.data["nplwvs_at_kpoints"],
+                         [1719, 1714, 1722, 1728, 1722, 1726, 1722, 1720, 1717, 1724, 1715, 1724, 1726, 1724, 1728,
+                          1715, 1722, 1715, 1726, 1730, 1730, 1715, 1716, 1729, 1727, 1723, 1721, 1712, 1723, 1719,
+                          1717, 1717, 1724, 1719, 1719, 1727, 1726, 1730, 1719, 1720, 1718, 1717, 1722, 1719, 1709,
+                          1714, 1724, 1726, 1718, 1713, 1720, 1713, 1711, 1713, 1715, 1717, 1728, 1726, 1712, 1722,
+                          1714, 1713, 1717, 1714, 1714, 1717, 1712, 1710, 1721, 1722, 1724, 1720, 1726, 1719, 1722,
+                          1714])
+        outcar = Outcar(self.TEST_FILES_DIR / "OUTCAR.CL")
+        self.assertEqual(outcar.data["nplwv"], [[None]])
+        self.assertEqual(outcar.data["nplwvs_at_kpoints"], [85687])
+
 
 class BSVasprunTest(PymatgenTest):
     _multiprocess_shared_ = True


### PR DESCRIPTION
## Summary

* Parse NPLWV from OUTCAR file using the read_pattern method of Outcar class
* Parse numbers of plane waves at each kpoint from OUTCAR file using the read_table_pattern method of Outcar class

## Checklist

Before a pull request can be merged, the following items must be checked:

- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). 
      Run [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/) and [flake8](http://flake8.pycqa.org/en/latest/)
      on your local machine.
- [x] All existing tests pass.