### PR TITLE
Update cube.py

### DIFF
--- a/pymatgen/io/cube.py
+++ b/pymatgen/io/cube.py
@@ -1,21 +1,24 @@
 """
-Module for reading Gaussian cube files, which have become one of the standard file formats for volumetric data
-in quantum chemistry and solid state physics software packages (VASP being an exception).
+Module for reading Gaussian cube files, which have become one of the standard file formats
+for volumetric data in quantum chemistry and solid state physics software packages
+(VASP being an exception).
 
-Some basic info about cube files (abridged info from http://paulbourke.net/dataformats/cube/ by Paul Bourke)
+Some basic info about cube files
+(abridged info from http://paulbourke.net/dataformats/cube/ by Paul Bourke)
 
-The file consists of a header which includes the atom information and the size as well as orientation of the
-volumetric data. The first two lines of the header are comments. The third line has the number of atoms
-included in the file followed by the position of the origin of the volumetric data. The next three lines
-give the number of voxels along each axis (x, y, z) followed by the axis vector. The last section in the
-header is one line for each atom consisting of 5 numbers, the first is the atom number, the second is the
-charge, and the last three are the x,y,z coordinates of the atom center. The volumetric data is straightforward,
+The file consists of a header which includes the atom information and the size as well
+as orientation of the volumetric data. The first two lines of the header are comments. The
+third line has the number of atoms included in the file followed by the position of the
+origin of the volumetric data. The next three lines give the number of voxels along each axis
+(x, y, z) followed by the axis vector. The last section in the header is one line for each
+atom consisting of 5 numbers, the first is the atom number, the second is the charge, and
+the last three are the x,y,z coordinates of the atom center. The volumetric data is straightforward,
 one floating point number for each volumetric element.
 
 
 Example
-In the following example the volumetric data is a 40 by 40 by 40 grid,
-each voxel is 0.283459 units wide and the volume is aligned with the coordinate axis. There are three atoms.
+In the following example the volumetric data is a 40 by 40 by 40 grid, each voxel is 0.283459 units
+wide and the volume is aligned with the coordinate axis. There are three atoms.
 
  CPMD CUBE FILE.
  OUTER LOOP: X, MIDDLE LOOP: Y, INNER LOOP: Z
@@ -65,12 +68,12 @@ class Cube:
         for i in range(2):
             f.readline()
 
-        # number of atoms included in the file followed by the position of the origin of the volumetric data
+        # number of atoms followed by the position of the origin of the volumetric data
         line = f.readline().split()
         self.natoms = int(line[0])
         self.origin = np.array(list(map(float, line[1:])))
 
-        # The next three lines give the number of voxels along each axis (x, y, z) followed by the axis vector.
+        # The number of voxels along each axis (x, y, z) followed by the axis vector.
         line = f.readline().split()
         self.NX = int(line[0])
         self.X = np.array([bohr_to_angstrom * float(l) for l in line[1:]])
@@ -86,11 +89,12 @@ class Cube:
         self.Z = np.array([bohr_to_angstrom * float(l) for l in line[1:]])
         self.dZ = np.linalg.norm(self.Z)
 
-        self.voxelVolume = abs(np.dot(np.cross(self.X, self.Y), self.Z))
+        self.voxel_volume = abs(np.dot(np.cross(self.X, self.Y), self.Z))
         self.volume = abs(np.dot(np.cross(self.X.dot(self.NZ), self.Y.dot(self.NY)), self.Z.dot(self.NZ)))
 
         # The last section in the header is one line for each atom consisting of 5 numbers,
-        # the first is the atom number, second is charge, the last three are the x,y,z coordinates of the atom center.
+        # the first is the atom number, second is charge,
+        # the last three are the x,y,z coordinates of the atom center.
         self.sites = []
         for i in range(self.natoms):
             line = f.readline().split()
@@ -104,9 +108,7 @@ class Cube:
         )
 
         # Volumetric data
-        self.data = np.reshape(
-            np.array(f.read().split()).astype(float),
-            (self.NX, self.NY, self.NZ))
+        self.data = np.reshape(np.array(f.read().split()).astype(float), (self.NX, self.NY, self.NZ))
 
     def mask_sphere(self, radius, cx, cy, cz):
         """
@@ -114,24 +116,24 @@ class Cube:
 
         Args:
             radius: (flaot) of the mask (in Angstroms)
