### PR TITLE
Refactor `interface_reactions` module, add support for Plotly

### DIFF
--- a/pymatgen/analysis/chempot_diagram.py
+++ b/pymatgen/analysis/chempot_diagram.py
@@ -32,10 +32,11 @@ from monty.json import MSONable
 from plotly.graph_objects import Scatter, Scatter3d, Mesh3d, Figure
 from scipy.spatial import ConvexHull, HalfspaceIntersection
 
-from pymatgen.analysis.phase_diagram import PDPlotter, PhaseDiagram, PDEntry
+from pymatgen.analysis.phase_diagram import PhaseDiagram, PDEntry
 from pymatgen.core.composition import Composition, Element
 from pymatgen.entries.computed_entries import ComputedEntry
 from pymatgen.util.coord import Simplex
+from pymatgen.util.string import htmlify
 
 with open(os.path.join(os.path.dirname(__file__), "..", "util", "plotly_chempot_layouts.json")) as f:
     plotly_layouts = json.load(f)
@@ -473,7 +474,7 @@ class ChemicalPotentialDiagram(MSONable):
     @staticmethod
     def _get_annotation(ann_loc: np.ndarray, formula: str) -> Dict[str, Union[str, float]]:
         """Returns a Plotly annotation dict given a formula and location"""
-        formula = PDPlotter._htmlize_formula(formula)
+        formula = htmlify(formula)
         annotation = plotly_layouts["default_annotation_layout"].copy()
         annotation.update({"x": ann_loc[0], "y": ann_loc[1], "text": formula})
         if len(ann_loc) == 3:

--- a/pymatgen/analysis/interface_reactions.py
+++ b/pymatgen/analysis/interface_reactions.py
@@ -11,34 +11,32 @@ code in your own work.
 
 References:
 
-    Richards, W. D., Miara, L. J., Wang, Y., Kim, J. C., &amp; Ceder, G. (2015).
+    (1) Richards, W. D., Miara, L. J., Wang, Y., Kim, J. C., &amp; Ceder, G. (2015).
     Interface stability in solid-state batteries. Chemistry of Materials, 28(1),
     266–273. https://doi.org/10.1021/acs.chemmater.5b04082
 
-    Xiao, Y., Wang, Y., Bo, S.-H., Kim, J. C., Miara, L. J., &amp; Ceder, G. (2019).
+    (2) Xiao, Y., Wang, Y., Bo, S.-H., Kim, J. C., Miara, L. J., &amp; Ceder, G. (2019).
     Understanding interface stability in solid-state batteries.
     Nature Reviews Materials, 5(2), 105–126. https://doi.org/10.1038/s41578-019-0157-5
 
 """
 
-import os
 import json
+import os
 import warnings
-
 from typing import List, Tuple
+
 import numpy as np
-
-from monty.json import MSONable
-from monty.dev import deprecated
-from pymatgen.util.plotting import pretty_plot
-from pymatgen.util.string import latexify, htmlify
-
 import pandas
+from monty.dev import deprecated
+from monty.json import MSONable
 from plotly.graph_objects import Scatter, Figure
 
 from pymatgen.analysis.phase_diagram import PhaseDiagram, GrandPotentialPhaseDiagram
 from pymatgen.analysis.reaction_calculator import Reaction
 from pymatgen.core.composition import Composition
+from pymatgen.util.plotting import pretty_plot
+from pymatgen.util.string import latexify, htmlify
 
 __author__ = "Yihan Xiao, Matthew McDermott"
 __maintainer__ = "Matthew McDermott"
@@ -80,7 +78,7 @@ class InterfacialReactivity(MSONable):
         pd: PhaseDiagram,
         norm: bool = True,
         use_hull_energy: bool = False,
-        **kwargs
+        **kwargs,
     ):
         """
         Args:
@@ -613,9 +611,7 @@ class InterfacialReactivity(MSONable):
     @deprecated(products)
     def get_products(self):
         """
-
-        Returns:
-
+        Deprecated method. Use the "products" property.
         """
         return self.products
 
@@ -673,8 +669,9 @@ class GrandPotentialInterfacialReactivity(InterfacialReactivity):
         if is_grand and use_hull_energy and not pd_non_grand:
             raise ValueError("Please provide non-grand phase diagram if" " you want to use convex hull energy.")
 
-        super().__init__(c1=c1, c2=c2, pd=grand_pd, norm=norm,
-                         use_hull_energy=use_hull_energy, bypass_grand_warning=True)
+        super().__init__(
+            c1=c1, c2=c2, pd=grand_pd, norm=norm, use_hull_energy=use_hull_energy, bypass_grand_warning=True
+        )
 
         self.pd_non_grand = pd_non_grand
 

--- a/pymatgen/analysis/interface_reactions.py
+++ b/pymatgen/analysis/interface_reactions.py
@@ -356,7 +356,7 @@ class InterfacialReactivity(MSONable):
 
         annotations = self._get_plotly_annotations(x, energy, reactions)  # type: ignore
 
-        min_idx = energy.index(min(energy))
+        min_idx = energy.index(min(energy))  # type: ignore
 
         x_min = x.pop(min_idx)
         e_min = energy.pop(min_idx)

--- a/pymatgen/analysis/interface_reactions.py
+++ b/pymatgen/analysis/interface_reactions.py
@@ -3,153 +3,394 @@
 # Distributed under the terms of the MIT License.
 
 """
-This module provides class to generate and analyze interfacial reactions.
+This module provides a class to predict and analyze interfacial reactions between two
+solids, with or without an open element (e.g., flowing O2).
+
+Please consider citing one or both of the following papers if you use this
+code in your own work.
+
+References:
+
+    Richards, W. D., Miara, L. J., Wang, Y., Kim, J. C., &amp; Ceder, G. (2015).
+    Interface stability in solid-state batteries. Chemistry of Materials, 28(1),
+    266–273. https://doi.org/10.1021/acs.chemmater.5b04082
+
+    Xiao, Y., Wang, Y., Bo, S.-H., Kim, J. C., Miara, L. J., &amp; Ceder, G. (2019).
+    Understanding interface stability in solid-state batteries.
+    Nature Reviews Materials, 5(2), 105–126. https://doi.org/10.1038/s41578-019-0157-5
+
 """
 
+import os
+import json
 import warnings
 
-import matplotlib.pylab as plt
+from typing import Optional, List, Tuple
 import numpy as np
 
-from pymatgen.core.composition import Composition
-from pymatgen.analysis.phase_diagram import GrandPotentialPhaseDiagram
+from monty.json import MSONable
+from monty.dev import deprecated
+from pymatgen.util.plotting import pretty_plot
+from pymatgen.util.string import latexify
+
+import pandas
+from plotly.graph_objects import Scatter, Figure
+
+from pymatgen.analysis.phase_diagram import PhaseDiagram, GrandPotentialPhaseDiagram
 from pymatgen.analysis.reaction_calculator import Reaction
+from pymatgen.core.composition import Composition
 
