### PR TITLE
Return None for complete_dos.spin_polarization if ISPIN=1

### DIFF
--- a/pymatgen/electronic_structure/dos.py
+++ b/pymatgen/electronic_structure/dos.py
@@ -7,7 +7,7 @@ This module defines classes to represent the density of states, etc.
 
 import functools
 import warnings
-from typing import Dict
+from typing import Dict, Optional
 
 import numpy as np
 from monty.json import MSONable
@@ -498,7 +498,7 @@ class FermiDos(Dos, MSONable):
             * self.de[: self.idx_vbm + 1],
             axis=0,
         )
-        return (vb_integral - cb_integral) / (self.volume * self.A_to_cm ** 3)
+        return (vb_integral - cb_integral) / (self.volume * self.A_to_cm**3)
 
     def get_fermi_interextrapolated(
         self, concentration: float, temperature: float, warn: bool = True, c_ref: float = 1e10, **kwargs
@@ -785,7 +785,7 @@ class CompleteDos(Dos):
         return {orb: Dos(self.efermi, self.energies, densities) for orb, densities in el_dos.items()}
 
     @property
-    def spin_polarization(self) -> float:
+    def spin_polarization(self) -> Optional[float]:
         """
         Calculates spin polarization at Fermi level. If the
         calculation is not spin-polarized, None will be

--- a/pymatgen/electronic_structure/dos.py
+++ b/pymatgen/electronic_structure/dos.py
@@ -787,7 +787,9 @@ class CompleteDos(Dos):
     @property
     def spin_polarization(self) -> float:
         """
-        Calculates spin polarization at Fermi level.
+        Calculates spin polarization at Fermi level. If the
+        calculation is not spin-polarized, None will be
+        returned.
 
         See Sanvito et al., doi: 10.1126/sciadv.1602241 for
         an example usage.
@@ -799,6 +801,8 @@ class CompleteDos(Dos):
         n_F = self.get_interpolated_value(self.efermi)
 
         n_F_up = n_F[Spin.up]
+        if Spin.down not in n_F:
+            return None
         n_F_down = n_F[Spin.down]
 
         if (n_F_up + n_F_down) == 0:

--- a/pymatgen/io/vasp/tests/test_outputs.py
+++ b/pymatgen/io/vasp/tests/test_outputs.py
@@ -175,6 +175,9 @@ class VasprunTest(PymatgenTest):
         self.assertEqual(vasprun.parameters["NELM"], 60)
         # test pdos parsing
 
+        self.assertEqual(vasprun.complete_dos.spin_polarization, 1.0)
+        self.assertTrue(Vasprun(self.TEST_FILES_DIR / "vasprun.xml.etest1.gz").complete_dos.spin_polarization is None)
+
         pdos0 = vasprun.complete_dos.pdos[vasprun.final_structure[0]]
         self.assertAlmostEqual(pdos0[Orbital.s][Spin.up][16], 0.0026)
         self.assertAlmostEqual(pdos0[Orbital.pz][Spin.down][16], 0.0012)


### PR DESCRIPTION
Addresses #2408.

If a VASP calculation is carried out with ISPIN=1, the `Vasprun('vasprun.xml').complete_dos.spin_polarization` property throws a `KeyError`. This PR makes it so that `None` is returned instead.

The `.spin_polarization` property also had no tests. I added them.