### PR TITLE
Move cython to setup_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,9 @@ setup(
     ),
     version="2022.2.7",
     python_requires=">=3.8",
+    setup_requires=[
+        "Cython>=0.29.23",
+    ],
     install_requires=[
         "numpy>=1.20.1",
         "requests",
@@ -92,7 +95,6 @@ setup(
         "pandas",
         "plotly>=4.5.0",
         "uncertainties>=3.1.4",
-        "Cython>=0.29.23",
         "pybtex",
         "tqdm",
     ],


### PR DESCRIPTION
## Summary

Move cython to `setup_requires`. Allows for availability to be checked before attempting to build native extensions. Avoiding #2426

## Checklist

Work-in-progress pull requests are encouraged, but please put [WIP]
in the pull request title.

Before a pull request can be merged, the following items must be checked:

- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). The easiest way to handle this
      is to run the following in the **correct sequence** on your local machine. Start with running
      [black](https://black.readthedocs.io/en/stable/index.html) on your new code. This will automatically reformat
      your code to PEP8 conventions and removes most issues. Then run
      [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/), followed by
      [flake8](http://flake8.pycqa.org/en/latest/).
- [x] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [x] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) to type check your code.
- [ ] Tests have been added for any new functionality or bug fixes.
- [ ] All linting and tests pass.

Note that the CI system will run all the above checks. But it will be much more efficient if you already fix most
errors prior to submitting the PR. It is highly recommended that you use the pre-commit hook provided in the pymatgen
repository. Simply `cp pre-commit .git/hooks` and a check will be run prior to allowing commits.
