### PR TITLE
Fix for correct bonds_broken in slab generation

### DIFF
--- a/pymatgen/core/surface.py
+++ b/pymatgen/core/surface.py
@@ -1091,7 +1091,7 @@ class SlabGenerator:
         return shifts
 
     def _get_c_ranges(self, bonds):
-        c_ranges = set()
+        c_ranges = []
         bonds = {(get_el_sp(s1), get_el_sp(s2)): dist for (s1, s2), dist in bonds.items()}
         for (sp1, sp2), bond_dist in bonds.items():
             for site in self.oriented_unit_cell:
@@ -1102,15 +1102,15 @@ class SlabGenerator:
                             if c_range[1] > 1:
                                 # Takes care of PBC when c coordinate of site
                                 # goes beyond the upper boundary of the cell
-                                c_ranges.add((c_range[0], 1))
-                                c_ranges.add((0, c_range[1] - 1))
+                                c_ranges.append((c_range[0], 1))
+                                c_ranges.append((0, c_range[1] - 1))
                             elif c_range[0] < 0:
                                 # Takes care of PBC when c coordinate of site
                                 # is below the lower boundary of the unit cell
-                                c_ranges.add((0, c_range[1]))
-                                c_ranges.add((c_range[0] + 1, 1))
+                                c_ranges.append((0, c_range[1]))
+                                c_ranges.append((c_range[0] + 1, 1))
                             elif c_range[0] != c_range[1]:
-                                c_ranges.add(c_range)
+                                c_ranges.append((c_range[0], c_range[1]))
         return c_ranges
 
     def get_slabs(
@@ -1154,7 +1154,7 @@ class SlabGenerator:
             ([Slab]) List of all possible terminations of a particular surface.
             Slabs are sorted by the # of bonds broken.
         """
-        c_ranges = set() if bonds is None else self._get_c_ranges(bonds)
+        c_ranges = [] if bonds is None else self._get_c_ranges(bonds)
 
         slabs = []
         for shift in self._calculate_possible_shifts(tol=ftol):

--- a/pymatgen/core/tests/test_surface.py
+++ b/pymatgen/core/tests/test_surface.py
@@ -620,7 +620,25 @@ class SlabGeneratorTest(PymatgenTest):
         all_top = [slab[i].frac_coords[2] > slab.center_of_mass[2] for i in bottom_index]
         self.assertTrue(all(all_top))
 
-
+    def test_bonds_broken(self):
+        # Querying the Materials Project database for Si
+        s = self.get_mp_structure("mp-149")
+        # Conventional unit cell is supplied to ensure miller indices
+        # correspond to usual crystallographic definitions
+        conv_bulk = SpacegroupAnalyzer(s).get_conventional_standard_structure()
+        slabgen = SlabGenerator(conv_bulk, [1, 1, 1], 10, 10, center_slab=True)
+        # Setting a generous estimate for max_broken_bonds
+        # so that all terminations are generated. These slabs
+        # are ordered by ascending number of bonds broken
+        # which is assigned to Slab.energy
+        slabs = slabgen.get_slabs(bonds={('Si', 'Si'): 2.40}, max_broken_bonds = 30)
+        # Looking at the two slabs generated in VESTA, we
+        # expect 2 and 6 bonds broken so we check for this.
+        # Number of broken bonds are floats due to primitive
+        # flag check and subsequent transformation of slabs.
+        self.assertTrue(slabs[0].energy, 2.0)
+        self.assertTrue(slabs[1].energy, 6.0)
+        
 class ReconstructionGeneratorTests(PymatgenTest):
     def setUp(self):
 


### PR DESCRIPTION
## Summary

`SlabGenerator._get_c_ranges()` takes in a `bonds` dictionary and returns a set of tuples of fractional z-coordinates of neighboring (nearest) atoms if they have distinct z-coordinates. This set is then used in the `SlabGenerator.get_slabs()` method in order to calculate the total number of broken bonds. The issue with the current version is that the tuples are stored in a `set()` which can only have unique elements so all but one of the bonds between say z_coord1 and z_coord2 are ignored.

I tested this by simply generating Si(111) slabs, calculating the number of bonds broken reported by pymatgen, and comparing them by what I expect from looking at the slabs in VESTA. 

Here's the code I used to generate the slabs;

```
from pymatgen.core.surface import SlabGenerator
from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
from pymatgen import MPRester

struct = MPRester().get_structure_by_material_id('mp-149')

bulk_conv = SpacegroupAnalyzer(struct).get_conventional_standard_structure()

SG = SlabGenerator(initial_structure = bulk_conv,
                   miller_index = [1,1,1],
                   center_slab = True,
                   primitive = True,
                   in_unit_planes = True,
                   lll_reduce = True,
                   max_normal_search= 1,
                   min_slab_size = 7,
                   min_vacuum_size = 12)

slabs = SG.get_slabs(bonds = {('Si','Si'):2.60}, ftol = 0.1, tol = 0.1, max_broken_bonds = 20,
                              symmetrize = False, repair = False)

for slab in slabs:
    print(slab.energy)
```

This prints 0.5 for both terminations whereas looking at the slabs in VESTA, one expects 2 and 6. 

By changing c_ranges from a set() to an empty list instead and appending to it, tuples for all the bonds are preserved and the above script prints 2 and 6.

For consistency, I also changed c_ranges to an empty list if `bonds` is `None` in `get_slabs()`.
