### PR TITLE
Add support for *^ scientific notation for XYZ parser (Useful for QM9 Database)

### DIFF
--- a/pymatgen/io/tests/test_xyz.py
+++ b/pymatgen/io/tests/test_xyz.py
@@ -83,6 +83,16 @@ C 1.16730636786 -1.38166622735 -2.77112970359e-06
         self.assertTrue(abs(mol[0].z) < 1e-5)
         self.assertTrue(abs(mol[1].z) < 1e-5)
 
+        mol_str = """2
+Random, Alternate Scientific Notation
+C 2.39132145462 -0.700993488928 -7.222*^-06
+C 1.16730636786 -1.38166622735 -2.771*^-06
+"""
+        xyz = XYZ.from_string(mol_str)
+        mol = xyz.molecule
+        self.assertEqual(mol[0].z, -7.222e-06)
+        self.assertEqual(mol[1].z, -2.771e-06)
+
         mol_str = """3
 Random
 C   0.000000000000E+00  2.232615992397E+01  0.000000000000E+00

--- a/pymatgen/io/xyz.py
+++ b/pymatgen/io/xyz.py
@@ -60,16 +60,18 @@ class XYZ:
         coords = []
         sp = []
         coord_patt = re.compile(
-            r"(\w+)\s+([0-9\-\+\.eEdD]+)\s+([0-9\-\+\.eEdD]+)\s+([0-9\-\+\.eEdD]+)"
-        )
+            r"(\w+)\s+([0-9\-\+\.*^eEdD]+)\s+([0-9\-\+\.*^eEdD]+)\s+(["
+            r"0-9\-\+\.*^eEdD]+)"        )
         for i in range(2, 2 + num_sites):
             m = coord_patt.search(lines[i])
             if m:
                 sp.append(m.group(1))  # this is 1-indexed
                 # this is 0-indexed
                 # in case of 0.0D+00 or 0.00d+01 old double precision writing
-                # replace d or D by e for ten power exponent
-                xyz = [val.lower().replace("d", "e") for val in m.groups()[1:4]]
+                # replace d or D by e for ten power exponent,
+                # and some files use *^ convention in place of e
+                xyz = [val.lower().replace("d", "e").replace('*^', 'e') for val
+                 in m.groups()[1:4]]
                 coords.append([float(val) for val in xyz])
         return Molecule(sp, coords)
 
@@ -89,7 +91,8 @@ class XYZ:
         white_space = r"[ \t\r\f\v]"
         natoms_line = white_space + r"*\d+" + white_space + r"*\n"
         comment_line = r"[^\n]*\n"
-        coord_lines = r"(\s*\w+\s+[0-9\-\+\.eEdD]+\s+[0-9\-\+\.eEdD]+\s+[0-9\-\+\.eEdD]+.*\n)+"
+        coord_lines = r"(\s*\w+\s+[0-9\-\+\.*^eEdD]+\s+[0-9\-\+\.*^eEdD]+" \
+                      r"\s+[0-9\-\+\.*^eEdD]+.*\n)+"
         frame_pattern_text = natoms_line + comment_line + coord_lines
         pat = re.compile(frame_pattern_text, re.MULTILINE)
         mols = []

--- a/pymatgen/io/xyz.py
+++ b/pymatgen/io/xyz.py
@@ -60,8 +60,8 @@ class XYZ:
         coords = []
         sp = []
         coord_patt = re.compile(
-            r"(\w+)\s+([0-9\-\+\.*^eEdD]+)\s+([0-9\-\+\.*^eEdD]+)\s+(["
-            r"0-9\-\+\.*^eEdD]+)"        )
+            r"(\w+)\s+([0-9\-\+\.*^eEdD]+)\s+([0-9\-\+\.*^eEdD]+)\s+"
+            r"([0-9\-\+\.*^eEdD]+)")
         for i in range(2, 2 + num_sites):
             m = coord_patt.search(lines[i])
             if m:
@@ -71,7 +71,7 @@ class XYZ:
                 # replace d or D by e for ten power exponent,
                 # and some files use *^ convention in place of e
                 xyz = [val.lower().replace("d", "e").replace('*^', 'e') for val
-                 in m.groups()[1:4]]
+                       in m.groups()[1:4]]
                 coords.append([float(val) for val in xyz])
         return Molecule(sp, coords)
 


### PR DESCRIPTION
## Summary

The QM9 database uses a special format for scientific notation in their .xyz files, wherein e.g. `3.14e-6` would be represented `3.14*^-6`. This addresses issue #1875 (which was not a bug per se, but simply brushing up against unimplemented behavior).

- The XYZ file parser can now handle this formatting for coordinates.
* This means changing the regular expressions which detect coordinate lines, as well as a substitution from the '*^' notation to 'e' notation.
- This capability is unit tested.

## Checklist

Before a pull request can be merged, the following items must be checked:

- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). 
      Run [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/) and [flake8](http://flake8.pycqa.org/en/latest/)
      on your local machine.
- [N/A] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [N/A] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) 
      to type check your code.
- [X] Tests have been added for any new functionality or bug fixes.
- [X] All existing tests pass.

Note that the CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR. It is
highly recommended that you use the pre-commit hook provided in the pymatgen 
repository. Simply `cp pre-commit .git/hooks` and a check will be run prior to
allowing commits.
