### PR TITLE
Update bader_caller.py

### DIFF
--- a/pymatgen/command_line/bader_caller.py
+++ b/pymatgen/command_line/bader_caller.py
@@ -326,12 +326,12 @@ class BaderAnalysis:
 
     def get_decorated_structure(self, property_name, average=False):
         """
-        Get the property decorated structure from the Bader analysis.
+        Get a property-decorated structure from the Bader analysis.
 
         This is distinct from getting charge decorated structure, which assumes
         the "standard" Bader analysis of electron densities followed by converting
         electron count to charge. The expected way to use this is to call Bader on
-        a non-charge density file such as a spin denisty file, electrostatic potential
+        a non-charge density file such as a spin density file, electrostatic potential
         file, etc., while using the charge density file as the reference (chgref_filename)
         so that the partitioning is determined via the charge, but averaging or integrating
         is done for another property.
@@ -342,7 +342,9 @@ class BaderAnalysis:
         property and you have an appropriate reference file.
 
         Args:
-            property_name: name of the property to assign to the structure
+            property_name: name of the property to assign to the structure, note that 
+                if name is "spin" this is handled as a special case, and the appropriate 
+                spin properties are set on the species in the structure
             average: whether or not to return the average of this property, rather
                 than the total, by dividing by the atomic volume.
 

--- a/pymatgen/command_line/bader_caller.py
+++ b/pymatgen/command_line/bader_caller.py
@@ -216,7 +216,11 @@ class BaderAnalysis:
 
                 atomic_densities = []
                 # For each atom in the structure
-                for atom, loc, chg in zip(self.chgcar.structure, self.chgcar.structure.frac_coords, atom_chgcars,):
+                for atom, loc, chg in zip(
+                    self.chgcar.structure,
+                    self.chgcar.structure.frac_coords,
+                    atom_chgcars,
+                ):
                     # Find the index of the atom in the charge density atom
                     index = np.round(np.multiply(loc, chg.dim))
 
@@ -234,7 +238,9 @@ class BaderAnalysis:
                         starty = y // 2 - (ywidth // 2)
                         startz = z // 2 - (zwidth // 2)
                         return data[
-                            startx : startx + xwidth, starty : starty + ywidth, startz : startz + zwidth,
+                            startx : startx + xwidth,
+                            starty : starty + ywidth,
+                            startz : startz + zwidth,
                         ]
 
                     # Finds the central encompassing volume which holds all the data within a precision
@@ -428,7 +434,11 @@ class BaderAnalysis:
             chgref.write_file(chgref_filename)
         else:
             chgref_filename = None
-        return cls(chgcar_filename=chgcar_filename, potcar_filename=potcar_filename, chgref_filename=chgref_filename,)
+        return cls(
+            chgcar_filename=chgcar_filename,
+            potcar_filename=potcar_filename,
+            chgref_filename=chgref_filename,
+        )
 
 
 def get_filepath(filename, warning, path, suffix):
@@ -541,7 +551,11 @@ def bader_analysis_from_objects(chgcar, potcar=None, aeccar0=None, aeccar2=None)
         else:
             potcar_path = None
 
-        ba = BaderAnalysis(chgcar_filename=chgcar_path, potcar_filename=potcar_path, chgref_filename=chgref_path,)
+        ba = BaderAnalysis(
+            chgcar_filename=chgcar_path,
+            potcar_filename=potcar_path,
+            chgref_filename=chgref_path,
+        )
 
         summary = {
             "min_dist": [d["min_dist"] for d in ba.data],
@@ -565,7 +579,9 @@ def bader_analysis_from_objects(chgcar, potcar=None, aeccar0=None, aeccar2=None)
 
             chgcar_mag_path = os.path.join(temp_dir, "CHGCAR_mag")
             ba = BaderAnalysis(
-                chgcar_filename=chgcar_mag_path, potcar_filename=potcar_path, chgref_filename=chgref_path,
+                chgcar_filename=chgcar_mag_path,
+                potcar_filename=potcar_path,
+                chgref_filename=chgref_path,
             )
             summary["magmom"] = [d["charge"] for d in ba.data]
 

--- a/pymatgen/command_line/bader_caller.py
+++ b/pymatgen/command_line/bader_caller.py
@@ -342,8 +342,8 @@ class BaderAnalysis:
         property and you have an appropriate reference file.
 
         Args:
-            property_name: name of the property to assign to the structure, note that 
-                if name is "spin" this is handled as a special case, and the appropriate 
+            property_name: name of the property to assign to the structure, note that
+                if name is "spin" this is handled as a special case, and the appropriate
                 spin properties are set on the species in the structure
             average: whether or not to return the average of this property, rather
                 than the total, by dividing by the atomic volume.


### PR DESCRIPTION
## Summary

My last PR for the bader caller had some issues, which this PR resolves. (edited after discussion below)

* Fix 1: Previously, I had "self.nelects" for cube analysis created by looking for the site property with that name. It didn't occur to me that the self.structure object is not user-defined, but created from the cube file, and this property will never exist. I removed this, and changed the functions to have an optional nelect(s) argument for when parsing cube files.

* Feature 1:  I have added get_decorated_structure method. Which is like the previous "get_spin_decorated_structure", but more general. Assuming you ran bader with an appropriate reference using `chgref_filename`, this lets you assign a generic property to a structure using the reference file for the partitioning and the main file for the integrating. This can be, for example, be used to parse a spin density cube file to get spin decorated structure or a hartree cube file to get a electrostatic potential decorated structure.
