### PR TITLE
No double CI runs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,10 @@
 name: Linting
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 permissions:
   contents: read

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -3,7 +3,11 @@
 # The ext package is also only tested in this workflow. Coverage is also computed based on this platform.
 name: Testing Linux
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 permissions:
   contents: read

--- a/metadata.yml
+++ b/metadata.yml
@@ -6,748 +6,599 @@ accessibility: OS
 software_type: S
 developers:
 - affiliations: ['University of California, Berkeley', Lawrence Berkeley National Laboratory]
-  email: ''
   first_name: Iulia-Oxana
   last_name: Andriuc
   orcid: ''
 - affiliations: [Micron Technology Inc.]
-  email: ''
   first_name: Saurabh
   last_name: Bajaj
   orcid: ''
 - affiliations: [Hitachi]
-  email: ''
   first_name: Janakiraman
   last_name: Balachandran
   orcid: ''
 - affiliations: [Optum]
-  email: ''
   first_name: Tonnam
   last_name: Balankura
   orcid: ''
 - affiliations: ['University of California, Berkeley']
-  email: ''
   first_name: Luis
   last_name: Barroso-Luque
   orcid: ''
 - affiliations: [Tilde Materials Informatics]
-  email: ''
   first_name: Evgeny
   last_name: Blokhin
   orcid: 0000-0002-5333-3947
 - affiliations: [The Pennsylvania State University]
-  email: ''
   first_name: Brandon
   last_name: Bocklund
   orcid: 0000-0002-3264-8413
 - affiliations: [RWTH Aachen University, Université catholique de Louvain]
-  email: ''
   first_name: Alexander
   last_name: Bonkowski
   orcid: 0000-0002-0525-4742
 - affiliations: [Lawrence Berkeley National Laboratory]
-  email: ''
   first_name: Danny
   last_name: Broberg
   orcid: ''
 - affiliations: [University of Pennsylvania]
-  email: ''
   first_name: Nathan
   last_name: C. Frey
   orcid: 0000-0001-5291-6131
 - affiliations: [University College London]
-  email: ''
   first_name: Bruno
   last_name: Camino
   orcid: 0000-0002-9569-2219
 - affiliations: [Cornell University]
-  email: ''
   first_name: Rees
   last_name: Chang
   orcid: ''
 - affiliations: [University of California, San Diego]
-  email: ''
   first_name: Chi
   last_name: Chen
   orcid: ''
 - affiliations: [Institute of Applied Physics and Computational Mathematics]
-  email: ''
   first_name: Xin
   last_name: Chen
   orcid: 0000-0001-9643-0870
 - affiliations: [University of California, San Diego]
-  email: ''
   first_name: Yiming
   last_name: Chen
   orcid: 0000-0002-1501-5550
 - affiliations: [Lawrence Berkeley National Laboratory]
-  email: ''
   first_name: Shreyas
   last_name: Cholia
   orcid: 0000-0002-4775-8201
 - affiliations: [National Institute of Standards and Technology]
-  email: ''
   first_name: Kamal
   last_name: Choudhary
   orcid: 0000-0001-9737-8074
 - affiliations: [UC Berkeley, Lawrence Berkeley National Laboratory]
-  email: ''
   first_name: Orion
   last_name: Cohen
   orcid: ''
 - affiliations: [University of Florida]
-  email: ''
   first_name: Conrad
   last_name: Cole
   orcid: ''
 - affiliations: [Lawrence Berkeley National Laboratory]
-  email: ''
   first_name: John
   last_name: Dagdelen
   orcid: ''
 - affiliations: [Light Bytes Technology Ltd.]
-  email: ''
   first_name: Liam
   last_name: Deacon
   orcid: ''
 - affiliations: [D. E. Shaw Research]
-  email: ''
   first_name: Elizabeth
   last_name: Decolvenaere
   orcid: 0000-0002-6350-3559
 - affiliations: [Centre for Advanced 2D Materials, National University of Singapore]
-  email: ''
   first_name: Miguel
   last_name: Dias Costa
   orcid: 0000-0001-8859-5763
 - affiliations: [University of Liverpool]
-  email: ''
   first_name: Robert
   last_name: Dickson
   orcid: 0000-0003-3007-808X
 - affiliations: [Lawrence Berkeley National Laboratory, 'University of California, Berkeley']
-  email: ''
   first_name: Alex
   last_name: Dunn
   orcid: 0000-0002-8567-1879
 - affiliations: [LBL]
-  email: ''
   first_name: Shyam
   last_name: Dwaraknath
   orcid: 0000-0003-0289-2607
 - affiliations: [Northwestern University]
-  email: ''
   first_name: Maxwell
   last_name: Dylla
   orcid: ''
 - affiliations: [University of California, Santa Barbara]
-  email: ''
   first_name: Mark
   last_name: E. Turiansky
   orcid: 0000-0002-9154-3582
 - affiliations: [Swiss Federal Laboratories for Materials Science and Technology]
-  email: ''
   first_name: Kristjan
   last_name: Eimre
   orcid: 0000-0002-3444-3286
 - affiliations: ['University of California, Berkeley', ' Lawrence Berkeley National Laboratory']
-  email: ''
   first_name: Alex
   last_name: Epstein
   orcid: 0000-0002-9914-2388
 - affiliations: [UCLouvain]
-  email: ''
   first_name: Matthew
   last_name: Evans
   orcid: 0000-0002-1182-9098
-- affiliations: ["CERMICS, Inria Paris and École des Ponts-ParisTech"]
-  email: ''
+- affiliations: ['CERMICS, Inria Paris and École des Ponts-ParisTech']
   first_name: Michael
   last_name: F. Herbst
   orcid: 0000-0003-0378-7921
-- affiliations: ["Université catholique de Louvain"]
-  email: ''
+- affiliations: [Université catholique de Louvain]
   first_name: Adam
   last_name: Fekete
   orcid: ''
 - affiliations: [Northwestern University]
-  email: ''
   first_name: Dale
   last_name: Gaines II
   orcid: 0000-0001-9280-1240
 - affiliations: [Lawrence Berkeley National Laboratory]
-  email: ''
   first_name: Alex
   last_name: Ganose
   orcid: 0000-0002-4486-3321
