### PR TITLE
Remove last remaining star imports

### DIFF
--- a/pymatgen/analysis/chemenv/utils/scripts_utils.py
+++ b/pymatgen/analysis/chemenv/utils/scripts_utils.py
@@ -10,16 +10,6 @@ import re
 
 import numpy as np
 
-from pymatgen.ext.matproj import MPRester
-from pymatgen.io.cif import CifParser
-
-try:
-    from pymatgen.vis.structure_vtk import StructureVis
-
-    no_vis = False
-except ImportError:
-    StructureVis = None  # type: ignore
-    no_vis = True
 from pymatgen.analysis.chemenv.coordination_environments.chemenv_strategies import (
     SimplestChemenvStrategy,
 )
@@ -38,6 +28,16 @@ from pymatgen.analysis.chemenv.utils.coordination_geometry_utils import rotateCo
 from pymatgen.analysis.chemenv.utils.defs_utils import chemenv_citations
 from pymatgen.core.sites import PeriodicSite
 from pymatgen.core.structure import Molecule
+from pymatgen.ext.matproj import MPRester
+from pymatgen.io.cif import CifParser
+
+try:
+    from pymatgen.vis.structure_vtk import StructureVis
+
+    no_vis = False
+except ImportError:
+    StructureVis = None  # type: ignore
+    no_vis = True
 
 __author__ = "David Waroquiers"
 __copyright__ = "Copyright 2012, The Materials Project"

--- a/pymatgen/analysis/elasticity/__init__.py
+++ b/pymatgen/analysis/elasticity/__init__.py
@@ -5,6 +5,19 @@
 Package for analyzing elastic tensors and properties.
 """
 
-from .elastic import *  # noqa
-from .strain import *  # noqa
-from .stress import *  # noqa
+from .elastic import (
+    ComplianceTensor,
+    ElasticTensor,
+    ElasticTensorExpansion,
+    NthOrderElasticTensor,
+    diff_fit,
+    find_eq_stress,
+    generate_pseudo,
+    get_diff_coeff,
+    get_strain_state_dict,
+    get_symbol_list,
+    raise_error_if_unphysical,
+    subs,
+)
+from .strain import Deformation, DeformedStructureSet, Strain
+from .stress import Stress

--- a/pymatgen/analysis/graphs.py
+++ b/pymatgen/analysis/graphs.py
@@ -13,12 +13,12 @@ import warnings
 from collections import defaultdict, namedtuple
 from itertools import combinations
 from operator import itemgetter
+from shutil import which
 
 import networkx as nx
 import networkx.algorithms.isomorphism as iso
 import numpy as np
 from monty.json import MSONable
-from monty.os.path import which
 from networkx.drawing.nx_agraph import write_dot
 from networkx.readwrite import json_graph
 from scipy.spatial import KDTree

--- a/pymatgen/analysis/magnetism/__init__.py
+++ b/pymatgen/analysis/magnetism/__init__.py
@@ -5,4 +5,10 @@
 Package for analysis of magnetic structures.
 """
 
-from pymatgen.analysis.magnetism.analyzer import *  # noqa
+from pymatgen.analysis.magnetism.analyzer import (
+    CollinearMagneticStructureAnalyzer,
+    MagneticStructureEnumerator,
+    Ordering,
+    OverwriteMagmomMode,
+    magnetic_deformation,
+)

--- a/pymatgen/analysis/magnetism/tests/test_analyzer.py
+++ b/pymatgen/analysis/magnetism/tests/test_analyzer.py
@@ -4,9 +4,9 @@
 import os
 import unittest
 import warnings
+from shutil import which
 
 import numpy as np
