### PR TITLE
Pass oxidation states between Pymatgen structure/molecule and ASE Atoms

### DIFF
--- a/pymatgen/io/ase.py
+++ b/pymatgen/io/ase.py
@@ -69,13 +69,32 @@ class AseAtomsAdaptor:
         # Note: ASE distinguishes between initial and converged
         # magnetic moment site properties, whereas pymatgen does not. Therefore, we
         # have to distinguish between "magmom" and an "initial_magmom" site property.
-        if "magmom" in structure.site_properties:
-            magmoms = structure.site_properties["magmom"]
-            calc = SinglePointDFTCalculator(atoms, **{"magmoms": magmoms})
-            atoms.calc = calc
         if "initial_magmom" in structure.site_properties:
             initial_magmoms = structure.site_properties["initial_magmom"]
             atoms.set_initial_magnetic_moments(initial_magmoms)
+        if "initial_charge" in structure.site_properties:
+            initial_charges = structure.site_properties["initial_charge"]
+            atoms.set_initial_charges(initial_charges)
+
+        if "magmom" in structure.site_properties:
+            magmoms = structure.site_properties["magmom"]
+        else:
+            magmoms = None
+        if "charge" in structure.site_properties:
+            charges = structure.site_properties["charge"]
+        else:
+            charges = None
+        if magmoms or charges:
+            if magmoms and charges:
+                calc = SinglePointDFTCalculator(atoms, **{"magmoms": magmoms, "charges": charges})
+            elif magmoms:
+                calc = SinglePointDFTCalculator(atoms, **{"magmoms": magmoms})
+            elif charges:
+                calc = SinglePointDFTCalculator(atoms, **{"charges": charges})
+            atoms.calc = calc
+
+        # Get the oxidation states from the structure
+        oxi_states = [getattr(site.specie, "oxi_state", None) for site in structure]
 
         # Read in selective dynamics if present. Note that the ASE FixAtoms class fixes (x,y,z), so
         # here we make sure that [False, False, False] or [True, True, True] is set for the site selective
@@ -101,8 +120,10 @@ class AseAtomsAdaptor:
 
         # Add any remaining site properties to the ASE Atoms object
         for prop in structure.site_properties:
-            if prop not in ["magmom", "initial_magmom", "selective_dynamics"]:
+            if prop not in ["magmom", "charge", "initial_magmom", "initial_charge", "selective_dynamics"]:
                 atoms.set_array(prop, np.array(structure.site_properties[prop]))
+        if np.any(oxi_states):
+            atoms.set_array("oxi_states", np.array(oxi_states))
 
         return atoms
 
@@ -128,13 +149,23 @@ class AseAtomsAdaptor:
         # Get the site magmoms from the ASE Atoms objects.
         if getattr(atoms, "calc", None) is not None and getattr(atoms.calc, "results", None) is not None:
             magmoms = atoms.calc.results.get("magmoms", None)
+            charges = atoms.calc.results.get("charges", None)
         else:
             magmoms = None
+            charges = None
 
         if atoms.has("initial_magmoms"):
             initial_magmoms = atoms.get_initial_magnetic_moments()
         else:
             initial_magmoms = None
+        if atoms.has("initial_charges"):
+            initial_charges = atoms.get_initial_charges()
+        else:
+            initial_charges = None
+        if atoms.has("oxi_states"):
+            oxi_states = atoms.get_array("oxi_states")
+        else:
+            oxi_states = None
 
         # If the ASE Atoms object has constraints, make sure that they are of the
         # kind FixAtoms, which are the only ones that can be supported in Pymatgen.
@@ -168,12 +199,28 @@ class AseAtomsAdaptor:
             structure.add_site_property("magmom", magmoms)
         if initial_magmoms is not None:
             structure.add_site_property("initial_magmom", initial_magmoms)
+        if charges is not None:
+            structure.add_site_property("charge", charges)
+        if initial_charges is not None:
+            structure.add_site_property("initial_charge", initial_charges)
         if sel_dyn is not None and ~np.all(sel_dyn):
             structure.add_site_property("selective_dynamics", sel_dyn)
 
+        # Add oxidation states by site
+        if oxi_states is not None:
+            structure.add_oxidation_state_by_site(oxi_states)
+
         # Add any remaining site properties to the Pymatgen structure object
         for prop in atoms.arrays:
-            if prop not in ["numbers", "positions", "magmom", "initial_magmom"]:
+            if prop not in [
+                "numbers",
+                "positions",
+                "magmom",
+                "initial_magmom",
+                "charge",
+                "initial_charge",
+                "oxi_states",
+            ]:
                 structure.add_site_property(prop, atoms.get_array(prop).tolist())
 
         return structure

