### PR TITLE
Use numpy tolist() in DOS-family object as_dict() methods

### DIFF
--- a/pymatgen/electronic_structure/dos.py
+++ b/pymatgen/electronic_structure/dos.py
@@ -398,8 +398,8 @@ class Dos(MSONable):
             "@module": self.__class__.__module__,
             "@class": self.__class__.__name__,
             "efermi": self.efermi,
-            "energies": list(self.energies),
-            "densities": {str(spin): list(dens) for spin, dens in self.densities.items()},
+            "energies": self.energies.tolist(),
+            "densities": {str(spin): dens.tolist() for spin, dens in self.densities.items()},
         }
 
 
@@ -620,8 +620,8 @@ class FermiDos(Dos, MSONable):
             "@module": self.__class__.__module__,
             "@class": self.__class__.__name__,
             "efermi": self.efermi,
-            "energies": list(self.energies),
-            "densities": {str(spin): list(dens) for spin, dens in self.densities.items()},
+            "energies": self.energies.tolist(),
+            "densities": {str(spin): dens.tolist() for spin, dens in self.densities.items()},
             "structure": self.structure,
             "nelecs": self.nelecs,
         }
@@ -840,8 +840,8 @@ class CompleteDos(Dos):
             "@class": self.__class__.__name__,
             "efermi": self.efermi,
             "structure": self.structure.as_dict(),
-            "energies": list(self.energies),
-            "densities": {str(spin): list(dens) for spin, dens in self.densities.items()},
+            "energies": self.energies.tolist(),
+            "densities": {str(spin): dens.tolist() for spin, dens in self.densities.items()},
             "pdos": [],
         }
         if len(self.pdos) > 0:

--- a/pymatgen/electronic_structure/tests/test_dos.py
+++ b/pymatgen/electronic_structure/tests/test_dos.py
@@ -49,6 +49,16 @@ class DosTest(unittest.TestCase):
         for spin in Spin:
             self.assertAlmostEqual(sum(dens[spin]), sum(smeared[spin]))
 
+    def test_as_dict(self):
+        dos_dict = self.dos.as_dict()
+        self.assertIsInstance(dos_dict["energies"], list)
+        self.assertIsInstance(dos_dict["energies"][0], float)
+        self.assertNotIsInstance(dos_dict["energies"][0], np.float64)
+
+        self.assertIsInstance(dos_dict["densities"]["1"], list)
+        self.assertIsInstance(dos_dict["densities"]["1"][0], float)
+        self.assertNotIsInstance(dos_dict["densities"]["1"][0], np.float64)
+
 
 class FermiDosTest(unittest.TestCase):
     def setUp(self):
@@ -85,6 +95,16 @@ class FermiDosTest(unittest.TestCase):
         self.assertAlmostEqual(sci_dos.get_fermi_interextrapolated(-1e26, 300), 7.5108, 4)
         self.assertAlmostEqual(sci_dos.get_fermi_interextrapolated(1e26, 300), -1.4182, 4)
         self.assertAlmostEqual(sci_dos.get_fermi_interextrapolated(0.0, 300), 2.5226, 4)
+
+    def test_as_dict(self):
+        dos_dict = self.dos.as_dict()
+        self.assertIsInstance(dos_dict["energies"], list)
+        self.assertIsInstance(dos_dict["energies"][0], float)
+        self.assertNotIsInstance(dos_dict["energies"][0], np.float64)
+
+        self.assertIsInstance(dos_dict["densities"]["1"], list)
+        self.assertIsInstance(dos_dict["densities"]["1"][0], float)
+        self.assertNotIsInstance(dos_dict["densities"]["1"][0], np.float64)
 
 
 class CompleteDosTest(unittest.TestCase):
@@ -154,6 +174,16 @@ class CompleteDosTest(unittest.TestCase):
 
     def test_str(self):
         self.assertIsNotNone(str(self.dos))
+
+    def test_as_dict(self):
+        dos_dict = self.dos.as_dict()
+        self.assertIsInstance(dos_dict["energies"], list)
+        self.assertIsInstance(dos_dict["energies"][0], float)
+        self.assertNotIsInstance(dos_dict["energies"][0], np.float64)
+
+        self.assertIsInstance(dos_dict["densities"]["1"], list)
+        self.assertIsInstance(dos_dict["densities"]["1"][0], float)
+        self.assertNotIsInstance(dos_dict["densities"]["1"][0], np.float64)
 
 
 class DOSTest(PymatgenTest):


### PR DESCRIPTION
Use `np.ndarray.tolist()` method instead of python `list()` to convert density of state (`Dos`, `FermiDos`, `CompleteDos`) energies and densities in their `as_dict()` methods.

This fixes an issue where numpy numerical types (e.g. numpy.float64) exist in the results of {`Dos`, `FermiDos`, `CompleteDos`}`.as_dict()`.

This allows these objects to be saved and stored more easily by [mincePy Sci](https://github.com/muhrin/mincepy_sci).
