### PR TITLE
Remove vertical lines from VoltageProfilePlotter.get_plotly_figure()

### DIFF
--- a/pymatgen/apps/battery/plotter.py
+++ b/pymatgen/apps/battery/plotter.py
@@ -149,7 +149,15 @@ class VoltageProfilePlotter:
             (x, y) = self.get_plot_data(electrode, term_zero=term_zero)
             wion_symbol.add(electrode.working_ion.symbol)
             formula.add(electrode.framework_formula)
-            data.append(go.Scatter(x=x, y=y, name=label, hovertemplate=hover_temp))
+            # add Nones to x and y so vertical connecting lines are not plotted
+            plot_x, plot_y = [x[0]], [y[0]]
+            for i in range(1, len(x)):
+                if x[i - 1] == x[i]:
+                    plot_x.append(None)
+                    plot_y.append(None)
+                plot_x.append(x[i])
+                plot_y.append(y[i])
+            data.append(go.Scatter(x=plot_x, y=plot_y, name=label, hovertemplate=hover_temp))
 
         fig = go.Figure(
             data=data,


### PR DESCRIPTION
Change VoltageProfilePlotter.get_plotly_figure() so connecting vertical lines are not drawn in voltage profile. These vertical lines are misleading for interpreting voltage profile plots. 

@mkhorton this change was discussed with Kristin at the Jun 13 meeting on the current state of the battery code infrastructure. Please let me know if any revisions are needed but otherwise I think this PR is ready to merge.