### PR TITLE
QOL changes to phase_diagram.py 

### DIFF
--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -78,13 +78,15 @@ class PDEntry(Entry):
     @property
     def energy(self) -> float:
         """
-        :return: the energy of the entry.
+        Returns:
+            the energy of the entry.
         """
         return self._energy
 
     def as_dict(self):
         """
-        :return: MSONable dict.
+        Returns:
+            the energy of the entry.
         """
         return_dict = super().as_dict()
         return_dict.update({"name": self.name, "attribute": self.attribute})
@@ -93,8 +95,11 @@ class PDEntry(Entry):
     @classmethod
     def from_dict(cls, d):
         """
-        :param d: Dict representation
-        :return: PDEntry
+        Args:
+            d (dict): dictionary representation of PDEntry
+
+        Returns:
+            PDEntry
         """
         return cls(
             Composition(d["composition"]),
@@ -107,7 +112,7 @@ class PDEntry(Entry):
 class GrandPotPDEntry(PDEntry):
     """
     A grand potential pd entry object encompassing all relevant data for phase
-    diagrams.  Chemical potentials are given as a element-chemical potential
+    diagrams. Chemical potentials are given as a element-chemical potential
     dict.
     """
 
@@ -166,7 +171,8 @@ class GrandPotPDEntry(PDEntry):
 
     def as_dict(self):
         """
-        :return: MSONAble dict
+        Returns:
+            MSONable dictionary representation of GrandPotPDEntry
         """
         return {
             "@module": self.__class__.__module__,
@@ -179,8 +185,11 @@ class GrandPotPDEntry(PDEntry):
     @classmethod
     def from_dict(cls, d):
         """
-        :param d: Dict representation
-        :return: PDStructureEntry
+        Args:
+            d (dict): dictionary representation of GrandPotPDEntry
+
+        Returns:
+            GrandPotPDEntry
         """
         chempots = {Element(symbol): u for symbol, u in d["chempots"].items()}
         entry = MontyDecoder().process_decoded(d["entry"])
@@ -250,7 +259,8 @@ class TransformedPDEntry(PDEntry):
 
     def as_dict(self):
         """
-        :return: MSONable dict
+        Returns:
+            MSONable dictionary representation of TransformedPDEntry
         """
         d = {
             "@module": self.__class__.__module__,
@@ -263,8 +273,11 @@ class TransformedPDEntry(PDEntry):
     @classmethod
     def from_dict(cls, d):
         """
-        :param d: Dict representation
-        :return: TransformedPDEntry
+        Args:
+            d (dict): dictionary representation of TransformedPDEntry
+
+        Returns:
+            TransformedPDEntry
         """
         sp_mapping = d["sp_mapping"]
         del d["sp_mapping"]
@@ -328,7 +341,7 @@ class BasePhaseDiagram(MSONable):
         Args:
             entries ([PDEntry]): A list of PDEntry-like objects having an
                 energy, energy_per_atom and composition.
-            elements ([Element]): Optional list of elements in the phase
+            elements ([Element], optional): Optional list of elements in the phase
                 diagram. If set to None, the elements are determined from
                 the the entries themselves and are sorted alphabetically.
                 If specified, element ordering (e.g. for pd coordinates)
@@ -424,36 +437,48 @@ class BasePhaseDiagram(MSONable):
 
         """
         if set(comp.elements).difference(self.elements):
-            raise ValueError("{} has elements not in the phase diagram {}" "".format(comp, self.elements))
+            raise ValueError(f"{comp} has elements not in the phase diagram {self.elements}")
         return np.array([comp.get_atomic_fraction(el) for el in self.elements[1:]])
 
     @property
     def all_entries_hulldata(self):
         """
-        :return: The actual ndarray used to construct the convex hull.
+        Returns:
+            The actual ndarray used to construct the convex hull.
         """
         data = []
-        for entry in self.all_entries:
-            comp = entry.composition
-            row = [comp.get_atomic_fraction(el) for el in self.elements]
-            row.append(entry.energy_per_atom)
-            data.append(row)
+        data = [
+            [e.composition.get_atomic_fraction(el) for el in self.elements] + [e.energy_per_atom]
+            for e in self.all_entries
+        ]
         return np.array(data)[:, 1:]
 
     @property
     def unstable_entries(self):
         """
-        Returns a list of Entries that are unstable in the phase diagram.
-        Includes positive formation energy entries.
+        Returns:
+            list of Entries that are unstable in the phase diagram.
+                Includes positive formation energy entries.
         """
         return [e for e in self.all_entries if e not in self.stable_entries]
 
     @property
     def stable_entries(self):
         """
-        Returns the set of stable entries in the phase diagram.
+        Returns:
+            the set of stable entries in the phase diagram.
         """
         return self._stable_entries
+
+    def get_reference_energy_per_atom(self, comp):
+        """
+        Args:
+            comp (Composition): Input composition
+
+        Returns:
+            Reference energy of the terminal species at a given composition.
+        """
+        return sum([comp[el] * self.el_refs[el].energy_per_atom for el in comp.elements]) / comp.num_atoms
 
     def get_form_energy(self, entry):
         """
@@ -505,7 +530,28 @@ class BasePhaseDiagram(MSONable):
         for f, s in zip(self.facets, self.simplexes):
             if s.in_simplex(c, PhaseDiagram.numerical_tol / 10):
                 return f, s
+
         raise RuntimeError("No facet found for comp = {}".format(comp))
+
+    def _get_all_facets_and_simplexes(self, comp):
+        """
+        Get all facets that a composition falls into.
+
+        Args:
+            comp (Composition): A composition
+
+        """
+        c = self.pd_coords(comp)
+
+        all_facets = [
+            f for f, s in zip(self.facets, self.simplexes)
+            if s.in_simplex(c, PhaseDiagram.numerical_tol / 10)
+        ]
+
+        if not len(all_facets):
+            raise RuntimeError("No facets found for comp = {}".format(comp))
+
+        return all_facets
 
     def _get_facet_chempots(self, facet):
         """
@@ -521,7 +567,28 @@ class BasePhaseDiagram(MSONable):
         energylist = [self.qhull_entries[i].energy_per_atom for i in facet]
         m = [[c.get_atomic_fraction(e) for e in self.elements] for c in complist]
         chempots = np.linalg.solve(m, energylist)
+
         return dict(zip(self.elements, chempots))
+
+    def _get_simplex_intersections(self, c1, c2):
+        """
+        Returns co-ordinates of the itersection of the tie line between two compositions
+        and the simplexes of the PhaseDiagram.
+
+        Args:
+            c1: Reduced dimension co-ordinates of first composition
+            c2: Reduced dimension co-ordinates of second composition
+
+        Returns:
+            Array of the intersections between the tie line and the simplexes of
+            the PhaseDiagram
+        """
+
+        intersections = [c1, c2]
+        for sc in self.simplexes:
+            intersections.extend(sc.line_intersection(c1, c2))
+
+        return np.array(intersections)
 
     def get_decomposition(self, comp):
         """
@@ -540,6 +607,27 @@ class BasePhaseDiagram(MSONable):
             self.qhull_entries[f]: amt for f, amt in zip(facet, decomp_amts) if abs(amt) > PhaseDiagram.numerical_tol
         }
 
+    def get_decomp_and_hull_energy_per_atom(self, comp):
+        """
+        Args:
+            comp (Composition): Input composition
+
+        Returns:
+            Energy of lowest energy equilibrium at desired composition per atom
+        """
+        decomp = self.get_decomposition(comp)
+        return decomp, sum([e.energy_per_atom * n for e, n in decomp.items()])
+
+    def get_hull_energy_per_atom(self, comp):
+        """
+        Args:
+            comp (Composition): Input composition
+
+        Returns:
+            Energy of lowest energy equilibrium at desired composition.
+        """
+        return self.get_decomp_and_hull_energy_per_atom(comp)[1]
+
     def get_hull_energy(self, comp):
         """
         Args:
@@ -549,8 +637,7 @@ class BasePhaseDiagram(MSONable):
             Energy of lowest energy equilibrium at desired composition. Not
                 normalized by atoms, i.e. E(Li4O2) = 2 * E(Li2O)
         """
-        decomp = self.get_decomposition(comp)
-        return comp.num_atoms * sum([e.energy_per_atom * n for e, n in decomp.items()])
+        return comp.num_atoms * self.get_hull_energy_per_atom(comp)
 
     def get_decomp_and_e_above_hull(self, entry, allow_negative=False, check_stable=True):
         """
@@ -579,8 +666,8 @@ class BasePhaseDiagram(MSONable):
         if check_stable and entry in self.stable_entries:
             return {entry: 1}, 0
 
-        decomp = self.get_decomposition(entry.composition)
-        e_above_hull = entry.energy_per_atom - sum([e.energy_per_atom * n for e, n in decomp.items()])
+        decomp, hull_energy = self.get_decomp_and_hull_energy_per_atom(entry.composition)
+        e_above_hull = entry.energy_per_atom - hull_energy
 
         if allow_negative or e_above_hull >= -PhaseDiagram.numerical_tol:
             return decomp, e_above_hull
@@ -616,7 +703,7 @@ class BasePhaseDiagram(MSONable):
         # NOTE scaled duplicates of stable_entries will not be caught.
         if entry not in self.stable_entries:
             raise ValueError(
-                "{} is unstable, the equilibrium reaction energy is" "available only for stable entries.".format(entry)
+                f"{entry} is unstable, the equilibrium reaction energy is available only for stable entries."
             )
 
         if entry.is_element:
@@ -624,10 +711,16 @@ class BasePhaseDiagram(MSONable):
 
         entries = [e for e in self.stable_entries if e != entry]
         modpd = PhaseDiagram(entries, self.elements)
+
         return modpd.get_decomp_and_e_above_hull(entry, allow_negative=True)[1]
 
     def get_decomp_and_phase_separation_energy(
-        self, entry, space_limit=200, stable_only=False, tol=1e-10, maxiter=1000
+        self,
+        entry,
+        space_limit=200,
+        stable_only=False,
+        tols=[1e-8],
+        maxiter=1000,
     ):
         """
         Provides the combination of entries in the PhaseDiagram that gives the
@@ -660,8 +753,8 @@ class BasePhaseDiagram(MSONable):
                 before calculating a second convex hull to reducing the complexity
                 of the optimization.
             stable_only (bool): Only use stable materials as competing entries.
-            tol (float): The tolerence for convergence of the SLSQP optimization
-                when finding the equilibrium reaction.
+            tol (list): Tolerences for convergence of the SLSQP optimization
+                when finding the equilibrium reaction. Tighter tolerences tested first.
             maxiter (int): The maximum number of iterations of the SLSQP optimizer
                 when finding the equilibrium reaction.
 
@@ -671,6 +764,8 @@ class BasePhaseDiagram(MSONable):
             fractional composition. The phase separation energy is given per atom.
         """
 
+        # NOTE comprhys: for large PatchedPhaseDiagrams this is a bottleneck,
+        # I have a solution but leaving to later PR with PatchedPhaseDiagram
         # For unstable or novel materials use simplex approach
         if entry.composition.fractional_composition not in [
             e.composition.fractional_composition for e in self.stable_entries
@@ -715,20 +810,14 @@ class BasePhaseDiagram(MSONable):
             competing_entries = list(self.stable_entries.union(inner_hull.stable_entries))
             competing_entries = [c for c in competing_entries if c != entry]
 
-        solution = _get_slsqp_decomp(entry, competing_entries, tol, maxiter)
+        decomp = _get_slsqp_decomp(entry.composition, competing_entries, tols, maxiter)
 
-        if solution.success:
-            decomp_amts = solution.x
-            decomp = {c: amt for c, amt in zip(competing_entries, decomp_amts) if amt > PhaseDiagram.numerical_tol}
+        # find the minimum alternative formation energy for the decomposition
+        decomp_enthalpy = np.sum([c.energy_per_atom * amt for c, amt in decomp.items()])
 
-            # find the minimum alternative formation energy for the decomposition
-            decomp_enthalpy = np.sum([c.energy_per_atom * amt for c, amt in decomp.items()])
+        decomp_enthalpy = entry.energy_per_atom - decomp_enthalpy
 
-            decomp_enthalpy = entry.energy_per_atom - decomp_enthalpy
-
-            return decomp, decomp_enthalpy
-
-        raise ValueError("No valid decomp found for {}!".format(entry))
+        return decomp, decomp_enthalpy
 
     def get_phase_separation_energy(self, entry, **kwargs):
         """
@@ -763,8 +852,11 @@ class BasePhaseDiagram(MSONable):
         """
         Get the chemical potentials for all elements at a given composition.
 
-        :param comp: Composition
-        :return: Dict of chemical potentials.
+        Args:
+            comp (Composition): Composition
+
+        Returns:
+            Dictionary of chemical potentials.
         """
         facet = self._get_facet_and_simplex(comp)[0]
         return self._get_facet_chempots(facet)
@@ -773,25 +865,19 @@ class BasePhaseDiagram(MSONable):
         """
         Get chemical potentials at a given compositon.
 
-        :param comp: Composition
-        :return: Chemical potentials.
-        """
-        # NOTE the top part takes from format of _get_facet_and_simplex,
-        # but wants to return all facets rather than the first one that
-        # meets this criteria
-        c = self.pd_coords(comp)
-        all_facets = []
-        for f, s in zip(self.facets, self.simplexes):
-            if s.in_simplex(c, PhaseDiagram.numerical_tol / 10):
-                all_facets.append(f)
+        Args:
+            comp (Composition): Composition
 
-        if not len(all_facets):
-            raise RuntimeError("No facets found for comp = {}".format(comp))
+        Returns:
+            Chemical potentials.
+        """
+        all_facets = self._get_all_facets_and_simplexes(comp)
 
         chempots = {}
         for facet in all_facets:
             facet_name = "-".join([self.qhull_entries[j].name for j in facet])
             chempots[facet_name] = self._get_facet_chempots(facet)
+
         return chempots
 
     def get_transition_chempots(self, element):
@@ -829,8 +915,10 @@ class BasePhaseDiagram(MSONable):
         Get the critical compositions along the tieline between two
         compositions. I.e. where the decomposition products change.
         The endpoints are also returned.
+
         Args:
             comp1, comp2 (Composition): compositions that define the tieline
+
         Returns:
             [(Composition)]: list of critical compositions. All are of
                 the form x * comp1 + (1-x) * comp2
@@ -840,20 +928,19 @@ class BasePhaseDiagram(MSONable):
         n2 = comp2.num_atoms
         pd_els = self.elements
 
-        # the reduced dimensionality Simplexes don't use the
+        # NOTE the reduced dimensionality Simplexes don't use the
         # first element in the PD
         c1 = self.pd_coords(comp1)
         c2 = self.pd_coords(comp2)
 
-        # none of the projections work if c1 == c2, so just return *copies*
-        # of the inputs
+        # NOTE none of the projections work if c1 == c2, so just
+        # return *copies* of the inputs
         if np.all(c1 == c2):
             return [comp1.copy(), comp2.copy()]
 
-        intersections = [c1, c2]
-        for sc in self.simplexes:
-            intersections.extend(sc.line_intersection(c1, c2))
-        intersections = np.array(intersections)
+        # NOTE made into method to facilitate inheritance of this method
+        # in PatchedPhaseDiagram if approximate solution can be found.
+        intersections = self._get_simplex_intersections(c1, c2)
 
         # find position along line
         l = c2 - c1
@@ -867,19 +954,23 @@ class BasePhaseDiagram(MSONable):
         proj.sort()
 
         # only unique compositions
-        valid = np.ones(len(proj), dtype=np.bool)
+        valid = np.ones(len(proj), dtype=bool)
         valid[1:] = proj[1:] > proj[:-1] + self.numerical_tol
         proj = proj[valid]
 
         ints = c1 + l * proj[:, None]
+
         # reconstruct full-dimensional composition array
         cs = np.concatenate([np.array([1 - np.sum(ints, axis=-1)]).T, ints], axis=-1)
+
         # mixing fraction when compositions are normalized
         x = proj / np.dot(c2 - c1, l)
+
         # mixing fraction when compositions are not normalized
         x_unnormalized = x * n1 / (n2 + x * (n1 - n2))
         num_atoms = n1 + (n2 - n1) * x_unnormalized
         cs *= num_atoms[:, None]
+
         return [Composition((c, v) for c, v in zip(pd_els, m)) for m in cs]
 
     def get_element_profile(self, element, comp, comp_tol=1e-5):
@@ -905,6 +996,7 @@ class BasePhaseDiagram(MSONable):
 
         if element not in self.elements:
             raise ValueError("get_transition_chempots can only be called with" " elements in the phase diagram.")
+
         gccomp = Composition({el: amt for el, amt in comp.items() if el != element})
         elref = self.el_refs[element]
         elcomp = Composition(element.symbol)
@@ -951,15 +1043,20 @@ class BasePhaseDiagram(MSONable):
         for facet in self.facets:
             chempots = self._get_facet_chempots(facet)
             all_chempots.append([chempots[el] for el in self.elements])
+
         inds = [self.elements.index(el) for el in elements]
+
         if referenced:
             el_energies = {el: self.el_refs[el].energy_per_atom for el in elements}
         else:
             el_energies = {el: 0.0 for el in elements}
+
         chempot_ranges = collections.defaultdict(list)
         vertices = [list(range(len(self.elements)))]
+
         if len(all_chempots) > len(self.elements):
             vertices = get_facets(all_chempots, joggle=joggle)
+
         for ufacet in vertices:
             for combi in itertools.combinations(ufacet, 2):
                 data1 = self.facets[combi[0]]
@@ -992,7 +1089,7 @@ class BasePhaseDiagram(MSONable):
             tol_en: a tolerance on the energy to set
 
         Returns:
-             [{Element:mu}]: An array of conditions on simplex vertices for
+             [{Element: mu}]: An array of conditions on simplex vertices for
              which each element has a chemical potential set to a given
              value. "absolute" values (i.e., not referenced to element energies)
         """
@@ -1002,7 +1099,9 @@ class BasePhaseDiagram(MSONable):
         for e in self.elements:
             if e not in target_comp.elements:
                 target_comp = target_comp + Composition({e: 0.0})
+
         coeff = [-target_comp[e] for e in self.elements if e != dep_elt]
+
         for e, chempots in chempot_ranges.items():
             if e.composition.reduced_composition == target_comp.reduced_composition:
                 multiplicator = e.composition[dep_elt] / target_comp[dep_elt]
@@ -1043,7 +1142,7 @@ class BasePhaseDiagram(MSONable):
             open_elt: Element that you want to constrain to be max or min
 
         Returns:
-             {Element:(mu_min,mu_max)}: Chemical potentials are given in
+             {Element: (mu_min, mu_max)}: Chemical potentials are given in
              "absolute" values (i.e., not referenced to 0)
         """
         muref = np.array([self.el_refs[e].energy_per_atom for e in self.elements if e != open_elt])
@@ -1051,11 +1150,13 @@ class BasePhaseDiagram(MSONable):
         for e in self.elements:
             if e not in target_comp.elements:
                 target_comp = target_comp + Composition({e: 0.0})
+
         coeff = [-target_comp[e] for e in self.elements if e != open_elt]
         max_open = -float("inf")
         min_open = float("inf")
         max_mus = None
         min_mus = None
+
         for e, chempots in chempot_ranges.items():
             if e.composition.reduced_composition == target_comp.reduced_composition:
                 multiplicator = e.composition[open_elt] / target_comp[open_elt]
@@ -1071,10 +1172,13 @@ class BasePhaseDiagram(MSONable):
                         if test_open < min_open:
                             min_open = test_open
                             min_mus = v
+
         elts = [e for e in self.elements if e != open_elt]
         res = {}
+
         for i, el in enumerate(elts):
             res[el] = (min_mus[i] + muref[i], max_mus[i] + muref[i])
+
         res[open_elt] = (min_open, max_open)
         return res
 
@@ -1093,48 +1197,26 @@ class PhaseDiagram(BasePhaseDiagram):
        principles calculations. Electrochem. Comm., 2010, 12(3), 427-430.
        doi:10.1016/j.elecom.2010.01.010
 
-    .. attribute: elements:
-
-        Elements in the phase diagram.
-
-    ..attribute: all_entries
-
-        All entries provided for Phase Diagram construction. Note that this
-        does not mean that all these entries are actually used in the phase
-        diagram. For example, this includes the positive formation energy
-        entries that are filtered out before Phase Diagram construction.
-
-    .. attribute: qhull_data
-
-        Data used in the convex hull operation. This is essentially a matrix of
-        composition data and energy per atom values created from qhull_entries.
-
-    .. attribute: qhull_entries:
-
-        Actual entries used in convex hull. Excludes all positive formation
-        energy entries.
-
-    .. attribute: dim
-
-        The dimensionality of the phase diagram.
-
-    .. attribute: facets
-
-        Facets of the phase diagram in the form of  [[1,2,3],[4,5,6]...].
-        For a ternary, it is the indices (references to qhull_entries and
-        qhull_data) for the vertices of the phase triangles. Similarly
-        extended to higher D simplices for higher dimensions.
-
-    .. attribute: el_refs:
-
-        List of elemental references for the phase diagrams. These are
-        entries corresponding to the lowest energy element entries for simple
-        compositional phase diagrams.
-
-    .. attribute: simplices:
-
-        The simplices of the phase diagram as a list of np.ndarray, i.e.,
-        the list of stable compositional coordinates in the phase diagram.
+    Attributes:
+        dim (int): The dimensionality of the phase diagram.
+        elements: Elements in the phase diagram.
+        el_refs: List of elemental references for the phase diagrams. These are
+            entries corresponding to the lowest energy element entries for simple
+            compositional phase diagrams.
+        all_entries: All entries provided for Phase Diagram construction. Note that this
+            does not mean that all these entries are actually used in the phase
+            diagram. For example, this includes the positive formation energy
+            entries that are filtered out before Phase Diagram construction.
+        qhull_entries: Actual entries used in convex hull. Excludes all positive formation
+            energy entries.
+        qhull_data: Data used in the convex hull operation. This is essentially a matrix of
+            composition data and energy per atom values created from qhull_entries.
+        facets: Facets of the phase diagram in the form of  [[1,2,3],[4,5,6]...].
+            For a ternary, it is the indices (references to qhull_entries and
+            qhull_data) for the vertices of the phase triangles. Similarly
+            extended to higher D simplices for higher dimensions.
+        simplices: The simplices of the phase diagram as a list of np.ndarray, i.e.,
+            the list of stable compositional coordinates in the phase diagram.
     """
 
     def __init__(self, entries, elements=None):
@@ -1332,7 +1414,8 @@ class CompoundPhaseDiagram(PhaseDiagram):
 
     def as_dict(self):
         """
-        :return: MSONable dict
+        Returns:
+            MSONable dictionary representation of CompoundPhaseDiagram
         """
         return {
             "@module": self.__class__.__module__,
@@ -1345,8 +1428,11 @@ class CompoundPhaseDiagram(PhaseDiagram):
     @classmethod
     def from_dict(cls, d):
         """
-        :param d: Dict Representation
-        :return: CompoundPhaseDiagram
+        Args:
+            d (dict): dictionary representation of CompoundPhaseDiagram
+
+        Returns:
+            CompoundPhaseDiagram
         """
         dec = MontyDecoder()
         entries = dec.process_decoded(d["original_entries"])
@@ -1501,7 +1587,7 @@ class ReactionDiagram:
         plotting.
 
         Returns:
-            (CompoundPhaseDiagram)
+            CompoundPhaseDiagram
         """
         # For this plot, since the reactions are reported in formation
         # energies, we need to set the energies of the terminal compositions
@@ -1547,7 +1633,12 @@ def get_facets(qhull_data, joggle=False):
     return ConvexHull(qhull_data, qhull_options="Qt i").simplices
 
 
-def _get_slsqp_decomp(comp, competing_entries, tol=1e-10, maxiter=1000):
+def _get_slsqp_decomp(
+    comp,
+    competing_entries,
+    tols=[1e-8],
+    maxiter=1000,
+):
     """
     Finds the amounts of competing compositions that minimize the energy of a
     given composition
@@ -1559,58 +1650,69 @@ def _get_slsqp_decomp(comp, competing_entries, tol=1e-10, maxiter=1000):
         machine-learned formation energies, npj Computational Materials 6, 97 (2020)
 
     Args:
-        entry (PDEntry): A PDEntry like entry to analyze
+        comp (Composition): A Composition to analyze
         competing_entries ([PDEntry]): List of entries to consider for decomposition
+        tols (list): tolerences to try for SLSQP convergence. Issues observed for
+            tol > 1e-7 in the fractional composition (default 1e-8)
+        maxiter (int): maximum number of SLSQP iterations
 
     Returns:
-        scipy.optimize.minimize result. If sucessful this gives the linear combination of
-            competing entrys that minimizes the competing formation energy
+            decomposition as a dict of {PDEntry: amount} where amount
+            is the amount of the fractional composition.
     """
-    if not isinstance(comp, Composition):
-        comp = comp.composition
 
     # Elemental amount present in given entry
-    amts = comp.fractional_composition.get_el_amt_dict()
+    amts = comp.get_el_amt_dict()
     chemical_space = tuple(amts.keys())
     b = np.array([amts[el] for el in chemical_space])
 
     # Elemental amounts present in competing entries
     A_transpose = np.zeros((len(chemical_space), len(competing_entries)))
     for j, comp_entry in enumerate(competing_entries):
-        amts = comp_entry.composition.fractional_composition.get_el_amt_dict()
+        amts = comp_entry.composition.get_el_amt_dict()
         for i, el in enumerate(chemical_space):
             A_transpose[i, j] = amts[el]
+
+    # NOTE normalize arrays to avoid calls to fractional_composition
+    b = b / np.sum(b)
+    A_transpose = A_transpose / np.sum(A_transpose, axis=0)
 
     # Energies of competing entries
     Es = np.array([comp_entry.energy_per_atom for comp_entry in competing_entries])
 
-    molar_constraint = {
-        "type": "eq",
-        "fun": lambda x: np.dot(A_transpose, x) - b,
-        "jac": lambda x: A_transpose,
-    }
+    molar_constraint = {"type": "eq", "fun": lambda x: np.dot(A_transpose, x) - b, "jac": lambda x: A_transpose}
 
     options = {"maxiter": maxiter, "disp": False}
 
+    # NOTE max_bound needs to be larger than 1
     max_bound = comp.num_atoms
     bounds = [(0, max_bound)] * len(competing_entries)
     x0 = [1 / len(competing_entries)] * len(competing_entries)
 
     # NOTE the tolerence needs to be tight to stop the optimization
     # from exiting before convergence is reached. Issues observed for
-    # tol > 1e-7 in the fractional composition (default 1e-10).
-    solution = minimize(
-        fun=lambda x: np.dot(x, Es),
-        x0=x0,
-        method="SLSQP",
-        jac=lambda x: Es,
-        bounds=bounds,
-        constraints=[molar_constraint],
-        tol=tol,
-        options=options,
-    )
+    # tol > 1e-7 in the fractional composition (default 1e-8).
+    for tol in sorted(tols):
+        solution = minimize(
+            fun=lambda x: np.dot(x, Es),
+            x0=x0,
+            method="SLSQP",
+            jac=lambda x: Es,
+            bounds=bounds,
+            constraints=[molar_constraint],
+            tol=tol,
+            options=options,
+        )
 
-    return solution
+        if solution.success:
+            decomp_amts = solution.x
+            return {
+                c: amt  # NOTE this is the amount of the fractional composition.
+                for c, amt in zip(competing_entries, decomp_amts)
+                if amt > PhaseDiagram.numerical_tol
+            }
+
+    raise ValueError("No valid decomp found for {}!".format(comp))
 
 
 class PDPlotter:
@@ -1732,18 +1834,21 @@ class PDPlotter:
         label_uncertainties=False,
     ):
         """
-        :param label_stable: Whether to label stable compounds.
-        :param label_unstable: Whether to label unstable compounds.
-        :param ordering: Ordering of vertices (matplotlib backend only).
-        :param energy_colormap: Colormap for coloring energy (matplotlib backend only).
-        :param process_attributes: Whether to process the attributes (matplotlib
-            backend only).
-        :param plt: Existing plt object if plotting multiple phase diagrams (
-            matplotlib backend only).
-        :param label_uncertainties: Whether to add error bars to the hull (plotly
-            backend only). For binaries, this also shades the hull with the
-            uncertainty window.
-        :return: go.Figure (plotly) or matplotlib.pyplot (matplotlib)
+        Args:
+            label_stable: Whether to label stable compounds.
+            label_unstable: Whether to label unstable compounds.
+            ordering: Ordering of vertices (matplotlib backend only).
+            energy_colormap: Colormap for coloring energy (matplotlib backend only).
+            process_attributes: Whether to process the attributes (matplotlib
+                backend only).
+            plt: Existing plt object if plotting multiple phase diagrams (
+                matplotlib backend only).
+            label_uncertainties: Whether to add error bars to the hull (plotly
+                backend only). For binaries, this also shades the hull with the
+                uncertainty window.
+
+        Returns:
+            go.Figure (plotly) or matplotlib.pyplot (matplotlib)
         """
         fig = None
 
@@ -2283,7 +2388,8 @@ class PDPlotter:
         """
         Creates Plotly scatter (line) plots for all phase diagram facets.
 
-        :return: go.Scatter (or go.Scatter3d) plot
+        Returns:
+            go.Scatter (or go.Scatter3d) plot
         """
         line_plot = None
         x, y, z, energies = [], [], [], []
@@ -2329,7 +2435,8 @@ class PDPlotter:
         Creates a (hidable) scatter trace containing labels of stable phases.
         Contains some functionality for creating sensible label positions.
 
-        :return: go.Scatter (or go.Scatter3d) plot
+        Returns:
+            go.Scatter (or go.Scatter3d) plot
         """
         x, y, z, text, textpositions = [], [], [], [], []
         stable_labels_plot = None
@@ -2415,7 +2522,8 @@ class PDPlotter:
         """
         Creates terminal element annotations for Plotly phase diagrams.
 
-        :return: list of annotation dicts.
+        Returns:
+            list of annotation dicts.
         """
         annotations_list = []
         x, y, z = None, None, None
@@ -2474,7 +2582,11 @@ class PDPlotter:
         Creates layout for plotly phase diagram figure and updates with
         figure annotations.
 
-        :return: Dictionary with Plotly figure layout settings.
+        Args:
+            label_stable (bool): Whether to label stable compounds
+
+        Returns:
+            Dictionary with Plotly figure layout settings.
         """
         annotations_list = None
         layout = {}
@@ -2498,8 +2610,9 @@ class PDPlotter:
         """
         Creates stable and unstable marker plots for overlaying on the phase diagram.
 
-        :return: Tuple of Plotly go.Scatter (or go.Scatter3d) objects in order: (
-            stable markers, unstable markers)
+        Returns:
+            Tuple of Plotly go.Scatter (or go.Scatter3d) objects in order:
+            (stable markers, unstable markers)
         """
 
         def get_marker_props(coords, entries, stable=True):
@@ -2696,9 +2809,12 @@ class PDPlotter:
         Creates shaded uncertainty region for stable entries. Currently only works
         for binary (dim=2) phase diagrams.
 
-        :param stable_marker_plot: go.Scatter object with stable markers and their
+        Args:
+            stable_marker_plot: go.Scatter object with stable markers and their
             error bars.
-        :return: Plotly go.Scatter object with uncertainty window shading.
+
+        Returns:
+            Plotly go.Scatter object with uncertainty window shading.
         """
 
         uncertainty_plot = None
@@ -2747,7 +2863,8 @@ class PDPlotter:
         Creates support lines which aid in seeing the ternary hull in three
         dimensions.
 
-        :return: go.Scatter3d plot of support lines for ternary phase diagram.
+        Returns:
+            go.Scatter3d plot of support lines for ternary phase diagram.
         """
         stable_entry_coords = dict(map(reversed, self.pd_plot_data[1].items()))
 
@@ -2780,7 +2897,8 @@ class PDPlotter:
         """
         Creates shaded mesh plot for coloring the ternary hull by formation energy.
 
-        :return: go.Mesh3d plot
+        Returns:
+            go.Mesh3d plot
         """
         facets = np.array(self._pd.facets)
         coords = np.array([triangular_coord(c) for c in zip(self._pd.qhull_data[:-1, 0], self._pd.qhull_data[:-1, 1])])

--- a/pymatgen/analysis/tests/test_phase_diagram.py
+++ b/pymatgen/analysis/tests/test_phase_diagram.py
@@ -161,17 +161,18 @@ class PhaseDiagramTest(unittest.TestCase):
         self.assertRaises(ValueError, PhaseDiagram, entries)
 
     def test_dim1(self):
-        # Ensure that dim 1 PDs can eb generated.
+        # Ensure that dim 1 PDs can be generated.
         for el in ["Li", "Fe", "O2"]:
             entries = [e for e in self.entries if e.composition.reduced_formula == el]
             pd = PhaseDiagram(entries)
             self.assertEqual(len(pd.stable_entries), 1)
 
             for e in entries:
-                decomp, ehull = pd.get_decomp_and_e_above_hull(e)
+                ehull = pd.get_e_above_hull(e)
                 self.assertGreaterEqual(ehull, 0)
+
             plotter = PDPlotter(pd)
-            lines, stable_entries, unstable_entries = plotter.pd_plot_data
+            lines, *_ = plotter.pd_plot_data
             self.assertEqual(lines[0][1], [0, 0])
 
     def test_ordering(self):
@@ -245,15 +246,16 @@ class PhaseDiagramTest(unittest.TestCase):
         self.assertIsNotNone(str(self.pd))
 
     def test_get_e_above_hull(self):
-        for entry in self.pd.stable_entries:
-            self.assertLess(
-                self.pd.get_e_above_hull(entry),
-                1e-11,
-                "Stable entries should have e above hull of zero!",
-            )
-
         for entry in self.pd.all_entries:
-            if entry not in self.pd.stable_entries:
+            for entry in self.pd.stable_entries:
+                decomp, e_hull = self.pd.get_decomp_and_e_above_hull(entry)
+                self.assertLess(
+                    e_hull,
+                    1e-11,
+                    "Stable entries should have e above hull of zero!",
+                )
+                self.assertEqual(decomp[entry], 1, "Decomposition of stable entry should be itself.")
+            else:
                 e_ah = self.pd.get_e_above_hull(entry)
                 self.assertTrue(isinstance(e_ah, Number))
                 self.assertGreaterEqual(e_ah, 0)


### PR DESCRIPTION
Added google docstrings to fit `pymatgen` style guide and whitespace line changes for better readability. Several typos/whitespaces. Slightly adjusted the function of `_get_slsqp_decomp()` to make it more useful as a stand alone function. Added a few ease of use methods for intermediary calculations that help in the `PatchedPhaseDiagram` implementation to come.