### PR TITLE
Element: add from_name()

### DIFF
--- a/pymatgen/core/periodic_table.py
+++ b/pymatgen/core/periodic_table.py
@@ -600,6 +600,22 @@ class ElementBase(Enum):
         raise ValueError(f"No element with this atomic number {z}")
 
     @staticmethod
+    def from_name(name: str) -> Element:
+        """
+        Get an element from its long name.
+
+        Args:
+            name: Long name of the element, e.g. 'Hydrogen' or
+                  'Iron'. Not case-sensitive.
+        Returns:
+            Element with the name 'name'
+        """
+        for sym, data in _pt_data.items():
+            if data["Name"] == name.capitalize():
+                return Element(sym)
+        raise ValueError(f"No element with the name {name}")
+
+    @staticmethod
     def from_row_and_group(row: int, group: int) -> Element:
         """
         Returns an element from a row and group number.

--- a/pymatgen/core/tests/test_periodic_table.py
+++ b/pymatgen/core/tests/test_periodic_table.py
@@ -135,6 +135,20 @@ class ElementTestCase(PymatgenTest):
         for k, v in testsets.items():
             self.assertEqual(Element(k).row, v)
 
+    def test_from_name(self):
+        testsets = {
+            "H": "hydrogen",
+            "He": "Helium",
+            "Li": "lithium",
+            "O": "Oxygen",
+            "Fe": "Iron",
+            "La": "lanthanum",
+            "Ce": "Cerium",
+            "U": "Uranium",
+        }
+        for k, v in testsets.items():
+            self.assertEqual(ElementBase.from_name(v), Element(k))
+
     def test_from_row_and_group(self):
         testsets = {
             "H": (1, 1),


### PR DESCRIPTION
Adds an `Element.from_name` convenience function to make it possible to init an `Element` from its long name, in addition to existing methods based on symbol (default), atomic number (`Element.from_Z`), or row and group (`Element.from_row_and_group``)

```
>>> Element.from_name('Sodium')
Element Na
```