### PR TITLE
Rosen spin

### DIFF
--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -282,8 +282,8 @@ class DictSet(VaspInputSet):
     structure and the configuration settings. The order in which the magmom is
     determined is as follows:
 
-    1. If the site itself has a magmom setting, that is used.
-    2. If the species on the site has a spin setting, that is used.
+    1. If the site itself has a magmom setting (`site.magmom`), that is used.
+    2. If the species on the site has a spin setting (`site.spin`), that is used.
     3. If the species itself has a particular setting in the config file, that
        is used, e.g., Mn3+ may have a different magmom than Mn4+.
     4. Lastly, the element symbol itself is checked in the config file. If
@@ -509,18 +509,26 @@ class DictSet(VaspInputSet):
                     elif hasattr(site.specie, "spin"):
                         mag.append(site.specie.spin)
                     elif str(site.specie) in v:
+                        if type(v) is not dict:
+                            raise ValueError(
+                                "MAGMOM must be supplied in a dictionary format, e.g. {'Fe': 5}. "
+                                "If you want site-specific magnetic moments, set them in the site.magmom properties "
+                                "of the site objects in the structure"
+                            )
                         if site.specie.symbol == "Co":
                             warnings.warn(
-                                "Co without oxidation state is initialized low spin by default. If this is "
-                                "not desired, please set the spin on the magmom on the site directly to "
+                                "Co without an oxidation state is initialized as low spin by default in Pymatgen "
+                                "(unless you have provided a MAGMOM dictionary specifying otherwise). If this default "
+                                "behavior is not desired, please set the spin on the magmom on the site directly to "
                                 "ensure correct initialization"
                             )
                         mag.append(v.get(str(site.specie)))
                     else:
                         if site.specie.symbol == "Co":
                             warnings.warn(
-                                "Co without oxidation state is initialized low spin by default. If this is "
-                                "not desired, please set the spin on the magmom on the site directly to "
+                                "Co without an oxidation state is initialized as low spin by default in Pymatgen "
+                                "(unless you have provided a MAGMOM dictionary specifying otherwise). If this default "
+                                "behavior is not desired, please set the spin on the magmom on the site directly to "
                                 "ensure correct initialization"
                             )
                         mag.append(v.get(site.specie.symbol, 0.6))
@@ -574,7 +582,7 @@ class DictSet(VaspInputSet):
                 warnings.warn(
                     "constrain_total_magmom was set to True, but the sum of MAGMOM"
                     "values is not an integer. NUPDOWN is meant to set the spin"
-                    "multiplet and should likely be an integer. You are likely"
+                    "multiplet and should typically be an integer. You are likely"
                     "better off changing the values of MAGMOM or simply setting"
                     "NUPDOWN directly in your INCAR settings."
                 )

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -570,6 +570,13 @@ class DictSet(VaspInputSet):
 
         if self.constrain_total_magmom:
             nupdown = sum([mag if abs(mag) > 0.6 else 0 for mag in incar["MAGMOM"]])
+            if nupdown != round(nupdown):
+                warnings.warn(
+                    "constrain_total_magmom was set to True, but the sum of MAGMOM"
+                    "values is not an integer. NUPDOWN is meant to set the spin"
+                    "multiplet and should likely be an integer. Make sure you know"
+                    "what you are doing."
+                )
             incar["NUPDOWN"] = nupdown
 
         if self.use_structure_charge:

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -574,8 +574,9 @@ class DictSet(VaspInputSet):
                 warnings.warn(
                     "constrain_total_magmom was set to True, but the sum of MAGMOM"
                     "values is not an integer. NUPDOWN is meant to set the spin"
-                    "multiplet and should likely be an integer. Make sure you know"
-                    "what you are doing."
+                    "multiplet and should likely be an integer. You are likely"
+                    "better off changing the values of MAGMOM or simply setting"
+                    "NUPDOWN directly in your INCAR settings."
                 )
             incar["NUPDOWN"] = nupdown
 

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -287,7 +287,7 @@ class DictSet(VaspInputSet):
     3. If the species itself has a particular setting in the config file, that
        is used, e.g., Mn3+ may have a different magmom than Mn4+.
     4. Lastly, the element symbol itself is checked in the config file. If
-       there are no settings, VASP's default of 0.6 is used.
+       there are no settings, a default value of 0.6 is used.
     """
 
     def __init__(

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -580,10 +580,10 @@ class DictSet(VaspInputSet):
             nupdown = sum([mag if abs(mag) > 0.6 else 0 for mag in incar["MAGMOM"]])
             if nupdown != round(nupdown):
                 warnings.warn(
-                    "constrain_total_magmom was set to True, but the sum of MAGMOM"
-                    "values is not an integer. NUPDOWN is meant to set the spin"
-                    "multiplet and should typically be an integer. You are likely"
-                    "better off changing the values of MAGMOM or simply setting"
+                    "constrain_total_magmom was set to True, but the sum of MAGMOM "
+                    "values is not an integer. NUPDOWN is meant to set the spin "
+                    "multiplet and should typically be an integer. You are likely "
+                    "better off changing the values of MAGMOM or simply setting "
                     "NUPDOWN directly in your INCAR settings."
                 )
             incar["NUPDOWN"] = nupdown


### PR DESCRIPTION
Currently, the handling of the MAGMOM INCAR flag in `pymatgen.io.vasp.sets` could be made clearer. This became apparent to me when trying to modify MAGMOM in an atomate workflow, which did not at all do what I expected it to do (and led to some confusing errors).

1.  The data type for the "MAGMOM" setting is not immediately obvious. In VASP, MAGMOM is given in the format "1\*5.0 1\*5.0" or "2\*5.0". Naively, one might think then to supply {"MAGMOM": [5.0, 5.0]} or maybe even {"MAGMOM": "2*5.0"}, neither of which work appropriately with pymatgen.io.vasp.sets.incar(), which expects something like {"MAGMOM": {"Fe": 5"}}. An error is now raised if MAGMOM is not a dict, and the user is appropriately notified that this is an element-specific flag, not a site-specific flag like in the typical VASP INCAR.

2. The `constrain_total_magmom` flag, when set to `True`, sums up the magnetic moments on each site and sets that as NUPDOWN. When pulling from the MP sets, this is not a concern because the default magnetic moments are integers (except for 0.6 values that are floored to 0 for low-spin). However, more generally, this is almost never desirable. [NUPDOWN](https://www.vasp.at/wiki/index.php/NUPDOWN) is meant to specify the spin multiplet, i.e. 2*S where S is the total spin angular momentum, which is an integer value. While NUPDOWN technically can take non-integer values, that is [not what NUPDOWN is meant to do](https://www.vasp.at/forum/viewtopic.php?f=4&t=2910).  If the user specified a custom MAGMOM, then there is no guarantee the summed values are integers. I have therefore added a warning if `round(sum(magmoms)) != sum(magmoms)`.

3. The warning about Co being initialized as low-spin could be made clearer. Currently, Pymatgen prints out this warning whenever MAGMOM has an entry for Co and there is no site-specific `magmom` or `spin`. If one were to change the config to have high-spin Co or modify MAGMOM directly (e.g. `{"MAGMOM": {"Co":5}}`), the warning would still appear despite the fact that it is no longer relevant. I have clarified the wording in the warning.

4. The documentation says that if the symbol is not in the config file, VASP's default of 0.6 is used. The [VASP default is 1.0](https://www.vasp.at/wiki/index.php/MAGMOM); the Pymatgen default is 0.6. I've clarified the phrasing.

This is WIP because I need to add a test or two.