### PR TITLE
VolumetricData speedup

### DIFF
--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -3011,16 +3011,17 @@ class VolumetricData(MSONable):
                 original_line = line
                 line = line.strip()
                 if read_dataset:
-                    toks = line.split()
-                    for tok in toks:
+                    for tok in line.split():
                         if data_count < ngrid_pts:
                             # This complicated procedure is necessary because
                             # vasp outputs x as the fastest index, followed by y
                             # then z.
-                            x = data_count % dim[0]
-                            y = int(math.floor(data_count / dim[0])) % dim[1]
-                            z = int(math.floor(data_count / dim[0] / dim[1]))
-                            dataset[x, y, z] = float(tok)
+                            no_x = data_count // dim[0]
+                            dataset[
+                                data_count % dim[0],
+                                no_x % dim[1],
+                                no_x // dim[1]
+                            ] = float(tok)
                             data_count += 1
                     if data_count >= ngrid_pts:
                         read_dataset = False


### PR DESCRIPTION
## Summary

Got frustrated while reading a 1.5 GB file, so I tried to speed it up. Changed a couple lines in VolumetricData.parse_file, and here's what I got on my computer:

* test_files/CHGCAR.Fe3O4: 655 ms -> 368 ms (1.78x speedup)
* test_files/CHGCAR.NiO_SOC.gz: 779 ms -> 495 ms (1.57x)
* test_files/LOCPOT: 28.8 ms -> 16.1 ms (1.79x)
* test_files/ELFCAR.gz: 40.6 ms -> 22.7 ms (1.79x)
* 384 MB CHGCAR: 19.8 s -> 10.9 s (1.82x)
* 1.5 GB AECCAR: 81 s -> 48.3 s (1.68x)

<img width=400 alt="It ain't much, but it's honest work." src="https://i.kym-cdn.com/entries/icons/original/000/028/021/work.jpg"/>

## Additional dependencies introduced (if any)

None.

## TODO (if any)

None.

## Checklist

Work-in-progress pull requests are encouraged, but please put [WIP]
in the pull request title.

Before a pull request can be merged, the following items must be checked:

- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). 
      Run [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/) and [flake8](http://flake8.pycqa.org/en/latest/)
      on your local machine.
- [x] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [x] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) 
      to type check your code.
- [x] Tests have been added for any new functionality or bug fixes.
- [x] All existing tests pass.

Note that the CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR. It is
highly recommended that you use the pre-commit hook provided in the pymatgen 
repository. Simply `cp pre-commit .git/hooks` and a check will be run prior to
allowing commits.
