### PR TITLE
VaspInputSet couldn't write cif structures

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
         additional_dependencies: [flake8-bugbear]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.981
+    rev: v0.982
     hooks:
       - id: mypy
 

--- a/pymatgen/io/lobster/inputs.py
+++ b/pymatgen/io/lobster/inputs.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import itertools
 import os
 import warnings
-from typing import Any, Dict, List, Sequence
+from typing import Any, Sequence
 
 import numpy as np
 import spglib
@@ -19,6 +19,7 @@ from monty.io import zopen
 from monty.json import MSONable
 from monty.serialization import loadfn
 
+from pymatgen.core.composition import Composition
 from pymatgen.core.structure import Structure
 from pymatgen.io.vasp import Vasprun
 from pymatgen.io.vasp.inputs import Incar, Kpoints, Potcar
@@ -27,7 +28,7 @@ from pymatgen.symmetry.bandstructure import HighSymmKpath
 __author__ = "Janine George, Marco Esters"
 __copyright__ = "Copyright 2017, The Materials Project"
 __version__ = "0.2"
-__maintainer__ = "Janine George, Marco Esters "
+__maintainer__ = "Janine George, Marco Esters"
 __email__ = "janine.george@uclouvain.be, esters@uoregon.edu"
 __date__ = "Dec 13, 2017"
 
@@ -135,7 +136,7 @@ class Lobsterin(dict, MSONable):
 
     def __getitem__(self, item):
         """
-        implements getitem from dict to avoid problems with cases
+        Implements getitem from dict to avoid problems with cases
         """
         found = False
         for key_here in self:
@@ -152,8 +153,10 @@ class Lobsterin(dict, MSONable):
         """
         Diff function for lobsterin. Compares two lobsterin and indicates which parameters are the same.
         Similar to the diff in INCAR.
+
         Args:
             other (Lobsterin): Lobsterin object to compare to
+
         Returns:
             dict with differences and similarities
         """
@@ -209,12 +212,12 @@ class Lobsterin(dict, MSONable):
 
     def _get_nbands(self, structure: Structure):
         """
-        get number of nbands
+        Get number of bands.
         """
         if self.get("basisfunctions") is None:
             raise OSError("No basis functions are provided. The program cannot calculate nbands.")
 
-        basis_functions = []  # type: List[str]
+        basis_functions: list[str] = []
         for string_basis in self["basisfunctions"]:
             # string_basis.lstrip()
             string_basis_raw = string_basis.strip().split(" ")
@@ -238,7 +241,8 @@ class Lobsterin(dict, MSONable):
 
     def write_lobsterin(self, path="lobsterin", overwritedict=None):
         """
-        writes a lobsterin file
+        Writes a lobsterin file
+
         Args:
             path (str): filename of the lobsterin file that will be written
             overwritedict (dict): dict that can be used to overwrite lobsterin, e.g. {"skipdos": True}
@@ -302,6 +306,7 @@ class Lobsterin(dict, MSONable):
         """
         Will only make the run static, insert nbands, make ISYM=-1, set LWAVE=True and write a new INCAR.
         You have to check for the rest.
+
         Args:
             incar_input (str): path to input INCAR
             incar_output (str): path to output INCAR
@@ -335,11 +340,13 @@ class Lobsterin(dict, MSONable):
         address_basis_file: str = None,
     ):
         """
-        will get the basis from given potcar_symbols (e.g., ["Fe_pv","Si"]
+        Will get the basis from given potcar_symbols (e.g., ["Fe_pv","Si"]
         #include this in lobsterin class
+
         Args:
             structure (Structure): Structure object
             potcar_symbols: list of potcar symbols
+
         Returns:
             returns basis
         """
@@ -415,7 +422,8 @@ class Lobsterin(dict, MSONable):
         POSCAR_input="POSCAR", POSCAR_output="POSCAR.lobster", symprec: float = 0.01
     ):
         """
-        writes a POSCAR with the standard primitive cell. This is needed to arrive at the correct kpath
+        Writes a POSCAR with the standard primitive cell. This is needed to arrive at the correct kpath
+
         Args:
             POSCAR_input (str): filename of input POSCAR
             POSCAR_output (str): filename of output POSCAR
@@ -439,7 +447,8 @@ class Lobsterin(dict, MSONable):
         symprec: float = 0.01,
     ):
         """
-        writes a KPOINT file for lobster (only ISYM=-1 and ISYM=0 are possible), grids are gamma centered
+        Writes a KPOINT file for lobster (only ISYM=-1 and ISYM=0 are possible), grids are gamma centered
+
         Args:
             POSCAR_input (str): path to POSCAR
             KPOINTS_output (str): path to output KPOINTS
