### PR TITLE
Added 'get_ir_reciprocal_mesh_map'-method

### DIFF
--- a/pymatgen/symmetry/analyzer.py
+++ b/pymatgen/symmetry/analyzer.py
@@ -386,6 +386,30 @@ class SpacegroupAnalyzer:
         for i, count in zip(*np.unique(mapping, return_counts=True)):
             results.append(((grid[i] + shift * (0.5, 0.5, 0.5)) / mesh, count))
         return results
+       
+    def get_ir_reciprocal_mesh_map(self, mesh=(10, 10, 10), is_shift=(0, 0, 0)):
+        """
+        Same as 'get_ir_reciprocal_mesh' but the full grid together with
+        the mapping that maps a reducible to an irreducible kpoint is
+        returned.
+
+        Args:
+            mesh (3x1 array): The number of kpoint for the mesh needed in
+                each direction
+            is_shift (3x1 array): Whether to shift the kpoint grid. (1, 1,
+            1) means all points are shifted by 0.5, 0.5, 0.5.
+
+        Returns:
+            A tuple containing two numpy.ndarray. The first is the mesh in
+            fractional coordinates and the second is an array of integers 
+            that maps all the reducible kpoints from to irreducible ones.
+        """
+        shift = np.array([1 if i else 0 for i in is_shift])
+        mapping, grid = spglib.get_ir_reciprocal_mesh(np.array(mesh), self._cell, is_shift=shift, symprec=self._symprec)
+
+        grid_fractional_coords = grid / shift * (0.5, 0.5, 0.5)) / mesh
+       
+        return grid_fractional_coords, mapping
 
     def get_conventional_to_primitive_transformation_matrix(self, international_monoclinic=True):
         """

--- a/pymatgen/symmetry/analyzer.py
+++ b/pymatgen/symmetry/analyzer.py
@@ -386,7 +386,7 @@ class SpacegroupAnalyzer:
         for i, count in zip(*np.unique(mapping, return_counts=True)):
             results.append(((grid[i] + shift * (0.5, 0.5, 0.5)) / mesh, count))
         return results
-       
+
     def get_ir_reciprocal_mesh_map(self, mesh=(10, 10, 10), is_shift=(0, 0, 0)):
         """
         Same as 'get_ir_reciprocal_mesh' but the full grid together with
@@ -401,14 +401,14 @@ class SpacegroupAnalyzer:
 
         Returns:
             A tuple containing two numpy.ndarray. The first is the mesh in
