### PR TITLE
Added get_proj_plot() method in phonon.plotter.PhononBSPlotter class

### DIFF
--- a/pymatgen/phonon/plotter.py
+++ b/pymatgen/phonon/plotter.py
@@ -10,11 +10,11 @@ from __future__ import annotations
 import logging
 from collections import namedtuple
 
+import matplotlib.pyplot as plt
 import numpy as np
 import scipy.constants as const
 from monty.json import jsanitize
-import matplotlib.pyplot as plt
-        
+
 from pymatgen.electronic_structure.plotter import plot_brillouin_zone
 from pymatgen.phonon.bandstructure import PhononBandStructureSymmLine
 from pymatgen.phonon.gruneisen import GruneisenPhononBandStructureSymmLine
@@ -382,9 +382,7 @@ class PhononBSPlotter:
 
         return plt
 
-    def _get_weight(self,
-                    vec: np.array,
-                    indices: list[list[int]]) -> np.array:
+    def _get_weight(self, vec: np.array, indices: list[list[int]]) -> np.array:
         """
         compute the weight for each combintaion of sites according to the
         eigenvector
@@ -425,11 +423,13 @@ class PhononBSPlotter:
             b = (1 - colors[2]) * (1 - colors[3])
             return [r, g, b]
 
-    def get_proj_plot(self,
-                      site_comb: str | list[list[int]] = "element",
-                      ylim: tuple[None | float, None | float] = None,
-                      units: str = "thz",
-                      rgb_labels: tuple[None | str] = None) -> plt.Axes:
+    def get_proj_plot(
+        self,
+        site_comb: str | list[list[int]] = "element",
+        ylim: tuple[None | float, None | float] = None,
+        units: str = "thz",
+        rgb_labels: tuple[None | str] = None,
+    ) -> plt.Axes:
         """
         Get a matplotlib object for the bandstructure plot projected along atomic
         sites.
@@ -457,21 +457,18 @@ class PhononBSPlotter:
                     if ele == unique_species:
                         indices[j].append(i)
         else:
-            assert 2 <= len(site_comb) <= 4,\
-                "the length of site_comb must be 2, 3 or 4"
+            assert 2 <= len(site_comb) <= 4, "the length of site_comb must be 2, 3 or 4"
             all_sites = self._bs.structure.sites
-            all_indices = set([i for i in range(len(all_sites))])
+            all_indices = {i for i in range(len(all_sites))}
             for comb in site_comb:
                 for i in comb:
-                    assert 0 <= i < len(all_sites),\
-                        "one or more indices in site_comb does not exist"
+                    assert 0 <= i < len(all_sites), "one or more indices in site_comb does not exist"
                     all_indices.remove(i)
             if len(all_indices) != 0:
-                raise Exception("not all {} indices are included in site_comb".format(len(all_sites)))
+                raise Exception(f"not all {len(all_sites)} indices are included in site_comb")
             indices = site_comb
-        assert rgb_labels is None or len(rgb_labels) == len(indices),\
-            "wrong number of rgb_labels"
-            
+        assert rgb_labels is None or len(rgb_labels) == len(indices), "wrong number of rgb_labels"
+
         u = freq_units(units)
         fig, ax = plt.subplots(figsize=(12, 8), dpi=300)
         self._maketicks(plt)
@@ -548,11 +545,13 @@ class PhononBSPlotter:
         plt.savefig(filename, format=img_format)
         plt.close()
 
-    def show_proj(self,
-                  site_comb: str | list[list[int]] = "element",
-                  ylim: tuple[None | float, None | float] = None,
-                  units: str = "thz",
-                  rgb_labels: tuple[str] = None):
+    def show_proj(
+        self,
+        site_comb: str | list[list[int]] = "element",
+        ylim: tuple[None | float, None | float] = None,
+        units: str = "thz",
+        rgb_labels: tuple[str] = None,
+    ):
         """
         Show the projected plot using matplotlib.
 
@@ -564,12 +563,15 @@ class PhononBSPlotter:
         self.get_proj_plot(site_comb=site_comb, ylim=ylim, units=units, rgb_labels=rgb_labels)
         plt.show()
 
-    def save_proj_plot(self, filename,
-                       img_format="eps",
-                       site_comb: str | list[list[int]] = "element",
-                       ylim: tuple[None | float, None | float] = None,
-                       units: str = "thz",
-                       rgb_labels: tuple[str] = None):
+    def save_proj_plot(
+        self,
+        filename,
+        img_format="eps",
+        site_comb: str | list[list[int]] = "element",
+        ylim: tuple[None | float, None | float] = None,
+        units: str = "thz",
+        rgb_labels: tuple[str] = None,
+    ):
         """
         Save matplotlib projected plot to a file.
 

