### PR TITLE
Add warning if LASPH != True for meta-GGA/hybrid/vdW/+U

### DIFF
--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -568,6 +568,17 @@ class DictSet(VaspInputSet):
             elif any(el.Z > 20 for el in structure.composition):
                 incar["LMAXMIX"] = 4
 
+        # Warn user about LASPH for meta-GGAs, hybrids, and vdW-DF
+        if not settings.get("LASPH", False) and (
+            settings.get("METAGGA", False)
+            or settings.get("LHFCALC", False)
+            or settings.get("LDAU", False)
+            or settings.get("LUSE_VDW", False)
+        ):
+            warnings.warn(
+                "LASPH = True should be set for +U, meta-GGAs, and vdW-DFT", BadInputSetWarning,
+            )
+
         if self.constrain_total_magmom:
             nupdown = sum([mag if abs(mag) > 0.6 else 0 for mag in incar["MAGMOM"]])
             incar["NUPDOWN"] = nupdown

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -576,7 +576,8 @@ class DictSet(VaspInputSet):
             or settings.get("LUSE_VDW", False)
         ):
             warnings.warn(
-                "LASPH = True should be set for +U, meta-GGAs, and vdW-DFT", BadInputSetWarning,
+                "LASPH = True should be set for +U, meta-GGAs, and vdW-DFT",
+                BadInputSetWarning,
             )
 
         if self.constrain_total_magmom:

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -568,7 +568,7 @@ class DictSet(VaspInputSet):
             elif any(el.Z > 20 for el in structure.composition):
                 incar["LMAXMIX"] = 4
 
-        # Warn user about LASPH for meta-GGAs, hybrids, and vdW-DF
+        # Warn user about LASPH for +U, meta-GGAs, hybrids, and vdW-DF
         if not settings.get("LASPH", False) and (
             settings.get("METAGGA", False)
             or settings.get("LHFCALC", False)
@@ -576,7 +576,7 @@ class DictSet(VaspInputSet):
             or settings.get("LUSE_VDW", False)
         ):
             warnings.warn(
-                "LASPH = True should be set for +U, meta-GGAs, and vdW-DFT",
+                "LASPH = True should be set for +U, meta-GGAs, hybrids, and vdW-DFT",
                 BadInputSetWarning,
             )
 

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -570,7 +570,7 @@ class DictSet(VaspInputSet):
 
         # Warn user about LASPH for +U, meta-GGAs, hybrids, and vdW-DF
         if not settings.get("LASPH", False) and (
-            settings.get("METAGGA", False)
+            settings.get("METAGGA")
             or settings.get("LHFCALC", False)
             or settings.get("LDAU", False)
             or settings.get("LUSE_VDW", False)

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -500,6 +500,16 @@ class MPStaticSetTest(PymatgenTest):
         self.assertEqual(vis.incar["ENCUT"], 600)
         self.assertEqual(vis.kpoints.style, Kpoints.supported_modes.Monkhorst)
 
+        # Check warning if LASPH is set to False for meta-GGAs/hybrids/+U/vdW
+        with pytest.warns(BadInputSetWarning, match=r"LASPH"):
+            MPStaticSet(vis.structure, user_incar_settings={"METAGGA": "M06L", "LASPH": False})
+        with pytest.warns(BadInputSetWarning, match=r"LASPH"):
+            MPStaticSet(vis.structure, user_incar_settings={"LHFCALC": True, "LASPH": False})
+        with pytest.warns(BadInputSetWarning, match=r"LASPH"):
+            MPStaticSet(vis.structure, user_incar_settings={"LDAU": True, "LASPH": False})
+        with pytest.warns(BadInputSetWarning, match=r"LASPH"):
+            MPStaticSet(vis.structure, user_incar_settings={"LUSE_VDW": True, "LASPH": False})
+
         non_prev_vis = MPStaticSet(vis.structure, user_incar_settings={"LORBIT": 12, "LWAVE": True})
         self.assertEqual(non_prev_vis.incar["NSW"], 0)
         # Check that the ENCUT and Kpoints style has NOT been inherited.

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -502,13 +502,17 @@ class MPStaticSetTest(PymatgenTest):
 
         # Check warning if LASPH is set to False for meta-GGAs/hybrids/+U/vdW
         with pytest.warns(BadInputSetWarning, match=r"LASPH"):
-            MPStaticSet(vis.structure, user_incar_settings={"METAGGA": "M06L", "LASPH": False})
+            vis = MPStaticSet(vis.structure, user_incar_settings={"METAGGA": "M06L", "LASPH": False})
+            vis.incar.items()
         with pytest.warns(BadInputSetWarning, match=r"LASPH"):
-            MPStaticSet(vis.structure, user_incar_settings={"LHFCALC": True, "LASPH": False})
+            vis = MPStaticSet(vis.structure, user_incar_settings={"LHFCALC": True, "LASPH": False})
+            vis.incar.items()
         with pytest.warns(BadInputSetWarning, match=r"LASPH"):
-            MPStaticSet(vis.structure, user_incar_settings={"LDAU": True, "LASPH": False})
+            vis = MPStaticSet(vis.structure, user_incar_settings={"LDAU": True, "LASPH": False})
+            vis.incar.items()
         with pytest.warns(BadInputSetWarning, match=r"LASPH"):
-            MPStaticSet(vis.structure, user_incar_settings={"LUSE_VDW": True, "LASPH": False})
+            vis = MPStaticSet(vis.structure, user_incar_settings={"LUSE_VDW": True, "LASPH": False})
+            vis.incar.items()
 
         non_prev_vis = MPStaticSet(vis.structure, user_incar_settings={"LORBIT": 12, "LWAVE": True})
         self.assertEqual(non_prev_vis.incar["NSW"], 0)


### PR DESCRIPTION
This PR implements a simple `BadInputSetWarning` if `LASPH = False` (or is not set) yet the user is running a meta-GGA/hybrid/DFT+U/vdW-DF calculation.