### PR TITLE
unittest2pytest pymatgen/core/tests --write --nobackups

### DIFF
--- a/pymatgen/analysis/structure_matcher.py
+++ b/pymatgen/analysis/structure_matcher.py
@@ -456,7 +456,7 @@ class StructureMatcher(MSONable):
         """
         Computes all supercells of one structure close to the lattice of the
         other
-        if s1_supercell == True, it makes the supercells of struct1, otherwise
+        if s1_supercell is True, it makes the supercells of struct1, otherwise
         it makes them of s2
 
         yields: s1, s2, supercell_matrix, average_lattice, supercell_matrix

--- a/pymatgen/core/tests/test_bonds.py
+++ b/pymatgen/core/tests/test_bonds.py
@@ -5,6 +5,8 @@
 import unittest
 import warnings
 
+import pytest
+
 from pymatgen.core.bonds import (
     CovalentBond,
     get_bond_length,
@@ -32,62 +34,65 @@ class CovalentBondTest(unittest.TestCase):
     def test_length(self):
         site1 = Site("C", [0, 0, 0])
         site2 = Site("H", [0, 0.7, 0.6])
-        self.assertAlmostEqual(CovalentBond(site1, site2).length, 0.92195444572928864)
+        assert pytest.approx(CovalentBond(site1, site2).length - 0.92195444572928864) == 0
 
     def test_get_bond_order(self):
         site1 = Site("C", [0, 0, 0])
         site2 = Site("H", [0, 0, 1.08])
-        self.assertAlmostEqual(CovalentBond(site1, site2).get_bond_order(), 1)
+        assert pytest.approx(CovalentBond(site1, site2).get_bond_order() - 1) == 0
         bond = CovalentBond(Site("C", [0, 0, 0]), Site("Br", [0, 0, 2]))
-        self.assertAlmostEqual(bond.get_bond_order(0.5, 1.9), 0.894736842105263)
+        assert pytest.approx(bond.get_bond_order(0.5, 1.9) - 0.894736842105263) == 0
 
     def test_is_bonded(self):
         site1 = Site("C", [0, 0, 0])
         site2 = Site("H", [0, 0, 1])
-        self.assertTrue(CovalentBond.is_bonded(site1, site2))
+        assert CovalentBond.is_bonded(site1, site2)
         site2 = Site("H", [0, 0, 1.5])
-        self.assertFalse(CovalentBond.is_bonded(site1, site2))
+        assert not CovalentBond.is_bonded(site1, site2)
         site1 = Site("U", [0, 0, 0])
-        self.assertRaises(ValueError, CovalentBond.is_bonded, site1, site2)
-        self.assertTrue(CovalentBond.is_bonded(site1, site2, default_bl=2))
+        with pytest.raises(ValueError):
+            CovalentBond.is_bonded(site1, site2)
+        assert CovalentBond.is_bonded(site1, site2, default_bl=2)
 
     def test_str(self):
         site1 = Site("C", [0, 0, 0])
         site2 = Site("H", [0, 0.7, 0.6])
-        self.assertIsNotNone(CovalentBond(site1, site2))
+        assert CovalentBond(site1, site2) is not None
 
 
 class FuncTest(unittest.TestCase):
     def test_get_bond_length(self):
-        self.assertAlmostEqual(get_bond_length("C", "C", 1), 1.54)
-        self.assertAlmostEqual(get_bond_length("C", "C", 2), 1.34)
-        self.assertAlmostEqual(get_bond_length("C", "H", 1), 1.08)
-        self.assertEqual(get_bond_length("C", "H", 2), 0.95)
-        self.assertAlmostEqual(get_bond_length("C", "Br", 1), 1.85)
+        assert pytest.approx(get_bond_length("C", "C", 1) - 1.54) == 0
+        assert pytest.approx(get_bond_length("C", "C", 2) - 1.34) == 0
+        assert pytest.approx(get_bond_length("C", "H", 1) - 1.08) == 0
+        assert get_bond_length("C", "H", 2) == 0.95
+        assert pytest.approx(get_bond_length("C", "Br", 1) - 1.85) == 0
 
     def test_obtain_all_bond_lengths(self):
-        self.assertDictEqual(obtain_all_bond_lengths("C", "C"), {1.0: 1.54, 2.0: 1.34, 3.0: 1.2})
-        self.assertRaises(ValueError, obtain_all_bond_lengths, "Br", Element("C"))
-        self.assertDictEqual(obtain_all_bond_lengths("C", Element("Br"), 1.76), {1: 1.76})
+        assert obtain_all_bond_lengths("C", "C") == {1.0: 1.54, 2.0: 1.34, 3.0: 1.2}
+        with pytest.raises(ValueError):
+            obtain_all_bond_lengths("Br", Element("C"))
+        assert obtain_all_bond_lengths("C", Element("Br"), 1.76) == {1: 1.76}
         bond_lengths_dict = obtain_all_bond_lengths("C", "N")
         bond_lengths_dict[4] = 999
-        self.assertDictEqual(obtain_all_bond_lengths("C", "N"), {1.0: 1.47, 2.0: 1.3, 3.0: 1.16})
+        assert obtain_all_bond_lengths("C", "N") == {1.0: 1.47, 2.0: 1.3, 3.0: 1.16}
 
     def test_get_bond_order(self):
-        self.assertAlmostEqual(get_bond_order("C", "C", 1), 3)
-        self.assertAlmostEqual(get_bond_order("C", "C", 1.2), 3)
-        self.assertAlmostEqual(get_bond_order("C", "C", 1.25), 2.642857142857143)
-        self.assertAlmostEqual(get_bond_order("C", "C", 1.34), 2)
-        self.assertAlmostEqual(get_bond_order("C", "C", 1.4), 1.7)  # bond length in benzene
-        self.assertAlmostEqual(get_bond_order("C", "C", 1.54), 1)
-        self.assertAlmostEqual(get_bond_order("C", "C", 2.5), 0)
-        self.assertAlmostEqual(get_bond_order("C", "C", 9999), 0)
-        self.assertAlmostEqual(get_bond_order("C", "Br", 1.9, default_bl=1.9), 1)
-        self.assertAlmostEqual(get_bond_order("C", "Br", 2, default_bl=1.9), 0.7368421052631575)
-        self.assertAlmostEqual(get_bond_order("C", "Br", 1.9, tol=0.5, default_bl=1.9), 1)
-        self.assertAlmostEqual(get_bond_order("C", "Br", 2, tol=0.5, default_bl=1.9), 0.894736842105263)
-        self.assertRaises(ValueError, get_bond_order, "C", "Br", 1.9)
-        self.assertAlmostEqual(get_bond_order("N", "N", 1.25), 2)
+        assert pytest.approx(get_bond_order("C", "C", 1) - 3) == 0
+        assert pytest.approx(get_bond_order("C", "C", 1.2) - 3) == 0
+        assert pytest.approx(get_bond_order("C", "C", 1.25) - 2.642857142857143) == 0
+        assert pytest.approx(get_bond_order("C", "C", 1.34) - 2) == 0
+        assert pytest.approx(get_bond_order("C", "C", 1.4) - 1.7) == 0  # bond length in benzene
+        assert pytest.approx(get_bond_order("C", "C", 1.54) - 1) == 0
+        assert pytest.approx(get_bond_order("C", "C", 2.5) - 0) == 0
+        assert pytest.approx(get_bond_order("C", "C", 9999) - 0) == 0
+        assert pytest.approx(get_bond_order("C", "Br", 1.9, default_bl=1.9) - 1) == 0
+        assert pytest.approx(get_bond_order("C", "Br", 2, default_bl=1.9) - 0.7368421052631575) == 0
+        assert pytest.approx(get_bond_order("C", "Br", 1.9, tol=0.5, default_bl=1.9) - 1) == 0
+        assert pytest.approx(get_bond_order("C", "Br", 2, tol=0.5, default_bl=1.9) - 0.894736842105263) == 0
+        with pytest.raises(ValueError):
+            get_bond_order("C", "Br", 1.9)
+        assert pytest.approx(get_bond_order("N", "N", 1.25) - 2) == 0
 
 
 if __name__ == "__main__":

--- a/pymatgen/core/tests/test_composition.py
+++ b/pymatgen/core/tests/test_composition.py
@@ -9,6 +9,8 @@ Created on Nov 10, 2012
 import random
 import unittest
 
+import pytest
+
 from pymatgen.core.composition import ChemicalPotential, Composition
 from pymatgen.core.periodic_table import Element, Species
 from pymatgen.util.testing import PymatgenTest
@@ -42,40 +44,44 @@ class CompositionTest(PymatgenTest):
         try:
             self.comp[0]["Fe"] = 1
         except Exception as ex:
-            self.assertIsInstance(ex, TypeError)
+            assert isinstance(ex, TypeError)
 
         try:
             del self.comp[0]["Fe"]
         except Exception as ex:
-            self.assertIsInstance(ex, TypeError)
+            assert isinstance(ex, TypeError)
 
     def test_in(self):
-        self.assertIn("Fe", self.comp[0])
-        self.assertNotIn("Fe", self.comp[2])
-        self.assertIn(Element("Fe"), self.comp[0])
-        self.assertEqual(self.comp[0]["Fe"], 2)
-        self.assertEqual(self.comp[0]["Mn"], 0)
-        self.assertRaises(TypeError, self.comp[0].__getitem__, "Hello")
-        self.assertRaises(TypeError, self.comp[0].__getitem__, "Vac")
+        assert "Fe" in self.comp[0]
+        assert "Fe" not in self.comp[2]
+        assert Element("Fe") in self.comp[0]
+        assert self.comp[0]["Fe"] == 2
+        assert self.comp[0]["Mn"] == 0
+        with pytest.raises(TypeError):
+            self.comp[0]["Hello"]
+        with pytest.raises(TypeError):
+            self.comp[0]["Vac"]
 
     def test_hill_formula(self):
         c = Composition("CaCO3")
-        self.assertEqual(c.hill_formula, "C Ca O3")
+        assert c.hill_formula == "C Ca O3"
         c = Composition("C2H5OH")
-        self.assertEqual(c.hill_formula, "C2 H6 O")
+        assert c.hill_formula == "C2 H6 O"
 
     def test_init_(self):
-        self.assertRaises(ValueError, Composition, {"H": -0.1})
+        with pytest.raises(ValueError):
+            Composition({"H": -0.1})
         f = {"Fe": 4, "Li": 4, "O": 16, "P": 4}
-        self.assertEqual("Li4 Fe4 P4 O16", Composition(f).formula)
+        assert "Li4 Fe4 P4 O16" == Composition(f).formula
         f = {None: 4, "Li": 4, "O": 16, "P": 4}
-        self.assertRaises(TypeError, Composition, f)
+        with pytest.raises(TypeError):
+            Composition(f)
         f = {1: 2, 8: 1}
-        self.assertEqual("H2 O1", Composition(f).formula)
-        self.assertEqual("Na2 O1", Composition(Na=2, O=1).formula)
+        assert "H2 O1" == Composition(f).formula
+        assert "Na2 O1" == Composition(Na=2, O=1).formula
 
         c = Composition({"S": Composition.amount_tolerance / 2})
-        self.assertEqual(len(c.elements), 0)
+        assert len(c.elements) == 0
 
     def test_average_electroneg(self):
         val = [
@@ -89,13 +95,13 @@ class CompositionTest(PymatgenTest):
             2.43,
         ]
         for i, c in enumerate(self.comp):
-            self.assertAlmostEqual(c.average_electroneg, val[i])
+            assert round(abs(c.average_electroneg - val[i]), 7) == 0
 
     def test_total_electrons(self):
         test_cases = {"C": 6, "SrTiO3": 84}
         for key, val in test_cases.items():
             c = Composition(key)
-            self.assertAlmostEqual(c.total_electrons, val)
+            assert round(abs(c.total_electrons - val), 7) == 0
 
     def test_formula(self):
         correct_formulas = [
@@ -109,19 +115,20 @@ class CompositionTest(PymatgenTest):
             "Zn1 H1 O1",
         ]
         all_formulas = [c.formula for c in self.comp]
-        self.assertEqual(all_formulas, correct_formulas)
-        self.assertRaises(ValueError, Composition, "(co2)(po4)2")
+        assert all_formulas == correct_formulas
+        with pytest.raises(ValueError):
+            Composition("(co2)(po4)2")
 
-        self.assertEqual(Composition("K Na 2").reduced_formula, "KNa2")
+        assert Composition("K Na 2").reduced_formula == "KNa2"
 
-        self.assertEqual(Composition("K3 Na 2").reduced_formula, "K3Na2")
+        assert Composition("K3 Na 2").reduced_formula == "K3Na2"
 
-        self.assertEqual(Composition("Na 3 Zr (PO 4) 3").reduced_formula, "Na3Zr(PO4)3")
+        assert Composition("Na 3 Zr (PO 4) 3").reduced_formula == "Na3Zr(PO4)3"
 
     def test_to_latex_html_unicode(self):
-        self.assertEqual(self.comp[0].to_latex_string(), "Li$_{3}$Fe$_{2}$P$_{3}$O$_{12}$")
-        self.assertEqual(self.comp[0].to_html_string(), "Li<sub>3</sub>Fe<sub>2</sub>P<sub>3</sub>O<sub>12</sub>")
-        self.assertEqual(self.comp[0].to_unicode_string(), "Li₃Fe₂P₃O₁₂")
+        assert self.comp[0].to_latex_string() == "Li$_{3}$Fe$_{2}$P$_{3}$O$_{12}$"
+        assert self.comp[0].to_html_string() == "Li<sub>3</sub>Fe<sub>2</sub>P<sub>3</sub>O<sub>12</sub>"
+        assert self.comp[0].to_unicode_string() == "Li₃Fe₂P₃O₁₂"
 
     def test_iupac_formula(self):
         correct_formulas = [
@@ -135,13 +142,13 @@ class CompositionTest(PymatgenTest):
             "Zn1 H1 O1",
         ]
         all_formulas = [c.iupac_formula for c in self.comp]
-        self.assertEqual(all_formulas, correct_formulas)
+        assert all_formulas == correct_formulas
 
     def test_mixed_valence(self):
         comp = Composition({"Fe2+": 2, "Fe3+": 4, "Li+": 8})
-        self.assertEqual(comp.reduced_formula, "Li4Fe3")
-        self.assertEqual(comp.alphabetical_formula, "Fe6 Li8")
-        self.assertEqual(comp.formula, "Li8 Fe6")
+        assert comp.reduced_formula == "Li4Fe3"
+        assert comp.alphabetical_formula == "Fe6 Li8"
+        assert comp.formula == "Li8 Fe6"
 
     def test_indeterminate_formula(self):
         correct_formulas = [
@@ -160,7 +167,7 @@ class CompositionTest(PymatgenTest):
             [],
         ]
         for i, c in enumerate(correct_formulas):
-            self.assertEqual([Composition(comp) for comp in c], self.indeterminate_comp[i])
+            assert [Composition(comp) for comp in c] == self.indeterminate_comp[i]
 
     def test_alphabetical_formula(self):
         correct_formulas = [
@@ -174,7 +181,7 @@ class CompositionTest(PymatgenTest):
             "H1 O1 Zn1",
         ]
         all_formulas = [c.alphabetical_formula for c in self.comp]
-        self.assertEqual(all_formulas, correct_formulas)
+        assert all_formulas == correct_formulas
 
     def test_reduced_composition(self):
         correct_reduced_formulas = [
@@ -188,10 +195,7 @@ class CompositionTest(PymatgenTest):
             "ZnHO",
         ]
         for idx, comp in enumerate(self.comp):
-            self.assertEqual(
-                comp.get_reduced_composition_and_factor()[0],
-                Composition(correct_reduced_formulas[idx]),
-            )
+            assert comp.get_reduced_composition_and_factor()[0] == Composition(correct_reduced_formulas[idx])
 
     def test_reduced_formula(self):
         correct_reduced_formulas = [
@@ -205,19 +209,16 @@ class CompositionTest(PymatgenTest):
             "ZnHO",
         ]
         all_formulas = [c.reduced_formula for c in self.comp]
-        self.assertEqual(all_formulas, correct_reduced_formulas)
+        assert all_formulas == correct_reduced_formulas
 
         # test iupac reduced formula (polyanions should still appear at the end)
         all_formulas = [c.get_reduced_formula_and_factor(iupac_ordering=True)[0] for c in self.comp]
-        self.assertEqual(all_formulas, correct_reduced_formulas)
-        self.assertEqual(
-            Composition("H6CN").get_integer_formula_and_factor(iupac_ordering=True)[0],
-            "CNH6",
-        )
+        assert all_formulas == correct_reduced_formulas
+        assert Composition("H6CN").get_integer_formula_and_factor(iupac_ordering=True)[0] == "CNH6"
 
         # test rounding
         c = Composition({"Na": 2 - Composition.amount_tolerance / 2, "Cl": 2})
-        self.assertEqual("NaCl", c.reduced_formula)
+        assert "NaCl" == c.reduced_formula
 
     def test_integer_formula(self):
         correct_reduced_formulas = [
@@ -231,26 +232,23 @@ class CompositionTest(PymatgenTest):
             "ZnHO",
         ]
         all_formulas = [c.get_integer_formula_and_factor()[0] for c in self.comp]
-        self.assertEqual(all_formulas, correct_reduced_formulas)
-        self.assertEqual(Composition("Li0.5O0.25").get_integer_formula_and_factor(), ("Li2O", 0.25))
-        self.assertEqual(Composition("O0.25").get_integer_formula_and_factor(), ("O2", 0.125))
+        assert all_formulas == correct_reduced_formulas
+        assert Composition("Li0.5O0.25").get_integer_formula_and_factor() == ("Li2O", 0.25)
+        assert Composition("O0.25").get_integer_formula_and_factor() == ("O2", 0.125)
         formula, factor = Composition("Li0.16666667B1.0H1.0").get_integer_formula_and_factor()
-        self.assertEqual(formula, "Li(BH)6")
-        self.assertAlmostEqual(factor, 1 / 6)
+        assert formula == "Li(BH)6"
+        assert round(abs(factor - 1 / 6), 7) == 0
 
         # test iupac reduced formula (polyanions should still appear at the end)
         all_formulas = [c.get_integer_formula_and_factor(iupac_ordering=True)[0] for c in self.comp]
-        self.assertEqual(all_formulas, correct_reduced_formulas)
-        self.assertEqual(
-            Composition("H6CN0.5").get_integer_formula_and_factor(iupac_ordering=True),
-            ("C2NH12", 0.5),
-        )
+        assert all_formulas == correct_reduced_formulas
+        assert Composition("H6CN0.5").get_integer_formula_and_factor(iupac_ordering=True) == ("C2NH12", 0.5)
 
     def test_num_atoms(self):
         correct_num_atoms = [20, 10, 7, 8, 20, 75, 2, 3]
 
         all_natoms = [c.num_atoms for c in self.comp]
-        self.assertEqual(all_natoms, correct_num_atoms)
+        assert all_natoms == correct_num_atoms
 
     def test_weight(self):
         correct_weights = [
@@ -269,12 +267,8 @@ class CompositionTest(PymatgenTest):
     def test_get_atomic_fraction(self):
         correct_at_frac = {"Li": 0.15, "Fe": 0.1, "P": 0.15, "O": 0.6}
         for el in ["Li", "Fe", "P", "O"]:
-            self.assertEqual(
-                self.comp[0].get_atomic_fraction(el),
-                correct_at_frac[el],
-                "Wrong computed atomic fractions",
-            )
-        self.assertEqual(self.comp[0].get_atomic_fraction("S"), 0, "Wrong computed atomic fractions")
+            assert self.comp[0].get_atomic_fraction(el) == correct_at_frac[el], "Wrong computed atomic fractions"
+        assert self.comp[0].get_atomic_fraction("S") == 0, "Wrong computed atomic fractions"
 
     def test_anonymized_formula(self):
         expected_formulas = [
@@ -288,7 +282,7 @@ class CompositionTest(PymatgenTest):
             "ABC",
         ]
         for idx, comp in enumerate(self.comp):
-            self.assertEqual(comp.anonymized_formula, expected_formulas[idx])
+            assert comp.anonymized_formula == expected_formulas[idx]
 
     def test_get_wt_fraction(self):
         correct_wt_frac = {
@@ -298,40 +292,29 @@ class CompositionTest(PymatgenTest):
             "O": 0.459943320496,
         }
         for el in ["Li", "Fe", "P", "O"]:
-            self.assertAlmostEqual(
-                correct_wt_frac[el],
-                self.comp[0].get_wt_fraction(el),
-                5,
-                "Wrong computed weight fraction",
-            )
-        self.assertEqual(
-            self.comp[0].get_wt_fraction(Element("S")),
-            0,
-            "Wrong computed weight fractions",
-        )
+            assert (
+                round(abs(correct_wt_frac[el] - self.comp[0].get_wt_fraction(el)), 5) == 0
+            ), "Wrong computed weight fraction"
+        assert self.comp[0].get_wt_fraction(Element("S")) == 0, "Wrong computed weight fractions"
 
     def test_from_dict(self):
         sym_dict = {"Fe": 6, "O": 8}
-        self.assertEqual(
-            Composition.from_dict(sym_dict).reduced_formula,
-            "Fe3O4",
-            "Creation form sym_amount dictionary failed!",
-        )
+        assert Composition.from_dict(sym_dict).reduced_formula == "Fe3O4", "Creation form sym_amount dictionary failed!"
         comp = Composition({"Fe2+": 2, "Fe3+": 4, "O2-": 8})
         comp2 = Composition.from_dict(comp.as_dict())
-        self.assertEqual(comp, comp2)
+        assert comp == comp2
 
     def test_as_dict(self):
         c = Composition.from_dict({"Fe": 4, "O": 6})
         d = c.as_dict()
         correct_dict = {"Fe": 4.0, "O": 6.0}
-        self.assertEqual(d["Fe"], correct_dict["Fe"])
-        self.assertEqual(d["O"], correct_dict["O"])
+        assert d["Fe"] == correct_dict["Fe"]
+        assert d["O"] == correct_dict["O"]
         correct_dict = {"Fe": 2.0, "O": 3.0}
         d = c.to_reduced_dict
-        self.assertIsInstance(d, dict)
-        self.assertEqual(d["Fe"], correct_dict["Fe"])
-        self.assertEqual(d["O"], correct_dict["O"])
+        assert isinstance(d, dict)
+        assert d["Fe"] == correct_dict["Fe"]
+        assert d["O"] == correct_dict["O"]
 
     def test_pickle(self):
         for c in self.comp:
@@ -341,47 +324,36 @@ class CompositionTest(PymatgenTest):
     def test_to_data_dict(self):
         comp = Composition("Fe0.00009Ni0.99991")
         d = comp.to_data_dict
-        self.assertAlmostEqual(d["reduced_cell_composition"]["Fe"], 9e-5)
+        assert round(abs(d["reduced_cell_composition"]["Fe"] - 9e-5), 7) == 0
 
     def test_add(self):
-        self.assertEqual(
-            (self.comp[0] + self.comp[2]).formula,
-            "Li4 Mn2 Fe2 P3 O16",
-            "Incorrect composition after addition!",
-        )
-        self.assertEqual(
-            (self.comp[3] + {"Fe": 4, "O": 4}).formula,
-            "Li4 Fe4 O8",
-            "Incorrect composition after addition!",
-        )
+        assert (self.comp[0] + self.comp[2]).formula == "Li4 Mn2 Fe2 P3 O16", "Incorrect composition after addition!"
+        assert (self.comp[3] + {"Fe": 4, "O": 4}).formula == "Li4 Fe4 O8", "Incorrect composition after addition!"
 
         Fe = Element("Fe")
-        self.assertEqual(self.comp[0].__add__(Fe), NotImplemented)  # pylint: disable=C2801
+        assert self.comp[0].__add__(Fe) == NotImplemented  # pylint: disable=C2801
 
     def test_sub(self):
-        self.assertEqual(
-            (self.comp[0] - Composition("Li2O")).formula,
-            "Li1 Fe2 P3 O11",
-            "Incorrect composition after addition!",
-        )
-        self.assertEqual((self.comp[0] - {"Fe": 2, "O": 3}).formula, "Li3 P3 O9")
+        assert (self.comp[0] - Composition("Li2O")).formula == "Li1 Fe2 P3 O11", "Incorrect composition after addition!"
+        assert (self.comp[0] - {"Fe": 2, "O": 3}).formula == "Li3 P3 O9"
 
-        self.assertRaises(ValueError, Composition("O").__sub__, Composition("H"))
+        with pytest.raises(ValueError):
+            Composition("O") - Composition("H")
 
         # check that S is completely removed by subtraction
         c1 = Composition({"S": 1 + Composition.amount_tolerance / 2, "O": 1})
         c2 = Composition({"S": 1})
-        self.assertEqual(len((c1 - c2).elements), 1)
+        assert len((c1 - c2).elements) == 1
 
         Fe = Element("Fe")
-        self.assertEqual(self.comp[0].__add__(Fe), NotImplemented)  # pylint: disable=C2801
+        assert self.comp[0].__add__(Fe) == NotImplemented  # pylint: disable=C2801
 
     def test_mul(self):
-        self.assertEqual((self.comp[0] * 4).formula, "Li12 Fe8 P12 O48")
-        self.assertEqual((3 * self.comp[1]).formula, "Li9 Fe3 P3 O15")
+        assert (self.comp[0] * 4).formula == "Li12 Fe8 P12 O48"
+        assert (3 * self.comp[1]).formula == "Li9 Fe3 P3 O15"
 
     def test_div(self):
-        self.assertEqual((self.comp[0] / 4).formula, "Li0.75 Fe0.5 P0.75 O3")
+        assert (self.comp[0] / 4).formula == "Li0.75 Fe0.5 P0.75 O3"
 
     def test_equals(self):
         # generate randomized compositions for robustness (tests might pass for specific elements
@@ -396,25 +368,21 @@ class CompositionTest(PymatgenTest):
         while other_z == random_z:
             other_z = random.randint(1, 92)
         comp2 = Composition({fixed_el: 1, Element.from_Z(other_z): 0})
-        self.assertEqual(
-            comp1,
-            comp2,
-            f"Composition equality test failed. {comp1.formula} should be equal to {comp2.formula}",
-        )
-        self.assertEqual(hash(comp1), hash(comp2), "Hashcode equality test failed!")
+        assert comp1 == comp2, f"Composition equality test failed. {comp1.formula} should be equal to {comp2.formula}"
+        assert hash(comp1) == hash(comp2), "Hashcode equality test failed!"
 
         c1, c2 = self.comp[:2]
-        self.assertTrue(c1 == c1)
-        self.assertFalse(c1 == c2)
+        assert c1 == c1
+        assert not c1 == c2
 
     def test_hash_robustness(self):
         c1 = Composition(f"O{0.2}Fe{0.8}Na{Composition.amount_tolerance*0.99}")
         c2 = Composition(f"O{0.2}Fe{0.8}Na{Composition.amount_tolerance*1.01}")
         c3 = Composition(f"O{0.2}Fe{0.8+Composition.amount_tolerance*0.99}")
 
-        self.assertTrue(c1 == c3, "__eq__ not robust")
-        self.assertEqual(c1 == c3, hash(c1) == hash(c3), "Hash doesn't match eq when true")
-        self.assertFalse(hash(c1) == hash(c2), "Hash equal for different chemical systems")
+        assert c1 == c3, "__eq__ not robust"
+        assert (c1 == c3) == (hash(c1) == hash(c3)), "Hash doesn't match eq when true"
+        assert not hash(c1) == hash(c2), "Hash equal for different chemical systems"
 
     def test_comparisons(self):
         c1 = Composition({"S": 1})
@@ -422,79 +390,75 @@ class CompositionTest(PymatgenTest):
         c2 = Composition({"S": 2})
         c3 = Composition({"O": 1})
         c4 = Composition({"O": 1, "S": 1})
-        self.assertFalse(c1 > c2)
-        self.assertFalse(c1_1 > c1)
-        self.assertFalse(c1_1 < c1)
-        self.assertTrue(c1 > c3)
-        self.assertTrue(c3 < c1)
-        self.assertTrue(c4 > c1)
-        self.assertEqual(sorted([c1, c1_1, c2, c4, c3]), [c3, c1, c1_1, c4, c2])
+        assert not c1 > c2
+        assert not c1_1 > c1
+        assert not c1_1 < c1
+        assert c1 > c3
+        assert c3 < c1
+        assert c4 > c1
+        assert sorted([c1, c1_1, c2, c4, c3]) == [c3, c1, c1_1, c4, c2]
 
         Fe = Element("Fe")
-        self.assertFalse(c1 == Fe, NotImplemented)
-        self.assertTrue(c1 != Fe)
-        self.assertRaises(TypeError, lambda: c1 < Fe)
+        assert not c1 == Fe, NotImplemented
+        assert c1 != Fe
+        with pytest.raises(TypeError):
+            c1 < Fe  # noqa: B015
 
     def test_almost_equals(self):
         c1 = Composition({"Fe": 2.0, "O": 3.0, "Mn": 0})
         c2 = Composition({"O": 3.2, "Fe": 1.9, "Zn": 0})
         c3 = Composition({"Ag": 2.0, "O": 3.0})
         c4 = Composition({"Fe": 2.0, "O": 3.0, "Ag": 2.0})
-        self.assertTrue(c1.almost_equals(c2, rtol=0.1))
-        self.assertFalse(c1.almost_equals(c2, rtol=0.01))
-        self.assertFalse(c1.almost_equals(c3, rtol=0.1))
-        self.assertFalse(c1.almost_equals(c4, rtol=0.1))
+        assert c1.almost_equals(c2, rtol=0.1)
+        assert not c1.almost_equals(c2, rtol=0.01)
+        assert not c1.almost_equals(c3, rtol=0.1)
+        assert not c1.almost_equals(c4, rtol=0.1)
 
     def test_equality(self):
-        self.assertTrue(self.comp[0] == self.comp[0])
-        self.assertFalse(self.comp[0] == self.comp[1])
-        self.assertFalse(self.comp[0] != self.comp[0])
-        self.assertTrue(self.comp[0] != self.comp[1])
+        assert self.comp[0] == self.comp[0]
+        assert not self.comp[0] == self.comp[1]
+        assert not self.comp[0] != self.comp[0]
+        assert self.comp[0] != self.comp[1]
 
     def test_fractional_composition(self):
         for c in self.comp:
-            self.assertAlmostEqual(c.fractional_composition.num_atoms, 1)
+            assert round(abs(c.fractional_composition.num_atoms - 1), 7) == 0
 
     def test_init_numerical_tolerance(self):
-        self.assertEqual(Composition({"B": 1, "C": -1e-12}), Composition("B"))
+        assert Composition({"B": 1, "C": -1e-12}) == Composition("B")
 
     def test_negative_compositions(self):
-        self.assertEqual(Composition("Li-1(PO-1)4", allow_negative=True).formula, "Li-1 P4 O-4")
-        self.assertEqual(
-            Composition("Li-1(PO-1)4", allow_negative=True).reduced_formula,
-            "Li-1(PO-1)4",
+        assert Composition("Li-1(PO-1)4", allow_negative=True).formula == "Li-1 P4 O-4"
+        assert Composition("Li-1(PO-1)4", allow_negative=True).reduced_formula == "Li-1(PO-1)4"
+        assert Composition("Li-2Mg4", allow_negative=True).reduced_composition == Composition(
+            "Li-1Mg2", allow_negative=True
         )
-        self.assertEqual(
-            Composition("Li-2Mg4", allow_negative=True).reduced_composition,
-            Composition("Li-1Mg2", allow_negative=True),
-        )
-        self.assertEqual(
-            Composition("Li-2.5Mg4", allow_negative=True).reduced_composition,
-            Composition("Li-2.5Mg4", allow_negative=True),
+        assert Composition("Li-2.5Mg4", allow_negative=True).reduced_composition == Composition(
+            "Li-2.5Mg4", allow_negative=True
         )
 
         # test math
         c1 = Composition("LiCl", allow_negative=True)
         c2 = Composition("Li")
-        self.assertEqual(c1 - 2 * c2, Composition({"Li": -1, "Cl": 1}, allow_negative=True))
-        self.assertEqual((c1 + c2).allow_negative, True)
-        self.assertEqual(c1 / -1, Composition("Li-1Cl-1", allow_negative=True))
+        assert c1 - 2 * c2 == Composition({"Li": -1, "Cl": 1}, allow_negative=True)
+        assert (c1 + c2).allow_negative is True
+        assert c1 / -1 == Composition("Li-1Cl-1", allow_negative=True)
 
         # test num_atoms
         c1 = Composition("Mg-1Li", allow_negative=True)
-        self.assertEqual(c1.num_atoms, 2)
-        self.assertEqual(c1.get_atomic_fraction("Mg"), 0.5)
-        self.assertEqual(c1.get_atomic_fraction("Li"), 0.5)
-        self.assertEqual(c1.fractional_composition, Composition("Mg-0.5Li0.5", allow_negative=True))
+        assert c1.num_atoms == 2
+        assert c1.get_atomic_fraction("Mg") == 0.5
+        assert c1.get_atomic_fraction("Li") == 0.5
+        assert c1.fractional_composition == Composition("Mg-0.5Li0.5", allow_negative=True)
 
         # test copy
-        self.assertEqual(c1.copy(), c1)
+        assert c1.copy() == c1
 
         # test species
         c1 = Composition({"Mg": 1, "Mg2+": -1}, allow_negative=True)
-        self.assertEqual(c1.num_atoms, 2)
-        self.assertEqual(c1.element_composition, Composition())
-        self.assertEqual(c1.average_electroneg, 1.31)
+        assert c1.num_atoms == 2
+        assert c1.element_composition == Composition()
+        assert c1.average_electroneg == 1.31
 
     def test_special_formulas(self):
         special_formulas = {
@@ -511,88 +475,82 @@ class CompositionTest(PymatgenTest):
             "H": "H2",
         }
         for k, v in special_formulas.items():
-            self.assertEqual(Composition(k).reduced_formula, v)
+            assert Composition(k).reduced_formula == v
 
     def test_oxi_state_guesses(self):
-        self.assertEqual(Composition("LiFeO2").oxi_state_guesses(), ({"Li": 1, "Fe": 3, "O": -2},))
+        assert Composition("LiFeO2").oxi_state_guesses() == ({"Li": 1, "Fe": 3, "O": -2},)
 
-        self.assertEqual(Composition("Fe4O5").oxi_state_guesses(), ({"Fe": 2.5, "O": -2},))
+        assert Composition("Fe4O5").oxi_state_guesses() == ({"Fe": 2.5, "O": -2},)
 
-        self.assertEqual(Composition("V2O3").oxi_state_guesses(), ({"V": 3, "O": -2},))
+        assert Composition("V2O3").oxi_state_guesses() == ({"V": 3, "O": -2},)
 
         # all_oxidation_states produces *many* possible responses
-        self.assertEqual(len(Composition("MnO").oxi_state_guesses(all_oxi_states=True)), 4)
+        assert len(Composition("MnO").oxi_state_guesses(all_oxi_states=True)) == 4
 
         # can't balance b/c missing V4+
-        self.assertEqual(
-            Composition("VO2").oxi_state_guesses(oxi_states_override={"V": [2, 3, 5]}),
-            [],
-        )
+        assert Composition("VO2").oxi_state_guesses(oxi_states_override={"V": [2, 3, 5]}) == []
 
         # missing V4+, but can balance due to additional sites
-        self.assertEqual(
-            Composition("V2O4").oxi_state_guesses(oxi_states_override={"V": [2, 3, 5]}),
-            ({"V": 4, "O": -2},),
-        )
+        assert Composition("V2O4").oxi_state_guesses(oxi_states_override={"V": [2, 3, 5]}) == ({"V": 4, "O": -2},)
 
         # multiple solutions - Mn/Fe = 2+/4+ or 3+/3+ or 4+/2+
-        self.assertEqual(
-            len(Composition("MnFeO3").oxi_state_guesses(oxi_states_override={"Mn": [2, 3, 4], "Fe": [2, 3, 4]})),
-            3,
-        )
+        assert len(Composition("MnFeO3").oxi_state_guesses(oxi_states_override={"Mn": [2, 3, 4], "Fe": [2, 3, 4]})) == 3
 
         # multiple solutions prefers 3/3 over 2/4 or 4/2
-        self.assertEqual(
-            Composition("MnFeO3").oxi_state_guesses(oxi_states_override={"Mn": [2, 3, 4], "Fe": [2, 3, 4]})[0],
-            {"Mn": 3, "Fe": 3, "O": -2},
-        )
+        assert Composition("MnFeO3").oxi_state_guesses(oxi_states_override={"Mn": [2, 3, 4], "Fe": [2, 3, 4]})[0] == {
+            "Mn": 3,
+            "Fe": 3,
+            "O": -2,
+        }
 
         # target charge of 1
-        self.assertEqual(
-            Composition("V2O6").oxi_state_guesses(oxi_states_override={"V": [2, 3, 4, 5]}, target_charge=-2),
-            ({"V": 5, "O": -2},),
+        assert Composition("V2O6").oxi_state_guesses(oxi_states_override={"V": [2, 3, 4, 5]}, target_charge=-2) == (
+            {"V": 5, "O": -2},
         )
 
         # max_sites for very large composition - should timeout if incorrect
-        self.assertEqual(
-            Composition("Li10000Fe10000P10000O40000").oxi_state_guesses(max_sites=7)[0],
-            {"Li": 1, "Fe": 2, "P": 5, "O": -2},
-        )
+        assert Composition("Li10000Fe10000P10000O40000").oxi_state_guesses(max_sites=7)[0] == {
+            "Li": 1,
+            "Fe": 2,
+            "P": 5,
+            "O": -2,
+        }
 
         # max_sites for very large composition - should timeout if incorrect
-        self.assertEqual(
-            Composition("Li10000Fe10000P10000O40000").oxi_state_guesses(max_sites=-1)[0],
-            {"Li": 1, "Fe": 2, "P": 5, "O": -2},
-        )
+        assert Composition("Li10000Fe10000P10000O40000").oxi_state_guesses(max_sites=-1)[0] == {
+            "Li": 1,
+            "Fe": 2,
+            "P": 5,
+            "O": -2,
+        }
 
         # negative max_sites less than -1 - should throw error if cannot reduce
         # to under the abs(max_sites) number of sites. Will also timeout if
         # incorrect.
-        self.assertEqual(
-            Composition("Sb10000O10000F10000").oxi_state_guesses(max_sites=-3)[0],
-            {"Sb": 3, "O": -2, "F": -1},
-        )
-        self.assertRaises(ValueError, Composition("LiOF").oxi_state_guesses, max_sites=-2)
+        assert Composition("Sb10000O10000F10000").oxi_state_guesses(max_sites=-3)[0] == {"Sb": 3, "O": -2, "F": -1}
+        with pytest.raises(ValueError):
+            Composition("LiOF").oxi_state_guesses(max_sites=-2)
 
-        self.assertRaises(ValueError, Composition("V2O3").oxi_state_guesses, max_sites=1)
+        with pytest.raises(ValueError):
+            Composition("V2O3").oxi_state_guesses(max_sites=1)
 
     def test_oxi_state_decoration(self):
         # Basic test: Get compositions where each element is in a single charge state
         decorated = Composition("H2O").add_charges_from_oxi_state_guesses()
-        self.assertIn(Species("H", 1), decorated)
-        self.assertEqual(2, decorated.get(Species("H", 1)))
+        assert Species("H", 1) in decorated
+        assert 2 == decorated.get(Species("H", 1))
 
         # Test: More than one charge state per element
         decorated = Composition("Fe3O4").add_charges_from_oxi_state_guesses()
-        self.assertEqual(1, decorated.get(Species("Fe", 2)))
-        self.assertEqual(2, decorated.get(Species("Fe", 3)))
-        self.assertEqual(4, decorated.get(Species("O", -2)))
+        assert 1 == decorated.get(Species("Fe", 2))
+        assert 2 == decorated.get(Species("Fe", 3))
+        assert 4 == decorated.get(Species("O", -2))
 
         # Test: No possible charge states
         #   It should return an uncharged composition
         decorated = Composition("NiAl").add_charges_from_oxi_state_guesses()
-        self.assertEqual(1, decorated.get(Species("Ni", 0)))
-        self.assertEqual(1, decorated.get(Species("Al", 0)))
+        assert 1 == decorated.get(Species("Ni", 0))
+        assert 1 == decorated.get(Species("Al", 0))
 
     def test_Metallofullerene(self):
         # Test: Parse Metallofullerene formula (e.g. Y3N@C80)
@@ -600,51 +558,52 @@ class CompositionTest(PymatgenTest):
         sym_dict = {"Y": 3, "N": 1, "C": 80}
         cmp = Composition(formula)
         cmp2 = Composition.from_dict(sym_dict)
-        self.assertEqual(cmp, cmp2)
+        assert cmp == cmp2
 
     def test_contains_element_type(self):
 
         formula = "EuTiO3"
         cmp = Composition(formula)
-        self.assertTrue(cmp.contains_element_type("lanthanoid"))
-        self.assertFalse(cmp.contains_element_type("noble_gas"))
-        self.assertTrue(cmp.contains_element_type("f-block"))
-        self.assertFalse(cmp.contains_element_type("s-block"))
+        assert cmp.contains_element_type("lanthanoid")
+        assert not cmp.contains_element_type("noble_gas")
+        assert cmp.contains_element_type("f-block")
+        assert not cmp.contains_element_type("s-block")
 
     def test_chemical_system(self):
-        self.assertEqual(Composition({"Na": 1, "Cl": 1}).chemical_system, "Cl-Na")
-        self.assertEqual(Composition({"Na+": 1, "Cl-": 1}).chemical_system, "Cl-Na")
+        assert Composition({"Na": 1, "Cl": 1}).chemical_system == "Cl-Na"
+        assert Composition({"Na+": 1, "Cl-": 1}).chemical_system == "Cl-Na"
 
     def test_is_valid(self):
 
         formula = "NaCl"
         cmp = Composition(formula)
-        self.assertTrue(cmp.valid)
+        assert cmp.valid
 
         formula = "NaClX"
         cmp = Composition(formula)
-        self.assertFalse(cmp.valid)
+        assert not cmp.valid
 
-        self.assertRaises(ValueError, Composition, "NaClX", strict=True)
+        with pytest.raises(ValueError):
+            Composition("NaClX", strict=True)
 
     def test_remove_charges(self):
         cmp1 = Composition({"Al3+": 2.0, "O2-": 3.0})
 
         cmp2 = Composition({"Al": 2.0, "O": 3.0})
-        self.assertNotEqual(str(cmp1), str(cmp2))
+        assert str(cmp1) != str(cmp2)
 
         cmp1 = cmp1.remove_charges()
-        self.assertEqual(str(cmp1), str(cmp2))
+        assert str(cmp1) == str(cmp2)
 
         cmp1 = cmp1.remove_charges()
-        self.assertEqual(str(cmp1), str(cmp2))
+        assert str(cmp1) == str(cmp2)
 
         cmp1 = Composition({"Fe3+": 2.0, "Fe2+": 3.0, "O2-": 6.0})
         cmp2 = Composition({"Fe": 5.0, "O": 6.0})
-        self.assertNotEqual(str(cmp1), str(cmp2))
+        assert str(cmp1) != str(cmp2)
 
         cmp1 = cmp1.remove_charges()
-        self.assertEqual(str(cmp1), str(cmp2))
+        assert str(cmp1) == str(cmp2)
 
     def test_replace(self):
         Fe2O3 = Composition("Fe2O3")
@@ -653,18 +612,18 @@ class CompositionTest(PymatgenTest):
         Mg2Cu2O3 = Composition("Mg2Cu2O3")
 
         Cu2O3_repl = Fe2O3.replace({"Fe": "Cu"})
-        self.assertEqual(Cu2O3_repl, Cu2O3)
+        assert Cu2O3_repl == Cu2O3
 
         # handles one-to-many substitutions
         MgCuO3_repl = Fe2O3.replace({"Fe": {"Cu": 0.5, "Mg": 0.5}})
-        self.assertEqual(MgCuO3_repl, MgCuO3)
+        assert MgCuO3_repl == MgCuO3
 
         # handles unnormalized one-to-many substitutions
         Mg2Cu2O3_repl = Fe2O3.replace({"Fe": {"Cu": 1, "Mg": 1}})
-        self.assertEqual(Mg2Cu2O3_repl, Mg2Cu2O3)
+        assert Mg2Cu2O3_repl == Mg2Cu2O3
 
         # leaves the composition unchanged when replacing non-existent species
-        self.assertEqual(Fe2O3, Fe2O3.replace({"Li": "Cu"}))
+        assert Fe2O3 == Fe2O3.replace({"Li": "Cu"})
 
         # check for complex substitutions where element is involved at
         # multiple places
@@ -691,9 +650,10 @@ class CompositionTest(PymatgenTest):
 class ChemicalPotentialTest(unittest.TestCase):
     def test_init(self):
         d = {"Fe": 1, Element("Fe"): 1}
-        self.assertRaises(ValueError, ChemicalPotential, d)
+        with pytest.raises(ValueError):
+            ChemicalPotential(d)
         for k in ChemicalPotential(Fe=1):
-            self.assertIsInstance(k, Element)
+            assert isinstance(k, Element)
 
     def test_math(self):
         fepot = ChemicalPotential({"Fe": 1})
@@ -703,25 +663,27 @@ class ChemicalPotentialTest(unittest.TestCase):
         feo2 = Composition("FeO2")
 
         # test get_energy()
-        self.assertAlmostEqual(pots.get_energy(feo2), 5.2)
-        self.assertAlmostEqual(fepot.get_energy(feo2, False), 1)
-        self.assertRaises(ValueError, fepot.get_energy, feo2)
+        assert round(abs(pots.get_energy(feo2) - 5.2), 7) == 0
+        assert round(abs(fepot.get_energy(feo2, False) - 1), 7) == 0
+        with pytest.raises(ValueError):
+            fepot.get_energy(feo2)
 
         # test multiplication
-        self.assertRaises(TypeError, lambda: pots * pots)
-        self.assertDictEqual(pots * 2, potsx2)
-        self.assertDictEqual(2 * pots, potsx2)
+        with pytest.raises(TypeError):
+            pots * pots
+        assert pots * 2 == potsx2
+        assert 2 * pots == potsx2
 
         # test division
-        self.assertDictEqual(potsx2 / 2, pots)
-        self.assertEqual(pots.__div__(pots), NotImplemented)
-        self.assertEqual(pots.__div__(feo2), NotImplemented)
+        assert potsx2 / 2 == pots
+        assert pots.__div__(pots) == NotImplemented
+        assert pots.__div__(feo2) == NotImplemented
 
         # test add/subtract
-        self.assertDictEqual(pots + pots, potsx2)
-        self.assertDictEqual(potsx2 - pots, pots)
-        self.assertDictEqual(fepot + opot, pots)
-        self.assertDictEqual(fepot - opot, pots - opot - opot)
+        assert pots + pots == potsx2
+        assert potsx2 - pots == pots
+        assert fepot + opot == pots
+        assert fepot - opot == pots - opot - opot
 
 
 if __name__ == "__main__":

--- a/pymatgen/core/tests/test_ion.py
+++ b/pymatgen/core/tests/test_ion.py
@@ -5,6 +5,8 @@
 import random
 import unittest
 
+import pytest
+
 from pymatgen.core.composition import Composition
 from pymatgen.core.ion import Ion
 from pymatgen.core.periodic_table import Element
@@ -26,30 +28,30 @@ class IonTest(unittest.TestCase):
     def test_init_(self):
         c = Composition({"Fe": 4, "O": 16, "P": 4})
         charge = 4
-        self.assertEqual("Fe4 P4 O16 +4", Ion(c, charge).formula)
+        assert "Fe4 P4 O16 +4" == Ion(c, charge).formula
         f = {1: 1, 8: 1}
         charge = -1
-        self.assertEqual("H1 O1 -1", Ion(Composition(f), charge).formula)
-        self.assertEqual("S2 O3 -2", Ion(Composition(S=2, O=3), -2).formula)
+        assert "H1 O1 -1" == Ion(Composition(f), charge).formula
+        assert "S2 O3 -2" == Ion(Composition(S=2, O=3), -2).formula
 
     def test_charge_from_formula(self):
-        self.assertEqual(Ion.from_formula("Li+").charge, 1)
-        self.assertEqual(Ion.from_formula("Li[+]").charge, 1)
-        self.assertEqual(Ion.from_formula("Ca[2+]").charge, 2)
-        self.assertEqual(Ion.from_formula("Ca[+2]").charge, 2)
-        self.assertEqual(Ion.from_formula("Ca++").charge, 2)
-        self.assertEqual(Ion.from_formula("Ca[++]").charge, 2)
-        self.assertEqual(Ion.from_formula("Ca2+").charge, 1)
+        assert Ion.from_formula("Li+").charge == 1
+        assert Ion.from_formula("Li[+]").charge == 1
+        assert Ion.from_formula("Ca[2+]").charge == 2
+        assert Ion.from_formula("Ca[+2]").charge == 2
+        assert Ion.from_formula("Ca++").charge == 2
+        assert Ion.from_formula("Ca[++]").charge == 2
+        assert Ion.from_formula("Ca2+").charge == 1
 
-        self.assertEqual(Ion.from_formula("Cl-").charge, -1)
-        self.assertEqual(Ion.from_formula("Cl[-]").charge, -1)
-        self.assertEqual(Ion.from_formula("SO4[-2]").charge, -2)
-        self.assertEqual(Ion.from_formula("SO4-2").charge, -2)
-        self.assertEqual(Ion.from_formula("SO42-").charge, -1)
-        self.assertEqual(Ion.from_formula("SO4--").charge, -2)
-        self.assertEqual(Ion.from_formula("SO4[--]").charge, -2)
+        assert Ion.from_formula("Cl-").charge == -1
+        assert Ion.from_formula("Cl[-]").charge == -1
+        assert Ion.from_formula("SO4[-2]").charge == -2
+        assert Ion.from_formula("SO4-2").charge == -2
+        assert Ion.from_formula("SO42-").charge == -1
+        assert Ion.from_formula("SO4--").charge == -2
+        assert Ion.from_formula("SO4[--]").charge == -2
 
-        self.assertEqual(Ion.from_formula("Na[+-+]").charge, 1)
+        assert Ion.from_formula("Na[+-+]").charge == 1
 
     def test_special_formulas(self):
         special_formulas = [
@@ -70,10 +72,10 @@ class IonTest(unittest.TestCase):
         ]
 
         for tup in special_formulas:
-            self.assertEqual(Ion.from_formula(tup[0]).reduced_formula, tup[1])
+            assert Ion.from_formula(tup[0]).reduced_formula == tup[1]
 
-        self.assertEqual(Ion.from_formula("Fe(OH)4+").get_reduced_formula_and_factor(hydrates=False), ("Fe(OH)4", 1))
-        self.assertEqual(Ion.from_formula("Zr(OH)4").get_reduced_formula_and_factor(hydrates=False), ("Zr(OH)4", 1))
+        assert Ion.from_formula("Fe(OH)4+").get_reduced_formula_and_factor(hydrates=False) == ("Fe(OH)4", 1)
+        assert Ion.from_formula("Zr(OH)4").get_reduced_formula_and_factor(hydrates=False) == ("Zr(OH)4", 1)
 
     def test_formula(self):
         correct_formulas = [
@@ -88,14 +90,15 @@ class IonTest(unittest.TestCase):
             "Na1 H1 O1 (aq)",
         ]
         all_formulas = [c.formula for c in self.comp]
-        self.assertEqual(all_formulas, correct_formulas)
-        self.assertRaises(ValueError, Ion.from_formula, "(co2)(po4)2")
+        assert all_formulas == correct_formulas
+        with pytest.raises(ValueError):
+            Ion.from_formula("(co2)(po4)2")
 
     def test_mixed_valence(self):
         comp = Ion(Composition({"Fe2+": 2, "Fe3+": 4, "Li+": 8}))
-        self.assertEqual(comp.reduced_formula, "Li4Fe3(aq)")
-        self.assertEqual(comp.alphabetical_formula, "Fe6 Li8 (aq)")
-        self.assertEqual(comp.formula, "Li8 Fe6 (aq)")
+        assert comp.reduced_formula == "Li4Fe3(aq)"
+        assert comp.alphabetical_formula == "Fe6 Li8 (aq)"
+        assert comp.formula == "Li8 Fe6 (aq)"
 
     def test_oxi_state_guesses(self):
         i = Ion.from_formula("SO4-2")
@@ -115,12 +118,12 @@ class IonTest(unittest.TestCase):
             "H1 Na1 O1 (aq)",
         ]
         all_formulas = [c.alphabetical_formula for c in self.comp]
-        self.assertEqual(all_formulas, correct_formulas)
+        assert all_formulas == correct_formulas
 
     def test_num_atoms(self):
         correct_num_atoms = [1, 5, 1, 4, 13, 13, 72, 1, 3]
         all_natoms = [c.num_atoms for c in self.comp]
-        self.assertEqual(all_natoms, correct_num_atoms)
+        assert all_natoms == correct_num_atoms
 
     def test_anonymized_formula(self):
         expected_formulas = [
@@ -135,26 +138,22 @@ class IonTest(unittest.TestCase):
             "ABC(aq)",
         ]
         for i, _ in enumerate(self.comp):
-            self.assertEqual(self.comp[i].anonymized_formula, expected_formulas[i])
+            assert self.comp[i].anonymized_formula == expected_formulas[i]
 
     def test_from_dict(self):
         sym_dict = {"P": 1, "O": 4, "charge": -2}
-        self.assertEqual(
-            Ion.from_dict(sym_dict).reduced_formula,
-            "PO4[-2]",
-            "Creation form sym_amount dictionary failed!",
-        )
+        assert Ion.from_dict(sym_dict).reduced_formula == "PO4[-2]", "Creation form sym_amount dictionary failed!"
 
     def test_as_dict(self):
         c = Ion.from_dict({"Mn": 1, "O": 4, "charge": -1})
         d = c.as_dict()
         correct_dict = {"Mn": 1.0, "O": 4.0, "charge": -1.0}
-        self.assertEqual(d, correct_dict)
-        self.assertEqual(d["charge"], correct_dict["charge"])
+        assert d == correct_dict
+        assert d["charge"] == correct_dict["charge"]
         correct_dict = {"Mn": 1.0, "O": 4.0, "charge": -1}
         d = c.to_reduced_dict
-        self.assertEqual(d, correct_dict)
-        self.assertEqual(d["charge"], correct_dict["charge"])
+        assert d == correct_dict
+        assert d["charge"] == correct_dict["charge"]
 
     def test_equals(self):
         random_z = random.randint(1, 92)
@@ -167,28 +166,20 @@ class IonTest(unittest.TestCase):
         while other_z == random_z:
             other_z = random.randint(1, 92)
         comp2 = Ion(Composition({fixed_el: 1, Element.from_Z(other_z): 0}), 1)
-        self.assertEqual(
-            comp1,
-            comp2,
-            f"Composition equality test failed. {comp1.formula} should be equal to {comp2.formula}",
-        )
-        self.assertEqual(hash(comp1), hash(comp2), "Hashcode equality test failed!")
+        assert comp1 == comp2, f"Composition equality test failed. {comp1.formula} should be equal to {comp2.formula}"
+        assert hash(comp1) == hash(comp2), "Hashcode equality test failed!"
 
     def test_equality(self):
-        self.assertTrue(self.comp[0] == (self.comp[0]))
-        self.assertFalse(self.comp[0] == (self.comp[1]))
-        self.assertFalse(self.comp[0] != (self.comp[0]))
-        self.assertTrue(self.comp[0] != (self.comp[1]))
+        assert self.comp[0] == (self.comp[0])
+        assert not self.comp[0] == (self.comp[1])
+        assert not self.comp[0] != (self.comp[0])
+        assert self.comp[0] != (self.comp[1])
 
     def test_mul(self):
-        self.assertEqual(
-            (self.comp[1] * 4).formula,
-            "Mn4 O16 -4",
-            "Incorrect composition after addition!",
-        )
+        assert (self.comp[1] * 4).formula == "Mn4 O16 -4", "Incorrect composition after addition!"
 
     def test_len(self):
-        self.assertEqual(len(self.comp[1]), 2, "Lengths are not equal!")
+        assert len(self.comp[1]) == 2, "Lengths are not equal!"
 
     def test_to_latex_string(self):
         correct_latex = [
@@ -203,7 +194,7 @@ class IonTest(unittest.TestCase):
             "NaOH",
         ]
         all_latex = [c.to_latex_string() for c in self.comp]
-        self.assertEqual(all_latex, correct_latex)
+        assert all_latex == correct_latex
 
 
 if __name__ == "__main__":

--- a/pymatgen/core/tests/test_lattice.py
+++ b/pymatgen/core/tests/test_lattice.py
@@ -5,6 +5,7 @@
 import itertools
 
 import numpy as np
+import pytest
 
 from pymatgen.core.lattice import Lattice, get_points_in_spheres
 from pymatgen.core.operations import SymmOp
@@ -37,49 +38,44 @@ class LatticeTestCase(PymatgenTest):
             self.families[name] = getattr(self, name)
 
     def test_equal(self):
-        self.assertEqual(self.cubic, self.cubic)
-        self.assertEqual(self.cubic, self.lattice)
+        assert self.cubic == self.cubic
+        assert self.cubic == self.lattice
         for name1, latt1 in self.families.items():
             for name2, latt2 in self.families.items():
-                self.assertEqual(name1 == name2, latt1 == latt2)
+                assert (name1 == name2) == (latt1 == latt2)
 
         # ensure partial periodic boundaries is unequal to all full periodic boundaries
-        self.assertFalse(any(self.cubic_partial_pbc == x for x in self.families.values()))
+        assert not any(self.cubic_partial_pbc == x for x in self.families.values())
 
     def test_format(self):
-        self.assertEqual(
-            "[[10.000, 0.000, 0.000], [0.000, 10.000, 0.000], [0.000, 0.000, 10.000]]",
-            format(self.lattice, ".3fl"),
+        assert "[[10.000, 0.000, 0.000], [0.000, 10.000, 0.000], [0.000, 0.000, 10.000]]" == format(
+            self.lattice, ".3fl"
         )
-        self.assertEqual(
-            """10.000 0.000 0.000
+        assert """10.000 0.000 0.000
 0.000 10.000 0.000
-0.000 0.000 10.000""",
-            format(self.lattice, ".3f"),
+0.000 0.000 10.000""" == format(
+            self.lattice, ".3f"
         )
-        self.assertEqual("{10.0, 10.0, 10.0, 90.0, 90.0, 90.0}", format(self.lattice, ".1fp"))
+        assert "{10.0, 10.0, 10.0, 90.0, 90.0, 90.0}" == format(self.lattice, ".1fp")
 
     def test_init(self):
         a = 9.026
         lattice = Lattice.cubic(a)
-        self.assertIsNotNone(lattice, "Initialization from new_cubic failed")
+        assert lattice is not None, "Initialization from new_cubic failed"
         self.assertArrayEqual(lattice.pbc, (True, True, True))
         lattice2 = Lattice([[a, 0, 0], [0, a, 0], [0, 0, a]])
         for i in range(0, 3):
             for j in range(0, 3):
-                self.assertAlmostEqual(
-                    lattice.matrix[i][j],
-                    lattice2.matrix[i][j],
-                    5,
-                    "Inconsistent matrix from two inits!",
-                )
+                assert (
+                    round(abs(lattice.matrix[i][j] - lattice2.matrix[i][j]), 5) == 0
+                ), "Inconsistent matrix from two inits!"
         self.assertArrayEqual(self.cubic_partial_pbc.pbc, (True, True, False))
 
     def test_copy(self):
         cubic_copy = self.cubic.copy()
-        self.assertTrue(cubic_copy == self.cubic)
-        self.assertTrue(self.cubic_partial_pbc.copy() == self.cubic_partial_pbc)
-        self.assertFalse(cubic_copy._matrix is self.cubic._matrix)
+        assert cubic_copy == self.cubic
+        assert self.cubic_partial_pbc.copy() == self.cubic_partial_pbc
+        assert cubic_copy._matrix is not self.cubic._matrix
 
     def test_get_cartesian_or_frac_coord(self):
         coord = self.lattice.get_cartesian_coords([0.15, 0.3, 0.4])
@@ -118,7 +114,7 @@ class LatticeTestCase(PymatgenTest):
         cubic_copy = self.cubic.copy()
         hkl = (1, 2, 3)
         dhkl = ((hkl[0] ** 2 + hkl[1] ** 2 + hkl[2] ** 2) / (cubic_copy.a**2)) ** (-1 / 2)
-        self.assertEqual(dhkl, cubic_copy.d_hkl(hkl))
+        assert dhkl == cubic_copy.d_hkl(hkl)
 
     def test_reciprocal_lattice(self):
         recip_latt = self.lattice.reciprocal_lattice
@@ -146,26 +142,26 @@ class LatticeTestCase(PymatgenTest):
         lengths = newlatt.lengths
         angles = newlatt.angles
         for i in range(0, 3):
-            self.assertAlmostEqual(lengths[i], lengths_c[i], 5, "Lengths incorrect!")
-            self.assertAlmostEqual(angles[i], angles_c[i], 5, "Angles incorrect!")
+            assert round(abs(lengths[i] - lengths_c[i]), 5) == 0, "Lengths incorrect!"
+            assert round(abs(angles[i] - angles_c[i]), 5) == 0, "Angles incorrect!"
         latt = Lattice.from_parameters(*lengths, *angles)
         lengths = latt.lengths
         angles = latt.angles
         for i in range(0, 3):
-            self.assertAlmostEqual(lengths[i], lengths_c[i], 5, "Lengths incorrect!")
-            self.assertAlmostEqual(angles[i], angles_c[i], 5, "Angles incorrect!")
+            assert round(abs(lengths[i] - lengths_c[i]), 5) == 0, "Lengths incorrect!"
+            assert round(abs(angles[i] - angles_c[i]), 5) == 0, "Angles incorrect!"
 
     def test_attributes(self):
         """docstring for test_attributes"""
         lattice = Lattice.cubic(10.0)
-        self.assertEqual(lattice.a, 10.0)
-        self.assertEqual(lattice.b, 10.0)
-        self.assertEqual(lattice.c, 10.0)
-        self.assertAlmostEqual(lattice.volume, 1000.0)
+        assert lattice.a == 10.0
+        assert lattice.b == 10.0
+        assert lattice.c == 10.0
+        assert round(abs(lattice.volume - 1000.0), 7) == 0
         xyz = lattice.get_cartesian_coords([0.25, 0.35, 0.45])
-        self.assertEqual(xyz[0], 2.5)
-        self.assertEqual(xyz[1], 3.5)
-        self.assertEqual(xyz[2], 4.5)
+        assert xyz[0] == 2.5
+        assert xyz[1] == 3.5
+        assert xyz[2] == 4.5
 
     def test_lattice_matrices(self):
         """
