### PR TITLE
Pourbaix: default to filter_solids=True

### DIFF
--- a/pymatgen/analysis/pourbaix_diagram.py
+++ b/pymatgen/analysis/pourbaix_diagram.py
@@ -21,7 +21,7 @@ import warnings
 from copy import deepcopy
 from functools import cmp_to_key, lru_cache, partial
 from multiprocessing import Pool
-from typing import Optional, Union, List
+from typing import Optional, Union, List, Dict
 
 import numpy as np
 from monty.json import MontyDecoder, MSONable
@@ -470,8 +470,8 @@ class PourbaixDiagram(MSONable):
     def __init__(
         self,
         entries: Union[List[PourbaixEntry], List[MultiEntry]],
-        comp_dict: Optional[dict[str, float]] = None,
-        conc_dict: Optional[dict[str, float]] = None,
+        comp_dict: Optional[Dict[str, float]] = None,
+        conc_dict: Optional[Dict[str, float]] = None,
         filter_solids: bool = True,
         nproc: Optional[int] = None,
     ):

--- a/pymatgen/analysis/pourbaix_diagram.py
+++ b/pymatgen/analysis/pourbaix_diagram.py
@@ -973,7 +973,7 @@ class PourbaixDiagram(MSONable):
             include_unprocessed_entries (): DEPRECATED. Whether to include unprocessed
                 entries (equivalent to filter_solids=False). Serialization now includes
                 all unprocessed entries by default. Set filter_solids=False before
-                serializing to exclude unstable solids from the generated Pourbaix Diagram.
+                serializing to include unstable solids from the generated Pourbaix Diagram.
 
         Returns:
             MSONable dict.

--- a/pymatgen/analysis/pourbaix_diagram.py
+++ b/pymatgen/analysis/pourbaix_diagram.py
@@ -21,6 +21,7 @@ import warnings
 from copy import deepcopy
 from functools import cmp_to_key, lru_cache, partial
 from multiprocessing import Pool
+from typing import Optional, Union, List
 
 import numpy as np
 from monty.json import MontyDecoder, MSONable
@@ -466,7 +467,14 @@ class PourbaixDiagram(MSONable):
     Class to create a Pourbaix diagram from entries
     """
 
-    def __init__(self, entries, comp_dict=None, conc_dict=None, filter_solids=True, nproc=None):
+    def __init__(
+        self,
+        entries: Union[List[PourbaixEntry], List[MultiEntry]],
+        comp_dict: Optional[dict[str, float]] = None,
+        conc_dict: Optional[dict[str, float]] = None,
+        filter_solids: bool = True,
+        nproc: Optional[int] = None,
+    ):
         """
         Args:
             entries ([PourbaixEntry] or [MultiEntry]): Entries list
@@ -491,8 +499,9 @@ class PourbaixDiagram(MSONable):
         self.filter_solids = filter_solids
 
         # Get non-OH elements
-        self.pbx_elts = set(itertools.chain.from_iterable([entry.composition.elements for entry in entries]))
-        self.pbx_elts = list(self.pbx_elts - ELEMENTS_HO)
+        self.pbx_elts = list(
+            set(itertools.chain.from_iterable([entry.composition.elements for entry in entries])) - ELEMENTS_HO
+        )
         self.dim = len(self.pbx_elts) - 1
 
         # Process multientry inputs
@@ -970,8 +979,12 @@ class PourbaixDiagram(MSONable):
             MSONable dict.
         """
         if include_unprocessed_entries:
-            warnings.warn(DeprecationWarning("The include_unprocessed_entries kwarg is deprecated! "
-                                             "Set filter_solids=True / False before serializing instead."))
+            warnings.warn(
+                DeprecationWarning(
+                    "The include_unprocessed_entries kwarg is deprecated! "
+                    "Set filter_solids=True / False before serializing instead."
+                )
+            )
         d = {
             "@module": self.__class__.__module__,
             "@class": self.__class__.__name__,

--- a/pymatgen/analysis/pourbaix_diagram.py
+++ b/pymatgen/analysis/pourbaix_diagram.py
@@ -466,7 +466,7 @@ class PourbaixDiagram(MSONable):
     Class to create a Pourbaix diagram from entries
     """
 