-- affiliations: ["Federal Institute for Materials Research and Testing (BAM), Berlin, Germany. Friedrich-Schiller-Universität Jena, Germany."]
-  email: ''
+- affiliations: ['Federal Institute for Materials Research and Testing (BAM), Berlin, Germany. Friedrich-Schiller-Universität Jena, Germany.']
   first_name: Janine
   last_name: George
   orcid: 0000-0001-8907-0336
 - affiliations: [University of Pau and Pays de l'Adour]
-  email: ''
   first_name: Salvato-Vallverdu
   last_name: Germain
   orcid: 0000-0003-1116-8776
-- affiliations: ["Université catholique de Louvain"]
-  email: ''
+- affiliations: [Université catholique de Louvain]
   first_name: Matteo
   last_name: Giantomassi
   orcid: ''
-- affiliations: ["Université catholique de Louvain"]
-  email: ''
+- affiliations: [Université catholique de Louvain]
   first_name: Yannick
   last_name: Gillet
   orcid: 0000-0001-6201-0317
 - affiliations: [University of Cambridge]
-  email: ''
   first_name: Rhys
   last_name: Goodall
   orcid: 0000-0002-6589-1700
 - affiliations: [Lawrence Berkeley National Laboratory]
-  email: ''
   first_name: Dan
   last_name: Gunter
   orcid: 0000-0002-2779-2744
 - affiliations: ['University of California, Berkeley']
-  email: ''
   first_name: Ayush
   last_name: Gupta
   orcid: ''
 - affiliations: [University of Texas at Austin]
-  email: ''
   first_name: Viet-Anh
   last_name: Ha
   orcid: 0000-0002-6665-1274
 - affiliations: [Los Alamos National Laboratory]
-  email: ''
   first_name: Steven
   last_name: Hartman
   orcid: ''
-- affiliations: ["Université catholique de Louvain"]
-  email: ''
+- affiliations: [Université catholique de Louvain]
   first_name: Geoffroy
   last_name: Hautier
   orcid: 0000-0003-1754-2220
 - affiliations: [Max Planck Institute for Solid State Research]
-  email: ''
   first_name: Niclas
   last_name: Heinsdorf
   orcid: ''
 - affiliations: [West Virginia University]
-  email: ''
   first_name: Uthpala
   last_name: Herath
   orcid: 0000-0002-4585-3002
 - affiliations: [West Virginia University]
-  email: ''
   first_name: Uthpala
-  last_name: 'Herath '
+  last_name: Herath
   orcid: 0000-0002-4585-3002
 - affiliations: []
-  email: ''
   first_name: Tim
   last_name: Holme
   orcid: 0000-0003-3789-3511
 - affiliations: [Lawrence Berkeley National Laboratory]
-  email: ''
   first_name: Matthew
   last_name: Horton
   orcid: 0000-0001-7777-8871
 - affiliations: ['University of California, Berkeley']
-  email: ''
   first_name: Tingzheng
   last_name: Hou
   orcid: 0000-0002-7163-2561
 - affiliations: ['University of California, Berkeley']
-  email: ''
   first_name: Yu
   last_name: Hsuan Liang
   orcid: ''
 - affiliations: [Lawrence Berkeley National Laboratory]
-  email: ''
   first_name: Patrick
   last_name: Huck
   orcid: ''
 - affiliations: [University of Notre Dame]
-  email: ''
   first_name: Michael
   last_name: Humbert
   orcid: 0000-0003-1966-6382
 - affiliations: [Toyota Research Institute]
-  email: ''
   first_name: Linda
   last_name: Hung
   orcid: 0000-0002-1578-6152
 - affiliations: [Scientific Computing Department, Science and Technology Facilities Council, UK]
-  email: ''
   first_name: Adam
   last_name: J. Jackson
   orcid: 0000-0001-5272-6530
 - affiliations: [University of Bath]
-  email: ''
   first_name: Benjamin
   last_name: J. Morgan
   orcid: 0000-0002-3056-8233
 - affiliations: [imec Leuven, ' European Theoretical Spectroscopy Facility']
-  email: ''
   first_name: Michiel
   last_name: J. van Setten
   orcid: 0000-0003-0557-5260
 - affiliations: [Lawrence Berkeley National Laboratory]
-  email: ''
   first_name: Anubhav
   last_name: Jain
   orcid: 0000-0001-5893-9967
 - affiliations: [SUNY Stony Brook]
-  email: ''
   first_name: Jonathan
   last_name: James Denney
   orcid: 0000-0002-7615-997X
 - affiliations: [Los Alamos National Laboratory]
-  email: ''
   first_name: Jan
   last_name: Janssen
   orcid: 0000-0001-9948-7119
-- affiliations: ["Max-Planck-Institut für Eisenforschung GmbH"]
-  email: ''
+- affiliations: [Max-Planck-Institut für Eisenforschung GmbH]
   first_name: Jan
-  last_name: 'Janssen '
+  last_name: Janssen
   orcid: 0000-0001-9948-7119
-- affiliations: [RWTH Aachen, " Forschungszentrum Jülich"]
-  email: ''
+- affiliations: [RWTH Aachen, Forschungszentrum Jülich]
   first_name: Henning
-  last_name: "Jan\xDFen"
+  last_name: Jan\xDFen
   orcid: 0000-0003-3558-9487
 - affiliations: [Lawrence Berkeley National Laboratory]
-  email: ''
   first_name: Benjamin
   last_name: Justus
   orcid: ''
 - affiliations: [RIKEN]
-  email: ''
   first_name: Eisuke
   last_name: Kawashima
   orcid: ''
 - affiliations: [NIOSH]
-  email: ''
   first_name: Alan
   last_name: Kent Dozier
   orcid: ''
 - affiliations: [Lawrence Berkeley National Laboratory]
-  email: ''
   first_name: Ryan
   last_name: Kingsbury
   orcid: 0000-0002-7168-3967
 - affiliations: [Lawrence Berkeley National Laboratory]
-  email: ''
   first_name: Ryan
   last_name: Kingsbury
   orcid: 0000-0002-7168-3967
 - affiliations: [Erudita]
-  email: ''
   first_name: Michael
   last_name: Kocher
   orcid: ''
 - affiliations: [Institute of Metal Physics, UB RAS]
-  email: ''
   first_name: Dmitry
   last_name: Korotin
   orcid: 0000-0002-4070-2045
 - affiliations: [Tokyo Institute of Technology]
-  email: ''
   first_name: Yu
   last_name: Kumagai
   orcid: 0000-0003-0489-8148
 - affiliations: [Carnegie Mellon University]
-  email: ''
   first_name: Rachel
   last_name: Kurchin
   orcid: 0000-0002-2147-4809
 - affiliations: [Physics, University of California, Berkeley]
-  email: ''
   first_name: Katherine
   last_name: Latimer
   orcid: ''
 - affiliations: [Tsinghua University]
-  email: ''
   first_name: Weitang
   last_name: Li
   orcid: 0000-0002-8739-641X
 - affiliations: [University of California, San Diego]
-  email: ''
   first_name: Xiangguo
   last_name: Li
   orcid: 0000-0002-2062-3809
 - affiliations: [TSMC]
-  email: ''
   first_name: Yuh-Chieh
   last_name: Lin
   orcid: ''
 - affiliations: ['University of California, Berkeley']
-  email: ''
   first_name: Handong
   last_name: Ling
   orcid: ''
-- affiliations: ["University of Michigan - Shanghai Jiao Tong University Joint Institute"]
-  email: ''
+- affiliations: ['University of Michigan - Shanghai Jiao Tong University Joint Institute']
   first_name: Ke
   last_name: Liu
   orcid: 0000-0003-3604-1026
 - affiliations: [California Institute of Technology]
-  email: ''
   first_name: Zachary
   last_name: M Gibbs
   orcid: ''
 - affiliations: [Lawrence Berkeley National Laboratory]
-  email: ''
   first_name: Samuel
   last_name: M. Blau
   orcid: 0000-0003-3132-3032
 - affiliations: [Lawrence Berkeley National Laboratory]
-  email: ''
   first_name: Brandon
   last_name: M. Wood
   orcid: 0000-0002-7251-337X
-- affiliations: ["École Polytechnique Fédérale de Lausanne"]
-  email: ''
+- affiliations: ['École Polytechnique Fédérale de Lausanne']
   first_name: Kevin
   last_name: Maik Jablonka
   orcid: 0000-0003-4894-4660
 - affiliations: []
-  email: ''
   first_name: Kiran
   last_name: Mathew
   orcid: ''
 - affiliations: [University of Wisconsin-Madison]
-  email: ''
   first_name: Tam
   last_name: Mayeshiba
   orcid: 0000-0003-3445-7925
 - affiliations: [Lawrence Berkeley National Laboratory, 'University of California, Berkeley']
-  email: ''
   first_name: Matthew
   last_name: McDermott
   orcid: ''
 - affiliations: [University of Delaware]
-  email: ''
   first_name: Bharat
   last_name: Medasani
   orcid: 0000-0002-2073-4162
 - affiliations: [Brookhaven National Laboratory]
-  email: ''
   first_name: Fanchen
   last_name: Meng
   orcid: ''
 - affiliations: [Brookhaven National Laboratory]
-  email: ''
   first_name: Fanchen
   last_name: Meng
   orcid: ''
 - affiliations: [Vilnius University Institute of Biotechnology]
-  email: ''
   first_name: Andrius
   last_name: Merkys
   orcid: 0000-0002-7731-6236
-- affiliations: ["Université catholique de Louvain"]
-  email: ''
+- affiliations: [Université catholique de Louvain]
   first_name: Henrique
   last_name: Miranda
   orcid: 0000-0002-2843-0876
 - affiliations: [University of Tokyo]
-  email: ''
   first_name: Shishin
   last_name: Mo
   orcid: ''
 - affiliations: [The University of Tokyo]
-  email: ''
   first_name: Shishin
   last_name: Mo
   orcid: ''
 - affiliations: [Toyota Research Institute]
-  email: ''
   first_name: Joseph
   last_name: Montoya
   orcid: 0000-0001-5760-2860
 - affiliations: [Lawrence Berkeley National Laboratory, 'University of California, Berkeley']
-  email: ''
   first_name: Guy
   last_name: Moore
   orcid: ''
 - affiliations: [Lawrence Berkeley National Laboratory]
-  email: ''
   first_name: Jason
   last_name: Munro
   orcid: ''
 - affiliations: [Lawrence Berkeley National Laboratory]
-  email: ''
   first_name: Koki
   last_name: Muraoka
   orcid: 0000-0003-1830-7978
 - affiliations: [Cornell University]
-  email: ''
   first_name: Hillary
   last_name: Pan
   orcid: 0000-0002-4073-2180
 - affiliations: [University of Cagliari]
-  email: ''
   first_name: Drew
   last_name: Parsons
   orcid: 0000-0002-3956-6031
 - affiliations: [Stanford University]
-  email: ''
   first_name: Anjli
   last_name: Patel
   orcid: 0000-0002-0590-7619
 - affiliations: [Frontier Institute of Science and Technology, Xi''an Jiaotong University,
     ' Massachusetts Institute of Technology']
-  email: ''
   first_name: Kai
   last_name: Pei
   orcid: 0000-0001-7378-9987
 - affiliations: []
-  email: ''
   first_name: Ioannis
   last_name: Petousis
   orcid: ''
-- affiliations: ["Université catholique de Louvain"]
-  email: ''
+- affiliations: [Université catholique de Louvain]
   first_name: Guido
   last_name: Petretto
   orcid: ''
 - affiliations: [Brookhaven National Laboratory]
-  email: ''
   first_name: Xiaohui
   last_name: Qu
   orcid: 0000-0001-5651-8405
 - affiliations: ['Materials, Imperial College London', ' Chemistry, University College London', 'Thomas Young Centre']
-  email: ''
-  first_name: "Se\xE1n"
+  first_name: 'Se\xE1n'
   last_name: R. Kavanagh
   orcid: 0000-0003-4577-9647
-- affiliations: ["Friedrich-Schiller-Universität Jena"]
-  email: ''
+- affiliations: ['Friedrich-Schiller-Universität Jena']
   first_name: Jens
-  last_name: "Ren\xE8 Suckert"
+  last_name: 'Ren\xE8 Suckert'
   orcid: ''
-- affiliations: ["IMCN/MODL - Université catholique de Louvain"]
-  email: ''
+- affiliations: ['IMCN/MODL - Université catholique de Louvain']
   first_name: Francesco
   last_name: Ricci
   orcid: 0000-0002-2677-7227
 - affiliations: [University of Cambridge]
-  email: ''
   first_name: Janosh
   last_name: Riebesell
   orcid: ''
 - affiliations: [Department of Chemical & Biological Engineering, Northwestern University]
-  email: ''
   first_name: Andrew
   last_name: Rosen
   orcid: 0000-0002-0141-7006
 - affiliations: [University of California Berkeley]
-  email: ''
   first_name: Ann
   last_name: Rutt
   orcid: 0000-0001-6534-454X
 - affiliations: [Department of Materials Science and Engineering, Massachusetts Institute of Technology]
-  email: ''
   first_name: Daniel
   last_name: Schwalbe-Koda
   orcid: 0000-0001-9176-0854
 - affiliations: [UC Berkeley, LBL]
-  email: ''
   first_name: Jimmy-Xuan
   last_name: Shen
   orcid: 0000-0002-2743-7531
 - affiliations: [Kyoto University]
-  email: ''
   first_name: Kohei
   last_name: Shinohara
   orcid: ''
 - affiliations: [Lawrence Berkeley National Laboratory, 'University of California, Berkeley']
-  email: ''
   first_name: Martin
   last_name: Siron
   orcid: 0000-0002-4562-7814
 - affiliations: ['University of California, Berkeley', ' Lawrence Berkeley National Laboratory']
-  email: ''
   first_name: Eric
   last_name: Sivonxay
   orcid: ''
 - affiliations: [Lawrence Berkeley National Laboratory]
-  email: ''
   first_name: Tess
   last_name: Smidt
   orcid: 0000-0001-5581-5344
 - affiliations: [Karlsruhe Institute of Technology]
-  email: ''
   first_name: Christopher
   last_name: Stihl
   orcid: ''
 - affiliations: [University of North Carolina (Chapel Hill)]
-  email: ''
   first_name: Jack
   last_name: Sundberg
   orcid: 0000-0001-5739-8919
 - affiliations: [High Energy Accelerator Research Organization, SOKENDAI]
-  email: ''
   first_name: Yuta
   last_name: Suzuki
   orcid: 0000-0002-0019-4832
 - affiliations: [Microsoft]
-  email: ''
   first_name: Leopold
   last_name: Talirz
   orcid: 0000-0002-1524-5903
 - affiliations: [PKSHA]
-  email: ''
   first_name: Yohei
   last_name: Tamura
   orcid: ''
 - affiliations: [UC San Diego]
-  email: ''
   first_name: Hanmei
   last_name: Tang
   orcid: 0000-0003-2659-7768
 - affiliations: [Harvard University]
-  email: ''
   first_name: Steven
   last_name: Torrisi
   orcid: 0000-0002-4283-8077
 - affiliations: [University of California, San Diego]
-  email: ''
   first_name: Richard
   last_name: Tran
   orcid: ''
 - affiliations: [Carnegie Mellon University]
-  email: ''
   first_name: Richard
   last_name: Tran
   orcid: 0000-0002-0308-2182
 - affiliations: [ExoMatter GmbH]
-  email: ''
   first_name: Josua
   last_name: Vieten
   orcid: 0000-0002-2060-2039
 - affiliations: ['University of California, Berkeley']
-  email: ''
   first_name: Sudarshan
   last_name: Vijay
   orcid: 0000-0001-8242-0161
-- affiliations: ["Humboldt-Universität zu Berlin"]
-  email: ''
+- affiliations: ['Humboldt-Universität zu Berlin']
   first_name: Christian
   last_name: Vorwerk
   orcid: 0000-0002-2516-9553
 - affiliations: [IDA]
-  email: ''
   first_name: Nicholas
   last_name: Wagner
   orcid: ''
 - affiliations: [Institute for Defense Analyses]
-  email: ''
   first_name: Nicholas
   last_name: Wagner
   orcid: ''
 - affiliations: [Lawrence Berkeley National Laboratory, 'University of California, Berkeley']
-  email: ''
   first_name: Evan
   last_name: Walter Clark Spotte-Smith
   orcid: 0000-0003-1554-197X
 - affiliations: ['University of California, Berkeley']
-  email: ''
   first_name: Amanda
   last_name: Wang
   orcid: ''
 - affiliations: [University of California, San Diego]
-  email: ''
   first_name: Zhenbin
   last_name: Wang
   orcid: ''
 - affiliations: [Argonne National Laboratory]
-  email: ''
   first_name: Logan
   last_name: Ward
   orcid: 0000-0002-1323-5939
-- affiliations: [Argonne National Laboratory ]
-  email: ''
+- affiliations: [Argonne National Laboratory]
   first_name: Logan
-  last_name: 'Ward '
+  last_name: Ward
   orcid: 0000-0002-1323-5939
-- affiliations: ["Université catholique de Louvain"]
-  email: ''
+- affiliations: [Université catholique de Louvain]
   first_name: David
   last_name: Waroquiers
   orcid: ''
 - affiliations: [Michigan Technological University]
-  email: ''
   first_name: Kevin
   last_name: Waters
   orcid: ''
 - affiliations: [Max Planck Institute for Solid State Research]
-  email: ''
   first_name: Oskar
   last_name: Weser
   orcid: 0000-0001-5503-1195
 - affiliations: [University of California Berkeley, Lawrence Berkeley National Lab]
-  email: ''
   first_name: Nicholas
   last_name: Winner
   orcid: 0000-0003-3648-3959
 - affiliations: [Consulting at donnywinston.com]
-  email: ''
   first_name: Donny
   last_name: Winston
   orcid: 0000-0002-8424-0604
 - affiliations: [Computational Materials Physics, Faculty of Physics, University of Vienna]
-  email: ''
   first_name: Michael
   last_name: Wolloch
   orcid: 0000-0002-3419-5526
 - affiliations: [Lawrence Berkeley National Laboratory, 'University of California, Berkeley', ' National Renewable Energy Laboratory']
-  email: ''
   first_name: Rachel
   last_name: Woods-Robinson
   orcid: 0000-0001-5009-9510
 - affiliations: ['University of California, Berkeley']
-  email: ''
   first_name: Michael
   last_name: Wu
   orcid: ''
 - affiliations: ['University of California, Berkeley']
-  email: ''
   first_name: Yihan
   last_name: Xiao
   orcid: 0000-0002-4409-6898
 - affiliations: [McGill University]
-  email: ''
   first_name: Shuaishuai
   last_name: Yuan
   orcid: 0000-0001-8999-5814
 - affiliations: ['Department of Chemistry, University of Bath']
-  email: ''
   first_name: Pezhman
   last_name: Zarabadi-Poor
   orcid: 0000-0002-6377-7592
 - affiliations: [Hebei Vocational University of Technology and Engineering]
-  email: ''
   first_name: Hongsheng
   last_name: Zhao
   orcid: ''
 - affiliations: [UNNC]
-  email: ''
   first_name: Steven
   last_name: Zhu
   orcid: ''
 - affiliations: [Parent]
-  email: ''
   first_name: Nils
   last_name: Zimmermann
   orcid: 0000-0003-1063-5926
 - affiliations: [SpaceX]
-  email: ''
   first_name: Maarten
   last_name: de Jong
   orcid: 0000-0001-9945-1941
@@ -767,5 +618,5 @@ programming_languages: [Python]
 documentation_url: https://pymatgen.org
 country_of_origin: United States
 licenses: [MIT License]
-date_record_added: "2018-06-14"
-date_record_updated: "2022-07-19"
+date_record_added: '2018-06-14'
+date_record_updated: '2022-10-20'

--- a/pymatgen/alchemy/tests/test_filters.py
+++ b/pymatgen/alchemy/tests/test_filters.py
@@ -39,49 +39,49 @@ class ContainsSpecieFilterTest(PymatgenTest):
 
         species1 = [Species("Si", 5), Species("Mg", 2)]
         f1 = ContainsSpecieFilter(species1, strict_compare=True, AND=False)
-        self.assertFalse(f1.test(s), "Incorrect filter")
+        assert not f1.test(s), "Incorrect filter"
         f2 = ContainsSpecieFilter(species1, strict_compare=False, AND=False)
-        self.assertTrue(f2.test(s), "Incorrect filter")
+        assert f2.test(s), "Incorrect filter"
         species2 = [Species("Si", 4), Species("Mg", 2)]
         f3 = ContainsSpecieFilter(species2, strict_compare=True, AND=False)
-        self.assertTrue(f3.test(s), "Incorrect filter")
+        assert f3.test(s), "Incorrect filter"
         f4 = ContainsSpecieFilter(species2, strict_compare=False, AND=False)
-        self.assertTrue(f4.test(s), "Incorrect filter")
+        assert f4.test(s), "Incorrect filter"
 
         species3 = [Species("Si", 5), Species("O", -2)]
         f5 = ContainsSpecieFilter(species3, strict_compare=True, AND=True)
-        self.assertFalse(f5.test(s), "Incorrect filter")
+        assert not f5.test(s), "Incorrect filter"
         f6 = ContainsSpecieFilter(species3, strict_compare=False, AND=True)
-        self.assertTrue(f6.test(s), "Incorrect filter")
+        assert f6.test(s), "Incorrect filter"
         species4 = [Species("Si", 4), Species("Mg", 2)]
         f7 = ContainsSpecieFilter(species4, strict_compare=True, AND=True)
-        self.assertFalse(f7.test(s), "Incorrect filter")
+        assert not f7.test(s), "Incorrect filter"
         f8 = ContainsSpecieFilter(species4, strict_compare=False, AND=True)
-        self.assertFalse(f8.test(s), "Incorrect filter")
+        assert not f8.test(s), "Incorrect filter"
 
     def test_to_from_dict(self):
         species1 = ["Si5+", "Mg2+"]
         f1 = ContainsSpecieFilter(species1, strict_compare=True, AND=False)
         d = f1.as_dict()
-        self.assertIsInstance(ContainsSpecieFilter.from_dict(d), ContainsSpecieFilter)
+        assert isinstance(ContainsSpecieFilter.from_dict(d), ContainsSpecieFilter)
 
 
 class SpecieProximityFilterTest(PymatgenTest):
     def test_filter(self):
         s = self.get_structure("Li10GeP2S12")
         sf = SpecieProximityFilter({"Li": 1})
-        self.assertTrue(sf.test(s))
+        assert sf.test(s)
         sf = SpecieProximityFilter({"Li": 2})
-        self.assertFalse(sf.test(s))
+        assert not sf.test(s)
         sf = SpecieProximityFilter({"P": 1})
-        self.assertTrue(sf.test(s))
+        assert sf.test(s)
         sf = SpecieProximityFilter({"P": 5})
-        self.assertFalse(sf.test(s))
+        assert not sf.test(s)
 
     def test_to_from_dict(self):
         sf = SpecieProximityFilter({"Li": 1})
         d = sf.as_dict()
-        self.assertIsInstance(SpecieProximityFilter.from_dict(d), SpecieProximityFilter)
+        assert isinstance(SpecieProximityFilter.from_dict(d), SpecieProximityFilter)
 
 
 class RemoveDuplicatesFilterTest(unittest.TestCase):
@@ -95,12 +95,12 @@ class RemoveDuplicatesFilterTest(unittest.TestCase):
         transmuter = StandardTransmuter.from_structures(self._struct_list)
         fil = RemoveDuplicatesFilter()
         transmuter.apply_filter(fil)
-        self.assertEqual(len(transmuter.transformed_structures), 11)
+        assert len(transmuter.transformed_structures) == 11
 
     def test_to_from_dict(self):
         fil = RemoveDuplicatesFilter()
         d = fil.as_dict()
-        self.assertIsInstance(RemoveDuplicatesFilter().from_dict(d), RemoveDuplicatesFilter)
+        assert isinstance(RemoveDuplicatesFilter().from_dict(d), RemoveDuplicatesFilter)
 
 
 class RemoveExistingFilterTest(unittest.TestCase):
@@ -115,12 +115,10 @@ class RemoveExistingFilterTest(unittest.TestCase):
         fil = RemoveExistingFilter(self._exisiting_structures)
         transmuter = StandardTransmuter.from_structures(self._struct_list)
         transmuter.apply_filter(fil)
-        self.assertEqual(len(transmuter.transformed_structures), 1)
-        self.assertTrue(
-            self._sm.fit(
-                self._struct_list[-1],
-                transmuter.transformed_structures[-1].final_structure,
-            )
+        assert len(transmuter.transformed_structures) == 1
+        assert self._sm.fit(
+            self._struct_list[-1],
+            transmuter.transformed_structures[-1].final_structure,
         )
 
 

--- a/pymatgen/alchemy/tests/test_materials.py
+++ b/pymatgen/alchemy/tests/test_materials.py
@@ -6,6 +6,8 @@ import os
 import unittest
 import warnings
 
+import pytest
+
 from pymatgen.alchemy.filters import ContainsSpecieFilter
 from pymatgen.alchemy.materials import TransformedStructure
 from pymatgen.core import SETTINGS
@@ -30,8 +32,8 @@ class TransformedStructureTest(PymatgenTest):
     def test_append_transformation(self):
         t = SubstitutionTransformation({"Fe": "Mn"})
         self.trans.append_transformation(t)
-        self.assertEqual("NaMnPO4", self.trans.final_structure.composition.reduced_formula)
-        self.assertEqual(len(self.trans.structures), 3)
+        assert "NaMnPO4" == self.trans.final_structure.composition.reduced_formula
+        assert len(self.trans.structures) == 3
         coords = []
         coords.append([0, 0, 0])
         coords.append([0.75, 0.5, 0.75])
@@ -47,7 +49,7 @@ class TransformedStructureTest(PymatgenTest):
             PartialRemoveSpecieTransformation("Si4+", 0.5, algo=PartialRemoveSpecieTransformation.ALGO_COMPLETE),
             5,
         )
-        self.assertEqual(len(alt), 2)
+        assert len(alt) == 2
 
     def test_append_filter(self):
         f3 = ContainsSpecieFilter(["O2-"], strict_compare=True, AND=False)
@@ -56,11 +58,11 @@ class TransformedStructureTest(PymatgenTest):
     def test_get_vasp_input(self):
         SETTINGS["PMG_VASP_PSP_DIR"] = PymatgenTest.TEST_FILES_DIR
         potcar = self.trans.get_vasp_input(MPRelaxSet)["POTCAR"]
-        self.assertEqual("Na_pv\nFe_pv\nP\nO", "\n".join([p.symbol for p in potcar]))
-        self.assertEqual(len(self.trans.structures), 2)
+        assert "Na_pv\nFe_pv\nP\nO" == "\n".join([p.symbol for p in potcar])
+        assert len(self.trans.structures) == 2
 
     def test_final_structure(self):
-        self.assertEqual("NaFePO4", self.trans.final_structure.composition.reduced_formula)
+        assert "NaFePO4" == self.trans.final_structure.composition.reduced_formula
 
     def test_from_dict(self):
         d = json.load(open(os.path.join(PymatgenTest.TEST_FILES_DIR, "transformations.json")))
@@ -68,8 +70,8 @@ class TransformedStructureTest(PymatgenTest):
         ts = TransformedStructure.from_dict(d)
         ts.other_parameters["author"] = "Will"
         ts.append_transformation(SubstitutionTransformation({"Fe": "Mn"}))
-        self.assertEqual("MnPO4", ts.final_structure.composition.reduced_formula)
-        self.assertEqual(ts.other_parameters, {"author": "Will", "tags": ["test"]})
+        assert "MnPO4" == ts.final_structure.composition.reduced_formula
+        assert ts.other_parameters == {"author": "Will", "tags": ["test"]}
 
     def test_undo_and_redo_last_change(self):
         trans = [
@@ -77,17 +79,19 @@ class TransformedStructureTest(PymatgenTest):
             SubstitutionTransformation({"Fe": "Mn"}),
         ]
         ts = TransformedStructure(self.structure, trans)
-        self.assertEqual("NaMnPO4", ts.final_structure.composition.reduced_formula)
+        assert "NaMnPO4" == ts.final_structure.composition.reduced_formula
         ts.undo_last_change()
-        self.assertEqual("NaFePO4", ts.final_structure.composition.reduced_formula)
+        assert "NaFePO4" == ts.final_structure.composition.reduced_formula
         ts.undo_last_change()
-        self.assertEqual("LiFePO4", ts.final_structure.composition.reduced_formula)
-        self.assertRaises(IndexError, ts.undo_last_change)
+        assert "LiFePO4" == ts.final_structure.composition.reduced_formula
+        with pytest.raises(IndexError):
+            ts.undo_last_change()
         ts.redo_next_change()
-        self.assertEqual("NaFePO4", ts.final_structure.composition.reduced_formula)
+        assert "NaFePO4" == ts.final_structure.composition.reduced_formula
         ts.redo_next_change()
-        self.assertEqual("NaMnPO4", ts.final_structure.composition.reduced_formula)
-        self.assertRaises(IndexError, ts.redo_next_change)
+        assert "NaMnPO4" == ts.final_structure.composition.reduced_formula
+        with pytest.raises(IndexError):
+            ts.redo_next_change()
         # Make sure that this works with filters.
         f3 = ContainsSpecieFilter(["O2-"], strict_compare=True, AND=False)
         ts.append_filter(f3)
@@ -97,29 +101,25 @@ class TransformedStructureTest(PymatgenTest):
     def test_as_dict(self):
         self.trans.set_parameter("author", "will")
         d = self.trans.as_dict()
-        self.assertIn("last_modified", d)
-        self.assertIn("history", d)
-        self.assertIn("author", d["other_parameters"])
-        self.assertEqual(Structure.from_dict(d).formula, "Na4 Fe4 P4 O16")
+        assert "last_modified" in d
+        assert "history" in d
+        assert "author" in d["other_parameters"]
+        assert Structure.from_dict(d).formula == "Na4 Fe4 P4 O16"
 
     def test_snl(self):
         self.trans.set_parameter("author", "will")
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             snl = self.trans.to_snl([("will", "will@test.com")])
-            self.assertEqual(
-                len(w),
-                1,
-                "Warning not raised on type conversion with other_parameters",
-            )
+            assert len(w) == 1, "Warning not raised on type conversion with other_parameters"
         ts = TransformedStructure.from_snl(snl)
-        self.assertEqual(ts.history[-1]["@class"], "SubstitutionTransformation")
+        assert ts.history[-1]["@class"] == "SubstitutionTransformation"
 
         h = ("testname", "testURL", {"test": "testing"})
         snl = StructureNL(ts.final_structure, [("will", "will@test.com")], history=[h])
         snl = TransformedStructure.from_snl(snl).to_snl([("notwill", "notwill@test.com")])
-        self.assertEqual(snl.history, [h])
-        self.assertEqual(snl.authors, [("notwill", "notwill@test.com")])
+        assert snl.history == [h]
+        assert snl.authors == [("notwill", "notwill@test.com")]
 
 
 if __name__ == "__main__":

--- a/pymatgen/alchemy/tests/test_transmuters.py
+++ b/pymatgen/alchemy/tests/test_transmuters.py
@@ -27,11 +27,11 @@ class CifTransmuterTest(PymatgenTest):
         trans = []
         trans.append(SubstitutionTransformation({"Fe": "Mn", "Fe2+": "Mn2+"}))
         tsc = CifTransmuter.from_filenames([os.path.join(self.TEST_FILES_DIR, "MultiStructure.cif")], trans)
-        self.assertEqual(len(tsc), 2)
+        assert len(tsc) == 2
         expected_ans = {"Mn", "O", "Li", "P"}
         for s in tsc:
             els = {el.symbol for el in s.final_structure.composition.elements}
-            self.assertEqual(expected_ans, els)
+            assert expected_ans == els
 
 
 class PoscarTransmuterTest(PymatgenTest):
@@ -41,20 +41,20 @@ class PoscarTransmuterTest(PymatgenTest):
         tsc = PoscarTransmuter.from_filenames(
             [os.path.join(self.TEST_FILES_DIR, "POSCAR"), os.path.join(self.TEST_FILES_DIR, "POSCAR")], trans
         )
-        self.assertEqual(len(tsc), 2)
+        assert len(tsc) == 2
         expected_ans = {"Mn", "O", "P"}
         for s in tsc:
             els = {el.symbol for el in s.final_structure.composition.elements}
-            self.assertEqual(expected_ans, els)
+            assert expected_ans == els
 
     def test_transmuter(self):
         tsc = PoscarTransmuter.from_filenames([os.path.join(self.TEST_FILES_DIR, "POSCAR")])
         tsc.append_transformation(RemoveSpeciesTransformation("O"))
-        self.assertEqual(len(tsc[0].final_structure), 8)
+        assert len(tsc[0].final_structure) == 8
 
         tsc.append_transformation(SubstitutionTransformation({"Fe": {"Fe2+": 0.25, "Mn3+": 0.75}, "P": "P5+"}))
         tsc.append_transformation(OrderDisorderedStructureTransformation(), extend_collection=50)
-        self.assertEqual(len(tsc), 4)
+        assert len(tsc) == 4
 
         t = SuperTransformation(
             [
@@ -64,37 +64,24 @@ class PoscarTransmuterTest(PymatgenTest):
             ]
         )
         tsc.append_transformation(t, extend_collection=True)
-        self.assertEqual(len(tsc), 12)
+        assert len(tsc) == 12
         for x in tsc:
             # should be 4 trans + starting structure
-            self.assertEqual(
-                len(x),
-                5,
-                "something might be wrong with the number of transformations in the history",
-            )
+            assert len(x) == 5, "something might be wrong with the number of transformations in the history"
 
         # test the filter
         tsc.apply_filter(ContainsSpecieFilter(["Zn2+", "Be2+", "Mn4+"], strict_compare=True, AND=False))
-        self.assertEqual(len(tsc), 8)
-        self.assertEqual(
-            tsc.transformed_structures[0].as_dict()["history"][-1]["@class"],
-            "ContainsSpecieFilter",
-        )
+        assert len(tsc) == 8
+        assert tsc.transformed_structures[0].as_dict()["history"][-1]["@class"] == "ContainsSpecieFilter"
 
         tsc.apply_filter(ContainsSpecieFilter(["Be2+"]))
-        self.assertEqual(len(tsc), 4)
+        assert len(tsc) == 4
 
         # Test set_parameter and add_tag.
         tsc.set_parameter("para1", "hello")
-        self.assertEqual(
-            tsc.transformed_structures[0].as_dict()["other_parameters"]["para1"],
-            "hello",
-        )
+        assert tsc.transformed_structures[0].as_dict()["other_parameters"]["para1"] == "hello"
         tsc.add_tags(["world", "universe"])
-        self.assertEqual(
-            tsc.transformed_structures[0].as_dict()["other_parameters"]["tags"],
-            ["world", "universe"],
-        )
+        assert tsc.transformed_structures[0].as_dict()["other_parameters"]["tags"] == ["world", "universe"]
 
 
 if __name__ == "__main__":

--- a/pymatgen/analysis/chemenv/coordination_environments/tests/test_chemenv_strategies.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/tests/test_chemenv_strategies.py
@@ -5,6 +5,8 @@ __author__ = "waroquiers"
 
 import unittest
 
+import pytest
+
 from pymatgen.analysis.chemenv.coordination_environments.chemenv_strategies import (
     AdditionalConditionInt,
     AngleCutoffFloat,
@@ -18,76 +20,73 @@ from pymatgen.util.testing import PymatgenTest
 class StrategyOptionsTest(PymatgenTest):
     def test_options(self):
         # DistanceCutoffFloat
-        with self.assertRaises(ValueError) as cm:
+        with pytest.raises(ValueError) as exc_info:
             DistanceCutoffFloat(0.5)
-        self.assertEqual(str(cm.exception), "Distance cutoff should be between 1.0 and +infinity")
+        assert str(exc_info.value) == "Distance cutoff should be between 1.0 and +infinity"
         dc1 = DistanceCutoffFloat(1.2)
         dc1_dict = dc1.as_dict()
         dc2 = DistanceCutoffFloat.from_dict(dc1_dict)
-        self.assertEqual(dc1, dc2)
+        assert dc1 == dc2
 
         # AngleCutoffFloat
-        with self.assertRaises(ValueError) as cm:
+        with pytest.raises(ValueError) as exc_info:
             AngleCutoffFloat(1.2)
-        self.assertEqual(str(cm.exception), "Angle cutoff should be between 0.0 and 1.0")
+        assert str(exc_info.value) == "Angle cutoff should be between 0.0 and 1.0"
         ac1 = AngleCutoffFloat(0.3)
         ac1_dict = ac1.as_dict()
         ac2 = AngleCutoffFloat.from_dict(ac1_dict)
-        self.assertEqual(ac1, ac2)
+        assert ac1 == ac2
 
         # CSMFloat
-        with self.assertRaises(ValueError) as cm:
+        with pytest.raises(ValueError) as exc_info:
             CSMFloat(100.1)
-        self.assertEqual(
-            str(cm.exception),
-            "Continuous symmetry measure limits should be between 0.0 and 100.0",
-        )
+        assert str(exc_info.value) == "Continuous symmetry measure limits should be between 0.0 and 100.0"
         csm1 = CSMFloat(0.458)
         csm1_dict = csm1.as_dict()
         csm2 = CSMFloat.from_dict(csm1_dict)
-        self.assertEqual(csm1, csm2)
+        assert csm1 == csm2
 
         # AdditionalConditions
-        with self.assertRaises(ValueError) as cm:
+        with pytest.raises(ValueError) as exc_info:
             AdditionalConditionInt(5)
-        self.assertEqual(str(cm.exception), "Additional condition 5 is not allowed")
-        with self.assertRaises(ValueError) as cm:
+        assert str(exc_info.value) == "Additional condition 5 is not allowed"
+        with pytest.raises(ValueError) as exc_info:
             AdditionalConditionInt(0.458)
-        self.assertEqual(str(cm.exception), "Additional condition 0.458 is not an integer")
+        assert str(exc_info.value) == "Additional condition 0.458 is not an integer"
         acd1 = AdditionalConditionInt(3)
         acd1_dict = acd1.as_dict()
         acd2 = AdditionalConditionInt.from_dict(acd1_dict)
-        self.assertEqual(acd1, acd2)
+        assert acd1 == acd2
 
     def test_strategies(self):
         simplest_strategy = SimplestChemenvStrategy()
-        self.assertTrue(simplest_strategy.uniquely_determines_coordination_environments)
-        self.assertAlmostEqual(simplest_strategy.continuous_symmetry_measure_cutoff, 10.0)
-        self.assertAlmostEqual(simplest_strategy.distance_cutoff, 1.4)
-        self.assertAlmostEqual(simplest_strategy.angle_cutoff, 0.3)
+        assert simplest_strategy.uniquely_determines_coordination_environments
+        assert round(abs(simplest_strategy.continuous_symmetry_measure_cutoff - 10.0), 7) == 0
+        assert round(abs(simplest_strategy.distance_cutoff - 1.4), 7) == 0
+        assert round(abs(simplest_strategy.angle_cutoff - 0.3), 7) == 0
 
         simplest_strategy = SimplestChemenvStrategy(
             distance_cutoff=1.3,
             angle_cutoff=0.45,
             continuous_symmetry_measure_cutoff=8.26,
         )
-        self.assertAlmostEqual(simplest_strategy.continuous_symmetry_measure_cutoff, 8.26)
-        self.assertAlmostEqual(simplest_strategy.distance_cutoff, 1.3)
-        self.assertAlmostEqual(simplest_strategy.angle_cutoff, 0.45)
+        assert round(abs(simplest_strategy.continuous_symmetry_measure_cutoff - 8.26), 7) == 0
+        assert round(abs(simplest_strategy.distance_cutoff - 1.3), 7) == 0
+        assert round(abs(simplest_strategy.angle_cutoff - 0.45), 7) == 0
 
         simplest_strategy.set_option("distance_cutoff", 1.5)
-        self.assertAlmostEqual(simplest_strategy.distance_cutoff, 1.5)
+        assert round(abs(simplest_strategy.distance_cutoff - 1.5), 7) == 0
 
-        with self.assertRaises(ValueError) as cm:
+        with pytest.raises(ValueError) as exc_info:
             simplest_strategy.set_option("distance_cutoff", 0.5)
-        self.assertEqual(str(cm.exception), "Distance cutoff should be between 1.0 and +infinity")
+        assert str(exc_info.value) == "Distance cutoff should be between 1.0 and +infinity"
 
         simplest_strategy.set_option("angle_cutoff", 0.2)
-        self.assertAlmostEqual(simplest_strategy.angle_cutoff, 0.2)
+        assert round(abs(simplest_strategy.angle_cutoff - 0.2), 7) == 0
 
-        with self.assertRaises(ValueError) as cm:
+        with pytest.raises(ValueError) as exc_info:
             simplest_strategy.set_option("angle_cutoff", 1.5)
-        self.assertEqual(str(cm.exception), "Angle cutoff should be between 0.0 and 1.0")
+        assert str(exc_info.value) == "Angle cutoff should be between 0.0 and 1.0"
 
         simplest_strategy.setup_options(
             {
@@ -96,23 +95,17 @@ class StrategyOptionsTest(PymatgenTest):
                 "continuous_symmetry_measure_cutoff": 8.5,
             }
         )
-        self.assertAlmostEqual(simplest_strategy.distance_cutoff, 1.4)
-        self.assertAlmostEqual(simplest_strategy.continuous_symmetry_measure_cutoff, 8.5)
-        self.assertEqual(simplest_strategy.additional_condition, 3)
+        assert round(abs(simplest_strategy.distance_cutoff - 1.4), 7) == 0
+        assert round(abs(simplest_strategy.continuous_symmetry_measure_cutoff - 8.5), 7) == 0
+        assert simplest_strategy.additional_condition == 3
 
-        with self.assertRaises(ValueError) as cm:
+        with pytest.raises(ValueError) as exc_info:
             simplest_strategy.setup_options({"continuous_symmetry_measure_cutoff": -0.1})
-        self.assertEqual(
-            str(cm.exception),
-            "Continuous symmetry measure limits should be between 0.0 and 100.0",
-        )
+        assert str(exc_info.value) == "Continuous symmetry measure limits should be between 0.0 and 100.0"
 
-        with self.assertRaises(ValueError) as cm:
+        with pytest.raises(ValueError) as exc_info:
             simplest_strategy.setup_options({"continuous_symmetry_measure_cutoff": 100.1})
-        self.assertEqual(
-            str(cm.exception),
-            "Continuous symmetry measure limits should be between 0.0 and 100.0",
-        )
+        assert str(exc_info.value) == "Continuous symmetry measure limits should be between 0.0 and 100.0"
 
 
 if __name__ == "__main__":

--- a/pymatgen/analysis/chemenv/coordination_environments/tests/test_coordination_geometries.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/tests/test_coordination_geometries.py
@@ -6,6 +6,7 @@ __author__ = "waroquiers"
 import unittest
 
 import numpy as np
+import pytest
 
 from pymatgen.analysis.chemenv.coordination_environments.coordination_geometries import (
     AllCoordinationGeometries,
@@ -27,46 +28,41 @@ class CoordinationGeometriesTest(PymatgenTest):
     def test_algorithms(self):
         expl_algo = ExplicitPermutationsAlgorithm(permutations=[[0, 1, 2], [1, 2, 3]])
         expl_algo2 = ExplicitPermutationsAlgorithm.from_dict(expl_algo.as_dict)
-        self.assertEqual(expl_algo.permutations, expl_algo2.permutations)
+        assert expl_algo.permutations == expl_algo2.permutations
 
         sepplane_algos_oct = allcg["O:6"].algorithms
-        self.assertEqual(len(sepplane_algos_oct[0].safe_separation_permutations()), 24)
-        self.assertEqual(len(sepplane_algos_oct[1].safe_separation_permutations()), 36)
+        assert len(sepplane_algos_oct[0].safe_separation_permutations()) == 24
+        assert len(sepplane_algos_oct[1].safe_separation_permutations()) == 36
 
         sepplane_algos_oct_0 = SeparationPlane.from_dict(sepplane_algos_oct[0].as_dict)
-        self.assertEqual(sepplane_algos_oct[0].plane_points, sepplane_algos_oct_0.plane_points)
-        self.assertEqual(sepplane_algos_oct[0].mirror_plane, sepplane_algos_oct_0.mirror_plane)
-        self.assertEqual(sepplane_algos_oct[0].ordered_plane, sepplane_algos_oct_0.ordered_plane)
-        self.assertEqual(sepplane_algos_oct[0].point_groups, sepplane_algos_oct_0.point_groups)
-        self.assertEqual(
-            sepplane_algos_oct[0].ordered_point_groups,
-            sepplane_algos_oct_0.ordered_point_groups,
-        )
-        self.assertTrue(
-            all(
-                [
-                    np.array_equal(
-                        perm,
-                        sepplane_algos_oct_0.explicit_optimized_permutations[iperm],
-                    )
-                    for iperm, perm in enumerate(sepplane_algos_oct[0].explicit_optimized_permutations)
-                ]
-            )
+        assert sepplane_algos_oct[0].plane_points == sepplane_algos_oct_0.plane_points
+        assert sepplane_algos_oct[0].mirror_plane == sepplane_algos_oct_0.mirror_plane
+        assert sepplane_algos_oct[0].ordered_plane == sepplane_algos_oct_0.ordered_plane
+        assert sepplane_algos_oct[0].point_groups == sepplane_algos_oct_0.point_groups
+        assert sepplane_algos_oct[0].ordered_point_groups == sepplane_algos_oct_0.ordered_point_groups
+        assert all(
+            [
+                np.array_equal(
+                    perm,
+                    sepplane_algos_oct_0.explicit_optimized_permutations[iperm],
+                )
+                for iperm, perm in enumerate(sepplane_algos_oct[0].explicit_optimized_permutations)
+            ]
         )
 
-        self.assertEqual(
-            str(sepplane_algos_oct[0]),
-            "Separation plane algorithm with the following reference separation :\n[[4]] | [[0, 2, 1, 3]] | [[5]]",
+        assert (
+            str(sepplane_algos_oct[0])
+            == "Separation plane algorithm with the following reference separation :\n[[4]] | [[0, 2, 1, 3]] | [[5]]"
         )
 
     def test_hints(self):
         hints = CoordinationGeometry.NeighborsSetsHints(hints_type="single_cap", options={"cap_index": 2, "csm_max": 8})
         myhints = hints.hints({"csm": 12.0})
-        self.assertEqual(myhints, [])
+        assert myhints == []
 
         hints2 = CoordinationGeometry.NeighborsSetsHints.from_dict(hints.as_dict())
-        self.assertEqual(hints.hints_type, hints2.hints_type)
-        self.assertEqual(hints.options, hints2.options)
+        assert hints.hints_type == hints2.hints_type
+        assert hints.options == hints2.options
 
     def test_coordination_geometry(self):
         cg_oct = allcg["O:6"]
@@ -74,9 +70,8 @@ class CoordinationGeometriesTest(PymatgenTest):
 
         self.assertArrayAlmostEqual(cg_oct.central_site, cg_oct2.central_site)
         self.assertArrayAlmostEqual(cg_oct.points, cg_oct2.points)
-        self.assertEqual(
-            str(cg_oct),
-            "Coordination geometry type : Octahedron (IUPAC: OC-6 || IUCr: [6o])\n"
+        assert (
+            str(cg_oct) == "Coordination geometry type : Octahedron (IUPAC: OC-6 || IUCr: [6o])\n"
             "\n"
             "  - coordination number : 6\n"
             "  - list of points :\n"
@@ -86,21 +81,21 @@ class CoordinationGeometriesTest(PymatgenTest):
             "    - [-1.0, 0.0, 0.0]\n"
             "    - [0.0, 1.0, 0.0]\n"
             "    - [0.0, -1.0, 0.0]\n"
-            "------------------------------------------------------------\n",
+            "------------------------------------------------------------\n"
         )
 
-        self.assertEqual(len(cg_oct), 6)
-        self.assertEqual(cg_oct.ce_symbol, cg_oct.mp_symbol)
-        self.assertTrue(cg_oct.is_implemented())
-        self.assertEqual(cg_oct.get_name(), "Octahedron")
-        self.assertEqual(cg_oct.IUPAC_symbol, "OC-6")
-        self.assertEqual(cg_oct.IUPAC_symbol_str, "OC-6")
-        self.assertEqual(cg_oct.IUCr_symbol, "[6o]")
-        self.assertEqual(cg_oct.IUCr_symbol_str, "[6o]")
+        assert len(cg_oct) == 6
+        assert cg_oct.ce_symbol == cg_oct.mp_symbol
+        assert cg_oct.is_implemented()
+        assert cg_oct.get_name() == "Octahedron"
+        assert cg_oct.IUPAC_symbol == "OC-6"
+        assert cg_oct.IUPAC_symbol_str == "OC-6"
+        assert cg_oct.IUCr_symbol == "[6o]"
+        assert cg_oct.IUCr_symbol_str == "[6o]"
 
         cg_oct.permutations_safe_override = True
-        self.assertEqual(cg_oct.number_of_permutations, 720.0)
-        self.assertEqual(cg_oct.ref_permutation([0, 3, 2, 4, 5, 1]), (0, 3, 1, 5, 2, 4))
+        assert cg_oct.number_of_permutations == 720.0
+        assert cg_oct.ref_permutation([0, 3, 2, 4, 5, 1]) == (0, 3, 1, 5, 2, 4)
 
         sites = [FakeSite(coords=pp) for pp in cg_oct.points]
         faces = [
@@ -165,9 +160,8 @@ class CoordinationGeometriesTest(PymatgenTest):
         )
 
         pmeshes = cg_oct.get_pmeshes(sites=sites)
-        self.assertEqual(
-            pmeshes[0]["pmesh_string"],
-            "14\n     0.00000000      0.00000000      1.00000000\n"
+        assert (
+            pmeshes[0]["pmesh_string"] == "14\n     0.00000000      0.00000000      1.00000000\n"
             "     0.00000000      0.00000000     -1.00000000\n"
             "     1.00000000      0.00000000      0.00000000\n"
             "    -1.00000000      0.00000000      0.00000000\n"
@@ -183,10 +177,10 @@ class CoordinationGeometriesTest(PymatgenTest):
             "    -0.33333333     -0.33333333     -0.33333333\n"
             "8\n4\n0\n2\n4\n0\n4\n0\n2\n5\n0\n4\n0\n3\n4\n0\n"
             "4\n0\n3\n5\n0\n4\n1\n2\n4\n1\n4\n1\n2\n5\n1\n4\n"
-            "1\n3\n4\n1\n4\n1\n3\n5\n1\n",
+            "1\n3\n4\n1\n4\n1\n3\n5\n1\n"
         )
 
-        self.assertTrue(
+        assert (
             "\n#=======================================================#\n"
             "# List of coordination geometries currently implemented #\n"
             "#=======================================================#\n"
@@ -197,7 +191,7 @@ class CoordinationGeometriesTest(PymatgenTest):
             "------------------------------------------------------------\n\n" in str(allcg)
         )
 
-        self.assertTrue(
+        assert (
             "Coordination geometry type : Trigonal plane (IUPAC: TP-3 || IUCr: [3l])\n\n"
             "  - coordination number : 3\n"
             "  - list of points :\n" in str(allcg)
@@ -274,186 +268,171 @@ class CoordinationGeometriesTest(PymatgenTest):
             "UNCLEAR",
         ]
 
-        self.assertEqual(len(allcg.get_geometries()), 68)
-        self.assertEqual(len(allcg.get_geometries(coordination=3)), 3)
-        self.assertEqual(sorted(allcg.get_geometries(returned="mp_symbol")), sorted(all_symbols))
-        self.assertEqual(
-            sorted(allcg.get_geometries(returned="mp_symbol", coordination=3)),
-            ["TL:3", "TS:3", "TY:3"],
-        )
+        assert len(allcg.get_geometries()) == 68
+        assert len(allcg.get_geometries(coordination=3)) == 3
+        assert sorted(allcg.get_geometries(returned="mp_symbol")) == sorted(all_symbols)
+        assert sorted(allcg.get_geometries(returned="mp_symbol", coordination=3)) == ["TL:3", "TS:3", "TY:3"]
 
-        self.assertEqual(
-            allcg.get_symbol_name_mapping(coordination=3),
-            {
-                "TY:3": "Triangular non-coplanar",
-                "TL:3": "Trigonal plane",
-                "TS:3": "T-shaped",
-            },
-        )
-        self.assertEqual(
-            allcg.get_symbol_cn_mapping(coordination=3),
-            {"TY:3": 3, "TL:3": 3, "TS:3": 3},
-        )
-        self.assertEqual(
-            sorted(allcg.get_implemented_geometries(coordination=4, returned="mp_symbol")),
-            ["S:4", "SS:4", "SY:4", "T:4"],
-        )
-        self.assertEqual(
-            sorted(allcg.get_not_implemented_geometries(returned="mp_symbol")),
-            ["CO:11", "H:10", "S:10", "S:12", "UNCLEAR", "UNKNOWN"],
-        )
+        assert allcg.get_symbol_name_mapping(coordination=3) == {
+            "TY:3": "Triangular non-coplanar",
+            "TL:3": "Trigonal plane",
+            "TS:3": "T-shaped",
+        }
+        assert allcg.get_symbol_cn_mapping(coordination=3) == {"TY:3": 3, "TL:3": 3, "TS:3": 3}
+        assert sorted(allcg.get_implemented_geometries(coordination=4, returned="mp_symbol")) == [
+            "S:4",
+            "SS:4",
+            "SY:4",
+            "T:4",
+        ]
+        assert sorted(allcg.get_not_implemented_geometries(returned="mp_symbol")) == [
+            "CO:11",
+            "H:10",
+            "S:10",
+            "S:12",
+            "UNCLEAR",
+            "UNKNOWN",
+        ]
 
-        self.assertEqual(allcg.get_geometry_from_name("Octahedron").mp_symbol, cg_oct.mp_symbol)
-        with self.assertRaises(LookupError) as cm:
+        assert allcg.get_geometry_from_name("Octahedron").mp_symbol == cg_oct.mp_symbol
+        with pytest.raises(LookupError) as exc_info:
             allcg.get_geometry_from_name("Octahedran")
-        self.assertEqual(str(cm.exception), 'No coordination geometry found with name "Octahedran"')
+        assert str(exc_info.value) == 'No coordination geometry found with name "Octahedran"'
 
-        self.assertEqual(allcg.get_geometry_from_IUPAC_symbol("OC-6").mp_symbol, cg_oct.mp_symbol)
-        with self.assertRaises(LookupError) as cm:
+        assert allcg.get_geometry_from_IUPAC_symbol("OC-6").mp_symbol == cg_oct.mp_symbol
+        with pytest.raises(LookupError) as exc_info:
             allcg.get_geometry_from_IUPAC_symbol("OC-7")
-        self.assertEqual(str(cm.exception), 'No coordination geometry found with IUPAC symbol "OC-7"')
+        assert str(exc_info.value) == 'No coordination geometry found with IUPAC symbol "OC-7"'
 
-        self.assertEqual(allcg.get_geometry_from_IUCr_symbol("[6o]").mp_symbol, cg_oct.mp_symbol)
-        with self.assertRaises(LookupError) as cm:
+        assert allcg.get_geometry_from_IUCr_symbol("[6o]").mp_symbol == cg_oct.mp_symbol
+        with pytest.raises(LookupError) as exc_info:
             allcg.get_geometry_from_IUCr_symbol("[6oct]")
-        self.assertEqual(
-            str(cm.exception),
-            'No coordination geometry found with IUCr symbol "[6oct]"',
-        )
+        assert str(exc_info.value) == 'No coordination geometry found with IUCr symbol "[6oct]"'
 
-        with self.assertRaises(LookupError) as cm:
+        with pytest.raises(LookupError) as exc_info:
             allcg.get_geometry_from_mp_symbol("O:7")
-        self.assertEqual(str(cm.exception), 'No coordination geometry found with mp_symbol "O:7"')
+        assert str(exc_info.value) == 'No coordination geometry found with mp_symbol "O:7"'
 
-        self.assertEqual(
-            allcg.pretty_print(maxcn=4),
-            "+-------------------------+\n| Coordination geometries |\n+-------------------------+\n"
+        assert (
+            allcg.pretty_print(maxcn=4)
+            == "+-------------------------+\n| Coordination geometries |\n+-------------------------+\n"
             "\n==>> CN = 1 <<==\n - S:1 : Single neighbor\n\n"
             "==>> CN = 2 <<==\n"
             " - L:2 : Linear\n - A:2 : Angular\n\n"
             "==>> CN = 3 <<==\n"
             " - TL:3 : Trigonal plane\n - TY:3 : Triangular non-coplanar\n - TS:3 : T-shaped\n\n"
             "==>> CN = 4 <<==\n - T:4 : Tetrahedron\n - S:4 : Square plane\n"
-            " - SY:4 : Square non-coplanar\n - SS:4 : See-saw\n\n",
+            " - SY:4 : Square non-coplanar\n - SS:4 : See-saw\n\n"
         )
-        self.assertEqual(
-            allcg.pretty_print(maxcn=2, type="all_geometries_latex"),
-            "\\subsection*{Coordination 1}\n\n\\begin{itemize}\n"
+        assert (
+            allcg.pretty_print(maxcn=2, type="all_geometries_latex")
+            == "\\subsection*{Coordination 1}\n\n\\begin{itemize}\n"
             "\\item S:1 $\\rightarrow$ Single neighbor (IUPAC : None - IUCr : $[$1l$]$)\n"
             "\\end{itemize}\n\n\\subsection*{Coordination 2}\n\n\\begin{itemize}\n"
             "\\item L:2 $\\rightarrow$ Linear (IUPAC : L-2 - IUCr : $[$2l$]$)\n"
             "\\item A:2 $\\rightarrow$ Angular (IUPAC : A-2 - IUCr : $[$2n$]$)\n"
-            "\\end{itemize}\n\n",
+            "\\end{itemize}\n\n"
         )
-        self.assertEqual(
-            allcg.pretty_print(maxcn=2, type="all_geometries_latex_images"),
-            "\\section*{Coordination 1}\n\n\\subsubsection*{S:1 : Single neighbor}\n\n"
+        assert (
+            allcg.pretty_print(maxcn=2, type="all_geometries_latex_images")
+            == "\\section*{Coordination 1}\n\n\\subsubsection*{S:1 : Single neighbor}\n\n"
             "IUPAC : None\n\nIUCr : [1l]\n\n\\begin{center}\n"
             "\\includegraphics[scale=0.15]{images/S_1.png}\n"
             "\\end{center}\n\n\\section*{Coordination 2}\n\n"
             "\\subsubsection*{L:2 : Linear}\n\nIUPAC : L-2\n\n"
             "IUCr : [2l]\n\n\\begin{center}\n\\includegraphics[scale=0.15]{images/L_2.png}\n"
             "\\end{center}\n\n\\subsubsection*{A:2 : Angular}\n\nIUPAC : A-2\n\nIUCr : [2n]\n\n"
-            "\\begin{center}\n\\includegraphics[scale=0.15]{images/A_2.png}\n\\end{center}\n\n",
+            "\\begin{center}\n\\includegraphics[scale=0.15]{images/A_2.png}\n\\end{center}\n\n"
         )
-        self.assertDictEqual(allcg.minpoints, {6: 2, 7: 2, 8: 2, 9: 2, 10: 2, 11: 2, 12: 2, 13: 3, 20: 2})
-        self.assertDictEqual(
-            allcg.maxpoints,
-            {6: 5, 7: 5, 8: 6, 9: 7, 10: 6, 11: 5, 12: 8, 13: 6, 20: 10},
-        )
-        self.assertDictEqual(
-            allcg.maxpoints_inplane,
-            {6: 5, 7: 5, 8: 6, 9: 7, 10: 6, 11: 5, 12: 8, 13: 6, 20: 10},
-        )
-        self.assertDictEqual(
-            allcg.separations_cg,
-            {
-                6: {
-                    (0, 3, 3): ["O:6", "T:6"],
-                    (1, 4, 1): ["O:6"],
-                    (0, 5, 1): ["PP:6"],
-                    (2, 2, 2): ["PP:6"],
-                    (0, 4, 2): ["T:6"],
-                },
-                7: {
-                    (1, 3, 3): ["ET:7", "FO:7"],
-                    (2, 3, 2): ["PB:7", "ST:7", "ET:7"],
-                    (1, 4, 2): ["ST:7", "FO:7"],
-                    (1, 5, 1): ["PB:7"],
-                },
-                8: {
-                    (1, 6, 1): ["HB:8"],
-                    (0, 4, 4): ["C:8", "SA:8", "SBT:8"],
-                    (1, 4, 3): ["SA:8", "SBT:8", "BO_2:8", "BO_3:8"],
-                    (2, 4, 2): [
-                        "C:8",
-                        "TBT:8",
-                        "DD:8",
-                        "DDPN:8",
-                        "HB:8",
-                        "BO_1:8",
-                        "BO_1:8",
-                        "BO_2:8",
-                        "BO_2:8",
-                        "BO_3:8",
-                        "BO_3:8",
-                    ],
-                },
-                9: {
-                    (3, 3, 3): [
-                        "TT_1:9",
-                        "TT_1:9",
-                        "TT_2:9",
-                        "SMA:9",
-                        "SMA:9",
-                        "TO_1:9",
-                        "TO_3:9",
-                    ],
-                    (0, 6, 3): ["TC:9"],
-                    (2, 4, 3): [
-                        "TC:9",
-                        "TT_2:9",
-                        "TT_3:9",
-                        "TI:9",
-                        "SS:9",
-                        "TO_1:9",
-                        "TO_1:9",
-                        "TO_2:9",
-                        "TO_3:9",
-                    ],
-                    (1, 3, 5): ["TI:9"],
-                    (1, 4, 4): ["TT_1:9", "SMA:9", "SS:9"],
-                    (2, 3, 4): ["TC:9"],
-                    (2, 5, 2): ["TT_3:9", "SS:9", "TO_2:9"],
-                    (1, 7, 1): ["HD:9"],
-                },
-                10: {
-                    (0, 5, 5): ["PP:10", "PA:10"],
-                    (3, 4, 3): ["PA:10", "SBSA:10", "MI:10", "BS_2:10", "TBSA:10"],
-                    (2, 6, 2): ["BS_1:10"],
-                    (2, 4, 4): ["PP:10", "MI:10", "BS_2:10"],
-                    (3, 3, 4): ["SBSA:10"],
-                    (1, 4, 5): ["BS_2:10"],
-                    (0, 4, 6): ["BS_1:10", "TBSA:10"],
-                },
-                11: {
-                    (4, 3, 4): ["PCPA:11"],
-                    (3, 4, 4): ["DI:11"],
-                    (1, 5, 5): ["PCPA:11", "DI:11"],
-                    (3, 5, 3): ["H:11"],
-                },
-                12: {
-                    (3, 3, 6): ["TT:12"],
-                    (2, 4, 6): ["TT:12"],
-                    (0, 6, 6): ["HP:12", "HA:12"],
-                    (3, 6, 3): ["C:12", "AC:12"],
-                    (4, 4, 4): ["I:12", "PBP:12", "C:12", "HP:12"],
-                    (0, 8, 4): ["SC:12"],
-                },
-                13: {(0, 6, 7): ["SH:13"]},
-                20: {(5, 10, 5): ["DD:20"]},
+        assert allcg.minpoints == {6: 2, 7: 2, 8: 2, 9: 2, 10: 2, 11: 2, 12: 2, 13: 3, 20: 2}
+        assert allcg.maxpoints == {6: 5, 7: 5, 8: 6, 9: 7, 10: 6, 11: 5, 12: 8, 13: 6, 20: 10}
+        assert allcg.maxpoints_inplane == {6: 5, 7: 5, 8: 6, 9: 7, 10: 6, 11: 5, 12: 8, 13: 6, 20: 10}
+        assert allcg.separations_cg == {
+            6: {
+                (0, 3, 3): ["O:6", "T:6"],
+                (1, 4, 1): ["O:6"],
+                (0, 5, 1): ["PP:6"],
+                (2, 2, 2): ["PP:6"],
+                (0, 4, 2): ["T:6"],
             },
-        )
+            7: {
+                (1, 3, 3): ["ET:7", "FO:7"],
+                (2, 3, 2): ["PB:7", "ST:7", "ET:7"],
+                (1, 4, 2): ["ST:7", "FO:7"],
+                (1, 5, 1): ["PB:7"],
+            },
+            8: {
+                (1, 6, 1): ["HB:8"],
+                (0, 4, 4): ["C:8", "SA:8", "SBT:8"],
+                (1, 4, 3): ["SA:8", "SBT:8", "BO_2:8", "BO_3:8"],
+                (2, 4, 2): [
+                    "C:8",
+                    "TBT:8",
+                    "DD:8",
+                    "DDPN:8",
+                    "HB:8",
+                    "BO_1:8",
+                    "BO_1:8",
+                    "BO_2:8",
+                    "BO_2:8",
+                    "BO_3:8",
+                    "BO_3:8",
+                ],
+            },
+            9: {
+                (3, 3, 3): [
+                    "TT_1:9",
+                    "TT_1:9",
+                    "TT_2:9",
+                    "SMA:9",
+                    "SMA:9",
+                    "TO_1:9",
+                    "TO_3:9",
+                ],
+                (0, 6, 3): ["TC:9"],
+                (2, 4, 3): [
+                    "TC:9",
+                    "TT_2:9",
+                    "TT_3:9",
+                    "TI:9",
+                    "SS:9",
+                    "TO_1:9",
+                    "TO_1:9",
+                    "TO_2:9",
+                    "TO_3:9",
+                ],
+                (1, 3, 5): ["TI:9"],
+                (1, 4, 4): ["TT_1:9", "SMA:9", "SS:9"],
+                (2, 3, 4): ["TC:9"],
+                (2, 5, 2): ["TT_3:9", "SS:9", "TO_2:9"],
+                (1, 7, 1): ["HD:9"],
+            },
+            10: {
+                (0, 5, 5): ["PP:10", "PA:10"],
+                (3, 4, 3): ["PA:10", "SBSA:10", "MI:10", "BS_2:10", "TBSA:10"],
+                (2, 6, 2): ["BS_1:10"],
+                (2, 4, 4): ["PP:10", "MI:10", "BS_2:10"],
+                (3, 3, 4): ["SBSA:10"],
+                (1, 4, 5): ["BS_2:10"],
+                (0, 4, 6): ["BS_1:10", "TBSA:10"],
+            },
+            11: {
+                (4, 3, 4): ["PCPA:11"],
+                (3, 4, 4): ["DI:11"],
+                (1, 5, 5): ["PCPA:11", "DI:11"],
+                (3, 5, 3): ["H:11"],
+            },
+            12: {
+                (3, 3, 6): ["TT:12"],
+                (2, 4, 6): ["TT:12"],
+                (0, 6, 6): ["HP:12", "HA:12"],
+                (3, 6, 3): ["C:12", "AC:12"],
+                (4, 4, 4): ["I:12", "PBP:12", "C:12", "HP:12"],
+                (0, 8, 4): ["SC:12"],
+            },
+            13: {(0, 6, 7): ["SH:13"]},
+            20: {(5, 10, 5): ["DD:20"]},
+        }
 
 
 if __name__ == "__main__":

--- a/pymatgen/analysis/chemenv/coordination_environments/tests/test_coordination_geometry_finder.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/tests/test_coordination_geometry_finder.py
@@ -7,6 +7,7 @@ import os
 import unittest
 
 import numpy as np
+import pytest
 
 from pymatgen.analysis.chemenv.coordination_environments.coordination_geometries import (
     AllCoordinationGeometries,
@@ -44,16 +45,15 @@ class CoordinationGeometryFinderTest(PymatgenTest):
         self.assertArrayAlmostEqual(abstract_geom.centre, [0.0, 0.0, 0.0])
         abstract_geom = AbstractGeometry.from_cg(cg=cg_ts3, centering_type="centroid")
         self.assertArrayAlmostEqual(abstract_geom.centre, [0.0, 0.0, 0.33333333333])
-        with self.assertRaises(ValueError) as cm:
+        with pytest.raises(ValueError) as exc_info:
             AbstractGeometry.from_cg(
                 cg=cg_ts3,
                 centering_type="central_site",
                 include_central_site_in_centroid=True,
             )
-        self.assertEqual(
-            str(cm.exception),
-            "The center is the central site, no calculation of the centroid, "
-            "variable include_central_site_in_centroid should be set to False",
+        assert (
+            str(exc_info.value) == "The center is the central site, no calculation of the centroid, "
+            "variable include_central_site_in_centroid should be set to False"
         )
         abstract_geom = AbstractGeometry.from_cg(
             cg=cg_ts3, centering_type="centroid", include_central_site_in_centroid=True
@@ -70,37 +70,37 @@ class CoordinationGeometryFinderTest(PymatgenTest):
         #                  '  [ 0.   0.   0.25]\n')
 
         symm_dict = symmetry_measure([[0.0, 0.0, 0.0]], [1.1, 2.2, 3.3])
-        self.assertAlmostEqual(symm_dict["symmetry_measure"], 0.0)
-        self.assertEqual(symm_dict["scaling_factor"], None)
-        self.assertEqual(symm_dict["rotation_matrix"], None)
+        assert symm_dict["symmetry_measure"] == pytest.approx(0.0)
+        assert symm_dict["scaling_factor"] is None
+        assert symm_dict["rotation_matrix"] is None
 
         tio2_struct = self.get_structure("TiO2")
 
         envs = self.lgf.compute_coordination_environments(structure=tio2_struct, indices=[0])
-        self.assertAlmostEqual(envs[0][0]["csm"], 1.5309987846957258)
-        self.assertAlmostEqual(envs[0][0]["ce_fraction"], 1.0)
-        self.assertEqual(envs[0][0]["ce_symbol"], "O:6")
-        self.assertEqual(sorted(envs[0][0]["permutation"]), sorted([0, 4, 1, 5, 2, 3]))
+        assert envs[0][0]["csm"] == pytest.approx(1.5309987846957258)
+        assert envs[0][0]["ce_fraction"] == pytest.approx(1.0)
+        assert envs[0][0]["ce_symbol"] == "O:6"
+        assert sorted(envs[0][0]["permutation"]) == sorted([0, 4, 1, 5, 2, 3])
 
         self.lgf.setup_random_structure(coordination=5)
-        self.assertEqual(len(self.lgf.structure), 6)
+        assert len(self.lgf.structure) == 6
 
         self.lgf.setup_random_indices_local_geometry(coordination=5)
-        self.assertEqual(self.lgf.icentral_site, 0)
-        self.assertEqual(len(self.lgf.indices), 5)
+        assert self.lgf.icentral_site == 0
+        assert len(self.lgf.indices) == 5
 
         self.lgf.setup_ordered_indices_local_geometry(coordination=5)
-        self.assertEqual(self.lgf.icentral_site, 0)
-        self.assertEqual(self.lgf.indices, list(range(1, 6)))
+        assert self.lgf.icentral_site == 0
+        assert self.lgf.indices == list(range(1, 6))
 
         self.lgf.setup_explicit_indices_local_geometry(explicit_indices=[3, 5, 2, 0, 1, 4])
-        self.assertEqual(self.lgf.icentral_site, 0)
-        self.assertEqual(self.lgf.indices, [4, 6, 3, 1, 2, 5])
+        assert self.lgf.icentral_site == 0
+        assert self.lgf.indices == [4, 6, 3, 1, 2, 5]
 
         LiFePO4_struct = self.get_structure("LiFePO4")
         isite = 10
         envs_LiFePO4 = self.lgf.compute_coordination_environments(structure=LiFePO4_struct, indices=[isite])
-        self.assertAlmostEqual(envs_LiFePO4[isite][0]["csm"], 0.140355832317)
+        assert envs_LiFePO4[isite][0]["csm"] == pytest.approx(0.140355832317)
         nbs_coords = [
             np.array([6.16700437, -4.55194317, -5.89031356]),
             np.array([4.71588167, -4.54248093, -3.75553856]),
@@ -131,7 +131,7 @@ class CoordinationGeometryFinderTest(PymatgenTest):
             perfect2local_maps,
         ) = res
         for perm_csm_dict in permutations_symmetry_measures:
-            self.assertAlmostEqual(perm_csm_dict["symmetry_measure"], 0.140355832317)
+            assert perm_csm_dict["symmetry_measure"] == pytest.approx(0.140355832317)
 
     #
     # def _strategy_test(self, strategy):
@@ -211,12 +211,9 @@ class CoordinationGeometryFinderTest(PymatgenTest):
                     max_cn=cg.coordination_number,
                     only_symbols=[mp_symbol],
                 )
-                self.assertAlmostEqual(
-                    se.get_csm(0, mp_symbol)["symmetry_measure"],
-                    0.0,
-                    delta=1e-8,
-                    msg=f"Failed to get perfect environment with mp_symbol {mp_symbol}",
-                )
+                assert (
+                    abs(se.get_csm(0, mp_symbol)["symmetry_measure"] - 0.0) < 1e-8
+                ), f"Failed to get perfect environment with mp_symbol {mp_symbol}"
 
     def test_disable_hints(self):
         allcg = AllCoordinationGeometries()
@@ -251,11 +248,11 @@ class CoordinationGeometryFinderTest(PymatgenTest):
             only_symbols=mp_symbols,
             get_from_hints=True,
         )
-        with self.assertRaises(KeyError):
+        with pytest.raises(KeyError):
             abc = se_nohints.ce_list[0][12]
             abc.minimum_geometries()
         self.assertAlmostEqual(se_hints.ce_list[0][13][0], se_nohints.ce_list[0][13][0])
-        self.assertTrue(set(se_nohints.ce_list[0]).issubset(set(se_hints.ce_list[0])))
+        assert set(se_nohints.ce_list[0]).issubset(set(se_hints.ce_list[0]))
 
 
 if __name__ == "__main__":

--- a/pymatgen/analysis/chemenv/coordination_environments/tests/test_read_write.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/tests/test_read_write.py
@@ -1,14 +1,10 @@
-#!/usr/bin/env python
-
-
-__author__ = "waroquiers"
-
 import json
 import os
 import shutil
 import unittest
 
 import numpy as np
+import pytest
 
 from pymatgen.analysis.chemenv.coordination_environments.chemenv_strategies import (
     AngleNbSetWeight,
@@ -33,6 +29,8 @@ from pymatgen.analysis.chemenv.coordination_environments.voronoi import (
 from pymatgen.core.structure import Structure
 from pymatgen.util.testing import PymatgenTest
 
+__author__ = "waroquiers"
+
 json_files_dir = os.path.join(
     PymatgenTest.TEST_FILES_DIR,
     "chemenv",
@@ -50,7 +48,7 @@ class ReadWriteChemenvTest(unittest.TestCase):
     def setUpClass(cls):
         cls.lgf = LocalGeometryFinder()
         cls.lgf.setup_parameters(centering_type="standard")
-        os.makedirs("tmp_dir")
+        os.makedirs("tmp_dir", exist_ok=True)
 
     def test_read_write_structure_environments(self):
         with open(f"{json_files_dir}/test_T--4_FePO4_icsd_4266.json") as f:
@@ -72,7 +70,7 @@ class ReadWriteChemenvTest(unittest.TestCase):
 
         se2 = StructureEnvironments.from_dict(dd)
 
-        self.assertEqual(se, se2)
+        assert se == se2
 
         strategy = SimplestChemenvStrategy()
         lse = LightStructureEnvironments.from_structure_environments(
@@ -87,7 +85,7 @@ class ReadWriteChemenvTest(unittest.TestCase):
 
         lse2 = LightStructureEnvironments.from_dict(dd)
 
-        self.assertEqual(lse, lse2)
+        assert lse == lse2
 
     def test_structure_environments_neighbors_sets(self):
         with open(f"{se_files_dir}/se_mp-7000.json") as f:
@@ -109,7 +107,7 @@ class ReadWriteChemenvTest(unittest.TestCase):
             ]
         )
 
-        self.assertTrue(np.allclose(np.array(nb_set.voronoi_grid_surface_points()), nb_set_surface_points))
+        assert np.allclose(np.array(nb_set.voronoi_grid_surface_points()), nb_set_surface_points)
 
         neighb_sites = nb_set.neighb_sites
         coords = [
@@ -130,63 +128,44 @@ class ReadWriteChemenvTest(unittest.TestCase):
         np.testing.assert_array_almost_equal(nb_set.structure[nb_set.isite].coords, neighb_coords[0])
 
         normdist = nb_set.normalized_distances
-        self.assertAlmostEqual(
-            sorted(normdist),
-            sorted([1.0017922783963027, 1.0017922780870239, 1.000000000503177, 1.0]),
+        assert sorted(normdist) == pytest.approx(
+            sorted([1.0017922783963027, 1.0017922780870239, 1.000000000503177, 1.0])
         )
         normang = nb_set.normalized_angles
-        self.assertAlmostEqual(
-            sorted(normang),
-            sorted([0.9999999998419052, 1.0, 0.9930136530585189, 0.9930136532867929]),
+        assert sorted(normang) == pytest.approx(
+            sorted([0.9999999998419052, 1.0, 0.9930136530585189, 0.9930136532867929])
         )
         dist = nb_set.distances
-        self.assertAlmostEqual(
-            sorted(dist),
-            sorted(
-                [
-                    1.6284399814843944,
-                    1.6284399809816534,
-                    1.6255265861208676,
-                    1.6255265853029401,
-                ]
-            ),
+        assert sorted(dist) == pytest.approx(
+            sorted([1.6284399814843944, 1.6284399809816534, 1.6255265861208676, 1.6255265853029401])
         )
         ang = nb_set.angles
-        self.assertAlmostEqual(
-            sorted(ang),
-            sorted(
-                [
-                    3.117389876236432,
-                    3.117389876729275,
-                    3.095610709498583,
-                    3.0956107102102024,
-                ]
-            ),
+        assert sorted(ang) == pytest.approx(
+            sorted([3.117389876236432, 3.117389876729275, 3.095610709498583, 3.0956107102102024])
         )
 
         nb_set_info = nb_set.info
 
-        self.assertAlmostEqual(nb_set_info["normalized_angles_mean"], 0.996506826547)
-        self.assertAlmostEqual(nb_set_info["normalized_distances_std"], 0.000896138995037)
-        self.assertAlmostEqual(nb_set_info["angles_std"], 0.0108895833142)
-        self.assertAlmostEqual(nb_set_info["distances_std"], 0.00145669776056)
-        self.assertAlmostEqual(nb_set_info["distances_mean"], 1.62698328347)
+        assert round(abs(nb_set_info["normalized_angles_mean"] - 0.996506826547), 7) == 0
+        assert round(abs(nb_set_info["normalized_distances_std"] - 0.000896138995037), 7) == 0
+        assert round(abs(nb_set_info["angles_std"] - 0.0108895833142), 7) == 0
+        assert round(abs(nb_set_info["distances_std"] - 0.00145669776056), 7) == 0
+        assert round(abs(nb_set_info["distances_mean"] - 1.62698328347), 7) == 0
 
-        self.assertEqual(
-            str(nb_set),
-            "Neighbors Set for site #6 :\n - Coordination number : 4\n - Voronoi indices : 1, 4, 5, 6\n",
+        assert (
+            str(nb_set) == "Neighbors Set for site #6 :\n - Coordination number : 4\n - Voronoi indices : 1, 4, 5, 6\n"
         )
 
-        self.assertFalse(nb_set != nb_set)
+        assert not nb_set != nb_set
 
-        self.assertEqual(hash(nb_set), 4)
+        assert hash(nb_set) == 4
 
     def test_strategies(self):
         simplest_strategy_1 = SimplestChemenvStrategy()
         simplest_strategy_2 = SimplestChemenvStrategy(distance_cutoff=1.5, angle_cutoff=0.5)
-        self.assertFalse(simplest_strategy_1 == simplest_strategy_2)
+        assert not simplest_strategy_1 == simplest_strategy_2
         simplest_strategy_1_from_dict = SimplestChemenvStrategy.from_dict(simplest_strategy_1.as_dict())
-        self.assertTrue(simplest_strategy_1, simplest_strategy_1_from_dict)
+        assert simplest_strategy_1, simplest_strategy_1_from_dict
 
         effective_csm_estimator = {
             "function": "power2_inverse_decreasing",
@@ -260,11 +239,11 @@ class ReadWriteChemenvTest(unittest.TestCase):
         )
         multi_weights_strategy_1_from_dict = MultiWeightsChemenvStrategy.from_dict(multi_weights_strategy_1.as_dict())
 
-        self.assertTrue(multi_weights_strategy_1 == multi_weights_strategy_1_from_dict)
-        self.assertFalse(simplest_strategy_1 == multi_weights_strategy_1)
-        self.assertFalse(multi_weights_strategy_1 == multi_weights_strategy_2)
-        self.assertFalse(multi_weights_strategy_1 == multi_weights_strategy_3)
-        self.assertFalse(multi_weights_strategy_2 == multi_weights_strategy_3)
+        assert multi_weights_strategy_1 == multi_weights_strategy_1_from_dict
+        assert not simplest_strategy_1 == multi_weights_strategy_1
+        assert not multi_weights_strategy_1 == multi_weights_strategy_2
+        assert not multi_weights_strategy_1 == multi_weights_strategy_3
+        assert not multi_weights_strategy_2 == multi_weights_strategy_3
 
     def test_read_write_voronoi(self):
         with open(f"{json_files_dir}/test_T--4_FePO4_icsd_4266.json") as f:
@@ -284,7 +263,7 @@ class ReadWriteChemenvTest(unittest.TestCase):
 
         detailed_voronoi_container2 = DetailedVoronoiContainer.from_dict(dd)
 
-        self.assertEqual(detailed_voronoi_container, detailed_voronoi_container2)
+        assert detailed_voronoi_container == detailed_voronoi_container2
 
     @classmethod
     def tearDownClass(cls):

--- a/pymatgen/analysis/chemenv/coordination_environments/tests/test_structure_environments.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/tests/test_structure_environments.py
@@ -102,19 +102,19 @@ class StructureEnvironmentsTest(PymatgenTest):
             )
 
             se.save_environments_figure(isite=isite, imagename="image.png")
-            self.assertTrue(os.path.exists("image.png"))
+            assert os.path.exists("image.png")
 
-            self.assertEqual(len(se.differences_wrt(se)), 0)
+            assert len(se.differences_wrt(se)) == 0
 
-            self.assertFalse(se != se)
+            assert not se != se
 
             ce = se.ce_list[isite][4][0]
 
-            self.assertTrue(len(ce), 4)
+            assert len(ce), 4
 
             symbol, mingeom = ce.minimum_geometry(symmetry_measure_type="csm_wocs_ctwocc")
-            self.assertEqual(symbol, "T:4")
-            self.assertAlmostEqual(mingeom["symmetry_measure"], 0.00988778424054)
+            assert symbol == "T:4"
+            assert round(abs(mingeom["symmetry_measure"] - 0.00988778424054), 7) == 0
 
             np.testing.assert_array_almost_equal(
                 mingeom["other_symmetry_measures"]["rotation_matrix_wcs_csc"],
@@ -124,35 +124,35 @@ class StructureEnvironmentsTest(PymatgenTest):
                     [-0.22754236927612112, 0.9737681809261427, 1.3979531202869064e-13],
                 ],
             )
-            self.assertEqual(mingeom["detailed_voronoi_index"], {"index": 0, "cn": 4})
-            self.assertAlmostEqual(
-                mingeom["other_symmetry_measures"]["scaling_factor_wocs_ctwocc"],
-                1.6270605877934026,
+            assert mingeom["detailed_voronoi_index"] == {"index": 0, "cn": 4}
+            assert (
+                round(abs(mingeom["other_symmetry_measures"]["scaling_factor_wocs_ctwocc"] - 1.6270605877934026), 7)
+                == 0
             )
 
-            self.assertTrue("csm1 (with central site) : 0.00988" in str(ce))
-            self.assertTrue("csm2 (without central site) : 0.00981" in str(ce))
-            self.assertTrue("csm1 (with central site) : 12.987" in str(ce))
-            self.assertTrue("csm2 (without central site) : 11.827" in str(ce))
-            self.assertTrue("csm1 (with central site) : 32.466" in str(ce))
-            self.assertTrue("csm2 (without central site) : 32.466" in str(ce))
-            self.assertTrue("csm1 (with central site) : 34.644" in str(ce))
-            self.assertTrue("csm2 (without central site) : 32.466" in str(ce))
+            assert "csm1 (with central site) : 0.00988" in str(ce)
+            assert "csm2 (without central site) : 0.00981" in str(ce)
+            assert "csm1 (with central site) : 12.987" in str(ce)
+            assert "csm2 (without central site) : 11.827" in str(ce)
+            assert "csm1 (with central site) : 32.466" in str(ce)
+            assert "csm2 (without central site) : 32.466" in str(ce)
+            assert "csm1 (with central site) : 34.644" in str(ce)
+            assert "csm2 (without central site) : 32.466" in str(ce)
 
             mingeoms = ce.minimum_geometries(symmetry_measure_type="csm_wocs_ctwocc", max_csm=12.0)
-            self.assertEqual(len(mingeoms), 2)
+            assert len(mingeoms) == 2
             mingeoms = ce.minimum_geometries(symmetry_measure_type="csm_wocs_ctwcc", max_csm=12.0)
-            self.assertEqual(len(mingeoms), 1)
+            assert len(mingeoms) == 1
             mingeoms = ce.minimum_geometries(n=3)
-            self.assertEqual(len(mingeoms), 3)
+            assert len(mingeoms) == 3
 
             ce2 = se.ce_list[7][4][0]
 
-            self.assertTrue(ce.is_close_to(ce2, rtol=0.01, atol=1e-4))
-            self.assertFalse(ce.is_close_to(ce2, rtol=0.0, atol=1e-8))
+            assert ce.is_close_to(ce2, rtol=0.01, atol=1e-4)
+            assert not ce.is_close_to(ce2, rtol=0.0, atol=1e-8)
 
-            self.assertFalse(ce == ce2)
-            self.assertTrue(ce != ce2)
+            assert not ce == ce2
+            assert ce != ce2
 
     def test_light_structure_environments(self):
         with ScratchDir("."):
@@ -185,16 +185,15 @@ class StructureEnvironmentsTest(PymatgenTest):
             np.testing.assert_array_almost_equal(neighb_indices, [iai["index"] for iai in nb_iai])
             np.testing.assert_array_equal(neighb_images, [iai["image_cell"] for iai in nb_iai])
 
-            self.assertEqual(len(nb_set), 4)
-            self.assertEqual(hash(nb_set), 4)
+            assert len(nb_set) == 4
+            assert hash(nb_set) == 4
 
-            self.assertFalse(nb_set != nb_set)
+            assert not nb_set != nb_set
 
-            self.assertEqual(
-                str(nb_set),
-                "Neighbors Set for site #6 :\n"
+            assert (
+                str(nb_set) == "Neighbors Set for site #6 :\n"
                 " - Coordination number : 4\n"
-                " - Neighbors sites indices : 0, 1, 2, 3\n",
+                " - Neighbors sites indices : 0, 1, 2, 3\n"
             )
 
             stats = lse.get_statistics()
@@ -206,21 +205,18 @@ class StructureEnvironmentsTest(PymatgenTest):
             self.assertArrayAlmostEqual(neighbors[3].coords, np.array([0.82616785, 3.65833945, 0.70467298]))
 
             equiv_site_index_and_transform = lse.strategy.equivalent_site_index_and_transform(neighbors[0])
-            self.assertEqual(equiv_site_index_and_transform[0], 0)
+            assert equiv_site_index_and_transform[0] == 0
             self.assertArrayAlmostEqual(equiv_site_index_and_transform[1], [0.0, 0.0, 0.0])
             self.assertArrayAlmostEqual(equiv_site_index_and_transform[2], [0.0, 0.0, -1.0])
 
             equiv_site_index_and_transform = lse.strategy.equivalent_site_index_and_transform(neighbors[1])
-            self.assertEqual(equiv_site_index_and_transform[0], 3)
+            assert equiv_site_index_and_transform[0] == 3
             self.assertArrayAlmostEqual(equiv_site_index_and_transform[1], [0.0, 0.0, 0.0])
             self.assertArrayAlmostEqual(equiv_site_index_and_transform[2], [0.0, 0.0, 0.0])
 
-            self.assertEqual(stats["atom_coordination_environments_present"], {"Si": {"T:4": 3.0}})
-            self.assertEqual(stats["coordination_environments_atom_present"], {"T:4": {"Si": 3.0}})
-            self.assertEqual(
-                stats["fraction_atom_coordination_environments_present"],
-                {"Si": {"T:4": 1.0}},
-            )
+            assert stats["atom_coordination_environments_present"] == {"Si": {"T:4": 3.0}}
+            assert stats["coordination_environments_atom_present"] == {"T:4": {"Si": 3.0}}
+            assert stats["fraction_atom_coordination_environments_present"] == {"Si": {"T:4": 1.0}}
 
             site_info_ce = lse.get_site_info_for_specie_ce(specie=Species("Si", 4), ce_symbol="T:4")
             np.testing.assert_array_almost_equal(site_info_ce["fractions"], [1.0, 1.0, 1.0])
@@ -228,37 +224,34 @@ class StructureEnvironmentsTest(PymatgenTest):
                 site_info_ce["csms"],
                 [0.009887784240541068, 0.009887786546730826, 0.009887787384385317],
             )
-            self.assertEqual(site_info_ce["isites"], [6, 7, 8])
+            assert site_info_ce["isites"] == [6, 7, 8]
 
             site_info_allces = lse.get_site_info_for_specie_allces(specie=Species("Si", 4))
 
-            self.assertEqual(site_info_allces["T:4"], site_info_ce)
+            assert site_info_allces["T:4"] == site_info_ce
 
-            self.assertFalse(lse.contains_only_one_anion("I-"))
-            self.assertFalse(lse.contains_only_one_anion_atom("I"))
-            self.assertTrue(lse.site_contains_environment(isite=isite, ce_symbol="T:4"))
-            self.assertFalse(lse.site_contains_environment(isite=isite, ce_symbol="S:4"))
-            self.assertFalse(lse.structure_contains_atom_environment(atom_symbol="Si", ce_symbol="S:4"))
-            self.assertTrue(lse.structure_contains_atom_environment(atom_symbol="Si", ce_symbol="T:4"))
-            self.assertFalse(lse.structure_contains_atom_environment(atom_symbol="O", ce_symbol="T:4"))
-            self.assertTrue(lse.uniquely_determines_coordination_environments)
-            self.assertFalse(lse != lse)
+            assert not lse.contains_only_one_anion("I-")
+            assert not lse.contains_only_one_anion_atom("I")
+            assert lse.site_contains_environment(isite=isite, ce_symbol="T:4")
+            assert not lse.site_contains_environment(isite=isite, ce_symbol="S:4")
+            assert not lse.structure_contains_atom_environment(atom_symbol="Si", ce_symbol="S:4")
+            assert lse.structure_contains_atom_environment(atom_symbol="Si", ce_symbol="T:4")
+            assert not lse.structure_contains_atom_environment(atom_symbol="O", ce_symbol="T:4")
+            assert lse.uniquely_determines_coordination_environments
+            assert not lse != lse
 
             envs = lse.strategy.get_site_coordination_environments(lse.structure[6])
-            self.assertEqual(len(envs), 1)
-            self.assertEqual(envs[0][0], "T:4")
+            assert len(envs) == 1
+            assert envs[0][0] == "T:4"
 
             multi_strategy = MultiWeightsChemenvStrategy.stats_article_weights_parameters()
 
             lse_multi = LightStructureEnvironments.from_structure_environments(
                 strategy=multi_strategy, structure_environments=se, valences="undefined"
             )
-            self.assertAlmostEqual(
-                lse_multi.coordination_environments[isite][0]["csm"],
-                0.009887784240541068,
-            )
-            self.assertAlmostEqual(lse_multi.coordination_environments[isite][0]["ce_fraction"], 1.0)
-            self.assertEqual(lse_multi.coordination_environments[isite][0]["ce_symbol"], "T:4")
+            assert round(abs(lse_multi.coordination_environments[isite][0]["csm"] - 0.009887784240541068), 7) == 0
+            assert round(abs(lse_multi.coordination_environments[isite][0]["ce_fraction"] - 1.0), 7) == 0
+            assert lse_multi.coordination_environments[isite][0]["ce_symbol"] == "T:4"
 
 
 if __name__ == "__main__":

--- a/pymatgen/analysis/chemenv/coordination_environments/tests/test_voronoi.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/tests/test_voronoi.py
@@ -59,15 +59,15 @@ class VoronoiContainerTest(PymatgenTest):
                 normalized_distance_tolerance=0.0100001,
                 isites=[0],
             )
-            self.assertEqual(len(detailed_voronoi_container.voronoi_list2[0]), 6)
+            assert len(detailed_voronoi_container.voronoi_list2[0]) == 6
             neighbors = detailed_voronoi_container.neighbors(0, 1.0, 0.5, True)
-            self.assertEqual(len(neighbors), 6)
+            assert len(neighbors) == 6
             neighbors = detailed_voronoi_container.neighbors(0, 1.02, 0.5, True)
-            self.assertEqual(len(neighbors), 6)
+            assert len(neighbors) == 6
             neighbors = detailed_voronoi_container.neighbors(0, 1.026, 0.5, True)
-            self.assertEqual(len(neighbors), 6)
+            assert len(neighbors) == 6
             neighbors = detailed_voronoi_container.neighbors(0, 1.5, 0.5, True)
-            self.assertEqual(len(neighbors), 6)
+            assert len(neighbors) == 6
 
             # First fake structure with a given normalized_distance_tolerance of 0.001
             detailed_voronoi_container = DetailedVoronoiContainer(
@@ -76,24 +76,24 @@ class VoronoiContainerTest(PymatgenTest):
                 normalized_distance_tolerance=0.001,
                 isites=[0],
             )
-            self.assertEqual(len(detailed_voronoi_container.voronoi_list2[0]), 6)
+            assert len(detailed_voronoi_container.voronoi_list2[0]) == 6
             neighbors = detailed_voronoi_container.neighbors(0, 1.0, 0.5, True)
-            self.assertEqual(len(neighbors), 1)
-            self.assertEqual(neighbors[0]["site"], fake_structure[sorted[0]])
+            assert len(neighbors) == 1
+            assert neighbors[0]["site"] == fake_structure[sorted[0]]
             neighbors = detailed_voronoi_container.neighbors(0, 1.02, 0.5, True)
             nbs = [nb["site"] for nb in neighbors]
-            self.assertEqual(len(neighbors), 3)
-            self.assertTrue(fake_structure[sorted[0]] in nbs)
-            self.assertTrue(fake_structure[sorted[1]] in nbs)
-            self.assertTrue(fake_structure[sorted[2]] in nbs)
+            assert len(neighbors) == 3
+            assert fake_structure[sorted[0]] in nbs
+            assert fake_structure[sorted[1]] in nbs
+            assert fake_structure[sorted[2]] in nbs
             neighbors = detailed_voronoi_container.neighbors(0, 1.026, 0.5, True)
             nbs = [nb["site"] for nb in neighbors]
-            self.assertEqual(len(neighbors), 3)
-            self.assertTrue(fake_structure[sorted[0]] in nbs)
-            self.assertTrue(fake_structure[sorted[1]] in nbs)
-            self.assertTrue(fake_structure[sorted[2]] in nbs)
+            assert len(neighbors) == 3
+            assert fake_structure[sorted[0]] in nbs
+            assert fake_structure[sorted[1]] in nbs
+            assert fake_structure[sorted[2]] in nbs
             neighbors = detailed_voronoi_container.neighbors(0, 1.5, 0.5, True)
-            self.assertEqual(len(neighbors), 6)
+            assert len(neighbors) == 6
 
             # Second fake structure
             coords2 = [[5.0, 5.0, 5.0]]
@@ -117,27 +117,27 @@ class VoronoiContainerTest(PymatgenTest):
                 normalized_distance_tolerance=0.0100001,
                 isites=[0],
             )
-            self.assertEqual(len(detailed_voronoi_container.voronoi_list2[0]), 6)
+            assert len(detailed_voronoi_container.voronoi_list2[0]) == 6
             neighbors = detailed_voronoi_container.neighbors(0, 1.0, 0.5, True)
             nbs = [nb["site"] for nb in neighbors]
-            self.assertEqual(len(neighbors), 3)
-            self.assertTrue(fake_structure2[sorted[0]] in nbs)
-            self.assertTrue(fake_structure2[sorted[1]] in nbs)
-            self.assertTrue(fake_structure2[sorted[2]] in nbs)
+            assert len(neighbors) == 3
+            assert fake_structure2[sorted[0]] in nbs
+            assert fake_structure2[sorted[1]] in nbs
+            assert fake_structure2[sorted[2]] in nbs
             neighbors = detailed_voronoi_container.neighbors(0, 1.02, 0.5, True)
             nbs = [nb["site"] for nb in neighbors]
-            self.assertEqual(len(neighbors), 3)
-            self.assertTrue(fake_structure2[sorted[0]] in nbs)
-            self.assertTrue(fake_structure2[sorted[1]] in nbs)
-            self.assertTrue(fake_structure2[sorted[2]] in nbs)
+            assert len(neighbors) == 3
+            assert fake_structure2[sorted[0]] in nbs
+            assert fake_structure2[sorted[1]] in nbs
+            assert fake_structure2[sorted[2]] in nbs
             neighbors = detailed_voronoi_container.neighbors(0, 1.026, 0.5, True)
             nbs = [nb["site"] for nb in neighbors]
-            self.assertEqual(len(neighbors), 3)
-            self.assertTrue(fake_structure2[sorted[0]] in nbs)
-            self.assertTrue(fake_structure2[sorted[1]] in nbs)
-            self.assertTrue(fake_structure2[sorted[2]] in nbs)
+            assert len(neighbors) == 3
+            assert fake_structure2[sorted[0]] in nbs
+            assert fake_structure2[sorted[1]] in nbs
+            assert fake_structure2[sorted[2]] in nbs
             neighbors = detailed_voronoi_container.neighbors(0, 1.5, 0.5, True)
-            self.assertEqual(len(neighbors), 6)
+            assert len(neighbors) == 6
 
             species = ["Cu", "Cu", "O", "O", "O", "Cu", "O"]
             valences = [2, 2, -2, -2, -2, 2, -2]
@@ -160,20 +160,20 @@ class VoronoiContainerTest(PymatgenTest):
                 isites=[0],
                 additional_conditions=[DetailedVoronoiContainer.AC.ONLY_ACB],
             )
-            self.assertEqual(len(detailed_voronoi_container.voronoi_list2[0]), 6)
+            assert len(detailed_voronoi_container.voronoi_list2[0]) == 6
             neighbors = detailed_voronoi_container.neighbors(0, 1.01, 0.5, True)
             nbs = [nb["site"] for nb in neighbors]
-            self.assertEqual(len(neighbors), 6)
-            self.assertTrue(fake_structure3[1] in nbs)
-            self.assertTrue(fake_structure3[2] in nbs)
-            self.assertTrue(fake_structure3[3] in nbs)
-            self.assertTrue(fake_structure3[4] in nbs)
-            self.assertTrue(fake_structure3[5] in nbs)
-            self.assertTrue(fake_structure3[6] in nbs)
+            assert len(neighbors) == 6
+            assert fake_structure3[1] in nbs
+            assert fake_structure3[2] in nbs
+            assert fake_structure3[3] in nbs
+            assert fake_structure3[4] in nbs
+            assert fake_structure3[5] in nbs
+            assert fake_structure3[6] in nbs
 
             # Test of the as_dict() and from_dict() methods as well as __eq__ method
             other_detailed_voronoi_container = DetailedVoronoiContainer.from_dict(detailed_voronoi_container.as_dict())
-            self.assertTrue(detailed_voronoi_container, other_detailed_voronoi_container)
+            assert detailed_voronoi_container, other_detailed_voronoi_container
 
     def test_get_vertices_dist_ang_indices(self):
         with ScratchDir("."):
@@ -209,12 +209,12 @@ class VoronoiContainerTest(PymatgenTest):
                     fake_parameter_indices_list.append((ii, jj))
 
             points = detailed_voronoi_container._get_vertices_dist_ang_indices(fake_parameter_indices_list)
-            self.assertEqual(points[0], (2, 7))
-            self.assertEqual(points[1], (4, 7))
-            self.assertEqual(points[2], (4, 10))
-            self.assertEqual(points[3], (6, 10))
-            self.assertEqual(points[4], (6, 13))
-            self.assertEqual(points[5], (2, 13))
+            assert points[0] == (2, 7)
+            assert points[1] == (4, 7)
+            assert points[2] == (4, 10)
+            assert points[3] == (6, 10)
+            assert points[4] == (6, 13)
+            assert points[5] == (2, 13)
 
 
 if __name__ == "__main__":

--- a/pymatgen/analysis/chemenv/coordination_environments/tests/test_weights.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/tests/test_weights.py
@@ -7,6 +7,8 @@ import json
 import os
 import unittest
 
+import pytest
+
 from pymatgen.analysis.chemenv.coordination_environments.chemenv_strategies import (
     AngleNbSetWeight,
     CNBiasNbSetWeight,
@@ -60,36 +62,36 @@ class StrategyWeightsTest(PymatgenTest):
         ]
         angle_weight = AngleNbSetWeight(aa=1.0)
         aw = angle_weight.weight(nb_set=fake_nb_set, structure_environments=dummy_se)
-        self.assertAlmostEqual(aw, 0.9634354419021528, delta=1e-8)
+        assert abs(aw - 0.9634354419021528) < 1e-8
         angle_weight = AngleNbSetWeight(aa=2.0)
         aw = angle_weight.weight(nb_set=fake_nb_set, structure_environments=dummy_se)
-        self.assertAlmostEqual(aw, 0.92820785071319645, delta=1e-8)
+        assert abs(aw - 0.92820785071319645) < 1e-8
         angle_weight = AngleNbSetWeight(aa=0.5)
         aw = angle_weight.weight(nb_set=fake_nb_set, structure_environments=dummy_se)
-        self.assertAlmostEqual(aw, 0.98154747307613843, delta=1e-8)
+        assert abs(aw - 0.98154747307613843) < 1e-8
 
-        self.assertNotEqual(AngleNbSetWeight(1.0), AngleNbSetWeight(2.0))
+        assert AngleNbSetWeight(1.0) != AngleNbSetWeight(2.0)
 
         # nb_set with no neighbor
         fake_nb_set.angles = []
         angle_weight = AngleNbSetWeight(aa=1.0)
         aw = angle_weight.weight(nb_set=fake_nb_set, structure_environments=dummy_se)
-        self.assertAlmostEqual(aw, 0.0, delta=1e-8)
+        assert abs(aw - 0.0) < 1e-8
         angle_weight = AngleNbSetWeight(aa=2.0)
         aw = angle_weight.weight(nb_set=fake_nb_set, structure_environments=dummy_se)
-        self.assertAlmostEqual(aw, 0.0, delta=1e-8)
+        assert abs(aw - 0.0) < 1e-8
 
         # nb_set with one neighbor
         fake_nb_set.angles = [3.08570351705799]
         angle_weight = AngleNbSetWeight(aa=1.0)
         aw = angle_weight.weight(nb_set=fake_nb_set, structure_environments=dummy_se)
-        self.assertAlmostEqual(aw, 0.24555248382791284, delta=1e-8)
+        assert abs(aw - 0.24555248382791284) < 1e-8
         angle_weight = AngleNbSetWeight(aa=2.0)
         aw = angle_weight.weight(nb_set=fake_nb_set, structure_environments=dummy_se)
-        self.assertAlmostEqual(aw, 0.060296022314057396, delta=1e-8)
+        assert abs(aw - 0.060296022314057396) < 1e-8
         angle_weight = AngleNbSetWeight(aa=0.5)
         aw = angle_weight.weight(nb_set=fake_nb_set, structure_environments=dummy_se)
-        self.assertAlmostEqual(aw, 0.49553252549950022, delta=1e-8)
+        assert abs(aw - 0.49553252549950022) < 1e-8
 
         # nb_set with 6 neighbors (sum of the angles is 4*pi, i.e. the full sphere)
         fake_nb_set.angles = [
@@ -102,13 +104,13 @@ class StrategyWeightsTest(PymatgenTest):
         ]
         angle_weight = AngleNbSetWeight(aa=1.0)
         aw = angle_weight.weight(nb_set=fake_nb_set, structure_environments=dummy_se)
-        self.assertAlmostEqual(aw, 1.0, delta=1e-8)
+        assert abs(aw - 1.0) < 1e-8
         angle_weight = AngleNbSetWeight(aa=2.0)
         aw = angle_weight.weight(nb_set=fake_nb_set, structure_environments=dummy_se)
-        self.assertAlmostEqual(aw, 1.0, delta=1e-8)
+        assert abs(aw - 1.0) < 1e-8
         angle_weight = AngleNbSetWeight(aa=0.5)
         aw = angle_weight.weight(nb_set=fake_nb_set, structure_environments=dummy_se)
-        self.assertAlmostEqual(aw, 1.0, delta=1e-8)
+        assert abs(aw - 1.0) < 1e-8
 
     def test_normalized_angle_distance_weight(self):
         fake_nb_set = FakeNbSet()
@@ -126,12 +128,11 @@ class StrategyWeightsTest(PymatgenTest):
         nadw10 = NormalizedAngleDistanceNbSetWeight(average_type="arithmetic", aa=2, bb=2)
         nadw11 = NormalizedAngleDistanceNbSetWeight(average_type="geometric", aa=1, bb=2)
         nadw12 = NormalizedAngleDistanceNbSetWeight(average_type="geometric", aa=2, bb=1)
-        self.assertNotEqual(nadw11, nadw12)
-        with self.assertRaisesRegex(ValueError, "Both exponents are 0."):
+        assert nadw11 != nadw12
+        with pytest.raises(ValueError, match="Both exponents are 0."):
             NormalizedAngleDistanceNbSetWeight(average_type="arithmetic", aa=0, bb=0)
-        with self.assertRaisesRegex(
-            ValueError,
-            'Average type is "arithmetix" ' 'while it should be "geometric" or "arithmetic"',
+        with pytest.raises(
+            ValueError, match='Average type is "arithmetix" ' 'while it should be "geometric" or "arithmetic"'
         ):
             NormalizedAngleDistanceNbSetWeight(average_type="arithmetix", aa=1, bb=1)
 
@@ -150,29 +151,29 @@ class StrategyWeightsTest(PymatgenTest):
             0.7354996568248028,
         ]
         w1 = nadw1.weight(nb_set=fake_nb_set, structure_environments=dummy_se)
-        self.assertAlmostEqual(w1, 0.67310887189488189, delta=1e-8)
+        assert abs(w1 - 0.67310887189488189) < 1e-8
         w2 = nadw2.weight(nb_set=fake_nb_set, structure_environments=dummy_se)
-        self.assertAlmostEqual(w2, 0.69422258996523023, delta=1e-8)
+        assert abs(w2 - 0.69422258996523023) < 1e-8
         w3 = nadw3.weight(nb_set=fake_nb_set, structure_environments=dummy_se)
-        self.assertAlmostEqual(w3, 0.8700949310182079, delta=1e-8)
+        assert abs(w3 - 0.8700949310182079) < 1e-8
         w4 = nadw4.weight(nb_set=fake_nb_set, structure_environments=dummy_se)
-        self.assertAlmostEqual(w4, 0.7847083661164217, delta=1e-8)
+        assert abs(w4 - 0.7847083661164217) < 1e-8
         w5 = nadw5.weight(nb_set=fake_nb_set, structure_environments=dummy_se)
-        self.assertAlmostEqual(w5, 0.96148050989126843, delta=1e-8)
+        assert abs(w5 - 0.96148050989126843) < 1e-8
         w6 = nadw6.weight(nb_set=fake_nb_set, structure_environments=dummy_se)
-        self.assertAlmostEqual(w6, 0.98621181678741754, delta=1e-8)
+        assert abs(w6 - 0.98621181678741754) < 1e-8
         w7 = nadw7.weight(nb_set=fake_nb_set, structure_environments=dummy_se)
-        self.assertAlmostEqual(w7, 0.97479580875402994, delta=1e-8)
+        assert abs(w7 - 0.97479580875402994) < 1e-8
         w8 = nadw8.weight(nb_set=fake_nb_set, structure_environments=dummy_se)
-        self.assertAlmostEqual(w8, 0.63348507114489783, delta=1e-8)
+        assert abs(w8 - 0.63348507114489783) < 1e-8
         w9 = nadw9.weight(nb_set=fake_nb_set, structure_environments=dummy_se)
-        self.assertAlmostEqual(w9, 0.7668954450583646, delta=1e-8)
+        assert abs(w9 - 0.7668954450583646) < 1e-8
         w10 = nadw10.weight(nb_set=fake_nb_set, structure_environments=dummy_se)
-        self.assertAlmostEqual(w10, 0.51313920014833292, delta=1e-8)
+        assert abs(w10 - 0.51313920014833292) < 1e-8
         w11 = nadw11.weight(nb_set=fake_nb_set, structure_environments=dummy_se)
-        self.assertAlmostEqual(w11, 0.585668617459, delta=1e-8)
+        assert abs(w11 - 0.585668617459) < 1e-8
         w12 = nadw12.weight(nb_set=fake_nb_set, structure_environments=dummy_se)
-        self.assertAlmostEqual(w12, 0.520719679281, delta=1e-8)
+        assert abs(w12 - 0.520719679281) < 1e-8
 
     def test_CN_bias_weight(self):
         fake_nb_set = FakeNbSet()
@@ -196,36 +197,36 @@ class StrategyWeightsTest(PymatgenTest):
                 13: 4.8,
             }
         )
-        with self.assertRaisesRegex(ValueError, "Weights should be provided for CN 1 to 13"):
+        with pytest.raises(ValueError, match="Weights should be provided for CN 1 to 13"):
             CNBiasNbSetWeight.explicit(cn_weights={1: 1.0, 13: 2.0})
 
         fake_nb_set.cn = 1
         w1 = bias_weight1.weight(nb_set=fake_nb_set, structure_environments=dummy_se)
-        self.assertAlmostEqual(w1, 1.0, delta=1e-8)
+        assert abs(w1 - 1.0) < 1e-8
         w2 = bias_weight2.weight(nb_set=fake_nb_set, structure_environments=dummy_se)
-        self.assertAlmostEqual(w2, 1.0, delta=1e-8)
+        assert abs(w2 - 1.0) < 1e-8
         w3 = bias_weight3.weight(nb_set=fake_nb_set, structure_environments=dummy_se)
-        self.assertAlmostEqual(w3, 1.0, delta=1e-8)
+        assert abs(w3 - 1.0) < 1e-8
         fake_nb_set.cn = 7
         w1 = bias_weight1.weight(nb_set=fake_nb_set, structure_environments=dummy_se)
-        self.assertAlmostEqual(w1, 7.0, delta=1e-8)
+        assert abs(w1 - 7.0) < 1e-8
         w2 = bias_weight2.weight(nb_set=fake_nb_set, structure_environments=dummy_se)
-        self.assertAlmostEqual(w2, 1.1**6, delta=1e-8)
+        assert abs(w2 - 1.1**6) < 1e-8
         w3 = bias_weight3.weight(nb_set=fake_nb_set, structure_environments=dummy_se)
-        self.assertAlmostEqual(w3, 4.3, delta=1e-8)
+        assert abs(w3 - 4.3) < 1e-8
         fake_nb_set.cn = 13
         w1 = bias_weight1.weight(nb_set=fake_nb_set, structure_environments=dummy_se)
-        self.assertAlmostEqual(w1, 13.0, delta=1e-8)
+        assert abs(w1 - 13.0) < 1e-8
         w2 = bias_weight2.weight(nb_set=fake_nb_set, structure_environments=dummy_se)
-        self.assertAlmostEqual(w2, 1.1**12, delta=1e-8)
+        assert abs(w2 - 1.1**12) < 1e-8
         w3 = bias_weight3.weight(nb_set=fake_nb_set, structure_environments=dummy_se)
-        self.assertAlmostEqual(w3, 4.8, delta=1e-8)
+        assert abs(w3 - 4.8) < 1e-8
 
         bias_weight4 = CNBiasNbSetWeight.from_description(
             {"type": "linearly_equidistant", "weight_cn1": 2.0, "weight_cn13": 26.0}
         )
         for cn in range(1, 14):
-            self.assertAlmostEqual(bias_weight4.cn_weights[cn], 2.0 * cn)
+            assert round(abs(bias_weight4.cn_weights[cn] - 2.0 * cn), 7) == 0
 
         bias_weight5 = CNBiasNbSetWeight.from_description(
             {
@@ -234,19 +235,19 @@ class StrategyWeightsTest(PymatgenTest):
                 "weight_cn13": 13.0,
             }
         )
-        self.assertAlmostEqual(bias_weight5.cn_weights[1], 1.0)
-        self.assertAlmostEqual(bias_weight5.cn_weights[3], 1.5334062370163877)
-        self.assertAlmostEqual(bias_weight5.cn_weights[9], 5.5287748136788739)
-        self.assertAlmostEqual(bias_weight5.cn_weights[12], 10.498197520079623)
+        assert round(abs(bias_weight5.cn_weights[1] - 1.0), 7) == 0
+        assert round(abs(bias_weight5.cn_weights[3] - 1.5334062370163877), 7) == 0
+        assert round(abs(bias_weight5.cn_weights[9] - 5.5287748136788739), 7) == 0
+        assert round(abs(bias_weight5.cn_weights[12] - 10.498197520079623), 7) == 0
 
         cn_weights = {cn: 0.0 for cn in range(1, 14)}
         cn_weights[6] = 2.0
         cn_weights[4] = 1.0
         bias_weight6 = CNBiasNbSetWeight.from_description({"type": "explicit", "cn_weights": cn_weights})
 
-        self.assertAlmostEqual(bias_weight6.cn_weights[1], 0.0)
-        self.assertAlmostEqual(bias_weight6.cn_weights[4], 1.0)
-        self.assertAlmostEqual(bias_weight6.cn_weights[6], 2.0)
+        assert round(abs(bias_weight6.cn_weights[1] - 0.0), 7) == 0
+        assert round(abs(bias_weight6.cn_weights[4] - 1.0), 7) == 0
+        assert round(abs(bias_weight6.cn_weights[6] - 2.0), 7) == 0
 
     def test_self_csms_weight(self):
         # Get the StructureEnvironments for K2NaNb2Fe7Si8H4O31 (mp-743972)
@@ -281,7 +282,7 @@ class StrategyWeightsTest(PymatgenTest):
             weight_estimator=weight_estimator2,
             symmetry_measure_type=symmetry_measure_type,
         )
-        self.assertNotEqual(self_weight, self_weight2)
+        assert self_weight != self_weight2
 
         additional_info = {}
         cn_map = (12, 3)
@@ -291,7 +292,7 @@ class StrategyWeightsTest(PymatgenTest):
             cn_map=cn_map,
             additional_info=additional_info,
         )
-        self.assertAlmostEqual(self_w, 0.11671945916431022, delta=1e-8)
+        assert abs(self_w - 0.11671945916431022) < 1e-8
         cn_map = (12, 2)
         self_w = self_weight.weight(
             nb_set=nbsets[cn_map],
@@ -299,7 +300,7 @@ class StrategyWeightsTest(PymatgenTest):
             cn_map=cn_map,
             additional_info=additional_info,
         )
-        self.assertAlmostEqual(self_w, 0.0, delta=1e-8)
+        assert abs(self_w - 0.0) < 1e-8
         cn_map = (12, 0)
         self_w = self_weight.weight(
             nb_set=nbsets[cn_map],
@@ -307,7 +308,7 @@ class StrategyWeightsTest(PymatgenTest):
             cn_map=cn_map,
             additional_info=additional_info,
         )
-        self.assertAlmostEqual(self_w, 0.0, delta=1e-8)
+        assert abs(self_w - 0.0) < 1e-8
         cn_map = (12, 1)
         self_w = self_weight.weight(
             nb_set=nbsets[cn_map],
@@ -315,7 +316,7 @@ class StrategyWeightsTest(PymatgenTest):
             cn_map=cn_map,
             additional_info=additional_info,
         )
-        self.assertAlmostEqual(self_w, 0.0, delta=1e-8)
+        assert abs(self_w - 0.0) < 1e-8
         cn_map = (13, 2)
         self_w = self_weight.weight(
             nb_set=nbsets[cn_map],
@@ -323,7 +324,7 @@ class StrategyWeightsTest(PymatgenTest):
             cn_map=cn_map,
             additional_info=additional_info,
         )
-        self.assertAlmostEqual(self_w, 0.14204073172729198, delta=1e-8)
+        assert abs(self_w - 0.14204073172729198) < 1e-8
 
         # Get the StructureEnvironments for SiO2 (mp-7000)
         with open(os.path.join(se_files_dir, "se_mp-7000.json")) as f:
@@ -358,7 +359,7 @@ class StrategyWeightsTest(PymatgenTest):
             cn_map=cn_map,
             additional_info=additional_info,
         )
-        self.assertAlmostEqual(self_w, 0.8143992162836029, delta=1e-8)
+        assert abs(self_w - 0.8143992162836029) < 1e-8
         cn_map = (4, 0)
         self_w = self_weight.weight(
             nb_set=nbsets[cn_map],
@@ -366,7 +367,7 @@ class StrategyWeightsTest(PymatgenTest):
             cn_map=cn_map,
             additional_info=additional_info,
         )
-        self.assertAlmostEqual(self_w, 0.99629742352359496, delta=1e-8)
+        assert abs(self_w - 0.99629742352359496) < 1e-8
 
     def test_delta_csms_weight(self):
         # Get the StructureEnvironments for K2NaNb2Fe7Si8H4O31 (mp-743972)
@@ -401,7 +402,7 @@ class StrategyWeightsTest(PymatgenTest):
             cn_map=cn_map,
             additional_info=additional_info,
         )
-        self.assertAlmostEqual(delta_w, 0.0, delta=1e-8)
+        assert abs(delta_w - 0.0) < 1e-8
         cn_map = (12, 2)
         delta_w = delta_weight.weight(
             nb_set=nbsets[cn_map],
@@ -409,7 +410,7 @@ class StrategyWeightsTest(PymatgenTest):
             cn_map=cn_map,
             additional_info=additional_info,
         )
-        self.assertAlmostEqual(delta_w, 0.0, delta=1e-8)
+        assert abs(delta_w - 0.0) < 1e-8
         cn_map = (12, 0)
         delta_w = delta_weight.weight(
             nb_set=nbsets[cn_map],
@@ -417,7 +418,7 @@ class StrategyWeightsTest(PymatgenTest):
             cn_map=cn_map,
             additional_info=additional_info,
         )
-        self.assertAlmostEqual(delta_w, 0.0, delta=1e-8)
+        assert abs(delta_w - 0.0) < 1e-8
         cn_map = (12, 1)
         delta_w = delta_weight.weight(
             nb_set=nbsets[cn_map],
@@ -425,7 +426,7 @@ class StrategyWeightsTest(PymatgenTest):
             cn_map=cn_map,
             additional_info=additional_info,
         )
-        self.assertAlmostEqual(delta_w, 0.0, delta=1e-8)
+        assert abs(delta_w - 0.0) < 1e-8
         cn_map = (13, 2)
         delta_w = delta_weight.weight(
             nb_set=nbsets[cn_map],
@@ -433,7 +434,7 @@ class StrategyWeightsTest(PymatgenTest):
             cn_map=cn_map,
             additional_info=additional_info,
         )
-        self.assertAlmostEqual(delta_w, 1.0, delta=1e-8)
+        assert abs(delta_w - 1.0) < 1e-8
         cn_map = (13, 0)
         delta_w = delta_weight.weight(
             nb_set=nbsets[cn_map],
@@ -441,7 +442,7 @@ class StrategyWeightsTest(PymatgenTest):
             cn_map=cn_map,
             additional_info=additional_info,
         )
-        self.assertAlmostEqual(delta_w, 0.0, delta=1e-8)
+        assert abs(delta_w - 0.0) < 1e-8
         cn_map = (13, 1)
         delta_w = delta_weight.weight(
             nb_set=nbsets[cn_map],
@@ -449,7 +450,7 @@ class StrategyWeightsTest(PymatgenTest):
             cn_map=cn_map,
             additional_info=additional_info,
         )
-        self.assertAlmostEqual(delta_w, 0.0, delta=1e-8)
+        assert abs(delta_w - 0.0) < 1e-8
 
         effective_csm_estimator = {
             "function": "power2_inverse_decreasing",
@@ -475,7 +476,7 @@ class StrategyWeightsTest(PymatgenTest):
             cn_map=cn_map,
             additional_info=additional_info,
         )
-        self.assertAlmostEqual(delta_w, 0.040830741048481355, delta=1e-8)
+        assert abs(delta_w - 0.040830741048481355) < 1e-8
         cn_map = (13, 2)
         delta_w = delta_weight.weight(
             nb_set=nbsets[cn_map],
@@ -483,7 +484,7 @@ class StrategyWeightsTest(PymatgenTest):
             cn_map=cn_map,
             additional_info=additional_info,
         )
-        self.assertAlmostEqual(delta_w, 1.0, delta=1e-8)
+        assert abs(delta_w - 1.0) < 1e-8
         cn_map = (13, 0)
         delta_w = delta_weight.weight(
             nb_set=nbsets[cn_map],
@@ -491,7 +492,7 @@ class StrategyWeightsTest(PymatgenTest):
             cn_map=cn_map,
             additional_info=additional_info,
         )
-        self.assertAlmostEqual(delta_w, 0.103515625, delta=1e-8)
+        assert abs(delta_w - 0.103515625) < 1e-8
         cn_map = (13, 1)
         delta_w = delta_weight.weight(
             nb_set=nbsets[cn_map],
@@ -499,7 +500,7 @@ class StrategyWeightsTest(PymatgenTest):
             cn_map=cn_map,
             additional_info=additional_info,
         )
-        self.assertAlmostEqual(delta_w, 0.103515625, delta=1e-8)
+        assert abs(delta_w - 0.103515625) < 1e-8
 
         # Get the StructureEnvironments for SiO2 (mp-7000)
         with open(os.path.join(se_files_dir, "se_mp-7000.json")) as f:
@@ -534,7 +535,7 @@ class StrategyWeightsTest(PymatgenTest):
             cn_map=cn_map,
             additional_info=additional_info,
         )
-        self.assertAlmostEqual(delta_w, 0.0, delta=1e-8)
+        assert abs(delta_w - 0.0) < 1e-8
         cn_map = (4, 0)
         delta_w = delta_weight.weight(
             nb_set=nbsets[cn_map],
@@ -542,7 +543,7 @@ class StrategyWeightsTest(PymatgenTest):
             cn_map=cn_map,
             additional_info=additional_info,
         )
-        self.assertAlmostEqual(delta_w, 1.0, delta=1e-8)
+        assert abs(delta_w - 1.0) < 1e-8
 
     def test_dist_angle_area_weight(self):
 
@@ -560,33 +561,33 @@ class StrategyWeightsTest(PymatgenTest):
         )
 
         d1, d2, a1, a2 = 1.05, 1.15, 0.05, 0.08
-        self.assertFalse(da_area_weight.rectangle_crosses_area(d1=d1, d2=d2, a1=a1, a2=a2))
+        assert not da_area_weight.rectangle_crosses_area(d1=d1, d2=d2, a1=a1, a2=a2)
         d1, d2, a1, a2 = 1.05, 1.15, 0.1, 0.2
-        self.assertFalse(da_area_weight.rectangle_crosses_area(d1=d1, d2=d2, a1=a1, a2=a2))
+        assert not da_area_weight.rectangle_crosses_area(d1=d1, d2=d2, a1=a1, a2=a2)
         d1, d2, a1, a2 = 1.9, 1.95, 0.1, 0.2
-        self.assertFalse(da_area_weight.rectangle_crosses_area(d1=d1, d2=d2, a1=a1, a2=a2))
+        assert not da_area_weight.rectangle_crosses_area(d1=d1, d2=d2, a1=a1, a2=a2)
         d1, d2, a1, a2 = 1.05, 1.95, 0.05, 0.25
-        self.assertTrue(da_area_weight.rectangle_crosses_area(d1=d1, d2=d2, a1=a1, a2=a2))
+        assert da_area_weight.rectangle_crosses_area(d1=d1, d2=d2, a1=a1, a2=a2)
         d1, d2, a1, a2 = 1.05, 1.95, 0.75, 0.9
-        self.assertTrue(da_area_weight.rectangle_crosses_area(d1=d1, d2=d2, a1=a1, a2=a2))
+        assert da_area_weight.rectangle_crosses_area(d1=d1, d2=d2, a1=a1, a2=a2)
         d1, d2, a1, a2 = 1.1, 1.9, 0.1, 0.9
-        self.assertTrue(da_area_weight.rectangle_crosses_area(d1=d1, d2=d2, a1=a1, a2=a2))
+        assert da_area_weight.rectangle_crosses_area(d1=d1, d2=d2, a1=a1, a2=a2)
         d1, d2, a1, a2 = 1.23, 1.77, 0.48, 0.52
-        self.assertTrue(da_area_weight.rectangle_crosses_area(d1=d1, d2=d2, a1=a1, a2=a2))
+        assert da_area_weight.rectangle_crosses_area(d1=d1, d2=d2, a1=a1, a2=a2)
         d1, d2, a1, a2 = 1.23, 1.24, 0.48, 0.52
-        self.assertFalse(da_area_weight.rectangle_crosses_area(d1=d1, d2=d2, a1=a1, a2=a2))
+        assert not da_area_weight.rectangle_crosses_area(d1=d1, d2=d2, a1=a1, a2=a2)
         d1, d2, a1, a2 = 1.4, 1.6, 0.4, 0.6
-        self.assertTrue(da_area_weight.rectangle_crosses_area(d1=d1, d2=d2, a1=a1, a2=a2))
+        assert da_area_weight.rectangle_crosses_area(d1=d1, d2=d2, a1=a1, a2=a2)
         d1, d2, a1, a2 = 1.6, 1.9, 0.7, 0.9
-        self.assertFalse(da_area_weight.rectangle_crosses_area(d1=d1, d2=d2, a1=a1, a2=a2))
+        assert not da_area_weight.rectangle_crosses_area(d1=d1, d2=d2, a1=a1, a2=a2)
         d1, d2, a1, a2 = 1.5, 1.6, 0.75, 0.78
-        self.assertFalse(da_area_weight.rectangle_crosses_area(d1=d1, d2=d2, a1=a1, a2=a2))
+        assert not da_area_weight.rectangle_crosses_area(d1=d1, d2=d2, a1=a1, a2=a2)
         d1, d2, a1, a2 = 1.5, 1.6, 0.75, 0.95
-        self.assertFalse(da_area_weight.rectangle_crosses_area(d1=d1, d2=d2, a1=a1, a2=a2))
+        assert not da_area_weight.rectangle_crosses_area(d1=d1, d2=d2, a1=a1, a2=a2)
         d1, d2, a1, a2 = 1.4, 1.6, 0.1, 0.9
-        self.assertTrue(da_area_weight.rectangle_crosses_area(d1=d1, d2=d2, a1=a1, a2=a2))
+        assert da_area_weight.rectangle_crosses_area(d1=d1, d2=d2, a1=a1, a2=a2)
         d1, d2, a1, a2 = 1.4, 1.6, 0.3, 0.7
-        self.assertTrue(da_area_weight.rectangle_crosses_area(d1=d1, d2=d2, a1=a1, a2=a2))
+        assert da_area_weight.rectangle_crosses_area(d1=d1, d2=d2, a1=a1, a2=a2)
 
     def test_dist_nb_set_weight(self):
 
@@ -673,26 +674,26 @@ class StrategyWeightsTest(PymatgenTest):
         cn_map7 = (7, 0)
 
         myweight1 = dnbset_weight.weight(fake_nb_set1, dummy_se, cn_map=cn_map1, additional_info=None)
-        self.assertAlmostEqual(myweight1, 0.0, delta=1e-8)
+        assert abs(myweight1 - 0.0) < 1e-8
         myweight2 = dnbset_weight.weight(fake_nb_set2, dummy_se, cn_map=cn_map2, additional_info=None)
-        self.assertAlmostEqual(myweight2, 0.103515625, delta=1e-8)
+        assert abs(myweight2 - 0.103515625) < 1e-8
         myweight3 = dnbset_weight.weight(fake_nb_set3, dummy_se, cn_map=cn_map3, additional_info=None)
-        self.assertAlmostEqual(myweight3, 0.5, delta=1e-8)
+        assert abs(myweight3 - 0.5) < 1e-8
         myweight4 = dnbset_weight.weight(fake_nb_set4, dummy_se, cn_map=cn_map4, additional_info=None)
-        self.assertAlmostEqual(myweight4, 0.896484375, delta=1e-8)
+        assert abs(myweight4 - 0.896484375) < 1e-8
         myweight5 = dnbset_weight.weight(fake_nb_set5, dummy_se, cn_map=cn_map5, additional_info=None)
-        self.assertAlmostEqual(myweight5, 1.0, delta=1e-8)
+        assert abs(myweight5 - 1.0) < 1e-8
         myweight5_m2 = dnbset_weight.weight(fake_nb_set5_m2, dummy_se, cn_map=cn_map5_m2, additional_info=None)
-        self.assertAlmostEqual(myweight5_m2, 0.103515625, delta=1e-8)
+        assert abs(myweight5_m2 - 0.103515625) < 1e-8
         myweight7 = dnbset_weight.weight(fake_nb_set7, dummy_se, cn_map=cn_map7, additional_info=None)
-        self.assertAlmostEqual(myweight7, 1.0, delta=1e-8)
+        assert abs(myweight7 - 1.0) < 1e-8
 
         myweight_2_3 = dnbset_weight2.weight(fake_nb_set3, dummy_se, cn_map=cn_map3, additional_info=None)
-        self.assertAlmostEqual(myweight_2_3, 0.5, delta=1e-8)
+        assert abs(myweight_2_3 - 0.5) < 1e-8
         myweight_2_4 = dnbset_weight2.weight(fake_nb_set4, dummy_se, cn_map=cn_map4, additional_info=None)
-        self.assertAlmostEqual(myweight_2_4, 0.84375, delta=1e-8)
+        assert abs(myweight_2_4 - 0.84375) < 1e-8
         myweight_2_2 = dnbset_weight2.weight(fake_nb_set2, dummy_se, cn_map=cn_map2, additional_info=None)
-        self.assertAlmostEqual(myweight_2_2, 0.15625, delta=1e-8)
+        assert abs(myweight_2_2 - 0.15625) < 1e-8
 
         dnbset_weight3 = DistanceNbSetWeight(
             weight_function={
@@ -710,9 +711,9 @@ class StrategyWeightsTest(PymatgenTest):
         )
 
         myweight_3_6 = dnbset_weight3.weight(fake_nb_set6, dummy_se, cn_map=cn_map6, additional_info=None)
-        self.assertAlmostEqual(myweight_3_6, 1.0, delta=1e-8)
+        assert abs(myweight_3_6 - 1.0) < 1e-8
         myweight_4_6 = dnbset_weight4.weight(fake_nb_set6, dummy_se, cn_map=cn_map6, additional_info=None)
-        self.assertAlmostEqual(myweight_4_6, 0.15625, delta=1e-8)
+        assert abs(myweight_4_6 - 0.15625) < 1e-8
 
         deltadnbset_weight = DeltaDistanceNbSetWeight(
             weight_function={
@@ -722,11 +723,11 @@ class StrategyWeightsTest(PymatgenTest):
         )
 
         myweightdelta1 = deltadnbset_weight.weight(fake_nb_set1, dummy_se, cn_map=cn_map1, additional_info=None)
-        self.assertAlmostEqual(myweightdelta1, 1.0, delta=1e-8)
+        assert abs(myweightdelta1 - 1.0) < 1e-8
         myweightdelta2 = deltadnbset_weight.weight(fake_nb_set2, dummy_se, cn_map=cn_map2, additional_info=None)
-        self.assertAlmostEqual(myweightdelta2, 0.0, delta=1e-8)
+        assert abs(myweightdelta2 - 0.0) < 1e-8
         myweightdelta3 = deltadnbset_weight.weight(fake_nb_set3, dummy_se, cn_map=cn_map3, additional_info=None)
-        self.assertAlmostEqual(myweightdelta3, 0.0, delta=1e-8)
+        assert abs(myweightdelta3 - 0.0) < 1e-8
 
         deltadnbset_weight2 = DeltaDistanceNbSetWeight(
             weight_function={
@@ -736,11 +737,11 @@ class StrategyWeightsTest(PymatgenTest):
         )
 
         myweightdelta1 = deltadnbset_weight2.weight(fake_nb_set1, dummy_se, cn_map=cn_map1, additional_info=None)
-        self.assertAlmostEqual(myweightdelta1, 0.5, delta=1e-8)
+        assert abs(myweightdelta1 - 0.5) < 1e-8
         myweightdelta2 = deltadnbset_weight2.weight(fake_nb_set2, dummy_se, cn_map=cn_map2, additional_info=None)
-        self.assertAlmostEqual(myweightdelta2, 0.0, delta=1e-8)
+        assert abs(myweightdelta2 - 0.0) < 1e-8
         myweightdelta3 = deltadnbset_weight2.weight(fake_nb_set3, dummy_se, cn_map=cn_map3, additional_info=None)
-        self.assertAlmostEqual(myweightdelta3, 0.0, delta=1e-8)
+        assert abs(myweightdelta3 - 0.0) < 1e-8
 
         deltadnbset_weight3 = DeltaDistanceNbSetWeight(
             weight_function={
@@ -750,9 +751,9 @@ class StrategyWeightsTest(PymatgenTest):
         )
 
         myweightdelta1 = deltadnbset_weight3.weight(fake_nb_set1, dummy_se, cn_map=cn_map1, additional_info=None)
-        self.assertAlmostEqual(myweightdelta1, 0.15625, delta=1e-8)
+        assert abs(myweightdelta1 - 0.15625) < 1e-8
         myweightdelta6 = deltadnbset_weight3.weight(fake_nb_set6, dummy_se, cn_map=cn_map6, additional_info=None)
-        self.assertAlmostEqual(myweightdelta6, 0.31640625, delta=1e-8)
+        assert abs(myweightdelta6 - 0.31640625) < 1e-8
 
         deltadnbset_weight4 = DeltaDistanceNbSetWeight(
             weight_function={
@@ -763,9 +764,9 @@ class StrategyWeightsTest(PymatgenTest):
         )
 
         myweightdelta1 = deltadnbset_weight4.weight(fake_nb_set1, dummy_se, cn_map=cn_map1, additional_info=None)
-        self.assertAlmostEqual(myweightdelta1, 0.15625, delta=1e-8)
+        assert abs(myweightdelta1 - 0.15625) < 1e-8
         myweightdelta6 = deltadnbset_weight4.weight(fake_nb_set6, dummy_se, cn_map=cn_map6, additional_info=None)
-        self.assertAlmostEqual(myweightdelta6, 1.0, delta=1e-8)
+        assert abs(myweightdelta6 - 1.0) < 1e-8
 
 
 if __name__ == "__main__":

--- a/pymatgen/analysis/chemenv/utils/tests/test_chemenv_config.py
+++ b/pymatgen/analysis/chemenv/utils/tests/test_chemenv_config.py
@@ -25,18 +25,17 @@ class ChemenvConfigTest(unittest.TestCase):
             config = ChemEnvConfig()
 
             if SETTINGS.get("PMG_MAPI_KEY", "") != "":
-                self.assertTrue(config.has_materials_project_access)
+                assert config.has_materials_project_access
             else:
-                self.assertFalse(config.has_materials_project_access)
+                assert not config.has_materials_project_access
 
             package_options = ChemEnvConfig.DEFAULT_PACKAGE_OPTIONS
             package_options["default_max_distance_factor"] = 1.8
 
             config = ChemEnvConfig(package_options=package_options)
 
-            self.assertEqual(
-                config.package_options_description(),
-                "Package options :\n"
+            assert (
+                config.package_options_description() == "Package options :\n"
                 " - Maximum distance factor : 1.8000\n"
                 ' - Default strategy is "SimplestChemenvStrategy" :\n'
                 "    Simplest ChemenvStrategy using fixed angle and distance parameters \n"
@@ -47,14 +46,14 @@ class ChemenvConfigTest(unittest.TestCase):
                 "     - distance_cutoff : 1.4\n"
                 "     - angle_cutoff : 0.3\n"
                 "     - additional_condition : 1\n"
-                "     - continuous_symmetry_measure_cutoff : 10.0\n",
+                "     - continuous_symmetry_measure_cutoff : 10.0\n"
             )
 
             config.save(root_dir="tmp_dir")
 
             config = config.auto_load(root_dir="tmp_dir")
 
-            self.assertEqual(config.package_options, package_options)
+            assert config.package_options == package_options
 
 
 if __name__ == "__main__":

--- a/pymatgen/analysis/chemenv/utils/tests/test_coordination_geometry_utils.py
+++ b/pymatgen/analysis/chemenv/utils/tests/test_coordination_geometry_utils.py
@@ -25,14 +25,14 @@ class PlanesUtilsTest(PymatgenTest):
     def test_factors_abcd_normal_vector(self):
         factors = self.plane.coefficients / self.expected_coefficients
         self.assertArrayAlmostEqual([factors[0]] * 4, [ff for ff in factors])
-        self.assertTrue(np.allclose([2.0 / 3.0, 1.0 / 3.0, -2.0 / 3.0], self.plane.normal_vector))
+        assert np.allclose([2.0 / 3.0, 1.0 / 3.0, -2.0 / 3.0], self.plane.normal_vector)
 
     def test_from_npoints_plane(self):
         best_fits = ["least_square_distance", "maximum_distance"]
         delta = 0.0001
         for best_fit in best_fits:
             plane = Plane.from_npoints([self.p1, self.p2, self.p3], best_fit=best_fit)
-            self.assertTrue(self.plane.is_same_plane_as(plane))
+            assert self.plane.is_same_plane_as(plane)
             points = [
                 np.array([5.1, 0.3, -2.3]),
                 np.array([-2.0, 4.3, -6.3]),
@@ -58,7 +58,7 @@ class PlanesUtilsTest(PymatgenTest):
                     coeff[3] * plane.d,
                 )
                 fit_error = plane_changed.fit_error(points, fit=best_fit)
-                self.assertGreater(fit_error, fit_error_plane)
+                assert fit_error > fit_error_plane
             coeff = [-2.1, -2.1, -2.1, -2.1]
             plane_not_changed = Plane.from_coefficients(
                 coeff[0] * plane.a,
@@ -67,50 +67,50 @@ class PlanesUtilsTest(PymatgenTest):
                 coeff[3] * plane.d,
             )
             fit_error = plane_not_changed.fit_error(points, fit=best_fit)
-            self.assertAlmostEqual(fit_error, fit_error_plane)
+            assert round(abs(fit_error - fit_error_plane), 7) == 0
 
     def test_is_in_plane(self):
-        self.assertTrue(self.plane.is_in_plane(self.p1, 0.001))
-        self.assertTrue(self.plane.is_in_plane(self.p2, 0.001))
-        self.assertTrue(self.plane.is_in_plane(self.p3, 0.001))
-        self.assertFalse(self.plane.is_in_plane(np.zeros(3), 0.001))
-        self.assertTrue(self.plane.is_in_plane(np.array([1.0, 1.0, 2.25]), 0.001))
-        self.assertTrue(self.plane.is_in_plane(np.array([1.0, 1.0, 2.22]), 0.1))
-        self.assertFalse(self.plane.is_in_plane(np.array([1.0, 1.0, 2.22]), 0.001))
-        self.assertTrue(self.plane.is_in_plane(self.p1 + self.plane.normal_vector * 1.0, 1.000001))
-        self.assertFalse(self.plane.is_in_plane(self.p1 + self.plane.normal_vector * 1.00001, 1.0))
-        self.assertFalse(self.plane.is_in_plane(self.p1 + self.plane.normal_vector * 1.0, 0.999999))
-        self.assertTrue(self.plane.is_in_plane(self.plane.p1, 0.00001))
-        self.assertTrue(self.plane.is_in_plane(self.plane.p2, 0.00001))
-        self.assertTrue(self.plane.is_in_plane(self.plane.p3, 0.00001))
+        assert self.plane.is_in_plane(self.p1, 0.001)
+        assert self.plane.is_in_plane(self.p2, 0.001)
+        assert self.plane.is_in_plane(self.p3, 0.001)
+        assert not self.plane.is_in_plane(np.zeros(3), 0.001)
+        assert self.plane.is_in_plane(np.array([1.0, 1.0, 2.25]), 0.001)
+        assert self.plane.is_in_plane(np.array([1.0, 1.0, 2.22]), 0.1)
+        assert not self.plane.is_in_plane(np.array([1.0, 1.0, 2.22]), 0.001)
+        assert self.plane.is_in_plane(self.p1 + self.plane.normal_vector * 1.0, 1.000001)
+        assert not self.plane.is_in_plane(self.p1 + self.plane.normal_vector * 1.00001, 1.0)
+        assert not self.plane.is_in_plane(self.p1 + self.plane.normal_vector * 1.0, 0.999999)
+        assert self.plane.is_in_plane(self.plane.p1, 0.00001)
+        assert self.plane.is_in_plane(self.plane.p2, 0.00001)
+        assert self.plane.is_in_plane(self.plane.p3, 0.00001)
 
     def test_normal_vector_is_normed(self):
-        self.assertTrue(np.isclose(np.linalg.norm(self.plane.normal_vector), 1.0))
+        assert np.isclose(np.linalg.norm(self.plane.normal_vector), 1.0)
 
     def test_orthonormal_vectors(self):
         ortho = self.plane.orthonormal_vectors()
-        self.assertTrue(np.isclose(np.dot(ortho[0], self.plane.normal_vector), 0.0))
-        self.assertTrue(np.isclose(np.dot(ortho[1], self.plane.normal_vector), 0.0))
-        self.assertTrue(np.isclose(np.dot(ortho[2], self.plane.normal_vector), 1.0))
-        self.assertTrue(np.isclose(np.dot(ortho[0], ortho[1]), 0.0))
-        self.assertTrue(np.isclose(np.dot(ortho[1], ortho[2]), 0.0))
-        self.assertTrue(np.isclose(np.dot(ortho[2], ortho[0]), 0.0))
-        self.assertTrue(np.allclose(np.cross(ortho[0], ortho[1]), ortho[2]))
-        self.assertTrue(np.allclose(np.cross(ortho[0], ortho[1]), self.plane.normal_vector))
-        self.assertTrue(np.allclose(np.cross(ortho[1], ortho[2]), ortho[0]))
-        self.assertTrue(np.allclose(np.cross(ortho[2], ortho[0]), ortho[1]))
-        self.assertFalse(np.allclose(np.cross(ortho[1], ortho[0]), ortho[2]))
-        self.assertTrue(np.allclose(np.cross(ortho[0], ortho[1]), self.plane.normal_vector))
+        assert np.isclose(np.dot(ortho[0], self.plane.normal_vector), 0.0)
+        assert np.isclose(np.dot(ortho[1], self.plane.normal_vector), 0.0)
+        assert np.isclose(np.dot(ortho[2], self.plane.normal_vector), 1.0)
+        assert np.isclose(np.dot(ortho[0], ortho[1]), 0.0)
+        assert np.isclose(np.dot(ortho[1], ortho[2]), 0.0)
+        assert np.isclose(np.dot(ortho[2], ortho[0]), 0.0)
+        assert np.allclose(np.cross(ortho[0], ortho[1]), ortho[2])
+        assert np.allclose(np.cross(ortho[0], ortho[1]), self.plane.normal_vector)
+        assert np.allclose(np.cross(ortho[1], ortho[2]), ortho[0])
+        assert np.allclose(np.cross(ortho[2], ortho[0]), ortho[1])
+        assert not np.allclose(np.cross(ortho[1], ortho[0]), ortho[2])
+        assert np.allclose(np.cross(ortho[0], ortho[1]), self.plane.normal_vector)
 
     def test_plane_comparison(self):
         plane_test_1 = Plane.from_coefficients(4, 2, -4, 3)
-        self.assertTrue(self.plane.is_same_plane_as(plane_test_1))
+        assert self.plane.is_same_plane_as(plane_test_1)
         plane_test_2 = Plane.from_coefficients(-4, -2, 4, -3)
-        self.assertTrue(self.plane.is_same_plane_as(plane_test_2))
+        assert self.plane.is_same_plane_as(plane_test_2)
         plane_test_3 = Plane.from_coefficients(-12, -6, 12, -9)
-        self.assertTrue(self.plane.is_same_plane_as(plane_test_3))
+        assert self.plane.is_same_plane_as(plane_test_3)
         plane_test_4 = Plane.from_coefficients(3, 0, 2, 4)
-        self.assertFalse(self.plane.is_same_plane_as(plane_test_4))
+        assert not self.plane.is_same_plane_as(plane_test_4)
 
     def test_plane_is_in_list_of_planes(self):
         plane_test_1 = Plane.from_coefficients(-8.1, 2, -4, 3)
@@ -118,37 +118,37 @@ class PlanesUtilsTest(PymatgenTest):
         plane_test_3 = Plane.from_coefficients(-12, -6, 12, -9)
         plane_test_4 = Plane.from_coefficients(3, 0, 0, 4)
         plane_list = [plane_test_1, plane_test_2, plane_test_3, plane_test_4]
-        self.assertTrue(self.plane.is_in_list(plane_list))
+        assert self.plane.is_in_list(plane_list)
         plane_list = [plane_test_1, plane_test_2, plane_test_4]
-        self.assertFalse(self.plane.is_in_list(plane_list))
+        assert not self.plane.is_in_list(plane_list)
 
     def test_plane_3_coefficients(self):
         plane_1 = Plane.from_coefficients(0, 2, -1, 3)
-        self.assertTrue(plane_1.is_in_plane(plane_1.p1, 0.000001))
-        self.assertTrue(plane_1.is_in_plane(plane_1.p2, 0.000001))
-        self.assertTrue(plane_1.is_in_plane(plane_1.p3, 0.000001))
+        assert plane_1.is_in_plane(plane_1.p1, 0.000001)
+        assert plane_1.is_in_plane(plane_1.p2, 0.000001)
+        assert plane_1.is_in_plane(plane_1.p3, 0.000001)
         plane_2 = Plane.from_coefficients(12, 0, 2, -4)
-        self.assertTrue(plane_2.is_in_plane(plane_2.p1, 0.000001))
-        self.assertTrue(plane_2.is_in_plane(plane_2.p2, 0.000001))
-        self.assertTrue(plane_2.is_in_plane(plane_2.p3, 0.000001))
+        assert plane_2.is_in_plane(plane_2.p1, 0.000001)
+        assert plane_2.is_in_plane(plane_2.p2, 0.000001)
+        assert plane_2.is_in_plane(plane_2.p3, 0.000001)
         plane_3 = Plane.from_coefficients(-8, 8, 0, 0)
-        self.assertTrue(plane_3.is_in_plane(plane_3.p1, 0.000001))
-        self.assertTrue(plane_3.is_in_plane(plane_3.p2, 0.000001))
-        self.assertTrue(plane_3.is_in_plane(plane_3.p3, 0.000001))
+        assert plane_3.is_in_plane(plane_3.p1, 0.000001)
+        assert plane_3.is_in_plane(plane_3.p2, 0.000001)
+        assert plane_3.is_in_plane(plane_3.p3, 0.000001)
 
     def test_plane_2_coefficients(self):
         plane_1 = Plane.from_coefficients(-21, 0, 0, 3)
-        self.assertTrue(plane_1.is_in_plane(plane_1.p1, 0.000001))
-        self.assertTrue(plane_1.is_in_plane(plane_1.p2, 0.000001))
-        self.assertTrue(plane_1.is_in_plane(plane_1.p3, 0.000001))
+        assert plane_1.is_in_plane(plane_1.p1, 0.000001)
+        assert plane_1.is_in_plane(plane_1.p2, 0.000001)
+        assert plane_1.is_in_plane(plane_1.p3, 0.000001)
         plane_2 = Plane.from_coefficients(0, 4, 0, -4)
-        self.assertTrue(plane_2.is_in_plane(plane_2.p1, 0.000001))
-        self.assertTrue(plane_2.is_in_plane(plane_2.p2, 0.000001))
-        self.assertTrue(plane_2.is_in_plane(plane_2.p3, 0.000001))
+        assert plane_2.is_in_plane(plane_2.p1, 0.000001)
+        assert plane_2.is_in_plane(plane_2.p2, 0.000001)
+        assert plane_2.is_in_plane(plane_2.p3, 0.000001)
         plane_3 = Plane.from_coefficients(0, 0, 3, 1)
-        self.assertTrue(plane_3.is_in_plane(plane_3.p1, 0.000001))
-        self.assertTrue(plane_3.is_in_plane(plane_3.p2, 0.000001))
-        self.assertTrue(plane_3.is_in_plane(plane_3.p3, 0.000001))
+        assert plane_3.is_in_plane(plane_3.p1, 0.000001)
+        assert plane_3.is_in_plane(plane_3.p2, 0.000001)
+        assert plane_3.is_in_plane(plane_3.p3, 0.000001)
 
     def test_indices_separate(self):
         # Test with the common test plane
@@ -162,75 +162,75 @@ class PlanesUtilsTest(PymatgenTest):
         point_8 = np.array([100.0, 0.0, 0.0], np.float_)
         plist = [point_1, point_2, point_3, point_4, point_5, point_6, point_7, point_8]
         sep = self.plane.indices_separate(plist, 0.000001)
-        self.assertEqual(len(sep[0]), 0)
-        self.assertEqual(len(sep[1]), 3)
-        self.assertEqual(len(sep[2]), 5)
-        self.assertTrue(np.allclose(sep[1], [1, 2, 4]))
-        self.assertTrue(np.allclose(sep[2], [0, 3, 5, 6, 7]))
+        assert len(sep[0]) == 0
+        assert len(sep[1]) == 3
+        assert len(sep[2]) == 5
+        assert np.allclose(sep[1], [1, 2, 4])
+        assert np.allclose(sep[2], [0, 3, 5, 6, 7])
         sep = self.plane.indices_separate(plist, 10)
-        self.assertEqual(len(sep[0]), 0)
-        self.assertEqual(len(sep[1]), 6)
-        self.assertEqual(len(sep[2]), 2)
-        self.assertTrue(np.allclose(sep[1], [0, 1, 2, 3, 4, 6]))
-        self.assertTrue(np.allclose(sep[2], [5, 7]))
+        assert len(sep[0]) == 0
+        assert len(sep[1]) == 6
+        assert len(sep[2]) == 2
+        assert np.allclose(sep[1], [0, 1, 2, 3, 4, 6])
+        assert np.allclose(sep[2], [5, 7])
         sep = self.plane.indices_separate(plist, 100000)
-        self.assertEqual(len(sep[0]), 0)
-        self.assertEqual(len(sep[1]), 8)
-        self.assertEqual(len(sep[2]), 0)
+        assert len(sep[0]) == 0
+        assert len(sep[1]) == 8
+        assert len(sep[2]) == 0
         # Test with 2 coeff facets (Normal vector = [1, 0, 0] or [0, 1, 0] or [0, 0, 1])
         # Plane x-2=0 (perpendicular to x)
         plane = Plane.from_coefficients(-4, 0, 0, 8)
         sep = plane.indices_separate(plist, 0.00001)
-        self.assertEqual(sep[0], [0, 1, 2, 3, 4])
-        self.assertEqual(sep[1], [])
-        self.assertEqual(sep[2], [5, 6, 7])
+        assert sep[0] == [0, 1, 2, 3, 4]
+        assert sep[1] == []
+        assert sep[2] == [5, 6, 7]
         sep = plane.indices_separate(plist, 1.0)
-        self.assertEqual(sep[0], [0, 1, 2, 4])
-        self.assertEqual(sep[1], [3])
-        self.assertEqual(sep[2], [5, 6, 7])
+        assert sep[0] == [0, 1, 2, 4]
+        assert sep[1] == [3]
+        assert sep[2] == [5, 6, 7]
         # Plane 2y+1=0 (perpendicular to y)
         plane = Plane.from_coefficients(0, 2, 0, 1)
         sep = plane.indices_separate(plist, 0.00001)
-        self.assertEqual(sep[0], [4])
-        self.assertEqual(sep[1], [])
-        self.assertEqual(sep[2], [0, 1, 2, 3, 5, 6, 7])
+        assert sep[0] == [4]
+        assert sep[1] == []
+        assert sep[2] == [0, 1, 2, 3, 5, 6, 7]
         sep = plane.indices_separate(plist, 1.0)
-        self.assertEqual(sep[0], [])
-        self.assertEqual(sep[1], [0, 1, 2, 3, 4, 7])
-        self.assertEqual(sep[2], [5, 6])
+        assert sep[0] == []
+        assert sep[1] == [0, 1, 2, 3, 4, 7]
+        assert sep[2] == [5, 6]
         # Plane 4z-3=0 (perpendicular to z)
         plane = Plane.from_coefficients(0, 0, -4, 3)
         sep = plane.indices_separate(plist, 0.00001)
-        self.assertEqual(sep[0], [0, 2, 3, 4, 5, 7])
-        self.assertEqual(sep[1], [1])
-        self.assertEqual(sep[2], [6])
+        assert sep[0] == [0, 2, 3, 4, 5, 7]
+        assert sep[1] == [1]
+        assert sep[2] == [6]
         sep = plane.indices_separate(plist, 0.75)
-        self.assertEqual(sep[0], [5])
-        self.assertEqual(sep[1], [0, 1, 2, 3, 4, 7])
-        self.assertEqual(sep[2], [6])
+        assert sep[0] == [5]
+        assert sep[1] == [0, 1, 2, 3, 4, 7]
+        assert sep[2] == [6]
         # Test with 3 coeff facets (Normal vector = [0, a, b] or [a, 0, b] or [a, b, 0])
         # Plane 2y-z+4=0
         plane = Plane.from_coefficients(0, 2, -1, 0)
         sep = plane.indices_separate(plist, 0.00001)
-        self.assertEqual(sep[0], [1, 4])
-        self.assertEqual(sep[1], [0, 2, 3, 7])
-        self.assertEqual(sep[2], [5, 6])
+        assert sep[0] == [1, 4]
+        assert sep[1] == [0, 2, 3, 7]
+        assert sep[2] == [5, 6]
         sep = plane.indices_separate(plist, 0.75)
-        self.assertEqual(sep[0], [4])
-        self.assertEqual(sep[1], [0, 1, 2, 3, 7])
-        self.assertEqual(sep[2], [5, 6])
+        assert sep[0] == [4]
+        assert sep[1] == [0, 1, 2, 3, 7]
+        assert sep[2] == [5, 6]
         # Plane 2y-z+4=0
         plane = Plane.from_coefficients(4, 0, -2, -20)
         sep = plane.indices_separate(plist, 0.00001)
-        self.assertEqual(sep[0], [0, 1, 2, 3, 4])
-        self.assertEqual(sep[1], [6])
-        self.assertEqual(sep[2], [5, 7])
+        assert sep[0] == [0, 1, 2, 3, 4]
+        assert sep[1] == [6]
+        assert sep[2] == [5, 7]
         # Plane 2y-z+4=0
         plane = Plane.from_coefficients(-2, 9, 0, 2)
         sep = plane.indices_separate(plist, 0.00001)
-        self.assertEqual(sep[0], [0, 1, 2, 6])
-        self.assertEqual(sep[1], [3, 5])
-        self.assertEqual(sep[2], [4, 7])
+        assert sep[0] == [0, 1, 2, 6]
+        assert sep[1] == [3, 5]
+        assert sep[2] == [4, 7]
 
     def test_distances(self):
         # Test with the common test plane
@@ -277,7 +277,7 @@ class PlanesUtilsTest(PymatgenTest):
         plist = [point_1, point_2, point_3, point_4, point_5, point_6, point_7, point_8]
         distances, indices_sorted = plane.distances_indices_sorted(plist)
         self.assertArrayAlmostEqual(distances, [0.5, 0.5, 0.5, 0.5, -1.0, 2.5, 10.5, 0.5])
-        self.assertEqual(set(indices_sorted[:5]), {0, 1, 2, 3, 7})
+        assert set(indices_sorted[:5]) == {0, 1, 2, 3, 7}
         # Plane z=0 (plane xy)
         plane = Plane.from_coefficients(0, 0, 1, 0)
         zzs = [0.1, -0.2, 0.7, -2.1, -1.85, 0.0, -0.71, -0.82, -6.5, 1.8]
@@ -331,13 +331,11 @@ class PlanesUtilsTest(PymatgenTest):
         projected_points = self.plane.projectionpoints(expected_projected_points)
         projected_2d = self.plane.project_and_to2dim(expected_projected_points, "mean")
         for ii, pp in enumerate(expected_projected_points):
-            self.assertTrue(np.allclose(pp, projected_points[ii]))
+            assert np.allclose(pp, projected_points[ii])
         for i1, i2 in itertools.combinations(list(range(len(expected_projected_points))), 2):
-            self.assertTrue(
-                np.isclose(
-                    np.linalg.norm(expected_projected_points[i1] - expected_projected_points[i2]),
-                    np.linalg.norm(projected_2d[i1] - projected_2d[i2]),
-                )
+            assert np.isclose(
+                np.linalg.norm(expected_projected_points[i1] - expected_projected_points[i2]),
+                np.linalg.norm(projected_2d[i1] - projected_2d[i2]),
             )
         # Projections of random points (check on distances between the 3D points and the 2D points)
         points_to_project = [
@@ -353,17 +351,15 @@ class PlanesUtilsTest(PymatgenTest):
         projected_2d = self.plane.project_and_to2dim(points_to_project, "mean")
         projected_2d_bis = self.plane.project_and_to2dim(points_to_project, meanpoint)
         for ii, pp in enumerate(projected_2d):
-            self.assertTrue(np.allclose(pp, projected_2d_bis[ii]))
+            assert np.allclose(pp, projected_2d_bis[ii])
         for i1, i2 in itertools.combinations(list(range(len(projected_points))), 2):
-            self.assertTrue(
-                np.isclose(
-                    np.linalg.norm(projected_points[i1] - projected_points[i2]),
-                    np.linalg.norm(projected_2d[i1] - projected_2d[i2]),
-                )
+            assert np.isclose(
+                np.linalg.norm(projected_points[i1] - projected_points[i2]),
+                np.linalg.norm(projected_2d[i1] - projected_2d[i2]),
             )
         for pp in points_to_project:
             projected_2d = self.plane.project_and_to2dim([pp], pp)
-            self.assertTrue(np.allclose(projected_2d[0], 0.0))
+            assert np.allclose(projected_2d[0], 0.0)
         # Check some specific projections
         points = [
             np.zeros(3, np.float_),
@@ -381,16 +377,16 @@ class PlanesUtilsTest(PymatgenTest):
             np.array([-1.55555556, 0.72222222, -0.44444444]),
         ]
         for ii, pp in enumerate(projected_points):
-            self.assertTrue(np.allclose(pp, expected_projected_points[ii]))
-            self.assertTrue(self.plane.is_in_plane(pp, 0.0000001))
+            assert np.allclose(pp, expected_projected_points[ii])
+            assert self.plane.is_in_plane(pp, 0.0000001)
         projected_2d_points_000 = self.plane.project_and_to2dim(points, [0.0, 0.0, 0.0])
         projected_2d_points_mean = self.plane.project_and_to2dim(points, "mean")
         for i1, i2 in itertools.combinations(list(range(len(projected_2d_points_000))), 2):
             norm_000 = np.linalg.norm(projected_2d_points_000[i1] - projected_2d_points_000[i2])
             norm_mean = np.linalg.norm(projected_2d_points_mean[i1] - projected_2d_points_mean[i2])
             norm_xyz_projected = np.linalg.norm(projected_points[i1] - projected_points[i2])
-            self.assertTrue(np.isclose(norm_000, norm_mean))
-            self.assertTrue(np.isclose(norm_000, norm_xyz_projected))
+            assert np.isclose(norm_000, norm_mean)
+            assert np.isclose(norm_000, norm_xyz_projected)
 
 
 if __name__ == "__main__":

--- a/pymatgen/analysis/chemenv/utils/tests/test_func_utils.py
+++ b/pymatgen/analysis/chemenv/utils/tests/test_func_utils.py
@@ -6,6 +6,7 @@ __author__ = "waroquiers"
 import unittest
 
 import numpy as np
+import pytest
 
 from pymatgen.analysis.chemenv.utils.func_utils import (
     CSMFiniteRatioFunction,
@@ -22,11 +23,11 @@ class FuncUtilsTest(unittest.TestCase):
             function="power2_decreasing_exp",
             options_dict={"max_csm": max_csm, "alpha": alpha},
         )
-        self.assertEqual(csm_finite_ratio.evaluate(0.0), 1.0)
-        self.assertAlmostEqual(csm_finite_ratio.evaluate(2.0), 0.43807544047766522)
-        self.assertAlmostEqual(csm_finite_ratio.evaluate(4.0), 0.15163266492815836)
-        self.assertEqual(csm_finite_ratio.evaluate(8.0), 0.0)
-        self.assertEqual(csm_finite_ratio.evaluate(9.0), 0.0)
+        assert csm_finite_ratio.evaluate(0.0) == 1.0
+        assert round(abs(csm_finite_ratio.evaluate(2.0) - 0.43807544047766522), 7) == 0
+        assert round(abs(csm_finite_ratio.evaluate(4.0) - 0.15163266492815836), 7) == 0
+        assert csm_finite_ratio.evaluate(8.0) == 0.0
+        assert csm_finite_ratio.evaluate(9.0) == 0.0
 
         max_csm = 8.0
         alpha = 2.0
@@ -34,10 +35,10 @@ class FuncUtilsTest(unittest.TestCase):
             function="power2_decreasing_exp",
             options_dict={"max_csm": max_csm, "alpha": alpha},
         )
-        self.assertEqual(csm_finite_ratio.evaluate(0.0), 1.0)
-        self.assertAlmostEqual(csm_finite_ratio.evaluate(4.0), 0.091969860292860584)
-        self.assertEqual(csm_finite_ratio.evaluate(8.0), 0.0)
-        self.assertEqual(csm_finite_ratio.evaluate(9.0), 0.0)
+        assert csm_finite_ratio.evaluate(0.0) == 1.0
+        assert round(abs(csm_finite_ratio.evaluate(4.0) - 0.091969860292860584), 7) == 0
+        assert csm_finite_ratio.evaluate(8.0) == 0.0
+        assert csm_finite_ratio.evaluate(9.0) == 0.0
 
         max_csm = 4.0
         alpha = 1.0
@@ -45,54 +46,51 @@ class FuncUtilsTest(unittest.TestCase):
             function="power2_decreasing_exp",
             options_dict={"max_csm": max_csm, "alpha": alpha},
         )
-        self.assertEqual(csm_finite_ratio.evaluate(0.0), 1.0)
-        self.assertAlmostEqual(csm_finite_ratio.evaluate(1.0), 0.43807544047766522)
-        self.assertAlmostEqual(csm_finite_ratio.evaluate(2.0), 0.15163266492815836)
-        self.assertEqual(csm_finite_ratio.evaluate(4.0), 0.0)
-        self.assertEqual(csm_finite_ratio.evaluate(4.5), 0.0)
+        assert csm_finite_ratio.evaluate(0.0) == 1.0
+        assert round(abs(csm_finite_ratio.evaluate(1.0) - 0.43807544047766522), 7) == 0
+        assert round(abs(csm_finite_ratio.evaluate(2.0) - 0.15163266492815836), 7) == 0
+        assert csm_finite_ratio.evaluate(4.0) == 0.0
+        assert csm_finite_ratio.evaluate(4.5) == 0.0
 
-        self.assertRaises(
-            ValueError,
-            CSMFiniteRatioFunction,
-            function="powern_decreasing",
-            options_dict={"max_csm": max_csm, "nn": 2},
-        )
+        with pytest.raises(ValueError):
+            CSMFiniteRatioFunction(
+                function="powern_decreasing",
+                options_dict={"max_csm": max_csm, "nn": 2},
+            )
 
     def test_CSMInfiniteRatioFunction(self):
         max_csm = 8.0
-        self.assertRaises(
-            ValueError,
-            CSMInfiniteRatioFunction,
-            function="power2_inverse_decreasing",
-            options_dict={"max_csm": max_csm, "nn": 2},
-        )
+        with pytest.raises(ValueError):
+            CSMInfiniteRatioFunction(
+                function="power2_inverse_decreasing",
+                options_dict={"max_csm": max_csm, "nn": 2},
+            )
 
-        self.assertRaises(
-            ValueError,
-            CSMInfiniteRatioFunction,
-            function="power2_tangent_decreasing",
-            options_dict={"max_csm": max_csm},
-        )
+        with pytest.raises(ValueError):
+            CSMInfiniteRatioFunction(
+                function="power2_tangent_decreasing",
+                options_dict={"max_csm": max_csm},
+            )
 
         csm_infinite_ratio = CSMInfiniteRatioFunction(
             function="power2_inverse_decreasing", options_dict={"max_csm": max_csm}
         )
         # csm_infinite_ratio = CSMInfiniteRatioFunction(function='power2_inverse_decreasing')
-        self.assertEqual(csm_infinite_ratio.evaluate(0.0), np.inf)
-        self.assertAlmostEqual(csm_infinite_ratio.evaluate(2.0), 2.25)
-        self.assertEqual(csm_infinite_ratio.evaluate(4.0), 0.5)
-        self.assertEqual(csm_infinite_ratio.evaluate(8.0), 0.0)
-        self.assertEqual(csm_infinite_ratio.evaluate(9.0), 0.0)
+        assert csm_infinite_ratio.evaluate(0.0) == np.inf
+        assert round(abs(csm_infinite_ratio.evaluate(2.0) - 2.25), 7) == 0
+        assert csm_infinite_ratio.evaluate(4.0) == 0.5
+        assert csm_infinite_ratio.evaluate(8.0) == 0.0
+        assert csm_infinite_ratio.evaluate(9.0) == 0.0
 
         csm_infinite_ratio = CSMInfiniteRatioFunction(
             function="power2_inverse_power2_decreasing",
             options_dict={"max_csm": max_csm},
         )
-        self.assertEqual(csm_infinite_ratio.evaluate(0.0), np.inf)
-        self.assertEqual(csm_infinite_ratio.evaluate(2.0), 9.0)
-        self.assertEqual(csm_infinite_ratio.evaluate(4.0), 1.0)
-        self.assertEqual(csm_infinite_ratio.evaluate(8.0), 0.0)
-        self.assertEqual(csm_infinite_ratio.evaluate(9.0), 0.0)
+        assert csm_infinite_ratio.evaluate(0.0) == np.inf
+        assert csm_infinite_ratio.evaluate(2.0) == 9.0
+        assert csm_infinite_ratio.evaluate(4.0) == 1.0
+        assert csm_infinite_ratio.evaluate(8.0) == 0.0
+        assert csm_infinite_ratio.evaluate(9.0) == 0.0
 
         max_csm = 12.0
         csm_infinite_ratio = CSMInfiniteRatioFunction(
@@ -100,47 +98,47 @@ class FuncUtilsTest(unittest.TestCase):
             options_dict={"max_csm": max_csm},
         )
 
-        self.assertEqual(csm_infinite_ratio.evaluate(0.0), np.inf)
-        self.assertEqual(csm_infinite_ratio.evaluate(3.0), 9.0)
-        self.assertEqual(csm_infinite_ratio.evaluate(6.0), 1.0)
-        self.assertEqual(csm_infinite_ratio.evaluate(12.0), 0.0)
-        self.assertEqual(csm_infinite_ratio.evaluate(20.0), 0.0)
+        assert csm_infinite_ratio.evaluate(0.0) == np.inf
+        assert csm_infinite_ratio.evaluate(3.0) == 9.0
+        assert csm_infinite_ratio.evaluate(6.0) == 1.0
+        assert csm_infinite_ratio.evaluate(12.0) == 0.0
+        assert csm_infinite_ratio.evaluate(20.0) == 0.0
 
     def test_DeltaCSMRatioFunction(self):
-        self.assertRaises(ValueError, DeltaCSMRatioFunction, function="smoothstep", options_dict={})
-        self.assertRaises(ValueError, DeltaCSMRatioFunction, function="smootherstep", options_dict={})
-        self.assertRaises(
-            ValueError,
-            DeltaCSMRatioFunction,
-            function="smootherstep",
-            options_dict={"delta_csm_min": 1.0},
-        )
-        self.assertRaises(
-            ValueError,
-            DeltaCSMRatioFunction,
-            function="smootherstep",
-            options_dict={"delta_csm_max": 1.0},
-        )
+        with pytest.raises(ValueError):
+            DeltaCSMRatioFunction(function="smoothstep", options_dict={})
+        with pytest.raises(ValueError):
+            DeltaCSMRatioFunction(function="smootherstep", options_dict={})
+        with pytest.raises(ValueError):
+            DeltaCSMRatioFunction(
+                function="smootherstep",
+                options_dict={"delta_csm_min": 1.0},
+            )
+        with pytest.raises(ValueError):
+            DeltaCSMRatioFunction(
+                function="smootherstep",
+                options_dict={"delta_csm_max": 1.0},
+            )
 
         delta_csm_ratio_function = DeltaCSMRatioFunction(
             function="smootherstep",
             options_dict={"delta_csm_min": 1.0, "delta_csm_max": 4.0},
         )
-        self.assertEqual(delta_csm_ratio_function.evaluate(0.0), 0.0)
-        self.assertEqual(delta_csm_ratio_function.evaluate(1.0), 0.0)
-        self.assertEqual(delta_csm_ratio_function.evaluate(2.5), 0.5)
-        self.assertEqual(delta_csm_ratio_function.evaluate(4.0), 1.0)
-        self.assertEqual(delta_csm_ratio_function.evaluate(5.0), 1.0)
+        assert delta_csm_ratio_function.evaluate(0.0) == 0.0
+        assert delta_csm_ratio_function.evaluate(1.0) == 0.0
+        assert delta_csm_ratio_function.evaluate(2.5) == 0.5
+        assert delta_csm_ratio_function.evaluate(4.0) == 1.0
+        assert delta_csm_ratio_function.evaluate(5.0) == 1.0
 
         delta_csm_ratio_function = DeltaCSMRatioFunction(
             function="smootherstep",
             options_dict={"delta_csm_min": 2.0, "delta_csm_max": 8.0},
         )
-        self.assertEqual(delta_csm_ratio_function.evaluate(0.0), 0.0)
-        self.assertEqual(delta_csm_ratio_function.evaluate(2.0), 0.0)
-        self.assertEqual(delta_csm_ratio_function.evaluate(5.0), 0.5)
-        self.assertEqual(delta_csm_ratio_function.evaluate(8.0), 1.0)
-        self.assertEqual(delta_csm_ratio_function.evaluate(12.0), 1.0)
+        assert delta_csm_ratio_function.evaluate(0.0) == 0.0
+        assert delta_csm_ratio_function.evaluate(2.0) == 0.0
+        assert delta_csm_ratio_function.evaluate(5.0) == 0.5
+        assert delta_csm_ratio_function.evaluate(8.0) == 1.0
+        assert delta_csm_ratio_function.evaluate(12.0) == 1.0
 
 
 if __name__ == "__main__":

--- a/pymatgen/analysis/chemenv/utils/tests/test_graph_utils.py
+++ b/pymatgen/analysis/chemenv/utils/tests/test_graph_utils.py
@@ -1,6 +1,7 @@
 __author__ = "waroquiers"
 
 import numpy as np
+import pytest
 
 from pymatgen.analysis.chemenv.connectivity.environment_nodes import EnvironmentNode
 from pymatgen.analysis.chemenv.utils.graph_utils import (
@@ -74,18 +75,18 @@ class GraphUtilsTest(PymatgenTest):
         n1 = FakeNode(3)
         n2 = FakeNode(7)
         edge_data = {"start": 3, "end": 7, "delta": [2, 6, 4]}
-        self.assertTrue(np.allclose(get_delta(n1, n2, edge_data), [2, 6, 4]))
+        assert np.allclose(get_delta(n1, n2, edge_data), [2, 6, 4])
         edge_data = {"start": 7, "end": 3, "delta": [2, 6, 4]}
-        self.assertTrue(np.allclose(get_delta(n1, n2, edge_data), [-2, -6, -4]))
-        with self.assertRaisesRegex(
+        assert np.allclose(get_delta(n1, n2, edge_data), [-2, -6, -4])
+        with pytest.raises(
             ValueError,
-            "Trying to find a delta between two nodes with an edge that seems not to link these nodes.",
+            match="Trying to find a delta between two nodes with an edge that seems not to link these nodes.",
         ):
             edge_data = {"start": 6, "end": 3, "delta": [2, 6, 4]}
             get_delta(n1, n2, edge_data)
-        with self.assertRaisesRegex(
+        with pytest.raises(
             ValueError,
-            "Trying to find a delta between two nodes with an edge that seems not to link these nodes.",
+            match="Trying to find a delta between two nodes with an edge that seems not to link these nodes.",
         ):
             edge_data = {"start": 7, "end": 2, "delta": [2, 6, 4]}
             get_delta(n1, n2, edge_data)
@@ -95,97 +96,91 @@ class GraphUtilsTest(PymatgenTest):
 
         # Test equality
         sg_cycle2 = SimpleGraphCycle([1, 2, 3, 0])
-        self.assertEqual(sg_cycle1, sg_cycle2)
+        assert sg_cycle1 == sg_cycle2
         sg_cycle2 = SimpleGraphCycle([2, 3, 0, 1])
-        self.assertEqual(sg_cycle1, sg_cycle2)
+        assert sg_cycle1 == sg_cycle2
         sg_cycle2 = SimpleGraphCycle([3, 0, 1, 2])
-        self.assertEqual(sg_cycle1, sg_cycle2)
+        assert sg_cycle1 == sg_cycle2
 
         # Test reversed cycles
         sg_cycle2 = SimpleGraphCycle([0, 3, 2, 1])
-        self.assertEqual(sg_cycle1, sg_cycle2)
+        assert sg_cycle1 == sg_cycle2
         sg_cycle2 = SimpleGraphCycle([3, 2, 1, 0])
-        self.assertEqual(sg_cycle1, sg_cycle2)
+        assert sg_cycle1 == sg_cycle2
         sg_cycle2 = SimpleGraphCycle([2, 1, 0, 3])
-        self.assertEqual(sg_cycle1, sg_cycle2)
+        assert sg_cycle1 == sg_cycle2
         sg_cycle2 = SimpleGraphCycle([1, 0, 3, 2])
-        self.assertEqual(sg_cycle1, sg_cycle2)
+        assert sg_cycle1 == sg_cycle2
 
         # Test different cycle lengths inequality
         sg_cycle2 = SimpleGraphCycle([0, 1, 2, 3, 4])
-        self.assertNotEqual(sg_cycle1, sg_cycle2)
+        assert sg_cycle1 != sg_cycle2
 
         # Test equality of self-loops
-        self.assertEqual(SimpleGraphCycle([0]), SimpleGraphCycle([0]))
-        self.assertNotEqual(SimpleGraphCycle([0]), SimpleGraphCycle([4]))
+        assert SimpleGraphCycle([0]) == SimpleGraphCycle([0])
+        assert SimpleGraphCycle([0]) != SimpleGraphCycle([4])
 
         # Test inequality inversing two nodes
         sg_cycle2 = SimpleGraphCycle([0, 1, 3, 2])
-        self.assertNotEqual(sg_cycle1, sg_cycle2)
+        assert sg_cycle1 != sg_cycle2
 
         # Test inequality with different nodes
         sg_cycle2 = SimpleGraphCycle([4, 1, 2, 3])
-        self.assertNotEqual(sg_cycle1, sg_cycle2)
+        assert sg_cycle1 != sg_cycle2
 
         # Test hashing function
-        self.assertEqual(hash(sg_cycle1), 4)
-        self.assertEqual(hash(SimpleGraphCycle([0])), 1)
-        self.assertEqual(hash(SimpleGraphCycle([0, 1, 3, 6])), 4)
-        self.assertEqual(hash(SimpleGraphCycle([0, 1, 2])), 3)
+        assert hash(sg_cycle1) == 4
+        assert hash(SimpleGraphCycle([0])) == 1
+        assert hash(SimpleGraphCycle([0, 1, 3, 6])) == 4
+        assert hash(SimpleGraphCycle([0, 1, 2])) == 3
 
         # Test from_edges function
         #   3-nodes cycle
         edges = [(0, 2), (4, 2), (0, 4)]
         sg_cycle = SimpleGraphCycle.from_edges(edges=edges, edges_are_ordered=False)
-        self.assertEqual(sg_cycle, SimpleGraphCycle([4, 0, 2]))
+        assert sg_cycle == SimpleGraphCycle([4, 0, 2])
 
         #   Self-loop cycle
         edges = [(2, 2)]
         sg_cycle = SimpleGraphCycle.from_edges(edges=edges)
-        self.assertEqual(sg_cycle, SimpleGraphCycle([2]))
+        assert sg_cycle == SimpleGraphCycle([2])
 
         #   5-nodes cycle
         edges = [(0, 2), (4, 7), (2, 7), (4, 5), (5, 0)]
         sg_cycle = SimpleGraphCycle.from_edges(edges=edges, edges_are_ordered=False)
-        self.assertEqual(sg_cycle, SimpleGraphCycle([2, 7, 4, 5, 0]))
+        assert sg_cycle == SimpleGraphCycle([2, 7, 4, 5, 0])
 
         #   two identical 3-nodes cycles
-        with self.assertRaisesRegex(
-            ValueError,
-            expected_regex="SimpleGraphCycle is not valid : Duplicate nodes.",
-        ):
+        with pytest.raises(ValueError, match="SimpleGraphCycle is not valid : Duplicate nodes."):
             edges = [(0, 2), (4, 2), (0, 4), (0, 2), (4, 2), (0, 4)]
             SimpleGraphCycle.from_edges(edges=edges, edges_are_ordered=False)
 
         #   two cycles in from_edges
-        with self.assertRaisesRegex(ValueError, expected_regex="Could not construct a cycle from edges."):
+        with pytest.raises(ValueError, match="Could not construct a cycle from edges."):
             edges = [(0, 2), (4, 2), (0, 4), (1, 3), (6, 7), (3, 6), (1, 7)]
             SimpleGraphCycle.from_edges(edges=edges, edges_are_ordered=False)
 
-        with self.assertRaisesRegex(ValueError, expected_regex="Could not construct a cycle from edges."):
+        with pytest.raises(ValueError, match="Could not construct a cycle from edges."):
             edges = [(0, 2), (4, 6), (2, 7), (4, 5), (5, 0)]
             SimpleGraphCycle.from_edges(edges=edges, edges_are_ordered=False)
 
-        with self.assertRaisesRegex(ValueError, expected_regex="Could not construct a cycle from edges."):
+        with pytest.raises(ValueError, match="Could not construct a cycle from edges."):
             edges = [(0, 2), (4, 7), (2, 7), (4, 10), (5, 0)]
             SimpleGraphCycle.from_edges(edges=edges, edges_are_ordered=False)
 
         # Test as_dict from_dict and len method
         sg_cycle = SimpleGraphCycle([0, 1, 2, 3])
-        self.assertEqual(sg_cycle, SimpleGraphCycle.from_dict(sg_cycle.as_dict()))
-        self.assertEqual(len(sg_cycle), 4)
+        assert sg_cycle == SimpleGraphCycle.from_dict(sg_cycle.as_dict())
+        assert len(sg_cycle) == 4
         sg_cycle = SimpleGraphCycle([4])
-        self.assertEqual(sg_cycle, SimpleGraphCycle.from_dict(sg_cycle.as_dict()))
-        self.assertEqual(len(sg_cycle), 1)
+        assert sg_cycle == SimpleGraphCycle.from_dict(sg_cycle.as_dict())
+        assert len(sg_cycle) == 1
         sg_cycle = SimpleGraphCycle([4, 2, 6, 7, 9, 3, 15])
-        self.assertEqual(sg_cycle, SimpleGraphCycle.from_dict(sg_cycle.as_dict()))
-        self.assertEqual(len(sg_cycle), 7)
+        assert sg_cycle == SimpleGraphCycle.from_dict(sg_cycle.as_dict())
+        assert len(sg_cycle) == 7
 
         # Check validation at instance creation time
-        with self.assertRaisesRegex(
-            ValueError,
-            expected_regex="SimpleGraphCycle is not valid : Duplicate nodes.",
-        ):
+        with pytest.raises(ValueError, match="SimpleGraphCycle is not valid : Duplicate nodes."):
             SimpleGraphCycle([0, 2, 4, 6, 2])
 
         # Check the validate method
@@ -195,31 +190,21 @@ class GraphUtilsTest(PymatgenTest):
             validate=False,
             ordered=False,
         )
-        self.assertFalse(sgc.ordered)
-        self.assertEqual(
-            sgc.nodes,
-            (FakeNodeWithEqMethod(1), FakeNodeWithEqMethod(0), FakeNodeWithEqMethod(2)),
-        )
+        assert not sgc.ordered
+        assert sgc.nodes == (FakeNodeWithEqMethod(1), FakeNodeWithEqMethod(0), FakeNodeWithEqMethod(2))
         sgc.validate(check_strict_ordering=False)
-        with self.assertRaisesRegex(
-            ValueError,
-            expected_regex="SimpleGraphCycle is not valid : The nodes are not sortable.",
-        ):
+        with pytest.raises(ValueError, match="SimpleGraphCycle is not valid : The nodes are not sortable."):
             sgc.validate(check_strict_ordering=True)
 
         # Empty cycle not valid
         sgc = SimpleGraphCycle([], validate=False, ordered=False)
-        with self.assertRaisesRegex(
-            ValueError,
-            expected_regex="SimpleGraphCycle is not valid : Empty cycle is not valid.",
-        ):
+        with pytest.raises(ValueError, match="SimpleGraphCycle is not valid : Empty cycle is not valid."):
             sgc.validate()
 
         # Simple graph cycle with 2 nodes not valid
         sgc = SimpleGraphCycle([1, 2], validate=False, ordered=False)
-        with self.assertRaisesRegex(
-            ValueError,
-            expected_regex="SimpleGraphCycle is not valid : Simple graph cycle with 2 nodes is not valid.",
+        with pytest.raises(
+            ValueError, match="SimpleGraphCycle is not valid : Simple graph cycle with 2 nodes is not valid."
         ):
             sgc.validate()
 
@@ -234,10 +219,9 @@ class GraphUtilsTest(PymatgenTest):
             validate=False,
             ordered=False,
         )
-        with self.assertRaisesRegex(
+        with pytest.raises(
             ValueError,
-            expected_regex="SimpleGraphCycle is not valid : "
-            "The list of nodes in the cycle cannot be strictly ordered.",
+            match="SimpleGraphCycle is not valid : " "The list of nodes in the cycle cannot be strictly ordered.",
         ):
             sgc.validate(check_strict_ordering=True)
 
@@ -253,11 +237,10 @@ class GraphUtilsTest(PymatgenTest):
             ordered=False,
         )
         sgc.order(raise_on_fail=False)
-        self.assertFalse(sgc.ordered)
-        with self.assertRaisesRegex(
+        assert not sgc.ordered
+        with pytest.raises(
             ValueError,
-            expected_regex="SimpleGraphCycle is not valid : "
-            "The list of nodes in the cycle cannot be strictly ordered.",
+            match="SimpleGraphCycle is not valid : " "The list of nodes in the cycle cannot be strictly ordered.",
         ):
             sgc.order(raise_on_fail=True)
 
@@ -272,11 +255,8 @@ class GraphUtilsTest(PymatgenTest):
             ordered=False,
         )
         sgc.order(raise_on_fail=False)
-        self.assertFalse(sgc.ordered)
-        with self.assertRaisesRegex(
-            ValueError,
-            expected_regex="SimpleGraphCycle is not valid : The nodes are not sortable.",
-        ):
+        assert not sgc.ordered
+        with pytest.raises(ValueError, match="SimpleGraphCycle is not valid : The nodes are not sortable."):
             sgc.order(raise_on_fail=True)
 
         sgc = SimpleGraphCycle(
@@ -290,15 +270,12 @@ class GraphUtilsTest(PymatgenTest):
             ordered=False,
         )
         sgc.order(raise_on_fail=True)
-        self.assertTrue(sgc.ordered)
-        self.assertEqual(
-            sgc.nodes,
-            (
-                FakeNodeWithEqLtMethods(0),
-                FakeNodeWithEqLtMethods(6),
-                FakeNodeWithEqLtMethods(3),
-                FakeNodeWithEqLtMethods(8),
-            ),
+        assert sgc.ordered
+        assert sgc.nodes == (
+            FakeNodeWithEqLtMethods(0),
+            FakeNodeWithEqLtMethods(6),
+            FakeNodeWithEqLtMethods(3),
+            FakeNodeWithEqLtMethods(8),
         )
 
         sgc = SimpleGraphCycle(
@@ -312,27 +289,23 @@ class GraphUtilsTest(PymatgenTest):
             ordered=False,
         )
         sgc.order(raise_on_fail=False)
-        self.assertFalse(sgc.ordered)
-        self.assertEqual(
-            sgc.nodes,
-            (
-                FakeNodeWithEqLtMethodsBis(8),
-                FakeNodeWithEqLtMethods(0),
-                FakeNodeWithEqLtMethods(6),
-                FakeNodeWithEqLtMethods(3),
-            ),
+        assert not sgc.ordered
+        assert sgc.nodes == (
+            FakeNodeWithEqLtMethodsBis(8),
+            FakeNodeWithEqLtMethods(0),
+            FakeNodeWithEqLtMethods(6),
+            FakeNodeWithEqLtMethods(3),
         )
-        with self.assertRaisesRegex(
-            ValueError,
-            expected_regex="Could not order simple graph cycle as the nodes are of different classes.",
+        with pytest.raises(
+            ValueError, match="Could not order simple graph cycle as the nodes are of different classes."
         ):
             sgc.order(raise_on_fail=True)
 
         sgc = SimpleGraphCycle([FakeNodeWithEqLtMethods(85)], validate=False, ordered=False)
-        self.assertFalse(sgc.ordered)
+        assert not sgc.ordered
         sgc.order()
-        self.assertTrue(sgc.ordered)
-        self.assertEqual(sgc.nodes, tuple([FakeNodeWithEqLtMethods(85)]))
+        assert sgc.ordered
+        assert sgc.nodes == tuple([FakeNodeWithEqLtMethods(85)])
 
         sgc = SimpleGraphCycle(
             [
@@ -348,29 +321,25 @@ class GraphUtilsTest(PymatgenTest):
             validate=False,
             ordered=False,
         )
-        self.assertFalse(sgc.ordered)
+        assert not sgc.ordered
         sgc.order()
-        self.assertTrue(sgc.ordered)
-        self.assertEqual(
-            sgc.nodes,
-            tuple(
-                [
-                    FakeNodeWithEqLtMethods(1),
-                    FakeNodeWithEqLtMethods(4),
-                    FakeNodeWithEqLtMethods(3),
-                    FakeNodeWithEqLtMethods(6),
-                    FakeNodeWithEqLtMethods(2),
-                    FakeNodeWithEqLtMethods(8),
-                    FakeNodeWithEqLtMethods(32),
-                    FakeNodeWithEqLtMethods(64),
-                ]
-            ),
+        assert sgc.ordered
+        assert sgc.nodes == tuple(
+            [
+                FakeNodeWithEqLtMethods(1),
+                FakeNodeWithEqLtMethods(4),
+                FakeNodeWithEqLtMethods(3),
+                FakeNodeWithEqLtMethods(6),
+                FakeNodeWithEqLtMethods(2),
+                FakeNodeWithEqLtMethods(8),
+                FakeNodeWithEqLtMethods(32),
+                FakeNodeWithEqLtMethods(64),
+            ]
         )
 
         # Test str method
-        self.assertEqual(
-            str(sgc),
-            "Simple cycle with nodes :\n"
+        assert (
+            str(sgc) == "Simple cycle with nodes :\n"
             "FakeNode_1\n"
             "FakeNode_4\n"
             "FakeNode_3\n"
@@ -378,29 +347,25 @@ class GraphUtilsTest(PymatgenTest):
             "FakeNode_2\n"
             "FakeNode_8\n"
             "FakeNode_32\n"
-            "FakeNode_64",
+            "FakeNode_64"
         )
 
     def test_multigraph_cycle(self):
         mg_cycle1 = MultiGraphCycle([2, 4, 3, 5], [1, 0, 2, 0])
         # Check is_valid method
         is_valid, msg = MultiGraphCycle._is_valid(mg_cycle1)
-        self.assertTrue(is_valid)
-        self.assertEqual(msg, "")
-        with self.assertRaisesRegex(
+        assert is_valid
+        assert msg == ""
+        with pytest.raises(
             ValueError,
-            expected_regex="MultiGraphCycle is not valid : "
-            "Number of nodes different from number of "
-            "edge indices.",
+            match="MultiGraphCycle is not valid : " "Number of nodes different from number of " "edge indices.",
         ):
             MultiGraphCycle([0, 2, 4], [0, 0])  # number of nodes is different from number of edge_indices
-        with self.assertRaisesRegex(ValueError, expected_regex="MultiGraphCycle is not valid : Duplicate nodes."):
+        with pytest.raises(ValueError, match="MultiGraphCycle is not valid : Duplicate nodes."):
             MultiGraphCycle([0, 2, 4, 3, 2], [0, 0, 0, 0, 0])  # duplicated nodes
-        with self.assertRaisesRegex(
+        with pytest.raises(
             ValueError,
-            expected_regex="MultiGraphCycle is not valid : "
-            "Cycles with two nodes cannot use the same "
-            "edge for the cycle.",
+            match="MultiGraphCycle is not valid : " "Cycles with two nodes cannot use the same " "edge for the cycle.",
         ):
             MultiGraphCycle([3, 5], [1, 1])  # number of nodes is different from number of edge_indices
 
@@ -408,65 +373,65 @@ class GraphUtilsTest(PymatgenTest):
 
         #   Test different cycle lengths inequality
         mg_cycle2 = MultiGraphCycle([2, 3, 4, 5, 6], [1, 0, 2, 0, 0])
-        self.assertFalse(mg_cycle1 == mg_cycle2)
+        assert not mg_cycle1 == mg_cycle2
 
         #   Test equality
         mg_cycle2 = MultiGraphCycle([2, 4, 3, 5], [1, 0, 2, 0])
-        self.assertTrue(mg_cycle1 == mg_cycle2)
+        assert mg_cycle1 == mg_cycle2
         mg_cycle2 = MultiGraphCycle([4, 3, 5, 2], [0, 2, 0, 1])
-        self.assertTrue(mg_cycle1 == mg_cycle2)
+        assert mg_cycle1 == mg_cycle2
         mg_cycle2 = MultiGraphCycle([3, 5, 2, 4], [2, 0, 1, 0])
-        self.assertTrue(mg_cycle1 == mg_cycle2)
+        assert mg_cycle1 == mg_cycle2
         mg_cycle2 = MultiGraphCycle([5, 2, 4, 3], [0, 1, 0, 2])
-        self.assertTrue(mg_cycle1 == mg_cycle2)
+        assert mg_cycle1 == mg_cycle2
         #   Test equality (reversed)
         mg_cycle2 = MultiGraphCycle([2, 5, 3, 4], [0, 2, 0, 1])
-        self.assertTrue(mg_cycle1 == mg_cycle2)
+        assert mg_cycle1 == mg_cycle2
         mg_cycle2 = MultiGraphCycle([5, 3, 4, 2], [2, 0, 1, 0])
-        self.assertTrue(mg_cycle1 == mg_cycle2)
+        assert mg_cycle1 == mg_cycle2
         mg_cycle2 = MultiGraphCycle([3, 4, 2, 5], [0, 1, 0, 2])
-        self.assertTrue(mg_cycle1 == mg_cycle2)
+        assert mg_cycle1 == mg_cycle2
         mg_cycle2 = MultiGraphCycle([4, 2, 5, 3], [1, 0, 2, 0])
-        self.assertTrue(mg_cycle1 == mg_cycle2)
+        assert mg_cycle1 == mg_cycle2
         #   Test inequality
         mg_cycle2 = MultiGraphCycle([2, 5, 3, 4], [0, 1, 0, 1])
-        self.assertFalse(mg_cycle1 == mg_cycle2)
+        assert not mg_cycle1 == mg_cycle2
         mg_cycle2 = MultiGraphCycle([2, 5, 3, 4], [1, 0, 2, 0])
-        self.assertFalse(mg_cycle1 == mg_cycle2)
+        assert not mg_cycle1 == mg_cycle2
         mg_cycle2 = MultiGraphCycle([3, 5, 2, 4], [1, 0, 2, 0])
-        self.assertFalse(mg_cycle1 == mg_cycle2)
+        assert not mg_cycle1 == mg_cycle2
 
         #   Test Self-loop case
-        self.assertTrue(MultiGraphCycle([2], [1]) == MultiGraphCycle([2], [1]))
-        self.assertFalse(MultiGraphCycle([1], [1]) == MultiGraphCycle([2], [1]))
-        self.assertFalse(MultiGraphCycle([2], [1]) == MultiGraphCycle([2], [0]))
-        self.assertFalse(MultiGraphCycle([2], [1]) == MultiGraphCycle([1], [1]))
-        self.assertFalse(MultiGraphCycle([2], [0]) == MultiGraphCycle([2], [1]))
+        assert MultiGraphCycle([2], [1]) == MultiGraphCycle([2], [1])
+        assert not MultiGraphCycle([1], [1]) == MultiGraphCycle([2], [1])
+        assert not MultiGraphCycle([2], [1]) == MultiGraphCycle([2], [0])
+        assert not MultiGraphCycle([2], [1]) == MultiGraphCycle([1], [1])
+        assert not MultiGraphCycle([2], [0]) == MultiGraphCycle([2], [1])
 
         #   Test special case with two nodes
-        self.assertTrue(MultiGraphCycle([2, 4], [1, 3]) == MultiGraphCycle([2, 4], [1, 3]))
-        self.assertTrue(MultiGraphCycle([2, 4], [1, 3]) == MultiGraphCycle([2, 4], [3, 1]))
-        self.assertTrue(MultiGraphCycle([2, 4], [1, 3]) == MultiGraphCycle([4, 2], [3, 1]))
-        self.assertTrue(MultiGraphCycle([2, 4], [1, 3]) == MultiGraphCycle([4, 2], [1, 3]))
-        self.assertFalse(MultiGraphCycle([2, 4], [1, 3]) == MultiGraphCycle([4, 2], [1, 2]))
-        self.assertFalse(MultiGraphCycle([2, 4], [1, 3]) == MultiGraphCycle([4, 0], [1, 3]))
+        assert MultiGraphCycle([2, 4], [1, 3]) == MultiGraphCycle([2, 4], [1, 3])
+        assert MultiGraphCycle([2, 4], [1, 3]) == MultiGraphCycle([2, 4], [3, 1])
+        assert MultiGraphCycle([2, 4], [1, 3]) == MultiGraphCycle([4, 2], [3, 1])
+        assert MultiGraphCycle([2, 4], [1, 3]) == MultiGraphCycle([4, 2], [1, 3])
+        assert not MultiGraphCycle([2, 4], [1, 3]) == MultiGraphCycle([4, 2], [1, 2])
+        assert not MultiGraphCycle([2, 4], [1, 3]) == MultiGraphCycle([4, 0], [1, 3])
 
         # Test hashing function
-        self.assertEqual(hash(mg_cycle1), 4)
-        self.assertEqual(hash(MultiGraphCycle([0], [0])), 1)
-        self.assertEqual(hash(MultiGraphCycle([0, 3], [0, 1])), 2)
-        self.assertEqual(hash(MultiGraphCycle([0, 3, 5, 7, 8], [0, 1, 0, 0, 0])), 5)
+        assert hash(mg_cycle1) == 4
+        assert hash(MultiGraphCycle([0], [0])) == 1
+        assert hash(MultiGraphCycle([0, 3], [0, 1])) == 2
+        assert hash(MultiGraphCycle([0, 3, 5, 7, 8], [0, 1, 0, 0, 0])) == 5
 
         # Test as_dict from_dict and len method
         mg_cycle = MultiGraphCycle([0, 1, 2, 3], [1, 2, 0, 3])
-        self.assertTrue(mg_cycle == MultiGraphCycle.from_dict(mg_cycle.as_dict()))
-        self.assertEqual(len(mg_cycle), 4)
+        assert mg_cycle == MultiGraphCycle.from_dict(mg_cycle.as_dict())
+        assert len(mg_cycle) == 4
         mg_cycle = MultiGraphCycle([2, 5, 3, 4, 1, 0], [0, 0, 2, 0, 1, 0])
-        self.assertTrue(mg_cycle == MultiGraphCycle.from_dict(mg_cycle.as_dict()))
-        self.assertEqual(len(mg_cycle), 6)
+        assert mg_cycle == MultiGraphCycle.from_dict(mg_cycle.as_dict())
+        assert len(mg_cycle) == 6
         mg_cycle = MultiGraphCycle([8], [1])
-        self.assertTrue(mg_cycle == MultiGraphCycle.from_dict(mg_cycle.as_dict()))
-        self.assertEqual(len(mg_cycle), 1)
+        assert mg_cycle == MultiGraphCycle.from_dict(mg_cycle.as_dict())
+        assert len(mg_cycle) == 1
 
         # Check the validate method
         # Number of nodes and edges do not match
@@ -480,21 +445,16 @@ class GraphUtilsTest(PymatgenTest):
             validate=False,
             ordered=False,
         )
-        self.assertFalse(mgc.ordered)
-        with self.assertRaisesRegex(
+        assert not mgc.ordered
+        with pytest.raises(
             ValueError,
-            expected_regex="MultiGraphCycle is not valid : "
-            "Number of nodes different from "
-            "number of edge indices.",
+            match="MultiGraphCycle is not valid : " "Number of nodes different from " "number of edge indices.",
         ):
             mgc.validate(check_strict_ordering=False)
 
         # Empty cycle not valid
         mgc = MultiGraphCycle([], edge_indices=[], validate=False, ordered=False)
-        with self.assertRaisesRegex(
-            ValueError,
-            expected_regex="MultiGraphCycle is not valid : Empty cycle is not valid.",
-        ):
+        with pytest.raises(ValueError, match="MultiGraphCycle is not valid : Empty cycle is not valid."):
             mgc.validate()
 
         # Multi graph cycle with duplicate nodes not valid
@@ -504,10 +464,7 @@ class GraphUtilsTest(PymatgenTest):
             validate=False,
             ordered=False,
         )
-        with self.assertRaisesRegex(
-            ValueError,
-            expected_regex="MultiGraphCycle is not valid : Duplicate nodes.",
-        ):
+        with pytest.raises(ValueError, match="MultiGraphCycle is not valid : Duplicate nodes."):
             mgc.validate()
 
         # Multi graph cycle with two nodes cannot use the same edge
@@ -517,10 +474,9 @@ class GraphUtilsTest(PymatgenTest):
             validate=False,
             ordered=False,
         )
-        with self.assertRaisesRegex(
+        with pytest.raises(
             ValueError,
-            expected_regex="MultiGraphCycle is not valid : "
-            "Cycles with two nodes cannot use the same edge for the cycle.",
+            match="MultiGraphCycle is not valid : " "Cycles with two nodes cannot use the same edge for the cycle.",
         ):
             mgc.validate()
 
@@ -531,16 +487,10 @@ class GraphUtilsTest(PymatgenTest):
             validate=False,
             ordered=False,
         )
-        self.assertFalse(mgc.ordered)
-        self.assertEqual(
-            mgc.nodes,
-            (FakeNodeWithEqMethod(1), FakeNodeWithEqMethod(0), FakeNodeWithEqMethod(2)),
-        )
+        assert not mgc.ordered
+        assert mgc.nodes == (FakeNodeWithEqMethod(1), FakeNodeWithEqMethod(0), FakeNodeWithEqMethod(2))
         mgc.validate(check_strict_ordering=False)
-        with self.assertRaisesRegex(
-            ValueError,
-            expected_regex="MultiGraphCycle is not valid : The nodes are not sortable.",
-        ):
+        with pytest.raises(ValueError, match="MultiGraphCycle is not valid : The nodes are not sortable."):
             mgc.validate(check_strict_ordering=True)
 
         # Multi graph cycle with nodes that cannot be strictly ordered
@@ -555,10 +505,9 @@ class GraphUtilsTest(PymatgenTest):
             validate=False,
             ordered=False,
         )
-        with self.assertRaisesRegex(
+        with pytest.raises(
             ValueError,
-            expected_regex="MultiGraphCycle is not valid : "
-            "The list of nodes in the cycle cannot be strictly ordered.",
+            match="MultiGraphCycle is not valid : " "The list of nodes in the cycle cannot be strictly ordered.",
         ):
             mgc.validate(check_strict_ordering=True)
 
@@ -575,11 +524,10 @@ class GraphUtilsTest(PymatgenTest):
             ordered=False,
         )
         mgc.order(raise_on_fail=False)
-        self.assertFalse(mgc.ordered)
-        with self.assertRaisesRegex(
+        assert not mgc.ordered
+        with pytest.raises(
             ValueError,
-            expected_regex="MultiGraphCycle is not valid : "
-            "The list of nodes in the cycle cannot be strictly ordered.",
+            match="MultiGraphCycle is not valid : " "The list of nodes in the cycle cannot be strictly ordered.",
         ):
             mgc.order(raise_on_fail=True)
 
@@ -595,11 +543,8 @@ class GraphUtilsTest(PymatgenTest):
             ordered=False,
         )
         mgc.order(raise_on_fail=False)
-        self.assertFalse(mgc.ordered)
-        with self.assertRaisesRegex(
-            ValueError,
-            expected_regex="MultiGraphCycle is not valid : The nodes are not sortable.",
-        ):
+        assert not mgc.ordered
+        with pytest.raises(ValueError, match="MultiGraphCycle is not valid : The nodes are not sortable."):
             mgc.order(raise_on_fail=True)
 
         mgc = MultiGraphCycle(
@@ -614,17 +559,14 @@ class GraphUtilsTest(PymatgenTest):
             ordered=False,
         )
         mgc.order(raise_on_fail=True)
-        self.assertTrue(mgc.ordered)
-        self.assertEqual(
-            mgc.nodes,
-            (
-                FakeNodeWithEqLtMethods(0),
-                FakeNodeWithEqLtMethods(6),
-                FakeNodeWithEqLtMethods(3),
-                FakeNodeWithEqLtMethods(8),
-            ),
+        assert mgc.ordered
+        assert mgc.nodes == (
+            FakeNodeWithEqLtMethods(0),
+            FakeNodeWithEqLtMethods(6),
+            FakeNodeWithEqLtMethods(3),
+            FakeNodeWithEqLtMethods(8),
         )
-        self.assertEqual(mgc.edge_indices, (5, 3, 7, 2))
+        assert mgc.edge_indices == (5, 3, 7, 2)
 
         mgc = MultiGraphCycle(
             [
@@ -638,20 +580,16 @@ class GraphUtilsTest(PymatgenTest):
             ordered=False,
         )
         mgc.order(raise_on_fail=False)
-        self.assertFalse(mgc.ordered)
-        self.assertEqual(
-            mgc.nodes,
-            (
-                FakeNodeWithEqLtMethodsBis(8),
-                FakeNodeWithEqLtMethods(0),
-                FakeNodeWithEqLtMethods(6),
-                FakeNodeWithEqLtMethods(3),
-            ),
+        assert not mgc.ordered
+        assert mgc.nodes == (
+            FakeNodeWithEqLtMethodsBis(8),
+            FakeNodeWithEqLtMethods(0),
+            FakeNodeWithEqLtMethods(6),
+            FakeNodeWithEqLtMethods(3),
         )
-        self.assertEqual(mgc.edge_indices, (2, 5, 3, 7))
-        with self.assertRaisesRegex(
-            ValueError,
-            expected_regex="Could not order simple graph cycle as the nodes are of different classes.",
+        assert mgc.edge_indices == (2, 5, 3, 7)
+        with pytest.raises(
+            ValueError, match="Could not order simple graph cycle as the nodes are of different classes."
         ):
             mgc.order(raise_on_fail=True)
 
@@ -661,11 +599,11 @@ class GraphUtilsTest(PymatgenTest):
             validate=False,
             ordered=False,
         )
-        self.assertFalse(mgc.ordered)
+        assert not mgc.ordered
         mgc.order()
-        self.assertTrue(mgc.ordered)
-        self.assertEqual(mgc.nodes, tuple([FakeNodeWithEqLtMethods(85)]))
-        self.assertEqual(mgc.edge_indices, tuple([7]))
+        assert mgc.ordered
+        assert mgc.nodes == tuple([FakeNodeWithEqLtMethods(85)])
+        assert mgc.edge_indices == tuple([7])
 
         mgc = MultiGraphCycle(
             [
@@ -682,25 +620,22 @@ class GraphUtilsTest(PymatgenTest):
             validate=False,
             ordered=False,
         )
-        self.assertFalse(mgc.ordered)
+        assert not mgc.ordered
         mgc.order()
-        self.assertTrue(mgc.ordered)
-        self.assertEqual(
-            mgc.nodes,
-            tuple(
-                [
-                    FakeNodeWithEqLtMethods(1),
-                    FakeNodeWithEqLtMethods(4),
-                    FakeNodeWithEqLtMethods(3),
-                    FakeNodeWithEqLtMethods(6),
-                    FakeNodeWithEqLtMethods(2),
-                    FakeNodeWithEqLtMethods(8),
-                    FakeNodeWithEqLtMethods(32),
-                    FakeNodeWithEqLtMethods(64),
-                ]
-            ),
+        assert mgc.ordered
+        assert mgc.nodes == tuple(
+            [
+                FakeNodeWithEqLtMethods(1),
+                FakeNodeWithEqLtMethods(4),
+                FakeNodeWithEqLtMethods(3),
+                FakeNodeWithEqLtMethods(6),
+                FakeNodeWithEqLtMethods(2),
+                FakeNodeWithEqLtMethods(8),
+                FakeNodeWithEqLtMethods(32),
+                FakeNodeWithEqLtMethods(64),
+            ]
         )
-        self.assertEqual(mgc.edge_indices, tuple([0, 1, 4, 0, 2, 2, 5, 3]))
+        assert mgc.edge_indices == tuple([0, 1, 4, 0, 2, 2, 5, 3])
 
         # Testing all cases for a length-4 cycle
         nodes_ref = tuple(FakeNodeWithEqLtMethods(inode) for inode in range(4))
@@ -720,16 +655,8 @@ class GraphUtilsTest(PymatgenTest):
                 edge_indices=[iedge for iedge in iedges],
             )
             strnodes = ", ".join([str(i) for i in inodes])
-            self.assertEqual(
-                mgc.nodes,
-                nodes_ref,
-                msg=f"Nodes not equal for inodes = ({', '.join([str(i) for i in inodes])})",
-            )
-            self.assertEqual(
-                mgc.edge_indices,
-                edges_ref,
-                msg=f"Edges not equal for inodes = ({strnodes})",
-            )
+            assert mgc.nodes == nodes_ref, f"Nodes not equal for inodes = ({', '.join([str(i) for i in inodes])})"
+            assert mgc.edge_indices == edges_ref, f"Edges not equal for inodes = ({strnodes})"
 
 
 class EnvironmentNodesGraphUtilsTest(PymatgenTest):
@@ -743,52 +670,52 @@ class EnvironmentNodesGraphUtilsTest(PymatgenTest):
         # Tests of SimpleGraphCycle with EnvironmentNodes
         c1 = SimpleGraphCycle([e2])
         c2 = SimpleGraphCycle([e2])
-        self.assertEqual(c1, c2)
+        assert c1 == c2
 
         c1 = SimpleGraphCycle([e1])
         c2 = SimpleGraphCycle([e2])
-        self.assertNotEqual(c1, c2)
+        assert c1 != c2
 
         c1 = SimpleGraphCycle([e1, e2, e3])
         c2 = SimpleGraphCycle([e2, e1, e3])
-        self.assertEqual(c1, c2)
+        assert c1 == c2
         c2 = SimpleGraphCycle([e2, e3, e1])
-        self.assertEqual(c1, c2)
+        assert c1 == c2
 
         c1 = SimpleGraphCycle([e3, e2, e4, e1, e5])
         c2 = SimpleGraphCycle([e1, e4, e2, e3, e5])
-        self.assertEqual(c1, c2)
+        assert c1 == c2
         c2 = SimpleGraphCycle([e2, e3, e5, e1, e4])
-        self.assertEqual(c1, c2)
+        assert c1 == c2
 
         c1 = SimpleGraphCycle([e2, e3, e4, e1, e5])
         c2 = SimpleGraphCycle([e2, e3, e5, e1, e4])
-        self.assertNotEqual(c1, c2)
+        assert c1 != c2
 
         # Tests of MultiGraphCycle with EnvironmentNodes
         c1 = MultiGraphCycle([e1], [2])
         c2 = MultiGraphCycle([e1], [2])
-        self.assertEqual(c1, c2)
+        assert c1 == c2
         c2 = MultiGraphCycle([e1], [1])
-        self.assertNotEqual(c1, c2)
+        assert c1 != c2
         c2 = MultiGraphCycle([e2], [2])
-        self.assertNotEqual(c1, c2)
+        assert c1 != c2
 
         c1 = MultiGraphCycle([e1, e2], [0, 1])
         c2 = MultiGraphCycle([e1, e2], [1, 0])
-        self.assertEqual(c1, c2)
+        assert c1 == c2
         c2 = MultiGraphCycle([e2, e1], [1, 0])
-        self.assertEqual(c1, c2)
+        assert c1 == c2
         c2 = MultiGraphCycle([e2, e1], [0, 1])
-        self.assertEqual(c1, c2)
+        assert c1 == c2
         c2 = MultiGraphCycle([e2, e1], [2, 1])
-        self.assertNotEqual(c1, c2)
+        assert c1 != c2
 
         c1 = MultiGraphCycle([e1, e2, e3], [0, 1, 2])
         c2 = MultiGraphCycle([e2, e1, e3], [0, 2, 1])
-        self.assertEqual(c1, c2)
+        assert c1 == c2
         c2 = MultiGraphCycle([e2, e3, e1], [1, 2, 0])
-        self.assertEqual(c1, c2)
+        assert c1 == c2
 
 
 if __name__ == "__main__":

--- a/pymatgen/analysis/chemenv/utils/tests/test_math_utils.py
+++ b/pymatgen/analysis/chemenv/utils/tests/test_math_utils.py
@@ -26,48 +26,49 @@ from pymatgen.util.testing import PymatgenTest
 class MathUtilsTest(PymatgenTest):
     def test_list_cartesian_product(self):
         list_of_lists = [[0, 1], [2, 5, 4], [5]]
-        self.assertEqual(
-            _cartesian_product(lists=list_of_lists),
-            [[0, 2, 5], [1, 2, 5], [0, 5, 5], [1, 5, 5], [0, 4, 5], [1, 4, 5]],
-        )
+        assert _cartesian_product(lists=list_of_lists) == [
+            [0, 2, 5],
+            [1, 2, 5],
+            [0, 5, 5],
+            [1, 5, 5],
+            [0, 4, 5],
+            [1, 4, 5],
+        ]
         list_of_lists = [[0, 1], [2, 5, 4], []]
-        self.assertEqual(_cartesian_product(lists=list_of_lists), [])
+        assert _cartesian_product(lists=list_of_lists) == []
         list_of_lists = [[1], [3], [2]]
-        self.assertEqual(_cartesian_product(lists=list_of_lists), [[1, 3, 2]])
+        assert _cartesian_product(lists=list_of_lists) == [[1, 3, 2]]
         list_of_lists = [[7]]
-        self.assertEqual(_cartesian_product(lists=list_of_lists), [[7]])
+        assert _cartesian_product(lists=list_of_lists) == [[7]]
 
     def test_math_utils(self):
         ff = prime_factors(250)
-        self.assertEqual(ff, [5, 5, 5, 2])
+        assert ff == [5, 5, 5, 2]
         div = divisors(560)
-        self.assertEqual(
-            div,
-            [
-                1,
-                2,
-                4,
-                5,
-                7,
-                8,
-                10,
-                14,
-                16,
-                20,
-                28,
-                35,
-                40,
-                56,
-                70,
-                80,
-                112,
-                140,
-                280,
-                560,
-            ],
-        )
+        assert div == [
+            1,
+            2,
+            4,
+            5,
+            7,
+            8,
+            10,
+            14,
+            16,
+            20,
+            28,
+            35,
+            40,
+            56,
+            70,
+            80,
+            112,
+            140,
+            280,
+            560,
+        ]
         center = get_center_of_arc([0.0, 0.0], [1.0, 0.0], 0.5)
-        self.assertEqual(center, (0.5, 0.0))
+        assert center == (0.5, 0.0)
 
     def test_linearly_independent_vectors(self):
         v1 = np.array([1, 0, 0])
@@ -76,13 +77,13 @@ class MathUtilsTest(PymatgenTest):
         v4 = np.array([-1, 0, 0])
         v5 = np.array([1, 1, 0])
         independent_vectors = get_linearly_independent_vectors([v1, v2, v3])
-        self.assertEqual(len(independent_vectors), 3)
+        assert len(independent_vectors) == 3
         independent_vectors = get_linearly_independent_vectors([v1, v2, v4])
-        self.assertEqual(len(independent_vectors), 2)
+        assert len(independent_vectors) == 2
         independent_vectors = get_linearly_independent_vectors([v1, v2, v5])
-        self.assertEqual(len(independent_vectors), 2)
+        assert len(independent_vectors) == 2
         independent_vectors = get_linearly_independent_vectors([v1, v2, v3, v4, v5])
-        self.assertEqual(len(independent_vectors), 3)
+        assert len(independent_vectors) == 3
 
     def test_scale_and_clamp(self):
         edge0 = 7.0
@@ -90,38 +91,44 @@ class MathUtilsTest(PymatgenTest):
         clamp0 = 0.0
         clamp1 = 1.0
         vals = np.linspace(5.0, 12.0, num=8)
-        self.assertEqual(
-            scale_and_clamp(vals, edge0, edge1, clamp0, clamp1).tolist(),
-            [0.0, 0.0, 0.0, 0.25, 0.5, 0.75, 1.0, 1.0],
-        )
+        assert scale_and_clamp(vals, edge0, edge1, clamp0, clamp1).tolist() == [
+            0.0,
+            0.0,
+            0.0,
+            0.25,
+            0.5,
+            0.75,
+            1.0,
+            1.0,
+        ]
 
     def test_smoothstep(self):
         vals = np.linspace(5.0, 12.0, num=8)
-        self.assertEqual(smoothstep(vals, edges=[0.0, 1.0]).tolist(), [1.0] * 8)
-        self.assertEqual(
-            smoothstep(vals, edges=[7.0, 11.0]).tolist(),
-            [0.0, 0.0, 0.0, 0.15625, 0.5, 0.84375, 1.0, 1.0],
-        )
+        assert smoothstep(vals, edges=[0.0, 1.0]).tolist() == [1.0] * 8
+        assert smoothstep(vals, edges=[7.0, 11.0]).tolist() == [0.0, 0.0, 0.0, 0.15625, 0.5, 0.84375, 1.0, 1.0]
 
     def test_smootherstep(self):
         vals = np.linspace(5.0, 12.0, num=8)
-        self.assertEqual(smootherstep(vals, edges=[0.0, 1.0]).tolist(), [1.0] * 8)
-        self.assertEqual(
-            smootherstep(vals, edges=[7.0, 11.0]).tolist(),
-            [0.0, 0.0, 0.0, 0.103515625, 0.5, 0.896484375, 1.0, 1.0],
-        )
+        assert smootherstep(vals, edges=[0.0, 1.0]).tolist() == [1.0] * 8
+        assert smootherstep(vals, edges=[7.0, 11.0]).tolist() == [
+            0.0,
+            0.0,
+            0.0,
+            0.103515625,
+            0.5,
+            0.896484375,
+            1.0,
+            1.0,
+        ]
 
     def test_power3_step(self):
         vals = np.linspace(5.0, 12.0, num=8)
-        self.assertEqual(power3_step(vals, edges=[0.0, 1.0]).tolist(), [1.0] * 8)
-        self.assertEqual(
-            power3_step(vals, edges=[7.0, 11.0]).tolist(),
-            [0.0, 0.0, 0.0, 0.15625, 0.5, 0.84375, 1.0, 1.0],
-        )
+        assert power3_step(vals, edges=[0.0, 1.0]).tolist() == [1.0] * 8
+        assert power3_step(vals, edges=[7.0, 11.0]).tolist() == [0.0, 0.0, 0.0, 0.15625, 0.5, 0.84375, 1.0, 1.0]
 
     def test_cosinus_step(self):
         vals = np.linspace(5.0, 12.0, num=8)
-        self.assertEqual(cosinus_step(vals, edges=[0.0, 1.0]).tolist(), [1.0] * 8)
+        assert cosinus_step(vals, edges=[0.0, 1.0]).tolist() == [1.0] * 8
         self.assertArrayAlmostEqual(
             cosinus_step(vals, edges=[7.0, 11.0]).tolist(),
             [0.0, 0.0, 0.0, 0.14644660940672616, 0.5, 0.8535533905932737, 1.0, 1.0],
@@ -130,21 +137,30 @@ class MathUtilsTest(PymatgenTest):
 
     def test_powern_parts_step(self):
         vals = np.linspace(5.0, 12.0, num=8)
-        self.assertEqual(powern_parts_step(vals, edges=[0.0, 1.0], nn=2).tolist(), [1.0] * 8)
-        self.assertEqual(powern_parts_step(vals, edges=[0.0, 1.0], nn=3).tolist(), [1.0] * 8)
-        self.assertEqual(powern_parts_step(vals, edges=[0.0, 1.0], nn=4).tolist(), [1.0] * 8)
-        self.assertEqual(
-            powern_parts_step(vals, edges=[7.0, 11.0], nn=2).tolist(),
-            [0.0, 0.0, 0.0, 0.125, 0.5, 0.875, 1.0, 1.0],
-        )
-        self.assertEqual(
-            powern_parts_step(vals, edges=[7.0, 11.0], nn=3).tolist(),
-            [0.0, 0.0, 0.0, 0.0625, 0.5, 0.9375, 1.0, 1.0],
-        )
-        self.assertEqual(
-            powern_parts_step(vals, edges=[7.0, 11.0], nn=4).tolist(),
-            [0.0, 0.0, 0.0, 0.03125, 0.5, 0.96875, 1.0, 1.0],
-        )
+        assert powern_parts_step(vals, edges=[0.0, 1.0], nn=2).tolist() == [1.0] * 8
+        assert powern_parts_step(vals, edges=[0.0, 1.0], nn=3).tolist() == [1.0] * 8
+        assert powern_parts_step(vals, edges=[0.0, 1.0], nn=4).tolist() == [1.0] * 8
+        assert powern_parts_step(vals, edges=[7.0, 11.0], nn=2).tolist() == [0.0, 0.0, 0.0, 0.125, 0.5, 0.875, 1.0, 1.0]
+        assert powern_parts_step(vals, edges=[7.0, 11.0], nn=3).tolist() == [
+            0.0,
+            0.0,
+            0.0,
+            0.0625,
+            0.5,
+            0.9375,
+            1.0,
+            1.0,
+        ]
+        assert powern_parts_step(vals, edges=[7.0, 11.0], nn=4).tolist() == [
+            0.0,
+            0.0,
+            0.0,
+            0.03125,
+            0.5,
+            0.96875,
+            1.0,
+            1.0,
+        ]
 
 
 if __name__ == "__main__":

--- a/pymatgen/analysis/tests/test_phase_diagram.py
+++ b/pymatgen/analysis/tests/test_phase_diagram.py
@@ -42,42 +42,42 @@ class PDEntryTest(unittest.TestCase):
         self.gpentry = GrandPotPDEntry(self.entry, {Element("O"): 1.5})
 
     def test_get_energy(self):
-        self.assertEqual(self.entry.energy, 53, "Wrong energy!")
-        self.assertEqual(self.gpentry.energy, 50, "Wrong energy!")
+        assert self.entry.energy == 53, "Wrong energy!"
+        assert self.gpentry.energy == 50, "Wrong energy!"
 
     def test_get_chemical_energy(self):
-        self.assertEqual(self.gpentry.chemical_energy, 3, "Wrong energy!")
+        assert self.gpentry.chemical_energy == 3, "Wrong energy!"
 
     def test_get_energy_per_atom(self):
-        self.assertEqual(self.entry.energy_per_atom, 53.0 / 4, "Wrong energy per atom!")
-        self.assertEqual(self.gpentry.energy_per_atom, 50.0 / 2, "Wrong energy per atom!")
+        assert self.entry.energy_per_atom == 53.0 / 4, "Wrong energy per atom!"
+        assert self.gpentry.energy_per_atom == 50.0 / 2, "Wrong energy per atom!"
 
     def test_get_name(self):
-        self.assertEqual(self.entry.name, "mp-757614", "Wrong name!")
-        self.assertEqual(self.gpentry.name, "mp-757614", "Wrong name!")
+        assert self.entry.name == "mp-757614", "Wrong name!"
+        assert self.gpentry.name == "mp-757614", "Wrong name!"
 
     def test_get_composition(self):
         comp = self.entry.composition
         expected_comp = Composition("LiFeO2")
-        self.assertEqual(comp, expected_comp, "Wrong composition!")
+        assert comp == expected_comp, "Wrong composition!"
         comp = self.gpentry.composition
         expected_comp = Composition("LiFe")
-        self.assertEqual(comp, expected_comp, "Wrong composition!")
+        assert comp == expected_comp, "Wrong composition!"
 
     def test_is_element(self):
-        self.assertFalse(self.entry.is_element)
-        self.assertFalse(self.gpentry.is_element)
+        assert not self.entry.is_element
+        assert not self.gpentry.is_element
 
     def test_to_from_dict(self):
         d = self.entry.as_dict()
         gpd = self.gpentry.as_dict()
         entry = PDEntry.from_dict(d)
 
-        self.assertEqual(entry.name, "mp-757614", "Wrong name!")
-        self.assertEqual(entry.energy_per_atom, 53.0 / 4)
+        assert entry.name == "mp-757614", "Wrong name!"
+        assert entry.energy_per_atom == 53.0 / 4
         gpentry = GrandPotPDEntry.from_dict(gpd)
-        self.assertEqual(gpentry.name, "mp-757614", "Wrong name!")
-        self.assertEqual(gpentry.energy_per_atom, 50.0 / 2)
+        assert gpentry.name == "mp-757614", "Wrong name!"
+        assert gpentry.energy_per_atom == 50.0 / 2
 
         d_anon = d.copy()
         del d_anon["name"]
@@ -87,16 +87,16 @@ class PDEntryTest(unittest.TestCase):
             self.fail("Should not need to supply name!")
 
     def test_str(self):
-        self.assertEqual(str(self.entry), "PDEntry : Li1 Fe1 O2 (mp-757614) with energy = 53.0000")
+        assert str(self.entry) == "PDEntry : Li1 Fe1 O2 (mp-757614) with energy = 53.0000"
         pde = self.entry.as_dict()
         del pde["name"]
         pde = PDEntry.from_dict(pde)
-        self.assertEqual(str(pde), "PDEntry : Li1 Fe1 O2 with energy = 53.0000")
+        assert str(pde) == "PDEntry : Li1 Fe1 O2 with energy = 53.0000"
 
     def test_read_csv(self):
         entries = EntrySet.from_csv(module_dir / "pdentries_test.csv")
-        self.assertEqual(entries.chemsys, {"Li", "Fe", "O"}, "Wrong elements!")
-        self.assertEqual(len(entries), 490, "Wrong number of entries!")
+        assert entries.chemsys == {"Li", "Fe", "O"}, "Wrong elements!"
+        assert len(entries) == 490, "Wrong number of entries!"
 
 
 class TransformedPDEntryTest(unittest.TestCase):
@@ -114,38 +114,38 @@ class TransformedPDEntryTest(unittest.TestCase):
         self.transformed_entry = TransformedPDEntry(entry, sp_mapping)
 
     def test_get_energy(self):
-        self.assertEqual(self.transformed_entry.energy, 53, "Wrong energy!")
-        self.assertAlmostEqual(self.transformed_entry.original_entry.energy, 53.0, 11)
+        assert self.transformed_entry.energy == 53, "Wrong energy!"
+        assert round(abs(self.transformed_entry.original_entry.energy - 53.0), 11) == 0
 
     def test_get_energy_per_atom(self):
-        self.assertAlmostEqual(self.transformed_entry.energy_per_atom, 53.0 / (23 / 15), 11)
+        assert round(abs(self.transformed_entry.energy_per_atom - 53.0 / (23 / 15)), 11) == 0
 
     def test_get_name(self):
-        self.assertEqual(self.transformed_entry.name, "LiFeO2", "Wrong name!")
+        assert self.transformed_entry.name == "LiFeO2", "Wrong name!"
 
     def test_get_composition(self):
         comp = self.transformed_entry.composition
         expected_comp = Composition({DummySpecies("Xf"): 14 / 30, DummySpecies("Xg"): 1.0, DummySpecies("Xh"): 2 / 30})
-        self.assertEqual(comp, expected_comp, "Wrong composition!")
+        assert comp == expected_comp, "Wrong composition!"
 
     def test_is_element(self):
-        self.assertFalse(self.transformed_entry.is_element)
+        assert not self.transformed_entry.is_element
 
     def test_to_from_dict(self):
         d = self.transformed_entry.as_dict()
         entry = TransformedPDEntry.from_dict(d)
-        self.assertEqual(entry.name, "LiFeO2", "Wrong name!")
-        self.assertAlmostEqual(entry.energy_per_atom, 53.0 / (23 / 15), 11)
+        assert entry.name == "LiFeO2", "Wrong name!"
+        assert round(abs(entry.energy_per_atom - 53.0 / (23 / 15)), 11) == 0
 
     def test_str(self):
-        self.assertIsNotNone(str(self.transformed_entry))
+        assert str(self.transformed_entry) is not None
 
     def test_normalize(self):
         norm_entry = self.transformed_entry.normalize(mode="atom")
         expected_comp = Composition(
             {DummySpecies("Xf"): 7 / 23, DummySpecies("Xg"): 15 / 23, DummySpecies("Xh"): 1 / 23}
         )
-        self.assertEqual(norm_entry.composition, expected_comp, "Wrong composition!")
+        assert norm_entry.composition == expected_comp, "Wrong composition!"
 
 
 class PhaseDiagramTest(unittest.TestCase):
@@ -164,7 +164,8 @@ class PhaseDiagramTest(unittest.TestCase):
             lambda e: (not e.composition.is_element) or e.composition.elements[0] != Element("Li"),
             self.entries,
         )
-        self.assertRaises(ValueError, PhaseDiagram, entries)
+        with pytest.raises(ValueError):
+            PhaseDiagram(entries)
 
     def test_repr(self):
         assert (
@@ -177,31 +178,31 @@ class PhaseDiagramTest(unittest.TestCase):
         for el in ["Li", "Fe", "O2"]:
             entries = [e for e in self.entries if e.composition.reduced_formula == el]
             pd = PhaseDiagram(entries)
-            self.assertEqual(len(pd.stable_entries), 1)
+            assert len(pd.stable_entries) == 1
 
             for e in entries:
                 ehull = pd.get_e_above_hull(e)
-                self.assertGreaterEqual(ehull, 0)
+                assert ehull >= 0
 
             plotter = PDPlotter(pd)
             lines, *_ = plotter.pd_plot_data
-            self.assertEqual(lines[0][1], [0, 0])
+            assert lines[0][1] == [0, 0]
 
     def test_ordering(self):
         # Test sorting of elements
         entries = [ComputedEntry(Composition(formula), 0) for formula in ["O", "N", "Fe"]]
         pd = PhaseDiagram(entries)
         sorted_elements = (Element("Fe"), Element("N"), Element("O"))
-        self.assertEqual(tuple(pd.elements), sorted_elements)
+        assert tuple(pd.elements) == sorted_elements
 
         entries.reverse()
         pd = PhaseDiagram(entries)
-        self.assertEqual(tuple(pd.elements), sorted_elements)
+        assert tuple(pd.elements) == sorted_elements
 
         # Test manual specification of order
         ordering = [Element(elt_string) for elt_string in ["O", "N", "Fe"]]
         pd = PhaseDiagram(entries, elements=ordering)
-        self.assertEqual(tuple(pd.elements), tuple(ordering))
+        assert tuple(pd.elements) == tuple(ordering)
 
     def test_stable_entries(self):
         stable_formulas = [ent.composition.reduced_formula for ent in self.pd.stable_entries]
@@ -217,7 +218,7 @@ class PhaseDiagramTest(unittest.TestCase):
             "FeO",
         ]
         for formula in expected_stable:
-            self.assertTrue(formula in stable_formulas, formula + " not in stable entries!")
+            assert formula in stable_formulas, formula + " not in stable entries!"
 
     def test_get_formation_energy(self):
         stable_formation_energies = {
@@ -237,10 +238,10 @@ class PhaseDiagramTest(unittest.TestCase):
             "O2": 0.0,
         }
         for formula, energy in expected_formation_energies.items():
-            self.assertAlmostEqual(energy, stable_formation_energies[formula], 7)
+            assert round(abs(energy - stable_formation_energies[formula]), 7) == 0
 
     def test_all_entries_hulldata(self):
-        self.assertEqual(len(self.pd.all_entries_hulldata), 490)
+        assert len(self.pd.all_entries_hulldata) == 490
 
     def test_planar_inputs(self):
         e1 = PDEntry("H", 0)
@@ -252,25 +253,21 @@ class PhaseDiagramTest(unittest.TestCase):
 
         pd = PhaseDiagram([e1, e2, e3, e4, e5, e6], map(Element, ["Rb", "He", "B", "Be", "Li", "H"]))
 
-        self.assertEqual(len(pd.facets), 1)
+        assert len(pd.facets) == 1
 
     def test_str(self):
-        self.assertIsNotNone(str(self.pd))
+        assert str(self.pd) is not None
 
     def test_get_e_above_hull(self):
         for entry in self.pd.all_entries:
             for entry in self.pd.stable_entries:
                 decomp, e_hull = self.pd.get_decomp_and_e_above_hull(entry)
-                self.assertLess(
-                    e_hull,
-                    1e-11,
-                    "Stable entries should have e above hull of zero!",
-                )
-                self.assertEqual(decomp[entry], 1, "Decomposition of stable entry should be itself.")
+                assert e_hull < 1e-11, "Stable entries should have e above hull of zero!"
+                assert decomp[entry] == 1, "Decomposition of stable entry should be itself."
             else:
                 e_ah = self.pd.get_e_above_hull(entry)
-                self.assertTrue(isinstance(e_ah, Number))
-                self.assertGreaterEqual(e_ah, 0)
+                assert isinstance(e_ah, Number)
+                assert e_ah >= 0
 
     def test_get_decomp_and_e_above_hull_on_error(self):
 
@@ -319,51 +316,46 @@ class PhaseDiagramTest(unittest.TestCase):
 
     def test_get_equilibrium_reaction_energy(self):
         for entry in self.pd.stable_entries:
-            self.assertLessEqual(
-                self.pd.get_equilibrium_reaction_energy(entry),
-                0,
-                "Stable entries should have negative equilibrium reaction energy!",
-            )
+            assert (
+                self.pd.get_equilibrium_reaction_energy(entry) <= 0
+            ), "Stable entries should have negative equilibrium reaction energy!"
 
     def test_get_phase_separation_energy(self):
         for entry in self.pd.unstable_entries:
             if entry.composition.fractional_composition not in [
                 e.composition.fractional_composition for e in self.pd.stable_entries
             ]:
-                self.assertGreaterEqual(
-                    self.pd.get_phase_separation_energy(entry),
-                    0,
-                    "Unstable entries should have positive decomposition energy!",
-                )
+                assert (
+                    self.pd.get_phase_separation_energy(entry) >= 0
+                ), "Unstable entries should have positive decomposition energy!"
             else:
                 if entry.is_element:
                     el_ref = self.pd.el_refs[entry.composition.elements[0]]
                     e_d = entry.energy_per_atom - el_ref.energy_per_atom
-                    self.assertAlmostEqual(self.pd.get_phase_separation_energy(entry), e_d, 7)
+                    assert round(abs(self.pd.get_phase_separation_energy(entry) - e_d), 7) == 0
                 # NOTE the remaining materials would require explicit tests as they
                 # could be either positive or negative
 
         for entry in self.pd.stable_entries:
             if entry.composition.is_element:
-                self.assertEqual(
-                    self.pd.get_phase_separation_energy(entry),
-                    0,
-                    "Stable elemental entries should have decomposition energy of zero!",
-                )
+                assert (
+                    self.pd.get_phase_separation_energy(entry) == 0
+                ), "Stable elemental entries should have decomposition energy of zero!"
             else:
-                self.assertLessEqual(
-                    self.pd.get_phase_separation_energy(entry),
-                    0,
-                    "Stable entries should have negative decomposition energy!",
-                )
-                self.assertAlmostEqual(
-                    self.pd.get_phase_separation_energy(entry, stable_only=True),
-                    self.pd.get_equilibrium_reaction_energy(entry),
-                    7,
-                    (
-                        "Using `stable_only=True` should give decomposition energy equal to "
-                        "equilibrium reaction energy!"
-                    ),
+                assert (
+                    self.pd.get_phase_separation_energy(entry) <= 0
+                ), "Stable entries should have negative decomposition energy!"
+                assert (
+                    round(
+                        abs(
+                            self.pd.get_phase_separation_energy(entry, stable_only=True)
+                            - self.pd.get_equilibrium_reaction_energy(entry)
+                        ),
+                        7,
+                    )
+                    == 0
+                ), (
+                    "Using `stable_only=True` should give decomposition energy equal to " "equilibrium reaction energy!"
                 )
 
         # Test that we get correct behavior with a polymorph
@@ -377,63 +369,44 @@ class PhaseDiagramTest(unittest.TestCase):
         toy_pd = PhaseDiagram([PDEntry(c, e) for c, e in toy_entries.items()])
 
         # stable entry
-        self.assertAlmostEqual(
-            toy_pd.get_phase_separation_energy(PDEntry("Li2O", -5)),
-            -1.0,
-            7,
-        )
+        assert round(abs(toy_pd.get_phase_separation_energy(PDEntry("Li2O", -5)) - -1.0), 7) == 0
         # polymorph
-        self.assertAlmostEqual(
-            toy_pd.get_phase_separation_energy(PDEntry("Li2O", -4)),
-            -2.0 / 3.0,
-            7,
-        )
+        assert round(abs(toy_pd.get_phase_separation_energy(PDEntry("Li2O", -4)) - -2.0 / 3.0), 7) == 0
 
         # Test that the method works for novel entries
         novel_stable_entry = PDEntry("Li5FeO4", -999)
-        self.assertLess(
-            self.pd.get_phase_separation_energy(novel_stable_entry),
-            0,
-            "Novel stable entries should have negative decomposition energy!",
-        )
+        assert (
+            self.pd.get_phase_separation_energy(novel_stable_entry) < 0
+        ), "Novel stable entries should have negative decomposition energy!"
 
         novel_unstable_entry = PDEntry("Li5FeO4", 999)
-        self.assertGreater(
-            self.pd.get_phase_separation_energy(novel_unstable_entry),
-            0,
-            "Novel unstable entries should have positive decomposition energy!",
-        )
+        assert (
+            self.pd.get_phase_separation_energy(novel_unstable_entry) > 0
+        ), "Novel unstable entries should have positive decomposition energy!"
 
         duplicate_entry = PDEntry("Li2O", -14.31361175)
         scaled_dup_entry = PDEntry("Li4O2", -14.31361175 * 2)
         stable_entry = [e for e in self.pd.stable_entries if e.name == "Li2O"][0]
 
-        self.assertEqual(
-            self.pd.get_phase_separation_energy(duplicate_entry),
-            self.pd.get_phase_separation_energy(stable_entry),
-            "Novel duplicates of stable entries should have same decomposition energy!",
-        )
+        assert self.pd.get_phase_separation_energy(duplicate_entry) == self.pd.get_phase_separation_energy(
+            stable_entry
+        ), "Novel duplicates of stable entries should have same decomposition energy!"
 
-        self.assertEqual(
-            self.pd.get_phase_separation_energy(scaled_dup_entry),
-            self.pd.get_phase_separation_energy(stable_entry),
-            "Novel scaled duplicates of stable entries should have same decomposition energy!",
-        )
+        assert self.pd.get_phase_separation_energy(scaled_dup_entry) == self.pd.get_phase_separation_energy(
+            stable_entry
+        ), "Novel scaled duplicates of stable entries should have same decomposition energy!"
 
     def test_get_decomposition(self):
         for entry in self.pd.stable_entries:
-            self.assertEqual(
-                len(self.pd.get_decomposition(entry.composition)),
-                1,
-                "Stable composition should have only 1 decomposition!",
-            )
+            assert (
+                len(self.pd.get_decomposition(entry.composition)) == 1
+            ), "Stable composition should have only 1 decomposition!"
         dim = len(self.pd.elements)
         for entry in self.pd.all_entries:
             ndecomp = len(self.pd.get_decomposition(entry.composition))
-            self.assertTrue(
-                ndecomp > 0 and ndecomp <= dim,
-                "The number of decomposition phases can at most be equal to the number of components.",
-            )
+            assert (
+                ndecomp > 0 and ndecomp <= dim
+            ), "The number of decomposition phases can at most be equal to the number of components."
 
         # Just to test decomposition for a fictitious composition
         ansdict = {
@@ -445,20 +418,17 @@ class PhaseDiagramTest(unittest.TestCase):
             "Fe6 O8": 0.33333333333333393,
         }
         for k, v in expected_ans.items():
-            self.assertAlmostEqual(ansdict[k], v, 7)
+            assert round(abs(ansdict[k] - v), 7) == 0
 
     def test_get_transition_chempots(self):
         for el in self.pd.elements:
-            self.assertLessEqual(len(self.pd.get_transition_chempots(el)), len(self.pd.facets))
+            assert len(self.pd.get_transition_chempots(el)) <= len(self.pd.facets)
 
     def test_get_element_profile(self):
         for el in self.pd.elements:
             for entry in self.pd.stable_entries:
                 if not entry.composition.is_element:
-                    self.assertLessEqual(
-                        len(self.pd.get_element_profile(el, entry.composition)),
-                        len(self.pd.facets),
-                    )
+                    assert len(self.pd.get_element_profile(el, entry.composition)) <= len(self.pd.facets)
 
         expected = [
             {
@@ -479,17 +449,17 @@ class PhaseDiagramTest(unittest.TestCase):
         ]
         result = self.pd.get_element_profile(Element("O"), Composition("Li2O"))
         for d1, d2 in zip(expected, result):
-            self.assertAlmostEqual(d1["evolution"], d2["evolution"])
-            self.assertAlmostEqual(d1["chempot"], d2["chempot"])
-            self.assertEqual(d1["reaction"], str(d2["reaction"]))
+            assert round(abs(d1["evolution"] - d2["evolution"]), 7) == 0
+            assert round(abs(d1["chempot"] - d2["chempot"]), 7) == 0
+            assert d1["reaction"] == str(d2["reaction"])
 
     def test_get_get_chempot_range_map(self):
         elements = [el for el in self.pd.elements if el.symbol != "Fe"]
-        self.assertEqual(len(self.pd.get_chempot_range_map(elements)), 10)
+        assert len(self.pd.get_chempot_range_map(elements)) == 10
 
     def test_getmu_vertices_stability_phase(self):
         results = self.pd.getmu_vertices_stability_phase(Composition("LiFeO2"), Element("O"))
-        self.assertAlmostEqual(len(results), 6)
+        assert round(abs(len(results) - 6), 7) == 0
         test_equality = False
         for c in results:
             if (
@@ -498,32 +468,32 @@ class PhaseDiagramTest(unittest.TestCase):
                 and abs(c[Element("Li")] + 3.931) < 1e-2
             ):
                 test_equality = True
-        self.assertTrue(test_equality, "there is an expected vertex missing in the list")
+        assert test_equality, "there is an expected vertex missing in the list"
 
     def test_getmu_range_stability_phase(self):
         results = self.pd.get_chempot_range_stability_phase(Composition("LiFeO2"), Element("O"))
-        self.assertAlmostEqual(results[Element("O")][1], -4.4501812249999997)
-        self.assertAlmostEqual(results[Element("Fe")][0], -6.5961470999999996)
-        self.assertAlmostEqual(results[Element("Li")][0], -3.6250022625000007)
+        assert round(abs(results[Element("O")][1] - -4.4501812249999997), 7) == 0
+        assert round(abs(results[Element("Fe")][0] - -6.5961470999999996), 7) == 0
+        assert round(abs(results[Element("Li")][0] - -3.6250022625000007), 7) == 0
 
     def test_get_hull_energy(self):
         for entry in self.pd.stable_entries:
             h_e = self.pd.get_hull_energy(entry.composition)
-            self.assertAlmostEqual(h_e, entry.energy)
+            assert round(abs(h_e - entry.energy), 7) == 0
             n_h_e = self.pd.get_hull_energy(entry.composition.fractional_composition)
-            self.assertAlmostEqual(n_h_e, entry.energy_per_atom)
+            assert round(abs(n_h_e - entry.energy_per_atom), 7) == 0
 
     def test_get_hull_energy_per_atom(self):
         for entry in self.pd.stable_entries:
             h_e = self.pd.get_hull_energy_per_atom(entry.composition)
-            self.assertAlmostEqual(h_e, entry.energy_per_atom)
+            assert round(abs(h_e - entry.energy_per_atom), 7) == 0
 
     def test_1d_pd(self):
         entry = PDEntry("H", 0)
         pd = PhaseDiagram([entry])
         decomp, e = pd.get_decomp_and_e_above_hull(PDEntry("H", 1))
-        self.assertAlmostEqual(e, 1)
-        self.assertAlmostEqual(decomp[entry], 1.0)
+        assert round(abs(e - 1), 7) == 0
+        assert round(abs(decomp[entry] - 1.0), 7) == 0
 
     def test_get_critical_compositions_fractional(self):
         c1 = Composition("Fe2O3").fractional_composition
@@ -537,7 +507,7 @@ class PhaseDiagramTest(unittest.TestCase):
             Composition("Li3FeO4").fractional_composition,
         ]
         for crit, exp in zip(comps, expected):
-            self.assertTrue(crit.almost_equals(exp, rtol=0, atol=1e-5))
+            assert crit.almost_equals(exp, rtol=0, atol=1e-5)
 
         comps = self.pd.get_critical_compositions(c1, c3)
         expected = [
@@ -547,7 +517,7 @@ class PhaseDiagramTest(unittest.TestCase):
             Composition("Li2O").fractional_composition,
         ]
         for crit, exp in zip(comps, expected):
-            self.assertTrue(crit.almost_equals(exp, rtol=0, atol=1e-5))
+            assert crit.almost_equals(exp, rtol=0, atol=1e-5)
 
     def test_get_critical_compositions(self):
         c1 = Composition("Fe2O3")
@@ -561,7 +531,7 @@ class PhaseDiagramTest(unittest.TestCase):
             Composition("Li3FeO4"),
         ]
         for crit, exp in zip(comps, expected):
-            self.assertTrue(crit.almost_equals(exp, rtol=0, atol=1e-5))
+            assert crit.almost_equals(exp, rtol=0, atol=1e-5)
 
         comps = self.pd.get_critical_compositions(c1, c3)
         expected = [
@@ -571,26 +541,24 @@ class PhaseDiagramTest(unittest.TestCase):
             Composition("Li2O"),
         ]
         for crit, exp in zip(comps, expected):
-            self.assertTrue(crit.almost_equals(exp, rtol=0, atol=1e-5))
+            assert crit.almost_equals(exp, rtol=0, atol=1e-5)
 
         # Don't fail silently if input compositions aren't in phase diagram
         # Can be very confusing if you're working with a GrandPotentialPD
-        self.assertRaises(
-            ValueError,
-            self.pd.get_critical_compositions,
-            Composition("Xe"),
-            Composition("Mn"),
-        )
+        with pytest.raises(ValueError):
+            self.pd.get_critical_compositions(
+                Composition("Xe"),
+                Composition("Mn"),
+            )
 
         # For the moment, should also fail even if compositions are in the gppd
         # because it isn't handled properly
         gppd = GrandPotentialPhaseDiagram(self.pd.all_entries, {"Xe": 1}, self.pd.elements + [Element("Xe")])
-        self.assertRaises(
-            ValueError,
-            gppd.get_critical_compositions,
-            Composition("Fe2O3"),
-            Composition("Li3FeO4Xe"),
-        )
+        with pytest.raises(ValueError):
+            gppd.get_critical_compositions(
+                Composition("Fe2O3"),
+                Composition("Li3FeO4Xe"),
+            )
 
         # check that the function still works though
         comps = gppd.get_critical_compositions(c1, c2)
@@ -600,10 +568,10 @@ class PhaseDiagramTest(unittest.TestCase):
             Composition("Li3FeO4"),
         ]
         for crit, exp in zip(comps, expected):
-            self.assertTrue(crit.almost_equals(exp, rtol=0, atol=1e-5))
+            assert crit.almost_equals(exp, rtol=0, atol=1e-5)
 
         # case where the endpoints are identical
-        self.assertEqual(self.pd.get_critical_compositions(c1, c1 * 2), [c1, c1 * 2])
+        assert self.pd.get_critical_compositions(c1, c1 * 2) == [c1, c1 * 2]
 
     def test_get_composition_chempots(self):
         c1 = Composition("Fe3.1O4")
@@ -614,7 +582,7 @@ class PhaseDiagramTest(unittest.TestCase):
 
         cp = self.pd.get_composition_chempots(c1)
         calc_e2 = e1 + sum(cp[k] * v for k, v in (c2 - c1).items())
-        self.assertAlmostEqual(e2, calc_e2)
+        assert round(abs(e2 - calc_e2), 7) == 0
 
     def test_get_all_chempots(self):
         c1 = Composition("Fe3.1O4")
@@ -628,7 +596,7 @@ class PhaseDiagramTest(unittest.TestCase):
         }
 
         for elem, energy in cpresult.items():
-            self.assertAlmostEqual(cp1["Fe3O4-FeO-LiFeO2"][elem], energy)
+            assert round(abs(cp1["Fe3O4-FeO-LiFeO2"][elem] - energy), 7) == 0
 
         cp2 = self.pd.get_all_chempots(c2)
         cpresult = {
@@ -638,7 +606,7 @@ class PhaseDiagramTest(unittest.TestCase):
         }
 
         for elem, energy in cpresult.items():
-            self.assertAlmostEqual(cp2["FeO-LiFeO2-Fe"][elem], energy)
+            assert round(abs(cp2["FeO-LiFeO2-Fe"][elem] - energy), 7) == 0
 
     def test_to_from_dict(self):
         # test round-trip for other entry types such as ComputedEntry
@@ -646,12 +614,12 @@ class PhaseDiagramTest(unittest.TestCase):
         pd = PhaseDiagram([entry])
         pd_dict = pd.as_dict()
         pd_roundtrip = PhaseDiagram.from_dict(pd_dict)
-        self.assertEqual(pd.all_entries[0].entry_id, pd_roundtrip.all_entries[0].entry_id)
+        assert pd.all_entries[0].entry_id == pd_roundtrip.all_entries[0].entry_id
         dd = self.pd.as_dict()
         new_pd = PhaseDiagram.from_dict(dd)
         new_pd_dict = new_pd.as_dict()
-        self.assertEqual(new_pd_dict, dd)
-        self.assertIsInstance(pd.to_json(), str)
+        assert new_pd_dict == dd
+        assert isinstance(pd.to_json(), str)
 
     def test_read_json(self):
         with ScratchDir("."):
@@ -669,8 +637,8 @@ class GrandPotentialPhaseDiagramTest(unittest.TestCase):
         stable_formulas = [ent.original_entry.composition.reduced_formula for ent in self.pd.stable_entries]
         expected_stable = ["Li5FeO4", "Li2FeO3", "LiFeO2", "Fe2O3", "Li2O2"]
         for formula in expected_stable:
-            self.assertTrue(formula in stable_formulas, f"{formula} not in stable entries!")
-        self.assertEqual(len(self.pd6.stable_entries), 4)
+            assert formula in stable_formulas, f"{formula} not in stable entries!"
+        assert len(self.pd6.stable_entries) == 4
 
     def test_get_formation_energy(self):
         stable_formation_energies = {
@@ -685,15 +653,12 @@ class GrandPotentialPhaseDiagramTest(unittest.TestCase):
             "Li2O2": 0.0,
         }
         for formula, energy in expected_formation_energies.items():
-            self.assertAlmostEqual(
-                energy,
-                stable_formation_energies[formula],
-                7,
-                f"Calculated formation for {formula} is not correct!",
-            )
+            assert (
+                round(abs(energy - stable_formation_energies[formula]), 7) == 0
+            ), f"Calculated formation for {formula} is not correct!"
 
     def test_str(self):
-        self.assertIsNotNone(str(self.pd))
+        assert str(self.pd) is not None
 
 
 class CompoundPhaseDiagramTest(unittest.TestCase):
@@ -705,7 +670,7 @@ class CompoundPhaseDiagramTest(unittest.TestCase):
         stable_formulas = [ent.name for ent in self.pd.stable_entries]
         expected_stable = ["Fe2O3", "Li5FeO4", "LiFeO2", "Li2O"]
         for formula in expected_stable:
-            self.assertTrue(formula in stable_formulas)
+            assert formula in stable_formulas
 
     def test_get_formation_energy(self):
         stable_formation_energies = {ent.name: self.pd.get_form_energy(ent) for ent in self.pd.stable_entries}
@@ -716,10 +681,10 @@ class CompoundPhaseDiagramTest(unittest.TestCase):
             "Li2O": 0,
         }
         for formula, energy in expected_formation_energies.items():
-            self.assertAlmostEqual(energy, stable_formation_energies[formula], 7)
+            assert round(abs(energy - stable_formation_energies[formula]), 7) == 0
 
     def test_str(self):
-        self.assertIsNotNone(str(self.pd))
+        assert str(self.pd) is not None
 
 
 class PatchedPhaseDiagramTest(unittest.TestCase):
@@ -735,7 +700,7 @@ class PatchedPhaseDiagramTest(unittest.TestCase):
         # novel entries not in any of the patches
         self.novel_comps = [Composition("H5C2OP"), Composition("V2PH4C")]
         for c in self.novel_comps:
-            self.assertTrue(c.chemical_system not in self.ppd.spaces)
+            assert c.chemical_system not in self.ppd.spaces
 
         self.novel_entries = [PDEntry(c, -39.8) for c in self.novel_comps]
 
@@ -869,11 +834,11 @@ class ReactionDiagramTest(unittest.TestCase):
 
     def test_formula(self):
         for e in self.rd.rxn_entries:
-            self.assertIn(Element.V, e.composition)
-            self.assertIn(Element.O, e.composition)
-            self.assertIn(Element.C, e.composition)
-            self.assertIn(Element.P, e.composition)
-            self.assertIn(Element.H, e.composition)
+            assert Element.V in e.composition
+            assert Element.O in e.composition
+            assert Element.C in e.composition
+            assert Element.P in e.composition
+            assert Element.H in e.composition
         # formed_formula = [e.composition.reduced_formula for e in self.rd.rxn_entries]
         # expected_formula = [
         #     "V0.12707182P0.12707182H0.0441989C0.03314917O0.66850829",
@@ -914,27 +879,18 @@ class PDPlotterTest(unittest.TestCase):
 
     def test_pd_plot_data(self):
         (lines, labels, unstable_entries) = self.plotter_ternary_mpl.pd_plot_data
-        self.assertEqual(len(lines), 22)
-        self.assertEqual(
-            len(labels),
-            len(self.pd_ternary.stable_entries),
-            "Incorrect number of lines generated!",
-        )
-        self.assertEqual(
-            len(unstable_entries),
-            len(self.pd_ternary.all_entries) - len(self.pd_ternary.stable_entries),
-            "Incorrect number of lines generated!",
-        )
+        assert len(lines) == 22
+        assert len(labels) == len(self.pd_ternary.stable_entries), "Incorrect number of lines generated!"
+        assert len(unstable_entries) == len(self.pd_ternary.all_entries) - len(
+            self.pd_ternary.stable_entries
+        ), "Incorrect number of lines generated!"
         (lines, labels, unstable_entries) = self.plotter_quaternary_mpl.pd_plot_data
-        self.assertEqual(len(lines), 33)
-        self.assertEqual(len(labels), len(self.pd_quaternary.stable_entries))
-        self.assertEqual(
-            len(unstable_entries),
-            len(self.pd_quaternary.all_entries) - len(self.pd_quaternary.stable_entries),
-        )
+        assert len(lines) == 33
+        assert len(labels) == len(self.pd_quaternary.stable_entries)
+        assert len(unstable_entries) == len(self.pd_quaternary.all_entries) - len(self.pd_quaternary.stable_entries)
         (lines, labels, unstable_entries) = self.plotter_binary_mpl.pd_plot_data
-        self.assertEqual(len(lines), 3)
-        self.assertEqual(len(labels), len(self.pd_binary.stable_entries))
+        assert len(lines) == 3
+        assert len(labels) == len(self.pd_binary.stable_entries)
 
     def test_mpl_plots(self):
         # Some very basic ("non")-tests. Just to make sure the methods are callable.
@@ -992,17 +948,17 @@ class UtilityFunctionTest(unittest.TestCase):
             (399, 400),
             (20, 400),
         }
-        self.assertEqual(uniquelines(testdata), expected_ans)
+        assert uniquelines(testdata) == expected_ans
 
     def test_triangular_coord(self):
         coord = [0.5, 0.5]
         coord = triangular_coord(coord)
-        self.assertTrue(np.allclose(coord, [0.75, 0.4330127]))
+        assert np.allclose(coord, [0.75, 0.4330127])
 
     def test_tet_coord(self):
         coord = [0.5, 0.5, 0.5]
         coord = tet_coord(coord)
-        self.assertTrue(np.allclose(coord, [1.0, 0.57735027, 0.40824829]))
+        assert np.allclose(coord, [1.0, 0.57735027, 0.40824829])
 
 
 if __name__ == "__main__":

--- a/pymatgen/entries/tests/test_compatibility.py
+++ b/pymatgen/entries/tests/test_compatibility.py
@@ -314,8 +314,8 @@ class MaterialsProjectCompatibilityTest(unittest.TestCase):
 
     def test_process_entry(self):
         # Correct parameters
-        self.assertIsNotNone(self.compat.process_entry(self.entry1))
-        self.assertIsNone(self.ggacompat.process_entry(self.entry1))
+        assert self.compat.process_entry(self.entry1) is not None
+        assert self.ggacompat.process_entry(self.entry1) is None
 
         # Correct parameters
         entry = ComputedEntry(
@@ -338,8 +338,8 @@ class MaterialsProjectCompatibilityTest(unittest.TestCase):
                 ],
             },
         )
-        self.assertIsNone(self.compat.process_entry(entry))
-        self.assertIsNotNone(self.ggacompat.process_entry(entry))
+        assert self.compat.process_entry(entry) is None
+        assert self.ggacompat.process_entry(entry) is not None
 
         entry = ComputedEntry(
             "Fe2O3",
@@ -361,11 +361,11 @@ class MaterialsProjectCompatibilityTest(unittest.TestCase):
                 ],
             },
         )
-        self.assertIsNotNone(self.compat.process_entry(entry))
+        assert self.compat.process_entry(entry) is not None
 
     def test_correction_values(self):
         # test_corrections
-        self.assertAlmostEqual(self.compat.process_entry(self.entry1).correction, -2.733 * 2 - 0.70229 * 3)
+        assert self.compat.process_entry(self.entry1).correction == pytest.approx(-2.733 * 2 - 0.70229 * 3)
 
         entry = ComputedEntry(
             "FeF3",
@@ -387,12 +387,12 @@ class MaterialsProjectCompatibilityTest(unittest.TestCase):
                 ],
             },
         )
-        self.assertIsNotNone(self.compat.process_entry(entry))
+        assert self.compat.process_entry(entry) is not None
 
         # Check actual correction
-        self.assertAlmostEqual(self.compat.process_entry(entry).correction, -2.733)
+        assert self.compat.process_entry(entry).correction == pytest.approx(-2.733)
 
-        self.assertAlmostEqual(self.compat.process_entry(self.entry_sulfide).correction, -0.66346)
+        assert self.compat.process_entry(self.entry_sulfide).correction == pytest.approx(-0.66346)
 
     def test_U_values(self):
         # Wrong U value
@@ -416,7 +416,7 @@ class MaterialsProjectCompatibilityTest(unittest.TestCase):
                 ],
             },
         )
-        self.assertIsNone(self.compat.process_entry(entry))
+        assert self.compat.process_entry(entry) is None
 
         # GGA run of U
         entry = ComputedEntry(
@@ -439,7 +439,7 @@ class MaterialsProjectCompatibilityTest(unittest.TestCase):
                 ],
             },
         )
-        self.assertIsNone(self.compat.process_entry(entry))
+        assert self.compat.process_entry(entry) is None
 
         # GGA+U run of non-U
         entry = ComputedEntry(
@@ -462,7 +462,7 @@ class MaterialsProjectCompatibilityTest(unittest.TestCase):
                 ],
             },
         )
-        self.assertIsNone(self.compat.process_entry(entry))
+        assert self.compat.process_entry(entry) is None
 
         # Materials project should not have a U for sulfides
         entry = ComputedEntry(
@@ -485,7 +485,7 @@ class MaterialsProjectCompatibilityTest(unittest.TestCase):
                 ],
             },
         )
-        self.assertIsNone(self.compat.process_entry(entry))
+        assert self.compat.process_entry(entry) is None
 
     def test_wrong_psp(self):
         # Wrong psp
@@ -509,7 +509,7 @@ class MaterialsProjectCompatibilityTest(unittest.TestCase):
                 ],
             },
         )
-        self.assertIsNone(self.compat.process_entry(entry))
+        assert self.compat.process_entry(entry) is None
 
     def test_element_processing(self):
         entry = ComputedEntry(
@@ -530,8 +530,8 @@ class MaterialsProjectCompatibilityTest(unittest.TestCase):
         )
         entry = self.compat.process_entry(entry)
         #        self.assertEqual(entry.entry_id, -8)
-        self.assertAlmostEqual(entry.energy, -1)
-        self.assertAlmostEqual(self.ggacompat.process_entry(entry).energy, -1)
+        assert entry.energy == pytest.approx(-1)
+        assert self.ggacompat.process_entry(entry).energy == pytest.approx(-1)
 
     def test_get_explanation_dict(self):
         compat = MaterialsProjectCompatibility(check_potcar_hash=False)
@@ -556,7 +556,7 @@ class MaterialsProjectCompatibilityTest(unittest.TestCase):
             },
         )
         d = compat.get_explanation_dict(entry)
-        self.assertEqual("MPRelaxSet Potcar Correction", d["corrections"][0]["name"])
+        assert "MPRelaxSet Potcar Correction" == d["corrections"][0]["name"]
 
     def test_get_corrections_dict(self):
         compat = MaterialsProjectCompatibility(check_potcar_hash=False)
@@ -584,23 +584,23 @@ class MaterialsProjectCompatibilityTest(unittest.TestCase):
             },
         )
         c = compat.get_corrections_dict(entry)[0]
-        self.assertAlmostEqual(c["MP Anion Correction"], -2.10687)
-        self.assertAlmostEqual(c["MP Advanced Correction"], -5.466)
+        assert c["MP Anion Correction"] == pytest.approx(-2.10687)
+        assert c["MP Advanced Correction"] == pytest.approx(-5.466)
 
         entry.parameters["is_hubbard"] = False
         del entry.parameters["hubbards"]
         c = ggacompat.get_corrections_dict(entry)[0]
-        self.assertNotIn("MP Advanced Correction", c)
+        assert "MP Advanced Correction" not in c
 
     def test_process_entries(self):
         entries = self.compat.process_entries([self.entry1, self.entry2, self.entry3, self.entry4])
-        self.assertEqual(len(entries), 2)
+        assert len(entries) == 2
 
     def test_msonable(self):
         compat_dict = self.compat.as_dict()
         decoder = MontyDecoder()
         temp_compat = decoder.process_decoded(compat_dict)
-        self.assertIsInstance(temp_compat, MaterialsProjectCompatibility)
+        assert isinstance(temp_compat, MaterialsProjectCompatibility)
 
 
 class MaterialsProjectCompatibility2020Test(unittest.TestCase):
@@ -696,8 +696,8 @@ class MaterialsProjectCompatibility2020Test(unittest.TestCase):
 
     def test_process_entry(self):
         # Correct parameters
-        self.assertIsNotNone(self.compat.process_entry(self.entry1))
-        self.assertIsNone(self.ggacompat.process_entry(self.entry1))
+        assert self.compat.process_entry(self.entry1) is not None
+        assert self.ggacompat.process_entry(self.entry1) is None
 
         # Correct parameters
         entry = ComputedEntry(
@@ -720,8 +720,8 @@ class MaterialsProjectCompatibility2020Test(unittest.TestCase):
                 ],
             },
         )
