### PR TITLE
fix issue #2216

### DIFF
--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -3151,6 +3151,13 @@ class Structure(IStructure, collections.abc.MutableSequence):
                 have to be the same length as the atomic species and
                 fractional_coords. Defaults to None for no properties.
         """
+        # To check whether the coords are cartesian or not
+        for coord in coords:
+            for i in coord:
+                if i > 1 or i < 0:
+                    coords_are_cartesian = True
+                    break   
+                    
         super().__init__(
             lattice,
             species,


### PR DESCRIPTION
## Summary

Add a few lines code to exam the coords fed to `Structure` object are cartesian or not.
The setting of `coords_are_cartesian` was defaulted to `False` and problem may occur when feeding cartesian coords to `Structure`.


* Fix  issue #2216 

## Additional dependencies introduced (if any)

None

## TODO (if any)

I noticed there are several codes set `coords_are_cartesian` to `False` by default, but I'm not sure if they are properly set when cartesian coords are fed and may be examed first like this case.


## Checklist

Work-in-progress pull requests are encouraged, but please put [WIP]
in the pull request title.

Before a pull request can be merged, the following items must be checked:

- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). The easiest way to handle this
      is to run the following in the **correct sequence** on your local machine. Start with running
      [black](https://black.readthedocs.io/en/stable/index.html) on your new code. This will automatically reformat
      your code to PEP8 conventions and removes most issues. Then run 
      [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/), followed by 
      [flake8](http://flake8.pycqa.org/en/latest/).
- [x] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [x] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) to type check your code.
- [x] Tests have been added for any new functionality or bug fixes.
- [x] All linting and tests pass.

Note that the CI system will run all the above checks. But it will be much more efficient if you already fix most 
errors prior to submitting the PR. It is highly recommended that you use the pre-commit hook provided in the pymatgen 
repository. Simply `cp pre-commit .git/hooks` and a check will be run prior to allowing commits.