-__author__ = "Yihan Xiao"
-__copyright__ = "Copyright 2011, The Materials Project"
-__version__ = "1.0"
-__maintainer__ = "Yihan Xiao"
-__email__ = "eric.xyh2011@gmail.com"
-__status__ = "Production"
-__date__ = "Aug 15 2017"
+__author__ = "Yihan Xiao, Matthew McDermott"
+__maintainer__ = "Matthew McDermott"
+__email__ = "mcdermott@lbl.gov"
+__date__ = "Sep 1, 2021"
+
+with open(os.path.join(os.path.dirname(__file__), "..", "util", "plotly_interface_rxn_layouts.json")) as f:
+    plotly_layouts = json.load(f)
 
 
-class InterfacialReactivity:
+class InterfacialReactivity(MSONable):
     """
-    An object encompassing all relevant data for interface reactions.
+    Class for modeling an interface between two solids and its possible reactions.
+    The two reactants are provided as Composition objects (c1 and c2), along with the
+    relevant compositional PhaseDiagram object. Possible reactions are calculated by
+    finding all points along a tie-line between c1 and c2 where there is a "kink" in
+    the phase diagram; i.e. a point or facet of the phase diagram.
+
+    Please consider citing one or both of the following papers if you use this code
+    in your own work.
+
+    References:
+        Richards, W. D., Miara, L. J., Wang, Y., Kim, J. C., &amp; Ceder, G. (2015).
+        Interface stability in solid-state batteries. Chemistry of Materials, 28(1),
+        266–273. https://doi.org/10.1021/acs.chemmater.5b04082
+
+        Xiao, Y., Wang, Y., Bo, S.-H., Kim, J. C., Miara, L. J., &amp; Ceder, G. (2019).
+        Understanding interface stability in solid-state batteries.
+        Nature Reviews Materials, 5(2), 105–126.
+        https://doi.org/10.1038/s41578-019-0157-5
     """
 
     EV_TO_KJ_PER_MOL = 96.4853
 
     def __init__(
         self,
-        c1,
-        c2,
-        pd,
-        norm=True,
-        include_no_mixing_energy=False,
-        pd_non_grand=None,
-        use_hull_energy=False,
+        c1: Composition,
+        c2: Composition,
+        pd: PhaseDiagram,
+        norm: bool = True,
+        use_hull_energy: bool = False,
     ):
         """
         Args:
-            c1 (Composition): Composition object for reactant 1.
-            c2 (Composition): Composition object for reactant 2.
-            pd (PhaseDiagram): PhaseDiagram object or GrandPotentialPhaseDiagram
-                object built from all elements in composition c1 and c2.
-            norm (bool): Whether or not the total number of atoms in composition
+            c1: Reactant 1 composition
+            c2: Reactant 2 composition
+            pd: Phase diagram object built from all elements in composition c1 and c2.
+            norm: Whether or not the total number of atoms in composition
                 of reactant will be normalized to 1.
-            include_no_mixing_energy (bool): No_mixing_energy for a reactant is the
-                opposite number of its energy above grand potential convex hull. In
-                cases where reactions involve elements reservoir, this param
-                determines whether no_mixing_energy of reactants will be included
-                in the final reaction energy calculation. By definition, if pd is
-                not a GrandPotentialPhaseDiagram object, this param is False.
-            pd_non_grand (PhaseDiagram): PhaseDiagram object but not
-                GrandPotentialPhaseDiagram object built from elements in c1 and c2.
-            use_hull_energy (bool): Whether or not use the convex hull energy for
+            use_hull_energy: Whether or not use the convex hull energy for
                 a given composition for reaction energy calculation. If false,
                 the energy of ground state structure will be used instead.
                 Note that in case when ground state can not be found for a
                 composition, convex hull energy will be used associated with a
                 warning message.
         """
-        self.grand = isinstance(pd, GrandPotentialPhaseDiagram)
+        if isinstance(pd, GrandPotentialPhaseDiagram):
+            raise ValueError(
+                "Please use the GrandPotentialInterfacialReactivity "
+                "class for interfacial reactions with open elements!"
+            )
 
-        # if include_no_mixing_energy is True, pd should be a
-        # GrandPotentialPhaseDiagram object and pd_non_grand should be given.
-        if include_no_mixing_energy and not self.grand:
-            raise ValueError("Please provide grand phase diagram to compute" " no_mixing_energy!")
-        if include_no_mixing_energy and not pd_non_grand:
-            raise ValueError("Please provide non-grand phase diagram to " "compute no_mixing_energy!")
-        if self.grand and use_hull_energy and not pd_non_grand:
-            raise ValueError("Please provide non-grand phase diagram if" " you want to use convex hull energy.")
-
-        # Keeps copy of original compositions.
-        self.c1_original = c1
-        self.c2_original = c2
-
-        # Two sets of composition attributes for two processing conditions:
-        # normalization with and without exluding element(s) from reservoir.
         self.c1 = c1
         self.c2 = c2
+        self.pd = pd
+        self.norm = norm
+        self.use_hull_energy = use_hull_energy
+
+        self.c1_original = c1
+        self.c2_original = c2
         self.comp1 = c1
         self.comp2 = c2
 
-        self.norm = norm
-        self.pd = pd
-        self.pd_non_grand = pd_non_grand
-        self.use_hull_energy = use_hull_energy
-
         # Factor is the compositional ratio between composition self.c1 and
-        # processed composition self.comp1. E.g., factor for
-        # Composition('SiO2') and Composition('O') is 2.0. This factor will
-        # be used to convert mixing ratio in self.comp1 - self.comp2
-        # tie line to that in self.c1 - self.c2 tie line.
-        self.factor1 = 1
-        self.factor2 = 1
-
-        if self.grand:
-            # Excludes element(s) from reservoir.
-            self.comp1 = Composition({k: v for k, v in c1.items() if k not in pd.chempots})
-            self.comp2 = Composition({k: v for k, v in c2.items() if k not in pd.chempots})
-            # Calculate the factors in case where self.grand = True and
-            # self.norm = True.
-            factor1 = self.comp1.num_atoms / c1.num_atoms
-            factor2 = self.comp2.num_atoms / c2.num_atoms
+        # processed composition self.comp1. For example, the factor for
+        # Composition('SiO2') and  Composition('O') is 2.0. This factor will be used
+        # to convert mixing ratio in self.comp1 - self.comp2 tie line to that in
+        # self.c1 - self.c2 tie line.
+        self.factor1 = 1.
+        self.factor2 = 1.
 
         if self.norm:
             self.c1 = c1.fractional_composition
             self.c2 = c2.fractional_composition
             self.comp1 = self.comp1.fractional_composition
             self.comp2 = self.comp2.fractional_composition
-            if self.grand:
-                # Only when self.grand = True and self.norm = True
-                # will self.factor be updated.
-                self.factor1 = factor1
-                self.factor2 = factor2
 
         # Computes energies for reactants in different scenarios.
-        if not self.grand:
-            if self.use_hull_energy:
-                self.e1 = self.pd.get_hull_energy(self.comp1)
-                self.e2 = self.pd.get_hull_energy(self.comp2)
-            else:
-                # Use entry energy as reactant energy if no reservoir
-                # is present.
-                self.e1 = InterfacialReactivity._get_entry_energy(self.pd, self.comp1)
-                self.e2 = InterfacialReactivity._get_entry_energy(self.pd, self.comp2)
+        if self.use_hull_energy:
+            self.e1 = self.pd.get_hull_energy(self.comp1)
+            self.e2 = self.pd.get_hull_energy(self.comp2)
         else:
