### PR TITLE
Extension ThermalDisplacementMatrices class

### DIFF
--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -615,12 +615,7 @@ class CifParser:
         """
         try:
 
-            lengths = [str2float(data["_cell_length_" + i]) for i in length_strings]
-            angles = [str2float(data["_cell_angle_" + i]) for i in angle_strings]
-            if not lattice_type:
-                return Lattice.from_parameters(*lengths, *angles)
-
-            return getattr(Lattice, lattice_type)(*(lengths + angles))
+            return self.get_lattice_no_exception(angle_strings, data, lattice_type, length_strings)
 
         except KeyError:
             # Missing Key search for cell setting
@@ -644,6 +639,18 @@ class CifParser:
                 else:
                     return None
         return None
+
+    @staticmethod
+    def get_lattice_no_exception(data,
+                          length_strings=("a", "b", "c"),
+        angle_strings=("alpha", "beta", "gamma"),
+        lattice_type=None):
+        """ Will use usual strings to get lattice"""
+        lengths = [str2float(data["_cell_length_" + i]) for i in length_strings]
+        angles = [str2float(data["_cell_angle_" + i]) for i in angle_strings]
+        if not lattice_type:
+            return Lattice.from_parameters(*lengths, *angles)
+        return getattr(Lattice, lattice_type)(*(lengths + angles))
 
     def get_symops(self, data):
         """

--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -615,7 +615,7 @@ class CifParser:
         """
         try:
 
-            return self.get_lattice_no_exception(angle_strings, data, lattice_type, length_strings)
+            return self.get_lattice_no_exception(data=data, angle_strings=angle_strings,lattice_type=lattice_type, length_strings=length_strings)
 
         except KeyError:
             # Missing Key search for cell setting
@@ -645,7 +645,17 @@ class CifParser:
                           length_strings=("a", "b", "c"),
         angle_strings=("alpha", "beta", "gamma"),
         lattice_type=None):
-        """ Will use usual strings to get lattice"""
+        """
+        Generate the lattice from the provided lattice parameters.
+        Args:
+            data:
+            length_strings:
+            angle_strings:
+            lattice_type:
+
+        Returns:
+
+        """
         lengths = [str2float(data["_cell_length_" + i]) for i in length_strings]
         angles = [str2float(data["_cell_angle_" + i]) for i in angle_strings]
         if not lattice_type:

--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -615,7 +615,9 @@ class CifParser:
         """
         try:
 
-            return self.get_lattice_no_exception(data=data, angle_strings=angle_strings,lattice_type=lattice_type, length_strings=length_strings)
+            return self.get_lattice_no_exception(
+                data=data, angle_strings=angle_strings, lattice_type=lattice_type, length_strings=length_strings
+            )
 
         except KeyError:
             # Missing Key search for cell setting
@@ -641,10 +643,9 @@ class CifParser:
         return None
 
     @staticmethod
