### PR TITLE
Removed double slashes for RST inline math

### DIFF
--- a/pymatgen/analysis/diffraction/xrd.py
+++ b/pymatgen/analysis/diffraction/xrd.py
@@ -67,28 +67,28 @@ class XRDCalculator(AbstractDiffractionPatternCalculator):
     is as follows
 
     1. Calculate reciprocal lattice of structure. Find all reciprocal points
-       within the limiting sphere given by :math:`\\frac{2}{\\lambda}`.
+       within the limiting sphere given by :math:` \frac{2}{ \lambda}`.
 
-    2. For each reciprocal point :math:`\\mathbf{g_{hkl}}` corresponding to
+    2. For each reciprocal point :math:` \mathbf{g_{hkl}}` corresponding to
        lattice plane :math:`(hkl)`, compute the Bragg condition
-       :math:`\\sin(\\theta) = \\frac{\\lambda}{2d_{hkl}}`
+       :math:` \sin( \theta) =  \frac{ \lambda}{2d_{hkl}}`
 
     3. Compute the structure factor as the sum of the atomic scattering
        factors. The atomic scattering factors are given by
 
        .. math::
 
-           f(s) = Z - 41.78214 \\times s^2 \\times \\sum\\limits_{i=1}^n a_i \
-           \\exp(-b_is^2)
+           f(s) = Z - 41.78214 \times s^2 \times \sum \limits_{i=1}^n a_i \
+            \exp(-b_is^2)
 
-       where :math:`s = \\frac{\\sin(\\theta)}{\\lambda}` and :math:`a_i`
+       where :math:`s = \ frac{\ sin(\ theta)}{\ lambda}` and :math:`a_i`
        and :math:`b_i` are the fitted parameters for each element. The
        structure factor is then given by
 
        .. math::
 
-           F_{hkl} = \\sum\\limits_{j=1}^N f_j \\exp(2\\pi i \\mathbf{g_{hkl}}
-           \\cdot \\mathbf{r})
+           F_{hkl} =  \sum \limits_{j=1}^N f_j  \exp(2 \pi i  \mathbf{g_{hkl}}
+            \cdot  \mathbf{r})
 
     4. The intensity is then given by the modulus square of the structure
        factor.
@@ -102,8 +102,8 @@ class XRDCalculator(AbstractDiffractionPatternCalculator):
 
        .. math::
 
-           P(\\theta) = \\frac{1 + \\cos^2(2\\theta)}
-           {\\sin^2(\\theta)\\cos(\\theta)}
+           P( \theta) =  \frac{1 +  \cos^2(2 \theta)}
+           { \sin^2( \theta) \cos( \theta)}
     """
 
     # Tuple of available radiation keywords.


### PR DESCRIPTION
The double slashes were being misinterpreted in the current version of the documentation.

## Summary


* Replaced double backslases with ` \` as the `\\` was escaping and leading to no character bring printed in the rst math docstring.

## Checklist

Work-in-progress pull requests are encouraged, but please put [WIP]
in the pull request title.

Before a pull request can be merged, the following items must be checked:

- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). The easiest way to handle this
      is to run the following in the **correct sequence** on your local machine. Start with running
      [black](https://black.readthedocs.io/en/stable/index.html) on your new code. This will automatically reformat
      your code to PEP8 conventions and removes most issues. Then run 
      [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/), followed by 
      [flake8](http://flake8.pycqa.org/en/latest/).
- [x] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [x] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) to type check your code.
- [x] Tests have been added for any new functionality or bug fixes.
- [x] All linting and tests pass.

Note that the CI system will run all the above checks. But it will be much more efficient if you already fix most 
errors prior to submitting the PR. It is highly recommended that e above checks. But it will be much moreyou use the pre-commit hook provided in the pymatgen 
repository. Simply `cp pre-commit .git/hooks` and a check will be run prior to allowing commits.
