### PR TITLE
[WIP] add pretty_parity_plot function

### DIFF
--- a/pymatgen/util/plotting.py
+++ b/pymatgen/util/plotting.py
@@ -79,11 +79,11 @@ def pretty_parity_plot(x: Union[np.ndarray, List],
                        xlim: Optional[Tuple] = None,
                        ylim: Optional[Tuple] = None,
                        width: float = 6,
-                       hegith: float = 6,
+                       height: float = 6,
                        show_diagonal: bool = True,
+                       diagonal_ls: str = "k--",
                        show_regression_stats: bool = True,
                        show_regression_line: bool = False,
-                       diagonal_ls: str = "k--",
                        regression_ls: str = "r-",
                        ax: Optional[Axes] = None,
                        ):
@@ -107,20 +107,22 @@ def pretty_parity_plot(x: Union[np.ndarray, List],
         width: Plot width in inches. (Default: 6)
         height: Plot height in inches. (Default: 6)
         show_diagonal: Show a diagonal y=x line. (Default: True)
+        diagonal_ls: Linestyle string for the diagonal y=x line. (Default: 'k--')
         show_regression_stats: Show a summary of the linear regression statistics (slope, intercept,
             root mean squared error, etc.) on the plot. (Default: True)
         show_regression_line: Plot the line of best fit from the linear regression. (Default: False)
-
-        diagonal_ls: Linestyle string for the diagonal y=x line. (Default: 'k--')
         regression_ls: Linestyle string for the regression line. (Default: 'r-')
+        ax: matplotlib Axes object to plot onto. If None (Default), then a new plotting instance 
+            will be created using pretty_plot()
 
     Returns:
         matplotlib Figure instance
     """
     if isinstance(ax, Axes):
         ax = ax
+        plt = ax.get_figure()
     else:
-        plt = pretty_plot(width=6, height=6)
+        plt = pretty_plot(width=width, height=height)
         ax = plt.gca()
     ax.plot(x, y, '.', color=color, alpha=alpha)
 


### PR DESCRIPTION
## Summary

Adds a new plotting function `pretty_parity_plot` to facilitate creating customizable and nicely-formatted plots that compare two quantities. An example is shown below.

* Most common plot customizations are exposed through explicitly documented kwargs
* Automatically plot or hide linear regression line, regression statistics, and 1:1 line
* 'units' are automatically appended to both axes and error metrics (if visible)
* Robust enough to plot data that includes `np.nan` / `np.inf`
* Optional `ax` kwarg allows plotting directly to a subplot axis of another figure

## Example

```
parityplot(x,
                 y,
                 "$\Delta H_f^{R2SCAN}$",
                 "$\Delta H_f^{SCAN}$", 
                 units="eV/atom", 
                 show_regression_line=False,
                 show_diagonal=True,
                 regression_ls='k-'
                 )
```
![image](https://user-images.githubusercontent.com/1908695/102265884-904abe00-3ecc-11eb-853a-18b829cebcd9.png)


## Additional dependencies introduced (if any)

* `scikit-learn` for calculation of error metrics (see TODO)

## TODO (if any)
- [ ] Find an alternative to `sklearn.metrics` to avoid introducing a new dependency (probably will just hand-code the calculations of RMSE, max error, mean absolute error)
- [ ] Implement the `ax` kwarg
- [ ] Determine what kind of tests are needed