-    def get_lattice_no_exception(data,
-                          length_strings=("a", "b", "c"),
-        angle_strings=("alpha", "beta", "gamma"),
-        lattice_type=None):
+    def get_lattice_no_exception(
+        data, length_strings=("a", "b", "c"), angle_strings=("alpha", "beta", "gamma"), lattice_type=None
+    ):
         """
         Generate the lattice from the provided lattice parameters.
         Args:

--- a/pymatgen/phonon/tests/test_thermal_displacements.py
+++ b/pymatgen/phonon/tests/test_thermal_displacements.py
@@ -291,23 +291,24 @@ class ThermalDisplacementTest(PymatgenTest):
     def test_ratio_prolate(self):
         self.assertAlmostEqual(self.thermal.ratio_prolate[0], 6.854889e-03 / 2.893872e-03)
 
-
-
     def test_to_structure_with_site_properties(self):
         # test creation of structure with site properties
-        structure=self.thermal.to_structure_with_site_properties_Ucif()
+        structure = self.thermal.to_structure_with_site_properties_Ucif()
         # test reading of structure with site properties
-        new_thermals=ThermalDisplacementMatrices.from_structure_with_site_properties_Ucif(structure)
-        self.assertArrayAlmostEqual(self.thermal.thermal_displacement_matrix_cart,
-                                    new_thermals.thermal_displacement_matrix_cart)
-        self.assertArrayAlmostEqual(self.thermal.structure.frac_coords,new_thermals.structure.frac_coords)
-        self.assertArrayAlmostEqual(self.thermal.structure.lattice.volume,new_thermals.structure.lattice.volume)
+        new_thermals = ThermalDisplacementMatrices.from_structure_with_site_properties_Ucif(structure)
+        self.assertArrayAlmostEqual(
+            self.thermal.thermal_displacement_matrix_cart, new_thermals.thermal_displacement_matrix_cart
+        )
+        self.assertArrayAlmostEqual(self.thermal.structure.frac_coords, new_thermals.structure.frac_coords)
+        self.assertArrayAlmostEqual(self.thermal.structure.lattice.volume, new_thermals.structure.lattice.volume)
 
     def test_visualization_directionality_criterion(self):
         # test file creation for VESTA
         printed = False
         with tempfile.TemporaryDirectory() as tmpdirname:
-            self.thermal.visualize_directionality_quality_criterion(filename=os.path.join(tmpdirname, "U.vesta"), other=self.thermal,which_structure=0)
+            self.thermal.visualize_directionality_quality_criterion(
+                filename=os.path.join(tmpdirname, "U.vesta"), other=self.thermal, which_structure=0
+            )
             with open(os.path.join(tmpdirname, "U.vesta")) as file:
                 file.seek(0)  # set position to start of file
                 lines = file.read().splitlines()  # now we won't have those newlines
@@ -319,9 +320,7 @@ class ThermalDisplacementTest(PymatgenTest):
 
         with tempfile.TemporaryDirectory() as tmpdirname:
             self.thermal.write_cif(os.path.join(tmpdirname, "U.cif"))
-            new_thermals=ThermalDisplacementMatrices.from_cif_P1(os.path.join(tmpdirname, "U.cif"))
-            self.assertArrayAlmostEqual(new_thermals[0].thermal_displacement_matrix_cif_matrixform,
-                                        self.thermal.Ucif)
-            self.assertArrayAlmostEqual(new_thermals[0].structure.frac_coords,self.thermal.structure.frac_coords)
-            self.assertArrayAlmostEqual(new_thermals[0].structure.lattice.volume,self.thermal.structure.lattice.volume)
-
+            new_thermals = ThermalDisplacementMatrices.from_cif_P1(os.path.join(tmpdirname, "U.cif"))
+            self.assertArrayAlmostEqual(new_thermals[0].thermal_displacement_matrix_cif_matrixform, self.thermal.Ucif)
+            self.assertArrayAlmostEqual(new_thermals[0].structure.frac_coords, self.thermal.structure.frac_coords)
+            self.assertArrayAlmostEqual(new_thermals[0].structure.lattice.volume, self.thermal.structure.lattice.volume)

--- a/pymatgen/phonon/tests/test_thermal_displacements.py
+++ b/pymatgen/phonon/tests/test_thermal_displacements.py
@@ -290,3 +290,38 @@ class ThermalDisplacementTest(PymatgenTest):
 
     def test_ratio_prolate(self):
         self.assertAlmostEqual(self.thermal.ratio_prolate[0], 6.854889e-03 / 2.893872e-03)
+
+
+
+    def test_to_structure_with_site_properties(self):
+        # test creation of structure with site properties
+        structure=self.thermal.to_structure_with_site_properties_Ucif()
+        # test reading of structure with site properties
+        new_thermals=ThermalDisplacementMatrices.from_structure_with_site_properties_Ucif(structure)
+        self.assertArrayAlmostEqual(self.thermal.thermal_displacement_matrix_cart,
+                                    new_thermals.thermal_displacement_matrix_cart)
+        self.assertArrayAlmostEqual(self.thermal.structure.frac_coords,new_thermals.structure.frac_coords)
+        self.assertArrayAlmostEqual(self.thermal.structure.lattice.volume,new_thermals.structure.lattice.volume)
+
+    def test_visualization_directionality_criterion(self):
+        # test file creation for VESTA
+        printed = False
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            self.thermal.visualize_directionality_quality_criterion(filename=os.path.join(tmpdirname, "U.vesta"), other=self.thermal,which_structure=0)
+            with open(os.path.join(tmpdirname, "U.vesta")) as file:
+                file.seek(0)  # set position to start of file
+                lines = file.read().splitlines()  # now we won't have those newlines
+                if "VECTR" in lines:
+                    printed = True
+        self.assertTrue(printed)
+
+    def test_from_cif_P1(self):
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            self.thermal.write_cif(os.path.join(tmpdirname, "U.cif"))
+            new_thermals=ThermalDisplacementMatrices.from_cif_P1(os.path.join(tmpdirname, "U.cif"))
+            self.assertArrayAlmostEqual(new_thermals[0].thermal_displacement_matrix_cif_matrixform,
+                                        self.thermal.Ucif)
+            self.assertArrayAlmostEqual(new_thermals[0].structure.frac_coords,self.thermal.structure.frac_coords)
+            self.assertArrayAlmostEqual(new_thermals[0].structure.lattice.volume,self.thermal.structure.lattice.volume)
+

--- a/pymatgen/phonon/thermal_displacements.py
+++ b/pymatgen/phonon/thermal_displacements.py
@@ -535,20 +535,7 @@ class ThermalDisplacementMatrices(MSONable):
                 if not symbol:
                     continue
 
-                if oxi_states is not None:
-                    o_s = oxi_states.get(symbol, 0)
-                    # use _atom_site_type_symbol if possible for oxidation state
-                    if "_atom_site_type_symbol" in data.data:
-                        oxi_symbol = data["_atom_site_type_symbol"][i]
-                        o_s = oxi_states.get(oxi_symbol, o_s)
-                    try:
-                        el = Species(symbol, o_s)
-                    except Exception:
-                        el = DummySpecies(symbol, o_s)
-                else:
-                    el = Species(get_el_sp(symbol))
-
-                allspecies.append(el)
+                allspecies.append(symbol)
                 x = str2float(data["_atom_site_fract_x"][i])
                 y = str2float(data["_atom_site_fract_y"][i])
                 z = str2float(data["_atom_site_fract_z"][i])

--- a/pymatgen/phonon/thermal_displacements.py
+++ b/pymatgen/phonon/thermal_displacements.py
@@ -9,7 +9,6 @@ import numpy as np
 from monty.json import MSONable
 
 from pymatgen.analysis.structure_matcher import StructureMatcher
-from pymatgen.core.structure import Structure
 from pymatgen.io.cif import CifWriter
 
 try:

--- a/pymatgen/phonon/thermal_displacements.py
+++ b/pymatgen/phonon/thermal_displacements.py
@@ -546,7 +546,7 @@ class ThermalDisplacementMatrices(MSONable):
                     except Exception:
                         el = DummySpecies(symbol, o_s)
                 else:
-                    el = get_el_sp(symbol)
+                    el = Species(get_el_sp(symbol))
 
                 allspecies.append(el)
                 x = str2float(data["_atom_site_fract_x"][i])

--- a/pymatgen/phonon/thermal_displacements.py
+++ b/pymatgen/phonon/thermal_displacements.py
@@ -478,7 +478,7 @@ class ThermalDisplacementMatrices(MSONable):
             properties
             temperature: temperature for Ucif data
 
-        Returns: ThermalDisplacementMatrices object
+        Returns: ThermalDisplacementMatrices Object.
 
         """
         Ucif_matrix = []

