### PR TITLE
Fix parsing of "Atomic configuration" in POTCAR

### DIFF
--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -1737,17 +1737,20 @@ class PotcarSingle:
         array_search = re.compile(r"(-*[0-9.]+)")
         orbitals = []
         descriptions = []
-        atomic_configuration = re.search(r"Atomic configuration\s*\n?" r"(.*?)Description", search_lines)
+        atomic_configuration = re.search(
+            r"(?s)Atomic configuration(.*?)Description",
+            search_lines,
+        )
         if atomic_configuration:
             lines = atomic_configuration.group(1).splitlines()
-            num_entries = re.search(r"([0-9]+)", lines[0]).group(1)
+            num_entries = re.search(r"([0-9]+)", lines[1]).group(1)
             num_entries = int(num_entries)
             PSCTR["nentries"] = num_entries
-            for line in lines[1:]:
+            for line in lines[3:]:
                 orbit = array_search.findall(line)
                 if orbit:
                     orbitals.append(
-                        self.Orbital(
+                        Orbital(
                             int(orbit[0]),
                             int(orbit[1]),
                             float(orbit[2]),
@@ -2121,6 +2124,8 @@ class PotcarSingle:
         """
         hash_str = ""
         for k, v in self.PSCTR.items():
+            if k in ("nentries", "Orbitals"):
+                continue
             hash_str += f"{k}"
             if isinstance(v, int):
                 hash_str += f"{v}"

--- a/pymatgen/io/vasp/tests/test_inputs.py
+++ b/pymatgen/io/vasp/tests/test_inputs.py
@@ -881,6 +881,37 @@ class PotcarSingleTest(PymatgenTest):
         }
         self.assertEqual(self.psingle.keywords, data)
 
+    def test_psctr(self):
+        filename = PymatgenTest.TEST_FILES_DIR / "POT_GGA_PAW_PBE_54" / "POTCAR.Fe.gz"
+
+        with pytest.warns(None):
+            psingle = PotcarSingle.from_file(filename)
+
+        data = {
+            "nentries": 9,
+            "Orbitals": (
+                (1, 0, 0.50, -6993.8440, 2.0000),
+                (2, 0, 0.50, -0814.6047, 2.0000),
+                (2, 1, 1.50, -0693.3689, 6.0000),
+                (3, 0, 0.50, -0089.4732, 2.0000),
+                (3, 1, 1.50, -0055.6373, 6.0000),
+                (3, 2, 2.50, -0003.8151, 7.0000),
+                (4, 0, 0.50, -0004.2551, 1.0000),
+                (4, 1, 1.50, -0003.4015, 0.0000),
+                (4, 3, 2.50, -0001.3606, 0.0000),
+            ),
+            "OrbitalDescriptions": (
+                (2, -3.8151135, 23, 2.300, None, None),
+                (2, -5.1756961, 23, 2.300, None, None),
+                (0, -4.2550963, 23, 2.300, None, None),
+                (0, 07.2035603, 23, 2.300, None, None),
+                (1, -2.7211652, 23, 2.300, None, None),
+                (1, 18.4316424, 23, 2.300, None, None),
+            ),
+        }
+        for k, v in data.items():
+            self.assertEqual(psingle.PSCTR[k], v)
+
     def test_nelectrons(self):
         self.assertEqual(self.psingle.nelectrons, 13)
 

--- a/pymatgen/io/vasp/tests/test_inputs.py
+++ b/pymatgen/io/vasp/tests/test_inputs.py
@@ -884,7 +884,7 @@ class PotcarSingleTest(PymatgenTest):
     def test_psctr(self):
         filename = PymatgenTest.TEST_FILES_DIR / "POT_GGA_PAW_PBE_54" / "POTCAR.Fe.gz"
 
-        with pytest.warns(None):
+        with pytest.warns():
             psingle = PotcarSingle.from_file(filename)
 
         data = {
@@ -969,7 +969,7 @@ class PotcarSingleTest(PymatgenTest):
     def test_identify_potcar(self):
         filename = PymatgenTest.TEST_FILES_DIR / "POT_GGA_PAW_PBE_54" / "POTCAR.Fe.gz"
 
-        with pytest.warns(None):
+        with pytest.warns():
             psingle = PotcarSingle.from_file(filename)
         assert "PBE_54" in psingle.identify_potcar()[0]
         assert "Fe" in psingle.identify_potcar()[1]


### PR DESCRIPTION
First of all, thank you so much for the development of pymatgen!

## Summary

Due to the missing regex option of `(?s)` (https://docs.python.org/3/library/re.html#re.S, which makes the `.` special character match any character at all, including a newline), "Atomic configuration" in POTCAR (52 and 54) was actually not parsed. I think this part is sometimes useful for, e.g., estimating a reasonable NBANDS value. My pull request fixes the issue above. In more detail:
- `re.search` for this is slightly simplified.
- The change above adds "nentries" and "Orbitals" to PSCTR. In `get_potcar_hash`, these two keys are excluded to keep the same hash values as before.
- A new test `test_psctr` is added to check if the parsing is done correctly.