### PR TITLE
Update docs to say min python is 3.8

### DIFF
--- a/ADMIN.rst
+++ b/ADMIN.rst
@@ -28,11 +28,9 @@ also need sphinx and doc2dash. Install these using::
 
 	pip install --upgrade invoke sphinx doc2dash
 
-For 2018, we will release both py27 and py37 versions of pymatgen. Create
-environments for py27 and py37 using conda::
+Create environment for py38 using conda::
 
-	conda create --yes -n py37 python=3.7
-	conda create --yes -n py27 python=2.7
+	conda create --yes -n py38 python=3.8
 
 For each env, install some packages using conda followed by dev install for
 pymatgen::

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -99,7 +99,7 @@ following must be satisfied for your contributions to be accepted into pymatgen.
    To aid you, you can copy the example pre-commit hook into your .git/hooks
    directly. This will automatically run pycodestyle and other linting services
    prior to any commits. At the very least, copy pre-commit to .git/hooks/pre-push.
-3. **Python 3**. We only support Python 3.7+.
+3. **Python 3**. We only support Python 3.8+.
 4. **Documentation** required for all modules, classes and methods. In
    particular, the method doc strings should make clear the arguments expected
    and the return values. For complex algorithms (e.g., an Ewald summation), a

--- a/README.rst
+++ b/README.rst
@@ -109,7 +109,7 @@ installation using conda, which will make things a lot easier, especially on Win
 
     conda install --channel conda-forge pymatgen
 
-In line with the Scientific Python stack, pymatgen will now support a minimum python version off 3.7 from v2021.1.1.
+In line with the Scientific Python stack, in particular :code:`numpy`, :code:`pymatgen` support a minimum Python version off 3.8 from v2022.01.08.
 
 The version at the `Python Package Index (PyPI) <https://pypi.org/project/pymatgen>`_ is always the latest stable
 release that is relatively bug-free and can be installed via pip::

--- a/docs_rst/compatibility.rst
+++ b/docs_rst/compatibility.rst
@@ -57,7 +57,7 @@ Minimum Python Version
 ----------------------
 
 As a rule of thumb, pymatgen will support whatever versions of Python the latest
-version of numpy supports (at the time of writing, this is Python 3.7+). You can
+version of numpy supports (at the time of writing, this is Python 3.8+). You can
 also check what versions of Python are being tested automatically as part of our
 continuous integration testing on GitHub. We currently test pymatgen on Mac,
 Windows and Linux.

--- a/docs_rst/contributing.rst
+++ b/docs_rst/contributing.rst
@@ -136,11 +136,11 @@ following must be satisfied for your contributions to be accepted into pymatgen.
    To aid you, you can copy the example pre-commit hook into your .git/hooks
    directly. This will automatically run pycodestyle and other linting services
    prior to any commits. At the very least, copy pre-commit to .git/hooks/pre-push.
-3. **Python 3**. We only support Python 3.7+.
+3. **Python 3**. We only support Python 3.8+.
 4. **Documentation** required for all modules, classes and methods. In
    particular, the method docstrings should make clear the arguments expected
    and the return values. For complex algorithms (e.g., an Ewald summation), a
-   summary of the alogirthm should be provided, and preferably with a link to a
+   summary of the algorithm should be provided, and preferably with a link to a
    publication outlining the method in detail.
 5. **IDE**. We highly recommend the use of Pycharm. You should also set up
    pycodestyle and turn those on within the IDE setup. This will warn of any

--- a/docs_rst/introduction.rst
+++ b/docs_rst/introduction.rst
@@ -32,7 +32,7 @@ for materials analysis. These are some of the main features:
 5. Integration with the Materials Project REST API, Crystallography Open
    Database and other external data sources.
 
-As of 2021, pymatgen only supports Python 3.7 and above. Our support schedule follows closely that of the Scientific
+As of 2022, pymatgen only supports Python 3.8 and above. Our support schedule follows closely that of the Scientific
 Python software stack, i.e., when packages such as numpy drops support for Python versions, we will drop support for
 newer versions. Similarly, support for new Python versions will be adopted only when most of the core dependencies
 support the new Python versions.


### PR DESCRIPTION
Update readme and docs in all places stating `pymatgen` still supports py37.