### PR TITLE
Ensure all MP2020 corrections have unique names; tweak oxi state detection

### DIFF
--- a/pymatgen/entries/compatibility.py
+++ b/pymatgen/entries/compatibility.py
@@ -1012,7 +1012,7 @@ class MaterialsProject2020Compatibility(Compatibility):
         # first check for a pre-populated oxidation states key
         # the key is expected to comprise a dict corresponding to the first element output by
         # Composition.oxi_state_guesses(), e.g. {'Al': 3.0, 'S': 2.0, 'O': -2.0} for 'Al2SO4'
-        if not entry.data.get("oxidation_states"):
+        if "oxidation_states" not in entry.data.keys():
             # try to guess the oxidation states from composition
             # for performance reasons, fail if the composition is too large
             try:

--- a/pymatgen/entries/compatibility.py
+++ b/pymatgen/entries/compatibility.py
@@ -1048,7 +1048,7 @@ class MaterialsProject2020Compatibility(Compatibility):
                             self.comp_correction[anion],
                             comp[anion],
                             uncertainty_per_atom=self.comp_errors[anion],
-                            name="MP2020 anion correction",
+                            name="MP2020 anion correction ({})".format(anion),
                             cls=self.as_dict(),
                         )
                     )

--- a/pymatgen/entries/compatibility.py
+++ b/pymatgen/entries/compatibility.py
@@ -1024,13 +1024,13 @@ class MaterialsProject2020Compatibility(Compatibility):
                 entry.data["oxidation_states"] = {}
             else:
                 entry.data["oxidation_states"] = oxi_states[0]
-        
+
         if entry.data["oxidation_states"] == {}:
             warnings.warn(
-                    f"Failed to guess oxidation states for Entry {entry.entry_id} "
-                    f"({entry.composition.reduced_formula}. Assigning anion correction to "
-                    "only the most electronegative atom."
-                )
+                f"Failed to guess oxidation states for Entry {entry.entry_id} "
+                f"({entry.composition.reduced_formula}. Assigning anion correction to "
+                "only the most electronegative atom."
+            )
 
         for anion in ["Br", "I", "Se", "Si", "Sb", "Te", "H", "N", "F", "Cl"]:
             if Element(anion) in comp and anion in self.comp_correction:

--- a/pymatgen/entries/compatibility.py
+++ b/pymatgen/entries/compatibility.py
@@ -1008,31 +1008,33 @@ class MaterialsProject2020Compatibility(Compatibility):
             )
 
         # Check for anion corrections
+        # only apply anion corrections if the element is an anion
+        # first check for a pre-populated oxidation states key
+        # the key is expected to comprise a dict corresponding to the first element output by
+        # Composition.oxi_state_guesses(), e.g. {'Al': 3.0, 'S': 2.0, 'O': -2.0} for 'Al2SO4'
+        if not entry.data.get("oxidation_states"):
+            # try to guess the oxidation states from composition
+            # for performance reasons, fail if the composition is too large
+            try:
+                oxi_states = entry.composition.oxi_state_guesses(max_sites=-20)
+            except ValueError:
+                oxi_states = []
+
+            if oxi_states == []:
+                entry.data["oxidation_states"] = {}
+            else:
+                entry.data["oxidation_states"] = oxi_states[0]
+        
+        if entry.data["oxidation_states"] == {}:
+            warnings.warn(
+                    f"Failed to guess oxidation states for Entry {entry.entry_id} "
+                    f"({entry.composition.reduced_formula}. Assigning anion correction to "
+                    "only the most electronegative atom."
+                )
+
         for anion in ["Br", "I", "Se", "Si", "Sb", "Te", "H", "N", "F", "Cl"]:
             if Element(anion) in comp and anion in self.comp_correction:
                 apply_correction = False
-                # only apply anion corrections if the element is an anion
-                # first check for a pre-populated oxidation states key
-                # the key is expected to comprise a dict corresponding to the first element output by
-                # Composition.oxi_state_guesses(), e.g. {'Al': 3.0, 'S': 2.0, 'O': -2.0} for 'Al2SO4'
-                if not entry.data.get("oxidation_states"):
-                    # try to guess the oxidation states from composition
-                    # for performance reasons, fail if the composition is too large
-                    try:
-                        oxi_states = entry.composition.oxi_state_guesses(max_sites=-20)
-                    except ValueError:
-                        oxi_states = []
-
-                    if oxi_states == []:
-                        warnings.warn(
-                            f"Failed to guess oxidation states for Entry {entry.entry_id} "
-                            f"({entry.composition.reduced_formula}. Assigning anion correction to "
-                            "only the most electronegative atom."
-                        )
-                        entry.data["oxidation_states"] = {}
-                    else:
-                        entry.data["oxidation_states"] = oxi_states[0]
-
                 # if the oxidation_states key is not populated, only apply the correction if the anion
                 # is the most electronegative element
                 if entry.data["oxidation_states"].get(anion, 0) < 0:
@@ -1052,6 +1054,7 @@ class MaterialsProject2020Compatibility(Compatibility):
                             cls=self.as_dict(),
                         )
                     )
+
         # GGA / GGA+U mixing scheme corrections
         calc_u = entry.parameters.get("hubbards", None)
         calc_u = defaultdict(int) if calc_u is None else calc_u

--- a/pymatgen/entries/tests/test_compatibility.py
+++ b/pymatgen/entries/tests/test_compatibility.py
@@ -712,12 +712,31 @@ class MaterialsProject2020CompatibilityTest(unittest.TestCase):
             },
         )
 
+        # An entry that should receive multiple anion corrections if oxidation
+        # states are populated
+        entry_multi_anion = ComputedEntry(
+            "C8N4Cl4",
+            -87.69656726,
+            correction=0.0,
+            parameters={
+                "run_type": "GGA",
+                "is_hubbard": False,
+                "pseudo_potential": {"functional": "PBE", "labels": ["C", "N", "Cl"], "pot_type": "paw"},
+                "hubbards": {},
+                "potcar_symbols": ["PBE C", "PBE N", "PBE Cl"],
+                "oxide_type": "None",
+            },
+        )
+
         with pytest.warns(UserWarning, match="Failed to guess oxidation state"):
             e1 = self.compat.process_entry(entry_blank)
             self.assertAlmostEqual(e1.correction, -0.422)
 
         e2 = self.compat.process_entry(entry_oxi)
         self.assertAlmostEqual(e2.correction, -0.687 + -3.202 * 2 + -0.614 * 8)
+
+        e3 = self.compat.process_entry(entry_multi_anion)
+        self.assertAlmostEqual(e3.correction, -0.361 * 4 + -0.614 * 4)
 
     def test_correction_values(self):
         # test_corrections


### PR DESCRIPTION
Ensures that energy corrections applied to each anion have unique names (e.g., N vs. Cl vs. Br).

If this is not the case, then in a compound with multiple corrected anions like `C2NCl`,  `Compatibility` will apply a correction to the first anion, then think the second is a duplicate, warning

```
warnings.warn(
2021-05-01T11:22:13.8878461Z /users/home/ghrunner/actions-runner/_work/_tool/Python/3.8.7/x64/lib/python3.8/site-packages/pymatgen/entries/compatibility.py:579: UserWarning: Entry mp-567221 already has an energy adjustment called MP2020 anion correction, but its value differs from the value of -0.718 calculated here. This Entry will be discarded.
```

Also makes some tweaks to oxidation state detection to work better with the Builders.