### PR TITLE
reorder SETTINGS load priority

### DIFF
--- a/pymatgen/core/__init__.py
+++ b/pymatgen/core/__init__.py
@@ -37,18 +37,24 @@ SETTINGS_FILE = os.path.join(os.path.expanduser("~"), ".pmgrc.yaml")
 
 
 def _load_pmg_settings():
+    # Load environment variables by default as backup
+    d = {}
+    for k, v in os.environ.items():
+        if k.startswith("PMG_"):
+            d[k] = v
+        elif k in ["VASP_PSP_DIR", "MAPI_KEY", "DEFAULT_FUNCTIONAL"]:
+            d["PMG_" + k] = v
+
+    # Override anything in env vars with that in yml file
     try:
         with open(SETTINGS_FILE, "rt") as f:
-            d = yaml.safe_load(f)
+            dyml = yaml.safe_load(f)
+        d.update(dyml)
     except IOError:
         # If there are any errors, default to using environment variables
         # if present.
-        d = {}
-        for k, v in os.environ.items():
-            if k.startswith("PMG_"):
-                d[k] = v
-            elif k in ["VASP_PSP_DIR", "MAPI_KEY", "DEFAULT_FUNCTIONAL"]:
-                d["PMG_" + k] = v
+        pass
+
     d = d or {}
     return dict(d)
 

--- a/pymatgen/core/__init__.py
+++ b/pymatgen/core/__init__.py
@@ -48,8 +48,8 @@ def _load_pmg_settings():
     # Override anything in env vars with that in yml file
     try:
         with open(SETTINGS_FILE, "rt") as f:
-            dyml = yaml.safe_load(f)
-        d.update(dyml)
+            d_yml = yaml.safe_load(f)
+        d.update(d_yml)
     except IOError:
         # If there are any errors, default to using environment variables
         # if present.


### PR DESCRIPTION
## Summary

When both a .pmgrc.yaml and environment variables are specified, any pmg environment variable will not be read into `pymatgen.core.__init__`'s `SETTINGS`.

E.g., I have a `PMG_MAPI_KEY` as an environment variable and my .pmgrc.yaml does not contain that key - it looks like

```
#.pmgrc.yaml
MAPI_DB_VERSION:
  LAST_ACCESSED: '2021_05_13'
  LOG: {'2021_05_13': 6}
```

`PMG_MAPI_KEY` will not be found in `SETTINGS`. 

This PR assumes this is not the desired behavior. `SETTINGS` here are now loaded as the union of env vars and pmgrc.yaml values, with the priority being pmgrc.yaml in case of a setting being defined in both sources.

If the desired behavior is in fact to void env variables for `SETTINGS` if .pmgrc.yaml exists, please close this PR. 


## Checklist

Before a pull request can be merged, the following items must be checked:

- [X] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). The easiest way to handle this
      is to run the following in the **correct sequence** on your local machine. Start with running
      [black](https://black.readthedocs.io/en/stable/index.html) on your new code. This will automatically reformat
      your code to PEP8 conventions and removes most issues. Then run 
      [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/), followed by 
      [flake8](http://flake8.pycqa.org/en/latest/).
- [X] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [X] N/A Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) to type check your code.
- [X] N/A Tests have been added for any new functionality or bug fixes.
- [X] All linting and tests pass.
