### PR TITLE
enforce KSPACING cap in MPScanRelaxSet

### DIFF
--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -962,8 +962,10 @@ class MPScanRelaxSet(DictSet):
             rmin = 25.22 - 2.87 * bandgap  # Eq. 25
             kspacing = 2 * np.pi * 1.0265 / (rmin - 1.0183)  # Eq. 29
             # cap the KSPACING at a max of 0.44, per internal benchmarking
-            kspacing = min(0.44, kspacing)
-            updates["KSPACING"] = kspacing
+            if 0.22 < kspacing < 0.44:
+                updates["KSPACING"] = kspacing
+            else:
+                updates["KSPACING"] = 0.44
             updates["ISMEAR"] = -5
             updates["SIGMA"] = 0.05
 

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -1283,6 +1283,16 @@ class MPScanRelaxSetTest(PymatgenTest):
         self.assertEqual(incar["ISMEAR"], -5)
         self.assertEqual(incar["SIGMA"], 0.05)
 
+    def test_kspacing_cap(self):
+        # Test that KSPACING is capped at 0.44 for insulators
+        file_path = self.TEST_FILES_DIR / "POSCAR.O2"
+        struct = Poscar.from_file(file_path, check_for_POTCAR=False).structure
+        scan_nonmetal_set = MPScanRelaxSet(struct, bandgap=10)
+        incar = scan_nonmetal_set.incar
+        self.assertAlmostEqual(incar["KSPACING"], 0.44, places=5)
+        self.assertEqual(incar["ISMEAR"], -5)
+        self.assertEqual(incar["SIGMA"], 0.05)
+
     def test_incar_overrides(self):
         # use 'user_incar_settings' to override the KSPACING, ISMEAR, and SIGMA
         # parameters that MPScanSet normally determines


### PR DESCRIPTION
## Summary

Add a guard statement and a test to ensure that the KSPACING value calculated by `MPScanRelaxSet` never exceeds the range 0.22 - 0.44. 

This is a follow up to #2163. After that PR was merged I noticed from our atomate tests of the SCAN workflow that if a material's bandgap was sufficiently large >9 eV or so, it could actually reverse the sign of KSPACING, leading to large negative values that broke the logic. This PR fixes that bug and will be needed to keep atomate tests passing.

