### PR TITLE
address DeprecationWarning triggered by get_pourbaix_entries

### DIFF
--- a/pymatgen/analysis/pourbaix_diagram.py
+++ b/pymatgen/analysis/pourbaix_diagram.py
@@ -127,9 +127,6 @@ class PourbaixEntry(MSONable):
         if self.phase_type == "Solid":
             return self.entry.composition.reduced_formula + "(s)"
 
-        if self.phase_type == "Ion":
-            return self.entry.name + "(aq)"
-
         return self.entry.name
 
     @property

--- a/pymatgen/analysis/pourbaix_diagram.py
+++ b/pymatgen/analysis/pourbaix_diagram.py
@@ -375,7 +375,7 @@ class IonEntry(PDEntry):
         self.ion = ion
         # Auto-assign name
         name = name if name else self.ion.reduced_formula
-        super(IonEntry, self).__init__(
+        super().__init__(
             composition=ion.composition, energy=energy, name=name,
             attribute=attribute)
 

--- a/pymatgen/entries/compatibility.py
+++ b/pymatgen/entries/compatibility.py
@@ -1138,7 +1138,7 @@ class MaterialsProjectAqueousCompatibility(Compatibility):
     """
 
     def __init__(self,
-                 solid_compat: Optional[Compatibility] = None,
+                 solid_compat: Optional[Compatibility] = MaterialsProjectCompatibility,
                  o2_energy: Optional[float] = None,
                  h2o_energy: Optional[float] = None,
                  h2o_adjustments: Optional[float] = None):
@@ -1147,12 +1147,14 @@ class MaterialsProjectAqueousCompatibility(Compatibility):
 
         Note that this class requires as inputs the ground-state DFT energies of O2 and H2O, plus the value of any
         energy adjustments applied to an H2O molecule. If these parameters are not provided in __init__, they can
-        be automatically populated by included ComputedEntry for the ground state of O2 and H2O in a list of entries
+        be automatically populated by including ComputedEntry for the ground state of O2 and H2O in a list of entries
         passed to process_entries. process_entries will fail if one or the other is not provided.
 
         Args:
             solid_compat: Compatiblity scheme used to pre-process solid DFT energies prior to applying aqueous
-                energy adjustments. Default: MaterialsProjectCompatibility.
+                energy adjustments. May be passed as a class (e.g. MaterialsProjectCompatibility) or an instance
+                (e.g., MaterialsProjectCompatibility()). If None, solid DFT energies are used as-is.
+                Default: MaterialsProjectCompatibility
             o2_energy: The ground-state DFT energy of oxygen gas, including any adjustments or corrections, in eV/atom.
                 If not set, this value will be determined from any O2 entries passed to process_entries.
                 Default: None
@@ -1164,6 +1166,10 @@ class MaterialsProjectAqueousCompatibility(Compatibility):
                 Default: None
         """
         self.solid_compat = solid_compat
+        if self.solid_compat:
+            if not isinstance(self.solid_compat, Compatibility):  # check whether solid_compat has been instantiated
+                self.solid_compat = solid_compat()
+
         self.o2_energy = o2_energy
         self.h2o_energy = h2o_energy
         self.h2o_adjustments = h2o_adjustments

--- a/pymatgen/entries/tests/test_compatibility.py
+++ b/pymatgen/entries/tests/test_compatibility.py
@@ -1903,7 +1903,7 @@ class TestMaterialsProjectAqueousCompatibility:
     def test_h_h2o_energy_with_args(self):
 
         compat = MaterialsProjectAqueousCompatibility(
-            o2_energy=-4.9276, h2o_energy=-5.195, h2o_adjustments=-0.234
+            o2_energy=-4.9276, h2o_energy=-5.195, h2o_adjustments=-0.234, solid_compat=None
         )
 
         h2o_entry_1 = ComputedEntry(Composition("H2O"), -16)
@@ -1932,7 +1932,7 @@ class TestMaterialsProjectAqueousCompatibility:
         with pytest.warns(
             UserWarning, match="You did not provide the required O2 and H2O energies."
         ):
-            compat = MaterialsProjectAqueousCompatibility()
+            compat = MaterialsProjectAqueousCompatibility(solid_compat=None)
 
         h2o_entry_1 = ComputedEntry(
             Composition("H2O"), (-5.195 + 0.234) * 3, correction=-0.234 * 3
@@ -1974,7 +1974,7 @@ class TestMaterialsProjectAqueousCompatibility:
 
     def test_compound_entropy(self):
         compat = MaterialsProjectAqueousCompatibility(
-            o2_energy=-10, h2o_energy=-20, h2o_adjustments=-0.5
+            o2_energy=-10, h2o_energy=-20, h2o_adjustments=-0.5, solid_compat=None
         )
 
         o2_entry_1 = ComputedEntry(Composition("O2"), -4.9276 * 2)
@@ -1989,7 +1989,7 @@ class TestMaterialsProjectAqueousCompatibility:
 
     def test_hydrate_adjustment(self):
         compat = MaterialsProjectAqueousCompatibility(
-            o2_energy=-10, h2o_energy=-20, h2o_adjustments=-0.5
+            o2_energy=-10, h2o_energy=-20, h2o_adjustments=-0.5, solid_compat=None
         )
 
         hydrate_entry = ComputedEntry(Composition("FeH4O2"), -10)

--- a/pymatgen/ext/matproj.py
+++ b/pymatgen/ext/matproj.py
@@ -591,8 +591,9 @@ class MPRester:
         a pourbaix diagram from the rest interface.
 
         Args:
-            chemsys ([str]): A list of elements comprising the chemical
-                system, e.g. ['Li', 'Fe']
+            chemsys (str or [str]): Chemical system string comprising element
+                symbols separated by dashes, e.g., "Li-Fe-O" or List of element
+                symbols, e.g., ["Li", "Fe", "O"].
             solid_compat: Compatiblity scheme used to pre-process solid DFT energies prior to applying aqueous
                 energy adjustments. May be passed as a class (e.g. MaterialsProjectCompatibility) or an instance
                 (e.g., MaterialsProjectCompatibility()). If None, solid DFT energies are used as-is.
@@ -603,6 +604,9 @@ class MPRester:
         from pymatgen.core.ion import Ion
 
         pbx_entries = []
+
+        if isinstance(chemsys, str):
+            chemsys = chemsys.split('-')
 
         # Get ion entries first, because certain ions have reference
         # solids that aren't necessarily in the chemsys (Na2SO4)

--- a/pymatgen/ext/matproj.py
+++ b/pymatgen/ext/matproj.py
@@ -584,7 +584,7 @@ class MPRester:
         return entries
 
     def get_pourbaix_entries(
-        self, chemsys, solid_compat=MaterialsProjectCompatibility()
+        self, chemsys, solid_compat=MaterialsProjectCompatibility
     ):
         """
         A helper function to get all entries necessary to generate
@@ -594,7 +594,9 @@ class MPRester:
             chemsys ([str]): A list of elements comprising the chemical
                 system, e.g. ['Li', 'Fe']
             solid_compat: Compatiblity scheme used to pre-process solid DFT energies prior to applying aqueous
-                energy adjustments. Default: MaterialsProjectCompatibility().
+                energy adjustments. May be passed as a class (e.g. MaterialsProjectCompatibility) or an instance
+                (e.g., MaterialsProjectCompatibility()). If None, solid DFT energies are used as-is.
+                Default: MaterialsProjectCompatibility
         """
         from pymatgen.analysis.pourbaix_diagram import PourbaixEntry, IonEntry
         from pymatgen.analysis.phase_diagram import PhaseDiagram

--- a/pymatgen/ext/tests/test_matproj.py
+++ b/pymatgen/ext/tests/test_matproj.py
@@ -1,7 +1,6 @@
 # coding: utf-8
 # Copyright (c) Pymatgen Development Team.
 # Distributed under the terms of the MIT License.
-import platform
 import re
 import unittest
 import warnings
@@ -358,14 +357,14 @@ class MPResterTest(PymatgenTest):
         self.assertAlmostEqual(so4_two_minus.energy, 0.0644980568750011)
 
         # Ensure entries are pourbaix compatible
-        pbx = PourbaixDiagram(pbx_entries)
+        PourbaixDiagram(pbx_entries)
 
     def test_get_exp_entry(self):
         entry = self.rester.get_exp_entry("Fe2O3")
         self.assertEqual(entry.energy, -825.5)
 
-    def test_submit_query_delete_snl(self):
-        s = Structure([[5, 0, 0], [0, 5, 0], [0, 0, 5]], ["Fe"], [[0, 0, 0]])
+    # def test_submit_query_delete_snl(self):
+        # s = Structure([[5, 0, 0], [0, 5, 0], [0, 0, 5]], ["Fe"], [[0, 0, 0]])
         # d = self.rester.submit_snl(
         #     [s, s], remarks=["unittest"],
         #     authors="Test User <test@materialsproject.com>")

--- a/pymatgen/ext/tests/test_matproj.py
+++ b/pymatgen/ext/tests/test_matproj.py
@@ -336,7 +336,13 @@ class MPResterTest(PymatgenTest):
         self.assertEqual(Fe_entries[0].data["e_above_hull"], 0)
 
     def test_get_pourbaix_entries(self):
+        # test input chemsys as a list of elements
         pbx_entries = self.rester.get_pourbaix_entries(["Fe", "Cr"])
+        for pbx_entry in pbx_entries:
+            self.assertTrue(isinstance(pbx_entry, PourbaixEntry))
+
+        # test input chemsys as a string
+        pbx_entries = self.rester.get_pourbaix_entries("Fe-Cr")
         for pbx_entry in pbx_entries:
             self.assertTrue(isinstance(pbx_entry, PourbaixEntry))
 


### PR DESCRIPTION
The recent introduction of the `solid_compat` kwarg to `get_pourbaix_entries` began triggering a `DeprecationWarning` when the module was imported, because the kwarg defaulted to an instance of `MaterialsProjectCompatibility()`. This commit changes the interface slightly to avoid instantiating the class on import and therefore avoid triggering the `DeprecationWarning` until `get_pourbaix_entries` is actually called.

* `MaterialsProjectAqueousCompatibility` now accepts `None`, `Compatibility()`, or `Compatibility` as the `solid_compat`
* `MaterialsProjectAqueousCompatibility` now defaults to `solid_compat=MaterialsProjectCompatibility` (was previously `None`)
* allow `get_pourbaix_entries` to accept str as the `chemsys` argument (e.g. "Fe-Cr") for consistency with `get_entries_in_chemsys`
* pylint fixes and updates for `pourbaix_diagram.py`

TODO

* Fix the warnings suppression when `get_pourbaix_entries` calls `MaterialsProjectAqueousCompatibility` (can be addressed in a future PR; not changed by this one).