### PR TITLE
Fix regular expression of read_onsite_density_matrices

### DIFF
--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -2172,7 +2172,7 @@ class Outcar:
         # therefore regex assumes f, but filter out None values if d
 
         header_pattern = r"spin component  1\n"
-        row_pattern = r'[^\S\r\n]*(?:([\d.-]+))' + r'(?:[^\S\r\n]*(-?[\d.]+)[^\S\r\n]*)?' * 6 + r'.*?'
+        row_pattern = r'[^\S\r\n]*(?:(-?[\d.]+))' + r'(?:[^\S\r\n]*(-?[\d.]+)[^\S\r\n]*)?' * 6 + r'.*?'
         footer_pattern = r"\nspin component  2"
         spin1_component = self.read_table_pattern(header_pattern, row_pattern,
                                                   footer_pattern, postprocess=lambda x: float(x) if x else None,

--- a/pymatgen/io/vasp/tests/test_outputs.py
+++ b/pymatgen/io/vasp/tests/test_outputs.py
@@ -1017,6 +1017,10 @@ class OutcarTest(PymatgenTest):
         self.assertEqual(len(matrices[0][Spin.up][0]), 7)
         self.assertTrue("onsite_density_matrices" in outcar.as_dict())
 
+        outcar = Outcar(self.TEST_FILES_DIR / "OUTCAR_merged_numbers2")
+        self.assertTrue("onsite_density_matrices" in outcar.as_dict())
+
+
     def test_nplwvs(self):
         outcar = Outcar(self.TEST_FILES_DIR / "OUTCAR")
         self.assertEqual(outcar.data["nplwv"], [[34560]])

--- a/test_files/OUTCAR_merged_numbers2
+++ b/test_files/OUTCAR_merged_numbers2
@@ -1,0 +1,5956 @@
+ vasp.5.4.4.18Apr17-6-g9f103f2a35 (build Apr 25 2017 10:43:04) complex          
+  
+ executed on             LinuxIFC date 2020.06.28  00:19:40
+ running on   36 total cores
+ distrk:  each k-point on   18 cores,    2 groups
+ distr:  one band on NCORES_PER_BAND=   1 cores,   18 groups
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ INCAR:
+ POTCAR:    PAW_PBE Li 17Jan2003                  
+ POTCAR:    PAW_PBE Sc 04Feb2005                  
+ POTCAR:    PAW_PBE W 08Apr2002                   
+ POTCAR:    PAW_PBE O 08Apr2002                   
+ POTCAR:    PAW_PBE H 15Jun2001                   
+
+ ----------------------------------------------------------------------------- 
+|                                                                             |
+|           W    W    AA    RRRRR   N    N  II  N    N   GGGG   !!!           |
+|           W    W   A  A   R    R  NN   N  II  NN   N  G    G  !!!           |
+|           W    W  A    A  R    R  N N  N  II  N N  N  G       !!!           |
+|           W WW W  AAAAAA  RRRRR   N  N N  II  N  N N  G  GGG   !            |
+|           WW  WW  A    A  R   R   N   NN  II  N   NN  G    G                |
+|           W    W  A    A  R    R  N    N  II  N    N   GGGG   !!!           |
+|                                                                             |
+|      For optimal performance we recommend to set                            |
+|        NCORE= 4 - approx SQRT( number of cores)                             |
+|      NCORE specifies how many cores store one orbital (NPAR=cpu/NCORE).     |
+|      This setting can  greatly improve the performance of VASP for DFT.     |
+|      The default,   NCORE=1            might be grossly inefficient         |
+|      on modern multi-core architectures or massively parallel machines.     |
+|      Do your own testing !!!!                                               |
+|      Unfortunately you need to use the default for GW and RPA calculations. |
+|      (for HF NCORE is supported but not extensively tested yet)             |
+|                                                                             |
+ ----------------------------------------------------------------------------- 
+
+
+ ----------------------------------------------------------------------------- 
+|                                                                             |
+|           W    W    AA    RRRRR   N    N  II  N    N   GGGG   !!!           |
+|           W    W   A  A   R    R  NN   N  II  NN   N  G    G  !!!           |
+|           W    W  A    A  R    R  N N  N  II  N N  N  G       !!!           |
+|           W WW W  AAAAAA  RRRRR   N  N N  II  N  N N  G  GGG   !            |
+|           WW  WW  A    A  R   R   N   NN  II  N   NN  G    G                |
+|           W    W  A    A  R    R  N    N  II  N    N   GGGG   !!!           |
+|                                                                             |
+|      You have enabled k-point parallelism (KPAR>1).                         |
+|      This developmental code was originally  written by Paul Kent at ORNL,  |
+|      and carefully double checked in Vienna.                                |
+|      GW as well as linear response parallelism added by Martijn Marsman     |
+|      and Georg Kresse.                                                      |
+|      Carefully verify results versus KPAR=1.                                |
+|      Report problems to Paul Kent and Vienna.                               |
+|                                                                             |
+ ----------------------------------------------------------------------------- 
+
+ POTCAR:    PAW_PBE Li 17Jan2003                  
+   VRHFIN =Li: s1p0                                                             
+   LEXCH  = PE                                                                  
+   EATOM  =     5.3001 eV,    0.3895 Ry                                         
+                                                                                
+   TITEL  = PAW_PBE Li 17Jan2003                                                
+   LULTRA =        F    use ultrasoft PP ?                                      
+   IUNSCR =        1    unscreen: 0-lin 1-nonlin 2-no                           
+   RPACOR =    1.500    partial core radius                                     
+   POMASS =    7.010; ZVAL   =    1.000    mass and valenz                      
+   RCORE  =    2.050    outmost cutoff radius                                   
+   RWIGS  =    2.600; RWIGS  =    1.376    wigner-seitz radius (au A)           
+   ENMAX  =  140.000; ENMIN  =  100.000 eV                                      
+   ICORE  =        2    local potential                                         
+   LCOR   =        T    correct aug charges                                     
+   LPAW   =        T    paw PP                                                  
+   EAUG   =  331.638                                                            
+   DEXC   =    0.000                                                            
+   RMAX   =    2.098    core radius for proj-oper                               
+   RAUG   =    1.300    factor for augmentation sphere                          
+   RDEP   =    2.094    radius for radial grids                                 
+   RDEPT  =    1.810    core radius for aug-charge                              
+                                                                                
+   Atomic configuration                                                         
+    4 entries                                                                   
+     n  l   j            E        occ.                                          
+     1  0  0.50       -51.8549   2.0000                                         
+     2  0  0.50        -2.8742   1.0000                                         
+     2  1  0.50        -1.3606   0.0000                                         
+     3  2  1.50        -1.3606   0.0000                                         
+   Description                                                                  
+     l       E           TYP  RCUT    TYP  RCUT                                 
+     0     -2.8742052     23  2.050                                             
+     0     27.2116520     23  2.050                                             
+     1     -1.3605826     23  2.050                                             
+     2     -1.3605826     23  2.050                                             
+  local pseudopotential read in
+  partial core-charges read in
+  partial kinetic energy density read in
+  atomic valenz-charges read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+    PAW grid and wavefunctions read in
+ 
+   number of l-projection  operators is LMAX  =           3
+   number of lm-projection operators is LMMAX =           5
+ 
+ POTCAR:    PAW_PBE Sc 04Feb2005                  
+   VRHFIN =Sc: 3p4s3d                                                           
+   LEXCH  = PE                                                                  
+   EATOM  =    44.6420 eV,    3.2811 Ry                                         
+                                                                                
+   TITEL  = PAW_PBE Sc 04Feb2005                                                
+   LULTRA =        F    use ultrasoft PP ?                                      
+   IUNSCR =        1    unscreen: 0-lin 1-nonlin 2-no                           
+   RPACOR =    2.000    partial core radius                                     
+   POMASS =   44.956; ZVAL   =    3.000    mass and valenz                      
+   RCORE  =    3.000    outmost cutoff radius                                   
+   RWIGS  =    3.000; RWIGS  =    1.588    wigner-seitz radius (au A)           
+   ENMAX  =  154.763; ENMIN  =  116.072 eV                                      
+   RCLOC  =    1.776    cutoff for local pot                                    
+   LCOR   =        T    correct aug charges                                     
+   LPAW   =        T    paw PP                                                  
+   EAUG   =  301.784                                                            
+   DEXC   =    0.000                                                            
+   RMAX   =    3.066    core radius for proj-oper                               
+   RAUG   =    1.300    factor for augmentation sphere                          
+   RDEP   =    3.011    radius for radial grids                                 
+   RDEPT  =    2.461    core radius for aug-charge                              
+                                                                                
+   Atomic configuration                                                         
+    9 entries                                                                   
+     n  l   j            E        occ.                                          
+     1  0  0.50     -4394.2533   2.0000                                         
+     2  0  0.50      -471.0040   2.0000                                         
+     2  1  1.50      -384.9788   6.0000                                         
+     3  0  0.50       -52.1410   2.0000                                         
+     3  1  1.50       -30.8841   6.0000                                         
+     3  2  2.50        -1.3655   2.0000                                         
+     4  0  0.50        -3.5584   1.0000                                         
+     4  1  0.50        -2.7212   0.0000                                         
+     4  3  2.50        -1.3606   0.0000                                         
+   Description                                                                  
+     l       E           TYP  RCUT    TYP  RCUT                                 
+     2     -1.3655439     23  3.000                                             
+     2     -2.7261265     23  3.000                                             
+     0     -3.5583719     23  3.000                                             
+     0     27.2116520     23  3.000                                             
+     1     -5.4423304     23  3.000                                             
+  local pseudopotential read in
+  partial core-charges read in
+  partial kinetic energy density read in
+  atomic valenz-charges read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+    PAW grid and wavefunctions read in
+ 
+   number of l-projection  operators is LMAX  =           5
+   number of lm-projection operators is LMMAX =          15
+ 
+ POTCAR:    PAW_PBE W 08Apr2002                   
+   VRHFIN =W : 6s5d                                                             
+   LEXCH  = PE                                                                  
+   EATOM  =   204.6103 eV,   15.0384 Ry                                         
+                                                                                
+   TITEL  = PAW_PBE W 08Apr2002                                                 
+   LULTRA =        F    use ultrasoft PP ?                                      
+   IUNSCR =        1    unscreen: 0-lin 1-nonlin 2-no                           
+   RPACOR =    2.330    partial core radius                                     
+   POMASS =  183.850; ZVAL   =    6.000    mass and valenz                      
+   RCORE  =    2.750    outmost cutoff radius                                   
+   RWIGS  =    2.750; RWIGS  =    1.455    wigner-seitz radius (au A)           
+   ENMAX  =  223.057; ENMIN  =  167.293 eV                                      
+   RCLOC  =    2.147    cutoff for local pot                                    
+   LCOR   =        T    correct aug charges                                     
+   LPAW   =        T    paw PP                                                  
+   EAUG   =  373.438                                                            
+   DEXC   =    0.000                                                            
+   RMAX   =    2.801    core radius for proj-oper                               
+   RAUG   =    1.300    factor for augmentation sphere                          
+   RDEP   =    2.886    radius for radial grids                                 
+   RDEPT  =    2.230    core radius for aug-charge                              
+                                                                                
+   Atomic configuration                                                         
+   16 entries                                                                   
+     n  l   j            E        occ.                                          
+     1  0  0.50    -69465.5836   2.0000                                         
+     2  0  0.50    -11986.2642   2.0000                                         
+     2  1  1.50    -10479.8616   6.0000                                         
+     3  0  0.50     -2759.0758   2.0000                                         
+     3  1  1.50     -2313.1857   6.0000                                         
+     3  2  2.50     -1801.1185  10.0000                                         
+     4  0  0.50      -567.6791   2.0000                                         
+     4  1  1.50      -421.4694   6.0000                                         
+     4  2  2.50      -236.3473  10.0000                                         
+     4  3  3.50       -31.2666  14.0000                                         
+     5  0  0.50       -77.1085   2.0000                                         
+     5  1  1.50       -41.3856   6.0000                                         
+     5  2  2.50        -3.3185   5.0000                                         
+     6  0  0.50        -5.1438   1.0000                                         
+     6  1  0.50        -3.8096   0.0000                                         
+     5  3  2.50        -1.3606   0.0000                                         
+   Description                                                                  
+     l       E           TYP  RCUT    TYP  RCUT                                 
+     2     -3.3185288     23  2.500                                             
+     2     -1.5965414     23  2.500                                             
+     0     -5.1438054     23  2.500                                             
+     0      4.9117504     23  2.500                                             
+     1      2.7211652     23  2.750                                             
+     1     27.2116520     23  2.750                                             
+  local pseudopotential read in
+  partial core-charges read in
+  partial kinetic energy density read in
+  atomic valenz-charges read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+    PAW grid and wavefunctions read in
+ 
+   number of l-projection  operators is LMAX  =           6
+   number of lm-projection operators is LMMAX =          18
+ 
+ POTCAR:    PAW_PBE O 08Apr2002                   
+   VRHFIN =O: s2p4                                                              
+   LEXCH  = PE                                                                  
+   EATOM  =   432.3788 eV,   31.7789 Ry                                         
+                                                                                
+   TITEL  = PAW_PBE O 08Apr2002                                                 
+   LULTRA =        F    use ultrasoft PP ?                                      
+   IUNSCR =        1    unscreen: 0-lin 1-nonlin 2-no                           
+   RPACOR =    1.200    partial core radius                                     
+   POMASS =   16.000; ZVAL   =    6.000    mass and valenz                      
+   RCORE  =    1.520    outmost cutoff radius                                   
+   RWIGS  =    1.550; RWIGS  =    0.820    wigner-seitz radius (au A)           
+   ENMAX  =  400.000; ENMIN  =  300.000 eV                                      
+   ICORE  =        2    local potential                                         
+   LCOR   =        T    correct aug charges                                     
+   LPAW   =        T    paw PP                                                  
+   EAUG   =  605.392                                                            
+   DEXC   =    0.000                                                            
+   RMAX   =    1.553    core radius for proj-oper                               
+   RAUG   =    1.300    factor for augmentation sphere                          
+   RDEP   =    1.550    radius for radial grids                                 
+   RDEPT  =    1.329    core radius for aug-charge                              
+                                                                                
+   Atomic configuration                                                         
+    4 entries                                                                   
+     n  l   j            E        occ.                                          
+     1  0  0.50      -514.6923   2.0000                                         
+     2  0  0.50       -23.9615   2.0000                                         
+     2  1  0.50        -9.0305   4.0000                                         
+     3  2  1.50        -9.5241   0.0000                                         
+   Description                                                                  
+     l       E           TYP  RCUT    TYP  RCUT                                 
+     0    -23.9615318     23  1.200                                             
+     0     -9.5240782     23  1.200                                             
+     1     -9.0304911     23  1.520                                             
+     1      8.1634956     23  1.520                                             
+     2     -9.5240782      7  1.500                                             
+  local pseudopotential read in
+  partial core-charges read in
+  partial kinetic energy density read in
+  kinetic energy density of atom read in
+  atomic valenz-charges read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+    PAW grid and wavefunctions read in
+ 
+   number of l-projection  operators is LMAX  =           4
+   number of lm-projection operators is LMMAX =           8
+ 
+ POTCAR:    PAW_PBE H 15Jun2001                   
+   VRHFIN =H: ultrasoft test                                                    
+   LEXCH  = PE                                                                  
+   EATOM  =    12.4884 eV,    0.9179 Ry                                         
+                                                                                
+   TITEL  = PAW_PBE H 15Jun2001                                                 
+   LULTRA =        F    use ultrasoft PP ?                                      
+   IUNSCR =        0    unscreen: 0-lin 1-nonlin 2-no                           
+   RPACOR =    0.000    partial core radius                                     
+   POMASS =    1.000; ZVAL   =    1.000    mass and valenz                      
+   RCORE  =    1.100    outmost cutoff radius                                   
+   RWIGS  =    0.700; RWIGS  =    0.370    wigner-seitz radius (au A)           
+   ENMAX  =  250.000; ENMIN  =  200.000 eV                                      
+   RCLOC  =    0.701    cutoff for local pot                                    
+   LCOR   =        T    correct aug charges                                     
+   LPAW   =        T    paw PP                                                  
+   EAUG   =  400.000                                                            
+   RMAX   =    1.123    core radius for proj-oper                               
+   RAUG   =    1.200    factor for augmentation sphere                          
+   RDEP   =    1.112    radius for radial grids                                 
+   RDEPT  =    0.926    core radius for aug-charge                              
+                                                                                
+   Atomic configuration                                                         
+    2 entries                                                                   
+     n  l   j            E        occ.                                          
+     1  0  0.50        -6.4927   1.0000                                         
+     2  1  0.50        -3.4015   0.0000                                         
+   Description                                                                  
+     l       E           TYP  RCUT    TYP  RCUT                                 
+     0     -6.4927494     23  1.100                                             
+     0      6.8029130     23  1.100                                             
+     1     -4.0817478     23  1.100                                             
+  local pseudopotential read in
+  atomic valenz-charges read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+    PAW grid and wavefunctions read in
+ 
+   number of l-projection  operators is LMAX  =           3
+   number of lm-projection operators is LMMAX =           5
+ 
+ Optimization of the real space projectors (new method)
+
+ maximal supplied QI-value         = 18.33
+ optimisation between [QCUT,QGAM] = [ 10.08, 20.35] = [ 28.46,115.93] Ry 
+ Optimized for a Real-space Cutoff    1.16 Angstroem
+
+   l    n(q)    QCUT    max X(q) W(low)/X(q) W(high)/X(q)  e(spline) 
+   0      7    10.082    33.825    0.44E-03    0.14E-03    0.78E-07
+   0      7    10.082     8.944    0.33E-03    0.12E-03    0.56E-07
+   1      6    10.082     4.214    0.33E-03    0.37E-03    0.39E-07
+ Optimization of the real space projectors (new method)
+
+ maximal supplied QI-value         = 12.47
+ optimisation between [QCUT,QGAM] = [ 10.23, 20.45] = [ 29.29,117.16] Ry 
+ Optimized for a Real-space Cutoff    1.75 Angstroem
+
+   l    n(q)    QCUT    max X(q) W(low)/X(q) W(high)/X(q)  e(spline) 
+   2     10    10.227   127.680    0.22E-03    0.15E-03    0.46E-06
+   2     10    10.227   113.778    0.22E-03    0.15E-03    0.46E-06
+   0     11    10.227    22.778    0.40E-04    0.79E-04    0.80E-06
+   0     11    10.227    11.292    0.26E-04    0.56E-04    0.58E-06
+   1     10    10.227    11.256    0.36E-04    0.13E-04    0.28E-07
+ Optimization of the real space projectors (new method)
+
+ maximal supplied QI-value         = 13.61
+ optimisation between [QCUT,QGAM] = [ 10.20, 20.41] = [ 29.16,116.64] Ry 
+ Optimized for a Real-space Cutoff    1.55 Angstroem
+
+   l    n(q)    QCUT    max X(q) W(low)/X(q) W(high)/X(q)  e(spline) 
+   2      9    10.205   130.855    0.41E-03    0.84E-03    0.64E-06
+   2      9    10.205   114.007    0.41E-03    0.84E-03    0.64E-06
+   0      9    10.205    84.709    0.58E-04    0.61E-04    0.12E-06
+   0      9    10.205    49.163    0.53E-04    0.55E-04    0.11E-06
+   1      9    10.205    15.765    0.16E-03    0.32E-03    0.27E-06
+   1      9    10.205    10.638    0.14E-03    0.24E-03    0.21E-06
+ Optimization of the real space projectors (new method)
+
+ maximal supplied QI-value         = 24.76
+ optimisation between [QCUT,QGAM] = [ 10.15, 20.30] = [ 28.85,115.39] Ry 
+ Optimized for a Real-space Cutoff    1.38 Angstroem
+
+   l    n(q)    QCUT    max X(q) W(low)/X(q) W(high)/X(q)  e(spline) 
+   0      8    10.150    20.381    0.22E-03    0.32E-03    0.29E-06
+   0      8    10.150    15.268    0.23E-03    0.35E-03    0.30E-06
+   1      8    10.150     5.964    0.46E-03    0.53E-03    0.21E-06
+   1      8    10.150     5.382    0.38E-03    0.45E-03    0.19E-06
+ Optimization of the real space projectors (new method)
+
+ maximal supplied QI-value         = 34.20
+ optimisation between [QCUT,QGAM] = [  9.92, 20.18] = [ 27.55,114.04] Ry 
+ Optimized for a Real-space Cutoff    1.26 Angstroem
+
+   l    n(q)    QCUT    max X(q) W(low)/X(q) W(high)/X(q)  e(spline) 
+   0      8     9.919    19.460    0.50E-03    0.23E-03    0.29E-06
+   0      8     9.919    12.209    0.48E-03    0.23E-03    0.28E-06
+   1      7     9.919     4.655    0.17E-03    0.75E-03    0.30E-06
+
+ ----------------------------------------------------------------------------- 
+|                                                                             |
+|  ADVICE TO THIS USER RUNNING 'VASP/VAMP'   (HEAR YOUR MASTER'S VOICE ...):  |
+|                                                                             |
+|      You enforced a specific xc-type in the INCAR file,                     |
+|      a different type was found on the POTCAR file                          |
+|          I HOPE YOU KNOW, WHAT YOU ARE  DOING                               |
+|                                                                             |
+ ----------------------------------------------------------------------------- 
+
+  PAW_PBE Li 17Jan2003                  :
+ energy of atom  1       EATOM=   -5.3001
+ kinetic energy error for atom=    0.0000 (will be added to EATOM!!)
+  PAW_PBE Sc 04Feb2005                  :
+ energy of atom  2       EATOM=  -44.6420
+ kinetic energy error for atom=    0.0001 (will be added to EATOM!!)
+  PAW_PBE W 08Apr2002                   :
+ energy of atom  3       EATOM= -204.6103
+ kinetic energy error for atom=    0.0024 (will be added to EATOM!!)
+  PAW_PBE O 08Apr2002                   :
+ energy of atom  4       EATOM= -432.3788
+ kinetic energy error for atom=    0.1156 (will be added to EATOM!!)
+  PAW_PBE H 15Jun2001                   :
+ energy of atom  5       EATOM=  -12.4884
+ kinetic energy error for atom=    0.0098 (will be added to EATOM!!)
+ 
+ 
+ POSCAR: Li8 Sc8 H1 W16 O63                      
+  positions in direct lattice
+  velocities in cartesian coordinates
+ exchange correlation table for  LEXCH =       14
+   RHO(1)=    0.500       N(1)  =     2000
+   RHO(2)=  100.500       N(2)  =     4000
+ 
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ ion  position               nearest neighbor table
+   1  0.499  0.839  0.126-  60 2.08  56 2.09  55 2.11  50 2.12  38 2.21  34 2.32  11 3.19  12 3.25
+
+   2  0.497  0.840  0.625-  61 2.08  54 2.09  57 2.09  51 2.11  35 2.32  39 2.33  12 3.13  11 3.19
+
+   3  0.505  0.151  0.374-  62 2.00  58 2.06  53 2.11  48 2.13  36 2.34   9 3.26  10 3.32  22 3.38
+
+   4  0.501  0.156  0.876-  59 2.06  63 2.08  52 2.09  49 2.14  33 2.33  37 2.34  10 3.19   9 3.21
+
+   5  0.004  0.342  0.131-  82 1.97  92 2.08  88 2.09  87 2.16  66 2.35  70 2.36  15 3.10  16 3.24
+                            27 3.31
+   6  0.003  0.346  0.626-  89 1.95  93 2.06  83 2.11  86 2.15  67 2.34  71 2.38  16 3.22  15 3.22
+
+   7  0.000  0.658  0.375-  94 2.03  90 2.09  85 2.11  80 2.12  68 2.32  64 2.32  13 3.20  14 3.20
+                            30 3.39
+   8  0.002  0.656  0.877-  95 2.02  84 2.07  91 2.07  81 2.14  65 2.34  69 2.36  13 3.17  14 3.22
+
+   9  0.499  0.336  0.125-  72 1.99  76 2.06  33 2.07  36 2.08  48 2.16  52 2.17   4 3.21   3 3.26
+                            28 3.53  31 3.55  27 3.58  32 3.63
+  10  0.502  0.336  0.631-  73 2.03  37 2.04  96 2.05  77 2.05  49 2.13  53 2.15   4 3.19   3 3.32
+                            32 3.52  28 3.60  31 3.62
+  11  0.497  0.665  0.376-  78 2.04  74 2.07  38 2.08  35 2.09  54 2.13  50 2.16   2 3.19   1 3.19
+                            29 3.51  26 3.56  25 3.62  30 3.65  23 3.65
+  12  0.497  0.665  0.868-  39 2.01  79 2.04  75 2.07  34 2.13  51 2.14  55 2.15   2 3.13   1 3.25
+                            30 3.56  26 3.58  29 3.59  25 3.61  24 3.64
+  13  0.001  0.832  0.124-  44 2.07  65 2.07  40 2.08  68 2.08  84 2.12  80 2.13   8 3.17   7 3.20
+                            23 3.56  20 3.56  24 3.60  29 3.62  19 3.63
+  14  0.001  0.834  0.625-  45 2.07  41 2.07  69 2.07  64 2.07  85 2.10  81 2.14   7 3.20   8 3.22
+                            19 3.55  24 3.56  23 3.60  20 3.62  30 3.64
+  15  0.004  0.171  0.372-  82 1.96  70 2.08  42 2.08  67 2.09  46 2.15  86 2.15   5 3.10   6 3.22
+                            17 3.57  18 3.57  21 3.59  27 3.62  31 3.63
+  16  0.000  0.166  0.875-  43 2.06  66 2.07  47 2.07  71 2.07  83 2.13  87 2.13   6 3.22   5 3.24
+                            22 3.56  17 3.57  18 3.61  21 3.62  32 3.64
+  17  0.257  0.088  0.128-  48 1.80  66 1.80  59 1.89  42 1.95  60 2.07  44 2.17  23 3.19  24 3.20
+                            16 3.57  15 3.57
+  18  0.257  0.088  0.626-  49 1.80  67 1.80  58 1.88  43 1.96  61 2.06  45 2.16  24 3.20  23 3.20
+                            15 3.57  16 3.61
+  19  0.744  0.912  0.374-  50 1.79  64 1.81  57 1.89  40 1.96  62 2.06  46 2.16  22 3.18  21 3.19
+                            14 3.55  13 3.63
+  20  0.743  0.912  0.873-  51 1.79  65 1.81  56 1.88  41 1.96  63 2.05  47 2.17  21 3.19  22 3.20
+                            13 3.56  14 3.62
+  21  0.743  0.086  0.123-  52 1.79  70 1.79  62 1.89  47 1.96  56 2.06  40 2.17  20 3.19  19 3.19
+                            15 3.59  16 3.62
+  22  0.744  0.088  0.622-  53 1.80  71 1.81  63 1.89  46 1.94  57 2.06  41 2.17  19 3.18  20 3.20
+                             3 3.38  16 3.56
+  23  0.256  0.912  0.376-  54 1.79  68 1.80  60 1.88  45 1.96  58 2.07  42 2.14  17 3.19  18 3.20
+                            13 3.56  14 3.60  11 3.65
+  24  0.257  0.913  0.877-  55 1.79  69 1.80  61 1.89  44 1.95  59 2.07  43 2.17  18 3.20  17 3.20
+                            14 3.56  13 3.60  12 3.64
+  25  0.755  0.588  0.126-  34 1.80  80 1.80  91 1.90  74 1.95  92 2.08  76 2.15  32 3.18  31 3.20
+                            12 3.61  11 3.62
+  26  0.756  0.588  0.626-  81 1.79  35 1.81  90 1.88  75 1.95  93 2.07  77 2.17  31 3.20  32 3.20
+                            11 3.56  12 3.58
+  27  0.241  0.418  0.365-  82 1.93  96 2.00  72 2.07  89 2.09  94 2.10  78 2.16  29 3.13  30 3.17
+                             5 3.31   9 3.58  15 3.62
+  28  0.243  0.413  0.876-  83 1.80  33 1.81  88 1.87  73 1.95  95 2.05  79 2.16  30 3.18  29 3.19
+                             9 3.53  10 3.60
+  29  0.248  0.592  0.122-  84 1.81  38 1.82  94 1.86  79 1.96  88 2.09  72 2.11  27 3.13  28 3.19
+                            11 3.51  12 3.59  13 3.62
+  30  0.235  0.582  0.623-  85 1.80  39 1.86  95 1.88  89 1.90  78 1.99  73 2.20  27 3.17  28 3.18
+                             7 3.39  12 3.56  14 3.64  11 3.65
+  31  0.755  0.412  0.376-  86 1.78  36 1.81  92 1.87  77 1.97  90 2.06  74 2.17  26 3.20  25 3.20
+                             9 3.55  10 3.62  15 3.63
+  32  0.759  0.413  0.877-  87 1.79  37 1.82  93 1.88  76 1.96  91 2.04  75 2.17  25 3.18  26 3.20
+                            10 3.52   9 3.63  16 3.64
+  33  0.374  0.317  0.952-  28 1.81   9 2.07   4 2.33
+  34  0.625  0.681  0.046-  25 1.80  12 2.13   1 2.32
+  35  0.626  0.682  0.549-  26 1.81  11 2.09   2 2.32
+  36  0.622  0.318  0.301-  31 1.81   9 2.08   3 2.34
+  37  0.627  0.317  0.801-  32 1.82  10 2.04   4 2.34
+  38  0.378  0.689  0.200-  29 1.82  11 2.08   1 2.21
+  39  0.374  0.677  0.699-  30 1.86  12 2.01   2 2.33
+  40  0.857  0.942  0.215-  19 1.96  13 2.08  21 2.17
+  41  0.858  0.943  0.715-  20 1.96  14 2.07  22 2.17
+  42  0.143  0.054  0.285-  17 1.95  15 2.08  23 2.14
+  43  0.144  0.058  0.785-  18 1.96  16 2.06  24 2.17
+  44  0.144  0.943  0.035-  24 1.95  13 2.07  17 2.17
+  45  0.144  0.944  0.535-  23 1.96  14 2.07  18 2.16
+  46  0.856  0.057  0.465-  22 1.94  15 2.15  19 2.16
+  47  0.857  0.056  0.965-  21 1.96  16 2.07  20 2.17
+  48  0.378  0.192  0.201-  17 1.80   3 2.13   9 2.16
+  49  0.381  0.192  0.696-  18 1.80  10 2.13   4 2.14
+  50  0.621  0.808  0.305-  19 1.79   1 2.12  11 2.16
+  51  0.621  0.809  0.801-  20 1.79   2 2.11  12 2.14
+  52  0.620  0.189  0.053-  21 1.79   4 2.09   9 2.17
+  53  0.619  0.191  0.554-  22 1.80   3 2.11  10 2.15
+  54  0.379  0.809  0.448-  23 1.79   2 2.09  11 2.13
+  55  0.381  0.810  0.946-  24 1.79   1 2.11  12 2.15
+  56  0.643  0.948  0.029-  20 1.88  21 2.06   1 2.09
+  57  0.642  0.949  0.530-  19 1.89  22 2.06   2 2.09
+  58  0.358  0.051  0.470-  18 1.88   3 2.06  23 2.07
+  59  0.358  0.050  0.972-  17 1.89   4 2.06  24 2.07
+  60  0.358  0.950  0.221-  23 1.88  17 2.07   1 2.08
+  61  0.358  0.951  0.721-  24 1.89  18 2.06   2 2.08
+  62  0.642  0.048  0.279-  21 1.89   3 2.00  19 2.06
+  63  0.643  0.050  0.779-  22 1.89  20 2.05   4 2.08
+  64  0.876  0.818  0.452-  19 1.81  14 2.07   7 2.32
+  65  0.876  0.818  0.950-  20 1.81  13 2.07   8 2.34
+  66  0.125  0.180  0.048-  17 1.80  16 2.07   5 2.35
+  67  0.126  0.182  0.550-  18 1.80  15 2.09   6 2.34
+  68  0.125  0.818  0.299-  23 1.80  13 2.08   7 2.32
+  69  0.126  0.820  0.798-  24 1.80  14 2.07   8 2.36
+  70  0.872  0.180  0.201-  21 1.79  15 2.08   5 2.36
+  71  0.875  0.181  0.702-  22 1.81  16 2.07   6 2.38
+  72  0.368  0.452  0.203-   9 1.99  27 2.07  29 2.11
+  73  0.360  0.442  0.719-  28 1.95  10 2.03  30 2.20
+  74  0.643  0.558  0.285-  25 1.95  11 2.07  31 2.17
+  75  0.644  0.555  0.784-  26 1.95  12 2.07  32 2.17
+  76  0.644  0.443  0.035-  32 1.96   9 2.06  25 2.15
+  77  0.641  0.444  0.536-  31 1.97  10 2.05  26 2.17
+  78  0.359  0.554  0.466-  30 1.99  11 2.04  27 2.16
+  79  0.358  0.558  0.962-  29 1.96  12 2.04  28 2.16
+  80  0.879  0.690  0.196-  25 1.80   7 2.12  13 2.13
+  81  0.880  0.690  0.698-  26 1.79   8 2.14  14 2.14
+  82  0.110  0.302  0.297-  27 1.93  15 1.96   5 1.97
+  83  0.120  0.310  0.805-  28 1.80   6 2.11  16 2.13
+  84  0.124  0.694  0.047-  29 1.81   8 2.07  13 2.12
+  85  0.119  0.692  0.553-  30 1.80  14 2.10   7 2.11
+  86  0.875  0.309  0.450-  31 1.78   6 2.15  15 2.15
+  87  0.881  0.309  0.948-  32 1.79  16 2.13   5 2.16
+  88  0.144  0.452  0.031-  28 1.87  29 2.09   5 2.09
+  89  0.138  0.453  0.545-  30 1.90   6 1.95  27 2.09
+  90  0.856  0.550  0.470-  26 1.88  31 2.06   7 2.09
+  91  0.858  0.550  0.970-  25 1.90  32 2.04   8 2.07
+  92  0.855  0.449  0.221-  31 1.87  25 2.08   5 2.08
+  93  0.858  0.449  0.721-  32 1.88   6 2.06  26 2.07
+  94  0.140  0.561  0.271-  29 1.86   7 2.03  27 2.10
+  95  0.144  0.553  0.786-  30 1.88   8 2.02  28 2.05
+  96  0.384  0.316  0.457-  27 2.00  10 2.05
+ 
+  LATTYP: Found a simple monoclinic cell.
+ ALAT       =    13.5557677184
+ B/A-ratio  =     0.8475316765
+ C/A-ratio  =     1.6065527774
+ COS(beta)  =    -0.9481251469
+  
+  Lattice vectors:
+  
+ A1 = (  -9.2505505867,   0.0000000000,  -9.9088925858)
+ A2 = (   0.0000000000, -11.4889425400,   0.0000000000)
+ A3 = (   9.0299017771,   0.0000000000,  19.8177851716)
+
+
+Analysis of symmetry for initial positions (statically):
+=====================================================================
+ Subroutine PRICEL returns:
+ Original cell was already a primitive cell.
+ 
+
+ Routine SETGRP: Setting up the symmetry group for a 
+ simple monoclinic supercell.
+
+
+ Subroutine GETGRP returns: Found  1 space group operations
+ (whereof  1 operations were pure point group operations)
+ out of a pool of  4 trial point group operations.
+
+
+The static configuration has the point symmetry C_1 .
+
+
+Analysis of symmetry for dynamics (positions and initial velocities):
+=====================================================================
+ Subroutine PRICEL returns:
+ Original cell was already a primitive cell.
+ 
+
+ Routine SETGRP: Setting up the symmetry group for a 
+ simple monoclinic supercell.
+
+
+ Subroutine GETGRP returns: Found  1 space group operations
+ (whereof  1 operations were pure point group operations)
+ out of a pool of  4 trial point group operations.
+
+
+The dynamic configuration has the point symmetry C_1 .
+
+
+Analysis of structural, dynamic, and magnetic symmetry:
+=====================================================================
+ Subroutine PRICEL returns:
+ Original cell was already a primitive cell.
+ 
+
+ Routine SETGRP: Setting up the symmetry group for a 
+ simple monoclinic supercell.
+
+
+ Subroutine GETGRP returns: Found  1 space group operations
+ (whereof  1 operations were pure point group operations)
+ out of a pool of  4 trial point group operations.
+
+
+The magnetic configuration has the point symmetry C_1 .
+
+
+ Subroutine INISYM returns: Found  1 space group operations
+ (whereof  1 operations are pure point group operations),
+ and found     1 'primitive' translations
+
+ 
+ 
+ KPOINTS: Num irrep kpoints: 4                    
+
+Automatic generation of k-mesh.
+Space group operators:
+ irot       det(A)        alpha          n_x          n_y          n_z        tau_x        tau_y        tau_z
+    1     1.000000     0.000000     1.000000     0.000000     0.000000     0.000000     0.000000     0.000000
+ 
+ Subroutine IBZKPT returns following result:
+ ===========================================
+ 
+ Found      4 irreducible k-points:
+ 
+ Following reciprocal coordinates:
+            Coordinates               Weight
+  0.000000  0.000000  0.000000      1.000000
+  0.500000  0.000000  0.000000      1.000000
+  0.000000  0.000000  0.500000      1.000000
+  0.500000  0.000000  0.500000      1.000000
+ 
+ Following cartesian coordinates:
+            Coordinates               Weight
+  0.000000  0.000000  0.000000      1.000000
+  0.052792  0.000000  0.001176      1.000000
+  0.000000  0.000000  0.050460      1.000000
+  0.052792  0.000000  0.051635      1.000000
+ 
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+ Dimension of arrays:
+   k-points           NKPTS =      4   k-points in BZ     NKDIM =      4   number of bands    NBANDS=    360
+   number of dos      NEDOS =    301   number of ions     NIONS =     96
+   non local maximal  LDIM  =      6   non local SUM 2l+1 LMDIM =     18
+   total plane-waves  NPLWV = 129024
+   max r-space proj   IRMAX =   2730   max aug-charges    IRDMAX=   9601
+   dimension x,y,z NGX =    48 NGY =   56 NGZ =   48
+   dimension x,y,z NGXF=    96 NGYF=  112 NGZF=   96
+   support grid    NGXF=    96 NGYF=  112 NGZF=   96
+   ions per type =               8   8  16  63   1
+   NGX,Y,Z   is equivalent  to a cutoff of   8.43,  8.10,  8.05 a.u.
+   NGXF,Y,Z  is equivalent  to a cutoff of  16.85, 16.21, 16.10 a.u.
+
+ SYSTEM =  unknown system                          
+ POSCAR =  Li8 Sc8 H1 W16 O63                      
+
+ Startparameter for this run:
+   NWRITE =      2    write-flag & timer
+   PREC   = normal    normal or accurate (medium, high low for compatibility)
+   ISTART =      1    job   : 0-new  1-cont  2-samecut
+   ICHARG =      0    charge: 1-file 2-atom 10-const
+   ISPIN  =      2    spin polarized calculation?
+   LNONCOLLINEAR =      F non collinear calculations
+   LSORBIT =      F    spin-orbit coupling
+   INIWAV =      1    electr: 0-lowe 1-rand  2-diag
+   LASPH  =      T    aspherical Exc in radial PAW
+   METAGGA=      F    non-selfconsistent MetaGGA calc.
+
+ Electronic Relaxation 1
+   ENCUT  =  400.0 eV  29.40 Ry    5.42 a.u.  15.45 18.74 16.16*2*pi/ulx,y,z
+   ENINI  =  400.0     initial cutoff
+   ENAUG  =  605.4 eV  augmentation charge cutoff
+   NELM   =    100;   NELMIN=  2; NELMDL=  0     # of ELM steps 
+   EDIFF  = 0.1E-04   stopping-criterion for ELM
+   LREAL  =      T    real-space projection
+   NLSPLINE    = F    spline interpolate recip. space projectors
+   LCOMPAT=      F    compatible to vasp.4.4
+   GGA_COMPAT  = T    GGA compatible to vasp.4.4-vasp.4.6
+   LMAXPAW     = -100 max onsite density
+   LMAXMIX     =    6 max onsite mixed and CHGCAR
+   VOSKOWN=      0    Vosko Wilk Nusair interpolation
+   ROPT   =   -0.00050  -0.00050  -0.00050  -0.00050
+   ROPT   =   -0.00050
+ Ionic relaxation
+   EDIFFG = -.3E-01   stopping-criterion for IOM
+   NSW    =     50    number of steps for IOM
+   NBLOCK =      1;   KBLOCK =     50    inner block; outer block 
+   IBRION =      2    ionic relax: 0-MD 1-quasi-New 2-CG
+   NFREE  =      1    steps in history (QN), initial steepest desc. (CG)
+   ISIF   =      2    stress and relaxation
+   IWAVPR =     11    prediction:  0-non 1-charg 2-wave 3-comb
+   ISYM   =      2    0-nonsym 1-usesym 2-fastsym
+   LCORR  =      T    Harris-Foulkes like correction to forces
+
+   POTIM  = 0.5000    time-step for ionic-motion
+   TEIN   =    0.0    initial temperature
+   TEBEG  =    0.0;   TEEND  =   0.0 temperature during run
+   SMASS  =  -3.00    Nose mass-parameter (am)
+   estimated Nose-frequenzy (Omega)   =  0.10E-29 period in steps =****** mass=  -0.205E-26a.u.
+   SCALEE = 1.0000    scale energy and forces
+   NPACO  =    256;   APACO  = 16.0  distance and # of slots for P.C.
+   PSTRESS=    0.0 pullay stress
+
+  Mass of Ions in am
+   POMASS =   7.01 44.96183.85 16.00  1.00
+  Ionic Valenz
+   ZVAL   =   1.00  3.00  6.00  6.00  1.00
+  Atomic Wigner-Seitz radii
+   RWIGS  =  -1.00 -1.00 -1.00 -1.00 -1.00
+  virtual crystal weights 
+   VCA    =   1.00  1.00  1.00  1.00  1.00
+   NELECT =     508.0000    total number of electrons
+   NUPDOWN=      -1.0000    fix difference up-down
+
+ DOS related values:
+   EMIN   =  10.00;   EMAX   =-10.00  energy-range for DOS
+   EFERMI =   0.00
+   ISMEAR =     0;   SIGMA  =   0.10  broadening in eV -4-tet -1-fermi 0-gaus
+
+ Electronic relaxation 2 (details)
+   IALGO  =     38    algorithm
+   LDIAG  =      T    sub-space diagonalisation (order eigenvalues)
+   LSUBROT=      F    optimize rotation matrix (better conditioning)
+   TURBO    =      0    0=normal 1=particle mesh
+   IRESTART =      0    0=no restart 2=restart with 2 vectors
+   NREBOOT  =      0    no. of reboots
+   NMIN     =      0    reboot dimension
+   EREF     =   0.00    reference energy to select bands
+   IMIX   =      4    mixing-type and parameters
+     AMIX     =   0.40;   BMIX     =  1.00
+     AMIX_MAG =   1.60;   BMIX_MAG =  1.00
+     AMIN     =   0.10
+     WC   =   100.;   INIMIX=   1;  MIXPRE=   1;  MAXMIX= -45
+
+ Intra band minimization:
+   WEIMIN = 0.0010     energy-eigenvalue tresh-hold
+   EBREAK =  0.69E-08  absolut break condition
+   DEPER  =   0.30     relativ break condition  
+
+   TIME   =   0.40     timestep for ELM
+
+  volume/ion in A,a.u.               =      11.23        75.79
+  Fermi-wavevector in a.u.,A,eV,Ry     =   1.273873  2.407270 22.078875  1.622752
+  Thomas-Fermi vector in A             =   2.406672
+ 
+ Write flags
+   LWAVE        =      T    write WAVECAR
+   LDOWNSAMPLE  =      F    k-point downsampling of WAVECAR
+   LCHARG       =      F    write CHGCAR
+   LVTOT        =      F    write LOCPOT, total local potential
+   LVHAR        =      F    write LOCPOT, Hartree potential only
+   LELF         =      F    write electronic localiz. function (ELF)
+   LORBIT       =     10    0 simple, 1 ext, 2 COOP (PROOUT), +10 PAW based schemes
+
+
+ Dipole corrections
+   LMONO  =      F    monopole corrections only (constant potential shift)
+   LDIPOL =      F    correct potential (dipole corrections)
+   IDIPOL =      0    1-x, 2-y, 3-z, 4-all directions 
+   EPSILON=  1.0000000 bulk dielectric constant
+
+ LDA+U is selected, type is set to LDAUTYPE =  2
+   angular momentum for each species LDAUL =    -1   -1    2   -1   -1
+   U (eV)           for each species LDAUU =   0.0  0.0  3.0  0.0  0.0
+   J (eV)           for each species LDAUJ =   0.0  0.0  0.0  0.0  0.0
+ Exchange correlation treatment:
+   GGA     =    PS    GGA type
+   LEXCH   =    14    internal setting for exchange type
+   VOSKOWN=      0    Vosko Wilk Nusair interpolation
+   LHFCALC =     F    Hartree Fock is set to
+   LHFONE  =     F    Hartree Fock one center treatment
+   AEXX    =    0.0000 exact exchange contribution
+
+ Linear response parameters
+   LEPSILON=     F    determine dielectric tensor
+   LRPA    =     F    only Hartree local field effects (RPA)
+   LNABLA  =     F    use nabla operator in PAW spheres
+   LVEL    =     F    velocity operator in full k-point grid
+   LINTERFAST=   F  fast interpolation
+   KINTER  =     0    interpolate to denser k-point grid
+   CSHIFT  =0.1000    complex shift for real part using Kramers Kronig
+   OMEGAMAX=  -1.0    maximum frequency
+   DEG_THRESHOLD= 0.2000000E-02 threshold for treating states as degnerate
+   RTIME   =   -0.100 relaxation time in fs
+  (WPLASMAI=    0.000 imaginary part of plasma frequency in eV, 0.658/RTIME)
+   DFIELD  = 0.0000000 0.0000000 0.0000000 field for delta impulse in time
+ 
+ Orbital magnetization related:
+   ORBITALMAG=     F  switch on orbital magnetization
+   LCHIMAG   =     F  perturbation theory with respect to B field
+   DQ        =  0.001000  dq finite difference perturbation B field
+   LLRAUG    =     F  two centre corrections for induced B field
+
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ conjugate gradient relaxation of ions
+ charge density and potential will be updated during run
+ spin polarized calculation
+ Variant of blocked Davidson
+ Davidson routine will perform the subspace rotation
+ perform sub-space diagonalisation
+    after iterative eigenvector-optimisation
+ modified Broyden-mixing scheme, WC =      100.0
+ initial mixing is a Kerker type mixing with AMIX =  0.4000 and BMIX =      1.0000
+ Hartree-type preconditioning will be used
+ using additional bands          106
+ real space projection scheme for non local part
+ use partial core corrections
+ calculate Harris-corrections to forces 
+   (improved forces if not selfconsistent)
+ use gradient corrections 
+ use of overlap-Matrix (Vanderbilt PP)
+ Gauss-broadening in eV      SIGMA  =   0.10
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+  energy-cutoff  :      400.00
+  volume of cell :     1078.23
+      direct lattice vectors                 reciprocal lattice vectors
+     9.471199396  0.000000000  0.000000000     0.105583249  0.000000000  0.002351102
+     0.000000000 11.488942540  0.000000000     0.000000000  0.087040212  0.000000000
+    -0.220648810  0.000000000  9.908892586     0.000000000  0.000000000  0.100919451
+
+  length of vectors
+     9.471199396 11.488942540  9.911348958     0.105609422  0.087040212  0.100919451
+
+
+ 
+ old parameters found on file WAVECAR:
+  energy-cutoff  :      400.00
+  volume of cell :     1078.23
+      direct lattice vectors                 reciprocal lattice vectors
+     9.471199396  0.000000000  0.000000000     0.105583249  0.000000000  0.002351102
+     0.000000000 11.488942540  0.000000000     0.000000000  0.087040212  0.000000000
+    -0.220648810  0.000000000  9.908892586     0.000000000  0.000000000  0.100919451
+
+  length of vectors
+
+ 
+ k-points in units of 2pi/SCALE and weight: Num irrep kpoints: 4                    
+   0.00000000  0.00000000  0.00000000       0.250
+   0.05279162  0.00000000  0.00117555       0.250
+   0.00000000  0.00000000  0.05045973       0.250
+   0.05279162  0.00000000  0.05163528       0.250
+ 
+ k-points in reciprocal lattice and weights: Num irrep kpoints: 4                    
+   0.00000000  0.00000000  0.00000000       0.250
+   0.50000000  0.00000000  0.00000000       0.250
+   0.00000000  0.00000000  0.50000000       0.250
+   0.50000000  0.00000000  0.50000000       0.250
+ 
+ position of ions in fractional coordinates (direct lattice) 
+   0.49918762  0.83931243  0.12595534
+   0.49744454  0.84010112  0.62495161
+   0.50540049  0.15052405  0.37393766
+   0.50061721  0.15637177  0.87638983
+   0.00412403  0.34211124  0.13053393
+   0.00349653  0.34603986  0.62585298
+   0.00025043  0.65771449  0.37461246
+   0.00226007  0.65647201  0.87726442
+   0.49897070  0.33591255  0.12458523
+   0.50230420  0.33621735  0.63109880
+   0.49735868  0.66455852  0.37596391
+   0.49672197  0.66541119  0.86761426
+   0.00095578  0.83238138  0.12353886
+   0.00109737  0.83351435  0.62486682
+   0.00386251  0.17119304  0.37195586
+   0.00039892  0.16618848  0.87461347
+   0.25686314  0.08821175  0.12801788
+   0.25745796  0.08812106  0.62609512
+   0.74403534  0.91184131  0.37435655
+   0.74334000  0.91209877  0.87268028
+   0.74273475  0.08604782  0.12316065
+   0.74379728  0.08768626  0.62237229
+   0.25607275  0.91196673  0.37609029
+   0.25728548  0.91284790  0.87686814
+   0.75461665  0.58770848  0.12588435
+   0.75636183  0.58781408  0.62610655
+   0.24051807  0.41841833  0.36509682
+   0.24338673  0.41314951  0.87593065
+   0.24832768  0.59197887  0.12174422
+   0.23519869  0.58226618  0.62251506
+   0.75503772  0.41178362  0.37646041
+   0.75944644  0.41262637  0.87714602
+   0.37412574  0.31706313  0.95244302
+   0.62511837  0.68077912  0.04635593
+   0.62556811  0.68217338  0.54851501
+   0.62152757  0.31820242  0.30070678
+   0.62678003  0.31742553  0.80055019
+   0.37798366  0.68880693  0.19957213
+   0.37448303  0.67732773  0.69941509
+   0.85695956  0.94163264  0.21503295
+   0.85787894  0.94336657  0.71475781
+   0.14286253  0.05410926  0.28451710
+   0.14412324  0.05763564  0.78514960
+   0.14360641  0.94325647  0.03512050
+   0.14356541  0.94396981  0.53512205
+   0.85579804  0.05665305  0.46529795
+   0.85738459  0.05620953  0.96495974
+   0.37823558  0.19215431  0.20084360
+   0.38063951  0.19194568  0.69556163
+   0.62119878  0.80840602  0.30454002
+   0.62107053  0.80905075  0.80108564
+   0.61952206  0.18864887  0.05273721
+   0.61897044  0.19097168  0.55356352
+   0.37936948  0.80930437  0.44762908
+   0.38077871  0.80987510  0.94602905
+   0.64271956  0.94766485  0.02890764
+   0.64217733  0.94899284  0.53006117
+   0.35786967  0.05071252  0.46999098
+   0.35809932  0.05046767  0.97225381
+   0.35809050  0.94962972  0.22101488
+   0.35817838  0.95072272  0.72089711
+   0.64196604  0.04837550  0.27942269
+   0.64329413  0.04970930  0.77949103
+   0.87583461  0.81783761  0.45179442
+   0.87550221  0.81832641  0.95034489
+   0.12518361  0.17969527  0.04774060
+   0.12635598  0.18238626  0.54979782
+   0.12497119  0.81782446  0.29874084
+   0.12558518  0.82000798  0.79835692
+   0.87203966  0.18004527  0.20108548
+   0.87465181  0.18122761  0.70187808
+   0.36759611  0.45202224  0.20295913
+   0.35958021  0.44216099  0.71906793
+   0.64269401  0.55792249  0.28497363
+   0.64386126  0.55540913  0.78430462
+   0.64443618  0.44306051  0.03470978
+   0.64081477  0.44403333  0.53550967
+   0.35866703  0.55444129  0.46611798
+   0.35840688  0.55827012  0.96155575
+   0.87940757  0.69026465  0.19559279
+   0.87966227  0.69033661  0.69754488
+   0.11007709  0.30201165  0.29732598
+   0.12003087  0.30994926  0.80450603
+   0.12385551  0.69425195  0.04725911
+   0.11897744  0.69234741  0.55296766
+   0.87461204  0.30873276  0.45013815
+   0.88102485  0.30896138  0.94843107
+   0.14392458  0.45150242  0.03064873
+   0.13819195  0.45252871  0.54520776
+   0.85626153  0.54982836  0.47036403
+   0.85803379  0.54967135  0.97041957
+   0.85541634  0.44856798  0.22131235
+   0.85809479  0.44924134  0.72058537
+   0.14000105  0.56060720  0.27133530
+   0.14371022  0.55259499  0.78575803
+   0.38380437  0.31615418  0.45713738
+ 
+ position of ions in cartesian coordinates  (Angst):
+   4.70011358  9.64281233  1.24807791
+   4.57350159  9.65187348  6.19257834
+   4.70423996  1.72936222  3.70530807
+   4.54807107  1.79654626  8.68405266
+   0.01025735  3.93049635  1.29344669
+  -0.10497742  3.97563206  6.20150996
+  -0.08028595  7.55644397  3.71199464
+  -0.17216173  7.54216919  8.69271894
+   4.69836143  3.85927996  1.23450169
+   4.61817202  3.86278182  6.25349023
+   4.62762728  7.63507461  3.72538596
+   4.51311480  7.64487090  8.59709654
+  -0.01820629  9.56318187  1.22413325
+  -0.12748273  9.57619848  6.19173819
+  -0.04548903  1.96682698  3.68567066
+  -0.18920420  1.90932992  8.66645096
+   2.40455503  1.01345971  1.26851538
+   2.30028854  1.01241775  6.20390933
+   6.96430569 10.47609244  3.70945880
+   6.84776553 10.47905035  8.64729514
+   7.00741363  0.98859842  1.22038562
+   6.90732666  1.00742237  6.16702018
+   2.34233220 10.47753333  3.72663829
+   2.24332216 10.48765703  8.68879219
+   7.11934850  6.75214897  1.24737447
+   7.02550402  6.75336222  6.20402260
+   2.19743639  4.80718418  3.61770515
+   2.11189116  4.74665094  8.67950270
+   2.32509827  6.80121121  1.20635038
+   2.09025653  6.68962274  6.16843485
+   7.06804727  4.73095838  3.73030580
+   6.99932740  4.74064067  8.69154572
+   3.33326404  3.64272004  9.43765558
+   5.91039232  7.82143215  0.45933592
+   5.80385116  7.83745076  5.43517636
+   5.82026099  3.65580933  2.97967121
+   5.75971822  3.64688362  7.93256586
+   3.53592324  7.91366328  1.97753877
+   3.39247831  7.78177932  6.93042904
+   8.06898814 10.81836330  2.13073844
+   7.96743202 10.83828434  7.08245838
+   1.29030117  0.62165821  2.81924936
+   1.19177761  0.66217256  7.77996303
+   1.35237561 10.83701936  0.34800527
+   1.24166255 10.84521493  5.30246689
+   8.00276648  0.65088365  4.61058741
+   7.90754319  0.64578804  9.56168238
+   3.53802870  2.20764985  1.99013764
+   3.45163789  2.20525285  6.89224546
+   5.81630112  9.28773030  3.01765431
+   5.70552422  9.29513756  7.93787156
+   5.85598054  2.16737605  0.52256733
+   5.74024932  2.19406263  5.48520146
+   3.49431512  9.29805138  4.43550843
+   3.39769087  9.30460846  9.37410026
+   6.08094667 10.88766704  0.28644269
+   5.96523217 10.90292420  5.25231923
+   3.28575206  0.58263320  4.65709011
+   3.17710338  0.57982020  9.63395856
+   3.34277990 10.91024128  2.19001271
+   3.23331373 10.92279866  7.14329201
+   6.01853409  0.55578331  2.76876939
+   5.92077316  0.57110724  7.72389286
+   8.19551633  9.39608936  4.47678235
+   8.08236354  9.40170507  9.41686544
+   1.17510505  2.06450865  0.47305650
+   1.07543047  2.09542530  5.44788755
+   1.11771028  9.39593828  2.96019094
+   1.01328581  9.42102459  7.91083301
+   8.21489227  2.06852974  1.99253441
+   8.12913309  2.08211358  6.95483452
+   3.43679332  5.19325753  2.01110025
+   3.24699435  5.07996222  7.12516690
+   6.02420404  6.40993940  2.82377310
+   5.92508250  6.38106359  7.77159027
+   6.09592488  5.09029672  0.34393552
+   5.95112487  5.10147345  5.30630775
+   3.29415854  6.36994414  4.61871296
+   3.18237689  6.41393334  9.52795260
+   8.28588711  7.93041092  1.93810793
+   8.17754429  7.93123770  6.91189733
+   0.97695747  3.46979447  2.94617118
+   0.95932304  3.56098929  7.97176386
+   1.16263260  7.97622071  0.46828542
+   1.00484741  7.95433956  5.47929715
+   8.18430261  3.54701297  4.46037054
+   8.13509181  3.54963954  9.39790160
+   1.35637581  5.18728541  0.30369502
+   1.18854407  5.19907630  5.40240515
+   8.00603841  6.31694644  4.66078669
+   7.91248715  6.31514261  9.61578333
+   8.05298639  5.15357169  2.19296035
+   7.96819057  5.16130792  7.14020305
+   1.26610807  6.44078389  2.68863238
+   1.18773156  6.34873209  7.78599188
+   3.53422094  3.63227719  4.52972519
+ 
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ k-point  1 :   0.0000 0.0000 0.0000  plane waves:   19591
+ k-point  2 :   0.5000 0.0000 0.0000  plane waves:   19562
+ k-point  3 :   0.0000 0.0000 0.5000  plane waves:   19606
+ k-point  4 :   0.5000 0.0000 0.5000  plane waves:   19580
+
+ maximum and minimum number of plane-waves per node :     19606    19562
+
+ maximum number of plane-waves:     19606
+ maximum index in each direction: 
+   IXMAX=   15   IYMAX=   18   IZMAX=   16
+   IXMIN=  -15   IYMIN=  -18   IZMIN=  -16
+
+
+ serial   3D FFT for wavefunctions
+ parallel 3D FFT for charge:
+    minimum data exchange during FFTs selected (reduces bandwidth)
+
+
+ total amount of memory used by VASP MPI-rank0   123409. kBytes
+=======================================================================
+
+   base      :      30000. kBytes
+   nonlr-proj:      17792. kBytes
+   fftplans  :       2682. kBytes
+   grid      :      17235. kBytes
+   one-center:       2985. kBytes
+   wavefun   :      52715. kBytes
+ 
+     INWAV:  cpu time    2.5400: real time    2.5432
+ Broyden mixing: mesh for mixing (old mesh)
+   NGX = 31   NGY = 37   NGZ = 33
+  (NGX  = 96   NGY  =112   NGZ  = 96)
+  gives a total of  37851 points
+
+ charge density for first step will be calculated from the start-wavefunctions
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ Maximum index for non-local projection operator         2618
+ Maximum index for augmentation-charges          923 (set IRDMAX)
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ initial charge from wavefunction
+ First call to EWALD:  gamma=   0.173
+ Maximum number of real-space cells 3x 3x 3
+ Maximum number of reciprocal cells 3x 3x 3
+
+    FEWALD:  cpu time    0.0040: real time    0.0038
+
+
+--------------------------------------- Iteration      1(   1)  ---------------------------------------
+
+
+    POTLOK:  cpu time    0.0760: real time    0.0791
+    SETDIJ:  cpu time    0.7560: real time    0.7545
+atom =  17  type =  3  l = 2
+ 
+ onsite density matrix
+ 
+spin component  1
+ 
+  0.5282  0.1503 -0.0206 -0.0063 -0.0159
+  0.1503  0.4075  0.0081 -0.0328 -0.0062
+ -0.0206  0.0081  0.3748 -0.1390  0.0232
+ -0.0063 -0.0328 -0.1390  0.5263 -0.0327
+ -0.0159 -0.0062  0.0232 -0.0327  0.3211
+ 
+spin component  2
+ 
+  0.5281  0.1503 -0.0206 -0.0064 -0.0159
+  0.1503  0.4075  0.0081 -0.0328 -0.0062
+ -0.0206  0.0081  0.3748 -0.1390  0.0232
+ -0.0064 -0.0328 -0.1390  0.5263 -0.0327
+ -0.0159 -0.0062  0.0232 -0.0327  0.3210
+ 
+ occupancies and eigenvectors
+ 
+  o =  0.2896  v =  0.1897 -0.1739  0.8433  0.4656 -0.0768  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2896  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.1917 -0.1769  0.8426  0.4650 -0.0760      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3039  v =  0.5227 -0.8095 -0.1684 -0.2064  0.0241  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3039  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.5223 -0.8086 -0.1716 -0.2076  0.0278      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3146  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.0562  0.0308 -0.0037  0.1563  0.9856      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3147  v =  0.0579  0.0277 -0.0036  0.1558  0.9857  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6111  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.4375  0.1916 -0.4730  0.7255 -0.1478      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6112  v =  0.4368  0.1910 -0.4732  0.7260 -0.1475  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6385  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.7042 -0.5264 -0.1920  0.4358 -0.0133      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6385  v = -0.7047 -0.5266 -0.1915  0.4351 -0.0132  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+atom =  18  type =  3  l = 2
+ 
+ onsite density matrix
+ 
+spin component  1
+ 
+  0.5414  0.1523 -0.0209 -0.0031 -0.0132
+  0.1523  0.4042  0.0106 -0.0379 -0.0016
+ -0.0209  0.0106  0.3800 -0.1436  0.0219
+ -0.0031 -0.0379 -0.1436  0.5168 -0.0341
+ -0.0132 -0.0016  0.0219 -0.0341  0.3232
+ 
+spin component  2
+ 
+  0.5414  0.1523 -0.0209 -0.0031 -0.0132
+  0.1523  0.4042  0.0106 -0.0379 -0.0016
+ -0.0209  0.0106  0.3800 -0.1436  0.0219
+ -0.0031 -0.0379 -0.1436  0.5168 -0.0341
+ -0.0132 -0.0016  0.0219 -0.0341  0.3231
+ 
+ occupancies and eigenvectors
+ 
+  o =  0.2878  v =  0.0910 -0.0233  0.8429  0.5294  0.0217  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2878  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.0908 -0.0228  0.8430  0.5293  0.0204      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3015  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.5316 -0.8350  0.0004 -0.1300  0.0572      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3015  v =  0.5315 -0.8349 -0.0004 -0.1300  0.0597  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3169  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.0118  0.0576 -0.0939  0.1120  0.9875      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3170  v =  0.0103  0.0598 -0.0950  0.1116  0.9873  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6130  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.3682  0.1063 -0.5087  0.7572 -0.1449      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6130  v =  0.3683  0.1064 -0.5086  0.7572 -0.1448  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6463  v = -0.7573 -0.5362 -0.1476  0.3421 -0.0125  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6463  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.7573 -0.5363 -0.1475  0.3421 -0.0125      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+atom =  19  type =  3  l = 2
+ 
+ onsite density matrix
+ 
+spin component  1
+ 
+  0.5389  0.1531 -0.0259  0.0020 -0.0142
+  0.1531  0.4032  0.0089 -0.0331 -0.0040
+ -0.0259  0.0089  0.3779 -0.1428  0.0232
+  0.0020 -0.0331 -0.1428  0.5186 -0.0351
+ -0.0142 -0.0040  0.0232 -0.0351  0.3220
+ 
+spin component  2
+ 
+  0.5389  0.1531 -0.0259  0.0020 -0.0142
+  0.1531  0.4032  0.0089 -0.0331 -0.0040
+ -0.0259  0.0089  0.3779 -0.1428  0.0232
+  0.0020 -0.0331 -0.1428  0.5186 -0.0351
+ -0.0142 -0.0040  0.0232 -0.0351  0.3220
+ 
+ occupancies and eigenvectors
+ 
+  o =  0.2868  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.1783 -0.1592  0.8380  0.4904 -0.0110      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2868  v =  0.1782 -0.1590  0.8380  0.4904 -0.0110  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3001  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.5107 -0.8191 -0.1349 -0.2218 -0.0290      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3001  v =  0.5107 -0.8192 -0.1347 -0.2217 -0.0291  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3153  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.0638 -0.0150 -0.0719  0.1169  0.9884      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3153  v =  0.0639 -0.0151 -0.0718  0.1169  0.9884  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6174  v =  0.1631 -0.0297 -0.5237  0.8227 -0.1463  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6174  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.1630 -0.0297 -0.5237  0.8227 -0.1463      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6410  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.8227 -0.5501 -0.0115  0.1407  0.0273      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6410  v = -0.8226 -0.5501 -0.0115  0.1408  0.0273  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+atom =  20  type =  3  l = 2
+ 
+ onsite density matrix
+ 
+spin component  1
+ 
+  0.5341  0.1529 -0.0224  0.0006 -0.0115
+  0.1529  0.4047  0.0106 -0.0309 -0.0030
+ -0.0224  0.0106  0.3786 -0.1432  0.0237
+  0.0006 -0.0309 -0.1432  0.5225 -0.0356
+ -0.0115 -0.0030  0.0237 -0.0356  0.3226
+ 
+spin component  2
+ 
+  0.5341  0.1529 -0.0224  0.0006 -0.0115
+  0.1529  0.4047  0.0106 -0.0309 -0.0029
+ -0.0224  0.0106  0.3786 -0.1432  0.0237
+  0.0006 -0.0309 -0.1432  0.5225 -0.0357
+ -0.0115 -0.0029  0.0237 -0.0357  0.3226
+ 
+ occupancies and eigenvectors
+ 
+  o =  0.2876  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.2260 -0.2486  0.8201  0.4620 -0.0313      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2876  v =  0.2259 -0.2483  0.8202  0.4621 -0.0313  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3013  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.4979 -0.7927 -0.2293 -0.2651 -0.0289      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3013  v =  0.4980 -0.7928 -0.2290 -0.2650 -0.0290  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3159  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.0619 -0.0228 -0.0578  0.1269  0.9880      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3159  v =  0.0620 -0.0229 -0.0578  0.1269  0.9880  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6189  v =  0.3010  0.0780 -0.5093  0.7887 -0.1481  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6189  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.3010  0.0780 -0.5093  0.7887 -0.1481      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6387  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.7788 -0.5506 -0.1100  0.2795 -0.0062      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6387  v = -0.7788 -0.5506 -0.1100  0.2795 -0.0062  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+atom =  21  type =  3  l = 2
+ 
+ onsite density matrix
+ 
+spin component  1
+ 
+  0.5451  0.1600  0.0224  0.0033  0.0105
+  0.1600  0.4099 -0.0104  0.0375  0.0012
+  0.0224 -0.0104  0.3774 -0.1404  0.0228
+  0.0033  0.0375 -0.1404  0.5239 -0.0324
+  0.0105  0.0012  0.0228 -0.0324  0.3235
+ 
+spin component  2
+ 
+  0.5451  0.1600  0.0224  0.0034  0.0106
+  0.1600  0.4099 -0.0104  0.0376  0.0012
+  0.0224 -0.0104  0.3774 -0.1404  0.0228
+  0.0034  0.0376 -0.1404  0.5239 -0.0324
+  0.0106  0.0012  0.0228 -0.0324  0.3236
+ 
+ occupancies and eigenvectors
+ 
+  o =  0.2900  v = -0.1922  0.1832  0.8401  0.4685 -0.0646  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2900  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.1923  0.1831  0.8401  0.4685 -0.0646      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3002  v = -0.5130  0.8105 -0.1649 -0.2267  0.0356  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3002  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.5130  0.8105 -0.1649 -0.2268  0.0352      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3179  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.0313 -0.0223 -0.0113  0.1523  0.9875      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3179  v = -0.0310 -0.0227 -0.0112  0.1525  0.9875  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6149  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.3076  0.0705  0.5064 -0.7903  0.1391      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6149  v =  0.3069  0.0701  0.5065 -0.7906  0.1390  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6568  v = -0.7776 -0.5514  0.1015 -0.2844  0.0080  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6568  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.7774 -0.5514  0.1018 -0.2851  0.0080      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+atom =  22  type =  3  l = 2
+ 
+ onsite density matrix
+ 
+spin component  1
+ 
+  0.5317  0.1454  0.0245  0.0068  0.0085
+  0.1454  0.4013 -0.0079  0.0323  0.0036
+  0.0245 -0.0079  0.3807 -0.1437  0.0225
+  0.0068  0.0323 -0.1437  0.5206 -0.0345
+  0.0085  0.0036  0.0225 -0.0345  0.3198
+ 
+spin component  2
+ 
+  0.5317  0.1454  0.0245  0.0068  0.0085
+  0.1454  0.4014 -0.0079  0.0322  0.0036
+  0.0245 -0.0079  0.3808 -0.1437  0.0225
+  0.0068  0.0322 -0.1437  0.5206 -0.0345
+  0.0085  0.0036  0.0225 -0.0345  0.3198
+ 
+ occupancies and eigenvectors
+ 
+  o =  0.2876  v = -0.2027  0.1788  0.8289  0.4893 -0.0214  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2877  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.2027  0.1786  0.8289  0.4893 -0.0216      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3047  v = -0.4742  0.7921 -0.1495 -0.2438 -0.2567  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3047  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.4742  0.7922 -0.1494 -0.2437 -0.2568      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3144  v = -0.1685  0.2097 -0.0991  0.0634  0.9559  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3145  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.1686  0.2098 -0.0990  0.0636  0.9559      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6130  v =  0.4936  0.2198  0.4779 -0.6796  0.1334  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6131  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.4929  0.2193  0.4782 -0.6801  0.1335      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6343  v = -0.6797 -0.4983  0.2287 -0.4851  0.0454  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6344  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.6802 -0.4985  0.2282 -0.4844  0.0453      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+atom =  23  type =  3  l = 2
+ 
+ onsite density matrix
+ 
+spin component  1
+ 
+  0.5374  0.1517  0.0219 -0.0029  0.0134
+  0.1517  0.4051 -0.0085  0.0324  0.0037
+  0.0219 -0.0085  0.3768 -0.1423  0.0219
+ -0.0029  0.0324 -0.1423  0.5205 -0.0338
+  0.0134  0.0037  0.0219 -0.0338  0.3211
+ 
+spin component  2
+ 
+  0.5374  0.1517  0.0219 -0.0029  0.0134
+  0.1517  0.4052 -0.0085  0.0324  0.0037
+  0.0219 -0.0085  0.3769 -0.1423  0.0220
+ -0.0029  0.0324 -0.1423  0.5205 -0.0338
+  0.0134  0.0037  0.0220 -0.0338  0.3213
+ 
+ occupancies and eigenvectors
+ 
+  o =  0.2880  v = -0.0952  0.0436  0.8517  0.5134 -0.0049  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2881  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.0950  0.0437  0.8521  0.5128 -0.0104      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3020  v = -0.5351  0.8320 -0.0156 -0.1442 -0.0230  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3021  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.5351  0.8319 -0.0158 -0.1441 -0.0217      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3150  v = -0.0573  0.0087 -0.0691  0.1127  0.9895  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3152  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.0571  0.0079 -0.0645  0.1160  0.9895      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6168  v =  0.2099  0.0069  0.5169 -0.8178  0.1413  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6168  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.2095  0.0066  0.5169 -0.8178  0.1416      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6391  v = -0.8107 -0.5530  0.0490 -0.1849 -0.0176  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6392  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.8108 -0.5530  0.0487 -0.1844 -0.0176      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+atom =  24  type =  3  l = 2
+ 
+ onsite density matrix
+ 
+spin component  1
+ 
+  0.5387  0.1517  0.0279  0.0002  0.0132
+  0.1517  0.4036 -0.0090  0.0348  0.0039
+  0.0279 -0.0090  0.3786 -0.1422  0.0215
+  0.0002  0.0348 -0.1422  0.5215 -0.0322
+  0.0132  0.0039  0.0215 -0.0322  0.3235
+ 
+spin component  2
+ 
+  0.5387  0.1517  0.0279  0.0002  0.0132
+  0.1517  0.4036 -0.0090  0.0348  0.0039
+  0.0279 -0.0090  0.3786 -0.1422  0.0215
+  0.0002  0.0348 -0.1422  0.5215 -0.0322
+  0.0132  0.0039  0.0215 -0.0322  0.3235
+ 
+ occupancies and eigenvectors
+ 
+  o =  0.2878  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.2171  0.2076  0.8291  0.4713 -0.0174      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2878  v = -0.2169  0.2073  0.8291  0.4715 -0.0172  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3020  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.4940  0.8091 -0.1878 -0.2548 -0.0347      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3020  v = -0.4941  0.8091 -0.1875 -0.2546 -0.0348  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3178  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.0661  0.0215 -0.0636  0.1084  0.9896      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3178  v = -0.0661  0.0215 -0.0637  0.1083  0.9896  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6177  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.2365  0.0164  0.5204 -0.8087  0.1374      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6177  v =  0.2364  0.0164  0.5204 -0.8088  0.1374  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6407  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.8053 -0.5492  0.0498 -0.2171 -0.0149      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6407  v = -0.8054 -0.5492  0.0498 -0.2171 -0.0149  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+atom =  25  type =  3  l = 2
+ 
+ onsite density matrix
+ 
+spin component  1
+ 
+  0.5378  0.1544 -0.0233 -0.0041 -0.0129
+  0.1544  0.4039  0.0053 -0.0383 -0.0007
+ -0.0233  0.0053  0.3754 -0.1390  0.0217
+ -0.0041 -0.0383 -0.1390  0.5215 -0.0311
+ -0.0129 -0.0007  0.0217 -0.0311  0.3243
+ 
+spin component  2
+ 
+  0.5378  0.1544 -0.0233 -0.0041 -0.0129
+  0.1544  0.4039  0.0053 -0.0383 -0.0007
+ -0.0233  0.0053  0.3754 -0.1390  0.0217
+ -0.0041 -0.0383 -0.1390  0.5215 -0.0311
+ -0.0129 -0.0007  0.0217 -0.0311  0.3243
+ 
+ occupancies and eigenvectors
+ 
+  o =  0.2892  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.0113 -0.1181 -0.8454 -0.5176  0.0582      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2892  v = -0.0114 -0.1181 -0.8454 -0.5176  0.0578  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2985  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.5468 -0.8200  0.1344 -0.0333  0.0974      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2985  v =  0.5468 -0.8200  0.1343 -0.0333  0.0976  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3190  v =  0.0119 -0.0976  0.0350 -0.1451 -0.9839  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3190  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.0117 -0.0975  0.0347 -0.1452 -0.9839      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6107  v =  0.3292  0.0888 -0.5046  0.7811 -0.1380  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6107  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.3293  0.0888 -0.5045  0.7811 -0.1380      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6454  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.7696 -0.5444 -0.1074  0.3159 -0.0057      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6454  v = -0.7696 -0.5444 -0.1074  0.3159 -0.0057  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+atom =  26  type =  3  l = 2
+ 
+ onsite density matrix
+ 
+spin component  1
+ 
+  0.5362  0.1482 -0.0222  0.0013 -0.0113
+  0.1482  0.4065  0.0098 -0.0327 -0.0030
+ -0.0222  0.0098  0.3813 -0.1440  0.0211
+  0.0013 -0.0327 -0.1440  0.5220 -0.0338
+ -0.0113 -0.0030  0.0211 -0.0338  0.3203
+ 
+spin component  2
+ 
+  0.5362  0.1482 -0.0222  0.0013 -0.0113
+  0.1482  0.4065  0.0098 -0.0327 -0.0030
+ -0.0222  0.0098  0.3813 -0.1439  0.0211
+  0.0013 -0.0327 -0.1439  0.5221 -0.0338
+ -0.0113 -0.0030  0.0211 -0.0338  0.3203
+ 
+ occupancies and eigenvectors
+ 
+  o =  0.2899  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.1291  0.0907 -0.8433 -0.5131 -0.0252      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2899  v = -0.1286  0.0899 -0.8433 -0.5134 -0.0260  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3059  v = -0.5214  0.8251  0.0540  0.1808  0.1080  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3059  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.5212  0.8250  0.0549  0.1814  0.1082      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3147  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.0937 -0.0804 -0.0999  0.0780  0.9842      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3147  v =  0.0935 -0.0802 -0.1004  0.0777  0.9842  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6191  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.3426  0.0984 -0.5076  0.7723 -0.1373      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6191  v =  0.3424  0.0984 -0.5077  0.7723 -0.1373  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6368  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.7652 -0.5431 -0.1346  0.3183 -0.0104      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6368  v = -0.7653 -0.5431 -0.1346  0.3181 -0.0104  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+atom =  27  type =  3  l = 2
+ 
+ onsite density matrix
+ 
+spin component  1
+ 
+  6.1320 -7.9985  9.9720  5.1366 -1.5481
+ -7.9985 11.2215-13.7153 -6.9893  2.1083
+  9.9720-13.7153 17.1305  8.6130 -2.6035
+  5.1366 -6.9893  8.6130  4.6441 -1.3773
+ -1.5481  2.1083 -2.6035 -1.3773  0.5186
+ 
+spin component  2
+ 
+  0.2072  0.0820 -0.0441  0.0155  0.0005
+  0.0820  0.1381  0.0032  0.0204 -0.0103
+ -0.0441  0.0032  0.1180 -0.0734  0.0235
+  0.0155  0.0204 -0.0734  0.1874 -0.0333
+  0.0005 -0.0103  0.0235 -0.0333  0.0992
+ 
+ occupancies and eigenvectors
+ 
+  o =  0.0468  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.4007 -0.4807  0.6783  0.3348 -0.1899      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.0870  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.0773  0.1272  0.1803  0.4100  0.8816      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.0993  v = -0.1076  0.1772  0.1452  0.3876  0.8864  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.1074  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.3689  0.6772  0.4975  0.2171 -0.3328      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.1206  v = -0.3300  0.6451  0.5453  0.2247 -0.3565  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2143  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.5090  0.3531  0.3436 -0.6661  0.2332      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2310  v =  0.5058  0.3287  0.3497 -0.6774  0.2346  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2943  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.6620 -0.4117  0.3766 -0.4784  0.1468      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3170  v =  0.6868  0.3988 -0.3484  0.4755 -0.1472  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o = 38.8788  v = -0.3899  0.5342 -0.6618 -0.3381  0.1021  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+atom =  28  type =  3  l = 2
+ 
+ onsite density matrix
+ 
+spin component  1
+ 
+  0.5341  0.1460 -0.0226  0.0047 -0.0094
+  0.1460  0.4044  0.0160 -0.0391  0.0006
+ -0.0226  0.0160  0.3830 -0.1456  0.0253
+  0.0047 -0.0391 -0.1456  0.5246 -0.0406
+ -0.0094  0.0006  0.0253 -0.0406  0.3196
+ 
+spin component  2
+ 
+  0.5342  0.1459 -0.0227  0.0047 -0.0094
+  0.1459  0.4047  0.0159 -0.0391  0.0006
+ -0.0227  0.0159  0.3840 -0.1454  0.0253
+  0.0047 -0.0391 -0.1454  0.5248 -0.0406
+ -0.0094  0.0006  0.0253 -0.0406  0.3197
+ 
+ occupancies and eigenvectors
+ 
+  o =  0.2903  v = -0.1614  0.1548 -0.8393 -0.4953 -0.0167  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2912  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.1649  0.1592 -0.8380 -0.4949 -0.0183      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3039  v = -0.5027  0.8095  0.0979  0.2459  0.1482  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3042  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.5014  0.8080  0.1017  0.2491  0.1526      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3121  v =  0.1089 -0.1231 -0.1127  0.0841  0.9763  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3122  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.1107 -0.1262 -0.1153  0.0815  0.9756      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6218  v =  0.6286  0.2871 -0.4086  0.5816 -0.1312  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6221  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.6317  0.2899 -0.4075  0.5777 -0.1306      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6376  v = -0.5606 -0.4724 -0.3262  0.5906 -0.0856  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6378  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.5568 -0.4710 -0.3287  0.5939 -0.0862      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+atom =  29  type =  3  l = 2
+ 
+ onsite density matrix
+ 
+spin component  1
+ 
+  0.5253  0.1456  0.0173 -0.0110  0.0126
+  0.1456  0.4023 -0.0032  0.0269  0.0017
+  0.0173 -0.0032  0.3762 -0.1492  0.0263
+ -0.0110  0.0269 -0.1492  0.5379 -0.0494
+  0.0126  0.0017  0.0263 -0.0494  0.3172
+ 
+spin component  2
+ 
+  0.5252  0.1456  0.0174 -0.0112  0.0127
+  0.1456  0.3986 -0.0030  0.0253  0.0009
+  0.0174 -0.0030  0.3762 -0.1491  0.0264
+ -0.0112  0.0253 -0.1491  0.5376 -0.0502
+  0.0127  0.0009  0.0264 -0.0502  0.3171
+ 
+ occupancies and eigenvectors
+ 
+  o =  0.2854  v = -0.0856  0.2082 -0.8072 -0.5291 -0.1332  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2855  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.0826  0.2041 -0.8072 -0.5295 -0.1398      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3009  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.5332  0.7823  0.1699  0.0550  0.2680      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3036  v = -0.5414  0.7868  0.1899  0.0517  0.2214  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3076  v =  0.0750 -0.1599 -0.2487  0.0651  0.9501  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3076  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.1021  0.1985  0.2628 -0.0610 -0.9367      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6204  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.7987 -0.5510  0.0882 -0.2248  0.0097      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6220  v = -0.8054 -0.5577  0.0661 -0.1899  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6402  v =  0.2128  0.0316  0.4961 -0.8228  0.1748  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6404  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.2460  0.0574  0.4926 -0.8138  0.1766      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+atom =  30  type =  3  l = 2
+ 
+ onsite density matrix
+ 
+spin component  1
+ 
+  0.5360  0.1692  0.0086  0.0177  0.0020
+  0.1692  0.4031 -0.0239  0.0417 -0.0093
+  0.0086 -0.0239  0.3871 -0.1406  0.0438
+  0.0177  0.0417 -0.1406  0.4928 -0.0407
+  0.0020 -0.0093  0.0438 -0.0407  0.3362
+ 
+spin component  2
+ 
+  0.5361  0.1692  0.0079  0.0175  0.0016
+  0.1692  0.4033 -0.0239  0.0418 -0.0095
+  0.0079 -0.0239  0.3860 -0.1417  0.0425
+  0.0175  0.0418 -0.1417  0.4918 -0.0418
+  0.0016 -0.0095  0.0425 -0.0418  0.3349
+ 
+ occupancies and eigenvectors
+ 
+  o =  0.2790  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.4144  0.5694  0.6238  0.3113 -0.1342      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2791  v = -0.4362  0.6048  0.5888  0.2792 -0.1390  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2888  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.3643  0.5973 -0.5291 -0.4087  0.2522      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2895  v = -0.3378  0.5608 -0.5608 -0.4152  0.2907  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3252  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.0139 -0.0654  0.1021  0.3361  0.9339      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3276  v =  0.0138 -0.0723  0.1330  0.3567  0.9218  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.5881  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.4507  0.1827  0.5136 -0.6796  0.1945      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.5883  v =  0.4497  0.1815  0.5150 -0.6791  0.1960  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6708  v = -0.7023 -0.5305  0.2364 -0.4015  0.0902  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6712  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.7016 -0.5304  0.2382 -0.4016  0.0917      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+atom =  31  type =  3  l = 2
+ 
+ onsite density matrix
+ 
+spin component  1
+ 
+  0.5379  0.1526  0.0216 -0.0080  0.0157
+  0.1526  0.4090 -0.0126  0.0278  0.0076
+  0.0216 -0.0126  0.3792 -0.1430  0.0219
+ -0.0080  0.0278 -0.1430  0.5216 -0.0334
+  0.0157  0.0076  0.0219 -0.0334  0.3246
+ 
+spin component  2
+ 
+  0.5380  0.1526  0.0215 -0.0080  0.0157
+  0.1526  0.4091 -0.0126  0.0278  0.0076
+  0.0215 -0.0126  0.3794 -0.1429  0.0216
+ -0.0080  0.0278 -0.1429  0.5217 -0.0335
+  0.0157  0.0076  0.0216 -0.0335  0.3251
+ 
+ occupancies and eigenvectors
+ 
+  o =  0.2887  v = -0.1903  0.2215  0.8309  0.4726 -0.0310  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2889  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.1904  0.2207  0.8306  0.4741 -0.0214      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3048  v =  0.5000 -0.7911  0.1816  0.2625  0.1492  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3048  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.5001 -0.7913  0.1795  0.2617  0.1518      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3185  v = -0.1364  0.1104 -0.0743  0.0882  0.9777  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3191  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.1358  0.1104 -0.0826  0.0828  0.9776      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6196  v =  0.0302 -0.1147  0.5183 -0.8366  0.1320  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6196  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.0306 -0.1144  0.5184 -0.8366  0.1318      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6406  v = -0.8333 -0.5475 -0.0499  0.0049 -0.0586  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6407  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.8332 -0.5476 -0.0496  0.0044 -0.0585      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+atom =  32  type =  3  l = 2
+ 
+ onsite density matrix
+ 
+spin component  1
+ 
+  0.5340  0.1505  0.0253 -0.0046  0.0100
+  0.1505  0.4055 -0.0137  0.0305  0.0026
+  0.0253 -0.0137  0.3818 -0.1459  0.0250
+ -0.0046  0.0305 -0.1459  0.5187 -0.0386
+  0.0100  0.0026  0.0250 -0.0386  0.3217
+ 
+spin component  2
+ 
+  0.5340  0.1505  0.0252 -0.0046  0.0100
+  0.1505  0.4055 -0.0138  0.0305  0.0026
+  0.0252 -0.0138  0.3819 -0.1459  0.0250
+ -0.0046  0.0305 -0.1459  0.5187 -0.0386
+  0.0100  0.0026  0.0250 -0.0386  0.3217
+ 
+ occupancies and eigenvectors
+ 
+  o =  0.2856  v = -0.2425  0.2801  0.8065  0.4603 -0.0186  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2857  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.2424  0.2802  0.8066  0.4602 -0.0196      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3037  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.4729  0.7660 -0.2346 -0.3126 -0.1920      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3037  v = -0.4731  0.7662 -0.2346 -0.3124 -0.1911  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3148  v = -0.1351  0.1539 -0.1147  0.0754  0.9691  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3148  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.1358  0.1549 -0.1142  0.0755  0.9689      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6226  v =  0.2071 -0.0017  0.5281 -0.8089  0.1546  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6226  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.2073 -0.0016  0.5281 -0.8089  0.1546      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6351  v = -0.8101 -0.5575  0.0497 -0.1748 -0.0050  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6351  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.8100 -0.5574  0.0499 -0.1749 -0.0049      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+     EDDAV:  cpu time    4.1560: real time    4.1615
+       DOS:  cpu time    0.0040: real time    0.0010
+    CHARGE:  cpu time    0.1400: real time    0.1423
+    MIXING:  cpu time    0.0040: real time    0.0030
+    --------------------------------------------
+      LOOP:  cpu time    5.1360: real time    5.1415
+
+ eigenvalue-minimisations  :  3492
+ total energy-change (2. order) :-0.2822363E+04  (-0.4660382E-05)
+ number of electron     507.9999664 magnetization       2.0000001
+ augmentation part       52.2566189 magnetization       0.5684723
+
+ Broyden mixing:
+  rms(total) = 0.21965E-01    rms(broyden)= 0.21965E-01
+  rms(prec ) = 0.21965E-01
+  weight for this iteration     100.00
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      1704.46002184
+  Ewald energy   TEWEN  =    -23930.25020506
+  -Hartree energ DENC   =     -9206.68988730
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =       393.84006283
+  PAW double counting   =   2700830.30888769 -2696977.44709764
+  entropy T*S    EENTRO =        -0.00000000
+  eigenvalues    EBANDS =     -6446.42746587
+  atomic energy  EATOM  =     30809.84260991
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =     -2822.36307361 eV
+
+  energy without entropy =    -2822.36307361  energy(sigma->0) =    -2822.36307361
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(   2)  ---------------------------------------
+
+
+    POTLOK:  cpu time    0.0720: real time    0.0831
+    SETDIJ:  cpu time    0.7880: real time    0.7850
+atom =  17  type =  3  l = 2
+ 
+ onsite density matrix
+ 
+spin component  1
+ 
+  0.5282  0.1503 -0.0206 -0.0063 -0.0159
+  0.1503  0.4075  0.0081 -0.0328 -0.0062
+ -0.0206  0.0081  0.3748 -0.1390  0.0232
+ -0.0063 -0.0328 -0.1390  0.5263 -0.0327
+ -0.0159 -0.0062  0.0232 -0.0327  0.3211
+ 
+spin component  2
+ 
+  0.5281  0.1503 -0.0206 -0.0064 -0.0159
+  0.1503  0.4075  0.0081 -0.0328 -0.0062
+ -0.0206  0.0081  0.3748 -0.1390  0.0232
+ -0.0064 -0.0328 -0.1390  0.5263 -0.0327
+ -0.0159 -0.0062  0.0232 -0.0327  0.3210
+ 
+ occupancies and eigenvectors
+ 
+  o =  0.2896  v =  0.1897 -0.1739  0.8433  0.4656 -0.0768  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2896  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.1917 -0.1769  0.8426  0.4650 -0.0760      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3039  v =  0.5227 -0.8095 -0.1684 -0.2064  0.0241  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3039  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.5223 -0.8086 -0.1716 -0.2076  0.0278      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3146  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.0562  0.0308 -0.0037  0.1563  0.9856      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3147  v =  0.0579  0.0277 -0.0036  0.1558  0.9857  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6111  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.4375  0.1916 -0.4730  0.7255 -0.1478      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6112  v =  0.4368  0.1910 -0.4732  0.7260 -0.1475  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6385  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.7042 -0.5264 -0.1920  0.4358 -0.0133      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6385  v = -0.7047 -0.5266 -0.1915  0.4351 -0.0132  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+atom =  18  type =  3  l = 2
+ 
+ onsite density matrix
+ 
+spin component  1
+ 
+  0.5414  0.1523 -0.0209 -0.0031 -0.0132
+  0.1523  0.4042  0.0106 -0.0379 -0.0016
+ -0.0209  0.0106  0.3800 -0.1436  0.0219
+ -0.0031 -0.0379 -0.1436  0.5168 -0.0341
+ -0.0132 -0.0016  0.0219 -0.0341  0.3232
+ 
+spin component  2
+ 
+  0.5414  0.1523 -0.0209 -0.0031 -0.0132
+  0.1523  0.4042  0.0106 -0.0379 -0.0016
+ -0.0209  0.0106  0.3800 -0.1436  0.0219
+ -0.0031 -0.0379 -0.1436  0.5168 -0.0341
+ -0.0132 -0.0016  0.0219 -0.0341  0.3231
+ 
+ occupancies and eigenvectors
+ 
+  o =  0.2878  v =  0.0910 -0.0233  0.8429  0.5294  0.0217  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2878  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.0907 -0.0228  0.8430  0.5293  0.0204      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3015  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.5316 -0.8350  0.0004 -0.1300  0.0572      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3015  v =  0.5315 -0.8349 -0.0003 -0.1300  0.0597  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3169  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.0118  0.0576 -0.0939  0.1120  0.9875      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3170  v =  0.0103  0.0598 -0.0950  0.1116  0.9873  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6130  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.3683  0.1063 -0.5087  0.7572 -0.1449      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6130  v =  0.3683  0.1064 -0.5086  0.7572 -0.1448  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6463  v = -0.7573 -0.5362 -0.1476  0.3422 -0.0125  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6463  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.7573 -0.5363 -0.1475  0.3421 -0.0125      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+atom =  19  type =  3  l = 2
+ 
+ onsite density matrix
+ 
+spin component  1
+ 
+  0.5389  0.1531 -0.0259  0.0020 -0.0142
+  0.1531  0.4032  0.0089 -0.0331 -0.0040
+ -0.0259  0.0089  0.3779 -0.1428  0.0232
+  0.0020 -0.0331 -0.1428  0.5186 -0.0351
+ -0.0142 -0.0040  0.0232 -0.0351  0.3220
+ 
+spin component  2
+ 
+  0.5389  0.1531 -0.0259  0.0020 -0.0142
+  0.1531  0.4032  0.0089 -0.0331 -0.0040
+ -0.0259  0.0089  0.3779 -0.1428  0.0232
+  0.0020 -0.0331 -0.1428  0.5186 -0.0351
+ -0.0142 -0.0040  0.0232 -0.0351  0.3220
+ 
+ occupancies and eigenvectors
+ 
+  o =  0.2868  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.1783 -0.1592  0.8380  0.4904 -0.0110      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2868  v =  0.1782 -0.1590  0.8380  0.4904 -0.0110  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3001  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.5107 -0.8191 -0.1348 -0.2218 -0.0290      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3001  v =  0.5107 -0.8192 -0.1347 -0.2217 -0.0291  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3153  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.0638 -0.0150 -0.0719  0.1169  0.9884      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3153  v =  0.0639 -0.0151 -0.0718  0.1169  0.9884  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6174  v =  0.1631 -0.0297 -0.5237  0.8227 -0.1463  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6174  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.1630 -0.0297 -0.5237  0.8227 -0.1463      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6410  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.8227 -0.5501 -0.0115  0.1407  0.0273      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6410  v = -0.8226 -0.5501 -0.0115  0.1408  0.0273  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+atom =  20  type =  3  l = 2
+ 
+ onsite density matrix
+ 
+spin component  1
+ 
+  0.5341  0.1529 -0.0224  0.0006 -0.0115
+  0.1529  0.4047  0.0106 -0.0309 -0.0030
+ -0.0224  0.0106  0.3786 -0.1432  0.0237
+  0.0006 -0.0309 -0.1432  0.5225 -0.0357
+ -0.0115 -0.0030  0.0237 -0.0357  0.3225
+ 
+spin component  2
+ 
+  0.5341  0.1529 -0.0224  0.0006 -0.0115
+  0.1529  0.4047  0.0106 -0.0309 -0.0029
+ -0.0224  0.0106  0.3786 -0.1432  0.0237
+  0.0006 -0.0309 -0.1432  0.5225 -0.0357
+ -0.0115 -0.0029  0.0237 -0.0357  0.3225
+ 
+ occupancies and eigenvectors
+ 
+  o =  0.2876  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.2260 -0.2486  0.8202  0.4621 -0.0313      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2876  v =  0.2258 -0.2483  0.8202  0.4621 -0.0313  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3013  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.4979 -0.7928 -0.2292 -0.2651 -0.0289      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3013  v =  0.4980 -0.7928 -0.2289 -0.2649 -0.0290  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3159  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.0619 -0.0228 -0.0578  0.1269  0.9880      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3159  v =  0.0620 -0.0229 -0.0578  0.1269  0.9880  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6189  v =  0.3010  0.0780 -0.5093  0.7887 -0.1481  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6189  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.3011  0.0780 -0.5093  0.7887 -0.1481      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6387  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.7788 -0.5506 -0.1100  0.2796 -0.0062      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6387  v = -0.7788 -0.5506 -0.1100  0.2796 -0.0062  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+atom =  21  type =  3  l = 2
+ 
+ onsite density matrix
+ 
+spin component  1
+ 
+  0.5451  0.1600  0.0224  0.0033  0.0105
+  0.1600  0.4099 -0.0104  0.0375  0.0012
+  0.0224 -0.0104  0.3774 -0.1404  0.0228
+  0.0033  0.0375 -0.1404  0.5239 -0.0324
+  0.0105  0.0012  0.0228 -0.0324  0.3235
+ 
+spin component  2
+ 
+  0.5451  0.1600  0.0224  0.0034  0.0106
+  0.1600  0.4099 -0.0104  0.0376  0.0012
+  0.0224 -0.0104  0.3774 -0.1404  0.0228
+  0.0034  0.0376 -0.1404  0.5239 -0.0324
+  0.0106  0.0012  0.0228 -0.0324  0.3235
+ 
+ occupancies and eigenvectors
+ 
+  o =  0.2900  v = -0.1922  0.1831  0.8402  0.4685 -0.0646  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2900  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.1923  0.1831  0.8402  0.4685 -0.0646      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3002  v = -0.5130  0.8105 -0.1649 -0.2266  0.0356  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3002  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.5130  0.8106 -0.1649 -0.2267  0.0352      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3179  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.0313 -0.0223 -0.0113  0.1523  0.9875      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3179  v = -0.0310 -0.0227 -0.0112  0.1525  0.9875  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6149  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.3076  0.0706  0.5064 -0.7903  0.1391      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6149  v =  0.3069  0.0701  0.5065 -0.7906  0.1390  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6568  v = -0.7776 -0.5514  0.1015 -0.2844  0.0080  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6568  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.7774 -0.5514  0.1018 -0.2851  0.0080      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+atom =  22  type =  3  l = 2
+ 
+ onsite density matrix
+ 
+spin component  1
+ 
+  0.5317  0.1454  0.0245  0.0068  0.0085
+  0.1454  0.4013 -0.0079  0.0323  0.0036
+  0.0245 -0.0079  0.3807 -0.1437  0.0225
+  0.0068  0.0323 -0.1437  0.5206 -0.0345
+  0.0085  0.0036  0.0225 -0.0345  0.3198
+ 
+spin component  2
+ 
+  0.5317  0.1454  0.0245  0.0068  0.0085
+  0.1454  0.4014 -0.0079  0.0323  0.0036
+  0.0245 -0.0079  0.3808 -0.1437  0.0225
+  0.0068  0.0323 -0.1437  0.5206 -0.0345
+  0.0085  0.0036  0.0225 -0.0345  0.3198
+ 
+ occupancies and eigenvectors
+ 
+  o =  0.2876  v = -0.2027  0.1787  0.8289  0.4893 -0.0214  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2877  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.2026  0.1786  0.8289  0.4893 -0.0216      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3047  v = -0.4742  0.7921 -0.1495 -0.2438 -0.2567  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3047  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.4742  0.7922 -0.1494 -0.2437 -0.2568      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3144  v = -0.1685  0.2098 -0.0991  0.0634  0.9559  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3144  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.1686  0.2098 -0.0990  0.0635  0.9559      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6130  v =  0.4937  0.2198  0.4779 -0.6796  0.1334  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6131  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.4929  0.2193  0.4782 -0.6800  0.1335      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6343  v = -0.6797 -0.4983  0.2288 -0.4851  0.0454  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6344  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.6802 -0.4985  0.2282 -0.4844  0.0453      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+atom =  23  type =  3  l = 2
+ 
+ onsite density matrix
+ 
+spin component  1
+ 
+  0.5374  0.1517  0.0219 -0.0029  0.0134
+  0.1517  0.4051 -0.0085  0.0324  0.0037
+  0.0219 -0.0085  0.3768 -0.1423  0.0219
+ -0.0029  0.0324 -0.1423  0.5205 -0.0338
+  0.0134  0.0037  0.0219 -0.0338  0.3211
+ 
+spin component  2
+ 
+  0.5374  0.1517  0.0219 -0.0029  0.0134
+  0.1517  0.4052 -0.0085  0.0324  0.0037
+  0.0219 -0.0085  0.3769 -0.1423  0.0220
+ -0.0029  0.0324 -0.1423  0.5205 -0.0338
+  0.0134  0.0037  0.0220 -0.0338  0.3213
+ 
+ occupancies and eigenvectors
+ 
+  o =  0.2880  v = -0.0952  0.0435  0.8517  0.5134 -0.0049  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2881  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.0949  0.0436  0.8521  0.5128 -0.0104      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3020  v = -0.5351  0.8320 -0.0156 -0.1441 -0.0229  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3021  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.5351  0.8320 -0.0158 -0.1441 -0.0217      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3150  v = -0.0573  0.0087 -0.0691  0.1127  0.9895  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3152  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.0571  0.0079 -0.0645  0.1160  0.9895      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6168  v =  0.2100  0.0069  0.5169 -0.8178  0.1413  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6168  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.2095  0.0066  0.5169 -0.8178  0.1416      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6391  v = -0.8107 -0.5530  0.0491 -0.1849 -0.0176  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6392  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.8108 -0.5530  0.0487 -0.1844 -0.0176      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+atom =  24  type =  3  l = 2
+ 
+ onsite density matrix
+ 
+spin component  1
+ 
+  0.5387  0.1517  0.0279  0.0002  0.0132
+  0.1517  0.4036 -0.0090  0.0348  0.0039
+  0.0279 -0.0090  0.3786 -0.1422  0.0215
+  0.0002  0.0348 -0.1422  0.5215 -0.0322
+  0.0132  0.0039  0.0215 -0.0322  0.3235
+ 
+spin component  2
+ 
+  0.5387  0.1517  0.0279  0.0002  0.0132
+  0.1517  0.4036 -0.0090  0.0348  0.0039
+  0.0279 -0.0090  0.3786 -0.1422  0.0215
+  0.0002  0.0348 -0.1422  0.5215 -0.0322
+  0.0132  0.0039  0.0215 -0.0322  0.3235
+ 
+ occupancies and eigenvectors
+ 
+  o =  0.2878  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.2170  0.2076  0.8291  0.4713 -0.0174      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2878  v = -0.2168  0.2073  0.8291  0.4715 -0.0172  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3020  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.4940  0.8091 -0.1878 -0.2548 -0.0347      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3020  v = -0.4941  0.8092 -0.1875 -0.2546 -0.0348  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3178  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.0661  0.0215 -0.0636  0.1084  0.9896      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3178  v = -0.0661  0.0215 -0.0637  0.1083  0.9896  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6177  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.2365  0.0164  0.5204 -0.8087  0.1374      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6177  v =  0.2364  0.0164  0.5204 -0.8088  0.1374  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6407  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.8053 -0.5492  0.0498 -0.2171 -0.0149      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6407  v = -0.8054 -0.5492  0.0498 -0.2171 -0.0149  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+atom =  25  type =  3  l = 2
+ 
+ onsite density matrix
+ 
+spin component  1
+ 
+  0.5378  0.1544 -0.0233 -0.0041 -0.0129
+  0.1544  0.4039  0.0053 -0.0383 -0.0007
+ -0.0233  0.0053  0.3754 -0.1390  0.0217
+ -0.0041 -0.0383 -0.1390  0.5215 -0.0311
+ -0.0129 -0.0007  0.0217 -0.0311  0.3243
+ 
+spin component  2
+ 
+  0.5378  0.1544 -0.0233 -0.0041 -0.0129
+  0.1544  0.4039  0.0053 -0.0383 -0.0007
+ -0.0233  0.0053  0.3754 -0.1390  0.0217
+ -0.0041 -0.0383 -0.1390  0.5215 -0.0311
+ -0.0129 -0.0007  0.0217 -0.0311  0.3243
+ 
+ occupancies and eigenvectors
+ 
+  o =  0.2892  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.0114 -0.1181 -0.8454 -0.5176  0.0582      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2892  v = -0.0114 -0.1180 -0.8454 -0.5176  0.0578  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2985  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.5468 -0.8200  0.1343 -0.0334  0.0974      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2985  v =  0.5468 -0.8200  0.1342 -0.0334  0.0976  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3190  v =  0.0118 -0.0975  0.0350 -0.1451 -0.9839  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3190  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.0117 -0.0974  0.0347 -0.1452 -0.9839      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6107  v =  0.3292  0.0887 -0.5046  0.7811 -0.1380  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6107  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.3292  0.0888 -0.5045  0.7811 -0.1380      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6454  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.7696 -0.5444 -0.1074  0.3159 -0.0057      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6454  v = -0.7696 -0.5444 -0.1074  0.3159 -0.0057  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+atom =  26  type =  3  l = 2
+ 
+ onsite density matrix
+ 
+spin component  1
+ 
+  0.5362  0.1482 -0.0222  0.0013 -0.0113
+  0.1482  0.4065  0.0098 -0.0327 -0.0030
+ -0.0222  0.0098  0.3813 -0.1440  0.0211
+  0.0013 -0.0327 -0.1440  0.5220 -0.0338
+ -0.0113 -0.0030  0.0211 -0.0338  0.3203
+ 
+spin component  2
+ 
+  0.5362  0.1482 -0.0222  0.0013 -0.0113
+  0.1482  0.4065  0.0098 -0.0327 -0.0030
+ -0.0222  0.0098  0.3813 -0.1439  0.0211
+  0.0013 -0.0327 -0.1439  0.5221 -0.0338
+ -0.0113 -0.0030  0.0211 -0.0338  0.3203
+ 
+ occupancies and eigenvectors
+ 
+  o =  0.2899  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.1291  0.0907 -0.8433 -0.5131 -0.0252      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2899  v = -0.1286  0.0899 -0.8433 -0.5134 -0.0260  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3059  v = -0.5214  0.8251  0.0540  0.1808  0.1080  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3059  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.5212  0.8250  0.0549  0.1814  0.1082      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3147  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.0937 -0.0804 -0.0999  0.0780  0.9842      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3147  v =  0.0935 -0.0802 -0.1004  0.0777  0.9842  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6191  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.3426  0.0984 -0.5076  0.7723 -0.1373      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6191  v =  0.3424  0.0983 -0.5077  0.7723 -0.1373  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6368  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.7652 -0.5431 -0.1346  0.3183 -0.0104      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6368  v = -0.7653 -0.5431 -0.1346  0.3181 -0.0104  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+atom =  27  type =  3  l = 2
+ 
+ onsite density matrix
+ 
+spin component  1
+ 
+  6.1317 -7.9982  9.9721  5.1364 -1.5479
+ -7.9982 11.2209-13.7154 -6.9890  2.1080
+  9.9721-13.7154 17.1316  8.6131 -2.6032
+  5.1364 -6.9890  8.6131  4.6440 -1.3771
+ -1.5479  2.1080 -2.6032 -1.3771  0.5185
+ 
+spin component  2
+ 
+  0.2073  0.0818 -0.0441  0.0156  0.0004
+  0.0818  0.1384  0.0033  0.0202 -0.0101
+ -0.0441  0.0033  0.1174 -0.0735  0.0233
+  0.0156  0.0202 -0.0735  0.1875 -0.0334
+  0.0004 -0.0101  0.0233 -0.0334  0.0992
+ 
+ occupancies and eigenvectors
+ 
+  o =  0.0468  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.3980 -0.4751  0.6841  0.3377 -0.1840      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.0869  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.0807  0.1312  0.1747  0.4071  0.8832      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.0993  v = -0.1076  0.1772  0.1452  0.3876  0.8864  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.1074  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.3715  0.6801  0.4931  0.2152 -0.3317      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.1206  v = -0.3300  0.6451  0.5453  0.2247 -0.3566  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2143  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.5081  0.3542  0.3424 -0.6669  0.2334      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2310  v =  0.5058  0.3287  0.3497 -0.6774  0.2346  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2943  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.6625 -0.4112  0.3758 -0.4788  0.1469      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3170  v =  0.6868  0.3988 -0.3484  0.4755 -0.1472  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o = 38.8788  v = -0.3898  0.5341 -0.6618 -0.3381  0.1021  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+atom =  28  type =  3  l = 2
+ 
+ onsite density matrix
+ 
+spin component  1
+ 
+  0.5341  0.1460 -0.0226  0.0047 -0.0094
+  0.1460  0.4044  0.0160 -0.0391  0.0006
+ -0.0226  0.0160  0.3830 -0.1456  0.0253
+  0.0047 -0.0391 -0.1456  0.5246 -0.0406
+ -0.0094  0.0006  0.0253 -0.0406  0.3196
+ 
+spin component  2
+ 
+  0.5342  0.1459 -0.0227  0.0047 -0.0094
+  0.1459  0.4047  0.0159 -0.0391  0.0006
+ -0.0227  0.0159  0.3840 -0.1454  0.0253
+  0.0047 -0.0391 -0.1454  0.5248 -0.0405
+ -0.0094  0.0006  0.0253 -0.0405  0.3197
+ 
+ occupancies and eigenvectors
+ 
+  o =  0.2903  v = -0.1614  0.1548 -0.8393 -0.4953 -0.0167  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2912  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.1649  0.1592 -0.8380 -0.4949 -0.0183      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3039  v = -0.5027  0.8095  0.0979  0.2459  0.1482  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3042  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.5014  0.8080  0.1017  0.2491  0.1526      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3121  v =  0.1089 -0.1231 -0.1127  0.0841  0.9763  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3122  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.1107 -0.1262 -0.1153  0.0816  0.9756      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6218  v =  0.6286  0.2870 -0.4086  0.5816 -0.1312  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6221  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.6317  0.2899 -0.4075  0.5777 -0.1306      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6376  v = -0.5606 -0.4724 -0.3261  0.5906 -0.0856  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6378  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.5568 -0.4710 -0.3287  0.5939 -0.0862      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+atom =  29  type =  3  l = 2
+ 
+ onsite density matrix
+ 
+spin component  1
+ 
+  0.5253  0.1456  0.0173 -0.0110  0.0126
+  0.1456  0.4023 -0.0032  0.0269  0.0017
+  0.0173 -0.0032  0.3762 -0.1492  0.0263
+ -0.0110  0.0269 -0.1492  0.5379 -0.0494
+  0.0126  0.0017  0.0263 -0.0494  0.3172
+ 
+spin component  2
+ 
+  0.5252  0.1456  0.0174 -0.0112  0.0127
+  0.1456  0.3986 -0.0030  0.0253  0.0009
+  0.0174 -0.0030  0.3762 -0.1491  0.0264
+ -0.0112  0.0253 -0.1491  0.5376 -0.0502
+  0.0127  0.0009  0.0264 -0.0502  0.3171
+ 
+ occupancies and eigenvectors
+ 
+  o =  0.2854  v = -0.0856  0.2082 -0.8072 -0.5291 -0.1332  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2855  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.0826  0.2041 -0.8072 -0.5295 -0.1398      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3009  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.5332  0.7823  0.1699  0.0550  0.2679      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3036  v = -0.5414  0.7869  0.1900  0.0517  0.2212  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3076  v =  0.0749 -0.1598 -0.2487  0.0651  0.9501  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3076  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.1021  0.1984  0.2628 -0.0610 -0.9367      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6204  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.7987 -0.5510  0.0882 -0.2248  0.0097      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6220  v = -0.8054 -0.5577  0.0661 -0.1899  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6402  v =  0.2128  0.0316  0.4961 -0.8228  0.1748  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6404  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.2460  0.0574  0.4926 -0.8138  0.1766      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+atom =  30  type =  3  l = 2
+ 
+ onsite density matrix
+ 
+spin component  1
+ 
+  0.5360  0.1692  0.0086  0.0177  0.0020
+  0.1692  0.4031 -0.0239  0.0417 -0.0093
+  0.0086 -0.0239  0.3871 -0.1406  0.0438
+  0.0177  0.0417 -0.1406  0.4928 -0.0407
+  0.0020 -0.0093  0.0438 -0.0407  0.3362
+ 
+spin component  2
+ 
+  0.5361  0.1692  0.0079  0.0175  0.0015
+  0.1692  0.4033 -0.0239  0.0418 -0.0095
+  0.0079 -0.0239  0.3860 -0.1417  0.0425
+  0.0175  0.0418 -0.1417  0.4918 -0.0418
+  0.0015 -0.0095  0.0425 -0.0418  0.3349
+ 
+ occupancies and eigenvectors
+ 
+  o =  0.2790  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.4145  0.5694  0.6237  0.3113 -0.1342      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2792  v = -0.4361  0.6048  0.5888  0.2793 -0.1390  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2888  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.3643  0.5973 -0.5291 -0.4087  0.2522      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2895  v = -0.3378  0.5609 -0.5608 -0.4152  0.2906  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3252  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.0139 -0.0654  0.1021  0.3361  0.9339      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3276  v =  0.0138 -0.0724  0.1330  0.3567  0.9218  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.5881  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.4507  0.1827  0.5136 -0.6796  0.1945      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.5883  v =  0.4497  0.1815  0.5150 -0.6791  0.1960  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6708  v = -0.7023 -0.5305  0.2364 -0.4015  0.0902  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6712  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.7016 -0.5304  0.2382 -0.4016  0.0917      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+atom =  31  type =  3  l = 2
+ 
+ onsite density matrix
+ 
+spin component  1
+ 
+  0.5379  0.1526  0.0216 -0.0080  0.0157
+  0.1526  0.4090 -0.0126  0.0278  0.0076
+  0.0216 -0.0126  0.3792 -0.1430  0.0219
+ -0.0080  0.0278 -0.1430  0.5216 -0.0334
+  0.0157  0.0076  0.0219 -0.0334  0.3246
+ 
+spin component  2
+ 
+  0.5380  0.1526  0.0215 -0.0080  0.0157
+  0.1526  0.4091 -0.0126  0.0278  0.0076
+  0.0215 -0.0126  0.3794 -0.1429  0.0216
+ -0.0080  0.0278 -0.1429  0.5217 -0.0335
+  0.0157  0.0076  0.0216 -0.0335  0.3251
+ 
+ occupancies and eigenvectors
+ 
+  o =  0.2887  v = -0.1903  0.2215  0.8309  0.4726 -0.0310  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2889  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.1904  0.2207  0.8306  0.4741 -0.0214      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3048  v =  0.5000 -0.7911  0.1816  0.2625  0.1492  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3048  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.5001 -0.7913  0.1795  0.2617  0.1518      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3185  v = -0.1364  0.1104 -0.0743  0.0882  0.9777  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3191  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.1358  0.1104 -0.0826  0.0828  0.9776      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6196  v =  0.0301 -0.1147  0.5183 -0.8366  0.1320  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6196  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.0306 -0.1144  0.5184 -0.8366  0.1318      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6406  v = -0.8333 -0.5475 -0.0499  0.0049 -0.0586  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6407  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.8332 -0.5476 -0.0496  0.0044 -0.0585      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+atom =  32  type =  3  l = 2
+ 
+ onsite density matrix
+ 
+spin component  1
+ 
+  0.5340  0.1505  0.0253 -0.0046  0.0100
+  0.1505  0.4055 -0.0137  0.0305  0.0026
+  0.0253 -0.0137  0.3818 -0.1459  0.0250
+ -0.0046  0.0305 -0.1459  0.5187 -0.0386
+  0.0100  0.0026  0.0250 -0.0386  0.3217
+ 
+spin component  2
+ 
+  0.5340  0.1505  0.0252 -0.0046  0.0100
+  0.1505  0.4055 -0.0138  0.0305  0.0026
+  0.0252 -0.0138  0.3819 -0.1459  0.0250
+ -0.0046  0.0305 -0.1459  0.5187 -0.0386
+  0.0100  0.0026  0.0250 -0.0386  0.3217
+ 
+ occupancies and eigenvectors
+ 
+  o =  0.2856  v = -0.2426  0.2802  0.8065  0.4603 -0.0186  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.2857  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.2424  0.2803  0.8066  0.4602 -0.0196      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3037  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.4729  0.7660 -0.2346 -0.3126 -0.1920      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3037  v = -0.4731  0.7662 -0.2346 -0.3124 -0.1911  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3148  v = -0.1351  0.1539 -0.1147  0.0754  0.9691  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.3148  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.1358  0.1549 -0.1142  0.0755  0.9689      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6226  v =  0.2071 -0.0017  0.5281 -0.8089  0.1546  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6226  v =  0.0000  0.0000  0.0000  0.0000  0.0000  0.2072 -0.0016  0.5281 -0.8089  0.1546      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6351  v = -0.8101 -0.5575  0.0496 -0.1748 -0.0050  0.0000  0.0000  0.0000  0.0000  0.0000      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+  o =  0.6351  v =  0.0000  0.0000  0.0000  0.0000  0.0000 -0.8101 -0.5574  0.0498 -0.1748 -0.0049      0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+     EDDAV:  cpu time    4.0640: real time    4.0687
+       DOS:  cpu time    0.0000: real time    0.0010
+    --------------------------------------------
+      LOOP:  cpu time    4.9240: real time    4.9377
+
+ eigenvalue-minimisations  :  3456
+ total energy-change (2. order) :-0.7260125E-05  (-0.4401144E-05)
+ number of electron     507.9999664 magnetization       2.0000001
+ augmentation part       52.2566189 magnetization       0.5684723
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      1704.46002184
+  Ewald energy   TEWEN  =    -23930.25020506
+  -Hartree energ DENC   =     -9206.68973859
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =       393.84009908
+  PAW double counting   =   2700830.39828598 -2696977.53661756
+  entropy T*S    EENTRO =        -0.00000000
+  eigenvalues    EBANDS =     -6446.42753647
+  atomic energy  EATOM  =     30809.84260991
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =     -2822.36308087 eV
+
+  energy without entropy =    -2822.36308087  energy(sigma->0) =    -2822.36308087
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+ average (electrostatic) potential at core
+  the test charge radii are     0.9748  1.3152  1.1823  0.7215  0.5201
+  (the norm of the test charge is              1.0000)
+       1 -24.7852       2 -24.8005       3 -24.8769       4 -24.8574       5 -24.5258
+       6 -24.5654       7 -24.7595       8 -24.7258       9 -42.2692      10 -42.5281
+      11 -42.4909      12 -42.2992      13 -42.5005      14 -42.4827      15 -42.1355
+      16 -42.5061      17 -44.1686      18 -44.1697      19 -44.1420      20 -44.1467
+      21 -44.0984      22 -44.1440      23 -44.1732      24 -44.1476      25 -44.1355
+      26 -44.1445      27 -33.9782      28 -44.0310      29 -44.0191      30 -43.9063
+      31 -44.0880      32 -44.1833      33 -71.8144      34 -71.9146      35 -71.9462
+      36 -71.8829      37 -71.9461      38 -71.8190      39 -71.2782      40 -71.7798
+      41 -71.7960      42 -71.8189      43 -71.8369      44 -71.8090      45 -71.8517
+      46 -71.7467      47 -71.8133      48 -72.0852      49 -72.1296      50 -72.0466
+      51 -72.0824      52 -72.0423      53 -72.0716      54 -72.0745      55 -72.0847
+      56 -71.8603      57 -71.8264      58 -71.8788      59 -71.8604      60 -71.8640
+      61 -71.8586      62 -71.8526      63 -71.8080      64 -71.9269      65 -71.9047
+      66 -71.9442      67 -71.9400      68 -71.9611      69 -71.9383      70 -71.9100
+      71 -71.9248      72 -71.1284      73 -71.6729      74 -71.8260      75 -71.8231
+      76 -71.8232      77 -71.8075      78 -71.5749      79 -71.6766      80 -72.0543
+      81 -72.0851      82 -70.5992      83 -71.9827      84 -71.8295      85 -71.9050
+      86 -72.0569      87 -72.1204      88 -71.7329      89 -70.9657      90 -71.8712
+      91 -71.8514      92 -71.8354      93 -71.8856      94 -71.5727      95 -71.6969
+      96 -30.5515
+ 
+ 
+ 
+ E-fermi :   2.8765     XC(G=0): -10.9336     alpha+bet :-10.9268
+
+
+ spin component 1
+
+ k-point     1 :       0.0000    0.0000    0.0000
+  band No.  band energies     occupation 
+      1   -4169.2078      1.00000
+      2    -103.3792      1.00000
+      3     -16.1979      1.00000
+      4     -16.0196      1.00000
+      5     -15.9207      1.00000
+      6     -15.7289      1.00000
+      7     -15.5450      1.00000
+      8     -15.5412      1.00000
+      9     -15.4904      1.00000
+     10     -15.4773      1.00000
+     11     -15.4147      1.00000
+     12     -15.4106      1.00000
+     13     -15.2931      1.00000
+     14     -15.2726      1.00000
+     15     -15.2268      1.00000
+     16     -15.2043      1.00000
+     17     -15.1940      1.00000
+     18     -15.1645      1.00000
+     19     -15.1239      1.00000
+     20     -15.1070      1.00000
+     21     -15.1024      1.00000
+     22     -15.0908      1.00000
+     23     -15.0677      1.00000
+     24     -15.0445      1.00000
+     25     -15.0352      1.00000
+     26     -14.9927      1.00000
+     27     -14.9481      1.00000
+     28     -14.9303      1.00000
+     29     -14.9249      1.00000
+     30     -14.8972      1.00000
+     31     -14.8626      1.00000
+     32     -14.8486      1.00000
+     33     -14.8345      1.00000
+     34     -14.8222      1.00000
+     35     -14.8079      1.00000
+     36     -14.7405      1.00000
+     37     -14.7126      1.00000
+     38     -14.6961      1.00000
+     39     -14.6859      1.00000
+     40     -14.6658      1.00000
+     41     -14.6595      1.00000
+     42     -14.6321      1.00000
+     43     -14.6122      1.00000
+     44     -14.5694      1.00000
+     45     -14.5474      1.00000
+     46     -14.5291      1.00000
+     47     -14.4704      1.00000
+     48     -14.4212      1.00000
+     49     -14.3935      1.00000
+     50     -14.3765      1.00000
+     51     -14.3742      1.00000
+     52     -14.3627      1.00000
+     53     -14.3594      1.00000
+     54     -14.3466      1.00000
+     55     -14.3434      1.00000
+     56     -14.3347      1.00000
+     57     -14.3063      1.00000
+     58     -14.3008      1.00000
+     59     -14.2616      1.00000
+     60     -14.2211      1.00000
+     61     -14.1868      1.00000
+     62     -14.1375      1.00000
+     63     -13.9879      1.00000
+     64     -13.6508      1.00000
+     65     -13.4590      1.00000
+     66      -3.8557      1.00000
+     67      -3.8102      1.00000
+     68      -3.7224      1.00000
+     69      -3.7071      1.00000
+     70      -3.6546      1.00000
+     71      -3.6451      1.00000
+     72      -3.6075      1.00000
+     73      -3.5567      1.00000
+     74      -3.5516      1.00000
+     75      -3.5290      1.00000
+     76      -3.4706      1.00000
+     77      -3.4046      1.00000
+     78      -3.3935      1.00000
+     79      -3.3870      1.00000
+     80      -3.3662      1.00000
+     81      -3.3616      1.00000
+     82      -3.3288      1.00000
+     83      -3.2865      1.00000
+     84      -3.2580      1.00000
+     85      -3.1985      1.00000
+     86      -3.1768      1.00000
+     87      -3.1573      1.00000
+     88      -3.1413      1.00000
+     89      -3.1029      1.00000
+     90      -3.0927      1.00000
+     91      -3.0507      1.00000
+     92      -3.0458      1.00000
+     93      -2.9952      1.00000
+     94      -2.9631      1.00000
+     95      -2.9249      1.00000
+     96      -2.8275      1.00000
+     97      -2.8102      1.00000
+     98      -2.7569      1.00000
+     99      -2.6871      1.00000
+    100      -2.6549      1.00000
+    101      -2.6082      1.00000
+    102      -2.5734      1.00000
+    103      -2.5358      1.00000
+    104      -2.4558      1.00000
+    105      -2.4236      1.00000
+    106      -2.3829      1.00000
+    107      -2.3482      1.00000
+    108      -2.3357      1.00000
+    109      -2.3191      1.00000
+    110      -2.2834      1.00000
+    111      -2.2306      1.00000
+    112      -2.1809      1.00000
+    113      -2.1614      1.00000
+    114      -2.1441      1.00000
+    115      -2.1176      1.00000
+    116      -2.0648      1.00000
+    117      -2.0484      1.00000
+    118      -1.9988      1.00000
+    119      -1.9692      1.00000
+    120      -1.9514      1.00000
+    121      -1.9209      1.00000
+    122      -1.8795      1.00000
+    123      -1.8742      1.00000
+    124      -1.8522      1.00000
+    125      -1.8350      1.00000
+    126      -1.8201      1.00000
+    127      -1.7976      1.00000
+    128      -1.7794      1.00000
+    129      -1.7167      1.00000
+    130      -1.6945      1.00000
+    131      -1.6688      1.00000
+    132      -1.6374      1.00000
+    133      -1.6092      1.00000
+    134      -1.6015      1.00000
+    135      -1.5508      1.00000
+    136      -1.5216      1.00000
+    137      -1.5044      1.00000
+    138      -1.4883      1.00000
+    139      -1.4568      1.00000
+    140      -1.4260      1.00000
+    141      -1.4058      1.00000
+    142      -1.3036      1.00000
+    143      -1.2676      1.00000
+    144      -1.2172      1.00000
+    145      -1.1549      1.00000
+    146      -1.1027      1.00000
+    147      -1.0711      1.00000
+    148      -1.0520      1.00000
+    149      -1.0280      1.00000
+    150      -1.0060      1.00000
+    151      -0.9639      1.00000
+    152      -0.9323      1.00000
+    153      -0.9267      1.00000
+    154      -0.9004      1.00000
+    155      -0.8691      1.00000
+    156      -0.8215      1.00000
+    157      -0.7896      1.00000
+    158      -0.7300      1.00000
+    159      -0.7143      1.00000
+    160      -0.6904      1.00000
+    161      -0.6239      1.00000
+    162      -0.5985      1.00000
+    163      -0.5453      1.00000
+    164      -0.5123      1.00000
+    165      -0.4888      1.00000
+    166      -0.4720      1.00000
+    167      -0.4482      1.00000
+    168      -0.4095      1.00000
+    169      -0.3976      1.00000
+    170      -0.3718      1.00000
+    171      -0.3408      1.00000
+    172      -0.3230      1.00000
+    173      -0.2407      1.00000
+    174      -0.2143      1.00000
+    175      -0.1943      1.00000
+    176      -0.1538      1.00000
+    177      -0.1360      1.00000
+    178      -0.1067      1.00000
+    179      -0.0371      1.00000
+    180      -0.0153      1.00000
+    181       0.0077      1.00000
+    182       0.0781      1.00000
+    183       0.0890      1.00000
+    184       0.1196      1.00000
+    185       0.1591      1.00000
+    186       0.1748      1.00000
+    187       0.1945      1.00000
+    188       0.2130      1.00000
+    189       0.2279      1.00000
+    190       0.2440      1.00000
+    191       0.2612      1.00000
+    192       0.2780      1.00000
+    193       0.2948      1.00000
+    194       0.3143      1.00000
+    195       0.3366      1.00000
+    196       0.3559      1.00000
+    197       0.3899      1.00000
+    198       0.4243      1.00000
+    199       0.4612      1.00000
+    200       0.5068      1.00000
+    201       0.5284      1.00000
+    202       0.5717      1.00000
+    203       0.5928      1.00000
+    204       0.6308      1.00000
+    205       0.6428      1.00000
+    206       0.6675      1.00000
+    207       0.6698      1.00000
+    208       0.7033      1.00000
+    209       0.7312      1.00000
+    210       0.7518      1.00000
+    211       0.7565      1.00000
+    212       0.7740      1.00000
+    213       0.7945      1.00000
+    214       0.8274      1.00000
+    215       0.8471      1.00000
+    216       0.8771      1.00000
+    217       0.8872      1.00000
+    218       0.9268      1.00000
+    219       0.9388      1.00000
+    220       0.9568      1.00000
+    221       0.9706      1.00000
+    222       0.9987      1.00000
+    223       1.0077      1.00000
+    224       1.0134      1.00000
+    225       1.0212      1.00000
+    226       1.0491      1.00000
+    227       1.0614      1.00000
+    228       1.0735      1.00000
+    229       1.1064      1.00000
+    230       1.1344      1.00000
+    231       1.1641      1.00000
+    232       1.1998      1.00000
+    233       1.2303      1.00000
+    234       1.2552      1.00000
+    235       1.2701      1.00000
+    236       1.2865      1.00000
+    237       1.3049      1.00000
+    238       1.3201      1.00000
+    239       1.3408      1.00000
+    240       1.3615      1.00000
+    241       1.3932      1.00000
+    242       1.3964      1.00000
+    243       1.4375      1.00000
+    244       1.4632      1.00000
+    245       1.4683      1.00000
+    246       1.5078      1.00000
+    247       1.5196      1.00000
+    248       1.5215      1.00000
+    249       1.5583      1.00000
+    250       1.5973      1.00000
+    251       1.6414      1.00000
+    252       1.7188      1.00000
+    253       1.7578      1.00000
+    254       1.8008      1.00000
+    255       1.8693      1.00000
+    256       5.1969      0.00000
+    257       5.2660      0.00000
+    258       5.3634      0.00000
+    259       5.4104      0.00000
+    260       5.4228      0.00000
+    261       5.4431      0.00000
+    262       5.4524      0.00000
+    263       5.4691      0.00000
+    264       5.4748      0.00000
+    265       5.5530      0.00000
+    266       5.5658      0.00000
+    267       5.5730      0.00000
+    268       5.6059      0.00000
+    269       5.6669      0.00000
+    270       5.6818      0.00000
+    271       5.7195      0.00000
+    272       5.7320      0.00000
+    273       5.7627      0.00000
+    274       5.7833      0.00000
+    275       5.8192      0.00000
+    276       5.8368      0.00000
+    277       5.8506      0.00000
+    278       5.8976      0.00000
+    279       5.9312      0.00000
+    280       5.9547      0.00000
+    281       5.9966      0.00000
+    282       6.0180      0.00000
+    283       6.0526      0.00000
+    284       6.0663      0.00000
+    285       6.0799      0.00000
+    286       6.1021      0.00000
+    287       6.1149      0.00000
+    288       6.1442      0.00000
+    289       6.1736      0.00000
+    290       6.2067      0.00000
+    291       6.2525      0.00000
+    292       6.2772      0.00000
+    293       6.3355      0.00000
+    294       6.3884      0.00000
+    295       6.4353      0.00000
+    296       6.4942      0.00000
+    297       6.5057      0.00000
+    298       6.5399      0.00000
+    299       6.6754      0.00000
+    300       6.7082      0.00000
+    301       6.7639      0.00000
+    302       6.8362      0.00000
+    303       6.9104      0.00000
+    304       6.9568      0.00000
+    305       6.9694      0.00000
+    306       6.9809      0.00000
+    307       7.0316      0.00000
+    308       7.0494      0.00000
+    309       7.0889      0.00000
+    310       7.1159      0.00000
+    311       7.1192      0.00000
+    312       7.1683      0.00000
+    313       7.2011      0.00000
+    314       7.2110      0.00000
+    315       7.2309      0.00000
+    316       7.2747      0.00000
+    317       7.3216      0.00000
+    318       7.3342      0.00000
+    319       7.3738      0.00000
+    320       7.4160      0.00000
+    321       7.4411      0.00000
+    322       7.4875      0.00000
+    323       7.5418      0.00000
+    324       7.6889      0.00000
+    325       8.1896      0.00000
+    326       8.3114      0.00000
+    327       8.5217      0.00000
+    328       8.6391      0.00000
+    329       8.6701      0.00000
+    330       8.7417      0.00000
+    331       8.7841      0.00000
+    332       8.8203      0.00000
+    333       8.8331      0.00000
+    334       8.8536      0.00000
+    335       8.8890      0.00000
+    336       8.9009      0.00000
+    337       8.9434      0.00000
+    338       8.9783      0.00000
+    339       9.0162      0.00000
+    340       9.0508      0.00000
+    341       9.1031      0.00000
+    342       9.1693      0.00000
+    343       9.2746      0.00000
+    344       9.2847      0.00000
+    345       9.3264      0.00000
+    346       9.3970      0.00000
+    347       9.4376      0.00000
+    348       9.4446      0.00000
+    349       9.5673      0.00000
+    350       9.6796      0.00000
+    351       9.6949      0.00000
+    352       9.7644      0.00000
+    353       9.7982      0.00000
+    354       9.8678      0.00000
+    355       9.9339      0.00000
+    356       9.9576      0.00000
+    357      10.0234      0.00000
+    358      10.1491      0.00000
+    359      10.2471      0.00000
+    360      10.2556      0.00000
+
+ k-point     2 :       0.5000    0.0000    0.0000
+  band No.  band energies     occupation 
+      1   -4169.2767      1.00000
+      2    -103.3792      1.00000
+      3     -16.1097      1.00000
+      4     -16.0722      1.00000
+      5     -15.9591      1.00000
+      6     -15.7625      1.00000
+      7     -15.5156      1.00000
+      8     -15.5088      1.00000
+      9     -15.4818      1.00000
+     10     -15.4712      1.00000
+     11     -15.4460      1.00000
+     12     -15.4416      1.00000
+     13     -15.3045      1.00000
+     14     -15.2868      1.00000
+     15     -15.2365      1.00000
+     16     -15.1985      1.00000
+     17     -15.1602      1.00000
+     18     -15.1510      1.00000
+     19     -15.1406      1.00000
+     20     -15.1302      1.00000
+     21     -15.1128      1.00000
+     22     -15.0872      1.00000
+     23     -15.0739      1.00000
+     24     -15.0657      1.00000
+     25     -15.0344      1.00000
+     26     -14.9898      1.00000
+     27     -14.9632      1.00000
+     28     -14.9503      1.00000
+     29     -14.9370      1.00000
+     30     -14.8998      1.00000
+     31     -14.8929      1.00000
+     32     -14.8502      1.00000
+     33     -14.7866      1.00000
+     34     -14.7476      1.00000
+     35     -14.7262      1.00000
+     36     -14.7227      1.00000
+     37     -14.7104      1.00000
+     38     -14.6961      1.00000
+     39     -14.6881      1.00000
+     40     -14.6783      1.00000
+     41     -14.6700      1.00000
+     42     -14.6467      1.00000
+     43     -14.6436      1.00000
+     44     -14.5613      1.00000
+     45     -14.5339      1.00000
+     46     -14.5058      1.00000
+     47     -14.4637      1.00000
+     48     -14.4042      1.00000
+     49     -14.3978      1.00000
+     50     -14.3848      1.00000
+     51     -14.3796      1.00000
+     52     -14.3501      1.00000
+     53     -14.3419      1.00000
+     54     -14.3344      1.00000
+     55     -14.3213      1.00000
+     56     -14.3134      1.00000
+     57     -14.3049      1.00000
+     58     -14.2853      1.00000
+     59     -14.2840      1.00000
+     60     -14.2469      1.00000
+     61     -14.2238      1.00000
+     62     -14.1869      1.00000
+     63     -13.9949      1.00000
+     64     -13.6551      1.00000
+     65     -13.4599      1.00000
+     66      -3.8058      1.00000
+     67      -3.7897      1.00000
+     68      -3.7747      1.00000
+     69      -3.6981      1.00000
+     70      -3.6185      1.00000
+     71      -3.6093      1.00000
+     72      -3.5808      1.00000
+     73      -3.5739      1.00000
+     74      -3.5565      1.00000
+     75      -3.5171      1.00000
+     76      -3.4899      1.00000
+     77      -3.4654      1.00000
+     78      -3.4509      1.00000
+     79      -3.4192      1.00000
+     80      -3.3701      1.00000
+     81      -3.3619      1.00000
+     82      -3.2491      1.00000
+     83      -3.2340      1.00000
+     84      -3.2278      1.00000
+     85      -3.1801      1.00000
+     86      -3.1642      1.00000
+     87      -3.1504      1.00000
+     88      -3.1241      1.00000
+     89      -3.1047      1.00000
+     90      -3.0839      1.00000
+     91      -3.0649      1.00000
+     92      -3.0418      1.00000
+     93      -3.0248      1.00000
+     94      -2.9567      1.00000
+     95      -2.8844      1.00000
+     96      -2.7965      1.00000
+     97      -2.7695      1.00000
+     98      -2.6858      1.00000
+     99      -2.6578      1.00000
+    100      -2.6346      1.00000
+    101      -2.6163      1.00000
+    102      -2.5956      1.00000
+    103      -2.5428      1.00000
+    104      -2.5169      1.00000
+    105      -2.4856      1.00000
+    106      -2.4668      1.00000
+    107      -2.4144      1.00000
+    108      -2.3955      1.00000
+    109      -2.3548      1.00000
+    110      -2.3406      1.00000
+    111      -2.2952      1.00000
+    112      -2.2743      1.00000
+    113      -2.2637      1.00000
+    114      -2.1878      1.00000
+    115      -2.0998      1.00000
+    116      -2.0818      1.00000
+    117      -2.0430      1.00000
+    118      -2.0216      1.00000
+    119      -1.9690      1.00000
+    120      -1.9459      1.00000
+    121      -1.8909      1.00000
+    122      -1.8885      1.00000
+    123      -1.8507      1.00000
+    124      -1.8101      1.00000
+    125      -1.8040      1.00000
+    126      -1.7503      1.00000
+    127      -1.7322      1.00000
+    128      -1.7179      1.00000
+    129      -1.6788      1.00000
+    130      -1.6694      1.00000
+    131      -1.6396      1.00000
+    132      -1.6263      1.00000
+    133      -1.5938      1.00000
+    134      -1.5314      1.00000
+    135      -1.4921      1.00000
+    136      -1.4717      1.00000
+    137      -1.4614      1.00000
+    138      -1.4472      1.00000
+    139      -1.4251      1.00000
+    140      -1.4017      1.00000
+    141      -1.3944      1.00000
+    142      -1.3693      1.00000
+    143      -1.3297      1.00000
+    144      -1.2922      1.00000
+    145      -1.2712      1.00000
+    146      -1.2215      1.00000
+    147      -1.1902      1.00000
+    148      -1.1675      1.00000
+    149      -1.1007      1.00000
+    150      -1.0560      1.00000
+    151      -1.0386      1.00000
+    152      -0.9926      1.00000
+    153      -0.9807      1.00000
+    154      -0.9327      1.00000
+    155      -0.9011      1.00000
+    156      -0.8636      1.00000
+    157      -0.8325      1.00000
+    158      -0.7735      1.00000
+    159      -0.7440      1.00000
+    160      -0.6938      1.00000
+    161      -0.6549      1.00000
+    162      -0.6151      1.00000
+    163      -0.5226      1.00000
+    164      -0.4913      1.00000
+    165      -0.4783      1.00000
+    166      -0.3961      1.00000
+    167      -0.3633      1.00000
+    168      -0.3216      1.00000
+    169      -0.2897      1.00000
+    170      -0.2439      1.00000
+    171      -0.2393      1.00000
+    172      -0.2121      1.00000
+    173      -0.2073      1.00000
+    174      -0.2018      1.00000
+    175      -0.1657      1.00000
+    176      -0.1146      1.00000
+    177      -0.1053      1.00000
+    178      -0.0309      1.00000
+    179       0.0038      1.00000
+    180       0.0321      1.00000
+    181       0.0688      1.00000
+    182       0.1048      1.00000
+    183       0.1185      1.00000
+    184       0.1342      1.00000
+    185       0.1699      1.00000
+    186       0.1997      1.00000
+    187       0.2121      1.00000
+    188       0.2285      1.00000
+    189       0.2554      1.00000
+    190       0.2869      1.00000
+    191       0.3218      1.00000
+    192       0.3645      1.00000
+    193       0.3737      1.00000
+    194       0.3908      1.00000
+    195       0.4057      1.00000
+    196       0.4334      1.00000
+    197       0.4516      1.00000
+    198       0.4693      1.00000
+    199       0.4940      1.00000
+    200       0.5350      1.00000
+    201       0.5584      1.00000
+    202       0.5777      1.00000
+    203       0.5944      1.00000
+    204       0.6500      1.00000
+    205       0.6511      1.00000
+    206       0.6631      1.00000
+    207       0.6716      1.00000
+    208       0.6762      1.00000
+    209       0.7269      1.00000
+    210       0.7419      1.00000
+    211       0.7653      1.00000
+    212       0.7708      1.00000
+    213       0.7809      1.00000
+    214       0.8062      1.00000
+    215       0.8211      1.00000
+    216       0.8349      1.00000
+    217       0.8593      1.00000
+    218       0.8973      1.00000
+    219       0.9055      1.00000
+    220       0.9500      1.00000
+    221       0.9770      1.00000
+    222       0.9814      1.00000
+    223       1.0043      1.00000
+    224       1.0190      1.00000
+    225       1.0295      1.00000
+    226       1.0396      1.00000
+    227       1.0487      1.00000
+    228       1.0766      1.00000
+    229       1.1216      1.00000
+    230       1.1283      1.00000
+    231       1.1373      1.00000
+    232       1.1551      1.00000
+    233       1.1604      1.00000
+    234       1.1661      1.00000
+    235       1.1866      1.00000
+    236       1.2047      1.00000
+    237       1.2178      1.00000
+    238       1.2659      1.00000
+    239       1.2734      1.00000
+    240       1.2817      1.00000
+    241       1.2989      1.00000
+    242       1.3538      1.00000
+    243       1.3680      1.00000
+    244       1.3966      1.00000
+    245       1.4599      1.00000
+    246       1.4708      1.00000
+    247       1.5005      1.00000
+    248       1.5275      1.00000
+    249       1.5400      1.00000
+    250       1.6043      1.00000
+    251       1.6443      1.00000
+    252       1.7295      1.00000
+    253       1.7623      1.00000
+    254       1.8205      1.00000
+    255       1.8573      1.00000
+    256       5.1783      0.00000
+    257       5.2891      0.00000
+    258       5.3802      0.00000
+    259       5.3910      0.00000
+    260       5.4196      0.00000
+    261       5.4354      0.00000
+    262       5.5069      0.00000
+    263       5.5459      0.00000
+    264       5.5560      0.00000
+    265       5.5663      0.00000
+    266       5.5920      0.00000
+    267       5.6293      0.00000
+    268       5.6478      0.00000
+    269       5.7021      0.00000
+    270       5.7149      0.00000
+    271       5.7316      0.00000
+    272       5.7654      0.00000
+    273       5.7706      0.00000
+    274       5.8111      0.00000
+    275       5.8173      0.00000
+    276       5.8488      0.00000
+    277       5.8544      0.00000
+    278       5.8835      0.00000
+    279       5.9038      0.00000
+    280       5.9211      0.00000
+    281       5.9387      0.00000
+    282       5.9932      0.00000
+    283       6.0223      0.00000
+    284       6.0254      0.00000
+    285       6.0548      0.00000
+    286       6.0816      0.00000
+    287       6.1230      0.00000
+    288       6.1820      0.00000
+    289       6.2216      0.00000
+    290       6.2524      0.00000
+    291       6.2782      0.00000
+    292       6.3406      0.00000
+    293       6.3594      0.00000
+    294       6.3738      0.00000
+    295       6.3978      0.00000
+    296       6.4114      0.00000
+    297       6.4454      0.00000
+    298       6.4643      0.00000
+    299       6.4824      0.00000
+    300       6.5044      0.00000
+    301       6.7319      0.00000
+    302       6.8679      0.00000
+    303       6.9151      0.00000
+    304       6.9716      0.00000
+    305       7.0194      0.00000
+    306       7.0634      0.00000
+    307       7.0719      0.00000
+    308       7.1207      0.00000
+    309       7.1344      0.00000
+    310       7.1602      0.00000
+    311       7.1852      0.00000
+    312       7.2082      0.00000
+    313       7.2195      0.00000
+    314       7.2345      0.00000
+    315       7.2763      0.00000
+    316       7.2998      0.00000
+    317       7.3168      0.00000
+    318       7.3343      0.00000
+    319       7.3599      0.00000
+    320       7.4024      0.00000
+    321       7.4674      0.00000
+    322       7.5023      0.00000
+    323       7.5354      0.00000
+    324       7.6100      0.00000
+    325       8.1931      0.00000
+    326       8.3232      0.00000
+    327       8.5660      0.00000
+    328       8.6010      0.00000
+    329       8.6344      0.00000
+    330       8.7256      0.00000
+    331       8.7380      0.00000
+    332       8.8045      0.00000
+    333       8.8108      0.00000
+    334       8.8310      0.00000
+    335       8.8445      0.00000
+    336       8.9020      0.00000
+    337       8.9599      0.00000
+    338       9.0070      0.00000
+    339       9.0664      0.00000
+    340       9.1499      0.00000
+    341       9.1796      0.00000
+    342       9.1955      0.00000
+    343       9.2336      0.00000
+    344       9.3672      0.00000
+    345       9.4327      0.00000
+    346       9.4723      0.00000
+    347       9.5154      0.00000
+    348       9.5558      0.00000
+    349       9.5718      0.00000
+    350       9.6120      0.00000
+    351       9.6280      0.00000
+    352       9.7115      0.00000
+    353       9.7531      0.00000
+    354       9.8060      0.00000
+    355       9.8214      0.00000
+    356       9.9129      0.00000
+    357       9.9419      0.00000
+    358      10.0333      0.00000
+    359      10.0996      0.00000
+    360      10.1935      0.00000
+
+ k-point     3 :       0.0000    0.0000    0.5000
+  band No.  band energies     occupation 
+      1   -4169.3415      1.00000
+      2    -103.3795      1.00000
+      3     -16.0213      1.00000
+      4     -15.9947      1.00000
+      5     -15.8646      1.00000
+      6     -15.8423      1.00000
+      7     -15.7746      1.00000
+      8     -15.7611      1.00000
+      9     -15.6709      1.00000
+     10     -15.3952      1.00000
+     11     -15.3315      1.00000
+     12     -15.3192      1.00000
+     13     -15.2849      1.00000
+     14     -15.2457      1.00000
+     15     -15.1867      1.00000
+     16     -15.1799      1.00000
+     17     -15.1659      1.00000
+     18     -15.1500      1.00000
+     19     -15.1147      1.00000
+     20     -15.1106      1.00000
+     21     -15.0467      1.00000
+     22     -15.0394      1.00000
+     23     -15.0344      1.00000
+     24     -15.0237      1.00000
+     25     -15.0213      1.00000
+     26     -15.0009      1.00000
+     27     -14.9916      1.00000
+     28     -14.9483      1.00000
+     29     -14.9167      1.00000
+     30     -14.8734      1.00000
+     31     -14.8516      1.00000
+     32     -14.8435      1.00000
+     33     -14.8271      1.00000
+     34     -14.7732      1.00000
+     35     -14.7291      1.00000
+     36     -14.7010      1.00000
+     37     -14.6924      1.00000
+     38     -14.6800      1.00000
+     39     -14.6700      1.00000
+     40     -14.6584      1.00000
+     41     -14.6457      1.00000
+     42     -14.6435      1.00000
+     43     -14.6296      1.00000
+     44     -14.5991      1.00000
+     45     -14.5801      1.00000
+     46     -14.5601      1.00000
+     47     -14.5380      1.00000
+     48     -14.5075      1.00000
+     49     -14.4867      1.00000
+     50     -14.4121      1.00000
+     51     -14.3975      1.00000
+     52     -14.3665      1.00000
+     53     -14.3411      1.00000
+     54     -14.3390      1.00000
+     55     -14.3312      1.00000
+     56     -14.3024      1.00000
+     57     -14.2708      1.00000
+     58     -14.2607      1.00000
+     59     -14.2324      1.00000
+     60     -14.2222      1.00000
+     61     -14.2058      1.00000
+     62     -14.1680      1.00000
+     63     -14.0025      1.00000
+     64     -13.6565      1.00000
+     65     -13.4580      1.00000
+     66      -3.7653      1.00000
+     67      -3.7580      1.00000
+     68      -3.7471      1.00000
+     69      -3.7206      1.00000
+     70      -3.6984      1.00000
+     71      -3.6902      1.00000
+     72      -3.6450      1.00000
+     73      -3.6271      1.00000
+     74      -3.4816      1.00000
+     75      -3.3874      1.00000
+     76      -3.3673      1.00000
+     77      -3.3571      1.00000
+     78      -3.3430      1.00000
+     79      -3.3177      1.00000
+     80      -3.2705      1.00000
+     81      -3.2616      1.00000
+     82      -3.2464      1.00000
+     83      -3.2176      1.00000
+     84      -3.2081      1.00000
+     85      -3.1776      1.00000
+     86      -3.1037      1.00000
+     87      -3.0860      1.00000
+     88      -3.0617      1.00000
+     89      -3.0403      1.00000
+     90      -3.0197      1.00000
+     91      -2.9938      1.00000
+     92      -2.9673      1.00000
+     93      -2.9616      1.00000
+     94      -2.9397      1.00000
+     95      -2.9287      1.00000
+     96      -2.8843      1.00000
+     97      -2.8324      1.00000
+     98      -2.8048      1.00000
+     99      -2.7600      1.00000
+    100      -2.7545      1.00000
+    101      -2.7357      1.00000
+    102      -2.7220      1.00000
+    103      -2.6567      1.00000
+    104      -2.6186      1.00000
+    105      -2.5816      1.00000
+    106      -2.5771      1.00000
+    107      -2.5232      1.00000
+    108      -2.5094      1.00000
+    109      -2.4199      1.00000
+    110      -2.3800      1.00000
+    111      -2.3472      1.00000
+    112      -2.3167      1.00000
+    113      -2.3078      1.00000
+    114      -2.2767      1.00000
+    115      -2.2501      1.00000
+    116      -2.2017      1.00000
+    117      -2.1790      1.00000
+    118      -2.1515      1.00000
+    119      -2.1320      1.00000
+    120      -2.0766      1.00000
+    121      -1.9980      1.00000
+    122      -1.9448      1.00000
+    123      -1.8938      1.00000
+    124      -1.8228      1.00000
+    125      -1.7892      1.00000
+    126      -1.7520      1.00000
+    127      -1.7022      1.00000
+    128      -1.6870      1.00000
+    129      -1.6624      1.00000
+    130      -1.6527      1.00000
+    131      -1.6422      1.00000
+    132      -1.6143      1.00000
+    133      -1.6026      1.00000
+    134      -1.5803      1.00000
+    135      -1.4917      1.00000
+    136      -1.4624      1.00000
+    137      -1.4240      1.00000
+    138      -1.3963      1.00000
+    139      -1.3673      1.00000
+    140      -1.3462      1.00000
+    141      -1.3071      1.00000
+    142      -1.2771      1.00000
+    143      -1.2225      1.00000
+    144      -1.2134      1.00000
+    145      -1.1543      1.00000
+    146      -1.0839      1.00000
+    147      -1.0733      1.00000
+    148      -1.0617      1.00000
+    149      -1.0206      1.00000
+    150      -1.0007      1.00000
+    151      -0.9191      1.00000
+    152      -0.8860      1.00000
+    153      -0.8508      1.00000
+    154      -0.8133      1.00000
+    155      -0.7833      1.00000
+    156      -0.7495      1.00000
+    157      -0.7349      1.00000
+    158      -0.7036      1.00000
+    159      -0.6328      1.00000
+    160      -0.6074      1.00000
+    161      -0.5893      1.00000
+    162      -0.5468      1.00000
+    163      -0.4936      1.00000
+    164      -0.4558      1.00000
+    165      -0.4216      1.00000
+    166      -0.4081      1.00000
+    167      -0.3348      1.00000
+    168      -0.2808      1.00000
+    169      -0.2574      1.00000
+    170      -0.2484      1.00000
+    171      -0.2213      1.00000
+    172      -0.1964      1.00000
+    173      -0.1656      1.00000
+    174      -0.1499      1.00000
+    175      -0.1344      1.00000
+    176      -0.1229      1.00000
+    177      -0.0837      1.00000
+    178      -0.0595      1.00000
+    179      -0.0432      1.00000
+    180      -0.0130      1.00000
+    181       0.0073      1.00000
+    182       0.0260      1.00000
+    183       0.0636      1.00000
+    184       0.0715      1.00000
+    185       0.1087      1.00000
+    186       0.1721      1.00000
+    187       0.1851      1.00000
+    188       0.2170      1.00000
+    189       0.2277      1.00000
+    190       0.2450      1.00000
+    191       0.2931      1.00000
+    192       0.3108      1.00000
+    193       0.3202      1.00000
+    194       0.3587      1.00000
+    195       0.3681      1.00000
+    196       0.3838      1.00000
+    197       0.4063      1.00000
+    198       0.4147      1.00000
+    199       0.4488      1.00000
+    200       0.4859      1.00000
+    201       0.5041      1.00000
+    202       0.5264      1.00000
+    203       0.5418      1.00000
+    204       0.5628      1.00000
+    205       0.5803      1.00000
+    206       0.5897      1.00000
+    207       0.6160      1.00000
+    208       0.6457      1.00000
+    209       0.6625      1.00000
+    210       0.7078      1.00000
+    211       0.7288      1.00000
+    212       0.7672      1.00000
+    213       0.7986      1.00000
+    214       0.8109      1.00000
+    215       0.8188      1.00000
+    216       0.8391      1.00000
+    217       0.8606      1.00000
+    218       0.8849      1.00000
+    219       0.9126      1.00000
+    220       0.9193      1.00000
+    221       0.9313      1.00000
+    222       0.9441      1.00000
+    223       0.9922      1.00000
+    224       1.0040      1.00000
+    225       1.0118      1.00000
+    226       1.0234      1.00000
+    227       1.0547      1.00000
+    228       1.0669      1.00000
+    229       1.0834      1.00000
+    230       1.0919      1.00000
+    231       1.1163      1.00000
+    232       1.1375      1.00000
+    233       1.1795      1.00000
+    234       1.2009      1.00000
+    235       1.2230      1.00000
+    236       1.2249      1.00000
+    237       1.2785      1.00000
+    238       1.2976      1.00000
+    239       1.3305      1.00000
+    240       1.3803      1.00000
+    241       1.3847      1.00000
+    242       1.4279      1.00000
+    243       1.4559      1.00000
+    244       1.4718      1.00000
+    245       1.4859      1.00000
+    246       1.4974      1.00000
+    247       1.5068      1.00000
+    248       1.5360      1.00000
+    249       1.5550      1.00000
+    250       1.5842      1.00000
+    251       1.6291      1.00000
+    252       1.6683      1.00000
+    253       1.7469      1.00000
+    254       1.8436      1.00000
+    255       1.8680      1.00000
+    256       5.2509      0.00000
+    257       5.2681      0.00000
+    258       5.3255      0.00000
+    259       5.3333      0.00000
+    260       5.3764      0.00000
+    261       5.3885      0.00000
+    262       5.4421      0.00000
+    263       5.4663      0.00000
+    264       5.4927      0.00000
+    265       5.5241      0.00000
+    266       5.5925      0.00000
+    267       5.6220      0.00000
+    268       5.6520      0.00000
+    269       5.6591      0.00000
+    270       5.6969      0.00000
+    271       5.7357      0.00000
+    272       5.7543      0.00000
+    273       5.7606      0.00000
+    274       5.7956      0.00000
+    275       5.8034      0.00000
+    276       5.8774      0.00000
+    277       5.8946      0.00000
+    278       5.9221      0.00000
+    279       5.9296      0.00000
+    280       5.9343      0.00000
+    281       5.9501      0.00000
+    282       5.9591      0.00000
+    283       6.0047      0.00000
+    284       6.0188      0.00000
+    285       6.0745      0.00000
+    286       6.1056      0.00000
+    287       6.1278      0.00000
+    288       6.1553      0.00000
+    289       6.1781      0.00000
+    290       6.2193      0.00000
+    291       6.2589      0.00000
+    292       6.3102      0.00000
+    293       6.3672      0.00000
+    294       6.4110      0.00000
+    295       6.4638      0.00000
+    296       6.4726      0.00000
+    297       6.5364      0.00000
+    298       6.6650      0.00000
+    299       6.6717      0.00000
+    300       6.7091      0.00000
+    301       6.7582      0.00000
+    302       6.8597      0.00000
+    303       6.9136      0.00000
+    304       6.9398      0.00000
+    305       6.9603      0.00000
+    306       6.9790      0.00000
+    307       7.0237      0.00000
+    308       7.0450      0.00000
+    309       7.0946      0.00000
+    310       7.1118      0.00000
+    311       7.1163      0.00000
+    312       7.1589      0.00000
+    313       7.1660      0.00000
+    314       7.1807      0.00000
+    315       7.2106      0.00000
+    316       7.2503      0.00000
+    317       7.3437      0.00000
+    318       7.3636      0.00000
+    319       7.3881      0.00000
+    320       7.3943      0.00000
+    321       7.4443      0.00000
+    322       7.4968      0.00000
+    323       7.5997      0.00000
+    324       7.6555      0.00000
+    325       8.1772      0.00000
+    326       8.3107      0.00000
+    327       8.5112      0.00000
+    328       8.5685      0.00000
+    329       8.6011      0.00000
+    330       8.6691      0.00000
+    331       8.7619      0.00000
+    332       8.8441      0.00000
+    333       8.8960      0.00000
+    334       8.9072      0.00000
+    335       8.9376      0.00000
+    336       8.9558      0.00000
+    337       8.9855      0.00000
+    338       9.0453      0.00000
+    339       9.0930      0.00000
+    340       9.1151      0.00000
+    341       9.2069      0.00000
+    342       9.2476      0.00000
+    343       9.2633      0.00000
+    344       9.3278      0.00000
+    345       9.3950      0.00000
+    346       9.4109      0.00000
+    347       9.4307      0.00000
+    348       9.4462      0.00000
+    349       9.5562      0.00000
+    350       9.6163      0.00000
+    351       9.6501      0.00000
+    352       9.7686      0.00000
+    353       9.7844      0.00000
+    354       9.8224      0.00000
+    355       9.8385      0.00000
+    356       9.8832      0.00000
+    357      10.0193      0.00000
+    358      10.0986      0.00000
+    359      10.1584      0.00000
+    360      10.2215      0.00000
+
+ k-point     4 :       0.5000    0.0000    0.5000
+  band No.  band energies     occupation 
+      1   -4169.3459      1.00000
+      2    -103.3794      1.00000
+      3     -15.9373      1.00000
+      4     -15.9171      1.00000
+      5     -15.9006      1.00000
+      6     -15.8978      1.00000
+      7     -15.8153      1.00000
+      8     -15.7947      1.00000
+      9     -15.7082      1.00000
+     10     -15.4172      1.00000
+     11     -15.3200      1.00000
+     12     -15.2935      1.00000
+     13     -15.2679      1.00000
+     14     -15.2576      1.00000
+     15     -15.2068      1.00000
+     16     -15.1815      1.00000
+     17     -15.1755      1.00000
+     18     -15.1655      1.00000
+     19     -15.1101      1.00000
+     20     -15.0951      1.00000
+     21     -15.0822      1.00000
+     22     -15.0726      1.00000
+     23     -15.0579      1.00000
+     24     -15.0115      1.00000
+     25     -14.9923      1.00000
+     26     -14.9867      1.00000
+     27     -14.9799      1.00000
+     28     -14.9345      1.00000
+     29     -14.9269      1.00000
+     30     -14.9130      1.00000
+     31     -14.8276      1.00000
+     32     -14.8076      1.00000
+     33     -14.7718      1.00000
+     34     -14.7631      1.00000
+     35     -14.7460      1.00000
+     36     -14.7347      1.00000
+     37     -14.7093      1.00000
+     38     -14.6805      1.00000
+     39     -14.6703      1.00000
+     40     -14.6583      1.00000
+     41     -14.6317      1.00000
+     42     -14.6299      1.00000
+     43     -14.6158      1.00000
+     44     -14.5725      1.00000
+     45     -14.5637      1.00000
+     46     -14.5351      1.00000
+     47     -14.5052      1.00000
+     48     -14.4851      1.00000
+     49     -14.4655      1.00000
+     50     -14.4276      1.00000
+     51     -14.4135      1.00000
+     52     -14.3549      1.00000
+     53     -14.3446      1.00000
+     54     -14.3321      1.00000
+     55     -14.3239      1.00000
+     56     -14.3086      1.00000
+     57     -14.3000      1.00000
+     58     -14.2863      1.00000
+     59     -14.2460      1.00000
+     60     -14.2257      1.00000
+     61     -14.2245      1.00000
+     62     -14.1769      1.00000
+     63     -14.0137      1.00000
+     64     -13.6596      1.00000
+     65     -13.4596      1.00000
+     66      -3.8041      1.00000
+     67      -3.7808      1.00000
+     68      -3.7145      1.00000
+     69      -3.6996      1.00000
+     70      -3.6957      1.00000
+     71      -3.6804      1.00000
+     72      -3.6495      1.00000
+     73      -3.6385      1.00000
+     74      -3.4834      1.00000
+     75      -3.4535      1.00000
+     76      -3.4404      1.00000
+     77      -3.3868      1.00000
+     78      -3.3749      1.00000
+     79      -3.3458      1.00000
+     80      -3.2441      1.00000
+     81      -3.2047      1.00000
+     82      -3.1931      1.00000
+     83      -3.1838      1.00000
+     84      -3.1023      1.00000
+     85      -3.0944      1.00000
+     86      -3.0639      1.00000
+     87      -3.0345      1.00000
+     88      -3.0202      1.00000
+     89      -3.0075      1.00000
+     90      -3.0030      1.00000
+     91      -2.9722      1.00000
+     92      -2.9500      1.00000
+     93      -2.9309      1.00000
+     94      -2.9166      1.00000
+     95      -2.8880      1.00000
+     96      -2.8693      1.00000
+     97      -2.8534      1.00000
+     98      -2.8337      1.00000
+     99      -2.7713      1.00000
+    100      -2.7656      1.00000
+    101      -2.7211      1.00000
+    102      -2.7127      1.00000
+    103      -2.6868      1.00000
+    104      -2.6779      1.00000
+    105      -2.6211      1.00000
+    106      -2.5934      1.00000
+    107      -2.5482      1.00000
+    108      -2.4984      1.00000
+    109      -2.4577      1.00000
+    110      -2.4091      1.00000
+    111      -2.3726      1.00000
+    112      -2.3422      1.00000
+    113      -2.2988      1.00000
+    114      -2.2611      1.00000
+    115      -2.2405      1.00000
+    116      -2.1991      1.00000
+    117      -2.1687      1.00000
+    118      -2.1482      1.00000
+    119      -2.0913      1.00000
+    120      -2.0849      1.00000
+    121      -2.0466      1.00000
+    122      -2.0118      1.00000
+    123      -1.9419      1.00000
+    124      -1.8685      1.00000
+    125      -1.8081      1.00000
+    126      -1.7893      1.00000
+    127      -1.7077      1.00000
+    128      -1.6994      1.00000
+    129      -1.6903      1.00000
+    130      -1.6671      1.00000
+    131      -1.6462      1.00000
+    132      -1.6303      1.00000
+    133      -1.6042      1.00000
+    134      -1.5816      1.00000
+    135      -1.5478      1.00000
+    136      -1.5014      1.00000
+    137      -1.4851      1.00000
+    138      -1.4436      1.00000
+    139      -1.4118      1.00000
+    140      -1.4006      1.00000
+    141      -1.3595      1.00000
+    142      -1.3440      1.00000
+    143      -1.3324      1.00000
+    144      -1.2829      1.00000
+    145      -1.2341      1.00000
+    146      -1.1139      1.00000
+    147      -1.0377      1.00000
+    148      -1.0162      1.00000
+    149      -0.9845      1.00000
+    150      -0.9383      1.00000
+    151      -0.9006      1.00000
+    152      -0.8648      1.00000
+    153      -0.8436      1.00000
+    154      -0.7989      1.00000
+    155      -0.7737      1.00000
+    156      -0.7024      1.00000
+    157      -0.6607      1.00000
+    158      -0.6350      1.00000
+    159      -0.6239      1.00000
+    160      -0.5700      1.00000
+    161      -0.5547      1.00000
+    162      -0.5249      1.00000
+    163      -0.4551      1.00000
+    164      -0.4447      1.00000
+    165      -0.4020      1.00000
+    166      -0.3619      1.00000
+    167      -0.3488      1.00000
+    168      -0.3166      1.00000
+    169      -0.3052      1.00000
+    170      -0.2686      1.00000
+    171      -0.2436      1.00000
+    172      -0.2345      1.00000
+    173      -0.1989      1.00000
+    174      -0.1731      1.00000
+    175      -0.1171      1.00000
+    176      -0.0903      1.00000
+    177      -0.0609      1.00000
+    178      -0.0118      1.00000
+    179       0.0192      1.00000
+    180       0.0436      1.00000
+    181       0.0662      1.00000
+    182       0.0803      1.00000
+    183       0.1235      1.00000
+    184       0.1576      1.00000
+    185       0.1874      1.00000
+    186       0.2042      1.00000
+    187       0.2221      1.00000
+    188       0.2303      1.00000
+    189       0.2504      1.00000
+    190       0.2815      1.00000
+    191       0.3197      1.00000
+    192       0.3365      1.00000
+    193       0.3855      1.00000
+    194       0.4363      1.00000
+    195       0.4484      1.00000
+    196       0.4793      1.00000
+    197       0.5105      1.00000
+    198       0.5277      1.00000
+    199       0.5441      1.00000
+    200       0.5536      1.00000
+    201       0.5620      1.00000
+    202       0.5725      1.00000
+    203       0.5993      1.00000
+    204       0.6185      1.00000
+    205       0.6387      1.00000
+    206       0.6561      1.00000
+    207       0.6743      1.00000
+    208       0.6807      1.00000
+    209       0.6847      1.00000
+    210       0.7101      1.00000
+    211       0.7199      1.00000
+    212       0.7235      1.00000
+    213       0.7481      1.00000
+    214       0.7684      1.00000
+    215       0.7760      1.00000
+    216       0.7932      1.00000
+    217       0.8230      1.00000
+    218       0.8479      1.00000
+    219       0.8656      1.00000
+    220       0.8856      1.00000
+    221       0.9191      1.00000
+    222       0.9325      1.00000
+    223       0.9436      1.00000
+    224       0.9637      1.00000
+    225       0.9703      1.00000
+    226       0.9752      1.00000
+    227       0.9967      1.00000
+    228       1.0025      1.00000
+    229       1.0309      1.00000
+    230       1.0366      1.00000
+    231       1.0537      1.00000
+    232       1.0685      1.00000
+    233       1.0869      1.00000
+    234       1.1238      1.00000
+    235       1.1656      1.00000
+    236       1.1874      1.00000
+    237       1.2113      1.00000
+    238       1.2467      1.00000
+    239       1.3247      1.00000
+    240       1.3483      1.00000
+    241       1.3558      1.00000
+    242       1.3780      1.00000
+    243       1.3948      1.00000
+    244       1.4566      1.00000
+    245       1.4681      1.00000
+    246       1.4796      1.00000
+    247       1.5005      1.00000
+    248       1.5312      1.00000
+    249       1.5573      1.00000
+    250       1.5770      1.00000
+    251       1.6354      1.00000
+    252       1.6593      1.00000
+    253       1.7125      1.00000
+    254       1.8339      1.00000
+    255       1.8700      1.00000
+    256       5.2282      0.00000
+    257       5.2570      0.00000
+    258       5.3034      0.00000
+    259       5.3539      0.00000
+    260       5.4374      0.00000
+    261       5.4816      0.00000
+    262       5.4932      0.00000
+    263       5.5081      0.00000
+    264       5.5212      0.00000
+    265       5.5219      0.00000
+    266       5.5836      0.00000
+    267       5.5970      0.00000
+    268       5.6578      0.00000
+    269       5.6731      0.00000
+    270       5.7232      0.00000
+    271       5.7493      0.00000
+    272       5.7668      0.00000
+    273       5.8065      0.00000
+    274       5.8101      0.00000
+    275       5.8266      0.00000
+    276       5.8462      0.00000
+    277       5.8730      0.00000
+    278       5.9001      0.00000
+    279       5.9135      0.00000
+    280       5.9428      0.00000
+    281       5.9507      0.00000
+    282       5.9758      0.00000
+    283       6.0051      0.00000
+    284       6.0503      0.00000
+    285       6.0892      0.00000
+    286       6.1398      0.00000
+    287       6.1643      0.00000
+    288       6.2050      0.00000
+    289       6.2229      0.00000
+    290       6.2335      0.00000
+    291       6.2885      0.00000
+    292       6.3145      0.00000
+    293       6.3538      0.00000
+    294       6.3957      0.00000
+    295       6.4152      0.00000
+    296       6.4213      0.00000
+    297       6.4358      0.00000
+    298       6.4409      0.00000
+    299       6.4678      0.00000
+    300       6.5052      0.00000
+    301       6.7776      0.00000
+    302       6.8910      0.00000
+    303       6.9537      0.00000
+    304       6.9740      0.00000
+    305       6.9990      0.00000
+    306       7.0329      0.00000
+    307       7.0497      0.00000
+    308       7.0784      0.00000
+    309       7.0873      0.00000
+    310       7.1214      0.00000
+    311       7.1504      0.00000
+    312       7.1907      0.00000
+    313       7.2044      0.00000
+    314       7.2197      0.00000
+    315       7.2588      0.00000
+    316       7.2673      0.00000
+    317       7.3417      0.00000
+    318       7.3625      0.00000
+    319       7.3906      0.00000
+    320       7.4224      0.00000
+    321       7.4963      0.00000
+    322       7.5426      0.00000
+    323       7.5751      0.00000
+    324       7.6205      0.00000
+    325       8.1881      0.00000
+    326       8.3260      0.00000
+    327       8.5304      0.00000
+    328       8.6110      0.00000
+    329       8.6483      0.00000
+    330       8.6836      0.00000
+    331       8.7219      0.00000
+    332       8.7558      0.00000
+    333       8.8212      0.00000
+    334       8.8597      0.00000
+    335       8.9147      0.00000
+    336       8.9605      0.00000
+    337       8.9848      0.00000
+    338       9.0174      0.00000
+    339       9.0871      0.00000
+    340       9.1108      0.00000
+    341       9.1755      0.00000
+    342       9.2200      0.00000
+    343       9.2581      0.00000
+    344       9.2718      0.00000
+    345       9.2885      0.00000
+    346       9.3423      0.00000
+    347       9.4240      0.00000
+    348       9.6241      0.00000
+    349       9.6567      0.00000
+    350       9.7369      0.00000
+    351       9.7541      0.00000
+    352       9.8012      0.00000
+    353       9.8311      0.00000
+    354       9.8792      0.00000
+    355       9.9270      0.00000
+    356       9.9380      0.00000
+    357       9.9883      0.00000
+    358      10.0697      0.00000
+    359      10.1395      0.00000
+    360      10.1883      0.00000
+
+ spin component 2
+
+ k-point     1 :       0.0000    0.0000    0.0000
+  band No.  band energies     occupation 
+      1     -16.1980      1.00000
+      2     -16.0197      1.00000
+      3     -15.9208      1.00000
+      4     -15.7305      1.00000
+      5     -15.5450      1.00000
+      6     -15.5412      1.00000
+      7     -15.4905      1.00000
+      8     -15.4774      1.00000
+      9     -15.4148      1.00000
+     10     -15.4107      1.00000
+     11     -15.2933      1.00000
+     12     -15.2732      1.00000
+     13     -15.2270      1.00000
+     14     -15.2046      1.00000
+     15     -15.1940      1.00000
+     16     -15.1645      1.00000
+     17     -15.1248      1.00000
+     18     -15.1071      1.00000
+     19     -15.1025      1.00000
+     20     -15.0909      1.00000
+     21     -15.0677      1.00000
+     22     -15.0447      1.00000
+     23     -15.0351      1.00000
+     24     -14.9931      1.00000
+     25     -14.9482      1.00000
+     26     -14.9303      1.00000
+     27     -14.9251      1.00000
+     28     -14.8968      1.00000
+     29     -14.8628      1.00000
+     30     -14.8486      1.00000
+     31     -14.8343      1.00000
+     32     -14.8223      1.00000
+     33     -14.8079      1.00000
+     34     -14.7406      1.00000
+     35     -14.7119      1.00000
+     36     -14.6961      1.00000
+     37     -14.6859      1.00000
+     38     -14.6662      1.00000
+     39     -14.6596      1.00000
+     40     -14.6321      1.00000
+     41     -14.6115      1.00000
+     42     -14.5692      1.00000
+     43     -14.5474      1.00000
+     44     -14.5275      1.00000
+     45     -14.4704      1.00000
+     46     -14.4197      1.00000
+     47     -14.3938      1.00000
+     48     -14.3763      1.00000
+     49     -14.3742      1.00000
+     50     -14.3628      1.00000
+     51     -14.3593      1.00000
+     52     -14.3466      1.00000
+     53     -14.3435      1.00000
+     54     -14.3347      1.00000
+     55     -14.3063      1.00000
+     56     -14.3009      1.00000
+     57     -14.2619      1.00000
+     58     -14.2217      1.00000
+     59     -14.1869      1.00000
+     60     -14.1378      1.00000
+     61     -13.9877      1.00000
+     62     -13.6459      1.00000
+     63     -13.4789      1.00000
+     64      -3.8556      1.00000
+     65      -3.8107      1.00000
+     66      -3.7224      1.00000
+     67      -3.7072      1.00000
+     68      -3.6546      1.00000
+     69      -3.6452      1.00000
+     70      -3.6077      1.00000
+     71      -3.5564      1.00000
+     72      -3.5515      1.00000
+     73      -3.5294      1.00000
+     74      -3.4707      1.00000
+     75      -3.4050      1.00000
+     76      -3.3937      1.00000
+     77      -3.3862      1.00000
+     78      -3.3668      1.00000
+     79      -3.3617      1.00000
+     80      -3.3287      1.00000
+     81      -3.2868      1.00000
+     82      -3.2564      1.00000
+     83      -3.1981      1.00000
+     84      -3.1770      1.00000
+     85      -3.1565      1.00000
+     86      -3.1419      1.00000
+     87      -3.1038      1.00000
+     88      -3.0923      1.00000
+     89      -3.0514      1.00000
+     90      -3.0453      1.00000
+     91      -2.9954      1.00000
+     92      -2.9616      1.00000
+     93      -2.9249      1.00000
+     94      -2.8268      1.00000
+     95      -2.8165      1.00000
+     96      -2.7572      1.00000
+     97      -2.7048      1.00000
+     98      -2.6574      1.00000
+     99      -2.6174      1.00000
+    100      -2.5713      1.00000
+    101      -2.5342      1.00000
+    102      -2.4598      1.00000
+    103      -2.4269      1.00000
+    104      -2.3818      1.00000
+    105      -2.3489      1.00000
+    106      -2.3349      1.00000
+    107      -2.3170      1.00000
+    108      -2.2857      1.00000
+    109      -2.2309      1.00000
+    110      -2.1807      1.00000
+    111      -2.1607      1.00000
+    112      -2.1483      1.00000
+    113      -2.1184      1.00000
+    114      -2.0627      1.00000
+    115      -2.0500      1.00000
+    116      -1.9968      1.00000
+    117      -1.9676      1.00000
+    118      -1.9558      1.00000
+    119      -1.9232      1.00000
+    120      -1.8803      1.00000
+    121      -1.8735      1.00000
+    122      -1.8610      1.00000
+    123      -1.8346      1.00000
+    124      -1.8211      1.00000
+    125      -1.7949      1.00000
+    126      -1.7820      1.00000
+    127      -1.7195      1.00000
+    128      -1.6942      1.00000
+    129      -1.6673      1.00000
+    130      -1.6375      1.00000
+    131      -1.6097      1.00000
+    132      -1.6018      1.00000
+    133      -1.5473      1.00000
+    134      -1.5243      1.00000
+    135      -1.5062      1.00000
+    136      -1.4866      1.00000
+    137      -1.4578      1.00000
+    138      -1.4267      1.00000
+    139      -1.4033      1.00000
+    140      -1.3102      1.00000
+    141      -1.2658      1.00000
+    142      -1.2167      1.00000
+    143      -1.1542      1.00000
+    144      -1.0978      1.00000
+    145      -1.0699      1.00000
+    146      -1.0510      1.00000
+    147      -1.0262      1.00000
+    148      -1.0058      1.00000
+    149      -0.9631      1.00000
+    150      -0.9325      1.00000
+    151      -0.9281      1.00000
+    152      -0.8990      1.00000
+    153      -0.8674      1.00000
+    154      -0.8210      1.00000
+    155      -0.7888      1.00000
+    156      -0.7320      1.00000
+    157      -0.7158      1.00000
+    158      -0.6892      1.00000
+    159      -0.6222      1.00000
+    160      -0.6029      1.00000
+    161      -0.5502      1.00000
+    162      -0.5180      1.00000
+    163      -0.4851      1.00000
+    164      -0.4566      1.00000
+    165      -0.4515      1.00000
+    166      -0.4130      1.00000
+    167      -0.3938      1.00000
+    168      -0.3726      1.00000
+    169      -0.3380      1.00000
+    170      -0.3217      1.00000
+    171      -0.2375      1.00000
+    172      -0.2146      1.00000
+    173      -0.2019      1.00000
+    174      -0.1624      1.00000
+    175      -0.1368      1.00000
+    176      -0.0934      1.00000
+    177      -0.0361      1.00000
+    178      -0.0102      1.00000
+    179       0.0113      1.00000
+    180       0.0722      1.00000
+    181       0.0899      1.00000
+    182       0.1153      1.00000
+    183       0.1573      1.00000
+    184       0.1761      1.00000
+    185       0.1965      1.00000
+    186       0.2119      1.00000
+    187       0.2289      1.00000
+    188       0.2458      1.00000
+    189       0.2584      1.00000
+    190       0.2792      1.00000
+    191       0.2980      1.00000
+    192       0.3172      1.00000
+    193       0.3344      1.00000
+    194       0.3557      1.00000
+    195       0.3905      1.00000
+    196       0.4236      1.00000
+    197       0.4667      1.00000
+    198       0.5038      1.00000
+    199       0.5284      1.00000
+    200       0.5704      1.00000
+    201       0.5926      1.00000
+    202       0.6292      1.00000
+    203       0.6414      1.00000
+    204       0.6659      1.00000
+    205       0.6722      1.00000
+    206       0.7029      1.00000
+    207       0.7318      1.00000
+    208       0.7471      1.00000
+    209       0.7538      1.00000
+    210       0.7743      1.00000
+    211       0.7963      1.00000
+    212       0.8314      1.00000
+    213       0.8466      1.00000
+    214       0.8788      1.00000
+    215       0.8885      1.00000
+    216       0.9243      1.00000
+    217       0.9377      1.00000
+    218       0.9575      1.00000
+    219       0.9713      1.00000
+    220       0.9914      1.00000
+    221       1.0074      1.00000
+    222       1.0131      1.00000
+    223       1.0220      1.00000
+    224       1.0492      1.00000
+    225       1.0617      1.00000
+    226       1.0767      1.00000
+    227       1.1052      1.00000
+    228       1.1328      1.00000
+    229       1.1649      1.00000
+    230       1.2023      1.00000
+    231       1.2281      1.00000
+    232       1.2560      1.00000
+    233       1.2711      1.00000
+    234       1.2863      1.00000
+    235       1.3043      1.00000
+    236       1.3198      1.00000
+    237       1.3406      1.00000
+    238       1.3622      1.00000
+    239       1.3861      1.00000
+    240       1.3937      1.00000
+    241       1.4372      1.00000
+    242       1.4638      1.00000
+    243       1.4671      1.00000
+    244       1.5052      1.00000
+    245       1.5180      1.00000
+    246       1.5230      1.00000
+    247       1.5541      1.00000
+    248       1.5951      1.00000
+    249       1.6365      1.00000
+    250       1.7205      1.00000
+    251       1.7477      1.00000
+    252       1.7888      1.00000
+    253       1.8498      1.00000
+    254       5.1968      0.00000
+    255       5.2660      0.00000
+    256       5.3625      0.00000
+    257       5.4108      0.00000
+    258       5.4202      0.00000
+    259       5.4428      0.00000
+    260       5.4515      0.00000
+    261       5.4695      0.00000
+    262       5.4750      0.00000
+    263       5.5527      0.00000
+    264       5.5668      0.00000
+    265       5.5734      0.00000
+    266       5.6063      0.00000
+    267       5.6667      0.00000
+    268       5.6810      0.00000
+    269       5.7199      0.00000
+    270       5.7328      0.00000
+    271       5.7613      0.00000
+    272       5.7843      0.00000
+    273       5.8199      0.00000
+    274       5.8338      0.00000
+    275       5.8507      0.00000
+    276       5.8963      0.00000
+    277       5.9304      0.00000
+    278       5.9571      0.00000
+    279       5.9987      0.00000
+    280       6.0204      0.00000
+    281       6.0534      0.00000
+    282       6.0675      0.00000
+    283       6.0785      0.00000
+    284       6.1014      0.00000
+    285       6.1139      0.00000
+    286       6.1440      0.00000
+    287       6.1742      0.00000
+    288       6.2024      0.00000
+    289       6.2544      0.00000
+    290       6.2775      0.00000
+    291       6.3353      0.00000
+    292       6.3917      0.00000
+    293       6.4349      0.00000
+    294       6.4909      0.00000
+    295       6.4998      0.00000
+    296       6.5427      0.00000
+    297       6.6852      0.00000
+    298       6.7157      0.00000
+    299       6.7640      0.00000
+    300       6.8345      0.00000
+    301       6.9108      0.00000
+    302       6.9569      0.00000
+    303       6.9709      0.00000
+    304       6.9829      0.00000
+    305       7.0332      0.00000
+    306       7.0497      0.00000
+    307       7.0913      0.00000
+    308       7.1162      0.00000
+    309       7.1227      0.00000
+    310       7.1638      0.00000
+    311       7.2037      0.00000
+    312       7.2122      0.00000
+    313       7.2363      0.00000
+    314       7.2731      0.00000
+    315       7.3279      0.00000
+    316       7.3444      0.00000
+    317       7.3773      0.00000
+    318       7.4193      0.00000
+    319       7.4515      0.00000
+    320       7.4880      0.00000
+    321       7.5450      0.00000
+    322       7.7053      0.00000
+    323       8.2410      0.00000
+    324       8.5684      0.00000
+    325       8.6094      0.00000
+    326       8.6437      0.00000
+    327       8.6781      0.00000
+    328       8.7440      0.00000
+    329       8.7871      0.00000
+    330       8.8216      0.00000
+    331       8.8381      0.00000
+    332       8.8664      0.00000
+    333       8.8825      0.00000
+    334       8.9347      0.00000
+    335       8.9642      0.00000
+    336       8.9943      0.00000
+    337       9.0489      0.00000
+    338       9.0687      0.00000
+    339       9.1390      0.00000
+    340       9.2052      0.00000
+    341       9.2807      0.00000
+    342       9.3017      0.00000
+    343       9.3264      0.00000
+    344       9.4343      0.00000
+    345       9.4453      0.00000
+    346       9.5243      0.00000
+    347       9.6141      0.00000
+    348       9.6474      0.00000
+    349       9.6978      0.00000
+    350       9.7706      0.00000
+    351       9.8414      0.00000
+    352       9.8563      0.00000
+    353       9.9168      0.00000
+    354       9.9578      0.00000
+    355      10.0107      0.00000
+    356      10.1153      0.00000
+    357      10.2379      0.00000
+    358      10.2631      0.00000
+    359      10.3141      0.00000
+    360      10.3652      0.00000
+
+ k-point     2 :       0.5000    0.0000    0.0000
+  band No.  band energies     occupation 
+      1     -16.1097      1.00000
+      2     -16.0724      1.00000
+      3     -15.9591      1.00000
+      4     -15.7641      1.00000
+      5     -15.5157      1.00000
+      6     -15.5088      1.00000
+      7     -15.4819      1.00000
+      8     -15.4713      1.00000
+      9     -15.4461      1.00000
+     10     -15.4417      1.00000
+     11     -15.3049      1.00000
+     12     -15.2870      1.00000
+     13     -15.2372      1.00000
+     14     -15.1986      1.00000
+     15     -15.1602      1.00000
+     16     -15.1512      1.00000
+     17     -15.1407      1.00000
+     18     -15.1301      1.00000
+     19     -15.1130      1.00000
+     20     -15.0874      1.00000
+     21     -15.0740      1.00000
+     22     -15.0658      1.00000
+     23     -15.0352      1.00000
+     24     -14.9898      1.00000
+     25     -14.9632      1.00000
+     26     -14.9506      1.00000
+     27     -14.9371      1.00000
+     28     -14.8993      1.00000
+     29     -14.8926      1.00000
+     30     -14.8502      1.00000
+     31     -14.7865      1.00000
+     32     -14.7475      1.00000
+     33     -14.7260      1.00000
+     34     -14.7228      1.00000
+     35     -14.7103      1.00000
+     36     -14.6961      1.00000
+     37     -14.6879      1.00000
+     38     -14.6782      1.00000
+     39     -14.6699      1.00000
+     40     -14.6466      1.00000
+     41     -14.6436      1.00000
+     42     -14.5604      1.00000
+     43     -14.5339      1.00000
+     44     -14.5057      1.00000
+     45     -14.4614      1.00000
+     46     -14.4043      1.00000
+     47     -14.3979      1.00000
+     48     -14.3848      1.00000
+     49     -14.3796      1.00000
+     50     -14.3502      1.00000
+     51     -14.3418      1.00000
+     52     -14.3344      1.00000
+     53     -14.3214      1.00000
+     54     -14.3132      1.00000
+     55     -14.3048      1.00000
+     56     -14.2859      1.00000
+     57     -14.2841      1.00000
+     58     -14.2469      1.00000
+     59     -14.2246      1.00000
+     60     -14.1869      1.00000
+     61     -13.9948      1.00000
+     62     -13.6503      1.00000
+     63     -13.4797      1.00000
+     64      -3.8057      1.00000
+     65      -3.7897      1.00000
+     66      -3.7748      1.00000
+     67      -3.6982      1.00000
+     68      -3.6186      1.00000
+     69      -3.6094      1.00000
+     70      -3.5807      1.00000
+     71      -3.5741      1.00000
+     72      -3.5565      1.00000
+     73      -3.5170      1.00000
+     74      -3.4900      1.00000
+     75      -3.4656      1.00000
+     76      -3.4502      1.00000
+     77      -3.4225      1.00000
+     78      -3.3701      1.00000
+     79      -3.3607      1.00000
+     80      -3.2491      1.00000
+     81      -3.2335      1.00000
+     82      -3.2272      1.00000
+     83      -3.1797      1.00000
+     84      -3.1641      1.00000
+     85      -3.1504      1.00000
+     86      -3.1238      1.00000
+     87      -3.1039      1.00000
+     88      -3.0837      1.00000
+     89      -3.0662      1.00000
+     90      -3.0417      1.00000
+     91      -3.0253      1.00000
+     92      -2.9548      1.00000
+     93      -2.8867      1.00000
+     94      -2.7965      1.00000
+     95      -2.7778      1.00000
+     96      -2.6943      1.00000
+     97      -2.6572      1.00000
+     98      -2.6369      1.00000
+     99      -2.6148      1.00000
+    100      -2.5982      1.00000
+    101      -2.5565      1.00000
+    102      -2.5185      1.00000
+    103      -2.4847      1.00000
+    104      -2.4666      1.00000
+    105      -2.4144      1.00000
+    106      -2.3994      1.00000
+    107      -2.3555      1.00000
+    108      -2.3388      1.00000
+    109      -2.2947      1.00000
+    110      -2.2735      1.00000
+    111      -2.2616      1.00000
+    112      -2.1894      1.00000
+    113      -2.1053      1.00000
+    114      -2.0841      1.00000
+    115      -2.0409      1.00000
+    116      -2.0331      1.00000
+    117      -1.9674      1.00000
+    118      -1.9449      1.00000
+    119      -1.8938      1.00000
+    120      -1.8888      1.00000
+    121      -1.8516      1.00000
+    122      -1.8103      1.00000
+    123      -1.8034      1.00000
+    124      -1.7491      1.00000
+    125      -1.7321      1.00000
+    126      -1.7164      1.00000
+    127      -1.6751      1.00000
+    128      -1.6708      1.00000
+    129      -1.6332      1.00000
+    130      -1.6263      1.00000
+    131      -1.5941      1.00000
+    132      -1.5368      1.00000
+    133      -1.4923      1.00000
+    134      -1.4718      1.00000
+    135      -1.4613      1.00000
+    136      -1.4467      1.00000
+    137      -1.4247      1.00000
+    138      -1.4033      1.00000
+    139      -1.3942      1.00000
+    140      -1.3682      1.00000
+    141      -1.3337      1.00000
+    142      -1.2896      1.00000
+    143      -1.2709      1.00000
+    144      -1.2317      1.00000
+    145      -1.1880      1.00000
+    146      -1.1669      1.00000
+    147      -1.0988      1.00000
+    148      -1.0527      1.00000
+    149      -1.0337      1.00000
+    150      -0.9960      1.00000
+    151      -0.9823      1.00000
+    152      -0.9324      1.00000
+    153      -0.9031      1.00000
+    154      -0.8610      1.00000
+    155      -0.8457      1.00000
+    156      -0.7722      1.00000
+    157      -0.7448      1.00000
+    158      -0.6931      1.00000
+    159      -0.6530      1.00000
+    160      -0.6131      1.00000
+    161      -0.5200      1.00000
+    162      -0.5039      1.00000
+    163      -0.4705      1.00000
+    164      -0.3866      1.00000
+    165      -0.3644      1.00000
+    166      -0.3152      1.00000
+    167      -0.2838      1.00000
+    168      -0.2420      1.00000
+    169      -0.2344      1.00000
+    170      -0.2216      1.00000
+    171      -0.2039      1.00000
+    172      -0.2000      1.00000
+    173      -0.1662      1.00000
+    174      -0.1134      1.00000
+    175      -0.1020      1.00000
+    176      -0.0259      1.00000
+    177       0.0055      1.00000
+    178       0.0334      1.00000
+    179       0.0690      1.00000
+    180       0.1088      1.00000
+    181       0.1192      1.00000
+    182       0.1346      1.00000
+    183       0.1715      1.00000
+    184       0.2012      1.00000
+    185       0.2078      1.00000
+    186       0.2158      1.00000
+    187       0.2551      1.00000
+    188       0.2889      1.00000
+    189       0.3176      1.00000
+    190       0.3669      1.00000
+    191       0.3763      1.00000
+    192       0.3899      1.00000
+    193       0.4022      1.00000
+    194       0.4278      1.00000
+    195       0.4516      1.00000
+    196       0.4697      1.00000
+    197       0.4960      1.00000
+    198       0.5345      1.00000
+    199       0.5580      1.00000
+    200       0.5762      1.00000
+    201       0.5941      1.00000
+    202       0.6501      1.00000
+    203       0.6536      1.00000
+    204       0.6645      1.00000
+    205       0.6724      1.00000
+    206       0.6764      1.00000
+    207       0.7279      1.00000
+    208       0.7409      1.00000
+    209       0.7579      1.00000
+    210       0.7709      1.00000
+    211       0.7800      1.00000
+    212       0.8055      1.00000
+    213       0.8245      1.00000
+    214       0.8347      1.00000
+    215       0.8576      1.00000
+    216       0.8967      1.00000
+    217       0.9052      1.00000
+    218       0.9509      1.00000
+    219       0.9742      1.00000
+    220       0.9812      1.00000
+    221       1.0015      1.00000
+    222       1.0189      1.00000
+    223       1.0304      1.00000
+    224       1.0393      1.00000
+    225       1.0504      1.00000
+    226       1.0750      1.00000
+    227       1.1221      1.00000
+    228       1.1278      1.00000
+    229       1.1376      1.00000
+    230       1.1545      1.00000
+    231       1.1609      1.00000
+    232       1.1651      1.00000
+    233       1.1881      1.00000
+    234       1.2038      1.00000
+    235       1.2184      1.00000
+    236       1.2607      1.00000
+    237       1.2731      1.00000
+    238       1.2820      1.00000
+    239       1.2979      1.00000
+    240       1.3552      1.00000
+    241       1.3661      1.00000
+    242       1.3970      1.00000
+    243       1.4597      1.00000
+    244       1.4680      1.00000
+    245       1.5000      1.00000
+    246       1.5258      1.00000
+    247       1.5374      1.00000
+    248       1.6040      1.00000
+    249       1.6448      1.00000
+    250       1.7274      1.00000
+    251       1.7640      1.00000
+    252       1.7892      1.00000
+    253       1.8441      1.00000
+    254       5.1781      0.00000
+    255       5.2888      0.00000
+    256       5.3807      0.00000
+    257       5.3920      0.00000
+    258       5.4193      0.00000
+    259       5.4377      0.00000
+    260       5.5060      0.00000
+    261       5.5456      0.00000
+    262       5.5559      0.00000
+    263       5.5648      0.00000
+    264       5.5925      0.00000
+    265       5.6305      0.00000
+    266       5.6481      0.00000
+    267       5.7022      0.00000
+    268       5.7106      0.00000
+    269       5.7309      0.00000
+    270       5.7670      0.00000
+    271       5.7706      0.00000
+    272       5.8082      0.00000
+    273       5.8157      0.00000
+    274       5.8464      0.00000
+    275       5.8547      0.00000
+    276       5.8832      0.00000
+    277       5.9056      0.00000
+    278       5.9197      0.00000
+    279       5.9433      0.00000
+    280       5.9919      0.00000
+    281       6.0242      0.00000
+    282       6.0259      0.00000
+    283       6.0548      0.00000
+    284       6.0783      0.00000
+    285       6.1230      0.00000
+    286       6.1841      0.00000
+    287       6.2240      0.00000
+    288       6.2535      0.00000
+    289       6.2798      0.00000
+    290       6.3417      0.00000
+    291       6.3581      0.00000
+    292       6.3747      0.00000
+    293       6.3979      0.00000
+    294       6.4075      0.00000
+    295       6.4424      0.00000
+    296       6.4657      0.00000
+    297       6.4819      0.00000
+    298       6.5045      0.00000
+    299       6.7392      0.00000
+    300       6.8673      0.00000
+    301       6.9157      0.00000
+    302       6.9723      0.00000
+    303       7.0227      0.00000
+    304       7.0649      0.00000
+    305       7.0733      0.00000
+    306       7.1240      0.00000
+    307       7.1399      0.00000
+    308       7.1608      0.00000
+    309       7.1861      0.00000
+    310       7.2184      0.00000
+    311       7.2292      0.00000
+    312       7.2390      0.00000
+    313       7.2796      0.00000
+    314       7.2928      0.00000
+    315       7.3168      0.00000
+    316       7.3348      0.00000
+    317       7.3621      0.00000
+    318       7.4138      0.00000
+    319       7.4669      0.00000
+    320       7.5023      0.00000
+    321       7.5498      0.00000
+    322       7.6132      0.00000
+    323       8.2543      0.00000
+    324       8.5653      0.00000
+    325       8.5908      0.00000
+    326       8.6230      0.00000
+    327       8.7050      0.00000
+    328       8.7261      0.00000
+    329       8.7456      0.00000
+    330       8.8026      0.00000
+    331       8.8177      0.00000
+    332       8.8344      0.00000
+    333       8.8575      0.00000
+    334       8.9117      0.00000
+    335       8.9729      0.00000
+    336       9.0369      0.00000
+    337       9.1296      0.00000
+    338       9.1589      0.00000
+    339       9.1810      0.00000
+    340       9.2286      0.00000
+    341       9.3317      0.00000
+    342       9.4004      0.00000
+    343       9.4462      0.00000
+    344       9.4646      0.00000
+    345       9.5198      0.00000
+    346       9.5541      0.00000
+    347       9.5637      0.00000
+    348       9.6187      0.00000
+    349       9.6525      0.00000
+    350       9.7261      0.00000
+    351       9.7676      0.00000
+    352       9.8018      0.00000
+    353       9.8836      0.00000
+    354       9.8955      0.00000
+    355       9.9780      0.00000
+    356       9.9923      0.00000
+    357      10.1019      0.00000
+    358      10.1698      0.00000
+    359      10.2247      0.00000
+    360      10.2516      0.00000
+
+ k-point     3 :       0.0000    0.0000    0.5000
+  band No.  band energies     occupation 
+      1     -16.0214      1.00000
+      2     -15.9948      1.00000
+      3     -15.8647      1.00000
+      4     -15.8425      1.00000
+      5     -15.7747      1.00000
+      6     -15.7612      1.00000
+      7     -15.6726      1.00000
+      8     -15.3961      1.00000
+      9     -15.3316      1.00000
+     10     -15.3192      1.00000
+     11     -15.2850      1.00000
+     12     -15.2456      1.00000
+     13     -15.1867      1.00000
+     14     -15.1799      1.00000
+     15     -15.1661      1.00000
+     16     -15.1499      1.00000
+     17     -15.1147      1.00000
+     18     -15.1106      1.00000
+     19     -15.0471      1.00000
+     20     -15.0395      1.00000
+     21     -15.0344      1.00000
+     22     -15.0238      1.00000
+     23     -15.0213      1.00000
+     24     -15.0010      1.00000
+     25     -14.9917      1.00000
+     26     -14.9482      1.00000
+     27     -14.9167      1.00000
+     28     -14.8735      1.00000
+     29     -14.8515      1.00000
+     30     -14.8435      1.00000
+     31     -14.8269      1.00000
+     32     -14.7733      1.00000
+     33     -14.7290      1.00000
+     34     -14.7009      1.00000
+     35     -14.6922      1.00000
+     36     -14.6807      1.00000
+     37     -14.6700      1.00000
+     38     -14.6583      1.00000
+     39     -14.6456      1.00000
+     40     -14.6436      1.00000
+     41     -14.6297      1.00000
+     42     -14.5991      1.00000
+     43     -14.5799      1.00000
+     44     -14.5600      1.00000
+     45     -14.5380      1.00000
+     46     -14.5080      1.00000
+     47     -14.4836      1.00000
+     48     -14.4122      1.00000
+     49     -14.3976      1.00000
+     50     -14.3664      1.00000
+     51     -14.3410      1.00000
+     52     -14.3391      1.00000
+     53     -14.3314      1.00000
+     54     -14.3025      1.00000
+     55     -14.2709      1.00000
+     56     -14.2610      1.00000
+     57     -14.2329      1.00000
+     58     -14.2222      1.00000
+     59     -14.2060      1.00000
+     60     -14.1692      1.00000
+     61     -14.0016      1.00000
+     62     -13.6514      1.00000
+     63     -13.4778      1.00000
+     64      -3.7654      1.00000
+     65      -3.7582      1.00000
+     66      -3.7471      1.00000
+     67      -3.7209      1.00000
+     68      -3.6988      1.00000
+     69      -3.6903      1.00000
+     70      -3.6450      1.00000
+     71      -3.6272      1.00000
+     72      -3.4811      1.00000
+     73      -3.3874      1.00000
+     74      -3.3676      1.00000
+     75      -3.3567      1.00000
+     76      -3.3429      1.00000
+     77      -3.3170      1.00000
+     78      -3.2706      1.00000
+     79      -3.2622      1.00000
+     80      -3.2465      1.00000
+     81      -3.2188      1.00000
+     82      -3.2089      1.00000
+     83      -3.1774      1.00000
+     84      -3.1043      1.00000
+     85      -3.0860      1.00000
+     86      -3.0619      1.00000
+     87      -3.0404      1.00000
+     88      -3.0202      1.00000
+     89      -2.9934      1.00000
+     90      -2.9669      1.00000
+     91      -2.9613      1.00000
+     92      -2.9396      1.00000
+     93      -2.9284      1.00000
+     94      -2.8857      1.00000
+     95      -2.8307      1.00000
+     96      -2.8042      1.00000
+     97      -2.7598      1.00000
+     98      -2.7546      1.00000
+     99      -2.7343      1.00000
+    100      -2.7225      1.00000
+    101      -2.6561      1.00000
+    102      -2.6202      1.00000
+    103      -2.5858      1.00000
+    104      -2.5773      1.00000
+    105      -2.5223      1.00000
+    106      -2.5097      1.00000
+    107      -2.4140      1.00000
+    108      -2.3765      1.00000
+    109      -2.3555      1.00000
+    110      -2.3205      1.00000
+    111      -2.3074      1.00000
+    112      -2.2781      1.00000
+    113      -2.2583      1.00000
+    114      -2.2121      1.00000
+    115      -2.1824      1.00000
+    116      -2.1630      1.00000
+    117      -2.1314      1.00000
+    118      -2.0731      1.00000
+    119      -2.0266      1.00000
+    120      -1.9426      1.00000
+    121      -1.8925      1.00000
+    122      -1.8221      1.00000
+    123      -1.7875      1.00000
+    124      -1.7535      1.00000
+    125      -1.7026      1.00000
+    126      -1.6870      1.00000
+    127      -1.6625      1.00000
+    128      -1.6524      1.00000
+    129      -1.6449      1.00000
+    130      -1.6159      1.00000
+    131      -1.6013      1.00000
+    132      -1.5788      1.00000
+    133      -1.4914      1.00000
+    134      -1.4647      1.00000
+    135      -1.4236      1.00000
+    136      -1.3984      1.00000
+    137      -1.3682      1.00000
+    138      -1.3431      1.00000
+    139      -1.3058      1.00000
+    140      -1.2799      1.00000
+    141      -1.2210      1.00000
+    142      -1.2121      1.00000
+    143      -1.1576      1.00000
+    144      -1.0837      1.00000
+    145      -1.0748      1.00000
+    146      -1.0620      1.00000
+    147      -1.0231      1.00000
+    148      -1.0113      1.00000
+    149      -0.9110      1.00000
+    150      -0.8886      1.00000
+    151      -0.8493      1.00000
+    152      -0.8130      1.00000
+    153      -0.7832      1.00000
+    154      -0.7479      1.00000
+    155      -0.7316      1.00000
+    156      -0.7066      1.00000
+    157      -0.6327      1.00000
+    158      -0.6070      1.00000
+    159      -0.5898      1.00000
+    160      -0.5400      1.00000
+    161      -0.4840      1.00000
+    162      -0.4547      1.00000
+    163      -0.4188      1.00000
+    164      -0.4063      1.00000
+    165      -0.3361      1.00000
+    166      -0.2806      1.00000
+    167      -0.2569      1.00000
+    168      -0.2485      1.00000
+    169      -0.2201      1.00000
+    170      -0.1960      1.00000
+    171      -0.1604      1.00000
+    172      -0.1511      1.00000
+    173      -0.1355      1.00000
+    174      -0.1219      1.00000
+    175      -0.0871      1.00000
+    176      -0.0578      1.00000
+    177      -0.0427      1.00000
+    178      -0.0138      1.00000
+    179       0.0072      1.00000
+    180       0.0208      1.00000
+    181       0.0666      1.00000
+    182       0.0744      1.00000
+    183       0.1123      1.00000
+    184       0.1732      1.00000
+    185       0.1853      1.00000
+    186       0.2195      1.00000
+    187       0.2293      1.00000
+    188       0.2459      1.00000
+    189       0.2954      1.00000
+    190       0.3113      1.00000
+    191       0.3214      1.00000
+    192       0.3591      1.00000
+    193       0.3699      1.00000
+    194       0.3868      1.00000
+    195       0.4085      1.00000
+    196       0.4198      1.00000
+    197       0.4490      1.00000
+    198       0.4871      1.00000
+    199       0.5034      1.00000
+    200       0.5273      1.00000
+    201       0.5464      1.00000
+    202       0.5642      1.00000
+    203       0.5811      1.00000
+    204       0.5910      1.00000
+    205       0.6159      1.00000
+    206       0.6471      1.00000
+    207       0.6630      1.00000
+    208       0.7092      1.00000
+    209       0.7305      1.00000
+    210       0.7663      1.00000
+    211       0.7954      1.00000
+    212       0.8109      1.00000
+    213       0.8199      1.00000
+    214       0.8378      1.00000
+    215       0.8613      1.00000
+    216       0.8804      1.00000
+    217       0.9065      1.00000
+    218       0.9207      1.00000
+    219       0.9312      1.00000
+    220       0.9448      1.00000
+    221       0.9954      1.00000
+    222       1.0022      1.00000
+    223       1.0125      1.00000
+    224       1.0226      1.00000
+    225       1.0542      1.00000
+    226       1.0677      1.00000
+    227       1.0817      1.00000
+    228       1.0887      1.00000
+    229       1.1135      1.00000
+    230       1.1388      1.00000
+    231       1.1781      1.00000
+    232       1.1957      1.00000
+    233       1.2196      1.00000
+    234       1.2247      1.00000
+    235       1.2776      1.00000
+    236       1.2949      1.00000
+    237       1.3281      1.00000
+    238       1.3739      1.00000
+    239       1.3862      1.00000
+    240       1.4268      1.00000
+    241       1.4553      1.00000
+    242       1.4696      1.00000
+    243       1.4858      1.00000
+    244       1.4932      1.00000
+    245       1.5065      1.00000
+    246       1.5301      1.00000
+    247       1.5545      1.00000
+    248       1.5839      1.00000
+    249       1.6267      1.00000
+    250       1.6615      1.00000
+    251       1.7472      1.00000
+    252       1.8190      1.00000
+    253       1.8521      1.00000
+    254       5.2501      0.00000
+    255       5.2682      0.00000
+    256       5.3254      0.00000
+    257       5.3339      0.00000
+    258       5.3763      0.00000
+    259       5.3885      0.00000
+    260       5.4423      0.00000
+    261       5.4652      0.00000
+    262       5.4918      0.00000
+    263       5.5232      0.00000
+    264       5.5916      0.00000
+    265       5.6228      0.00000
+    266       5.6518      0.00000
+    267       5.6592      0.00000
+    268       5.6965      0.00000
+    269       5.7356      0.00000
+    270       5.7541      0.00000
+    271       5.7615      0.00000
+    272       5.7962      0.00000
+    273       5.8056      0.00000
+    274       5.8716      0.00000
+    275       5.8950      0.00000
+    276       5.9225      0.00000
+    277       5.9309      0.00000
+    278       5.9327      0.00000
+    279       5.9511      0.00000
+    280       5.9598      0.00000
+    281       6.0087      0.00000
+    282       6.0205      0.00000
+    283       6.0759      0.00000
+    284       6.1076      0.00000
+    285       6.1299      0.00000
+    286       6.1563      0.00000
+    287       6.1793      0.00000
+    288       6.2177      0.00000
+    289       6.2544      0.00000
+    290       6.3105      0.00000
+    291       6.3662      0.00000
+    292       6.4104      0.00000
+    293       6.4578      0.00000
+    294       6.4736      0.00000
+    295       6.5392      0.00000
+    296       6.6656      0.00000
+    297       6.6678      0.00000
+    298       6.7103      0.00000
+    299       6.7736      0.00000
+    300       6.8558      0.00000
+    301       6.9143      0.00000
+    302       6.9362      0.00000
+    303       6.9622      0.00000
+    304       6.9803      0.00000
+    305       7.0233      0.00000
+    306       7.0434      0.00000
+    307       7.0953      0.00000
+    308       7.1162      0.00000
+    309       7.1186      0.00000
+    310       7.1601      0.00000
+    311       7.1686      0.00000
+    312       7.1831      0.00000
+    313       7.2123      0.00000
+    314       7.2518      0.00000
+    315       7.3464      0.00000
+    316       7.3655      0.00000
+    317       7.3932      0.00000
+    318       7.4032      0.00000
+    319       7.4471      0.00000
+    320       7.4988      0.00000
+    321       7.6210      0.00000
+    322       7.6590      0.00000
+    323       8.2562      0.00000
+    324       8.5186      0.00000
+    325       8.5628      0.00000
+    326       8.5764      0.00000
+    327       8.6036      0.00000
+    328       8.7121      0.00000
+    329       8.7791      0.00000
+    330       8.8587      0.00000
+    331       8.9039      0.00000
+    332       8.9377      0.00000
+    333       8.9481      0.00000
+    334       8.9791      0.00000
+    335       9.0402      0.00000
+    336       9.0709      0.00000
+    337       9.1030      0.00000
+    338       9.1293      0.00000
+    339       9.2234      0.00000
+    340       9.2436      0.00000
+    341       9.2875      0.00000
+    342       9.3705      0.00000
+    343       9.3967      0.00000
+    344       9.4147      0.00000
+    345       9.4423      0.00000
+    346       9.5151      0.00000
+    347       9.5672      0.00000
+    348       9.6139      0.00000
+    349       9.6300      0.00000
+    350       9.7406      0.00000
+    351       9.7815      0.00000
+    352       9.8391      0.00000
+    353       9.8521      0.00000
+    354       9.9338      0.00000
+    355      10.0336      0.00000
+    356      10.1167      0.00000
+    357      10.1388      0.00000
+    358      10.1987      0.00000
+    359      10.2645      0.00000
+    360      10.3071      0.00000
+
+ k-point     4 :       0.5000    0.0000    0.5000
+  band No.  band energies     occupation 
+      1     -15.9373      1.00000
+      2     -15.9172      1.00000
+      3     -15.9007      1.00000
+      4     -15.8981      1.00000
+      5     -15.8153      1.00000
+      6     -15.7948      1.00000
+      7     -15.7101      1.00000
+      8     -15.4179      1.00000
+      9     -15.3201      1.00000
+     10     -15.2936      1.00000
+     11     -15.2681      1.00000
+     12     -15.2575      1.00000
+     13     -15.2069      1.00000
+     14     -15.1815      1.00000
+     15     -15.1755      1.00000
+     16     -15.1656      1.00000
+     17     -15.1102      1.00000
+     18     -15.0951      1.00000
+     19     -15.0824      1.00000
+     20     -15.0727      1.00000
+     21     -15.0580      1.00000
+     22     -15.0115      1.00000
+     23     -14.9926      1.00000
+     24     -14.9868      1.00000
+     25     -14.9798      1.00000
+     26     -14.9345      1.00000
+     27     -14.9269      1.00000
+     28     -14.9129      1.00000
+     29     -14.8279      1.00000
+     30     -14.8077      1.00000
+     31     -14.7718      1.00000
+     32     -14.7631      1.00000
+     33     -14.7457      1.00000
+     34     -14.7349      1.00000
+     35     -14.7089      1.00000
+     36     -14.6806      1.00000
+     37     -14.6702      1.00000
+     38     -14.6584      1.00000
+     39     -14.6311      1.00000
+     40     -14.6300      1.00000
+     41     -14.6159      1.00000
+     42     -14.5724      1.00000
+     43     -14.5637      1.00000
+     44     -14.5348      1.00000
+     45     -14.5042      1.00000
+     46     -14.4847      1.00000
+     47     -14.4647      1.00000
+     48     -14.4278      1.00000
+     49     -14.4135      1.00000
+     50     -14.3549      1.00000
+     51     -14.3446      1.00000
+     52     -14.3322      1.00000
+     53     -14.3238      1.00000
+     54     -14.3087      1.00000
+     55     -14.3003      1.00000
+     56     -14.2865      1.00000
+     57     -14.2463      1.00000
+     58     -14.2260      1.00000
+     59     -14.2249      1.00000
+     60     -14.1775      1.00000
+     61     -14.0129      1.00000
+     62     -13.6544      1.00000
+     63     -13.4795      1.00000
+     64      -3.8043      1.00000
+     65      -3.7809      1.00000
+     66      -3.7146      1.00000
+     67      -3.6997      1.00000
+     68      -3.6958      1.00000
+     69      -3.6805      1.00000
+     70      -3.6496      1.00000
+     71      -3.6385      1.00000
+     72      -3.4835      1.00000
+     73      -3.4532      1.00000
+     74      -3.4402      1.00000
+     75      -3.3867      1.00000
+     76      -3.3758      1.00000
+     77      -3.3458      1.00000
+     78      -3.2437      1.00000
+     79      -3.2037      1.00000
+     80      -3.1932      1.00000
+     81      -3.1851      1.00000
+     82      -3.1021      1.00000
+     83      -3.0945      1.00000
+     84      -3.0638      1.00000
+     85      -3.0347      1.00000
+     86      -3.0203      1.00000
+     87      -3.0076      1.00000
+     88      -3.0028      1.00000
+     89      -2.9718      1.00000
+     90      -2.9497      1.00000
+     91      -2.9316      1.00000
+     92      -2.9167      1.00000
+     93      -2.8940      1.00000
+     94      -2.8688      1.00000
+     95      -2.8526      1.00000
+     96      -2.8332      1.00000
+     97      -2.7703      1.00000
+     98      -2.7646      1.00000
+     99      -2.7210      1.00000
+    100      -2.7126      1.00000
+    101      -2.6864      1.00000
+    102      -2.6771      1.00000
+    103      -2.6234      1.00000
+    104      -2.5946      1.00000
+    105      -2.5470      1.00000
+    106      -2.4979      1.00000
+    107      -2.4660      1.00000
+    108      -2.4077      1.00000
+    109      -2.3734      1.00000
+    110      -2.3378      1.00000
+    111      -2.2984      1.00000
+    112      -2.2611      1.00000
+    113      -2.2400      1.00000
+    114      -2.2040      1.00000
+    115      -2.1727      1.00000
+    116      -2.1467      1.00000
+    117      -2.1187      1.00000
+    118      -2.0831      1.00000
+    119      -2.0639      1.00000
+    120      -2.0145      1.00000
+    121      -1.9481      1.00000
+    122      -1.8662      1.00000
+    123      -1.8116      1.00000
+    124      -1.7860      1.00000
+    125      -1.7070      1.00000
+    126      -1.6990      1.00000
+    127      -1.6905      1.00000
+    128      -1.6650      1.00000
+    129      -1.6456      1.00000
+    130      -1.6295      1.00000
+    131      -1.6101      1.00000
+    132      -1.5820      1.00000
+    133      -1.5469      1.00000
+    134      -1.5093      1.00000
+    135      -1.4837      1.00000
+    136      -1.4429      1.00000
+    137      -1.4145      1.00000
+    138      -1.3986      1.00000
+    139      -1.3597      1.00000
+    140      -1.3433      1.00000
+    141      -1.3324      1.00000
+    142      -1.2851      1.00000
+    143      -1.2415      1.00000
+    144      -1.1173      1.00000
+    145      -1.0351      1.00000
+    146      -1.0064      1.00000
+    147      -0.9885      1.00000
+    148      -0.9337      1.00000
+    149      -0.9008      1.00000
+    150      -0.8709      1.00000
+    151      -0.8433      1.00000
+    152      -0.7962      1.00000
+    153      -0.7750      1.00000
+    154      -0.7038      1.00000
+    155      -0.6394      1.00000
+    156      -0.6371      1.00000
+    157      -0.6231      1.00000
+    158      -0.5768      1.00000
+    159      -0.5538      1.00000
+    160      -0.5252      1.00000
+    161      -0.4516      1.00000
+    162      -0.4446      1.00000
+    163      -0.3988      1.00000
+    164      -0.3604      1.00000
+    165      -0.3476      1.00000
+    166      -0.3132      1.00000
+    167      -0.3055      1.00000
+    168      -0.2667      1.00000
+    169      -0.2537      1.00000
+    170      -0.2290      1.00000
+    171      -0.1970      1.00000
+    172      -0.1738      1.00000
+    173      -0.1160      1.00000
+    174      -0.0888      1.00000
+    175      -0.0625      1.00000
+    176      -0.0094      1.00000
+    177       0.0244      1.00000
+    178       0.0441      1.00000
+    179       0.0685      1.00000
+    180       0.0895      1.00000
+    181       0.1239      1.00000
+    182       0.1599      1.00000
+    183       0.1881      1.00000
+    184       0.2037      1.00000
+    185       0.2233      1.00000
+    186       0.2305      1.00000
+    187       0.2510      1.00000
+    188       0.2828      1.00000
+    189       0.3233      1.00000
+    190       0.3402      1.00000
+    191       0.3862      1.00000
+    192       0.4365      1.00000
+    193       0.4472      1.00000
+    194       0.4837      1.00000
+    195       0.5114      1.00000
+    196       0.5274      1.00000
+    197       0.5459      1.00000
+    198       0.5511      1.00000
+    199       0.5625      1.00000
+    200       0.5729      1.00000
+    201       0.5996      1.00000
+    202       0.6182      1.00000
+    203       0.6390      1.00000
+    204       0.6567      1.00000
+    205       0.6737      1.00000
+    206       0.6806      1.00000
+    207       0.6855      1.00000
+    208       0.7105      1.00000
+    209       0.7195      1.00000
+    210       0.7211      1.00000
+    211       0.7495      1.00000
+    212       0.7641      1.00000
+    213       0.7763      1.00000
+    214       0.7931      1.00000
+    215       0.8255      1.00000
+    216       0.8486      1.00000
+    217       0.8630      1.00000
+    218       0.8847      1.00000
+    219       0.9160      1.00000
+    220       0.9333      1.00000
+    221       0.9435      1.00000
+    222       0.9628      1.00000
+    223       0.9658      1.00000
+    224       0.9748      1.00000
+    225       0.9897      1.00000
+    226       1.0027      1.00000
+    227       1.0299      1.00000
+    228       1.0373      1.00000
+    229       1.0559      1.00000
+    230       1.0699      1.00000
+    231       1.0870      1.00000
+    232       1.1209      1.00000
+    233       1.1637      1.00000
+    234       1.1870      1.00000
+    235       1.2111      1.00000
+    236       1.2465      1.00000
+    237       1.3235      1.00000
+    238       1.3340      1.00000
+    239       1.3561      1.00000
+    240       1.3791      1.00000
+    241       1.3951      1.00000
+    242       1.4563      1.00000
+    243       1.4677      1.00000
+    244       1.4795      1.00000
+    245       1.4956      1.00000
+    246       1.5296      1.00000
+    247       1.5562      1.00000
+    248       1.5711      1.00000
+    249       1.6344      1.00000
+    250       1.6548      1.00000
+    251       1.7119      1.00000
+    252       1.8028      1.00000
+    253       1.8611      1.00000
+    254       5.2271      0.00000
+    255       5.2575      0.00000
+    256       5.3035      0.00000
+    257       5.3542      0.00000
+    258       5.4368      0.00000
+    259       5.4816      0.00000
+    260       5.4930      0.00000
+    261       5.5080      0.00000
+    262       5.5201      0.00000
+    263       5.5217      0.00000
+    264       5.5834      0.00000
+    265       5.5950      0.00000
+    266       5.6599      0.00000
+    267       5.6745      0.00000
+    268       5.7237      0.00000
+    269       5.7493      0.00000
+    270       5.7675      0.00000
+    271       5.8060      0.00000
+    272       5.8106      0.00000
+    273       5.8256      0.00000
+    274       5.8460      0.00000
+    275       5.8740      0.00000
+    276       5.8982      0.00000
+    277       5.9141      0.00000
+    278       5.9426      0.00000
+    279       5.9510      0.00000
+    280       5.9762      0.00000
+    281       6.0061      0.00000
+    282       6.0496      0.00000
+    283       6.0906      0.00000
+    284       6.1447      0.00000
+    285       6.1631      0.00000
+    286       6.2065      0.00000
+    287       6.2229      0.00000
+    288       6.2355      0.00000
+    289       6.2855      0.00000
+    290       6.3138      0.00000
+    291       6.3543      0.00000
+    292       6.3958      0.00000
+    293       6.4133      0.00000
+    294       6.4217      0.00000
+    295       6.4345      0.00000
+    296       6.4400      0.00000
+    297       6.4684      0.00000
+    298       6.5013      0.00000
+    299       6.7836      0.00000
+    300       6.8827      0.00000
+    301       6.9560      0.00000
+    302       6.9753      0.00000
+    303       7.0034      0.00000
+    304       7.0376      0.00000
+    305       7.0522      0.00000
+    306       7.0790      0.00000
+    307       7.0883      0.00000
+    308       7.1234      0.00000
+    309       7.1541      0.00000
+    310       7.1902      0.00000
+    311       7.2087      0.00000
+    312       7.2193      0.00000
+    313       7.2662      0.00000
+    314       7.2705      0.00000
+    315       7.3480      0.00000
+    316       7.3672      0.00000
+    317       7.3928      0.00000
+    318       7.4233      0.00000
+    319       7.5014      0.00000
+    320       7.5601      0.00000
+    321       7.5779      0.00000
+    322       7.6236      0.00000
+    323       8.2739      0.00000
+    324       8.5261      0.00000
+    325       8.5784      0.00000
+    326       8.6230      0.00000
+    327       8.6501      0.00000
+    328       8.6925      0.00000
+    329       8.7452      0.00000
+    330       8.7904      0.00000
+    331       8.8331      0.00000
+    332       8.8766      0.00000
+    333       8.9510      0.00000
+    334       8.9603      0.00000
+    335       8.9869      0.00000
+    336       9.0760      0.00000
+    337       9.0982      0.00000
+    338       9.1282      0.00000
+    339       9.1893      0.00000
+    340       9.2502      0.00000
+    341       9.2659      0.00000
+    342       9.3074      0.00000
+    343       9.3473      0.00000
+    344       9.3961      0.00000
+    345       9.4349      0.00000
+    346       9.6124      0.00000
+    347       9.6791      0.00000
+    348       9.7320      0.00000
+    349       9.7468      0.00000
+    350       9.7864      0.00000
+    351       9.8347      0.00000
+    352       9.8825      0.00000
+    353       9.9048      0.00000
+    354       9.9544      0.00000
+    355       9.9852      0.00000
+    356      10.0705      0.00000
+    357      10.1528      0.00000
+    358      10.1945      0.00000
+    359      10.2667      0.00000
+    360      10.3583      0.00000
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ soft charge-density along one line, spin component           1
+         0         1         2         3         4         5         6         7         8         9
+ total charge-density along one line
+ 
+ soft charge-density along one line, spin component           2
+         0         1         2         3         4         5         6         7         8         9
+ total charge-density along one line
+ 
+ pseudopotential strength for first ion, spin component:           1
+  1.197   5.320  -0.000  -0.000   0.000
+  5.320  22.628  -0.002  -0.000   0.001
+ -0.000  -0.002  -0.265  -0.000   0.001
+ -0.000  -0.000  -0.000  -0.262  -0.000
+  0.000   0.001   0.001  -0.000  -0.262
+ pseudopotential strength for first ion, spin component:           2
+  1.197   5.320  -0.000  -0.000   0.000
+  5.320  22.628  -0.002  -0.000   0.001
+ -0.000  -0.002  -0.265  -0.000   0.001
+ -0.000  -0.000  -0.000  -0.262  -0.000
+  0.000   0.001   0.001  -0.000  -0.262
+ total augmentation occupancy for first ion, spin component:           1
+  0.757  -0.024   0.014   0.004  -0.009
+ -0.024   0.001  -0.000  -0.000   0.000
+  0.014  -0.000   0.059  -0.001   0.002
+  0.004  -0.000  -0.001   0.073  -0.000
+ -0.009   0.000   0.002  -0.000   0.068
+ total augmentation occupancy for first ion, spin component:           2
+  0.000  -0.000  -0.000   0.000   0.000
+ -0.000   0.000   0.000  -0.000   0.000
+ -0.000   0.000   0.000  -0.000  -0.000
+  0.000  -0.000  -0.000   0.000  -0.000
+  0.000   0.000  -0.000  -0.000  -0.000
+
+
+------------------------ aborting loop because EDIFF is reached ----------------------------------------
+
+
+ 
+
+
+ total charge     
+ 
+# of ion       s       p       d       tot
+------------------------------------------
+    1        0.071   0.145   0.000   0.217
+    2        0.071   0.145   0.000   0.216
+    3        0.075   0.151   0.000   0.226
+    4        0.071   0.144   0.000   0.216
+    5        0.077   0.157   0.000   0.234
+    6        0.078   0.159   0.000   0.237
+    7        0.073   0.148   0.000   0.221
+    8        0.074   0.152   0.000   0.226
+    9        0.450   0.754   1.643   2.848
+   10        0.437   0.725   1.572   2.734
+   11        0.439   0.737   1.598   2.774
+   12        0.446   0.748   1.633   2.827
+   13        0.440   0.743   1.597   2.780
+   14        0.443   0.749   1.612   2.804
+   15        0.452   0.758   1.656   2.865
+   16        0.442   0.746   1.608   2.795
+   17        0.737   1.083   4.217   6.036
+   18        0.739   1.091   4.231   6.061
+   19        0.738   1.091   4.222   6.050
+   20        0.739   1.092   4.225   6.055
+   21        0.742   1.093   4.258   6.093
+   22        0.736   1.086   4.210   6.031
+   23        0.738   1.090   4.223   6.050
+   24        0.739   1.088   4.232   6.059
+   25        0.737   1.086   4.226   6.050
+   26        0.739   1.087   4.233   6.059
+   27        0.530   0.598  37.436  38.563
+   28        0.740   1.096   4.233   6.069
+   29        0.739   1.105   4.214   6.058
+   30        0.737   1.110   4.207   6.055
+   31        0.740   1.085   4.245   6.070
+   32        0.739   1.094   4.224   6.057
+   33        1.598   3.485   0.000   5.083
+   34        1.599   3.476   0.000   5.075
+   35        1.599   3.481   0.000   5.080
+   36        1.598   3.481   0.000   5.079
+   37        1.598   3.485   0.000   5.083
+   38        1.597   3.487   0.000   5.084
+   39        1.595   3.485   0.000   5.081
+   40        1.588   3.508   0.000   5.096
+   41        1.588   3.510   0.000   5.098
+   42        1.588   3.515   0.000   5.103
+   43        1.588   3.511   0.000   5.099
+   44        1.588   3.511   0.000   5.099
+   45        1.588   3.511   0.000   5.099
+   46        1.588   3.505   0.000   5.093
+   47        1.588   3.510   0.000   5.098
+   48        1.596   3.481   0.000   5.077
+   49        1.597   3.485   0.000   5.082
+   50        1.597   3.484   0.000   5.081
+   51        1.597   3.487   0.000   5.084
+   52        1.597   3.485   0.000   5.082
+   53        1.596   3.482   0.000   5.078
+   54        1.597   3.486   0.000   5.083
+   55        1.598   3.486   0.000   5.083
+   56        1.594   3.495   0.000   5.089
+   57        1.593   3.493   0.000   5.086
+   58        1.593   3.495   0.000   5.088
+   59        1.593   3.496   0.000   5.088
+   60        1.594   3.494   0.000   5.087
+   61        1.593   3.496   0.000   5.089
+   62        1.592   3.504   0.000   5.096
+   63        1.593   3.496   0.000   5.089
+   64        1.598   3.484   0.000   5.083
+   65        1.598   3.483   0.000   5.081
+   66        1.600   3.484   0.000   5.083
+   67        1.599   3.480   0.000   5.079
+   68        1.599   3.482   0.000   5.081
+   69        1.599   3.483   0.000   5.082
+   70        1.600   3.484   0.000   5.084
+   71        1.599   3.482   0.000   5.081
+   72        1.586   3.529   0.000   5.114
+   73        1.589   3.512   0.000   5.101
+   74        1.588   3.511   0.000   5.099
+   75        1.588   3.513   0.000   5.102
+   76        1.588   3.515   0.000   5.103
+   77        1.588   3.512   0.000   5.100
+   78        1.586   3.523   0.000   5.109
+   79        1.589   3.519   0.000   5.108
+   80        1.597   3.485   0.000   5.082
+   81        1.597   3.484   0.000   5.081
+   82        1.589   3.531   0.000   5.120
+   83        1.596   3.487   0.000   5.083
+   84        1.596   3.491   0.000   5.087
+   85        1.596   3.492   0.000   5.088
+   86        1.599   3.482   0.000   5.081
+   87        1.598   3.484   0.000   5.082
+   88        1.595   3.492   0.000   5.086
+   89        1.589   3.521   0.000   5.110
+   90        1.594   3.495   0.000   5.088
+   91        1.593   3.498   0.000   5.091
+   92        1.594   3.492   0.000   5.086
+   93        1.594   3.495   0.000   5.089
+   94        1.593   3.511   0.000   5.104
+   95        1.593   3.505   0.000   5.097
+   96        0.565   0.002   0.000   0.567
+--------------------------------------------------
+tot        116.726 244.381 113.753 474.860
+ 
+
+
+ magnetization (x)
+ 
+# of ion       s       p       d       tot
+------------------------------------------
+    1        0.000   0.000   0.000   0.000
+    2        0.000   0.000   0.000   0.000
+    3       -0.000  -0.000   0.000  -0.000
+    4       -0.000  -0.000   0.000  -0.000
+    5       -0.000  -0.000   0.000  -0.000
+    6       -0.000   0.000   0.000  -0.000
+    7        0.000   0.000   0.000   0.000
+    8        0.000   0.000   0.000   0.000
+    9        0.000   0.001   0.001   0.002
+   10       -0.000  -0.001  -0.001  -0.003
+   11       -0.000  -0.000  -0.000  -0.000
+   12       -0.000  -0.000  -0.000  -0.000
+   13        0.000   0.000   0.000   0.000
+   14        0.000   0.000   0.000   0.000
+   15       -0.000  -0.001  -0.002  -0.003
+   16        0.000   0.000  -0.000   0.000
+   17        0.000   0.000   0.000   0.000
+   18        0.000   0.000   0.000   0.000
+   19        0.000  -0.000   0.000   0.000
+   20        0.000   0.000   0.000   0.000
+   21       -0.000  -0.000  -0.000  -0.000
+   22       -0.000  -0.000  -0.000  -0.000
+   23       -0.000  -0.000  -0.000  -0.001
+   24       -0.000   0.000   0.000   0.000
+   25       -0.000   0.000   0.000   0.000
+   26       -0.000  -0.000   0.000   0.000
+   27        0.007   0.008  35.980  35.995
+   28       -0.000  -0.000  -0.002  -0.002
+   29        0.001   0.001   0.004   0.006
+   30       -0.000  -0.000   0.003   0.003
+   31       -0.000  -0.000  -0.001  -0.001
+   32       -0.000  -0.000  -0.000  -0.000
+   33        0.000   0.000   0.000   0.000
+   34        0.000   0.000   0.000   0.000
+   35       -0.000  -0.000   0.000  -0.000
+   36        0.000   0.000   0.000   0.000
+   37       -0.000  -0.000   0.000  -0.000
+   38        0.000   0.000   0.000   0.000
+   39       -0.000  -0.000   0.000  -0.000
+   40        0.000   0.000   0.000   0.000
+   41        0.000  -0.000   0.000  -0.000
+   42        0.000  -0.000   0.000  -0.000
+   43        0.000   0.000   0.000   0.000
+   44        0.000   0.000   0.000   0.000
+   45        0.000   0.000   0.000   0.000
+   46       -0.000  -0.000   0.000  -0.000
+   47        0.000   0.000   0.000   0.000
+   48        0.000   0.001   0.000   0.001
+   49       -0.000  -0.000   0.000  -0.000
+   50        0.000  -0.000   0.000  -0.000
+   51       -0.000  -0.000   0.000  -0.000
+   52        0.000   0.000   0.000   0.000
+   53       -0.000  -0.000   0.000  -0.000
+   54        0.000   0.000   0.000   0.000
+   55       -0.000  -0.000   0.000  -0.000
+   56       -0.000  -0.000   0.000  -0.000
+   57        0.000  -0.000   0.000  -0.000
+   58        0.000  -0.000   0.000  -0.000
+   59        0.000   0.000   0.000   0.000
+   60       -0.000   0.000   0.000   0.000
+   61        0.000   0.000   0.000   0.000
+   62        0.000  -0.000   0.000  -0.000
+   63        0.000  -0.000   0.000  -0.000
+   64        0.000   0.000   0.000   0.000
+   65        0.000   0.000   0.000   0.000
+   66       -0.000  -0.000   0.000  -0.000
+   67        0.000   0.000   0.000   0.000
+   68        0.000   0.000   0.000   0.000
+   69       -0.000   0.000   0.000   0.000
+   70       -0.000  -0.000   0.000  -0.000
+   71        0.000  -0.000   0.000  -0.000
+   72       -0.000   0.002   0.000   0.002
+   73        0.000   0.000   0.000   0.000
+   74        0.000  -0.000   0.000  -0.000
+   75        0.000   0.000   0.000   0.000
+   76       -0.000  -0.000   0.000  -0.000
+   77        0.000   0.000   0.000   0.000
+   78       -0.000  -0.005   0.000  -0.005
+   79       -0.000  -0.000   0.000  -0.000
+   80       -0.000  -0.000   0.000  -0.000
+   81       -0.000  -0.000   0.000  -0.000
+   82       -0.001  -0.020   0.000  -0.021
+   83        0.000   0.000   0.000   0.000
+   84        0.000  -0.000   0.000  -0.000
+   85        0.000   0.001   0.000   0.001
+   86        0.000   0.000   0.000   0.000
+   87       -0.000  -0.000   0.000  -0.000
+   88        0.000  -0.000   0.000  -0.000
+   89        0.000   0.011   0.000   0.011
+   90        0.000  -0.000   0.000  -0.000
+   91       -0.000  -0.000   0.000  -0.000
+   92        0.000   0.000   0.000   0.000
+   93       -0.000  -0.000   0.000  -0.000
+   94       -0.000   0.001   0.000   0.001
+   95       -0.000  -0.000   0.000  -0.000
+   96       -0.004   0.000   0.000  -0.004
+--------------------------------------------------
+tot          0.004  -0.002  35.982  35.984
+ 
+    CHARGE:  cpu time    0.1400: real time    0.1392
+    FORLOC:  cpu time    0.0200: real time    0.0216
+    FORNL :  cpu time    1.3280: real time    1.3271
+    STRESS:  cpu time    3.9320: real time    3.9370
+    FORCOR:  cpu time    0.0840: real time    0.0838
+    FORHAR:  cpu time    0.0280: real time    0.0284
+    MIXING:  cpu time    0.0040: real time    0.0026
+    OFIELD:  cpu time    0.0000: real time    0.0000
+
+  FORCE on cell =-STRESS in cart. coord.  units (eV):
+  Direction    XX          YY          ZZ          XY          YZ          ZX
+  --------------------------------------------------------------------------------------
+  Alpha Z  1704.46002  1704.46002  1704.46002
+  Ewald   -8588.59217 -8166.95682 -7174.88644    51.46675    40.35572    26.15924
+  Hartree  2723.20630  2991.52772  3491.95193     1.88972    19.25963   -20.32327
+  E(xc)   -2434.34796 -2423.93432 -2431.06700     0.32451     0.29852    -2.40068
+  Local   -2100.40818 -2776.52308 -4210.64499   -48.04982   -58.39108    -0.35500
+  n-local -1596.27884 -1618.14116 -1642.90879    74.39554    18.91464    15.70126
+  augment   527.92400   528.38089   520.33016    -0.90081    -0.14931     0.82366
+  Kinetic  9695.45034  9693.84703  9662.05004   -60.11188   -16.19054   -16.35874
+  Fock        0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+  -------------------------------------------------------------------------------------
+  Total     -68.58650   -67.33971   -80.71506    19.01401     4.09758     3.24645
+  in kB    -101.91522  -100.06258  -119.93750    28.25362     6.08875     4.82402
+  external pressure =     -107.31 kB  Pullay stress =        0.00 kB
+
+
+ VOLUME and BASIS-vectors are now :
+ -----------------------------------------------------------------------------
+  energy-cutoff  :      400.00
+  volume of cell :     1078.23
+      direct lattice vectors                 reciprocal lattice vectors
+     9.471199396  0.000000000  0.000000000     0.105583249  0.000000000  0.002351102
+     0.000000000 11.488942540  0.000000000     0.000000000  0.087040212  0.000000000
+    -0.220648810  0.000000000  9.908892586     0.000000000  0.000000000  0.100919451
+
+  length of vectors
+     9.471199396 11.488942540  9.911348958     0.105609422  0.087040212  0.100919451
+
+
+ FORCES acting on ions
+    electron-ion (+dipol)            ewald-force                    non-local-force                 convergence-correction
+ -----------------------------------------------------------------------------------------------
+   -.131E+01 0.260E+00 -.179E+00   0.120E+01 -.927E-01 0.216E+00   0.105E+00 -.174E+00 -.414E-01   0.954E-05 0.121E-03 0.408E-05
+   0.686E+00 0.172E+01 0.437E+00   -.730E+00 -.146E+01 -.454E+00   0.416E-01 -.259E+00 0.115E-01   0.155E-04 0.148E-03 -.269E-05
+   0.756E+01 -.144E+02 -.401E+01   -.739E+01 0.138E+02 0.392E+01   -.172E+00 0.542E+00 0.808E-01   0.325E-04 -.145E-03 -.264E-04
+   0.116E+01 -.407E+01 0.204E+01   -.111E+01 0.373E+01 -.192E+01   -.490E-01 0.336E+00 -.122E+00   0.410E-04 -.161E-03 0.292E-04
+   -.219E+00 0.106E+01 0.780E+00   0.580E+00 -.899E+00 -.127E+00   -.365E+00 -.156E+00 -.659E+00   -.429E-04 -.111E-03 0.893E-06
+   -.998E+00 0.621E+01 0.349E+01   0.140E+01 -.544E+01 -.358E+01   -.405E+00 -.764E+00 0.807E-01   -.488E-04 -.128E-03 -.738E-05
+   -.158E+00 0.630E+00 -.118E+01   0.317E+00 -.965E+00 0.109E+01   -.162E+00 0.345E+00 0.915E-01   -.919E-05 0.148E-03 -.627E-04
+   0.197E+01 -.228E+01 0.109E+01   -.175E+01 0.187E+01 -.985E+00   -.220E+00 0.415E+00 -.111E+00   -.188E-04 0.145E-03 0.666E-04
+   0.320E+01 0.128E+02 -.148E+02   -.366E+01 -.123E+02 0.148E+02   0.457E+00 -.452E+00 -.860E-01   0.152E-03 -.451E-03 0.416E-05
+   0.278E+02 0.915E+01 0.439E+02   -.274E+02 -.924E+01 -.429E+02   -.437E+00 0.933E-01 -.961E+00   0.173E-03 -.516E-03 -.692E-05
+   0.441E+01 0.729E+01 -.358E+01   -.447E+01 -.704E+01 0.364E+01   0.594E-01 -.249E+00 -.622E-01   0.272E-04 0.514E-03 -.208E-03
+   -.468E+01 -.311E+01 0.183E+00   0.418E+01 0.317E+01 -.624E+00   0.495E+00 -.611E-01 0.433E+00   0.752E-04 0.529E-03 0.203E-03
+   0.141E+01 0.164E+01 -.320E+01   -.136E+01 -.205E+01 0.308E+01   -.515E-01 0.412E+00 0.117E+00   -.109E-04 0.332E-03 0.152E-04
+   -.509E+00 0.858E+00 0.128E+01   0.637E+00 -.129E+01 -.135E+01   -.126E+00 0.435E+00 0.618E-01   -.369E-04 0.446E-03 -.601E-04
+   -.307E+01 -.346E+01 -.100E+02   0.385E+01 0.486E+01 0.930E+01   -.763E+00 -.138E+01 0.703E+00   -.117E-03 -.498E-03 -.621E-04
+   -.116E+01 -.547E+01 0.216E+01   0.124E+01 0.583E+01 -.214E+01   -.819E-01 -.355E+00 -.217E-01   -.131E-03 -.494E-03 0.946E-04
+   -.145E+02 -.427E+02 -.209E+02   0.145E+02 0.428E+02 0.206E+02   0.150E-01 -.102E+00 0.268E+00   -.108E-03 -.765E-03 -.873E-04
+   -.173E+02 -.524E+02 0.123E+02   0.173E+02 0.526E+02 -.126E+02   -.393E-01 -.162E+00 0.268E+00   -.149E-03 -.743E-03 -.441E-04
+   0.638E+01 0.151E+02 0.439E+01   -.645E+01 -.152E+02 -.415E+01   0.704E-01 0.149E+00 -.250E+00   0.328E-03 0.482E-03 -.278E-03
+   0.747E+01 0.183E+02 0.779E+01   -.753E+01 -.184E+02 -.756E+01   0.505E-01 0.126E+00 -.238E+00   0.931E-04 0.565E-03 0.247E-03
+   0.115E+02 -.292E+02 0.106E+01   -.115E+02 0.294E+02 -.767E+00   0.584E-01 -.230E+00 -.297E+00   0.186E-03 -.560E-03 -.132E-04
+   0.144E+02 -.359E+02 0.132E+02   -.144E+02 0.360E+02 -.129E+02   -.136E-02 -.891E-01 -.242E+00   0.178E-03 -.470E-03 0.575E-04
+   -.922E+01 0.115E+02 -.139E+02   0.927E+01 -.116E+02 0.135E+02   -.554E-01 0.108E+00 0.321E+00   -.275E-03 0.324E-03 -.303E-03
+   -.937E+01 0.138E+02 -.132E+01   0.940E+01 -.139E+02 0.104E+01   -.280E-01 0.178E+00 0.280E+00   -.219E-03 0.450E-03 0.413E-03
+   -.754E+01 -.138E+02 -.145E+02   0.762E+01 0.140E+02 0.142E+02   -.710E-01 -.205E+00 0.289E+00   0.337E-03 0.625E-03 0.507E-04
+   -.229E+01 -.117E+02 0.350E+00   0.232E+01 0.119E+02 -.643E+00   -.313E-01 -.165E+00 0.283E+00   0.354E-03 0.417E-03 -.386E-04
+   -.507E+02 0.105E+03 -.455E+02   0.484E+02 -.105E+03 0.447E+02   0.223E+01 -.368E+00 0.778E+00   -.385E-03 -.339E-03 -.244E-03
+   0.260E+01 0.379E+02 0.145E+02   -.260E+01 -.380E+02 -.142E+02   0.920E-02 0.634E-01 -.294E+00   -.357E-03 -.237E-03 0.348E-03
+   0.185E+01 -.783E+01 -.914E+01   -.203E+01 0.772E+01 0.963E+01   0.182E+00 0.140E+00 -.487E+00   -.358E-03 0.100E-02 0.119E-03
+   -.816E+01 -.753E+01 0.281E+02   0.795E+01 0.723E+01 -.279E+02   0.198E+00 0.310E+00 -.200E+00   -.347E-03 0.791E-03 -.172E-03
+   0.857E+01 0.314E+02 -.933E+01   -.851E+01 -.317E+02 0.907E+01   -.592E-01 0.249E+00 0.259E+00   0.313E-03 -.458E-03 -.316E-03
+   -.341E+01 0.300E+02 -.236E+01   0.341E+01 -.301E+02 0.215E+01   0.544E-02 0.451E-01 0.213E+00   0.344E-03 -.544E-03 0.296E-03
+   -.632E+02 0.882E+02 -.215E+02   0.743E+02 -.104E+03 0.251E+02   -.112E+02 0.158E+02 -.364E+01   0.124E-03 -.130E-02 0.304E-03
+   0.645E+02 -.789E+02 0.203E+02   -.772E+02 0.948E+02 -.259E+02   0.127E+02 -.158E+02 0.557E+01   0.466E-03 0.114E-02 0.467E-03
+   0.719E+02 -.716E+02 0.243E+02   -.837E+02 0.875E+02 -.286E+02   0.118E+02 -.159E+02 0.427E+01   0.355E-03 0.120E-02 -.264E-03
+   0.107E+03 0.839E+02 -.680E+01   -.120E+03 -.994E+02 0.303E+01   0.121E+02 0.155E+02 0.376E+01   0.636E-03 -.116E-02 -.197E-03
+   0.739E+02 0.852E+02 0.324E+02   -.847E+02 -.101E+03 -.352E+02   0.108E+02 0.157E+02 0.288E+01   0.690E-03 -.137E-02 0.366E-03
+   -.605E+02 -.660E+02 -.323E+02   0.717E+02 0.818E+02 0.361E+02   -.112E+02 -.158E+02 -.377E+01   -.315E-03 0.125E-02 -.148E-03
+   -.612E+02 -.737E+02 -.199E+01   0.698E+02 0.866E+02 0.316E+01   -.863E+01 -.129E+02 -.118E+01   -.296E-03 0.134E-02 -.122E-03
+   -.877E+02 0.360E+02 0.238E+02   0.986E+02 -.365E+02 -.306E+02   -.109E+02 0.478E+00 0.679E+01   0.315E-03 0.103E-03 -.116E-03
+   -.888E+02 0.356E+02 0.316E+02   0.997E+02 -.358E+02 -.383E+02   -.109E+02 0.223E+00 0.668E+01   -.159E-04 0.549E-03 0.144E-03
+   0.817E+02 -.637E+02 -.397E+02   -.937E+02 0.641E+02 0.466E+02   0.120E+02 -.381E+00 -.685E+01   -.334E-03 -.808E-03 -.121E-03
+   0.816E+02 -.547E+02 -.186E+02   -.922E+02 0.551E+02 0.253E+02   0.106E+02 -.321E+00 -.672E+01   -.364E-03 -.548E-03 0.341E-03
+   0.866E+02 0.333E+02 -.298E+02   -.975E+02 -.334E+02 0.368E+02   0.108E+02 0.135E+00 -.697E+01   -.391E-03 -.596E-04 0.234E-03
+   0.827E+02 0.290E+02 -.250E+02   -.936E+02 -.292E+02 0.318E+02   0.109E+02 0.249E+00 -.677E+01   -.338E-03 0.265E-03 -.378E-03
+   -.924E+02 -.568E+02 0.318E+02   0.105E+03 0.582E+02 -.399E+02   -.126E+02 -.146E+01 0.811E+01   0.248E-04 -.471E-03 -.130E-03
+   -.874E+02 -.498E+02 0.260E+02   0.985E+02 0.502E+02 -.327E+02   -.110E+02 -.396E+00 0.670E+01   0.313E-04 -.433E-03 0.134E-03
+   -.574E+02 -.879E+02 -.957E+02   0.687E+02 0.100E+03 0.107E+03   -.113E+02 -.125E+02 -.112E+02   0.101E-03 -.139E-02 -.117E-03
+   -.590E+02 -.816E+02 -.696E+01   0.705E+02 0.938E+02 0.179E+02   -.116E+02 -.122E+02 -.109E+02   0.110E-03 -.160E-02 0.215E-03
+   0.633E+02 0.552E+02 0.472E+02   -.752E+02 -.679E+02 -.581E+02   0.118E+02 0.127E+02 0.109E+02   0.375E-03 0.107E-02 -.432E-03
+   0.654E+02 0.545E+02 0.546E+02   -.769E+02 -.669E+02 -.657E+02   0.115E+02 0.124E+02 0.110E+02   0.344E-03 0.146E-02 0.297E-03
+   0.708E+02 -.642E+02 0.413E+02   -.831E+02 0.771E+02 -.521E+02   0.123E+02 -.129E+02 0.108E+02   0.453E-03 -.131E-02 -.616E-05
+   0.984E+02 -.795E+02 0.683E+02   -.110E+03 0.918E+02 -.789E+02   0.119E+02 -.123E+02 0.106E+02   0.576E-03 -.132E-02 -.207E-04
+   -.604E+02 0.578E+02 -.558E+02   0.720E+02 -.699E+02 0.670E+02   -.115E+02 0.121E+02 -.112E+02   -.406E-03 0.120E-02 -.429E-03
+   -.662E+02 0.508E+02 -.451E+02   0.785E+02 -.634E+02 0.562E+02   -.122E+02 0.126E+02 -.111E+02   -.298E-03 0.135E-02 0.539E-03
+   0.122E+03 0.467E+02 -.436E+02   -.140E+03 -.521E+02 0.545E+02   0.180E+02 0.541E+01 -.109E+02   0.345E-03 0.343E-03 -.762E-05
+   0.126E+03 0.411E+02 -.381E+02   -.144E+03 -.464E+02 0.489E+02   0.180E+02 0.538E+01 -.108E+02   0.450E-03 0.523E-03 -.793E-04
+   -.120E+03 -.978E+02 0.429E+02   0.138E+03 0.103E+03 -.536E+02   -.177E+02 -.475E+01 0.107E+02   -.206E-03 -.611E-03 -.215E-03
+   -.122E+03 -.638E+02 0.395E+02   0.139E+03 0.688E+02 -.499E+02   -.178E+02 -.494E+01 0.104E+02   -.116E-03 -.551E-03 0.221E-03
+   -.122E+03 0.358E+02 0.325E+02   0.140E+03 -.410E+02 -.433E+02   -.182E+02 0.520E+01 0.108E+02   -.322E-03 0.130E-03 -.172E-03
+   -.121E+03 0.419E+02 0.481E+02   0.139E+03 -.470E+02 -.586E+02   -.180E+02 0.511E+01 0.105E+02   -.575E-04 0.426E-03 0.205E-03
+   0.129E+03 -.692E+02 -.460E+02   -.146E+03 0.739E+02 0.561E+02   0.176E+02 -.472E+01 -.101E+02   0.487E-03 -.416E-03 -.197E-03
+   0.126E+03 -.639E+02 -.329E+02   -.144E+03 0.694E+02 0.430E+02   0.177E+02 -.551E+01 -.100E+02   0.363E-03 -.379E-03 0.262E-03
+   -.653E+02 0.814E+02 -.188E+02   0.770E+02 -.970E+02 0.227E+02   -.116E+02 0.156E+02 -.389E+01   0.296E-03 0.113E-02 -.449E-03
+   -.632E+02 0.816E+02 -.206E+02   0.747E+02 -.970E+02 0.245E+02   -.116E+02 0.155E+02 -.382E+01   0.322E-03 0.994E-03 0.614E-03
+   0.584E+02 -.920E+02 0.126E+02   -.703E+02 0.108E+03 -.167E+02   0.119E+02 -.156E+02 0.407E+01   -.378E-03 -.136E-02 -.159E-03
+   0.331E+02 -.114E+03 0.414E+02   -.455E+02 0.130E+03 -.456E+02   0.124E+02 -.159E+02 0.417E+01   -.565E-03 -.129E-02 -.308E-03
+   0.642E+02 0.820E+02 0.141E+02   -.761E+02 -.979E+02 -.182E+02   0.119E+02 0.159E+02 0.407E+01   -.367E-03 0.911E-03 -.480E-03
+   0.622E+02 0.796E+02 0.288E+02   -.740E+02 -.954E+02 -.329E+02   0.118E+02 0.158E+02 0.403E+01   -.354E-03 0.104E-02 0.466E-03
+   -.638E+02 -.911E+02 -.304E+02   0.760E+02 0.107E+03 0.351E+02   -.122E+02 -.162E+02 -.469E+01   -.897E-04 -.117E-02 -.256E-04
+   -.666E+02 -.888E+02 -.119E+02   0.782E+02 0.104E+03 0.159E+02   -.116E+02 -.157E+02 -.401E+01   -.104E-03 -.116E-02 0.162E-03
+   -.695E+02 0.789E+02 -.459E+02   0.785E+02 -.793E+02 0.435E+02   -.905E+01 0.481E+00 0.236E+01   -.120E-03 0.174E-03 -.170E-03
+   -.890E+02 0.663E+02 0.743E+02   0.993E+02 -.652E+02 -.810E+02   -.104E+02 -.110E+01 0.671E+01   -.408E-04 -.215E-03 0.156E-03
+   0.953E+02 -.253E+02 -.399E+02   -.106E+03 0.256E+02 0.470E+02   0.106E+02 -.314E+00 -.711E+01   0.514E-03 0.597E-03 -.421E-03
+   0.923E+02 -.329E+02 -.201E+02   -.103E+03 0.329E+02 0.274E+02   0.110E+02 -.326E-01 -.726E+01   0.643E-03 0.272E-03 0.306E-03
+   0.911E+02 0.545E+02 -.337E+02   -.102E+03 -.553E+02 0.401E+02   0.111E+02 0.834E+00 -.650E+01   0.627E-03 -.257E-03 0.259E-03
+   0.123E+03 0.661E+02 -.110E+02   -.133E+03 -.661E+02 0.171E+02   0.108E+02 0.560E-01 -.610E+01   0.662E-03 -.371E-03 -.184E-03
+   -.781E+02 0.250E+02 0.340E+02   0.888E+02 -.248E+02 -.382E+02   -.107E+02 -.219E+00 0.419E+01   -.290E-03 0.793E-03 -.412E-03
+   -.891E+02 -.318E+02 0.256E+02   0.994E+02 0.317E+02 -.320E+02   -.104E+02 0.763E-01 0.641E+01   -.332E-03 0.635E-03 0.624E-03
+   -.633E+02 -.470E+02 -.549E+02   0.751E+02 0.589E+02 0.659E+02   -.117E+02 -.119E+02 -.110E+02   0.428E-03 0.115E-02 -.253E-03
+   -.625E+02 -.497E+02 -.470E+02   0.743E+02 0.619E+02 0.584E+02   -.118E+02 -.122E+02 -.114E+02   0.260E-03 0.106E-02 0.105E-03
+   -.610E+01 0.118E+02 0.582E+01   0.147E+01 -.176E+02 -.141E+02   0.464E+01 0.575E+01 0.825E+01   -.437E-03 -.106E-02 0.256E-03
+   0.511E+02 0.577E+02 0.643E+02   -.624E+02 -.695E+02 -.754E+02   0.113E+02 0.118E+02 0.111E+02   -.718E-03 -.118E-02 0.323E-03
+   0.642E+02 -.444E+02 0.445E+02   -.745E+02 0.557E+02 -.558E+02   0.103E+02 -.112E+02 0.113E+02   -.621E-03 0.142E-02 0.484E-03
+   0.479E+02 -.415E+02 0.569E+02   -.580E+02 0.540E+02 -.678E+02   0.101E+02 -.126E+02 0.109E+02   -.489E-03 0.139E-02 -.449E-03
+   -.710E+02 0.543E+02 -.500E+02   0.828E+02 -.676E+02 0.620E+02   -.118E+02 0.133E+02 -.120E+02   0.678E-04 -.117E-02 -.230E-03
+   -.623E+02 0.559E+02 -.547E+02   0.741E+02 -.682E+02 0.665E+02   -.118E+02 0.124E+02 -.117E+02   0.219E-04 -.115E-02 0.127E-03
+   0.118E+03 0.643E+02 -.600E+02   -.136E+03 -.685E+02 0.719E+02   0.180E+02 0.423E+01 -.119E+02   -.630E-03 0.170E-03 0.131E-03
+   0.727E+02 0.106E+03 0.258E+02   -.877E+02 -.117E+03 -.240E+02   0.150E+02 0.113E+02 -.181E+01   -.709E-03 -.153E-03 -.324E-03
+   -.124E+03 -.385E+02 0.464E+02   0.143E+03 0.434E+02 -.573E+02   -.181E+02 -.496E+01 0.109E+02   0.383E-03 0.421E-03 -.463E-03
+   -.122E+03 -.476E+02 0.342E+02   0.140E+03 0.535E+02 -.438E+02   -.182E+02 -.581E+01 0.968E+01   0.329E-03 0.509E-03 0.433E-03
+   -.125E+03 0.597E+02 0.306E+02   0.143E+03 -.645E+02 -.419E+02   -.180E+02 0.483E+01 0.113E+02   0.126E-03 -.740E-04 -.198E-03
+   -.118E+03 0.597E+02 0.506E+02   0.135E+03 -.646E+02 -.618E+02   -.178E+02 0.490E+01 0.112E+02   0.177E-03 -.399E-03 0.194E-03
+   0.104E+03 -.964E+01 -.736E+02   -.122E+03 0.139E+02 0.850E+02   0.180E+02 -.427E+01 -.114E+02   -.629E-03 0.113E-02 -.262E-03
+   0.113E+03 -.475E+02 -.296E+02   -.130E+03 0.537E+02 0.411E+02   0.165E+02 -.617E+01 -.115E+02   -.743E-03 0.684E-03 0.525E-03
+   -.443E+01 0.104E+02 0.798E+00   0.478E+01 -.111E+02 -.876E+00   -.354E+00 0.730E+00 0.717E-01   -.541E-05 -.193E-03 -.580E-04
+ -----------------------------------------------------------------------------------------------
+   -.495E+01 0.161E+02 -.380E+01   0.480E-13 0.282E-12 -.212E-12   0.486E+01 -.158E+02 0.336E+01   0.657E-04 0.230E-02 0.912E-03
+ 
+ 
+ POSITION                                       TOTAL-FORCE (eV/Angst)
+ -----------------------------------------------------------------------------------
+      4.70011      9.64281      1.24808        -0.002752     -0.009790      0.000279
+      4.57350      9.65187      6.19258        -0.001932     -0.002687     -0.001523
+      4.70424      1.72936      3.70531         0.002198      0.002482     -0.001254
+      4.54807      1.79655      8.68405         0.002873     -0.003012     -0.000800
+      0.01026      3.93050      1.29345        -0.002561      0.003341     -0.001655
+     -0.10498      3.97563      6.20151         0.000860      0.001350     -0.000224
+     -0.08029      7.55644      3.71199        -0.001856      0.006238     -0.001640
+     -0.17216      7.54217      8.69272        -0.001674     -0.001065      0.001066
+      4.69836      3.85928      1.23450         0.002274     -0.004382      0.000433
+      4.61817      3.86278      6.25349         0.000230     -0.001819      0.000640
+      4.62763      7.63507      3.72539         0.003919      0.000820     -0.000369
+      4.51311      7.64487      8.59710        -0.000505      0.001537     -0.002728
+     -0.01821      9.56318      1.22413         0.001784     -0.001039     -0.001409
+     -0.12748      9.57620      6.19174         0.003255      0.000515     -0.001851
+     -0.04549      1.96683      3.68567         0.011518      0.013452     -0.006375
+     -0.18920      1.90933      8.66645        -0.004448     -0.002351     -0.001505
+      2.40456      1.01346      1.26852         0.005201      0.003369      0.003650
+      2.30029      1.01242      6.20391        -0.001280     -0.002182     -0.003930
+      6.96431     10.47609      3.70946        -0.000439      0.000488     -0.004366
+      6.84777     10.47905      8.64730        -0.005121      0.005976      0.000128
+      7.00741      0.98860      1.22039         0.001102     -0.005997      0.001476
+      6.90733      1.00742      6.16702        -0.002875     -0.000732     -0.000208
+      2.34233     10.47753      3.72664        -0.002262      0.004281     -0.003719
+      2.24332     10.48766      8.68879         0.008061      0.010887      0.003862
+      7.11935      6.75215      1.24737         0.003711     -0.003782      0.002963
+      7.02550      6.75336      6.20402         0.000606     -0.002767     -0.006029
+      2.19744      4.80718      3.61771        -0.010349     -0.014241      0.005939
+      2.11189      4.74665      8.67950         0.002727      0.002767      0.005090
+      2.32510      6.80121      1.20635         0.003517      0.021795      0.002204
+      2.09026      6.68962      6.16843        -0.009483      0.012641      0.003339
+      7.06805      4.73096      3.73031        -0.001963     -0.005296      0.001491
+      6.99933      4.74064      8.69155         0.007682     -0.013848      0.006792
+      3.33326      3.64272      9.43766        -0.001041      0.002577      0.001668
+      5.91039      7.82143      0.45934         0.001475     -0.003510     -0.003262
+      5.80385      7.83745      5.43518        -0.002491      0.000263     -0.000837
+      5.82026      3.65581      2.97967         0.000510     -0.001064      0.000994
+      5.75972      3.64688      7.93257        -0.002671     -0.004169      0.002442
+      3.53592      7.91366      1.97754         0.003452     -0.004692     -0.000497
+      3.39248      7.78178      6.93043        -0.003932     -0.002597     -0.006207
+      8.06899     10.81836      2.13074        -0.001071     -0.004648      0.000285
+      7.96743     10.83828      7.08246         0.000441      0.000621     -0.000874
+      1.29030      0.62166      2.81925        -0.003082      0.000088      0.000535
+      1.19178      0.66217      7.77996         0.002101      0.003617      0.000068
+      1.35238     10.83702      0.34801         0.002370      0.000865     -0.001886
+      1.24166     10.84521      5.30247        -0.000403      0.001701     -0.001941
+      8.00277      0.65088      4.61059        -0.000886     -0.004330     -0.000333
+      7.90754      0.64579      9.56168        -0.000751     -0.002248     -0.001776
+      3.53803      2.20765      1.99014        -0.004871      0.001349     -0.002126
+      3.45164      2.20525      6.89225         0.002669      0.003482      0.004641
+      5.81630      9.28773      3.01765        -0.002110     -0.008670     -0.002419
+      5.70552      9.29514      7.93787         0.000553     -0.001722     -0.002781
+      5.85598      2.16738      0.52257        -0.003526     -0.001116      0.001694
+      5.74025      2.19406      5.48520         0.000703      0.002615      0.001269
+      3.49432      9.29805      4.43551         0.004467     -0.006658     -0.001265
+      3.39769      9.30461      9.37410         0.005163     -0.001642      0.000725
+      6.08095     10.88767      0.28644         0.000731     -0.003390     -0.004398
+      5.96523     10.90292      5.25232        -0.001338     -0.004814     -0.000499
+      3.28575      0.58263      4.65709        -0.002403     -0.000561      0.003842
+      3.17710      0.57982      9.63396        -0.003104      0.004224      0.004491
+      3.34278     10.91024      2.19001        -0.001075      0.001809     -0.000535
+      3.23331     10.92280      7.14329         0.004199      0.003403     -0.001008
+      6.01853      0.55578      2.76877         0.002114     -0.006196     -0.001992
+      5.92077      0.57111      7.72389        -0.000320     -0.001035     -0.000791
+      8.19552      9.39609      4.47678         0.003340     -0.002304     -0.000266
+      8.08236      9.40171      9.41687         0.007154     -0.005107     -0.001951
+      1.17511      2.06451      0.47306        -0.003485      0.002019     -0.003543
+      1.07543      2.09543      5.44789         0.000302      0.002515     -0.001171
+      1.11771      9.39594      2.96019        -0.003699      0.001321     -0.002398
+      1.01329      9.42102      7.91083        -0.001621     -0.000287     -0.001115
+      8.21489      2.06853      1.99253         0.000276     -0.001757      0.005840
+      8.12913      2.08211      6.95483         0.002365     -0.000602     -0.002095
+      3.43679      5.19326      2.01110        -0.000898      0.007328     -0.004590
+      3.24699      5.07996      7.12517         0.001149      0.001911     -0.000820
+      6.02420      6.40994      2.82377        -0.001161      0.000019      0.001359
+      5.92508      6.38106      7.77159        -0.000615     -0.002387     -0.000814
+      6.09592      5.09030      0.34394         0.001189     -0.001434     -0.001039
+      5.95112      5.10147      5.30631        -0.003478      0.000240      0.002441
+      3.29416      6.36994      4.61871         0.000544     -0.000573      0.001124
+      3.18238      6.41393      9.52795         0.003616     -0.001469      0.001770
+      8.28589      7.93041      1.93811         0.003096     -0.003410     -0.003714
+      8.17754      7.93124      6.91190        -0.001016      0.000172      0.000390
+      0.97696      3.46979      2.94617         0.011896      0.015365      0.017301
+      0.95932      3.56099      7.97176        -0.004808      0.001541      0.000359
+      1.16263      7.97622      0.46829         0.002578     -0.001596      0.003995
+      1.00485      7.95434      5.47930         0.006216     -0.007153     -0.002590
+      8.18430      3.54701      4.46037        -0.003919     -0.002503      0.001005
+      8.13509      3.54964      9.39790        -0.006041      0.004666     -0.002586
+      1.35638      5.18729      0.30370         0.002960      0.000923     -0.002409
+      1.18854      5.19908      5.40241        -0.004578      0.000141      0.001578
+      8.00604      6.31695      4.66079        -0.003285     -0.000657      0.002122
+      7.91249      6.31514      9.61578         0.003571     -0.002977      0.000074
+      8.05299      5.15357      2.19296        -0.004773     -0.002173      0.002514
+      7.96819      5.16131      7.14020        -0.002295     -0.000562     -0.001902
+      1.26611      6.44078      2.68863        -0.004326      0.013171      0.000025
+      1.18773      6.34873      7.78599        -0.003471     -0.000061      0.005322
+      3.53422      3.63228      4.52973        -0.004676      0.005177     -0.001207
+ -----------------------------------------------------------------------------------
+    total drift:                               -0.091235      0.311581     -0.439260
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+  FREE ENERGIE OF THE ION-ELECTRON SYSTEM (eV)
+  ---------------------------------------------------
+  free  energy   TOTEN  =     -2822.36308087 eV
+
+  energy  without entropy=    -2822.36308087  energy(sigma->0) =    -2822.36308087
+ 
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+    POTLOK:  cpu time    0.7680: real time    0.7664
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+  
+ reached required accuracy - stopping structural energy minimisation
+ writing wavefunctions
+     LOOP+:  cpu time   20.4400: real time   22.3903
+    4ORBIT:  cpu time    0.0000: real time    0.0000
+ 
+
+
+ total charge     
+ 
+# of ion       s       p       d       tot
+------------------------------------------
+    1        0.071   0.145   0.000   0.217
+    2        0.071   0.145   0.000   0.216
+    3        0.075   0.151   0.000   0.226
+    4        0.071   0.144   0.000   0.216
+    5        0.077   0.157   0.000   0.234
+    6        0.078   0.159   0.000   0.237
+    7        0.073   0.148   0.000   0.221
+    8        0.074   0.152   0.000   0.226
+    9        0.450   0.754   1.643   2.848
+   10        0.437   0.725   1.572   2.734
+   11        0.439   0.737   1.598   2.774
+   12        0.446   0.748   1.633   2.827
+   13        0.440   0.743   1.597   2.780
+   14        0.443   0.749   1.612   2.804
+   15        0.452   0.758   1.656   2.865
+   16        0.442   0.746   1.608   2.795
+   17        0.737   1.083   4.217   6.036
+   18        0.739   1.091   4.231   6.061
+   19        0.738   1.091   4.222   6.050
+   20        0.739   1.092   4.225   6.055
+   21        0.742   1.093   4.258   6.093
+   22        0.736   1.086   4.210   6.031
+   23        0.738   1.090   4.223   6.050
+   24        0.739   1.088   4.232   6.059
+   25        0.737   1.086   4.226   6.050
+   26        0.739   1.087   4.233   6.059
+   27        0.530   0.598  37.436  38.563
+   28        0.740   1.096   4.233   6.069
+   29        0.739   1.105   4.214   6.058
+   30        0.737   1.110   4.207   6.055
+   31        0.740   1.085   4.245   6.070
+   32        0.739   1.094   4.224   6.057
+   33        1.598   3.485   0.000   5.083
+   34        1.599   3.476   0.000   5.075
+   35        1.599   3.481   0.000   5.080
+   36        1.598   3.481   0.000   5.079
+   37        1.598   3.485   0.000   5.083
+   38        1.597   3.487   0.000   5.084
+   39        1.595   3.485   0.000   5.081
+   40        1.588   3.508   0.000   5.096
+   41        1.588   3.510   0.000   5.098
+   42        1.588   3.515   0.000   5.103
+   43        1.588   3.511   0.000   5.099
+   44        1.588   3.511   0.000   5.099
+   45        1.588   3.511   0.000   5.099
+   46        1.588   3.505   0.000   5.093
+   47        1.588   3.510   0.000   5.098
+   48        1.596   3.481   0.000   5.077
+   49        1.597   3.485   0.000   5.082
+   50        1.597   3.484   0.000   5.081
+   51        1.597   3.487   0.000   5.084
+   52        1.597   3.485   0.000   5.082
+   53        1.596   3.482   0.000   5.078
+   54        1.597   3.486   0.000   5.083
+   55        1.598   3.486   0.000   5.083
+   56        1.594   3.495   0.000   5.089
+   57        1.593   3.493   0.000   5.086
+   58        1.593   3.495   0.000   5.088
+   59        1.593   3.496   0.000   5.088
+   60        1.594   3.494   0.000   5.087
+   61        1.593   3.496   0.000   5.089
+   62        1.592   3.504   0.000   5.096
+   63        1.593   3.496   0.000   5.089
+   64        1.598   3.484   0.000   5.083
+   65        1.598   3.483   0.000   5.081
+   66        1.600   3.484   0.000   5.083
+   67        1.599   3.480   0.000   5.079
+   68        1.599   3.482   0.000   5.081
+   69        1.599   3.483   0.000   5.082
+   70        1.600   3.484   0.000   5.084
+   71        1.599   3.482   0.000   5.081
+   72        1.586   3.529   0.000   5.114
+   73        1.589   3.512   0.000   5.101
+   74        1.588   3.511   0.000   5.099
+   75        1.588   3.513   0.000   5.102
+   76        1.588   3.515   0.000   5.103
+   77        1.588   3.512   0.000   5.100
+   78        1.586   3.523   0.000   5.109
+   79        1.589   3.519   0.000   5.108
+   80        1.597   3.485   0.000   5.082
+   81        1.597   3.484   0.000   5.081
+   82        1.589   3.531   0.000   5.120
+   83        1.596   3.487   0.000   5.083
+   84        1.596   3.491   0.000   5.087
+   85        1.596   3.492   0.000   5.088
+   86        1.599   3.482   0.000   5.081
+   87        1.598   3.484   0.000   5.082
+   88        1.595   3.492   0.000   5.086
+   89        1.589   3.521   0.000   5.110
+   90        1.594   3.495   0.000   5.088
+   91        1.593   3.498   0.000   5.091
+   92        1.594   3.492   0.000   5.086
+   93        1.594   3.495   0.000   5.089
+   94        1.593   3.511   0.000   5.104
+   95        1.593   3.505   0.000   5.097
+   96        0.565   0.002   0.000   0.567
+--------------------------------------------------
+tot        116.726 244.381 113.753 474.860
+ 
+
+
+ magnetization (x)
+ 
+# of ion       s       p       d       tot
+------------------------------------------
+    1        0.000   0.000   0.000   0.000
+    2        0.000   0.000   0.000   0.000
+    3       -0.000  -0.000   0.000  -0.000
+    4       -0.000  -0.000   0.000  -0.000
+    5       -0.000  -0.000   0.000  -0.000
+    6       -0.000   0.000   0.000  -0.000
+    7        0.000   0.000   0.000   0.000
+    8        0.000   0.000   0.000   0.000
+    9        0.000   0.001   0.001   0.002
+   10       -0.000  -0.001  -0.001  -0.003
+   11       -0.000  -0.000  -0.000  -0.000
+   12       -0.000  -0.000  -0.000  -0.000
+   13        0.000   0.000   0.000   0.000
+   14        0.000   0.000   0.000   0.000
+   15       -0.000  -0.001  -0.002  -0.003
+   16        0.000   0.000  -0.000   0.000
+   17        0.000   0.000   0.000   0.000
+   18        0.000   0.000   0.000   0.000
+   19        0.000  -0.000   0.000   0.000
+   20        0.000   0.000   0.000   0.000
+   21       -0.000  -0.000  -0.000  -0.000
+   22       -0.000  -0.000  -0.000  -0.000
+   23       -0.000  -0.000  -0.000  -0.001
+   24       -0.000   0.000   0.000   0.000
+   25       -0.000   0.000   0.000   0.000
+   26       -0.000  -0.000   0.000   0.000
+   27        0.007   0.008  35.980  35.995
+   28       -0.000  -0.000  -0.002  -0.002
+   29        0.001   0.001   0.004   0.006
+   30       -0.000  -0.000   0.003   0.003
+   31       -0.000  -0.000  -0.001  -0.001
+   32       -0.000  -0.000  -0.000  -0.000
+   33        0.000   0.000   0.000   0.000
+   34        0.000   0.000   0.000   0.000
+   35       -0.000  -0.000   0.000  -0.000
+   36        0.000   0.000   0.000   0.000
+   37       -0.000  -0.000   0.000  -0.000
+   38        0.000   0.000   0.000   0.000
+   39       -0.000  -0.000   0.000  -0.000
+   40        0.000   0.000   0.000   0.000
+   41        0.000  -0.000   0.000  -0.000
+   42        0.000  -0.000   0.000  -0.000
+   43        0.000   0.000   0.000   0.000
+   44        0.000   0.000   0.000   0.000
+   45        0.000   0.000   0.000   0.000
+   46       -0.000  -0.000   0.000  -0.000
+   47        0.000   0.000   0.000   0.000
+   48        0.000   0.001   0.000   0.001
+   49       -0.000  -0.000   0.000  -0.000
+   50        0.000  -0.000   0.000  -0.000
+   51       -0.000  -0.000   0.000  -0.000
+   52        0.000   0.000   0.000   0.000
+   53       -0.000  -0.000   0.000  -0.000
+   54        0.000   0.000   0.000   0.000
+   55       -0.000  -0.000   0.000  -0.000
+   56       -0.000  -0.000   0.000  -0.000
+   57        0.000  -0.000   0.000  -0.000
+   58        0.000  -0.000   0.000  -0.000
+   59        0.000   0.000   0.000   0.000
+   60       -0.000   0.000   0.000   0.000
+   61        0.000   0.000   0.000   0.000
+   62        0.000  -0.000   0.000  -0.000
+   63        0.000  -0.000   0.000  -0.000
+   64        0.000   0.000   0.000   0.000
+   65        0.000   0.000   0.000   0.000
+   66       -0.000  -0.000   0.000  -0.000
+   67        0.000   0.000   0.000   0.000
+   68        0.000   0.000   0.000   0.000
+   69       -0.000   0.000   0.000   0.000
+   70       -0.000  -0.000   0.000  -0.000
+   71        0.000  -0.000   0.000  -0.000
+   72       -0.000   0.002   0.000   0.002
+   73        0.000   0.000   0.000   0.000
+   74        0.000  -0.000   0.000  -0.000
+   75        0.000   0.000   0.000   0.000
+   76       -0.000  -0.000   0.000  -0.000
+   77        0.000   0.000   0.000   0.000
+   78       -0.000  -0.005   0.000  -0.005
+   79       -0.000  -0.000   0.000  -0.000
+   80       -0.000  -0.000   0.000  -0.000
+   81       -0.000  -0.000   0.000  -0.000
+   82       -0.001  -0.020   0.000  -0.021
+   83        0.000   0.000   0.000   0.000
+   84        0.000  -0.000   0.000  -0.000
+   85        0.000   0.001   0.000   0.001
+   86        0.000   0.000   0.000   0.000
+   87       -0.000  -0.000   0.000  -0.000
+   88        0.000  -0.000   0.000  -0.000
+   89        0.000   0.011   0.000   0.011
+   90        0.000  -0.000   0.000  -0.000
+   91       -0.000  -0.000   0.000  -0.000
+   92        0.000   0.000   0.000   0.000
+   93       -0.000  -0.000   0.000  -0.000
+   94       -0.000   0.001   0.000   0.001
+   95       -0.000  -0.000   0.000  -0.000
+   96       -0.004   0.000   0.000  -0.004
+--------------------------------------------------
+tot          0.004  -0.002  35.982  35.984
+ 
+
+ total amount of memory used by VASP MPI-rank0   123409. kBytes
+=======================================================================
+
+   base      :      30000. kBytes
+   nonlr-proj:      17792. kBytes
+   fftplans  :       2682. kBytes
+   grid      :      17235. kBytes
+   one-center:       2985. kBytes
+   wavefun   :      52715. kBytes
+ 
+  
+  
+ General timing and accounting informations for this job:
+ ========================================================
+  
+                  Total CPU time used (sec):       26.364
+                            User time (sec):       24.812
+                          System time (sec):        1.552
+                         Elapsed time (sec):       28.611
+  
+                   Maximum memory used (kb):      179120.
+                   Average memory used (kb):           0.
+  
+                          Minor page faults:       335927
+                          Major page faults:            6
+                 Voluntary context switches:         1959


### PR DESCRIPTION
## Summary

Include a summary of major changes in bullet points:

* Fixed regular expression to parse density matrix

At Line 1476 -- 1490 in OUTCAR_merged_numbers2 file in test_files

-------------------------------------------------------
spin component  1
 
  6.1320 -7.9985  9.9720  5.1366 -1.5481
 -7.9985 11.2215-13.7153 -6.9893  2.1083 **(Parse this line was okay.)**
  9.9720-13.7153 17.1305  8.6130 -2.6035   **(Parse this line was failed.)**
  5.1366 -6.9893  8.6130  4.6441 -1.3773
 -1.5481  2.1083 -2.6035 -1.3773  0.5186
 
spin component  2
 
  0.2072  0.0820 -0.0441  0.0155  0.0005
  0.0820  0.1381  0.0032  0.0204 -0.0103
 -0.0441  0.0032  0.1180 -0.0734  0.0235
  0.0155  0.0204 -0.0734  0.1874 -0.0333
  0.0005 -0.0103  0.0235 -0.0333  0.0992

-------------------------------------------------------