### PR TITLE
Brillouin sone -> Brillouin zone

### DIFF
--- a/pymatgen/analysis/chemenv/coordination_environments/coordination_geometry_finder.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/coordination_geometry_finder.py
@@ -7,11 +7,11 @@ If you use this module, please cite the following:
 David Waroquiers, Xavier Gonze, Gian-Marco Rignanese, Cathrin Welker-Nieuwoudt, Frank Rosowski,
 Michael Goebel, Stephan Schenk, Peter Degelmann, Rute Andre, Robert Glaum, and Geoffroy Hautier,
 "Statistical analysis of coordination environments in oxides",
-Chem. Mater., 2017, 29 (19), pp 8346–8360,
+Chem. Mater., 2017, 29 (19), pp 8346-8360,
 DOI: 10.1021/acs.chemmater.7b02766
 D. Waroquiers, J. George, M. Horton, S. Schenk, K. A. Persson, G.-M. Rignanese, X. Gonze, G. Hautier
 "ChemEnv: a fast and robust coordination environment identification tool",
-Acta Cryst. B 2020, 76, pp 683–695,
+Acta Cryst. B 2020, 76, pp 683-695,
 DOI: 10.1107/S2052520620007994
 """
 

--- a/pymatgen/analysis/chemenv/utils/defs_utils.py
+++ b/pymatgen/analysis/chemenv/utils/defs_utils.py
@@ -26,7 +26,7 @@ STATS_ENV_PAPER = (
     "\n"
     "D. Waroquiers, J. George, M. Horton, S. Schenk, K. A. Persson, G.-M. Rignanese, X. Gonze, G. Hautier,\n"
     '"ChemEnv: a fast and robust coordination environment identification tool",\n'
-    "Acta Cryst. B 2020, 76, pp 683–695\n."
+    "Acta Cryst. B 2020, 76, pp 683-695\n."
     "DOI: 10.1107/S2052520620007994\n"
 )
 

--- a/pymatgen/analysis/chempot_diagram.py
+++ b/pymatgen/analysis/chempot_diagram.py
@@ -11,7 +11,7 @@ For more information, please cite/reference the paper below:
     Todd, P. K., McDermott, M. J., Rom, C. L., Corrao, A. A., Denney, J. J., Dwaraknath,
     S. S.,  Khalifah, P. G., Persson, K. A., & Neilson, J. R. (2021). Selectivity in
     Yttrium Manganese Oxide Synthesis via Local Chemical Potentials in Hyperdimensional
-    Phase Space. Journal of the American Chemical Society, 143(37), 15185–15194.
+    Phase Space. Journal of the American Chemical Society, 143(37), 15185-15194.
     https://doi.org/10.1021/jacs.1c06229
 
 Please also consider referencing the original 1999 paper by H. Yokokawa,
@@ -60,7 +60,7 @@ class ChemicalPotentialDiagram(MSONable):
         Todd, P. K., McDermott, M. J., Rom, C. L., Corrao, A. A., Denney, J. J., Dwaraknath,
         S. S.,  Khalifah, P. G., Persson, K. A., & Neilson, J. R. (2021). Selectivity in
         Yttrium Manganese Oxide Synthesis via Local Chemical Potentials in Hyperdimensional
-        Phase Space. Journal of the American Chemical Society, 143(37), 15185–15194.
+        Phase Space. Journal of the American Chemical Society, 143(37), 15185-15194.
         https://doi.org/10.1021/jacs.1c06229
     """
 

--- a/pymatgen/analysis/functional_groups.py
+++ b/pymatgen/analysis/functional_groups.py
@@ -129,7 +129,7 @@ class FunctionalGroupExtractor:
         The conditions for marking carbon atoms are (quoted from Ertl):
             "- atoms connected by non-aromatic double or triple bond to any
             heteroatom
-            - atoms in nonaromatic carbon–carbon double or triple bonds
+            - atoms in nonaromatic carbon-carbon double or triple bonds
             - acetal carbons, i.e. sp3 carbons connected to two or more oxygens,
             nitrogens or sulfurs; these O, N or S atoms must have only single bonds
             - all atoms in oxirane, aziridine and thiirane rings"

