### PR TITLE
Apply the structure charge to initial and final structure

### DIFF
--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -1172,6 +1172,8 @@ class Vasprun(MSONable):
             if charge:
                 for s in self.structures:
                     s._charge = charge
+                self.final_structure._charge = charge
+                self.initial_structure._charge = charge
 
     def as_dict(self):
         """

--- a/pymatgen/io/vasp/tests/test_outputs.py
+++ b/pymatgen/io/vasp/tests/test_outputs.py
@@ -739,6 +739,8 @@ class VasprunTest(PymatgenTest):
         vasprun.update_charge_from_potcar(potcar_path)
         self.assertEqual(vasprun.parameters.get("NELECT", 8), 9)
         self.assertEqual(vasprun.structures[0].charge, -1)
+        self.assertEqual(vasprun.initial_structure.charge, -1)
+        self.assertEqual(vasprun.final_structure.charge, -1)
 
         vpath = self.TEST_FILES_DIR / "vasprun.split.charged.xml"
         potcar_path = self.TEST_FILES_DIR / "POTCAR.split.charged.gz"
@@ -746,6 +748,8 @@ class VasprunTest(PymatgenTest):
         vasprun.update_charge_from_potcar(potcar_path)
         self.assertEqual(vasprun.parameters.get("NELECT", 0), 7)
         self.assertEqual(vasprun.structures[-1].charge, -1)
+        self.assertEqual(vasprun.initial_structure.charge, -1)
+        self.assertEqual(vasprun.final_structure.charge, -1)
 
     def test_kpointset_electronvelocities(self):
         vpath = self.TEST_FILES_DIR / "vasprun.lvel.Si2H.xml"


### PR DESCRIPTION
## Bug Fix in Vasprun

The current code does not decorate the initial and final structures in `Vasprun` with the charge.  This affects Atomate2 
https://github.com/materialsproject/atomate2/issues/154
