### PR TITLE
Correct link to Fleur website in addon entry for `pymatgen-io-fleur`

### DIFF
--- a/docs_rst/addons.rst
+++ b/docs_rst/addons.rst
@@ -17,7 +17,7 @@ release an add-on package.
   plots, etc.). This package is maintained by the Materials Virtual Lab.
 
 * `pymatgen-io-fleur <http://pypi.org/project/pymatgen-io-fleur>`_: Provides modules for reading and writing
-  files used by the `fleur <www.flapw.de>`_ DFT code. This package is maintained by the juDFT team.
+  files used by the `fleur <https://www.flapw.de/rel>`_ DFT code. This package is maintained by the juDFT team.
 
 * `pymatgen-analysis-defects <https://pypi.org/project/pymatgen-analysis-defects>`_: Provides functionality related to
   defect analysis. This package is maintained by Jimmy-Xuan Shen, and officially supported by the Materials Project.


### PR DESCRIPTION
The link in the docs was mistakenly interpreted as relative inside the pymatgen documentation. Also added `rel/`, which will always point to the documentation for the latest version of the code
