### PR TITLE
Fix typo in equation that computes interplanar angels

### DIFF
--- a/pymatgen/analysis/diffraction/tem.py
+++ b/pymatgen/analysis/diffraction/tem.py
@@ -404,7 +404,7 @@ class TEMCalculator(AbstractDiffractionPatternCalculator):
             + p1[2] ** 2 * c_star**2
             + 2 * p1[0] * p1[1] * a_star * b_star * cos_gamma_star
             + 2 * p1[0] * p1[2] * a_star * c_star * cos_beta_star
-            + 2 * p1[1] * p1[2] * b_star * c_star * cos_gamma_star
+            + 2 * p1[1] * p1[2] * b_star * c_star * cos_alpha_star
         )
         r2_norm = np.sqrt(
             p2[0] ** 2 * a_star**2
@@ -412,14 +412,14 @@ class TEMCalculator(AbstractDiffractionPatternCalculator):
             + p2[2] ** 2 * c_star**2
             + 2 * p2[0] * p2[1] * a_star * b_star * cos_gamma_star
             + 2 * p2[0] * p2[2] * a_star * c_star * cos_beta_star
-            + 2 * p2[1] * p2[2] * b_star * c_star * cos_gamma_star
+            + 2 * p2[1] * p2[2] * b_star * c_star * cos_alpha_star
         )
         r1_dot_r2 = (
             p1[0] * p2[0] * a_star**2
             + p1[1] * p2[1] * b_star**2
             + p1[2] * p2[2] * c_star**2
             + (p1[0] * p2[1] + p2[0] * p1[1]) * a_star * b_star * cos_gamma_star
-            + (p1[0] * p2[2] + p2[0] * p1[1]) * a_star * c_star * cos_beta_star
+            + (p1[0] * p2[2] + p2[0] * p1[2]) * a_star * c_star * cos_beta_star
             + (p1[1] * p2[2] + p2[1] * p1[2]) * b_star * c_star * cos_alpha_star
         )
         phi = np.arccos(r1_dot_r2 / (r1_norm * r2_norm))


### PR DESCRIPTION
## Summary

In the function get_interplnar_angle of module analysis/diffraction/tem.py, there are some typos about the angels and index. 

## Todo (if any)

N/A

## Checklist

Work-in-progress pull requests are encouraged, but please put \[WIP\] in the pull request title.

Before a pull request can be merged, the following items must be checked:

- [ ] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html). Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [ ] Type annotations are *highly* encouraged. Run [`mypy path/to/file.py`](https://github.com/python/mypy) to type check your code.
- [ ] Tests have been added for any new functionality or bug fixes.
- [ ] All linting and tests pass.

Note that the CI system will run all the above checks. But it will be much more efficient if you already fix most errors prior to submitting the PR. We highly recommended installing `pre-commit` hooks. Simply Run

```sh
pip install -U pre-commit
pre-commit install
```

in the repo's root directory. Afterwards linters will run before every commit and abort if any issues pop up.