--- a/pymatgen/io/tests/test_ase.py
+++ b/pymatgen/io/tests/test_ase.py
@@ -25,6 +25,7 @@ class AseAtomsAdaptorTest(unittest.TestCase):
         self.assertTrue(atoms.get_pbc() is not None and atoms.get_pbc().all())
         self.assertEqual(atoms.get_chemical_symbols(), [s.species_string for s in structure])
         self.assertFalse(atoms.has("initial_magmoms"))
+        self.assertTrue(atoms.calc is None)
 
         p = Poscar.from_file(os.path.join(PymatgenTest.TEST_FILES_DIR, "POSCAR"))
         structure = p.structure
@@ -45,12 +46,56 @@ class AseAtomsAdaptorTest(unittest.TestCase):
 
         p = Poscar.from_file(os.path.join(PymatgenTest.TEST_FILES_DIR, "POSCAR"))
         structure = p.structure
+        initial_mags = [0.5] * len(structure)
+        structure.add_site_property("initial_magmom", initial_mags)
+        atoms = aio.AseAtomsAdaptor.get_atoms(structure)
+        self.assertEqual(atoms.get_initial_magnetic_moments().tolist(), initial_mags)
+
+        p = Poscar.from_file(os.path.join(PymatgenTest.TEST_FILES_DIR, "POSCAR"))
+        structure = p.structure
         mags = [1.0] * len(structure)
         structure.add_site_property("magmom", mags)
         initial_mags = [2.0] * len(structure)
         structure.add_site_property("initial_magmom", initial_mags)
         atoms = aio.AseAtomsAdaptor.get_atoms(structure)
         self.assertTrue(atoms.get_initial_magnetic_moments().tolist(), initial_mags)
+        self.assertTrue(atoms.get_magnetic_moments().tolist(), mags)
+
+    @unittest.skipIf(not aio.ase_loaded, "ASE not loaded.")
+    def test_get_atoms_from_structure_charge(self):
+        p = Poscar.from_file(os.path.join(PymatgenTest.TEST_FILES_DIR, "POSCAR"))
+        structure = p.structure
+        charges = [1.0] * len(structure)
+        structure.add_site_property("charge", charges)
+        atoms = aio.AseAtomsAdaptor.get_atoms(structure)
+        self.assertFalse(atoms.has("initial_charges"))
+        self.assertEqual(atoms.get_charges().tolist(), charges)
+
+        p = Poscar.from_file(os.path.join(PymatgenTest.TEST_FILES_DIR, "POSCAR"))
+        structure = p.structure
+        initial_charges = [0.5] * len(structure)
+        structure.add_site_property("initial_charge", initial_charges)
+        atoms = aio.AseAtomsAdaptor.get_atoms(structure)
+        self.assertEqual(atoms.get_initial_charges().tolist(), initial_charges)
+
+        p = Poscar.from_file(os.path.join(PymatgenTest.TEST_FILES_DIR, "POSCAR"))
+        structure = p.structure
+        charges = [1.0] * len(structure)
+        structure.add_site_property("charge", charges)
+        initial_charges = [2.0] * len(structure)
+        structure.add_site_property("initial_charge", initial_charges)
+        atoms = aio.AseAtomsAdaptor.get_atoms(structure)
+        self.assertTrue(atoms.get_initial_charges().tolist(), initial_charges)
+        self.assertTrue(atoms.get_charges().tolist(), charges)
+
+    @unittest.skipIf(not aio.ase_loaded, "ASE not loaded.")
+    def test_get_atoms_from_structure_oxistates(self):
+        p = Poscar.from_file(os.path.join(PymatgenTest.TEST_FILES_DIR, "POSCAR"))
+        structure = p.structure
+        oxi_states = [1.0] * len(structure)
+        structure.add_oxidation_state_by_site(oxi_states)
+        atoms = aio.AseAtomsAdaptor.get_atoms(structure)
+        self.assertEqual(atoms.get_array("oxi_states").tolist(), oxi_states)
 
     @unittest.skipIf(not aio.ase_loaded, "ASE not loaded.")
     def test_get_atoms_from_structure_dyn(self):
@@ -70,6 +115,7 @@ class AseAtomsAdaptorTest(unittest.TestCase):
         self.assertTrue(atoms.get_pbc() is None or not atoms.get_pbc().any())
         self.assertEqual(atoms.get_chemical_symbols(), [s.species_string for s in m])
         self.assertFalse(atoms.has("initial_magmoms"))
+        self.assertTrue(atoms.calc is None)
 
     @unittest.skipIf(not aio.ase_loaded, "ASE not loaded.")
     def test_get_atoms_from_molecule_mags(self):