-            if include_no_mixing_energy:
-                # Computing grand potentials needs compositions containing
-                # element(s) from reservoir, so self.c1 and self.c2 are used.
-                self.e1 = self._get_grand_potential(self.c1)
-                self.e2 = self._get_grand_potential(self.c2)
-            else:
-                self.e1 = self.pd.get_hull_energy(self.comp1)
-                self.e2 = self.pd.get_hull_energy(self.comp2)
+            self.e1 = self._get_entry_energy(self.pd, self.comp1)
+            self.e2 = self._get_entry_energy(self.pd, self.comp2)
+
+    def get_kinks(self) -> List[Tuple[int, float, float, str, float]]:
+        """
+        Finds all the kinks in mixing ratio where reaction products changes
+        along the tie-line of composition self.c1 and composition self.c2.
+
+        Returns:
+            Zip object of tuples (index, mixing ratio,
+                                  reaction energy per atom in eV/atom,
+                                  reaction formula,
+                                  reaction energy per mol of reaction
+                                  formula in kJ/mol).
+        """
+        c1_coord = self.pd.pd_coords(self.comp1)
+        c2_coord = self.pd.pd_coords(self.comp2)
+
+        n1 = self.comp1.num_atoms
+        n2 = self.comp2.num_atoms
+
+        critical_comp = self.pd.get_critical_compositions(self.comp1, self.comp2)
+        x_kink, energy_kink, react_kink, energy_per_rxt_formula = [], [], [], []
+
+        if (c1_coord == c2_coord).all():
+            x_kink = [0, 1]
+            energy_kink = [self._get_energy(x) for x in x_kink]
+            react_kink = [self._get_reaction(x) for x in x_kink]
+            num_atoms = [(x * self.comp1.num_atoms + (1 - x) * self.comp2.num_atoms) for x in x_kink]
+            energy_per_rxt_formula = [
+                energy_kink[i]
+                * self._get_elmt_amt_in_rxt(react_kink[i])
+                / num_atoms[i]
+                * InterfacialReactivity.EV_TO_KJ_PER_MOL
+                for i in range(2)
+            ]
+        else:
+            for i in reversed(critical_comp):
+                # Gets mixing ratio x at kinks.
+                c = self.pd.pd_coords(i)
+                x = np.linalg.norm(c - c2_coord) / np.linalg.norm(c1_coord - c2_coord)
+                # Modifies mixing ratio in case compositions self.comp1 and
+                # self.comp2 are not normalized.
+                x = x * n2 / (n1 + x * (n2 - n1))
+                n_atoms = x * self.comp1.num_atoms + (1 - x) * self.comp2.num_atoms
+                # Converts mixing ratio in comp1 - comp2 tie line to that in
+                # c1 - c2 tie line.
+                x_converted = InterfacialReactivity._convert(x, self.factor1, self.factor2)
+                x_kink.append(x_converted)
+                # Gets reaction energy at kinks
+                normalized_energy = self._get_energy(x)
+                energy_kink.append(normalized_energy)
+                # Gets balanced reaction at kinks
+                rxt = self._get_reaction(x)
+                react_kink.append(rxt)
+                rxt_energy = normalized_energy * self._get_elmt_amt_in_rxt(rxt) / n_atoms
+                energy_per_rxt_formula.append(rxt_energy * InterfacialReactivity.EV_TO_KJ_PER_MOL)
+        index_kink = range(1, len(critical_comp) + 1)
+
+        return list(zip(index_kink, x_kink, energy_kink, react_kink, energy_per_rxt_formula))
+
+    def plot(self, backend: str = "plotly") -> Figure:
+        """
+        Plots reaction energy as a function of mixing ratio x in self.c1 - self.c2
+        tie line.
+
+        Args:
+            backend: Plotting library used to create plot. Defaults to "plotly".
+            Can alternatively be set to "matplotlib"
+
+        Returns:
+            Plot of reaction energies as a function of mixing ratio
+        """
+        fig = None
+
+        if backend.lower() == "plotly":
+            fig = self._get_plotly_figure()
+        elif backend.lower() in ["matplotlib", "mpl", "plt"]:
+            fig = self._get_matplotlib_figure()
+        else:
+            raise ValueError("The provided backend is not a valid option!")
+
+        return fig
+
+    def get_dataframe(self):
+        """
+
+        Returns:
+
+        """
+        rxns = [
+            {
+                "Atomic fraction": round(ratio, 3),
+                "Reaction": rxn,
+                "E$_{\textrm{rxn}}$ (kJ/mol)": round(rxn_energy, 1),
+                "E$_{\textrm{rxn}}$ (eV/atom)": round(reactivity, 3),
+            }
+            for _, ratio, reactivity, rxn, rxn_energy in self.get_kinks()
+        ]
+
+        df = pandas.DataFrame(rxns)
+        return df
+
+    def get_critical_original_kink_ratio(self):
+        """
+        Returns a list of molar mixing ratio for each kink between ORIGINAL
+        (instead of processed) reactant compositions. This is the
+        same list as mixing ratio obtained from get_kinks method
+        if self.norm = False.
+
+        Returns:
+            A list of floats representing molar mixing ratios between
+            the original reactant compositions for each kink.
+        """
+        ratios = []
+        if self.c1_original == self.c2_original:
+            return [0, 1]
+        reaction_kink = [k[3] for k in self.get_kinks()]
+        for rxt in reaction_kink:
+            ratios.append(abs(self._get_original_composition_ratio(rxt)))
+        return ratios
+
+    def _get_original_composition_ratio(self, reaction):
+        """
+        Returns the molar mixing ratio between the reactants with ORIGINAL (
+        instead of processed) compositions for a reaction.
+
+        Args:
+            reaction (Reaction): Reaction object that contains the original
+                reactant compositions.
+
+        Returns:
+            The molar mixing ratio between the original reactant
+            compositions for a reaction.
+        """
+        if self.c1_original == self.c2_original:
+            return 1
+        c1_coeff = reaction.get_coeff(self.c1_original) if self.c1_original in reaction.reactants else 0
+        c2_coeff = reaction.get_coeff(self.c2_original) if self.c2_original in reaction.reactants else 0
+        return c1_coeff * 1.0 / (c1_coeff + c2_coeff)
+
+    def _get_energy(self, x):
+        """
+        Computes reaction energy in eV/atom at mixing ratio x : (1-x) for
+        self.comp1 : self.comp2.
+
+        Args:
+            x (float): Mixing ratio x of reactants, a float between 0 and 1.
+
+        Returns:
+            Reaction energy.
+        """
+        return self.pd.get_hull_energy(self.comp1 * x + self.comp2 * (1 - x)) - self.e1 * x - self.e2 * (1 - x)
+
+    def _get_reactants(self, x):
+        # Uses original composition for reactants.
+        if np.isclose(x, 0):
+            reactants = [self.c2_original]
+        elif np.isclose(x, 1):
+            reactants = [self.c1_original]
+        else:
+            reactants = list(set([self.c1_original, self.c2_original]))
+
+        return reactants
+
+    def _get_reaction(self, x):
+        """
+        Generates balanced reaction at mixing ratio x : (1-x) for
+        self.comp1 : self.comp2.
+
+        Args:
+            x (float): Mixing ratio x of reactants, a float between 0 and 1.
+
+        Returns:
+            Reaction object.
+        """
+        mix_comp = self.comp1 * x + self.comp2 * (1 - x)
+        decomp = self.pd.get_decomposition(mix_comp)
+
+        reactants = self._get_reactants(x)
+
+        product = [Composition(k.name) for k, v in decomp.items()]
+        reaction = Reaction(reactants, product)
+
+        x_original = self._get_original_composition_ratio(reaction)
+
+        if np.isclose(x_original, 1):
+            reaction.normalize_to(self.c1_original, x_original)
+        else:
+            reaction.normalize_to(self.c2_original, 1 - x_original)
+
+        return reaction
+
+    def _get_elmt_amt_in_rxt(self, rxt):
+        """
+        Computes total number of atoms in a reaction formula for elements
+        not in external reservoir. This method is used in the calculation
+        of reaction energy per mol of reaction formula.
+
+        Args:
+            rxt (Reaction): a reaction.
+
+        Returns:
+            Total number of atoms for non_reservoir elements.
+        """
+        return sum([rxt.get_el_amount(e) for e in self.pd.elements])
+
+    def _get_plotly_figure(self):
+        kinks = list(zip(*self.get_kinks()))
+        _, x, energy, reactions, _ = kinks
+
+        lines = Scatter(x=x, y=energy, mode="lines")
+
+        data = [lines]
+        layout = plotly_layouts["default_interface_rxn_plot"]
+
+        fig = Figure(data=data, layout=layout)
+        return fig
+
+    def _get_matplotlib_figure(self):
+        plt = pretty_plot(8, 6)
+        plt.xlim([-0.05, 1.05])
+
+        kinks = list(zip(*self.get_kinks()))
+        _, x, energy, reactions, _ = kinks
+
+        plt.plot(x, energy, "o-", markersize=8, c="navy")
+        plt.scatter(self.minimum[0], self.minimum[1], marker="*", c="red", s=300)
+
+        for x_coord, y_coord, rxn in zip(x, energy, reactions):
+            products = ", ".join([latexify(p.reduced_formula) for p in rxn.products])
+            plt.annotate(
+                products,
+                xy=(x_coord, y_coord),
+                xytext=(10, 20),
+                textcoords="offset points",
+                ha="right",
+                va="bottom",
+                arrowprops=dict(arrowstyle="->", connectionstyle="arc3,rad=0"),
+            )
+
+        if self.norm:
+            plt.ylabel("Energy (eV/atom)")
+        else:
+            plt.ylabel("Energy (eV/f.u.)")
+
+        plt.xlabel(f"$x$ in $x$ {latexify(self.c1.reduced_formula)} + $(1-x)$ " f"{latexify(self.c2.reduced_formula)}")
+
+        return plt.gcf()
 
     @staticmethod
