### PR TITLE
[WIP] add kwarg to pass in a plt ax to plot_brillouin

### DIFF
--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -929,7 +929,7 @@ class BSPlotter:
             plt.legend(handles=handles)
         return plt
 
-    def plot_brillouin(self):
+    def plot_brillouin(self, ax=None):
         """
         plot the Brillouin zone
         """
@@ -949,7 +949,7 @@ class BSPlotter:
                 ]
             )
 
-        plot_brillouin_zone(self._bs[0].lattice_rec, lines=lines, labels=labels)
+        plot_brillouin_zone(self._bs[0].lattice_rec, lines=lines, labels=labels, ax=ax)
 
 
 class BSPlotterProjected(BSPlotter):

--- a/pymatgen/phonon/plotter.py
+++ b/pymatgen/phonon/plotter.py
@@ -529,7 +529,7 @@ class PhononBSPlotter:
 
         return plt
 
-    def plot_brillouin(self):
+    def plot_brillouin(self, ax=None):
         """
         plot the Brillouin zone
         """
@@ -549,7 +549,7 @@ class PhononBSPlotter:
                 ]
             )
 
-        plot_brillouin_zone(self._bs.lattice_rec, lines=lines, labels=labels)
+        plot_brillouin_zone(self._bs.lattice_rec, lines=lines, labels=labels, ax=ax)
 
 
 class ThermoPlotter:


### PR DESCRIPTION
## Summary

Adds the ability to plot Brillouin zones into a `plt.subplot`

## TODO (if any)

- Does this need a test?

## Checklist

- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). 
      Run [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/) and [flake8](http://flake8.pycqa.org/en/latest/)
      on your local machine.
- [ ] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [ ] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) 
      to type check your code.
- [ ] Tests have been added for any new functionality or bug fixes.
- [x] All existing tests pass.

Note that the CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR. It is
highly recommended that you use the pre-commit hook provided in the pymatgen 
repository. Simply `cp pre-commit .git/hooks` and a check will be run prior to
allowing commits.