@@ -178,22 +174,22 @@ class LatticeTestCase(PymatgenTest):
             # self.assertArrayAlmostEqual(mat1, mat2)
             return ((mat1 - mat2) ** 2).sum() < 1e-6
 
-        self.assertTrue(_identical(2, 3, 4, 90, 90, 90))
-        self.assertTrue(_identical(2, 3, 4, 90, 90, 80))
-        self.assertTrue(_identical(2, 3, 4, 90, 90, 100))
+        assert _identical(2, 3, 4, 90, 90, 90)
+        assert _identical(2, 3, 4, 90, 90, 80)
+        assert _identical(2, 3, 4, 90, 90, 100)
 
-        self.assertFalse(_identical(2, 3, 4, 100, 90, 90))
-        self.assertFalse(_identical(2, 3, 4, 90, 100, 90))
-        self.assertFalse(_identical(2, 3, 4, 100, 100, 100))
+        assert not _identical(2, 3, 4, 100, 90, 90)
+        assert not _identical(2, 3, 4, 90, 100, 90)
+        assert not _identical(2, 3, 4, 100, 100, 100)
 
     def test_get_lll_reduced_lattice(self):
         lattice = Lattice([1.0, 1, 1, -1.0, 0, 2, 3.0, 5, 6])
         reduced_latt = lattice.get_lll_reduced_lattice()
 
         expected_ans = Lattice(np.array([0.0, 1.0, 0.0, 1.0, 0.0, 1.0, -2.0, 0.0, 1.0]).reshape((3, 3)))
-        self.assertAlmostEqual(np.linalg.det(np.linalg.solve(expected_ans.matrix, reduced_latt.matrix)), 1)
+        assert round(abs(np.linalg.det(np.linalg.solve(expected_ans.matrix, reduced_latt.matrix)) - 1), 7) == 0
         self.assertArrayAlmostEqual(sorted(reduced_latt.abc), sorted(expected_ans.abc))
-        self.assertAlmostEqual(reduced_latt.volume, lattice.volume)
+        assert round(abs(reduced_latt.volume - lattice.volume), 7) == 0
         latt = [
             7.164750,
             2.481942,
@@ -221,7 +217,7 @@ class LatticeTestCase(PymatgenTest):
             )
         )
         reduced_latt = Lattice(latt).get_lll_reduced_lattice()
-        self.assertAlmostEqual(np.linalg.det(np.linalg.solve(expected_ans.matrix, reduced_latt.matrix)), 1)
+        assert round(abs(np.linalg.det(np.linalg.solve(expected_ans.matrix, reduced_latt.matrix)) - 1), 7) == 0
         self.assertArrayAlmostEqual(sorted(reduced_latt.abc), sorted(expected_ans.abc))
 
         expected_ans = Lattice([0.0, 10.0, 10.0, 10.0, 10.0, 0.0, 30.0, -30.0, 40.0])
@@ -230,25 +226,25 @@ class LatticeTestCase(PymatgenTest):
         lattice = lattice.reshape(3, 3)
         lattice = Lattice(lattice.T)
         reduced_latt = lattice.get_lll_reduced_lattice()
-        self.assertAlmostEqual(np.linalg.det(np.linalg.solve(expected_ans.matrix, reduced_latt.matrix)), 1)
+        assert round(abs(np.linalg.det(np.linalg.solve(expected_ans.matrix, reduced_latt.matrix)) - 1), 7) == 0
         self.assertArrayAlmostEqual(sorted(reduced_latt.abc), sorted(expected_ans.abc))
 
         random_latt = Lattice(np.random.random((3, 3)))
         if np.linalg.det(random_latt.matrix) > 1e-8:
             reduced_random_latt = random_latt.get_lll_reduced_lattice()
-            self.assertAlmostEqual(reduced_random_latt.volume, random_latt.volume)
+            assert round(abs(reduced_random_latt.volume - random_latt.volume), 7) == 0
 
     def test_get_niggli_reduced_lattice(self):
         latt = Lattice.from_parameters(3, 5.196, 2, 103 + 55 / 60, 109 + 28 / 60, 134 + 53 / 60)
         reduced_cell = latt.get_niggli_reduced_lattice()
         abc = reduced_cell.lengths
         angles = reduced_cell.angles
-        self.assertAlmostEqual(abc[0], 2, 3)
-        self.assertAlmostEqual(abc[1], 3, 3)
-        self.assertAlmostEqual(abc[2], 3, 3)
-        self.assertAlmostEqual(angles[0], 116.382855225, 3)
-        self.assertAlmostEqual(angles[1], 94.769790287999996, 3)
-        self.assertAlmostEqual(angles[2], 109.466666667, 3)
+        assert round(abs(abc[0] - 2), 3) == 0
+        assert round(abs(abc[1] - 3), 3) == 0
+        assert round(abs(abc[2] - 3), 3) == 0
+        assert round(abs(angles[0] - 116.382855225), 3) == 0
+        assert round(abs(angles[1] - 94.769790287999996), 3) == 0
+        assert round(abs(angles[2] - 109.466666667), 3) == 0
 
         mat = [[5.0, 0, 0], [0, 5.0, 0], [5.0, 0, 5.0]]
         latt = Lattice(np.dot([[1, 1, 1], [1, 1, 0], [0, 1, 1]], mat))
@@ -256,9 +252,9 @@ class LatticeTestCase(PymatgenTest):
         abc = reduced_cell.lengths
         angles = reduced_cell.angles
         for l in abc:
-            self.assertAlmostEqual(l, 5, 3)
+            assert round(abs(l - 5), 3) == 0
         for a in angles:
