### PR TITLE
Add ability to request additional OPTIMADE fields

### DIFF
--- a/pymatgen/ext/optimade.py
+++ b/pymatgen/ext/optimade.py
@@ -6,7 +6,7 @@ import logging
 import sys
 from collections import namedtuple
 from os.path import join
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union, Set
 from urllib.parse import urlparse
 
 import requests
@@ -17,8 +17,6 @@ from pymatgen.core.periodic_table import DummySpecies
 from pymatgen.core.structure import Structure
 from pymatgen.util.provenance import StructureNL
 from pymatgen.util.sequence import PBar
-
-# from retrying import retry
 
 
 # TODO: importing optimade-python-tool's data structures will make more sense
@@ -32,15 +30,19 @@ _logger.setLevel(logging.WARNING)
 
 class OptimadeRester:
     """
-    Class to call OPTIMADE-compliant APIs, see optimade.org
+    Class to call OPTIMADE-compliant APIs, see https://optimade.org and [1].
 
-    This class is ready to use but considered in-development and subject to change
-    until the OPTIMADE paper is published.
+    This class is ready to use but considered in-development and subject to change.
+
+    [1] Andersen, C.W., *et al*. 
+        OPTIMADE, an API for exchanging materials data. 
+        Sci Data 8, 217 (2021). https://doi.org/10.1038/s41597-021-00974-z
+
     """
 
     # regenerate on-demand from official providers.json using OptimadeRester.refresh_aliases()
     # these aliases are provided as a convenient shortcut for users of the OptimadeRester class
-    aliases = {
+    aliases: Dict[str, str] = {
         "aflow": "http://aflow.org/API/optimade/",
         "cod": "https://www.crystallography.net/cod/optimade",
         "mcloud.2dstructures": "https://aiida.materialscloud.org/2dstructures/optimade",
@@ -63,7 +65,7 @@ class OptimadeRester:
         "tcod": "https://www.crystallography.net/tcod/optimade",
     }
 
-    def __init__(self, aliases_or_resource_urls: Optional[Union[str, List[str]]] = None, timeout=5):
+    def __init__(self, aliases_or_resource_urls: Optional[Union[str, List[str]]] = None, timeout: int = 5):
         """
         OPTIMADE is an effort to provide a standardized interface to retrieve information
         from many different materials science databases.
@@ -155,7 +157,11 @@ class OptimadeRester:
 
     @staticmethod
     def _build_filter(
-        elements=None, nelements=None, nsites=None, chemical_formula_anonymous=None, chemical_formula_hill=None
+        elements: Union[str, List[str]] = None, 
+        nelements: int = None, 
+        nsites: int = None, 
+        chemical_formula_anonymous: str = None,
+        chemical_formula_hill: str = None, 
     ):
         """
         Convenience method to build an OPTIMADE filter.
@@ -191,11 +197,11 @@ class OptimadeRester:
 
     def get_structures(
         self,
-        elements=None,
-        nelements=None,
-        nsites=None,
-        chemical_formula_anonymous=None,
-        chemical_formula_hill=None,
+        elements: Union[List[str], str] = None,
+        nelements: int = None,
+        nsites: int = None,
+        chemical_formula_anonymous: str = None,
+        chemical_formula_hill: str = None,
     ) -> Dict[str, Dict[str, Structure]]:
         """
         Retrieve Structures from OPTIMADE providers.
@@ -225,11 +231,11 @@ class OptimadeRester:
 
     def get_snls(
         self,
-        elements=None,
-        nelements=None,
-        nsites=None,
-        chemical_formula_anonymous=None,
-        chemical_formula_hill=None,
+        elements: Union[List[str], str] = None,
+        nelements: int = None,
+        nsites: int = None,
+        chemical_formula_anonymous: str = None,
+        chemical_formula_hill: str = None,
     ) -> Dict[str, Dict[str, StructureNL]]:
         """
         Retrieve StructureNL from OPTIMADE providers.

--- a/pymatgen/ext/optimade.py
+++ b/pymatgen/ext/optimade.py
@@ -34,8 +34,8 @@ class OptimadeRester:
 
     This class is ready to use but considered in-development and subject to change.
 
-    [1] Andersen, C.W., *et al*. 
-        OPTIMADE, an API for exchanging materials data. 
+    [1] Andersen, C.W., *et al*.
+        OPTIMADE, an API for exchanging materials data.
         Sci Data 8, 217 (2021). https://doi.org/10.1038/s41597-021-00974-z
 
     """
@@ -160,11 +160,11 @@ class OptimadeRester:
 
     @staticmethod
     def _build_filter(
-        elements: Union[str, List[str]] = None, 
-        nelements: int = None, 
-        nsites: int = None, 
+        elements: Union[str, List[str]] = None,
+        nelements: int = None,
+        nsites: int = None,
         chemical_formula_anonymous: str = None,
-        chemical_formula_hill: str = None, 
+        chemical_formula_hill: str = None,
     ):
         """
         Convenience method to build an OPTIMADE filter.
@@ -271,9 +271,7 @@ class OptimadeRester:
             chemical_formula_hill=chemical_formula_hill,
         )
 