--- a/pymatgen/phonon/plotter.py
+++ b/pymatgen/phonon/plotter.py
@@ -429,7 +429,7 @@ class PhononBSPlotter:
                       site_comb: str | list[list[int]] = "element",
                       ylim: tuple[None | float, None | float] = None,
                       units: str = "thz",
-                      rgb_labels: tuple[str] = None) -> plt.Axes:
+                      rgb_labels: tuple[None | str] = None) -> plt.Axes:
         """
         Get a matplotlib object for the bandstructure plot projected along atomic
         sites.

--- a/pymatgen/phonon/plotter.py
+++ b/pymatgen/phonon/plotter.py
@@ -427,7 +427,7 @@ class PhononBSPlotter:
 
     def get_proj_plot(self,
                       site_comb: str | list[list[int]] = "element",
-                      ylim: tuple(None | float, None | float) = None,
+                      ylim: tuple[None | float, None | float] = None,
                       units: str = "thz") -> plt.Axes:
         """
         Get a matplotlib object for the bandstructure plot projected along atomic
@@ -544,7 +544,7 @@ class PhononBSPlotter:
 
     def show_proj(self,
                   site_comb: str | list[list[int]] = "element",
-                  ylim: tuple(None | float, None | float)= None,
+                  ylim: tuple[None | float, None | float]= None,
                   units: str = "thz"):
         """
         Show the projected plot using matplotlib.
@@ -560,7 +560,7 @@ class PhononBSPlotter:
     def save_proj_plot(self, filename,
                        img_format="eps",
                        site_comb: str | list[list[int]] = "element",
-                       ylim: tuple(None | float, None | float) = None,
+                       ylim: tuple[None | float, None | float] = None,
                        units: str = "thz"):
         """
         Save matplotlib projected plot to a file.

--- a/pymatgen/phonon/plotter.py
+++ b/pymatgen/phonon/plotter.py
@@ -393,9 +393,10 @@ class PhononBSPlotter:
         # get the projectors for each group
         gw = []
         norm_f = 0
-        for i, comb in enumerate(site_comb):
+        for comb in site_comb:
             projector = np.zeros(len(new_vec))
-            for j in range(len(projector)):
+            l = len(projector)
+            for j in range(l):
                 if j in comb:
                     projector[j] = 1
             group_weight = np.dot(projector, new_vec)
@@ -423,7 +424,7 @@ class PhononBSPlotter:
 
     def get_proj_plot(self, site_comb="element", ylim=None, units="thz"):
         """
-        Get a matplotlib object for the bandstructure plot projected olong atomic
+        Get a matplotlib object for the bandstructure plot projected along atomic
         sites.
 
         Args:

--- a/pymatgen/phonon/plotter.py
+++ b/pymatgen/phonon/plotter.py
@@ -428,7 +428,8 @@ class PhononBSPlotter:
     def get_proj_plot(self,
                       site_comb: str | list[list[int]] = "element",
                       ylim: tuple[None | float, None | float] = None,
-                      units: str = "thz") -> plt.Axes:
+                      units: str = "thz",
+                      rgb_labels: tuple[str] = None) -> plt.Axes:
         """
         Get a matplotlib object for the bandstructure plot projected along atomic
         sites.
@@ -468,6 +469,8 @@ class PhononBSPlotter:
             if len(all_indices) != 0:
                 raise Exception("not all {} indices are included in site_comb".format(len(all_sites)))
             indices = site_comb
+        assert rgb_labels is None or len(rgb_labels) == len(indices),\
+            "wrong number of rgb_labels"
             
         u = freq_units(units)
         fig, ax = plt.subplots(figsize=(12, 8), dpi=300)
@@ -503,10 +506,13 @@ class PhononBSPlotter:
         ax.set_ylabel(ylabel, fontsize=28)
         ax.tick_params(labelsize=28)
         # make color legend
-        if site_comb == "element":
-            labels = [e.symbol for e in self._bs.structure.composition.elements]
+        if rgb_labels is not None:
+            labels = rgb_labels
         else:
