### PR TITLE
[WIP] build system: adopt PEP-518

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
-
 [tool.black]
 line-length = 120
 target-version = ['py38']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.19.2
+numpy==1.20.0
 sympy==1.7.1
 requests==2.25.0
 monty==4.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.20.0
+numpy==1.19.2
 sympy==1.7.1
 requests==2.25.0
 monty==4.0.2

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,12 @@ setup(
     cmdclass={"build_ext": build_ext},
     python_requires=">=3.6",
     install_requires=[
-        "numpy>=1.18.0",
+        # pin NumPy version used in the build, to avoid building against the latest
+        # NumPy from PyPI (and potentially introducing ABI compatibilities with the
+        # actual NumPy version in the environment)
+        "numpy>=1.18,<1.20; python_version<='3.9'",
+        # don't pin version for as-yet-unreleased versions of Python
+        "numpy>=1.18; python_version>'3.9'",
         "requests",
         "ruamel.yaml>=0.15.6",
         "monty>=3.0.2",


### PR DESCRIPTION
fix #2010

## Summary

The setup.py was using the deprecated `setup_requires` keyword, which
can result in dependencies being installed via `easy_install`.
`easy_install` is outdated and should no longer be used to install
packages.

This commit adopts PEP 518 and uses the `pyproject.toml` file to specify
the dependencies of the build system.


## Checklist

Work-in-progress pull requests are encouraged, but please put [WIP]
in the pull request title.

Before a pull request can be merged, the following items must be checked:

- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). The easiest way to handle this
      is to run the following in the **correct sequence** on your local machine. Start with running
      [black](https://black.readthedocs.io/en/stable/index.html) on your new code. This will automatically reformat
      your code to PEP8 conventions and removes most issues. Then run 
      [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/), followed by 
      [flake8](http://flake8.pycqa.org/en/latest/).
- [x] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [x] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) to type check your code.
- [x] Tests have been added for any new functionality or bug fixes.
- [ ] All linting and tests pass.

Note that the CI system will run all the above checks. But it will be much more efficient if you already fix most 
errors prior to submitting the PR. It is highly recommended that you use the pre-commit hook provided in the pymatgen 
repository. Simply `cp pre-commit .git/hooks` and a check will be run prior to allowing commits.
