### PR TITLE
fix MoS test filename in test_graph.py

### DIFF
--- a/pymatgen/analysis/tests/test_graphs.py
+++ b/pymatgen/analysis/tests/test_graphs.py
@@ -472,7 +472,7 @@ from    to  to_image
             "bc_square_single.pdf",
             "bc_square.pdf",
             "MoS2_premul.pdf",
-            "MOS2_single.pdf",
+            "MoS2_single.pdf",
             "MoS2_twice_mul.pdf",
             "MoS2.pdf",
             "square_single.pdf",


### PR DESCRIPTION
test file is MoS2_single.pdf not MOS2_single.pdf

"MOS2_single.pdf" triggers an error: "No such file or directory: 'MOS2_single.pdf'" from `os.remove(test_file)`
