### PR TITLE
method to estimate NBANDS + tests

### DIFF
--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -173,7 +173,6 @@ class MITMPRelaxSetTest(PymatgenTest):
         self.assertAlmostEqual(MITRelaxSet(s).nelect, 16)
         self.assertAlmostEqual(MPRelaxSet(s).nelect, 22)
 
-
     def test_get_incar(self):
 
         incar = self.mpset.incar

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -153,6 +153,15 @@ class MITMPRelaxSetTest(PymatgenTest):
         s = Structure(lattice, ["Si", "Si", "Fe"], coords)
         self.assertAlmostEqual(MITRelaxSet(s).nelect, 16)
 
+        # Test estimate of number of bands (function of nelect) with nmag>0
+        self.assertAlmostEqual(MITRelaxSet(s).estimate_nbands(), 13)
+        self.assertAlmostEqual(MPRelaxSet(s).estimate_nbands(), 17)
+
+        # Test estimate of number of bands (function of nelect) with nmag==0
+        s = Structure(lattice, ["Si", "Si", "Si"], coords)
+        self.assertAlmostEqual(MITRelaxSet(s).estimate_nbands(), 11)
+        self.assertAlmostEqual(MPRelaxSet(s).estimate_nbands(), 11)
+
         # Check that it works even when oxidation states are present. Was a bug
         # previously.
         s = Structure(lattice, ["Si4+", "Si4+", "Fe2+"], coords)
@@ -163,6 +172,7 @@ class MITMPRelaxSetTest(PymatgenTest):
         s = Structure(lattice, ["Si4+", "Fe2+", "Si4+"], coords)
         self.assertAlmostEqual(MITRelaxSet(s).nelect, 16)
         self.assertAlmostEqual(MPRelaxSet(s).nelect, 22)
+
 
     def test_get_incar(self):
 


### PR DESCRIPTION
## Summary

* created method to estimate NBANDS for VASP input set
* simplified `nelect` property
* added tests

## Checklist

- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). 
      Run [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/) and [flake8](http://flake8.pycqa.org/en/latest/)
      on your local machine.
- [x] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [x] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) 
      to type check your code.
- [x] Tests have been added for any new functionality or bug fixes.
- [x] All existing tests pass.