--- a/pymatgen/phonon/thermal_displacements.py
+++ b/pymatgen/phonon/thermal_displacements.py
@@ -6,15 +6,12 @@ This module provides classes to handle thermal displacement matrices (anisotropi
 """
 
 import re
-from collections import deque
 from functools import partial
-from inspect import getfullargspec as getargspec
 
 import numpy as np
 from monty.json import MSONable
 
 from pymatgen.analysis.structure_matcher import StructureMatcher
-from pymatgen.core.periodic_table import DummySpecies, Species, get_el_sp
 from pymatgen.core.structure import Structure
 from pymatgen.io.cif import CifFile, CifParser, CifWriter, str2float
 from pymatgen.symmetry.groups import SYMM_DATA
@@ -337,7 +334,7 @@ class ThermalDisplacementMatrices(MSONable):
                     f"{isite + 1} {site.species_string} {site.species_string}{isite + 1} 1.0000 {site.frac_coords[0]} "
                     f"{site.frac_coords[1]} {site.frac_coords[2]} 1a 1\n"
                 )
-                f.write(f" 0.000000 0.000000 0.000000 0.00\n")  # error on positions - zero here
+                f.write(" 0.000000 0.000000 0.000000 0.00\n")  # error on positions - zero here
 
             # now we iterate over the whole structure and write down the frational coordinates (with errors)
             f.write("  0 0 0 0 0 0 0\n")
@@ -460,7 +457,7 @@ class ThermalDisplacementMatrices(MSONable):
         else:
             cif_matrix = self.thermal_displacement_matrix_cif
         for atom_ucif in cif_matrix:
-            ## U11, U22, U33, U23, U13, U12
+            # U11, U22, U33, U23, U13, U12
             site_properties["U11_cif"].append(atom_ucif[0])
             site_properties["U22_cif"].append(atom_ucif[1])
             site_properties["U33_cif"].append(atom_ucif[2])
@@ -521,7 +518,6 @@ class ThermalDisplacementMatrices(MSONable):
             # raise ValueError("Can only read cifs in P1 symmetry")
 
             lattice = CifParser.get_lattice_no_exception(data)
-            oxi_states = CifParser.parse_oxi_states(data)
 
             allcoords = []
             allspecies = []

--- a/pymatgen/phonon/thermal_displacements.py
+++ b/pymatgen/phonon/thermal_displacements.py
@@ -377,7 +377,7 @@ class ThermalDisplacementMatrices(MSONable):
 
             counter = 1
             # two vectors per atom
-            for i in range(len(result)):
+            for _i in range(len(result)):
                 f.write(f"{counter} 0.2 255 0 0 1\n")
                 counter += 1
                 f.write(f"{counter} 0.2 0 0 255 1\n")

--- a/pymatgen/phonon/thermal_displacements.py
+++ b/pymatgen/phonon/thermal_displacements.py
@@ -326,14 +326,16 @@ class ThermalDisplacementMatrices(MSONable):
             f.write("1 1 P 1\n\n")
             f.write("CELLP\n")
             f.write(
-                f"{structure.lattice.a} {structure.lattice.b} {structure.lattice.c} {structure.lattice.alpha} {structure.lattice.beta} {structure.lattice.gamma}\n"
+                f"{structure.lattice.a} {structure.lattice.b} {structure.lattice.c} "
+                f"{structure.lattice.alpha} {structure.lattice.beta} {structure.lattice.gamma}\n"
             )
             f.write("  0.000000   0.000000   0.000000   0.000000   0.000000   0.000000\n")  # error on parameters
             f.write("STRUC\n")
 
             for isite, site in enumerate(structure):
                 f.write(
-                    f"{isite + 1} {site.species_string} {site.species_string}{isite + 1} 1.0000 {site.frac_coords[0]} {site.frac_coords[1]} {site.frac_coords[2]} 1a 1\n"
+                    f"{isite + 1} {site.species_string} {site.species_string}{isite + 1} 1.0000 {site.frac_coords[0]} "
+                    f"{site.frac_coords[1]} {site.frac_coords[2]} 1a 1\n"
                 )
                 f.write(f" 0.000000 0.000000 0.000000 0.00\n")  # error on positions - zero here
 
@@ -343,12 +345,11 @@ class ThermalDisplacementMatrices(MSONable):
             f.write("THERM\n")
             # print all U11s (make sure they are in the correct order)
             counter = 1
-            # order here:
-            # VESTA order _atom_site_aniso_U_12    _atom_site_aniso_U_13    _atom_site_aniso_U_23
-            # file.write("_atom_site_aniso_U_23\n")             file.write("_atom_site_aniso_U_13\n")        file.write("_atom_site_aniso_U_12\n")
+            # VESTA order: _U_12    _U_13    _atom_site_aniso_U_23
             for atom_therm, site in zip(matrix_cif, structure):
                 f.write(
-                    f"{counter} {site.species_string}{counter} {atom_therm[0]} {atom_therm[1]} {atom_therm[2]} {atom_therm[5]} {atom_therm[4]} {atom_therm[3]}\n"
+                    f"{counter} {site.species_string}{counter} {atom_therm[0]} "
+                    f"{atom_therm[1]} {atom_therm[2]} {atom_therm[5]} {atom_therm[4]} {atom_therm[3]}\n"
                 )
                 counter += 1
             f.write("  0 0 0 0 0 0 0 0\n")

--- a/pymatgen/phonon/thermal_displacements.py
+++ b/pymatgen/phonon/thermal_displacements.py
@@ -80,7 +80,8 @@ class ThermalDisplacementMatrices(MSONable):
     @staticmethod
     def get_full_matrix(thermal_displacement):
         """
-        transfers the reduced matrix to the full matrix (order of reduced matrix U11, U22, U33, U23, U13, U12)
+        Transfers the reduced matrix to the full matrix (order of reduced matrix U11, U22, U33, U23, U13, U12)
+
         Args:
             thermal_displacement: 2d numpy array, first dimension are the atoms
 
@@ -104,7 +105,8 @@ class ThermalDisplacementMatrices(MSONable):
     @staticmethod
     def get_reduced_matrix(thermal_displacement):
         """
-        transfers the full matrix to reduced matrix (order of reduced matrix U11, U22, U33, U23, U13, U12)
+        Transfers the full matrix to reduced matrix (order of reduced matrix U11, U22, U33, U23, U13, U12)
+
         Args:
             thermal_displacement: 2d numpy array, first dimension are the atoms
 
@@ -125,7 +127,7 @@ class ThermalDisplacementMatrices(MSONable):
     @property
     def Ustar(self):
         """
-        computation as described in R. W. Grosse-Kunstleve, P. D. Adams, J Appl Cryst 2002, 35, 477–480.
+        Computation as described in R. W. Grosse-Kunstleve, P. D. Adams, J Appl Cryst 2002, 35, 477–480.
         Returns: Ustar as a numpy array, first dimension are the atoms in the structure
         """
         A = self.structure.lattice.matrix.T
@@ -139,7 +141,7 @@ class ThermalDisplacementMatrices(MSONable):
     @property
     def Ucif(self):
         """
-        computation as described in R. W. Grosse-Kunstleve, P. D. Adams, J Appl Cryst 2002, 35, 477–480.
+        Computation as described in R. W. Grosse-Kunstleve, P. D. Adams, J Appl Cryst 2002, 35, 477–480.
         Returns: Ucif as a numpy array, first dimension are the atoms in the structure
         """
         if self.thermal_displacement_matrix_cif is None:
@@ -161,10 +163,9 @@ class ThermalDisplacementMatrices(MSONable):
     @property
     def B(self):
         """
-        computation as described in R. W. Grosse-Kunstleve, P. D. Adams, J Appl Cryst 2002, 35, 477–480.
+        Computation as described in R. W. Grosse-Kunstleve, P. D. Adams, J Appl Cryst 2002, 35, 477–480.
         Returns: B as a numpy array, first dimension are the atoms in the structure
         """
-
         B = []
         for mat in self.Ucif:
             mat_B = mat * 8 * np.pi**2
@@ -174,7 +175,7 @@ class ThermalDisplacementMatrices(MSONable):
     @property
     def beta(self):
         """
-        computation as described in R. W. Grosse-Kunstleve, P. D. Adams, J Appl Cryst 2002, 35, 477–480.
+        Computation as described in R. W. Grosse-Kunstleve, P. D. Adams, J Appl Cryst 2002, 35, 477–480.
         Returns: beta as a numpy array, first dimension are the atoms in the structure
         """
         # will compute beta based on Ustar
@@ -187,7 +188,7 @@ class ThermalDisplacementMatrices(MSONable):
     @property
     def U1U2U3(self):
         """
-        computation as described in R. W. Grosse-Kunstleve, P. D. Adams, J Appl Cryst 2002, 35, 477–480.
+        Computation as described in R. W. Grosse-Kunstleve, P. D. Adams, J Appl Cryst 2002, 35, 477–480.
         Returns: numpy array of eigenvalues of Ucart,  first dimension are the atoms in the structure
         """
         U1U2U3 = []
@@ -197,14 +198,15 @@ class ThermalDisplacementMatrices(MSONable):
 
     def write_cif(self, filename):
         """
-        writes a cif including thermal displacements
+        Writes a cif including thermal displacements
+
         Args:
             filename: name of the cif file
         """
         w = CifWriter(self.structure)
         w.write_file(filename)
-        # This will simply append the thermal displacement part to the cif from the cifwriter
-        # In the long run, cifwriter could be extended to handle thermal displacement matrices
+        # This will simply append the thermal displacement part to the cif from the CifWriter
+        # In the long run, CifWriter could be extended to handle thermal displacement matrices
         with open(filename, "a") as file:
             file.write("loop_ \n")
             file.write("_atom_site_aniso_label\n")
@@ -249,7 +251,6 @@ class ThermalDisplacementMatrices(MSONable):
               These vectors can then, for example, be drawn into the structure with VESTA.
               Vectors are given in Cartesian coordinates
         """
-
         # compare the atoms string at least
         for spec1, spec2 in zip(self.structure.species, other.structure.species):
             if spec1 != spec2:
@@ -292,13 +293,12 @@ class ThermalDisplacementMatrices(MSONable):
     ):
         """
         Will create a VESTA file for visualization of the directionality criterion.
+
         Args:
             other: ThermalDisplacementMatrices
             filename:           Filename of the VESTA file
             which_structure:    0 means structure of the self object will be used, 1 means structure of the other
                                 object will be used
-
-
         """
         # will return a VESTA file including vectors to visualize the quality criterion
         result = self.compute_directionality_quality_criterion(other=other)
