### PR TITLE
## fix openbabel 3.0 compatibility in lammps submodule

### DIFF
--- a/pymatgen/io/babel.py
+++ b/pymatgen/io/babel.py
@@ -48,7 +48,6 @@ class BabelMolAdaptor:
             mol: pymatgen's Molecule or OpenBabel OBMol
         """
         if isinstance(mol, Molecule):
-            print("test")
             if not mol.is_ordered:
                 raise ValueError("OpenBabel Molecule only supports ordered "
                                  "molecules.")
@@ -74,7 +73,7 @@ class BabelMolAdaptor:
             obmol.SetTotalCharge(int(mol.charge))
             obmol.Center()
             obmol.EndModify()
-            self._obmol = obmol #
+            self._obmol = obmol
         elif isinstance(mol, ob.OBMol):
             self._obmol = mol
 

--- a/pymatgen/io/babel.py
+++ b/pymatgen/io/babel.py
@@ -48,6 +48,7 @@ class BabelMolAdaptor:
             mol: pymatgen's Molecule or OpenBabel OBMol
         """
         if isinstance(mol, Molecule):
+            print("test")
             if not mol.is_ordered:
                 raise ValueError("OpenBabel Molecule only supports ordered "
                                  "molecules.")
@@ -73,7 +74,7 @@ class BabelMolAdaptor:
             obmol.SetTotalCharge(int(mol.charge))
             obmol.Center()
             obmol.EndModify()
-            self._obmol = obmol
+            self._obmol = obmol #
         elif isinstance(mol, ob.OBMol):
             self._obmol = mol
 

--- a/pymatgen/io/lammps/utils.py
+++ b/pymatgen/io/lammps/utils.py
@@ -22,7 +22,7 @@ except ImportError:
 from pymatgen import Molecule
 from pymatgen.core.operations import SymmOp
 from pymatgen.util.coord import get_angle
-from ..babel import BabelMolAdaptor
+from pymatgen.io.babel import BabelMolAdaptor
 
 from monty.os.path import which
 from monty.tempfile import ScratchDir
@@ -264,14 +264,14 @@ class PackmolRunner:
             for idx, mol in enumerate(self.mols):
                 filename = os.path.join(
                     input_dir, '{}.{}'.format(
-                        idx, self.control_params["filetype"])).encode("ascii")
+                        idx, self.control_params["filetype"]))
                 # pdb
                 if self.control_params["filetype"] == "pdb":
                     self.write_pdb(mol, filename, num=idx + 1)
                 # all other filetypes
                 else:
                     a = BabelMolAdaptor(mol)
-                    pm = pb.Molecule(a.openbabel_mol) ##
+                    pm = pb.Molecule(a.openbabel_mol)
                     pm.write(self.control_params["filetype"], filename=filename,
                              overwrite=True)
 

--- a/pymatgen/io/lammps/utils.py
+++ b/pymatgen/io/lammps/utils.py
@@ -15,14 +15,14 @@ from subprocess import Popen, PIPE
 import numpy as np
 
 try:
-    import pybel as pb
+    from openbabel import pybel as pb
 except ImportError:
     pb = None
 
 from pymatgen import Molecule
 from pymatgen.core.operations import SymmOp
 from pymatgen.util.coord import get_angle
-from pymatgen.io.babel import BabelMolAdaptor
+from ..babel import BabelMolAdaptor
 
 from monty.os.path import which
 from monty.tempfile import ScratchDir
@@ -271,7 +271,7 @@ class PackmolRunner:
                 # all other filetypes
                 else:
                     a = BabelMolAdaptor(mol)
-                    pm = pb.Molecule(a.openbabel_mol)
+                    pm = pb.Molecule(a.openbabel_mol) ##
                     pm.write(self.control_params["filetype"], filename=filename,
                              overwrite=True)
 

--- a/pymatgen/io/lammps/utils.py
+++ b/pymatgen/io/lammps/utils.py
@@ -271,7 +271,7 @@ class PackmolRunner:
                 # all other filetypes
                 else:
                     a = BabelMolAdaptor(mol)
-                    pm = pb.Molecule(a.openbabel_mol) #
+                    pm = pb.Molecule(a.openbabel_mol)
                     pm.write(self.control_params["filetype"], filename=filename,
                              overwrite=True)
 

--- a/pymatgen/io/tests/test_xyz.py
+++ b/pymatgen/io/tests/test_xyz.py
@@ -4,6 +4,8 @@
 
 import unittest
 import os
+import pandas as pd
+import numpy as np
 
 from pymatgen.core.structure import Molecule
 from pymatgen.io.xyz import XYZ
