### PR TITLE
Symmetrically equivalent surfaces in slabs

### DIFF
--- a/pymatgen/core/surface.py
+++ b/pymatgen/core/surface.py
@@ -313,8 +313,8 @@ class Slab(Structure):
         sg = SpacegroupAnalyzer(self, symprec=symprec)
         symmops = sg.get_point_group_operations()
 
-        if sg.is_laue() or any([op.translation_vector[2] != 0 for op in symmops]) or \
-                any([np.alltrue(op.rotation_matrix[2] == np.array([0,0,-1])) for op in symmops]):
+        if sg.is_laue() or any(op.translation_vector[2] != 0 for op in symmops) or \
+                any(np.alltrue(op.rotation_matrix[2] == np.array([0,0,-1])) for op in symmops):
             # Check for inversion symmetry. Or if sites from surface (a) can be translated
             # to surface (b) along the [hkl]-axis, surfaces are symmetric. Or because the
             # two surfaces of our slabs are always parallel to the (hkl) plane,

--- a/pymatgen/core/surface.py
+++ b/pymatgen/core/surface.py
@@ -316,7 +316,7 @@ class Slab(Structure):
         if (
             sg.is_laue()
             or any(op.translation_vector[2] != 0 for op in symmops)
-            or any(np.alltrue(op.rotation_matrix[2] == np.array([0,0,-1])) for op in symmops)
+            or any(np.alltrue(op.rotation_matrix[2] == np.array([0, 0, -1])) for op in symmops)
         ):
             # Check for inversion symmetry. Or if sites from surface (a) can be translated
             # to surface (b) along the [hkl]-axis, surfaces are symmetric. Or because the

--- a/pymatgen/core/surface.py
+++ b/pymatgen/core/surface.py
@@ -324,8 +324,8 @@ class Slab(Structure):
             # if sites from surface (a) can be translated to
             # surface (b) along the [hkl]-axis, surfaces are symmetric
             return True
-        else:
-            return False
+
+        return False
 
     def get_sorted_structure(self, key=None, reverse=False):
         """

--- a/pymatgen/core/surface.py
+++ b/pymatgen/core/surface.py
@@ -313,13 +313,16 @@ class Slab(Structure):
         sg = SpacegroupAnalyzer(self, symprec=symprec)
         symmops = sg.get_point_group_operations()
 
-        if sg.is_laue() or any(op.translation_vector[2] != 0 for op in symmops) or \
-                any(np.alltrue(op.rotation_matrix[2] == np.array([0,0,-1])) for op in symmops):
+        if (
+            sg.is_laue()
+            or any(op.translation_vector[2] != 0 for op in symmops)
+            or any(np.alltrue(op.rotation_matrix[2] == np.array([0,0,-1])) for op in symmops)
+        ):
             # Check for inversion symmetry. Or if sites from surface (a) can be translated
             # to surface (b) along the [hkl]-axis, surfaces are symmetric. Or because the
             # two surfaces of our slabs are always parallel to the (hkl) plane,
             # any operation where theres an (hkl) mirror plane has surface symmetry
-                return True
+            return True
         return False
 
     def get_sorted_structure(self, key=None, reverse=False):
@@ -1331,8 +1334,7 @@ class SlabGenerator:
                     nonstoich_slabs.append(slab)
 
         if len(slab) <= len(self.parent):
-            warnings.warn("Too many sites removed, please use a larger slab "
-                          "size.")
+            warnings.warn("Too many sites removed, please use a larger slab size.")
 
         return nonstoich_slabs
 

--- a/pymatgen/core/surface.py
+++ b/pymatgen/core/surface.py
@@ -313,19 +313,15 @@ class Slab(Structure):
         sg = SpacegroupAnalyzer(self, symprec=symprec)
         symmops = sg.get_point_group_operations()
 
-        if sg.is_laue():
-            # check for inversion symmetry
-            return True
-        elif any([np.alltrue(op.rotation_matrix[2] == np.array([0,0,-1])) for op in symmops]):
-            # Because the two surfaces of our slabs are always parallel to the (hkl) plane,
+        if sg.is_laue() or any([op.translation_vector[2] != 0 for op in symmops]) or \
+                any([np.alltrue(op.rotation_matrix[2] == np.array([0,0,-1])) for op in symmops]):
+            # Check for inversion symmetry. Or if sites from surface (a) can be translated
+            # to surface (b) along the [hkl]-axis, surfaces are symmetric. Or because the
+            # two surfaces of our slabs are always parallel to the (hkl) plane,
             # any operation where theres an (hkl) mirror plane has surface symmetry
-            return True
-        elif any([op.translation_vector[2] != 0 for op in symmops]):
-            # if sites from surface (a) can be translated to
-            # surface (b) along the [hkl]-axis, surfaces are symmetric
-            return True
-
-        return False
+                return True
+        else:
+            return False
 
     def get_sorted_structure(self, key=None, reverse=False):
         """