@@ -400,7 +400,8 @@ class ThermalDisplacementMatrices(MSONable):
     @staticmethod
     def from_Ucif(thermal_displacement_matrix_cif, structure, temperature):
         """
-        starting from a numpy array, it will convert Ucif values into Ucart values and initialize the class
+        Starting from a numpy array, it will convert Ucif values into Ucart values and initialize the class
+
         Args:
             thermal_displacement_matrix_cif: np.array,
                 first dimension are the atoms,
@@ -448,9 +449,7 @@ class ThermalDisplacementMatrices(MSONable):
         new_structure0 = Structure.from_sites(sorted(structure0, key=sort_order))
 
         Returns: Structure object.
-
         """
-
         site_properties = {"U11_cif": [], "U22_cif": [], "U33_cif": [], "U23_cif": [], "U13_cif": [], "U12_cif": []}
         if self.thermal_displacement_matrix_cif is None:
             cif_matrix = self.get_reduced_matrix(self.Ucif)
@@ -471,6 +470,7 @@ class ThermalDisplacementMatrices(MSONable):
     def from_structure_with_site_properties_Ucif(structure: Structure, temperature: float = None):
         """
         Will create this object with the help of a structure with site properties.
+
         Args:
             structure: Structure object including U11_cif, U22_cif, U33_cif, U23_cif, U13_cif, U12_cif as site
             properties

--- a/pymatgen/phonon/thermal_displacements.py
+++ b/pymatgen/phonon/thermal_displacements.py
@@ -10,7 +10,6 @@ from functools import partial
 
 import numpy as np
 from monty.json import MSONable
-
 from pymatgen.analysis.structure_matcher import StructureMatcher
 from pymatgen.core.structure import Structure
 from pymatgen.io.cif import CifFile, CifParser, CifWriter, str2float
@@ -167,7 +166,7 @@ class ThermalDisplacementMatrices(MSONable):
 
         B = []
         for mat in self.Ucif:
-            mat_B = mat * 8 * np.pi**2
+            mat_B = mat * 8 * np.pi ** 2
             B.append(mat_B)
         return np.array(B)
 
@@ -180,7 +179,7 @@ class ThermalDisplacementMatrices(MSONable):
         # will compute beta based on Ustar
         beta = []
         for mat in self.Ustar:
-            mat_beta = mat * 2 * np.pi**2
+            mat_beta = mat * 2 * np.pi ** 2
             beta.append(mat_beta)
         return beta
 
@@ -264,7 +263,7 @@ class ThermalDisplacementMatrices(MSONable):
 
         results = []
         for self_Ucart, other_Ucart in zip(
-            self.thermal_displacement_matrix_cart_matrixform, other.thermal_displacement_matrix_cart_matrixform
+                self.thermal_displacement_matrix_cart_matrixform, other.thermal_displacement_matrix_cart_matrixform
         ):
             result_dict = {}
 
@@ -288,7 +287,7 @@ class ThermalDisplacementMatrices(MSONable):
         return results
 
     def visualize_directionality_quality_criterion(
-        self, other, filename: str = "visualization.vesta", which_structure: int = 0
+            self, other, filename: str = "visualization.vesta", which_structure: int = 0
     ):
         """
         Will create a VESTA file for visualization of the directionality criterion.
