### PR TITLE
Remove bad param when setting OPTIMADE response fields

### DIFF
--- a/pymatgen/ext/optimade.py
+++ b/pymatgen/ext/optimade.py
@@ -291,7 +291,7 @@ class OptimadeRester:
 
             fields = "response_fields=lattice_vectors,cartesian_site_positions,species,species_at_sites"
 
-            url = join(resource, f"v1/structures?filter={optimade_filter}&fields={fields}")
+            url = join(resource, f"v1/structures?filter={optimade_filter}&{fields}")
 
             try:
 

--- a/pymatgen/ext/tests/test_optimade.py
+++ b/pymatgen/ext/tests/test_optimade.py
@@ -13,9 +13,19 @@ class OptimadeTest(PymatgenTest):
 
             structs = optimade.get_structures(elements=["Ga", "N"], nelements=2)
 
+        with OptimadeRester("mp") as optimade:
+
+            _filter = 'elements HAS ALL "Ga", "N" AND nelements=2'
+            raw_filter_structs = optimade.get_structures_with_filter(_filter)
+
         test_struct = next(iter(structs["mp"].values()))
 
         self.assertEqual([str(el) for el in test_struct.types_of_species], ["Ga", "N"])
+        self.assertEqual(
+            len(structs["mp"]),
+            len(raw_filter_structs["mp"]),
+            msg="Raw filter {_filter} did not return the same number of results as the query builder.",
+        )
 
     def test_get_structures_mcloud_2dstructures(self):
 


### PR DESCRIPTION
## Summary

OPTIMADE uses the `response_fields` URL parameter to select the response fields, this PR removes an extraneous URL parameter that is added when using a raw OPTIMADE filter through `OptimadeRester`.

Addresses and closes #2243 (cc @mkhorton)

~Haven't added any tests as I don't think this extension is being tested at the moment~

## Checklist

Work-in-progress pull requests are encouraged, but please put [WIP]
in the pull request title.

Before a pull request can be merged, the following items must be checked:

- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). The easiest way to handle this
      is to run the following in the **correct sequence** on your local machine. Start with running
      [black](https://black.readthedocs.io/en/stable/index.html) on your new code. This will automatically reformat
      your code to PEP8 conventions and removes most issues. Then run 
      [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/), followed by 
      [flake8](http://flake8.pycqa.org/en/latest/).
- [x] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [x] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) to type check your code.
- [x] Tests have been added for any new functionality or bug fixes.
- [x] All linting and tests pass.