### PR TITLE
Bandstructure path name changes and Kpoint from_dict

### DIFF
--- a/pymatgen/electronic_structure/bandstructure.py
+++ b/pymatgen/electronic_structure/bandstructure.py
@@ -137,6 +137,25 @@ class Kpoint(MSONable):
             "@class": self.__class__.__name__,
         }
 
+    @classmethod
+    def from_dict(cls, d):
+        """
+        Create from dict.
+
+        Args:
+            A dict with all data for a kpoint object.
+
+        Returns:
+            A Kpoint object
+        """
+
+        return cls(
+            coords=d["fcoords"],
+            lattice=Lattice.from_dict(d["lattice"]),
+            coords_are_cartesian=False,
+            label=d["label"],
+        )
+
 
 class BandStructure:
     """

--- a/pymatgen/electronic_structure/tests/test_bandstructure.py
+++ b/pymatgen/electronic_structure/tests/test_bandstructure.py
@@ -51,6 +51,24 @@ class KpointTest(unittest.TestCase):
         self.assertListEqual(self.kpoint.as_dict()["fcoords"], [0.1, 0.4, -0.5])
         self.assertListEqual(self.kpoint.as_dict()["ccoords"], [1.0, 4.0, -5.0])
 
+    def test_from_dict(self):
+
+        d = self.kpoint.as_dict()
+
+        kpoint = Kpoint.from_dict(d)
+
+        self.assertEqual(kpoint.frac_coords[0], 0.1)
+        self.assertEqual(kpoint.frac_coords[1], 0.4)
+        self.assertEqual(kpoint.frac_coords[2], -0.5)
+        self.assertEqual(kpoint.a, 0.1)
+        self.assertEqual(kpoint.b, 0.4)
+        self.assertEqual(kpoint.c, -0.5)
+        self.assertEqual(kpoint.lattice, Lattice.cubic(10.0))
+        self.assertEqual(kpoint.cart_coords[0], 1.0)
+        self.assertEqual(kpoint.cart_coords[1], 4.0)
+        self.assertEqual(kpoint.cart_coords[2], -5.0)
+        self.assertEqual(kpoint.label, "X")
+
 
 class BandStructureSymmLine_test(PymatgenTest):
     def setUp(self):

--- a/pymatgen/symmetry/bandstructure.py
+++ b/pymatgen/symmetry/bandstructure.py
@@ -71,13 +71,13 @@ class HighSymmKpath(KPathBase):
                 should point. If all magnetic moments are provided as
                 vectors then this argument is not used.
             path_type (string): Chooses which convention to use to generate
-                the high symmetry path. Options are: 'setyawan_curtarolo', 'hinuma', 
-                'latimer_munro' for the Setyawan & Curtarolo, Hinuma et al., and  
-                Latimer & Munro conventions. Choosing 'all' will generate one path 
+                the high symmetry path. Options are: 'setyawan_curtarolo', 'hinuma',
+                'latimer_munro' for the Setyawan & Curtarolo, Hinuma et al., and
+                Latimer & Munro conventions. Choosing 'all' will generate one path
                 with points from all three conventions. Equivalent labels between
-                each will also be generated. Order will always be Latimer & Munro, 
-                Setyawan & Curtarolo, and Hinuma et al. Lengths for each of the paths 
-                will also be generated and output as a list. Note for 'all' the user 
+                each will also be generated. Order will always be Latimer & Munro,
+                Setyawan & Curtarolo, and Hinuma et al. Lengths for each of the paths
+                will also be generated and output as a list. Note for 'all' the user
                 will have to alter the labels on their own for plotting.
             symprec (float): Tolerance for symmetry finding
             angle_tolerance (float): Angle tolerance for symmetry finding.
@@ -248,7 +248,9 @@ of the input structure. Use `KPathSeek` for the path in the original author-inte
 
         n_op = len(rpg)
 
-        pairs = itertools.permutations([{"setyawan_curtarolo": sc_path}, {"latimer_munro": lm_path}, {"hinuma": hin_path}], r=2)
+        pairs = itertools.permutations(
+            [{"setyawan_curtarolo": sc_path}, {"latimer_munro": lm_path}, {"hinuma": hin_path}], r=2
+        )
         labels = {"setyawan_curtarolo": {}, "latimer_munro": {}, "hinuma": {}}
 
         for (a, b) in pairs:

--- a/pymatgen/symmetry/bandstructure.py
+++ b/pymatgen/symmetry/bandstructure.py
@@ -52,7 +52,7 @@ class HighSymmKpath(KPathBase):
         structure,
         has_magmoms=False,
         magmom_axis=None,
-        path_type="sc",
+        path_type="setyawan_curtarolo",
         symprec=0.01,
         angle_tolerance=5,
         atol=1e-5,

--- a/pymatgen/symmetry/bandstructure.py
+++ b/pymatgen/symmetry/bandstructure.py
@@ -71,14 +71,14 @@ class HighSymmKpath(KPathBase):
                 should point. If all magnetic moments are provided as
                 vectors then this argument is not used.
             path_type (string): Chooses which convention to use to generate
-                the high symmetry path. Options are: 'sc', 'hin', 'lm' for the
-                Setyawan & Curtarolo, Hinuma et al., and  Latimer & Munro conventions.
-                Choosing 'all' will generate one path with points from all three
-                conventions. Equivalent labels between each will also be generated.
-                Order will always be Latimer & Munro, Setyawan & Curtarolo, and Hinuma et al.
-                Lengths for each of the paths will also be generated and output
-                as a list. Note for 'all' the user will have to alter the labels on
-                their own for plotting.
+                the high symmetry path. Options are: 'setyawan_curtarolo', 'hinuma', 
+                'latimer_munro' for the Setyawan & Curtarolo, Hinuma et al., and  
+                Latimer & Munro conventions. Choosing 'all' will generate one path 
+                with points from all three conventions. Equivalent labels between
+                each will also be generated. Order will always be Latimer & Munro, 
+                Setyawan & Curtarolo, and Hinuma et al. Lengths for each of the paths 
+                will also be generated and output as a list. Note for 'all' the user 
+                will have to alter the labels on their own for plotting.
             symprec (float): Tolerance for symmetry finding
             angle_tolerance (float): Angle tolerance for symmetry finding.
             atol (float): Absolute tolerance used to determine symmetric
@@ -95,11 +95,11 @@ class HighSymmKpath(KPathBase):
 
         if path_type != "all":
 
-            if path_type == "lm":
+            if path_type == "latimer_munro":
                 self._kpath = self._get_lm_kpath(has_magmoms, magmom_axis, symprec, angle_tolerance, atol).kpath
-            elif path_type == "sc":
+            elif path_type == "setyawan_curtarolo":
                 self._kpath = self._get_sc_kpath(symprec, angle_tolerance, atol).kpath
-            elif path_type == "hin":
+            elif path_type == "hinuma":
                 hin_dat = self._get_hin_kpath(symprec, angle_tolerance, atol, not has_magmoms)
                 self._kpath = hin_dat.kpath
                 self._hin_tmat = hin_dat._tmat
@@ -248,8 +248,8 @@ of the input structure. Use `KPathSeek` for the path in the original author-inte
 
         n_op = len(rpg)
 
-        pairs = itertools.permutations([{"sc": sc_path}, {"lm": lm_path}, {"hin": hin_path}], r=2)
-        labels = {"sc": {}, "lm": {}, "hin": {}}
+        pairs = itertools.permutations([{"setyawan_curtarolo": sc_path}, {"latimer_munro": lm_path}, {"hinuma": hin_path}], r=2)
+        labels = {"setyawan_curtarolo": {}, "latimer_munro": {}, "hinuma": {}}
 
         for (a, b) in pairs:
             [(a_type, a_path)] = list(a.items())


### PR DESCRIPTION
## Summary

* Path type names in `HighSymmKpath` changed from short form ('sc', 'hin', and 'lm') to long form ('setyawan_curtarolo', 'hinuma', 'latimer_munro'). 
* Proper `from_dict` method added to `Kpoint` class in `from pymatgen.electronic_structure.bandstructure`.

## Checklist

- [X] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). The easiest way to handle this
      is to run the following in the **correct sequence** on your local machine. Start with running
      [black](https://black.readthedocs.io/en/stable/index.html) on your new code. This will automatically reformat
      your code to PEP8 conventions and removes most issues. Then run 
      [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/), followed by 
      [flake8](http://flake8.pycqa.org/en/latest/).
- [X] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [X] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) to type check your code.
- [x] Tests have been added for any new functionality or bug fixes.
- [x] All linting and tests pass.

