### PR TITLE
Added 'get_orbit_and_generators'-method to SpaceGroup to class.

### DIFF
--- a/pymatgen/symmetry/groups.py
+++ b/pymatgen/symmetry/groups.py
@@ -190,6 +190,7 @@ class PointGroup(SymmetryGroup):
                 orbit.append(pp)
         return orbit
 
+
 @cached_class
 class SpaceGroup(SymmetryGroup):
     """

--- a/pymatgen/symmetry/groups.py
+++ b/pymatgen/symmetry/groups.py
@@ -190,7 +190,6 @@ class PointGroup(SymmetryGroup):
                 orbit.append(pp)
         return orbit
 
-
 @cached_class
 class SpaceGroup(SymmetryGroup):
     """
@@ -387,6 +386,32 @@ class SpaceGroup(SymmetryGroup):
             if not in_array_list(orbit, pp, tol=tol):
                 orbit.append(pp)
         return orbit
+
+    def get_orbit_and_generators(self, p: ArrayLike, tol: float = 1e-5) -> tuple[list, list]:
+        """
+        Returns the orbit and its generators for a point.
+
+        Args:
+            p: Point as a 3x1 array.
+            tol: Tolerance for determining if sites are the same. 1e-5 should
+                be sufficient for most purposes. Set to 0 for exact matching
+                (and also needed for symbolic orbits).
+
+        Returns:
+            ([array], [array]) Orbit and generators for point.
+        """
+        from pymatgen.core.operations import SymmOp
+
+        orbit: list[ArrayLike] = [np.array(p, dtype=float)]
+        identity = SymmOp.from_rotation_and_translation(np.eye(3), np.zeros(3))
+        generators: list[ArrayLike] = [identity]
+        for o in self.symmetry_ops:
+            pp = o.operate(p)
+            pp = np.mod(np.round(pp, decimals=10), 1)
+            if not in_array_list(orbit, pp, tol=tol):
+                orbit.append(pp)
+                generators.append(o)
+        return orbit, generators
 
     def is_compatible(self, lattice: Lattice, tol: float = 1e-5, angle_tol: float = 5) -> bool:
         """

--- a/pymatgen/symmetry/tests/test_groups.py
+++ b/pymatgen/symmetry/tests/test_groups.py
@@ -124,6 +124,16 @@ class SpaceGroupTest(unittest.TestCase):
         p = np.random.randint(0, 100 + 1, size=(3,)) / 100
         self.assertLessEqual(len(sg.get_orbit(p)), sg.order)
 
+    def test_get_orbit_and_generators(self):
+        sg = SpaceGroup("Fm-3m")
+        p = np.random.randint(0, 100 + 1, size=(3,)) / 100
+        orbit, generators = sg.get_orbit_and_generators(p)
+        self.assertLessEqual(len(orbit), sg.order)
+        pp = generators[0].operate(orbit[0])
+        self.assertAlmostEqual(p[0], pp[0])
+        self.assertAlmostEqual(p[1], pp[1])
+        self.assertAlmostEqual(p[2], pp[2])
+
     def test_is_compatible(self):
         cubic = Lattice.cubic(1)
         hexagonal = Lattice.hexagonal(1, 2)


### PR DESCRIPTION
## SUMMARY

I added a method to the SpaceGroup class that returns both the orbit (like the 'get_orbit'-method does) as well as the symmetry operations that generate it. As opposed to 'get_orbit' the method makes sure that the first element of the orbit is the point that has been passed to the function. Therefore the first element in the list of generators that are returned is always the identity operation. 

A test making sure that this is always true has been implemented. 

The above functionality is useful if a physical property (e.g. angular momentum) that needs to obey the crystal symmetry is assigned to a given site. The user can then generate the corresponding  properties of the other sites of the orbit by using the generators of the orbit. 

## TODO 

It would be probably nice to implement this for PointGroup as well