### PR TITLE
Gaussian: allow None for functional, bset, charge and multiplicity

### DIFF
--- a/pymatgen/io/gaussian.py
+++ b/pymatgen/io/gaussian.py
@@ -461,13 +461,13 @@ class GaussianInput:
         bset_str = '' if self.basis_set is None else self.basis_set.strip()
 
         if func_str != "" and bset_str != "":
-            func_bset_str = "{}/{}".format(func_str, bset_str)
+            func_bset_str = " {}/{}".format(func_str, bset_str)
         else:
             # don't use the slash if either or both are set as empty
-             func_bset_str = "{}{}".format(func_str, bset_str)
+            func_bset_str = " {}{}".format(func_str, bset_str).rstrip()
 
         output.append(
-            "{diez} {func_bset} {route}".format(
+            "{diez}{func_bset} {route}".format(
                 diez=self.dieze_tag,
                 func_bset=func_bset_str,
                 route=para_dict_to_string(self.route_parameters),
@@ -477,9 +477,9 @@ class GaussianInput:
         output.append(self.title)
         output.append("")
 
-        charge_str = '' if self.charge is None else str(self.charge)
-        multip_str = '' if self.spin_multiplicity is None else str(self.spin_multiplicity)
-        output.append("%s %s" % (charge_str, multip_str))
+        charge_str = "" if self.charge is None else "%d" % self.charge
+        multip_str = "" if self.spin_multiplicity is None else " %d" % self.spin_multiplicity
+        output.append("{}{}".format(charge_str, multip_str))
 
         if isinstance(self._mol, Molecule):
             if cart_coords is True:

--- a/pymatgen/io/gaussian.py
+++ b/pymatgen/io/gaussian.py
@@ -455,10 +455,10 @@ class GaussianInput:
         output = []
         if self.link0_parameters:
             output.append(para_dict_to_string(self.link0_parameters, "\n"))
-        
+
         # Handle functional or basis set set to None, empty string or whitespace
-        func_str = '' if self.functional is None else self.functional.strip()
-        bset_str = '' if self.basis_set is None else self.basis_set.strip()
+        func_str = "" if self.functional is None else self.functional.strip()
+        bset_str = "" if self.basis_set is None else self.basis_set.strip()
 
         if func_str != "" and bset_str != "":
             func_bset_str = " {}/{}".format(func_str, bset_str)

--- a/pymatgen/io/gaussian.py
+++ b/pymatgen/io/gaussian.py
@@ -156,8 +156,6 @@ class GaussianInput:
             # Get a title from the molecule name
             self.title = title if title else self._mol.composition.formula
         else:
-            if charge is None or spin_multiplicity is None:
-                raise ValueError("`charge` and `spin_multiplicity` must be specified")
             self.charge = charge
             self.spin_multiplicity = spin_multiplicity
 
@@ -457,18 +455,32 @@ class GaussianInput:
         output = []
         if self.link0_parameters:
             output.append(para_dict_to_string(self.link0_parameters, "\n"))
+        
+        # Handle functional or basis set set to None, empty string or whitespace
+        func_str = '' if self.functional is None else self.functional.strip()
+        bset_str = '' if self.basis_set is None else self.basis_set.strip()
+
+        if func_str != "" and bset_str != "":
+            func_bset_str = "{}/{}".format(func_str, bset_str)
+        else:
+            # don't use the slash if either or both are set as empty
+             func_bset_str = "{}{}".format(func_str, bset_str)
+
         output.append(
-            "{diez} {func}/{bset} {route}".format(
+            "{diez} {func_bset} {route}".format(
                 diez=self.dieze_tag,
-                func=self.functional,
-                bset=self.basis_set,
+                func_bset=func_bset_str,
                 route=para_dict_to_string(self.route_parameters),
             )
         )
         output.append("")
         output.append(self.title)
         output.append("")
-        output.append("%d %d" % (self.charge, self.spin_multiplicity))
+
+        charge_str = '' if self.charge is None else str(self.charge)
+        multip_str = '' if self.spin_multiplicity is None else str(self.spin_multiplicity)
+        output.append("%s %s" % (charge_str, multip_str))
+
         if isinstance(self._mol, Molecule):
             if cart_coords is True:
                 output.append(self.get_cart_coords())

--- a/pymatgen/io/tests/test_gaussian.py
+++ b/pymatgen/io/tests/test_gaussian.py
@@ -193,16 +193,38 @@ H 0
         self.assertEqual(gin.spin_multiplicity, 1)
 
     def test_no_molecule(self):
-        """Test that we can write output files without a geometry"""
-
-        # Note that we must manually specify charge
-        with self.assertRaises(ValueError):
-            GaussianInput(None)
+        """Test that we can write input files without a geometry"""
 
         # Makes a file without geometry
         input_file = GaussianInput(None, charge=0, spin_multiplicity=2)
         input_str = input_file.to_string().strip()
         self.assertTrue(input_str.endswith("0 2"))
+
+    def test_no_molecule_func_bset_charge_mult(self):
+        """
+        Test that we can write inputs files without a geometry,
+        functional, basis set, charge or multiplicity
+        (mainly for postprocessing jobs where this info is read from .chk)
+        """
+        gau_str = "#P chkbasis geom=allcheck guess=(only,read) pop=naturalorbital\n"
+        gau_str += "\n"
+        gau_str += "Restart"
+        
+        input_file = GaussianInput(
+            None,
+            charge=None,
+            spin_multiplicity=None,
+            functional=None,
+            basis_set=None,
+            route_parameters = {
+                "chkbasis": None,
+                "geom": "allcheck",
+                "guess": {"only": None,"read": None},
+                "pop": "naturalorbital",
+            },
+        )
+        input_str = input_file.to_string().strip()
+        self.assertEqual(input_str, gau_str)
 
 
 class GaussianOutputTest(unittest.TestCase):


### PR DESCRIPTION
Hi pymatgen community!

I would like to use the Gaussian input generator for post-processing runs, such as this one 

~~~
%chk=g.chk
%oldchk=../g.chk
#P chkbasis geom=allcheck guess=(only,read) pop=naturalorbital

test
~~~

This would read the geometry, functional, basis set, charge and multiplicity from `../g.chk` and perform natural orbital analysis.

This PR enables this by making 
* functional and basis set are not outputted when set to `None`
* if geometry is `None`, then charge or multiplicity set to `None` will not be displayed

I also added a test for this and I had to modify an existing test.