### PR TITLE
Fix zpsp to have element names as its keys

### DIFF
--- a/pymatgen/command_line/critic2_caller.py
+++ b/pymatgen/command_line/critic2_caller.py
@@ -297,7 +297,7 @@ class Critic2Caller:
 
             if potcar_path:
                 potcar = Potcar.from_file(potcar_path)
-                zpsp = {p.symbol: p.zval for p in potcar}
+                zpsp = {p.element: p.zval for p in potcar}
 
         if not zpsp:
 


### PR DESCRIPTION
##  Summary

This fix is needed as symbol shows the POTCAR label e.g. "Ca_pv" while element its name "Ca",

Fix #1890 
