### PR TITLE
Drop-ordered-dict

### DIFF
--- a/dev_scripts/regen_libxcfunc.py
+++ b/dev_scripts/regen_libxcfunc.py
@@ -7,11 +7,9 @@ and update the enum values declared in LibxcFunc.
 The script must be executed inside pymatgen/dev_scripts.
 """
 
-import sys
-import os
 import json
-
-from collections import OrderedDict
+import os
+import sys
 
 
 def parse_libxc_docs(path):
@@ -29,7 +27,7 @@ def parse_libxc_docs(path):
 
         return int(d["Number"]), d
 
-    d = OrderedDict()
+    d = {}
     with open(path) as fh:
         section = []
         for line in fh:

--- a/pymatgen/analysis/chemenv/coordination_environments/chemenv_strategies.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/chemenv_strategies.py
@@ -19,7 +19,6 @@ __date__ = "Feb 20, 2016"
 
 import abc
 import os
-from collections import OrderedDict
 from typing import Dict, List, Optional
 
 import numpy as np
@@ -198,7 +197,7 @@ class AbstractChemenvStrategy(MSONable, metaclass=abc.ABCMeta):
     """
 
     AC = AdditionalConditions()
-    STRATEGY_OPTIONS = OrderedDict()  # type: Dict[str, Dict]
+    STRATEGY_OPTIONS = {}  # type: Dict[str, Dict]
     STRATEGY_DESCRIPTION = None  # type: str
     STRATEGY_INFO_FIELDS = []  # type: List
     DEFAULT_SYMMETRY_MEASURE_TYPE = "csm_wcs_ctwcc"
@@ -483,7 +482,7 @@ class SimplestChemenvStrategy(AbstractChemenvStrategy):
     DEFAULT_ANGLE_CUTOFF = 0.3
     DEFAULT_CONTINUOUS_SYMMETRY_MEASURE_CUTOFF = 10.0
     DEFAULT_ADDITIONAL_CONDITION = AbstractChemenvStrategy.AC.ONLY_ACB