@@ -80,6 +126,13 @@ class AseAtomsAdaptorTest(unittest.TestCase):
         atoms = aio.AseAtomsAdaptor.get_atoms(molecule)
         self.assertFalse(atoms.has("initial_magmoms"))
         self.assertEqual(atoms.get_magnetic_moments().tolist(), mags)
+
+        molecule = Molecule.from_file(os.path.join(PymatgenTest.TEST_FILES_DIR, "acetylene.xyz"))
+        atoms = aio.AseAtomsAdaptor.get_atoms(molecule)
+        initial_mags = [0.5] * len(molecule)
+        molecule.add_site_property("initial_magmom", initial_mags)
+        atoms = aio.AseAtomsAdaptor.get_atoms(molecule)
+        self.assertEqual(atoms.get_initial_magnetic_moments().tolist(), initial_mags)
 
     @unittest.skipIf(not aio.ase_loaded, "ASE not loaded.")
     def test_get_atoms_from_molecule_dyn(self):
@@ -140,11 +193,41 @@ class AseAtomsAdaptorTest(unittest.TestCase):
         self.assertEqual(molecule.spin_multiplicity, 1)
 
         atoms = read(os.path.join(PymatgenTest.TEST_FILES_DIR, "acetylene.xyz"))
-        atoms.set_initial_charges([1.0] * len(atoms))
-        atoms.set_initial_magnetic_moments([1.0] * len(atoms))
+        initial_charges = [2.0] * len(atoms)
+        initial_mags = [1.0] * len(atoms)
+        atoms.set_initial_charges(initial_charges)
+        atoms.set_initial_magnetic_moments(initial_mags)
         molecule = aio.AseAtomsAdaptor.get_molecule(atoms)
-        self.assertEqual(molecule.charge, np.sum([1.0] * len(atoms)))
-        self.assertEqual(molecule.spin_multiplicity, np.sum([1.0] * len(atoms)) + 1)
+        self.assertEqual(molecule.charge, np.sum(initial_charges))
+        self.assertEqual(molecule.spin_multiplicity, np.sum(initial_mags) + 1)
+        self.assertEqual(molecule.site_properties.get("initial_charge", None), initial_charges)
+        self.assertEqual(molecule.site_properties.get("initial_magmom", None), initial_mags)
+
+    @unittest.skipIf(not aio.ase_loaded, "ASE not loaded.")
+    def test_back_forth(self):
+        from ase.io import read
+        from ase.constraints import FixAtoms
+
+        atoms = read(os.path.join(PymatgenTest.TEST_FILES_DIR, "OUTCAR"))
+        atoms.set_constraint(FixAtoms(mask=[True] * len(atoms)))
+        atoms.set_initial_charges([1.0] * len(atoms))
+        atoms.set_initial_magnetic_moments([2.0] * len(atoms))
+        atoms.set_array("prop", np.array([3.0] * len(atoms)))
+        structure = aio.AseAtomsAdaptor.get_structure(atoms)
+        atoms_back = aio.AseAtomsAdaptor.get_atoms(structure)
+        structure_back = aio.AseAtomsAdaptor.get_structure(atoms)
+        self.assertEqual(structure, structure_back)
+
+        atoms = read(os.path.join(PymatgenTest.TEST_FILES_DIR, "acetylene.xyz"))
+        atoms.set_constraint(FixAtoms(mask=[True] * len(atoms)))
+        atoms.set_initial_charges([1.0] * len(atoms))
+        atoms.set_initial_magnetic_moments([2.0] * len(atoms))
+        atoms.set_array("prop", np.array([3.0] * len(atoms)))
+        molecule = aio.AseAtomsAdaptor.get_molecule(atoms)
+        atoms_back = aio.AseAtomsAdaptor.get_atoms(molecule)
+        self.assertEqual(atoms, atoms_back)
+        molecule_back = aio.AseAtomsAdaptor.get_molecule(atoms)
+        self.assertEqual(molecule, molecule_back)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This hopefully should be my last update in my quest to enhance the `AseAtomsAdaptor`. 

In this PR:
1. Oxidation states are now passed from Pymatgen structure/molecule objects to ASE atoms objects. Since these aren't `site_properties`, they never got transferred. This is the main change.
2. Charges passed from Pymatgen to ASE now get assigned "intelligently" in the ASE Atoms object such that the ASE-recommended `atoms.get_charges()` function retrieves them.
3. Several new tests have been added to the test suite, most importantly a check that doing Atoms --> Structure --> Atoms as well as Structure --> Atoms --> Structure result in identical objects before/after the transformation cycle. This is an important check that was missing, as it's very easy for a property to be lost in the translation if not coded appropriately. This will also help future-proof the module if/when others make changes.