### PR TITLE
Ion bugfixes and enhancements

### DIFF
--- a/pymatgen/analysis/tests/test_pourbaix_diagram.py
+++ b/pymatgen/analysis/tests/test_pourbaix_diagram.py
@@ -46,7 +46,7 @@ class PourbaixEntryTest(unittest.TestCase):
 
     def test_pourbaix_entry(self):
         self.assertEqual(self.PxIon.entry.energy, 25, "Wrong Energy!")
-        self.assertEqual(self.PxIon.entry.name, "MnO4[-]", "Wrong Entry!")
+        self.assertEqual(self.PxIon.entry.name, "MnO4[-1]", "Wrong Entry!")
         self.assertEqual(self.PxSol.entry.energy, 49, "Wrong Energy!")
         self.assertEqual(self.PxSol.entry.name, "Mn2O3", "Wrong Entry!")
         # self.assertEqual(self.PxIon.energy, 25, "Wrong Energy!")
@@ -65,7 +65,7 @@ class PourbaixEntryTest(unittest.TestCase):
     def test_to_from_dict(self):
         d = self.PxIon.as_dict()
         ion_entry = self.PxIon.from_dict(d)
-        self.assertEqual(ion_entry.entry.name, "MnO4[-]", "Wrong Entry!")
+        self.assertEqual(ion_entry.entry.name, "MnO4[-1]", "Wrong Entry!")
 
         d = self.PxSol.as_dict()
         sol_entry = self.PxSol.from_dict(d)

--- a/pymatgen/core/composition.py
+++ b/pymatgen/core/composition.py
@@ -299,10 +299,7 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
         Returns a formula string, with elements sorted by alphabetically
         e.g., Fe4 Li4 O16 P4.
         """
-        sym_amt = self.get_el_amt_dict()
-        syms = sorted(sym_amt.keys())
-        formula = [s + formula_double_format(sym_amt[s], False) for s in syms]
-        return " ".join(formula)
+        return " ".join(sorted(self.formula.split(" ")))
 
     @property
     def iupac_formula(self) -> str:

--- a/pymatgen/core/ion.py
+++ b/pymatgen/core/ion.py
@@ -8,11 +8,12 @@ Module containing class to create an ion
 
 import re
 from copy import deepcopy
+from typing import Dict, Tuple
 
 from monty.json import MSONable
 
 from pymatgen.core.composition import Composition, reduce_formula
-from pymatgen.util.string import formula_double_format, charge_string, Stringify
+from pymatgen.util.string import Stringify, charge_string, formula_double_format
 
 
 class Ion(Composition, MSONable, Stringify):
@@ -80,7 +81,7 @@ class Ion(Composition, MSONable, Stringify):
         return cls(composition, charge)
 
     @property
-    def formula(self):
+    def formula(self) -> str:
         """
         Returns a formula string, with elements sorted by electronegativity,
         e.g., Li4 Fe4 P4 O16.
@@ -89,7 +90,7 @@ class Ion(Composition, MSONable, Stringify):
         return formula + " " + charge_string(self.charge, brackets=False)
 
     @property
-    def anonymized_formula(self):
+    def anonymized_formula(self) -> str:
         """
         An anonymized formula. Appends charge to the end
         of anonymized composition
@@ -98,7 +99,7 @@ class Ion(Composition, MSONable, Stringify):
         chg_str = charge_string(self._charge, brackets=False)
         return anon_formula + chg_str
 
-    def get_reduced_formula_and_factor(self):
+    def get_reduced_formula_and_factor(self, iupac_ordering: bool = False) -> Tuple[str, float]:
         """
         Calculates a reduced formula and factor.
 
@@ -108,6 +109,19 @@ class Ion(Composition, MSONable, Stringify):
         'Fe(HO)2'), and special formulas that apply to solids (e.g. Li2O2 instead of LiO)
         are not used.
 
+        Note that the formula returned by this method does not contain a charge.
+        To include charge, use formula or reduced_formula instead.
+
+        Args:
+            iupac_ordering (bool, optional): Whether to order the
+                formula by the iupac "electronegativity" series, defined in
+                Table VI of "Nomenclature of Inorganic Chemistry (IUPAC
+                Recommendations 2005)". This ordering effectively follows
+                the groups and rows of the periodic table, except the
+                Lanthanides, Actanides and hydrogen. Note that polyanions
+                will still be determined based on the true electronegativity of
+                the elements.
+
         Returns:
             A pretty normalized formula and a multiplicative factor, i.e.,
             H4O4 returns ('H2O2', 2.0).
