### PR TITLE
Compat.process_entry

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,8 @@
 exclude: ^(docs|.*test_files|cmd_line|dev_scripts)
 
+default_language_version:
+  python: python3.8
+
 repos:
   - repo: https://github.com/psf/black
     rev: 21.12b0
@@ -34,3 +37,8 @@ repos:
           - --remove-all-unused-imports
           - --expand-star-imports
           - --ignore-init-module-imports
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.930
+    hooks:
+      - id: mypy

--- a/pymatgen/analysis/tests/test_phase_diagram.py
+++ b/pymatgen/analysis/tests/test_phase_diagram.py
@@ -1,16 +1,13 @@
 # Copyright (c) Pymatgen Development Team.
 # Distributed under the terms of the MIT License.
 
-import json
 import os
 import unittest
 import warnings
 from numbers import Number
 from pathlib import Path
-from collections import OrderedDict
 
 import numpy as np
-from monty.json import MontyDecoder, MontyEncoder
 
 from pymatgen.analysis.phase_diagram import (
     CompoundPhaseDiagram,
@@ -105,7 +102,7 @@ class TransformedPDEntryTest(unittest.TestCase):
         terminal_compositions = ["Li2O", "FeO", "LiO8"]
         terminal_compositions = [Composition(c) for c in terminal_compositions]
 
-        sp_mapping = OrderedDict()
+        sp_mapping = {}
         for i, comp in enumerate(terminal_compositions):
             sp_mapping[comp] = DummySpecies("X" + chr(102 + i))
 

--- a/pymatgen/entries/compatibility.py
+++ b/pymatgen/entries/compatibility.py
@@ -535,7 +535,7 @@ class Compatibility(MSONable, metaclass=abc.ABCMeta):
             CompatibilityError if the entry is not compatible
         """
 
-    def process_entry(self, entry):
+    def process_entry(self, entry: ComputedEntry) -> Optional[ComputedEntry]:
         """
         Process a single entry with the chosen Corrections. Note
         that this method will change the data of the original entry.
@@ -546,13 +546,14 @@ class Compatibility(MSONable, metaclass=abc.ABCMeta):
             An adjusted entry if entry is compatible, otherwise None is
             returned.
         """
-        if self.process_entries(entry):
+        try:
             return self.process_entries(entry)[0]
-        return None
+        except IndexError:
+            return None
 
     def process_entries(
         self, entries: Union[ComputedEntry, ComputedStructureEntry, list], clean: bool = True, verbose: bool = False
-    ):
+    ) -> List[ComputedEntry]:
         """
         Process a sequence of entries with the chosen Compatibility scheme. Note
         that this method will change the data of the original entries.


### PR DESCRIPTION
`Compatibility.process_entry()` needlessly does its work twice to check if it got a result. More EAFP to use `try/except`.