### PR TITLE
Speed up nearest-neighbor routines & structure graph generation

### DIFF
--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -1257,9 +1257,9 @@ class JmolNN(NearNeighbors):
                 siw.append(
                     {
                         "site": nn,
-                        "image": self._get_image(structure, nn),
+                        "image": nn.image,
                         "weight": weight,
-                        "site_index": self._get_original_site(structure, nn),
+                        "site_index": nn.index,
                     }
                 )
         return siw
@@ -1339,9 +1339,9 @@ class MinimumDistanceNN(NearNeighbors):
                 siw.append(
                     {
                         "site": nn,
-                        "image": self._get_image(structure, nn) if is_periodic else None,
+                        "image": nn.image if is_periodic else None,
                         "weight": w,
-                        "site_index": self._get_original_site(structure, nn),
+                        "site_index": nn.index,
                     }
                 )
         else:
@@ -1353,9 +1353,9 @@ class MinimumDistanceNN(NearNeighbors):
                     siw.append(
                         {
                             "site": nn,
-                            "image": self._get_image(structure, nn) if is_periodic else None,
+                            "image": nn.image if is_periodic else None,
                             "weight": w,
-                            "site_index": self._get_original_site(structure, nn),
+                            "site_index": nn.index,
                         }
                     )
         return siw
@@ -1775,9 +1775,9 @@ class MinimumOKeeffeNN(NearNeighbors):
                 siw.append(
                     {
                         "site": s,
-                        "image": self._get_image(structure, s),
+                        "image": s.image,
                         "weight": w,
-                        "site_index": self._get_original_site(structure, s),
+                        "site_index": s.index,
                     }
                 )
 
@@ -1853,9 +1853,9 @@ class MinimumVIRENN(NearNeighbors):
                 siw.append(
                     {
                         "site": s,
-                        "image": self._get_image(vire.structure, s),
+                        "image": s.image,
                         "weight": w,
-                        "site_index": self._get_original_site(vire.structure, s),
+                        "site_index": s.index,
                     }
                 )
 
@@ -3419,9 +3419,9 @@ class BrunnerNN_reciprocal(NearNeighbors):
                 siw.append(
                     {
                         "site": s,
-                        "image": self._get_image(structure, s),
+                        "image": s.image,
                         "weight": w,
-                        "site_index": self._get_original_site(structure, s),
+                        "site_index": s.index,
                     }
                 )
         return siw
@@ -3492,9 +3492,9 @@ class BrunnerNN_relative(NearNeighbors):
                 siw.append(
                     {
                         "site": s,
-                        "image": self._get_image(structure, s),
+                        "image": s.image,
                         "weight": w,
-                        "site_index": self._get_original_site(structure, s),
+                        "site_index": s.index,
                     }
                 )
         return siw
@@ -3565,9 +3565,9 @@ class BrunnerNN_real(NearNeighbors):
                 siw.append(
                     {
                         "site": s,
-                        "image": self._get_image(structure, s),
+                        "image": s.image,
                         "weight": w,
-                        "site_index": self._get_original_site(structure, s),
+                        "site_index": s.index,
                     }
                 )
         return siw
@@ -3681,9 +3681,9 @@ class EconNN(NearNeighbors):
                 if w > self.tol:
                     bonded_site = {
                         "site": nn,
-                        "image": self._get_image(structure, nn),
+                        "image": nn.image,
                         "weight": w,
-                        "site_index": self._get_original_site(structure, nn),
+                        "site_index": nn.index,
                     }
                     siw.append(bonded_site)
         return siw
@@ -4244,9 +4244,9 @@ class CutOffDictNN(NearNeighbors):
                 nn_info.append(
                     {
                         "site": n_site,
-                        "image": self._get_image(structure, n_site),
+                        "image": n_site.image,
                         "weight": dist,
-                        "site_index": self._get_original_site(structure, n_site),
+                        "site_index": n_site.index,
                     }
                 )
 

--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -12,6 +12,7 @@ import json
 import math
 import os
 import warnings
+import collections
 from bisect import bisect_left
 from collections import defaultdict, namedtuple
 from copy import deepcopy
@@ -4226,9 +4227,8 @@ class CutOffDictNN(NearNeighbors):
                 sites.
 
         Returns:
