### PR TITLE
Remove redundant operation

### DIFF
--- a/pymatgen/electronic_structure/dos.py
+++ b/pymatgen/electronic_structure/dos.py
@@ -1058,7 +1058,6 @@ class CompleteDos(Dos):
         densities = dos.get_densities(spin=spin)
 
         # Only consider a given erange, if desired
-        energies = dos.energies - dos.efermi
         if erange:
             densities = densities[(energies >= erange[0]) & (energies <= erange[1])]
             energies = energies[(energies >= erange[0]) & (energies <= erange[1])]


### PR DESCRIPTION
Removed a redundant mathematical operation in the `CompleteDos` properties. The line `energies = dos.energies - dos.efermi` was included in two places. I deleted the second instance.
https://github.com/materialsproject/pymatgen/blob/040c45a68f7c787e062078aca28c3532c7c817e9/pymatgen/electronic_structure/dos.py#L860-L864
Apologies for not catching this during the previous docstring cleanup.