### PR TITLE
Add tqdm as requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -129,6 +129,7 @@ setup(
         "pandas",
         "plotly>=4.5.0",
         "uncertainties>=3.1.4",
+        "tqdm",
     ],
     extras_require={
         "provenance": ["pybtex"],


### PR DESCRIPTION
Because it is used in pymatgen.analysis.pourbaix_diagram
