### PR TITLE
fix saving _acc_factor instead of _accf

### DIFF
--- a/pymatgen/analysis/ewald.py
+++ b/pymatgen/analysis/ewald.py
@@ -458,7 +458,7 @@ class EwaldSummation(MSONable):
             "structure": self._s.as_dict(),
             "compute_forces": self._compute_forces,
             "eta": self._eta,
-            "acc_factor": self._accf,
+            "acc_factor": self._acc_factor,
             "real_space_cut": self._rmax,
             "recip_space_cut": self._gmax,
             "_recip": None if self._recip is None else self._recip.tolist(),

--- a/pymatgen/analysis/tests/test_ewald.py
+++ b/pymatgen/analysis/tests/test_ewald.py
@@ -88,9 +88,11 @@ class EwaldSummationTest(unittest.TestCase):
         d = ham.as_dict()
         self.assertTrue(d["compute_forces"])
         self.assertEqual(d["eta"], ham._eta)
-        self.assertEqual(d["acc_factor"], ham._accf)
+        self.assertEqual(d["acc_factor"], ham._acc_factor)
         self.assertEqual(d["real_space_cut"], ham._rmax)
         self.assertEqual(d["recip_space_cut"], ham._gmax)
+        self.assertEqual(ham.as_dict(),
+                         EwaldSummation.from_dict(d).as_dict())
 
 
 class EwaldMinimizerTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
Fix `as_dict` in EwaldSummation to save `_acc_factor` and not `_accf`, to recreate the exact object as before. Previous tests did not catch this since the actual Ewald summation values remained within numerical tolerance (my bad for not catching this before).

## Checklist

Before a pull request can be merged, the following items must be checked:

- [X] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). 
      Run [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/) and [flake8](http://flake8.pycqa.org/en/latest/)
      on your local machine.
- [X] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [ ] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) 
      to type check your code.
- [X] Tests have been added for any new functionality or bug fixes.
- [ ] All existing tests pass. pylint is failing, not sure why.

Note that the CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR. It is
highly recommended that you use the pre-commit hook provided in the pymatgen 
repository. Simply `cp pre-commit .git/hooks` and a check will be run prior to
allowing commits.