-    def _get_entry_energy(pd, composition):
+    def _get_entry_energy(pd: PhaseDiagram, composition: Composition):
         """
         Finds the lowest entry energy for entries matching the composition.
         Entries with non-negative formation energies are excluded. If no
         entry is found, use the convex hull energy for the composition.
 
         Args:
-            pd (PhaseDiagram): PhaseDiagram object.
-            composition (Composition): Composition object that the target
-            entry should match.
+            pd: Phase diagram object
+            composition: Composition object that the target entry should match
 
         Returns:
             The lowest entry energy among entries matching the composition.
@@ -170,99 +411,6 @@ class InterfacialReactivity:
             return pd.get_hull_energy(composition)
         min_entry_energy = min(candidate)
         return min_entry_energy * composition.num_atoms
-
-    def _get_grand_potential(self, composition):
-        """
-        Computes the grand potential Phi at a given composition and
-        chemical potential(s).
-
-        Args:
-            composition (Composition): Composition object.
-
-        Returns:
-            Grand potential at a given composition at chemical potential(s).
-        """
-        if self.use_hull_energy:
-            grand_potential = self.pd_non_grand.get_hull_energy(composition)
-        else:
-            grand_potential = InterfacialReactivity._get_entry_energy(self.pd_non_grand, composition)
-        grand_potential -= sum([composition[e] * mu for e, mu in self.pd.chempots.items()])
-        if self.norm:
-            # Normalizes energy to the composition excluding element(s)
-            # from reservoir.
-            grand_potential /= sum([composition[el] for el in composition if el not in self.pd.chempots])
-        return grand_potential
-
-    def _get_energy(self, x):
-        """
-        Computes reaction energy in eV/atom at mixing ratio x : (1-x) for
-        self.comp1 : self.comp2.
-
-        Args:
-            x (float): Mixing ratio x of reactants, a float between 0 and 1.
-
-        Returns:
-            Reaction energy.
-        """
-        return self.pd.get_hull_energy(self.comp1 * x + self.comp2 * (1 - x)) - self.e1 * x - self.e2 * (1 - x)
-
-    def _get_reaction(self, x):
-        """
-        Generates balanced reaction at mixing ratio x : (1-x) for
-        self.comp1 : self.comp2.
-
-        Args:
-            x (float): Mixing ratio x of reactants, a float between 0 and 1.
-
-        Returns:
-            Reaction object.
-        """
-        mix_comp = self.comp1 * x + self.comp2 * (1 - x)
-        decomp = self.pd.get_decomposition(mix_comp)
-
-        # Uses original composition for reactants.
-        if np.isclose(x, 0):
-            reactant = [self.c2_original]
-        elif np.isclose(x, 1):
-            reactant = [self.c1_original]
-        else:
-            reactant = list(set([self.c1_original, self.c2_original]))
-
-        if self.grand:
-            reactant += [Composition(e.symbol) for e, v in self.pd.chempots.items()]
-
-        product = [Composition(k.name) for k, v in decomp.items()]
-        reaction = Reaction(reactant, product)
-
-        x_original = self._get_original_composition_ratio(reaction)
-        if np.isclose(x_original, 1):
-            reaction.normalize_to(self.c1_original, x_original)
-        else:
-            reaction.normalize_to(self.c2_original, 1 - x_original)
-        return reaction
-
-    def _get_elmt_amt_in_rxt(self, rxt):
-        """
-        Computes total number of atoms in a reaction formula for elements
-        not in external reservoir. This method is used in the calculation
-        of reaction energy per mol of reaction formula.
-
-        Args:
-            rxt (Reaction): a reaction.
-
-        Returns:
-            Total number of atoms for non_reservoir elements.
-        """
-        return sum([rxt.get_el_amount(e) for e in self.pd.elements])
-
-    def get_products(self):
-        """
-        List of formulas of potential products. E.g., ['Li','O2','Mn'].
-        """
-        products = set()
-        for _, _, _, react, _ in self.get_kinks():
-            products = products.union({k.reduced_formula for k in react.products})
-        return list(products)
 
     @staticmethod
     def _convert(x, factor1, factor2):
@@ -303,188 +451,6 @@ class InterfacialReactivity:
             Mixing ratio in comp1 - comp2 tie line, a float between 0 and 1.
         """
         return x * factor1 / ((1 - x) * factor2 + x * factor1)
