### PR TITLE
Autoflake

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,11 +6,6 @@ repos:
     hooks:
       - id: black
 
-  - repo: https://github.com/pre-commit/mirrors-pylint
-    rev: v3.0.0a4
-    hooks:
-      - id: pylint
-
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.1.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,3 +38,4 @@ repos:
           - --remove-unused-variables
           - --remove-all-unused-imports
           - --expand-star-imports
+          - --ignore-init-module-imports

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,7 @@ v2022.1.20
 * YAML deprecation fixes. (@janosh)
 * ASE adaptor support for charge, spin multiiciplity and site properties of molecules. (@arosen93).
 * New keyword option (`keep_site_properties`) in various `structure.symmetry.analyzer` functions to keep the site properties on the sites after a transformation. (@arosen93)
-* Bug fixes for Lobster module (@JaGeo). 
+* Bug fixes for Lobster module (@JaGeo).
 * SCAN / GGA(+U) mixing scheme (@rkingsbury). Mixing scheme code lives in the new file `mixing_scheme.py` and is implemented as a `Compatibility` class.
 * Fix for parsing of QuantumExpresso files due to new format (@vorwerkc)
 
@@ -781,7 +781,7 @@ v2018.9.30
 * Fix: Outcar parsing issues with certain values of electrostatic potential (@sivonxay)
 * Fix: bug in EnumlibAdaptor/EnumerateStructureTransformation involving incorrect
   stoichiometries in some instances (#1286) (@shyuep)
-* Fix: fractional co-ordinate finite precision errors in CifParser, now
+* Fix: fractional coordinate finite precision errors in CifParser, now
   also includes additional warnings for implicit hydrogens (@mkhorton)
 * New features and improvements to GBGenerator (@ucsdlxg, @shyuep)
 * New analysis options in StructureGraph, speed up tests (@mkhorton)

--- a/docs_rst/change_log.rst
+++ b/docs_rst/change_log.rst
@@ -11,7 +11,7 @@ v2022.1.20
 * YAML deprecation fixes. (@janosh)
 * ASE adaptor support for charge, spin multiiciplity and site properties of molecules. (@arosen93).
 * New keyword option (`keep_site_properties`) in various `structure.symmetry.analyzer` functions to keep the site properties on the sites after a transformation. (@arosen93)
-* Bug fixes for Lobster module (@JaGeo). 
+* Bug fixes for Lobster module (@JaGeo).
 * SCAN / GGA(+U) mixing scheme (@rkingsbury). Mixing scheme code lives in the new file `mixing_scheme.py` and is implemented as a `Compatibility` class.
 * Fix for parsing of QuantumExpresso files due to new format (@vorwerkc)
 
@@ -781,7 +781,7 @@ v2018.9.30
 * Fix: Outcar parsing issues with certain values of electrostatic potential (@sivonxay)
 * Fix: bug in EnumlibAdaptor/EnumerateStructureTransformation involving incorrect
   stoichiometries in some instances (#1286) (@shyuep)
-* Fix: fractional co-ordinate finite precision errors in CifParser, now
+* Fix: fractional coordinate finite precision errors in CifParser, now
   also includes additional warnings for implicit hydrogens (@mkhorton)
 * New features and improvements to GBGenerator (@ucsdlxg, @shyuep)
 * New analysis options in StructureGraph, speed up tests (@mkhorton)

--- a/pymatgen/alchemy/filters.py
+++ b/pymatgen/alchemy/filters.py
@@ -317,7 +317,6 @@ class ChargeBalanceFilter(AbstractStructureFilter):
         """
         No args required.
         """
-        pass
 
     def test(self, structure):
         """

--- a/pymatgen/analysis/bond_dissociation.py
+++ b/pymatgen/analysis/bond_dissociation.py
@@ -326,7 +326,7 @@ class BondDissociationEnergies(MSONable):
             entry["final_molgraph"] = MoleculeGraph.with_local_env_strategy(
                 Molecule.from_dict(entry["final_molecule"]), OpenBabelNN()
             )
-            # Classify any potential structural change that occured during optimization:
+            # Classify any potential structural change that occurred during optimization:
             if entry["initial_molgraph"].isomorphic_to(entry["final_molgraph"]):
                 entry["structure_change"] = "no_change"
             else:

--- a/pymatgen/analysis/chemenv/connectivity/tests/test_environment_nodes.py
+++ b/pymatgen/analysis/chemenv/connectivity/tests/test_environment_nodes.py
@@ -4,14 +4,8 @@
 __author__ = "waroquiers"
 
 import os
-import shutil
 
-import networkx as nx
-
-from pymatgen.analysis.chemenv.connectivity.environment_nodes import (
-    EnvironmentNode,
-    get_environment_node,
-)
+from pymatgen.analysis.chemenv.connectivity.environment_nodes import EnvironmentNode
 from pymatgen.util.testing import PymatgenTest
 
 try:

--- a/pymatgen/analysis/chemenv/coordination_environments/tests/test_voronoi.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/tests/test_voronoi.py
@@ -5,7 +5,6 @@ __author__ = "waroquiers"
 
 import os
 import random
-import shutil
 import unittest
 
 import numpy as np

--- a/pymatgen/analysis/chemenv/coordination_environments/tests/test_weights.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/tests/test_weights.py
@@ -36,8 +36,6 @@ class FakeNbSet:
     def __len__(self):
         return self.cn
 
-    pass
-
 
 class DummyStructureEnvironments:
     pass

--- a/pymatgen/analysis/chemenv/utils/tests/test_chemenv_config.py
+++ b/pymatgen/analysis/chemenv/utils/tests/test_chemenv_config.py
@@ -4,7 +4,6 @@
 __author__ = "waroquiers"
 
 import os
-import shutil
 import unittest
 
 from monty.tempfile import ScratchDir

--- a/pymatgen/analysis/defects/defect_compatibility.py
+++ b/pymatgen/analysis/defects/defect_compatibility.py
@@ -253,7 +253,7 @@ class DefectCompatibility(MSONable):
             try:
                 defect_entry = self.perform_kumagai(defect_entry)
             except Exception:
-                logger.info("Kumagai correction error occured! Wont perform correction.")
+                logger.info("Kumagai correction error occurred! Wont perform correction.")
 
         # add potalign based on preferred correction setting if it does not already exist in defect entry
         if self.preferred_cc == "freysoldt":

--- a/pymatgen/analysis/diffraction/core.py
+++ b/pymatgen/analysis/diffraction/core.py
@@ -72,7 +72,6 @@ class AbstractDiffractionPatternCalculator(abc.ABC):
         Returns:
             (DiffractionPattern)
         """
-        pass
 
     def get_plot(
         self,

--- a/pymatgen/analysis/diffraction/tests/test_neutron.py
+++ b/pymatgen/analysis/diffraction/tests/test_neutron.py
@@ -3,7 +3,6 @@
 
 import unittest
 
-import matplotlib as mpl
 
 from pymatgen.analysis.diffraction.neutron import NDCalculator
 from pymatgen.core.lattice import Lattice

--- a/pymatgen/analysis/elasticity/tests/test_stress.py
+++ b/pymatgen/analysis/elasticity/tests/test_stress.py
@@ -1,5 +1,4 @@
 import unittest
-import warnings
 
 import numpy as np
 

--- a/pymatgen/analysis/eos.py
+++ b/pymatgen/analysis/eos.py
@@ -102,7 +102,7 @@ class EOSBase(metaclass=ABCMeta):
 
     def func(self, volume):
         """
-        The equation of state function with the paramters other than volume set
+        The equation of state function with the parameters other than volume set
         to the ones obtained from fitting.
 
         Args:

--- a/pymatgen/analysis/ferroelectricity/tests/test_polarization.py
+++ b/pymatgen/analysis/ferroelectricity/tests/test_polarization.py
@@ -1,11 +1,12 @@
 import os
 import unittest
 
+import numpy as np
+
 from pymatgen.analysis.ferroelectricity.polarization import (
     EnergyTrend,
     Polarization,
     get_total_ionic_dipole,
-    np,
     zval_dict_from_potcar,
 )
 from pymatgen.core.structure import Structure

--- a/pymatgen/analysis/ferroelectricity/tests/test_polarization.py
+++ b/pymatgen/analysis/ferroelectricity/tests/test_polarization.py
@@ -1,7 +1,13 @@
 import os
 import unittest
 
-from pymatgen.analysis.ferroelectricity.polarization import *
+from pymatgen.analysis.ferroelectricity.polarization import (
+    EnergyTrend,
+    Polarization,
+    get_total_ionic_dipole,
+    np,
+    zval_dict_from_potcar,
+)
 from pymatgen.core.structure import Structure
 from pymatgen.io.vasp.inputs import Potcar
 from pymatgen.io.vasp.outputs import Outcar

--- a/pymatgen/analysis/interfaces/__init__.py
+++ b/pymatgen/analysis/interfaces/__init__.py
@@ -1,4 +1,7 @@
-""" Module that implements various algorithms related to interface construction and analysis """
+"""
+Module that implements various algorithms related to interface construction and analysis
+"""
+
 from pymatgen.analysis.interfaces.coherent_interfaces import CoherentInterfaceBuilder
 from pymatgen.analysis.interfaces.substrate_analyzer import (
     SubstrateAnalyzer,

--- a/pymatgen/analysis/interfaces/tests/test_coherent_interface.py
+++ b/pymatgen/analysis/interfaces/tests/test_coherent_interface.py
@@ -10,7 +10,6 @@ from pymatgen.analysis.interfaces.coherent_interfaces import (
     get_2d_transform,
     get_rot_3d_for_2d,
 )
-from pymatgen.core.surface import SlabGenerator
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.util.testing import PymatgenTest
 

--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -579,7 +579,7 @@ class NearNeighbors:
         the given site whose ideal CN corresponds to the
         underlying motif (e.g., CN=4, then calculate the
         square planar, tetrahedral, see-saw-like,
-        rectangular see-saw-like order paramters).
+        rectangular see-saw-like order parameters).
 
         Args:
             structure: Structure object
@@ -1968,7 +1968,7 @@ def get_okeeffe_params(el_symbol):
     if el not in list(BV_PARAMS.keys()):
         raise RuntimeError(
             "Could not find O'Keeffe parameters for element"
-            ' "{}" in "BV_PARAMS"dictonary'
+            ' "{}" in "BV_PARAMS"dictionary'
             " provided by pymatgen".format(el_symbol)
         )
 

--- a/pymatgen/analysis/magnetism/analyzer.py
+++ b/pymatgen/analysis/magnetism/analyzer.py
@@ -598,7 +598,7 @@ class CollinearMagneticStructureAnalyzer:
 
     def __str__(self):
         """
-        Sorts a Structure (by fractional co-ordinate), and
+        Sorts a Structure (by fractional coordinate), and
         prints sites with magnetic information. This is
         useful over Structure.__str__ because sites are in
         a consistent order, which makes visual comparison between

--- a/pymatgen/analysis/magnetism/tests/test_analyzer.py
+++ b/pymatgen/analysis/magnetism/tests/test_analyzer.py
@@ -4,6 +4,7 @@
 import os
 import unittest
 
+import numpy as np
 from monty.os.path import which
 
 from pymatgen.analysis.magnetism import (
@@ -12,7 +13,6 @@ from pymatgen.analysis.magnetism import (
     Ordering,
     loadfn,
     magnetic_deformation,
-    np,
     warnings,
 )
 from pymatgen.core import Element, Lattice, Species, Structure

--- a/pymatgen/analysis/magnetism/tests/test_analyzer.py
+++ b/pymatgen/analysis/magnetism/tests/test_analyzer.py
@@ -6,7 +6,15 @@ import unittest
 
 from monty.os.path import which
 
-from pymatgen.analysis.magnetism import *
+from pymatgen.analysis.magnetism import (
+    CollinearMagneticStructureAnalyzer,
+    MagneticStructureEnumerator,
+    Ordering,
+    loadfn,
+    magnetic_deformation,
+    np,
+    warnings,
+)
 from pymatgen.core import Element, Lattice, Species, Structure
 from pymatgen.io.cif import CifParser
 from pymatgen.util.testing import PymatgenTest
@@ -78,7 +86,7 @@ class CollinearMagneticStructureAnalyzerTest(unittest.TestCase):
         self.assertEqual(Fe_spin[0].specie.spin, 5)
 
         # test we can remove magnetic moment information
-        Fe_none = msa.get_nonmagnetic_structure()
+        msa.get_nonmagnetic_structure()
         self.assertFalse("magmom" in Fe_spin.site_properties)
 
         # test with disorder on magnetic site
@@ -153,7 +161,7 @@ class CollinearMagneticStructureAnalyzerTest(unittest.TestCase):
         s1_magmoms_ref = [5.0, 0.0]
         self.assertListEqual(s1_magmoms, s1_magmoms_ref)
 
-        msa2 = CollinearMagneticStructureAnalyzer(self.NiO_AFM_111, overwrite_magmom_mode="replace_all_if_undefined")
+        _ = CollinearMagneticStructureAnalyzer(self.NiO_AFM_111, overwrite_magmom_mode="replace_all_if_undefined")
         s2 = msa.get_ferromagnetic_structure(make_primitive=False)
         s2_magmoms = [float(m) for m in s2.site_properties["magmom"]]
         s2_magmoms_ref = [5.0, 0.0]

--- a/pymatgen/analysis/magnetism/tests/test_jahnteller.py
+++ b/pymatgen/analysis/magnetism/tests/test_jahnteller.py
@@ -3,7 +3,7 @@
 
 import unittest
 
-from pymatgen.analysis.magnetism.jahnteller import *
+from pymatgen.analysis.magnetism.jahnteller import JahnTellerAnalyzer, Species, np, os
 from pymatgen.io.cif import CifParser
 from pymatgen.util.testing import PymatgenTest
 

--- a/pymatgen/analysis/magnetism/tests/test_jahnteller.py
+++ b/pymatgen/analysis/magnetism/tests/test_jahnteller.py
@@ -1,9 +1,12 @@
 # Copyright (c) Pymatgen Development Team.
 # Distributed under the terms of the MIT License.
 
+import os
 import unittest
 
-from pymatgen.analysis.magnetism.jahnteller import JahnTellerAnalyzer, Species, np, os
+import numpy as np
+
+from pymatgen.analysis.magnetism.jahnteller import JahnTellerAnalyzer, Species
 from pymatgen.io.cif import CifParser
 from pymatgen.util.testing import PymatgenTest
 

--- a/pymatgen/analysis/molecule_matcher.py
+++ b/pymatgen/analysis/molecule_matcher.py
@@ -69,7 +69,6 @@ class AbstractMolAtomMapper(MSONable, metaclass=abc.ABCMeta):
             order.
             (None, None) if unform atom is not available.
         """
-        pass
 
     @abc.abstractmethod
     def get_molecule_hash(self, mol):
@@ -83,7 +82,6 @@ class AbstractMolAtomMapper(MSONable, metaclass=abc.ABCMeta):
         Returns:
             A hashable object. Examples can be string formulas, etc.
         """
-        pass
 
     @classmethod
     def from_dict(cls, d):

--- a/pymatgen/analysis/molecule_structure_comparator.py
+++ b/pymatgen/analysis/molecule_structure_comparator.py
@@ -3,7 +3,7 @@
 
 
 """
-This module provides classes to comparsion the structures of the two
+This module provides classes to comparison the structures of the two
 molecule. As long as the two molecule have the same bond connection tables,
 the molecules are deemed to be same. The atom in the two molecule must be
 paired accordingly.
@@ -194,7 +194,7 @@ class MoleculeStructureComparator(MSONable):
 
         Args:
             mol1: first molecule. pymatgen Molecule object.
-            mol2: second moleculs. pymatgen Molecule objec.
+            mol2: second molecules. pymatgen Molecule object.
         """
         b1 = set(self._get_bonds(mol1))
         b2 = set(self._get_bonds(mol2))

--- a/pymatgen/analysis/nmr.py
+++ b/pymatgen/analysis/nmr.py
@@ -65,7 +65,7 @@ class ChemicalShielding(SquareTensor):
     def principal_axis_system(self):
         """
         Returns a chemical shielding tensor aligned to the principle axis system
-        so that only the 3 diagnol components are non-zero
+        so that only the 3 diagonal components are non-zero
         """
         return ChemicalShielding(np.diag(np.sort(np.linalg.eigvals(self.symmetrized))))
 
@@ -160,7 +160,7 @@ class ElectricFieldGradient(SquareTensor):
     @property
     def principal_axis_system(self):
         """
-        Returns a electric field gradient tensor aligned to the principle axis system so that only the 3 diagnol
+        Returns a electric field gradient tensor aligned to the principle axis system so that only the 3 diagonal
         components are non-zero
         """
         return ElectricFieldGradient(np.diag(np.sort(np.linalg.eigvals(self))))
@@ -201,13 +201,13 @@ class ElectricFieldGradient(SquareTensor):
 
     def coupling_constant(self, specie):
         """
-        Computes the couplling constant C_q as defined in:
+        Computes the coupling constant C_q as defined in:
             Wasylishen R E, Ashbrook S E, Wimperis S. NMR of quadrupolar nuclei
             in solid materials[M]. John Wiley & Sons, 2012. (Chapter 3.2)
 
         C_q for a specific atom type for this electric field tensor:
                 C_q=e*Q*V_zz/h
-            h: planck's constant
+            h: Planck's constant
             Q: nuclear electric quadrupole moment in mb (millibarn
             e: elementary proton charge
 
@@ -240,6 +240,6 @@ class ElectricFieldGradient(SquareTensor):
         elif isinstance(specie, Species):
             Q = specie.get_nmr_quadrupole_moment()
         else:
-            raise ValueError("Invalid speciie provided for quadrupolar coupling constant calcuations")
+            raise ValueError("Invalid species provided for quadrupolar coupling constant calculations")
 
         return (e * Q * Vzz / planks_constant).to("MHz")

--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -869,7 +869,7 @@ class PhaseDiagram(MSONable):
             phase separation energy per atom of entry. Stable entries should have
             energies <= 0, Stable elemental entries should have energies = 0 and
             unstable entries should have energies > 0. Entries that have the same
-            composition as a stable energy may have postive or negative phase
+            composition as a stable energy may have positive or negative phase
             separation energies depending on their own energy.
         """
         return self.get_decomp_and_phase_separation_energy(entry, **kwargs)[1]
@@ -2171,7 +2171,7 @@ class PDPlotter:
             image_format
                 format for image. Can be any of matplotlib supported formats.
                 Defaults to svg for best results for vector graphics.
-            **kwargs: Pass through to get_plot functino.
+            **kwargs: Pass through to get_plot function.
         """
         plt = self.get_plot(**kwargs)
 

--- a/pymatgen/analysis/quasiharmonic.py
+++ b/pymatgen/analysis/quasiharmonic.py
@@ -108,7 +108,7 @@ class QuasiharmonicDebyeApprox:
 
     def optimize_gibbs_free_energy(self):
         """
-        Evaluate the gibbs free energy as a function of V, T and P i.e
+        Evaluate the Gibbs free energy as a function of V, T and P i.e
         G(V, T, P), minimize G(V, T, P) wrt V for each T and store the
         optimum values.
 
@@ -137,11 +137,11 @@ class QuasiharmonicDebyeApprox:
         Evaluate G(V, T, P) at the given temperature(and pressure) and
         minimize it wrt V.
 
-        1. Compute the  vibrational helmholtz free energy, A_vib.
-        2. Compute the gibbs free energy as a function of volume, temperature
+        1. Compute the  vibrational Helmholtz free energy, A_vib.
+        2. Compute the Gibbs free energy as a function of volume, temperature
             and pressure, G(V,T,P).
-        3. Preform an equation of state fit to get the functional form of
-            gibbs free energy:G(V, T, P).
+        3. Perform an equation of state fit to get the functional form of
+            Gibbs free energy:G(V, T, P).
         4. Finally G(V, P, T) is minimized with respect to V.
 
         Args:
@@ -251,7 +251,7 @@ class QuasiharmonicDebyeApprox:
     def gruneisen_parameter(self, temperature, volume):
         """
         Slater-gamma formulation(the default):
-            gruneisen paramter = - d log(theta)/ d log(V)
+            gruneisen parameter = - d log(theta)/ d log(V)
                                = - ( 1/6 + 0.5 d log(B)/ d log(V) )
                                = - (1/6 + 0.5 V/B dB/dV),
                                     where dB/dV = d^2E/dV^2 + V * d^3E/dV^3

--- a/pymatgen/analysis/structure_analyzer.py
+++ b/pymatgen/analysis/structure_analyzer.py
@@ -17,10 +17,10 @@ import numpy as np
 from monty.dev import deprecated
 from scipy.spatial import Voronoi
 
+from pymatgen.analysis.local_env import JmolNN, VoronoiNN
 from pymatgen.core.composition import Composition
 from pymatgen.core.periodic_table import Element, Species
 from pymatgen.core.sites import PeriodicSite
-from pymatgen.analysis.local_env import JmolNN, VoronoiNN
 from pymatgen.core.surface import SlabGenerator
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.util.num import abs_cap
@@ -126,7 +126,7 @@ class VoronoiAnalyzer:
             step_freq (int): perform analysis every step_freq steps
             qhull_options (str): options to pass to qhull
             most_frequent_polyhedra (int): this many unique polyhedra with
-                highest frequences is stored.
+                highest frequencies is stored.
 
         Returns:
             A list of tuples in the form (voronoi_index,frequency)

--- a/pymatgen/analysis/structure_prediction/dopant_predictor.py
+++ b/pymatgen/analysis/structure_prediction/dopant_predictor.py
@@ -66,7 +66,7 @@ def get_dopants_from_shannon_radii(bonded_structure, num_dopants=5, match_oxi_si
         bonded_structure (StructureGraph): A pymatgen structure graph
             decorated with oxidation states. For example, generated using the
             CrystalNN.get_bonded_structure() method.
-        num_dopants (int): The nummber of suggestions to return for
+        num_dopants (int): The number of suggestions to return for
             n- and p-type dopants.
         match_oxi_sign (bool): Whether to force the dopant and original species
             to have the same sign of oxidation state. E.g. If the original site

--- a/pymatgen/analysis/structure_prediction/volume_predictor.py
+++ b/pymatgen/analysis/structure_prediction/volume_predictor.py
@@ -102,7 +102,7 @@ class RLSVolumePredictor:
 
                 return ref_structure.volume * (numerator / denominator) ** 3
             except Exception:
-                warnings.warn("Exception occured. Will attempt atomic radii.")
+                warnings.warn("Exception occurred. Will attempt atomic radii.")
                 # If error occurs during use of ionic radii scheme, pass
                 # and see if we can resolve it using atomic radii.
 

--- a/pymatgen/analysis/structure_prediction/volume_predictor.py
+++ b/pymatgen/analysis/structure_prediction/volume_predictor.py
@@ -105,7 +105,6 @@ class RLSVolumePredictor:
                 warnings.warn("Exception occured. Will attempt atomic radii.")
                 # If error occurs during use of ionic radii scheme, pass
                 # and see if we can resolve it using atomic radii.
-                pass
 
         if "atomic" in self.radii_type:
             comp = structure.composition

--- a/pymatgen/analysis/surface_analysis.py
+++ b/pymatgen/analysis/surface_analysis.py
@@ -1859,7 +1859,7 @@ class NanoscaleStability:
     def scaled_wulff(self, wulffshape, r):
         """
         Scales the Wulff shape with an effective radius r. Note that the resulting
-            Wulff does not neccesarily have the same effective radius as the one
+            Wulff does not necessarily have the same effective radius as the one
             provided. The Wulff shape is scaled by its surface energies where first
             the surface energies are scale by the minimum surface energy and then
             multiplied by the given effective radius.

--- a/pymatgen/analysis/tests/test_fragmenter.py
+++ b/pymatgen/analysis/tests/test_fragmenter.py
@@ -4,7 +4,7 @@ import pytest
 
 from pymatgen.analysis.fragmenter import Fragmenter
 from pymatgen.analysis.graphs import MoleculeGraph
-from pymatgen.analysis.local_env import OpenBabelNN, metal_edge_extender
+from pymatgen.analysis.local_env import OpenBabelNN
 from pymatgen.core.structure import Molecule
 from pymatgen.util.testing import PymatgenTest
 

--- a/pymatgen/analysis/tests/test_phase_diagram.py
+++ b/pymatgen/analysis/tests/test_phase_diagram.py
@@ -7,9 +7,7 @@ import warnings
 from numbers import Number
 from pathlib import Path
 from collections import OrderedDict
-import json
 
-from monty.json import MontyEncoder, MontyDecoder
 
 import numpy as np
 
@@ -286,7 +284,6 @@ class PhaseDiagramTest(unittest.TestCase):
                     self.assertAlmostEqual(self.pd.get_phase_separation_energy(entry), e_d, 7)
                 # NOTE the remaining materials would require explicit tests as they
                 # could be either positive or negative
-                pass
 
         for entry in self.pd.stable_entries:
             if entry.composition.is_element:

--- a/pymatgen/analysis/tests/test_piezo.py
+++ b/pymatgen/analysis/tests/test_piezo.py
@@ -13,7 +13,6 @@ __email__ = "shyamd@lbl.gov"
 __status__ = "Development"
 __date__ = "4/1/16"
 
-import os
 import unittest
 
 import numpy as np

--- a/pymatgen/analysis/tests/test_piezo_sensitivity.py
+++ b/pymatgen/analysis/tests/test_piezo_sensitivity.py
@@ -19,10 +19,13 @@ import unittest
 import numpy as np
 
 import pymatgen
-from pymatgen.analysis.piezo import PiezoTensor
-from pymatgen.analysis.piezo_sensitivity import *
-from pymatgen.symmetry import site_symmetries as ss
-from pymatgen.symmetry.analyzer import SpacegroupAnalyzer as sga
+from pymatgen.analysis.piezo_sensitivity import (
+    BornEffectiveCharge,
+    ForceConstantMatrix,
+    InternalStrainTensor,
+    get_piezo,
+    rand_piezo,
+)
 from pymatgen.util.testing import PymatgenTest
 
 try:

--- a/pymatgen/analysis/tests/test_pourbaix_diagram.py
+++ b/pymatgen/analysis/tests/test_pourbaix_diagram.py
@@ -13,7 +13,6 @@ import numpy as np
 from monty.serialization import loadfn, dumpfn
 from monty.tempfile import ScratchDir
 
-from pymatgen.core import SETTINGS
 from pymatgen.analysis.pourbaix_diagram import (
     IonEntry,
     MultiEntry,

--- a/pymatgen/analysis/tests/test_quasiharmonic_debye_approx.py
+++ b/pymatgen/analysis/tests/test_quasiharmonic_debye_approx.py
@@ -117,7 +117,7 @@ class TestQuasiharmociDebyeApprox(unittest.TestCase):
         theta = self.qhda.debye_temperature(self.opt_vol)
         np.testing.assert_almost_equal(theta, 2559.675227, 3)
 
-    def test_gruneisen_paramter(self):
+    def test_gruneisen_parameter(self):
         gamma = self.qhda.gruneisen_parameter(self.T, self.opt_vol)
         np.testing.assert_almost_equal(gamma, 1.670486, 3)
 
@@ -188,7 +188,7 @@ direct
         theta = self.qhda.debye_temperature(self.opt_vol)
         np.testing.assert_approx_equal(theta, 601.239096, 4)
 
-    def test_gruneisen_paramter(self):
+    def test_gruneisen_parameter(self):
         gamma = self.qhda.gruneisen_parameter(0, self.qhda.ev_eos_fit.v0)
         np.testing.assert_almost_equal(gamma, 2.188302, 3)
 

--- a/pymatgen/command_line/tests/test_bader_caller.py
+++ b/pymatgen/command_line/tests/test_bader_caller.py
@@ -3,7 +3,7 @@
 
 import unittest
 
-from pymatgen.command_line.bader_caller import *
+from pymatgen.command_line.bader_caller import BaderAnalysis, bader_analysis_from_path, np, os, warnings, which
 from pymatgen.util.testing import PymatgenTest
 
 

--- a/pymatgen/command_line/tests/test_bader_caller.py
+++ b/pymatgen/command_line/tests/test_bader_caller.py
@@ -1,9 +1,17 @@
 # Copyright (c) Pymatgen Development Team.
 # Distributed under the terms of the MIT License.
 
+import os
 import unittest
+import warnings
 
-from pymatgen.command_line.bader_caller import BaderAnalysis, bader_analysis_from_path, np, os, warnings, which
+import numpy as np
+
+from pymatgen.command_line.bader_caller import (
+    BaderAnalysis,
+    bader_analysis_from_path,
+    which,
+)
 from pymatgen.util.testing import PymatgenTest
 
 

--- a/pymatgen/command_line/tests/test_critic2_caller.py
+++ b/pymatgen/command_line/tests/test_critic2_caller.py
@@ -5,7 +5,7 @@ import unittest
 
 from monty.os.path import which
 
-from pymatgen.command_line.critic2_caller import *
+from pymatgen.command_line.critic2_caller import Critic2Analysis, Critic2Caller, os
 from pymatgen.core.structure import Structure
 from pymatgen.util.testing import PymatgenTest
 

--- a/pymatgen/command_line/tests/test_critic2_caller.py
+++ b/pymatgen/command_line/tests/test_critic2_caller.py
@@ -1,11 +1,12 @@
 # Copyright (c) Pymatgen Development Team.
 # Distributed under the terms of the MIT License.
 
+import os
 import unittest
 
 from monty.os.path import which
 
-from pymatgen.command_line.critic2_caller import Critic2Analysis, Critic2Caller, os
+from pymatgen.command_line.critic2_caller import Critic2Analysis, Critic2Caller
 from pymatgen.core.structure import Structure
 from pymatgen.util.testing import PymatgenTest
 

--- a/pymatgen/core/surface.py
+++ b/pymatgen/core/surface.py
@@ -1768,7 +1768,7 @@ def generate_all_slabs(
             specified as a dict of tuples: float of specie1, specie2
             and the max bonding distance. For example, PO4 groups may be
             defined as {("P", "O"): 3}.
-        tol (float): General tolerance paramter for getting primitive
+        tol (float): General tolerance parameter for getting primitive
             cells and matching structures
         ftol (float): Threshold parameter in fcluster in order to check
             if two atoms are lying on the same plane. Default thresh set

--- a/pymatgen/core/tensors.py
+++ b/pymatgen/core/tensors.py
@@ -941,7 +941,7 @@ class SquareTensor(Tensor):
     def refine_rotation(self):
         """
         Helper method for refining rotation matrix by ensuring
-        that second and third rows are perpindicular to the first.
+        that second and third rows are perpendicular to the first.
         Gets new y vector from an orthogonal projection of x onto y
         and the new z vector from a cross product of the new x and y
 

--- a/pymatgen/core/tests/test_sites.py
+++ b/pymatgen/core/tests/test_sites.py
@@ -3,7 +3,6 @@
 
 
 import pickle
-import timeit
 
 import numpy as np
 

--- a/pymatgen/core/tests/test_tensors.py
+++ b/pymatgen/core/tests/test_tensors.py
@@ -1,6 +1,9 @@
 import math
+import os
 import unittest
+import warnings
 
+import numpy as np
 from monty.serialization import MontyDecoder
 
 from pymatgen.core.operations import SymmOp
@@ -11,10 +14,7 @@ from pymatgen.core.tensors import (
     TensorMapping,
     itertools,
     loadfn,
-    np,
-    os,
     symmetry_reduce,
-    warnings,
 )
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.util.testing import PymatgenTest

--- a/pymatgen/core/tests/test_tensors.py
+++ b/pymatgen/core/tests/test_tensors.py
@@ -4,7 +4,18 @@ import unittest
 from monty.serialization import MontyDecoder
 
 from pymatgen.core.operations import SymmOp
-from pymatgen.core.tensors import *
+from pymatgen.core.tensors import (
+    SquareTensor,
+    Tensor,
+    TensorCollection,
+    TensorMapping,
+    itertools,
+    loadfn,
+    np,
+    os,
+    symmetry_reduce,
+    warnings,
+)
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.util.testing import PymatgenTest
 
@@ -443,7 +454,7 @@ class TensorCollectionTest(PymatgenTest):
 
         # Convert to ieee
         for entry in self.ieee_data[:2]:
-            xtal = entry["xtal"]
+            entry["xtal"]
             tc = TensorCollection([entry["original_tensor"]] * 3)
             struct = entry["structure"]
             self.list_based_function_check("convert_to_ieee", tc, struct)

--- a/pymatgen/electronic_structure/bandstructure.py
+++ b/pymatgen/electronic_structure/bandstructure.py
@@ -632,7 +632,7 @@ class BandStructure:
         d["labels_dict"] = {}
         d["is_spin_polarized"] = self.is_spin_polarized
 
-        # MongoDB does not accept keys starting with $. Add a blanck space to fix the problem
+        # MongoDB does not accept keys starting with $. Add a blank space to fix the problem
         for c, label in self.labels_dict.items():
             mongo_key = c if not c.startswith("$") else " " + c
             d["labels_dict"][mongo_key] = label.as_dict()["fcoords"]
@@ -992,7 +992,7 @@ class LobsterBandStructureSymmLine(BandStructureSymmLine):
         d["band_gap"] = self.get_band_gap()
         d["labels_dict"] = {}
         d["is_spin_polarized"] = self.is_spin_polarized
-        # MongoDB does not accept keys starting with $. Add a blanck space to fix the problem
+        # MongoDB does not accept keys starting with $. Add a blank space to fix the problem
         for c, label in self.labels_dict.items():
             mongo_key = c if not c.startswith("$") else " " + c
             d["labels_dict"][mongo_key] = label.as_dict()["fcoords"]

--- a/pymatgen/electronic_structure/boltztrap.py
+++ b/pymatgen/electronic_structure/boltztrap.py
@@ -997,7 +997,7 @@ class BoltztrapAnalyzer:
         - "avg_corr": average of correlation coefficient over the 8 bands
         - "avg_dist": average of energy distance over the 8 bands
         - "nb_list": list of indexes of the 8 compared bands
-        - "acc_thr": list of two float corresponing to the two warning
+        - "acc_thr": list of two float corresponding to the two warning
                      thresholds in input
         - "acc_err": list of two bools:
                      True if the avg_corr > warn_thr[0], and

--- a/pymatgen/electronic_structure/boltztrap2.py
+++ b/pymatgen/electronic_structure/boltztrap2.py
@@ -682,11 +682,11 @@ class BztTransportProperties:
                 compute_properties_doping() method for details.
             npts_mu: number of energy points at which to calculate transport properties
             CRTA: constant value of the relaxation time
-            save_bztTranspProps: Default False. If True all computed tranport properties
+            save_bztTranspProps: Default False. If True all computed transport properties
                 will be stored in fname file.
-            load_bztTranspProps: Default False. If True all computed tranport properties
+            load_bztTranspProps: Default False. If True all computed transport properties
                 will be loaded from fname file.
-            fname: File path where to save/load tranport properties.
+            fname: File path where to save/load transport properties.
 
         Upon creation, it contains properties tensors w.r.t. the chemical potential
         of size (len(temp_r),npts_mu,3,3):
@@ -914,7 +914,7 @@ class BztTransportProperties:
     #     return epsilon[pos]
 
     def save(self, fname="bztTranspProps.json.gz"):
-        """Save the tranport properties to fname file."""
+        """Save the transport properties to fname file."""
         lst_props = [
             self.temp_r,
             self.CRTA,
@@ -950,7 +950,7 @@ class BztTransportProperties:
         dumpfn(lst_props, fname)
 
     def load(self, fname="bztTranspProps.json.gz"):
-        """Load the tranport properties from fname file."""
+        """Load the transport properties from fname file."""
         d = loadfn(fname)
         (
             self.temp_r,

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -265,7 +265,7 @@ class BSPlotter:
 
     def _check_bs_kpath(self, bs_list):
         """
-        Helper method that chack the all the band objs in bs_list are
+        Helper method that check all the band objs in bs_list are
         BandStructureSymmLine objs and they all have the same kpath.
         """
 

--- a/pymatgen/entries/compatibility.py
+++ b/pymatgen/entries/compatibility.py
@@ -9,27 +9,26 @@ import abc
 import os
 import warnings
 from collections import defaultdict
-from typing import Optional, Sequence, Union, List, Type
+from typing import List, Optional, Sequence, Type, Union
 
 import numpy as np
 from monty.design_patterns import cached_class
 from monty.json import MSONable
 from monty.serialization import loadfn
-from uncertainties import ufloat
 from tqdm import tqdm
+from uncertainties import ufloat
 
 from pymatgen.analysis.structure_analyzer import oxide_type, sulfide_type
 from pymatgen.core.periodic_table import Element
 from pymatgen.entries.computed_entries import (
-    EnergyAdjustment,
     CompositionEnergyAdjustment,
     ComputedEntry,
     ComputedStructureEntry,
     ConstantEnergyAdjustment,
+    EnergyAdjustment,
     TemperatureEnergyAdjustment,
 )
 from pymatgen.io.vasp.sets import MITRelaxSet, MPRelaxSet
-
 
 MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
 MU_H2O = -2.4583  # Free energy of formation of water, eV/H2O, used by MaterialsProjectAqueousCompatibility
@@ -1419,7 +1418,7 @@ class MaterialsProjectAqueousCompatibility(Compatibility):
                 "being assigned the same energy. This should not cause problems "
                 "with Pourbaix diagram construction, but may be confusing. "
                 "Pass all entries to process_entries() at once in if you want to "
-                "preserve H2 polymorph energy differnces."
+                "preserve H2 polymorph energy differences."
             )
 
         # extract the DFT energies of oxygen and water from the list of entries, if present

--- a/pymatgen/entries/mixing_scheme.py
+++ b/pymatgen/entries/mixing_scheme.py
@@ -74,7 +74,7 @@ class MaterialsProjectDFTMixingScheme(Compatibility):
 
                 The list of run_type_1 entries provided to process_entries MUST form a complete
                 Phase Diagram in order for the mixing scheme to work. If this condition is not
-                satisifed, processing the entries will fail.
+                satisfied, processing the entries will fail.
 
                 Note that the special string "GGA(+U)" (default) will treat both GGA and GGA+U
                 calculations as a single type. This option exists because GGA/GGA+U mixing is
@@ -90,7 +90,7 @@ class MaterialsProjectDFTMixingScheme(Compatibility):
             fuzzy_matching: Whether to use less strict structure matching logic for
                 diatomic elements O2, N2, F2, H2, and Cl2 as well as I and Br. Outputs of DFT
                 relaxations using
-                different functionals frequently fail to struture match for these elements
+                different functionals frequently fail to structure match for these elements
                 even though they come from the same original material. Fuzzy structure matching
                 considers the materials equivalent if the formula, number of sites, and
                 space group are all identical. If there are multiple materials of run_type_2
@@ -446,7 +446,7 @@ class MaterialsProjectDFTMixingScheme(Compatibility):
                 f"because there are no {self.run_type_2} ground states at this composition."
             )
 
-        # this statement is here to make pylint happy by gauranteeing a return or raise
+        # this statement is here to make pylint happy by guaranteeing a return or raise
         else:
             raise CompatibilityError(
                 "WARNING! If you see this Exception it means you have encountered"

--- a/pymatgen/io/abinit/abiobjects.py
+++ b/pymatgen/io/abinit/abiobjects.py
@@ -1159,7 +1159,7 @@ class RelaxationMethod(AbivarAble, MSONable):
 
 
 class PPModelModes(Enum):
-    """Differnt kind of plasmon-pole models."""
+    """Different kind of plasmon-pole models."""
 
     noppmodel = 0
     godby = 1
@@ -1281,7 +1281,7 @@ class HilbertTransform(AbivarAble):
         Args:
             nomegasf: Number of points for sampling the spectral function along the real axis.
             domegasf: Step in Ha for the linear mesh used for the spectral function.
-            spmeth: Algorith for the representation of the delta function.
+            spmeth: Algorithm for the representation of the delta function.
             nfreqre: Number of points along the real axis (linear mesh).
             freqremax: Maximum frequency for W along the real axis (in hartree).
             nfreqim: Number of point along the imaginary axis (Gauss-Legendre mesh).

--- a/pymatgen/io/abinit/abitimer.py
+++ b/pymatgen/io/abinit/abitimer.py
@@ -46,7 +46,7 @@ class AbinitTimerParser(collections.abc.Iterable):
         parser = AbinitTimerParser()
         parser.parse(list_of_files)
 
-    To analyze all *.abo files withing top, use:
+    To analyze all *.abo files within top, use:
 
         parser, paths, okfiles = AbinitTimerParser.walk(top=".", ext=".abo")
     """
@@ -439,7 +439,7 @@ class AbinitTimerParser(collections.abc.Iterable):
         Args:
             key: Keyword used to extract data from the timers. Only the first `nmax`
                 sections with largest value are show.
-            mmax: Maximum nuber of sections to show. Other entries are grouped together
+            mmax: Maximum number of sections to show. Other entries are grouped together
                 in the `others` section.
             ax: matplotlib :class:`Axes` or None if a new figure should be created.
 

--- a/pymatgen/io/abinit/inputs.py
+++ b/pymatgen/io/abinit/inputs.py
@@ -1031,7 +1031,7 @@ class BasicMultiDataset:
         for i in range(multi.ndtset):
             multi[i].set_vars(ecut=1)
 
-    BasicMultiDataset provides its own implementaion of __getattr__ so that one can simply use:
+    BasicMultiDataset provides its own implementation of __getattr__ so that one can simply use:
 
         multi.set_vars(ecut=1)
 

--- a/pymatgen/io/abinit/pseudos.py
+++ b/pymatgen/io/abinit/pseudos.py
@@ -1388,7 +1388,7 @@ class PawXmlSetup(Pseudo, PawPseudo):
         return np.array(mesh)
 
     def _parse_radfunc(self, func_name):
-        """Parse the first occurence of func_name in the XML file."""
+        """Parse the first occurrence of func_name in the XML file."""
         # pylint: disable=E1101
         node = self.root.find(func_name)
         grid = node.attrib["grid"]
@@ -1943,7 +1943,7 @@ class PseudoTable(collections.abc.Sequence, MSONable, metaclass=abc.ABCMeta):
 
     def select_family(self, family):
         """
-        Return PseudoTable with element beloging to the specified family, e.g. familiy="alkaline"
+        Return PseudoTable with element belonging to the specified family, e.g. family="alkaline"
         """
         # e.g element.is_alkaline
         return self.__class__([p for p in self if getattr(p.element, "is_" + family)])

--- a/pymatgen/io/abinit/tests/test_abiobjects.py
+++ b/pymatgen/io/abinit/tests/test_abiobjects.py
@@ -3,6 +3,8 @@
 
 import os
 
+import numpy as np
+
 from pymatgen.core.structure import Structure
 from pymatgen.core.units import Ha_to_eV, bohr_to_ang
 from pymatgen.io.abinit.abiobjects import (
@@ -14,7 +16,6 @@ from pymatgen.io.abinit.abiobjects import (
     Smearing,
     SpinMode,
     lattice_from_abivars,
-    np,
     species_by_znucl,
     structure_to_abivars,
 )

--- a/pymatgen/io/abinit/tests/test_abiobjects.py
+++ b/pymatgen/io/abinit/tests/test_abiobjects.py
@@ -2,11 +2,22 @@
 # Distributed under the terms of the MIT License.
 
 import os
-import warnings
 
 from pymatgen.core.structure import Structure
 from pymatgen.core.units import Ha_to_eV, bohr_to_ang
-from pymatgen.io.abinit.abiobjects import *
+from pymatgen.io.abinit.abiobjects import (
+    Electrons,
+    ElectronsAlgorithm,
+    KSampling,
+    PPModel,
+    RelaxationMethod,
+    Smearing,
+    SpinMode,
+    lattice_from_abivars,
+    np,
+    species_by_znucl,
+    structure_to_abivars,
+)
 from pymatgen.util.testing import PymatgenTest
 
 
@@ -147,7 +158,7 @@ class SmearingTest(PymatgenTest):
 class ElectronsAlgorithmTest(PymatgenTest):
     def test_base(self):
         algo = ElectronsAlgorithm(nstep=70)
-        abivars = algo.to_abivars()
+        _ = algo.to_abivars()
 
         # Test pickle
         self.serialize_with_pickle(algo)
@@ -163,7 +174,7 @@ class ElectronsTest(PymatgenTest):
         self.assertTrue(default_electrons.nspinor == 1)
         self.assertTrue(default_electrons.nspden == 2)
 
-        abivars = default_electrons.to_abivars()
+        _ = default_electrons.to_abivars()
 
         # new = Electron.from_dict(default_electrons.as_dict())
 

--- a/pymatgen/io/abinit/tests/test_inputs.py
+++ b/pymatgen/io/abinit/tests/test_inputs.py
@@ -3,7 +3,6 @@
 
 import os
 import tempfile
-import unittest
 
 import numpy as np
 

--- a/pymatgen/io/adf.py
+++ b/pymatgen/io/adf.py
@@ -68,15 +68,11 @@ class AdfInputError(Exception):
     The default error class for ADF.
     """
 
-    pass
-
 
 class AdfOutputError(Exception):
     """
     The default error class for errors raised by ``AdfOutput``.
     """
-
-    pass
 
 
 class AdfKey(MSONable):

--- a/pymatgen/io/adf.py
+++ b/pymatgen/io/adf.py
@@ -271,7 +271,7 @@ class AdfKey(MSONable):
         Parameters
         ----------
         option : Sized or str or int or float
-            A new option to add. This must have the same format with exsiting
+            A new option to add. This must have the same format with existing
             options.
 
         Raises

--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -342,7 +342,7 @@ class CifParser:
             structure (heuristic).
             """
             # Doesn't seem to be a canonical way to test if magCIF file
-            # describes incommensurate strucure or not, so instead check
+            # describes incommensurate structure or not, so instead check
             # for common datanames
             if not self.feature_flags["magcif"]:
                 return False
@@ -559,7 +559,7 @@ class CifParser:
                     try:
                         frac = str2float(frac)
                     except Exception:
-                        # co-ordinate might not be defined e.g. '?'
+                        # coordinate might not be defined e.g. '?'
                         continue
                     for comparison_frac in important_fracs:
                         if abs(1 - frac / comparison_frac) < 1e-4:
@@ -1032,7 +1032,7 @@ class CifParser:
                     # moments as Species 'spin' property, instead of site
                     # property, but this introduces ambiguities for end user
                     # (such as unintended use of `spin` and Species will have
-                    # fictious oxidation state).
+                    # fictitious oxidation state).
                     raise NotImplementedError("Disordered magnetic structures not currently supported.")
 
         if coord_to_species.items():

--- a/pymatgen/io/cp2k/inputs.py
+++ b/pymatgen/io/cp2k/inputs.py
@@ -122,7 +122,7 @@ class Keyword(MSONable):
     @classmethod
     def from_dict(cls, d):
         """
-        Initialise from dictonary
+        Initialise from dictionary
         """
         return Keyword(
             d["name"],

--- a/pymatgen/io/cp2k/sets.py
+++ b/pymatgen/io/cp2k/sets.py
@@ -249,7 +249,7 @@ class DftSet(Cp2kInputSet):
                 reasonable results for most properties.
             max_scf (int): The max number of SCF cycles before terminating the solver. NOTE: With the OT solver, this
                 corresponds to the max number of INNER scf loops, and then the outer loops are set with outer_max_scf,
-                while with diagnolization it corresponds to the overall (INNER*OUTER) number of SCF steps, with the
+                while with diagonalization it corresponds to the overall (INNER*OUTER) number of SCF steps, with the
                 inner loop limit set by
             minimizer (str): The minimization scheme. DIIS can be as much as 50% faster than the more robust conjugate
                 gradient method, and so it is chosen as default. Switch to CG if dealing with a difficult system.
@@ -259,7 +259,7 @@ class DftSet(Cp2kInputSet):
                 in which case FULL_KINETIC might be preferred.
             cutoff (int): Cutoff energy (in Ry) for the finest level of the multigrid. A high cutoff will allow you to
                 have very accurate calculations PROVIDED that REL_CUTOFF is appropriate.
-            rel_cutoff (int): This cutoff decides how the Guassians are mapped onto the different levels of the
+            rel_cutoff (int): This cutoff decides how the Gaussians are mapped onto the different levels of the
                 multigrid. From CP2K: A Gaussian is mapped onto the coarsest level of the multi-grid, on which the
                     function will cover number of grid points greater than or equal to the number of grid points
                     will cover on a reference grid defined by REL_CUTOFF.

--- a/pymatgen/io/cp2k/tests/test_sets.py
+++ b/pymatgen/io/cp2k/tests/test_sets.py
@@ -2,7 +2,6 @@
 # Distributed under the terms of the MIT License.
 
 import unittest
-from pathlib import Path
 
 from pymatgen.core.structure import Molecule, Structure
 from pymatgen.io.cp2k.inputs import Cp2kInput

--- a/pymatgen/io/feff/tests/test_sets.py
+++ b/pymatgen/io/feff/tests/test_sets.py
@@ -9,7 +9,7 @@ import unittest
 import numpy as np
 
 from pymatgen.core.structure import Structure
-from pymatgen.io.cif import CifFile, CifParser
+from pymatgen.io.cif import CifParser
 from pymatgen.io.feff.inputs import Atoms, Header, Potential, Tags
 from pymatgen.io.feff.sets import FEFFDictSet, MPELNESSet, MPEXAFSSet, MPXANESSet
 from pymatgen.util.testing import PymatgenTest

--- a/pymatgen/io/fiesta.py
+++ b/pymatgen/io/fiesta.py
@@ -522,7 +522,7 @@ class FiestaInput(MSONable):
     $nit_gw
 # dumping for BSE and TDDFT
     $do_bse    $do_tddft
-# number of occp. and virtual bands fo BSE: nocore and up to 40 eVs
+# number of occp. and virtual bands of BSE: nocore and up to 40 eVs
     $nv_bse   $nc_bse
 # number of excitations needed and number of iterations
     $npsi_bse   $nit_bse
@@ -681,7 +681,7 @@ $geometry
         toks = l.split()
         BSE_TDDFT_options["do_bse"] = toks[0]
         BSE_TDDFT_options["do_tddft"] = toks[1]
-        # number of occp. and virtual bands fo BSE: nocore and up to 40 eVs
+        # number of occp. and virtual bands of BSE: nocore and up to 40 eVs
         lines.pop(0)
         l = lines.pop(0).strip()
         toks = l.split()

--- a/pymatgen/io/lobster/inputs.py
+++ b/pymatgen/io/lobster/inputs.py
@@ -379,7 +379,7 @@ class Lobsterin(dict, MSONable):
         Args:
             structure: Structure object
             potcar_symbols: list of the potcar symbols
-            address_basis_file_min: path to file with the minium required basis by the POTCAR
+            address_basis_file_min: path to file with the minimum required basis by the POTCAR
             address_basis_file_max: path to file with the largest possible basis of the POTCAR
 
         Returns: List of dictionaries that can be used to create new Lobsterin objects in

--- a/pymatgen/io/lobster/outputs.py
+++ b/pymatgen/io/lobster/outputs.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, List, Optional
 
 import numpy as np
 from monty.io import zopen
+
 from pymatgen.core.structure import Structure
 from pymatgen.electronic_structure.bandstructure import LobsterBandStructureSymmLine
 from pymatgen.electronic_structure.core import Orbital, Spin
@@ -717,10 +718,10 @@ class Lobsterout:
         Boolean, indicates that DOSCAR.lobster is present
 
       .. attribute: has_Projection
-        Boolean, indcates that projectionData.lobster is present
+        Boolean, indicates that projectionData.lobster is present
 
       .. attribute: has_bandoverlaps
-        Boolean, indcates that bandOverlaps.lobster is present
+        Boolean, indicates that bandOverlaps.lobster is present
 
       .. attribute: has_density_of_energies
         Boolean, indicates that DensityOfEnergy.lobster is present

--- a/pymatgen/io/qchem/tests/test_outputs.py
+++ b/pymatgen/io/qchem/tests/test_outputs.py
@@ -12,8 +12,9 @@ from pymatgen.io.qchem.outputs import QCOutput, check_for_structure_changes
 from pymatgen.util.testing import PymatgenTest
 
 try:
-    pass
+    from openbabel import openbabel
 
+    openbabel  # reference openbabel so it's not unused import
     have_babel = True
 except ImportError:
     have_babel = False

--- a/pymatgen/io/qchem/tests/test_outputs.py
+++ b/pymatgen/io/qchem/tests/test_outputs.py
@@ -5,7 +5,6 @@
 import os
 import unittest
 
-from monty.os.path import which
 from monty.serialization import dumpfn, loadfn
 
 from pymatgen.core.structure import Molecule
@@ -13,7 +12,7 @@ from pymatgen.io.qchem.outputs import QCOutput, check_for_structure_changes
 from pymatgen.util.testing import PymatgenTest
 
 try:
-    from openbabel import openbabel
+    pass
 
     have_babel = True
 except ImportError:

--- a/pymatgen/io/qchem/tests/test_sets.py
+++ b/pymatgen/io/qchem/tests/test_sets.py
@@ -5,7 +5,16 @@
 import os
 import unittest
 
-from pymatgen.io.qchem.sets import *
+from pymatgen.io.qchem.sets import (
+    ForceSet,
+    FreqSet,
+    OptSet,
+    PESScanSet,
+    QCInput,
+    QChemDictSet,
+    SinglePointSet,
+    TransitionStateSet,
+)
 from pymatgen.util.testing import PymatgenTest
 
 __author__ = "Samuel Blau, Brandon Wood, Shyam Dwaraknath, Evan Spotte-Smith"

--- a/pymatgen/io/tests/test_fiesta.py
+++ b/pymatgen/io/tests/test_fiesta.py
@@ -55,7 +55,7 @@ class FiestaInputTest(PymatgenTest):
             "# number of COHSEX iter, scf on wfns, mixing coeff; V=RI-V  I=RI-D\n    0   V       0       0.500\n"
             "# number of GW corrected occp and unoccp bands\n   10   10\n# number of GW iterations\n    3\n"
             "# dumping for BSE and TDDFT\n    1    0\n"
-            "# number of occp. and virtual bands fo BSE: nocore and up to 40 eVs\n    21   382\n"
+            "# number of occp. and virtual bands of BSE: nocore and up to 40 eVs\n    21   382\n"
             "# number of excitations needed and number of iterations\n    1   50\n"
             "# list of symbols in order\nC\nH\n"
             "# scaling factor\n    1.000\n# atoms x,y,z cartesian .. will be multiplied by scale\n 0.0 0.0 0.0 1\n"

--- a/pymatgen/io/tests/test_phonopy.py
+++ b/pymatgen/io/tests/test_phonopy.py
@@ -2,6 +2,7 @@ import os
 import unittest
 from pathlib import Path
 
+import numpy as np
 from monty.tempfile import ScratchDir
 
 from pymatgen.core.periodic_table import Element
@@ -21,7 +22,6 @@ from pymatgen.io.phonopy import (
     get_phonon_dos_from_fc,
     get_phonopy_structure,
     get_pmg_structure,
-    np,
 )
 from pymatgen.util.testing import PymatgenTest
 

--- a/pymatgen/io/tests/test_phonopy.py
+++ b/pymatgen/io/tests/test_phonopy.py
@@ -5,13 +5,29 @@ from pathlib import Path
 from monty.tempfile import ScratchDir
 
 from pymatgen.core.periodic_table import Element
-from pymatgen.io.phonopy import *
+from pymatgen.io.phonopy import (
+    CompletePhononDos,
+    PhononBandStructure,
+    PhononBandStructureSymmLine,
+    Structure,
+    get_complete_ph_dos,
+    get_displaced_structures,
+    get_gruneisen_ph_bs_symm_line,
+    get_gruneisenparameter,
+    get_ph_bs_symm_line,
+    get_ph_dos,
+    get_phonon_band_structure_from_fc,
+    get_phonon_band_structure_symm_line_from_fc,
+    get_phonon_dos_from_fc,
+    get_phonopy_structure,
+    get_pmg_structure,
+    np,
+)
 from pymatgen.util.testing import PymatgenTest
 
 try:
     from phonopy import Phonopy
-    from phonopy.file_IO import parse_FORCE_CONSTANTS, write_disp_yaml
-    from phonopy.structure.atoms import PhonopyAtoms
+    from phonopy.file_IO import parse_FORCE_CONSTANTS
 except ImportError as ex:
     print(ex)
     Phonopy = None

--- a/pymatgen/io/tests/test_pwscf.py
+++ b/pymatgen/io/tests/test_pwscf.py
@@ -8,7 +8,6 @@ import numpy as np
 
 from pymatgen.io.pwscf import PWInput, PWInputError, PWOutput
 from pymatgen.util.testing import PymatgenTest
-from pymatgen.core import Lattice, Structure
 
 
 class PWInputTest(PymatgenTest):

--- a/pymatgen/io/tests/test_zeopp.py
+++ b/pymatgen/io/tests/test_zeopp.py
@@ -279,7 +279,6 @@ class GetVoidVolumeSurfaceTest(unittest.TestCase):
         self._vac_struct = p
 
     def test_void_volume_surface_area(self):
-        pass
         vol, sa = get_void_volume_surfarea(self._vac_struct, self._radii)
         # print "vol:  ", vol, "sa:  ", sa
         self.assertIsInstance(vol, float)

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -1014,7 +1014,7 @@ class Kpoints_supported_modes(Enum):
         for m in Kpoints_supported_modes:
             if m.name.lower()[0] == c:
                 return m
-        raise ValueError(f"Can't interprete Kpoint mode {s}")
+        raise ValueError(f"Can't interpret Kpoint mode {s}")
 
 
 class Kpoints(MSONable):

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -56,6 +56,7 @@ from monty.dev import deprecated
 from monty.io import zopen
 from monty.json import MSONable
 from monty.serialization import loadfn
+
 from pymatgen.analysis.structure_matcher import StructureMatcher
 from pymatgen.core.periodic_table import Element, Species
 from pymatgen.core.sites import PeriodicSite
@@ -3059,7 +3060,7 @@ _dummy_structure = Structure(
 
 def get_valid_magmom_struct(structure, inplace=True, spin_mode="auto"):
     """
-    Make sure that the structure has valid magmoms based on the kind of caculation
+    Make sure that the structure has valid magmoms based on the kind of calculation
     Fill in missing Magmom values
 
     Args:

--- a/pymatgen/io/xtb/tests/test_outputs.py
+++ b/pymatgen/io/xtb/tests/test_outputs.py
@@ -11,8 +11,9 @@ from pymatgen.io.xtb.outputs import CRESTOutput
 from pymatgen.util.testing import PymatgenTest
 
 try:
-    pass
+    from openbabel import openbabel
 
+    openbabel  # reference openbabel so it's not unused import
     have_babel = True
 except ImportError:
     have_babel = False

--- a/pymatgen/io/xtb/tests/test_outputs.py
+++ b/pymatgen/io/xtb/tests/test_outputs.py
@@ -11,7 +11,7 @@ from pymatgen.io.xtb.outputs import CRESTOutput
 from pymatgen.util.testing import PymatgenTest
 
 try:
-    from openbabel import openbabel as ob
+    pass
 
     have_babel = True
 except ImportError:

--- a/pymatgen/phonon/tests/test_bandstructure.py
+++ b/pymatgen/phonon/tests/test_bandstructure.py
@@ -3,7 +3,6 @@ import os
 import unittest
 
 from pymatgen.phonon.bandstructure import (
-    PhononBandStructure,
     PhononBandStructureSymmLine,
 )
 from pymatgen.util.testing import PymatgenTest

--- a/pymatgen/symmetry/tests/test_analyzer.py
+++ b/pymatgen/symmetry/tests/test_analyzer.py
@@ -2,9 +2,9 @@
 # Distributed under the terms of the MIT License.
 
 
-import unittest
-from pathlib import Path
 import os
+import unittest
+
 import numpy as np
 
 from pymatgen.core.sites import PeriodicSite
@@ -19,7 +19,6 @@ from pymatgen.symmetry.analyzer import (
     iterative_symmetrize,
 )
 from pymatgen.util.testing import PymatgenTest
-
 
 test_dir_mol = os.path.join(PymatgenTest.TEST_FILES_DIR, "molecules")
 
@@ -628,7 +627,7 @@ class PointGroupAnalyzerTest(PymatgenTest):
         coords = sym_mol.cart_coords
         for i, eq_set in eq_sets.items():
             for j in eq_set:
-                rotated = np.dot(ops[i][j], coords[i])
+                _ = np.dot(ops[i][j], coords[i])
                 self.assertTrue(np.allclose(np.dot(ops[i][j], coords[i]), coords[j]))
 
     def test_symmetrize_molecule2(self):

--- a/pymatgen/symmetry/tests/test_kpaths.py
+++ b/pymatgen/symmetry/tests/test_kpaths.py
@@ -9,7 +9,6 @@ from monty.serialization import loadfn
 
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Structure
-from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.symmetry.bandstructure import HighSymmKpath
 from pymatgen.util.testing import PymatgenTest
 
@@ -59,7 +58,7 @@ class HighSymmKpathTest(PymatgenTest):
 
             # Throws error if something doesn't work, causing test to fail.
             kpath = HighSymmKpath(struct, path_type="all")
-            kpoints = kpath.get_kpoints()
+            _ = kpath.get_kpoints()
 
     def test_continuous_kpath(self):
         bs = loadfn(os.path.join(PymatgenTest.TEST_FILES_DIR, "Cu2O_361_bandstructure.json"))

--- a/pymatgen/symmetry/tests/test_settings.py
+++ b/pymatgen/symmetry/tests/test_settings.py
@@ -4,7 +4,7 @@ import unittest
 
 import numpy as np
 
-from pymatgen.symmetry.settings import *
+from pymatgen.symmetry.settings import JonesFaithfulTransformation, Lattice, SymmOp
 
 __author__ = "Matthew Horton"
 __copyright__ = "Copyright 2017, The Materials Project"

--- a/pymatgen/symmetry/tests/test_site_symmetries.py
+++ b/pymatgen/symmetry/tests/test_site_symmetries.py
@@ -10,11 +10,9 @@ __status__ = "Development"
 __date__ = "4/23/19"
 
 import os
-import unittest
 
 import numpy as np
 
-import pymatgen
 from pymatgen.symmetry import site_symmetries as ss
 from pymatgen.util.testing import PymatgenTest
 

--- a/pymatgen/transformations/tests/test_advanced_transformations.py
+++ b/pymatgen/transformations/tests/test_advanced_transformations.py
@@ -10,13 +10,12 @@ import numpy as np
 from monty.os.path import which
 from monty.serialization import loadfn
 
+from pymatgen.analysis.energy_models import IsingModel
+from pymatgen.analysis.gb.grain import GrainBoundaryGenerator
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.periodic_table import Species
 from pymatgen.core.structure import Molecule, Structure
-from pymatgen.analysis.energy_models import IsingModel
-from pymatgen.analysis.gb.grain import GrainBoundaryGenerator
 from pymatgen.core.surface import SlabGenerator
-from pymatgen.io import atat
 from pymatgen.io.cif import CifParser
 from pymatgen.io.vasp.inputs import Poscar
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
@@ -345,7 +344,7 @@ class MagOrderingTransformationTest(PymatgenTest):
         trans = MagOrderingTransformation({"Fe": 5}, order_parameter=0.75)
         d = trans.as_dict()
         # Check json encodability
-        s = json.dumps(d)
+        _ = json.dumps(d)
         trans = MagOrderingTransformation.from_dict(d)
         self.assertEqual(trans.mag_species_spin, {"Fe": 5})
         from pymatgen.analysis.energy_models import SymmetryModel
@@ -580,7 +579,7 @@ class DopingTransformationTest(PymatgenTest):
         trans = DopingTransformation("Al3+", min_length=5, alio_tol=1, codopant=False, max_structures_per_enum=1)
         d = trans.as_dict()
         # Check json encodability
-        s = json.dumps(d)
+        _ = json.dumps(d)
         trans = DopingTransformation.from_dict(d)
         self.assertEqual(str(trans.dopant), "Al3+")
         self.assertEqual(trans.max_structures_per_enum, 1)

--- a/pymatgen/transformations/tests/test_standard_transformations.py
+++ b/pymatgen/transformations/tests/test_standard_transformations.py
@@ -16,7 +16,27 @@ from pymatgen.core.periodic_table import Element
 from pymatgen.core.sites import PeriodicSite
 from pymatgen.io.vasp.inputs import Poscar
 from pymatgen.symmetry.structure import SymmetrizedStructure
-from pymatgen.transformations.standard_transformations import *
+from pymatgen.transformations.standard_transformations import (
+    AutoOxiStateDecorationTransformation,
+    ChargedCellTransformation,
+    ConventionalCellTransformation,
+    DeformStructureTransformation,
+    DiscretizeOccupanciesTransformation,
+    EwaldSummation,
+    Fraction,
+    OrderDisorderedStructureTransformation,
+    OxidationStateDecorationTransformation,
+    OxidationStateRemovalTransformation,
+    PartialRemoveSpecieTransformation,
+    PerturbStructureTransformation,
+    PrimitiveCellTransformation,
+    RemoveSpeciesTransformation,
+    RotationTransformation,
+    ScaleToRelaxedTransformation,
+    Structure,
+    SubstitutionTransformation,
+    SupercellTransformation,
+)
 from pymatgen.util.testing import PymatgenTest
 
 

--- a/pymatgen/util/tests/test_coord.py
+++ b/pymatgen/util/tests/test_coord.py
@@ -5,7 +5,25 @@
 import random
 
 from pymatgen.core.lattice import Lattice
-from pymatgen.util.coord import *
+from pymatgen.util.coord import (
+    Simplex,
+    all_distances,
+    barycentric_coords,
+    coord_list_mapping,
+    coord_list_mapping_pbc,
+    find_in_coord_list,
+    find_in_coord_list_pbc,
+    get_angle,
+    get_linear_interpolated_value,
+    in_coord_list,
+    in_coord_list_pbc,
+    is_coord_subset,
+    is_coord_subset_pbc,
+    lattice_points_in_supercell,
+    np,
+    pbc_diff,
+    pbc_shortest_vectors,
+)
 from pymatgen.util.testing import PymatgenTest
 
 

--- a/pymatgen/util/tests/test_coord.py
+++ b/pymatgen/util/tests/test_coord.py
@@ -4,26 +4,10 @@
 
 import random
 
+import numpy as np
+
+import pymatgen.util.coord as coord
 from pymatgen.core.lattice import Lattice
-from pymatgen.util.coord import (
-    Simplex,
-    all_distances,
-    barycentric_coords,
-    coord_list_mapping,
-    coord_list_mapping_pbc,
-    find_in_coord_list,
-    find_in_coord_list_pbc,
-    get_angle,
-    get_linear_interpolated_value,
-    in_coord_list,
-    in_coord_list_pbc,
-    is_coord_subset,
-    is_coord_subset_pbc,
-    lattice_points_in_supercell,
-    np,
-    pbc_diff,
-    pbc_shortest_vectors,
-)
 from pymatgen.util.testing import PymatgenTest
 
 
@@ -31,26 +15,26 @@ class CoordUtilsTest(PymatgenTest):
     def test_get_linear_interpolated_value(self):
         xvals = [0, 1, 2, 3, 4, 5]
         yvals = [3, 6, 7, 8, 10, 12]
-        self.assertEqual(get_linear_interpolated_value(xvals, yvals, 3.6), 9.2)
-        self.assertRaises(ValueError, get_linear_interpolated_value, xvals, yvals, 6)
+        self.assertEqual(coord.get_linear_interpolated_value(xvals, yvals, 3.6), 9.2)
+        self.assertRaises(ValueError, coord.get_linear_interpolated_value, xvals, yvals, 6)
 
     def test_in_coord_list(self):
         coords = [[0, 0, 0], [0.5, 0.5, 0.5]]
         test_coord = [0.1, 0.1, 0.1]
-        self.assertFalse(in_coord_list(coords, test_coord))
-        self.assertTrue(in_coord_list(coords, test_coord, atol=0.15))
-        self.assertFalse(in_coord_list([0.99, 0.99, 0.99], test_coord, atol=0.15))
+        self.assertFalse(coord.in_coord_list(coords, test_coord))
+        self.assertTrue(coord.in_coord_list(coords, test_coord, atol=0.15))
+        self.assertFalse(coord.in_coord_list([0.99, 0.99, 0.99], test_coord, atol=0.15))
 
     def test_is_coord_subset(self):
         c1 = [0, 0, 0]
         c2 = [0, 1.2, -1]
         c3 = [3, 2, 1]
         c4 = [3 - 9e-9, 2 - 9e-9, 1 - 9e-9]
-        self.assertTrue(is_coord_subset([c1, c2, c3], [c1, c4, c2]))
-        self.assertTrue(is_coord_subset([c1], [c2, c1]))
-        self.assertTrue(is_coord_subset([c1, c2], [c2, c1]))
-        self.assertFalse(is_coord_subset([c1, c2], [c2, c3]))
-        self.assertFalse(is_coord_subset([c1, c2], [c2]))
+        self.assertTrue(coord.is_coord_subset([c1, c2, c3], [c1, c4, c2]))
+        self.assertTrue(coord.is_coord_subset([c1], [c2, c1]))
+        self.assertTrue(coord.is_coord_subset([c1, c2], [c2, c1]))
+        self.assertFalse(coord.is_coord_subset([c1, c2], [c2, c3]))
+        self.assertFalse(coord.is_coord_subset([c1, c2], [c2]))
 
     def test_coord_list_mapping(self):
         c1 = [0, 0.124, 0]
@@ -58,10 +42,10 @@ class CoordUtilsTest(PymatgenTest):
         c3 = [3, 2, 1]
         a = np.array([c1, c2])
         b = np.array([c3, c2, c1])
-        inds = coord_list_mapping(a, b)
+        inds = coord.coord_list_mapping(a, b)
         self.assertTrue(np.allclose(a, b[inds]))
-        self.assertRaises(Exception, coord_list_mapping, [c1, c2], [c2, c3])
-        self.assertRaises(Exception, coord_list_mapping, [c2], [c2, c2])
+        self.assertRaises(Exception, coord.coord_list_mapping, [c1, c2], [c2, c3])
+        self.assertRaises(Exception, coord.coord_list_mapping, [c2], [c2, c2])
 
     def test_coord_list_mapping_pbc(self):
         c1 = [0.1, 0.2, 0.3]
@@ -72,89 +56,89 @@ class CoordUtilsTest(PymatgenTest):
         a = np.array([c1, c3, c2])
         b = np.array([c4, c2, c1])
 
-        inds = coord_list_mapping_pbc(a, b)
+        inds = coord.coord_list_mapping_pbc(a, b)
         diff = a - b[inds]
         diff -= np.round(diff)
         self.assertTrue(np.allclose(diff, 0))
-        self.assertRaises(Exception, coord_list_mapping_pbc, [c1, c2], [c2, c3])
-        self.assertRaises(Exception, coord_list_mapping_pbc, [c2], [c2, c2])
+        self.assertRaises(Exception, coord.coord_list_mapping_pbc, [c1, c2], [c2, c3])
+        self.assertRaises(Exception, coord.coord_list_mapping_pbc, [c2], [c2, c2])
 
     def test_find_in_coord_list(self):
         coords = [[0, 0, 0], [0.5, 0.5, 0.5]]
         test_coord = [0.1, 0.1, 0.1]
-        self.assertEqual(find_in_coord_list(coords, test_coord).size, 0)
-        self.assertEqual(find_in_coord_list(coords, test_coord, atol=0.15)[0], 0)
-        self.assertEqual(find_in_coord_list([0.99, 0.99, 0.99], test_coord, atol=0.15).size, 0)
+        self.assertEqual(coord.find_in_coord_list(coords, test_coord).size, 0)
+        self.assertEqual(coord.find_in_coord_list(coords, test_coord, atol=0.15)[0], 0)
+        self.assertEqual(coord.find_in_coord_list([0.99, 0.99, 0.99], test_coord, atol=0.15).size, 0)
         coords = [[0, 0, 0], [0.5, 0.5, 0.5], [0.1, 0.1, 0.1]]
-        self.assertArrayEqual(find_in_coord_list(coords, test_coord, atol=0.15), [0, 2])
+        self.assertArrayEqual(coord.find_in_coord_list(coords, test_coord, atol=0.15), [0, 2])
 
     def test_all_distances(self):
         coords1 = [[0, 0, 0], [0.5, 0.5, 0.5]]
         coords2 = [[1, 2, -1], [1, 0, 0], [1, 0, 0]]
         result = [[2.44948974, 1, 1], [2.17944947, 0.8660254, 0.8660254]]
-        self.assertArrayAlmostEqual(all_distances(coords1, coords2), result, 4)
+        self.assertArrayAlmostEqual(coord.all_distances(coords1, coords2), result, 4)
 
     def test_pbc_diff(self):
-        self.assertArrayAlmostEqual(pbc_diff([0.1, 0.1, 0.1], [0.3, 0.5, 0.9]), [-0.2, -0.4, 0.2])
-        self.assertArrayAlmostEqual(pbc_diff([0.9, 0.1, 1.01], [0.3, 0.5, 0.9]), [-0.4, -0.4, 0.11])
-        self.assertArrayAlmostEqual(pbc_diff([0.1, 0.6, 1.01], [0.6, 0.1, 0.9]), [-0.5, 0.5, 0.11])
-        self.assertArrayAlmostEqual(pbc_diff([100.1, 0.2, 0.3], [0123123.4, 0.5, 502312.6]), [-0.3, -0.3, -0.3])
+        self.assertArrayAlmostEqual(coord.pbc_diff([0.1, 0.1, 0.1], [0.3, 0.5, 0.9]), [-0.2, -0.4, 0.2])
+        self.assertArrayAlmostEqual(coord.pbc_diff([0.9, 0.1, 1.01], [0.3, 0.5, 0.9]), [-0.4, -0.4, 0.11])
+        self.assertArrayAlmostEqual(coord.pbc_diff([0.1, 0.6, 1.01], [0.6, 0.1, 0.9]), [-0.5, 0.5, 0.11])
+        self.assertArrayAlmostEqual(coord.pbc_diff([100.1, 0.2, 0.3], [0123123.4, 0.5, 502312.6]), [-0.3, -0.3, -0.3])
 
     def test_in_coord_list_pbc(self):
         coords = [[0, 0, 0], [0.5, 0.5, 0.5]]
         test_coord = [0.1, 0.1, 0.1]
-        self.assertFalse(in_coord_list_pbc(coords, test_coord))
-        self.assertTrue(in_coord_list_pbc(coords, test_coord, atol=0.15))
+        self.assertFalse(coord.in_coord_list_pbc(coords, test_coord))
+        self.assertTrue(coord.in_coord_list_pbc(coords, test_coord, atol=0.15))
         test_coord = [0.99, 0.99, 0.99]
-        self.assertFalse(in_coord_list_pbc(coords, test_coord, atol=0.01))
+        self.assertFalse(coord.in_coord_list_pbc(coords, test_coord, atol=0.01))
 
     def test_find_in_coord_list_pbc(self):
         coords = [[0, 0, 0], [0.5, 0.5, 0.5]]
         test_coord = [0.1, 0.1, 0.1]
-        self.assertEqual(find_in_coord_list_pbc(coords, test_coord).size, 0)
-        self.assertEqual(find_in_coord_list_pbc(coords, test_coord, atol=0.15)[0], 0)
+        self.assertEqual(coord.find_in_coord_list_pbc(coords, test_coord).size, 0)
+        self.assertEqual(coord.find_in_coord_list_pbc(coords, test_coord, atol=0.15)[0], 0)
         test_coord = [0.99, 0.99, 0.99]
-        self.assertEqual(find_in_coord_list_pbc(coords, test_coord, atol=0.02)[0], 0)
+        self.assertEqual(coord.find_in_coord_list_pbc(coords, test_coord, atol=0.02)[0], 0)
         test_coord = [-0.499, -0.499, -0.499]
-        self.assertEqual(find_in_coord_list_pbc(coords, test_coord, atol=0.01)[0], 1)
+        self.assertEqual(coord.find_in_coord_list_pbc(coords, test_coord, atol=0.01)[0], 1)
 
     def test_is_coord_subset_pbc(self):
         c1 = [0, 0, 0]
         c2 = [0, 1.2, -1]
         c3 = [2.3, 0, 1]
         c4 = [1.3 - 9e-9, -1 - 9e-9, 1 - 9e-9]
-        self.assertTrue(is_coord_subset_pbc([c1, c2, c3], [c1, c4, c2]))
-        self.assertTrue(is_coord_subset_pbc([c1], [c2, c1]))
-        self.assertTrue(is_coord_subset_pbc([c1, c2], [c2, c1]))
-        self.assertFalse(is_coord_subset_pbc([c1, c2], [c2, c3]))
-        self.assertFalse(is_coord_subset_pbc([c1, c2], [c2]))
+        self.assertTrue(coord.is_coord_subset_pbc([c1, c2, c3], [c1, c4, c2]))
+        self.assertTrue(coord.is_coord_subset_pbc([c1], [c2, c1]))
+        self.assertTrue(coord.is_coord_subset_pbc([c1, c2], [c2, c1]))
+        self.assertFalse(coord.is_coord_subset_pbc([c1, c2], [c2, c3]))
+        self.assertFalse(coord.is_coord_subset_pbc([c1, c2], [c2]))
 
         # test tolerances
         c5 = [0.1, 0.1, 0.2]
         atol1 = [0.25, 0.15, 0.15]
         atol2 = [0.15, 0.15, 0.25]
-        self.assertFalse(is_coord_subset_pbc([c1], [c5], atol1))
-        self.assertTrue(is_coord_subset_pbc([c1], [c5], atol2))
+        self.assertFalse(coord.is_coord_subset_pbc([c1], [c5], atol1))
+        self.assertTrue(coord.is_coord_subset_pbc([c1], [c5], atol2))
 
         # test mask
         mask1 = [[True]]
-        self.assertFalse(is_coord_subset_pbc([c1], [c5], atol2, mask1))
+        self.assertFalse(coord.is_coord_subset_pbc([c1], [c5], atol2, mask1))
         mask2 = [[True, False]]
-        self.assertTrue(is_coord_subset_pbc([c1], [c2, c1], mask=mask2))
-        self.assertFalse(is_coord_subset_pbc([c1], [c1, c2], mask=mask2))
+        self.assertTrue(coord.is_coord_subset_pbc([c1], [c2, c1], mask=mask2))
+        self.assertFalse(coord.is_coord_subset_pbc([c1], [c1, c2], mask=mask2))
         mask3 = [[False, True]]
-        self.assertFalse(is_coord_subset_pbc([c1], [c2, c1], mask=mask3))
-        self.assertTrue(is_coord_subset_pbc([c1], [c1, c2], mask=mask3))
+        self.assertFalse(coord.is_coord_subset_pbc([c1], [c2, c1], mask=mask3))
+        self.assertTrue(coord.is_coord_subset_pbc([c1], [c1, c2], mask=mask3))
 
     def test_lattice_points_in_supercell(self):
         supercell = np.array([[1, 3, 5], [-3, 2, 3], [-5, 3, 1]])
-        points = lattice_points_in_supercell(supercell)
+        points = coord.lattice_points_in_supercell(supercell)
         self.assertAlmostEqual(len(points), abs(np.linalg.det(supercell)))
         self.assertGreaterEqual(np.min(points), -1e-10)
         self.assertLessEqual(np.max(points), 1 - 1e-10)
 
         supercell = np.array([[-5, -5, -3], [0, -4, -2], [0, -5, -2]])
-        points = lattice_points_in_supercell(supercell)
+        points = coord.lattice_points_in_supercell(supercell)
         self.assertAlmostEqual(len(points), abs(np.linalg.det(supercell)))
         self.assertGreaterEqual(np.min(points), -1e-10)
         self.assertLessEqual(np.max(points), 1 - 1e-10)
@@ -163,7 +147,7 @@ class CoordUtilsTest(PymatgenTest):
         # 2d test
         simplex1 = np.array([[0.3, 0.1], [0.2, -1.2], [1.3, 2.3]])
         pts1 = np.array([[0.6, 0.1], [1.3, 2.3], [0.5, 0.5], [0.7, 1]])
-        output1 = barycentric_coords(pts1, simplex1)
+        output1 = coord.barycentric_coords(pts1, simplex1)
         # do back conversion to cartesian
         o_dot_s = np.sum(output1[:, :, None] * simplex1[None, :, :], axis=1)
         self.assertTrue(np.allclose(pts1, o_dot_s))
@@ -171,13 +155,13 @@ class CoordUtilsTest(PymatgenTest):
         # do 3d tests
         simplex2 = np.array([[0, 0, 1], [0, 1, 0], [1, 0, 0], [0, 0, 0]])
         pts2 = np.array([[0, 0, 1], [0, 0.5, 0.5], [1.0 / 3, 1.0 / 3, 1.0 / 3]])
-        output2 = barycentric_coords(pts2, simplex2)
+        output2 = coord.barycentric_coords(pts2, simplex2)
         self.assertTrue(np.allclose(output2[1], [0.5, 0.5, 0, 0]))
         # do back conversion to cartesian
         o_dot_s = np.sum(output2[:, :, None] * simplex2[None, :, :], axis=1)
         self.assertTrue(np.allclose(pts2, o_dot_s))
         # test single point
-        self.assertTrue(np.allclose(output2[2], barycentric_coords(pts2[2], simplex2)))
+        self.assertTrue(np.allclose(output2[2], coord.barycentric_coords(pts2[2], simplex2)))
 
     def test_pbc_shortest_vectors(self):
         fcoords = np.array(
@@ -199,7 +183,7 @@ class CoordUtilsTest(PymatgenTest):
             ]
         )
 
-        vectors = pbc_shortest_vectors(lattice, fcoords[:-1], fcoords)
+        vectors = coord.pbc_shortest_vectors(lattice, fcoords[:-1], fcoords)
         dists = np.sum(vectors ** 2, axis=-1) ** 0.5
         self.assertArrayAlmostEqual(dists, expected, 3)
 
@@ -209,7 +193,7 @@ class CoordUtilsTest(PymatgenTest):
         prev_threshold = coord.LOOP_THRESHOLD
         coord.LOOP_THRESHOLD = 0
 
-        vectors = pbc_shortest_vectors(lattice, fcoords[:-1], fcoords)
+        vectors = coord.pbc_shortest_vectors(lattice, fcoords[:-1], fcoords)
         dists = np.sum(vectors ** 2, axis=-1) ** 0.5
         self.assertArrayAlmostEqual(dists, expected, 3)
 
@@ -218,8 +202,8 @@ class CoordUtilsTest(PymatgenTest):
     def test_get_angle(self):
         v1 = (1, 0, 0)
         v2 = (1, 1, 1)
-        self.assertAlmostEqual(get_angle(v1, v2), 54.7356103172)
-        self.assertAlmostEqual(get_angle(v1, v2, units="radians"), 0.9553166181245092)
+        self.assertAlmostEqual(coord.get_angle(v1, v2), 54.7356103172)
+        self.assertAlmostEqual(coord.get_angle(v1, v2, units="radians"), 0.9553166181245092)
 
 
 class SimplexTest(PymatgenTest):
@@ -229,12 +213,12 @@ class SimplexTest(PymatgenTest):
         coords.append([0, 1, 0])
         coords.append([0, 0, 1])
         coords.append([1, 0, 0])
-        self.simplex = Simplex(coords)
+        self.simplex = coord.Simplex(coords)
 
     def test_equal(self):
         c2 = list(self.simplex.coords)
         random.shuffle(c2)
-        self.assertEqual(Simplex(c2), self.simplex)
+        self.assertEqual(coord.Simplex(c2), self.simplex)
 
     def test_in_simplex(self):
         self.assertTrue(self.simplex.in_simplex([0.1, 0.1, 0.1]))
@@ -244,13 +228,13 @@ class SimplexTest(PymatgenTest):
             self.assertTrue(self.simplex.in_simplex(coord))
 
     def test_2dtriangle(self):
-        s = Simplex([[0, 1], [1, 1], [1, 0]])
+        s = coord.Simplex([[0, 1], [1, 1], [1, 0]])
         self.assertArrayAlmostEqual(s.bary_coords([0.5, 0.5]), [0.5, 0, 0.5])
         self.assertArrayAlmostEqual(s.bary_coords([0.5, 1]), [0.5, 0.5, 0])
         self.assertArrayAlmostEqual(s.bary_coords([0.5, 0.75]), [0.5, 0.25, 0.25])
         self.assertArrayAlmostEqual(s.bary_coords([0.75, 0.75]), [0.25, 0.5, 0.25])
 
-        s = Simplex([[1, 1], [1, 0]])
+        s = coord.Simplex([[1, 1], [1, 0]])
         self.assertRaises(ValueError, s.bary_coords, [0.5, 0.5])
 
     def test_volume(self):
@@ -262,7 +246,7 @@ class SimplexTest(PymatgenTest):
         self.assertTrue(repr(self.simplex).startswith("3-simplex in 4D space"))
 
     def test_bary_coords(self):
-        s = Simplex([[0, 2], [3, 1], [1, 0]])
+        s = coord.Simplex([[0, 2], [3, 1], [1, 0]])
         point = [0.7, 0.5]
         bc = s.bary_coords(point)
         self.assertArrayAlmostEqual(bc, [0.26, -0.02, 0.76])
@@ -271,7 +255,7 @@ class SimplexTest(PymatgenTest):
 
     def test_intersection(self):
         # simple test, with 2 intersections at faces
-        s = Simplex([[0, 2], [3, 1], [1, 0]])
+        s = coord.Simplex([[0, 2], [3, 1], [1, 0]])
         point1 = [0.7, 0.5]
         point2 = [0.5, 0.7]
         intersections = s.line_intersection(point1, point2)

--- a/pymatgen/util/tests/test_coord.py
+++ b/pymatgen/util/tests/test_coord.py
@@ -6,8 +6,8 @@ import random
 
 import numpy as np
 
-import pymatgen.util.coord as coord
 from pymatgen.core.lattice import Lattice
+from pymatgen.util import coord
 from pymatgen.util.testing import PymatgenTest
 
 
@@ -186,9 +186,6 @@ class CoordUtilsTest(PymatgenTest):
         vectors = coord.pbc_shortest_vectors(lattice, fcoords[:-1], fcoords)
         dists = np.sum(vectors ** 2, axis=-1) ** 0.5
         self.assertArrayAlmostEqual(dists, expected, 3)
-
-        # now try with small loop threshold
-        from pymatgen.util import coord
 
         prev_threshold = coord.LOOP_THRESHOLD
         coord.LOOP_THRESHOLD = 0


### PR DESCRIPTION
Add `--ignore-init-module-imports` to `autoflake` hook in `.pre-commit-config.yaml`. Applies all the other rules across the code base.