### PR TITLE
Fix CI status badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 .. image:: https://github.com/materialsproject/pymatgen/actions/workflows/test.yml/badge.svg
       :alt: CI Status
-      :target: https://github.com/materialsproject/pymatgen/actions/workflows/test.yml
+      :target: https://github.com/materialsproject/pymatgen/actions/workflows/test-linux.yml
 
 .. image:: https://anaconda.org/conda-forge/pymatgen/badges/downloads.svg
       :alt: Conda Downloads


### PR DESCRIPTION
The CI status badge isn't loading on the README because the test workflow got renamed. This should fix it.