@@ -116,7 +130,7 @@ class Ion(Composition, MSONable, Stringify):
         if not all_int:
             return self.formula.replace(" ", ""), 1
         d = {k: int(round(v)) for k, v in self.get_el_amt_dict().items()}
-        (formula, factor) = reduce_formula(d)
+        (formula, factor) = reduce_formula(d, iupac_ordering=iupac_ordering)
 
         if "HO" in formula:
             formula = formula.replace("HO", "OH")
@@ -128,7 +142,7 @@ class Ion(Composition, MSONable, Stringify):
         return formula, factor
 
     @property
-    def reduced_formula(self):
+    def reduced_formula(self) -> str:
         """
         Returns a reduced formula string with appended charge. The
         charge is placed in brackets with the sign preceding the magnitude, e.g.,
@@ -140,7 +154,7 @@ class Ion(Composition, MSONable, Stringify):
         return reduced_formula + chg_str
 
     @property
-    def alphabetical_formula(self):
+    def alphabetical_formula(self) -> str:
         """
         Returns a formula string, with elements sorted by alphabetically and
         appended charge
@@ -149,13 +163,13 @@ class Ion(Composition, MSONable, Stringify):
         return alph_formula + " " + charge_string(self.charge, brackets=False)
 
     @property
-    def charge(self):
+    def charge(self) -> float:
         """
         Charge of the ion
         """
         return self._charge
 
-    def as_dict(self):
+    def as_dict(self) -> Dict[str, float]:
         """
         Returns:
             dict with composition, as well as charge
@@ -165,7 +179,7 @@ class Ion(Composition, MSONable, Stringify):
         return d
 
     @classmethod
-    def from_dict(cls, d):
+    def from_dict(cls, d) -> "Ion":
         """
         Generates an ion object from a dict created by as_dict().
 
@@ -179,7 +193,7 @@ class Ion(Composition, MSONable, Stringify):
         return Ion(composition, charge)
 
     @property
-    def to_reduced_dict(self):
+    def to_reduced_dict(self) -> dict:
         """
         Returns:
             dict with element symbol and reduced amount e.g.,
@@ -190,7 +204,7 @@ class Ion(Composition, MSONable, Stringify):
         return d
 
     @property
-    def composition(self):
+    def composition(self) -> Composition:
         """Composition of ion."""
         return Composition(self._data)
 

--- a/pymatgen/core/ion.py
+++ b/pymatgen/core/ion.py
@@ -100,8 +100,8 @@ class Ion(Composition, MSONable, Stringify):
 
     def get_reduced_formula_and_factor(self):
         """