-    def __init__(self, entries, comp_dict=None, conc_dict=None, filter_solids=False, nproc=None):
+    def __init__(self, entries, comp_dict=None, conc_dict=None, filter_solids=True, nproc=None):
         """
         Args:
             entries ([PourbaixEntry] or [MultiEntry]): Entries list
@@ -475,15 +475,20 @@ class PourbaixDiagram(MSONable):
                 defaults to equal parts of each elements
             conc_dict ({str: float}): Dictionary of ion concentrations,
                 defaults to 1e-6 for each element
-            filter_solids (bool): applying this filter to a pourbaix
-                diagram ensures all included phases are filtered by
-                stability on the compositional phase diagram.  This
-                breaks some of the functionality of the analysis,
-                though, so use with caution.
+            filter_solids (bool): applying this filter to a Pourbaix
+                diagram ensures all included solid phases are filtered by
+                stability on the compositional phase diagram. Defaults to True.
+                The practical consequence of this is that highly oxidized or reduced
+                phases that might show up in experiments due to kinetic limitations
+                on oxygen/hydrogen evolution won't appear in the diagram, but they are
+                not actually "stable" (and are frequently overstabilized from DFT errors).
+                Hence, including only the stable solid phases generally leads to the
+                most accurate Pourbaix diagrams.
             nproc (int): number of processes to generate multientries with
                 in parallel.  Defaults to None (serial processing)
         """
         entries = deepcopy(entries)
+        self.filter_solids = filter_solids
 
         # Get non-OH elements
         self.pbx_elts = set(itertools.chain.from_iterable([entry.composition.elements for entry in entries]))
@@ -531,14 +536,13 @@ class PourbaixDiagram(MSONable):
             if not len(solid_entries + ion_entries) == len(entries):
                 raise ValueError("All supplied entries must have a phase type of " 'either "Solid" or "Ion"')
 
-            if filter_solids:
+            if self.filter_solids:
                 # O is 2.46 b/c pbx entry finds energies referenced to H2O
                 entries_HO = [ComputedEntry("H", 0), ComputedEntry("O", 2.46)]
                 solid_pd = PhaseDiagram(solid_entries + entries_HO)
                 solid_entries = list(set(solid_pd.stable_entries) - set(entries_HO))
 
             self._filtered_entries = solid_entries + ion_entries
-
             if len(comp_dict) > 1:
                 self._multielement = True
                 self._processed_entries = self._preprocess_pourbaix_entries(self._filtered_entries, nproc=nproc)
@@ -954,24 +958,27 @@ class PourbaixDiagram(MSONable):
         """
         return self._unprocessed_entries
 
-    def as_dict(self, include_unprocessed_entries=False):
+    def as_dict(self, include_unprocessed_entries=None):
         """
         Args:
-            include_unprocessed_entries (): Whether to include unprocessed entries.
+            include_unprocessed_entries (): DEPRECATED. Whether to include unprocessed
+                entries (equivalent to filter_solids=False). Serialization now includes
+                all unprocessed entries by default. Set filter_solids=False before
+                serializing to exclude unstable solids from the generated Pourbaix Diagram.
 
         Returns:
             MSONable dict.
         """
         if include_unprocessed_entries:
-            entries = [e.as_dict() for e in self._unprocessed_entries]
-        else:
-            entries = [e.as_dict() for e in self._processed_entries]
+            warnings.warn(DeprecationWarning("The include_unprocessed_entries kwarg is deprecated! "
+                                             "Set filter_solids=True / False before serializing instead."))
         d = {
             "@module": self.__class__.__module__,
             "@class": self.__class__.__name__,
-            "entries": entries,
+            "entries": [e.as_dict() for e in self._unprocessed_entries],
             "comp_dict": self._elt_comp,
             "conc_dict": self._conc_dict,
+            "filter_solids": self.filter_solids,
         }
         return d
 
@@ -985,7 +992,7 @@ class PourbaixDiagram(MSONable):
             PourbaixDiagram
         """
         decoded_entries = MontyDecoder().process_decoded(d["entries"])
-        return cls(decoded_entries, d.get("comp_dict"), d.get("conc_dict"))
+        return cls(decoded_entries, d.get("comp_dict"), d.get("conc_dict"), d.get("filter_solids"))
 
 
 class PourbaixPlotter:

