### PR TITLE
Add poscar attribute to Elfcar modeled after Chgcar

### DIFF
--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -3364,7 +3364,7 @@ class Chgcar(VolumetricData):
     def __init__(self, poscar, data, data_aug=None):
         """
         Args:
-            poscar (Poscar): Poscar object containing structure, or Structure object.
+            poscar (Poscar or Structure): Object containing structure.
             data: Actual data.
             data_aug: Augmentation charge data
         """
@@ -3416,7 +3416,7 @@ class Elfcar(VolumetricData):
     def __init__(self, poscar, data):
         """
         Args:
-            poscar (Poscar): Poscar object containing structure, or Structure object.
+            poscar (Poscar or Structure): Object containing structure.
             data: Actual data.
         """
         # allow for poscar or structure files to be passed

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -3364,7 +3364,7 @@ class Chgcar(VolumetricData):
     def __init__(self, poscar, data, data_aug=None):
         """
         Args:
-            poscar (Poscar): Poscar object containing structure.
+            poscar (Poscar): Poscar object containing structure, or Structure object.
             data: Actual data.
             data_aug: Augmentation charge data
         """
@@ -3416,7 +3416,7 @@ class Elfcar(VolumetricData):
     def __init__(self, poscar, data):
         """
         Args:
-            poscar (Poscar): Poscar object containing structure.
+            poscar (Poscar): Poscar object containing structure, or Structure object.
             data: Actual data.
         """
         # allow for poscar or structure files to be passed

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -3419,7 +3419,15 @@ class Elfcar(VolumetricData):
             poscar (Poscar): Poscar object containing structure.
             data: Actual data.
         """
-        super().__init__(poscar.structure, data)
+        # allow for poscar or structure files to be passed
+        if isinstance(poscar, Poscar):
+            tmp_struct = poscar.structure
+            self.poscar = poscar
+        elif isinstance(poscar, Structure):
+            tmp_struct = poscar
+            self.poscar = Poscar(poscar)
+
+        super().__init__(tmp_struct, data)
         # TODO: modify VolumetricData so that the correct keys can be used.
         # for ELF, instead of "total" and "diff" keys we have
         # "Spin.up" and "Spin.down" keys

--- a/pymatgen/io/vasp/tests/test_outputs.py
+++ b/pymatgen/io/vasp/tests/test_outputs.py
@@ -1205,6 +1205,9 @@ class ElfcarTest(PymatgenTest):
         elfcar = Elfcar.from_file(self.TEST_FILES_DIR / 'ELFCAR.gz')
         self.assertAlmostEqual(0.19076207645194002, np.mean(elfcar.data["total"]))
         self.assertAlmostEqual(0.19076046677910055, np.mean(elfcar.data["diff"]))
+        reconstituted = Elfcar.from_dict(elfcar.as_dict())
+        self.assertEqual(elfcar.data, reconstituted.data)
+        self.assertEqual(elfcar.poscar.structure, reconstituted.poscar.structure)
 
     def test_alpha(self):
         elfcar = Elfcar.from_file(self.TEST_FILES_DIR / 'ELFCAR.gz')


### PR DESCRIPTION
## Summary
* Add a `poscar` attribute to the `Elfcar` class patterned after the `Chgcar` constructor
* Fixes bug described in #1858 
@rkingsbury @mkhorton 