### PR TITLE
Minor fixes to Zeo++ interface

### DIFF
--- a/pymatgen/io/tests/test_zeopp.py
+++ b/pymatgen/io/tests/test_zeopp.py
@@ -179,7 +179,7 @@ class GetVoronoiNodesTest(unittest.TestCase):
         print(len(vor_face_center_struct.sites))
 
 
-@unittest.skipIf(not zeo, "zeo not present.")
+@unittest.skip("file free_sph.cif not present")
 class GetFreeSphereParamsTest(unittest.TestCase):
     def setUp(self):
         filepath = os.path.join(test_dir, 'free_sph.cif')

--- a/pymatgen/io/zeopp.py
+++ b/pymatgen/io/zeopp.py
@@ -234,11 +234,11 @@ class ZeoVoronoiXYZ(XYZ):
             return ZeoVoronoiXYZ.from_string(f.read())
 
     def __str__(self):
-        output = [str(len(self._mol)), self._mol.composition.formula]
+        output = [str(len(self._mols[0])), self._mols[0].composition.formula]
         fmtstr = "{{}} {{:.{0}f}} {{:.{0}f}} {{:.{0}f}} {{:.{0}f}}".format(
             self.precision
         )
-        for site in self._mol:
+        for site in self._mols[0]:
             output.append(fmtstr.format(
                 site.specie.symbol, site.z, site.x, site.y,
                 site.properties['voronoi_radius']
@@ -299,7 +299,7 @@ def get_voronoi_nodes(structure, rad_dict=None, probe_rad=0.1):
         coords.append(list(site.coords))
         prop.append(site.properties['voronoi_radius'])
 
-    lattice = Lattice.from_parameters(structure.lattice.parameters)
+    lattice = Lattice.from_parameters(*structure.lattice.parameters)
     vor_node_struct = Structure(
         lattice, species, coords, coords_are_cartesian=True,
         to_unit_cell=True, site_properties={"voronoi_radius": prop})
@@ -376,7 +376,7 @@ def get_high_accuracy_voronoi_nodes(structure, rad_dict, probe_rad=0.1):
         coords.append(list(site.coords))
         prop.append(site.properties['voronoi_radius'])
 
-    lattice = Lattice.from_parameters(structure.lattice.parameters)
+    lattice = Lattice.from_parameters(*structure.lattice.parameters)
     vor_node_struct = Structure(
         lattice, species, coords, coords_are_cartesian=True,
         to_unit_cell=True, site_properties={"voronoi_radius": prop})


### PR DESCRIPTION
## Summary

Fixes minor bugs on Zeo++ interface.

* `from_parameters(structure.lattice.parameters)` -> `from_parameters(*structure.lattice.parameters)` (starred)
* `self._mol` does not exist in `pymatgen.io.xyz.XYZ` anymore. Replaced by `self._mols[0]`.
* Test for getting free sphere parameters skipped, as file `free_sph.cif` does not exist anymore. All other tests for the zeopp file are ok.