### PR TITLE
Handle disordered structures in `CrystalNN.get_bonded_structure()` and `get_cn()`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,16 +6,10 @@ ci:
 
 repos:
 
-  - repo: https://github.com/myint/autoflake
+  - repo: https://github.com/PyCQA/autoflake
     rev: v1.4
     hooks:
       - id: autoflake
-        args:
-          - --in-place
-          - --remove-unused-variables
-          - --remove-all-unused-imports
-          - --expand-star-imports
-          - --ignore-init-module-imports
 
   - repo: https://github.com/asottile/pyupgrade
     rev: v2.37.3

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,16 +51,16 @@ Welcome to new contributors @naveensrinivasan, @xivh, @dgaines2, @yang-ruoxi, @c
 * Enhancement: Remove not converged warning for VASP AIMD runs, PR #2571 by @mjwen
 * Fix: generation of continuous line-mode band structures, PR #2533 by @munrojm
 * Fix: duplicate site properties for magnetic moments hwen using `AseAtomsAdaptor`, PR #2545 by @arosen93
-* Fix: bug in Grüneisen parameter calculation, PR #2543 by by @ab5424
+* Fix: bug in Grüneisen parameter calculation, PR #2543 by @ab5424
 * Fix: allow a comment on final line of KPOINTS file, PR #2549 by @xivh
 * Fix: for `Composition.replace` with complex mappings, PR #2555 by @jacksund
 * Fix: Implement equality method and fix __iter__ for InputSet, PR #2575 by @rkingsbury
 * Fix: use negative charge convention for electron in "update_charge_from_potcar", PR #2577 by @jmmshn
 * Fix: ensure charge is applied to initial and final structures parsed from vasprun.xml, PR #2579 by @jmmshn
 * Chore: Set permissions for GitHub actions, PR #2547 by @naveensrinivasan
-* Chore: Included GitHub actions in the Dependabot config, PR #2548 by by @naveensrinivasan
+* Chore: Included GitHub actions in the Dependabot config, PR #2548 by @naveensrinivasan
 * Documentation: fix typos in pymatgen.symmetry.analyzer docstrings, PR #2561 by @dgaines2
-* Documentation: clarification about usage of InputFile, PR #2570 by by @orionarcher
+* Documentation: clarification about usage of InputFile, PR #2570 by @orionarcher
 * Documentation: Improve messages and warnings, PR #2572 and PR #2573 by @cajfisher
 * Documentation: fix typo, PR #2580 by @janosh
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -123,7 +123,7 @@ v2022.3.22
 * Support kwargs for ASE adaptor. (@arosen93)
 * Fix for cation error in Lobster analysis. (@JaGeo)
 * Major revampt of Abstract interface for Input classes in IO. (@rkingsbury)
-* Orbital-projected band center, band filling, band ceneter, skewness, kurtosis, etc. (@arosen93)
+* Orbital-projected band center, band filling, band center, skewness, kurtosis, etc. (@arosen93)
 * Misc cleanups. (@janosh)
 
 v2022.3.7

--- a/docs_rst/change_log.rst
+++ b/docs_rst/change_log.rst
@@ -51,16 +51,16 @@ Welcome to new contributors @naveensrinivasan, @xivh, @dgaines2, @yang-ruoxi, @c
 * Enhancement: Remove not converged warning for VASP AIMD runs, PR #2571 by @mjwen
 * Fix: generation of continuous line-mode band structures, PR #2533 by @munrojm
 * Fix: duplicate site properties for magnetic moments hwen using `AseAtomsAdaptor`, PR #2545 by @arosen93
-* Fix: bug in Grüneisen parameter calculation, PR #2543 by by @ab5424
+* Fix: bug in Grüneisen parameter calculation, PR #2543 by @ab5424
 * Fix: allow a comment on final line of KPOINTS file, PR #2549 by @xivh
 * Fix: for `Composition.replace` with complex mappings, PR #2555 by @jacksund
 * Fix: Implement equality method and fix __iter__ for InputSet, PR #2575 by @rkingsbury
 * Fix: use negative charge convention for electron in "update_charge_from_potcar", PR #2577 by @jmmshn
 * Fix: ensure charge is applied to initial and final structures parsed from vasprun.xml, PR #2579 by @jmmshn
 * Chore: Set permissions for GitHub actions, PR #2547 by @naveensrinivasan
-* Chore: Included GitHub actions in the Dependabot config, PR #2548 by by @naveensrinivasan
+* Chore: Included GitHub actions in the Dependabot config, PR #2548 by @naveensrinivasan
 * Documentation: fix typos in pymatgen.symmetry.analyzer docstrings, PR #2561 by @dgaines2
-* Documentation: clarification about usage of InputFile, PR #2570 by by @orionarcher
+* Documentation: clarification about usage of InputFile, PR #2570 by @orionarcher
 * Documentation: Improve messages and warnings, PR #2572 and PR #2573 by @cajfisher
 * Documentation: fix typo, PR #2580 by @janosh
 

--- a/docs_rst/change_log.rst
+++ b/docs_rst/change_log.rst
@@ -123,7 +123,7 @@ v2022.3.22
 * Support kwargs for ASE adaptor. (@arosen93)
 * Fix for cation error in Lobster analysis. (@JaGeo)
 * Major revampt of Abstract interface for Input classes in IO. (@rkingsbury)
-* Orbital-projected band center, band filling, band ceneter, skewness, kurtosis, etc. (@arosen93)
+* Orbital-projected band center, band filling, band center, skewness, kurtosis, etc. (@arosen93)
 * Misc cleanups. (@janosh)
 
 v2022.3.7

--- a/pymatgen/analysis/diffraction/neutron.py
+++ b/pymatgen/analysis/diffraction/neutron.py
@@ -13,14 +13,13 @@ from math import asin, cos, degrees, pi, radians, sin
 
 import numpy as np
 
