### PR TITLE
Fixing QChem frequency parsing when calculating Raman intensities 

### DIFF
--- a/pymatgen/io/qchem/tests/test_outputs.py
+++ b/pymatgen/io/qchem/tests/test_outputs.py
@@ -216,7 +216,7 @@ class TestQCOutput(PymatgenTest):
             print('Testing ', key)
             self._test_property(key, single_outs, multi_outs)
 
-    @unittest.skipIf((not (have_babel)) or (not which("babel")),
+    @unittest.skipIf((not (have_babel)),
                      "OpenBabel not installed.")
     def test_structural_change(self):
         


### PR DESCRIPTION


* Fixes issue #1905 
* All frequency information can now be correctly parsed even when Raman intensities are being calculated
