### PR TITLE
Let env vars override `.pmgrc.yaml` in `_load_pmg_settings()` and make `~/.config` new default location for `.pmgrc.yaml`

### DIFF
--- a/pymatgen/cli/pmg_config.py
+++ b/pymatgen/cli/pmg_config.py
@@ -19,7 +19,7 @@ from urllib.request import urlretrieve
 
 from monty.serialization import dumpfn, loadfn
 
-from pymatgen.core import SETTINGS_FILE
+from pymatgen.core import OLD_SETTINGS_FILE, SETTINGS_FILE
 
 
 def setup_potcars(potcar_dirs: list[str]):
@@ -178,18 +178,27 @@ def install_software(install: Literal["enumlib", "bader"]):
 
 def add_config_var(tokens: list[str], backup_suffix: str) -> None:
     """Add/update keys in .pmgrc.yaml config file."""
-    d = {}
     if os.path.exists(SETTINGS_FILE):
+        # read and write new config file if exists
+        fpath = SETTINGS_FILE
+    elif os.path.exists(OLD_SETTINGS_FILE):
+        # else use old config file if exists
+        fpath = OLD_SETTINGS_FILE
+    else:
+        # if neither exists, create new config file
+        fpath = SETTINGS_FILE
+    d = {}
+    if os.path.exists(fpath):
         if backup_suffix:
-            shutil.copy(SETTINGS_FILE, SETTINGS_FILE + backup_suffix)
-            print(f"Existing {SETTINGS_FILE} backed up to {SETTINGS_FILE}{backup_suffix}")
-        d = loadfn(SETTINGS_FILE)
+            shutil.copy(fpath, fpath + backup_suffix)
+            print(f"Existing {fpath} backed up to {fpath}{backup_suffix}")
+        d = loadfn(fpath)
     if len(tokens) % 2 != 0:
         raise ValueError(f"Uneven number {len(tokens)} of tokens passed to pmg config. Needs a value for every key.")
     for key, val in zip(tokens[0::2], tokens[1::2]):
         d[key] = val
-    dumpfn(d, SETTINGS_FILE)
-    print(f"New {SETTINGS_FILE} written!")
+    dumpfn(d, fpath)
+    print(f"New {fpath} written!")
 
 
 def configure_pmg(args: Namespace):

--- a/pymatgen/core/__init__.py
+++ b/pymatgen/core/__init__.py
@@ -28,29 +28,34 @@ __maintainer_email__ = "shyuep@gmail.com"
 __version__ = "2022.9.21"
 
 
-SETTINGS_FILE = os.path.join(os.path.expanduser("~"), ".pmgrc.yaml")
+SETTINGS_FILE = os.path.join(os.path.expanduser("~"), ".config", ".pmgrc.yaml")
+OLD_SETTINGS_FILE = os.path.join(os.path.expanduser("~"), ".pmgrc.yaml")
 
 
 def _load_pmg_settings() -> dict[str, str]:
     settings = {}
     # Load .pmgrc.yaml file
+    yaml = YAML()
     try:
-        yaml = YAML()
         with open(SETTINGS_FILE) as yml_file:
             settings = yaml.load(yml_file)
     except FileNotFoundError:
-        pass
+        try:
+            with open(OLD_SETTINGS_FILE) as yml_file:
+                settings = yaml.load(yml_file)
+        except FileNotFoundError:
+            pass
     except Exception as ex:
         # If there are any errors, default to using environment variables
         # if present.
         warnings.warn(f"Error loading .pmgrc.yaml: {ex}. You may need to reconfigure your yaml file.")
 
     # Override .pmgrc.yaml with env vars if present
-    for k, v in os.environ.items():
-        if k.startswith("PMG_"):
-            settings[k] = v
-        elif k in ["VASP_PSP_DIR", "MAPI_KEY", "DEFAULT_FUNCTIONAL"]:
-            settings["PMG_" + k] = v
+    for key, val in os.environ.items():
+        if key.startswith("PMG_"):
+            settings[key] = val
+        elif key in ("VASP_PSP_DIR", "MAPI_KEY", "DEFAULT_FUNCTIONAL"):
+            settings[f"PMG_{key}"] = val
 
     return settings
 

--- a/pymatgen/core/__init__.py
+++ b/pymatgen/core/__init__.py
@@ -34,16 +34,16 @@ SETTINGS_FILE = os.path.join(os.path.expanduser("~"), ".pmgrc.yaml")
 def _load_pmg_settings() -> dict[str, str]:
     settings = {}
     # Load .pmgrc.yaml file
-    if os.path.exists(SETTINGS_FILE):
-        try:
-            yaml = YAML()
-            with open(SETTINGS_FILE) as f:
-                d_yml = yaml.load(f)
-            settings.update(d_yml)
-        except Exception as ex:
-            # If there are any errors, default to using environment variables
-            # if present.
-            warnings.warn(f"Error loading .pmgrc.yaml: {ex}. You may need to reconfigure your yaml file.")
+    try:
+        yaml = YAML()
+        with open(SETTINGS_FILE) as yml_file:
+            settings = yaml.load(yml_file)
+    except FileNotFoundError:
+        pass
+    except Exception as ex:
+        # If there are any errors, default to using environment variables
+        # if present.
+        warnings.warn(f"Error loading .pmgrc.yaml: {ex}. You may need to reconfigure your yaml file.")
 
     # Override .pmgrc.yaml with env vars if present
     for k, v in os.environ.items():

