### PR TITLE
allow to change voronoi_distance_cutoff in ChemEnv

### DIFF
--- a/pymatgen/analysis/chemenv/coordination_environments/coordination_geometry_finder.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/coordination_geometry_finder.py
@@ -563,6 +563,7 @@ class LocalGeometryFinder:
         get_from_hints=False,
         voronoi_normalized_distance_tolerance=PRESETS["DEFAULT"]["voronoi_normalized_distance_tolerance"],
         voronoi_normalized_angle_tolerance=PRESETS["DEFAULT"]["voronoi_normalized_angle_tolerance"],
+        voronoi_distance_cutoff=None,
         recompute=None,
         optimization=PRESETS["DEFAULT"]["optimization"],
     ):
@@ -592,6 +593,8 @@ class LocalGeometryFinder:
             neighbors sets
         :param voronoi_normalized_angle_tolerance: tolerance for the normalized angle used to distinguish
             neighbors sets
+        :param voronoi_distance_cutoff: determines distance of considered neighbors. Especially important to increase it
+            for molecules in a box.
         :param recompute: whether to recompute the sites already computed (when initial_structure_environments
             is not None)
         :param optimization: optimization algorithm
@@ -673,6 +676,8 @@ class LocalGeometryFinder:
             normalized_angle_tolerance = DetailedVoronoiContainer.default_normalized_angle_tolerance
         else:
             normalized_angle_tolerance = voronoi_normalized_angle_tolerance
+        if voronoi_distance_cutoff is None:
+            voronoi_distance_cutoff=DetailedVoronoiContainer.default_voronoi_cutoff
         self.detailed_voronoi = DetailedVoronoiContainer(
             self.structure,
             isites=sites_indices,
@@ -682,6 +687,7 @@ class LocalGeometryFinder:
             additional_conditions=additional_conditions,
             normalized_distance_tolerance=normalized_distance_tolerance,
             normalized_angle_tolerance=normalized_angle_tolerance,
+            voronoi_cutoff =voronoi_distance_cutoff,
         )
         logging.debug("DetailedVoronoiContainer has been set up")
 

--- a/pymatgen/analysis/chemenv/coordination_environments/coordination_geometry_finder.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/coordination_geometry_finder.py
@@ -677,7 +677,7 @@ class LocalGeometryFinder:
         else:
             normalized_angle_tolerance = voronoi_normalized_angle_tolerance
         if voronoi_distance_cutoff is None:
-            voronoi_distance_cutoff=DetailedVoronoiContainer.default_voronoi_cutoff
+            voronoi_distance_cutoff = DetailedVoronoiContainer.default_voronoi_cutoff
         self.detailed_voronoi = DetailedVoronoiContainer(
             self.structure,
             isites=sites_indices,
@@ -687,7 +687,7 @@ class LocalGeometryFinder:
             additional_conditions=additional_conditions,
             normalized_distance_tolerance=normalized_distance_tolerance,
             normalized_angle_tolerance=normalized_angle_tolerance,
-            voronoi_cutoff =voronoi_distance_cutoff,
+            voronoi_cutoff=voronoi_distance_cutoff,
         )
         logging.debug("DetailedVoronoiContainer has been set up")
 

--- a/pymatgen/analysis/chemenv/coordination_environments/tests/test_coordination_geometry_finder.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/tests/test_coordination_geometry_finder.py
@@ -16,8 +16,8 @@ from pymatgen.analysis.chemenv.coordination_environments.coordination_geometry_f
     LocalGeometryFinder,
     symmetry_measure,
 )
+from pymatgen.core.structure import Lattice, Structure
 from pymatgen.util.testing import PymatgenTest
-from pymatgen.core.structure import Structure, Lattice
 
 json_files_dir = os.path.join(
     PymatgenTest.TEST_FILES_DIR,
@@ -96,7 +96,6 @@ class CoordinationGeometryFinderTest(PymatgenTest):
         self.lgf.setup_explicit_indices_local_geometry(explicit_indices=[3, 5, 2, 0, 1, 4])
         self.assertEqual(self.lgf.icentral_site, 0)
         self.assertEqual(self.lgf.indices, [4, 6, 3, 1, 2, 5])
-
 
         LiFePO4_struct = self.get_structure("LiFePO4")
         isite = 10

--- a/pymatgen/analysis/chemenv/coordination_environments/tests/test_coordination_geometry_finder.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/tests/test_coordination_geometry_finder.py
@@ -17,6 +17,7 @@ from pymatgen.analysis.chemenv.coordination_environments.coordination_geometry_f
     symmetry_measure,
 )
 from pymatgen.util.testing import PymatgenTest
