### PR TITLE
fixed deserialization of phase diagrams

### DIFF
--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -358,6 +358,8 @@ class PhaseDiagram(MSONable):
         self.entries = entries
         if computed_data is None:
             computed_data = self._compute()
+        else:
+            computed_data = MontyDecoder().process_decoded(computed_data)
         self.computed_data = computed_data
         self.facets = computed_data["facets"]
         self.simplexes = computed_data["simplexes"]

--- a/pymatgen/analysis/tests/test_phase_diagram.py
+++ b/pymatgen/analysis/tests/test_phase_diagram.py
@@ -8,6 +8,8 @@ from numbers import Number
 from pathlib import Path
 
 import numpy as np
+from monty.serialization import dumpfn, loadfn
+from monty.tempfile import ScratchDir
 
 from pymatgen.analysis.phase_diagram import (
     CompoundPhaseDiagram,
@@ -596,6 +598,11 @@ class PhaseDiagramTest(unittest.TestCase):
         new_dd = new_pd.as_dict()
         self.assertEqual(new_dd, dd)
         self.assertIsInstance(pd.to_json(), str)
+
+    def test_read_json(self):
+        with ScratchDir("."):
+            dumpfn(self.pd, "pd.json")
+            loadfn("pd.json")
 
 
 class GrandPotentialPhaseDiagramTest(unittest.TestCase):


### PR DESCRIPTION
JSON reconstruction bug:
The problem is: Because MSONables from_dict was replaced, there is no recursive reconstruction of the objects when you hit `el_ref` .  When you do `as_dict` -> `from_dict`  in python everything looks fine.
but the object was never completely serialized.
If you completely serialized it like putting it into as json file or database then you cannot reconstruct the phase diagram.