@@ -514,8 +513,6 @@ class ThermalDisplacementMatrices(MSONable):
         thermals = []
         for data in cif.data.values():
             # can only handle P1 symmetry for now
-            # TODO: potenially add a check for the P1 here
-            # raise ValueError("Can only read cifs in P1 symmetry")
 
             lattice = CifParser.get_lattice_no_exception(data)
 

--- a/pymatgen/phonon/thermal_displacements.py
+++ b/pymatgen/phonon/thermal_displacements.py
@@ -5,21 +5,18 @@
 This module provides classes to handle thermal displacement matrices (anisotropic displacement parameters).
 """
 
-from monty.json import MSONable
-
-from pymatgen.analysis.structure_matcher import StructureMatcher
-from pymatgen.io.cif import CifWriter
-from pymatgen.io.cif import CifFile, CifParser, str2float
-
 import re
 from collections import deque
 from functools import partial
 from inspect import getfullargspec as getargspec
 
 import numpy as np
+from monty.json import MSONable
 
+from pymatgen.analysis.structure_matcher import StructureMatcher
 from pymatgen.core.periodic_table import DummySpecies, Species, get_el_sp
 from pymatgen.core.structure import Structure
+from pymatgen.io.cif import CifFile, CifParser, CifWriter, str2float
 from pymatgen.symmetry.groups import SYMM_DATA
 
 sub_spgrp = partial(re.sub, r"[\s_]", "")
@@ -173,7 +170,7 @@ class ThermalDisplacementMatrices(MSONable):
 
         B = []
         for mat in self.Ucif:
-            mat_B = mat * 8 * np.pi ** 2
+            mat_B = mat * 8 * np.pi**2
             B.append(mat_B)
         return np.array(B)
 
@@ -186,7 +183,7 @@ class ThermalDisplacementMatrices(MSONable):
         # will compute beta based on Ustar
         beta = []
         for mat in self.Ustar:
-            mat_beta = mat * 2 * np.pi ** 2
+            mat_beta = mat * 2 * np.pi**2
             beta.append(mat_beta)
         return beta
 
@@ -270,7 +267,7 @@ class ThermalDisplacementMatrices(MSONable):
 
         results = []
         for self_Ucart, other_Ucart in zip(
-                self.thermal_displacement_matrix_cart_matrixform, other.thermal_displacement_matrix_cart_matrixform
+            self.thermal_displacement_matrix_cart_matrixform, other.thermal_displacement_matrix_cart_matrixform
         ):
             result_dict = {}
 
@@ -293,8 +290,9 @@ class ThermalDisplacementMatrices(MSONable):
 
         return results
 
-    def visualize_directionality_quality_criterion(self, other,
-                                                   filename: str = "visualization.vesta", which_structure: int = 0):
+    def visualize_directionality_quality_criterion(
+        self, other, filename: str = "visualization.vesta", which_structure: int = 0
+    ):
         """
         Will create a VESTA file for visualization of the directionality criterion.
         Args:
