### PR TITLE
Fix serialisation of slabs with list scale_factor

### DIFF
--- a/pymatgen/core/surface.py
+++ b/pymatgen/core/surface.py
@@ -116,7 +116,7 @@ class Slab(Structure):
                 this Slab is created (by scaling in the c-direction).
             shift (float): The shift in the c-direction applied to get the
                 termination.
-            scale_factor (array): scale_factor Final computed scale factor
+            scale_factor (np.ndarray): scale_factor Final computed scale factor
                 that brings the parent cell to the surface cell.
             reorient_lattice (bool): reorients the lattice parameters such that
                 the c direction is the third vector of the lattice matrix
@@ -136,7 +136,7 @@ class Slab(Structure):
         self.miller_index = tuple(miller_index)
         self.shift = shift
         self.reconstruction = reconstruction
-        self.scale_factor = scale_factor
+        self.scale_factor = np.array(scale_factor)
         self.energy = energy
         self.reorient_lattice = reorient_lattice
         lattice = Lattice.from_parameters(lattice.a, lattice.b, lattice.c,

--- a/pymatgen/core/tests/test_surface.py
+++ b/pymatgen/core/tests/test_surface.py
@@ -250,6 +250,15 @@ class SlabTest(PymatgenTest):
         d = json.loads(s)
         self.assertEqual(slab, Slab.from_dict(d))
 
+        # test initialising with a list scale_factor
+        slab = Slab(self.zno55.lattice, self.zno55.species,
+                    self.zno55.frac_coords, self.zno55.miller_index,
+                    self.zno55.oriented_unit_cell, 0,
+                    self.zno55.scale_factor.tolist())
+        s = json.dumps(slab.as_dict())
+        d = json.loads(s)
+        self.assertEqual(slab, Slab.from_dict(d))
+
 
 class SlabGeneratorTest(PymatgenTest):
 


### PR DESCRIPTION
## Summary

A recent bug fix (1a3ce601c932ed80db14930da6e2c11a8a246771) introduced an incompatibility of the `Slab` class with the atomate `TransformerFW` and therefore broke surface workflows. Specifically, the `Slab` class now assumes the `scale_factor` input is a numpy array, whereas the `TransformerFW` supplies a list `scale_factor`. This caused an error during serialisation of the Slab when `tolist()` was called on a list.

This PR casts the `scale_factor` to a numpy array during initialisation of the Slab.

I've added a test.