### PR TITLE
Remove unused mypy ignores

### DIFF
--- a/docs_rst/usage.rst
+++ b/docs_rst/usage.rst
@@ -97,8 +97,8 @@ add these keys if they are not present, but for better long term stability
 through the encoder), the easiest way is to add the following to any to_dict
 property::
 
-    d["@module"] = self.__class__.__module__
-    d["@class"] = self.__class__.__name__
+    d["@module"] = type(self).__module__
+    d["@class"] = type(self).__name__
 
 To use the MontyDecoder, simply specify it as the *cls* kwarg when using json
 load, e.g.::

--- a/pymatgen/alchemy/filters.py
+++ b/pymatgen/alchemy/filters.py
@@ -99,8 +99,8 @@ class ContainsSpecieFilter(AbstractStructureFilter):
         Returns: MSONAble dict
         """
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "init_args": {
                 "species": [str(sp) for sp in self._species],
                 "strict_compare": self._strict,
@@ -168,8 +168,8 @@ class SpecieProximityFilter(AbstractStructureFilter):
         Returns: MSONable dict
         """
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "init_args": {"specie_and_min_dist_dict": {str(sp): v for sp, v in self.specie_and_min_dist.items()}},
         }
 
@@ -299,8 +299,8 @@ class RemoveExistingFilter(AbstractStructureFilter):
         Returns: MSONable dict
         """
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "init_args": {"structure_matcher": self.structure_matcher.as_dict()},
         }
 

--- a/pymatgen/alchemy/materials.py
+++ b/pymatgen/alchemy/materials.py
@@ -340,8 +340,8 @@ class TransformedStructure(MSONable):
         Dict representation of the TransformedStructure.
         """
         d = self.final_structure.as_dict()
-        d["@module"] = self.__class__.__module__
-        d["@class"] = self.__class__.__name__
+        d["@module"] = type(self).__module__
+        d["@class"] = type(self).__name__
         d["history"] = jsanitize(self.history)
         d["last_modified"] = str(datetime.datetime.utcnow())
         d["other_parameters"] = jsanitize(self.other_parameters)

--- a/pymatgen/analysis/chemenv/connectivity/connected_components.py
+++ b/pymatgen/analysis/chemenv/connectivity/connected_components.py
@@ -898,8 +898,8 @@ class ConnectedComponent(MSONable):
                     ied = self._edgekey_to_edgedictkey(ie)
                     new_dict_of_dicts[in1][in2][ied] = jsanitize(edge_data)
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "nodes": {strindex: (node.as_dict(), data) for strindex, (node, data) in nodes.items()},
             "graph": new_dict_of_dicts,
         }

--- a/pymatgen/analysis/chemenv/connectivity/structure_connectivity.py
+++ b/pymatgen/analysis/chemenv/connectivity/structure_connectivity.py
@@ -356,8 +356,8 @@ class StructureConnectivity(MSONable):
 
         """
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "light_structure_environments": self.light_structure_environments.as_dict(),
             "connectivity_graph": jsanitize(nx.to_dict_of_dicts(self._graph)),
             "environment_subgraphs": {

--- a/pymatgen/analysis/chemenv/coordination_environments/chemenv_strategies.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/chemenv_strategies.py
@@ -81,8 +81,8 @@ class DistanceCutoffFloat(float, StrategyOption):
     def as_dict(self):
         """MSONAble dict"""
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "value": self,
         }
 
@@ -111,8 +111,8 @@ class AngleCutoffFloat(float, StrategyOption):
     def as_dict(self):
         """MSONAble dict"""
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "value": self,
         }
 
@@ -142,8 +142,8 @@ class CSMFloat(float, StrategyOption):
     def as_dict(self):
         """MSONable dict"""
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "value": self,
         }
 
@@ -175,8 +175,8 @@ class AdditionalConditionInt(int, StrategyOption):
     def as_dict(self):
         """MSONable dict"""
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "value": self,
         }
 
@@ -441,8 +441,8 @@ class AbstractChemenvStrategy(MSONable, metaclass=abc.ABCMeta):
         raise NotImplementedError()
 
     def __str__(self):
-        out = f'  Chemenv Strategy "{self.__class__.__name__}"\n'
-        out += f"  {'=' * (19 + len(self.__class__.__name__))}\n\n"
+        out = f'  Chemenv Strategy "{type(self).__name__}"\n'
+        out += f"  {'=' * (19 + len(type(self).__name__))}\n\n"
         out += f"  Description :\n  {'-' * 13}\n"
         out += self.STRATEGY_DESCRIPTION
         out += "\n\n"
@@ -822,7 +822,7 @@ class SimplestChemenvStrategy(AbstractChemenvStrategy):
 
     def __eq__(self, other):
         return (
-            self.__class__.__name__ == other.__class__.__name__
+            type(self).__name__ == other.__class__.__name__
             and self._distance_cutoff == other._distance_cutoff
             and self._angle_cutoff == other._angle_cutoff
             and self._additional_condition == other._additional_condition
@@ -836,8 +836,8 @@ class SimplestChemenvStrategy(AbstractChemenvStrategy):
         :return: Bson-serializable dict representation of the SimplestChemenvStrategy object.
         """
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "distance_cutoff": float(self._distance_cutoff),
             "angle_cutoff": float(self._angle_cutoff),
             "additional_condition": int(self._additional_condition),
@@ -1027,8 +1027,7 @@ class SimpleAbundanceChemenvStrategy(AbstractChemenvStrategy):
 
     def __eq__(self, other):
         return (
-            self.__class__.__name__ == other.__class__.__name__
-            and self._additional_condition == other.additional_condition
+            type(self).__name__ == other.__class__.__name__ and self._additional_condition == other.additional_condition
         )
 
     def as_dict(self):
@@ -1037,8 +1036,8 @@ class SimpleAbundanceChemenvStrategy(AbstractChemenvStrategy):
         :return: Bson-serializable dict representation of the SimpleAbundanceChemenvStrategy object.
         """
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "additional_condition": self._additional_condition,
         }
 
@@ -1188,8 +1187,8 @@ class TargettedPenaltiedAbundanceChemenvStrategy(SimpleAbundanceChemenvStrategy)
         :return: Bson-serializable dict representation of the TargettedPenaltiedAbundanceChemenvStrategy object.
         """
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "additional_condition": self._additional_condition,
             "max_nabundant": self.max_nabundant,
             "target_environments": self.target_environments,
@@ -1199,7 +1198,7 @@ class TargettedPenaltiedAbundanceChemenvStrategy(SimpleAbundanceChemenvStrategy)
 
     def __eq__(self, other):
         return (
-            self.__class__.__name__ == other.__class__.__name__
+            type(self).__name__ == other.__class__.__name__
             and self._additional_condition == other.additional_condition
             and self.max_nabundant == other.max_nabundant
             and self.target_environments == other.target_environments
@@ -1298,8 +1297,8 @@ class AngleNbSetWeight(NbSetWeight):
     def as_dict(self):
         """MSONAble dict"""
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "aa": self.aa,
         }
 
@@ -1367,8 +1366,8 @@ class NormalizedAngleDistanceNbSetWeight(NbSetWeight):
     def as_dict(self):
         """MSONable dict"""
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "average_type": self.average_type,
             "aa": self.aa,
             "bb": self.bb,
@@ -1629,8 +1628,8 @@ class SelfCSMNbSetWeight(NbSetWeight):
     def as_dict(self):
         """MSONable dict"""
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "effective_csm_estimator": self.effective_csm_estimator,
             "weight_estimator": self.weight_estimator,
             "symmetry_measure_type": self.symmetry_measure_type,
@@ -1858,8 +1857,8 @@ class DeltaCSMNbSetWeight(NbSetWeight):
         :return:
         """
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "effective_csm_estimator": self.effective_csm_estimator,
             "weight_estimator": self.weight_estimator,
             "delta_cn_weight_estimators": self.delta_cn_weight_estimators,
@@ -1919,8 +1918,8 @@ class CNBiasNbSetWeight(NbSetWeight):
     def as_dict(self):
         """MSONable dict"""
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "cn_weights": {str(cn): cnw for cn, cnw in self.cn_weights.items()},
             "initialization_options": self.initialization_options,
         }
@@ -2221,8 +2220,8 @@ class DistanceAngleAreaNbSetWeight(NbSetWeight):
     def as_dict(self):
         """MSONable dict"""
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "weight_type": self.weight_type,
             "surface_definition": self.surface_definition,
             "nb_sets_from_hints": self.nb_sets_from_hints,
@@ -2290,8 +2289,8 @@ class DistancePlateauNbSetWeight(NbSetWeight):
     def as_dict(self):
         """MSONable dict"""
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "distance_function": self.distance_function,
             "weight_function": self.weight_function,
         }
@@ -2353,8 +2352,8 @@ class AnglePlateauNbSetWeight(NbSetWeight):
     def as_dict(self):
         """MSONable dict"""
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "angle_function": self.angle_function,
             "weight_function": self.weight_function,
         }
@@ -2430,8 +2429,8 @@ class DistanceNbSetWeight(NbSetWeight):
     def as_dict(self):
         """MSOnable dict"""
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "weight_function": self.weight_function,
             "nbs_source": self.nbs_source,
         }
@@ -2510,8 +2509,8 @@ class DeltaDistanceNbSetWeight(NbSetWeight):
     def as_dict(self):
         """MSONable dict"""
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "weight_function": self.weight_function,
             "nbs_source": self.nbs_source,
         }
@@ -2787,7 +2786,7 @@ class WeightedNbSetChemenvStrategy(AbstractChemenvStrategy):
 
     def __eq__(self, other):
         return (
-            self.__class__.__name__ == other.__class__.__name__
+            type(self).__name__ == other.__class__.__name__
             and self._additional_condition == other._additional_condition
             and self.symmetry_measure_type == other.symmetry_measure_type
             and self.nb_set_weights == other.nb_set_weights
@@ -2803,8 +2802,8 @@ class WeightedNbSetChemenvStrategy(AbstractChemenvStrategy):
         :return: Bson-serializable dict representation of the WeightedNbSetChemenvStrategy object.
         """
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "additional_condition": self._additional_condition,
             "symmetry_measure_type": self.symmetry_measure_type,
             "nb_set_weights": [nb_set_weight.as_dict() for nb_set_weight in self.nb_set_weights],
@@ -2950,7 +2949,7 @@ class MultiWeightsChemenvStrategy(WeightedNbSetChemenvStrategy):
 
     def __eq__(self, other):
         return (
-            self.__class__.__name__ == other.__class__.__name__
+            type(self).__name__ == other.__class__.__name__
             and self._additional_condition == other._additional_condition
             and self.symmetry_measure_type == other.symmetry_measure_type
             and self.dist_ang_area_weight == other.dist_ang_area_weight
@@ -2971,8 +2970,8 @@ class MultiWeightsChemenvStrategy(WeightedNbSetChemenvStrategy):
         :return: Bson-serializable dict representation of the MultiWeightsChemenvStrategy object.
         """
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "additional_condition": self._additional_condition,
             "symmetry_measure_type": self.symmetry_measure_type,
             "dist_ang_area_weight": self.dist_ang_area_weight.as_dict()

--- a/pymatgen/analysis/chemenv/coordination_environments/coordination_geometries.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/coordination_geometries.py
@@ -106,8 +106,8 @@ class ExplicitPermutationsAlgorithm(AbstractChemenvAlgorithm):
         Returns: a JSON-serializable dict representation of this ExplicitPermutationsAlgorithm algorithm.
         """
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "permutations": self._permutations,
         }
 