-            labels = [f"group{i}" for i in range(len(site_comb))]
+            if site_comb == "element":
+                labels = [e.symbol for e in self._bs.structure.composition.elements]
+            else:
+                labels = [f"{i}" for i in range(len(site_comb))]
         if len(indices) == 2:
             BSDOSPlotter._rb_line(ax, labels[0], labels[1], "best")
         elif len(indices) == 3:
@@ -544,7 +550,7 @@ class PhononBSPlotter:
 
     def show_proj(self,
                   site_comb: str | list[list[int]] = "element",
-                  ylim: tuple[None | float, None | float]= None,
+                  ylim: tuple[None | float, None | float] = None,
                   units: str = "thz"):
         """
         Show the projected plot using matplotlib.

--- a/pymatgen/phonon/plotter.py
+++ b/pymatgen/phonon/plotter.py
@@ -551,7 +551,8 @@ class PhononBSPlotter:
     def show_proj(self,
                   site_comb: str | list[list[int]] = "element",
                   ylim: tuple[None | float, None | float] = None,
-                  units: str = "thz"):
+                  units: str = "thz",
+                  rgb_labels: tuple[str] = None):
         """
         Show the projected plot using matplotlib.
 
@@ -560,14 +561,15 @@ class PhononBSPlotter:
                 the code choose.
             units: units for the frequencies. Accepted values thz, ev, mev, ha, cm-1, cm^-1.
         """
-        self.get_proj_plot(site_comb=site_comb, ylim=ylim, units=units)
+        self.get_proj_plot(site_comb=site_comb, ylim=ylim, units=units, rgb_labels=rgb_labels)
         plt.show()
 
     def save_proj_plot(self, filename,
                        img_format="eps",
                        site_comb: str | list[list[int]] = "element",
                        ylim: tuple[None | float, None | float] = None,
-                       units: str = "thz"):
+                       units: str = "thz",
+                       rgb_labels: tuple[str] = None):
         """
         Save matplotlib projected plot to a file.
 
@@ -577,7 +579,7 @@ class PhononBSPlotter:
             ylim: Specifies the y-axis limits.
             units: units for the frequencies. Accepted values thz, ev, mev, ha, cm-1, cm^-1.
         """
-        ax = self.get_proj_plot(site_comb=site_comb, ylim=ylim, units=units)
+        ax = self.get_proj_plot(site_comb=site_comb, ylim=ylim, units=units, rgb_labels=rgb_labels)
         ax.figure.savefig(filename, format=img_format)
         plt.close()
 

--- a/pymatgen/phonon/plotter.py
+++ b/pymatgen/phonon/plotter.py
@@ -566,28 +566,6 @@ class PhononBSPlotter:
         self.get_proj_plot(site_comb=site_comb, ylim=ylim, units=units, rgb_labels=rgb_labels)
         plt.show()
 
-    def save_proj_plot(
-        self,
-        filename,
-        img_format="eps",
-        site_comb: str | list[list[int]] = "element",
-        ylim: tuple[None | float, None | float] = None,
-        units: str = "thz",
-        rgb_labels: tuple[str] = None,
-    ):
-        """
-        Save matplotlib projected plot to a file.
-
-        Args:
-            filename: Filename to write to.
-            img_format: Image format to use. Defaults to EPS.
-            ylim: Specifies the y-axis limits.
-            units: units for the frequencies. Accepted values thz, ev, mev, ha, cm-1, cm^-1.
-        """
-        ax = self.get_proj_plot(site_comb=site_comb, ylim=ylim, units=units, rgb_labels=rgb_labels)
-        ax.figure.savefig(filename, format=img_format)
-        plt.close()
-
     def get_ticks(self):
         """
         Get all ticks and labels for a band structure plot.

--- a/pymatgen/phonon/plotter.py
+++ b/pymatgen/phonon/plotter.py
@@ -381,17 +381,16 @@ class PhononBSPlotter:
 
         return plt
 
-    def _get_weight(self, vec,site_comb):
+    def _get_weight(self, vec, site_comb):
         """
         compute the weight for each combintaion of sites according to the
-        eigenvector 
+        eigenvector
         """
         num_atom = int(self._nb_bands / 3)
         new_vec = np.zeros(num_atom)
         for i in range(num_atom):
