### PR TITLE
InputSet: implement equality method and fix __iter__

### DIFF
--- a/pymatgen/io/core.py
+++ b/pymatgen/io/core.py
@@ -144,7 +144,7 @@ class InputSet(MSONable, MutableMapping):
         return len(self.inputs.keys())
 
     def __iter__(self):
-        return iter(self.inputs.items())
+        return iter(self.inputs)
 
     def __getitem__(self, key):
         return self.inputs[key]
@@ -154,6 +154,9 @@ class InputSet(MSONable, MutableMapping):
 
     def __delitem__(self, key):
         del self.inputs[key]
+
+    def __eq__(self, other):
+        return (self.inputs == other.inputs) and (self.__dict__ == other.__dict__)
 
     def write_input(
         self,

--- a/pymatgen/io/tests/test_core.py
+++ b/pymatgen/io/tests/test_core.py
@@ -86,7 +86,8 @@ class TestInputSet:
         with pytest.raises(AttributeError):
             inp_set.kwarg3
         expected = [("cif1", sif1), ("cif2", sif2), ("cif3", sif3)]
-        for (fname, contents), (exp_fname, exp_contents) in zip(inp_set, expected):
+
+        for (fname, contents), (exp_fname, exp_contents) in zip(inp_set.items(), expected):
             assert fname == exp_fname
             assert contents is exp_contents
 
@@ -104,9 +105,66 @@ class TestInputSet:
 
         assert len(inp_set) == 2
         expected = [("cif1", sif1), ("cif3", sif3)]
-        for (fname, contents), (exp_fname, exp_contents) in zip(inp_set, expected):
+        for (fname, contents), (exp_fname, exp_contents) in zip(inp_set.items(), expected):
             assert fname == exp_fname
             assert contents is exp_contents
+    
+    def test_equality(self):
+        sif1 = StructInputFile.from_file(os.path.join(test_dir, "Li.cif"))
+        sif2 = StructInputFile.from_file(os.path.join(test_dir, "LiFePO4.cif"))
+        sif3 = StructInputFile.from_file(os.path.join(test_dir, "Li2O.cif"))
+
+        inp_set = InputSet(
+            {
+                "cif1": sif1,
+                "cif2": sif2,
+            },
+            kwarg1=1,
+            kwarg2="hello",
+        )
+
+        inp_set2 = InputSet(
+            {
+                "cif1": sif1,
+                "cif2": sif2,
+            },
+            kwarg1=1,
+            kwarg2="hello",
+        )
+
+        inp_set3 = InputSet(
+            {
+                "cif1": sif1,
+                "cif2": sif2,
+                "cif3": sif3,
+            },
+            kwarg1=1,
+            kwarg2="hello",
+        )
+
+        inp_set4 = InputSet(
+            {
+                "cif1": sif1,
+                "cif2": sif2,
+            },
+            kwarg1=1,
+            kwarg2="goodbye",
+        )
+
+        inp_set5 = InputSet(
+            {
+                "cif1": sif1,
+                "cif2": sif2,
+            },
+            kwarg1=1,
+            kwarg2="hello",
+            kwarg3="goodbye"
+        )
+
+        assert inp_set == inp_set2
+        assert inp_set != inp_set3
+        assert inp_set != inp_set4
+        assert inp_set != inp_set5
 
     def test_msonable(self):
         sif1 = StructInputFile.from_file(os.path.join(test_dir, "Li.cif"))
@@ -127,7 +185,7 @@ class TestInputSet:
         assert temp_inp_set.kwarg1 == 1
         assert temp_inp_set.kwarg2 == "hello"
         assert temp_inp_set._kwargs == inp_set._kwargs
-        for (fname, contents), (fname2, contents2) in zip(temp_inp_set, inp_set):
+        for (fname, contents), (fname2, contents2) in zip(temp_inp_set.items(), inp_set.items()):
             assert fname == fname2
             assert contents.structure == contents2.structure
 

--- a/pymatgen/io/tests/test_core.py
+++ b/pymatgen/io/tests/test_core.py
@@ -108,7 +108,7 @@ class TestInputSet:
         for (fname, contents), (exp_fname, exp_contents) in zip(inp_set.items(), expected):
             assert fname == exp_fname
             assert contents is exp_contents
-    
+
     def test_equality(self):
         sif1 = StructInputFile.from_file(os.path.join(test_dir, "Li.cif"))
         sif2 = StructInputFile.from_file(os.path.join(test_dir, "LiFePO4.cif"))
@@ -158,7 +158,7 @@ class TestInputSet:
             },
             kwarg1=1,
             kwarg2="hello",
-            kwarg3="goodbye"
+            kwarg3="goodbye",
         )
 
         assert inp_set == inp_set2


### PR DESCRIPTION
## Summary

This pull request fixes two items in `InputSet`:

1. `__iter__` was previously iterating an iterator over `self.inputs.items()` rather than `self.inputs`. This was not a correct implementation (see example for implementing a `dict`-like class from `MutableMapping` [here](https://stackoverflow.com/questions/21361106/how-would-i-implement-a-dict-with-abstract-base-classes-in-python)) and prevented `__eq__` from working properly
2. After fixing item 1), I realized that the built-in `__eq__` method was only comparing the `inputs` and not the kwargs. Therefore, I added a custom `__eq__` method to ensure that `InputSet` are considered equal only if both the `inputs` and all kwargs are equal.

Note that a small change in some of the pre-existing tests was required due to the changed behavior of `__iter__`.

Thanks @orionarcher  for identifying this bug. Also flagging @utf in case the changed behavior of `__iter__` will affect your new input sets in atomate2