--- a/pymatgen/core/__init__.py
+++ b/pymatgen/core/__init__.py
@@ -6,6 +6,8 @@ This package contains core modules and classes for representing structures and
 operations on them.
 """
 
+from __future__ import annotations
+
 import os
 import warnings
 
@@ -29,28 +31,28 @@ __version__ = "2022.9.21"
 SETTINGS_FILE = os.path.join(os.path.expanduser("~"), ".pmgrc.yaml")
 
 
-def _load_pmg_settings():
-    # Load environment variables by default as backup
-    d = {}
-    for k, v in os.environ.items():
-        if k.startswith("PMG_"):
-            d[k] = v
-        elif k in ["VASP_PSP_DIR", "MAPI_KEY", "DEFAULT_FUNCTIONAL"]:
-            d["PMG_" + k] = v
-
-    # Override anything in env vars with that in yml file
+def _load_pmg_settings() -> dict[str, str]:
+    settings = {}
+    # Load .pmgrc.yaml file
     if os.path.exists(SETTINGS_FILE):
         try:
             yaml = YAML()
             with open(SETTINGS_FILE) as f:
                 d_yml = yaml.load(f)
-            d.update(d_yml)
+            settings.update(d_yml)
         except Exception as ex:
             # If there are any errors, default to using environment variables
             # if present.
             warnings.warn(f"Error loading .pmgrc.yaml: {ex}. You may need to reconfigure your yaml file.")
 
-    return d
+    # Override .pmgrc.yaml with env vars if present
+    for k, v in os.environ.items():
+        if k.startswith("PMG_"):
+            settings[k] = v
+        elif k in ["VASP_PSP_DIR", "MAPI_KEY", "DEFAULT_FUNCTIONAL"]:
+            settings["PMG_" + k] = v
+
+    return settings
 
 
 SETTINGS = _load_pmg_settings()

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -470,7 +470,6 @@ class Poscar(MSONable):
         Returns:
             String representation of POSCAR.
         """
-
         # This corrects for VASP really annoying bug of crashing on lattices
         # which have triple product < 0. We will just invert the lattice
         # vectors.
@@ -1244,12 +1243,9 @@ class Kpoints(MSONable):
             reciprocal lattice vector proportional to its length.
 
         Args:
-            structure:
-                Input structure
-            kppa:
-                Grid density
+            structure: Input structure
+            kppa: Grid density
         """
-
         latt = structure.lattice
         lengths = latt.abc
         ngrid = kppa / structure.num_sites
@@ -1889,8 +1885,8 @@ class PotcarSingle:
         :param functional: E.g., PBE
         :return: PotcarSingle
         """
-        if functional is None:
-            functional = SETTINGS.get("PMG_DEFAULT_FUNCTIONAL", "PBE")
+        functional = functional or SETTINGS.get("PMG_DEFAULT_FUNCTIONAL", "PBE")
+        assert isinstance(functional, str)  # type narrowing
         funcdir = PotcarSingle.functional_dir[functional]
         d = SETTINGS.get("PMG_VASP_PSP_DIR")
         if d is None:
@@ -2158,7 +2154,6 @@ class PotcarSingle:
         For float type properties, they are converted to the correct float. By
         default, all energies in eV and all length scales are in Angstroms.
         """
-
         try:
             return self.keywords[a.upper()]
         except Exception:
@@ -2420,7 +2415,9 @@ class VaspInput(dict, MSONable):
         :param err_file: File to write err.
         """
         self.write_input(output_dir=run_dir)
-        vasp_cmd = vasp_cmd or SETTINGS.get("PMG_VASP_EXE")
+        vasp_cmd = vasp_cmd or SETTINGS.get("PMG_VASP_EXE")  # type: ignore[assignment]
+        if not vasp_cmd:
+            raise ValueError("No VASP executable specified!")
         vasp_cmd = [os.path.expanduser(os.path.expandvars(t)) for t in vasp_cmd]
         if not vasp_cmd:
             raise RuntimeError("You need to supply vasp_cmd or set the PMG_VASP_EXE in .pmgrc.yaml to run VASP.")


### PR DESCRIPTION
@shyuep @mkhorton `_load_pmg_settings()` currently reads env vars first and then overrides them with `.pmgrc.yaml`. It's usually the other way around.

This gives users no way to override on a case by case basis. E.g.

```sh
PMG_MAPI_KEY=xxxxxxxxxxxxxxxx python -c 'from pymatgen.ext.matproj import MPRester; MPRester().query("mp-1234", ["formula"])'
```

will be identical to

```py
python -c 'from pymatgen.ext.matproj import MPRester; MPRester().query("mp-1234", ["formula"])'
```

Following [POLA](https://en.wikipedia.org/wiki/Principle_of_least_astonishment), I think we should swap this around and let env vars override `.pmgrc.yaml`.