### PR TITLE
Add "unit" to plot_compare in PhononBSPlotter

### DIFF
--- a/pymatgen/phonon/plotter.py
+++ b/pymatgen/phonon/plotter.py
@@ -670,9 +670,9 @@ class ThermoPlotter:
         self._plot_thermo(self.dos.entropy, temperatures, ylim=ylim, ax=fig.axes[0],
                           label=r"$S$ (J/K/mol{})".format(mol), **kwargs)
         self._plot_thermo(self.dos.internal_energy, temperatures, ylim=ylim, ax=fig.axes[0], factor=1e-3,
-                          label=r"$\Delta E$ (kJ/K/mol{})".format(mol), **kwargs)
+                          label=r"$\Delta E$ (kJ/mol{})".format(mol), **kwargs)
         self._plot_thermo(self.dos.helmholtz_free_energy, temperatures, ylim=ylim, ax=fig.axes[0], factor=1e-3,
-                          label=r"$\Delta F$ (kJ/K/mol{})".format(mol), **kwargs)
+                          label=r"$\Delta F$ (kJ/mol{})".format(mol), **kwargs)
 
         fig.axes[0].legend(loc="best")
 

--- a/pymatgen/phonon/plotter.py
+++ b/pymatgen/phonon/plotter.py
@@ -438,7 +438,7 @@ class PhononBSPlotter:
                 previous_branch = this_branch
         return {'distance': tick_distance, 'label': tick_labels}
 
-    def plot_compare(self, other_plotter):
+    def plot_compare(self, other_plotter, units="thz"):
         """
         plot two band structure for comparison. One is in red the other in blue.
         The two band structures need to be defined on the same symmetry lines!
@@ -453,18 +453,21 @@ class PhononBSPlotter:
 
         """
 
+        u = freq_units(units)
+
         data_orig = self.bs_plot_data()
         data = other_plotter.bs_plot_data()
 
         if len(data_orig['distances']) != len(data['distances']):
             raise ValueError('The two objects are not compatible.')
 
-        plt = self.get_plot()
+        plt = self.get_plot(units=units)
         band_linewidth = 1
         for i in range(other_plotter._nb_bands):
             for d in range(len(data_orig['distances'])):
                 plt.plot(data_orig['distances'][d],
-                         [e[i] for e in data['frequency']][d],
+                         [data['frequency'][d][i][j] * u.factor
+                          for j in range(len(data_orig['distances'][d]))],
                          'r-', linewidth=band_linewidth)
 
         return plt

--- a/pymatgen/phonon/tests/test_plotter.py
+++ b/pymatgen/phonon/tests/test_plotter.py
@@ -72,6 +72,12 @@ class PhononBSPlotterTest(unittest.TestCase):
         rc('text', usetex=False)
         self.plotter.get_plot(units="mev")
 
+    def test_plot_compare(self):
+        # Disabling latex for testing.
+        from matplotlib import rc
+        rc('text', usetex=False)
+        self.plotter.plot_compare(self.plotter, units="mev")
+
 
 class ThermoPlotterTest(unittest.TestCase):
 

--- a/pymatgen/phonon/tests/test_plotter.py
+++ b/pymatgen/phonon/tests/test_plotter.py
@@ -71,12 +71,6 @@ class PhononBSPlotterTest(unittest.TestCase):
         from matplotlib import rc
         rc('text', usetex=False)
         self.plotter.get_plot(units="mev")
-        
-    def test_plot_compare(self):
-        # Disabling latex for testing.
-        from matplotlib import rc
-        rc('text', usetex=False)
-        self.plotter.plot_compare(self.bs, units="mev")
 
     def test_plot_compare(self):
         # Disabling latex for testing.


### PR DESCRIPTION
The frequency unit can only be changed for a single bandstructure plot: https://github.com/materialsproject/pymatgen/blob/604d59c93f21c4a180663bdc6cd64bf1329c5239/pymatgen/phonon/plotter.py#L329 This is missing for plot_compare. I also provided a test (although it is not very useful to compare a bandstructure object with itself). 