-            self.assertAlmostEqual(a, 90, 3)
+            assert round(abs(a - 90), 3) == 0
 
         latt = Lattice(
             [
@@ -301,14 +297,14 @@ class LatticeTestCase(PymatgenTest):
 
         latt2 = Lattice(np.dot(rot, np.dot(scale, m).T).T)
         (aligned_out, rot_out, scale_out) = latt2.find_mapping(latt)
-        self.assertAlmostEqual(abs(np.linalg.det(rot)), 1)
+        assert round(abs(abs(np.linalg.det(rot)) - 1), 7) == 0
 
         rotated = SymmOp.from_rotation_and_translation(rot_out).operate_multi(latt.matrix)
 
         self.assertArrayAlmostEqual(rotated, aligned_out.matrix)
         self.assertArrayAlmostEqual(np.dot(scale_out, latt2.matrix), aligned_out.matrix)
         self.assertArrayAlmostEqual(aligned_out.parameters, latt.parameters)
-        self.assertFalse(np.allclose(aligned_out.parameters, latt2.parameters))
+        assert not np.allclose(aligned_out.parameters, latt2.parameters)
 
     def test_find_all_mappings(self):
         m = np.array([[0.1, 0.2, 0.3], [-0.1, 0.2, 0.7], [0.6, 0.9, 0.2]])
@@ -324,51 +320,51 @@ class LatticeTestCase(PymatgenTest):
             self.assertArrayAlmostEqual(np.inner(latt2.matrix, rot_out), aligned_out.matrix, 5)
             self.assertArrayAlmostEqual(np.dot(scale_out, latt.matrix), aligned_out.matrix)
             self.assertArrayAlmostEqual(aligned_out.parameters, latt2.parameters)
-            self.assertFalse(np.allclose(aligned_out.parameters, latt.parameters))
+            assert not np.allclose(aligned_out.parameters, latt.parameters)
 
         latt = Lattice.orthorhombic(9, 9, 5)
-        self.assertEqual(len(list(latt.find_all_mappings(latt))), 16)
+        assert len(list(latt.find_all_mappings(latt))) == 16
 
         # catch the singular matrix error
         latt = Lattice.from_parameters(1, 1, 1, 10, 10, 10)
         for l, _, _ in latt.find_all_mappings(latt, ltol=0.05, atol=11):
-            self.assertTrue(isinstance(l, Lattice))
+            assert isinstance(l, Lattice)
 
     def test_mapping_symmetry(self):
         l = Lattice.cubic(1)
         l2 = Lattice.orthorhombic(1.1001, 1, 1)
-        self.assertEqual(l.find_mapping(l2, ltol=0.1), None)
-        self.assertEqual(l2.find_mapping(l, ltol=0.1), None)
+        assert l.find_mapping(l2, ltol=0.1) is None
+        assert l2.find_mapping(l, ltol=0.1) is None
         l2 = Lattice.orthorhombic(1.0999, 1, 1)
-        self.assertNotEqual(l2.find_mapping(l, ltol=0.1), None)
-        self.assertNotEqual(l.find_mapping(l2, ltol=0.1), None)
+        assert l2.find_mapping(l, ltol=0.1) is not None
+        assert l.find_mapping(l2, ltol=0.1) is not None
 
     def test_to_from_dict(self):
         d = self.tetragonal.as_dict()
         t = Lattice.from_dict(d)
         for i in range(3):
-            self.assertEqual(t.abc[i], self.tetragonal.abc[i])
-            self.assertEqual(t.angles[i], self.tetragonal.angles[i])
+            assert t.abc[i] == self.tetragonal.abc[i]
+            assert t.angles[i] == self.tetragonal.angles[i]
         # Make sure old style dicts work.
         d = self.tetragonal.as_dict(verbosity=1)
         del d["matrix"]
         t = Lattice.from_dict(d)
         for i in range(3):
-            self.assertEqual(t.abc[i], self.tetragonal.abc[i])
-            self.assertEqual(t.angles[i], self.tetragonal.angles[i])
+            assert t.abc[i] == self.tetragonal.abc[i]
+            assert t.angles[i] == self.tetragonal.angles[i]
 
     def test_scale(self):
         new_volume = 10
         for lattice in self.families.values():
             new_lattice = lattice.scale(new_volume)
-            self.assertAlmostEqual(new_lattice.volume, new_volume)
+            assert round(abs(new_lattice.volume - new_volume), 7) == 0
             self.assertArrayAlmostEqual(new_lattice.angles, lattice.angles)
 
     def test_get_wigner_seitz_cell(self):
         ws_cell = Lattice([[10, 0, 0], [0, 5, 0], [0, 0, 1]]).get_wigner_seitz_cell()
-        self.assertEqual(6, len(ws_cell))
+        assert 6 == len(ws_cell)
         for l in ws_cell[3]:
-            self.assertEqual([abs(i) for i in l], [5.0, 2.5, 0.5])
+            assert [abs(i) for i in l] == [5.0, 2.5, 0.5]
 
     def test_dot_and_norm(self):
         frac_basis = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
@@ -381,18 +377,18 @@ class LatticeTestCase(PymatgenTest):
                 length = lattice.norm(vec)
                 self.assertArrayAlmostEqual(length[0], lattice.abc[i], 5)
                 # We always get a ndarray.
-                self.assertTrue(hasattr(length, "shape"))
+                assert hasattr(length, "shape")
 
         # Passing complex arrays should raise TypeError
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             lattice.norm(np.zeros(3, dtype=np.complex128))
 
         # Cannot reshape the second argument.
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             lattice.dot(np.zeros(6), np.zeros(8))
 
         # Passing vectors of different length is invalid.
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             lattice.dot(np.zeros(3), np.zeros(6))
 
     def test_get_points_in_sphere(self):
@@ -404,21 +400,21 @@ class LatticeTestCase(PymatgenTest):
 
         # Test getting neighbors within 1 neighbor distance of the origin
         fcoords, dists, inds, images = latt.get_points_in_sphere(pts, [0, 0, 0], 0.20001, zip_results=False)
-        self.assertEqual(len(fcoords), 7)  # There are 7 neighbors
-        self.assertEqual(np.isclose(dists, 0.2).sum(), 6)  # 6 are at 0.2
-        self.assertEqual(np.isclose(dists, 0).sum(), 1)  # 1 is at 0
-        self.assertEqual(len(set(inds)), 7)  # They have unique indices
+        assert len(fcoords) == 7  # There are 7 neighbors
+        assert np.isclose(dists, 0.2).sum() == 6  # 6 are at 0.2
+        assert np.isclose(dists, 0).sum() == 1  # 1 is at 0
+        assert len(set(inds)) == 7  # They have unique indices
         self.assertArrayEqual(images[np.isclose(dists, 0)], [[0, 0, 0]])
 
         # More complicated case, using the zip output
         result = latt.get_points_in_sphere(pts, [0.5, 0.5, 0.5], 1.0001)
-        self.assertEqual(len(result), 552)
-        self.assertEqual(len(result[0]), 4)  # coords, dists, ind, supercell
+        assert len(result) == 552
+        assert len(result[0]) == 4  # coords, dists, ind, supercell
 
         # test pbc
         latt_pbc = Lattice([[1, 5, 0], [0, 1, 0], [5, 0, 1]], pbc=(True, True, False))
         fcoords, dists, inds, images = latt_pbc.get_points_in_sphere(pts, [0, 0, 0], 0.20001, zip_results=False)
-        self.assertEqual(len(fcoords), 6)
+        assert len(fcoords) == 6
 
     def test_get_all_distances(self):
         fcoords = np.array(
@@ -448,7 +444,7 @@ class LatticeTestCase(PymatgenTest):
         # test distance when initial points are not in unit cell
         f1 = [0, 0, 17]
         f2 = [0, 0, 10]
-        self.assertEqual(lattice.get_all_distances(f1, f2)[0, 0], 0)
+        assert lattice.get_all_distances(f1, f2)[0, 0] == 0
 
         # test pbc
         lattice_pbc = Lattice.from_parameters(8, 8, 4, 90, 76, 58, pbc=(True, True, False))
@@ -465,21 +461,21 @@ class LatticeTestCase(PymatgenTest):
 
     def test_monoclinic(self):
         a, b, c, alpha, beta, gamma = self.monoclinic.parameters
-        self.assertNotAlmostEqual(beta, 90)
-        self.assertAlmostEqual(alpha, 90)
-        self.assertAlmostEqual(gamma, 90)
+        assert round(abs(beta - 90), 7) != 0
+        assert round(abs(alpha - 90), 7) == 0
+        assert round(abs(gamma - 90), 7) == 0
 
     def test_is_hexagonal(self):
-        self.assertFalse(self.cubic.is_hexagonal())
-        self.assertFalse(self.tetragonal.is_hexagonal())
-        self.assertFalse(self.orthorhombic.is_hexagonal())
-        self.assertFalse(self.monoclinic.is_hexagonal())
-        self.assertFalse(self.rhombohedral.is_hexagonal())
-        self.assertTrue(self.hexagonal.is_hexagonal())
+        assert not self.cubic.is_hexagonal()
+        assert not self.tetragonal.is_hexagonal()
+        assert not self.orthorhombic.is_hexagonal()
+        assert not self.monoclinic.is_hexagonal()
+        assert not self.rhombohedral.is_hexagonal()
+        assert self.hexagonal.is_hexagonal()
 
     def test_get_distance_and_image(self):
         dist, image = self.cubic.get_distance_and_image([0, 0, 0.1], [0, 0.0, 0.9])
-        self.assertAlmostEqual(dist, 2)
+        assert round(abs(dist - 2), 7) == 0
         self.assertArrayAlmostEqual(image, [0, 0, -1])
 
     def test_get_distance_and_image_strict(self):
@@ -500,7 +496,7 @@ class LatticeTestCase(PymatgenTest):
                     min_image_dist = (dist, image)
 
             pmg_result = lattice.get_distance_and_image(f1, f2)
-            self.assertGreaterEqual(min_image_dist[0] + 1e-7, pmg_result[0])
+            assert min_image_dist[0] + 1e-7 >= pmg_result[0]
             if abs(min_image_dist[0] - pmg_result[0]) < 1e-12:
                 self.assertArrayAlmostEqual(min_image_dist[1], pmg_result[1])
 
@@ -534,7 +530,7 @@ class LatticeTestCase(PymatgenTest):
         s1 = np.array([0.5, -1.5, 3])
         s2 = np.array([0.5, 3.0, -1.5])
         s3 = np.array([2.5, 1.5, -4.0])
-        self.assertEqual(m.get_miller_index_from_coords([s1, s2, s3]), (2, 1, 1))
+        assert m.get_miller_index_from_coords([s1, s2, s3]) == (2, 1, 1)
 
         # test on a hexagonal system
         m = Lattice([[2.319, -4.01662582, 0.0], [2.319, 4.01662582, 0.0], [0.0, 0.0, 7.252]])
@@ -543,20 +539,20 @@ class LatticeTestCase(PymatgenTest):
         s2 = np.array([1.1595, 0.66943764, 4.5325])
         s3 = np.array([1.1595, 0.66943764, 0.9065])
         hkl = m.get_miller_index_from_coords([s1, s2, s3])
-        self.assertEqual(hkl, (2, -1, 0))
+        assert hkl == (2, -1, 0)
 
         # test for previous failing structure
         m = Lattice([10, 0, 0, 0, 10, 0, 0, 0, 10])
         sites = [[0.5, 0.8, 0.8], [0.5, 0.4, 0.2], [0.5, 0.3, 0.7]]
 
         hkl = m.get_miller_index_from_coords(sites, coords_are_cartesian=False)
-        self.assertEqual(hkl, (1, 0, 0))
+        assert hkl == (1, 0, 0)
 
         # test for more than 3 sites
         sites = [[0.5, 0.8, 0.8], [0.5, 0.4, 0.2], [0.5, 0.3, 0.7], [0.5, 0.1, 0.2]]
 
         hkl = m.get_miller_index_from_coords(sites, coords_are_cartesian=False)
-        self.assertEqual(hkl, (1, 0, 0))
+        assert hkl == (1, 0, 0)
 
     def test_points_in_spheres(self):
         points = [[0.0, 0.0, 0.0], [2.0, 2.0, 2.0]]
@@ -570,7 +566,7 @@ class LatticeTestCase(PymatgenTest):
             lattice=lattice,
             numerical_tol=1e-8,
         )
-        self.assertEqual(len(nns[0]), 2)  # two neighbors
+        assert len(nns[0]) == 2  # two neighbors
 
         nns = get_points_in_spheres(
             all_coords=np.array(points),
@@ -581,7 +577,7 @@ class LatticeTestCase(PymatgenTest):
             numerical_tol=1e-8,
             return_fcoords=True,
         )
-        self.assertEqual(len(nns[0]), 12)
+        assert len(nns[0]) == 12
 
         nns = get_points_in_spheres(
             all_coords=np.array(points),
@@ -590,7 +586,7 @@ class LatticeTestCase(PymatgenTest):
             pbc=np.array([True, False, False], dtype=int),
             lattice=lattice,
         )
-        self.assertEqual(len(nns[0]), 4)
+        assert len(nns[0]) == 4
 
     def test_selling_dist(self):
         # verification process described here
@@ -628,8 +624,8 @@ class LatticeTestCase(PymatgenTest):
         )
 
     def test_is_3d_periodic(self):
-        self.assertTrue(self.cubic.is_3d_periodic)
-        self.assertFalse(self.cubic_partial_pbc.is_3d_periodic)
+        assert self.cubic.is_3d_periodic
+        assert not self.cubic_partial_pbc.is_3d_periodic
 
 
 if __name__ == "__main__":

--- a/pymatgen/core/tests/test_molecular_orbitals.py
+++ b/pymatgen/core/tests/test_molecular_orbitals.py
@@ -4,6 +4,8 @@
 
 import unittest
 
+import pytest
+
 from pymatgen.core.molecular_orbitals import MolecularOrbitals
 from pymatgen.util.testing import PymatgenTest
 
@@ -13,7 +15,7 @@ test_case = MolecularOrbitals("NaCl")
 class MolecularOrbitalTestCase(PymatgenTest):
     def test_max_electronegativity(self):
         test_elec_neg = 2.23
-        self.assertEqual(test_elec_neg, test_case.max_electronegativity())
+        assert test_elec_neg == test_case.max_electronegativity()
 
     def test_aos_as_list(self):
         test_list = [
@@ -27,7 +29,7 @@ class MolecularOrbitalTestCase(PymatgenTest):
             ["Cl", "3p", -0.32038],
             ["Na", "3s", -0.103415],
         ]
-        self.assertEqual(test_list, test_case.aos_as_list())
+        assert test_list == test_case.aos_as_list()
 
     def test_obtain_band_edges(self):
         test_edges = {
@@ -36,11 +38,12 @@ class MolecularOrbitalTestCase(PymatgenTest):
             "metal": False,
         }
         for key, val in test_edges.items():
-            self.assertEqual(val, test_case.obtain_band_edges()[key])
+            assert val == test_case.obtain_band_edges()[key]
 
     # test for raising ValueError for fractional composition
     def test_fractional_compositions(self):
-        self.assertRaises(ValueError, lambda: MolecularOrbitals("Na0.5Cl0.5"))
+        with pytest.raises(ValueError):
+            MolecularOrbitals("Na0.5Cl0.5")
 
 
 if __name__ == "__main__":

--- a/pymatgen/core/tests/test_operations.py
+++ b/pymatgen/core/tests/test_operations.py
@@ -43,7 +43,7 @@ class SymmOpTestCase(PymatgenTest):
         point = np.random.rand(3)
         newcoord = refl.operate(point)
         # Distance to the plane should be negatives of each other.
-        self.assertAlmostEqual(np.dot(newcoord - origin, normal), -np.dot(point - origin, normal))
+        assert round(abs(np.dot(newcoord - origin, normal) - -np.dot(point - origin, normal)), 7) == 0
 
     def test_apply_rotation_only(self):
         point = np.random.rand(3)
@@ -153,8 +153,8 @@ class SymmOpTestCase(PymatgenTest):
     def test_are_symmetrically_related(self):
         point = np.random.rand(3)
         newcoord = self.op.operate(point)
-        self.assertTrue(self.op.are_symmetrically_related(point, newcoord))
-        self.assertTrue(self.op.are_symmetrically_related(newcoord, point))
+        assert self.op.are_symmetrically_related(point, newcoord)
+        assert self.op.are_symmetrically_related(newcoord, point)
 
     def test_are_symmetrically_related_vectors(self):
         tol = 0.001
@@ -169,17 +169,17 @@ class SymmOpTestCase(PymatgenTest):
         r_b = self.op.apply_rotation_only(r_a) - floored[0] + floored[1]
         from_b = from_b % 1
         to_b = to_b % 1
-        self.assertTrue(self.op.are_symmetrically_related_vectors(from_a, to_a, r_a, from_b, to_b, r_b)[0])
-        self.assertFalse(self.op.are_symmetrically_related_vectors(from_a, to_a, r_a, from_b, to_b, r_b)[1])
-        self.assertTrue(self.op.are_symmetrically_related_vectors(to_a, from_a, -r_a, from_b, to_b, r_b)[0])
-        self.assertTrue(self.op.are_symmetrically_related_vectors(to_a, from_a, -r_a, from_b, to_b, r_b)[1])
+        assert self.op.are_symmetrically_related_vectors(from_a, to_a, r_a, from_b, to_b, r_b)[0]
+        assert not self.op.are_symmetrically_related_vectors(from_a, to_a, r_a, from_b, to_b, r_b)[1]
+        assert self.op.are_symmetrically_related_vectors(to_a, from_a, -r_a, from_b, to_b, r_b)[0]
+        assert self.op.are_symmetrically_related_vectors(to_a, from_a, -r_a, from_b, to_b, r_b)[1]
 
     def test_to_from_dict(self):
         d = self.op.as_dict()
         op = SymmOp.from_dict(d)
         point = np.random.rand(3)
         newcoord = self.op.operate(point)
-        self.assertTrue(op.are_symmetrically_related(point, newcoord))
+        assert op.are_symmetrically_related(point, newcoord)
 
     def test_inversion(self):
         origin = np.random.rand(3)
@@ -191,13 +191,13 @@ class SymmOpTestCase(PymatgenTest):
     def test_xyz(self):
         op = SymmOp([[1, -1, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1]])
         s = op.as_xyz_string()
-        self.assertEqual(s, "x-y, -y, -z")
-        self.assertEqual(op, SymmOp.from_xyz_string(s))
+        assert s == "x-y, -y, -z"
+        assert op == SymmOp.from_xyz_string(s)
 
         op2 = SymmOp([[0, -1, 0, 0.5], [1, 0, 0, 0.5], [0, 0, 1, 0.5 + 1e-7], [0, 0, 0, 1]])
         s2 = op2.as_xyz_string()
-        self.assertEqual(s2, "-y+1/2, x+1/2, z+1/2")
-        self.assertEqual(op2, SymmOp.from_xyz_string(s2))
+        assert s2 == "-y+1/2, x+1/2, z+1/2"
+        assert op2 == SymmOp.from_xyz_string(s2)
 
         op2 = SymmOp(
             [
@@ -208,18 +208,18 @@ class SymmOpTestCase(PymatgenTest):
             ]
         )
         s2 = op2.as_xyz_string()
-        self.assertEqual(s2, "3x-2y-z+1/2, -x+12/13, z+1/2")
-        self.assertEqual(op2, SymmOp.from_xyz_string(s2))
+        assert s2 == "3x-2y-z+1/2, -x+12/13, z+1/2"
+        assert op2 == SymmOp.from_xyz_string(s2)
 
         op3 = SymmOp.from_xyz_string("3x - 2y - z+1 /2 , -x+12/ 13, z+1/2")
-        self.assertEqual(op2, op3)
+        assert op2 == op3
 
         # Ensure strings can be read in any order
         op4 = SymmOp.from_xyz_string("1 /2 + 3X - 2y - z , 12/ 13-x, z+1/2")
         op5 = SymmOp.from_xyz_string("+1 /2 + 3x - 2y - z , 12/ 13-x, +1/2+z")
-        self.assertEqual(op4, op3)
-        self.assertEqual(op4, op5)
-        self.assertEqual(op3, op5)
+        assert op4 == op3
+        assert op4 == op5
+        assert op3 == op5
 
         # TODO: assertWarns not in Python 2.x unittest
         # update PymatgenTest for unittest2?
@@ -239,7 +239,7 @@ class MagSymmOpTestCase(PymatgenTest):
         for xyzt_string in xyzt_strings:
             op = MagSymmOp.from_xyzt_string(xyzt_string)
             xyzt_string_out = op.as_xyzt_string()
-            self.assertEqual(xyzt_string, xyzt_string_out)
+            assert xyzt_string == xyzt_string_out
 
         op = SymmOp(
             [
@@ -252,8 +252,8 @@ class MagSymmOpTestCase(PymatgenTest):
 
         magop = MagSymmOp.from_symmop(op, -1)
         magop_str = magop.as_xyzt_string()
-        self.assertEqual(magop.time_reversal, -1)
-        self.assertEqual(magop_str, "3x-2y-z+1/2, -x+12/13, z+1/2, -1")
+        assert magop.time_reversal == -1
+        assert magop_str == "3x-2y-z+1/2, -x+12/13, z+1/2, -1"
 
     def test_to_from_dict(self):
         op = SymmOp(
@@ -266,8 +266,8 @@ class MagSymmOpTestCase(PymatgenTest):
         )
         magop = MagSymmOp.from_symmop(op, -1)
         magop2 = MagSymmOp.from_dict(magop.as_dict())
-        self.assertEqual(magop2.time_reversal, -1)
-        self.assertEqual(magop2.as_xyzt_string(), "3x-2y-z+1/2, -x+12/13, z+1/2, -1")
+        assert magop2.time_reversal == -1
+        assert magop2.as_xyzt_string() == "3x-2y-z+1/2, -x+12/13, z+1/2, -1"
 
     def test_operate_magmom(self):
 
@@ -285,7 +285,7 @@ class MagSymmOpTestCase(PymatgenTest):
         for xyzt_string, transformed_magmom in zip(xyzt_strings, transformed_magmoms):
             for magmom in magmoms:
                 op = MagSymmOp.from_xyzt_string(xyzt_string)
-                self.assertTrue(np.allclose(transformed_magmom, op.operate_magmom(magmom).global_moment))
+                assert np.allclose(transformed_magmom, op.operate_magmom(magmom).global_moment)
 
 
 if __name__ == "__main__":

--- a/pymatgen/core/tests/test_periodic_table.py
+++ b/pymatgen/core/tests/test_periodic_table.py
@@ -10,6 +10,7 @@ import warnings
 from copy import deepcopy
 
 import numpy as np
+import pytest
 
 from pymatgen.core.periodic_table import (
     DummySpecies,
@@ -23,31 +24,32 @@ from pymatgen.util.testing import PymatgenTest
 
 class ElementTestCase(PymatgenTest):
     def test_init(self):
-        self.assertEqual("Fe", Element("Fe").symbol, "Fe test failed")
+        assert "Fe" == Element("Fe").symbol, "Fe test failed"
 
         fictional_symbols = ["D", "T", "Zebra"]
 
         for sym in fictional_symbols:
-            self.assertRaises(ValueError, Element, sym)
+            with pytest.raises(ValueError):
+                Element(sym)
 
         # Test caching
-        self.assertEqual(id(Element("Fe")), id(Element("Fe")))
+        assert id(Element("Fe")) == id(Element("Fe"))
 
     def test_is_metal(self):
         for metal in ["Fe", "Eu", "Li", "Ca", "In"]:
-            self.assertTrue(Element(metal).is_metal)
+            assert Element(metal).is_metal
         for non_metal in ["Ge", "Si", "O", "He"]:
-            self.assertFalse(Element(non_metal).is_metal)
+            assert not Element(non_metal).is_metal
 
     def test_nan_X(self):
-        self.assertTrue(math.isnan(Element.He.X))
+        assert math.isnan(Element.He.X)
         els = sorted([Element.He, Element.H, Element.F])
-        self.assertEqual(els, [Element.H, Element.F, Element.He])
+        assert els == [Element.H, Element.F, Element.He]
 
     def test_dict(self):
         fe = Element.Fe
         d = fe.as_dict()
-        self.assertEqual(fe, Element.from_dict(d))
+        assert fe == Element.from_dict(d)
 
     def test_block(self):
         testsets = {
@@ -60,7 +62,7 @@ class ElementTestCase(PymatgenTest):
             "Lr": "d",
         }
         for k, v in testsets.items():
-            self.assertEqual(Element(k).block, v)
+            assert Element(k).block == v
 
     def test_full_electronic_structure(self):
         testsets = {
@@ -97,9 +99,9 @@ class ElementTestCase(PymatgenTest):
             ],
         }
         for k, v in testsets.items():
-            self.assertEqual(Element(k).full_electronic_structure, v)
+            assert Element(k).full_electronic_structure == v
 
-        self.assertEqual(Element.Ac.electronic_structure, "[Rn].6d1.7s2")
+        assert Element.Ac.electronic_structure == "[Rn].6d1.7s2"
 
     def test_group(self):
         testsets = {
@@ -116,7 +118,7 @@ class ElementTestCase(PymatgenTest):
             "Og": 18,
         }
         for k, v in testsets.items():
-            self.assertEqual(Element(k).group, v)
+            assert Element(k).group == v
 
     def test_row(self):
         testsets = {
@@ -133,7 +135,7 @@ class ElementTestCase(PymatgenTest):
             "Og": 7,
         }
         for k, v in testsets.items():
-            self.assertEqual(Element(k).row, v)
+            assert Element(k).row == v
 
     def test_from_name(self):
         testsets = {
@@ -147,7 +149,7 @@ class ElementTestCase(PymatgenTest):
             "U": "Uranium",
         }
         for k, v in testsets.items():
-            self.assertEqual(ElementBase.from_name(v), Element(k))
+            assert ElementBase.from_name(v) == Element(k)
 
     def test_from_row_and_group(self):
         testsets = {
@@ -164,19 +166,19 @@ class ElementTestCase(PymatgenTest):
             "Og": (7, 18),
         }
         for k, v in testsets.items():
-            self.assertEqual(ElementBase.from_row_and_group(v[0], v[1]), Element(k))
+            assert ElementBase.from_row_and_group(v[0], v[1]) == Element(k)
 
     def test_valence(self):
         testsets = {"O": (1, 4), "Fe": (2, 6), "Li": (0, 1), "Be": (0, 2)}
         for k, v in testsets.items():
-            self.assertEqual(Element(k).valence, v)
+            assert Element(k).valence == v
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             Element("U").valence
 
         valence = Element("He").valence
-        self.assertTrue(np.isnan(valence[0]))
-        self.assertEqual(valence[1], 0)
+        assert np.isnan(valence[0])
+        assert valence[1] == 0
 
     def test_term_symbols(self):
         testsets = {
@@ -210,7 +212,7 @@ class ElementTestCase(PymatgenTest):
             ],  # f3
         }
         for k, v in testsets.items():
-            self.assertEqual(Element(k).term_symbols, v)
+            assert Element(k).term_symbols == v
 
     def test_ground_state_term_symbol(self):
         testsets = {
@@ -221,7 +223,7 @@ class ElementTestCase(PymatgenTest):
             "Pr": "4I4.5",
         }  # f3
         for k, v in testsets.items():
-            self.assertEqual(Element(k).ground_state_term_symbol, v)
+            assert Element(k).ground_state_term_symbol == v
 
     def test_attributes(self):
         is_true = {
@@ -238,7 +240,7 @@ class ElementTestCase(PymatgenTest):
 
         for k, v in is_true.items():
             for sym in k:
-                self.assertTrue(getattr(Element(sym), v), sym + " is false")
+                assert getattr(Element(sym), v), sym + " is false"
 
         keys = [
             "mendeleev_no",
@@ -288,63 +290,64 @@ class ElementTestCase(PymatgenTest):
             for k in keys:
                 k_str = k.capitalize().replace("_", " ")
                 if k_str in d and (not str(d[k_str]).startswith("no data")):
-                    self.assertIsNotNone(getattr(el, k))
+                    assert getattr(el, k) is not None
                 elif k == "long_name":
-                    self.assertEqual(getattr(el, "long_name"), d["Name"])
+                    assert el.long_name == d["Name"]
                 elif k == "iupac_ordering":
-                    self.assertTrue("IUPAC ordering" in d)
-                    self.assertIsNotNone(getattr(el, k))
+                    assert "IUPAC ordering" in d
+                    assert getattr(el, k) is not None
             el = Element.from_Z(i)
             if len(el.oxidation_states) > 0:
-                self.assertEqual(max(el.oxidation_states), el.max_oxidation_state)
-                self.assertEqual(min(el.oxidation_states), el.min_oxidation_state)
+                assert max(el.oxidation_states) == el.max_oxidation_state
+                assert min(el.oxidation_states) == el.min_oxidation_state
 
             if el.symbol not in ["He", "Ne", "Ar"]:
-                self.assertTrue(el.X > 0, f"No electroneg for {el}")
+                assert el.X > 0, f"No electroneg for {el}"
 
-        self.assertRaises(ValueError, Element.from_Z, 1000)
+        with pytest.raises(ValueError):
+            Element.from_Z(1000)
 
     def test_ie_ea(self):
-        self.assertAlmostEqual(Element.Fe.ionization_energies[2], 30.651)
-        self.assertEqual(Element.Fe.ionization_energy, Element.Fe.ionization_energies[0])
-        self.assertAlmostEqual(Element.Br.electron_affinity, 3.3635883)
+        assert round(abs(Element.Fe.ionization_energies[2] - 30.651), 7) == 0
+        assert Element.Fe.ionization_energy == Element.Fe.ionization_energies[0]
+        assert round(abs(Element.Br.electron_affinity - 3.3635883), 7) == 0
 
     def test_oxidation_states(self):
         el = Element.Fe
-        self.assertEqual(el.oxidation_states, (-2, -1, 1, 2, 3, 4, 5, 6))
-        self.assertEqual(el.common_oxidation_states, (2, 3))
-        self.assertEqual(el.icsd_oxidation_states, (2, 3))
+        assert el.oxidation_states == (-2, -1, 1, 2, 3, 4, 5, 6)
+        assert el.common_oxidation_states == (2, 3)
+        assert el.icsd_oxidation_states == (2, 3)
 
     def test_deepcopy(self):
         el1 = Element.Fe
         el2 = Element.Na
         ellist = [el1, el2]
-        self.assertEqual(ellist, deepcopy(ellist), "Deepcopy operation doesn't produce exact copy")
+        assert ellist == deepcopy(ellist), "Deepcopy operation doesn't produce exact copy"
 
     def test_radii(self):
         el = Element.Pd
-        self.assertEqual(el.atomic_radius, 1.40)
-        self.assertEqual(el.atomic_radius_calculated, 1.69)
-        self.assertEqual(el.van_der_waals_radius, 2.10)
+        assert el.atomic_radius == 1.40
+        assert el.atomic_radius_calculated == 1.69
+        assert el.van_der_waals_radius == 2.10
 
     def test_data(self):
-        self.assertEqual(Element.Pd.data["Atomic radius"], 1.4)
+        assert Element.Pd.data["Atomic radius"] == 1.4
         al = Element.Al
         val = al.thermal_conductivity
-        self.assertEqual(val, 235)
-        self.assertEqual(str(val.unit), "W K^-1 m^-1")
+        assert val == 235
+        assert str(val.unit) == "W K^-1 m^-1"
         val = al.electrical_resistivity
-        self.assertEqual(val, 2.7e-08)
-        self.assertEqual(str(val.unit), "m ohm")
+        assert val == 2.7e-08
+        assert str(val.unit) == "m ohm"
 
     def test_sort(self):
         els = [Element.Se, Element.C]
-        self.assertEqual(sorted(els), [Element.C, Element.Se])
+        assert sorted(els) == [Element.C, Element.Se]
 
     def test_pickle(self):
         el1 = Element.Fe
         o = pickle.dumps(el1)
-        self.assertEqual(el1, pickle.loads(o))
+        assert el1 == pickle.loads(o)
 
         # Test all elements up to Uranium
         for i in range(1, 93):
@@ -354,7 +357,7 @@ class ElementTestCase(PymatgenTest):
         Element.print_periodic_table()
 
     def test_is(self):
-        self.assertTrue(Element("Bi").is_post_transition_metal, True)
+        assert Element("Bi").is_post_transition_metal, True
 
 
 class SpecieTestCase(PymatgenTest):
@@ -365,40 +368,37 @@ class SpecieTestCase(PymatgenTest):
         self.specie4 = Species("Fe", 2, {"spin": 5})
 
     def test_init(self):
-        self.assertRaises(ValueError, Species, "Fe", 2, {"magmom": 5})
+        with pytest.raises(ValueError):
+            Species("Fe", 2, {"magmom": 5})
 
     def test_ionic_radius(self):
-        self.assertEqual(self.specie2.ionic_radius, 78.5 / 100)
-        self.assertEqual(self.specie3.ionic_radius, 92 / 100)
-        self.assertAlmostEqual(Species("Mn", 4).ionic_radius, 0.67)
+        assert self.specie2.ionic_radius == 78.5 / 100
+        assert self.specie3.ionic_radius == 92 / 100
+        assert round(abs(Species("Mn", 4).ionic_radius - 0.67), 7) == 0
 
     def test_eq(self):
-        self.assertEqual(
-            self.specie1,
-            self.specie3,
-            "Static and actual constructor gives unequal result!",
-        )
-        self.assertNotEqual(self.specie1, self.specie2, "Fe2+ should not be equal to Fe3+")
-        self.assertNotEqual(self.specie4, self.specie3)
-        self.assertFalse(self.specie1 == Element("Fe"))
-        self.assertFalse(Element("Fe") == self.specie1)
+        assert self.specie1 == self.specie3, "Static and actual constructor gives unequal result!"
+        assert self.specie1 != self.specie2, "Fe2+ should not be equal to Fe3+"
+        assert self.specie4 != self.specie3
+        assert not self.specie1 == Element("Fe")
+        assert not Element("Fe") == self.specie1
 
     def test_cmp(self):
-        self.assertLess(self.specie1, self.specie2, "Fe2+ should be < Fe3+")
-        self.assertLess(Species("C", 1), Species("Se", 1))
+        assert self.specie1 < self.specie2, "Fe2+ should be < Fe3+"
+        assert Species("C", 1) < Species("Se", 1)
 
     def test_attr(self):
-        self.assertEqual(self.specie1.Z, 26, "Z attribute for Fe2+ should be = Element Fe.")
-        self.assertEqual(self.specie4.spin, 5)
+        assert self.specie1.Z == 26, "Z attribute for Fe2+ should be = Element Fe."
+        assert self.specie4.spin == 5
 
     def test_deepcopy(self):
         el1 = Species("Fe", 4)
         el2 = Species("Na", 1)
         ellist = [el1, el2]
-        self.assertEqual(ellist, deepcopy(ellist), "Deepcopy operation doesn't produce exact copy.")
+        assert ellist == deepcopy(ellist), "Deepcopy operation doesn't produce exact copy."
 
     def test_pickle(self):
-        self.assertEqual(self.specie1, pickle.loads(pickle.dumps(self.specie1)))
+        assert self.specie1 == pickle.loads(pickle.dumps(self.specie1))
         for i in range(1, 5):
             self.serialize_with_pickle(getattr(self, f"specie{i}"), test_eq=True)
         cs = Species("Cs", 1)
@@ -409,67 +409,73 @@ class SpecieTestCase(PymatgenTest):
 
         with open("cscl.pickle", "rb") as f:
             d = pickle.load(f)
-            self.assertEqual(d, (cs, cl))
+            assert d == (cs, cl)
         os.remove("cscl.pickle")
 
     def test_get_crystal_field_spin(self):
-        self.assertEqual(Species("Fe", 2).get_crystal_field_spin(), 4)
-        self.assertEqual(Species("Fe", 3).get_crystal_field_spin(), 5)
-        self.assertEqual(Species("Fe", 4).get_crystal_field_spin(), 4)
-        self.assertEqual(Species("Co", 3).get_crystal_field_spin(spin_config="low"), 0)
-        self.assertEqual(Species("Co", 4).get_crystal_field_spin(spin_config="low"), 1)
-        self.assertEqual(Species("Ni", 3).get_crystal_field_spin(spin_config="low"), 1)
-        self.assertEqual(Species("Ni", 4).get_crystal_field_spin(spin_config="low"), 0)
+        assert Species("Fe", 2).get_crystal_field_spin() == 4
+        assert Species("Fe", 3).get_crystal_field_spin() == 5
+        assert Species("Fe", 4).get_crystal_field_spin() == 4
+        assert Species("Co", 3).get_crystal_field_spin(spin_config="low") == 0
+        assert Species("Co", 4).get_crystal_field_spin(spin_config="low") == 1
+        assert Species("Ni", 3).get_crystal_field_spin(spin_config="low") == 1
+        assert Species("Ni", 4).get_crystal_field_spin(spin_config="low") == 0
 
-        self.assertRaises(AttributeError, Species("Li", 1).get_crystal_field_spin)
-        self.assertRaises(AttributeError, Species("Ge", 4).get_crystal_field_spin)
-        self.assertRaises(AttributeError, Species("H", 1).get_crystal_field_spin)
-        self.assertRaises(AttributeError, Species("Fe", 10).get_crystal_field_spin)
-        self.assertRaises(ValueError, Species("Fe", 2).get_crystal_field_spin, "hex")
+        with pytest.raises(AttributeError):
+            Species("Li", 1).get_crystal_field_spin()
+        with pytest.raises(AttributeError):
+            Species("Ge", 4).get_crystal_field_spin()
+        with pytest.raises(AttributeError):
+            Species("H", 1).get_crystal_field_spin()
+        with pytest.raises(AttributeError):
+            Species("Fe", 10).get_crystal_field_spin()
+        with pytest.raises(ValueError):
+            Species("Fe", 2).get_crystal_field_spin("hex")
 
         s = Species("Co", 3).get_crystal_field_spin("tet", spin_config="low")
-        self.assertEqual(s, 2)
+        assert s == 2
 
     def test_get_nmr_mom(self):
-        self.assertEqual(Species("H").get_nmr_quadrupole_moment(), 2.860)
-        self.assertEqual(Species("Li").get_nmr_quadrupole_moment(), -0.808)
-        self.assertEqual(Species("Li").get_nmr_quadrupole_moment("Li-7"), -40.1)
-        self.assertEqual(Species("Si").get_nmr_quadrupole_moment(), 0.0)
-        self.assertRaises(ValueError, Species("Li").get_nmr_quadrupole_moment, "Li-109")
+        assert Species("H").get_nmr_quadrupole_moment() == 2.860
+        assert Species("Li").get_nmr_quadrupole_moment() == -0.808
+        assert Species("Li").get_nmr_quadrupole_moment("Li-7") == -40.1
+        assert Species("Si").get_nmr_quadrupole_moment() == 0.0
+        with pytest.raises(ValueError):
+            Species("Li").get_nmr_quadrupole_moment("Li-109")
 
     def test_get_shannon_radius(self):
-        self.assertEqual(Species("Li", 1).get_shannon_radius("IV"), 0.59)
+        assert Species("Li", 1).get_shannon_radius("IV") == 0.59
         mn2 = Species("Mn", 2)
-        self.assertEqual(mn2.get_shannon_radius("IV", "High Spin"), 0.66)
-        self.assertEqual(mn2.get_shannon_radius("V", "High Spin"), 0.75)
+        assert mn2.get_shannon_radius("IV", "High Spin") == 0.66
+        assert mn2.get_shannon_radius("V", "High Spin") == 0.75
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             # Trigger a warning.
             r = mn2.get_shannon_radius("V")
             # Verify some things
-            self.assertEqual(len(w), 1)
-            self.assertIs(w[-1].category, UserWarning)
-            self.assertEqual(r, 0.75)
+            assert len(w) == 1
+            assert w[-1].category is UserWarning
+            assert r == 0.75
 
-        self.assertEqual(mn2.get_shannon_radius("VI", "Low Spin"), 0.67)
-        self.assertEqual(mn2.get_shannon_radius("VI", "High Spin"), 0.83)
-        self.assertEqual(mn2.get_shannon_radius("VII", "High Spin"), 0.9)
-        self.assertEqual(mn2.get_shannon_radius("VIII"), 0.96)
+        assert mn2.get_shannon_radius("VI", "Low Spin") == 0.67
+        assert mn2.get_shannon_radius("VI", "High Spin") == 0.83
+        assert mn2.get_shannon_radius("VII", "High Spin") == 0.9
+        assert mn2.get_shannon_radius("VIII") == 0.96
 
     def test_sort(self):
         els = map(get_el_sp, ["N3-", "Si4+", "Si3+"])
-        self.assertEqual(sorted(els), [Species("Si", 3), Species("Si", 4), Species("N", -3)])
+        assert sorted(els) == [Species("Si", 3), Species("Si", 4), Species("N", -3)]
 
     def test_to_from_string(self):
         fe3 = Species("Fe", 3, {"spin": 5})
-        self.assertEqual(str(fe3), "Fe3+,spin=5")
+        assert str(fe3) == "Fe3+,spin=5"
         fe = Species.from_string("Fe3+,spin=5")
-        self.assertEqual(fe.spin, 5)
+        assert fe.spin == 5
         mo0 = Species("Mo", 0, {"spin": 5})
-        self.assertEqual(str(mo0), "Mo0+,spin=5")
+        assert str(mo0) == "Mo0+,spin=5"
         mo = Species.from_string("Mo0+,spin=4")
-        self.assertEqual(mo.spin, 4)
+        assert mo.spin == 4
 
         # Shyue Ping: I don't understand the need for a None for oxidation state. That to me is basically an element.
         # Why make the thing so complicated for a use case that I have never seen???
@@ -479,61 +485,64 @@ class SpecieTestCase(PymatgenTest):
 
     def test_no_oxidation_state(self):
         mo0 = Species("Mo", None, {"spin": 5})
-        self.assertEqual(str(mo0), "Mo,spin=5")
+        assert str(mo0) == "Mo,spin=5"
 
     def test_stringify(self):
-        self.assertEqual(self.specie2.to_latex_string(), "Fe$^{3+}$")
-        self.assertEqual(self.specie2.to_unicode_string(), "Fe³⁺")
-        self.assertEqual(Species("S", -2).to_latex_string(), "S$^{2-}$")
-        self.assertEqual(Species("S", -2).to_unicode_string(), "S²⁻")
+        assert self.specie2.to_latex_string() == "Fe$^{3+}$"
+        assert self.specie2.to_unicode_string() == "Fe³⁺"
+        assert Species("S", -2).to_latex_string() == "S$^{2-}$"
+        assert Species("S", -2).to_unicode_string() == "S²⁻"
 
 
 class DummySpecieTestCase(unittest.TestCase):
     def test_init(self):
         self.specie1 = DummySpecies("X")
-        self.assertRaises(ValueError, DummySpecies, "Xe")
-        self.assertRaises(ValueError, DummySpecies, "Xec")
-        self.assertRaises(ValueError, DummySpecies, "Vac")
+        with pytest.raises(ValueError):
+            DummySpecies("Xe")
+        with pytest.raises(ValueError):
+            DummySpecies("Xec")
+        with pytest.raises(ValueError):
+            DummySpecies("Vac")
         self.specie2 = DummySpecies("X", 2, {"spin": 3})
-        self.assertEqual(self.specie2.spin, 3)
+        assert self.specie2.spin == 3
 
     def test_eq(self):
-        self.assertFalse(DummySpecies("Xg") == DummySpecies("Xh"))
-        self.assertFalse(DummySpecies("Xg") == DummySpecies("Xg", 3))
-        self.assertTrue(DummySpecies("Xg", 3) == DummySpecies("Xg", 3))
+        assert not DummySpecies("Xg") == DummySpecies("Xh")
+        assert not DummySpecies("Xg") == DummySpecies("Xg", 3)
+        assert DummySpecies("Xg", 3) == DummySpecies("Xg", 3)
 
     def test_from_string(self):
         sp = DummySpecies.from_string("X")
-        self.assertEqual(sp.oxi_state, 0)
+        assert sp.oxi_state == 0
         sp = DummySpecies.from_string("X2+")
-        self.assertEqual(sp.oxi_state, 2)
-        self.assertEqual(sp.to_latex_string(), "X$^{2+}$")
+        assert sp.oxi_state == 2
+        assert sp.to_latex_string() == "X$^{2+}$"
         sp = DummySpecies.from_string("X2+spin=5")
-        self.assertEqual(sp.oxi_state, 2)
-        self.assertEqual(sp.spin, 5)
-        self.assertEqual(sp.to_latex_string(), "X$^{2+}$")
-        self.assertEqual(sp.to_html_string(), "X<sup>2+</sup>")
-        self.assertEqual(sp.to_unicode_string(), "X²⁺")
+        assert sp.oxi_state == 2
+        assert sp.spin == 5
+        assert sp.to_latex_string() == "X$^{2+}$"
+        assert sp.to_html_string() == "X<sup>2+</sup>"
+        assert sp.to_unicode_string() == "X²⁺"
 
     def test_pickle(self):
         el1 = DummySpecies("X", 3)
         o = pickle.dumps(el1)
-        self.assertEqual(el1, pickle.loads(o))
+        assert el1 == pickle.loads(o)
 
     def test_sort(self):
         r = sorted([Element.Fe, DummySpecies("X")])
-        self.assertEqual(r, [DummySpecies("X"), Element.Fe])
-        self.assertTrue(DummySpecies("X", 3) < DummySpecies("X", 4))
+        assert r == [DummySpecies("X"), Element.Fe]
+        assert DummySpecies("X", 3) < DummySpecies("X", 4)
 
 
 class FuncTest(unittest.TestCase):
     def test_get_el_sp(self):
-        self.assertEqual(get_el_sp("Fe2+"), Species("Fe", 2))
-        self.assertEqual(get_el_sp("3"), Element.Li)
-        self.assertEqual(get_el_sp("3.0"), Element.Li)
-        self.assertEqual(get_el_sp("U"), Element.U)
-        self.assertEqual(get_el_sp("X2+"), DummySpecies("X", 2))
-        self.assertEqual(get_el_sp("Mn3+"), Species("Mn", 3))
+        assert get_el_sp("Fe2+") == Species("Fe", 2)
+        assert get_el_sp("3") == Element.Li
+        assert get_el_sp("3.0") == Element.Li
+        assert get_el_sp("U") == Element.U
+        assert get_el_sp("X2+") == DummySpecies("X", 2)
+        assert get_el_sp("Mn3+") == Species("Mn", 3)
 
 
 if __name__ == "__main__":

--- a/pymatgen/core/tests/test_sites.py
+++ b/pymatgen/core/tests/test_sites.py
@@ -5,6 +5,7 @@
 import pickle
 
 import numpy as np
+import pytest
 
 from pymatgen.core.composition import Composition
 from pymatgen.core.lattice import Lattice
@@ -27,56 +28,58 @@ class SiteTest(PymatgenTest):
         self.dummy_site = Site("X", [0, 0, 0])
 
     def test_properties(self):
-        self.assertRaises(AttributeError, getattr, self.disordered_site, "specie")
-        self.assertIsInstance(self.ordered_site.specie, Element)
-        self.assertEqual(self.propertied_site.properties["magmom"], 5.1)
-        self.assertEqual(self.propertied_site.properties["charge"], 4.2)
+        with pytest.raises(AttributeError):
+            self.disordered_site.specie
+        assert isinstance(self.ordered_site.specie, Element)
+        assert self.propertied_site.properties["magmom"] == 5.1
+        assert self.propertied_site.properties["charge"] == 4.2
 
     def test_to_from_dict(self):
         d = self.disordered_site.as_dict()
         site = Site.from_dict(d)
-        self.assertEqual(site, self.disordered_site)
-        self.assertNotEqual(site, self.ordered_site)
+        assert site == self.disordered_site
+        assert site != self.ordered_site
         d = self.propertied_site.as_dict()
         site = Site.from_dict(d)
-        self.assertEqual(site.properties["magmom"], 5.1)
-        self.assertEqual(site.properties["charge"], 4.2)
+        assert site.properties["magmom"] == 5.1
+        assert site.properties["charge"] == 4.2
         d = self.propertied_magmomvector_site.as_dict()
         site = Site.from_dict(d)
-        self.assertEqual(site.properties["magmom"], Magmom([2.6, 2.6, 3.5]))
-        self.assertEqual(site.properties["charge"], 4.2)
+        assert site.properties["magmom"] == Magmom([2.6, 2.6, 3.5])
+        assert site.properties["charge"] == 4.2
         d = self.dummy_site.as_dict()
         site = Site.from_dict(d)
-        self.assertEqual(site.species, self.dummy_site.species)
+        assert site.species == self.dummy_site.species
 
     def test_hash(self):
-        self.assertEqual(hash(self.ordered_site), 26)
-        self.assertEqual(hash(self.disordered_site), 51)
+        assert hash(self.ordered_site) == 26
+        assert hash(self.disordered_site) == 51
 
     def test_cmp(self):
-        self.assertTrue(self.ordered_site > self.disordered_site)
+        assert self.ordered_site > self.disordered_site
 
     def test_distance(self):
         osite = self.ordered_site
-        self.assertAlmostEqual(np.linalg.norm([0.25, 0.35, 0.45]), osite.distance_from_point([0, 0, 0]))
-        self.assertAlmostEqual(osite.distance(self.disordered_site), 0)
+        assert round(abs(np.linalg.norm([0.25, 0.35, 0.45]) - osite.distance_from_point([0, 0, 0])), 7) == 0
+        assert round(abs(osite.distance(self.disordered_site) - 0), 7) == 0
 
     def test_pickle(self):
         o = pickle.dumps(self.propertied_site)
-        self.assertEqual(pickle.loads(o), self.propertied_site)
+        assert pickle.loads(o) == self.propertied_site
 
     def test_setters(self):
         self.disordered_site.species = "Cu"
-        self.assertEqual(self.disordered_site.species, Composition("Cu"))
+        assert self.disordered_site.species == Composition("Cu")
         self.disordered_site.x = 1.25
         self.disordered_site.y = 1.35
-        self.assertEqual(self.disordered_site.coords[0], 1.25)
-        self.assertEqual(self.disordered_site.coords[1], 1.35)
+        assert self.disordered_site.coords[0] == 1.25
+        assert self.disordered_site.coords[1] == 1.35
 
         def set_bad_species():
             self.disordered_site.species = {"Cu": 0.5, "Gd": 0.6}
 
-        self.assertRaises(ValueError, set_bad_species)
+        with pytest.raises(ValueError):
+            set_bad_species()
 
 
 class PeriodicSiteTest(PymatgenTest):
@@ -85,11 +88,7 @@ class PeriodicSiteTest(PymatgenTest):
         self.si = Element("Si")
         self.site = PeriodicSite("Fe", [0.25, 0.35, 0.45], self.lattice)
         self.site2 = PeriodicSite({"Si": 0.5}, [0, 0, 0], self.lattice)
-        self.assertEqual(
-            self.site2.species,
-            Composition({Element("Si"): 0.5}),
-            "Inconsistent site created!",
-        )
+        assert self.site2.species == Composition({Element("Si"): 0.5}), "Inconsistent site created!"
         self.propertied_site = PeriodicSite(
             Species("Fe", 2),
             [0.25, 0.35, 0.45],
@@ -102,101 +101,85 @@ class PeriodicSiteTest(PymatgenTest):
         """
         Test the properties for a site
         """
-        self.assertEqual(self.site.a, 0.25)
-        self.assertEqual(self.site.b, 0.35)
-        self.assertEqual(self.site.c, 0.45)
-        self.assertEqual(self.site.x, 2.5)
-        self.assertEqual(self.site.y, 3.5)
-        self.assertEqual(self.site.z, 4.5)
-        self.assertTrue(self.site.is_ordered)
-        self.assertFalse(self.site2.is_ordered)
-        self.assertEqual(self.propertied_site.properties["magmom"], 5.1)
-        self.assertEqual(self.propertied_site.properties["charge"], 4.2)
+        assert self.site.a == 0.25
+        assert self.site.b == 0.35
+        assert self.site.c == 0.45
+        assert self.site.x == 2.5
+        assert self.site.y == 3.5
+        assert self.site.z == 4.5
+        assert self.site.is_ordered
+        assert not self.site2.is_ordered
+        assert self.propertied_site.properties["magmom"] == 5.1
+        assert self.propertied_site.properties["charge"] == 4.2
 
     def test_distance(self):
         other_site = PeriodicSite("Fe", np.array([0, 0, 0]), self.lattice)
-        self.assertAlmostEqual(self.site.distance(other_site), 6.22494979899, 5)
+        assert round(abs(self.site.distance(other_site) - 6.22494979899), 5) == 0
 
     def test_distance_from_point(self):
-        self.assertNotAlmostEqual(self.site.distance_from_point([0.1, 0.1, 0.1]), 6.22494979899, 5)
-        self.assertAlmostEqual(self.site.distance_from_point([0.1, 0.1, 0.1]), 6.0564015718906887, 5)
+        assert round(abs(self.site.distance_from_point([0.1, 0.1, 0.1]) - 6.22494979899), 5) != 0
+        assert round(abs(self.site.distance_from_point([0.1, 0.1, 0.1]) - 6.0564015718906887), 5) == 0
 
     def test_distance_and_image(self):
         other_site = PeriodicSite("Fe", np.array([1, 1, 1]), self.lattice)
         (distance, image) = self.site.distance_and_image(other_site)
-        self.assertAlmostEqual(distance, 6.22494979899, 5)
-        self.assertTrue(([-1, -1, -1] == image).all())
+        assert round(abs(distance - 6.22494979899), 5) == 0
+        assert ([-1, -1, -1] == image).all()
         (distance, image) = self.site.distance_and_image(other_site, [1, 0, 0])
-        self.assertAlmostEqual(distance, 19.461500456028563, 5)
+        assert round(abs(distance - 19.461500456028563), 5) == 0
         # Test that old and new distance algo give the same ans for
         # "standard lattices"
         lattice = Lattice(np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]))
         site1 = PeriodicSite("Fe", np.array([0.01, 0.02, 0.03]), lattice)
         site2 = PeriodicSite("Fe", np.array([0.99, 0.98, 0.97]), lattice)
-        self.assertAlmostEqual(
-            get_distance_and_image_old(site1, site2)[0],
-            site1.distance_and_image(site2)[0],
-        )
+        assert round(abs(get_distance_and_image_old(site1, site2)[0] - site1.distance_and_image(site2)[0]), 7) == 0
         lattice = Lattice.from_parameters(1, 0.01, 1, 10, 10, 10)
         site1 = PeriodicSite("Fe", np.array([0.01, 0.02, 0.03]), lattice)
         site2 = PeriodicSite("Fe", np.array([0.99, 0.98, 0.97]), lattice)
-        self.assertTrue(get_distance_and_image_old(site1, site2)[0] > site1.distance_and_image(site2)[0])
+        assert get_distance_and_image_old(site1, site2)[0] > site1.distance_and_image(site2)[0]
         site2 = PeriodicSite("Fe", np.random.rand(3), lattice)
         (dist_old, jimage_old) = get_distance_and_image_old(site1, site2)
         (dist_new, jimage_new) = site1.distance_and_image(site2)
-        self.assertTrue(
-            dist_old - dist_new > -1e-8,
-            "New distance algo should give smaller answers!",
-        )
-        self.assertFalse(
-            (abs(dist_old - dist_new) < 1e-8) ^ (jimage_old == jimage_new).all(),
-            "If old dist == new dist, images must be the same!",
-        )
+        assert dist_old - dist_new > -1e-8, "New distance algo should give smaller answers!"
+        assert (
+            not (abs(dist_old - dist_new) < 1e-8) ^ (jimage_old == jimage_new).all()
+        ), "If old dist == new dist, images must be the same!"
         latt = Lattice.from_parameters(3.0, 3.1, 10.0, 2.96, 2.0, 1.0)
         site = PeriodicSite("Fe", [0.1, 0.1, 0.1], latt)
         site2 = PeriodicSite("Fe", [0.99, 0.99, 0.99], latt)
         (dist, img) = site.distance_and_image(site2)
-        self.assertAlmostEqual(dist, 0.15495358379511573)
-        self.assertEqual(list(img), [-11, 6, 0])
+        assert round(abs(dist - 0.15495358379511573), 7) == 0
+        assert list(img) == [-11, 6, 0]
 
     def test_is_periodic_image(self):
         other = PeriodicSite("Fe", np.array([1.25, 2.35, 4.45]), self.lattice)
-        self.assertTrue(
-            self.site.is_periodic_image(other),
-            "This other site should be a periodic image.",
-        )
+        assert self.site.is_periodic_image(other), "This other site should be a periodic image."
         other = PeriodicSite("Fe", np.array([1.25, 2.35, 4.46]), self.lattice)
-        self.assertFalse(
-            self.site.is_periodic_image(other),
-            "This other site should not be a periodic image.",
-        )
+        assert not self.site.is_periodic_image(other), "This other site should not be a periodic image."
         other = PeriodicSite("Fe", np.array([1.25, 2.35, 4.45]), Lattice.rhombohedral(2, 60))
-        self.assertFalse(
-            self.site.is_periodic_image(other),
-            "Different lattices should not be periodic images.",
-        )
+        assert not self.site.is_periodic_image(other), "Different lattices should not be periodic images."
 
     def test_equality(self):
         other_site = PeriodicSite("Fe", np.array([1, 1, 1]), self.lattice)
-        self.assertTrue(self.site == self.site)
-        self.assertFalse(other_site == self.site)
-        self.assertFalse(self.site != self.site)
-        self.assertTrue(other_site != self.site)
+        assert self.site == self.site
+        assert not other_site == self.site
+        assert not self.site != self.site
+        assert other_site != self.site
 
     def test_as_from_dict(self):
         d = self.site2.as_dict()
         site = PeriodicSite.from_dict(d)
-        self.assertEqual(site, self.site2)
-        self.assertNotEqual(site, self.site)
+        assert site == self.site2
+        assert site != self.site
         d = self.propertied_site.as_dict()
         site3 = PeriodicSite({"Si": 0.5, "Fe": 0.5}, [0, 0, 0], self.lattice)
         d = site3.as_dict()
         site = PeriodicSite.from_dict(d)
-        self.assertEqual(site.species, site3.species)
+        assert site.species == site3.species
 
         d = self.dummy_site.as_dict()
         site = PeriodicSite.from_dict(d)
-        self.assertEqual(site.species, self.dummy_site.species)
+        assert site.species == self.dummy_site.species
 
     def test_to_unit_cell(self):
         site = PeriodicSite("Fe", np.array([1.25, 2.35, 4.46]), self.lattice)
@@ -213,20 +196,21 @@ class PeriodicSiteTest(PymatgenTest):
     def test_setters(self):
         site = self.propertied_site
         site.species = "Cu"
-        self.assertEqual(site.species, Composition("Cu"))
+        assert site.species == Composition("Cu")
         site.x = 1.25
         site.y = 1.35
-        self.assertEqual(site.coords[0], 1.25)
-        self.assertEqual(site.coords[1], 1.35)
-        self.assertEqual(site.a, 0.125)
-        self.assertEqual(site.b, 0.135)
+        assert site.coords[0] == 1.25
+        assert site.coords[1] == 1.35
+        assert site.a == 0.125
+        assert site.b == 0.135
         site.lattice = Lattice.cubic(100)
-        self.assertEqual(site.x, 12.5)
+        assert site.x == 12.5
 
         def set_bad_species():
             site.species = {"Cu": 0.5, "Gd": 0.6}
 
-        self.assertRaises(ValueError, set_bad_species)
+        with pytest.raises(ValueError):
+            set_bad_species()
 
         site.frac_coords = [0, 0, 0.1]
         self.assertArrayAlmostEqual(site.coords, [0, 0, 10])
@@ -234,10 +218,7 @@ class PeriodicSiteTest(PymatgenTest):
         self.assertArrayAlmostEqual(site.frac_coords, [0.015, 0.0325, 0.05])
 
     def test_repr(self):
-        self.assertEqual(
-            repr(self.propertied_site),
-            "PeriodicSite: Fe2+ (2.5000, 3.5000, 4.5000) [0.2500, 0.3500, 0.4500]",
-        )
+        assert repr(self.propertied_site) == "PeriodicSite: Fe2+ (2.5000, 3.5000, 4.5000) [0.2500, 0.3500, 0.4500]"
 
 
 def get_distance_and_image_old(site1, site2, jimage=None):

--- a/pymatgen/core/tests/test_spectrum.py
+++ b/pymatgen/core/tests/test_spectrum.py
@@ -20,34 +20,31 @@ class SpectrumTest(PymatgenTest):
 
     def test_normalize(self):
         self.spec1.normalize(mode="max")
-        self.assertAlmostEqual(np.max(self.spec1.y), 1)
+        assert round(abs(np.max(self.spec1.y) - 1), 7) == 0
         self.spec1.normalize(mode="sum")
-        self.assertAlmostEqual(np.sum(self.spec1.y), 1)
+        assert round(abs(np.sum(self.spec1.y) - 1), 7) == 0
 
         self.multi_spec1.normalize(mode="sum")
-        self.assertAlmostEqual(np.sum(self.multi_spec1.y[:, 0]), 1)
-        self.assertAlmostEqual(np.sum(self.multi_spec1.y[:, 1]), 1)
+        assert round(abs(np.sum(self.multi_spec1.y[:, 0]) - 1), 7) == 0
+        assert round(abs(np.sum(self.multi_spec1.y[:, 1]) - 1), 7) == 0
 
         # XRD style mode.
         self.spec1.normalize(mode="max", value=100)
-        self.assertAlmostEqual(np.max(self.spec1.y), 100)
+        assert round(abs(np.max(self.spec1.y) - 100), 7) == 0
 
     def test_operators(self):
         scaled_spect = 3 * self.spec1 + self.spec2
-        self.assertTrue(np.allclose(scaled_spect.y, 3 * self.spec1.y + self.spec2.y))
-        self.assertAlmostEqual(
-            self.spec1.get_interpolated_value(0.05),
-            (self.spec1.y[0] + self.spec1.y[1]) / 2,
-        )
+        assert np.allclose(scaled_spect.y, 3 * self.spec1.y + self.spec2.y)
+        assert round(abs(self.spec1.get_interpolated_value(0.05) - (self.spec1.y[0] + self.spec1.y[1]) / 2), 7) == 0
 
         scaled_spect = self.spec1 - self.spec2
-        self.assertTrue(np.allclose(scaled_spect.y, self.spec1.y - self.spec2.y))
+        assert np.allclose(scaled_spect.y, self.spec1.y - self.spec2.y)
 
         scaled_spect = self.spec1 / 3
-        self.assertTrue(np.allclose(scaled_spect.y, self.spec1.y / 3))
+        assert np.allclose(scaled_spect.y, self.spec1.y / 3)
 
         scaled_spect = 3 * self.multi_spec1 + self.multi_spec2
-        self.assertTrue(np.allclose(scaled_spect.y, 3 * self.multi_spec1.y + self.multi_spec2.y))
+        assert np.allclose(scaled_spect.y, 3 * self.multi_spec1.y + self.multi_spec2.y)
         self.assertArrayAlmostEqual(
             self.multi_spec1.get_interpolated_value(0.05),
             (self.multi_spec1.y[0, :] + self.multi_spec1.y[1, :]) / 2,
@@ -60,34 +57,34 @@ class SpectrumTest(PymatgenTest):
         y[75] = 1
         spec = Spectrum(np.linspace(-10, 10, 100), y)
         spec.smear(0.3)
-        self.assertFalse(np.allclose(y, spec.y))
-        self.assertAlmostEqual(sum(y), sum(spec.y))
+        assert not np.allclose(y, spec.y)
+        assert round(abs(sum(y) - sum(spec.y)), 7) == 0
 
         # Test direct callable use of smearing.
         spec2 = Spectrum(np.linspace(-10, 10, 100), y)
         spec2.smear(0, func=lambda x: stats.norm.pdf(x, scale=0.3))
-        self.assertTrue(np.allclose(spec.y, spec2.y))
+        assert np.allclose(spec.y, spec2.y)
 
         spec = Spectrum(np.linspace(-10, 10, 100), y)
         spec.smear(0.3, func="lorentzian")
-        self.assertFalse(np.allclose(y, spec.y))
-        self.assertAlmostEqual(sum(y), sum(spec.y))
+        assert not np.allclose(y, spec.y)
+        assert round(abs(sum(y) - sum(spec.y)), 7) == 0
 
         y = np.array(self.multi_spec1.y)
         self.multi_spec1.smear(0.2)
-        self.assertFalse(np.allclose(y, self.multi_spec1.y))
+        assert not np.allclose(y, self.multi_spec1.y)
         self.assertArrayAlmostEqual(np.sum(y, axis=0), np.sum(self.multi_spec1.y, axis=0))
 
     def test_str(self):
         # Just make sure that these methods work.
-        self.assertIsNotNone(str(self.spec1))
-        self.assertIsNotNone(str(self.multi_spec1))
+        assert str(self.spec1) is not None
+        assert str(self.multi_spec1) is not None
 
     def test_copy(self):
         spec1copy = self.spec1.copy()
         spec1copy.y[0] = spec1copy.y[0] + 1
-        self.assertNotEqual(spec1copy.y[0], self.spec1.y[0])
-        self.assertEqual(spec1copy.y[1], self.spec1.y[1])
+        assert spec1copy.y[0] != self.spec1.y[0]
+        assert spec1copy.y[1] == self.spec1.y[1]
 
 
 if __name__ == "__main__":

--- a/pymatgen/core/tests/test_structure.py
+++ b/pymatgen/core/tests/test_structure.py
@@ -45,20 +45,19 @@ class IStructureTest(PymatgenTest):
             ]
         )
         self.struct = IStructure(self.lattice, ["Si"] * 2, coords)
-        self.assertEqual(len(self.struct), 2, "Wrong number of sites in structure!")
-        self.assertTrue(self.struct.is_ordered)
-        self.assertTrue(self.struct.ntypesp == 1)
+        assert len(self.struct) == 2, "Wrong number of sites in structure!"
+        assert self.struct.is_ordered
+        assert self.struct.ntypesp == 1
         coords = []
         coords.append([0, 0, 0])
         coords.append([0.0, 0, 0.0000001])
-        self.assertRaises(
-            StructureError,
-            IStructure,
-            self.lattice,
-            ["Si"] * 2,
-            coords,
-            validate_proximity=True,
-        )
+        with pytest.raises(StructureError):
+            IStructure(
+                self.lattice,
+                ["Si"] * 2,
+                coords,
+                validate_proximity=True,
+            )
         self.propertied_structure = IStructure(self.lattice, ["Si"] * 2, coords, site_properties={"magmom": [5, -5]})
 
         self.lattice_pbc = Lattice(
@@ -73,72 +72,71 @@ class IStructureTest(PymatgenTest):
     @unittest.skipIf(not (mcsqs_cmd and enum_cmd), "enumlib or mcsqs executable not present")
     def test_get_orderings(self):
         ordered = Structure.from_spacegroup("Im-3m", Lattice.cubic(3), ["Fe"], [[0, 0, 0]])
-        self.assertEqual(ordered.get_orderings()[0], ordered)
+        assert ordered.get_orderings()[0] == ordered
         disordered = Structure.from_spacegroup("Im-3m", Lattice.cubic(3), [Composition("Fe0.5Mn0.5")], [[0, 0, 0]])
         orderings = disordered.get_orderings()
-        self.assertEqual(len(orderings), 1)
+        assert len(orderings) == 1
         super_cell = disordered * 2
         orderings = super_cell.get_orderings()
-        self.assertEqual(len(orderings), 59)
+        assert len(orderings) == 59
         sqs = disordered.get_orderings(mode="sqs", scaling=[2, 2, 2])
-        self.assertEqual(sqs[0].formula, "Mn8 Fe8")
+        assert sqs[0].formula == "Mn8 Fe8"
 
         sqs = super_cell.get_orderings(mode="sqs")
-        self.assertEqual(sqs[0].formula, "Mn8 Fe8")
+        assert sqs[0].formula == "Mn8 Fe8"
 
     def test_as_dataframe(self):
         df = self.propertied_structure.as_dataframe()
-        self.assertEqual(df.attrs["Reduced Formula"], "Si")
-        self.assertEqual(df.shape, (2, 8))
+        assert df.attrs["Reduced Formula"] == "Si"
+        assert df.shape == (2, 8)
 
     def test_equal(self):
         struct = self.struct
-        self.assertTrue(struct == struct)
-        self.assertTrue(struct == struct.copy())
-        self.assertFalse(struct == 2 * struct)
+        assert struct == struct
+        assert struct == struct.copy()
+        assert not struct == 2 * struct
 
-        self.assertFalse(struct == "a" * len(struct))  # GH-2584
-        self.assertFalse(struct is None)
-        self.assertFalse(struct == 42)  # GH-2587
+        assert not struct == "a" * len(struct)  # GH-2584
+        assert struct is not None
+        assert not struct == 42  # GH-2587
 
-        self.assertTrue(struct == Structure.from_dict(struct.as_dict()))
+        assert struct == Structure.from_dict(struct.as_dict())
 
         struct_2 = Structure.from_sites(struct)
-        self.assertTrue(struct, struct_2)
+        assert struct, struct_2
         struct_2.apply_strain(0.5)
-        self.assertNotEqual(struct, struct_2)
+        assert struct != struct_2
 
     def test_matches(self):
         ss = self.struct * 2
-        self.assertTrue(ss.matches(self.struct))
+        assert ss.matches(self.struct)
 
     def test_bad_structure(self):
         coords = []
         coords.append([0, 0, 0])
         coords.append([0.75, 0.5, 0.75])
         coords.append([0.75, 0.5, 0.75])
-        self.assertRaises(
-            StructureError,
-            IStructure,
-            self.lattice,
-            ["Si"] * 3,
-            coords,
-            validate_proximity=True,
-        )
+        with pytest.raises(StructureError):
+            IStructure(
+                self.lattice,
+                ["Si"] * 3,
+                coords,
+                validate_proximity=True,
+            )
         # these shouldn't raise an error
         IStructure(self.lattice, ["Si"] * 2, coords[:2], True)
         IStructure(self.lattice, ["Si"], coords[:1], True)
 
     def test_volume_and_density(self):
-        self.assertAlmostEqual(self.struct.volume, 40.04, 2, "Volume wrong!")
-        self.assertAlmostEqual(self.struct.density, 2.33, 2, "Incorrect density")
+        assert round(abs(self.struct.volume - 40.04), 2) == 0, "Volume wrong!"
+        assert round(abs(self.struct.density - 2.33), 2) == 0, "Incorrect density"
 
     def test_specie_init(self):
         coords = []
         coords.append([0, 0, 0])
         coords.append([0.75, 0.5, 0.75])
         s = IStructure(self.lattice, [{Species("O", -2): 1.0}, {Species("Mg", 2): 0.8}], coords)
-        self.assertEqual(s.composition.formula, "Mg0.8 O1")
+        assert s.composition.formula == "Mg0.8 O1"
 
     def test_get_sorted_structure(self):
         coords = []
@@ -146,40 +144,34 @@ class IStructureTest(PymatgenTest):
         coords.append([0.75, 0.5, 0.75])
         s = IStructure(self.lattice, ["O", "Li"], coords, site_properties={"charge": [-2, 1]})
         sorted_s = s.get_sorted_structure()
-        self.assertEqual(sorted_s[0].species, Composition("Li"))
-        self.assertEqual(sorted_s[1].species, Composition("O"))
-        self.assertEqual(sorted_s[0].charge, 1)
-        self.assertEqual(sorted_s[1].charge, -2)
+        assert sorted_s[0].species == Composition("Li")
+        assert sorted_s[1].species == Composition("O")
+        assert sorted_s[0].charge == 1
+        assert sorted_s[1].charge == -2
         s = IStructure(
             self.lattice,
             ["Se", "C", "Se", "C"],
             [[0] * 3, [0.5] * 3, [0.25] * 3, [0.75] * 3],
         )
-        self.assertEqual(
-            [site.specie.symbol for site in s.get_sorted_structure()],
-            ["C", "C", "Se", "Se"],
-        )
+        assert [site.specie.symbol for site in s.get_sorted_structure()] == ["C", "C", "Se", "Se"]
 
     def test_get_space_group_data(self):
-        self.assertEqual(self.struct.get_space_group_info(), ("Fd-3m", 227))
+        assert self.struct.get_space_group_info() == ("Fd-3m", 227)
 
     def test_fractional_occupations(self):
         coords = []
         coords.append([0, 0, 0])
         coords.append([0.75, 0.5, 0.75])
         s = IStructure(self.lattice, [{"O": 1.0}, {"Mg": 0.8}], coords)
-        self.assertEqual(s.composition.formula, "Mg0.8 O1")
-        self.assertFalse(s.is_ordered)
+        assert s.composition.formula == "Mg0.8 O1"
+        assert not s.is_ordered
 
     def test_get_distance(self):
-        self.assertAlmostEqual(self.struct.get_distance(0, 1), 2.35, 2, "Distance calculated wrongly!")
+        assert round(abs(self.struct.get_distance(0, 1) - 2.35), 2) == 0, "Distance calculated wrongly!"
         pt = [0.9, 0.9, 0.8]
-        self.assertAlmostEqual(
-            self.struct[0].distance_from_point(pt),
-            1.50332963784,
-            2,
-            "Distance calculated wrongly!",
-        )
+        assert (
+            round(abs(self.struct[0].distance_from_point(pt) - 1.50332963784), 2) == 0
+        ), "Distance calculated wrongly!"
 
     def test_as_dict(self):
         si = Species("Si", 4)
@@ -188,10 +180,10 @@ class IStructureTest(PymatgenTest):
         coords.append([0, 0, 0])
         coords.append([0.75, 0.5, 0.75])
         struct = IStructure(self.lattice, [{si: 0.5, mn: 0.5}, {si: 0.5}], coords)
-        self.assertIn("lattice", struct.as_dict())
-        self.assertIn("sites", struct.as_dict())
+        assert "lattice" in struct.as_dict()
+        assert "sites" in struct.as_dict()
         d = self.propertied_structure.as_dict()
-        self.assertEqual(d["sites"][0]["properties"]["magmom"], 5)
+        assert d["sites"][0]["properties"]["magmom"] == 5
         coords = []
         coords.append([0, 0, 0])
         coords.append([0.75, 0.5, 0.75])
@@ -205,21 +197,21 @@ class IStructureTest(PymatgenTest):
             site_properties={"magmom": [5, -5]},
         )
         d = s.as_dict()
-        self.assertEqual(d["sites"][0]["properties"]["magmom"], 5)
-        self.assertEqual(d["sites"][0]["species"][0]["properties"]["spin"], 3)
+        assert d["sites"][0]["properties"]["magmom"] == 5
+        assert d["sites"][0]["species"][0]["properties"]["spin"] == 3
 
         d = s.as_dict(0)
-        self.assertNotIn("volume", d["lattice"])
-        self.assertNotIn("xyz", d["sites"][0])
+        assert "volume" not in d["lattice"]
+        assert "xyz" not in d["sites"][0]
 
     def test_from_dict(self):
 
         d = self.propertied_structure.as_dict()
         s = IStructure.from_dict(d)
-        self.assertEqual(s[0].magmom, 5)
+        assert s[0].magmom == 5
         d = self.propertied_structure.as_dict(0)
         s2 = IStructure.from_dict(d)
-        self.assertEqual(s, s2)
+        assert s == s2
 
         d = {
             "lattice": {
@@ -270,22 +262,22 @@ class IStructureTest(PymatgenTest):
             ],
         }
         s = IStructure.from_dict(d)
-        self.assertEqual(s[0].magmom, 5)
-        self.assertEqual(s[0].specie.spin, 3)
-        self.assertEqual(type(s), IStructure)
+        assert s[0].magmom == 5
+        assert s[0].specie.spin == 3
+        assert isinstance(s, IStructure)
 
     def test_site_properties(self):
         site_props = self.propertied_structure.site_properties
-        self.assertEqual(site_props["magmom"], [5, -5])
-        self.assertEqual(self.propertied_structure[0].magmom, 5)
-        self.assertEqual(self.propertied_structure[1].magmom, -5)
+        assert site_props["magmom"] == [5, -5]
+        assert self.propertied_structure[0].magmom == 5
+        assert self.propertied_structure[1].magmom == -5
 
     def test_copy(self):
         new_struct = self.propertied_structure.copy(site_properties={"charge": [2, 3]})
-        self.assertEqual(new_struct[0].magmom, 5)
-        self.assertEqual(new_struct[1].magmom, -5)
-        self.assertEqual(new_struct[0].charge, 2)
-        self.assertEqual(new_struct[1].charge, 3)
+        assert new_struct[0].magmom == 5
+        assert new_struct[1].magmom == -5
+        assert new_struct[0].charge == 2
+        assert new_struct[1].charge == 3
 
         coords = []
         coords.append([0, 0, 0])
@@ -294,11 +286,11 @@ class IStructureTest(PymatgenTest):
         structure = IStructure(self.lattice, ["O", "Si"], coords, site_properties={"magmom": [5, -5]})
 
         new_struct = structure.copy(site_properties={"charge": [2, 3]}, sanitize=True)
-        self.assertEqual(new_struct[0].magmom, -5)
-        self.assertEqual(new_struct[1].magmom, 5)
-        self.assertEqual(new_struct[0].charge, 3)
-        self.assertEqual(new_struct[1].charge, 2)
-        self.assertAlmostEqual(new_struct.volume, structure.volume)
+        assert new_struct[0].magmom == -5
+        assert new_struct[1].magmom == 5
+        assert new_struct[0].charge == 3
+        assert new_struct[1].charge == 2
+        assert round(abs(new_struct.volume - structure.volume), 7) == 0
 
     def test_interpolate(self):
         coords = []
@@ -311,26 +303,28 @@ class IStructureTest(PymatgenTest):
         struct2 = IStructure(self.struct.lattice, ["Si"] * 2, coords2)
         int_s = struct.interpolate(struct2, 10)
         for s in int_s:
-            self.assertIsNotNone(s, "Interpolation Failed!")
-            self.assertEqual(int_s[0].lattice, s.lattice)
+            assert s is not None, "Interpolation Failed!"
+            assert int_s[0].lattice == s.lattice
         self.assertArrayEqual(int_s[1][1].frac_coords, [0.725, 0.5, 0.725])
 
         # test ximages
         int_s = struct.interpolate(struct2, nimages=np.linspace(0.0, 1.0, 3))
         for s in int_s:
-            self.assertIsNotNone(s, "Interpolation Failed!")
-            self.assertEqual(int_s[0].lattice, s.lattice)
+            assert s is not None, "Interpolation Failed!"
+            assert int_s[0].lattice == s.lattice
         self.assertArrayEqual(int_s[1][1].frac_coords, [0.625, 0.5, 0.625])
 
         badlattice = [[1, 0.00, 0.00], [0, 1, 0.00], [0.00, 0, 1]]
         struct2 = IStructure(badlattice, ["Si"] * 2, coords2)
-        self.assertRaises(ValueError, struct.interpolate, struct2)
+        with pytest.raises(ValueError):
+            struct.interpolate(struct2)
 
         coords2 = []
         coords2.append([0, 0, 0])
         coords2.append([0.5, 0.5, 0.5])
         struct2 = IStructure(self.struct.lattice, ["Si", "Fe"], coords2)
-        self.assertRaises(ValueError, struct.interpolate, struct2)
+        with pytest.raises(ValueError):
+            struct.interpolate(struct2)
 
         # Test autosort feature.
         s1 = Structure.from_spacegroup("Fm-3m", Lattice.cubic(3), ["Fe"], [[0, 0, 0]])
@@ -360,7 +354,7 @@ class IStructureTest(PymatgenTest):
         species = [{"S": 1.0}, {"Ni": 1.0}]
         coordinate = [(0.252100, 0.252100, 0.252100), (0.500000, 0.244900, -0.244900)]
         s = Structure.from_spacegroup("R32:R", lattice, species, coordinate)
-        self.assertEqual(s.formula, "Ni3 S2")
+        assert s.formula == "Ni3 S2"
 
         # test pbc
         coords = [[0.85, 0.85, 0.85]]
@@ -389,8 +383,8 @@ class IStructureTest(PymatgenTest):
         self.assertArrayAlmostEqual(int_angles, int_s[1].lattice.angles)
 
         # Assert that volume is monotonic
-        self.assertTrue(struct2.lattice.volume >= int_s[1].lattice.volume)
-        self.assertTrue(int_s[1].lattice.volume >= struct.lattice.volume)
+        assert struct2.lattice.volume >= int_s[1].lattice.volume
+        assert int_s[1].lattice.volume >= struct.lattice.volume
 
     def test_interpolate_lattice_rotation(self):
         l1 = Lattice([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
@@ -401,29 +395,29 @@ class IStructureTest(PymatgenTest):
         int_s = struct1.interpolate(struct2, 2, interpolate_lattices=True)
 
         # Assert that volume is monotonic
-        self.assertTrue(struct2.lattice.volume >= int_s[1].lattice.volume)
-        self.assertTrue(int_s[1].lattice.volume >= struct1.lattice.volume)
+        assert struct2.lattice.volume >= int_s[1].lattice.volume
+        assert int_s[1].lattice.volume >= struct1.lattice.volume
 
     def test_get_primitive_structure(self):
         coords = [[0, 0, 0], [0.5, 0.5, 0], [0, 0.5, 0.5], [0.5, 0, 0.5]]
         fcc_ag = IStructure(Lattice.cubic(4.09), ["Ag"] * 4, coords)
-        self.assertEqual(len(fcc_ag.get_primitive_structure()), 1)
+        assert len(fcc_ag.get_primitive_structure()) == 1
         coords = [[0, 0, 0], [0.5, 0.5, 0.5]]
         bcc_li = IStructure(Lattice.cubic(4.09), ["Li"] * 2, coords)
         bcc_prim = bcc_li.get_primitive_structure()
-        self.assertEqual(len(bcc_prim), 1)
-        self.assertAlmostEqual(bcc_prim.lattice.alpha, 109.47122, 3)
+        assert len(bcc_prim) == 1
+        assert round(abs(bcc_prim.lattice.alpha - 109.47122), 3) == 0
         bcc_li = IStructure(Lattice.cubic(4.09), ["Li"] * 2, coords, site_properties={"magmom": [1, -1]})
         bcc_prim = bcc_li.get_primitive_structure()
-        self.assertEqual(len(bcc_prim), 1)
-        self.assertAlmostEqual(bcc_prim.lattice.alpha, 109.47122, 3)
+        assert len(bcc_prim) == 1
+        assert round(abs(bcc_prim.lattice.alpha - 109.47122), 3) == 0
         bcc_prim = bcc_li.get_primitive_structure(use_site_props=True)
-        self.assertEqual(len(bcc_prim), 2)
-        self.assertAlmostEqual(bcc_prim.lattice.alpha, 90, 3)
+        assert len(bcc_prim) == 2
+        assert round(abs(bcc_prim.lattice.alpha - 90), 3) == 0
 
         coords = [[0] * 3, [0.5] * 3, [0.25] * 3, [0.26] * 3]
         s = IStructure(Lattice.cubic(4.09), ["Ag"] * 4, coords)
-        self.assertEqual(len(s.get_primitive_structure()), 4)
+        assert len(s.get_primitive_structure()) == 4
 
     def test_primitive_cell_site_merging(self):
         l = Lattice.cubic(10)
@@ -438,8 +432,8 @@ class IStructureTest(PymatgenTest):
         fcc_ag = Structure(Lattice.cubic(4.09), ["Ag"] * 4, coords)
         fcc_ag.make_supercell([2, 2, 2])
         fcc_ag_prim = fcc_ag.get_primitive_structure()
-        self.assertEqual(len(fcc_ag_prim), 1)
-        self.assertAlmostEqual(fcc_ag_prim.volume, 17.10448225)
+        assert len(fcc_ag_prim) == 1
+        assert round(abs(fcc_ag_prim.volume - 17.10448225), 7) == 0
 
     def test_primitive_positions(self):
         coords = [[0, 0, 0], [0.3, 0.35, 0.45]]
@@ -452,8 +446,8 @@ class IStructureTest(PymatgenTest):
             sc.make_supercell(sc_matrix)
             prim = sc.get_primitive_structure(0.01)
 
-            self.assertEqual(len(prim), 2)
-            self.assertAlmostEqual(prim.distance_matrix[0, 1], 1.0203432356739286)
+            assert len(prim) == 2
+            assert round(abs(prim.distance_matrix[0, 1] - 1.0203432356739286), 7) == 0
 
     def test_primitive_structure_volume_check(self):
         l = Lattice.tetragonal(10, 30)
@@ -467,7 +461,7 @@ class IStructureTest(PymatgenTest):
         ]
         s = IStructure(l, ["Ag"] * 6, coords)
         sprim = s.get_primitive_structure(tolerance=0.1)
-        self.assertEqual(len(sprim), 6)
+        assert len(sprim) == 6
 
     def test_get_miller_index(self):
         """Test for get miller index convenience method"""
@@ -482,30 +476,30 @@ class IStructureTest(PymatgenTest):
             coords_are_cartesian=True,
         )
         hkl = struct.get_miller_index_from_site_indexes([0, 1, 2])
-        self.assertEqual(hkl, (2, -1, 0))
+        assert hkl == (2, -1, 0)
 
     def test_get_all_neighbors_and_get_neighbors(self):
         s = self.struct
         nn = s.get_neighbors_in_shell(s[0].frac_coords, 2, 4, include_index=True, include_image=True)
-        self.assertEqual(len(nn), 47)
+        assert len(nn) == 47
         r = random.uniform(3, 6)
         all_nn = s.get_all_neighbors(r, True, True)
         for idx, site in enumerate(s):
-            self.assertEqual(4, len(all_nn[idx][0]))
-            self.assertEqual(len(all_nn[idx]), len(s.get_neighbors(site, r)))
+            assert 4 == len(all_nn[idx][0])
+            assert len(all_nn[idx]) == len(s.get_neighbors(site, r))
 
         for site, nns in zip(s, all_nn):
             for nn in nns:
-                self.assertTrue(nn[0].is_periodic_image(s[nn[2]]))
+                assert nn[0].is_periodic_image(s[nn[2]])
                 d = sum((site.coords - nn[0].coords) ** 2) ** 0.5
-                self.assertAlmostEqual(d, nn[1])
+                assert round(abs(d - nn[1]), 7) == 0
 
         s = Structure(Lattice.cubic(1), ["Li"], [[0, 0, 0]])
         s.make_supercell([2, 2, 2])
-        self.assertEqual(sum(map(len, s.get_all_neighbors(3))), 976)
+        assert sum(map(len, s.get_all_neighbors(3))) == 976
 
         all_nn = s.get_all_neighbors(0.05)
-        self.assertEqual([len(nn) for nn in all_nn], [0] * len(s))
+        assert [len(nn) for nn in all_nn] == [0] * len(s)
 
         # the following test is from issue #2226
         poscar = """POSCAR
@@ -535,9 +529,9 @@ Direct
         site0 = s.sites[1]
         site1 = s.sites[9]
         neigh_sites = s.get_neighbors(site0, 2.0)
-        self.assertTrue(len(neigh_sites) == 1)
+        assert len(neigh_sites) == 1
         neigh_sites = s.get_neighbors(site1, 2.0)
-        self.assertTrue(len(neigh_sites) == 1)
+        assert len(neigh_sites) == 1
 
     def test_get_neighbor_list(self):
         s = self.struct
@@ -591,34 +585,34 @@ Direct
         # tetragonal group with all bonds related by symmetry
         s = Structure.from_spacegroup(100, [[1, 0, 0], [0, 1, 0], [0, 0, 2]], ["Fe"], [[0.0, 0.0, 0.0]])
         c_indices, p_indices, offsets, distances, s_indices, symops = s.get_symmetric_neighbor_list(0.8, sg=100)
-        self.assertTrue(len(np.unique(s_indices)) == 1)
-        self.assertTrue(s_indices[0] == 0)
-        self.assertTrue((~np.isnan(s_indices)).all())
-        self.assertTrue((symops[0].affine_matrix == np.eye(4)).all())
+        assert len(np.unique(s_indices)) == 1
+        assert s_indices[0] == 0
+        assert (~np.isnan(s_indices)).all()
+        assert (symops[0].affine_matrix == np.eye(4)).all()
         # now more complicated example with bonds of same length but with different symmetry
         s2 = Structure.from_spacegroup(198, [[8.908, 0, 0], [0, 8.908, 0], [0, 0, 8.908]], ["Cu"], [[0.0, 0.0, 0.0]])
         c_indices2, p_indices2, offsets2, distances2, s_indices2, symops2 = s2.get_symmetric_neighbor_list(7, sg=198)
-        self.assertTrue(len(np.unique(s_indices2)) == 2)
-        self.assertTrue(len(s_indices2) == 48)
-        self.assertTrue(len(s_indices2[s_indices2 == 0]) == len(s_indices2[s_indices2 == 1]))
-        self.assertTrue(s_indices2[0] == 0)
-        self.assertTrue(s_indices2[24] == 1)
-        self.assertTrue(np.isclose(distances2[0], distances2[24]))
-        self.assertTrue((symops2[0].affine_matrix == np.eye(4)).all())
-        self.assertTrue((symops2[24].affine_matrix == np.eye(4)).all())
+        assert len(np.unique(s_indices2)) == 2
+        assert len(s_indices2) == 48
+        assert len(s_indices2[s_indices2 == 0]) == len(s_indices2[s_indices2 == 1])
+        assert s_indices2[0] == 0
+        assert s_indices2[24] == 1
+        assert np.isclose(distances2[0], distances2[24])
+        assert (symops2[0].affine_matrix == np.eye(4)).all()
+        assert (symops2[24].affine_matrix == np.eye(4)).all()
         from_a2 = s2[c_indices2[0]].frac_coords
         to_a2 = s2[p_indices2[0]].frac_coords
         r_a2 = offsets2[0]
         from_b2 = s2[c_indices2[1]].frac_coords
         to_b2 = s2[p_indices2[1]].frac_coords
         r_b2 = offsets2[1]
-        self.assertTrue(symops2[1].are_symmetrically_related_vectors(from_a2, to_a2, r_a2, from_b2, to_b2, r_b2))
-        self.assertTrue(symops2[1].are_symmetrically_related_vectors(from_b2, to_b2, r_b2, from_a2, to_a2, r_a2))
+        assert symops2[1].are_symmetrically_related_vectors(from_a2, to_a2, r_a2, from_b2, to_b2, r_b2)
+        assert symops2[1].are_symmetrically_related_vectors(from_b2, to_b2, r_b2, from_a2, to_a2, r_a2)
         c_indices3, p_indices3, offsets3, distances3, s_indices3, symops3 = s2.get_symmetric_neighbor_list(
             7, sg=198, unique=True
         )
-        self.assertTrue((np.sort(np.array([c_indices3, p_indices3]).flatten()) == np.sort(c_indices2)).all())
-        self.assertTrue((np.sort(np.array([c_indices3, p_indices3]).flatten()) == np.sort(p_indices2)).all())
+        assert (np.sort(np.array([c_indices3, p_indices3]).flatten()) == np.sort(c_indices2)).all()
+        assert (np.sort(np.array([c_indices3, p_indices3]).flatten()) == np.sort(p_indices2)).all()
 
     def test_get_all_neighbors_outside_cell(self):
         s = Structure(
@@ -629,10 +623,10 @@ Direct
         all_nn = s.get_all_neighbors(0.2, True)
         for site, nns in zip(s, all_nn):
             for nn in nns:
-                self.assertTrue(nn[0].is_periodic_image(s[nn[2]]))
+                assert nn[0].is_periodic_image(s[nn[2]])
                 d = sum((site.coords - nn[0].coords) ** 2) ** 0.5
-                self.assertAlmostEqual(d, nn[1])
-        self.assertEqual(list(map(len, all_nn)), [2, 2, 2, 0])
+                assert round(abs(d - nn[1]), 7) == 0
+        assert list(map(len, all_nn)) == [2, 2, 2, 0]
 
     def test_get_all_neighbors_small_cutoff(self):
         s = Structure(
@@ -641,12 +635,12 @@ Direct
             [[3.1] * 3, [0.11] * 3, [-1.91] * 3, [0.5] * 3],
         )
         all_nn = s.get_all_neighbors(1e-5, True)
-        self.assertEqual(len(all_nn), len(s))
-        self.assertEqual([], all_nn[0])
+        assert len(all_nn) == len(s)
+        assert [] == all_nn[0]
 
         all_nn = s.get_all_neighbors(0, True)
-        self.assertEqual(len(all_nn), len(s))
-        self.assertEqual([], all_nn[0])
+        assert len(all_nn) == len(s)
+        assert [] == all_nn[0]
 
     def test_coincide_sites(self):
         s = Structure(
@@ -656,7 +650,7 @@ Direct
             coords_are_cartesian=True,
         )
         all_nn = s.get_all_neighbors(1e-5, True)
-        self.assertEqual([len(i) for i in all_nn], [0, 0, 0])
+        assert [len(i) for i in all_nn] == [0, 0, 0]
 
     def test_get_all_neighbors_equal(self):
         with pytest.warns(FutureWarning, match="get_all_neighbors_old is deprecated"):
@@ -669,8 +663,8 @@ Direct
             nn_cell_lists = s.get_all_neighbors(4, include_index=True, include_image=True)
 
             for i in range(4):
-                self.assertEqual(len(nn_traditional[i]), len(nn_cell_lists[i]))
-                self.assertTrue(
+                assert len(nn_traditional[i]) == len(nn_cell_lists[i])
+                assert (
                     np.linalg.norm(
                         np.array(sorted(j[1] for j in nn_traditional[i]))
                         - np.array(sorted(j[1] for j in nn_cell_lists[i]))
@@ -685,46 +679,48 @@ Direct
     def test_to_from_file_string(self):
         for fmt in ["cif", "json", "poscar", "cssr"]:
             s = self.struct.to(fmt=fmt)
-            self.assertIsNotNone(s)
+            assert s is not None
             ss = IStructure.from_str(s, fmt=fmt)
             self.assertArrayAlmostEqual(ss.lattice.parameters, self.struct.lattice.parameters, decimal=5)
             self.assertArrayAlmostEqual(ss.frac_coords, self.struct.frac_coords)
-            self.assertIsInstance(ss, IStructure)
+            assert isinstance(ss, IStructure)
 
-        self.assertTrue("Fd-3m" in self.struct.to(fmt="CIF", symprec=0.1))
+        assert "Fd-3m" in self.struct.to(fmt="CIF", symprec=0.1)
 
         self.struct.to(filename="POSCAR.testing")
-        self.assertTrue(os.path.exists("POSCAR.testing"))
+        assert os.path.exists("POSCAR.testing")
         os.remove("POSCAR.testing")
 
         self.struct.to(filename="Si_testing.yaml")
-        self.assertTrue(os.path.exists("Si_testing.yaml"))
+        assert os.path.exists("Si_testing.yaml")
         s = Structure.from_file("Si_testing.yaml")
-        self.assertEqual(s, self.struct)
+        assert s == self.struct
         # Test Path support.
         s = Structure.from_file(Path("Si_testing.yaml"))
-        self.assertEqual(s, self.struct)
+        assert s == self.struct
 
         # Test .yml extension works too.
         os.replace("Si_testing.yaml", "Si_testing.yml")
         s = Structure.from_file("Si_testing.yml")
-        self.assertEqual(s, self.struct)
+        assert s == self.struct
         os.remove("Si_testing.yml")
 
-        self.assertRaises(ValueError, self.struct.to, filename="whatever")
-        self.assertRaises(ValueError, self.struct.to, fmt="badformat")
+        with pytest.raises(ValueError):
+            self.struct.to(filename="whatever")
+        with pytest.raises(ValueError):
+            self.struct.to(fmt="badformat")
 
         self.struct.to(filename="POSCAR.testing.gz")
         s = Structure.from_file("POSCAR.testing.gz")
-        self.assertEqual(s, self.struct)
+        assert s == self.struct
         os.remove("POSCAR.testing.gz")
 
     def test_pbc(self):
         self.assertArrayEqual(self.struct.pbc, (True, True, True))
-        self.assertTrue(self.struct.is_3d_periodic)
+        assert self.struct.is_3d_periodic
         struct_pbc = Structure(self.lattice_pbc, ["Si"] * 2, self.struct.frac_coords)
         self.assertArrayEqual(struct_pbc.pbc, (True, True, False))
-        self.assertFalse(struct_pbc.is_3d_periodic)
+        assert not struct_pbc.is_3d_periodic
 
 
 class StructureTest(PymatgenTest):
@@ -744,112 +740,114 @@ class StructureTest(PymatgenTest):
     def test_mutable_sequence_methods(self):
         s = self.structure
         s[0] = "Fe"
-        self.assertEqual(s.formula, "Fe1 Si1")
+        assert s.formula == "Fe1 Si1"
         s[0] = "Fe", [0.5, 0.5, 0.5]
-        self.assertEqual(s.formula, "Fe1 Si1")
+        assert s.formula == "Fe1 Si1"
         self.assertArrayAlmostEqual(s[0].frac_coords, [0.5, 0.5, 0.5])
         s.reverse()
-        self.assertEqual(s[0].specie, Element("Si"))
+        assert s[0].specie == Element("Si")
         self.assertArrayAlmostEqual(s[0].frac_coords, [0.75, 0.5, 0.75])
         s[0] = {"Mn": 0.5}
-        self.assertEqual(s.formula, "Mn0.5 Fe1")
+        assert s.formula == "Mn0.5 Fe1"
         del s[1]
-        self.assertEqual(s.formula, "Mn0.5")
+        assert s.formula == "Mn0.5"
         s[0] = "Fe", [0.9, 0.9, 0.9], {"magmom": 5}
-        self.assertEqual(s.formula, "Fe1")
-        self.assertEqual(s[0].magmom, 5)
+        assert s.formula == "Fe1"
+        assert s[0].magmom == 5
 
         # Test atomic replacement.
         s["Fe"] = "Mn"
-        self.assertEqual(s.formula, "Mn1")
+        assert s.formula == "Mn1"
 
         # Test slice replacement.
         s = PymatgenTest.get_structure("Li2O")
         s[0:2] = "S"
-        self.assertEqual(s.formula, "Li1 S2")
+        assert s.formula == "Li1 S2"
 
     def test_non_hash(self):
-        self.assertRaises(TypeError, dict, [(self.structure, 1)])
+        with pytest.raises(TypeError):
+            dict([(self.structure, 1)])
 
     def test_sort(self):
         s = self.structure
         s[0] = "F"
         s.sort()
-        self.assertEqual(s[0].species_string, "Si")
-        self.assertEqual(s[1].species_string, "F")
+        assert s[0].species_string == "Si"
+        assert s[1].species_string == "F"
         s.sort(key=lambda site: site.species_string)
-        self.assertEqual(s[0].species_string, "F")
-        self.assertEqual(s[1].species_string, "Si")
+        assert s[0].species_string == "F"
+        assert s[1].species_string == "Si"
         s.sort(key=lambda site: site.species_string, reverse=True)
-        self.assertEqual(s[0].species_string, "Si")
-        self.assertEqual(s[1].species_string, "F")
+        assert s[0].species_string == "Si"
+        assert s[1].species_string == "F"
 
     def test_append_insert_remove_replace_substitute(self):
         s = self.structure
         s.insert(1, "O", [0.5, 0.5, 0.5])
-        self.assertEqual(s.formula, "Si2 O1")
-        self.assertTrue(s.ntypesp == 2)
-        self.assertTrue(s.symbol_set == ("O", "Si"))
-        self.assertTrue(s.indices_from_symbol("Si") == (0, 2))
-        self.assertTrue(s.indices_from_symbol("O") == (1,))
+        assert s.formula == "Si2 O1"
+        assert s.ntypesp == 2
+        assert s.symbol_set == ("O", "Si")
+        assert s.indices_from_symbol("Si") == (0, 2)
+        assert s.indices_from_symbol("O") == (1,)
         del s[2]
-        self.assertEqual(s.formula, "Si1 O1")
-        self.assertTrue(s.indices_from_symbol("Si") == (0,))
-        self.assertTrue(s.indices_from_symbol("O") == (1,))
+        assert s.formula == "Si1 O1"
+        assert s.indices_from_symbol("Si") == (0,)
+        assert s.indices_from_symbol("O") == (1,)
         s.append("N", [0.25, 0.25, 0.25])
-        self.assertEqual(s.formula, "Si1 N1 O1")
-        self.assertTrue(s.ntypesp == 3)
-        self.assertTrue(s.symbol_set == ("N", "O", "Si"))
-        self.assertTrue(s.indices_from_symbol("Si") == (0,))
-        self.assertTrue(s.indices_from_symbol("O") == (1,))
-        self.assertTrue(s.indices_from_symbol("N") == (2,))
+        assert s.formula == "Si1 N1 O1"
+        assert s.ntypesp == 3
+        assert s.symbol_set == ("N", "O", "Si")
+        assert s.indices_from_symbol("Si") == (0,)
+        assert s.indices_from_symbol("O") == (1,)
+        assert s.indices_from_symbol("N") == (2,)
         s[0] = "Ge"
-        self.assertEqual(s.formula, "Ge1 N1 O1")
-        self.assertTrue(s.symbol_set == ("Ge", "N", "O"))
+        assert s.formula == "Ge1 N1 O1"
+        assert s.symbol_set == ("Ge", "N", "O")
         s.replace_species({"Ge": "Si"})
-        self.assertEqual(s.formula, "Si1 N1 O1")
-        self.assertTrue(s.ntypesp == 3)
+        assert s.formula == "Si1 N1 O1"
+        assert s.ntypesp == 3
 
         s.replace_species({"Si": {"Ge": 0.5, "Si": 0.5}})
-        self.assertEqual(s.formula, "Si0.5 Ge0.5 N1 O1")
+        assert s.formula == "Si0.5 Ge0.5 N1 O1"
         # this should change the .5Si .5Ge sites to .75Si .25Ge
         s.replace_species({"Ge": {"Ge": 0.5, "Si": 0.5}})
-        self.assertEqual(s.formula, "Si0.75 Ge0.25 N1 O1")
+        assert s.formula == "Si0.75 Ge0.25 N1 O1"
 
-        self.assertEqual(s.ntypesp, 4)
+        assert s.ntypesp == 4
 
         s.replace_species({"Ge": "Si"})
         s.substitute(1, "hydroxyl")
-        self.assertEqual(s.formula, "Si1 H1 N1 O1")
-        self.assertTrue(s.symbol_set == ("H", "N", "O", "Si"))
+        assert s.formula == "Si1 H1 N1 O1"
+        assert s.symbol_set == ("H", "N", "O", "Si")
         # Distance between O and H
-        self.assertAlmostEqual(s.get_distance(2, 3), 0.96)
+        assert round(abs(s.get_distance(2, 3) - 0.96), 7) == 0
         # Distance between Si and H
-        self.assertAlmostEqual(s.get_distance(0, 3), 2.09840889)
+        assert round(abs(s.get_distance(0, 3) - 2.09840889), 7) == 0
 
         s.remove_species(["H"])
-        self.assertEqual(s.formula, "Si1 N1 O1")
+        assert s.formula == "Si1 N1 O1"
 
         s.remove_sites([1, 2])
-        self.assertEqual(s.formula, "Si1")
+        assert s.formula == "Si1"
 
     def test_add_remove_site_property(self):
         s = self.structure
         s.add_site_property("charge", [4.1, -5])
-        self.assertEqual(s[0].charge, 4.1)
-        self.assertEqual(s[1].charge, -5)
+        assert s[0].charge == 4.1
+        assert s[1].charge == -5
         s.add_site_property("magmom", [3, 2])
-        self.assertEqual(s[0].charge, 4.1)
-        self.assertEqual(s[0].magmom, 3)
+        assert s[0].charge == 4.1
+        assert s[0].magmom == 3
         s.remove_site_property("magmom")
-        self.assertRaises(AttributeError, getattr, s[0], "magmom")
+        with pytest.raises(AttributeError):
+            s[0].magmom
 
     def test_propertied_structure(self):
         # Make sure that site properties are set to None for missing values.
         s = self.structure
         s.add_site_property("charge", [4.1, -5])
         s.append("Li", [0.3, 0.3, 0.3])
-        self.assertEqual(len(s.site_properties["charge"]), 3)
+        assert len(s.site_properties["charge"]) == 3
 
     def test_perturb(self):
         d = 0.1
@@ -858,36 +856,29 @@ class StructureTest(PymatgenTest):
         post_perturbation_sites = self.structure.sites
 
         for i, x in enumerate(pre_perturbation_sites):
-            self.assertAlmostEqual(
-                x.distance(post_perturbation_sites[i]),
-                d,
-                3,
-                "Bad perturbation distance",
-            )
+            assert round(abs(x.distance(post_perturbation_sites[i]) - d), 3) == 0, "Bad perturbation distance"
 
         structure2 = pre_perturbation_sites.copy()
         structure2.perturb(distance=d, min_distance=0)
         post_perturbation_sites2 = structure2.sites
 
         for i, x in enumerate(pre_perturbation_sites):
-            self.assertLessEqual(x.distance(post_perturbation_sites2[i]), d)
-            self.assertGreaterEqual(x.distance(post_perturbation_sites2[i]), 0)
+            assert x.distance(post_perturbation_sites2[i]) <= d
+            assert x.distance(post_perturbation_sites2[i]) >= 0
 
     def test_add_oxidation_states(self):
         oxidation_states = {"Si": -4}
         self.structure.add_oxidation_state_by_element(oxidation_states)
         for site in self.structure:
             for k in site.species:
-                self.assertEqual(
-                    k.oxi_state,
-                    oxidation_states[k.symbol],
-                    "Wrong oxidation state assigned!",
-                )
+                assert k.oxi_state == oxidation_states[k.symbol], "Wrong oxidation state assigned!"
         oxidation_states = {"Fe": 2}
-        self.assertRaises(ValueError, self.structure.add_oxidation_state_by_element, oxidation_states)
+        with pytest.raises(ValueError):
+            self.structure.add_oxidation_state_by_element(oxidation_states)
         self.structure.add_oxidation_state_by_site([2, -4])
-        self.assertEqual(self.structure[0].specie.oxi_state, 2)
-        self.assertRaises(ValueError, self.structure.add_oxidation_state_by_site, [1])
+        assert self.structure[0].specie.oxi_state == 2
+        with pytest.raises(ValueError):
+            self.structure.add_oxidation_state_by_site([1])
 
     def test_remove_oxidation_states(self):
         co_elem = Element("Co")
@@ -901,13 +892,13 @@ class StructureTest(PymatgenTest):
         s_elem = Structure(lattice, [co_elem, o_elem], coords)
         s_specie = Structure(lattice, [co_specie, o_specie], coords)
         s_specie.remove_oxidation_states()
-        self.assertEqual(s_elem, s_specie, "Oxidation state remover failed")
+        assert s_elem == s_specie, "Oxidation state remover failed"
 
     def test_add_oxidation_states_by_guess(self):
         s = PymatgenTest.get_structure("Li2O")
         s.add_oxidation_state_by_guess()
         for i in s:
-            self.assertTrue(i.specie in [Species("Li", 1), Species("O", -2)])
+            assert i.specie in [Species("Li", 1), Species("O", -2)]
 
     def test_add_remove_spin_states(self):
 
@@ -921,14 +912,15 @@ class StructureTest(PymatgenTest):
 
         spins = {"Ni": 5}
         nio.add_spin_by_element(spins)
-        self.assertEqual(nio[0].specie.spin, 5, "Failed to add spin states")
+        assert nio[0].specie.spin == 5, "Failed to add spin states"
 
         nio.remove_spin()
-        self.assertRaises(AttributeError, getattr, nio[0].specie, "spin")
+        with pytest.raises(AttributeError):
+            nio[0].specie.spin
 
         spins = [5, -5, -5, 5, 0, 0, 0, 0]  # AFM on (001)
         nio.add_spin_by_site(spins)
-        self.assertEqual(nio[1].specie.spin, -5, "Failed to add spin states")
+        assert nio[1].specie.spin == -5, "Failed to add spin states"
 
     def test_apply_operation(self):
         op = SymmOp.from_axis_angle_and_translation([0, 0, 1], 90)
@@ -961,14 +953,14 @@ class StructureTest(PymatgenTest):
         s = self.structure
         initial_coord = s[1].coords
         s.apply_strain(0.01)
-        self.assertAlmostEqual(s.lattice.abc, (3.8785999130369997, 3.878600984287687, 3.8785999130549516))
+        assert pytest.approx(s.lattice.abc) == (3.8785999130369997, 3.878600984287687, 3.8785999130549516)
         self.assertArrayAlmostEqual(s[1].coords, initial_coord * 1.01)
         a1, b1, c1 = s.lattice.abc
         s.apply_strain([0.1, 0.2, 0.3])
         a2, b2, c2 = s.lattice.abc
-        self.assertAlmostEqual(a2 / a1, 1.1)
-        self.assertAlmostEqual(b2 / b1, 1.2)
-        self.assertAlmostEqual(c2 / c1, 1.3)
+        assert round(abs(a2 / a1 - 1.1), 7) == 0
+        assert round(abs(b2 / b1 - 1.2), 7) == 0
+        assert round(abs(c2 / c1 - 1.3), 7) == 0
 
     def test_scale_lattice(self):
         initial_coord = self.structure[1].coords
@@ -1012,21 +1004,21 @@ class StructureTest(PymatgenTest):
 
     def test_mul(self):
         self.structure *= [2, 1, 1]
-        self.assertEqual(self.structure.formula, "Si4")
+        assert self.structure.formula == "Si4"
         s = [2, 1, 1] * self.structure
-        self.assertEqual(s.formula, "Si8")
-        self.assertIsInstance(s, Structure)
+        assert s.formula == "Si8"
+        assert isinstance(s, Structure)
         s = self.structure * [[1, 0, 0], [2, 1, 0], [0, 0, 2]]
-        self.assertEqual(s.formula, "Si8")
+        assert s.formula == "Si8"
         self.assertArrayAlmostEqual(s.lattice.abc, [7.6803959, 17.5979979, 7.6803959])
 
     def test_make_supercell(self):
         self.structure.make_supercell([2, 1, 1])
-        self.assertEqual(self.structure.formula, "Si4")
+        assert self.structure.formula == "Si4"
         self.structure.make_supercell([[1, 0, 0], [2, 1, 0], [0, 0, 1]])
-        self.assertEqual(self.structure.formula, "Si4")
+        assert self.structure.formula == "Si4"
         self.structure.make_supercell(2)
-        self.assertEqual(self.structure.formula, "Si32")
+        assert self.structure.formula == "Si32"
         self.assertArrayAlmostEqual(self.structure.lattice.abc, [15.360792, 35.195996, 7.680396], 5)
 
     def test_disordered_supercell_primitive_cell(self):
@@ -1036,57 +1028,57 @@ class StructureTest(PymatgenTest):
         s = Structure(l, sp, f)
         # this supercell often breaks things
         s.make_supercell([[0, -1, 1], [-1, 1, 0], [1, 1, 1]])
-        self.assertEqual(len(s.get_primitive_structure()), 1)
+        assert len(s.get_primitive_structure()) == 1
 
     def test_another_supercell(self):
         # this is included b/c for some reason the old algo was failing on it
         s = self.structure.copy()
         s.make_supercell([[0, 2, 2], [2, 0, 2], [2, 2, 0]])
-        self.assertEqual(s.formula, "Si32")
+        assert s.formula == "Si32"
         s = self.structure.copy()
         s.make_supercell([[0, 2, 0], [1, 0, 0], [0, 0, 1]])
-        self.assertEqual(s.formula, "Si4")
+        assert s.formula == "Si4"
 
     def test_to_from_dict(self):
         d = self.structure.as_dict()
         s2 = Structure.from_dict(d)
-        self.assertEqual(type(s2), Structure)
+        assert isinstance(s2, Structure)
 
     def test_default_dict_attrs(self):
         d = self.structure.as_dict()
-        self.assertEqual(d["charge"], 0)
+        assert d["charge"] == 0
 
     def test_to_from_abivars(self):
         """Test as_dict, from_dict with fmt == abivars."""
         d = self.structure.as_dict(fmt="abivars")
         s2 = Structure.from_dict(d, fmt="abivars")
-        self.assertEqual(s2, self.structure)
-        self.assertEqual(type(s2), Structure)
+        assert s2 == self.structure
+        assert isinstance(s2, Structure)
 
     def test_to_from_file_string(self):
         for fmt in ["cif", "json", "poscar", "cssr", "yaml", "xsf"]:
             s = self.structure.to(fmt=fmt)
-            self.assertIsNotNone(s)
+            assert s is not None
             ss = Structure.from_str(s, fmt=fmt)
             self.assertArrayAlmostEqual(ss.lattice.parameters, self.structure.lattice.parameters, decimal=5)
             self.assertArrayAlmostEqual(ss.frac_coords, self.structure.frac_coords)
-            self.assertIsInstance(ss, Structure)
+            assert isinstance(ss, Structure)
 
         self.structure.to(filename="POSCAR.testing")
-        self.assertTrue(os.path.exists("POSCAR.testing"))
+        assert os.path.exists("POSCAR.testing")
         os.remove("POSCAR.testing")
 
         self.structure.to(filename="structure_testing.json")
-        self.assertTrue(os.path.exists("structure_testing.json"))
+        assert os.path.exists("structure_testing.json")
         s = Structure.from_file("structure_testing.json")
-        self.assertEqual(s, self.structure)
+        assert s == self.structure
         os.remove("structure_testing.json")
 
     def test_from_spacegroup(self):
         s1 = Structure.from_spacegroup("Fm-3m", Lattice.cubic(3), ["Li", "O"], [[0.25, 0.25, 0.25], [0, 0, 0]])
-        self.assertEqual(s1.formula, "Li8 O4")
+        assert s1.formula == "Li8 O4"
         s2 = Structure.from_spacegroup(225, Lattice.cubic(3), ["Li", "O"], [[0.25, 0.25, 0.25], [0, 0, 0]])
-        self.assertEqual(s1, s2)
+        assert s1 == s2
 
         s2 = Structure.from_spacegroup(
             225,
@@ -1095,32 +1087,30 @@ class StructureTest(PymatgenTest):
             [[0.25, 0.25, 0.25], [0, 0, 0]],
             site_properties={"charge": [1, -2]},
         )
-        self.assertEqual(sum(s2.site_properties["charge"]), 0)
+        assert sum(s2.site_properties["charge"]) == 0
 
         s = Structure.from_spacegroup("Pm-3m", Lattice.cubic(3), ["Cs", "Cl"], [[0, 0, 0], [0.5, 0.5, 0.5]])
-        self.assertEqual(s.formula, "Cs1 Cl1")
+        assert s.formula == "Cs1 Cl1"
 
-        self.assertRaises(
-            ValueError,
-            Structure.from_spacegroup,
-            "Pm-3m",
-            Lattice.tetragonal(1, 3),
-            ["Cs", "Cl"],
-            [[0, 0, 0], [0.5, 0.5, 0.5]],
-        )
+        with pytest.raises(ValueError):
+            Structure.from_spacegroup(
+                "Pm-3m",
+                Lattice.tetragonal(1, 3),
+                ["Cs", "Cl"],
+                [[0, 0, 0], [0.5, 0.5, 0.5]],
+            )
 
-        self.assertRaises(
-            ValueError,
-            Structure.from_spacegroup,
-            "Pm-3m",
-            Lattice.cubic(3),
-            ["Cs"],
-            [[0, 0, 0], [0.5, 0.5, 0.5]],
-        )
+        with pytest.raises(ValueError):
+            Structure.from_spacegroup(
+                "Pm-3m",
+                Lattice.cubic(3),
+                ["Cs"],
+                [[0, 0, 0], [0.5, 0.5, 0.5]],
+            )
         from fractions import Fraction
 
         s = Structure.from_spacegroup(139, np.eye(3), ["H"], [[Fraction(1, 2), Fraction(1, 4), Fraction(0)]])
-        self.assertEqual(len(s), 8)
+        assert len(s) == 8
 
     def test_from_magnetic_spacegroup(self):
 
@@ -1133,10 +1123,10 @@ class StructureTest(PymatgenTest):
             {"magmom": [4, 0]},
         )
 
-        self.assertEqual(s1.formula, "Mn2 F4")
-        self.assertEqual(sum(map(float, s1.site_properties["magmom"])), 0)
-        self.assertEqual(max(map(float, s1.site_properties["magmom"])), 4)
-        self.assertEqual(min(map(float, s1.site_properties["magmom"])), -4)
+        assert s1.formula == "Mn2 F4"
+        assert sum(map(float, s1.site_properties["magmom"])) == 0
+        assert max(map(float, s1.site_properties["magmom"])) == 4
+        assert min(map(float, s1.site_properties["magmom"])) == -4
 
         # AFM LaMnO3, ordered on (001) planes
         s2 = Structure.from_magnetic_spacegroup(
@@ -1152,10 +1142,10 @@ class StructureTest(PymatgenTest):
             {"magmom": [0, Magmom([4, 0, 0]), 0, 0]},
         )
 
-        self.assertEqual(s2.formula, "La4 Mn4 O12")
-        self.assertEqual(sum(map(float, s2.site_properties["magmom"])), 0)
-        self.assertEqual(max(map(float, s2.site_properties["magmom"])), 4)
-        self.assertEqual(min(map(float, s2.site_properties["magmom"])), -4)
+        assert s2.formula == "La4 Mn4 O12"
+        assert sum(map(float, s2.site_properties["magmom"])) == 0
+        assert max(map(float, s2.site_properties["magmom"])) == 4
+        assert min(map(float, s2.site_properties["magmom"])) == -4
 
     def test_merge_sites(self):
         species = [
@@ -1176,8 +1166,8 @@ class StructureTest(PymatgenTest):
         ]
         s = Structure(Lattice.cubic(1), species, coords)
         s.merge_sites(mode="s")
-        self.assertEqual(s[0].specie.symbol, "Ag")
-        self.assertEqual(s[1].species, Composition({"Cl": 0.35, "F": 0.25}))
+        assert s[0].specie.symbol == "Ag"
+        assert s[1].species == Composition({"Cl": 0.35, "F": 0.25})
         self.assertArrayAlmostEqual(s[1].frac_coords, [0.5, 0.5, 0.5005])
 
         # Test for TaS2 with spacegroup 166 in 160 setting.
@@ -1219,83 +1209,66 @@ class StructureTest(PymatgenTest):
         navs2 = Structure.from_spacegroup(160, l, species, coords, site_properties=site_props)
         navs2.insert(0, "Na", coords[0], properties={"prop1": 100.0})
         navs2.merge_sites(mode="a")
-        self.assertEqual(len(navs2), 12)
-        self.assertEqual(51.5 in [itr.properties["prop1"] for itr in navs2.sites], True)
+        assert len(navs2) == 12
+        assert 51.5 in [itr.properties["prop1"] for itr in navs2.sites]
 
     def test_properties(self):
-        self.assertEqual(self.structure.num_sites, len(self.structure))
+        assert self.structure.num_sites == len(self.structure)
         self.structure.make_supercell(2)
         self.structure[1] = "C"
         sites = list(self.structure.group_by_types())
-        self.assertEqual(sites[-1].specie.symbol, "C")
+        assert sites[-1].specie.symbol == "C"
         self.structure.add_oxidation_state_by_element({"Si": 4, "C": 2})
-        self.assertEqual(self.structure.charge, 62)
+        assert self.structure.charge == 62
 
     def test_set_item(self):
         s = self.structure.copy()
         s[0] = "C"
-        self.assertEqual(s.formula, "Si1 C1")
+        assert s.formula == "Si1 C1"
         s[(0, 1)] = "Ge"
-        self.assertEqual(s.formula, "Ge2")
+        assert s.formula == "Ge2"
         s[0:2] = "Sn"
-        self.assertEqual(s.formula, "Sn2")
+        assert s.formula == "Sn2"
 
         s = self.structure.copy()
         s["Si"] = "C"
-        self.assertEqual(s.formula, "C2")
+        assert s.formula == "C2"
         s["C"] = "C0.25Si0.5"
-        self.assertEqual(s.formula, "Si1 C0.5")
+        assert s.formula == "Si1 C0.5"
         s["C"] = "C0.25Si0.5"
-        self.assertEqual(s.formula, "Si1.25 C0.125")
+        assert s.formula == "Si1.25 C0.125"
 
     def test_init_error(self):
-        self.assertRaises(
-            StructureError,
-            Structure,
-            Lattice.cubic(3),
-            ["Si"],
-            [[0, 0, 0], [0.5, 0.5, 0.5]],
-        )
+        with pytest.raises(StructureError):
+            Structure(
+                Lattice.cubic(3),
+                ["Si"],
+                [[0, 0, 0], [0.5, 0.5, 0.5]],
+            )
 
     def test_from_sites(self):
         self.structure.add_site_property("hello", [1, 2])
         s = Structure.from_sites(self.structure, to_unit_cell=True)
-        self.assertEqual(s.site_properties["hello"][1], 2)
+        assert s.site_properties["hello"][1] == 2
 
     def test_charge(self):
         s = Structure.from_sites(self.structure)
-        self.assertEqual(
-            s.charge,
-            0,
-            "Initial Structure not defaulting to behavior in SiteCollection",
-        )
+        assert s.charge == 0, "Initial Structure not defaulting to behavior in SiteCollection"
         s.add_oxidation_state_by_site([1, 1])
-        self.assertEqual(
-            s.charge,
-            2,
-            "Initial Structure not defaulting to behavior in SiteCollection",
-        )
+        assert s.charge == 2, "Initial Structure not defaulting to behavior in SiteCollection"
         s = Structure.from_sites(s, charge=1)
-        self.assertEqual(s.charge, 1, "Overall charge not being stored in separate property")
+        assert s.charge == 1, "Overall charge not being stored in separate property"
         s = s.copy()
-        self.assertEqual(s.charge, 1, "Overall charge not being copied properly with no sanitization")
+        assert s.charge == 1, "Overall charge not being copied properly with no sanitization"
         s = s.copy(sanitize=True)
-        self.assertEqual(s.charge, 1, "Overall charge not being copied properly with sanitization")
+        assert s.charge == 1, "Overall charge not being copied properly with sanitization"
         super_cell = s * 3
-        self.assertEqual(
-            super_cell.charge,
-            27,
-            "Overall charge is not being properly multiplied in IStructure __mul__",
-        )
-        self.assertIn("Overall Charge: +1", str(s), "String representation not adding charge")
+        assert super_cell.charge == 27, "Overall charge is not being properly multiplied in IStructure __mul__"
+        assert "Overall Charge: +1" in str(s), "String representation not adding charge"
         sorted_s = super_cell.get_sorted_structure()
-        self.assertEqual(
-            sorted_s.charge,
-            27,
-            "Overall charge is not properly copied during structure sorting",
-        )
+        assert sorted_s.charge == 27, "Overall charge is not properly copied during structure sorting"
         super_cell.set_charge(25)
-        self.assertEqual(super_cell.charge, 25, "Set charge not properly modifying _charge")
+        assert super_cell.charge == 25, "Set charge not properly modifying _charge"
 
     def test_vesta_lattice_matrix(self):
         silica_zeolite = Molecule.from_file(self.TEST_FILES_DIR / "CON_vesta.xyz")
@@ -1310,7 +1283,7 @@ class StructureTest(PymatgenTest):
 
         s_vesta = s_vesta.get_primitive_structure()
         s_vesta.merge_sites(0.01, "delete")
-        self.assertEqual(s_vesta.formula, "Si56 O112")
+        assert s_vesta.formula == "Si56 O112"
 
         broken_s = Structure(
             lattice=Lattice.from_parameters(22.6840, 13.3730, 12.5530, 90, 69.479, 90),
@@ -1321,7 +1294,7 @@ class StructureTest(PymatgenTest):
         )
 
         broken_s.merge_sites(0.01, "delete")
-        self.assertEqual(broken_s.formula, "Si56 O134")
+        assert broken_s.formula == "Si56 O134"
 
     def test_extract_cluster(self):
         coords = [
@@ -1345,13 +1318,13 @@ class StructureTest(PymatgenTest):
         for site in structure:
             if site.specie.symbol == "C":
                 cluster = Molecule.from_sites(structure.extract_cluster([site]))
-                self.assertEqual(cluster.formula, "H4 C1")
+                assert cluster.formula == "H4 C1"
 
     @unittest.skipIf(m3gnet is None, "Relaxation test requires m3gnet.")
     def test_relax(self):
         structure = self.get_structure("Si")
         relaxed = structure.relax()
-        self.assertAlmostEqual(relaxed.lattice.a, 3.849563, 4)
+        assert round(abs(relaxed.lattice.a - 3.849563), 4) == 0
 
     def test_from_prototype(self):
         for pt in ["bcc", "fcc", "hcp", "diamond"]:
@@ -1400,19 +1373,19 @@ class IMoleculeTest(PymatgenTest):
     def test_set_item(self):
         s = self.mol.copy()
         s[0] = "Si"
-        self.assertEqual(s.formula, "Si1 H4")
+        assert s.formula == "Si1 H4"
         s[(0, 1)] = "Ge"
-        self.assertEqual(s.formula, "Ge2 H3")
+        assert s.formula == "Ge2 H3"
         s[0:2] = "Sn"
-        self.assertEqual(s.formula, "Sn2 H3")
+        assert s.formula == "Sn2 H3"
 
         s = self.mol.copy()
         s["H"] = "F"
-        self.assertEqual(s.formula, "C1 F4")
+        assert s.formula == "C1 F4"
         s["C"] = "C0.25Si0.5"
-        self.assertEqual(s.formula, "Si0.5 C0.25 F4")
+        assert s.formula == "Si0.5 C0.25 F4"
         s["C"] = "C0.25Si0.5"
-        self.assertEqual(s.formula, "Si0.625 C0.0625 F4")
+        assert s.formula == "Si0.625 C0.0625 F4"
 
     def test_bad_molecule(self):
         coords = [
@@ -1423,18 +1396,17 @@ class IMoleculeTest(PymatgenTest):
             [-0.513360, 0.889165, -0.363000],
             [-0.513360, 0.889165, -0.36301],
         ]
-        self.assertRaises(
-            StructureError,
-            Molecule,
-            ["C", "H", "H", "H", "H", "H"],
-            coords,
-            validate_proximity=True,
-        )
+        with pytest.raises(StructureError):
+            Molecule(
+                ["C", "H", "H", "H", "H", "H"],
+                coords,
+                validate_proximity=True,
+            )
 
     def test_get_angle_dihedral(self):
-        self.assertAlmostEqual(self.mol.get_angle(1, 0, 2), 109.47122144618737)
-        self.assertAlmostEqual(self.mol.get_angle(3, 1, 2), 60.00001388659683)
-        self.assertAlmostEqual(self.mol.get_dihedral(0, 1, 2, 3), -35.26438851071765)
+        assert round(abs(self.mol.get_angle(1, 0, 2) - 109.47122144618737), 7) == 0
+        assert round(abs(self.mol.get_angle(3, 1, 2) - 60.00001388659683), 7) == 0
+        assert round(abs(self.mol.get_dihedral(0, 1, 2, 3) - -35.26438851071765), 7) == 0
 
         coords = []
         coords.append([0, 0, 0])
@@ -1442,15 +1414,15 @@ class IMoleculeTest(PymatgenTest):
         coords.append([0, 1, 1])
         coords.append([1, 1, 1])
         self.mol2 = Molecule(["C", "O", "N", "S"], coords)
-        self.assertAlmostEqual(self.mol2.get_dihedral(0, 1, 2, 3), -90)
+        assert round(abs(self.mol2.get_dihedral(0, 1, 2, 3) - -90), 7) == 0
 
     def test_get_covalent_bonds(self):
-        self.assertEqual(len(self.mol.get_covalent_bonds()), 4)
+        assert len(self.mol.get_covalent_bonds()) == 4
 
     def test_properties(self):
-        self.assertEqual(len(self.mol), 5)
-        self.assertTrue(self.mol.is_ordered)
-        self.assertEqual(self.mol.formula, "H4 C1")
+        assert len(self.mol) == 5
+        assert self.mol.is_ordered
+        assert self.mol.formula == "H4 C1"
 
     def test_repr_str(self):
         ans = """Full Formula (H4 C1)
@@ -1462,14 +1434,14 @@ Sites (5)
 2 H     1.026719     0.000000    -0.363000
 3 H    -0.513360    -0.889165    -0.363000
 4 H    -0.513360     0.889165    -0.363000"""
-        self.assertEqual(str(self.mol), ans)
+        assert str(self.mol) == ans
         ans = """Molecule Summary
 Site: C (0.0000, 0.0000, 0.0000)
 Site: H (0.0000, 0.0000, 1.0890)
 Site: H (1.0267, 0.0000, -0.3630)
 Site: H (-0.5134, -0.8892, -0.3630)
 Site: H (-0.5134, 0.8892, -0.3630)"""
-        self.assertEqual(repr(self.mol), ans)
+        assert repr(self.mol) == ans
 
     def test_site_properties(self):
         propertied_mol = Molecule(
@@ -1477,56 +1449,56 @@ Site: H (-0.5134, 0.8892, -0.3630)"""
             self.coords,
             site_properties={"magmom": [0.5, -0.5, 1, 2, 3]},
         )
-        self.assertEqual(propertied_mol[0].magmom, 0.5)
-        self.assertEqual(propertied_mol[1].magmom, -0.5)
+        assert propertied_mol[0].magmom == 0.5
+        assert propertied_mol[1].magmom == -0.5
 
     def test_get_boxed_structure(self):
         s = self.mol.get_boxed_structure(9, 9, 9)
         # C atom should be in center of box.
         self.assertArrayAlmostEqual(s[4].frac_coords, [0.50000001, 0.5, 0.5])
         self.assertArrayAlmostEqual(s[1].frac_coords, [0.6140799, 0.5, 0.45966667])
-        self.assertRaises(ValueError, self.mol.get_boxed_structure, 1, 1, 1)
+        with pytest.raises(ValueError):
+            self.mol.get_boxed_structure(1, 1, 1)
         s2 = self.mol.get_boxed_structure(5, 5, 5, (2, 3, 4))
-        self.assertEqual(len(s2), 24 * 5)
-        self.assertEqual(s2.lattice.abc, (10, 15, 20))
+        assert len(s2) == 24 * 5
+        assert s2.lattice.abc == (10, 15, 20)
 
         # Test offset option
         s3 = self.mol.get_boxed_structure(9, 9, 9, offset=[0.5, 0.5, 0.5])
         self.assertArrayAlmostEqual(s3[4].coords, [5, 5, 5])
         # Test no_cross option
-        self.assertRaises(
-            ValueError,
-            self.mol.get_boxed_structure,
-            5,
-            5,
-            5,
-            offset=[10, 10, 10],
-            no_cross=True,
-        )
+        with pytest.raises(ValueError):
+            self.mol.get_boxed_structure(
+                5,
+                5,
+                5,
+                offset=[10, 10, 10],
+                no_cross=True,
+            )
 
         # Test reorder option
         no_reorder = self.mol.get_boxed_structure(10, 10, 10, reorder=False)
-        self.assertEqual(str(s3[0].specie), "H")
-        self.assertEqual(str(no_reorder[0].specie), "C")
+        assert str(s3[0].specie) == "H"
+        assert str(no_reorder[0].specie) == "C"
 
     def test_get_distance(self):
-        self.assertAlmostEqual(self.mol.get_distance(0, 1), 1.089)
+        assert round(abs(self.mol.get_distance(0, 1) - 1.089), 7) == 0
 
     def test_get_neighbors(self):
         nn = self.mol.get_neighbors(self.mol[0], 1)
-        self.assertEqual(len(nn), 0)
+        assert len(nn) == 0
         nn = self.mol.get_neighbors(self.mol[0], 2)
-        self.assertEqual(len(nn), 4)
+        assert len(nn) == 4
 
     def test_get_neighbors_in_shell(self):
         nn = self.mol.get_neighbors_in_shell([0, 0, 0], 0, 1)
-        self.assertEqual(len(nn), 1)
+        assert len(nn) == 1
         nn = self.mol.get_neighbors_in_shell([0, 0, 0], 1, 0.9)
-        self.assertEqual(len(nn), 4)
+        assert len(nn) == 4
         nn = self.mol.get_neighbors_in_shell([0, 0, 0], 1, 0.9)
-        self.assertEqual(len(nn), 4)
+        assert len(nn) == 4
         nn = self.mol.get_neighbors_in_shell([0, 0, 0], 2, 0.1)
-        self.assertEqual(len(nn), 0)
+        assert len(nn) == 0
 
     def test_get_dist_matrix(self):
         ans = [
@@ -1540,29 +1512,28 @@ Site: H (-0.5134, 0.8892, -0.3630)"""
 
     def test_break_bond(self):
         (mol1, mol2) = self.mol.break_bond(0, 1)
-        self.assertEqual(mol1.formula, "H3 C1")
-        self.assertEqual(mol2.formula, "H1")
+        assert mol1.formula == "H3 C1"
+        assert mol2.formula == "H1"
 
     def test_prop(self):
-        self.assertEqual(self.mol.charge, 0)
-        self.assertEqual(self.mol.spin_multiplicity, 1)
-        self.assertEqual(self.mol.nelectrons, 10)
+        assert self.mol.charge == 0
+        assert self.mol.spin_multiplicity == 1
+        assert self.mol.nelectrons == 10
         self.assertArrayAlmostEqual(self.mol.center_of_mass, [0, 0, 0])
-        self.assertRaises(
-            ValueError,
-            Molecule,
-            ["C", "H", "H", "H", "H"],
-            self.coords,
-            charge=1,
-            spin_multiplicity=1,
-        )
+        with pytest.raises(ValueError):
+            Molecule(
+                ["C", "H", "H", "H", "H"],
+                self.coords,
+                charge=1,
+                spin_multiplicity=1,
+            )
         mol = Molecule(["C", "H", "H", "H", "H"], self.coords, charge=1)
-        self.assertEqual(mol.spin_multiplicity, 2)
-        self.assertEqual(mol.nelectrons, 9)
+        assert mol.spin_multiplicity == 2
+        assert mol.nelectrons == 9
 
         # Triplet O2
         mol = IMolecule(["O"] * 2, [[0, 0, 0], [0, 0, 1.2]], spin_multiplicity=3)
-        self.assertEqual(mol.spin_multiplicity, 3)
+        assert mol.spin_multiplicity == 3
 
     def test_no_spin_check(self):
         coords = [
@@ -1574,12 +1545,12 @@ Site: H (-0.5134, 0.8892, -0.3630)"""
         with pytest.raises(ValueError):
             mol = IMolecule(["C", "H", "H", "H"], coords, charge=0, spin_multiplicity=1)
         mol = IMolecule(["C", "H", "H", "H"], coords, charge=0, spin_multiplicity=1, charge_spin_check=False)
-        self.assertEqual(mol.spin_multiplicity, 1)
-        self.assertEqual(mol.charge, 0)
+        assert mol.spin_multiplicity == 1
+        assert mol.charge == 0
 
     def test_equal(self):
         mol = IMolecule(["C", "H", "H", "H", "H"], self.coords, charge=1)
-        self.assertNotEqual(mol, self.mol)
+        assert mol != self.mol
 
     def test_get_centered_molecule(self):
         mol = IMolecule(["O"] * 2, [[0, 0, 0], [0, 0, 1.2]], spin_multiplicity=3)
@@ -1589,7 +1560,7 @@ Site: H (-0.5134, 0.8892, -0.3630)"""
     def test_to_from_dict(self):
         d = self.mol.as_dict()
         mol2 = IMolecule.from_dict(d)
-        self.assertEqual(type(mol2), IMolecule)
+        assert isinstance(mol2, IMolecule)
         propertied_mol = Molecule(
             ["C", "H", "H", "H", "H"],
             self.coords,
@@ -1597,33 +1568,33 @@ Site: H (-0.5134, 0.8892, -0.3630)"""
             site_properties={"magmom": [0.5, -0.5, 1, 2, 3]},
         )
         d = propertied_mol.as_dict()
-        self.assertEqual(d["sites"][0]["properties"]["magmom"], 0.5)
+        assert d["sites"][0]["properties"]["magmom"] == 0.5
         mol = Molecule.from_dict(d)
-        self.assertEqual(propertied_mol, mol)
-        self.assertEqual(mol[0].magmom, 0.5)
-        self.assertEqual(mol.formula, "H4 C1")
-        self.assertEqual(mol.charge, 1)
+        assert propertied_mol == mol
+        assert mol[0].magmom == 0.5
+        assert mol.formula == "H4 C1"
+        assert mol.charge == 1
 
     def test_default_dict_attrs(self):
         d = self.mol.as_dict()
-        self.assertEqual(d["charge"], 0)
-        self.assertEqual(d["spin_multiplicity"], 1)
+        assert d["charge"] == 0
+        assert d["spin_multiplicity"] == 1
 
     def test_to_from_file_string(self):
         for fmt in ["xyz", "json", "g03", "yaml"]:
             s = self.mol.to(fmt=fmt)
-            self.assertIsNotNone(s)
+            assert s is not None
             m = IMolecule.from_str(s, fmt=fmt)
-            self.assertEqual(m, self.mol)
-            self.assertIsInstance(m, IMolecule)
+            assert m == self.mol
+            assert isinstance(m, IMolecule)
 
         self.mol.to(filename="CH4_testing.xyz")
-        self.assertTrue(os.path.exists("CH4_testing.xyz"))
+        assert os.path.exists("CH4_testing.xyz")
         os.remove("CH4_testing.xyz")
         self.mol.to(filename="CH4_testing.yaml")
-        self.assertTrue(os.path.exists("CH4_testing.yaml"))
+        assert os.path.exists("CH4_testing.yaml")
         mol = Molecule.from_file("CH4_testing.yaml")
-        self.assertEqual(self.mol, mol)
+        assert self.mol == mol
         os.remove("CH4_testing.yaml")
 
 
@@ -1645,30 +1616,31 @@ class MoleculeTest(PymatgenTest):
     def test_mutable_sequence_methods(self):
         s = self.mol
         s[1] = ("F", [0.5, 0.5, 0.5])
-        self.assertEqual(s.formula, "H3 C1 F1")
+        assert s.formula == "H3 C1 F1"
         self.assertArrayAlmostEqual(s[1].coords, [0.5, 0.5, 0.5])
         s.reverse()
-        self.assertEqual(s[0].specie, Element("H"))
+        assert s[0].specie == Element("H")
         self.assertArrayAlmostEqual(s[0].coords, [-0.513360, 0.889165, -0.363000])
         del s[1]
-        self.assertEqual(s.formula, "H2 C1 F1")
+        assert s.formula == "H2 C1 F1"
         s[3] = "N", [0, 0, 0], {"charge": 4}
-        self.assertEqual(s.formula, "H2 N1 F1")
-        self.assertEqual(s[3].charge, 4)
+        assert s.formula == "H2 N1 F1"
+        assert s[3].charge == 4
 
     def test_insert_remove_append(self):
         mol = self.mol
         mol.insert(1, "O", [0.5, 0.5, 0.5])
-        self.assertEqual(mol.formula, "H4 C1 O1")
+        assert mol.formula == "H4 C1 O1"
         del mol[2]
-        self.assertEqual(mol.formula, "H3 C1 O1")
+        assert mol.formula == "H3 C1 O1"
         mol.set_charge_and_spin(0)
-        self.assertEqual(mol.spin_multiplicity, 2)
+        assert mol.spin_multiplicity == 2
         mol.append("N", [1, 1, 1])
-        self.assertEqual(mol.formula, "H3 C1 N1 O1")
-        self.assertRaises(TypeError, dict, [(mol, 1)])
+        assert mol.formula == "H3 C1 N1 O1"
+        with pytest.raises(TypeError):
+            dict([(mol, 1)])
         mol.remove_sites([0, 1])
-        self.assertEqual(mol.formula, "H3 N1")
+        assert mol.formula == "H3 N1"
 
     def test_translate_sites(self):
         self.mol.translate_sites([0, 1], [0.5, 0.5, 0.5])
@@ -1680,14 +1652,14 @@ class MoleculeTest(PymatgenTest):
 
     def test_replace(self):
         self.mol[0] = "Ge"
-        self.assertEqual(self.mol.formula, "Ge1 H4")
+        assert self.mol.formula == "Ge1 H4"
 
         self.mol.replace_species({Element("Ge"): {Element("Ge"): 0.5, Element("Si"): 0.5}})
-        self.assertEqual(self.mol.formula, "Si0.5 Ge0.5 H4")
+        assert self.mol.formula == "Si0.5 Ge0.5 H4"
 
         # this should change the .5Si .5Ge sites to .75Si .25Ge
         self.mol.replace_species({Element("Ge"): {Element("Ge"): 0.5, Element("Si"): 0.5}})
-        self.assertEqual(self.mol.formula, "Si0.75 Ge0.25 H4")
+        assert self.mol.formula == "Si0.75 Ge0.25 H4"
 
         d = 0.1
         pre_perturbation_sites = self.mol.sites[:]
@@ -1695,29 +1667,25 @@ class MoleculeTest(PymatgenTest):
         post_perturbation_sites = self.mol.sites
 
         for i, x in enumerate(pre_perturbation_sites):
-            self.assertAlmostEqual(
-                x.distance(post_perturbation_sites[i]),
-                d,
-                3,
-                "Bad perturbation distance",
-            )
+            assert round(abs(x.distance(post_perturbation_sites[i]) - d), 3) == 0, "Bad perturbation distance"
 
     def test_add_site_property(self):
         self.mol.add_site_property("charge", [4.1, -2, -2, -2, -2])
-        self.assertEqual(self.mol[0].charge, 4.1)
-        self.assertEqual(self.mol[1].charge, -2)
+        assert self.mol[0].charge == 4.1
+        assert self.mol[1].charge == -2
 
         self.mol.add_site_property("magmom", [3, 2, 2, 2, 2])
-        self.assertEqual(self.mol[0].charge, 4.1)
-        self.assertEqual(self.mol[0].magmom, 3)
+        assert self.mol[0].charge == 4.1
+        assert self.mol[0].magmom == 3
         self.mol.remove_site_property("magmom")
-        self.assertRaises(AttributeError, getattr, self.mol[0], "magmom")
+        with pytest.raises(AttributeError):
+            self.mol[0].magmom
 
     def test_to_from_dict(self):
         self.mol.append("X", [2, 0, 0])
         d = self.mol.as_dict()
         mol2 = Molecule.from_dict(d)
-        self.assertEqual(type(mol2), Molecule)
+        assert isinstance(mol2, Molecule)
         self.assertMSONable(self.mol)
 
     def test_apply_operation(self):
@@ -1735,18 +1703,18 @@ class MoleculeTest(PymatgenTest):
         ]
         sub = Molecule(["X", "C", "H", "H", "H"], coords)
         self.mol.substitute(1, sub)
