### PR TITLE
[WIP] change the relative location of the filename for source code lookup. Fixes #2126 

### DIFF
--- a/docs_rst/conf-normal.py
+++ b/docs_rst/conf-normal.py
@@ -340,9 +340,12 @@ def linkcode_resolve(domain, info):
         return None
 
     try:
-        filename = "pymatgen/%s#L%d-L%d" % find_source()
+        rel_path, line_start, line_end = find_source()
+        # __file__ is imported from pymatgen.core
+        filename = f"pymatgen/core/{rel_path}#L{line_start}-L{line_end}"
     except:
+        # no need to be relative to core here as module includes full path.
         filename = info["module"].replace(".", "/") + ".py"
 
     tag = "v" + __version__
-    return "https://github.com/materialsproject/pymatgen/blob/%s/pymatgen/%s" % (tag, filename)
+    return f"https://github.com/materialsproject/pymatgen/blob/{tag}/{filename}"

--- a/docs_rst/conf.py
+++ b/docs_rst/conf.py
@@ -340,9 +340,12 @@ def linkcode_resolve(domain, info):
         return None
 
     try:
-        filename = "pymatgen/%s#L%d-L%d" % find_source()
+        rel_path, line_start, line_end = find_source()
+        # __file__ is imported from pymatgen.core
+        filename = f"pymatgen/core/{rel_path}#L{line_start}-L{line_end}"
     except:
+        # no need to be relative to core here as module includes full path.
         filename = info["module"].replace(".", "/") + ".py"
 
     tag = "v" + __version__
-    return "https://github.com/materialsproject/pymatgen/blob/%s/pymatgen/%s" % (tag, filename)
+    return f"https://github.com/materialsproject/pymatgen/blob/{tag}/{filename}"


### PR DESCRIPTION
## Summary

* Generation of links to source code in the pymatgen.core have been fixed.
* Generation of links to source code where the line numbers cannot be found have been fixed.

This fixes #2126. I was unsure on the difference between conf-docset.py, conf-normal.py and conf.py so I only updated the ones with the linkcode_resolve function in.

## TODO (if any)

Generation of the Documentation, I couldn't find a guide to building the documentation and when I do I get far more changes than I expect as well as 608 warnings from sphinx some of which are listed below:

* Adds '()' to end of property names in genindex.html
* Adds a space to the end of the meta tags
* Removes alt="Documentation Home" from every page. 

Also I have noticed that the documentation for BoltzTraP2 is missing on the [doc site](https://pymatgen.org/pymatgen.electronic_structure.boltztrap2.html) however when I build it is present.

Before a pull request can be merged, the following items must be checked:

- [ ] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). The easiest way to handle this
      is to run the following in the **correct sequence** on your local machine. Start with running
      [black](https://black.readthedocs.io/en/stable/index.html) on your new code. This will automatically reformat
      your code to PEP8 conventions and removes most issues. Then run 
      [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/), followed by 
      [flake8](http://flake8.pycqa.org/en/latest/).
- [x] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [x] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) to type check your code.
- [x] Tests have been added for any new functionality or bug fixes.
- [ ] All linting and tests pass.
