### PR TITLE
Add spacegroup details to SymmetrizedStructure string 

### DIFF
--- a/pymatgen/symmetry/structure.py
+++ b/pymatgen/symmetry/structure.py
@@ -99,6 +99,7 @@ class SymmetrizedStructure(Structure):
             "SymmetrizedStructure",
             "Full Formula ({s})".format(s=self.composition.formula),
             "Reduced Formula: {}".format(self.composition.reduced_formula),
+            "Spacegroup: {} ({})".format(self.spacegroup.int_symbol, self.spacegroup.int_number),
         ]
 
         def to_s(x):


### PR DESCRIPTION
Wyckoff letters are meaningless without the context of the spacegroup, current SymmetrizedStructure __str__ doesn't include the spacegroup so I've added it in - this is purely a cosmetic change.