### PR TITLE
gaussian std orientation bug fix

### DIFF
--- a/pymatgen/io/gaussian.py
+++ b/pymatgen/io/gaussian.py
@@ -537,7 +537,8 @@ class GaussianOutput:
 
     .. attribute:: opt_structures
 
-        All optimized structures from the calculation in the input orientation
+        All optimized structures from the calculation in the standard orientation,
+        if the attribute 'standard_orientation' is True, otherwise in the input
         or the Z-matrix orientation.
 
     .. attribute:: energies
@@ -1114,7 +1115,10 @@ class GaussianOutput:
                         if " -- Stationary point found." not in line:
                             warnings.warn("\n" + self.filename +
                                           ": Optimization complete but this is not a stationary point")
-                        opt_structures.append(input_structures[-1])
+                        if standard_orientation:
+                            opt_structures.append(std_structures[-1])
+                        else:
+                            opt_structures.append(input_structures[-1])
                     elif not read_eigen and orbital_patt.search(line):
                         eigen_txt.append(line)
                         read_eigen = True

--- a/pymatgen/io/tests/test_gaussian.py
+++ b/pymatgen/io/tests/test_gaussian.py
@@ -348,13 +348,24 @@ class GaussianOutputTest(unittest.TestCase):
         self.assertAlmostEqual(0.94710, d["coords"]["R1"][6])
         self.assertAlmostEqual(0.94277, d["coords"]["R2"][17])
 
+    def test_geo_opt()
+        # Test an optimization where no "input orientation" is outputted
+        gau = GaussianOutput(os.path.join(test_dir, "acene-n_gaussian09_opt.out"))
+        self.assertAlmostEqual(-1812.58399675, gau.energies[-1])
+        self.assertEqual(len(gau.structures), 6)
+        # Test the first 3 atom coordinates
+        coords = [[-13.642932,  0.715060,  0.000444],
+                  [-13.642932, -0.715060,  0.000444],
+                  [-12.444202,  1.416837,  0.000325]]
+        self.assertAlmostEqual(gau.opt_structures[-1].cart_coords[:3].tolist(), coords)
+
     def test_td(self):
         gau = GaussianOutput(os.path.join(test_dir, "so2_td.log"))
         transitions = gau.read_excitation_energies()
         self.assertEqual(len(transitions), 4)
         self.assertAlmostEqual(transitions[0], (3.9281, 315.64, 0.0054))
 
-    def test_multiple_paramaters(self):
+    def test_multiple_parameters(self):
         """
         This test makes sure that input files with multi-parameter keywords
         and route cards with multiple lines can be parsed accurately.

--- a/pymatgen/io/tests/test_gaussian.py
+++ b/pymatgen/io/tests/test_gaussian.py
@@ -337,9 +337,9 @@ class GaussianOutputTest(unittest.TestCase):
         self.assertAlmostEqual(124.01095, d["coords"]["ASO"][2])
         gau = GaussianOutput(os.path.join(test_dir, "H2O_scan_G16.out"))
         self.assertEqual(21, len(gau.opt_structures))
-        coords = [[0.104226,  0.000000,  0.087456],
-                  [-0.059296, 0.000000,  1.014833],
-                  [0.989118,  0.000000, -0.234619]]
+        coords = [[0.000000,  0.000000,  0.094168],
+                  [0.000000,  0.815522, -0.376673],
+                  [0.000000, -0.815522, -0.376673]]
         self.assertAlmostEqual(gau.opt_structures[-1].cart_coords.tolist(), coords)
         d = gau.read_scan()
         self.assertAlmostEqual(-0.00523, d["energies"][-1])
@@ -348,8 +348,10 @@ class GaussianOutputTest(unittest.TestCase):
         self.assertAlmostEqual(0.94710, d["coords"]["R1"][6])
         self.assertAlmostEqual(0.94277, d["coords"]["R2"][17])
 
-    def test_geo_opt()
-        # Test an optimization where no "input orientation" is outputted
+    def test_geo_opt(self):
+        """
+        Test an optimization where no "input orientation" is outputted
+        """
         gau = GaussianOutput(os.path.join(test_dir, "acene-n_gaussian09_opt.out"))
         self.assertAlmostEqual(-1812.58399675, gau.energies[-1])
         self.assertEqual(len(gau.structures), 6)

--- a/test_files/molecules/acene-n_gaussian09_opt.out
+++ b/test_files/molecules/acene-n_gaussian09_opt.out
@@ -1,0 +1,6349 @@
+ Entering Gaussian System, Link 0=g09
+ Input=g.com
+ Output=g.log
+ Initial command:
+ /cluster/apps/gaussian/g09/l1.exe "/scratch/133741165.tmpdir/Gau-27393.inp" -scrdir="/scratch/133741165.tmpdir/"
+ Entering Link 1 = /cluster/apps/gaussian/g09/l1.exe PID=     27400.
+  
+ Copyright (c) 1988,1990,1992,1993,1995,1998,2003,2009,2013,
+            Gaussian, Inc.  All Rights Reserved.
+  
+ This is part of the Gaussian(R) 09 program.  It is based on
+ the Gaussian(R) 03 system (copyright 2003, Gaussian, Inc.),
+ the Gaussian(R) 98 system (copyright 1998, Gaussian, Inc.),
+ the Gaussian(R) 94 system (copyright 1995, Gaussian, Inc.),
+ the Gaussian 92(TM) system (copyright 1992, Gaussian, Inc.),
+ the Gaussian 90(TM) system (copyright 1990, Gaussian, Inc.),
+ the Gaussian 88(TM) system (copyright 1988, Gaussian, Inc.),
+ the Gaussian 86(TM) system (copyright 1986, Carnegie Mellon
+ University), and the Gaussian 82(TM) system (copyright 1983,
+ Carnegie Mellon University). Gaussian is a federally registered
+ trademark of Gaussian, Inc.
+  
+ This software contains proprietary and confidential information,
+ including trade secrets, belonging to Gaussian, Inc.
+  
+ This software is provided under written license and may be
+ used, copied, transmitted, or stored only in accord with that
+ written license.
+  
+ The following legend is applicable only to US Government
+ contracts under FAR:
+  
+                    RESTRICTED RIGHTS LEGEND
+  
+ Use, reproduction and disclosure by the US Government is
+ subject to restrictions as set forth in subparagraphs (a)
+ and (c) of the Commercial Computer Software - Restricted
+ Rights clause in FAR 52.227-19.
+  
+ Gaussian, Inc.
+ 340 Quinnipiac St., Bldg. 40, Wallingford CT 06492
+  
+  
+ ---------------------------------------------------------------
+ Warning -- This program may not be used in any manner that
+ competes with the business of Gaussian, Inc. or will provide
+ assistance to any competitor of Gaussian, Inc.  The licensee
+ of this program is prohibited from giving any competitor of
+ Gaussian, Inc. access to this program.  By using this program,
+ the user acknowledges that Gaussian, Inc. is engaged in the
+ business of creating and licensing software in the field of
+ computational chemistry and represents and warrants to the
+ licensee that it is not a competitor of Gaussian, Inc. and that
+ it will not use this program in any manner prohibited above.
+ ---------------------------------------------------------------
+  
+
+ Cite this work as:
+ Gaussian 09, Revision D.01,
+ M. J. Frisch, G. W. Trucks, H. B. Schlegel, G. E. Scuseria, 
+ M. A. Robb, J. R. Cheeseman, G. Scalmani, V. Barone, B. Mennucci, 
+ G. A. Petersson, H. Nakatsuji, M. Caricato, X. Li, H. P. Hratchian, 
+ A. F. Izmaylov, J. Bloino, G. Zheng, J. L. Sonnenberg, M. Hada, 
+ M. Ehara, K. Toyota, R. Fukuda, J. Hasegawa, M. Ishida, T. Nakajima, 
+ Y. Honda, O. Kitao, H. Nakai, T. Vreven, J. A. Montgomery, Jr., 
+ J. E. Peralta, F. Ogliaro, M. Bearpark, J. J. Heyd, E. Brothers, 
+ K. N. Kudin, V. N. Staroverov, T. Keith, R. Kobayashi, J. Normand, 
+ K. Raghavachari, A. Rendell, J. C. Burant, S. S. Iyengar, J. Tomasi, 
+ M. Cossi, N. Rega, J. M. Millam, M. Klene, J. E. Knox, J. B. Cross, 
+ V. Bakken, C. Adamo, J. Jaramillo, R. Gomperts, R. E. Stratmann, 
+ O. Yazyev, A. J. Austin, R. Cammi, C. Pomelli, J. W. Ochterski, 
+ R. L. Martin, K. Morokuma, V. G. Zakrzewski, G. A. Voth, 
+ P. Salvador, J. J. Dannenberg, S. Dapprich, A. D. Daniels, 
+ O. Farkas, J. B. Foresman, J. V. Ortiz, J. Cioslowski, 
+ and D. J. Fox, Gaussian, Inc., Wallingford CT, 2013.
+ 
+ ******************************************
+ Gaussian 09:  ES64L-G09RevD.01 24-Apr-2013
+                 4-Aug-2020 
+ ******************************************
+ %chk=r-b3lyp-sto3g.chk
+ ------------------------------------------------------
+ #p b3lyp/sto-3g scf=(maxcycle=2048,cdiis,conver=7) opt
+ ------------------------------------------------------
+ 1/14=-1,18=20,19=15,26=3,38=1/1,3;
+ 2/9=110,12=2,17=6,18=5,40=1/2;
+ 3/6=3,11=2,16=1,25=1,30=1,71=1,74=-5/1,2,3;
+ 4//1;
+ 5/5=2,6=7,7=2048,22=12,38=5/2;
+ 6/7=2,8=2,9=2,10=2,28=1/1;
+ 7//1,2,3,16;
+ 1/14=-1,18=20,19=15,26=3/3(2);
+ 2/9=110/2;
+ 99//99;
+ 2/9=110/2;
+ 3/6=3,11=2,16=1,25=1,30=1,71=1,74=-5/1,2,3;
+ 4/5=5,16=3,69=1/1;
+ 5/5=2,6=7,7=2048,22=12,38=5/2;
+ 7//1,2,3,16;
+ 1/14=-1,18=20,19=15,26=3/3(-5);
+ 2/9=110/2;
+ 6/7=2,8=2,9=2,10=2,19=2,28=1/1;
+ 99/9=1/99;
+ Leave Link    1 at Tue Aug  4 10:38:18 2020, MaxMem=           0 cpu:         0.0
+ (Enter /cluster/apps/gaussian/g09/l101.exe)
+ --------
+ acene-nh
+ --------
+ Symbolic Z-matrix:
+ Charge =  0 Multiplicity = 1
+ C                     21.54843   8.20577   5.06779 
+ C                     21.54843   6.79418   5.06779 
+ C                     22.73795   8.89845   5.06763 
+ C                     23.9788   8.21526   5.06746 
+ C                     23.9788   6.78469   5.06746 
+ C                     22.73795   6.1015    5.06763 
+ C                     25.22247   6.10183   5.06729 
+ C                     26.41679   6.78416   5.06713 
+ C                     26.41679   8.21579   5.06713 
+ C                     25.22247   8.89812   5.06729 
+ N                     27.64667   8.86161   5.06693 
+ C                     28.88     8.2243    5.06696 
+ C                     28.88001   6.77566   5.06696 
+ N                     27.64667   6.13834   5.06693 
+ C                     30.06402   6.09499   5.06696 
+ C                     31.32477   6.77333   5.06696 
+ C                     31.32477   8.22663   5.06696 
+ C                     30.06402   8.90496   5.06696 
+ C                     32.5326   8.90396   5.06696 
+ C                     33.77492   8.22633   5.06696 
+ C                     33.77492   6.77363   5.06696 
+ C                     32.5326   6.096     5.06696 
+ C                     35.       6.09585   5.06696 
+ C                     36.22508   6.77364   5.06696 
+ C                     36.22508   8.22633   5.06696 
+ C                     35.       8.90411   5.06696 
+ C                     37.4674   8.90396   5.06696 
+ C                     38.67522   8.22663   5.06696 
+ C                     38.67523   6.77333   5.06696 
+ C                     37.4674   6.096     5.06696 
+ C                     39.93599   6.095     5.06696 
+ C                     41.12     6.77566   5.06696 
+ C                     41.12     8.2243    5.06696 
+ C                     39.93598   8.90497   5.06696 
+ N                     42.35333   8.86162   5.06693 
+ C                     43.58321   8.2158    5.06713 
+ C                     43.58321   6.78417   5.06713 
+ N                     42.35333   6.13835   5.06693 
+ C                     44.77753   6.10184   5.06729 
+ C                     46.0212   6.7847    5.06746 
+ C                     46.0212   8.21527   5.06746 
+ C                     44.77752   8.89813   5.06729 
+ C                     47.26205   8.89846   5.06763 
+ C                     48.45157   8.20578   5.06779 
+ C                     48.45157   6.79419   5.06779 
+ C                     47.26205   6.10151   5.06763 
+ H                     20.60712   8.74362   5.06792 
+ H                     20.60712   6.25633   5.06792 
+ H                     22.73841   9.98377   5.06763 
+ H                     22.73841   5.01618   5.06763 
+ H                     25.22799   5.01599   5.0673 
+ H                     25.22798   9.98396   5.0673 
+ H                     30.05719   5.00924   5.06697 
+ H                     30.05719   9.99072   5.06697 
+ H                     32.53324   5.01006   5.06696 
+ H                     35.       9.99012   5.06696 
+ H                     37.46676   5.01006   5.06696 
+ H                     39.94281   9.99072   5.06697 
+ H                     44.77202   5.016     5.0673 
+ H                     44.77201   9.98397   5.0673 
+ H                     47.26159   9.98378   5.06763 
+ H                     49.39288   8.74363   5.06792 
+ H                     49.39288   6.25634   5.06792 
+ H                     47.26159   5.01619   5.06763 
+ H                     32.53324   9.9899    5.06696 
+ H                     37.46676   9.9899    5.06696 
+ H                     35.       5.00985   5.06696 
+ H                     39.94281   5.00924   5.06697 
+ H                     27.64433   9.86957   5.06696 
+ H                     42.35567   9.86957   5.06698 
+ H                     27.64433   5.13039   5.06698 
+ H                     42.35567   5.13039   5.06696 
+ 
+ NAtoms=     72 NQM=       72 NQMF=       0 NMMI=      0 NMMIF=      0
+                NMic=       0 NMicF=      0.
+                    Isotopes and Nuclear Properties:
+ (Nuclear quadrupole moments (NQMom) in fm**2, nuclear magnetic moments (NMagM)
+  in nuclear magnetons)
+
+  Atom         1           2           3           4           5           6           7           8           9          10
+ IAtWgt=          12          12          12          12          12          12          12          12          12          12
+ AtmWgt=  12.0000000  12.0000000  12.0000000  12.0000000  12.0000000  12.0000000  12.0000000  12.0000000  12.0000000  12.0000000
+ NucSpn=           0           0           0           0           0           0           0           0           0           0
+ AtZEff=   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000
+ NQMom=    0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000
+ NMagM=    0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000
+ AtZNuc=   6.0000000   6.0000000   6.0000000   6.0000000   6.0000000   6.0000000   6.0000000   6.0000000   6.0000000   6.0000000
+
+  Atom        11          12          13          14          15          16          17          18          19          20
+ IAtWgt=          14          12          12          14          12          12          12          12          12          12
+ AtmWgt=  14.0030740  12.0000000  12.0000000  14.0030740  12.0000000  12.0000000  12.0000000  12.0000000  12.0000000  12.0000000
+ NucSpn=           2           0           0           2           0           0           0           0           0           0
+ AtZEff=   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000
+ NQMom=    2.0440000   0.0000000   0.0000000   2.0440000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000
+ NMagM=    0.4037610   0.0000000   0.0000000   0.4037610   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000
+ AtZNuc=   7.0000000   6.0000000   6.0000000   7.0000000   6.0000000   6.0000000   6.0000000   6.0000000   6.0000000   6.0000000
+
+  Atom        21          22          23          24          25          26          27          28          29          30
+ IAtWgt=          12          12          12          12          12          12          12          12          12          12
+ AtmWgt=  12.0000000  12.0000000  12.0000000  12.0000000  12.0000000  12.0000000  12.0000000  12.0000000  12.0000000  12.0000000
+ NucSpn=           0           0           0           0           0           0           0           0           0           0
+ AtZEff=   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000
+ NQMom=    0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000
+ NMagM=    0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000
+ AtZNuc=   6.0000000   6.0000000   6.0000000   6.0000000   6.0000000   6.0000000   6.0000000   6.0000000   6.0000000   6.0000000
+
+  Atom        31          32          33          34          35          36          37          38          39          40
+ IAtWgt=          12          12          12          12          14          12          12          14          12          12
+ AtmWgt=  12.0000000  12.0000000  12.0000000  12.0000000  14.0030740  12.0000000  12.0000000  14.0030740  12.0000000  12.0000000
+ NucSpn=           0           0           0           0           2           0           0           2           0           0
+ AtZEff=   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000
+ NQMom=    0.0000000   0.0000000   0.0000000   0.0000000   2.0440000   0.0000000   0.0000000   2.0440000   0.0000000   0.0000000
+ NMagM=    0.0000000   0.0000000   0.0000000   0.0000000   0.4037610   0.0000000   0.0000000   0.4037610   0.0000000   0.0000000
+ AtZNuc=   6.0000000   6.0000000   6.0000000   6.0000000   7.0000000   6.0000000   6.0000000   7.0000000   6.0000000   6.0000000
+
+  Atom        41          42          43          44          45          46          47          48          49          50
+ IAtWgt=          12          12          12          12          12          12           1           1           1           1
+ AtmWgt=  12.0000000  12.0000000  12.0000000  12.0000000  12.0000000  12.0000000   1.0078250   1.0078250   1.0078250   1.0078250
+ NucSpn=           0           0           0           0           0           0           1           1           1           1
+ AtZEff=   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000
+ NQMom=    0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000
+ NMagM=    0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   2.7928460   2.7928460   2.7928460   2.7928460
+ AtZNuc=   6.0000000   6.0000000   6.0000000   6.0000000   6.0000000   6.0000000   1.0000000   1.0000000   1.0000000   1.0000000
+
+  Atom        51          52          53          54          55          56          57          58          59          60
+ IAtWgt=           1           1           1           1           1           1           1           1           1           1
+ AtmWgt=   1.0078250   1.0078250   1.0078250   1.0078250   1.0078250   1.0078250   1.0078250   1.0078250   1.0078250   1.0078250
+ NucSpn=           1           1           1           1           1           1           1           1           1           1
+ AtZEff=   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000
+ NQMom=    0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000
+ NMagM=    2.7928460   2.7928460   2.7928460   2.7928460   2.7928460   2.7928460   2.7928460   2.7928460   2.7928460   2.7928460
+ AtZNuc=   1.0000000   1.0000000   1.0000000   1.0000000   1.0000000   1.0000000   1.0000000   1.0000000   1.0000000   1.0000000
+
+  Atom        61          62          63          64          65          66          67          68          69          70
+ IAtWgt=           1           1           1           1           1           1           1           1           1           1
+ AtmWgt=   1.0078250   1.0078250   1.0078250   1.0078250   1.0078250   1.0078250   1.0078250   1.0078250   1.0078250   1.0078250
+ NucSpn=           1           1           1           1           1           1           1           1           1           1
+ AtZEff=   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000
+ NQMom=    0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000   0.0000000
+ NMagM=    2.7928460   2.7928460   2.7928460   2.7928460   2.7928460   2.7928460   2.7928460   2.7928460   2.7928460   2.7928460
+ AtZNuc=   1.0000000   1.0000000   1.0000000   1.0000000   1.0000000   1.0000000   1.0000000   1.0000000   1.0000000   1.0000000
+
+  Atom        71          72
+ IAtWgt=           1           1
+ AtmWgt=   1.0078250   1.0078250
+ NucSpn=           1           1
+ AtZEff=   0.0000000   0.0000000
+ NQMom=    0.0000000   0.0000000
+ NMagM=    2.7928460   2.7928460
+ AtZNuc=   1.0000000   1.0000000
+ Leave Link  101 at Tue Aug  4 10:38:18 2020, MaxMem=    33554432 cpu:         0.1
+ (Enter /cluster/apps/gaussian/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Initialization pass.
+                           ----------------------------
+                           !    Initial Parameters    !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  1.4116         estimate D2E/DX2                !
+ ! R2    R(1,3)                  1.3765         estimate D2E/DX2                !
+ ! R3    R(1,47)                 1.0841         estimate D2E/DX2                !
+ ! R4    R(2,6)                  1.3765         estimate D2E/DX2                !
+ ! R5    R(2,48)                 1.0841         estimate D2E/DX2                !
+ ! R6    R(3,4)                  1.4165         estimate D2E/DX2                !
+ ! R7    R(3,49)                 1.0853         estimate D2E/DX2                !
+ ! R8    R(4,5)                  1.4306         estimate D2E/DX2                !
+ ! R9    R(4,10)                 1.4188         estimate D2E/DX2                !
+ ! R10   R(5,6)                  1.4165         estimate D2E/DX2                !
+ ! R11   R(5,7)                  1.4188         estimate D2E/DX2                !
+ ! R12   R(6,50)                 1.0853         estimate D2E/DX2                !
+ ! R13   R(7,8)                  1.3755         estimate D2E/DX2                !
+ ! R14   R(7,51)                 1.0859         estimate D2E/DX2                !
+ ! R15   R(8,9)                  1.4316         estimate D2E/DX2                !
+ ! R16   R(8,14)                 1.3891         estimate D2E/DX2                !
+ ! R17   R(9,10)                 1.3755         estimate D2E/DX2                !
+ ! R18   R(9,11)                 1.3891         estimate D2E/DX2                !
+ ! R19   R(10,52)                1.0859         estimate D2E/DX2                !
+ ! R20   R(11,12)                1.3883         estimate D2E/DX2                !
+ ! R21   R(11,69)                1.008          estimate D2E/DX2                !
+ ! R22   R(12,13)                1.4486         estimate D2E/DX2                !
+ ! R23   R(12,18)                1.3657         estimate D2E/DX2                !
+ ! R24   R(13,14)                1.3883         estimate D2E/DX2                !
+ ! R25   R(13,15)                1.3657         estimate D2E/DX2                !
+ ! R26   R(14,71)                1.008          estimate D2E/DX2                !
+ ! R27   R(15,16)                1.4317         estimate D2E/DX2                !
+ ! R28   R(15,53)                1.0858         estimate D2E/DX2                !
+ ! R29   R(16,17)                1.4533         estimate D2E/DX2                !
+ ! R30   R(16,22)                1.3848         estimate D2E/DX2                !
+ ! R31   R(17,18)                1.4317         estimate D2E/DX2                !
+ ! R32   R(17,19)                1.3848         estimate D2E/DX2                !
+ ! R33   R(18,54)                1.0858         estimate D2E/DX2                !
+ ! R34   R(19,20)                1.4151         estimate D2E/DX2                !
+ ! R35   R(19,65)                1.0859         estimate D2E/DX2                !
+ ! R36   R(20,21)                1.4527         estimate D2E/DX2                !
+ ! R37   R(20,26)                1.4001         estimate D2E/DX2                !
+ ! R38   R(21,22)                1.4151         estimate D2E/DX2                !
+ ! R39   R(21,23)                1.4001         estimate D2E/DX2                !
+ ! R40   R(22,55)                1.0859         estimate D2E/DX2                !
+ ! R41   R(23,24)                1.4001         estimate D2E/DX2                !
+ ! R42   R(23,67)                1.086          estimate D2E/DX2                !
+ ! R43   R(24,25)                1.4527         estimate D2E/DX2                !
+ ! R44   R(24,30)                1.4151         estimate D2E/DX2                !
+ ! R45   R(25,26)                1.4001         estimate D2E/DX2                !
+ ! R46   R(25,27)                1.4151         estimate D2E/DX2                !
+ ! R47   R(26,56)                1.086          estimate D2E/DX2                !
+ ! R48   R(27,28)                1.3848         estimate D2E/DX2                !
+ ! R49   R(27,66)                1.0859         estimate D2E/DX2                !
+ ! R50   R(28,29)                1.4533         estimate D2E/DX2                !
+ ! R51   R(28,34)                1.4317         estimate D2E/DX2                !
+ ! R52   R(29,30)                1.3848         estimate D2E/DX2                !
+ ! R53   R(29,31)                1.4317         estimate D2E/DX2                !
+ ! R54   R(30,57)                1.0859         estimate D2E/DX2                !
+ ! R55   R(31,32)                1.3657         estimate D2E/DX2                !
+ ! R56   R(31,68)                1.0858         estimate D2E/DX2                !
+ ! R57   R(32,33)                1.4486         estimate D2E/DX2                !
+ ! R58   R(32,38)                1.3883         estimate D2E/DX2                !
+ ! R59   R(33,34)                1.3657         estimate D2E/DX2                !
+ ! R60   R(33,35)                1.3883         estimate D2E/DX2                !
+ ! R61   R(34,58)                1.0858         estimate D2E/DX2                !
+ ! R62   R(35,36)                1.3891         estimate D2E/DX2                !
+ ! R63   R(35,70)                1.008          estimate D2E/DX2                !
+ ! R64   R(36,37)                1.4316         estimate D2E/DX2                !
+ ! R65   R(36,42)                1.3755         estimate D2E/DX2                !
+ ! R66   R(37,38)                1.3891         estimate D2E/DX2                !
+ ! R67   R(37,39)                1.3755         estimate D2E/DX2                !
+ ! R68   R(38,72)                1.008          estimate D2E/DX2                !
+ ! R69   R(39,40)                1.4188         estimate D2E/DX2                !
+ ! R70   R(39,59)                1.0859         estimate D2E/DX2                !
+ ! R71   R(40,41)                1.4306         estimate D2E/DX2                !
+ ! R72   R(40,46)                1.4165         estimate D2E/DX2                !
+ ! R73   R(41,42)                1.4188         estimate D2E/DX2                !
+ ! R74   R(41,43)                1.4165         estimate D2E/DX2                !
+ ! R75   R(42,60)                1.0859         estimate D2E/DX2                !
+ ! R76   R(43,44)                1.3765         estimate D2E/DX2                !
+ ! R77   R(43,61)                1.0853         estimate D2E/DX2                !
+ ! R78   R(44,45)                1.4116         estimate D2E/DX2                !
+ ! R79   R(44,62)                1.0841         estimate D2E/DX2                !
+ ! R80   R(45,46)                1.3765         estimate D2E/DX2                !
+ ! R81   R(45,63)                1.0841         estimate D2E/DX2                !
+ ! R82   R(46,64)                1.0853         estimate D2E/DX2                !
+ ! A1    A(2,1,3)              120.2132         estimate D2E/DX2                !
+ ! A2    A(2,1,47)             119.743          estimate D2E/DX2                !
+ ! A3    A(3,1,47)             120.0437         estimate D2E/DX2                !
+ ! A4    A(1,2,6)              120.2132         estimate D2E/DX2                !
+ ! A5    A(1,2,48)             119.743          estimate D2E/DX2                !
+ ! A6    A(6,2,48)             120.0438         estimate D2E/DX2                !
+ ! A7    A(1,3,4)              120.9505         estimate D2E/DX2                !
+ ! A8    A(1,3,49)             120.2377         estimate D2E/DX2                !
+ ! A9    A(4,3,49)             118.8118         estimate D2E/DX2                !
+ ! A10   A(3,4,5)              118.8363         estimate D2E/DX2                !
+ ! A11   A(3,4,10)             122.394          estimate D2E/DX2                !
+ ! A12   A(5,4,10)             118.7697         estimate D2E/DX2                !
+ ! A13   A(4,5,6)              118.8363         estimate D2E/DX2                !
+ ! A14   A(4,5,7)              118.7697         estimate D2E/DX2                !
+ ! A15   A(6,5,7)              122.394          estimate D2E/DX2                !
+ ! A16   A(2,6,5)              120.9505         estimate D2E/DX2                !
+ ! A17   A(2,6,50)             120.2377         estimate D2E/DX2                !
+ ! A18   A(5,6,50)             118.8118         estimate D2E/DX2                !
+ ! A19   A(5,7,8)              121.4905         estimate D2E/DX2                !
+ ! A20   A(5,7,51)             119.0605         estimate D2E/DX2                !
+ ! A21   A(8,7,51)             119.4491         estimate D2E/DX2                !
+ ! A22   A(7,8,9)              119.7399         estimate D2E/DX2                !
+ ! A23   A(7,8,14)             122.5558         estimate D2E/DX2                !
+ ! A24   A(9,8,14)             117.7043         estimate D2E/DX2                !
+ ! A25   A(8,9,10)             119.7398         estimate D2E/DX2                !
+ ! A26   A(8,9,11)             117.7044         estimate D2E/DX2                !
+ ! A27   A(10,9,11)            122.5558         estimate D2E/DX2                !
+ ! A28   A(4,10,9)             121.4905         estimate D2E/DX2                !
+ ! A29   A(4,10,52)            119.0604         estimate D2E/DX2                !
+ ! A30   A(9,10,52)            119.4491         estimate D2E/DX2                !
+ ! A31   A(9,11,12)            124.9683         estimate D2E/DX2                !
+ ! A32   A(9,11,69)            117.571          estimate D2E/DX2                !
+ ! A33   A(12,11,69)           117.4607         estimate D2E/DX2                !
+ ! A34   A(11,12,13)           117.3274         estimate D2E/DX2                !
+ ! A35   A(11,12,18)           122.7789         estimate D2E/DX2                !
+ ! A36   A(13,12,18)           119.8937         estimate D2E/DX2                !
+ ! A37   A(12,13,14)           117.3274         estimate D2E/DX2                !
+ ! A38   A(12,13,15)           119.8938         estimate D2E/DX2                !
+ ! A39   A(14,13,15)           122.7789         estimate D2E/DX2                !
+ ! A40   A(8,14,13)            124.9683         estimate D2E/DX2                !
+ ! A41   A(8,14,71)            117.571          estimate D2E/DX2                !
+ ! A42   A(13,14,71)           117.4607         estimate D2E/DX2                !
+ ! A43   A(13,15,16)           121.8243         estimate D2E/DX2                !
+ ! A44   A(13,15,53)           119.5334         estimate D2E/DX2                !
+ ! A45   A(16,15,53)           118.6422         estimate D2E/DX2                !
+ ! A46   A(15,16,17)           118.2819         estimate D2E/DX2                !
+ ! A47   A(15,16,22)           122.4351         estimate D2E/DX2                !
+ ! A48   A(17,16,22)           119.283          estimate D2E/DX2                !
+ ! A49   A(16,17,18)           118.2819         estimate D2E/DX2                !
+ ! A50   A(16,17,19)           119.2829         estimate D2E/DX2                !
+ ! A51   A(18,17,19)           122.4351         estimate D2E/DX2                !
+ ! A52   A(12,18,17)           121.8243         estimate D2E/DX2                !
+ ! A53   A(12,18,54)           119.5334         estimate D2E/DX2                !
+ ! A54   A(17,18,54)           118.6423         estimate D2E/DX2                !
+ ! A55   A(17,19,20)           122.1065         estimate D2E/DX2                !
+ ! A56   A(17,19,65)           119.3165         estimate D2E/DX2                !
+ ! A57   A(20,19,65)           118.577          estimate D2E/DX2                !
+ ! A58   A(19,20,21)           118.6106         estimate D2E/DX2                !
+ ! A59   A(19,20,26)           122.4356         estimate D2E/DX2                !
+ ! A60   A(21,20,26)           118.9538         estimate D2E/DX2                !
+ ! A61   A(20,21,22)           118.6106         estimate D2E/DX2                !
+ ! A62   A(20,21,23)           118.9539         estimate D2E/DX2                !
+ ! A63   A(22,21,23)           122.4355         estimate D2E/DX2                !
+ ! A64   A(16,22,21)           122.1064         estimate D2E/DX2                !
+ ! A65   A(16,22,55)           119.3165         estimate D2E/DX2                !
+ ! A66   A(21,22,55)           118.5771         estimate D2E/DX2                !
+ ! A67   A(21,23,24)           122.0923         estimate D2E/DX2                !
+ ! A68   A(21,23,67)           118.9539         estimate D2E/DX2                !
+ ! A69   A(24,23,67)           118.9538         estimate D2E/DX2                !
+ ! A70   A(23,24,25)           118.9539         estimate D2E/DX2                !
+ ! A71   A(23,24,30)           122.4356         estimate D2E/DX2                !
+ ! A72   A(25,24,30)           118.6106         estimate D2E/DX2                !
+ ! A73   A(24,25,26)           118.9538         estimate D2E/DX2                !
+ ! A74   A(24,25,27)           118.6106         estimate D2E/DX2                !
+ ! A75   A(26,25,27)           122.4356         estimate D2E/DX2                !
+ ! A76   A(20,26,25)           122.0923         estimate D2E/DX2                !
+ ! A77   A(20,26,56)           118.9539         estimate D2E/DX2                !
+ ! A78   A(25,26,56)           118.9538         estimate D2E/DX2                !
+ ! A79   A(25,27,28)           122.1065         estimate D2E/DX2                !
+ ! A80   A(25,27,66)           118.5771         estimate D2E/DX2                !
+ ! A81   A(28,27,66)           119.3164         estimate D2E/DX2                !
+ ! A82   A(27,28,29)           119.283          estimate D2E/DX2                !
+ ! A83   A(27,28,34)           122.4352         estimate D2E/DX2                !
+ ! A84   A(29,28,34)           118.2819         estimate D2E/DX2                !
+ ! A85   A(28,29,30)           119.2829         estimate D2E/DX2                !
+ ! A86   A(28,29,31)           118.2819         estimate D2E/DX2                !
+ ! A87   A(30,29,31)           122.4351         estimate D2E/DX2                !
+ ! A88   A(24,30,29)           122.1064         estimate D2E/DX2                !
+ ! A89   A(24,30,57)           118.5771         estimate D2E/DX2                !
+ ! A90   A(29,30,57)           119.3164         estimate D2E/DX2                !
+ ! A91   A(29,31,32)           121.8243         estimate D2E/DX2                !
+ ! A92   A(29,31,68)           118.6423         estimate D2E/DX2                !
+ ! A93   A(32,31,68)           119.5334         estimate D2E/DX2                !
+ ! A94   A(31,32,33)           119.8937         estimate D2E/DX2                !
+ ! A95   A(31,32,38)           122.7789         estimate D2E/DX2                !
+ ! A96   A(33,32,38)           117.3274         estimate D2E/DX2                !
+ ! A97   A(32,33,34)           119.8938         estimate D2E/DX2                !
+ ! A98   A(32,33,35)           117.3273         estimate D2E/DX2                !
+ ! A99   A(34,33,35)           122.7789         estimate D2E/DX2                !
+ ! A100  A(28,34,33)           121.8243         estimate D2E/DX2                !
+ ! A101  A(28,34,58)           118.6422         estimate D2E/DX2                !
+ ! A102  A(33,34,58)           119.5334         estimate D2E/DX2                !
+ ! A103  A(33,35,36)           124.9683         estimate D2E/DX2                !
+ ! A104  A(33,35,70)           117.4607         estimate D2E/DX2                !
+ ! A105  A(36,35,70)           117.571          estimate D2E/DX2                !
+ ! A106  A(35,36,37)           117.7044         estimate D2E/DX2                !
+ ! A107  A(35,36,42)           122.5559         estimate D2E/DX2                !
+ ! A108  A(37,36,42)           119.7398         estimate D2E/DX2                !
+ ! A109  A(36,37,38)           117.7043         estimate D2E/DX2                !
+ ! A110  A(36,37,39)           119.7398         estimate D2E/DX2                !
+ ! A111  A(38,37,39)           122.5559         estimate D2E/DX2                !
+ ! A112  A(32,38,37)           124.9683         estimate D2E/DX2                !
+ ! A113  A(32,38,72)           117.4607         estimate D2E/DX2                !
+ ! A114  A(37,38,72)           117.571          estimate D2E/DX2                !
+ ! A115  A(37,39,40)           121.4905         estimate D2E/DX2                !
+ ! A116  A(37,39,59)           119.449          estimate D2E/DX2                !
+ ! A117  A(40,39,59)           119.0605         estimate D2E/DX2                !
+ ! A118  A(39,40,41)           118.7697         estimate D2E/DX2                !
+ ! A119  A(39,40,46)           122.3941         estimate D2E/DX2                !
+ ! A120  A(41,40,46)           118.8362         estimate D2E/DX2                !
+ ! A121  A(40,41,42)           118.7696         estimate D2E/DX2                !
+ ! A122  A(40,41,43)           118.8363         estimate D2E/DX2                !
+ ! A123  A(42,41,43)           122.3941         estimate D2E/DX2                !
+ ! A124  A(36,42,41)           121.4906         estimate D2E/DX2                !
+ ! A125  A(36,42,60)           119.449          estimate D2E/DX2                !
+ ! A126  A(41,42,60)           119.0604         estimate D2E/DX2                !
+ ! A127  A(41,43,44)           120.9505         estimate D2E/DX2                !
+ ! A128  A(41,43,61)           118.8118         estimate D2E/DX2                !
+ ! A129  A(44,43,61)           120.2377         estimate D2E/DX2                !
+ ! A130  A(43,44,45)           120.2132         estimate D2E/DX2                !
+ ! A131  A(43,44,62)           120.0437         estimate D2E/DX2                !
+ ! A132  A(45,44,62)           119.7431         estimate D2E/DX2                !
+ ! A133  A(44,45,46)           120.2132         estimate D2E/DX2                !
+ ! A134  A(44,45,63)           119.7429         estimate D2E/DX2                !
+ ! A135  A(46,45,63)           120.0438         estimate D2E/DX2                !
+ ! A136  A(40,46,45)           120.9505         estimate D2E/DX2                !
+ ! A137  A(40,46,64)           118.8118         estimate D2E/DX2                !
+ ! A138  A(45,46,64)           120.2377         estimate D2E/DX2                !
+ ! D1    D(3,1,2,6)              0.0            estimate D2E/DX2                !
+ ! D2    D(3,1,2,48)          -179.9999         estimate D2E/DX2                !
+ ! D3    D(47,1,2,6)           180.0            estimate D2E/DX2                !
+ ! D4    D(47,1,2,48)            0.0            estimate D2E/DX2                !
+ ! D5    D(2,1,3,4)             -0.0001         estimate D2E/DX2                !
+ ! D6    D(2,1,3,49)          -180.0            estimate D2E/DX2                !
+ ! D7    D(47,1,3,4)           180.0            estimate D2E/DX2                !
+ ! D8    D(47,1,3,49)            0.0001         estimate D2E/DX2                !
+ ! D9    D(1,2,6,5)              0.0            estimate D2E/DX2                !
+ ! D10   D(1,2,6,50)           179.9999         estimate D2E/DX2                !
+ ! D11   D(48,2,6,5)          -180.0            estimate D2E/DX2                !
+ ! D12   D(48,2,6,50)           -0.0001         estimate D2E/DX2                !
+ ! D13   D(1,3,4,5)              0.0            estimate D2E/DX2                !
+ ! D14   D(1,3,4,10)          -179.9997         estimate D2E/DX2                !
+ ! D15   D(49,3,4,5)           180.0            estimate D2E/DX2                !
+ ! D16   D(49,3,4,10)            0.0002         estimate D2E/DX2                !
+ ! D17   D(3,4,5,6)              0.0            estimate D2E/DX2                !
+ ! D18   D(3,4,5,7)           -179.9999         estimate D2E/DX2                !
+ ! D19   D(10,4,5,6)           179.9998         estimate D2E/DX2                !
+ ! D20   D(10,4,5,7)            -0.0001         estimate D2E/DX2                !
+ ! D21   D(3,4,10,9)          -179.9997         estimate D2E/DX2                !
+ ! D22   D(3,4,10,52)            0.0            estimate D2E/DX2                !
+ ! D23   D(5,4,10,9)             0.0005         estimate D2E/DX2                !
+ ! D24   D(5,4,10,52)         -179.9998         estimate D2E/DX2                !
+ ! D25   D(4,5,6,2)             -0.0001         estimate D2E/DX2                !
+ ! D26   D(4,5,6,50)          -180.0            estimate D2E/DX2                !
+ ! D27   D(7,5,6,2)            179.9998         estimate D2E/DX2                !
+ ! D28   D(7,5,6,50)             0.0            estimate D2E/DX2                !
+ ! D29   D(4,5,7,8)             -0.0003         estimate D2E/DX2                !
+ ! D30   D(4,5,7,51)           179.9999         estimate D2E/DX2                !
+ ! D31   D(6,5,7,8)            179.9997         estimate D2E/DX2                !
+ ! D32   D(6,5,7,51)            -0.0001         estimate D2E/DX2                !
+ ! D33   D(5,7,8,9)              0.0004         estimate D2E/DX2                !
+ ! D34   D(5,7,8,14)          -179.9985         estimate D2E/DX2                !
+ ! D35   D(51,7,8,9)          -179.9998         estimate D2E/DX2                !
+ ! D36   D(51,7,8,14)            0.0013         estimate D2E/DX2                !
+ ! D37   D(7,8,9,10)             0.0            estimate D2E/DX2                !
+ ! D38   D(7,8,9,11)          -179.999          estimate D2E/DX2                !
+ ! D39   D(14,8,9,10)          179.9989         estimate D2E/DX2                !
+ ! D40   D(14,8,9,11)           -0.0001         estimate D2E/DX2                !
+ ! D41   D(7,8,14,13)         -179.9898         estimate D2E/DX2                !
+ ! D42   D(7,8,14,71)           -0.0046         estimate D2E/DX2                !
+ ! D43   D(9,8,14,13)            0.0113         estimate D2E/DX2                !
+ ! D44   D(9,8,14,71)          179.9966         estimate D2E/DX2                !
+ ! D45   D(8,9,10,4)            -0.0004         estimate D2E/DX2                !
+ ! D46   D(8,9,10,52)          179.9998         estimate D2E/DX2                !
+ ! D47   D(11,9,10,4)          179.9985         estimate D2E/DX2                !
+ ! D48   D(11,9,10,52)          -0.0012         estimate D2E/DX2                !
+ ! D49   D(8,9,11,12)           -0.011          estimate D2E/DX2                !
+ ! D50   D(8,9,11,69)         -179.998          estimate D2E/DX2                !
+ ! D51   D(10,9,11,12)         179.99           estimate D2E/DX2                !
+ ! D52   D(10,9,11,69)           0.003          estimate D2E/DX2                !
+ ! D53   D(9,11,12,13)           0.011          estimate D2E/DX2                !
+ ! D54   D(9,11,12,18)        -179.99           estimate D2E/DX2                !
+ ! D55   D(69,11,12,13)        179.998          estimate D2E/DX2                !
+ ! D56   D(69,11,12,18)         -0.0029         estimate D2E/DX2                !
+ ! D57   D(11,12,13,14)          0.0001         estimate D2E/DX2                !
+ ! D58   D(11,12,13,15)        179.9991         estimate D2E/DX2                !
+ ! D59   D(18,12,13,14)       -179.9989         estimate D2E/DX2                !
+ ! D60   D(18,12,13,15)          0.0            estimate D2E/DX2                !
+ ! D61   D(11,12,18,17)       -179.9985         estimate D2E/DX2                !
+ ! D62   D(11,12,18,54)          0.0013         estimate D2E/DX2                !
+ ! D63   D(13,12,18,17)          0.0005         estimate D2E/DX2                !
+ ! D64   D(13,12,18,54)       -179.9997         estimate D2E/DX2                !
+ ! D65   D(12,13,14,8)          -0.0113         estimate D2E/DX2                !
+ ! D66   D(12,13,14,71)       -179.9965         estimate D2E/DX2                !
+ ! D67   D(15,13,14,8)         179.9898         estimate D2E/DX2                !
+ ! D68   D(15,13,14,71)          0.0046         estimate D2E/DX2                !
+ ! D69   D(12,13,15,16)         -0.0005         estimate D2E/DX2                !
+ ! D70   D(12,13,15,53)        179.9999         estimate D2E/DX2                !
+ ! D71   D(14,13,15,16)        179.9984         estimate D2E/DX2                !
+ ! D72   D(14,13,15,53)         -0.0012         estimate D2E/DX2                !
+ ! D73   D(13,15,16,17)          0.0005         estimate D2E/DX2                !
+ ! D74   D(13,15,16,22)       -179.9997         estimate D2E/DX2                !
+ ! D75   D(53,15,16,17)       -179.9999         estimate D2E/DX2                !
+ ! D76   D(53,15,16,22)         -0.0001         estimate D2E/DX2                !
+ ! D77   D(15,16,17,18)          0.0            estimate D2E/DX2                !
+ ! D78   D(15,16,17,19)        179.9999         estimate D2E/DX2                !
+ ! D79   D(22,16,17,18)       -179.9998         estimate D2E/DX2                !
+ ! D80   D(22,16,17,19)          0.0            estimate D2E/DX2                !
+ ! D81   D(15,16,22,21)       -179.9998         estimate D2E/DX2                !
+ ! D82   D(15,16,22,55)          0.0002         estimate D2E/DX2                !
+ ! D83   D(17,16,22,21)          0.0            estimate D2E/DX2                !
+ ! D84   D(17,16,22,55)        180.0            estimate D2E/DX2                !
+ ! D85   D(16,17,18,12)         -0.0005         estimate D2E/DX2                !
+ ! D86   D(16,17,18,54)        179.9997         estimate D2E/DX2                !
+ ! D87   D(19,17,18,12)        179.9997         estimate D2E/DX2                !
+ ! D88   D(19,17,18,54)         -0.0002         estimate D2E/DX2                !
+ ! D89   D(16,17,19,20)         -0.0001         estimate D2E/DX2                !
+ ! D90   D(16,17,19,65)       -179.9999         estimate D2E/DX2                !
+ ! D91   D(18,17,19,20)        179.9998         estimate D2E/DX2                !
+ ! D92   D(18,17,19,65)         -0.0001         estimate D2E/DX2                !
+ ! D93   D(17,19,20,21)          0.0001         estimate D2E/DX2                !
+ ! D94   D(17,19,20,26)       -179.9999         estimate D2E/DX2                !
+ ! D95   D(65,19,20,21)        179.9999         estimate D2E/DX2                !
+ ! D96   D(65,19,20,26)         -0.0001         estimate D2E/DX2                !
+ ! D97   D(19,20,21,22)          0.0            estimate D2E/DX2                !
+ ! D98   D(19,20,21,23)        180.0            estimate D2E/DX2                !
+ ! D99   D(26,20,21,22)        180.0            estimate D2E/DX2                !
+ ! D100  D(26,20,21,23)          0.0            estimate D2E/DX2                !
+ ! D101  D(19,20,26,25)        180.0            estimate D2E/DX2                !
+ ! D102  D(19,20,26,56)          0.0            estimate D2E/DX2                !
+ ! D103  D(21,20,26,25)          0.0            estimate D2E/DX2                !
+ ! D104  D(21,20,26,56)        180.0            estimate D2E/DX2                !
+ ! D105  D(20,21,22,16)          0.0            estimate D2E/DX2                !
+ ! D106  D(20,21,22,55)        180.0            estimate D2E/DX2                !
+ ! D107  D(23,21,22,16)        180.0            estimate D2E/DX2                !
+ ! D108  D(23,21,22,55)          0.0            estimate D2E/DX2                !
+ ! D109  D(20,21,23,24)          0.0            estimate D2E/DX2                !
+ ! D110  D(20,21,23,67)        180.0            estimate D2E/DX2                !
+ ! D111  D(22,21,23,24)       -180.0            estimate D2E/DX2                !
+ ! D112  D(22,21,23,67)          0.0            estimate D2E/DX2                !
+ ! D113  D(21,23,24,25)          0.0            estimate D2E/DX2                !
+ ! D114  D(21,23,24,30)        180.0            estimate D2E/DX2                !
+ ! D115  D(67,23,24,25)        180.0            estimate D2E/DX2                !
+ ! D116  D(67,23,24,30)          0.0            estimate D2E/DX2                !
+ ! D117  D(23,24,25,26)          0.0            estimate D2E/DX2                !
+ ! D118  D(23,24,25,27)        180.0            estimate D2E/DX2                !
+ ! D119  D(30,24,25,26)        180.0            estimate D2E/DX2                !
+ ! D120  D(30,24,25,27)          0.0            estimate D2E/DX2                !
+ ! D121  D(23,24,30,29)       -179.9999         estimate D2E/DX2                !
+ ! D122  D(23,24,30,57)         -0.0001         estimate D2E/DX2                !
+ ! D123  D(25,24,30,29)          0.0001         estimate D2E/DX2                !
+ ! D124  D(25,24,30,57)        179.9999         estimate D2E/DX2                !
+ ! D125  D(24,25,26,20)          0.0            estimate D2E/DX2                !
+ ! D126  D(24,25,26,56)        180.0            estimate D2E/DX2                !
+ ! D127  D(27,25,26,20)       -180.0            estimate D2E/DX2                !
+ ! D128  D(27,25,26,56)          0.0            estimate D2E/DX2                !
+ ! D129  D(24,25,27,28)          0.0            estimate D2E/DX2                !
+ ! D130  D(24,25,27,66)        180.0            estimate D2E/DX2                !
+ ! D131  D(26,25,27,28)        180.0            estimate D2E/DX2                !
+ ! D132  D(26,25,27,66)          0.0            estimate D2E/DX2                !
+ ! D133  D(25,27,28,29)          0.0            estimate D2E/DX2                !
+ ! D134  D(25,27,28,34)       -179.9998         estimate D2E/DX2                !
+ ! D135  D(66,27,28,29)        180.0            estimate D2E/DX2                !
+ ! D136  D(66,27,28,34)          0.0002         estimate D2E/DX2                !
+ ! D137  D(27,28,29,30)          0.0            estimate D2E/DX2                !
+ ! D138  D(27,28,29,31)       -179.9998         estimate D2E/DX2                !
+ ! D139  D(34,28,29,30)        179.9999         estimate D2E/DX2                !
+ ! D140  D(34,28,29,31)          0.0            estimate D2E/DX2                !
+ ! D141  D(27,28,34,33)       -179.9997         estimate D2E/DX2                !
+ ! D142  D(27,28,34,58)         -0.0001         estimate D2E/DX2                !
+ ! D143  D(29,28,34,33)          0.0005         estimate D2E/DX2                !
+ ! D144  D(29,28,34,58)       -179.9999         estimate D2E/DX2                !
+ ! D145  D(28,29,30,24)         -0.0001         estimate D2E/DX2                !
+ ! D146  D(28,29,30,57)       -179.9999         estimate D2E/DX2                !
+ ! D147  D(31,29,30,24)        179.9998         estimate D2E/DX2                !
+ ! D148  D(31,29,30,57)         -0.0001         estimate D2E/DX2                !
+ ! D149  D(28,29,31,32)         -0.0005         estimate D2E/DX2                !
+ ! D150  D(28,29,31,68)        179.9997         estimate D2E/DX2                !
+ ! D151  D(30,29,31,32)        179.9997         estimate D2E/DX2                !
+ ! D152  D(30,29,31,68)         -0.0002         estimate D2E/DX2                !
+ ! D153  D(29,31,32,33)          0.0005         estimate D2E/DX2                !
+ ! D154  D(29,31,32,38)       -179.9985         estimate D2E/DX2                !
+ ! D155  D(68,31,32,33)       -179.9997         estimate D2E/DX2                !
+ ! D156  D(68,31,32,38)          0.0013         estimate D2E/DX2                !
+ ! D157  D(31,32,33,34)          0.0            estimate D2E/DX2                !
+ ! D158  D(31,32,33,35)       -179.9989         estimate D2E/DX2                !
+ ! D159  D(38,32,33,34)        179.9991         estimate D2E/DX2                !
+ ! D160  D(38,32,33,35)          0.0001         estimate D2E/DX2                !
+ ! D161  D(31,32,38,37)       -179.99           estimate D2E/DX2                !
+ ! D162  D(31,32,38,72)         -0.0029         estimate D2E/DX2                !
+ ! D163  D(33,32,38,37)          0.011          estimate D2E/DX2                !
+ ! D164  D(33,32,38,72)        179.998          estimate D2E/DX2                !
+ ! D165  D(32,33,34,28)         -0.0005         estimate D2E/DX2                !
+ ! D166  D(32,33,34,58)        179.9999         estimate D2E/DX2                !
+ ! D167  D(35,33,34,28)        179.9984         estimate D2E/DX2                !
+ ! D168  D(35,33,34,58)         -0.0012         estimate D2E/DX2                !
+ ! D169  D(32,33,35,36)         -0.0113         estimate D2E/DX2                !
+ ! D170  D(32,33,35,70)       -179.9965         estimate D2E/DX2                !
+ ! D171  D(34,33,35,36)        179.9898         estimate D2E/DX2                !
+ ! D172  D(34,33,35,70)          0.0046         estimate D2E/DX2                !
+ ! D173  D(33,35,36,37)          0.0113         estimate D2E/DX2                !
+ ! D174  D(33,35,36,42)       -179.9898         estimate D2E/DX2                !
+ ! D175  D(70,35,36,37)        179.9966         estimate D2E/DX2                !
+ ! D176  D(70,35,36,42)         -0.0046         estimate D2E/DX2                !
+ ! D177  D(35,36,37,38)         -0.0001         estimate D2E/DX2                !
+ ! D178  D(35,36,37,39)        179.9989         estimate D2E/DX2                !
+ ! D179  D(42,36,37,38)       -179.999          estimate D2E/DX2                !
+ ! D180  D(42,36,37,39)          0.0            estimate D2E/DX2                !
+ ! D181  D(35,36,42,41)       -179.9985         estimate D2E/DX2                !
+ ! D182  D(35,36,42,60)          0.0013         estimate D2E/DX2                !
+ ! D183  D(37,36,42,41)          0.0004         estimate D2E/DX2                !
+ ! D184  D(37,36,42,60)       -179.9998         estimate D2E/DX2                !
+ ! D185  D(36,37,38,32)         -0.011          estimate D2E/DX2                !
+ ! D186  D(36,37,38,72)       -179.998          estimate D2E/DX2                !
+ ! D187  D(39,37,38,32)        179.99           estimate D2E/DX2                !
+ ! D188  D(39,37,38,72)          0.003          estimate D2E/DX2                !
+ ! D189  D(36,37,39,40)         -0.0004         estimate D2E/DX2                !
+ ! D190  D(36,37,39,59)        179.9998         estimate D2E/DX2                !
+ ! D191  D(38,37,39,40)        179.9985         estimate D2E/DX2                !
+ ! D192  D(38,37,39,59)         -0.0012         estimate D2E/DX2                !
+ ! D193  D(37,39,40,41)          0.0005         estimate D2E/DX2                !
+ ! D194  D(37,39,40,46)       -179.9997         estimate D2E/DX2                !
+ ! D195  D(59,39,40,41)       -179.9998         estimate D2E/DX2                !
+ ! D196  D(59,39,40,46)          0.0            estimate D2E/DX2                !
+ ! D197  D(39,40,41,42)         -0.0001         estimate D2E/DX2                !
+ ! D198  D(39,40,41,43)        179.9998         estimate D2E/DX2                !
+ ! D199  D(46,40,41,42)       -179.9999         estimate D2E/DX2                !
+ ! D200  D(46,40,41,43)          0.0            estimate D2E/DX2                !
+ ! D201  D(39,40,46,45)       -179.9997         estimate D2E/DX2                !
+ ! D202  D(39,40,46,64)          0.0002         estimate D2E/DX2                !
+ ! D203  D(41,40,46,45)          0.0            estimate D2E/DX2                !
+ ! D204  D(41,40,46,64)        180.0            estimate D2E/DX2                !
+ ! D205  D(40,41,42,36)         -0.0003         estimate D2E/DX2                !
+ ! D206  D(40,41,42,60)        179.9999         estimate D2E/DX2                !
+ ! D207  D(43,41,42,36)        179.9997         estimate D2E/DX2                !
+ ! D208  D(43,41,42,60)         -0.0001         estimate D2E/DX2                !
+ ! D209  D(40,41,43,44)         -0.0001         estimate D2E/DX2                !
+ ! D210  D(40,41,43,61)       -180.0            estimate D2E/DX2                !
+ ! D211  D(42,41,43,44)        179.9998         estimate D2E/DX2                !
+ ! D212  D(42,41,43,61)          0.0            estimate D2E/DX2                !
+ ! D213  D(41,43,44,45)          0.0            estimate D2E/DX2                !
+ ! D214  D(41,43,44,62)       -180.0            estimate D2E/DX2                !
+ ! D215  D(61,43,44,45)        179.9999         estimate D2E/DX2                !
+ ! D216  D(61,43,44,62)         -0.0001         estimate D2E/DX2                !
+ ! D217  D(43,44,45,46)          0.0            estimate D2E/DX2                !
+ ! D218  D(43,44,45,63)        180.0            estimate D2E/DX2                !
+ ! D219  D(62,44,45,46)       -179.9999         estimate D2E/DX2                !
+ ! D220  D(62,44,45,63)          0.0            estimate D2E/DX2                !
+ ! D221  D(44,45,46,40)         -0.0001         estimate D2E/DX2                !
+ ! D222  D(44,45,46,64)       -180.0            estimate D2E/DX2                !
+ ! D223  D(63,45,46,40)        180.0            estimate D2E/DX2                !
+ ! D224  D(63,45,46,64)          0.0001         estimate D2E/DX2                !
+ --------------------------------------------------------------------------------
+ Trust Radius=3.00D-01 FncErr=1.00D-07 GrdErr=1.00D-06
+ Number of steps in this run=    432 maximum allowed number of steps=    432.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Tue Aug  4 10:38:18 2020, MaxMem=    33554432 cpu:         0.0
+ (Enter /cluster/apps/gaussian/g09/l202.exe)
+ Stoichiometry    C42H26N4
+ Framework group  C2[X(C42H26N4)]
+ Deg. of freedom   106
+ Full point group                 C2      NOp   2
+ Largest Abelian subgroup         C2      NOp   2
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0        0.705793   13.451571    0.000611
+      2          6           0       -0.705795   13.451570    0.000611
+      3          6           0        1.398477   12.262053    0.000448
+      4          6           0        0.715286   11.021197    0.000280
+      5          6           0       -0.715287   11.021196    0.000281
+      6          6           0       -1.398477   12.262053    0.000449
+      7          6           0       -1.398143    9.777526    0.000115
+      8          6           0       -0.715815    8.583208   -0.000052
+      9          6           0        0.715814    8.583208   -0.000052
+     10          6           0        1.398143    9.777526    0.000115
+     11          7           0        1.361636    7.353327   -0.000245
+     12          6           0        0.724320    6.119996   -0.000220
+     13          6           0       -0.724320    6.119995   -0.000220
+     14          7           0       -1.361636    7.353327   -0.000248
+     15          6           0       -1.404984    4.935984   -0.000215
+     16          6           0       -0.726649    3.675225   -0.000220
+     17          6           0        0.726649    3.675226   -0.000220
+     18          6           0        1.404985    4.935984   -0.000215
+     19          6           0        1.403978    2.467398   -0.000222
+     20          6           0        0.726346    1.225079   -0.000222
+     21          6           0       -0.726346    1.225078   -0.000222
+     22          6           0       -1.403978    2.467397   -0.000221
+     23          6           0       -1.404128    0.000000   -0.000222
+     24          6           0       -0.726346   -1.225079   -0.000222
+     25          6           0        0.726346   -1.225078   -0.000222
+     26          6           0        1.404128    0.000000   -0.000222
+     27          6           0        1.403978   -2.467397   -0.000221
+     28          6           0        0.726649   -3.675225   -0.000220
+     29          6           0       -0.726649   -3.675226   -0.000220
+     30          6           0       -1.403978   -2.467398   -0.000222
+     31          6           0       -1.404985   -4.935984   -0.000215
+     32          6           0       -0.724320   -6.119996   -0.000220
+     33          6           0        0.724320   -6.119995   -0.000220
+     34          6           0        1.404984   -4.935984   -0.000215
+     35          7           0        1.361636   -7.353327   -0.000248
+     36          6           0        0.715815   -8.583208   -0.000052
+     37          6           0       -0.715814   -8.583208   -0.000052
+     38          7           0       -1.361636   -7.353327   -0.000245
+     39          6           0       -1.398143   -9.777526    0.000115
+     40          6           0       -0.715286  -11.021197    0.000280
+     41          6           0        0.715287  -11.021196    0.000281
+     42          6           0        1.398143   -9.777526    0.000115
+     43          6           0        1.398477  -12.262053    0.000449
+     44          6           0        0.705795  -13.451570    0.000611
+     45          6           0       -0.705793  -13.451571    0.000611
+     46          6           0       -1.398477  -12.262053    0.000448
+     47          1           0        1.243646   14.392883    0.000739
+     48          1           0       -1.243646   14.392882    0.000739
+     49          1           0        2.483798   12.261590    0.000448
+     50          1           0       -2.483798   12.261590    0.000450
+     51          1           0       -2.483986    9.772016    0.000117
+     52          1           0        2.483986    9.772016    0.000117
+     53          1           0       -2.490738    4.942813   -0.000213
+     54          1           0        2.490739    4.942813   -0.000210
+     55          1           0       -2.489920    2.466763   -0.000221
+     56          1           0        2.490136    0.000000   -0.000222
+     57          1           0       -2.489920   -2.466763   -0.000221
+     58          1           0        2.490738   -4.942813   -0.000213
+     59          1           0       -2.483986   -9.772016    0.000117
+     60          1           0        2.483986   -9.772016    0.000117
+     61          1           0        2.483798  -12.261590    0.000450
+     62          1           0        1.243646  -14.392882    0.000739
+     63          1           0       -1.243646  -14.392883    0.000739
+     64          1           0       -2.483798  -12.261590    0.000448
+     65          1           0        2.489920    2.466763   -0.000221
+     66          1           0        2.489920   -2.466763   -0.000221
+     67          1           0       -2.490136    0.000000   -0.000222
+     68          1           0       -2.490739   -4.942813   -0.000210
+     69          1           0        2.369590    7.355674   -0.000214
+     70          1           0        2.369591   -7.355673   -0.000194
+     71          1           0       -2.369591    7.355673   -0.000194
+     72          1           0       -2.369590   -7.355674   -0.000214
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      0.6176181      0.0129472      0.0126814
+ Leave Link  202 at Tue Aug  4 10:38:18 2020, MaxMem=    33554432 cpu:         0.0
+ (Enter /cluster/apps/gaussian/g09/l301.exe)
+ Standard basis: STO-3G (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are   128 symmetry adapted cartesian basis functions of A   symmetry.
+ There are   128 symmetry adapted cartesian basis functions of B   symmetry.
+ There are   128 symmetry adapted basis functions of A   symmetry.
+ There are   128 symmetry adapted basis functions of B   symmetry.
+   256 basis functions,   768 primitive gaussians,   256 cartesian basis functions
+   153 alpha electrons      153 beta electrons
+       nuclear repulsion energy      4341.4528379089 Hartrees.
+ IExCor=  402 DFT=T Ex+Corr=B3LYP ExCW=0 ScaHFX=  0.200000
+ ScaDFX=  0.800000  0.720000  1.000000  0.810000 ScalE2=  1.000000  1.000000
+ IRadAn=      0 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=  4
+ NAtoms=   72 NActive=   72 NUniq=   36 SFac= 4.00D+00 NAtFMM=   60 NAOKFM=T Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ Leave Link  301 at Tue Aug  4 10:38:18 2020, MaxMem=    33554432 cpu:         0.0
+ (Enter /cluster/apps/gaussian/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+ One-electron integral symmetry used in STVInt
+ NBasis=   256 RedAO= T EigKep=  1.21D-01  NBF=   128   128
+ NBsUse=   256 1.00D-06 EigRej= -1.00D+00 NBFU=   128   128
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           0 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   218   218   218   218   218 MxSgAt=    72 MxSgA2=    71.
+ Leave Link  302 at Tue Aug  4 10:38:19 2020, MaxMem=    33554432 cpu:         1.2
+ (Enter /cluster/apps/gaussian/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Tue Aug  4 10:38:20 2020, MaxMem=    33554432 cpu:         0.0
+ (Enter /cluster/apps/gaussian/g09/l401.exe)
+ ExpMin= 1.69D-01 ExpMax= 9.91D+01 ExpMxC= 9.91D+01 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=        2000
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Harris En= -1811.88203540418    
+ JPrj=0 DoOrth=F DoCkMO=F.
+ Initial guess orbital symmetries:
+       Occupied  (B) (A) (A) (B) (B) (A) (B) (A) (B) (A) (B) (A)
+                 (B) (A) (B) (A) (A) (B) (A) (B) (B) (A) (A) (B)
+                 (B) (A) (A) (B) (A) (B) (A) (B) (B) (A) (B) (A)
+                 (B) (A) (B) (A) (B) (A) (B) (A) (B) (A) (A) (B)
+                 (A) (B) (A) (B) (A) (B) (A) (B) (A) (B) (B) (A)
+                 (B) (A) (A) (B) (B) (A) (B) (A) (A) (B) (B) (A)
+                 (A) (B) (A) (B) (B) (A) (A) (A) (B) (B) (A) (B)
+                 (A) (B) (A) (B) (A) (A) (B) (B) (B) (A) (A) (B)
+                 (B) (A) (A) (B) (B) (A) (A) (B) (A) (B) (B) (B)
+                 (A) (A) (B) (A) (A) (B) (B) (A) (A) (B) (B) (B)
+                 (A) (B) (A) (A) (A) (B) (B) (A) (B) (A) (B) (A)
+                 (A) (B) (A) (B) (B) (A) (B) (A) (A) (B) (B) (A)
+                 (A) (B) (B) (A) (B) (A) (B) (A) (B)
+       Virtual   (A) (B) (A) (A) (B) (B) (A) (A) (B) (A) (B) (B)
+                 (A) (A) (B) (A) (B) (A) (B) (A) (B) (B) (A) (B)
+                 (A) (B) (A) (A) (B) (A) (B) (B) (A) (B) (A) (B)
+                 (A) (A) (B) (B) (A) (B) (A) (A) (B) (A) (B) (A)
+                 (B) (A) (B) (B) (A) (A) (B) (A) (A) (B) (B) (B)
+                 (A) (A) (B) (B) (B) (A) (A) (A) (B) (A) (B) (B)
+                 (B) (A) (A) (A) (A) (B) (B) (B) (A) (B) (A) (B)
+                 (A) (B) (A) (A) (B) (A) (B) (A) (B) (A) (B) (A)
+                 (B) (A) (B) (A) (B) (B) (A)
+ The electronic state of the initial guess is 1-A.
+ Leave Link  401 at Tue Aug  4 10:38:21 2020, MaxMem=    33554432 cpu:         1.5
+ (Enter /cluster/apps/gaussian/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=    10.
+ Integral symmetry usage will be decided dynamically.
+ IVT=     4406646 IEndB=     4406646 NGot=    33554432 MDV=    33411979
+ LenX=    33411979 LenY=    33346002
+ Requested convergence on RMS density matrix=1.00D-07 within2048 cycles.
+ Requested convergence on MAX density matrix=1.00D-05.
+ Requested convergence on             energy=1.00D-05.
+ Level shift goal  0.100 maximum shift  0.100.
+ No special actions if energy rises.
+ Fock matrices will be formed incrementally for  20 cycles.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+
+ Cycle   1  Pass 0  IDiag  1:
+ FoFJK:  IHMeth= 1 ICntrl=       0 DoSepK=F KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf= 400000000 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=        2000
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=       0 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ E= -1812.13185104053    
+ DIIS: error= 5.28D-02 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -1812.13185104053     IErMin= 1 ErrMin= 5.28D-02
+ ErrMax= 5.28D-02  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.76D-01 BMatP= 2.76D-01
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.149 Goal=     0.100 Shift=    0.000
+ GapD=    0.149 DampG=1.000 DampE=0.500 DampFc=0.5000 IDamp=-1.
+ Damping current iteration by 5.00D-01
+ RMSDP=8.70D-03 MaxDP=3.06D-01              OVMax= 0.00D+00
+
+ Cycle   2  Pass 0  IDiag  1:
+ RMSU=  4.34D-03    CP:  9.92D-01
+ E= -1812.16218301074     Delta-E=       -0.030331970212 Rises=F Damp=T
+ DIIS: error= 2.26D-02 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -1812.16218301074     IErMin= 2 ErrMin= 2.26D-02
+ ErrMax= 2.26D-02  0.00D+00 EMaxC= 1.00D+00 BMatC= 8.73D-02 BMatP= 2.76D-01
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.315D+00 0.685D+00
+ Coeff:      0.315D+00 0.685D+00
+ Gap=     0.136 Goal=     0.100 Shift=    0.000
+ GapD=    0.136 DampG=1.000 DampE=0.500 DampFc=0.5000 IDamp=-1.
+ Damping current iteration by 5.00D-01
+ RMSDP=2.76D-03 MaxDP=1.25D-01 DE=-3.03D-02 OVMax= 0.00D+00
+
+ Cycle   3  Pass 0  IDiag  1:
+ RMSU=  1.07D-03    CP:  9.95D-01  8.01D-01
+ E= -1812.38135152135     Delta-E=       -0.219168510614 Rises=F Damp=T
+ DIIS: error= 6.70D-03 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -1812.38135152135     IErMin= 3 ErrMin= 6.70D-03
+ ErrMax= 6.70D-03  0.00D+00 EMaxC= 1.00D+00 BMatC= 9.38D-03 BMatP= 8.73D-02
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.514D-01-0.287D+00 0.124D+01
+ Coeff:      0.514D-01-0.287D+00 0.124D+01
+ Gap=     0.093 Goal=     0.100 Shift=    0.007
+ GapD=    0.093 DampG=0.500 DampE=1.000 DampFc=0.5000 IDamp=-1.
+ Damping current iteration by 5.00D-01
+ RMSDP=9.44D-04 MaxDP=2.13D-02 DE=-2.19D-01 OVMax= 0.00D+00
+
+ Cycle   4  Pass 0  IDiag  1:
+ RMSU=  3.59D-04    CP:  9.96D-01  7.60D-01  1.23D+00
+ E= -1812.46601695786     Delta-E=       -0.084665436509 Rises=F Damp=T
+ DIIS: error= 4.26D-03 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -1812.46601695786     IErMin= 4 ErrMin= 4.26D-03
+ ErrMax= 4.26D-03  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.70D-03 BMatP= 9.38D-03
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.991D-02-0.160D+00-0.177D+00 0.133D+01
+ Coeff:      0.991D-02-0.160D+00-0.177D+00 0.133D+01
+ Gap=     0.094 Goal=     0.100 Shift=    0.006
+ GapD=    0.094 DampG=0.500 DampE=1.000 DampFc=0.5000 IDamp=-1.
+ Damping current iteration by 5.00D-01
+ RMSDP=5.15D-04 MaxDP=1.85D-02 DE=-8.47D-02 OVMax= 0.00D+00
+
+ Cycle   5  Pass 0  IDiag  1:
+ RMSU=  1.23D-04    CP:  9.96D-01  7.38D-01  1.38D+00  1.33D+00
+ E= -1812.50831439699     Delta-E=       -0.042297439128 Rises=F Damp=T
+ DIIS: error= 2.30D-03 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -1812.50831439699     IErMin= 5 ErrMin= 2.30D-03
+ ErrMax= 2.30D-03  0.00D+00 EMaxC= 1.00D+00 BMatC= 9.00D-04 BMatP= 2.70D-03
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.411D-02-0.615D-01-0.260D+00 0.204D+00 0.111D+01
+ Coeff:      0.411D-02-0.615D-01-0.260D+00 0.204D+00 0.111D+01
+ Gap=     0.095 Goal=     0.100 Shift=    0.005
+ GapD=    0.095 DampG=0.500 DampE=1.000 DampFc=0.5000 IDamp=-1.
+ Damping current iteration by 5.00D-01
+ RMSDP=2.77D-04 MaxDP=9.24D-03 DE=-4.23D-02 OVMax= 0.00D+00
+
+ Cycle   6  Pass 0  IDiag  1:
+ RMSU=  3.15D-05    CP:  9.97D-01  7.25D-01  1.46D+00  1.56D+00  1.19D+00
+ E= -1812.52939061419     Delta-E=       -0.021076217206 Rises=F Damp=T
+ DIIS: error= 1.23D-03 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -1812.52939061419     IErMin= 6 ErrMin= 1.23D-03
+ ErrMax= 1.23D-03  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.67D-04 BMatP= 9.00D-04
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.274D-02-0.287D-01-0.152D+00 0.694D-01 0.139D+00 0.969D+00
+ Coeff:      0.274D-02-0.287D-01-0.152D+00 0.694D-01 0.139D+00 0.969D+00
+ Gap=     0.095 Goal=     0.100 Shift=    0.005
+ GapD=    0.095 DampG=0.500 DampE=1.000 DampFc=0.5000 IDamp=-1.
+ Damping current iteration by 5.00D-01
+ RMSDP=1.45D-04 MaxDP=4.55D-03 DE=-2.11D-02 OVMax= 0.00D+00
+
+ Cycle   7  Pass 0  IDiag  1:
+ RMSU=  9.25D-06    CP:  9.97D-01  7.18D-01  1.51D+00  1.68D+00  1.30D+00
+                    CP:  1.27D+00
+ E= -1812.53986882858     Delta-E=       -0.010478214391 Rises=F Damp=T
+ DIIS: error= 6.52D-04 at cycle   7 NSaved=   7.
+ NSaved= 7 IEnMin= 7 EnMin= -1812.53986882858     IErMin= 7 ErrMin= 6.52D-04
+ ErrMax= 6.52D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 7.55D-05 BMatP= 2.67D-04
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.107D-02-0.169D-02 0.412D-03 0.109D-01-0.858D-01-0.860D+00
+ Coeff-Com:  0.193D+01
+ Coeff:      0.107D-02-0.169D-02 0.412D-03 0.109D-01-0.858D-01-0.860D+00
+ Coeff:      0.193D+01
+ Gap=     0.095 Goal=     0.100 Shift=    0.005
+ RMSDP=7.73D-05 MaxDP=2.60D-03 DE=-1.05D-02 OVMax= 0.00D+00
+
+ Cycle   8  Pass 0  IDiag  1:
+ RMSU=  4.51D-06    CP:  9.97D-01  7.09D-01  1.55D+00  1.80D+00  1.42D+00
+                    CP:  1.67D+00  2.05D+00
+ E= -1812.55028022975     Delta-E=       -0.010411401162 Rises=F Damp=F
+ DIIS: error= 2.47D-05 at cycle   8 NSaved=   8.
+ NSaved= 8 IEnMin= 8 EnMin= -1812.55028022975     IErMin= 8 ErrMin= 2.47D-05
+ ErrMax= 2.47D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.06D-07 BMatP= 7.55D-05
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.589D-03-0.208D-03 0.654D-02 0.471D-02-0.503D-01-0.542D+00
+ Coeff-Com:  0.111D+01 0.469D+00
+ Coeff:      0.589D-03-0.208D-03 0.654D-02 0.471D-02-0.503D-01-0.542D+00
+ Coeff:      0.111D+01 0.469D+00
+ Gap=     0.095 Goal=     0.100 Shift=    0.005
+ RMSDP=2.63D-06 MaxDP=1.12D-04 DE=-1.04D-02 OVMax= 0.00D+00
+
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ Cycle   9  Pass 1  IDiag  1:
+ E= -1812.54967126382     Delta-E=        0.000608965926 Rises=F Damp=F
+ DIIS: error= 1.28D-05 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -1812.54967126382     IErMin= 1 ErrMin= 1.28D-05
+ ErrMax= 1.28D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.44D-08 BMatP= 3.44D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.095 Goal=   None    Shift=    0.000
+ RMSDP=2.63D-06 MaxDP=1.12D-04 DE= 6.09D-04 OVMax= 0.00D+00
+
+ Cycle  10  Pass 1  IDiag  1:
+ RMSU=  2.07D-06    CP:  1.00D+00
+ E= -1812.54967128419     Delta-E=       -0.000000020366 Rises=F Damp=F
+ DIIS: error= 1.54D-05 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -1812.54967128419     IErMin= 1 ErrMin= 1.28D-05
+ ErrMax= 1.54D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.98D-08 BMatP= 3.44D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.475D+00 0.525D+00
+ Coeff:      0.475D+00 0.525D+00
+ Gap=     0.095 Goal=   None    Shift=    0.000
+ RMSDP=1.85D-06 MaxDP=7.74D-05 DE=-2.04D-08 OVMax= 0.00D+00
+
+ Cycle  11  Pass 1  IDiag  1:
+ RMSU=  1.25D-06    CP:  1.00D+00  3.42D-01
+ E= -1812.54967130662     Delta-E=       -0.000000022437 Rises=F Damp=F
+ DIIS: error= 1.16D-05 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -1812.54967130662     IErMin= 3 ErrMin= 1.16D-05
+ ErrMax= 1.16D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.53D-08 BMatP= 2.98D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.553D-04 0.416D+00 0.584D+00
+ Coeff:     -0.553D-04 0.416D+00 0.584D+00
+ Gap=     0.095 Goal=   None    Shift=    0.000
+ RMSDP=7.96D-07 MaxDP=2.85D-05 DE=-2.24D-08 OVMax= 0.00D+00
+
+ Cycle  12  Pass 1  IDiag  1:
+ RMSU=  2.38D-07    CP:  1.00D+00  6.16D-01  5.94D-01
+ E= -1812.54967132787     Delta-E=       -0.000000021250 Rises=F Damp=F
+ DIIS: error= 1.34D-06 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -1812.54967132787     IErMin= 4 ErrMin= 1.34D-06
+ ErrMax= 1.34D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 5.95D-10 BMatP= 1.53D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.161D-01 0.246D+00 0.360D+00 0.410D+00
+ Coeff:     -0.161D-01 0.246D+00 0.360D+00 0.410D+00
+ Gap=     0.095 Goal=   None    Shift=    0.000
+ RMSDP=1.48D-07 MaxDP=5.84D-06 DE=-2.13D-08 OVMax= 0.00D+00
+
+ Cycle  13  Pass 1  IDiag  1:
+ RMSU=  3.71D-08    CP:  1.00D+00  6.19D-01  6.17D-01  4.12D-01
+ E= -1812.54967132939     Delta-E=       -0.000000001518 Rises=F Damp=F
+ DIIS: error= 1.66D-07 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -1812.54967132939     IErMin= 5 ErrMin= 1.66D-07
+ ErrMax= 1.66D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 6.03D-12 BMatP= 5.95D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.619D-02 0.789D-01 0.108D+00 0.142D+00 0.677D+00
+ Coeff:     -0.619D-02 0.789D-01 0.108D+00 0.142D+00 0.677D+00
+ Gap=     0.095 Goal=   None    Shift=    0.000
+ RMSDP=1.61D-08 MaxDP=6.68D-07 DE=-1.52D-09 OVMax= 0.00D+00
+
+ SCF Done:  E(RB3LYP) =  -1812.54967133     A.U. after   13 cycles
+            NFock= 13  Conv=0.16D-07     -V/T= 2.0175
+ KE= 1.781433988106D+03 PE=-1.288133025192D+04 EE= 4.945893754574D+03
+ Leave Link  502 at Tue Aug  4 10:39:01 2020, MaxMem=    33554432 cpu:        39.8
+ (Enter /cluster/apps/gaussian/g09/l601.exe)
+ Copying SCF densities to generalized density rwf, IOpCl= 0 IROHF=0.
+
+ **********************************************************************
+
+            Population analysis using the SCF density.
+
+ **********************************************************************
+
+ Orbital symmetries:
+       Occupied  (B) (A) (B) (A) (B) (A) (A) (B) (B) (A) (B) (A)
+                 (B) (A) (B) (A) (B) (A) (B) (A) (B) (A) (B) (A)
+                 (B) (A) (B) (A) (B) (A) (B) (A) (B) (A) (B) (A)
+                 (B) (A) (A) (B) (B) (A) (A) (B) (B) (A) (A) (B)
+                 (B) (A) (A) (B) (A) (B) (A) (B) (A) (B) (B) (A)
+                 (B) (A) (A) (B) (B) (A) (A) (B) (B) (A) (A) (B)
+                 (B) (A) (A) (B) (B) (A) (A) (B) (A) (A) (B) (B)
+                 (A) (A) (B) (B) (A) (A) (B) (B) (A) (B) (A) (B)
+                 (A) (B) (B) (A) (B) (A) (A) (B) (A) (B) (A) (B)
+                 (B) (A) (B) (B) (A) (A) (A) (A) (B) (A) (B) (B)
+                 (B) (A) (A) (B) (B) (B) (B) (A) (A) (A) (B) (A)
+                 (B) (A) (B) (B) (A) (A) (A) (B) (A) (B) (B) (A)
+                 (A) (B) (B) (A) (B) (A) (A) (B) (B)
+       Virtual   (A) (B) (A) (A) (B) (B) (A) (A) (B) (B) (A) (B)
+                 (A) (A) (B) (A) (B) (A) (B) (A) (B) (B) (A) (A)
+                 (B) (B) (A) (A) (B) (B) (A) (B) (A) (A) (B) (B)
+                 (A) (A) (B) (B) (A) (B) (A) (A) (B) (A) (B) (A)
+                 (B) (A) (A) (B) (B) (B) (A) (A) (A) (B) (B) (A)
+                 (B) (A) (B) (B) (A) (B) (B) (A) (A) (A) (B) (A)
+                 (B) (B) (A) (A) (A) (B) (B) (B) (A) (B) (A) (B)
+                 (B) (A) (A) (A) (A) (B) (B) (B) (A) (A) (B) (A)
+                 (B) (A) (B) (A) (B) (B) (A)
+ The electronic state is 1-A.
+ Alpha  occ. eigenvalues --  -14.21420 -14.21420 -14.21418 -14.21418 -10.07355
+ Alpha  occ. eigenvalues --  -10.07355 -10.07272 -10.07272 -10.07184 -10.07184
+ Alpha  occ. eigenvalues --  -10.07095 -10.07095 -10.01458 -10.01458 -10.01377
+ Alpha  occ. eigenvalues --  -10.01377 -10.01075 -10.01075 -10.00986 -10.00986
+ Alpha  occ. eigenvalues --  -10.00491 -10.00487 -10.00404 -10.00398 -10.00044
+ Alpha  occ. eigenvalues --  -10.00044 -10.00036 -10.00036  -9.99827  -9.99827
+ Alpha  occ. eigenvalues --   -9.99783  -9.99783  -9.99755  -9.99755  -9.99717
+ Alpha  occ. eigenvalues --   -9.99717  -9.99397  -9.99397  -9.99390  -9.99390
+ Alpha  occ. eigenvalues --   -9.98772  -9.98771  -9.98765  -9.98764  -9.98762
+ Alpha  occ. eigenvalues --   -9.98753  -0.95200  -0.95200  -0.90024  -0.90024
+ Alpha  occ. eigenvalues --   -0.83290  -0.83085  -0.82264  -0.81302  -0.79820
+ Alpha  occ. eigenvalues --   -0.78199  -0.76694  -0.74798  -0.73830  -0.73543
+ Alpha  occ. eigenvalues --   -0.72793  -0.72338  -0.71932  -0.70496  -0.69760
+ Alpha  occ. eigenvalues --   -0.68757  -0.68186  -0.67389  -0.66866  -0.65847
+ Alpha  occ. eigenvalues --   -0.63340  -0.63253  -0.62080  -0.60086  -0.59058
+ Alpha  occ. eigenvalues --   -0.57793  -0.57408  -0.55578  -0.55550  -0.55478
+ Alpha  occ. eigenvalues --   -0.54509  -0.54312  -0.54243  -0.51928  -0.50353
+ Alpha  occ. eigenvalues --   -0.50175  -0.50095  -0.50075  -0.49377  -0.49181
+ Alpha  occ. eigenvalues --   -0.48969  -0.45934  -0.45867  -0.45769  -0.44101
+ Alpha  occ. eigenvalues --   -0.43892  -0.42172  -0.41231  -0.41196  -0.40634
+ Alpha  occ. eigenvalues --   -0.40278  -0.40193  -0.40041  -0.39823  -0.39806
+ Alpha  occ. eigenvalues --   -0.39799  -0.39438  -0.38552  -0.38385  -0.38276
+ Alpha  occ. eigenvalues --   -0.37095  -0.36980  -0.36951  -0.36725  -0.36324
+ Alpha  occ. eigenvalues --   -0.35941  -0.35569  -0.34748  -0.34117  -0.34075
+ Alpha  occ. eigenvalues --   -0.33900  -0.33392  -0.33049  -0.32743  -0.32396
+ Alpha  occ. eigenvalues --   -0.31436  -0.31179  -0.31177  -0.30417  -0.29874
+ Alpha  occ. eigenvalues --   -0.29624  -0.29604  -0.28421  -0.28420  -0.27930
+ Alpha  occ. eigenvalues --   -0.27659  -0.27512  -0.26158  -0.24862  -0.24286
+ Alpha  occ. eigenvalues --   -0.23185  -0.22414  -0.21808  -0.21268  -0.20273
+ Alpha  occ. eigenvalues --   -0.18739  -0.18225  -0.15941  -0.14437  -0.12704
+ Alpha  occ. eigenvalues --   -0.11167  -0.10164  -0.09050
+ Alpha virt. eigenvalues --    0.00416   0.04407   0.05553   0.06755   0.07085
+ Alpha virt. eigenvalues --    0.08040   0.10248   0.11090   0.13641   0.13954
+ Alpha virt. eigenvalues --    0.14141   0.15205   0.17867   0.17928   0.20359
+ Alpha virt. eigenvalues --    0.22192   0.25922   0.27218   0.27309   0.29807
+ Alpha virt. eigenvalues --    0.30354   0.30534   0.30783   0.31141   0.33882
+ Alpha virt. eigenvalues --    0.34311   0.35074   0.35568   0.35571   0.35680
+ Alpha virt. eigenvalues --    0.35925   0.36323   0.37036   0.37891   0.37894
+ Alpha virt. eigenvalues --    0.39260   0.39799   0.40774   0.41067   0.41182
+ Alpha virt. eigenvalues --    0.41893   0.42139   0.42174   0.42449   0.42955
+ Alpha virt. eigenvalues --    0.43824   0.44440   0.44696   0.45651   0.45653
+ Alpha virt. eigenvalues --    0.46672   0.46678   0.47218   0.47352   0.47814
+ Alpha virt. eigenvalues --    0.48181   0.48279   0.48421   0.49004   0.49950
+ Alpha virt. eigenvalues --    0.50072   0.50327   0.51244   0.52720   0.53409
+ Alpha virt. eigenvalues --    0.55304   0.55485   0.55633   0.57178   0.57350
+ Alpha virt. eigenvalues --    0.58062   0.58908   0.58984   0.59029   0.59754
+ Alpha virt. eigenvalues --    0.60941   0.63511   0.64059   0.64592   0.64841
+ Alpha virt. eigenvalues --    0.65411   0.66071   0.66848   0.67184   0.68319
+ Alpha virt. eigenvalues --    0.68686   0.69465   0.70625   0.71169   0.71613
+ Alpha virt. eigenvalues --    0.71935   0.72954   0.73166   0.76190   0.76975
+ Alpha virt. eigenvalues --    0.80641   0.82163   0.82982   0.83956   0.84035
+ Alpha virt. eigenvalues --    0.84414   0.86063   0.86405
+          Condensed to atoms (all electrons):
+ Mulliken charges:
+               1
+     1  C   -0.085779
+     2  C   -0.085779
+     3  C   -0.082889
+     4  C   -0.006020
+     5  C   -0.006019
+     6  C   -0.082889
+     7  C   -0.100966
+     8  C    0.086490
+     9  C    0.086490
+    10  C   -0.100966
+    11  N   -0.296121
+    12  C    0.087469
+    13  C    0.087469
+    14  N   -0.296121
+    15  C   -0.104832
+    16  C   -0.005949
+    17  C   -0.005949
+    18  C   -0.104832
+    19  C   -0.084497
+    20  C   -0.008416
+    21  C   -0.008416
+    22  C   -0.084497
+    23  C   -0.081781
+    24  C   -0.008416
+    25  C   -0.008416
+    26  C   -0.081781
+    27  C   -0.084497
+    28  C   -0.005949
+    29  C   -0.005949
+    30  C   -0.084497
+    31  C   -0.104832
+    32  C    0.087469
+    33  C    0.087469
+    34  C   -0.104832
+    35  N   -0.296121
+    36  C    0.086490
+    37  C    0.086490
+    38  N   -0.296121
+    39  C   -0.100966
+    40  C   -0.006020
+    41  C   -0.006019
+    42  C   -0.100966
+    43  C   -0.082889
+    44  C   -0.085779
+    45  C   -0.085779
+    46  C   -0.082889
+    47  H    0.078865
+    48  H    0.078865
+    49  H    0.076226
+    50  H    0.076226
+    51  H    0.073547
+    52  H    0.073547
+    53  H    0.071926
+    54  H    0.071926
+    55  H    0.072874
+    56  H    0.073792
+    57  H    0.072874
+    58  H    0.071926
+    59  H    0.073547
+    60  H    0.073547
+    61  H    0.076226
+    62  H    0.078865
+    63  H    0.078865
+    64  H    0.076226
+    65  H    0.072874
+    66  H    0.072874
+    67  H    0.073792
+    68  H    0.071926
+    69  H    0.232065
+    70  H    0.232065
+    71  H    0.232065
+    72  H    0.232065
+ Sum of Mulliken charges =   0.00000
+ Mulliken charges with hydrogens summed into heavy atoms:
+               1
+     1  C   -0.006914
+     2  C   -0.006914
+     3  C   -0.006663
+     4  C   -0.006020
+     5  C   -0.006019
+     6  C   -0.006663
+     7  C   -0.027419
+     8  C    0.086490
+     9  C    0.086490
+    10  C   -0.027419
+    11  N   -0.064056
+    12  C    0.087469
+    13  C    0.087469
+    14  N   -0.064056
+    15  C   -0.032906
+    16  C   -0.005949
+    17  C   -0.005949
+    18  C   -0.032906
+    19  C   -0.011623
+    20  C   -0.008416
+    21  C   -0.008416
+    22  C   -0.011623
+    23  C   -0.007989
+    24  C   -0.008416
+    25  C   -0.008416
+    26  C   -0.007989
+    27  C   -0.011623
+    28  C   -0.005949
+    29  C   -0.005949
+    30  C   -0.011623
+    31  C   -0.032906
+    32  C    0.087469
+    33  C    0.087469
+    34  C   -0.032906
+    35  N   -0.064056
+    36  C    0.086490
+    37  C    0.086490
+    38  N   -0.064056
+    39  C   -0.027419
+    40  C   -0.006020
+    41  C   -0.006019
+    42  C   -0.027419
+    43  C   -0.006663
+    44  C   -0.006914
+    45  C   -0.006914
+    46  C   -0.006663
+ Electronic spatial extent (au):  <R**2>=          75732.0451
+ Charge=              0.0000 electrons
+ Dipole moment (field-independent basis, Debye):
+    X=              0.0000    Y=              0.0000    Z=              0.0003  Tot=              0.0003
+ Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=           -209.1588   YY=           -235.1361   ZZ=           -252.9023
+   XY=              0.0000   XZ=              0.0000   YZ=              0.0000
+ Traceless Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=             23.2402   YY=             -2.7370   ZZ=            -20.5033
+   XY=              0.0000   XZ=              0.0000   YZ=              0.0000
+ Octapole moment (field-independent basis, Debye-Ang**2):
+  XXX=              0.0000  YYY=              0.0000  ZZZ=             -0.0024  XYY=              0.0000
+  XXY=              0.0000  XXZ=             -0.0018  XZZ=              0.0000  YZZ=              0.0000
+  YYZ=              0.0304  XYZ=             -0.0013
+ Hexadecapole moment (field-independent basis, Debye-Ang**3):
+ XXXX=          -2073.7480 YYYY=         -98251.0307 ZZZZ=           -202.1759 XXXY=              0.0014
+ XXXZ=              0.0000 YYYX=              0.0053 YYYZ=              0.0000 ZZZX=              0.0000
+ ZZZY=              0.0000 XXYY=         -14657.0036 XXZZ=           -457.8469 YYZZ=         -17130.5238
+ XXYZ=              0.0000 YYXZ=              0.0000 ZZXY=              0.0006
+ N-N= 4.341452837909D+03 E-N=-1.288133020074D+04  KE= 1.781433988106D+03
+ Symmetry A    KE= 8.888477935583D+02
+ Symmetry B    KE= 8.925861945473D+02
+ No NMR shielding tensors so no spin-rotation constants.
+ Leave Link  601 at Tue Aug  4 10:39:01 2020, MaxMem=    33554432 cpu:         0.2
+ (Enter /cluster/apps/gaussian/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ Leave Link  701 at Tue Aug  4 10:39:02 2020, MaxMem=    33554432 cpu:         0.2
+ (Enter /cluster/apps/gaussian/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Tue Aug  4 10:39:02 2020, MaxMem=    33554432 cpu:         0.0
+ (Enter /cluster/apps/gaussian/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=F KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         0 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=        2800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2127 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Tue Aug  4 10:39:14 2020, MaxMem=    33554432 cpu:        12.0
+ (Enter /cluster/apps/gaussian/g09/l716.exe)
+ Dipole        = 5.50948328D-15 2.46261412D-14 1.36828152D-04
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6          -0.003892658    0.003618612    0.000000352
+      2        6          -0.003893006   -0.003617522    0.000000463
+      3        6          -0.003868128    0.007797280    0.000000667
+      4        6           0.000926869   -0.001988020    0.000000017
+      5        6           0.000925924    0.001988011   -0.000000199
+      6        6          -0.003866906   -0.007797811    0.000000684
+      7        6          -0.000605272   -0.012386111    0.000000038
+      8        6          -0.015952193    0.003715694    0.000002009
+      9        6          -0.015953304   -0.003715774    0.000001977
+     10        6          -0.000605240    0.012385885   -0.000000161
+     11        7          -0.000502662    0.002829583   -0.000004836
+     12        6           0.016399937   -0.005889645   -0.000000104
+     13        6           0.016398691    0.005889410   -0.000000089
+     14        7          -0.000502292   -0.002829363   -0.000005128
+     15        6           0.000434868   -0.012376473   -0.000000238
+     16        6          -0.000510122    0.002538665    0.000000141
+     17        6          -0.000510287   -0.002539444   -0.000000042
+     18        6           0.000434001    0.012376398   -0.000000121
+     19        6          -0.000355762    0.010345081    0.000000186
+     20        6          -0.000109646   -0.002890563   -0.000000087
+     21        6          -0.000110393    0.002890573    0.000000037
+     22        6          -0.000356811   -0.010343654   -0.000000052
+     23        6           0.000000901   -0.010141283   -0.000000025
+     24        6           0.000109646    0.002890563   -0.000000087
+     25        6           0.000110393   -0.002890573    0.000000037
+     26        6          -0.000000901    0.010141283   -0.000000025
+     27        6           0.000356811    0.010343654   -0.000000052
+     28        6           0.000510122   -0.002538665    0.000000141
+     29        6           0.000510287    0.002539444   -0.000000042
+     30        6           0.000355762   -0.010345081    0.000000186
+     31        6          -0.000434001   -0.012376398   -0.000000121
+     32        6          -0.016399937    0.005889645   -0.000000104
+     33        6          -0.016398691   -0.005889410   -0.000000089
+     34        6          -0.000434868    0.012376473   -0.000000238
+     35        7           0.000502292    0.002829363   -0.000005128
+     36        6           0.015952193   -0.003715694    0.000002009
+     37        6           0.015953304    0.003715774    0.000001977
+     38        7           0.000502662   -0.002829583   -0.000004836
+     39        6           0.000605240   -0.012385885   -0.000000161
+     40        6          -0.000926869    0.001988020    0.000000017
+     41        6          -0.000925924   -0.001988011   -0.000000199
+     42        6           0.000605272    0.012386111    0.000000038
+     43        6           0.003866906    0.007797811    0.000000684
+     44        6           0.003893006    0.003617522    0.000000463
+     45        6           0.003892658   -0.003618612    0.000000352
+     46        6           0.003868128   -0.007797280    0.000000667
+     47        1          -0.009939645    0.005371516    0.000001369
+     48        1          -0.009940238   -0.005371973    0.000001374
+     49        1           0.000237931    0.010480685   -0.000000061
+     50        1           0.000237978   -0.010480696   -0.000000082
+     51        1           0.000452853   -0.009116491   -0.000000147
+     52        1           0.000452856    0.009116513   -0.000000146
+     53        1          -0.000352872   -0.008954209   -0.000000025
+     54        1          -0.000352849    0.008954200   -0.000000139
+     55        1           0.000054504   -0.009797172    0.000000014
+     56        1           0.000000046    0.009955474    0.000000002
+     57        1          -0.000054444   -0.009796634   -0.000000050
+     58        1           0.000352872    0.008954209   -0.000000025
+     59        1          -0.000452856   -0.009116513   -0.000000146
+     60        1          -0.000452853    0.009116491   -0.000000147
+     61        1          -0.000237978    0.010480696   -0.000000082
+     62        1           0.009940238    0.005371973    0.000001374
+     63        1           0.009939645   -0.005371516    0.000001369
+     64        1          -0.000237931   -0.010480685   -0.000000061
+     65        1           0.000054444    0.009796634   -0.000000050
+     66        1          -0.000054504    0.009797172    0.000000014
+     67        1          -0.000000046   -0.009955474    0.000000002
+     68        1           0.000352849   -0.008954200   -0.000000139
+     69        1          -0.000162365    0.034125752    0.000001051
+     70        1           0.000162357    0.034125369    0.000001351
+     71        1          -0.000162357   -0.034125369    0.000001351
+     72        1           0.000162365   -0.034125752    0.000001051
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.034125752 RMS     0.007304316
+ Leave Link  716 at Tue Aug  4 10:39:14 2020, MaxMem=    33554432 cpu:         0.0
+ (Enter /cluster/apps/gaussian/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.038156270 RMS     0.009143475
+ Search for a local minimum.
+ Step number   1 out of a maximum of  432
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .91435D-02 SwitMx=.10000D-02 MixMth= 1
+ Mixed Optimization -- RFO/linear search
+ Second derivative matrix not updated -- first step.
+ ITU=  0
+     Eigenvalues ---    0.01654   0.01659   0.01708   0.01738   0.01766
+     Eigenvalues ---    0.01771   0.01777   0.01785   0.01785   0.01811
+     Eigenvalues ---    0.01811   0.01821   0.01821   0.01822   0.01838
+     Eigenvalues ---    0.01841   0.01841   0.01841   0.01841   0.01841
+     Eigenvalues ---    0.01841   0.01858   0.01865   0.01873   0.01876
+     Eigenvalues ---    0.01882   0.01898   0.01898   0.01904   0.01904
+     Eigenvalues ---    0.01938   0.01938   0.01981   0.01981   0.02006
+     Eigenvalues ---    0.02006   0.02047   0.02047   0.02047   0.02047
+     Eigenvalues ---    0.02088   0.02088   0.02088   0.02091   0.02091
+     Eigenvalues ---    0.02101   0.02101   0.02110   0.02110   0.02123
+     Eigenvalues ---    0.02124   0.02128   0.02128   0.02139   0.02139
+     Eigenvalues ---    0.02156   0.02156   0.02163   0.02163   0.02168
+     Eigenvalues ---    0.02168   0.02203   0.02203   0.02206   0.02206
+     Eigenvalues ---    0.02259   0.02259   0.02276   0.02276   0.16000
+     Eigenvalues ---    0.16000   0.16000   0.16000   0.16000   0.16000
+     Eigenvalues ---    0.16000   0.16000   0.16000   0.16000   0.16000
+     Eigenvalues ---    0.16000   0.16000   0.16000   0.16000   0.16000
+     Eigenvalues ---    0.16000   0.16000   0.16000   0.16000   0.16000
+     Eigenvalues ---    0.16000   0.16000   0.16000   0.16000   0.16000
+     Eigenvalues ---    0.22000   0.22000   0.22492   0.22492   0.22785
+     Eigenvalues ---    0.22861   0.22974   0.23100   0.23215   0.23314
+     Eigenvalues ---    0.23398   0.23457   0.23488   0.23652   0.23681
+     Eigenvalues ---    0.23739   0.23824   0.23920   0.24018   0.24124
+     Eigenvalues ---    0.24232   0.24316   0.24565   0.24565   0.25000
+     Eigenvalues ---    0.25000   0.25000   0.25000   0.25000   0.25000
+     Eigenvalues ---    0.25000   0.25000   0.25000   0.33227   0.33911
+     Eigenvalues ---    0.34849   0.35278   0.35278   0.35286   0.35286
+     Eigenvalues ---    0.35286   0.35286   0.35296   0.35296   0.35296
+     Eigenvalues ---    0.35296   0.35305   0.35305   0.35305   0.35305
+     Eigenvalues ---    0.35359   0.35359   0.35359   0.35359   0.35499
+     Eigenvalues ---    0.35499   0.35499   0.35499   0.35644   0.36282
+     Eigenvalues ---    0.36932   0.37452   0.37771   0.38745   0.38749
+     Eigenvalues ---    0.39523   0.39523   0.40121   0.40121   0.40476
+     Eigenvalues ---    0.40477   0.40530   0.40661   0.40661   0.40716
+     Eigenvalues ---    0.41761   0.42127   0.42127   0.42448   0.42448
+     Eigenvalues ---    0.42754   0.42782   0.42987   0.42987   0.43330
+     Eigenvalues ---    0.43330   0.44628   0.45608   0.45608   0.46316
+     Eigenvalues ---    0.46316   0.46316   0.46316   0.46590   0.46590
+     Eigenvalues ---    0.46768   0.46770   0.47547   0.47547   0.47552
+     Eigenvalues ---    0.47552   0.47675   0.47705   0.47960   0.47960
+     Eigenvalues ---    0.48194   0.48194   0.49185   0.49185   0.49345
+     Eigenvalues ---    0.49345   0.49700   0.49700   0.51085   0.51086
+ RFO step:  Lambda=-7.16358325D-02 EMin= 1.65432370D-02
+ Linear search not attempted -- first point.
+ Maximum step size (   0.300) exceeded in Quadratic search.
+    -- Step size scaled by   0.804
+ Iteration  1 RMS(Cart)=  0.08452609 RMS(Int)=  0.00001285
+ Iteration  2 RMS(Cart)=  0.00005249 RMS(Int)=  0.00000257
+ Iteration  3 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000257
+ ITry= 1 IFail=0 DXMaxC= 3.39D-01 DCOld= 1.00D+10 DXMaxT= 3.00D-01 DXLimC= 3.00D+00 Rises=F
+ ClnCor:  largest displacement from symmetrization is 4.75D-09 for atom    67.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.66751   0.01747   0.00000   0.02765   0.02764   2.69516
+    R2        2.60121   0.01622   0.00000   0.02294   0.02294   2.62415
+    R3        2.04872   0.01130   0.00000   0.02128   0.02128   2.07000
+    R4        2.60121   0.01622   0.00000   0.02294   0.02294   2.62415
+    R5        2.04872   0.01130   0.00000   0.02128   0.02128   2.07000
+    R6        2.67680   0.02002   0.00000   0.03205   0.03205   2.70885
+    R7        2.05096   0.01048   0.00000   0.01981   0.01981   2.07077
+    R8        2.70339   0.01890   0.00000   0.03102   0.03102   2.73441
+    R9        2.68115   0.01983   0.00000   0.03177   0.03177   2.71292
+   R10        2.67680   0.02002   0.00000   0.03205   0.03205   2.70885
+   R11        2.68115   0.01983   0.00000   0.03177   0.03177   2.71292
+   R12        2.05096   0.01048   0.00000   0.01981   0.01981   2.07077
+   R13        2.59930   0.01966   0.00000   0.02788   0.02788   2.62717
+   R14        2.05197   0.00912   0.00000   0.01726   0.01726   2.06923
+   R15        2.70539   0.02500   0.00000   0.04255   0.04255   2.74794
+   R16        2.62508   0.03740   0.00000   0.05507   0.05508   2.68016
+   R17        2.59930   0.01966   0.00000   0.02787   0.02788   2.62717
+   R18        2.62508   0.03740   0.00000   0.05508   0.05508   2.68016
+   R19        2.05197   0.00912   0.00000   0.01726   0.01726   2.06923
+   R20        2.62344   0.03816   0.00000   0.05592   0.05592   2.67936
+   R21        1.90476   0.03413   0.00000   0.05128   0.05128   1.95605
+   R22        2.73753   0.02334   0.00000   0.04151   0.04151   2.77905
+   R23        2.58083   0.01992   0.00000   0.02735   0.02735   2.60818
+   R24        2.62344   0.03816   0.00000   0.05592   0.05592   2.67936
+   R25        2.58083   0.01992   0.00000   0.02735   0.02735   2.60818
+   R26        1.90476   0.03413   0.00000   0.05128   0.05128   1.95605
+   R27        2.70545   0.01992   0.00000   0.03318   0.03318   2.73862
+   R28        2.05182   0.00896   0.00000   0.01695   0.01695   2.06877
+   R29        2.74634   0.01846   0.00000   0.03257   0.03257   2.77891
+   R30        2.61686   0.02012   0.00000   0.02923   0.02923   2.64609
+   R31        2.70545   0.01992   0.00000   0.03318   0.03318   2.73862
+   R32        2.61686   0.02012   0.00000   0.02924   0.02924   2.64609
+   R33        2.05182   0.00896   0.00000   0.01695   0.01695   2.06877
+   R34        2.67417   0.02023   0.00000   0.03223   0.03223   2.70641
+   R35        2.05213   0.00980   0.00000   0.01855   0.01855   2.07068
+   R36        2.74519   0.01707   0.00000   0.03034   0.03034   2.77553
+   R37        2.64576   0.02039   0.00000   0.03106   0.03106   2.67681
+   R38        2.67417   0.02023   0.00000   0.03223   0.03223   2.70641
+   R39        2.64575   0.02039   0.00000   0.03106   0.03106   2.67681
+   R40        2.05213   0.00980   0.00000   0.01855   0.01855   2.07068
+   R41        2.64576   0.02039   0.00000   0.03106   0.03106   2.67681
+   R42        2.05226   0.00996   0.00000   0.01885   0.01885   2.07111
+   R43        2.74519   0.01707   0.00000   0.03034   0.03034   2.77553
+   R44        2.67417   0.02023   0.00000   0.03223   0.03223   2.70641
+   R45        2.64575   0.02039   0.00000   0.03106   0.03106   2.67681
+   R46        2.67417   0.02023   0.00000   0.03223   0.03223   2.70641
+   R47        2.05226   0.00996   0.00000   0.01885   0.01885   2.07111
+   R48        2.61686   0.02012   0.00000   0.02923   0.02923   2.64609
+   R49        2.05213   0.00980   0.00000   0.01855   0.01855   2.07068
+   R50        2.74634   0.01846   0.00000   0.03257   0.03257   2.77891
+   R51        2.70545   0.01992   0.00000   0.03318   0.03318   2.73862
+   R52        2.61686   0.02012   0.00000   0.02924   0.02924   2.64609
+   R53        2.70545   0.01992   0.00000   0.03318   0.03318   2.73862
+   R54        2.05213   0.00980   0.00000   0.01855   0.01855   2.07068
+   R55        2.58083   0.01992   0.00000   0.02735   0.02735   2.60818
+   R56        2.05182   0.00896   0.00000   0.01695   0.01695   2.06877
+   R57        2.73753   0.02334   0.00000   0.04151   0.04151   2.77905
+   R58        2.62344   0.03816   0.00000   0.05592   0.05592   2.67936
+   R59        2.58083   0.01992   0.00000   0.02735   0.02735   2.60818
+   R60        2.62344   0.03816   0.00000   0.05592   0.05592   2.67936
+   R61        2.05182   0.00896   0.00000   0.01695   0.01695   2.06877
+   R62        2.62508   0.03740   0.00000   0.05507   0.05508   2.68016
+   R63        1.90476   0.03413   0.00000   0.05128   0.05128   1.95605
+   R64        2.70539   0.02500   0.00000   0.04255   0.04255   2.74794
+   R65        2.59930   0.01966   0.00000   0.02788   0.02788   2.62717
+   R66        2.62508   0.03740   0.00000   0.05508   0.05508   2.68016
+   R67        2.59930   0.01966   0.00000   0.02787   0.02788   2.62717
+   R68        1.90476   0.03413   0.00000   0.05128   0.05128   1.95605
+   R69        2.68115   0.01983   0.00000   0.03177   0.03177   2.71292
+   R70        2.05197   0.00912   0.00000   0.01726   0.01726   2.06923
+   R71        2.70339   0.01890   0.00000   0.03102   0.03102   2.73441
+   R72        2.67680   0.02002   0.00000   0.03205   0.03205   2.70885
+   R73        2.68115   0.01983   0.00000   0.03177   0.03177   2.71292
+   R74        2.67680   0.02002   0.00000   0.03205   0.03205   2.70885
+   R75        2.05197   0.00912   0.00000   0.01726   0.01726   2.06923
+   R76        2.60121   0.01622   0.00000   0.02294   0.02294   2.62415
+   R77        2.05096   0.01048   0.00000   0.01981   0.01981   2.07077
+   R78        2.66751   0.01747   0.00000   0.02765   0.02764   2.69516
+   R79        2.04872   0.01130   0.00000   0.02128   0.02128   2.07000
+   R80        2.60121   0.01622   0.00000   0.02294   0.02294   2.62415
+   R81        2.04872   0.01130   0.00000   0.02128   0.02128   2.07000
+   R82        2.05096   0.01048   0.00000   0.01981   0.01981   2.07077
+    A1        2.09812   0.00054   0.00000   0.00149   0.00148   2.09959
+    A2        2.08991  -0.00054   0.00000  -0.00169  -0.00169   2.08822
+    A3        2.09516   0.00000   0.00000   0.00021   0.00021   2.09537
+    A4        2.09812   0.00054   0.00000   0.00149   0.00148   2.09959
+    A5        2.08991  -0.00054   0.00000  -0.00169  -0.00169   2.08822
+    A6        2.09516   0.00000   0.00000   0.00021   0.00021   2.09537
+    A7        2.11098  -0.00011   0.00000  -0.00052  -0.00052   2.11046
+    A8        2.09854   0.00030   0.00000   0.00109   0.00109   2.09964
+    A9        2.07366  -0.00018   0.00000  -0.00057  -0.00057   2.07309
+   A10        2.07408  -0.00043   0.00000  -0.00096  -0.00095   2.07313
+   A11        2.13618  -0.00093   0.00000  -0.00166  -0.00166   2.13451
+   A12        2.07292   0.00136   0.00000   0.00263   0.00262   2.07554
+   A13        2.07408  -0.00043   0.00000  -0.00096  -0.00095   2.07313
+   A14        2.07292   0.00136   0.00000   0.00263   0.00262   2.07554
+   A15        2.13618  -0.00093   0.00000  -0.00166  -0.00166   2.13451
+   A16        2.11098  -0.00011   0.00000  -0.00052  -0.00052   2.11046
+   A17        2.09854   0.00030   0.00000   0.00109   0.00109   2.09964
+   A18        2.07366  -0.00018   0.00000  -0.00057  -0.00057   2.07309
+   A19        2.12041  -0.00133   0.00000  -0.00346  -0.00346   2.11695
+   A20        2.07800   0.00108   0.00000   0.00318   0.00318   2.08117
+   A21        2.08478   0.00025   0.00000   0.00028   0.00028   2.08506
+   A22        2.08986  -0.00003   0.00000   0.00083   0.00084   2.09069
+   A23        2.13900  -0.00044   0.00000  -0.00216  -0.00216   2.13684
+   A24        2.05433   0.00047   0.00000   0.00133   0.00133   2.05565
+   A25        2.08985  -0.00003   0.00000   0.00083   0.00084   2.09069
+   A26        2.05433   0.00047   0.00000   0.00132   0.00132   2.05565
+   A27        2.13900  -0.00044   0.00000  -0.00216  -0.00216   2.13684
+   A28        2.12041  -0.00133   0.00000  -0.00346  -0.00346   2.11695
+   A29        2.07800   0.00108   0.00000   0.00318   0.00318   2.08117
+   A30        2.08478   0.00025   0.00000   0.00028   0.00028   2.08506
+   A31        2.18111  -0.00124   0.00000  -0.00284  -0.00284   2.17827
+   A32        2.05200   0.00054   0.00000   0.00115   0.00114   2.05315
+   A33        2.05008   0.00070   0.00000   0.00169   0.00169   2.05177
+   A34        2.04775   0.00077   0.00000   0.00151   0.00151   2.04926
+   A35        2.14290  -0.00068   0.00000  -0.00242  -0.00243   2.14047
+   A36        2.09254  -0.00009   0.00000   0.00091   0.00092   2.09346
+   A37        2.04775   0.00077   0.00000   0.00151   0.00151   2.04926
+   A38        2.09254  -0.00009   0.00000   0.00091   0.00092   2.09346
+   A39        2.14290  -0.00068   0.00000  -0.00242  -0.00243   2.14047
+   A40        2.18111  -0.00123   0.00000  -0.00284  -0.00284   2.17827
+   A41        2.05200   0.00054   0.00000   0.00115   0.00114   2.05315
+   A42        2.05008   0.00070   0.00000   0.00169   0.00169   2.05177
+   A43        2.12624  -0.00106   0.00000  -0.00276  -0.00276   2.12347
+   A44        2.08625   0.00023   0.00000   0.00033   0.00033   2.08658
+   A45        2.07070   0.00084   0.00000   0.00244   0.00244   2.07313
+   A46        2.06441   0.00115   0.00000   0.00185   0.00185   2.06625
+   A47        2.13690  -0.00103   0.00000  -0.00213  -0.00212   2.13477
+   A48        2.08188  -0.00012   0.00000   0.00027   0.00027   2.08216
+   A49        2.06441   0.00115   0.00000   0.00185   0.00185   2.06626
+   A50        2.08188  -0.00012   0.00000   0.00027   0.00028   2.08216
+   A51        2.13690  -0.00103   0.00000  -0.00213  -0.00212   2.13477
+   A52        2.12624  -0.00106   0.00000  -0.00276  -0.00276   2.12347
+   A53        2.08625   0.00023   0.00000   0.00033   0.00033   2.08658
+   A54        2.07070   0.00084   0.00000   0.00244   0.00244   2.07313
+   A55        2.13116  -0.00013   0.00000  -0.00053  -0.00054   2.13063
+   A56        2.08247   0.00011   0.00000   0.00044   0.00044   2.08291
+   A57        2.06956   0.00001   0.00000   0.00009   0.00009   2.06965
+   A58        2.07014   0.00025   0.00000   0.00026   0.00026   2.07040
+   A59        2.13690  -0.00030   0.00000  -0.00049  -0.00049   2.13642
+   A60        2.07614   0.00006   0.00000   0.00023   0.00023   2.07636
+   A61        2.07015   0.00025   0.00000   0.00026   0.00026   2.07040
+   A62        2.07614   0.00006   0.00000   0.00023   0.00023   2.07636
+   A63        2.13690  -0.00030   0.00000  -0.00049  -0.00049   2.13642
+   A64        2.13116  -0.00013   0.00000  -0.00053  -0.00053   2.13062
+   A65        2.08247   0.00011   0.00000   0.00044   0.00044   2.08291
+   A66        2.06956   0.00001   0.00000   0.00009   0.00009   2.06965
+   A67        2.13091  -0.00011   0.00000  -0.00045  -0.00045   2.13046
+   A68        2.07614   0.00006   0.00000   0.00023   0.00023   2.07636
+   A69        2.07614   0.00006   0.00000   0.00023   0.00023   2.07636
+   A70        2.07614   0.00006   0.00000   0.00023   0.00023   2.07636
+   A71        2.13690  -0.00030   0.00000  -0.00049  -0.00049   2.13642
+   A72        2.07014   0.00025   0.00000   0.00026   0.00026   2.07040
+   A73        2.07614   0.00006   0.00000   0.00023   0.00023   2.07636
+   A74        2.07015   0.00025   0.00000   0.00026   0.00026   2.07040
+   A75        2.13690  -0.00030   0.00000  -0.00049  -0.00049   2.13642
+   A76        2.13091  -0.00011   0.00000  -0.00045  -0.00045   2.13046
+   A77        2.07614   0.00006   0.00000   0.00023   0.00023   2.07636
+   A78        2.07614   0.00006   0.00000   0.00023   0.00023   2.07636
+   A79        2.13116  -0.00013   0.00000  -0.00053  -0.00053   2.13062
+   A80        2.06956   0.00001   0.00000   0.00009   0.00009   2.06965
+   A81        2.08247   0.00011   0.00000   0.00044   0.00044   2.08291
+   A82        2.08188  -0.00012   0.00000   0.00027   0.00027   2.08216
+   A83        2.13690  -0.00103   0.00000  -0.00213  -0.00212   2.13477
+   A84        2.06441   0.00115   0.00000   0.00185   0.00185   2.06625
+   A85        2.08188  -0.00012   0.00000   0.00027   0.00028   2.08216
+   A86        2.06441   0.00115   0.00000   0.00185   0.00185   2.06626
+   A87        2.13690  -0.00103   0.00000  -0.00213  -0.00212   2.13477
+   A88        2.13116  -0.00013   0.00000  -0.00053  -0.00054   2.13063
+   A89        2.06956   0.00001   0.00000   0.00009   0.00009   2.06965
+   A90        2.08247   0.00011   0.00000   0.00044   0.00044   2.08291
+   A91        2.12624  -0.00106   0.00000  -0.00276  -0.00276   2.12347
+   A92        2.07070   0.00084   0.00000   0.00244   0.00244   2.07313
+   A93        2.08625   0.00023   0.00000   0.00033   0.00033   2.08658
+   A94        2.09254  -0.00009   0.00000   0.00091   0.00092   2.09346
+   A95        2.14290  -0.00068   0.00000  -0.00242  -0.00243   2.14047
+   A96        2.04775   0.00077   0.00000   0.00151   0.00151   2.04926
+   A97        2.09254  -0.00009   0.00000   0.00091   0.00092   2.09346
+   A98        2.04775   0.00077   0.00000   0.00151   0.00151   2.04926
+   A99        2.14290  -0.00068   0.00000  -0.00242  -0.00243   2.14047
+   A100       2.12624  -0.00106   0.00000  -0.00276  -0.00276   2.12347
+   A101       2.07070   0.00084   0.00000   0.00244   0.00244   2.07313
+   A102       2.08625   0.00023   0.00000   0.00033   0.00033   2.08658
+   A103       2.18111  -0.00123   0.00000  -0.00284  -0.00284   2.17827
+   A104       2.05008   0.00070   0.00000   0.00169   0.00169   2.05177
+   A105       2.05200   0.00054   0.00000   0.00115   0.00114   2.05315
+   A106       2.05433   0.00047   0.00000   0.00133   0.00133   2.05565
+   A107       2.13900  -0.00044   0.00000  -0.00216  -0.00216   2.13684
+   A108       2.08986  -0.00003   0.00000   0.00083   0.00084   2.09069
+   A109       2.05433   0.00047   0.00000   0.00132   0.00132   2.05565
+   A110       2.08985  -0.00003   0.00000   0.00083   0.00084   2.09069
+   A111       2.13900  -0.00044   0.00000  -0.00216  -0.00216   2.13684
+   A112       2.18111  -0.00124   0.00000  -0.00284  -0.00284   2.17827
+   A113       2.05008   0.00070   0.00000   0.00169   0.00169   2.05177
+   A114       2.05200   0.00054   0.00000   0.00115   0.00114   2.05315
+   A115       2.12041  -0.00133   0.00000  -0.00346  -0.00346   2.11695
+   A116       2.08478   0.00025   0.00000   0.00028   0.00028   2.08506
+   A117       2.07800   0.00108   0.00000   0.00318   0.00318   2.08117
+   A118       2.07292   0.00136   0.00000   0.00263   0.00262   2.07554
+   A119       2.13618  -0.00093   0.00000  -0.00166  -0.00166   2.13451
+   A120       2.07408  -0.00043   0.00000  -0.00096  -0.00095   2.07313
+   A121       2.07292   0.00136   0.00000   0.00263   0.00262   2.07554
+   A122       2.07408  -0.00043   0.00000  -0.00096  -0.00095   2.07313
+   A123       2.13618  -0.00093   0.00000  -0.00166  -0.00166   2.13451
+   A124       2.12041  -0.00133   0.00000  -0.00346  -0.00346   2.11695
+   A125       2.08478   0.00025   0.00000   0.00028   0.00028   2.08506
+   A126       2.07800   0.00108   0.00000   0.00318   0.00318   2.08117
+   A127       2.11098  -0.00011   0.00000  -0.00052  -0.00052   2.11046
+   A128       2.07366  -0.00018   0.00000  -0.00057  -0.00057   2.07309
+   A129       2.09854   0.00030   0.00000   0.00109   0.00109   2.09964
+   A130       2.09812   0.00054   0.00000   0.00149   0.00148   2.09959
+   A131       2.09516   0.00000   0.00000   0.00021   0.00021   2.09537
+   A132       2.08991  -0.00054   0.00000  -0.00169  -0.00169   2.08822
+   A133       2.09812   0.00054   0.00000   0.00149   0.00148   2.09959
+   A134       2.08991  -0.00054   0.00000  -0.00169  -0.00169   2.08822
+   A135       2.09516   0.00000   0.00000   0.00021   0.00021   2.09537
+   A136       2.11098  -0.00011   0.00000  -0.00052  -0.00052   2.11046
+   A137       2.07366  -0.00018   0.00000  -0.00057  -0.00057   2.07309
+   A138       2.09854   0.00030   0.00000   0.00109   0.00109   2.09964
+    D1        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D2       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+    D3        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+    D4        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D5        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D6       -3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+    D7        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+    D8        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D9        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D10        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D11       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D12        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D13        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D14       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D15        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D16        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D17        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D18       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D19        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D20        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D21       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D22        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D23        0.00001   0.00000   0.00000   0.00000   0.00000   0.00001
+   D24       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D25        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D26       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D27        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D28        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D29       -0.00001   0.00000   0.00000   0.00000   0.00000  -0.00001
+   D30        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D31        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D32        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D33        0.00001   0.00000   0.00000   0.00000   0.00000   0.00001
+   D34       -3.14157   0.00000   0.00000   0.00000   0.00000  -3.14157
+   D35       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D36        0.00002   0.00000   0.00000   0.00000   0.00000   0.00002
+   D37        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D38       -3.14158   0.00000   0.00000   0.00000   0.00000  -3.14158
+   D39        3.14157   0.00000   0.00000   0.00000   0.00000   3.14157
+   D40        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D41       -3.14142   0.00000   0.00000  -0.00001  -0.00001  -3.14142
+   D42       -0.00008   0.00000   0.00000   0.00000   0.00000  -0.00008
+   D43        0.00020   0.00000   0.00000  -0.00001  -0.00001   0.00019
+   D44        3.14153   0.00000   0.00000   0.00000   0.00000   3.14153
+   D45       -0.00001   0.00000   0.00000   0.00000   0.00000  -0.00001
+   D46        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D47        3.14157   0.00000   0.00000   0.00000   0.00000   3.14157
+   D48       -0.00002   0.00000   0.00000   0.00000   0.00000  -0.00002
+   D49       -0.00019   0.00000   0.00000   0.00001   0.00001  -0.00019
+   D50       -3.14156   0.00000   0.00000   0.00000   0.00000  -3.14156
+   D51        3.14142   0.00000   0.00000   0.00001   0.00001   3.14142
+   D52        0.00005   0.00000   0.00000   0.00000   0.00000   0.00005
+   D53        0.00019   0.00000   0.00000  -0.00001  -0.00001   0.00018
+   D54       -3.14142   0.00000   0.00000  -0.00001  -0.00001  -3.14142
+   D55        3.14156   0.00000   0.00000   0.00000   0.00000   3.14156
+   D56       -0.00005   0.00000   0.00000   0.00000   0.00000  -0.00005
+   D57        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D58        3.14158   0.00000   0.00000   0.00000   0.00000   3.14158
+   D59       -3.14157   0.00000   0.00000   0.00000   0.00000  -3.14157
+   D60        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D61       -3.14157   0.00000   0.00000   0.00000   0.00000  -3.14157
+   D62        0.00002   0.00000   0.00000   0.00000   0.00000   0.00002
+   D63        0.00001   0.00000   0.00000   0.00000   0.00000   0.00001
+   D64       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D65       -0.00020   0.00000   0.00000   0.00001   0.00001  -0.00019
+   D66       -3.14153   0.00000   0.00000   0.00000   0.00000  -3.14153
+   D67        3.14142   0.00000   0.00000   0.00001   0.00001   3.14142
+   D68        0.00008   0.00000   0.00000   0.00000   0.00000   0.00008
+   D69       -0.00001   0.00000   0.00000   0.00000   0.00000  -0.00001
+   D70        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D71        3.14156   0.00000   0.00000   0.00000   0.00000   3.14156
+   D72       -0.00002   0.00000   0.00000   0.00000   0.00000  -0.00002
+   D73        0.00001   0.00000   0.00000   0.00000   0.00000   0.00001
+   D74       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D75       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D76        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D77        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D78        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D79       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D80        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D81       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D82        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D83        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D84        3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D85       -0.00001   0.00000   0.00000   0.00000   0.00000  -0.00001
+   D86        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D87        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D88        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D89        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D90       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D91        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D92        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D93        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D94       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D95        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D96        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D97        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D98        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D99        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D100       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D101       3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D102       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D103       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D104       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D105       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D106       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D107       3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D108       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D109       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D110       3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D111      -3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D112       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D113       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D114       3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D115       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D116       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D117       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D118       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D119       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D120       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D121      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D122       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D123       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D124       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D125       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D126       3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D127      -3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D128       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D129       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D130      -3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D131       3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D132       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D133       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D134      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D135       3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D136       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D137       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D138      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D139       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D140       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D141      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D142       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D143       0.00001   0.00000   0.00000   0.00000   0.00000   0.00001
+   D144      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D145       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D146      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D147       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D148       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D149      -0.00001   0.00000   0.00000   0.00000   0.00000  -0.00001
+   D150       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D151       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D152       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D153       0.00001   0.00000   0.00000   0.00000   0.00000   0.00001
+   D154      -3.14157   0.00000   0.00000   0.00000   0.00000  -3.14157
+   D155      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D156       0.00002   0.00000   0.00000   0.00000   0.00000   0.00002
+   D157       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D158      -3.14157   0.00000   0.00000   0.00000   0.00000  -3.14157
+   D159       3.14158   0.00000   0.00000   0.00000   0.00000   3.14158
+   D160       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D161      -3.14142   0.00000   0.00000  -0.00001  -0.00001  -3.14142
+   D162      -0.00005   0.00000   0.00000   0.00000   0.00000  -0.00005
+   D163       0.00019   0.00000   0.00000  -0.00001  -0.00001   0.00018
+   D164       3.14156   0.00000   0.00000   0.00000   0.00000   3.14156
+   D165      -0.00001   0.00000   0.00000   0.00000   0.00000  -0.00001
+   D166       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D167       3.14156   0.00000   0.00000   0.00000   0.00000   3.14156
+   D168      -0.00002   0.00000   0.00000   0.00000   0.00000  -0.00002
+   D169      -0.00020   0.00000   0.00000   0.00001   0.00001  -0.00019
+   D170      -3.14153   0.00000   0.00000   0.00000   0.00000  -3.14153
+   D171       3.14142   0.00000   0.00000   0.00001   0.00001   3.14142
+   D172       0.00008   0.00000   0.00000   0.00000   0.00000   0.00008
+   D173       0.00020   0.00000   0.00000  -0.00001  -0.00001   0.00019
+   D174      -3.14142   0.00000   0.00000  -0.00001  -0.00001  -3.14142
+   D175       3.14153   0.00000   0.00000   0.00000   0.00000   3.14153
+   D176      -0.00008   0.00000   0.00000   0.00000   0.00000  -0.00008
+   D177       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D178       3.14157   0.00000   0.00000   0.00000   0.00000   3.14157
+   D179      -3.14158   0.00000   0.00000   0.00000   0.00000  -3.14158
+   D180       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D181      -3.14157   0.00000   0.00000   0.00000   0.00000  -3.14157
+   D182       0.00002   0.00000   0.00000   0.00000   0.00000   0.00002
+   D183       0.00001   0.00000   0.00000   0.00000   0.00000   0.00001
+   D184      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D185      -0.00019   0.00000   0.00000   0.00001   0.00001  -0.00019
+   D186      -3.14156   0.00000   0.00000   0.00000   0.00000  -3.14156
+   D187       3.14142   0.00000   0.00000   0.00001   0.00001   3.14142
+   D188       0.00005   0.00000   0.00000   0.00000   0.00000   0.00005
+   D189      -0.00001   0.00000   0.00000   0.00000   0.00000  -0.00001
+   D190       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D191       3.14157   0.00000   0.00000   0.00000   0.00000   3.14157
+   D192      -0.00002   0.00000   0.00000   0.00000   0.00000  -0.00002
+   D193       0.00001   0.00000   0.00000   0.00000   0.00000   0.00001
+   D194      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D195      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D196       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D197       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D198       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D199      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D200       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D201      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D202       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D203       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D204       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D205      -0.00001   0.00000   0.00000   0.00000   0.00000  -0.00001
+   D206       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D207       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D208       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D209       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D210      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D211       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D212       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D213       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D214      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D215       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D216       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D217       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D218       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D219      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D220       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D221       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D222      -3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D223       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D224       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.038156     0.000450     NO 
+ RMS     Force            0.009143     0.000300     NO 
+ Maximum Displacement     0.339172     0.001800     NO 
+ RMS     Displacement     0.084479     0.001200     NO 
+ Predicted change in Energy=-3.766089D-02
+ Lowest energy point so far.  Saving SCF results.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Tue Aug  4 10:39:14 2020, MaxMem=    33554432 cpu:         0.1
+ (Enter /cluster/apps/gaussian/g09/l202.exe)
+ Stoichiometry    C42H26N4
+ Framework group  C2[X(C42H26N4)]
+ Deg. of freedom   106
+ Full point group                 C2      NOp   2
+ RotChk:  IX=0 Diff= 2.00D+00
+ Largest Abelian subgroup         C2      NOp   2
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0      -13.620360    0.713109    0.000578
+      2          6           0      -13.620360   -0.713106    0.000578
+      3          6           0      -12.421386    1.413669    0.000424
+      4          6           0      -11.165013    0.723495    0.000264
+      5          6           0      -11.165013   -0.723493    0.000265
+      6          6           0      -12.421387   -1.413667    0.000425
+      7          6           0       -9.908422   -1.417732    0.000107
+      8          6           0       -8.701873   -0.727073   -0.000052
+      9          6           0       -8.701873    0.727074   -0.000052
+     10          6           0       -9.908421    1.417734    0.000107
+     11          7           0       -7.447064    1.388109   -0.000239
+     12          6           0       -6.188428    0.735305   -0.000211
+     13          6           0       -6.188428   -0.735303   -0.000211
+     14          7           0       -7.447064   -1.388108   -0.000242
+     15          6           0       -4.992501   -1.424275   -0.000203
+     16          6           0       -3.717551   -0.735266   -0.000205
+     17          6           0       -3.717551    0.735267   -0.000205
+     18          6           0       -4.992501    1.424276   -0.000203
+     19          6           0       -2.496418    1.420499   -0.000205
+     20          6           0       -1.239304    0.734373   -0.000204
+     21          6           0       -1.239304   -0.734372   -0.000204
+     22          6           0       -2.496418   -1.420499   -0.000205
+     23          6           0        0.000000   -1.420392   -0.000204
+     24          6           0        1.239304   -0.734373   -0.000204
+     25          6           0        1.239304    0.734372   -0.000204
+     26          6           0        0.000000    1.420392   -0.000204
+     27          6           0        2.496418    1.420499   -0.000205
+     28          6           0        3.717551    0.735266   -0.000205
+     29          6           0        3.717551   -0.735267   -0.000205
+     30          6           0        2.496418   -1.420499   -0.000205
+     31          6           0        4.992501   -1.424276   -0.000203
+     32          6           0        6.188428   -0.735305   -0.000211
+     33          6           0        6.188428    0.735303   -0.000211
+     34          6           0        4.992501    1.424275   -0.000203
+     35          7           0        7.447064    1.388108   -0.000242
+     36          6           0        8.701873    0.727073   -0.000052
+     37          6           0        8.701873   -0.727074   -0.000052
+     38          7           0        7.447064   -1.388109   -0.000239
+     39          6           0        9.908421   -1.417734    0.000107
+     40          6           0       11.165013   -0.723495    0.000264
+     41          6           0       11.165013    0.723493    0.000265
+     42          6           0        9.908422    1.417732    0.000107
+     43          6           0       12.421387    1.413667    0.000425
+     44          6           0       13.620360    0.713106    0.000578
+     45          6           0       13.620360   -0.713109    0.000578
+     46          6           0       12.421386   -1.413669    0.000424
+     47          1           0      -14.572364    1.254941    0.000700
+     48          1           0      -14.572365   -1.254939    0.000700
+     49          1           0      -12.421338    2.509472    0.000424
+     50          1           0      -12.421339   -2.509470    0.000426
+     51          1           0       -9.902254   -2.512705    0.000109
+     52          1           0       -9.902254    2.512707    0.000109
+     53          1           0       -5.000032   -2.518994   -0.000201
+     54          1           0       -5.000032    2.518995   -0.000199
+     55          1           0       -2.495596   -2.516256   -0.000205
+     56          1           0        0.000000    2.516375   -0.000204
+     57          1           0        2.495596   -2.516257   -0.000205
+     58          1           0        5.000032    2.518994   -0.000201
+     59          1           0        9.902254   -2.512707    0.000109
+     60          1           0        9.902254    2.512705    0.000109
+     61          1           0       12.421339    2.509470    0.000426
+     62          1           0       14.572365    1.254939    0.000700
+     63          1           0       14.572364   -1.254941    0.000700
+     64          1           0       12.421338   -2.509472    0.000424
+     65          1           0       -2.495596    2.516257   -0.000205
+     66          1           0        2.495596    2.516256   -0.000205
+     67          1           0        0.000000   -2.516375   -0.000204
+     68          1           0        5.000032   -2.518995   -0.000199
+     69          1           0       -7.449660    2.423200   -0.000207
+     70          1           0        7.449660    2.423199   -0.000188
+     71          1           0       -7.449660   -2.423199   -0.000188
+     72          1           0        7.449660   -2.423200   -0.000207
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      0.6013537      0.0126214      0.0123619
+ Leave Link  202 at Tue Aug  4 10:39:14 2020, MaxMem=    33554432 cpu:         0.0
+ (Enter /cluster/apps/gaussian/g09/l301.exe)
+ Standard basis: STO-3G (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are   128 symmetry adapted cartesian basis functions of A   symmetry.
+ There are   128 symmetry adapted cartesian basis functions of B   symmetry.
+ There are   128 symmetry adapted basis functions of A   symmetry.
+ There are   128 symmetry adapted basis functions of B   symmetry.
+   256 basis functions,   768 primitive gaussians,   256 cartesian basis functions
+   153 alpha electrons      153 beta electrons
+       nuclear repulsion energy      4285.7181138520 Hartrees.
+ IExCor=  402 DFT=T Ex+Corr=B3LYP ExCW=0 ScaHFX=  0.200000
+ ScaDFX=  0.800000  0.720000  1.000000  0.810000 ScalE2=  1.000000  1.000000
+ IRadAn=      0 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=  4
+ NAtoms=   72 NActive=   72 NUniq=   36 SFac= 4.00D+00 NAtFMM=   60 NAOKFM=T Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ Leave Link  301 at Tue Aug  4 10:39:14 2020, MaxMem=    33554432 cpu:         0.0
+ (Enter /cluster/apps/gaussian/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+ One-electron integral symmetry used in STVInt
+ NBasis=   256 RedAO= T EigKep=  1.27D-01  NBF=   128   128
+ NBsUse=   256 1.00D-06 EigRej= -1.00D+00 NBFU=   128   128
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           0 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   216   218   218   218   218 MxSgAt=    72 MxSgA2=    71.
+ Leave Link  302 at Tue Aug  4 10:39:15 2020, MaxMem=    33554432 cpu:         1.2
+ (Enter /cluster/apps/gaussian/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Tue Aug  4 10:39:15 2020, MaxMem=    33554432 cpu:         0.0
+ (Enter /cluster/apps/gaussian/g09/l401.exe)
+ Initial guess from the checkpoint file:  "r-b3lyp-sto3g.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    0.707107    0.000000    0.000000   -0.707107 Ang= -90.00 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess orbital symmetries:
+       Occupied  (B) (A) (B) (A) (B) (A) (A) (B) (B) (A) (B) (A)
+                 (B) (A) (B) (A) (B) (A) (B) (A) (B) (A) (B) (A)
+                 (B) (A) (B) (A) (B) (A) (B) (A) (B) (A) (B) (A)
+                 (B) (A) (A) (B) (B) (A) (A) (B) (B) (A) (A) (B)
+                 (B) (A) (A) (B) (A) (B) (A) (B) (A) (B) (B) (A)
+                 (B) (A) (A) (B) (B) (A) (A) (B) (B) (A) (A) (B)
+                 (B) (A) (A) (B) (B) (A) (A) (B) (A) (A) (B) (B)
+                 (A) (A) (B) (B) (A) (A) (B) (B) (A) (B) (A) (B)
+                 (A) (B) (B) (A) (B) (A) (A) (B) (A) (B) (A) (B)
+                 (B) (A) (B) (B) (A) (A) (A) (A) (B) (A) (B) (B)
+                 (B) (A) (A) (B) (B) (B) (B) (A) (A) (A) (B) (A)
+                 (B) (A) (B) (B) (A) (A) (A) (B) (A) (B) (B) (A)
+                 (A) (B) (B) (A) (B) (A) (A) (B) (B)
+       Virtual   (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (B) (B) (B) (B) (B) (B) (B) (B)
+                 (B) (B) (B) (B) (B) (B) (B) (B) (B) (B) (B) (B)
+                 (B) (B) (B) (B) (B) (B) (B) (B) (B) (B) (B) (B)
+                 (B) (B) (B) (B) (B) (B) (B) (B) (B) (B) (B) (B)
+                 (B) (B) (B) (B) (B) (B) (B)
+ The electronic state of the initial guess is 1-A.
+ Generating alternative initial guess.
+ ExpMin= 1.69D-01 ExpMax= 9.91D+01 ExpMxC= 9.91D+01 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=        2000
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Harris En= -1811.91845501181    
+ Leave Link  401 at Tue Aug  4 10:39:17 2020, MaxMem=    33554432 cpu:         1.6
+ (Enter /cluster/apps/gaussian/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=    10.
+ Integral symmetry usage will be decided dynamically.
+ IVT=     4406646 IEndB=     4406646 NGot=    33554432 MDV=    33411979
+ LenX=    33411979 LenY=    33346002
+ Requested convergence on RMS density matrix=1.00D-07 within2048 cycles.
+ Requested convergence on MAX density matrix=1.00D-05.
+ Requested convergence on             energy=1.00D-05.
+ Level shift goal  0.100 maximum shift  0.100.
+ No special actions if energy rises.
+ Fock matrices will be formed incrementally for  20 cycles.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+
+ Cycle   1  Pass 0  IDiag  1:
+ FoFJK:  IHMeth= 1 ICntrl=       0 DoSepK=F KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf= 390000000 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=        2000
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=       0 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ E= -1812.58069501290    
+ DIIS: error= 3.34D-03 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -1812.58069501290     IErMin= 1 ErrMin= 3.34D-03
+ ErrMax= 3.34D-03  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.24D-03 BMatP= 2.24D-03
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.442 Goal=     0.100 Shift=    0.000
+ GapD=    0.442 DampG=2.000 DampE=1.000 DampFc=2.0000 IDamp=-1.
+ RMSDP=3.31D-04 MaxDP=1.05D-02              OVMax= 0.00D+00
+
+ Cycle   2  Pass 0  IDiag  1:
+ RMSU=  3.27D-04    CP:  1.00D+00
+ E= -1812.58303028444     Delta-E=       -0.002335271546 Rises=F Damp=F
+ DIIS: error= 1.07D-03 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -1812.58303028444     IErMin= 2 ErrMin= 1.07D-03
+ ErrMax= 1.07D-03  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.77D-04 BMatP= 2.24D-03
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.101D+00 0.899D+00
+ Coeff:      0.101D+00 0.899D+00
+ Gap=     0.094 Goal=     0.100 Shift=    0.006
+ GapD=    0.094 DampG=0.500 DampE=1.000 DampFc=0.5000 IDamp=-1.
+ Damping current iteration by 5.00D-01
+ RMSDP=1.87D-04 MaxDP=8.20D-03 DE=-2.34D-03 OVMax= 0.00D+00
+
+ Cycle   3  Pass 0  IDiag  1:
+ RMSU=  9.31D-05    CP:  1.00D+00  9.71D-01
+ E= -1812.58311253982     Delta-E=       -0.000082255378 Rises=F Damp=T
+ DIIS: error= 3.67D-04 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -1812.58311253982     IErMin= 3 ErrMin= 3.67D-04
+ ErrMax= 3.67D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.28D-05 BMatP= 1.77D-04
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.733D-02 0.207D+00 0.801D+00
+ Coeff:     -0.733D-02 0.207D+00 0.801D+00
+ Gap=     0.094 Goal=     0.100 Shift=    0.006
+ RMSDP=4.84D-05 MaxDP=1.96D-03 DE=-8.23D-05 OVMax= 0.00D+00
+
+ Cycle   4  Pass 0  IDiag  1:
+ RMSU=  4.04D-05    CP:  1.00D+00  1.01D+00  7.50D-01
+ E= -1812.58324491098     Delta-E=       -0.000132371155 Rises=F Damp=F
+ DIIS: error= 2.90D-04 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -1812.58324491098     IErMin= 4 ErrMin= 2.90D-04
+ ErrMax= 2.90D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.60D-05 BMatP= 2.28D-05
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.103D-01 0.736D-01 0.469D+00 0.467D+00
+ Coeff:     -0.103D-01 0.736D-01 0.469D+00 0.467D+00
+ Gap=     0.094 Goal=     0.100 Shift=    0.006
+ RMSDP=2.45D-05 MaxDP=1.11D-03 DE=-1.32D-04 OVMax= 0.00D+00
+
+ Cycle   5  Pass 0  IDiag  1:
+ RMSU=  9.31D-06    CP:  1.00D+00  1.01D+00  8.58D-01  4.98D-01
+ E= -1812.58326599695     Delta-E=       -0.000021085971 Rises=F Damp=F
+ DIIS: error= 5.29D-05 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -1812.58326599695     IErMin= 5 ErrMin= 5.29D-05
+ ErrMax= 5.29D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 4.80D-07 BMatP= 1.60D-05
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.357D-02 0.169D-01 0.125D+00 0.193D+00 0.668D+00
+ Coeff:     -0.357D-02 0.169D-01 0.125D+00 0.193D+00 0.668D+00
+ Gap=     0.094 Goal=     0.100 Shift=    0.006
+ RMSDP=4.59D-06 MaxDP=1.61D-04 DE=-2.11D-05 OVMax= 0.00D+00
+
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ Cycle   6  Pass 1  IDiag  1:
+ E= -1812.58275078254     Delta-E=        0.000515214405 Rises=F Damp=F
+ DIIS: error= 1.30D-05 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -1812.58275078254     IErMin= 1 ErrMin= 1.30D-05
+ ErrMax= 1.30D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 5.91D-08 BMatP= 5.91D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.094 Goal=   None    Shift=    0.000
+ RMSDP=4.59D-06 MaxDP=1.61D-04 DE= 5.15D-04 OVMax= 0.00D+00
+
+ Cycle   7  Pass 1  IDiag  1:
+ RMSU=  3.03D-06    CP:  1.00D+00
+ E= -1812.58275075147     Delta-E=        0.000000031070 Rises=F Damp=F
+ DIIS: error= 2.05D-05 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 1 EnMin= -1812.58275078254     IErMin= 1 ErrMin= 1.30D-05
+ ErrMax= 2.05D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 9.06D-08 BMatP= 5.91D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.563D+00 0.437D+00
+ Coeff:      0.563D+00 0.437D+00
+ Gap=     0.094 Goal=   None    Shift=    0.000
+ RMSDP=2.11D-06 MaxDP=8.22D-05 DE= 3.11D-08 OVMax= 0.00D+00
+
+ Cycle   8  Pass 1  IDiag  1:
+ RMSU=  1.05D-06    CP:  1.00D+00  3.99D-01
+ E= -1812.58275087581     Delta-E=       -0.000000124338 Rises=F Damp=F
+ DIIS: error= 5.39D-06 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -1812.58275087581     IErMin= 3 ErrMin= 5.39D-06
+ ErrMax= 5.39D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 5.21D-09 BMatP= 5.91D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.237D-01 0.194D+00 0.782D+00
+ Coeff:      0.237D-01 0.194D+00 0.782D+00
+ Gap=     0.094 Goal=   None    Shift=    0.000
+ RMSDP=4.98D-07 MaxDP=2.01D-05 DE=-1.24D-07 OVMax= 0.00D+00
+
+ Cycle   9  Pass 1  IDiag  1:
+ RMSU=  2.44D-07    CP:  1.00D+00  5.23D-01  7.95D-01
+ E= -1812.58275088304     Delta-E=       -0.000000007230 Rises=F Damp=F
+ DIIS: error= 1.28D-06 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -1812.58275088304     IErMin= 4 ErrMin= 1.28D-06
+ ErrMax= 1.28D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 4.83D-10 BMatP= 5.21D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.967D-02 0.921D-01 0.435D+00 0.482D+00
+ Coeff:     -0.967D-02 0.921D-01 0.435D+00 0.482D+00
+ Gap=     0.094 Goal=   None    Shift=    0.000
+ RMSDP=1.42D-07 MaxDP=7.36D-06 DE=-7.23D-09 OVMax= 0.00D+00
+
+ Cycle  10  Pass 1  IDiag  1:
+ RMSU=  6.80D-08    CP:  1.00D+00  5.16D-01  8.26D-01  5.17D-01
+ E= -1812.58275088380     Delta-E=       -0.000000000758 Rises=F Damp=F
+ DIIS: error= 5.11D-07 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -1812.58275088380     IErMin= 5 ErrMin= 5.11D-07
+ ErrMax= 5.11D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.26D-11 BMatP= 4.83D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.575D-02 0.388D-01 0.188D+00 0.258D+00 0.521D+00
+ Coeff:     -0.575D-02 0.388D-01 0.188D+00 0.258D+00 0.521D+00
+ Gap=     0.094 Goal=   None    Shift=    0.000
+ RMSDP=5.18D-08 MaxDP=1.55D-06 DE=-7.58D-10 OVMax= 0.00D+00
+
+ SCF Done:  E(RB3LYP) =  -1812.58275088     A.U. after   10 cycles
+            NFock= 10  Conv=0.52D-07     -V/T= 2.0185
+ KE= 1.779710775506D+03 PE=-1.276981953346D+04 EE= 4.891807893221D+03
+ Leave Link  502 at Tue Aug  4 10:39:49 2020, MaxMem=    33554432 cpu:        32.6
+ (Enter /cluster/apps/gaussian/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ Leave Link  701 at Tue Aug  4 10:39:50 2020, MaxMem=    33554432 cpu:         0.2
+ (Enter /cluster/apps/gaussian/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Tue Aug  4 10:39:50 2020, MaxMem=    33554432 cpu:         0.0
+ (Enter /cluster/apps/gaussian/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=F KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         0 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=        2800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2127 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Tue Aug  4 10:40:01 2020, MaxMem=    33554432 cpu:        11.7
+ (Enter /cluster/apps/gaussian/g09/l716.exe)
+ Dipole        = 1.70419184D-13-1.93942112D-15 1.50406801D-04
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6           0.000953556    0.001175818   -0.000000253
+      2        6           0.000953391   -0.001175551   -0.000000170
+      3        6          -0.002022776    0.000895213    0.000000375
+      4        6           0.000488184   -0.002959882    0.000000050
+      5        6           0.000487783    0.002959903   -0.000000140
+      6        6          -0.002022463   -0.000895369    0.000000388
+      7        6           0.001297220   -0.002904673   -0.000000325
+      8        6          -0.005448075    0.002854469    0.000000878
+      9        6          -0.005448424   -0.002854536    0.000000815
+     10        6           0.001297178    0.002904667   -0.000000489
+     11        7          -0.000094516    0.003584855   -0.000001442
+     12        6           0.005819210   -0.002942141    0.000000206
+     13        6           0.005818764    0.002942024    0.000000263
+     14        7          -0.000094376   -0.003584717   -0.000001285
+     15        6          -0.002081360   -0.003032165   -0.000000333
+     16        6           0.001294668    0.002056760    0.000000093
+     17        6           0.001294776   -0.002056943   -0.000000045
+     18        6          -0.002081622    0.003032187   -0.000000232
+     19        6          -0.001054539    0.001890076    0.000000155
+     20        6           0.000500136   -0.001883624   -0.000000052
+     21        6           0.000499844    0.001883456    0.000000049
+     22        6          -0.001054687   -0.001889662   -0.000000051
+     23        6           0.000000268   -0.001825082   -0.000000032
+     24        6          -0.000500136    0.001883624   -0.000000052
+     25        6          -0.000499844   -0.001883456    0.000000049
+     26        6          -0.000000268    0.001825082   -0.000000032
+     27        6           0.001054687    0.001889662   -0.000000051
+     28        6          -0.001294668   -0.002056760    0.000000093
+     29        6          -0.001294776    0.002056943   -0.000000045
+     30        6           0.001054539   -0.001890076    0.000000155
+     31        6           0.002081622   -0.003032187   -0.000000232
+     32        6          -0.005819210    0.002942141    0.000000206
+     33        6          -0.005818764   -0.002942024    0.000000263
+     34        6           0.002081360    0.003032165   -0.000000333
+     35        7           0.000094376    0.003584717   -0.000001285
+     36        6           0.005448075   -0.002854469    0.000000878
+     37        6           0.005448424    0.002854536    0.000000815
+     38        7           0.000094516   -0.003584855   -0.000001442
+     39        6          -0.001297178   -0.002904667   -0.000000489
+     40        6          -0.000488184    0.002959882    0.000000050
+     41        6          -0.000487783   -0.002959903   -0.000000140
+     42        6          -0.001297220    0.002904673   -0.000000325
+     43        6           0.002022463    0.000895369    0.000000388
+     44        6          -0.000953391    0.001175551   -0.000000170
+     45        6          -0.000953556   -0.001175818   -0.000000253
+     46        6           0.002022776   -0.000895213    0.000000375
+     47        1          -0.001937449    0.000880234    0.000000259
+     48        1          -0.001937526   -0.000880359    0.000000265
+     49        1           0.000224550    0.001998680   -0.000000047
+     50        1           0.000224541   -0.001998676   -0.000000070
+     51        1           0.000167374   -0.001787397   -0.000000075
+     52        1           0.000167380    0.001787393   -0.000000076
+     53        1          -0.000093091   -0.001777901    0.000000006
+     54        1          -0.000093069    0.001777904   -0.000000101
+     55        1           0.000032753   -0.001940450    0.000000018
+     56        1           0.000000040    0.001973817    0.000000012
+     57        1          -0.000032696   -0.001940340   -0.000000036
+     58        1           0.000093091    0.001777901    0.000000006
+     59        1          -0.000167380   -0.001787393   -0.000000076
+     60        1          -0.000167374    0.001787397   -0.000000075
+     61        1          -0.000224541    0.001998676   -0.000000070
+     62        1           0.001937526    0.000880359    0.000000265
+     63        1           0.001937449   -0.000880234    0.000000259
+     64        1          -0.000224550   -0.001998680   -0.000000047
+     65        1           0.000032696    0.001940340   -0.000000036
+     66        1          -0.000032753    0.001940450    0.000000018
+     67        1          -0.000000040   -0.001973817    0.000000012
+     68        1           0.000093069   -0.001777904   -0.000000101
+     69        1          -0.000045246    0.005503172    0.000000813
+     70        1           0.000045278    0.005503124    0.000000612
+     71        1          -0.000045278   -0.005503124    0.000000612
+     72        1           0.000045246   -0.005503172    0.000000813
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.005819210 RMS     0.001924781
+ Leave Link  716 at Tue Aug  4 10:40:01 2020, MaxMem=    33554432 cpu:         0.0
+ (Enter /cluster/apps/gaussian/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.007809339 RMS     0.001571145
+ Search for a local minimum.
+ Step number   2 out of a maximum of  432
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .15711D-02 SwitMx=.10000D-02 MixMth= 1
+ Mixed Optimization -- RFO/linear search
+ Update second derivatives using D2CorX and points    1    2
+ DE= -3.31D-02 DEPred=-3.77D-02 R= 8.78D-01
+ TightC=F SS=  1.41D+00  RLast= 3.00D-01 DXNew= 5.0454D-01 9.0000D-01
+ Trust test= 8.78D-01 RLast= 3.00D-01 DXMaxT set to 5.05D-01
+ ITU=  1  0
+ Use linear search instead of GDIIS.
+     Eigenvalues ---    0.01654   0.01659   0.01708   0.01738   0.01765
+     Eigenvalues ---    0.01771   0.01776   0.01785   0.01785   0.01811
+     Eigenvalues ---    0.01811   0.01821   0.01821   0.01822   0.01838
+     Eigenvalues ---    0.01841   0.01841   0.01841   0.01841   0.01841
+     Eigenvalues ---    0.01841   0.01857   0.01864   0.01872   0.01876
+     Eigenvalues ---    0.01882   0.01897   0.01897   0.01903   0.01903
+     Eigenvalues ---    0.01938   0.01938   0.01980   0.01980   0.02005
+     Eigenvalues ---    0.02005   0.02047   0.02047   0.02047   0.02047
+     Eigenvalues ---    0.02088   0.02088   0.02088   0.02091   0.02091
+     Eigenvalues ---    0.02101   0.02101   0.02109   0.02109   0.02123
+     Eigenvalues ---    0.02124   0.02127   0.02127   0.02139   0.02139
+     Eigenvalues ---    0.02156   0.02156   0.02163   0.02163   0.02167
+     Eigenvalues ---    0.02167   0.02203   0.02203   0.02205   0.02205
+     Eigenvalues ---    0.02259   0.02259   0.02276   0.02276   0.15998
+     Eigenvalues ---    0.16000   0.16000   0.16000   0.16000   0.16000
+     Eigenvalues ---    0.16000   0.16000   0.16000   0.16000   0.16000
+     Eigenvalues ---    0.16000   0.16000   0.16000   0.16000   0.16000
+     Eigenvalues ---    0.16000   0.16000   0.16000   0.16000   0.16000
+     Eigenvalues ---    0.16000   0.16000   0.16000   0.16000   0.16000
+     Eigenvalues ---    0.22000   0.22000   0.22490   0.22490   0.22782
+     Eigenvalues ---    0.22861   0.22971   0.23100   0.23214   0.23314
+     Eigenvalues ---    0.23337   0.23434   0.23457   0.23654   0.23684
+     Eigenvalues ---    0.23742   0.23825   0.23921   0.24020   0.24127
+     Eigenvalues ---    0.24234   0.24317   0.24565   0.24565   0.25000
+     Eigenvalues ---    0.25000   0.25000   0.25000   0.25000   0.25000
+     Eigenvalues ---    0.25000   0.25000   0.25000   0.33299   0.33987
+     Eigenvalues ---    0.34930   0.35278   0.35280   0.35286   0.35286
+     Eigenvalues ---    0.35286   0.35290   0.35296   0.35296   0.35296
+     Eigenvalues ---    0.35301   0.35305   0.35305   0.35305   0.35332
+     Eigenvalues ---    0.35359   0.35359   0.35359   0.35419   0.35499
+     Eigenvalues ---    0.35499   0.35499   0.35604   0.35745   0.36337
+     Eigenvalues ---    0.36984   0.37482   0.37986   0.38803   0.38806
+     Eigenvalues ---    0.39552   0.39853   0.40193   0.40193   0.40478
+     Eigenvalues ---    0.40595   0.40714   0.40714   0.40714   0.40774
+     Eigenvalues ---    0.41829   0.42141   0.42198   0.42449   0.42516
+     Eigenvalues ---    0.42788   0.42900   0.43120   0.43120   0.43331
+     Eigenvalues ---    0.43710   0.44641   0.45608   0.45737   0.46316
+     Eigenvalues ---    0.46316   0.46316   0.46603   0.46608   0.46684
+     Eigenvalues ---    0.46784   0.46787   0.47364   0.47547   0.47547
+     Eigenvalues ---    0.47553   0.47712   0.47985   0.47985   0.48222
+     Eigenvalues ---    0.48222   0.48395   0.49188   0.49273   0.49352
+     Eigenvalues ---    0.49739   0.49739   0.50530   0.51093   0.56836
+ RFO step:  Lambda=-4.54390788D-04 EMin= 1.65416896D-02
+ Quartic linear search produced a step of  0.21164.
+ Iteration  1 RMS(Cart)=  0.01097637 RMS(Int)=  0.00000576
+ Iteration  2 RMS(Cart)=  0.00003703 RMS(Int)=  0.00000118
+ Iteration  3 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000118
+ ITry= 1 IFail=0 DXMaxC= 4.39D-02 DCOld= 1.00D+10 DXMaxT= 5.05D-01 DXLimC= 3.00D+00 Rises=F
+ ClnCor:  largest displacement from symmetrization is 3.62D-09 for atom    67.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.69516   0.00299   0.00585   0.00044   0.00629   2.70144
+    R2        2.62415   0.00132   0.00485  -0.00320   0.00166   2.62581
+    R3        2.07000   0.00212   0.00450   0.00111   0.00561   2.07561
+    R4        2.62415   0.00132   0.00485  -0.00320   0.00166   2.62581
+    R5        2.07000   0.00212   0.00450   0.00111   0.00561   2.07561
+    R6        2.70885   0.00338   0.00678   0.00051   0.00729   2.71614
+    R7        2.07077   0.00200   0.00419   0.00114   0.00533   2.07610
+    R8        2.73441   0.00172   0.00657  -0.00369   0.00287   2.73728
+    R9        2.71292   0.00332   0.00672   0.00045   0.00717   2.72009
+   R10        2.70885   0.00338   0.00678   0.00051   0.00729   2.71614
+   R11        2.71292   0.00332   0.00672   0.00045   0.00717   2.72009
+   R12        2.07077   0.00200   0.00419   0.00114   0.00533   2.07610
+   R13        2.62717   0.00170   0.00590  -0.00363   0.00228   2.62945
+   R14        2.06923   0.00179   0.00365   0.00117   0.00482   2.07405
+   R15        2.74794   0.00361   0.00901  -0.00124   0.00777   2.75571
+   R16        2.68016   0.00765   0.01166   0.00412   0.01578   2.69594
+   R17        2.62717   0.00170   0.00590  -0.00363   0.00228   2.62945
+   R18        2.68016   0.00765   0.01166   0.00412   0.01578   2.69594
+   R19        2.06923   0.00179   0.00365   0.00117   0.00482   2.07405
+   R20        2.67936   0.00781   0.01184   0.00420   0.01604   2.69540
+   R21        1.95605   0.00550   0.01085   0.00001   0.01087   1.96691
+   R22        2.77905   0.00361   0.00879  -0.00054   0.00825   2.78730
+   R23        2.60818   0.00150   0.00579  -0.00410   0.00169   2.60987
+   R24        2.67936   0.00781   0.01183   0.00420   0.01604   2.69540
+   R25        2.60818   0.00150   0.00579  -0.00410   0.00169   2.60987
+   R26        1.95605   0.00550   0.01085   0.00001   0.01087   1.96691
+   R27        2.73862   0.00379   0.00702   0.00187   0.00889   2.74752
+   R28        2.06877   0.00178   0.00359   0.00122   0.00481   2.07357
+   R29        2.77891   0.00254   0.00689  -0.00113   0.00576   2.78467
+   R30        2.64609   0.00215   0.00619  -0.00277   0.00341   2.64951
+   R31        2.73862   0.00379   0.00702   0.00187   0.00889   2.74752
+   R32        2.64609   0.00215   0.00619  -0.00277   0.00341   2.64951
+   R33        2.06877   0.00178   0.00359   0.00122   0.00481   2.07357
+   R34        2.70641   0.00319   0.00682  -0.00015   0.00667   2.71307
+   R35        2.07068   0.00194   0.00393   0.00132   0.00524   2.07593
+   R36        2.77553   0.00209   0.00642  -0.00198   0.00444   2.77997
+   R37        2.67681   0.00267   0.00657  -0.00163   0.00494   2.68176
+   R38        2.70641   0.00319   0.00682  -0.00015   0.00667   2.71307
+   R39        2.67681   0.00267   0.00657  -0.00163   0.00495   2.68176
+   R40        2.07068   0.00194   0.00393   0.00132   0.00524   2.07593
+   R41        2.67681   0.00267   0.00657  -0.00163   0.00494   2.68176
+   R42        2.07111   0.00197   0.00399   0.00135   0.00534   2.07644
+   R43        2.77553   0.00209   0.00642  -0.00198   0.00444   2.77997
+   R44        2.70641   0.00319   0.00682  -0.00015   0.00667   2.71307
+   R45        2.67681   0.00267   0.00657  -0.00163   0.00495   2.68176
+   R46        2.70641   0.00319   0.00682  -0.00015   0.00667   2.71307
+   R47        2.07111   0.00197   0.00399   0.00135   0.00534   2.07644
+   R48        2.64609   0.00215   0.00619  -0.00277   0.00341   2.64951
+   R49        2.07068   0.00194   0.00393   0.00132   0.00524   2.07593
+   R50        2.77891   0.00254   0.00689  -0.00113   0.00576   2.78467
+   R51        2.73862   0.00379   0.00702   0.00187   0.00889   2.74752
+   R52        2.64609   0.00215   0.00619  -0.00277   0.00341   2.64951
+   R53        2.73862   0.00379   0.00702   0.00187   0.00889   2.74752
+   R54        2.07068   0.00194   0.00393   0.00132   0.00524   2.07593
+   R55        2.60818   0.00150   0.00579  -0.00410   0.00169   2.60987
+   R56        2.06877   0.00178   0.00359   0.00122   0.00481   2.07357
+   R57        2.77905   0.00361   0.00879  -0.00054   0.00825   2.78730
+   R58        2.67936   0.00781   0.01184   0.00420   0.01604   2.69540
+   R59        2.60818   0.00150   0.00579  -0.00410   0.00169   2.60987
+   R60        2.67936   0.00781   0.01183   0.00420   0.01604   2.69540
+   R61        2.06877   0.00178   0.00359   0.00122   0.00481   2.07357
+   R62        2.68016   0.00765   0.01166   0.00412   0.01578   2.69594
+   R63        1.95605   0.00550   0.01085   0.00001   0.01087   1.96691
+   R64        2.74794   0.00361   0.00901  -0.00124   0.00777   2.75571
+   R65        2.62717   0.00170   0.00590  -0.00363   0.00228   2.62945
+   R66        2.68016   0.00765   0.01166   0.00412   0.01578   2.69594
+   R67        2.62717   0.00170   0.00590  -0.00363   0.00228   2.62945
+   R68        1.95605   0.00550   0.01085   0.00001   0.01087   1.96691
+   R69        2.71292   0.00332   0.00672   0.00045   0.00717   2.72009
+   R70        2.06923   0.00179   0.00365   0.00117   0.00482   2.07405
+   R71        2.73441   0.00172   0.00657  -0.00369   0.00287   2.73728
+   R72        2.70885   0.00338   0.00678   0.00051   0.00729   2.71614
+   R73        2.71292   0.00332   0.00672   0.00045   0.00717   2.72009
+   R74        2.70885   0.00338   0.00678   0.00051   0.00729   2.71614
+   R75        2.06923   0.00179   0.00365   0.00117   0.00482   2.07405
+   R76        2.62415   0.00132   0.00485  -0.00320   0.00166   2.62581
+   R77        2.07077   0.00200   0.00419   0.00114   0.00533   2.07610
+   R78        2.69516   0.00299   0.00585   0.00044   0.00629   2.70144
+   R79        2.07000   0.00212   0.00450   0.00111   0.00561   2.07561
+   R80        2.62415   0.00132   0.00485  -0.00320   0.00166   2.62581
+   R81        2.07000   0.00212   0.00450   0.00111   0.00561   2.07561
+   R82        2.07077   0.00200   0.00419   0.00114   0.00533   2.07610
+    A1        2.09959   0.00022   0.00031   0.00068   0.00099   2.10058
+    A2        2.08822  -0.00031  -0.00036  -0.00154  -0.00190   2.08632
+    A3        2.09537   0.00009   0.00004   0.00086   0.00091   2.09628
+    A4        2.09959   0.00022   0.00031   0.00068   0.00099   2.10058
+    A5        2.08822  -0.00031  -0.00036  -0.00154  -0.00190   2.08632
+    A6        2.09537   0.00009   0.00004   0.00086   0.00091   2.09628
+    A7        2.11046  -0.00030  -0.00011  -0.00142  -0.00153   2.10893
+    A8        2.09964   0.00038   0.00023   0.00219   0.00242   2.10206
+    A9        2.07309  -0.00008  -0.00012  -0.00078  -0.00090   2.07219
+   A10        2.07313   0.00007  -0.00020   0.00074   0.00054   2.07367
+   A11        2.13451  -0.00073  -0.00035  -0.00326  -0.00361   2.13090
+   A12        2.07554   0.00066   0.00055   0.00252   0.00307   2.07861
+   A13        2.07313   0.00007  -0.00020   0.00074   0.00054   2.07367
+   A14        2.07554   0.00066   0.00055   0.00252   0.00307   2.07861
+   A15        2.13451  -0.00073  -0.00035  -0.00326  -0.00361   2.13090
+   A16        2.11046  -0.00030  -0.00011  -0.00142  -0.00153   2.10893
+   A17        2.09964   0.00038   0.00023   0.00219   0.00242   2.10206
+   A18        2.07309  -0.00008  -0.00012  -0.00078  -0.00090   2.07219
+   A19        2.11695  -0.00127  -0.00073  -0.00550  -0.00623   2.11072
+   A20        2.08117   0.00080   0.00067   0.00351   0.00418   2.08535
+   A21        2.08506   0.00047   0.00006   0.00199   0.00205   2.08711
+   A22        2.09069   0.00061   0.00018   0.00298   0.00316   2.09385
+   A23        2.13684  -0.00106  -0.00046  -0.00492  -0.00538   2.13146
+   A24        2.05565   0.00045   0.00028   0.00194   0.00222   2.05787
+   A25        2.09069   0.00061   0.00018   0.00298   0.00316   2.09385
+   A26        2.05565   0.00045   0.00028   0.00194   0.00222   2.05787
+   A27        2.13684  -0.00106  -0.00046  -0.00492  -0.00538   2.13146
+   A28        2.11695  -0.00127  -0.00073  -0.00550  -0.00623   2.11072
+   A29        2.08117   0.00080   0.00067   0.00351   0.00418   2.08535
+   A30        2.08506   0.00047   0.00006   0.00199   0.00205   2.08711
+   A31        2.17827  -0.00090  -0.00060  -0.00372  -0.00432   2.17395
+   A32        2.05315   0.00042   0.00024   0.00172   0.00196   2.05510
+   A33        2.05177   0.00048   0.00036   0.00200   0.00236   2.05413
+   A34        2.04926   0.00044   0.00032   0.00178   0.00210   2.05136
+   A35        2.14047  -0.00118  -0.00051  -0.00519  -0.00570   2.13476
+   A36        2.09346   0.00074   0.00019   0.00341   0.00361   2.09706
+   A37        2.04926   0.00044   0.00032   0.00178   0.00210   2.05136
+   A38        2.09346   0.00074   0.00019   0.00341   0.00360   2.09706
+   A39        2.14047  -0.00118  -0.00051  -0.00519  -0.00570   2.13476
+   A40        2.17827  -0.00090  -0.00060  -0.00372  -0.00432   2.17395
+   A41        2.05315   0.00042   0.00024   0.00172   0.00196   2.05510
+   A42        2.05177   0.00048   0.00036   0.00200   0.00236   2.05413
+   A43        2.12347  -0.00122  -0.00058  -0.00551  -0.00609   2.11738
+   A44        2.08658   0.00053   0.00007   0.00246   0.00253   2.08911
+   A45        2.07313   0.00069   0.00052   0.00304   0.00356   2.07669
+   A46        2.06625   0.00048   0.00039   0.00210   0.00249   2.06874
+   A47        2.13477  -0.00084  -0.00045  -0.00375  -0.00420   2.13058
+   A48        2.08216   0.00036   0.00006   0.00165   0.00171   2.08387
+   A49        2.06626   0.00048   0.00039   0.00210   0.00248   2.06874
+   A50        2.08216   0.00036   0.00006   0.00165   0.00171   2.08387
+   A51        2.13477  -0.00084  -0.00045  -0.00375  -0.00420   2.13058
+   A52        2.12347  -0.00122  -0.00058  -0.00551  -0.00609   2.11738
+   A53        2.08658   0.00053   0.00007   0.00247   0.00253   2.08911
+   A54        2.07313   0.00069   0.00052   0.00304   0.00356   2.07669
+   A55        2.13063  -0.00060  -0.00011  -0.00290  -0.00301   2.12761
+   A56        2.08291   0.00033   0.00009   0.00164   0.00173   2.08464
+   A57        2.06965   0.00027   0.00002   0.00126   0.00128   2.07093
+   A58        2.07040   0.00024   0.00006   0.00124   0.00130   2.07170
+   A59        2.13642  -0.00057  -0.00010  -0.00282  -0.00293   2.13349
+   A60        2.07636   0.00032   0.00005   0.00158   0.00163   2.07799
+   A61        2.07040   0.00024   0.00005   0.00124   0.00130   2.07170
+   A62        2.07636   0.00032   0.00005   0.00158   0.00163   2.07799
+   A63        2.13642  -0.00057  -0.00010  -0.00282  -0.00293   2.13349
+   A64        2.13062  -0.00060  -0.00011  -0.00290  -0.00301   2.12761
+   A65        2.08291   0.00033   0.00009   0.00164   0.00173   2.08464
+   A66        2.06965   0.00027   0.00002   0.00126   0.00128   2.07094
+   A67        2.13046  -0.00064  -0.00010  -0.00316  -0.00326   2.12720
+   A68        2.07636   0.00032   0.00005   0.00158   0.00163   2.07799
+   A69        2.07636   0.00032   0.00005   0.00158   0.00163   2.07799
+   A70        2.07636   0.00032   0.00005   0.00158   0.00163   2.07799
+   A71        2.13642  -0.00057  -0.00010  -0.00282  -0.00293   2.13349
+   A72        2.07040   0.00024   0.00006   0.00124   0.00130   2.07170
+   A73        2.07636   0.00032   0.00005   0.00158   0.00163   2.07799
+   A74        2.07040   0.00024   0.00005   0.00124   0.00130   2.07170
+   A75        2.13642  -0.00057  -0.00010  -0.00282  -0.00293   2.13349
+   A76        2.13046  -0.00064  -0.00010  -0.00316  -0.00326   2.12720
+   A77        2.07636   0.00032   0.00005   0.00158   0.00163   2.07799
+   A78        2.07636   0.00032   0.00005   0.00158   0.00163   2.07799
+   A79        2.13062  -0.00060  -0.00011  -0.00290  -0.00301   2.12761
+   A80        2.06965   0.00027   0.00002   0.00126   0.00128   2.07094
+   A81        2.08291   0.00033   0.00009   0.00164   0.00173   2.08464
+   A82        2.08216   0.00036   0.00006   0.00165   0.00171   2.08387
+   A83        2.13477  -0.00084  -0.00045  -0.00375  -0.00420   2.13058
+   A84        2.06625   0.00048   0.00039   0.00210   0.00249   2.06874
+   A85        2.08216   0.00036   0.00006   0.00165   0.00171   2.08387
+   A86        2.06626   0.00048   0.00039   0.00210   0.00248   2.06874
+   A87        2.13477  -0.00084  -0.00045  -0.00375  -0.00420   2.13058
+   A88        2.13063  -0.00060  -0.00011  -0.00290  -0.00301   2.12761
+   A89        2.06965   0.00027   0.00002   0.00126   0.00128   2.07093
+   A90        2.08291   0.00033   0.00009   0.00164   0.00173   2.08464
+   A91        2.12347  -0.00122  -0.00058  -0.00551  -0.00609   2.11738
+   A92        2.07313   0.00069   0.00052   0.00304   0.00356   2.07669
+   A93        2.08658   0.00053   0.00007   0.00247   0.00253   2.08911
+   A94        2.09346   0.00074   0.00019   0.00341   0.00361   2.09706
+   A95        2.14047  -0.00118  -0.00051  -0.00519  -0.00570   2.13476
+   A96        2.04926   0.00044   0.00032   0.00178   0.00210   2.05136
+   A97        2.09346   0.00074   0.00019   0.00341   0.00360   2.09706
+   A98        2.04926   0.00044   0.00032   0.00178   0.00210   2.05136
+   A99        2.14047  -0.00118  -0.00051  -0.00519  -0.00570   2.13476
+   A100       2.12347  -0.00122  -0.00058  -0.00551  -0.00609   2.11738
+   A101       2.07313   0.00069   0.00052   0.00304   0.00356   2.07669
+   A102       2.08658   0.00053   0.00007   0.00246   0.00253   2.08911
+   A103       2.17827  -0.00090  -0.00060  -0.00372  -0.00432   2.17395
+   A104       2.05177   0.00048   0.00036   0.00200   0.00236   2.05413
+   A105       2.05315   0.00042   0.00024   0.00172   0.00196   2.05510
+   A106       2.05565   0.00045   0.00028   0.00194   0.00222   2.05787
+   A107       2.13684  -0.00106  -0.00046  -0.00492  -0.00538   2.13146
+   A108       2.09069   0.00061   0.00018   0.00298   0.00316   2.09385
+   A109       2.05565   0.00045   0.00028   0.00194   0.00222   2.05787
+   A110       2.09069   0.00061   0.00018   0.00298   0.00316   2.09385
+   A111       2.13684  -0.00106  -0.00046  -0.00492  -0.00538   2.13146
+   A112       2.17827  -0.00090  -0.00060  -0.00372  -0.00432   2.17395
+   A113       2.05177   0.00048   0.00036   0.00200   0.00236   2.05413
+   A114       2.05315   0.00042   0.00024   0.00172   0.00196   2.05510
+   A115       2.11695  -0.00127  -0.00073  -0.00550  -0.00623   2.11072
+   A116       2.08506   0.00047   0.00006   0.00199   0.00205   2.08711
+   A117       2.08117   0.00080   0.00067   0.00351   0.00418   2.08535
+   A118       2.07554   0.00066   0.00055   0.00252   0.00307   2.07861
+   A119       2.13451  -0.00073  -0.00035  -0.00326  -0.00361   2.13090
+   A120       2.07313   0.00007  -0.00020   0.00074   0.00054   2.07367
+   A121       2.07554   0.00066   0.00055   0.00252   0.00307   2.07861
+   A122       2.07313   0.00007  -0.00020   0.00074   0.00054   2.07367
+   A123       2.13451  -0.00073  -0.00035  -0.00326  -0.00361   2.13090
+   A124       2.11695  -0.00127  -0.00073  -0.00550  -0.00623   2.11072
+   A125       2.08506   0.00047   0.00006   0.00199   0.00205   2.08711
+   A126       2.08117   0.00080   0.00067   0.00351   0.00418   2.08535
+   A127       2.11046  -0.00030  -0.00011  -0.00142  -0.00153   2.10893
+   A128       2.07309  -0.00008  -0.00012  -0.00078  -0.00090   2.07219
+   A129       2.09964   0.00038   0.00023   0.00219   0.00242   2.10206
+   A130       2.09959   0.00022   0.00031   0.00068   0.00099   2.10058
+   A131       2.09537   0.00009   0.00004   0.00086   0.00091   2.09628
+   A132       2.08822  -0.00031  -0.00036  -0.00154  -0.00190   2.08632
+   A133       2.09959   0.00022   0.00031   0.00068   0.00099   2.10058
+   A134       2.08822  -0.00031  -0.00036  -0.00154  -0.00190   2.08632
+   A135       2.09537   0.00009   0.00004   0.00086   0.00091   2.09628
+   A136       2.11046  -0.00030  -0.00011  -0.00142  -0.00153   2.10893
+   A137       2.07309  -0.00008  -0.00012  -0.00078  -0.00090   2.07219
+   A138       2.09964   0.00038   0.00023   0.00219   0.00242   2.10206
+    D1        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D2       -3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+    D3        3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+    D4        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D5        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D6        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+    D7        3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+    D8        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D9        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D10        3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D11       -3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D12        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D13        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D14       -3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D15        3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D16        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D17        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D18       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D19        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D20        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D21       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D22        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D23        0.00001   0.00000   0.00000   0.00000   0.00000   0.00001
+   D24       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D25        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D26       -3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D27        3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D28        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D29       -0.00001   0.00000   0.00000   0.00000   0.00000  -0.00001
+   D30        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D31        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D32        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D33        0.00001   0.00000   0.00000   0.00000   0.00000   0.00001
+   D34       -3.14157   0.00000   0.00000   0.00000   0.00000  -3.14156
+   D35       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D36        0.00002   0.00000   0.00000   0.00000   0.00000   0.00002
+   D37        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D38       -3.14158   0.00000   0.00000   0.00000   0.00000  -3.14157
+   D39        3.14157   0.00000   0.00000   0.00000   0.00000   3.14157
+   D40        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D41       -3.14142   0.00000   0.00000  -0.00001  -0.00002  -3.14144
+   D42       -0.00008   0.00000   0.00000  -0.00001  -0.00001  -0.00009
+   D43        0.00019   0.00000   0.00000  -0.00001  -0.00001   0.00018
+   D44        3.14153   0.00000   0.00000  -0.00001  -0.00001   3.14152
+   D45       -0.00001   0.00000   0.00000   0.00000   0.00000  -0.00001
+   D46        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D47        3.14157   0.00000   0.00000   0.00000   0.00000   3.14157
+   D48       -0.00002   0.00000   0.00000   0.00000   0.00000  -0.00002
+   D49       -0.00019   0.00000   0.00000   0.00001   0.00002  -0.00017
+   D50       -3.14156   0.00000   0.00000   0.00002   0.00002  -3.14154
+   D51        3.14142   0.00000   0.00000   0.00002   0.00002   3.14144
+   D52        0.00005   0.00000   0.00000   0.00002   0.00002   0.00007
+   D53        0.00018   0.00000   0.00000  -0.00001  -0.00002   0.00017
+   D54       -3.14142   0.00000   0.00000  -0.00002  -0.00002  -3.14144
+   D55        3.14156   0.00000   0.00000  -0.00002  -0.00002   3.14154
+   D56       -0.00005   0.00000   0.00000  -0.00002  -0.00002  -0.00007
+   D57        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D58        3.14158   0.00000   0.00000   0.00000   0.00000   3.14157
+   D59       -3.14157   0.00000   0.00000   0.00000   0.00000  -3.14157
+   D60        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D61       -3.14157   0.00000   0.00000   0.00000   0.00000  -3.14156
+   D62        0.00002   0.00000   0.00000   0.00000   0.00000   0.00002
+   D63        0.00001   0.00000   0.00000   0.00000   0.00000   0.00001
+   D64       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D65       -0.00019   0.00000   0.00000   0.00001   0.00001  -0.00018
+   D66       -3.14153   0.00000   0.00000   0.00001   0.00001  -3.14152
+   D67        3.14142   0.00000   0.00000   0.00002   0.00002   3.14144
+   D68        0.00008   0.00000   0.00000   0.00001   0.00001   0.00009
+   D69       -0.00001   0.00000   0.00000   0.00000   0.00000  -0.00001
+   D70        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D71        3.14156   0.00000   0.00000   0.00000   0.00000   3.14156
+   D72       -0.00002   0.00000   0.00000   0.00000   0.00000  -0.00002
+   D73        0.00001   0.00000   0.00000   0.00000   0.00000   0.00001
+   D74       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14158
+   D75       -3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D76        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D77        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D78        3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D79       -3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D80        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D81       -3.14159   0.00000   0.00000   0.00000  -0.00001   3.14159
+   D82        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D83        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D84       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D85       -0.00001   0.00000   0.00000   0.00000   0.00000  -0.00001
+   D86        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D87        3.14159   0.00000   0.00000   0.00000   0.00000   3.14158
+   D88        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D89        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D90       -3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D91        3.14159   0.00000   0.00000   0.00001   0.00001  -3.14159
+   D92        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D93        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D94       -3.14159   0.00000   0.00000  -0.00001  -0.00001   3.14159
+   D95        3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D96        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D97        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D98        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D99        3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D100       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D101      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D102       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D103       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D104       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D105       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D106       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D107      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D108       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D109       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D110      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D111       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D112       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D113       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D114      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D115       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D116       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D117       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D118       3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D119       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D120       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D121      -3.14159   0.00000   0.00000  -0.00001  -0.00001   3.14159
+   D122       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D123       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D124       3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D125       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D126      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D127       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D128       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D129       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D130       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D131      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D132       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D133       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D134      -3.14159   0.00000   0.00000   0.00000  -0.00001   3.14159
+   D135      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D136       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D137       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D138      -3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D139       3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D140       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D141      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14158
+   D142       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D143       0.00001   0.00000   0.00000   0.00000   0.00000   0.00001
+   D144      -3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D145       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D146      -3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D147       3.14159   0.00000   0.00000   0.00001   0.00001  -3.14159
+   D148       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D149      -0.00001   0.00000   0.00000   0.00000   0.00000  -0.00001
+   D150       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D151       3.14159   0.00000   0.00000   0.00000   0.00000   3.14158
+   D152       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D153       0.00001   0.00000   0.00000   0.00000   0.00000   0.00001
+   D154      -3.14157   0.00000   0.00000   0.00000   0.00000  -3.14156
+   D155      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D156       0.00002   0.00000   0.00000   0.00000   0.00000   0.00002
+   D157       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D158      -3.14157   0.00000   0.00000   0.00000   0.00000  -3.14157
+   D159       3.14158   0.00000   0.00000   0.00000   0.00000   3.14157
+   D160       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D161      -3.14142   0.00000   0.00000  -0.00002  -0.00002  -3.14144
+   D162      -0.00005   0.00000   0.00000  -0.00002  -0.00002  -0.00007
+   D163       0.00018   0.00000   0.00000  -0.00001  -0.00002   0.00017
+   D164       3.14156   0.00000   0.00000  -0.00002  -0.00002   3.14154
+   D165      -0.00001   0.00000   0.00000   0.00000   0.00000  -0.00001
+   D166       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D167       3.14156   0.00000   0.00000   0.00000   0.00000   3.14156
+   D168      -0.00002   0.00000   0.00000   0.00000   0.00000  -0.00002
+   D169      -0.00019   0.00000   0.00000   0.00001   0.00001  -0.00018
+   D170      -3.14153   0.00000   0.00000   0.00001   0.00001  -3.14152
+   D171       3.14142   0.00000   0.00000   0.00002   0.00002   3.14144
+   D172       0.00008   0.00000   0.00000   0.00001   0.00001   0.00009
+   D173       0.00019   0.00000   0.00000  -0.00001  -0.00001   0.00018
+   D174      -3.14142   0.00000   0.00000  -0.00001  -0.00002  -3.14144
+   D175       3.14153   0.00000   0.00000  -0.00001  -0.00001   3.14152
+   D176      -0.00008   0.00000   0.00000  -0.00001  -0.00001  -0.00009
+   D177       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D178       3.14157   0.00000   0.00000   0.00000   0.00000   3.14157
+   D179      -3.14158   0.00000   0.00000   0.00000   0.00000  -3.14157
+   D180       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D181      -3.14157   0.00000   0.00000   0.00000   0.00000  -3.14156
+   D182       0.00002   0.00000   0.00000   0.00000   0.00000   0.00002
+   D183       0.00001   0.00000   0.00000   0.00000   0.00000   0.00001
+   D184      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D185      -0.00019   0.00000   0.00000   0.00001   0.00002  -0.00017
+   D186      -3.14156   0.00000   0.00000   0.00002   0.00002  -3.14154
+   D187       3.14142   0.00000   0.00000   0.00002   0.00002   3.14144
+   D188       0.00005   0.00000   0.00000   0.00002   0.00002   0.00007
+   D189      -0.00001   0.00000   0.00000   0.00000   0.00000  -0.00001
+   D190       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D191       3.14157   0.00000   0.00000   0.00000   0.00000   3.14157
+   D192      -0.00002   0.00000   0.00000   0.00000   0.00000  -0.00002
+   D193       0.00001   0.00000   0.00000   0.00000   0.00000   0.00001
+   D194      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D195      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D196       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D197       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D198       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D199      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D200       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D201      -3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D202       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D203       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D204       3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D205      -0.00001   0.00000   0.00000   0.00000   0.00000  -0.00001
+   D206       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D207       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D208       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D209       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D210      -3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D211       3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D212       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D213       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D214      -3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D215       3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D216       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D217       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D218       3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D219      -3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D220       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D221       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D222       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D223       3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D224       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.007809     0.000450     NO 
+ RMS     Force            0.001571     0.000300     NO 
+ Maximum Displacement     0.043923     0.001800     NO 
+ RMS     Displacement     0.010945     0.001200     NO 
+ Predicted change in Energy=-1.151394D-03
+ Lowest energy point so far.  Saving SCF results.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Tue Aug  4 10:40:01 2020, MaxMem=    33554432 cpu:         0.1
+ (Enter /cluster/apps/gaussian/g09/l202.exe)
+ Stoichiometry    C42H26N4
+ Framework group  C2[X(C42H26N4)]
+ Deg. of freedom   106
+ Full point group                 C2      NOp   2
+ RotChk:  IX=0 Diff= 1.40D-07
+ Largest Abelian subgroup         C2      NOp   2
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0      -13.639993    0.714770    0.000445
+      2          6           0      -13.639993   -0.714771    0.000445
+      3          6           0      -12.440958    1.416961    0.000325
+      4          6           0      -11.181576    0.724254    0.000198
+      5          6           0      -11.181576   -0.724254    0.000198
+      6          6           0      -12.440958   -1.416962    0.000325
+      7          6           0       -9.923810   -1.424197    0.000072
+      8          6           0       -8.718405   -0.729129   -0.000056
+      9          6           0       -8.718405    0.729129   -0.000056
+     10          6           0       -9.923810    1.424197    0.000072
+     11          7           0       -7.457686    1.396855   -0.000213
+     12          6           0       -6.192898    0.737487   -0.000170
+     13          6           0       -6.192898   -0.737487   -0.000171
+     14          7           0       -7.457686   -1.396856   -0.000217
+     15          6           0       -4.998690   -1.431214   -0.000153
+     16          6           0       -3.721321   -0.736791   -0.000144
+     17          6           0       -3.721322    0.736791   -0.000144
+     18          6           0       -4.998691    1.431214   -0.000153
+     19          6           0       -2.499790    1.424999   -0.000137
+     20          6           0       -1.240472    0.735547   -0.000132
+     21          6           0       -1.240472   -0.735547   -0.000132
+     22          6           0       -2.499790   -1.424999   -0.000137
+     23          6           0        0.000000   -1.424855   -0.000131
+     24          6           0        1.240472   -0.735547   -0.000132
+     25          6           0        1.240472    0.735547   -0.000132
+     26          6           0        0.000000    1.424855   -0.000131
+     27          6           0        2.499790    1.424999   -0.000137
+     28          6           0        3.721321    0.736791   -0.000144
+     29          6           0        3.721322   -0.736791   -0.000144
+     30          6           0        2.499790   -1.424999   -0.000137
+     31          6           0        4.998691   -1.431214   -0.000153
+     32          6           0        6.192898   -0.737487   -0.000170
+     33          6           0        6.192898    0.737487   -0.000171
+     34          6           0        4.998690    1.431214   -0.000153
+     35          7           0        7.457686    1.396856   -0.000217
+     36          6           0        8.718405    0.729129   -0.000056
+     37          6           0        8.718405   -0.729129   -0.000056
+     38          7           0        7.457686   -1.396855   -0.000213
+     39          6           0        9.923810   -1.424197    0.000072
+     40          6           0       11.181576   -0.724254    0.000198
+     41          6           0       11.181576    0.724254    0.000198
+     42          6           0        9.923810    1.424197    0.000072
+     43          6           0       12.440958    1.416962    0.000325
+     44          6           0       13.639993    0.714771    0.000445
+     45          6           0       13.639993   -0.714770    0.000445
+     46          6           0       12.440958   -1.416961    0.000325
+     47          1           0      -14.595607    1.256258    0.000541
+     48          1           0      -14.595607   -1.256259    0.000541
+     49          1           0      -12.439336    2.515586    0.000325
+     50          1           0      -12.439336   -2.515587    0.000324
+     51          1           0       -9.916414   -2.521713    0.000071
+     52          1           0       -9.916414    2.521712    0.000072
+     53          1           0       -5.007414   -2.528468   -0.000154
+     54          1           0       -5.007414    2.528468   -0.000152
+     55          1           0       -2.498947   -2.523532   -0.000139
+     56          1           0        0.000000    2.523662   -0.000132
+     57          1           0        2.498947   -2.523532   -0.000139
+     58          1           0        5.007414    2.528468   -0.000154
+     59          1           0        9.916414   -2.521712    0.000072
+     60          1           0        9.916414    2.521713    0.000071
+     61          1           0       12.439336    2.515587    0.000324
+     62          1           0       14.595607    1.256259    0.000541
+     63          1           0       14.595607   -1.256258    0.000541
+     64          1           0       12.439336   -2.515586    0.000325
+     65          1           0       -2.498947    2.523532   -0.000139
+     66          1           0        2.498947    2.523532   -0.000139
+     67          1           0        0.000000   -2.523662   -0.000132
+     68          1           0        5.007414   -2.528468   -0.000152
+     69          1           0       -7.460569    2.437696   -0.000164
+     70          1           0        7.460569    2.437696   -0.000155
+     71          1           0       -7.460569   -2.437696   -0.000155
+     72          1           0        7.460569   -2.437696   -0.000164
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      0.5969227      0.0125840      0.0123242
+ Leave Link  202 at Tue Aug  4 10:40:01 2020, MaxMem=    33554432 cpu:         0.0
+ (Enter /cluster/apps/gaussian/g09/l301.exe)
+ Standard basis: STO-3G (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are   128 symmetry adapted cartesian basis functions of A   symmetry.
+ There are   128 symmetry adapted cartesian basis functions of B   symmetry.
+ There are   128 symmetry adapted basis functions of A   symmetry.
+ There are   128 symmetry adapted basis functions of B   symmetry.
+   256 basis functions,   768 primitive gaussians,   256 cartesian basis functions
+   153 alpha electrons      153 beta electrons
+       nuclear repulsion energy      4276.7961128731 Hartrees.
+ IExCor=  402 DFT=T Ex+Corr=B3LYP ExCW=0 ScaHFX=  0.200000
+ ScaDFX=  0.800000  0.720000  1.000000  0.810000 ScalE2=  1.000000  1.000000
+ IRadAn=      0 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=  4
+ NAtoms=   72 NActive=   72 NUniq=   36 SFac= 4.00D+00 NAtFMM=   60 NAOKFM=T Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ Leave Link  301 at Tue Aug  4 10:40:02 2020, MaxMem=    33554432 cpu:         0.0
+ (Enter /cluster/apps/gaussian/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+ One-electron integral symmetry used in STVInt
+ NBasis=   256 RedAO= T EigKep=  1.28D-01  NBF=   128   128
+ NBsUse=   256 1.00D-06 EigRej= -1.00D+00 NBFU=   128   128
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           0 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   217   218   218   218   218 MxSgAt=    72 MxSgA2=    71.
+ Leave Link  302 at Tue Aug  4 10:40:03 2020, MaxMem=    33554432 cpu:         1.2
+ (Enter /cluster/apps/gaussian/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Tue Aug  4 10:40:03 2020, MaxMem=    33554432 cpu:         0.1
+ (Enter /cluster/apps/gaussian/g09/l401.exe)
+ Initial guess from the checkpoint file:  "r-b3lyp-sto3g.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess orbital symmetries:
+       Occupied  (B) (A) (B) (A) (B) (A) (A) (B) (B) (A) (B) (A)
+                 (B) (A) (B) (A) (B) (A) (B) (A) (B) (A) (B) (A)
+                 (B) (A) (B) (A) (B) (A) (B) (A) (B) (A) (B) (A)
+                 (B) (A) (A) (B) (B) (A) (A) (B) (B) (A) (A) (B)
+                 (B) (A) (A) (B) (A) (B) (A) (B) (A) (B) (B) (A)
+                 (B) (A) (A) (B) (B) (A) (A) (B) (B) (A) (B) (A)
+                 (B) (A) (A) (B) (B) (A) (A) (B) (A) (A) (B) (B)
+                 (A) (B) (A) (B) (A) (A) (B) (B) (B) (A) (A) (B)
+                 (A) (B) (B) (A) (B) (A) (A) (B) (A) (A) (B) (B)
+                 (A) (B) (B) (A) (B) (A) (A) (A) (B) (A) (B) (B)
+                 (B) (A) (B) (A) (B) (B) (A) (B) (A) (A) (B) (A)
+                 (B) (A) (B) (A) (B) (A) (A) (B) (A) (B) (B) (A)
+                 (A) (B) (B) (A) (B) (A) (A) (B) (B)
+       Virtual   (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (B) (B) (B) (B) (B) (B) (B) (B)
+                 (B) (B) (B) (B) (B) (B) (B) (B) (B) (B) (B) (B)
+                 (B) (B) (B) (B) (B) (B) (B) (B) (B) (B) (B) (B)
+                 (B) (B) (B) (B) (B) (B) (B) (B) (B) (B) (B) (B)
+                 (B) (B) (B) (B) (B) (B) (B)
+ The electronic state of the initial guess is 1-A.
+ Generating alternative initial guess.
+ ExpMin= 1.69D-01 ExpMax= 9.91D+01 ExpMxC= 9.91D+01 IAcc=1 IRadAn=         1 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       1 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         1 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=        2000
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=     500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Harris En= -1811.91997258493    
+ Leave Link  401 at Tue Aug  4 10:40:04 2020, MaxMem=    33554432 cpu:         1.6
+ (Enter /cluster/apps/gaussian/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=    10.
+ Integral symmetry usage will be decided dynamically.
+ IVT=     4406646 IEndB=     4406646 NGot=    33554432 MDV=    33411979
+ LenX=    33411979 LenY=    33346002
+ Requested convergence on RMS density matrix=1.00D-07 within2048 cycles.
+ Requested convergence on MAX density matrix=1.00D-05.
+ Requested convergence on             energy=1.00D-05.
+ Level shift goal  0.100 maximum shift  0.100.
+ No special actions if energy rises.
+ Fock matrices will be formed incrementally for  20 cycles.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+
+ Cycle   1  Pass 0  IDiag  1:
+ FoFJK:  IHMeth= 1 ICntrl=       0 DoSepK=F KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf= 390000000 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=        2000
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=       0 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ E= -1812.58429630604    
+ DIIS: error= 6.31D-04 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -1812.58429630604     IErMin= 1 ErrMin= 6.31D-04
+ ErrMax= 6.31D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.23D-04 BMatP= 1.23D-04
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.439 Goal=     0.100 Shift=    0.000
+ RMSDP=8.38D-05 MaxDP=2.70D-03              OVMax= 0.00D+00
+
+ Cycle   2  Pass 0  IDiag  1:
+ RMSU=  8.31D-05    CP:  1.00D+00
+ E= -1812.58445569944     Delta-E=       -0.000159393399 Rises=F Damp=F
+ DIIS: error= 2.19D-04 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -1812.58445569944     IErMin= 2 ErrMin= 2.19D-04
+ ErrMax= 2.19D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 9.62D-06 BMatP= 1.23D-04
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.103D+00 0.897D+00
+ Coeff:      0.103D+00 0.897D+00
+ Gap=     0.094 Goal=     0.100 Shift=    0.006
+ RMSDP=3.99D-05 MaxDP=1.92D-03 DE=-1.59D-04 OVMax= 0.00D+00
+
+ Cycle   3  Pass 0  IDiag  1:
+ RMSU=  3.98D-05    CP:  1.00D+00  1.02D+00
+ E= -1812.58444771274     Delta-E=        0.000007986700 Rises=F Damp=F
+ DIIS: error= 3.40D-04 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 2 EnMin= -1812.58445569944     IErMin= 2 ErrMin= 2.19D-04
+ ErrMax= 3.40D-04  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.70D-05 BMatP= 9.62D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.156D-01 0.578D+00 0.438D+00
+ Coeff:     -0.156D-01 0.578D+00 0.438D+00
+ Gap=     0.094 Goal=   None    Shift=    0.000
+ RMSDP=2.59D-05 MaxDP=1.10D-03 DE= 7.99D-06 OVMax= 0.00D+00
+
+ Cycle   4  Pass 0  IDiag  1:
+ RMSU=  1.03D-05    CP:  1.00D+00  1.05D+00  4.08D-01
+ E= -1812.58446702320     Delta-E=       -0.000019310458 Rises=F Damp=F
+ DIIS: error= 8.31D-05 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -1812.58446702320     IErMin= 4 ErrMin= 8.31D-05
+ ErrMax= 8.31D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.16D-06 BMatP= 9.62D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.143D-01 0.322D+00 0.279D+00 0.414D+00
+ Coeff:     -0.143D-01 0.322D+00 0.279D+00 0.414D+00
+ Gap=     0.094 Goal=     0.100 Shift=    0.006
+ RMSDP=7.15D-06 MaxDP=3.08D-04 DE=-1.93D-05 OVMax= 0.00D+00
+
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ Cycle   5  Pass 1  IDiag  1:
+ E= -1812.58398000835     Delta-E=        0.000487014856 Rises=F Damp=F
+ DIIS: error= 1.73D-05 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -1812.58398000835     IErMin= 1 ErrMin= 1.73D-05
+ ErrMax= 1.73D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 7.23D-08 BMatP= 7.23D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.094 Goal=   None    Shift=    0.000
+ RMSDP=7.15D-06 MaxDP=3.08D-04 DE= 4.87D-04 OVMax= 0.00D+00
+
+ Cycle   6  Pass 1  IDiag  1:
+ RMSU=  3.69D-06    CP:  1.00D+00
+ E= -1812.58397988169     Delta-E=        0.000000126658 Rises=F Damp=F
+ DIIS: error= 3.43D-05 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 1 EnMin= -1812.58398000835     IErMin= 1 ErrMin= 1.73D-05
+ ErrMax= 3.43D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.62D-07 BMatP= 7.23D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.613D+00 0.387D+00
+ Coeff:      0.613D+00 0.387D+00
+ Gap=     0.094 Goal=   None    Shift=    0.000
+ RMSDP=3.10D-06 MaxDP=1.27D-04 DE= 1.27D-07 OVMax= 0.00D+00
+
+ Cycle   7  Pass 1  IDiag  1:
+ RMSU=  1.43D-06    CP:  1.00D+00  2.55D-01
+ E= -1812.58398010298     Delta-E=       -0.000000221293 Rises=F Damp=F
+ DIIS: error= 1.19D-05 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 3 EnMin= -1812.58398010298     IErMin= 3 ErrMin= 1.19D-05
+ ErrMax= 1.19D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.46D-08 BMatP= 7.23D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.122D+00 0.238D+00 0.641D+00
+ Coeff:      0.122D+00 0.238D+00 0.641D+00
+ Gap=     0.094 Goal=   None    Shift=    0.000
+ RMSDP=8.65D-07 MaxDP=3.38D-05 DE=-2.21D-07 OVMax= 0.00D+00
+
+ Cycle   8  Pass 1  IDiag  1:
+ RMSU=  4.29D-07    CP:  1.00D+00  4.11D-01  6.63D-01
+ E= -1812.58398012234     Delta-E=       -0.000000019356 Rises=F Damp=F
+ DIIS: error= 2.91D-06 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -1812.58398012234     IErMin= 4 ErrMin= 2.91D-06
+ ErrMax= 2.91D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.77D-09 BMatP= 1.46D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.556D-03 0.100D+00 0.369D+00 0.532D+00
+ Coeff:     -0.556D-03 0.100D+00 0.369D+00 0.532D+00
+ Gap=     0.094 Goal=   None    Shift=    0.000
+ RMSDP=2.42D-07 MaxDP=1.11D-05 DE=-1.94D-08 OVMax= 0.00D+00
+
+ Cycle   9  Pass 1  IDiag  1:
+ RMSU=  1.07D-07    CP:  1.00D+00  4.13D-01  7.39D-01  5.63D-01
+ E= -1812.58398012452     Delta-E=       -0.000000002184 Rises=F Damp=F
+ DIIS: error= 5.36D-07 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -1812.58398012452     IErMin= 5 ErrMin= 5.36D-07
+ ErrMax= 5.36D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 5.93D-11 BMatP= 1.77D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.589D-02 0.379D-01 0.143D+00 0.256D+00 0.569D+00
+ Coeff:     -0.589D-02 0.379D-01 0.143D+00 0.256D+00 0.569D+00
+ Gap=     0.094 Goal=   None    Shift=    0.000
+ RMSDP=5.73D-08 MaxDP=2.06D-06 DE=-2.18D-09 OVMax= 0.00D+00
+
+ SCF Done:  E(RB3LYP) =  -1812.58398012     A.U. after    9 cycles
+            NFock=  9  Conv=0.57D-07     -V/T= 2.0186
+ KE= 1.779406238371D+03 PE=-1.275203869986D+04 EE= 4.883252368494D+03
+ Leave Link  502 at Tue Aug  4 10:40:35 2020, MaxMem=    33554432 cpu:        30.4
+ (Enter /cluster/apps/gaussian/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ Leave Link  701 at Tue Aug  4 10:40:35 2020, MaxMem=    33554432 cpu:         0.2
+ (Enter /cluster/apps/gaussian/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Tue Aug  4 10:40:35 2020, MaxMem=    33554432 cpu:         0.0
+ (Enter /cluster/apps/gaussian/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=F KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         0 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=        2800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2127 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Tue Aug  4 10:40:47 2020, MaxMem=    33554432 cpu:        11.5
+ (Enter /cluster/apps/gaussian/g09/l716.exe)
+ Dipole        =-1.25274788D-13 1.52100556D-14 1.73904178D-04
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6           0.000054179    0.000607565    0.000000038
+      2        6           0.000054154   -0.000607556   -0.000000011
+      3        6          -0.000662936    0.000225505    0.000000020
+      4        6           0.000120110   -0.001107491    0.000000010
+      5        6           0.000120056    0.001107489    0.000000061
+      6        6          -0.000662895   -0.000225511    0.000000033
+      7        6           0.000064725   -0.000581904   -0.000000203
+      8        6          -0.000119192    0.000783738    0.000000059
+      9        6          -0.000119200   -0.000783750    0.000000104
+     10        6           0.000064699    0.000581912   -0.000000231
+     11        7          -0.000078862    0.000312368   -0.000000401
+     12        6           0.000310250   -0.000607072    0.000000030
+     13        6           0.000310168    0.000607042    0.000000034
+     14        7          -0.000078808   -0.000312345   -0.000000166
+     15        6          -0.000496535   -0.000531265   -0.000000199
+     16        6           0.000521420    0.000646874    0.000000043
+     17        6           0.000521479   -0.000646892    0.000000060
+     18        6          -0.000496587    0.000531287   -0.000000242
+     19        6          -0.000417501    0.000260201   -0.000000049
+     20        6           0.000233684   -0.000678556    0.000000010
+     21        6           0.000233621    0.000678535   -0.000000008
+     22        6          -0.000417477   -0.000260185   -0.000000035
+     23        6           0.000000028   -0.000288411   -0.000000035
+     24        6          -0.000233684    0.000678556    0.000000010
+     25        6          -0.000233621   -0.000678535   -0.000000008
+     26        6          -0.000000028    0.000288411   -0.000000035
+     27        6           0.000417477    0.000260185   -0.000000035
+     28        6          -0.000521420   -0.000646874    0.000000043
+     29        6          -0.000521479    0.000646892    0.000000060
+     30        6           0.000417501   -0.000260201   -0.000000049
+     31        6           0.000496587   -0.000531287   -0.000000242
+     32        6          -0.000310250    0.000607072    0.000000030
+     33        6          -0.000310168   -0.000607042    0.000000034
+     34        6           0.000496535    0.000531265   -0.000000199
+     35        7           0.000078808    0.000312345   -0.000000166
+     36        6           0.000119192   -0.000783738    0.000000059
+     37        6           0.000119200    0.000783750    0.000000104
+     38        7           0.000078862   -0.000312368   -0.000000401
+     39        6          -0.000064699   -0.000581912   -0.000000231
+     40        6          -0.000120110    0.001107491    0.000000010
+     41        6          -0.000120056   -0.001107489    0.000000061
+     42        6          -0.000064725    0.000581904   -0.000000203
+     43        6           0.000662895    0.000225511    0.000000033
+     44        6          -0.000054154    0.000607556   -0.000000011
+     45        6          -0.000054179   -0.000607565    0.000000038
+     46        6           0.000662936   -0.000225505    0.000000020
+     47        1           0.000127375   -0.000208549   -0.000000017
+     48        1           0.000127384    0.000208550   -0.000000013
+     49        1           0.000097737   -0.000264895    0.000000008
+     50        1           0.000097736    0.000264898    0.000000010
+     51        1          -0.000053646    0.000341627    0.000000027
+     52        1          -0.000053645   -0.000341631    0.000000032
+     53        1           0.000095696    0.000353399    0.000000035
+     54        1           0.000095697   -0.000353402    0.000000036
+     55        1           0.000041053    0.000319835    0.000000043
+     56        1           0.000000003   -0.000320072    0.000000037
+     57        1          -0.000041048    0.000319834    0.000000043
+     58        1          -0.000095696   -0.000353399    0.000000035
+     59        1           0.000053645    0.000341631    0.000000032
+     60        1           0.000053646   -0.000341627    0.000000027
+     61        1          -0.000097736   -0.000264898    0.000000010
+     62        1          -0.000127384   -0.000208550   -0.000000013
+     63        1          -0.000127375    0.000208549   -0.000000017
+     64        1          -0.000097737    0.000264895    0.000000008
+     65        1           0.000041048   -0.000319834    0.000000043
+     66        1          -0.000041053   -0.000319835    0.000000043
+     67        1          -0.000000003    0.000320072    0.000000037
+     68        1          -0.000095697    0.000353402    0.000000036
+     69        1           0.000003150   -0.000141058    0.000000503
+     70        1          -0.000003143   -0.000141065    0.000000334
+     71        1           0.000003143    0.000141065    0.000000334
+     72        1          -0.000003150    0.000141058    0.000000503
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.001107491 RMS     0.000339638
+ Leave Link  716 at Tue Aug  4 10:40:47 2020, MaxMem=    33554432 cpu:         0.0
+ (Enter /cluster/apps/gaussian/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ GSVD:  received Info=                   1 from GESDD.
+ Internal  Forces:  Max     0.000822869 RMS     0.000163316
+ Search for a local minimum.
+ Step number   3 out of a maximum of  432
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .16332D-03 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Update second derivatives using D2CorX and points    1    2    3
+ DE= -1.23D-03 DEPred=-1.15D-03 R= 1.07D+00
+ TightC=F SS=  1.41D+00  RLast= 7.74D-02 DXNew= 8.4853D-01 2.3229D-01
+ Trust test= 1.07D+00 RLast= 7.74D-02 DXMaxT set to 5.05D-01
+ ITU=  1  1  0
+ Use linear search instead of GDIIS.
+     Eigenvalues ---    0.01654   0.01658   0.01707   0.01737   0.01765
+     Eigenvalues ---    0.01770   0.01776   0.01784   0.01785   0.01811
+     Eigenvalues ---    0.01811   0.01821   0.01821   0.01822   0.01837
+     Eigenvalues ---    0.01841   0.01841   0.01841   0.01841   0.01841
+     Eigenvalues ---    0.01841   0.01856   0.01863   0.01872   0.01876
+     Eigenvalues ---    0.01881   0.01896   0.01896   0.01902   0.01902
+     Eigenvalues ---    0.01938   0.01938   0.01978   0.01978   0.02004
+     Eigenvalues ---    0.02004   0.02047   0.02047   0.02047   0.02047
+     Eigenvalues ---    0.02088   0.02088   0.02088   0.02091   0.02091
+     Eigenvalues ---    0.02101   0.02101   0.02109   0.02109   0.02123
+     Eigenvalues ---    0.02124   0.02127   0.02127   0.02140   0.02140
+     Eigenvalues ---    0.02155   0.02155   0.02164   0.02164   0.02167
+     Eigenvalues ---    0.02167   0.02203   0.02203   0.02205   0.02205
+     Eigenvalues ---    0.02259   0.02259   0.02276   0.02276   0.15954
+     Eigenvalues ---    0.16000   0.16000   0.16000   0.16000   0.16000
+     Eigenvalues ---    0.16000   0.16000   0.16000   0.16000   0.16000
+     Eigenvalues ---    0.16000   0.16000   0.16000   0.16000   0.16000
+     Eigenvalues ---    0.16000   0.16000   0.16000   0.16000   0.16000
+     Eigenvalues ---    0.16000   0.16000   0.16000   0.16000   0.16009
+     Eigenvalues ---    0.22000   0.22000   0.22484   0.22489   0.22766
+     Eigenvalues ---    0.22861   0.22965   0.23100   0.23212   0.23314
+     Eigenvalues ---    0.23373   0.23457   0.23658   0.23688   0.23742
+     Eigenvalues ---    0.23746   0.23828   0.23924   0.24024   0.24131
+     Eigenvalues ---    0.24237   0.24319   0.24566   0.24566   0.25000
+     Eigenvalues ---    0.25000   0.25000   0.25000   0.25000   0.25000
+     Eigenvalues ---    0.25000   0.25000   0.25000   0.33303   0.33990
+     Eigenvalues ---    0.34940   0.35278   0.35280   0.35286   0.35286
+     Eigenvalues ---    0.35286   0.35289   0.35296   0.35296   0.35296
+     Eigenvalues ---    0.35301   0.35305   0.35305   0.35305   0.35339
+     Eigenvalues ---    0.35359   0.35359   0.35359   0.35455   0.35499
+     Eigenvalues ---    0.35499   0.35499   0.35687   0.36010   0.36338
+     Eigenvalues ---    0.36971   0.37486   0.38039   0.38824   0.38828
+     Eigenvalues ---    0.38852   0.39556   0.40217   0.40217   0.40476
+     Eigenvalues ---    0.40615   0.40727   0.40727   0.40783   0.40791
+     Eigenvalues ---    0.41849   0.41861   0.42140   0.42447   0.42476
+     Eigenvalues ---    0.42786   0.42819   0.43163   0.43163   0.43331
+     Eigenvalues ---    0.43539   0.44637   0.45608   0.45738   0.46292
+     Eigenvalues ---    0.46316   0.46316   0.46316   0.46607   0.46617
+     Eigenvalues ---    0.46790   0.46792   0.47045   0.47547   0.47547
+     Eigenvalues ---    0.47553   0.47710   0.47992   0.47992   0.48231
+     Eigenvalues ---    0.48231   0.48231   0.49187   0.49346   0.49402
+     Eigenvalues ---    0.49757   0.49757   0.50566   0.51085   0.54769
+ RFO step:  Lambda=-3.15262524D-05 EMin= 1.65370415D-02
+ Quartic linear search produced a step of  0.00649.
+ Iteration  1 RMS(Cart)=  0.00222983 RMS(Int)=  0.00000011
+ Iteration  2 RMS(Cart)=  0.00000013 RMS(Int)=  0.00000001
+ ITry= 1 IFail=0 DXMaxC= 8.36D-03 DCOld= 1.00D+10 DXMaxT= 5.05D-01 DXLimC= 3.00D+00 Rises=F
+ ClnCor:  largest displacement from symmetrization is 7.09D-09 for atom    63.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.70144   0.00021   0.00004   0.00054   0.00058   2.70202
+    R2        2.62581  -0.00025   0.00001  -0.00048  -0.00047   2.62533
+    R3        2.07561  -0.00021   0.00004  -0.00057  -0.00053   2.07508
+    R4        2.62581  -0.00025   0.00001  -0.00048  -0.00047   2.62533
+    R5        2.07561  -0.00021   0.00004  -0.00057  -0.00053   2.07508
+    R6        2.71614   0.00041   0.00005   0.00100   0.00105   2.71719
+    R7        2.07610  -0.00026   0.00003  -0.00072  -0.00068   2.07542
+    R8        2.73728  -0.00082   0.00002  -0.00204  -0.00203   2.73526
+    R9        2.72009   0.00029   0.00005   0.00073   0.00078   2.72087
+   R10        2.71614   0.00041   0.00005   0.00100   0.00105   2.71719
+   R11        2.72009   0.00029   0.00005   0.00074   0.00078   2.72087
+   R12        2.07610  -0.00026   0.00003  -0.00072  -0.00068   2.07542
+   R13        2.62945   0.00027   0.00001   0.00058   0.00060   2.63005
+   R14        2.07405  -0.00034   0.00003  -0.00094  -0.00091   2.07314
+   R15        2.75571  -0.00059   0.00005  -0.00140  -0.00135   2.75436
+   R16        2.69594   0.00037   0.00010   0.00088   0.00098   2.69692
+   R17        2.62945   0.00027   0.00001   0.00058   0.00060   2.63005
+   R18        2.69594   0.00037   0.00010   0.00088   0.00098   2.69692
+   R19        2.07405  -0.00034   0.00003  -0.00094  -0.00091   2.07314
+   R20        2.69540   0.00044   0.00010   0.00104   0.00114   2.69654
+   R21        1.96691  -0.00014   0.00007  -0.00023  -0.00016   1.96675
+   R22        2.78730  -0.00048   0.00005  -0.00120  -0.00115   2.78615
+   R23        2.60987   0.00014   0.00001   0.00028   0.00029   2.61016
+   R24        2.69540   0.00044   0.00010   0.00104   0.00114   2.69654
+   R25        2.60987   0.00014   0.00001   0.00028   0.00029   2.61016
+   R26        1.96691  -0.00014   0.00007  -0.00023  -0.00016   1.96675
+   R27        2.74752   0.00054   0.00006   0.00140   0.00146   2.74898
+   R28        2.07357  -0.00035   0.00003  -0.00098  -0.00095   2.07263
+   R29        2.78467  -0.00060   0.00004  -0.00156  -0.00152   2.78315
+   R30        2.64951  -0.00003   0.00002  -0.00005  -0.00002   2.64948
+   R31        2.74752   0.00054   0.00006   0.00140   0.00146   2.74898
+   R32        2.64951  -0.00003   0.00002  -0.00005  -0.00002   2.64948
+   R33        2.07357  -0.00035   0.00003  -0.00098  -0.00095   2.07263
+   R34        2.71307   0.00036   0.00004   0.00090   0.00094   2.71402
+   R35        2.07593  -0.00032   0.00003  -0.00088  -0.00084   2.07508
+   R36        2.77997  -0.00066   0.00003  -0.00169  -0.00166   2.77830
+   R37        2.68176   0.00013   0.00003   0.00033   0.00036   2.68212
+   R38        2.71307   0.00036   0.00004   0.00090   0.00094   2.71402
+   R39        2.68176   0.00013   0.00003   0.00033   0.00036   2.68212
+   R40        2.07593  -0.00032   0.00003  -0.00088  -0.00084   2.07508
+   R41        2.68176   0.00013   0.00003   0.00033   0.00036   2.68212
+   R42        2.07644  -0.00032   0.00003  -0.00088  -0.00084   2.07560
+   R43        2.77997  -0.00066   0.00003  -0.00169  -0.00166   2.77830
+   R44        2.71307   0.00036   0.00004   0.00090   0.00094   2.71402
+   R45        2.68176   0.00013   0.00003   0.00033   0.00036   2.68212
+   R46        2.71307   0.00036   0.00004   0.00090   0.00094   2.71402
+   R47        2.07644  -0.00032   0.00003  -0.00088  -0.00084   2.07560
+   R48        2.64951  -0.00003   0.00002  -0.00005  -0.00002   2.64948
+   R49        2.07593  -0.00032   0.00003  -0.00088  -0.00084   2.07508
+   R50        2.78467  -0.00060   0.00004  -0.00156  -0.00152   2.78315
+   R51        2.74752   0.00054   0.00006   0.00140   0.00146   2.74898
+   R52        2.64951  -0.00003   0.00002  -0.00005  -0.00002   2.64948
+   R53        2.74752   0.00054   0.00006   0.00140   0.00146   2.74898
+   R54        2.07593  -0.00032   0.00003  -0.00088  -0.00084   2.07508
+   R55        2.60987   0.00014   0.00001   0.00028   0.00029   2.61016
+   R56        2.07357  -0.00035   0.00003  -0.00098  -0.00095   2.07263
+   R57        2.78730  -0.00048   0.00005  -0.00120  -0.00115   2.78615
+   R58        2.69540   0.00044   0.00010   0.00104   0.00114   2.69654
+   R59        2.60987   0.00014   0.00001   0.00028   0.00029   2.61016
+   R60        2.69540   0.00044   0.00010   0.00104   0.00114   2.69654
+   R61        2.07357  -0.00035   0.00003  -0.00098  -0.00095   2.07263
+   R62        2.69594   0.00037   0.00010   0.00088   0.00098   2.69692
+   R63        1.96691  -0.00014   0.00007  -0.00023  -0.00016   1.96675
+   R64        2.75571  -0.00059   0.00005  -0.00140  -0.00135   2.75436
+   R65        2.62945   0.00027   0.00001   0.00058   0.00060   2.63005
+   R66        2.69594   0.00037   0.00010   0.00088   0.00098   2.69692
+   R67        2.62945   0.00027   0.00001   0.00058   0.00060   2.63005
+   R68        1.96691  -0.00014   0.00007  -0.00023  -0.00016   1.96675
+   R69        2.72009   0.00029   0.00005   0.00073   0.00078   2.72087
+   R70        2.07405  -0.00034   0.00003  -0.00094  -0.00091   2.07314
+   R71        2.73728  -0.00082   0.00002  -0.00204  -0.00203   2.73526
+   R72        2.71614   0.00041   0.00005   0.00100   0.00105   2.71719
+   R73        2.72009   0.00029   0.00005   0.00074   0.00078   2.72087
+   R74        2.71614   0.00041   0.00005   0.00100   0.00105   2.71719
+   R75        2.07405  -0.00034   0.00003  -0.00094  -0.00091   2.07314
+   R76        2.62581  -0.00025   0.00001  -0.00048  -0.00047   2.62533
+   R77        2.07610  -0.00026   0.00003  -0.00072  -0.00068   2.07542
+   R78        2.70144   0.00021   0.00004   0.00054   0.00058   2.70202
+   R79        2.07561  -0.00021   0.00004  -0.00057  -0.00053   2.07508
+   R80        2.62581  -0.00025   0.00001  -0.00048  -0.00047   2.62533
+   R81        2.07561  -0.00021   0.00004  -0.00057  -0.00053   2.07508
+   R82        2.07610  -0.00026   0.00003  -0.00072  -0.00068   2.07542
+    A1        2.10058  -0.00007   0.00001  -0.00023  -0.00023   2.10036
+    A2        2.08632  -0.00009  -0.00001  -0.00067  -0.00068   2.08565
+    A3        2.09628   0.00016   0.00001   0.00090   0.00090   2.09718
+    A4        2.10058  -0.00007   0.00001  -0.00023  -0.00023   2.10036
+    A5        2.08632  -0.00009  -0.00001  -0.00067  -0.00068   2.08565
+    A6        2.09628   0.00016   0.00001   0.00090   0.00090   2.09718
+    A7        2.10893   0.00005  -0.00001   0.00021   0.00020   2.10914
+    A8        2.10206   0.00008   0.00002   0.00054   0.00056   2.10262
+    A9        2.07219  -0.00013  -0.00001  -0.00076  -0.00076   2.07143
+   A10        2.07367   0.00002   0.00000   0.00002   0.00002   2.07369
+   A11        2.13090  -0.00003  -0.00002  -0.00006  -0.00008   2.13082
+   A12        2.07861   0.00001   0.00002   0.00004   0.00006   2.07868
+   A13        2.07367   0.00002   0.00000   0.00002   0.00002   2.07369
+   A14        2.07861   0.00001   0.00002   0.00004   0.00006   2.07868
+   A15        2.13090  -0.00003  -0.00002  -0.00006  -0.00008   2.13082
+   A16        2.10893   0.00005  -0.00001   0.00021   0.00020   2.10914
+   A17        2.10206   0.00008   0.00002   0.00054   0.00056   2.10262
+   A18        2.07219  -0.00013  -0.00001  -0.00076  -0.00076   2.07143
+   A19        2.11072   0.00002  -0.00004   0.00003  -0.00001   2.11071
+   A20        2.08535  -0.00006   0.00003  -0.00034  -0.00032   2.08504
+   A21        2.08711   0.00004   0.00001   0.00032   0.00033   2.08744
+   A22        2.09385  -0.00003   0.00002  -0.00007  -0.00005   2.09380
+   A23        2.13146   0.00007  -0.00003   0.00027   0.00024   2.13170
+   A24        2.05787  -0.00004   0.00001  -0.00020  -0.00019   2.05769
+   A25        2.09385  -0.00003   0.00002  -0.00007  -0.00005   2.09380
+   A26        2.05787  -0.00004   0.00001  -0.00020  -0.00019   2.05769
+   A27        2.13146   0.00007  -0.00003   0.00027   0.00024   2.13170
+   A28        2.11072   0.00002  -0.00004   0.00003  -0.00001   2.11071
+   A29        2.08535  -0.00006   0.00003  -0.00034  -0.00031   2.08504
+   A30        2.08711   0.00004   0.00001   0.00032   0.00033   2.08744
+   A31        2.17395   0.00012  -0.00003   0.00048   0.00045   2.17440
+   A32        2.05510  -0.00005   0.00001  -0.00022  -0.00021   2.05489
+   A33        2.05413  -0.00006   0.00002  -0.00025  -0.00024   2.05389
+   A34        2.05136  -0.00008   0.00001  -0.00027  -0.00026   2.05110
+   A35        2.13476   0.00008  -0.00004   0.00034   0.00030   2.13506
+   A36        2.09706  -0.00001   0.00002  -0.00006  -0.00004   2.09702
+   A37        2.05136  -0.00008   0.00001  -0.00027  -0.00026   2.05110
+   A38        2.09706  -0.00001   0.00002  -0.00006  -0.00004   2.09702
+   A39        2.13476   0.00008  -0.00004   0.00034   0.00030   2.13506
+   A40        2.17395   0.00012  -0.00003   0.00048   0.00045   2.17440
+   A41        2.05510  -0.00005   0.00001  -0.00022  -0.00021   2.05489
+   A42        2.05413  -0.00006   0.00002  -0.00025  -0.00024   2.05389
+   A43        2.11738   0.00007  -0.00004   0.00027   0.00023   2.11761
+   A44        2.08911   0.00006   0.00002   0.00047   0.00049   2.08960
+   A45        2.07669  -0.00013   0.00002  -0.00074  -0.00071   2.07598
+   A46        2.06874  -0.00006   0.00002  -0.00020  -0.00019   2.06855
+   A47        2.13058   0.00009  -0.00003   0.00037   0.00034   2.13092
+   A48        2.08387  -0.00002   0.00001  -0.00016  -0.00015   2.08372
+   A49        2.06874  -0.00006   0.00002  -0.00020  -0.00019   2.06855
+   A50        2.08387  -0.00002   0.00001  -0.00016  -0.00015   2.08372
+   A51        2.13058   0.00009  -0.00003   0.00037   0.00034   2.13092
+   A52        2.11738   0.00007  -0.00004   0.00027   0.00023   2.11761
+   A53        2.08911   0.00006   0.00002   0.00047   0.00049   2.08960
+   A54        2.07669  -0.00013   0.00002  -0.00074  -0.00071   2.07598
+   A55        2.12761   0.00011  -0.00002   0.00049   0.00047   2.12808
+   A56        2.08464  -0.00001   0.00001   0.00003   0.00004   2.08468
+   A57        2.07093  -0.00010   0.00001  -0.00051  -0.00051   2.07043
+   A58        2.07170  -0.00009   0.00001  -0.00032  -0.00031   2.07139
+   A59        2.13349   0.00012  -0.00002   0.00045   0.00044   2.13393
+   A60        2.07799  -0.00003   0.00001  -0.00013  -0.00012   2.07787
+   A61        2.07170  -0.00009   0.00001  -0.00032  -0.00031   2.07139
+   A62        2.07799  -0.00003   0.00001  -0.00013  -0.00012   2.07787
+   A63        2.13349   0.00012  -0.00002   0.00045   0.00044   2.13393
+   A64        2.12761   0.00011  -0.00002   0.00049   0.00047   2.12808
+   A65        2.08464  -0.00001   0.00001   0.00003   0.00004   2.08468
+   A66        2.07094  -0.00010   0.00001  -0.00051  -0.00051   2.07043
+   A67        2.12720   0.00006  -0.00002   0.00026   0.00024   2.12745
+   A68        2.07799  -0.00003   0.00001  -0.00013  -0.00012   2.07787
+   A69        2.07799  -0.00003   0.00001  -0.00013  -0.00012   2.07787
+   A70        2.07799  -0.00003   0.00001  -0.00013  -0.00012   2.07787
+   A71        2.13349   0.00012  -0.00002   0.00045   0.00044   2.13393
+   A72        2.07170  -0.00009   0.00001  -0.00032  -0.00031   2.07139
+   A73        2.07799  -0.00003   0.00001  -0.00013  -0.00012   2.07787
+   A74        2.07170  -0.00009   0.00001  -0.00032  -0.00031   2.07139
+   A75        2.13349   0.00012  -0.00002   0.00045   0.00044   2.13393
+   A76        2.12720   0.00006  -0.00002   0.00026   0.00024   2.12745
+   A77        2.07799  -0.00003   0.00001  -0.00013  -0.00012   2.07787
+   A78        2.07799  -0.00003   0.00001  -0.00013  -0.00012   2.07787
+   A79        2.12761   0.00011  -0.00002   0.00049   0.00047   2.12808
+   A80        2.07094  -0.00010   0.00001  -0.00051  -0.00051   2.07043
+   A81        2.08464  -0.00001   0.00001   0.00003   0.00004   2.08468
+   A82        2.08387  -0.00002   0.00001  -0.00016  -0.00015   2.08372
+   A83        2.13058   0.00009  -0.00003   0.00037   0.00034   2.13092
+   A84        2.06874  -0.00006   0.00002  -0.00020  -0.00019   2.06855
+   A85        2.08387  -0.00002   0.00001  -0.00016  -0.00015   2.08372
+   A86        2.06874  -0.00006   0.00002  -0.00020  -0.00019   2.06855
+   A87        2.13058   0.00009  -0.00003   0.00037   0.00034   2.13092
+   A88        2.12761   0.00011  -0.00002   0.00049   0.00047   2.12808
+   A89        2.07093  -0.00010   0.00001  -0.00051  -0.00051   2.07043
+   A90        2.08464  -0.00001   0.00001   0.00003   0.00004   2.08468
+   A91        2.11738   0.00007  -0.00004   0.00027   0.00023   2.11761
+   A92        2.07669  -0.00013   0.00002  -0.00074  -0.00071   2.07598
+   A93        2.08911   0.00006   0.00002   0.00047   0.00049   2.08960
+   A94        2.09706  -0.00001   0.00002  -0.00006  -0.00004   2.09702
+   A95        2.13476   0.00008  -0.00004   0.00034   0.00030   2.13506
+   A96        2.05136  -0.00008   0.00001  -0.00027  -0.00026   2.05110
+   A97        2.09706  -0.00001   0.00002  -0.00006  -0.00004   2.09702
+   A98        2.05136  -0.00008   0.00001  -0.00027  -0.00026   2.05110
+   A99        2.13476   0.00008  -0.00004   0.00034   0.00030   2.13506
+   A100       2.11738   0.00007  -0.00004   0.00027   0.00023   2.11761
+   A101       2.07669  -0.00013   0.00002  -0.00074  -0.00071   2.07598
+   A102       2.08911   0.00006   0.00002   0.00047   0.00049   2.08960
+   A103       2.17395   0.00012  -0.00003   0.00048   0.00045   2.17440
+   A104       2.05413  -0.00006   0.00002  -0.00025  -0.00024   2.05389
+   A105       2.05510  -0.00005   0.00001  -0.00022  -0.00021   2.05489
+   A106       2.05787  -0.00004   0.00001  -0.00020  -0.00019   2.05769
+   A107       2.13146   0.00007  -0.00003   0.00027   0.00024   2.13170
+   A108       2.09385  -0.00003   0.00002  -0.00007  -0.00005   2.09380
+   A109       2.05787  -0.00004   0.00001  -0.00020  -0.00019   2.05769
+   A110       2.09385  -0.00003   0.00002  -0.00007  -0.00005   2.09380
+   A111       2.13146   0.00007  -0.00003   0.00027   0.00024   2.13170
+   A112       2.17395   0.00012  -0.00003   0.00048   0.00045   2.17440
+   A113       2.05413  -0.00006   0.00002  -0.00025  -0.00024   2.05389
+   A114       2.05510  -0.00005   0.00001  -0.00022  -0.00021   2.05489
+   A115       2.11072   0.00002  -0.00004   0.00003  -0.00001   2.11071
+   A116       2.08711   0.00004   0.00001   0.00032   0.00033   2.08744
+   A117       2.08535  -0.00006   0.00003  -0.00034  -0.00031   2.08504
+   A118       2.07861   0.00001   0.00002   0.00004   0.00006   2.07868
+   A119       2.13090  -0.00003  -0.00002  -0.00006  -0.00008   2.13082
+   A120       2.07367   0.00002   0.00000   0.00002   0.00002   2.07369
+   A121       2.07861   0.00001   0.00002   0.00004   0.00006   2.07868
+   A122       2.07367   0.00002   0.00000   0.00002   0.00002   2.07369
+   A123       2.13090  -0.00003  -0.00002  -0.00006  -0.00008   2.13082
+   A124       2.11072   0.00002  -0.00004   0.00003  -0.00001   2.11071
+   A125       2.08711   0.00004   0.00001   0.00032   0.00033   2.08744
+   A126       2.08535  -0.00006   0.00003  -0.00034  -0.00032   2.08504
+   A127       2.10893   0.00005  -0.00001   0.00021   0.00020   2.10914
+   A128       2.07219  -0.00013  -0.00001  -0.00076  -0.00076   2.07143
+   A129       2.10206   0.00008   0.00002   0.00054   0.00056   2.10262
+   A130       2.10058  -0.00007   0.00001  -0.00023  -0.00023   2.10036
+   A131       2.09628   0.00016   0.00001   0.00090   0.00090   2.09718
+   A132       2.08632  -0.00009  -0.00001  -0.00067  -0.00068   2.08565
+   A133       2.10058  -0.00007   0.00001  -0.00023  -0.00023   2.10036
+   A134       2.08632  -0.00009  -0.00001  -0.00067  -0.00068   2.08565
+   A135       2.09628   0.00016   0.00001   0.00090   0.00090   2.09718
+   A136       2.10893   0.00005  -0.00001   0.00021   0.00020   2.10914
+   A137       2.07219  -0.00013  -0.00001  -0.00076  -0.00076   2.07143
+   A138       2.10206   0.00008   0.00002   0.00054   0.00056   2.10262
+    D1        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D2        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+    D3       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+    D4        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D5        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D6        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+    D7       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+    D8        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D9        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D10       -3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D11        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D12        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D13        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D14        3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D15       -3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D16        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D17        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D18       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D19        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D20        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D21       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D22        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D23        0.00001   0.00000   0.00000   0.00000   0.00000   0.00000
+   D24       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D25        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D26        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D27       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D28        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D29       -0.00001   0.00000   0.00000   0.00000   0.00000   0.00000
+   D30        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D31        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D32        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D33        0.00001   0.00000   0.00000   0.00000   0.00000   0.00000
+   D34       -3.14156   0.00000   0.00000   0.00000   0.00000  -3.14157
+   D35       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D36        0.00002   0.00000   0.00000   0.00000   0.00000   0.00002
+   D37        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D38       -3.14157   0.00000   0.00000   0.00000   0.00000  -3.14158
+   D39        3.14157   0.00000   0.00000   0.00000   0.00000   3.14157
+   D40        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D41       -3.14144   0.00000   0.00000   0.00000   0.00000  -3.14144
+   D42       -0.00009   0.00000   0.00000  -0.00001  -0.00001  -0.00010
+   D43        0.00018   0.00000   0.00000  -0.00001  -0.00001   0.00017
+   D44        3.14152   0.00000   0.00000  -0.00001  -0.00001   3.14152
+   D45       -0.00001   0.00000   0.00000   0.00000   0.00000   0.00000
+   D46        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D47        3.14157   0.00000   0.00000   0.00000   0.00000   3.14157
+   D48       -0.00002   0.00000   0.00000   0.00000   0.00000  -0.00002
+   D49       -0.00017   0.00000   0.00000   0.00001   0.00001  -0.00016
+   D50       -3.14154   0.00000   0.00000   0.00001   0.00001  -3.14153
+   D51        3.14144   0.00000   0.00000   0.00000   0.00000   3.14145
+   D52        0.00007   0.00000   0.00000   0.00001   0.00001   0.00008
+   D53        0.00017   0.00000   0.00000  -0.00001  -0.00001   0.00016
+   D54       -3.14144   0.00000   0.00000   0.00000   0.00000  -3.14145
+   D55        3.14154   0.00000   0.00000  -0.00001  -0.00001   3.14153
+   D56       -0.00007   0.00000   0.00000  -0.00001  -0.00001  -0.00008
+   D57        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D58        3.14157   0.00000   0.00000   0.00000   0.00000   3.14158
+   D59       -3.14157   0.00000   0.00000   0.00000   0.00000  -3.14157
+   D60        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D61       -3.14156   0.00000   0.00000   0.00000   0.00000  -3.14157
+   D62        0.00002   0.00000   0.00000   0.00000   0.00000   0.00002
+   D63        0.00001   0.00000   0.00000   0.00000   0.00000   0.00001
+   D64       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D65       -0.00018   0.00000   0.00000   0.00001   0.00001  -0.00017
+   D66       -3.14152   0.00000   0.00000   0.00001   0.00001  -3.14152
+   D67        3.14144   0.00000   0.00000   0.00000   0.00000   3.14144
+   D68        0.00009   0.00000   0.00000   0.00001   0.00001   0.00010
+   D69       -0.00001   0.00000   0.00000   0.00000   0.00000  -0.00001
+   D70        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D71        3.14156   0.00000   0.00000   0.00000   0.00000   3.14156
+   D72       -0.00002   0.00000   0.00000   0.00000   0.00000  -0.00002
+   D73        0.00001   0.00000   0.00000   0.00000   0.00000   0.00001
+   D74       -3.14158   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D75        3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D76        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D77        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D78       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D79        3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D80        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D81        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D82        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D83        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D84       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D85       -0.00001   0.00000   0.00000   0.00000   0.00000  -0.00001
+   D86        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D87        3.14158   0.00000   0.00000   0.00000   0.00000   3.14159
+   D88        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D89        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D90        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D91       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D92        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D93        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D94        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D95       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D96        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D97        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D98        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D99       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D100       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D101      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D102       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D103       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D104       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D105       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D106       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D107      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D108       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D109       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D110      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D111       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D112       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D113       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D114      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D115       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D116       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D117       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D118      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D119       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D120       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D121       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D122       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D123       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D124      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D125       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D126      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D127       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D128       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D129       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D130       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D131      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D132       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D133       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D134       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D135      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D136       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D137       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D138       3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D139      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D140       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D141      -3.14158   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D142       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D143       0.00001   0.00000   0.00000   0.00000   0.00000   0.00001
+   D144       3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D145       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D146       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D147      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D148       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D149      -0.00001   0.00000   0.00000   0.00000   0.00000  -0.00001
+   D150       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D151       3.14158   0.00000   0.00000   0.00000   0.00000   3.14159
+   D152       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D153       0.00001   0.00000   0.00000   0.00000   0.00000   0.00001
+   D154      -3.14156   0.00000   0.00000   0.00000   0.00000  -3.14157
+   D155      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D156       0.00002   0.00000   0.00000   0.00000   0.00000   0.00002
+   D157       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D158      -3.14157   0.00000   0.00000   0.00000   0.00000  -3.14157
+   D159       3.14157   0.00000   0.00000   0.00000   0.00000   3.14158
+   D160       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D161      -3.14144   0.00000   0.00000   0.00000   0.00000  -3.14145
+   D162      -0.00007   0.00000   0.00000  -0.00001  -0.00001  -0.00008
+   D163       0.00017   0.00000   0.00000  -0.00001  -0.00001   0.00016
+   D164       3.14154   0.00000   0.00000  -0.00001  -0.00001   3.14153
+   D165      -0.00001   0.00000   0.00000   0.00000   0.00000  -0.00001
+   D166       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D167       3.14156   0.00000   0.00000   0.00000   0.00000   3.14156
+   D168      -0.00002   0.00000   0.00000   0.00000   0.00000  -0.00002
+   D169      -0.00018   0.00000   0.00000   0.00001   0.00001  -0.00017
+   D170      -3.14152   0.00000   0.00000   0.00001   0.00001  -3.14152
+   D171       3.14144   0.00000   0.00000   0.00000   0.00000   3.14144
+   D172       0.00009   0.00000   0.00000   0.00001   0.00001   0.00010
+   D173       0.00018   0.00000   0.00000  -0.00001  -0.00001   0.00017
+   D174      -3.14144   0.00000   0.00000   0.00000   0.00000  -3.14144
+   D175       3.14152   0.00000   0.00000  -0.00001  -0.00001   3.14152
+   D176      -0.00009   0.00000   0.00000  -0.00001  -0.00001  -0.00010
+   D177       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D178       3.14157   0.00000   0.00000   0.00000   0.00000   3.14157
+   D179      -3.14157   0.00000   0.00000   0.00000   0.00000  -3.14158
+   D180       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D181      -3.14156   0.00000   0.00000   0.00000   0.00000  -3.14157
+   D182       0.00002   0.00000   0.00000   0.00000   0.00000   0.00002
+   D183       0.00001   0.00000   0.00000   0.00000   0.00000   0.00000
+   D184      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D185      -0.00017   0.00000   0.00000   0.00001   0.00001  -0.00016
+   D186      -3.14154   0.00000   0.00000   0.00001   0.00001  -3.14153
+   D187       3.14144   0.00000   0.00000   0.00000   0.00000   3.14145
+   D188       0.00007   0.00000   0.00000   0.00001   0.00001   0.00008
+   D189      -0.00001   0.00000   0.00000   0.00000   0.00000   0.00000
+   D190       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D191       3.14157   0.00000   0.00000   0.00000   0.00000   3.14157
+   D192      -0.00002   0.00000   0.00000   0.00000   0.00000  -0.00002
+   D193       0.00001   0.00000   0.00000   0.00000   0.00000   0.00000
+   D194      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D195      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D196       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D197       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D198       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D199      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D200       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D201       3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D202       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D203       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D204      -3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D205      -0.00001   0.00000   0.00000   0.00000   0.00000   0.00000
+   D206       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D207       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D208       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D209       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D210       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D211      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D212       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D213       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D214       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D215      -3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D216       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D217       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D218      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D219       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D220       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D221       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D222       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D223      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D224       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000823     0.000450     NO 
+ RMS     Force            0.000163     0.000300     YES
+ Maximum Displacement     0.008361     0.001800     NO 
+ RMS     Displacement     0.002230     0.001200     NO 
+ Predicted change in Energy=-1.581246D-05
+ Lowest energy point so far.  Saving SCF results.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Tue Aug  4 10:40:47 2020, MaxMem=    33554432 cpu:         0.2
+ (Enter /cluster/apps/gaussian/g09/l202.exe)
+ Stoichiometry    C42H26N4
+ Framework group  C2[X(C42H26N4)]
+ Deg. of freedom   106
+ Full point group                 C2      NOp   2
+ RotChk:  IX=0 Diff= 1.99D-08
+ Largest Abelian subgroup         C2      NOp   2
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0      -13.644295    0.714925    0.000456
+      2          6           0      -13.644295   -0.714925    0.000456
+      3          6           0      -12.445318    1.416719    0.000334
+      4          6           0      -11.185464    0.723718    0.000204
+      5          6           0      -11.185464   -0.723718    0.000204
+      6          6           0      -12.445318   -1.416719    0.000334
+      7          6           0       -9.927380   -1.423940    0.000076
+      8          6           0       -8.721668   -0.728772   -0.000053
+      9          6           0       -8.721668    0.728772   -0.000052
+     10          6           0       -9.927380    1.423940    0.000077
+     11          7           0       -7.460364    1.396504   -0.000208
+     12          6           0       -6.194868    0.737183   -0.000173
+     13          6           0       -6.194868   -0.737183   -0.000173
+     14          7           0       -7.460364   -1.396504   -0.000213
+     15          6           0       -5.000501   -1.430940   -0.000159
+     16          6           0       -3.722321   -0.736388   -0.000153
+     17          6           0       -3.722321    0.736389   -0.000153
+     18          6           0       -5.000501    1.430940   -0.000159
+     19          6           0       -2.500697    1.424405   -0.000147
+     20          6           0       -1.240723    0.735108   -0.000143
+     21          6           0       -1.240723   -0.735108   -0.000143
+     22          6           0       -2.500697   -1.424405   -0.000147
+     23          6           0        0.000000   -1.424357   -0.000142
+     24          6           0        1.240723   -0.735108   -0.000143
+     25          6           0        1.240723    0.735108   -0.000143
+     26          6           0        0.000000    1.424357   -0.000142
+     27          6           0        2.500697    1.424405   -0.000147
+     28          6           0        3.722321    0.736388   -0.000153
+     29          6           0        3.722321   -0.736389   -0.000153
+     30          6           0        2.500697   -1.424405   -0.000147
+     31          6           0        5.000501   -1.430940   -0.000159
+     32          6           0        6.194868   -0.737183   -0.000173
+     33          6           0        6.194868    0.737183   -0.000173
+     34          6           0        5.000501    1.430940   -0.000159
+     35          7           0        7.460364    1.396504   -0.000213
+     36          6           0        8.721668    0.728772   -0.000053
+     37          6           0        8.721668   -0.728772   -0.000052
+     38          7           0        7.460364   -1.396504   -0.000208
+     39          6           0        9.927380   -1.423940    0.000077
+     40          6           0       11.185464   -0.723718    0.000204
+     41          6           0       11.185464    0.723718    0.000204
+     42          6           0        9.927380    1.423940    0.000076
+     43          6           0       12.445318    1.416719    0.000334
+     44          6           0       13.644295    0.714925    0.000456
+     45          6           0       13.644295   -0.714925    0.000456
+     46          6           0       12.445318   -1.416719    0.000334
+     47          1           0      -14.600032    1.255626    0.000554
+     48          1           0      -14.600032   -1.255626    0.000554
+     49          1           0      -12.442835    2.514981    0.000334
+     50          1           0      -12.442835   -2.514981    0.000333
+     51          1           0       -9.920401   -2.520976    0.000076
+     52          1           0       -9.920401    2.520976    0.000077
+     53          1           0       -5.008645   -2.527697   -0.000158
+     54          1           0       -5.008645    2.527697   -0.000157
+     55          1           0       -2.499643   -2.522491   -0.000147
+     56          1           0        0.000000    2.522718   -0.000142
+     57          1           0        2.499643   -2.522491   -0.000147
+     58          1           0        5.008645    2.527697   -0.000158
+     59          1           0        9.920401   -2.520976    0.000077
+     60          1           0        9.920401    2.520976    0.000076
+     61          1           0       12.442835    2.514981    0.000333
+     62          1           0       14.600032    1.255626    0.000554
+     63          1           0       14.600032   -1.255626    0.000554
+     64          1           0       12.442835   -2.514981    0.000334
+     65          1           0       -2.499643    2.522491   -0.000147
+     66          1           0        2.499643    2.522491   -0.000147
+     67          1           0        0.000000   -2.522718   -0.000142
+     68          1           0        5.008645   -2.527697   -0.000157
+     69          1           0       -7.463268    2.437262   -0.000148
+     70          1           0        7.463268    2.437262   -0.000142
+     71          1           0       -7.463268   -2.437262   -0.000142
+     72          1           0        7.463268   -2.437262   -0.000148
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      0.5972737      0.0125754      0.0123161
+ Leave Link  202 at Tue Aug  4 10:40:47 2020, MaxMem=    33554432 cpu:         0.0
+ (Enter /cluster/apps/gaussian/g09/l301.exe)
+ Standard basis: STO-3G (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are   128 symmetry adapted cartesian basis functions of A   symmetry.
+ There are   128 symmetry adapted cartesian basis functions of B   symmetry.
+ There are   128 symmetry adapted basis functions of A   symmetry.
+ There are   128 symmetry adapted basis functions of B   symmetry.
+   256 basis functions,   768 primitive gaussians,   256 cartesian basis functions
+   153 alpha electrons      153 beta electrons
+       nuclear repulsion energy      4276.0544435453 Hartrees.
+ IExCor=  402 DFT=T Ex+Corr=B3LYP ExCW=0 ScaHFX=  0.200000
+ ScaDFX=  0.800000  0.720000  1.000000  0.810000 ScalE2=  1.000000  1.000000
+ IRadAn=      0 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=  4
+ NAtoms=   72 NActive=   72 NUniq=   36 SFac= 4.00D+00 NAtFMM=   60 NAOKFM=T Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ Leave Link  301 at Tue Aug  4 10:40:47 2020, MaxMem=    33554432 cpu:         0.0
+ (Enter /cluster/apps/gaussian/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+ One-electron integral symmetry used in STVInt
+ NBasis=   256 RedAO= T EigKep=  1.28D-01  NBF=   128   128
+ NBsUse=   256 1.00D-06 EigRej= -1.00D+00 NBFU=   128   128
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           0 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   217   218   218   218   218 MxSgAt=    72 MxSgA2=    71.
+ Leave Link  302 at Tue Aug  4 10:40:48 2020, MaxMem=    33554432 cpu:         1.2
+ (Enter /cluster/apps/gaussian/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Tue Aug  4 10:40:48 2020, MaxMem=    33554432 cpu:         0.0
+ (Enter /cluster/apps/gaussian/g09/l401.exe)
+ Initial guess from the checkpoint file:  "r-b3lyp-sto3g.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess orbital symmetries:
+       Occupied  (B) (A) (B) (A) (B) (A) (A) (B) (B) (A) (B) (A)
+                 (B) (A) (B) (A) (B) (A) (B) (A) (B) (A) (B) (A)
+                 (B) (A) (B) (A) (B) (A) (B) (A) (B) (A) (B) (A)
+                 (B) (A) (A) (B) (B) (A) (A) (B) (B) (A) (A) (B)
+                 (B) (A) (A) (B) (A) (B) (A) (B) (A) (B) (B) (A)
+                 (B) (A) (A) (B) (B) (A) (A) (B) (B) (A) (B) (A)
+                 (B) (A) (A) (B) (B) (A) (A) (B) (A) (A) (B) (B)
+                 (A) (B) (A) (B) (A) (A) (B) (B) (B) (A) (A) (B)
+                 (A) (B) (A) (B) (B) (A) (B) (A) (A) (B) (A) (B)
+                 (A) (B) (B) (A) (B) (A) (A) (A) (B) (A) (B) (B)
+                 (B) (A) (B) (A) (B) (B) (A) (B) (A) (A) (B) (A)
+                 (B) (A) (B) (A) (B) (A) (A) (B) (A) (B) (B) (A)
+                 (A) (B) (B) (A) (B) (A) (A) (B) (B)
+       Virtual   (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (B) (B) (B) (B) (B) (B) (B) (B)
+                 (B) (B) (B) (B) (B) (B) (B) (B) (B) (B) (B) (B)
+                 (B) (B) (B) (B) (B) (B) (B) (B) (B) (B) (B) (B)
+                 (B) (B) (B) (B) (B) (B) (B) (B) (B) (B) (B) (B)
+                 (B) (B) (B) (B) (B) (B) (B)
+ The electronic state of the initial guess is 1-A.
+ Leave Link  401 at Tue Aug  4 10:40:48 2020, MaxMem=    33554432 cpu:         0.2
+ (Enter /cluster/apps/gaussian/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=    10.
+ Integral symmetry usage will be decided dynamically.
+ IVT=     4406646 IEndB=     4406646 NGot=    33554432 MDV=    33411979
+ LenX=    33411979 LenY=    33346002
+ Requested convergence on RMS density matrix=1.00D-07 within2048 cycles.
+ Requested convergence on MAX density matrix=1.00D-05.
+ Requested convergence on             energy=1.00D-05.
+ Level shift goal  0.100 maximum shift  0.100.
+ No special actions if energy rises.
+ Fock matrices will be formed incrementally for  20 cycles.
+
+ Cycle   1  Pass 1  IDiag  1:
+ FoFJK:  IHMeth= 1 ICntrl=       0 DoSepK=F KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf= 390000000 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=        2000
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=       0 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ E= -1812.58399222045    
+ DIIS: error= 7.70D-05 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -1812.58399222045     IErMin= 1 ErrMin= 7.70D-05
+ ErrMax= 7.70D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.37D-06 BMatP= 1.37D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.439 Goal=     0.100 Shift=    0.000
+ RMSDP=1.15D-05 MaxDP=3.22D-04              OVMax= 0.00D+00
+
+ Cycle   2  Pass 1  IDiag  1:
+ RMSU=  1.15D-05    CP:  1.00D+00
+ E= -1812.58399501634     Delta-E=       -0.000002795889 Rises=F Damp=F
+ DIIS: error= 1.71D-05 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -1812.58399501634     IErMin= 2 ErrMin= 1.71D-05
+ ErrMax= 1.71D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 5.29D-08 BMatP= 1.37D-06
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.828D-02 0.992D+00
+ Coeff:      0.828D-02 0.992D+00
+ Gap=     0.094 Goal=     0.100 Shift=    0.006
+ RMSDP=3.34D-06 MaxDP=1.21D-04 DE=-2.80D-06 OVMax= 0.00D+00
+
+ Cycle   3  Pass 1  IDiag  1:
+ RMSU=  3.13D-06    CP:  1.00D+00  1.10D+00
+ E= -1812.58399497831     Delta-E=        0.000000038029 Rises=F Damp=F
+ DIIS: error= 2.29D-05 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 2 EnMin= -1812.58399501634     IErMin= 2 ErrMin= 1.71D-05
+ ErrMax= 2.29D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.15D-07 BMatP= 5.29D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.283D-01 0.620D+00 0.408D+00
+ Coeff:     -0.283D-01 0.620D+00 0.408D+00
+ Gap=     0.094 Goal=     0.100 Shift=    0.006
+ RMSDP=2.14D-06 MaxDP=8.41D-05 DE= 3.80D-08 OVMax= 0.00D+00
+
+ Cycle   4  Pass 1  IDiag  1:
+ RMSU=  9.74D-07    CP:  1.00D+00  1.14D+00  4.12D-01
+ E= -1812.58399512565     Delta-E=       -0.000000147338 Rises=F Damp=F
+ DIIS: error= 7.27D-06 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -1812.58399512565     IErMin= 4 ErrMin= 7.27D-06
+ ErrMax= 7.27D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 6.54D-09 BMatP= 5.29D-08
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.198D-01 0.296D+00 0.238D+00 0.485D+00
+ Coeff:     -0.198D-01 0.296D+00 0.238D+00 0.485D+00
+ Gap=     0.094 Goal=     0.100 Shift=    0.006
+ RMSDP=6.11D-07 MaxDP=2.27D-05 DE=-1.47D-07 OVMax= 0.00D+00
+
+ Cycle   5  Pass 1  IDiag  1:
+ RMSU=  3.98D-07    CP:  1.00D+00  1.15D+00  4.94D-01  6.06D-01
+ E= -1812.58399513442     Delta-E=       -0.000000008777 Rises=F Damp=F
+ DIIS: error= 2.26D-06 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -1812.58399513442     IErMin= 5 ErrMin= 2.26D-06
+ ErrMax= 2.26D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 6.31D-10 BMatP= 6.54D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.144D-02-0.208D-01 0.836D-02 0.240D+00 0.774D+00
+ Coeff:     -0.144D-02-0.208D-01 0.836D-02 0.240D+00 0.774D+00
+ Gap=     0.094 Goal=     0.100 Shift=    0.006
+ RMSDP=2.08D-07 MaxDP=7.35D-06 DE=-8.78D-09 OVMax= 0.00D+00
+
+ Cycle   6  Pass 1  IDiag  1:
+ RMSU=  1.01D-07    CP:  1.00D+00  1.16D+00  4.94D-01  7.51D-01  8.91D-01
+ E= -1812.58399513543     Delta-E=       -0.000000001010 Rises=F Damp=F
+ DIIS: error= 4.28D-07 at cycle   6 NSaved=   6.
+ NSaved= 6 IEnMin= 6 EnMin= -1812.58399513543     IErMin= 6 ErrMin= 4.28D-07
+ ErrMax= 4.28D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 4.90D-11 BMatP= 6.31D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.433D-03-0.260D-01-0.840D-02 0.801D-01 0.353D+00 0.601D+00
+ Coeff:      0.433D-03-0.260D-01-0.840D-02 0.801D-01 0.353D+00 0.601D+00
+ Gap=     0.094 Goal=     0.100 Shift=    0.006
+ RMSDP=5.91D-08 MaxDP=2.11D-06 DE=-1.01D-09 OVMax= 0.00D+00
+
+ SCF Done:  E(RB3LYP) =  -1812.58399514     A.U. after    6 cycles
+            NFock=  6  Conv=0.59D-07     -V/T= 2.0186
+ KE= 1.779401857429D+03 PE=-1.275054982593D+04 EE= 4.882509529822D+03
+ Leave Link  502 at Tue Aug  4 10:41:15 2020, MaxMem=    33554432 cpu:        26.5
+ (Enter /cluster/apps/gaussian/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ Leave Link  701 at Tue Aug  4 10:41:15 2020, MaxMem=    33554432 cpu:         0.2
+ (Enter /cluster/apps/gaussian/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Tue Aug  4 10:41:15 2020, MaxMem=    33554432 cpu:         0.0
+ (Enter /cluster/apps/gaussian/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=F KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         0 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=        2800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2127 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Tue Aug  4 10:41:27 2020, MaxMem=    33554432 cpu:        11.5
+ (Enter /cluster/apps/gaussian/g09/l716.exe)
+ Dipole        = 4.08402478D-13 1.69655956D-14 2.02667721D-04
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6           0.000221395    0.000290298   -0.000000033
+      2        6           0.000221394   -0.000290302   -0.000000016
+      3        6          -0.000286209   -0.000007028    0.000000041
+      4        6           0.000182335   -0.000229677   -0.000000003
+      5        6           0.000182326    0.000229677   -0.000000021
+      6        6          -0.000286208    0.000007031    0.000000034
+      7        6          -0.000019336   -0.000033979   -0.000000090
+      8        6           0.000023824    0.000081658    0.000000060
+      9        6           0.000023833   -0.000081657    0.000000106
+     10        6          -0.000019342    0.000033979   -0.000000120
+     11        7          -0.000011061    0.000035696   -0.000000334
+     12        6           0.000073024    0.000046883    0.000000113
+     13        6           0.000073001   -0.000046890    0.000000058
+     14        7          -0.000011043   -0.000035690   -0.000000123
+     15        6          -0.000177381   -0.000005157   -0.000000088
+     16        6           0.000130968    0.000028303    0.000000008
+     17        6           0.000130989   -0.000028303    0.000000011
+     18        6          -0.000177394    0.000005161   -0.000000118
+     19        6          -0.000142428    0.000019720    0.000000003
+     20        6           0.000067048   -0.000078855    0.000000004
+     21        6           0.000067037    0.000078850    0.000000007
+     22        6          -0.000142411   -0.000019721    0.000000005
+     23        6          -0.000000004   -0.000029114    0.000000004
+     24        6          -0.000067048    0.000078855    0.000000004
+     25        6          -0.000067037   -0.000078850    0.000000007
+     26        6           0.000000004    0.000029114    0.000000004
+     27        6           0.000142411    0.000019721    0.000000005
+     28        6          -0.000130968   -0.000028303    0.000000008
+     29        6          -0.000130989    0.000028303    0.000000011
+     30        6           0.000142428   -0.000019720    0.000000003
+     31        6           0.000177394   -0.000005161   -0.000000118
+     32        6          -0.000073024   -0.000046883    0.000000113
+     33        6          -0.000073001    0.000046890    0.000000058
+     34        6           0.000177381    0.000005157   -0.000000088
+     35        7           0.000011043    0.000035690   -0.000000123
+     36        6          -0.000023824   -0.000081658    0.000000060
+     37        6          -0.000023833    0.000081657    0.000000106
+     38        7           0.000011061   -0.000035696   -0.000000334
+     39        6           0.000019342   -0.000033979   -0.000000120
+     40        6          -0.000182335    0.000229677   -0.000000003
+     41        6          -0.000182326   -0.000229677   -0.000000021
+     42        6           0.000019336    0.000033979   -0.000000090
+     43        6           0.000286208   -0.000007031    0.000000034
+     44        6          -0.000221394    0.000290302   -0.000000016
+     45        6          -0.000221395   -0.000290298   -0.000000033
+     46        6           0.000286209    0.000007028    0.000000041
+     47        1          -0.000017561   -0.000017815    0.000000001
+     48        1          -0.000017560    0.000017815    0.000000000
+     49        1           0.000031518    0.000030040   -0.000000007
+     50        1           0.000031517   -0.000030040   -0.000000007
+     51        1          -0.000012877   -0.000043346    0.000000009
+     52        1          -0.000012876    0.000043346    0.000000010
+     53        1           0.000031841   -0.000049404    0.000000005
+     54        1           0.000031842    0.000049404    0.000000009
+     55        1           0.000019923   -0.000046810   -0.000000010
+     56        1          -0.000000001    0.000043371   -0.000000010
+     57        1          -0.000019923   -0.000046811   -0.000000009
+     58        1          -0.000031841    0.000049404    0.000000005
+     59        1           0.000012876   -0.000043346    0.000000010
+     60        1           0.000012877    0.000043346    0.000000009
+     61        1          -0.000031517    0.000030040   -0.000000007
+     62        1           0.000017560   -0.000017815    0.000000000
+     63        1           0.000017561    0.000017815    0.000000001
+     64        1          -0.000031518   -0.000030040   -0.000000007
+     65        1           0.000019923    0.000046811   -0.000000009
+     66        1          -0.000019923    0.000046810   -0.000000010
+     67        1           0.000000001   -0.000043371   -0.000000010
+     68        1          -0.000031842   -0.000049404    0.000000009
+     69        1           0.000003634   -0.000053297    0.000000308
+     70        1          -0.000003631   -0.000053295    0.000000192
+     71        1           0.000003631    0.000053295    0.000000192
+     72        1          -0.000003634    0.000053297    0.000000308
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.000290302 RMS     0.000087623
+ Leave Link  716 at Tue Aug  4 10:41:27 2020, MaxMem=    33554432 cpu:         0.0
+ (Enter /cluster/apps/gaussian/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.000209806 RMS     0.000049283
+ Search for a local minimum.
+ Step number   4 out of a maximum of  432
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .49283D-04 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Swapping is turned off.
+ Update second derivatives using D2CorX and points    1    2    3    4
+ DE= -1.50D-05 DEPred=-1.58D-05 R= 9.49D-01
+ TightC=F SS=  1.41D+00  RLast= 9.49D-03 DXNew= 8.4853D-01 2.8476D-02
+ Trust test= 9.49D-01 RLast= 9.49D-03 DXMaxT set to 5.05D-01
+ ITU=  1  1  1  0
+     Eigenvalues ---    0.01654   0.01659   0.01707   0.01737   0.01765
+     Eigenvalues ---    0.01770   0.01776   0.01784   0.01785   0.01811
+     Eigenvalues ---    0.01811   0.01821   0.01821   0.01822   0.01837
+     Eigenvalues ---    0.01841   0.01841   0.01841   0.01841   0.01841
+     Eigenvalues ---    0.01841   0.01856   0.01863   0.01872   0.01876
+     Eigenvalues ---    0.01881   0.01896   0.01896   0.01902   0.01902
+     Eigenvalues ---    0.01938   0.01938   0.01978   0.01978   0.02004
+     Eigenvalues ---    0.02004   0.02047   0.02047   0.02047   0.02047
+     Eigenvalues ---    0.02088   0.02088   0.02088   0.02091   0.02091
+     Eigenvalues ---    0.02101   0.02101   0.02109   0.02109   0.02123
+     Eigenvalues ---    0.02124   0.02127   0.02127   0.02140   0.02140
+     Eigenvalues ---    0.02155   0.02155   0.02164   0.02164   0.02167
+     Eigenvalues ---    0.02167   0.02203   0.02203   0.02205   0.02205
+     Eigenvalues ---    0.02259   0.02259   0.02277   0.02277   0.15112
+     Eigenvalues ---    0.15999   0.16000   0.16000   0.16000   0.16000
+     Eigenvalues ---    0.16000   0.16000   0.16000   0.16000   0.16000
+     Eigenvalues ---    0.16000   0.16000   0.16000   0.16000   0.16000
+     Eigenvalues ---    0.16000   0.16000   0.16000   0.16000   0.16000
+     Eigenvalues ---    0.16000   0.16000   0.16000   0.16000   0.16005
+     Eigenvalues ---    0.22000   0.22000   0.22397   0.22489   0.22567
+     Eigenvalues ---    0.22861   0.22902   0.23100   0.23161   0.23314
+     Eigenvalues ---    0.23367   0.23457   0.23658   0.23688   0.23746
+     Eigenvalues ---    0.23829   0.23925   0.24024   0.24131   0.24137
+     Eigenvalues ---    0.24238   0.24319   0.24566   0.24567   0.25000
+     Eigenvalues ---    0.25000   0.25000   0.25000   0.25000   0.25000
+     Eigenvalues ---    0.25000   0.25000   0.25000   0.33305   0.33977
+     Eigenvalues ---    0.34942   0.35125   0.35278   0.35280   0.35286
+     Eigenvalues ---    0.35286   0.35286   0.35296   0.35296   0.35296
+     Eigenvalues ---    0.35301   0.35305   0.35305   0.35305   0.35312
+     Eigenvalues ---    0.35355   0.35359   0.35359   0.35359   0.35499
+     Eigenvalues ---    0.35499   0.35499   0.35502   0.36081   0.36339
+     Eigenvalues ---    0.36517   0.37486   0.37633   0.38822   0.38826
+     Eigenvalues ---    0.38966   0.39556   0.40216   0.40216   0.40476
+     Eigenvalues ---    0.40612   0.40726   0.40726   0.40788   0.40801
+     Eigenvalues ---    0.41668   0.41846   0.42140   0.42447   0.42526
+     Eigenvalues ---    0.42787   0.42826   0.43160   0.43160   0.43331
+     Eigenvalues ---    0.44638   0.44916   0.45608   0.45801   0.46316
+     Eigenvalues ---    0.46316   0.46316   0.46592   0.46608   0.46743
+     Eigenvalues ---    0.46789   0.46792   0.47547   0.47547   0.47553
+     Eigenvalues ---    0.47710   0.47991   0.47991   0.48010   0.48231
+     Eigenvalues ---    0.48231   0.48415   0.49167   0.49188   0.49346
+     Eigenvalues ---    0.49756   0.49756   0.50469   0.51086   0.59617
+ En-DIIS/RFO-DIIS IScMMF=        0 using points:     4    3
+ RFO step:  Lambda=-1.65091470D-06.
+ NNeg= 0 NP= 2 Switch=  2.50D-03 Rises=F DC=  1.50D-05 SmlDif=  1.00D-05
+ RMS Error=  0.7773362107D-04 NUsed= 2 EDIIS=F
+ DidBck=F Rises=F RFO-DIIS coefs:    0.95169    0.04831
+ Iteration  1 RMS(Cart)=  0.00065338 RMS(Int)=  0.00000001
+ Iteration  2 RMS(Cart)=  0.00000005 RMS(Int)=  0.00000000
+ ITry= 1 IFail=0 DXMaxC= 2.65D-03 DCOld= 1.00D+10 DXMaxT= 5.05D-01 DXLimC= 3.00D+00 Rises=F
+ ClnCor:  largest displacement from symmetrization is 9.56D-09 for atom    63.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.70202   0.00021  -0.00003   0.00054   0.00051   2.70254
+    R2        2.62533  -0.00021   0.00002  -0.00044  -0.00042   2.62491
+    R3        2.07508   0.00001   0.00003  -0.00003  -0.00001   2.07507
+    R4        2.62533  -0.00021   0.00002  -0.00044  -0.00042   2.62491
+    R5        2.07508   0.00001   0.00003  -0.00003  -0.00001   2.07507
+    R6        2.71719   0.00009  -0.00005   0.00036   0.00031   2.71749
+    R7        2.07542   0.00003   0.00003   0.00001   0.00004   2.07546
+    R8        2.73526  -0.00011   0.00010  -0.00048  -0.00038   2.73487
+    R9        2.72087  -0.00010  -0.00004  -0.00010  -0.00014   2.72073
+   R10        2.71719   0.00009  -0.00005   0.00036   0.00031   2.71749
+   R11        2.72087  -0.00010  -0.00004  -0.00010  -0.00014   2.72073
+   R12        2.07542   0.00003   0.00003   0.00001   0.00004   2.07546
+   R13        2.63005  -0.00006  -0.00003  -0.00001  -0.00004   2.63001
+   R14        2.07314   0.00004   0.00004   0.00001   0.00006   2.07319
+   R15        2.75436  -0.00004   0.00007  -0.00023  -0.00017   2.75419
+   R16        2.69692  -0.00011  -0.00005  -0.00006  -0.00011   2.69681
+   R17        2.63005  -0.00006  -0.00003  -0.00001  -0.00004   2.63001
+   R18        2.69692  -0.00011  -0.00005  -0.00006  -0.00011   2.69681
+   R19        2.07314   0.00004   0.00004   0.00001   0.00006   2.07319
+   R20        2.69654  -0.00011  -0.00006  -0.00003  -0.00009   2.69646
+   R21        1.96675  -0.00005   0.00001  -0.00009  -0.00008   1.96667
+   R22        2.78615   0.00004   0.00006  -0.00002   0.00004   2.78619
+   R23        2.61016  -0.00016  -0.00001  -0.00023  -0.00025   2.60991
+   R24        2.69654  -0.00011  -0.00006  -0.00003  -0.00009   2.69646
+   R25        2.61016  -0.00016  -0.00001  -0.00023  -0.00025   2.60991
+   R26        1.96675  -0.00005   0.00001  -0.00009  -0.00008   1.96667
+   R27        2.74898  -0.00001  -0.00007   0.00018   0.00011   2.74909
+   R28        2.07263   0.00005   0.00005   0.00002   0.00007   2.07270
+   R29        2.78315   0.00003   0.00007  -0.00008   0.00000   2.78314
+   R30        2.64948  -0.00014   0.00000  -0.00026  -0.00026   2.64922
+   R31        2.74898  -0.00001  -0.00007   0.00018   0.00011   2.74909
+   R32        2.64948  -0.00014   0.00000  -0.00026  -0.00026   2.64922
+   R33        2.07263   0.00005   0.00005   0.00002   0.00007   2.07270
+   R34        2.71402  -0.00002  -0.00005   0.00011   0.00006   2.71408
+   R35        2.07508   0.00005   0.00004   0.00003   0.00007   2.07515
+   R36        2.77830   0.00001   0.00008  -0.00015  -0.00007   2.77823
+   R37        2.68212  -0.00009  -0.00002  -0.00011  -0.00012   2.68200
+   R38        2.71402  -0.00002  -0.00005   0.00011   0.00006   2.71408
+   R39        2.68212  -0.00009  -0.00002  -0.00011  -0.00012   2.68200
+   R40        2.07508   0.00005   0.00004   0.00003   0.00007   2.07515
+   R41        2.68212  -0.00009  -0.00002  -0.00011  -0.00012   2.68200
+   R42        2.07560   0.00004   0.00004   0.00002   0.00006   2.07566
+   R43        2.77830   0.00001   0.00008  -0.00015  -0.00007   2.77823
+   R44        2.71402  -0.00002  -0.00005   0.00011   0.00006   2.71408
+   R45        2.68212  -0.00009  -0.00002  -0.00011  -0.00012   2.68200
+   R46        2.71402  -0.00002  -0.00005   0.00011   0.00006   2.71408
+   R47        2.07560   0.00004   0.00004   0.00002   0.00006   2.07566
+   R48        2.64948  -0.00014   0.00000  -0.00026  -0.00026   2.64922
+   R49        2.07508   0.00005   0.00004   0.00003   0.00007   2.07515
+   R50        2.78315   0.00003   0.00007  -0.00008   0.00000   2.78314
+   R51        2.74898  -0.00001  -0.00007   0.00018   0.00011   2.74909
+   R52        2.64948  -0.00014   0.00000  -0.00026  -0.00026   2.64922
+   R53        2.74898  -0.00001  -0.00007   0.00018   0.00011   2.74909
+   R54        2.07508   0.00005   0.00004   0.00003   0.00007   2.07515
+   R55        2.61016  -0.00016  -0.00001  -0.00023  -0.00025   2.60991
+   R56        2.07263   0.00005   0.00005   0.00002   0.00007   2.07270
+   R57        2.78615   0.00004   0.00006  -0.00002   0.00004   2.78619
+   R58        2.69654  -0.00011  -0.00006  -0.00003  -0.00009   2.69646
+   R59        2.61016  -0.00016  -0.00001  -0.00023  -0.00025   2.60991
+   R60        2.69654  -0.00011  -0.00006  -0.00003  -0.00009   2.69646
+   R61        2.07263   0.00005   0.00005   0.00002   0.00007   2.07270
+   R62        2.69692  -0.00011  -0.00005  -0.00006  -0.00011   2.69681
+   R63        1.96675  -0.00005   0.00001  -0.00009  -0.00008   1.96667
+   R64        2.75436  -0.00004   0.00007  -0.00023  -0.00017   2.75419
+   R65        2.63005  -0.00006  -0.00003  -0.00001  -0.00004   2.63001
+   R66        2.69692  -0.00011  -0.00005  -0.00006  -0.00011   2.69681
+   R67        2.63005  -0.00006  -0.00003  -0.00001  -0.00004   2.63001
+   R68        1.96675  -0.00005   0.00001  -0.00009  -0.00008   1.96667
+   R69        2.72087  -0.00010  -0.00004  -0.00010  -0.00014   2.72073
+   R70        2.07314   0.00004   0.00004   0.00001   0.00006   2.07319
+   R71        2.73526  -0.00011   0.00010  -0.00048  -0.00038   2.73487
+   R72        2.71719   0.00009  -0.00005   0.00036   0.00031   2.71749
+   R73        2.72087  -0.00010  -0.00004  -0.00010  -0.00014   2.72073
+   R74        2.71719   0.00009  -0.00005   0.00036   0.00031   2.71749
+   R75        2.07314   0.00004   0.00004   0.00001   0.00006   2.07319
+   R76        2.62533  -0.00021   0.00002  -0.00044  -0.00042   2.62491
+   R77        2.07542   0.00003   0.00003   0.00001   0.00004   2.07546
+   R78        2.70202   0.00021  -0.00003   0.00054   0.00051   2.70254
+   R79        2.07508   0.00001   0.00003  -0.00003  -0.00001   2.07507
+   R80        2.62533  -0.00021   0.00002  -0.00044  -0.00042   2.62491
+   R81        2.07508   0.00001   0.00003  -0.00003  -0.00001   2.07507
+   R82        2.07542   0.00003   0.00003   0.00001   0.00004   2.07546
+    A1        2.10036   0.00002   0.00001   0.00007   0.00008   2.10044
+    A2        2.08565  -0.00004   0.00003  -0.00028  -0.00025   2.08539
+    A3        2.09718   0.00001  -0.00004   0.00022   0.00017   2.09736
+    A4        2.10036   0.00002   0.00001   0.00007   0.00008   2.10044
+    A5        2.08565  -0.00004   0.00003  -0.00028  -0.00025   2.08539
+    A6        2.09718   0.00001  -0.00004   0.00022   0.00017   2.09736
+    A7        2.10914  -0.00005  -0.00001  -0.00018  -0.00019   2.10895
+    A8        2.10262   0.00006  -0.00003   0.00037   0.00034   2.10296
+    A9        2.07143  -0.00001   0.00004  -0.00019  -0.00015   2.07128
+   A10        2.07369   0.00003   0.00000   0.00011   0.00011   2.07380
+   A11        2.13082  -0.00008   0.00000  -0.00032  -0.00032   2.13051
+   A12        2.07868   0.00005   0.00000   0.00021   0.00020   2.07888
+   A13        2.07369   0.00003   0.00000   0.00011   0.00011   2.07380
+   A14        2.07868   0.00005   0.00000   0.00021   0.00020   2.07888
+   A15        2.13082  -0.00008   0.00000  -0.00032  -0.00032   2.13051
+   A16        2.10914  -0.00005  -0.00001  -0.00018  -0.00019   2.10895
+   A17        2.10262   0.00006  -0.00003   0.00037   0.00034   2.10296
+   A18        2.07143  -0.00001   0.00004  -0.00019  -0.00015   2.07128
+   A19        2.11071  -0.00009   0.00000  -0.00035  -0.00035   2.11036
+   A20        2.08504   0.00003   0.00002   0.00005   0.00007   2.08511
+   A21        2.08744   0.00006  -0.00002   0.00030   0.00028   2.08772
+   A22        2.09380   0.00003   0.00000   0.00014   0.00014   2.09395
+   A23        2.13170  -0.00006  -0.00001  -0.00021  -0.00022   2.13148
+   A24        2.05769   0.00003   0.00001   0.00006   0.00007   2.05776
+   A25        2.09380   0.00003   0.00000   0.00014   0.00014   2.09395
+   A26        2.05769   0.00003   0.00001   0.00006   0.00007   2.05776
+   A27        2.13170  -0.00006  -0.00001  -0.00021  -0.00022   2.13148
+   A28        2.11071  -0.00009   0.00000  -0.00035  -0.00035   2.11036
+   A29        2.08504   0.00003   0.00002   0.00005   0.00007   2.08511
+   A30        2.08744   0.00006  -0.00002   0.00030   0.00028   2.08772
+   A31        2.17440  -0.00003  -0.00002  -0.00008  -0.00010   2.17430
+   A32        2.05489   0.00002   0.00001   0.00006   0.00007   2.05496
+   A33        2.05389   0.00001   0.00001   0.00002   0.00003   2.05392
+   A34        2.05110   0.00001   0.00001   0.00001   0.00002   2.05113
+   A35        2.13506  -0.00006  -0.00001  -0.00019  -0.00020   2.13486
+   A36        2.09702   0.00005   0.00000   0.00018   0.00018   2.09720
+   A37        2.05110   0.00001   0.00001   0.00001   0.00002   2.05113
+   A38        2.09702   0.00005   0.00000   0.00018   0.00018   2.09720
+   A39        2.13506  -0.00006  -0.00001  -0.00019  -0.00020   2.13486
+   A40        2.17440  -0.00003  -0.00002  -0.00008  -0.00010   2.17430
+   A41        2.05489   0.00002   0.00001   0.00006   0.00007   2.05496
+   A42        2.05389   0.00001   0.00001   0.00002   0.00003   2.05392
+   A43        2.11761  -0.00008  -0.00001  -0.00027  -0.00028   2.11733
+   A44        2.08960   0.00007  -0.00002   0.00041   0.00039   2.08998
+   A45        2.07598   0.00000   0.00003  -0.00014  -0.00010   2.07587
+   A46        2.06855   0.00002   0.00001   0.00009   0.00010   2.06865
+   A47        2.13092  -0.00007  -0.00002  -0.00025  -0.00026   2.13065
+   A48        2.08372   0.00005   0.00001   0.00015   0.00016   2.08388
+   A49        2.06855   0.00002   0.00001   0.00009   0.00010   2.06865
+   A50        2.08372   0.00005   0.00001   0.00015   0.00016   2.08388
+   A51        2.13092  -0.00007  -0.00002  -0.00025  -0.00026   2.13065
+   A52        2.11761  -0.00008  -0.00001  -0.00027  -0.00028   2.11733
+   A53        2.08960   0.00007  -0.00002   0.00041   0.00039   2.08998
+   A54        2.07598   0.00000   0.00003  -0.00014  -0.00010   2.07587
+   A55        2.12808  -0.00008  -0.00002  -0.00024  -0.00026   2.12782
+   A56        2.08468   0.00006   0.00000   0.00028   0.00028   2.08495
+   A57        2.07043   0.00002   0.00002  -0.00004  -0.00001   2.07042
+   A58        2.07139   0.00003   0.00002   0.00009   0.00010   2.07149
+   A59        2.13393  -0.00007  -0.00002  -0.00024  -0.00026   2.13367
+   A60        2.07787   0.00004   0.00001   0.00015   0.00016   2.07802
+   A61        2.07139   0.00003   0.00002   0.00009   0.00010   2.07149
+   A62        2.07787   0.00004   0.00001   0.00015   0.00016   2.07802
+   A63        2.13393  -0.00007  -0.00002  -0.00024  -0.00026   2.13367
+   A64        2.12808  -0.00008  -0.00002  -0.00024  -0.00026   2.12782
+   A65        2.08468   0.00006   0.00000   0.00028   0.00028   2.08495
+   A66        2.07043   0.00002   0.00002  -0.00004  -0.00001   2.07042
+   A67        2.12745  -0.00008  -0.00001  -0.00030  -0.00031   2.12714
+   A68        2.07787   0.00004   0.00001   0.00015   0.00016   2.07802
+   A69        2.07787   0.00004   0.00001   0.00015   0.00016   2.07802
+   A70        2.07787   0.00004   0.00001   0.00015   0.00016   2.07802
+   A71        2.13393  -0.00007  -0.00002  -0.00024  -0.00026   2.13367
+   A72        2.07139   0.00003   0.00002   0.00009   0.00010   2.07149
+   A73        2.07787   0.00004   0.00001   0.00015   0.00016   2.07802
+   A74        2.07139   0.00003   0.00002   0.00009   0.00010   2.07149
+   A75        2.13393  -0.00007  -0.00002  -0.00024  -0.00026   2.13367
+   A76        2.12745  -0.00008  -0.00001  -0.00030  -0.00031   2.12714
+   A77        2.07787   0.00004   0.00001   0.00015   0.00016   2.07802
+   A78        2.07787   0.00004   0.00001   0.00015   0.00016   2.07802
+   A79        2.12808  -0.00008  -0.00002  -0.00024  -0.00026   2.12782
+   A80        2.07043   0.00002   0.00002  -0.00004  -0.00001   2.07042
+   A81        2.08468   0.00006   0.00000   0.00028   0.00028   2.08495
+   A82        2.08372   0.00005   0.00001   0.00015   0.00016   2.08388
+   A83        2.13092  -0.00007  -0.00002  -0.00025  -0.00026   2.13065
+   A84        2.06855   0.00002   0.00001   0.00009   0.00010   2.06865
+   A85        2.08372   0.00005   0.00001   0.00015   0.00016   2.08388
+   A86        2.06855   0.00002   0.00001   0.00009   0.00010   2.06865
+   A87        2.13092  -0.00007  -0.00002  -0.00025  -0.00026   2.13065
+   A88        2.12808  -0.00008  -0.00002  -0.00024  -0.00026   2.12782
+   A89        2.07043   0.00002   0.00002  -0.00004  -0.00001   2.07042
+   A90        2.08468   0.00006   0.00000   0.00028   0.00028   2.08495
+   A91        2.11761  -0.00008  -0.00001  -0.00027  -0.00028   2.11733
+   A92        2.07598   0.00000   0.00003  -0.00014  -0.00010   2.07587
+   A93        2.08960   0.00007  -0.00002   0.00041   0.00039   2.08998
+   A94        2.09702   0.00005   0.00000   0.00018   0.00018   2.09720
+   A95        2.13506  -0.00006  -0.00001  -0.00019  -0.00020   2.13486
+   A96        2.05110   0.00001   0.00001   0.00001   0.00002   2.05113
+   A97        2.09702   0.00005   0.00000   0.00018   0.00018   2.09720
+   A98        2.05110   0.00001   0.00001   0.00001   0.00002   2.05113
+   A99        2.13506  -0.00006  -0.00001  -0.00019  -0.00020   2.13486
+   A100       2.11761  -0.00008  -0.00001  -0.00027  -0.00028   2.11733
+   A101       2.07598   0.00000   0.00003  -0.00014  -0.00010   2.07587
+   A102       2.08960   0.00007  -0.00002   0.00041   0.00039   2.08998
+   A103       2.17440  -0.00003  -0.00002  -0.00008  -0.00010   2.17430
+   A104       2.05389   0.00001   0.00001   0.00002   0.00003   2.05392
+   A105       2.05489   0.00002   0.00001   0.00006   0.00007   2.05496
+   A106       2.05769   0.00003   0.00001   0.00006   0.00007   2.05776
+   A107       2.13170  -0.00006  -0.00001  -0.00021  -0.00022   2.13148
+   A108       2.09380   0.00003   0.00000   0.00014   0.00014   2.09395
+   A109       2.05769   0.00003   0.00001   0.00006   0.00007   2.05776
+   A110       2.09380   0.00003   0.00000   0.00014   0.00014   2.09395
+   A111       2.13170  -0.00006  -0.00001  -0.00021  -0.00022   2.13148
+   A112       2.17440  -0.00003  -0.00002  -0.00008  -0.00010   2.17430
+   A113       2.05389   0.00001   0.00001   0.00002   0.00003   2.05392
+   A114       2.05489   0.00002   0.00001   0.00006   0.00007   2.05496
+   A115       2.11071  -0.00009   0.00000  -0.00035  -0.00035   2.11036
+   A116       2.08744   0.00006  -0.00002   0.00030   0.00028   2.08772
+   A117       2.08504   0.00003   0.00002   0.00005   0.00007   2.08511
+   A118       2.07868   0.00005   0.00000   0.00021   0.00020   2.07888
+   A119       2.13082  -0.00008   0.00000  -0.00032  -0.00032   2.13051
+   A120       2.07369   0.00003   0.00000   0.00011   0.00011   2.07380
+   A121       2.07868   0.00005   0.00000   0.00021   0.00020   2.07888
+   A122       2.07369   0.00003   0.00000   0.00011   0.00011   2.07380
+   A123       2.13082  -0.00008   0.00000  -0.00032  -0.00032   2.13051
+   A124       2.11071  -0.00009   0.00000  -0.00035  -0.00035   2.11036
+   A125       2.08744   0.00006  -0.00002   0.00030   0.00028   2.08772
+   A126       2.08504   0.00003   0.00002   0.00005   0.00007   2.08511
+   A127       2.10914  -0.00005  -0.00001  -0.00018  -0.00019   2.10895
+   A128       2.07143  -0.00001   0.00004  -0.00019  -0.00015   2.07128
+   A129       2.10262   0.00006  -0.00003   0.00037   0.00034   2.10296
+   A130       2.10036   0.00002   0.00001   0.00007   0.00008   2.10044
+   A131       2.09718   0.00001  -0.00004   0.00022   0.00017   2.09736
+   A132       2.08565  -0.00004   0.00003  -0.00028  -0.00025   2.08539
+   A133       2.10036   0.00002   0.00001   0.00007   0.00008   2.10044
+   A134       2.08565  -0.00004   0.00003  -0.00028  -0.00025   2.08539
+   A135       2.09718   0.00001  -0.00004   0.00022   0.00017   2.09736
+   A136       2.10914  -0.00005  -0.00001  -0.00018  -0.00019   2.10895
+   A137       2.07143  -0.00001   0.00004  -0.00019  -0.00015   2.07128
+   A138       2.10262   0.00006  -0.00003   0.00037   0.00034   2.10296
+    D1        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D2        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+    D3       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+    D4        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D5        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D6        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+    D7       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+    D8        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D9        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D10        3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D11        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D12        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D13        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D14       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D15        3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D16        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D17        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D18       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D19        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D20        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D21       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D22        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D23        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D24       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D25        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D26        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D27       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D28        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D29        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D30        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D31        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D32        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D33        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D34       -3.14157   0.00000   0.00000   0.00000   0.00000  -3.14157
+   D35       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D36        0.00002   0.00000   0.00000   0.00000   0.00000   0.00002
+   D37        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D38       -3.14158   0.00000   0.00000   0.00000   0.00000  -3.14157
+   D39        3.14157   0.00000   0.00000   0.00000   0.00000   3.14157
+   D40        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D41       -3.14144   0.00000   0.00000   0.00000   0.00000  -3.14145
+   D42       -0.00010   0.00000   0.00000  -0.00001  -0.00001  -0.00010
+   D43        0.00017   0.00000   0.00000   0.00000   0.00000   0.00017
+   D44        3.14152   0.00000   0.00000  -0.00001   0.00000   3.14151
+   D45        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D46        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D47        3.14157   0.00000   0.00000   0.00000   0.00000   3.14157
+   D48       -0.00002   0.00000   0.00000   0.00000   0.00000  -0.00002
+   D49       -0.00016   0.00000   0.00000   0.00000   0.00000  -0.00016
+   D50       -3.14153   0.00000   0.00000   0.00001   0.00001  -3.14152
+   D51        3.14145   0.00000   0.00000   0.00000   0.00000   3.14145
+   D52        0.00008   0.00000   0.00000   0.00001   0.00001   0.00009
+   D53        0.00016   0.00000   0.00000   0.00000   0.00000   0.00016
+   D54       -3.14145   0.00000   0.00000   0.00000   0.00000  -3.14145
+   D55        3.14153   0.00000   0.00000  -0.00001  -0.00001   3.14152
+   D56       -0.00008   0.00000   0.00000  -0.00001  -0.00001  -0.00009
+   D57        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D58        3.14158   0.00000   0.00000   0.00000   0.00000   3.14158
+   D59       -3.14157   0.00000   0.00000   0.00000   0.00000  -3.14157
+   D60        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D61       -3.14157   0.00000   0.00000   0.00000   0.00000  -3.14157
+   D62        0.00002   0.00000   0.00000   0.00000   0.00000   0.00002
+   D63        0.00001   0.00000   0.00000   0.00000   0.00000   0.00001
+   D64       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D65       -0.00017   0.00000   0.00000   0.00000   0.00000  -0.00017
+   D66       -3.14152   0.00000   0.00000   0.00001   0.00000  -3.14151
+   D67        3.14144   0.00000   0.00000   0.00000   0.00000   3.14145
+   D68        0.00010   0.00000   0.00000   0.00001   0.00001   0.00010
+   D69       -0.00001   0.00000   0.00000   0.00000   0.00000  -0.00001
+   D70        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D71        3.14156   0.00000   0.00000   0.00000   0.00000   3.14156
+   D72       -0.00002   0.00000   0.00000   0.00000   0.00000  -0.00002
+   D73        0.00001   0.00000   0.00000   0.00000   0.00000   0.00001
+   D74       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D75       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D76        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D77        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D78       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D79       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D80        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D81        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D82        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D83        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D84       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D85       -0.00001   0.00000   0.00000   0.00000   0.00000  -0.00001
+   D86        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D87        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D88        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D89        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D90        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D91       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D92        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D93        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D94        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D95       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D96        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D97        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D98        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D99       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D100       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D101      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D102       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D103       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D104       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D105       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D106       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D107      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D108       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D109       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D110      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D111       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D112       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D113       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D114      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D115       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D116       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D117       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D118      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D119       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D120       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D121       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D122       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D123       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D124      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D125       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D126      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D127       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D128       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D129       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D130       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D131      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D132       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D133       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D134       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D135      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D136       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D137       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D138      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D139      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D140       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D141      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D142       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D143       0.00001   0.00000   0.00000   0.00000   0.00000   0.00001
+   D144      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D145       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D146       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D147      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D148       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D149      -0.00001   0.00000   0.00000   0.00000   0.00000  -0.00001
+   D150       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D151       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D152       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D153       0.00001   0.00000   0.00000   0.00000   0.00000   0.00001
+   D154      -3.14157   0.00000   0.00000   0.00000   0.00000  -3.14157
+   D155      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D156       0.00002   0.00000   0.00000   0.00000   0.00000   0.00002
+   D157       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D158      -3.14157   0.00000   0.00000   0.00000   0.00000  -3.14157
+   D159       3.14158   0.00000   0.00000   0.00000   0.00000   3.14158
+   D160       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D161      -3.14145   0.00000   0.00000   0.00000   0.00000  -3.14145
+   D162      -0.00008   0.00000   0.00000  -0.00001  -0.00001  -0.00009
+   D163       0.00016   0.00000   0.00000   0.00000   0.00000   0.00016
+   D164       3.14153   0.00000   0.00000  -0.00001  -0.00001   3.14152
+   D165      -0.00001   0.00000   0.00000   0.00000   0.00000  -0.00001
+   D166       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D167       3.14156   0.00000   0.00000   0.00000   0.00000   3.14156
+   D168      -0.00002   0.00000   0.00000   0.00000   0.00000  -0.00002
+   D169      -0.00017   0.00000   0.00000   0.00000   0.00000  -0.00017
+   D170      -3.14152   0.00000   0.00000   0.00001   0.00000  -3.14151
+   D171       3.14144   0.00000   0.00000   0.00000   0.00000   3.14145
+   D172       0.00010   0.00000   0.00000   0.00001   0.00001   0.00010
+   D173       0.00017   0.00000   0.00000   0.00000   0.00000   0.00017
+   D174      -3.14144   0.00000   0.00000   0.00000   0.00000  -3.14145
+   D175       3.14152   0.00000   0.00000  -0.00001   0.00000   3.14151
+   D176      -0.00010   0.00000   0.00000  -0.00001  -0.00001  -0.00010
+   D177       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D178       3.14157   0.00000   0.00000   0.00000   0.00000   3.14157
+   D179      -3.14158   0.00000   0.00000   0.00000   0.00000  -3.14157
+   D180       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D181      -3.14157   0.00000   0.00000   0.00000   0.00000  -3.14157
+   D182       0.00002   0.00000   0.00000   0.00000   0.00000   0.00002
+   D183       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D184      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D185      -0.00016   0.00000   0.00000   0.00000   0.00000  -0.00016
+   D186      -3.14153   0.00000   0.00000   0.00001   0.00001  -3.14152
+   D187       3.14145   0.00000   0.00000   0.00000   0.00000   3.14145
+   D188       0.00008   0.00000   0.00000   0.00001   0.00001   0.00009
+   D189       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D190       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D191       3.14157   0.00000   0.00000   0.00000   0.00000   3.14157
+   D192      -0.00002   0.00000   0.00000   0.00000   0.00000  -0.00002
+   D193       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D194      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D195      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D196       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D197       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D198       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D199      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D200       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D201      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D202       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D203       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D204       3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D205       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D206       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D207       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D208       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D209       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D210       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D211      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D212       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D213       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D214       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D215       3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D216       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D217       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D218      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D219       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D220       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D221       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D222       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D223      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D224       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000210     0.000450     YES
+ RMS     Force            0.000049     0.000300     YES
+ Maximum Displacement     0.002654     0.001800     NO 
+ RMS     Displacement     0.000653     0.001200     YES
+ Predicted change in Energy=-1.341448D-06
+ Lowest energy point so far.  Saving SCF results.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Leave Link  103 at Tue Aug  4 10:41:27 2020, MaxMem=    33554432 cpu:         0.1
+ (Enter /cluster/apps/gaussian/g09/l202.exe)
+ Stoichiometry    C42H26N4
+ Framework group  C2[X(C42H26N4)]
+ Deg. of freedom   106
+ Full point group                 C2      NOp   2
+ RotChk:  IX=0 Diff= 1.89D-09
+ Largest Abelian subgroup         C2      NOp   2
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0      -13.642932    0.715060    0.000444
+      2          6           0      -13.642932   -0.715060    0.000444
+      3          6           0      -12.444202    1.416837    0.000325
+      4          6           0      -11.184284    0.723616    0.000199
+      5          6           0      -11.184284   -0.723616    0.000198
+      6          6           0      -12.444202   -1.416837    0.000324
+      7          6           0       -9.926406   -1.424059    0.000073
+      8          6           0       -8.720812   -0.728728   -0.000052
+      9          6           0       -8.720812    0.728728   -0.000051
+     10          6           0       -9.926406    1.424059    0.000074
+     11          7           0       -7.459610    1.396524   -0.000204
+     12          6           0       -6.194172    0.737193   -0.000168
+     13          6           0       -6.194172   -0.737193   -0.000169
+     14          7           0       -7.459610   -1.396524   -0.000209
+     15          6           0       -5.000042   -1.431099   -0.000155
+     16          6           0       -3.721882   -0.736387   -0.000148
+     17          6           0       -3.721882    0.736387   -0.000148
+     18          6           0       -5.000042    1.431099   -0.000155
+     19          6           0       -2.500489    1.424532   -0.000142
+     20          6           0       -1.240559    0.735088   -0.000138
+     21          6           0       -1.240559   -0.735088   -0.000138
+     22          6           0       -2.500489   -1.424532   -0.000142
+     23          6           0        0.000000   -1.424498   -0.000137
+     24          6           0        1.240559   -0.735088   -0.000138
+     25          6           0        1.240559    0.735088   -0.000138
+     26          6           0        0.000000    1.424498   -0.000137
+     27          6           0        2.500489    1.424532   -0.000142
+     28          6           0        3.721882    0.736387   -0.000148
+     29          6           0        3.721882   -0.736387   -0.000148
+     30          6           0        2.500489   -1.424532   -0.000142
+     31          6           0        5.000042   -1.431099   -0.000155
+     32          6           0        6.194172   -0.737193   -0.000168
+     33          6           0        6.194172    0.737193   -0.000169
+     34          6           0        5.000042    1.431099   -0.000155
+     35          7           0        7.459610    1.396524   -0.000209
+     36          6           0        8.720812    0.728728   -0.000052
+     37          6           0        8.720812   -0.728728   -0.000051
+     38          7           0        7.459610   -1.396524   -0.000204
+     39          6           0        9.926406   -1.424059    0.000074
+     40          6           0       11.184284   -0.723616    0.000199
+     41          6           0       11.184284    0.723616    0.000198
+     42          6           0        9.926406    1.424059    0.000073
+     43          6           0       12.444202    1.416837    0.000324
+     44          6           0       13.642932    0.715060    0.000444
+     45          6           0       13.642932   -0.715060    0.000444
+     46          6           0       12.444202   -1.416837    0.000325
+     47          1           0      -14.598801    1.255518    0.000539
+     48          1           0      -14.598801   -1.255518    0.000539
+     49          1           0      -12.441431    2.515120    0.000324
+     50          1           0      -12.441431   -2.515120    0.000324
+     51          1           0       -9.919575   -2.521125    0.000073
+     52          1           0       -9.919575    2.521125    0.000075
+     53          1           0       -5.007958   -2.527894   -0.000154
+     54          1           0       -5.007958    2.527894   -0.000152
+     55          1           0       -2.499308   -2.522656   -0.000142
+     56          1           0        0.000000    2.522893   -0.000137
+     57          1           0        2.499308   -2.522656   -0.000143
+     58          1           0        5.007958    2.527894   -0.000154
+     59          1           0        9.919575   -2.521125    0.000075
+     60          1           0        9.919575    2.521125    0.000073
+     61          1           0       12.441431    2.515120    0.000324
+     62          1           0       14.598801    1.255518    0.000539
+     63          1           0       14.598801   -1.255518    0.000539
+     64          1           0       12.441431   -2.515120    0.000324
+     65          1           0       -2.499308    2.522656   -0.000143
+     66          1           0        2.499308    2.522656   -0.000142
+     67          1           0        0.000000   -2.522893   -0.000137
+     68          1           0        5.007958   -2.527894   -0.000152
+     69          1           0       -7.462516    2.437237   -0.000137
+     70          1           0        7.462516    2.437237   -0.000133
+     71          1           0       -7.462516   -2.437237   -0.000133
+     72          1           0        7.462516   -2.437237   -0.000137
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      0.5972060      0.0125779      0.0123185
+ Leave Link  202 at Tue Aug  4 10:41:27 2020, MaxMem=    33554432 cpu:         0.0
+ (Enter /cluster/apps/gaussian/g09/l301.exe)
+ Standard basis: STO-3G (5D, 7F)
+ Ernie: Thresh=  0.10000D-02 Tol=  0.10000D-05 Strict=F.
+ There are   128 symmetry adapted cartesian basis functions of A   symmetry.
+ There are   128 symmetry adapted cartesian basis functions of B   symmetry.
+ There are   128 symmetry adapted basis functions of A   symmetry.
+ There are   128 symmetry adapted basis functions of B   symmetry.
+   256 basis functions,   768 primitive gaussians,   256 cartesian basis functions
+   153 alpha electrons      153 beta electrons
+       nuclear repulsion energy      4276.3031765865 Hartrees.
+ IExCor=  402 DFT=T Ex+Corr=B3LYP ExCW=0 ScaHFX=  0.200000
+ ScaDFX=  0.800000  0.720000  1.000000  0.810000 ScalE2=  1.000000  1.000000
+ IRadAn=      0 IRanWt=     -1 IRanGd=            0 ICorTp=0 IEmpDi=  4
+ NAtoms=   72 NActive=   72 NUniq=   36 SFac= 4.00D+00 NAtFMM=   60 NAOKFM=T Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ Leave Link  301 at Tue Aug  4 10:41:27 2020, MaxMem=    33554432 cpu:         0.0
+ (Enter /cluster/apps/gaussian/g09/l302.exe)
+ NPDir=0 NMtPBC=     1 NCelOv=     1 NCel=       1 NClECP=     1 NCelD=      1
+         NCelK=      1 NCelE2=     1 NClLst=     1 CellRange=     0.0.
+ One-electron integrals computed using PRISM.
+ One-electron integral symmetry used in STVInt
+ NBasis=   256 RedAO= T EigKep=  1.28D-01  NBF=   128   128
+ NBsUse=   256 1.00D-06 EigRej= -1.00D+00 NBFU=   128   128
+ Precomputing XC quadrature grid using
+ IXCGrd= 4 IRadAn=           0 IRanWt=          -1 IRanGd=           0 AccXCQ= 0.00D+00.
+ Generated NRdTot=       0 NPtTot=           0 NUsed=           0 NTot=          32
+ NSgBfM=   217   218   218   218   218 MxSgAt=    72 MxSgA2=    71.
+ Leave Link  302 at Tue Aug  4 10:41:28 2020, MaxMem=    33554432 cpu:         1.2
+ (Enter /cluster/apps/gaussian/g09/l303.exe)
+ DipDrv:  MaxL=1.
+ Leave Link  303 at Tue Aug  4 10:41:28 2020, MaxMem=    33554432 cpu:         0.1
+ (Enter /cluster/apps/gaussian/g09/l401.exe)
+ Initial guess from the checkpoint file:  "r-b3lyp-sto3g.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Guess basis will be translated and rotated to current coordinates.
+ JPrj=2 DoOrth=T DoCkMO=T.
+ Initial guess orbital symmetries:
+       Occupied  (B) (A) (B) (A) (B) (A) (A) (B) (B) (A) (B) (A)
+                 (B) (A) (B) (A) (B) (A) (B) (A) (B) (A) (B) (A)
+                 (B) (A) (B) (A) (B) (A) (B) (A) (B) (A) (B) (A)
+                 (B) (A) (A) (B) (B) (A) (A) (B) (B) (A) (A) (B)
+                 (B) (A) (A) (B) (A) (B) (A) (B) (A) (B) (B) (A)
+                 (B) (A) (A) (B) (B) (A) (A) (B) (B) (A) (B) (A)
+                 (B) (A) (A) (B) (B) (A) (A) (B) (A) (A) (B) (B)
+                 (A) (B) (A) (B) (A) (A) (B) (B) (B) (A) (A) (B)
+                 (A) (B) (A) (B) (B) (A) (B) (A) (A) (B) (A) (B)
+                 (A) (B) (B) (A) (B) (A) (A) (A) (B) (A) (B) (B)
+                 (B) (A) (B) (A) (B) (B) (A) (B) (A) (A) (B) (A)
+                 (B) (A) (B) (A) (B) (A) (A) (B) (A) (B) (B) (A)
+                 (A) (B) (B) (A) (B) (A) (A) (B) (B)
+       Virtual   (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (B) (B) (B) (B) (B) (B) (B) (B)
+                 (B) (B) (B) (B) (B) (B) (B) (B) (B) (B) (B) (B)
+                 (B) (B) (B) (B) (B) (B) (B) (B) (B) (B) (B) (B)
+                 (B) (B) (B) (B) (B) (B) (B) (B) (B) (B) (B) (B)
+                 (B) (B) (B) (B) (B) (B) (B)
+ The electronic state of the initial guess is 1-A.
+ Leave Link  401 at Tue Aug  4 10:41:28 2020, MaxMem=    33554432 cpu:         0.2
+ (Enter /cluster/apps/gaussian/g09/l502.exe)
+ Closed shell SCF:
+ Using DIIS extrapolation, IDIIS=    10.
+ Integral symmetry usage will be decided dynamically.
+ IVT=     4406646 IEndB=     4406646 NGot=    33554432 MDV=    33411979
+ LenX=    33411979 LenY=    33346002
+ Requested convergence on RMS density matrix=1.00D-07 within2048 cycles.
+ Requested convergence on MAX density matrix=1.00D-05.
+ Requested convergence on             energy=1.00D-05.
+ Level shift goal  0.100 maximum shift  0.100.
+ No special actions if energy rises.
+ Fock matrices will be formed incrementally for  20 cycles.
+
+ Cycle   1  Pass 1  IDiag  1:
+ FoFJK:  IHMeth= 1 ICntrl=       0 DoSepK=F KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf= 390000000 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=        2000
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=       0 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ E= -1812.58399641120    
+ DIIS: error= 1.80D-05 at cycle   1 NSaved=   1.
+ NSaved= 1 IEnMin= 1 EnMin= -1812.58399641120     IErMin= 1 ErrMin= 1.80D-05
+ ErrMax= 1.80D-05  0.00D+00 EMaxC= 1.00D+00 BMatC= 1.13D-07 BMatP= 1.13D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.100D+01
+ Coeff:      0.100D+01
+ Gap=     0.439 Goal=     0.100 Shift=    0.000
+ RMSDP=3.99D-06 MaxDP=1.60D-04              OVMax= 0.00D+00
+
+ Cycle   2  Pass 1  IDiag  1:
+ RMSU=  3.99D-06    CP:  1.00D+00
+ E= -1812.58399673534     Delta-E=       -0.000000324135 Rises=F Damp=F
+ DIIS: error= 5.88D-06 at cycle   2 NSaved=   2.
+ NSaved= 2 IEnMin= 2 EnMin= -1812.58399673534     IErMin= 2 ErrMin= 5.88D-06
+ ErrMax= 5.88D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 3.55D-09 BMatP= 1.13D-07
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.436D-01 0.104D+01
+ Coeff:     -0.436D-01 0.104D+01
+ Gap=     0.094 Goal=     0.100 Shift=    0.006
+ RMSDP=1.12D-06 MaxDP=3.45D-05 DE=-3.24D-07 OVMax= 0.00D+00
+
+ Cycle   3  Pass 1  IDiag  1:
+ RMSU=  9.35D-07    CP:  1.00D+00  1.15D+00
+ E= -1812.58399673388     Delta-E=        0.000000001460 Rises=F Damp=F
+ DIIS: error= 9.61D-06 at cycle   3 NSaved=   3.
+ NSaved= 3 IEnMin= 2 EnMin= -1812.58399673534     IErMin= 2 ErrMin= 5.88D-06
+ ErrMax= 9.61D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 9.82D-09 BMatP= 3.55D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.508D-01 0.690D+00 0.360D+00
+ Coeff:     -0.508D-01 0.690D+00 0.360D+00
+ Gap=     0.094 Goal=     0.100 Shift=    0.006
+ RMSDP=6.64D-07 MaxDP=2.33D-05 DE= 1.46D-09 OVMax= 0.00D+00
+
+ Cycle   4  Pass 1  IDiag  1:
+ RMSU=  2.90D-07    CP:  1.00D+00  1.19D+00  3.78D-01
+ E= -1812.58399674761     Delta-E=       -0.000000013732 Rises=F Damp=F
+ DIIS: error= 1.21D-06 at cycle   4 NSaved=   4.
+ NSaved= 4 IEnMin= 4 EnMin= -1812.58399674761     IErMin= 4 ErrMin= 1.21D-06
+ ErrMax= 1.21D-06  0.00D+00 EMaxC= 1.00D+00 BMatC= 2.33D-10 BMatP= 3.55D-09
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com: -0.936D-02 0.535D-01 0.130D+00 0.825D+00
+ Coeff:     -0.936D-02 0.535D-01 0.130D+00 0.825D+00
+ Gap=     0.094 Goal=     0.100 Shift=    0.006
+ RMSDP=1.54D-07 MaxDP=4.07D-06 DE=-1.37D-08 OVMax= 0.00D+00
+
+ Cycle   5  Pass 1  IDiag  1:
+ RMSU=  1.01D-07    CP:  1.00D+00  1.21D+00  4.75D-01  9.83D-01
+ E= -1812.58399674801     Delta-E=       -0.000000000401 Rises=F Damp=F
+ DIIS: error= 5.98D-07 at cycle   5 NSaved=   5.
+ NSaved= 5 IEnMin= 5 EnMin= -1812.58399674801     IErMin= 5 ErrMin= 5.98D-07
+ ErrMax= 5.98D-07  0.00D+00 EMaxC= 1.00D+00 BMatC= 8.25D-11 BMatP= 2.33D-10
+ IDIUse=1 WtCom= 1.00D+00 WtEn= 0.00D+00
+ Coeff-Com:  0.139D-02-0.641D-01 0.325D-01 0.495D+00 0.535D+00
+ Coeff:      0.139D-02-0.641D-01 0.325D-01 0.495D+00 0.535D+00
+ Gap=     0.094 Goal=     0.100 Shift=    0.006
+ RMSDP=5.82D-08 MaxDP=2.13D-06 DE=-4.01D-10 OVMax= 0.00D+00
+
+ SCF Done:  E(RB3LYP) =  -1812.58399675     A.U. after    5 cycles
+            NFock=  5  Conv=0.58D-07     -V/T= 2.0186
+ KE= 1.779405659201D+03 PE=-1.275105123030D+04 EE= 4.882758397761D+03
+ Leave Link  502 at Tue Aug  4 10:41:50 2020, MaxMem=    33554432 cpu:        22.0
+ (Enter /cluster/apps/gaussian/g09/l701.exe)
+ Compute integral first derivatives.
+ ... and contract with generalized density number  0.
+ Leave Link  701 at Tue Aug  4 10:41:51 2020, MaxMem=    33554432 cpu:         0.2
+ (Enter /cluster/apps/gaussian/g09/l702.exe)
+ L702 exits ... SP integral derivatives will be done elsewhere.
+ Leave Link  702 at Tue Aug  4 10:41:51 2020, MaxMem=    33554432 cpu:         0.0
+ (Enter /cluster/apps/gaussian/g09/l703.exe)
+ Compute integral first derivatives, UseDBF=F ICtDFT=           0.
+ Integral derivatives from FoFJK, PRISM(SPDF).
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ FoFJK:  IHMeth= 1 ICntrl=    2127 DoSepK=F KAlg= 0 I1Cent=   0 FoldK=F
+ IRaf=         0 NMat=   1 IRICut=       1 DoRegI=T DoRafI=F ISym2E= 1.
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=        2800
+         NFxFlg=           0 DoJE=F BraDBF=F KetDBF=F FulRan=T
+         wScrn=  0.000000 ICntrl=    2127 IOpCl=  0 I1Cent=           0 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Leave Link  703 at Tue Aug  4 10:42:02 2020, MaxMem=    33554432 cpu:        11.5
+ (Enter /cluster/apps/gaussian/g09/l716.exe)
+ Dipole        =-5.37347942D-13 2.39478570D-14 2.16867197D-04
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6           0.000077523    0.000096133   -0.000000011
+      2        6           0.000077525   -0.000096134   -0.000000011
+      3        6          -0.000116351   -0.000014789    0.000000015
+      4        6           0.000090756   -0.000044778    0.000000000
+      5        6           0.000090756    0.000044778   -0.000000003
+      6        6          -0.000116353    0.000014790    0.000000014
+      7        6          -0.000049714    0.000013652   -0.000000048
+      8        6           0.000041567    0.000003042    0.000000025
+      9        6           0.000041574   -0.000003040    0.000000079
+     10        6          -0.000049716   -0.000013653   -0.000000064
+     11        7          -0.000005825   -0.000023619   -0.000000251
+     12        6          -0.000004523    0.000066156    0.000000080
+     13        6          -0.000004527   -0.000066157    0.000000022
+     14        7          -0.000005821    0.000023618   -0.000000067
+     15        6          -0.000033421    0.000027082   -0.000000050
+     16        6           0.000021854   -0.000014902    0.000000007
+     17        6           0.000021858    0.000014903    0.000000010
+     18        6          -0.000033423   -0.000027082   -0.000000069
+     19        6          -0.000032940   -0.000007737    0.000000005
+     20        6           0.000013748   -0.000016972   -0.000000005
+     21        6           0.000013748    0.000016971   -0.000000003
+     22        6          -0.000032935    0.000007736    0.000000005
+     23        6          -0.000000002    0.000008414    0.000000004
+     24        6          -0.000013748    0.000016972   -0.000000005
+     25        6          -0.000013748   -0.000016971   -0.000000003
+     26        6           0.000000002   -0.000008414    0.000000004
+     27        6           0.000032935   -0.000007736    0.000000005
+     28        6          -0.000021854    0.000014902    0.000000007
+     29        6          -0.000021858   -0.000014903    0.000000010
+     30        6           0.000032940    0.000007737    0.000000005
+     31        6           0.000033423    0.000027082   -0.000000069
+     32        6           0.000004523   -0.000066156    0.000000080
+     33        6           0.000004527    0.000066157    0.000000022
+     34        6           0.000033421   -0.000027082   -0.000000050
+     35        7           0.000005821   -0.000023618   -0.000000067
+     36        6          -0.000041567   -0.000003042    0.000000025
+     37        6          -0.000041574    0.000003040    0.000000079
+     38        7           0.000005825    0.000023619   -0.000000251
+     39        6           0.000049716    0.000013653   -0.000000064
+     40        6          -0.000090756    0.000044778    0.000000000
+     41        6          -0.000090756   -0.000044778   -0.000000003
+     42        6           0.000049714   -0.000013652   -0.000000048
+     43        6           0.000116353   -0.000014790    0.000000014
+     44        6          -0.000077525    0.000096134   -0.000000011
+     45        6          -0.000077523   -0.000096133   -0.000000011
+     46        6           0.000116351    0.000014789    0.000000015
+     47        1          -0.000018292   -0.000007464    0.000000002
+     48        1          -0.000018293    0.000007464    0.000000003
+     49        1           0.000010782    0.000008903   -0.000000002
+     50        1           0.000010782   -0.000008903   -0.000000002
+     51        1           0.000002497   -0.000010677    0.000000005
+     52        1           0.000002497    0.000010677    0.000000008
+     53        1           0.000005375   -0.000010949    0.000000006
+     54        1           0.000005375    0.000010949    0.000000009
+     55        1           0.000005770   -0.000009081   -0.000000003
+     56        1           0.000000000    0.000009118   -0.000000003
+     57        1          -0.000005770   -0.000009081   -0.000000003
+     58        1          -0.000005375    0.000010949    0.000000006
+     59        1          -0.000002497   -0.000010677    0.000000008
+     60        1          -0.000002497    0.000010677    0.000000005
+     61        1          -0.000010782    0.000008903   -0.000000002
+     62        1           0.000018293   -0.000007464    0.000000003
+     63        1           0.000018292    0.000007464    0.000000002
+     64        1          -0.000010782   -0.000008903   -0.000000002
+     65        1           0.000005770    0.000009081   -0.000000003
+     66        1          -0.000005770    0.000009081   -0.000000003
+     67        1           0.000000000   -0.000009118   -0.000000003
+     68        1          -0.000005375   -0.000010949    0.000000009
+     69        1           0.000001390   -0.000018802    0.000000189
+     70        1          -0.000001389   -0.000018801    0.000000105
+     71        1           0.000001389    0.000018801    0.000000105
+     72        1          -0.000001390    0.000018802    0.000000189
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.000116353 RMS     0.000031684
+ Leave Link  716 at Tue Aug  4 10:42:02 2020, MaxMem=    33554432 cpu:         0.0
+ (Enter /cluster/apps/gaussian/g09/l103.exe)
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.000067025 RMS     0.000013288
+ Search for a local minimum.
+ Step number   5 out of a maximum of  432
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ RMS Force = .13288D-04 SwitMx=.10000D-02 MixMth= 2
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Swapping is turned off.
+ Update second derivatives using D2CorX and points    1    2    3    4    5
+ DE= -1.61D-06 DEPred=-1.34D-06 R= 1.20D+00
+ TightC=F SS=  1.41D+00  RLast= 2.95D-03 DXNew= 8.4853D-01 8.8585D-03
+ Trust test= 1.20D+00 RLast= 2.95D-03 DXMaxT set to 5.05D-01
+ ITU=  1  1  1  1  0
+     Eigenvalues ---    0.01654   0.01659   0.01707   0.01737   0.01765
+     Eigenvalues ---    0.01770   0.01776   0.01784   0.01785   0.01811
+     Eigenvalues ---    0.01811   0.01821   0.01821   0.01822   0.01837
+     Eigenvalues ---    0.01841   0.01841   0.01841   0.01841   0.01841
+     Eigenvalues ---    0.01841   0.01856   0.01863   0.01872   0.01876
+     Eigenvalues ---    0.01881   0.01896   0.01896   0.01902   0.01902
+     Eigenvalues ---    0.01938   0.01938   0.01978   0.01978   0.02004
+     Eigenvalues ---    0.02004   0.02047   0.02047   0.02047   0.02047
+     Eigenvalues ---    0.02088   0.02088   0.02088   0.02091   0.02091
+     Eigenvalues ---    0.02101   0.02101   0.02110   0.02110   0.02123
+     Eigenvalues ---    0.02124   0.02127   0.02127   0.02140   0.02140
+     Eigenvalues ---    0.02155   0.02155   0.02164   0.02164   0.02167
+     Eigenvalues ---    0.02167   0.02203   0.02203   0.02205   0.02205
+     Eigenvalues ---    0.02259   0.02259   0.02277   0.02277   0.13796
+     Eigenvalues ---    0.16000   0.16000   0.16000   0.16000   0.16000
+     Eigenvalues ---    0.16000   0.16000   0.16000   0.16000   0.16000
+     Eigenvalues ---    0.16000   0.16000   0.16000   0.16000   0.16000
+     Eigenvalues ---    0.16000   0.16000   0.16000   0.16000   0.16000
+     Eigenvalues ---    0.16000   0.16000   0.16000   0.16003   0.16082
+     Eigenvalues ---    0.22000   0.22000   0.22299   0.22489   0.22555
+     Eigenvalues ---    0.22841   0.22861   0.23100   0.23119   0.23314
+     Eigenvalues ---    0.23382   0.23457   0.23658   0.23688   0.23746
+     Eigenvalues ---    0.23829   0.23925   0.24024   0.24131   0.24238
+     Eigenvalues ---    0.24319   0.24567   0.24567   0.25000   0.25000
+     Eigenvalues ---    0.25000   0.25000   0.25000   0.25000   0.25000
+     Eigenvalues ---    0.25000   0.25000   0.25101   0.33134   0.33304
+     Eigenvalues ---    0.34010   0.34941   0.35278   0.35280   0.35286
+     Eigenvalues ---    0.35286   0.35286   0.35292   0.35296   0.35296
+     Eigenvalues ---    0.35296   0.35301   0.35305   0.35305   0.35305
+     Eigenvalues ---    0.35355   0.35359   0.35359   0.35359   0.35499
+     Eigenvalues ---    0.35499   0.35499   0.35549   0.35869   0.36338
+     Eigenvalues ---    0.36461   0.37486   0.37486   0.38823   0.38826
+     Eigenvalues ---    0.38965   0.39556   0.40217   0.40217   0.40476
+     Eigenvalues ---    0.40612   0.40722   0.40726   0.40726   0.40788
+     Eigenvalues ---    0.41509   0.41846   0.42140   0.42447   0.42485
+     Eigenvalues ---    0.42787   0.42821   0.43160   0.43160   0.43331
+     Eigenvalues ---    0.44466   0.44637   0.45608   0.45855   0.46316
+     Eigenvalues ---    0.46316   0.46316   0.46564   0.46608   0.46715
+     Eigenvalues ---    0.46789   0.46792   0.47547   0.47547   0.47553
+     Eigenvalues ---    0.47710   0.47896   0.47991   0.47991   0.48091
+     Eigenvalues ---    0.48231   0.48231   0.48460   0.49187   0.49346
+     Eigenvalues ---    0.49756   0.49756   0.50443   0.51085   0.56004
+ En-DIIS/RFO-DIIS IScMMF=        0 using points:     5    4    3
+ RFO step:  Lambda=-1.38320632D-07.
+ NNeg= 0 NP= 3 Switch=  2.50D-03 Rises=F DC=  1.50D-05 SmlDif=  1.00D-05
+ RMS Error=  0.2412383423D-04 NUsed= 3 EDIIS=F
+ DidBck=F Rises=F RFO-DIIS coefs:    1.25964   -0.24658   -0.01306
+ Iteration  1 RMS(Cart)=  0.00010030 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ITry= 1 IFail=0 DXMaxC= 4.76D-04 DCOld= 1.00D+10 DXMaxT= 5.05D-01 DXLimC= 3.00D+00 Rises=F
+ ClnCor:  largest displacement from symmetrization is 2.16D-08 for atom    67.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.70254   0.00006   0.00014   0.00006   0.00020   2.70274
+    R2        2.62491  -0.00007  -0.00011  -0.00008  -0.00019   2.62472
+    R3        2.07507   0.00001  -0.00001   0.00004   0.00004   2.07511
+    R4        2.62491  -0.00007  -0.00011  -0.00008  -0.00019   2.62472
+    R5        2.07507   0.00001  -0.00001   0.00004   0.00004   2.07511
+    R6        2.71749   0.00005   0.00009   0.00011   0.00020   2.71769
+    R7        2.07546   0.00001   0.00000   0.00002   0.00002   2.07548
+    R8        2.73487  -0.00003  -0.00013  -0.00002  -0.00014   2.73473
+    R9        2.72073  -0.00004  -0.00003  -0.00009  -0.00011   2.72062
+   R10        2.71749   0.00005   0.00009   0.00011   0.00020   2.71769
+   R11        2.72073  -0.00004  -0.00003  -0.00009  -0.00011   2.72062
+   R12        2.07546   0.00001   0.00000   0.00002   0.00002   2.07548
+   R13        2.63001   0.00001   0.00000   0.00004   0.00003   2.63004
+   R14        2.07319   0.00001   0.00000   0.00002   0.00002   2.07322
+   R15        2.75419  -0.00002  -0.00006  -0.00001  -0.00007   2.75412
+   R16        2.69681  -0.00004  -0.00002  -0.00007  -0.00009   2.69672
+   R17        2.63001   0.00001   0.00000   0.00004   0.00003   2.63004
+   R18        2.69681  -0.00004  -0.00002  -0.00007  -0.00009   2.69672
+   R19        2.07319   0.00001   0.00000   0.00002   0.00002   2.07322
+   R20        2.69646  -0.00004  -0.00001  -0.00007  -0.00008   2.69638
+   R21        1.96667  -0.00002  -0.00002  -0.00002  -0.00005   1.96662
+   R22        2.78619   0.00003  -0.00001   0.00008   0.00008   2.78626
+   R23        2.60991  -0.00003  -0.00006  -0.00002  -0.00008   2.60983
+   R24        2.69646  -0.00004  -0.00001  -0.00007  -0.00008   2.69638
+   R25        2.60991  -0.00003  -0.00006  -0.00002  -0.00008   2.60983
+   R26        1.96667  -0.00002  -0.00002  -0.00002  -0.00005   1.96662
+   R27        2.74909   0.00000   0.00005  -0.00001   0.00004   2.74913
+   R28        2.07270   0.00001   0.00001   0.00002   0.00002   2.07272
+   R29        2.78314   0.00001  -0.00002   0.00003   0.00000   2.78314
+   R30        2.64922  -0.00002  -0.00007   0.00000  -0.00007   2.64915
+   R31        2.74909   0.00000   0.00005  -0.00001   0.00004   2.74913
+   R32        2.64922  -0.00002  -0.00007   0.00000  -0.00007   2.64915
+   R33        2.07270   0.00001   0.00001   0.00002   0.00002   2.07272
+   R34        2.71408   0.00001   0.00003   0.00002   0.00005   2.71413
+   R35        2.07515   0.00001   0.00001   0.00001   0.00002   2.07518
+   R36        2.77823  -0.00001  -0.00004  -0.00003  -0.00007   2.77816
+   R37        2.68200  -0.00001  -0.00003   0.00001  -0.00001   2.68198
+   R38        2.71408   0.00001   0.00003   0.00002   0.00005   2.71413
+   R39        2.68200  -0.00001  -0.00003   0.00001  -0.00001   2.68198
+   R40        2.07515   0.00001   0.00001   0.00001   0.00002   2.07518
+   R41        2.68200  -0.00001  -0.00003   0.00001  -0.00001   2.68198
+   R42        2.07566   0.00001   0.00001   0.00002   0.00002   2.07568
+   R43        2.77823  -0.00001  -0.00004  -0.00003  -0.00007   2.77816
+   R44        2.71408   0.00001   0.00003   0.00002   0.00005   2.71413
+   R45        2.68200  -0.00001  -0.00003   0.00001  -0.00001   2.68198
+   R46        2.71408   0.00001   0.00003   0.00002   0.00005   2.71413
+   R47        2.07566   0.00001   0.00001   0.00002   0.00002   2.07568
+   R48        2.64922  -0.00002  -0.00007   0.00000  -0.00007   2.64915
+   R49        2.07515   0.00001   0.00001   0.00001   0.00002   2.07518
+   R50        2.78314   0.00001  -0.00002   0.00003   0.00000   2.78314
+   R51        2.74909   0.00000   0.00005  -0.00001   0.00004   2.74913
+   R52        2.64922  -0.00002  -0.00007   0.00000  -0.00007   2.64915
+   R53        2.74909   0.00000   0.00005  -0.00001   0.00004   2.74913
+   R54        2.07515   0.00001   0.00001   0.00001   0.00002   2.07518
+   R55        2.60991  -0.00003  -0.00006  -0.00002  -0.00008   2.60983
+   R56        2.07270   0.00001   0.00001   0.00002   0.00002   2.07272
+   R57        2.78619   0.00003  -0.00001   0.00008   0.00008   2.78626
+   R58        2.69646  -0.00004  -0.00001  -0.00007  -0.00008   2.69638
+   R59        2.60991  -0.00003  -0.00006  -0.00002  -0.00008   2.60983
+   R60        2.69646  -0.00004  -0.00001  -0.00007  -0.00008   2.69638
+   R61        2.07270   0.00001   0.00001   0.00002   0.00002   2.07272
+   R62        2.69681  -0.00004  -0.00002  -0.00007  -0.00009   2.69672
+   R63        1.96667  -0.00002  -0.00002  -0.00002  -0.00005   1.96662
+   R64        2.75419  -0.00002  -0.00006  -0.00001  -0.00007   2.75412
+   R65        2.63001   0.00001   0.00000   0.00004   0.00003   2.63004
+   R66        2.69681  -0.00004  -0.00002  -0.00007  -0.00009   2.69672
+   R67        2.63001   0.00001   0.00000   0.00004   0.00003   2.63004
+   R68        1.96667  -0.00002  -0.00002  -0.00002  -0.00005   1.96662
+   R69        2.72073  -0.00004  -0.00003  -0.00009  -0.00011   2.72062
+   R70        2.07319   0.00001   0.00000   0.00002   0.00002   2.07322
+   R71        2.73487  -0.00003  -0.00013  -0.00002  -0.00014   2.73473
+   R72        2.71749   0.00005   0.00009   0.00011   0.00020   2.71769
+   R73        2.72073  -0.00004  -0.00003  -0.00009  -0.00011   2.72062
+   R74        2.71749   0.00005   0.00009   0.00011   0.00020   2.71769
+   R75        2.07319   0.00001   0.00000   0.00002   0.00002   2.07322
+   R76        2.62491  -0.00007  -0.00011  -0.00008  -0.00019   2.62472
+   R77        2.07546   0.00001   0.00000   0.00002   0.00002   2.07548
+   R78        2.70254   0.00006   0.00014   0.00006   0.00020   2.70274
+   R79        2.07507   0.00001  -0.00001   0.00004   0.00004   2.07511
+   R80        2.62491  -0.00007  -0.00011  -0.00008  -0.00019   2.62472
+   R81        2.07507   0.00001  -0.00001   0.00004   0.00004   2.07511
+   R82        2.07546   0.00001   0.00000   0.00002   0.00002   2.07548
+    A1        2.10044   0.00001   0.00002   0.00000   0.00002   2.10045
+    A2        2.08539  -0.00002  -0.00007  -0.00009  -0.00016   2.08523
+    A3        2.09736   0.00001   0.00006   0.00009   0.00015   2.09750
+    A4        2.10044   0.00001   0.00002   0.00000   0.00002   2.10045
+    A5        2.08539  -0.00002  -0.00007  -0.00009  -0.00016   2.08523
+    A6        2.09736   0.00001   0.00006   0.00009   0.00015   2.09750
+    A7        2.10895   0.00000  -0.00005   0.00002  -0.00002   2.10893
+    A8        2.10296   0.00001   0.00010   0.00003   0.00012   2.10308
+    A9        2.07128  -0.00001  -0.00005  -0.00005  -0.00010   2.07118
+   A10        2.07380   0.00000   0.00003  -0.00002   0.00001   2.07381
+   A11        2.13051  -0.00001  -0.00008   0.00002  -0.00006   2.13044
+   A12        2.07888   0.00001   0.00005   0.00000   0.00005   2.07893
+   A13        2.07380   0.00000   0.00003  -0.00002   0.00001   2.07381
+   A14        2.07888   0.00001   0.00005   0.00000   0.00005   2.07893
+   A15        2.13051  -0.00001  -0.00008   0.00002  -0.00006   2.13044
+   A16        2.10895   0.00000  -0.00005   0.00002  -0.00002   2.10893
+   A17        2.10296   0.00001   0.00010   0.00003   0.00012   2.10308
+   A18        2.07128  -0.00001  -0.00005  -0.00005  -0.00010   2.07118
+   A19        2.11036  -0.00001  -0.00009   0.00003  -0.00006   2.11029
+   A20        2.08511   0.00001   0.00001   0.00003   0.00004   2.08515
+   A21        2.08772   0.00000   0.00008  -0.00005   0.00002   2.08775
+   A22        2.09395   0.00000   0.00004  -0.00003   0.00001   2.09396
+   A23        2.13148   0.00000  -0.00005   0.00004  -0.00002   2.13146
+   A24        2.05776   0.00000   0.00002  -0.00001   0.00001   2.05777
+   A25        2.09395   0.00000   0.00004  -0.00003   0.00001   2.09396
+   A26        2.05776   0.00000   0.00002  -0.00001   0.00001   2.05777
+   A27        2.13148   0.00000  -0.00005   0.00004  -0.00002   2.13146
+   A28        2.11036  -0.00001  -0.00009   0.00003  -0.00006   2.11029
+   A29        2.08511   0.00001   0.00001   0.00003   0.00004   2.08515
+   A30        2.08772   0.00000   0.00008  -0.00005   0.00002   2.08775
+   A31        2.17430   0.00000  -0.00002   0.00004   0.00002   2.17432
+   A32        2.05496   0.00000   0.00002  -0.00001   0.00000   2.05497
+   A33        2.05392   0.00000   0.00000  -0.00002  -0.00002   2.05390
+   A34        2.05113  -0.00001   0.00000  -0.00003  -0.00003   2.05110
+   A35        2.13486   0.00000  -0.00005   0.00006   0.00001   2.13487
+   A36        2.09720   0.00000   0.00005  -0.00003   0.00001   2.09721
+   A37        2.05113  -0.00001   0.00000  -0.00003  -0.00003   2.05110
+   A38        2.09720   0.00000   0.00005  -0.00003   0.00001   2.09721
+   A39        2.13486   0.00000  -0.00005   0.00006   0.00001   2.13487
+   A40        2.17430   0.00000  -0.00002   0.00004   0.00002   2.17432
+   A41        2.05496   0.00000   0.00002  -0.00001   0.00000   2.05497
+   A42        2.05392   0.00000   0.00000  -0.00002  -0.00002   2.05390
+   A43        2.11733   0.00000  -0.00007   0.00006  -0.00001   2.11732
+   A44        2.08998   0.00001   0.00011  -0.00003   0.00007   2.09006
+   A45        2.07587   0.00000  -0.00004  -0.00003  -0.00006   2.07581
+   A46        2.06865   0.00000   0.00002  -0.00002   0.00000   2.06866
+   A47        2.13065   0.00000  -0.00006   0.00004  -0.00002   2.13063
+   A48        2.08388   0.00000   0.00004  -0.00002   0.00002   2.08390
+   A49        2.06865   0.00000   0.00002  -0.00002   0.00000   2.06866
+   A50        2.08388   0.00000   0.00004  -0.00002   0.00002   2.08390
+   A51        2.13065   0.00000  -0.00006   0.00004  -0.00002   2.13063
+   A52        2.11733   0.00000  -0.00007   0.00006  -0.00001   2.11732
+   A53        2.08998   0.00001   0.00011  -0.00003   0.00007   2.09006
+   A54        2.07587   0.00000  -0.00004  -0.00003  -0.00006   2.07581
+   A55        2.12782  -0.00001  -0.00006   0.00003  -0.00003   2.12779
+   A56        2.08495   0.00001   0.00007   0.00000   0.00007   2.08503
+   A57        2.07042   0.00000  -0.00001  -0.00003  -0.00004   2.07037
+   A58        2.07149   0.00000   0.00002  -0.00001   0.00001   2.07150
+   A59        2.13367   0.00000  -0.00006   0.00003  -0.00003   2.13364
+   A60        2.07802   0.00000   0.00004  -0.00002   0.00002   2.07804
+   A61        2.07149   0.00000   0.00002  -0.00001   0.00001   2.07150
+   A62        2.07802   0.00000   0.00004  -0.00002   0.00002   2.07804
+   A63        2.13367   0.00000  -0.00006   0.00003  -0.00003   2.13364
+   A64        2.12782  -0.00001  -0.00006   0.00003  -0.00003   2.12779
+   A65        2.08495   0.00001   0.00007   0.00000   0.00007   2.08503
+   A66        2.07042   0.00000  -0.00001  -0.00003  -0.00004   2.07037
+   A67        2.12714   0.00000  -0.00008   0.00005  -0.00003   2.12710
+   A68        2.07802   0.00000   0.00004  -0.00002   0.00002   2.07804
+   A69        2.07802   0.00000   0.00004  -0.00002   0.00002   2.07804
+   A70        2.07802   0.00000   0.00004  -0.00002   0.00002   2.07804
+   A71        2.13367   0.00000  -0.00006   0.00003  -0.00003   2.13364
+   A72        2.07149   0.00000   0.00002  -0.00001   0.00001   2.07150
+   A73        2.07802   0.00000   0.00004  -0.00002   0.00002   2.07804
+   A74        2.07149   0.00000   0.00002  -0.00001   0.00001   2.07150
+   A75        2.13367   0.00000  -0.00006   0.00003  -0.00003   2.13364
+   A76        2.12714   0.00000  -0.00008   0.00005  -0.00003   2.12710
+   A77        2.07802   0.00000   0.00004  -0.00002   0.00002   2.07804
+   A78        2.07802   0.00000   0.00004  -0.00002   0.00002   2.07804
+   A79        2.12782  -0.00001  -0.00006   0.00003  -0.00003   2.12779
+   A80        2.07042   0.00000  -0.00001  -0.00003  -0.00004   2.07037
+   A81        2.08495   0.00001   0.00007   0.00000   0.00007   2.08503
+   A82        2.08388   0.00000   0.00004  -0.00002   0.00002   2.08390
+   A83        2.13065   0.00000  -0.00006   0.00004  -0.00002   2.13063
+   A84        2.06865   0.00000   0.00002  -0.00002   0.00000   2.06866
+   A85        2.08388   0.00000   0.00004  -0.00002   0.00002   2.08390
+   A86        2.06865   0.00000   0.00002  -0.00002   0.00000   2.06866
+   A87        2.13065   0.00000  -0.00006   0.00004  -0.00002   2.13063
+   A88        2.12782  -0.00001  -0.00006   0.00003  -0.00003   2.12779
+   A89        2.07042   0.00000  -0.00001  -0.00003  -0.00004   2.07037
+   A90        2.08495   0.00001   0.00007   0.00000   0.00007   2.08503
+   A91        2.11733   0.00000  -0.00007   0.00006  -0.00001   2.11732
+   A92        2.07587   0.00000  -0.00004  -0.00003  -0.00006   2.07581
+   A93        2.08998   0.00001   0.00011  -0.00003   0.00007   2.09006
+   A94        2.09720   0.00000   0.00005  -0.00003   0.00001   2.09721
+   A95        2.13486   0.00000  -0.00005   0.00006   0.00001   2.13487
+   A96        2.05113  -0.00001   0.00000  -0.00003  -0.00003   2.05110
+   A97        2.09720   0.00000   0.00005  -0.00003   0.00001   2.09721
+   A98        2.05113  -0.00001   0.00000  -0.00003  -0.00003   2.05110
+   A99        2.13486   0.00000  -0.00005   0.00006   0.00001   2.13487
+   A100       2.11733   0.00000  -0.00007   0.00006  -0.00001   2.11732
+   A101       2.07587   0.00000  -0.00004  -0.00003  -0.00006   2.07581
+   A102       2.08998   0.00001   0.00011  -0.00003   0.00007   2.09006
+   A103       2.17430   0.00000  -0.00002   0.00004   0.00002   2.17432
+   A104       2.05392   0.00000   0.00000  -0.00002  -0.00002   2.05390
+   A105       2.05496   0.00000   0.00002  -0.00001   0.00000   2.05497
+   A106       2.05776   0.00000   0.00002  -0.00001   0.00001   2.05777
+   A107       2.13148   0.00000  -0.00005   0.00004  -0.00002   2.13146
+   A108       2.09395   0.00000   0.00004  -0.00003   0.00001   2.09396
+   A109       2.05776   0.00000   0.00002  -0.00001   0.00001   2.05777
+   A110       2.09395   0.00000   0.00004  -0.00003   0.00001   2.09396
+   A111       2.13148   0.00000  -0.00005   0.00004  -0.00002   2.13146
+   A112       2.17430   0.00000  -0.00002   0.00004   0.00002   2.17432
+   A113       2.05392   0.00000   0.00000  -0.00002  -0.00002   2.05390
+   A114       2.05496   0.00000   0.00002  -0.00001   0.00000   2.05497
+   A115       2.11036  -0.00001  -0.00009   0.00003  -0.00006   2.11029
+   A116       2.08772   0.00000   0.00008  -0.00005   0.00002   2.08775
+   A117       2.08511   0.00001   0.00001   0.00003   0.00004   2.08515
+   A118       2.07888   0.00001   0.00005   0.00000   0.00005   2.07893
+   A119       2.13051  -0.00001  -0.00008   0.00002  -0.00006   2.13044
+   A120       2.07380   0.00000   0.00003  -0.00002   0.00001   2.07381
+   A121       2.07888   0.00001   0.00005   0.00000   0.00005   2.07893
+   A122       2.07380   0.00000   0.00003  -0.00002   0.00001   2.07381
+   A123       2.13051  -0.00001  -0.00008   0.00002  -0.00006   2.13044
+   A124       2.11036  -0.00001  -0.00009   0.00003  -0.00006   2.11029
+   A125       2.08772   0.00000   0.00008  -0.00005   0.00002   2.08775
+   A126       2.08511   0.00001   0.00001   0.00003   0.00004   2.08515
+   A127       2.10895   0.00000  -0.00005   0.00002  -0.00002   2.10893
+   A128       2.07128  -0.00001  -0.00005  -0.00005  -0.00010   2.07118
+   A129       2.10296   0.00001   0.00010   0.00003   0.00012   2.10308
+   A130       2.10044   0.00001   0.00002   0.00000   0.00002   2.10045
+   A131       2.09736   0.00001   0.00006   0.00009   0.00015   2.09750
+   A132       2.08539  -0.00002  -0.00007  -0.00009  -0.00016   2.08523
+   A133       2.10044   0.00001   0.00002   0.00000   0.00002   2.10045
+   A134       2.08539  -0.00002  -0.00007  -0.00009  -0.00016   2.08523
+   A135       2.09736   0.00001   0.00006   0.00009   0.00015   2.09750
+   A136       2.10895   0.00000  -0.00005   0.00002  -0.00002   2.10893
+   A137       2.07128  -0.00001  -0.00005  -0.00005  -0.00010   2.07118
+   A138       2.10296   0.00001   0.00010   0.00003   0.00012   2.10308
+    D1        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D2        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+    D3       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+    D4        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D5        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D6        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+    D7       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+    D8        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+    D9        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D10       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D11        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D12        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D13        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D14       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D15       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D16        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D17        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D18       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D19        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D20        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D21       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D22        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D23        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D24       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D25        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D26        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D27       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D28        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D29        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D30        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D31        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D32        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D33        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D34       -3.14157   0.00000   0.00000   0.00000   0.00000  -3.14157
+   D35       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D36        0.00002   0.00000   0.00000   0.00000   0.00000   0.00002
+   D37        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D38       -3.14157   0.00000   0.00000   0.00000   0.00000  -3.14157
+   D39        3.14157   0.00000   0.00000   0.00000   0.00000   3.14157
+   D40        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D41       -3.14145   0.00000   0.00000   0.00000   0.00000  -3.14145
+   D42       -0.00010   0.00000   0.00000   0.00000   0.00000  -0.00011
+   D43        0.00017   0.00000   0.00000   0.00000   0.00000   0.00017
+   D44        3.14151   0.00000   0.00000   0.00000   0.00000   3.14151
+   D45        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D46        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D47        3.14157   0.00000   0.00000   0.00000   0.00000   3.14157
+   D48       -0.00002   0.00000   0.00000   0.00000   0.00000  -0.00002
+   D49       -0.00016   0.00000   0.00000   0.00000   0.00000  -0.00016
+   D50       -3.14152   0.00000   0.00000   0.00000   0.00001  -3.14151
+   D51        3.14145   0.00000   0.00000   0.00000   0.00000   3.14145
+   D52        0.00009   0.00000   0.00000   0.00000   0.00001   0.00010
+   D53        0.00016   0.00000   0.00000   0.00000   0.00000   0.00016
+   D54       -3.14145   0.00000   0.00000   0.00000   0.00000  -3.14145
+   D55        3.14152   0.00000   0.00000   0.00000  -0.00001   3.14151
+   D56       -0.00009   0.00000   0.00000   0.00000  -0.00001  -0.00010
+   D57        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D58        3.14158   0.00000   0.00000   0.00000   0.00000   3.14157
+   D59       -3.14157   0.00000   0.00000   0.00000   0.00000  -3.14157
+   D60        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D61       -3.14157   0.00000   0.00000   0.00000   0.00000  -3.14157
+   D62        0.00002   0.00000   0.00000   0.00000   0.00000   0.00002
+   D63        0.00001   0.00000   0.00000   0.00000   0.00000   0.00001
+   D64       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D65       -0.00017   0.00000   0.00000   0.00000   0.00000  -0.00017
+   D66       -3.14151   0.00000   0.00000   0.00000   0.00000  -3.14151
+   D67        3.14145   0.00000   0.00000   0.00000   0.00000   3.14145
+   D68        0.00010   0.00000   0.00000   0.00000   0.00000   0.00011
+   D69       -0.00001   0.00000   0.00000   0.00000   0.00000  -0.00001
+   D70        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D71        3.14156   0.00000   0.00000   0.00000   0.00000   3.14157
+   D72       -0.00002   0.00000   0.00000   0.00000   0.00000  -0.00002
+   D73        0.00001   0.00000   0.00000   0.00000   0.00000   0.00001
+   D74       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D75       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D76        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D77        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D78       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D79       -3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D80        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D81        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D82        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D83        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D84       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D85       -0.00001   0.00000   0.00000   0.00000   0.00000  -0.00001
+   D86        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D87        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D88        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D89        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D90        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D91       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D92        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D93        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D94        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D95       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D96        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D97        0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D98        3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D99       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D100       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D101      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D102       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D103       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D104       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D105       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D106       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D107      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D108       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D109       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D110      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D111       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D112       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D113       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D114      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D115       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D116       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D117       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D118      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D119       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D120       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D121       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D122       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D123       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D124      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D125       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D126      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D127       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D128       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D129       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D130       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D131      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D132       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D133       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D134       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D135      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D136       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D137       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D138      -3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D139      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D140       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D141      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D142       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D143       0.00001   0.00000   0.00000   0.00000   0.00000   0.00001
+   D144      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D145       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D146       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D147      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D148       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D149      -0.00001   0.00000   0.00000   0.00000   0.00000  -0.00001
+   D150       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D151       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D152       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D153       0.00001   0.00000   0.00000   0.00000   0.00000   0.00001
+   D154      -3.14157   0.00000   0.00000   0.00000   0.00000  -3.14157
+   D155      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D156       0.00002   0.00000   0.00000   0.00000   0.00000   0.00002
+   D157       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D158      -3.14157   0.00000   0.00000   0.00000   0.00000  -3.14157
+   D159       3.14158   0.00000   0.00000   0.00000   0.00000   3.14157
+   D160       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D161      -3.14145   0.00000   0.00000   0.00000   0.00000  -3.14145
+   D162      -0.00009   0.00000   0.00000   0.00000  -0.00001  -0.00010
+   D163       0.00016   0.00000   0.00000   0.00000   0.00000   0.00016
+   D164       3.14152   0.00000   0.00000   0.00000  -0.00001   3.14151
+   D165      -0.00001   0.00000   0.00000   0.00000   0.00000  -0.00001
+   D166       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D167       3.14156   0.00000   0.00000   0.00000   0.00000   3.14157
+   D168      -0.00002   0.00000   0.00000   0.00000   0.00000  -0.00002
+   D169      -0.00017   0.00000   0.00000   0.00000   0.00000  -0.00017
+   D170      -3.14151   0.00000   0.00000   0.00000   0.00000  -3.14151
+   D171       3.14145   0.00000   0.00000   0.00000   0.00000   3.14145
+   D172       0.00010   0.00000   0.00000   0.00000   0.00000   0.00011
+   D173       0.00017   0.00000   0.00000   0.00000   0.00000   0.00017
+   D174      -3.14145   0.00000   0.00000   0.00000   0.00000  -3.14145
+   D175       3.14151   0.00000   0.00000   0.00000   0.00000   3.14151
+   D176      -0.00010   0.00000   0.00000   0.00000   0.00000  -0.00011
+   D177       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D178       3.14157   0.00000   0.00000   0.00000   0.00000   3.14157
+   D179      -3.14157   0.00000   0.00000   0.00000   0.00000  -3.14157
+   D180       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D181      -3.14157   0.00000   0.00000   0.00000   0.00000  -3.14157
+   D182       0.00002   0.00000   0.00000   0.00000   0.00000   0.00002
+   D183       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D184      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D185      -0.00016   0.00000   0.00000   0.00000   0.00000  -0.00016
+   D186      -3.14152   0.00000   0.00000   0.00000   0.00001  -3.14151
+   D187       3.14145   0.00000   0.00000   0.00000   0.00000   3.14145
+   D188       0.00009   0.00000   0.00000   0.00000   0.00001   0.00010
+   D189       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D190       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D191       3.14157   0.00000   0.00000   0.00000   0.00000   3.14157
+   D192      -0.00002   0.00000   0.00000   0.00000   0.00000  -0.00002
+   D193       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D194      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D195      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D196       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D197       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D198       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D199      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D200       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D201      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D202       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D203       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D204      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D205       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D206       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D207       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D208       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D209       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D210       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D211      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D212       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D213       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D214       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D215      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D216       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D217       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D218      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D219       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D220       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D221       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+   D222       3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D223      -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D224       0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000067     0.000450     YES
+ RMS     Force            0.000013     0.000300     YES
+ Maximum Displacement     0.000476     0.001800     YES
+ RMS     Displacement     0.000100     0.001200     YES
+ Predicted change in Energy=-1.291947D-07
+ Optimization completed.
+    -- Stationary point found.
+                           ----------------------------
+                           !   Optimized Parameters   !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  1.4301         -DE/DX =    0.0001              !
+ ! R2    R(1,3)                  1.389          -DE/DX =   -0.0001              !
+ ! R3    R(1,47)                 1.0981         -DE/DX =    0.0                 !
+ ! R4    R(2,6)                  1.389          -DE/DX =   -0.0001              !
+ ! R5    R(2,48)                 1.0981         -DE/DX =    0.0                 !
+ ! R6    R(3,4)                  1.438          -DE/DX =    0.0001              !
+ ! R7    R(3,49)                 1.0983         -DE/DX =    0.0                 !
+ ! R8    R(4,5)                  1.4472         -DE/DX =    0.0                 !
+ ! R9    R(4,10)                 1.4397         -DE/DX =    0.0                 !
+ ! R10   R(5,6)                  1.438          -DE/DX =    0.0001              !
+ ! R11   R(5,7)                  1.4397         -DE/DX =    0.0                 !
+ ! R12   R(6,50)                 1.0983         -DE/DX =    0.0                 !
+ ! R13   R(7,8)                  1.3917         -DE/DX =    0.0                 !
+ ! R14   R(7,51)                 1.0971         -DE/DX =    0.0                 !
+ ! R15   R(8,9)                  1.4575         -DE/DX =    0.0                 !
+ ! R16   R(8,14)                 1.4271         -DE/DX =    0.0                 !
+ ! R17   R(9,10)                 1.3917         -DE/DX =    0.0                 !
+ ! R18   R(9,11)                 1.4271         -DE/DX =    0.0                 !
+ ! R19   R(10,52)                1.0971         -DE/DX =    0.0                 !
+ ! R20   R(11,12)                1.4269         -DE/DX =    0.0                 !
+ ! R21   R(11,69)                1.0407         -DE/DX =    0.0                 !
+ ! R22   R(12,13)                1.4744         -DE/DX =    0.0                 !
+ ! R23   R(12,18)                1.3811         -DE/DX =    0.0                 !
+ ! R24   R(13,14)                1.4269         -DE/DX =    0.0                 !
+ ! R25   R(13,15)                1.3811         -DE/DX =    0.0                 !
+ ! R26   R(14,71)                1.0407         -DE/DX =    0.0                 !
+ ! R27   R(15,16)                1.4548         -DE/DX =    0.0                 !
+ ! R28   R(15,53)                1.0968         -DE/DX =    0.0                 !
+ ! R29   R(16,17)                1.4728         -DE/DX =    0.0                 !
+ ! R30   R(16,22)                1.4019         -DE/DX =    0.0                 !
+ ! R31   R(17,18)                1.4548         -DE/DX =    0.0                 !
+ ! R32   R(17,19)                1.4019         -DE/DX =    0.0                 !
+ ! R33   R(18,54)                1.0968         -DE/DX =    0.0                 !
+ ! R34   R(19,20)                1.4362         -DE/DX =    0.0                 !
+ ! R35   R(19,65)                1.0981         -DE/DX =    0.0                 !
+ ! R36   R(20,21)                1.4702         -DE/DX =    0.0                 !
+ ! R37   R(20,26)                1.4193         -DE/DX =    0.0                 !
+ ! R38   R(21,22)                1.4362         -DE/DX =    0.0                 !
+ ! R39   R(21,23)                1.4193         -DE/DX =    0.0                 !
+ ! R40   R(22,55)                1.0981         -DE/DX =    0.0                 !
+ ! R41   R(23,24)                1.4193         -DE/DX =    0.0                 !
+ ! R42   R(23,67)                1.0984         -DE/DX =    0.0                 !
+ ! R43   R(24,25)                1.4702         -DE/DX =    0.0                 !
+ ! R44   R(24,30)                1.4362         -DE/DX =    0.0                 !
+ ! R45   R(25,26)                1.4193         -DE/DX =    0.0                 !
+ ! R46   R(25,27)                1.4362         -DE/DX =    0.0                 !
+ ! R47   R(26,56)                1.0984         -DE/DX =    0.0                 !
+ ! R48   R(27,28)                1.4019         -DE/DX =    0.0                 !
+ ! R49   R(27,66)                1.0981         -DE/DX =    0.0                 !
+ ! R50   R(28,29)                1.4728         -DE/DX =    0.0                 !
+ ! R51   R(28,34)                1.4548         -DE/DX =    0.0                 !
+ ! R52   R(29,30)                1.4019         -DE/DX =    0.0                 !
+ ! R53   R(29,31)                1.4548         -DE/DX =    0.0                 !
+ ! R54   R(30,57)                1.0981         -DE/DX =    0.0                 !
+ ! R55   R(31,32)                1.3811         -DE/DX =    0.0                 !
+ ! R56   R(31,68)                1.0968         -DE/DX =    0.0                 !
+ ! R57   R(32,33)                1.4744         -DE/DX =    0.0                 !
+ ! R58   R(32,38)                1.4269         -DE/DX =    0.0                 !
+ ! R59   R(33,34)                1.3811         -DE/DX =    0.0                 !
+ ! R60   R(33,35)                1.4269         -DE/DX =    0.0                 !
+ ! R61   R(34,58)                1.0968         -DE/DX =    0.0                 !
+ ! R62   R(35,36)                1.4271         -DE/DX =    0.0                 !
+ ! R63   R(35,70)                1.0407         -DE/DX =    0.0                 !
+ ! R64   R(36,37)                1.4575         -DE/DX =    0.0                 !
+ ! R65   R(36,42)                1.3917         -DE/DX =    0.0                 !
+ ! R66   R(37,38)                1.4271         -DE/DX =    0.0                 !
+ ! R67   R(37,39)                1.3917         -DE/DX =    0.0                 !
+ ! R68   R(38,72)                1.0407         -DE/DX =    0.0                 !
+ ! R69   R(39,40)                1.4397         -DE/DX =    0.0                 !
+ ! R70   R(39,59)                1.0971         -DE/DX =    0.0                 !
+ ! R71   R(40,41)                1.4472         -DE/DX =    0.0                 !
+ ! R72   R(40,46)                1.438          -DE/DX =    0.0001              !
+ ! R73   R(41,42)                1.4397         -DE/DX =    0.0                 !
+ ! R74   R(41,43)                1.438          -DE/DX =    0.0001              !
+ ! R75   R(42,60)                1.0971         -DE/DX =    0.0                 !
+ ! R76   R(43,44)                1.389          -DE/DX =   -0.0001              !
+ ! R77   R(43,61)                1.0983         -DE/DX =    0.0                 !
+ ! R78   R(44,45)                1.4301         -DE/DX =    0.0001              !
+ ! R79   R(44,62)                1.0981         -DE/DX =    0.0                 !
+ ! R80   R(45,46)                1.389          -DE/DX =   -0.0001              !
+ ! R81   R(45,63)                1.0981         -DE/DX =    0.0                 !
+ ! R82   R(46,64)                1.0983         -DE/DX =    0.0                 !
+ ! A1    A(2,1,3)              120.3461         -DE/DX =    0.0                 !
+ ! A2    A(2,1,47)             119.4843         -DE/DX =    0.0                 !
+ ! A3    A(3,1,47)             120.1696         -DE/DX =    0.0                 !
+ ! A4    A(1,2,6)              120.3461         -DE/DX =    0.0                 !
+ ! A5    A(1,2,48)             119.4843         -DE/DX =    0.0                 !
+ ! A6    A(6,2,48)             120.1696         -DE/DX =    0.0                 !
+ ! A7    A(1,3,4)              120.8338         -DE/DX =    0.0                 !
+ ! A8    A(1,3,49)             120.4907         -DE/DX =    0.0                 !
+ ! A9    A(4,3,49)             118.6755         -DE/DX =    0.0                 !
+ ! A10   A(3,4,5)              118.8201         -DE/DX =    0.0                 !
+ ! A11   A(3,4,10)             122.069          -DE/DX =    0.0                 !
+ ! A12   A(5,4,10)             119.111          -DE/DX =    0.0                 !
+ ! A13   A(4,5,6)              118.8201         -DE/DX =    0.0                 !
+ ! A14   A(4,5,7)              119.111          -DE/DX =    0.0                 !
+ ! A15   A(6,5,7)              122.069          -DE/DX =    0.0                 !
+ ! A16   A(2,6,5)              120.8338         -DE/DX =    0.0                 !
+ ! A17   A(2,6,50)             120.4907         -DE/DX =    0.0                 !
+ ! A18   A(5,6,50)             118.6755         -DE/DX =    0.0                 !
+ ! A19   A(5,7,8)              120.9146         -DE/DX =    0.0                 !
+ ! A20   A(5,7,51)             119.4677         -DE/DX =    0.0                 !
+ ! A21   A(8,7,51)             119.6176         -DE/DX =    0.0                 !
+ ! A22   A(7,8,9)              119.9744         -DE/DX =    0.0                 !
+ ! A23   A(7,8,14)             122.1248         -DE/DX =    0.0                 !
+ ! A24   A(9,8,14)             117.9008         -DE/DX =    0.0                 !
+ ! A25   A(8,9,10)             119.9744         -DE/DX =    0.0                 !
+ ! A26   A(8,9,11)             117.9008         -DE/DX =    0.0                 !
+ ! A27   A(10,9,11)            122.1248         -DE/DX =    0.0                 !
+ ! A28   A(4,10,9)             120.9146         -DE/DX =    0.0                 !
+ ! A29   A(4,10,52)            119.4677         -DE/DX =    0.0                 !
+ ! A30   A(9,10,52)            119.6176         -DE/DX =    0.0                 !
+ ! A31   A(9,11,12)            124.5783         -DE/DX =    0.0                 !
+ ! A32   A(9,11,69)            117.7408         -DE/DX =    0.0                 !
+ ! A33   A(12,11,69)           117.6809         -DE/DX =    0.0                 !
+ ! A34   A(11,12,13)           117.5208         -DE/DX =    0.0                 !
+ ! A35   A(11,12,18)           122.3184         -DE/DX =    0.0                 !
+ ! A36   A(13,12,18)           120.1608         -DE/DX =    0.0                 !
+ ! A37   A(12,13,14)           117.5208         -DE/DX =    0.0                 !
+ ! A38   A(12,13,15)           120.1608         -DE/DX =    0.0                 !
+ ! A39   A(14,13,15)           122.3184         -DE/DX =    0.0                 !
+ ! A40   A(8,14,13)            124.5783         -DE/DX =    0.0                 !
+ ! A41   A(8,14,71)            117.7408         -DE/DX =    0.0                 !
+ ! A42   A(13,14,71)           117.6809         -DE/DX =    0.0                 !
+ ! A43   A(13,15,16)           121.3141         -DE/DX =    0.0                 !
+ ! A44   A(13,15,53)           119.7472         -DE/DX =    0.0                 !
+ ! A45   A(16,15,53)           118.9387         -DE/DX =    0.0                 !
+ ! A46   A(15,16,17)           118.5252         -DE/DX =    0.0                 !
+ ! A47   A(15,16,22)           122.0775         -DE/DX =    0.0                 !
+ ! A48   A(17,16,22)           119.3973         -DE/DX =    0.0                 !
+ ! A49   A(16,17,18)           118.5252         -DE/DX =    0.0                 !
+ ! A50   A(16,17,19)           119.3973         -DE/DX =    0.0                 !
+ ! A51   A(18,17,19)           122.0775         -DE/DX =    0.0                 !
+ ! A52   A(12,18,17)           121.3141         -DE/DX =    0.0                 !
+ ! A53   A(12,18,54)           119.7472         -DE/DX =    0.0                 !
+ ! A54   A(17,18,54)           118.9387         -DE/DX =    0.0                 !
+ ! A55   A(17,19,20)           121.9148         -DE/DX =    0.0                 !
+ ! A56   A(17,19,65)           119.459          -DE/DX =    0.0                 !
+ ! A57   A(20,19,65)           118.6262         -DE/DX =    0.0                 !
+ ! A58   A(19,20,21)           118.6878         -DE/DX =    0.0                 !
+ ! A59   A(19,20,26)           122.2501         -DE/DX =    0.0                 !
+ ! A60   A(21,20,26)           119.062          -DE/DX =    0.0                 !
+ ! A61   A(20,21,22)           118.6878         -DE/DX =    0.0                 !
+ ! A62   A(20,21,23)           119.062          -DE/DX =    0.0                 !
+ ! A63   A(22,21,23)           122.2501         -DE/DX =    0.0                 !
+ ! A64   A(16,22,21)           121.9148         -DE/DX =    0.0                 !
+ ! A65   A(16,22,55)           119.459          -DE/DX =    0.0                 !
+ ! A66   A(21,22,55)           118.6262         -DE/DX =    0.0                 !
+ ! A67   A(21,23,24)           121.8759         -DE/DX =    0.0                 !
+ ! A68   A(21,23,67)           119.062          -DE/DX =    0.0                 !
+ ! A69   A(24,23,67)           119.062          -DE/DX =    0.0                 !
+ ! A70   A(23,24,25)           119.062          -DE/DX =    0.0                 !
+ ! A71   A(23,24,30)           122.2501         -DE/DX =    0.0                 !
+ ! A72   A(25,24,30)           118.6878         -DE/DX =    0.0                 !
+ ! A73   A(24,25,26)           119.062          -DE/DX =    0.0                 !
+ ! A74   A(24,25,27)           118.6878         -DE/DX =    0.0                 !
+ ! A75   A(26,25,27)           122.2501         -DE/DX =    0.0                 !
+ ! A76   A(20,26,25)           121.8759         -DE/DX =    0.0                 !
+ ! A77   A(20,26,56)           119.062          -DE/DX =    0.0                 !
+ ! A78   A(25,26,56)           119.062          -DE/DX =    0.0                 !
+ ! A79   A(25,27,28)           121.9148         -DE/DX =    0.0                 !
+ ! A80   A(25,27,66)           118.6262         -DE/DX =    0.0                 !
+ ! A81   A(28,27,66)           119.459          -DE/DX =    0.0                 !
+ ! A82   A(27,28,29)           119.3973         -DE/DX =    0.0                 !
+ ! A83   A(27,28,34)           122.0775         -DE/DX =    0.0                 !
+ ! A84   A(29,28,34)           118.5252         -DE/DX =    0.0                 !
+ ! A85   A(28,29,30)           119.3973         -DE/DX =    0.0                 !
+ ! A86   A(28,29,31)           118.5252         -DE/DX =    0.0                 !
+ ! A87   A(30,29,31)           122.0775         -DE/DX =    0.0                 !
+ ! A88   A(24,30,29)           121.9148         -DE/DX =    0.0                 !
+ ! A89   A(24,30,57)           118.6262         -DE/DX =    0.0                 !
+ ! A90   A(29,30,57)           119.459          -DE/DX =    0.0                 !
+ ! A91   A(29,31,32)           121.3141         -DE/DX =    0.0                 !
+ ! A92   A(29,31,68)           118.9387         -DE/DX =    0.0                 !
+ ! A93   A(32,31,68)           119.7472         -DE/DX =    0.0                 !
+ ! A94   A(31,32,33)           120.1608         -DE/DX =    0.0                 !
+ ! A95   A(31,32,38)           122.3184         -DE/DX =    0.0                 !
+ ! A96   A(33,32,38)           117.5208         -DE/DX =    0.0                 !
+ ! A97   A(32,33,34)           120.1608         -DE/DX =    0.0                 !
+ ! A98   A(32,33,35)           117.5208         -DE/DX =    0.0                 !
+ ! A99   A(34,33,35)           122.3184         -DE/DX =    0.0                 !
+ ! A100  A(28,34,33)           121.3141         -DE/DX =    0.0                 !
+ ! A101  A(28,34,58)           118.9387         -DE/DX =    0.0                 !
+ ! A102  A(33,34,58)           119.7472         -DE/DX =    0.0                 !
+ ! A103  A(33,35,36)           124.5783         -DE/DX =    0.0                 !
+ ! A104  A(33,35,70)           117.6809         -DE/DX =    0.0                 !
+ ! A105  A(36,35,70)           117.7408         -DE/DX =    0.0                 !
+ ! A106  A(35,36,37)           117.9008         -DE/DX =    0.0                 !
+ ! A107  A(35,36,42)           122.1248         -DE/DX =    0.0                 !
+ ! A108  A(37,36,42)           119.9744         -DE/DX =    0.0                 !
+ ! A109  A(36,37,38)           117.9008         -DE/DX =    0.0                 !
+ ! A110  A(36,37,39)           119.9744         -DE/DX =    0.0                 !
+ ! A111  A(38,37,39)           122.1248         -DE/DX =    0.0                 !
+ ! A112  A(32,38,37)           124.5783         -DE/DX =    0.0                 !
+ ! A113  A(32,38,72)           117.6809         -DE/DX =    0.0                 !
+ ! A114  A(37,38,72)           117.7408         -DE/DX =    0.0                 !
+ ! A115  A(37,39,40)           120.9146         -DE/DX =    0.0                 !
+ ! A116  A(37,39,59)           119.6176         -DE/DX =    0.0                 !
+ ! A117  A(40,39,59)           119.4677         -DE/DX =    0.0                 !
+ ! A118  A(39,40,41)           119.111          -DE/DX =    0.0                 !
+ ! A119  A(39,40,46)           122.069          -DE/DX =    0.0                 !
+ ! A120  A(41,40,46)           118.8201         -DE/DX =    0.0                 !
+ ! A121  A(40,41,42)           119.111          -DE/DX =    0.0                 !
+ ! A122  A(40,41,43)           118.8201         -DE/DX =    0.0                 !
+ ! A123  A(42,41,43)           122.069          -DE/DX =    0.0                 !
+ ! A124  A(36,42,41)           120.9146         -DE/DX =    0.0                 !
+ ! A125  A(36,42,60)           119.6176         -DE/DX =    0.0                 !
+ ! A126  A(41,42,60)           119.4677         -DE/DX =    0.0                 !
+ ! A127  A(41,43,44)           120.8338         -DE/DX =    0.0                 !
+ ! A128  A(41,43,61)           118.6755         -DE/DX =    0.0                 !
+ ! A129  A(44,43,61)           120.4907         -DE/DX =    0.0                 !
+ ! A130  A(43,44,45)           120.3461         -DE/DX =    0.0                 !
+ ! A131  A(43,44,62)           120.1696         -DE/DX =    0.0                 !
+ ! A132  A(45,44,62)           119.4843         -DE/DX =    0.0                 !
+ ! A133  A(44,45,46)           120.3461         -DE/DX =    0.0                 !
+ ! A134  A(44,45,63)           119.4843         -DE/DX =    0.0                 !
+ ! A135  A(46,45,63)           120.1696         -DE/DX =    0.0                 !
+ ! A136  A(40,46,45)           120.8338         -DE/DX =    0.0                 !
+ ! A137  A(40,46,64)           118.6755         -DE/DX =    0.0                 !
+ ! A138  A(45,46,64)           120.4907         -DE/DX =    0.0                 !
+ ! D1    D(3,1,2,6)              0.0            -DE/DX =    0.0                 !
+ ! D2    D(3,1,2,48)           180.0            -DE/DX =    0.0                 !
+ ! D3    D(47,1,2,6)          -180.0            -DE/DX =    0.0                 !
+ ! D4    D(47,1,2,48)            0.0            -DE/DX =    0.0                 !
+ ! D5    D(2,1,3,4)              0.0            -DE/DX =    0.0                 !
+ ! D6    D(2,1,3,49)           180.0            -DE/DX =    0.0                 !
+ ! D7    D(47,1,3,4)          -180.0            -DE/DX =    0.0                 !
+ ! D8    D(47,1,3,49)            0.0            -DE/DX =    0.0                 !
+ ! D9    D(1,2,6,5)              0.0            -DE/DX =    0.0                 !
+ ! D10   D(1,2,6,50)          -180.0            -DE/DX =    0.0                 !
+ ! D11   D(48,2,6,5)           180.0            -DE/DX =    0.0                 !
+ ! D12   D(48,2,6,50)            0.0            -DE/DX =    0.0                 !
+ ! D13   D(1,3,4,5)              0.0            -DE/DX =    0.0                 !
+ ! D14   D(1,3,4,10)          -180.0            -DE/DX =    0.0                 !
+ ! D15   D(49,3,4,5)          -180.0            -DE/DX =    0.0                 !
+ ! D16   D(49,3,4,10)            0.0            -DE/DX =    0.0                 !
+ ! D17   D(3,4,5,6)              0.0            -DE/DX =    0.0                 !
+ ! D18   D(3,4,5,7)           -180.0            -DE/DX =    0.0                 !
+ ! D19   D(10,4,5,6)           180.0            -DE/DX =    0.0                 !
+ ! D20   D(10,4,5,7)             0.0            -DE/DX =    0.0                 !
+ ! D21   D(3,4,10,9)          -179.9998         -DE/DX =    0.0                 !
+ ! D22   D(3,4,10,52)            0.0            -DE/DX =    0.0                 !
+ ! D23   D(5,4,10,9)             0.0003         -DE/DX =    0.0                 !
+ ! D24   D(5,4,10,52)         -179.9999         -DE/DX =    0.0                 !
+ ! D25   D(4,5,6,2)              0.0            -DE/DX =    0.0                 !
+ ! D26   D(4,5,6,50)           180.0            -DE/DX =    0.0                 !
+ ! D27   D(7,5,6,2)           -180.0            -DE/DX =    0.0                 !
+ ! D28   D(7,5,6,50)             0.0            -DE/DX =    0.0                 !
+ ! D29   D(4,5,7,8)             -0.0002         -DE/DX =    0.0                 !
+ ! D30   D(4,5,7,51)           180.0            -DE/DX =    0.0                 !
+ ! D31   D(6,5,7,8)            179.9998         -DE/DX =    0.0                 !
+ ! D32   D(6,5,7,51)             0.0            -DE/DX =    0.0                 !
+ ! D33   D(5,7,8,9)              0.0003         -DE/DX =    0.0                 !
+ ! D34   D(5,7,8,14)          -179.9985         -DE/DX =    0.0                 !
+ ! D35   D(51,7,8,9)          -179.9999         -DE/DX =    0.0                 !
+ ! D36   D(51,7,8,14)            0.0013         -DE/DX =    0.0                 !
+ ! D37   D(7,8,9,10)             0.0            -DE/DX =    0.0                 !
+ ! D38   D(7,8,9,11)          -179.999          -DE/DX =    0.0                 !
+ ! D39   D(14,8,9,10)          179.9988         -DE/DX =    0.0                 !
+ ! D40   D(14,8,9,11)           -0.0002         -DE/DX =    0.0                 !
+ ! D41   D(7,8,14,13)         -179.9916         -DE/DX =    0.0                 !
+ ! D42   D(7,8,14,71)           -0.0059         -DE/DX =    0.0                 !
+ ! D43   D(9,8,14,13)            0.0096         -DE/DX =    0.0                 !
+ ! D44   D(9,8,14,71)          179.9953         -DE/DX =    0.0                 !
+ ! D45   D(8,9,10,4)            -0.0002         -DE/DX =    0.0                 !
+ ! D46   D(8,9,10,52)          179.9999         -DE/DX =    0.0                 !
+ ! D47   D(11,9,10,4)          179.9987         -DE/DX =    0.0                 !
+ ! D48   D(11,9,10,52)          -0.0012         -DE/DX =    0.0                 !
+ ! D49   D(8,9,11,12)           -0.0093         -DE/DX =    0.0                 !
+ ! D50   D(8,9,11,69)         -179.9958         -DE/DX =    0.0                 !
+ ! D51   D(10,9,11,12)         179.9918         -DE/DX =    0.0                 !
+ ! D52   D(10,9,11,69)           0.0052         -DE/DX =    0.0                 !
+ ! D53   D(9,11,12,13)           0.0093         -DE/DX =    0.0                 !
+ ! D54   D(9,11,12,18)        -179.9918         -DE/DX =    0.0                 !
+ ! D55   D(69,11,12,13)        179.9958         -DE/DX =    0.0                 !
+ ! D56   D(69,11,12,18)         -0.0052         -DE/DX =    0.0                 !
+ ! D57   D(11,12,13,14)          0.0002         -DE/DX =    0.0                 !
+ ! D58   D(11,12,13,15)        179.999          -DE/DX =    0.0                 !
+ ! D59   D(18,12,13,14)       -179.9988         -DE/DX =    0.0                 !
+ ! D60   D(18,12,13,15)          0.0            -DE/DX =    0.0                 !
+ ! D61   D(11,12,18,17)       -179.9986         -DE/DX =    0.0                 !
+ ! D62   D(11,12,18,54)          0.0012         -DE/DX =    0.0                 !
+ ! D63   D(13,12,18,17)          0.0004         -DE/DX =    0.0                 !
+ ! D64   D(13,12,18,54)       -179.9999         -DE/DX =    0.0                 !
+ ! D65   D(12,13,14,8)          -0.0096         -DE/DX =    0.0                 !
+ ! D66   D(12,13,14,71)       -179.9953         -DE/DX =    0.0                 !
+ ! D67   D(15,13,14,8)         179.9916         -DE/DX =    0.0                 !
+ ! D68   D(15,13,14,71)          0.0059         -DE/DX =    0.0                 !
+ ! D69   D(12,13,15,16)         -0.0004         -DE/DX =    0.0                 !
+ ! D70   D(12,13,15,53)        179.9999         -DE/DX =    0.0                 !
+ ! D71   D(14,13,15,16)        179.9984         -DE/DX =    0.0                 !
+ ! D72   D(14,13,15,53)         -0.0013         -DE/DX =    0.0                 !
+ ! D73   D(13,15,16,17)          0.0003         -DE/DX =    0.0                 !
+ ! D74   D(13,15,16,22)       -179.9996         -DE/DX =    0.0                 !
+ ! D75   D(53,15,16,17)       -179.9999         -DE/DX =    0.0                 !
+ ! D76   D(53,15,16,22)          0.0001         -DE/DX =    0.0                 !
+ ! D77   D(15,16,17,18)          0.0            -DE/DX =    0.0                 !
+ ! D78   D(15,16,17,19)       -180.0            -DE/DX =    0.0                 !
+ ! D79   D(22,16,17,18)        180.0            -DE/DX =    0.0                 !
+ ! D80   D(22,16,17,19)          0.0            -DE/DX =    0.0                 !
+ ! D81   D(15,16,22,21)        179.9999         -DE/DX =    0.0                 !
+ ! D82   D(15,16,22,55)          0.0            -DE/DX =    0.0                 !
+ ! D83   D(17,16,22,21)         -0.0001         -DE/DX =    0.0                 !
+ ! D84   D(17,16,22,55)       -180.0            -DE/DX =    0.0                 !
+ ! D85   D(16,17,18,12)         -0.0004         -DE/DX =    0.0                 !
+ ! D86   D(16,17,18,54)        179.9999         -DE/DX =    0.0                 !
+ ! D87   D(19,17,18,12)        179.9996         -DE/DX =    0.0                 !
+ ! D88   D(19,17,18,54)         -0.0001         -DE/DX =    0.0                 !
+ ! D89   D(16,17,19,20)          0.0001         -DE/DX =    0.0                 !
+ ! D90   D(16,17,19,65)        180.0            -DE/DX =    0.0                 !
+ ! D91   D(18,17,19,20)       -179.9999         -DE/DX =    0.0                 !
+ ! D92   D(18,17,19,65)          0.0            -DE/DX =    0.0                 !
+ ! D93   D(17,19,20,21)         -0.0001         -DE/DX =    0.0                 !
+ ! D94   D(17,19,20,26)        179.9998         -DE/DX =    0.0                 !
+ ! D95   D(65,19,20,21)       -180.0            -DE/DX =    0.0                 !
+ ! D96   D(65,19,20,26)         -0.0001         -DE/DX =    0.0                 !
+ ! D97   D(19,20,21,22)          0.0            -DE/DX =    0.0                 !
+ ! D98   D(19,20,21,23)        179.9999         -DE/DX =    0.0                 !
+ ! D99   D(26,20,21,22)       -179.9999         -DE/DX =    0.0                 !
+ ! D100  D(26,20,21,23)          0.0            -DE/DX =    0.0                 !
+ ! D101  D(19,20,26,25)       -179.9998         -DE/DX =    0.0                 !
+ ! D102  D(19,20,26,56)          0.0001         -DE/DX =    0.0                 !
+ ! D103  D(21,20,26,25)          0.0001         -DE/DX =    0.0                 !
+ ! D104  D(21,20,26,56)        180.0            -DE/DX =    0.0                 !
+ ! D105  D(20,21,22,16)          0.0001         -DE/DX =    0.0                 !
+ ! D106  D(20,21,22,55)        180.0            -DE/DX =    0.0                 !
+ ! D107  D(23,21,22,16)       -179.9998         -DE/DX =    0.0                 !
+ ! D108  D(23,21,22,55)          0.0001         -DE/DX =    0.0                 !
+ ! D109  D(20,21,23,24)         -0.0001         -DE/DX =    0.0                 !
+ ! D110  D(20,21,23,67)       -180.0            -DE/DX =    0.0                 !
+ ! D111  D(22,21,23,24)        179.9998         -DE/DX =    0.0                 !
+ ! D112  D(22,21,23,67)         -0.0001         -DE/DX =    0.0                 !
+ ! D113  D(21,23,24,25)          0.0001         -DE/DX =    0.0                 !
+ ! D114  D(21,23,24,30)       -179.9998         -DE/DX =    0.0                 !
+ ! D115  D(67,23,24,25)        180.0            -DE/DX =    0.0                 !
+ ! D116  D(67,23,24,30)          0.0001         -DE/DX =    0.0                 !
+ ! D117  D(23,24,25,26)          0.0            -DE/DX =    0.0                 !
+ ! D118  D(23,24,25,27)       -179.9999         -DE/DX =    0.0                 !
+ ! D119  D(30,24,25,26)        179.9999         -DE/DX =    0.0                 !
+ ! D120  D(30,24,25,27)          0.0            -DE/DX =    0.0                 !
+ ! D121  D(23,24,30,29)        179.9998         -DE/DX =    0.0                 !
+ ! D122  D(23,24,30,57)         -0.0001         -DE/DX =    0.0                 !
+ ! D123  D(25,24,30,29)         -0.0001         -DE/DX =    0.0                 !
+ ! D124  D(25,24,30,57)       -180.0            -DE/DX =    0.0                 !
+ ! D125  D(24,25,26,20)         -0.0001         -DE/DX =    0.0                 !
+ ! D126  D(24,25,26,56)       -180.0            -DE/DX =    0.0                 !
+ ! D127  D(27,25,26,20)        179.9998         -DE/DX =    0.0                 !
+ ! D128  D(27,25,26,56)         -0.0001         -DE/DX =    0.0                 !
+ ! D129  D(24,25,27,28)          0.0001         -DE/DX =    0.0                 !
+ ! D130  D(24,25,27,66)        180.0            -DE/DX =    0.0                 !
+ ! D131  D(26,25,27,28)       -179.9998         -DE/DX =    0.0                 !
+ ! D132  D(26,25,27,66)          0.0001         -DE/DX =    0.0                 !
+ ! D133  D(25,27,28,29)         -0.0001         -DE/DX =    0.0                 !
+ ! D134  D(25,27,28,34)        179.9999         -DE/DX =    0.0                 !
+ ! D135  D(66,27,28,29)       -180.0            -DE/DX =    0.0                 !
+ ! D136  D(66,27,28,34)          0.0            -DE/DX =    0.0                 !
+ ! D137  D(27,28,29,30)          0.0            -DE/DX =    0.0                 !
+ ! D138  D(27,28,29,31)        180.0            -DE/DX =    0.0                 !
+ ! D139  D(34,28,29,30)       -180.0            -DE/DX =    0.0                 !
+ ! D140  D(34,28,29,31)          0.0            -DE/DX =    0.0                 !
+ ! D141  D(27,28,34,33)       -179.9996         -DE/DX =    0.0                 !
+ ! D142  D(27,28,34,58)          0.0001         -DE/DX =    0.0                 !
+ ! D143  D(29,28,34,33)          0.0003         -DE/DX =    0.0                 !
+ ! D144  D(29,28,34,58)       -179.9999         -DE/DX =    0.0                 !
+ ! D145  D(28,29,30,24)          0.0001         -DE/DX =    0.0                 !
+ ! D146  D(28,29,30,57)        180.0            -DE/DX =    0.0                 !
+ ! D147  D(31,29,30,24)       -179.9999         -DE/DX =    0.0                 !
+ ! D148  D(31,29,30,57)          0.0            -DE/DX =    0.0                 !
+ ! D149  D(28,29,31,32)         -0.0004         -DE/DX =    0.0                 !
+ ! D150  D(28,29,31,68)        179.9999         -DE/DX =    0.0                 !
+ ! D151  D(30,29,31,32)        179.9996         -DE/DX =    0.0                 !
+ ! D152  D(30,29,31,68)         -0.0001         -DE/DX =    0.0                 !
+ ! D153  D(29,31,32,33)          0.0004         -DE/DX =    0.0                 !
+ ! D154  D(29,31,32,38)       -179.9986         -DE/DX =    0.0                 !
+ ! D155  D(68,31,32,33)       -179.9999         -DE/DX =    0.0                 !
+ ! D156  D(68,31,32,38)          0.0012         -DE/DX =    0.0                 !
+ ! D157  D(31,32,33,34)          0.0            -DE/DX =    0.0                 !
+ ! D158  D(31,32,33,35)       -179.9988         -DE/DX =    0.0                 !
+ ! D159  D(38,32,33,34)        179.999          -DE/DX =    0.0                 !
+ ! D160  D(38,32,33,35)          0.0002         -DE/DX =    0.0                 !
+ ! D161  D(31,32,38,37)       -179.9918         -DE/DX =    0.0                 !
+ ! D162  D(31,32,38,72)         -0.0052         -DE/DX =    0.0                 !
+ ! D163  D(33,32,38,37)          0.0093         -DE/DX =    0.0                 !
+ ! D164  D(33,32,38,72)        179.9958         -DE/DX =    0.0                 !
+ ! D165  D(32,33,34,28)         -0.0004         -DE/DX =    0.0                 !
+ ! D166  D(32,33,34,58)        179.9999         -DE/DX =    0.0                 !
+ ! D167  D(35,33,34,28)        179.9984         -DE/DX =    0.0                 !
+ ! D168  D(35,33,34,58)         -0.0013         -DE/DX =    0.0                 !
+ ! D169  D(32,33,35,36)         -0.0096         -DE/DX =    0.0                 !
+ ! D170  D(32,33,35,70)       -179.9953         -DE/DX =    0.0                 !
+ ! D171  D(34,33,35,36)        179.9916         -DE/DX =    0.0                 !
+ ! D172  D(34,33,35,70)          0.0059         -DE/DX =    0.0                 !
+ ! D173  D(33,35,36,37)          0.0096         -DE/DX =    0.0                 !
+ ! D174  D(33,35,36,42)       -179.9916         -DE/DX =    0.0                 !
+ ! D175  D(70,35,36,37)        179.9953         -DE/DX =    0.0                 !
+ ! D176  D(70,35,36,42)         -0.0059         -DE/DX =    0.0                 !
+ ! D177  D(35,36,37,38)         -0.0002         -DE/DX =    0.0                 !
+ ! D178  D(35,36,37,39)        179.9988         -DE/DX =    0.0                 !
+ ! D179  D(42,36,37,38)       -179.999          -DE/DX =    0.0                 !
+ ! D180  D(42,36,37,39)          0.0            -DE/DX =    0.0                 !
+ ! D181  D(35,36,42,41)       -179.9985         -DE/DX =    0.0                 !
+ ! D182  D(35,36,42,60)          0.0013         -DE/DX =    0.0                 !
+ ! D183  D(37,36,42,41)          0.0003         -DE/DX =    0.0                 !
+ ! D184  D(37,36,42,60)       -179.9999         -DE/DX =    0.0                 !
+ ! D185  D(36,37,38,32)         -0.0093         -DE/DX =    0.0                 !
+ ! D186  D(36,37,38,72)       -179.9958         -DE/DX =    0.0                 !
+ ! D187  D(39,37,38,32)        179.9918         -DE/DX =    0.0                 !
+ ! D188  D(39,37,38,72)          0.0052         -DE/DX =    0.0                 !
+ ! D189  D(36,37,39,40)         -0.0002         -DE/DX =    0.0                 !
+ ! D190  D(36,37,39,59)        179.9999         -DE/DX =    0.0                 !
+ ! D191  D(38,37,39,40)        179.9987         -DE/DX =    0.0                 !
+ ! D192  D(38,37,39,59)         -0.0012         -DE/DX =    0.0                 !
+ ! D193  D(37,39,40,41)          0.0003         -DE/DX =    0.0                 !
+ ! D194  D(37,39,40,46)       -179.9998         -DE/DX =    0.0                 !
+ ! D195  D(59,39,40,41)       -179.9999         -DE/DX =    0.0                 !
+ ! D196  D(59,39,40,46)          0.0            -DE/DX =    0.0                 !
+ ! D197  D(39,40,41,42)          0.0            -DE/DX =    0.0                 !
+ ! D198  D(39,40,41,43)        180.0            -DE/DX =    0.0                 !
+ ! D199  D(46,40,41,42)       -180.0            -DE/DX =    0.0                 !
+ ! D200  D(46,40,41,43)          0.0            -DE/DX =    0.0                 !
+ ! D201  D(39,40,46,45)       -180.0            -DE/DX =    0.0                 !
+ ! D202  D(39,40,46,64)          0.0            -DE/DX =    0.0                 !
+ ! D203  D(41,40,46,45)          0.0            -DE/DX =    0.0                 !
+ ! D204  D(41,40,46,64)       -180.0            -DE/DX =    0.0                 !
+ ! D205  D(40,41,42,36)         -0.0002         -DE/DX =    0.0                 !
+ ! D206  D(40,41,42,60)        180.0            -DE/DX =    0.0                 !
+ ! D207  D(43,41,42,36)        179.9998         -DE/DX =    0.0                 !
+ ! D208  D(43,41,42,60)          0.0            -DE/DX =    0.0                 !
+ ! D209  D(40,41,43,44)          0.0            -DE/DX =    0.0                 !
+ ! D210  D(40,41,43,61)        180.0            -DE/DX =    0.0                 !
+ ! D211  D(42,41,43,44)       -180.0            -DE/DX =    0.0                 !
+ ! D212  D(42,41,43,61)          0.0            -DE/DX =    0.0                 !
+ ! D213  D(41,43,44,45)          0.0            -DE/DX =    0.0                 !
+ ! D214  D(41,43,44,62)        180.0            -DE/DX =    0.0                 !
+ ! D215  D(61,43,44,45)       -180.0            -DE/DX =    0.0                 !
+ ! D216  D(61,43,44,62)          0.0            -DE/DX =    0.0                 !
+ ! D217  D(43,44,45,46)          0.0            -DE/DX =    0.0                 !
+ ! D218  D(43,44,45,63)       -180.0            -DE/DX =    0.0                 !
+ ! D219  D(62,44,45,46)        180.0            -DE/DX =    0.0                 !
+ ! D220  D(62,44,45,63)          0.0            -DE/DX =    0.0                 !
+ ! D221  D(44,45,46,40)          0.0            -DE/DX =    0.0                 !
+ ! D222  D(44,45,46,64)        180.0            -DE/DX =    0.0                 !
+ ! D223  D(63,45,46,40)       -180.0            -DE/DX =    0.0                 !
+ ! D224  D(63,45,46,64)          0.0            -DE/DX =    0.0                 !
+ --------------------------------------------------------------------------------
+ Lowest energy point so far.  Saving SCF results.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Largest change from initial coordinates is atom   47      10.994 Angstoms.
+ Leave Link  103 at Tue Aug  4 10:42:02 2020, MaxMem=    33554432 cpu:         0.1
+ (Enter /cluster/apps/gaussian/g09/l202.exe)
+ Stoichiometry    C42H26N4
+ Framework group  C2[X(C42H26N4)]
+ Deg. of freedom   106
+ Full point group                 C2      NOp   2
+ RotChk:  IX=0 Diff= 2.31D-15
+ Largest Abelian subgroup         C2      NOp   2
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0      -13.642932    0.715060    0.000444
+      2          6           0      -13.642932   -0.715060    0.000444
+      3          6           0      -12.444202    1.416837    0.000325
+      4          6           0      -11.184284    0.723616    0.000199
+      5          6           0      -11.184284   -0.723616    0.000198
+      6          6           0      -12.444202   -1.416837    0.000324
+      7          6           0       -9.926406   -1.424059    0.000073
+      8          6           0       -8.720812   -0.728728   -0.000052
+      9          6           0       -8.720812    0.728728   -0.000051
+     10          6           0       -9.926406    1.424059    0.000074
+     11          7           0       -7.459610    1.396524   -0.000204
+     12          6           0       -6.194172    0.737193   -0.000168
+     13          6           0       -6.194172   -0.737193   -0.000169
+     14          7           0       -7.459610   -1.396524   -0.000209
+     15          6           0       -5.000042   -1.431099   -0.000155
+     16          6           0       -3.721882   -0.736387   -0.000148
+     17          6           0       -3.721882    0.736387   -0.000148
+     18          6           0       -5.000042    1.431099   -0.000155
+     19          6           0       -2.500489    1.424532   -0.000142
+     20          6           0       -1.240559    0.735088   -0.000138
+     21          6           0       -1.240559   -0.735088   -0.000138
+     22          6           0       -2.500489   -1.424532   -0.000142
+     23          6           0        0.000000   -1.424498   -0.000137
+     24          6           0        1.240559   -0.735088   -0.000138
+     25          6           0        1.240559    0.735088   -0.000138
+     26          6           0        0.000000    1.424498   -0.000137
+     27          6           0        2.500489    1.424532   -0.000142
+     28          6           0        3.721882    0.736387   -0.000148
+     29          6           0        3.721882   -0.736387   -0.000148
+     30          6           0        2.500489   -1.424532   -0.000142
+     31          6           0        5.000042   -1.431099   -0.000155
+     32          6           0        6.194172   -0.737193   -0.000168
+     33          6           0        6.194172    0.737193   -0.000169
+     34          6           0        5.000042    1.431099   -0.000155
+     35          7           0        7.459610    1.396524   -0.000209
+     36          6           0        8.720812    0.728728   -0.000052
+     37          6           0        8.720812   -0.728728   -0.000051
+     38          7           0        7.459610   -1.396524   -0.000204
+     39          6           0        9.926406   -1.424059    0.000074
+     40          6           0       11.184284   -0.723616    0.000199
+     41          6           0       11.184284    0.723616    0.000198
+     42          6           0        9.926406    1.424059    0.000073
+     43          6           0       12.444202    1.416837    0.000324
+     44          6           0       13.642932    0.715060    0.000444
+     45          6           0       13.642932   -0.715060    0.000444
+     46          6           0       12.444202   -1.416837    0.000325
+     47          1           0      -14.598801    1.255518    0.000539
+     48          1           0      -14.598801   -1.255518    0.000539
+     49          1           0      -12.441431    2.515120    0.000324
+     50          1           0      -12.441431   -2.515120    0.000324
+     51          1           0       -9.919575   -2.521125    0.000073
+     52          1           0       -9.919575    2.521125    0.000075
+     53          1           0       -5.007958   -2.527894   -0.000154
+     54          1           0       -5.007958    2.527894   -0.000152
+     55          1           0       -2.499308   -2.522656   -0.000142
+     56          1           0        0.000000    2.522893   -0.000137
+     57          1           0        2.499308   -2.522656   -0.000143
+     58          1           0        5.007958    2.527894   -0.000154
+     59          1           0        9.919575   -2.521125    0.000075
+     60          1           0        9.919575    2.521125    0.000073
+     61          1           0       12.441431    2.515120    0.000324
+     62          1           0       14.598801    1.255518    0.000539
+     63          1           0       14.598801   -1.255518    0.000539
+     64          1           0       12.441431   -2.515120    0.000324
+     65          1           0       -2.499308    2.522656   -0.000143
+     66          1           0        2.499308    2.522656   -0.000142
+     67          1           0        0.000000   -2.522893   -0.000137
+     68          1           0        5.007958   -2.527894   -0.000152
+     69          1           0       -7.462516    2.437237   -0.000137
+     70          1           0        7.462516    2.437237   -0.000133
+     71          1           0       -7.462516   -2.437237   -0.000133
+     72          1           0        7.462516   -2.437237   -0.000137
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      0.5972060      0.0125779      0.0123185
+ Leave Link  202 at Tue Aug  4 10:42:02 2020, MaxMem=    33554432 cpu:         0.0
+ (Enter /cluster/apps/gaussian/g09/l601.exe)
+ Copying SCF densities to generalized density rwf, IOpCl= 0 IROHF=0.
+
+ **********************************************************************
+
+            Population analysis using the SCF density.
+
+ **********************************************************************
+
+ Orbital symmetries:
+       Occupied  (B) (A) (B) (A) (B) (A) (A) (B) (B) (A) (B) (A)
+                 (B) (A) (B) (A) (B) (A) (B) (A) (B) (A) (B) (A)
+                 (B) (A) (B) (A) (B) (A) (B) (A) (B) (A) (B) (A)
+                 (B) (A) (A) (B) (B) (A) (A) (B) (B) (A) (A) (B)
+                 (B) (A) (A) (B) (A) (B) (A) (B) (A) (B) (B) (A)
+                 (B) (A) (A) (B) (B) (A) (A) (B) (B) (A) (B) (A)
+                 (B) (A) (A) (B) (B) (A) (A) (B) (A) (A) (B) (B)
+                 (A) (B) (A) (B) (A) (A) (B) (B) (B) (A) (A) (B)
+                 (A) (B) (B) (A) (B) (A) (B) (A) (A) (B) (A) (B)
+                 (A) (B) (B) (A) (B) (A) (A) (A) (B) (A) (B) (B)
+                 (B) (A) (B) (A) (B) (B) (A) (B) (A) (A) (B) (A)
+                 (B) (A) (B) (A) (B) (A) (A) (B) (A) (B) (B) (A)
+                 (A) (B) (B) (A) (B) (A) (A) (B) (B)
+       Virtual   (A) (B) (A) (A) (B) (B) (A) (A) (B) (B) (A) (B)
+                 (A) (A) (B) (A) (A) (B) (B) (A) (B) (B) (A) (A)
+                 (B) (A) (B) (A) (B) (A) (B) (B) (A) (A) (B) (B)
+                 (A) (A) (B) (B) (A) (B) (A) (A) (B) (A) (B) (A)
+                 (B) (A) (B) (A) (B) (A) (B) (A) (B) (A) (B) (A)
+                 (B) (A) (B) (B) (A) (B) (B) (A) (A) (A) (B) (A)
+                 (B) (B) (A) (A) (A) (B) (B) (B) (A) (B) (A) (B)
+                 (B) (A) (A) (A) (A) (B) (B) (B) (A) (A) (B) (A)
+                 (B) (A) (B) (A) (B) (B) (A)
+ The electronic state is 1-A.
+ Alpha  occ. eigenvalues --  -14.20408 -14.20408 -14.20406 -14.20406 -10.07124
+ Alpha  occ. eigenvalues --  -10.07124 -10.07034 -10.07034 -10.06984 -10.06984
+ Alpha  occ. eigenvalues --  -10.06890 -10.06890 -10.01554 -10.01554 -10.01469
+ Alpha  occ. eigenvalues --  -10.01469 -10.01246 -10.01246 -10.01154 -10.01154
+ Alpha  occ. eigenvalues --  -10.00674 -10.00669 -10.00582 -10.00577 -10.00191
+ Alpha  occ. eigenvalues --  -10.00191 -10.00185 -10.00185  -9.99926  -9.99926
+ Alpha  occ. eigenvalues --   -9.99890  -9.99890  -9.99859  -9.99859  -9.99809
+ Alpha  occ. eigenvalues --   -9.99809  -9.99588  -9.99588  -9.99581  -9.99581
+ Alpha  occ. eigenvalues --   -9.98980  -9.98980  -9.98975  -9.98973  -9.98972
+ Alpha  occ. eigenvalues --   -9.98963  -0.92539  -0.92539  -0.87662  -0.87662
+ Alpha  occ. eigenvalues --   -0.82131  -0.81889  -0.81189  -0.80233  -0.78720
+ Alpha  occ. eigenvalues --   -0.77118  -0.75688  -0.73834  -0.73033  -0.72686
+ Alpha  occ. eigenvalues --   -0.72037  -0.71377  -0.71247  -0.69753  -0.68825
+ Alpha  occ. eigenvalues --   -0.67972  -0.67216  -0.66760  -0.65829  -0.65340
+ Alpha  occ. eigenvalues --   -0.62680  -0.61748  -0.60579  -0.59107  -0.58015
+ Alpha  occ. eigenvalues --   -0.56984  -0.56549  -0.55029  -0.54906  -0.54861
+ Alpha  occ. eigenvalues --   -0.54002  -0.53746  -0.53681  -0.51220  -0.49008
+ Alpha  occ. eigenvalues --   -0.48792  -0.48581  -0.48461  -0.48456  -0.48065
+ Alpha  occ. eigenvalues --   -0.47921  -0.45229  -0.45150  -0.45056  -0.43446
+ Alpha  occ. eigenvalues --   -0.42959  -0.41839  -0.40984  -0.40432  -0.40431
+ Alpha  occ. eigenvalues --   -0.40059  -0.39811  -0.39521  -0.39513  -0.38760
+ Alpha  occ. eigenvalues --   -0.38160  -0.37976  -0.37965  -0.37829  -0.37749
+ Alpha  occ. eigenvalues --   -0.36615  -0.36602  -0.36502  -0.36057  -0.35839
+ Alpha  occ. eigenvalues --   -0.35455  -0.35334  -0.33844  -0.33733  -0.33385
+ Alpha  occ. eigenvalues --   -0.33154  -0.33036  -0.32416  -0.32131  -0.31948
+ Alpha  occ. eigenvalues --   -0.30537  -0.30264  -0.29572  -0.29567  -0.29534
+ Alpha  occ. eigenvalues --   -0.29230  -0.28792  -0.28290  -0.28290  -0.27879
+ Alpha  occ. eigenvalues --   -0.27168  -0.26919  -0.26159  -0.24173  -0.23745
+ Alpha  occ. eigenvalues --   -0.22676  -0.21876  -0.21220  -0.20734  -0.19756
+ Alpha  occ. eigenvalues --   -0.18342  -0.17762  -0.15697  -0.14225  -0.12534
+ Alpha  occ. eigenvalues --   -0.11010  -0.10091  -0.09066
+ Alpha virt. eigenvalues --    0.00349   0.04270   0.05336   0.06493   0.06700
+ Alpha virt. eigenvalues --    0.07728   0.09690   0.10546   0.12998   0.13346
+ Alpha virt. eigenvalues --    0.13513   0.14492   0.17058   0.17248   0.19488
+ Alpha virt. eigenvalues --    0.21075   0.24026   0.24094   0.24687   0.28554
+ Alpha virt. eigenvalues --    0.29212   0.29525   0.29691   0.29811   0.30894
+ Alpha virt. eigenvalues --    0.31216   0.32377   0.33947   0.34007   0.34234
+ Alpha virt. eigenvalues --    0.34463   0.34561   0.35867   0.36495   0.36512
+ Alpha virt. eigenvalues --    0.37040   0.37975   0.38214   0.38945   0.39375
+ Alpha virt. eigenvalues --    0.40010   0.40342   0.40388   0.40635   0.40847
+ Alpha virt. eigenvalues --    0.41581   0.42569   0.42732   0.43484   0.43487
+ Alpha virt. eigenvalues --    0.44127   0.44186   0.44253   0.44950   0.45231
+ Alpha virt. eigenvalues --    0.45832   0.45959   0.46019   0.46353   0.47681
+ Alpha virt. eigenvalues --    0.47908   0.47999   0.49309   0.50932   0.51708
+ Alpha virt. eigenvalues --    0.53089   0.53362   0.53401   0.54807   0.55303
+ Alpha virt. eigenvalues --    0.55548   0.56587   0.56700   0.56818   0.57417
+ Alpha virt. eigenvalues --    0.58405   0.60690   0.61661   0.61994   0.62375
+ Alpha virt. eigenvalues --    0.63237   0.63638   0.64166   0.64403   0.65405
+ Alpha virt. eigenvalues --    0.65841   0.67022   0.68068   0.68224   0.68773
+ Alpha virt. eigenvalues --    0.69180   0.69975   0.70387   0.72876   0.73939
+ Alpha virt. eigenvalues --    0.77624   0.79170   0.79811   0.80695   0.80741
+ Alpha virt. eigenvalues --    0.81014   0.82582   0.83035
+          Condensed to atoms (all electrons):
+ Mulliken charges:
+               1
+     1  C   -0.083081
+     2  C   -0.083081
+     3  C   -0.080604
+     4  C   -0.005788
+     5  C   -0.005788
+     6  C   -0.080604
+     7  C   -0.098845
+     8  C    0.082673
+     9  C    0.082673
+    10  C   -0.098845
+    11  N   -0.284405
+    12  C    0.083617
+    13  C    0.083617
+    14  N   -0.284405
+    15  C   -0.102431
+    16  C   -0.005660
+    17  C   -0.005660
+    18  C   -0.102431
+    19  C   -0.082291
+    20  C   -0.008171
+    21  C   -0.008171
+    22  C   -0.082291
+    23  C   -0.079744
+    24  C   -0.008171
+    25  C   -0.008171
+    26  C   -0.079744
+    27  C   -0.082291
+    28  C   -0.005660
+    29  C   -0.005660
+    30  C   -0.082291
+    31  C   -0.102431
+    32  C    0.083617
+    33  C    0.083617
+    34  C   -0.102431
+    35  N   -0.284405
+    36  C    0.082673
+    37  C    0.082673
+    38  N   -0.284405
+    39  C   -0.098845
+    40  C   -0.005788
+    41  C   -0.005788
+    42  C   -0.098845
+    43  C   -0.080604
+    44  C   -0.083081
+    45  C   -0.083081
+    46  C   -0.080604
+    47  H    0.076803
+    48  H    0.076803
+    49  H    0.074687
+    50  H    0.074687
+    51  H    0.073274
+    52  H    0.073274
+    53  H    0.071794
+    54  H    0.071794
+    55  H    0.071798
+    56  H    0.072583
+    57  H    0.071798
+    58  H    0.071794
+    59  H    0.073274
+    60  H    0.073274
+    61  H    0.074687
+    62  H    0.076803
+    63  H    0.076803
+    64  H    0.074687
+    65  H    0.071798
+    66  H    0.071798
+    67  H    0.072583
+    68  H    0.071794
+    69  H    0.220211
+    70  H    0.220211
+    71  H    0.220211
+    72  H    0.220211
+ Sum of Mulliken charges =   0.00000
+ Mulliken charges with hydrogens summed into heavy atoms:
+               1
+     1  C   -0.006278
+     2  C   -0.006278
+     3  C   -0.005916
+     4  C   -0.005788
+     5  C   -0.005788
+     6  C   -0.005916
+     7  C   -0.025571
+     8  C    0.082673
+     9  C    0.082673
+    10  C   -0.025571
+    11  N   -0.064194
+    12  C    0.083617
+    13  C    0.083617
+    14  N   -0.064194
+    15  C   -0.030638
+    16  C   -0.005660
+    17  C   -0.005660
+    18  C   -0.030638
+    19  C   -0.010493
+    20  C   -0.008171
+    21  C   -0.008171
+    22  C   -0.010493
+    23  C   -0.007161
+    24  C   -0.008171
+    25  C   -0.008171
+    26  C   -0.007161
+    27  C   -0.010493
+    28  C   -0.005660
+    29  C   -0.005660
+    30  C   -0.010493
+    31  C   -0.030638
+    32  C    0.083617
+    33  C    0.083617
+    34  C   -0.030638
+    35  N   -0.064194
+    36  C    0.082673
+    37  C    0.082673
+    38  N   -0.064194
+    39  C   -0.025571
+    40  C   -0.005788
+    41  C   -0.005788
+    42  C   -0.025571
+    43  C   -0.005916
+    44  C   -0.006278
+    45  C   -0.006278
+    46  C   -0.005916
+ Electronic spatial extent (au):  <R**2>=          77944.9288
+ Charge=              0.0000 electrons
+ Dipole moment (field-independent basis, Debye):
+    X=              0.0000    Y=              0.0000    Z=              0.0006  Tot=              0.0006
+ Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=           -232.6105   YY=           -207.3624   ZZ=           -253.7126
+   XY=              0.0000   XZ=              0.0000   YZ=              0.0000
+ Traceless Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=             -1.3820   YY=             23.8661   ZZ=            -22.4841
+   XY=              0.0000   XZ=              0.0000   YZ=              0.0000
+ Octapole moment (field-independent basis, Debye-Ang**2):
+  XXX=              0.0000  YYY=              0.0000  ZZZ=             -0.0017  XYY=              0.0000
+  XXY=              0.0000  XXZ=              0.0436  XZZ=              0.0000  YZZ=              0.0000
+  YYZ=             -0.0002  XYZ=              0.0004
+ Hexadecapole moment (field-independent basis, Debye-Ang**3):
+ XXXX=        -100076.3518 YYYY=          -2117.6285 ZZZZ=           -203.1417 XXXY=              0.0001
+ XXXZ=              0.0000 YYYX=              0.0001 YYYZ=              0.0000 ZZZX=              0.0000
+ ZZZY=              0.0000 XXYY=         -14976.3590 XXZZ=         -17683.0360 YYZZ=           -472.1871
+ XXYZ=              0.0000 YYXZ=              0.0000 ZZXY=              0.0000
+ N-N= 4.276303176586D+03 E-N=-1.275105115549D+04  KE= 1.779405659201D+03
+ Symmetry A    KE= 8.878614587945D+02
+ Symmetry B    KE= 8.915442004063D+02
+ No NMR shielding tensors so no spin-rotation constants.
+ Leave Link  601 at Tue Aug  4 10:42:03 2020, MaxMem=    33554432 cpu:         0.2
+ (Enter /cluster/apps/gaussian/g09/l9999.exe)
+ 1\1\GINC-EU-MS-002-31\FOpt\RB3LYP\STO-3G\C42H26N4\CARLOP\04-Aug-2020\0
+ \\#p b3lyp/sto-3g scf=(maxcycle=2048,cdiis,conver=7) opt\\acene-nh\\0,
+ 1\C,21.3570675441,8.2150343245,5.0676285493\C,21.3570681776,6.78491429
+ 67,5.0676284231\C,22.5557972171,8.9168114895,5.0675093572\C,23.8157152
+ 182,8.2235917504,5.0673833853\C,23.8157158595,6.7763590465,5.067383260
+ 7\C,22.5557984733,6.0831381917,5.0675091152\C,25.073594921,6.075917419
+ 2,5.0672579335\C,26.2791877777,6.7712485978,5.0671330756\C,26.27918712
+ 83,8.2287043754,5.0671336513\C,25.0735936602,8.9240344905,5.0672586694
+ \N,27.5403892523,8.8965006619,5.0669804694\C,28.8058278978,8.237170728
+ 6,5.0670168094\C,28.8058285522,6.7627844833,5.067016319\N,27.540390487
+ 2,6.1034534303,5.066975958\C,29.9999589275,6.0688792115,5.0670298105\C
+ ,31.2781183731,6.7635914975,5.067036655\C,31.2781177203,8.2363658907,5
+ .0670366131\C,29.9999576646,8.9310770503,5.0670303091\C,32.499509937,8
+ .9245109438,5.0670426545\C,33.7594401894,8.2350681117,5.0670465584\C,3
+ 3.75944084,6.7648914652,5.0670465735\C,32.4995111934,6.0754475229,5.06
+ 70427187\C,35.0000004579,6.0754819245,5.0670478375\C,36.2405594642,6.7
+ 648925615,5.0670465584\C,36.2405588136,8.235069208,5.0670465735\C,34.9
+ 999991957,8.9244787487,5.0670478375\C,37.5004884602,8.9245131503,5.067
+ 0427187\C,38.7218812805,8.2363691757,5.067036655\C,38.7218819333,6.763
+ 5947825,5.0670366131\C,37.5004897166,6.0754497294,5.0670426545\C,40.00
+ 0041989,6.0688836229,5.0670303091\C,41.1941717558,6.7627899446,5.06701
+ 68094\C,41.1941711014,8.2371761899,5.067016319\C,40.0000407261,8.93108
+ 14617,5.0670298105\N,42.4596091664,8.8965072429,5.066975958\C,43.72081
+ 18759,8.2287120754,5.0671330756\C,43.7208125253,6.7712562978,5.0671336
+ 513\N,42.4596104013,6.1034600113,5.0669804694\C,44.9264059934,6.075926
+ 1827,5.0672586694\C,46.1842844354,6.7763689228,5.0673833853\C,46.18428
+ 37941,8.2236016267,5.0673832607\C,44.9264047325,8.924043254,5.06725793
+ 35\C,47.4442011803,8.9168224815,5.0675091152\C,48.642931476,8.21504637
+ 65,5.0676284231\C,48.6429321095,6.7849263487,5.0676285493\C,47.4442024
+ 365,6.0831491837,5.0675093572\H,20.4011984659,8.7554919788,5.067723831
+ 2\H,20.40119958,6.2444557925,5.0677235962\H,22.5585680002,10.015094733
+ 4,5.067509118\H,22.5585702284,4.9848549505,5.0675086417\H,25.080426108
+ 9,4.9788512096,5.0672579831\H,25.0804238777,10.0211007059,5.0672596119
+ \H,29.9920427359,4.9720842487,5.0670311688\H,29.9920405066,10.02787200
+ 59,5.0670325192\H,32.5006929136,4.9773236811,5.0670423748\H,34.9999987
+ 092,10.022873093,5.0670475411\H,37.4993089694,4.9773258869,5.067042325
+ \H,40.0079569177,10.0278764245,5.0670311688\H,44.9195757759,4.97885996
+ 73,5.0672596119\H,44.9195735447,10.0211094636,5.0672579831\H,47.441429
+ 4252,10.0151057227,5.0675086417\H,49.5988000736,8.7555048807,5.0677235
+ 962\H,49.5988011877,6.2444686944,5.0677238312\H,47.4414316534,4.984865
+ 9398,5.067509118\H,32.5006906842,10.0226347863,5.067042325\H,37.499306
+ 74,10.0226369921,5.0670423748\H,35.0000009444,4.9770875802,5.067047541
+ 1\H,40.007959147,4.9720886673,5.0670325192\H,27.5374822864,9.937214085
+ 6,5.0670481102\H,42.4625152083,9.9372206677,5.0670514792\H,27.53748444
+ 53,5.0627400055,5.0670514792\H,42.4625173672,5.0627465876,5.0670481102
+ \\Version=ES64L-G09RevD.01\State=1-A\HF=-1812.5839967\RMSD=5.819e-08\R
+ MSF=3.168e-05\Dipole=0.,0.,0.0002169\Quadrupole=-1.02747,17.7438784,-1
+ 6.7164084,-0.0000084,0.,0.\PG=C02 [X(C42H26N4)]\\@
+
+
+ I KNOW YOU BELIEVE YOU UNDERSTAND WHAT YOU THINK I SAID,
+ BUT I AM NOT SURE YOU REALIZE THAT WHAT YOU HEARD IS NOT WHAT I MEANT.
+ Job cpu time:       0 days  0 hours  3 minutes 44.3 seconds.
+ File lengths (MBytes):  RWF=     48 Int=      0 D2E=      0 Chk=     10 Scr=      1
+ Normal termination of Gaussian 09 at Tue Aug  4 10:42:03 2020.


### PR DESCRIPTION
Hi pymatgen community!

In gaussian log, there are geometries outputted either in "standard" or "input" orientation or both together. The current implementation assumed that "input orientation" is always outputted but that is not the case (try e.g. [g.txt](https://github.com/materialsproject/pymatgen/files/5019019/g.txt)) and I was getting an error.

I modified the code such that by default, if it's there, the `opt_structure` will be of "standard orientation" and otherwise "input orientation". This is reflected by the `standard_orientation` boolean attribute and the same convention was already used for the `structures` attribute.

Previous version was mainly modified by @gVallverdu, so ping to you in case you're curious.