### PR TITLE
simplify cleaning of EnergyAdjustment

### DIFF
--- a/pymatgen/entries/compatibility.py
+++ b/pymatgen/entries/compatibility.py
@@ -472,8 +472,7 @@ class Compatibility(MSONable, metaclass=abc.ABCMeta):
             ignore_entry = False
             # if clean is True, remove all previous adjustments from the entry
             if clean:
-                for ea in entry.energy_adjustments:
-                    entry.energy_adjustments.remove(ea)
+                entry.energy_adjustments = []
 
             # get the energy adjustments
             try:


### PR DESCRIPTION
Replaces the code that removes previous `EnergyAdjustment` from `ComputedEntry` with a more robust alternative. See #1922 