### PR TITLE
Requirement typing_extensions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ networkx==2.4
 dataclasses>=0.6; python_version < '3.7'
 plotly==4.5.0
 beautifulsoup4==4.8.2
+typing-extensions==3.7.4.2 


### PR DESCRIPTION
## Summary
Hi, 

we are currently working on including a workflow in atomate. Unfortunately, some of the tests fail with the current development version of pymatgen: https://circleci.com/gh/hackingmaterials/atomate/2517?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link
It looks like the requirement "type-extensions" is missing. 
@gpetretto did a short test. He gets the same error in "pymatgen/command_line/tests/test_mcsqs_caller.py" after installing pymatgen in a clean python3.6 environment. The error vanishes when he installs the optional dependencies. 


Best, 
JG