### PR TITLE
Update MPScanRelaxSet doc string

### DIFF
--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -891,12 +891,11 @@ class MPScanRelaxSet(DictSet):
     (SCAN) metaGGA density functional.
 
     Notes:
-        1. This functional is currently not officially supported in VASP. Source
-        code may be obtained by contacting the authors of the manuscript in the
-        References section. The original SCAN functional, available from VASP 5.4.3
-        onwards, maybe used instead by passing `user_incar_settings={"METAGGA": "SCAN"}`
-        when instantiating this InputSet. r2SCAN and SCAN are expected to yield
-        very similar results.
+        1. This functional is officially supported in VASP 6.0.0 and above. On older version,
+        source code may be obtained by contacting the authors of the referenced manuscript.
+        The original SCAN functional, available from VASP 5.4.3 onwards, maybe used instead
+        by passing `user_incar_settings={"METAGGA": "SCAN"}` when instantiating this InputSet.
+        r2SCAN and SCAN are expected to yield very similar results.
 
         2. Meta-GGA calculations require POTCAR files that include
         information on the kinetic energy density of the core-electrons,


### PR DESCRIPTION
[VASP officially supports r2SCAN in v6](https://www.vasp.at/forum/viewtopic.php?f=4&t=18058&p=20113&hilit=r2scan#p20113).