-        self.assertIsNone(self.compat.process_entry(entry))
-        self.assertIsNotNone(self.ggacompat.process_entry(entry))
+        assert self.compat.process_entry(entry) is None
+        assert self.ggacompat.process_entry(entry) is not None
 
         entry = ComputedEntry(
             "Fe2O3",
@@ -743,7 +743,7 @@ class MaterialsProjectCompatibility2020Test(unittest.TestCase):
                 ],
             },
         )
-        self.assertIsNotNone(self.compat.process_entry(entry))
+        assert self.compat.process_entry(entry) is not None
 
     def test_oxi_state_guess(self):
         # An entry where Composition.oxi_state_guesses will return an empty list
@@ -794,17 +794,17 @@ class MaterialsProjectCompatibility2020Test(unittest.TestCase):
 
         with pytest.warns(UserWarning, match="Failed to guess oxidation state"):
             e1 = self.compat.process_entry(entry_blank)
-            self.assertAlmostEqual(e1.correction, -0.422)
+            assert e1.correction == pytest.approx(-0.422)
 
         e2 = self.compat.process_entry(entry_oxi)
-        self.assertAlmostEqual(e2.correction, -0.687 + -3.202 * 2 + -0.614 * 8)
+        assert e2.correction == pytest.approx(-0.687 + -3.202 * 2 + -0.614 * 8)
 
         e3 = self.compat.process_entry(entry_multi_anion)
