### PR TITLE
PackmolRunner enhancements for safe looping

### DIFF
--- a/pymatgen/io/lammps/utils.py
+++ b/pymatgen/io/lammps/utils.py
@@ -285,7 +285,7 @@ class PackmolRunner:
                     inp.write('  {} {}\n'.format(k, self._format_param_val(v)))
                 inp.write('end structure\n')
 
-    def run(self, copy_to_current_on_exit=False, site_property=None):
+    def run(self, site_property=None):
         """
         Write the input file to the scratch directory, run packmol and return
         the packed molecule to the current working directory.
@@ -298,7 +298,6 @@ class PackmolRunner:
                 Molecule object
         """
         with tempfile.TemporaryDirectory() as scratch_dir:
-        # with ScratchDir(scratch, copy_to_current_on_exit=copy_to_current_on_exit) as scratch_dir:
             self._write_input(input_dir=scratch_dir)
             with open(os.path.join(scratch_dir, self.input_file), 'r') as packmol_input:
                 with Popen(self.packmol_bin, stdin=packmol_input, stdout=PIPE, stderr=PIPE) as p:

--- a/pymatgen/io/lammps/utils.py
+++ b/pymatgen/io/lammps/utils.py
@@ -288,25 +288,22 @@ class PackmolRunner:
     def run(self, copy_to_current_on_exit=False, site_property=None):
         """
         Write the input file to the scratch directory, run packmol and return
-        the packed molecule.
+        the packed molecule to the current working directory.
 
         Args:
-            copy_to_current_on_exit (bool): Whether or not to copy the packmol
-                input/output files from the scratch directory to the current
-                directory.
             site_property (str): if set then the specified site property
                 for the the final packed molecule will be restored.
 
         Returns:
                 Molecule object
         """
-        scratch = tempfile.gettempdir()
-        with ScratchDir(scratch, copy_to_current_on_exit=copy_to_current_on_exit) as scratch_dir:
+        with tempfile.TemporaryDirectory() as scratch_dir:
+        # with ScratchDir(scratch, copy_to_current_on_exit=copy_to_current_on_exit) as scratch_dir:
             self._write_input(input_dir=scratch_dir)
-            packmol_input = open(os.path.join(scratch_dir, self.input_file), 'r')
-            p = Popen(self.packmol_bin, stdin=packmol_input, stdout=PIPE, stderr=PIPE)
-            (stdout, stderr) = p.communicate()
-            output_file = os.path.join(scratch_dir, self.control_params["output"])
+            with open(os.path.join(scratch_dir, self.input_file), 'r') as packmol_input:
+                with Popen(self.packmol_bin, stdin=packmol_input, stdout=PIPE, stderr=PIPE) as p:
+                    (stdout, stderr) = p.communicate()
+            output_file = os.path.join(self.control_params["output"])
             if os.path.isfile(output_file):
                 packed_mol = BabelMolAdaptor.from_file(output_file,
                                                        self.control_params["filetype"])


### PR DESCRIPTION
Enhance `PackmolRunner` to work more robustly when called within for loops.

* Use context managers for opening the input file and running the subprocess to ensure that both are properly closed
* Replace `ScratchDir` with `TemporaryDirectory` to eliminate non-obvious file deletion

Re: bullet point 2 - when the `ScratchDir` class is called with `copy_to_current_on_exit=True`, it not only copies output files from the temporary to the current directory, but also DELETES any file in the current working directory that is not present in the temporary directory. This behavior is undocumented and made it impossible to use `PackmolRunner` to loop through a series of structures and place output files in a single directory (everything except the latest output would be deleted on each iteration).

