### PR TITLE
fix bug in GGA run_type when METAGGA=None

### DIFF
--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -644,7 +644,7 @@ class Vasprun(MSONable):
 
         Hubbard U terms and vdW corrections are detected automatically as well.
         """
-        GGA_TYPES = {"RE": "revPBE", "PE": "PBE", "PS": "PBESol", "RP": "RevPBE+PADE",
+        GGA_TYPES = {"RE": "revPBE", "PE": "PBE", "PS": "PBEsol", "RP": "RevPBE+PADE",
                      "AM": "AM05", "OR": "optPBE", "BO": "optB88", "MK": "optB86b",
                      "--": "GGA"}
 
@@ -673,7 +673,7 @@ class Vasprun(MSONable):
             rt = "B3LYP"
         elif self.parameters.get("LHFCALC", True):
             rt = "PBEO or other Hybrid Functional"
-        elif self.incar.get("METAGGA") and self.incar.get("METAGGA") != "--":
+        elif self.incar.get("METAGGA") and self.incar.get("METAGGA") not in ["--", "None"]:
             incar_tag = self.incar.get("METAGGA", "").strip().upper()
             rt = METAGGA_TYPES.get(incar_tag, incar_tag)
         elif self.parameters.get("GGA"):

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -644,7 +644,7 @@ class Vasprun(MSONable):
 
         Hubbard U terms and vdW corrections are detected automatically as well.
         """
-        GGA_TYPES = {"RE": "revPBE", "PE": "PBE", "PS": "PBEsol", "RP": "RevPBE+PADE",
+        GGA_TYPES = {"RE": "revPBE", "PE": "PBE", "PS": "PBEsol", "RP": "revPBE+Padé",
                      "AM": "AM05", "OR": "optPBE", "BO": "optB88", "MK": "optB86b",
                      "--": "GGA"}
 

--- a/pymatgen/io/vasp/tests/test_outputs.py
+++ b/pymatgen/io/vasp/tests/test_outputs.py
@@ -104,6 +104,9 @@ class VasprunTest(PymatgenTest):
         v = Vasprun(self.TEST_FILES_DIR / "vasprun.xml.scan")
         self.assertIn(v.run_type, "SCAN")
 
+        v = Vasprun(self.TEST_FILES_DIR / "vasprun.xml.pbesol")
+        self.assertIn(v.run_type, "PBEsol")
+
         v = Vasprun(self.TEST_FILES_DIR / "vasprun.xml.rscan")
         self.assertIn(v.run_type, "RSCAN")
 


### PR DESCRIPTION
This PR fixes a recently discovered bug in which the `Vasprun.run_type` of a calculation in which `METAGGA=None` would not be set correctly.