### PR TITLE
Gau

### DIFF
--- a/pymatgen/io/gaussian.py
+++ b/pymatgen/io/gaussian.py
@@ -1115,7 +1115,7 @@ class GaussianOutput:
                         line = f.readline()
                         if " -- Stationary point found." not in line:
                             warnings.warn("\n" + self.filename +
-                                ": Optimization complete but this is not a stationary point")
+                                          ": Optimization complete but this is not a stationary point")
                         opt_structures.append(input_structures[-1])
                     elif not read_eigen and orbital_patt.search(line):
                         eigen_txt.append(line)
@@ -1444,7 +1444,7 @@ class GaussianOutput:
         d, plt = self.get_spectre_plot(sigma, step)
         plt.savefig(filename, format=img_format)
 
-    def to_input(self, mol=None,  charge=None,
+    def to_input(self, mol=None, charge=None,
                  spin_multiplicity=None, title=None, functional=None,
                  basis_set=None, route_parameters=None, input_parameters=None,
                  link0_parameters=None, dieze_tag=None, cart_coords=False):

--- a/pymatgen/io/gaussian.py
+++ b/pymatgen/io/gaussian.py
@@ -132,7 +132,7 @@ class GaussianInput:
         # Determine multiplicity and charge settings
         if isinstance(mol, Molecule):
             self.charge = charge if charge is not None else mol.charge
-            nelectrons = - self.charge + mol.charge + mol.nelectrons
+            nelectrons = mol.charge + mol.nelectrons - self.charge
             if spin_multiplicity is not None:
                 self.spin_multiplicity = spin_multiplicity
                 if (nelectrons + spin_multiplicity) % 2 != 1:
@@ -533,7 +533,13 @@ class GaussianOutput:
 
     .. attribute:: structures_input_orientation
 
-        All structures from the calculation in the input orientation.
+        All structures from the calculation in the input orientation or the
+        Z-matrix orientation (if an opt=z-matrix was requested).
+
+    .. attribute:: opt_structures
+
+        All optimized structures from the calculation in the input orientation
+        or the Z-matrix orientation.
 
     .. attribute:: energies
 
@@ -752,7 +758,7 @@ class GaussianOutput:
         end_mulliken_patt = re.compile(
             r'(Sum of Mulliken )(.*)(charges)\s*=\s*(\D)')
         std_orientation_patt = re.compile(r"Standard orientation")
-        input_orientation_patt = re.compile(r"Input orientation")
+        input_orientation_patt = re.compile(r"Input orientation|Z-Matrix orientation")
         orbital_patt = re.compile(r"(Alpha|Beta)\s*\S+\s*eigenvalues --(.*)")
         thermo_patt = re.compile(r"(Zero-point|Thermal) correction(.*)="
                                  r"\s+([\d\.-]+)")
@@ -814,6 +820,7 @@ class GaussianOutput:
         input_structures = list()
         std_structures = list()
         geom_orientation = None
+        opt_structures = list()
 
         with zopen(filename) as f:
             for line in f:
@@ -1104,6 +1111,12 @@ class GaussianOutput:
                     elif input_orientation_patt.search(line):
                         geom_orientation = "input"
                         read_coord = True
+                    elif "Optimization completed." in line:
+                        line = f.readline()
+                        if " -- Stationary point found." not in line:
+                            warnings.warn("\n" + self.filename +
+                                ": Optimization complete but this is not a stationary point")
+                        opt_structures.append(input_structures[-1])
                     elif not read_eigen and orbital_patt.search(line):
                         eigen_txt.append(line)
                         read_eigen = True
@@ -1158,6 +1171,8 @@ class GaussianOutput:
         else:
             self.structures = input_structures
             self.structures_input_orientation = input_structures
+        # store optimized structure in input orientation 
+        self.opt_structures = opt_structures
 
         if not terminated:
             warnings.warn("\n" + self.filename +
@@ -1247,6 +1262,7 @@ class GaussianOutput:
 
         scan_patt = re.compile(r"^\sSummary of the potential surface scan:")
         optscan_patt = re.compile(r"^\sSummary of Optimized Potential Surface Scan")
+        coord_patt = re.compile(r"^\s*(\w+)((\s*[+-]?\d+\.\d+)+)")
 
         # data dict return
         data = {"energies": list(), "coords": dict()}
@@ -1263,14 +1279,14 @@ class GaussianOutput:
                     while not endScan:
                         data["energies"] += floatList(float_patt.findall(line))
                         line = f.readline()
-                        while not re.search(r"(^\s+(\d+)|^\s-+)", line):
+                        while coord_patt.match(line):
                             icname = line.split()[0].strip()
                             if icname in data["coords"]:
                                 data["coords"][icname] += floatList(float_patt.findall(line))
                             else:
                                 data["coords"][icname] = floatList(float_patt.findall(line))
                             line = f.readline()
-                        if re.search(r"^\s-+", line):
+                        if not re.search(r"^\s+((\s*\d+)+)", line):
                             endScan = True
                         else:
                             line = f.readline()

--- a/pymatgen/io/tests/test_gaussian.py
+++ b/pymatgen/io/tests/test_gaussian.py
@@ -327,6 +327,26 @@ class GaussianOutputTest(unittest.TestCase):
         self.assertEqual(len(d["coords"]), 1)
         self.assertEqual(len(d["energies"]), len(gau.energies))
         self.assertEqual(len(d["energies"]), 21)
+        gau = GaussianOutput(os.path.join(test_dir, "so2_scan_opt.log"))
+        self.assertEqual(21, len(gau.opt_structures))
+        d = gau.read_scan()
+        self.assertAlmostEqual(-548.02336, d["energies"][-1])
+        self.assertEqual(len(d["coords"]), 2)
+        self.assertEqual(len(d["energies"]), 21)
+        self.assertAlmostEqual(1.60000, d["coords"]["DSO"][6])
+        self.assertAlmostEqual(124.01095, d["coords"]["ASO"][2])
+        gau = GaussianOutput(os.path.join(test_dir, "H2O_scan_G16.out"))
+        self.assertEqual(21, len(gau.opt_structures))
+        coords = [[ 0.104226,   -0.000000,    0.087456],
+                  [-0.059296,   -0.000000,    1.014833],
+                  [ 0.989118,    0.000000,   -0.234619]]
+        self.assertAlmostEqual(gau.opt_structures[-1].cart_coords.tolist(), coords)
+        d = gau.read_scan()
+        self.assertAlmostEqual(-0.00523, d["energies"][-1])
+        self.assertEqual(len(d["coords"]), 3)
+        self.assertEqual(len(d["energies"]), 21)
+        self.assertAlmostEqual(0.94710, d["coords"]["R1"][6])
+        self.assertAlmostEqual(0.94277, d["coords"]["R2"][17])
 
     def test_td(self):
         gau = GaussianOutput(os.path.join(test_dir, "so2_td.log"))

--- a/pymatgen/io/tests/test_gaussian.py
+++ b/pymatgen/io/tests/test_gaussian.py
@@ -337,9 +337,9 @@ class GaussianOutputTest(unittest.TestCase):
         self.assertAlmostEqual(124.01095, d["coords"]["ASO"][2])
         gau = GaussianOutput(os.path.join(test_dir, "H2O_scan_G16.out"))
         self.assertEqual(21, len(gau.opt_structures))
-        coords = [[ 0.104226,   -0.000000,    0.087456],
-                  [-0.059296,   -0.000000,    1.014833],
-                  [ 0.989118,    0.000000,   -0.234619]]
+        coords = [[0.104226,  0.000000,  0.087456],
+                  [-0.059296, 0.000000,  1.014833],
+                  [0.989118,  0.000000, -0.234619]]
         self.assertAlmostEqual(gau.opt_structures[-1].cart_coords.tolist(), coords)
         d = gau.read_scan()
         self.assertAlmostEqual(-0.00523, d["energies"][-1])

--- a/test_files/molecules/H2O_scan_G16.out
+++ b/test_files/molecules/H2O_scan_G16.out
@@ -1,0 +1,5390 @@
+ Entering Gaussian System, Link 0=/usr/local/g16/g16
+ Initial command:
+ /usr/local/g16/l1.exe "/scratch/webmodemo/webmo-4350/627084/Gau-13488.inp" -scrdir="/scratch/webmodemo/webmo-4350/627084/"
+ Entering Link 1 = /usr/local/g16/l1.exe PID=     13489.
+  
+ Copyright (c) 1988-2017, Gaussian, Inc.  All Rights Reserved.
+  
+ This is part of the Gaussian(R) 16 program.  It is based on
+ the Gaussian(R) 09 system (copyright 2009, Gaussian, Inc.),
+ the Gaussian(R) 03 system (copyright 2003, Gaussian, Inc.),
+ the Gaussian(R) 98 system (copyright 1998, Gaussian, Inc.),
+ the Gaussian(R) 94 system (copyright 1995, Gaussian, Inc.),
+ the Gaussian 92(TM) system (copyright 1992, Gaussian, Inc.),
+ the Gaussian 90(TM) system (copyright 1990, Gaussian, Inc.),
+ the Gaussian 88(TM) system (copyright 1988, Gaussian, Inc.),
+ the Gaussian 86(TM) system (copyright 1986, Carnegie Mellon
+ University), and the Gaussian 82(TM) system (copyright 1983,
+ Carnegie Mellon University). Gaussian is a federally registered
+ trademark of Gaussian, Inc.
+  
+ This software contains proprietary and confidential information,
+ including trade secrets, belonging to Gaussian, Inc.
+  
+ This software is provided under written license and may be
+ used, copied, transmitted, or stored only in accord with that
+ written license.
+  
+ The following legend is applicable only to US Government
+ contracts under FAR:
+  
+                    RESTRICTED RIGHTS LEGEND
+  
+ Use, reproduction and disclosure by the US Government is
+ subject to restrictions as set forth in subparagraphs (a)
+ and (c) of the Commercial Computer Software - Restricted
+ Rights clause in FAR 52.227-19.
+  
+ Gaussian, Inc.
+ 340 Quinnipiac St., Bldg. 40, Wallingford CT 06492
+  
+  
+ ---------------------------------------------------------------
+ Warning -- This program may not be used in any manner that
+ competes with the business of Gaussian, Inc. or will provide
+ assistance to any competitor of Gaussian, Inc.  The licensee
+ of this program is prohibited from giving any competitor of
+ Gaussian, Inc. access to this program.  By using this program,
+ the user acknowledges that Gaussian, Inc. is engaged in the
+ business of creating and licensing software in the field of
+ computational chemistry and represents and warrants to the
+ licensee that it is not a competitor of Gaussian, Inc. and that
+ it will not use this program in any manner prohibited above.
+ ---------------------------------------------------------------
+  
+
+ Cite this work as:
+ Gaussian 16, Revision B.01,
+ M. J. Frisch, G. W. Trucks, H. B. Schlegel, G. E. Scuseria, 
+ M. A. Robb, J. R. Cheeseman, G. Scalmani, V. Barone, 
+ G. A. Petersson, H. Nakatsuji, X. Li, M. Caricato, A. V. Marenich, 
+ J. Bloino, B. G. Janesko, R. Gomperts, B. Mennucci, H. P. Hratchian, 
+ J. V. Ortiz, A. F. Izmaylov, J. L. Sonnenberg, D. Williams-Young, 
+ F. Ding, F. Lipparini, F. Egidi, J. Goings, B. Peng, A. Petrone, 
+ T. Henderson, D. Ranasinghe, V. G. Zakrzewski, J. Gao, N. Rega, 
+ G. Zheng, W. Liang, M. Hada, M. Ehara, K. Toyota, R. Fukuda, 
+ J. Hasegawa, M. Ishida, T. Nakajima, Y. Honda, O. Kitao, H. Nakai, 
+ T. Vreven, K. Throssell, J. A. Montgomery, Jr., J. E. Peralta, 
+ F. Ogliaro, M. J. Bearpark, J. J. Heyd, E. N. Brothers, K. N. Kudin, 
+ V. N. Staroverov, T. A. Keith, R. Kobayashi, J. Normand, 
+ K. Raghavachari, A. P. Rendell, J. C. Burant, S. S. Iyengar, 
+ J. Tomasi, M. Cossi, J. M. Millam, M. Klene, C. Adamo, R. Cammi, 
+ J. W. Ochterski, R. L. Martin, K. Morokuma, O. Farkas, 
+ J. B. Foresman, and D. J. Fox, Gaussian, Inc., Wallingford CT, 2016.
+ 
+ ******************************************
+ Gaussian 16:  ES64L-G16RevB.01 20-Dec-2017
+                 7-Apr-2020 
+ ******************************************
+ --------------------------------------------------
+ #N HF/6-31G(d) OPT(AddRedundant) Geom=Connectivity
+ --------------------------------------------------
+ 1/18=120,19=15,38=1,57=2/1,3;
+ 2/9=110,12=2,17=6,18=5,40=1/2;
+ 3/5=1,6=6,7=1,11=9,25=1,30=1,71=1/1,2,3;
+ 4//1;
+ 5/5=2,38=5/2;
+ 6/7=2,8=2,9=2,10=2,28=1/1;
+ 7//1,2,3,16;
+ 1/18=20,19=15/3(2);
+ 2/9=110/2;
+ 99//99;
+ 2/9=110/2;
+ 3/5=1,6=6,7=1,11=9,25=1,30=1,71=1/1,2,3;
+ 4/5=5,16=3,69=1/1;
+ 5/5=2,38=5/2;
+ 7//1,2,3,16;
+ 1/18=20,19=15/3(-5);
+ 2/9=110/2;
+ 6/7=2,8=2,9=2,10=2,19=2,28=1/1;
+ 99/9=1/99;
+ ---
+ H2O
+ ---
+ Symbolic Z-matrix:
+ Charge =  0 Multiplicity = 1
+ O
+ H                    1    B1
+ H                    1    B2       2    A1
+       Variables:
+  B1                    1.05                     
+  B2                    1.05                     
+  A1                  100.                       
+ 
+ The following ModRedundant input section has been read:
+ A       2       1       3 S  20 1.0000                                        
+ 
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Initialization pass.
+                           ----------------------------
+                           !    Initial Parameters    !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  1.05           estimate D2E/DX2                !
+ ! R2    R(1,3)                  1.05           estimate D2E/DX2                !
+ ! A1    A(2,1,3)               100.0           Scan                            !
+ --------------------------------------------------------------------------------
+ Trust Radius=3.00D-01 FncErr=1.00D-07 GrdErr=1.00D-07 EigMax=2.50D+02 EigMin=1.00D-04
+ Number of optimizations in scan=  21
+ Number of steps in this run=     20 maximum allowed number of steps=    100.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.000000    0.000000    0.000000
+      2          1           0        0.000000    0.000000    1.050000
+      3          1           0        1.034048    0.000000   -0.182331
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    1.050000   0.000000
+     3  H    1.050000   1.608693   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.000000   -0.000000    0.134985
+      2          1           0        0.000000    0.804347   -0.539942
+      3          1           0       -0.000000   -0.804347   -0.539942
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):         619.7747411         387.5391029         238.4430122
+ Standard basis: 6-31G(d) (6D, 7F)
+ There are    10 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    10 symmetry adapted basis functions of A1  symmetry.
+ There are     1 symmetry adapted basis functions of A2  symmetry.
+ There are     3 symmetry adapted basis functions of B1  symmetry.
+ There are     5 symmetry adapted basis functions of B2  symmetry.
+    19 basis functions,    36 primitive gaussians,    19 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         8.3926012085 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    19 RedAO= T EigKep=  2.58D-02  NBF=    10     1     3     5
+ NBsUse=    19 1.00D-06 EigRej= -1.00D+00 NBFU=    10     1     3     5
+ ExpMin= 1.61D-01 ExpMax= 5.48D+03 ExpMxC= 8.25D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor=  205 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor=  205 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (B2) (A1) (B1) (A1) (B2) (A1) (A1) (A2)
+                 (B1) (A1) (B2) (A1)
+ The electronic state of the initial guess is 1-A1.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=845746.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -75.9926467975     A.U. after   10 cycles
+            NFock= 10  Conv=0.52D-08     -V/T= 2.0064
+
+ **********************************************************************
+
+            Population analysis using the SCF Density.
+
+ **********************************************************************
+
+ Orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (B2) (A1) (A1) (B1) (B2) (A1) (A1) (A2)
+                 (B1) (A1) (B2) (A1)
+ The electronic state is 1-A1.
+ Alpha  occ. eigenvalues --  -20.58090  -1.30287  -0.65227  -0.56299  -0.49500
+ Alpha virt. eigenvalues --    0.18891   0.27508   0.96857   1.06997   1.13851
+ Alpha virt. eigenvalues --    1.16611   1.35432   1.45104   2.03108   2.05720
+ Alpha virt. eigenvalues --    2.07777   2.51207   2.77957   3.91666
+          Condensed to atoms (all electrons):
+               1          2          3
+     1  O    8.344084   0.245327   0.245327
+     2  H    0.245327   0.355759  -0.018454
+     3  H    0.245327  -0.018454   0.355759
+ Mulliken charges:
+               1
+     1  O   -0.834737
+     2  H    0.417369
+     3  H    0.417369
+ Sum of Mulliken charges =  -0.00000
+ Mulliken charges with hydrogens summed into heavy atoms:
+               1
+     1  O   -0.000000
+ Electronic spatial extent (au):  <R**2>=             20.2087
+ Charge=             -0.0000 electrons
+ Dipole moment (field-independent basis, Debye):
+    X=             -0.0000    Y=             -0.0000    Z=             -2.3678  Tot=              2.3678
+ Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=             -7.4141   YY=             -4.1904   ZZ=             -5.8610
+   XY=              0.0000   XZ=              0.0000   YZ=             -0.0000
+ Traceless Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=             -1.5923   YY=              1.6314   ZZ=             -0.0391
+   XY=              0.0000   XZ=              0.0000   YZ=             -0.0000
+ Octapole moment (field-independent basis, Debye-Ang**2):
+  XXX=              0.0000  YYY=             -0.0000  ZZZ=             -1.4868  XYY=             -0.0000
+  XXY=              0.0000  XXZ=             -0.3316  XZZ=             -0.0000  YZZ=              0.0000
+  YYZ=             -1.6328  XYZ=             -0.0000
+ Hexadecapole moment (field-independent basis, Debye-Ang**3):
+ XXXX=             -5.4216 YYYY=             -6.3720 ZZZZ=             -6.7644 XXXY=             -0.0000
+ XXXZ=             -0.0000 YYYX=              0.0000 YYYZ=              0.0000 ZZZX=             -0.0000
+ ZZZY=              0.0000 XXYY=             -2.2898 XXZZ=             -2.1165 YYZZ=             -1.6520
+ XXYZ=              0.0000 YYXZ=              0.0000 ZZXY=              0.0000
+ N-N= 8.392601208535D+00 E-N=-1.970955529014D+02  KE= 7.551311275115D+01
+ Symmetry A1   KE= 6.759360816483D+01
+ Symmetry A2   KE= 1.090486515693D-34
+ Symmetry B1   KE= 4.587837092809D+00
+ Symmetry B2   KE= 3.331667493514D+00
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8           0.084847370    0.000000000    0.071195397
+      2        1          -0.004026369   -0.000000000   -0.081357838
+      3        1          -0.080821001   -0.000000000    0.010162441
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.084847370 RMS     0.053269211
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.081357838 RMS     0.066588343
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20 on scan point     1 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- RFO/linear search
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.39877
+           R2           0.00000   0.39877
+           A1           0.00000   0.00000   0.16000
+ ITU=  0
+     Eigenvalues ---    0.39877   0.398771000.00000
+ RFO step:  Lambda=-3.08163656D-02 EMin= 3.98766852D-01
+ Linear search not attempted -- first point.
+ Iteration  1 RMS(Cart)=  0.13162563 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 1.56D-15 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.98421  -0.08136   0.00000  -0.18939  -0.18939   1.79482
+    R2        1.98421  -0.08136   0.00000  -0.18939  -0.18939   1.79482
+    A1        1.74533   0.00799   0.00000   0.00000   0.00000   1.74533
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.081358     0.000450     NO 
+ RMS     Force            0.081358     0.000300     NO 
+ Maximum Displacement     0.137221     0.001800     NO 
+ RMS     Displacement     0.131626     0.001200     NO 
+ Predicted change in Energy=-1.651350D-02
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.032899   -0.000000    0.027606
+      2          1           0        0.032899   -0.000000    0.977386
+      3          1           0        0.968250    0.000000   -0.137322
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.949780   0.000000
+     3  H    0.949780   1.455148   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0       -0.000000    0.000000    0.122101
+      2          1           0        0.000000    0.727574   -0.488406
+      3          1           0       -0.000000   -0.727574   -0.488406
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):         757.4713005         473.6394189         291.4183598
+ Standard basis: 6-31G(d) (6D, 7F)
+ There are    10 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    10 symmetry adapted basis functions of A1  symmetry.
+ There are     1 symmetry adapted basis functions of A2  symmetry.
+ There are     3 symmetry adapted basis functions of B1  symmetry.
+ There are     5 symmetry adapted basis functions of B2  symmetry.
+    19 basis functions,    36 primitive gaussians,    19 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.2781789003 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    19 RedAO= T EigKep=  2.20D-02  NBF=    10     1     3     5
+ NBsUse=    19 1.00D-06 EigRej= -1.00D+00 NBFU=    10     1     3     5
+ Initial guess from the checkpoint file:  "/scratch/webmodemo/webmo-4350/627084/Gau-13489.chk"
+ B after Tr=     0.000000    0.000000   -0.000000
+         Rot=    1.000000   -0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (B2) (A1) (A1) (B1) (B2) (A1) (A1) (A2)
+                 (B1) (A1) (B2) (A1)
+ ExpMin= 1.61D-01 ExpMax= 5.48D+03 ExpMxC= 8.25D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor=  205 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor=  205 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=845746.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -76.0098514887     A.U. after   10 cycles
+            NFock= 10  Conv=0.78D-08     -V/T= 2.0020
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8           0.012289065    0.000000000    0.010311750
+      2        1          -0.010535014   -0.000000000    0.000076497
+      3        1          -0.001754051   -0.000000000   -0.010388247
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.012289065 RMS     0.007297930
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.018908502 RMS     0.010917007
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20 on scan point     1 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Update second derivatives using D2CorX and points    1    2
+ DE= -1.72D-02 DEPred=-1.65D-02 R= 1.04D+00
+ TightC=F SS=  1.41D+00  RLast= 2.68D-01 DXNew= 5.0454D-01 8.0350D-01
+ Trust test= 1.04D+00 RLast= 2.68D-01 DXMaxT set to 5.05D-01
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.41438
+           R2           0.01561   0.41438
+           A1           0.02883   0.02883   0.16387
+ ITU=  1  0
+ Use linear search instead of GDIIS.
+     Eigenvalues ---    0.39877   0.429991000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 3.98766852D-01
+ Quartic linear search produced a step of -0.00068.
+ Iteration  1 RMS(Cart)=  0.00009006 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 5.59D-15 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.79482   0.00008   0.00013   0.00000   0.00013   1.79495
+    R2        1.79482   0.00008   0.00013  -0.00000   0.00013   1.79495
+    A1        1.74533   0.01891   0.00000   0.00000   0.00000   1.74533
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000076     0.000450     YES
+ RMS     Force            0.000076     0.000300     YES
+ Maximum Displacement     0.000094     0.001800     YES
+ RMS     Displacement     0.000090     0.001200     YES
+ Predicted change in Energy=-1.260525D-08
+ Optimization completed.
+    -- Stationary point found.
+                           ----------------------------
+                           !   Optimized Parameters   !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  0.9498         -DE/DX =    0.0001              !
+ ! R2    R(1,3)                  0.9498         -DE/DX =    0.0001              !
+ ! A1    A(2,1,3)               100.0           -DE/DX =    0.0189              !
+ --------------------------------------------------------------------------------
+ Iteration  1 RMS(Cart)=  0.00997894 RMS(Int)=  0.00005580
+ Iteration  2 RMS(Cart)=  0.00004754 RMS(Int)=  0.00000000
+ Iteration  3 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.036131   -0.000000    0.030318
+      2          1           0        0.027842   -0.000000    0.980130
+      3          1           0        0.970075    0.000000   -0.142779
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.949849   0.000000
+     3  H    0.949849   1.465853   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0       -0.000000   -0.000000    0.120836
+      2          1           0       -0.000000    0.732927   -0.483343
+      3          1           0       -0.000000   -0.732927   -0.483343
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):         773.4235941         466.7463740         291.0832123
+ Standard basis: 6-31G(d) (6D, 7F)
+ There are    10 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    10 symmetry adapted basis functions of A1  symmetry.
+ There are     1 symmetry adapted basis functions of A2  symmetry.
+ There are     3 symmetry adapted basis functions of B1  symmetry.
+ There are     5 symmetry adapted basis functions of B2  symmetry.
+    19 basis functions,    36 primitive gaussians,    19 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.2748794002 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    19 RedAO= T EigKep=  2.20D-02  NBF=    10     1     3     5
+ NBsUse=    19 1.00D-06 EigRej= -1.00D+00 NBFU=    10     1     3     5
+ Initial guess from the checkpoint file:  "/scratch/webmodemo/webmo-4350/627084/Gau-13489.chk"
+ B after Tr=    -0.000000   -0.000000    0.000000
+         Rot=    1.000000    0.000000   -0.000000   -0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (B2) (A1) (B1) (A1) (B2) (A1) (A1) (A2)
+                 (B1) (A1) (B2) (A1)
+ ExpMin= 1.61D-01 ExpMax= 5.48D+03 ExpMxC= 8.25D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor=  205 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor=  205 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=845746.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -76.0101498489     A.U. after    8 cycles
+            NFock=  8  Conv=0.43D-08     -V/T= 2.0020
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8           0.010608222    0.000000000    0.008901355
+      2        1          -0.008516873   -0.000000000   -0.000621857
+      3        1          -0.002091349   -0.000000000   -0.008279498
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.010608222 RMS     0.006124778
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.015296555 RMS     0.008842777
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20 on scan point     2 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- RFO/linear search
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.41438
+           R2           0.01561   0.41438
+           A1           0.02883   0.02883   0.16387
+ ITU=  0
+     Eigenvalues ---    0.39877   0.429991000.00000
+ RFO step:  Lambda=-1.39431194D-06 EMin= 3.98766852D-01
+ Linear search not attempted -- first point.
+ Iteration  1 RMS(Cart)=  0.00088845 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 8.12D-15 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.79495  -0.00055   0.00000  -0.00127  -0.00127   1.79368
+    R2        1.79495  -0.00055   0.00000  -0.00127  -0.00127   1.79368
+    A1        1.76278   0.01530   0.00000   0.00000   0.00000   1.76278
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000548     0.000450     NO 
+ RMS     Force            0.000548     0.000300     NO 
+ Maximum Displacement     0.000926     0.001800     YES
+ RMS     Displacement     0.000888     0.001200     YES
+ Predicted change in Energy=-6.971560D-07
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.036350   -0.000000    0.030501
+      2          1           0        0.028067   -0.000000    0.979640
+      3          1           0        0.969631    0.000000   -0.142472
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.949175   0.000000
+     3  H    0.949175   1.464814   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0       -0.000000    0.000000    0.120750
+      2          1           0        0.000000    0.732407   -0.483000
+      3          1           0       -0.000000   -0.732407   -0.483000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):         774.5220742         467.4092858         291.4966327
+ Standard basis: 6-31G(d) (6D, 7F)
+ There are    10 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    10 symmetry adapted basis functions of A1  symmetry.
+ There are     1 symmetry adapted basis functions of A2  symmetry.
+ There are     3 symmetry adapted basis functions of B1  symmetry.
+ There are     5 symmetry adapted basis functions of B2  symmetry.
+    19 basis functions,    36 primitive gaussians,    19 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.2814635383 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    19 RedAO= T EigKep=  2.20D-02  NBF=    10     1     3     5
+ NBsUse=    19 1.00D-06 EigRej= -1.00D+00 NBFU=    10     1     3     5
+ Initial guess from the checkpoint file:  "/scratch/webmodemo/webmo-4350/627084/Gau-13489.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (B2) (A1) (B1) (A1) (B2) (A1) (A1) (A2)
+                 (B1) (A1) (B2) (A1)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=845746.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -76.0101502727     A.U. after    7 cycles
+            NFock=  7  Conv=0.59D-08     -V/T= 2.0020
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8           0.009924041    0.000000000    0.008327259
+      2        1          -0.008573580   -0.000000000    0.000140460
+      3        1          -0.001350461   -0.000000000   -0.008467718
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.009924041 RMS     0.005914970
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.015375482 RMS     0.008878779
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20 on scan point     2 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Update second derivatives using D2CorX and points    1    2
+ DE= -4.24D-07 DEPred=-6.97D-07 R= 6.08D-01
+ Trust test= 6.08D-01 RLast= 1.80D-03 DXMaxT set to 5.05D-01
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.49891
+           R2           0.10014   0.49891
+           A1           0.03099   0.03099   0.16321
+ ITU=  0  0
+ Use linear search instead of GDIIS.
+     Eigenvalues ---    0.39877   0.599051000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 3.98766852D-01
+ Quartic linear search produced a step of -0.28175.
+ Iteration  1 RMS(Cart)=  0.00025032 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 2.49D-15 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.79368   0.00022   0.00036  -0.00000   0.00036   1.79404
+    R2        1.79368   0.00022   0.00036   0.00000   0.00036   1.79404
+    A1        1.76278   0.01538  -0.00000   0.00000  -0.00000   1.76278
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000215     0.000450     YES
+ RMS     Force            0.000215     0.000300     YES
+ Maximum Displacement     0.000261     0.001800     YES
+ RMS     Displacement     0.000250     0.001200     YES
+ Predicted change in Energy=-7.735855D-08
+ Optimization completed.
+    -- Stationary point found.
+                           ----------------------------
+                           !   Optimized Parameters   !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  0.9492         -DE/DX =    0.0002              !
+ ! R2    R(1,3)                  0.9492         -DE/DX =    0.0002              !
+ ! A1    A(2,1,3)              101.0            -DE/DX =    0.0154              !
+ --------------------------------------------------------------------------------
+ Iteration  1 RMS(Cart)=  0.00992689 RMS(Int)=  0.00005578
+ Iteration  2 RMS(Cart)=  0.00004770 RMS(Int)=  0.00000000
+ Iteration  3 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.039565   -0.000000    0.033199
+      2          1           0        0.022996   -0.000000    0.982419
+      3          1           0        0.971487    0.000000   -0.147949
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.949365   0.000000
+     3  H    0.949365   1.475590   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.000000    0.000000    0.119491
+      2          1           0        0.000000    0.737795   -0.477964
+      3          1           0       -0.000000   -0.737795   -0.477964
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):         790.9290605         460.6070152         291.0882721
+ Standard basis: 6-31G(d) (6D, 7F)
+ There are    10 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    10 symmetry adapted basis functions of A1  symmetry.
+ There are     1 symmetry adapted basis functions of A2  symmetry.
+ There are     3 symmetry adapted basis functions of B1  symmetry.
+ There are     5 symmetry adapted basis functions of B2  symmetry.
+    19 basis functions,    36 primitive gaussians,    19 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.2770413956 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    19 RedAO= T EigKep=  2.20D-02  NBF=    10     1     3     5
+ NBsUse=    19 1.00D-06 EigRej= -1.00D+00 NBFU=    10     1     3     5
+ Initial guess from the checkpoint file:  "/scratch/webmodemo/webmo-4350/627084/Gau-13489.chk"
+ B after Tr=    -0.000000    0.000000    0.000000
+         Rot=    1.000000   -0.000000   -0.000000   -0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (B2) (A1) (B1) (A1) (B2) (A1) (A1) (A2)
+                 (B1) (A1) (B2) (A1)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=845746.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -76.0103872258     A.U. after    8 cycles
+            NFock=  8  Conv=0.42D-08     -V/T= 2.0020
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8           0.008347145    0.000000000    0.007004086
+      2        1          -0.006566626   -0.000000000   -0.000650113
+      3        1          -0.001780519   -0.000000000   -0.006353973
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.008347145 RMS     0.004782125
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.011799348 RMS     0.006826369
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20 on scan point     3 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- RFO/linear search
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.49891
+           R2           0.10014   0.49891
+           A1           0.03099   0.03099   0.16321
+ ITU=  0
+     Eigenvalues ---    0.39877   0.599051000.00000
+ RFO step:  Lambda=-9.57058666D-07 EMin= 3.98766852D-01
+ Linear search not attempted -- first point.
+ Iteration  1 RMS(Cart)=  0.00062605 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 7.25D-15 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.79404  -0.00054   0.00000  -0.00089  -0.00089   1.79315
+    R2        1.79404  -0.00054   0.00000  -0.00089  -0.00089   1.79315
+    A1        1.78024   0.01180   0.00000   0.00000  -0.00000   1.78024
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000535     0.000450     NO 
+ RMS     Force            0.000535     0.000300     NO 
+ Maximum Displacement     0.000653     0.001800     YES
+ RMS     Displacement     0.000626     0.001200     YES
+ Predicted change in Energy=-4.785293D-07
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.039717    0.000000    0.033326
+      2          1           0        0.023156   -0.000000    0.982074
+      3          1           0        0.971175    0.000000   -0.147731
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.948892   0.000000
+     3  H    0.948892   1.474855   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.000000   -0.000000    0.119431
+      2          1           0       -0.000000    0.737428   -0.477726
+      3          1           0       -0.000000   -0.737428   -0.477726
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):         791.7177049         461.0662917         291.3785196
+ Standard basis: 6-31G(d) (6D, 7F)
+ There are    10 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    10 symmetry adapted basis functions of A1  symmetry.
+ There are     1 symmetry adapted basis functions of A2  symmetry.
+ There are     3 symmetry adapted basis functions of B1  symmetry.
+ There are     5 symmetry adapted basis functions of B2  symmetry.
+    19 basis functions,    36 primitive gaussians,    19 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.2816653653 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    19 RedAO= T EigKep=  2.20D-02  NBF=    10     1     3     5
+ NBsUse=    19 1.00D-06 EigRej= -1.00D+00 NBFU=    10     1     3     5
+ Initial guess from the checkpoint file:  "/scratch/webmodemo/webmo-4350/627084/Gau-13489.chk"
+ B after Tr=     0.000000   -0.000000   -0.000000
+         Rot=    1.000000    0.000000    0.000000   -0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (B2) (A1) (B1) (A1) (B2) (A1) (A1) (A2)
+                 (B1) (A1) (B2) (A1)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=845746.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -76.0103877037     A.U. after    7 cycles
+            NFock=  7  Conv=0.41D-08     -V/T= 2.0020
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8           0.007869919    0.000000000    0.006603646
+      2        1          -0.006609535   -0.000000000   -0.000114389
+      3        1          -0.001260385   -0.000000000   -0.006489257
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.007869919 RMS     0.004630117
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.011853634 RMS     0.006843699
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20 on scan point     3 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Update second derivatives using D2CorX and points    1    2
+ DE= -4.78D-07 DEPred=-4.79D-07 R= 9.99D-01
+ Trust test= 9.99D-01 RLast= 1.26D-03 DXMaxT set to 5.05D-01
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.49946
+           R2           0.10069   0.49946
+           A1           0.03037   0.03037   0.16307
+ ITU=  0  0
+ Use linear search instead of GDIIS.
+     Eigenvalues ---    0.39877   0.600151000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 3.98766852D-01
+ Quartic linear search produced a step of -0.00183.
+ Iteration  1 RMS(Cart)=  0.00000114 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 4.70D-15 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.79315   0.00000   0.00000   0.00000   0.00000   1.79315
+    R2        1.79315   0.00000   0.00000  -0.00000   0.00000   1.79315
+    A1        1.78024   0.01185   0.00000   0.00000   0.00000   1.78024
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000001     0.000450     YES
+ RMS     Force            0.000001     0.000300     YES
+ Maximum Displacement     0.000001     0.001800     YES
+ RMS     Displacement     0.000001     0.001200     YES
+ Predicted change in Energy=-1.602587D-12
+ Optimization completed.
+    -- Stationary point found.
+                           ----------------------------
+                           !   Optimized Parameters   !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  0.9489         -DE/DX =    0.0                 !
+ ! R2    R(1,3)                  0.9489         -DE/DX =    0.0                 !
+ ! A1    A(2,1,3)              102.0            -DE/DX =    0.0119              !
+ --------------------------------------------------------------------------------
+ Iteration  1 RMS(Cart)=  0.00987494 RMS(Int)=  0.00005575
+ Iteration  2 RMS(Cart)=  0.00004786 RMS(Int)=  0.00000000
+ Iteration  3 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.043015   -0.000000    0.036094
+      2          1           0        0.018175   -0.000000    0.984661
+      3          1           0        0.972858    0.000000   -0.153085
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.948893   0.000000
+     3  H    0.948893   1.485222   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.000000   -0.000000    0.118140
+      2          1           0       -0.000000    0.742611   -0.472560
+      3          1           0       -0.000000   -0.742611   -0.472560
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):         809.1220569         454.6519215         291.0875712
+ Standard basis: 6-31G(d) (6D, 7F)
+ There are    10 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    10 symmetry adapted basis functions of A1  symmetry.
+ There are     1 symmetry adapted basis functions of A2  symmetry.
+ There are     3 symmetry adapted basis functions of B1  symmetry.
+ There are     5 symmetry adapted basis functions of B2  symmetry.
+    19 basis functions,    36 primitive gaussians,    19 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.2791526903 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    19 RedAO= T EigKep=  2.20D-02  NBF=    10     1     3     5
+ NBsUse=    19 1.00D-06 EigRej= -1.00D+00 NBFU=    10     1     3     5
+ Initial guess from the checkpoint file:  "/scratch/webmodemo/webmo-4350/627084/Gau-13489.chk"
+ B after Tr=    -0.000000    0.000000   -0.000000
+         Rot=    1.000000   -0.000000   -0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (B2) (A1) (B1) (A1) (B2) (A1) (A1) (A2)
+                 (B1) (A1) (B2) (A1)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=845746.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -76.0105639427     A.U. after    8 cycles
+            NFock=  8  Conv=0.42D-08     -V/T= 2.0020
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8           0.006084522    0.000000000    0.005105520
+      2        1          -0.004641707   -0.000000000   -0.000646615
+      3        1          -0.001442815   -0.000000000   -0.004458905
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.006084522 RMS     0.003448266
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.008350764 RMS     0.004840326
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20 on scan point     4 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- RFO/linear search
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.49946
+           R2           0.10069   0.49946
+           A1           0.03037   0.03037   0.16307
+ ITU=  0
+     Eigenvalues ---    0.39877   0.600151000.00000
+ RFO step:  Lambda=-9.18125544D-07 EMin= 3.98766852D-01
+ Linear search not attempted -- first point.
+ Iteration  1 RMS(Cart)=  0.00061498 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 2.75D-15 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.79315  -0.00052   0.00000  -0.00087  -0.00087   1.79227
+    R2        1.79315  -0.00052   0.00000  -0.00087  -0.00087   1.79227
+    A1        1.79769   0.00835   0.00000   0.00000   0.00000   1.79769
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000525     0.000450     NO 
+ RMS     Force            0.000525     0.000300     NO 
+ Maximum Displacement     0.000641     0.001800     YES
+ RMS     Displacement     0.000615     0.001200     YES
+ Predicted change in Energy=-4.590628D-07
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.043162   -0.000000    0.036217
+      2          1           0        0.018335   -0.000000    0.984322
+      3          1           0        0.972552    0.000000   -0.152870
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.948430   0.000000
+     3  H    0.948430   1.484498   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.000000    0.000000    0.118082
+      2          1           0       -0.000000    0.742249   -0.472329
+      3          1           0       -0.000000   -0.742249   -0.472329
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):         809.9119185         455.0957508         291.3717297
+ Standard basis: 6-31G(d) (6D, 7F)
+ There are    10 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    10 symmetry adapted basis functions of A1  symmetry.
+ There are     1 symmetry adapted basis functions of A2  symmetry.
+ There are     3 symmetry adapted basis functions of B1  symmetry.
+ There are     5 symmetry adapted basis functions of B2  symmetry.
+    19 basis functions,    36 primitive gaussians,    19 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.2836807207 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    19 RedAO= T EigKep=  2.20D-02  NBF=    10     1     3     5
+ NBsUse=    19 1.00D-06 EigRej= -1.00D+00 NBFU=    10     1     3     5
+ Initial guess from the checkpoint file:  "/scratch/webmodemo/webmo-4350/627084/Gau-13489.chk"
+ B after Tr=     0.000000   -0.000000    0.000000
+         Rot=    1.000000    0.000000   -0.000000   -0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (B2) (A1) (B1) (A1) (B2) (A1) (A1) (A2)
+                 (B1) (A1) (B2) (A1)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=845746.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -76.0105644009     A.U. after    7 cycles
+            NFock=  7  Conv=0.40D-08     -V/T= 2.0020
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8           0.005620277    0.000000000    0.004715972
+      2        1          -0.004686808   -0.000000000   -0.000121459
+      3        1          -0.000933469   -0.000000000   -0.004594513
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.005620277 RMS     0.003296290
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.008402858 RMS     0.004851393
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20 on scan point     4 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Update second derivatives using D2CorX and points    1    2
+ DE= -4.58D-07 DEPred=-4.59D-07 R= 9.98D-01
+ Trust test= 9.98D-01 RLast= 1.24D-03 DXMaxT set to 5.05D-01
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.50018
+           R2           0.10142   0.50018
+           A1           0.02978   0.02978   0.16295
+ ITU=  0  0
+ Use linear search instead of GDIIS.
+     Eigenvalues ---    0.39877   0.601601000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 3.98766852D-01
+ Quartic linear search produced a step of -0.00241.
+ Iteration  1 RMS(Cart)=  0.00000148 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 1.34D-15 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.79227   0.00000   0.00000   0.00000   0.00000   1.79228
+    R2        1.79227   0.00000   0.00000  -0.00000   0.00000   1.79228
+    A1        1.79769   0.00840  -0.00000   0.00000   0.00000   1.79769
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000001     0.000450     YES
+ RMS     Force            0.000001     0.000300     YES
+ Maximum Displacement     0.000002     0.001800     YES
+ RMS     Displacement     0.000001     0.001200     YES
+ Predicted change in Energy=-2.676024D-12
+ Optimization completed.
+    -- Stationary point found.
+                           ----------------------------
+                           !   Optimized Parameters   !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  0.9484         -DE/DX =    0.0                 !
+ ! R2    R(1,3)                  0.9484         -DE/DX =    0.0                 !
+ ! A1    A(2,1,3)              103.0            -DE/DX =    0.0084              !
+ --------------------------------------------------------------------------------
+ Iteration  1 RMS(Cart)=  0.00982310 RMS(Int)=  0.00005572
+ Iteration  2 RMS(Cart)=  0.00004802 RMS(Int)=  0.00000000
+ Iteration  3 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.046481   -0.000000    0.039002
+      2          1           0        0.013381   -0.000000    0.986855
+      3          1           0        0.974186    0.000000   -0.158188
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.948431   0.000000
+     3  H    0.948431   1.494748   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.000000    0.000000    0.116782
+      2          1           0       -0.000000    0.747374   -0.467130
+      3          1           0       -0.000000   -0.747374   -0.467130
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):         828.0412004         448.8758205         291.0820884
+ Standard basis: 6-31G(d) (6D, 7F)
+ There are    10 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    10 symmetry adapted basis functions of A1  symmetry.
+ There are     1 symmetry adapted basis functions of A2  symmetry.
+ There are     3 symmetry adapted basis functions of B1  symmetry.
+ There are     5 symmetry adapted basis functions of B2  symmetry.
+    19 basis functions,    36 primitive gaussians,    19 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.2812258687 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    19 RedAO= T EigKep=  2.20D-02  NBF=    10     1     3     5
+ NBsUse=    19 1.00D-06 EigRej= -1.00D+00 NBFU=    10     1     3     5
+ Initial guess from the checkpoint file:  "/scratch/webmodemo/webmo-4350/627084/Gau-13489.chk"
+ B after Tr=    -0.000000   -0.000000    0.000000
+         Rot=    1.000000    0.000000   -0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (B2) (A1) (B1) (A1) (B2) (A1) (A1) (A2)
+                 (B1) (A1) (B2) (A1)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=845746.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -76.0106808674     A.U. after    8 cycles
+            NFock=  8  Conv=0.42D-08     -V/T= 2.0020
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8           0.003821656    0.000000000    0.003206750
+      2        1          -0.002743514   -0.000000000   -0.000611018
+      3        1          -0.001078142   -0.000000000   -0.002595732
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.003821656 RMS     0.002126257
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.004952355 RMS     0.002889986
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20 on scan point     5 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- RFO/linear search
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.50018
+           R2           0.10142   0.50018
+           A1           0.02978   0.02978   0.16295
+ ITU=  0
+     Eigenvalues ---    0.39877   0.601601000.00000
+ RFO step:  Lambda=-8.81381225D-07 EMin= 3.98766852D-01
+ Linear search not attempted -- first point.
+ Iteration  1 RMS(Cart)=  0.00060411 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 5.04D-15 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.79228  -0.00051   0.00000  -0.00086  -0.00086   1.79142
+    R2        1.79228  -0.00051   0.00000  -0.00086  -0.00086   1.79142
+    A1        1.81514   0.00495   0.00000   0.00000  -0.00000   1.81514
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000515     0.000450     NO 
+ RMS     Force            0.000515     0.000300     NO 
+ Maximum Displacement     0.000630     0.001800     YES
+ RMS     Displacement     0.000604     0.001200     YES
+ Predicted change in Energy=-4.406906D-07
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.046623   -0.000000    0.039121
+      2          1           0        0.013539   -0.000000    0.986522
+      3          1           0        0.973886    0.000000   -0.157974
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.947978   0.000000
+     3  H    0.947978   1.494034   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0       -0.000000   -0.000000    0.116727
+      2          1           0        0.000000    0.747017   -0.466907
+      3          1           0       -0.000000   -0.747017   -0.466907
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):         828.8326074         449.3048371         291.3602925
+ Standard basis: 6-31G(d) (6D, 7F)
+ There are    10 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    10 symmetry adapted basis functions of A1  symmetry.
+ There are     1 symmetry adapted basis functions of A2  symmetry.
+ There are     3 symmetry adapted basis functions of B1  symmetry.
+ There are     5 symmetry adapted basis functions of B2  symmetry.
+    19 basis functions,    36 primitive gaussians,    19 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.2856601125 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    19 RedAO= T EigKep=  2.19D-02  NBF=    10     1     3     5
+ NBsUse=    19 1.00D-06 EigRej= -1.00D+00 NBFU=    10     1     3     5
+ Initial guess from the checkpoint file:  "/scratch/webmodemo/webmo-4350/627084/Gau-13489.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000   -0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (B2) (A1) (B1) (A1) (B2) (A1) (A1) (A2)
+                 (B1) (A1) (B2) (A1)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=845746.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -76.0106813073     A.U. after    7 cycles
+            NFock=  7  Conv=0.40D-08     -V/T= 2.0020
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8           0.003370143    0.000000000    0.002827885
+      2        1          -0.002790754   -0.000000000   -0.000096242
+      3        1          -0.000579389   -0.000000000   -0.002731644
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.003370143 RMS     0.001970616
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.005002381 RMS     0.002888126
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20 on scan point     5 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Update second derivatives using D2CorX and points    1    2
+ DE= -4.40D-07 DEPred=-4.41D-07 R= 9.98D-01
+ Trust test= 9.98D-01 RLast= 1.21D-03 DXMaxT set to 5.05D-01
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.50089
+           R2           0.10213   0.50089
+           A1           0.02922   0.02922   0.16283
+ ITU=  0  0
+ Use linear search instead of GDIIS.
+     Eigenvalues ---    0.39877   0.603021000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 3.98766852D-01
+ Quartic linear search produced a step of -0.00235.
+ Iteration  1 RMS(Cart)=  0.00000142 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 4.97D-15 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.79142   0.00000   0.00000   0.00000   0.00000   1.79142
+    R2        1.79142   0.00000   0.00000  -0.00000   0.00000   1.79142
+    A1        1.81514   0.00500   0.00000   0.00000   0.00000   1.81514
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000001     0.000450     YES
+ RMS     Force            0.000001     0.000300     YES
+ Maximum Displacement     0.000001     0.001800     YES
+ RMS     Displacement     0.000001     0.001200     YES
+ Predicted change in Energy=-2.439564D-12
+ Optimization completed.
+    -- Stationary point found.
+                           ----------------------------
+                           !   Optimized Parameters   !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  0.948          -DE/DX =    0.0                 !
+ ! R2    R(1,3)                  0.948          -DE/DX =    0.0                 !
+ ! A1    A(2,1,3)              104.0            -DE/DX =    0.005               !
+ --------------------------------------------------------------------------------
+ Iteration  1 RMS(Cart)=  0.00977137 RMS(Int)=  0.00005569
+ Iteration  2 RMS(Cart)=  0.00004818 RMS(Int)=  0.00000000
+ Iteration  3 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.049963   -0.000000    0.041924
+      2          1           0        0.008613   -0.000000    0.989001
+      3          1           0        0.975472    0.000000   -0.163256
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.947979   0.000000
+     3  H    0.947979   1.504165   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.000000   -0.000000    0.115419
+      2          1           0       -0.000000    0.752082   -0.461675
+      3          1           0       -0.000000   -0.752082   -0.461675
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):         847.7261038         443.2728168         291.0722325
+ Standard basis: 6-31G(d) (6D, 7F)
+ There are    10 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    10 symmetry adapted basis functions of A1  symmetry.
+ There are     1 symmetry adapted basis functions of A2  symmetry.
+ There are     3 symmetry adapted basis functions of B1  symmetry.
+ There are     5 symmetry adapted basis functions of B2  symmetry.
+    19 basis functions,    36 primitive gaussians,    19 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.2832645015 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    19 RedAO= T EigKep=  2.19D-02  NBF=    10     1     3     5
+ NBsUse=    19 1.00D-06 EigRej= -1.00D+00 NBFU=    10     1     3     5
+ Initial guess from the checkpoint file:  "/scratch/webmodemo/webmo-4350/627084/Gau-13489.chk"
+ B after Tr=    -0.000000    0.000000   -0.000000
+         Rot=    1.000000   -0.000000    0.000000   -0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (B2) (A1) (B1) (A1) (B2) (A1) (A1) (A2)
+                 (B1) (A1) (B2) (A1)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=845746.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -76.0107388912     A.U. after    8 cycles
+            NFock=  8  Conv=0.42D-08     -V/T= 2.0020
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8           0.001560799    0.000000000    0.001309666
+      2        1          -0.000873360   -0.000000000   -0.000544047
+      3        1          -0.000687439   -0.000000000   -0.000765619
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.001560799 RMS     0.000834586
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.001605578 RMS     0.001014693
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20 on scan point     6 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- RFO/linear search
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.50089
+           R2           0.10213   0.50089
+           A1           0.02922   0.02922   0.16283
+ ITU=  0
+     Eigenvalues ---    0.39877   0.603021000.00000
+ RFO step:  Lambda=-8.47279093D-07 EMin= 3.98766852D-01
+ Linear search not attempted -- first point.
+ Iteration  1 RMS(Cart)=  0.00059384 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 8.63D-15 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.79142  -0.00051   0.00000  -0.00084  -0.00084   1.79058
+    R2        1.79142  -0.00051   0.00000  -0.00084  -0.00084   1.79058
+    A1        1.83260   0.00161   0.00000   0.00000   0.00000   1.83260
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000505     0.000450     NO 
+ RMS     Force            0.000505     0.000300     NO 
+ Maximum Displacement     0.000619     0.001800     YES
+ RMS     Displacement     0.000594     0.001200     YES
+ Predicted change in Energy=-4.236395D-07
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.050101   -0.000000    0.042040
+      2          1           0        0.008770   -0.000000    0.988674
+      3          1           0        0.975177    0.000000   -0.163044
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.947536   0.000000
+     3  H    0.947536   1.503461   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.000000    0.000000    0.115365
+      2          1           0       -0.000000    0.751731   -0.461459
+      3          1           0       -0.000000   -0.751731   -0.461459
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):         848.5199280         443.6879045         291.3447971
+ Standard basis: 6-31G(d) (6D, 7F)
+ There are    10 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    10 symmetry adapted basis functions of A1  symmetry.
+ There are     1 symmetry adapted basis functions of A2  symmetry.
+ There are     3 symmetry adapted basis functions of B1  symmetry.
+ There are     5 symmetry adapted basis functions of B2  symmetry.
+    19 basis functions,    36 primitive gaussians,    19 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.2876099824 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    19 RedAO= T EigKep=  2.19D-02  NBF=    10     1     3     5
+ NBsUse=    19 1.00D-06 EigRej= -1.00D+00 NBFU=    10     1     3     5
+ Initial guess from the checkpoint file:  "/scratch/webmodemo/webmo-4350/627084/Gau-13489.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (B2) (A1) (B1) (A1) (B2) (A1) (A1) (A2)
+                 (B1) (A1) (B2) (A1)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=845746.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -76.0107393141     A.U. after    7 cycles
+            NFock=  7  Conv=0.39D-08     -V/T= 2.0020
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8           0.001121476    0.000000000    0.000941030
+      2        1          -0.000922717   -0.000000000   -0.000039125
+      3        1          -0.000198758   -0.000000000   -0.000901905
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.001121476 RMS     0.000653972
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.001653685 RMS     0.000954756
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20 on scan point     6 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Update second derivatives using D2CorX and points    2
+ DE= -4.23D-07 DEPred=-4.24D-07 R= 9.98D-01
+ Trust test= 9.98D-01 RLast= 1.19D-03 DXMaxT set to 5.05D-01
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.50089
+           R2           0.10213   0.50089
+           A1           0.02922   0.02922   0.16283
+ ITU=  0  0
+ Use linear search instead of GDIIS.
+     Eigenvalues ---    0.39877   0.603021000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 3.98766852D-01
+ Quartic linear search produced a step of -0.00229.
+ Iteration  1 RMS(Cart)=  0.00000136 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 1.63D-15 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.79058   0.00000   0.00000  -0.00000   0.00000   1.79058
+    R2        1.79058   0.00000   0.00000   0.00000   0.00000   1.79058
+    A1        1.83260   0.00165  -0.00000   0.00000  -0.00000   1.83260
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000001     0.000450     YES
+ RMS     Force            0.000001     0.000300     YES
+ Maximum Displacement     0.000001     0.001800     YES
+ RMS     Displacement     0.000001     0.001200     YES
+ Predicted change in Energy=-2.235139D-12
+ Optimization completed.
+    -- Stationary point found.
+                           ----------------------------
+                           !   Optimized Parameters   !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  0.9475         -DE/DX =    0.0                 !
+ ! R2    R(1,3)                  0.9475         -DE/DX =    0.0                 !
+ ! A1    A(2,1,3)              105.0            -DE/DX =    0.0017              !
+ --------------------------------------------------------------------------------
+ Iteration  1 RMS(Cart)=  0.00971976 RMS(Int)=  0.00005567
+ Iteration  2 RMS(Cart)=  0.00004834 RMS(Int)=  0.00000000
+ Iteration  3 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.053462    0.000000    0.044860
+      2          1           0        0.003872   -0.000000    0.991098
+      3          1           0        0.976714    0.000000   -0.168289
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.947537   0.000000
+     3  H    0.947537   1.513473   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0       -0.000000    0.000000    0.114048
+      2          1           0        0.000000    0.756736   -0.456193
+      3          1           0       -0.000000   -0.756736   -0.456193
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):         868.2190727         437.8372782         291.0584029
+ Standard basis: 6-31G(d) (6D, 7F)
+ There are    10 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    10 symmetry adapted basis functions of A1  symmetry.
+ There are     1 symmetry adapted basis functions of A2  symmetry.
+ There are     3 symmetry adapted basis functions of B1  symmetry.
+ There are     5 symmetry adapted basis functions of B2  symmetry.
+    19 basis functions,    36 primitive gaussians,    19 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.2852720923 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    19 RedAO= T EigKep=  2.19D-02  NBF=    10     1     3     5
+ NBsUse=    19 1.00D-06 EigRej= -1.00D+00 NBFU=    10     1     3     5
+ Initial guess from the checkpoint file:  "/scratch/webmodemo/webmo-4350/627084/Gau-13489.chk"
+ B after Tr=    -0.000000   -0.000000    0.000000
+         Rot=    1.000000    0.000000   -0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (B2) (A1) (B1) (A1) (B2) (A1) (A1) (A2)
+                 (B1) (A1) (B2) (A1)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=845746.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -76.0107389306     A.U. after    8 cycles
+            NFock=  8  Conv=0.41D-08     -V/T= 2.0020
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8          -0.000695773    0.000000000   -0.000583822
+      2        1           0.000967456   -0.000000000   -0.000446463
+      3        1          -0.000271683   -0.000000000    0.001030285
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.001030285 RMS     0.000586472
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.001688099 RMS     0.001055568
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20 on scan point     7 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- RFO/linear search
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.50089
+           R2           0.10213   0.50089
+           A1           0.02922   0.02922   0.16283
+ ITU=  0
+     Eigenvalues ---    0.39877   0.603021000.00000
+ RFO step:  Lambda=-8.17538481D-07 EMin= 3.98766852D-01
+ Linear search not attempted -- first point.
+ Iteration  1 RMS(Cart)=  0.00058549 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 2.00D-14 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.79058  -0.00050   0.00000  -0.00082  -0.00082   1.78976
+    R2        1.79058  -0.00050   0.00000  -0.00082  -0.00082   1.78976
+    A1        1.85005  -0.00169   0.00000   0.00000  -0.00000   1.85005
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000496     0.000450     NO 
+ RMS     Force            0.000496     0.000300     NO 
+ Maximum Displacement     0.000610     0.001800     YES
+ RMS     Displacement     0.000585     0.001200     YES
+ Predicted change in Energy=-4.087692D-07
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.053596    0.000000    0.044973
+      2          1           0        0.004029   -0.000000    0.990776
+      3          1           0        0.976423    0.000000   -0.168079
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.947101   0.000000
+     3  H    0.947101   1.512777   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.000000   -0.000000    0.113996
+      2          1           0       -0.000000    0.756389   -0.455984
+      3          1           0       -0.000000   -0.756389   -0.455984
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):         869.0180537         438.2401991         291.3262503
+ Standard basis: 6-31G(d) (6D, 7F)
+ There are    10 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    10 symmetry adapted basis functions of A1  symmetry.
+ There are     1 symmetry adapted basis functions of A2  symmetry.
+ There are     3 symmetry adapted basis functions of B1  symmetry.
+ There are     5 symmetry adapted basis functions of B2  symmetry.
+    19 basis functions,    36 primitive gaussians,    19 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.2895435087 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    19 RedAO= T EigKep=  2.19D-02  NBF=    10     1     3     5
+ NBsUse=    19 1.00D-06 EigRej= -1.00D+00 NBFU=    10     1     3     5
+ Initial guess from the checkpoint file:  "/scratch/webmodemo/webmo-4350/627084/Gau-13489.chk"
+ B after Tr=     0.000000    0.000000   -0.000000
+         Rot=    1.000000   -0.000000    0.000000   -0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (B2) (A1) (B1) (A1) (B2) (A1) (A1) (A2)
+                 (B1) (A1) (B2) (A1)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=845746.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -76.0107393377     A.U. after    7 cycles
+            NFock=  7  Conv=0.38D-08     -V/T= 2.0020
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8          -0.001124415    0.000000000   -0.000943496
+      2        1           0.000915878   -0.000000000    0.000050260
+      3        1           0.000208537   -0.000000000    0.000893236
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.001124415 RMS     0.000652960
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.001641664 RMS     0.000947817
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20 on scan point     7 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Update second derivatives using D2CorX and points    2
+ DE= -4.07D-07 DEPred=-4.09D-07 R= 9.96D-01
+ Trust test= 9.96D-01 RLast= 1.16D-03 DXMaxT set to 5.05D-01
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.50089
+           R2           0.10213   0.50089
+           A1           0.02922   0.02922   0.16283
+ ITU=  0  0
+ Use linear search instead of GDIIS.
+     Eigenvalues ---    0.39877   0.603021000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 3.98766852D-01
+ Quartic linear search produced a step of -0.00452.
+ Iteration  1 RMS(Cart)=  0.00000265 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 5.04D-15 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.78976   0.00000   0.00000   0.00000   0.00000   1.78977
+    R2        1.78976   0.00000   0.00000  -0.00000   0.00000   1.78977
+    A1        1.85005  -0.00164   0.00000   0.00000  -0.00000   1.85005
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000002     0.000450     YES
+ RMS     Force            0.000002     0.000300     YES
+ Maximum Displacement     0.000003     0.001800     YES
+ RMS     Displacement     0.000003     0.001200     YES
+ Predicted change in Energy=-8.453466D-12
+ Optimization completed.
+    -- Stationary point found.
+                           ----------------------------
+                           !   Optimized Parameters   !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  0.9471         -DE/DX =    0.0                 !
+ ! R2    R(1,3)                  0.9471         -DE/DX =    0.0                 !
+ ! A1    A(2,1,3)              106.0            -DE/DX =   -0.0016              !
+ --------------------------------------------------------------------------------
+ Iteration  1 RMS(Cart)=  0.00966828 RMS(Int)=  0.00005564
+ Iteration  2 RMS(Cart)=  0.00004850 RMS(Int)=  0.00000000
+ Iteration  3 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.056978    0.000000    0.047810
+      2          1           0       -0.000842   -0.000000    0.993146
+      3          1           0        0.977912    0.000000   -0.173287
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.947103   0.000000
+     3  H    0.947103   1.522670   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.000000   -0.000000    0.112672
+      2          1           0       -0.000000    0.761335   -0.450687
+      3          1           0       -0.000000   -0.761335   -0.450687
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):         889.5653291         432.5638219         291.0409912
+ Standard basis: 6-31G(d) (6D, 7F)
+ There are    10 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    10 symmetry adapted basis functions of A1  symmetry.
+ There are     1 symmetry adapted basis functions of A2  symmetry.
+ There are     3 symmetry adapted basis functions of B1  symmetry.
+ There are     5 symmetry adapted basis functions of B2  symmetry.
+    19 basis functions,    36 primitive gaussians,    19 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.2872520814 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    19 RedAO= T EigKep=  2.19D-02  NBF=    10     1     3     5
+ NBsUse=    19 1.00D-06 EigRej= -1.00D+00 NBFU=    10     1     3     5
+ Initial guess from the checkpoint file:  "/scratch/webmodemo/webmo-4350/627084/Gau-13489.chk"
+ B after Tr=    -0.000000   -0.000000   -0.000000
+         Rot=    1.000000    0.000000   -0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (B2) (A1) (B1) (A1) (B2) (A1) (A1) (A2)
+                 (B1) (A1) (B2) (A1)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=845746.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -76.0106819277     A.U. after    8 cycles
+            NFock=  8  Conv=0.41D-08     -V/T= 2.0020
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8          -0.002945757    0.000000000   -0.002471784
+      2        1           0.002777642   -0.000000000   -0.000319065
+      3        1           0.000168115   -0.000000000    0.002790848
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.002945757 RMS     0.001838520
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.004927193 RMS     0.002872490
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20 on scan point     8 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- RFO/linear search
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.50089
+           R2           0.10213   0.50089
+           A1           0.02922   0.02922   0.16283
+ ITU=  0
+     Eigenvalues ---    0.39877   0.603021000.00000
+ RFO step:  Lambda=-7.89967976D-07 EMin= 3.98766852D-01
+ Linear search not attempted -- first point.
+ Iteration  1 RMS(Cart)=  0.00057764 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 1.68D-14 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.78977  -0.00049   0.00000  -0.00081  -0.00081   1.78896
+    R2        1.78977  -0.00049   0.00000  -0.00081  -0.00081   1.78896
+    A1        1.86750  -0.00493   0.00000   0.00000  -0.00000   1.86750
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000488     0.000450     NO 
+ RMS     Force            0.000488     0.000300     NO 
+ Maximum Displacement     0.000602     0.001800     YES
+ RMS     Displacement     0.000578     0.001200     YES
+ Predicted change in Energy=-3.949840D-07
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.057108    0.000000    0.047919
+      2          1           0       -0.000685   -0.000000    0.992828
+      3          1           0        0.977626    0.000000   -0.173078
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.946675   0.000000
+     3  H    0.946675   1.521982   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0       -0.000000    0.000000    0.112621
+      2          1           0       -0.000000    0.760991   -0.450483
+      3          1           0       -0.000000   -0.760991   -0.450483
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):         890.3703914         432.9552950         291.3043852
+ Standard basis: 6-31G(d) (6D, 7F)
+ There are    10 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    10 symmetry adapted basis functions of A1  symmetry.
+ There are     1 symmetry adapted basis functions of A2  symmetry.
+ There are     3 symmetry adapted basis functions of B1  symmetry.
+ There are     5 symmetry adapted basis functions of B2  symmetry.
+    19 basis functions,    36 primitive gaussians,    19 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.2914536427 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    19 RedAO= T EigKep=  2.19D-02  NBF=    10     1     3     5
+ NBsUse=    19 1.00D-06 EigRej= -1.00D+00 NBFU=    10     1     3     5
+ Initial guess from the checkpoint file:  "/scratch/webmodemo/webmo-4350/627084/Gau-13489.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000   -0.000000    0.000000   -0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (B2) (A1) (B1) (A1) (B2) (A1) (A1) (A2)
+                 (B1) (A1) (B2) (A1)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=845746.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -76.0106823202     A.U. after    7 cycles
+            NFock=  7  Conv=0.38D-08     -V/T= 2.0020
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8          -0.003364154    0.000000000   -0.002822860
+      2        1           0.002723846   -0.000000000    0.000169897
+      3        1           0.000640307   -0.000000000    0.002652963
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.003364154 RMS     0.001948859
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.004882307 RMS     0.002818803
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20 on scan point     8 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Update second derivatives using D2CorX and points    2
+ DE= -3.93D-07 DEPred=-3.95D-07 R= 9.94D-01
+ Trust test= 9.94D-01 RLast= 1.14D-03 DXMaxT set to 5.05D-01
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.50089
+           R2           0.10213   0.50089
+           A1           0.02922   0.02922   0.16283
+ ITU=  0  0
+ Use linear search instead of GDIIS.
+     Eigenvalues ---    0.39877   0.603021000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 3.98766852D-01
+ Quartic linear search produced a step of -0.00669.
+ Iteration  1 RMS(Cart)=  0.00000387 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 2.17D-15 for atom     1.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.78896   0.00000   0.00001   0.00000   0.00001   1.78896
+    R2        1.78896   0.00000   0.00001  -0.00000   0.00001   1.78896
+    A1        1.86750  -0.00488   0.00000   0.00000  -0.00000   1.86750
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000003     0.000450     YES
+ RMS     Force            0.000003     0.000300     YES
+ Maximum Displacement     0.000004     0.001800     YES
+ RMS     Displacement     0.000004     0.001200     YES
+ Predicted change in Energy=-1.798900D-11
+ Optimization completed.
+    -- Stationary point found.
+                           ----------------------------
+                           !   Optimized Parameters   !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  0.9467         -DE/DX =    0.0                 !
+ ! R2    R(1,3)                  0.9467         -DE/DX =    0.0                 !
+ ! A1    A(2,1,3)              107.0            -DE/DX =   -0.0049              !
+ --------------------------------------------------------------------------------
+ Iteration  1 RMS(Cart)=  0.00961693 RMS(Int)=  0.00005562
+ Iteration  2 RMS(Cart)=  0.00004865 RMS(Int)=  0.00000000
+ Iteration  3 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.060509   -0.000000    0.050773
+      2          1           0       -0.005528   -0.000000    0.995145
+      3          1           0        0.979066    0.000000   -0.178249
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.946678   0.000000
+     3  H    0.946678   1.531757   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.000000   -0.000000    0.111289
+      2          1           0       -0.000000    0.765878   -0.445154
+      3          1           0       -0.000000   -0.765878   -0.445154
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):         911.8132592         427.4473030         291.0203805
+ Standard basis: 6-31G(d) (6D, 7F)
+ There are    10 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    10 symmetry adapted basis functions of A1  symmetry.
+ There are     1 symmetry adapted basis functions of A2  symmetry.
+ There are     3 symmetry adapted basis functions of B1  symmetry.
+ There are     5 symmetry adapted basis functions of B2  symmetry.
+    19 basis functions,    36 primitive gaussians,    19 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.2892078528 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    19 RedAO= T EigKep=  2.19D-02  NBF=    10     1     3     5
+ NBsUse=    19 1.00D-06 EigRej= -1.00D+00 NBFU=    10     1     3     5
+ Initial guess from the checkpoint file:  "/scratch/webmodemo/webmo-4350/627084/Gau-13489.chk"
+ B after Tr=    -0.000000   -0.000000   -0.000000
+         Rot=    1.000000    0.000000   -0.000000   -0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (B2) (A1) (B1) (A1) (B2) (A1) (A1) (A2)
+                 (B1) (A1) (B2) (A1)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=845746.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -76.0105688505     A.U. after    8 cycles
+            NFock=  8  Conv=0.41D-08     -V/T= 2.0020
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8          -0.005186828    0.000000000   -0.004352266
+      2        1           0.004555917   -0.000000000   -0.000162687
+      3        1           0.000630911   -0.000000000    0.004514953
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.005186828 RMS     0.003116464
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.008110204 RMS     0.004698808
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20 on scan point     9 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- RFO/linear search
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.50089
+           R2           0.10213   0.50089
+           A1           0.02922   0.02922   0.16283
+ ITU=  0
+     Eigenvalues ---    0.39877   0.603021000.00000
+ RFO step:  Lambda=-7.64458089D-07 EMin= 3.98766852D-01
+ Linear search not attempted -- first point.
+ Iteration  1 RMS(Cart)=  0.00057030 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 9.08D-15 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.78896  -0.00048   0.00000  -0.00080  -0.00080   1.78817
+    R2        1.78896  -0.00048   0.00000  -0.00080  -0.00080   1.78817
+    A1        1.88496  -0.00811   0.00000   0.00000   0.00000   1.88496
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000480     0.000450     NO 
+ RMS     Force            0.000480     0.000300     NO 
+ Maximum Displacement     0.000594     0.001800     YES
+ RMS     Displacement     0.000570     0.001200     YES
+ Predicted change in Energy=-3.822290D-07
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.060636   -0.000000    0.050879
+      2          1           0       -0.005372   -0.000000    0.994831
+      3          1           0        0.978784    0.000000   -0.178041
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.946256   0.000000
+     3  H    0.946256   1.531075   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.000000   -0.000000    0.111239
+      2          1           0       -0.000000    0.765537   -0.444956
+      3          1           0       -0.000000   -0.765537   -0.444956
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):         912.6253791         427.8280152         291.2795821
+ Standard basis: 6-31G(d) (6D, 7F)
+ There are    10 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    10 symmetry adapted basis functions of A1  symmetry.
+ There are     1 symmetry adapted basis functions of A2  symmetry.
+ There are     3 symmetry adapted basis functions of B1  symmetry.
+ There are     5 symmetry adapted basis functions of B2  symmetry.
+    19 basis functions,    36 primitive gaussians,    19 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.2933437169 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    19 RedAO= T EigKep=  2.19D-02  NBF=    10     1     3     5
+ NBsUse=    19 1.00D-06 EigRej= -1.00D+00 NBFU=    10     1     3     5
+ Initial guess from the checkpoint file:  "/scratch/webmodemo/webmo-4350/627084/Gau-13489.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000   -0.000000    0.000000   -0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (B2) (A1) (B1) (A1) (B2) (A1) (A1) (A2)
+                 (B1) (A1) (B2) (A1)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=845746.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -76.0105692296     A.U. after    7 cycles
+            NFock=  7  Conv=0.38D-08     -V/T= 2.0020
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8          -0.005595405    0.000000000   -0.004695102
+      2        1           0.004499902   -0.000000000    0.000318948
+      3        1           0.001095503   -0.000000000    0.004376154
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.005595405 RMS     0.003232719
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.008066752 RMS     0.004657343
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20 on scan point     9 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Update second derivatives using D2CorX and points    2
+ DE= -3.79D-07 DEPred=-3.82D-07 R= 9.92D-01
+ Trust test= 9.92D-01 RLast= 1.13D-03 DXMaxT set to 5.05D-01
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.50089
+           R2           0.10213   0.50089
+           A1           0.02922   0.02922   0.16283
+ ITU=  0  0
+ Use linear search instead of GDIIS.
+     Eigenvalues ---    0.39877   0.603021000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 3.98766852D-01
+ Quartic linear search produced a step of -0.00881.
+ Iteration  1 RMS(Cart)=  0.00000503 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 4.29D-15 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.78817   0.00000   0.00001   0.00000   0.00001   1.78817
+    R2        1.78817   0.00000   0.00001  -0.00000   0.00001   1.78817
+    A1        1.88496  -0.00807   0.00000   0.00000   0.00000   1.88496
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000004     0.000450     YES
+ RMS     Force            0.000004     0.000300     YES
+ Maximum Displacement     0.000005     0.001800     YES
+ RMS     Displacement     0.000005     0.001200     YES
+ Predicted change in Energy=-3.029069D-11
+ Optimization completed.
+    -- Stationary point found.
+                           ----------------------------
+                           !   Optimized Parameters   !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  0.9463         -DE/DX =    0.0                 !
+ ! R2    R(1,3)                  0.9463         -DE/DX =    0.0                 !
+ ! A1    A(2,1,3)              108.0            -DE/DX =   -0.0081              !
+ --------------------------------------------------------------------------------
+ Iteration  1 RMS(Cart)=  0.00956572 RMS(Int)=  0.00005559
+ Iteration  2 RMS(Cart)=  0.00004881 RMS(Int)=  0.00000000
+ Iteration  3 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.064057    0.000000    0.053750
+      2          1           0       -0.010186   -0.000000    0.997093
+      3          1           0        0.980177    0.000000   -0.183174
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.946260   0.000000
+     3  H    0.946260   1.540730   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.000000    0.000000    0.109899
+      2          1           0       -0.000000    0.770365   -0.439597
+      3          1           0       -0.000000   -0.770365   -0.439597
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):         935.0146850         422.4828023         290.9969470
+ Standard basis: 6-31G(d) (6D, 7F)
+ There are    10 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    10 symmetry adapted basis functions of A1  symmetry.
+ There are     1 symmetry adapted basis functions of A2  symmetry.
+ There are     3 symmetry adapted basis functions of B1  symmetry.
+ There are     5 symmetry adapted basis functions of B2  symmetry.
+    19 basis functions,    36 primitive gaussians,    19 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.2911427394 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    19 RedAO= T EigKep=  2.19D-02  NBF=    10     1     3     5
+ NBsUse=    19 1.00D-06 EigRej= -1.00D+00 NBFU=    10     1     3     5
+ Initial guess from the checkpoint file:  "/scratch/webmodemo/webmo-4350/627084/Gau-13489.chk"
+ B after Tr=    -0.000000   -0.000000    0.000000
+         Rot=    1.000000    0.000000   -0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (B2) (A1) (B1) (A1) (B2) (A1) (A1) (A2)
+                 (B1) (A1) (B2) (A1)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=845746.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -76.0104006933     A.U. after    8 cycles
+            NFock=  8  Conv=0.40D-08     -V/T= 2.0020
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8          -0.007416635    0.000000000   -0.006223296
+      2        1           0.006301011   -0.000000000    0.000021796
+      3        1           0.001115624   -0.000000000    0.006201500
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.007416635 RMS     0.004386118
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.011235618 RMS     0.006498356
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20 on scan point    10 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- RFO/linear search
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.50089
+           R2           0.10213   0.50089
+           A1           0.02922   0.02922   0.16283
+ ITU=  0
+     Eigenvalues ---    0.39877   0.603021000.00000
+ RFO step:  Lambda=-7.40907690D-07 EMin= 3.98766852D-01
+ Linear search not attempted -- first point.
+ Iteration  1 RMS(Cart)=  0.00056345 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 2.11D-15 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.78817  -0.00047   0.00000  -0.00078  -0.00078   1.78739
+    R2        1.78817  -0.00047   0.00000  -0.00078  -0.00078   1.78739
+    A1        1.90241  -0.01124   0.00000   0.00000  -0.00000   1.90241
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000473     0.000450     NO 
+ RMS     Force            0.000473     0.000300     NO 
+ Maximum Displacement     0.000586     0.001800     YES
+ RMS     Displacement     0.000563     0.001200     YES
+ Predicted change in Energy=-3.704538D-07
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.064180    0.000000    0.053854
+      2          1           0       -0.010030   -0.000000    0.996783
+      3          1           0        0.979898    0.000000   -0.182967
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.945845   0.000000
+     3  H    0.945845   1.540055   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0       -0.000000    0.000000    0.109851
+      2          1           0        0.000000    0.770027   -0.439404
+      3          1           0       -0.000000   -0.770027   -0.439404
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):         935.8348952         422.8534111         291.2522142
+ Standard basis: 6-31G(d) (6D, 7F)
+ There are    10 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    10 symmetry adapted basis functions of A1  symmetry.
+ There are     1 symmetry adapted basis functions of A2  symmetry.
+ There are     3 symmetry adapted basis functions of B1  symmetry.
+ There are     5 symmetry adapted basis functions of B2  symmetry.
+    19 basis functions,    36 primitive gaussians,    19 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.2952170173 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    19 RedAO= T EigKep=  2.19D-02  NBF=    10     1     3     5
+ NBsUse=    19 1.00D-06 EigRej= -1.00D+00 NBFU=    10     1     3     5
+ Initial guess from the checkpoint file:  "/scratch/webmodemo/webmo-4350/627084/Gau-13489.chk"
+ B after Tr=     0.000000    0.000000   -0.000000
+         Rot=    1.000000   -0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (B2) (A1) (A1) (B1) (B2) (A1) (A2) (A1)
+                 (B1) (A1) (B2) (A1)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=845746.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -76.0104010599     A.U. after    7 cycles
+            NFock=  7  Conv=0.38D-08     -V/T= 2.0020
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8          -0.007815807    0.000000000   -0.006558241
+      2        1           0.006242768   -0.000000000    0.000496537
+      3        1           0.001573039   -0.000000000    0.006061704
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.007815807 RMS     0.004503514
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.011193487 RMS     0.006462564
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20 on scan point    10 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Update second derivatives using D2CorX and points    2
+ DE= -3.67D-07 DEPred=-3.70D-07 R= 9.89D-01
+ Trust test= 9.89D-01 RLast= 1.11D-03 DXMaxT set to 5.05D-01
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.50089
+           R2           0.10213   0.50089
+           A1           0.02922   0.02922   0.16283
+ ITU=  0  0
+ Use linear search instead of GDIIS.
+     Eigenvalues ---    0.39877   0.603021000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 3.98766852D-01
+ Quartic linear search produced a step of -0.01088.
+ Iteration  1 RMS(Cart)=  0.00000613 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 1.37D-15 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.78739   0.00001   0.00001   0.00000   0.00001   1.78740
+    R2        1.78739   0.00001   0.00001  -0.00000   0.00001   1.78740
+    A1        1.90241  -0.01119   0.00000   0.00000   0.00000   1.90241
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000005     0.000450     YES
+ RMS     Force            0.000005     0.000300     YES
+ Maximum Displacement     0.000006     0.001800     YES
+ RMS     Displacement     0.000006     0.001200     YES
+ Predicted change in Energy=-4.490779D-11
+ Optimization completed.
+    -- Stationary point found.
+                           ----------------------------
+                           !   Optimized Parameters   !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  0.9458         -DE/DX =    0.0                 !
+ ! R2    R(1,3)                  0.9458         -DE/DX =    0.0                 !
+ ! A1    A(2,1,3)              109.0            -DE/DX =   -0.0112              !
+ --------------------------------------------------------------------------------
+ Iteration  1 RMS(Cart)=  0.00951467 RMS(Int)=  0.00005557
+ Iteration  2 RMS(Cart)=  0.00004896 RMS(Int)=  0.00000000
+ Iteration  3 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.067621   -0.000000    0.056741
+      2          1           0       -0.014815   -0.000000    0.998991
+      3          1           0        0.981242    0.000000   -0.188063
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.945850   0.000000
+     3  H    0.945850   1.549589   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0       -0.000000   -0.000000    0.108503
+      2          1           0        0.000000    0.774795   -0.434014
+      3          1           0       -0.000000   -0.774795   -0.434014
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):         959.2251633         417.6656157         290.9710592
+ Standard basis: 6-31G(d) (6D, 7F)
+ There are    10 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    10 symmetry adapted basis functions of A1  symmetry.
+ There are     1 symmetry adapted basis functions of A2  symmetry.
+ There are     3 symmetry adapted basis functions of B1  symmetry.
+ There are     5 symmetry adapted basis functions of B2  symmetry.
+    19 basis functions,    36 primitive gaussians,    19 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.2930600283 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    19 RedAO= T EigKep=  2.19D-02  NBF=    10     1     3     5
+ NBsUse=    19 1.00D-06 EigRej= -1.00D+00 NBFU=    10     1     3     5
+ Initial guess from the checkpoint file:  "/scratch/webmodemo/webmo-4350/627084/Gau-13489.chk"
+ B after Tr=    -0.000000   -0.000000    0.000000
+         Rot=    1.000000   -0.000000   -0.000000   -0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (B2) (A1) (A1) (B1) (B2) (A1) (A2) (A1)
+                 (B1) (A1) (B2) (A1)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=845746.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -76.0101784768     A.U. after    8 cycles
+            NFock=  8  Conv=0.40D-08     -V/T= 2.0020
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8          -0.009632799    0.000000000   -0.008082878
+      2        1           0.008011660   -0.000000000    0.000233476
+      3        1           0.001621139   -0.000000000    0.007849402
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.009632799 RMS     0.005643149
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.014301896 RMS     0.008265953
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20 on scan point    11 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- RFO/linear search
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.50089
+           R2           0.10213   0.50089
+           A1           0.02922   0.02922   0.16283
+ ITU=  0
+     Eigenvalues ---    0.39877   0.603021000.00000
+ RFO step:  Lambda=-7.19223191D-07 EMin= 3.98766852D-01
+ Linear search not attempted -- first point.
+ Iteration  1 RMS(Cart)=  0.00055711 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 8.68D-15 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.78740  -0.00047   0.00000  -0.00077  -0.00077   1.78662
+    R2        1.78740  -0.00047   0.00000  -0.00077  -0.00077   1.78662
+    A1        1.91986  -0.01430   0.00000   0.00000   0.00000   1.91986
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000466     0.000450     NO 
+ RMS     Force            0.000466     0.000300     NO 
+ Maximum Displacement     0.000579     0.001800     YES
+ RMS     Displacement     0.000557     0.001200     YES
+ Predicted change in Energy=-3.596116D-07
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.067741   -0.000000    0.056841
+      2          1           0       -0.014660   -0.000000    0.998685
+      3          1           0        0.980967    0.000000   -0.187857
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.945441   0.000000
+     3  H    0.945441   1.548920   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0       -0.000000    0.000000    0.108457
+      2          1           0        0.000000    0.774460   -0.433826
+      3          1           0       -0.000000   -0.774460   -0.433826
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):         960.0545581         418.0267506         291.2226476
+ Standard basis: 6-31G(d) (6D, 7F)
+ There are    10 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    10 symmetry adapted basis functions of A1  symmetry.
+ There are     1 symmetry adapted basis functions of A2  symmetry.
+ There are     3 symmetry adapted basis functions of B1  symmetry.
+ There are     5 symmetry adapted basis functions of B2  symmetry.
+    19 basis functions,    36 primitive gaussians,    19 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.2970767863 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    19 RedAO= T EigKep=  2.19D-02  NBF=    10     1     3     5
+ NBsUse=    19 1.00D-06 EigRej= -1.00D+00 NBFU=    10     1     3     5
+ Initial guess from the checkpoint file:  "/scratch/webmodemo/webmo-4350/627084/Gau-13489.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000   -0.000000   -0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (B2) (A1) (A1) (B1) (B2) (A1) (A2) (A1)
+                 (B1) (A1) (B2) (A1)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=845746.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -76.0101788318     A.U. after    7 cycles
+            NFock=  7  Conv=0.37D-08     -V/T= 2.0020
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8          -0.010022972    0.000000000   -0.008410272
+      2        1           0.007951175   -0.000000000    0.000701750
+      3        1           0.002071796   -0.000000000    0.007708522
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.010022972 RMS     0.005760208
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.014260982 RMS     0.008233583
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20 on scan point    11 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Update second derivatives using D2CorX and points    2
+ DE= -3.55D-07 DEPred=-3.60D-07 R= 9.87D-01
+ Trust test= 9.87D-01 RLast= 1.09D-03 DXMaxT set to 5.05D-01
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.50089
+           R2           0.10213   0.50089
+           A1           0.02922   0.02922   0.16283
+ ITU=  0  0
+ Use linear search instead of GDIIS.
+     Eigenvalues ---    0.39877   0.603021000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 3.98766852D-01
+ Quartic linear search produced a step of -0.01289.
+ Iteration  1 RMS(Cart)=  0.00000718 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 3.87D-15 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.78662   0.00001   0.00001  -0.00000   0.00001   1.78663
+    R2        1.78662   0.00001   0.00001   0.00000   0.00001   1.78663
+    A1        1.91986  -0.01426  -0.00000   0.00000   0.00000   1.91986
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000006     0.000450     YES
+ RMS     Force            0.000006     0.000300     YES
+ Maximum Displacement     0.000007     0.001800     YES
+ RMS     Displacement     0.000007     0.001200     YES
+ Predicted change in Energy=-6.147715D-11
+ Optimization completed.
+    -- Stationary point found.
+                           ----------------------------
+                           !   Optimized Parameters   !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  0.9454         -DE/DX =    0.0                 !
+ ! R2    R(1,3)                  0.9454         -DE/DX =    0.0                 !
+ ! A1    A(2,1,3)              110.0            -DE/DX =   -0.0143              !
+ --------------------------------------------------------------------------------
+ Iteration  1 RMS(Cart)=  0.00946377 RMS(Int)=  0.00005555
+ Iteration  2 RMS(Cart)=  0.00004911 RMS(Int)=  0.00000000
+ Iteration  3 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.071201   -0.000000    0.059745
+      2          1           0       -0.019416   -0.000000    1.000839
+      3          1           0        0.982262    0.000000   -0.192914
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.945446   0.000000
+     3  H    0.945446   1.558334   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.000000    0.000000    0.107101
+      2          1           0        0.000000    0.779167   -0.428405
+      3          1           0       -0.000000   -0.779167   -0.428405
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):         984.5043144         412.9912437         290.9430795
+ Standard basis: 6-31G(d) (6D, 7F)
+ There are    10 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    10 symmetry adapted basis functions of A1  symmetry.
+ There are     1 symmetry adapted basis functions of A2  symmetry.
+ There are     3 symmetry adapted basis functions of B1  symmetry.
+ There are     5 symmetry adapted basis functions of B2  symmetry.
+    19 basis functions,    36 primitive gaussians,    19 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.2949629632 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    19 RedAO= T EigKep=  2.19D-02  NBF=    10     1     3     5
+ NBsUse=    19 1.00D-06 EigRej= -1.00D+00 NBFU=    10     1     3     5
+ Initial guess from the checkpoint file:  "/scratch/webmodemo/webmo-4350/627084/Gau-13489.chk"
+ B after Tr=    -0.000000   -0.000000    0.000000
+         Rot=    1.000000    0.000000   -0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (B2) (A1) (A1) (B1) (B2) (A1) (A2) (A1)
+                 (B1) (A1) (B2) (A1)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=845746.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -76.0099032484     A.U. after    8 cycles
+            NFock=  8  Conv=0.40D-08     -V/T= 2.0020
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8          -0.011832917    0.000000000   -0.009928996
+      2        1           0.009686611   -0.000000000    0.000471405
+      3        1           0.002146306   -0.000000000    0.009457591
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.011832917 RMS     0.006885639
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.017307484 RMS     0.009999512
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20 on scan point    12 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- RFO/linear search
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.50089
+           R2           0.10213   0.50089
+           A1           0.02922   0.02922   0.16283
+ ITU=  0
+     Eigenvalues ---    0.39877   0.603021000.00000
+ RFO step:  Lambda=-6.99317793D-07 EMin= 3.98766852D-01
+ Linear search not attempted -- first point.
+ Iteration  1 RMS(Cart)=  0.00055126 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 2.55D-15 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.78663  -0.00046   0.00000  -0.00076  -0.00076   1.78587
+    R2        1.78663  -0.00046   0.00000  -0.00076  -0.00076   1.78587
+    A1        1.93732  -0.01731   0.00000   0.00000  -0.00000   1.93732
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000459     0.000450     NO 
+ RMS     Force            0.000459     0.000300     NO 
+ Maximum Displacement     0.000573     0.001800     YES
+ RMS     Displacement     0.000551     0.001200     YES
+ Predicted change in Energy=-3.496589D-07
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.071318   -0.000000    0.059843
+      2          1           0       -0.019260   -0.000000    1.000535
+      3          1           0        0.981991    0.000000   -0.192709
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.945043   0.000000
+     3  H    0.945043   1.557670   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.000000   -0.000000    0.107056
+      2          1           0        0.000000    0.778835   -0.428223
+      3          1           0       -0.000000   -0.778835   -0.428223
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):         985.3440553         413.3435079         291.1912417
+ Standard basis: 6-31G(d) (6D, 7F)
+ There are    10 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    10 symmetry adapted basis functions of A1  symmetry.
+ There are     1 symmetry adapted basis functions of A2  symmetry.
+ There are     3 symmetry adapted basis functions of B1  symmetry.
+ There are     5 symmetry adapted basis functions of B2  symmetry.
+    19 basis functions,    36 primitive gaussians,    19 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.2989262251 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    19 RedAO= T EigKep=  2.19D-02  NBF=    10     1     3     5
+ NBsUse=    19 1.00D-06 EigRej= -1.00D+00 NBFU=    10     1     3     5
+ Initial guess from the checkpoint file:  "/scratch/webmodemo/webmo-4350/627084/Gau-13489.chk"
+ B after Tr=     0.000000    0.000000   -0.000000
+         Rot=    1.000000   -0.000000   -0.000000   -0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (B2) (A1) (A1) (B1) (B2) (A1) (A2) (A1)
+                 (B1) (A1) (B2) (A1)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=845746.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -76.0099035930     A.U. after    7 cycles
+            NFock=  7  Conv=0.37D-08     -V/T= 2.0020
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8          -0.012214486    0.000000000   -0.010249170
+      2        1           0.009623864   -0.000000000    0.000933639
+      3        1           0.002590621   -0.000000000    0.009315532
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.012214486 RMS     0.007001746
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.017267685 RMS     0.009969504
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20 on scan point    12 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Update second derivatives using D2CorX and points    2
+ DE= -3.45D-07 DEPred=-3.50D-07 R= 9.85D-01
+ Trust test= 9.85D-01 RLast= 1.08D-03 DXMaxT set to 5.05D-01
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.50089
+           R2           0.10213   0.50089
+           A1           0.02922   0.02922   0.16283
+ ITU=  0  0
+ Use linear search instead of GDIIS.
+     Eigenvalues ---    0.39877   0.603021000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 3.98766852D-01
+ Quartic linear search produced a step of -0.01486.
+ Iteration  1 RMS(Cart)=  0.00000819 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 6.99D-15 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.78587   0.00001   0.00001  -0.00000   0.00001   1.78588
+    R2        1.78587   0.00001   0.00001   0.00000   0.00001   1.78588
+    A1        1.93732  -0.01727   0.00000   0.00000   0.00000   1.93732
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000007     0.000450     YES
+ RMS     Force            0.000007     0.000300     YES
+ Maximum Displacement     0.000009     0.001800     YES
+ RMS     Displacement     0.000008     0.001200     YES
+ Predicted change in Energy=-7.971221D-11
+ Optimization completed.
+    -- Stationary point found.
+                           ----------------------------
+                           !   Optimized Parameters   !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  0.945          -DE/DX =    0.0                 !
+ ! R2    R(1,3)                  0.945          -DE/DX =    0.0                 !
+ ! A1    A(2,1,3)              111.0            -DE/DX =   -0.0173              !
+ --------------------------------------------------------------------------------
+ Iteration  1 RMS(Cart)=  0.00941305 RMS(Int)=  0.00005552
+ Iteration  2 RMS(Cart)=  0.00004926 RMS(Int)=  0.00000000
+ Iteration  3 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.074798   -0.000000    0.062763
+      2          1           0       -0.023987   -0.000000    1.002635
+      3          1           0        0.983237    0.000000   -0.197728
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.945049   0.000000
+     3  H    0.945049   1.566963   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.000000    0.000000    0.105693
+      2          1           0       -0.000000    0.783481   -0.422772
+      3          1           0       -0.000000   -0.783481   -0.422772
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):        1010.9161860         408.4553814         290.9133632
+ Standard basis: 6-31G(d) (6D, 7F)
+ There are    10 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    10 symmetry adapted basis functions of A1  symmetry.
+ There are     1 symmetry adapted basis functions of A2  symmetry.
+ There are     3 symmetry adapted basis functions of B1  symmetry.
+ There are     5 symmetry adapted basis functions of B2  symmetry.
+    19 basis functions,    36 primitive gaussians,    19 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.2968547466 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    19 RedAO= T EigKep=  2.19D-02  NBF=    10     1     3     5
+ NBsUse=    19 1.00D-06 EigRej= -1.00D+00 NBFU=    10     1     3     5
+ Initial guess from the checkpoint file:  "/scratch/webmodemo/webmo-4350/627084/Gau-13489.chk"
+ B after Tr=    -0.000000   -0.000000   -0.000000
+         Rot=    1.000000   -0.000000   -0.000000   -0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (B2) (A1) (A1) (B1) (B2) (A1) (A2) (A1)
+                 (B1) (A1) (B2) (A1)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=845746.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -76.0095760832     A.U. after    8 cycles
+            NFock=  8  Conv=0.40D-08     -V/T= 2.0020
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8          -0.014014559    0.000000000   -0.011759611
+      2        1           0.011324619   -0.000000000    0.000734600
+      3        1           0.002689940   -0.000000000    0.011025010
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.014014559 RMS     0.008112196
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.020250802 RMS     0.011697659
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20 on scan point    13 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- RFO/linear search
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.50089
+           R2           0.10213   0.50089
+           A1           0.02922   0.02922   0.16283
+ ITU=  0
+     Eigenvalues ---    0.39877   0.603021000.00000
+ RFO step:  Lambda=-6.81110848D-07 EMin= 3.98766852D-01
+ Linear search not attempted -- first point.
+ Iteration  1 RMS(Cart)=  0.00054590 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 1.76D-14 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.78588  -0.00045   0.00000  -0.00075  -0.00075   1.78513
+    R2        1.78588  -0.00045   0.00000  -0.00075  -0.00075   1.78513
+    A1        1.95477  -0.02025   0.00000   0.00000   0.00000   1.95477
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000453     0.000450     NO 
+ RMS     Force            0.000453     0.000300     NO 
+ Maximum Displacement     0.000567     0.001800     YES
+ RMS     Displacement     0.000546     0.001200     YES
+ Predicted change in Energy=-3.405554D-07
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.074911   -0.000000    0.062858
+      2          1           0       -0.023832   -0.000000    1.002335
+      3          1           0        0.982969    0.000000   -0.197523
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.944652   0.000000
+     3  H    0.944652   1.566304   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0       -0.000000    0.000000    0.105649
+      2          1           0        0.000000    0.783152   -0.422594
+      3          1           0       -0.000000   -0.783152   -0.422594
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):        1011.7675070         408.7993532         291.1583495
+ Standard basis: 6-31G(d) (6D, 7F)
+ There are    10 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    10 symmetry adapted basis functions of A1  symmetry.
+ There are     1 symmetry adapted basis functions of A2  symmetry.
+ There are     3 symmetry adapted basis functions of B1  symmetry.
+ There are     5 symmetry adapted basis functions of B2  symmetry.
+    19 basis functions,    36 primitive gaussians,    19 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.3007684941 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    19 RedAO= T EigKep=  2.19D-02  NBF=    10     1     3     5
+ NBsUse=    19 1.00D-06 EigRej= -1.00D+00 NBFU=    10     1     3     5
+ Initial guess from the checkpoint file:  "/scratch/webmodemo/webmo-4350/627084/Gau-13489.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000   -0.000000    0.000000   -0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (B2) (A1) (A1) (B1) (B2) (A1) (A2) (A1)
+                 (B1) (A1) (B2) (A1)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=845746.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -76.0095764181     A.U. after    7 cycles
+            NFock=  7  Conv=0.37D-08     -V/T= 2.0020
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8          -0.014387908    0.000000000   -0.012072889
+      2        1           0.011259584   -0.000000000    0.001191216
+      3        1           0.003128325   -0.000000000    0.010881673
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.014387908 RMS     0.008227062
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.020212023 RMS     0.011669419
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20 on scan point    13 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Update second derivatives using D2CorX and points    2
+ DE= -3.35D-07 DEPred=-3.41D-07 R= 9.83D-01
+ Trust test= 9.83D-01 RLast= 1.06D-03 DXMaxT set to 5.05D-01
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.50089
+           R2           0.10213   0.50089
+           A1           0.02922   0.02922   0.16283
+ ITU=  0  0
+ Use linear search instead of GDIIS.
+     Eigenvalues ---    0.39877   0.603021000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 3.98766852D-01
+ Quartic linear search produced a step of -0.01678.
+ Iteration  1 RMS(Cart)=  0.00000916 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 2.55D-15 for atom     1.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.78513   0.00001   0.00001  -0.00000   0.00001   1.78515
+    R2        1.78513   0.00001   0.00001   0.00000   0.00001   1.78515
+    A1        1.95477  -0.02021  -0.00000   0.00000   0.00000   1.95477
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000008     0.000450     YES
+ RMS     Force            0.000008     0.000300     YES
+ Maximum Displacement     0.000010     0.001800     YES
+ RMS     Displacement     0.000009     0.001200     YES
+ Predicted change in Energy=-9.939347D-11
+ Optimization completed.
+    -- Stationary point found.
+                           ----------------------------
+                           !   Optimized Parameters   !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  0.9447         -DE/DX =    0.0                 !
+ ! R2    R(1,3)                  0.9447         -DE/DX =    0.0                 !
+ ! A1    A(2,1,3)              112.0            -DE/DX =   -0.0202              !
+ --------------------------------------------------------------------------------
+ Iteration  1 RMS(Cart)=  0.00936250 RMS(Int)=  0.00005550
+ Iteration  2 RMS(Cart)=  0.00004941 RMS(Int)=  0.00000000
+ Iteration  3 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.078410   -0.000000    0.065794
+      2          1           0       -0.028529   -0.000000    1.004380
+      3          1           0        0.984167    0.000000   -0.202504
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.944658   0.000000
+     3  H    0.944658   1.575474   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0       -0.000000   -0.000000    0.104278
+      2          1           0       -0.000000    0.787737   -0.417114
+      3          1           0       -0.000000   -0.787737   -0.417114
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):        1038.5296538         404.0539090         290.8822595
+ Standard basis: 6-31G(d) (6D, 7F)
+ There are    10 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    10 symmetry adapted basis functions of A1  symmetry.
+ There are     1 symmetry adapted basis functions of A2  symmetry.
+ There are     3 symmetry adapted basis functions of B1  symmetry.
+ There are     5 symmetry adapted basis functions of B2  symmetry.
+    19 basis functions,    36 primitive gaussians,    19 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.2987385400 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    19 RedAO= T EigKep=  2.19D-02  NBF=    10     1     3     5
+ NBsUse=    19 1.00D-06 EigRej= -1.00D+00 NBFU=    10     1     3     5
+ Initial guess from the checkpoint file:  "/scratch/webmodemo/webmo-4350/627084/Gau-13489.chk"
+ B after Tr=    -0.000000    0.000000   -0.000000
+         Rot=    1.000000    0.000000   -0.000000   -0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (B2) (A1) (A1) (B1) (B2) (A1) (A2) (A1)
+                 (B1) (A1) (B2) (A1)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=845746.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -76.0091980836     A.U. after    8 cycles
+            NFock=  8  Conv=0.40D-08     -V/T= 2.0020
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8          -0.016175269    0.000000000   -0.013572662
+      2        1           0.012924448   -0.000000000    0.001022041
+      3        1           0.003250821   -0.000000000    0.012550621
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.016175269 RMS     0.009321590
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.023130250 RMS     0.013359256
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20 on scan point    14 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- RFO/linear search
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.50089
+           R2           0.10213   0.50089
+           A1           0.02922   0.02922   0.16283
+ ITU=  0
+     Eigenvalues ---    0.39877   0.603021000.00000
+ RFO step:  Lambda=-6.64527344D-07 EMin= 3.98766852D-01
+ Linear search not attempted -- first point.
+ Iteration  1 RMS(Cart)=  0.00054105 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 1.79D-14 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.78515  -0.00045   0.00000  -0.00074  -0.00074   1.78440
+    R2        1.78515  -0.00045   0.00000  -0.00074  -0.00074   1.78440
+    A1        1.97222  -0.02313   0.00000   0.00000   0.00000   1.97222
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000448     0.000450     YES
+ RMS     Force            0.000448     0.000300     NO 
+ Maximum Displacement     0.000562     0.001800     YES
+ RMS     Displacement     0.000541     0.001200     YES
+ Predicted change in Energy=-3.322637D-07
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.078521   -0.000000    0.065887
+      2          1           0       -0.028373   -0.000000    1.004082
+      3          1           0        0.983901    0.000000   -0.202299
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.944266   0.000000
+     3  H    0.944266   1.574819   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0       -0.000000   -0.000000    0.104235
+      2          1           0       -0.000000    0.787410   -0.416940
+      3          1           0       -0.000000   -0.787410   -0.416940
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):        1039.3938673         404.3901429         291.1243175
+ Standard basis: 6-31G(d) (6D, 7F)
+ There are    10 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    10 symmetry adapted basis functions of A1  symmetry.
+ There are     1 symmetry adapted basis functions of A2  symmetry.
+ There are     3 symmetry adapted basis functions of B1  symmetry.
+ There are     5 symmetry adapted basis functions of B2  symmetry.
+    19 basis functions,    36 primitive gaussians,    19 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.3026067131 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    19 RedAO= T EigKep=  2.19D-02  NBF=    10     1     3     5
+ NBsUse=    19 1.00D-06 EigRej= -1.00D+00 NBFU=    10     1     3     5
+ Initial guess from the checkpoint file:  "/scratch/webmodemo/webmo-4350/627084/Gau-13489.chk"
+ B after Tr=     0.000000   -0.000000   -0.000000
+         Rot=    1.000000   -0.000000    0.000000   -0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (B2) (A1) (A1) (B1) (B2) (A1) (A2) (A1)
+                 (B1) (A1) (B2) (A1)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=845746.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -76.0091984097     A.U. after    7 cycles
+            NFock=  7  Conv=0.37D-08     -V/T= 2.0020
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8          -0.016540773    0.000000000   -0.013879357
+      2        1           0.012857091   -0.000000000    0.001473457
+      3        1           0.003683682   -0.000000000    0.012405900
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.016540773 RMS     0.009435073
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.023092399 RMS     0.013332404
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20 on scan point    14 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Update second derivatives using D2CorX and points    2
+ DE= -3.26D-07 DEPred=-3.32D-07 R= 9.81D-01
+ Trust test= 9.81D-01 RLast= 1.05D-03 DXMaxT set to 5.05D-01
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.50089
+           R2           0.10213   0.50089
+           A1           0.02922   0.02922   0.16283
+ ITU=  0  0
+ Use linear search instead of GDIIS.
+     Eigenvalues ---    0.39877   0.603021000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 3.98766852D-01
+ Quartic linear search produced a step of -0.01866.
+ Iteration  1 RMS(Cart)=  0.00001009 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 2.60D-15 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.78440   0.00001   0.00001  -0.00000   0.00001   1.78442
+    R2        1.78440   0.00001   0.00001   0.00000   0.00001   1.78442
+    A1        1.97222  -0.02309   0.00000   0.00000   0.00000   1.97222
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000009     0.000450     YES
+ RMS     Force            0.000009     0.000300     YES
+ Maximum Displacement     0.000010     0.001800     YES
+ RMS     Displacement     0.000010     0.001200     YES
+ Predicted change in Energy=-1.203603D-10
+ Optimization completed.
+    -- Stationary point found.
+                           ----------------------------
+                           !   Optimized Parameters   !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  0.9443         -DE/DX =    0.0                 !
+ ! R2    R(1,3)                  0.9443         -DE/DX =    0.0                 !
+ ! A1    A(2,1,3)              113.0            -DE/DX =   -0.0231              !
+ --------------------------------------------------------------------------------
+ Iteration  1 RMS(Cart)=  0.00931214 RMS(Int)=  0.00005548
+ Iteration  2 RMS(Cart)=  0.00004956 RMS(Int)=  0.00000000
+ Iteration  3 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.082038   -0.000000    0.068838
+      2          1           0       -0.033040   -0.000000    1.006072
+      3          1           0        0.985050    0.000000   -0.207241
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.944273   0.000000
+     3  H    0.944273   1.583868   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.000000   -0.000000    0.102858
+      2          1           0       -0.000000    0.791934   -0.411430
+      3          1           0       -0.000000   -0.791934   -0.411430
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):        1067.4188658         399.7828830         290.8501110
+ Standard basis: 6-31G(d) (6D, 7F)
+ There are    10 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    10 symmetry adapted basis functions of A1  symmetry.
+ There are     1 symmetry adapted basis functions of A2  symmetry.
+ There are     3 symmetry adapted basis functions of B1  symmetry.
+ There are     5 symmetry adapted basis functions of B2  symmetry.
+    19 basis functions,    36 primitive gaussians,    19 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.3006174649 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    19 RedAO= T EigKep=  2.19D-02  NBF=    10     1     3     5
+ NBsUse=    19 1.00D-06 EigRej= -1.00D+00 NBFU=    10     1     3     5
+ Initial guess from the checkpoint file:  "/scratch/webmodemo/webmo-4350/627084/Gau-13489.chk"
+ B after Tr=    -0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000   -0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (B2) (A1) (A1) (B1) (B2) (A1) (A2) (A1)
+                 (B1) (A1) (B2) (A1)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=845746.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -76.0087703801     A.U. after    8 cycles
+            NFock=  8  Conv=0.40D-08     -V/T= 2.0020
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8          -0.018312565    0.000000000   -0.015366066
+      2        1           0.014484871   -0.000000000    0.001332668
+      3        1           0.003827694   -0.000000000    0.014033398
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.018312565 RMS     0.010512643
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.025944203 RMS     0.014983250
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20 on scan point    15 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- RFO/linear search
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.50089
+           R2           0.10213   0.50089
+           A1           0.02922   0.02922   0.16283
+ ITU=  0
+     Eigenvalues ---    0.39877   0.603021000.00000
+ RFO step:  Lambda=-6.49497089D-07 EMin= 3.98766852D-01
+ Linear search not attempted -- first point.
+ Iteration  1 RMS(Cart)=  0.00053668 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 1.12D-14 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.78442  -0.00044   0.00000  -0.00073  -0.00073   1.78368
+    R2        1.78442  -0.00044   0.00000  -0.00073  -0.00073   1.78368
+    A1        1.98968  -0.02594   0.00000   0.00000   0.00000   1.98968
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000443     0.000450     YES
+ RMS     Force            0.000443     0.000300     NO 
+ Maximum Displacement     0.000557     0.001800     YES
+ RMS     Displacement     0.000537     0.001200     YES
+ Predicted change in Energy=-3.247485D-07
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.082146   -0.000000    0.068929
+      2          1           0       -0.032885   -0.000000    1.005778
+      3          1           0        0.984787    0.000000   -0.207037
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.943885   0.000000
+     3  H    0.943885   1.583216   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.000000   -0.000000    0.102815
+      2          1           0       -0.000000    0.791608   -0.411261
+      3          1           0       -0.000000   -0.791608   -0.411261
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):        1068.2973693         400.1119110         291.0894855
+ Standard basis: 6-31G(d) (6D, 7F)
+ There are    10 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    10 symmetry adapted basis functions of A1  symmetry.
+ There are     1 symmetry adapted basis functions of A2  symmetry.
+ There are     3 symmetry adapted basis functions of B1  symmetry.
+ There are     5 symmetry adapted basis functions of B2  symmetry.
+    19 basis functions,    36 primitive gaussians,    19 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.3044439594 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    19 RedAO= T EigKep=  2.19D-02  NBF=    10     1     3     5
+ NBsUse=    19 1.00D-06 EigRej= -1.00D+00 NBFU=    10     1     3     5
+ Initial guess from the checkpoint file:  "/scratch/webmodemo/webmo-4350/627084/Gau-13489.chk"
+ B after Tr=     0.000000   -0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000   -0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (B2) (A1) (A1) (B1) (B2) (A1) (A2) (A1)
+                 (B1) (A1) (B2) (A1)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=845746.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -76.0087706982     A.U. after    7 cycles
+            NFock=  7  Conv=0.38D-08     -V/T= 2.0020
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8          -0.018670586    0.000000000   -0.015666482
+      2        1           0.014415152   -0.000000000    0.001779300
+      3        1           0.004255433   -0.000000000    0.013887182
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.018670586 RMS     0.010624680
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.025907191 RMS     0.014957526
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20 on scan point    15 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Update second derivatives using D2CorX and points    2
+ DE= -3.18D-07 DEPred=-3.25D-07 R= 9.80D-01
+ Trust test= 9.80D-01 RLast= 1.04D-03 DXMaxT set to 5.05D-01
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.50089
+           R2           0.10213   0.50089
+           A1           0.02922   0.02922   0.16283
+ ITU=  0  0
+ Use linear search instead of GDIIS.
+     Eigenvalues ---    0.39877   0.603021000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 3.98766852D-01
+ Quartic linear search produced a step of -0.02050.
+ Iteration  1 RMS(Cart)=  0.00001100 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 7.72D-15 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.78368   0.00001   0.00002  -0.00000   0.00002   1.78370
+    R2        1.78368   0.00001   0.00002   0.00000   0.00002   1.78370
+    A1        1.98968  -0.02591  -0.00000   0.00000  -0.00000   1.98968
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000009     0.000450     YES
+ RMS     Force            0.000009     0.000300     YES
+ Maximum Displacement     0.000011     0.001800     YES
+ RMS     Displacement     0.000011     0.001200     YES
+ Predicted change in Energy=-1.425037D-10
+ Optimization completed.
+    -- Stationary point found.
+                           ----------------------------
+                           !   Optimized Parameters   !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  0.9439         -DE/DX =    0.0                 !
+ ! R2    R(1,3)                  0.9439         -DE/DX =    0.0                 !
+ ! A1    A(2,1,3)              114.0            -DE/DX =   -0.0259              !
+ --------------------------------------------------------------------------------
+ Iteration  1 RMS(Cart)=  0.00926199 RMS(Int)=  0.00005545
+ Iteration  2 RMS(Cart)=  0.00004970 RMS(Int)=  0.00000000
+ Iteration  3 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.085682   -0.000000    0.071895
+      2          1           0       -0.037521   -0.000000    1.007713
+      3          1           0        0.985888    0.000000   -0.211939
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.943893   0.000000
+     3  H    0.943893   1.592142   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0       -0.000000   -0.000000    0.101431
+      2          1           0       -0.000000    0.796071   -0.405722
+      3          1           0       -0.000000   -0.796071   -0.405722
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):        1097.6637345         395.6385275         290.8172542
+ Standard basis: 6-31G(d) (6D, 7F)
+ There are    10 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    10 symmetry adapted basis functions of A1  symmetry.
+ There are     1 symmetry adapted basis functions of A2  symmetry.
+ There are     3 symmetry adapted basis functions of B1  symmetry.
+ There are     5 symmetry adapted basis functions of B2  symmetry.
+    19 basis functions,    36 primitive gaussians,    19 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.3024946004 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    19 RedAO= T EigKep=  2.19D-02  NBF=    10     1     3     5
+ NBsUse=    19 1.00D-06 EigRej= -1.00D+00 NBFU=    10     1     3     5
+ Initial guess from the checkpoint file:  "/scratch/webmodemo/webmo-4350/627084/Gau-13489.chk"
+ B after Tr=    -0.000000    0.000000   -0.000000
+         Rot=    1.000000   -0.000000   -0.000000   -0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (B2) (A1) (A1) (B1) (B2) (A1) (A2) (A1)
+                 (B1) (A1) (B2) (A1)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=845746.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -76.0082941319     A.U. after    8 cycles
+            NFock=  8  Conv=0.40D-08     -V/T= 2.0020
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8          -0.020423939    0.000000000   -0.017137719
+      2        1           0.016004670   -0.000000000    0.001665387
+      3        1           0.004419268   -0.000000000    0.015472332
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.020423939 RMS     0.011684200
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.028691011 RMS     0.016568621
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20 on scan point    16 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- RFO/linear search
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.50089
+           R2           0.10213   0.50089
+           A1           0.02922   0.02922   0.16283
+ ITU=  0
+     Eigenvalues ---    0.39877   0.603021000.00000
+ RFO step:  Lambda=-6.35954315D-07 EMin= 3.98766852D-01
+ Linear search not attempted -- first point.
+ Iteration  1 RMS(Cart)=  0.00053280 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 2.44D-14 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.78370  -0.00044   0.00000  -0.00073  -0.00073   1.78297
+    R2        1.78370  -0.00044   0.00000  -0.00073  -0.00073   1.78297
+    A1        2.00713  -0.02869   0.00000   0.00000   0.00000   2.00713
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000438     0.000450     YES
+ RMS     Force            0.000438     0.000300     NO 
+ Maximum Displacement     0.000553     0.001800     YES
+ RMS     Displacement     0.000533     0.001200     YES
+ Predicted change in Energy=-3.179772D-07
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.085787   -0.000000    0.071984
+      2          1           0       -0.037366   -0.000000    1.007420
+      3          1           0        0.985627    0.000000   -0.211735
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.943508   0.000000
+     3  H    0.943508   1.591494   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0       -0.000000   -0.000000    0.101389
+      2          1           0       -0.000000    0.795747   -0.405557
+      3          1           0       -0.000000   -0.795747   -0.405557
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):        1098.5580167         395.9608598         291.0541872
+ Standard basis: 6-31G(d) (6D, 7F)
+ There are    10 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    10 symmetry adapted basis functions of A1  symmetry.
+ There are     1 symmetry adapted basis functions of A2  symmetry.
+ There are     3 symmetry adapted basis functions of B1  symmetry.
+ There are     5 symmetry adapted basis functions of B2  symmetry.
+    19 basis functions,    36 primitive gaussians,    19 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.3062832661 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    19 RedAO= T EigKep=  2.19D-02  NBF=    10     1     3     5
+ NBsUse=    19 1.00D-06 EigRej= -1.00D+00 NBFU=    10     1     3     5
+ Initial guess from the checkpoint file:  "/scratch/webmodemo/webmo-4350/627084/Gau-13489.chk"
+ B after Tr=     0.000000   -0.000000   -0.000000
+         Rot=    1.000000    0.000000   -0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (B2) (A1) (A1) (B1) (B2) (A1) (A2) (A1)
+                 (B1) (A1) (B2) (A1)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=845746.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -76.0082944427     A.U. after    7 cycles
+            NFock=  7  Conv=0.38D-08     -V/T= 2.0020
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8          -0.020774826    0.000000000   -0.017432149
+      2        1           0.015932543   -0.000000000    0.002107646
+      3        1           0.004842283   -0.000000000    0.015324503
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.020774826 RMS     0.011794770
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.028654754 RMS     0.016543832
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20 on scan point    16 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Update second derivatives using D2CorX and points    2
+ DE= -3.11D-07 DEPred=-3.18D-07 R= 9.78D-01
+ Trust test= 9.78D-01 RLast= 1.03D-03 DXMaxT set to 5.05D-01
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.50089
+           R2           0.10213   0.50089
+           A1           0.02922   0.02922   0.16283
+ ITU=  0  0
+ Use linear search instead of GDIIS.
+     Eigenvalues ---    0.39877   0.603021000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 3.98766852D-01
+ Quartic linear search produced a step of -0.02230.
+ Iteration  1 RMS(Cart)=  0.00001188 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 6.24D-15 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.78297   0.00001   0.00002  -0.00000   0.00002   1.78299
+    R2        1.78297   0.00001   0.00002   0.00000   0.00002   1.78299
+    A1        2.00713  -0.02865   0.00000   0.00000   0.00000   2.00713
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000010     0.000450     YES
+ RMS     Force            0.000010     0.000300     YES
+ Maximum Displacement     0.000012     0.001800     YES
+ RMS     Displacement     0.000012     0.001200     YES
+ Predicted change in Energy=-1.657604D-10
+ Optimization completed.
+    -- Stationary point found.
+                           ----------------------------
+                           !   Optimized Parameters   !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  0.9435         -DE/DX =    0.0                 !
+ ! R2    R(1,3)                  0.9435         -DE/DX =    0.0                 !
+ ! A1    A(2,1,3)              115.0            -DE/DX =   -0.0287              !
+ --------------------------------------------------------------------------------
+ Iteration  1 RMS(Cart)=  0.00921204 RMS(Int)=  0.00005543
+ Iteration  2 RMS(Cart)=  0.00004985 RMS(Int)=  0.00000000
+ Iteration  3 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.089341   -0.000000    0.074966
+      2          1           0       -0.041971   -0.000000    1.009300
+      3          1           0        0.986679    0.000000   -0.216597
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.943517   0.000000
+     3  H    0.943517   1.600295   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0       -0.000000    0.000000    0.099998
+      2          1           0       -0.000000    0.800148   -0.399990
+      3          1           0       -0.000000   -0.800148   -0.399990
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):        1129.3504826         391.6172261         290.7840191
+ Standard basis: 6-31G(d) (6D, 7F)
+ There are    10 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    10 symmetry adapted basis functions of A1  symmetry.
+ There are     1 symmetry adapted basis functions of A2  symmetry.
+ There are     3 symmetry adapted basis functions of B1  symmetry.
+ There are     5 symmetry adapted basis functions of B2  symmetry.
+    19 basis functions,    36 primitive gaussians,    19 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.3043729811 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    19 RedAO= T EigKep=  2.20D-02  NBF=    10     1     3     5
+ NBsUse=    19 1.00D-06 EigRej= -1.00D+00 NBFU=    10     1     3     5
+ Initial guess from the checkpoint file:  "/scratch/webmodemo/webmo-4350/627084/Gau-13489.chk"
+ B after Tr=    -0.000000    0.000000   -0.000000
+         Rot=    1.000000   -0.000000   -0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (B2) (A1) (A1) (B1) (B2) (A1) (A2) (A1)
+                 (B1) (A1) (B2) (A1)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=845746.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -76.0077705268     A.U. after    8 cycles
+            NFock=  8  Conv=0.41D-08     -V/T= 2.0020
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8          -0.022506856    0.000000000   -0.018885494
+      2        1           0.017482637   -0.000000000    0.002019065
+      3        1           0.005024219   -0.000000000    0.016866429
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.022506856 RMS     0.012835103
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.031369001 RMS     0.018114362
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20 on scan point    17 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- RFO/linear search
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.50089
+           R2           0.10213   0.50089
+           A1           0.02922   0.02922   0.16283
+ ITU=  0
+     Eigenvalues ---    0.39877   0.603021000.00000
+ RFO step:  Lambda=-6.23837315D-07 EMin= 3.98766852D-01
+ Linear search not attempted -- first point.
+ Iteration  1 RMS(Cart)=  0.00052942 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 6.01D-15 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.78299  -0.00043   0.00000  -0.00072  -0.00072   1.78227
+    R2        1.78299  -0.00043   0.00000  -0.00072  -0.00072   1.78227
+    A1        2.02458  -0.03137   0.00000   0.00000   0.00000   2.02458
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000434     0.000450     YES
+ RMS     Force            0.000434     0.000300     NO 
+ Maximum Displacement     0.000549     0.001800     YES
+ RMS     Displacement     0.000529     0.001200     YES
+ Predicted change in Energy=-3.119187D-07
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.089444   -0.000000    0.075052
+      2          1           0       -0.041815   -0.000000    1.009010
+      3          1           0        0.986420    0.000000   -0.216393
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.943136   0.000000
+     3  H    0.943136   1.599650   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.000000    0.000000    0.099957
+      2          1           0       -0.000000    0.799825   -0.399829
+      3          1           0       -0.000000   -0.799825   -0.399829
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):        1130.2621306         391.9333521         291.0187493
+ Standard basis: 6-31G(d) (6D, 7F)
+ There are    10 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    10 symmetry adapted basis functions of A1  symmetry.
+ There are     1 symmetry adapted basis functions of A2  symmetry.
+ There are     3 symmetry adapted basis functions of B1  symmetry.
+ There are     5 symmetry adapted basis functions of B2  symmetry.
+    19 basis functions,    36 primitive gaussians,    19 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.3081276183 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    19 RedAO= T EigKep=  2.19D-02  NBF=    10     1     3     5
+ NBsUse=    19 1.00D-06 EigRej= -1.00D+00 NBFU=    10     1     3     5
+ Initial guess from the checkpoint file:  "/scratch/webmodemo/webmo-4350/627084/Gau-13489.chk"
+ B after Tr=     0.000000   -0.000000    0.000000
+         Rot=    1.000000   -0.000000   -0.000000   -0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (B2) (A1) (A1) (B1) (B2) (A1) (A2) (A1)
+                 (B1) (A1) (B2) (A1)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=845746.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -76.0077708312     A.U. after    7 cycles
+            NFock=  7  Conv=0.38D-08     -V/T= 2.0020
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8          -0.022850947    0.000000000   -0.019174222
+      2        1           0.017408047   -0.000000000    0.002457357
+      3        1           0.005442900   -0.000000000    0.016716864
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.022850947 RMS     0.012944214
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.031333418 RMS     0.018090359
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20 on scan point    17 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Update second derivatives using D2CorX and points    2
+ DE= -3.04D-07 DEPred=-3.12D-07 R= 9.76D-01
+ Trust test= 9.76D-01 RLast= 1.02D-03 DXMaxT set to 5.05D-01
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.50089
+           R2           0.10213   0.50089
+           A1           0.02922   0.02922   0.16283
+ ITU=  0  0
+ Use linear search instead of GDIIS.
+     Eigenvalues ---    0.39877   0.603021000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 3.98766852D-01
+ Quartic linear search produced a step of -0.02407.
+ Iteration  1 RMS(Cart)=  0.00001274 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 1.83D-15 for atom     1.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.78227   0.00001   0.00002  -0.00000   0.00002   1.78229
+    R2        1.78227   0.00001   0.00002   0.00000   0.00002   1.78229
+    A1        2.02458  -0.03133  -0.00000   0.00000   0.00000   2.02458
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000011     0.000450     YES
+ RMS     Force            0.000011     0.000300     YES
+ Maximum Displacement     0.000013     0.001800     YES
+ RMS     Displacement     0.000013     0.001200     YES
+ Predicted change in Energy=-1.901074D-10
+ Optimization completed.
+    -- Stationary point found.
+                           ----------------------------
+                           !   Optimized Parameters   !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  0.9431         -DE/DX =    0.0                 !
+ ! R2    R(1,3)                  0.9431         -DE/DX =    0.0                 !
+ ! A1    A(2,1,3)              116.0            -DE/DX =   -0.0313              !
+ --------------------------------------------------------------------------------
+ Iteration  1 RMS(Cart)=  0.00916232 RMS(Int)=  0.00005541
+ Iteration  2 RMS(Cart)=  0.00004999 RMS(Int)=  0.00000000
+ Iteration  3 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.093016   -0.000000    0.078049
+      2          1           0       -0.046390   -0.000000    1.010835
+      3          1           0        0.987423    0.000000   -0.221215
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.943145   0.000000
+     3  H    0.943145   1.608327   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0       -0.000000    0.000000    0.098558
+      2          1           0       -0.000000    0.804164   -0.394234
+      3          1           0       -0.000000   -0.804164   -0.394234
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):        1162.5722502         387.7155142         290.7507291
+ Standard basis: 6-31G(d) (6D, 7F)
+ There are    10 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    10 symmetry adapted basis functions of A1  symmetry.
+ There are     1 symmetry adapted basis functions of A2  symmetry.
+ There are     3 symmetry adapted basis functions of B1  symmetry.
+ There are     5 symmetry adapted basis functions of B2  symmetry.
+    19 basis functions,    36 primitive gaussians,    19 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.3062555937 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    19 RedAO= T EigKep=  2.20D-02  NBF=    10     1     3     5
+ NBsUse=    19 1.00D-06 EigRej= -1.00D+00 NBFU=    10     1     3     5
+ Initial guess from the checkpoint file:  "/scratch/webmodemo/webmo-4350/627084/Gau-13489.chk"
+ B after Tr=    -0.000000   -0.000000   -0.000000
+         Rot=    1.000000    0.000000   -0.000000   -0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (B2) (A1) (A1) (B1) (B2) (A1) (A2) (A1)
+                 (B1) (A1) (B2) (A1)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=845746.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -76.0072007824     A.U. after    8 cycles
+            NFock=  8  Conv=0.41D-08     -V/T= 2.0020
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8          -0.024558756    0.000000000   -0.020607243
+      2        1           0.018917572   -0.000000000    0.002392531
+      3        1           0.005641184   -0.000000000    0.018214713
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.024558756 RMS     0.013964194
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.033976472 RMS     0.019619466
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20 on scan point    18 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- RFO/linear search
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.50089
+           R2           0.10213   0.50089
+           A1           0.02922   0.02922   0.16283
+ ITU=  0
+     Eigenvalues ---    0.39877   0.603021000.00000
+ RFO step:  Lambda=-6.13087919D-07 EMin= 3.98766852D-01
+ Linear search not attempted -- first point.
+ Iteration  1 RMS(Cart)=  0.00052651 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 1.15D-14 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.78229  -0.00043   0.00000  -0.00071  -0.00071   1.78157
+    R2        1.78229  -0.00043   0.00000  -0.00071  -0.00071   1.78157
+    A1        2.04204  -0.03398   0.00000   0.00000   0.00000   2.04204
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000430     0.000450     YES
+ RMS     Force            0.000430     0.000300     NO 
+ Maximum Displacement     0.000546     0.001800     YES
+ RMS     Displacement     0.000527     0.001200     YES
+ Predicted change in Energy=-3.065440D-07
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.093116   -0.000000    0.078134
+      2          1           0       -0.046234   -0.000000    1.010546
+      3          1           0        0.987166    0.000000   -0.221011
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.942768   0.000000
+     3  H    0.942768   1.607684   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0       -0.000000    0.000000    0.098519
+      2          1           0       -0.000000    0.803842   -0.394076
+      3          1           0       -0.000000   -0.803842   -0.394076
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):        1163.5029572         388.0259031         290.9834920
+ Standard basis: 6-31G(d) (6D, 7F)
+ There are    10 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    10 symmetry adapted basis functions of A1  symmetry.
+ There are     1 symmetry adapted basis functions of A2  symmetry.
+ There are     3 symmetry adapted basis functions of B1  symmetry.
+ There are     5 symmetry adapted basis functions of B2  symmetry.
+    19 basis functions,    36 primitive gaussians,    19 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.3099799490 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    19 RedAO= T EigKep=  2.20D-02  NBF=    10     1     3     5
+ NBsUse=    19 1.00D-06 EigRej= -1.00D+00 NBFU=    10     1     3     5
+ Initial guess from the checkpoint file:  "/scratch/webmodemo/webmo-4350/627084/Gau-13489.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000   -0.000000   -0.000000   -0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (A1) (B2) (A1) (B1) (B2) (A1) (A2) (A1)
+                 (B1) (A1) (B2) (A1)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=845746.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -76.0072010809     A.U. after    7 cycles
+            NFock=  7  Conv=0.39D-08     -V/T= 2.0020
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8          -0.024896376    0.000000000   -0.020890540
+      2        1           0.018840460    0.000000000    0.002827258
+      3        1           0.006055917   -0.000000000    0.018063283
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.024896376 RMS     0.014071867
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.033941486 RMS     0.019596128
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20 on scan point    18 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Update second derivatives using D2CorX and points    2
+ DE= -2.99D-07 DEPred=-3.07D-07 R= 9.74D-01
+ Trust test= 9.74D-01 RLast= 1.01D-03 DXMaxT set to 5.05D-01
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.50089
+           R2           0.10213   0.50089
+           A1           0.02922   0.02922   0.16283
+ ITU=  0  0
+ Use linear search instead of GDIIS.
+     Eigenvalues ---    0.39877   0.603021000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 3.98766852D-01
+ Quartic linear search produced a step of -0.02581.
+ Iteration  1 RMS(Cart)=  0.00001359 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 1.04D-14 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.78157   0.00001   0.00002  -0.00000   0.00002   1.78159
+    R2        1.78157   0.00001   0.00002   0.00000   0.00002   1.78159
+    A1        2.04204  -0.03394  -0.00000   0.00000   0.00000   2.04204
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000011     0.000450     YES
+ RMS     Force            0.000011     0.000300     YES
+ Maximum Displacement     0.000014     0.001800     YES
+ RMS     Displacement     0.000014     0.001200     YES
+ Predicted change in Energy=-2.155577D-10
+ Optimization completed.
+    -- Stationary point found.
+                           ----------------------------
+                           !   Optimized Parameters   !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  0.9428         -DE/DX =    0.0                 !
+ ! R2    R(1,3)                  0.9428         -DE/DX =    0.0                 !
+ ! A1    A(2,1,3)              117.0            -DE/DX =   -0.0339              !
+ --------------------------------------------------------------------------------
+ Iteration  1 RMS(Cart)=  0.00911283 RMS(Int)=  0.00005539
+ Iteration  2 RMS(Cart)=  0.00005013 RMS(Int)=  0.00000000
+ Iteration  3 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.096706   -0.000000    0.081146
+      2          1           0       -0.050777   -0.000000    1.012316
+      3          1           0        0.988120    0.000000   -0.225793
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.942778   0.000000
+     3  H    0.942778   1.616237   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.000000    0.000000    0.097113
+      2          1           0        0.000000    0.808118   -0.388453
+      3          1           0       -0.000000   -0.808118   -0.388453
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):        1197.4297711         383.9300716         290.7177009
+ Standard basis: 6-31G(d) (6D, 7F)
+ There are    10 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    10 symmetry adapted basis functions of A1  symmetry.
+ There are     1 symmetry adapted basis functions of A2  symmetry.
+ There are     3 symmetry adapted basis functions of B1  symmetry.
+ There are     5 symmetry adapted basis functions of B2  symmetry.
+    19 basis functions,    36 primitive gaussians,    19 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.3081453732 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    19 RedAO= T EigKep=  2.20D-02  NBF=    10     1     3     5
+ NBsUse=    19 1.00D-06 EigRej= -1.00D+00 NBFU=    10     1     3     5
+ Initial guess from the checkpoint file:  "/scratch/webmodemo/webmo-4350/627084/Gau-13489.chk"
+ B after Tr=    -0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000   -0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (A1) (B2) (A1) (B1) (B2) (A1) (A2) (A1)
+                 (B1) (A1) (B2) (A1)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=845746.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -76.0065861456     A.U. after    8 cycles
+            NFock=  8  Conv=0.41D-08     -V/T= 2.0020
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8          -0.026577056    0.000000000   -0.022300798
+      2        1           0.020308287    0.000000000    0.002784576
+      3        1           0.006268769   -0.000000000    0.019516222
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.026577056 RMS     0.015070303
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.036511699 RMS     0.021082917
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20 on scan point    19 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- RFO/linear search
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.50089
+           R2           0.10213   0.50089
+           A1           0.02922   0.02922   0.16283
+ ITU=  0
+     Eigenvalues ---    0.39877   0.603021000.00000
+ RFO step:  Lambda=-6.03650835D-07 EMin= 3.98766852D-01
+ Linear search not attempted -- first point.
+ Iteration  1 RMS(Cart)=  0.00052409 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 9.73D-15 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.78159  -0.00043   0.00000  -0.00071  -0.00071   1.78088
+    R2        1.78159  -0.00043   0.00000  -0.00071  -0.00071   1.78088
+    A1        2.05949  -0.03651   0.00000   0.00000   0.00000   2.05949
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000427     0.000450     YES
+ RMS     Force            0.000427     0.000300     NO 
+ Maximum Displacement     0.000543     0.001800     YES
+ RMS     Displacement     0.000524     0.001200     YES
+ Predicted change in Energy=-3.018254D-07
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.096804   -0.000000    0.081228
+      2          1           0       -0.050620   -0.000000    1.012029
+      3          1           0        0.987864    0.000000   -0.225588
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.942403   0.000000
+     3  H    0.942403   1.615595   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0       -0.000000    0.000000    0.097075
+      2          1           0       -0.000000    0.807797   -0.388299
+      3          1           0       -0.000000   -0.807797   -0.388299
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):        1198.3813438         384.2351729         290.9487283
+ Standard basis: 6-31G(d) (6D, 7F)
+ There are    10 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    10 symmetry adapted basis functions of A1  symmetry.
+ There are     1 symmetry adapted basis functions of A2  symmetry.
+ There are     3 symmetry adapted basis functions of B1  symmetry.
+ There are     5 symmetry adapted basis functions of B2  symmetry.
+    19 basis functions,    36 primitive gaussians,    19 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.3118431341 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    19 RedAO= T EigKep=  2.20D-02  NBF=    10     1     3     5
+ NBsUse=    19 1.00D-06 EigRej= -1.00D+00 NBFU=    10     1     3     5
+ Initial guess from the checkpoint file:  "/scratch/webmodemo/webmo-4350/627084/Gau-13489.chk"
+ B after Tr=     0.000000   -0.000000    0.000000
+         Rot=    1.000000   -0.000000    0.000000   -0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (A1) (B2) (A1) (B1) (B2) (A1) (A2) (A1)
+                 (B1) (A1) (B2) (A1)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=845746.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -76.0065864390     A.U. after    7 cycles
+            NFock=  7  Conv=0.39D-08     -V/T= 2.0020
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8          -0.026908514    0.000000000   -0.022578924
+      2        1           0.020228585    0.000000000    0.003216133
+      3        1           0.006679929   -0.000000000    0.019362792
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.026908514 RMS     0.015176569
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.036477235 RMS     0.021060144
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20 on scan point    19 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Update second derivatives using D2CorX and points    2
+ DE= -2.93D-07 DEPred=-3.02D-07 R= 9.72D-01
+ Trust test= 9.72D-01 RLast= 1.00D-03 DXMaxT set to 5.05D-01
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.50089
+           R2           0.10213   0.50089
+           A1           0.02922   0.02922   0.16283
+ ITU=  0  0
+ Use linear search instead of GDIIS.
+     Eigenvalues ---    0.39877   0.603021000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 3.98766852D-01
+ Quartic linear search produced a step of -0.02752.
+ Iteration  1 RMS(Cart)=  0.00001442 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 6.09D-15 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.78088   0.00001   0.00002  -0.00000   0.00002   1.78090
+    R2        1.78088   0.00001   0.00002   0.00000   0.00002   1.78090
+    A1        2.05949  -0.03648  -0.00000   0.00000   0.00000   2.05949
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000012     0.000450     YES
+ RMS     Force            0.000012     0.000300     YES
+ Maximum Displacement     0.000015     0.001800     YES
+ RMS     Displacement     0.000014     0.001200     YES
+ Predicted change in Energy=-2.421567D-10
+ Optimization completed.
+    -- Stationary point found.
+                           ----------------------------
+                           !   Optimized Parameters   !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  0.9424         -DE/DX =    0.0                 !
+ ! R2    R(1,3)                  0.9424         -DE/DX =    0.0                 !
+ ! A1    A(2,1,3)              118.0            -DE/DX =   -0.0365              !
+ --------------------------------------------------------------------------------
+ Iteration  1 RMS(Cart)=  0.00906359 RMS(Int)=  0.00005537
+ Iteration  2 RMS(Cart)=  0.00005027 RMS(Int)=  0.00000000
+ Iteration  3 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.100411   -0.000000    0.084255
+      2          1           0       -0.055132   -0.000000    1.013744
+      3          1           0        0.988769    0.000000   -0.230329
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.942414   0.000000
+     3  H    0.942414   1.624022   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0       -0.000000    0.000000    0.095662
+      2          1           0       -0.000000    0.812011   -0.382649
+      3          1           0       -0.000000   -0.812011   -0.382649
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):        1234.0321265         380.2577155         290.6852444
+ Standard basis: 6-31G(d) (6D, 7F)
+ There are    10 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    10 symmetry adapted basis functions of A1  symmetry.
+ There are     1 symmetry adapted basis functions of A2  symmetry.
+ There are     3 symmetry adapted basis functions of B1  symmetry.
+ There are     5 symmetry adapted basis functions of B2  symmetry.
+    19 basis functions,    36 primitive gaussians,    19 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.3100451977 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    19 RedAO= T EigKep=  2.20D-02  NBF=    10     1     3     5
+ NBsUse=    19 1.00D-06 EigRej= -1.00D+00 NBFU=    10     1     3     5
+ Initial guess from the checkpoint file:  "/scratch/webmodemo/webmo-4350/627084/Gau-13489.chk"
+ B after Tr=    -0.000000    0.000000   -0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (A1) (B2) (A1) (B1) (B2) (A1) (A2) (A1)
+                 (B1) (A1) (B2) (A1)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=845746.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -76.0059278940     A.U. after    8 cycles
+            NFock=  8  Conv=0.42D-08     -V/T= 2.0020
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8          -0.028559145    0.000000000   -0.023963968
+      2        1           0.021653604    0.000000000    0.003193956
+      3        1           0.006905541   -0.000000000    0.020770013
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.028559145 RMS     0.016152249
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.038972933 RMS     0.022503693
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20 on scan point    20 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- RFO/linear search
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.50089
+           R2           0.10213   0.50089
+           A1           0.02922   0.02922   0.16283
+ ITU=  0
+     Eigenvalues ---    0.39877   0.603021000.00000
+ RFO step:  Lambda=-5.95473254D-07 EMin= 3.98766852D-01
+ Linear search not attempted -- first point.
+ Iteration  1 RMS(Cart)=  0.00052214 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 1.88D-15 for atom     1.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.78090  -0.00042   0.00000  -0.00070  -0.00070   1.78020
+    R2        1.78090  -0.00042   0.00000  -0.00070  -0.00070   1.78020
+    A1        2.07694  -0.03897   0.00000   0.00000   0.00000   2.07694
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000424     0.000450     YES
+ RMS     Force            0.000424     0.000300     NO 
+ Maximum Displacement     0.000540     0.001800     YES
+ RMS     Displacement     0.000522     0.001200     YES
+ Predicted change in Energy=-2.977366D-07
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.100507   -0.000000    0.084336
+      2          1           0       -0.054974   -0.000000    1.013458
+      3          1           0        0.988515    0.000000   -0.230124
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.942042   0.000000
+     3  H    0.942042   1.623382   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0       -0.000000    0.000000    0.095624
+      2          1           0       -0.000000    0.811691   -0.382498
+      3          1           0       -0.000000   -0.811691   -0.382498
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):        1235.0064938         380.5579595         290.9147637
+ Standard basis: 6-31G(d) (6D, 7F)
+ There are    10 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    10 symmetry adapted basis functions of A1  symmetry.
+ There are     1 symmetry adapted basis functions of A2  symmetry.
+ There are     3 symmetry adapted basis functions of B1  symmetry.
+ There are     5 symmetry adapted basis functions of B2  symmetry.
+    19 basis functions,    36 primitive gaussians,    19 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.3137199860 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    19 RedAO= T EigKep=  2.20D-02  NBF=    10     1     3     5
+ NBsUse=    19 1.00D-06 EigRej= -1.00D+00 NBFU=    10     1     3     5
+ Initial guess from the checkpoint file:  "/scratch/webmodemo/webmo-4350/627084/Gau-13489.chk"
+ B after Tr=     0.000000   -0.000000   -0.000000
+         Rot=    1.000000    0.000000   -0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (A1) (B2) (A1) (B1) (A1) (B2) (A2) (A1)
+                 (B1) (A1) (B2) (A1)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=845746.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -76.0059281829     A.U. after    7 cycles
+            NFock=  7  Conv=0.40D-08     -V/T= 2.0020
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8          -0.028884737    0.000000000   -0.024237172
+      2        1           0.021571238    0.000000000    0.003622730
+      3        1           0.007313499   -0.000000000    0.020614442
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.028884737 RMS     0.016257147
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.038938920 RMS     0.022481398
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20 on scan point    20 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Update second derivatives using D2CorX and points    2
+ DE= -2.89D-07 DEPred=-2.98D-07 R= 9.70D-01
+ Trust test= 9.70D-01 RLast= 9.94D-04 DXMaxT set to 5.05D-01
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.50089
+           R2           0.10213   0.50089
+           A1           0.02922   0.02922   0.16283
+ ITU=  0  0
+ Use linear search instead of GDIIS.
+     Eigenvalues ---    0.39877   0.603021000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 3.98766852D-01
+ Quartic linear search produced a step of -0.02921.
+ Iteration  1 RMS(Cart)=  0.00001525 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 6.06D-15 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.78020   0.00001   0.00002   0.00000   0.00002   1.78022
+    R2        1.78020   0.00001   0.00002  -0.00000   0.00002   1.78022
+    A1        2.07694  -0.03894  -0.00000   0.00000  -0.00000   2.07694
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000013     0.000450     YES
+ RMS     Force            0.000013     0.000300     YES
+ Maximum Displacement     0.000016     0.001800     YES
+ RMS     Displacement     0.000015     0.001200     YES
+ Predicted change in Energy=-2.699779D-10
+ Optimization completed.
+    -- Stationary point found.
+                           ----------------------------
+                           !   Optimized Parameters   !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  0.942          -DE/DX =    0.0                 !
+ ! R2    R(1,3)                  0.942          -DE/DX =    0.0                 !
+ ! A1    A(2,1,3)              119.0            -DE/DX =   -0.0389              !
+ --------------------------------------------------------------------------------
+ Iteration  1 RMS(Cart)=  0.00901461 RMS(Int)=  0.00005535
+ Iteration  2 RMS(Cart)=  0.00005040 RMS(Int)=  0.00000000
+ Iteration  3 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.104131   -0.000000    0.087377
+      2          1           0       -0.059454   -0.000000    1.015117
+      3          1           0        0.989371    0.000000   -0.234825
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.942053   0.000000
+     3  H    0.942053   1.631683   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0       -0.000000   -0.000000    0.094205
+      2          1           0        0.000000    0.815842   -0.376821
+      3          1           0       -0.000000   -0.815842   -0.376821
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):        1272.4975876         376.6953936         290.6536622
+ Standard basis: 6-31G(d) (6D, 7F)
+ There are    10 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    10 symmetry adapted basis functions of A1  symmetry.
+ There are     1 symmetry adapted basis functions of A2  symmetry.
+ There are     3 symmetry adapted basis functions of B1  symmetry.
+ There are     5 symmetry adapted basis functions of B2  symmetry.
+    19 basis functions,    36 primitive gaussians,    19 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.3119578811 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    19 RedAO= T EigKep=  2.20D-02  NBF=    10     1     3     5
+ NBsUse=    19 1.00D-06 EigRej= -1.00D+00 NBFU=    10     1     3     5
+ Initial guess from the checkpoint file:  "/scratch/webmodemo/webmo-4350/627084/Gau-13489.chk"
+ B after Tr=    -0.000000   -0.000000   -0.000000
+         Rot=    1.000000   -0.000000   -0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (A1) (B2) (A1) (B1) (A1) (B2) (A2) (A1)
+                 (B1) (A1) (B2) (A1)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=845746.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -76.0052273358     A.U. after    8 cycles
+            NFock=  8  Conv=0.43D-08     -V/T= 2.0020
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8          -0.030502392    0.000000000   -0.025594546
+      2        1           0.022952358    0.000000000    0.003619385
+      3        1           0.007550034   -0.000000000    0.021975161
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.030502392 RMS     0.017208842
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.041358398 RMS     0.023880759
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20 on scan point    21 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- RFO/linear search
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.50089
+           R2           0.10213   0.50089
+           A1           0.02922   0.02922   0.16283
+ ITU=  0
+     Eigenvalues ---    0.39877   0.603021000.00000
+ RFO step:  Lambda=-5.88504846D-07 EMin= 3.98766852D-01
+ Linear search not attempted -- first point.
+ Iteration  1 RMS(Cart)=  0.00052066 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 1.61D-15 for atom     2.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.78022  -0.00042   0.00000  -0.00070  -0.00070   1.77952
+    R2        1.78022  -0.00042   0.00000  -0.00070  -0.00070   1.77952
+    A1        2.09440  -0.04136   0.00000   0.00000  -0.00000   2.09440
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000421     0.000450     YES
+ RMS     Force            0.000421     0.000300     NO 
+ Maximum Displacement     0.000538     0.001800     YES
+ RMS     Displacement     0.000521     0.001200     YES
+ Predicted change in Energy=-2.942524D-07
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.104226   -0.000000    0.087456
+      2          1           0       -0.059296   -0.000000    1.014833
+      3          1           0        0.989118    0.000000   -0.234619
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.941683   0.000000
+     3  H    0.941683   1.631043   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0       -0.000000   -0.000000    0.094168
+      2          1           0       -0.000000    0.815522   -0.376673
+      3          1           0       -0.000000   -0.815522   -0.376673
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):        1273.4968098         376.9911917         290.8818965
+ Standard basis: 6-31G(d) (6D, 7F)
+ There are    10 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    10 symmetry adapted basis functions of A1  symmetry.
+ There are     1 symmetry adapted basis functions of A2  symmetry.
+ There are     3 symmetry adapted basis functions of B1  symmetry.
+ There are     5 symmetry adapted basis functions of B2  symmetry.
+    19 basis functions,    36 primitive gaussians,    19 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy         9.3156132472 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 1 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    19 RedAO= T EigKep=  2.20D-02  NBF=    10     1     3     5
+ NBsUse=    19 1.00D-06 EigRej= -1.00D+00 NBFU=    10     1     3     5
+ Initial guess from the checkpoint file:  "/scratch/webmodemo/webmo-4350/627084/Gau-13489.chk"
+ B after Tr=     0.000000    0.000000   -0.000000
+         Rot=    1.000000   -0.000000    0.000000   -0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (A1) (B2) (A1) (B1) (A1) (B2) (A2) (A1)
+                 (B1) (A1) (B2) (A1)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=845746.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RHF) =  -76.0052276208     A.U. after    7 cycles
+            NFock=  7  Conv=0.40D-08     -V/T= 2.0020
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8          -0.030822397    0.000000000   -0.025863062
+      2        1           0.022867248    0.000000000    0.004045757
+      3        1           0.007955149   -0.000000000    0.021817305
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.030822397 RMS     0.017312412
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.041324767 RMS     0.023858868
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20 on scan point    21 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Update second derivatives using D2CorX and points    2
+ DE= -2.85D-07 DEPred=-2.94D-07 R= 9.69D-01
+ Trust test= 9.69D-01 RLast= 9.88D-04 DXMaxT set to 5.05D-01
+ The second derivative matrix:
+                          R1        R2        A1
+           R1           0.50089
+           R2           0.10213   0.50089
+           A1           0.02922   0.02922   0.16283
+ ITU=  0  0
+ Use linear search instead of GDIIS.
+     Eigenvalues ---    0.39877   0.603021000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 3.98766852D-01
+ Quartic linear search produced a step of -0.03088.
+ Iteration  1 RMS(Cart)=  0.00001608 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ Iteration  1 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 1.99D-14 for atom     3.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        1.77952   0.00001   0.00002  -0.00000   0.00002   1.77954
+    R2        1.77952   0.00001   0.00002   0.00000   0.00002   1.77954
+    A1        2.09440  -0.04132   0.00000   0.00000   0.00000   2.09440
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000013     0.000450     YES
+ RMS     Force            0.000013     0.000300     YES
+ Maximum Displacement     0.000017     0.001800     YES
+ RMS     Displacement     0.000016     0.001200     YES
+ Predicted change in Energy=-2.991224D-10
+ Optimization completed.
+    -- Stationary point found.
+                           ----------------------------
+                           !   Optimized Parameters   !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  0.9417         -DE/DX =    0.0                 !
+ ! R2    R(1,3)                  0.9417         -DE/DX =    0.0                 !
+ ! A1    A(2,1,3)              120.0            -DE/DX =   -0.0413              !
+ --------------------------------------------------------------------------------
+ Summary of Optimized Potential Surface Scan (add -76.0 to energies):
+                           1         2         3         4         5
+     Eigenvalues --    -0.00985  -0.01015  -0.01039  -0.01056  -0.01068
+           R1           0.94978   0.94918   0.94889   0.94843   0.94798
+           R2           0.94978   0.94918   0.94889   0.94843   0.94798
+           A1         100.00000 101.00000 102.00000 103.00000 104.00000
+                           6         7         8         9        10
+     Eigenvalues --    -0.01074  -0.01074  -0.01068  -0.01057  -0.01040
+           R1           0.94754   0.94710   0.94667   0.94626   0.94585
+           R2           0.94754   0.94710   0.94667   0.94626   0.94585
+           A1         105.00000 106.00000 107.00000 108.00000 109.00000
+                          11        12        13        14        15
+     Eigenvalues --    -0.01018  -0.00990  -0.00958  -0.00920  -0.00877
+           R1           0.94544   0.94504   0.94465   0.94427   0.94388
+           R2           0.94544   0.94504   0.94465   0.94427   0.94388
+           A1         110.00000 111.00000 112.00000 113.00000 114.00000
+                          16        17        18        19        20
+     Eigenvalues --    -0.00829  -0.00777  -0.00720  -0.00659  -0.00593
+           R1           0.94351   0.94314   0.94277   0.94240   0.94204
+           R2           0.94351   0.94314   0.94277   0.94240   0.94204
+           A1         115.00000 116.00000 117.00000 118.00000 119.00000
+                          21
+     Eigenvalues --    -0.00523
+           R1           0.94168
+           R2           0.94168
+           A1         120.00000
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.104226   -0.000000    0.087456
+      2          1           0       -0.059296   -0.000000    1.014833
+      3          1           0        0.989118    0.000000   -0.234619
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  O    0.000000
+     2  H    0.941683   0.000000
+     3  H    0.941683   1.631043   0.000000
+ Stoichiometry    H2O
+ Framework group  C2V[C2(O),SGV(H2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.000000    0.000000    0.094168
+      2          1           0       -0.000000    0.815522   -0.376673
+      3          1           0       -0.000000   -0.815522   -0.376673
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):        1273.4968098         376.9911917         290.8818965
+
+ **********************************************************************
+
+            Population analysis using the SCF Density.
+
+ **********************************************************************
+
+ Orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1)
+       Virtual   (A1) (B2) (A1) (B2) (A1) (B1) (A1) (B2) (A2) (A1)
+                 (B1) (A1) (B2) (A1)
+ The electronic state is 1-A1.
+ Alpha  occ. eigenvalues --  -20.54770  -1.33688  -0.74166  -0.54224  -0.49229
+ Alpha virt. eigenvalues --    0.21444   0.30875   1.07290   1.11958   1.16373
+ Alpha virt. eigenvalues --    1.17241   1.39606   1.40121   2.01793   2.06102
+ Alpha virt. eigenvalues --    2.08321   2.70050   2.92523   4.00580
+          Condensed to atoms (all electrons):
+               1          2          3
+     1  O    8.362481   0.269057   0.269057
+     2  H    0.269057   0.293695  -0.013050
+     3  H    0.269057  -0.013050   0.293695
+ Mulliken charges:
+               1
+     1  O   -0.900595
+     2  H    0.450297
+     3  H    0.450297
+ Sum of Mulliken charges =   0.00000
+ Mulliken charges with hydrogens summed into heavy atoms:
+               1
+     1  O    0.000000
+ Electronic spatial extent (au):  <R**2>=             18.6855
+ Charge=              0.0000 electrons
+ Dipole moment (field-independent basis, Debye):
+    X=             -0.0000    Y=              0.0000    Z=             -1.9182  Tot=              1.9182
+ Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=             -7.1958   YY=             -3.4774   ZZ=             -6.3667
+   XY=              0.0000   XZ=              0.0000   YZ=             -0.0000
+ Traceless Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=             -1.5158   YY=              2.2025   ZZ=             -0.6868
+   XY=              0.0000   XZ=              0.0000   YZ=             -0.0000
+ Octapole moment (field-independent basis, Debye-Ang**2):
+  XXX=              0.0000  YYY=              0.0000  ZZZ=             -1.1450  XYY=             -0.0000
+  XXY=              0.0000  XXZ=             -0.3377  XZZ=              0.0000  YZZ=              0.0000
+  YYZ=             -1.3204  XYZ=             -0.0000
+ Hexadecapole moment (field-independent basis, Debye-Ang**3):
+ XXXX=             -5.1781 YYYY=             -4.7475 ZZZZ=             -5.7575 XXXY=             -0.0000
+ XXXZ=             -0.0000 YYYX=              0.0000 YYYZ=             -0.0000 ZZZX=             -0.0000
+ ZZZY=             -0.0000 XXYY=             -2.0300 XXZZ=             -1.8441 YYZZ=             -1.6518
+ XXYZ=             -0.0000 YYXZ=              0.0000 ZZXY=              0.0000
+ N-N= 9.315613247206D+00 E-N=-1.991752745682D+02  KE= 7.585513499506D+01
+ Symmetry A1   KE= 6.780487005995D+01
+ Symmetry A2   KE= 1.071993303398D-34
+ Symmetry B1   KE= 4.529406464939D+00
+ Symmetry B2   KE= 3.520858470171D+00
+ B after Tr=    -0.137871    0.000000   -0.115687
+         Rot=    1.000000    0.000000   -0.000000    0.000000 Ang=   0.00 deg.
+ Final structure in terms of initial Z-matrix:
+ O
+ H,1,B1
+ H,1,B2,2,A1
+      Variables:
+ B1=0.94168314
+ B2=0.94168314
+ A1=120.
+ 1\1\GINC-BUCHNER\Scan\RHF\6-31G(d)\H2O1\WEBMODEMO\07-Apr-2020\0\\#N HF
+ /6-31G(d) OPT(AddRedundant) Geom=Connectivity\\H2O\\0,1\O,0.1042256668
+ ,0.,0.0874557185\H,-0.0592958953,0.,1.0148325806\H,0.9891183692,0.,-0.
+ 2346188857\\Version=ES64L-G16RevB.01\State=1-A1\HF=-76.0098515,-76.010
+ 1503,-76.0103877,-76.0105644,-76.0106813,-76.0107393,-76.0107393,-76.0
+ 106823,-76.0105692,-76.0104011,-76.0101788,-76.0099036,-76.0095764,-76
+ .0091984,-76.0087707,-76.0082944,-76.0077708,-76.0072011,-76.0065864,-
+ 76.0059282,-76.0052276\RMSD=7.776e-09,5.851e-09,4.112e-09,4.030e-09,3.
+ 955e-09,3.890e-09,3.844e-09,3.805e-09,3.775e-09,3.753e-09,3.739e-09,3.
+ 733e-09,3.735e-09,3.745e-09,3.762e-09,3.787e-09,3.819e-09,3.860e-09,3.
+ 908e-09,3.964e-09,4.029e-09\PG=C02V [C2(O1),SGV(H2)]\\@
+
+
+ THE MORE POWERFUL THE METHOD, THE MORE CATASTROPHIC THE ERRORS.
+     -- M.D. KAMEN
+ Job cpu time:       0 days  0 hours  0 minutes 41.1 seconds.
+ Elapsed time:       0 days  0 hours  0 minutes 37.6 seconds.
+ File lengths (MBytes):  RWF=      6 Int=      0 D2E=      0 Chk=      2 Scr=      1
+ Normal termination of Gaussian 16 at Tue Apr  7 17:23:14 2020.

