### PR TITLE
SpacegroupOperations Description Fix

### DIFF
--- a/pymatgen/symmetry/analyzer.py
+++ b/pymatgen/symmetry/analyzer.py
@@ -1557,8 +1557,8 @@ class SpacegroupOperations(list):
         symmetrically distinct arrangements of atoms.
 
         Args:
-            sites1 ([Site]): 1st set of sites
-            sites2 ([Site]): 2nd set of sites
+            sites1 ([PeriodicSite]): 1st set of sites
+            sites2 ([PeriodicSite]): 2nd set of sites
             symm_prec (float): Tolerance in atomic distance to test if atoms
                 are symmetrically similar.
 


### PR DESCRIPTION
## Summary

* Fixed description for SpacegroupOperations.are_symmetrically_equivalent(). Input set of sites requires a list of PeriodicSite objects (not a Site objects).

## Additional dependencies introduced (if any)

* None 

## TODO (if any)

* n/a

## Checklist

Work-in-progress pull requests are encouraged, but please put [WIP]
in the pull request title.

Before a pull request can be merged, the following items must be checked:

- [ ] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). 
      Run [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/) and [flake8](http://flake8.pycqa.org/en/latest/)
      on your local machine.
- [ ] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [ ] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) 
      to type check your code.
- [ ] Tests have been added for any new functionality or bug fixes.
- [ ] All existing tests pass.

Note that the CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR. It is
highly recommended that you use the pre-commit hook provided in the pymatgen 
repository. Simply `cp pre-commit .git/hooks` and a check will be run prior to
allowing commits.
