### PR TITLE
fix write Trajectory XDATACAR with variable lattice

### DIFF
--- a/pymatgen/core/tests/test_trajectory.py
+++ b/pymatgen/core/tests/test_trajectory.py
@@ -499,6 +499,13 @@ class TrajectoryTest(PymatgenTest):
             all(np.allclose(struct.lattice.matrix, structures[i].lattice.matrix) for i, struct in enumerate(traj))
         )
 
+        # Check if the file is written correctly when lattice is not constant.
+        traj.write_Xdatcar(filename="traj_test_XDATCAR")
+        # Load trajectory from written xdatcar and compare to original
+        written_traj = Trajectory.from_file("traj_test_XDATCAR", constant_lattice=False)
+        self._check_traj_equality(traj, written_traj)
+        os.remove("traj_test_XDATCAR")
+
     def test_to_from_dict(self):
         d = self.traj.as_dict()
         traj = Trajectory.from_dict(d)

--- a/pymatgen/core/trajectory.py
+++ b/pymatgen/core/trajectory.py
@@ -502,7 +502,7 @@ class Trajectory(MSONable):
 
         for si, frac_coords in enumerate(self.frac_coords):
             # Only print out the info block if
-            if self.constant_lattice and si == 0:
+            if si == 0 or not self.constant_lattice:
                 lines.extend([system, "1.0"])
 
                 if self.constant_lattice:


### PR DESCRIPTION
## Summary

In the current implementation of the write_Xdatcar in Trajectory the lattice is either written only once if `constan_lattice==True` or never if `constan_lattice==False`. Fix to write it multiple times if the lattice is not constant.
Added a specific check in the tests. 
