### PR TITLE
HighSymmKpath Hinuma setting bug fix

### DIFF
--- a/pymatgen/symmetry/bandstructure.py
+++ b/pymatgen/symmetry/bandstructure.py
@@ -10,6 +10,7 @@ import itertools
 
 import networkx as nx
 import numpy as np
+from warnings import warn
 
 from pymatgen.symmetry.kpath import (
     KPathBase,
@@ -231,6 +232,13 @@ class HighSymmKpath(KPathBase):
         tmat = bs._tmat
         for key in kpoints:
             kpoints[key] = np.dot(np.transpose(np.linalg.inv(tmat)), kpoints[key])
+
+        bs.kpath["kpoints"] = kpoints
+        self._rec_lattice = self._structure.lattice.reciprocal_lattice
+
+        warn("K-path from the Hinuma et al. convention has been transformed to basis " 
+        "of the reciprocal lattice of the input structure. "
+        "Use `KPathSeek` for the path in the original author-intended basis.")
 
         return bs
 

--- a/pymatgen/symmetry/bandstructure.py
+++ b/pymatgen/symmetry/bandstructure.py
@@ -7,10 +7,11 @@ generate high-symmetry k-paths using different conventions.
 """
 
 import itertools
+from warnings import warn
 
 import networkx as nx
 import numpy as np
-from warnings import warn
+
 
 from pymatgen.symmetry.kpath import (
     KPathBase,
@@ -236,9 +237,8 @@ class HighSymmKpath(KPathBase):
         bs.kpath["kpoints"] = kpoints
         self._rec_lattice = self._structure.lattice.reciprocal_lattice
 
-        warn("K-path from the Hinuma et al. convention has been transformed to basis " 
-        "of the reciprocal lattice of the input structure. "
-        "Use `KPathSeek` for the path in the original author-intended basis.")
+        warn("K-path from the Hinuma et al. convention has been transformed to the basis of the reciprocal lattice \
+of the input structure. Use `KPathSeek` for the path in the original author-intended basis.")
 
         return bs
 


### PR DESCRIPTION
## Summary

This PR contains a small bug fix for the `HighSymmKpath` class. Currently, the k-path from this class produced by the Hinuma et al. convention is not properly transformed into the basis of the reciprocal lattice of the input structure in all cases. This has been fixed, and a warning has been added to tell the user to use `KPathSeek` if they would like the path in the original author-intended basis. 

## Checklist

Work-in-progress pull requests are encouraged, but please put [WIP]
in the pull request title.

Before a pull request can be merged, the following items must be checked:

- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). 
      Run [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/) and [flake8](http://flake8.pycqa.org/en/latest/)
      on your local machine.
- [x] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [x] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) 
      to type check your code.
- [x] Tests have been added for any new functionality or bug fixes.
- [x] All existing tests pass.

