### PR TITLE
Fix KeyError when initializing XRDCalculator with integer wavelength

### DIFF
--- a/pymatgen/analysis/diffraction/tests/test_xrd.py
+++ b/pymatgen/analysis/diffraction/tests/test_xrd.py
@@ -24,6 +24,11 @@ __date__ = "5/22/14"
 
 
 class XRDCalculatorTest(PymatgenTest):
+    def test_type_wavelength(self):
+        """Test TypeError is raised if wavelength is unaccepted type"""
+        wavelength = [1.78, 2.78]  # just a list
+        self.assertRaises(TypeError, XRDCalculator, wavelength)
+
     def test_get_pattern(self):
         s = self.get_structure("CsCl")
         c = XRDCalculator()

--- a/pymatgen/analysis/diffraction/tests/test_xrd.py
+++ b/pymatgen/analysis/diffraction/tests/test_xrd.py
@@ -3,9 +3,6 @@
 # Distributed under the terms of the MIT License.
 
 import unittest
-
-import matplotlib as mpl
-
 from pymatgen.analysis.diffraction.xrd import XRDCalculator
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Structure

--- a/pymatgen/analysis/diffraction/xrd.py
+++ b/pymatgen/analysis/diffraction/xrd.py
@@ -130,9 +130,13 @@ class XRDCalculator(AbstractDiffractionPatternCalculator):
         """
         if isinstance(wavelength, float):
             self.wavelength = wavelength
-        else:
+        elif isinstance(wavelength, int):
+            self.wavelength = float(wavelength)
+        elif isinstance(wavelength, str):
             self.radiation = wavelength
             self.wavelength = WAVELENGTHS[wavelength]
+        else:
+            raise TypeError("'wavelength' must be either of: float, int or str")
         self.symprec = symprec
         self.debye_waller_factors = debye_waller_factors or {}
 

--- a/pymatgen/analysis/diffraction/xrd.py
+++ b/pymatgen/analysis/diffraction/xrd.py
@@ -128,10 +128,8 @@ class XRDCalculator(AbstractDiffractionPatternCalculator):
                 specification of Debye-Waller factors. Note that these
                 factors are temperature dependent.
         """
-        if isinstance(wavelength, float):
+        if isinstance(wavelength, (float, int)):
             self.wavelength = wavelength
-        elif isinstance(wavelength, int):
-            self.wavelength = float(wavelength)
         elif isinstance(wavelength, str):
             self.radiation = wavelength
             self.wavelength = WAVELENGTHS[wavelength]

--- a/pymatgen/core/composition.py
+++ b/pymatgen/core/composition.py
@@ -1243,8 +1243,10 @@ class ChemicalPotential(dict, MSONable):
     def __repr__(self):
         return "ChemPots: " + super().__repr__()
 
+
 class CompositionError(Exception):
     """Exception class for composition errors"""
+
 
 if __name__ == "__main__":
     import doctest


### PR DESCRIPTION
## Summary

Include a summary of major changes in bullet points:

* Fix 1: attempting to create a XRDCalculator instance with an integer wavelength (e.g. 1, when wavelength is 1 Angstrom) throws a KeyError.  Made changes to the __init__ method to accept integers for wavelength.  Also raise TypeError if wavelength is neither of float, int or str.  Added test to test if TypeError is raised.



Before a pull request can be merged, the following items must be checked:

- [x ] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). The easiest way to handle this
      is to run the following in the **correct sequence** on your local machine. Start with running
      [black](https://black.readthedocs.io/en/stable/index.html) on your new code. This will automatically reformat
      your code to PEP8 conventions and removes most issues. Then run 
      [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/), followed by 
      [flake8](http://flake8.pycqa.org/en/latest/).
- [ ] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [ ] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) to type check your code.
- [x ] Tests have been added for any new functionality or bug fixes.
- [x ] All linting and tests pass. --- Some linting does not pass.  However, it was inherited.  It is not due to this contribution.

Note that the CI system will run all the above checks. But it will be much more efficient if you already fix most 
errors prior to submitting the PR. It is highly recommended that you use the pre-commit hook provided in the pymatgen 
repository. Simply `cp pre-commit .git/hooks` and a check will be run prior to allowing commits.
