### PR TITLE
[WIP] Relaxation Transformation

### DIFF
--- a/pymatgen/transformations/standard_transformations.py
+++ b/pymatgen/transformations/standard_transformations.py
@@ -1131,7 +1131,7 @@ class RelaxationTransformation(AbstractTransformation):
         """
         self.final_structure = final_structure
         self.metadata = metadata if metadata else {}
-        
+
     def __str__(self):
         return "RelaxationTransformation"
 

--- a/pymatgen/transformations/standard_transformations.py
+++ b/pymatgen/transformations/standard_transformations.py
@@ -1113,3 +1113,45 @@ class ScaleToRelaxedTransformation(AbstractTransformation):
         Returns: False
         """
         return False
+
+
+class RelaxationTransformation(AbstractTransformation):
+    """
+    Represents the relaxation (e.g. as performed in DFT) as
+    a transformation. Whatever structure you give it, you
+    get back the "final structure".
+    """
+
+    def __init__(self, final_structure, metadata=None):
+        """
+        Args:
+            final_structure: the structure after relaxation
+            metadata: metadata to store with the transformation
+                (i.e. info about the relaxation)
+        """
+        self.final_structure = final_structure
+        self.metadata = metadata if metadata else {}
+        
+    def __str__(self):
+        return "RelaxationTransformation"
+
+    def __repr__(self):
+        return self.__str__()
+
+    def apply_transformation(self, structure):
+        """
+        Apply the transformation
+        """
+        return self.final_structure
+
+    def inverse(self):
+        """
+        No inverse.
+        """
+        return
+
+    def is_one_to_many(self):
+        """
+        Is not one to many
+        """
+        return False


### PR DESCRIPTION
Sometimes, we have calculations with continue from a previous calculation. For example, you run a coarse relaxation followed by a fine relaxation in separate fireworks. In that case, it would be convenient to have a Transformation which represents that relaxation that can be part of the second calculation's transformation history, rather than starting from the coarse-relaxed structure.

Perhaps this should be named something else, though? Relaxation is probably the most common potential use case, but it could be more general perhaps. Open to suggestions.
