### PR TITLE
Configured test files dir

### DIFF
--- a/pymatgen/alchemy/tests/test_materials.py
+++ b/pymatgen/alchemy/tests/test_materials.py
@@ -55,9 +55,7 @@ class TransformedStructureTest(PymatgenTest):
         self.trans.append_filter(f3)
 
     def test_get_vasp_input(self):
-        SETTINGS["PMG_VASP_PSP_DIR"] = os.path.abspath(
-            os.path.join(os.path.dirname(__file__), "..", "..", "..", "test_files")
-        )
+        SETTINGS["PMG_VASP_PSP_DIR"] = PymatgenTest.TEST_FILES_DIR
         potcar = self.trans.get_vasp_input(MPRelaxSet)["POTCAR"]
         self.assertEqual("Na_pv\nFe_pv\nP\nO", "\n".join([p.symbol for p in potcar]))
         self.assertEqual(len(self.trans.structures), 2)

--- a/pymatgen/analysis/chemenv/connectivity/tests/test_environment_nodes.py
+++ b/pymatgen/analysis/chemenv/connectivity/tests/test_environment_nodes.py
@@ -20,13 +20,7 @@ except ModuleNotFoundError:
     bson = None
 
 json_files_dir = os.path.join(
-    os.path.dirname(__file__),
-    "..",
-    "..",
-    "..",
-    "..",
-    "..",
-    "test_files",
+    PymatgenTest.TEST_FILES_DIR,
     "chemenv",
     "json_test_files",
 )

--- a/pymatgen/analysis/chemenv/coordination_environments/tests/test_coordination_geometry_finder.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/tests/test_coordination_geometry_finder.py
@@ -19,13 +19,7 @@ from pymatgen.analysis.chemenv.coordination_environments.coordination_geometry_f
 from pymatgen.util.testing import PymatgenTest
 
 json_files_dir = os.path.join(
-    os.path.dirname(__file__),
-    "..",
-    "..",
-    "..",
-    "..",
-    "..",
-    "test_files",
+    PymatgenTest.TEST_FILES_DIR,
     "chemenv",
     "json_test_files",
 )

--- a/pymatgen/analysis/chemenv/coordination_environments/tests/test_read_write.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/tests/test_read_write.py
@@ -31,26 +31,15 @@ from pymatgen.analysis.chemenv.coordination_environments.voronoi import (
     DetailedVoronoiContainer,
 )
 from pymatgen.core.structure import Structure
+from pymatgen.util.testing import PymatgenTest
 
 json_files_dir = os.path.join(
-    os.path.dirname(__file__),
-    "..",
-    "..",
-    "..",
-    "..",
-    "..",
-    "test_files",
+    PymatgenTest.TEST_FILES_DIR,
     "chemenv",
     "json_test_files",
 )
 se_files_dir = os.path.join(
-    os.path.dirname(__file__),
-    "..",
-    "..",
-    "..",
-    "..",
-    "..",
-    "test_files",
+    PymatgenTest.TEST_FILES_DIR,
     "chemenv",
     "structure_environments_files",
 )

--- a/pymatgen/analysis/chemenv/coordination_environments/tests/test_structure_environments.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/tests/test_structure_environments.py
@@ -23,13 +23,7 @@ from pymatgen.core.periodic_table import Species
 from pymatgen.util.testing import PymatgenTest
 
 se_files_dir = os.path.join(
-    os.path.dirname(__file__),
-    "..",
-    "..",
-    "..",
-    "..",
-    "..",
-    "test_files",
+    PymatgenTest.TEST_FILES_DIR,
     "chemenv",
     "structure_environments_files",
 )

--- a/pymatgen/analysis/chemenv/coordination_environments/tests/test_voronoi.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/tests/test_voronoi.py
@@ -19,24 +19,12 @@ from pymatgen.core.structure import Structure
 from pymatgen.util.testing import PymatgenTest
 
 json_files_dir = os.path.join(
-    os.path.dirname(__file__),
-    "..",
-    "..",
-    "..",
-    "..",
-    "..",
-    "test_files",
+    PymatgenTest.TEST_FILES_DIR,
     "chemenv",
     "json_test_files",
 )
 img_files_dir = os.path.join(
-    os.path.dirname(__file__),
-    "..",
-    "..",
-    "..",
-    "..",
-    "..",
-    "test_files",
+    PymatgenTest.TEST_FILES_DIR,
     "chemenv",
     "images",
 )

