### PR TITLE
Add validation and extrapolation for XAS stitching

### DIFF
--- a/pymatgen/analysis/xas/spectrum.py
+++ b/pymatgen/analysis/xas/spectrum.py
@@ -272,9 +272,8 @@ def site_weighted_spectrum(xas_list: List['XAS'], num_samples: int = 500) -> 'XA
     weighted_spectrum = np.zeros(num_samples)
     sum_multiplicities = sum(multiplicities)
 
-    for i in range(len(multiplicities)):
-        weighted_spectrum += (multiplicities[i] * fs[i](x_axis)) \
-                             / sum_multiplicities
+    for i, j in enumerate(multiplicities):
+        weighted_spectrum += (j * fs[i](x_axis)) / sum_multiplicities
 
     return XAS(x_axis, weighted_spectrum, ss, xas.absorbing_element, xas.edge,
                xas.spectrum_type)


### PR DESCRIPTION
## Summary


* Add check for empty spectrum and negative intensities
* Fix the jump in intensities at the L2 and L3-edge junction by extrapolating L2-edge XANES
* Add tests 

