### PR TITLE
Add warning if improper ALGO is used for hybrid calculations

### DIFF
--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -575,6 +575,13 @@ class DictSet(VaspInputSet):
         if self.use_structure_charge:
             incar["NELECT"] = self.nelect
 
+        # Check that ALGO is appropriate
+        if incar.get("LHFCALC", False) is True and incar.get("ALGO", "Normal") not in ["Normal", "All", "Damped"]:
+            warnings.warn(
+                "Hybrid functionals only support Algo = All, Damped, or Normal.",
+                BadInputSetWarning,
+            )
+
         # Ensure adequate number of KPOINTS are present for the tetrahedron
         # method (ISMEAR=-5). If KSPACING is in the INCAR file the number
         # of kpoints is not known before calling VASP, but a warning is raised

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -1182,7 +1182,7 @@ class MPHSEBSTest(PymatgenTest):
         self.assertEqual(vis.incar["ISYM"], 3)
         self.assertEqual(len(vis.kpoints.kpts), 180)
 
-        with pytest.raises(ValueError, match=r"Hybrid functionals"):
+        with pytest.warns(BadInputSetWarning, match=r"Hybrid functionals"):
             MPHSEBSSet.from_prev_calc(prev_calc_dir=prev_run, user_incar_settings={"ALGO": "Fast"})
 
     def test_override_from_prev_calc(self):

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -1182,6 +1182,9 @@ class MPHSEBSTest(PymatgenTest):
         self.assertEqual(vis.incar["ISYM"], 3)
         self.assertEqual(len(vis.kpoints.kpts), 180)
 
+        with pytest.raises(ValueError, match=r"Hybrid functionals"):
+            MPHSEBSSet.from_prev_calc(prev_calc_dir=prev_run, user_incar_settings={"ALGO": "Fast"})
+
     def test_override_from_prev_calc(self):
         prev_run = self.TEST_FILES_DIR / "static_silicon"
         vis = MPHSEBSSet(_dummy_structure, mode="uniform")

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -1184,7 +1184,7 @@ class MPHSEBSTest(PymatgenTest):
 
         with pytest.warns(BadInputSetWarning, match=r"Hybrid functionals"):
             vis = MPHSEBSSet(PymatgenTest.get_structure("Li2O"), user_incar_settings={"ALGO": "Fast"})
-            print(vis.incar.items())
+            vis.incar.items()
 
     def test_override_from_prev_calc(self):
         prev_run = self.TEST_FILES_DIR / "static_silicon"

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -1183,7 +1183,8 @@ class MPHSEBSTest(PymatgenTest):
         self.assertEqual(len(vis.kpoints.kpts), 180)
 
         with pytest.warns(BadInputSetWarning, match=r"Hybrid functionals"):
-            vis = MPHSEBSSet.from_prev_calc(prev_calc_dir=prev_run, user_incar_settings={"ALGO": "Fast"})
+            vis = MPHSEBSSet(PymatgenTest.get_structure("Li2O"), user_incar_settings={"ALGO": "Fast"})
+            print(vis.incar.items())
 
     def test_override_from_prev_calc(self):
         prev_run = self.TEST_FILES_DIR / "static_silicon"

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -1183,7 +1183,7 @@ class MPHSEBSTest(PymatgenTest):
         self.assertEqual(len(vis.kpoints.kpts), 180)
 
         with pytest.warns(BadInputSetWarning, match=r"Hybrid functionals"):
-            MPHSEBSSet.from_prev_calc(prev_calc_dir=prev_run, user_incar_settings={"ALGO": "Fast"})
+            vis = MPHSEBSSet.from_prev_calc(prev_calc_dir=prev_run, user_incar_settings={"ALGO": "Fast"})
 
     def test_override_from_prev_calc(self):
         prev_run = self.TEST_FILES_DIR / "static_silicon"


### PR DESCRIPTION
Per the VASP manual (https://www.vasp.at/wiki/index.php/LHFCALC), hybrid calculations should only be run with ALGO = All, Damped, or Normal (never Fast or VeryFast despite no clear error written in the output). This PR implements a `BadInputSetWarning` if LHFCALC = True and Algo is not one of the three supported options.