### PR TITLE
Structure __eq__ bugfix

### DIFF
--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -1052,7 +1052,7 @@ class IStructure(SiteCollection, MSONable):
             return False
         if len(self) != len(other):
             return False
-        if not hasattr(other, 'lattice'):
+        if not hasattr(other, "lattice"):
             return False
         if self.lattice != other.lattice:
             return False

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -1052,6 +1052,8 @@ class IStructure(SiteCollection, MSONable):
             return False
         if len(self) != len(other):
             return False
+        if not hasattr(other, 'lattice'):
+            return False
         if self.lattice != other.lattice:
             return False
         for site in self:


### PR DESCRIPTION
Ran into an obscure bug where `other` was a length-18 string and `self` was a structure with 18 atoms

## Summary

Include a summary of major changes in bullet points:

* Check that the structure being compared against has a lattice parameter before trying to access the lattice parameter.

## Additional dependencies introduced (if any)

* None

## TODO (if any)

None

## Checklist

Work-in-progress pull requests are encouraged, but please put [WIP]
in the pull request title.

Before a pull request can be merged, the following items must be checked:

- [ X] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). The easiest way to handle this
      is to run the following in the **correct sequence** on your local machine. Start with running
      [black](https://black.readthedocs.io/en/stable/index.html) on your new code. This will automatically reformat
      your code to PEP8 conventions and removes most issues. Then run
      [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/), followed by
      [flake8](http://flake8.pycqa.org/en/latest/).
- [ ] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [ ] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) to type check your code.
- [ ] Tests have been added for any new functionality or bug fixes.
- [ ] All linting and tests pass.

Note that the CI system will run all the above checks. But it will be much more efficient if you already fix most
errors prior to submitting the PR. It is highly recommended that you use the pre-commit hook provided in the pymatgen
repository. Simply `cp pre-commit .git/hooks` and a check will be run prior to allowing commits.