@@ -307,14 +305,18 @@ class ThermalDisplacementMatrices(MSONable):
         """
         # will return a VESTA file including vectors to visualize the quality criterion
         result = self.compute_directionality_quality_criterion(other=other)
-        matrix_cif= self.thermal_displacement_matrix_cif if self.thermal_displacement_matrix_cif is not None else self.get_reduced_matrix(self.Ucif)
+        matrix_cif = (
+            self.thermal_displacement_matrix_cif
+            if self.thermal_displacement_matrix_cif is not None
+            else self.get_reduced_matrix(self.Ucif)
+        )
 
         if which_structure == 0:
             structure = self.structure
         elif which_structure == 1:
             structure = other.structure
 
-        with open(filename, 'w') as f:
+        with open(filename, "w") as f:
             #
             f.write("#VESTA_FORMAT_VERSION 3.5.4\n \n \n")
             f.write("CRYSTAL\n\n")
@@ -324,14 +326,16 @@ class ThermalDisplacementMatrices(MSONable):
             f.write("1 1 P 1\n\n")
             f.write("CELLP\n")
             f.write(
-                f"{structure.lattice.a} {structure.lattice.b} {structure.lattice.c} {structure.lattice.alpha} {structure.lattice.beta} {structure.lattice.gamma}\n")
+                f"{structure.lattice.a} {structure.lattice.b} {structure.lattice.c} {structure.lattice.alpha} {structure.lattice.beta} {structure.lattice.gamma}\n"
+            )
             f.write("  0.000000   0.000000   0.000000   0.000000   0.000000   0.000000\n")  # error on parameters
             f.write("STRUC\n")
 
             for isite, site in enumerate(structure):
                 f.write(
-                    f'{isite + 1} {site.species_string} {site.species_string}{isite + 1} 1.0000 {site.frac_coords[0]} {site.frac_coords[1]} {site.frac_coords[2]} 1a 1\n')
-                f.write(f' 0.000000 0.000000 0.000000 0.00\n')  # error on positions - zero here
+                    f"{isite + 1} {site.species_string} {site.species_string}{isite + 1} 1.0000 {site.frac_coords[0]} {site.frac_coords[1]} {site.frac_coords[2]} 1a 1\n"
+                )
+                f.write(f" 0.000000 0.000000 0.000000 0.00\n")  # error on positions - zero here
 
             # now we iterate over the whole structure and write down the frational coordinates (with errors)
             f.write("  0 0 0 0 0 0 0\n")
@@ -344,7 +348,8 @@ class ThermalDisplacementMatrices(MSONable):
             # file.write("_atom_site_aniso_U_23\n")             file.write("_atom_site_aniso_U_13\n")        file.write("_atom_site_aniso_U_12\n")
             for atom_therm, site in zip(matrix_cif, structure):
                 f.write(
-                    f"{counter} {site.species_string}{counter} {atom_therm[0]} {atom_therm[1]} {atom_therm[2]} {atom_therm[5]} {atom_therm[4]} {atom_therm[3]}\n")
+                    f"{counter} {site.species_string}{counter} {atom_therm[0]} {atom_therm[1]} {atom_therm[2]} {atom_therm[5]} {atom_therm[4]} {atom_therm[3]}\n"
+                )
                 counter += 1
             f.write("  0 0 0 0 0 0 0 0\n")
             f.write("VECTR\n")
@@ -450,9 +455,9 @@ class ThermalDisplacementMatrices(MSONable):
 
         site_properties = {"U11_cif": [], "U22_cif": [], "U33_cif": [], "U23_cif": [], "U13_cif": [], "U12_cif": []}
         if self.thermal_displacement_matrix_cif is None:
-            cif_matrix=self.get_reduced_matrix(self.Ucif)
+            cif_matrix = self.get_reduced_matrix(self.Ucif)
         else:
-            cif_matrix=self.thermal_displacement_matrix_cif
+            cif_matrix = self.thermal_displacement_matrix_cif
         for atom_ucif in cif_matrix:
             ## U11, U22, U33, U23, U13, U12
             site_properties["U11_cif"].append(atom_ucif[0])
@@ -465,7 +470,7 @@ class ThermalDisplacementMatrices(MSONable):
         return self.structure.copy(site_properties=site_properties)
 
     @staticmethod
-    def from_structure_with_site_properties_Ucif(structure:Structure, temperature: float=None):
+    def from_structure_with_site_properties_Ucif(structure: Structure, temperature: float = None):
         """
         Will create this object with the help of a structure with site properties.
         Args:
