### PR TITLE
KPathLM labels bug fix

### DIFF
--- a/pymatgen/symmetry/kpath.py
+++ b/pymatgen/symmetry/kpath.py
@@ -2195,6 +2195,8 @@ class KPathLatimerMunro(KPathBase):
                         if max_cosine_orbits_copy[grouped_ind][j][0] not in initial_max_cosine_label_inds:
                             next_choices.append(max_cosine_orbits_copy[grouped_ind][j][1])
                             break
+                        else:
+                            j += 1
                 worst_next_choice = next_choices.index(min(next_choices))
                 for grouped_ind in grouped_inds[i]:
                     if grouped_ind != worst_next_choice:

--- a/pymatgen/symmetry/tests/test_kpath_lm.py
+++ b/pymatgen/symmetry/tests/test_kpath_lm.py
@@ -51,6 +51,10 @@ class KPathLatimerMunroTest(PymatgenTest):
             struct = Structure.from_spacegroup(sg_num, lattice, species, coords)
             kpath = KPathLatimerMunro(struct)  # Throws error if something doesn't work, causing test to fail.
 
+        sstruct_file_path = os.path.join(test_dir_structs, "AgO_kpath_test.cif")
+        struct = Structure.from_file(struct_file_path)
+        kpath = KPathLatimerMunro(struct)  # Throws error if something doesn't work, causing test to fail.
+
     def test_kpath_acentered(self):
         species = ["K", "La", "Ti"]
         coords = [[0.345, 5, 0.77298], [0.1345, 5.1, 0.77298], [0.7, 0.8, 0.9]]

--- a/pymatgen/symmetry/tests/test_kpath_lm.py
+++ b/pymatgen/symmetry/tests/test_kpath_lm.py
@@ -51,7 +51,7 @@ class KPathLatimerMunroTest(PymatgenTest):
             struct = Structure.from_spacegroup(sg_num, lattice, species, coords)
             kpath = KPathLatimerMunro(struct)  # Throws error if something doesn't work, causing test to fail.
 
-        sstruct_file_path = os.path.join(test_dir_structs, "AgO_kpath_test.cif")
+        struct_file_path = os.path.join(test_dir_structs, "AgO_kpath_test.cif")
         struct = Structure.from_file(struct_file_path)
         kpath = KPathLatimerMunro(struct)  # Throws error if something doesn't work, causing test to fail.
 

--- a/test_files/AgO_kpath_test.cif
+++ b/test_files/AgO_kpath_test.cif
@@ -1,0 +1,30 @@
+# generated using pymatgen
+data_AgO
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.29851313
+_cell_length_b   3.29851244
+_cell_length_c   5.60909883
+_cell_angle_alpha   89.53511639
+_cell_angle_beta   89.53513249
+_cell_angle_gamma   86.62157169
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   AgO
+_chemical_formula_sum   'Ag2 O2'
+_cell_volume   60.91819306
+_cell_formula_units_Z   2
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  Ag  Ag0  1  0.00000000  0.50000000  0.50000000  1
+  Ag  Ag1  1  0.50000000  0.00000000  0.00000000  1
+  O  O2  1  0.99806500  0.00193500  0.25000000  1
+  O  O3  1  0.00193500  0.99806500  0.75000000  1


### PR DESCRIPTION
## Summary

This PR fixes a small bug in the `KPathLM` class where the code would hang when assigning labels to each of the points in a k-path for some complex cases. 