### PR TITLE
Add `check_egg_sources_txt_for_completeness()` to `tasks.py`

### DIFF
--- a/pymatgen/entries/compatibility.py
+++ b/pymatgen/entries/compatibility.py
@@ -61,7 +61,7 @@ class Correction(metaclass=abc.ABCMeta):
     """
 
     @abc.abstractmethod
-    def get_correction(self, entry):
+    def get_correction(self, entry: AnyComputedEntry) -> EnergyAdjustment:
         """
         Returns correction and uncertainty for a single entry.
 
@@ -74,7 +74,7 @@ class Correction(metaclass=abc.ABCMeta):
         Raises:
             CompatibilityError if entry is not compatible.
         """
-        return
+        raise NotImplementedError
 
     def correct_entry(self, entry):
         """
@@ -133,7 +133,7 @@ class PotcarCorrection(Correction):
 
         Raises:
             ValueError if entry do not contain "potcar_symbols" key.
-            CombatibilityError if wrong potcar symbols
+            CompatibilityError if wrong potcar symbols
         """
         potcar_settings = input_set.CONFIG["POTCAR"]
         if isinstance(list(potcar_settings.values())[-1], dict):

--- a/tasks.py
+++ b/tasks.py
@@ -346,7 +346,7 @@ def check_egg_sources_txt_for_completeness():
         if not os.path.exists(src_file):
             raise ValueError(f"{src_file} does not exist!")
 
-    for ext in ("py", "json", "yaml"):
+    for ext in ("py", "json", "json.gz", "yaml", "csv"):
         for filepath in glob(f"pymatgen/**/*.{ext}", recursive=True):
             if "/tests/" in filepath:
                 continue

--- a/tasks.py
+++ b/tasks.py
@@ -6,12 +6,12 @@ To cut a new pymatgen release, use `invoke update-changelog` followed by `invoke
 Author: Shyue Ping Ong
 """
 import datetime
-import glob
 import json
 import os
 import re
 import subprocess
 import webbrowser
+from glob import glob
 
 import requests
 from invoke import task
@@ -44,7 +44,7 @@ def make_doc(ctx):
         ctx.run("rm pymatgen.*.rst", warn=True)
         ctx.run("sphinx-apidoc --implicit-namespaces --separate -d 7 -o . -f ../pymatgen")
         ctx.run("rm *.tests.*rst")
-        for f in glob.glob("*.rst"):
+        for f in glob("*.rst"):
             if f.startswith("pymatgen") and f.endswith("rst"):
                 newoutput = []
                 suboutput = []
@@ -222,8 +222,7 @@ def release_github(ctx, version):
     print(response.text)
 
 
-@task
-def post_discourse(ctx, version):
+def post_discourse(version):
     """
     Post release announcement to http://discuss.matsci.org/c/pymatgen.
 
@@ -235,7 +234,7 @@ def post_discourse(ctx, version):
     desc = toks[1].strip()
     toks = desc.split("\n")
     desc = "\n".join(toks[:-1]).strip()
-    raw = "v" + version + "\n\n" + desc
+    raw = f"v{version}\n\n{desc}"
     payload = {
         "topic_id": 36,
         "raw": raw,
@@ -249,12 +248,13 @@ def post_discourse(ctx, version):
 
 
 @task
-def update_changelog(ctx, version=datetime.datetime.now().strftime("%Y.%-m.%-d"), sim=False):
+def update_changelog(ctx, version=None, sim=False):
     """
     Create a preliminary change log using the git logs.
 
     :param ctx:
     """
+    version = version or f"{datetime.datetime.now():%Y.%-m.%-d}"
     output = subprocess.check_output(["git", "log", "--pretty=format:%s", f"v{CURRENT_VER}..HEAD"])
     lines = []
     misc = []
@@ -292,13 +292,14 @@ def update_changelog(ctx, version=datetime.datetime.now().strftime("%Y.%-m.%-d")
 
 
 @task
-def release(ctx, version=datetime.datetime.now().strftime("%Y.%-m.%-d"), nodoc=False):
+def release(ctx, version=None, nodoc=False):
     """
     Run full sequence for releasing pymatgen.
 
     :param ctx:
     :param nodoc: Whether to skip doc generation.
     """
+    version = version or f"{datetime.datetime.now():%Y.%-m.%-d}"
     ctx.run("rm -r dist build pymatgen.egg-info", warn=True)
     set_ver(ctx, version)
     if not nodoc:
@@ -307,6 +308,7 @@ def release(ctx, version=datetime.datetime.now().strftime("%Y.%-m.%-d"), nodoc=F
         ctx.run('git commit -a -m "Update docs"')
         ctx.run("git push")
     release_github(ctx, version)
+    check_egg_sources_txt_for_completeness()
     ctx.run("rm -f dist/*.*", warn=True)
     ctx.run("python setup.py sdist bdist_wheel", warn=True)
     ctx.run("twine upload --skip-existing dist/*.whl", warn=True)
@@ -329,3 +331,24 @@ def open_doc(ctx):
 def lint(ctx):
     for cmd in ["pycodestyle", "mypy", "flake8", "pydocstyle"]:
         ctx.run(f"{cmd} pymatgen")
+
+
+def check_egg_sources_txt_for_completeness():
+    """Check that all source and data files in pymatgen/ are listed in pymatgen.egg-info/SOURCES.txt."""
+    src_txt = "pymatgen.egg-info/SOURCES.txt"
+    if not os.path.exists(src_txt):
+        raise FileNotFoundError(f"{src_txt} not found. Run `pip install .` to create")
+
+    with open(src_txt) as file:
+        sources = file.read()
+
+    for src_file in sources.splitlines():
+        if not os.path.exists(src_file):
+            raise ValueError(f"{src_file} does not exist!")
+
+    for ext in ("py", "json", "yaml"):
+        for filepath in glob(f"pymatgen/**/*.{ext}", recursive=True):
+            if "/tests/" in filepath:
+                continue
+            if filepath not in sources:
+                raise ValueError(f"{filepath} not found in {src_txt}")


### PR DESCRIPTION
Following discussion initiated by @sgbaird and @mkhorton in https://github.com/materialsproject/pymatgen/pull/2708#issuecomment-1292477362.

@shyuep I'm not familiar with `invoke`. The function I added `check_egg_sources_txt_for_completeness()` is not `@task` decorated. it's simply called by the `release` task. Every other function in `tasks.py` seems to be. Is that a requirement?