### PR TITLE
Ignore POTCAR.spec in Vasprun

### DIFF
--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -881,7 +881,7 @@ class Vasprun(MSONable):
         """
         def get_potcar_in_path(p):
             for fn in os.listdir(os.path.abspath(p)):
-                if fn.startswith('POTCAR'):
+                if fn.startswith('POTCAR') and ".spec" not in fn:
                     pc = Potcar.from_file(os.path.join(p, fn))
                     if {d.header for d in pc} == set(self.potcar_symbols):
                         return pc

--- a/test_files/POTCAR.spec
+++ b/test_files/POTCAR.spec
@@ -1,0 +1,3 @@
+Dummy POTCAR.spec file 
+
+This file sould be ignored by Vasprun.get_potcars()


### PR DESCRIPTION
To facilitate testing in the absence of proprietary POTCAR files, `InputSet` have the option to write a `POTCAR.spec` file instead of an actual POTCAR. However, when a `POTCAR.spec` file is present, `Vasprun.get_potcars()` tries to read it, resulting in an error.

This PR causes Vasprun.get_potcars() to ignore POTCAR.spec when present. See also a related atomate PR which requires this change: https://github.com/hackingmaterials/atomate/pull/454