### PR TITLE
Update corrections.py

### DIFF
--- a/pymatgen/analysis/defects/corrections.py
+++ b/pymatgen/analysis/defects/corrections.py
@@ -113,9 +113,9 @@ class FreysoldtCorrection(DefectCorrection):
         """
 
         if self.axis is None:
-            list_axis_grid = np.array(entry.parameters["axis_grid"])
-            list_bulk_plnr_avg_esp = np.array(entry.parameters["bulk_planar_averages"])
-            list_defect_plnr_avg_esp = np.array(entry.parameters["defect_planar_averages"])
+            list_axis_grid = np.array(entry.parameters["axis_grid"], dtype=object)
+            list_bulk_plnr_avg_esp = np.array(entry.parameters["bulk_planar_averages"], dtype=object)
+            list_defect_plnr_avg_esp = np.array(entry.parameters["defect_planar_averages"], dtype=object)
             list_axes = range(len(list_axis_grid))
         else:
             list_axes = np.array(self.axis)


### PR DESCRIPTION
Specify `dtype` in numpy array generation

## Summary
Due to the new `VisibleDeprecationWarning` in `numpy` for creating arrays from ragged nested sequences, the `dtype` must be specified when generating the arrays, otherwise the following three warnings are printed for each defect correction calculated:

```
/home/dngsykes/miniconda3/envs/toolbox/lib/python3.8/site-packages/pymatgen/analysis/defects/corrections.py:102: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray
  list_axis_grid = np.array(entry.parameters["axis_grid"])
/home/dngsykes/miniconda3/envs/toolbox/lib/python3.8/site-packages/pymatgen/analysis/defects/corrections.py:103: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray
  list_bulk_plnr_avg_esp = np.array(entry.parameters["bulk_planar_averages"])
/home/dngsykes/miniconda3/envs/toolbox/lib/python3.8/site-packages/pymatgen/analysis/defects/corrections.py:104: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray
  list_defect_plnr_avg_esp = np.array(entry.parameters["defect_planar_averages"])
```

This has been fixed in the PR code