--- a/pymatgen/core/surface.py
+++ b/pymatgen/core/surface.py
@@ -300,17 +300,32 @@ class Slab(Structure):
 
     def is_symmetric(self, symprec=0.1):
         """
-        Checks if slab is symmetric, i.e., contains inversion symmetry.
+        Checks if surfaces are symmetric, i.e., contains inversion, mirror on x-y plane,
+            glide on x/y (translation and reflection) or screw axis (rotation and translation).
 
         Args:
             symprec (float): Symmetry precision used for SpaceGroup analyzer.
 
         Returns:
-            (bool) Whether slab contains inversion symmetry.
+            (bool) Whether surfaces are symmetric.
         """
 
         sg = SpacegroupAnalyzer(self, symprec=symprec)
-        return sg.is_laue()
+        symmops = sg.get_point_group_operations()
+
+        if sg.is_laue():
+            # check for inversion symmetry
+            return True
+        elif any([np.alltrue(op.rotation_matrix[2] == np.array([0,0,-1])) for op in symmops]):
+            # Because the two surfaces of our slabs are always parallel to the xy plane,
+            # any operation where theres an x-y mirror plane has surface symmetry
+            return True
+        elif any([op.translation_vector[2] != 0 for op in symmops]):
+            # if sites from surface a can be translated to
+            # surface b along the z-axis, surfaces are symmetric
+            return True
+        else:
+            return False
 
     def get_sorted_structure(self, key=None, reverse=False):
         """
@@ -596,38 +611,6 @@ class Slab(Structure):
         if tag:
             self.add_site_property("is_surf_site", properties)
         return surf_sites_dict
-
-    def have_equivalent_surfaces(self):
-        """
-        Check if we have same number of equivalent sites on both surfaces.
-        This is an alternative to checking Laue symmetry (is_symmetric())
-        if we want to ensure both surfaces in the slab are the same
-        """
-
-        # tag the sites as either surface sites or not
-        self.get_surface_sites(tag=True)
-
-        a = SpacegroupAnalyzer(self)
-        symm_structure = a.get_symmetrized_structure()
-
-        # ensure each site on one surface has a
-        # corresponding equivalent site on the other
-        equal_surf_sites = []
-        for equ in symm_structure.equivalent_sites:
-            # Top and bottom are arbitrary, we will just determine
-            # if one site is on one side of the slab or the other
-            top, bottom = 0, 0
-            for s in equ:
-                if s.is_surf_site:
-                    if s.frac_coords[2] > self.center_of_mass[2]:
-                        top += 1
-                    else:
-                        bottom += 1
-            # Check to see if the number of equivalent sites
-            # on one side of the slab are equal to the other
-            equal_surf_sites.append(top == bottom)
-
-        return all(equal_surf_sites)
 
     def get_symmetric_site(self, point, cartesian=False):
         """
@@ -1305,7 +1288,8 @@ class SlabGenerator:
             energy=init_slab.energy,
         )
 
-    def nonstoichiometric_symmetrized_slab(self, init_slab, tol=1e-3):
+    def nonstoichiometric_symmetrized_slab(self, init_slab):
+
         """
         This method checks whether or not the two surfaces of the slab are
         equivalent. If the point group of the slab has an inversion symmetry (
@@ -1317,15 +1301,12 @@ class SlabGenerator:
 
         Arg:
             init_slab (Structure): A single slab structure
-            tol (float): Tolerance for SpaceGroupanalyzer.
 
         Returns:
             Slab (structure): A symmetrized Slab object.
         """
 
