### PR TITLE
Fix errors on entries_charge/entries_discharge attributes

### DIFF
--- a/pymatgen/apps/battery/conversion_battery.py
+++ b/pymatgen/apps/battery/conversion_battery.py
@@ -374,8 +374,8 @@ class ConversionVoltagePair(AbstractVoltagePair):
         frac_discharge = totalcomp.get_atomic_fraction(Element(working_ion))
 
         rxn = rxn
-        entries_charge = step2["entries"]
-        entries_discharge = step1["entries"]
+        entries_charge = step1["entries"]
+        entries_discharge = step2["entries"]
 
         return ConversionVoltagePair(  # pylint: disable=E1123
             rxn=rxn,


### PR DESCRIPTION
The results that entries_discharge and entries_discharge attributes returned in _pymatgen/apps/battery/conversion_battery.py_ were confused. I fixed this problem that entries in charge/discharged state should be the entries from step1/step2, respectively.

We can find evidence in similar attribute, vol_discharge, that properties in discharge states should be retrieved from the step2.
```python
        vol_discharge = sum(
            abs(curr_rxn.get_coeff(e.composition)) * e.structure.volume
            for e in step2["entries"]
            if e.composition.reduced_formula != working_ion
        )
```