### PR TITLE
Clean up tests

### DIFF
--- a/docs_rst/conf-normal.py
+++ b/docs_rst/conf-normal.py
@@ -342,7 +342,7 @@ def linkcode_resolve(domain, info):
         rel_path, line_start, line_end = find_source()
         # __file__ is imported from pymatgen.core
         filename = f"pymatgen/core/{rel_path}#L{line_start}-L{line_end}"
-    except:
+    except Exception:
         # no need to be relative to core here as module includes full path.
         filename = info["module"].replace(".", "/") + ".py"
 

--- a/docs_rst/conf.py
+++ b/docs_rst/conf.py
@@ -342,7 +342,7 @@ def linkcode_resolve(domain, info):
         rel_path, line_start, line_end = find_source()
         # __file__ is imported from pymatgen.core
         filename = f"pymatgen/core/{rel_path}#L{line_start}-L{line_end}"
-    except:
+    except Exception:
         # no need to be relative to core here as module includes full path.
         filename = info["module"].replace(".", "/") + ".py"
 

--- a/pymatgen/analysis/elasticity/tests/test_elastic.py
+++ b/pymatgen/analysis/elasticity/tests/test_elastic.py
@@ -193,7 +193,7 @@ class ElasticTensorTest(PymatgenTest):
     def test_from_independent_strains(self):
         strains = self.toec_dict["strains"]
         stresses = self.toec_dict["stresses"]
-        with warnings.catch_warnings(record=True) as w:
+        with warnings.catch_warnings(record=True):
             et = ElasticTensor.from_independent_strains(strains, stresses)
         self.assertArrayAlmostEqual(et.voigt, self.toec_dict["C2_raw"], decimal=-1)
 
@@ -294,11 +294,15 @@ class ElasticTensorExpansionTest(PymatgenTest):
         # Get Gruneisen parameter
         gp = self.exp_cu.get_gruneisen_parameter()
         self.assertAlmostEqual(gp, 2.59631832)
-        gpt = self.exp_cu.get_gruneisen_parameter(temperature=200, structure=self.cu)
+        _ = self.exp_cu.get_gruneisen_parameter(temperature=200, structure=self.cu)
 
     def test_thermal_expansion_coeff(self):
         # TODO get rid of duplicates
         alpha_dp = self.exp_cu.thermal_expansion_coeff(self.cu, 300, mode="dulong-petit")
+        alpha_dp_ground_truth = 6.3471959e-07 * np.ones((3, 3))
+        alpha_dp_ground_truth[np.diag_indices(3)] = 2.2875769e-7
+        self.assertArrayAlmostEqual(alpha_dp_ground_truth, alpha_dp, decimal=4)
+
         alpha_debye = self.exp_cu.thermal_expansion_coeff(self.cu, 300, mode="debye")
         alpha_comp = 5.9435148e-7 * np.ones((3, 3))
         alpha_comp[np.diag_indices(3)] = 21.4533472e-06

--- a/pymatgen/analysis/tests/test_path_finder.py
+++ b/pymatgen/analysis/tests/test_path_finder.py
@@ -26,7 +26,6 @@ class PathFinderTest(unittest.TestCase):
         test_file_dir = os.path.join(PymatgenTest.TEST_FILES_DIR, "path_finder")
         start_s = Poscar.from_file(os.path.join(test_file_dir, "LFP_POSCAR_s")).structure
         end_s = Poscar.from_file(os.path.join(test_file_dir, "LFP_POSCAR_e")).structure
-        mid_s = start_s.interpolate(end_s, nimages=2, interpolate_lattices=False)[1]
         chg = Chgcar.from_file(os.path.join(test_file_dir, "LFP_CHGCAR.gz"))
         moving_cation_specie = Element("Li")
         relax_sites = []
@@ -46,14 +45,6 @@ class PathFinderTest(unittest.TestCase):
                 images.append(image)
         self.assertEqual(len(images), 9)
 
-        pf_mid = NEBPathfinder(
-            start_s,
-            end_s,
-            relax_sites=relax_sites,
-            v=ChgcarPotential(chg).get_v(),
-            n_images=10,
-            mid_struct=mid_s,
-        )
         moving_site = relax_sites[0]
         dists = [s1.sites[moving_site].distance(s2.sites[moving_site]) for s1, s2 in zip(pf.images[:-1], pf.images[1:])]
         # check that all the small distances are about equal

