### PR TITLE
Define `EntryLike` in `pymatgen/util/typing.py`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,6 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-
 ---
 
 **Describe the bug**
@@ -24,8 +23,9 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
- - OS: [e.g. Mac,Windows,Linux]
- - Version [e.g. 2019.9.16]
+
+- OS: [e.g. Mac,Windows,Linux]
+- Version [e.g. 2019.9.16]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,6 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,15 +7,6 @@ Include a summary of major changes in bullet points:
 - Fix 1
 - Fix 2
 
-## Additional dependencies introduced (if any)
-
-- List all new dependencies needed and justify why. While adding dependencies that bring
-significantly useful functionality is perfectly fine, adding ones that
-add trivial functionality, e.g., to use one single easily implementable
-function, is frowned upon. Provide a justification why that dependency is needed.
-Especially frowned upon are circular dependencies, e.g., depending on derivative
-modules of pymatgen such as custodian or Fireworks.
-
 ## TODO (if any)
 
 If this is a work-in-progress, write something about what else needs
@@ -30,18 +21,11 @@ in the pull request title.
 
 Before a pull request can be merged, the following items must be checked:
 
-- [ ] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). The easiest way to handle this
-      is to run the following in the **correct sequence*- on your local machine. Start with running
-      [black](https://black.readthedocs.io/en/stable/index.html) on your new code. This will automatically reformat
-      your code to PEP8 conventions and removes most issues. Then run
-      [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/), followed by
-      [flake8](http://flake8.pycqa.org/en/latest/).
 - [ ] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
       Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
-- [ ] Type annotations are **highly*- encouraged. Run [mypy](https://github.com/python/mypy) to type check your code.
+- [ ] Type annotations are **highly*- encouraged. Run [`mypy`](https://github.com/python/mypy) `path/to/file.py` to type check your code.
 - [ ] Tests have been added for any new functionality or bug fixes.
 - [ ] All linting and tests pass.
 
 Note that the CI system will run all the above checks. But it will be much more efficient if you already fix most
-errors prior to submitting the PR. It is highly recommended that you use the `pre-commit` hooks specified in the pymatgen
-repo. Simply `pip install -U pre-commit && pre-commit install` and linters will run prior to every commit.
+errors prior to submitting the PR. We highly recommended installing `pre-commit` hooks. Simply `pip install -U pre-commit && pre-commit install` in the repo's root directory. Afterwards linters will run before every commit and abort if any issues pop up.

--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -510,19 +510,18 @@ class PhaseDiagram(MSONable):
         return np.array(data)[:, 1:]
 
     @property
-    def unstable_entries(self):
+    def unstable_entries(self) -> set[Entry]:
         """
         Returns:
-            list of Entries that are unstable in the phase diagram.
-                Includes positive formation energy entries.
+            set[Entry]: unstable entries in the phase diagram. Includes positive formation energy entries.
         """
-        return [e for e in self.all_entries if e not in self.stable_entries]
+        return {e for e in self.all_entries if e not in self.stable_entries}
 
     @property
-    def stable_entries(self):
+    def stable_entries(self) -> set[Entry]:
         """
         Returns:
-            the set of stable entries in the phase diagram.
+            set[Entry]: of stable entries in the phase diagram.
         """
         return set(self._stable_entries)
 
@@ -537,7 +536,7 @@ class PhaseDiagram(MSONable):
         """
         return [e for e, s in zip(self._stable_entries, self._stable_spaces) if space.issuperset(s)]
 
-    def get_reference_energy_per_atom(self, comp):
+    def get_reference_energy_per_atom(self, comp: Composition) -> float:
         """
         Args:
             comp (Composition): Input composition
@@ -556,7 +555,7 @@ class PhaseDiagram(MSONable):
             entry (PDEntry): A PDEntry-like object.
 
         Returns:
-            Formation energy from the elemental references.
+            float: Formation energy from the elemental references.
         """
         comp = entry.composition
         return entry.energy - sum(comp[el] * self.el_refs[el].energy_per_atom for el in comp.elements)
@@ -574,7 +573,7 @@ class PhaseDiagram(MSONable):
         """
         return self.get_form_energy(entry) / entry.composition.num_atoms
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         symbols = [el.symbol for el in self.elements]
         output = [
             f"{'-'.join(symbols)} phase diagram",
@@ -584,7 +583,7 @@ class PhaseDiagram(MSONable):
         return "\n".join(output)
 
     @lru_cache(1)
-    def _get_facet_and_simplex(self, comp):
+    def _get_facet_and_simplex(self, comp: Composition) -> tuple[Simplex, Simplex]:
         """
         Get any facet that a composition falls into. Cached so successive
         calls at same composition are fast.
@@ -885,7 +884,7 @@ class PhaseDiagram(MSONable):
             return self.get_decomp_and_e_above_hull(entry, allow_negative=True, **kwargs)
 
         # take entries with negative e_form and different compositions as competing entries
-        competing_entries = [c for c in compare_entries if id(c) not in same_comp_mem_ids]
+        competing_entries = {c for c in compare_entries if id(c) not in same_comp_mem_ids}
 
         # NOTE SLSQP optimizer doesn't scale well for > 300 competing entries.
         if len(competing_entries) > space_limit and not stable_only:
@@ -905,7 +904,7 @@ class PhaseDiagram(MSONable):
             inner_hull = PhaseDiagram(reduced_space)
 
             competing_entries = inner_hull.stable_entries.union(self._get_stable_entries_in_space(entry_elems))
-            competing_entries = [c for c in compare_entries if id(c) not in same_comp_mem_ids]
+            competing_entries = {c for c in compare_entries if id(c) not in same_comp_mem_ids}
 
         if len(competing_entries) > space_limit:
             warnings.warn(
@@ -1969,7 +1968,7 @@ class PhaseDiagramError(Exception):
     """
 
 
-def get_facets(qhull_data, joggle=False):
+def get_facets(qhull_data: np.ndarray, joggle: bool = False) -> ConvexHull:
     """
     Get the simplex facets for the Convex hull.
 

--- a/pymatgen/apps/battery/tests/test_insertion_battery.py
+++ b/pymatgen/apps/battery/tests/test_insertion_battery.py
@@ -6,6 +6,7 @@ import json
 import os
 import unittest
 
+import pytest
 from monty.json import MontyDecoder, MontyEncoder
 
 from pymatgen.apps.battery.insertion_battery import (
@@ -39,47 +40,47 @@ class InsertionElectrodeTest(unittest.TestCase):
 
     def test_voltage(self):
         # test basic voltage
-        self.assertAlmostEqual(self.ie_LTO.max_voltage, 2.78583901, 3)
-        self.assertAlmostEqual(self.ie_LTO.min_voltage, 0.89702381, 3)
-        self.assertAlmostEqual(self.ie_LTO.get_average_voltage(), 1.84143141, 3)
+        assert self.ie_LTO.max_voltage == pytest.approx(2.78583901)
+        assert self.ie_LTO.min_voltage == pytest.approx(0.89702381)
+        assert self.ie_LTO.get_average_voltage() == pytest.approx(1.84143141)
         # test voltage range selectors
-        self.assertAlmostEqual(self.ie_LTO.get_average_voltage(0, 1), 0.89702381, 3)
-        self.assertAlmostEqual(self.ie_LTO.get_average_voltage(2, 3), 2.78583901, 3)
+        assert self.ie_LTO.get_average_voltage(0, 1) == pytest.approx(0.89702381)
+        assert self.ie_LTO.get_average_voltage(2, 3) == pytest.approx(2.78583901)
         # test non-existing voltage range
-        self.assertAlmostEqual(self.ie_LTO.get_average_voltage(0, 0.1), 0, 3)
-        self.assertAlmostEqual(self.ie_LTO.get_average_voltage(4, 5), 0, 3)
+        assert self.ie_LTO.get_average_voltage(0, 0.1) == pytest.approx(0)
+        assert self.ie_LTO.get_average_voltage(4, 5) == pytest.approx(0)
 
-        self.assertAlmostEqual(self.ie_MVO.get_average_voltage(), 2.513767, 3)
+        assert self.ie_MVO.get_average_voltage() == pytest.approx(2.513767)
 
     def test_capacities(self):
         # test basic capacity
-        self.assertAlmostEqual(self.ie_LTO.get_capacity_grav(), 308.74865045, 3)
-        self.assertAlmostEqual(self.ie_LTO.get_capacity_vol(), 1205.99391136, 3)
+        assert self.ie_LTO.get_capacity_grav() == pytest.approx(308.74865045)
+        assert self.ie_LTO.get_capacity_vol() == pytest.approx(1205.99391136)
 
         # test capacity selector
-        self.assertAlmostEqual(self.ie_LTO.get_capacity_grav(1, 3), 154.374325225, 3)
+        assert self.ie_LTO.get_capacity_grav(1, 3) == pytest.approx(154.374325225)
 
         # test alternate normalization option
-        self.assertAlmostEqual(self.ie_LTO.get_capacity_grav(1, 3, False), 160.803169506, 3)
-        self.assertIsNotNone(self.ie_LTO.get_summary_dict(True))
+        assert self.ie_LTO.get_capacity_grav(1, 3, False) == pytest.approx(160.803169506)
+        assert self.ie_LTO.get_summary_dict(True) is not None
 
-        self.assertAlmostEqual(self.ie_MVO.get_capacity_grav(), 281.845548242, 3)
-        self.assertAlmostEqual(self.ie_MVO.get_capacity_vol(), 1145.80087994, 3)
+        assert self.ie_MVO.get_capacity_grav() == pytest.approx(281.845548242)
+        assert self.ie_MVO.get_capacity_vol() == pytest.approx(1145.80087994)
 
     def test_get_instability(self):
-        self.assertIsNone(self.ie_LTO.get_max_instability())
-        self.assertAlmostEqual(self.ie_MVO.get_max_instability(), 0.7233711650000014)
-        self.assertAlmostEqual(self.ie_MVO.get_min_instability(), 0.4913575099999994)
+        assert self.ie_LTO.get_max_instability() is None
+        assert self.ie_MVO.get_max_instability() == pytest.approx(0.7233711650000014)
+        assert self.ie_MVO.get_min_instability() == pytest.approx(0.4913575099999994)
 
     def test_get_muO2(self):
-        self.assertIsNone(self.ie_LTO.get_max_muO2())
-        self.assertAlmostEqual(self.ie_MVO.get_max_muO2(), -4.93552791875)
-        self.assertAlmostEqual(self.ie_MVO.get_min_muO2(), -11.06599657)
+        assert self.ie_LTO.get_max_muO2() is None
+        assert self.ie_MVO.get_max_muO2() == pytest.approx(-4.93552791875)
+        assert self.ie_MVO.get_min_muO2() == pytest.approx(-11.06599657)
 
     def test_entries(self):
         # test that the proper number of sub-electrodes are returned
-        self.assertEqual(len(self.ie_LTO.get_sub_electrodes(False, True)), 3)
-        self.assertEqual(len(self.ie_LTO.get_sub_electrodes(True, True)), 2)
+        assert len(self.ie_LTO.get_sub_electrodes(False, True)) == 3
+        assert len(self.ie_LTO.get_sub_electrodes(True, True)) == 2
 
     def test_get_all_entries(self):
         self.ie_LTO.get_all_entries()
@@ -87,44 +88,44 @@ class InsertionElectrodeTest(unittest.TestCase):
     def test_to_from_dict(self):
         d = self.ie_LTO.as_dict()
         ie = InsertionElectrode.from_dict(d)
-        self.assertAlmostEqual(ie.max_voltage, 2.78583901, 3)
-        self.assertAlmostEqual(ie.min_voltage, 0.89702381, 3)
-        self.assertAlmostEqual(ie.get_average_voltage(), 1.84143141, 3)
+        assert ie.max_voltage == pytest.approx(2.78583901)
+        assert ie.min_voltage == pytest.approx(0.89702381)
+        assert ie.get_average_voltage() == pytest.approx(1.84143141)
 
         # Just to make sure json string works.
         json_str = json.dumps(self.ie_LTO, cls=MontyEncoder)
         ie = json.loads(json_str, cls=MontyDecoder)
-        self.assertAlmostEqual(ie.max_voltage, 2.78583901, 3)
-        self.assertAlmostEqual(ie.min_voltage, 0.89702381, 3)
-        self.assertAlmostEqual(ie.get_average_voltage(), 1.84143141, 3)
+        assert ie.max_voltage == pytest.approx(2.78583901)
+        assert ie.min_voltage == pytest.approx(0.89702381)
+        assert ie.get_average_voltage() == pytest.approx(1.84143141)
 
     def test_voltage_pair(self):
         vpair = self.ie_LTO[0]
-        self.assertAlmostEqual(vpair.voltage, 2.78583901)
-        self.assertAlmostEqual(vpair.mAh, 13400.7411749, 2)
-        self.assertAlmostEqual(vpair.mass_charge, 79.8658)
-        self.assertAlmostEqual(vpair.mass_discharge, 83.3363)
-        self.assertAlmostEqual(vpair.vol_charge, 37.553684467)
-        self.assertAlmostEqual(vpair.vol_discharge, 37.917719932)
-        self.assertAlmostEqual(vpair.frac_charge, 0.0)
-        self.assertAlmostEqual(vpair.frac_discharge, 0.14285714285714285)
-        self.assertAlmostEqual(vpair.x_charge, 0.0)
-        self.assertAlmostEqual(vpair.x_discharge, 0.5)
+        assert vpair.voltage == pytest.approx(2.78583901)
+        assert vpair.mAh == pytest.approx(13400.7411749)
+        assert vpair.mass_charge == pytest.approx(79.8658)
+        assert vpair.mass_discharge == pytest.approx(83.3363)
+        assert vpair.vol_charge == pytest.approx(37.553684467)
+        assert vpair.vol_discharge == pytest.approx(37.917719932)
+        assert vpair.frac_charge == pytest.approx(0.0)
+        assert vpair.frac_discharge == pytest.approx(0.14285714285714285)
+        assert vpair.x_charge == pytest.approx(0.0)
+        assert vpair.x_discharge == pytest.approx(0.5)
         # reconstruct the voltage pair
         dd = vpair.as_dict()
         vv = InsertionVoltagePair.from_dict(dd)
-        self.assertAlmostEqual(vv.entry_charge.energy, -105.53608265)
-        self.assertAlmostEqual(vv.voltage, 2.78583901)
+        assert vv.entry_charge.energy == pytest.approx(-105.53608265)
+        assert vv.voltage == pytest.approx(2.78583901)
 
     def test_get_summary_dict(self):
         d = self.ie_CMO.get_summary_dict()
-        self.assertAlmostEqual(d["stability_charge"], 0.2346574583333325)
-        self.assertAlmostEqual(d["stability_discharge"], 0.33379544031249786)
-        self.assertAlmostEqual(d["muO2_data"]["mp-714969"][0]["chempot"], -4.93552791875)
+        assert d["stability_charge"] == pytest.approx(0.2346574583333325)
+        assert d["stability_discharge"] == pytest.approx(0.33379544031249786)
+        assert d["muO2_data"]["mp-714969"][0]["chempot"] == pytest.approx(-4.93552791875)
 
-        self.assertAlmostEqual(d["adj_pairs"][0]["muO2_data"]["mp-714969"][0]["chempot"], -4.93552791875)
-        self.assertAlmostEqual(d["framework_formula"], "MoO2")
-        self.assertAlmostEqual(d["adj_pairs"][1]["framework_formula"], "MoO2")
+        assert d["adj_pairs"][0]["muO2_data"]["mp-714969"][0]["chempot"] == pytest.approx(-4.93552791875)
+        assert d["framework_formula"] == "MoO2"
+        assert d["adj_pairs"][1]["framework_formula"] == "MoO2"
 
     def test_init_no_structure(self):
         def remove_structure(entries):
@@ -138,14 +139,14 @@ class InsertionElectrodeTest(unittest.TestCase):
 
         ie_CMO_no_struct = InsertionElectrode.from_entries(remove_structure(self.entries_CMO), self.entry_Ca)
         d = ie_CMO_no_struct.get_summary_dict()
-        self.assertAlmostEqual(d["stability_charge"], 0.2346574583333325)
-        self.assertAlmostEqual(d["stability_discharge"], 0.33379544031249786)
-        self.assertAlmostEqual(d["muO2_data"]["mp-714969"][0]["chempot"], -4.93552791875)
+        assert d["stability_charge"] == pytest.approx(0.2346574583333325)
+        assert d["stability_discharge"] == pytest.approx(0.33379544031249786)
+        assert d["muO2_data"]["mp-714969"][0]["chempot"] == pytest.approx(-4.93552791875)
 
         ie_LTO_no_struct = InsertionElectrode.from_entries(self.entries_LTO, self.entry_Li, strip_structures=True)
         vols_no_struct = [ient.data["volume"] for ient in ie_LTO_no_struct.get_all_entries()]
         vols_struct = [ient.structure.volume for ient in self.ie_LTO.get_all_entries()]
-        self.assertAlmostEqual(vols_no_struct, vols_struct)
+        assert vols_no_struct == pytest.approx(vols_struct, rel=1e-3)
 
 
 if __name__ == "__main__":

--- a/pymatgen/core/tests/test_structure.py
+++ b/pymatgen/core/tests/test_structure.py
@@ -1329,14 +1329,15 @@ class StructureTest(PymatgenTest):
     def test_from_prototype(self):
         for pt in ["bcc", "fcc", "hcp", "diamond"]:
             s = Structure.from_prototype(pt, ["C"], a=3, c=4)
-            self.assertIsInstance(s, Structure)
+            assert isinstance(s, Structure)
 
-        self.assertRaises(ValueError, Structure.from_prototype, "hcp", ["C"], a=3)
+        with pytest.raises(ValueError):
+            Structure.from_prototype("hcp", ["C"], a=3)
 
         s = Structure.from_prototype("rocksalt", ["Li", "Cl"], a=2.56)
-        self.assertEqual(
-            str(s),
-            """Full Formula (Li4 Cl4)
+        assert (
+            str(s)
+            == """Full Formula (Li4 Cl4)
 Reduced Formula: LiCl
 abc   :   2.560000   2.560000   2.560000
 angles:  90.000000  90.000000  90.000000
@@ -1351,11 +1352,11 @@ Sites (8)
   4  Cl    0.5  0    0.5
   5  Cl    0    0.5  0.5
   6  Cl    0.5  0.5  0
-  7  Cl    0    0    0""",
+  7  Cl    0    0    0"""
         )
         for pt in ("cscl", "fluorite", "antifluorite", "zincblende"):
             s = Structure.from_prototype(pt, ["Cs", "Cl"], a=5)
-            self.assertTrue(s.lattice.is_orthogonal)
+            assert s.lattice.is_orthogonal
 
 
 class IMoleculeTest(PymatgenTest):

--- a/pymatgen/core/tests/test_trajectory.py
+++ b/pymatgen/core/tests/test_trajectory.py
@@ -96,11 +96,11 @@ class TrajectoryTest(PymatgenTest):
         traj = Trajectory(lattice, species, frac_coords, site_properties=props)
 
         # compare the overall site properties list
-        self.assertEqual(traj.site_properties, props)
+        assert traj.site_properties == props
 
         # compare the site properties after slicing
-        self.assertEqual(traj[0].site_properties, props[0])
-        self.assertEqual(traj[1:].site_properties, props[1:])
+        assert traj[0].site_properties == props[0]
+        assert traj[1:].site_properties == props[1:]
 
     def test_frame_properties(self):
         lattice, species, frac_coords = self._get_lattice_species_and_coords()
@@ -110,11 +110,11 @@ class TrajectoryTest(PymatgenTest):
         traj = Trajectory(lattice, species, frac_coords, frame_properties=props)
 
         # compare the overall site properties
-        self.assertEqual(traj.frame_properties, props)
+        assert traj.frame_properties == props
 
         # compare the site properties after slicing
         expected = props[1:]
-        self.assertEqual(traj[1:].frame_properties, expected)
+        assert traj[1:].frame_properties == expected
 
     def test_extend(self):
         traj = copy.deepcopy(self.traj)
@@ -175,61 +175,61 @@ class TrajectoryTest(PymatgenTest):
         traj_combined = copy.deepcopy(traj_1)
         traj_combined.extend(traj_1)
         expected_site_props = props_1
-        self.assertEqual(traj_combined.site_properties, expected_site_props)
+        assert traj_combined.site_properties == expected_site_props
 
         # const & const (both constant but different site properties)
         traj_combined = copy.deepcopy(traj_1)
         traj_combined.extend(traj_2)
         expected_site_props = [props_1] * num_frames + [props_2] * num_frames
-        self.assertEqual(traj_combined.site_properties, expected_site_props)
+        assert traj_combined.site_properties == expected_site_props
 
         # const & changing
         traj_combined = copy.deepcopy(traj_1)
         traj_combined.extend(traj_3)
         expected_site_props = [props_1] * num_frames + props_3
-        self.assertEqual(traj_combined.site_properties, expected_site_props)
+        assert traj_combined.site_properties == expected_site_props
 
         # const & none
         traj_combined = copy.deepcopy(traj_1)
         traj_combined.extend(traj_4)
         expected_site_props = [props_1] * num_frames + [None] * num_frames
-        self.assertEqual(traj_combined.site_properties, expected_site_props)
+        assert traj_combined.site_properties == expected_site_props
 
         # changing & const
         traj_combined = copy.deepcopy(traj_3)
         traj_combined.extend(traj_1)
         expected_site_props = props_3 + [props_1] * num_frames
-        self.assertEqual(traj_combined.site_properties, expected_site_props)
+        assert traj_combined.site_properties == expected_site_props
 
         # changing & changing
         traj_combined = copy.deepcopy(traj_3)
         traj_combined.extend(traj_3)
         expected_site_props = props_3 + props_3
-        self.assertEqual(traj_combined.site_properties, expected_site_props)
+        assert traj_combined.site_properties == expected_site_props
 
         # changing & none
         traj_combined = copy.deepcopy(traj_3)
         traj_combined.extend(traj_4)
         expected_site_props = props_3 + [None] * num_frames
-        self.assertEqual(traj_combined.site_properties, expected_site_props)
+        assert traj_combined.site_properties == expected_site_props
 
         # none & const
         traj_combined = copy.deepcopy(traj_4)
         traj_combined.extend(traj_1)
         expected_site_props = [None] * num_frames + [props_1] * num_frames
-        self.assertEqual(traj_combined.site_properties, expected_site_props)
+        assert traj_combined.site_properties == expected_site_props
 
         # none & changing
         traj_combined = copy.deepcopy(traj_4)
         traj_combined.extend(traj_3)
         expected_site_props = [None] * num_frames + props_3
-        self.assertEqual(traj_combined.site_properties, expected_site_props)
+        assert traj_combined.site_properties == expected_site_props
 
         # none & none
         traj_combined = copy.deepcopy(traj_4)
         traj_combined.extend(traj_4)
         expected_site_props = None
-        self.assertEqual(traj_combined.site_properties, expected_site_props)
+        assert traj_combined.site_properties == expected_site_props
 
     def test_extend_frame_props(self):
         lattice, species, frac_coords = self._get_lattice_species_and_coords()
@@ -253,18 +253,18 @@ class TrajectoryTest(PymatgenTest):
         traj_combined = copy.deepcopy(traj_1)
         traj_combined.extend(traj_2)
         expected_props = props_1 + props_2
-        self.assertEqual(traj_combined.frame_properties, expected_props)
+        assert traj_combined.frame_properties == expected_props
 
         # test combining two where one has properties and the other does not
         traj_combined = copy.deepcopy(traj_1)
         traj_combined.extend(traj_3)
         expected_props = props_1 + [None] * len(frac_coords)
-        self.assertEqual(traj_combined.frame_properties, expected_props)
+        assert traj_combined.frame_properties == expected_props
 
         # test combining two both of which have no properties
         traj_combined = copy.deepcopy(traj_3)
         traj_combined.extend(traj_3)
-        self.assertEqual(traj_combined.frame_properties, None)
+        assert traj_combined.frame_properties is None
 
     def test_length(self):
         assert len(self.traj) == len(self.structures)

--- a/pymatgen/ext/tests/test_cod.py
+++ b/pymatgen/ext/tests/test_cod.py
@@ -29,17 +29,17 @@ class CODTest(unittest.TestCase):
     @unittest.skipIf(not which("mysql"), "No mysql.")
     def test_get_cod_ids(self):
         ids = COD().get_cod_ids("Li2O")
-        self.assertTrue(len(ids) > 15)
+        assert len(ids) > 15
 
     @unittest.skipIf(not which("mysql"), "No mysql.")
     def test_get_structure_by_formula(self):
         data = COD().get_structure_by_formula("Li2O")
-        self.assertTrue(len(data) > 15)
-        self.assertEqual(data[0]["structure"].composition.reduced_formula, "Li2O")
+        assert len(data) > 15
+        assert data[0]["structure"].composition.reduced_formula == "Li2O"
 
     def test_get_structure_by_id(self):
         s = COD().get_structure_by_id(2002926)
-        self.assertEqual(s.formula, "Be8 H64 N16 F32")
+        assert s.formula == "Be8 H64 N16 F32"
 
 
 if __name__ == "__main__":

--- a/pymatgen/ext/tests/test_matproj.py
+++ b/pymatgen/ext/tests/test_matproj.py
@@ -5,6 +5,7 @@ import re
 import unittest
 import warnings
 
+import pytest
 import requests
 from ruamel.yaml import YAML
 
@@ -53,14 +54,14 @@ class MPResterOldTest(PymatgenTest):
         mids = self.rester.get_materials_ids("Al2O3")
         random.shuffle(mids)
         doc = self.rester.get_doc(mids.pop(0))
-        self.assertEqual(doc["pretty_formula"], "Al2O3")
+        assert doc["pretty_formula"] == "Al2O3"
 
     def test_get_xas_data(self):
         # Test getting XAS data
         data = self.rester.get_xas_data("mp-19017", "Li")
-        self.assertEqual("mp-19017,Li", data["mid_and_el"])
-        self.assertAlmostEqual(data["spectrum"]["x"][0], 55.178, places=2)
-        self.assertAlmostEqual(data["spectrum"]["y"][0], 0.0164634, places=2)
+        assert "mp-19017,Li" == data["mid_and_el"]
+        assert data["spectrum"]["x"][0] == pytest.approx(55.178)
+        assert data["spectrum"]["y"][0] == pytest.approx(0.0164634)
 
     def test_get_data(self):
         props = {
@@ -96,52 +97,50 @@ class MPResterOldTest(PymatgenTest):
                 val = self.rester.get_data(mpid, prop=prop)[0][prop]
                 if prop in ["energy", "energy_per_atom"]:
                     prop = "final_" + prop
-                self.assertAlmostEqual(expected_vals[prop], val, 2, f"Failed with property {prop}")
+                assert expected_vals[prop] == pytest.approx(val), f"Failed with property {prop}"
             elif prop in ["elements", "icsd_ids", "task_ids"]:
                 upstream_vals = set(self.rester.get_data(mpid, prop=prop)[0][prop])
-                self.assertLessEqual(set(expected_vals[prop]), upstream_vals)
+                assert set(expected_vals[prop]) <= upstream_vals
             else:
-                self.assertEqual(
-                    expected_vals[prop],
-                    self.rester.get_data(mpid, prop=prop)[0][prop],
-                )
+                assert expected_vals[prop] == self.rester.get_data(mpid, prop=prop)[0][prop]
 
         props = ["structure", "initial_structure", "final_structure", "entry"]
         for prop in props:
             obj = self.rester.get_data(mpid, prop=prop)[0][prop]
             if prop.endswith("structure"):
-                self.assertIsInstance(obj, Structure)
+                assert isinstance(obj, Structure)
             elif prop == "entry":
                 obj = self.rester.get_data(mpid, prop=prop)[0][prop]
-                self.assertIsInstance(obj, ComputedEntry)
+                assert isinstance(obj, ComputedEntry)
 
         # Test chemsys search
         data = self.rester.get_data("Fe-Li-O", prop="unit_cell_formula")
-        self.assertTrue(len(data) > 1)
+        assert len(data) > 1
         elements = {Element("Li"), Element("Fe"), Element("O")}
         for d in data:
-            self.assertTrue(set(Composition(d["unit_cell_formula"]).elements).issubset(elements))
+            assert set(Composition(d["unit_cell_formula"]).elements).issubset(elements)
 
-        self.assertRaises(MPRestError, self.rester.get_data, "Fe2O3", "badmethod")
+        with pytest.raises(MPRestError):
+            self.rester.get_data("Fe2O3", "badmethod")
 
     def test_get_materials_id_from_task_id(self):
-        self.assertEqual(self.rester.get_materials_id_from_task_id("mp-540081"), "mp-19017")
+        assert self.rester.get_materials_id_from_task_id("mp-540081") == "mp-19017"
 
     def test_get_materials_id_references(self):
         # nosetests pymatgen/matproj/tests/test_matproj.py:MPResterOldTest.test_get_materials_id_references
         m = _MPResterLegacy()
         data = m.get_materials_id_references("mp-123")
-        self.assertTrue(len(data) > 1000)
+        assert len(data) > 1000
 
     def test_find_structure(self):
         # nosetests pymatgen/matproj/tests/test_matproj.py:MPResterOldTest.test_find_structure
         m = _MPResterLegacy()
         ciffile = self.TEST_FILES_DIR / "Fe3O4.cif"
         data = m.find_structure(str(ciffile))
-        self.assertTrue(len(data) > 1)
+        assert len(data) > 1
         s = CifParser(ciffile).get_structures()[0]
         data = m.find_structure(s)
-        self.assertTrue(len(data) > 1)
+        assert len(data) > 1
 
     def test_get_entries_in_chemsys(self):
         syms = ["Li", "Fe", "O"]
@@ -150,119 +149,122 @@ class MPResterOldTest(PymatgenTest):
         entries2 = self.rester.get_entries_in_chemsys(syms2)
         elements = {Element(sym) for sym in syms}
         for e in entries:
-            self.assertIsInstance(e, ComputedEntry)
-            self.assertTrue(set(e.composition.elements).issubset(elements))
+            assert isinstance(e, ComputedEntry)
+            assert set(e.composition.elements).issubset(elements)
 
         e1 = {i.entry_id for i in entries}
         e2 = {i.entry_id for i in entries2}
-        self.assertTrue(e1 == e2)
+        assert e1 == e2
 
         stable_entries = self.rester.get_entries_in_chemsys(syms, additional_criteria={"e_above_hull": {"$lte": 0.001}})
-        self.assertTrue(len(stable_entries) < len(entries))
+        assert len(stable_entries) < len(entries)
 
     def test_get_structure_by_material_id(self):
         s1 = self.rester.get_structure_by_material_id("mp-1")
-        self.assertEqual(s1.formula, "Cs1")
+        assert s1.formula == "Cs1"
 
         # requesting via task-id instead of mp-id
-        self.assertWarns(Warning, self.rester.get_structure_by_material_id, "mp-698856")
+        with pytest.warns(Warning):
+            self.rester.get_structure_by_material_id("mp-698856")
 
         # requesting unknown mp-id
-        self.assertRaises(MPRestError, self.rester.get_structure_by_material_id, "mp-does-not-exist")
+        with pytest.raises(MPRestError):
+            self.rester.get_structure_by_material_id("mp-does-not-exist")
 
     def test_get_entry_by_material_id(self):
         entry = self.rester.get_entry_by_material_id("mp-19017")
-        self.assertIsInstance(entry, ComputedEntry)
-        self.assertTrue(entry.composition.reduced_formula, "LiFePO4")
+        assert isinstance(entry, ComputedEntry)
+        assert entry.composition.reduced_formula, "LiFePO4"
 
         # "mp-2022" does not exist
-        self.assertRaises(MPRestError, self.rester.get_entry_by_material_id, "mp-2022")
+        with pytest.raises(MPRestError):
+            self.rester.get_entry_by_material_id("mp-2022")
 
     def test_query(self):
         criteria = {"elements": {"$in": ["Li", "Na", "K"], "$all": ["O"]}}
         props = ["pretty_formula", "energy"]
         data = self.rester.query(criteria=criteria, properties=props, chunk_size=0)
-        self.assertTrue(len(data) > 6)
+        assert len(data) > 6
         data = self.rester.query(criteria="*2O", properties=props, chunk_size=0)
-        self.assertGreaterEqual(len(data), 52)
-        self.assertIn("Li2O", (d["pretty_formula"] for d in data))
+        assert len(data) >= 52
+        assert "Li2O" in (d["pretty_formula"] for d in data)
 
     def test_query_chunk_size(self):
         criteria = {"nelements": 2, "elements": "O"}
         props = ["pretty_formula"]
         data1 = self.rester.query(criteria=criteria, properties=props, chunk_size=0)
         data2 = self.rester.query(criteria=criteria, properties=props, chunk_size=500)
-        self.assertEqual({d["pretty_formula"] for d in data1}, {d["pretty_formula"] for d in data2})
-        self.assertIn("Al2O3", {d["pretty_formula"] for d in data1})
+        assert {d["pretty_formula"] for d in data1} == {d["pretty_formula"] for d in data2}
+        assert "Al2O3" in {d["pretty_formula"] for d in data1}
 
     def test_get_exp_thermo_data(self):
         data = self.rester.get_exp_thermo_data("Fe2O3")
-        self.assertTrue(len(data) > 0)
+        assert len(data) > 0
         for d in data:
-            self.assertEqual(d.formula, "Fe2O3")
+            assert d.formula == "Fe2O3"
 
     def test_get_dos_by_id(self):
         dos = self.rester.get_dos_by_material_id("mp-2254")
-        self.assertIsInstance(dos, CompleteDos)
+        assert isinstance(dos, CompleteDos)
 
     def test_get_bandstructure_by_material_id(self):
         bs = self.rester.get_bandstructure_by_material_id("mp-2254")
-        self.assertIsInstance(bs, BandStructureSymmLine)
+        assert isinstance(bs, BandStructureSymmLine)
         bs_unif = self.rester.get_bandstructure_by_material_id("mp-2254", line_mode=False)
-        self.assertIsInstance(bs_unif, BandStructure)
-        self.assertNotIsInstance(bs_unif, BandStructureSymmLine)
+        assert isinstance(bs_unif, BandStructure)
+        assert not isinstance(bs_unif, BandStructureSymmLine)
 
     def test_get_phonon_data_by_material_id(self):
         bs = self.rester.get_phonon_bandstructure_by_material_id("mp-661")
-        self.assertIsInstance(bs, PhononBandStructureSymmLine)
+        assert isinstance(bs, PhononBandStructureSymmLine)
         dos = self.rester.get_phonon_dos_by_material_id("mp-661")
-        self.assertIsInstance(dos, CompletePhononDos)
+        assert isinstance(dos, CompletePhononDos)
         ddb_str = self.rester.get_phonon_ddb_by_material_id("mp-661")
-        self.assertIsInstance(ddb_str, str)
+        assert isinstance(ddb_str, str)
 
     def test_get_structures(self):
         structs = self.rester.get_structures("Mn3O4")
-        self.assertTrue(len(structs) > 0)
+        assert len(structs) > 0
 
     def test_get_entries(self):
         entries = self.rester.get_entries("TiO2")
-        self.assertTrue(len(entries) > 1)
+        assert len(entries) > 1
         for e in entries:
-            self.assertEqual(e.composition.reduced_formula, "TiO2")
+            assert e.composition.reduced_formula == "TiO2"
 
         entries = self.rester.get_entries("TiO2", inc_structure=True)
-        self.assertTrue(len(entries) > 1)
+        assert len(entries) > 1
         for e in entries:
-            self.assertEqual(e.structure.composition.reduced_formula, "TiO2")
+            assert e.structure.composition.reduced_formula == "TiO2"
 
         # all_entries = self.rester.get_entries("Fe", compatible_only=False)
         # entries = self.rester.get_entries("Fe", compatible_only=True)
         # self.assertTrue(len(entries) < len(all_entries))
         entries = self.rester.get_entries("Fe", compatible_only=True, property_data=["cif"])
-        self.assertIn("cif", entries[0].data)
+        assert "cif" in entries[0].data
 
         for e in self.rester.get_entries("CdO2", inc_structure=False):
-            self.assertIsNotNone(e.data["oxide_type"])
+            assert e.data["oxide_type"] is not None
 
         # test if it will retrieve the conventional unit cell of Ni
         entry = self.rester.get_entry_by_material_id("mp-23", inc_structure=True, conventional_unit_cell=True)
         Ni = entry.structure
-        self.assertEqual(Ni.lattice.a, Ni.lattice.b)
-        self.assertEqual(Ni.lattice.a, Ni.lattice.c)
-        self.assertEqual(Ni.lattice.alpha, 90)
-        self.assertEqual(Ni.lattice.beta, 90)
-        self.assertEqual(Ni.lattice.gamma, 90)
+        assert Ni.lattice.a == Ni.lattice.b
+        assert Ni.lattice.a == Ni.lattice.c
+        assert Ni.lattice.alpha == 90
+        assert Ni.lattice.beta == 90
+        assert Ni.lattice.gamma == 90
 
         # Ensure energy per atom is same
         primNi = self.rester.get_entry_by_material_id("mp-23", inc_structure=True, conventional_unit_cell=False)
-        self.assertEqual(primNi.energy_per_atom, entry.energy_per_atom)
+        assert primNi.energy_per_atom == entry.energy_per_atom
 
         Ni = self.rester.get_structure_by_material_id("mp-23", conventional_unit_cell=True)
-        self.assertEqual(Ni.lattice.a, Ni.lattice.b)
-        self.assertEqual(Ni.lattice.a, Ni.lattice.c)
-        self.assertEqual(Ni.lattice.alpha, 90)
-        self.assertEqual(Ni.lattice.beta, 90)
-        self.assertEqual(Ni.lattice.gamma, 90)
+        assert Ni.lattice.a == Ni.lattice.b
+        assert Ni.lattice.a == Ni.lattice.c
+        assert Ni.lattice.alpha == 90
+        assert Ni.lattice.beta == 90
+        assert Ni.lattice.gamma == 90
 
         # Test case where convs are different from initial and final
         # th = self.rester.get_structure_by_material_id(
@@ -278,18 +280,18 @@ class MPResterOldTest(PymatgenTest):
         # Test if the polymorphs of Fe are properly sorted
         # by e_above_hull when sort_by_e_above_hull=True
         Fe_entries = self.rester.get_entries("Fe", sort_by_e_above_hull=True)
-        self.assertEqual(Fe_entries[0].data["e_above_hull"], 0)
+        assert Fe_entries[0].data["e_above_hull"] == 0
 
     def test_get_pourbaix_entries(self):
         # test input chemsys as a list of elements
         pbx_entries = self.rester.get_pourbaix_entries(["Fe", "Cr"])
         for pbx_entry in pbx_entries:
-            self.assertTrue(isinstance(pbx_entry, PourbaixEntry))
+            assert isinstance(pbx_entry, PourbaixEntry)
 
         # test input chemsys as a string
         pbx_entries = self.rester.get_pourbaix_entries("Fe-Cr")
         for pbx_entry in pbx_entries:
-            self.assertTrue(isinstance(pbx_entry, PourbaixEntry))
+            assert isinstance(pbx_entry, PourbaixEntry)
 
         # fe_two_plus = [e for e in pbx_entries if e.entry_id == "ion-0"][0]
         # self.assertAlmostEqual(fe_two_plus.energy, -1.12369, places=3)
@@ -307,7 +309,7 @@ class MPResterOldTest(PymatgenTest):
 
     def test_get_exp_entry(self):
         entry = self.rester.get_exp_entry("Fe2O3")
-        self.assertEqual(entry.energy, -825.5)
+        assert entry.energy == -825.5
 
     # def test_submit_query_delete_snl(self):
     # s = Structure([[5, 0, 0], [0, 5, 0], [0, 0, 5]], ["Fe"], [[0, 0, 0]])
@@ -348,148 +350,146 @@ class MPResterOldTest(PymatgenTest):
                     if d["entry_id"] == e.entry_id:
                         data = d
                         break
-                self.assertAlmostEqual(pd.get_e_above_hull(e), data["e_above_hull"])
+                assert pd.get_e_above_hull(e) == pytest.approx(data["e_above_hull"])
 
     def test_get_reaction(self):
         rxn = self.rester.get_reaction(["Li", "O"], ["Li2O"])
-        self.assertIn("Li2O", rxn["Experimental_references"])
+        assert "Li2O" in rxn["Experimental_references"]
 
     def test_get_substrates(self):
         substrate_data = self.rester.get_substrates("mp-123", 5, [1, 0, 0])
         substrates = [sub_dict["sub_id"] for sub_dict in substrate_data]
-        self.assertIn("mp-2534", substrates)
+        assert "mp-2534" in substrates
 
     def test_get_surface_data(self):
         data = self.rester.get_surface_data("mp-126")  # Pt
         one_surf = self.rester.get_surface_data("mp-129", miller_index=[-2, -3, 1])
-        self.assertAlmostEqual(one_surf["surface_energy"], 2.99156963, places=2)
+        assert one_surf["surface_energy"] == pytest.approx(2.99156963)
         self.assertArrayAlmostEqual(one_surf["miller_index"], [3, 2, 1])
-        self.assertIn("surfaces", data)
+        assert "surfaces" in data
         surfaces = data["surfaces"]
-        self.assertTrue(len(surfaces) > 0)
+        assert len(surfaces) > 0
         surface = surfaces.pop()
-        self.assertIn("miller_index", surface)
-        self.assertIn("surface_energy", surface)
-        self.assertIn("is_reconstructed", surface)
+        assert "miller_index" in surface
+        assert "surface_energy" in surface
+        assert "is_reconstructed" in surface
         data_inc = self.rester.get_surface_data("mp-126", inc_structures=True)
-        self.assertIn("structure", data_inc["surfaces"][0])
+        assert "structure" in data_inc["surfaces"][0]
 
     def test_get_wulff_shape(self):
         ws = self.rester.get_wulff_shape("mp-126")
-        self.assertTrue(isinstance(ws, WulffShape))
+        assert isinstance(ws, WulffShape)
 
     def test_get_cohesive_energy(self):
         ecoh = self.rester.get_cohesive_energy("mp-13")
-        self.assertTrue(ecoh, 5.04543279)
+        assert ecoh, 5.04543279
 
     def test_get_gb_data(self):
         mo_gbs = self.rester.get_gb_data(chemsys="Mo")
-        self.assertEqual(len(mo_gbs), 10)
+        assert len(mo_gbs) == 10
         mo_gbs_s5 = self.rester.get_gb_data(pretty_formula="Mo", sigma=5)
-        self.assertEqual(len(mo_gbs_s5), 3)
+        assert len(mo_gbs_s5) == 3
         mo_s3_112 = self.rester.get_gb_data(
             material_id="mp-129",
             sigma=3,
             gb_plane=[1, -1, -2],
             include_work_of_separation=True,
         )
-        self.assertEqual(len(mo_s3_112), 1)
+        assert len(mo_s3_112) == 1
         gb_f = mo_s3_112[0]["final_structure"]
         self.assertArrayAlmostEqual(gb_f.rotation_axis, [1, 1, 0])
-        self.assertAlmostEqual(gb_f.rotation_angle, 109.47122, places=4)
-        self.assertAlmostEqual(mo_s3_112[0]["gb_energy"], 0.47965, places=2)
-        self.assertAlmostEqual(mo_s3_112[0]["work_of_separation"], 6.318144, places=2)
-        self.assertIn("Mo24", gb_f.formula)
+        assert gb_f.rotation_angle == pytest.approx(109.47122)
+        assert mo_s3_112[0]["gb_energy"] == pytest.approx(0.47965)
+        assert mo_s3_112[0]["work_of_separation"] == pytest.approx(6.318144)
+        assert "Mo24" in gb_f.formula
         hcp_s7 = self.rester.get_gb_data(material_id="mp-87", gb_plane=[0, 0, 0, 1], include_work_of_separation=True)
-        self.assertAlmostEqual(hcp_s7[0]["gb_energy"], 1.12, places=2)
-        self.assertAlmostEqual(hcp_s7[0]["work_of_separation"], 2.47, places=2)
+        assert hcp_s7[0]["gb_energy"] == pytest.approx(1.12)
+        assert hcp_s7[0]["work_of_separation"] == pytest.approx(2.47)
 
     def test_get_interface_reactions(self):
         kinks = self.rester.get_interface_reactions("LiCoO2", "Li3PS4")
-        self.assertTrue(len(kinks) > 0)
+        assert len(kinks) > 0
         kink = kinks[0]
-        self.assertIn("energy", kink)
-        self.assertIn("ratio_atomic", kink)
-        self.assertIn("rxn", kink)
-        self.assertTrue(isinstance(kink["rxn"], Reaction))
+        assert "energy" in kink
+        assert "ratio_atomic" in kink
+        assert "rxn" in kink
+        assert isinstance(kink["rxn"], Reaction)
         kinks_open_O = self.rester.get_interface_reactions("LiCoO2", "Li3PS4", open_el="O", relative_mu=-1)
-        self.assertTrue(len(kinks_open_O) > 0)
+        assert len(kinks_open_O) > 0
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings("always", message="The reactant.+")
             self.rester.get_interface_reactions("LiCoO2", "MnO9")
-            self.assertTrue("The reactant" in str(w[-1].message))
+            assert "The reactant" in str(w[-1].message)
 
     def test_download_info(self):
         material_ids = ["mvc-2970"]
         task_types = [TaskType.GGA_OPT, TaskType.GGAU_UNIFORM]
         file_patterns = ["vasprun*", "OUTCAR*"]
         meta, urls = self.rester.get_download_info(material_ids, task_types=task_types, file_patterns=file_patterns)
-        self.assertDictEqual(
-            dict(meta),
-            {
-                "mvc-2970": [{"task_id": "mp-1738602", "task_type": "GGA+U NSCF Uniform"}],
-            },
-        )
-        self.assertEqual(
-            urls[0],
-            "https://nomad-lab.eu/prod/rae/api/raw/query?file_pattern=vasprun*&file_pattern=OUTCAR*&external_id=mp"
-            "-1738602",
+        assert dict(meta) == {
+            "mvc-2970": [{"task_id": "mp-1738602", "task_type": "GGA+U NSCF Uniform"}],
+        }
+        assert (
+            urls[0] == "https://nomad-lab.eu/prod/rae/api/raw/query?file_pattern=vasprun*"
+            "&file_pattern=OUTCAR*&external_id=mp-1738602"
         )
 
     def test_parse_criteria(self):
         crit = _MPResterLegacy.parse_criteria("mp-1234 Li-*")
-        self.assertIn("Li-O", crit["$or"][1]["chemsys"]["$in"])
-        self.assertIn({"task_id": "mp-1234"}, crit["$or"])
+        assert "Li-O" in crit["$or"][1]["chemsys"]["$in"]
+        assert {"task_id": "mp-1234"} in crit["$or"]
 
         crit = _MPResterLegacy.parse_criteria("Li2*")
-        self.assertIn("Li2O", crit["pretty_formula"]["$in"])
-        self.assertIn("Li2I", crit["pretty_formula"]["$in"])
-        self.assertIn("CsLi2", crit["pretty_formula"]["$in"])
+        assert "Li2O" in crit["pretty_formula"]["$in"]
+        assert "Li2I" in crit["pretty_formula"]["$in"]
+        assert "CsLi2" in crit["pretty_formula"]["$in"]
 
         crit = _MPResterLegacy.parse_criteria("Li-*-*")
-        self.assertIn("Li-Re-Ru", crit["chemsys"]["$in"])
-        self.assertNotIn("Li-Li", crit["chemsys"]["$in"])
+        assert "Li-Re-Ru" in crit["chemsys"]["$in"]
+        assert "Li-Li" not in crit["chemsys"]["$in"]
 
         comps = _MPResterLegacy.parse_criteria("**O3")["pretty_formula"]["$in"]
         for c in comps:
-            self.assertEqual(len(Composition(c)), 3, f"Failed in {c}")
+            assert len(Composition(c)) == 3, f"Failed in {c}"
 
         chemsys = _MPResterLegacy.parse_criteria("{Fe,Mn}-O")["chemsys"]["$in"]
-        self.assertEqual(len(chemsys), 2)
+        assert len(chemsys) == 2
         comps = _MPResterLegacy.parse_criteria("{Fe,Mn,Co}O")["pretty_formula"]["$in"]
-        self.assertEqual(len(comps), 3, comps)
+        assert len(comps) == 3, comps
 
         # Let's test some invalid symbols
 
-        self.assertRaises(ValueError, _MPResterLegacy.parse_criteria, "li-fe")
-        self.assertRaises(ValueError, _MPResterLegacy.parse_criteria, "LO2")
+        with pytest.raises(ValueError):
+            _MPResterLegacy.parse_criteria("li-fe")
+        with pytest.raises(ValueError):
+            _MPResterLegacy.parse_criteria("LO2")
 
         crit = _MPResterLegacy.parse_criteria("POPO2")
-        self.assertIn("P2O3", crit["pretty_formula"]["$in"])
+        assert "P2O3" in crit["pretty_formula"]["$in"]
 
     def test_include_user_agent(self):
         headers = self.rester.session.headers
-        self.assertIn("user-agent", headers, msg="Include user-agent header by default")
+        assert "user-agent" in headers, "Include user-agent header by default"
         m = re.match(
             r"pymatgen/(\d+)\.(\d+)\.(\d+)\.?(\d+)? \(Python/(\d+)\.(\d)+\.(\d+) ([^\/]*)/([^\)]*)\)",
             headers["user-agent"],
         )
-        self.assertIsNotNone(m, msg=f"Unexpected user-agent value {headers['user-agent']}")
+        assert m is not None, f"Unexpected user-agent value {headers['user-agent']}"
         self.rester = _MPResterLegacy(include_user_agent=False)
-        self.assertNotIn("user-agent", self.rester.session.headers, msg="user-agent header unwanted")
+        assert "user-agent" not in self.rester.session.headers, "user-agent header unwanted"
 
     def test_database_version(self):
 
         with _MPResterLegacy(notify_db_version=True) as mpr:
             db_version = mpr.get_database_version()
 
-        self.assertIsInstance(db_version, str)
+        assert isinstance(db_version, str)
         yaml = YAML()
         with open(MP_LOG_FILE) as f:
             d = yaml.load(f)
 
-        self.assertEqual(d["MAPI_DB_VERSION"]["LAST_ACCESSED"], db_version)
-        self.assertIsInstance(d["MAPI_DB_VERSION"]["LOG"][db_version], int)
+        assert d["MAPI_DB_VERSION"]["LAST_ACCESSED"] == db_version
+        assert isinstance(d["MAPI_DB_VERSION"]["LOG"][db_version], int)
 
     def test_pourbaix_heavy(self):
 
@@ -510,14 +510,14 @@ class MPResterOldTest(PymatgenTest):
 
         data = self.rester.get_pourbaix_entries(["Ag", "Te"])
         pbx = PourbaixDiagram(data, filter_solids=True, conc_dict={"Ag": 1e-8, "Te": 1e-8})
-        self.assertEqual(len(pbx.stable_entries), 29)
+        assert len(pbx.stable_entries) == 29
         test_entry = pbx.find_stable_entry(8, 2)
-        self.assertEqual(sorted(test_entry.entry_id), ["ion-10", "mp-499"])
+        assert sorted(test_entry.entry_id) == ["ion-10", "mp-499"]
 
         # Test against ion sets with multiple equivalent ions (Bi-V regression)
         entries = self.rester.get_pourbaix_entries(["Bi", "V"])
         pbx = PourbaixDiagram(entries, filter_solids=True, conc_dict={"Bi": 1e-8, "V": 1e-8})
-        self.assertTrue(all(["Bi" in entry.composition and "V" in entry.composition for entry in pbx.all_entries]))
+        assert all(["Bi" in entry.composition and "V" in entry.composition for entry in pbx.all_entries])
 
 
 if __name__ == "__main__":

--- a/pymatgen/ext/tests/test_optimade.py
+++ b/pymatgen/ext/tests/test_optimade.py
@@ -35,13 +35,11 @@ class OptimadeTest(PymatgenTest):
             if ("mp" in structs) and ("mp" in raw_filter_structs):
 
                 test_struct = next(iter(structs["mp"].values()))
-                self.assertEqual([str(el) for el in test_struct.types_of_species], ["Ga", "N"])
+                assert [str(el) for el in test_struct.types_of_species] == ["Ga", "N"]
 
-                self.assertEqual(
-                    len(structs["mp"]),
-                    len(raw_filter_structs["mp"]),
-                    msg="Raw filter {_filter} did not return the same number of results as the query builder.",
-                )
+                assert len(structs["mp"]) == len(
+                    raw_filter_structs["mp"]
+                ), "Raw filter {_filter} did not return the same number of results as the query builder."
 
     def test_get_snls_mp(self):
         with OptimadeRester("mp") as optimade:
@@ -56,8 +54,8 @@ class OptimadeTest(PymatgenTest):
                 elements=["Ga", "N"], nelements=2, additional_response_fields={"nsites", "nelements"}
             )
             if ("mp" in response_field_structs_single) and ("mp" in response_field_structs_set):
-                self.assertEqual(len(structs["mp"]), len(response_field_structs_single["mp"]))
-                self.assertEqual(len(structs["mp"]), len(response_field_structs_set["mp"]))
+                assert len(structs["mp"]) == len(response_field_structs_single["mp"])
+                assert len(structs["mp"]) == len(response_field_structs_set["mp"])
 
                 # Check that the requested response fields appear in the SNL metadata
                 s = list(response_field_structs_single["mp"].values())[0]

--- a/pymatgen/symmetry/tests/test_groups.py
+++ b/pymatgen/symmetry/tests/test_groups.py
@@ -4,6 +4,7 @@ import unittest
 import warnings
 
 import numpy as np
+import pytest
 
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.operations import SymmOp
@@ -22,13 +23,13 @@ class PointGroupTest(unittest.TestCase):
         order = {"mmm": 8, "432": 24, "-6m2": 12}
         for k, v in order.items():
             pg = PointGroup(k)
-            self.assertEqual(v, len(pg.symmetry_ops))
+            assert v == len(pg.symmetry_ops)
 
     def test_get_orbit(self):
         pg = PointGroup("mmm")
-        self.assertEqual(len(pg.get_orbit([0.1, 0.1, 0.1])), 8)
-        self.assertEqual(len(pg.get_orbit([0, 0, 0.1])), 2)
-        self.assertEqual(len(pg.get_orbit([1.2, 1.2, 1])), 8)
+        assert len(pg.get_orbit([0.1, 0.1, 0.1])) == 8
+        assert len(pg.get_orbit([0, 0, 0.1])) == 2
+        assert len(pg.get_orbit([1.2, 1.2, 1])) == 8
 
     def test_is_sub_super_group(self):
         with warnings.catch_warnings():
@@ -37,17 +38,17 @@ class PointGroupTest(unittest.TestCase):
             pgmm2 = PointGroup("mm2")
             pg222 = PointGroup("222")
             pg4 = PointGroup("4")
-            self.assertTrue(pgmmm.is_supergroup(pgmm2))
-            self.assertTrue(pgmm2.is_subgroup(pgmmm))
-            self.assertTrue(pgmmm.is_supergroup(pg222))
-            self.assertFalse(pgmmm.is_supergroup(pg4))
+            assert pgmmm.is_supergroup(pgmm2)
+            assert pgmm2.is_subgroup(pgmmm)
+            assert pgmmm.is_supergroup(pg222)
+            assert not pgmmm.is_supergroup(pg4)
             pgm3m = PointGroup("m-3m")
             pg6mmm = PointGroup("6/mmm")
             pg3m = PointGroup("-3m")
             # TODO: Fix the test below.
             # self.assertTrue(pg3m.is_subgroup(pgm3m))
-            self.assertTrue(pg3m.is_subgroup(pg6mmm))
-            self.assertFalse(pgm3m.is_supergroup(pg6mmm))
+            assert pg3m.is_subgroup(pg6mmm)
+            assert not pgm3m.is_supergroup(pg6mmm)
 
 
 class SpaceGroupTest(unittest.TestCase):
@@ -65,74 +66,68 @@ class SpaceGroupTest(unittest.TestCase):
 
     def test_abbrev_symbols(self):
         sg = SpaceGroup("P2/c")
-        self.assertEqual(sg.int_number, 13)
+        assert sg.int_number == 13
         sg = SpaceGroup("R-3mH")
-        self.assertEqual(sg.int_number, 166)
+        assert sg.int_number == 166
 
     def test_attr(self):
         sg = SpaceGroup("Fm-3m")
-        self.assertEqual(sg.full_symbol, "F4/m-32/m")
-        self.assertEqual(sg.point_group, "m-3m")
+        assert sg.full_symbol == "F4/m-32/m"
+        assert sg.point_group == "m-3m"
 
     def test_point_group_is_set(self):
         for i in range(1, 231):
             sg = SpaceGroup.from_int_number(i)
-            self.assertTrue(hasattr(sg, "point_group"))
+            assert hasattr(sg, "point_group")
 
         for symbol in _get_symm_data("space_group_encoding"):
             sg = SpaceGroup(symbol)
-            self.assertTrue(hasattr(sg, "point_group"))
+            assert hasattr(sg, "point_group")
 
     def test_full_symbols(self):
         sg = SpaceGroup("P2/m2/m2/m")
-        self.assertEqual(sg.symbol, "Pmmm")
+        assert sg.symbol == "Pmmm"
 
     def test_order_symm_ops(self):
         for name in SpaceGroup.SG_SYMBOLS:
             sg = SpaceGroup(name)
-            self.assertEqual(len(sg.symmetry_ops), sg.order)
+            assert len(sg.symmetry_ops) == sg.order
 
     def test_get_settings(self):
-        self.assertEqual({"Fm-3m(a-1/4,b-1/4,c-1/4)", "Fm-3m"}, SpaceGroup.get_settings("Fm-3m"))
-        self.assertEqual(
-            {
-                "Pmmn",
-                "Pmnm:1",
-                "Pnmm:2",
-                "Pmnm:2",
-                "Pnmm",
-                "Pnmm:1",
-                "Pmmn:1",
-                "Pmnm",
-                "Pmmn:2",
-            },
-            SpaceGroup.get_settings("Pmmn"),
-        )
-        self.assertEqual(
-            {"Pnmb", "Pman", "Pncm", "Pmna", "Pcnm", "Pbmn"},
-            SpaceGroup.get_settings("Pmna"),
-        )
+        assert {"Fm-3m(a-1/4,b-1/4,c-1/4)", "Fm-3m"} == SpaceGroup.get_settings("Fm-3m")
+        assert {
+            "Pmmn",
+            "Pmnm:1",
+            "Pnmm:2",
+            "Pmnm:2",
+            "Pnmm",
+            "Pnmm:1",
+            "Pmmn:1",
+            "Pmnm",
+            "Pmmn:2",
+        } == SpaceGroup.get_settings("Pmmn")
+        assert {"Pnmb", "Pman", "Pncm", "Pmna", "Pcnm", "Pbmn"} == SpaceGroup.get_settings("Pmna")
 
     def test_crystal_system(self):
         sg = SpaceGroup("R-3c")
-        self.assertEqual(sg.crystal_system, "trigonal")
+        assert sg.crystal_system == "trigonal"
         sg = SpaceGroup("R-3cH")
-        self.assertEqual(sg.crystal_system, "trigonal")
+        assert sg.crystal_system == "trigonal"
 
     def test_get_orbit(self):
         sg = SpaceGroup("Fm-3m")
         p = np.random.randint(0, 100 + 1, size=(3,)) / 100
-        self.assertLessEqual(len(sg.get_orbit(p)), sg.order)
+        assert len(sg.get_orbit(p)) <= sg.order
 
     def test_get_orbit_and_generators(self):
         sg = SpaceGroup("Fm-3m")
         p = np.random.randint(0, 100 + 1, size=(3,)) / 100
         orbit, generators = sg.get_orbit_and_generators(p)
-        self.assertLessEqual(len(orbit), sg.order)
+        assert len(orbit) <= sg.order
         pp = generators[0].operate(orbit[0])
-        self.assertAlmostEqual(p[0], pp[0])
-        self.assertAlmostEqual(p[1], pp[1])
-        self.assertAlmostEqual(p[2], pp[2])
+        assert p[0] == pytest.approx(pp[0])
+        assert p[1] == pytest.approx(pp[1])
+        assert p[2] == pytest.approx(pp[2])
 
     def test_is_compatible(self):
         cubic = Lattice.cubic(1)
@@ -141,77 +136,78 @@ class SpaceGroupTest(unittest.TestCase):
         tet = Lattice.tetragonal(1, 2)
         ortho = Lattice.orthorhombic(1, 2, 3)
         sg = SpaceGroup("Fm-3m")
-        self.assertTrue(sg.is_compatible(cubic))
-        self.assertFalse(sg.is_compatible(hexagonal))
+        assert sg.is_compatible(cubic)
+        assert not sg.is_compatible(hexagonal)
         sg = SpaceGroup("R-3m:H")
-        self.assertFalse(sg.is_compatible(cubic))
-        self.assertTrue(sg.is_compatible(hexagonal))
+        assert not sg.is_compatible(cubic)
+        assert sg.is_compatible(hexagonal)
         sg = SpaceGroup("R-3m:R")
-        self.assertTrue(sg.is_compatible(cubic))
-        self.assertTrue(sg.is_compatible(rhom))
-        self.assertFalse(sg.is_compatible(hexagonal))
+        assert sg.is_compatible(cubic)
+        assert sg.is_compatible(rhom)
+        assert not sg.is_compatible(hexagonal)
         sg = SpaceGroup("Pnma")
-        self.assertTrue(sg.is_compatible(cubic))
-        self.assertTrue(sg.is_compatible(tet))
-        self.assertTrue(sg.is_compatible(ortho))
-        self.assertFalse(sg.is_compatible(rhom))
-        self.assertFalse(sg.is_compatible(hexagonal))
+        assert sg.is_compatible(cubic)
+        assert sg.is_compatible(tet)
+        assert sg.is_compatible(ortho)
+        assert not sg.is_compatible(rhom)
+        assert not sg.is_compatible(hexagonal)
         sg = SpaceGroup("P12/c1")
-        self.assertTrue(sg.is_compatible(cubic))
-        self.assertTrue(sg.is_compatible(tet))
-        self.assertTrue(sg.is_compatible(ortho))
-        self.assertFalse(sg.is_compatible(rhom))
-        self.assertFalse(sg.is_compatible(hexagonal))
+        assert sg.is_compatible(cubic)
+        assert sg.is_compatible(tet)
+        assert sg.is_compatible(ortho)
+        assert not sg.is_compatible(rhom)
+        assert not sg.is_compatible(hexagonal)
         sg = SpaceGroup("P-1")
-        self.assertTrue(sg.is_compatible(cubic))
-        self.assertTrue(sg.is_compatible(tet))
-        self.assertTrue(sg.is_compatible(ortho))
-        self.assertTrue(sg.is_compatible(rhom))
-        self.assertTrue(sg.is_compatible(hexagonal))
+        assert sg.is_compatible(cubic)
+        assert sg.is_compatible(tet)
+        assert sg.is_compatible(ortho)
+        assert sg.is_compatible(rhom)
+        assert sg.is_compatible(hexagonal)
         sg = SpaceGroup("Pmmn:2")
-        self.assertTrue(sg.is_compatible(cubic))
-        self.assertTrue(sg.is_compatible(tet))
-        self.assertTrue(sg.is_compatible(ortho))
-        self.assertFalse(sg.is_compatible(rhom))
-        self.assertFalse(sg.is_compatible(hexagonal))
+        assert sg.is_compatible(cubic)
+        assert sg.is_compatible(tet)
+        assert sg.is_compatible(ortho)
+        assert not sg.is_compatible(rhom)
+        assert not sg.is_compatible(hexagonal)
 
         sg = SpaceGroup.from_int_number(165)
-        self.assertFalse(sg.is_compatible(cubic))
-        self.assertFalse(sg.is_compatible(tet))
-        self.assertFalse(sg.is_compatible(ortho))
-        self.assertFalse(sg.is_compatible(rhom))
-        self.assertTrue(sg.is_compatible(hexagonal))
+        assert not sg.is_compatible(cubic)
+        assert not sg.is_compatible(tet)
+        assert not sg.is_compatible(ortho)
+        assert not sg.is_compatible(rhom)
+        assert sg.is_compatible(hexagonal)
 
     def test_symmops(self):
         sg = SpaceGroup("Pnma")
         op = SymmOp.from_rotation_and_translation([[1, 0, 0], [0, -1, 0], [0, 0, -1]], [0.5, 0.5, 0.5])
-        self.assertIn(op, sg.symmetry_ops)
+        assert op in sg.symmetry_ops
 
     def test_other_settings(self):
         sg = SpaceGroup("Pbnm")
-        self.assertEqual(sg.int_number, 62)
-        self.assertEqual(sg.order, 8)
-        self.assertRaises(ValueError, SpaceGroup, "hello")
+        assert sg.int_number == 62
+        assert sg.order == 8
+        with pytest.raises(ValueError):
+            SpaceGroup("hello")
 
     def test_subgroup_supergroup(self):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            self.assertTrue(SpaceGroup("Pma2").is_subgroup(SpaceGroup("Pccm")))
-            self.assertFalse(SpaceGroup.from_int_number(229).is_subgroup(SpaceGroup.from_int_number(230)))
+            assert SpaceGroup("Pma2").is_subgroup(SpaceGroup("Pccm"))
+            assert not SpaceGroup.from_int_number(229).is_subgroup(SpaceGroup.from_int_number(230))
 
     def test_hexagonal(self):
         sgs = [146, 148, 155, 160, 161, 166, 167]
         for sg in sgs:
             s = SpaceGroup.from_int_number(sg, hexagonal=False)
-            self.assertTrue(not s.symbol.endswith("H"))
+            assert not s.symbol.endswith("H")
 
     def test_string(self):
         sg = SpaceGroup("R-3c")
-        self.assertEqual(sg.to_latex_string(), r"R$\overline{3}$cH")
+        assert sg.to_latex_string() == r"R$\overline{3}$cH"
         sg = SpaceGroup("P6/mmm")
-        self.assertEqual(sg.to_latex_string(), "P6/mmm")
+        assert sg.to_latex_string() == "P6/mmm"
         sg = SpaceGroup("P4_1")
-        self.assertEqual(sg.to_unicode_string(), "P4₁")
+        assert sg.to_unicode_string() == "P4₁"
 
 
 if __name__ == "__main__":

--- a/pymatgen/symmetry/tests/test_kpath_hin.py
+++ b/pymatgen/symmetry/tests/test_kpath_hin.py
@@ -4,6 +4,8 @@
 
 import unittest
 
+import pytest
+
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Structure
 from pymatgen.symmetry.kpath import KPathSeek
@@ -66,88 +68,69 @@ class KPathSeekTest(PymatgenTest):
         kpoints = kpath._kpath["kpoints"]
         labels = list(kpoints)
 
-        self.assertEqual(
-            sorted(labels),
-            sorted(
-                [
-                    "B_0",
-                    "B_2",
-                    "DELTA_0",
-                    "F_0",
-                    "GAMMA",
-                    "G_0",
-                    "G_2",
-                    "R",
-                    "R_2",
-                    "S",
-                    "T",
-                    "T_2",
-                    "Y",
-                    "Z",
-                    "Z_2",
-                ]
-            ),
+        assert sorted(labels) == sorted(
+            ["B_0", "B_2", "DELTA_0", "F_0", "GAMMA", "G_0", "G_2", "R", "R_2", "S", "T", "T_2", "Y", "Z", "Z_2"]
         )
 
-        self.assertAlmostEqual(kpoints["GAMMA"][0], 0.0)
-        self.assertAlmostEqual(kpoints["GAMMA"][1], 0.0)
-        self.assertAlmostEqual(kpoints["GAMMA"][2], 0.0)
+        assert kpoints["GAMMA"][0] == pytest.approx(0.0)
+        assert kpoints["GAMMA"][1] == pytest.approx(0.0)
+        assert kpoints["GAMMA"][2] == pytest.approx(0.0)
 
-        self.assertAlmostEqual(kpoints["Y"][0], 0.5)
-        self.assertAlmostEqual(kpoints["Y"][1], 0.5)
-        self.assertAlmostEqual(kpoints["Y"][2], 0.0)
+        assert kpoints["Y"][0] == pytest.approx(0.5)
+        assert kpoints["Y"][1] == pytest.approx(0.5)
+        assert kpoints["Y"][2] == pytest.approx(0.0)
 
-        self.assertAlmostEqual(kpoints["T"][0], 0.5)
-        self.assertAlmostEqual(kpoints["T"][1], 0.5)
-        self.assertAlmostEqual(kpoints["T"][2], 0.5)
+        assert kpoints["T"][0] == pytest.approx(0.5)
+        assert kpoints["T"][1] == pytest.approx(0.5)
+        assert kpoints["T"][2] == pytest.approx(0.5)
 
-        self.assertAlmostEqual(kpoints["T_2"][0], 0.5)
-        self.assertAlmostEqual(kpoints["T_2"][1], 0.5)
-        self.assertAlmostEqual(kpoints["T_2"][2], -0.5)
+        assert kpoints["T_2"][0] == pytest.approx(0.5)
+        assert kpoints["T_2"][1] == pytest.approx(0.5)
+        assert kpoints["T_2"][2] == pytest.approx(-0.5)
 
-        self.assertAlmostEqual(kpoints["Z"][0], 0.0)
-        self.assertAlmostEqual(kpoints["Z"][1], 0.0)
-        self.assertAlmostEqual(kpoints["Z"][2], 0.5)
+        assert kpoints["Z"][0] == pytest.approx(0.0)
+        assert kpoints["Z"][1] == pytest.approx(0.0)
+        assert kpoints["Z"][2] == pytest.approx(0.5)
 
-        self.assertAlmostEqual(kpoints["Z_2"][0], 0.0)
-        self.assertAlmostEqual(kpoints["Z_2"][1], 0.0)
-        self.assertAlmostEqual(kpoints["Z_2"][2], -0.5)
+        assert kpoints["Z_2"][0] == pytest.approx(0.0)
+        assert kpoints["Z_2"][1] == pytest.approx(0.0)
+        assert kpoints["Z_2"][2] == pytest.approx(-0.5)
 
-        self.assertAlmostEqual(kpoints["S"][0], 0.0)
-        self.assertAlmostEqual(kpoints["S"][1], 0.5)
-        self.assertAlmostEqual(kpoints["S"][2], 0.0)
+        assert kpoints["S"][0] == pytest.approx(0.0)
+        assert kpoints["S"][1] == pytest.approx(0.5)
+        assert kpoints["S"][2] == pytest.approx(0.0)
 
-        self.assertAlmostEqual(kpoints["R"][0], 0.0)
-        self.assertAlmostEqual(kpoints["R"][1], 0.5)
-        self.assertAlmostEqual(kpoints["R"][2], 0.5)
+        assert kpoints["R"][0] == pytest.approx(0.0)
+        assert kpoints["R"][1] == pytest.approx(0.5)
+        assert kpoints["R"][2] == pytest.approx(0.5)
 
-        self.assertAlmostEqual(kpoints["R_2"][0], 0.0)
-        self.assertAlmostEqual(kpoints["R_2"][1], 0.5)
-        self.assertAlmostEqual(kpoints["R_2"][2], -0.5)
+        assert kpoints["R_2"][0] == pytest.approx(0.0)
+        assert kpoints["R_2"][1] == pytest.approx(0.5)
+        assert kpoints["R_2"][2] == pytest.approx(-0.5)
 
-        self.assertAlmostEqual(kpoints["DELTA_0"][0], -0.25308641975308643)
-        self.assertAlmostEqual(kpoints["DELTA_0"][1], 0.25308641975308643)
-        self.assertAlmostEqual(kpoints["DELTA_0"][2], 0.0)
+        assert kpoints["DELTA_0"][0] == pytest.approx(-0.25308641975308643)
+        assert kpoints["DELTA_0"][1] == pytest.approx(0.25308641975308643)
+        assert kpoints["DELTA_0"][2] == pytest.approx(0.0)
 
-        self.assertAlmostEqual(kpoints["F_0"][0], 0.25308641975308643)
-        self.assertAlmostEqual(kpoints["F_0"][1], 0.7469135802469136)
-        self.assertAlmostEqual(kpoints["F_0"][2], 0.0)
+        assert kpoints["F_0"][0] == pytest.approx(0.25308641975308643)
+        assert kpoints["F_0"][1] == pytest.approx(0.7469135802469136)
+        assert kpoints["F_0"][2] == pytest.approx(0.0)
 
-        self.assertAlmostEqual(kpoints["B_0"][0], -0.25308641975308643)
-        self.assertAlmostEqual(kpoints["B_0"][1], 0.25308641975308643)
-        self.assertAlmostEqual(kpoints["B_0"][2], 0.5)
+        assert kpoints["B_0"][0] == pytest.approx(-0.25308641975308643)
+        assert kpoints["B_0"][1] == pytest.approx(0.25308641975308643)
+        assert kpoints["B_0"][2] == pytest.approx(0.5)
 
-        self.assertAlmostEqual(kpoints["B_2"][0], -0.25308641975308643)
-        self.assertAlmostEqual(kpoints["B_2"][1], 0.25308641975308643)
-        self.assertAlmostEqual(kpoints["B_2"][2], -0.5)
+        assert kpoints["B_2"][0] == pytest.approx(-0.25308641975308643)
+        assert kpoints["B_2"][1] == pytest.approx(0.25308641975308643)
+        assert kpoints["B_2"][2] == pytest.approx(-0.5)
 
-        self.assertAlmostEqual(kpoints["G_0"][0], 0.25308641975308643)
-        self.assertAlmostEqual(kpoints["G_0"][1], 0.7469135802469136)
-        self.assertAlmostEqual(kpoints["G_0"][2], 0.5)
+        assert kpoints["G_0"][0] == pytest.approx(0.25308641975308643)
+        assert kpoints["G_0"][1] == pytest.approx(0.7469135802469136)
+        assert kpoints["G_0"][2] == pytest.approx(0.5)
 
-        self.assertAlmostEqual(kpoints["G_2"][0], 0.25308641975308643)
-        self.assertAlmostEqual(kpoints["G_2"][1], 0.7469135802469136)
-        self.assertAlmostEqual(kpoints["G_2"][2], -0.5)
+        assert kpoints["G_2"][0] == pytest.approx(0.25308641975308643)
+        assert kpoints["G_2"][1] == pytest.approx(0.7469135802469136)
+        assert kpoints["G_2"][2] == pytest.approx(-0.5)
 
 
 if __name__ == "__main__":

--- a/pymatgen/symmetry/tests/test_kpath_lm.py
+++ b/pymatgen/symmetry/tests/test_kpath_lm.py
@@ -6,6 +6,7 @@ import os
 import unittest
 
 import numpy as np
+import pytest
 
 from pymatgen.analysis.magnetism.analyzer import CollinearMagneticStructureAnalyzer
 from pymatgen.core.lattice import Lattice
@@ -71,34 +72,31 @@ class KPathLatimerMunroTest(PymatgenTest):
         kpoints = kpath._kpath["kpoints"]
         labels = list(kpoints)
 
-        self.assertEqual(
-            sorted(labels),
-            sorted(["a", "b", "c", "d", "d_{1}", "e", "f", "q", "q_{1}", "Γ"]),
-        )
+        assert sorted(labels) == sorted(["a", "b", "c", "d", "d_{1}", "e", "f", "q", "q_{1}", "Γ"])
 
-        self.assertAlmostEqual(kpoints["a"][0], 0.0)
-        self.assertAlmostEqual(kpoints["a"][1], 0.4999999999999997)
-        self.assertAlmostEqual(kpoints["a"][2], 0.0)
+        assert kpoints["a"][0] == pytest.approx(0.0)
+        assert kpoints["a"][1] == pytest.approx(0.4999999999999997)
+        assert kpoints["a"][2] == pytest.approx(0.0)
 
-        self.assertAlmostEqual(kpoints["f"][0], -0.49999999999999933)
-        self.assertAlmostEqual(kpoints["f"][1], 0.4999999999999992)
-        self.assertAlmostEqual(kpoints["f"][2], 0.4999999999999999)
+        assert kpoints["f"][0] == pytest.approx(-0.49999999999999933)
+        assert kpoints["f"][1] == pytest.approx(0.4999999999999992)
+        assert kpoints["f"][2] == pytest.approx(0.4999999999999999)
 
-        self.assertAlmostEqual(kpoints["c"][0], 0.0)
-        self.assertAlmostEqual(kpoints["c"][1], 0.0)
-        self.assertAlmostEqual(kpoints["c"][2], 0.5)
+        assert kpoints["c"][0] == pytest.approx(0.0)
+        assert kpoints["c"][1] == pytest.approx(0.0)
+        assert kpoints["c"][2] == pytest.approx(0.5)
 
-        self.assertAlmostEqual(kpoints["b"][0], -0.5000000000000002)
-        self.assertAlmostEqual(kpoints["b"][1], 0.500000000000000)
-        self.assertAlmostEqual(kpoints["b"][2], 0.0)
+        assert kpoints["b"][0] == pytest.approx(-0.5000000000000002)
+        assert kpoints["b"][1] == pytest.approx(0.500000000000000)
+        assert kpoints["b"][2] == pytest.approx(0.0)
 
-        self.assertAlmostEqual(kpoints["Γ"][0], 0)
-        self.assertAlmostEqual(kpoints["Γ"][1], 0)
-        self.assertAlmostEqual(kpoints["Γ"][2], 0)
+        assert kpoints["Γ"][0] == pytest.approx(0)
+        assert kpoints["Γ"][1] == pytest.approx(0)
+        assert kpoints["Γ"][2] == pytest.approx(0)
 
-        self.assertAlmostEqual(kpoints["e"][0], 0.0)
-        self.assertAlmostEqual(kpoints["e"][1], 0.49999999999999956)
-        self.assertAlmostEqual(kpoints["e"][2], 0.5000000000000002)
+        assert kpoints["e"][0] == pytest.approx(0.0)
+        assert kpoints["e"][1] == pytest.approx(0.49999999999999956)
+        assert kpoints["e"][2] == pytest.approx(0.5000000000000002)
 
         d = False
         if np.allclose(kpoints["d_{1}"], [0.2530864197530836, 0.25308641975308915, 0.0], atol=1e-5) or np.allclose(
@@ -106,7 +104,7 @@ class KPathLatimerMunroTest(PymatgenTest):
         ):
             d = True
 
-        self.assertTrue(d)
+        assert d
 
         q = False
         if np.allclose(kpoints["q_{1}"], [0.2530864197530836, 0.25308641975308915, 0.5], atol=1e-5) or np.allclose(
@@ -114,7 +112,7 @@ class KPathLatimerMunroTest(PymatgenTest):
         ):
             q = True
 
-        self.assertTrue(q)
+        assert q
 
     def test_magnetic_kpath_generation(self):
         struct_file_path = os.path.join(test_dir_structs, "LaMnO3_magnetic.mcif")
@@ -139,42 +137,39 @@ class KPathLatimerMunroTest(PymatgenTest):
         kpoints = kpath._kpath["kpoints"]
         labels = list(kpoints)
 
-        self.assertEqual(
-            sorted(labels),
-            sorted(["a", "b", "c", "d", "d_{1}", "e", "f", "g", "g_{1}", "Γ"]),
-        )
+        assert sorted(labels) == sorted(["a", "b", "c", "d", "d_{1}", "e", "f", "g", "g_{1}", "Γ"])
 
-        self.assertAlmostEqual(kpoints["e"][0], -0.4999999999999998)
-        self.assertAlmostEqual(kpoints["e"][1], 0.0)
-        self.assertAlmostEqual(kpoints["e"][2], 0.5000000000000002)
+        assert kpoints["e"][0] == pytest.approx(-0.4999999999999998)
+        assert kpoints["e"][1] == pytest.approx(0.0)
+        assert kpoints["e"][2] == pytest.approx(0.5000000000000002)
 
-        self.assertAlmostEqual(kpoints["g"][0], -0.4999999999999999)
-        self.assertAlmostEqual(kpoints["g"][1], -0.49999999999999994)
-        self.assertAlmostEqual(kpoints["g"][2], 0.5000000000000002)
+        assert kpoints["g"][0] == pytest.approx(-0.4999999999999999)
+        assert kpoints["g"][1] == pytest.approx(-0.49999999999999994)
+        assert kpoints["g"][2] == pytest.approx(0.5000000000000002)
 
-        self.assertAlmostEqual(kpoints["a"][0], -0.4999999999999999)
-        self.assertAlmostEqual(kpoints["a"][1], 0.0)
-        self.assertAlmostEqual(kpoints["a"][2], 0.0)
+        assert kpoints["a"][0] == pytest.approx(-0.4999999999999999)
+        assert kpoints["a"][1] == pytest.approx(0.0)
+        assert kpoints["a"][2] == pytest.approx(0.0)
 
-        self.assertAlmostEqual(kpoints["g_{1}"][0], 0.4999999999999999)
-        self.assertAlmostEqual(kpoints["g_{1}"][1], -0.5)
-        self.assertAlmostEqual(kpoints["g_{1}"][2], 0.5000000000000001)
+        assert kpoints["g_{1}"][0] == pytest.approx(0.4999999999999999)
+        assert kpoints["g_{1}"][1] == pytest.approx(-0.5)
+        assert kpoints["g_{1}"][2] == pytest.approx(0.5000000000000001)
 
-        self.assertAlmostEqual(kpoints["f"][0], 0.0)
-        self.assertAlmostEqual(kpoints["f"][1], -0.5)
-        self.assertAlmostEqual(kpoints["f"][2], 0.5000000000000002)
+        assert kpoints["f"][0] == pytest.approx(0.0)
+        assert kpoints["f"][1] == pytest.approx(-0.5)
+        assert kpoints["f"][2] == pytest.approx(0.5000000000000002)
 
-        self.assertAlmostEqual(kpoints["c"][0], 0.0)
-        self.assertAlmostEqual(kpoints["c"][1], 0.0)
-        self.assertAlmostEqual(kpoints["c"][2], 0.5000000000000001)
+        assert kpoints["c"][0] == pytest.approx(0.0)
+        assert kpoints["c"][1] == pytest.approx(0.0)
+        assert kpoints["c"][2] == pytest.approx(0.5000000000000001)
 
-        self.assertAlmostEqual(kpoints["b"][0], 0.0)
-        self.assertAlmostEqual(kpoints["b"][1], -0.5)
-        self.assertAlmostEqual(kpoints["b"][2], 0.0)
+        assert kpoints["b"][0] == pytest.approx(0.0)
+        assert kpoints["b"][1] == pytest.approx(-0.5)
+        assert kpoints["b"][2] == pytest.approx(0.0)
 
-        self.assertAlmostEqual(kpoints["Γ"][0], 0)
-        self.assertAlmostEqual(kpoints["Γ"][1], 0)
-        self.assertAlmostEqual(kpoints["Γ"][2], 0)
+        assert kpoints["Γ"][0] == pytest.approx(0)
+        assert kpoints["Γ"][1] == pytest.approx(0)
+        assert kpoints["Γ"][2] == pytest.approx(0)
 
         d = False
         if np.allclose(kpoints["d_{1}"], [-0.5, -0.5, 0.0], atol=1e-5) or np.allclose(
@@ -182,7 +177,7 @@ class KPathLatimerMunroTest(PymatgenTest):
         ):
             d = True
 
-        self.assertTrue(d)
+        assert d
 
         g = False
         if np.allclose(kpoints["g_{1}"], [-0.5, -0.5, 0.5], atol=1e-5) or np.allclose(
@@ -190,7 +185,7 @@ class KPathLatimerMunroTest(PymatgenTest):
         ):
             g = True
 
-        self.assertTrue(g)
+        assert g
 
 
 if __name__ == "__main__":

--- a/pymatgen/symmetry/tests/test_kpath_sc.py
+++ b/pymatgen/symmetry/tests/test_kpath_sc.py
@@ -5,6 +5,8 @@
 import os
 import unittest
 
+import pytest
+
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Structure
 from pymatgen.symmetry.kpath import KPathSetyawanCurtarolo
@@ -54,7 +56,7 @@ class BandStructureSCTest(PymatgenTest):
         struct_file_path = os.path.join(test_dir_structs, "ICSD_170.cif")
         struct = Structure.from_file(struct_file_path)
         hkp = KPathSetyawanCurtarolo(struct)
-        self.assertEqual(hkp.name, "MCLC5")
+        assert hkp.name == "MCLC5"
 
     def test_kpath_acentered(self):
         species = ["K", "La", "Ti"]
@@ -66,50 +68,47 @@ class BandStructureSCTest(PymatgenTest):
         kpoints = kpath._kpath["kpoints"]
         labels = list(kpoints)
 
-        self.assertEqual(
-            sorted(labels),
-            sorted(["\\Gamma", "A", "A_1", "R", "S", "T", "X", "X_1", "Y", "Z"]),
-        )
+        assert sorted(labels) == sorted(["\\Gamma", "A", "A_1", "R", "S", "T", "X", "X_1", "Y", "Z"])
 
-        self.assertEqual(kpoints["\\Gamma"][0], 0.00000000)
-        self.assertAlmostEqual(kpoints["\\Gamma"][1], 0.00000000)
-        self.assertAlmostEqual(kpoints["\\Gamma"][2], 0.00000000)
+        assert kpoints["\\Gamma"][0] == 0.00000000
+        assert kpoints["\\Gamma"][1] == pytest.approx(0.00000000)
+        assert kpoints["\\Gamma"][2] == pytest.approx(0.00000000)
 
-        self.assertAlmostEqual(kpoints["A"][0], 0.25308642)
-        self.assertAlmostEqual(kpoints["A"][1], 0.25308642)
-        self.assertAlmostEqual(kpoints["A"][2], 0.50000000)
+        assert kpoints["A"][0] == pytest.approx(0.25308642)
+        assert kpoints["A"][1] == pytest.approx(0.25308642)
+        assert kpoints["A"][2] == pytest.approx(0.50000000)
 
-        self.assertAlmostEqual(kpoints["A_1"][0], -0.25308642)
-        self.assertAlmostEqual(kpoints["A_1"][1], 0.74691358)
-        self.assertAlmostEqual(kpoints["A_1"][2], 0.50000000)
+        assert kpoints["A_1"][0] == pytest.approx(-0.25308642)
+        assert kpoints["A_1"][1] == pytest.approx(0.74691358)
+        assert kpoints["A_1"][2] == pytest.approx(0.50000000)
 
-        self.assertAlmostEqual(kpoints["R"][0], 0.00000000)
-        self.assertAlmostEqual(kpoints["R"][1], 0.50000000)
-        self.assertAlmostEqual(kpoints["R"][2], 0.50000000)
+        assert kpoints["R"][0] == pytest.approx(0.00000000)
+        assert kpoints["R"][1] == pytest.approx(0.50000000)
+        assert kpoints["R"][2] == pytest.approx(0.50000000)
 
-        self.assertAlmostEqual(kpoints["S"][0], 0.00000000)
-        self.assertAlmostEqual(kpoints["S"][1], 0.50000000)
-        self.assertAlmostEqual(kpoints["S"][2], 0.00000000)
+        assert kpoints["S"][0] == pytest.approx(0.00000000)
+        assert kpoints["S"][1] == pytest.approx(0.50000000)
+        assert kpoints["S"][2] == pytest.approx(0.00000000)
 
-        self.assertAlmostEqual(kpoints["T"][0], -0.50000000)
-        self.assertAlmostEqual(kpoints["T"][1], 0.50000000)
-        self.assertAlmostEqual(kpoints["T"][2], 0.50000000)
+        assert kpoints["T"][0] == pytest.approx(-0.50000000)
+        assert kpoints["T"][1] == pytest.approx(0.50000000)
+        assert kpoints["T"][2] == pytest.approx(0.50000000)
 
-        self.assertAlmostEqual(kpoints["X"][0], 0.25308642)
-        self.assertAlmostEqual(kpoints["X"][1], 0.25308642)
-        self.assertAlmostEqual(kpoints["X"][2], 0.00000000)
+        assert kpoints["X"][0] == pytest.approx(0.25308642)
+        assert kpoints["X"][1] == pytest.approx(0.25308642)
+        assert kpoints["X"][2] == pytest.approx(0.00000000)
 
-        self.assertAlmostEqual(kpoints["X_1"][0], -0.25308642)
-        self.assertAlmostEqual(kpoints["X_1"][1], 0.74691358)
-        self.assertAlmostEqual(kpoints["X_1"][2], 0.00000000)
+        assert kpoints["X_1"][0] == pytest.approx(-0.25308642)
+        assert kpoints["X_1"][1] == pytest.approx(0.74691358)
+        assert kpoints["X_1"][2] == pytest.approx(0.00000000)
 
-        self.assertAlmostEqual(kpoints["Y"][0], -0.50000000)
-        self.assertAlmostEqual(kpoints["Y"][1], 0.50000000)
-        self.assertAlmostEqual(kpoints["Y"][2], 0.00000000)
+        assert kpoints["Y"][0] == pytest.approx(-0.50000000)
+        assert kpoints["Y"][1] == pytest.approx(0.50000000)
+        assert kpoints["Y"][2] == pytest.approx(0.00000000)
 
-        self.assertAlmostEqual(kpoints["Z"][0], 0.00000000)
-        self.assertAlmostEqual(kpoints["Z"][1], 0.00000000)
-        self.assertAlmostEqual(kpoints["Z"][2], 0.50000000)
+        assert kpoints["Z"][0] == pytest.approx(0.00000000)
+        assert kpoints["Z"][1] == pytest.approx(0.00000000)
+        assert kpoints["Z"][2] == pytest.approx(0.50000000)
 
 
 if __name__ == "__main__":

--- a/pymatgen/symmetry/tests/test_kpaths.py
+++ b/pymatgen/symmetry/tests/test_kpaths.py
@@ -65,8 +65,8 @@ class HighSymmKpathTest(PymatgenTest):
         cont_bs = loadfn(os.path.join(PymatgenTest.TEST_FILES_DIR, "Cu2O_361_bandstructure_continuous.json.gz"))
         alt_bs = HighSymmKpath(bs.structure).get_continuous_path(bs)
 
-        self.assertEqual(cont_bs.as_dict(), alt_bs.as_dict())
-        self.assertEqual(alt_bs.kpoints[0].label, alt_bs.kpoints[-1].label)
+        assert cont_bs.as_dict() == alt_bs.as_dict()
+        assert alt_bs.kpoints[0].label == alt_bs.kpoints[-1].label
 
 
 if __name__ == "__main__":

--- a/pymatgen/symmetry/tests/test_maggroups.py
+++ b/pymatgen/symmetry/tests/test_maggroups.py
@@ -33,19 +33,19 @@ class MagneticSpaceGroupTest(PymatgenTest):
         msg_from_bns_2 = MagneticSpaceGroup([71, 538])
         msg_from_og_1 = MagneticSpaceGroup.from_og("C_Immm")
         msg_from_og_2 = MagneticSpaceGroup.from_og([65, 10, 554])
-        self.assertEqual(msg_from_bns_1, msg_from_bns_2)
-        self.assertEqual(msg_from_og_1, msg_from_og_2)
-        self.assertEqual(msg_from_bns_1, msg_from_og_1)
+        assert msg_from_bns_1 == msg_from_bns_2
+        assert msg_from_og_1 == msg_from_og_2
+        assert msg_from_bns_1 == msg_from_og_1
 
     def test_crystal_system(self):
-        self.assertEqual(self.msg_1.crystal_system, "orthorhombic")
-        self.assertEqual(self.msg_2.crystal_system, "orthorhombic")
-        self.assertEqual(self.msg_3.crystal_system, "orthorhombic")
+        assert self.msg_1.crystal_system == "orthorhombic"
+        assert self.msg_2.crystal_system == "orthorhombic"
+        assert self.msg_3.crystal_system == "orthorhombic"
 
     def test_sg_symbol(self):
-        self.assertEqual(self.msg_1.sg_symbol, "Fd'd'd")
-        self.assertEqual(self.msg_2.sg_symbol, "Pn'ma'")
-        self.assertEqual(self.msg_3.sg_symbol, "C_A222_1")
+        assert self.msg_1.sg_symbol == "Fd'd'd"
+        assert self.msg_2.sg_symbol == "Pn'ma'"
+        assert self.msg_3.sg_symbol == "C_A222_1"
 
     def test_is_compatible(self):
         cubic = Lattice.cubic(1)
@@ -54,26 +54,26 @@ class MagneticSpaceGroupTest(PymatgenTest):
         tet = Lattice.tetragonal(1, 2)
         ortho = Lattice.orthorhombic(1, 2, 3)
         msg = MagneticSpaceGroup("Fm-3m")
-        self.assertTrue(msg.is_compatible(cubic))
-        self.assertFalse(msg.is_compatible(hexagonal))
+        assert msg.is_compatible(cubic)
+        assert not msg.is_compatible(hexagonal)
         msg = MagneticSpaceGroup("Pnma")
-        self.assertTrue(msg.is_compatible(cubic))
-        self.assertTrue(msg.is_compatible(tet))
-        self.assertTrue(msg.is_compatible(ortho))
-        self.assertFalse(msg.is_compatible(rhom))
-        self.assertFalse(msg.is_compatible(hexagonal))
+        assert msg.is_compatible(cubic)
+        assert msg.is_compatible(tet)
+        assert msg.is_compatible(ortho)
+        assert not msg.is_compatible(rhom)
+        assert not msg.is_compatible(hexagonal)
         msg = MagneticSpaceGroup("P2/c")
-        self.assertTrue(msg.is_compatible(cubic))
-        self.assertTrue(msg.is_compatible(tet))
-        self.assertTrue(msg.is_compatible(ortho))
-        self.assertFalse(msg.is_compatible(rhom))
-        self.assertFalse(msg.is_compatible(hexagonal))
+        assert msg.is_compatible(cubic)
+        assert msg.is_compatible(tet)
+        assert msg.is_compatible(ortho)
+        assert not msg.is_compatible(rhom)
+        assert not msg.is_compatible(hexagonal)
         msg = MagneticSpaceGroup("P-1")
-        self.assertTrue(msg.is_compatible(cubic))
-        self.assertTrue(msg.is_compatible(tet))
-        self.assertTrue(msg.is_compatible(ortho))
-        self.assertTrue(msg.is_compatible(rhom))
-        self.assertTrue(msg.is_compatible(hexagonal))
+        assert msg.is_compatible(cubic)
+        assert msg.is_compatible(tet)
+        assert msg.is_compatible(ortho)
+        assert msg.is_compatible(rhom)
+        assert msg.is_compatible(hexagonal)
 
     def test_symmetry_ops(self):
 
@@ -140,14 +140,14 @@ x+1/2, y, z+1/2, -1
 x, -y+1/2, -z+1/2, -1
 -x, y+1/2, -z, -1
 -x, -y+1/2, z, -1"""
-        self.assertEqual(msg_3_symmops, msg_3_symmops_ref)
+        assert msg_3_symmops == msg_3_symmops_ref
 
         msg_4_symmops = "\n".join([str(op) for op in self.msg_4.symmetry_ops])
         msg_4_symmops_ref = """x, y, z, +1
 -x, -y, -z, +1
 x+1/2, y, z, -1
 -x+1/2, -y, -z, -1"""
-        self.assertEqual(msg_4_symmops, msg_4_symmops_ref)
+        assert msg_4_symmops == msg_4_symmops_ref
 
     def test_equivalence_to_spacegroup(self):
 
@@ -161,13 +161,13 @@ x+1/2, y, z, -1
         for label in labels:
             sg = SpaceGroup(label)
             msg = MagneticSpaceGroup(label)
-            self.assertEqual(sg.crystal_system, msg.crystal_system)
+            assert sg.crystal_system == msg.crystal_system
             for p in points:
                 pp_sg = np.array(sg.get_orbit(p))
                 pp_msg = np.array(msg.get_orbit(p, 0)[0])  # discarding magnetic moment information
                 pp_sg = pp_sg[np.lexsort(np.transpose(pp_sg)[::-1])]  # sorting arrays so we can compare them
                 pp_msg = pp_msg[np.lexsort(np.transpose(pp_msg)[::-1])]
-                self.assertTrue(np.allclose(pp_sg, pp_msg))
+                assert np.allclose(pp_sg, pp_msg)
 
     def test_str(self):
 

--- a/pymatgen/symmetry/tests/test_settings.py
+++ b/pymatgen/symmetry/tests/test_settings.py
@@ -34,16 +34,16 @@ class JonesFaithfulTransformationTest(unittest.TestCase):
         for test_string, test_Pp in zip(self.test_strings, self.test_Pps):
             jft = JonesFaithfulTransformation.from_transformation_string(test_string)
             jft2 = JonesFaithfulTransformation(test_Pp[0], test_Pp[1])
-            self.assertTrue(np.allclose(jft.P, jft2.P))
-            self.assertTrue(np.allclose(jft.p, jft2.p))
-            self.assertEqual(test_string, jft.transformation_string)
-            self.assertEqual(test_string, jft2.transformation_string)
+            assert np.allclose(jft.P, jft2.P)
+            assert np.allclose(jft.p, jft2.p)
+            assert test_string == jft.transformation_string
+            assert test_string == jft2.transformation_string
 
     def test_inverse(self):
         for test_string in self.test_strings:
             jft = JonesFaithfulTransformation.from_transformation_string(test_string)
-            self.assertEqual(jft, jft.inverse.inverse)
-            self.assertEqual(jft.transformation_string, jft.inverse.inverse.transformation_string)
+            assert jft == jft.inverse.inverse
+            assert jft.transformation_string == jft.inverse.inverse.transformation_string
 
     def test_transform_lattice(self):
         lattice = Lattice.cubic(5)
@@ -57,7 +57,7 @@ class JonesFaithfulTransformationTest(unittest.TestCase):
 
         for ref_lattice, (P, p) in zip(all_ref_lattices, self.test_Pps):
             jft = JonesFaithfulTransformation(P, p)
-            self.assertTrue(np.allclose(jft.transform_lattice(lattice).matrix, ref_lattice))
+            assert np.allclose(jft.transform_lattice(lattice).matrix, ref_lattice)
 
     def test_transform_coords(self):
         coords = [[0, 0, 0], [0.5, 0.5, 0.5]]
@@ -73,7 +73,7 @@ class JonesFaithfulTransformationTest(unittest.TestCase):
             jft = JonesFaithfulTransformation(P, p)
             transformed_coords = jft.transform_coords(coords)
             for coord, ref_coord in zip(transformed_coords, ref_coords):
-                self.assertTrue(np.allclose(coord, ref_coord))
+                assert np.allclose(coord, ref_coord)
 
     def test_transform_symmops(self):
 
@@ -188,7 +188,7 @@ y,-x,-z+1/2
         transformed_symmops = [jft.transform_symmop(op) for op in input_symmops]
 
         for transformed_op, ref_transformed_op in zip(transformed_symmops, ref_transformed_symmops):
-            self.assertEqual(transformed_op, ref_transformed_op)
+            assert transformed_op == ref_transformed_op
 
 
 if __name__ == "__main__":

--- a/pymatgen/symmetry/tests/test_site_symmetries.py
+++ b/pymatgen/symmetry/tests/test_site_symmetries.py
@@ -27,8 +27,8 @@ class SiteSymmetriesTest(PymatgenTest):
 
     def test_get_site_symmetries(self):
         point_ops = ss.get_site_symmetries(self.piezo_struc)
-        self.assertTrue(np.all(point_ops == self.point_ops))
+        assert np.all(point_ops == self.point_ops)
 
     def test_get_shared_symmetries_operations(self):
         shared_ops = ss.get_shared_symmetry_operations(self.piezo_struc, self.point_ops)
-        self.assertTrue(np.all(shared_ops == self.shared_ops))
+        assert np.all(shared_ops == self.shared_ops)

--- a/pymatgen/util/num.py
+++ b/pymatgen/util/num.py
@@ -11,7 +11,7 @@ import numpy as np
 def abs_cap(val, max_abs_val=1):
     """
     Returns the value with its absolute value capped at max_abs_val.
-    Particularly useful in passing values to trignometric functions where
+    Particularly useful in passing values to trigonometric functions where
     numerical errors may result in an argument > 1 being passed in.
 
     Args:
@@ -72,10 +72,9 @@ def non_decreasing(values):
 
 
 def monotonic(values, mode="<", atol=1.0e-8):
-    """
-    Returns False if values are not monotonic (decreasing|increasing).
+    """True if values are monotonically (decreasing|increasing).
     mode is "<" for a decreasing sequence, ">" for an increasing sequence.
-    Two numbers are considered equal if they differ less that atol.
+    Two numbers are considered equal if they differ less than atol.
 
     .. warning:
         Not very efficient for large data sets.

--- a/pymatgen/util/tests/test_typing.py
+++ b/pymatgen/util/tests/test_typing.py
@@ -1,0 +1,50 @@
+from typing import Any
+
+# pymatgen.entries needs to be imported before pymatgen.util.typing
+# to avoid circular import.
+from pymatgen.entries import Entry
+from pymatgen.util.typing import (
+    CompositionLike,
+    EntryLike,
+    MatrixLike,
+    PathLike,
+    SpeciesLike,
+    VectorLike,
+)
+
+# This module tests types are as expected and can be imported without circular ImportError.
+
+
+def _type_str(some_type: Any) -> str:
+    return str(some_type).replace("typing.", "").replace("pymatgen.core.periodic_table.", "")
+
+
+def test_entry_like():
+    assert (
+        _type_str(EntryLike) == "Union[Dict[str, Any], ForwardRef('Entry'), "
+        "ForwardRef('PDEntry'), ForwardRef('ComputedEntry'), ForwardRef('ComputedStructureEntry')]"
+    )
+    assert Entry.__name__ in str(EntryLike)
+
+
+def test_species_like():
+    assert _type_str(SpeciesLike) == "Union[str, Element, Species, DummySpecies]"
+
+
+def test_composition_like():
+    assert (
+        _type_str(CompositionLike)
+        == "Union[str, Element, Species, DummySpecies, dict, pymatgen.core.composition.Composition]"
+    )
+
+
+def test_vector_like():
+    assert _type_str(VectorLike) == "Union[Sequence[float], numpy.ndarray]"
+
+
+def test_matrix_like():
+    assert _type_str(MatrixLike) == "Union[Sequence[Sequence[float]], Sequence[numpy.ndarray], numpy.ndarray]"
+
+
+def test_path_like():
+    assert _type_str(PathLike) == "Union[str, pathlib.Path]"

--- a/pymatgen/util/tests/test_typing.py
+++ b/pymatgen/util/tests/test_typing.py
@@ -14,6 +14,10 @@ from pymatgen.util.typing import (
 
 # This module tests types are as expected and can be imported without circular ImportError.
 
+__author__ = "Janosh Riebesell"
+__date__ = "2022-10-20"
+__email__ = "janosh@lbl.gov"
+
 
 def _type_str(some_type: Any) -> str:
     return str(some_type).replace("typing.", "").replace("pymatgen.core.periodic_table.", "")

--- a/pymatgen/util/typing.py
+++ b/pymatgen/util/typing.py
@@ -22,6 +22,11 @@ try:
 except ImportError:
     ArrayLike = Union[Sequence[float], Sequence[Sequence[float]], Sequence[np.ndarray], np.ndarray]  # type: ignore
 
+if TYPE_CHECKING:  # needed to avoid circular imports
+    from pymatgen.analysis.phase_diagram import PDEntry
+    from pymatgen.entries import Entry
+    from pymatgen.entries.computed_entries import ComputedEntry, ComputedStructureEntry
+
 VectorLike = Union[Sequence[float], np.ndarray]
 MatrixLike = Union[Sequence[Sequence[float]], Sequence[np.ndarray], np.ndarray]
 
@@ -33,10 +38,6 @@ SpeciesLike = Union[str, Element, Species, DummySpecies]
 # Things that can be cast to a Composition
 CompositionLike = Union[str, Element, Species, DummySpecies, dict, Composition]
 
-if TYPE_CHECKING:  # needed to avoid circular imports
-    from pymatgen.analysis.phase_diagram import PDEntry
-    from pymatgen.entries import Entry
-    from pymatgen.entries.computed_entries import ComputedEntry, ComputedStructureEntry
 
-    # Entry or any of its subclasses or dicts that can be unpacked into any of them
-    EntryLike = Union[Dict[str, Any], Entry, PDEntry, ComputedEntry, ComputedStructureEntry]
+# Entry or any of its subclasses or dicts that can be unpacked into any of them
+EntryLike = Union[Dict[str, Any], "Entry", "PDEntry", "ComputedEntry", "ComputedStructureEntry"]

--- a/pymatgen/util/typing.py
+++ b/pymatgen/util/typing.py
@@ -38,6 +38,5 @@ SpeciesLike = Union[str, Element, Species, DummySpecies]
 # Things that can be cast to a Composition
 CompositionLike = Union[str, Element, Species, DummySpecies, dict, Composition]
 
-
 # Entry or any of its subclasses or dicts that can be unpacked into any of them
 EntryLike = Union[Dict[str, Any], "Entry", "PDEntry", "ComputedEntry", "ComputedStructureEntry"]

--- a/pymatgen/util/typing.py
+++ b/pymatgen/util/typing.py
@@ -10,24 +10,33 @@ change until best practices are established.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Sequence, Union
+from typing import TYPE_CHECKING, Any, Dict, Sequence, Union
 
 import numpy as np
+
+from pymatgen.core.composition import Composition
+from pymatgen.core.periodic_table import DummySpecies, Element, Species
 
 try:
     from numpy.typing import ArrayLike
 except ImportError:
     ArrayLike = Union[Sequence[float], Sequence[Sequence[float]], Sequence[np.ndarray], np.ndarray]  # type: ignore
-from pymatgen.core.composition import Composition
-from pymatgen.core.periodic_table import DummySpecies, Element, Species
 
 VectorLike = Union[Sequence[float], np.ndarray]
 MatrixLike = Union[Sequence[Sequence[float]], Sequence[np.ndarray], np.ndarray]
 
 PathLike = Union[str, Path]
 
-# Things that can be cast into a Species-like object using get_el_sp
+# Things that can be cast to a Species-like object using get_el_sp
 SpeciesLike = Union[str, Element, Species, DummySpecies]
 
-# Things that can be cast into a Composition
+# Things that can be cast to a Composition
 CompositionLike = Union[str, Element, Species, DummySpecies, dict, Composition]
+
+if TYPE_CHECKING:  # needed to avoid circular imports
+    from pymatgen.analysis.phase_diagram import PDEntry
+    from pymatgen.entries import Entry
+    from pymatgen.entries.computed_entries import ComputedEntry, ComputedStructureEntry
+
+    # Entry or any of its subclasses or dicts that can be unpacked into any of them
+    EntryLike = Union[Dict[str, Any], Entry, PDEntry, ComputedEntry, ComputedStructureEntry]


### PR DESCRIPTION
```py
if TYPE_CHECKING:  # needed to avoid circular imports
    from pymatgen.analysis.phase_diagram import PDEntry
    from pymatgen.entries import Entry
    from pymatgen.entries.computed_entries import ComputedEntry, ComputedStructureEntry

    # Entry or any of its subclasses or dicts that can be unpacked into any of them
    EntryLike = Union[Dict[str, Any], Entry, PDEntry, ComputedEntry, ComputedStructureEntry]
```