-        sg = SpacegroupAnalyzer(init_slab, symprec=tol)
-
-        if sg.is_laue():
+        if init_slab.is_symmetric():
             return [init_slab]
 
         nonstoich_slabs = []
@@ -1350,13 +1331,13 @@ class SlabGenerator:
                     break
 
                 # Check if the altered surface is symmetric
-                sg = SpacegroupAnalyzer(slab, symprec=tol)
-                if sg.is_laue():
+                if slab.is_symmetric():
                     asym = False
                     nonstoich_slabs.append(slab)
 
         if len(slab) <= len(self.parent):
-            warnings.warn("Too many sites removed, please use a larger slab " "size.")
+            warnings.warn("Too many sites removed, please use a larger slab "
+                          "size.")
 
         return nonstoich_slabs
 

--- a/pymatgen/core/surface.py
+++ b/pymatgen/core/surface.py
@@ -320,8 +320,7 @@ class Slab(Structure):
             # two surfaces of our slabs are always parallel to the (hkl) plane,
             # any operation where theres an (hkl) mirror plane has surface symmetry
                 return True
-        else:
-            return False
+        return False
 
     def get_sorted_structure(self, key=None, reverse=False):
         """

--- a/pymatgen/core/surface.py
+++ b/pymatgen/core/surface.py
@@ -300,8 +300,8 @@ class Slab(Structure):
 
     def is_symmetric(self, symprec=0.1):
         """
-        Checks if surfaces are symmetric, i.e., contains inversion, mirror on x-y plane,
-            glide on x/y (translation and reflection) or screw axis (rotation and translation).
+        Checks if surfaces are symmetric, i.e., contains inversion, mirror on (hkl) plane,
+            or screw axis (rotation and translation) about [hkl].
 
         Args:
             symprec (float): Symmetry precision used for SpaceGroup analyzer.
@@ -317,12 +317,12 @@ class Slab(Structure):
             # check for inversion symmetry
             return True
         elif any([np.alltrue(op.rotation_matrix[2] == np.array([0,0,-1])) for op in symmops]):
-            # Because the two surfaces of our slabs are always parallel to the xy plane,
-            # any operation where theres an x-y mirror plane has surface symmetry
+            # Because the two surfaces of our slabs are always parallel to the (hkl) plane,
+            # any operation where theres an (hkl) mirror plane has surface symmetry
             return True
         elif any([op.translation_vector[2] != 0 for op in symmops]):
-            # if sites from surface a can be translated to
-            # surface b along the z-axis, surfaces are symmetric
+            # if sites from surface (a) can be translated to
+            # surface (b) along the [hkl]-axis, surfaces are symmetric
             return True
         else:
             return False

--- a/pymatgen/core/tests/test_surface.py
+++ b/pymatgen/core/tests/test_surface.py
@@ -59,10 +59,19 @@ class SlabTest(PymatgenTest):
             ],
         )
 
+        m = [[3.913449, 0, 0],
+             [0, 3.913449, 0],
+             [0, 0, 5.842644]]
+        latt = Lattice(m)
+        fcoords = [[0.5, 0, 0.222518], [0, 0.5, 0.777482],
+                   [0, 0, 0], [0, 0, 0.5], [0.5, 0.5, 0]]
+        non_laue = Structure(latt, ['Nb', 'Nb', 'N', 'N', 'N'], fcoords)
+
         self.ti = Ti
         self.agfcc = Ag_fcc
         self.zno1 = zno1
         self.zno55 = zno55
+        self.nonlaue = non_laue
         self.h = Structure(Lattice.cubic(3), ["H"], [[0, 0, 0]])
         self.libcc = Structure(Lattice.cubic(3.51004), ["Li", "Li"], [[0, 0, 0], [0.5, 0.5, 0.5]])
 
@@ -241,6 +250,13 @@ class SlabTest(PymatgenTest):
             # Check if slabs are all symmetric
             self.assertEqual(assymetric_count, 0)
             self.assertEqual(symmetric_count, len(slabs))
+
+        # Check if we can generate symmetric slabs from bulk with no inversion
+        all_non_laue_slabs = generate_all_slabs(self.nonlaue,
+                                                1, 15, 15,
+                                                symmetrize=True)
+        self.assertTrue(len(all_non_laue_slabs) > 0)
+
 
     def test_get_symmetric_sites(self):
 