-            Cx, Cy, Cz: (float) the fractional coordinates of the center of the sphere
+            cx, cy, cz: (float) the fractional coordinates of the center of the sphere
         """
-        dx, dy, dz = np.floor(radius / np.linalg.norm(self.X)).astype(int), \
-            np.floor(radius / np.linalg.norm(self.Y)).astype(int), \
+        dx, dy, dz = (
+            np.floor(radius / np.linalg.norm(self.X)).astype(int),
+            np.floor(radius / np.linalg.norm(self.Y)).astype(int),
             np.floor(radius / np.linalg.norm(self.Z)).astype(int)
+        )
         gcd = max(np.gcd(dx, dy), np.gcd(dy, dz), np.gcd(dx, dz))
         sx, sy, sz = dx // gcd, dy // gcd, dz // gcd
         r = min(dx, dy, dz)
 
-        x0, y0, z0 = int(np.round(self.NX * cx)), \
-            int(np.round(self.NY * cy)), \
-            int(np.round(self.NZ * cz))
+        x0, y0, z0 = int(np.round(self.NX * cx)), int(np.round(self.NY * cy)), int(np.round(self.NZ * cz))
 
         centerx, centery, centerz = self.NX // 2, self.NY // 2, self.NZ // 2
         a = np.roll(self.data, (centerx - x0, centery - y0, centerz - z0))
 
         i, j, k = np.indices(a.shape, sparse=True)
-        a = np.sqrt((sx*i - sx*centerx) ** 2 + (sy*j - sy*centery) ** 2 + (sz*k - sz*centerz) ** 2)
+        a = np.sqrt((sx * i - sx * centerx) ** 2 + (sy * j - sy * centery) ** 2 + (sz * k - sz * centerz) ** 2)
 
         indices = a > r
         a[indices] = 0
@@ -150,7 +152,7 @@ class Cube:
         returns:
             Array of site averages, [Average around site 1, Average around site 2, ...]
         """
-        return [self._get_atomic_site_average(s, atomic_site_radii[s.species_string])for s in self.structure.sites]
+        return [self._get_atomic_site_average(s, atomic_site_radii[s.species_string]) for s in self.structure.sites]
 
     def _get_atomic_site_average(self, site, radius):
         """
@@ -174,14 +176,10 @@ class Cube:
                 atomic_site_radii (dict): dictionary determining the cutoff radius (in Angstroms)
                     for averaging around atomic sites (e.g. {'Li': 0.97, 'B': 0.77, ...}. If
                     not provided, then the
-                nproc (int or None): number of processes to use in calculating atomic site averages. If
-                    nproc=None, then Pool will use os.cpu_count() to set nproc as the number of available
-                    cpus.
-
             returns:
                 Array of site averages, [Average around site 1, Average around site 2, ...]
             """
-        return [self._get_atomic_site_total(s, atomic_site_radii[s.species_string])for s in self.structure.sites]
+        return [self._get_atomic_site_total(s, atomic_site_radii[s.species_string]) for s in self.structure.sites]
 
     def _get_atomic_site_total(self, site, radius):
         """

--- a/pymatgen/io/cube.py
+++ b/pymatgen/io/cube.py
@@ -118,7 +118,7 @@ class Cube:
         """
         dx, dy, dz = np.floor(radius / np.linalg.norm(self.X)).astype(int), \
             np.floor(radius / np.linalg.norm(self.Y)).astype(int), \
-            np.floor(radius / np.linalg.norm(self.Z)).astype(int),
+            np.floor(radius / np.linalg.norm(self.Z)).astype(int)
         gcd = max(np.gcd(dx, dy), np.gcd(dy, dz), np.gcd(dx, dz))
         sx, sy, sz = dx // gcd, dy // gcd, dz // gcd
         r = min(dx, dy, dz)

--- a/pymatgen/io/cube.py
+++ b/pymatgen/io/cube.py
@@ -53,12 +53,14 @@ class Cube:
     """
     Class to read Gaussian cube file formats for volumetric data.
 
-    Cube files are, by default, written in atomic units.
+    Cube files are, by default, written in atomic units, and this
+    class assumes that convention.
     """
 
     def __init__(self, fname):
         """
         Initialize the cube object and store the data as self.data
+
         Args:
             fname (str): filename of the cube to read
         """
@@ -142,10 +144,9 @@ class Cube:
 
     def get_atomic_site_averages(self, atomic_site_radii):
         """
-        Given a cube (pymatgen.io.cube.Cube), get the average value around each atomic site.
+        Get the average value around each atomic site.
 
         Args:
-            cube (Cube): pymatgen cube object
             atomic_site_radii (dict): dictionary determining the cutoff radius (in Angstroms)
                 for averaging around atomic sites (e.g. {'Li': 0.97, 'B': 0.77, ...}. If
                 not provided, then the
@@ -159,7 +160,8 @@ class Cube:
         Helper function for get_atomic_site_averages.
 
         Args:
-            args: (tuple) Contains the site and the atomic_site_radius for given atomic species
+            site: Site in the structure around which to get the average
+            radius: (float) the atomic_site_radius (in Angstroms) for given atomic species
 
         returns:
             Average around the atomic site
@@ -169,10 +171,9 @@ class Cube:
 
     def get_atomic_site_totals(self, atomic_site_radii):
         """
-        Given a cube (pymatgen.io.cube.Cube), get the average value around each atomic site.
+        Get the integrated total in a sphere around each atomic site.
 
         Args:
