### PR TITLE
[WIP] Jsmol viewer for jupyter notebook

### DIFF
--- a/pymatgen/vis/structure_jsmol.py
+++ b/pymatgen/vis/structure_jsmol.py
@@ -1,11 +1,5 @@
+"""Visualization for structures using jupyter-jsmol.
 """
-Visualization for structures using jupyter-jsmol.
-"""
-
-import numpy as np
-from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
-from pymatgen.analysis.molecule_structure_comparator import CovalentRadius
-from monty.dev import requires
 
 try:
     from jupyter_jsmol import JsmolView
@@ -13,18 +7,23 @@ try:
 except ImportError:
     jupyter_jsmol_loaded = False
 
+from monty.dev import requires
+
+from pymatgen import Structure
+from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
+
 
 @requires(jupyter_jsmol_loaded, "To use quick_view, you need to have jupyter_jsmol installed.")
-def quick_view(structure, conventional=False, transform=None, show_box=True):
-    """
-    A function to visualize pymatgen Structure objects in jupyter notebook using chemview package.
+def quick_view(structure: Structure, conventional: bool = False, transform: list = None) -> JsmolView:
+    """A function to visualize pymatgen Structure objects in jupyter notebook using jupyter_jsmol package.
 
     Args:
-        structure: pymatgen Structure
-        conventional: (bool) use conventional cell. Defaults to False.
-        transform: (list) can be used to make supercells with pymatgen.Structure.make_supercell method
+        structure: pymatgen Structure object.
+        conventional: use conventional cell. Defaults to False.
+        transform: can be used to make supercells with pymatgen.Structure.make_supercell method.
+
     Returns:
-        A JsmolView object.
+        A jupyter widget object.
     """
 
     s = structure.copy()
@@ -35,7 +34,3 @@ def quick_view(structure, conventional=False, transform=None, show_box=True):
         s.make_supercell(transform)
 
     return JsmolView.from_str(s.to('cif'))
-
-
-def close_all():
-    JsmolView.close_all()


### PR DESCRIPTION
## Summary

The tiny interface for visualising structures in jupyter notebook/lab using JSmol. The [`jupyter_jsmol`](https://github.com/fekad/jupyter-jsmol) package provides a widget (fully compatible with any other ipywidgets widgets) which is using the JSmol. 
More information about the features of the package can be found [here](https://github.com/fekad/jupyter-jsmol/tree/master/examples).

Features:
* Although it is not the fastest it is full of features. Any custom [command/script](https://chemapps.stolaf.edu/jmol/docs/) can be sent to the JSmol "applet"
* it is easy to integrate the viewer with other ipywidgets (Layout, slider etc...)
* works offline and  support Jupyter lab as well


## Checklist

Before a pull request can be merged, the following items must be checked:

- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). 
      Run [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/) and [flake8](http://flake8.pycqa.org/en/latest/)
      on your local machine.
- [x] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) 
      to type check your code.
- [ ] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.