--- a/pymatgen/analysis/interface_reactions.py
+++ b/pymatgen/analysis/interface_reactions.py
@@ -12,11 +12,11 @@ References:
 
     (1) Richards, W. D., Miara, L. J., Wang, Y., Kim, J. C., &amp; Ceder, G. (2015).
     Interface stability in solid-state batteries. Chemistry of Materials, 28(1),
-    266–273. https://doi.org/10.1021/acs.chemmater.5b04082
+    266-273. https://doi.org/10.1021/acs.chemmater.5b04082
 
     (2) Xiao, Y., Wang, Y., Bo, S.-H., Kim, J. C., Miara, L. J., &amp; Ceder, G. (2019).
     Understanding interface stability in solid-state batteries.
-    Nature Reviews Materials, 5(2), 105–126. https://doi.org/10.1038/s41578-019-0157-5
+    Nature Reviews Materials, 5(2), 105-126. https://doi.org/10.1038/s41578-019-0157-5
 
 """
 
@@ -62,11 +62,11 @@ class InterfacialReactivity(MSONable):
     References:
         Richards, W. D., Miara, L. J., Wang, Y., Kim, J. C., &amp; Ceder, G. (2015).
         Interface stability in solid-state batteries. Chemistry of Materials, 28(1),
-        266–273. https://doi.org/10.1021/acs.chemmater.5b04082
+        266-273. https://doi.org/10.1021/acs.chemmater.5b04082
 
         Xiao, Y., Wang, Y., Bo, S.-H., Kim, J. C., Miara, L. J., &amp; Ceder, G. (2019).
         Understanding interface stability in solid-state batteries.
-        Nature Reviews Materials, 5(2), 105–126.
+        Nature Reviews Materials, 5(2), 105-126.
         https://doi.org/10.1038/s41578-019-0157-5
     """
 

--- a/pymatgen/analysis/nmr.py
+++ b/pymatgen/analysis/nmr.py
@@ -29,7 +29,7 @@ class ChemicalShielding(SquareTensor):
     NMR Chemical shielding tensors
 
     Three notations to describe chemical shielding tensor (RK Harris; Magn. Reson.
-    Chem. 2008, 46, 582–598; DOI: 10.1002/mrc.2225) are supported.
+    Chem. 2008, 46, 582-598; DOI: 10.1002/mrc.2225) are supported.
 
     Authors: Shyam Dwaraknath, Xiaohui Qu
     """
@@ -102,7 +102,7 @@ class ChemicalShielding(SquareTensor):
         pas = self.principal_axis_system
         sigma_iso = pas.trace() / 3
         omega = np.diag(pas)[2] - np.diag(pas)[0]
-        # There is a typo in equation 20 from Magn. Reson. Chem. 2008, 46, 582–598, the sign is wrong.
+        # There is a typo in equation 20 from Magn. Reson. Chem. 2008, 46, 582-598, the sign is wrong.
         # There correct order is presented in Solid State Nucl. Magn. Reson. 1993, 2, 285-288.
         kappa = 3.0 * (np.diag(pas)[1] - sigma_iso) / omega
         return self.MarylandNotation(sigma_iso, omega, kappa)

--- a/pymatgen/analysis/surface_analysis.py
+++ b/pymatgen/analysis/surface_analysis.py
@@ -14,7 +14,7 @@ consider citing the following works::
 
     Kang, S., Mo, Y., Ong, S. P., & Ceder, G. (2014). Nanoscale
     stabilization of sodium oxides: Implications for Na-O2 batteries.
-    Nano Letters, 14(2), 1016–1020. https://doi.org/10.1021/nl404557w
+    Nano Letters, 14(2), 1016-1020. https://doi.org/10.1021/nl404557w
 
     and
 
@@ -1728,7 +1728,7 @@ class NanoscaleStability:
 
         Kang, S., Mo, Y., Ong, S. P., & Ceder, G. (2014). Nanoscale
             stabilization of sodium oxides: Implications for Na-O2
-            batteries. Nano Letters, 14(2), 1016–1020.
+            batteries. Nano Letters, 14(2), 1016-1020.
             https://doi.org/10.1021/nl404557w
 
     .. attribute:: se_analyzers

--- a/pymatgen/analysis/xps.py
+++ b/pymatgen/analysis/xps.py
@@ -11,7 +11,7 @@ You may wish to look at the optional dependency galore for more functionality su
 Note that the atomic_subshell_photoionization_cross_sections.csv has been reparsed from the original compilation::
 
     Yeh, J. J.; Lindau, I. Atomic Subshell Photoionization Cross Sections and Asymmetry Parameters: 1 ⩽ Z ⩽ 103.
-    Atomic Data and Nuclear Data Tables 1985, 32 (1), 1–155. https://doi.org/10.1016/0092-640X(85)90016-6.
+    Atomic Data and Nuclear Data Tables 1985, 32 (1), 1-155. https://doi.org/10.1016/0092-640X(85)90016-6.
 
 This version contains all detailed information for all orbitals.
 """

