### PR TITLE
Allow to switch off print of ChemEnv citation

### DIFF
--- a/pymatgen/analysis/chemenv/coordination_environments/coordination_geometry_finder.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/coordination_geometry_finder.py
@@ -406,7 +406,7 @@ class LocalGeometryFinder:
             bva_distance_scale_factor=None,
             structure_refinement=self.STRUCTURE_REFINEMENT_NONE,
         )
-        if not print_citation:
+        if print_citation:
             print(chemenv_citations())
 
     def setup_parameters(

--- a/pymatgen/analysis/chemenv/coordination_environments/coordination_geometry_finder.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/coordination_geometry_finder.py
@@ -376,12 +376,18 @@ class LocalGeometryFinder:
         debug_level=None,
         plane_safe_permutations=False,
         only_symbols=None,
+        print_citation=True,
     ):
         """
-        Constructor for the LocalGeometryFinder, initializes the list of coordination geometries
-        :param permutations_safe_override: If set to True, all permutations are tested (very time-consuming for large
+
+        Args:
+            permutations_safe_override:  If set to True, all permutations are tested (very time-consuming for large
             coordination numbers!)
-        :param plane_ordering_override: If set to False, the ordering of the points in the plane is disabled
+            plane_ordering_override: If set to False, the ordering of the points in the plane is disabled
+            debug_level: decides the level of debugging
+            permutations_safe_override: Whether to use safe permutations.
+            only_symbols: Whether to restrict the list of environments to be identified.
+            print_citation: If True, the ChemEnv citation will be printed
         """
         self.allcg = AllCoordinationGeometries(
             permutations_safe_override=permutations_safe_override,
@@ -396,7 +402,8 @@ class LocalGeometryFinder:
             bva_distance_scale_factor=None,
             structure_refinement=self.STRUCTURE_REFINEMENT_NONE,
         )
-        print(chemenv_citations())
+        if not print_citation:
+            print(chemenv_citations())
 
     def setup_parameters(
         self,

--- a/pymatgen/analysis/chemenv/coordination_environments/coordination_geometry_finder.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/coordination_geometry_finder.py
@@ -9,6 +9,10 @@ Michael Goebel, Stephan Schenk, Peter Degelmann, Rute Andre, Robert Glaum, and G
 "Statistical analysis of coordination environments in oxides",
 Chem. Mater., 2017, 29 (19), pp 8346–8360,
 DOI: 10.1021/acs.chemmater.7b02766
+D. Waroquiers, J. George, M. Horton, S. Schenk, K. A. Persson, G.-M. Rignanese, X. Gonze, G. Hautier
+"ChemEnv: a fast and robust coordination environment identification tool",
+Acta Cryst. B 2020, 76, pp 683–695,
+DOI: 10.1107/S2052520620007994
 """
 
 __author__ = "David Waroquiers"
@@ -376,7 +380,7 @@ class LocalGeometryFinder:
         debug_level=None,
         plane_safe_permutations=False,
         only_symbols=None,
-        print_citation=True,
+        print_citation=False,
     ):
         """
 

--- a/pymatgen/analysis/chemenv/coordination_environments/tests/test_coordination_geometry_finder.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/tests/test_coordination_geometry_finder.py
@@ -32,7 +32,7 @@ class CoordinationGeometryFinderTest(PymatgenTest):
             centering_type="standard",
             structure_refinement=self.lgf.STRUCTURE_REFINEMENT_NONE,
         )
-        self.lgf2 = LocalGeometryFinder(print_citation=False)
+        self.lgf2 = LocalGeometryFinder(print_citation=True)
 
     #     self.strategies = [SimplestChemenvStrategy(), SimpleAbundanceChemenvStrategy()]
 

--- a/pymatgen/analysis/chemenv/coordination_environments/tests/test_coordination_geometry_finder.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/tests/test_coordination_geometry_finder.py
@@ -32,6 +32,7 @@ class CoordinationGeometryFinderTest(PymatgenTest):
             centering_type="standard",
             structure_refinement=self.lgf.STRUCTURE_REFINEMENT_NONE,
         )
+        self.lgf2 = LocalGeometryFinder(print_citation=False)
 
     #     self.strategies = [SimplestChemenvStrategy(), SimpleAbundanceChemenvStrategy()]
 

--- a/pymatgen/analysis/chemenv/utils/defs_utils.py
+++ b/pymatgen/analysis/chemenv/utils/defs_utils.py
@@ -18,11 +18,17 @@ from pymatgen.analysis.chemenv.utils.coordination_geometry_utils import (
 )
 
 STATS_ENV_PAPER = (
-    "David Waroquiers, Xavier Gonze, Gian-Marco Rignanese, Cathrin Welker-Nieuwoudt, Frank Rosowski,\n"
-    "Michael Goebel, Stephan Schenk, Peter Degelmann, Rute Andre, Robert Glaum, and Geoffroy Hautier,\n"
+    "D. Waroquiers, X. Gonze, G.-M. Rignanese, C. Welker-Nieuwoudt, F. Rosowski,\n"
+    "M. Goebel, S. Schenk, P. Degelmann, R. Andre, R. Glaum, and G. Hautier,\n"
     '"Statistical analysis of coordination environments in oxides",\n'
     "Chem. Mater., 2017, 29 (19), pp 8346-8360,\n"
     "DOI: 10.1021/acs.chemmater.7b02766\n"
+    "\n"
+    "D. Waroquiers, J. George, M. Horton, S. Schenk, K. A. Persson, G.-M. Rignanese, X. Gonze, G. Hautier,\n"
+    '"ChemEnv: a fast and robust coordination environment identification tool",\n'
+    "Acta Cryst. B 2020, 76, pp 683–695\n."
+    "DOI: 10.1107/S2052520620007994\n"
+
 )
 
 

--- a/pymatgen/analysis/chemenv/utils/defs_utils.py
+++ b/pymatgen/analysis/chemenv/utils/defs_utils.py
@@ -28,7 +28,6 @@ STATS_ENV_PAPER = (
     '"ChemEnv: a fast and robust coordination environment identification tool",\n'
     "Acta Cryst. B 2020, 76, pp 683–695\n."
     "DOI: 10.1107/S2052520620007994\n"
-
 )
 
 


### PR DESCRIPTION
## Summary

I am adding a small parameter to switch off the ChemEnv citation print. This will make it easier to use ChemEnv in other program packages. I am also updating the citation of ChemEnv.

I am tagging @davidwaroquiers  here, so that he knows.

Let me know if I should do anything additionally.