### PR TITLE
Remove self.kwargs.get pattern in MP input sets

### DIFF
--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -883,6 +883,7 @@ class MPRelaxSet(DictSet):
         :param kwargs: Same as those supported by DictSet.
         """
         super().__init__(structure, MPRelaxSet.CONFIG, **kwargs)
+        self.kwargs = kwargs
 
 
 class MPScanRelaxSet(DictSet):
@@ -948,6 +949,7 @@ class MPScanRelaxSet(DictSet):
         """
         super().__init__(structure, MPScanRelaxSet.CONFIG, **kwargs)
         self.bandgap = bandgap
+        self.kwargs = kwargs
 
         if self.potcar_functional not in ["PBE_52", "PBE_54"]:
             raise ValueError("SCAN calculations require PBE_52 or PBE_54!")
@@ -1013,6 +1015,7 @@ class MPMetalRelaxSet(MPRelaxSet):
         super().__init__(structure, **kwargs)
         self._config_dict["INCAR"].update({"ISMEAR": 1, "SIGMA": 0.2})
         self._config_dict["KPOINTS"].update({"reciprocal_density": 200})
+        self.kwargs = kwargs
 
 
 class MPHSERelaxSet(DictSet):
@@ -1028,6 +1031,7 @@ class MPHSERelaxSet(DictSet):
         :param kwargs: Same as those supported by DictSet.
         """
         super().__init__(structure, MPHSERelaxSet.CONFIG, **kwargs)
+        self.kwargs = kwargs
 
 
 class MPStaticSet(MPRelaxSet):
@@ -1072,6 +1076,7 @@ class MPStaticSet(MPRelaxSet):
         self.prev_incar = prev_incar
         self.prev_kpoints = prev_kpoints
         self.reciprocal_density = reciprocal_density
+        self.kwargs = kwargs
         self.lepsilon = lepsilon
         self.lcalcpol = lcalcpol
         self.small_gap_multiply = small_gap_multiply
@@ -1251,6 +1256,7 @@ class MPScanStaticSet(MPScanRelaxSet):
             prev_incar = Incar.from_file(prev_incar)
 
         self.prev_incar = prev_incar
+        self.kwargs = kwargs
         self.lepsilon = lepsilon
         self.lcalcpol = lcalcpol
 
@@ -1570,6 +1576,7 @@ class MPNonSCFSet(MPRelaxSet):
         if isinstance(prev_incar, str):
             prev_incar = Incar.from_file(prev_incar)
         self.prev_incar = prev_incar
+        self.kwargs = kwargs
         self.nedos = nedos
         self.dedos = dedos
         self.reciprocal_density = reciprocal_density

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -338,6 +338,16 @@ class MITMPRelaxSetTest(PymatgenTest):
         mpr = MPRelaxSet(struct)
         self.assertEqual(mpr.incar["MAGMOM"], [1, 0.6])
 
+        # test passing user_incar_settings and user_kpoint_settings of None
+        sets = [
+            MPRelaxSet(struct, user_incar_settings=None, user_kpoints_settings=None),
+            MPStaticSet(struct, user_incar_settings=None, user_kpoints_settings=None),
+            MPNonSCFSet(struct, user_incar_settings=None, user_kpoints_settings=None)
+        ]
+        for mp_set in sets:
+            self.assertNotEqual(mp_set.kpoints, None)
+            self.assertNotEqual(mp_set.incar, None)
+
     def test_get_kpoints(self):
         kpoints = MPRelaxSet(self.structure).kpoints
         self.assertEqual(kpoints.kpts, [[2, 4, 5]])


### PR DESCRIPTION
A common pattern in many of the MP VASP input sets is to store the input kwargs in the constructor and then access them using `self.kwargs.get` in the `incar` and `kpoint` functions. Unfortunately, this can lead to discrepancies between the actual attributes of the input set and the data stored in the `kwargs` variable.

For example, the following causes an error:
```python
static_set = MPStaticSet(structure, user_incar_settings=None)
static_set.incar()

#  File ".../pymatgen/io/vasp/sets.py", line 974, in incar
#    self.kwargs.get("user_incar_settings", {}).keys()
# AttributeError: 'NoneType' object has no attribute 'keys'
```

This is surprising since the default value of `user_incar_settings` in the `VaspInputSet` constructor is `None`, and the following code works fine.
```python
static_set = MPStaticSet(structure)
static_set.incar()
```

The issue arises because the `incar` and `kpoints` functions call `self.kwargs.get("user_incar_settings", {}).keys()` which evaluates to `None.key()`. This issue can be avoided by just calling `self.user_incar_settings.keys()`. This is because the `VaspInputSet` constructor initialises `user_incar_settings` to as an empty dictionary if `None` is given as the argument.

I've left the `self.kwargs` pattern in the input set constructor as the `kwargs` variable is used by the monty decoder in the `as_dict` function. Note that I only edited MP input sets.

This issue is responsible for a bug in atomate: hackingmaterials/atomate#445.