--- a/pymatgen/analysis/tests/test_pourbaix_diagram.py
+++ b/pymatgen/analysis/tests/test_pourbaix_diagram.py
@@ -8,6 +8,7 @@ import multiprocessing
 import os
 import unittest
 import warnings
+import pytest
 
 import numpy as np
 from monty.serialization import loadfn, dumpfn
@@ -258,9 +259,10 @@ class PourbaixDiagramTest(unittest.TestCase):
             "List of stable entries does not match",
         )
 
-        # Test with unprocessed entries included, this should result in the
+        # Test with unstable solid entries included (filter_solids=False), this should result in the
         # previously filtered entries being included
-        d = self.pbx.as_dict(include_unprocessed_entries=True)
+        with pytest.warns(DeprecationWarning, match="The include_unprocessed_entries kwarg is deprecated!"):
+            d = self.pbx_nofilter.as_dict(include_unprocessed_entries=True)
         new = PourbaixDiagram.from_dict(d)
         self.assertEqual(
             set([e.name for e in new.stable_entries]),

--- a/pymatgen/entries/__init__.py
+++ b/pymatgen/entries/__init__.py
@@ -12,6 +12,7 @@ and PDEntry inherit from this class.
 
 from numbers import Number
 from abc import ABCMeta, abstractmethod
+from typing import Union
 
 import numpy as np
 
@@ -39,7 +40,7 @@ class Entry(MSONable, metaclass=ABCMeta):
 
     def __init__(
         self,
-        composition: Composition,
+        composition: Union[Composition, str, dict[str, float]],
         energy: float,
     ):
         """

--- a/pymatgen/entries/__init__.py
+++ b/pymatgen/entries/__init__.py
@@ -12,7 +12,7 @@ and PDEntry inherit from this class.
 
 from numbers import Number
 from abc import ABCMeta, abstractmethod
-from typing import Union
+from typing import Union, Dict
 
 import numpy as np
 
@@ -40,7 +40,7 @@ class Entry(MSONable, metaclass=ABCMeta):
 
     def __init__(
         self,
-        composition: Union[Composition, str, dict[str, float]],
+        composition: Union[Composition, str, Dict[str, float]],
         energy: float,
     ):
         """

--- a/pymatgen/entries/compatibility.py
+++ b/pymatgen/entries/compatibility.py
@@ -1220,12 +1220,12 @@ class MaterialsProjectAqueousCompatibility(Compatibility):
         # check whether solid_compat has been instantiated
         if solid_compat is None:
             self.solid_compat = None
-        elif isinstance(solid_compat, str):
+        elif isinstance(solid_compat, type) and issubclass(solid_compat, Compatibility):
             self.solid_compat = solid_compat()
         elif issubclass(type(solid_compat), Compatibility):
             self.solid_compat = solid_compat
         else:
-            raise ValueError("Expected a Compatability class as a string, instance of a Compatability or None")
+            raise ValueError("Expected a Compatability class, instance of a Compatability or None")
 
         self.o2_energy = o2_energy
         self.h2o_energy = h2o_energy

--- a/pymatgen/entries/compatibility.py
+++ b/pymatgen/entries/compatibility.py
@@ -1220,12 +1220,12 @@ class MaterialsProjectAqueousCompatibility(Compatibility):
         # check whether solid_compat has been instantiated
         if solid_compat is None:
             self.solid_compat = None
-        elif issubclass(solid_compat, Compatibility):
+        elif isinstance(solid_compat, str):
             self.solid_compat = solid_compat()
         elif issubclass(type(solid_compat), Compatibility):
             self.solid_compat = solid_compat
         else:
-            raise ValueError("Expected a Compatability class, instance of a Compatability or None")
+            raise ValueError("Expected a Compatability class as a string, instance of a Compatability or None")
 
         self.o2_energy = o2_energy
         self.h2o_energy = h2o_energy

--- a/pymatgen/entries/computed_entries.py
+++ b/pymatgen/entries/computed_entries.py
@@ -15,7 +15,7 @@ import json
 import os
 import warnings
 from itertools import combinations
-from typing import List, Union
+from typing import List, Union, Dict
 
 import numpy as np
 from monty.json import MontyDecoder, MontyEncoder, MSONable
@@ -310,7 +310,7 @@ class ComputedEntry(Entry):
 
     def __init__(
         self,
-        composition: Union[Composition, str, dict[str, float]],
+        composition: Union[Composition, str, Dict[str, float]],
         energy: float,
         correction: float = 0.0,
         energy_adjustments: list = None,
@@ -582,7 +582,7 @@ class ComputedStructureEntry(ComputedEntry):
         structure: Structure,
         energy: float,
         correction: float = 0.0,
-        composition: Union[Composition, str, dict[str, float]] = None,
+        composition: Union[Composition, str, Dict[str, float]] = None,
         energy_adjustments: list = None,
         parameters: dict = None,
         data: dict = None,

--- a/pymatgen/entries/computed_entries.py
+++ b/pymatgen/entries/computed_entries.py
@@ -15,7 +15,7 @@ import json
 import os
 import warnings
 from itertools import combinations
-from typing import List
+from typing import List, Union
 
 import numpy as np
 from monty.json import MontyDecoder, MontyEncoder, MSONable
@@ -310,7 +310,7 @@ class ComputedEntry(Entry):
 
     def __init__(
         self,
-        composition: Composition,
+        composition: Union[Composition, str, dict[str, float]],
         energy: float,
         correction: float = 0.0,
         energy_adjustments: list = None,
@@ -582,7 +582,7 @@ class ComputedStructureEntry(ComputedEntry):
         structure: Structure,
         energy: float,
         correction: float = 0.0,
-        composition: Composition = None,
+        composition: Union[Composition, str, dict[str, float]] = None,
         energy_adjustments: list = None,
         parameters: dict = None,
         data: dict = None,
@@ -598,6 +598,10 @@ class ComputedStructureEntry(ComputedEntry):
             energy_adjustments: An optional list of EnergyAdjustment to
                 be applied to the energy. This is used to modify the energy for
                 certain analyses. Defaults to None.
+            composition (Composition): Composition of the entry. For
+                flexibility, this can take the form of all the typical input
+                taken by a Composition, including a {symbol: amt} dict,
+                a string formula, and others.
             parameters: An optional dict of parameters associated with
                 the entry. Defaults to None.
             data: An optional dict of any additional data associated

--- a/pymatgen/ext/matproj.py
+++ b/pymatgen/ext/matproj.py
@@ -602,10 +602,13 @@ class MPRester:
             self.solid_compat = MaterialsProjectCompatibility()
         elif solid_compat == "MaterialsProject2020Compatibility":
             self.solid_compat = MaterialsProject2020Compatibility()
-        elif solid_compat and not isinstance(solid_compat, Compatibility):
-            self.solid_compat = solid_compat()
-        else:
+        elif isinstance(solid_compat, Compatibility):
             self.solid_compat = solid_compat
+        else:
+            raise ValueError(
+                "Solid compatibility can only be 'MaterialsProjectCompatibility', "
+                "'MaterialsProject2020Compatibility', or an instance of a Compatability class"
+            )
 
         pbx_entries = []
 


### PR DESCRIPTION
## Summary

Default `PourbaixDiagram` to use `filter_solids=True` for consistency with the MP website and discussion in #2173. 

In addition:
* Fix a bug in `MaterialsProjectAqueousCompatibility` introduced by e8028b0cfe783f8628c9090da07ff6e435244f6c
* add type hinting to `PourbaixDiagram` and make a few type hinting fixes to `Entry` classes (necessary to make mypy happy on `PourbaixDiagram`).
* Deprecate the `include_unprocessed_entries` kwarg to `PourbaixDiagram.as_dict`. This was necessary in order to make serialization work properly after switching to `filter_solids=True` by default. To me, it appears this kwarg was a sort of workaround to allow a user to effectively decide whether to filter solids at the serialization / deserialization stage. In my mind, it makes more sense for the user to make that decision via the `filter_solids` kwarg when the diagram is constructed, then serialize the `filter_solids` kwarg along with all unprocessed entries always. I feel this is more consistent with the way I "expect" serialization to work. @montoyjh please comment if you have any concerns or had a specific reason for keeping this is a kwarg to `as_dict`

Closes #2173 