### PR TITLE
Add new automatic kpoint scheme that normalizes by lattice lengths

### DIFF
--- a/pymatgen/command_line/bader_caller.py
+++ b/pymatgen/command_line/bader_caller.py
@@ -473,7 +473,7 @@ def bader_analysis_from_path(path, suffix=""):
 
     This method will:
 
-    1. Look for files CHGCAR, AECAR0, AECAR2, POTCAR or their gzipped
+    1. Look for files CHGCAR, AECCAR0, AECCAR2, POTCAR or their gzipped
     counterparts.
     2. If AECCAR* files are present, constructs a temporary reference
     file as AECCAR0 + AECCAR2

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -1310,7 +1310,7 @@ class Kpoints(MSONable):
         Algorithm:
             For a given dimension, the # of k-points is chosen as
             length_density = # of kpoints * lattice constant, e.g. [50.0, 50.0, 1.0] would
-            have k-points of 50/a x 50/b x 1/c].
+            have k-points of 50/a x 50/b x 1/c.
 
         Args:
             structure (Structure): Input structure

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -1310,7 +1310,7 @@ class Kpoints(MSONable):
         Algorithm:
             For a given dimension, the # of k-points is chosen as
             length_density = # of kpoints * lattice constant, e.g. [50.0, 50.0, 1.0] would
-            have a 50:50:1 ratio of k-points along each lattice direction.
+            have k-points of 50/a x 50/b x 1/c].
 
         Args:
             structure (Structure): Input structure
@@ -1321,7 +1321,7 @@ class Kpoints(MSONable):
         Returns:
             Kpoints
         """
-        comment = f"Length-based k-point density of {length_densities}/A"
+        comment = f"k-point density of {length_densities}/[a, b, c]"
         lattice = structure.lattice
         abc = lattice.abc
         num_div = [

--- a/pymatgen/io/vasp/tests/test_inputs.py
+++ b/pymatgen/io/vasp/tests/test_inputs.py
@@ -783,6 +783,9 @@ Cartesian
         kpoints = Kpoints.automatic_density_by_vol(poscar.structure, 1000)
         self.assertEqual(kpoints.kpts, [[6, 10, 13]])
         self.assertEqual(kpoints.style, Kpoints.supported_modes.Gamma)
+        kpoints = Kpoints.automatic_density_by_lengths(poscar.structure, [50, 50, 1], True)
+        self.assertEqual(kpoints.kpts, [[5, 9, 1]])
+        self.assertEqual(kpoints.style, Kpoints.supported_modes.Gamma)
 
         s = poscar.structure
         s.make_supercell(3)


### PR DESCRIPTION
## Summary
This PR creates a new automatic k-point generation scheme, `automatic_density_by_lengths`, which allows the user to specify a density of k-points in each dimension (rather than just for the entire volume). This is particularly important for slab calculations, because you almost always want 1 k-point in the vacuum dimension but don't want the vacuum space volume to influence your k-point generation otherwise.

For instance, doing `automatic_density_by_lengths(struct, [50, 50, 1])` would specify a k-point density of 50/a x 50/b x 1/c, with each rounded up to the next integer.

This is a more general implementation of the k-point scheme used in `MVLSlabSet` (reproduced below) and can be found in several papers from the Persson group, such as [this one](https://www.nature.com/articles/s41467-019-08356-1#Sec7).
https://github.com/materialsproject/pymatgen/blob/fcb84a1e129da3a3010b9f6b9cf18beddf39f245/pymatgen/io/vasp/sets.py#L2213-L2244

Tagging @oxana-a, @mhsiron in case they're curious.