-
-    def get_kinks(self):
-        """
-        Finds all the kinks in mixing ratio where reaction products changes
-        along the tie line of composition self.c1 and composition self.c2.
-
-        Returns:
-            Zip object of tuples (index, mixing ratio,
-                                  reaction energy per atom in eV/atom,
-                                  reaction formula,
-                                  reaction energy per mol of reaction
-                                  formula in kJ/mol).
-        """
-        c1_coord = self.pd.pd_coords(self.comp1)
-        c2_coord = self.pd.pd_coords(self.comp2)
-        n1 = self.comp1.num_atoms
-        n2 = self.comp2.num_atoms
-        critical_comp = self.pd.get_critical_compositions(self.comp1, self.comp2)
-        x_kink, energy_kink, react_kink, energy_per_rxt_formula = [], [], [], []
-        if all(c1_coord == c2_coord):
-            x_kink = [0, 1]
-            energy_kink = [self._get_energy(x) for x in x_kink]
-            react_kink = [self._get_reaction(x) for x in x_kink]
-            num_atoms = [(x * self.comp1.num_atoms + (1 - x) * self.comp2.num_atoms) for x in x_kink]
-            energy_per_rxt_formula = [
-                energy_kink[i]
-                * self._get_elmt_amt_in_rxt(react_kink[i])
-                / num_atoms[i]
-                * InterfacialReactivity.EV_TO_KJ_PER_MOL
-                for i in range(2)
-            ]
-        else:
-            for i in reversed(critical_comp):
-                # Gets mixing ratio x at kinks.
-                c = self.pd.pd_coords(i)
-                x = np.linalg.norm(c - c2_coord) / np.linalg.norm(c1_coord - c2_coord)
-                # Modifies mixing ratio in case compositions self.comp1 and
-                # self.comp2 are not normalized.
-                x = x * n2 / (n1 + x * (n2 - n1))
-                n_atoms = x * self.comp1.num_atoms + (1 - x) * self.comp2.num_atoms
-                # Converts mixing ratio in comp1 - comp2 tie line to that in
-                # c1 - c2 tie line.
-                x_converted = InterfacialReactivity._convert(x, self.factor1, self.factor2)
-                x_kink.append(x_converted)
-                # Gets reaction energy at kinks
-                normalized_energy = self._get_energy(x)
-                energy_kink.append(normalized_energy)
-                # Gets balanced reaction at kinks
-                rxt = self._get_reaction(x)
-                react_kink.append(rxt)
-                rxt_energy = normalized_energy * self._get_elmt_amt_in_rxt(rxt) / n_atoms
-                energy_per_rxt_formula.append(rxt_energy * InterfacialReactivity.EV_TO_KJ_PER_MOL)
-        index_kink = range(1, len(critical_comp) + 1)
-        return zip(index_kink, x_kink, energy_kink, react_kink, energy_per_rxt_formula)
-
-    def get_critical_original_kink_ratio(self):
-        """
-        Returns a list of molar mixing ratio for each kink between ORIGINAL
-        (instead of processed) reactant compositions. This is the
-        same list as mixing ratio obtained from get_kinks method
-        if self.norm = False.
-
-        Returns:
-            A list of floats representing molar mixing ratios between
-            the original reactant compositions for each kink.
-        """
-        ratios = []
-        if self.c1_original == self.c2_original:
-            return [0, 1]
-        reaction_kink = [k[3] for k in self.get_kinks()]
-        for rxt in reaction_kink:
-            ratios.append(abs(self._get_original_composition_ratio(rxt)))
-        return ratios
-
-    def _get_original_composition_ratio(self, reaction):
-        """
-        Returns the molar mixing ratio between the reactants with ORIGINAL (
-        instead of processed) compositions for a reaction.
-
-        Args:
-            reaction (Reaction): Reaction object that contains the original
-                reactant compositions.
-
-        Returns:
-            The molar mixing ratio between the original reactant
-            compositions for a reaction.
-        """
-        if self.c1_original == self.c2_original:
-            return 1
-        c1_coeff = reaction.get_coeff(self.c1_original) if self.c1_original in reaction.reactants else 0
-        c2_coeff = reaction.get_coeff(self.c2_original) if self.c2_original in reaction.reactants else 0
-        return c1_coeff * 1.0 / (c1_coeff + c2_coeff)
-
-    def labels(self):
-        """
-        Returns a dictionary containing kink information:
-        {index: 'x= mixing_ratio energy= reaction_energy reaction_equation'}.
-        E.g., {1: 'x= 0.0 energy = 0.0 Mn -> Mn',
-               2: 'x= 0.5 energy = -15.0 O2 + Mn -> MnO2',
-               3: 'x= 1.0 energy = 0.0 O2 -> O2'}.
-        """
-        return {
-            j: "x= " + str(round(x, 4)) + " energy in eV/atom = " + str(round(energy, 4)) + " " + str(reaction)
-            for j, x, energy, reaction, _ in self.get_kinks()
-        }
-
-    def plot(self):
-        """
-        Plots reaction energy as a function of mixing ratio x in
-        self.c1 - self.c2 tie line using pylab.
-
-        Returns:
-            Pylab object that plots reaction energy as a function of
-            mixing ratio x.
-        """
-        plt.rcParams["xtick.major.pad"] = "6"
-        plt.rcParams["ytick.major.pad"] = "6"
-        plt.rcParams["axes.linewidth"] = 2
-        npoint = 1000
-        xs = np.linspace(0, 1, npoint)
-
-        # Converts sampling points in self.c1 - self.c2 tie line to those in
-        # self.comp1 - self.comp2 tie line.
-        xs_reverse_converted = InterfacialReactivity._reverse_convert(xs, self.factor1, self.factor2)
-        energies = [self._get_energy(x) for x in xs_reverse_converted]
-        plt.plot(xs, energies, "k-")
-
-        # Marks kinks and minimum energy point.
-        kinks = self.get_kinks()
-        _, x_kink, energy_kink, _, _ = zip(*kinks)
-        plt.scatter(x_kink, energy_kink, marker="o", c="blue", s=20)
-        plt.scatter(self.minimum()[0], self.minimum()[1], marker="*", c="red", s=300)
-
-        # Labels kinks with indices. Labels are made draggable
-        # in case of overlapping.
-        for index, x, energy, _, _ in kinks:
-            plt.annotate(
-                index,
-                xy=(x, energy),
-                xytext=(5, 30),
-                textcoords="offset points",
-                ha="right",
-                va="bottom",
-                arrowprops=dict(arrowstyle="->", connectionstyle="arc3,rad=0"),
-            ).draggable()
-        plt.xlim([-0.05, 1.05])
-        if self.norm:
-            plt.ylabel("Energy (eV/atom)")
-        else:
-            plt.ylabel("Energy (eV/f.u.)")
-        plt.xlabel("$x$ in $x$ {} + $(1-x)$ {}".format(self.c1.reduced_formula, self.c2.reduced_formula))
-        return plt
-
-    def minimum(self):
-        """
-        Finds the minimum reaction energy E_min and corresponding
-        mixing ratio x_min.
-
-        Returns:
-            Tuple (x_min, E_min).
-        """
-        return min([(x, energy) for _, x, energy, _, _ in self.get_kinks()], key=lambda i: i[1])
-
-    def get_no_mixing_energy(self):
-        """
-        Generates the opposite number of energy above grand potential
-        convex hull for both reactants.
-
-        Returns:
-            [(reactant1, no_mixing_energy1),(reactant2,no_mixing_energy2)].
-        """
-        assert self.grand == 1, "Please provide grand potential phase diagram for computing no_mixing_energy!"
-
-        energy1 = self.pd.get_hull_energy(self.comp1) - self._get_grand_potential(self.c1)
-        energy2 = self.pd.get_hull_energy(self.comp2) - self._get_grand_potential(self.c2)
-        unit = "eV/f.u."
-        if self.norm:
-            unit = "eV/atom"
-        return [
-            (self.c1_original.reduced_formula + " ({0})".format(unit), energy1),
-            (self.c2_original.reduced_formula + " ({0})".format(unit), energy2),
-        ]
 
     @staticmethod
     def get_chempot_correction(element, temp, pres):
@@ -535,3 +501,174 @@ class InterfacialReactivity:
         # considered, the gas molecules are all diatomic.
         dG /= 2
         return dG