-        self.assertAlmostEqual(e3.correction, -0.361 * 4 + -0.614 * 4)
+        assert e3.correction == pytest.approx(-0.361 * 4 + -0.614 * 4)
 
     def test_correction_values(self):
         # test_corrections
-        self.assertAlmostEqual(self.compat.process_entry(self.entry1).correction, -2.256 * 2 - 0.687 * 3)
+        assert self.compat.process_entry(self.entry1).correction == pytest.approx(-2.256 * 2 - 0.687 * 3)
 
         entry = ComputedEntry(
             "FeF3",
@@ -826,12 +826,12 @@ class MaterialsProjectCompatibility2020Test(unittest.TestCase):
                 ],
             },
         )
-        self.assertIsNotNone(self.compat.process_entry(entry))
+        assert self.compat.process_entry(entry) is not None
 
         # Check actual correction
-        self.assertAlmostEqual(self.compat.process_entry(entry).correction, -0.462 * 3 + -2.256)
+        assert self.compat.process_entry(entry).correction == pytest.approx(-0.462 * 3 + -2.256)
 
-        self.assertAlmostEqual(self.compat.process_entry(self.entry_sulfide).correction, -0.503)
+        assert self.compat.process_entry(self.entry_sulfide).correction == pytest.approx(-0.503)
 
     def test_oxdiation_by_electronegativity(self):
         # make sure anion corrections are only applied when the element has
