### PR TITLE
Make clean=True default in Compatibility.process_entries()

### DIFF
--- a/pymatgen/entries/compatibility.py
+++ b/pymatgen/entries/compatibility.py
@@ -455,7 +455,7 @@ class Compatibility(MSONable, metaclass=abc.ABCMeta):
         else:
             return None
 
-    def process_entries(self, entries: Union[ComputedEntry, list], clean: bool = False):
+    def process_entries(self, entries: Union[ComputedEntry, list], clean: bool = True):
         """
         Process a sequence of entries with the chosen Compatibility scheme.
 
@@ -463,7 +463,7 @@ class Compatibility(MSONable, metaclass=abc.ABCMeta):
             entries: ComputedEntry or [ComputedEntry]
             clean: bool, whether to remove any previously-applied energy adjustments.
                 If True, all EnergyAdjustment are removed prior to processing the Entry.
-                Default is False.
+                Default is True.
 
         Returns:
             A list of adjusted entries.  Entries in the original list which

--- a/pymatgen/entries/compatibility.py
+++ b/pymatgen/entries/compatibility.py
@@ -469,7 +469,7 @@ class Compatibility(MSONable, metaclass=abc.ABCMeta):
 
         for entry in entries:
             ignore_entry = False
-            # if clean is True, remove all previous adjustments, other than Manual adjustments, from the entry
+            # if clean is True, remove all previous adjustments from the entry
             if clean:
                 for ea in entry.energy_adjustments:
                     entry.energy_adjustments.remove(ea)
@@ -508,6 +508,7 @@ class Compatibility(MSONable, metaclass=abc.ABCMeta):
 
         return processed_entry_list
 
+    @staticmethod
     def explain(self, entry):
         """
         Prints an explanation of the energy adjustments applied by the
@@ -989,4 +990,4 @@ class MaterialsProjectAqueousCompatibility(Compatibility):
                 self.h2o_energy = h2o_entries[0].energy_per_atom
                 self.h2o_adjustments = h2o_entries[0].correction / h2o_entries[0].composition.num_atoms
 
-        return super().process_entries(entries)
+        return super().process_entries(entries, clean=clean)

--- a/pymatgen/entries/compatibility.py
+++ b/pymatgen/entries/compatibility.py
@@ -111,21 +111,19 @@ class PotcarCorrection(Correction):
             CombatibilityError if wrong potcar symbols
         """
         potcar_settings = input_set.CONFIG["POTCAR"]
-        if isinstance(list(potcar_settings.values())[-1],
-                      dict):
+        if isinstance(list(potcar_settings.values())[-1], dict):
             if check_hash:
-                self.valid_potcars = {k: d["hash"] for k, d in
-                                      potcar_settings.items()}
+                self.valid_potcars = {k: d["hash"] for k, d in potcar_settings.items()}
             else:
-                self.valid_potcars = {k: d["symbol"] for k, d in
-                                      potcar_settings.items()}
+                self.valid_potcars = {
+                    k: d["symbol"] for k, d in potcar_settings.items()
+                }
         else:
             if check_hash:
-                raise ValueError('Cannot check hashes of potcars,'
-                                 ' hashes are not set')
-            else:
-                self.valid_potcars = {k: d for k, d in
-                                      potcar_settings.items()}
+                raise ValueError(
+                    "Cannot check hashes of potcars, since hashes are not included in the entry."
+                )
+            self.valid_potcars = potcar_settings
 
         self.input_set = input_set
         self.check_hash = check_hash
@@ -137,25 +135,19 @@ class PotcarCorrection(Correction):
         """
         if self.check_hash:
             if entry.parameters.get("potcar_spec"):
-                psp_settings = set([d.get("hash")
-                                    for d in entry.parameters[
-                                        "potcar_spec"] if d])
+                psp_settings = {d.get("hash") for d in entry.parameters["potcar_spec"] if d}
             else:
-                raise ValueError('Cannot check hash '
-                                 'without potcar_spec field')
+                raise ValueError("Cannot check hash without potcar_spec field")
         else:
             if entry.parameters.get("potcar_spec"):
-                psp_settings = set([d.get("titel").split()[1]
-                                    for d in entry.parameters[
-                                        "potcar_spec"] if d])
+                psp_settings = {d.get("titel").split()[1] for d in entry.parameters["potcar_spec"] if d}
             else:
-                psp_settings = set([sym.split()[1]
-                                    for sym in entry.parameters[
-                                        "potcar_symbols"] if sym])
+                psp_settings = {sym.split()[1] for sym in entry.parameters["potcar_symbols"] if sym}
 
-        if {self.valid_potcars.get(str(el))
-                for el in entry.composition.elements} != psp_settings:
-            raise CompatibilityError('Incompatible potcar')
+        if {
+            self.valid_potcars.get(str(el)) for el in entry.composition.elements
+        } != psp_settings:
+            raise CompatibilityError("Incompatible potcar")
         return 0
 
     def __str__(self):

--- a/pymatgen/entries/compatibility.py
+++ b/pymatgen/entries/compatibility.py
@@ -444,8 +444,7 @@ class Compatibility(MSONable, metaclass=abc.ABCMeta):
         """
         if self.process_entries(entry):
             return self.process_entries(entry)[0]
-        else:
-            return None
+        return None
 
     def process_entries(self, entries: Union[ComputedEntry, list], clean: bool = True):
         """

--- a/pymatgen/entries/tests/test_compatibility.py
+++ b/pymatgen/entries/tests/test_compatibility.py
@@ -61,9 +61,9 @@ def test_clean_arg():
     compat = DummyCompatibility()
 
     assert entry.correction == -4
-    compat.process_entries(entry)
+    compat.process_entries(entry, clean=False)
     assert entry.correction == -14
-    compat.process_entries(entry, clean=True)
+    compat.process_entries(entry)
     assert entry.correction == -10
 
 
@@ -73,14 +73,17 @@ def test_energy_adjustment_normalize():
     by the normalize method
     """
     entry = ComputedEntry("Fe4O6", -2, correction=-4)
-    compat = DummyCompatibility()
-    entry = compat.process_entries(entry)[0]
     entry.normalize()
-    assert entry.correction == -7
     for ea in entry.energy_adjustments:
         if "Manual" in ea.name:
             assert ea.value == -2
-        elif "Dummy" in ea.name:
+
+    compat = DummyCompatibility()
+    entry = ComputedEntry("Fe4O6", -2, correction=-4)
+    entry = compat.process_entries(entry)[0]
+    entry.normalize()
+    for ea in entry.energy_adjustments:
+        if "Dummy" in ea.name:
             assert ea.value == -5
 
 
@@ -98,7 +101,7 @@ def test_overlapping_adjustments():
 
     # in case of a collision between EnergyAdjustment, check for a UserWarning
     with pytest.warns(UserWarning, match="already has an energy adjustment called Dummy"):
-        processed = compat.process_entries(entry)
+        processed = compat.process_entries(entry, clean=False)
 
     assert len(processed) == 0
 


### PR DESCRIPTION
The new Compatibility interface (see #1826) provides a boolean `clean` argument to `process_entries` that determines whether or not previously-applied corrections are discarded when `process_entries` is called. We set this to `False` by default, but this has proven to be a bad choice. Myself, @shyamd and @awvio have all made errors using the new `process_entries()` because repeated calls to `process_entries` resulted in corrections being applied multiple times (contrary to our expectations). 

This PR changes the default to `True` so that corrections will only be applied one time by default, even if `process_entries` is called multiple times on the same entry.
