### PR TITLE
PDEntry.__repr__ include name attr if not fallback value

### DIFF
--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -69,6 +69,12 @@ class PDEntry(Entry):
         self.name = name if name else self.composition.reduced_formula
         self.attribute = attribute
 
+    def __repr__(self):
+        name = ""
+        if self.name != self.composition.reduced_formula:
+            name = f" ({self.name})"
+        return f"{self.__class__.__name__} : {self.composition}{name} with energy = {self.energy:.4f}"
+
     @property
     def energy(self) -> float:
         """

--- a/pymatgen/analysis/tests/test_phase_diagram.py
+++ b/pymatgen/analysis/tests/test_phase_diagram.py
@@ -1,17 +1,16 @@
 # Copyright (c) Pymatgen Development Team.
 # Distributed under the terms of the MIT License.
 
+import json
 import os
 import unittest
 import warnings
+from collections import OrderedDict
 from numbers import Number
 from pathlib import Path
-from collections import OrderedDict
-import json
-
-from monty.json import MontyEncoder, MontyDecoder
 
 import numpy as np
+from monty.json import MontyDecoder, MontyEncoder
 
 from pymatgen.analysis.phase_diagram import (
     CompoundPhaseDiagram,
@@ -37,7 +36,7 @@ module_dir = Path(__file__).absolute().parent
 class PDEntryTest(unittest.TestCase):
     def setUp(self):
         comp = Composition("LiFeO2")
-        self.entry = PDEntry(comp, 53)
+        self.entry = PDEntry(comp, 53, name="mp-757614")
         self.gpentry = GrandPotPDEntry(self.entry, {Element("O"): 1.5})
 
     def test_get_energy(self):
@@ -86,7 +85,11 @@ class PDEntryTest(unittest.TestCase):
             self.fail("Should not need to supply name!")
 
     def test_str(self):
-        self.assertIsNotNone(str(self.entry))
+        self.assertEqual(str(self.entry), "PDEntry : Li1 Fe1 O2 (mp-757614) with energy = 53.0000")
+        pde = self.entry.as_dict()
+        del pde["name"]
+        pde = PDEntry.from_dict(pde)
+        self.assertEqual(str(pde), "PDEntry : Li1 Fe1 O2 with energy = 53.0000")
 
     def test_read_csv(self):
         entries = EntrySet.from_csv(str(module_dir / "pdentries_test.csv"))


### PR DESCRIPTION
Override `Entry.__repr__` in `PDEntry` to include the `name` if its not the fallback value of reduced composition.

**Before**

```py
PDEntry("LiFeO2", 53, name="mp-757614")
>>> PDEntry : Li1 Fe1 O2 with energy = 53.0000
```

**After**

```py
PDEntry("LiFeO2", 53, name="mp-757614")
>>> PDEntry : Li1 Fe1 O2 (mp-757614) with energy = 53.0000

PDEntry("LiFeO2", 53)
>>> PDEntry : Li1 Fe1 O2 with energy = 53.0000
```

Added a test for both cases.

We could also do

```py
PDEntry mp-757614 : Li1 Fe1 O2 with energy = 53.0000
```

if preferred.