-        self.assertAlmostEqual(self.mol.get_distance(0, 4), 1.54)
+        assert round(abs(self.mol.get_distance(0, 4) - 1.54), 7) == 0
         f = Molecule(["X", "F"], [[0, 0, 0], [0, 0, 1.11]])
         self.mol.substitute(2, f)
-        self.assertAlmostEqual(self.mol.get_distance(0, 7), 1.35)
+        assert round(abs(self.mol.get_distance(0, 7) - 1.35), 7) == 0
         oh = Molecule(
             ["X", "O", "H"],
             [[0, 0.780362, -0.456316], [0, 0, 0.114079], [0, -0.780362, -0.456316]],
         )
         self.mol.substitute(1, oh)
-        self.assertAlmostEqual(self.mol.get_distance(0, 7), 1.43)
+        assert round(abs(self.mol.get_distance(0, 7) - 1.43), 7) == 0
         self.mol.substitute(3, "methyl")
-        self.assertEqual(self.mol.formula, "H7 C3 O1 F1")
+        assert self.mol.formula == "H7 C3 O1 F1"
         coords = [
             [0.00000, 1.40272, 0.00000],
             [0.00000, 2.49029, 0.00000],
@@ -1763,23 +1731,23 @@ class MoleculeTest(PymatgenTest):
         ]
         benzene = Molecule(["C", "H", "C", "H", "C", "H", "C", "H", "C", "H", "C", "H"], coords)
         benzene.substitute(1, sub)
