### PR TITLE
Fix reading of orbitalwise ICOHP

### DIFF
--- a/pymatgen/io/lobster/outputs.py
+++ b/pymatgen/io/lobster/outputs.py
@@ -323,7 +323,7 @@ class Icohplist:
 
         # check if orbitalwise ICOHPLIST
         # include case when there is only one ICOHP!!!
-        if len(data) > 2 and "_" in data[2].split()[1]:
+        if len(data) > 2 and "_" in data[1].split()[1]:
             self.orbitalwise = True
             warnings.warn("This is an orbitalwise IC**LIST.lobter. Currently, the orbitalwise information is not read!")
         else:

--- a/pymatgen/io/lobster/tests/test_lobster.py
+++ b/pymatgen/io/lobster/tests/test_lobster.py
@@ -436,6 +436,17 @@ class IcohplistTest(unittest.TestCase):
             filename=os.path.join(PymatgenTest.TEST_FILES_DIR, "cohp", "ICOBILIST.lobster.spinpolarized"),
             are_cobis=True,
         )
+        # make sure the correct line is read to check if this is a orbitalwise ICOBILIST
+        self.icobi_orbitalwise_add = Icohplist(
+            filename=os.path.join(PymatgenTest.TEST_FILES_DIR, "cohp", "ICOBILIST.lobster.additional_case"),
+            are_cobis=True,
+        )
+        self.icobi_orbitalwise_spinpolarized_add = Icohplist(
+            filename=os.path.join(
+                PymatgenTest.TEST_FILES_DIR, "cohp", "ICOBILIST.lobster.spinpolarized.additional_case"
+            ),
+            are_cobis=True,
+        )
 
     def test_attributes(self):
         self.assertFalse(self.icohp_bise.are_coops)
@@ -463,6 +474,9 @@ class IcohplistTest(unittest.TestCase):
         self.assertFalse(self.icobi.orbitalwise)
 
         self.assertTrue(self.icobi_orbitalwise_spinpolarized.orbitalwise)
+
+        self.assertTrue(self.icobi_orbitalwise_add.orbitalwise)
+        self.assertTrue(self.icobi_orbitalwise_spinpolarized_add.orbitalwise)
 
     def test_values(self):
         icohplist_bise = {

--- a/test_files/cohp/ICOBILIST.lobster.additional_case
+++ b/test_files/cohp/ICOBILIST.lobster.additional_case
@@ -1,0 +1,5 @@
+  COBI#       atomMU       atomNU     distance     translation      ICOBI (at) eF   for spin  1
+      1           O5          Ta2      1.99474       0   0  -1            0.58649 
+      1        O5_2s       Ta2_6s      1.99474       0   0  -1            0.04940
+      2           O5          Ta2      1.99474       0   0   0            0.58649
+      2        O5_2s       Ta2_6s      1.99474       0   0   0            0.04940 

--- a/test_files/cohp/ICOBILIST.lobster.spinpolarized.additional_case
+++ b/test_files/cohp/ICOBILIST.lobster.spinpolarized.additional_case
@@ -1,0 +1,10 @@
+  COBI#       atomMU       atomNU     distance     translation      ICOBI (at) eF   for spin  1
+      1           O5          Ta2      1.99474       0   0  -1            0.29324 
+      1        O5_2s       Ta2_6s      1.99474       0   0  -1            0.02470
+      2           O5          Ta2      1.99474       0   0   0            0.29324 
+      2        O5_2s       Ta2_6s      1.99474       0   0   0            0.02470
+  COBI#       atomMU       atomNU     distance     translation      ICOBI (at) eF   for spin  2
+      1           O5          Ta2      1.99474       0   0  -1            0.29324 
+      1        O5_2s       Ta2_6s      1.99474       0   0  -1            0.02470 
+      2           O5          Ta2      1.99474       0   0   0            0.29324
+      2        O5_2s       Ta2_6s      1.99474       0   0   0            0.02470 


### PR DESCRIPTION
## Summary
By accident, the wrong line in ICOHPLIST.lobster was read to assess whether orbitalwise interactions are included in these files. This lead to erros in case the first atom only has one relevant valence orbital. I fixed the problem. And, I included a test to fix this for the future. 

JG