@@ -308,8 +308,8 @@ class SeparationPlane(AbstractChemenvAlgorithm):
         Returns: a JSON-serializable dict representation of this SeparationPlane algorithm.
         """
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "plane_points": self.plane_points,
             "mirror_plane": self.mirror_plane,
             "ordered_plane": self.ordered_plane,

--- a/pymatgen/analysis/chemenv/coordination_environments/structure_environments.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/structure_environments.py
@@ -1331,8 +1331,8 @@ class StructureEnvironments(MSONable):
         ]
 
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "voronoi": self.voronoi.as_dict(),
             "valences": self.valences,
             "sites_map": self.sites_map,
@@ -2087,8 +2087,8 @@ class LightStructureEnvironments(MSONable):
             Bson-serializable dict representation of the LightStructureEnvironments object.
         """
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "strategy": self.strategy.as_dict(),
             "structure": self.structure.as_dict(),
             "coordination_environments": self.coordination_environments,
@@ -2417,8 +2417,8 @@ class ChemicalEnvironments(MSONable):
             A dictionary representation of the ChemicalEnvironments object.
         """
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "coord_geoms": jsanitize(self.coord_geoms),
         }
 

--- a/pymatgen/analysis/chemenv/coordination_environments/voronoi.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/voronoi.py
@@ -961,8 +961,8 @@ class DetailedVoronoiContainer(MSONable):
         """
         bson_nb_voro_list2 = self.to_bson_voronoi_list2()
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "bson_nb_voro_list2": bson_nb_voro_list2,
             # "neighbors_lists": self.neighbors_lists,
             "structure": self.structure.as_dict(),