@@ -166,6 +168,31 @@ O 9.405548 4.550379 1.231183
 O 9.960184 1.516793 1.393875"""
         self.assertEqual(str(xyz), ans)
 
+    def test_as_dataframe(self):
+        coords = [[0.000000, 0.000000, 0.000000],
+                  [0.000000, 0.000000, 1.089000],
+                  [1.026719, 0.000000, -0.363000],
+                  [-0.513360, -0.889165, -0.363000],
+                  [-0.513360, 0.889165, -0.363000]]
+        test_df = pd.DataFrame(coords, columns=['x', 'y', 'z'])
+        test_df.insert(0, "atom", ["C", "H", "H", "H", "H"])
+        test_df.index += 1
+        coords2 = [[0.000000, 0.000000, 0.000000],
+                  [0.000000, 0.000000, 1.089000],
+                  [1.026719, 0.000000, 0.363000],
+                  [0.513360, 0.889165, 0.363000],
+                  [0.513360, 0.889165, 0.363000]]
+        test_df2 = pd.DataFrame(coords2, columns=['x', 'y', 'z'])
+        test_df2.insert(0, "atom", ["C", "H", "H", "H", "H"])
+        test_df2.index += 1
+        mol_df = self.xyz.as_dataframe()
+
+        # body tests
+        pd.testing.assert_frame_equal(mol_df, test_df)
+
+        # index tests
+        np.testing.assert_array_equal(mol_df.columns, test_df.columns)
+        np.testing.assert_array_equal(mol_df.index, test_df.index)
 
 if __name__ == "__main__":
     unittest.main()

--- a/pymatgen/io/tests/test_xyz.py
+++ b/pymatgen/io/tests/test_xyz.py
@@ -178,10 +178,10 @@ O 9.960184 1.516793 1.393875"""
         test_df.insert(0, "atom", ["C", "H", "H", "H", "H"])
         test_df.index += 1
         coords2 = [[0.000000, 0.000000, 0.000000],
-                  [0.000000, 0.000000, 1.089000],
-                  [1.026719, 0.000000, 0.363000],
-                  [0.513360, 0.889165, 0.363000],
-                  [0.513360, 0.889165, 0.363000]]
+                   [0.000000, 0.000000, 1.089000],
+                   [1.026719, 0.000000, 0.363000],
+                   [0.513360, 0.889165, 0.363000],
+                   [0.513360, 0.889165, 0.363000]]
         test_df2 = pd.DataFrame(coords2, columns=['x', 'y', 'z'])
         test_df2.insert(0, "atom", ["C", "H", "H", "H", "H"])
         test_df2.index += 1
@@ -193,6 +193,7 @@ O 9.960184 1.516793 1.393875"""
         # index tests
         np.testing.assert_array_equal(mol_df.columns, test_df.columns)
         np.testing.assert_array_equal(mol_df.index, test_df.index)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/pymatgen/io/xyz.py
+++ b/pymatgen/io/xyz.py
@@ -10,6 +10,8 @@ import re
 
 from pymatgen.core.structure import Molecule
 from monty.io import zopen
+from io import StringIO
+import pandas as pd
 
 
 class XYZ:
@@ -114,6 +116,28 @@ class XYZ:
         """
         with zopen(filename) as f:
             return XYZ.from_string(f.read())
+
+    def as_dataframe(self):
+        """
+        Generates a coordinates data frame with columns: atom, x, y, and z
+        In case of multiple frame XYZ, returns the last frame.
+
+        Returns:
+            pandas.DataFrame
+
+        """
+        lines = str(self)
+
+        sio = StringIO(lines)
+        df = pd.read_csv(sio,
+                         header=None,
+                         skiprows=[0,1],
+                         comment="#",
+                         delim_whitespace=True,
+                         names=['atom', 'x', 'y', 'z'])
+        df.index += 1
+        return df
+
 
     def _frame_str(self, frame_mol):
         output = [str(len(frame_mol)), frame_mol.composition.formula]

--- a/pymatgen/io/xyz.py
+++ b/pymatgen/io/xyz.py
@@ -131,13 +131,12 @@ class XYZ:
         sio = StringIO(lines)
         df = pd.read_csv(sio,
                          header=None,
-                         skiprows=[0,1],
+                         skiprows=[0, 1],
                          comment="#",
                          delim_whitespace=True,
                          names=['atom', 'x', 'y', 'z'])
         df.index += 1
         return df
-
 
     def _frame_str(self, frame_mol):
         output = [str(len(frame_mol)), frame_mol.composition.formula]


### PR DESCRIPTION
## Summary


* Fix: small changes to important statements to align with openbabel 3.0 syntax
* Fix: removed casting to ASCII bytecode that was causing errors
* Feature: added as_dataframe method for XYZ and associated unit tests

## Additional dependencies introduced

* added imports for numpy and pandas to XYZ


Before a pull request can be merged, the following items must be checked:

- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). 
      Run [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/) and [flake8](http://flake8.pycqa.org/en/latest/)
      on your local machine.
- [x] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [x] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) 
      to type check your code.
- [ ] Tests have been added for any new functionality or bug fixes.
- [ ] All existing tests pass.

Note that the CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR. It is
highly recommended that you use the pre-commit hook provided in the pymatgen 
repository. Simply `cp pre-commit .git/hooks` and a check will be run prior to
allowing commits.
