### PR TITLE
Add new compact style for hkl annotations to peaks in diffraction patterns

### DIFF
--- a/pymatgen/analysis/diffraction/core.py
+++ b/pymatgen/analysis/diffraction/core.py
@@ -79,7 +79,7 @@ class AbstractDiffractionPatternCalculator(abc.ABC):
         self,
         structure,
         two_theta_range=(0, 90),
-        annotate_peaks="full",
+        annotate_peaks="compact",
         ax=None,
         with_labels=True,
         fontsize=16,
@@ -94,9 +94,9 @@ class AbstractDiffractionPatternCalculator(abc.ABC):
                 None if you want all diffracted beams within the limiting
                 sphere of radius 2 / wavelength.
             annotate_peaks (str or None): Whether and how to annotate the peaks
-                with hkl indices.  Default is 'full', e.g. (1, 0, 0). If
-                'compact', show short version (oriented vertically), e.g.
-                100.  If None, do not annotate.
+                with hkl indices.  Default is 'compact', i.e. show short
+                version (oriented vertically), e.g. 100.  If 'full', show
+                long version, e.g. (1, 0, 0).  If None, do not show anything.
             ax: matplotlib :class:`Axes` or None if a new figure should be
                 created.
             with_labels: True to add xlabels and ylabels to the plot.
@@ -176,9 +176,9 @@ class AbstractDiffractionPatternCalculator(abc.ABC):
                 None if you want all diffracted beams within the limiting
                 sphere of radius 2 / wavelength.
             annotate_peaks (str or None): Whether and how to annotate the peaks
-                with hkl indices.  Default is 'full', e.g. (1, 0, 0). If
-                'compact', show short version (oriented vertically), e.g.
-                100.  If None, do not annotate.
+                with hkl indices.  Default is 'compact', i.e. show short
+                version (oriented vertically), e.g. 100.  If 'full', show
+                long version, e.g. (1, 0, 0).  If None, do not show anything.
         """
         self.get_plot(structure, **kwargs).show()
 
@@ -194,9 +194,9 @@ class AbstractDiffractionPatternCalculator(abc.ABC):
                 None if you want all diffracted beams within the limiting
                 sphere of radius 2 / wavelength.
             annotate_peaks (str or None): Whether and how to annotate the peaks
-                with hkl indices.  Default is 'full', e.g. (1, 0, 0). If
-                'compact', show short version (oriented vertically), e.g.
-                100.  If None, do not annotate.
+                with hkl indices.  Default is 'compact', i.e. show short
+                version (oriented vertically), e.g. 100.  If 'full', show
+                long version, e.g. (1, 0, 0).  If None, do not show anything.
             fontsize: (int) fontsize for peak labels.
         """
         import matplotlib.pyplot as plt

--- a/pymatgen/analysis/diffraction/core.py
+++ b/pymatgen/analysis/diffraction/core.py
@@ -131,7 +131,7 @@ class AbstractDiffractionPatternCalculator(abc.ABC):
                         fontsize=fontsize,
                     )
                 elif annotate_peaks == "compact":
-                    if all([all([i < 10 for i in hkl_tuple]) for hkl_tuple in hkl_tuples]):
+                    if all(all(i < 10 for i in hkl_tuple) for hkl_tuple in hkl_tuples):
                         label = ",".join(["".join([str(i) for i in hkl_tuple]) for hkl_tuple in hkl_tuples])
                         # 'compact' label.  Would be unclear for indices >= 10
                         # It would have more than 3 figures, e.g. 1031

--- a/pymatgen/analysis/diffraction/core.py
+++ b/pymatgen/analysis/diffraction/core.py
@@ -79,7 +79,7 @@ class AbstractDiffractionPatternCalculator(abc.ABC):
         self,
         structure,
         two_theta_range=(0, 90),
-        annotate_peaks=True,
+        annotate_peaks="full",
         ax=None,
         with_labels=True,
         fontsize=16,
@@ -93,9 +93,12 @@ class AbstractDiffractionPatternCalculator(abc.ABC):
                 two_thetas to calculate in degrees. Defaults to (0, 90). Set to
                 None if you want all diffracted beams within the limiting
                 sphere of radius 2 / wavelength.
-            annotate_peaks: Whether to annotate the peaks with plane
-                information.
-            ax: matplotlib :class:`Axes` or None if a new figure should be created.
+            annotate_peaks (str or None): Whether and how to annotate the peaks
+                with hkl indices.  Default is 'full', e.g. (1, 0, 0). If
+                'compact', show short version (oriented vertically), e.g.
+                100.  If None, do not annotate.
+            ax: matplotlib :class:`Axes` or None if a new figure should be
+                created.
             with_labels: True to add xlabels and ylabels to the plot.
             fontsize: (int) fontsize for peak labels.
 
