### PR TITLE
Added missing keyword from LOBSTER 4.1 to lobsterin generation class

### DIFF
--- a/pymatgen/io/lobster/inputs.py
+++ b/pymatgen/io/lobster/inputs.py
@@ -96,6 +96,7 @@ class Lobsterin(dict, MSONable):
         "forceEnergyRange",
         "bandwiseSpilling",
         "kpointwiseSpilling",
+        "LSODOS",
     ]
     # several of these keywords + ending can be used in a lobsterin file:
     LISTKEYWORDS = ["basisfunctions", "cohpbetween", "createFatband"]


### PR DESCRIPTION
Added new parameter tag for writing orthonormalized DOSCAR

## LSODOS keyword was missing in lobsterin generation class

- Added this keyword
