### PR TITLE
Fix `MPRester.get_entry_by_material_id()` for missing ID

### DIFF
--- a/pymatgen/ext/matproj.py
+++ b/pymatgen/ext/matproj.py
@@ -772,6 +772,9 @@ class _MPResterLegacy:
             conventional_unit_cell (bool): Whether to get the standard
                 conventional unit cell
 
+        Raises:
+            MPRestError if no data for given material_id is found.
+
         Returns:
             ComputedEntry or ComputedStructureEntry object.
         """
@@ -782,6 +785,8 @@ class _MPResterLegacy:
             property_data=property_data,
             conventional_unit_cell=conventional_unit_cell,
         )
+        if len(data) == 0:
+            raise MPRestError(f"{material_id = } does not exist")
         return data[0]
 
     def get_dos_by_material_id(self, material_id):

--- a/pymatgen/ext/tests/test_matproj.py
+++ b/pymatgen/ext/tests/test_matproj.py
@@ -171,9 +171,12 @@ class MPResterOldTest(PymatgenTest):
         self.assertRaises(MPRestError, self.rester.get_structure_by_material_id, "mp-does-not-exist")
 
     def test_get_entry_by_material_id(self):
-        e = self.rester.get_entry_by_material_id("mp-19017")
-        self.assertIsInstance(e, ComputedEntry)
-        self.assertTrue(e.composition.reduced_formula, "LiFePO4")
+        entry = self.rester.get_entry_by_material_id("mp-19017")
+        self.assertIsInstance(entry, ComputedEntry)
+        self.assertTrue(entry.composition.reduced_formula, "LiFePO4")
+
+        # "mp-2022" does not exist
+        self.assertRaises(MPRestError, self.rester.get_entry_by_material_id, "mp-2022")
 
     def test_query(self):
         criteria = {"elements": {"$in": ["Li", "Na", "K"], "$all": ["O"]}}


### PR DESCRIPTION
Closes #2612.