@@ -889,10 +889,10 @@ class MaterialsProjectCompatibility2020Test(unittest.TestCase):
         )
 
         # CaSi; only correction should be Si
-        self.assertAlmostEqual(self.compat.process_entry(entry1).correction, 0.071 * 2)
+        assert self.compat.process_entry(entry1).correction == pytest.approx(0.071 * 2)
 
         # SiO2; only corrections should be oxide
-        self.assertAlmostEqual(self.compat.process_entry(entry2).correction, -0.687 * 4)
+        assert self.compat.process_entry(entry2).correction == pytest.approx(-0.687 * 4)
 
     def test_oxdiation(self):
         # make sure anion corrections are only applied when the element has
@@ -956,10 +956,10 @@ class MaterialsProjectCompatibility2020Test(unittest.TestCase):
         )
 
         # CaSi; only correction should be Si
-        self.assertAlmostEqual(self.compat.process_entry(entry1).correction, 0.071 * 2)
+        assert self.compat.process_entry(entry1).correction == pytest.approx(0.071 * 2)
 
         # SiO2; only corrections should be oxide
-        self.assertAlmostEqual(self.compat.process_entry(entry2).correction, -0.687 * 4)
+        assert self.compat.process_entry(entry2).correction == pytest.approx(-0.687 * 4)
 
     def test_U_values(self):
         # Wrong U value
