### PR TITLE
Fix lobsterout.get_doc() typo

### DIFF
--- a/pymatgen/io/lobster/outputs.py
+++ b/pymatgen/io/lobster/outputs.py
@@ -861,7 +861,7 @@ class Lobsterout:
         LobsterDict["hasProjection"] = self.has_Projection
         LobsterDict["hasbandoverlaps"] = self.has_bandoverlaps
         LobsterDict["hasfatband"] = self.has_fatbands
-        LobsterDict["hasGrossPopuliation"] = self.has_grosspopulation
+        LobsterDict["hasGrossPopulation"] = self.has_grosspopulation
         LobsterDict["hasDensityOfEnergies"] = self.has_density_of_energies
 
         return LobsterDict

--- a/pymatgen/io/lobster/tests/test_lobster.py
+++ b/pymatgen/io/lobster/tests/test_lobster.py
@@ -1455,7 +1455,7 @@ class LobsteroutTest(PymatgenTest):
             "hasProjection": False,
             "hasbandoverlaps": True,
             "hasfatband": False,
-            "hasGrossPopuliation": False,
+            "hasGrossPopulation": False,
             "hasDensityOfEnergies": False,
         }
         for key, item in self.lobsterout_normal.get_doc().items():


### PR DESCRIPTION
## Summary

There was typo in document generated. Thus fixed  those 
