### PR TITLE
fix: #1985 and add test to stop computed entry being used for get_quasi_e_to_hull

### DIFF
--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -688,8 +688,8 @@ class BasePhaseDiagram(MSONable):
         # handled between PDEntry and ComputedEntry
         if isinstance(entry, ComputedEntry):
             raise ValueError(
-            "`get_quasi_e_to_hull` is not compatible with `ComputedEntry`"
-        )
+                "`get_quasi_e_to_hull` is not compatible with `ComputedEntry`"
+            )
 
         # For unstable or novel materials use simplex approach
         if entry.normalize(inplace=False) not in self.get_stable_entries_normed():
@@ -780,8 +780,8 @@ class BasePhaseDiagram(MSONable):
         # handled between PDEntry and ComputedEntry
         if isinstance(entry, ComputedEntry):
             raise ValueError(
-            "`get_quasi_e_to_hull` is not compatible with `ComputedEntry`"
-        )
+                "`get_quasi_e_to_hull` is not compatible with `ComputedEntry`"
+            )
 
         # Handle unstable and novel materials
         if entry.normalize(inplace=False) not in self.get_stable_entries_normed():

--- a/pymatgen/analysis/tests/test_phase_diagram.py
+++ b/pymatgen/analysis/tests/test_phase_diagram.py
@@ -323,6 +323,14 @@ class PhaseDiagramTest(unittest.TestCase):
             "Novel scaled duplicates of stable entries should have same decomposition energy!",
         )
 
+        comp_entry = ComputedEntry("Li", 0.0, 0.0, entry_id="test")
+        self.assertRaises(
+            ValueError,
+            self.pd.get_quasi_e_to_hull,
+            comp_entry,
+            msg="`get_quasi_e_to_hull` not compatible with `ComputedEntry`"
+        )
+
     def test_get_decomposition(self):
         for entry in self.pd.stable_entries:
             self.assertEqual(


### PR DESCRIPTION
@rkingsbury 

As the proper fix in #2014 seems like it might still take a while to get merged this is the temp fix I should have done for #1985 when I first saw it. It avoids the bug that I introduced by not (at that point) being aware that `ComputedEntry` was supposed to be interoperable with `PDEntry` and adds a catch to stop another bug in `get_quasi_e_to_hull` that would be caused by the same issues with `__eq__` and `__hash__` for `ComputedEntry` that caused this bug.