+
+    @property
+    def labels(self):
+        """
+        Returns a dictionary containing kink information:
+        {index: 'x= mixing_ratio energy= reaction_energy reaction_equation'}.
+        E.g., {1: 'x= 0.0 energy = 0.0 Mn -> Mn',
+               2: 'x= 0.5 energy = -15.0 O2 + Mn -> MnO2',
+               3: 'x= 1.0 energy = 0.0 O2 -> O2'}.
+        """
+        return {
+            j: "x= " + str(round(x, 4)) + " energy in eV/atom = " + str(round(energy, 4)) + " " + str(reaction)
+            for j, x, energy, reaction, _ in self.get_kinks()
+        }
+
+    @property
+    def minimum(self):
+        """
+        Finds the minimum reaction energy E_min and corresponding
+        mixing ratio x_min.
+
+        Returns:
+            Tuple (x_min, E_min).
+        """
+        return min([(x, energy) for _, x, energy, _, _ in self.get_kinks()], key=lambda i: i[1])
+
+    @property
+    def products(self):
+        """
+        List of formulas of potential products. E.g., ['Li','O2','Mn'].
+        """
+        products = set()
+        for _, _, _, react, _ in self.get_kinks():
+            products = products.union({k.reduced_formula for k in react.products})
+        return list(products)
+
+    @deprecated(products)
+    def get_products(self):
+        """
+
+        Returns:
+
+        """
+        return self.products
+
+
+class GrandPotentialInterfacialReactivity(InterfacialReactivity):
+    """
+    Extends upon InterfacialReactivity to allow for modelling possible reactions
+    at the interface between two solids in the presence of an open element. The
+    thermodynamics of the open system are provided by the user via the
+    GrandPotentialPhaseDiagram class.
+    """
+    def __init__(
+        self,
+        c1: Composition,
+        c2: Composition,
+        grand_pd: GrandPotentialPhaseDiagram,
+        norm: bool = True,
+        include_no_mixing_energy: bool = False,
+        pd_non_grand: Optional[PhaseDiagram] = None,
+        use_hull_energy: bool = True,
+    ):
+        """
+        Args:
+            c1: Reactant 1 composition
+            c2: Reactant 2 composition
+            pd: Phase diagram (can be PhaseDiagram or GrandPotentialPhaseDiagram)
+                object built from all elements in composition c1 and c2.
+            norm: Whether or not the total number of atoms in composition
+                of reactant will be normalized to 1.
+            include_no_mixing_energy: No_mixing_energy for a reactant is the
+                opposite number of its energy above grand potential convex hull. In
+                cases where reactions involve elements reservoir, this param
+                determines whether no_mixing_energy of reactants will be included
+                in the final reaction energy calculation. By definition, if pd is
+                not a GrandPotentialPhaseDiagram object, this param is False.
+            pd_non_grand: PhaseDiagram object but not
+                GrandPotentialPhaseDiagram object built from elements in c1 and c2.
+            use_hull_energy: Whether or not use the convex hull energy for
+                a given composition for reaction energy calculation. If false,
+                the energy of ground state structure will be used instead.
+                Note that in case when ground state can not be found for a
+                composition, convex hull energy will be used associated with a
+                warning message.
+        """
+        # if include_no_mixing_energy is True, pd should be a
+        # GrandPotentialPhaseDiagram object and pd_non_grand should be given.
+        is_grand = isinstance(grand_pd, GrandPotentialPhaseDiagram)
+
+        if include_no_mixing_energy and not is_grand:
+            raise ValueError("Please provide grand phase diagram to compute" " no_mixing_energy!")
+        if include_no_mixing_energy and not pd_non_grand:
+            raise ValueError("Please provide non-grand phase diagram to " "compute no_mixing_energy!")
+        if is_grand and use_hull_energy and not pd_non_grand:
+            raise ValueError("Please provide non-grand phase diagram if" " you want to use convex hull energy.")
+
+        super().__init__(c1=c1, c2=c2, pd=grand_pd, norm=norm, use_hull_energy=use_hull_energy)
+
+        self.pd_non_grand = pd_non_grand
+
+        # Excludes element(s) from reservoir.
+        self.comp1 = Composition({k: v for k, v in c1.items() if k not in
+                                  grand_pd.chempots})
+        self.comp2 = Composition({k: v for k, v in c2.items() if k not in
+                                  grand_pd.chempots})
+        # Calculate the factors in case where self.grand = True and
+        # self.norm = True.
+
+        factor1 = self.comp1.num_atoms / c1.num_atoms
+        factor2 = self.comp2.num_atoms / c2.num_atoms
+
+        if self.norm:
+            self.factor1 = factor1
+            self.factor2 = factor2
+
+        if include_no_mixing_energy:
+            # Computing grand potentials needs compositions containing
+            # element(s) from reservoir, so self.c1 and self.c2 are used.
+            self.e1 = self._get_grand_potential(self.c1)
+            self.e2 = self._get_grand_potential(self.c2)
+        else:
+            self.e1 = self.pd.get_hull_energy(self.comp1)
+            self.e2 = self.pd.get_hull_energy(self.comp2)
+
+    def get_no_mixing_energy(self):
+        """
+        Generates the opposite number of energy above grand potential
+        convex hull for both reactants.
+
+        Returns:
+            [(reactant1, no_mixing_energy1),(reactant2,no_mixing_energy2)].
+        """
+
+        energy1 = self.pd.get_hull_energy(self.comp1) - self._get_grand_potential(self.c1)
+        energy2 = self.pd.get_hull_energy(self.comp2) - self._get_grand_potential(self.c2)
+        unit = "eV/f.u."
+        if self.norm:
+            unit = "eV/atom"
+        return [
+            (self.c1_original.reduced_formula + " ({0})".format(unit), energy1),
+            (self.c2_original.reduced_formula + " ({0})".format(unit), energy2),
+        ]
+
+    def _get_reactants(self, x):
+        reactants = super()._get_reactants(x)
+        reactants += [Composition(e.symbol) for e, v in self.pd.chempots.items()]
+
+        return reactants
+
+    def _get_grand_potential(self, composition):
+        """
+        Computes the grand potential Phi at a given composition and
+        chemical potential(s).
+
+        Args:
+            composition (Composition): Composition object.
+
+        Returns:
+            Grand potential at a given composition at chemical potential(s).
+        """
+        if self.use_hull_energy:
+            grand_potential = self.pd_non_grand.get_hull_energy(composition)
+        else:
+            grand_potential = InterfacialReactivity._get_entry_energy(self.pd_non_grand, composition)
+        grand_potential -= sum([composition[e] * mu for e, mu in self.pd.chempots.items()])
+        if self.norm:
+            # Normalizes energy to the composition excluding element(s)
+            # from reservoir.
+            grand_potential /= sum([composition[el] for el in composition if el not in self.pd.chempots])
+        return grand_potential

--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -27,7 +27,7 @@ from pymatgen.core.periodic_table import DummySpecies, Element, get_el_sp
 from pymatgen.entries import Entry
 from pymatgen.util.coord import Simplex, in_coord_list
 from pymatgen.util.plotting import pretty_plot
-from pymatgen.util.string import latexify
+from pymatgen.util.string import latexify, htmlify
 
 logger = logging.getLogger(__name__)
 
@@ -2380,7 +2380,7 @@ class PDPlotter:
                 comp = entry.original_entry.composition
 
             formula = list(comp.reduced_formula)
-            text.append(self._htmlize_formula(formula))
+            text.append(htmlify(formula))
 
         visible = True
         if not label_stable or self._dim == 4:
@@ -2430,7 +2430,7 @@ class PDPlotter:
                 clean_formula = str(entry.composition.elements[0])
                 if hasattr(entry, "original_entry"):
                     orig_comp = entry.original_entry.composition
-                    clean_formula = self._htmlize_formula(orig_comp.reduced_formula)
+                    clean_formula = htmlify(orig_comp.reduced_formula)
 
                 font_dict = {"color": "#000000", "size": 24.0}
                 opacity = 1.0
@@ -2513,7 +2513,7 @@ class PDPlotter:
                     entry_id = getattr(entry, "attribute", "no ID")
 
                 formula = comp.reduced_formula
-                clean_formula = self._htmlize_formula(formula)
+                clean_formula = htmlify(formula)
                 label = f"{clean_formula} ({entry_id}) <br> " f"{energy} eV/atom"
 
                 if not stable:
@@ -2798,23 +2798,6 @@ class PDPlotter:
             flatshading=True,
             showlegend=True,
         )
-
-    @staticmethod
-    def _htmlize_formula(formula: str):
-        """
-        Adds HTML tags for displaying chemical formula in Plotly figure annotations.
-
-        :param formula: chemical formula
-        :return: clean chemical formula with necessary HTML tags
-        """
-        s = []
-        for char in formula:
-            if char.isdigit():
-                s.append(f"<sub>{char}</sub>")
-            else:
-                s.append(char)
-
-        return "".join(s)
 
 
 def uniquelines(q):

--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -2379,7 +2379,7 @@ class PDPlotter:
             if hasattr(entry, "original_entry"):
                 comp = entry.original_entry.composition
 
-            formula = list(comp.reduced_formula)
+            formula = comp.reduced_formula
             text.append(htmlify(formula))
 
         visible = True

--- a/pymatgen/analysis/tests/test_interface_reactions.py
+++ b/pymatgen/analysis/tests/test_interface_reactions.py
@@ -290,21 +290,21 @@ class InterfaceReactionTest(unittest.TestCase):
             [Composition("Mn"), Composition("O2"), Composition("Li")],
             [Composition("LiMnO2")],
         )
-        test1 = np.isclose(self.ir[2]._get_elmt_amt_in_rxt(rxt1), 3)
+        test1 = np.isclose(self.ir[2]._get_elmt_amt_in_rxn(rxt1), 3)
         self.assertTrue(test1, "_get_get_elmt_amt_in_rxt: gpd elements amounts gets error!")
 
         rxt2 = rxt1
         rxt2.normalize_to(Composition("Li"), 0.5)
