### PR TITLE
Fix DOS docstring

### DIFF
--- a/pymatgen/electronic_structure/dos.py
+++ b/pymatgen/electronic_structure/dos.py
@@ -956,7 +956,7 @@ class CompleteDos(Dos):
                 Default is None, which means all energies are considered.
 
         Returns:
-            Orbital-projected bandwidth in eV
+            Orbital-projected skewness in eV
         """
 
         skewness = self.get_n_moment(
@@ -991,7 +991,7 @@ class CompleteDos(Dos):
                 Default is None, which means all energies are considered.
 
         Returns:
-            Orbital-projected bandwidth in eV
+            Orbital-projected kurtosis in eV
         """
 
         kurtosis = (


### PR DESCRIPTION
Fixes a typo in the docstrings for the new `CompleteDos` properties I introduced in #2455.