### PR TITLE
Add missing elements to MPScanRelaxSet PBE .54 potentials

### DIFF
--- a/pymatgen/io/vasp/MPSCANRelaxSet.yaml
+++ b/pymatgen/io/vasp/MPSCANRelaxSet.yaml
@@ -29,8 +29,10 @@ POTCAR:
   Ac: Ac
   Ag: Ag
   Al: Al
+  Am: Am
   Ar: Ar
   As: As
+  At: At
   Au: Au
   B: B
   Ba: Ba_sv
@@ -41,7 +43,9 @@ POTCAR:
   Ca: Ca_sv
   Cd: Cd
   Ce: Ce
+  Cf: Cf
   Cl: Cl
+  Cm: Cm
   Co: Co
   Cr: Cr_pv
   Cs: Cs_sv
@@ -51,6 +55,7 @@ POTCAR:
   Eu: Eu
   F: F
   Fe: Fe_pv
+  Fr: Fr_sv
   Ga: Ga_d
   Gd: Gd
   Ge: Ge_d
@@ -84,12 +89,15 @@ POTCAR:
   Pb: Pb_d
   Pd: Pd
   Pm: Pm_3
+  Po: Po_d
   Pr: Pr_3
   Pt: Pt
   Pu: Pu
+  Ra: Ra_sv
   Rb: Rb_sv
   Re: Re_pv
   Rh: Rh_pv
+  Rn: Rn
   Ru: Ru_pv
   S: S
   Sb: Sb

--- a/pymatgen/io/vasp/MPSCANRelaxSet.yaml
+++ b/pymatgen/io/vasp/MPSCANRelaxSet.yaml
@@ -1,6 +1,6 @@
 # Default VASP settings for calculations in the Materials Project
-# using the Strongly Constrained and Appropriately Normed (SCAN)
-# functional.
+# using the Regularized-Restored Strongly Constrained and Appropriately
+# Normed functional (r2SCAN).
 PARENT: VASPIncarBase
 INCAR:
   ALGO: ALL

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -42,7 +42,7 @@ class SetChangeCheckTest(PymatgenTest):
             "MVLRelax52Set.yaml": "eb538ffb45c0cd13f13df48afc1e71c44d2e34b2",
             "MPHSERelaxSet.yaml": "2bb969e64b57ff049077c8ec10e64f94c9c97f42",
             "VASPIncarBase.yaml": "19762515f8deefb970f2968fca48a0d67f7964d4",
-            "MPSCANRelaxSet.yaml": "2604952d387f6531bfc37641ac3b1ffcce9f1bc1",
+            "MPSCANRelaxSet.yaml": "dfa9fee19178cb38c6a121ce6096db40693478e8",
             "MPRelaxSet.yaml": "4ea97d776fbdc7e168036f73e9176012a56c0a45",
             "MITRelaxSet.yaml": "1a0970f8cad9417ec810f7ab349dc854eaa67010",
             "vdW_parameters.yaml": "66541f58b221c8966109156f4f651b2ca8aa76da",


### PR DESCRIPTION
@rkingsbury and @mkhorton: Some elements that are currently in the VASP PAW .54 PBE library have defined pseudopotentials but aren't in the `MPScanRelaxSet.yaml` file because they never existed in the original PAW PBE set used in the GGA calculations on MP. This change won't influence anything in your R2SCAN workflow because: a) The jobs would have never run with these elements since no pseudopotentials were defined; b) none of these elements exist on MP right now because of the aforementioned statement.

Most of the elements I added have only one PAW PBE potential to use. In the case of multiple, I used the VASP-recommended set.

I know this breaks the hash for `MPScanRelaxSet.yaml`. It would need your blessing.