-        self.assertEqual(benzene.formula, "H8 C7")
+        assert benzene.formula == "H8 C7"
         # Carbon attached should be in plane.
-        self.assertAlmostEqual(benzene[11].coords[2], 0)
+        assert round(abs(benzene[11].coords[2] - 0), 7) == 0
         benzene[14] = "Br"
         benzene.substitute(13, sub)
-        self.assertEqual(benzene.formula, "H9 C8 Br1")
+        assert benzene.formula == "H9 C8 Br1"
 
     def test_to_from_file_string(self):
         for fmt in ["xyz", "json", "g03"]:
             s = self.mol.to(fmt=fmt)
-            self.assertIsNotNone(s)
+            assert s is not None
             m = Molecule.from_str(s, fmt=fmt)
-            self.assertEqual(m, self.mol)
-            self.assertIsInstance(m, Molecule)
+            assert m == self.mol
+            assert isinstance(m, Molecule)
 
         self.mol.to(filename="CH4_testing.xyz")
-        self.assertTrue(os.path.exists("CH4_testing.xyz"))
+        assert os.path.exists("CH4_testing.xyz")
         os.remove("CH4_testing.xyz")
 
     def test_extract_cluster(self):
@@ -1787,8 +1755,8 @@ class MoleculeTest(PymatgenTest):
         coords = list(self.mol.cart_coords) + list(self.mol.cart_coords + [10, 0, 0])
         mol = Molecule(species, coords)
         cluster = Molecule.from_sites(mol.extract_cluster([mol[0]]))