--- a/pymatgen/analysis/tests/test_phase_diagram.py
+++ b/pymatgen/analysis/tests/test_phase_diagram.py
@@ -682,22 +682,22 @@ class ReactionDiagramTest(unittest.TestCase):
             self.assertIn(Element.C, e.composition)
             self.assertIn(Element.P, e.composition)
             self.assertIn(Element.H, e.composition)
-        [e.composition.reduced_formula for e in self.rd.rxn_entries]
-        expected_formula = [
-            "V0.12707182P0.12707182H0.0441989C0.03314917O0.66850829",
-            "V0.125P0.125H0.05C0.0375O0.6625",
-            "V0.12230216P0.12230216H0.05755396C0.04316547O0.65467626",
-            "V0.11340206P0.11340206H0.08247423C0.06185567O0.62886598",
-            "V0.11267606P0.11267606H0.08450704C0.06338028O0.62676056",
-            "V0.11229947P0.11229947H0.0855615C0.06417112O0.62566845",
-            "V0.09677419P0.09677419H0.12903226C0.09677419O0.58064516",
-            "V0.05882353P0.05882353H0.23529412C0.17647059O0.47058824",
-            "V0.04225352P0.04225352H0.28169014C0.21126761O0.42253521",
-        ]
+        # formed_formula = [e.composition.reduced_formula for e in self.rd.rxn_entries]
+        # expected_formula = [
+        #     "V0.12707182P0.12707182H0.0441989C0.03314917O0.66850829",
+        #     "V0.125P0.125H0.05C0.0375O0.6625",
+        #     "V0.12230216P0.12230216H0.05755396C0.04316547O0.65467626",
+        #     "V0.11340206P0.11340206H0.08247423C0.06185567O0.62886598",
+        #     "V0.11267606P0.11267606H0.08450704C0.06338028O0.62676056",
+        #     "V0.11229947P0.11229947H0.0855615C0.06417112O0.62566845",
+        #     "V0.09677419P0.09677419H0.12903226C0.09677419O0.58064516",
+        #     "V0.05882353P0.05882353H0.23529412C0.17647059O0.47058824",
+        #     "V0.04225352P0.04225352H0.28169014C0.21126761O0.42253521",
+        # ]
 
-        # Please do not uncomment this test. This test is far too fragile beacuse of numerical precision errors.
-        # Unless someone wants to make an effort to write a PROPER test which do not fail with changes in
-        # OS or numpy versions, DO NOT UNCOMMENT!
+        # # Please do not uncomment this test. This test is far too fragile because of numerical precision errors.
+        # # Unless someone wants to make an effort to write a PROPER test which do not fail with changes in
+        # # OS or numpy versions, DO NOT UNCOMMENT!
         # for formula in expected_formula:
         #     self.assertTrue(formula in formed_formula, f"{formed_formula} not in {expected_formula}")
 

--- a/pymatgen/ext/tests/test_cod.py
+++ b/pymatgen/ext/tests/test_cod.py
@@ -12,7 +12,7 @@ from pymatgen.ext.cod import COD
 
 try:
     website_is_up = requests.get("https://www.crystallography.net").status_code == 200
-except:
+except requests.exceptions.ConnectionError:
     website_is_up = False
 
 

--- a/pymatgen/ext/tests/test_crystalsai.py
+++ b/pymatgen/ext/tests/test_crystalsai.py
@@ -10,7 +10,7 @@ from pymatgen.util.testing import PymatgenTest
 
 try:
     website_is_up = requests.get("http://megnet.crystals.ai").status_code == 200
-except:
+except requests.exceptions.ConnectionError:
     website_is_up = False
 
 

--- a/pymatgen/ext/tests/test_jhu.py
+++ b/pymatgen/ext/tests/test_jhu.py
@@ -21,7 +21,7 @@ class JhuTest(PymatgenTest):
     def test_get_kpoints(self):
         si = PymatgenTest.get_structure("Si")
         input_set = MPRelaxSet(si)
-        kpoints = get_kpoints(si, incar=input_set.incar)
+        _ = get_kpoints(si, incar=input_set.incar)
 
 
 if __name__ == "__main__":

