### PR TITLE
Literal-types

### DIFF
--- a/pymatgen/analysis/interface_reactions.py
+++ b/pymatgen/analysis/interface_reactions.py
@@ -23,8 +23,9 @@ References:
 
 import json
 import os
+import sys
 import warnings
-from typing import List, Literal, Tuple, Union
+from typing import List, Tuple, Union
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -38,6 +39,11 @@ from pymatgen.analysis.reaction_calculator import Reaction
 from pymatgen.core.composition import Composition
 from pymatgen.util.plotting import pretty_plot
 from pymatgen.util.string import htmlify, latexify
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 __author__ = "Yihan Xiao, Matthew McDermott"
 __maintainer__ = "Matthew McDermott"

--- a/pymatgen/analysis/magnetism/jahnteller.py
+++ b/pymatgen/analysis/magnetism/jahnteller.py
@@ -8,8 +8,9 @@ JahnTeller distortion analysis.
 
 
 import os
+import sys
 import warnings
-from typing import Any, Dict, Literal, Optional, Tuple, Union, cast
+from typing import Any, Dict, Optional, Tuple, Union, cast
 
 import numpy as np
 
@@ -21,6 +22,11 @@ from pymatgen.analysis.local_env import (
 from pymatgen.core.periodic_table import Species, get_el_sp
 from pymatgen.core.structure import Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
 

--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -13,8 +13,8 @@ import logging
 import math
 import os
 import re
+import sys
 from functools import lru_cache
-from typing import Literal
 
 import numpy as np
 import plotly.graph_objs as go
@@ -29,6 +29,11 @@ from pymatgen.entries import Entry
 from pymatgen.util.coord import Simplex, in_coord_list
 from pymatgen.util.plotting import pretty_plot
 from pymatgen.util.string import htmlify, latexify
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 logger = logging.getLogger(__name__)
 

--- a/pymatgen/analysis/xas/spectrum.py
+++ b/pymatgen/analysis/xas/spectrum.py
@@ -6,8 +6,9 @@
 This module defines classes to represent all xas and stitching methods
 """
 import math
+import sys
 import warnings
-from typing import List, Literal
+from typing import List
 
 import numpy as np
 from scipy.interpolate import interp1d
@@ -15,6 +16,11 @@ from scipy.interpolate import interp1d
 from pymatgen.analysis.structure_matcher import StructureMatcher
 from pymatgen.core.spectrum import Spectrum
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 __author__ = "Chen Zheng, Yiming Chen"
 __copyright__ = "Copyright 2012, The Materials Project"

--- a/pymatgen/core/periodic_table.py
+++ b/pymatgen/core/periodic_table.py
@@ -6,19 +6,25 @@
 import ast
 import json
 import re
+import sys
 import warnings
 from collections import Counter
 from enum import Enum
 from io import open
 from itertools import combinations, product
 from pathlib import Path
-from typing import Callable, Dict, List, Literal, Optional, Tuple, Union
+from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 from monty.json import MSONable
 
 from pymatgen.core.units import SUPPORTED_UNIT_NAMES, FloatWithUnit, Length, Mass, Unit
 from pymatgen.util.string import Stringify, formula_double_format
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 # Loads element data from json file
 with open(str(Path(__file__).absolute().parent / "periodic_table.json"), "rt") as f:

--- a/pymatgen/core/spectrum.py
+++ b/pymatgen/core/spectrum.py
@@ -7,7 +7,8 @@ This module defines classes to represent any type of spectrum, essentially any
 x y value pairs.
 """
 
-from typing import Callable, List, Literal, Union
+import sys
+from typing import Callable, List, Union
 
 import numpy as np
 from monty.json import MSONable
@@ -16,6 +17,11 @@ from scipy.ndimage.filters import convolve1d
 
 from pymatgen.util.coord import get_linear_interpolated_value
 from pymatgen.util.typing import ArrayLike
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 def lorentzian(x, x_0: float = 0, sigma: float = 1.0):

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -15,6 +15,7 @@ import math
 import os
 import random
 import re
+import sys
 import warnings
 from abc import ABCMeta, abstractmethod
 from fnmatch import fnmatch
@@ -25,7 +26,6 @@ from typing import (
     Iterable,
     Iterator,
     List,
-    Literal,
     Optional,
     Sequence,
     Set,
@@ -49,6 +49,11 @@ from pymatgen.core.sites import PeriodicSite, Site
 from pymatgen.core.units import Length, Mass
 from pymatgen.util.coord import all_distances, get_angle, lattice_points_in_supercell
 from pymatgen.util.typing import ArrayLike, CompositionLike, SpeciesLike
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 class Neighbor(Site):

--- a/pymatgen/entries/__init__.py
+++ b/pymatgen/entries/__init__.py
@@ -10,14 +10,20 @@ store calculated information. Other Entry classes such as ComputedEntry
 and PDEntry inherit from this class.
 """
 
+import sys
 from abc import ABCMeta, abstractmethod
 from numbers import Number
-from typing import Dict, Literal, Union
+from typing import Dict, Union
 
 import numpy as np
 from monty.json import MSONable
 
 from pymatgen.core.composition import Composition
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 __author__ = "Shyue Ping Ong, Anubhav Jain, Ayush Gupta"
 __copyright__ = "Copyright 2020, The Materials Project"

--- a/pymatgen/entries/computed_entries.py
+++ b/pymatgen/entries/computed_entries.py
@@ -13,9 +13,10 @@ diagram analysis.
 import abc
 import json
 import os
+import sys
 import warnings
 from itertools import combinations
-from typing import Dict, List, Literal, Union
+from typing import Dict, List, Union
 
 import numpy as np
 from monty.json import MontyDecoder, MontyEncoder, MSONable
@@ -25,6 +26,11 @@ from uncertainties import ufloat
 from pymatgen.core.composition import Composition
 from pymatgen.core.structure import Structure
 from pymatgen.entries import Entry
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 __author__ = "Ryan Kingsbury, Matt McDermott, Shyue Ping Ong, Anubhav Jain"
 __copyright__ = "Copyright 2011-2020, The Materials Project"

--- a/pymatgen/io/cp2k/inputs.py
+++ b/pymatgen/io/cp2k/inputs.py
@@ -16,9 +16,10 @@ A quick overview of the module:
 import copy
 import os
 import re
+import sys
 import textwrap
 import warnings
-from typing import Dict, List, Literal, Sequence, Tuple, Union
+from typing import Dict, List, Sequence, Tuple, Union
 
 from monty.io import zopen
 from monty.json import MSONable
@@ -26,6 +27,11 @@ from monty.json import MSONable
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Molecule, Structure
 from pymatgen.io.cp2k.utils import _postprocessor, _preprocessor
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 __author__ = "Nicholas Winner"
 __version__ = "0.3"

--- a/pymatgen/io/qchem/inputs.py
+++ b/pymatgen/io/qchem/inputs.py
@@ -7,7 +7,7 @@ Classes for reading/manipulating/writing QChem input files.
 """
 import logging
 import sys
-from typing import Union, Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Union
 
 from monty.io import zopen
 from monty.json import MSONable

--- a/pymatgen/io/qchem/sets.py
+++ b/pymatgen/io/qchem/sets.py
@@ -8,13 +8,19 @@ Input sets for Qchem
 
 import logging
 import os
-from typing import Dict, List, Literal, Optional
+import sys
+from typing import Dict, List, Optional
 
 from monty.io import zopen
 
 from pymatgen.core.structure import Molecule
 from pymatgen.io.qchem.inputs import QCInput
 from pymatgen.io.qchem.utils import lower_and_check_unique
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 __author__ = "Samuel Blau, Brandon Wood, Shyam Dwaraknath, Evan Spotte-Smith, Ryan Kingsbury"
 __copyright__ = "Copyright 2018-2021, The Materials Project"

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -15,11 +15,12 @@ import math
 import os
 import re
 import subprocess
+import sys
 import warnings
 from collections import OrderedDict, namedtuple
 from enum import Enum
 from hashlib import md5
-from typing import Any, Dict, Literal, Sequence, Tuple, Union
+from typing import Any, Dict, Sequence, Tuple, Union
 
 import numpy as np
 import scipy.constants as const
@@ -38,6 +39,11 @@ from pymatgen.electronic_structure.core import Magmom
 from pymatgen.util.io_utils import clean_lines
 from pymatgen.util.string import str_delimited
 from pymatgen.util.typing import ArrayLike, PathLike
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 __author__ = "Shyue Ping Ong, Geoffroy Hautier, Rickard Armiento, Vincent L Chevrier, Stephen Dacek"
 __copyright__ = "Copyright 2011, The Materials Project"


### PR DESCRIPTION
Follow up to #2247.

@CompRhys informed me that due to #2247, Pymatgen is no longer installable in Google Colab which is locked to Python 3.7 while `typing.Literal` was only added in Python 3.8.

There's a relatively recent but quiet issue tracking the ability to select different Python versions in Colab: https://github.com/googlecolab/colabtools/issues/2165

In the meantime though, I assume Pymatgen wants to keep supporting Google Colab. I think the best solution for that would be to protect `Literal` imports with

```py
from typing import TYPE_CHECKING

if TYPE_CHECKING:
    from typing import Literal
```

and then use the string form `"Literal"` in type hints. Happy to add those changes to this PR if that's acceptable.