### PR TITLE
Fix descriptions in external tools

### DIFF
--- a/docs_rst/addons.rst
+++ b/docs_rst/addons.rst
@@ -42,7 +42,7 @@ External Tools
 If you would like your own tool to be listed here, please `submit a PR <https://github.com/materialsproject/pymatgen/edit/master/docs_rst/addons.rst>`_! For a more complete but less curated list, have a
 look at `pymatgen dependents <https://github.com/materialsproject/pymatgen/network/dependents>`_.
 
-* `QuAcc <https://github.com/JaGeo/LobsterPy>`_: A platform to enable high-throughput, database-driven quantum
+* `QuAcc <https://github.com/arosen93/quacc>`_: A platform to enable high-throughput, database-driven quantum
   chemistry and computational materials science.
 
 * `LobsterPy <https://github.com/JaGeo/LobsterPy>`_: Automatically analyze Lobster (<http://www.cohp.de>) runs.

--- a/docs_rst/addons.rst
+++ b/docs_rst/addons.rst
@@ -42,10 +42,10 @@ External Tools
 If you would like your own tool to be listed here, please `submit a PR <https://github.com/materialsproject/pymatgen/edit/master/docs_rst/addons.rst>`_! For a more complete but less curated list, have a
 look at `pymatgen dependents <https://github.com/materialsproject/pymatgen/network/dependents>`_.
 
-* `QuAcc <https://github.com/JaGeo/LobsterPy>`_: Automatically analyze Lobster runs.
-
-* `LobsterPy <https://github.com/JaGeo/LobsterPy>`_: A platform to enable high-throughput, database-driven quantum
+* `QuAcc <https://github.com/JaGeo/LobsterPy>`_: A platform to enable high-throughput, database-driven quantum
   chemistry and computational materials science.
+
+* `LobsterPy <https://github.com/JaGeo/LobsterPy>`_: Automatically analyze Lobster (<http://www.cohp.de>) runs.
 
 * `pymatviz <https://github.com/janosh/pymatviz>`_: Complements ``pymatgen`` with additional plotting
   functionality for larger datasets common in materials informatics.

--- a/docs_rst/addons.rst
+++ b/docs_rst/addons.rst
@@ -45,7 +45,7 @@ look at `pymatgen dependents <https://github.com/materialsproject/pymatgen/netwo
 * `QuAcc <https://github.com/arosen93/quacc>`_: A platform to enable high-throughput, database-driven quantum
   chemistry and computational materials science.
 
-* `LobsterPy <https://github.com/JaGeo/LobsterPy>`_: Automatically analyze Lobster (<http://www.cohp.de>) runs.
+* `LobsterPy <https://github.com/JaGeo/LobsterPy>`_: Automatically analyze Lobster (http://www.cohp.de) runs.
 
 * `pymatviz <https://github.com/janosh/pymatviz>`_: Complements ``pymatgen`` with additional plotting
   functionality for larger datasets common in materials informatics.


### PR DESCRIPTION
## Summary

Descriptions of the external tools got mixed up. Switched the LobsterPy and the QuAcc description. 