### PR TITLE
Breaking: swap `fmt` and `filename` in `Structure.to()`

### DIFF
--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -2419,7 +2419,7 @@ class IStructure(SiteCollection, MSONable):
         charge = d.get("charge", None)
         return cls.from_sites(sites, charge=charge)
 
-    def to(self, fmt: str = None, filename: str = None, **kwargs) -> str | None:  # type: ignore
+    def to(self, fmt: str = "", filename: str = "", **kwargs) -> str | None:  # type: ignore
         """
         Outputs the structure to a file or string.
 
@@ -2439,56 +2439,57 @@ class IStructure(SiteCollection, MSONable):
         Returns:
             (str) if filename is None. None otherwise.
         """
-        filename = filename or ""
-        fmt = "" if fmt is None else fmt.lower()
-        fname = os.path.basename(filename)
+        fmt = fmt.lower()
 
-        if fmt == "cif" or fnmatch(fname.lower(), "*.cif*"):
+        if fmt == "cif" or fnmatch(filename.lower(), "*.cif*"):
             from pymatgen.io.cif import CifWriter
 
             writer = CifWriter(self, **kwargs)
-        elif fmt == "mcif" or fnmatch(fname.lower(), "*.mcif*"):
+        elif fmt == "mcif" or fnmatch(filename.lower(), "*.mcif*"):
             from pymatgen.io.cif import CifWriter
 
             writer = CifWriter(self, write_magmoms=True, **kwargs)
-        elif fmt == "poscar" or fnmatch(fname, "*POSCAR*"):
+        elif fmt == "poscar" or fnmatch(filename, "*POSCAR*"):
             from pymatgen.io.vasp import Poscar
 
             writer = Poscar(self, **kwargs)
-        elif fmt == "cssr" or fnmatch(fname.lower(), "*.cssr*"):
+        elif fmt == "cssr" or fnmatch(filename.lower(), "*.cssr*"):
             from pymatgen.io.cssr import Cssr
 
             writer = Cssr(self)  # type: ignore
-        elif fmt == "json" or fnmatch(fname.lower(), "*.json"):
+        elif fmt == "json" or fnmatch(filename.lower(), "*.json"):
             s = json.dumps(self.as_dict())
             if filename:
                 with zopen(filename, "wt") as f:
                     f.write(s)
             return s
-        elif fmt == "xsf" or fnmatch(fname.lower(), "*.xsf*"):
+        elif fmt == "xsf" or fnmatch(filename.lower(), "*.xsf*"):
             from pymatgen.io.xcrysden import XSF
 
             s = XSF(self).to_string()
             if filename:
-                with zopen(fname, "wt", encoding="utf8") as f:
+                with zopen(filename, "wt", encoding="utf8") as f:
                     f.write(s)
             return s
         elif (
-            fmt == "mcsqs" or fnmatch(fname, "*rndstr.in*") or fnmatch(fname, "*lat.in*") or fnmatch(fname, "*bestsqs*")
+            fmt == "mcsqs"
+            or fnmatch(filename, "*rndstr.in*")
+            or fnmatch(filename, "*lat.in*")
+            or fnmatch(filename, "*bestsqs*")
         ):
             from pymatgen.io.atat import Mcsqs
 
             s = Mcsqs(self).to_string()
             if filename:
-                with zopen(fname, "wt", encoding="ascii") as f:
+                with zopen(filename, "wt", encoding="ascii") as f:
                     f.write(s)
             return s
-        elif fmt == "prismatic" or fnmatch(fname, "*prismatic*"):
+        elif fmt == "prismatic" or fnmatch(filename, "*prismatic*"):
             from pymatgen.io.prismatic import Prismatic
 
             s = Prismatic(self).to_string()
             return s
-        elif fmt == "yaml" or fnmatch(fname, "*.yaml*") or fnmatch(fname, "*.yml*"):
+        elif fmt == "yaml" or fnmatch(filename, "*.yaml*") or fnmatch(filename, "*.yml*"):
             yaml = YAML()
             if filename:
                 with zopen(filename, "wt") as f:
@@ -2497,11 +2498,11 @@ class IStructure(SiteCollection, MSONable):
             sio = StringIO()
             yaml.dump(self.as_dict(), sio)
             return sio.getvalue()
-        elif fmt == "fleur-inpgen" or fnmatch(fname, "*.in*"):
+        elif fmt == "fleur-inpgen" or fnmatch(filename, "*.in*"):
             from pymatgen.io.fleur import FleurInput
 
             writer = FleurInput(self, **kwargs)
-        elif fmt == "res" or fnmatch(fname, "*.res"):
+        elif fmt == "res" or fnmatch(filename, "*.res"):
             from pymatgen.io.res import ResIO
 
             s = ResIO.structure_to_str(self)

