### PR TITLE
InputSet: remove __eq__ method

### DIFF
--- a/pymatgen/io/core.py
+++ b/pymatgen/io/core.py
@@ -156,9 +156,6 @@ class InputSet(MSONable, MutableMapping):
     def __delitem__(self, key):
         del self.inputs[key]
 
-    def __eq__(self, other):
-        return (self.inputs == other.inputs) and (self.__dict__ == other.__dict__)
-
     def write_input(
         self,
         directory: str | Path,

--- a/pymatgen/io/tests/test_core.py
+++ b/pymatgen/io/tests/test_core.py
@@ -161,10 +161,10 @@ class TestInputSet:
             kwarg3="goodbye",
         )
 
-        assert inp_set == inp_set2
-        assert inp_set != inp_set3
-        assert inp_set != inp_set4
-        assert inp_set != inp_set5
+        assert inp_set.as_dict() == inp_set2.as_dict()
+        assert inp_set.as_dict() != inp_set3.as_dict()
+        assert inp_set.as_dict() != inp_set4.as_dict()
+        assert inp_set.as_dict() != inp_set5.as_dict()
 
     def test_msonable(self):
         sif1 = StructInputFile.from_file(os.path.join(test_dir, "Li.cif"))


### PR DESCRIPTION
## Summary

Remove the `__eq__` method from `InputSet`, per discussion in #2665 (and will replace that PR).

Flagging @utf in case this change will affect development of VASP `InputSet` in `atomate2`.