-from monty.os.path import which
 from monty.serialization import loadfn
 
 from pymatgen.analysis.magnetism import (

--- a/pymatgen/analysis/magnetism/tests/test_analyzer.py
+++ b/pymatgen/analysis/magnetism/tests/test_analyzer.py
@@ -3,17 +3,17 @@
 
 import os
 import unittest
+import warnings
 
 import numpy as np
 from monty.os.path import which
+from monty.serialization import loadfn
 
 from pymatgen.analysis.magnetism import (
     CollinearMagneticStructureAnalyzer,
     MagneticStructureEnumerator,
     Ordering,
-    loadfn,
     magnetic_deformation,
-    warnings,
 )
 from pymatgen.core import Element, Lattice, Species, Structure
 from pymatgen.io.cif import CifParser

--- a/pymatgen/analysis/tests/test_graphs.py
+++ b/pymatgen/analysis/tests/test_graphs.py
@@ -5,10 +5,17 @@
 import copy
 import os
 import unittest
+import warnings
+from shutil import which
 
-from monty.serialization import loadfn  # , dumpfn
+from monty.serialization import loadfn
 
-from pymatgen.analysis.graphs import *
+from pymatgen.analysis.graphs import (
+    MoleculeGraph,
+    MolGraphSplitError,
+    PeriodicSite,
+    StructureGraph,
+)
 from pymatgen.analysis.local_env import (
     CovalentBondNN,
     CutOffDictNN,
@@ -18,7 +25,8 @@ from pymatgen.analysis.local_env import (
     VoronoiNN,
 )
 from pymatgen.command_line.critic2_caller import Critic2Analysis
-from pymatgen.core.structure import FunctionalGroups, Molecule, Site, Structure
+from pymatgen.core import Lattice, Molecule, Site, Structure
+from pymatgen.core.structure import FunctionalGroups
 from pymatgen.util.testing import PymatgenTest
 
 try:
@@ -256,12 +264,6 @@ class StructureGraphTest(PymatgenTest):
 
         sg = StructureGraph.with_empty_graph(self.structure)
         sg.add_edge(0, 0)
-
-        ref_edges = [
-            (0, 0, {"to_jimage": (1, 1, 0)}),
-            (0, 0, {"to_jimage": (0, 1, 0)}),
-            (0, 0, {"to_jimage": (1, 0, 0)}),
-        ]
 
         self.assertEqual(len(list(sg.graph.edges(data=True))), 3)
 

--- a/pymatgen/analysis/tests/test_local_env.py
+++ b/pymatgen/analysis/tests/test_local_env.py
@@ -4,10 +4,10 @@ import os
 import unittest
 import warnings
 from math import pi
+from shutil import which
 
 import numpy as np
 import pytest
-from monty.os.path import which
 
 from pymatgen.analysis.graphs import MoleculeGraph
 from pymatgen.analysis.local_env import (
@@ -1061,7 +1061,7 @@ class LocalStructOrderParamsTest(PymatgenTest):
         ops_099 = LocalStructOrderParams(op_types, parameters=op_params, cutoff=0.99)
         ops_101 = LocalStructOrderParams(op_types, parameters=op_params, cutoff=1.01)
         ops_501 = LocalStructOrderParams(op_types, parameters=op_params, cutoff=5.01)
-        ops_voro = LocalStructOrderParams(op_types, parameters=op_params)
+        _ = LocalStructOrderParams(op_types, parameters=op_params)
 
         # Single bond.
         op_vals = ops_101.get_order_parameters(self.single_bond, 0)

--- a/pymatgen/command_line/bader_caller.py
+++ b/pymatgen/command_line/bader_caller.py
@@ -20,11 +20,11 @@ import os
 import shutil
 import subprocess
 import warnings
+from shutil import which
 
 import numpy as np
 from monty.dev import requires
 from monty.io import zopen
-from monty.os.path import which
 from monty.tempfile import ScratchDir
 
 from pymatgen.io.cube import Cube

--- a/pymatgen/command_line/chargemol_caller.py
+++ b/pymatgen/command_line/chargemol_caller.py
@@ -54,10 +54,10 @@ import os
 import shutil
 import subprocess
 import warnings
+from shutil import which
 
 import numpy as np
 from monty.io import zopen
-from monty.os.path import which
 from monty.tempfile import ScratchDir
 
 from pymatgen.core import Element

--- a/pymatgen/command_line/critic2_caller.py
+++ b/pymatgen/command_line/critic2_caller.py
@@ -43,11 +43,11 @@ import os
 import subprocess
 import warnings
 from enum import Enum
+from shutil import which
 
 import numpy as np
 from monty.dev import requires
 from monty.json import MSONable
-from monty.os.path import which
 from monty.serialization import loadfn
 from monty.tempfile import ScratchDir
 from scipy.spatial import KDTree

--- a/pymatgen/command_line/enumlib_caller.py
+++ b/pymatgen/command_line/enumlib_caller.py
@@ -34,12 +34,12 @@ import logging
 import math
 import re
 import subprocess
+from shutil import which
 from threading import Timer
 
 import numpy as np
 from monty.dev import requires
 from monty.fractions import lcm
-from monty.os.path import which
 from monty.tempfile import ScratchDir
 
 from pymatgen.core.periodic_table import DummySpecies

--- a/pymatgen/command_line/mcsqs_caller.py
+++ b/pymatgen/command_line/mcsqs_caller.py
@@ -8,11 +8,11 @@ import tempfile
 import warnings
 from collections import namedtuple
 from pathlib import Path
+from shutil import which
 from subprocess import Popen, TimeoutExpired
 from typing import Dict, List, Optional, Union
 
 from monty.dev import requires
-from monty.os.path import which
 
 from pymatgen.core.structure import Structure
 

--- a/pymatgen/command_line/tests/test_critic2_caller.py
+++ b/pymatgen/command_line/tests/test_critic2_caller.py
@@ -3,8 +3,7 @@
 
 import os
 import unittest
-
-from monty.os.path import which
+from shutil import which
 
 from pymatgen.command_line.critic2_caller import Critic2Analysis, Critic2Caller
 from pymatgen.core.structure import Structure

--- a/pymatgen/command_line/tests/test_enumlib_caller.py
+++ b/pymatgen/command_line/tests/test_enumlib_caller.py
@@ -4,8 +4,7 @@
 import os
 import unittest
 import warnings
-
-from monty.os.path import which
+from shutil import which
 
 from pymatgen.command_line.enumlib_caller import EnumError, EnumlibAdaptor
 from pymatgen.core.periodic_table import Element

--- a/pymatgen/command_line/tests/test_gulp_caller.py
+++ b/pymatgen/command_line/tests/test_gulp_caller.py
@@ -10,8 +10,7 @@ Created on Jan 22, 2013
 import os
 import sys
 import unittest
-
-from monty.os.path import which
+from shutil import which
 
 from pymatgen.analysis.bond_valence import BVAnalyzer
 from pymatgen.command_line.gulp_caller import (
@@ -91,7 +90,7 @@ class GulpCallerTest(unittest.TestCase):
             fmt="poscar",
         )
 
-        bp = BuckinghamPotential(bush_lewis_flag="bush")
+        _ = BuckinghamPotential(bush_lewis_flag="bush")
         gio = GulpIO()
         input = gio.buckingham_input(struct, ["relax conp"])
         caller = GulpCaller()

--- a/pymatgen/command_line/tests/test_mcsqs_caller.py
+++ b/pymatgen/command_line/tests/test_mcsqs_caller.py
@@ -1,7 +1,7 @@
 import os
 import unittest
+from shutil import which
 
-from monty.os.path import which
 from monty.serialization import loadfn
 
 from pymatgen.command_line.mcsqs_caller import run_mcsqs

--- a/pymatgen/command_line/tests/test_vampire_caller.py
+++ b/pymatgen/command_line/tests/test_vampire_caller.py
@@ -4,9 +4,9 @@
 import os
 import unittest
 import warnings
+from shutil import which
 
 import pandas as pd
-from monty.os.path import which
 
 import pymatgen.command_line.vampire_caller as vampirecaller
 from pymatgen.core.structure import Structure

--- a/pymatgen/command_line/vampire_caller.py
+++ b/pymatgen/command_line/vampire_caller.py
@@ -18,11 +18,11 @@ and R. W. Chantrell. J. Phys.: Condens. Matter 26, 103202 (2014)
 
 import logging
 import subprocess
+from shutil import which
 
 import pandas as pd
 from monty.dev import requires
 from monty.json import MSONable
-from monty.os.path import which
 
 from pymatgen.analysis.magnetism.heisenberg import HeisenbergMapper
 

--- a/pymatgen/core/tests/test_structure.py
+++ b/pymatgen/core/tests/test_structure.py
@@ -6,10 +6,10 @@ import random
 import unittest
 import warnings
 from pathlib import Path
+from shutil import which
 
 import numpy as np
 import pytest
-from monty.os.path import which
 
 from pymatgen.core.composition import Composition
 from pymatgen.core.lattice import Lattice

--- a/pymatgen/core/tests/test_tensors.py
+++ b/pymatgen/core/tests/test_tensors.py
@@ -4,7 +4,7 @@ import unittest
 import warnings
 
 import numpy as np
-from monty.serialization import MontyDecoder
+from monty.serialization import MontyDecoder, loadfn
 
 from pymatgen.core.operations import SymmOp
 from pymatgen.core.tensors import (
@@ -13,7 +13,6 @@ from pymatgen.core.tensors import (
     TensorCollection,
     TensorMapping,
     itertools,
-    loadfn,
     symmetry_reduce,
 )
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer

--- a/pymatgen/electronic_structure/boltztrap.py
+++ b/pymatgen/electronic_structure/boltztrap.py
@@ -23,12 +23,12 @@ import os
 import subprocess
 import tempfile
 import time
+from shutil import which
 
 import numpy as np
 from monty.dev import requires
 from monty.json import MSONable, jsanitize
 from monty.os import cd
-from monty.os.path import which
 from scipy import constants
 from scipy.spatial import distance
 

--- a/pymatgen/electronic_structure/tests/test_boltztrap.py
+++ b/pymatgen/electronic_structure/tests/test_boltztrap.py
@@ -6,8 +6,8 @@ import json
 import os
 import unittest
 import warnings
+from shutil import which
 
-from monty.os.path import which
 from monty.serialization import loadfn
 
 from pymatgen.electronic_structure.bandstructure import BandStructure

--- a/pymatgen/electronic_structure/tests/test_plotter.py
+++ b/pymatgen/electronic_structure/tests/test_plotter.py
@@ -5,9 +5,9 @@ import json
 import os
 import unittest
 import warnings
+from shutil import which
 
 import scipy
-from monty.os.path import which
 
 from pymatgen.core.structure import Structure
 from pymatgen.electronic_structure.bandstructure import BandStructureSymmLine

--- a/pymatgen/ext/cod.py
+++ b/pymatgen/ext/cod.py
@@ -31,10 +31,10 @@ stipulated by the COD developers)::
 
 import re
 import subprocess
+from shutil import which
 
 import requests
 from monty.dev import requires
-from monty.os.path import which
 
 from pymatgen.core.composition import Composition
 from pymatgen.core.structure import Structure

--- a/pymatgen/ext/tests/test_cod.py
+++ b/pymatgen/ext/tests/test_cod.py
@@ -4,9 +4,9 @@
 
 import unittest
 import warnings
+from shutil import which
 
 import requests
-from monty.os.path import which
 
 from pymatgen.ext.cod import COD
 

--- a/pymatgen/io/abinit/__init__.py
+++ b/pymatgen/io/abinit/__init__.py
@@ -2,5 +2,32 @@
 # Distributed under the terms of the MIT License.
 """This package implements basic input and output capabilities for Abinit."""
 
-from .netcdf import *  # noqa
-from .pseudos import *  # noqa
+from .netcdf import (
+    NO_DEFAULT,
+    ETSF_Reader,
+    NetcdfReader,
+    NetcdfReaderError,
+    as_etsfreader,
+    as_ncreader,
+    structure_from_ncdata,
+)
+from .pseudos import (
+    AbinitHeader,
+    AbinitPseudo,
+    Hint,
+    NcAbinitHeader,
+    NcAbinitPseudo,
+    NcPseudo,
+    PawAbinitHeader,
+    PawAbinitPseudo,
+    PawPseudo,
+    PawXmlSetup,
+    Pseudo,
+    PseudoParser,
+    PseudoParserError,
+    PseudoTable,
+    RadialFunction,
+    l2str,
+    str2l,
+    straceback,
+)

--- a/pymatgen/io/exciting/__init__.py
+++ b/pymatgen/io/exciting/__init__.py
@@ -7,4 +7,4 @@ This package contains classes to parse input files from the exciting
 code package.
 """
 
-from .inputs import *  # noqa
+from .inputs import ExcitingInput

--- a/pymatgen/io/feff/__init__.py
+++ b/pymatgen/io/feff/__init__.py
@@ -8,5 +8,15 @@ This package provides the modules to perform FEFF IO.
 FEFF: http://feffproject.org/feffproject-feff.html
 """
 
-from .inputs import *  # noqa
-from .outputs import *  # noqa
+from .inputs import (
+    VALID_FEFF_TAGS,
+    Atoms,
+    FeffParserError,
+    Header,
+    Paths,
+    Potential,
+    Tags,
+    get_absorbing_atom_symbol_index,
+    get_atom_map,
+)
+from .outputs import Eels, LDos, Xmu

--- a/pymatgen/io/lammps/utils.py
+++ b/pymatgen/io/lammps/utils.py
@@ -17,7 +17,8 @@ try:
 except ImportError:
     pb = None
 
-from monty.os.path import which
+from shutil import which
+
 from monty.tempfile import ScratchDir
 
 from pymatgen.core.operations import SymmOp

--- a/pymatgen/io/lammps/utils.py
+++ b/pymatgen/io/lammps/utils.py
@@ -8,23 +8,22 @@ This module defines utility classes and functions.
 
 import os
 import tempfile
+from shutil import which
 from subprocess import PIPE, Popen
 
 import numpy as np
-
-try:
-    from openbabel import pybel as pb
-except ImportError:
-    pb = None
-
-from shutil import which
-
 from monty.tempfile import ScratchDir
 
 from pymatgen.core.operations import SymmOp
 from pymatgen.core.structure import Molecule
 from pymatgen.io.babel import BabelMolAdaptor
 from pymatgen.util.coord import get_angle
+
+try:
+    from openbabel import pybel as pb
+except ImportError:
+    pb = None
+
 
 __author__ = "Kiran Mathew, Brandon Wood, Michael Humbert"
 __email__ = "kmathew@lbl.gov"

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -15,6 +15,7 @@ import numpy as np
 import pytest  # type: ignore
 from _pytest.monkeypatch import MonkeyPatch  # type: ignore
 from monty.json import MontyDecoder
+from monty.serialization import loadfn
 
 from pymatgen.analysis.structure_matcher import StructureMatcher
 from pymatgen.core import SETTINGS, Lattice, Species, Structure
@@ -46,7 +47,6 @@ from pymatgen.io.vasp.sets import (
     batch_write_input,
     get_structure_from_prev_run,
     get_valid_magmom_struct,
-    loadfn,
 )
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.util.testing import PymatgenTest

--- a/pymatgen/io/zeopp.py
+++ b/pymatgen/io/zeopp.py
@@ -47,7 +47,7 @@ except ImportError:
     zeo_found = False
 
 __author__ = "Bharat Medasani"
-__copyright = "Copyright 2013, The Materials Project"
+__copyright__ = "Copyright 2013, The Materials Project"
 __version__ = "0.1"
 __maintainer__ = "Bharat Medasani"
 __email__ = "mbkumar@gmail.com"

--- a/pymatgen/transformations/tests/test_advanced_transformations.py
+++ b/pymatgen/transformations/tests/test_advanced_transformations.py
@@ -5,9 +5,9 @@ import json
 import os
 import unittest
 import warnings
+from shutil import which
 
 import numpy as np
-from monty.os.path import which
 from monty.serialization import loadfn
 
 from pymatgen.analysis.energy_models import IsingModel

--- a/pymatgen/transformations/tests/test_site_transformations.py
+++ b/pymatgen/transformations/tests/test_site_transformations.py
@@ -3,9 +3,9 @@
 
 
 import unittest
+from shutil import which
 
 import numpy as np
-from monty.os.path import which
 
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Molecule, Structure

--- a/pymatgen/transformations/tests/test_standard_transformations.py
+++ b/pymatgen/transformations/tests/test_standard_transformations.py
@@ -7,9 +7,9 @@ import os
 import random
 import unittest
 import warnings
+from shutil import which
 
 from monty.json import MontyDecoder
-from monty.os.path import which
 
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.periodic_table import Element


### PR DESCRIPTION
`flake8` complains about star imports (for good reason imo, they make code harder to understand and debug).

One step closer to enabling `flake8` in CI.

I noticed one odd thing, 

```
pymatgen/io/abinit/netcdf.py
pymatgen/io/abinit/pseudos.py
```

both define `class AbinitHeader(dict)`. The 2nd starred import was overwriting the class from the first file in `pymatgen/io/abinit/__init__.py` so I imported that one for backwards compat.