-from pymatgen.core.structure import Structure
-from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
-
-from .core import (
+from pymatgen.analysis.diffraction.core import (
     AbstractDiffractionPatternCalculator,
     DiffractionPattern,
     get_unique_families,
 )
+from pymatgen.core.structure import Structure
+from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 
 __author__ = "Yuta Suzuki"
 __copyright__ = "Copyright 2018, The Materials Project"
@@ -50,7 +49,7 @@ class NDCalculator(AbstractDiffractionPatternCalculator):
 
     """
 
-    def __init__(self, wavelength=1.54184, symprec=0, debye_waller_factors=None):
+    def __init__(self, wavelength=1.54184, symprec: float = 0, debye_waller_factors=None):
         """
         Initializes the ND calculator with a given radiation.
 

--- a/pymatgen/analysis/diffraction/xrd.py
+++ b/pymatgen/analysis/diffraction/xrd.py
@@ -13,14 +13,13 @@ from math import asin, cos, degrees, pi, radians, sin
 
 import numpy as np
 
-from pymatgen.core.structure import Structure
-from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
-
-from .core import (
+from pymatgen.analysis.diffraction.core import (
     AbstractDiffractionPatternCalculator,
     DiffractionPattern,
     get_unique_families,
 )
+from pymatgen.core.structure import Structure
+from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 
 # XRD wavelengths in angstroms
 WAVELENGTHS = {
@@ -112,7 +111,7 @@ class XRDCalculator(AbstractDiffractionPatternCalculator):
     # Tuple of available radiation keywords.
     AVAILABLE_RADIATION = tuple(WAVELENGTHS)
 
-    def __init__(self, wavelength="CuKa", symprec=0, debye_waller_factors=None):
+    def __init__(self, wavelength="CuKa", symprec: float = 0, debye_waller_factors=None):
         """
         Initializes the XRD calculator with a given radiation.
 

--- a/pymatgen/analysis/energy_models.py
+++ b/pymatgen/analysis/energy_models.py
@@ -107,7 +107,7 @@ class SymmetryModel(EnergyModel):
     :class:`pymatgen.symmetry.finder.SpacegroupAnalyzer`.
     """
 
-    def __init__(self, symprec=0.1, angle_tolerance=5):
+    def __init__(self, symprec: float = 0.1, angle_tolerance=5):
         """
         Args:
             symprec (float): Symmetry tolerance. Defaults to 0.1.

--- a/pymatgen/analysis/gb/grain.py
+++ b/pymatgen/analysis/gb/grain.py
@@ -339,7 +339,7 @@ class GrainBoundaryGenerator:
     Users can use structure matcher in pymatgen to get rid of the redundant structures.
     """
 
-    def __init__(self, initial_structure, symprec=0.1, angle_tolerance=1):
+    def __init__(self, initial_structure, symprec: float = 0.1, angle_tolerance=1):
         """
         initial_structure (Structure): Initial input structure. It can
                be conventional or primitive cell (primitive cell works for bcc and fcc).

--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -212,6 +212,8 @@ class ValenceIonicRadiusEvaluator:
 
 
 def _handle_disorder(structure: Structure, on_disorder: Literal["take majority", "take max species", "error"]):
+    """What to do in bonding and coordination number analysis if a site is disordered."""
+
     if all(site.is_ordered for site in structure):
         return structure
 
@@ -233,7 +235,7 @@ def _handle_disorder(structure: Structure, on_disorder: Literal["take majority",
         for idx, site in enumerate(structure):
             max_specie = max(site.species, key=site.species.get)  # type: ignore
             max_val = site.species[max_specie]
-            if max_val < 0.5 and on_disorder == "take majority":
+            if max_val <= 0.5 and on_disorder == "take majority":
                 raise ValueError(
                     f"Site {idx} has no majority species, the max species is {max_specie} with occupancy {max_val}"
                 )

--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -18,7 +18,7 @@ from collections import defaultdict, namedtuple
 from copy import deepcopy
 from functools import lru_cache
 from math import acos, asin, atan2, cos, exp, fabs, pi, pow, sin, sqrt
-from typing import Any
+from typing import Any, Literal
 
 import numpy as np
 from monty.dev import requires
@@ -211,22 +211,46 @@ class ValenceIonicRadiusEvaluator:
         return valences
 
 
+def _handle_disorder(structure: Structure, on_disorder: Literal["take majority", "error"]):
+    if all(site.is_ordered for site in structure):
+        return structure
+
+    if on_disorder == "error":
+        raise ValueError(
+            "Generating StructureGraphs for disordered Structures is currently unsupported. Pass "
+            "on_disorder='take majority' to consider only the majority species from each site in "
+            f"the bonding algorithm. Offending {structure = }"
+        )
+    elif on_disorder == "take majority":
+        # disordered structures raise AttributeError when passed to NearNeighbors.get_cn()
+        # or NearNeighbors.get_bonded_structure() (and probably others too, see GH-2070).
+        # As a workaround, we create a new structure with majority species on each site.
+        structure = structure.copy()  # make a copy so we don't mutate the original structure
+        for site in structure:
+            # get majority species for each site
+            site.species = max(site.species, key=site.species.get)  # type: ignore
+    else:
+        raise ValueError(f"Unexpected {on_disorder = }, should be 'take majority' or 'error'")
+
+    return structure
+
+
 class NearNeighbors:
     """
     Base class to determine near neighbors that typically include nearest
     neighbors and others that are within some tolerable distance.
     """
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, type(self)):
             return self.__dict__ == other.__dict__
         return False
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return len(self.__dict__.items())
 
     @property
-    def structures_allowed(self):
+    def structures_allowed(self) -> bool:
         """
         Boolean property: can this NearNeighbors class be used with Structure
         objects?
@@ -234,7 +258,7 @@ class NearNeighbors:
         raise NotImplementedError("structures_allowed is not defined!")
 
     @property
-    def molecules_allowed(self):
+    def molecules_allowed(self) -> bool:
         """
         Boolean property: can this NearNeighbors class be used with Molecule
         objects?
@@ -242,7 +266,7 @@ class NearNeighbors:
         raise NotImplementedError("molecules_allowed is not defined!")
 
     @property
-    def extend_structure_molecules(self):
+    def extend_structure_molecules(self) -> bool:
         """
         Boolean property: Do Molecules need to be converted to Structures to use
         this NearNeighbors class? Note: this property is not defined for classes
@@ -250,31 +274,37 @@ class NearNeighbors:
         """
         raise NotImplementedError("extend_structures_molecule is not defined!")
 
-    def get_cn(self, structure: Structure, n, use_weights=False):
+    def get_cn(
+        self,
+        structure: Structure,
+        n: int,
+        use_weights: bool = False,
+        on_disorder: Literal["take majority", "error"] = "take majority",
+    ) -> float:
         """
         Get coordination number, CN, of site with index n in structure.
 
         Args:
             structure (Structure): input structure.
-            n (integer): index of site for which to determine CN.
-            use_weights (boolean): flag indicating whether (True)
-                to use weights for computing the coordination number
-                or not (False, default: each coordinated site has equal
-                weight).
+            n (int): index of site for which to determine CN.
+            use_weights (boolean): flag indicating whether (True) to use weights for computing the coordination
+                number or not (False, default: each coordinated site has equal weight).
+            on_disorder ('take majority' | 'error'): What to do when encountering a disordered structure.
+                'error' will raise ValueError. 'take majority' will use the majority species on each site.
         Returns:
-            cn (integer or float): coordination number.
+            cn (int or float): coordination number.
         """
-
+        structure = _handle_disorder(structure, on_disorder)
         siw = self.get_nn_info(structure, n)
         return sum(e["weight"] for e in siw) if use_weights else len(siw)
 
-    def get_cn_dict(self, structure: Structure, n, use_weights=False):
+    def get_cn_dict(self, structure: Structure, n: int, use_weights: bool = False):
         """
         Get coordination number, CN, of each element bonded to site with index n in structure
 
         Args:
             structure (Structure): input structure
-            n (integer): index of site for which to determine CN.
+            n (int): index of site for which to determine CN.
             use_weights (boolean): flag indicating whether (True)
                 to use weights for computing the coordination number
                 or not (False, default: each coordinated site has equal
@@ -287,16 +317,16 @@ class NearNeighbors:
         siw = self.get_nn_info(structure, n)
 
         cn_dict = {}
-        for i in siw:
-            site_element = i["site"].species_string
+        for idx in siw:
+            site_element = idx["site"].species_string
             if site_element not in cn_dict:
                 if use_weights:
-                    cn_dict[site_element] = i["weight"]
+                    cn_dict[site_element] = idx["weight"]
                 else:
                     cn_dict[site_element] = 1
             else:
                 if use_weights:
-                    cn_dict[site_element] += i["weight"]
+                    cn_dict[site_element] += idx["weight"]
                 else:
                     cn_dict[site_element] += 1
         return cn_dict
@@ -307,7 +337,7 @@ class NearNeighbors:
 
         Args:
             structure (Structure): input structure.
-            n (integer): index of site in structure for which to determine
+            n (int): index of site in structure for which to determine
                     neighbors.
         Returns:
             sites (list of Site objects): near neighbors.
@@ -322,7 +352,7 @@ class NearNeighbors:
 
         Args:
             structure (Structure): input structure.
-            n (integer): index of site for which to determine the weights.
+            n (int): index of site for which to determine the weights.
         Returns:
             weights (list of floats): near-neighbor weights.
         """
@@ -336,7 +366,7 @@ class NearNeighbors:
 
         Args:
             structure (Structure): input structure.
-            n (integer): index of site for which to determine the image
+            n (int): index of site for which to determine the image
                 location of near neighbors.
         Returns:
             images (list of 3D integer array): image locations of
@@ -547,6 +577,7 @@ class NearNeighbors:
         decorate: bool = False,
         weights: bool = True,
         edge_properties: bool = False,
+        on_disorder: Literal["take majority", "error"] = "take majority",
     ) -> StructureGraph | MoleculeGraph:
         """
         Obtain a StructureGraph object using this NearNeighbor
@@ -555,16 +586,17 @@ class NearNeighbors:
 
         Args:
             structure: Structure object.
-            decorate (bool): whether to annotate site properties
-            with order parameters using neighbors determined by
-            this NearNeighbor class
-            weights (bool): whether to include edge weights from
-            NearNeighbor class in StructureGraph
-            edge_properties (bool) whether to include further
-             edge properties from NearNeighbor class in StructureGraph
+            decorate (bool): whether to annotate site properties with order parameters using neighbors
+                determined by this NearNeighbor class
+            weights (bool): whether to include edge weights from NearNeighbor class in StructureGraph
+            edge_properties (bool) whether to include further edge properties from NearNeighbor class in StructureGraph
+            on_disorder ('take majority' | 'error'): What to do when encountering a disordered structure.
+                'error' will raise ValueError. 'take majority' will use the majority species on each site.
 
         Returns: a pymatgen.analysis.graphs.StructureGraph object
         """
+        structure = _handle_disorder(structure, on_disorder)
+
         if decorate:
             # Decorate all sites in the underlying structure
             # with site properties that provides information on the
@@ -610,7 +642,7 @@ class NearNeighbors:
                 params.append(tmp)
             lostops = LocalStructOrderParams(types, parameters=params)
             sites = [structure[n]] + self.get_nn(structure, n)
-            lostop_vals = lostops.get_order_parameters(sites, 0, indices_neighs=list(range(1, cn + 1)))
+            lostop_vals = lostops.get_order_parameters(sites, 0, indices_neighs=list(range(1, cn + 1)))  # type: ignore
             d = {}
             for i, lostop in enumerate(lostop_vals):
                 d[names[i]] = lostop
@@ -685,7 +717,7 @@ class VoronoiNN(NearNeighbors):
         Args:
             structure (Structure): structure for which to evaluate the
                 coordination environment.
-            n (integer): site index.
+            n (int): site index.
 
         Returns:
             A dict of sites sharing a common Voronoi facet with the site
@@ -941,7 +973,7 @@ class VoronoiNN(NearNeighbors):
 
         Args:
             structure (Structure): input structure.
-            n (integer): index of site for which to determine near-neighbor
+            n (int): index of site for which to determine near-neighbor
                 sites.
 
         Returns:
@@ -1235,7 +1267,7 @@ class JmolNN(NearNeighbors):
 
         Args:
             structure (Structure): input structure.
-            n (integer): index of site for which to determine near
+            n (int): index of site for which to determine near
                 neighbors.
 
         Returns:
@@ -1327,7 +1359,7 @@ class MinimumDistanceNN(NearNeighbors):
 
         Args:
             structure (Structure): input structure.
-            n (integer): index of site for which to determine near
+            n (int): index of site for which to determine near
                 neighbors.
 
         Returns:
@@ -1737,7 +1769,7 @@ class MinimumOKeeffeNN(NearNeighbors):
 
         Args:
             structure (Structure): input structure.
-            n (integer): index of site for which to determine near
+            n (int): index of site for which to determine near
                 neighbors.
 
         Returns:
@@ -1824,7 +1856,7 @@ class MinimumVIRENN(NearNeighbors):
 
         Args:
             structure (Structure): input structure.
-            n (integer): index of site for which to determine near
+            n (int): index of site for which to determine near
                 neighbors.
 
         Returns:
@@ -2800,7 +2832,9 @@ class LocalStructOrderParams:
             raise ValueError("Index for getting parameters associated with order parameter calculation out-of-bounds!")
         return self._params[index]
 
-    def get_order_parameters(self, structure: Structure, n, indices_neighs=None, tol: float = 0.0, target_spec=None):
+    def get_order_parameters(
+        self, structure: Structure, n: int, indices_neighs: list[int] = None, tol: float = 0.0, target_spec=None
+    ):
         """
         Compute all order parameters of site n.
 
@@ -2810,7 +2844,7 @@ class LocalStructOrderParams:
                 for which OPs are to be
                 calculated. Note that we do not use the sites iterator
                 here, but directly access sites via struct[index].
-            indices_neighs ([int]): list of indices of those neighbors
+            indices_neighs (list[int]): list of indices of those neighbors
                 in Structure object
                 structure that are to be considered for OP computation.
                 This optional argument overwrites the way neighbors are
@@ -3391,7 +3425,7 @@ class BrunnerNN_reciprocal(NearNeighbors):
 
         Args:
             structure (Structure): input structure.
-            n (integer): index of site for which to determine near-neighbor
+            n (int): index of site for which to determine near-neighbor
                 sites.
 
         Returns:
@@ -3464,7 +3498,7 @@ class BrunnerNN_relative(NearNeighbors):
 
         Args:
             structure (Structure): input structure.
-            n (integer): index of site for which to determine near-neighbor
+            n (int): index of site for which to determine near-neighbor
                 sites.
 
         Returns:
@@ -3537,7 +3571,7 @@ class BrunnerNN_real(NearNeighbors):
 
         Args:
             structure (Structure): input structure.
-            n (integer): index of site for which to determine near-neighbor
+            n (int): index of site for which to determine near-neighbor
                 sites.
 
         Returns:
@@ -3634,7 +3668,7 @@ class EconNN(NearNeighbors):
 
         Args:
             structure (Structure): input structure.
-            n (integer): index of site for which to determine near-neighbor
+            n (int): index of site for which to determine near-neighbor
                 sites.
 
         Returns:
@@ -3819,7 +3853,7 @@ class CrystalNN(NearNeighbors):
         """
         return False
 
-    def get_nn_info(self, structure: Structure, n: int = None) -> list[dict]:
+    def get_nn_info(self, structure: Structure, n: int) -> list[dict]:
         """
         Get all near-neighbor information.
         Args:
@@ -3834,7 +3868,6 @@ class CrystalNN(NearNeighbors):
                 to the coordination number (1 or smaller), 'site_index' gives index of
                 the corresponding site in the original structure.
         """
-
         nndata = self.get_nn_data(structure, n)
 
         if not self.weighted_cn:
@@ -3855,7 +3888,7 @@ class CrystalNN(NearNeighbors):
 
         return nndata.all_nninfo
 
-    def get_nn_data(self, structure: Structure, n, length=None):
+    def get_nn_data(self, structure: Structure, n: int, length=None):
         """
         The main logic of the method to compute near neighbor.
 
@@ -3986,32 +4019,36 @@ class CrystalNN(NearNeighbors):
 
         return self.transform_to_length(self.NNData(nn, cn_weights, cn_nninfo), length)
 
-    def get_cn(self, structure: Structure, n, use_weights=False):
+    def get_cn(self, structure: Structure, n: int, **kwargs) -> float:  # type: ignore
         """
         Get coordination number, CN, of site with index n in structure.
 
         Args:
             structure (Structure): input structure.
-            n (integer): index of site for which to determine CN.
+            n (int): index of site for which to determine CN.
             use_weights (boolean): flag indicating whether (True)
                 to use weights for computing the coordination number
                 or not (False, default: each coordinated site has equal
                 weight).
+            on_disorder ('take majority' | 'error'): What to do when encountering a disordered structure.
+                'error' will raise ValueError. 'take majority' will use the majority species on each site.
+
         Returns:
-            cn (integer or float): coordination number.
+            cn (int or float): coordination number.
         """
+        use_weights = kwargs.get("use_weights", False)
         if self.weighted_cn != use_weights:
             raise ValueError("The weighted_cn parameter and use_weights parameter should match!")
 
-        return super().get_cn(structure, n, use_weights)
+        return super().get_cn(structure, n, **kwargs)
 
-    def get_cn_dict(self, structure: Structure, n, use_weights=False):
+    def get_cn_dict(self, structure: Structure, n: int, use_weights: bool = False, **kwargs):
         """
         Get coordination number, CN, of each element bonded to site with index n in structure
 
         Args:
             structure (Structure): input structure
-            n (integer): index of site for which to determine CN.
+            n (int): index of site for which to determine CN.
             use_weights (boolean): flag indicating whether (True)
                 to use weights for computing the coordination number
                 or not (False, default: each coordinated site has equal
@@ -4217,7 +4254,7 @@ class CutOffDictNN(NearNeighbors):
 
         Args:
             structure (Structure): input structure.
-            n (integer): index of site for which to determine near-neighbor
+            n (int): index of site for which to determine near-neighbor
                 sites.
 
         Returns:
@@ -4329,7 +4366,7 @@ class Critic2NN(NearNeighbors):
 
         Args:
             structure (Structure): input structure.
-            n (integer): index of site for which to determine near-neighbor
+            n (int): index of site for which to determine near-neighbor
                 sites.
 
         Returns:

--- a/pymatgen/analysis/magnetism/heisenberg.py
+++ b/pymatgen/analysis/magnetism/heisenberg.py
@@ -59,20 +59,14 @@ class HeisenbergMapper:
                 being equal.
 
         Parameters:
-            strategy (object): Class from pymatgen.analysis.local_env for
-                constructing graphs.
+            strategy (object): Class from pymatgen.analysis.local_env for constructing graphs.
             sgraphs (list): StructureGraph objects.
-            unique_site_ids (dict): Maps each site to its unique numerical
-                identifier.
-            wyckoff_ids (dict): Maps unique numerical identifier to wyckoff
-                position.
-            nn_interacations (dict): {i: j} pairs of NN interactions
-                between unique sites.
+            unique_site_ids (dict): Maps each site to its unique numerical identifier.
+            wyckoff_ids (dict): Maps unique numerical identifier to wyckoff position.
+            nn_interactions (dict): {i: j} pairs of NN interactions between unique sites.
             dists (dict): NN, NNN, and NNNN interaction distances
-            ex_mat (DataFrame): Invertible Heisenberg Hamiltonian for each
-                graph.
+            ex_mat (DataFrame): Invertible Heisenberg Hamiltonian for each graph.
             ex_params (dict): Exchange parameter values (meV/atom)
-
         """
 
         # Save original copies of inputs
@@ -893,7 +887,7 @@ class HeisenbergModel(MSONable):
                 identifier.
             wyckoff_ids (dict): Maps unique numerical identifier to wyckoff
                 position.
-            nn_interacations (dict): {i: j} pairs of NN interactions
+            nn_interactions (dict): {i: j} pairs of NN interactions
                 between unique sites.
             dists (dict): NN, NNN, and NNNN interaction distances
             ex_mat (DataFrame): Invertible Heisenberg Hamiltonian for each

--- a/pymatgen/analysis/structure_prediction/substitutor.py
+++ b/pymatgen/analysis/structure_prediction/substitutor.py
@@ -38,7 +38,7 @@ class Substitutor(MSONable):
     Inorganic Chemistry, 50(2), 656-663. doi:10.1021/ic102031h
     """
 
-    def __init__(self, threshold=1e-3, symprec=0.1, **kwargs):
+    def __init__(self, threshold=1e-3, symprec: float = 0.1, **kwargs):
         """
         This substitutor uses the substitution probability class to
         find good substitutions for a given chemistry or structure.

--- a/pymatgen/analysis/tests/test_graphs.py
+++ b/pymatgen/analysis/tests/test_graphs.py
@@ -165,12 +165,12 @@ class StructureGraphTest(PymatgenTest):
         coords = nx.get_node_attributes(self.square_sg.graph, "coords")
         properties = nx.get_node_attributes(self.square_sg.graph, "properties")
 
-        for i in range(len(self.square_sg.structure)):
-            self.assertEqual(str(specie[i]), str(self.square_sg.structure[i].specie))
-            self.assertEqual(coords[i][0], self.square_sg.structure[i].coords[0])
-            self.assertEqual(coords[i][1], self.square_sg.structure[i].coords[1])
-            self.assertEqual(coords[i][2], self.square_sg.structure[i].coords[2])
-            self.assertEqual(properties[i], self.square_sg.structure[i].properties)
+        for idx, site in enumerate(self.square_sg.structure):
+            self.assertEqual(str(specie[idx]), str(site.specie))
+            self.assertEqual(coords[idx][0], site.coords[0])
+            self.assertEqual(coords[idx][1], site.coords[1])
+            self.assertEqual(coords[idx][2], site.coords[2])
+            self.assertEqual(properties[idx], site.properties)
 
     def test_edge_editing(self):
         square = copy.deepcopy(self.square_sg)
@@ -685,12 +685,12 @@ class MoleculeGraphTest(unittest.TestCase):
         coords = nx.get_node_attributes(self.ethylene.graph, "coords")
         properties = nx.get_node_attributes(self.ethylene.graph, "properties")
 
-        for i in range(len(self.ethylene.molecule)):
-            self.assertEqual(str(specie[i]), str(self.ethylene.molecule[i].specie))
-            self.assertEqual(coords[i][0], self.ethylene.molecule[i].coords[0])
-            self.assertEqual(coords[i][1], self.ethylene.molecule[i].coords[1])
-            self.assertEqual(coords[i][2], self.ethylene.molecule[i].coords[2])
-            self.assertEqual(properties[i], self.ethylene.molecule[i].properties)
+        for idx, site in enumerate(self.ethylene.molecule):
+            self.assertEqual(str(specie[idx]), str(site.specie))
+            self.assertEqual(coords[idx][0], site.coords[0])
+            self.assertEqual(coords[idx][1], site.coords[1])
+            self.assertEqual(coords[idx][2], site.coords[2])
+            self.assertEqual(properties[idx], site.properties)
 
     def test_coordination(self):
         molecule = Molecule(["C", "C"], [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])

--- a/pymatgen/apps/battery/battery_abc.py
+++ b/pymatgen/apps/battery/battery_abc.py
@@ -400,7 +400,7 @@ class AbstractElectrode(Sequence, MSONable):
                 subelectrodes.
 
         Returns:
-            A summary of this electrode"s properties in dict format.
+            A summary of this electrode's properties in dict format.
         """
 
         d = {

--- a/pymatgen/apps/battery/conversion_battery.py
+++ b/pymatgen/apps/battery/conversion_battery.py
@@ -248,7 +248,7 @@ class ConversionElectrode(AbstractElectrode):
                 subelectrodes.
 
         Returns:
-            A summary of this electrode"s properties in dict format.
+            A summary of this electrode's properties in dict format.
         """
 
         d = super().get_summary_dict(print_subelectrodes=print_subelectrodes)

--- a/pymatgen/apps/battery/insertion_battery.py
+++ b/pymatgen/apps/battery/insertion_battery.py
@@ -328,7 +328,7 @@ class InsertionElectrode(AbstractElectrode):
                 subelectrodes.
 
         Returns:
-            A summary of this electrode"s properties in dict format.
+            A summary of this electrode's properties in dict format.
         """
 
         d = super().get_summary_dict(print_subelectrodes=print_subelectrodes)

--- a/pymatgen/apps/borg/hive.py
+++ b/pymatgen/apps/borg/hive.py
@@ -37,7 +37,7 @@ class AbstractDrone(MSONable, metaclass=abc.ABCMeta):
     def assimilate(self, path):
         """
         Assimilate data in a directory path into a pymatgen object. Because of
-        the quirky nature of Python"s multiprocessing, the object must support
+        the quirky nature of Python's multiprocessing, the object must support
         pymatgen's as_dict() for parallel processing.
 
         Args:
@@ -334,12 +334,12 @@ class GaussianToComputedEntryDrone(AbstractDrone):
             parameters (list): Input parameters to include. It has to be one of
                 the properties supported by the GaussianOutput object. See
                 :class:`pymatgen.io.gaussianio GaussianOutput`. The parameters
-                have to be one of python"s primitive types, i.e., list, dict of
+                have to be one of python's primitive types, i.e., list, dict of
                 strings and integers. If parameters is None, a default set of
                 parameters will be set.
             data (list): Output data to include. Has to be one of the properties
                 supported by the GaussianOutput object. The parameters have to
-                be one of python"s primitive types, i.e. list, dict of strings
+                be one of python's primitive types, i.e. list, dict of strings
                 and integers. If data is None, a default set will be set.
             file_extensions (list):
                 File extensions to be considered as Gaussian output files.

--- a/pymatgen/cli/pmg.py
+++ b/pymatgen/cli/pmg.py
@@ -141,7 +141,7 @@ def main():
     )
     parser_config.set_defaults(func=configure_pmg)
 
-    parser_analyze = subparsers.add_parser("analyze", help="Vasp calculation analysis tools.")
+    parser_analyze = subparsers.add_parser("analyze", help="VASP calculation analysis tools.")
     parser_analyze.add_argument(
         "directories",
         metavar="dir",

--- a/pymatgen/command_line/vampire_caller.py
+++ b/pymatgen/command_line/vampire_caller.py
@@ -83,7 +83,7 @@ class VampireCaller:
         Parameters:
             sgraph (StructureGraph): Ground state graph.
             unique_site_ids (dict): Maps each site to its unique identifier
-            nn_interacations (dict): {i: j} pairs of NN interactions
+            nn_interactions (dict): {i: j} pairs of NN interactions
                 between unique sites.
             ex_params (dict): Exchange parameter values (meV/atom)
             mft_t (float): Mean field theory estimate of critical T

--- a/pymatgen/core/surface.py
+++ b/pymatgen/core/surface.py
@@ -297,7 +297,7 @@ class Slab(Structure):
         unique = [ss[0] for ss in s.group_structures(slabs)]
         return unique
 
-    def is_symmetric(self, symprec=0.1):
+    def is_symmetric(self, symprec: float = 0.1):
         """
         Checks if surfaces are symmetric, i.e., contains inversion, mirror on (hkl) plane,
             or screw axis (rotation and translation) about [hkl].

--- a/pymatgen/core/tensors.py
+++ b/pymatgen/core/tensors.py
@@ -102,7 +102,7 @@ class Tensor(np.ndarray, MSONable):
     def __repr__(self):
         return f"{type(self).__name__}({self})"
 
-    def zeroed(self, tol=1e-3):
+    def zeroed(self, tol: float = 1e-3):
         """
         returns the matrix with all entries below a certain threshold
         (i.e. tol) set to zero
@@ -120,7 +120,7 @@ class Tensor(np.ndarray, MSONable):
         """
         return self.__class__(symm_op.transform_tensor(self))
 
-    def rotate(self, matrix, tol=1e-3):
+    def rotate(self, matrix, tol: float = 1e-3):
         """
         Applies a rotation directly, and tests input matrix to ensure a valid
         rotation.
@@ -315,7 +315,7 @@ class Tensor(np.ndarray, MSONable):
         new_v = sum(np.transpose(v, ind) for ind in perms) / len(perms)
         return type(self).from_voigt(new_v)
 
-    def is_symmetric(self, tol=1e-5):
+    def is_symmetric(self, tol: float = 1e-5):
         """
         Tests whether a tensor is symmetric or not based on the residual
         with its symmetric part, from self.symmetrized
@@ -340,7 +340,7 @@ class Tensor(np.ndarray, MSONable):
         symm_ops = sga.get_symmetry_operations(cartesian=True)
         return sum(self.transform(symm_op) for symm_op in symm_ops) / len(symm_ops)
 
-    def is_fit_to_structure(self, structure: Structure, tol=1e-2):
+    def is_fit_to_structure(self, structure: Structure, tol: float = 1e-2):
         """
         Tests whether a tensor is invariant with respect to the
         symmetry operations of a particular structure by testing
@@ -366,20 +366,20 @@ class Tensor(np.ndarray, MSONable):
             warnings.warn("Tensor is not symmetric, information may be lost in voigt conversion.")
         return v_matrix * self._vscale
 
-    def is_voigt_symmetric(self, tol=1e-6):
+    def is_voigt_symmetric(self, tol: float = 1e-6):
         """
         Tests symmetry of tensor to that necessary for voigt-conversion
         by grouping indices into pairs and constructing a sequence of
         possible permutations to be used in a tensor transpose
         """
         transpose_pieces = [[[0 for i in range(self.rank % 2)]]]
-        transpose_pieces += [[range(j, j + 2)] for j in range(self.rank % 2, self.rank, 2)]
+        transpose_pieces += [[list(range(j, j + 2))] for j in range(self.rank % 2, self.rank, 2)]
         for n in range(self.rank % 2, len(transpose_pieces)):
             if len(transpose_pieces[n][0]) == 2:
                 transpose_pieces[n] += [transpose_pieces[n][0][::-1]]
         for trans_seq in itertools.product(*transpose_pieces):
-            trans_seq = list(itertools.chain(*trans_seq))
-            if (self - self.transpose(trans_seq) > tol).any():
+            transpose_seq = list(itertools.chain(*trans_seq))
+            if any(self - self.transpose(transpose_seq) > tol):
                 return False
         return True
 
@@ -727,7 +727,7 @@ class TensorCollection(collections.abc.Sequence, MSONable):
     def __iter__(self):
         return self.tensors.__iter__()
 
-    def zeroed(self, tol=1e-3):
+    def zeroed(self, tol: float = 1e-3):
         """
         :param tol: Tolerance
         :return: TensorCollection where small values are set to 0.
@@ -743,7 +743,7 @@ class TensorCollection(collections.abc.Sequence, MSONable):
         """
         return self.__class__([t.transform(symm_op) for t in self])
 
-    def rotate(self, matrix, tol=1e-3):
+    def rotate(self, matrix, tol: float = 1e-3):
         """
         Rotates TensorCollection.
 
@@ -760,7 +760,7 @@ class TensorCollection(collections.abc.Sequence, MSONable):
         """
         return self.__class__([t.symmetrized for t in self])
 
-    def is_symmetric(self, tol=1e-5):
+    def is_symmetric(self, tol: float = 1e-5):
         """
         :param tol: tolerance
         :return: Whether all tensors are symmetric.
@@ -777,7 +777,7 @@ class TensorCollection(collections.abc.Sequence, MSONable):
         """
         return self.__class__([t.fit_to_structure(structure, symprec) for t in self])
 
-    def is_fit_to_structure(self, structure: Structure, tol=1e-2):
+    def is_fit_to_structure(self, structure: Structure, tol: float = 1e-2):
         """
         :param structure: Structure
         :param tol: tolerance
@@ -799,7 +799,7 @@ class TensorCollection(collections.abc.Sequence, MSONable):
         """
         return [t.rank for t in self]
 
-    def is_voigt_symmetric(self, tol=1e-6):
+    def is_voigt_symmetric(self, tol: float = 1e-6):
         """
         :param tol: tolerance
         :return: Whether all tensors are voigt symmetric.
@@ -920,7 +920,7 @@ class SquareTensor(Tensor):
         """
         return np.linalg.det(self)
 
-    def is_rotation(self, tol=1e-3, include_improper=True):
+    def is_rotation(self, tol: float = 1e-3, include_improper=True):
         """
         Test to see if tensor is a valid rotation matrix, performs a
         test to check whether the inverse is equal to the transpose
@@ -992,7 +992,7 @@ def get_uvec(vec):
     return vec / l
 
 
-def symmetry_reduce(tensors, structure: Structure, tol=1e-8, **kwargs):
+def symmetry_reduce(tensors, structure: Structure, tol: float = 1e-8, **kwargs):
     """
     Function that converts a list of tensors corresponding to a structure
     and returns a dictionary consisting of unique tensor keys with symmop
@@ -1039,7 +1039,7 @@ class TensorMapping(collections.abc.MutableMapping):
 
     """
 
-    def __init__(self, tensors=None, values=None, tol=1e-5):
+    def __init__(self, tensors=None, values=None, tol: float = 1e-5):
         """
         Initialize a TensorMapping
 

--- a/pymatgen/core/tensors.py
+++ b/pymatgen/core/tensors.py
@@ -325,7 +325,7 @@ class Tensor(np.ndarray, MSONable):
         """
         return (self - self.symmetrized < tol).all()
 
-    def fit_to_structure(self, structure: Structure, symprec=0.1):
+    def fit_to_structure(self, structure: Structure, symprec: float = 0.1):
         """
         Returns a tensor that is invariant with respect to symmetry
         operations corresponding to a structure
@@ -379,7 +379,7 @@ class Tensor(np.ndarray, MSONable):
                 transpose_pieces[n] += [transpose_pieces[n][0][::-1]]
         for trans_seq in itertools.product(*transpose_pieces):
             transpose_seq = list(itertools.chain(*trans_seq))
-            if any(self - self.transpose(transpose_seq) > tol):
+            if (self - self.transpose(transpose_seq) > tol).any():
                 return False
         return True
 
@@ -767,7 +767,7 @@ class TensorCollection(collections.abc.Sequence, MSONable):
         """
         return all(t.is_symmetric(tol) for t in self)
 
-    def fit_to_structure(self, structure: Structure, symprec=0.1):
+    def fit_to_structure(self, structure: Structure, symprec: float = 0.1):
         """
         Fits all tensors to a Structure.
 

--- a/pymatgen/io/abinit/inputs.py
+++ b/pymatgen/io/abinit/inputs.py
@@ -474,7 +474,7 @@ def ion_ioncell_relax_input(
     return multi
 
 
-def calc_shiftk(structure, symprec=0.01, angle_tolerance=5):
+def calc_shiftk(structure, symprec: float = 0.01, angle_tolerance=5):
     """
     Find the values of ``shiftk`` and ``nshiftk`` appropriated for the sampling of the Brillouin zone.
 

--- a/pymatgen/io/babel.py
+++ b/pymatgen/io/babel.py
@@ -44,7 +44,7 @@ class BabelMolAdaptor:
     )
     def __init__(self, mol):
         """
-        Initializes with pymatgen Molecule or OpenBabel"s OBMol.
+        Initializes with pymatgen Molecule or OpenBabel's OBMol.
 
         Args:
             mol: pymatgen's Molecule/IMolecule or OpenBabel OBMol

--- a/pymatgen/io/exciting/inputs.py
+++ b/pymatgen/io/exciting/inputs.py
@@ -167,7 +167,7 @@ class ExcitingInput(MSONable):
             data = f.read().replace("\n", "")
         return ExcitingInput.from_string(data)
 
-    def write_etree(self, celltype, cartesian=False, bandstr=False, symprec=0.4, angle_tolerance=5, **kwargs):
+    def write_etree(self, celltype, cartesian=False, bandstr=False, symprec: float = 0.4, angle_tolerance=5, **kwargs):
         """
         Writes the exciting input parameters to an xml object.
 
@@ -222,14 +222,14 @@ class ExcitingInput(MSONable):
 
         # write lattice
         basis = new_struct.lattice.matrix
-        for i in range(3):
+        for idx in range(3):
             basevect = ET.SubElement(crystal, "basevect")
-            basevect.text = f"{basis[i][0]:16.8f} {basis[i][1]:16.8f} {basis[i][2]:16.8f}"
+            basevect.text = f"{basis[idx][0]:16.8f} {basis[idx][1]:16.8f} {basis[idx][2]:16.8f}"
         # write atomic positions for each species
         index = 0
-        for i in sorted(new_struct.types_of_species, key=lambda el: el.X):
-            species = ET.SubElement(structure, "species", speciesfile=i.symbol + ".xml")
-            sites = new_struct.indices_from_symbol(i.symbol)
+        for elem in sorted(new_struct.types_of_species, key=lambda el: el.X):
+            species = ET.SubElement(structure, "species", speciesfile=elem.symbol + ".xml")
+            sites = new_struct.indices_from_symbol(elem.symbol)
 
             for j in sites:
                 fc = new_struct[j].frac_coords
@@ -254,11 +254,11 @@ class ExcitingInput(MSONable):
             kpath = HighSymmKpath(new_struct, symprec=symprec, angle_tolerance=angle_tolerance)
             prop = ET.SubElement(root, "properties")
             bandstrct = ET.SubElement(prop, "bandstructure")
-            for i in range(len(kpath.kpath["path"])):
+            for idx in range(len(kpath.kpath["path"])):
                 plot = ET.SubElement(bandstrct, "plot1d")
                 path = ET.SubElement(plot, "path", steps="100")
-                for j in range(len(kpath.kpath["path"][i])):
-                    symbol = kpath.kpath["path"][i][j]
+                for j in range(len(kpath.kpath["path"][idx])):
+                    symbol = kpath.kpath["path"][idx][j]
                     coords = kpath.kpath["kpoints"][symbol]
                     coord = f"{coords[0]:16.8f} {coords[1]:16.8f} {coords[2]:16.8f}"
                     if symbol == "\\Gamma":
@@ -275,7 +275,7 @@ class ExcitingInput(MSONable):
 
         return root
 
-    def write_string(self, celltype, cartesian=False, bandstr=False, symprec=0.4, angle_tolerance=5, **kwargs):
+    def write_string(self, celltype, cartesian=False, bandstr=False, symprec: float = 0.4, angle_tolerance=5, **kwargs):
         """
         Writes exciting input.xml as a string.
 
@@ -310,7 +310,9 @@ class ExcitingInput(MSONable):
             raise ValueError("Incorrect celltype!")
         return string
 
-    def write_file(self, celltype, filename, cartesian=False, bandstr=False, symprec=0.4, angle_tolerance=5, **kwargs):
+    def write_file(
+        self, celltype, filename, cartesian=False, bandstr=False, symprec: float = 0.4, angle_tolerance=5, **kwargs
+    ):
         """
         Writes exciting input file.
 

--- a/pymatgen/io/lammps/tests/test_data.py
+++ b/pymatgen/io/lammps/tests/test_data.py
@@ -699,6 +699,7 @@ class ForceFieldTest(unittest.TestCase):
         )
         self.assertEqual(v.masses.at[3, "mass"], 15.9994)
         v_ff = v.force_field
+        assert isinstance(v_ff, dict)
         self.assertNotIn("Pair Coeffs", v_ff)
         self.assertEqual(v_ff["PairIJ Coeffs"].iat[5, 4], 1.93631)
         self.assertEqual(v_ff["Bond Coeffs"].at[2, "coeff2"], 0.855906)
@@ -718,6 +719,7 @@ class ForceFieldTest(unittest.TestCase):
         e = self.ethane
         self.assertEqual(e.masses.at[1, "mass"], 12.01115)
         e_ff = e.force_field
+        assert isinstance(e_ff, dict)
         self.assertNotIn("PairIJ Coeffs", e_ff)
         self.assertEqual(e_ff["Pair Coeffs"].at[1, "coeff2"], 3.854)
         self.assertEqual(e_ff["Bond Coeffs"].at[2, "coeff4"], 844.6)

--- a/pymatgen/io/lobster/inputs.py
+++ b/pymatgen/io/lobster/inputs.py
@@ -413,7 +413,9 @@ class Lobsterin(dict, MSONable):
         return list_basis_dict
 
     @staticmethod
-    def write_POSCAR_with_standard_primitive(POSCAR_input="POSCAR", POSCAR_output="POSCAR.lobster", symprec=0.01):
+    def write_POSCAR_with_standard_primitive(
+        POSCAR_input="POSCAR", POSCAR_output="POSCAR.lobster", symprec: float = 0.01
+    ):
         """
         writes a POSCAR with the standard primitive cell. This is needed to arrive at the correct kpath
         Args:

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -203,7 +203,7 @@ class Poscar(MSONable):
         super().__setattr__(name, value)
 
     @staticmethod
-    def from_file(filename, check_for_POTCAR=True, read_velocities=True):
+    def from_file(filename, check_for_POTCAR=True, read_velocities=True) -> Poscar:
         """
         Reads a Poscar from a file.
 

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -213,7 +213,7 @@ class Poscar(MSONable):
         1. If check_for_POTCAR is True, the code will try to check if a POTCAR
         is in the same directory as the POSCAR and use elements from that by
         default. (This is the VASP default sequence of priority).
-        2. If the input file is Vasp5-like and contains element symbols in the
+        2. If the input file is VASP5-like and contains element symbols in the
         6th line, the code will use that if check_for_POTCAR is False or there
         is no POTCAR found.
         3. Failing (2), the code will check if a symbol is provided at the end
@@ -261,7 +261,7 @@ class Poscar(MSONable):
         default names comes from an external source, such as a POTCAR in the
         same directory.
 
-        2. If there are no valid default names but the input file is Vasp5-like
+        2. If there are no valid default names but the input file is VASP5-like
         and contains element symbols in the 6th line, the code will use that.
 
         3. Failing (2), the code will check if a symbol is provided at the end
@@ -1721,7 +1721,7 @@ class PotcarSingle:
         """
         self.data = data  # raw POTCAR as a string
 
-        # Vasp parses header in vasprun.xml and this differs from the titel
+        # VASP parses header in vasprun.xml and this differs from the titel
         self.header = data.split("\n")[0].strip()
 
         search_lines = re.search(

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -4395,7 +4395,7 @@ def get_band_structure_from_vasp_multiple_branches(dir_name, efermi=None, projec
     "branch_x". If the run has not been divided in branches the method will
     turn to parsing vasprun.xml directly.
 
-    The method returns None is there"s a parsing error
+    The method returns None is there's a parsing error
 
     Args:
         dir_name: Directory containing all bandstructure runs.

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -157,7 +157,7 @@ class Vasprun(MSONable):
     Speedup over Dom is at least 2x for smallish files (~1Mb) to orders of
     magnitude for larger files (~10Mb).
 
-    **Vasp results**
+    **VASP results**
 
     .. attribute:: ionic_steps
 
@@ -263,7 +263,7 @@ class Vasprun(MSONable):
             }
         ]
 
-    **Vasp inputs**
+    **VASP inputs**
 
     .. attribute:: incar
 
@@ -1735,7 +1735,7 @@ class Outcar:
 
     .. attribute:: is_stopped
 
-        True if OUTCAR is from a stopped run (using STOPCAR, see Vasp Manual).
+        True if OUTCAR is from a stopped run (using STOPCAR, see VASP Manual).
 
     .. attribute:: run_stats
 

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -71,7 +71,7 @@ MODULE_DIR = Path(__file__).resolve().parent
 
 class VaspInputSet(MSONable, metaclass=abc.ABCMeta):
     """
-    Base class representing a set of Vasp input parameters with a structure
+    Base class representing a set of VASP input parameters with a structure
     supplied as init parameters. Typically, you should not inherit from this
     class. Start from DictSet or MPRelaxSet or MITRelaxSet.
     """
@@ -1210,8 +1210,8 @@ class MPStaticSet(MPRelaxSet):
     @classmethod
     def from_prev_calc(cls, prev_calc_dir, **kwargs):
         """
-        Generate a set of Vasp input files for static calculations from a
-        directory of previous Vasp run.
+        Generate a set of VASP input files for static calculations from a
+        directory of previous VASP run.
 
         Args:
             prev_calc_dir (str): Directory containing the outputs(
@@ -1312,8 +1312,8 @@ class MPScanStaticSet(MPScanRelaxSet):
     @classmethod
     def from_prev_calc(cls, prev_calc_dir, **kwargs):
         """
-        Generate a set of Vasp input files for static calculations from a
-        directory of previous Vasp run.
+        Generate a set of VASP input files for static calculations from a
+        directory of previous VASP run.
 
         Args:
             prev_calc_dir (str): Directory containing the outputs(
@@ -1489,8 +1489,8 @@ class MPHSEBSSet(MPHSERelaxSet):
     @classmethod
     def from_prev_calc(cls, prev_calc_dir, **kwargs):
         """
-        Generate a set of Vasp input files for HSE calculations from a
-        directory of previous Vasp run.
+        Generate a set of VASP input files for HSE calculations from a
+        directory of previous VASP run.
 
         Args:
             prev_calc_dir (str): Directory containing the outputs
@@ -1728,8 +1728,8 @@ class MPNonSCFSet(MPRelaxSet):
     @classmethod
     def from_prev_calc(cls, prev_calc_dir, **kwargs):
         """
-        Generate a set of Vasp input files for NonSCF calculations from a
-        directory of previous static Vasp run.
+        Generate a set of VASP input files for NonSCF calculations from a
+        directory of previous static VASP run.
 
         Args:
             prev_calc_dir (str): The directory contains the outputs(
@@ -1871,8 +1871,8 @@ class MPSOCSet(MPStaticSet):
     @classmethod
     def from_prev_calc(cls, prev_calc_dir, **kwargs):
         """
-        Generate a set of Vasp input files for SOC calculations from a
-        directory of previous static Vasp run. SOC calc requires all 3
+        Generate a set of VASP input files for SOC calculations from a
+        directory of previous static VASP run. SOC calc requires all 3
         components for MAGMOM for each atom in the structure.
 
         Args:
@@ -2140,8 +2140,8 @@ class MVLGWSet(DictSet):
     @classmethod
     def from_prev_calc(cls, prev_calc_dir, mode="DIAG", **kwargs):
         """
-        Generate a set of Vasp input files for GW or BSE calculations from a
-        directory of previous Exact Diag Vasp run.
+        Generate a set of VASP input files for GW or BSE calculations from a
+        directory of previous Exact Diag VASP run.
 
         Args:
             prev_calc_dir (str): The directory contains the outputs(
@@ -2907,7 +2907,7 @@ def get_structure_from_prev_run(vasprun, outcar=None):
 
     Returns:
         Returns the magmom-decorated structure that can be passed to get
-        Vasp input files, e.g. get_kpoints.
+        VASP input files, e.g. get_kpoints.
     """
     structure = vasprun.final_structure
 
@@ -3273,7 +3273,7 @@ class MPAbsorptionSet(MPRelaxSet):
     @classmethod
     def from_prev_calc(cls, prev_calc_dir, mode, **kwargs):
         """
-        Generate a set of Vasp input files for absorption calculation
+        Generate a set of VASP input files for absorption calculation
         Args:
             prev_calc_dir (str): The directory contains the outputs(
                 vasprun.xml of previous vasp run.

--- a/pymatgen/io/vasp/tests/test_inputs.py
+++ b/pymatgen/io/vasp/tests/test_inputs.py
@@ -37,7 +37,7 @@ class PoscarTest(PymatgenTest):
         comp = poscar.structure.composition
         self.assertEqual(comp, Composition("Fe4P4O16"))
 
-        # Vasp 4 type with symbols at the end.
+        # VASP 4 type with symbols at the end.
         poscar_string = """Test1
 1.0
 3.840198 0.000000 0.000000
@@ -54,7 +54,7 @@ direct
         poscar_string = ""
         self.assertRaises(ValueError, Poscar.from_string, poscar_string)
 
-        # Vasp 4 tyle file with default names, i.e. no element symbol found.
+        # VASP 4 tyle file with default names, i.e. no element symbol found.
         poscar_string = """Test2
 1.0
 3.840198 0.000000 0.000000
@@ -69,7 +69,7 @@ direct
             warnings.simplefilter("ignore")
             poscar = Poscar.from_string(poscar_string)
         self.assertEqual(poscar.structure.composition, Composition("HHe"))
-        # Vasp 4 tyle file with default names, i.e. no element symbol found.
+        # VASP 4 tyle file with default names, i.e. no element symbol found.
         poscar_string = """Test3
 1.0
 3.840198 0.000000 0.000000
@@ -237,7 +237,7 @@ direct
 
         self.assertEqual(str(poscar), expected_str, "Wrong POSCAR output!")
 
-        # Vasp 4 type with symbols at the end.
+        # VASP 4 type with symbols at the end.
         poscar_string = """Test1
 1.0
 -3.840198 0.000000 0.000000

--- a/pymatgen/symmetry/analyzer.py
+++ b/pymatgen/symmetry/analyzer.py
@@ -43,7 +43,7 @@ class SpacegroupAnalyzer:
     Uses spglib to perform various symmetry finding operations.
     """
 
-    def __init__(self, structure: Structure, symprec=0.01, angle_tolerance=5.0):
+    def __init__(self, structure: Structure, symprec: float = 0.01, angle_tolerance=5.0):
         """
         Args:
             structure (Structure/IStructure): Structure to find symmetry

--- a/pymatgen/symmetry/kpath.py
+++ b/pymatgen/symmetry/kpath.py
@@ -47,7 +47,7 @@ class KPathBase(metaclass=abc.ABCMeta):
     """
 
     @abc.abstractmethod
-    def __init__(self, structure: Structure, symprec=0.01, angle_tolerance=5, atol=1e-5, *args, **kwargs):
+    def __init__(self, structure: Structure, symprec: float = 0.01, angle_tolerance=5, atol=1e-5, *args, **kwargs):
         """
         Args:
         structure (Structure): Structure object.
@@ -153,7 +153,7 @@ class KPathSetyawanCurtarolo(KPathBase):
     are returned for the reciprocal cell basis defined in the paper.
     """
 
-    def __init__(self, structure: Structure, symprec=0.01, angle_tolerance=5, atol=1e-5):
+    def __init__(self, structure: Structure, symprec: float = 0.01, angle_tolerance=5, atol=1e-5):
         """
         Args:
         structure (Structure): Structure object.
@@ -952,7 +952,7 @@ class KPathSeek(KPathBase):
         get_path is not None,
         "SeeK-path needs to be installed to use the convention of Hinuma et al. (2015)",
     )
-    def __init__(self, structure: Structure, symprec=0.01, angle_tolerance=5, atol=1e-5, system_is_tri=True):
+    def __init__(self, structure: Structure, symprec: float = 0.01, angle_tolerance=5, atol=1e-5, system_is_tri=True):
         """
         Args:
             structure (Structure): Structure object

--- a/pymatgen/transformations/advanced_transformations.py
+++ b/pymatgen/transformations/advanced_transformations.py
@@ -686,7 +686,6 @@ class MagOrderingTransformation(AbstractTransformation):
         mag_species_occurrences = {}
         for site in disordered_structure:
             if not site.is_ordered:
-                op = max(site.species.values())
                 # this very hacky bit of code only works because we know
                 # that on disordered sites in this class, all species are the same
                 # but have different spins, and this is comma-delimited
@@ -694,6 +693,7 @@ class MagOrderingTransformation(AbstractTransformation):
                 if sp in mag_species_order_parameter:
                     mag_species_occurrences[sp] += 1
                 else:
+                    op = max(site.species.values())
                     mag_species_order_parameter[sp] = op
                     mag_species_occurrences[sp] = 1
 
@@ -827,14 +827,21 @@ class MagOrderingTransformation(AbstractTransformation):
         logger.debug(f"Structure with spin magnitudes:\n{structure}")
         return structure
 
-    def apply_transformation(self, structure: Structure, return_ranked_list=False):
-        """
-        Apply MagOrderTransformation to an input structure.
-        :param structure: Any ordered structure.
-        :param return_ranked_list: As in other Transformations.
-        :return:
-        """
+    def apply_transformation(
+        self, structure: Structure, return_ranked_list: bool | int = False
+    ) -> Structure | list[Structure]:
+        """Apply MagOrderTransformation to an input structure.
 
+        Args:
+            structure (Structure): Any ordered structure.
+            return_ranked_list (bool, optional): As in other Transformations. Defaults to False.
+
+        Raises:
+            ValueError: On disordered structures.
+
+        Returns:
+            Structure | list[Structure]: Structure(s) after MagOrderTransformation.
+        """
         if not structure.is_ordered:
             raise ValueError("Create an ordered approximation of your  input structure first.")
 
@@ -902,7 +909,7 @@ class MagOrderingTransformation(AbstractTransformation):
 
         self._all_structures = sorted(out, key=lambda d: d["energy"])
 
-        return self._all_structures[0:num_to_return]
+        return self._all_structures[0:num_to_return]  # type: ignore
 
     def __str__(self):
         return "MagOrderingTransformation"

--- a/pymatgen/transformations/standard_transformations.py
+++ b/pymatgen/transformations/standard_transformations.py
@@ -760,7 +760,7 @@ class ConventionalCellTransformation(AbstractTransformation):
     This class finds the conventional cell of the input structure.
     """
 
-    def __init__(self, symprec=0.01, angle_tolerance=5, international_monoclinic=True):
+    def __init__(self, symprec: float = 0.01, angle_tolerance=5, international_monoclinic=True):
         """
         Args:
             symprec (float): tolerance as in SpacegroupAnalyzer

--- a/pymatgen/util/convergence.py
+++ b/pymatgen/util/convergence.py
@@ -480,7 +480,7 @@ def multi_reciprocal_extra(xs, ys, noise=False):
     return fit_results[best[2]]["popt"], fit_results[best[2]]["pcov"], best
 
 
-def print_plot_line(function, popt, xs, ys, name, tol=0.05, extra=""):
+def print_plot_line(function, popt, xs, ys, name, tol: float = 0.05, extra=""):
     """
     print the gnuplot command line to plot the x, y data with the fitted function using the popt parameters
     """
@@ -516,7 +516,7 @@ def print_plot_line(function, popt, xs, ys, name, tol=0.05, extra=""):
         f.write("pause -1 \n")
 
 
-def determine_convergence(xs, ys, name, tol=0.0001, extra="", verbose=False, mode="extra", plots=True):
+def determine_convergence(xs, ys, name, tol: float = 0.0001, extra="", verbose=False, mode="extra", plots=True):
     """
     test it and at which x_value dy(x)/dx < tol for all x >= x_value, conv is true is such a x_value exists.
     """
@@ -539,7 +539,7 @@ def determine_convergence(xs, ys, name, tol=0.0001, extra="", verbose=False, mod
                         popt, pcov, func = multi_reciprocal_extra(xs, ys)
                     else:
                         print(xs, ys)
-                        popt, pcov = None, None
+                        popt, pcov = None, None  # type: ignore
                 elif mode == "extra_noise":
                     popt, pcov, func = multi_reciprocal_extra(xs, ys, noise=True)
                 else:
@@ -565,7 +565,7 @@ def determine_convergence(xs, ys, name, tol=0.0001, extra="", verbose=False, mod
                     print_plot_line(func[0], popt, xs, ys, name, tol=tol, extra=extra)
 
         except ImportError:
-            popt, pcov = None, None
+            popt, pcov = None, None  # type: ignore
         for n in range(0, len(ds), 1):
             if verbose:
                 print(n, ys[n])

--- a/pymatgen/vis/structure_vtk.py
+++ b/pymatgen/vis/structure_vtk.py
@@ -55,7 +55,7 @@ class StructureVis:
             element_color_mapping: Optional color mapping for the elements,
                 as a dict of {symbol: rgb tuple}. For example, {"Fe": (255,
                 123,0), ....} If None is specified, a default based on
-                Jmol"s color scheme is used.
+                Jmol's color scheme is used.
             show_unit_cell: Set to False to not show the unit cell
                 boundaries. Defaults to True.
             show_bonds: Set to True to show bonds. Defaults to True.
@@ -967,7 +967,7 @@ class MultiStructuresVis(StructureVis):
             element_color_mapping: Optional color mapping for the elements,
                 as a dict of {symbol: rgb tuple}. For example, {"Fe": (255,
                 123,0), ....} If None is specified, a default based on
-                Jmol"s color scheme is used.
+                Jmol's color scheme is used.
             show_unit_cell: Set to False to not show the unit cell
                 boundaries. Defaults to True.
             show_bonds: Set to True to show bonds. Defaults to True.

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,3 +53,10 @@ ignore_missing_imports = True
 
 [mypy-requests.*]
 ignore_missing_imports = True
+
+[autoflake]
+in-place = True
+remove-unused-variables = True
+remove-all-unused-imports = True
+expand-star-imports = True
+ignore-init-module-imports = True


### PR DESCRIPTION
Closes #2070.

This PR fixes the `AttributeError` currently raised when passing disordered structures to methods like `get_cn()` and `get_bonded_structure()` of `CrystalNN` and other `NearNeighbors` subclasses.

Several open questions:
1. I added a helper function `_handle_disorder(structure: Structure, on_disorder: Literal["take majority", "error"])` that's reused in multiple places since there doesn't appear to be one central place where disordered structures can be ordered by taking majority species from each site for all downstream processing like @mkhorton [suggested](https://github.com/materialsproject/pymatgen/issues/2070#issuecomment-782239047).
2. What should the options for the `on_disorder` kwarg be? Is `"take majority"` and `"error"` ok?
3. Perhaps most important @shyuep @mkhorton: What should the default for `on_disorder` be? I chose `'take majority'` to avoid new people encountering issues like #2070 but safer and less backward incompatible change would be `'error'`.

I added tests that check both the error case and `'take majority'` case to make sure we no longer raise a generic `AttributeError` without a clear explanation of why it's not working.