--- a/pymatgen/ext/tests/test_matproj.py
+++ b/pymatgen/ext/tests/test_matproj.py
@@ -30,7 +30,7 @@ from pymatgen.util.testing import PymatgenTest
 
 try:
     website_is_up = requests.get("https://www.materialsproject.org").status_code == 200
-except:
+except requests.exceptions.ConnectionError:
     website_is_up = False
 
 

--- a/pymatgen/ext/tests/test_optimade.py
+++ b/pymatgen/ext/tests/test_optimade.py
@@ -11,7 +11,7 @@ from pymatgen.util.testing import PymatgenTest
 
 try:
     website_is_up = requests.get("https://www.materialsproject.org").status_code == 200
-except:
+except requests.exceptions.ConnectionError:
     website_is_up = False
 
 

--- a/pymatgen/io/cp2k/tests/test_sets.py
+++ b/pymatgen/io/cp2k/tests/test_sets.py
@@ -40,6 +40,7 @@ property_structure = Structure(
     coords=[[0, 0, 0], [0.25, 0.25, 0.25], [0.5, 0.5, 0.5], [1, 1, 1]],
 )
 
+
 # TODO More comprehensive testing
 class SetTest(PymatgenTest):
     def setUp(self):

--- a/pymatgen/io/lobster/tests/test_lobster.py
+++ b/pymatgen/io/lobster/tests/test_lobster.py
@@ -533,7 +533,6 @@ class IcohplistTest(unittest.TestCase):
                 "translation": [0, 0, 0],
             },
         }
-        # TODO: why is this unused?
         icooplist_bise = {
             "1": {
                 "length": 2.88231,
@@ -619,6 +618,7 @@ class IcohplistTest(unittest.TestCase):
 
         self.assertEqual(icohplist_bise, self.icohp_bise.icohplist)
         self.assertEqual(icooplist_fe, self.icoop_fe.icohplist)
+        self.assertEqual(icooplist_bise, self.icoop_bise.icohplist)
         self.assertAlmostEqual(self.icobi.icohplist["1"]["icohp"][Spin.up], 0.58649)
         self.assertAlmostEqual(self.icobi_orbitalwise.icohplist["2"]["icohp"][Spin.up], 0.58649)
         self.assertAlmostEqual(self.icobi_orbitalwise.icohplist["1"]["icohp"][Spin.up], 0.58649)

--- a/pymatgen/io/lobster/tests/test_lobster.py
+++ b/pymatgen/io/lobster/tests/test_lobster.py
@@ -533,6 +533,7 @@ class IcohplistTest(unittest.TestCase):
                 "translation": [0, 0, 0],
             },
         }
