### PR TITLE
Fix type of reciprocal lattice in KPathSeek

### DIFF
--- a/pymatgen/symmetry/kpath.py
+++ b/pymatgen/symmetry/kpath.py
@@ -20,6 +20,7 @@ import spglib
 from monty.dev import requires
 
 from pymatgen.core.operations import SymmOp, MagSymmOp
+from pymatgen.core.lattice import Lattice
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 
 try:
@@ -963,7 +964,7 @@ class KPathSeek(KPathBase):
         spath_dat = get_path(spg_struct, system_is_tri, "hpkot", atol, symprec, angle_tolerance)
 
         self._tmat = self._trans_sc_to_Hin(spath_dat["bravais_lattice_extended"])
-        self._rec_lattice = spath_dat["reciprocal_primitive_lattice"]
+        self._rec_lattice = Lattice(spath_dat["reciprocal_primitive_lattice"])
 
         spath_data_formatted = [[spath_dat["path"][0][0]]]
         count = 0

--- a/pymatgen/symmetry/tests/test_kpath_hin.py
+++ b/pymatgen/symmetry/tests/test_kpath_hin.py
@@ -52,6 +52,7 @@ class KPathSeekTest(PymatgenTest):
 
             struct = Structure.from_spacegroup(sg_num, lattice, species, coords)
             kpath = KPathSeek(struct)  # Throws error if something doesn't work, causing test to fail.
+            kpoints = kpath.get_kpoints()  # noqa: F841
 
     @unittest.skipIf(get_path is None, "No seek path present.")
     def test_kpath_acentered(self):


### PR DESCRIPTION
## Summary

The abstract class of KPathSeek, KPathBase, expects a type of a reciprocal lattice as `pymatgen.core.lattice.Lattice`. This tiny PR fixes to cast a reciprocal lattice returned by `seekpath` into pymatgen's lattice class.

## Checklist

Before a pull request can be merged, the following items must be checked:

- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). 
      Run [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/) and [flake8](http://flake8.pycqa.org/en/latest/)
      on your local machine.
- [ ] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [ ] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) 
      to type check your code.
- [x] Tests have been added for any new functionality or bug fixes.
- [ ] All existing tests pass.
