### PR TITLE
Fix outcar serialization

### DIFF
--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -1722,6 +1722,9 @@ class Outcar:
             self.read_pseudo_zval()
 
         # Read electrostatic potential
+        self.electrostatic_potential = None
+        self.ngf = None
+        self.sampling_radii = None
         self.read_pattern({
             'electrostatic': r"average \(electrostatic\) potential at core"})
         if self.data.get('electrostatic', []):

--- a/pymatgen/io/vasp/tests/test_outputs.py
+++ b/pymatgen/io/vasp/tests/test_outputs.py
@@ -830,8 +830,12 @@ class OutcarTest(PymatgenTest):
         cl = Outcar(filepath).read_core_state_eigen()
         self.assertAlmostEqual(cl[6]["2s"][-1], -174.4779)
         filepath = self.TEST_FILES_DIR / "OUTCAR.icorelevel"
-        cl = Outcar(filepath).read_core_state_eigen()
+        outcar = Outcar(filepath)
+        cl = outcar.read_core_state_eigen()
         self.assertAlmostEqual(cl[4]["3d"][-1], -31.4522)
+
+        # test serialization
+        outcar.as_dict()
 
     def test_avg_core_poten(self):
         filepath = self.TEST_FILES_DIR / "OUTCAR.lepsilon"


### PR DESCRIPTION
## Summary

`Outcar.as_dict` method fails if the OUTCAR doesn't contain the average electrostatic potential at atomic cores. This can occur if `ICORELEVEL = 1` is set. I've fixed this behaviour and added a test. 

- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). 
      Run [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/) and [flake8](http://flake8.pycqa.org/en/latest/)
      on your local machine.
- [x] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [x] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) 
      to type check your code.
- [x] Tests have been added for any new functionality or bug fixes.
- [x] All existing tests pass.