### PR TITLE
Don't perform dict type-check on the MAGMOM flag in io.vasp.sets (fixes downstream Atomate issue)

### DIFF
--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -502,13 +502,10 @@ class DictSet(VaspInputSet):
 
         for k, v in settings.items():
             if k == "MAGMOM":
+                if isinstance(v, list):
+                    incar[k] = v
+                    continue
                 mag = []
-                if v and not isinstance(v, dict):
-                    raise TypeError(
-                        "MAGMOM must be supplied in a dictionary format, e.g. {'Fe': 5}. "
-                        "If you want site-specific magnetic moments, set them in the site magmom properties "
-                        "of the site objects in the structure."
-                    )
                 for site in structure:
                     if hasattr(site, "magmom"):
                         mag.append(site.magmom)

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -502,9 +502,6 @@ class DictSet(VaspInputSet):
 
         for k, v in settings.items():
             if k == "MAGMOM":
-                if isinstance(v, list):
-                    incar[k] = v
-                    continue
                 mag = []
                 for site in structure:
                     if hasattr(site, "magmom"):

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -503,13 +503,13 @@ class DictSet(VaspInputSet):
         for k, v in settings.items():
             if k == "MAGMOM":
                 mag = []
+                if v and not isinstance(v, dict):
+                    raise TypeError(
+                        "MAGMOM must be supplied in a dictionary format, e.g. {'Fe': 5}. "
+                        "If you want site-specific magnetic moments, set them in the site magmom properties "
+                        "of the site objects in the structure."
+                    )
                 for site in structure:
-                    if v and not isinstance(v, dict):
-                        raise TypeError(
-                            "MAGMOM must be supplied in a dictionary format, e.g. {'Fe': 5}. "
-                            "If you want site-specific magnetic moments, set them in the site magmom properties "
-                            "of the site objects in the structure."
-                        )
                     if hasattr(site, "magmom"):
                         mag.append(site.magmom)
                     elif hasattr(site.specie, "spin"):

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -256,6 +256,13 @@ class MITMPRelaxSetTest(PymatgenTest):
         incar = MITRelaxSet(struct).incar
         self.assertEqual(incar["LDAUU"], [4.0, 0])
 
+        # This seems counterintuitive at first, but even if the prior INCAR has a MAGMOM flag,
+        # because the structure has no site properties, the default MAGMOM is assigned from the
+        # config dictionary.
+        struct = Structure(lattice, ["Fe", "F"], coords)
+        incar = MPRelaxSet(struct, prev_incar=os.path.join(self.TEST_FILES_DIR, "INCAR")).incar
+        self.assertEqual(incar["MAGMOM"], [5, 0.6])
+
         # Make sure this works with species.
         struct = Structure(lattice, ["Fe2+", "O2-"], coords)
         incar = MPRelaxSet(struct).incar
@@ -271,10 +278,6 @@ class MITMPRelaxSetTest(PymatgenTest):
         struct = Structure(lattice, [Species("Fe", 2, {"spin": 4.1}), "Mn"], coords)
         incar = MPRelaxSet(struct).incar
         self.assertEqual(incar["MAGMOM"], [5, 4.1])
-
-        struct = Structure(lattice, [Species("Fe", 2, {"spin": 4.1}), "Mn"], coords)
-        incar = MPRelaxSet(struct, user_incar_settings={"MAGMOM": [1.0, 1.0]}).incar
-        self.assertEqual(incar["MAGMOM"], [1.0, 1.0])
 
         struct = Structure(lattice, ["Mn3+", "Mn4+"], coords)
         incar = MITRelaxSet(struct).incar
@@ -522,16 +525,6 @@ class MITMPRelaxSetTest(PymatgenTest):
                 user_incar_settings={"MAGMOM": {"Fe": 5.1}},
                 user_potcar_settings={"Fe": "Fe"},
                 constrain_total_magmom=True,
-            )
-            vis.incar.items()
-
-        # Test the behavior of passing in the wrong type of MAGMOM to user_incar_settings
-        struct = self.structure.copy()
-        with pytest.raises(TypeError, match=r"MAGMOM must be supplied"):
-            vis = MPRelaxSet(
-                struct,
-                user_incar_settings={"MAGMOM": [5.0, 5.0]},
-                user_potcar_settings={"Fe": "Fe"},
             )
             vis.incar.items()
 

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -272,6 +272,10 @@ class MITMPRelaxSetTest(PymatgenTest):
         incar = MPRelaxSet(struct).incar
         self.assertEqual(incar["MAGMOM"], [5, 4.1])
 
+        struct = Structure(lattice, [Species("Fe", 2, {"spin": 4.1}), "Mn"], coords)
+        incar = MPRelaxSet(struct, user_incar_settings={"MAGMOM": [1.0, 1.0]}).incar
+        self.assertEqual(incar["MAGMOM"], [1.0, 1.0])
+
         struct = Structure(lattice, ["Mn3+", "Mn4+"], coords)
         incar = MITRelaxSet(struct).incar
         self.assertEqual(incar["MAGMOM"], [4, 3])

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -260,7 +260,7 @@ class MITMPRelaxSetTest(PymatgenTest):
         # because the structure has no site properties, the default MAGMOM is assigned from the
         # config dictionary.
         struct = Structure(lattice, ["Fe", "F"], coords)
-        incar = MPRelaxSet(struct, prev_incar=os.path.join(self.TEST_FILES_DIR, "INCAR")).incar
+        incar = MPStaticSet(struct, prev_incar=os.path.join(self.TEST_FILES_DIR, "INCAR")).incar
         self.assertEqual(incar["MAGMOM"], [5, 0.6])
 
         # Make sure this works with species.


### PR DESCRIPTION
- Addresses https://github.com/materialsproject/pymatgen/commit/9cfef441c16fd4c68290b80bb0383d52a0a8c0fe#r64164646 by reverting the type-check on the MAGMOM key-value pair.