+        # TODO: why is this unused?
         icooplist_bise = {
             "1": {
                 "length": 2.88231,

--- a/pymatgen/io/lobster/tests/test_lobsterenv.py
+++ b/pymatgen/io/lobster/tests/test_lobsterenv.py
@@ -215,7 +215,7 @@ class TestLobsterNeighbors(unittest.TestCase):
 
     def test_use_of_coop(self):
         with self.assertRaises(ValueError):
-            test = LobsterNeighbors(
+            _ = LobsterNeighbors(
                 are_coops=True,
                 filename_ICOHP=os.path.join(test_dir_env, "ICOHPLIST.lobster.mp_353.gz"),
                 structure=Structure.from_file(os.path.join(test_dir_env, "POSCAR.mp_353.gz")),
@@ -226,7 +226,7 @@ class TestLobsterNeighbors(unittest.TestCase):
 
     def test_cation_anion_mode_without_ions(self):
         with self.assertRaises(ValueError) as err:
-            test = LobsterNeighbors(
+            _ = LobsterNeighbors(
                 are_coops=False,
                 filename_ICOHP=os.path.join(test_dir_env, "../ICOHPLIST.lobster"),
                 structure=Structure.from_file(os.path.join(test_dir_env, "../POSCAR")),
@@ -237,7 +237,7 @@ class TestLobsterNeighbors(unittest.TestCase):
             str(err.exception), "Valences cannot be assigned, additional_conditions 1 and 3 and 5 and 6 will not work"
         )
         with self.assertRaises(ValueError) as err:
-            test = LobsterNeighbors(
+            _ = LobsterNeighbors(
                 are_coops=False,
                 filename_ICOHP=os.path.join(test_dir_env, "../ICOHPLIST.lobster"),
                 structure=Structure.from_file(os.path.join(test_dir_env, "../POSCAR")),
@@ -251,7 +251,7 @@ class TestLobsterNeighbors(unittest.TestCase):
 
     def test_wrong_additional_correction(self):
         with self.assertRaises(ValueError):
-            test = LobsterNeighbors(
+            _ = LobsterNeighbors(
                 are_coops=False,
                 filename_ICOHP=os.path.join(test_dir_env, "ICOHPLIST.lobster.mp_353.gz"),
                 structure=Structure.from_file(os.path.join(test_dir_env, "POSCAR.mp_353.gz")),

--- a/pymatgen/io/qchem/tests/test_inputs.py
+++ b/pymatgen/io/qchem/tests/test_inputs.py
@@ -149,8 +149,8 @@ $end"""
 $end"""
         self.assertEqual(vdw_test_sequential, vdw_actual_sequential)
 
-        with self.assertRaises(ValueError):
-            bad_vdw_test = QCInput.van_der_waals_template(vdw_params, mode="mymode")
+        with self.assertRaises(ValueError):  # bad vdw test
+            QCInput.van_der_waals_template(vdw_params, mode="mymode")
 
     def test_find_sections(self):
         str_single_job_input = """$molecule

--- a/pymatgen/symmetry/tests/test_groups.py
+++ b/pymatgen/symmetry/tests/test_groups.py
@@ -31,7 +31,7 @@ class PointGroupTest(unittest.TestCase):
         self.assertEqual(len(pg.get_orbit([1.2, 1.2, 1])), 8)
 
     def test_is_sub_super_group(self):
-        with warnings.catch_warnings() as w:
+        with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             pgmmm = PointGroup("mmm")
             pgmm2 = PointGroup("mm2")
@@ -184,7 +184,7 @@ class SpaceGroupTest(unittest.TestCase):
         self.assertRaises(ValueError, SpaceGroup, "hello")
 
     def test_subgroup_supergroup(self):
-        with warnings.catch_warnings() as w:
+        with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             self.assertTrue(SpaceGroup("Pma2").is_subgroup(SpaceGroup("Pccm")))
             self.assertFalse(SpaceGroup.from_int_number(229).is_subgroup(SpaceGroup.from_int_number(230)))

--- a/pymatgen/symmetry/tests/test_kpath_lm.py
+++ b/pymatgen/symmetry/tests/test_kpath_lm.py
@@ -53,11 +53,11 @@ class KPathLatimerMunroTest(PymatgenTest):
                 lattice = Lattice.cubic(2)
 
             struct = Structure.from_spacegroup(sg_num, lattice, species, coords)
-            kpath = KPathLatimerMunro(struct)  # Throws error if something doesn't work, causing test to fail.
+            _ = KPathLatimerMunro(struct)  # Throws error if something doesn't work, causing test to fail.
 
         struct_file_path = os.path.join(test_dir_structs, "AgO_kpath_test.cif")
         struct = Structure.from_file(struct_file_path)
-        kpath = KPathLatimerMunro(struct)  # Throws error if something doesn't work, causing test to fail.
+        _ = KPathLatimerMunro(struct)  # Throws error if something doesn't work, causing test to fail.
 
     def test_kpath_acentered(self):
         species = ["K", "La", "Ti"]

--- a/pymatgen/symmetry/tests/test_kpath_sc.py
+++ b/pymatgen/symmetry/tests/test_kpath_sc.py
@@ -49,7 +49,7 @@ class BandStructureSCTest(PymatgenTest):
                 lattice = Lattice.cubic(2)
 
             struct = Structure.from_spacegroup(sg_num, lattice, species, coords)
-            kpath = KPathSetyawanCurtarolo(struct)  # Throws error if something doesn't work, causing test to fail.
+            _ = KPathSetyawanCurtarolo(struct)  # Throws error if something doesn't work, causing test to fail.
 
         struct_file_path = os.path.join(test_dir_structs, "ICSD_170.cif")
         struct = Structure.from_file(struct_file_path)


### PR DESCRIPTION
Boring part of this PR: Fix some flake8 violations.

Worth reviewing are changes to
- `PathFinderTest.test_image_num()`
- dulong-petit test case in `ElasticTensorExpansionTest.test_thermal_expansion_coeff()`