-            new_vec[i] = np.linalg.norm(vec[i*3:i*3+3])
-        
-        #get the projectors for each group
+            new_vec[i] = np.linalg.norm(vec[i * 3 : i * 3 + 3])
+        # get the projectors for each group
         gw = []
         norm_f = 0
         for i, comb in enumerate(site_comb):
@@ -403,35 +402,35 @@ class PhononBSPlotter:
             gw.append(group_weight)
             norm_f += group_weight
         return np.array(gw, dtype=float) / norm_f
-    
+
     @staticmethod
     def _make_color(colors):
         """
-        convert the eigendisplacements to rgb colors 
+        convert the eigendisplacements to rgb colors
 
         """
         # if there are two groups, use red and blue
         if len(colors) == 2:
-            return [colors[0],0,colors[1]]
+            return [colors[0], 0, colors[1]]
         elif len(colors) == 3:
             return colors
         # if there are four groups, use cyan, magenta, yellow and black
         elif len(colors) == 4:
-            r = (1-colors[0])*(1-colors[3]) 
-            g = (1-colors[1])*(1-colors[3]) 
-            b = (1-colors[2])*(1-colors[3])
-            return [r,g,b]
+            r = (1 - colors[0]) * (1 - colors[3])
+            g = (1 - colors[1]) * (1 - colors[3])
+            b = (1 - colors[2]) * (1 - colors[3])
+            return [r, g, b]
 
