### PR TITLE
bugfix in surface and composition

### DIFF
--- a/pymatgen/core/composition.py
+++ b/pymatgen/core/composition.py
@@ -662,13 +662,13 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable):
         return d
 
     @property
-    def to_reduced_dict(self):
+    def to_reduced_dict(self) -> dict:
         """
         Returns:
             Dict with element symbol and reduced amount e.g.,
             {"Fe": 2.0, "O":3.0}
         """
-        return self.get_reduced_composition_and_factor()[0]
+        return self.get_reduced_composition_and_factor()[0].as_dict()
 
     @property
     def to_data_dict(self):

--- a/pymatgen/core/ion.py
+++ b/pymatgen/core/ion.py
@@ -167,7 +167,7 @@ class Ion(Composition, MSONable):
             dict with element symbol and reduced amount e.g.,
             {"Fe": 2.0, "O":3.0}.
         """
-        d = self.composition.to_reduced_dict.as_dict()
+        d = self.composition.to_reduced_dict
         d['charge'] = self.charge
         return d
 

--- a/pymatgen/core/surface.py
+++ b/pymatgen/core/surface.py
@@ -139,10 +139,14 @@ class Slab(Structure):
         self.scale_factor = np.array(scale_factor)
         self.energy = energy
         self.reorient_lattice = reorient_lattice
-        lattice = Lattice.from_parameters(lattice.a, lattice.b, lattice.c,
-                                          lattice.alpha, lattice.beta,
-                                          lattice.gamma) \
-            if self.reorient_lattice else lattice
+        if self.reorient_lattice:
+            if coords_are_cartesian:
+                coords = lattice.get_fractional_coords(coords)
+                coords_are_cartesian = False
+            lattice = Lattice.from_parameters(lattice.a, lattice.b, lattice.c,
+                                              lattice.alpha, lattice.beta,
+                                              lattice.gamma)
+
         super().__init__(
             lattice, species, coords, validate_proximity=validate_proximity,
             to_unit_cell=to_unit_cell,


### PR DESCRIPTION
## Summary

Two bug fixes:

* with the current implementation the Surface object can get weird results when instantiating with `reorient_lattice=True `and `coords_are_cartesian=True`. Fixed by switching to frac coords when needed.
* after dec6ecb6a9a80dbd4bfdfb924040cdfc7fe4ebb3 `Composition.to_reduced_dict` is not returning a dict but a Composition instance. 