-            fractional coordinates and the second is an array of integers 
+            fractional coordinates and the second is an array of integers
             that maps all the reducible kpoints from to irreducible ones.
         """
         shift = np.array([1 if i else 0 for i in is_shift])
         mapping, grid = spglib.get_ir_reciprocal_mesh(np.array(mesh), self._cell, is_shift=shift, symprec=self._symprec)
 
         grid_fractional_coords = grid / shift * (0.5, 0.5, 0.5)) / mesh
-       
+
         return grid_fractional_coords, mapping
 
     def get_conventional_to_primitive_transformation_matrix(self, international_monoclinic=True):

--- a/pymatgen/symmetry/analyzer.py
+++ b/pymatgen/symmetry/analyzer.py
@@ -407,7 +407,7 @@ class SpacegroupAnalyzer:
         shift = np.array([1 if i else 0 for i in is_shift])
         mapping, grid = spglib.get_ir_reciprocal_mesh(np.array(mesh), self._cell, is_shift=shift, symprec=self._symprec)
 
-        grid_fractional_coords = grid / shift * (0.5, 0.5, 0.5)) / mesh
+        grid_fractional_coords = (grid + shift * (0.5, 0.5, 0.5)) / mesh
 
         return grid_fractional_coords, mapping
 

--- a/pymatgen/symmetry/tests/test_analyzer.py
+++ b/pymatgen/symmetry/tests/test_analyzer.py
@@ -214,7 +214,7 @@ class SpacegroupAnalyzerTest(PymatgenTest):
         self.assertAlmostEqual(grid[1][0][1], 0.0)
         self.assertAlmostEqual(grid[1][0][2], 0.0)
         self.assertAlmostEqual(grid[1][1], 2)
-        
+
     def test_get_ir_reciprocal_mesh_map(self):
         mesh = (6, 6, 6)
         grid = self.sg.get_ir_reciprocal_mesh(mesh=mesh)

--- a/pymatgen/symmetry/tests/test_analyzer.py
+++ b/pymatgen/symmetry/tests/test_analyzer.py
@@ -218,7 +218,7 @@ class SpacegroupAnalyzerTest(PymatgenTest):
     def test_get_ir_reciprocal_mesh_map(self):
         mesh = (6, 6, 6)
         grid = self.sg.get_ir_reciprocal_mesh(mesh=mesh)
-        full_grid, mapping = self.sg.get_ir_reciprocal_mesh(mesh=mesh)
+        full_grid, mapping = self.sg.get_ir_reciprocal_mesh_map(mesh=mesh)
         self.assertEqual(len(np.unique(mapping)), len(grid))
         for i in np.unique(mapping):
             self.assertAlmostequal(full_grid[i][0], grid[i][0][0]

--- a/pymatgen/symmetry/tests/test_analyzer.py
+++ b/pymatgen/symmetry/tests/test_analyzer.py
@@ -220,10 +220,10 @@ class SpacegroupAnalyzerTest(PymatgenTest):
         grid = self.sg.get_ir_reciprocal_mesh(mesh=mesh)
         full_grid, mapping = self.sg.get_ir_reciprocal_mesh_map(mesh=mesh)
         self.assertEqual(len(np.unique(mapping)), len(grid))
-        for i in np.unique(mapping):
-            self.assertAlmostequal(full_grid[i][0], grid[i][0][0]
-            self.assertAlmostequal(full_grid[i][1], grid[i][0][1]
-            self.assertAlmostequal(full_grid[i][2], grid[i][0][2]
+        for _, i in enumerate(np.unique(mapping)):
+            self.assertAlmostequal(full_grid[i][0], grid[_][0][0]
+            self.assertAlmostequal(full_grid[i][1], grid[_][0][1]
+            self.assertAlmostequal(full_grid[i][2], grid[_][0][2]
 
     def test_get_conventional_standard_structure(self):
         parser = CifParser(os.path.join(PymatgenTest.TEST_FILES_DIR, "bcc_1927.cif"))

--- a/pymatgen/symmetry/tests/test_analyzer.py
+++ b/pymatgen/symmetry/tests/test_analyzer.py
@@ -214,6 +214,16 @@ class SpacegroupAnalyzerTest(PymatgenTest):
         self.assertAlmostEqual(grid[1][0][1], 0.0)
         self.assertAlmostEqual(grid[1][0][2], 0.0)
         self.assertAlmostEqual(grid[1][1], 2)
+        
+    def test_get_ir_reciprocal_mesh_map(self):
+        mesh = (6, 6, 6)
+        grid = self.sg.get_ir_reciprocal_mesh(mesh=mesh)
+        full_grid, mapping = self.sg.get_ir_reciprocal_mesh(mesh=mesh)
+        self.assertEqual(len(np.unique(mapping)), len(grid))
+        for i in np.unique(mapping):
+            self.assertAlmostequal(full_grid[i][0], grid[i][0][0]
+            self.assertAlmostequal(full_grid[i][1], grid[i][0][1]
+            self.assertAlmostequal(full_grid[i][2], grid[i][0][2]
 
     def test_get_conventional_standard_structure(self):
         parser = CifParser(os.path.join(PymatgenTest.TEST_FILES_DIR, "bcc_1927.cif"))

--- a/pymatgen/symmetry/tests/test_analyzer.py
+++ b/pymatgen/symmetry/tests/test_analyzer.py
@@ -221,9 +221,9 @@ class SpacegroupAnalyzerTest(PymatgenTest):
         full_grid, mapping = self.sg.get_ir_reciprocal_mesh_map(mesh=mesh)
         self.assertEqual(len(np.unique(mapping)), len(grid))
         for _, i in enumerate(np.unique(mapping)):
-            self.assertAlmostequal(full_grid[i][0], grid[_][0][0]
-            self.assertAlmostequal(full_grid[i][1], grid[_][0][1]
-            self.assertAlmostequal(full_grid[i][2], grid[_][0][2]
+            self.assertAlmostEqual(full_grid[i][0], grid[_][0][0]
+            self.assertAlmostEqual(full_grid[i][1], grid[_][0][1]
+            self.assertAlmostEqual(full_grid[i][2], grid[_][0][2]
 
     def test_get_conventional_standard_structure(self):
         parser = CifParser(os.path.join(PymatgenTest.TEST_FILES_DIR, "bcc_1927.cif"))

--- a/pymatgen/symmetry/tests/test_analyzer.py
+++ b/pymatgen/symmetry/tests/test_analyzer.py
@@ -221,9 +221,9 @@ class SpacegroupAnalyzerTest(PymatgenTest):
         full_grid, mapping = self.sg.get_ir_reciprocal_mesh_map(mesh=mesh)
         self.assertEqual(len(np.unique(mapping)), len(grid))
         for _, i in enumerate(np.unique(mapping)):
-            self.assertAlmostEqual(full_grid[i][0], grid[_][0][0]
-            self.assertAlmostEqual(full_grid[i][1], grid[_][0][1]
-            self.assertAlmostEqual(full_grid[i][2], grid[_][0][2]
+            self.assertAlmostEqual(full_grid[i][0], grid[_][0][0])
+            self.assertAlmostEqual(full_grid[i][1], grid[_][0][1])
+            self.assertAlmostEqual(full_grid[i][2], grid[_][0][2])
 
     def test_get_conventional_standard_structure(self):
         parser = CifParser(os.path.join(PymatgenTest.TEST_FILES_DIR, "bcc_1927.cif"))


### PR DESCRIPTION
## Summary

In physical simulations it is often desirable to make use of the lattice symmetries to save computational time. The 'get_ir_reciprocal_mesh' function (which is basically an interface to spglib) returns an irreducible mesh and the weight, which just tells how many other kpoints a given irreducible kpoint is mapped to. 

This function does the same, but instead of returning the irreducible kpoints and their weights it returns the full grid and the mapping that is used to generate the irreducible grid. This is useful if physical objects are calculated that do not include a summation over all kpoints, because in that case the weight of an irreducible kpoint is not enough and the mapping is needed to relate any kpoint to the irreducible mesh. 


## TODO (if any)

It would be nice if that function could also return a list of symmetry operations that show which symmetry maps a given k-point to its irreducible counterpart. This would be very useful if the properties calculated do not transform as scalars. 


## Checklist
Implemented a test that compares to the already tested 'get_ir_reciprocal_mesh'-method.