--- a/pymatgen/analysis/chemenv/utils/func_utils.py
+++ b/pymatgen/analysis/chemenv/utils/func_utils.py
@@ -41,8 +41,7 @@ class AbstractRatioFunction:
         """
         if function not in self.ALLOWED_FUNCTIONS:
             raise ValueError(
-                'Function "{}" is not allowed in RatioFunction of '
-                'type "{}"'.format(function, self.__class__.__name__)
+                'Function "{}" is not allowed in RatioFunction of ' 'type "{}"'.format(function, type(self).__name__)
             )
         self.eval = object.__getattribute__(self, function)
         self.function = function
@@ -83,14 +82,14 @@ class AbstractRatioFunction:
                         missing = "only {} were provided.".format(" and ".join([missing1, f'"{optgiven[-1]}"']))
                 raise ValueError(
                     '{} should be provided for function "{}" in RatioFunction of '
-                    'type "{}" while {}'.format(opts, self.function, self.__class__.__name__, missing)
+                    'type "{}" while {}'.format(opts, self.function, type(self).__name__, missing)
                 )
             # Setup the options and raise an error if a wrong option is provided
             for key, val in options_dict.items():
                 if key not in function_options:
                     raise ValueError(
                         'Option "{}" not allowed for function "{}" in RatioFunction of '
-                        'type "{}"'.format(key, self.function, self.__class__.__name__)
+                        'type "{}"'.format(key, self.function, type(self).__name__)
                     )
                 self.__setattr__(key, val)
 

--- a/pymatgen/analysis/defects/core.py
+++ b/pymatgen/analysis/defects/core.py
@@ -533,8 +533,8 @@ class DefectEntry(MSONable):
         JSON-serializable dict representation of DefectEntry
         """
         d = {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "defect": self.defect.as_dict(),
             "uncorrected_energy": self.uncorrected_energy,
             "corrections": self.corrections,

--- a/pymatgen/analysis/defects/core.py
+++ b/pymatgen/analysis/defects/core.py
@@ -86,7 +86,7 @@ class Defect(MSONable, metaclass=ABCMeta):
         """
         return self._multiplicity
 
-    @property  # type: ignore
+    @property
     @abstractmethod
     def defect_composition(self):
         """
@@ -103,7 +103,7 @@ class Defect(MSONable, metaclass=ABCMeta):
         """
         return
 
-    @property  # type: ignore
+    @property
     @abstractmethod
     def name(self):
         """

--- a/pymatgen/analysis/defects/thermodynamics.py
+++ b/pymatgen/analysis/defects/thermodynamics.py
@@ -92,8 +92,8 @@ class DefectPhaseDiagram(MSONable):
             JSON-serializable dict representation of DefectPhaseDiagram
         """
         d = {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "entries": [entry.as_dict() for entry in self.entries],
             "vbm": self.vbm,
             "band_gap": self.band_gap,

--- a/pymatgen/analysis/defects/utils.py
+++ b/pymatgen/analysis/defects/utils.py
@@ -58,7 +58,7 @@ invang_to_ev = 3.80986
 kumagai_to_V = 1.809512739e2  # = Electron charge * 1e10 / VacuumPermittivity Constant
 
 motif_cn_op = {}
-for cn, di in cn_opt_params.items():  # type: ignore
+for cn, di in cn_opt_params.items():
     for mot, li in di.items():
         motif_cn_op[mot] = {"cn": int(cn), "optype": li[0]}
         motif_cn_op[mot]["params"] = deepcopy(li[1]) if len(li) > 1 else None

--- a/pymatgen/analysis/diffusion_analyzer.py
+++ b/pymatgen/analysis/diffusion_analyzer.py
@@ -749,8 +749,8 @@ class DiffusionAnalyzer(MSONable):
         Returns: MSONable dict
         """
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "structure": self.structure.as_dict(),
             "displacements": self.disp.tolist(),
             "specie": self.specie,

--- a/pymatgen/analysis/energy_models.py
+++ b/pymatgen/analysis/energy_models.py
@@ -87,8 +87,8 @@ class EwaldElectrostaticModel(EnergyModel):
         """
         return {
             "version": __version__,
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "init_args": {
                 "real_space_cut": self.real_space_cut,
                 "recip_space_cut": self.recip_space_cut,
@@ -130,8 +130,8 @@ class SymmetryModel(EnergyModel):
         """
         return {
             "version": __version__,
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "init_args": {
                 "symprec": self.symprec,
                 "angle_tolerance": self.angle_tolerance,
@@ -172,8 +172,8 @@ class IsingModel(EnergyModel):
         """
         return {
             "version": __version__,
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "init_args": {"j": self.j, "max_radius": self.max_radius},
         }
 
@@ -198,7 +198,7 @@ class NsitesModel(EnergyModel):
         """
         return {
             "version": __version__,
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "init_args": {},
         }

--- a/pymatgen/analysis/eos.py
+++ b/pymatgen/analysis/eos.py
@@ -191,9 +191,9 @@ class EOSBase(metaclass=ABCMeta):
         plt = pretty_plot(width=width, height=height, plt=plt, dpi=dpi)
 
         color = kwargs.get("color", "r")
-        label = kwargs.get("label", f"{self.__class__.__name__} fit")
+        label = kwargs.get("label", f"{type(self).__name__} fit")
         lines = [
-            f"Equation of State: {self.__class__.__name__}",
+            f"Equation of State: {type(self).__name__}",
             f"Minimum energy = {self.e0:1.2f} eV",
             f"Minimum or reference volume = {self.v0:1.2f} Ang^3",
             f"Bulk modulus = {self.b0:1.2f} eV/Ang^3 = {self.b0_GPa:1.2f} GPa",
@@ -240,9 +240,9 @@ class EOSBase(metaclass=ABCMeta):
         ax, fig, plt = get_ax_fig_plt(ax=ax)
 
         color = kwargs.get("color", "r")
-        label = kwargs.get("label", f"{self.__class__.__name__} fit")
+        label = kwargs.get("label", f"{type(self).__name__} fit")
         lines = [
-            f"Equation of State: {self.__class__.__name__}",
+            f"Equation of State: {type(self).__name__}",
             f"Minimum energy = {self.e0:1.2f} eV",
             f"Minimum or reference volume = {self.v0:1.2f} Ang^3",
             f"Bulk modulus = {self.b0:1.2f} eV/Ang^3 = {self.b0_GPa:1.2f} GPa",

--- a/pymatgen/analysis/ewald.py
+++ b/pymatgen/analysis/ewald.py
@@ -454,8 +454,8 @@ class EwaldSummation(MSONable):
         """
 
         d = {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "structure": self._s.as_dict(),
             "compute_forces": self._compute_forces,
             "eta": self._eta,

--- a/pymatgen/analysis/gb/grain.py
+++ b/pymatgen/analysis/gb/grain.py
@@ -276,8 +276,8 @@ class GrainBoundary(Structure):
             Dictionary representation of GrainBoundary object
         """
         d = super().as_dict()
-        d["@module"] = self.__class__.__module__
-        d["@class"] = self.__class__.__name__
+        d["@module"] = type(self).__module__
+        d["@class"] = type(self).__name__
         d["init_cell"] = self.init_cell.as_dict()
         d["rotation_axis"] = self.rotation_axis
         d["rotation_angle"] = self.rotation_angle

--- a/pymatgen/analysis/graphs.py
+++ b/pymatgen/analysis/graphs.py
@@ -1080,8 +1080,8 @@ class StructureGraph(MSONable):
         """
 
         d = {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "structure": self.structure.as_dict(),
             "graphs": json_graph.adjacency_data(self.graph),
         }
@@ -1299,8 +1299,8 @@ class StructureGraph(MSONable):
 
         # return new instance of StructureGraph with supercell
         d = {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "structure": new_structure.as_dict(),
             "graphs": json_graph.adjacency_data(new_g),
         }
@@ -2738,8 +2738,8 @@ class MoleculeGraph(MSONable):
         """
 
         d = {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "molecule": self.molecule.as_dict(),
             "graphs": json_graph.adjacency_data(self.graph),
         }

--- a/pymatgen/analysis/interface_reactions.py
+++ b/pymatgen/analysis/interface_reactions.py
@@ -342,7 +342,7 @@ class InterfacialReactivity(MSONable):
 
     def _get_plotly_figure(self) -> Figure:
         """Returns a Plotly figure of reaction kinks diagram"""
-        kinks = map(list, zip(*self.get_kinks()))  # type: ignore
+        kinks = map(list, zip(*self.get_kinks()))
         _, x, energy, reactions, _ = kinks
 
         lines = Scatter(
@@ -411,7 +411,7 @@ class InterfacialReactivity(MSONable):
         pretty_plot(8, 5)
         plt.xlim([-0.05, 1.05])  # plot boundary is 5% wider on each side
 
-        kinks = list(zip(*self.get_kinks()))  # type: ignore
+        kinks = list(zip(*self.get_kinks()))
         _, x, energy, reactions, _ = kinks
 
         plt.plot(x, energy, "o-", markersize=8, c="navy", zorder=1)
@@ -419,11 +419,7 @@ class InterfacialReactivity(MSONable):
 
         for x_coord, y_coord, rxn in zip(x, energy, reactions):
             products = ", ".join(
-                [
-                    latexify(p.reduced_formula)
-                    for p in rxn.products  # type: ignore
-                    if not np.isclose(rxn.get_coeff(p), 0)  # type: ignore
-                ]
+                [latexify(p.reduced_formula) for p in rxn.products if not np.isclose(rxn.get_coeff(p), 0)]
             )
             plt.annotate(
                 products,

--- a/pymatgen/analysis/magnetism/analyzer.py
+++ b/pymatgen/analysis/magnetism/analyzer.py
@@ -679,7 +679,7 @@ class MagneticStructureEnumerator:
                 MagOrderingTransformation, to change automatic cell size limits, etc.
         """
 
-        self.logger = logging.getLogger(self.__class__.__name__)
+        self.logger = logging.getLogger(type(self).__name__)
 
         self.structure = structure
 

--- a/pymatgen/analysis/magnetism/heisenberg.py
+++ b/pymatgen/analysis/magnetism/heisenberg.py
@@ -925,8 +925,8 @@ class HeisenbergModel(MSONable):
         """
 
         d = {}
-        d["@module"] = self.__class__.__module__
-        d["@class"] = self.__class__.__name__
+        d["@module"] = type(self).__module__
+        d["@class"] = type(self).__name__
         d["@version"] = __version__
         d["formula"] = self.formula
         d["structures"] = [s.as_dict() for s in self.structures]

--- a/pymatgen/analysis/molecule_matcher.py
+++ b/pymatgen/analysis/molecule_matcher.py
@@ -190,8 +190,8 @@ class IsomorphismMolAtomMapper(AbstractMolAtomMapper):
         """
         return {
             "version": __version__,
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
         }
 
     @classmethod
@@ -226,8 +226,8 @@ class InchiMolAtomMapper(AbstractMolAtomMapper):
         """
         return {
             "version": __version__,
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "angle_tolerance": self._angle_tolerance,
         }
 
@@ -719,8 +719,8 @@ class MoleculeMatcher(MSONable):
         """
         return {
             "version": __version__,
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "tolerance": self._tolerance,
             "mapper": self._mapper.as_dict(),
         }

--- a/pymatgen/analysis/molecule_structure_comparator.py
+++ b/pymatgen/analysis/molecule_structure_comparator.py
@@ -273,8 +273,8 @@ class MoleculeStructureComparator(MSONable):
         """
         return {
             "version": __version__,
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "bond_length_cap": self.bond_length_cap,
             "covalent_radius": self.covalent_radius,
             "priority_bonds": self.priority_bonds,

--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -73,7 +73,7 @@ class PDEntry(Entry):
         name = ""
         if self.name != self.composition.reduced_formula:
             name = f" ({self.name})"
-        return f"{self.__class__.__name__} : {self.composition}{name} with energy = {self.energy:.4f}"
+        return f"{type(self).__name__} : {self.composition}{name} with energy = {self.energy:.4f}"
 
     @property
     def energy(self) -> float:
@@ -175,8 +175,8 @@ class GrandPotPDEntry(PDEntry):
             MSONable dictionary representation of GrandPotPDEntry
         """
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "entry": self.original_entry.as_dict(),
             "chempots": {el.symbol: u for el, u in self.chempots.items()},
             "name": self.name,
@@ -263,8 +263,8 @@ class TransformedPDEntry(PDEntry):
             MSONable dictionary representation of TransformedPDEntry
         """
         d = {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "sp_mapping": self.sp_mapping,
         }
         d.update(self.original_entry.as_dict())
@@ -373,8 +373,8 @@ class PhaseDiagram(MSONable):
         :return: MSONAble dict
         """
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "all_entries": [e.as_dict() for e in self.all_entries],
             "elements": [e.as_dict() for e in self.elements],
             "computed_data": self.computed_data,
@@ -1278,8 +1278,8 @@ class GrandPotentialPhaseDiagram(PhaseDiagram):
         :return: MSONable dict
         """
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "all_entries": [e.as_dict() for e in self.all_entries],
             "chempots": self.chempots,
             "elements": [e.as_dict() for e in self.elements],
@@ -1377,8 +1377,8 @@ class CompoundPhaseDiagram(PhaseDiagram):
             MSONable dictionary representation of CompoundPhaseDiagram
         """
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "original_entries": [e.as_dict() for e in self.original_entries],
             "terminal_compositions": [c.as_dict() for c in self.terminal_compositions],
             "normalize_terminal_compositions": self.normalize_terminals,

--- a/pymatgen/analysis/pourbaix_diagram.py
+++ b/pymatgen/analysis/pourbaix_diagram.py
@@ -215,7 +215,7 @@ class PourbaixEntry(MSONable, Stringify):
         Note that the pH, voltage, H2O factors are always calculated when
         constructing a PourbaixEntry object.
         """
-        d = {"@module": self.__class__.__module__, "@class": self.__class__.__name__}
+        d = {"@module": type(self).__module__, "@class": type(self).__name__}
         if isinstance(self.entry, IonEntry):
             d["entry_type"] = "Ion"
         else:
@@ -360,8 +360,8 @@ class MultiEntry(PourbaixEntry):
         Returns: MSONable dict
         """
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "entry_list": [e.as_dict() for e in self.entry_list],
             "weights": self.weights,
         }
@@ -982,8 +982,8 @@ class PourbaixDiagram(MSONable):
                 )
             )
         d = {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "entries": [e.as_dict() for e in self._unprocessed_entries],
             "comp_dict": self._elt_comp,
             "conc_dict": self._conc_dict,

--- a/pymatgen/analysis/reaction_calculator.py
+++ b/pymatgen/analysis/reaction_calculator.py
@@ -245,8 +245,8 @@ class BalancedReaction(MSONable):
             A dictionary representation of BalancedReaction.
         """
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "reactants": {str(comp): coeff for comp, coeff in self.reactants_coeffs.items()},
             "products": {str(comp): coeff for comp, coeff in self.products_coeffs.items()},
         }
@@ -383,8 +383,8 @@ class Reaction(BalancedReaction):
             A dictionary representation of Reaction.
         """
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "reactants": [comp.as_dict() for comp in self._input_reactants],
             "products": [comp.as_dict() for comp in self._input_products],
         }
@@ -494,8 +494,8 @@ class ComputedReaction(Reaction):
             A dictionary representation of ComputedReaction.
         """
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "reactants": [e.as_dict() for e in self._reactant_entries],
             "products": [e.as_dict() for e in self._product_entries],
         }

--- a/pymatgen/analysis/structure_matcher.py
+++ b/pymatgen/analysis/structure_matcher.py
@@ -102,8 +102,8 @@ class AbstractComparator(MSONable, metaclass=abc.ABCMeta):
         """
         return {
             "version": __version__,
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
         }
 
 
@@ -850,8 +850,8 @@ class StructureMatcher(MSONable):
         """
         return {
             "version": __version__,
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "comparator": self._comparator.as_dict(),
             "stol": self.stol,
             "ltol": self.ltol,

--- a/pymatgen/analysis/structure_matcher.py
+++ b/pymatgen/analysis/structure_matcher.py
@@ -17,12 +17,9 @@ from pymatgen.core.composition import Composition
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.periodic_table import get_el_sp
 from pymatgen.core.structure import Structure
-from pymatgen.optimization.linear_assignment import LinearAssignment  # type: ignore
+from pymatgen.optimization.linear_assignment import LinearAssignment
 from pymatgen.util.coord import lattice_points_in_supercell
-from pymatgen.util.coord_cython import (  # type: ignore
-    is_coord_subset_pbc,
-    pbc_shortest_vectors,
-)
+from pymatgen.util.coord_cython import is_coord_subset_pbc, pbc_shortest_vectors
 
 __author__ = "William Davidson Richards, Stephen Dacek, Shyue Ping Ong"
 __copyright__ = "Copyright 2011, The Materials Project"

--- a/pymatgen/analysis/structure_prediction/substitution_probability.py
+++ b/pymatgen/analysis/structure_prediction/substitution_probability.py
@@ -158,11 +158,11 @@ class SubstitutionProbability:
         Returns: MSONAble dict
         """
         return {
-            "name": self.__class__.__name__,
+            "name": type(self).__name__,
             "version": __version__,
             "init_args": {"lambda_table": self._l, "alpha": self.alpha},
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
         }
 
     @classmethod

--- a/pymatgen/analysis/structure_prediction/substitutor.py
+++ b/pymatgen/analysis/structure_prediction/substitutor.py
@@ -251,12 +251,12 @@ class Substitutor(MSONable):
         Returns: MSONable dict
         """
         return {
-            "name": self.__class__.__name__,
+            "name": type(self).__name__,
             "version": __version__,
             "kwargs": self._kwargs,
             "threshold": self._threshold,
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
         }
 
     @classmethod

--- a/pymatgen/analysis/surface_analysis.py
+++ b/pymatgen/analysis/surface_analysis.py
@@ -149,7 +149,7 @@ class SlabEntry(ComputedStructureEntry):
         Returns dict which contains Slab Entry data.
         """
 
-        d = {"@module": self.__class__.__module__, "@class": self.__class__.__name__}
+        d = {"@module": type(self).__module__, "@class": type(self).__name__}
         d["structure"] = self.structure
         d["energy"] = self.energy
         d["miller_index"] = self.miller_index

--- a/pymatgen/analysis/thermochemistry.py
+++ b/pymatgen/analysis/thermochemistry.py
@@ -95,8 +95,8 @@ class ThermoData:
         Returns: MSONable dict
         """
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "type": self.type,
             "formula": self.formula,
             "compound_name": self.compound_name,

--- a/pymatgen/analysis/transition_state.py
+++ b/pymatgen/analysis/transition_state.py
@@ -283,8 +283,8 @@ class NEBAnalysis(MSONable):
             JSON-serializable dict representation.
         """
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "r": jsanitize(self.r),
             "energies": jsanitize(self.energies),
             "forces": jsanitize(self.forces),

--- a/pymatgen/apps/battery/battery_abc.py
+++ b/pymatgen/apps/battery/battery_abc.py
@@ -256,7 +256,7 @@ class AbstractElectrode(Sequence, MSONable):
         """
         NotImplementedError(
             "The get_sub_electrodes function must be implemented for each concrete electrode "
-            f"class {self.__class__.__name__,}"
+            f"class {type(self).__name__,}"
         )
 
     def get_average_voltage(self, min_voltage=None, max_voltage=None):

--- a/pymatgen/apps/battery/insertion_battery.py
+++ b/pymatgen/apps/battery/insertion_battery.py
@@ -314,7 +314,7 @@ class InsertionElectrode(AbstractElectrode):
                 stable_entries = filter(in_range, self.get_stable_entries())
                 all_entries = list(stable_entries)
                 all_entries.extend(unstable_entries)
-                battery_list.append(self.__class__.from_entries(all_entries, self.working_ion_entry))
+                battery_list.append(type(self).from_entries(all_entries, self.working_ion_entry))
         return battery_list
 
     def get_summary_dict(self, print_subelectrodes=True) -> dict:
@@ -401,8 +401,8 @@ class InsertionElectrode(AbstractElectrode):
         Returns: MSONAble dict
         """
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "entries": [entry.as_dict() for entry in self.get_all_entries()],
             "working_ion_entry": self.working_ion_entry.as_dict(),
         }

--- a/pymatgen/apps/borg/hive.py
+++ b/pymatgen/apps/borg/hive.py
@@ -183,8 +183,8 @@ class VaspToComputedEntryDrone(AbstractDrone):
                 "parameters": self._parameters,
                 "data": self._data,
             },
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
         }
 
     @classmethod
@@ -298,8 +298,8 @@ class SimpleVaspToComputedEntryDrone(VaspToComputedEntryDrone):
         """
         return {
             "init_args": {"inc_structure": self._inc_structure},
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
         }
 
     @classmethod
@@ -423,8 +423,8 @@ class GaussianToComputedEntryDrone(AbstractDrone):
                 "data": self._data,
                 "file_extensions": self._file_extensions,
             },
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
         }
 
     @classmethod

--- a/pymatgen/core/lattice.py
+++ b/pymatgen/core/lattice.py
@@ -1395,8 +1395,8 @@ class Lattice(MSONable):
         if not frac_coords:
             cart_a, cart_b = coords_a, coords_b
         else:
-            cart_a = np.reshape([self.get_cartesian_coords(vec) for vec in coords_a], (-1, 3))  # type: ignore
-            cart_b = np.reshape([self.get_cartesian_coords(vec) for vec in coords_b], (-1, 3))  # type: ignore
+            cart_a = np.reshape([self.get_cartesian_coords(vec) for vec in coords_a], (-1, 3))
+            cart_b = np.reshape([self.get_cartesian_coords(vec) for vec in coords_b], (-1, 3))
 
         return np.array([dot(a, b) for a, b in zip(cart_a, cart_b)])
 
@@ -1456,13 +1456,11 @@ class Lattice(MSONable):
         """
         try:
             # pylint: disable=C0415
-            from pymatgen.optimization.neighbors import (
-                find_points_in_spheres,  # type: ignore
-            )
+            from pymatgen.optimization.neighbors import find_points_in_spheres
         except ImportError:
             return self.get_points_in_sphere_py(frac_points=frac_points, center=center, r=r, zip_results=zip_results)
         else:
-            frac_points = np.ascontiguousarray(frac_points, dtype=np.float_)  # type: ignore
+            frac_points = np.ascontiguousarray(frac_points, dtype=np.float_)
             r = float(r)
             lattice_matrix = np.array(self.matrix)
             lattice_matrix = np.ascontiguousarray(lattice_matrix)

--- a/pymatgen/core/lattice.py
+++ b/pymatgen/core/lattice.py
@@ -941,8 +941,8 @@ class Lattice(MSONable):
         """
 
         d = {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "matrix": self._matrix.tolist(),
         }
         a, b, c, alpha, beta, gamma = self.parameters

--- a/pymatgen/core/libxcfunc.py
+++ b/pymatgen/core/libxcfunc.py
@@ -492,8 +492,8 @@ class LibxcFunc(Enum):
         """
         return {
             "name": self.name,
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
         }
 
     @staticmethod

--- a/pymatgen/core/operations.py
+++ b/pymatgen/core/operations.py
@@ -396,8 +396,8 @@ class SymmOp(MSONable):
         :return: MSONAble dict.
         """
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "matrix": self.affine_matrix.tolist(),
             "tolerance": self.tol,
         }
@@ -597,8 +597,8 @@ class MagSymmOp(SymmOp):
         :return: MSONABle dict
         """
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "matrix": self.affine_matrix.tolist(),
             "tolerance": self.tol,
             "time_reversal": self.time_reversal,

--- a/pymatgen/core/operations.py
+++ b/pymatgen/core/operations.py
@@ -290,7 +290,7 @@ class SymmOp(MSONable):
             - u * (b * v + c * w)  # type: ignore
             + (u * (b * v + c * w) - a * (v2 + w2)) * cos_t  # type: ignore
             + (b * w - c * v) * l * sin_t  # type: ignore
-        ) / l2  # type: ignore
+        ) / l2
 
         m21 = (u * v * (1 - cos_t) + w * l * sin_t) / l2  # type: ignore
         m22 = (v2 + (u2 + w2) * cos_t) / l2  # type: ignore
@@ -300,7 +300,7 @@ class SymmOp(MSONable):
             - v * (a * u + c * w)  # type: ignore
             + (v * (a * u + c * w) - b * (u2 + w2)) * cos_t  # type: ignore
             + (c * u - a * w) * l * sin_t  # type: ignore
-        ) / l2  # type: ignore
+        ) / l2
 
         m31 = (u * w * (1 - cos_t) - v * l * sin_t) / l2  # type: ignore
         m32 = (v * w * (1 - cos_t) + u * l * sin_t) / l2  # type: ignore

--- a/pymatgen/core/periodic_table.py
+++ b/pymatgen/core/periodic_table.py
@@ -857,8 +857,8 @@ class ElementBase(Enum):
         easier serialization.
         """
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "element": self.symbol,
         }
 
@@ -1339,8 +1339,8 @@ class Species(MSONable, Stringify):
         :return: Json-able dictionary representation.
         """
         d = {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "element": self.symbol,
             "oxidation_state": self._oxi_state,
         }
@@ -1525,8 +1525,8 @@ class DummySpecies(Species):
         :return: MSONAble dict representation.
         """
         d = {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "element": self.symbol,
             "oxidation_state": self._oxi_state,
         }

--- a/pymatgen/core/periodic_table.py
+++ b/pymatgen/core/periodic_table.py
@@ -447,7 +447,7 @@ class ElementBase(Enum):
         if data[0][0] == "[":
             sym = data[0].replace("[", "").replace("]", "")
             data = list(Element(sym).full_electronic_structure) + data[1:]
-        return data  # type: ignore
+        return data
 
     @property
     def valence(self):
@@ -880,7 +880,7 @@ class ElementBase(Enum):
                 try:
                     el = Element.from_row_and_group(row, group)
                 except ValueError:
-                    el = None  # type: ignore
+                    el = None
                 if el and ((not filter_function) or filter_function(el)):
                     rowstr.append(f"{el.symbol:3s}")
                 else:
@@ -1270,8 +1270,8 @@ class Species(MSONable, Stringify):
         """
         radii = self._el.data["Shannon radii"]
         radii = radii[str(int(self._oxi_state))][cn]  # type: ignore
-        if len(radii) == 1:  # type: ignore
-            k, data = list(radii.items())[0]  # type: ignore
+        if len(radii) == 1:
+            k, data = list(radii.items())[0]
             if k != spin:
                 warnings.warn(
                     f"Specified spin state of {spin} not consistent with database "
@@ -1601,7 +1601,7 @@ def get_el_sp(obj) -> Element | Species | DummySpecies:
         i = int(c)
         i = i if i == c else None  # type: ignore
     except (ValueError, TypeError):
-        i = None  # type: ignore
+        i = None
 
     if i is not None:
         return Element.from_Z(i)

--- a/pymatgen/core/sites.py
+++ b/pymatgen/core/sites.py
@@ -260,8 +260,8 @@ class Site(collections.abc.Hashable, MSONable):
             "species": species_list,
             "xyz": [float(c) for c in self.coords],
             "properties": self.properties,
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
         }
         if self.properties:
             d["properties"] = self.properties
@@ -612,8 +612,8 @@ class PeriodicSite(Site, MSONable):
             "species": species_list,
             "abc": [float(c) for c in self._frac_coords],  # type: ignore
             "lattice": self._lattice.as_dict(verbosity=verbosity),
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
         }
 
         if verbosity > 0:

--- a/pymatgen/core/sites.py
+++ b/pymatgen/core/sites.py
@@ -83,7 +83,7 @@ class Site(collections.abc.Hashable, MSONable):
         """
         :return: The species on the site as a composition, e.g., Fe0.5Mn0.5.
         """
-        return self._species  # type: ignore
+        return self._species
 
     @species.setter
     def species(self, species: SpeciesLike | CompositionLike):
@@ -102,33 +102,33 @@ class Site(collections.abc.Hashable, MSONable):
         """
         Cartesian x coordinate
         """
-        return self.coords[0]  # type: ignore
+        return self.coords[0]
 
     @x.setter
     def x(self, x: float):
-        self.coords[0] = x  # type: ignore
+        self.coords[0] = x
 
     @property
     def y(self) -> float:
         """
         Cartesian y coordinate
         """
-        return self.coords[1]  # type: ignore
+        return self.coords[1]
 
     @y.setter
     def y(self, y: float):
-        self.coords[1] = y  # type: ignore
+        self.coords[1] = y
 
     @property
     def z(self) -> float:
         """
         Cartesian z coordinate
         """
-        return self.coords[2]  # type: ignore
+        return self.coords[2]
 
     @z.setter
     def z(self, z: float):
-        self.coords[2] = z  # type: ignore
+        self.coords[2] = z
 
     def distance(self, other) -> float:
         """
@@ -258,7 +258,7 @@ class Site(collections.abc.Hashable, MSONable):
         d = {
             "name": self.species_string,
             "species": species_list,
-            "xyz": [float(c) for c in self.coords],  # type: ignore
+            "xyz": [float(c) for c in self.coords],
             "properties": self.properties,
             "@module": self.__class__.__module__,
             "@class": self.__class__.__name__,

--- a/pymatgen/core/spectrum.py
+++ b/pymatgen/core/spectrum.py
@@ -218,7 +218,7 @@ class Spectrum(MSONable):
         """
         return "\n".join(
             [
-                self.__class__.__name__,
+                type(self).__name__,
                 f"{self.XLABEL}: {self.x}",
                 f"{self.YLABEL}: {self.y}",
             ]

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -258,13 +258,13 @@ class SiteCollection(collections.abc.Sequence, metaclass=ABCMeta):
         Tuple with the set of chemical symbols.
         Note that len(symbol_set) == len(types_of_specie)
         """
-        return tuple(sorted(specie.symbol for specie in self.types_of_species))  # type: ignore
+        return tuple(sorted(specie.symbol for specie in self.types_of_species))
 
-    @property  # type: ignore
+    @property
     def atomic_numbers(self) -> tuple[int, ...]:
         """List of atomic numbers."""
         try:
-            return tuple(site.specie.Z for site in self)  # type: ignore
+            return tuple(site.specie.Z for site in self)
         except AttributeError:
             raise AttributeError("atomic_numbers available only for ordered Structures")
 
@@ -858,7 +858,7 @@ class IStructure(SiteCollection, MSONable):
     @classmethod
     def from_magnetic_spacegroup(
         cls,
-        msg: str | MagneticSpaceGroup,  # type: ignore
+        msg: str | MagneticSpaceGroup,
         lattice: list | np.ndarray | Lattice,
         species: Sequence[str | Element | Species | DummySpecies | Composition],
         coords: Sequence[Sequence[float]],
@@ -916,7 +916,7 @@ class IStructure(SiteCollection, MSONable):
         magmoms = [Magmom(m) for m in site_properties["magmom"]]
 
         if not isinstance(msg, MagneticSpaceGroup):
-            msg = MagneticSpaceGroup(msg)  # type: ignore
+            msg = MagneticSpaceGroup(msg)
 
         if isinstance(lattice, Lattice):
             latt = lattice
@@ -1328,9 +1328,7 @@ class IStructure(SiteCollection, MSONable):
 
         """
         try:
-            from pymatgen.optimization.neighbors import (
-                find_points_in_spheres,  # type: ignore
-            )
+            from pymatgen.optimization.neighbors import find_points_in_spheres
         except ImportError:
             return self._get_neighbor_list_py(r, sites, exclude_self=exclude_self)  # type: ignore
         else:
@@ -1662,7 +1660,7 @@ class IStructure(SiteCollection, MSONable):
             raise ValueError(f"Invalid reduction algo : {reduction_algo}")
 
         if reduced_latt != self.lattice:
-            return self.__class__(  # type: ignore
+            return self.__class__(
                 reduced_latt,
                 self.species_and_occu,
                 self.cart_coords,  # type: ignore
@@ -1835,7 +1833,7 @@ class IStructure(SiteCollection, MSONable):
             else:
                 lat = self.lattice
             fcoords = start_coords + x * vec
-            structs.append(self.__class__(lat, sp, fcoords, site_properties=self.site_properties))  # type: ignore
+            structs.append(self.__class__(lat, sp, fcoords, site_properties=self.site_properties))
         return structs
 
     def get_miller_index_from_site_indexes(self, site_ids, round_dp=4, verbose=True):
@@ -2592,7 +2590,7 @@ class IMolecule(SiteCollection, MSONable):
         for site in sites:
             for sp, amt in site.species.items():
                 if not isinstance(sp, DummySpecies):
-                    nelectrons += sp.Z * amt  # type: ignore
+                    nelectrons += sp.Z * amt
         nelectrons -= charge
         self._nelectrons = nelectrons
         if spin_multiplicity:
@@ -2949,7 +2947,7 @@ class IMolecule(SiteCollection, MSONable):
         for i, j, k in itertools.product(
             list(range(images[0])), list(range(images[1])), list(range(images[2]))  # type: ignore
         ):
-            box_center = [(i + 0.5) * a, (j + 0.5) * b, (k + 0.5) * c]  # type: ignore
+            box_center = [(i + 0.5) * a, (j + 0.5) * b, (k + 0.5) * c]
             if random_rotation:
                 while True:
                     op = SymmOp.from_origin_axis_angle(
@@ -3013,9 +3011,9 @@ class IMolecule(SiteCollection, MSONable):
         """
         center = self.center_of_mass
         new_coords = np.array(self.cart_coords) - center
-        return self.__class__(  # type: ignore
+        return self.__class__(
             self.species_and_occu,
-            new_coords,  # type: ignore
+            new_coords,
             charge=self._charge,
             spin_multiplicity=self._spin_multiplicity,
             site_properties=self.site_properties,
@@ -3274,7 +3272,7 @@ class Structure(IStructure, collections.abc.MutableSequence):
                     raise ValueError("PeriodicSite added must have same lattice as Structure!")
                 if len(indices) != 1:
                     raise ValueError("Site assignments makes sense only for single int indices!")
-                self._sites[ii] = site  # type: ignore
+                self._sites[ii] = site
             else:
                 if isinstance(site, str) or (not isinstance(site, collections.abc.Sequence)):
                     self._sites[ii].species = site  # type: ignore
@@ -3402,7 +3400,7 @@ class Structure(IStructure, collections.abc.MutableSequence):
         elif coords_are_cartesian:
             frac_coords = self._lattice.get_fractional_coords(coords)
         else:
-            frac_coords = coords  # type: ignore
+            frac_coords = coords
 
         new_site = PeriodicSite(species, frac_coords, self._lattice, properties=properties)
         self._sites[i] = new_site
@@ -4039,7 +4037,7 @@ class Molecule(IMolecule, collections.abc.MutableSequence):
             vector = [0, 0, 0]
         for i in indices:
             site = self._sites[i]
-            new_site = Site(site.species, site.coords + vector, properties=site.properties)  # type: ignore
+            new_site = Site(site.species, site.coords + vector, properties=site.properties)
             self._sites[i] = new_site
 
     def rotate_sites(

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -1642,7 +1642,7 @@ class IStructure(SiteCollection, MSONable):
                 as if each comparison were reversed.
         """
         sites = sorted(self, key=key, reverse=reverse)
-        return self.__class__.from_sites(sites, charge=self._charge)
+        return type(self).from_sites(sites, charge=self._charge)
 
     def get_reduced_structure(self, reduction_algo: Literal["niggli", "LLL"] = "niggli") -> IStructure | Structure:
         """
@@ -1722,7 +1722,7 @@ class IStructure(SiteCollection, MSONable):
                 )
             )
         new_sites = sorted(new_sites)
-        return self.__class__.from_sites(new_sites, charge=self._charge)
+        return type(self).from_sites(new_sites, charge=self._charge)
 
     def interpolate(
         self,
@@ -2189,8 +2189,8 @@ class IStructure(SiteCollection, MSONable):
         del latt_dict["@class"]
 
         d = {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "charge": self.charge,
             "lattice": latt_dict,
             "sites": [],
@@ -2722,7 +2722,7 @@ class IMolecule(SiteCollection, MSONable):
                 raise ValueError("Not all sites are matched!")
             sites = unmatched
 
-        return tuple(self.__class__.from_sites(cluster) for cluster in clusters)
+        return tuple(type(self).from_sites(cluster) for cluster in clusters)
 
     def get_covalent_bonds(self, tol: float = 0.2) -> list[CovalentBond]:
         """
@@ -2792,8 +2792,8 @@ class IMolecule(SiteCollection, MSONable):
         JSON-serializable dict representation of Molecule
         """
         d = {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "charge": self.charge,
             "spin_multiplicity": self.spin_multiplicity,
             "sites": [],
@@ -4120,7 +4120,7 @@ class Molecule(IMolecule, collections.abc.MutableSequence):
         Returns:
             A copy of the Molecule.
         """
-        return self.__class__.from_sites(self)
+        return type(self).from_sites(self)
 
     def substitute(self, index: int, func_group: IMolecule | Molecule | str, bond_order: int = 1):
         """

--- a/pymatgen/core/surface.py
+++ b/pymatgen/core/surface.py
@@ -499,8 +499,8 @@ class Slab(Structure):
         :return: MSONAble dict
         """
         d = super().as_dict()
-        d["@module"] = self.__class__.__module__
-        d["@class"] = self.__class__.__name__
+        d["@module"] = type(self).__module__
+        d["@class"] = type(self).__name__
         d["oriented_unit_cell"] = self.oriented_unit_cell.as_dict()
         d["miller_index"] = self.miller_index
         d["shift"] = self.shift

--- a/pymatgen/core/tensors.py
+++ b/pymatgen/core/tensors.py
@@ -99,7 +99,7 @@ class Tensor(np.ndarray, MSONable):
         return hash(self.tostring())
 
     def __repr__(self):
-        return f"{self.__class__.__name__}({self.__str__()})"
+        return f"{type(self).__name__}({self.__str__()})"
 
     def zeroed(self, tol=1e-3):
         """
@@ -312,7 +312,7 @@ class Tensor(np.ndarray, MSONable):
         v = self.voigt
         perms = list(itertools.permutations(range(len(v.shape))))
         new_v = sum(np.transpose(v, ind) for ind in perms) / len(perms)
-        return self.__class__.from_voigt(new_v)
+        return type(self).from_voigt(new_v)
 
     def is_symmetric(self, tol=1e-5):
         """
@@ -687,8 +687,8 @@ class Tensor(np.ndarray, MSONable):
         """
         input_array = self.voigt if voigt else self
         d = {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "input_array": input_array.tolist(),
         }
         if voigt:
@@ -851,8 +851,8 @@ class TensorCollection(collections.abc.Sequence, MSONable):
         """
         tensor_list = self.voigt if voigt else self
         d = {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "tensor_list": [t.tolist() for t in tensor_list],
         }
         if voigt:

--- a/pymatgen/core/trajectory.py
+++ b/pymatgen/core/trajectory.py
@@ -363,8 +363,8 @@ class Trajectory(MSONable):
         :return: MSONAble dict.
         """
         d = {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "species": self.species,
             "time_step": self.time_step,
             "site_properties": self.site_properties,

--- a/pymatgen/core/xcfunc.py
+++ b/pymatgen/core/xcfunc.py
@@ -184,7 +184,7 @@ class XcFunc(MSONable):
         """
         Makes XcFunc obey the general json interface used in pymatgen for easier serialization.
         """
-        d = {"@module": self.__class__.__module__, "@class": self.__class__.__name__}
+        d = {"@module": type(self).__module__, "@class": type(self).__name__}
         if self.x is not None:
             d["x"] = self.x.as_dict()
         if self.c is not None:

--- a/pymatgen/electronic_structure/bandstructure.py
+++ b/pymatgen/electronic_structure/bandstructure.py
@@ -133,8 +133,8 @@ class Kpoint(MSONable):
             "fcoords": self.frac_coords.tolist(),
             "ccoords": self.cart_coords.tolist(),
             "label": self.label,
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
         }
 
     @classmethod
@@ -602,8 +602,8 @@ class BandStructure:
         JSON-serializable dict representation of BandStructure.
         """
         d = {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "lattice_rec": self.lattice_rec.as_dict(),
             "efermi": self.efermi,
             "kpoints": [],
@@ -963,8 +963,8 @@ class LobsterBandStructureSymmLine(BandStructureSymmLine):
         """
 
         d = {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "lattice_rec": self.lattice_rec.as_dict(),
             "efermi": self.efermi,
             "kpoints": [],

--- a/pymatgen/electronic_structure/boltztrap.py
+++ b/pymatgen/electronic_structure/boltztrap.py
@@ -748,8 +748,8 @@ class BoltztrapRunner(MSONable):
         :return: MSONable dict
         """
         results = {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "lpfac": self.lpfac,
             "bs": self.bs.as_dict(),
             "nelec": self._nelec,

--- a/pymatgen/electronic_structure/cohp.py
+++ b/pymatgen/electronic_structure/cohp.py
@@ -89,8 +89,8 @@ class Cohp(MSONable):
         JSON-serializable dict representation of COHP.
         """
         d = {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "are_coops": self.are_coops,
             "are_cobis": self.are_cobis,
             "efermi": self.efermi,
@@ -311,8 +311,8 @@ class CompleteCohp(Cohp):
         JSON-serializable dict representation of CompleteCohp.
         """
         d = {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "are_coops": self.are_coops,
             "are_cobis": self.are_cobis,
             "efermi": self.efermi,

--- a/pymatgen/electronic_structure/dos.py
+++ b/pymatgen/electronic_structure/dos.py
@@ -80,7 +80,7 @@ class DOS(Spectrum):
             tdos = self.y[:, 1]
 
         if not abs_tol:
-            tol = tol * tdos.sum() / tdos.shape[0]  # type: ignore
+            tol = tol * tdos.sum() / tdos.shape[0]
         energies = self.x
         below_fermi = [i for i in range(len(energies)) if energies[i] < self.efermi and tdos[i] > tol]
         above_fermi = [i for i in range(len(energies)) if energies[i] > self.efermi and tdos[i] > tol]
@@ -120,7 +120,7 @@ class DOS(Spectrum):
             tdos = self.y[:, 1]
 
         if not abs_tol:
-            tol = tol * tdos.sum() / tdos.shape[0]  # type: ignore
+            tol = tol * tdos.sum() / tdos.shape[0]
 
         # find index of fermi energy
         i_fermi = 0

--- a/pymatgen/electronic_structure/dos.py
+++ b/pymatgen/electronic_structure/dos.py
@@ -391,8 +391,8 @@ class Dos(MSONable):
         JSON-serializable dict representation of Dos.
         """
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "efermi": self.efermi,
             "energies": self.energies.tolist(),
             "densities": {str(spin): dens.tolist() for spin, dens in self.densities.items()},
@@ -613,8 +613,8 @@ class FermiDos(Dos, MSONable):
         JSON-serializable dict representation of Dos.
         """
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "efermi": self.efermi,
             "energies": self.energies.tolist(),
             "densities": {str(spin): dens.tolist() for spin, dens in self.densities.items()},
@@ -1184,8 +1184,8 @@ class CompleteDos(Dos):
         JSON-serializable dict representation of CompleteDos.
         """
         d = {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "efermi": self.efermi,
             "structure": self.structure.as_dict(),
             "energies": self.energies.tolist(),

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -2491,7 +2491,7 @@ class BSDOSPlotter:
                         spd_dos = dos.get_spd_dos()
                         for idx, orb in enumerate([OrbitalType.s, OrbitalType.p, OrbitalType.d, OrbitalType.f]):
                             if orb in spd_dos:
-                                dos_densities = spd_dos[orb].densities[spin] * int(spin)  # type: ignore
+                                dos_densities = spd_dos[orb].densities[spin] * int(spin)
                                 label = orb if spin == Spin.up else None  # type: ignore
                                 dos_ax.plot(
                                     dos_densities,

--- a/pymatgen/entries/__init__.py
+++ b/pymatgen/entries/__init__.py
@@ -87,7 +87,7 @@ class Entry(MSONable, metaclass=ABCMeta):
         return self.energy / self.composition.num_atoms
 
     def __repr__(self):
-        return f"{self.__class__.__name__} : {self.composition} with energy = {self.energy:.4f}"
+        return f"{type(self).__name__} : {self.composition} with energy = {self.energy:.4f}"
 
     def __str__(self):
         return self.__repr__()
@@ -129,8 +129,8 @@ class Entry(MSONable, metaclass=ABCMeta):
         :return: MSONable dict.
         """
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "energy": self._energy,
             "composition": self._composition.as_dict(),
         }
@@ -153,4 +153,4 @@ class Entry(MSONable, metaclass=ABCMeta):
     def __hash__(self):
         # NOTE truncate _energy to 8 dp to ensure same robustness
         # as np.allclose
-        return hash(f"{self.__class__.__name__}{self._composition.formula}{self._energy:.8f}")
+        return hash(f"{type(self).__name__}{self._composition.formula}{self._energy:.8f}")

--- a/pymatgen/entries/compatibility.py
+++ b/pymatgen/entries/compatibility.py
@@ -737,7 +737,7 @@ class CorrectionsList(Compatibility):
             corrected_energy = centry.energy
             correction_uncertainty = centry.correction_uncertainty
         d = {
-            "compatibility": self.__class__.__name__,
+            "compatibility": type(self).__name__,
             "uncorrected_energy": uncorrected_energy,
             "corrected_energy": corrected_energy,
             "correction_uncertainty": correction_uncertainty,

--- a/pymatgen/entries/computed_entries.py
+++ b/pymatgen/entries/computed_entries.py
@@ -874,7 +874,7 @@ class GibbsComputedStructureEntry(ComputedStructureEntry):
             alpha_i = pair[0][1]
             alpha_j = pair[1][1]
 
-            mass_sum += (alpha_i + alpha_j) * (m_i * m_j) / (m_i + m_j)  # type: ignore
+            mass_sum += (alpha_i + alpha_j) * (m_i * m_j) / (m_i + m_j)
 
         reduced_mass = (1 / denominator) * mass_sum
 

--- a/pymatgen/entries/computed_entries.py
+++ b/pymatgen/entries/computed_entries.py
@@ -99,7 +99,7 @@ class EnergyAdjustment(MSONable):
 
     def __repr__(self):
         output = [
-            f"{self.__class__.__name__}:",
+            f"{type(self).__name__}:",
             f"  Name: {self.name}",
             f"  Value: {self.value:.3f} eV",
             f"  Uncertainty: {self.uncertainty:.3f} eV",
@@ -463,7 +463,7 @@ class ComputedEntry(Entry):
         output = [
             "{} {:<10} - {:<12} ({})".format(
                 self.entry_id,
-                self.__class__.__name__,
+                type(self).__name__,
                 self.composition.formula,
                 self.composition.reduced_formula,
             ),
@@ -564,7 +564,7 @@ class ComputedEntry(Entry):
         # NOTE It is assumed that the user will ensure entry_id is a
         # unique identifier for ComputedEntry type classes.
         if self.entry_id is not None:
-            return hash(f"{self.__class__.__name__}{self.entry_id}")
+            return hash(f"{type(self).__name__}{self.entry_id}")
 
         return super().__hash__()
 
@@ -687,7 +687,7 @@ class ComputedStructureEntry(ComputedEntry):
         # TODO: this should raise TypeError since normalization does not make sense
         # raise TypeError("You cannot normalize a structure.")
         warnings.warn(
-            f"Normalization of a `{self.__class__.__name__}` makes "
+            f"Normalization of a `{type(self).__name__}` makes "
             "`self.composition` and `self.structure.composition` inconsistent"
             " - please use self.composition for all further calculations."
         )

--- a/pymatgen/entries/exp_entries.py
+++ b/pymatgen/entries/exp_entries.py
@@ -72,8 +72,8 @@ class ExpEntry(PDEntry, MSONable):
         :return: MSONable dict
         """
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "thermodata": [td.as_dict() for td in self._thermodata],
             "composition": self.composition.as_dict(),
             "temperature": self.temperature,

--- a/pymatgen/entries/mixing_scheme.py
+++ b/pymatgen/entries/mixing_scheme.py
@@ -162,7 +162,7 @@ class MaterialsProjectDFTMixingScheme(Compatibility):
 
         # We can't operate on single entries in this scheme
         if len(entries) == 1:
-            warnings.warn(f"{self.__class__.__name__} cannot process single entries. Supply a list of entries.")
+            warnings.warn(f"{type(self).__name__} cannot process single entries. Supply a list of entries.")
             return processed_entry_list
 
         # if clean is True, remove all previous adjustments from the entry
@@ -451,7 +451,7 @@ class MaterialsProjectDFTMixingScheme(Compatibility):
         else:
             raise CompatibilityError(
                 "WARNING! If you see this Exception it means you have encountered"
-                f"an edge case in {self.__class__.__name__}. Inspect your input carefully and post a bug report."
+                f"an edge case in {type(self).__name__}. Inspect your input carefully and post a bug report."
             )
 
     def get_mixing_state_data(self, entries: list[ComputedStructureEntry], verbose: bool = False):

--- a/pymatgen/entries/tests/test_compatibility.py
+++ b/pymatgen/entries/tests/test_compatibility.py
@@ -21,7 +21,7 @@ from collections import defaultdict
 from math import sqrt
 from pathlib import Path
 
-import pytest  # type: ignore
+import pytest
 from monty.json import MontyDecoder
 
 from pymatgen.core.composition import Composition

--- a/pymatgen/io/abinit/abiobjects.py
+++ b/pymatgen/io/abinit/abiobjects.py
@@ -536,7 +536,7 @@ class ElectronsAlgorithm(dict, AbivarAble, MSONable):
 
         for k in self:
             if k not in self._DEFAULT:
-                raise ValueError(f"{self.__class__.__name__}: No default value has been provided for key {k}")
+                raise ValueError(f"{type(self).__name__}: No default value has been provided for key {k}")
 
     def to_abivars(self):
         """Dictionary with Abinit input variables."""
@@ -604,8 +604,8 @@ class Electrons(AbivarAble, MSONable):
     def as_dict(self):
         """json friendly dict representation"""
         d = {}
-        d["@module"] = self.__class__.__module__
-        d["@class"] = self.__class__.__name__
+        d["@module"] = type(self).__module__
+        d["@class"] = type(self).__name__
         d["spin_mode"] = self.spin_mode.as_dict()
         d["smearing"] = self.smearing.as_dict()
         d["algorithm"] = self.algorithm.as_dict() if self.algorithm else None
@@ -1003,8 +1003,8 @@ class KSampling(AbivarAble, MSONable):
             "use_symmetries": self.use_symmetries,
             "use_time_reversal": self.use_time_reversal,
             "chksymbreak": self.chksymbreak,
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
         }
 
     @classmethod
@@ -1064,13 +1064,11 @@ class RelaxationMethod(AbivarAble, MSONable):
 
         for k in self.abivars:
             if k not in self._default_vars:
-                raise ValueError(f"{self.__class__.__name__}: No default value has been provided for key {k}")
+                raise ValueError(f"{type(self).__name__}: No default value has been provided for key {k}")
 
         for k in self.abivars:
             if k is MANDATORY:
-                raise ValueError(
-                    f"{self.__class__.__name__}: No default value has been provided for the mandatory key {k}"
-                )
+                raise ValueError(f"{type(self).__name__}: No default value has been provided for the mandatory key {k}")
 
     @classmethod
     def atoms_only(cls, atoms_constraints=None):
@@ -1138,8 +1136,8 @@ class RelaxationMethod(AbivarAble, MSONable):
     def as_dict(self):
         """Convert object to dict."""
         d = dict(self._default_vars)
-        d["@module"] = self.__class__.__module__
-        d["@class"] = self.__class__.__name__
+        d["@module"] = type(self).__module__
+        d["@class"] = type(self).__name__
         return d
 
     @classmethod
@@ -1226,7 +1224,7 @@ class PPModel(AbivarAble, MSONable):
     __nonzero__ = __bool__
 
     def __repr__(self):
-        return f"<{self.__class__.__name__} at {id(self)}, mode = {str(self.mode)}>"
+        return f"<{type(self).__name__} at {id(self)}, mode = {str(self.mode)}>"
 
     def to_abivars(self):
         """Return dictionary with Abinit variables."""
@@ -1244,8 +1242,8 @@ class PPModel(AbivarAble, MSONable):
         return {
             "mode": self.mode.name,
             "plasmon_freq": self.plasmon_freq,
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
         }
 
     @staticmethod

--- a/pymatgen/io/abinit/inputs.py
+++ b/pymatgen/io/abinit/inputs.py
@@ -609,7 +609,7 @@ class AbstractInput(MutableMapping, metaclass=abc.ABCMeta):
         return self.vars.__setitem__(key, value)
 
     def __repr__(self):
-        return f"<{self.__class__.__name__} at {id(self)}>"
+        return f"<{type(self).__name__} at {id(self)}>"
 
     def __str__(self):
         return self.to_string()
@@ -1159,7 +1159,7 @@ class BasicMultiDataset:
         if m is None:
             raise AttributeError(
                 "Cannot find attribute %s. Tried in %s and then in BasicAbinitInput object"
-                % (self.__class__.__name__, name)
+                % (type(self).__name__, name)
             )
         isattr = not callable(m)
 

--- a/pymatgen/io/abinit/pseudos.py
+++ b/pymatgen/io/abinit/pseudos.py
@@ -135,10 +135,10 @@ class Pseudo(MSONable, metaclass=abc.ABCMeta):
 
     def __repr__(self):
         try:
-            return f"<{self.__class__.__name__} at {os.path.relpath(self.filepath)}>"
+            return f"<{type(self).__name__} at {os.path.relpath(self.filepath)}>"
         except Exception:
             # relpath can fail if the code is executed in demon mode.
-            return f"<{self.__class__.__name__} at {self.filepath}>"
+            return f"<{type(self).__name__} at {self.filepath}>"
 
     def __str__(self):
         return self.to_string()
@@ -148,7 +148,7 @@ class Pseudo(MSONable, metaclass=abc.ABCMeta):
         # pylint: disable=E1101
         lines = []
         app = lines.append
-        app(f"<{self.__class__.__name__}: {self.basename}>")
+        app(f"<{type(self).__name__}: {self.basename}>")
         app("  summary: " + self.summary.strip())
         app(f"  number of valence electrons: {self.Z_val}")
         app(f"  maximum angular momentum: {l2str(self.l_max)}")
@@ -196,7 +196,7 @@ class Pseudo(MSONable, metaclass=abc.ABCMeta):
     @property
     def type(self):
         """Type of pseudo."""
-        return self.__class__.__name__
+        return type(self).__name__
 
     @property
     def element(self):
@@ -308,7 +308,7 @@ class Pseudo(MSONable, metaclass=abc.ABCMeta):
             shutil.copy(djrepo, os.path.join(tmpdir, os.path.basename(djrepo)))
 
         # Build new object and copy dojo_report if present.
-        new = self.__class__.from_file(new_path)
+        new = type(self).from_file(new_path)
         if self.has_dojo_report:
             new.dojo_report = self.dojo_report.deepcopy()
 
@@ -1694,7 +1694,7 @@ class PseudoTable(collections.abc.Sequence, MSONable, metaclass=abc.ABCMeta):
             yield from self._pseudos_with_z[z]
 
     def __repr__(self):
-        return f"<{self.__class__.__name__} at {id(self)}>"
+        return f"<{type(self).__name__} at {id(self)}>"
 
     def __str__(self):
         return self.to_table()
@@ -1731,8 +1731,8 @@ class PseudoTable(collections.abc.Sequence, MSONable, metaclass=abc.ABCMeta):
                 k += k.split("#")[0] + "#" + str(count)
                 count += 1
             d.update({k: p.as_dict()})
-        d["@module"] = self.__class__.__module__
-        d["@class"] = self.__class__.__name__
+        d["@module"] = type(self).__module__
+        d["@class"] = type(self).__name__
         return d
 
     @classmethod

--- a/pymatgen/io/adf.py
+++ b/pymatgen/io/adf.py
@@ -338,8 +338,8 @@ class AdfKey(MSONable):
         A JSON-serializable dict representation of self.
         """
         d = {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "name": self.name,
             "options": self.options,
         }
@@ -606,8 +606,8 @@ class AdfTask(MSONable):
         A JSON-serializable dict representation of self.
         """
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "operation": self.operation,
             "title": self.title,
             "xc": self.xc.as_dict(),

--- a/pymatgen/io/core.py
+++ b/pymatgen/io/core.py
@@ -186,7 +186,7 @@ class InputSet(MSONable, MutableMapping):
                 contents.write_file(file)
 
         if zip_inputs:
-            zipfilename = path / f"{self.__class__.__name__}.zip"
+            zipfilename = path / f"{type(self).__name__}.zip"
             with ZipFile(zipfilename, "w") as zip:
                 for fname, contents in self.inputs.items():
                     file = path / fname

--- a/pymatgen/io/cp2k/inputs.py
+++ b/pymatgen/io/cp2k/inputs.py
@@ -117,8 +117,8 @@ class Keyword(MSONable):
         Get a dictionary representation of the Keyword
         """
         d = {}
-        d["@module"] = self.__class__.__module__
-        d["@class"] = self.__class__.__name__
+        d["@module"] = type(self).__module__
+        d["@class"] = type(self).__name__
         d["name"] = self.name
         d["values"] = self.values
         d["description"] = self.description

--- a/pymatgen/io/feff/inputs.py
+++ b/pymatgen/io/feff/inputs.py
@@ -577,8 +577,8 @@ class Tags(dict):
             Dictionary of parameters from fefftags object
         """
         tags_dict = dict(self)
-        tags_dict["@module"] = self.__class__.__module__
-        tags_dict["@class"] = self.__class__.__name__
+        tags_dict["@module"] = type(self).__module__
+        tags_dict["@class"] = type(self).__name__
         return tags_dict
 
     @staticmethod

--- a/pymatgen/io/fiesta.py
+++ b/pymatgen/io/fiesta.py
@@ -80,8 +80,8 @@ class Nwchem2Fiesta(MSONable):
         :return: MSONable dict
         """
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "filename": self.filename,
             "folder": self.folder,
         }
@@ -183,8 +183,8 @@ class FiestaRun(MSONable):
         :return: MSONable dict
         """
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "log_file": self.log_file,
             "grid": self.grid,
             "folder": self.folder,

--- a/pymatgen/io/gaussian.py
+++ b/pymatgen/io/gaussian.py
@@ -500,8 +500,8 @@ class GaussianInput:
         :return: MSONable dict
         """
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "molecule": self.molecule.as_dict(),
             "functional": self.functional,
             "basis_set": self.basis_set,
@@ -1238,8 +1238,8 @@ class GaussianOutput:
         }
 
         d["output"] = vout
-        d["@module"] = self.__class__.__module__
-        d["@class"] = self.__class__.__name__
+        d["@module"] = type(self).__module__
+        d["@class"] = type(self).__name__
 
         return d
 

--- a/pymatgen/io/lammps/outputs.py
+++ b/pymatgen/io/lammps/outputs.py
@@ -91,8 +91,8 @@ class LammpsDump(MSONable):
         Returns: MSONable dict
         """
         d = {}
-        d["@module"] = self.__class__.__module__
-        d["@class"] = self.__class__.__name__
+        d["@module"] = type(self).__module__
+        d["@class"] = type(self).__name__
         d["timestep"] = self.timestep
         d["natoms"] = self.natoms
         d["box"] = self.box.as_dict()

--- a/pymatgen/io/lmto.py
+++ b/pymatgen/io/lmto.py
@@ -108,8 +108,8 @@ class LMTOCtrl:
         parameter of the primitive cell.
         """
         ctrl_dict = {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
         }
         if self.header is not None:
             ctrl_dict["HEADER"] = self.header

--- a/pymatgen/io/lobster/inputs.py
+++ b/pymatgen/io/lobster/inputs.py
@@ -279,8 +279,8 @@ class Lobsterin(dict, MSONable):
         :return: MSONable dict
         """
         d = dict(self)
-        d["@module"] = self.__class__.__module__
-        d["@class"] = self.__class__.__name__
+        d["@module"] = type(self).__module__
+        d["@class"] = type(self).__name__
         return d
 
     @classmethod

--- a/pymatgen/io/lobster/lobsterenv.py
+++ b/pymatgen/io/lobster/lobsterenv.py
@@ -1227,8 +1227,8 @@ class LobsterLightStructureEnvironments(LightStructureEnvironments):
         :return: Bson-serializable dict representation of the LightStructureEnvironments object.
         """
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "strategy": self.strategy,
             "structure": self.structure.as_dict(),
             "coordination_environments": self.coordination_environments,

--- a/pymatgen/io/nwchem.py
+++ b/pymatgen/io/nwchem.py
@@ -188,8 +188,8 @@ $theory_spec
         Returns: MSONable dict.
         """
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "charge": self.charge,
             "spin_multiplicity": self.spin_multiplicity,
             "title": self.title,

--- a/pymatgen/io/phonopy.py
+++ b/pymatgen/io/phonopy.py
@@ -33,7 +33,7 @@ except ImportError:
     PhonopyAtoms = None
 
 
-@requires(Phonopy, "phonopy not installed!")  # type: ignore
+@requires(Phonopy, "phonopy not installed!")
 def get_pmg_structure(phonopy_structure):
     """
     Convert a PhonopyAtoms object to pymatgen Structure object.
@@ -58,7 +58,7 @@ def get_pmg_structure(phonopy_structure):
     )
 
 
-@requires(Phonopy, "phonopy not installed!")  # type: ignore
+@requires(Phonopy, "phonopy not installed!")
 def get_phonopy_structure(pmg_structure):
     """
     Convert a pymatgen Structure object to a PhonopyAtoms object.

--- a/pymatgen/io/qchem/sets.py
+++ b/pymatgen/io/qchem/sets.py
@@ -266,7 +266,7 @@ class QChemDictSet(QCInput):
                         raise RuntimeError("Can't overwrite nbo params when NBO is not being run! Exiting...")
                     temp_nbo = lower_and_check_unique(sec_dict)
                     for k, v in temp_nbo.items():
-                        mynbo[k] = v  # type: ignore
+                        mynbo[k] = v
                 if sec == "opt":
                     temp_opts = lower_and_check_unique(sec_dict)
                     for k, v in temp_opts.items():

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -545,8 +545,8 @@ class Poscar(MSONable):
         :return: MSONable dict.
         """
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "structure": self.structure.as_dict(),
             "true_names": self.true_names,
             "selective_dynamics": np.array(self.selective_dynamics).tolist(),
@@ -676,8 +676,8 @@ class Incar(dict, MSONable):
         :return: MSONable dict.
         """
         d = dict(self)
-        d["@module"] = self.__class__.__module__
-        d["@class"] = self.__class__.__name__
+        d["@module"] = type(self).__module__
+        d["@class"] = type(self).__name__
         return d
 
     @classmethod
@@ -1564,8 +1564,8 @@ class Kpoints(MSONable):
         for para in optional_paras:
             if para in self.__dict__:
                 d[para] = self.__dict__[para]
-        d["@module"] = self.__class__.__module__
-        d["@class"] = self.__class__.__name__
+        d["@module"] = type(self).__module__
+        d["@class"] = type(self).__name__
         return d
 
     @classmethod
@@ -2205,8 +2205,8 @@ class Potcar(list, MSONable):
         return {
             "functional": self.functional,
             "symbols": self.symbols,
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
         }
 
     @classmethod
@@ -2337,8 +2337,8 @@ class VaspInput(dict, MSONable):
         :return: MSONable dict.
         """
         d = {k: v.as_dict() for k, v in self.items()}
-        d["@module"] = self.__class__.__module__
-        d["@class"] = self.__class__.__name__
+        d["@module"] = type(self).__module__
+        d["@class"] = type(self).__name__
         return d
 
     @classmethod

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -3264,8 +3264,8 @@ class Outcar:
         :return: MSONAble dict.
         """
         d = {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "efermi": self.efermi,
             "run_stats": self.run_stats,
             "magnetization": self.magnetization,

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -202,7 +202,7 @@ class VaspInputSet(MSONable, metaclass=abc.ABCMeta):
             s.to(filename=cifname)
 
         if zip_output:
-            filename = self.__class__.__name__ + ".zip"
+            filename = type(self).__name__ + ".zip"
             with ZipFile(os.path.join(output_dir, filename), "w") as zip:
                 for file in [
                     "INCAR",
@@ -713,10 +713,10 @@ class DictSet(VaspInputSet):
         return int(nbands)
 
     def __str__(self):
-        return self.__class__.__name__
+        return type(self).__name__
 
     def __repr__(self):
-        return self.__class__.__name__
+        return type(self).__name__
 
     def write_input(
         self,

--- a/pymatgen/io/vasp/tests/test_inputs.py
+++ b/pymatgen/io/vasp/tests/test_inputs.py
@@ -8,7 +8,7 @@ import warnings
 from pathlib import Path
 
 import numpy as np
-import pytest  # type: ignore
+import pytest
 import scipy.constants as const
 from monty.io import zopen
 from monty.tempfile import ScratchDir

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -12,8 +12,8 @@ from pathlib import Path
 from zipfile import ZipFile
 
 import numpy as np
-import pytest  # type: ignore
-from _pytest.monkeypatch import MonkeyPatch  # type: ignore
+import pytest
+from _pytest.monkeypatch import MonkeyPatch
 from monty.json import MontyDecoder
 from monty.serialization import loadfn
 

--- a/pymatgen/optimization/tests/test_linear_assignment.py
+++ b/pymatgen/optimization/tests/test_linear_assignment.py
@@ -6,7 +6,7 @@ import unittest
 
 import numpy as np
 
-from pymatgen.optimization.linear_assignment import LinearAssignment  # type: ignore
+from pymatgen.optimization.linear_assignment import LinearAssignment
 
 
 class LinearAssignmentTest(unittest.TestCase):

--- a/pymatgen/optimization/tests/test_neighbors.py
+++ b/pymatgen/optimization/tests/test_neighbors.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from pymatgen.core.lattice import Lattice
-from pymatgen.optimization.neighbors import find_points_in_spheres  # type: ignore
+from pymatgen.optimization.neighbors import find_points_in_spheres
 from pymatgen.util.testing import PymatgenTest
 
 

--- a/pymatgen/phonon/bandstructure.py
+++ b/pymatgen/phonon/bandstructure.py
@@ -250,8 +250,8 @@ class PhononBandStructure(MSONable):
         :return: MSONable dict
         """
         d = {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "lattice_rec": self.lattice_rec.as_dict(),
             "qpoints": [],
         }

--- a/pymatgen/phonon/dos.py
+++ b/pymatgen/phonon/dos.py
@@ -124,8 +124,8 @@ class PhononDos(MSONable):
         JSON-serializable dict representation of PhononDos.
         """
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "frequencies": list(self.frequencies),
             "densities": list(self.densities),
         }
@@ -387,8 +387,8 @@ class CompletePhononDos(PhononDos):
         JSON-serializable dict representation of CompletePhononDos.
         """
         d = {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "structure": self.structure.as_dict(),
             "frequencies": list(self.frequencies),
             "densities": list(self.densities),

--- a/pymatgen/phonon/gruneisen.py
+++ b/pymatgen/phonon/gruneisen.py
@@ -307,8 +307,8 @@ class GruneisenPhononBandStructure(PhononBandStructure):
 
         """
         d = {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "lattice_rec": self.lattice_rec.as_dict(),
             "qpoints": [],
         }

--- a/pymatgen/phonon/ir_spectra.py
+++ b/pymatgen/phonon/ir_spectra.py
@@ -70,8 +70,8 @@ class IRDielectricTensor(MSONable):
         JSON-serializable dict representation of IRDielectricTensor.
         """
         return {
-            "@module": self.__class__.__module__,
-            "@class": self.__class__.__name__,
+            "@module": type(self).__module__,
+            "@class": type(self).__name__,
             "oscillator_strength": self.oscillator_strength.tolist(),
             "ph_freqs_gamma": self.ph_freqs_gamma.tolist(),
             "structure": self.structure.as_dict(),

--- a/pymatgen/symmetry/kpath.py
+++ b/pymatgen/symmetry/kpath.py
@@ -22,7 +22,7 @@ from pymatgen.core.operations import MagSymmOp, SymmOp
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 
 try:
-    from seekpath import get_path  # type: ignore
+    from seekpath import get_path
 except ImportError:
     get_path = None
 

--- a/pymatgen/symmetry/settings.py
+++ b/pymatgen/symmetry/settings.py
@@ -198,7 +198,7 @@ class JonesFaithfulTransformation:
         for x in coords:
             x = np.array(x)
             Q = np.linalg.inv(self.P)
-            x_ = np.matmul(Q, (x - self.p))  # type: ignore
+            x_ = np.matmul(Q, (x - self.p))
             new_coords.append(x_.tolist())
         return new_coords
 

--- a/pymatgen/symmetry/tests/test_kpath_hin.py
+++ b/pymatgen/symmetry/tests/test_kpath_hin.py
@@ -10,7 +10,7 @@ from pymatgen.symmetry.kpath import KPathSeek
 from pymatgen.util.testing import PymatgenTest
 
 try:
-    from seekpath import get_path  # type: ignore
+    from seekpath import get_path
 except ImportError:
     get_path = None
 

--- a/pymatgen/symmetry/tests/test_kpaths.py
+++ b/pymatgen/symmetry/tests/test_kpaths.py
@@ -13,7 +13,7 @@ from pymatgen.symmetry.bandstructure import HighSymmKpath
 from pymatgen.util.testing import PymatgenTest
 
 try:
-    from seekpath import get_path  # type: ignore
+    from seekpath import get_path
 except ImportError:
     get_path = None
 

--- a/pymatgen/transformations/advanced_transformations.py
+++ b/pymatgen/transformations/advanced_transformations.py
@@ -46,7 +46,7 @@ from pymatgen.transformations.standard_transformations import (
 from pymatgen.transformations.transformation_abc import AbstractTransformation
 
 try:
-    import hiphive  # type: ignore
+    import hiphive
 except ImportError:
     hiphive = None
 
@@ -1564,7 +1564,7 @@ class CubicSupercellTransformation(AbstractTransformation):
             # round the entries of T and force T to be nonsingular
             self.transformation_matrix = _round_and_make_arr_singular(self.transformation_matrix)  # type: ignore
 
-            proposed_sc_lat_vecs = self.transformation_matrix @ lat_vecs  # type: ignore
+            proposed_sc_lat_vecs = self.transformation_matrix @ lat_vecs
 
             # Find the shortest dimension length and direction
             a = proposed_sc_lat_vecs[0]
@@ -2194,7 +2194,7 @@ class MonteCarloRattleTransformation(AbstractTransformation):
         Returns:
             Structure with sites perturbed.
         """
-        from hiphive.structure_generation.rattle import mc_rattle  # type: ignore
+        from hiphive.structure_generation.rattle import mc_rattle
 
         atoms = AseAtomsAdaptor.get_atoms(structure)
         seed = self.random_state.randint(1, 1000000000)

--- a/pymatgen/transformations/site_transformations.py
+++ b/pymatgen/transformations/site_transformations.py
@@ -314,7 +314,7 @@ class PartialRemoveSitesTransformation(AbstractTransformation):
         self.indices = indices
         self.fractions = fractions
         self.algo = algo
-        self.logger = logging.getLogger(self.__class__.__name__)
+        self.logger = logging.getLogger(type(self).__name__)
 
     def _best_first_ordering(self, structure, num_remove_dict):
         self.logger.debug("Performing best first ordering")

--- a/pymatgen/transformations/tests/test_advanced_transformations.py
+++ b/pymatgen/transformations/tests/test_advanced_transformations.py
@@ -47,7 +47,7 @@ from pymatgen.transformations.standard_transformations import (
 from pymatgen.util.testing import PymatgenTest
 
 try:
-    import hiphive  # type: ignore
+    import hiphive
 except ImportError:
     hiphive = None
 

--- a/pymatgen/util/provenance.py
+++ b/pymatgen/util/provenance.py
@@ -288,8 +288,8 @@ class StructureNL:
         Returns: MSONable dict
         """
         d = self.structure.as_dict()
-        d["@module"] = self.__class__.__module__
-        d["@class"] = self.__class__.__name__
+        d["@module"] = type(self).__module__
+        d["@class"] = type(self).__name__
         d["about"] = {
             "authors": [a.as_dict() for a in self.authors],
             "projects": self.projects,

--- a/pymatgen/util/serialization.py
+++ b/pymatgen/util/serialization.py
@@ -24,8 +24,8 @@ def pmg_serialize(method):
         self = args[0]
         d = method(*args, **kwargs)
         # Add @module and @class
-        d["@module"] = self.__class__.__module__
-        d["@class"] = self.__class__.__name__
+        d["@module"] = type(self).__module__
+        d["@class"] = type(self).__name__
         return d
 
     return wrapper


### PR DESCRIPTION
Might want to add

```cfg
[mypy]
warn_redundant_casts = true
warn_unused_ignores = true
check_untyped_defs = true
```

 to `setup.cfg` in future though currently emits too many type errors to deal with.