### PR TITLE
Parse projected magnetisation from non-collinear calculations

### DIFF
--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -431,7 +431,10 @@ class Vasprun(MSONable):
                 elif parse_eigen and tag == "eigenvalues":
                     self.eigenvalues = self._parse_eigen(elem)
                 elif parse_projected_eigen and tag == "projected":
-                    self.projected_eigenvalues, self.projected_magnetisation = self._parse_projected_eigen(elem)
+                    (
+                        self.projected_eigenvalues,
+                        self.projected_magnetisation,
+                    ) = self._parse_projected_eigen(elem)
                 elif tag == "dielectricfunction":
                     if (
                         "comment" not in elem.attrib
@@ -828,12 +831,13 @@ class Vasprun(MSONable):
             data=data,
         )
 
-    def get_band_structure(self,
-                           kpoints_filename: Optional[str] = None,
-                           efermi: Optional[Union[float, str]] = None,
-                           line_mode: bool = False,
-                           force_hybrid_mode: bool = False
-                           ):
+    def get_band_structure(
+        self,
+        kpoints_filename: Optional[str] = None,
+        efermi: Optional[Union[float, str]] = None,
+        line_mode: bool = False,
+        force_hybrid_mode: bool = False,
+    ):
         """
         Returns the band structure as a BandStructure object
 
@@ -1516,11 +1520,13 @@ class BSVasprun(Vasprun):
     etc. are ignored.
     """
 
-    def __init__(self,
-                 filename: str,
-                 parse_projected_eigen: Union[bool, str] = False,
-                 parse_potcar_file: Union[bool, str] = False,
-                 occu_tol: float = 1e-8):
+    def __init__(
+        self,
+        filename: str,
+        parse_projected_eigen: Union[bool, str] = False,
+        parse_potcar_file: Union[bool, str] = False,
+        occu_tol: float = 1e-8,
+    ):
         """
         Args:
             filename: Filename to parse
@@ -1574,7 +1580,10 @@ class BSVasprun(Vasprun):
                 elif tag == "eigenvalues":
                     self.eigenvalues = self._parse_eigen(elem)
                 elif parse_projected_eigen and tag == "projected":
-                    self.projected_eigenvalues, self.projected_magnetisation = self._parse_projected_eigen(elem)
+                    (
+                        self.projected_eigenvalues,
+                        self.projected_magnetisation,
+                    ) = self._parse_projected_eigen(elem)
                 elif tag == "structure" and elem.attrib.get("name") == "finalpos":
                     self.final_structure = self._parse_structure(elem)
         self.vasp_version = self.generator["version"]
@@ -2326,10 +2335,10 @@ class Outcar:
 
     def read_cs_core_contribution(self):
         """
-            Parse the core contribution of NMR chemical shielding.
+        Parse the core contribution of NMR chemical shielding.
 