-    def get_proj_plot(self, site_comb='element', ylim=None, units="thz"): 
+    def get_proj_plot(self, site_comb="element", ylim=None, units="thz"):
         """
         Get a matplotlib object for the bandstructure plot projected olong atomic
         sites.
 
         Args:
             site_comb: a list of list, for example, [[0],[1],[2,3,4]];
-                the numbers in each sublist represents the indices of atoms; 
+                the numbers in each sublist represents the indices of atoms;
                 the atoms in a same sublist will be plotted in a same color；
-                if not specified, unique elements are automatically grouped. 
+                if not specified, unique elements are automatically grouped.
             ylim: Specify the y-axis (frequency) limits; by default None let
                 the code choose.
             units: units for the frequencies. Accepted values thz, ev, mev, ha, cm-1, cm^-1.
@@ -440,40 +439,49 @@ class PhononBSPlotter:
         import matplotlib.pyplot as plt
         from matplotlib.collections import LineCollection
         from pymatgen.electronic_structure.plotter import BSDOSPlotter
-        
-        if site_comb == 'element':
+
+        if site_comb == "element":
             elements = [e.symbol for e in self._bs.structure.composition.elements]
-            assert len(elements) in [2,3,4], "the compound must have 2, 3 or 4 unique elements"
+            assert len(elements) in [
+                2,
+                3,
+                4,
+            ], "the compound must have 2, 3 or 4 unique elements"
             indices = [[] for _ in range(len(elements))]
             for i, ele in enumerate(self._bs.structure.species):
-                for j, unique_species in enumerate(self._bs.structure.composition.elements):
+                for j, unique_species in enumerate(
+                    self._bs.structure.composition.elements
+                ):
                     if ele == unique_species:
                         indices[j].append(i)
         else:
-            assert len(site_comb) in [2,3,4], "the length of site_combs must be 2, 3 or 4"
+            assert len(site_comb) in [
+                2,
+                3,
+                4,
+            ], "the length of site_combs must be 2, 3 or 4"
             indices = site_comb
             pass
-
-        u = freq_units(units)   
-        fig, ax = plt.subplots(figsize=(12,8), dpi=300)
+        u = freq_units(units)
+        fig, ax = plt.subplots(figsize=(12, 8), dpi=300)
         self._maketicks(plt)
 
         data = self.bs_plot_data()
-        k_dist = np.array(data['distances']).flatten()
-        for d in range(1,len(k_dist)):
-            #consider 2 k points each time so they connect
+        k_dist = np.array(data["distances"]).flatten()
+        for d in range(1, len(k_dist)):
+            # consider 2 k points each time so they connect
             colors = []
             for i in range(self._nb_bands):
-                eigenvec_1 = self._bs.eigendisplacements[i][d-1].flatten()
+                eigenvec_1 = self._bs.eigendisplacements[i][d - 1].flatten()
                 eigenvec_2 = self._bs.eigendisplacements[i][d].flatten()
                 colors1 = self._get_weight(eigenvec_1, indices)
                 colors2 = self._get_weight(eigenvec_2, indices)
-                colors.append(self._make_color((colors1 + colors2)/2))
+                colors.append(self._make_color((colors1 + colors2) / 2))
             seg = np.zeros((self._nb_bands, 2, 2))
-            seg[:,:, 1] = self._bs.bands[:,d-1:d+1] * u.factor
-            seg[:, 0, 0] = k_dist[d-1]
+            seg[:, :, 1] = self._bs.bands[:, d - 1 : d + 1] * u.factor
+            seg[:, 0, 0] = k_dist[d - 1]
             seg[:, 1, 0] = k_dist[d]
-            ls = LineCollection(seg, colors=colors, linestyles='-', linewidths=2.5)
+            ls = LineCollection(seg, colors=colors, linestyles="-", linewidths=2.5)
             ax.add_collection(ls)
         if ylim is None:
             y_max = max([max(b) for b in self._bs.bands]) * u.factor
@@ -488,7 +496,7 @@ class PhononBSPlotter:
         ax.set_ylabel(ylabel, fontsize=28)
         ax.tick_params(labelsize=28)
         # make color legend
-        if site_comb == 'element':
+        if site_comb == "element":
             labels = [e.symbol for e in self._bs.structure.composition.elements]
         else:
             labels = ["group{}".format(i) for i in range(len(site_comb))]

--- a/pymatgen/phonon/plotter.py
+++ b/pymatgen/phonon/plotter.py
@@ -439,6 +439,7 @@ class PhononBSPlotter:
 
         import matplotlib.pyplot as plt
         from matplotlib.collections import LineCollection
+
         from pymatgen.electronic_structure.plotter import BSDOSPlotter
 
         if site_comb == "element":
@@ -450,9 +451,7 @@ class PhononBSPlotter:
             ], "the compound must have 2, 3 or 4 unique elements"
             indices = [[] for _ in range(len(elements))]
             for i, ele in enumerate(self._bs.structure.species):
-                for j, unique_species in enumerate(
-                    self._bs.structure.composition.elements
-                ):
+                for j, unique_species in enumerate(self._bs.structure.composition.elements):
                     if ele == unique_species:
                         indices[j].append(i)
         else:
@@ -485,8 +484,8 @@ class PhononBSPlotter:
             ls = LineCollection(seg, colors=colors, linestyles="-", linewidths=2.5)
             ax.add_collection(ls)
         if ylim is None:
-            y_max = max([max(b) for b in self._bs.bands]) * u.factor
-            y_min = min([min(b) for b in self._bs.bands]) * u.factor
+            y_max = max(max(b) for b in self._bs.bands) * u.factor
+            y_min = min(min(b) for b in self._bs.bands) * u.factor
             y_margin = (y_max - y_min) * 0.05
             ylim = [y_min - y_margin, y_max + y_margin]
         ax.set_ylim(ylim)
@@ -500,7 +499,7 @@ class PhononBSPlotter:
         if site_comb == "element":
             labels = [e.symbol for e in self._bs.structure.composition.elements]
         else:
-            labels = ["group{}".format(i) for i in range(len(site_comb))]
+            labels = [f"group{i}" for i in range(len(site_comb))]
         if len(indices) == 2:
             BSDOSPlotter._rb_line(ax, labels[0], labels[1], "best")
         elif len(indices) == 3:
@@ -509,7 +508,7 @@ class PhononBSPlotter:
             # for 4 combinations, build a color square?
             pass
         return ax
-        
+
     def show(self, ylim=None, units="thz"):
         """
         Show the plot using matplotlib.

--- a/pymatgen/phonon/plotter.py
+++ b/pymatgen/phonon/plotter.py
@@ -381,6 +381,126 @@ class PhononBSPlotter:
 
         return plt
 
