### PR TITLE
add per_atom attributes to ComputedEntry

### DIFF
--- a/pymatgen/entries/computed_entries.py
+++ b/pymatgen/entries/computed_entries.py
@@ -338,6 +338,7 @@ class ComputedEntry(Entry):
         """
         return self.uncorrected_energy + self.correction
 
+    @property
     def uncorrected_energy_per_atom(self) -> float:
         """
         Returns:
@@ -364,6 +365,7 @@ class ComputedEntry(Entry):
         corr = ManualEnergyAdjustment(x)
         self.energy_adjustments = [corr]
 
+    @property
     def correction_per_atom(self) -> float:
         """
         Returns:
@@ -389,6 +391,7 @@ class ComputedEntry(Entry):
 
         return unc.std_dev
 
+    @property
     def correction_uncertainty_per_atom(self) -> float:
         """
         Returns:

--- a/pymatgen/entries/computed_entries.py
+++ b/pymatgen/entries/computed_entries.py
@@ -338,6 +338,14 @@ class ComputedEntry(Entry):
         """
         return self.uncorrected_energy + self.correction
 
+    def uncorrected_energy_per_atom(self) -> float:
+        """
+        Returns:
+            float: the *uncorrected* energy of the entry, normalized by atoms
+                (units of eV/atom)
+        """
+        return self.uncorrected_energy / self.composition.num_atoms
+
     @property
     def correction(self) -> float:
         """
@@ -351,6 +359,14 @@ class ComputedEntry(Entry):
         )
         return corr.nominal_value
 
+    def correction_per_atom(self) -> float:
+        """
+        Returns:
+            float: the total energy correction / adjustment applied to the entry,
+                normalized by atoms (units of eV/atom)
+        """
+        return self.correction / self.composition.num_atoms
+
     @correction.setter
     def correction(self, x: float) -> None:
         corr = ManualEnergyAdjustment(x)
@@ -360,7 +376,7 @@ class ComputedEntry(Entry):
     def correction_uncertainty(self) -> float:
         """
         Returns:
-            float: the uncertainty of the energy adjustment in eV
+            float: the uncertainty of the energy adjustments applied to the entry, in eV
         """
         # adds to ufloat(0.0, 0.0) to ensure that no corrections still result in ufloat object
         unc = ufloat(0.0, 0.0) + sum(
@@ -372,6 +388,14 @@ class ComputedEntry(Entry):
             return np.nan
 
         return unc.std_dev
+
+    def correction_uncertainty_per_atom(self) -> float:
+        """
+        Returns:
+            float: the uncertainty of the energy adjustments applied to the entry,
+                normalized by atoms (units of eV/atom)
+        """
+        return self.correction_uncertainty / self.composition.num_atoms
 
     def normalize(self, mode: str = "formula_unit") -> None:
         """

--- a/pymatgen/entries/computed_entries.py
+++ b/pymatgen/entries/computed_entries.py
@@ -359,6 +359,11 @@ class ComputedEntry(Entry):
         )
         return corr.nominal_value
 
+    @correction.setter
+    def correction(self, x: float) -> None:
+        corr = ManualEnergyAdjustment(x)
+        self.energy_adjustments = [corr]
+
     def correction_per_atom(self) -> float:
         """
         Returns:
@@ -366,11 +371,6 @@ class ComputedEntry(Entry):
                 normalized by atoms (units of eV/atom)
         """
         return self.correction / self.composition.num_atoms
-
-    @correction.setter
-    def correction(self, x: float) -> None:
-        corr = ManualEnergyAdjustment(x)
-        self.energy_adjustments = [corr]
 
     @property
     def correction_uncertainty(self) -> float:

--- a/pymatgen/entries/tests/test_computed_entries.py
+++ b/pymatgen/entries/tests/test_computed_entries.py
@@ -103,6 +103,20 @@ class ComputedEntryTest(unittest.TestCase):
         self.assertEqual(self.entry5.composition.reduced_formula, "Fe2O3")
         self.assertEqual(self.entry5.composition.get_reduced_formula_and_factor()[1], 3)
 
+    def test_per_atom_props(self):
+        entry = ComputedEntry("Fe6O9", 6.9)
+        entry.energy_adjustments.append(
+            CompositionEnergyAdjustment(-0.5, 9, uncertainty_per_atom=0.1, name="O")
+        )
+        self.assertAlmostEqual(entry.energy, 2.4)
+        self.assertAlmostEqual(entry.energy_per_atom, 2.4 / 15)
+        self.assertAlmostEqual(entry.uncorrected_energy, 6.9)
+        self.assertAlmostEqual(entry.uncorrected_energy_per_atom, 6.9 / 15)
+        self.assertAlmostEqual(entry.correction, -4.5)
+        self.assertAlmostEqual(entry.correction_per_atom, -4.5/15)
+        self.assertAlmostEqual(entry.correction_uncertainty, 0.9)
+        self.assertAlmostEqual(entry.correction_uncertainty_per_atom, 0.9/15)
+
     def test_normalize(self):
         entry = ComputedEntry("Fe6O9", 6.9, correction=1)
         entry.normalize()


### PR DESCRIPTION
By analogy with `energy` and `energy_per_atom`, add `per_atom` attributes for other energies of a `ComputedEntry`:

* `correction_per_atom`
* `correction_uncertainty_per_atom`
* `uncorrected_energy_per_atom`