### PR TITLE
Bump `actions/checkout` in GitHub CI to v3

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,37 +12,37 @@ jobs:
       matrix:
         python-version: [3.9]
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-        cache: pip
-        cache-dependency-path: requirements-dev.txt
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements-dev.txt --quiet
-    - name: mypy
-      run: |
-        mypy --version
-        rm -rf .mypy_cache
-        mypy pymatgen
-    - name: pydocstyle
-      run: |
-        pydocstyle --count pymatgen
-    - name: pylint
-      run: |
-        pylint pymatgen
-    - name: black
-      run: |
-        black --version
-        black --check --diff --color pymatgen
-    - name: flake8
-      run: |
-        flake8 --version
-        flake8 --count --show-source --statistics pymatgen
-        # exit-zero treats all errors as warnings.
-        flake8 --count --exit-zero --max-complexity=20 --statistics pymatgen
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt --quiet
+      - name: mypy
+        run: |
+          mypy --version
+          rm -rf .mypy_cache
+          mypy pymatgen
+      - name: pydocstyle
+        run: |
+          pydocstyle --count pymatgen
+      - name: pylint
+        run: |
+          pylint pymatgen
+      - name: black
+        run: |
+          black --version
+          black --check --diff --color pymatgen
+      - name: flake8
+        run: |
+          flake8 --version
+          flake8 --count --show-source --statistics pymatgen
+          # exit-zero treats all errors as warnings.
+          flake8 --count --exit-zero --max-complexity=20 --statistics pymatgen

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   release:
-    types: [ created ]
+    types: [created]
   workflow_dispatch:
 
 jobs:
@@ -33,7 +33,7 @@ jobs:
       GULP_LIB: ${{ github.workspace }}/cmd_line/gulp/Libraries
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 3.9
         uses: actions/setup-python@v2
         with:
@@ -54,12 +54,12 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        os: [ macos-latest, windows-latest ]
-        python-version: [ '3.8', '3.9', '3.10' ]
+        os: [macos-latest, windows-latest]
+        python-version: ['3.8', '3.9', '3.10']
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -3,10 +3,9 @@
 # The ext package is also only tested in this workflow. Coverage is also computed based on this platform.
 name: Testing Linux
 
-on: [ push, pull_request ]
+on: [push, pull_request]
 
 jobs:
-
   test:
     # prevent this action from running on forks
     if: github.repository == 'materialsproject/pymatgen'
@@ -33,14 +32,10 @@ jobs:
       GULP_LIB: ${{ github.workspace }}/cmd_line/gulp/Libraries
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: 3.9
-          cache: pip
-          cache-dependency-path: |
-            requirements*.txt
-            setup.py
       - name: Install OpenBabel and Libs
         shell: bash -l {0}
         run: |
@@ -71,7 +66,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 3.9
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -1,6 +1,6 @@
 name: Testing Mac
 
-on: [ pull_request ]
+on: [pull_request]
 
 jobs:
   test:
@@ -10,8 +10,8 @@ jobs:
     strategy:
       max-parallel: 20
       matrix:
-        os: [ macos-latest ]
-        python-version: [ '3.10' ]
+        os: [macos-latest]
+        python-version: ['3.10']
         # This distribution of tests is designed to ensure an approximately even time to finish for parallel jobs.
         pkg:
           - pymatgen/analysis/defects pymatgen/analysis/chemenv pymatgen/analysis/elasticity pymatgen/analysis/magnetism
@@ -28,7 +28,7 @@ jobs:
       GULP_LIB: ${{ github.workspace }}/cmd_line/gulp/Libraries
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -1,6 +1,6 @@
 name: Testing Windows
 
-on: [ pull_request ]
+on: [pull_request]
 
 jobs:
   test:
@@ -10,8 +10,8 @@ jobs:
     strategy:
       max-parallel: 20
       matrix:
-        os: [ windows-latest ]
-        python-version: [ '3.9' ]
+        os: [windows-latest]
+        python-version: ['3.9']
         # This distribution of tests is designed to ensure an approximately even time to finish for parallel jobs.
         pkg:
           - pymatgen/analysis/defects pymatgen/analysis/chemenv pymatgen/analysis/elasticity pymatgen/analysis/magnetism
@@ -28,7 +28,7 @@ jobs:
       GULP_LIB: ${{ github.workspace }}/cmd_line/gulp/Libraries
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
Only change appears to be that [runtime was updated from node v14 to v16](https://github.com/actions/checkout/releases/tag/v3.0.0).