-        test2 = np.isclose(self.ir[2]._get_elmt_amt_in_rxt(rxt2), 1.5)
+        test2 = np.isclose(self.ir[2]._get_elmt_amt_in_rxn(rxt2), 1.5)
         self.assertTrue(test2, "_get_get_elmt_amt_in_rxt: gpd elements amounts gets error!")
 
         rxt3 = Reaction([Composition("O2"), Composition("Li")], [Composition("Li2O")])
         # Li is not counted
-        test3 = np.isclose(self.ir[2]._get_elmt_amt_in_rxt(rxt3), 1)
+        test3 = np.isclose(self.ir[2]._get_elmt_amt_in_rxn(rxt3), 1)
         self.assertTrue(test3, "_get_get_elmt_amt_in_rxt: gpd elements amounts gets error!")
 
         # Li is counted
-        test4 = np.isclose(self.ir[6]._get_elmt_amt_in_rxt(rxt3), 3)
+        test4 = np.isclose(self.ir[6]._get_elmt_amt_in_rxn(rxt3), 3)
         self.assertTrue(test4, "_get_get_elmt_amt_in_rxt: pd elements amounts gets error!")
 
     def test_convert(self):

--- a/pymatgen/analysis/tests/test_interface_reactions.py
+++ b/pymatgen/analysis/tests/test_interface_reactions.py
@@ -7,8 +7,7 @@ from pandas import DataFrame
 from plotly.graph_objects import Figure as plotly_figure
 from scipy.spatial import ConvexHull
 
-from pymatgen.analysis.interface_reactions import InterfacialReactivity, \
-    GrandPotentialInterfacialReactivity
+from pymatgen.analysis.interface_reactions import InterfacialReactivity, GrandPotentialInterfacialReactivity
 from pymatgen.analysis.phase_diagram import GrandPotentialPhaseDiagram, PhaseDiagram
 from pymatgen.analysis.reaction_calculator import Reaction
 from pymatgen.core.composition import Composition, Element

--- a/pymatgen/analysis/tests/test_interface_reactions.py
+++ b/pymatgen/analysis/tests/test_interface_reactions.py
@@ -5,7 +5,7 @@ import numpy as np
 from scipy.spatial import ConvexHull
 
 from pymatgen.core.composition import Composition
-from pymatgen.analysis.interface_reactions import InterfacialReactivity
+from pymatgen.analysis.interface_reactions import InterfacialReactivity, GrandPotentialInterfacialReactivity
 from pymatgen.analysis.phase_diagram import GrandPotentialPhaseDiagram, PhaseDiagram
 from pymatgen.analysis.reaction_calculator import Reaction
 from pymatgen.entries.computed_entries import ComputedEntry
@@ -25,193 +25,143 @@ class InterfaceReactionTest(unittest.TestCase):
             ComputedEntry(Composition("LiMnO2"), -30),
         ]
         self.pd = PhaseDiagram(self.entries)
+
         chempots = {"Li": -3}
         self.gpd = GrandPotentialPhaseDiagram(self.entries, chempots)
-        self.ir = []
-        # ir[0]
-        self.ir.append(
-            InterfacialReactivity(
-                Composition("O2"),
-                Composition("Mn"),
-                self.pd,
-                norm=0,
-                include_no_mixing_energy=0,
-                pd_non_grand=None,
-                use_hull_energy=False,
-            )
-        )
-        # ir[1]
-        self.ir.append(
-            InterfacialReactivity(
-                Composition("MnO2"),
-                Composition("Mn"),
-                self.gpd,
-                norm=0,
-                include_no_mixing_energy=1,
-                pd_non_grand=self.pd,
-                use_hull_energy=False,
-            )
-        )
-        # ir[2]
-        self.ir.append(
-            InterfacialReactivity(
-                Composition("Mn"),
-                Composition("O2"),
-                self.gpd,
-                norm=1,
-                include_no_mixing_energy=1,
-                pd_non_grand=self.pd,
-                use_hull_energy=False,
-            )
-        )
-        # ir[3]
-        self.ir.append(
-            InterfacialReactivity(
-                Composition("Li2O"),
-                Composition("Mn"),
-                self.gpd,
-                norm=0,
-                include_no_mixing_energy=1,
-                pd_non_grand=self.pd,
-                use_hull_energy=False,
-            )
-        )
-        # ir[4]
-        self.ir.append(
-            InterfacialReactivity(
-                Composition("Mn"),
-                Composition("O2"),
-                self.gpd,
-                norm=1,
-                include_no_mixing_energy=0,
-                pd_non_grand=self.pd,
-                use_hull_energy=False,
-            )
-        )
-        # ir[5]
-        self.ir.append(
-            InterfacialReactivity(
-                Composition("Mn"),
-                Composition("Li2O"),
-                self.gpd,
-                norm=1,
-                include_no_mixing_energy=1,
-                pd_non_grand=self.pd,
-                use_hull_energy=False,
-            )
-        )
-        # ir[6]
-        self.ir.append(
-            InterfacialReactivity(
-                Composition("Li2O2"),
-                Composition("Li"),
-                self.pd,
-                norm=0,
-                include_no_mixing_energy=0,
-                pd_non_grand=None,
-                use_hull_energy=True,
-            )
-        )
-        # ir[7]
-        self.ir.append(
-            InterfacialReactivity(
-                Composition("Li2O2"),
-                Composition("Li"),
-                self.pd,
-                norm=0,
-                include_no_mixing_energy=0,
-                pd_non_grand=None,
-                use_hull_energy=False,
-            )
-        )
-        # ir[8]
-        self.ir.append(
-            InterfacialReactivity(
-                Composition("Li2O2"),
-                Composition("MnO2"),
-                self.gpd,
-                norm=0,
-                include_no_mixing_energy=0,
-                pd_non_grand=self.pd,
-                use_hull_energy=True,
-            )
-        )
-        # ir[9]
-        self.ir.append(
-            InterfacialReactivity(
-                Composition("Li2O2"),
-                Composition("MnO2"),
-                self.gpd,
-                norm=0,
-                include_no_mixing_energy=0,
-                pd_non_grand=self.pd,
-                use_hull_energy=False,
-            )
-        )
-        # ir[10]
-        self.ir.append(
-            InterfacialReactivity(
-                Composition("O2"),
-                Composition("Mn"),
-                self.pd,
-                norm=1,
-                include_no_mixing_energy=0,
-                pd_non_grand=None,
-                use_hull_energy=False,
-            )
-        )
-        # ir[11]
-        self.ir.append(
-            InterfacialReactivity(
-                Composition("Li2O2"),
-                Composition("Li2O2"),
-                self.gpd,
-                norm=1,
-                include_no_mixing_energy=1,
-                pd_non_grand=self.pd,
-                use_hull_energy=False,
-            )
-        )
-        # ir[12]
-        self.ir.append(
-            InterfacialReactivity(
-                Composition("Li2O2"),
-                Composition("Li2O2"),
-                self.pd,
-                norm=1,
-                include_no_mixing_energy=0,
-                pd_non_grand=None,
-                use_hull_energy=False,
-            )
-        )
 