+from pymatgen.core.structure import Structure, Lattice
 
 json_files_dir = os.path.join(
     PymatgenTest.TEST_FILES_DIR,
@@ -96,6 +97,7 @@ class CoordinationGeometryFinderTest(PymatgenTest):
         self.assertEqual(self.lgf.icentral_site, 0)
         self.assertEqual(self.lgf.indices, [4, 6, 3, 1, 2, 5])
 
+
         LiFePO4_struct = self.get_structure("LiFePO4")
         isite = 10
         envs_LiFePO4 = self.lgf.compute_coordination_environments(structure=LiFePO4_struct, indices=[isite])
@@ -106,6 +108,12 @@ class CoordinationGeometryFinderTest(PymatgenTest):
             np.array([6.88012571, -5.79877503, -3.73177541]),
             np.array([6.90041188, -3.32797839, -3.71812416]),
         ]
+
+        # test to check that one can pass voronoi_distance_cutoff
+        struct = Structure(Lattice.cubic(25), ["O", "C", "O"], [[0.0, 0.0, 0.0], [0.0, 0.0, 1.17], [0.0, 0.0, 2.34]])
+        self.lgf.setup_structure(structure=struct)
+        self.lgf.compute_structure_environments(voronoi_distance_cutoff=25)
+
         self.lgf.setup_structure(LiFePO4_struct)
         self.lgf.setup_local_geometry(isite, coords=nbs_coords)
 

--- a/pymatgen/analysis/chemenv/coordination_environments/voronoi.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/voronoi.py
@@ -15,7 +15,6 @@ __date__ = "Feb 20, 2016"
 
 import logging
 import time
-import warnings
 
 import numpy as np
 from monty.json import MSONable
@@ -144,7 +143,7 @@ class DetailedVoronoiContainer(MSONable):
         self.voronoi_list_coords = [None] * len(self.structure)
         logging.debug("Getting all neighbors in structure")
         struct_neighbors = self.structure.get_all_neighbors(voronoi_cutoff, include_index=True)
-        size_neighbors=[(not len(neigh) > 3) for neigh in struct_neighbors]
+        size_neighbors = [(not len(neigh) > 3) for neigh in struct_neighbors]
         if np.any(size_neighbors):
             logging.debug("Please consider increasing voronoi_distance_cutoff")
         t1 = time.process_time()

--- a/pymatgen/analysis/chemenv/coordination_environments/voronoi.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/voronoi.py
@@ -15,6 +15,7 @@ __date__ = "Feb 20, 2016"
 
 import logging
 import time
+import warnings
 
 import numpy as np
 from monty.json import MSONable
@@ -143,9 +144,11 @@ class DetailedVoronoiContainer(MSONable):
         self.voronoi_list_coords = [None] * len(self.structure)
         logging.debug("Getting all neighbors in structure")
         struct_neighbors = self.structure.get_all_neighbors(voronoi_cutoff, include_index=True)
+        size_neighbors=[(not len(neigh) > 3) for neigh in struct_neighbors]
+        if np.any(size_neighbors):
+            logging.debug("Please consider increasing voronoi_distance_cutoff")
         t1 = time.process_time()
         logging.debug("Setting up Voronoi list :")
-
         for jj, isite in enumerate(indices):
             logging.debug(f"  - Voronoi analysis for site #{isite:d} ({jj + 1:d}/{len(indices):d})")
             site = self.structure[isite]


### PR DESCRIPTION
## Summary
This pull-request allows to change the voronoi_distance cutoff in ChemEnv. Otherwise, molecules in too large boxes cannot be investigated. I have added a test and a warning for users in case the cutoff is too small. (Issue found by @rlaplaza)