### PR TITLE
bug fix for bsplotter and bztInterpolator

### DIFF
--- a/pymatgen/electronic_structure/boltztrap2.py
+++ b/pymatgen/electronic_structure/boltztrap2.py
@@ -123,8 +123,8 @@ class VasprunBSLoader:
         else:
             self.vbm_idx = None
             self.cbm_idx = None
-            self.vbm = self.fermi
-            self.cbm = self.fermi
+            self.vbm = self.fermi / units.eV
+            self.cbm = self.fermi / units.eV
 
         if nelect:
             self.nelect_all = nelect

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -633,6 +633,9 @@ class BSPlotter:
             if not data["is_metal"]:
                 cbm_max.append(data["cbm"][0][1])
                 vbm_min.append(data["vbm"][0][1])
+            else:
+                cbm_max.append(bs.efermi)
+                vbm_min.append(bs.efermi)
 
             for sp in bs.bands.keys():
                 ls = "-" if str(sp) == "1" else "--"


### PR DESCRIPTION
I fix two bugs:
- the units of vbm and cbm in the BztInterpolator were wrong and leading to a wrong energy range.
- BSPlotter in case of metallic bands and zero_to_efermi=False was broken.