### PR TITLE
automatic box size overwrite

### DIFF
--- a/pymatgen/io/lammps/data.py
+++ b/pymatgen/io/lammps/data.py
@@ -1239,7 +1239,9 @@ class CombinedData(LammpsData):
 
         """
 
-        self.box = list_of_molecules[0].box
+        max_xyz = coordinates[['x', 'y', 'z']].max().max()
+        min_xyz = coordinates[['x', 'y', 'z']].min().min()
+        self.box = LammpsBox(np.array(3*[[min_xyz - 0.1, max_xyz + 0.1]]))
         self.atom_style = atom_style
         self.n = sum(list_of_numbers)
         self.names = list_of_names

--- a/pymatgen/io/lammps/data.py
+++ b/pymatgen/io/lammps/data.py
@@ -1241,7 +1241,7 @@ class CombinedData(LammpsData):
 
         max_xyz = coordinates[['x', 'y', 'z']].max().max()
         min_xyz = coordinates[['x', 'y', 'z']].min().min()
-        self.box = LammpsBox(np.array(3*[[min_xyz - 0.1, max_xyz + 0.1]]))
+        self.box = LammpsBox(np.array(3*[[min_xyz - 0.5, max_xyz + 0.5]]))
         self.atom_style = atom_style
         self.n = sum(list_of_numbers)
         self.names = list_of_names

--- a/pymatgen/io/lammps/tests/test_data.py
+++ b/pymatgen/io/lammps/tests/test_data.py
@@ -823,9 +823,9 @@ class CombinedDataTest(unittest.TestCase):
         self.assertEqual(ff["Improper Coeffs"].shape, (2, 3))
         # header box
         np.testing.assert_array_equal(ec_fec.box.bounds,
-                                      [[-0.197365, 54.168350000000004],
-                                       [-0.197365, 54.168350000000004],
-                                       [-0.197365, 54.168350000000004]])
+                                      [[-0.597365, 54.56835],
+                                       [-0.597365, 54.56835],
+                                       [-0.597365, 54.56835]])
         # body
         self.assertEqual(ec_fec.masses.at[7, "mass"], 1.008)
         self.assertEqual(ff["Pair Coeffs"].at[9, "coeff2"], 3.750)
@@ -875,9 +875,9 @@ class CombinedDataTest(unittest.TestCase):
         self.assertEqual(ff["Improper Coeffs"].shape, (2, 3))
         # header box
         np.testing.assert_array_equal(ec_fec.box.bounds,
-                                      [[-0.197365, 54.168350000000004],
-                                       [-0.197365, 54.168350000000004],
-                                       [-0.197365, 54.168350000000004]])
+                                      [[-0.597365, 54.56835],
+                                       [-0.597365, 54.56835],
+                                       [-0.597365, 54.56835]])
         # body
         self.assertEqual(ec_fec.masses.at[7, "mass"], 1.008)
         self.assertEqual(ff["Pair Coeffs"].at[9, "coeff2"], 3.750)

--- a/pymatgen/io/lammps/tests/test_data.py
+++ b/pymatgen/io/lammps/tests/test_data.py
@@ -823,9 +823,9 @@ class CombinedDataTest(unittest.TestCase):
         self.assertEqual(ff["Improper Coeffs"].shape, (2, 3))
         # header box
         np.testing.assert_array_equal(ec_fec.box.bounds,
-                                      [[-1.000000, 54.000000],
-                                       [-1.000000, 54.000000],
-                                       [-1.000000, 54.000000]])
+                                      [[-0.197365, 54.168350000000004],
+                                       [-0.197365, 54.168350000000004],
+                                       [-0.197365, 54.168350000000004]])
         # body
         self.assertEqual(ec_fec.masses.at[7, "mass"], 1.008)
         self.assertEqual(ff["Pair Coeffs"].at[9, "coeff2"], 3.750)
@@ -875,9 +875,9 @@ class CombinedDataTest(unittest.TestCase):
         self.assertEqual(ff["Improper Coeffs"].shape, (2, 3))
         # header box
         np.testing.assert_array_equal(ec_fec.box.bounds,
-                                      [[-1.000000, 54.000000],
-                                       [-1.000000, 54.000000],
-                                       [-1.000000, 54.000000]])
+                                      [[-0.197365, 54.168350000000004],
+                                       [-0.197365, 54.168350000000004],
+                                       [-0.197365, 54.168350000000004]])
         # body
         self.assertEqual(ec_fec.masses.at[7, "mass"], 1.008)
         self.assertEqual(ff["Pair Coeffs"].at[9, "coeff2"], 3.750)


### PR DESCRIPTION
## Summary

*The box size values in the CombinedData object is now automatically updated by the min/max values of the coordinates.

