### PR TITLE
Fix deprecation warning on scipy gaussian_filter1d function

### DIFF
--- a/pymatgen/electronic_structure/dos.py
+++ b/pymatgen/electronic_structure/dos.py
@@ -234,7 +234,7 @@ class Dos(MSONable):
         Returns:
             Dict of Gaussian-smeared densities.
         """
-        from scipy.ndimage.filters import gaussian_filter1d
+        from scipy.ndimage import gaussian_filter1d
 
         smeared_dens = {}
         diff = [self.energies[i + 1] - self.energies[i] for i in range(len(self.energies) - 1)]


### PR DESCRIPTION
I changed
```python
from scipy.ndimage.filters import gaussian_filter1d
```
to
```python
from scipy.ndimage import gaussian_filter1d
```
in `pymatgen.electronic_structure.dos` since the former is deprecated.