-            cube (Cube): pymatgen cube object
             atomic_site_radii (dict): dictionary determining the cutoff radius (in Angstroms)
                 for averaging around atomic sites (e.g. {'Li': 0.97, 'B': 0.77, ...}. If
                 not provided, then the
@@ -186,7 +187,8 @@ class Cube:
         Helper function for get_atomic_site_averages.
 
         Args:
-            args: (tuple) Contains the site and the atomic_site_radius for given atomic species
+            site: Site in the structure around which to get the total
+            radius: (float) the atomic_site_radius (in Angstroms) for given atomic species
 
         returns:
             Average around the atomic site
@@ -213,8 +215,7 @@ class Cube:
         Modified from pymatgen.io.vasp.outputs
 
         Get the averaged total of the volumetric data a certain axis direction.
-        For example, useful for visualizing Hartree Potentials from a LOCPOT
-        file.
+        For example, useful for visualizing Hartree Potentials.
 
         Args:
             ind (int): Index of axis.

--- a/pymatgen/io/cube.py
+++ b/pymatgen/io/cube.py
@@ -121,7 +121,7 @@ class Cube:
         dx, dy, dz = (
             np.floor(radius / np.linalg.norm(self.X)).astype(int),
             np.floor(radius / np.linalg.norm(self.Y)).astype(int),
-            np.floor(radius / np.linalg.norm(self.Z)).astype(int)
+            np.floor(radius / np.linalg.norm(self.Z)).astype(int),
         )
         gcd = max(np.gcd(dx, dy), np.gcd(dy, dz), np.gcd(dx, dz))
         sx, sy, sz = dx // gcd, dy // gcd, dz // gcd
@@ -169,16 +169,16 @@ class Cube:
 
     def get_atomic_site_totals(self, atomic_site_radii):
         """
-            Given a cube (pymatgen.io.cube.Cube), get the average value around each atomic site.
+        Given a cube (pymatgen.io.cube.Cube), get the average value around each atomic site.
 
-            Args:
-                cube (Cube): pymatgen cube object
-                atomic_site_radii (dict): dictionary determining the cutoff radius (in Angstroms)
-                    for averaging around atomic sites (e.g. {'Li': 0.97, 'B': 0.77, ...}. If
-                    not provided, then the
-            returns:
-                Array of site averages, [Average around site 1, Average around site 2, ...]
-            """
+        Args:
+            cube (Cube): pymatgen cube object
+            atomic_site_radii (dict): dictionary determining the cutoff radius (in Angstroms)
+                for averaging around atomic sites (e.g. {'Li': 0.97, 'B': 0.77, ...}. If
+                not provided, then the
+        returns:
+            Array of site averages, [Average around site 1, Average around site 2, ...]
+        """
         return [self._get_atomic_site_total(s, atomic_site_radii[s.species_string]) for s in self.structure.sites]
 
     def _get_atomic_site_total(self, site, radius):


### PR DESCRIPTION
## Summary
 
* Feature 1: Spherical masks of the cube data is now supported
* Feature 2: Using spherical masks, atomic site averages and totals are now supported natively. These can be used, respectively, for getting the average electrostatic potential around a site using a V_HARTREE file from CP2K or the total spin on a site using a SPIN_DENSITY file from CP2K. These features are useful as an alternative to Bader partitioning for these properties when the bader executable is not available.
* Fix 1: Previously, cube files were loaded using for loops, which was prohibitively slow for files >1Gb. Now it is done with numpy and is much faster.

## TODO (if any)

* While not necessary, it would be nice to support multiprocessing for the atomic site functions. These can be pretty expensive when the cube files are >1Gb. I previously used the multiprocessing module for this, but ran into some errors while trying it out. It was exceeding the memory available for the Drone, and since the Drone is supposed to be automatic/not require user modifications, I removed multiprocessing for robustness, but it would be nice to have it back at some point. 
* New tests for the class methods have not been added yet.


## Checklist

Work-in-progress pull requests are encouraged, but please put [WIP]
in the pull request title.

Before a pull request can be merged, the following items must be checked:

- [x ] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). The easiest way to handle this
      is to run the following in the **correct sequence** on your local machine. Start with running
      [black](https://black.readthedocs.io/en/stable/index.html) on your new code. This will automatically reformat
      your code to PEP8 conventions and removes most issues. Then run 
      [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/), followed by 
      [flake8](http://flake8.pycqa.org/en/latest/).
- [x ] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [ x] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) to type check your code.
- [ ] Tests have been added for any new functionality or bug fixes.
- [x ] All linting and tests pass.

Note that the CI system will run all the above checks. But it will be much more efficient if you already fix most 
errors prior to submitting the PR. It is highly recommended that you use the pre-commit hook provided in the pymatgen 
repository. Simply `cp pre-commit .git/hooks` and a check will be run prior to allowing commits.