-        self.assertEqual(mol.formula, "H8 C2")
-        self.assertEqual(cluster.formula, "H4 C1")
+        assert mol.formula == "H8 C2"
+        assert cluster.formula == "H4 C1"
 
     def test_no_spin_check(self):
         coords = [
@@ -1803,11 +1771,11 @@ class MoleculeTest(PymatgenTest):
         with pytest.raises(ValueError):
             mol_valid.set_charge_and_spin(0, 1)
         mol = Molecule(["C", "H", "H", "H"], coords, charge=0, spin_multiplicity=1, charge_spin_check=False)
-        self.assertEqual(mol.spin_multiplicity, 1)
-        self.assertEqual(mol.charge, 0)
+        assert mol.spin_multiplicity == 1
+        assert mol.charge == 0
         mol.set_charge_and_spin(0, 3)
-        self.assertEqual(mol.charge, 0)
-        self.assertEqual(mol.spin_multiplicity, 3)
+        assert mol.charge == 0
+        assert mol.spin_multiplicity == 3
 
 
 if __name__ == "__main__":

--- a/pymatgen/core/tests/test_surface.py
+++ b/pymatgen/core/tests/test_surface.py
@@ -83,10 +83,10 @@ class SlabTest(PymatgenTest):
         )
         m = self.zno55.lattice.matrix
         area = np.linalg.norm(np.cross(m[0], m[1]))
-        self.assertAlmostEqual(zno_slab.surface_area, area)
-        self.assertEqual(zno_slab.lattice.parameters, self.zno55.lattice.parameters)
-        self.assertEqual(zno_slab.oriented_unit_cell.composition, self.zno1.composition)
-        self.assertEqual(len(zno_slab), 8)
+        assert round(abs(zno_slab.surface_area - area), 7) == 0
+        assert zno_slab.lattice.parameters == self.zno55.lattice.parameters
+        assert zno_slab.oriented_unit_cell.composition == self.zno1.composition
+        assert len(zno_slab) == 8
 
         # check reorient_lattice. get a slab not oriented and check that orientation
         # works even with Cartesian coordinates.
