### PR TITLE
Fix GitHub language statistics - take 2

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 # declare HTML, rST and test files as vendored/docs to exclude them when calculating repo languages on GitHub
-**/test_files/* linguist-vendored
+**/test_files/**/* linguist-vendored
 cmd_line/* linguist-vendored
-docs/**/* linguist-documentation
+docs/**/* linguist-generated
 docs_rst/**/* linguist-documentation
+dev_scripts/**/* linguist-vendored

--- a/pymatgen/analysis/path_finder.py
+++ b/pymatgen/analysis/path_finder.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import logging
 import math
 import warnings
-from abc import ABCMeta
 
 import numpy as np
 import numpy.linalg as la
@@ -311,7 +310,7 @@ class NEBPathfinder:
         )
 
 
-class StaticPotential(metaclass=ABCMeta):
+class StaticPotential:
     """
     Defines a general static potential for diffusion calculations. Implements
     grid-rescaling and smearing for the potential grid. Also provides a

--- a/pymatgen/cli/pmg_analyze.py
+++ b/pymatgen/cli/pmg_analyze.py
@@ -99,20 +99,20 @@ def get_energies(rootdir, reanalyze, verbose, quick, sort, fmt):
     return 0
 
 
-def get_magnetizations(mydir, ion_list):
+def get_magnetizations(dir: str, ion_list: list[int]):
     """
     Get magnetization info from OUTCARs.
 
     Args:
         mydir (str): Directory name
-        ion_list (List): List of ions to obtain magnetization information for.
+        ion_list (list[int]): List of ions to obtain magnetization information for.
 
     Returns:
-
+        int: 0 if successful.
     """
     data = []
     max_row = 0
-    for (parent, subdirs, files) in os.walk(mydir):
+    for (parent, _subdirs, files) in os.walk(dir):
         for f in files:
             if re.match(r"OUTCAR*", f):
                 try:

--- a/pymatgen/electronic_structure/boltztrap2.py
+++ b/pymatgen/electronic_structure/boltztrap2.py
@@ -534,9 +534,9 @@ class BztInterpolator:
         if isinstance(kpaths, list) and isinstance(kpoints_lbls_dict, dict):
             kpoints = []
             for kpath in kpaths:
-                for i, k in enumerate(kpath[:-1]):
-                    sta = kpoints_lbls_dict[kpath[i]]
-                    end = kpoints_lbls_dict[kpath[i + 1]]
+                for idx, k_pt in enumerate(kpath[:-1]):
+                    sta = kpoints_lbls_dict[k_pt]
+                    end = kpoints_lbls_dict[kpath[idx + 1]]
                     kpoints.append(np.linspace(sta, end, density))
             kpoints = np.concatenate(kpoints)
         else:

--- a/pymatgen/entries/mixing_scheme.py
+++ b/pymatgen/entries/mixing_scheme.py
@@ -61,7 +61,7 @@ class MaterialsProjectDFTMixingScheme(Compatibility):
     ):
         """
         Instantiate the mixing scheme. The init method creates a generator class that
-        contains relevant settings (e.g., StrutureMatcher instance, Compatibility settings
+        contains relevant settings (e.g., StructureMatcher instance, Compatibility settings
         for each functional) for processing groups of entries.
 
         Args:

--- a/pymatgen/symmetry/bandstructure.py
+++ b/pymatgen/symmetry/bandstructure.py
@@ -119,7 +119,7 @@ class HighSymmKpath(KPathBase):
             self._path_lengths = []
 
             for bs in [lm_bs, sc_bs, hin_bs]:
-                for key, value in enumerate(bs.kpath["kpoints"]):
+                for value in bs.kpath["kpoints"]:
                     cat_points[index] = bs.kpath["kpoints"][value]
                     label_index[index] = value
                     index += 1
@@ -259,7 +259,7 @@ class HighSymmKpath(KPathBase):
             for o_num in range(0, n_op):
                 a_tr_coord = []
 
-                for (label_a, coord_a) in a_path["kpoints"].items():
+                for coord_a in a_path["kpoints"].values():
                     a_tr_coord.append(np.dot(rpg[o_num], coord_a))
 
                 for coord_a in a_tr_coord:

--- a/pymatgen/symmetry/tests/test_groups.py
+++ b/pymatgen/symmetry/tests/test_groups.py
@@ -22,7 +22,7 @@ class PointGroupTest(unittest.TestCase):
         order = {"mmm": 8, "432": 24, "-6m2": 12}
         for k, v in order.items():
             pg = PointGroup(k)
-            self.assertEqual(order[k], len(pg.symmetry_ops))
+            self.assertEqual(v, len(pg.symmetry_ops))
 
     def test_get_orbit(self):
         pg = PointGroup("mmm")


### PR DESCRIPTION
I missed a few large HTML and test files in #2651:

```txt
dev_scripts/NIST Atomic Ionization Energies Output.html
test_files/cohp/bandOverlaps.lobster.1
test_files/cohp/bandOverlaps.lobster.2
test_files/cohp/bandOverlaps.lobster.new.1
test_files/cohp/bandOverlaps.lobster.new.2
test_files/cohp/lobsterin.1
test_files/cohp/lobsterin.2
test_files/cohp/lobsterin.3
```

Yet more wildcards in `.gitattributes` to the rescue.

One interesting thing I learned it that linguist overrides do not change how files are treated when performing a repo search for a specific language. E.g. using language qualifier `l=roff` will still return those files in the search results, even though they are treated as vendored by linguist.