### PR TITLE
[WIP] Fixed the mask_sphere function in cube.py

### DIFF
--- a/pymatgen/io/cube.py
+++ b/pymatgen/io/cube.py
@@ -43,6 +43,7 @@ wide and the volume is aligned with the coordinate axis. There are three atoms.
 import numpy as np
 from monty.io import zopen
 
+from pymatgen.core.lattice import Lattice
 from pymatgen.core.sites import Site
 from pymatgen.core.structure import Structure
 from pymatgen.core.units import bohr_to_angstrom
@@ -67,7 +68,7 @@ class Cube:
         f = zopen(fname, "rt")
 
         # skip header lines
-        for i in range(2):
+        for _ in range(2):
             f.readline()
 
         # number of atoms followed by the position of the origin of the volumetric data
@@ -98,7 +99,7 @@ class Cube:
         # the first is the atom number, second is charge,
         # the last three are the x,y,z coordinates of the atom center.
         self.sites = []
-        for i in range(self.natoms):
+        for _ in range(self.natoms):
             line = f.readline().split()
             self.sites.append(Site(line[0], np.multiply(bohr_to_angstrom, list(map(float, line[2:])))))
 
@@ -120,25 +121,28 @@ class Cube:
             radius: (float) of the mask (in Angstroms)
             cx, cy, cz: (float) the fractional coordinates of the center of the sphere
         """
-        dx, dy, dz = (
-            np.floor(radius / np.linalg.norm(self.X)).astype(int),
-            np.floor(radius / np.linalg.norm(self.Y)).astype(int),
-            np.floor(radius / np.linalg.norm(self.Z)).astype(int),
+        # create a lattice describing a single voxel
+        voxel_lattice = Lattice([self.X, self.Y, self.Z])
+        # find all voxels who's centre is within the radius of point (cx, cy, cz)
+        # convert (cx, cy, cz) into voxel lattice
+        coords = self.structure.lattice.get_cartesian_coords([cx, cy, cz])
+        voxel_coords = voxel_lattice.get_fractional_coords(coords)
+        # cube voxels are oriented around the centre of the voxel
+        _, _, _, image = voxel_lattice.get_points_in_sphere(
+            [[0.5, 0.5, 0.5]],
+            voxel_lattice.get_cartesian_coords(np.mod(voxel_coords, 1)),
+            radius,
+            zip_results=False,
         )
-        gcd = max(np.gcd(dx, dy), np.gcd(dy, dz), np.gcd(dx, dz))
-        sx, sy, sz = dx // gcd, dy // gcd, dz // gcd
-        r = min(dx, dy, dz)
+        image = np.array(image)
 
-        x0, y0, z0 = int(np.round(self.NX * cx)), int(np.round(self.NY * cy)), int(np.round(self.NZ * cz))
+        # convert into indices
+        idx = np.zeros(image.shape, dtype=int)
+        idx[:] = np.mod(np.add(voxel_coords, image), self.data.shape)
 
-        centerx, centery, centerz = self.NX // 2, self.NY // 2, self.NZ // 2
-        a = np.roll(self.data, (centerx - x0, centery - y0, centerz - z0))
-
-        i, j, k = np.indices(a.shape, sparse=True)
-        a = np.sqrt((sx * i - sx * centerx) ** 2 + (sy * j - sy * centery) ** 2 + (sz * k - sz * centerz) ** 2)
-
-        indices = a > r
-        a[indices] = 0
+        # create mask array
+        a = np.zeros(self.data.shape)
+        a[idx[:, 0], idx[:, 1], idx[:, 2]] = 1
 
         return a
 


### PR DESCRIPTION
## Summary

Include a summary of major changes in bullet points:

* The mask_sphere function returned a mask of distance values that doesn't vary with site 
* Changed this use the get_points_in_sphere from Lattice

## TODO (if any)

* A discussion about what this returns:
* I think just returning the indices rather than a full array would be better.
* Was it intentional to multiply by distance or is how I have set it up now (just 1 or 0) 
* Should I type hint the functions?

## Checklist

Work-in-progress pull requests are encouraged, but please put [WIP]
in the pull request title.

Before a pull request can be merged, the following items must be checked:

- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). The easiest way to handle this
      is to run the following in the **correct sequence** on your local machine. Start with running
      [black](https://black.readthedocs.io/en/stable/index.html) on your new code. This will automatically reformat
      your code to PEP8 conventions and removes most issues. Then run
      [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/), followed by
      [flake8](http://flake8.pycqa.org/en/latest/).
- [x] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [ ] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) to type check your code.
- [ ] Tests have been added for any new functionality or bug fixes.
- [ ] All linting and tests pass.