@@ -126,18 +126,18 @@ class SlabTest(PymatgenTest):
         )
         zno_slab.add_adsorbate_atom([1], "H", 1)
 
-        self.assertEqual(len(zno_slab), 9)
-        self.assertEqual(str(zno_slab[8].specie), "H")
-        self.assertAlmostEqual(zno_slab.get_distance(1, 8), 1.0)
-        self.assertTrue(zno_slab[8].c > zno_slab[0].c)
+        assert len(zno_slab) == 9
+        assert str(zno_slab[8].specie) == "H"
+        assert round(abs(zno_slab.get_distance(1, 8) - 1.0), 7) == 0
+        assert zno_slab[8].c > zno_slab[0].c
         m = self.zno55.lattice.matrix
         area = np.linalg.norm(np.cross(m[0], m[1]))
-        self.assertAlmostEqual(zno_slab.surface_area, area)
-        self.assertEqual(zno_slab.lattice.parameters, self.zno55.lattice.parameters)
+        assert round(abs(zno_slab.surface_area - area), 7) == 0
+        assert zno_slab.lattice.parameters == self.zno55.lattice.parameters
 
     def test_get_sorted_structure(self):
         species = [str(site.specie) for site in self.zno55.get_sorted_structure()]
-        self.assertEqual(species, ["Zn2+"] * 4 + ["O2-"] * 4)
+        assert species == ["Zn2+"] * 4 + ["O2-"] * 4
 
     def test_methods(self):
         # Test various structure methods
@@ -146,11 +146,11 @@ class SlabTest(PymatgenTest):
     def test_as_from_dict(self):
         d = self.zno55.as_dict()
         obj = Slab.from_dict(d)
-        self.assertEqual(obj.miller_index, (1, 0, 0))
+        assert obj.miller_index == (1, 0, 0)
 
     def test_dipole_and_is_polar(self):
         self.assertArrayAlmostEqual(self.zno55.dipole, [0, 0, 0])
-        self.assertFalse(self.zno55.is_polar())
+        assert not self.zno55.is_polar()
         cscl = self.get_structure("CsCl")
         cscl.add_oxidation_state_by_element({"Cs": 1, "Cl": -1})
         slab = SlabGenerator(
@@ -163,7 +163,7 @@ class SlabTest(PymatgenTest):
             center_slab=False,
         ).get_slab()
         self.assertArrayAlmostEqual(slab.dipole, [-4.209, 0, 0])
-        self.assertTrue(slab.is_polar())
+        assert slab.is_polar()
 
     def test_surface_sites_and_symmetry(self):
         # test if surfaces are equivalent by using
@@ -175,10 +175,10 @@ class SlabTest(PymatgenTest):
             slabgen = SlabGenerator(self.agfcc, (3, 1, 0), 10, 10, center_slab=bool)
             slab = slabgen.get_slabs()[0]
             surf_sites_dict = slab.get_surface_sites()
-            self.assertEqual(len(surf_sites_dict["top"]), len(surf_sites_dict["bottom"]))
+            assert len(surf_sites_dict["top"]) == len(surf_sites_dict["bottom"])
             total_surf_sites = sum(len(surf_sites_dict[key]) for key in surf_sites_dict)
-            self.assertTrue(slab.is_symmetric())
-            self.assertEqual(total_surf_sites / 2, 4)
+            assert slab.is_symmetric()
+            assert total_surf_sites / 2 == 4
 
             # Test if the ratio of surface sites per area is
             # constant, ie are the surface energies the same
@@ -244,12 +244,12 @@ class SlabTest(PymatgenTest):
                     symmetric_count += 1
 
             # Check if slabs are all symmetric
-            self.assertEqual(asymmetric_count, 0)
-            self.assertEqual(symmetric_count, len(slabs))
+            assert asymmetric_count == 0
+            assert symmetric_count == len(slabs)
 
         # Check if we can generate symmetric slabs from bulk with no inversion
         all_non_laue_slabs = generate_all_slabs(self.nonlaue, 1, 15, 15, symmetrize=True)
-        self.assertTrue(len(all_non_laue_slabs) > 0)
+        assert len(all_non_laue_slabs) > 0
 
     def test_get_symmetric_sites(self):
 
@@ -282,7 +282,7 @@ class SlabTest(PymatgenTest):
 
             # Check if slab is all symmetric
             sg = SpacegroupAnalyzer(slab)
-            self.assertTrue(sg.is_laue())
+            assert sg.is_laue()
 
     def test_oriented_unit_cell(self):
 
@@ -298,8 +298,8 @@ class SlabTest(PymatgenTest):
         for slab in all_slabs:
             ouc = slab.oriented_unit_cell
 
-            self.assertAlmostEqual(surface_area(slab), surface_area(ouc))
-            self.assertGreaterEqual(len(slab), len(ouc))
+            assert round(abs(surface_area(slab) - surface_area(ouc)), 7) == 0
+            assert len(slab) >= len(ouc)
 
     def test_get_slab_regions(self):
 
@@ -318,8 +318,8 @@ class SlabTest(PymatgenTest):
             else:
                 top_c.append(site.frac_coords[2])
         ranges = get_slab_regions(slab)
-        self.assertEqual(tuple(ranges[0]), (0, max(bottom_c)))
-        self.assertEqual(tuple(ranges[1]), (min(top_c), 1))
+        assert tuple(ranges[0]) == (0, max(bottom_c))
+        assert tuple(ranges[1]) == (min(top_c), 1)
 
     def test_as_dict(self):
         slabs = generate_all_slabs(
@@ -337,7 +337,7 @@ class SlabTest(PymatgenTest):
         slab = slabs[0]
         s = json.dumps(slab.as_dict())
         d = json.loads(s)
-        self.assertEqual(slab, Slab.from_dict(d))
+        assert slab == Slab.from_dict(d)
 
         # test initialising with a list scale_factor
         slab = Slab(
@@ -351,7 +351,7 @@ class SlabTest(PymatgenTest):
         )
         s = json.dumps(slab.as_dict())
         d = json.loads(s)
-        self.assertEqual(slab, Slab.from_dict(d))
+        assert slab == Slab.from_dict(d)
 
 
 class SlabGeneratorTest(PymatgenTest):
@@ -391,15 +391,15 @@ class SlabGeneratorTest(PymatgenTest):
         s = self.get_structure("LiFePO4")
         gen = SlabGenerator(s, [0, 0, 1], 10, 10)
         s = gen.get_slab(0.25)
-        self.assertAlmostEqual(s.lattice.abc[2], 20.820740000000001)
+        assert round(abs(s.lattice.abc[2] - 20.820740000000001), 7) == 0
 
         fcc = Structure.from_spacegroup("Fm-3m", Lattice.cubic(3), ["Fe"], [[0, 0, 0]])
         gen = SlabGenerator(fcc, [1, 1, 1], 10, 10, max_normal_search=1)
         slab = gen.get_slab()
-        self.assertEqual(len(slab), 6)
+        assert len(slab) == 6
         gen = SlabGenerator(fcc, [1, 1, 1], 10, 10, primitive=False, max_normal_search=1)
         slab_non_prim = gen.get_slab()
-        self.assertEqual(len(slab_non_prim), len(slab) * 4)
+        assert len(slab_non_prim) == len(slab) * 4
 
         # Some randomized testing of cell vectors
         for i in range(1, 231):
@@ -446,8 +446,8 @@ class SlabGeneratorTest(PymatgenTest):
                 )
             gen = SlabGenerator(s, miller, 10, 10)
             a, b, c = gen.oriented_unit_cell.lattice.matrix
-            self.assertAlmostEqual(np.dot(a, gen._normal), 0)
-            self.assertAlmostEqual(np.dot(b, gen._normal), 0)
+            assert round(abs(np.dot(a, gen._normal) - 0), 7) == 0
+            assert round(abs(np.dot(b, gen._normal) - 0), 7) == 0
 
     def test_normal_search(self):
         fcc = Structure.from_spacegroup("Fm-3m", Lattice.cubic(3), ["Fe"], [[0, 0, 0]])
@@ -455,15 +455,15 @@ class SlabGeneratorTest(PymatgenTest):
             gen = SlabGenerator(fcc, miller, 10, 10)
             gen_normal = SlabGenerator(fcc, miller, 10, 10, max_normal_search=max(miller))
             slab = gen_normal.get_slab()
-            self.assertAlmostEqual(slab.lattice.alpha, 90)
-            self.assertAlmostEqual(slab.lattice.beta, 90)
-            self.assertGreaterEqual(len(gen_normal.oriented_unit_cell), len(gen.oriented_unit_cell))
+            assert round(abs(slab.lattice.alpha - 90), 7) == 0
+            assert round(abs(slab.lattice.beta - 90), 7) == 0
+            assert len(gen_normal.oriented_unit_cell) >= len(gen.oriented_unit_cell)
 
         graphite = self.get_structure("Graphite")
         for miller in [(1, 0, 0), (1, 1, 0), (0, 0, 1), (2, 1, 1)]:
             gen = SlabGenerator(graphite, miller, 10, 10)
             gen_normal = SlabGenerator(graphite, miller, 10, 10, max_normal_search=max(miller))
-            self.assertGreaterEqual(len(gen_normal.oriented_unit_cell), len(gen.oriented_unit_cell))
+            assert len(gen_normal.oriented_unit_cell) >= len(gen.oriented_unit_cell)
 
         sc = Structure(
             Lattice.hexagonal(3.32, 5.15),
@@ -471,54 +471,51 @@ class SlabGeneratorTest(PymatgenTest):
             [[1 / 3, 2 / 3, 0.25], [2 / 3, 1 / 3, 0.75]],
         )
         gen = SlabGenerator(sc, (1, 1, 1), 10, 10, max_normal_search=1)
-        self.assertAlmostEqual(gen.oriented_unit_cell.lattice.angles[1], 90)
+        assert round(abs(gen.oriented_unit_cell.lattice.angles[1] - 90), 7) == 0
 
     def test_get_slabs(self):
         gen = SlabGenerator(self.get_structure("CsCl"), [0, 0, 1], 10, 10)
 
         # Test orthogonality of some internal variables.
         a, b, c = gen.oriented_unit_cell.lattice.matrix
-        self.assertAlmostEqual(np.dot(a, gen._normal), 0)
-        self.assertAlmostEqual(np.dot(b, gen._normal), 0)
+        assert round(abs(np.dot(a, gen._normal) - 0), 7) == 0
+        assert round(abs(np.dot(b, gen._normal) - 0), 7) == 0
 
-        self.assertEqual(len(gen.get_slabs()), 1)
+        assert len(gen.get_slabs()) == 1
 
         s = self.get_structure("LiFePO4")
         gen = SlabGenerator(s, [0, 0, 1], 10, 10)
-        self.assertEqual(len(gen.get_slabs()), 5)
+        assert len(gen.get_slabs()) == 5
 
-        self.assertEqual(len(gen.get_slabs(bonds={("P", "O"): 3})), 2)
+        assert len(gen.get_slabs(bonds={("P", "O"): 3})) == 2
 
         # There are no slabs in LFP that does not break either P-O or Fe-O
         # bonds for a miller index of [0, 0, 1].
-        self.assertEqual(len(gen.get_slabs(bonds={("P", "O"): 3, ("Fe", "O"): 3})), 0)
+        assert len(gen.get_slabs(bonds={("P", "O"): 3, ("Fe", "O"): 3})) == 0
 
         # If we allow some broken bonds, there are a few slabs.
-        self.assertEqual(
-            len(gen.get_slabs(bonds={("P", "O"): 3, ("Fe", "O"): 3}, max_broken_bonds=2)),
-            2,
-        )
+        assert len(gen.get_slabs(bonds={("P", "O"): 3, ("Fe", "O"): 3}, max_broken_bonds=2)) == 2
 
         # At this threshold, only the origin and center Li results in
         # clustering. All other sites are non-clustered. So the of
         # slabs is of sites in LiFePO4 unit cell - 2 + 1.
-        self.assertEqual(len(gen.get_slabs(tol=1e-4, ftol=1e-4)), 15)
+        assert len(gen.get_slabs(tol=1e-4, ftol=1e-4)) == 15
 
         LiCoO2 = Structure.from_file(get_path("icsd_LiCoO2.cif"), primitive=False)
         gen = SlabGenerator(LiCoO2, [0, 0, 1], 10, 10)
         lco = gen.get_slabs(bonds={("Co", "O"): 3})
-        self.assertEqual(len(lco), 1)
+        assert len(lco) == 1
         a, b, c = gen.oriented_unit_cell.lattice.matrix
-        self.assertAlmostEqual(np.dot(a, gen._normal), 0)
-        self.assertAlmostEqual(np.dot(b, gen._normal), 0)
+        assert round(abs(np.dot(a, gen._normal) - 0), 7) == 0
+        assert round(abs(np.dot(b, gen._normal) - 0), 7) == 0
 
         scc = Structure.from_spacegroup("Pm-3m", Lattice.cubic(3), ["Fe"], [[0, 0, 0]])
         gen = SlabGenerator(scc, [0, 0, 1], 10, 10)
         slabs = gen.get_slabs()
-        self.assertEqual(len(slabs), 1)
+        assert len(slabs) == 1
         gen = SlabGenerator(scc, [1, 1, 1], 10, 10, max_normal_search=1)
         slabs = gen.get_slabs()
-        self.assertEqual(len(slabs), 1)
+        assert len(slabs) == 1
 
         # Test whether using units of hkl planes instead of Angstroms for
         # min_slab_size and min_vac_size will give us the same number of atoms
@@ -529,7 +526,7 @@ class SlabGeneratorTest(PymatgenTest):
             natoms.append(len(slabgen.get_slab()))
         n = natoms[0]
         for i in natoms:
-            self.assertEqual(n, i)
+            assert n == i
 
     def test_triclinic_TeI(self):
         # Test case for a triclinic structure of TeI. Only these three
@@ -542,7 +539,7 @@ class SlabGeneratorTest(PymatgenTest):
         for k, v in numb_slabs.items():
             trclnc_TeI = SlabGenerator(TeI, k, 10, 10)
             TeI_slabs = trclnc_TeI.get_slabs()
-            self.assertEqual(v, len(TeI_slabs))
+            assert v == len(TeI_slabs)
 
     def test_get_orthogonal_c_slab(self):
         TeI = Structure.from_file(get_path("icsd_TeI.cif"), primitive=False)
@@ -550,8 +547,8 @@ class SlabGeneratorTest(PymatgenTest):
         TeI_slabs = trclnc_TeI.get_slabs()
         slab = TeI_slabs[0]
         norm_slab = slab.get_orthogonal_c_slab()
-        self.assertAlmostEqual(norm_slab.lattice.angles[0], 90)
-        self.assertAlmostEqual(norm_slab.lattice.angles[1], 90)
+        assert round(abs(norm_slab.lattice.angles[0] - 90), 7) == 0
+        assert round(abs(norm_slab.lattice.angles[1] - 90), 7) == 0
 
     def test_get_orthogonal_c_slab_site_props(self):
         TeI = Structure.from_file(get_path("icsd_TeI.cif"), primitive=False)
@@ -568,7 +565,7 @@ class SlabGeneratorTest(PymatgenTest):
         norm_slab = slab_with_site_props.get_orthogonal_c_slab()
 
         # Check if site properties is consistent (or kept)
-        self.assertEqual(slab_with_site_props.site_properties, norm_slab.site_properties)
+        assert slab_with_site_props.site_properties == norm_slab.site_properties
 
     def test_get_tasker2_slabs(self):
         # The uneven distribution of ions on the (111) facets of Halite
@@ -577,16 +574,16 @@ class SlabGeneratorTest(PymatgenTest):
         slabgen = SlabGenerator(self.MgO, (1, 1, 1), 10, 10, max_normal_search=1)
         # We generate the Tasker 3 structure first
         slab = slabgen.get_slabs()[0]
-        self.assertFalse(slab.is_symmetric())
-        self.assertTrue(slab.is_polar())
+        assert not slab.is_symmetric()
+        assert slab.is_polar()
         # Now to generate the Tasker 2 structure, we must
         # ensure there are enough ions on top to move around
         slab.make_supercell([2, 1, 1])
         slabs = slab.get_tasker2_slabs()
         # Check if our Tasker 2 slab is nonpolar and symmetric
         for slab in slabs:
-            self.assertTrue(slab.is_symmetric())
-            self.assertFalse(slab.is_polar())
+            assert slab.is_symmetric()
+            assert not slab.is_polar()
 
     def test_nonstoichiometric_symmetrized_slab(self):
         # For the (111) halite slab, sometimes a nonstoichiometric
@@ -596,17 +593,17 @@ class SlabGeneratorTest(PymatgenTest):
 
         # We should end up with two terminations, one with
         # an Mg rich surface and another O rich surface
-        self.assertEqual(len(slabs), 2)
+        assert len(slabs) == 2
         for slab in slabs:
-            self.assertTrue(slab.is_symmetric())
+            assert slab.is_symmetric()
 
         # For a low symmetry primitive_elemental system such as
         # R-3m, there should be some nonsymmetric slabs
         # without using nonstoichiometric_symmetrized_slab
         slabs = generate_all_slabs(self.Dy, 1, 30, 30, center_slab=True, symmetrize=True)
         for s in slabs:
-            self.assertTrue(s.is_symmetric())
-            self.assertGreater(len(s), len(self.Dy))
+            assert s.is_symmetric()
+            assert len(s) > len(self.Dy)
 
     def test_move_to_other_side(self):
 
@@ -620,13 +617,13 @@ class SlabGeneratorTest(PymatgenTest):
         top_index = [ss[1] for ss in surface_sites["top"]]
         slab = slabgen.move_to_other_side(slab, top_index)
         all_bottom = [slab[i].frac_coords[2] < slab.center_of_mass[2] for i in top_index]
-        self.assertTrue(all(all_bottom))
+        assert all(all_bottom)
 
         # check if bottom sites are moved to the top
         bottom_index = [ss[1] for ss in surface_sites["bottom"]]
         slab = slabgen.move_to_other_side(slab, bottom_index)
         all_top = [slab[i].frac_coords[2] > slab.center_of_mass[2] for i in bottom_index]
-        self.assertTrue(all(all_top))
+        assert all(all_top)
 
     def test_bonds_broken(self):
         # Querying the Materials Project database for Si
@@ -644,8 +641,8 @@ class SlabGeneratorTest(PymatgenTest):
         # expect 2 and 6 bonds broken so we check for this.
         # Number of broken bonds are floats due to primitive
         # flag check and subsequent transformation of slabs.
-        self.assertTrue(slabs[0].energy, 2.0)
-        self.assertTrue(slabs[1].energy, 6.0)
+        assert slabs[0].energy, 2.0
+        assert slabs[1].energy, 6.0
 
 
 class ReconstructionGeneratorTests(PymatgenTest):
@@ -676,36 +673,36 @@ class ReconstructionGeneratorTests(PymatgenTest):
         recon = ReconstructionGenerator(self.Ni, 10, 10, "fcc_110_missing_row_1x2")
         slab = recon.get_unreconstructed_slabs()[0]
         recon_slab = recon.build_slabs()[0]
-        self.assertTrue(recon_slab.reconstruction)
-        self.assertEqual(len(slab), len(recon_slab) + 2)
-        self.assertTrue(recon_slab.is_symmetric())
+        assert recon_slab.reconstruction
+        assert len(slab) == len(recon_slab) + 2
+        assert recon_slab.is_symmetric()
 
         # Test if the ouc corresponds to the reconstructed slab
         recon_ouc = recon_slab.oriented_unit_cell
         ouc = slab.oriented_unit_cell
-        self.assertEqual(ouc.lattice.b * 2, recon_ouc.lattice.b)
-        self.assertEqual(len(ouc) * 2, len(recon_ouc))
+        assert ouc.lattice.b * 2 == recon_ouc.lattice.b
+        assert len(ouc) * 2 == len(recon_ouc)
 
         # Test a reconstruction where we simply add atoms
         recon = ReconstructionGenerator(self.Ni, 10, 10, "fcc_111_adatom_t_1x1")
         slab = recon.get_unreconstructed_slabs()[0]
         recon_slab = recon.build_slabs()[0]
-        self.assertEqual(len(slab), len(recon_slab) - 2)
-        self.assertTrue(recon_slab.is_symmetric())
+        assert len(slab) == len(recon_slab) - 2
+        assert recon_slab.is_symmetric()
 
         # If a slab references another slab,
         # make sure it is properly generated
         recon = ReconstructionGenerator(self.Ni, 10, 10, "fcc_111_adatom_ft_1x1")
         slab = recon.build_slabs()[0]
-        self.assertTrue(slab.is_symmetric)
+        assert slab.is_symmetric
 
         # Test a reconstruction where it works on a specific
         # termination (Fd-3m (111))
         recon = ReconstructionGenerator(self.Si, 10, 10, "diamond_111_1x2")
         slab = recon.get_unreconstructed_slabs()[0]
         recon_slab = recon.build_slabs()[0]
-        self.assertEqual(len(slab), len(recon_slab) - 8)
-        self.assertTrue(recon_slab.is_symmetric())
+        assert len(slab) == len(recon_slab) - 8
+        assert recon_slab.is_symmetric()
 
         # Test a reconstruction where terminations give
         # different reconstructions with a non-primitive_elemental system
@@ -720,7 +717,7 @@ class ReconstructionGeneratorTests(PymatgenTest):
         recon2 = ReconstructionGenerator(self.Si, 20, 10, "diamond_100_2x1")
         s1 = recon.get_unreconstructed_slabs()[0]
         s2 = recon2.get_unreconstructed_slabs()[0]
-        self.assertAlmostEqual(get_d(s1), get_d(s2))
+        assert round(abs(get_d(s1) - get_d(s2)), 7) == 0
 
     @unittest.skip("This test relies on neighbor orders and is hard coded. Disable temporarily")
     def test_previous_reconstructions(self):
@@ -747,7 +744,7 @@ class ReconstructionGeneratorTests(PymatgenTest):
 
             slabs = rec.build_slabs()
             s = Structure.from_file(get_path(os.path.join("reconstructions", el + "_" + n + ".cif")))
-            self.assertTrue(any([len(m.group_structures([s, slab])) == 1 for slab in slabs]))
+            assert any([len(m.group_structures([s, slab])) == 1 for slab in slabs])
 
 
 class MillerIndexFinderTests(PymatgenTest):
@@ -784,29 +781,29 @@ class MillerIndexFinderTests(PymatgenTest):
         # Tests to see if the function obtains the known number of unique slabs
 
         indices = get_symmetrically_distinct_miller_indices(self.cscl, 1)
-        self.assertEqual(len(indices), 3)
+        assert len(indices) == 3
         indices = get_symmetrically_distinct_miller_indices(self.cscl, 2)
-        self.assertEqual(len(indices), 6)
+        assert len(indices) == 6
 
-        self.assertEqual(len(get_symmetrically_distinct_miller_indices(self.lifepo4, 1)), 7)
+        assert len(get_symmetrically_distinct_miller_indices(self.lifepo4, 1)) == 7
 
         # The TeI P-1 structure should have 13 unique millers (only inversion
         # symmetry eliminates pairs)
         indices = get_symmetrically_distinct_miller_indices(self.tei, 1)
-        self.assertEqual(len(indices), 13)
+        assert len(indices) == 13
 
         # P1 and P-1 should have the same # of miller indices since surfaces
         # always have inversion symmetry.
         indices = get_symmetrically_distinct_miller_indices(self.p1, 1)
-        self.assertEqual(len(indices), 13)
+        assert len(indices) == 13
 
         indices = get_symmetrically_distinct_miller_indices(self.graphite, 2)
-        self.assertEqual(len(indices), 12)
+        assert len(indices) == 12
 
         # Now try a trigonal system.
         indices = get_symmetrically_distinct_miller_indices(self.trigBi, 2, return_hkil=True)
-        self.assertEqual(len(indices), 17)
-        self.assertTrue(all([len(hkl) == 4 for hkl in indices]))
+        assert len(indices) == 17
+        assert all([len(hkl) == 4 for hkl in indices])
 
     def test_get_symmetrically_equivalent_miller_indices(self):
 
@@ -820,51 +817,51 @@ class MillerIndexFinderTests(PymatgenTest):
             (-1, 0, 0),
         ]
         indices = get_symmetrically_equivalent_miller_indices(self.cscl, (1, 0, 0))
-        self.assertTrue(all([hkl in indices for hkl in indices001]))
+        assert all([hkl in indices for hkl in indices001])
 
         # Tests to see if it captures expanded Miller indices in the family e.g. (001) == (002)
         hcp_indices_100 = get_symmetrically_equivalent_miller_indices(self.Mg, (1, 0, 0))
         hcp_indices_200 = get_symmetrically_equivalent_miller_indices(self.Mg, (2, 0, 0))
-        self.assertEqual(len(hcp_indices_100) * 2, len(hcp_indices_200))
-        self.assertEqual(len(hcp_indices_100), 6)
-        self.assertTrue(all([len(hkl) == 4 for hkl in hcp_indices_100]))
+        assert len(hcp_indices_100) * 2 == len(hcp_indices_200)
+        assert len(hcp_indices_100) == 6
+        assert all([len(hkl) == 4 for hkl in hcp_indices_100])
 
     def test_generate_all_slabs(self):
 
         slabs = generate_all_slabs(self.cscl, 1, 10, 10)
         # Only three possible slabs, one each in (100), (110) and (111).
-        self.assertEqual(len(slabs), 3)
+        assert len(slabs) == 3
 
         # make sure it generates reconstructions
         slabs = generate_all_slabs(self.Fe, 1, 10, 10, include_reconstructions=True)
 
         # Four possible slabs, (100), (110), (111) and the zigzag (100).
-        self.assertEqual(len(slabs), 4)
+        assert len(slabs) == 4
 
         slabs = generate_all_slabs(self.cscl, 1, 10, 10, bonds={("Cs", "Cl"): 4})
         # No slabs if we don't allow broken Cs-Cl
-        self.assertEqual(len(slabs), 0)
+        assert len(slabs) == 0
 
         slabs = generate_all_slabs(self.cscl, 1, 10, 10, bonds={("Cs", "Cl"): 4}, max_broken_bonds=100)
-        self.assertEqual(len(slabs), 3)
+        assert len(slabs) == 3
 
         slabs2 = generate_all_slabs(self.lifepo4, 1, 10, 10, bonds={("P", "O"): 3, ("Fe", "O"): 3})
-        self.assertEqual(len(slabs2), 0)
+        assert len(slabs2) == 0
 
         # There should be only one possible stable surfaces, all of which are
         # in the (001) oriented unit cell
         slabs3 = generate_all_slabs(self.LiCoO2, 1, 10, 10, bonds={("Co", "O"): 3})
-        self.assertEqual(len(slabs3), 1)
+        assert len(slabs3) == 1
         mill = (0, 0, 1)
         for s in slabs3:
-            self.assertEqual(s.miller_index, mill)
+            assert s.miller_index == mill
 
         slabs1 = generate_all_slabs(self.lifepo4, 1, 10, 10, tol=0.1, bonds={("P", "O"): 3})
-        self.assertEqual(len(slabs1), 4)
+        assert len(slabs1) == 4
 
         # Now we test this out for repair_broken_bonds()
         slabs1_repair = generate_all_slabs(self.lifepo4, 1, 10, 10, tol=0.1, bonds={("P", "O"): 3}, repair=True)
-        self.assertGreater(len(slabs1_repair), len(slabs1))
+        assert len(slabs1_repair) > len(slabs1)
 
         # Lets see if there are no broken PO4 polyhedrons
         miller_list = get_symmetrically_distinct_miller_indices(self.lifepo4, 1)
@@ -881,11 +878,11 @@ class MillerIndexFinderTests(PymatgenTest):
                     for nn in neighbors:
                         cn += 1 if nn[0].species_string == "O" else 0
                     broken.append(cn != 4)
-            self.assertFalse(any(broken))
+            assert not any(broken)
 
         # check if we were able to produce at least one
         # termination for each distinct Miller _index
-        self.assertEqual(len(miller_list), len(all_miller_list))
+        assert len(miller_list) == len(all_miller_list)
 
     def test_miller_index_from_sites(self):
         """Test surface miller index convenience function"""
@@ -895,7 +892,7 @@ class MillerIndexFinderTests(PymatgenTest):
         s1 = np.array([0.5, -1.5, 3])
         s2 = np.array([0.5, 3.0, -1.5])
         s3 = np.array([2.5, 1.5, -4.0])
-        self.assertEqual(miller_index_from_sites(m, [s1, s2, s3]), (2, 1, 1))
+        assert miller_index_from_sites(m, [s1, s2, s3]) == (2, 1, 1)
 
         # test casting from matrix to Lattice
         m = [[2.319, -4.01662582, 0.0], [2.319, 4.01662582, 0.0], [0.0, 0.0, 7.252]]
@@ -904,7 +901,7 @@ class MillerIndexFinderTests(PymatgenTest):
         s2 = np.array([1.1595, 0.66943764, 4.5325])
         s3 = np.array([1.1595, 0.66943764, 0.9065])
         hkl = miller_index_from_sites(m, [s1, s2, s3])
-        self.assertEqual(hkl, (2, -1, 0))
+        assert hkl == (2, -1, 0)
 
 
 if __name__ == "__main__":

--- a/pymatgen/core/tests/test_tensors.py
+++ b/pymatgen/core/tests/test_tensors.py
@@ -4,6 +4,7 @@ import unittest
 import warnings
 
 import numpy as np
+import pytest
 from monty.serialization import MontyDecoder, loadfn
 
 from pymatgen.core.operations import SymmOp
@@ -115,11 +116,13 @@ class TensorTest(PymatgenTest):
     def test_new(self):
         bad_2 = np.zeros((4, 4))
         bad_3 = np.zeros((4, 4, 4))
-        self.assertRaises(ValueError, Tensor, bad_2)
-        self.assertRaises(ValueError, Tensor, bad_3)
-        self.assertEqual(self.rand_rank2.rank, 2)
-        self.assertEqual(self.rand_rank3.rank, 3)
-        self.assertEqual(self.rand_rank4.rank, 4)
+        with pytest.raises(ValueError):
+            Tensor(bad_2)
+        with pytest.raises(ValueError):
+            Tensor(bad_3)
+        assert self.rand_rank2.rank == 2
+        assert self.rand_rank3.rank == 3
+        assert self.rand_rank4.rank == 4
 
     def test_zeroed(self):
         self.assertArrayEqual(
@@ -170,36 +173,38 @@ class TensorTest(PymatgenTest):
             SquareTensor([[0.531, 0.485, 0.271], [0.700, 0.5, 0.172], [0.171, 0.233, 0.068]]),
             decimal=3,
         )
-        self.assertRaises(ValueError, self.non_symm.rotate, self.symm_rank2)
+        with pytest.raises(ValueError):
+            self.non_symm.rotate(self.symm_rank2)
 
     def test_einsum_sequence(self):
         x = [1, 0, 0]
         test = Tensor(np.arange(0, 3**4).reshape((3, 3, 3, 3)))
         self.assertArrayAlmostEqual([0, 27, 54], test.einsum_sequence([x] * 3))
-        self.assertEqual(360, test.einsum_sequence([np.eye(3)] * 2))
-        self.assertRaises(ValueError, test.einsum_sequence, Tensor(np.zeros(3)))
+        assert 360 == test.einsum_sequence([np.eye(3)] * 2)
+        with pytest.raises(ValueError):
+            test.einsum_sequence(Tensor(np.zeros(3)))
 
     def test_symmetrized(self):
-        self.assertTrue(self.rand_rank2.symmetrized.is_symmetric())
-        self.assertTrue(self.rand_rank3.symmetrized.is_symmetric())
-        self.assertTrue(self.rand_rank4.symmetrized.is_symmetric())
+        assert self.rand_rank2.symmetrized.is_symmetric()
+        assert self.rand_rank3.symmetrized.is_symmetric()
+        assert self.rand_rank4.symmetrized.is_symmetric()
 
     def test_is_symmetric(self):
-        self.assertTrue(self.symm_rank2.is_symmetric())
-        self.assertTrue(self.symm_rank3.is_symmetric())
-        self.assertTrue(self.symm_rank4.is_symmetric())
+        assert self.symm_rank2.is_symmetric()
+        assert self.symm_rank3.is_symmetric()
+        assert self.symm_rank4.is_symmetric()
         tol_test = self.symm_rank4
         tol_test[0, 1, 2, 2] += 1e-6
-        self.assertFalse(self.low_val.is_symmetric(tol=1e-8))
+        assert not self.low_val.is_symmetric(tol=1e-8)
 
     def test_fit_to_structure(self):
         new_fit = self.unfit4.fit_to_structure(self.structure)
         self.assertArrayAlmostEqual(new_fit, self.fit_r4, 1)
 
     def test_is_fit_to_structure(self):
-        self.assertFalse(self.unfit4.is_fit_to_structure(self.structure))
-        self.assertTrue(self.fit_r3.is_fit_to_structure(self.structure))
-        self.assertTrue(self.fit_r4.is_fit_to_structure(self.structure))
+        assert not self.unfit4.is_fit_to_structure(self.structure)
+        assert self.fit_r3.is_fit_to_structure(self.structure)
+        assert self.fit_r4.is_fit_to_structure(self.structure)
 
     def test_convert_to_ieee(self):
         for entry in self.ieee_data:
@@ -245,7 +250,7 @@ class TensorTest(PymatgenTest):
         self.assertArrayAlmostEqual(rotated, transformed)
 
     def test_from_voigt(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             Tensor.from_voigt(
                 [
                     [59.33, 28.08, 28.08, 0],
@@ -276,7 +281,7 @@ class TensorTest(PymatgenTest):
     def test_symmetry_reduce(self):
         tbs = [Tensor.from_voigt(row) for row in np.eye(6) * 0.01]
         reduced = symmetry_reduce(tbs, self.get_structure("Sn"))
-        self.assertEqual(len(reduced), 2)
+        assert len(reduced) == 2
         self.assertArrayEqual([len(i) for i in reduced.values()], [2, 2])
         reconstructed = []
         for k, v in reduced.items():
@@ -291,13 +296,13 @@ class TensorTest(PymatgenTest):
         tkey = Tensor.from_values_indices([0.01], [(0, 0)])
         tval = reduced[tkey]
         for tens_1, tens_2 in zip(tval, reduced[tbs[0]]):
-            self.assertAlmostEqual(tens_1, tens_2)
+            assert pytest.approx(tens_1) == tens_2
         # Test set
         reduced[tkey] = "test_val"
-        self.assertEqual(reduced[tkey], "test_val")
+        assert reduced[tkey] == "test_val"
         # Test empty initialization
         empty = TensorMapping()
-        self.assertEqual(empty._tensor_list, [])
+        assert empty._tensor_list == []
 
     def test_populate(self):
         test_data = loadfn(os.path.join(PymatgenTest.TEST_FILES_DIR, "test_toec_data.json"))
@@ -309,12 +314,12 @@ class TensorTest(PymatgenTest):
         vtens[3, 3] = 73.48
         et = Tensor.from_voigt(vtens)
         populated = et.populate(sn, prec=1e-3).voigt.round(2)
-        self.assertAlmostEqual(populated[1, 1], 259.31)
-        self.assertAlmostEqual(populated[2, 2], 259.31)
-        self.assertAlmostEqual(populated[0, 2], 160.71)
-        self.assertAlmostEqual(populated[1, 2], 160.71)
-        self.assertAlmostEqual(populated[4, 4], 73.48)
-        self.assertAlmostEqual(populated[5, 5], 73.48)
+        assert round(abs(populated[1, 1] - 259.31), 7) == 0
+        assert round(abs(populated[2, 2] - 259.31), 7) == 0
+        assert round(abs(populated[0, 2] - 160.71), 7) == 0
+        assert round(abs(populated[1, 2] - 160.71), 7) == 0
+        assert round(abs(populated[4, 4] - 73.48), 7) == 0
+        assert round(abs(populated[5, 5] - 73.48), 7) == 0
         # test a rank 6 example
         vtens = np.zeros([6] * 3)
         indices = [(0, 0, 0), (0, 0, 1), (0, 1, 2), (0, 3, 3), (0, 5, 5), (3, 4, 5)]
@@ -323,13 +328,13 @@ class TensorTest(PymatgenTest):
             vtens[idx] = v
         toec = Tensor.from_voigt(vtens)
         toec = toec.populate(sn, prec=1e-3, verbose=True)
-        self.assertAlmostEqual(toec.voigt[1, 1, 1], -1271)
-        self.assertAlmostEqual(toec.voigt[0, 1, 1], -814)
-        self.assertAlmostEqual(toec.voigt[0, 2, 2], -814)
-        self.assertAlmostEqual(toec.voigt[1, 4, 4], -3)
-        self.assertAlmostEqual(toec.voigt[2, 5, 5], -3)
-        self.assertAlmostEqual(toec.voigt[1, 2, 0], -50)
-        self.assertAlmostEqual(toec.voigt[4, 5, 3], -95)
+        assert round(abs(toec.voigt[1, 1, 1] - -1271), 7) == 0
+        assert round(abs(toec.voigt[0, 1, 1] - -814), 7) == 0
+        assert round(abs(toec.voigt[0, 2, 2] - -814), 7) == 0
+        assert round(abs(toec.voigt[1, 4, 4] - -3), 7) == 0
+        assert round(abs(toec.voigt[2, 5, 5] - -3), 7) == 0
+        assert round(abs(toec.voigt[1, 2, 0] - -50), 7) == 0
+        assert round(abs(toec.voigt[4, 5, 3] - -95), 7) == 0
 
         et = Tensor.from_voigt(test_data["C3_raw"]).fit_to_structure(sn)
         new = np.zeros(et.voigt.shape)
@@ -343,12 +348,12 @@ class TensorTest(PymatgenTest):
         indices = [(0, 0), (0, 1), (3, 3)]
         values = [259.31, 160.71, 73.48]
         et = Tensor.from_values_indices(values, indices, structure=sn, populate=True).voigt.round(4)
-        self.assertAlmostEqual(et[1, 1], 259.31)
-        self.assertAlmostEqual(et[2, 2], 259.31)
-        self.assertAlmostEqual(et[0, 2], 160.71)
-        self.assertAlmostEqual(et[1, 2], 160.71)
-        self.assertAlmostEqual(et[4, 4], 73.48)
-        self.assertAlmostEqual(et[5, 5], 73.48)
+        assert round(abs(et[1, 1] - 259.31), 7) == 0
+        assert round(abs(et[2, 2] - 259.31), 7) == 0
+        assert round(abs(et[0, 2] - 160.71), 7) == 0
+        assert round(abs(et[1, 2] - 160.71), 7) == 0
+        assert round(abs(et[4, 4] - 73.48), 7) == 0
+        assert round(abs(et[5, 5] - 73.48), 7) == 0
 
     def test_serialization(self):
         # Test base serialize-deserialize
@@ -361,25 +366,22 @@ class TensorTest(PymatgenTest):
         self.assertArrayAlmostEqual(new, self.symm_rank3)
 
     def test_projection_methods(self):
-        self.assertAlmostEqual(self.rand_rank2.project([1, 0, 0]), self.rand_rank2[0, 0])
-        self.assertAlmostEqual(self.rand_rank2.project([1, 1, 1]), np.sum(self.rand_rank2) / 3)
+        assert round(abs(self.rand_rank2.project([1, 0, 0]) - self.rand_rank2[0, 0]), 7) == 0
+        assert round(abs(self.rand_rank2.project([1, 1, 1]) - np.sum(self.rand_rank2) / 3), 7) == 0
         # Test integration
         self.assertArrayAlmostEqual(self.ones.average_over_unit_sphere(), 1)
 
     def test_summary_methods(self):
-        self.assertEqual(
-            set(self.ones.get_grouped_indices()[0]),
-            set(itertools.product(range(3), range(3))),
-        )
-        self.assertEqual(self.ones.get_grouped_indices(voigt=True)[0], [(i,) for i in range(6)])
-        self.assertEqual(self.ones.get_symbol_dict(), {"T_1": 1})
-        self.assertEqual(self.ones.get_symbol_dict(voigt=False), {"T_11": 1})
+        assert set(self.ones.get_grouped_indices()[0]) == set(itertools.product(range(3), range(3)))
+        assert self.ones.get_grouped_indices(voigt=True)[0] == [(i,) for i in range(6)]
+        assert self.ones.get_symbol_dict() == {"T_1": 1}
+        assert self.ones.get_symbol_dict(voigt=False) == {"T_11": 1}
 
     def test_round(self):
         test = self.non_symm + 0.01
         rounded = test.round(1)
         self.assertArrayAlmostEqual(rounded, self.non_symm)
-        self.assertTrue(isinstance(rounded, Tensor))
+        assert isinstance(rounded, Tensor)
 
 
 class TensorCollectionTest(PymatgenTest):
@@ -433,8 +435,8 @@ class TensorCollectionTest(PymatgenTest):
         self.list_based_function_check("rotate", self.diff_rank, matrix=rotation)
 
         # is_symmetric
-        self.assertFalse(self.seq_tc.is_symmetric())
-        self.assertTrue(self.diff_rank.is_symmetric())
+        assert not self.seq_tc.is_symmetric()
+        assert self.diff_rank.is_symmetric()
 
         # fit_to_structure
         self.list_based_function_check("fit_to_structure", self.diff_rank, self.struct)
@@ -448,8 +450,8 @@ class TensorCollectionTest(PymatgenTest):
         self.list_based_function_check("voigt", self.diff_rank)
 
         # is_voigt_symmetric
-        self.assertTrue(self.diff_rank.is_voigt_symmetric())
-        self.assertFalse(self.seq_tc.is_voigt_symmetric())
+        assert self.diff_rank.is_voigt_symmetric()
+        assert not self.seq_tc.is_voigt_symmetric()
 
         # Convert to ieee
         for entry in self.ieee_data[:2]:
@@ -500,9 +502,12 @@ class SquareTensorTest(PymatgenTest):
         ]
         bad_matrix = [[0.1, 0.2], [0.2, 0.3, 0.4], [0.2, 0.3, 0.5]]
         too_high_rank = np.zeros((3, 3, 3))
-        self.assertRaises(ValueError, SquareTensor, non_sq_matrix)
-        self.assertRaises(ValueError, SquareTensor, bad_matrix)
-        self.assertRaises(ValueError, SquareTensor, too_high_rank)
+        with pytest.raises(ValueError):
+            SquareTensor(non_sq_matrix)
+        with pytest.raises(ValueError):
+            SquareTensor(bad_matrix)
+        with pytest.raises(ValueError):
+            SquareTensor(too_high_rank)
 
     def test_properties(self):
         # transpose
@@ -514,13 +519,13 @@ class SquareTensorTest(PymatgenTest):
         self.assertArrayEqual(self.symm_sqtensor, self.symm_sqtensor.trans)
         # inverse
         self.assertArrayEqual(self.non_symm.inv, np.linalg.inv(self.non_symm))
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             self.non_invertible.inv
 
         # determinant
-        self.assertEqual(self.rand_sqtensor.det, np.linalg.det(self.rand_sqtensor))
-        self.assertEqual(self.non_invertible.det, 0.0)
-        self.assertEqual(self.non_symm.det, 0.009)
+        assert self.rand_sqtensor.det == np.linalg.det(self.rand_sqtensor)
+        assert self.non_invertible.det == 0.0
+        assert self.non_symm.det == 0.009
 
         # symmetrized
         self.assertArrayEqual(
@@ -547,16 +552,16 @@ class SquareTensorTest(PymatgenTest):
         self.assertArrayAlmostEqual([i1, i2, i3], self.rand_sqtensor.principal_invariants)
 
     def test_is_rotation(self):
-        self.assertTrue(self.rotation.is_rotation())
-        self.assertFalse(self.symm_sqtensor.is_rotation())
-        self.assertTrue(self.low_val_2.is_rotation())
-        self.assertFalse(self.low_val_2.is_rotation(tol=1e-8))
+        assert self.rotation.is_rotation()
+        assert not self.symm_sqtensor.is_rotation()
+        assert self.low_val_2.is_rotation()
+        assert not self.low_val_2.is_rotation(tol=1e-8)
 
     def test_refine_rotation(self):
         self.assertArrayAlmostEqual(self.rotation, self.rotation.refine_rotation())
         new = self.rotation.copy()
         new[2, 2] += 0.02
-        self.assertFalse(new.is_rotation())
+        assert not new.is_rotation()
         self.assertArrayAlmostEqual(self.rotation, new.refine_rotation())
         new[1] *= 1.05
         self.assertArrayAlmostEqual(self.rotation, new.refine_rotation())
@@ -577,11 +582,11 @@ class SquareTensorTest(PymatgenTest):
         d = self.rand_sqtensor.as_dict()
         new = SquareTensor.from_dict(d)
         self.assertArrayAlmostEqual(new, self.rand_sqtensor)
-        self.assertIsInstance(new, SquareTensor)
+        assert isinstance(new, SquareTensor)
 
         # Ensure proper object-independent deserialization
         obj = MontyDecoder().process_decoded(d)
-        self.assertIsInstance(obj, SquareTensor)
+        assert isinstance(obj, SquareTensor)
 
         with warnings.catch_warnings(record=True):
             vsym = self.rand_sqtensor.voigt_symmetrized

--- a/pymatgen/core/tests/test_trajectory.py
+++ b/pymatgen/core/tests/test_trajectory.py
@@ -26,44 +26,44 @@ class TrajectoryTest(PymatgenTest):
         return all(i == j for i, j in zip(self.traj, traj_2))
 
     def test_single_index_slice(self):
-        self.assertTrue(all([self.traj[i] == self.structures[i] for i in range(0, len(self.structures), 19)]))
+        assert all([self.traj[i] == self.structures[i] for i in range(0, len(self.structures), 19)])
 
     def test_slice(self):
         sliced_traj = self.traj[2:99:3]
         sliced_traj_from_structs = Trajectory.from_structures(self.structures[2:99:3])
 
         if len(sliced_traj) == len(sliced_traj_from_structs):
-            self.assertTrue(all([sliced_traj[i] == sliced_traj_from_structs[i] for i in range(len(sliced_traj))]))
+            assert all([sliced_traj[i] == sliced_traj_from_structs[i] for i in range(len(sliced_traj))])
         else:
-            self.assertTrue(False)
+            raise AssertionError
 
         sliced_traj = self.traj[:-4:2]
         sliced_traj_from_structs = Trajectory.from_structures(self.structures[:-4:2])
 
         if len(sliced_traj) == len(sliced_traj_from_structs):
-            self.assertTrue(all([sliced_traj[i] == sliced_traj_from_structs[i] for i in range(len(sliced_traj))]))
+            assert all([sliced_traj[i] == sliced_traj_from_structs[i] for i in range(len(sliced_traj))])
         else:
-            self.assertTrue(False)
+            raise AssertionError
 
     def test_list_slice(self):
         sliced_traj = self.traj[[10, 30, 70]]
         sliced_traj_from_structs = Trajectory.from_structures([self.structures[i] for i in [10, 30, 70]])
 
         if len(sliced_traj) == len(sliced_traj_from_structs):
-            self.assertTrue(all([sliced_traj[i] == sliced_traj_from_structs[i] for i in range(len(sliced_traj))]))
+            assert all([sliced_traj[i] == sliced_traj_from_structs[i] for i in range(len(sliced_traj))])
         else:
-            self.assertTrue(False)
+            raise AssertionError
 
     def test_conversion(self):
         # Convert to displacements and back. Check structures
         self.traj.to_displacements()
         self.traj.to_positions()
 
-        self.assertTrue(all([struct == self.structures[i] for i, struct in enumerate(self.traj)]))
+        assert all([struct == self.structures[i] for i, struct in enumerate(self.traj)])
 
     def test_copy(self):
         traj_copy = self.traj.copy()
-        self.assertTrue(all([i == j for i, j in zip(self.traj, traj_copy)]))
+        assert all([i == j for i, j in zip(self.traj, traj_copy)])
 
     def test_site_properties(self):
         lattice = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
@@ -90,10 +90,10 @@ class TrajectoryTest(PymatgenTest):
         traj = Trajectory(lattice, species, frac_coords, site_properties=site_properties)
 
         # compare the overall site properties list
-        self.assertEqual(traj.site_properties, site_properties)
+        assert traj.site_properties == site_properties
         # # compare the site properties after slicing
-        self.assertEqual(traj[0].site_properties, site_properties[0])
-        self.assertEqual(traj[1:].site_properties, site_properties[1:])
+        assert traj[0].site_properties == site_properties[0]
+        assert traj[1:].site_properties == site_properties[1:]
 
     def test_frame_properties(self):
         lattice = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
@@ -127,10 +127,10 @@ class TrajectoryTest(PymatgenTest):
             frame_properties=frame_properties,
         )
         # compare the overall site properties list
-        self.assertEqual(traj.frame_properties, frame_properties)
+        assert traj.frame_properties == frame_properties
         # compare the site properties after slicing
         expected_output = {"energy_per_atom": [-3.0971, -3.0465]}
-        self.assertEqual(traj[1:].frame_properties, expected_output)
+        assert traj[1:].frame_properties == expected_output
 
     def test_extend(self):
         traj = self.traj.copy()
@@ -153,7 +153,7 @@ class TrajectoryTest(PymatgenTest):
         except Exception:
             incompatible_test_success = True
 
-        self.assertTrue(compatible_success and incompatible_test_success)
+        assert compatible_success and incompatible_test_success
 
     def test_extend_no_site_props(self):
         lattice = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
@@ -171,7 +171,7 @@ class TrajectoryTest(PymatgenTest):
         # Test combining two trajectories with no site properties
         traj_combined = traj_1.copy()
         traj_combined.extend(traj_2)
-        self.assertEqual(traj_combined.site_properties, None)
+        assert traj_combined.site_properties is None
 
     def test_extend_equivalent_site_props(self):
         lattice = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
@@ -202,7 +202,7 @@ class TrajectoryTest(PymatgenTest):
         # Test combining two trajectories with similar site_properties
         traj_combined = traj_1.copy()
         traj_combined.extend(traj_2)
-        self.assertEqual(traj_combined.site_properties, site_properties_1)
+        assert traj_combined.site_properties == site_properties_1
 
     def test_extend_inequivalent_site_props(self):
         lattice = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
@@ -259,7 +259,7 @@ class TrajectoryTest(PymatgenTest):
                 "magmom": [5, 5],
             },
         ]
-        self.assertEqual(traj_combined.site_properties, expected_site_props)
+        assert traj_combined.site_properties == expected_site_props
 
         # Trajectory with const site_properties and trajectory with changing site properties
         site_properties_1 = [
@@ -315,7 +315,7 @@ class TrajectoryTest(PymatgenTest):
                 "magmom": [5, 5],
             },
         ]
-        self.assertEqual(traj_combined.site_properties, expected_site_props)
+        assert traj_combined.site_properties == expected_site_props
 
         # The other way around
         traj_combined = traj_2.copy()
@@ -346,7 +346,7 @@ class TrajectoryTest(PymatgenTest):
                 "magmom": [5, 5],
             },
         ]
-        self.assertEqual(traj_combined.site_properties, expected_site_props)
+        assert traj_combined.site_properties == expected_site_props
 
         # Trajectory with no and trajectory with changing site properties
         site_properties_1 = None
@@ -388,7 +388,7 @@ class TrajectoryTest(PymatgenTest):
                 "magmom": [5, 5],
             },
         ]
-        self.assertEqual(traj_combined.site_properties, expected_site_props)
+        assert traj_combined.site_properties == expected_site_props
 
         # The other way around
         traj_combined = traj_2.copy()
@@ -410,7 +410,7 @@ class TrajectoryTest(PymatgenTest):
             None,
             None,
         ]
-        self.assertEqual(traj_combined.site_properties, expected_site_props)
+        assert traj_combined.site_properties == expected_site_props
 
     def test_extend_no_frame_props(self):
         lattice = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
@@ -428,7 +428,7 @@ class TrajectoryTest(PymatgenTest):
         # Test combining two trajectories with no site properties
         traj_combined = traj_1.copy()
         traj_combined.extend(traj_2)
-        self.assertEqual(traj_combined.frame_properties, None)
+        assert traj_combined.frame_properties is None
 
     def test_extend_frame_props(self):
         lattice = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
@@ -450,7 +450,7 @@ class TrajectoryTest(PymatgenTest):
         traj_combined = traj_1.copy()
         traj_combined.extend(traj_2)
         expected_frame_properties = {"energy": [-3, -3.9, -4.1, -4.2, -4.25, -4.3]}
-        self.assertEqual(traj_combined.frame_properties, expected_frame_properties)
+        assert traj_combined.frame_properties == expected_frame_properties
 
         # Mismatched frame propertied
         frame_properties_3 = {"energy": [-4.2, -4.25, -4.3], "pressure": [2, 2.5, 2.5]}
@@ -461,10 +461,10 @@ class TrajectoryTest(PymatgenTest):
             "energy": [-3, -3.9, -4.1, -4.2, -4.25, -4.3],
             "pressure": [None, None, None, 2, 2.5, 2.5],
         }
-        self.assertEqual(traj_combined.frame_properties, expected_frame_properties)
+        assert traj_combined.frame_properties == expected_frame_properties
 
     def test_length(self):
-        self.assertTrue(len(self.traj) == len(self.structures))
+        assert len(self.traj) == len(self.structures)
 
     def test_displacements(self):
         poscar = Poscar.from_file(os.path.join(PymatgenTest.TEST_FILES_DIR, "POSCAR"))
@@ -479,14 +479,14 @@ class TrajectoryTest(PymatgenTest):
         traj = Trajectory.from_structures(structures, constant_lattice=True)
         traj.to_displacements()
 
-        self.assertTrue(np.allclose(traj.frac_coords, displacements))
+        assert np.allclose(traj.frac_coords, displacements)
 
     def test_variable_lattice(self):
         structure = self.structures[0]
 
         # Generate structures with different lattices
         structures = []
-        for i in range(10):
+        for _ in range(10):
             new_lattice = np.dot(structure.lattice.matrix, np.diag(1 + np.random.random_sample(3) / 20))
             temp_struct = structure.copy()
             temp_struct.lattice = Lattice(new_lattice)
@@ -495,9 +495,7 @@ class TrajectoryTest(PymatgenTest):
         traj = Trajectory.from_structures(structures, constant_lattice=False)
 
         # Check if lattices were properly stored
-        self.assertTrue(
-            all(np.allclose(struct.lattice.matrix, structures[i].lattice.matrix) for i, struct in enumerate(traj))
-        )
+        assert all(np.allclose(struct.lattice.matrix, structures[i].lattice.matrix) for i, struct in enumerate(traj))
 
         # Check if the file is written correctly when lattice is not constant.
         traj.write_Xdatcar(filename="traj_test_XDATCAR")
@@ -509,7 +507,7 @@ class TrajectoryTest(PymatgenTest):
     def test_to_from_dict(self):
         d = self.traj.as_dict()
         traj = Trajectory.from_dict(d)
-        self.assertEqual(type(traj), Trajectory)
+        assert isinstance(traj, Trajectory)
 
     def test_xdatcar_write(self):
         self.traj.write_Xdatcar(filename="traj_test_XDATCAR")

--- a/pymatgen/core/tests/test_units.py
+++ b/pymatgen/core/tests/test_units.py
@@ -2,6 +2,8 @@
 # Distributed under the terms of the MIT License.
 
 
+import pytest
+
 from pymatgen.core.units import (
     ArrayWithUnit,
     Energy,
@@ -23,85 +25,86 @@ from pymatgen.util.testing import PymatgenTest
 class UnitTest(PymatgenTest):
     def test_init(self):
         u1 = Unit((("m", 1), ("s", -1)))
-        self.assertEqual(str(u1), "m s^-1")
+        assert str(u1) == "m s^-1"
         u2 = Unit("kg m ^ 2 s ^ -2")
-        self.assertEqual(str(u2), "J")
-        self.assertEqual(str(u1 * u2), "J m s^-1")
-        self.assertEqual(str(u2 / u1), "J s m^-1")
-        self.assertEqual(str(u1 / Unit("m")), "Hz")
-        self.assertEqual(str(u1 * Unit("s")), "m")
+        assert str(u2) == "J"
+        assert str(u1 * u2) == "J m s^-1"
+        assert str(u2 / u1) == "J s m^-1"
+        assert str(u1 / Unit("m")) == "Hz"
+        assert str(u1 * Unit("s")) == "m"
 
         acc = u1 / Unit("s")
         newton = Unit("kg") * acc
-        self.assertEqual(str(newton * Unit("m")), "N m")
+        assert str(newton * Unit("m")) == "N m"
 
 
 class FloatWithUnitTest(PymatgenTest):
     def test_energy(self):
         a = Energy(1.1, "eV")
         b = a.to("Ha")
-        self.assertAlmostEqual(b, 0.0404242579378)
+        assert round(abs(b - 0.0404242579378), 7) == 0
         c = Energy(3.14, "J")
-        self.assertAlmostEqual(c.to("eV"), 1.9598338493806797e19)
-        self.assertRaises(UnitError, Energy, 1, "m")
+        assert round(abs(c.to("eV") - 1.9598338493806797e19), 7) == 0
+        with pytest.raises(UnitError):
+            Energy(1, "m")
 
         d = Energy(1, "Ha")
-        self.assertAlmostEqual(a + d, 28.311386245987997)
-        self.assertAlmostEqual(a - d, -26.111386245987994)
-        self.assertEqual(a + 1, 2.1)
-        self.assertEqual(str(a / d), "1.1 eV Ha^-1")
+        assert round(abs(a + d - 28.311386245987997), 7) == 0
+        assert round(abs(a - d - -26.111386245987994), 7) == 0
+        assert a + 1 == 2.1
+        assert str(a / d) == "1.1 eV Ha^-1"
 
         e = Energy(1, "kJ")
         f = e.to("kCal")
-        self.assertAlmostEqual(f, 0.2390057361376673)
-        self.assertEqual(str(e + f), "2.0 kJ")
-        self.assertEqual(str(f + e), "0.4780114722753346 kCal")
+        assert round(abs(f - 0.2390057361376673), 7) == 0
+        assert str(e + f) == "2.0 kJ"
+        assert str(f + e) == "0.4780114722753346 kCal"
 
     def test_time(self):
         a = Time(20, "h")
-        self.assertAlmostEqual(float(a.to("s")), 3600 * 20)
+        assert round(abs(float(a.to("s")) - 3600 * 20), 7) == 0
         # Test left and right multiplication.
         b = a * 3
-        self.assertAlmostEqual(float(b), 60.0)
-        self.assertEqual(str(b.unit), "h")
-        self.assertEqual(float(3 * a), 60.0)
+        assert round(abs(float(b) - 60.0), 7) == 0
+        assert str(b.unit) == "h"
+        assert float(3 * a) == 60.0
         a = Time(0.5, "d")
-        self.assertAlmostEqual(float(a.to("s")), 3600 * 24 * 0.5)
+        assert round(abs(float(a.to("s")) - 3600 * 24 * 0.5), 7) == 0
 
     def test_length(self):
         x = Length(4.2, "ang")
-        self.assertAlmostEqual(x.to("cm"), 4.2e-08)
-        self.assertEqual(x.to("pm"), 420)
-        self.assertEqual(str(x / 2), "2.1 ang")
+        assert round(abs(x.to("cm") - 4.2e-08), 7) == 0
+        assert x.to("pm") == 420
+        assert str(x / 2) == "2.1 ang"
         y = x**3
-        self.assertAlmostEqual(y, 74.088)
-        self.assertEqual(str(y.unit), "ang^3")
+        assert round(abs(y - 74.088), 7) == 0
+        assert str(y.unit) == "ang^3"
 
     def test_memory(self):
         mega = Memory(1, "Mb")
-        self.assertEqual(mega.to("byte"), 1024**2)
-        self.assertEqual(mega, Memory(1, "mb"))
+        assert mega.to("byte") == 1024**2
+        assert mega == Memory(1, "mb")
 
         same_mega = Memory.from_string("1Mb")
-        self.assertEqual(same_mega.unit_type, "memory")
+        assert same_mega.unit_type == "memory"
 
         other_mega = Memory.from_string("+1.0 mb")
-        self.assertEqual(mega, other_mega)
+        assert mega == other_mega
 
     def test_unitized(self):
         @unitized("eV")
         def f():
             return [1, 2, 3]
 
-        self.assertEqual(str(f()[0]), "1.0 eV")
-        self.assertIsInstance(f(), list)
+        assert str(f()[0]) == "1.0 eV"
+        assert isinstance(f(), list)
 
         @unitized("eV")
         def g():
             return 2, 3, 4
 
-        self.assertEqual(str(g()[0]), "2.0 eV")
-        self.assertIsInstance(g(), tuple)
+        assert str(g()[0]) == "2.0 eV"
+        assert isinstance(g(), tuple)
 
         @unitized("pm")
         def h():
@@ -110,44 +113,45 @@ class FloatWithUnitTest(PymatgenTest):
                 d[i] = i * 20
             return d
 
-        self.assertEqual(str(h()[1]), "20.0 pm")
-        self.assertIsInstance(h(), dict)
+        assert str(h()[1]) == "20.0 pm"
+        assert isinstance(h(), dict)
 
         @unitized("kg")
         def i():
             return FloatWithUnit(5, "g")
 
-        self.assertEqual(i(), FloatWithUnit(0.005, "kg"))
+        assert i() == FloatWithUnit(0.005, "kg")
 
         @unitized("kg")
         def j():
             return ArrayWithUnit([5, 10], "g")
 
         j_out = j()
-        self.assertEqual(j_out.unit, Unit("kg"))
-        self.assertEqual(j_out[0], 0.005)
-        self.assertEqual(j_out[1], 0.01)
+        assert j_out.unit == Unit("kg")
+        assert j_out[0] == 0.005
+        assert j_out[1] == 0.01
 
     def test_compound_operations(self):
         g = 10 * Length(1, "m") / (Time(1, "s") ** 2)
         e = Mass(1, "kg") * g * Length(1, "m")
-        self.assertEqual(str(e), "10.0 N m")
+        assert str(e) == "10.0 N m"
         form_e = FloatWithUnit(10, unit="kJ mol^-1").to("eV atom^-1")
-        self.assertAlmostEqual(float(form_e), 0.103642691905)
-        self.assertEqual(str(form_e.unit), "eV atom^-1")
-        self.assertRaises(UnitError, form_e.to, "m s^-1")
+        assert round(abs(float(form_e) - 0.103642691905), 7) == 0
+        assert str(form_e.unit) == "eV atom^-1"
+        with pytest.raises(UnitError):
+            form_e.to("m s^-1")
         a = FloatWithUnit(1.0, "Ha^3")
         b = a.to("J^3")
-        self.assertAlmostEqual(b, 8.28672661615e-53)
-        self.assertEqual(str(b.unit), "J^3")
+        assert round(abs(b - 8.28672661615e-53), 7) == 0
+        assert str(b.unit) == "J^3"
         a = FloatWithUnit(1.0, "Ha bohr^-2")
         b = a.to("J m^-2")
-        self.assertAlmostEqual(b, 1556.8931028218924)
-        self.assertEqual(str(b.unit), "J m^-2")
+        assert round(abs(b - 1556.8931028218924), 7) == 0
+        assert str(b.unit) == "J m^-2"
 
     def test_as_base_units(self):
         x = FloatWithUnit(5, "MPa")
-        self.assertEqual(FloatWithUnit(5000000, "Pa"), x.as_base_units)
+        assert FloatWithUnit(5000000, "Pa") == x.as_base_units
 
 
 class ArrayWithFloatWithUnitTest(PymatgenTest):
@@ -166,15 +170,15 @@ class ArrayWithFloatWithUnitTest(PymatgenTest):
         """
         a = EnergyArray(1.1, "eV")
         b = a.to("Ha")
-        self.assertAlmostEqual(float(b), 0.0404242579378)
+        assert round(abs(float(b) - 0.0404242579378), 7) == 0
         c = EnergyArray(3.14, "J")
-        self.assertAlmostEqual(float(c.to("eV")), 1.9598338493806797e19, 5)
+        assert round(abs(float(c.to("eV")) - 1.9598338493806797e19), 5) == 0
         # self.assertRaises(ValueError, Energy, 1, "m")
 
         d = EnergyArray(1, "Ha")
-        self.assertAlmostEqual(float(a + d), 28.311386245987997)
-        self.assertAlmostEqual(float(a - d), -26.111386245987994)
-        self.assertEqual(float(a + 1), 2.1)
+        assert round(abs(float(a + d) - 28.311386245987997), 7) == 0
+        assert round(abs(float(a - d) - -26.111386245987994), 7) == 0
+        assert float(a + 1) == 2.1
 
     def test_time(self):
         """
@@ -184,10 +188,10 @@ class ArrayWithFloatWithUnitTest(PymatgenTest):
         # here there's a minor difference because we have a ndarray with
         # dtype=int.
         a = TimeArray(20, "h")
-        self.assertAlmostEqual(a.to("s"), 3600 * 20)
+        assert pytest.approx(a.to("s")) == 3600 * 20
         # Test left and right multiplication.
-        self.assertEqual(str(a * 3), "60 h")
-        self.assertEqual(str(3 * a), "60 h")
+        assert str(a * 3) == "60 h"
+        assert str(3 * a) == "60 h"
 
     def test_length(self):
         """
@@ -195,9 +199,9 @@ class ArrayWithFloatWithUnitTest(PymatgenTest):
         Check whether EnergyArray and FloatWithUnit have same behavior.
         """
         x = LengthArray(4.2, "ang")
-        self.assertAlmostEqual(float(x.to("cm")), 4.2e-08)
-        self.assertEqual(float(x.to("pm")), 420)
-        self.assertEqual(str(x / 2), "2.1 ang")
+        assert round(abs(float(x.to("cm")) - 4.2e-08), 7) == 0
+        assert float(x.to("pm")) == 420
+        assert str(x / 2) == "2.1 ang"
 
     def test_array_algebra(self):
         ene_ha = EnergyArray([1, 2], "Ha")
@@ -230,8 +234,8 @@ class ArrayWithFloatWithUnitTest(PymatgenTest):
             e4,
         ]
 
-        for i, obj in enumerate(objects_with_unit):
-            self.assertTrue(hasattr(obj, "unit"))
+        for obj in objects_with_unit:
+            assert hasattr(obj, "unit")
 
         objects_without_unit = [
             # Here we could return a FloatWithUnit object but I prefer this
@@ -241,18 +245,18 @@ class ArrayWithFloatWithUnitTest(PymatgenTest):
         ]
 
         for obj in objects_without_unit:
-            self.assertFalse(hasattr(obj, "unit"))
+            assert not hasattr(obj, "unit")
 
-        with self.assertRaises(UnitError):
+        with pytest.raises(UnitError):
             ene_ha + time_s
 
     def test_factors(self):
         e = EnergyArray([27.21138386, 1], "eV").to("Ha")
-        self.assertTrue(str(e).endswith("Ha"))
+        assert str(e).endswith("Ha")
         l = LengthArray([1.0], "ang").to("bohr")
-        self.assertTrue(str(l).endswith(" bohr"))
+        assert str(l).endswith(" bohr")
         v = ArrayWithUnit([1, 2, 3], "bohr^3").to("ang^3")
-        self.assertTrue(str(v).endswith(" ang^3"))
+        assert str(v).endswith(" ang^3")
 
     def test_as_base_units(self):
         x = ArrayWithUnit([5, 10], "MPa")
@@ -272,7 +276,7 @@ class DataPersistenceTest(PymatgenTest):
 
             for new_objects in new_objects_from_protocol:
                 for old_item, new_item in zip(objects, new_objects):
-                    self.assertTrue(str(old_item) == str(new_item))
+                    assert str(old_item) == str(new_item)
 
 
 if __name__ == "__main__":

--- a/pymatgen/entries/tests/test_mixing_scheme.py
+++ b/pymatgen/entries/tests/test_mixing_scheme.py
@@ -1449,9 +1449,9 @@ class TestMaterialsProjectDFTMixingSchemeStates:
                 assert e.correction == 3
                 assert e.parameters["run_type"] == "R2SCAN"
             elif e.entry_id == "gga-4":
-                assert False, "Entry gga-4 should have been discarded"
+                raise AssertionError("Entry gga-4 should have been discarded")
             elif e.entry_id == "gga-6":
-                assert False, "Entry gga-6 should have been discarded"
+                raise AssertionError("Entry gga-6 should have been discarded")
             else:
                 assert e.correction == 0, f"{e.entry_id}"
                 assert e.parameters["run_type"] == "GGA"
@@ -1496,7 +1496,7 @@ class TestMaterialsProjectDFTMixingSchemeStates:
             elif e.entry_id == "r2scan-7":
                 assert e.correction == 15
             elif e.entry_id in ["gga-4"]:
-                assert False, f"Entry {e.entry_id} should have been discarded"
+                raise AssertionError(f"Entry {e.entry_id} should have been discarded")
             else:
                 assert e.correction == 0, f"{e.entry_id}"
                 assert e.parameters["run_type"] == "GGA"
@@ -1540,7 +1540,7 @@ class TestMaterialsProjectDFTMixingSchemeStates:
                 assert e.correction == 3
                 assert e.parameters["run_type"] == "R2SCAN"
             elif e.entry_id in ["gga-4", "r2scan-8"]:
-                assert False, f"Entry {e.entry_id} should have been discarded"
+                raise AssertionError(f"Entry {e.entry_id} should have been discarded")
             else:
                 assert e.correction == 0, f"{e.entry_id}"
                 assert e.parameters["run_type"] == "GGA"

--- a/pymatgen/util/coord.py
+++ b/pymatgen/util/coord.py
@@ -14,9 +14,8 @@ from typing import Tuple
 import numpy as np
 from monty.json import MSONable
 
+from pymatgen.util import coord_cython as cuc
 from pymatgen.util.typing import ArrayLike
-
-from . import coord_cython as cuc
 
 # array size threshold for looping instead of broadcasting
 LOOP_THRESHOLD = 1e6
@@ -197,7 +196,7 @@ def pbc_shortest_vectors(lattice, fcoords1, fcoords2, mask=None, return_d2=False
             coord or any array of coords.
         fcoords2: Second set of fractional coordinates.
         mask (boolean array): Mask of matches that are not allowed.
-            i.e. if mask[1,2] == True, then subset[1] cannot be matched
+            i.e. if mask[1,2] is True, then subset[1] cannot be matched
             to superset[2]
         return_d2 (boolean): whether to also return the squared distances
 
@@ -258,7 +257,7 @@ def is_coord_subset_pbc(subset, superset, atol=1e-8, mask=None, pbc=(True, True,
         subset, superset: List of fractional coords
         atol (float or size 3 array): Tolerance for matching
         mask (boolean array): Mask of matches that are not allowed.
-            i.e. if mask[1,2] == True, then subset[1] cannot be matched
+            i.e. if mask[1,2] is True, then subset[1] cannot be matched
             to superset[2]
         pbc: a tuple defining the periodic boundary conditions along the three
             axis of the lattice.

--- a/pymatgen/util/testing.py
+++ b/pymatgen/util/testing.py
@@ -136,7 +136,7 @@ class PymatgenTest(unittest.TestCase):
         pickle. This method tries to serialize the objects with pickle and the
         protocols specified in input. Then it deserializes the pickle format
         and compares the two objects with the __eq__ operator if
-        test_eq == True.
+        test_eq is True.
 
         Args:
             objects: Object or list of objects.

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,11 +2,7 @@
 profile=black
 
 [tool:pytest]
-addopts = -x --durations=30 --quiet -rxXs --color=yes
-filterwarnings =
-    ignore::UserWarning
-    ignore::FutureWarning
-    ignore::RuntimeWarning
+addopts = -x --durations=30 --quiet -rxXs --color=yes -p no:warnings
 
 [pycodestyle]
 count = True


### PR DESCRIPTION
@shyuep What's your stance on converting `pymatgen` tests from `unittest` to `pytest`?

I find `pytest`'s functional style to be more concise and easier to read than `unittest`.
