### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           python-version: 3.9
           cache: pip
+          cache-dependency-path: setup.py
       - name: Install dependencies
         run: |
           pip install --upgrade pip wheel

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-.. image:: https://github.com/materialsproject/pymatgen/actions/workflows/test-linux.yml/badge.svg
+.. image:: https://github.com/materialsproject/pymatgen/actions/workflows/test.yml/badge.svg
    :alt: CI Status
-   :target: https://github.com/materialsproject/pymatgen/actions/workflows/test-linux.yml
+   :target: https://github.com/materialsproject/pymatgen/actions/workflows/test.yml
 .. image:: https://img.shields.io/pypi/dm/pymatgen?style=flat&color=blue&label=PyPI%20Downloads
    :alt: PyPI Downloads
    :target: https://pypi.org/project/pymatgen


### PR DESCRIPTION
The changes in c2124293 broke `.github/workflows/release.yml` causing

> Error: No file in /Users/runner/work/pymatgen/pymatgen matched to [**/requirements.txt], make sure you have checked out the target repository