### PR TITLE
Fix `TqdmExperimentalWarning`: Using `tqdm.autonotebook.tqdm` in notebook mode

### DIFF
--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -23,7 +23,7 @@ import plotly.graph_objs as go
 from monty.json import MontyDecoder, MSONable
 from scipy.optimize import minimize
 from scipy.spatial import ConvexHull
-from tqdm.autonotebook import tqdm
+from tqdm import tqdm
 
 from pymatgen.analysis.reaction_calculator import Reaction, ReactionError
 from pymatgen.core.composition import Composition, SpeciesLike


### PR DESCRIPTION
Occurs when importing `from pymatgen.ext.matproj import MPRester` in Jupyter.


Rest of warning: `pymatgen/analysis/phase_diagram.py:26`: Use `tqdm.tqdm` instead to force console mode (e.g. in jupyter console).