-            siw (list of tuples (Site, array, float)): tuples, each one
-                of which represents a coordinated site, its image location,
-                and its weight.
+            nn_info (list of dicts): each dict represents a coordinated site
+                and contains a site object, its image location, its weight and its site index in the structure.
         """
         site = structure[n]
 
@@ -4251,6 +4251,73 @@ class CutOffDictNN(NearNeighbors):
                 )
 
         return nn_info
+
+    def get_all_nn_info(self, structure, numerical_tol: float = 1e-8):
+        """
+        Precompute global neighbor list to speed up graph generation.
+
+        Adapted from :py:meth:`core.structure.IStructure.get_all_neighbors`.
+
+        Args:
+            structure (Structure): input structure.
+
+        Returns:
+            nn_info (list of (list of dicts)): each dict represents a coordinated site
+                and contains a site object, its image location, its weight and its site index in the structure.
+        """
+        center_indices, points_indices, offset_vectors, distances = structure.get_neighbor_list(self._max_dist)
+
+        f_coords = structure.frac_coords[points_indices] + offset_vectors
+        lattice = structure.lattice
+        nn_info_dict: Dict[int, List] = collections.defaultdict(list)
+        atol = Site.position_atol
+        sites = structure.sites
+        for cindex, pindex, image, f_coord, d in zip(
+            center_indices, points_indices, offset_vectors, f_coords, distances
+        ):
+
+            psite = sites[pindex]
+            csite = sites[cindex]
+
+            # skip if outside of cutoff radius for the respective elements
+            neigh_cut_off_dist = self._lookup_dict.get(structure[cindex].species_string, {}).get(
+                structure[pindex].species_string, 0.0
+            )
+            if d > neigh_cut_off_dist:
+                continue
+
+            if (
+                d > numerical_tol
+                or  # This simply compares the psite and csite. The reason why manual comparison is done is
+                # for speed. This does not check the lattice since they are always equal. Also, the or construct
+                # returns True immediately once one of the conditions are satisfied.
+                psite.species != csite.species
+                or (not np.allclose(psite.coords, csite.coords, atol=atol))
+                or (not psite.properties == csite.properties)
+            ):
+                neighbor_site = PeriodicNeighbor(
+                    species=psite.species,
+                    coords=f_coord,
+                    lattice=lattice,
+                    properties=psite.properties,
+                    nn_distance=d,
+                    index=pindex,
+                    image=tuple(image),
+                )
+                nn_info_dict[cindex].append(
+                    {
+                        "site": neighbor_site,
+                        "image": tuple(image),
+                        "weight": d,
+                        "site_index": pindex,
+                    }
+                )
+
+        neighbors: List[List[PeriodicNeighbor]] = []
+
+        for i in range(len(sites)):
+            neighbors.append(nn_info_dict[i])
+        return neighbors
 
 
 class Critic2NN(NearNeighbors):


### PR DESCRIPTION
## Summary

The `get_nn_info` routines of many nearest-neighbor flavors in `pymatgen.analysis.local_env` recomputed the original periodic image of sites although this information was already stored on the `PeriodicNeighbor` objects (at least it seems so to me - correct me if I'm wrong).
This resulted in O(N^2) instead of O(N) computational complexity (for structures beyond a certain size, almost all time was spent there).

This PR

 * Changes the `get_nn_info` methods to reuse the information from the `PeriodicNeighbor` objects (1st commit)
 * Introduces a faster implementation of `get_all_nn_info` for the `CutoffDictNN` (2nd commit)

The 2nd commit involves some code duplication and is perhaps not absolutely necessary.
It results in further substantial speedup, however.

Example to demonstrate the speedup (adapted from pymatgen test suite)
```python
from pymatgen.analysis.graphs import *
from pymatgen.analysis.local_env import (
    CovalentBondNN,
    CutOffDictNN,
    MinimumDistanceNN,
    MinimumOKeeffeNN,
    OpenBabelNN,
    VoronoiNN,
)

nacl_lattice = Lattice(
    [
        [3.48543625, 0.0, 2.01231756],
        [1.16181208, 3.28610081, 2.01231756],
        [0.0, 0.0, 4.02463512],
    ]
)
nacl = Structure(nacl_lattice, ["Na", "Cl"], [[0, 0, 0], [0.5, 0.5, 0.5]])

nacl.make_supercell([10,10,10])
print(len(nacl))  # 2000 atoms
```

```
# old
In [2]: %timeit -n1 -r1 nacl_graph = Struc
   ...: tureGraph.with_local_env_strategy(
   ...: nacl, CutOffDictNN({("Cl", "Cl"):
   ...: 5.0}))
6min 56s ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)

# improved get_nn_info
In [6]: %timeit -n1 -r1 nacl_graph = Struc
   ...: tureGraph.with_local_env_strategy(
   ...: nacl, CutOffDictNN({("Cl", "Cl"):
   ...: 5.0}))
4.42 s ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)

# improved get_all_nn_info
In [2]: %timeit -n1 -r1 nacl_graph = Struc
   ...: tureGraph.with_local_env_strategy(
   ...: nacl, CutOffDictNN({("Cl", "Cl"):
   ...: 5.0}))
444 ms ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)
```

I picked 2000 atoms since the original implementation was so slow.
On larger structures, the difference between commit 1 and commit 1+2 becomes larger than 10x, e.g. for 8192 atoms (16x16x16 supercell):
```
In [1]: %run test.py
8192

# improved get_nn_info
In [2]: %timeit -n1 -r1 nacl_graph = Struc
   ...: tureGraph.with_local_env_strategy(
   ...: nacl, CutOffDictNN({("Cl", "Cl"):
   ...: 5.0}))
1min 3s ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)

# improved get_all_nn_info
In [2]: %timeit -n1 -r1 nacl_graph = Struc
   ...: tureGraph.with_local_env_strategy(
   ...: nacl, CutOffDictNN({("Cl", "Cl"):
   ...: 5.0}))
1.8 s ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)
```


## Checklist

Before a pull request can be merged, the following items must be checked:

- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). The easiest way to handle this
      is to run the following in the **correct sequence** on your local machine. Start with running
      [black](https://black.readthedocs.io/en/stable/index.html) on your new code. This will automatically reformat
      your code to PEP8 conventions and removes most issues. Then run 
      [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/), followed by 
      [flake8](http://flake8.pycqa.org/en/latest/).
- [x] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [ ] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) to type check your code.
- [ ] Tests have been added for any new functionality or bug fixes.
- [ ] All linting and tests pass.

Note that the CI system will run all the above checks. But it will be much more efficient if you already fix most 
errors prior to submitting the PR. It is highly recommended that you use the pre-commit hook provided in the pymatgen 
repository. Simply `cp pre-commit .git/hooks` and a check will be run prior to allowing commits.
