### PR TITLE
Remove custom entry normalize methods, solve via optional composition

### DIFF
--- a/pymatgen/entries/__init__.py
+++ b/pymatgen/entries/__init__.py
@@ -10,10 +10,7 @@ store calculated information. Other Entry classes such as ComputedEntry
 and PDEntry inherit from this class.
 """
 
-import copy
-
 from numbers import Number
-from typing import Optional
 from abc import ABCMeta, abstractmethod
 
 import numpy as np

--- a/pymatgen/entries/tests/test_computed_entries.py
+++ b/pymatgen/entries/tests/test_computed_entries.py
@@ -396,7 +396,7 @@ class GibbsComputedStructureEntryTest(unittest.TestCase):
             self.entries_with_temps = {
                 temp: GibbsComputedStructureEntry(
                     self.struct,
-                    -2.436 * self.num_atoms,
+                    -2.436,
                     temp=temp,
                     gibbs_model="SISSO",
                     parameters=vasprun.incar,
@@ -426,7 +426,7 @@ class GibbsComputedStructureEntryTest(unittest.TestCase):
 
     def test_interpolation(self):
         temp = 450
-        e = GibbsComputedStructureEntry(self.struct, -2.436 * self.num_atoms, temp=temp)
+        e = GibbsComputedStructureEntry(self.struct, -2.436, temp=temp)
         self.assertAlmostEqual(e.energy, -53.7243542548528)
 
     def test_expt_gas_entry(self):


### PR DESCRIPTION
For **entry-equality branch**, to be reviewed by @mkhorton:

Solves the normalization issue by adding an optional composition parameter so that composition is not taken directly from the structure object. Also cleaned up a ton of other things! 

This doesn't yet do the major entry refactor.

