### PR TITLE
Fix labels in plot_thermodynamic_properties

### DIFF
--- a/pymatgen/phonon/plotter.py
+++ b/pymatgen/phonon/plotter.py
@@ -670,9 +670,9 @@ class ThermoPlotter:
         self._plot_thermo(self.dos.entropy, temperatures, ylim=ylim, ax=fig.axes[0],
                           label=r"$S$ (J/K/mol{})".format(mol), **kwargs)
         self._plot_thermo(self.dos.internal_energy, temperatures, ylim=ylim, ax=fig.axes[0], factor=1e-3,
-                          label=r"$\Delta E$ (kJ/K/mol{})".format(mol), **kwargs)
+                          label=r"$\Delta E$ (kJ/mol{})".format(mol), **kwargs)
         self._plot_thermo(self.dos.helmholtz_free_energy, temperatures, ylim=ylim, ax=fig.axes[0], factor=1e-3,
-                          label=r"$\Delta F$ (kJ/K/mol{})".format(mol), **kwargs)
+                          label=r"$\Delta F$ (kJ/mol{})".format(mol), **kwargs)
 
         fig.axes[0].legend(loc="best")
 


### PR DESCRIPTION
The labels seem to be incorrect (see https://github.com/materialsproject/pymatgen/blob/72d336d2d17ac140058fdcb74eb3336125bb12b7/pymatgen/phonon/dos.py#L229-L236 and https://github.com/materialsproject/pymatgen/blob/72d336d2d17ac140058fdcb74eb3336125bb12b7/pymatgen/phonon/dos.py#L263-L270 respecitvely)