### PR TITLE
Remove method and function that are no longer used for entry equality

### DIFF
--- a/pymatgen/entries/__init__.py
+++ b/pymatgen/entries/__init__.py
@@ -126,7 +126,7 @@ class Entry(MSONable, metaclass=ABCMeta):
         elif mode == "formula_unit":
             factor = self.composition.get_reduced_composition_and_factor()[1]
         else:
-            raise ValueError(f"{mode=} is not an allowed option for normalization")
+            raise ValueError(f"{mode} is not an allowed option for normalization")
 
         return factor
 


### PR DESCRIPTION
Previously when dealing with entry equality we wrote these function to do a robust eq check. After these changes didn't fix the results @mkhorton and @mattmcdermott came up with a better solution for the `__hash__` and `__eq__` but these functions were not removed. They are not referenced in `pymatgen` beyond their definitions and so I removed them in my `ppd` branch for code hygiene and think that it might also be sensible to remove on `main`.