+    def _get_weight(self, vec,site_comb):
+        """
+        compute the weight for each combintaion of sites according to the
+        eigenvector 
+        """
+        num_atom = int(self._nb_bands / 3)
+        new_vec = np.zeros(num_atom)
+        for i in range(num_atom):
+            new_vec[i] = np.linalg.norm(vec[i*3:i*3+3])
+        
+        #get the projectors for each group
+        gw = []
+        norm_f = 0
+        for i, comb in enumerate(site_comb):
+            projector = np.zeros(len(new_vec))
+            for j in range(len(projector)):
+                if j in comb:
+                    projector[j] = 1
+            group_weight = np.dot(projector, new_vec)
+            gw.append(group_weight)
+            norm_f += group_weight
+        return np.array(gw, dtype=float) / norm_f
+    
+    @staticmethod
+    def _make_color(colors):
+        """
+        convert the eigendisplacements to rgb colors 
+
+        """
+        # if there are two groups, use red and blue
+        if len(colors) == 2:
+            return [colors[0],0,colors[1]]
+        elif len(colors) == 3:
+            return colors
+        # if there are four groups, use cyan, magenta, yellow and black
+        elif len(colors) == 4:
+            r = (1-colors[0])*(1-colors[3]) 
+            g = (1-colors[1])*(1-colors[3]) 
+            b = (1-colors[2])*(1-colors[3])
+            return [r,g,b]
+
+    def get_proj_plot(self, site_comb='element', ylim=None, units="thz"): 
+        """
+        Get a matplotlib object for the bandstructure plot projected olong atomic
+        sites.
+
+        Args:
+            site_comb: a list of list, for example, [[0],[1],[2,3,4]];
+                the numbers in each sublist represents the indices of atoms; 
+                the atoms in a same sublist will be plotted in a same color；
+                if not specified, unique elements are automatically grouped. 
+            ylim: Specify the y-axis (frequency) limits; by default None let
+                the code choose.
+            units: units for the frequencies. Accepted values thz, ev, mev, ha, cm-1, cm^-1.
+        """
+
+        import matplotlib.pyplot as plt
+        from matplotlib.collections import LineCollection
+        from pymatgen.electronic_structure.plotter import BSDOSPlotter
+        
+        if site_comb == 'element':
+            elements = [e.symbol for e in self._bs.structure.composition.elements]
+            assert len(elements) in [2,3,4], "the compound must have 2, 3 or 4 unique elements"
+            indices = [[] for _ in range(len(elements))]
+            for i, ele in enumerate(self._bs.structure.species):
+                for j, unique_species in enumerate(self._bs.structure.composition.elements):
+                    if ele == unique_species:
+                        indices[j].append(i)
+        else:
+            assert len(site_comb) in [2,3,4], "the length of site_combs must be 2, 3 or 4"
+            indices = site_comb
+            pass
+
+        u = freq_units(units)   
+        fig, ax = plt.subplots(figsize=(12,8), dpi=300)
+        self._maketicks(plt)
+
+        data = self.bs_plot_data()
+        k_dist = np.array(data['distances']).flatten()
+        for d in range(1,len(k_dist)):
+            #consider 2 k points each time so they connect
+            colors = []
+            for i in range(self._nb_bands):
+                eigenvec_1 = self._bs.eigendisplacements[i][d-1].flatten()
+                eigenvec_2 = self._bs.eigendisplacements[i][d].flatten()
+                colors1 = self._get_weight(eigenvec_1, indices)
+                colors2 = self._get_weight(eigenvec_2, indices)
+                colors.append(self._make_color((colors1 + colors2)/2))
+            seg = np.zeros((self._nb_bands, 2, 2))
+            seg[:,:, 1] = self._bs.bands[:,d-1:d+1] * u.factor
+            seg[:, 0, 0] = k_dist[d-1]
+            seg[:, 1, 0] = k_dist[d]
+            ls = LineCollection(seg, colors=colors, linestyles='-', linewidths=2.5)
+            ax.add_collection(ls)
+        if ylim is None:
+            y_max = max([max(b) for b in self._bs.bands]) * u.factor
+            y_min = min([min(b) for b in self._bs.bands]) * u.factor
+            y_margin = (y_max - y_min) * 0.05
+            ylim = [y_min - y_margin, y_max + y_margin]
+        ax.set_ylim(ylim)
+        xlim = [min(k_dist), max(k_dist)]
+        ax.set_xlim(xlim)
+        ax.set_xlabel(r"$\mathrm{Wave\ Vector}$", fontsize=28)
+        ylabel = rf"$\mathrm{{Frequencies\ ({u.label})}}$"
+        ax.set_ylabel(ylabel, fontsize=28)
+        ax.tick_params(labelsize=28)
+        # make color legend
+        if site_comb == 'element':
+            labels = [e.symbol for e in self._bs.structure.composition.elements]
+        else:
+            labels = ["group{}".format(i) for i in range(len(site_comb))]
+        if len(indices) == 2:
+            BSDOSPlotter._rb_line(ax, labels[0], labels[1], "best")
+        elif len(indices) == 3:
+            BSDOSPlotter._rgb_triangle(ax, labels[0], labels[1], labels[2], "best")
+        else:
+            # for 4 combinations, build a color square?
+            pass
+        return ax
+        
     def show(self, ylim=None, units="thz"):
         """
         Show the plot using matplotlib.
@@ -739,6 +859,7 @@ class GruneisenPlotter:
             units: unit for the plots, accepted units: thz, ev, mev, ha, cm-1, cm^-1
 
         Returns: plot
+
         """
 
         u = freq_units(units)
