### PR TITLE
Python 3.6+ behavior of Exception.message

### DIFF
--- a/pymatgen/ext/matproj.py
+++ b/pymatgen/ext/matproj.py
@@ -1011,7 +1011,7 @@ class MPRester:
                     break
                 except MPRestError as e:
                     # pylint: disable=E1101
-                    match = re.search(r"error status code (\d+)", e.message)
+                    match = re.search(r"error status code (\d+)", str(e))
                     if match:
                         if not match.group(1).startswith("5"):
                             raise e


### PR DESCRIPTION
## Summary

Hey guys,

Python 3.6+ seems to abolish `Exception.message`.  
This PR addresses this problem.  
It does not seem to be easy to write a unittest to reproduce this without imposing a large load on MP.  
Here is a working example.  

- Current implementation

```python
import re
from pymatgen.ext.matproj import MPRestError
try:
    raise MPRestError("error status code 000")
except MPRestError as e:
    # pylint: disable=E1101
    match = re.search(r"error status code (\d+)", e.message)
    if match:
        print(e)
```

```
MPRestError                               Traceback (most recent call last)
<ipython-input-3-83f89fe43bab> in <module>
      2 try:
----> 3     raise MPRestError("error status code 000")
      4 except MPRestError as e:

MPRestError: 

During handling of the above exception, another exception occurred:

AttributeError                            Traceback (most recent call last)
<ipython-input-3-83f89fe43bab> in <module>
      4 except MPRestError as e:
      5     # pylint: disable=E1101
----> 6     match = re.search(r"error status code (\d+)", e.message)
      7     if match:
      8         print(e)

AttributeError: 'MPRestError' object has no attribute 'message'

```

- This PR

```python
import re
from pymatgen.ext.matproj import MPRestError
try:
    raise MPRestError("error status code 000")
except MPRestError as e:
    # pylint: disable=E1101
    match = re.search(r"error status code (\d+)", str(e))
    if match:
        print(e)
```

```
error status code 000
```

## Additional dependencies introduced (if any)

None

## TODO (if any)

None

## Checklist

Before a pull request can be merged, the following items must be checked:

- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). The easiest way to handle this
      is to run the following in the **correct sequence** on your local machine. Start with running
      [black](https://black.readthedocs.io/en/stable/index.html) on your new code. This will automatically reformat
      your code to PEP8 conventions and removes most issues. Then run 
      [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/), followed by 
      [flake8](http://flake8.pycqa.org/en/latest/).
- [x] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [ ] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) to type check your code.
- [ ] Tests have been added for any new functionality or bug fixes.
- [x] All linting and tests pass.

Note that the CI system will run all the above checks. But it will be much more efficient if you already fix most 
errors prior to submitting the PR. It is highly recommended that you use the pre-commit hook provided in the pymatgen 
repository. Simply `cp pre-commit .git/hooks` and a check will be run prior to allowing commits.