-        return self.get_snls_with_filter(
-            optimade_filter, additional_response_fields=additional_response_fields
-        )
+        return self.get_snls_with_filter(optimade_filter, additional_response_fields=additional_response_fields)
 
     def get_structures_with_filter(self, optimade_filter: str) -> Dict[str, Dict[str, Structure]]:
         """
@@ -294,8 +292,8 @@ class OptimadeRester:
         return all_structures
 
     def get_snls_with_filter(
-        self, 
-        optimade_filter: str, 
+        self,
+        optimade_filter: str,
         additional_response_fields: Union[str, List[str], Set[str]] = None,
     ) -> Dict[str, Dict[str, StructureNL]]:
         """
@@ -383,9 +381,9 @@ class OptimadeRester:
                 )
                 # Grab any custom fields or non-mandatory fields if they were requested
                 namespaced_data = {
-                    k: v for k, v in data["attributes"].items() 
-                    if k.startswith("_") 
-                    or k not in {"lattice_vectors", "species", "cartesian_site_positions"}
+                    k: v
+                    for k, v in data["attributes"].items()
+                    if k.startswith("_") or k not in {"lattice_vectors", "species", "cartesian_site_positions"}
                 }
 
                 # TODO: follow `references` to add reference information here
@@ -411,9 +409,9 @@ class OptimadeRester:
                     )
                     # Grab any custom fields or non-mandatory fields if they were requested
                     namespaced_data = {
-                        k: v for k, v in data["attributes"].items() 
-                        if k.startswith("_") 
-                        or k not in {"lattice_vectors", "species", "cartesian_site_positions"}
+                        k: v
+                        for k, v in data["attributes"].items()
+                        if k.startswith("_") or k not in {"lattice_vectors", "species", "cartesian_site_positions"}
                     }
 
                     # TODO: follow `references` to add reference information here
@@ -543,7 +541,6 @@ class OptimadeRester:
         if not additional_response_fields:
             additional_response_fields = set()
         return ",".join(set(additional_response_fields).union(self.mandatory_response_fields))
-        
 
     def refresh_aliases(self, providers_url="https://providers.optimade.org/providers.json"):
         """

--- a/pymatgen/ext/tests/test_optimade.py
+++ b/pymatgen/ext/tests/test_optimade.py
@@ -29,6 +29,30 @@ class OptimadeTest(PymatgenTest):
                     msg="Raw filter {_filter} did not return the same number of results as the query builder.",
                 )
 
+    def test_get_snls_mp(self):
+        with OptimadeRester("mp") as optimade:
+
+            structs = optimade.get_snls(elements=["Ga", "N"], nelements=2)
+
+        with OptimadeRester("mp") as optimade:
+            response_field_structs_single = optimade.get_snls(
+                elements=["Ga", "N"], nelements=2, additional_response_fields="nsites"
+            )
+            response_field_structs_set = optimade.get_snls(
+                elements=["Ga", "N"], nelements=2, additional_response_fields={"nsites", "nelements"}
+            )
+            if ("mp" in response_field_structs_single) and ("mp" in response_field_structs_set):
+                self.assertEqual(len(structs["mp"]), len(response_field_structs_single["mp"]))
+                self.assertEqual(len(structs["mp"]), len(response_field_structs_set["mp"]))
+
+                # Check that the requested response fields appear in the SNL metadata
+                s = list(response_field_structs_single["mp"].values())[0]
+                sp = list(response_field_structs_set["mp"].values())[0]
+                assert "nsites" in s.data["_optimade"]
+                assert "nsites" in sp.data["_optimade"]
+                assert "nelements" in sp.data["_optimade"]
+
+
     # Tests fail in CI for unknown reason, use for development only.
     # def test_get_structures_mcloud_2dstructures(self):
     #

--- a/pymatgen/ext/tests/test_optimade.py
+++ b/pymatgen/ext/tests/test_optimade.py
@@ -52,7 +52,6 @@ class OptimadeTest(PymatgenTest):
                 assert "nsites" in sp.data["_optimade"]
                 assert "nelements" in sp.data["_optimade"]
 
-
     # Tests fail in CI for unknown reason, use for development only.
     # def test_get_structures_mcloud_2dstructures(self):
     #


### PR DESCRIPTION
## Summary

Closes #2314 by adding the `additional_response_fields` argument when generating SNLs from OPTIMADE requests.

## Checklist

Work-in-progress pull requests are encouraged, but please put [WIP]
in the pull request title.

Before a pull request can be merged, the following items must be checked:

- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). The easiest way to handle this
      is to run the following in the **correct sequence** on your local machine. Start with running
      [black](https://black.readthedocs.io/en/stable/index.html) on your new code. This will automatically reformat
      your code to PEP8 conventions and removes most issues. Then run 
      [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/), followed by 
      [flake8](http://flake8.pycqa.org/en/latest/).
- [x] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [x] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) to type check your code.
- [x] Tests have been added for any new functionality or bug fixes.
- [x] All linting and tests pass.

Note that the CI system will run all the above checks. But it will be much more efficient if you already fix most 
errors prior to submitting the PR. It is highly recommended that you use the pre-commit hook provided in the pymatgen 
repository. Simply `cp pre-commit .git/hooks` and a check will be run prior to allowing commits.
