### PR TITLE
change setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -128,6 +128,7 @@ setup(
         "pymatgen.io": ["*.yaml"],
         "pymatgen.io.vasp": ["*.yaml", "*.json"],
         "pymatgen.io.lammps": ["templates/*.*", "*.yaml"],
+        "pymatgen.io.lobster": ["lobster_basis/*.*"],
         "pymatgen.io.feff": ["*.yaml"],
         "pymatgen.symmetry": ["*.yaml", "*.json", "*.sqlite"],
         "pymatgen.entries": ["*.yaml"],

--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ setup(
         "pymatgen.io": ["*.yaml"],
         "pymatgen.io.vasp": ["*.yaml", "*.json"],
         "pymatgen.io.lammps": ["templates/*.*", "*.yaml"],
-        "pymatgen.io.lobster": ["lobster_basis/*.*"],
+        "pymatgen.io.lobster": ["lobster_basis/*.yaml"],
         "pymatgen.io.feff": ["*.yaml"],
         "pymatgen.symmetry": ["*.yaml", "*.json", "*.sqlite"],
         "pymatgen.entries": ["*.yaml"],


### PR DESCRIPTION
## Summary

Hi, 

I forget to change the setup.py to reflect the correct folder structure of the new lobster module. Currently, the basis functions are not found when pymatgen is installed... (Is it maybe possible to check for this within an automatic test in the future?)

Best, 
JG