### PR TITLE
Colorbar label for PDPlotter

### DIFF
--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -2510,7 +2510,7 @@ class PDPlotter:
             _map.set_array(energies)
             cbar = plt.colorbar(_map)
             cbar.set_label(
-                "Energy [meV/at] above hull (in red)\nInverse energy [ meV/at] above hull (in green)",
+                "Energy [meV/at] above hull (positive values)\nInverse energy [meV/at] above hull (negative values)",
                 rotation=-90,
                 ha="center",
                 va="bottom",

--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -2512,8 +2512,8 @@ class PDPlotter:
             cbar.set_label(
                 "Energy [meV/at] above hull (in red)\nInverse energy [ meV/at] above hull (in green)",
                 rotation=-90,
-                ha="left",
-                va="center",
+                ha="center",
+                va="bottom",
             )
         f = plt.gcf()
         f.set_size_inches((8, 6))


### PR DESCRIPTION
## Summary

- Fix cbar label position
- Update label (colours were only valid for the default colormap)

before and after:
![before](https://user-images.githubusercontent.com/57258530/207351231-3d90bcab-0489-4ece-908e-7e7b9f58d4fe.png) ![after](https://user-images.githubusercontent.com/57258530/207351317-8936d390-6e7d-4584-b9e0-5e2426b10b34.png)

## Checklist

- [x] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html). Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [x] Type annotations are *highly* encouraged. Run [`mypy path/to/file.py`](https://github.com/python/mypy) to type check your code.
- [x] Tests have been added for any new functionality or bug fixes.
- [x] All linting and tests pass.