@@ -983,7 +983,7 @@ class MaterialsProjectCompatibility2020Test(unittest.TestCase):
                 ],
             },
         )
-        self.assertIsNone(self.compat.process_entry(entry))
+        assert self.compat.process_entry(entry) is None
 
         # GGA run of U
         entry = ComputedEntry(
@@ -1006,7 +1006,7 @@ class MaterialsProjectCompatibility2020Test(unittest.TestCase):
                 ],
             },
         )
-        self.assertIsNone(self.compat.process_entry(entry))
+        assert self.compat.process_entry(entry) is None
 
         # GGA+U run of non-U
         entry = ComputedEntry(
@@ -1029,7 +1029,7 @@ class MaterialsProjectCompatibility2020Test(unittest.TestCase):
                 ],
             },
         )
-        self.assertIsNone(self.compat.process_entry(entry))
+        assert self.compat.process_entry(entry) is None
 
         # Materials project should not have a U for sulfides
         entry = ComputedEntry(
@@ -1052,7 +1052,7 @@ class MaterialsProjectCompatibility2020Test(unittest.TestCase):
                 ],
             },
         )
-        self.assertIsNone(self.compat.process_entry(entry))
+        assert self.compat.process_entry(entry) is None
 
     def test_wrong_psp(self):
         # Wrong psp
