### PR TITLE
changed charge convention

### DIFF
--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -1167,7 +1167,7 @@ class Vasprun(MSONable):
             else:
                 nums = [len(list(g)) for _, g in itertools.groupby(self.atomic_symbols)]
                 potcar_nelect = sum(ps.ZVAL * num for ps, num in zip(potcar, nums))
-            charge = nelect - potcar_nelect
+            charge = potcar_nelect - nelect
 
             if charge:
                 for s in self.structures:

--- a/pymatgen/io/vasp/tests/test_outputs.py
+++ b/pymatgen/io/vasp/tests/test_outputs.py
@@ -738,14 +738,14 @@ class VasprunTest(PymatgenTest):
         vasprun = Vasprun(vpath, parse_potcar_file=False)
         vasprun.update_charge_from_potcar(potcar_path)
         self.assertEqual(vasprun.parameters.get("NELECT", 8), 9)
-        self.assertEqual(vasprun.structures[0].charge, 1)
+        self.assertEqual(vasprun.structures[0].charge, -1)
 
         vpath = self.TEST_FILES_DIR / "vasprun.split.charged.xml"
         potcar_path = self.TEST_FILES_DIR / "POTCAR.split.charged.gz"
         vasprun = Vasprun(vpath, parse_potcar_file=False)
         vasprun.update_charge_from_potcar(potcar_path)
         self.assertEqual(vasprun.parameters.get("NELECT", 0), 7)
-        self.assertEqual(vasprun.structures[-1].charge, 1)
+        self.assertEqual(vasprun.structures[-1].charge, -1)
 
     def test_kpointset_electronvelocities(self):
         vpath = self.TEST_FILES_DIR / "vasprun.lvel.Si2H.xml"


### PR DESCRIPTION
## The sign convention of the net charge parsed by Vasprun should be changed.

The current value of the parsed charge for Vasprun.structure is more positive if NELECT is higher.
If we used the electron -> negative charge convention then this expression should have the other sign
