### PR TITLE
add test and fix for computed entries

### DIFF
--- a/pymatgen/analysis/pourbaix_diagram.py
+++ b/pymatgen/analysis/pourbaix_diagram.py
@@ -235,7 +235,7 @@ class PourbaixEntry(MSONable, Stringify):
         if entry_type == "Ion":
             entry = IonEntry.from_dict(d["entry"])
         else:
-            entry = MontyDecoder().process_decoded(d['entry'])
+            entry = MontyDecoder().process_decoded(d["entry"])
         entry_id = d["entry_id"]
         concentration = d["concentration"]
         return PourbaixEntry(entry, entry_id, concentration)

--- a/pymatgen/analysis/pourbaix_diagram.py
+++ b/pymatgen/analysis/pourbaix_diagram.py
@@ -229,13 +229,13 @@ class PourbaixEntry(MSONable, Stringify):
     @classmethod
     def from_dict(cls, d):
         """
-        Invokes
+        Invokes a PourbaixEntry from a dictionary
         """
         entry_type = d["entry_type"]
         if entry_type == "Ion":
             entry = IonEntry.from_dict(d["entry"])
         else:
-            entry = PDEntry.from_dict(d["entry"])
+            entry = MontyDecoder().process_decoded(d['entry'])
         entry_id = d["entry_id"]
         concentration = d["concentration"]
         return PourbaixEntry(entry, entry_id, concentration)

--- a/pymatgen/analysis/tests/test_pourbaix_diagram.py
+++ b/pymatgen/analysis/tests/test_pourbaix_diagram.py
@@ -78,7 +78,7 @@ class PourbaixEntryTest(unittest.TestCase):
         # Ensure computed entry data persists
         entry = ComputedEntry("TiO2", energy=-20, data={"test": "test"})
         pbx_entry = PourbaixEntry(entry=entry)
-        with ScratchDir('.'):
+        with ScratchDir("."):
             dumpfn(pbx_entry, "pbx_entry.json")
             reloaded = loadfn("pbx_entry.json")
         self.assertIsInstance(reloaded.entry, ComputedEntry)

--- a/pymatgen/analysis/tests/test_pourbaix_diagram.py
+++ b/pymatgen/analysis/tests/test_pourbaix_diagram.py
@@ -10,7 +10,8 @@ import unittest
 import warnings
 
 import numpy as np
-from monty.serialization import loadfn
+from monty.serialization import loadfn, dumpfn
+from monty.tempfile import ScratchDir
 
 from pymatgen.core import SETTINGS
 from pymatgen.analysis.pourbaix_diagram import (
@@ -73,6 +74,15 @@ class PourbaixEntryTest(unittest.TestCase):
             self.PxSol.energy,
             "as_dict and from_dict energies unequal",
         )
+
+        # Ensure computed entry data persists
+        entry = ComputedEntry("TiO2", energy=-20, data={"test": "test"})
+        pbx_entry = PourbaixEntry(entry=entry)
+        with ScratchDir('.'):
+            dumpfn(pbx_entry, "pbx_entry.json")
+            reloaded = loadfn("pbx_entry.json")
+        self.assertIsInstance(reloaded.entry, ComputedEntry)
+        self.assertIsNotNone(reloaded.entry.data)
 
     def test_energy_functions(self):
         # TODO: test these for values


### PR DESCRIPTION
## Summary

* Updates PourbaixEntry.from_dict to invoke entries other than IonEntries using MontyDecoder, rather than hard-coding PDEntry.
* I initially had a bigger refactor which changed the ways Ions/IonEntries are invoked, but I'm a little worried about backwards compatibility of a core refactor, so I'm issuing this one for now.
* Addresses #2146

Before a pull request can be merged, the following items must be checked:

- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). The easiest way to handle this
      is to run the following in the **correct sequence** on your local machine. Start with running
      [black](https://black.readthedocs.io/en/stable/index.html) on your new code. This will automatically reformat
      your code to PEP8 conventions and removes most issues. Then run 
      [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/), followed by 
      [flake8](http://flake8.pycqa.org/en/latest/).
- [x] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [ ] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) to type check your code.
- [x] Tests have been added for any new functionality or bug fixes.
- [ ] All linting and tests pass.