--- a/pymatgen/analysis/chemenv/coordination_environments/tests/test_weights.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/tests/test_weights.py
@@ -23,13 +23,7 @@ from pymatgen.analysis.chemenv.coordination_environments.structure_environments 
 from pymatgen.util.testing import PymatgenTest
 
 se_files_dir = os.path.join(
-    os.path.dirname(__file__),
-    "..",
-    "..",
-    "..",
-    "..",
-    "..",
-    "test_files",
+    PymatgenTest.TEST_FILES_DIR,
     "chemenv",
     "structure_environments_files",
 )

--- a/pymatgen/analysis/chemenv/utils/tests/test_chemenv_config.py
+++ b/pymatgen/analysis/chemenv/utils/tests/test_chemenv_config.py
@@ -11,15 +11,10 @@ from monty.tempfile import ScratchDir
 
 from pymatgen.core import SETTINGS
 from pymatgen.analysis.chemenv.utils.chemenv_config import ChemEnvConfig
+from pymatgen.util.testing import PymatgenTest
 
 config_file_dir = os.path.join(
-    os.path.dirname(__file__),
-    "..",
-    "..",
-    "..",
-    "..",
-    "..",
-    "test_files",
+    PymatgenTest.TEST_FILES_DIR,
     "chemenv",
     "config",
 )

--- a/pymatgen/analysis/structure_prediction/tests/test_substitution_probability.py
+++ b/pymatgen/analysis/structure_prediction/tests/test_substitution_probability.py
@@ -15,6 +15,7 @@ from pymatgen.analysis.structure_prediction.substitution_probability import (
 from pymatgen.core.periodic_table import Species
 from pymatgen.util.testing import PymatgenTest
 
+
 def get_table():
     """
     Loads a lightweight lambda table for use in unit tests to reduce

--- a/pymatgen/analysis/structure_prediction/tests/test_substitution_probability.py
+++ b/pymatgen/analysis/structure_prediction/tests/test_substitution_probability.py
@@ -13,7 +13,7 @@ from pymatgen.analysis.structure_prediction.substitution_probability import (
     SubstitutionProbability,
 )
 from pymatgen.core.periodic_table import Species
-
+from pymatgen.util.testing import PymatgenTest
 
 def get_table():
     """
@@ -22,12 +22,7 @@ def get_table():
     default lambda table.
     """
     data_dir = os.path.join(
-        os.path.dirname(__file__),
-        "..",
-        "..",
-        "..",
-        "..",
-        "test_files",
+        PymatgenTest.TEST_FILES_DIR,
         "struct_predictor",
     )
 

--- a/pymatgen/analysis/structure_prediction/tests/test_substitutor.py
+++ b/pymatgen/analysis/structure_prediction/tests/test_substitutor.py
@@ -20,12 +20,7 @@ def get_table():
     default lambda table.
     """
     data_dir = os.path.join(
-        os.path.dirname(__file__),
-        "..",
-        "..",
-        "..",
-        "..",
-        "test_files",
+        PymatgenTest.TEST_FILES_DIR,
         "struct_predictor",
     )
     json_file = os.path.join(data_dir, "test_lambda.json")

--- a/pymatgen/analysis/tests/test_graphs.py
+++ b/pymatgen/analysis/tests/test_graphs.py
@@ -223,9 +223,7 @@ class StructureGraphTest(PymatgenTest):
         self.assertEqual(square_copy.graph.number_of_edges(), 3)
 
     def test_substitute(self):
-        structure = Structure.from_file(
-            os.path.join(PymatgenTest.TEST_FILES_DIR, "Li2O.cif")
-        )
+        structure = Structure.from_file(os.path.join(PymatgenTest.TEST_FILES_DIR, "Li2O.cif"))
         molecule = FunctionalGroups["methyl"]
 
         structure_copy = copy.deepcopy(structure)
@@ -600,9 +598,7 @@ class MoleculeGraphTest(unittest.TestCase):
             [6, 0],
             [6, 2],
         ]
