### PR TITLE
wrap SC to unit cell

### DIFF
--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -1114,7 +1114,7 @@ class IStructure(SiteCollection, MSONable):
                 new_sites.append(s)
 
         new_charge = self._charge * np.linalg.det(scale_matrix) if self._charge else None
-        return Structure.from_sites(new_sites, charge=new_charge)
+        return Structure.from_sites(new_sites, charge=new_charge, to_unit_cell=True)
 
     def __rmul__(self, scaling_matrix):
         """


### PR DESCRIPTION
When you create supercell I think the expected behavior should be that the sites in the SC sit in the unit-cell.
Currently, the behavior is:
```
# Si unit cell
Full Formula (Si2)
Reduced Formula: Si
abc   :   3.866974   3.866975   3.866975
angles:  60.000006  60.000002  60.000010
Sites (2)
  #  SP        a      b      c
---  ----  -----  -----  -----
  0  Si    0.875  0.875  0.875
  1  Si    0.125  0.125  0.125
# Si [[-1,1,1], [1,-1,1], [1,1,-1]] supercell 
Full Formula (Si8)
Reduced Formula: Si
abc   :   5.468729   5.468729   5.468728
angles:  90.000014  90.000001  90.000001
Sites (8)
  #  SP        a      b      c
---  ----  -----  -----  -----
  0  Si    0.875  0.875  0.875
  1  Si    1.375  1.375  0.875
  2  Si    1.375  0.875  1.375
  3  Si    0.875  1.375  1.375
  4  Si    0.125  0.125  0.125
  5  Si    0.625  0.625  0.125
  6  Si    0.625  0.125  0.625
  7  Si    0.125  0.625  0.625
```
The additional flag should fix this problem
