### PR TITLE
Fix circular import

### DIFF
--- a/pymatgen/util/coord.py
+++ b/pymatgen/util/coord.py
@@ -6,16 +6,20 @@ Utilities for manipulating coordinates or list of coordinates, under periodic
 boundary conditions or otherwise. Many of these are heavily vectorized in
 numpy for performance.
 """
+from __future__ import annotations
 
 import itertools
 import math
-from typing import Tuple
+import typing
 
 import numpy as np
 from monty.json import MSONable
 
 from pymatgen.util import coord_cython as cuc
-from pymatgen.util.typing import ArrayLike
+
+if typing.TYPE_CHECKING:
+    from pymatgen.util.typing import ArrayLike
+
 
 # array size threshold for looping instead of broadcasting
 LOOP_THRESHOLD = 1e6
@@ -161,7 +165,7 @@ def all_distances(coords1, coords2):
     return np.sum(z, axis=-1) ** 0.5
 
 
-def pbc_diff(fcoords1: ArrayLike, fcoords2: ArrayLike, pbc: Tuple[bool, bool, bool] = (True, True, True)):
+def pbc_diff(fcoords1: ArrayLike, fcoords2: ArrayLike, pbc: tuple[bool, bool, bool] = (True, True, True)):
     """
     Returns the 'fractional distance' between two coordinates taking into
     account periodic boundary conditions.


### PR DESCRIPTION
Fixes #2632 

Importing pbc_diff directly fails due to a circular import. This doesn't seem to impact the code or tests since other modules are imported first. E.g. running the following works fine:

```python
from pymatgen.core import Composition
from pymatgen.util.coord import pbc_diff
```

The issue arrises because the `pymatgen.util.coord` module imports `ArrayLike` from `pymatgen.util.typing` for type hinting. This module in turn imports `Composition` which then tries to import `pbc_shortest_vectors` thus creating the circular import.

This PR avoids the issue by using postponed annotations and the `TYPE_CHECKING` constant. See: https://peps.python.org/pep-0563/

Unfortunately, I can't add a test as the bug is very specific to the order imports occur which is outside the control of a specific test. 