--- a/pymatgen/command_line/critic2_caller.py
+++ b/pymatgen/command_line/critic2_caller.py
@@ -33,7 +33,7 @@ Comput. Phys. Commun. 185, 1007-1018 (2014)
 (https://doi.org/10.1016/j.cpc.2013.10.026)
 
 A. Otero-de-la-Roza, M. A. Blanco, A. Martín Pendás and
-V. Luaña, Comput. Phys. Commun. 180, 157–166 (2009)
+V. Luaña, Comput. Phys. Commun. 180, 157-166 (2009)
 (https://doi.org/10.1016/j.cpc.2008.07.018)
 """
 

--- a/pymatgen/core/surface.py
+++ b/pymatgen/core/surface.py
@@ -13,7 +13,7 @@ citing the following work::
 as well as::
 
     Sun, W.; Ceder, G. Efficient creation and convergence of surface slabs,
-    Surface Science, 2013, 617, 53–59, doi:10.1016/j.susc.2013.05.016.
+    Surface Science, 2013, 617, 53-59, doi:10.1016/j.susc.2013.05.016.
 """
 
 import copy
@@ -1422,7 +1422,7 @@ class ReconstructionGenerator:
 
                         Wood, E. A. (1964). Vocabulary of surface
                         crystallography. Journal of Applied Physics, 35(4),
-                        1306–1312.
+                        1306-1312.
 
                     "transformation_matrix" (numpy array): A 3x3 matrix to
                         transform the slab. Only the a and b lattice vectors

--- a/pymatgen/electronic_structure/boltztrap.py
+++ b/pymatgen/electronic_structure/boltztrap.py
@@ -1305,7 +1305,7 @@ class BoltztrapAnalyzer:
         X. (2014).
         How Does Chemistry Influence Electron Effective Mass in Oxides?
         A High-Throughput Computational Analysis. Chemistry of Materials,
-        26(19), 5447–5458. doi:10.1021/cm404079a
+        26(19), 5447-5458. doi:10.1021/cm404079a
 
         or
 

--- a/pymatgen/entries/compatibility.py
+++ b/pymatgen/entries/compatibility.py
@@ -871,7 +871,7 @@ class MaterialsProject2020Compatibility(Compatibility):
                 https://doi.org/10.1038/s41598-021-94550-5
 
             Jain, A. et al. Formation enthalpies by mixing GGA and GGA + U calculations.
-                Phys. Rev. B - Condens. Matter Mater. Phys. 84, 1–10 (2011).
+                Phys. Rev. B - Condens. Matter Mater. Phys. 84, 1-10 (2011).
         """
         if compat_type not in ["GGA", "Advanced"]:
             raise CompatibilityError(f"Invalid compat_type {compat_type}")
@@ -1198,7 +1198,7 @@ class MaterialsProjectAqueousCompatibility(Compatibility):
         K.A. Persson, B. Waldwick, P. Lazic, G. Ceder, Prediction of solid-aqueous
         equilibria: Scheme to combine first-principles calculations of solids with
         experimental aqueous states, Phys. Rev. B - Condens. Matter Mater. Phys.
-        85 (2012) 1–12. doi:10.1103/PhysRevB.85.235438.
+        85 (2012) 1-12. doi:10.1103/PhysRevB.85.235438.
     """
 
     def __init__(

--- a/pymatgen/ext/cod.py
+++ b/pymatgen/ext/cod.py
@@ -22,7 +22,7 @@ stipulated by the COD developers)::
 
     Grazulis, S., Chateigner, D., Downs, R. T., Yokochi, A. T., Quiros, M.,
     Lutterotti, L., Manakova, E., Butkus, J., Moeck, P. & Le Bail, A. (2009)
-    "Crystallography Open Database – an open-access collection of crystal
+    "Crystallography Open Database - an open-access collection of crystal
     structures". J. Appl. Cryst. 42, 726-729.
 
     Downs, R. T. & Hall-Wallace, M. (2003) "The American Mineralogist Crystal

--- a/pymatgen/ext/matproj.py
+++ b/pymatgen/ext/matproj.py
@@ -1407,7 +1407,7 @@ class MPRester:
 
         Tran, R., Xu, Z., Radhakrishnan, B., Winston, D., Sun, W., Persson, K.
         A., & Ong, S. P. (2016). Data Descripter: Surface energies of elemental
-        crystals. Scientific Data, 3(160080), 1–13.
+        crystals. Scientific Data, 3(160080), 1-13.
         https://doi.org/10.1038/sdata.2016.80
 
         Args:

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -952,7 +952,7 @@ class MPScanRelaxSet(DictSet):
         References:
             [1] P. Wisesa, K.A. McGill, T. Mueller, Efficient generation of
             generalized Monkhorst-Pack grids through the use of informatics,
-            Phys. Rev. B. 93 (2016) 1–10. doi:10.1103/PhysRevB.93.155109.
+            Phys. Rev. B. 93 (2016) 1-10. doi:10.1103/PhysRevB.93.155109.
         """
         super().__init__(structure, MPScanRelaxSet.CONFIG, **kwargs)
         self.bandgap = bandgap

--- a/pymatgen/symmetry/kpath.py
+++ b/pymatgen/symmetry/kpath.py
@@ -934,17 +934,13 @@ class KPathSetyawanCurtarolo(KPathBase):
 
 class KPathSeek(KPathBase):
     """
-    This class looks for a path along high-symmetry lines in
-    the Brillouin sone.
-    It is based on Hinuma, Y., Pizzi, G., Kumagai, Y., Oba, F.,
-    & Tanaka, I. (2017). Band structure diagram paths based on
-    crystallography. Computational Materials Science, 128, 140–184.
-    https://doi.org/10.1016/j.commatsci.2016.10.015
-    It should be used with primitive structures that
-    comply with the definition given in the paper.
-    The symmetry is determined by spglib using the
-    SpacegroupAnalyzer class. k-points are generated using the
-        get_kpoints() method for the reciprocal cell basis defined in the paper.
+    This class looks for a path along high-symmetry lines in the Brillouin zone. It is based on
+    Hinuma, Y., Pizzi, G., Kumagai, Y., Oba, F., & Tanaka, I. (2017). Band structure diagram paths
+    based on crystallography. Computational Materials Science, 128, 140-184.
+    https://doi.org/10.1016/j.commatsci.2016.10.015. It should be used with primitive structures that
+    comply with the definition given in the paper. The symmetry is determined by spglib using the
+    SpacegroupAnalyzer class. k-points are generated using the get_kpoints() method for the
+    reciprocal cell basis defined in the paper.
     """
 
     @requires(

--- a/pymatgen/symmetry/settings.py
+++ b/pymatgen/symmetry/settings.py
@@ -55,7 +55,7 @@ class JonesFaithfulTransformation:
         between magnetic and non-magnetic settings.
 
         See: International Tables for Crystallography (2016). Vol. A,
-        Chapter 1.5, pp. 75–106.
+        Chapter 1.5, pp. 75-106.
         """
         # using capital letters in violation of PEP8 to
         # be consistent with variables in supplied reference,


### PR DESCRIPTION
Also replaces unicode character U+2013 "–" with regular minus sign U+002d "-" as the latter is more commonly used in source code.