### PR TITLE
Use tighter EDIFF for DFPT calculations

### DIFF
--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -1112,6 +1112,9 @@ class MPStaticSet(MPRelaxSet):
             incar.pop("NSW", None)
             incar.pop("NPAR", None)
 
+            # tighter ediff for DFPT
+            incar["EDIFF"] = 1e-5
+
         if self.lcalcpol:
             incar["LCALCPOL"] = True
 

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -513,6 +513,7 @@ class MPStaticSetTest(PymatgenTest):
         leps_vis = MPStaticSet.from_prev_calc(prev_calc_dir=prev_run, lepsilon=True)
         self.assertTrue(leps_vis.incar["LEPSILON"])
         self.assertEqual(leps_vis.incar["IBRION"], 8)
+        self.assertEqual(leps_vis.incar["EDIFF"], 1e-5)
         self.assertNotIn("NPAR", leps_vis.incar)
         self.assertNotIn("NSW", leps_vis.incar)
         self.assertEqual(non_prev_vis.kpoints.kpts, [[11, 10, 10]])


### PR DESCRIPTION
## Summary

Set EDIFF = 1e-5 when `lepsilon = True` in `MPStaticSet`. Note that this is [already used in atomate](https://github.com/hackingmaterials/atomate/blob/128a754000533029ce2b3d1faf3eb06aabe6f88b/atomate/vasp/firetasks/write_inputs.py#L378), I'm just moving the configuration to the input set itself.