### PR TITLE
Use numpy tolist method in electronic_structure.bandstructure.Kpoint.as_dict

### DIFF
--- a/pymatgen/electronic_structure/bandstructure.py
+++ b/pymatgen/electronic_structure/bandstructure.py
@@ -130,8 +130,8 @@ class Kpoint(MSONable):
         """
         return {
             "lattice": self.lattice.as_dict(),
-            "fcoords": list(self.frac_coords),
-            "ccoords": list(self.cart_coords),
+            "fcoords": self.frac_coords.tolist(),
+            "ccoords": self.cart_coords.tolist(),
             "label": self.label,
             "@module": self.__class__.__module__,
             "@class": self.__class__.__name__,

--- a/pymatgen/electronic_structure/tests/test_bandstructure.py
+++ b/pymatgen/electronic_structure/tests/test_bandstructure.py
@@ -10,6 +10,7 @@ import warnings
 from io import open
 
 from monty.serialization import loadfn
+import numpy
 
 from pymatgen.core.lattice import Lattice
 from pymatgen.electronic_structure.bandstructure import (
@@ -41,6 +42,14 @@ class KpointTest(unittest.TestCase):
         self.assertEqual(self.kpoint.cart_coords[1], 4.0)
         self.assertEqual(self.kpoint.cart_coords[2], -5.0)
         self.assertEqual(self.kpoint.label, "X")
+
+    def test_as_dict(self):
+        self.assertIsInstance(self.kpoint.as_dict()["fcoords"], list)
+        self.assertIsInstance(self.kpoint.as_dict()["ccoords"], list)
+        self.assertNotIsInstance(self.kpoint.as_dict()["fcoords"][0], numpy.float64)
+        self.assertNotIsInstance(self.kpoint.as_dict()["ccoords"][0], numpy.float64)
+        self.assertListEqual(self.kpoint.as_dict()["fcoords"], [0.1, 0.4, -0.5])
+        self.assertListEqual(self.kpoint.as_dict()["ccoords"], [1.0, 4.0, -5.0])
 
 
 class BandStructureSymmLine_test(PymatgenTest):


### PR DESCRIPTION
Use `np.ndarray.tolist()` method instead of python `list()` to convert k-point coordinates in `pymatgen.electronic_structure.bandstructure.Kpoint.as_dict()`.

This fixes issue #2112, where numpy numerical types (e.g. numpy.float64) exist in the result of `Kpoint.as_dict()`.