### PR TITLE
Fix GitHub language calculation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
-test_files/* linguist-vendored
+# declare HTML, rST and test files as vendored/docs to exclude them when calculating repo languages on GitHub
+**/test_files/* linguist-vendored
 cmd_line/* linguist-vendored
-docs/* linguist-documentation
-docs_rst/* linguist-documentation
+docs/**/* linguist-documentation
+docs_rst/**/* linguist-documentation

--- a/pymatgen/optimization/neighbors.pyx
+++ b/pymatgen/optimization/neighbors.pyx
@@ -7,8 +7,6 @@
 # distutils: language = c
 # distutils: define_macros=NPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION
 
-from __future__ import print_function
-
 import numpy as np
 
 cimport numpy as np
@@ -43,7 +41,7 @@ def find_points_in_spheres(double[:, ::1] all_coords, double[:, ::1] center_coor
                            double tol=1e-8, float min_r=1.0):
     """
     For each point in `center_coords`, get all the neighboring points in `all_coords` that are within the
-    cutoff radius `r`. All the coordinates should be in cartesian.
+    cutoff radius `r`. All the coordinates should be in Cartesian.
 
     Args:
         all_coords: (np.ndarray[double, dim=2]) all available points. When periodic boundary is considered,


### PR DESCRIPTION
The paths in `.gitattributes` work the same as in `.gitignore`. So to exclude HTML, rST and test files from the GitHub language calculation, were currently missing a few wildcards to include more deeply nested files.

This change should turn the language composition bar into almost pure Python (once GH had time to recompute).

<img src="https://user-images.githubusercontent.com/30958850/190055014-63ba1975-dbc3-4391-b5bb-3d724ee956cc.png" alt="Screen Shot 2022-09-13 at 20 44 39" width=300 >

Related https://github.com/materialsproject/atomate2/pull/148.