--- a/pymatgen/core/tests/test_structure.py
+++ b/pymatgen/core/tests/test_structure.py
@@ -10,6 +10,7 @@ from shutil import which
 
 import numpy as np
 import pytest
+from monty.tempfile import ScratchDir
 
 from pymatgen.core.composition import Composition
 from pymatgen.core.lattice import Lattice
@@ -677,43 +678,41 @@ Direct
         self.assertArrayAlmostEqual(self.struct.distance_matrix, ans)
 
     def test_to_from_file_string(self):
-        for fmt in ["cif", "json", "poscar", "cssr"]:
-            s = self.struct.to(fmt=fmt)
-            assert s is not None
-            ss = IStructure.from_str(s, fmt=fmt)
-            self.assertArrayAlmostEqual(ss.lattice.parameters, self.struct.lattice.parameters, decimal=5)
-            self.assertArrayAlmostEqual(ss.frac_coords, self.struct.frac_coords)
-            assert isinstance(ss, IStructure)
+        with ScratchDir("."):
+            for fmt in ["cif", "json", "poscar", "cssr"]:
+                s = self.struct.to(fmt=fmt)
+                assert s is not None
+                ss = IStructure.from_str(s, fmt=fmt)
+                self.assertArrayAlmostEqual(ss.lattice.parameters, self.struct.lattice.parameters, decimal=5)
+                self.assertArrayAlmostEqual(ss.frac_coords, self.struct.frac_coords)
+                assert isinstance(ss, IStructure)
 
-        assert "Fd-3m" in self.struct.to(fmt="CIF", symprec=0.1)
+            assert "Fd-3m" in self.struct.to(fmt="CIF", symprec=0.1)
 
-        self.struct.to(filename="POSCAR.testing")
-        assert os.path.exists("POSCAR.testing")
-        os.remove("POSCAR.testing")
+            self.struct.to(filename="POSCAR.testing")
+            assert os.path.exists("POSCAR.testing")
 
-        self.struct.to(filename="Si_testing.yaml")
-        assert os.path.exists("Si_testing.yaml")
-        s = Structure.from_file("Si_testing.yaml")
-        assert s == self.struct
-        # Test Path support.
-        s = Structure.from_file(Path("Si_testing.yaml"))
-        assert s == self.struct
+            self.struct.to(filename="Si_testing.yaml")
+            assert os.path.exists("Si_testing.yaml")
+            s = Structure.from_file("Si_testing.yaml")
+            assert s == self.struct
+            # Test Path support.
+            s = Structure.from_file(Path("Si_testing.yaml"))
+            assert s == self.struct
 
-        # Test .yml extension works too.
-        os.replace("Si_testing.yaml", "Si_testing.yml")
-        s = Structure.from_file("Si_testing.yml")
-        assert s == self.struct
-        os.remove("Si_testing.yml")
+            # Test .yml extension works too.
+            os.replace("Si_testing.yaml", "Si_testing.yml")
+            s = Structure.from_file("Si_testing.yml")
+            assert s == self.struct
 
-        with pytest.raises(ValueError):
-            self.struct.to(filename="whatever")
-        with pytest.raises(ValueError):
-            self.struct.to(fmt="badformat")
+            with pytest.raises(ValueError):
+                self.struct.to(filename="whatever")
+            with pytest.raises(ValueError):
+                self.struct.to(fmt="badformat")
 
-        self.struct.to(filename="POSCAR.testing.gz")
-        s = Structure.from_file("POSCAR.testing.gz")
-        assert s == self.struct
-        os.remove("POSCAR.testing.gz")
+            self.struct.to(filename="POSCAR.testing.gz")
+            s = Structure.from_file("POSCAR.testing.gz")
+            assert s == self.struct
 
     def test_pbc(self):
         self.assertArrayEqual(self.struct.pbc, (True, True, True))
@@ -1056,23 +1055,20 @@ class StructureTest(PymatgenTest):
         assert isinstance(s2, Structure)
 
     def test_to_from_file_string(self):
-        for fmt in ["cif", "json", "poscar", "cssr", "yaml", "xsf", "res"]:
-            s = self.structure.to(fmt=fmt)
-            assert s is not None
-            ss = Structure.from_str(s, fmt=fmt)
-            self.assertArrayAlmostEqual(ss.lattice.parameters, self.structure.lattice.parameters, decimal=5)
-            self.assertArrayAlmostEqual(ss.frac_coords, self.structure.frac_coords)
-            assert isinstance(ss, Structure)
+        with ScratchDir("."):
+            for fmt in ["cif", "json", "poscar", "cssr", "yaml", "xsf", "res"]:
+                s = self.structure.to(fmt=fmt)
+                assert s is not None
+                ss = Structure.from_str(s, fmt=fmt)
+                self.assertArrayAlmostEqual(ss.lattice.parameters, self.structure.lattice.parameters, decimal=5)
+                self.assertArrayAlmostEqual(ss.frac_coords, self.structure.frac_coords)
+                assert isinstance(ss, Structure)
 