--- a/pymatgen/core/tests/test_surface.py
+++ b/pymatgen/core/tests/test_surface.py
@@ -174,7 +174,6 @@ class SlabTest(PymatgenTest):
             total_surf_sites = sum([len(surf_sites_dict[key]) for key in surf_sites_dict.keys()])
             self.assertTrue(slab.is_symmetric())
             self.assertEqual(total_surf_sites / 2, 4)
-            self.assertTrue(slab.have_equivalent_surfaces())
 
             # Test if the ratio of surface sites per area is
             # constant, ie are the surface energies the same

--- a/pymatgen/core/tests/test_surface.py
+++ b/pymatgen/core/tests/test_surface.py
@@ -252,7 +252,6 @@ class SlabTest(PymatgenTest):
         all_non_laue_slabs = generate_all_slabs(self.nonlaue, 1, 15, 15, symmetrize=True)
         self.assertTrue(len(all_non_laue_slabs) > 0)
 
-
     def test_get_symmetric_sites(self):
 
         # Check to see if we get an equivalent site on one

--- a/pymatgen/core/tests/test_surface.py
+++ b/pymatgen/core/tests/test_surface.py
@@ -59,12 +59,9 @@ class SlabTest(PymatgenTest):
             ],
         )
 
-        m = [[3.913449, 0, 0],
-             [0, 3.913449, 0],
-             [0, 0, 5.842644]]
+        m = [[3.913449, 0, 0], [0, 3.913449, 0], [0, 0, 5.842644]]
         latt = Lattice(m)
-        fcoords = [[0.5, 0, 0.222518], [0, 0.5, 0.777482],
-                   [0, 0, 0], [0, 0, 0.5], [0.5, 0.5, 0]]
+        fcoords = [[0.5, 0, 0.222518], [0, 0.5, 0.777482], [0, 0, 0], [0, 0, 0.5], [0.5, 0.5, 0]]
         non_laue = Structure(latt, ['Nb', 'Nb', 'N', 'N', 'N'], fcoords)
 
         self.ti = Ti
@@ -252,9 +249,7 @@ class SlabTest(PymatgenTest):
             self.assertEqual(symmetric_count, len(slabs))
 
         # Check if we can generate symmetric slabs from bulk with no inversion
-        all_non_laue_slabs = generate_all_slabs(self.nonlaue,
-                                                1, 15, 15,
-                                                symmetrize=True)
+        all_non_laue_slabs = generate_all_slabs(self.nonlaue, 1, 15, 15, symmetrize=True)
         self.assertTrue(len(all_non_laue_slabs) > 0)
 
 

--- a/pymatgen/core/tests/test_surface.py
+++ b/pymatgen/core/tests/test_surface.py
@@ -62,7 +62,7 @@ class SlabTest(PymatgenTest):
         m = [[3.913449, 0, 0], [0, 3.913449, 0], [0, 0, 5.842644]]
         latt = Lattice(m)
         fcoords = [[0.5, 0, 0.222518], [0, 0.5, 0.777482], [0, 0, 0], [0, 0, 0.5], [0.5, 0.5, 0]]
-        non_laue = Structure(latt, ['Nb', 'Nb', 'N', 'N', 'N'], fcoords)
+        non_laue = Structure(latt, ["Nb", "Nb", "N", "N", "N"], fcoords)
 
         self.ti = Ti
         self.agfcc = Ag_fcc


### PR DESCRIPTION
This pull request contains an improvement for analyzing surface symmetry of slabs. A slab now has symmetrically equivalent surfaces if (hkl) is a mirror plane, if [hkl] is a screw axis or if the slab has inversion symmetry.

Include a summary of major changes in bullet points:

* Modifications to is_symmetric() Slab class method. If slab contains inversion symmetry, the (hkl) plane is a mirror plane, or there is a screw axis about [hkl], the surfaces of the slab are symmetrically equivalent.
* Test for generating slabs that don't need inversion
* Remove really inefficient Slab class method for checking equivalent surfaces have_equivalent_surfaces()
* Modify SlabGenerator class method nonstoichiometric_symmetrized_slab() to use is_symmetric() when generating slabs