@@ -771,6 +892,7 @@ class GruneisenPlotter:
             units: units for the plot, accepted units: thz, ev, mev, ha, cm-1, cm^-1
 
         Returns: plot
+
         """
 
         plt = self.get_plot(units=units)
@@ -785,6 +907,7 @@ class GruneisenPlotter:
             units: accepted units: thz, ev, mev, ha, cm-1, cm^-1
 
         Returns:
+
         """
 
         plt = self.get_plot(units=units)
@@ -811,6 +934,7 @@ class GruneisenPhononBSPlotter(PhononBSPlotter):
         super().__init__(bs)
 
     def bs_plot_data(self):
+
         """
         Get the data nicely formatted for a plot
 
@@ -928,6 +1052,7 @@ class GruneisenPhononBSPlotter(PhononBSPlotter):
 
         Returns:
             a matplotlib object with both band structures
+
         """
 
         data_orig = self.bs_plot_data()

--- a/pymatgen/phonon/tests/test_plotter.py
+++ b/pymatgen/phonon/tests/test_plotter.py
@@ -76,6 +76,13 @@ class PhononBSPlotterTest(unittest.TestCase):
 
         rc("text", usetex=False)
         self.plotter.get_plot(units="mev")
+        
+    def test_proj_plot(self):
+        # Disabling latex for testing.
+        from matplotlib import rc
+
+        rc("text", usetex=False)
+        self.plotter.get_proj_plot(units="mev")
 
     def test_plot_compare(self):
         # Disabling latex for testing.

--- a/pymatgen/phonon/tests/test_plotter.py
+++ b/pymatgen/phonon/tests/test_plotter.py
@@ -87,14 +87,14 @@ class PhononBSPlotterTest(unittest.TestCase):
 
         rc("text", usetex=False)
         self.plotter.get_proj_plot(units="mev")
-        self.plotter.get_proj_plot(units="mev", ylim=(15,30), rgb_labels=("NA","CL"))
-        self.plotter.get_proj_plot(units="mev", site_comb=[[0],[1]])
-        self.plotter.get_proj_plot(units="mev", site_comb=[[0],[1]])
-        
+        self.plotter.get_proj_plot(units="mev", ylim=(15, 30), rgb_labels=("NA", "CL"))
+        self.plotter.get_proj_plot(units="mev", site_comb=[[0], [1]])
+        self.plotter.get_proj_plot(units="mev", site_comb=[[0], [1]])
+
         self.plotter_sto.get_proj_plot()
-        self.plotter_sto.get_proj_plot(ylim=(-2.5,5),site_comb=[[0],[1],[2,3,4]])
-        self.plotter_sto.get_proj_plot(site_comb=[[0],[1],[2,3,4]], rgb_labels=("SR", "TI", "O"))
-        self.plotter_sto.get_proj_plot(site_comb=[[0],[1],[2],[3,4]])
+        self.plotter_sto.get_proj_plot(ylim=(-2.5, 5), site_comb=[[0], [1], [2, 3, 4]])
+        self.plotter_sto.get_proj_plot(site_comb=[[0], [1], [2, 3, 4]], rgb_labels=("SR", "TI", "O"))
+        self.plotter_sto.get_proj_plot(site_comb=[[0], [1], [2], [3, 4]])
 
     def test_plot_compare(self):
         # Disabling latex for testing.

--- a/pymatgen/phonon/tests/test_plotter.py
+++ b/pymatgen/phonon/tests/test_plotter.py
@@ -50,6 +50,10 @@ class PhononBSPlotterTest(unittest.TestCase):
             d = json.loads(f.read())
             self.bs = PhononBandStructureSymmLine.from_dict(d)
             self.plotter = PhononBSPlotter(self.bs)
