### PR TITLE
Fix tensor mapping

### DIFF
--- a/pymatgen/core/tensors.py
+++ b/pymatgen/core/tensors.py
@@ -1050,8 +1050,8 @@ class TensorMapping(collections.abc.MutableMapping):
         """
         if len(values) != len(tensors):
             raise ValueError("TensorMapping must be initialized with tensors and values of equivalent length")
-        self._tensor_list = tensors
-        self._value_list = values
+        self._tensor_list = list(tensors)  # needs to be a list
+        self._value_list = list(values)  # needs to be a list
         self.tol = tol
 
     def __getitem__(self, item):

--- a/pymatgen/core/tests/test_tensors.py
+++ b/pymatgen/core/tests/test_tensors.py
@@ -302,7 +302,11 @@ class TensorTest(PymatgenTest):
         assert reduced[tkey] == "test_val"
         # Test empty initialization
         empty = TensorMapping()
-        assert empty._tensor_list == ()
+        assert empty._tensor_list == []
+
+        # test adding to empty tensor mapping
+        empty[tkey] = 1
+        assert empty[tkey] == 1
 
     def test_populate(self):
         test_data = loadfn(os.path.join(PymatgenTest.TEST_FILES_DIR, "test_toec_data.json"))


### PR DESCRIPTION
A recent change (1bdd1b7c6f5b12079c48cc06a6e6443bec070ed3) broke tensor mapping by making the default tensor and value lists immutable tuples. Tests didn't catch this because there was no tests for creating a tensor mapping starting from an empty mapping.

This PR fixes the bug and adds a new test. If possible, please could you release a new version with this bug fix as currently atomate, atomate2, amset, and other packages are broken.