### PR TITLE
Fixed charge function for Structure obj (also fix for #2673)

### DIFF
--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -341,8 +341,7 @@ class SiteCollection(collections.abc.Sequence, metaclass=ABCMeta):
         charge = 0
         for site in self:
             for specie, amt in site.species.items():
-                if hasattr(specie,"oxi_state") and specie.oxi_state:
-                    charge += specie.oxi_state * amt
+                charge += (getattr(specie, "oxi_state", 0) or 0)* amt
                     
         return charge
 

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -341,7 +341,9 @@ class SiteCollection(collections.abc.Sequence, metaclass=ABCMeta):
         charge = 0
         for site in self:
             for specie, amt in site.species.items():
-                charge += getattr(specie, "oxi_state", 0) * amt
+                if hasattr(specie,"oxi_state") and specie.oxi_state:
+                    charge += specie.oxi_state * amt
+                    
         return charge
 
     @property


### PR DESCRIPTION
AFAIK, a site.species in Structure can be either an Element or a Species obj.
The Element obj does not have an "oxi_state" attribute and the current function handle
this case setting the oxi_state value to zero. 
But it fails when a site.species is a Species obj with an oxi_state set to None.
This is the case when a spin is added to a structure (via e.g. add_spin_by_site()) or
when using the MagOrderingTransformation .

The edit to the function proposed here handles this case and should solve the issue #2673