@@ -479,9 +484,16 @@ class ThermalDisplacementMatrices(MSONable):
         Ucif_matrix = []
         ## U11, U22, U33, U23, U13, U12
         for site in structure:
-            Ucif_matrix.append([site.properties["U11_cif"], site.properties["U22_cif"],
-                                site.properties["U33_cif"], site.properties["U23_cif"],
-                                site.properties["U13_cif"], site.properties["U12_cif"]])
+            Ucif_matrix.append(
+                [
+                    site.properties["U11_cif"],
+                    site.properties["U22_cif"],
+                    site.properties["U33_cif"],
+                    site.properties["U23_cif"],
+                    site.properties["U13_cif"],
+                    site.properties["U12_cif"],
+                ]
+            )
 
         return ThermalDisplacementMatrices.from_Ucif(Ucif_matrix, structure, temperature=temperature)
 
@@ -546,15 +558,20 @@ class ThermalDisplacementMatrices(MSONable):
             thermals_Ucif = []
             # U11, U22, U33, U23, U13, U12
             for i in range(len(data["_atom_site_aniso_label"])):
-                thermals_Ucif.append([str2float(data["_atom_site_aniso_U_11"][i]),
-                                      str2float(data["_atom_site_aniso_U_22"][i]),
-                                      str2float(data["_atom_site_aniso_U_33"][i]),
-                                      str2float(data["_atom_site_aniso_U_23"][i]),
-                                      str2float(data["_atom_site_aniso_U_13"][i]),
-                                      str2float(data["_atom_site_aniso_U_12"][i])])
+                thermals_Ucif.append(
+                    [
+                        str2float(data["_atom_site_aniso_U_11"][i]),
+                        str2float(data["_atom_site_aniso_U_22"][i]),
+                        str2float(data["_atom_site_aniso_U_33"][i]),
+                        str2float(data["_atom_site_aniso_U_23"][i]),
+                        str2float(data["_atom_site_aniso_U_13"][i]),
+                        str2float(data["_atom_site_aniso_U_12"][i]),
+                    ]
+                )
             struct = Structure(lattice, allspecies, allcoords)
 