@@ -112,16 +115,44 @@ class AbstractDiffractionPatternCalculator(abc.ABC):
             import matplotlib.pyplot as plt
 
         xrd = self.get_pattern(structure, two_theta_range=two_theta_range)
+        imax = max(xrd.y)
 
         for two_theta, i, hkls, d_hkl in zip(xrd.x, xrd.y, xrd.hkls, xrd.d_hkls):
             if two_theta_range[0] <= two_theta <= two_theta_range[1]:
-                label = ", ".join([str(hkl["hkl"]) for hkl in hkls])
+                hkl_tuples = [hkl["hkl"] for hkl in hkls]
+                label = ", ".join([str(hkl_tuple) for hkl_tuple in hkl_tuples])  # 'full' label
                 ax.plot([two_theta, two_theta], [0, i], color="k", linewidth=3, label=label)
-                if annotate_peaks:
+
+                if annotate_peaks == "full":
                     ax.annotate(
                         label,
                         xy=[two_theta, i],
                         xytext=[two_theta, i],
+                        fontsize=fontsize,
+                    )
+                elif annotate_peaks == "compact":
+                    if all([all([i < 10 for i in hkl_tuple]) for hkl_tuple in hkl_tuples]):
+                        label = ",".join(["".join([str(i) for i in hkl_tuple]) for hkl_tuple in hkl_tuples])
+                        # 'compact' label.  Would be unclear for indices >= 10
+                        # It would have more than 3 figures, e.g. 1031
+
+                    if i / imax > 0.5:  # Big peak: annotation on the side
+                        xytext = [-fontsize / 4, 0]
+                        ha = "right"
+                        va = "top"
+                    else:  # Small peak: annotation on top
+                        xytext = [0, 10]
+                        ha = "center"
+                        va = "bottom"
+
+                    ax.annotate(
+                        label,
+                        xy=[two_theta, i],
+                        xytext=xytext,
+                        textcoords="offset points",
+                        va=va,
+                        ha=ha,
+                        rotation=90,
                         fontsize=fontsize,
                     )
 
@@ -144,8 +175,10 @@ class AbstractDiffractionPatternCalculator(abc.ABC):
                 two_thetas to calculate in degrees. Defaults to (0, 90). Set to
                 None if you want all diffracted beams within the limiting
                 sphere of radius 2 / wavelength.
-            annotate_peaks (bool): Whether to annotate the peaks with plane
-                information.
+            annotate_peaks (str or None): Whether and how to annotate the peaks
+                with hkl indices.  Default is 'full', e.g. (1, 0, 0). If
+                'compact', show short version (oriented vertically), e.g.
+                100.  If None, do not annotate.
         """
         self.get_plot(structure, **kwargs).show()
 
@@ -160,8 +193,10 @@ class AbstractDiffractionPatternCalculator(abc.ABC):
                 two_thetas to calculate in degrees. Defaults to (0, 90). Set to
                 None if you want all diffracted beams within the limiting
                 sphere of radius 2 / wavelength.
-            annotate_peaks (bool): Whether to annotate the peaks with plane
-                information.
+            annotate_peaks (str or None): Whether and how to annotate the peaks
+                with hkl indices.  Default is 'full', e.g. (1, 0, 0). If
+                'compact', show short version (oriented vertically), e.g.
+                100.  If None, do not annotate.
             fontsize: (int) fontsize for peak labels.
         """
         import matplotlib.pyplot as plt


### PR DESCRIPTION
Introducing a new optional style for the hkl labels in diffraction patterns (see example figure below).

The default style was not changed.  However, I would recommend making this new more-compact style the default because it prevents overlap of labels as in https://matgenb.materialsvirtuallab.org/2013/01/01/Calculating-XRD-patterns.html (a similar image can be seen here at the bottom)

```python
from pymatgen.core import Lattice, Structure
from pymatgen.analysis.diffraction.xrd import XRDCalculator
import matplotlib.pyplot as plt

a = 4.209
latt = Lattice.cubic(a)
struct = Structure(latt,  ["Cs", "Cl"], [[0, 0, 0], [0.5, 0.5, 0.5]])
c = XRDCalculator()
```

1. The new more-compact style:
```python
c.show_plot(struct, annotate_peaks='compact')
```
![Figure_1](https://user-images.githubusercontent.com/37553536/118284130-61af2e80-b4d0-11eb-8a22-c6c1093f5255.png)

2. The current default style (previously: True, now: 'full'):
```python
c.show_plot(struct, annotate_peaks='full')
```
![Figure_2](https://user-images.githubusercontent.com/37553536/118284646-eef28300-b4d0-11eb-83bd-75ed06849428.png)