+        with open(os.path.join(PymatgenTest.TEST_FILES_DIR, "SrTiO3_phonon_bandstructure.json")) as f:
+            d = json.loads(f.read())
+            self.bs_sto = PhononBandStructureSymmLine.from_dict(d)
+            self.plotter_sto = PhononBSPlotter(self.bs_sto)
 
     def test_bs_plot_data(self):
         self.assertEqual(
@@ -83,6 +87,11 @@ class PhononBSPlotterTest(unittest.TestCase):
 
         rc("text", usetex=False)
         self.plotter.get_proj_plot(units="mev")
+        self.plotter.get_proj_plot(units="mev", site_comb=[[0],[1]])
+        
+        self.plotter_sto.get_proj_plot()
+        self.plotter_sto.get_proj_plot(site_comb=[[0],[1],[2,3,4]])
+        self.plotter_sto.get_proj_plot(site_comb=[[0],[1],[2],[3,4]])
 
     def test_plot_compare(self):
         # Disabling latex for testing.

--- a/pymatgen/phonon/tests/test_plotter.py
+++ b/pymatgen/phonon/tests/test_plotter.py
@@ -76,7 +76,7 @@ class PhononBSPlotterTest(unittest.TestCase):
 
         rc("text", usetex=False)
         self.plotter.get_plot(units="mev")
-        
+
     def test_proj_plot(self):
         # Disabling latex for testing.
         from matplotlib import rc

--- a/pymatgen/phonon/tests/test_plotter.py
+++ b/pymatgen/phonon/tests/test_plotter.py
@@ -87,9 +87,11 @@ class PhononBSPlotterTest(unittest.TestCase):
 
         rc("text", usetex=False)
         self.plotter.get_proj_plot(units="mev")
+        self.plotter.get_proj_plot(units="mev", ylim=(15,30))
         self.plotter.get_proj_plot(units="mev", site_comb=[[0],[1]])
         
         self.plotter_sto.get_proj_plot()
+        self.plotter_sto.get_proj_plot(ylim=(-2.5,5))
         self.plotter_sto.get_proj_plot(site_comb=[[0],[1],[2,3,4]])
         self.plotter_sto.get_proj_plot(site_comb=[[0],[1],[2],[3,4]])
 

--- a/pymatgen/phonon/tests/test_plotter.py
+++ b/pymatgen/phonon/tests/test_plotter.py
@@ -87,12 +87,13 @@ class PhononBSPlotterTest(unittest.TestCase):
 
         rc("text", usetex=False)
         self.plotter.get_proj_plot(units="mev")
-        self.plotter.get_proj_plot(units="mev", ylim=(15,30))
+        self.plotter.get_proj_plot(units="mev", ylim=(15,30), rgb_labels=("NA","CL"))
+        self.plotter.get_proj_plot(units="mev", site_comb=[[0],[1]])
         self.plotter.get_proj_plot(units="mev", site_comb=[[0],[1]])
         
         self.plotter_sto.get_proj_plot()
-        self.plotter_sto.get_proj_plot(ylim=(-2.5,5))
-        self.plotter_sto.get_proj_plot(site_comb=[[0],[1],[2,3,4]])
+        self.plotter_sto.get_proj_plot(ylim=(-2.5,5),site_comb=[[0],[1],[2,3,4]])
+        self.plotter_sto.get_proj_plot(site_comb=[[0],[1],[2,3,4]], rgb_labels=("SR", "TI", "O"))
         self.plotter_sto.get_proj_plot(site_comb=[[0],[1],[2],[3,4]])
 
     def test_plot_compare(self):


### PR DESCRIPTION

## Summary

A method that allows users to plot the atom-resolved phonon band structures. The contribution from each type (or group) of atoms is calculated based on the magnitude of the eigendisplacements.  Support 2 (rb), 3 (rgb) and 4 (cmyk) unique groups of atoms.

So far I just used the existing NaCl example for testing, let me know if more cases are needed!

## Additional dependencies introduced (if any)

matplotlib.pyplot.plt —> essential for the colored plot
matplotlib.collections.LineCollection —> essential for the colored plot
pymatgen.electronic_structure.plotter.BSDOSPlotter —> For creating the color line and color triangle

## TODO (if any)

1. Make a color legend for the 4-color case.
2. Allow projecting band based on eigenvectors instead of eigendisplacement?

I would appreciate any suggestions from you! Thanks.