@@ -463,7 +472,7 @@ class Lobsterin(dict, MSONable):
         # we need to switch off symmetry here
         latt = structure.lattice.matrix
         positions = structure.frac_coords
-        unique_species = []  # type: List[Any]
+        unique_species: list[Composition] = []
         zs = []
         magmoms = []
 
@@ -572,7 +581,7 @@ class Lobsterin(dict, MSONable):
             data = f.read().split("\n")
         if len(data) == 0:
             raise OSError("lobsterin file contains no data.")
-        Lobsterindict = {}  # type: Dict
+        Lobsterindict: dict[str, Any] = {}
 
         for datum in data:
             # will remove all comments to avoid complications
@@ -608,9 +617,11 @@ class Lobsterin(dict, MSONable):
     @staticmethod
     def _get_potcar_symbols(POTCAR_input: str) -> list:
         """
-        will return the name of the species in the POTCAR
+        Will return the name of the species in the POTCAR
+
         Args:
-         POTCAR_input(str): string to potcar file
+            POTCAR_input(str): string to potcar file
+
         Returns:
             list of the names of the species in string format
         """
@@ -650,7 +661,7 @@ class Lobsterin(dict, MSONable):
         option: str = "standard",
     ):
         """
-        will generate Lobsterin with standard settings
+        Will generate Lobsterin with standard settings
 
         Args:
             POSCAR_input(str): path to POSCAR
@@ -694,7 +705,7 @@ class Lobsterin(dict, MSONable):
         ]:
             raise ValueError("The option is not valid!")
 
-        Lobsterindict = {}  # type: Dict[Any,Any]
+        Lobsterindict: dict[str, Any] = {}
         # this basis set covers most elements
         Lobsterindict["basisSet"] = "pbeVaspFit2015"
         # energies around e-fermi

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -1908,7 +1908,8 @@ class PotcarSingle:
                 psingle = PotcarSingle.from_file(p)
                 return psingle
         raise OSError(
-            f"You do not have the right POTCAR with functional {functional} and label {symbol} in your VASP_PSP_DIR"
+            f"You do not have the right POTCAR with functional {functional} and label {symbol} "
+            f"in your VASP_PSP_DIR. Paths tried: {paths_to_try}"
         )
 
     @property

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -192,7 +192,7 @@ class VaspInputSet(MSONable, metaclass=abc.ABCMeta):
         cifname = ""
         if include_cif:
             s = vinput["POSCAR"].structure
-            cifname = Path(output_dir) / (re.sub(r"\s", "", s.formula) + ".cif")
+            cifname = str(Path(output_dir) / (re.sub(r"\s", "", s.formula) + ".cif"))
             s.to(filename=cifname)
 
         if zip_output:

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -189,11 +189,11 @@ class VaspInputSet(MSONable, metaclass=abc.ABCMeta):
             vinput = self.get_vasp_input()
             vinput.write_input(output_dir, make_dir_if_not_present=make_dir_if_not_present)
 
-        cifname = ""
+        cif_name = ""
         if include_cif:
             s = vinput["POSCAR"].structure
-            cifname = str(Path(output_dir) / (re.sub(r"\s", "", s.formula) + ".cif"))
-            s.to(filename=cifname)
+            cif_name = f"{output_dir}/{s.formula.replace(' ', '')}.cif"
+            s.to(filename=cif_name)
 
         if zip_output:
             filename = type(self).__name__ + ".zip"
@@ -204,7 +204,7 @@ class VaspInputSet(MSONable, metaclass=abc.ABCMeta):
                     "KPOINTS",
                     "POTCAR",
                     "POTCAR.spec",
-                    cifname,
+                    cif_name,
                 ]:
                     try:
                         zip.write(os.path.join(output_dir, file), arcname=file)

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -734,6 +734,7 @@ class DictSet(VaspInputSet):
                 not have a license to specific Potcar files. Given a "POTCAR.spec",
                 the specific POTCAR file can be re-generated using pymatgen with the
                 "generate_potcar" function in the pymatgen CLI.
+            zip_output (bool): Whether to zip each VASP input file written to the output directory.
         """
         super().write_input(
             output_dir=output_dir,
@@ -755,6 +756,7 @@ class DictSet(VaspInputSet):
             max_prime_factor (int): the valid prime factors of the grid size in each direction
                 VASP has many different setting for this to handle many compiling options.
                 For typical MPI options all prime factors up to 7 are allowed
+            must_inc_2 (bool): Whether 2 must be a prime factor of the result. Defaults to True.
         """
         # TODO throw error for Ultrasoft potentials
 
@@ -3225,8 +3227,10 @@ class MPAbsorptionSet(MPRelaxSet):
     def override_from_prev_calc(self, prev_calc_dir=".", **kwargs):
         """
         Update the input set to include settings from a previous calculation.
+
         Args:
             prev_calc_dir (str): The path to the previous calculation directory.
+
         Returns:
             The input set with the settings (structure, k-points, incar, etc)
             updated using the previous VASP run.

--- a/pymatgen/symmetry/analyzer.py
+++ b/pymatgen/symmetry/analyzer.py
@@ -217,6 +217,11 @@ class SpacegroupAnalyzer:
             vectors in scaled positions.
         """
         d = spglib.get_symmetry(self._cell, symprec=self._symprec, angle_tolerance=self._angle_tol)
+        if d is None:
+            raise ValueError(
+                f"Symmetry detection for structure with formula {self._structure.formula} failed. "
+                f"Try setting symprec={self._symprec} to a different value."
+            )
         # Sometimes spglib returns small translation vectors, e.g.
         # [1e-4, 2e-4, 1e-4]
         # (these are in fractional coordinates, so should be small denominator

--- a/pymatgen/symmetry/analyzer.py
+++ b/pymatgen/symmetry/analyzer.py
@@ -219,7 +219,7 @@ class SpacegroupAnalyzer:
         d = spglib.get_symmetry(self._cell, symprec=self._symprec, angle_tolerance=self._angle_tol)
         if d is None:
             raise ValueError(
-                f"Symmetry detection for structure with formula {self._structure.formula} failed. "
+                f"Symmetry detection failed for structure with formula {self._structure.formula}. "
                 f"Try setting symprec={self._symprec} to a different value."
             )
         # Sometimes spglib returns small translation vectors, e.g.

--- a/pymatgen/symmetry/tests/test_analyzer.py
+++ b/pymatgen/symmetry/tests/test_analyzer.py
@@ -124,6 +124,17 @@ class SpacegroupAnalyzerTest(PymatgenTest):
         ds = self.sg.get_symmetry_dataset()
         assert ds["international"] == "Pnma"
 
+    def test_get_symmetry(self):
+        Co8 = Structure.from_file(os.path.join(PymatgenTest.TEST_FILES_DIR, "Co8.cif"))
+
+        symprec = 1e-1
+        with pytest.raises(
+            ValueError,
+            match=f"Symmetry detection failed for structure with formula {Co8.formula}. "
+            f"Try setting {symprec=} to a different value.",
+        ):
+            SpacegroupAnalyzer(Co8, symprec=symprec)._get_symmetry()
+
     def test_get_crystal_system(self):
         crystal_system = self.sg.get_crystal_system()
         assert "orthorhombic" == crystal_system

--- a/pymatgen/symmetry/tests/test_analyzer.py
+++ b/pymatgen/symmetry/tests/test_analyzer.py
@@ -125,9 +125,10 @@ class SpacegroupAnalyzerTest(PymatgenTest):
         assert ds["international"] == "Pnma"
 
     def test_get_symmetry(self):
+        # see discussion in https://github.com/materialsproject/pymatgen/pull/2724
         Co8 = Structure.from_file(os.path.join(PymatgenTest.TEST_FILES_DIR, "Co8.cif"))
-
         symprec = 1e-1
+
         with pytest.raises(
             ValueError,
             match=f"Symmetry detection failed for structure with formula {Co8.formula}. "

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ setup(
             "coveralls",
             "doc2dash",
             "flake8",
-            "mypy",
+            "mypy==0.982",
             "pre-commit",
             "pydocstyle",
             "pylint",

--- a/test_files/Co8.cif
+++ b/test_files/Co8.cif
@@ -1,0 +1,34 @@
+# generated using pymatgen
+data_Co
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.70701825
+_cell_length_b   3.70701825
+_cell_length_c   7.98790154
+_cell_angle_alpha   103.38852320
+_cell_angle_beta   103.38852320
+_cell_angle_gamma   89.96878549
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   Co
+_chemical_formula_sum   Co8
+_cell_volume   103.72064306
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  Co  Co0  1  0.62683200  0.62683200  0.25354400  1.0
+  Co  Co1  1  0.37316800  0.37316800  0.74645600  1.0
+  Co  Co2  1  0.50000000  0.00000000  0.00000000  1.0
+  Co  Co3  1  0.00000000  0.50000000  0.00000000  1.0
+  Co  Co4  1  0.74993500  0.25006500  0.50000000  1.0
+  Co  Co5  1  0.25006500  0.74993500  0.50000000  1.0
+  Co  Co6  1  0.87978400  0.87978400  0.75931100  1.0
+  Co  Co7  1  0.12021600  0.12021600  0.24068900  1.0


### PR DESCRIPTION
## Summary
This pr deals with the failure of writing .cif format structures by VaspInputSet. I encountered an error of `'PosixPath' object has no attribute 'lower'` when using the `write_input` method with `include_cif=True`. After casting the PosixPath to str, this problem is solved.