-        self.pc_frag1 = Molecule.from_file(
-            os.path.join(PymatgenTest.TEST_FILES_DIR, "graphs", "PC_frag1.xyz")
-        )
+        self.pc_frag1 = Molecule.from_file(os.path.join(PymatgenTest.TEST_FILES_DIR, "graphs", "PC_frag1.xyz"))
         self.pc_frag1_edges = [[0, 2], [4, 2], [2, 1], [1, 3]]
         self.tfsi = Molecule.from_file(os.path.join(PymatgenTest.TEST_FILES_DIR, "graphs", "TFSI.xyz"))
         self.tfsi_edges = (

--- a/pymatgen/analysis/tests/test_graphs.py
+++ b/pymatgen/analysis/tests/test_graphs.py
@@ -37,7 +37,7 @@ __status__ = "Beta"
 __date__ = "August 2017"
 
 module_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)))
-molecule_dir = os.path.join(os.path.dirname(__file__), "..", "..", "..", "test_files", "molecules")
+molecule_dir = os.path.join(PymatgenTest.TEST_FILES_DIR, "molecules")
 
 
 class StructureGraphTest(PymatgenTest):
@@ -83,21 +83,15 @@ class StructureGraphTest(PymatgenTest):
         # MoS2 example, structure graph obtained from critic2
         # (not ground state, from mp-1023924, single layer)
         stdout_file = os.path.join(
-            os.path.dirname(__file__),
-            "..",
-            "..",
-            "..",
-            "test_files/critic2/MoS2_critic2_stdout.txt",
+            PymatgenTest.TEST_FILES_DIR,
+            "critic2/MoS2_critic2_stdout.txt",
         )
         with open(stdout_file, "r") as f:
             reference_stdout = f.read()
         self.structure = Structure.from_file(
             os.path.join(
-                os.path.dirname(__file__),
-                "..",
-                "..",
-                "..",
-                "test_files/critic2/MoS2.cif",
+                PymatgenTest.TEST_FILES_DIR,
+                "critic2/MoS2.cif",
             )
         )
         c2o = Critic2Analysis(self.structure, reference_stdout)
@@ -230,7 +224,7 @@ class StructureGraphTest(PymatgenTest):
 
     def test_substitute(self):
         structure = Structure.from_file(
-            os.path.join(os.path.dirname(__file__), "..", "..", "..", "test_files", "Li2O.cif")
+            os.path.join(PymatgenTest.TEST_FILES_DIR, "Li2O.cif")
         )
         molecule = FunctionalGroups["methyl"]
 
@@ -471,11 +465,8 @@ from    to  to_image
     def test_extract_molecules(self):
 
         structure_file = os.path.join(
-            os.path.dirname(__file__),
-            "..",
-            "..",
-            "..",
-            "test_files/H6PbCI3N_mp-977013_symmetrized.cif",
+            PymatgenTest.TEST_FILES_DIR,
+            "H6PbCI3N_mp-977013_symmetrized.cif",
         )
 
         s = Structure.from_file(structure_file)
