### PR TITLE
Remove `from __future__ import annotations` in electrode base class due to bug

### DIFF
--- a/pymatgen/apps/battery/battery_abc.py
+++ b/pymatgen/apps/battery/battery_abc.py
@@ -9,8 +9,6 @@ can be defined in a general way. The Abc for battery classes implements some of
 these common definitions to allow sharing of common logic between them.
 """
 
-from __future__ import annotations
-
 from collections.abc import Sequence
 from dataclasses import dataclass
 


### PR DESCRIPTION
Suspect some interaction with `dataclasses` and `pydantic` but root cause of bug is still unclear.

Notifying @munrojm (can you add some context to this PR in case it helps others?) and also notifying @janosh since it relates to whether we should have these imports everywhere by default or not.