### PR TITLE
Allow BabelMolAdaptor to convert IMolecules

### DIFF
--- a/pymatgen/io/babel.py
+++ b/pymatgen/io/babel.py
@@ -14,7 +14,7 @@ import copy
 
 from monty.dev import requires
 
-from pymatgen.core.structure import Molecule
+from pymatgen.core.structure import Molecule, IMolecule
 
 try:
     from openbabel import openbabel as ob
@@ -46,9 +46,9 @@ class BabelMolAdaptor:
         Initializes with pymatgen Molecule or OpenBabel"s OBMol.
 
         Args:
-            mol: pymatgen's Molecule or OpenBabel OBMol
+            mol: pymatgen's Molecule/IMolecule or OpenBabel OBMol
         """
-        if isinstance(mol, Molecule):
+        if isinstance(mol, IMolecule):
             if not mol.is_ordered:
                 raise ValueError("OpenBabel Molecule only supports ordered "
                                  "molecules.")


### PR DESCRIPTION
## Summary

Instead of checking whether supplied objects are instances of ``Molecule``, ``BabelMolAdaptor`` now checks whether they are ``IMolecule``s instead (which is a superclass of ``Molecule`` so the old check still works). This fixes #1923.

## Checklist

Work-in-progress pull requests are encouraged, but please put [WIP]
in the pull request title.

Before a pull request can be merged, the following items must be checked:

- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). 
      Run [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/) and [flake8](http://flake8.pycqa.org/en/latest/)
      on your local machine.
- [x] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [x] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) 
      to type check your code.
- [x] Tests have been added for any new functionality or bug fixes.
- [ ] All existing tests pass.

Note that the CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR. It is
highly recommended that you use the pre-commit hook provided in the pymatgen 
repository. Simply `cp pre-commit .git/hooks` and a check will be run prior to
allowing commits.