-            thermal = ThermalDisplacementMatrices.from_Ucif(thermal_displacement_matrix_cif=thermals_Ucif,
-                                                            structure=struct, temperature=None)
+            thermal = ThermalDisplacementMatrices.from_Ucif(
+                thermal_displacement_matrix_cif=thermals_Ucif, structure=struct, temperature=None
+            )
             thermals.append(thermal)
         return thermals

--- a/pymatgen/phonon/thermal_displacements.py
+++ b/pymatgen/phonon/thermal_displacements.py
@@ -479,7 +479,7 @@ class ThermalDisplacementMatrices(MSONable):
 
         """
         Ucif_matrix = []
-        ## U11, U22, U33, U23, U13, U12
+        # U11, U22, U33, U23, U13, U12
         for site in structure:
             Ucif_matrix.append(
                 [


### PR DESCRIPTION
## Summary

I have extended the ThermalDisplacementMatrices class. It can now also read cif files in P1 format, produce structures including Ucif as site_property (handy for sorting structures and thermal displacement properties, for example), and print VESTA files in P1 space group including vectors indicating the directionality of two different sets of computed displacement parameters.

While doing so, I have refactored the classes parsing the cif files a tiny bit. In general, I found it very hard to reuse any of the code in there as this warning state of the class would require me to make instances of classes. While I understand the purpose of saving the warnings like this, it has this drawback. Otherwise, most of the methods in there could be static methods.