### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,42 @@
+
+cff-version: 1.2.0
+message: |
+  If you use pymatgen in your research, please consider citing the following:
+
+  In addition, some of pymatgen's functionality is based on scientific advances
+  / principles developed by the computational materials scientists in our team.
+  Please refer to pymatgen's docs at http://pymatgen.org on how to cite them.
+authors:
+- family-names: Jain
+  given-names: Anubhav
+- family-names: Ong
+  given-names: Shyue Ping
+- family-names: Hautier
+  given-names: Geoffroy
+- family-names: Chen
+  given-names: Wei
+- family-names: Richards
+  given-names: William Davidson
+- family-names: Dacek
+  given-names: Stephen
+- family-names: Cholia
+  given-names: Shreyas
+- family-names: Gunter
+  given-names: Dan
+- family-names: Skinner
+  given-names: David
+- family-names: Ceder
+  given-names: Gerbrand
+- family-names: Persson
+  given-names: Kristin
+title: 'The Materials Project: A materials genome approach to accelerating materials innovation'
+version: 2022.1.24 # replace with whatever version you use
+doi: 10.1063/1.4812323
+date-released: 2013-06-04
+url: https://github.com/materialsproject/pymatgen
+issn: 2166532X
+journal: APL Materials
+month: 9
+issue: 1
+volume: 1
+year: 2013

--- a/README.rst
+++ b/README.rst
@@ -128,24 +128,6 @@ Using pymatgen
 
 Please refer to the official `pymatgen page`_ for tutorials and examples.
 
-How to cite pymatgen
-====================
-
-If you use pymatgen in your research, please consider citing the following
-work:
-
-    Shyue Ping Ong, William Davidson Richards, Anubhav Jain, Geoffroy Hautier,
-    Michael Kocher, Shreyas Cholia, Dan Gunter, Vincent Chevrier, Kristin A.
-    Persson, Gerbrand Ceder. *Python Materials Genomics (pymatgen) : A Robust,
-    Open-Source Python Library for Materials Analysis.* Computational
-    Materials Science, 2013, 68, 314-319. `doi:10.1016/j.commatsci.2012.10.028
-    <https://doi.org/10.1016/j.commatsci.2012.10.028>`_
-
-In addition, some of pymatgen's functionality is based on scientific advances
-/ principles developed by the computational materials scientists in our team.
-Please refer to `pymatgen's documentation <http://pymatgen.org/>`_ on how to
-cite them.
-
 License
 =======
 

--- a/README.rst
+++ b/README.rst
@@ -128,6 +128,24 @@ Using pymatgen
 
 Please refer to the official `pymatgen page`_ for tutorials and examples.
 
+How to cite pymatgen
+====================
+
+If you use pymatgen in your research, please consider citing the following
+work:
+
+    Shyue Ping Ong, William Davidson Richards, Anubhav Jain, Geoffroy Hautier,
+    Michael Kocher, Shreyas Cholia, Dan Gunter, Vincent Chevrier, Kristin A.
+    Persson, Gerbrand Ceder. *Python Materials Genomics (pymatgen) : A Robust,
+    Open-Source Python Library for Materials Analysis.* Computational
+    Materials Science, 2013, 68, 314-319. `doi:10.1016/j.commatsci.2012.10.028
+    <https://doi.org/10.1016/j.commatsci.2012.10.028>`_
+
+In addition, some of pymatgen's functionality is based on scientific advances
+/ principles developed by the computational materials scientists in our team.
+Please refer to `pymatgen's documentation <http://pymatgen.org/>`_ on how to
+cite them.
+
 License
 =======
 


### PR DESCRIPTION
GitHub supports adding citation metadata to repos. This PR moves instructions on how to cite `pymatgen` from readme into the `CITATION.cff` file which GH uses to then display citations in BibTeX and APA formats in the side bar.  See [docs for details](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files).

Looks like this:

![Screen Shot 2022-02-21 at 19 24 57](https://user-images.githubusercontent.com/30958850/155017345-99d79922-2554-4bdf-bd8a-cc3f4ba31d00.png)
