### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,9 @@ name: Linting
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     # prevent this action from running on forks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     types: [created]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     # prevent this action from running on forks

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -2,6 +2,9 @@ name: Testing Mac
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     # prevent this action from running on forks

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -2,6 +2,9 @@ name: Testing Windows
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     # prevent this action from running on forks


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
