### PR TITLE
store bond keys of ICOHP in graph edge prop

### DIFF
--- a/pymatgen/io/lobster/lobsterenv.py
+++ b/pymatgen/io/lobster/lobsterenv.py
@@ -788,7 +788,7 @@ class LobsterNeighbors(NearNeighbors):
                         "edge_properties": {
                             "ICOHP": self.list_icohps[ineighbors][ineighbor],
                             "bond_length": self.list_lengths[ineighbors][ineighbor],
-                            "ICOHP_bond_key": self.list_keys[ineighbors][ineighbor],
+                            "bond_label": self.list_keys[ineighbors][ineighbor],
                             self.id_blist_sg1.upper(): self.bonding_list_1.icohpcollection.get_icohp_by_label(
                                 self.list_keys[ineighbors][ineighbor]
                             ),
@@ -826,7 +826,7 @@ class LobsterNeighbors(NearNeighbors):
                         "edge_properties": {
                             "ICOHP": self.list_icohps[ineighbors][ineighbor],
                             "bond_length": self.list_lengths[ineighbors][ineighbor],
-                            "ICOHP_bond_key": self.list_keys[ineighbors][ineighbor],
+                            "bond_label": self.list_keys[ineighbors][ineighbor],
                         },
                         "site_index": [
                             isite for isite, site in enumerate(self.structure) if neighbor.is_periodic_image(site)

--- a/pymatgen/io/lobster/lobsterenv.py
+++ b/pymatgen/io/lobster/lobsterenv.py
@@ -788,6 +788,7 @@ class LobsterNeighbors(NearNeighbors):
                         "edge_properties": {
                             "ICOHP": self.list_icohps[ineighbors][ineighbor],
                             "bond_length": self.list_lengths[ineighbors][ineighbor],
+                            "ICOHP_bond_key": self.list_keys[ineighbors][ineighbor],
                             self.id_blist_sg1.upper(): self.bonding_list_1.icohpcollection.get_icohp_by_label(
                                 self.list_keys[ineighbors][ineighbor]
                             ),
@@ -825,6 +826,7 @@ class LobsterNeighbors(NearNeighbors):
                         "edge_properties": {
                             "ICOHP": self.list_icohps[ineighbors][ineighbor],
                             "bond_length": self.list_lengths[ineighbors][ineighbor],
+                            "ICOHP_bond_key": self.list_keys[ineighbors][ineighbor],
                         },
                         "site_index": [
                             isite for isite, site in enumerate(self.structure) if neighbor.is_periodic_image(site)

--- a/pymatgen/io/lobster/tests/test_lobsterenv.py
+++ b/pymatgen/io/lobster/tests/test_lobsterenv.py
@@ -544,6 +544,8 @@ class TestLobsterNeighbors(unittest.TestCase):
         self.assertAlmostEqual(sg.graph.get_edge_data(0, 1)[0]["ICOHP"], -0.56541)
         self.assertAlmostEqual(sg.graph.get_edge_data(0, 1)[0]["ICOBI"], 0.08484)
         self.assertAlmostEqual(sg.graph.get_edge_data(0, 1)[0]["ICOOP"], 0.02826)
+        self.assertAlmostEqual(sg.graph.get_edge_data(0, 1)[0]["bond_label"], '21')
+        self.assertAlmostEqual(sg.graph.get_edge_data(0, 1)[5]["bond_label"], '30')
         self.assertEqual(type(sg), StructureGraph)
 
     def test_raises_extended_structure_graph(self):

--- a/pymatgen/io/lobster/tests/test_lobsterenv.py
+++ b/pymatgen/io/lobster/tests/test_lobsterenv.py
@@ -544,8 +544,8 @@ class TestLobsterNeighbors(unittest.TestCase):
         self.assertAlmostEqual(sg.graph.get_edge_data(0, 1)[0]["ICOHP"], -0.56541)
         self.assertAlmostEqual(sg.graph.get_edge_data(0, 1)[0]["ICOBI"], 0.08484)
         self.assertAlmostEqual(sg.graph.get_edge_data(0, 1)[0]["ICOOP"], 0.02826)
-        self.assertAlmostEqual(sg.graph.get_edge_data(0, 1)[0]["bond_label"], '21')
-        self.assertAlmostEqual(sg.graph.get_edge_data(0, 1)[5]["bond_label"], '30')
+        self.assertAlmostEqual(sg.graph.get_edge_data(0, 1)[0]["bond_label"], "21")
+        self.assertAlmostEqual(sg.graph.get_edge_data(0, 1)[5]["bond_label"], "30")
         self.assertEqual(type(sg), StructureGraph)
 
     def test_raises_extended_structure_graph(self):


### PR DESCRIPTION
## Summary

Minor addition to Lobster graph edge properties

* Store ICOHPlist bond key in graph edge properties. Helps in getting further information from 'Lobsterpy' package
