### PR TITLE
Don't double-include initial_magmoms in ASEAtomsAdaptor

### DIFF
--- a/pymatgen/io/ase.py
+++ b/pymatgen/io/ase.py
@@ -229,6 +229,7 @@ class AseAtomsAdaptor:
                 "numbers",
                 "positions",
                 "magmom",
+                "initial_magmoms",
                 "final_magmom",
                 "charge",
                 "final_charge",

--- a/pymatgen/io/tests/test_ase.py
+++ b/pymatgen/io/tests/test_ase.py
@@ -178,11 +178,13 @@ class AseAtomsAdaptorTest(unittest.TestCase):
         structure = aio.AseAtomsAdaptor.get_structure(atoms)
         self.assertEqual(structure.site_properties["magmom"], mags)
         self.assertTrue("final_magmom" not in structure.site_properties)
+        self.assertTrue("initial_magmoms" not in structure.site_properties)
 
         atoms = read(os.path.join(PymatgenTest.TEST_FILES_DIR, "OUTCAR"))
         structure = aio.AseAtomsAdaptor.get_structure(atoms)
         self.assertEqual(structure.site_properties["final_magmom"], atoms.get_magnetic_moments().tolist())
         self.assertTrue("magmom" not in structure.site_properties)
+        self.assertTrue("initial_magmoms" not in structure.site_properties)
 
     @unittest.skipIf(not aio.ase_loaded, "ASE not loaded.")
     def test_get_structure_dyn(self):


### PR DESCRIPTION
Currently, the `AseAtomsAdaptor()` conversion of an `Atoms` object to a Pymatgen `structure` object includes duplicate site properties for initial magnetic moments. This PR resolves the duplication -- the docs indicate that the initial magmoms should only be stored under `magmom` and that `initial_magmoms` should not exist as a site property.

```python
from pymatgen.io.ase import AseAtomsAdaptor
from ase.io import read

atoms = read('Ac.cif')
atoms.set_initial_magnetic_moments([1.0]*len(atoms))
struct = AseAtomsAdaptor.get_structure(atoms)
print(struct[0].properties)
```

This currently outputs
```python
{'magmom': 1.0, 'spacegroup_kinds': 0, 'initial_magmoms': 1.0}
```

The last entry should not be present.