@@ -1076,7 +1076,7 @@ class MaterialsProjectCompatibility2020Test(unittest.TestCase):
                 ],
             },
         )
-        self.assertIsNone(self.compat.process_entry(entry))
+        assert self.compat.process_entry(entry) is None
 
     def test_element_processing(self):
         entry = ComputedEntry(
@@ -1096,8 +1096,8 @@ class MaterialsProjectCompatibility2020Test(unittest.TestCase):
             },
         )
         entry = self.compat.process_entry(entry)
-        self.assertAlmostEqual(entry.energy, -1)
-        self.assertAlmostEqual(self.ggacompat.process_entry(entry).energy, -1)
+        assert entry.energy == pytest.approx(-1)
+        assert self.ggacompat.process_entry(entry).energy == pytest.approx(-1)
 
     def test_get_explanation_dict(self):
         compat = MaterialsProjectCompatibility(check_potcar_hash=False)
@@ -1122,7 +1122,7 @@ class MaterialsProjectCompatibility2020Test(unittest.TestCase):
             },
         )
         d = compat.get_explanation_dict(entry)
-        self.assertEqual("MPRelaxSet Potcar Correction", d["corrections"][0]["name"])
+        assert "MPRelaxSet Potcar Correction" == d["corrections"][0]["name"]
 
     def test_energy_adjustments(self):
         compat = MaterialsProject2020Compatibility(check_potcar_hash=False)