-    STRATEGY_OPTIONS = OrderedDict()  # type: Dict[str, Dict]
+    STRATEGY_OPTIONS = {}  # type: Dict[str, Dict]
     STRATEGY_OPTIONS["distance_cutoff"] = {
         "type": DistanceCutoffFloat,
         "internal": "_distance_cutoff",
@@ -873,7 +872,7 @@ class SimpleAbundanceChemenvStrategy(AbstractChemenvStrategy):
 
     DEFAULT_MAX_DIST = 2.0
     DEFAULT_ADDITIONAL_CONDITION = AbstractChemenvStrategy.AC.ONLY_ACB
-    STRATEGY_OPTIONS = OrderedDict()  # type: Dict[str, Dict]
+    STRATEGY_OPTIONS = {}  # type: Dict[str, Dict]
     STRATEGY_OPTIONS["additional_condition"] = {
         "type": AdditionalConditionInt,
         "internal": "_additional_condition",

--- a/pymatgen/analysis/chemenv/coordination_environments/coordination_geometry_finder.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/coordination_geometry_finder.py
@@ -23,7 +23,6 @@ __date__ = "Feb 20, 2016"
 import itertools
 import logging
 import time
-from collections import OrderedDict
 from random import shuffle
 
 import numpy as np
@@ -734,7 +733,7 @@ class LocalGeometryFinder:
             logging.debug(f" ... in site #{isite:d}/{len(self.structure):d} ({site.species_string})")
             t1 = time.process_time()
             if optimization > 0:
-                self.detailed_voronoi.local_planes[isite] = OrderedDict()
+                self.detailed_voronoi.local_planes[isite] = {}
                 self.detailed_voronoi.separations[isite] = {}
             se.init_neighbors_sets(
                 isite=isite,
@@ -875,7 +874,7 @@ class LocalGeometryFinder:
         self.setup_local_geometry(isite, coords=neighb_coords, optimization=optimization)
         if optimization > 0:
             logging.debug("Getting StructureEnvironments with optimized algorithm")
-            nb_set.local_planes = OrderedDict()
+            nb_set.local_planes = {}
             nb_set.separations = {}
             cncgsm = self.get_coordination_symmetry_measures_optim(nb_set=nb_set, optimization=optimization)
         else:

--- a/pymatgen/analysis/chemenv/coordination_environments/structure_environments.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/structure_environments.py
@@ -18,7 +18,6 @@ __maintainer__ = "David Waroquiers"
 __email__ = "david.waroquiers@gmail.com"
 __date__ = "Feb 20, 2016"
 
-from collections import OrderedDict
 
 import numpy as np
 from monty.json import MontyDecoder, MSONable, jsanitize
@@ -294,7 +293,7 @@ class StructureEnvironments(MSONable):
             next_dists = [src["dp_dict"]["next"] for src in mysrc]
             next_angs = [src["ap_dict"]["next"] for src in mysrc]
 
-            points_dict = OrderedDict()
+            points_dict = {}
 
             pdists = []
             pangs = []

--- a/pymatgen/analysis/chemenv/utils/scripts_utils.py
+++ b/pymatgen/analysis/chemenv/utils/scripts_utils.py
@@ -7,7 +7,6 @@ This module contains some script utils that are used in the chemenv package.
 
 
 import re
-from collections import OrderedDict
 
 import numpy as np
 
@@ -40,7 +39,6 @@ from pymatgen.analysis.chemenv.utils.defs_utils import chemenv_citations
 from pymatgen.core.sites import PeriodicSite
 from pymatgen.core.structure import Molecule
 
-
 __author__ = "David Waroquiers"
 __copyright__ = "Copyright 2012, The Materials Project"
 __credits__ = "Geoffroy Hautier"
@@ -49,7 +47,7 @@ __maintainer__ = "David Waroquiers"
 __email__ = "david.waroquiers@gmail.com"
 __date__ = "Feb 20, 2016"
 
-strategies_class_lookup = OrderedDict()  # type: dict
+strategies_class_lookup = {}
 strategies_class_lookup["SimplestChemenvStrategy"] = SimplestChemenvStrategy
 
 

--- a/pymatgen/analysis/elasticity/elastic.py
+++ b/pymatgen/analysis/elasticity/elastic.py
@@ -981,8 +981,7 @@ def get_strain_state_dict(strains, stresses, eq_stress=None, tol=1e-10, add_eq=T
         sort (bool): flag for whether to sort strain states
 
     Returns:
-        OrderedDict with strain state keys and dictionaries
-        with stress-strain data corresponding to strain state
+        dict: strain state keys and dictionaries with stress-strain data corresponding to strain state
     """
     # Recast stress/strains
     vstrains = np.array([Strain(s).zeroed(tol).voigt for s in strains])  # pylint: disable=E1101

--- a/pymatgen/analysis/elasticity/elastic.py
+++ b/pymatgen/analysis/elasticity/elastic.py
@@ -10,7 +10,6 @@ stress-strain data
 
 import itertools
 import warnings
-from collections import OrderedDict
 
 import numpy as np
 import sympy as sp
@@ -990,7 +989,7 @@ def get_strain_state_dict(strains, stresses, eq_stress=None, tol=1e-10, add_eq=T
     vstresses = np.array([Stress(s).zeroed(tol).voigt for s in stresses])  # pylint: disable=E1101
     # Collect independent strain states:
     independent = {tuple(np.nonzero(vstrain)[0].tolist()) for vstrain in vstrains}
-    strain_state_dict = OrderedDict()
+    strain_state_dict = {}
     if add_eq:
         if eq_stress is not None:
             veq_stress = Stress(eq_stress).voigt

--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -1349,7 +1349,7 @@ class CompoundPhaseDiagram(PhaseDiagram):
             terminal_compositions = [c.fractional_composition for c in terminal_compositions]
 
         # Map terminal compositions to unique dummy species.
-        sp_mapping = collections.OrderedDict()
+        sp_mapping = {}
         for i, comp in enumerate(terminal_compositions):
             sp_mapping[comp] = DummySpecies("X" + chr(102 + i))
 
@@ -1533,7 +1533,7 @@ class ReactionDiagram:
         self.entry1 = entry1
         self.entry2 = entry2
         self.rxn_entries = rxn_entries
-        self.labels = collections.OrderedDict()
+        self.labels = {}
         for i, e in enumerate(rxn_entries):
             self.labels[str(i + 1)] = e.attribute
             e.name = str(i + 1)

--- a/pymatgen/analysis/tests/test_phase_diagram.py
+++ b/pymatgen/analysis/tests/test_phase_diagram.py
@@ -1,16 +1,13 @@
 # Copyright (c) Pymatgen Development Team.
 # Distributed under the terms of the MIT License.
 
-import json
 import os
 import unittest
 import warnings
 from numbers import Number
 from pathlib import Path
-from collections import OrderedDict
 
 import numpy as np
-from monty.json import MontyDecoder, MontyEncoder
 
 from pymatgen.analysis.phase_diagram import (
     CompoundPhaseDiagram,
@@ -105,7 +102,7 @@ class TransformedPDEntryTest(unittest.TestCase):
         terminal_compositions = ["Li2O", "FeO", "LiO8"]
         terminal_compositions = [Composition(c) for c in terminal_compositions]
 
-        sp_mapping = OrderedDict()
+        sp_mapping = {}
         for i, comp in enumerate(terminal_compositions):
             sp_mapping[comp] = DummySpecies("X" + chr(102 + i))
 

--- a/pymatgen/apps/battery/plotter.py
+++ b/pymatgen/apps/battery/plotter.py
@@ -15,8 +15,6 @@ __email__ = "shyuep@gmail.com"
 __date__ = "Jul 12, 2012"
 
 
-from collections import OrderedDict
-
 import plotly.graph_objects as go
 from pymatgen.util.plotting import pretty_plot
 
@@ -36,7 +34,7 @@ class VoltageProfilePlotter:
             - frac_x: the atomic fraction of the working ion
             hide_negative: If True only plot the voltage steps above zero
         """
-        self._electrodes = OrderedDict()
+        self._electrodes = {}
         self.xaxis = xaxis
         self.hide_negative = hide_negative
 

--- a/pymatgen/cli/feff_plot_dos.py
+++ b/pymatgen/cli/feff_plot_dos.py
@@ -17,7 +17,6 @@ __email__ = "adozier@uky.edu"
 __date__ = "April 7, 2012"
 
 import argparse
-from collections import OrderedDict
 
 from pymatgen.electronic_structure.plotter import DosPlotter
 from pymatgen.io.feff.outputs import LDos
@@ -71,7 +70,7 @@ def main():
     f = LDos.from_file(args.filename1[0], args.filename[0])
     dos = f.complete_dos
 
-    all_dos = OrderedDict()
+    all_dos = {}
     all_dos["Total"] = dos
 
     structure = f.complete_dos.structure

--- a/pymatgen/cli/pmg_plot.py
+++ b/pymatgen/cli/pmg_plot.py
@@ -6,7 +6,6 @@
 Implementation for `pmg plot` CLI.
 """
 
-from collections import OrderedDict
 
 from pymatgen.core.structure import Structure
 from pymatgen.analysis.diffraction.xrd import XRDCalculator
@@ -25,7 +24,7 @@ def get_dos_plot(args):
     v = Vasprun(args.dos_file)
     dos = v.complete_dos
 
-    all_dos = OrderedDict()
+    all_dos = {}
     all_dos["Total"] = dos
 
     structure = v.final_structure

--- a/pymatgen/core/tests/test_units.py
+++ b/pymatgen/core/tests/test_units.py
@@ -2,8 +2,6 @@
 # Distributed under the terms of the MIT License.
 
 
-import collections
-
 from pymatgen.core.units import (
     ArrayWithUnit,
     Energy,
@@ -113,7 +111,7 @@ class FloatWithUnitTest(PymatgenTest):
             return d
 
         self.assertEqual(str(h()[1]), "20.0 pm")
-        self.assertIsInstance(h(), collections.OrderedDict)
+        self.assertIsInstance(h(), dict)
 
         @unitized("kg")
         def i():

--- a/pymatgen/core/tests/test_units.py
+++ b/pymatgen/core/tests/test_units.py
@@ -107,7 +107,7 @@ class FloatWithUnitTest(PymatgenTest):
 
         @unitized("pm")
         def h():
-            d = collections.OrderedDict()
+            d = {}
             for i in range(3):
                 d[i] = i * 20
             return d

--- a/pymatgen/core/xcfunc.py
+++ b/pymatgen/core/xcfunc.py
@@ -4,7 +4,7 @@
 This module provides
 """
 
-from collections import OrderedDict, namedtuple
+from collections import namedtuple
 
 from monty.functools import lazy_property
 from monty.json import MSONable  # , MontyEncoder
@@ -75,26 +75,25 @@ class XcFunc(MSONable):
     type_name = namedtuple("type_name", "type, name")
 
     xcf = LibxcFunc
-    defined_aliases = OrderedDict(
-        [  # (x, c) --> type_name
-            # LDAs
-            ((xcf.LDA_X, xcf.LDA_C_PW), type_name("LDA", "PW")),  # ixc 7
-            ((xcf.LDA_X, xcf.LDA_C_PW_MOD), type_name("LDA", "PW_MOD")),
-            ((xcf.LDA_X, xcf.LDA_C_PZ), type_name("LDA", "PZ")),  # ixc 2
-            ((xcf.LDA_X, xcf.LDA_C_WIGNER), type_name("LDA", "W")),  # ixc 4
-            ((xcf.LDA_X, xcf.LDA_C_HL), type_name("LDA", "HL")),  # ixc 5
-            ((xcf.LDA_X, xcf.LDA_C_GL), type_name("LDA", "GL")),
-            ((xcf.LDA_X, xcf.LDA_C_VWN), type_name("LDA", "VWN")),
-            # GGAs
-            ((xcf.GGA_X_PW91, xcf.GGA_C_PW91), type_name("GGA", "PW91")),
-            ((xcf.GGA_X_PBE, xcf.GGA_C_PBE), type_name("GGA", "PBE")),
-            ((xcf.GGA_X_RPBE, xcf.GGA_C_PBE), type_name("GGA", "RPBE")),  # ixc 15
-            ((xcf.GGA_X_PBE_R, xcf.GGA_C_PBE), type_name("GGA", "revPBE")),  # ixc 14
-            ((xcf.GGA_X_PBE_SOL, xcf.GGA_C_PBE_SOL), type_name("GGA", "PBEsol")),
-            ((xcf.GGA_X_AM05, xcf.GGA_C_AM05), type_name("GGA", "AM05")),
-            ((xcf.GGA_X_B88, xcf.GGA_C_LYP), type_name("GGA", "BLYP")),
-        ]
-    )
+    defined_aliases = {  # (x, c) --> type_name
+        # LDAs
+        (xcf.LDA_X, xcf.LDA_C_PW): type_name("LDA", "PW"),  # ixc 7
+        (xcf.LDA_X, xcf.LDA_C_PW_MOD): type_name("LDA", "PW_MOD"),
+        (xcf.LDA_X, xcf.LDA_C_PZ): type_name("LDA", "PZ"),  # ixc 2
+        (xcf.LDA_X, xcf.LDA_C_WIGNER): type_name("LDA", "W"),  # ixc 4
+        (xcf.LDA_X, xcf.LDA_C_HL): type_name("LDA", "HL"),  # ixc 5
+        (xcf.LDA_X, xcf.LDA_C_GL): type_name("LDA", "GL"),
+        (xcf.LDA_X, xcf.LDA_C_VWN): type_name("LDA", "VWN"),
+        # GGAs
+        (xcf.GGA_X_PW91, xcf.GGA_C_PW91): type_name("GGA", "PW91"),
+        (xcf.GGA_X_PBE, xcf.GGA_C_PBE): type_name("GGA", "PBE"),
+        (xcf.GGA_X_RPBE, xcf.GGA_C_PBE): type_name("GGA", "RPBE"),  # ixc 15
+        (xcf.GGA_X_PBE_R, xcf.GGA_C_PBE): type_name("GGA", "revPBE"),  # ixc 14
+        (xcf.GGA_X_PBE_SOL, xcf.GGA_C_PBE_SOL): type_name("GGA", "PBEsol"),
+        (xcf.GGA_X_AM05, xcf.GGA_C_AM05): type_name("GGA", "AM05"),
+        (xcf.GGA_X_B88, xcf.GGA_C_LYP): type_name("GGA", "BLYP"),
+    }
+
     del type_name
 
     # Correspondence between Abinit ixc notation and libxc notation.

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -9,7 +9,7 @@ import itertools
 import logging
 import math
 import warnings
-from collections import Counter, OrderedDict
+from collections import Counter
 
 import matplotlib.lines as mlines
 import numpy as np
@@ -71,7 +71,7 @@ class DosPlotter:
         self.zero_at_efermi = zero_at_efermi
         self.stack = stack
         self.sigma = sigma
-        self._doses = OrderedDict()
+        self._doses = {}
 
     def add_dos(self, label, dos):
         """
@@ -3671,7 +3671,7 @@ class CohpPlotter:
         self.zero_at_efermi = zero_at_efermi
         self.are_coops = are_coops
         self.are_cobis = are_cobis
-        self._cohps = OrderedDict()
+        self._cohps = {}
 
     def add_cohp(self, label, cohp):
         """

--- a/pymatgen/entries/correction_calculator.py
+++ b/pymatgen/entries/correction_calculator.py
@@ -438,13 +438,13 @@ class CorrectionCalculator:
         # elements with U values
         ggaucorrection_species = ["V", "Cr", "Mn", "Fe", "Co", "Ni", "W", "Mo"]
 
-        comp_corr: "OrderedDict[str, float]" = OrderedDict()
-        o: "OrderedDict[str, float]" = OrderedDict()
-        f: "OrderedDict[str, float]" = OrderedDict()
+        comp_corr: Dict[str, float] = {}
+        o: Dict[str, float] = {}
+        f: Dict[str, float] = {}
 
-        comp_corr_error: "OrderedDict[str, float]" = OrderedDict()
-        o_error: "OrderedDict[str, float]" = OrderedDict()
-        f_error: "OrderedDict[str, float]" = OrderedDict()
+        comp_corr_error: Dict[str, float] = {}
+        o_error: Dict[str, float] = {}
+        f_error: Dict[str, float] = {}
 
         for specie in list(self.species) + ["ozonide"]:
             if specie in ggaucorrection_species:

--- a/pymatgen/entries/correction_calculator.py
+++ b/pymatgen/entries/correction_calculator.py
@@ -5,7 +5,6 @@ entries given to the CorrectionCalculator constructor.
 
 import os
 import warnings
-from collections import OrderedDict
 from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
@@ -478,7 +477,6 @@ class CorrectionCalculator:
             path = fn
 
         yml = yaml.YAML()
-        yml.Representer.add_representer(OrderedDict, yml.Representer.represent_dict)
         yml.default_flow_style = False
         contents = yml.load(outline)
 

--- a/pymatgen/io/abinit/abitimer.py
+++ b/pymatgen/io/abinit/abitimer.py
@@ -87,7 +87,7 @@ class AbinitTimerParser(collections.abc.Iterable):
 
         # timers[filename][mpi_rank]
         # contains the timer extracted from the file filename associated to the MPI rank mpi_rank.
-        self._timers = collections.OrderedDict()
+        self._timers = {}
 
     def __iter__(self):
         return self._timers.__iter__()

--- a/pymatgen/io/abinit/inputs.py
+++ b/pymatgen/io/abinit/inputs.py
@@ -774,7 +774,7 @@ class BasicAbinitInput(AbstractInput, MSONable):
         """
         JSON interface used in pymatgen for easier serialization.
         """
-        # Use a list of (key, value) to serialize the OrderedDict
+        # Use a list of (key, value) to serialize the dict
         abi_args = []
         for key, value in self.items():
             if isinstance(value, np.ndarray):

--- a/pymatgen/io/abinit/inputs.py
+++ b/pymatgen/io/abinit/inputs.py
@@ -9,7 +9,7 @@ import copy
 import json
 import logging
 import os
-from collections import OrderedDict, namedtuple
+from collections import namedtuple
 from collections.abc import Mapping, MutableMapping
 from enum import Enum
 
@@ -752,7 +752,7 @@ class BasicAbinitInput(AbstractInput, MSONable):
         args = list(abi_args)[:]
         args.extend(list(abi_kwargs.items()))
 
-        self._vars = OrderedDict(args)
+        self._vars = dict(args)
         self.set_structure(structure)
 
         if pseudo_dir is not None:

--- a/pymatgen/io/abinit/netcdf.py
+++ b/pymatgen/io/abinit/netcdf.py
@@ -7,7 +7,6 @@
 import logging
 import os.path
 import warnings
-from collections import OrderedDict
 
 import numpy as np
 from monty.collections import AttrDict
@@ -468,7 +467,7 @@ _HDR_VARIABLES = (
     ),
     # _H(type(pawrhoij_type), allocatable :: pawrhoij(:) ! EVOLVING variable, only for paw
 )
-_HDR_VARIABLES = OrderedDict([(h.name, h) for h in _HDR_VARIABLES])  # type: ignore
+_HDR_VARIABLES = {h.name: h for h in _HDR_VARIABLES}  # type: ignore
 
 
 class AbinitHeader(AttrDict):

--- a/pymatgen/io/abinit/pseudos.py
+++ b/pymatgen/io/abinit/pseudos.py
@@ -10,7 +10,7 @@ import collections
 import logging
 import os
 import sys
-from collections import OrderedDict, defaultdict, namedtuple
+from collections import defaultdict, namedtuple
 
 import numpy as np
 from monty.collections import AttrDict, Namespace
@@ -880,7 +880,7 @@ class NcAbinitHeader(AbinitHeader):
         # Parse the section with the projectors.
         # 0   4.085   6.246    0   2.8786493        l,e99.0,e99.9,nproj,rcpsp
         # .00000000    .0000000000    .0000000000    .00000000   rms,ekb1,ekb2,epsatm
-        projectors = OrderedDict()
+        projectors = {}
         for idx in range(2 * (lmax + 1)):
             line = lines[idx]
             if idx % 2 == 0:
@@ -1054,19 +1054,17 @@ class PseudoParser:
     ppdesc = namedtuple("ppdesc", "pspcod name psp_type format")
 
     # TODO Recheck
-    _PSPCODES = OrderedDict(
-        {
-            1: ppdesc(1, "TM", "NC", None),
-            2: ppdesc(2, "GTH", "NC", None),
-            3: ppdesc(3, "HGH", "NC", None),
-            4: ppdesc(4, "Teter", "NC", None),
-            # 5: ppdesc(5, "NC",     , None),
-            6: ppdesc(6, "FHI", "NC", None),
-            7: ppdesc(6, "PAW_abinit_text", "PAW", None),
-            8: ppdesc(8, "ONCVPSP", "NC", None),
-            10: ppdesc(10, "HGHK", "NC", None),
-        }
-    )
+    _PSPCODES = {
+        1: ppdesc(1, "TM", "NC", None),
+        2: ppdesc(2, "GTH", "NC", None),
+        3: ppdesc(3, "HGH", "NC", None),
+        4: ppdesc(4, "Teter", "NC", None),
+        # 5: ppdesc(5, "NC",     , None),
+        6: ppdesc(6, "FHI", "NC", None),
+        7: ppdesc(6, "PAW_abinit_text", "PAW", None),
+        8: ppdesc(8, "ONCVPSP", "NC", None),
+        10: ppdesc(10, "HGHK", "NC", None),
+    }
     del ppdesc
 
     # renumber functionals from oncvpsp todo confirm that 3 is 2
@@ -1282,7 +1280,7 @@ class PawXmlSetup(Pseudo, PawPseudo):
         # In this way, we know that only the first two bound states (with f and n attributes)
         # should be used for constructing an initial guess for the wave functions.
 
-        self.valence_states = OrderedDict()
+        self.valence_states = {}
         for node in root.find("valence_states"):
             attrib = AttrDict(node.attrib)
             assert attrib.id not in self.valence_states
@@ -1420,7 +1418,7 @@ class PawXmlSetup(Pseudo, PawPseudo):
     @lazy_property
     def ae_partial_waves(self):
         """Dictionary with the AE partial waves indexed by state."""
-        ae_partial_waves = OrderedDict()
+        ae_partial_waves = {}
         for mesh, values, attrib in self._parse_all_radfuncs("ae_partial_wave"):
             state = attrib["state"]
             # val_state = self.valence_states[state]
@@ -1431,7 +1429,7 @@ class PawXmlSetup(Pseudo, PawPseudo):
     @property
     def pseudo_partial_waves(self):
         """Dictionary with the pseudo partial waves indexed by state."""
-        pseudo_partial_waves = OrderedDict()
+        pseudo_partial_waves = {}
         for (mesh, values, attrib) in self._parse_all_radfuncs("pseudo_partial_wave"):
             state = attrib["state"]
             # val_state = self.valence_states[state]
@@ -1442,7 +1440,7 @@ class PawXmlSetup(Pseudo, PawPseudo):
     @lazy_property
     def projector_functions(self):
         """Dictionary with the PAW projectors indexed by state."""
-        projector_functions = OrderedDict()
+        projector_functions = {}
         for (mesh, values, attrib) in self._parse_all_radfuncs("projector_function"):
             state = attrib["state"]
             # val_state = self.valence_states[state]
@@ -1775,7 +1773,7 @@ class PseudoTable(collections.abc.Sequence, MSONable, metaclass=abc.ABCMeta):
 
             table.all_combinations_for_elements(["Li", "F"])
         """
-        d = OrderedDict()
+        d = {}
         for symbol in element_symbols:
             d[symbol] = self.select_symbols(symbol, ret_list=True)
 

--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -10,7 +10,7 @@ import os
 import re
 import textwrap
 import warnings
-from collections import OrderedDict, deque
+from collections import deque
 from functools import partial
 from inspect import getfullargspec as getargspec
 from io import StringIO
@@ -197,7 +197,7 @@ class CifBlock:
         """
         q = cls._process_string(string)
         header = q.popleft()[0][5:]
-        data = OrderedDict()
+        data = {}
         loops = []
         while q:
             s = q.popleft()
@@ -261,7 +261,7 @@ class CifFile:
         :param string: String representation.
         :return: CifFile
         """
-        d = OrderedDict()
+        d = {}
         for x in re.split(r"^\s*data_", "x\n" + string, flags=re.MULTILINE | re.DOTALL)[1:]:
 
             # Skip over Cif block that contains powder diffraction data.
@@ -935,8 +935,8 @@ class CifParser:
 
         oxi_states = self.parse_oxi_states(data)
 
-        coord_to_species = OrderedDict()
-        coord_to_magmoms = OrderedDict()
+        coord_to_species = {}
+        coord_to_magmoms = {}
 
         def get_matching_coord(coord):
             keys = list(coord_to_species.keys())
@@ -1243,7 +1243,7 @@ class CifParser:
         """
         :return: MSONable dict
         """
-        d = OrderedDict()
+        d = {}
         for k, v in self._cif.data.items():
             d[k] = {}
             for k2, v2 in v.data.items():
@@ -1295,7 +1295,7 @@ class CifWriter:
 
         format_str = "{:.%df}" % significant_figures
 
-        block = OrderedDict()
+        block = {}
         loops = []
         spacegroup = ("P 1", 1)
         if symprec is not None:
@@ -1341,12 +1341,12 @@ class CifWriter:
         loops.append(["_symmetry_equiv_pos_site_id", "_symmetry_equiv_pos_as_xyz"])
 
         try:
-            symbol_to_oxinum = OrderedDict([(el.__str__(), float(el.oxi_state)) for el in sorted(comp.elements)])
+            symbol_to_oxinum = {el.__str__(): el.oxi_state for el in sorted(comp.elements)}
             block["_atom_type_symbol"] = symbol_to_oxinum.keys()
             block["_atom_type_oxidation_number"] = symbol_to_oxinum.values()
             loops.append(["_atom_type_symbol", "_atom_type_oxidation_number"])
         except (TypeError, AttributeError):
-            symbol_to_oxinum = OrderedDict([(el.symbol, 0) for el in sorted(comp.elements)])
+            symbol_to_oxinum = {el.symbol: 0 for el in sorted(comp.elements)}
 
         atom_site_type_symbol = []
         atom_site_symmetry_multiplicity = []
@@ -1440,7 +1440,7 @@ class CifWriter:
                     "_atom_site_moment_crystalaxis_z",
                 ]
             )
-        d = OrderedDict()
+        d = {}
         d[comp.reduced_formula] = CifBlock(block, loops, comp.reduced_formula)
         self._cf = CifFile(d)
 

--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -70,13 +70,10 @@ class CifBlock:
     def __init__(self, data, loops, header):
         """
         Args:
-            data: dict or OrderedDict of data to go into the cif. Values should
-                    be convertible to string, or lists of these if the key is
-                    in a loop
-            loops: list of lists of keys, grouped by which loop they should
-                    appear in
-            header: name of the block (appears after the data_ on the first
-                line)
+            data: dict of data to go into the cif. Values should be convertible to string,
+                or lists of these if the key is in a loop
+            loops: list of lists of keys, grouped by which loop they should appear in
+            header: name of the block (appears after the data_ on the first line)
         """
         self.loops = loops
         self.data = data
@@ -241,7 +238,7 @@ class CifFile:
     def __init__(self, data, orig_string=None, comment=None):
         """
         Args:
-            data (OrderedDict): Of CifBlock objects.å
+            data (dict): Of CifBlock objects.
             orig_string (str): The original cif string.
             comment (str): Comment string.
         """
@@ -517,8 +514,7 @@ class CifParser:
                 "_atom_site_moment_label",
             ]
 
-            # cannot mutate OrderedDict during enumeration,
-            # so store changes we want to make
+            # cannot mutate dict during enumeration, so store changes we want to make
             changes_to_make = {}
 
             for original_key in data.data:

--- a/pymatgen/io/feff/outputs.py
+++ b/pymatgen/io/feff/outputs.py
@@ -10,7 +10,7 @@ Currently supports the xmu.dat, ldos.dat output files are for non-spin case.
 
 
 import re
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 
 import numpy as np
 from monty.io import zopen
@@ -164,7 +164,7 @@ class LDos(MSONable):
             dictionary of dictionaries in order of potential sites
             ({"p": 0.154, "s": 0.078, "d": 0.0, "tot": 0.232}, ...)
         """
-        cht = OrderedDict()
+        cht = {}
         parameters = Tags.from_file(feff_inp_file)
 
         if "RECIPROCAL" in parameters:

--- a/pymatgen/io/lammps/data.py
+++ b/pymatgen/io/lammps/data.py
@@ -19,7 +19,6 @@ more info.
 import itertools
 import re
 import warnings
-from collections import OrderedDict
 from io import StringIO
 from pathlib import Path
 
@@ -371,9 +370,9 @@ class LammpsData(MSONable):
 """
         box = self.box.get_string(distance)
 
-        body_dict = OrderedDict()
+        body_dict = {}
         body_dict["Masses"] = self.masses
-        types = OrderedDict()
+        types = {}
         types["atom"] = len(self.masses)
         if self.force_field:
             all_ff_kws = SECTION_KEYWORDS["ff"] + SECTION_KEYWORDS["class2"]
@@ -384,7 +383,7 @@ class LammpsData(MSONable):
                     types[kw.lower()[:-7]] = len(self.force_field[kw])
 
         body_dict["Atoms"] = self.atoms
-        counts = OrderedDict()
+        counts = {}
         counts["atoms"] = len(self.atoms)
         if self.velocities is not None:
             body_dict["Velocities"] = self.velocities

--- a/pymatgen/io/lammps/data.py
+++ b/pymatgen/io/lammps/data.py
@@ -1032,7 +1032,7 @@ class ForceField(MSONable):
                 strings (symbols) and floats are all acceptable for the
                 values, with the first two converted to the atomic mass
                 of an element. It is recommended to use
-                OrderedDict.items() to prevent key duplications.
+                dict.items() to prevent key duplications.
                 [("C", 12.01), ("H", Element("H")), ("O", "O"), ...]
             nonbond_coeffs [coeffs]: List of pair or pairij
                 coefficients, of which the sequence must be sorted

--- a/pymatgen/io/lammps/tests/test_data.py
+++ b/pymatgen/io/lammps/tests/test_data.py
@@ -5,7 +5,6 @@ import json
 import os
 import random
 import unittest
-from collections import OrderedDict
 
 import numpy as np
 import pandas as pd
@@ -456,7 +455,7 @@ class LammpsDataTest(unittest.TestCase):
         self.assertEqual(self.tatb.atoms.loc[atom_id].name, atom_id)
 
     def test_from_ff_and_topologies(self):
-        mass = OrderedDict()
+        mass = {}
         mass["H"] = 1.0079401
         mass["O"] = 15.999400
         nonbond_coeffs = [[0.00774378, 0.98], [0.1502629, 3.1169]]

--- a/pymatgen/io/lobster/inputs.py
+++ b/pymatgen/io/lobster/inputs.py
@@ -9,7 +9,6 @@ on LOBSTER see www.cohp.de.
 import itertools
 import os
 import warnings
-from collections import OrderedDict
 from typing import Any, Dict, List, Optional
 
 import numpy as np
@@ -819,7 +818,7 @@ def get_all_possible_basis_combinations(min_basis: list, max_basis: list) -> lis
     min_basis_lists = [x.split() for x in min_basis]
 
     # get all possible basis functions
-    basis_dict = OrderedDict({})  # type:  Dict[Any, Any]
+    basis_dict = {}
     for iel, el in enumerate(max_basis_lists):
         basis_dict[el[0]] = {"fixed": [], "variable": [], "combinations": []}
         for basis in el[1:]:

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -15,7 +15,7 @@ import os
 import re
 import subprocess
 import warnings
-from collections import OrderedDict, namedtuple
+from collections import namedtuple
 from enum import Enum
 from hashlib import md5
 from typing import Any, Dict, Literal, Sequence, Tuple, Union
@@ -1737,7 +1737,7 @@ class PotcarSingle:
             except KeyError:
                 warnings.warn(f"Ignoring unknown variable type {key}")
 
-        PSCTR = OrderedDict()
+        PSCTR = {}
 
         array_search = re.compile(r"(-*[0-9.]+)")
         orbitals = []
@@ -1797,7 +1797,7 @@ class PotcarSingle:
                 PSCTR["RRKJ"] = tuple(rrkj_array)
 
         PSCTR.update(self.keywords)
-        self.PSCTR = OrderedDict(sorted(PSCTR.items(), key=lambda x: x[0]))
+        self.PSCTR = dict(sorted(PSCTR.items()))
 
         if symbol:
             self._symbol = symbol

--- a/pymatgen/phonon/bandstructure.py
+++ b/pymatgen/phonon/bandstructure.py
@@ -5,7 +5,6 @@
 This module provides classes to define a phonon band structure.
 """
 
-import collections
 
 import numpy as np
 from monty.json import MSONable
@@ -525,7 +524,7 @@ class PhononBandStructureSymmLine(PhononBandStructure):
         d["qpoints"] = qpoints
 
         # get labels
-        hsq_dict = collections.OrderedDict()
+        hsq_dict = {}
         for nq, q in enumerate(self.qpoints):
             if q.label is not None:
                 hsq_dict[nq] = q.label

--- a/pymatgen/phonon/plotter.py
+++ b/pymatgen/phonon/plotter.py
@@ -6,7 +6,7 @@ This module implements plotter for DOS and band structure.
 """
 
 import logging
-from collections import OrderedDict, namedtuple
+from collections import namedtuple
 
 import numpy as np
 import scipy.constants as const
@@ -85,7 +85,7 @@ class PhononDosPlotter:
         """
         self.stack = stack
         self.sigma = sigma
-        self._doses = OrderedDict()
+        self._doses = {}
 
     def add_dos(self, label, dos):
         """

--- a/pymatgen/util/num.py
+++ b/pymatgen/util/num.py
@@ -6,8 +6,6 @@
 This module provides utilities for basic math operations.
 """
 
-import collections
-
 import numpy as np
 
 
@@ -25,32 +23,6 @@ def abs_cap(val, max_abs_val=1):
         val if abs(val) < 1 else sign of val * max_abs_val.
     """
     return max(min(val, max_abs_val), -max_abs_val)
-
-
-def sort_dict(d, key=None, reverse=False):
-    """
-    Sorts a dict by value.
-
-    Args:
-        d: Input dictionary
-        key: Function which takes an tuple (key, object) and returns a value to
-            compare and sort by. By default, the function compares the values
-            of the dict i.e. key = lambda t : t[1]
-        reverse: Allows to reverse sort order.
-
-    Returns:
-        OrderedDict object whose keys are ordered according to their value.
-    """
-    kv_items = list(d.items())
-
-    # Sort kv_items according to key.
-    if key is None:
-        kv_items.sort(key=lambda t: t[1], reverse=reverse)
-    else:
-        kv_items.sort(key=key, reverse=reverse)
-
-    # Build ordered dict.
-    return collections.OrderedDict(kv_items)
 
 
 def minloc(seq):

--- a/pymatgen/vis/plotters.py
+++ b/pymatgen/vis/plotters.py
@@ -5,7 +5,6 @@
 This module defines generic plotters.
 """
 
-import collections
 import importlib
 
 from pymatgen.util.plotting import pretty_plot
@@ -52,7 +51,7 @@ class SpectrumPlotter:
         mod = importlib.import_module(f"palettable.colorbrewer.{color_cycle[0]}")
         self.colors_cycle = getattr(mod, color_cycle[1]).mpl_colors
         self.colors = []
-        self._spectra = collections.OrderedDict()
+        self._spectra = {}
 
     def add_spectrum(self, label, spectrum, color=None):
         """


### PR DESCRIPTION
Python 3.6 is [EOL since 23 Dec 2021](https://endoflife.date/python) and `dict`s are insertion-ordered in Python 3.7+ so safe to replace `OrderedDict` with regular `dict`.