### PR TITLE
Improvement of pre-commit hook settings for `pylint` 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,17 +55,16 @@ repos:
     hooks:
       - id: mypy
 
-  # You need to install pylint locally.
-  # See https://pylint.pycqa.org/en/latest/user_guide/pre-commit-integration.html
   - repo: local
     hooks:
       - id: pylint
         name: pylint
         entry: pylint
-        language: system
+        language: python
         types: [python]
         args:
           [
             "-sn",
             "--rcfile=pylintrc",
           ]
+        additional_dependencies: [pylint]

--- a/docs_rst/contributing.rst
+++ b/docs_rst/contributing.rst
@@ -36,7 +36,12 @@ Direct contributions to pymatgen main distribution
 
    Note that the entire Github repo is fairly large because of the presence of test files, but these are absolutely
    necessary for rigorous testing of the code.
-5. It is highly recommended you install all the optional dependencies as well.
+5. It is highly recommended you install all the optional dependencies as well::
+
+      pip install -r requirements.txt
+      pip install -r requirements-optional.txt
+      pip install -r requirements-dev.txt
+
 6. Code (see `Coding Guidelines`_). Commit early and commit often. Keep your code up to date. You need to add the main
    repository to the list of your remotes. Let's name the upstream repo as mpmaster (materialsproject master)::
 


### PR DESCRIPTION
Improvement of settings for `pylint` in `.pre-commit-config.yaml`, continuation of https://github.com/materialsproject/pymatgen/pull/2492 (@janosh, thank you for telling me the snippet!)
- I have confirmed `pylint` is now automatically installed when pre-commit hooks are called.
- Adding instructions to set up optional dependencies in docs.