### PR TITLE
write charge if set

### DIFF
--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -1173,11 +1173,10 @@ class Vasprun(MSONable):
                 potcar_nelect = sum(ps.ZVAL * num for ps, num in zip(potcar, nums))
             charge = potcar_nelect - nelect
 
-            if charge:
-                for s in self.structures:
-                    s._charge = charge
-                self.final_structure._charge = charge
-                self.initial_structure._charge = charge
+            for s in self.structures:
+                s._charge = charge
+            self.final_structure._charge = charge
+            self.initial_structure._charge = charge
 
     def as_dict(self):
         """


### PR DESCRIPTION
## Set the structure charge

Currently, the `_structure._charge` is `None` if the charge was determined to be 0.  If we ensure that the `_charge` parameter is always set, then we can use the check
```
_structure._charge is None
```
To figure out if the charge was properly read from the POTCAR files.
This allows some downstream logic for parsing charged defect outputs to be much easier.