### PR TITLE
Molecule: warn user about non-triplet O2

### DIFF
--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -2782,7 +2782,7 @@ class IMolecule(SiteCollection, MSONable):
         if self.species == [Element("O"), Element("O")] and self.charge == 0 and self._spin_multiplicity != 3:
             warnings.warn(
                 f"You have specified a spin multiplicity of {self._spin_multiplicity} for "
-                "an O2 molecule; however the ground state of molecular O2 has a spin multiplicity of 3."
+                "an O2 molecule; however the ground state of molecular O2 has a spin multiplicity of 3. "
                 "If this was intentional, you can safely ignore this message."
             )
 

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -2778,6 +2778,14 @@ class IMolecule(SiteCollection, MSONable):
         else:
             self._spin_multiplicity = 1 if nelectrons % 2 == 0 else 2
 
+        # Remind user about the unusual spin multiplicity of ground state O2
+        if self.species == [Element("O"), Element("O")] and self.charge == 0 and self._spin_multiplicity != 3:
+            warnings.warn(
+                f"You have specified a spin multiplicity of {self._spin_multiplicity} for "
+                "an O2 molecule; however the ground state of molecular O2 has a spin multiplicity of 3."
+                "If this was intentional, you can safely ignore this message."
+            )
+
     @property
     def charge(self) -> float:
         """

--- a/pymatgen/core/tests/test_structure.py
+++ b/pymatgen/core/tests/test_structure.py
@@ -468,7 +468,7 @@ class IStructureTest(PymatgenTest):
         self.assertEqual(len(nn), 47)
         r = random.uniform(3, 6)
         all_nn = s.get_all_neighbors(r, True, True)
-        for i in range(len(s)):
+        for i, _ in enumerate(s):
             self.assertEqual(4, len(all_nn[i][0]))
             self.assertEqual(len(all_nn[i]), len(s.get_neighbors(s[i], r)))
 
@@ -1411,7 +1411,7 @@ Sites (5)
 2 H     1.026719     0.000000    -0.363000
 3 H    -0.513360    -0.889165    -0.363000
 4 H    -0.513360     0.889165    -0.363000"""
-        self.assertEqual(self.mol.__str__(), ans)
+        self.assertEqual(str(self.mol), ans)
         ans = """Molecule Summary
 Site: C (0.0000, 0.0000, 0.0000)
 Site: H (0.0000, 0.0000, 1.0890)
@@ -1512,6 +1512,11 @@ Site: H (-0.5134, 0.8892, -0.3630)"""
         # Triplet O2
         mol = IMolecule(["O"] * 2, [[0, 0, 0], [0, 0, 1.2]], spin_multiplicity=3)
         self.assertEqual(mol.spin_multiplicity, 3)
+
+        # Warning reminding users that O2 ground state is triplet
+        # Triplet O2
+        with pytest.warns(UserWarning, match="the ground state of molecular O2 has a spin multiplicity of 3"):
+            mol = IMolecule(["O"] * 2, [[0, 0, 0], [0, 0, 1.2]], spin_multiplicity=1)
 
     def test_no_spin_check(self):
         coords = [
@@ -1760,6 +1765,5 @@ class MoleculeTest(PymatgenTest):
 
 
 if __name__ == "__main__":
-    import unittest
 
     unittest.main()


### PR DESCRIPTION
## Summary

When a user creates a `Molecule` to represent O2 with default keyword arguments, the spin_multiplicity will be set to 1. However, the ground state of the O2 molecule is triplet (unlike most molecules with a single covalent bond).

```
>>> mol = Molecule(["O"] * 2, [[0, 0, 0], [0, 0, 1.2]])
>>> m.spin_multiplicity
1
````

This PR adds a warning to remind users of this fact. The warning is only invoked when 1) the `Molecule` is O2 (not O4, or O8, etc.), 2) the charge is zero, and 3) the spin_multiplicity is not equal to 3. It does not change the internal spin multiplicity setting either; it merely alerts the user that they may have made a mistake.

```
>>> mol = Molecule(["O"] * 2, [[0, 0, 0], [0, 0, 1.2]])
UserWarning: You have specified a spin multiplicity of 1 for an O2 molecule; however the ground state of 
molecular O2 has a spin multiplicity of 3. If this was intentional, you can safely ignore this message.
>>> m.spin_multiplicity
1
````

This may be controversial; I recognize that we have to expect users to know what they are doing and can't anticipate every mistake or non-obvious behavior. That said, given how common O2 is to many different types of simulation work and that I'm sure the vast majority of users want the ground state when they make an O2 Molecule, I think it's valuable to include this warning to 1) help users catch their own mistakes (preventing wasted time and having to re-do calculations) and 2) educate less savvy users that this is something they need to think about.

Flagging @samblau and @mkhorton and @arosen93  for any additional thoughts