### PR TITLE
[WIP] Edge Case of VoronoiNN() not finding neighbours when called by StructureGraph.with_local_env_strategy()

### DIFF
--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -783,8 +783,6 @@ class VoronoiNN(NearNeighbors):
             sites.extend([x[0] for x in neighs])
             indices.extend([(x[2],) + x[3] for x in neighs])
 
-        ## The bug is probaly somewhere here
-
         # Get the non-duplicates (using the site indices for performance/numerical stability)
         indices = np.array(indices, dtype=np.int)
         indices, uniq_inds = np.unique(indices, return_index=True, axis=0)
@@ -794,8 +792,6 @@ class VoronoiNN(NearNeighbors):
         #   Exploit the fact that the array is sorted by the unique operation such that
         #   the images associated with atom 0 are first, followed by atom 1, etc.
         root_images, = np.nonzero(np.abs(indices[:, 1:]).max(axis=1) == 0)
-
-        ## End of section
 
         del indices  # Save memory (tessellations can be costly)
 

--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -783,6 +783,8 @@ class VoronoiNN(NearNeighbors):
             sites.extend([x[0] for x in neighs])
             indices.extend([(x[2],) + x[3] for x in neighs])
 
+        ## The bug is probaly somewhere here
+
         # Get the non-duplicates (using the site indices for performance/numerical stability)
         indices = np.array(indices, dtype=np.int)
         indices, uniq_inds = np.unique(indices, return_index=True, axis=0)
@@ -792,6 +794,8 @@ class VoronoiNN(NearNeighbors):
         #   Exploit the fact that the array is sorted by the unique operation such that
         #   the images associated with atom 0 are first, followed by atom 1, etc.
         root_images, = np.nonzero(np.abs(indices[:, 1:]).max(axis=1) == 0)
+
+        ## End of section
 
         del indices  # Save memory (tessellations can be costly)
 

--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -767,7 +767,7 @@ class VoronoiNN(NearNeighbors):
             targets = self.targets
 
         # Initialize the list of sites with the atoms in the origin unit cell
-        #  The `get_all_neighbors` function returns neighbors for each site's image in the
+        #   The `get_all_neighbors` function returns neighbors for each site's image in the
         #   original unit cell. We start off with these central atoms to ensure they are
         #   included in the tessellation
 
@@ -789,8 +789,8 @@ class VoronoiNN(NearNeighbors):
         sites = np.array(sites)[uniq_inds]
 
         # Sort array such that atoms in the root image are first
-        #   Exploit the fact that the array is sorted by the unique operation such that
-        #   the images associated with atom 0 are first, followed by atom 1, etc.
+        # Exploit the fact that the array is sorted by the unique operation such that
+        # the images associated with atom 0 are first, followed by atom 1, etc.
         root_images, = np.nonzero(np.abs(indices[:, 1:]).max(axis=1) == 0)
 
         del indices  # Save memory (tessellations can be costly)
@@ -925,9 +925,8 @@ class VoronoiNN(NearNeighbors):
                     results[other_site]['verts'] = vind
 
         # all sites should have atleast two connected ridges in periodic system
-        if not bool(results): 
-            raise ValueError("results is empty dictionary - unphysical result,"
-                                "all sites should have connected ridges.") 
+        if not bool(results):
+            raise ValueError("No Voronoi neighbours found for site - try increasing cutoff")
 
         # Get only target elements
         resultweighted = {}

--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -925,7 +925,7 @@ class VoronoiNN(NearNeighbors):
                     results[other_site]['verts'] = vind
 
         # all sites should have atleast two connected ridges in periodic system
-        if not bool(results):
+        if not results:
             raise ValueError("No Voronoi neighbours found for site - try increasing cutoff")
 
         # Get only target elements

--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -1015,6 +1015,8 @@ class VoronoiNN(NearNeighbors):
         else:
             targets = self.targets
 
+        assert len(nns.values()) > 1, "Failed to find Voronoi neighbours [fix WIP]"
+
         # Extract the NN info
         siw = []
         max_weight = max(nn[self.weight] for nn in nns.values())

--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -962,6 +962,8 @@ class VoronoiNN(NearNeighbors):
             for key, neighbors in adj_neighbors.items():
                 resultweighted[key]['adj_neighbors'] = neighbors
 
+        assert len(resultweighted) > 0, "Failed to find Voronoi neighbours [fix WIP]"
+
         return resultweighted
 
     def get_nn_info(self, structure, n):
@@ -1014,8 +1016,6 @@ class VoronoiNN(NearNeighbors):
             targets = structure.composition.elements
         else:
             targets = self.targets
-
-        assert len(nns.values()) > 1, "Failed to find Voronoi neighbours [fix WIP]"
 
         # Extract the NN info
         siw = []

--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -767,7 +767,7 @@ class VoronoiNN(NearNeighbors):
             targets = self.targets
 
         # Initialize the list of sites with the atoms in the origin unit cell
-        #   The `get_all_neighbors` function returns neighbors for each site's image in the
+        #  The `get_all_neighbors` function returns neighbors for each site's image in the
         #   original unit cell. We start off with these central atoms to ensure they are
         #   included in the tessellation
 
@@ -789,8 +789,8 @@ class VoronoiNN(NearNeighbors):
         sites = np.array(sites)[uniq_inds]
 
         # Sort array such that atoms in the root image are first
-        # Exploit the fact that the array is sorted by the unique operation such that
-        # the images associated with atom 0 are first, followed by atom 1, etc.
+        #   Exploit the fact that the array is sorted by the unique operation such that
+        #   the images associated with atom 0 are first, followed by atom 1, etc.
         root_images, = np.nonzero(np.abs(indices[:, 1:]).max(axis=1) == 0)
 
         del indices  # Save memory (tessellations can be costly)

--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -870,7 +870,7 @@ class VoronoiNN(NearNeighbors):
         # Iterate through all the faces in the tessellation
         results = {}
         for nn, vind in voro.ridge_dict.items():
-            # Get only those that include the cite in question
+            # Get only those that include the site in question
             if site_idx in nn:
                 other_site = nn[0] if nn[1] == site_idx else nn[1]
                 if -1 in vind:
@@ -924,6 +924,11 @@ class VoronoiNN(NearNeighbors):
                 if compute_adj_neighbors:
                     results[other_site]['verts'] = vind
 
+        # all sites should have atleast two connected ridges in periodic system
+        if not bool(results): 
+            raise ValueError("results is empty dictionary - unphysical result,"
+                                "all sites should have connected ridges.") 
+
         # Get only target elements
         resultweighted = {}
         for nn_index, nstats in results.items():
@@ -961,8 +966,6 @@ class VoronoiNN(NearNeighbors):
             # Store the results in the nn_info
             for key, neighbors in adj_neighbors.items():
                 resultweighted[key]['adj_neighbors'] = neighbors
-
-        assert len(resultweighted) > 0, "Failed to find Voronoi neighbours [fix WIP]"
 
         return resultweighted
 


### PR DESCRIPTION
## Summary
This PR is related to #1825 and aims to track down the source of the bug.

## Minimal Test for Edge Case
### Code
```
from pymatgen.core.structure import Structure
from pymatgen.analysis import local_env
from pymatgen.analysis.graphs import StructureGraph

with open("breaking-oqmd-4866.txt", 'r') as file:
    str_ = file.read()
    crystal = Structure.from_str(str_, fmt="json")

print(crystal)
StructureGraph.with_local_env_strategy(crystal, local_env.VoronoiNN())

```
### Input File
[breaking-oqmd-4866.txt](https://github.com/materialsproject/pymatgen/files/4474164/breaking-oqmd-4866.txt)
