### PR TITLE
Molecule: warn when writing charged mol to xyz

### DIFF
--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -3219,6 +3219,12 @@ class IMolecule(SiteCollection, MSONable):
         fmt = "" if fmt is None else fmt.lower()
         fname = os.path.basename(filename or "")
         if fmt == "xyz" or fnmatch(fname.lower(), "*.xyz*"):
+            if self.charge != 0:
+                warnings.warn(
+                    f"Your molecule has a charge of {self.charge}, but the XYZ "
+                    "format only stores atomic positions, not charge. Using Molecule.from_file() "
+                    "with this file will result in an uncharged Molecule."
+                )
             writer = XYZ(self)
         elif any(fmt == r or fnmatch(fname.lower(), f"*.{r}*") for r in ["gjf", "g03", "g09", "com", "inp"]):
             writer = GaussianInput(self)

--- a/pymatgen/core/tests/test_structure.py
+++ b/pymatgen/core/tests/test_structure.py
@@ -1566,6 +1566,11 @@ Site: H (-0.5134, 0.8892, -0.3630)"""
             self.assertEqual(m, self.mol)
             self.assertIsInstance(m, IMolecule)
 
+        # test warning when writing charged molecule to .xyz
+        m_charged = Molecule([Element("K")], [[0, 0, 0]], charge=1)
+        with pytest.warns(UserWarning, match="the XYZ format does not store charge"):
+            m_charged.to(fmt="xyz")
+
         self.mol.to(filename="CH4_testing.xyz")
         self.assertTrue(os.path.exists("CH4_testing.xyz"))
         os.remove("CH4_testing.xyz")

--- a/pymatgen/core/tests/test_structure.py
+++ b/pymatgen/core/tests/test_structure.py
@@ -468,7 +468,7 @@ class IStructureTest(PymatgenTest):
         self.assertEqual(len(nn), 47)
         r = random.uniform(3, 6)
         all_nn = s.get_all_neighbors(r, True, True)
-        for i in range(len(s)):
+        for i, _ in enumerate(s):
             self.assertEqual(4, len(all_nn[i][0]))
             self.assertEqual(len(all_nn[i]), len(s.get_neighbors(s[i], r)))
 
@@ -1411,7 +1411,7 @@ Sites (5)
 2 H     1.026719     0.000000    -0.363000
 3 H    -0.513360    -0.889165    -0.363000
 4 H    -0.513360     0.889165    -0.363000"""
-        self.assertEqual(self.mol.__str__(), ans)
+        self.assertEqual(str(self.mol), ans)
         ans = """Molecule Summary
 Site: C (0.0000, 0.0000, 0.0000)
 Site: H (0.0000, 0.0000, 1.0890)
@@ -1568,7 +1568,7 @@ Site: H (-0.5134, 0.8892, -0.3630)"""
 
         # test warning when writing charged molecule to .xyz
         m_charged = Molecule([Element("K")], [[0, 0, 0]], charge=1)
-        with pytest.warns(UserWarning, match="the XYZ format does not store charge"):
+        with pytest.warns(UserWarning, match="the XYZ format only stores atomic positions, not charge."):
             m_charged.to(fmt="xyz")
 
         self.mol.to(filename="CH4_testing.xyz")
@@ -1765,6 +1765,5 @@ class MoleculeTest(PymatgenTest):
 
 
 if __name__ == "__main__":
-    import unittest
 
     unittest.main()


### PR DESCRIPTION
## Summary

`Molecule.to()` supports many formats including .xyz; however .xyz format does not store charge information; only atomic positions. For users not intimately familiar with details of the .xyz format, this can lead to unexpected behavior when working with charged `Molecule`, e.g.

```
>>> m = Molecule([Element("K")], [[0,0,0]], charge =1)
>>> m.charge
1
>>> m.to(filename='test.xyz')
>>> m2=Molecule.from_file('test.xyz')
>>> m2.charge
0
```

This PR simply adds a warning to alert the user that they will lose information when writing to .xyz. The warning is only raised when 1) the `Molecule` has a charge and 2) the user tries to write to .xyz format.

```
>>> m.to(fmt='test.xyz')
UserWarning: Your molecule has a charge of 1, but the XYZ format only stores atomic positions, not charge. 
Using Molecule.from_file() with this file will result in an uncharged Molecule.
'1\nK1\nK 0.000000 0.000000 0.000000'
```

Other minor changes to `test_structure.py` were made to satisfy the `pylint` pre-commit hooks
