### PR TITLE
Fix `MPRester.__init__` raising `TypeError: NoneType not iterable` on empty `.pmgrc.yaml`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,9 +62,5 @@ repos:
         entry: pylint
         language: python
         types: [python]
-        args:
-          [
-            "-sn",
-            "--rcfile=pylintrc",
-          ]
+        args: [-sn, --rcfile=pylintrc]
         additional_dependencies: [pylint]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -93,7 +93,7 @@ v2022.2.1
 * Bigfix for gzipped DOSCAR (@JaGeo)
 * Updates for QChem Support (@samblau)
 * QuantumEspresso k-grid fix input fix. (@vorwerkc)
-* `Entry.__repr__()` now ouputs name where available. (@janosh)
+* `Entry.__repr__()` now outputs name where available. (@janosh)
 * Fixes to Vasprun.final_energy to report `e_0_energy` (the desired energy quantity) for VASP 6+. (@arosen93)
 * `Outcar().final_energy` now prints out `e_0_energy` (also called "energy(sigma->0)" in the OUTCAR) rather than `energy_fr_energy` (also called "free  energy   TOTEN" in the OUTCAR). This is to be consistent with `Vasprun().final_energy` and because it is generally the desired quantity. `Outcar` now has two new attributes: `.final_energy_wo_entrp` and `final_fr_energy`, which correspond to `e_wo_entrp` and `e_fr_energy`, respectively. (@arosen93)
 * Improved parsing of coupled cluster calculations in QChem (@espottesmith).
