### PR TITLE
parse scientific notation in OUTCAR (possibly without spaces in betwe…

### DIFF
--- a/pymatgen/analysis/costdb_elements.csv
+++ b/pymatgen/analysis/costdb_elements.csv
@@ -1,4 +1,3 @@
-O,3,,|@misc{wikipedia, title = "Wikipedia", month = "August", year = "2013", url = "http://en.wikipedia.org/wiki/Prices_of_elements_and_their_compounds"}|
 Ag,780.88,,|@misc{wolfram_alpha, title = "Wolfram Alpha", month = "September", year = "2013", url = "http://www.wolframalpha.org"}|
 Pd,23036.01,,|@misc{wolfram_alpha, title = "Wolfram Alpha", month = "September", year = "2013", url = "http://www.wolframalpha.org"}|
 C,24,,|@misc{wikipedia, title = "Wikipedia", month = "September", year = "2013", url = "http://en.wikipedia.org/wiki/Prices_of_elements_and_their_compounds"}|
@@ -77,3 +76,9 @@ Y,449.962942,,|@misc{wolfram_alpha, title = "Wolfram Alpha", month = "September"
 Yb,1599.892734,,|@misc{wolfram_alpha, title = "Wolfram Alpha", month = "September", year = "2013", url = "http://www.wolframalpha.org"}|
 Zn,2.33910182,,|@misc{wolfram_alpha, title = "Wolfram Alpha", month = "September", year = "2013", url = "http://www.wolframalpha.org"}|
 Zr,2.64995324,,|@misc{wolfram_alpha, title = "Wolfram Alpha", month = "September", year = "2013", url = "http://www.wolframalpha.org"}|
+He,15.9,,|@misc{wolfram_alpha, title = "Wolfram Alpha", month = "June", year = "2020", url = "http://www.wolframalpha.org"}|
+H,1.4,,|@misc{wikipedia, title = "Wikipedia", month = "June", year = "2020", url = "https://en.wikipedia.org/wiki/Hydrogen_economy#Costs"}|
+Ar,19.56,,|@misc{internet_search, title = "Aqua-Calc", month = "June", year = "2020", url = "https://www.aqua-calc.com/calculate/materials-price/substance/argon"}|
+Ne,660000,,|@misc{internet_search, title = "Pomona College", month = "June", year = "2020", url = "http://www.chemistry.pomona.edu/chemistry/periodic_table/elements/neptunium/the%20facts.htm"}|
+Kr,330,,|@misc{internet_search, title = "Chemicool", month = "June", year = "2020", url = "https://www.chemicool.com/elements/krypton.html"}|
+Tc,60000,,|@misc{internet_search, title = "Radiochemistry.org", month = "June", year = "2020", url = "https://www.radiochemistry.org/periodictable/elements/43.html"}|

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -1951,15 +1951,21 @@ class Outcar:
                     plasma_frequencies[read_plasma].append(
                         Outcar._parse_sci_notation(l))
                 elif read_dielectric:
+                    toks = None
                     if re.match(row_pattern, l.strip()):
                         toks = l.strip().split()
+                    elif Outcar._parse_sci_notation(l.strip()):
+                        toks = Outcar._parse_sci_notation(l.strip())
+                    elif re.match(r"\s*-+\s*", l):
+                        count += 1
+
+                    if toks:
                         if component == "IMAGINARY":
                             energies.append(float(toks[0]))
                         xx, yy, zz, xy, yz, xz = [float(t) for t in toks[1:]]
                         matrix = [[xx, xy, xz], [xy, yy, yz], [xz, yz, zz]]
                         data[component].append(matrix)
-                    elif re.match(r"\s*-+\s*", l):
-                        count += 1
+
                     if count == 2:
                         component = "REAL"
                     elif count == 3:


### PR DESCRIPTION
## Summary

This PR is very similar to #1836 , except it now supports the dielectric tensor section of the OUTCAR as well (instead of just plasma frequencies)

The unit test from #1836 should also cover this one