### PR TITLE
Clearer description in generated KPOINTS comment line

### DIFF
--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -1253,7 +1253,7 @@ class Kpoints(MSONable):
         Returns:
             Kpoints
         """
-        comment = "pymatgen v%s with grid density = %.0f / atom" % (__version__, kppa)
+        comment = "pymatgen v%s with grid density = %.0f / number of atoms" % (__version__, kppa)
         if math.fabs((math.floor(kppa ** (1 / 3) + 0.5)) ** 3 - kppa) < 1:
             kppa += kppa * 0.01
         latt = structure.lattice
@@ -1306,10 +1306,8 @@ class Kpoints(MSONable):
 
         style = Kpoints.supported_modes.Gamma
 
-        comment = (
-            "pymatgen 4.7.6+ generated KPOINTS with grid density = "
-            + "{} / atom".format(kppa)
-        )
+        comment = "pymatgen v%s with grid density = %.0f / number of atoms" % (__version__, kppa)
+
         num_kpts = 0
         return Kpoints(comment, num_kpts, style, [num_div], [0, 0, 0])
 


### PR DESCRIPTION
Change k-points / atom to k-points / number of atoms

## Summary
As mentioned in https://github.com/materialsproject/pymatgen/issues/1841, the comment line in the Pymatgen-generated VASP KPOINTS file is somewhat misleading. This PR changes it from being # kpoints/atom to # kpoints/number of atoms in the comment line, which is also consistent with what's on the [Materials Project documentation](https://materialsproject.org/docs/calculations). This should make it clearer that the number of k-points would be higher for smaller systems.

Perhaps worth noting: there is still the very minor ambiguity in that [pymatgen.ext.jhu](https://pymatgen.org/pymatgen.ext.jhu.html) takes `kppra` as an input argument, whereas [`pymatgen.io.vasp.inputs.Kpoints.automatic_density()`](https://github.com/materialsproject/pymatgen/blob/v2020.4.29/pymatgen/io/vasp/inputs.py#L1237) takes `kppa` as an input argument, but obviously the keywords should not be adjusted, and I think the documentation for the latter (which simply states `kppa` = grid density) is accurate without being confusing. Therefore, I did not make any changes to the documentation.