### PR TITLE
change equality comparison operation to `as_dict`

### DIFF
--- a/pymatgen/io/core.py
+++ b/pymatgen/io/core.py
@@ -157,7 +157,7 @@ class InputSet(MSONable, MutableMapping):
         del self.inputs[key]
 
     def __eq__(self, other):
-        return (self.inputs == other.inputs) and (self.__dict__ == other.__dict__)
+        return self.as_dict() == other.as_dict()
 
     def write_input(
         self,


### PR DESCRIPTION
## Summary

The current equality operation for InputSet's will fail if `InputSet.inputs` has mutable values. This happens often because InputSet is designed to support `InputFile`s as `inputs`. I have changed the equality operation to use `as_dict` which will coerce all nested elements to immutable types, enabling easier comparison. Would love a final look from @rkingsbury to make sure this makes sense.

This follows up on a previous issue I raised where the equality operation was failing entirely. 