@@ -1160,26 +1160,23 @@ class MaterialsProjectCompatibility2020Test(unittest.TestCase):
 
         for ea in c.energy_adjustments:
             if ea.name == "MP2020 GGA/GGA+U mixing correction (Fe)":
-                self.assertAlmostEqual(ea.value, -2.256 * 4)
-                self.assertAlmostEqual(ea.uncertainty, 0.0101 * 4)
+                assert ea.value == pytest.approx(-2.256 * 4)
+                assert ea.uncertainty == pytest.approx(0.0101 * 4)
             elif ea.name == "MP2020 GGA/GGA+U mixing correction (Co)":
-                self.assertAlmostEqual(ea.value, -1.638 * 2)
-                self.assertAlmostEqual(ea.uncertainty, 0.006 * 2)
+                assert ea.value == pytest.approx(-1.638 * 2)
+                assert ea.uncertainty == pytest.approx(0.006 * 2)
             elif ea.name == "MP2020 anion correction (oxide)":
-                self.assertAlmostEqual(ea.value, -0.687 * 8)
-                self.assertAlmostEqual(ea.uncertainty, 0.002 * 8)
+                assert ea.value == pytest.approx(-0.687 * 8)
+                assert ea.uncertainty == pytest.approx(0.002 * 8)
 
         entry.parameters["is_hubbard"] = False
         del entry.parameters["hubbards"]
         c = ggacompat.process_entry(entry)
-        self.assertNotIn(
-            "MP2020 GGA/GGA+U mixing correction",
-            [ea.name for ea in c.energy_adjustments],
-        )
+        assert "MP2020 GGA/GGA+U mixing correction" not in [ea.name for ea in c.energy_adjustments]
 
     def test_process_entries(self):
         entries = self.compat.process_entries([self.entry1, self.entry2, self.entry3])
-        self.assertEqual(len(entries), 2)
+        assert len(entries) == 2
 
     def test_config_file(self):
         config_file = Path(PymatgenTest.TEST_FILES_DIR / "MP2020Compatibility_alternate.yaml")
@@ -1187,13 +1184,13 @@ class MaterialsProjectCompatibility2020Test(unittest.TestCase):
         entry = compat.process_entry(self.entry1)
         for ea in entry.energy_adjustments:
             if ea.name == "MP2020 GGA/GGA+U mixing correction (Fe)":
-                self.assertAlmostEqual(ea.value, -0.224 * 2)
+                assert ea.value == pytest.approx(-0.224 * 2)
 
     def test_msonable(self):
         compat_dict = self.compat.as_dict()
         decoder = MontyDecoder()
         temp_compat = decoder.process_decoded(compat_dict)
-        self.assertIsInstance(temp_compat, MaterialsProject2020Compatibility)
+        assert isinstance(temp_compat, MaterialsProject2020Compatibility)
 
 
 class MITCompatibilityTest(unittest.TestCase):
@@ -1268,18 +1265,18 @@ class MITCompatibilityTest(unittest.TestCase):
 
     def test_process_entry(self):
         # Correct parameters
-        self.assertIsNotNone(self.compat.process_entry(self.entry_O))
-        self.assertIsNotNone(self.compat.process_entry(self.entry_F))
+        assert self.compat.process_entry(self.entry_O) is not None
+        assert self.compat.process_entry(self.entry_F) is not None
 
     def test_correction_value(self):
         # Check actual correction
-        self.assertAlmostEqual(self.compat.process_entry(self.entry_O).correction, -1.723 * 2 - 0.66975 * 3)
-        self.assertAlmostEqual(self.compat.process_entry(self.entry_F).correction, -1.723)
-        self.assertAlmostEqual(self.compat.process_entry(self.entry_S).correction, -1.113)
+        assert self.compat.process_entry(self.entry_O).correction == pytest.approx(-1.723 * 2 - 0.66975 * 3)
+        assert self.compat.process_entry(self.entry_F).correction == pytest.approx(-1.723)
+        assert self.compat.process_entry(self.entry_S).correction == pytest.approx(-1.113)
 
     def test_U_value(self):
         # MIT should have a U value for Fe containing sulfides
-        self.assertIsNotNone(self.compat.process_entry(self.entry_S))
+        assert self.compat.process_entry(self.entry_S) is not None
 
         # MIT should not have a U value for Ni containing sulfides
         entry = ComputedEntry(
@@ -1303,7 +1300,7 @@ class MITCompatibilityTest(unittest.TestCase):
             },
         )
 
-        self.assertIsNone(self.compat.process_entry(entry))
+        assert self.compat.process_entry(entry) is None
 
         entry = ComputedEntry(
             "NiS2",
@@ -1326,7 +1323,7 @@ class MITCompatibilityTest(unittest.TestCase):
             },
         )
 
-        self.assertIsNotNone(self.ggacompat.process_entry(entry))
+        assert self.ggacompat.process_entry(entry) is not None
 
     def test_wrong_U_value(self):
         # Wrong U value
@@ -1351,7 +1348,7 @@ class MITCompatibilityTest(unittest.TestCase):
             },
         )
 
-        self.assertIsNone(self.compat.process_entry(entry))
+        assert self.compat.process_entry(entry) is None
 
         # GGA run
         entry = ComputedEntry(
@@ -1374,8 +1371,8 @@ class MITCompatibilityTest(unittest.TestCase):
                 ],
             },
         )
-        self.assertIsNone(self.compat.process_entry(entry))
-        self.assertIsNotNone(self.ggacompat.process_entry(entry))
+        assert self.compat.process_entry(entry) is None
+        assert self.ggacompat.process_entry(entry) is not None
 
     def test_wrong_psp(self):
         # Wrong psp
@@ -1399,7 +1396,7 @@ class MITCompatibilityTest(unittest.TestCase):
                 ],
             },
         )
-        self.assertIsNone(self.compat.process_entry(entry))
+        assert self.compat.process_entry(entry) is None
 
     def test_element_processing(self):
         # Testing processing of elements.
@@ -1420,7 +1417,7 @@ class MITCompatibilityTest(unittest.TestCase):
             },
         )
         entry = self.compat.process_entry(entry)
-        self.assertAlmostEqual(entry.energy, -1)
+        assert entry.energy == pytest.approx(-1)
 
     def test_same_potcar_symbol(self):
         # Same symbol different hash thus a different potcar
@@ -1465,8 +1462,8 @@ class MITCompatibilityTest(unittest.TestCase):
         )
 
         compat = MITCompatibility()
-        self.assertEqual(len(compat.process_entries([entry, entry2])), 2)
-        self.assertEqual(len(self.compat.process_entries([entry, entry2])), 1)
+        assert len(compat.process_entries([entry, entry2])) == 2
+        assert len(self.compat.process_entries([entry, entry2])) == 1
 
     def test_revert_to_symbols(self):
         # Test that you can revert to potcar_symbols if potcar_spec is not present
@@ -1483,9 +1480,10 @@ class MITCompatibilityTest(unittest.TestCase):
             },
         )
 
-        self.assertIsNotNone(compat.process_entry(entry))
+        assert compat.process_entry(entry) is not None
         # raise if check_potcar_hash is set
-        self.assertRaises(ValueError, self.compat.process_entry, entry)
+        with pytest.raises(ValueError):
+            self.compat.process_entry(entry)
 
     def test_potcar_doenst_match_structure(self):
         compat = MITCompatibility()
@@ -1501,7 +1499,7 @@ class MITCompatibilityTest(unittest.TestCase):
             },
         )
 
-        self.assertIsNone(compat.process_entry(entry))
+        assert compat.process_entry(entry) is None
 
     def test_potcar_spec_is_none(self):
         compat = MITCompatibility(check_potcar_hash=True)
@@ -1517,7 +1515,7 @@ class MITCompatibilityTest(unittest.TestCase):
             },
         )
 
-        self.assertIsNone(compat.process_entry(entry))
+        assert compat.process_entry(entry) is None
 
     def test_get_explanation_dict(self):
         compat = MITCompatibility(check_potcar_hash=False)
@@ -1542,13 +1540,13 @@ class MITCompatibilityTest(unittest.TestCase):
             },
         )
         d = compat.get_explanation_dict(entry)
-        self.assertEqual("MITRelaxSet Potcar Correction", d["corrections"][0]["name"])
+        assert "MITRelaxSet Potcar Correction" == d["corrections"][0]["name"]
 
     def test_msonable(self):
         compat_dict = self.compat.as_dict()
         decoder = MontyDecoder()
         temp_compat = decoder.process_decoded(compat_dict)
-        self.assertIsInstance(temp_compat, MITCompatibility)
+        assert isinstance(temp_compat, MITCompatibility)
 
 
 class OxideTypeCorrectionTest(unittest.TestCase):
@@ -1578,7 +1576,7 @@ class OxideTypeCorrectionTest(unittest.TestCase):
         )
 
         lio2_entry_corrected = self.compat.process_entry(lio2_entry_nostruct)
-        self.assertAlmostEqual(lio2_entry_corrected.energy, -3 - 0.13893 * 4, 4)
+        assert lio2_entry_corrected.energy == pytest.approx(-3 - 0.13893 * 4)
 
     def test_process_entry_superoxide(self):
         el_li = Element("Li")
@@ -1614,7 +1612,7 @@ class OxideTypeCorrectionTest(unittest.TestCase):
         )
 
         lio2_entry_corrected = self.compat.process_entry(lio2_entry)
-        self.assertAlmostEqual(lio2_entry_corrected.energy, -3 - 0.13893 * 4, 4)
+        assert lio2_entry_corrected.energy == pytest.approx(-3 - 0.13893 * 4)
 
     def test_process_entry_peroxide(self):
         latt = Lattice.from_parameters(3.159597, 3.159572, 7.685205, 89.999884, 89.999674, 60.000510)
@@ -1653,7 +1651,7 @@ class OxideTypeCorrectionTest(unittest.TestCase):
         )
 
         li2o2_entry_corrected = self.compat.process_entry(li2o2_entry)
-        self.assertAlmostEqual(li2o2_entry_corrected.energy, -3 - 0.44317 * 4, 4)
+        assert li2o2_entry_corrected.energy == pytest.approx(-3 - 0.44317 * 4)
 
     def test_process_entry_ozonide(self):
         el_li = Element("Li")
@@ -1688,7 +1686,7 @@ class OxideTypeCorrectionTest(unittest.TestCase):
         )
 
         lio3_entry_corrected = self.compat.process_entry(lio3_entry)
-        self.assertAlmostEqual(lio3_entry_corrected.energy, -3.0)
+        assert lio3_entry_corrected.energy == pytest.approx(-3.0)
 
     def test_process_entry_oxide(self):
         el_li = Element("Li")
@@ -1718,7 +1716,7 @@ class OxideTypeCorrectionTest(unittest.TestCase):
         )
 
         li2o_entry_corrected = self.compat.process_entry(li2o_entry)
-        self.assertAlmostEqual(li2o_entry_corrected.energy, -3.0 - 0.66975, 4)
+        assert li2o_entry_corrected.energy == pytest.approx(-3.0 - 0.66975)
 
 
 class SulfideTypeCorrection2020Test(unittest.TestCase):
@@ -1879,7 +1877,7 @@ class SulfideTypeCorrection2020Test(unittest.TestCase):
         struct_corrected = self.compat.process_entry(na2s2_entry_struct)
         nostruct_corrected = self.compat.process_entry(na2s2_entry_nostruct)
 
-        self.assertAlmostEqual(struct_corrected.correction, nostruct_corrected.correction, 4)
+        assert struct_corrected.correction == pytest.approx(nostruct_corrected.correction)
 
 
 class OxideTypeCorrectionNoPeroxideCorrTest(unittest.TestCase):
@@ -1914,7 +1912,7 @@ class OxideTypeCorrectionNoPeroxideCorrTest(unittest.TestCase):
         )
 
         li2o_entry_corrected = self.compat.process_entry(li2o_entry)
-        self.assertAlmostEqual(li2o_entry_corrected.energy, -3.0 - 0.66975, 4)
+        assert li2o_entry_corrected.energy == pytest.approx(-3.0 - 0.66975)
 
     def test_peroxide_energy_corr(self):
         latt = Lattice.from_parameters(3.159597, 3.159572, 7.685205, 89.999884, 89.999674, 60.000510)
@@ -1953,8 +1951,9 @@ class OxideTypeCorrectionNoPeroxideCorrTest(unittest.TestCase):
         )
 
         li2o2_entry_corrected = self.compat.process_entry(li2o2_entry)
-        self.assertRaises(AssertionError, self.assertAlmostEqual, *(li2o2_entry_corrected.energy, -3 - 0.44317 * 4, 4))
-        self.assertAlmostEqual(li2o2_entry_corrected.energy, -3 - 0.66975 * 4, 4)
+        with pytest.raises(AssertionError):
+            self.assertAlmostEqual(*(li2o2_entry_corrected.energy, -3 - 0.44317 * 4, 4))
+        assert li2o2_entry_corrected.energy == pytest.approx(-3 - 0.66975 * 4)
 
     def test_ozonide(self):
         el_li = Element("Li")
@@ -1989,7 +1988,7 @@ class OxideTypeCorrectionNoPeroxideCorrTest(unittest.TestCase):
         )
 
         lio3_entry_corrected = self.compat.process_entry(lio3_entry)
-        self.assertAlmostEqual(lio3_entry_corrected.energy, -3.0 - 3 * 0.66975)
+        assert lio3_entry_corrected.energy == pytest.approx(-3.0 - 3 * 0.66975)
 
 
 class TestMaterialsProjectAqueousCompatibility:
@@ -2140,19 +2139,19 @@ class AqueousCorrectionTest(unittest.TestCase):
         H2_entry = self.corr.correct_entry(ComputedEntry(Composition("H2"), 3, parameters={"run_type": "GGA"}))
         H2O_entry = self.corr.correct_entry(ComputedEntry(Composition("H2O"), 3, parameters={"run_type": "GGA"}))
         H2O_formation_energy = H2O_entry.energy - (H2_entry.energy + O2_entry.energy / 2.0)
-        self.assertAlmostEqual(H2O_formation_energy, -2.46, 2)
+        assert H2O_formation_energy == pytest.approx(-2.46)
 
         entry = ComputedEntry(Composition("H2O"), -16, parameters={"run_type": "GGA"})
         entry = self.corr.correct_entry(entry)
-        self.assertAlmostEqual(entry.energy, -14.916, 4)
+        assert entry.energy == pytest.approx(-14.916)
 
         entry = ComputedEntry(Composition("H2O"), -24, parameters={"run_type": "GGA"})
         entry = self.corr.correct_entry(entry)
-        self.assertAlmostEqual(entry.energy, -14.916, 4)
+        assert entry.energy == pytest.approx(-14.916)
 
         entry = ComputedEntry(Composition("Cl"), -24, parameters={"run_type": "GGA"})
         entry = self.corr.correct_entry(entry)
-        self.assertAlmostEqual(entry.energy, -24.344373, 4)
+        assert entry.energy == pytest.approx(-24.344373)
 
 
 class MITAqueousCompatibilityTest(unittest.TestCase):
@@ -2205,7 +2204,7 @@ class MITAqueousCompatibilityTest(unittest.TestCase):
         lioh_entry_compat = self.compat.process_entry(lioh_entry)
         lioh_entry_compat_aqcorr = self.aqcorr.correct_entry(lioh_entry_compat)
         lioh_entry_aqcompat = self.aqcompat.process_entry(lioh_entry)
-        self.assertAlmostEqual(lioh_entry_compat_aqcorr.energy, lioh_entry_aqcompat.energy, 4)
+        assert lioh_entry_compat_aqcorr.energy == pytest.approx(lioh_entry_aqcompat.energy)
 
     def test_potcar_doenst_match_structure(self):
         compat = MITCompatibility()
@@ -2235,13 +2234,13 @@ class MITAqueousCompatibilityTest(unittest.TestCase):
             },
         )
 
-        self.assertIsNone(compat.process_entry(lioh_entry))
+        assert compat.process_entry(lioh_entry) is None
 
     def test_msonable(self):
         compat_dict = self.aqcompat.as_dict()
         decoder = MontyDecoder()
         temp_compat = decoder.process_decoded(compat_dict)
-        self.assertIsInstance(temp_compat, MITAqueousCompatibility)
+        assert isinstance(temp_compat, MITAqueousCompatibility)
 
     def test_dont_error_on_weird_elements(self):
         entry = ComputedEntry(
@@ -2261,7 +2260,7 @@ class MITAqueousCompatibilityTest(unittest.TestCase):
                 ]
             },
         )
-        self.assertIsNone(self.compat.process_entry(entry))
+        assert self.compat.process_entry(entry) is None
 
 
 class CorrectionErrors2020CompatibilityTest(unittest.TestCase):
@@ -2377,28 +2376,19 @@ class CorrectionErrors2020CompatibilityTest(unittest.TestCase):
 
     def test_errors(self):
         entry1_corrected = self.compat.process_entry(self.entry1)
-        self.assertAlmostEqual(
-            entry1_corrected.correction_uncertainty,
-            sqrt((2 * 0.0101) ** 2 + (3 * 0.002) ** 2),
-        )
+        assert entry1_corrected.correction_uncertainty == pytest.approx(sqrt((2 * 0.0101) ** 2 + (3 * 0.002) ** 2))
 
         entry2_corrected = self.compat.process_entry(self.entry2)
-        self.assertAlmostEqual(
-            entry2_corrected.correction_uncertainty,
-            sqrt((3 * 0.0101) ** 2 + (4 * 0.002) ** 2),
-        )
+        assert entry2_corrected.correction_uncertainty == pytest.approx(sqrt((3 * 0.0101) ** 2 + (4 * 0.002) ** 2))
 
         entry_sulfide_corrected = self.compat.process_entry(self.entry_sulfide)
-        self.assertAlmostEqual(entry_sulfide_corrected.correction_uncertainty, 0.0093)
+        assert entry_sulfide_corrected.correction_uncertainty == pytest.approx(0.0093)
 
         entry_fluoride_corrected = self.compat.process_entry(self.entry_fluoride)
-        self.assertAlmostEqual(
-            entry_fluoride_corrected.correction_uncertainty,
-            sqrt((3 * 0.0026) ** 2 + 0.0101**2),
-        )
+        assert entry_fluoride_corrected.correction_uncertainty == pytest.approx(sqrt((3 * 0.0026) ** 2 + 0.0101**2))
 
         entry_hydride_corrected = self.compat.process_entry(self.entry_hydride)
-        self.assertAlmostEqual(entry_hydride_corrected.correction_uncertainty, 0.0013)
+        assert entry_hydride_corrected.correction_uncertainty == pytest.approx(0.0013)
 
 
 if __name__ == "__main__":

--- a/pymatgen/entries/tests/test_computed_entries.py
+++ b/pymatgen/entries/tests/test_computed_entries.py
@@ -96,43 +96,43 @@ class ComputedEntryTest(unittest.TestCase):
         self.entry7 = ComputedEntry("Fe6O9", 6.9, energy_adjustments=[ea])
 
     def test_energy(self):
-        self.assertAlmostEqual(self.entry.energy, -269.38319884)
+        assert self.entry.energy == pytest.approx(-269.38319884)
         self.entry.correction = 1.0
-        self.assertAlmostEqual(self.entry.energy, -268.38319884)
-        self.assertAlmostEqual(self.entry3.energy_per_atom, 2.3 / 5)
+        assert self.entry.energy == pytest.approx(-268.38319884)
+        assert self.entry3.energy_per_atom == pytest.approx(2.3 / 5)
 
     def test_composition(self):
-        self.assertEqual(self.entry.composition.reduced_formula, "LiFe4(PO4)4")
-        self.assertEqual(self.entry2.composition.reduced_formula, "Fe2O3")
-        self.assertEqual(self.entry5.composition.reduced_formula, "Fe2O3")
-        self.assertEqual(self.entry5.composition.get_reduced_formula_and_factor()[1], 3)
+        assert self.entry.composition.reduced_formula == "LiFe4(PO4)4"
+        assert self.entry2.composition.reduced_formula == "Fe2O3"
+        assert self.entry5.composition.reduced_formula == "Fe2O3"
+        assert self.entry5.composition.get_reduced_formula_and_factor()[1] == 3
 
     def test_per_atom_props(self):
         entry = ComputedEntry("Fe6O9", 6.9)
         entry.energy_adjustments.append(CompositionEnergyAdjustment(-0.5, 9, uncertainty_per_atom=0.1, name="O"))
-        self.assertAlmostEqual(entry.energy, 2.4)
-        self.assertAlmostEqual(entry.energy_per_atom, 2.4 / 15)
-        self.assertAlmostEqual(entry.uncorrected_energy, 6.9)
-        self.assertAlmostEqual(entry.uncorrected_energy_per_atom, 6.9 / 15)
-        self.assertAlmostEqual(entry.correction, -4.5)
-        self.assertAlmostEqual(entry.correction_per_atom, -4.5 / 15)
-        self.assertAlmostEqual(entry.correction_uncertainty, 0.9)
-        self.assertAlmostEqual(entry.correction_uncertainty_per_atom, 0.9 / 15)
+        assert entry.energy == pytest.approx(2.4)
+        assert entry.energy_per_atom == pytest.approx(2.4 / 15)
+        assert entry.uncorrected_energy == pytest.approx(6.9)
+        assert entry.uncorrected_energy_per_atom == pytest.approx(6.9 / 15)
+        assert entry.correction == pytest.approx(-4.5)
+        assert entry.correction_per_atom == pytest.approx(-4.5 / 15)
+        assert entry.correction_uncertainty == pytest.approx(0.9)
+        assert entry.correction_uncertainty_per_atom == pytest.approx(0.9 / 15)
 
     def test_normalize(self):
         entry = ComputedEntry("Fe6O9", 6.9, correction=1)
         entry_formula = entry.normalize()
-        self.assertEqual(entry_formula.composition.formula, "Fe2 O3")
-        self.assertAlmostEqual(entry_formula.uncorrected_energy, 6.9 / 3)
-        self.assertAlmostEqual(entry_formula.correction, 1 / 3)
-        self.assertAlmostEqual(entry_formula.energy * 3, 6.9 + 1)
-        self.assertAlmostEqual(entry_formula.energy_adjustments[0].value, 1 / 3)
+        assert entry_formula.composition.formula == "Fe2 O3"
+        assert entry_formula.uncorrected_energy == pytest.approx(6.9 / 3)
+        assert entry_formula.correction == pytest.approx(1 / 3)
+        assert entry_formula.energy * 3 == pytest.approx(6.9 + 1)
+        assert entry_formula.energy_adjustments[0].value == pytest.approx(1 / 3)
         entry_atom = entry.normalize("atom")
-        self.assertEqual(entry_atom.composition.formula, "Fe0.4 O0.6")
-        self.assertAlmostEqual(entry_atom.uncorrected_energy, 6.9 / 15)
-        self.assertAlmostEqual(entry_atom.correction, 1 / 15)
-        self.assertAlmostEqual(entry_atom.energy * 15, 6.9 + 1)
-        self.assertAlmostEqual(entry_atom.energy_adjustments[0].value, 1 / 15)
+        assert entry_atom.composition.formula == "Fe0.4 O0.6"
+        assert entry_atom.uncorrected_energy == pytest.approx(6.9 / 15)
+        assert entry_atom.correction == pytest.approx(1 / 15)
+        assert entry_atom.energy * 15 == pytest.approx(6.9 + 1)
+        assert entry_atom.energy_adjustments[0].value == pytest.approx(1 / 15)
 
     def test_normalize_energy_adjustments(self):
         ealist = [
@@ -151,8 +151,8 @@ class ComputedEntryTest(unittest.TestCase):
     def test_to_from_dict(self):
         d = self.entry.as_dict()
         e = ComputedEntry.from_dict(d)
-        self.assertEqual(self.entry, e)
-        self.assertAlmostEqual(e.energy, -269.38319884)
+        assert self.entry == e
+        assert e.energy == pytest.approx(-269.38319884)
 
     def test_to_from_dict_with_adjustment(self):
         """
@@ -160,8 +160,8 @@ class ComputedEntryTest(unittest.TestCase):
         """
         d = self.entry6.as_dict()
         e = ComputedEntry.from_dict(d)
-        self.assertAlmostEqual(e.uncorrected_energy, 6.9)
-        self.assertEqual(e.energy_adjustments[0].value, self.entry6.energy_adjustments[0].value)
+        assert e.uncorrected_energy == pytest.approx(6.9)
+        assert e.energy_adjustments[0].value == self.entry6.energy_adjustments[0].value
 
     def test_to_from_dict_with_adjustment_2(self):
         """
@@ -169,8 +169,8 @@ class ComputedEntryTest(unittest.TestCase):
         """
         d = self.entry7.as_dict()
         e = ComputedEntry.from_dict(d)
-        self.assertAlmostEqual(e.uncorrected_energy, 6.9)
-        self.assertEqual(e.energy_adjustments[0].value, self.entry7.energy_adjustments[0].value)
+        assert e.uncorrected_energy == pytest.approx(6.9)
+        assert e.energy_adjustments[0].value == self.entry7.energy_adjustments[0].value
 
     def test_to_from_dict_with_adjustment_3(self):
         """
@@ -189,8 +189,8 @@ class ComputedEntryTest(unittest.TestCase):
             "correction": -10,
         }
         e = ComputedEntry.from_dict(d)
-        self.assertAlmostEqual(e.uncorrected_energy, 6.9)
-        self.assertAlmostEqual(e.correction, -10)
+        assert e.uncorrected_energy == pytest.approx(6.9)
+        assert e.correction == pytest.approx(-10)
         assert len(e.energy_adjustments) == 1
 
     def test_conflicting_correction_adjustment(self):
@@ -203,22 +203,22 @@ class ComputedEntryTest(unittest.TestCase):
             ComputedEntry("Fe6O9", 6.9, correction=-10, energy_adjustments=[ea])
 
     def test_entry_id(self):
-        self.assertEqual(self.entry4.entry_id, 1)
-        self.assertEqual(self.entry2.entry_id, None)
+        assert self.entry4.entry_id == 1
+        assert self.entry2.entry_id is None
 
     def test_str(self):
-        self.assertIsNotNone(str(self.entry))
+        assert str(self.entry) is not None
 
     def test_sulfide_energy(self):
         self.entry = ComputedEntry("BaS", -10.21249155)
-        self.assertAlmostEqual(self.entry.energy, -10.21249155)
-        self.assertAlmostEqual(self.entry.energy_per_atom, -10.21249155 / 2)
+        assert self.entry.energy == pytest.approx(-10.21249155)
+        assert self.entry.energy_per_atom == pytest.approx(-10.21249155 / 2)
         self.entry.correction = 1.0
-        self.assertAlmostEqual(self.entry.energy, -9.21249155)
+        assert self.entry.energy == pytest.approx(-9.21249155)
 
     def test_is_element(self):
         entry = ComputedEntry("Fe3", 2.3)
-        self.assertTrue(entry.is_element)
+        assert entry.is_element
 
 
 class ComputedStructureEntryTest(unittest.TestCase):
@@ -226,21 +226,21 @@ class ComputedStructureEntryTest(unittest.TestCase):
         self.entry = ComputedStructureEntry(vasprun.final_structure, vasprun.final_energy, parameters=vasprun.incar)
 
     def test_energy(self):
-        self.assertAlmostEqual(self.entry.energy, -269.38319884)
+        assert self.entry.energy == pytest.approx(-269.38319884)
         self.entry.correction = 1.0
-        self.assertAlmostEqual(self.entry.energy, -268.38319884)
+        assert self.entry.energy == pytest.approx(-268.38319884)
 
     def test_composition(self):
-        self.assertEqual(self.entry.composition.reduced_formula, "LiFe4(PO4)4")
+        assert self.entry.composition.reduced_formula == "LiFe4(PO4)4"
 
     def test_to_from_dict(self):
         d = self.entry.as_dict()
         e = ComputedStructureEntry.from_dict(d)
-        self.assertEqual(self.entry, e)
-        self.assertAlmostEqual(e.energy, -269.38319884)
+        assert self.entry == e
+        assert e.energy == pytest.approx(-269.38319884)
 
     def test_str(self):
-        self.assertIsNotNone(str(self.entry))
+        assert str(self.entry) is not None
 
     def test_to_from_dict_structure_with_adjustment_3(self):
         """
@@ -380,9 +380,9 @@ class ComputedStructureEntryTest(unittest.TestCase):
             },
         }
         e = ComputedEntry.from_dict(d)
-        self.assertAlmostEqual(e.uncorrected_energy, -39.42116819)
-        self.assertAlmostEqual(e.energy, -38.42116819)
-        self.assertAlmostEqual(e.correction, 1)
+        assert e.uncorrected_energy == pytest.approx(-39.42116819)
+        assert e.energy == pytest.approx(-38.42116819)
+        assert e.correction == pytest.approx(1)
         assert len(e.energy_adjustments) == 1
 
 
@@ -420,42 +420,42 @@ class GibbsComputedStructureEntryTest(unittest.TestCase):
             1800: -32.32513382051749,
         }
         for t in self.temps:
-            self.assertAlmostEqual(self.entries_with_temps[t].energy, energies[t])
+            assert self.entries_with_temps[t].energy == pytest.approx(energies[t])
 
     def test_interpolation(self):
         temp = 450
         e = GibbsComputedStructureEntry(self.struct, -2.436, temp=temp)
-        self.assertAlmostEqual(e.energy, -53.7243542548528)
+        assert e.energy == pytest.approx(-53.7243542548528)
 
     def test_expt_gas_entry(self):
         co2_entry = GibbsComputedStructureEntry(self.co2_struct, 0, temp=900)
-        self.assertAlmostEqual(co2_entry.energy, -16.406560223724014)
-        self.assertAlmostEqual(co2_entry.energy_per_atom, -1.3672133519770011)
+        assert co2_entry.energy == pytest.approx(-16.406560223724014)
+        assert co2_entry.energy_per_atom == pytest.approx(-1.3672133519770011)
 
     def test_from_entries(self):
         gibbs_entries = GibbsComputedStructureEntry.from_entries(self.mp_entries)
-        self.assertIsNotNone(gibbs_entries)
+        assert gibbs_entries is not None
 
     def test_from_pd(self):
         pd = PhaseDiagram(self.mp_entries)
         gibbs_entries = GibbsComputedStructureEntry.from_pd(pd)
-        self.assertIsNotNone(gibbs_entries)
+        assert gibbs_entries is not None
 
     def test_to_from_dict(self):
         test_entry = self.entries_with_temps[300]
         d = test_entry.as_dict()
         e = GibbsComputedStructureEntry.from_dict(d)
-        self.assertEqual(test_entry, e)
-        self.assertAlmostEqual(e.energy, test_entry.energy)
+        assert test_entry == e
+        assert e.energy == pytest.approx(test_entry.energy)
 
     def test_str(self):
-        self.assertIsNotNone(str(self.entries_with_temps[300]))
+        assert str(self.entries_with_temps[300]) is not None
 
     def test_normalize(self):
         for e in self.entries_with_temps.values():
             entry = copy.deepcopy(e)
             normed_entry = entry.normalize(mode="atom")
-            self.assertAlmostEqual(entry.uncorrected_energy, normed_entry.uncorrected_energy * self.num_atoms, 11)
+            assert entry.uncorrected_energy == pytest.approx(normed_entry.uncorrected_energy * self.num_atoms)
 
 
 if __name__ == "__main__":

--- a/pymatgen/entries/tests/test_correction_calculator.py
+++ b/pymatgen/entries/tests/test_correction_calculator.py
@@ -1,6 +1,8 @@
 import os
 import unittest
 
+import pytest
+
 from pymatgen.entries.correction_calculator import CorrectionCalculator
 from pymatgen.util.testing import PymatgenTest
 
@@ -113,7 +115,7 @@ class CorrectionCalculatorTest(unittest.TestCase):
         calculator = CorrectionCalculator(exclude_polyanions=self.exclude_polyanions)
         corrs = calculator.compute_from_files(exp_path, calc_path)
 
-        self.assertDictEqual(corrs, self.normal_corrections)
+        assert corrs == self.normal_corrections
 
     def test_warnings_options(self):
         """
@@ -126,7 +128,7 @@ class CorrectionCalculatorTest(unittest.TestCase):
         calculator = CorrectionCalculator(max_error=1, exclude_polyanions=[], allow_unstable=True)
         corrs = calculator.compute_from_files(exp_path, calc_path)
 
-        self.assertDictEqual(corrs, self.warnings_allowed_corrections)
+        assert corrs == self.warnings_allowed_corrections
 
     def test_no_uncertainties(self):
         """
@@ -139,7 +141,7 @@ class CorrectionCalculatorTest(unittest.TestCase):
         calculator = CorrectionCalculator(exclude_polyanions=self.exclude_polyanions)
         corrs = calculator.compute_from_files(exp_path, calc_path)
 
-        self.assertDictEqual(corrs, self.no_uncertainties_corrections)
+        assert corrs == self.no_uncertainties_corrections
 
     def test_missing_entry_response(self):
         """
@@ -150,7 +152,7 @@ class CorrectionCalculatorTest(unittest.TestCase):
         calc_path = os.path.join(self.test_dir, "calc_missing_compounds.json.gz")
 
         calculator = CorrectionCalculator(exclude_polyanions=self.exclude_polyanions)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             calculator.compute_from_files(exp_path, calc_path)
 
 

--- a/pymatgen/entries/tests/test_entry_tools.py
+++ b/pymatgen/entries/tests/test_entry_tools.py
@@ -6,6 +6,7 @@ import os
 import unittest
 from pathlib import Path
 
+import pytest
 from monty.serialization import dumpfn, loadfn
 
 from pymatgen.core.periodic_table import Element
@@ -24,10 +25,10 @@ class FuncTest(unittest.TestCase):
     def test_group_entries_by_structure(self):
         entries = loadfn(os.path.join(PymatgenTest.TEST_FILES_DIR, "TiO2_entries.json"))
         groups = group_entries_by_structure(entries)
-        self.assertEqual(sorted(len(g) for g in groups), [1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 4])
-        self.assertLess(len(groups), len(entries))
+        assert sorted(len(g) for g in groups) == [1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 4]
+        assert len(groups) < len(entries)
         # Make sure no entries are left behind
-        self.assertEqual(sum(len(g) for g in groups), len(entries))
+        assert sum(len(g) for g in groups) == len(entries)
 
     def test_group_entries_by_composition(self):
         entries = [
@@ -41,10 +42,10 @@ class FuncTest(unittest.TestCase):
         ]
 
         groups = group_entries_by_composition(entries)
-        self.assertEqual(sorted(len(g) for g in groups), [2, 2, 3])
-        self.assertLess(len(groups), len(entries))
+        assert sorted(len(g) for g in groups) == [2, 2, 3]
+        assert len(groups) < len(entries)
         # Make sure no entries are left behind
-        self.assertEqual(sum(len(g) for g in groups), len(entries))
+        assert sum(len(g) for g in groups) == len(entries)
         # test sorting by energy
         for g in groups:
             assert g == sorted(g, key=lambda e: e.energy_per_atom)
@@ -56,23 +57,24 @@ class EntrySetTest(unittest.TestCase):
         self.entry_set = EntrySet(entries)
 
     def test_chemsys(self):
-        self.assertEqual(self.entry_set.chemsys, {"Fe", "Li", "O", "P"})
+        assert self.entry_set.chemsys == {"Fe", "Li", "O", "P"}
 
     def test_get_subset(self):
         entries = self.entry_set.get_subset_in_chemsys(["Li", "O"])
         for e in entries:
-            self.assertTrue({Element.Li, Element.O}.issuperset(e.composition))
-        self.assertRaises(ValueError, self.entry_set.get_subset_in_chemsys, ["Fe", "F"])
+            assert {Element.Li, Element.O}.issuperset(e.composition)
+        with pytest.raises(ValueError):
+            self.entry_set.get_subset_in_chemsys(["Fe", "F"])
 
     def test_remove_non_ground_states(self):
         l = len(self.entry_set)
         self.entry_set.remove_non_ground_states()
-        self.assertLess(len(self.entry_set), l)
+        assert len(self.entry_set) < l
 
     def test_as_dict(self):
         dumpfn(self.entry_set, "temp_entry_set.json")
         entry_set = loadfn("temp_entry_set.json")
-        self.assertEqual(len(entry_set), len(self.entry_set))
+        assert len(entry_set) == len(self.entry_set)
         os.remove("temp_entry_set.json")
 
 

--- a/pymatgen/entries/tests/test_exp_entries.py
+++ b/pymatgen/entries/tests/test_exp_entries.py
@@ -19,15 +19,15 @@ class ExpEntryTest(unittest.TestCase):
         self.entry = ExpEntry("Fe2O3", thermodata)
 
     def test_energy(self):
-        self.assertAlmostEqual(self.entry.energy, -825.5)
+        assert round(abs(self.entry.energy - -825.5), 7) == 0
 
     def test_to_from_dict(self):
         d = self.entry.as_dict()
         e = ExpEntry.from_dict(d)
-        self.assertAlmostEqual(e.energy, -825.5)
+        assert round(abs(e.energy - -825.5), 7) == 0
 
     def test_str(self):
-        self.assertIsNotNone(str(self.entry))
+        assert str(self.entry) is not None
 
 
 if __name__ == "__main__":

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,4 +70,4 @@ expand-star-imports = true
 ignore-init-module-imports = true
 
 [codespell]
-ignore-words-list = titel,alls,ans,nd,mater,nwo,te,hart,ontop,ist,ot,
+ignore-words-list = titel,alls,ans,nd,mater,nwo,te,hart,ontop,ist,ot,fo


### PR DESCRIPTION
The `text-linux` and `lint` CI workflows currently run twice for every PR due to being triggered both by push and PR to _any_ branch:

```yml
name: Testing Linux

on: [push, pull_request]
```

![Screen Shot 2022-10-20 at 12 00 16](https://user-images.githubusercontent.com/30958850/197035102-46e3f011-b153-4eb1-95dd-563e4a1f6a6c.png)

We can run only once, thereby saving time, CI budget and energy (esp. with `test-linux` which takes long), by triggering only on push/PR to `master`:

```yml
on:
  push:
    branches: [master]
  pull_request:
    branches: [master]
```