### PR TITLE
Split CDER to real and imag parts

### DIFF
--- a/pymatgen/io/vasp/optics.py
+++ b/pymatgen/io/vasp/optics.py
@@ -78,7 +78,6 @@ class DielectricFunctionCalculator(MSONable):
         sspins = [Spin.up, Spin.down]
         eigs = np.stack([bands[spin] for spin in sspins[: vrun.parameters["ISPIN"]]], axis=2)[..., 0]
         eigs = np.swapaxes(eigs, 0, 1)
-        waveder.cder
         kweights = vrun.actual_kpoints_weights
         nedos = vrun.parameters["NEDOS"]
         deltae = vrun.dielectric[0][1]
@@ -116,7 +115,7 @@ class DielectricFunctionCalculator(MSONable):
 
     @property
     def cder(self):
-        """Complex CDER form WAVEDER."""
+        """Complex CDER from WAVEDER."""
         return self.cder_real + self.cder_imag * 1.0j
 
     def get_epsilon(

--- a/pymatgen/io/vasp/optics.py
+++ b/pymatgen/io/vasp/optics.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 __author__ = "Jimmy-Xuan Shen"
 __copyright__ = "Copyright 2022, The Materials Project"
-__maintainer__ = "Jimmy-Xuan Shen :"
+__maintainer__ = "Jimmy-Xuan Shen"
 __email__ = "jmmshn@gmail.com"
 
 

--- a/pymatgen/io/vasp/optics.py
+++ b/pymatgen/io/vasp/optics.py
@@ -78,7 +78,7 @@ class DielectricFunctionCalculator(MSONable):
         sspins = [Spin.up, Spin.down]
         eigs = np.stack([bands[spin] for spin in sspins[: vrun.parameters["ISPIN"]]], axis=2)[..., 0]
         eigs = np.swapaxes(eigs, 0, 1)
-        cder = waveder.cder
+        waveder.cder
         kweights = vrun.actual_kpoints_weights
         nedos = vrun.parameters["NEDOS"]
         deltae = vrun.dielectric[0][1]
@@ -117,7 +117,7 @@ class DielectricFunctionCalculator(MSONable):
     @property
     def cder(self):
         """Complex CDER form WAVEDER."""
-        return self.cder_real + cder_imag * 1.j
+        return self.cder_real + cder_imag * 1.0j
 
     def get_epsilon(
         self,

--- a/pymatgen/io/vasp/optics.py
+++ b/pymatgen/io/vasp/optics.py
@@ -1,13 +1,13 @@
 # Copyright (c) Pymatgen Development Team.
 # Distributed under the terms of the MIT License.
 """Classes for parsing and manipulating VASP optical properties calculations."""
+from __future__ import annotations
 
 __author__ = "Jimmy-Xuan Shen"
 __copyright__ = "Copyright 2022, The Materials Project"
-__maintainer__ = "Jimmy-Xuan Shen"
+__maintainer__ = "Jimmy-Xuan Shen :"
 __email__ = "jmmshn@gmail.com"
 
-from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
@@ -117,7 +117,7 @@ class DielectricFunctionCalculator(MSONable):
     @property
     def cder(self):
         """Complex CDER form WAVEDER."""
-        return self.cder_real + cder_imag * 1.0j
+        return self.cder_real + self.cder_imag * 1.0j
 
     def get_epsilon(
         self,

--- a/pymatgen/io/vasp/optics.py
+++ b/pymatgen/io/vasp/optics.py
@@ -1,6 +1,12 @@
 # Copyright (c) Pymatgen Development Team.
 # Distributed under the terms of the MIT License.
 """Classes for parsing and manipulating VASP optical properties calculations."""
+
+__author__ = "Jimmy-Xuan Shen"
+__copyright__ = "Copyright 2022, The Materials Project"
+__maintainer__ = "Jimmy-Xuan Shen"
+__email__ = "jmmshn@gmail.com"
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -46,7 +52,8 @@ class DielectricFunctionCalculator(MSONable):
     we can dramatically speed up the calculations here by considering only the irreducible kpoints.
     """
 
-    cder: npt.NDArray
+    cder_real: npt.NDArray
+    cder_imag: npt.NDArray
     eigs: npt.NDArray
     kweights: npt.NDArray
     nedos: int
@@ -85,7 +92,8 @@ class DielectricFunctionCalculator(MSONable):
             raise NotImplementedError("ISYM != 0 is not implemented yet")
 
         return DielectricFunctionCalculator(
-            cder=cder,
+            cder_real=waveder.cder_real,
+            cder_imag=waveder.cder_imag,
             eigs=eigs,
             kweights=kweights,
             nedos=nedos,
@@ -105,6 +113,11 @@ class DielectricFunctionCalculator(MSONable):
         vrun = Vasprun(d_ / "vasprun.xml")
         waveder = Waveder.from_binary(d_ / "WAVEDER")
         return cls.from_vasp_objects(vrun, waveder)
+
+    @property
+    def cder(self):
+        """Complex CDER form WAVEDER."""
+        return self.cder_real + cder_imag * 1.j
 
     def get_epsilon(
         self,


### PR DESCRIPTION
## Split CDER into real and imag parts

Serialization of complex ndarray is not supported by MSONable.
So any large object with complex numbers that need to be serialized should have the real and imaginary part split into two different arrays.