### PR TITLE
Fix suggest_larger_supercells bug

### DIFF
--- a/pymatgen/analysis/defects/thermodynamics.py
+++ b/pymatgen/analysis/defects/thermodynamics.py
@@ -387,7 +387,7 @@ class DefectPhaseDiagram(MSONable):
                     # consider if transition level is within
                     # tolerance of band edges
                     suggest_bigger_supercell = True
-                    for tl, chgset in self.transition_level_map.items():
+                    for tl, chgset in self.transition_level_map[def_type].items():
                         sorted_chgset = list(chgset)
                         sorted_chgset.sort(reverse=True)
                         if charge == sorted_chgset[0] and tl < tolerance:


### PR DESCRIPTION
## Summary

There's a small bug in the `DefectPhaseDiagram.suggest_larger_supercells()` method (line 390 in `pymatgen/analysis/defects/thermodynamics.py`, where the current code is:
```python
 for tl, chgset in self.transition_level_map.items():
```
which gives the wrong variables of Defect-Name, {Transition-Level: Charge-set}. It should be:
```python
 for tl, chgset in self.transition_level_map[def_type].items():
```
(it's within the `for def_type in self.defect_types:` loop), which gives the correct variables of which gives the wrong variables of Transition-Level, Charge-set.

See below for a quick demonstration of the bug, and the result when fixed:
![image](https://user-images.githubusercontent.com/51478689/85585697-239ae900-b638-11ea-819b-0af9507382f0.png)

