### PR TITLE
Ion: pass charge to oxi_state_guesses

### DIFF
--- a/pymatgen/core/ion.py
+++ b/pymatgen/core/ion.py
@@ -246,6 +246,45 @@ class Ion(Composition, MSONable, Stringify):
         """Composition of ion."""
         return Composition(self._data)
 
+    def oxi_state_guesses(  # type: ignore
+        self,
+        oxi_states_override: dict = None,
+        all_oxi_states: bool = False,
+        max_sites: int = None,
+    ) -> list[dict[str, float]]:
+        """
+        Checks if the composition is charge-balanced and returns back all
+        charge-balanced oxidation state combinations. Composition must have
+        integer values. Note that more num_atoms in the composition gives
+        more degrees of freedom. e.g., if possible oxidation states of
+        element X are [2,4] and Y are [-3], then XY is not charge balanced
+        but X2Y2 is. Results are returned from most to least probable based
+        on ICSD statistics. Use max_sites to improve performance if needed.
+
+        Args:
+            oxi_states_override (dict): dict of str->list to override an
+                element's common oxidation states, e.g. {"V": [2,3,4,5]}
+            all_oxi_states (bool): if True, an element defaults to
+                all oxidation states in pymatgen Element.icsd_oxidation_states.
+                Otherwise, default is Element.common_oxidation_states. Note
+                that the full oxidation state list is *very* inclusive and
+                can produce nonsensical results.
+            max_sites (int): if possible, will reduce Compositions to at most
+                this many sites to speed up oxidation state guesses. If the
+                composition cannot be reduced to this many sites a ValueError
+                will be raised. Set to -1 to just reduce fully. If set to a
+                number less than -1, the formula will be fully reduced but a
+                ValueError will be thrown if the number of atoms in the reduced
+                formula is greater than abs(max_sites).
+
+        Returns:
+            A list of dicts - each dict reports an element symbol and average
+                oxidation state across all sites in that composition. If the
+                composition is not charge balanced, an empty list is returned.
+        """
+
+        return self._get_oxid_state_guesses(all_oxi_states, max_sites, oxi_states_override, self.charge)[0]
+
     def __eq__(self, other):
         if self.composition != other.composition:
             return False

--- a/pymatgen/core/tests/test_ion.py
+++ b/pymatgen/core/tests/test_ion.py
@@ -97,6 +97,11 @@ class IonTest(unittest.TestCase):
         self.assertEqual(comp.alphabetical_formula, "Fe6 Li8 (aq)")
         self.assertEqual(comp.formula, "Li8 Fe6 (aq)")
 
+    def test_oxi_state_guesses(self):
+        i = Ion.from_formula("SO4-2")
+        assert i.oxi_state_guesses()[0].get("S") == 6
+        assert i.oxi_state_guesses()[0].get("O") == -2
+
     def test_alphabetical_formula(self):
         correct_formulas = [
             "Li1 +1",
@@ -129,7 +134,7 @@ class IonTest(unittest.TestCase):
             "A+2",
             "ABC(aq)",
         ]
-        for i in range(len(self.comp)):
+        for i, _ in enumerate(self.comp):
             self.assertEqual(self.comp[i].anonymized_formula, expected_formulas[i])
 
     def test_from_dict(self):
@@ -167,7 +172,7 @@ class IonTest(unittest.TestCase):
             comp2,
             "Composition equality test failed. " + f"{comp1.formula} should be equal to {comp2.formula}",
         )
-        self.assertEqual(comp1.__hash__(), comp2.__hash__(), "Hashcode equality test failed!")
+        self.assertEqual(hash(comp1), hash(comp2), "Hashcode equality test failed!")
 
     def test_equality(self):
         self.assertTrue(self.comp[0] == (self.comp[0]))


### PR DESCRIPTION
## Summary

`Ion.oxi_state_guesses()`  currently inherits from `Composition`, and generally fails to provide useful information unless the user specifies the `target_charge` (which is an optional kwarg):

```
>>> i=Ion.from_formula('SO4-2')
>>> i.oxi_state_guesses()
[]
```

This PR overloads the parent method such that `target_charge` is always set equal to the net charge on the `Ion` object. All other kwargs are passed to the parent method.

```
>>> i=Ion.from_formula('SO4-2')
>>> i.oxi_state_guesses()
({'S': 6.0, 'O': -2.0},)
```

Other minor changes to `test_ion.py` were made to satisfy the `pylint` pre-commit hooks
