### PR TITLE
ElementBase.X drop NaN warning

### DIFF
--- a/pymatgen/core/periodic_table.py
+++ b/pymatgen/core/periodic_table.py
@@ -211,9 +211,7 @@ class ElementBase(Enum):
             float: Electronegativity of element. If an element does not have an electronegativity,
                 NaN is returned.
         """
-        if "X" in self._data:
-            return self._data["X"]
-        return float("NaN")
+        return self._data.get("X", float("NaN"))
 
     @property
     def atomic_radius(self) -> Optional[FloatWithUnit]:

--- a/pymatgen/core/periodic_table.py
+++ b/pymatgen/core/periodic_table.py
@@ -207,16 +207,12 @@ class ElementBase(Enum):
     @property
     def X(self) -> float:
         """
-        :return: Electronegativity of element. Note that if an element does not
-            have an electronegativity, a NaN float is returned.
+        Returns:
+            float: Electronegativity of element. If an element does not have an electronegativity,
+                NaN is returned.
         """
         if "X" in self._data:
             return self._data["X"]
-        warnings.warn(
-            "No electronegativity for %s. Setting to NaN. "
-            "This has no physical meaning, and is mainly done to "
-            "avoid errors caused by the code expecting a float." % self.symbol
-        )
         return float("NaN")
 
     @property


### PR DESCRIPTION
The warning about missing electronegativities is by far the most prevalent one in my use of pymatgen and it has never once been useful. Would be great to get rid of it.

It comes up all the time and usually repeated a dozen times or so when iterating over a dataframe column involving creation of new `Elements()`.