### PR TITLE
Enable `dependabot` for `pip`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,9 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: monthly


### PR DESCRIPTION
Auto-updates `requirements{,-optional}.txt` monthly.

@shyuep Decided against using the `req.txt` files in `test.yml` workflow. I.e. we're installing purely from `setup.py`.

https://github.com/materialsproject/pymatgen/blob/b950dc16388d2d07c1ae602195c3b9cbfe586af3/.github/workflows/test.yml#L56

By installing unpinned packages in CI, we catch breaking changes in dependencies sooner. Once something breaks CI, we can look compare with `req.txt` files for a "last working version" to see which update was the culprit.