@@ -539,11 +530,8 @@ class MoleculeGraphTest(unittest.TestCase):
 
         cyclohexene = Molecule.from_file(
             os.path.join(
-                os.path.dirname(__file__),
-                "..",
-                "..",
-                "..",
-                "test_files/graphs/cyclohexene.xyz",
+                PymatgenTest.TEST_FILES_DIR,
+                "graphs/cyclohexene.xyz",
             )
         )
         self.cyclohexene = MoleculeGraph.with_empty_graph(
@@ -568,11 +556,8 @@ class MoleculeGraphTest(unittest.TestCase):
 
         butadiene = Molecule.from_file(
             os.path.join(
-                os.path.dirname(__file__),
-                "..",
-                "..",
-                "..",
-                "test_files/graphs/butadiene.xyz",
+                PymatgenTest.TEST_FILES_DIR,
+                "graphs/butadiene.xyz",
             )
         )
         self.butadiene = MoleculeGraph.with_empty_graph(butadiene, edge_weight_name="strength", edge_weight_units="")
@@ -588,11 +573,8 @@ class MoleculeGraphTest(unittest.TestCase):
 
         ethylene = Molecule.from_file(
             os.path.join(
-                os.path.dirname(__file__),
-                "..",
-                "..",
-                "..",
-                "test_files/graphs/ethylene.xyz",
+                PymatgenTest.TEST_FILES_DIR,
+                "graphs/ethylene.xyz",
             )
         )
         self.ethylene = MoleculeGraph.with_empty_graph(ethylene, edge_weight_name="strength", edge_weight_units="")
@@ -602,7 +584,7 @@ class MoleculeGraphTest(unittest.TestCase):
         self.ethylene.add_edge(1, 4, weight=1.0)
         self.ethylene.add_edge(1, 5, weight=1.0)
 
-        self.pc = Molecule.from_file(os.path.join(module_dir, "..", "..", "..", "test_files", "graphs", "PC.xyz"))
+        self.pc = Molecule.from_file(os.path.join(PymatgenTest.TEST_FILES_DIR, "graphs", "PC.xyz"))
         self.pc_edges = [
             [5, 10],
             [5, 12],
@@ -619,10 +601,10 @@ class MoleculeGraphTest(unittest.TestCase):
             [6, 2],
         ]
         self.pc_frag1 = Molecule.from_file(
-            os.path.join(module_dir, "..", "..", "..", "test_files", "graphs", "PC_frag1.xyz")
+            os.path.join(PymatgenTest.TEST_FILES_DIR, "graphs", "PC_frag1.xyz")
         )
         self.pc_frag1_edges = [[0, 2], [4, 2], [2, 1], [1, 3]]
-        self.tfsi = Molecule.from_file(os.path.join(module_dir, "..", "..", "..", "test_files", "graphs", "TFSI.xyz"))
+        self.tfsi = Molecule.from_file(os.path.join(PymatgenTest.TEST_FILES_DIR, "graphs", "TFSI.xyz"))
         self.tfsi_edges = (
             [14, 1],
             [1, 4],
@@ -920,11 +902,8 @@ class MoleculeGraphTest(unittest.TestCase):
     def test_isomorphic(self):
         ethylene = Molecule.from_file(
             os.path.join(
-                os.path.dirname(__file__),
-                "..",
-                "..",
-                "..",
-                "test_files/graphs/ethylene.xyz",
+                PymatgenTest.TEST_FILES_DIR,
+                "graphs/ethylene.xyz",
             )
         )
         # switch carbons

--- a/pymatgen/analysis/tests/test_path_finder.py
+++ b/pymatgen/analysis/tests/test_path_finder.py
@@ -9,6 +9,7 @@ from numpy import mean
 from pymatgen.analysis.path_finder import ChgcarPotential, NEBPathfinder
 from pymatgen.core.periodic_table import Element
 from pymatgen.io.vasp import Chgcar, Poscar
+from pymatgen.util.testing import PymatgenTest
 
 __author__ = "Ziqin (Shaun) Rong"
 __version__ = "0.1"
@@ -23,7 +24,7 @@ class PathFinderTest(unittest.TestCase):
 
     def test_image_num(self):
         module_dir = os.path.dirname(os.path.abspath(__file__))
-        test_file_dir = os.path.join(module_dir, "..", "..", "..", "test_files", "path_finder")
+        test_file_dir = os.path.join(PymatgenTest.TEST_FILES_DIR, "path_finder")
         start_s = Poscar.from_file(os.path.join(test_file_dir, "LFP_POSCAR_s")).structure
         end_s = Poscar.from_file(os.path.join(test_file_dir, "LFP_POSCAR_e")).structure
         mid_s = start_s.interpolate(end_s, nimages=2, interpolate_lattices=False)[1]

--- a/pymatgen/analysis/tests/test_surface_analysis.py
+++ b/pymatgen/analysis/tests/test_surface_analysis.py
@@ -25,7 +25,7 @@ __date__ = "Aug 24, 2017"
 
 def get_path(path_str):
     cwd = os.path.abspath(os.path.dirname(__file__))
-    path = os.path.join(cwd, "..", "..", "..", "test_files", "surface_tests", path_str)
+    path = os.path.join(PymatgenTest.TEST_FILES_DIR, "surface_tests", path_str)
     return path
 
 

--- a/pymatgen/command_line/tests/test_critic2_caller.py
+++ b/pymatgen/command_line/tests/test_critic2_caller.py
@@ -62,11 +62,8 @@ class Critic2CallerTest(unittest.TestCase):
         # uses promolecular density
         structure = Structure.from_file(
             os.path.join(
-                os.path.dirname(__file__),
-                "..",
-                "..",
-                "..",
-                "test_files/critic2/MoS2.cif",
+                PymatgenTest.TEST_FILES_DIR,
+                "critic2/MoS2.cif",
             )
         )
 

--- a/pymatgen/core/tests/test_surface.py
+++ b/pymatgen/core/tests/test_surface.py
@@ -29,7 +29,7 @@ from pymatgen.util.testing import PymatgenTest
 
 def get_path(path_str):
     cwd = os.path.abspath(os.path.dirname(__file__))
-    path = os.path.join(cwd, "..", "..", "..", "test_files", "surface_tests", path_str)
+    path = os.path.join(PymatgenTest.TEST_FILES_DIR, "surface_tests", path_str)
     return path
 
 

--- a/pymatgen/io/abinit/tests/test_inputs.py
+++ b/pymatgen/io/abinit/tests/test_inputs.py
@@ -21,7 +21,7 @@ from pymatgen.io.abinit.inputs import (
 )
 from pymatgen.util.testing import PymatgenTest
 
-_test_dir = os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", "test_files", "abinit")
+_test_dir = os.path.join(PymatgenTest.TEST_FILES_DIR, "abinit")
 
 
 def abiref_file(filename):

--- a/pymatgen/io/abinit/tests/test_netcdf.py
+++ b/pymatgen/io/abinit/tests/test_netcdf.py
@@ -16,7 +16,7 @@ try:
 except ImportError:
     netCDF4 = None
 
-_test_dir = os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", "test_files", "abinit")
+_test_dir = os.path.join(PymatgenTest.TEST_FILES_DIR, "abinit")
 
 
 def ref_file(filename):

--- a/pymatgen/io/abinit/tests/test_pseudos.py
+++ b/pymatgen/io/abinit/tests/test_pseudos.py
@@ -9,7 +9,7 @@ import os.path
 from pymatgen.io.abinit.pseudos import *
 from pymatgen.util.testing import PymatgenTest
 
-_test_dir = os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", "test_files", "abinit")
+_test_dir = os.path.join(PymatgenTest.TEST_FILES_DIR, "abinit")
 
 
 def ref_file(filename):

--- a/pymatgen/transformations/tests/test_advanced_transformations.py
+++ b/pymatgen/transformations/tests/test_advanced_transformations.py
@@ -60,7 +60,7 @@ def get_table():
     initialization time, and make unit tests insensitive to changes in the
     default lambda table.
     """
-    data_dir = os.path.join(os.path.dirname(__file__), "..", "..", "..", "test_files", "struct_predictor")
+    data_dir = os.path.join(PymatgenTest.TEST_FILES_DIR, "struct_predictor")
     json_file = os.path.join(data_dir, "test_lambda.json")
     with open(json_file) as f:
         lambda_table = json.load(f)


### PR DESCRIPTION
## Summary

* use PymatgenTest.TEST_FILES_DIR with all tests

Required to enable tests to run separately from the source, for instance for CI testing of packaging for Linux distributions,
see https://github.com/materialsproject/pymatgen/issues/2025

Before a pull request can be merged, the following items must be checked:

- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). Black is applied.
- [x] All linting and tests pass (testing against release v2022.0.11
