### PR TITLE
Correct doc description of electron affinity

### DIFF
--- a/pymatgen/core/periodic_table.py
+++ b/pymatgen/core/periodic_table.py
@@ -324,7 +324,7 @@ class ElementBase(Enum):
     @property
     def electron_affinity(self) -> float:
         """
-        First ionization energy of element.
+        The amount of energy released when an electron is attached to a neutral atom.
         """
         return self._data["Electron affinity"]
 


### PR DESCRIPTION
The electron affinity description is  duplicate with ionization energy. Updated the definition according to wiki (https://en.wikipedia.org/wiki/Electron_affinity).
