### PR TITLE
Run CI in lowest supported Python version

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       max-parallel: 20
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.8']
         # This distribution of tests is designed to ensure an approximately even time to finish for parallel jobs.
         include:
           - pkg: pymatgen/analysis/chemenv pymatgen/analysis/elasticity pymatgen/analysis/magnetism

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -14,7 +14,7 @@ jobs:
       max-parallel: 20
       matrix:
         os: [macos-latest]
-        python-version: ['3.10']
+        python-version: ['3.8']
         # This distribution of tests is designed to ensure an approximately even time to finish for parallel jobs.
         pkg:
           - pymatgen/analysis/chemenv pymatgen/analysis/elasticity pymatgen/analysis/magnetism

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -14,7 +14,7 @@ jobs:
       max-parallel: 20
       matrix:
         os: [windows-latest]
-        python-version: ['3.9']
+        python-version: ['3.8']
         # This distribution of tests is designed to ensure an approximately even time to finish for parallel jobs.
         pkg:
           - pymatgen/analysis/chemenv pymatgen/analysis/elasticity pymatgen/analysis/magnetism

--- a/pymatgen/core/trajectory.py
+++ b/pymatgen/core/trajectory.py
@@ -95,7 +95,7 @@ class Trajectory(MSONable):
                 `M=2`, the `frame_properties` can be [{'energy':1.0}, {'energy':2.0}].
             constant_lattice: Whether the lattice changes during the simulation.
                 Should be used together with `lattice`. See usage there.
-            time_step: Timestep of MD simulation in femto-seconds. Should be `None`
+            time_step: Time step of MD simulation in femto-seconds. Should be `None`
                 for relaxation trajectory.
             coords_are_displacement: Whether `frac_coords` are given in displacements
                 (True) or positions (False). Note, if this is `True`, `frac_coords`

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -12,18 +12,13 @@ import logging
 import math
 import warnings
 from collections import Counter
-from typing import Literal, cast
+from typing import List, Literal, cast
 
 import matplotlib.lines as mlines
 import numpy as np
 import scipy.interpolate as scint
 from monty.dev import requires
 from monty.json import jsanitize
-
-try:
-    from mayavi import mlab
-except ImportError:
-    mlab = None
 
 from pymatgen.core.periodic_table import Element
 from pymatgen.electronic_structure.bandstructure import BandStructureSymmLine
@@ -32,6 +27,11 @@ from pymatgen.electronic_structure.core import OrbitalType, Spin
 from pymatgen.electronic_structure.dos import CompleteDos, Dos
 from pymatgen.util.plotting import add_fig_kwargs, get_ax3d_fig_plt, pretty_plot
 from pymatgen.util.typing import ArrayLike
+
+try:
+    from mayavi import mlab
+except ImportError:
+    mlab = None
 
 __author__ = "Shyue Ping Ong, Geoffroy Hautier, Anubhav Jain"
 __copyright__ = "Copyright 2012, The Materials Project"
@@ -2416,7 +2416,7 @@ class BSDOSPlotter:
             if spin in bs.bands:
                 band_energies[spin] = []
                 for band in bs.bands[spin]:
-                    band = cast(list[float], band)
+                    band = cast(List[float], band)
                     band_energies[spin].append([e - bs.efermi for e in band])  # type: ignore
 
         # renormalize the DOS energies to Fermi level

--- a/pymatgen/io/lammps/outputs.py
+++ b/pymatgen/io/lammps/outputs.py
@@ -36,7 +36,7 @@ class LammpsDump(MSONable):
         Base constructor.
 
         Args:
-            timestep (int): Current timestep.
+            timestep (int): Current time step.
             natoms (int): Total number of atoms in the box.
             box (LammpsBox): Simulation box.
             data (pd.DataFrame): Dumped atomic data.
@@ -56,7 +56,7 @@ class LammpsDump(MSONable):
         """
         lines = string.split("\n")
         timestep = int(lines[1])
-        natoms = int(lines[3])
+        n_atoms = int(lines[3])
         box_arr = np.loadtxt(StringIO("\n".join(lines[5:8])))
         bounds = box_arr[:, :2]
         tilt = None
@@ -68,7 +68,7 @@ class LammpsDump(MSONable):
         box = LammpsBox(bounds, tilt)
         data_head = lines[8].replace("ITEM: ATOMS", "").split()
         data = pd.read_csv(StringIO("\n".join(lines[9:])), names=data_head, delim_whitespace=True)
-        return cls(timestep, natoms, box, data)
+        return cls(timestep, n_atoms, box, data)
 
     @classmethod
     def from_dict(cls, d):


### PR DESCRIPTION
The most important Python version to run CI is the lowest supported (currently 3.8). Running in higher versions means we won't catch some SyntaxErrors e.g. from modern type annotations like `lst: list[int] = [1, 2, 3]` (which [I think was the reason](https://github.com/materialsproject/pymatgen/runs/8157637404?check_suite_focus=true) for bumping to 3.10?). Such errors would now pop up at runtime for people below Python 3.10.

If we want to test later Python versions too (e.g. due to upcoming 3.11 release), we should setup a matrix strategy.