### PR TITLE
fix: update matplotlib 3daxes to use modern api.

### DIFF
--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -2056,11 +2056,10 @@ class PDPlotter:
         machines have matplotlib installed, I have done it this way.
         """
         import matplotlib.pyplot as plt
-        import mpl_toolkits.mplot3d.axes3d as p3
         from matplotlib.font_manager import FontProperties
 
         fig = plt.figure()
-        ax = p3.Axes3D(fig)
+        ax = fig.add_subplot(111, projection="3d")
         font = FontProperties(weight="bold", size=13)
         (lines, labels, unstable) = self.pd_plot_data
         count = 1


### PR DESCRIPTION
matplotlib is deprecating the old way to setup 3d plots used by the "matplotlib" backend in PDPlotter. This was giving me deprecation warnings in the testing scripts so I've replaced the calls with the more up to date api usage. I have tested the backend and it still works as before for 4d gibbs simplicies.