-            Returns:
-            G0 contribution matrix as list of list.
+        Returns:
+        G0 contribution matrix as list of list.
         """
         header_pattern = (
             r"^\s+Core NMR properties\s*$\n"
@@ -3311,7 +3320,7 @@ class Outcar:
                         npots = int((len(line) - 1) / 17)
                         for i in range(npots):
                             start = i * 17
-                            ap.append(float(line[start + 8:start + 17]))
+                            ap.append(float(line[start + 8 : start + 17]))
 
         return aps
 
@@ -5688,8 +5697,8 @@ class Waveder:
         with open(filename, "rb") as fp:
 
             def readData(dtype):
-                """ Read records from Fortran binary file and convert to
-                np.array of given dtype. """
+                """Read records from Fortran binary file and convert to
+                np.array of given dtype."""
                 data = b""
                 while True:
                     prefix = np.fromfile(fp, dtype=np.int32, count=1)[0]

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -197,6 +197,13 @@ class Vasprun(MSONable):
         kpoint, band and atom indices are 0-based (unlike the 1-based indexing
         in VASP).
 
+    .. attribute:: projected_magnetisation
+
+        Final projected magnetisation as a numpy array with the shape (nkpoints, nbands,
+        natoms, norbitals, 3). Where the last axis is the contribution in the 3
+        cartesian directions. This attribute is only set if spin-orbit coupling
+        (LSORBIT = True) or non-collinear magnetism (LNONCOLLINEAR = True) is turned
+        on in the INCAR.
 
     .. attribute:: other_dielectric
 
@@ -305,9 +312,9 @@ class Vasprun(MSONable):
                 True. Set to False to shave off significant time from the
                 parsing if you are not interested in getting those data.
             parse_projected_eigen (bool): Whether to parse the projected
-                eigenvalues. Defaults to False. Set to True to obtain projected
-                eigenvalues. **Note that this can take an extreme amount of time
-                and memory.** So use this wisely.
+                eigenvalues and magnetisation. Defaults to False. Set to True to obtain
+                projected eigenvalues and magnetisation. **Note that this can take an
+                extreme amount of time and memory.** So use this wisely.
             parse_potcar_file (bool/str): Whether to parse the potcar file to read
                 the potcar hashes for the potcar_spec attribute. Defaults to True,
                 where no hashes will be determined and the potcar_spec dictionaries
@@ -375,6 +382,7 @@ class Vasprun(MSONable):
         self.efermi = None
         self.eigenvalues = None
         self.projected_eigenvalues = None
+        self.projected_magnetisation = None
         self.dielectric_data = {}
         self.other_dielectric = {}
         ionic_steps = []
@@ -423,7 +431,7 @@ class Vasprun(MSONable):
                 elif parse_eigen and tag == "eigenvalues":
                     self.eigenvalues = self._parse_eigen(elem)
                 elif parse_projected_eigen and tag == "projected":
-                    self.projected_eigenvalues = self._parse_projected_eigen(elem)
+                    self.projected_eigenvalues, self.projected_magnetisation = self._parse_projected_eigen(elem)
                 elif tag == "dielectricfunction":
                     if (
                         "comment" not in elem.attrib
@@ -1209,6 +1217,9 @@ class Vasprun(MSONable):
                     for spin, v in self.projected_eigenvalues.items()
                 }
 
+            if self.projected_magnetisation is not None:
+                vout["projected_magnetisation"] = self.projected_magnetisation.tolist()
+
         vout["epsilon_static"] = self.epsilon_static
         vout["epsilon_static_wolfe"] = self.epsilon_static_wolfe
         vout["epsilon_ionic"] = self.epsilon_ionic
@@ -1456,7 +1467,7 @@ class Vasprun(MSONable):
             spin = int(re.match(r"spin(\d+)", s.attrib["comment"]).group(1))
 
             # Force spin to be +1 or -1
-            spin = Spin.up if spin == 1 else Spin.down
+            # spin = Spin.up if spin == 1 else Spin.down
             for kpt, ss in enumerate(s.findall("set")):
                 dk = []
                 for band, sss in enumerate(ss.findall("set")):
@@ -1464,8 +1475,21 @@ class Vasprun(MSONable):
                     dk.append(db)
                 proj_eigen[spin].append(dk)
         proj_eigen = {spin: np.array(v) for spin, v in proj_eigen.items()}
+
+        if len(proj_eigen) > 2:
+            # non-collinear magentism (also spin-orbit coupling) enabled, last three
+            # "spin channels" are the projected magnetisation of the orbitals in the
+            # x, y, and z cartesian coordinates
+            proj_mag = np.stack([proj_eigen.pop(i) for i in range(2, 5)], axis=-1)
+            proj_eigen = {Spin.up: proj_eigen[1]}
+        else:
+            proj_eigen = {
+                Spin.up if k == 1 else Spin.down: v for k, v in proj_eigen.items()
+            }
+            proj_mag = None
+
         elem.clear()
-        return proj_eigen
+        return proj_eigen, proj_mag
 
     @staticmethod
     def _parse_dynmat(elem):
@@ -1550,7 +1574,7 @@ class BSVasprun(Vasprun):
                 elif tag == "eigenvalues":
                     self.eigenvalues = self._parse_eigen(elem)
                 elif parse_projected_eigen and tag == "projected":
-                    self.projected_eigenvalues = self._parse_projected_eigen(elem)
+                    self.projected_eigenvalues, self.projected_magnetisation = self._parse_projected_eigen(elem)
                 elif tag == "structure" and elem.attrib.get("name") == "finalpos":
                     self.final_structure = self._parse_structure(elem)
         self.vasp_version = self.generator["version"]

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -1471,7 +1471,6 @@ class Vasprun(MSONable):
             spin = int(re.match(r"spin(\d+)", s.attrib["comment"]).group(1))
 
             # Force spin to be +1 or -1
-            # spin = Spin.up if spin == 1 else Spin.down
             for kpt, ss in enumerate(s.findall("set")):
                 dk = []
                 for band, sss in enumerate(ss.findall("set")):

--- a/pymatgen/io/vasp/tests/test_outputs.py
+++ b/pymatgen/io/vasp/tests/test_outputs.py
@@ -553,6 +553,13 @@ class VasprunTest(PymatgenTest):
             self.assertEqual(bs.get_branch(0)[0]["start_index"], 0)
             self.assertEqual(bs.get_branch(0)[0]["end_index"], 0)
 
+    def test_projected_magnetisation(self):
+        filepath = self.TEST_FILES_DIR / "vasprun.lvel.Si2H.xml"
+        vasprun = Vasprun(filepath, parse_projected_eigen=True)
+        self.assertTrue(vasprun.projected_magnetisation is not None)
+        self.assertEqual(vasprun.projected_magnetisation.shape, (76, 240, 4, 9, 3))
+        self.assertAlmostEqual(vasprun.projected_magnetisation[0, 0, 0, 0, 0], -0.0712)
+
     def test_smart_efermi(self):
         # branch 1 - E_fermi does not cross a band
         vrun = Vasprun(self.TEST_FILES_DIR / 'vasprun.xml.LiF')


### PR DESCRIPTION
## Summary

Added the ability to parse the projected magnetisation from VASP calculations that include spin-orbit coupling or non-collinear magnetism.

For calculations that include orbital projections (`LORBIT = 11`), the projections are written to the vasprun.xml file in the same format as in the PROCAR file (https://www.vasp.at/wiki/index.php/PROCAR). The format of the projections depends on the other calculation parameters:
- For spin-paired calculations (`ISPIN = 1`): There is only one spin channel present.
- For spin-polarised calculations (`ISPIN = 2`): There are two spin channels present.
- For non-collinear or SOC calculations: There are 4 spin channels present.

In the last case, the first spin channel is the usual projection of the wavefunctions onto the atomic orbitals. The last 3 spin channels are actually the projected magnetisation of those orbitals in the 3 cartesian directions.

Previously, the projected eigenvalues from SOC calculations incorrectly had two spin channels, while the remaining spin channels were ignored. This PR fixes the parsing so that the projected magnetisation is extracted correctly for SOC calculations.

I've added a unit test.

