### PR TITLE
use `build` to build packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,7 +112,6 @@ jobs:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
         run: |
-          python -m pip install --upgrade pip wheel setuptools twine
-          python -m pip install numpy Cython  # needed to get location of numpy header files in setup.py
-          python setup.py sdist bdist_wheel
+          python -m pip install --upgrade pip twine build
+          python -m build
           python -m twine upload --skip-existing dist/*.whl dist/*.tar.gz


### PR DESCRIPTION
## Summary

Use [`build`](https://github.com/pypa/build) to release wheels.

I notice the current workflow to use `python setup.py sdist bdist_wheel` to build wheels, which will not follow `build-system` in `pyproject.toml`. I recommend the official PEP-517 build frontend, [`build`](https://github.com/pypa/build). The dependencies are not required to be manually installed any more.

build documentation: https://pypa-build.readthedocs.io/en/stable/index.html