### PR TITLE
Do not introduce zero magmoms in SpacegroupAnalyzer

### DIFF
--- a/pymatgen/symmetry/analyzer.py
+++ b/pymatgen/symmetry/analyzer.py
@@ -76,12 +76,14 @@ class SpacegroupAnalyzer:
                 magmoms.append(site.magmom)
             elif site.is_ordered and hasattr(site.specie, "spin"):
                 magmoms.append(site.specie.spin)
-            else:
-                magmoms.append(0)  # needed for spglib
 
         self._unique_species = unique_species
         self._numbers = zs
-        self._cell = structure.lattice.matrix, structure.frac_coords, zs, magmoms
+
+        if len(magmoms) > 0:
+            self._cell = structure.lattice.matrix, structure.frac_coords, zs, magmoms
+        else:  # if no magmoms given do not add to cell
+            self._cell = structure.lattice.matrix, structure.frac_coords, zs
 
         self._space_group_data = spglib.get_symmetry_dataset(
             self._cell, symprec=self._symprec, angle_tolerance=angle_tolerance

--- a/pymatgen/symmetry/analyzer.py
+++ b/pymatgen/symmetry/analyzer.py
@@ -21,7 +21,7 @@ import warnings
 from collections import defaultdict
 from fractions import Fraction
 from math import cos, sin
-from typing import Literal
+from typing import Any, Literal
 
 import numpy as np
 import spglib
@@ -81,7 +81,7 @@ class SpacegroupAnalyzer:
         self._numbers = zs
 
         if len(magmoms) > 0:
-            self._cell = structure.lattice.matrix, structure.frac_coords, zs, magmoms
+            self._cell: tuple[Any, ...] = structure.lattice.matrix, structure.frac_coords, zs, magmoms
         else:  # if no magmoms given do not add to cell
             self._cell = structure.lattice.matrix, structure.frac_coords, zs
 

--- a/pymatgen/symmetry/tests/test_analyzer.py
+++ b/pymatgen/symmetry/tests/test_analyzer.py
@@ -134,7 +134,10 @@ class SpacegroupAnalyzerTest(PymatgenTest):
             match=f"Symmetry detection failed for structure with formula {Co8.formula}. "
             f"Try setting {symprec=} to a different value.",
         ):
-            SpacegroupAnalyzer(Co8, symprec=symprec)._get_symmetry()
+            sga = SpacegroupAnalyzer(Co8, symprec=symprec)
+            magmoms = [0] * len(Co8)  # bad magmoms, see https://github.com/materialsproject/pymatgen/pull/2727
+            sga._cell = (*sga._cell, magmoms)
+            sga._get_symmetry()
 
     def test_get_crystal_system(self):
         crystal_system = self.sg.get_crystal_system()


### PR DESCRIPTION
## Summary

Do not introduce zero `magmoms` in `SpacegroupAnalyzer` following changes in spglib >= 2. See #2725 

## TODO 

- With this change, the exception tested in the unit test added in #2724 is not raised.

## Checklist

Work-in-progress pull requests are encouraged, but please put [WIP]
in the pull request title.

Before a pull request can be merged, the following items must be checked:

- [X] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [X] Type annotations are **highly*- encouraged. Run [`mypy`](https://github.com/python/mypy) `path/to/file.py` to type check your code.
- [X] Tests have been added for any new functionality or bug fixes.
- [ ] All linting and tests pass.

Note that the CI system will run all the above checks. But it will be much more efficient if you already fix most
errors prior to submitting the PR. We highly recommended installing `pre-commit` hooks. Simply `pip install -U pre-commit && pre-commit install` in the repo's root directory. Afterwards linters will run before every commit and abort if any issues pop up.
