### PR TITLE
One attempt to fix ChemEnv error in tests

### DIFF
--- a/pymatgen/analysis/chemenv/coordination_environments/structure_environments.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/structure_environments.py
@@ -24,7 +24,7 @@ from pymatgen.analysis.chemenv.utils.chemenv_errors import ChemenvError
 from pymatgen.analysis.chemenv.utils.defs_utils import AdditionalConditions
 from pymatgen.core.periodic_table import Element, Species
 from pymatgen.core.sites import PeriodicSite
-from pymatgen.core.structure import Structure
+from pymatgen.core.structure import Structure, PeriodicNeighbor
 
 __author__ = "David Waroquiers"
 __copyright__ = "Copyright 2012, The Materials Project"
@@ -227,8 +227,6 @@ class StructureEnvironments(MSONable):
             """
             all_nbs_normalized_angles_sorted = sorted(nb["normalized_angle"] for nb in self.voronoi)
             minang = np.min(self.normalized_angles)
-            # print('minang', minang)
-            # print('all_nbs_normalized_angles_sorted', all_nbs_normalized_angles_sorted)
             for nb in self.voronoi:
                 print(nb)
             plateau = None
@@ -2091,9 +2089,10 @@ class LightStructureEnvironments(MSONable):
             "strategy": self.strategy.as_dict(),
             "structure": self.structure.as_dict(),
             "coordination_environments": self.coordination_environments,
-            "all_nbs_sites": [
-                {
-                    "site": nb_site["site"].as_dict(),
+            "all_nbs_sites": [{
+
+                    "site": PeriodicSite(species=nb_site["site"].species,coords=nb_site["site"].frac_coords, lattice= nb_site["site"].lattice,
+                                         to_unit_cell=False,coords_are_cartesian=False, properties=nb_site["site"].properties).as_dict(),
                     "index": nb_site["index"],
                     "image_cell": [int(ii) for ii in nb_site["image_cell"]],
                 }
@@ -2122,7 +2121,9 @@ class LightStructureEnvironments(MSONable):
         structure = dec.process_decoded(d["structure"])
         all_nbs_sites = []
         for nb_site in d["all_nbs_sites"]:
-            site = dec.process_decoded(nb_site["site"])
+            periodic_site = dec.process_decoded(nb_site["site"])
+            site=PeriodicNeighbor(species=periodic_site.species,coords=periodic_site.frac_coords, lattice= periodic_site.lattice,
+                                         properties=periodic_site.properties)
             if "image_cell" in nb_site:
                 image_cell = np.array(nb_site["image_cell"], int)
             else:

--- a/pymatgen/analysis/chemenv/coordination_environments/structure_environments.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/structure_environments.py
@@ -24,7 +24,7 @@ from pymatgen.analysis.chemenv.utils.chemenv_errors import ChemenvError
 from pymatgen.analysis.chemenv.utils.defs_utils import AdditionalConditions
 from pymatgen.core.periodic_table import Element, Species
 from pymatgen.core.sites import PeriodicSite
-from pymatgen.core.structure import Structure, PeriodicNeighbor
+from pymatgen.core.structure import PeriodicNeighbor, Structure
 
 __author__ = "David Waroquiers"
 __copyright__ = "Copyright 2012, The Materials Project"
@@ -2089,10 +2089,16 @@ class LightStructureEnvironments(MSONable):
             "strategy": self.strategy.as_dict(),
             "structure": self.structure.as_dict(),
             "coordination_environments": self.coordination_environments,
-            "all_nbs_sites": [{
-
-                    "site": PeriodicSite(species=nb_site["site"].species,coords=nb_site["site"].frac_coords, lattice= nb_site["site"].lattice,
-                                         to_unit_cell=False,coords_are_cartesian=False, properties=nb_site["site"].properties).as_dict(),
+            "all_nbs_sites": [
+                {
+                    "site": PeriodicSite(
+                        species=nb_site["site"].species,
+                        coords=nb_site["site"].frac_coords,
+                        lattice=nb_site["site"].lattice,
+                        to_unit_cell=False,
+                        coords_are_cartesian=False,
+                        properties=nb_site["site"].properties,
+                    ).as_dict(),
                     "index": nb_site["index"],
                     "image_cell": [int(ii) for ii in nb_site["image_cell"]],
                 }
@@ -2122,8 +2128,12 @@ class LightStructureEnvironments(MSONable):
         all_nbs_sites = []
         for nb_site in d["all_nbs_sites"]:
             periodic_site = dec.process_decoded(nb_site["site"])
-            site=PeriodicNeighbor(species=periodic_site.species,coords=periodic_site.frac_coords, lattice= periodic_site.lattice,
-                                         properties=periodic_site.properties)
+            site = PeriodicNeighbor(
+                species=periodic_site.species,
+                coords=periodic_site.frac_coords,
+                lattice=periodic_site.lattice,
+                properties=periodic_site.properties,
+            )
             if "image_cell" in nb_site:
                 image_cell = np.array(nb_site["image_cell"], int)
             else:

--- a/pymatgen/core/composition.py
+++ b/pymatgen/core/composition.py
@@ -162,6 +162,7 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
         """Defines == for Compositions."""
         if not isinstance(other, (Composition, dict)):
             return NotImplemented
+
         #  elements with amounts < Composition.amount_tolerance don't show up
         #  in the el_map, so checking len enables us to only check one
         #  composition's elements

--- a/pymatgen/core/composition.py
+++ b/pymatgen/core/composition.py
@@ -162,7 +162,6 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
         """Defines == for Compositions."""
         if not isinstance(other, (Composition, dict)):
             return NotImplemented
-
         #  elements with amounts < Composition.amount_tolerance don't show up
         #  in the el_map, so checking len enables us to only check one
         #  composition's elements


### PR DESCRIPTION
## Summary

As discussed in https://github.com/materialsproject/pymatgen/issues/2788, one way of fixing the ChemEnv error in the tests would be converting the PeriodicNeighbor object in a PeriodicSite object. I have implemented this. It might however affect the execution speed.

If someone else, manages to fix the as_dict from PeriodicNeighbor in a cheaper way, I would prefer this, of course.