### PR TITLE
Fix substrate analyzer not actually returning objects

### DIFF
--- a/pymatgen/analysis/interfaces/substrate_analyzer.py
+++ b/pymatgen/analysis/interfaces/substrate_analyzer.py
@@ -64,16 +64,24 @@ class SubstrateMatch(ZSLMatch):
         else:
             elastic_energy = 0
 
-        match_dict = match.as_dict()
-
-        cls(
+        return cls(
             film_miller=film_miller,
             substrate_miller=substrate_miller,
             strain=strain,
             von_mises_strain=von_mises_strain,
             elastic_energy=elastic_energy,
             ground_state_energy=ground_state_energy,
-            **{k: match_dict[k] for k in match_dict.keys() if not k.startswith("@")},
+            **{
+                k: getattr(match, k)
+                for k in [
+                    "film_sl_vectors",
+                    "substrate_sl_vectors",
+                    "film_vectors",
+                    "substrate_vectors",
+                    "film_transformation",
+                    "substrate_transformation",
+                ]
+            },
         )
 
     @property
@@ -183,6 +191,7 @@ class SubstrateAnalyzer(ZSLGenerator):
             substrate_miller,
         ] in surface_vector_sets:
             for match in self(film_vectors, substrate_vectors, lowest):
+
                 sub_match = SubstrateMatch.from_zsl(
                     match=match,
                     film=film,

--- a/pymatgen/analysis/interfaces/tests/test_substrate_analyzer.py
+++ b/pymatgen/analysis/interfaces/tests/test_substrate_analyzer.py
@@ -37,6 +37,7 @@ class SubstrateAnalyzerTest(PymatgenTest):
         self.assertEqual(len(matches), 192)
         for match in matches:
             assert match is not None
+            assert isinstance(match.match_area,float)
 
 
 if __name__ == "__main__":

--- a/pymatgen/analysis/interfaces/tests/test_substrate_analyzer.py
+++ b/pymatgen/analysis/interfaces/tests/test_substrate_analyzer.py
@@ -35,6 +35,8 @@ class SubstrateAnalyzerTest(PymatgenTest):
 
         matches = list(s.calculate(film, substrate, film_elac))
         self.assertEqual(len(matches), 192)
+        for match in matches:
+            assert match is not None
 
 
 if __name__ == "__main__":

--- a/pymatgen/analysis/interfaces/tests/test_substrate_analyzer.py
+++ b/pymatgen/analysis/interfaces/tests/test_substrate_analyzer.py
@@ -37,7 +37,7 @@ class SubstrateAnalyzerTest(PymatgenTest):
         self.assertEqual(len(matches), 192)
         for match in matches:
             assert match is not None
-            assert isinstance(match.match_area,float)
+            assert isinstance(match.match_area, float)
 
 
 if __name__ == "__main__":

--- a/pymatgen/analysis/interfaces/tests/test_zsl.py
+++ b/pymatgen/analysis/interfaces/tests/test_zsl.py
@@ -59,7 +59,7 @@ class ZSLGenTest(PymatgenTest):
         z.bidirectional = True
         matches = list(z(self.substrate.lattice.matrix[:2], self.film.lattice.matrix[:2]))
         self.assertEqual(len(matches), 48)
-        
+
         for match in matches:
             assert match is not None
 

--- a/pymatgen/analysis/interfaces/tests/test_zsl.py
+++ b/pymatgen/analysis/interfaces/tests/test_zsl.py
@@ -62,6 +62,7 @@ class ZSLGenTest(PymatgenTest):
 
         for match in matches:
             assert match is not None
+            assert isinstance(match.match_area,float)
 
 
 if __name__ == "__main__":

--- a/pymatgen/analysis/interfaces/tests/test_zsl.py
+++ b/pymatgen/analysis/interfaces/tests/test_zsl.py
@@ -59,6 +59,9 @@ class ZSLGenTest(PymatgenTest):
         z.bidirectional = True
         matches = list(z(self.substrate.lattice.matrix[:2], self.film.lattice.matrix[:2]))
         self.assertEqual(len(matches), 48)
+        
+        for match in matches:
+            assert match is not None
 
 
 if __name__ == "__main__":

--- a/pymatgen/analysis/interfaces/tests/test_zsl.py
+++ b/pymatgen/analysis/interfaces/tests/test_zsl.py
@@ -62,7 +62,7 @@ class ZSLGenTest(PymatgenTest):
 
         for match in matches:
             assert match is not None
-            assert isinstance(match.match_area,float)
+            assert isinstance(match.match_area, float)
 
 
 if __name__ == "__main__":

--- a/pymatgen/analysis/interfaces/zsl.py
+++ b/pymatgen/analysis/interfaces/zsl.py
@@ -6,7 +6,7 @@
 This module implements the Zur and McGill lattice matching algorithm
 """
 
-from typing import Iterator
+from typing import Iterator, List
 
 from dataclasses import dataclass
 from itertools import product
@@ -24,17 +24,17 @@ class ZSLMatch(MSONable):
     the appropriate transformation matrix
     """
 
-    film_sl_vectors: np.ndarray
-    substrate_sl_vectors: np.ndarray
-    film_vectors: np.ndarray
-    substrate_vectors: np.ndarray
-    film_transformation: np.ndarray
-    substrate_transformation: np.ndarray
+    film_sl_vectors: List
+    substrate_sl_vectors: List
+    film_vectors: List
+    substrate_vectors: List
+    film_transformation: List
+    substrate_transformation: List
 
     @property
     def match_area(self):
         """The area of the match between the substrate and film super lattice vectors"""
-        return vec_area(*self.film_sl_vectors.tolist())
+        return vec_area(*self.film_sl_vectors)
 
     @property
     def match_transformation(self):


### PR DESCRIPTION
This should fix #2198 , which was a bug introduced in the interfaces reorganization where the substrate analyzer was constructing matches to return, but not actually returning them... DOH!

I've added a test to check for this in the future. 

Edit: Should be #2198. Thanks @bernstei 
