### PR TITLE
Hexagonal Sym Issues

### DIFF
--- a/pymatgen/symmetry/groups.py
+++ b/pymatgen/symmetry/groups.py
@@ -382,11 +382,7 @@ class SpaceGroup(SymmetryGroup):
             a = abc[0]
             return check(abc, [a, a, a], tol) and check(angles, [90, 90, 90], angle_tol)
         elif crys_system == "hexagonal" or (
-                crys_system == "trigonal" and (
-                self.symbol.endswith("H") or
-                self.int_number in [143, 144, 145, 147, 149, 150, 151, 152,
-                                    153, 154, 156, 157, 158, 159, 162, 163,
-                                    164, 165])):
+                crys_system == "trigonal" and self.symbol.endswith("H")):
             a = abc[0]
             return check(abc, [a, a, None], tol) and check(angles, [90, 90, 120], angle_tol)
         elif crys_system == "trigonal":
@@ -479,8 +475,10 @@ class SpaceGroup(SymmetryGroup):
         Returns:
             (SpaceGroup)
         """
-        return SpaceGroup(sg_symbol_from_int_number(int_number,
-                                                    hexagonal=hexagonal))
+        sym = sg_symbol_from_int_number(int_number,hexagonal=hexagonal)
+        if not hexagonal and int_number in [146,148,155,160,161,166,167]:
+            sym += ':R'
+        return SpaceGroup(sym)
 
     def __str__(self):
         return "Spacegroup %s with international number %d and order %d" % (

--- a/pymatgen/symmetry/groups.py
+++ b/pymatgen/symmetry/groups.py
@@ -475,7 +475,7 @@ class SpaceGroup(SymmetryGroup):
         Returns:
             (SpaceGroup)
         """
-        sym = sg_symbol_from_int_number(int_number,hexagonal=hexagonal)
+        sym = sg_symbol_from_int_number(int_number, hexagonal=hexagonal)
         if not hexagonal and int_number in [146, 148, 155, 160, 161, 166, 167]:
             sym += ':R'
         return SpaceGroup(sym)

--- a/pymatgen/symmetry/groups.py
+++ b/pymatgen/symmetry/groups.py
@@ -382,7 +382,11 @@ class SpaceGroup(SymmetryGroup):
             a = abc[0]
             return check(abc, [a, a, a], tol) and check(angles, [90, 90, 90], angle_tol)
         elif crys_system == "hexagonal" or (
-                crys_system == "trigonal" and self.symbol.endswith("H")):
+                crys_system == "trigonal" and (
+                self.symbol.endswith("H") or
+                self.int_number in [143, 144, 145, 147, 149, 150, 151, 152,
+                                    153, 154, 156, 157, 158, 159, 162, 163,
+                                    164, 165])):
             a = abc[0]
             return check(abc, [a, a, None], tol) and check(angles, [90, 90, 120], angle_tol)
         elif crys_system == "trigonal":

--- a/pymatgen/symmetry/groups.py
+++ b/pymatgen/symmetry/groups.py
@@ -476,7 +476,7 @@ class SpaceGroup(SymmetryGroup):
             (SpaceGroup)
         """
         sym = sg_symbol_from_int_number(int_number,hexagonal=hexagonal)
-        if not hexagonal and int_number in [146,148,155,160,161,166,167]:
+        if not hexagonal and int_number in [146, 148, 155, 160, 161, 166, 167]:
             sym += ':R'
         return SpaceGroup(sym)
 

--- a/pymatgen/symmetry/tests/test_groups.py
+++ b/pymatgen/symmetry/tests/test_groups.py
@@ -172,7 +172,7 @@ class SpaceGroupTest(unittest.TestCase):
                 SpaceGroup.from_int_number(230)))
 
     def test_hexagonal(self):
-        sgs = [146,148,155,160,161,166,167]
+        sgs = [146, 148, 155, 160, 161, 166, 167]
         for sg in sgs:
             s = SpaceGroup.from_int_number(sg, hexagonal=False)
             self.assertTrue(not s.symbol.endswith('H'))

--- a/pymatgen/symmetry/tests/test_groups.py
+++ b/pymatgen/symmetry/tests/test_groups.py
@@ -149,8 +149,11 @@ class SpaceGroupTest(unittest.TestCase):
         self.assertFalse(sg.is_compatible(hexagonal))
 
         sg = SpaceGroup.from_int_number(165)
-        self.assertTrue(sg.is_compatible(rhom))
-        self.assertFalse(sg.is_compatible(hexagonal))
+        self.assertFalse(sg.is_compatible(cubic))
+        self.assertFalse(sg.is_compatible(tet))
+        self.assertFalse(sg.is_compatible(ortho))
+        self.assertFalse(sg.is_compatible(rhom))
+        self.assertTrue(sg.is_compatible(hexagonal))
 
     def test_symmops(self):
         sg = SpaceGroup("Pnma")

--- a/pymatgen/symmetry/tests/test_groups.py
+++ b/pymatgen/symmetry/tests/test_groups.py
@@ -149,11 +149,8 @@ class SpaceGroupTest(unittest.TestCase):
         self.assertFalse(sg.is_compatible(hexagonal))
 
         sg = SpaceGroup.from_int_number(165)
-        self.assertFalse(sg.is_compatible(cubic))
-        self.assertFalse(sg.is_compatible(tet))
-        self.assertFalse(sg.is_compatible(ortho))
-        self.assertFalse(sg.is_compatible(rhom))
-        self.assertTrue(sg.is_compatible(hexagonal))
+        self.assertTrue(sg.is_compatible(rhom))
+        self.assertFalse(sg.is_compatible(hexagonal))
 
     def test_symmops(self):
         sg = SpaceGroup("Pnma")
@@ -174,6 +171,12 @@ class SpaceGroupTest(unittest.TestCase):
             self.assertFalse(SpaceGroup.from_int_number(229).is_subgroup(
                 SpaceGroup.from_int_number(230)))
 
+    def test_hexagonal(self):
+        sgs = [146,148,155,160,161,166,167]
+        for sg in sgs:
+            s = SpaceGroup.from_int_number(sg, hexagonal=False)
+            self.assertTrue(not s.symbol.endswith('H'))
+        
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This merge request addresses issues #1801 and #1802. I decided to add the #1801 fix to the SpaceGroup.from_int_number() method, which is not the lowest function with the hexagonal=True input. The respective unittests for each fix were also added.