-        self.structure.to(filename="POSCAR.testing")
-        assert os.path.exists("POSCAR.testing")
-        os.remove("POSCAR.testing")
+            self.structure.to(filename="POSCAR.testing")
+            assert os.path.exists("POSCAR.testing")
 
-        self.structure.to(filename="structure_testing.json")
-        assert os.path.exists("structure_testing.json")
-        s = Structure.from_file("structure_testing.json")
-        assert s == self.structure
-        os.remove("structure_testing.json")
+            self.structure.to(filename="structure_testing.json")
+            assert Structure.from_file("structure_testing.json") == self.structure
 
     def test_from_spacegroup(self):
         s1 = Structure.from_spacegroup("Fm-3m", Lattice.cubic(3), ["Li", "O"], [[0.25, 0.25, 0.25], [0, 0, 0]])

--- a/pymatgen/io/tests/test_packmol.py
+++ b/pymatgen/io/tests/test_packmol.py
@@ -14,7 +14,7 @@ test_dir = os.path.join(PymatgenTest.TEST_FILES_DIR, "packmol")
 
 
 # Just skip this whole test for now since packmol is problematic.
-if True:  # which("packmol") is None:
+if True:  # if which("packmol") is None:
     pytest.skip("packmol executable not present", allow_module_level=True)
 
 

--- a/pymatgen/util/provenance.py
+++ b/pymatgen/util/provenance.py
@@ -5,12 +5,15 @@
 Classes and methods related to the Structure Notation Language (SNL)
 """
 
+from __future__ import annotations
+
 import datetime
 import json
 import re
 import sys
 from collections import namedtuple
 from io import StringIO
+from typing import Sequence
 
 from monty.json import MontyDecoder, MontyEncoder
 from monty.string import remove_non_ascii
@@ -34,7 +37,7 @@ MAX_HNODES = 100  # maximum number of HistoryNodes in SNL file
 MAX_BIBTEX_CHARS = 20000  # maximum number of characters for BibTeX reference
 
 
-def is_valid_bibtex(reference):
+def is_valid_bibtex(reference: str) -> bool:
     """
     Use pybtex to validate that a reference is in proper BibTeX format
 
@@ -80,14 +83,14 @@ class HistoryNode(namedtuple("HistoryNode", ["name", "url", "description"])):
         Structure (dict).
     """
 
-    def as_dict(self):
+    def as_dict(self) -> dict[str, str]:
         """
         Returns: Dict
         """
         return {"name": self.name, "url": self.url, "description": self.description}
 
     @staticmethod
-    def from_dict(h_node):
+    def from_dict(h_node: dict[str, str]) -> HistoryNode:
         """
         Args:
             d (dict): Dict representation
@@ -181,7 +184,7 @@ class Author(namedtuple("Author", ["name", "email"])):
 
 class StructureNL:
     """
-    The Structure Notation Language (SNL, pronounced 'snail') is container
+    The Structure Notation Language (SNL, pronounced 'snail') is a container
     for a pymatgen Structure/Molecule object with some additional fields for
     enhanced provenance. It is meant to be imported/exported in a JSON file
     format with the following structure:
@@ -329,8 +332,8 @@ class StructureNL:
     @classmethod
     def from_structures(
         cls,
-        structures,
-        authors,
+        structures: Sequence[Structure],
+        authors: Sequence[dict[str, str]],
         projects=None,
         references="",
         remarks=None,


### PR DESCRIPTION
@shyuep @mkhorton It's a breaking change but was wondering if we could swap the order of kwargs `fmt` and `filename` in `Structure.to()`.

https://github.com/materialsproject/pymatgen/blob/25768faa7aa0a34ee4357a92bc92ae41ef21bc1d/pymatgen/core/structure.py#L2421-L2427

The annoying thing about having `fmt` first is that the most common use case (imo writing to file) of `to()` raises an error:

```py
from pymatgen.core import Lattice, Structure

structure = Structure(
    lattice=Lattice.cubic(5),
    species=("Fe", "O"),
    coords=((0, 0, 0), (0.5, 0.5, 0.5)),
)

struct.to("struct.json")
>>> ValueError: Invalid format: `struct.json`
```

I did a quick look through the code base and didn't find any cases where `fmt` was passed as positional arg so don't think this would break much.

```py
struct.to("json")  # this would break
struct.to(fmt="json")  # this still works
```