### PR TITLE
Update the download link and citations for enumlib

### DIFF
--- a/pymatgen/command_line/enumlib_caller.py
+++ b/pymatgen/command_line/enumlib_caller.py
@@ -22,6 +22,10 @@ multilattices: Application to hcp alloys," Phys. Rev. B 80 014120 (July 2009)
 Gus L. W. Hart, Lance J. Nelson, and Rodney W. Forcade, "Generating
 derivative structures at a fixed concentration," Comp. Mat. Sci. 59
 101-107 (March 2012)
+
+Wiley S. Morgan, Gus L. W. Hart, Rodney W. Forcade, "Generating derivative
+superstructures for systems with high configurational freedom," Comp. Mat.
+Sci. 136 144-149 (May 2017)
 """
 
 import re

--- a/pymatgen/command_line/enumlib_caller.py
+++ b/pymatgen/command_line/enumlib_caller.py
@@ -8,7 +8,7 @@ code for enumerating derivative structures.
 
 This module depends on a compiled enumlib with the executables enum.x and
 makestr.x available in the path. Please download the library at
-http://enum.sourceforge.net/ and follow the instructions in the README to
+https://github.com/msg-byu/enumlib and follow the instructions in the README to
 compile these two executables accordingly.
 
 If you use this module, please cite the following:
@@ -67,8 +67,8 @@ makestr_cmd = which('makestr.x') or which('makeStr.x') or which('makeStr.py')
 @requires(enum_cmd and makestr_cmd,
           "EnumlibAdaptor requires the executables 'enum.x' or 'multienum.x' "
           "and 'makestr.x' or 'makeStr.py' to be in the path. Please download the "
-          "library at http://enum.sourceforge.net/ and follow the instructions in "
-          "the README to compile these two executables accordingly.")
+          "library at https://github.com/msg-byu/enumlib and follow the instructions "
+          "in the README to compile these two executables accordingly.")
 class EnumlibAdaptor:
     """
     An adaptor for enumlib.


### PR DESCRIPTION
## Summary

Enumlib has been migrated to github.

1. Update link of enumlib from Sourceforge to Github
2. Update the citations according to https://github.com/msg-byu/enumlib#brief-description