### PR TITLE
Pourbaix fix

### DIFF
--- a/pymatgen/analysis/pourbaix_diagram.py
+++ b/pymatgen/analysis/pourbaix_diagram.py
@@ -722,11 +722,13 @@ class PourbaixDiagram(MSONable):
             # their charge state.
             entry_comps = [e.composition for e in entry_list]
             rxn = Reaction(entry_comps + dummy_oh, [prod_comp])
-            coeffs = -np.array([rxn.get_coeff(comp) for comp in entry_comps])
+            react_coeffs = [-rxn.get_coeff(comp) for comp in entry_comps]
+            all_coeffs = react_coeffs + [rxn.get_coeff(prod_comp)]
 
-            # Return None if reaction coeff threshold is not met
-            if (coeffs > coeff_threshold).all():
-                return MultiEntry(entry_list, weights=coeffs.tolist())
+            # Check if reaction coeff threshold met for pourbaix compounds
+            # All reactant/product coefficients must be positive nonzero
+            if all([coeff > coeff_threshold for coeff in all_coeffs]):
+                return MultiEntry(entry_list, weights=react_coeffs)
             else:
                 return None
         except ReactionError:

--- a/pymatgen/analysis/tests/test_pourbaix_diagram.py
+++ b/pymatgen/analysis/tests/test_pourbaix_diagram.py
@@ -276,6 +276,15 @@ class PourbaixDiagramTest(unittest.TestCase):
         self.assertAlmostEqual(pbx.get_decomposition_energy(custom_ion_entry, 5, 2),
                                2.1209002582, 1)
 
+        # Test against ion sets with multiple equivalent ions (Bi-V regression)
+        entries = mpr.get_pourbaix_entries(["Bi", "V"])
+        pbx = PourbaixDiagram(entries, filter_solids=True,
+                              conc_dict={"Bi": 1e-8, "V": 1e-8})
+        self.assertTrue(
+            all(['Bi' in entry.composition and 'V' in entry.composition
+                 for entry in pbx.all_entries])
+        )
+
 
 class PourbaixPlotterTest(unittest.TestCase):
     def setUp(self):

--- a/pymatgen/ext/matproj.py
+++ b/pymatgen/ext/matproj.py
@@ -499,7 +499,7 @@ class MPRester:
 
         # position the ion energies relative to most stable reference state
         for n, i_d in enumerate(ion_data):
-            ion_entry = IonEntry(Ion.from_formula(i_d['Name']), i_d['Energy'])
+            ion = Ion.from_formula(i_d['Name'])
             refs = [e for e in ion_ref_entries
                     if e.composition.reduced_formula == i_d['Reference Solid']]
             if not refs:
@@ -508,8 +508,9 @@ class MPRester:
             rf = stable_ref.composition.get_reduced_composition_and_factor()[1]
             solid_diff = ion_ref_pd.get_form_energy(stable_ref) - i_d['Reference solid energy'] * rf
             elt = i_d['Major_Elements'][0]
-            correction_factor = ion_entry.ion.composition[elt] / stable_ref.composition[elt]
-            ion_entry.energy += solid_diff * correction_factor
+            correction_factor = ion.composition[elt] / stable_ref.composition[elt]
+            energy = i_d['Energy'] + solid_diff * correction_factor
+            ion_entry = IonEntry(ion, energy)
             pbx_entries.append(PourbaixEntry(ion_entry, 'ion-{}'.format(n)))
 
         # Construct the solid pourbaix entries from filtered ion_ref entries

--- a/pymatgen/ext/matproj.py
+++ b/pymatgen/ext/matproj.py
@@ -521,12 +521,9 @@ class MPRester:
             # Ensure no OH chemsys or extraneous elements from ion references
             if not (entry_elts <= {Element('H'), Element('O')} or
                     extra_elts.intersection(entry_elts)):
-                # replace energy with formation energy, use dict to
-                # avoid messing with the ion_ref_pd and to keep all old params
+                # Create new computed entry
                 form_e = ion_ref_pd.get_form_energy(entry)
-                new_entry = deepcopy(entry)
-                new_entry.uncorrected_energy = form_e
-                new_entry.correction = 0.0
+                new_entry = ComputedEntry(entry.composition, form_e, entry_id=entry.entry_id)
                 pbx_entry = PourbaixEntry(new_entry)
                 pbx_entries.append(pbx_entry)
 

--- a/pymatgen/ext/matproj.py
+++ b/pymatgen/ext/matproj.py
@@ -24,7 +24,6 @@ from monty.json import MontyDecoder, MontyEncoder
 
 from enum import Enum, unique
 from collections import defaultdict
-from copy import deepcopy
 
 from pymatgen import SETTINGS, __version__ as pmg_version
 

--- a/pymatgen/ext/tests/test_matproj.py
+++ b/pymatgen/ext/tests/test_matproj.py
@@ -272,19 +272,20 @@ class MPResterTest(PymatgenTest):
         pbx_entries = self.rester.get_pourbaix_entries(["Fe", "Cr"])
         for pbx_entry in pbx_entries:
             self.assertTrue(isinstance(pbx_entry, PourbaixEntry))
+
+        fe_two_plus = [e for e in pbx_entries if e.entry_id == "ion-0"][0]
+        self.assertAlmostEqual(fe_two_plus.energy, -1.580096075)
+
+        feo2 = [e for e in pbx_entries if e.entry_id == "mp-25332"][0]
+        self.assertAlmostEqual(feo2.energy, 2.51083231)
+
+        # Test S, which has Na in reference solids
+        pbx_entries = self.rester.get_pourbaix_entries(["S"])
+        so4_two_minus = pbx_entries[9]
+        self.assertAlmostEqual(so4_two_minus.energy, 0.047817821)
+
         # Ensure entries are pourbaix compatible
         pbx = PourbaixDiagram(pbx_entries)
-
-        # Try binary system
-        # pbx_entries = self.rester.get_pourbaix_entries(["Fe", "Cr"])
-        # pbx = PourbaixDiagram(pbx_entries)
-
-        # TODO: Shyue Ping: I do not understand this test. You seem to
-        # be grabbing Zn-S system, but I don't see proper test for anything,
-        # including Na ref. This test also takes a long time.
-
-        # Test Zn-S, which has Na in reference solids
-        # pbx_entries = self.rester.get_pourbaix_entries(["Zn", "S"])
 
     def test_get_exp_entry(self):
         entry = self.rester.get_exp_entry("Fe2O3")


### PR DESCRIPTION
## Fix to two bugs in Pourbaix Diagram code

* Fixes issue where Pourbaix diagram was considering MultiEntries where reaction calculator finds a balanced reaction with no product.
* Fixes issue with MPRester PourbaixEntry processing due to Entry refactor.  Specifically, `_energy`/`uncorrected_energy` mix-up.

## TODO (if any)

The regression test that I've added is heavier than I'd like (on an already too-heavy set of tests for the pourbaix_diagram module), I can create a more minimal test that encapsulates the issue more neatly, but will need a bit more time to do so, so figured I'd issue the PR in case the bug fixes are a priority.