@@ -178,7 +178,7 @@ you are acknowledged appropriately by filling out the linked form.
 * Improve appearance of periodic table heatmap (@penicillin0, #2272)
 * Small improvements to battery classes (@jmmshn, #2262)
 * Fix for Composition.chemical_system to match expected behaviour for compositions with oxidation states (@CompRhys, #2249)
-* Fix for bad param in OPTIMADE reponse fields (@ml-evs, #2244)
+* Fix for bad param in OPTIMADE response fields (@ml-evs, #2244)
 * Fix for issue in parsing `bandOverlaps.lobster` file (@pzarabadip, #2237)
 * Fix for Moladaptor (@orioncohen, #2269)
 * Fix for incorrect Potcar hash warnings (@mkhorton, #2273)
@@ -630,7 +630,7 @@ v2019.10.2
 ----------
 * IRSpectra class (@henriquemiranda)
 * Much faster get_neighbors written in Cython (@chc273).
-* VolumetricData allows for sum or substraction of data with different
+* VolumetricData allows for sum or subtraction of data with different
   structures, with warnings.
 
 v2019.9.16
@@ -894,7 +894,7 @@ v2018.9.19
 * Fix to allow mixed compressed/uncompressed loading of VASP band structures (@ajjackson)
 * New features and fixes to `chemenv` analysis module (@davidwaroquiers)
 * Fix to include structure predictor data with pip/conda-installed pymatgen (@shyamd)
-* Fixes to `Defect` objects, icluding allowing rotational supercell transformations (@dbroberg)
+* Fixes to `Defect` objects, including allowing rotational supercell transformations (@dbroberg)
 * Fix to `BSDOSPlotter` to correctly fill in parts of DOS (@fraricci)
 * Added '@' notation parsing in `Composition` (@tamuhey)
 * BibTex reference extraction updated in `CifParser` to support ICSD CIFs (@shyamd)
@@ -955,7 +955,7 @@ v2018.5.21
 
 v2018.5.14
 ----------
-* Dash docs now avaiable for pymatgen. See pymatgen.org "Offline docs" section
+* Dash docs now available for pymatgen. See pymatgen.org "Offline docs" section
   for details.
 * Better CrystalNN. (Anubhav Jain)
 * Fixes for elastic module. (Joseph Montoya)
@@ -1308,7 +1308,7 @@ v4.5.4
 v4.5.3
 ------
 * Added an alternative interstitial finder that works with a grid-based structure-motif search. (Nils Zimmermann)
-* Optionnal possibility to specify that the saddle_point in the NEB should have a zero slope. (David Waroquiers)
+* Optional possibility to specify that the saddle_point in the NEB should have a zero slope. (David Waroquiers)
 * Read intensity and normal modes for Gaussian. (Germain Salvato Vallverdu)
 * Minor bug fixes.
 
@@ -1321,7 +1321,7 @@ v4.5.1
 * You can now specify a different default functional choice for pymatgen by
   setting PMG_DEFAULT_FUNCTIONAL in .pmgrc.yaml. For use with newer
   functional sets, you need to specify PBE_52 or PBE_54 for example.
-* Swtich to ISYM 3 by default for HSE.
+* Switch to ISYM 3 by default for HSE.
 * Updates to FEFF>
 * Misc bug fixes and startup speed improvements.
 
@@ -1539,7 +1539,7 @@ v3.5.0
 v3.4.0
 ------
 * 10-100x speed up to Structure copying and Site init, which means many
-  functionality has seen signifcant speed improvement (e.g., structure
+  functionality has seen significant speed improvement (e.g., structure
   matching).
 * Convenience method Structure.matches now perform similarity matching
   for Structures.
@@ -1558,7 +1558,7 @@ v3.3.5
 * Added interpolation failure warnings and smooth tolerance for
   scipy.interpolate.splrep in bandstructures (Tess).
 * Added DiffusionAnalyzer.get_framework_rms_plot.
-* Complete rewrite of Procar class to use ND array access and zero-based
+* Complete rewrite of Procar class to use NDarray access and zero-based
   indexing.
 * OrderParameters class for analysis of local structural features
   (Nils Zimmermann).

--- a/docs_rst/change_log.rst
+++ b/docs_rst/change_log.rst
@@ -93,7 +93,7 @@ v2022.2.1
 * Bigfix for gzipped DOSCAR (@JaGeo)
 * Updates for QChem Support (@samblau)
 * QuantumEspresso k-grid fix input fix. (@vorwerkc)
-* `Entry.__repr__()` now ouputs name where available. (@janosh)
+* `Entry.__repr__()` now outputs name where available. (@janosh)
 * Fixes to Vasprun.final_energy to report `e_0_energy` (the desired energy quantity) for VASP 6+. (@arosen93)
 * `Outcar().final_energy` now prints out `e_0_energy` (also called "energy(sigma->0)" in the OUTCAR) rather than `energy_fr_energy` (also called "free  energy   TOTEN" in the OUTCAR). This is to be consistent with `Vasprun().final_energy` and because it is generally the desired quantity. `Outcar` now has two new attributes: `.final_energy_wo_entrp` and `final_fr_energy`, which correspond to `e_wo_entrp` and `e_fr_energy`, respectively. (@arosen93)
 * Improved parsing of coupled cluster calculations in QChem (@espottesmith).
@@ -178,7 +178,7 @@ you are acknowledged appropriately by filling out the linked form.
 * Improve appearance of periodic table heatmap (@penicillin0, #2272)
 * Small improvements to battery classes (@jmmshn, #2262)
 * Fix for Composition.chemical_system to match expected behaviour for compositions with oxidation states (@CompRhys, #2249)
-* Fix for bad param in OPTIMADE reponse fields (@ml-evs, #2244)
+* Fix for bad param in OPTIMADE response fields (@ml-evs, #2244)
 * Fix for issue in parsing `bandOverlaps.lobster` file (@pzarabadip, #2237)
 * Fix for Moladaptor (@orioncohen, #2269)
 * Fix for incorrect Potcar hash warnings (@mkhorton, #2273)
@@ -630,7 +630,7 @@ v2019.10.2
 ----------
 * IRSpectra class (@henriquemiranda)
 * Much faster get_neighbors written in Cython (@chc273).
-* VolumetricData allows for sum or substraction of data with different
+* VolumetricData allows for sum or subtraction of data with different
   structures, with warnings.
 
 v2019.9.16
@@ -894,7 +894,7 @@ v2018.9.19
 * Fix to allow mixed compressed/uncompressed loading of VASP band structures (@ajjackson)
 * New features and fixes to `chemenv` analysis module (@davidwaroquiers)
 * Fix to include structure predictor data with pip/conda-installed pymatgen (@shyamd)
-* Fixes to `Defect` objects, icluding allowing rotational supercell transformations (@dbroberg)
+* Fixes to `Defect` objects, including allowing rotational supercell transformations (@dbroberg)
 * Fix to `BSDOSPlotter` to correctly fill in parts of DOS (@fraricci)
 * Added '@' notation parsing in `Composition` (@tamuhey)
 * BibTex reference extraction updated in `CifParser` to support ICSD CIFs (@shyamd)
@@ -955,7 +955,7 @@ v2018.5.21
 
 v2018.5.14
 ----------
-* Dash docs now avaiable for pymatgen. See pymatgen.org "Offline docs" section
+* Dash docs now available for pymatgen. See pymatgen.org "Offline docs" section
   for details.
 * Better CrystalNN. (Anubhav Jain)
 * Fixes for elastic module. (Joseph Montoya)
@@ -1308,7 +1308,7 @@ v4.5.4
 v4.5.3
 ------
 * Added an alternative interstitial finder that works with a grid-based structure-motif search. (Nils Zimmermann)
-* Optionnal possibility to specify that the saddle_point in the NEB should have a zero slope. (David Waroquiers)
+* Optional possibility to specify that the saddle_point in the NEB should have a zero slope. (David Waroquiers)
 * Read intensity and normal modes for Gaussian. (Germain Salvato Vallverdu)
 * Minor bug fixes.
 
@@ -1321,7 +1321,7 @@ v4.5.1
 * You can now specify a different default functional choice for pymatgen by
   setting PMG_DEFAULT_FUNCTIONAL in .pmgrc.yaml. For use with newer
   functional sets, you need to specify PBE_52 or PBE_54 for example.
-* Swtich to ISYM 3 by default for HSE.
+* Switch to ISYM 3 by default for HSE.
 * Updates to FEFF>
 * Misc bug fixes and startup speed improvements.
 
@@ -1539,7 +1539,7 @@ v3.5.0
 v3.4.0
 ------
 * 10-100x speed up to Structure copying and Site init, which means many
-  functionality has seen signifcant speed improvement (e.g., structure
+  functionality has seen significant speed improvement (e.g., structure
   matching).
 * Convenience method Structure.matches now perform similarity matching
   for Structures.
@@ -1558,7 +1558,7 @@ v3.3.5
 * Added interpolation failure warnings and smooth tolerance for
   scipy.interpolate.splrep in bandstructures (Tess).
 * Added DiffusionAnalyzer.get_framework_rms_plot.
-* Complete rewrite of Procar class to use ND array access and zero-based
+* Complete rewrite of Procar class to use NDarray access and zero-based
   indexing.
 * OrderParameters class for analysis of local structural features
   (Nils Zimmermann).

--- a/docs_rst/installation.rst
+++ b/docs_rst/installation.rst
@@ -70,7 +70,7 @@ Conda-based install
 ===================
 
 For these instructions, we will assume the **64-bit** versions of all OSes.
-For OSX and Linux, both latest Python 3.x adn 2.7 are supported. For Windows,
+For OSX and Linux, both latest Python 3.x and 2.7 are supported. For Windows,
 only latest Python 3.x is supported. Most common functionality should work
 out of the box on Windows, but some specialized analyses relying on external
 programs may require you to compile those programs from source.
@@ -195,7 +195,7 @@ to see full list of choices.
 
     The Materials Project currently uses older versions of the VASP pseudopotentials
     for maximum compatibility with historical data, rather than the current 52/54
-    pseudopotentials. This setting can be overriden by the user if desired.
+    pseudopotentials. This setting can be overridden by the user if desired.
     As such, current versions of pymatgen will check the hashes of your pseudopotentials
     when constructing input sets to ensure the correct, compatible pseudopotential sets are
     used, so that total energies can be compared to those in the Materials Project database.
@@ -221,7 +221,7 @@ but it comes with some important caveats:
   will not be importable. The easiest way to install dependencies is using the
   `PyPy builds on conda-forge <https://conda-forge.org/blog/2020/03/10/pypy>`_. For spglib,
   cloning the repository and running ``python setup.py install`` manually is advised.
-* Performance improvements are unpredictible. Since pymatgen makes heavy use of numpy
+* Performance improvements are unpredictable. Since pymatgen makes heavy use of numpy
   and custom extensions where appropriate, many code hot spots have already been optimized.
 
 We welcome any developers interested in expanding our PyPy support.

--- a/docs_rst/references.rst
+++ b/docs_rst/references.rst
@@ -9,7 +9,7 @@ pymatgen.analysis.path_finder
 -----------------------------
 
 The path finder code, which finds diffusion paths through a structure based on
-a given potential field, is written by the Ceder group at UC Berkley::
+a given potential field, is written by the Ceder group at UC Berkeley::
 
     Rong, Z., Kitchaev, D., Canepa, P., Huang, W., & Ceder, G. (2016).
     An efficient algorithm for finding the minimum energy path for cation

--- a/docs_rst/team.rst
+++ b/docs_rst/team.rst
@@ -1158,7 +1158,7 @@ List of Developers (A–Z)
    :alt: ORCID profile for 0000-0002-6665-1274
 
 | **Weitang Li** |liwt31| |0000-0002-8739-641X|
-| Tsinghua Univeristy
+| Tsinghua University
 .. |liwt31| image:: https://cdnjs.cloudflare.com/ajax/libs/octicons/8.5.0/svg/mark-github.svg
    :target: https://github.com/materialsproject/pymatgen/pulls?q=is:pr+author:liwt31
    :width: 16

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -2388,13 +2388,14 @@ class IStructure(SiteCollection, MSONable):
         return df
 
     @classmethod
-    def from_dict(cls, d, fmt=None):
+    def from_dict(cls, d: dict[str, Any], fmt: Literal["abivars"] | None = None):
         """
         Reconstitute a Structure object from a dict representation of Structure
         created using as_dict().
 
         Args:
             d (dict): Dict representation of structure.
+            fmt ('abivars' | None): Use structure_from_abivars() to parse the dict. Defaults to None.
 
         Returns:
             Structure object
@@ -2409,7 +2410,7 @@ class IStructure(SiteCollection, MSONable):
         charge = d.get("charge", None)
         return cls.from_sites(sites, charge=charge)
 
-    def to(self, fmt: str = None, filename=None, **kwargs) -> str | None:
+    def to(self, fmt: str = None, filename: str = None, **kwargs) -> str | None:
         """
         Outputs the structure to a file or string.
 

--- a/pymatgen/ext/matproj.py
+++ b/pymatgen/ext/matproj.py
@@ -24,6 +24,7 @@ import sys
 import warnings
 from enum import Enum, unique
 from time import sleep
+from typing import Any, Sequence
 
 import requests
 from monty.json import MontyDecoder, MontyEncoder
@@ -45,13 +46,14 @@ logger = logging.getLogger(__name__)
 MP_LOG_FILE = os.path.join(os.path.expanduser("~"), ".mprester.log.yaml")
 
 
-def get_chunks(sequence, size=1):
+def get_chunks(sequence: Sequence[Any], size=1):
     """
     Args:
-        sequence ():
-        size ():
+        sequence (Sequence[Any]): Any sequence.
+        size (int): Chunk length. Defaults to 1.
 
     Returns:
+        list[Sequence[Any]]: input sequence in chunks of length size.
     """
     chunks = int(math.ceil(len(sequence) / float(size)))
     return [sequence[i * size : (i + 1) * size] for i in range(chunks)]
@@ -143,12 +145,8 @@ class MPRester:
     )
 
     def __init__(
-        self,
-        api_key=None,
-        endpoint=None,
-        notify_db_version=True,
-        include_user_agent=True,
-    ):
+        self, api_key: str = None, endpoint: str = None, notify_db_version: bool = True, include_user_agent: bool = True
+    ) -> None:
         """
         Args:
             api_key (str): A String API key for accessing the MaterialsProject
@@ -190,10 +188,8 @@ class MPRester:
         self.session = requests.Session()
         self.session.headers = {"x-api-key": self.api_key}
         if include_user_agent:
-            pymatgen_info = "pymatgen/" + PMG_VERSION
-            python_info = "Python/{}.{}.{}".format(
-                sys.version_info.major, sys.version_info.minor, sys.version_info.micro
-            )
+            pymatgen_info = f"pymatgen/{PMG_VERSION}"
+            python_info = f"Python/{sys.version.split()[0]}"
             platform_info = f"{platform.system()}/{platform.release()}"
             self.session.headers["user-agent"] = f"{pymatgen_info} ({python_info} {platform_info})"
 
@@ -205,10 +201,11 @@ class MPRester:
             try:
                 with open(MP_LOG_FILE) as f:
                     d = dict(yaml.load(f))
-            except OSError:
+            except (OSError, TypeError):
+                # TypeError: 'NoneType' object is not iterable occurs if MP_LOG_FILE exists but is empty
                 d = {}
 
-            d = d if d else {}
+            d = d or {}
 
             if "MAPI_DB_VERSION" not in d:
                 d["MAPI_DB_VERSION"] = {"LOG": {}, "LAST_ACCESSED": None}
@@ -236,7 +233,7 @@ class MPRester:
             d["MAPI_DB_VERSION"]["LAST_ACCESSED"] = db_version
 
             # write out new database log if possible
-            # bare except is not ideal (perhaps a PermissionError, etc.) but this is not critical
+            # base Exception is not ideal (perhaps a PermissionError, etc.) but this is not critical
             # and should be allowed to fail regardless of reason
             try:
                 with open(MP_LOG_FILE, "wt") as f:
@@ -691,17 +688,17 @@ class MPRester:
 
         return pbx_entries
 
-    def get_structure_by_material_id(self, material_id, final=True, conventional_unit_cell=False):
+    def get_structure_by_material_id(
+        self, material_id: str, final: bool = True, conventional_unit_cell: bool = False
+    ) -> Structure:
         """
         Get a Structure corresponding to a material_id.
 
         Args:
-            material_id (str): Materials Project material_id (a string,
-                e.g., mp-1234).
+            material_id (str): Materials Project ID (e.g. mp-1234).
             final (bool): Whether to get the final structure, or the initial
                 (pre-relaxation) structure. Defaults to True.
-            conventional_unit_cell (bool): Whether to get the standard
-                conventional unit cell
+            conventional_unit_cell (bool): Whether to get the standard conventional unit cell
 
         Returns:
             Structure object.
@@ -713,34 +710,32 @@ class MPRester:
                 new_material_id = self.get_materials_id_from_task_id(material_id)
                 if new_material_id:
                     warnings.warn(
-                        "The calculation task {} is mapped to canonical mp-id {}, "
-                        "so structure for {} returned. "
-                        "This is not an error, see documentation. "
-                        "If original task data for {} is required, "
-                        "use get_task_data(). To find the canonical mp-id from a task id "
-                        "use get_materials_id_from_task_id().".format(
-                            material_id, new_material_id, new_material_id, material_id
-                        )
+                        f"The calculation task {material_id} is mapped to canonical mp-id {new_material_id}, "
+                        f"so structure for {new_material_id} returned. This is not an error, see "
+                        f"documentation. If original task data for {material_id} is required, use "
+                        "get_task_data(). To find the canonical mp-id from a task id use "
+                        "get_materials_id_from_task_id()."
                     )
                 return self.get_structure_by_material_id(new_material_id)
             except MPRestError:
                 raise MPRestError(
-                    "material_id {} unknown, if this seems like "
-                    "an error please let us know at "
-                    "matsci.org/materials-project".format(material_id)
+                    f"material_id {material_id} unknown, if this seems like an error "
+                    "please let us know at matsci.org/materials-project"
                 )
+
+        structure = data[0][prop]
         if conventional_unit_cell:
-            data[0][prop] = SpacegroupAnalyzer(data[0][prop]).get_conventional_standard_structure()
-        return data[0][prop]
+            structure = SpacegroupAnalyzer(structure).get_conventional_standard_structure()
+        return structure
 
     def get_entry_by_material_id(
         self,
-        material_id,
-        compatible_only=True,
-        inc_structure=None,
-        property_data=None,
-        conventional_unit_cell=False,
-    ):
+        material_id: str,
+        compatible_only: bool = True,
+        inc_structure: str = None,
+        property_data: list[str] = None,
+        conventional_unit_cell: bool = False,
+    ) -> ComputedEntry | ComputedStructureEntry:
         """
         Get a ComputedEntry corresponding to a material_id.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ count = True
 ignore = E121,E123,E126,E133,E226,E241,E242,E704,W503,W504,W505,E741,W605,W293,W291,W292,E203,E231
 max-line-length = 120
 statistics = True
-exclude=docs_rst/*.py
+exclude = docs_rst/*.py
 
 [flake8]
 exclude = .git,__pycache__,docs_rst/conf.py,tests

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ issues, please use the [Discourse page](https://discuss.matsci.org/c/pymatgen).
 Why use pymatgen?
 =================
 
-There are many materials analysis codes out there, both commerical and free,
+There are many materials analysis codes out there, both commercial and free,
 but pymatgen offer several advantages:
 
 1. **It is (fairly) robust.** Pymatgen is used by thousands of researchers,


### PR DESCRIPTION
`MPRester.__init__()` raises 

```py
TypeError: 'NoneType' object is not iterable
```

if `.pmgrc.yaml` exists but is empty.

Plus add some more type hints for frequently used functions.