### PR TITLE
Fix extremum_icohpvalue() for  ICOBILIST.lobster files

### DIFF
--- a/pymatgen/electronic_structure/cohp.py
+++ b/pymatgen/electronic_structure/cohp.py
@@ -1273,11 +1273,11 @@ class IcohpCollection(MSONable):
                 if not self._are_coops and not self._are_cobis:
                     if value.summed_icohp < extremum:
                         extremum = value.summed_icohp
-                        #print(extremum)
+                        # print(extremum)
                 else:
                     if value.summed_icohp > extremum:
                         extremum = value.summed_icohp
-                        #print(extremum)
+                        # print(extremum)
         return extremum
 
     @property

--- a/pymatgen/electronic_structure/cohp.py
+++ b/pymatgen/electronic_structure/cohp.py
@@ -912,7 +912,7 @@ class IcohpValue(MSONable):
                 + str(self._icohp[Spin.up])
                 + " eV (Spin up)"
             )
-        if self._are_coops:
+        if self._are_coops and not self._are_cobis:
             if self._is_spin_polarized:
                 return (
                     "ICOOP "
@@ -942,7 +942,23 @@ class IcohpValue(MSONable):
                 + str(self._icohp[Spin.up])
                 + " (Spin up)"
             )
-        if self._is_spin_polarized:
+        if self._are_cobis and not self._are_coops:
+            if self._is_spin_polarized:
+                return (
+                    "ICOBI "
+                    + str(self._label)
+                    + " between "
+                    + str(self._atom1)
+                    + " and "
+                    + str(self._atom2)
+                    + " ("
+                    + str(self._translation)
+                    + "): "
+                    + str(self._icohp[Spin.up])
+                    + " (Spin up) and "
+                    + str(self._icohp[Spin.down])
+                    + " (Spin down)"
+                )
             return (
                 "ICOBI "
                 + str(self._label)
@@ -954,23 +970,8 @@ class IcohpValue(MSONable):
                 + str(self._translation)
                 + "): "
                 + str(self._icohp[Spin.up])
-                + " (Spin up) and "
-                + str(self._icohp[Spin.down])
-                + " (Spin down)"
+                + " (Spin up)"
             )
-        return (
-            "ICOBI "
-            + str(self._label)
-            + " between "
-            + str(self._atom1)
-            + " and "
-            + str(self._atom2)
-            + " ("
-            + str(self._translation)
-            + "): "
-            + str(self._icohp[Spin.up])
-            + " (Spin up)"
-        )
 
     @property
     def num_bonds(self):
@@ -1249,6 +1250,7 @@ class IcohpCollection(MSONable):
         """
         if self._are_coops or self._are_cobis:
             extremum = -sys.float_info.max
+
         else:
             extremum = sys.float_info.max
 
@@ -1271,11 +1273,11 @@ class IcohpCollection(MSONable):
                 if not self._are_coops and not self._are_cobis:
                     if value.summed_icohp < extremum:
                         extremum = value.summed_icohp
-                        # print(extremum)
+                        #print(extremum)
                 else:
                     if value.summed_icohp > extremum:
                         extremum = value.summed_icohp
-                        # print(extremum)
+                        #print(extremum)
         return extremum
 
     @property

--- a/pymatgen/io/lobster/outputs.py
+++ b/pymatgen/io/lobster/outputs.py
@@ -392,6 +392,7 @@ class Icohplist:
 
         self._icohpcollection = IcohpCollection(
             are_coops=are_coops,
+            are_cobis=are_cobis,
             list_labels=list_labels,
             list_atom1=list_atom1,
             list_atom2=list_atom2,

--- a/pymatgen/io/lobster/tests/test_lobster.py
+++ b/pymatgen/io/lobster/tests/test_lobster.py
@@ -636,8 +636,11 @@ class IcohplistTest(unittest.TestCase):
         }
 
         self.assertEqual(icohplist_bise, self.icohp_bise.icohplist)
+        self.assertEqual(-2.38796, self.icohp_bise.icohpcollection.extremum_icohpvalue())
         self.assertEqual(icooplist_fe, self.icoop_fe.icohplist)
+        self.assertEqual(-0.29919, self.icoop_fe.icohpcollection.extremum_icohpvalue())
         self.assertEqual(icooplist_bise, self.icoop_bise.icohplist)
+        self.assertEqual(0.24714, self.icoop_bise.icohpcollection.extremum_icohpvalue())
         self.assertAlmostEqual(self.icobi.icohplist["1"]["icohp"][Spin.up], 0.58649)
         self.assertAlmostEqual(self.icobi_orbitalwise.icohplist["2"]["icohp"][Spin.up], 0.58649)
         self.assertAlmostEqual(self.icobi_orbitalwise.icohplist["1"]["icohp"][Spin.up], 0.58649)
@@ -656,6 +659,7 @@ class IcohplistTest(unittest.TestCase):
             0.58649 / 2,
             3,
         )
+        self.assertEqual(0.58649, self.icobi.icohpcollection.extremum_icohpvalue())
 
 
 class DoscarTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

The value returned by extremum_icohpvalue() method from `Icohplist.icohpcollection` instance was wrong for ICOBILIST.lobster file.

- Fixed the above stated issue
- Updated the tests to ensure these values are returned correctly 