### PR TITLE
improve outcar parsing

### DIFF
--- a/pymatgen/io/vasp/tests/test_outputs.py
+++ b/pymatgen/io/vasp/tests/test_outputs.py
@@ -1543,6 +1543,34 @@ class OutcarTest(PymatgenTest):
         self.assertAlmostEqual(o.final_energy_wo_entrp, -15.83863167)
         self.assertAlmostEqual(o.final_fr_energy, -15.92115453)
 
+    def test_read_table_pattern(self):
+        outcar = Outcar(self.TEST_FILES_DIR / "OUTCAR")
+
+        header_pattern = r"\(the norm of the test charge is\s+[\.\-\d]+\)"
+        table_pattern = r"((?:\s+\d+\s*[\.\-\d]+)+)"
+        footer_pattern = r"\s+E-fermi :"
+
+        pots = outcar.read_table_pattern(header_pattern, table_pattern, footer_pattern, last_one_only=True)
+        ref_last = [
+            ["       1 -26.0704       2 -45.5046       3 -45.5046       4 -72.9539       5 -73.0621"],
+            ["       6 -72.9539       7 -73.0621"],
+        ]
+        self.assertEqual(pots, ref_last)
+
+        pots = outcar.read_table_pattern(
+            header_pattern, table_pattern, footer_pattern, last_one_only=False, first_one_only=True
+        )
+        ref_first = [
+            ["       1 -26.1149       2 -45.5359       3 -45.5359       4 -72.9831       5 -73.1068"],
+            ["       6 -72.9831       7 -73.1068"],
+        ]
+        self.assertEqual(pots, ref_first)
+
+        with self.assertRaises(ValueError):
+            outcar.read_table_pattern(
+                header_pattern, table_pattern, footer_pattern, last_one_only=True, first_one_only=True
+            )
+
 
 class BSVasprunTest(PymatgenTest):
     _multiprocess_shared_ = True


### PR DESCRIPTION
## Summary

While parsing a large OUTCAR file coming from an MD simulation I realized that a lot of time was taken by the `read_table_pattern` to extract the number of plane waves for kpoints. The quantitiy appears early in the file, but for very long simulations the execution of the regex on the rest of the file can be very slow and pointless. 

I added the option to stop the parsing of the table patterns at the first occurence and used it for the case of the plane waves.