+        ir_0 = InterfacialReactivity(
+            c1=Composition("O2"),
+            c2=Composition("Mn"),
+            pd=self.pd,
+            norm=False,
+            use_hull_energy=False,
+        )
+        ir_1 = GrandPotentialInterfacialReactivity(
+            c1=Composition("MnO2"),
+            c2=Composition("Mn"),
+            grand_pd=self.gpd,
+            pd_non_grand=self.pd,
+            norm=False,
+            include_no_mixing_energy=True,
+            use_hull_energy=False,
+        )
+        ir_2 = GrandPotentialInterfacialReactivity(
+            c1=Composition("Mn"),
+            c2=Composition("O2"),
+            grand_pd=self.gpd,
+            pd_non_grand=self.pd,
+            norm=True,
+            include_no_mixing_energy=True,
+            use_hull_energy=False,
+        )
+        ir_3 = GrandPotentialInterfacialReactivity(
+            c1=Composition("Li2O"),
+            c2=Composition("Mn"),
+            grand_pd=self.gpd,
+            norm=False,
+            include_no_mixing_energy=True,
+            pd_non_grand=self.pd,
+            use_hull_energy=False,
+        )
+        ir_4 = GrandPotentialInterfacialReactivity(
+            c1=Composition("Mn"),
+            c2=Composition("O2"),
+            grand_pd=self.gpd,
+            norm=True,
+            include_no_mixing_energy=False,
+            pd_non_grand=self.pd,
+            use_hull_energy=False,
+        )
+        ir_5 = GrandPotentialInterfacialReactivity(
+            c1=Composition("Mn"),
+            c2=Composition("Li2O"),
+            grand_pd=self.gpd,
+            pd_non_grand=self.pd,
+            norm=True,
+            include_no_mixing_energy=False,
+            use_hull_energy=False,
+        )
+        ir_6 = InterfacialReactivity(
+            c1=Composition("Li2O2"),
+            c2=Composition("Li"),
+            pd=self.pd,
+            norm=False,
+            use_hull_energy=True,
+        )
+        ir_7 = InterfacialReactivity(
+            c1=Composition("Li2O2"),
+            c2=Composition("Li"),
+            pd=self.pd,
+            norm=False,
+            use_hull_energy=False,
+        )
+        ir_8 = GrandPotentialInterfacialReactivity(
+            c1=Composition("Li2O2"),
+            c2=Composition("MnO2"),
+            grand_pd=self.gpd,
+            pd_non_grand=self.pd,
+            norm=False,
+            include_no_mixing_energy=False,
+            use_hull_energy=True,
+        )
+        ir_9 = GrandPotentialInterfacialReactivity(
+            c1=Composition("Li2O2"),
+            c2=Composition("MnO2"),
+            grand_pd=self.gpd,
+            pd_non_grand=self.pd,
+            norm=False,
+            include_no_mixing_energy=False,
+            use_hull_energy=False,
+        )
+        ir_10 = InterfacialReactivity(
+            Composition("O2"),
+            Composition("Mn"),
+            pd=self.pd,
+            norm=True,
+            use_hull_energy=False,
+        )
+        ir_11 = GrandPotentialInterfacialReactivity(
+            Composition("Li2O2"),
+            Composition("Li2O2"),
+            self.gpd,
+            norm=True,
+            include_no_mixing_energy=True,
+            pd_non_grand=self.pd,
+            use_hull_energy=False,
+        )
+        ir_12 = InterfacialReactivity(
+            Composition("Li2O2"),
+            Composition("Li2O2"),
+            self.pd,
+            norm=True,
+            use_hull_energy=False,
+        )
         with self.assertRaises(Exception) as context1:
-            self.ir.append(
-                InterfacialReactivity(
-                    Composition("Li2O2"),
-                    Composition("Li"),
-                    self.pd,
-                    norm=1,
-                    include_no_mixing_energy=1,
-                    pd_non_grand=None,
-                )
+            ir_13 = InterfacialReactivity(
+                Composition("Li2O2"),
+                Composition("Li"),
+                pd=self.gpd,
+                norm=True
             )
-        self.assertTrue("Please provide grand phase diagram to compute no_mixing_energy!" == str(context1.exception))
-
+            self.assertTrue(
+                "Please use the GrandPotentialInterfacialReactivity "
+                "class for interfacial reactions with open elements!" == str(context1.exception)
+            )
         with self.assertRaises(Exception) as context2:
-            self.ir.append(
-                InterfacialReactivity(
-                    Composition("O2"),
-                    Composition("Mn"),
-                    self.gpd,
-                    norm=0,
-                    include_no_mixing_energy=1,
-                    pd_non_grand=None,
-                )
+            ir_14 = GrandPotentialInterfacialReactivity(
+                Composition("O2"),
+                Composition("Mn"),
+                grand_pd=self.gpd,
+                pd_non_grand=None,
+                norm=False,
+                include_no_mixing_energy=True,
             )
-        self.assertTrue(
-            "Please provide non-grand phase diagram to compute no_mixing_energy!" == str(context2.exception)
-        )
+            self.assertTrue(
+                "Please provide non-grand phase diagram to compute no_mixing_energy!" == str(context2.exception)
+            )
+
+        self.ir = [ir_0, ir_1, ir_2, ir_3, ir_4, ir_5, ir_6, ir_7, ir_8, ir_9, ir_10,
+                   ir_11, ir_12]
 
     def test_get_entry_energy(self):
         # Test warning message.

--- a/pymatgen/util/plotly_interface_rxn_layouts.json
+++ b/pymatgen/util/plotly_interface_rxn_layouts.json
@@ -1,0 +1,63 @@
+{
+  "default_interface_rxn_layout": {
+    "autosize": true,
+    "height": 700,
+    "xaxis": {
+      "title": "Fraction",
+      "anchor": "y",
+      "mirror": "ticks",
+      "nticks": 8,
+      "showgrid": true,
+      "showline": true,
+      "side": "bottom",
+      "tickfont": {
+        "size": 16.0
+      },
+      "ticks": "inside",
+      "titlefont": {
+        "color": "#000000",
+        "size": 20.0
+      },
+      "type": "linear",
+      "zeroline": false,
+      "gridcolor": "rgba(0,0,0,0.1)"
+    },
+    "yaxis": {
+      "title": "Reaction energy (eV/atom)",
+      "anchor": "x",
+      "mirror": "ticks",
+      "showgrid": true,
+      "showline": true,
+      "side": "left",
+      "tickfont": {
+        "size": 16.0
+      },
+      "ticks": "inside",
+      "titlefont": {
+        "color": "#000000",
+        "size": 20.0
+      },
+      "type": "linear",
+      "gridcolor": "rgba(0,0,0,0.1)"
+    },
+    "hovermode": "closest",
+    "paper_bgcolor": "rgba(0,0,0,0)",
+    "plot_bgcolor": "rgba(0,0,0,0)",
+    "showlegend": true,
+    "legend": {
+      "orientation": "h",
+      "traceorder": "reversed",
+      "x": 0,
+      "y": 1.05,
+      "xanchor": "left",
+      "tracegroupgap": 7
+    },
+    "margin": {
+      "b": 20,
+      "l": 10,
+      "pad": 20,
+      "t": 20,
+      "r": 10
+    }
+  }
+}

--- a/pymatgen/util/plotly_interface_rxn_layouts.json
+++ b/pymatgen/util/plotly_interface_rxn_layouts.json
@@ -1,12 +1,11 @@
 {
   "default_interface_rxn_layout": {
     "autosize": true,
-    "height": 700,
+    "height": 600,
     "xaxis": {
       "title": "Fraction",
       "anchor": "y",
       "mirror": "ticks",
-      "nticks": 8,
       "showgrid": true,
       "showline": true,
       "side": "bottom",


### PR DESCRIPTION
## Summary

* Add: support for Plotly: calling `plot()` now provides a `backend` option for choosing matplotlib or Plotly.
* Add:`GrandPotentialInterfacialReactivity` class to separate code based on the use of grand potential phase diagrams (this greatly decreases the complexity of the `__init__` args) and is a more inherited approach in general
* Add: `get_dataframe()` method for plotting possible reactions in a Pandas dataframe. Users would typically have to write/copy boilerplate code to do this each time
* Fix: Better matplotlib plotting, included annotations 
* Fix: Cleaner, more readable code

## Checklist

- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). The easiest way to handle this
      is to run the following in the **correct sequence** on your local machine. Start with running
      [black](https://black.readthedocs.io/en/stable/index.html) on your new code. This will automatically reformat
      your code to PEP8 conventions and removes most issues. Then run 
      [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/), followed by 
      [flake8](http://flake8.pycqa.org/en/latest/).
- [x] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [x] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) to type check your code.
- [x] Tests have been added for any new functionality or bug fixes.
- [x] All linting and tests pass.