--- a/test_files/molecules/so2_scan_opt.log
+++ b/test_files/molecules/so2_scan_opt.log
@@ -1,0 +1,8666 @@
+===============================================
+Execution sur noeud     : dnas-node18.univ-pau.fr
+Job id = 320660
+Fichiers temporaire sur :  /scratch/320660
+===============================================
+Debut execution du job  : ven. sept. 18 17:39:29 CEST 2015
+ Entering Gaussian System, Link 0=g09
+ Initial command:
+ /opt/g09-d01/g09/l1.exe "/scratch/320660/Gau-10444.inp" -scrdir="/scratch/320660/"
+ Entering Link 1 = /opt/g09-d01/g09/l1.exe PID=     10445.
+  
+ Copyright (c) 1988,1990,1992,1993,1995,1998,2003,2009,2013,
+            Gaussian, Inc.  All Rights Reserved.
+  
+ This is part of the Gaussian(R) 09 program.  It is based on
+ the Gaussian(R) 03 system (copyright 2003, Gaussian, Inc.),
+ the Gaussian(R) 98 system (copyright 1998, Gaussian, Inc.),
+ the Gaussian(R) 94 system (copyright 1995, Gaussian, Inc.),
+ the Gaussian 92(TM) system (copyright 1992, Gaussian, Inc.),
+ the Gaussian 90(TM) system (copyright 1990, Gaussian, Inc.),
+ the Gaussian 88(TM) system (copyright 1988, Gaussian, Inc.),
+ the Gaussian 86(TM) system (copyright 1986, Carnegie Mellon
+ University), and the Gaussian 82(TM) system (copyright 1983,
+ Carnegie Mellon University). Gaussian is a federally registered
+ trademark of Gaussian, Inc.
+  
+ This software contains proprietary and confidential information,
+ including trade secrets, belonging to Gaussian, Inc.
+  
+ This software is provided under written license and may be
+ used, copied, transmitted, or stored only in accord with that
+ written license.
+  
+ The following legend is applicable only to US Government
+ contracts under FAR:
+  
+                    RESTRICTED RIGHTS LEGEND
+  
+ Use, reproduction and disclosure by the US Government is
+ subject to restrictions as set forth in subparagraphs (a)
+ and (c) of the Commercial Computer Software - Restricted
+ Rights clause in FAR 52.227-19.
+  
+ Gaussian, Inc.
+ 340 Quinnipiac St., Bldg. 40, Wallingford CT 06492
+  
+  
+ ---------------------------------------------------------------
+ Warning -- This program may not be used in any manner that
+ competes with the business of Gaussian, Inc. or will provide
+ assistance to any competitor of Gaussian, Inc.  The licensee
+ of this program is prohibited from giving any competitor of
+ Gaussian, Inc. access to this program.  By using this program,
+ the user acknowledges that Gaussian, Inc. is engaged in the
+ business of creating and licensing software in the field of
+ computational chemistry and represents and warrants to the
+ licensee that it is not a competitor of Gaussian, Inc. and that
+ it will not use this program in any manner prohibited above.
+ ---------------------------------------------------------------
+  
+
+ Cite this work as:
+ Gaussian 09, Revision D.01,
+ M. J. Frisch, G. W. Trucks, H. B. Schlegel, G. E. Scuseria, 
+ M. A. Robb, J. R. Cheeseman, G. Scalmani, V. Barone, B. Mennucci, 
+ G. A. Petersson, H. Nakatsuji, M. Caricato, X. Li, H. P. Hratchian, 
+ A. F. Izmaylov, J. Bloino, G. Zheng, J. L. Sonnenberg, M. Hada, 
+ M. Ehara, K. Toyota, R. Fukuda, J. Hasegawa, M. Ishida, T. Nakajima, 
+ Y. Honda, O. Kitao, H. Nakai, T. Vreven, J. A. Montgomery, Jr., 
+ J. E. Peralta, F. Ogliaro, M. Bearpark, J. J. Heyd, E. Brothers, 
+ K. N. Kudin, V. N. Staroverov, T. Keith, R. Kobayashi, J. Normand, 
+ K. Raghavachari, A. Rendell, J. C. Burant, S. S. Iyengar, J. Tomasi, 
+ M. Cossi, N. Rega, J. M. Millam, M. Klene, J. E. Knox, J. B. Cross, 
+ V. Bakken, C. Adamo, J. Jaramillo, R. Gomperts, R. E. Stratmann, 
+ O. Yazyev, A. J. Austin, R. Cammi, C. Pomelli, J. W. Ochterski, 
+ R. L. Martin, K. Morokuma, V. G. Zakrzewski, G. A. Voth, 
+ P. Salvador, J. J. Dannenberg, S. Dapprich, A. D. Daniels, 
+ O. Farkas, J. B. Foresman, J. V. Ortiz, J. Cioslowski, 
+ and D. J. Fox, Gaussian, Inc., Wallingford CT, 2013.
+ 
+ ******************************************
+ Gaussian 09:  EM64L-G09RevD.01 24-Apr-2013
+                18-Sep-2015 
+ ******************************************
+ %NProc=1
+ Will use up to    1 processors via shared memory.
+ ------------------------------
+ # B3LYP/6-31G* 5d opt=z-matrix
+ ------------------------------
+ 1/10=7,14=-1,18=40,26=3,38=1/1,3;
+ 2/12=2,17=6,18=5,29=3,40=1/2;
+ 3/5=1,6=6,7=1,8=1,11=2,16=1,25=1,30=1,71=1,74=-5/1,2,3;
+ 4//1;
+ 5/5=2,38=5/2;
+ 6/7=2,8=2,9=2,10=2,28=1/1;
+ 7/29=1/1,2,3,16;
+ 1/10=7,14=-1,18=40,26=3/3(2);
+ 2/29=3/2;
+ 99//99;
+ 2/29=3/2;
+ 3/5=1,6=6,7=1,8=1,11=2,16=1,25=1,30=1,71=1,74=-5/1,2,3;
+ 4/5=5,16=3,69=1/1;
+ 5/5=2,38=5/2;
+ 7//1,2,3,16;
+ 1/14=-1,18=40,26=3/3(-5);
+ 2/29=3/2;
+ 6/7=2,8=2,9=2,10=2,19=2,28=1/1;
+ 99/9=1/99;
+ ------------
+ SO2 molecule
+ ------------
+ Symbolic Z-matrix:
+ Charge =  0 Multiplicity = 1
+ S
+ O                    1    DSO
+ O                    1    DSO      2    ASO
+       Variables:
+  DSO                   1.     Scan 20    0.1    
+  ASO                 119.4                      
+ 
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Initialization pass.
+                       ----------------------------
+                       !    Initial Parameters    !
+                       ! (Angstroms and Degrees)  !
+ ----------------------                            ----------------------
+ !      Name          Value   Derivative information (Atomic Units)     !
+ ------------------------------------------------------------------------
+ !       DSO         1.0      Scan                                      !
+ !       ASO       119.4      estimate D2E/DX2                          !
+ ------------------------------------------------------------------------
+ Trust Radius=3.00D-01 FncErr=1.00D-07 GrdErr=1.00D-06
+ Number of optimizations in scan=  21
+ Number of steps in this run=     20 maximum allowed number of steps=    100.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   1.000000(     1)
+      3      3  O        1   1.000000(     2)      2  119.400(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    1.000000
+      3          8           0        0.871214    0.000000   -0.490904
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    1.000000   0.000000
+     3  O    1.000000   1.726791   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.252264
+      2          8           0        0.000000    0.863396   -0.252264
+      3          8           0        0.000000   -0.863396   -0.252264
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):    124.1612162     21.1926693     18.1027675
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy       155.0822423278 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  9.83D-03  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ ExpMin= 1.17D-01 ExpMax= 2.19D+04 ExpMxC= 3.30D+03 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (B2) (A1) (A1) (B2) (A1) (B1) (A1) (B2) (A1)
+                 (B1) (A2) (A1) (B2) (B2) (A1)
+       Virtual   (B1) (A1) (B2) (A1) (B1) (A1) (B2) (A1) (B1) (B2)
+                 (A2) (A1) (B1) (A1) (A2) (B2) (A1) (B2) (A1) (B2)
+                 (B1) (A2) (A1) (B2) (B1) (B2) (A2) (A1) (A1) (B2)
+ The electronic state of the initial guess is 1-A1.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(RB3LYP) =  -547.050773534     A.U. after   12 cycles
+            NFock= 12  Conv=0.12D-08     -V/T= 1.9840
+
+ **********************************************************************
+
+            Population analysis using the SCF density.
+
+ **********************************************************************
+
+ Orbital symmetries:
+       Occupied  (A1) (B2) (A1) (A1) (B2) (A1) (B1) (A1) (B2) (B1)
+                 (A1) (A1) (B2) (A2) (B2) (A1)
+       Virtual   (B1) (A1) (B2) (A1) (B1) (A1) (B2) (A1) (B2) (A2)
+                 (B1) (A1) (B1) (A2) (B2) (A1) (A1) (B2) (A1) (B2)
+                 (B1) (A2) (A1) (B2) (B1) (B2) (A2) (A1) (A1) (B2)
+ The electronic state is 1-A1.
+ Alpha  occ. eigenvalues --  -88.90450 -19.12781 -19.12776  -8.08178  -6.05659
+ Alpha  occ. eigenvalues --   -6.02247  -6.01725  -1.39828  -1.20611  -0.68333
+ Alpha  occ. eigenvalues --   -0.67903  -0.52855  -0.49322  -0.49164  -0.42449
+ Alpha  occ. eigenvalues --   -0.28265
+ Alpha virt. eigenvalues --    0.03562   0.13954   0.18510   0.29726   0.30765
+ Alpha virt. eigenvalues --    0.51789   0.59627   0.74121   0.76588   0.77983
+ Alpha virt. eigenvalues --    0.79200   0.84553   0.94949   1.03871   1.04930
+ Alpha virt. eigenvalues --    1.06394   1.41109   1.44365   1.73845   1.75071
+ Alpha virt. eigenvalues --    1.75879   1.80210   2.25798   2.37513   2.47287
+ Alpha virt. eigenvalues --    2.49227   2.50253   2.75591   2.96190   3.30258
+          Condensed to atoms (all electrons):
+               1          2          3
+     1  S   14.931698   0.359666   0.359666
+     2  O    0.359666   8.008034  -0.193214
+     3  O    0.359666  -0.193214   8.008034
+ Mulliken charges:
+               1
+     1  S    0.348971
+     2  O   -0.174485
+     3  O   -0.174485
+ Sum of Mulliken charges =   0.00000
+ Mulliken charges with hydrogens summed into heavy atoms:
+               1
+     1  S    0.348971
+     2  O   -0.174485
+     3  O   -0.174485
+ Electronic spatial extent (au):  <R**2>=             97.0600
+ Charge=              0.0000 electrons
+ Dipole moment (field-independent basis, Debye):
+    X=              0.0000    Y=              0.0000    Z=             -0.0175  Tot=              0.0175
+ Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=            -18.7393   YY=            -22.9525   ZZ=            -21.7870
+   XY=              0.0000   XZ=              0.0000   YZ=              0.0000
+ Traceless Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=              2.4203   YY=             -1.7929   ZZ=             -0.6274
+   XY=              0.0000   XZ=              0.0000   YZ=              0.0000
+ Octapole moment (field-independent basis, Debye-Ang**2):
+  XXX=              0.0000  YYY=              0.0000  ZZZ=             -4.4271  XYY=              0.0000
+  XXY=              0.0000  XXZ=             -0.9971  XZZ=              0.0000  YZZ=              0.0000
+  YYZ=              0.5757  XYZ=              0.0000
+ Hexadecapole moment (field-independent basis, Debye-Ang**3):
+ XXXX=            -15.6041 YYYY=            -65.6193 ZZZZ=            -31.4573 XXXY=              0.0000
+ XXXZ=              0.0000 YYYX=              0.0000 YYYZ=              0.0000 ZZZX=              0.0000
+ ZZZY=              0.0000 XXYY=            -12.7561 XXZZ=             -7.6713 YYZZ=            -15.5203
+ XXYZ=              0.0000 YYXZ=              0.0000 ZZXY=              0.0000
+ N-N= 1.550822423278D+02 E-N=-1.615805356533D+03  KE= 5.559615052081D+02
+ Symmetry A1   KE= 3.968733952101D+02
+ Symmetry A2   KE= 5.120110580307D+00
+ Symmetry B1   KE= 3.989093327995D+01
+ Symmetry B2   KE= 1.140770661377D+02
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16          -2.386863492    0.000000000   -1.394770410
+      2        8          -0.092178206    0.000000000    2.897442962
+      3        8           2.479041698    0.000000000   -1.502672552
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     2.897442962 RMS     1.648226215
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1   2.897443(     1)
+      3  O        1   2.897443(     2)      2   0.174192(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     2.897442962 RMS     2.367888943
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20 on scan point     1 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.27625   0.52753
+ ITU=  0
+     Eigenvalues ---    0.527531000.00000
+ RFO step:  Lambda=-5.23280998D-02 EMin= 5.27526757D-01
+ Linear search not attempted -- first point.
+ Maximum step size (   0.300) exceeded in Quadratic search.
+    -- Step size scaled by   0.999
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        1.88973   5.79489   0.00000   0.00000   0.00000   1.88973
+   ASO        2.08392   0.17419   0.00000   0.30000   0.30000   2.38392
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.174192     0.000450     NO 
+ RMS     Force            0.174192     0.000300     NO 
+ Maximum Displacement     0.300000     0.001800     NO 
+ RMS     Displacement     0.212132     0.001200     NO 
+ Predicted change in Energy=-2.851877D-02
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   1.000000(     1)
+      3      3  O        1   1.000000(     2)      2  136.589(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    1.000000
+      3          8           0        0.687230    0.000000   -0.726440
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    1.000000   0.000000
+     3  O    1.000000   1.858192   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.184919
+      2          8           0        0.000000    0.929096   -0.184919
+      3          8           0        0.000000   -0.929096   -0.184919
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):    231.0641398     18.3013822     16.9582110
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy       153.6953256375 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  9.42D-03  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (B2) (A1) (A1) (B2) (A1) (B1) (A1) (B2) (B1)
+                 (A1) (A1) (B2) (A2) (B2) (A1)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ ExpMin= 1.17D-01 ExpMax= 2.19D+04 ExpMxC= 3.30D+03 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(RB3LYP) =  -547.063875579     A.U. after   12 cycles
+            NFock= 12  Conv=0.19D-08     -V/T= 1.9844
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16          -2.016418339    0.000000000   -0.802659964
+      2        8           0.033259907    0.000000000    2.850568338
+      3        8           1.983158431    0.000000000   -2.047908374
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     2.850568338 RMS     1.526211653
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1   2.850568(     1)
+      3  O        1   2.850568(     2)      2  -0.062852(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     2.850568338 RMS     2.327762165
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20 on scan point     1 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Update second derivatives using D2CorN and points    1    2
+ DE= -1.31D-02 DEPred=-2.85D-02 R= 4.59D-01
+ Trust test= 4.59D-01 RLast= 3.00D-01 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.29437   0.79015
+ ITU=  0  0
+     Eigenvalues ---    0.790151000.00000
+ RFO step:  Lambda=-9.64422877D-07 EMin= 7.90145602D-01
+ Quartic linear search produced a step of -0.33126.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        1.88973   5.70114   0.00000   0.00000   0.00000   1.88973
+   ASO        2.38392  -0.06285  -0.09938   0.00000  -0.09938   2.28455
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.062852     0.000450     NO 
+ RMS     Force            0.062852     0.000300     NO 
+ Maximum Displacement     0.099377     0.001800     NO 
+ RMS     Displacement     0.070270     0.001200     NO 
+ Predicted change in Energy=-2.344395D-03
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   1.000000(     1)
+      3      3  O        1   1.000000(     2)      2  130.895(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    1.000000
+      3          8           0        0.755913    0.000000   -0.654673
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    1.000000   0.000000
+     3  O    1.000000   1.819161   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.207764
+      2          8           0        0.000000    0.909580   -0.207764
+      3          8           0        0.000000   -0.909580   -0.207764
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):    183.0437419     19.0951546     17.2913210
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy       154.0863809745 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  9.57D-03  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (B2) (A1) (A1) (B2) (A1) (B1) (A1) (B2) (B1)
+                 (A1) (A1) (A2) (B2) (B2) (A1)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ ExpMin= 1.17D-01 ExpMax= 2.19D+04 ExpMxC= 3.30D+03 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(RB3LYP) =  -547.067109898     A.U. after   11 cycles
+            NFock= 11  Conv=0.18D-08     -V/T= 1.9843
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16          -2.162720876    0.000000000   -0.988006749
+      2        8          -0.000057609    0.000000000    2.861199134
+      3        8           2.162778485    0.000000000   -1.873192386
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     2.861199134 RMS     1.564411139
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1   2.861199(     1)
+      3  O        1   2.861199(     2)      2   0.000109(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     2.861199134 RMS     2.336159311
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   3 out of a maximum of   20 on scan point     1 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Update second derivatives using D2CorN and points    2    3
+ DE= -3.23D-03 DEPred=-2.34D-03 R= 1.38D+00
+ TightC=F SS=  1.41D+00  RLast= 9.94D-02 DXNew= 5.0454D-01 2.9813D-01
+ Trust test= 1.38D+00 RLast= 9.94D-02 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.25416   0.63355
+ ITU=  1  0  0
+     Eigenvalues ---    0.633551000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 6.33554937D-01
+ Quartic linear search produced a step of -0.00155.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        1.88973   5.72240   0.00000   0.00000   0.00000   1.88973
+   ASO        2.28455   0.00011   0.00015   0.00000   0.00015   2.28470
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000109     0.000450     YES
+ RMS     Force            0.000109     0.000300     YES
+ Maximum Displacement     0.000154     0.001800     YES
+ RMS     Displacement     0.000109     0.001200     YES
+ Predicted change in Energy=-9.255738D-09
+ Optimization completed.
+    -- Stationary point found.
+                       ----------------------------
+                       !   Optimized Parameters   !
+                       ! (Angstroms and Degrees)  !
+ ----------------------                            ----------------------
+ !      Name          Value   Derivative information (Atomic Units)     !
+ ------------------------------------------------------------------------
+ !       DSO         1.0      -DE/DX =    5.7224                        !
+ !       ASO       130.8948   -DE/DX =    0.0001                        !
+ ------------------------------------------------------------------------
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   1.100000(     1)
+      3      3  O        1   1.100000(     2)      2  130.895(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    1.100000
+      3          8           0        0.831504    0.000000   -0.720140
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    1.100000   0.000000
+     3  O    1.100000   2.001077   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.228541
+      2          8           0        0.000000    1.000538   -0.228541
+      3          8           0        0.000000   -1.000538   -0.228541
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):    151.2758198     15.7811195     14.2903480
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy       140.0785281586 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  1.24D-02  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (B2) (A1) (A1) (B2) (A1) (B1) (A1) (B2) (B1)
+                 (A1) (A1) (A2) (B2) (B2) (A1)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ ExpMin= 1.17D-01 ExpMax= 2.19D+04 ExpMxC= 3.30D+03 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(RB3LYP) =  -547.872174319     A.U. after   13 cycles
+            NFock= 13  Conv=0.16D-08     -V/T= 1.9925
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16          -1.182901886    0.000000000   -0.540391069
+      2        8           0.019011675    0.000000000    1.523250089
+      3        8           1.163890212    0.000000000   -0.982859020
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     1.523250089 RMS     0.838820861
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1   1.523250(     1)
+      3  O        1   1.523250(     2)      2  -0.039520(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     1.523250089 RMS     1.243937761
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20 on scan point     2 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.25416   0.63355
+ ITU=  0
+     Eigenvalues ---    0.633551000.00000
+ RFO step:  Lambda=-2.45561094D-03 EMin= 6.33554937D-01
+ Linear search not attempted -- first point.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        2.07870   3.04650   0.00000   0.00000   0.00000   2.07870
+   ASO        2.28455  -0.03952   0.00000  -0.06214  -0.06214   2.22241
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.039520     0.000450     NO 
+ RMS     Force            0.039520     0.000300     NO 
+ Maximum Displacement     0.062137     0.001800     NO 
+ RMS     Displacement     0.043937     0.001200     NO 
+ Predicted change in Energy=-1.232546D-03
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   1.100000(     1)
+      3      3  O        1   1.100000(     2)      2  127.335(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    1.100000
+      3          8           0        0.874617    0.000000   -0.667117
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    1.100000   0.000000
+     3  O    1.100000   1.971714   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.243970
+      2          8           0        0.000000    0.985857   -0.243970
+      3          8           0        0.000000   -0.985857   -0.243970
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):    132.7462312     16.2546412     14.4814075
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy       140.3305671051 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  1.25D-02  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (B2) (A1) (A1) (B2) (B1) (A1) (A1) (B2) (B1)
+                 (A1) (A1) (B2) (A2) (B2) (A1)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ ExpMin= 1.17D-01 ExpMax= 2.19D+04 ExpMxC= 3.30D+03 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(RB3LYP) =  -547.873488959     A.U. after   11 cycles
+            NFock= 11  Conv=0.17D-08     -V/T= 1.9924
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16          -1.217296176    0.000000000   -0.602489028
+      2        8           0.000998895    0.000000000    1.528966519
+      3        8           1.216297280    0.000000000   -0.926477491
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     1.528966519 RMS     0.851161444
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1   1.528967(     1)
+      3  O        1   1.528967(     2)      2  -0.002076(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     1.528966519 RMS     1.248396511
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20 on scan point     2 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Update second derivatives using D2CorN and points    1    2
+ DE= -1.31D-03 DEPred=-1.23D-03 R= 1.07D+00
+ TightC=F SS=  1.41D+00  RLast= 6.21D-02 DXNew= 5.0454D-01 1.8641D-01
+ Trust test= 1.07D+00 RLast= 6.21D-02 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.21908   0.60259
+ ITU=  1  0
+     Eigenvalues ---    0.602591000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 6.02593820D-01
+ Quartic linear search produced a step of  0.05226.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        2.07870   3.05793   0.00000   0.00000   0.00000   2.07870
+   ASO        2.22241  -0.00208  -0.00325   0.00000  -0.00325   2.21916
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.002076     0.000450     NO 
+ RMS     Force            0.002076     0.000300     NO 
+ Maximum Displacement     0.003247     0.001800     NO 
+ RMS     Displacement     0.002296     0.001200     NO 
+ Predicted change in Energy=-3.565501D-06
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   1.100000(     1)
+      3      3  O        1   1.100000(     2)      2  127.149(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    1.100000
+      3          8           0        0.876779    0.000000   -0.664273
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    1.100000   0.000000
+     3  O    1.100000   1.970127   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.244770
+      2          8           0        0.000000    0.985064   -0.244770
+      3          8           0        0.000000   -0.985064   -0.244770
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):    131.8799811     16.2808379     14.4917975
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy       140.3444028278 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  1.25D-02  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (B2) (A1) (A1) (B2) (B1) (A1) (A1) (B2) (B1)
+                 (A1) (A1) (B2) (A2) (B2) (A1)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RB3LYP) =  -547.873492333     A.U. after    7 cycles
+            NFock=  7  Conv=0.41D-08     -V/T= 1.9924
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16          -1.218962471    0.000000000   -0.605779489
+      2        8          -0.000000161    0.000000000    1.529301272
+      3        8           1.218962632    0.000000000   -0.923521784
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     1.529301272 RMS     0.851819168
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1   1.529301(     1)
+      3  O        1   1.529301(     2)      2   0.000000(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     1.529301272 RMS     1.248669260
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   3 out of a maximum of   20 on scan point     2 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Update second derivatives using D2CorN and points    2    3
+ DE= -3.37D-06 DEPred=-3.57D-06 R= 9.46D-01
+ TightC=F SS=  1.41D+00  RLast= 3.25D-03 DXNew= 5.0454D-01 9.7410D-03
+ Trust test= 9.46D-01 RLast= 3.25D-03 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.21264   0.63959
+ ITU=  1  1  0
+     Eigenvalues ---    0.639591000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 6.39588797D-01
+ Quartic linear search produced a step of -0.00016.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        2.07870   3.05860   0.00000   0.00000   0.00000   2.07870
+   ASO        2.21916   0.00000   0.00000   0.00000   0.00000   2.21916
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000000     0.000450     YES
+ RMS     Force            0.000000     0.000300     YES
+ Maximum Displacement     0.000001     0.001800     YES
+ RMS     Displacement     0.000000     0.001200     YES
+ Predicted change in Energy=-8.736855D-14
+ Optimization completed.
+    -- Stationary point found.
+                       ----------------------------
+                       !   Optimized Parameters   !
+                       ! (Angstroms and Degrees)  !
+ ----------------------                            ----------------------
+ !      Name          Value   Derivative information (Atomic Units)     !
+ ------------------------------------------------------------------------
+ !       DSO         1.1      -DE/DX =    3.0586                        !
+ !       ASO       127.1486   -DE/DX =    0.0                           !
+ ------------------------------------------------------------------------
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   1.200000(     1)
+      3      3  O        1   1.200000(     2)      2  127.149(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    1.200000
+      3          8           0        0.956486    0.000000   -0.724662
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    1.200000   0.000000
+     3  O    1.200000   2.149230   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.267022
+      2          8           0        0.000000    1.074615   -0.267022
+      3          8           0        0.000000   -1.074615   -0.267022
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):    110.8158175     13.6804263     12.1771354
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy       128.6490359255 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  1.66D-02  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (B2) (A1) (A1) (B2) (B1) (A1) (A1) (B2) (B1)
+                 (A1) (A1) (B2) (A2) (B2) (A1)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ ExpMin= 1.17D-01 ExpMax= 2.19D+04 ExpMxC= 3.30D+03 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(RB3LYP) =  -548.293467354     A.U. after   12 cycles
+            NFock= 12  Conv=0.26D-08     -V/T= 1.9976
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16          -0.630803626    0.000000000   -0.313486188
+      2        8           0.013183977    0.000000000    0.764872301
+      3        8           0.617619649    0.000000000   -0.451386113
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.764872301 RMS     0.430322065
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1   0.764872(     1)
+      3  O        1   0.764872(     2)      2  -0.029897(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.764872301 RMS     0.624754112
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20 on scan point     3 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.21264   0.63959
+ ITU=  0
+     Eigenvalues ---    0.639591000.00000
+ RFO step:  Lambda=-1.39445455D-03 EMin= 6.39588797D-01
+ Linear search not attempted -- first point.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        2.26767   1.52974   0.00000   0.00000   0.00000   2.26767
+   ASO        2.21916  -0.02990   0.00000  -0.04664  -0.04664   2.17252
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.029897     0.000450     NO 
+ RMS     Force            0.029897     0.000300     NO 
+ Maximum Displacement     0.046642     0.001800     NO 
+ RMS     Displacement     0.032981     0.001200     NO 
+ Predicted change in Energy=-6.987474D-04
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   1.200000(     1)
+      3      3  O        1   1.200000(     2)      2  124.476(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    1.200000
+      3          8           0        0.989233    0.000000   -0.679277
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    1.200000   0.000000
+     3  O    1.200000   2.123738   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.279479
+      2          8           0        0.000000    1.061869   -0.279479
+      3          8           0        0.000000   -1.061869   -0.279479
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):    101.1574474     14.0108093     12.3063224
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy       128.8381778036 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  1.66D-02  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (B2) (A1) (A1) (B2) (B1) (A1) (A1) (B2) (A1)
+                 (B1) (A1) (B2) (A2) (B2) (A1)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ ExpMin= 1.17D-01 ExpMax= 2.19D+04 ExpMxC= 3.30D+03 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(RB3LYP) =  -548.294278849     A.U. after   11 cycles
+            NFock= 11  Conv=0.16D-08     -V/T= 1.9976
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16          -0.636131713    0.000000000   -0.334853635
+      2        8           0.002025918    0.000000000    0.767817575
+      3        8           0.634105795    0.000000000   -0.432963939
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.767817575 RMS     0.434087341
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1   0.767818(     1)
+      3  O        1   0.767818(     2)      2  -0.004594(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.767817575 RMS     0.626926035
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20 on scan point     3 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Update second derivatives using D2CorN and points    1    2
+ DE= -8.11D-04 DEPred=-6.99D-04 R= 1.16D+00
+ TightC=F SS=  1.41D+00  RLast= 4.66D-02 DXNew= 5.0454D-01 1.3993D-01
+ Trust test= 1.16D+00 RLast= 4.66D-02 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.16946   0.54249
+ ITU=  1  0
+     Eigenvalues ---    0.542491000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 5.42486465D-01
+ Quartic linear search produced a step of  0.17410.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        2.26767   1.53564   0.00000   0.00000   0.00000   2.26767
+   ASO        2.17252  -0.00459  -0.00812   0.00000  -0.00812   2.16440
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.004594     0.000450     NO 
+ RMS     Force            0.004594     0.000300     NO 
+ Maximum Displacement     0.008120     0.001800     NO 
+ RMS     Displacement     0.005742     0.001200     NO 
+ Predicted change in Energy=-1.942005D-05
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   1.200000(     1)
+      3      3  O        1   1.200000(     2)      2  124.011(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    1.200000
+      3          8           0        0.994717    0.000000   -0.671222
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    1.200000   0.000000
+     3  O    1.200000   2.119182   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.281632
+      2          8           0        0.000000    1.059591   -0.281632
+      3          8           0        0.000000   -1.059591   -0.281632
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     99.6164280     14.0711238     12.3295389
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy       128.8724657974 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  1.66D-02  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (B2) (A1) (A1) (B2) (B1) (A1) (A1) (B2) (A1)
+                 (B1) (A1) (B2) (A2) (B2) (A1)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RB3LYP) =  -548.294297535     A.U. after    7 cycles
+            NFock=  7  Conv=0.58D-08     -V/T= 1.9976
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16          -0.636946258    0.000000000   -0.338592233
+      2        8          -0.000000800    0.000000000    0.768396621
+      3        8           0.636947058    0.000000000   -0.429804388
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.768396621 RMS     0.434768389
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1   0.768397(     1)
+      3  O        1   0.768397(     2)      2   0.000002(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.768396621 RMS     0.627393214
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   3 out of a maximum of   20 on scan point     3 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Update second derivatives using D2CorN and points    2    3
+ DE= -1.87D-05 DEPred=-1.94D-05 R= 9.62D-01
+ TightC=F SS=  1.41D+00  RLast= 8.12D-03 DXNew= 5.0454D-01 2.4361D-02
+ Trust test= 9.62D-01 RLast= 8.12D-03 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.15604   0.56597
+ ITU=  1  1  0
+     Eigenvalues ---    0.565971000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 5.65969046D-01
+ Quartic linear search produced a step of -0.00039.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        2.26767   1.53679   0.00000   0.00000   0.00000   2.26767
+   ASO        2.16440   0.00000   0.00000   0.00000   0.00000   2.16440
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000002     0.000450     YES
+ RMS     Force            0.000002     0.000300     YES
+ Maximum Displacement     0.000003     0.001800     YES
+ RMS     Displacement     0.000002     0.001200     YES
+ Predicted change in Energy=-2.907317D-12
+ Optimization completed.
+    -- Stationary point found.
+                       ----------------------------
+                       !   Optimized Parameters   !
+                       ! (Angstroms and Degrees)  !
+ ----------------------                            ----------------------
+ !      Name          Value   Derivative information (Atomic Units)     !
+ ------------------------------------------------------------------------
+ !       DSO         1.2      -DE/DX =    1.5368                        !
+ !       ASO       124.011    -DE/DX =    0.0                           !
+ ------------------------------------------------------------------------
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   1.300000(     1)
+      3      3  O        1   1.300000(     2)      2  124.011(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    1.300000
+      3          8           0        1.077610    0.000000   -0.727157
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    1.300000   0.000000
+     3  O    1.300000   2.295780   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.305102
+      2          8           0        0.000000    1.147890   -0.305102
+      3          8           0        0.000000   -1.147890   -0.305102
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     84.8802700     11.9895966     10.5056426
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy       118.9591991976 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  2.22D-02  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (B2) (A1) (A1) (B2) (B1) (A1) (A1) (B2) (A1)
+                 (B1) (A1) (B2) (A2) (B2) (A1)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ ExpMin= 1.17D-01 ExpMax= 2.19D+04 ExpMxC= 3.30D+03 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(RB3LYP) =  -548.494691389     A.U. after   11 cycles
+            NFock= 11  Conv=0.51D-08     -V/T= 2.0008
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16          -0.289168323    0.000000000   -0.153718068
+      2        8           0.008109402    0.000000000    0.333589931
+      3        8           0.281058922    0.000000000   -0.179871863
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.333589931 RMS     0.191469050
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1   0.333590(     1)
+      3  O        1   0.333590(     2)      2  -0.019922(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.333589931 RMS     0.272617783
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20 on scan point     4 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.15604   0.56597
+ ITU=  0
+     Eigenvalues ---    0.565971000.00000
+ RFO step:  Lambda=-7.00376584D-04 EMin= 5.65969046D-01
+ Linear search not attempted -- first point.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        2.45664   0.66718   0.00000   0.00000   0.00000   2.45664
+   ASO        2.16440  -0.01992   0.00000  -0.03516  -0.03516   2.12924
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.019922     0.000450     NO 
+ RMS     Force            0.019922     0.000300     NO 
+ Maximum Displacement     0.035156     0.001800     NO 
+ RMS     Displacement     0.024859     0.001200     NO 
+ Predicted change in Energy=-3.506216D-04
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   1.300000(     1)
+      3      3  O        1   1.300000(     2)      2  121.997(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    1.300000
+      3          8           0        1.102503    0.000000   -0.688831
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    1.300000   0.000000
+     3  O    1.300000   2.273974   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.315143
+      2          8           0        0.000000    1.136987   -0.315143
+      3          8           0        0.000000   -1.136987   -0.315143
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     79.5574703     12.2206443     10.5934138
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy       119.1006614373 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  2.21D-02  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (B2) (A1) (A1) (B2) (B1) (A1) (A1) (B2) (A1)
+                 (B1) (A1) (B2) (A2) (B2) (A1)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ ExpMin= 1.17D-01 ExpMax= 2.19D+04 ExpMxC= 3.30D+03 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(RB3LYP) =  -548.495100324     A.U. after   10 cycles
+            NFock= 10  Conv=0.19D-08     -V/T= 2.0008
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16          -0.286091799    0.000000000   -0.158594189
+      2        8           0.001308735    0.000000000    0.334980109
+      3        8           0.284783064    0.000000000   -0.176385921
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.334980109 RMS     0.191899107
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1   0.334980(     1)
+      3  O        1   0.334980(     2)      2  -0.003215(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.334980109 RMS     0.273516413
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20 on scan point     4 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Update second derivatives using D2CorN and points    1    2
+ DE= -4.09D-04 DEPred=-3.51D-04 R= 1.17D+00
+ TightC=F SS=  1.41D+00  RLast= 3.52D-02 DXNew= 5.0454D-01 1.0547D-01
+ Trust test= 1.17D+00 RLast= 3.52D-02 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.11756   0.47522
+ ITU=  1  0
+     Eigenvalues ---    0.475221000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 4.75217532D-01
+ Quartic linear search produced a step of  0.18734.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        2.45664   0.66996   0.00000   0.00000   0.00000   2.45664
+   ASO        2.12924  -0.00322  -0.00659   0.00000  -0.00659   2.12266
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.003215     0.000450     NO 
+ RMS     Force            0.003215     0.000300     NO 
+ Maximum Displacement     0.006586     0.001800     NO 
+ RMS     Displacement     0.004657     0.001200     NO 
+ Predicted change in Energy=-1.086827D-05
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   1.300000(     1)
+      3      3  O        1   1.300000(     2)      2  121.619(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    1.300000
+      3          8           0        1.107016    0.000000   -0.681554
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    1.300000   0.000000
+     3  O    1.300000   2.269811   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.317013
+      2          8           0        0.000000    1.134905   -0.317013
+      3          8           0        0.000000   -1.134905   -0.317013
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     78.6214370     12.2655188     10.6102433
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy       119.1279809702 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  2.21D-02  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (B2) (A1) (A1) (B2) (B1) (A1) (A1) (B2) (A1)
+                 (B1) (A1) (B2) (A2) (B2) (A1)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RB3LYP) =  -548.495110923     A.U. after    7 cycles
+            NFock=  7  Conv=0.33D-08     -V/T= 2.0008
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16          -0.285502851    0.000000000   -0.159499092
+      2        8          -0.000000535    0.000000000    0.335275086
+      3        8           0.285503385    0.000000000   -0.175775994
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.335275086 RMS     0.191998439
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1   0.335275(     1)
+      3  O        1   0.335275(     2)      2   0.000001(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.335275086 RMS     0.273750961
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   3 out of a maximum of   20 on scan point     4 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Update second derivatives using D2CorN and points    2    3
+ DE= -1.06D-05 DEPred=-1.09D-05 R= 9.75D-01
+ TightC=F SS=  1.41D+00  RLast= 6.59D-03 DXNew= 5.0454D-01 1.9759D-02
+ Trust test= 9.75D-01 RLast= 6.59D-03 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.10357   0.48835
+ ITU=  1  1  0
+     Eigenvalues ---    0.488351000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 4.88347125D-01
+ Quartic linear search produced a step of -0.00041.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        2.45664   0.67055   0.00000   0.00000   0.00000   2.45664
+   ASO        2.12266   0.00000   0.00000   0.00000   0.00000   2.12266
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000001     0.000450     YES
+ RMS     Force            0.000001     0.000300     YES
+ Maximum Displacement     0.000003     0.001800     YES
+ RMS     Displacement     0.000002     0.001200     YES
+ Predicted change in Energy=-1.766087D-12
+ Optimization completed.
+    -- Stationary point found.
+                       ----------------------------
+                       !   Optimized Parameters   !
+                       ! (Angstroms and Degrees)  !
+ ----------------------                            ----------------------
+ !      Name          Value   Derivative information (Atomic Units)     !
+ ------------------------------------------------------------------------
+ !       DSO         1.3      -DE/DX =    0.6706                        !
+ !       ASO       121.6193   -DE/DX =    0.0                           !
+ ------------------------------------------------------------------------
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   1.400000(     1)
+      3      3  O        1   1.400000(     2)      2  121.619(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    1.400000
+      3          8           0        1.192171    0.000000   -0.733982
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    1.400000   0.000000
+     3  O    1.400000   2.444412   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.341399
+      2          8           0        0.000000    1.222206   -0.341399
+      3          8           0        0.000000   -1.222206   -0.341399
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     67.7909329     10.5758810      9.1486282
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy       110.6188394723 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  2.93D-02  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (B2) (A1) (A1) (B2) (B1) (A1) (A1) (B2) (A1)
+                 (B1) (A1) (B2) (A2) (B2) (A1)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ ExpMin= 1.17D-01 ExpMax= 2.19D+04 ExpMxC= 3.30D+03 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(RB3LYP) =  -548.571284857     A.U. after   12 cycles
+            NFock= 12  Conv=0.33D-08     -V/T= 2.0027
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16          -0.085473445    0.000000000   -0.047750615
+      2        8           0.004712322    0.000000000    0.091938860
+      3        8           0.080761123    0.000000000   -0.044188245
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.091938860 RMS     0.054299326
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1   0.091939(     1)
+      3  O        1   0.091939(     2)      2  -0.012467(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.091938860 RMS     0.075412055
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20 on scan point     5 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.10357   0.48835
+ ITU=  0
+     Eigenvalues ---    0.488351000.00000
+ RFO step:  Lambda=-3.18062218D-04 EMin= 4.88347125D-01
+ Linear search not attempted -- first point.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        2.64562   0.18388   0.00000   0.00000   0.00000   2.64562
+   ASO        2.12266  -0.01247   0.00000  -0.02551  -0.02551   2.09714
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.012467     0.000450     NO 
+ RMS     Force            0.012467     0.000300     NO 
+ Maximum Displacement     0.025512     0.001800     NO 
+ RMS     Displacement     0.018040     0.001200     NO 
+ Predicted change in Energy=-1.591347D-04
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   1.400000(     1)
+      3      3  O        1   1.400000(     2)      2  120.158(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    1.400000
+      3          8           0        1.210506    0.000000   -0.703331
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    1.400000   0.000000
+     3  O    1.400000   2.426794   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.349166
+      2          8           0        0.000000    1.213397   -0.349166
+      3          8           0        0.000000   -1.213397   -0.349166
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     64.8084050     10.7299972      9.2058342
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy       110.7194248643 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  2.91D-02  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (B2) (A1) (A1) (B2) (B1) (A1) (A1) (B2) (A1)
+                 (B1) (A1) (B2) (A2) (B2) (A1)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ ExpMin= 1.17D-01 ExpMax= 2.19D+04 ExpMxC= 3.30D+03 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(RB3LYP) =  -548.571471122     A.U. after   10 cycles
+            NFock= 10  Conv=0.32D-08     -V/T= 2.0027
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16          -0.081222812    0.000000000   -0.046745246
+      2        8           0.000788537    0.000000000    0.092567369
+      3        8           0.080434275    0.000000000   -0.045822122
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.092567369 RMS     0.053666607
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1   0.092567(     1)
+      3  O        1   0.092567(     2)      2  -0.002086(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.092567369 RMS     0.075590536
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20 on scan point     5 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Update second derivatives using D2CorN and points    1    2
+ DE= -1.86D-04 DEPred=-1.59D-04 R= 1.17D+00
+ TightC=F SS=  1.41D+00  RLast= 2.55D-02 DXNew= 5.0454D-01 7.6537D-02
+ Trust test= 1.17D+00 RLast= 2.55D-02 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.07642   0.40689
+ ITU=  1  0
+     Eigenvalues ---    0.406891000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 4.06894340D-01
+ Quartic linear search produced a step of  0.19762.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        2.64562   0.18513   0.00000   0.00000   0.00000   2.64562
+   ASO        2.09714  -0.00209  -0.00504   0.00000  -0.00504   2.09210
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.002086     0.000450     NO 
+ RMS     Force            0.002086     0.000300     NO 
+ Maximum Displacement     0.005042     0.001800     NO 
+ RMS     Displacement     0.003565     0.001200     NO 
+ Predicted change in Energy=-5.346452D-06
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   1.400000(     1)
+      3      3  O        1   1.400000(     2)      2  119.869(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    1.400000
+      3          8           0        1.214037    0.000000   -0.697219
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    1.400000   0.000000
+     3  O    1.400000   2.423265   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.350695
+      2          8           0        0.000000    1.211633   -0.350695
+      3          8           0        0.000000   -1.211633   -0.350695
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     64.2447896     10.7612672      9.2173269
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy       110.7397451526 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  2.91D-02  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (B2) (A1) (A1) (B2) (B1) (A1) (A1) (B2) (A1)
+                 (B1) (A1) (B2) (A2) (B2) (A1)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RB3LYP) =  -548.571476386     A.U. after    7 cycles
+            NFock=  7  Conv=0.39D-08     -V/T= 2.0027
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16          -0.080393581    0.000000000   -0.046538183
+      2        8          -0.000000172    0.000000000    0.092708369
+      3        8           0.080393753    0.000000000   -0.046170186
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.092708369 RMS     0.053560572
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1   0.092708(     1)
+      3  O        1   0.092708(     2)      2   0.000000(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.092708369 RMS     0.075696066
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   3 out of a maximum of   20 on scan point     5 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Update second derivatives using D2CorN and points    2    3
+ DE= -5.26D-06 DEPred=-5.35D-06 R= 9.84D-01
+ TightC=F SS=  1.41D+00  RLast= 5.04D-03 DXNew= 5.0454D-01 1.5125D-02
+ Trust test= 9.84D-01 RLast= 5.04D-03 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.06618   0.41388
+ ITU=  1  1  0
+     Eigenvalues ---    0.413881000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 4.13878661D-01
+ Quartic linear search produced a step of -0.00022.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        2.64562   0.18542   0.00000   0.00000   0.00000   2.64562
+   ASO        2.09210   0.00000   0.00000   0.00000   0.00000   2.09210
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000000     0.000450     YES
+ RMS     Force            0.000000     0.000300     YES
+ Maximum Displacement     0.000001     0.001800     YES
+ RMS     Displacement     0.000001     0.001200     YES
+ Predicted change in Energy=-2.502182D-13
+ Optimization completed.
+    -- Stationary point found.
+                       ----------------------------
+                       !   Optimized Parameters   !
+                       ! (Angstroms and Degrees)  !
+ ----------------------                            ----------------------
+ !      Name          Value   Derivative information (Atomic Units)     !
+ ------------------------------------------------------------------------
+ !       DSO         1.4      -DE/DX =    0.1854                        !
+ !       ASO       119.8687   -DE/DX =    0.0                           !
+ ------------------------------------------------------------------------
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   1.500000(     1)
+      3      3  O        1   1.500000(     2)      2  119.869(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    1.500000
+      3          8           0        1.300754    0.000000   -0.747021
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    1.500000   0.000000
+     3  O    1.500000   2.596355   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.375744
+      2          8           0        0.000000    1.298178   -0.375744
+      3          8           0        0.000000   -1.298178   -0.375744
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     55.9643500      9.3742594      8.0293159
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy       103.3570954757 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  3.78D-02  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (B2) (A1) (A1) (B2) (B1) (A1) (A1) (B2) (A1)
+                 (B1) (A1) (B2) (A2) (B2) (A1)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ ExpMin= 1.17D-01 ExpMax= 2.19D+04 ExpMxC= 3.30D+03 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(RB3LYP) =  -548.579071235     A.U. after   12 cycles
+            NFock= 12  Conv=0.60D-08     -V/T= 2.0039
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.029223049    0.000000000    0.016916619
+      2        8           0.002796128    0.000000000   -0.038529607
+      3        8          -0.032019177    0.000000000    0.021612988
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.038529607 RMS     0.021408349
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.038530(     1)
+      3  O        1  -0.038530(     2)      2  -0.007926(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.038529607 RMS     0.031790359
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20 on scan point     6 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.06618   0.41388
+ ITU=  0
+     Eigenvalues ---    0.413881000.00000
+ RFO step:  Lambda=-1.51726745D-04 EMin= 4.13878661D-01
+ Linear search not attempted -- first point.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        2.83459  -0.07706   0.00000   0.00000   0.00000   2.83459
+   ASO        2.09210  -0.00793   0.00000  -0.01914  -0.01914   2.07296
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.007926     0.000450     NO 
+ RMS     Force            0.007926     0.000300     NO 
+ Maximum Displacement     0.019143     0.001800     NO 
+ RMS     Displacement     0.013536     0.001200     NO 
+ Predicted change in Energy=-7.589118D-05
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   1.500000(     1)
+      3      3  O        1   1.500000(     2)      2  118.772(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    1.500000
+      3          8           0        1.314815    0.000000   -0.721985
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    1.500000   0.000000
+     3  O    1.500000   2.581851   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.381940
+      2          8           0        0.000000    1.290925   -0.381940
+      3          8           0        0.000000   -1.290925   -0.381940
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     54.1634582      9.4798829      8.0678234
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy       103.4303765963 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  3.75D-02  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (B1) (A1) (A1) (B2) (A1)
+                 (B2) (B1) (A1) (A2) (B2) (A1)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RB3LYP) =  -548.579160267     A.U. after    8 cycles
+            NFock=  8  Conv=0.17D-08     -V/T= 2.0039
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.032772540    0.000000000    0.019392495
+      2        8           0.000478600    0.000000000   -0.038197201
+      3        8          -0.033251139    0.000000000    0.018804707
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.038197201 RMS     0.022031842
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.038197(     1)
+      3  O        1  -0.038197(     2)      2  -0.001357(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.038197201 RMS     0.031197718
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20 on scan point     6 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Update second derivatives using D2CorN and points    1    2
+ DE= -8.90D-05 DEPred=-7.59D-05 R= 1.17D+00
+ TightC=F SS=  1.41D+00  RLast= 1.91D-02 DXNew= 5.0454D-01 5.7430D-02
+ Trust test= 1.17D+00 RLast= 1.91D-02 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.05045   0.34316
+ ITU=  1  0
+     Eigenvalues ---    0.343161000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 3.43162835D-01
+ Quartic linear search produced a step of  0.20435.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        2.83459  -0.07639   0.00000   0.00000   0.00000   2.83459
+   ASO        2.07296  -0.00136  -0.00391   0.00000  -0.00391   2.06905
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.001357     0.000450     NO 
+ RMS     Force            0.001357     0.000300     NO 
+ Maximum Displacement     0.003912     0.001800     NO 
+ RMS     Displacement     0.002766     0.001200     NO 
+ Predicted change in Energy=-2.681309D-06
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   1.500000(     1)
+      3      3  O        1   1.500000(     2)      2  118.548(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    1.500000
+      3          8           0        1.317629    0.000000   -0.716836
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    1.500000   0.000000
+     3  O    1.500000   2.578858   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.383201
+      2          8           0        0.000000    1.289429   -0.383201
+      3          8           0        0.000000   -1.289429   -0.383201
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     53.8073595      9.5019013      8.0757888
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy       103.4456013904 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  3.74D-02  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (B1) (A1) (A1) (B2) (A1)
+                 (B2) (B1) (A1) (A2) (B2) (A1)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RB3LYP) =  -548.579162922     A.U. after    7 cycles
+            NFock=  7  Conv=0.56D-08     -V/T= 2.0039
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.033486270    0.000000000    0.019903364
+      2        8          -0.000000033    0.000000000   -0.038120992
+      3        8          -0.033486237    0.000000000    0.018217628
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.038120992 RMS     0.022170787
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.038121(     1)
+      3  O        1  -0.038121(     2)      2   0.000000(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.038120992 RMS     0.031125660
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   3 out of a maximum of   20 on scan point     6 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Update second derivatives using D2CorN and points    2    3
+ DE= -2.65D-06 DEPred=-2.68D-06 R= 9.90D-01
+ TightC=F SS=  1.41D+00  RLast= 3.91D-03 DXNew= 5.0454D-01 1.1736D-02
+ Trust test= 9.90D-01 RLast= 3.91D-03 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.04471   0.34682
+ ITU=  1  1  0
+     Eigenvalues ---    0.346821000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 3.46820764D-01
+ Quartic linear search produced a step of -0.00007.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        2.83459  -0.07624   0.00000   0.00000   0.00000   2.83459
+   ASO        2.06905   0.00000   0.00000   0.00000   0.00000   2.06905
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000000     0.000450     YES
+ RMS     Force            0.000000     0.000300     YES
+ Maximum Displacement     0.000000     0.001800     YES
+ RMS     Displacement     0.000000     0.001200     YES
+ Predicted change in Energy=-1.255078D-14
+ Optimization completed.
+    -- Stationary point found.
+                       ----------------------------
+                       !   Optimized Parameters   !
+                       ! (Angstroms and Degrees)  !
+ ----------------------                            ----------------------
+ !      Name          Value   Derivative information (Atomic Units)     !
+ ------------------------------------------------------------------------
+ !       DSO         1.5      -DE/DX =   -0.0762                        !
+ !       ASO       118.5477   -DE/DX =    0.0                           !
+ ------------------------------------------------------------------------
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   1.600000(     1)
+      3      3  O        1   1.600000(     2)      2  118.548(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    1.600000
+      3          8           0        1.405471    0.000000   -0.764625
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    1.600000   0.000000
+     3  O    1.600000   2.750782   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.408748
+      2          8           0        0.000000    1.375391   -0.408748
+      3          8           0        0.000000   -1.375391   -0.408748
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     47.2916245      8.3512804      7.0978612
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        96.9802513035 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  4.73D-02  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (B1) (A1) (A1) (B2) (A1)
+                 (B2) (B1) (A1) (A2) (B2) (A1)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ ExpMin= 1.17D-01 ExpMax= 2.19D+04 ExpMxC= 3.30D+03 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(RB3LYP) =  -548.550602086     A.U. after   12 cycles
+            NFock= 12  Conv=0.91D-08     -V/T= 2.0045
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.089248588    0.000000000    0.053047029
+      2        8           0.001964726    0.000000000   -0.104906873
+      3        8          -0.091213314    0.000000000    0.051859844
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.104906873 RMS     0.060367322
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.104907(     1)
+      3  O        1  -0.104907(     2)      2  -0.005940(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.104906873 RMS     0.085724740
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20 on scan point     7 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.04471   0.34682
+ ITU=  0
+     Eigenvalues ---    0.346821000.00000
+ RFO step:  Lambda=-1.01720692D-04 EMin= 3.46820764D-01
+ Linear search not attempted -- first point.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        3.02356  -0.20981   0.00000   0.00000   0.00000   3.02356
+   ASO        2.06905  -0.00594   0.00000  -0.01712  -0.01712   2.05192
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.005940     0.000450     NO 
+ RMS     Force            0.005940     0.000300     NO 
+ Maximum Displacement     0.017123     0.001800     NO 
+ RMS     Displacement     0.012108     0.001200     NO 
+ Predicted change in Energy=-5.087526D-05
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   1.600000(     1)
+      3      3  O        1   1.600000(     2)      2  117.567(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    1.600000
+      3          8           0        1.418357    0.000000   -0.740447
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    1.600000   0.000000
+     3  O    1.600000   2.736683   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.414621
+      2          8           0        0.000000    1.368341   -0.414621
+      3          8           0        0.000000   -1.368341   -0.414621
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     45.9614177      8.4375508      7.1288447
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        97.0436800660 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  4.69D-02  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (B1) (A1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A2) (B2) (A1)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RB3LYP) =  -548.550662143     A.U. after    8 cycles
+            NFock=  8  Conv=0.56D-08     -V/T= 2.0045
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.092277602    0.000000000    0.055922050
+      2        8           0.000351469    0.000000000   -0.104675141
+      3        8          -0.092629071    0.000000000    0.048753091
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.104675141 RMS     0.061061398
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.104675(     1)
+      3  O        1  -0.104675(     2)      2  -0.001063(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.104675141 RMS     0.085469097
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20 on scan point     7 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Update second derivatives using D2CorN and points    1    2
+ DE= -6.01D-05 DEPred=-5.09D-05 R= 1.18D+00
+ TightC=F SS=  1.41D+00  RLast= 1.71D-02 DXNew= 5.0454D-01 5.1370D-02
+ Trust test= 1.18D+00 RLast= 1.71D-02 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.03589   0.28486
+ ITU=  1  0
+     Eigenvalues ---    0.284861000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 2.84861619D-01
+ Quartic linear search produced a step of  0.21601.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        3.02356  -0.20935   0.00000   0.00000   0.00000   3.02356
+   ASO        2.05192  -0.00106  -0.00370   0.00000  -0.00370   2.04823
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.001063     0.000450     NO 
+ RMS     Force            0.001063     0.000300     NO 
+ Maximum Displacement     0.003699     0.001800     NO 
+ RMS     Displacement     0.002615     0.001200     NO 
+ Predicted change in Energy=-1.982062D-06
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   1.600000(     1)
+      3      3  O        1   1.600000(     2)      2  117.355(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    1.600000
+      3          8           0        1.421086    0.000000   -0.735196
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    1.600000   0.000000
+     3  O    1.600000   2.733611   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.415886
+      2          8           0        0.000000    1.366805   -0.415886
+      3          8           0        0.000000   -1.366805   -0.415886
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     45.6823298      8.4565248      7.1356100
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        97.0575867839 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  4.68D-02  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (B1) (A1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A2) (B2) (A1)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RB3LYP) =  -548.550664109     A.U. after    8 cycles
+            NFock=  8  Conv=0.12D-08     -V/T= 2.0045
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.092920486    0.000000000    0.056546875
+      2        8          -0.000000027    0.000000000   -0.104619052
+      3        8          -0.092920460    0.000000000    0.048072178
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.104619052 RMS     0.061211889
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.104619(     1)
+      3  O        1  -0.104619(     2)      2   0.000000(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.104619052 RMS     0.085421098
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   3 out of a maximum of   20 on scan point     7 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Update second derivatives using D2CorN and points    2    3
+ DE= -1.97D-06 DEPred=-1.98D-06 R= 9.92D-01
+ TightC=F SS=  1.41D+00  RLast= 3.70D-03 DXNew= 5.0454D-01 1.1096D-02
+ Trust test= 9.92D-01 RLast= 3.70D-03 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.03311   0.28733
+ ITU=  1  1  0
+     Eigenvalues ---    0.287331000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 2.87327784D-01
+ Quartic linear search produced a step of -0.00008.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        3.02356  -0.20924   0.00000   0.00000   0.00000   3.02356
+   ASO        2.04823   0.00000   0.00000   0.00000   0.00000   2.04823
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000000     0.000450     YES
+ RMS     Force            0.000000     0.000300     YES
+ Maximum Displacement     0.000000     0.001800     YES
+ RMS     Displacement     0.000000     0.001200     YES
+ Predicted change in Energy=-1.124238D-14
+ Optimization completed.
+    -- Stationary point found.
+                       ----------------------------
+                       !   Optimized Parameters   !
+                       ! (Angstroms and Degrees)  !
+ ----------------------                            ----------------------
+ !      Name          Value   Derivative information (Atomic Units)     !
+ ------------------------------------------------------------------------
+ !       DSO         1.6      -DE/DX =   -0.2092                        !
+ !       ASO       117.3547   -DE/DX =    0.0                           !
+ ------------------------------------------------------------------------
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   1.700000(     1)
+      3      3  O        1   1.700000(     2)      2  117.355(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    1.700000
+      3          8           0        1.509904    0.000000   -0.781146
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    1.700000   0.000000
+     3  O    1.700000   2.904461   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.441878
+      2          8           0        0.000000    1.452231   -0.441878
+      3          8           0        0.000000   -1.452231   -0.441878
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     40.4660084      7.4909008      6.3208172
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        91.3483169731 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  5.76D-02  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (B1) (A1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A2) (B2) (A1)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ ExpMin= 1.17D-01 ExpMax= 2.19D+04 ExpMxC= 3.30D+03 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(RB3LYP) =  -548.504618145     A.U. after   13 cycles
+            NFock= 13  Conv=0.28D-08     -V/T= 2.0048
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.117236191    0.000000000    0.071344226
+      2        8           0.001608183    0.000000000   -0.134638770
+      3        8          -0.118844375    0.000000000    0.063294543
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.134638770 RMS     0.078240862
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.134639(     1)
+      3  O        1  -0.134639(     2)      2  -0.005166(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.134638770 RMS     0.109972554
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20 on scan point     8 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.03311   0.28733
+ ITU=  0
+     Eigenvalues ---    0.287331000.00000
+ RFO step:  Lambda=-9.28642464D-05 EMin= 2.87327784D-01
+ Linear search not attempted -- first point.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        3.21253  -0.26928   0.00000   0.00000   0.00000   3.21253
+   ASO        2.04823  -0.00517   0.00000  -0.01797  -0.01797   2.03025
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.005166     0.000450     NO 
+ RMS     Force            0.005166     0.000300     NO 
+ Maximum Displacement     0.017975     0.001800     NO 
+ RMS     Displacement     0.012710     0.001200     NO 
+ Predicted change in Energy=-4.644713D-05
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   1.700000(     1)
+      3      3  O        1   1.700000(     2)      2  116.325(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    1.700000
+      3          8           0        1.523701    0.000000   -0.753881
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    1.700000   0.000000
+     3  O    1.700000   2.888459   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.448386
+      2          8           0        0.000000    1.444229   -0.448386
+      3          8           0        0.000000   -1.444229   -0.448386
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     39.2998687      7.5741321      6.3502665
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        91.4129175954 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  5.70D-02  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (B1) (A1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A2) (B2) (A1)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RB3LYP) =  -548.504673061     A.U. after    9 cycles
+            NFock=  9  Conv=0.19D-08     -V/T= 2.0048
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.120040020    0.000000000    0.074537056
+      2        8           0.000290881    0.000000000   -0.134397673
+      3        8          -0.120330901    0.000000000    0.059860617
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.134397673 RMS     0.078945141
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.134398(     1)
+      3  O        1  -0.134398(     2)      2  -0.000934(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.134397673 RMS     0.109736567
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20 on scan point     8 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Update second derivatives using D2CorN and points    1    2
+ DE= -5.49D-05 DEPred=-4.64D-05 R= 1.18D+00
+ TightC=F SS=  1.41D+00  RLast= 1.80D-02 DXNew= 5.0454D-01 5.3925D-02
+ Trust test= 1.18D+00 RLast= 1.80D-02 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.02997   0.23543
+ ITU=  1  0
+     Eigenvalues ---    0.235431000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 2.35433221D-01
+ Quartic linear search produced a step of  0.21900.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        3.21253  -0.26880   0.00000   0.00000   0.00000   3.21253
+   ASO        2.03025  -0.00093  -0.00394   0.00000  -0.00394   2.02631
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000934     0.000450     NO 
+ RMS     Force            0.000934     0.000300     NO 
+ Maximum Displacement     0.003937     0.001800     NO 
+ RMS     Displacement     0.002784     0.001200     NO 
+ Predicted change in Energy=-1.854386D-06
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   1.700000(     1)
+      3      3  O        1   1.700000(     2)      2  116.099(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    1.700000
+      3          8           0        1.526657    0.000000   -0.747877
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    1.700000   0.000000
+     3  O    1.700000   2.884923   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.449807
+      2          8           0        0.000000    1.442462   -0.449807
+      3          8           0        0.000000   -1.442462   -0.449807
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     39.0520512      7.5927092      6.3567883
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        91.4272878099 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  5.68D-02  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (B1) (A1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A2) (B2) (A1)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RB3LYP) =  -548.504674901     A.U. after    8 cycles
+            NFock=  8  Conv=0.22D-08     -V/T= 2.0048
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.120641117    0.000000000    0.075239708
+      2        8          -0.000000010    0.000000000   -0.134339241
+      3        8          -0.120641108    0.000000000    0.059099533
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.134339241 RMS     0.079098642
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.134339(     1)
+      3  O        1  -0.134339(     2)      2   0.000000(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.134339241 RMS     0.109687531
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   3 out of a maximum of   20 on scan point     8 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Update second derivatives using D2CorN and points    2    3
+ DE= -1.84D-06 DEPred=-1.85D-06 R= 9.92D-01
+ TightC=F SS=  1.41D+00  RLast= 3.94D-03 DXNew= 5.0454D-01 1.1810D-02
+ Trust test= 9.92D-01 RLast= 3.94D-03 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.02983   0.23739
+ ITU=  1  1  0
+     Eigenvalues ---    0.237391000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 2.37391544D-01
+ Quartic linear search produced a step of -0.00003.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        3.21253  -0.26868   0.00000   0.00000   0.00000   3.21253
+   ASO        2.02631   0.00000   0.00000   0.00000   0.00000   2.02631
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000000     0.000450     YES
+ RMS     Force            0.000000     0.000300     YES
+ Maximum Displacement     0.000000     0.001800     YES
+ RMS     Displacement     0.000000     0.001200     YES
+ Predicted change in Energy=-2.000543D-15
+ Optimization completed.
+    -- Stationary point found.
+                       ----------------------------
+                       !   Optimized Parameters   !
+                       ! (Angstroms and Degrees)  !
+ ----------------------                            ----------------------
+ !      Name          Value   Derivative information (Atomic Units)     !
+ ------------------------------------------------------------------------
+ !       DSO         1.7      -DE/DX =   -0.2687                        !
+ !       ASO       116.0993   -DE/DX =    0.0                           !
+ ------------------------------------------------------------------------
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   1.800000(     1)
+      3      3  O        1   1.800000(     2)      2  116.099(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    1.800000
+      3          8           0        1.616460    0.000000   -0.791870
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    1.800000   0.000000
+     3  O    1.800000   3.054625   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.476266
+      2          8           0        0.000000    1.527312   -0.476266
+      3          8           0        0.000000   -1.527312   -0.476266
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     34.8334654      6.7725091      5.6700982
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        86.3479940426 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  6.84D-02  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (B1) (A1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A2) (B2) (A1)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ ExpMin= 1.17D-01 ExpMax= 2.19D+04 ExpMxC= 3.30D+03 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(RB3LYP) =  -548.451613491     A.U. after   13 cycles
+            NFock= 13  Conv=0.33D-08     -V/T= 2.0050
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.127142453    0.000000000    0.079294367
+      2        8           0.001435860    0.000000000   -0.143881075
+      3        8          -0.128578313    0.000000000    0.064586708
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.143881075 RMS     0.084235418
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.143881(     1)
+      3  O        1  -0.143881(     2)      2  -0.004884(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.143881075 RMS     0.117512243
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20 on scan point     9 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.02983   0.23739
+ ITU=  0
+     Eigenvalues ---    0.237391000.00000
+ RFO step:  Lambda=-1.00442603D-04 EMin= 2.37391544D-01
+ Linear search not attempted -- first point.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        3.40151  -0.28776   0.00000   0.00000   0.00000   3.40151
+   ASO        2.02631  -0.00488   0.00000  -0.02057  -0.02057   2.00575
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.004884     0.000450     NO 
+ RMS     Force            0.004884     0.000300     NO 
+ Maximum Displacement     0.020565     0.001800     NO 
+ RMS     Displacement     0.014542     0.001200     NO 
+ Predicted change in Energy=-5.024255D-05
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   1.800000(     1)
+      3      3  O        1   1.800000(     2)      2  114.921(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    1.800000
+      3          8           0        1.632402    0.000000   -0.758462
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    1.800000   0.000000
+     3  O    1.800000   3.034874   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.484093
+      2          8           0        0.000000    1.517437   -0.484093
+      3          8           0        0.000000   -1.517437   -0.484093
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     33.7161585      6.8609436      5.7008670
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        86.4201470756 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  6.74D-02  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (B1) (A1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (B2) (A1) (A2)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ ExpMin= 1.17D-01 ExpMax= 2.19D+04 ExpMxC= 3.30D+03 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(RB3LYP) =  -548.451672941     A.U. after   12 cycles
+            NFock= 12  Conv=0.27D-08     -V/T= 2.0050
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.129882196    0.000000000    0.082870088
+      2        8           0.000261092    0.000000000   -0.143626364
+      3        8          -0.130143288    0.000000000    0.060756276
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.143626364 RMS     0.084979761
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.143626(     1)
+      3  O        1  -0.143626(     2)      2  -0.000888(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.143626364 RMS     0.117271556
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20 on scan point     9 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Update second derivatives using D2CorN and points    1    2
+ DE= -5.94D-05 DEPred=-5.02D-05 R= 1.18D+00
+ TightC=F SS=  1.41D+00  RLast= 2.06D-02 DXNew= 5.0454D-01 6.1696D-02
+ Trust test= 1.18D+00 RLast= 2.06D-02 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.02730   0.19431
+ ITU=  1  0
+     Eigenvalues ---    0.194311000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 1.94307269D-01
+ Quartic linear search produced a step of  0.22035.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        3.40151  -0.28725   0.00000   0.00000   0.00000   3.40151
+   ASO        2.00575  -0.00089  -0.00453   0.00000  -0.00453   2.00122
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000888     0.000450     NO 
+ RMS     Force            0.000888     0.000300     NO 
+ Maximum Displacement     0.004532     0.001800     NO 
+ RMS     Displacement     0.003204     0.001200     NO 
+ Predicted change in Energy=-2.029451D-06
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   1.800000(     1)
+      3      3  O        1   1.800000(     2)      2  114.661(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    1.800000
+      3          8           0        1.635822    0.000000   -0.751057
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    1.800000   0.000000
+     3  O    1.800000   3.030479   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.485811
+      2          8           0        0.000000    1.515240   -0.485811
+      3          8           0        0.000000   -1.515240   -0.485811
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     33.4781351      6.8808594      5.7077324
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        86.4363319446 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  6.72D-02  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (B1) (A1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A1) (B2) (A2)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RB3LYP) =  -548.451674954     A.U. after    8 cycles
+            NFock=  8  Conv=0.39D-08     -V/T= 2.0050
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.130469684    0.000000000    0.083661494
+      2        8           0.000000001    0.000000000   -0.143564160
+      3        8          -0.130469685    0.000000000    0.059902666
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.143564160 RMS     0.085142312
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.143564(     1)
+      3  O        1  -0.143564(     2)      2   0.000000(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.143564160 RMS     0.117219646
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   3 out of a maximum of   20 on scan point     9 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Update second derivatives using D2CorN and points    2    3
+ DE= -2.01D-06 DEPred=-2.03D-06 R= 9.92D-01
+ TightC=F SS=  1.41D+00  RLast= 4.53D-03 DXNew= 5.0454D-01 1.3595D-02
+ Trust test= 9.92D-01 RLast= 4.53D-03 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.02738   0.19598
+ ITU=  1  1  0
+     Eigenvalues ---    0.195981000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 1.95980002D-01
+ Quartic linear search produced a step of  0.00000.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        3.40151  -0.28713   0.00000   0.00000   0.00000   3.40151
+   ASO        2.00122   0.00000   0.00000   0.00000   0.00000   2.00122
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000000     0.000450     YES
+ RMS     Force            0.000000     0.000300     YES
+ Maximum Displacement     0.000000     0.001800     YES
+ RMS     Displacement     0.000000     0.001200     YES
+ Predicted change in Energy=-3.238783D-17
+ Optimization completed.
+    -- Stationary point found.
+                       ----------------------------
+                       !   Optimized Parameters   !
+                       ! (Angstroms and Degrees)  !
+ ----------------------                            ----------------------
+ !      Name          Value   Derivative information (Atomic Units)     !
+ ------------------------------------------------------------------------
+ !       DSO         1.8      -DE/DX =   -0.2871                        !
+ !       ASO       114.6613   -DE/DX =    0.0                           !
+ ------------------------------------------------------------------------
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   1.900000(     1)
+      3      3  O        1   1.900000(     2)      2  114.661(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    1.900000
+      3          8           0        1.726701    0.000000   -0.792782
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    1.900000   0.000000
+     3  O    1.900000   3.198839   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.512800
+      2          8           0        0.000000    1.599420   -0.512800
+      3          8           0        0.000000   -1.599420   -0.512800
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     30.0468581      6.1756190      5.1227294
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        81.8870513159 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  7.91D-02  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (B1) (A1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A1) (B2) (A2)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ ExpMin= 1.17D-01 ExpMax= 2.19D+04 ExpMxC= 3.30D+03 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(RB3LYP) =  -548.397472707     A.U. after   13 cycles
+            NFock= 13  Conv=0.23D-08     -V/T= 2.0050
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.127142541    0.000000000    0.081528019
+      2        8           0.001338355    0.000000000   -0.141990247
+      3        8          -0.128480895    0.000000000    0.060462228
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.141990247 RMS     0.083757644
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.141990(     1)
+      3  O        1  -0.141990(     2)      2  -0.004805(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.141990247 RMS     0.115967742
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20 on scan point    10 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.02738   0.19598
+ ITU=  0
+     Eigenvalues ---    0.195981000.00000
+ RFO step:  Lambda=-1.17753695D-04 EMin= 1.95980002D-01
+ Linear search not attempted -- first point.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        3.59048  -0.28398   0.00000   0.00000   0.00000   3.59048
+   ASO        2.00122  -0.00481   0.00000  -0.02450  -0.02450   1.97671
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.004805     0.000450     NO 
+ RMS     Force            0.004805     0.000300     NO 
+ Maximum Displacement     0.024505     0.001800     NO 
+ RMS     Displacement     0.017328     0.001200     NO 
+ Predicted change in Energy=-5.891222D-05
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   1.900000(     1)
+      3      3  O        1   1.900000(     2)      2  113.257(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    1.900000
+      3          8           0        1.745608    0.000000   -0.750236
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    1.900000   0.000000
+     3  O    1.900000   3.173467   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.522560
+      2          8           0        0.000000    1.586734   -0.522560
+      3          8           0        0.000000   -1.586734   -0.522560
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     28.9349949      6.2747609      5.1565303
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        81.9716965972 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  7.78D-02  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (B1) (A1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A1) (B2) (A2)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ ExpMin= 1.17D-01 ExpMax= 2.19D+04 ExpMxC= 3.30D+03 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ EnCoef did     2 forward-backward iterations
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(RB3LYP) =  -548.397541634     A.U. after   12 cycles
+            NFock= 12  Conv=0.19D-08     -V/T= 2.0050
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.129861861    0.000000000    0.085534988
+      2        8           0.000225310    0.000000000   -0.141689712
+      3        8          -0.130087171    0.000000000    0.056154724
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.141689712 RMS     0.084546100
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.141690(     1)
+      3  O        1  -0.141690(     2)      2  -0.000809(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.141689712 RMS     0.115690108
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20 on scan point    10 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Update second derivatives using D2CorN and points    1    2
+ DE= -6.89D-05 DEPred=-5.89D-05 R= 1.17D+00
+ TightC=F SS=  1.41D+00  RLast= 2.45D-02 DXNew= 5.0454D-01 7.3514D-02
+ Trust test= 1.17D+00 RLast= 2.45D-02 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.02595   0.16308
+ ITU=  1  0
+     Eigenvalues ---    0.163081000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 1.63084927D-01
+ Quartic linear search produced a step of  0.20038.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        3.59048  -0.28338   0.00000   0.00000   0.00000   3.59048
+   ASO        1.97671  -0.00081  -0.00491   0.00000  -0.00491   1.97180
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000809     0.000450     NO 
+ RMS     Force            0.000809     0.000300     NO 
+ Maximum Displacement     0.004910     0.001800     NO 
+ RMS     Displacement     0.003472     0.001200     NO 
+ Predicted change in Energy=-2.006223D-06
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   1.900000(     1)
+      3      3  O        1   1.900000(     2)      2  112.976(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    1.900000
+      3          8           0        1.749271    0.000000   -0.741655
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    1.900000   0.000000
+     3  O    1.900000   3.168326   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.524506
+      2          8           0        0.000000    1.584163   -0.524506
+      3          8           0        0.000000   -1.584163   -0.524506
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     28.7206630      6.2951417      5.1634011
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        81.9890142839 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  7.76D-02  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (B1) (A1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A1) (B2) (A2)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RB3LYP) =  -548.397543622     A.U. after    8 cycles
+            NFock=  8  Conv=0.59D-08     -V/T= 2.0050
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.130388593    0.000000000    0.086341665
+      2        8           0.000000021    0.000000000   -0.141623827
+      3        8          -0.130388615    0.000000000    0.055282162
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.141623827 RMS     0.084702541
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.141624(     1)
+      3  O        1  -0.141624(     2)      2   0.000000(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.141623827 RMS     0.115635370
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   3 out of a maximum of   20 on scan point    10 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Update second derivatives using D2CorN and points    2    3
+ DE= -1.99D-06 DEPred=-2.01D-06 R= 9.91D-01
+ TightC=F SS=  1.41D+00  RLast= 4.91D-03 DXNew= 5.0454D-01 1.4731D-02
+ Trust test= 9.91D-01 RLast= 4.91D-03 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.02639   0.16474
+ ITU=  1  1  0
+     Eigenvalues ---    0.164741000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 1.64738324D-01
+ Quartic linear search produced a step of  0.00009.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        3.59048  -0.28325   0.00000   0.00000   0.00000   3.59048
+   ASO        1.97180   0.00000   0.00000   0.00000   0.00000   1.97180
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000000     0.000450     YES
+ RMS     Force            0.000000     0.000300     YES
+ Maximum Displacement     0.000000     0.001800     YES
+ RMS     Displacement     0.000000     0.001200     YES
+ Predicted change in Energy=-1.759378D-14
+ Optimization completed.
+    -- Stationary point found.
+                       ----------------------------
+                       !   Optimized Parameters   !
+                       ! (Angstroms and Degrees)  !
+ ----------------------                            ----------------------
+ !      Name          Value   Derivative information (Atomic Units)     !
+ ------------------------------------------------------------------------
+ !       DSO         1.9      -DE/DX =   -0.2832                        !
+ !       ASO       112.976    -DE/DX =    0.0                           !
+ ------------------------------------------------------------------------
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   2.000000(     1)
+      3      3  O        1   2.000000(     2)      2  112.976(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    2.000000
+      3          8           0        1.841337    0.000000   -0.780690
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    2.000000   0.000000
+     3  O    2.000000   3.335080   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.552112
+      2          8           0        0.000000    1.667540   -0.552112
+      3          8           0        0.000000   -1.667540   -0.552112
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     25.9203983      5.6813654      4.6599695
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        77.8895635697 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  8.97D-02  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (B1) (A1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A1) (B2) (A2)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ ExpMin= 1.17D-01 ExpMax= 2.19D+04 ExpMxC= 3.30D+03 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(RB3LYP) =  -548.345237691     A.U. after   13 cycles
+            NFock= 13  Conv=0.64D-08     -V/T= 2.0050
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.122215368    0.000000000    0.080929459
+      2        8           0.001179681    0.000000000   -0.134527798
+      3        8          -0.123395049    0.000000000    0.053598339
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.134527798 RMS     0.080058599
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.134528(     1)
+      3  O        1  -0.134528(     2)      2  -0.004459(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.134527798 RMS     0.109871645
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20 on scan point    11 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.02639   0.16474
+ ITU=  0
+     Eigenvalues ---    0.164741000.00000
+ RFO step:  Lambda=-1.20579615D-04 EMin= 1.64738324D-01
+ Linear search not attempted -- first point.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        3.77945  -0.26906   0.00000   0.00000   0.00000   3.77945
+   ASO        1.97180  -0.00446   0.00000  -0.02704  -0.02704   1.94476
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.004459     0.000450     NO 
+ RMS     Force            0.004459     0.000300     NO 
+ Maximum Displacement     0.027045     0.001800     NO 
+ RMS     Displacement     0.019123     0.001200     NO 
+ Predicted change in Energy=-6.033394D-05
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   2.000000(     1)
+      3      3  O        1   2.000000(     2)      2  111.426(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    2.000000
+      3          8           0        1.861775    0.000000   -0.730612
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    2.000000   0.000000
+     3  O    2.000000   3.304913   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.563336
+      2          8           0        0.000000    1.652456   -0.563336
+      3          8           0        0.000000   -1.652456   -0.563336
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     24.8978318      5.7855580      4.6946524
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        77.9822575259 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  8.81D-02  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (B1) (A1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A1) (B2) (A2)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ ExpMin= 1.17D-01 ExpMax= 2.19D+04 ExpMxC= 3.30D+03 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(RB3LYP) =  -548.345307812     A.U. after   12 cycles
+            NFock= 12  Conv=0.30D-08     -V/T= 2.0050
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.124695612    0.000000000    0.085019456
+      2        8           0.000189352    0.000000000   -0.134231194
+      3        8          -0.124884964    0.000000000    0.049211738
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.134231194 RMS     0.080838249
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.134231(     1)
+      3  O        1  -0.134231(     2)      2  -0.000716(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.134231194 RMS     0.109600090
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20 on scan point    11 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Update second derivatives using D2CorN and points    1    2
+ DE= -7.01D-05 DEPred=-6.03D-05 R= 1.16D+00
+ TightC=F SS=  1.41D+00  RLast= 2.70D-02 DXNew= 5.0454D-01 8.1134D-02
+ Trust test= 1.16D+00 RLast= 2.70D-02 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.02416   0.13840
+ ITU=  1  0
+     Eigenvalues ---    0.138401000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 1.38397180D-01
+ Quartic linear search produced a step of  0.18914.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        3.77945  -0.26846   0.00000   0.00000   0.00000   3.77945
+   ASO        1.94476  -0.00072  -0.00512   0.00000  -0.00512   1.93964
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000716     0.000450     NO 
+ RMS     Force            0.000716     0.000300     NO 
+ Maximum Displacement     0.005115     0.001800     NO 
+ RMS     Displacement     0.003617     0.001200     NO 
+ Predicted change in Energy=-1.850080D-06
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   2.000000(     1)
+      3      3  O        1   2.000000(     2)      2  111.133(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    2.000000
+      3          8           0        1.865488    0.000000   -0.721079
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    2.000000   0.000000
+     3  O    2.000000   3.299139   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.565447
+      2          8           0        0.000000    1.649569   -0.565447
+      3          8           0        0.000000   -1.649569   -0.565447
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     24.7122423      5.8058273      4.7013135
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        78.0001927042 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  8.78D-02  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (B1) (A1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A1) (B2) (A2)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RB3LYP) =  -548.345309644     A.U. after    8 cycles
+            NFock=  8  Conv=0.85D-08     -V/T= 2.0050
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.125145382    0.000000000    0.085795814
+      2        8           0.000000045    0.000000000   -0.134169131
+      3        8          -0.125145427    0.000000000    0.048373316
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.134169131 RMS     0.080983537
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.134169(     1)
+      3  O        1  -0.134169(     2)      2   0.000000(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.134169131 RMS     0.109548636
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   3 out of a maximum of   20 on scan point    11 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Update second derivatives using D2CorN and points    2    3
+ DE= -1.83D-06 DEPred=-1.85D-06 R= 9.90D-01
+ TightC=F SS=  1.41D+00  RLast= 5.12D-03 DXNew= 5.0454D-01 1.5346D-02
+ Trust test= 9.90D-01 RLast= 5.12D-03 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.02421   0.13987
+ ITU=  1  1  0
+     Eigenvalues ---    0.139871000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 1.39868868D-01
+ Quartic linear search produced a step of  0.00024.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        3.77945  -0.26834   0.00000   0.00000   0.00000   3.77945
+   ASO        1.93964   0.00000   0.00000   0.00000   0.00000   1.93964
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000000     0.000450     YES
+ RMS     Force            0.000000     0.000300     YES
+ Maximum Displacement     0.000001     0.001800     YES
+ RMS     Displacement     0.000001     0.001200     YES
+ Predicted change in Energy=-1.034663D-13
+ Optimization completed.
+    -- Stationary point found.
+                       ----------------------------
+                       !   Optimized Parameters   !
+                       ! (Angstroms and Degrees)  !
+ ----------------------                            ----------------------
+ !      Name          Value   Derivative information (Atomic Units)     !
+ ------------------------------------------------------------------------
+ !       DSO         2.0      -DE/DX =   -0.2683                        !
+ !       ASO       111.1333   -DE/DX =    0.0                           !
+ ------------------------------------------------------------------------
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   2.100000(     1)
+      3      3  O        1   2.100000(     2)      2  111.133(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    2.100000
+      3          8           0        1.958762    0.000000   -0.757133
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    2.100000   0.000000
+     3  O    2.100000   3.464096   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.593719
+      2          8           0        0.000000    1.732048   -0.593719
+      3          8           0        0.000000   -1.732048   -0.593719
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     22.4147322      5.2660565      4.2642299
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        74.2858978135 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  1.00D-01  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (B1) (A1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A1) (B2) (A2)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ ExpMin= 1.17D-01 ExpMax= 2.19D+04 ExpMxC= 3.30D+03 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(RB3LYP) =  -548.296365548     A.U. after   13 cycles
+            NFock= 13  Conv=0.48D-08     -V/T= 2.0049
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.114802798    0.000000000    0.078705258
+      2        8           0.001011794    0.000000000   -0.124556568
+      3        8          -0.115814592    0.000000000    0.045851310
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.124556568 RMS     0.074836804
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.124557(     1)
+      3  O        1  -0.124557(     2)      2  -0.004015(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.124556568 RMS     0.101726429
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20 on scan point    12 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.02421   0.13987
+ ITU=  0
+     Eigenvalues ---    0.139871000.00000
+ RFO step:  Lambda=-1.15170671D-04 EMin= 1.39868868D-01
+ Linear search not attempted -- first point.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        3.96842  -0.24911   0.00000   0.00000   0.00000   3.96842
+   ASO        1.93964  -0.00402   0.00000  -0.02868  -0.02868   1.91096
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.004015     0.000450     NO 
+ RMS     Force            0.004015     0.000300     NO 
+ Maximum Displacement     0.028683     0.001800     NO 
+ RMS     Displacement     0.020282     0.001200     NO 
+ Predicted change in Energy=-5.763275D-05
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   2.100000(     1)
+      3      3  O        1   2.100000(     2)      2  109.490(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    2.100000
+      3          8           0        1.979671    0.000000   -0.700645
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    2.100000   0.000000
+     3  O    2.100000   3.429681   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.606078
+      2          8           0        0.000000    1.714840   -0.606078
+      3          8           0        0.000000   -1.714840   -0.606078
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     21.5099152      5.3722707      4.2986492
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        74.3840013653 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  9.83D-02  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (B1) (A1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A1) (B2) (A2)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ ExpMin= 1.17D-01 ExpMax= 2.19D+04 ExpMxC= 3.30D+03 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(RB3LYP) =  -548.296433707     A.U. after   13 cycles
+            NFock= 13  Conv=0.71D-08     -V/T= 2.0049
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.116905980    0.000000000    0.082636443
+      2        8           0.000183644    0.000000000   -0.124271612
+      3        8          -0.117089623    0.000000000    0.041635169
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.124271612 RMS     0.075559193
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.124272(     1)
+      3  O        1  -0.124272(     2)      2  -0.000729(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.124271612 RMS     0.101468218
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20 on scan point    12 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Update second derivatives using D2CorN and points    1    2
+ DE= -6.82D-05 DEPred=-5.76D-05 R= 1.18D+00
+ TightC=F SS=  1.41D+00  RLast= 2.87D-02 DXNew= 5.0454D-01 8.6050D-02
+ Trust test= 1.18D+00 RLast= 2.87D-02 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.02204   0.11458
+ ITU=  1  0
+     Eigenvalues ---    0.114581000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 1.14576539D-01
+ Quartic linear search produced a step of  0.21967.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        3.96842  -0.24854   0.00000   0.00000   0.00000   3.96842
+   ASO        1.91096  -0.00073  -0.00630   0.00000  -0.00630   1.90466
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000729     0.000450     NO 
+ RMS     Force            0.000729     0.000300     NO 
+ Maximum Displacement     0.006301     0.001800     NO 
+ RMS     Displacement     0.004455     0.001200     NO 
+ Predicted change in Energy=-2.317520D-06
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   2.100000(     1)
+      3      3  O        1   2.100000(     2)      2  109.129(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    2.100000
+      3          8           0        1.984046    0.000000   -0.688158
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    2.100000   0.000000
+     3  O    2.100000   3.422026   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.608776
+      2          8           0        0.000000    1.711013   -0.608776
+      3          8           0        0.000000   -1.711013   -0.608776
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     21.3196660      5.3963316      4.3063332
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        74.4060897986 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  9.79D-02  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (B1) (A1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A1) (B2) (A2)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RB3LYP) =  -548.296436004     A.U. after    9 cycles
+            NFock=  9  Conv=0.35D-08     -V/T= 2.0049
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.117343977    0.000000000    0.083501680
+      2        8          -0.000000002    0.000000000   -0.124201927
+      3        8          -0.117343975    0.000000000    0.040700247
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.124201927 RMS     0.075714652
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.124202(     1)
+      3  O        1  -0.124202(     2)      2   0.000000(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.124201927 RMS     0.101410448
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   3 out of a maximum of   20 on scan point    12 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Update second derivatives using D2CorN and points    2    3
+ DE= -2.30D-06 DEPred=-2.32D-06 R= 9.91D-01
+ TightC=F SS=  1.41D+00  RLast= 6.30D-03 DXNew= 5.0454D-01 1.8902D-02
+ Trust test= 9.91D-01 RLast= 6.30D-03 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.02208   0.11567
+ ITU=  1  1  0
+     Eigenvalues ---    0.115671000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 1.15665206D-01
+ Quartic linear search produced a step of -0.00001.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        3.96842  -0.24840   0.00000   0.00000   0.00000   3.96842
+   ASO        1.90466   0.00000   0.00000   0.00000   0.00000   1.90466
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000000     0.000450     YES
+ RMS     Force            0.000000     0.000300     YES
+ Maximum Displacement     0.000000     0.001800     YES
+ RMS     Displacement     0.000000     0.001200     YES
+ Predicted change in Energy=-3.293668D-16
+ Optimization completed.
+    -- Stationary point found.
+                       ----------------------------
+                       !   Optimized Parameters   !
+                       ! (Angstroms and Degrees)  !
+ ----------------------                            ----------------------
+ !      Name          Value   Derivative information (Atomic Units)     !
+ ------------------------------------------------------------------------
+ !       DSO         2.1      -DE/DX =   -0.2484                        !
+ !       ASO       109.1289   -DE/DX =    0.0                           !
+ ------------------------------------------------------------------------
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   2.200000(     1)
+      3      3  O        1   2.200000(     2)      2  109.129(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    2.200000
+      3          8           0        2.078524    0.000000   -0.720927
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    2.200000   0.000000
+     3  O    2.200000   3.584980   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.637766
+      2          8           0        0.000000    1.792490   -0.637766
+      3          8           0        0.000000   -1.792490   -0.637766
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     19.4255634      4.9169054      3.9237457
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        71.0239948078 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  1.10D-01  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (B1) (A1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A1) (B2) (A2)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ ExpMin= 1.17D-01 ExpMax= 2.19D+04 ExpMxC= 3.30D+03 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(RB3LYP) =  -548.251470666     A.U. after   15 cycles
+            NFock= 15  Conv=0.28D-08     -V/T= 2.0049
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.106239277    0.000000000    0.075599602
+      2        8           0.000862754    0.000000000   -0.113660653
+      3        8          -0.107102030    0.000000000    0.038061051
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.113660653 RMS     0.068993607
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.113661(     1)
+      3  O        1  -0.113661(     2)      2  -0.003587(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.113660653 RMS     0.092826637
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20 on scan point    13 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.02208   0.11567
+ ITU=  0
+     Eigenvalues ---    0.115671000.00000
+ RFO step:  Lambda=-1.11121113D-04 EMin= 1.15665206D-01
+ Linear search not attempted -- first point.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        4.15740  -0.22732   0.00000   0.00000   0.00000   4.15740
+   ASO        1.90466  -0.00359   0.00000  -0.03098  -0.03098   1.87368
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.003587     0.000450     NO 
+ RMS     Force            0.003587     0.000300     NO 
+ Maximum Displacement     0.030981     0.001800     NO 
+ RMS     Displacement     0.021907     0.001200     NO 
+ Predicted change in Energy=-5.561393D-05
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   2.200000(     1)
+      3      3  O        1   2.200000(     2)      2  107.354(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    2.200000
+      3          8           0        2.099858    0.000000   -0.656198
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    2.200000   0.000000
+     3  O    2.200000   3.545035   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.651572
+      2          8           0        0.000000    1.772517   -0.651572
+      3          8           0        0.000000   -1.772517   -0.651572
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     18.6110776      5.0283362      3.9587595
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        71.1304428685 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  1.08D-01  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (A1) (B1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A1) (B2) (A2)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ ExpMin= 1.17D-01 ExpMax= 2.19D+04 ExpMxC= 3.30D+03 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(RB3LYP) =  -548.251535948     A.U. after   13 cycles
+            NFock= 13  Conv=0.43D-08     -V/T= 2.0049
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.108037649    0.000000000    0.079428582
+      2        8           0.000148810    0.000000000   -0.113392351
+      3        8          -0.108186459    0.000000000    0.033963769
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.113392351 RMS     0.069679208
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.113392(     1)
+      3  O        1  -0.113392(     2)      2  -0.000619(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.113392351 RMS     0.092585156
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20 on scan point    13 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Update second derivatives using D2CorN and points    1    2
+ DE= -6.53D-05 DEPred=-5.56D-05 R= 1.17D+00
+ TightC=F SS=  1.41D+00  RLast= 3.10D-02 DXNew= 5.0454D-01 9.2942D-02
+ Trust test= 1.17D+00 RLast= 3.10D-02 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.01970   0.09581
+ ITU=  1  0
+     Eigenvalues ---    0.095811000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 9.58069260D-02
+ Quartic linear search produced a step of  0.20619.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        4.15740  -0.22678   0.00000   0.00000   0.00000   4.15740
+   ASO        1.87368  -0.00062  -0.00639   0.00000  -0.00639   1.86729
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000619     0.000450     NO 
+ RMS     Force            0.000619     0.000300     NO 
+ Maximum Displacement     0.006388     0.001800     NO 
+ RMS     Displacement     0.004517     0.001200     NO 
+ Predicted change in Energy=-1.997239D-06
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   2.200000(     1)
+      3      3  O        1   2.200000(     2)      2  106.988(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    2.200000
+      3          8           0        2.104007    0.000000   -0.642771
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    2.200000   0.000000
+     3  O    2.200000   3.536692   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.654399
+      2          8           0        0.000000    1.768346   -0.654399
+      3          8           0        0.000000   -1.768346   -0.654399
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     18.4506084      5.0520857      3.9661009
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        71.1529774502 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  1.08D-01  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (A1) (B1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A1) (B2) (A2)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RB3LYP) =  -548.251537925     A.U. after    9 cycles
+            NFock=  9  Conv=0.29D-08     -V/T= 2.0049
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.108386282    0.000000000    0.080219439
+      2        8          -0.000000036    0.000000000   -0.113331238
+      3        8          -0.108386245    0.000000000    0.033111799
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.113331238 RMS     0.069817765
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.113331(     1)
+      3  O        1  -0.113331(     2)      2   0.000000(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.113331238 RMS     0.092534568
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   3 out of a maximum of   20 on scan point    13 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Update second derivatives using D2CorN and points    2    3
+ DE= -1.98D-06 DEPred=-2.00D-06 R= 9.90D-01
+ TightC=F SS=  1.41D+00  RLast= 6.39D-03 DXNew= 5.0454D-01 1.9163D-02
+ Trust test= 9.90D-01 RLast= 6.39D-03 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.01942   0.09687
+ ITU=  1  1  0
+     Eigenvalues ---    0.096871000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 9.68739103D-02
+ Quartic linear search produced a step of -0.00024.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        4.15740  -0.22666   0.00000   0.00000   0.00000   4.15740
+   ASO        1.86729   0.00000   0.00000   0.00000   0.00000   1.86729
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000000     0.000450     YES
+ RMS     Force            0.000000     0.000300     YES
+ Maximum Displacement     0.000002     0.001800     YES
+ RMS     Displacement     0.000001     0.001200     YES
+ Predicted change in Energy=-1.167545D-13
+ Optimization completed.
+    -- Stationary point found.
+                       ----------------------------
+                       !   Optimized Parameters   !
+                       ! (Angstroms and Degrees)  !
+ ----------------------                            ----------------------
+ !      Name          Value   Derivative information (Atomic Units)     !
+ ------------------------------------------------------------------------
+ !       DSO         2.2      -DE/DX =   -0.2267                        !
+ !       ASO       106.9878   -DE/DX =    0.0                           !
+ ------------------------------------------------------------------------
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   2.300000(     1)
+      3      3  O        1   2.300000(     2)      2  106.988(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    2.300000
+      3          8           0        2.199644    0.000000   -0.671988
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    2.300000   0.000000
+     3  O    2.300000   3.697451   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.684144
+      2          8           0        0.000000    1.848726   -0.684144
+      3          8           0        0.000000   -1.848726   -0.684144
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     16.8810860      4.6223242      3.6287199
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        68.0593697350 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  1.20D-01  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (A1) (B1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A1) (B2) (A2)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ ExpMin= 1.17D-01 ExpMax= 2.19D+04 ExpMxC= 3.30D+03 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(RB3LYP) =  -548.210698362     A.U. after   15 cycles
+            NFock= 15  Conv=0.40D-08     -V/T= 2.0048
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.097409362    0.000000000    0.072095142
+      2        8           0.000725389    0.000000000   -0.102833647
+      3        8          -0.098134751    0.000000000    0.030738505
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.102833647 RMS     0.063102090
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.102834(     1)
+      3  O        1  -0.102834(     2)      2  -0.003153(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.102833647 RMS     0.083983050
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20 on scan point    14 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.01942   0.09687
+ ITU=  0
+     Eigenvalues ---    0.096871000.00000
+ RFO step:  Lambda=-1.02501247D-04 EMin= 9.68739103D-02
+ Linear search not attempted -- first point.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        4.34637  -0.20567   0.00000   0.00000   0.00000   4.34637
+   ASO        1.86729  -0.00315   0.00000  -0.03251  -0.03251   1.83478
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.003153     0.000450     NO 
+ RMS     Force            0.003153     0.000300     NO 
+ Maximum Displacement     0.032511     0.001800     NO 
+ RMS     Displacement     0.022989     0.001200     NO 
+ Predicted change in Energy=-5.130485D-05
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   2.300000(     1)
+      3      3  O        1   2.300000(     2)      2  105.125(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    2.300000
+      3          8           0        2.220325    0.000000   -0.600133
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    2.300000   0.000000
+     3  O    2.300000   3.652480   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.699079
+      2          8           0        0.000000    1.826240   -0.699079
+      3          8           0        0.000000   -1.826240   -0.699079
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     16.1675030      4.7368496      3.6634968
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        68.1721477831 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  1.18D-01  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (A1) (B1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A1) (B2) (A2)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ ExpMin= 1.17D-01 ExpMax= 2.19D+04 ExpMxC= 3.30D+03 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(RB3LYP) =  -548.210758086     A.U. after   14 cycles
+            NFock= 14  Conv=0.67D-08     -V/T= 2.0048
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.098883994    0.000000000    0.075705008
+      2        8           0.000116828    0.000000000   -0.102585005
+      3        8          -0.099000822    0.000000000    0.026879997
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.102585005 RMS     0.063732676
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.102585(     1)
+      3  O        1  -0.102585(     2)      2  -0.000508(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.102585005 RMS     0.083760819
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20 on scan point    14 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Update second derivatives using D2CorN and points    1    2
+ DE= -5.97D-05 DEPred=-5.13D-05 R= 1.16D+00
+ TightC=F SS=  1.41D+00  RLast= 3.25D-02 DXNew= 5.0454D-01 9.7533D-02
+ Trust test= 1.16D+00 RLast= 3.25D-02 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.01736   0.08136
+ ITU=  1  0
+     Eigenvalues ---    0.081361000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 8.13578258D-02
+ Quartic linear search produced a step of  0.18854.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        4.34637  -0.20517   0.00000   0.00000   0.00000   4.34637
+   ASO        1.83478  -0.00051  -0.00613   0.00000  -0.00613   1.82865
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000508     0.000450     NO 
+ RMS     Force            0.000508     0.000300     NO 
+ Maximum Displacement     0.006130     0.001800     NO 
+ RMS     Displacement     0.004334     0.001200     NO 
+ Predicted change in Energy=-1.584085D-06
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   2.300000(     1)
+      3      3  O        1   2.300000(     2)      2  104.774(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    2.300000
+      3          8           0        2.223961    0.000000   -0.586512
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    2.300000   0.000000
+     3  O    2.300000   3.643893   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.701875
+      2          8           0        0.000000    1.821946   -0.701875
+      3          8           0        0.000000   -1.821946   -0.701875
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     16.0389844      4.7592018      3.6701644
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        68.1939993578 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  1.18D-01  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (A1) (B1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A1) (B2) (A2)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RB3LYP) =  -548.210759643     A.U. after    9 cycles
+            NFock=  9  Conv=0.65D-08     -V/T= 2.0048
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.099143521    0.000000000    0.076386789
+      2        8          -0.000000059    0.000000000   -0.102533225
+      3        8          -0.099143462    0.000000000    0.026146435
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.102533225 RMS     0.063849218
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.102533(     1)
+      3  O        1  -0.102533(     2)      2   0.000000(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.102533225 RMS     0.083718027
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   3 out of a maximum of   20 on scan point    14 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Update second derivatives using D2CorN and points    2    3
+ DE= -1.56D-06 DEPred=-1.58D-06 R= 9.83D-01
+ TightC=F SS=  1.41D+00  RLast= 6.13D-03 DXNew= 5.0454D-01 1.8389D-02
+ Trust test= 9.83D-01 RLast= 6.13D-03 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.01713   0.08288
+ ITU=  1  1  0
+     Eigenvalues ---    0.082881000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 8.28822028D-02
+ Quartic linear search produced a step of -0.00050.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        4.34637  -0.20507   0.00000   0.00000   0.00000   4.34637
+   ASO        1.82865   0.00000   0.00000   0.00000   0.00000   1.82865
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000000     0.000450     YES
+ RMS     Force            0.000000     0.000300     YES
+ Maximum Displacement     0.000003     0.001800     YES
+ RMS     Displacement     0.000002     0.001200     YES
+ Predicted change in Energy=-3.945740D-13
+ Optimization completed.
+    -- Stationary point found.
+                       ----------------------------
+                       !   Optimized Parameters   !
+                       ! (Angstroms and Degrees)  !
+ ----------------------                            ----------------------
+ !      Name          Value   Derivative information (Atomic Units)     !
+ ------------------------------------------------------------------------
+ !       DSO         2.3      -DE/DX =   -0.2051                        !
+ !       ASO       104.7739   -DE/DX =    0.0                           !
+ ------------------------------------------------------------------------
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   2.400000(     1)
+      3      3  O        1   2.400000(     2)      2  104.774(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    2.400000
+      3          8           0        2.320655    0.000000   -0.612012
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    2.400000   0.000000
+     3  O    2.400000   3.802323   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.732391
+      2          8           0        0.000000    1.901161   -0.732391
+      3          8           0        0.000000   -1.901161   -0.732391
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     14.7302478      4.3708641      3.3706892
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        65.3525827179 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  1.31D-01  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (A1) (B1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A1) (B2) (A2)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ ExpMin= 1.17D-01 ExpMax= 2.19D+04 ExpMxC= 3.30D+03 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(RB3LYP) =  -548.173910486     A.U. after   17 cycles
+            NFock= 17  Conv=0.22D-08     -V/T= 2.0047
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.088722123    0.000000000    0.068357449
+      2        8           0.000591734    0.000000000   -0.092523609
+      3        8          -0.089313857    0.000000000    0.024166161
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.092523609 RMS     0.057413019
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.092524(     1)
+      3  O        1  -0.092524(     2)      2  -0.002684(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.092523609 RMS     0.075561099
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20 on scan point    15 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.01713   0.08288
+ ITU=  0
+     Eigenvalues ---    0.082881000.00000
+ RFO step:  Lambda=-8.68074253D-05 EMin= 8.28822028D-02
+ Linear search not attempted -- first point.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        4.53534  -0.18505   0.00000   0.00000   0.00000   4.53534
+   ASO        1.82865  -0.00268   0.00000  -0.03235  -0.03235   1.79630
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.002684     0.000450     NO 
+ RMS     Force            0.002684     0.000300     NO 
+ Maximum Displacement     0.032346     0.001800     NO 
+ RMS     Displacement     0.022872     0.001200     NO 
+ Predicted change in Energy=-4.344917D-05
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   2.400000(     1)
+      3      3  O        1   2.400000(     2)      2  102.921(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    2.400000
+      3          8           0        2.339234    0.000000   -0.536641
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    2.400000   0.000000
+     3  O    2.400000   3.754448   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.747668
+      2          8           0        0.000000    1.877224   -0.747668
+      3          8           0        0.000000   -1.877224   -0.747668
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     14.1344241      4.4830455      3.4035380
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        65.4661609946 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  1.29D-01  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (A1) (B1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A1) (B2) (A2)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ ExpMin= 1.17D-01 ExpMax= 2.19D+04 ExpMxC= 3.30D+03 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(RB3LYP) =  -548.173960985     A.U. after   15 cycles
+            NFock= 15  Conv=0.31D-08     -V/T= 2.0047
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.089867678    0.000000000    0.071585708
+      2        8           0.000093524    0.000000000   -0.092319564
+      3        8          -0.089961202    0.000000000    0.020733856
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.092319564 RMS     0.057971769
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.092320(     1)
+      3  O        1  -0.092320(     2)      2  -0.000424(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.092319564 RMS     0.075379006
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20 on scan point    15 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Update second derivatives using D2CorN and points    1    2
+ DE= -5.05D-05 DEPred=-4.34D-05 R= 1.16D+00
+ TightC=F SS=  1.41D+00  RLast= 3.23D-02 DXNew= 5.0454D-01 9.7038D-02
+ Trust test= 1.16D+00 RLast= 3.23D-02 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.01487   0.06986
+ ITU=  1  0
+     Eigenvalues ---    0.069861000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 6.98557453D-02
+ Quartic linear search produced a step of  0.18350.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        4.53534  -0.18464   0.00000   0.00000   0.00000   4.53534
+   ASO        1.79630  -0.00042  -0.00594   0.00000  -0.00594   1.79037
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000424     0.000450     YES
+ RMS     Force            0.000424     0.000300     NO 
+ Maximum Displacement     0.005936     0.001800     NO 
+ RMS     Displacement     0.004197     0.001200     NO 
+ Predicted change in Energy=-1.287098D-06
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   2.400000(     1)
+      3      3  O        1   2.400000(     2)      2  102.581(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    2.400000
+      3          8           0        2.342378    0.000000   -0.522747
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    2.400000   0.000000
+     3  O    2.400000   3.745556   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.750450
+      2          8           0        0.000000    1.872778   -0.750450
+      3          8           0        0.000000   -1.872778   -0.750450
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     14.0298116      4.5043568      3.4096635
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        65.4875764296 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  1.28D-01  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (A1) (B1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A1) (B2) (A2)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RB3LYP) =  -548.173962245     A.U. after   10 cycles
+            NFock= 10  Conv=0.24D-08     -V/T= 2.0047
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.090062703    0.000000000    0.072178980
+      2        8          -0.000000055    0.000000000   -0.092278152
+      3        8          -0.090062648    0.000000000    0.020099172
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.092278152 RMS     0.058072379
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.092278(     1)
+      3  O        1  -0.092278(     2)      2   0.000000(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.092278152 RMS     0.075344796
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   3 out of a maximum of   20 on scan point    15 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Update second derivatives using D2CorN and points    2    3
+ DE= -1.26D-06 DEPred=-1.29D-06 R= 9.79D-01
+ TightC=F SS=  1.41D+00  RLast= 5.94D-03 DXNew= 5.0454D-01 1.7807D-02
+ Trust test= 9.79D-01 RLast= 5.94D-03 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.01441   0.07150
+ ITU=  1  1  0
+     Eigenvalues ---    0.071501000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 7.15029606D-02
+ Quartic linear search produced a step of -0.00058.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        4.53534  -0.18456   0.00000   0.00000   0.00000   4.53534
+   ASO        1.79037   0.00000   0.00000   0.00000   0.00000   1.79037
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000000     0.000450     YES
+ RMS     Force            0.000000     0.000300     YES
+ Maximum Displacement     0.000003     0.001800     YES
+ RMS     Displacement     0.000002     0.001200     YES
+ Predicted change in Energy=-4.307788D-13
+ Optimization completed.
+    -- Stationary point found.
+                       ----------------------------
+                       !   Optimized Parameters   !
+                       ! (Angstroms and Degrees)  !
+ ----------------------                            ----------------------
+ !      Name          Value   Derivative information (Atomic Units)     !
+ ------------------------------------------------------------------------
+ !       DSO         2.4      -DE/DX =   -0.1846                        !
+ !       ASO       102.5805   -DE/DX =    0.0                           !
+ ------------------------------------------------------------------------
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   2.500000(     1)
+      3      3  O        1   2.500000(     2)      2  102.581(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    2.500000
+      3          8           0        2.439977    0.000000   -0.544528
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    2.500000   0.000000
+     3  O    2.500000   3.901620   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.781719
+      2          8           0        0.000000    1.950810   -0.781719
+      3          8           0        0.000000   -1.950810   -0.781719
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     12.9298744      4.1512152      3.1423459
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        62.8680733724 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  1.41D-01  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (A1) (B1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A1) (B2) (A2)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ ExpMin= 1.17D-01 ExpMax= 2.19D+04 ExpMxC= 3.30D+03 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(RB3LYP) =  -548.140902597     A.U. after   17 cycles
+            NFock= 17  Conv=0.51D-08     -V/T= 2.0046
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.080178109    0.000000000    0.064257167
+      2        8           0.000480461    0.000000000   -0.082749972
+      3        8          -0.080658570    0.000000000    0.018492805
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.082749972 RMS     0.051911345
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.082750(     1)
+      3  O        1  -0.082750(     2)      2  -0.002270(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.082749972 RMS     0.067577777
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20 on scan point    16 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.01441   0.07150
+ ITU=  0
+     Eigenvalues ---    0.071501000.00000
+ RFO step:  Lambda=-7.19833036D-05 EMin= 7.15029606D-02
+ Linear search not attempted -- first point.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        4.72432  -0.16550   0.00000   0.00000   0.00000   4.72432
+   ASO        1.79037  -0.00227   0.00000  -0.03171  -0.03171   1.75865
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.002270     0.000450     NO 
+ RMS     Force            0.002270     0.000300     NO 
+ Maximum Displacement     0.031713     0.001800     NO 
+ RMS     Displacement     0.022424     0.001200     NO 
+ Predicted change in Energy=-3.602789D-05
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   2.500000(     1)
+      3      3  O        1   2.500000(     2)      2  100.763(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    2.500000
+      3          8           0        2.456016    0.000000   -0.466889
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    2.500000   0.000000
+     3  O    2.500000   3.851551   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.797087
+      2          8           0        0.000000    1.925775   -0.797087
+      3          8           0        0.000000   -1.925775   -0.797087
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     12.4361143      4.2598470      3.1729796
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        62.9809161875 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  1.40D-01  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (A1) (B1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A1) (B2) (A2)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ ExpMin= 1.17D-01 ExpMax= 2.19D+04 ExpMxC= 3.30D+03 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(RB3LYP) =  -548.140943652     A.U. after   15 cycles
+            NFock= 15  Conv=0.93D-08     -V/T= 2.0046
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.081044802    0.000000000    0.067089585
+      2        8           0.000064260    0.000000000   -0.082573832
+      3        8          -0.081109062    0.000000000    0.015484247
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.082573832 RMS     0.052393973
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.082574(     1)
+      3  O        1  -0.082574(     2)      2  -0.000304(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.082573832 RMS     0.067421479
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20 on scan point    16 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Update second derivatives using D2CorN and points    1    2
+ DE= -4.11D-05 DEPred=-3.60D-05 R= 1.14D+00
+ TightC=F SS=  1.41D+00  RLast= 3.17D-02 DXNew= 5.0454D-01 9.5139D-02
+ Trust test= 1.14D+00 RLast= 3.17D-02 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.01276   0.06200
+ ITU=  1  0
+     Eigenvalues ---    0.062001000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 6.20020407D-02
+ Quartic linear search produced a step of  0.15022.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        4.72432  -0.16515   0.00000   0.00000   0.00000   4.72432
+   ASO        1.75865  -0.00030  -0.00476   0.00000  -0.00476   1.75389
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000304     0.000450     YES
+ RMS     Force            0.000304     0.000300     NO 
+ Maximum Displacement     0.004764     0.001800     NO 
+ RMS     Displacement     0.003369     0.001200     NO 
+ Predicted change in Energy=-7.426862D-07
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   2.500000(     1)
+      3      3  O        1   2.500000(     2)      2  100.491(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    2.500000
+      3          8           0        2.458212    0.000000   -0.455183
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    2.500000   0.000000
+     3  O    2.500000   3.843945   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.799378
+      2          8           0        0.000000    1.921973   -0.799378
+      3          8           0        0.000000   -1.921973   -0.799378
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     12.3649219      4.2767208      3.1776501
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        62.9983144053 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  1.40D-01  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (A1) (B1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A1) (B2) (A2)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RB3LYP) =  -548.140944376     A.U. after   10 cycles
+            NFock= 10  Conv=0.41D-08     -V/T= 2.0046
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.081165342    0.000000000    0.067515840
+      2        8           0.000000013    0.000000000   -0.082545101
+      3        8          -0.081165356    0.000000000    0.015029261
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.082545101 RMS     0.052465427
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.082545(     1)
+      3  O        1  -0.082545(     2)      2   0.000000(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.082545101 RMS     0.067397793
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   3 out of a maximum of   20 on scan point    16 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Update second derivatives using D2CorN and points    2    3
+ DE= -7.24D-07 DEPred=-7.43D-07 R= 9.75D-01
+ Trust test= 9.75D-01 RLast= 4.76D-03 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.01241   0.06371
+ ITU=  0  1  0
+     Eigenvalues ---    0.063711000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 6.37105437D-02
+ Quartic linear search produced a step of  0.00021.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        4.72432  -0.16509   0.00000   0.00000   0.00000   4.72432
+   ASO        1.75389   0.00000   0.00000   0.00000   0.00000   1.75389
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000000     0.000450     YES
+ RMS     Force            0.000000     0.000300     YES
+ Maximum Displacement     0.000001     0.001800     YES
+ RMS     Displacement     0.000001     0.001200     YES
+ Predicted change in Energy=-3.177686D-14
+ Optimization completed.
+    -- Stationary point found.
+                       ----------------------------
+                       !   Optimized Parameters   !
+                       ! (Angstroms and Degrees)  !
+ ----------------------                            ----------------------
+ !      Name          Value   Derivative information (Atomic Units)     !
+ ------------------------------------------------------------------------
+ !       DSO         2.5      -DE/DX =   -0.1651                        !
+ !       ASO       100.4905   -DE/DX =    0.0                           !
+ ------------------------------------------------------------------------
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   2.600000(     1)
+      3      3  O        1   2.600000(     2)      2  100.491(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    2.600000
+      3          8           0        2.556541    0.000000   -0.473390
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    2.600000   0.000000
+     3  O    2.600000   3.997703   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.831353
+      2          8           0        0.000000    1.998851   -0.831353
+      3          8           0        0.000000   -1.998851   -0.831353
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     11.4320654      3.9540687      2.9379162
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        60.5753023127 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  1.53D-01  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (A1) (B1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A1) (B2) (A2)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ ExpMin= 1.17D-01 ExpMax= 2.19D+04 ExpMxC= 3.30D+03 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(RB3LYP) =  -548.111434125     A.U. after   17 cycles
+            NFock= 17  Conv=0.43D-08     -V/T= 2.0045
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.072045391    0.000000000    0.059929583
+      2        8           0.000390000    0.000000000   -0.073738948
+      3        8          -0.072435391    0.000000000    0.013809365
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.073738948 RMS     0.046734786
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.073739(     1)
+      3  O        1  -0.073739(     2)      2  -0.001916(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.073738948 RMS     0.060217762
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20 on scan point    17 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.01241   0.06371
+ ITU=  0
+     Eigenvalues ---    0.063711000.00000
+ RFO step:  Lambda=-5.75797737D-05 EMin= 6.37105437D-02
+ Linear search not attempted -- first point.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        4.91329  -0.14748   0.00000   0.00000   0.00000   4.91329
+   ASO        1.75389  -0.00192   0.00000  -0.03005  -0.03005   1.72384
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.001916     0.000450     NO 
+ RMS     Force            0.001916     0.000300     NO 
+ Maximum Displacement     0.030049     0.001800     NO 
+ RMS     Displacement     0.021248     0.001200     NO 
+ Predicted change in Energy=-2.881591D-05
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   2.600000(     1)
+      3      3  O        1   2.600000(     2)      2   98.769(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    2.600000
+      3          8           0        2.569610    0.000000   -0.396366
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    2.600000   0.000000
+     3  O    2.600000   3.947291   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.846275
+      2          8           0        0.000000    1.973645   -0.846275
+      3          8           0        0.000000   -1.973645   -0.846275
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     11.0324772      4.0557116      2.9655346
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        60.6834976781 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  1.51D-01  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (A1) (B1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A1) (B2) (A2)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ ExpMin= 1.17D-01 ExpMax= 2.19D+04 ExpMxC= 3.30D+03 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Problem detected with inexpensive integrals.
+ Switching to full accuracy and repeating last cycle.
+ SCF Done:  E(RB3LYP) =  -548.111466804     A.U. after   16 cycles
+            NFock= 16  Conv=0.23D-08     -V/T= 2.0045
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.072693872    0.000000000    0.062340475
+      2        8           0.000049661    0.000000000   -0.073611518
+      3        8          -0.072743533    0.000000000    0.011271043
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.073611518 RMS     0.047149938
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.073612(     1)
+      3  O        1  -0.073612(     2)      2  -0.000244(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.073611518 RMS     0.060103718
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20 on scan point    17 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Update second derivatives using D2CorN and points    1    2
+ DE= -3.27D-05 DEPred=-2.88D-05 R= 1.13D+00
+ TightC=F SS=  1.41D+00  RLast= 3.00D-02 DXNew= 5.0454D-01 9.0148D-02
+ Trust test= 1.13D+00 RLast= 3.00D-02 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.01045   0.05565
+ ITU=  1  0
+     Eigenvalues ---    0.055651000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 5.56481162D-02
+ Quartic linear search produced a step of  0.14158.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        4.91329  -0.14722   0.00000   0.00000   0.00000   4.91329
+   ASO        1.72384  -0.00024  -0.00425   0.00000  -0.00425   1.71959
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000244     0.000450     YES
+ RMS     Force            0.000244     0.000300     YES
+ Maximum Displacement     0.004254     0.001800     NO 
+ RMS     Displacement     0.003008     0.001200     NO 
+ Predicted change in Energy=-5.344601D-07
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   2.600000(     1)
+      3      3  O        1   2.600000(     2)      2   98.525(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    2.600000
+      3          8           0        2.571273    0.000000   -0.385430
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    2.600000   0.000000
+     3  O    2.600000   3.940081   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.848372
+      2          8           0        0.000000    1.970040   -0.848372
+      3          8           0        0.000000   -1.970040   -0.848372
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     10.9779982      4.0705677      2.9694979
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        60.6991974539 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  1.51D-01  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (A1) (B1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A1) (B2) (A2)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RB3LYP) =  -548.111467324     A.U. after   10 cycles
+            NFock= 10  Conv=0.69D-08     -V/T= 2.0045
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.072778443    0.000000000    0.062682162
+      2        8           0.000000027    0.000000000   -0.073591584
+      3        8          -0.072778471    0.000000000    0.010909422
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.073591584 RMS     0.047207812
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.073592(     1)
+      3  O        1  -0.073592(     2)      2   0.000000(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.073591584 RMS     0.060087277
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   3 out of a maximum of   20 on scan point    17 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Update second derivatives using D2CorN and points    2    3
+ DE= -5.20D-07 DEPred=-5.34D-07 R= 9.73D-01
+ Trust test= 9.73D-01 RLast= 4.25D-03 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.00991   0.05732
+ ITU=  0  1  0
+     Eigenvalues ---    0.057321000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 5.73209095D-02
+ Quartic linear search produced a step of  0.00055.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        4.91329  -0.14718   0.00000   0.00000   0.00000   4.91329
+   ASO        1.71959   0.00000   0.00000   0.00000   0.00000   1.71958
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000000     0.000450     YES
+ RMS     Force            0.000000     0.000300     YES
+ Maximum Displacement     0.000002     0.001800     YES
+ RMS     Displacement     0.000002     0.001200     YES
+ Predicted change in Energy=-1.578047D-13
+ Optimization completed.
+    -- Stationary point found.
+                       ----------------------------
+                       !   Optimized Parameters   !
+                       ! (Angstroms and Degrees)  !
+ ----------------------                            ----------------------
+ !      Name          Value   Derivative information (Atomic Units)     !
+ ------------------------------------------------------------------------
+ !       DSO         2.6      -DE/DX =   -0.1472                        !
+ !       ASO        98.5251   -DE/DX =    0.0                           !
+ ------------------------------------------------------------------------
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   2.700000(     1)
+      3      3  O        1   2.700000(     2)      2   98.525(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    2.700000
+      3          8           0        2.670168    0.000000   -0.400255
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    2.700000   0.000000
+     3  O    2.700000   4.091622   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.881002
+      2          8           0        0.000000    2.045811   -0.881002
+      3          8           0        0.000000   -2.045811   -0.881002
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):     10.1798721      3.7746279      2.7536085
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        58.4510790297 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  1.64D-01  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (A1) (B1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A1) (B2) (A2)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ ExpMin= 1.17D-01 ExpMax= 2.19D+04 ExpMxC= 3.30D+03 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(RB3LYP) =  -548.085196417     A.U. after   17 cycles
+            NFock= 17  Conv=0.58D-08     -V/T= 2.0044
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.064504290    0.000000000    0.055555851
+      2        8           0.000250300    0.000000000   -0.065515574
+      3        8          -0.064754590    0.000000000    0.009959723
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.065515574 RMS     0.041941708
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.065516(     1)
+      3  O        1  -0.065516(     2)      2  -0.001277(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.065515574 RMS     0.053498323
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20 on scan point    18 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.00991   0.05732
+ ITU=  0
+     Eigenvalues ---    0.057321000.00000
+ RFO step:  Lambda=-2.84393587D-05 EMin= 5.73209095D-02
+ Linear search not attempted -- first point.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        5.10226  -0.13103   0.00000   0.00000   0.00000   5.10226
+   ASO        1.71959  -0.00128   0.00000  -0.02227  -0.02227   1.69732
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.001277     0.000450     NO 
+ RMS     Force            0.001277     0.000300     NO 
+ Maximum Displacement     0.022269     0.001800     NO 
+ RMS     Displacement     0.015746     0.001200     NO 
+ Predicted change in Energy=-1.422673D-05
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   2.700000(     1)
+      3      3  O        1   2.700000(     2)      2   97.249(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    2.700000
+      3          8           0        2.678418    0.000000   -0.340699
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    2.700000   0.000000
+     3  O    2.700000   4.052132   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.892336
+      2          8           0        0.000000    2.026066   -0.892336
+      3          8           0        0.000000   -2.026066   -0.892336
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      9.9229026      3.8485584      2.7730442
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        58.5317456174 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  1.63D-01  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (A1) (B1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A1) (B2) (A2)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ ExpMin= 1.17D-01 ExpMax= 2.19D+04 ExpMxC= 3.30D+03 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Problem detected with inexpensive integrals.
+ Switching to full accuracy and repeating last cycle.
+ SCF Done:  E(RB3LYP) =  -548.085212901     A.U. after   16 cycles
+            NFock= 16  Conv=0.29D-08     -V/T= 2.0044
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.064894981    0.000000000    0.057163140
+      2        8           0.000038698    0.000000000   -0.065461815
+      3        8          -0.064933679    0.000000000    0.008298675
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.065461815 RMS     0.042228853
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.065462(     1)
+      3  O        1  -0.065462(     2)      2  -0.000197(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.065461815 RMS     0.053449470
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20 on scan point    18 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Update second derivatives using D2CorN and points    1    2
+ DE= -1.65D-05 DEPred=-1.42D-05 R= 1.16D+00
+ TightC=F SS=  1.41D+00  RLast= 2.23D-02 DXNew= 5.0454D-01 6.6806D-02
+ Trust test= 1.16D+00 RLast= 2.23D-02 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.00737   0.04848
+ ITU=  1  0
+     Eigenvalues ---    0.048481000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 4.84826833D-02
+ Quartic linear search produced a step of  0.17935.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        5.10226  -0.13092   0.00000   0.00000   0.00000   5.10226
+   ASO        1.69732  -0.00020  -0.00399   0.00000  -0.00399   1.69332
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000197     0.000450     YES
+ RMS     Force            0.000197     0.000300     YES
+ Maximum Displacement     0.003994     0.001800     NO 
+ RMS     Displacement     0.002824     0.001200     NO 
+ Predicted change in Energy=-4.019142D-07
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   2.700000(     1)
+      3      3  O        1   2.700000(     2)      2   97.020(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    2.700000
+      3          8           0        2.679758    0.000000   -0.329999
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    2.700000   0.000000
+     3  O    2.700000   4.044996   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.894358
+      2          8           0        0.000000    2.022498   -0.894358
+      3          8           0        0.000000   -2.022498   -0.894358
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      9.8781028      3.8621491      2.7765652
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        58.5464900685 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  1.63D-01  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (A1) (B1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A1) (B2) (A2)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RB3LYP) =  -548.085213296     A.U. after   11 cycles
+            NFock= 11  Conv=0.46D-08     -V/T= 2.0044
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.064960049    0.000000000    0.057451237
+      2        8           0.000000016    0.000000000   -0.065450764
+      3        8          -0.064960066    0.000000000    0.007999527
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.065450764 RMS     0.042279569
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.065451(     1)
+      3  O        1  -0.065451(     2)      2   0.000000(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.065450764 RMS     0.053440325
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   3 out of a maximum of   20 on scan point    18 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Update second derivatives using D2CorN and points    2    3
+ DE= -3.95D-07 DEPred=-4.02D-07 R= 9.82D-01
+ Trust test= 9.82D-01 RLast= 3.99D-03 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.00645   0.04942
+ ITU=  0  1  0
+     Eigenvalues ---    0.049421000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 4.94167324D-02
+ Quartic linear search produced a step of  0.00042.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        5.10226  -0.13090   0.00000   0.00000   0.00000   5.10226
+   ASO        1.69332   0.00000   0.00000   0.00000   0.00000   1.69332
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000000     0.000450     YES
+ RMS     Force            0.000000     0.000300     YES
+ Maximum Displacement     0.000002     0.001800     YES
+ RMS     Displacement     0.000001     0.001200     YES
+ Predicted change in Energy=-7.007006D-14
+ Optimization completed.
+    -- Stationary point found.
+                       ----------------------------
+                       !   Optimized Parameters   !
+                       ! (Angstroms and Degrees)  !
+ ----------------------                            ----------------------
+ !      Name          Value   Derivative information (Atomic Units)     !
+ ------------------------------------------------------------------------
+ !       DSO         2.7      -DE/DX =   -0.1309                        !
+ !       ASO        97.0203   -DE/DX =    0.0                           !
+ ------------------------------------------------------------------------
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   2.800000(     1)
+      3      3  O        1   2.800000(     2)      2   97.020(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    2.800000
+      3          8           0        2.779008    0.000000   -0.342221
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    2.800000   0.000000
+     3  O    2.800000   4.194811   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.927482
+      2          8           0        0.000000    2.097405   -0.927482
+      3          8           0        0.000000   -2.097405   -0.927482
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      9.1851236      3.5912075      2.5817807
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        56.4555439946 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  1.76D-01  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (A1) (B1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A1) (B2) (A2)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ ExpMin= 1.17D-01 ExpMax= 2.19D+04 ExpMxC= 3.30D+03 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(RB3LYP) =  -548.061915582     A.U. after   17 cycles
+            NFock= 17  Conv=0.76D-08     -V/T= 2.0043
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.057324828    0.000000000    0.050698581
+      2        8           0.000144243    0.000000000   -0.057920945
+      3        8          -0.057469071    0.000000000    0.007222364
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.057920945 RMS     0.037366347
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.057921(     1)
+      3  O        1  -0.057921(     2)      2  -0.000763(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.057920945 RMS     0.047294306
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20 on scan point    19 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.00645   0.04942
+ ITU=  0
+     Eigenvalues ---    0.049421000.00000
+ RFO step:  Lambda=-1.17876681D-05 EMin= 4.94167324D-02
+ Linear search not attempted -- first point.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        5.29123  -0.11584   0.00000   0.00000   0.00000   5.29123
+   ASO        1.69332  -0.00076   0.00000  -0.01544  -0.01544   1.67788
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000763     0.000450     NO 
+ RMS     Force            0.000763     0.000300     NO 
+ Maximum Displacement     0.015441     0.001800     NO 
+ RMS     Displacement     0.010918     0.001200     NO 
+ Predicted change in Energy=-5.893834D-06
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   2.800000(     1)
+      3      3  O        1   2.800000(     2)      2   96.136(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    2.800000
+      3          8           0        2.783961    0.000000   -0.299272
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    2.800000   0.000000
+     3  O    2.800000   4.166044   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.935551
+      2          8           0        0.000000    2.083022   -0.935551
+      3          8           0        0.000000   -2.083022   -0.935551
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      9.0273708      3.6409743      2.5945319
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        56.5112934769 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  1.75D-01  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (A1) (B1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A1) (B2) (A2)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RB3LYP) =  -548.061922603     A.U. after   12 cycles
+            NFock= 12  Conv=0.86D-08     -V/T= 2.0043
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.057533075    0.000000000    0.051679826
+      2        8           0.000027444    0.000000000   -0.057895097
+      3        8          -0.057560519    0.000000000    0.006215270
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.057895097 RMS     0.037541895
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.057895(     1)
+      3  O        1  -0.057895(     2)      2  -0.000145(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.057895097 RMS     0.047271223
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20 on scan point    19 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Update second derivatives using D2CorN and points    1    2
+ DE= -7.02D-06 DEPred=-5.89D-06 R= 1.19D+00
+ TightC=F SS=  1.41D+00  RLast= 1.54D-02 DXNew= 5.0454D-01 4.6323D-02
+ Trust test= 1.19D+00 RLast= 1.54D-02 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.00490   0.04002
+ ITU=  1  0
+     Eigenvalues ---    0.040021000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 4.00241822D-02
+ Quartic linear search produced a step of  0.23370.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        5.29123  -0.11579   0.00000   0.00000   0.00000   5.29123
+   ASO        1.67788  -0.00015  -0.00361   0.00000  -0.00361   1.67428
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000145     0.000450     YES
+ RMS     Force            0.000145     0.000300     YES
+ Maximum Displacement     0.003609     0.001800     NO 
+ RMS     Displacement     0.002552     0.001200     NO 
+ Predicted change in Energy=-2.634135D-07
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   2.800000(     1)
+      3      3  O        1   2.800000(     2)      2   95.929(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    2.800000
+      3          8           0        2.785022    0.000000   -0.289224
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    2.800000   0.000000
+     3  O    2.800000   4.159285   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.937428
+      2          8           0        0.000000    2.079643   -0.937428
+      3          8           0        0.000000   -2.079643   -0.937428
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      8.9912438      3.6528169      2.5975332
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        56.5245035106 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  1.75D-01  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (A1) (B1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A1) (B2) (A2)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RB3LYP) =  -548.061922865     A.U. after   11 cycles
+            NFock= 11  Conv=0.81D-08     -V/T= 2.0043
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.057578571    0.000000000    0.051908710
+      2        8           0.000000005    0.000000000   -0.057888228
+      3        8          -0.057578575    0.000000000    0.005979518
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.057888228 RMS     0.037582354
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.057888(     1)
+      3  O        1  -0.057888(     2)      2   0.000000(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.057888228 RMS     0.047265541
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   3 out of a maximum of   20 on scan point    19 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Update second derivatives using D2CorN and points    2    3
+ DE= -2.62D-07 DEPred=-2.63D-07 R= 9.95D-01
+ Trust test= 9.95D-01 RLast= 3.61D-03 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.00435   0.04023
+ ITU=  0  1  0
+     Eigenvalues ---    0.040231000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 4.02343974D-02
+ Quartic linear search produced a step of  0.00017.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        5.29123  -0.11578   0.00000   0.00000   0.00000   5.29123
+   ASO        1.67428   0.00000   0.00000   0.00000   0.00000   1.67427
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000000     0.000450     YES
+ RMS     Force            0.000000     0.000300     YES
+ Maximum Displacement     0.000001     0.001800     YES
+ RMS     Displacement     0.000000     0.001200     YES
+ Predicted change in Energy=-7.151209D-15
+ Optimization completed.
+    -- Stationary point found.
+                       ----------------------------
+                       !   Optimized Parameters   !
+                       ! (Angstroms and Degrees)  !
+ ----------------------                            ----------------------
+ !      Name          Value   Derivative information (Atomic Units)     !
+ ------------------------------------------------------------------------
+ !       DSO         2.8      -DE/DX =   -0.1158                        !
+ !       ASO        95.9289   -DE/DX =    0.0                           !
+ ------------------------------------------------------------------------
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   2.900000(     1)
+      3      3  O        1   2.900000(     2)      2   95.929(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    2.900000
+      3          8           0        2.884487    0.000000   -0.299553
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    2.900000   0.000000
+     3  O    2.900000   4.307831   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.970908
+      2          8           0        0.000000    2.153915   -0.970908
+      3          8           0        0.000000   -2.153915   -0.970908
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      8.3818492      3.4052419      2.4214816
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        54.5753826999 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  1.87D-01  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (A1) (B1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A1) (B2) (A2)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ ExpMin= 1.17D-01 ExpMax= 2.19D+04 ExpMxC= 3.30D+03 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(RB3LYP) =  -548.041373196     A.U. after   20 cycles
+            NFock= 20  Conv=0.48D-08     -V/T= 2.0042
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.050562695    0.000000000    0.045583699
+      2        8           0.000110802    0.000000000   -0.050957521
+      3        8          -0.050673497    0.000000000    0.005373822
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.050957521 RMS     0.033045125
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.050958(     1)
+      3  O        1  -0.050958(     2)      2  -0.000607(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.050957521 RMS     0.041608119
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20 on scan point    20 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.00435   0.04023
+ ITU=  0
+     Eigenvalues ---    0.040231000.00000
+ RFO step:  Lambda=-9.16416643D-06 EMin= 4.02343974D-02
+ Linear search not attempted -- first point.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        5.48021  -0.10192   0.00000   0.00000   0.00000   5.48021
+   ASO        1.67428  -0.00061   0.00000  -0.01509  -0.01509   1.65919
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000607     0.000450     NO 
+ RMS     Force            0.000607     0.000300     NO 
+ Maximum Displacement     0.015089     0.001800     NO 
+ RMS     Displacement     0.010669     0.001200     NO 
+ Predicted change in Energy=-4.582083D-06
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   2.900000(     1)
+      3      3  O        1   2.900000(     2)      2   95.064(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    2.900000
+      3          8           0        2.888679    0.000000   -0.255998
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    2.900000   0.000000
+     3  O    2.900000   4.278409   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.979005
+      2          8           0        0.000000    2.139205   -0.979005
+      3          8           0        0.000000   -2.139205   -0.979005
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      8.2437729      3.4522370      2.4332621
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        54.6294464564 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  1.87D-01  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (B1) (A1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A1) (B2) (A2)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RB3LYP) =  -548.041378744     A.U. after   14 cycles
+            NFock= 14  Conv=0.17D-08     -V/T= 2.0042
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.050712460    0.000000000    0.046417020
+      2        8           0.000023385    0.000000000   -0.050936759
+      3        8          -0.050735845    0.000000000    0.004519739
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.050936759 RMS     0.033192036
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.050937(     1)
+      3  O        1  -0.050937(     2)      2  -0.000128(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.050936759 RMS     0.041589755
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20 on scan point    20 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Update second derivatives using D2CorN and points    1    2
+ DE= -5.55D-06 DEPred=-4.58D-06 R= 1.21D+00
+ TightC=F SS=  1.41D+00  RLast= 1.51D-02 DXNew= 5.0454D-01 4.5266D-02
+ Trust test= 1.21D+00 RLast= 1.51D-02 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.00355   0.03175
+ ITU=  1  0
+     Eigenvalues ---    0.031751000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 3.17500766D-02
+ Quartic linear search produced a step of  0.26744.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        5.48021  -0.10187   0.00000   0.00000   0.00000   5.48021
+   ASO        1.65919  -0.00013  -0.00404   0.00000  -0.00404   1.65515
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000128     0.000450     YES
+ RMS     Force            0.000128     0.000300     YES
+ Maximum Displacement     0.004035     0.001800     NO 
+ RMS     Displacement     0.002853     0.001200     NO 
+ Predicted change in Energy=-2.586394D-07
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   2.900000(     1)
+      3      3  O        1   2.900000(     2)      2   94.833(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    2.900000
+      3          8           0        2.889688    0.000000   -0.244339
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    2.900000   0.000000
+     3  O    2.900000   4.270500   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.981161
+      2          8           0        0.000000    2.135250   -0.981161
+      3          8           0        0.000000   -2.135250   -0.981161
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      8.2075821      3.4650372      2.4364349
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        54.6441080897 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  1.86D-01  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (B1) (A1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A1) (B2) (A2)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RB3LYP) =  -548.041379003     A.U. after   12 cycles
+            NFock= 12  Conv=0.19D-08     -V/T= 2.0042
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.050749295    0.000000000    0.046639258
+      2        8          -0.000000002    0.000000000   -0.050930389
+      3        8          -0.050749293    0.000000000    0.004291131
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.050930389 RMS     0.033230709
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.050930(     1)
+      3  O        1  -0.050930(     2)      2   0.000000(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.050930389 RMS     0.041584488
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   3 out of a maximum of   20 on scan point    20 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Update second derivatives using D2CorN and points    2    3
+ DE= -2.59D-07 DEPred=-2.59D-07 R= 1.00D+00
+ Trust test= 1.00D+00 RLast= 4.04D-03 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.00335   0.03176
+ ITU=  0  1  0
+     Eigenvalues ---    0.031761000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 3.17612756D-02
+ Quartic linear search produced a step of -0.00007.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        5.48021  -0.10186   0.00000   0.00000   0.00000   5.48021
+   ASO        1.65515   0.00000   0.00000   0.00000   0.00000   1.65515
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000000     0.000450     YES
+ RMS     Force            0.000000     0.000300     YES
+ Maximum Displacement     0.000000     0.001800     YES
+ RMS     Displacement     0.000000     0.001200     YES
+ Predicted change in Energy=-1.441566D-15
+ Optimization completed.
+    -- Stationary point found.
+                       ----------------------------
+                       !   Optimized Parameters   !
+                       ! (Angstroms and Degrees)  !
+ ----------------------                            ----------------------
+ !      Name          Value   Derivative information (Atomic Units)     !
+ ------------------------------------------------------------------------
+ !       DSO         2.9      -DE/DX =   -0.1019                        !
+ !       ASO        94.8332   -DE/DX =    0.0                           !
+ ------------------------------------------------------------------------
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   3.000000(     1)
+      3      3  O        1   3.000000(     2)      2   94.833(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    3.000000
+      3          8           0        2.989333    0.000000   -0.252765
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    3.000000   0.000000
+     3  O    3.000000   4.417758   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    1.014994
+      2          8           0        0.000000    2.208879   -1.014994
+      3          8           0        0.000000   -2.208879   -1.014994
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      7.6695295      3.2378847      2.2767131
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        52.8226378201 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  1.97D-01  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B2) (A1) (B1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A1) (B2) (A2)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ ExpMin= 1.17D-01 ExpMax= 2.19D+04 ExpMxC= 3.30D+03 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Problem detected with inexpensive integrals.
+ Switching to full accuracy and repeating last cycle.
+ SCF Done:  E(RB3LYP) =  -548.023358598     A.U. after   18 cycles
+            NFock= 18  Conv=0.85D-08     -V/T= 2.0041
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.044234573    0.000000000    0.040652145
+      2        8           0.000071039    0.000000000   -0.044469722
+      3        8          -0.044305613    0.000000000    0.003817577
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.044469722 RMS     0.028991219
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.044470(     1)
+      3  O        1  -0.044470(     2)      2  -0.000403(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.044469722 RMS     0.036310120
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20 on scan point    21 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.00335   0.03176
+ ITU=  0
+     Eigenvalues ---    0.031761000.00000
+ RFO step:  Lambda=-5.10669450D-06 EMin= 3.17612756D-02
+ Linear search not attempted -- first point.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        5.66918  -0.08894   0.00000   0.00000   0.00000   5.66918
+   ASO        1.65515  -0.00040   0.00000  -0.01268  -0.01268   1.64247
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000403     0.000450     YES
+ RMS     Force            0.000403     0.000300     NO 
+ Maximum Displacement     0.012678     0.001800     NO 
+ RMS     Displacement     0.008965     0.001200     NO 
+ Predicted change in Energy=-2.553347D-06
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   3.000000(     1)
+      3      3  O        1   3.000000(     2)      2   94.107(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    3.000000
+      3          8           0        2.992297    0.000000   -0.214846
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    3.000000   0.000000
+     3  O    3.000000   4.391933   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    1.021975
+      2          8           0        0.000000    2.195967   -1.021975
+      3          8           0        0.000000   -2.195967   -1.021975
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      7.5651137      3.2760746      2.2860849
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        52.8677153860 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  1.97D-01  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1) (B2) (A1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A1) (B2) (A2)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RB3LYP) =  -548.023361770     A.U. after   13 cycles
+            NFock= 13  Conv=0.19D-08     -V/T= 2.0041
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.044329464    0.000000000    0.041260732
+      2        8           0.000017220    0.000000000   -0.044462082
+      3        8          -0.044346684    0.000000000    0.003201349
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.044462082 RMS     0.029100026
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.044462(     1)
+      3  O        1  -0.044462(     2)      2  -0.000098(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.044462082 RMS     0.036303181
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20 on scan point    21 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Update second derivatives using D2CorN and points    1    2
+ DE= -3.17D-06 DEPred=-2.55D-06 R= 1.24D+00
+ TightC=F SS=  1.41D+00  RLast= 1.27D-02 DXNew= 5.0454D-01 3.8034D-02
+ Trust test= 1.24D+00 RLast= 1.27D-02 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.00228   0.02407
+ ITU=  1  0
+     Eigenvalues ---    0.024071000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 2.40662790D-02
+ Quartic linear search produced a step of  0.31997.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        5.66918  -0.08892   0.00000   0.00000   0.00000   5.66918
+   ASO        1.64247  -0.00010  -0.00406   0.00000  -0.00406   1.63842
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000098     0.000450     YES
+ RMS     Force            0.000098     0.000300     YES
+ Maximum Displacement     0.004057     0.001800     NO 
+ RMS     Displacement     0.002868     0.001200     NO 
+ Predicted change in Energy=-1.979960D-07
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   3.000000(     1)
+      3      3  O        1   3.000000(     2)      2   93.874(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    3.000000
+      3          8           0        2.993144    0.000000   -0.202706
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    3.000000   0.000000
+     3  O    3.000000   4.383633   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    1.024200
+      2          8           0        0.000000    2.191816   -1.024200
+      3          8           0        0.000000   -2.191816   -1.024200
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      7.5322813      3.2884928      2.2891018
+ Standard basis: 6-31G(d) (5D, 7F)
+ There are    21 symmetry adapted cartesian basis functions of A1  symmetry.
+ There are     5 symmetry adapted cartesian basis functions of A2  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1  symmetry.
+ There are    15 symmetry adapted cartesian basis functions of B2  symmetry.
+ There are    19 symmetry adapted basis functions of A1  symmetry.
+ There are     5 symmetry adapted basis functions of A2  symmetry.
+ There are     8 symmetry adapted basis functions of B1  symmetry.
+ There are    14 symmetry adapted basis functions of B2  symmetry.
+    46 basis functions,   108 primitive gaussians,    49 cartesian basis functions
+    16 alpha electrons       16 beta electrons
+       nuclear repulsion energy        52.8823167122 Hartrees.
+ NAtoms=    3 NActive=    3 NUniq=    2 SFac= 2.25D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    46 RedAO= T EigKep=  1.97D-01  NBF=    19     5     8    14
+ NBsUse=    46 1.00D-06 EigRej= -1.00D+00 NBFU=    19     5     8    14
+ Initial guess from the checkpoint file:  "/scratch/320660/Gau-10445.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1) (B2) (A1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A1) (B2) (A2)
+       Virtual   (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1) (A1)
+                 (A1) (A2) (A2) (A2) (A2) (B1) (B1) (B1) (B1) (B1)
+                 (B1) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2) (B2)
+ Keep R1 ints in memory in symmetry-blocked form, NReq=1483476.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(RB3LYP) =  -548.023361968     A.U. after   12 cycles
+            NFock= 12  Conv=0.38D-08     -V/T= 2.0041
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1       16           0.044357370    0.000000000    0.041454937
+      2        8          -0.000000005    0.000000000   -0.044458970
+      3        8          -0.044357365    0.000000000    0.003004033
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.044458970 RMS     0.029134340
+ -----------------------------------------------------------------------------------------------
+                       Internal Coordinate Forces (Hartree/Bohr or radian)
+  Cent   Atom   N1       Length/X         N2         Alpha/Y        N3         Beta/Z          J
+ -----------------------------------------------------------------------------------------------
+      1  S 
+      2  O        1  -0.044459(     1)
+      3  O        1  -0.044459(     2)      2   0.000000(     3)
+ -----------------------------------------------------------------------------------------------
+ Internal  Forces:  Max     0.044458970 RMS     0.036300597
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   3 out of a maximum of   20 on scan point    21 out of    21
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Update second derivatives using D2CorN and points    1    3
+ DE= -1.98D-07 DEPred=-1.98D-07 R= 1.00D+00
+ Trust test= 1.00D+00 RLast= 4.06D-03 DXMaxT set to 3.00D-01
+ The second derivative matrix:
+                          DSO       ASO
+           DSO         35.18033
+           ASO          0.00178   0.02407
+ ITU=  0  1  0
+     Eigenvalues ---    0.024071000.00000
+ RFO step:  Lambda= 0.00000000D+00 EMin= 2.40676636D-02
+ Quartic linear search produced a step of -0.00028.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+   DSO        5.66918  -0.08892   0.00000   0.00000   0.00000   5.66918
+   ASO        1.63842   0.00000   0.00000   0.00000   0.00000   1.63842
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000000     0.000450     YES
+ RMS     Force            0.000000     0.000300     YES
+ Maximum Displacement     0.000001     0.001800     YES
+ RMS     Displacement     0.000001     0.001200     YES
+ Predicted change in Energy=-1.578206D-14
+ Optimization completed.
+    -- Stationary point found.
+                       ----------------------------
+                       !   Optimized Parameters   !
+                       ! (Angstroms and Degrees)  !
+ ----------------------                            ----------------------
+ !      Name          Value   Derivative information (Atomic Units)     !
+ ------------------------------------------------------------------------
+ !       DSO         3.0      -DE/DX =   -0.0889                        !
+ !       ASO        93.8744   -DE/DX =    0.0                           !
+ ------------------------------------------------------------------------
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Summary of Optimized Potential Surface Scan
+                           1         2         3         4         5
+     Eigenvalues --  -547.06711-547.87349-548.29430-548.49511-548.57148
+           DSO          1.00000   1.10000   1.20000   1.30000   1.40000
+           ASO        130.89483 127.14863 124.01095 121.61929 119.86867
+                           6         7         8         9        10
+     Eigenvalues --  -548.57916-548.55066-548.50467-548.45167-548.39754
+           DSO          1.50000   1.60000   1.70000   1.80000   1.90000
+           ASO        118.54771 117.35469 116.09926 114.66132 112.97596
+                          11        12        13        14        15
+     Eigenvalues --  -548.34531-548.29644-548.25154-548.21076-548.17396
+           DSO          2.00000   2.10000   2.20000   2.30000   2.40000
+           ASO        111.13333 109.12888 106.98783 104.77389 102.58051
+                          16        17        18        19        20
+     Eigenvalues --  -548.14094-548.11147-548.08521-548.06192-548.04138
+           DSO          2.50000   2.60000   2.70000   2.80000   2.90000
+           ASO        100.49054  98.52509  97.02035  95.92889  94.83318
+                          21
+     Eigenvalues --  -548.02336
+           DSO          3.00000
+           ASO         93.87436
+ ---------------------------------------------------------------------------------------------------
+                            Z-MATRIX (ANGSTROMS AND DEGREES)
+   CD    Cent   Atom    N1       Length/X        N2       Alpha/Y        N3        Beta/Z          J
+ ---------------------------------------------------------------------------------------------------
+      1      1  S 
+      2      2  O        1   3.000000(     1)
+      3      3  O        1   3.000000(     2)      2   93.874(     3)
+ ---------------------------------------------------------------------------------------------------
+                         Z-Matrix orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    0.000000
+      2          8           0        0.000000    0.000000    3.000000
+      3          8           0        2.993144    0.000000   -0.202706
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3
+     1  S    0.000000
+     2  O    3.000000   0.000000
+     3  O    3.000000   4.383633   0.000000
+ Stoichiometry    O2S
+ Framework group  C2V[C2(S),SGV(O2)]
+ Deg. of freedom     2
+ Full point group                 C2V     NOp   4
+ Largest Abelian subgroup         C2V     NOp   4
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1         16           0        0.000000    0.000000    1.024200
+      2          8           0        0.000000    2.191816   -1.024200
+      3          8           0        0.000000   -2.191816   -1.024200
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      7.5322813      3.2884928      2.2891018
+
+ **********************************************************************
+
+            Population analysis using the SCF density.
+
+ **********************************************************************
+
+ Orbital symmetries:
+       Occupied  (A1) (A1) (B2) (A1) (B1) (B2) (A1) (A1) (B2) (A1)
+                 (B2) (A1) (B1) (A1) (B2) (A2)
+       Virtual   (B1) (A1) (B2) (A1) (B1) (B2) (A1) (B2) (A1) (A2)
+                 (B1) (A1) (A2) (A1) (B1) (B2) (B2) (A1) (B2) (A1)
+                 (A2) (B1) (B2) (A1) (B2) (A1) (A2) (B1) (B2) (A1)
+ The electronic state is 1-A1.
+ Alpha  occ. eigenvalues --  -89.01810 -19.27265 -19.27264  -8.08167  -6.04302
+ Alpha  occ. eigenvalues --   -6.04183  -6.04138  -0.92144  -0.92114  -0.74434
+ Alpha  occ. eigenvalues --   -0.34833  -0.34679  -0.33601  -0.33284  -0.33215
+ Alpha  occ. eigenvalues --   -0.32124
+ Alpha virt. eigenvalues --   -0.28734  -0.25661  -0.25490   0.23488   0.30843
+ Alpha virt. eigenvalues --    0.33423   0.33650   0.65694   0.66760   0.67434
+ Alpha virt. eigenvalues --    0.67488   0.67740   0.85529   0.86500   0.86649
+ Alpha virt. eigenvalues --    0.86672   0.89778   0.90002   1.04273   1.10718
+ Alpha virt. eigenvalues --    1.75202   1.75529   1.75729   1.76261   1.76883
+ Alpha virt. eigenvalues --    1.77171   1.78163   1.78172   1.78526   1.78717
+          Condensed to atoms (all electrons):
+               1          2          3
+     1  S   15.674450   0.076634   0.076634
+     2  O    0.076634   8.009563  -0.000056
+     3  O    0.076634  -0.000056   8.009563
+ Mulliken charges:
+               1
+     1  S    0.172282
+     2  O   -0.086141
+     3  O   -0.086141
+ Sum of Mulliken charges =   0.00000
+ Mulliken charges with hydrogens summed into heavy atoms:
+               1
+     1  S    0.172282
+     2  O   -0.086141
+     3  O   -0.086141
+ Electronic spatial extent (au):  <R**2>=            447.0435
+ Charge=              0.0000 electrons
+ Dipole moment (field-independent basis, Debye):
+    X=              0.0000    Y=              0.0000    Z=              2.0537  Tot=              2.0537
+ Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=            -22.5830   YY=            -26.3567   ZZ=            -21.9193
+   XY=              0.0000   XZ=              0.0000   YZ=              0.0000
+ Traceless Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=              1.0367   YY=             -2.7370   ZZ=              1.7004
+   XY=              0.0000   XZ=              0.0000   YZ=              0.0000
+ Octapole moment (field-independent basis, Debye-Ang**2):
+  XXX=              0.0000  YYY=              0.0000  ZZZ=             -3.9820  XYY=              0.0000
+  XXY=              0.0000  XXZ=             -1.5807  XZZ=              0.0000  YZZ=              0.0000
+  YYZ=             -5.1701  XYZ=              0.0000
+ Hexadecapole moment (field-independent basis, Debye-Ang**3):
+ XXXX=            -22.3527 YYYY=           -327.1926 ZZZZ=           -162.7508 XXXY=              0.0000
+ XXXZ=              0.0000 YYYX=              0.0000 YYYZ=              0.0000 ZZZX=              0.0000
+ ZZZY=              0.0000 XXYY=            -57.4309 XXZZ=            -30.7104 YYZZ=            -70.9731
+ XXYZ=              0.0000 YYXZ=              0.0000 ZZXY=              0.0000
+ N-N= 5.288231671217D+01 E-N=-1.406486575718D+03  KE= 5.458114735119D+02
+ Symmetry A1   KE= 3.932825636694D+02
+ Symmetry A2   KE= 4.942008435996D+00
+ Symmetry B1   KE= 3.919123008702D+01
+ Symmetry B2   KE= 1.083956713195D+02
+ 1\1\GINC-DNAS-NODE18\Scan\RB3LYP\6-31G(d)\O2S1\GVALLVER\18-Sep-2015\1\
+ \# B3LYP/6-31G* 5d opt=z-matrix\\SO2 molecule\\0,1\S\O,1,DSO\O,1,DSO,2
+ ,ASO\\DSO=3.,s,20,0.1\ASO=93.87435707\\Version=EM64L-G09RevD.01\State=
+ 1-A1\HF=-547.0671099,-547.8734923,-548.2942975,-548.4951109,-548.57147
+ 64,-548.5791629,-548.5506641,-548.5046749,-548.451675,-548.3975436,-54
+ 8.3453096,-548.296436,-548.2515379,-548.2107596,-548.1739622,-548.1409
+ 444,-548.1114673,-548.0852133,-548.0619229,-548.041379,-548.023362\RMS
+ D=1.774e-09,4.063e-09,5.849e-09,3.251e-09,3.882e-09,5.646e-09,1.202e-0
+ 9,2.247e-09,3.890e-09,5.941e-09,8.482e-09,3.549e-09,2.856e-09,6.537e-0
+ 9,2.411e-09,4.106e-09,6.919e-09,4.644e-09,8.078e-09,1.880e-09,3.822e-0
+ 9\PG=C02V [C2(S1),SGV(O2)]\\@
+
+
+ DON'T WORRY CHARLIE BROWN...WE LEARN MORE FROM LOSING  THAN WE DO FROM WINNING.
+ THEN THAT MAKES ME THE SMARTEST PERSON IN THE WORLD...
+ CHARLES SCHULZ 'PEANUTS'
+ Job cpu time:       0 days  0 hours  1 minutes 46.4 seconds.
+ File lengths (MBytes):  RWF=      5 Int=      0 D2E=      0 Chk=      1 Scr=      1
+ Normal termination of Gaussian 09 at Fri Sep 18 17:41:19 2015.
+ Fin  execution du job  : ven. sept. 18 17:41:19 CEST 2015


### PR DESCRIPTION
## Summary

Improve parsing of structures if multiple optimization, for example in the case of relaxed scan.

*  In case of scan the attribute `opt_structures` store optimized structure contrary to the old `structures` attribute who store all structures
* Fix a bug in read_scan() function linked to a change between g09 and g16.