### PR TITLE
fix valence bug, add test

### DIFF
--- a/pymatgen/core/periodic_table.py
+++ b/pymatgen/core/periodic_table.py
@@ -653,9 +653,13 @@ class Element(Enum):
         L_symbols = 'SPDFGHIKLMNOQRTUVWXYZ'
         valence = []
         full_electron_config = self.full_electronic_structure
-        for _, l_symbol, ne in full_electron_config[::-1]:
+        last_orbital = full_electron_config[-1]
+        for n, l_symbol, ne in full_electron_config:
             l = L_symbols.lower().index(l_symbol)
             if ne < (2 * l + 1) * 2:
+                valence.append((l, ne))
+            # check for full last shell (e.g. column 2)
+            elif (n, l_symbol, ne) == last_orbital and ne == (2 * l + 1) * 2 and len(valence) == 0:
                 valence.append((l, ne))
         if len(valence) > 1:
             raise ValueError("Ambiguous valence")

--- a/pymatgen/core/tests/test_periodic_table.py
+++ b/pymatgen/core/tests/test_periodic_table.py
@@ -68,7 +68,8 @@ class ElementTestCase(PymatgenTest):
     def test_valence(self):
         testsets = {"O": (1, 4),
                     "Fe": (2, 6),
-                    "Li": (0, 1)}
+                    "Li": (0, 1),
+                    "Be": (0, 2)}
         for k, v in testsets.items():
             self.assertEqual(Element(k).valence, v)
 


### PR DESCRIPTION
Previously, asking for the valence property on an Element with full shells that wasn't noble (e.g. column 2 or 12) would cause an error. This resolves that.

## Summary

Include a summary of major changes in bullet points:

* Added a check for if the last orbital listed is fully-occupied and to choose that number as the valency
* Added a case to the tests to trigger this

## Additional dependencies introduced (if any)
none

## Checklist

Before a pull request can be merged, the following items must be checked:

- [ x ] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). 
      Run [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/) and [flake8](http://flake8.pycqa.org/en/latest/)
      on your local machine.
- [ x ] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [ x ] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) 
      to type check your code.
- [ x ] Tests have been added for any new functionality or bug fixes.
- [ ? ] All existing tests pass. --> I ran the test_periodic_table.py manually, but nosetests continually hangs after 1089 tests. I installed all dependencies (including optional and dev ones) in my environment so I'm not sure what the issue is with that, but I can't imagine what this would break that's not covered by the test I checked.