### PR TITLE
Update usage.rst

### DIFF
--- a/docs_rst/usage.rst
+++ b/docs_rst/usage.rst
@@ -186,7 +186,7 @@ example, to read a POSCAR and write a cif::
     from pymatgen.io.cif import CifWriter
 
     p = Poscar.from_file('POSCAR')
-    w = CifWriter(p.struct)
+    w = CifWriter(p.structure)
     w.write_file('mystructure.cif')
 
 For molecules, pymatgen has in-built support for XYZ and Gaussian input and


### PR DESCRIPTION

## Summary
I think there is a typo in line 189:
`w = CifWriter(p.struct)`
should be:
`w = CifWriter(p.structure)`
or else error **AttributeError: 'Poscar' object has no attribute 'struct'** will occur.

Include a summary of major changes in bullet points:
* fix a typo in usage.rst line 189

## Additional dependencies introduced (if any)

* None

## TODO (if any)

* None

## Checklist

Work-in-progress pull requests are encouraged, but please put [WIP]
in the pull request title.

Before a pull request can be merged, the following items must be checked:

- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). The easiest way to handle this
      is to run the following in the **correct sequence** on your local machine. Start with running
      [black](https://black.readthedocs.io/en/stable/index.html) on your new code. This will automatically reformat
      your code to PEP8 conventions and removes most issues. Then run 
      [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/), followed by 
      [flake8](http://flake8.pycqa.org/en/latest/).
- [x] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [x] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) to type check your code.
- [x] Tests have been added for any new functionality or bug fixes.
- [x] All linting and tests pass.

Note that the CI system will run all the above checks. But it will be much more efficient if you already fix most 
errors prior to submitting the PR. It is highly recommended that you use the pre-commit hook provided in the pymatgen 
repository. Simply `cp pre-commit .git/hooks` and a check will be run prior to allowing commits.