-        Calculates a reduced formula and factor. 
-        
+        Calculates a reduced formula and factor.
+
         Similar to Composition.get_reduced_formula_and_factor except that O-H formulas
         receive special handling to differentiate between hydrogen peroxide and OH-.
         Formulas containing HO are written with oxygen first (e.g. 'Fe(OH)2' rather than
@@ -110,7 +110,7 @@ class Ion(Composition, MSONable, Stringify):
 
         Returns:
             A pretty normalized formula and a multiplicative factor, i.e.,
-            H4O4 returns ('H2O2', 2.0). 
+            H4O4 returns ('H2O2', 2.0).
         """
         all_int = all(abs(x - round(x)) < Composition.amount_tolerance for x in self.values())
         if not all_int:
@@ -238,7 +238,7 @@ class Ion(Composition, MSONable, Stringify):
         """
         :return: Pretty string with proper superscripts.
         """
-        str_ = super().formula
+        str_ = super().reduced_formula
         if self.charge > 0:
             str_ += "^+" + formula_double_format(self.charge, False)
         elif self._charge < 0:

--- a/pymatgen/core/tests/test_ion.py
+++ b/pymatgen/core/tests/test_ion.py
@@ -58,6 +58,7 @@ class IonTest(unittest.TestCase):
                             ("F-", "F[-1]"),
                             ("H4O4", "H2O2(aq)"),
                             ("OH-", "OH[-1]"),
+                            ("Fe(OH)4+", "Fe(OH)4[+1]"),
         ]
 
         for tup in special_formulas:

--- a/pymatgen/core/tests/test_ion.py
+++ b/pymatgen/core/tests/test_ion.py
@@ -52,6 +52,17 @@ class IonTest(unittest.TestCase):
 
         self.assertEqual(Ion.from_formula("Na[+-+]").charge, 1)
 
+    def test_special_formulas(self):
+        special_formulas = [("Cl-", "Cl[-]"),
+                            ("H+", "H[+]"),
+                            ("F-", "F[-]"),
+                            ("H4O4", "H2O2(aq)"),
+                            ("OH-", "OH[-]"),
+        ]
+
+        for tup in special_formulas:
+            self.assertEqual(Ion.from_formula(tup[0]).reduced_formula, tup[1])
+
     def test_formula(self):
         correct_formulas = [
             "Li1 +1",

--- a/pymatgen/core/tests/test_ion.py
+++ b/pymatgen/core/tests/test_ion.py
@@ -53,11 +53,11 @@ class IonTest(unittest.TestCase):
         self.assertEqual(Ion.from_formula("Na[+-+]").charge, 1)
 
     def test_special_formulas(self):
-        special_formulas = [("Cl-", "Cl[-]"),
-                            ("H+", "H[+]"),
-                            ("F-", "F[-]"),
+        special_formulas = [("Cl-", "Cl[-1]"),
+                            ("H+", "H[+1]"),
+                            ("F-", "F[-1]"),
                             ("H4O4", "H2O2(aq)"),
-                            ("OH-", "OH[-]"),
+                            ("OH-", "OH[-1]"),
         ]
 
         for tup in special_formulas:

--- a/pymatgen/core/tests/test_ion.py
+++ b/pymatgen/core/tests/test_ion.py
@@ -33,6 +33,25 @@ class IonTest(unittest.TestCase):
         self.assertEqual("H1 O1 -1", Ion(Composition(f), charge).formula)
         self.assertEqual("S2 O3 -2", Ion(Composition(S=2, O=3), -2).formula)
 
+    def test_charge_from_formula(self):
+        self.assertEqual(Ion.from_formula("Li+").charge, 1)
+        self.assertEqual(Ion.from_formula("Li[+]").charge, 1)
+        self.assertEqual(Ion.from_formula("Ca[2+]").charge, 2)
+        self.assertEqual(Ion.from_formula("Ca[+2]").charge, 2)
+        self.assertEqual(Ion.from_formula("Ca++").charge, 2)
+        self.assertEqual(Ion.from_formula("Ca[++]").charge, 2)
+        self.assertEqual(Ion.from_formula("Ca2+").charge, 1)
+
+        self.assertEqual(Ion.from_formula("Cl-").charge, -1)
+        self.assertEqual(Ion.from_formula("Cl[-]").charge, -1)
+        self.assertEqual(Ion.from_formula("SO4[-2]").charge, -2)
+        self.assertEqual(Ion.from_formula("SO4-2").charge, -2)
+        self.assertEqual(Ion.from_formula("SO42-").charge, -1)
+        self.assertEqual(Ion.from_formula("SO4--").charge, -2)
+        self.assertEqual(Ion.from_formula("SO4[--]").charge, -2)
+
+        self.assertEqual(Ion.from_formula("Na[+-+]").charge, 1)
+
     def test_formula(self):
         correct_formulas = [
             "Li1 +1",

--- a/pymatgen/core/tests/test_ion.py
+++ b/pymatgen/core/tests/test_ion.py
@@ -62,7 +62,7 @@ class IonTest(unittest.TestCase):
             "Fe1 C6 N6 -4",
             "Fe2 P6 C10 O54 -3",
             "Ca1 +2",
-            "Na1 H1 O1",
+            "Na1 H1 O1 (aq)",
         ]
         all_formulas = [c.formula for c in self.comp]
         self.assertEqual(all_formulas, correct_formulas)
@@ -71,8 +71,8 @@ class IonTest(unittest.TestCase):
     def test_mixed_valence(self):
         comp = Ion(Composition({"Fe2+": 2, "Fe3+": 4, "Li+": 8}))
         self.assertEqual(comp.reduced_formula, "Li4Fe3(aq)")
-        self.assertEqual(comp.alphabetical_formula, "Fe6 Li8")
-        self.assertEqual(comp.formula, "Li8 Fe6")
+        self.assertEqual(comp.alphabetical_formula, "Fe6 Li8 (aq)")
+        self.assertEqual(comp.formula, "Li8 Fe6 (aq)")
 
     def test_alphabetical_formula(self):
         correct_formulas = [
@@ -84,7 +84,7 @@ class IonTest(unittest.TestCase):
             "C6 Fe1 N6 -4",
             "C10 Fe2 O54 P6 -3",
             "Ca1 +2",
-            "H1 Na1 O1",
+            "H1 Na1 O1 (aq)",
         ]
         all_formulas = [c.alphabetical_formula for c in self.comp]
         self.assertEqual(all_formulas, correct_formulas)
@@ -104,7 +104,7 @@ class IonTest(unittest.TestCase):
             "AB6C6-4",
             "AB3C5D27-3",
             "A+2",
-            "ABC",
+            "ABC(aq)",
         ]
         for i in range(len(self.comp)):
             self.assertEqual(self.comp[i].anonymized_formula, expected_formulas[i])
@@ -113,7 +113,7 @@ class IonTest(unittest.TestCase):
         sym_dict = {"P": 1, "O": 4, "charge": -2}
         self.assertEqual(
             Ion.from_dict(sym_dict).reduced_formula,
-            "PO4[2-]",
+            "PO4[-2]",
             "Creation form sym_amount dictionary failed!",
         )
 

--- a/pymatgen/core/tests/test_ion.py
+++ b/pymatgen/core/tests/test_ion.py
@@ -173,8 +173,20 @@ class IonTest(unittest.TestCase):
     def test_len(self):
         self.assertEqual(len(self.comp[1]), 2, "Lengths are not equal!")
 
-    def test_to_string(self):
-        self.assertEqual(self.comp[1].to_latex_string(), "Mn$_{1}$ O$_{4}$$^{-1}$")
+    def test_to_latex_string(self):
+        correct_latex = [
+            "Li$^{+1}$",
+            "MnO$_{4}$$^{-1}$",
+            "Mn$^{+2}$",
+            "PO$_{3}$$^{-2}$",
+            "Fe(CN)$_{6}$$^{-3}$",
+            "Fe(CN)$_{6}$$^{-4}$",
+            'FeP$_{3}$C$_{5}$O$_{27}$$^{-3}$',
+            'Ca$^{+2}$',
+            'NaOH',
+        ]
+        all_latex = [c.to_latex_string() for c in self.comp]
+        self.assertEqual(all_latex, correct_latex)
 
 
 if __name__ == "__main__":

--- a/pymatgen/core/tests/test_ion.py
+++ b/pymatgen/core/tests/test_ion.py
@@ -53,16 +53,28 @@ class IonTest(unittest.TestCase):
         self.assertEqual(Ion.from_formula("Na[+-+]").charge, 1)
 
     def test_special_formulas(self):
-        special_formulas = [("Cl-", "Cl[-1]"),
-                            ("H+", "H[+1]"),
-                            ("F-", "F[-1]"),
-                            ("H4O4", "H2O2(aq)"),
-                            ("OH-", "OH[-1]"),
-                            ("Fe(OH)4+", "Fe(OH)4[+1]"),
+        special_formulas = [
+            ("Cl-", "Cl[-1]"),
+            ("H+", "H[+1]"),
+            ("F-", "F[-1]"),
+            ("H4O4", "H2O2(aq)"),
+            ("OH-", "OH[-1]"),
+            ("CH3COO-", "CH3COO[-1]"),
+            ("CH3COOH", "CH3COOH(aq)"),
+            ("CH3OH", "CH3OH(aq)"),
+            ("H4CO", "CH3OH(aq)"),
+            ("C2H6O", "C2H5OH(aq)"),
+            ("C3H8O", "C3H7OH(aq)"),
+            ("C4H10O", "C4H9OH(aq)"),
+            ("Fe(OH)4+", "FeO2.2H2O[+1]"),
+            ("Zr(OH)4", "ZrO2.2H2O(aq)"),
         ]
 
         for tup in special_formulas:
             self.assertEqual(Ion.from_formula(tup[0]).reduced_formula, tup[1])
+
+        self.assertEqual(Ion.from_formula("Fe(OH)4+").get_reduced_formula_and_factor(hydrates=False), ("Fe(OH)4", 1))
+        self.assertEqual(Ion.from_formula("Zr(OH)4").get_reduced_formula_and_factor(hydrates=False), ("Zr(OH)4", 1))
 
     def test_formula(self):
         correct_formulas = [
@@ -182,9 +194,9 @@ class IonTest(unittest.TestCase):
             "PO$_{3}$$^{-2}$",
             "Fe(CN)$_{6}$$^{-3}$",
             "Fe(CN)$_{6}$$^{-4}$",
-            'FeP$_{3}$C$_{5}$O$_{27}$$^{-3}$',
-            'Ca$^{+2}$',
-            'NaOH',
+            "FeP$_{3}$C$_{5}$O$_{27}$$^{-3}$",
+            "Ca$^{+2}$",
+            "NaOH",
         ]
         all_latex = [c.to_latex_string() for c in self.comp]
         self.assertEqual(all_latex, correct_latex)

--- a/pymatgen/util/string.py
+++ b/pymatgen/util/string.py
@@ -141,6 +141,39 @@ def formula_double_format(afloat, ignore_ones=True, tol=1e-8):
     return str(round(afloat, 8))
 
 
+def charge_string(charge, brackets=True, explicit_one=False):
+    """
+    Returns a string representing the charge of an Ion. By default, the
+    charge is placed in brackets with the sign preceding the magnitude, e.g.,
+    '[+2]'. For uncharged species, the string returned is '(aq)'
+
+    Args:
+        brackets: whether to enclose the charge in brackets, e.g. [+2]. Default: True
+        explicit_one: whether to include the number one for monovalent ions, e.g.
+            +1 rather than +. Default: False
+    """
+    if charge > 0:
+        if abs(charge) == 1:
+            chg_str = "+"
+        else:
+            chg_str = f"+{formula_double_format(charge, False)}"
+    elif charge < 0:
+        if abs(charge) == 1:
+            chg_str = "-"
+        else:
+            chg_str = f"-{formula_double_format(abs(charge), False)}"
+    else:
+        chg_str = "(aq)"
+
+    if chg_str in ["+", "-"] and explicit_one:
+        chg_str += "1"
+
+    if chg_str != "(aq)" and brackets:
+        chg_str = "[" + chg_str + "]"
+
+    return chg_str
+
+
 def latexify(formula):
     """
     Generates a LaTeX formatted formula. E.g., Fe2O3 is transformed to

--- a/pymatgen/util/string.py
+++ b/pymatgen/util/string.py
@@ -141,7 +141,7 @@ def formula_double_format(afloat, ignore_ones=True, tol=1e-8):
     return str(round(afloat, 8))
 
 
-def charge_string(charge, brackets=True, explicit_one=False):
+def charge_string(charge, brackets=True, explicit_one=True):
     """
     Returns a string representing the charge of an Ion. By default, the
     charge is placed in brackets with the sign preceding the magnitude, e.g.,
@@ -150,23 +150,17 @@ def charge_string(charge, brackets=True, explicit_one=False):
     Args:
         brackets: whether to enclose the charge in brackets, e.g. [+2]. Default: True
         explicit_one: whether to include the number one for monovalent ions, e.g.
-            +1 rather than +. Default: False
+            +1 rather than +. Default: True
     """
     if charge > 0:
-        if abs(charge) == 1:
-            chg_str = "+"
-        else:
-            chg_str = f"+{formula_double_format(charge, False)}"
+        chg_str = f"+{formula_double_format(charge, False)}"
     elif charge < 0:
-        if abs(charge) == 1:
-            chg_str = "-"
-        else:
-            chg_str = f"-{formula_double_format(abs(charge), False)}"
+        chg_str = f"-{formula_double_format(abs(charge), False)}"
     else:
         chg_str = "(aq)"
 
-    if chg_str in ["+", "-"] and explicit_one:
-        chg_str += "1"
+    if chg_str in ["+1", "-1"] and not explicit_one:
+        chg_str = chg_str.replace("1", "")
 
     if chg_str != "(aq)" and brackets:
         chg_str = "[" + chg_str + "]"

--- a/pymatgen/util/tests/test_string.py
+++ b/pymatgen/util/tests/test_string.py
@@ -9,6 +9,7 @@ from pymatgen.core import Structure
 from pymatgen.util.string import (
     disordered_formula,
     formula_double_format,
+    charge_string,
     htmlify,
     latexify,
     latexify_spacegroup,
@@ -76,6 +77,21 @@ class FuncTest(unittest.TestCase):
         self.assertEqual(formula_double_format(2.00), "2")
         self.assertEqual(formula_double_format(2.10), "2.1")
         self.assertEqual(formula_double_format(2.10000000002), "2.1")
+    
+    def test_charge_string(self):
+        self.assertEqual(charge_string(1), "[+]")
+        self.assertEqual(charge_string(1, brackets=False), "+")
+        self.assertEqual(charge_string(1, explicit_one=True), "[+1]")
+
+        self.assertEqual(charge_string(-1), "[-]")
+        self.assertEqual(charge_string(-1, brackets=False), "-")
+        self.assertEqual(charge_string(-1, explicit_one=True), "[-1]")
+
+        self.assertEqual(charge_string(2), "[+2]")
+        self.assertEqual(charge_string(-4), "[-4]")
+        self.assertEqual(charge_string(3.5, brackets=False), "+3.5")
+        
+        self.assertEqual(charge_string(0), "(aq)")
 
     def test_transformation_to_string(self):
         m = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]

--- a/pymatgen/util/tests/test_string.py
+++ b/pymatgen/util/tests/test_string.py
@@ -79,13 +79,13 @@ class FuncTest(unittest.TestCase):
         self.assertEqual(formula_double_format(2.10000000002), "2.1")
     
     def test_charge_string(self):
-        self.assertEqual(charge_string(1), "[+]")
-        self.assertEqual(charge_string(1, brackets=False), "+")
-        self.assertEqual(charge_string(1, explicit_one=True), "[+1]")
+        self.assertEqual(charge_string(1), "[+1]")
+        self.assertEqual(charge_string(1, brackets=False), "+1")
+        self.assertEqual(charge_string(1, explicit_one=False), "[+]")
 
-        self.assertEqual(charge_string(-1), "[-]")
-        self.assertEqual(charge_string(-1, brackets=False), "-")
-        self.assertEqual(charge_string(-1, explicit_one=True), "[-1]")
+        self.assertEqual(charge_string(-1), "[-1]")
+        self.assertEqual(charge_string(-1, brackets=False), "-1")
+        self.assertEqual(charge_string(-1, explicit_one=False), "[-]")
 
         self.assertEqual(charge_string(2), "[+2]")
         self.assertEqual(charge_string(-4), "[-4]")

--- a/pymatgen/util/tests/test_string.py
+++ b/pymatgen/util/tests/test_string.py
@@ -77,7 +77,7 @@ class FuncTest(unittest.TestCase):
         self.assertEqual(formula_double_format(2.00), "2")
         self.assertEqual(formula_double_format(2.10), "2.1")
         self.assertEqual(formula_double_format(2.10000000002), "2.1")
-    
+
     def test_charge_string(self):
         self.assertEqual(charge_string(1), "[+1]")
         self.assertEqual(charge_string(1, brackets=False), "+1")
@@ -90,7 +90,7 @@ class FuncTest(unittest.TestCase):
         self.assertEqual(charge_string(2), "[+2]")
         self.assertEqual(charge_string(-4), "[-4]")
         self.assertEqual(charge_string(3.5, brackets=False), "+3.5")
-        
+
         self.assertEqual(charge_string(0), "(aq)")
 
     def test_transformation_to_string(self):


### PR DESCRIPTION
## Summary

This PR contains some miscellaneous bugfixes and enhancements for the `Ion` class.

* Fixes #2281 
* Partially address #2204 by overloading `get_reduced_formula_and_factor` to provide special formula handling for ions. The `reduced_formula` for hydroxide, hydrogen peroxide, acetate, acetic acid, and small alcohols are now more consistent with the way these species are usually written.
* Implement a `utils.string.charge_string` method to make the representation of ion charges more consistent across `formula`, `reduced_formula`, etc.
* Make representation of `Ion` formulae more consistent. By default, charges are now always appended in brackets, with the sign preceding the magnitude, e.g. `Na[+1]` or `SO4[-2]`. This provides unambiguous differentiation between stoichiometric coefficients and charges, and will facilitate using `Ion.reduced_formula` as database keys in, e.g., the Pourbaix ion data. For uncharged `Ion`, the formula is always followed by `(aq)`. 
* Change display of ions that may be hydrated metal complexes, e.g. `Zr(OH)4(aq)` becomes `ZrO2.2H2O(aq)`
* Add extra tests for `to_latex_string` and `Ion.from_formula`
* Add type hinting

## Additional dependencies introduced (if any)

None

## Checklist

- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). The easiest way to handle this
      is to run the following in the **correct sequence** on your local machine. Start with running
      [black](https://black.readthedocs.io/en/stable/index.html) on your new code. This will automatically reformat
      your code to PEP8 conventions and removes most issues. Then run 
      [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/), followed by 
      [flake8](http://flake8.pycqa.org/en/latest/).
- [x] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [x] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) to type check your code.
- [x] Tests have been added for any new functionality or bug fixes.
- [x] All linting and tests pass.
