### PR TITLE
Fix `Molecule.insert()`

### DIFF
--- a/pymatgen/analysis/diffraction/tem.py
+++ b/pymatgen/analysis/diffraction/tem.py
@@ -287,7 +287,7 @@ class TEMCalculator(AbstractDiffractionPatternCalculator):
         Returns all relevant TEM DP info in a pandas dataframe.
         Args:
             structure (Structure): The input structure.
-            scaled (boolean): Required value for inheritance, does nothing in TEM pattern
+            scaled (bool): Required value for inheritance, does nothing in TEM pattern
             two_theta_range (Tuple): Required value for inheritance, does nothing in TEM pattern
         Returns:
             PandasDataFrame

--- a/pymatgen/analysis/dimensionality.py
+++ b/pymatgen/analysis/dimensionality.py
@@ -482,7 +482,7 @@ def find_clusters(struct, connected_matrix):
 
     def visit(atom, atom_cluster):
         visited[atom] = True
-        new_cluster = set(np.where(connected_matrix[atom] != 0)[0]) | {atom_cluster}
+        new_cluster = set(np.where(connected_matrix[atom] != 0)[0]) | atom_cluster
         atom_cluster = new_cluster
         for new_atom in atom_cluster:
             if not visited[new_atom]:

--- a/pymatgen/analysis/dimensionality.py
+++ b/pymatgen/analysis/dimensionality.py
@@ -207,7 +207,7 @@ def calculate_dimensionality_of_site(bonded_structure, site_index, inc_vertices=
 
     def rank_increase(seen, candidate):
         rank0 = len(seen) - 1
-        rank1 = rank(seen.union({candidate}))
+        rank1 = rank(seen | {candidate})
         return rank1 > rank0
 
     connected_sites = {i: neighbours(i) for i in range(bonded_structure.structure.num_sites)}
@@ -482,7 +482,7 @@ def find_clusters(struct, connected_matrix):
 
     def visit(atom, atom_cluster):
         visited[atom] = True
-        new_cluster = set(np.where(connected_matrix[atom] != 0)[0]).union(atom_cluster)
+        new_cluster = set(np.where(connected_matrix[atom] != 0)[0]) | {atom_cluster}
         atom_cluster = new_cluster
         for new_atom in atom_cluster:
             if not visited[new_atom]:

--- a/pymatgen/analysis/elasticity/elastic.py
+++ b/pymatgen/analysis/elasticity/elastic.py
@@ -60,7 +60,7 @@ class NthOrderElasticTensor(Tensor):
         if obj.rank % 2 != 0:
             raise ValueError("ElasticTensor must have even rank")
         if not obj.is_voigt_symmetric(tol):
-            warnings.warn("Input elastic tensor does not satisfy standard voigt symmetries")
+            warnings.warn("Input elastic tensor does not satisfy standard Voigt symmetries")
         return obj.view(cls)
 
     @property
@@ -717,7 +717,7 @@ class ElasticTensorExpansion(TensorCollection):
             structure (Structure): Structure to be used in directional heat
                 capacity determination, only necessary if temperature
                 is specified
-            mode (string): mode for finding average heat-capacity,
+            mode (str): mode for finding average heat-capacity,
                 current supported modes are 'debye' and 'dulong-petit'
         """
         soec = ElasticTensor(self[0])

--- a/pymatgen/analysis/elasticity/elastic.py
+++ b/pymatgen/analysis/elasticity/elastic.py
@@ -500,7 +500,7 @@ class ElasticTensor(NthOrderElasticTensor):
             stresses (list of Stresses): list of stress objects to use in fit
                 corresponding to the list of strains
             eq_stress (Stress): equilibrium stress to use in fitting
-            vasp (boolean): flag for whether the stress tensor should be
+            vasp (bool): flag for whether the stress tensor should be
                 converted based on vasp units/convention for stress
             tol (float): tolerance for removing near-zero elements of the
                 resulting tensor

--- a/pymatgen/analysis/elasticity/strain.py
+++ b/pymatgen/analysis/elasticity/strain.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import collections
 import itertools
+from typing import Literal
 
 import numpy as np
 import scipy
@@ -18,6 +19,7 @@ import scipy
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Structure
 from pymatgen.core.tensors import SquareTensor, symmetry_reduce
+from pymatgen.util.typing import ArrayLike
 
 __author__ = "Joseph Montoya"
 __copyright__ = "Copyright 2012, The Materials Project"
@@ -109,8 +111,8 @@ class DeformedStructureSet(collections.abc.Sequence):
 
     def __init__(self, structure: Structure, norm_strains=None, shear_strains=None, symmetry=False):
         """
-        constructs the deformed geometries of a structure. Generates
-        m + n deformed structures according to the supplied parameters.
+        Construct the deformed geometries of a structure. Generates m + n deformed structures
+        according to the supplied parameters.
 
         Args:
             structure (Structure): structure to undergo deformation
@@ -177,9 +179,7 @@ class Strain(SquareTensor):
         obj = super().__new__(cls, strain_matrix, vscale=vscale)
         if not obj.is_symmetric():
             raise ValueError(
-                "Strain objects must be initialized "
-                "with a symmetric array or a voigt-notation "
-                "vector with six entries."
+                "Strain objects must be initialized with a symmetric array or a Voigt-notation vector with six entries."
             )
         return obj.view(cls)
 
@@ -190,13 +190,13 @@ class Strain(SquareTensor):
         self._vscale = getattr(obj, "_vscale", None)
 
     @classmethod
-    def from_deformation(cls, deformation):
+    def from_deformation(cls, deformation: ArrayLike) -> Strain:
         """
         Factory method that returns a Strain object from a deformation
         gradient
 
         Args:
-            deformation (3x3 array-like):
+            deformation (ArrayLike): 3x3 array defining the deformation
         """
         dfm = Deformation(deformation)
         return cls(0.5 * (np.dot(dfm.trans, dfm) - np.eye(3)))
@@ -210,8 +210,7 @@ class Strain(SquareTensor):
         symmetric strain.
 
         Args:
-            idx (tuple or integer): index to be perturbed, can be voigt or
-                full-tensor notation
+            idx (tuple or integer): index to be perturbed, can be Voigt or full-tensor notation
             amount (float): amount to perturb selected index
         """
         if np.array(idx).ndim == 0:
@@ -223,11 +222,17 @@ class Strain(SquareTensor):
             for i in itertools.permutations(idx):
                 v[i] = amount
             return cls(v)
-        raise ValueError("Index must either be 2-tuple or integer corresponding to full-tensor or voigt index")
+        raise ValueError("Index must either be 2-tuple or integer corresponding to full-tensor or Voigt index")
 
-    def get_deformation_matrix(self, shape="upper"):
+    def get_deformation_matrix(self, shape: Literal["upper", "lower", "symmetric"] = "upper"):
         """
-        returns the deformation matrix
+        Returns the deformation matrix.
+
+        Args:
+            shape ('upper' | 'lower' | 'symmetric'): method for determining deformation
+                'upper' produces an upper triangular defo
+                'lower' produces a lower triangular defo
+                'symmetric' produces a symmetric defo
         """
         return convert_strain_to_deformation(self, shape=shape)
 
@@ -241,17 +246,17 @@ class Strain(SquareTensor):
         return np.sqrt(np.sum(eps * eps) * 2 / 3)
 
 
-def convert_strain_to_deformation(strain, shape="upper"):
+def convert_strain_to_deformation(strain, shape: Literal["upper", "lower", "symmetric"]):
     """
     This function converts a strain to a deformation gradient that will
     produce that strain. Supports three methods:
 
     Args:
         strain (3x3 array-like): strain matrix
-        shape: (string): method for determining deformation, supports
-            "upper" produces an upper triangular defo
-            "lower" produces a lower triangular defo
-            "symmetric" produces a symmetric defo
+        shape: ('upper' | 'lower' | 'symmetric'): method for determining deformation
+            'upper' produces an upper triangular defo
+            'lower' produces a lower triangular defo
+            'symmetric' produces a symmetric defo
     """
     strain = SquareTensor(strain)
     ftdotf = 2 * strain + np.eye(3)

--- a/pymatgen/analysis/functional_groups.py
+++ b/pymatgen/analysis/functional_groups.py
@@ -210,7 +210,7 @@ class FunctionalGroupExtractor:
         # Graph representation of only marked atoms
         subgraph = self.molgraph.graph.subgraph(list(atoms)).to_undirected()
 
-        func_grps = []
+        func_groups = []
         for func_grp in nx.connected_components(subgraph):
             grp_hs = set()
             for node in func_grp:
@@ -219,11 +219,11 @@ class FunctionalGroupExtractor:
                     # Add all associated hydrogens into the functional group
                     if neighbor in hydrogens:
                         grp_hs.add(neighbor)
-            func_grp = func_grp.union(grp_hs)
+            func_grp = func_grp | grp_hs
 
-            func_grps.append(func_grp)
+            func_groups.append(func_grp)
 
-        return func_grps
+        return func_groups
 
     def get_basic_functional_groups(self, func_groups=None):
         """
@@ -305,7 +305,7 @@ class FunctionalGroupExtractor:
         """
         heteroatoms = self.get_heteroatoms(elements=elements)
         special_cs = self.get_special_carbon(elements=elements)
-        groups = self.link_marked_atoms(heteroatoms.union(special_cs))
+        groups = self.link_marked_atoms(heteroatoms | special_cs)
 
         if catch_basic:
             groups += self.get_basic_functional_groups(func_groups=func_groups)

--- a/pymatgen/analysis/gb/grain.py
+++ b/pymatgen/analysis/gb/grain.py
@@ -1328,7 +1328,7 @@ class GrainBoundaryGenerator:
         within a sigma value cutoff with known rotation axis in cubic system.
         The algorithm for this code is from reference, Acta Cryst, A40,108(1984)
         Args:
-            cutoff (integer): the cutoff of sigma values.
+            cutoff (int): the cutoff of sigma values.
             r_axis (list of three integers, e.g. u, v, w):
                     the rotation axis of the grain boundary, with the format of [u,v,w].
         Returns:
@@ -1404,7 +1404,7 @@ class GrainBoundaryGenerator:
         The algorithm for this code is from reference, Acta Cryst, A38,550(1982)
 
         Args:
-            cutoff (integer): the cutoff of sigma values.
+            cutoff (int): the cutoff of sigma values.
             r_axis (list of three integers, e.g. u, v, w
                     or four integers, e.g. u, v, t, w):
                     the rotation axis of the grain boundary.
@@ -1524,7 +1524,7 @@ class GrainBoundaryGenerator:
         The algorithm for this code is from reference, Acta Cryst, A45,505(1989).
 
         Args:
-            cutoff (integer): the cutoff of sigma values.
+            cutoff (int): the cutoff of sigma values.
             r_axis (list of three integers, e.g. u, v, w
                     or four integers, e.g. u, v, t, w):
                     the rotation axis of the grain boundary, with the format of [u,v,w]
@@ -1663,7 +1663,7 @@ class GrainBoundaryGenerator:
         The algorithm for this code is from reference, Acta Cryst, B46,117(1990)
 
         Args:
-            cutoff (integer): the cutoff of sigma values.
+            cutoff (int): the cutoff of sigma values.
             r_axis (list of three integers, e.g. u, v, w):
                     the rotation axis of the grain boundary, with the format of [u,v,w].
             c2_a2_ratio (list of two integers, e.g. mu, mv):
@@ -1775,7 +1775,7 @@ class GrainBoundaryGenerator:
         The algorithm for this code is from reference, Scipta Metallurgica 27, 291(1992)
 
         Args:
-            cutoff (integer): the cutoff of sigma values.
+            cutoff (int): the cutoff of sigma values.
             r_axis (list of three integers, e.g. u, v, w):
                     the rotation axis of the grain boundary, with the format of [u,v,w].
             c2_b2_a2_ratio (list of three integers, e.g. mu,lambda, mv):
@@ -1920,7 +1920,7 @@ class GrainBoundaryGenerator:
         'Symmetric tilt', 'Normal tilt', 'Mixed' GBs.
 
         Args:
-            plane_cutoff (integer): the cutoff of plane miller index.
+            plane_cutoff (int): the cutoff of plane miller index.
             r_axis (list of three integers, e.g. u, v, w):
                     the rotation axis of the grain boundary, with the format of [u,v,w].
             r_angle (float): rotation angle of the GBs.
@@ -1985,7 +1985,7 @@ class GrainBoundaryGenerator:
         Find all possible rotation angle for the given sigma value.
 
         Args:
-            sigma (integer):
+            sigma (int):
                     sigma value provided
             r_axis (list of three integers, e.g. u, v, w
                     or four integers, e.g. u, v, t, w for hex/rho system only):
@@ -2290,7 +2290,7 @@ class GrainBoundaryGenerator:
 
         Args:
             mat (3 by 3 array): input matrix
-            mag (integer): reduce times for the determinant
+            mag (int): reduce times for the determinant
             r_matrix (3 by 3 array): rotation matrix
         Return:
             the reduced integer array

--- a/pymatgen/analysis/graphs.py
+++ b/pymatgen/analysis/graphs.py
@@ -1376,9 +1376,10 @@ class StructureGraph(MSONable):
     def sort(self, key=None, reverse=False):
         """
         Same as Structure.sort(), also remaps nodes in graph.
-        :param key:
-        :param reverse:
-        :return:
+
+        Args:
+            key: key to sort by
+            reverse: reverse sort order
         """
         old_structure = self.structure.copy()
 
@@ -1490,7 +1491,7 @@ class StructureGraph(MSONable):
         if len(edges) == 0 and len(edges_other) == 0:
             jaccard_dist = 0  # by definition
         else:
-            jaccard_dist = 1 - len(edges.intersection(edges_other)) / len(edges.union(edges_other))
+            jaccard_dist = 1 - len(edges ^ edges_other) / len(edges | edges_other)
 
         return {
             "self": edges - edges_other,
@@ -2930,11 +2931,11 @@ class MoleculeGraph(MSONable):
         if len(edges) == 0 and len(edges_other) == 0:
             jaccard_dist = 0  # by definition
         else:
-            jaccard_dist = 1 - len(edges.intersection(edges_other)) / len(edges.union(edges_other))
+            jaccard_dist = 1 - len(edges ^ edges_other) / len(edges | edges_other)
 
         return {
             "self": edges - edges_other,
             "other": edges_other - edges,
-            "both": edges.intersection(edges_other),
+            "both": edges ^ edges_other,
             "dist": jaccard_dist,
         }

--- a/pymatgen/analysis/graphs.py
+++ b/pymatgen/analysis/graphs.py
@@ -1374,8 +1374,7 @@ class StructureGraph(MSONable):
         return len(self.structure)
 
     def sort(self, key=None, reverse=False):
-        """
-        Same as Structure.sort(), also remaps nodes in graph.
+        """Same as Structure.sort(). Also remaps nodes in graph.
 
         Args:
             key: key to sort by
@@ -1491,7 +1490,7 @@ class StructureGraph(MSONable):
         if len(edges) == 0 and len(edges_other) == 0:
             jaccard_dist = 0  # by definition
         else:
-            jaccard_dist = 1 - len(edges ^ edges_other) / len(edges | edges_other)
+            jaccard_dist = 1 - len(edges & edges_other) / len(edges | edges_other)
 
         return {
             "self": edges - edges_other,
@@ -2793,7 +2792,7 @@ class MoleculeGraph(MSONable):
         return len(self.molecule)
 
     def sort(self, key: Callable[[Molecule], float] | None = None, reverse: bool = False) -> None:
-        """Same as Molecule.sort(), also remaps nodes in graph.
+        """Same as Molecule.sort(). Also remaps nodes in graph.
 
         Args:
             key (callable, optional): Sort key. Defaults to None.

--- a/pymatgen/analysis/interface_reactions.py
+++ b/pymatgen/analysis/interface_reactions.py
@@ -616,7 +616,7 @@ class InterfacialReactivity(MSONable):
         """
         products = set()
         for _, _, _, react, _ in self.get_kinks():
-            products = products.union({k.reduced_formula for k in react.products})
+            products = products | {k.reduced_formula for k in react.products}
         return list(products)
 
 

--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -306,7 +306,7 @@ class NearNeighbors:
         Args:
             structure (Structure): input structure.
             n (int): index of site for which to determine CN.
-            use_weights (boolean): flag indicating whether (True) to use weights for computing the coordination
+            use_weights (bool): flag indicating whether (True) to use weights for computing the coordination
                 number or not (False, default: each coordinated site has equal weight).
             on_disorder ('take_majority_strict' | 'take_majority_drop' | 'take_max_species' | 'error'):
                 What to do when encountering a disordered structure. 'error' will raise ValueError.
@@ -329,7 +329,7 @@ class NearNeighbors:
         Args:
             structure (Structure): input structure
             n (int): index of site for which to determine CN.
-            use_weights (boolean): flag indicating whether (True)
+            use_weights (bool): flag indicating whether (True)
                 to use weights for computing the coordination number
                 or not (False, default: each coordinated site has equal
                 weight).
@@ -1337,7 +1337,7 @@ class MinimumDistanceNN(NearNeighbors):
                 (default: 0.1).
             cutoff (float): cutoff radius in Angstrom to look for trial
                 near-neighbor sites (default: 10.0).
-            get_all_sites (boolean): If this is set to True then the neighbor
+            get_all_sites (bool): If this is set to True then the neighbor
                 sites are only determined by the cutoff radius, tol is ignored
         """
         self.tol = tol
@@ -4028,7 +4028,7 @@ class CrystalNN(NearNeighbors):
         Args:
             structure (Structure): input structure.
             n (int): index of site for which to determine CN.
-            use_weights (boolean): flag indicating whether (True)
+            use_weights (bool): flag indicating whether (True)
                 to use weights for computing the coordination number
                 or not (False, default: each coordinated site has equal
                 weight).
@@ -4056,7 +4056,7 @@ class CrystalNN(NearNeighbors):
         Args:
             structure (Structure): input structure
             n (int): index of site for which to determine CN.
-            use_weights (boolean): flag indicating whether (True)
+            use_weights (bool): flag indicating whether (True)
                 to use weights for computing the coordination number
                 or not (False, default: each coordinated site has equal
                 weight).

--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -498,7 +498,7 @@ class NearNeighbors:
             raise ValueError("Shell must be positive")
 
         # Append this site to the list of previously-visited sites
-        _previous_steps = _previous_steps.union({(site_idx, _cur_image)})
+        _previous_steps = _previous_steps | {(site_idx, _cur_image)}
 
         # Get all the neighbors of this site
         possible_steps = list(all_nn_info[site_idx])

--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -1136,7 +1136,7 @@ class PhaseDiagram(MSONable):
                 [Element("Li"), Element("O")]
             referenced: If True, gives the results with a reference being the
                 energy of the elemental phase. If False, gives absolute values.
-            joggle (boolean): Whether to joggle the input to avoid precision
+            joggle (bool): Whether to joggle the input to avoid precision
                 errors.
 
         Returns:
@@ -1977,7 +1977,7 @@ def get_facets(qhull_data: ArrayLike, joggle: bool = False) -> ConvexHull:
         qhull_data (np.ndarray): The data from which to construct the convex
             hull as a Nxd array (N being number of data points and d being the
             dimension)
-        joggle (boolean): Whether to joggle the input to avoid precision
+        joggle (bool): Whether to joggle the input to avoid precision
             errors.
 
     Returns:

--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -895,16 +895,15 @@ class PhaseDiagram(MSONable):
                 "additional unstable entries"
             )
 
-            reduced_space = (
-                set(competing_entries)
-                .difference(self._get_stable_entries_in_space(entry_elems))
-                .union(self.el_refs.values())
-            )
+            reduced_space = competing_entries - {self._get_stable_entries_in_space(entry_elems)} | {
+                self.el_refs.values()
+            }
+
             # NOTE calling PhaseDiagram is only reasonable if the composition has fewer than 5 elements
-            # TODO can we call PatchedPhaseDiagram in the here?
+            # TODO can we call PatchedPhaseDiagram here?
             inner_hull = PhaseDiagram(reduced_space)
 
-            competing_entries = inner_hull.stable_entries.union(self._get_stable_entries_in_space(entry_elems))
+            competing_entries = inner_hull.stable_entries | {self._get_stable_entries_in_space(entry_elems)}
             competing_entries = {c for c in compare_entries if id(c) not in same_comp_mem_ids}
 
         if len(competing_entries) > space_limit:
@@ -1593,7 +1592,7 @@ class PatchedPhaseDiagram(PhaseDiagram):
         # Add terminal elements as we may not have PD patches including them
         # NOTE add el_refs in case no multielement entries are present for el
         _stable_entries = {se for pd in self.pds.values() for se in pd._stable_entries}
-        self._stable_entries = tuple(_stable_entries.union(self.el_refs.values()))
+        self._stable_entries = tuple(_stable_entries | {*self.el_refs.values()})
         self._stable_spaces = tuple(frozenset(e.composition.elements) for e in self._stable_entries)
 
     def __repr__(self):

--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -627,16 +627,16 @@ class PhaseDiagram(MSONable):
         Returns:
             {element: chempot} for all elements in the phase diagram.
         """
-        complist = [self.qhull_entries[i].composition for i in facet]
-        energylist = [self.qhull_entries[i].energy_per_atom for i in facet]
-        m = [[c.get_atomic_fraction(e) for e in self.elements] for c in complist]
-        chempots = np.linalg.solve(m, energylist)
+        comp_list = [self.qhull_entries[i].composition for i in facet]
+        energy_list = [self.qhull_entries[i].energy_per_atom for i in facet]
+        m = [[c.get_atomic_fraction(e) for e in self.elements] for c in comp_list]
+        chempots = np.linalg.solve(m, energy_list)
 
         return dict(zip(self.elements, chempots))
 
     def _get_simplex_intersections(self, c1, c2):
         """
-        Returns coordinates of the itersection of the tie line between two compositions
+        Returns coordinates of the intersection of the tie line between two compositions
         and the simplexes of the PhaseDiagram.
 
         Args:
@@ -895,15 +895,15 @@ class PhaseDiagram(MSONable):
                 "additional unstable entries"
             )
 
-            reduced_space = competing_entries - {self._get_stable_entries_in_space(entry_elems)} | {
-                self.el_refs.values()
+            reduced_space = competing_entries - {*self._get_stable_entries_in_space(entry_elems)} | {
+                *self.el_refs.values()
             }
 
             # NOTE calling PhaseDiagram is only reasonable if the composition has fewer than 5 elements
             # TODO can we call PatchedPhaseDiagram here?
             inner_hull = PhaseDiagram(reduced_space)
 
-            competing_entries = inner_hull.stable_entries | {self._get_stable_entries_in_space(entry_elems)}
+            competing_entries = inner_hull.stable_entries | {*self._get_stable_entries_in_space(entry_elems)}
             competing_entries = {c for c in compare_entries if id(c) not in same_comp_mem_ids}
 
         if len(competing_entries) > space_limit:

--- a/pymatgen/analysis/tests/test_functional_groups.py
+++ b/pymatgen/analysis/tests/test_functional_groups.py
@@ -90,7 +90,7 @@ class FunctionalGroupExtractorTest(unittest.TestCase):
         heteroatoms = self.extractor.get_heteroatoms()
         special_cs = self.extractor.get_special_carbon()
 
-        link = self.extractor.link_marked_atoms(heteroatoms.union(special_cs))
+        link = self.extractor.link_marked_atoms(heteroatoms | special_cs)
 
         self.assertEqual(len(link), 1)
         self.assertEqual(len(link[0]), 9)
@@ -98,7 +98,7 @@ class FunctionalGroupExtractorTest(unittest.TestCase):
         # Exclude Oxygen-related functional groups
         heteroatoms_no_o = self.extractor.get_heteroatoms(elements=["N"])
         special_cs_no_o = self.extractor.get_special_carbon(elements=["N"])
-        all_marked = heteroatoms_no_o.union(special_cs_no_o)
+        all_marked = heteroatoms_no_o | special_cs_no_o
 
         link_no_o = self.extractor.link_marked_atoms(all_marked)
 
@@ -118,7 +118,7 @@ class FunctionalGroupExtractorTest(unittest.TestCase):
         heteroatoms = self.extractor.get_heteroatoms()
         special_cs = self.extractor.get_special_carbon()
 
-        link = self.extractor.link_marked_atoms(heteroatoms.union(special_cs))
+        link = self.extractor.link_marked_atoms(heteroatoms | special_cs)
         basics = self.extractor.get_basic_functional_groups()
 
         all_func = self.extractor.get_all_functional_groups()

--- a/pymatgen/analysis/tests/test_wulff.py
+++ b/pymatgen/analysis/tests/test_wulff.py
@@ -89,7 +89,7 @@ class WulffShapeTest(PymatgenTest):
         # the point group of its conventional unit cell
 
         Args:
-            ucell (string): Unit cell that the Wulff shape is based on.
+            ucell (str): Unit cell that the Wulff shape is based on.
             wulff_vertices (list): List of all vertices on the Wulff
                 shape. Use wulff.wulff_pt_list to obtain the list
                 (see wulff_generator.py).

--- a/pymatgen/apps/battery/analyzer.py
+++ b/pymatgen/apps/battery/analyzer.py
@@ -188,7 +188,7 @@ class BatteryAnalyzer:
 
         numa = set()
         for oxid_el in oxid_els:
-            numa = numa.union(self._get_int_removals_helper(self.comp.copy(), oxid_el, oxid_els, numa))
+            numa = numa | self._get_int_removals_helper(self.comp.copy(), oxid_el, oxid_els, numa)
         # convert from num A in structure to num A removed
         num_working_ion = self.comp[Species(self.working_ion.symbol, self.working_ion_charge)]
         return {num_working_ion - a for a in numa}
@@ -235,13 +235,13 @@ class BatteryAnalyzer:
             spec.oxi_state * spec_amts_oxi[spec] for spec in spec_amts_oxi if spec.symbol not in self.working_ion.symbol
         )
         a = max(0, -oxi_noA / self.working_ion_charge)
-        numa = numa.union({a})
+        numa = numa | {a}
 
         # recursively try the other oxidation states
         if a == 0:
             return numa
         for red in redox_els:
-            numa = numa.union(self._get_int_removals_helper(spec_amts_oxi.copy(), red, redox_els, numa))
+            numa = numa | self._get_int_removals_helper(spec_amts_oxi.copy(), red, redox_els, numa)
         return numa
 
 

--- a/pymatgen/core/composition.py
+++ b/pymatgen/core/composition.py
@@ -1277,13 +1277,13 @@ class ChemicalPotential(dict, MSONable):
 
     def __sub__(self, other: object) -> ChemicalPotential:
         if isinstance(other, ChemicalPotential):
-            els = set(self) | {other}
+            els = {*self} | {*other}
             return ChemicalPotential({e: self.get(e, 0) - other.get(e, 0) for e in els})
         return NotImplemented
 
     def __add__(self, other: object) -> ChemicalPotential:
         if isinstance(other, ChemicalPotential):
-            els = set(self) | {other}
+            els = {*self} | {*other}
             return ChemicalPotential({e: self.get(e, 0) + other.get(e, 0) for e in els})
         return NotImplemented
 

--- a/pymatgen/core/composition.py
+++ b/pymatgen/core/composition.py
@@ -653,6 +653,9 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
 
         Args:
             weight_dict (dict): {symbol: weight_fraction} dict.
+
+        Returns:
+            Composition
         """
 
         weight_sum = sum([val / Element(el).atomic_mass for el, val in weight_dict.items()])
@@ -1275,13 +1278,13 @@ class ChemicalPotential(dict, MSONable):
 
     def __sub__(self, other: object) -> ChemicalPotential:
         if isinstance(other, ChemicalPotential):
-            els = set(self).union(other)
+            els = {*self} | {other}
             return ChemicalPotential({e: self.get(e, 0) - other.get(e, 0) for e in els})
         return NotImplemented
 
     def __add__(self, other: object) -> ChemicalPotential:
         if isinstance(other, ChemicalPotential):
-            els = set(self).union(other)
+            els = {*self} | {other}
             return ChemicalPotential({e: self.get(e, 0) + other.get(e, 0) for e in els})
         return NotImplemented
 

--- a/pymatgen/core/composition.py
+++ b/pymatgen/core/composition.py
@@ -657,8 +657,7 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
         Returns:
             Composition
         """
-
-        weight_sum = sum([val / Element(el).atomic_mass for el, val in weight_dict.items()])
+        weight_sum = sum(val / Element(el).atomic_mass for el, val in weight_dict.items())
         comp_dict = {el: val / Element(el).atomic_mass / weight_sum for el, val in weight_dict.items()}
 
         return cls(comp_dict)
@@ -1278,13 +1277,13 @@ class ChemicalPotential(dict, MSONable):
 
     def __sub__(self, other: object) -> ChemicalPotential:
         if isinstance(other, ChemicalPotential):
-            els = {*self} | {other}
+            els = set(self) | {other}
             return ChemicalPotential({e: self.get(e, 0) - other.get(e, 0) for e in els})
         return NotImplemented
 
     def __add__(self, other: object) -> ChemicalPotential:
         if isinstance(other, ChemicalPotential):
-            els = {*self} | {other}
+            els = set(self) | {other}
             return ChemicalPotential({e: self.get(e, 0) + other.get(e, 0) for e in els})
         return NotImplemented
 

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -4224,7 +4224,7 @@ class Molecule(IMolecule, collections.abc.MutableSequence):
             if isinstance(site, Site):
                 self._sites[ii] = site
             else:
-                if isinstance(site, str) or (not isinstance(site, collections.abc.Sequence)):
+                if isinstance(site, str) or not isinstance(site, collections.abc.Sequence):
                     self._sites[ii].species = site  # type: ignore
                 else:
                     self._sites[ii].species = site[0]  # type: ignore
@@ -4243,7 +4243,7 @@ class Molecule(IMolecule, collections.abc.MutableSequence):
         coords: ArrayLike,
         validate_proximity: bool = False,
         properties: dict | None = None,
-    ):
+    ) -> Molecule:
         """
         Appends a site to the molecule.
 
@@ -4301,7 +4301,7 @@ class Molecule(IMolecule, collections.abc.MutableSequence):
         coords: ArrayLike,
         validate_proximity: bool = False,
         properties: dict | None = None,
-    ):
+    ) -> Molecule:
         """
         Insert a site to the molecule.
 
@@ -4322,6 +4322,8 @@ class Molecule(IMolecule, collections.abc.MutableSequence):
                 if site.distance(new_site) < self.DISTANCE_TOLERANCE:
                     raise ValueError("New site is too close to an existing site!")
         self._sites.insert(i, new_site)
+
+        return self
 
     def remove_species(self, species: Sequence[SpeciesLike]):
         """

--- a/pymatgen/electronic_structure/boltztrap.py
+++ b/pymatgen/electronic_structure/boltztrap.py
@@ -997,7 +997,7 @@ class BoltztrapAnalyzer:
         of electron chemical potential values
 
         Args:
-            output (string): the type of output. 'tensor' give the full
+            output (str): the type of output. 'tensor' give the full
             3x3 tensor, 'eigs' its 3 eigenvalues and
             'average' the average of the three eigenvalues
             doping_levels (boolean): True for the results to be given at
@@ -1029,7 +1029,7 @@ class BoltztrapAnalyzer:
         of electron chemical potential values
 
         Args:
-            output (string): the type of output. 'tensor' give the full
+            output (str): the type of output. 'tensor' give the full
             3x3 tensor, 'eigs' its 3 eigenvalues and
             'average' the average of the three eigenvalues
             doping_levels (boolean): True for the results to be given at
@@ -1066,7 +1066,7 @@ class BoltztrapAnalyzer:
         electron chemical potential values
 
         Args:
-            output (string): the type of output. 'tensor' give the full 3x3
+            output (str): the type of output. 'tensor' give the full 3x3
             tensor, 'eigs' its 3 eigenvalues and
             'average' the average of the three eigenvalues
             doping_levels (boolean): True for the results to be given at
@@ -1130,7 +1130,7 @@ class BoltztrapAnalyzer:
         electron chemical potential values
 
         Args:
-            output (string): the type of output. 'tensor' give the full 3x3
+            output (str): the type of output. 'tensor' give the full 3x3
             tensor, 'eigs' its 3 eigenvalues and
             'average' the average of the three eigenvalues
             doping_levels (boolean): True for the results to be given at
@@ -1199,7 +1199,7 @@ class BoltztrapAnalyzer:
         lattice thermal conductivity
 
         Args:
-            output (string): the type of output. 'tensor' give the full 3x3
+            output (str): the type of output. 'tensor' give the full 3x3
             tensor, 'eigs' its 3 eigenvalues and
             'average' the average of the three eigenvalues
             doping_levels (boolean): True for the results to be given at
@@ -1295,7 +1295,7 @@ class BoltztrapAnalyzer:
         its 3 eigenvalues or an average
 
         Args:
-            output (string): 'eigs' for eigenvalues, 'tensor' for the full
+            output (str): 'eigs' for eigenvalues, 'tensor' for the full
             tensor and 'average' for an average (trace/3)
             doping_levels (boolean): True for the results to be given at
             different doping levels, False for results

--- a/pymatgen/electronic_structure/boltztrap.py
+++ b/pymatgen/electronic_structure/boltztrap.py
@@ -1000,7 +1000,7 @@ class BoltztrapAnalyzer:
             output (str): the type of output. 'tensor' give the full
             3x3 tensor, 'eigs' its 3 eigenvalues and
             'average' the average of the three eigenvalues
-            doping_levels (boolean): True for the results to be given at
+            doping_levels (bool): True for the results to be given at
             different doping levels, False for results
             at different electron chemical potentials
 
@@ -1032,7 +1032,7 @@ class BoltztrapAnalyzer:
             output (str): the type of output. 'tensor' give the full
             3x3 tensor, 'eigs' its 3 eigenvalues and
             'average' the average of the three eigenvalues
-            doping_levels (boolean): True for the results to be given at
+            doping_levels (bool): True for the results to be given at
             different doping levels, False for results
             at different electron chemical potentials
             relaxation_time (float): constant relaxation time in secs
@@ -1069,7 +1069,7 @@ class BoltztrapAnalyzer:
             output (str): the type of output. 'tensor' give the full 3x3
             tensor, 'eigs' its 3 eigenvalues and
             'average' the average of the three eigenvalues
-            doping_levels (boolean): True for the results to be given at
+            doping_levels (bool): True for the results to be given at
             different doping levels, False for results
             at different electron chemical potentials
             relaxation_time (float): constant relaxation time in secs
@@ -1133,10 +1133,10 @@ class BoltztrapAnalyzer:
             output (str): the type of output. 'tensor' give the full 3x3
             tensor, 'eigs' its 3 eigenvalues and
             'average' the average of the three eigenvalues
-            doping_levels (boolean): True for the results to be given at
+            doping_levels (bool): True for the results to be given at
             different doping levels, False for results
             at different electron chemical potentials
-            k_el (boolean): True for k_0-PF*T, False for k_0
+            k_el (bool): True for k_0-PF*T, False for k_0
             relaxation_time (float): constant relaxation time in secs
 
         Returns:
@@ -1202,7 +1202,7 @@ class BoltztrapAnalyzer:
             output (str): the type of output. 'tensor' give the full 3x3
             tensor, 'eigs' its 3 eigenvalues and
             'average' the average of the three eigenvalues
-            doping_levels (boolean): True for the results to be given at
+            doping_levels (bool): True for the results to be given at
             different doping levels, False for results
             at different electron chemical potentials
             relaxation_time (float): constant relaxation time in secs
@@ -1297,7 +1297,7 @@ class BoltztrapAnalyzer:
         Args:
             output (str): 'eigs' for eigenvalues, 'tensor' for the full
             tensor and 'average' for an average (trace/3)
-            doping_levels (boolean): True for the results to be given at
+            doping_levels (bool): True for the results to be given at
             different doping levels, False for results
             at different electron chemical potentials
         Returns:

--- a/pymatgen/entries/correction_calculator.py
+++ b/pymatgen/entries/correction_calculator.py
@@ -383,7 +383,7 @@ class CorrectionCalculator:
             raise RuntimeError("Please call compute_corrections or compute_from_files to calculate corrections first")
 
         # elements with U values
-        ggaucorrection_species = ["V", "Cr", "Mn", "Fe", "Co", "Ni", "W", "Mo"]
+        ggau_correction_species = ["V", "Cr", "Mn", "Fe", "Co", "Ni", "W", "Mo"]
 
         comp_corr: dict[str, float] = {}
         o: dict[str, float] = {}
@@ -394,7 +394,7 @@ class CorrectionCalculator:
         f_error: dict[str, float] = {}
 
         for specie in list(self.species) + ["ozonide"]:
-            if specie in ggaucorrection_species:
+            if specie in ggau_correction_species:
                 o[specie] = self.corrections_dict[specie][0]
                 f[specie] = self.corrections_dict[specie][0]
 

--- a/pymatgen/ext/optimade.py
+++ b/pymatgen/ext/optimade.py
@@ -531,10 +531,10 @@ class OptimadeRester:
             A string of comma-separated OPTIMADE response fields.
         """
         if isinstance(additional_response_fields, str):
-            additional_response_fields = [additional_response_fields]
+            additional_response_fields = {additional_response_fields}
         if not additional_response_fields:
             additional_response_fields = set()
-        return ",".join(set(additional_response_fields).union(self.mandatory_response_fields))
+        return ",".join({additional_response_fields} | self.mandatory_response_fields)
 
     def refresh_aliases(self, providers_url="https://providers.optimade.org/providers.json"):
         """

--- a/pymatgen/ext/optimade.py
+++ b/pymatgen/ext/optimade.py
@@ -275,7 +275,7 @@ class OptimadeRester:
         Get structures satisfying a given OPTIMADE filter.
 
         Args:
-            filter: An OPTIMADE-compliant filter
+            optimade_filter: An OPTIMADE-compliant filter
 
         Returns: Dict of Structures keyed by that database's id system
         """
@@ -296,7 +296,8 @@ class OptimadeRester:
         Get structures satisfying a given OPTIMADE filter.
 
         Args:
-            filter: An OPTIMADE-compliant filter
+            optimade_filter: An OPTIMADE-compliant filter
+            additional_response_fields: Any additional fields desired from the OPTIMADE API,
 
         Returns: Dict of Structures keyed by that database's id system
         """
@@ -534,7 +535,7 @@ class OptimadeRester:
             additional_response_fields = {additional_response_fields}
         if not additional_response_fields:
             additional_response_fields = set()
-        return ",".join({additional_response_fields} | self.mandatory_response_fields)
+        return ",".join({*additional_response_fields} | self.mandatory_response_fields)
 
     def refresh_aliases(self, providers_url="https://providers.optimade.org/providers.json"):
         """

--- a/pymatgen/io/abinit/abitimer.py
+++ b/pymatgen/io/abinit/abitimer.py
@@ -44,7 +44,6 @@ class AbinitTimerParser(collections.abc.Iterable):
     Assume the Abinit output files have been produced with `timopt -1`.
 
     Example:
-
         parser = AbinitTimerParser()
         parser.parse(list_of_files)
 
@@ -223,10 +222,10 @@ class AbinitTimerParser(collections.abc.Iterable):
             if idx == 0:
                 section_names = [s.name for s in timer.order_sections(ordkey)]
                 # check = section_names
-                # else:
-                #  new_set = set( [s.name for s in timer.order_sections(ordkey)])
-                #  section_names.intersection_update(new_set)
-                #  check = check.union(new_set)
+            # else:
+            #     new_set = {s.name for s in timer.order_sections(ordkey)}
+            #     section_names.intersection_update(new_set)
+            #     check = check | new_set
 
         # if check != section_names:
         #  print("sections", section_names)

--- a/pymatgen/io/lammps/utils.py
+++ b/pymatgen/io/lammps/utils.py
@@ -269,7 +269,7 @@ class PackmolRunner:
         Write the packmol input file to the input directory.
 
         Args:
-            input_dir (string): path to the input directory
+            input_dir (str): path to the input directory
         """
         with open(os.path.join(input_dir, self.input_file), "w", encoding="utf-8") as inp:
             for k, v in self.control_params.items():
@@ -448,8 +448,8 @@ class LammpsRunner:
     def __init__(self, input_filename="lammps.in", bin="lammps"):
         """
         Args:
-            input_filename (string): input file name
-            bin (string): command to run, excluding the input file name
+            input_filename (str): input file name
+            bin (str): command to run, excluding the input file name
         """
         self.lammps_bin = bin.split()
         if not which(self.lammps_bin[-1]):

--- a/pymatgen/io/lobster/lobsterenv.py
+++ b/pymatgen/io/lobster/lobsterenv.py
@@ -237,8 +237,8 @@ class LobsterNeighbors(NearNeighbors):
 
         Args:
             structure (Structure): input structure.
-            n (integer): index of site for which to determine CN.
-            use_weights (boolean): flag indicating whether (True)
+            n (int): index of site for which to determine CN.
+            use_weights (bool): flag indicating whether (True)
                 to use weights for computing the coordination number
                 or not (False, default: each coordinated site has equal
                 weight).

--- a/pymatgen/io/phonopy.py
+++ b/pymatgen/io/phonopy.py
@@ -264,7 +264,7 @@ def get_displaced_structures(pmg_structure, atom_disp=0.01, supercell_matrix=Non
         pmg_structure (Structure): A pymatgen structure object.
         atom_disp (float): Atomic displacement. Default is 0.01 $\\AA$.
         supercell_matrix (3x3 array): Scaling matrix for supercell.
-        yaml_fname (string): If not None, it represents the full path to
+        yaml_fname (str): If not None, it represents the full path to
             the outputting displacement yaml file, e.g. disp.yaml.
         **kwargs: Parameters used in Phonopy.generate_displacement method.
 

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -5341,11 +5341,11 @@ class Waveder(MSONable):
         between bands band_i and band_j for k-point index, spin-channel and Cartesian direction.
 
         Args:
-            band_i (Integer): Index of band i
-            band_j (Integer): Index of band j
-            kpoint (Integer): Index of k-point
-            spin   (Integer): Index of spin-channel (0 or 1)
-            cart_dir (Integer): Index of Cartesian direction (0,1,2)
+            band_i (int): Index of band i
+            band_j (int): Index of band j
+            kpoint (int): Index of k-point
+            spin   (int): Index of spin-channel (0 or 1)
+            cart_dir (int): Index of Cartesian direction (0,1,2)
 
         Returns:
             a float value

--- a/pymatgen/symmetry/bandstructure.py
+++ b/pymatgen/symmetry/bandstructure.py
@@ -59,7 +59,7 @@ class HighSymmKpath(KPathBase):
         """
         Args:
             structure (Structure): Structure object
-            has_magmoms (boolean): Whether the input structure contains
+            has_magmoms (bool): Whether the input structure contains
                 magnetic moments as site properties with the key 'magmom.'
                 Values may be in the form of 3-component vectors given in
                 the basis of the input lattice vectors, in

--- a/pymatgen/symmetry/bandstructure.py
+++ b/pymatgen/symmetry/bandstructure.py
@@ -69,7 +69,7 @@ class HighSymmKpath(KPathBase):
                 direction along which magnetic moments given as scalars
                 should point. If all magnetic moments are provided as
                 vectors then this argument is not used.
-            path_type (string): Chooses which convention to use to generate
+            path_type (str): Chooses which convention to use to generate
                 the high symmetry path. Options are: 'setyawan_curtarolo', 'hinuma',
                 'latimer_munro' for the Setyawan & Curtarolo, Hinuma et al., and
                 Latimer & Munro conventions. Choosing 'all' will generate one path

--- a/pymatgen/symmetry/kpath.py
+++ b/pymatgen/symmetry/kpath.py
@@ -959,7 +959,7 @@ class KPathSeek(KPathBase):
             angle_tolerance (float): Angle tolerance for symmetry finding.
             atol (float): Absolute tolerance used to determine edge cases
                 for settings of structures.
-            system_is_tri (boolean): Indicates if the system is time-reversal
+            system_is_tri (bool): Indicates if the system is time-reversal
                 invariant.
         """
         super().__init__(structure, symprec=symprec, angle_tolerance=angle_tolerance, atol=atol)
@@ -1091,7 +1091,7 @@ class KPathLatimerMunro(KPathBase):
         """
         Args:
             structure (Structure): Structure object
-            has_magmoms (boolean): Whether the input structure contains
+            has_magmoms (bool): Whether the input structure contains
                 magnetic moments as site properties with the key 'magmom.'
                 Values may be in the form of 3-component vectors given in
                 the basis of the input lattice vectors, or as scalars, in

--- a/pymatgen/util/coord.py
+++ b/pymatgen/util/coord.py
@@ -204,7 +204,7 @@ def pbc_shortest_vectors(lattice, fcoords1, fcoords2, mask=None, return_d2=False
         mask (boolean array): Mask of matches that are not allowed.
             i.e. if mask[1,2] is True, then subset[1] cannot be matched
             to superset[2]
-        return_d2 (boolean): whether to also return the squared distances
+        return_d2 (bool): whether to also return the squared distances
 
     Returns:
         array of displacement vectors from fcoords1 to fcoords2

--- a/pymatgen/util/plotting.py
+++ b/pymatgen/util/plotting.py
@@ -206,7 +206,7 @@ def periodic_table_heatmap(
             value assigned to it, e.g. surface energy and frequency, etc.
             Elements missing in the elemental_data will be grey by default
             in the final table elemental_data={"Fe": 4.2, "O": 5.0}.
-         cbar_label (string): Label of the colorbar. Default is "".
+         cbar_label (str): Label of the colorbar. Default is "".
          cbar_label_size (float): Font size for the colorbar label. Default is 14.
          cmap_range (tuple): Minimum and maximum value of the colormap scale.
             If None, the colormap will automatically scale to the range of the
@@ -216,11 +216,11 @@ def periodic_table_heatmap(
             is shown. Example: "%.4f" shows float to four decimals.
          value_fontsize (float): Font size for values. Default is 10.
          symbol_fontsize (float): Font size for element symbols. Default is 14.
-         cmap (string): Color scheme of the heatmap. Default is 'YlOrRd'.
+         cmap (str): Color scheme of the heatmap. Default is 'YlOrRd'.
             Refer to the matplotlib documentation for other options.
-         blank_color (string): Color assigned for the missing elements in
+         blank_color (str): Color assigned for the missing elements in
             elemental_data. Default is "grey".
-         edge_color (string): Color assigned for the edge of elements in the
+         edge_color (str): Color assigned for the edge of elements in the
             periodic table. Default is "white".
          max_row (integer): Maximum number of rows of the periodic table to be
             shown. Default is 9, which means the periodic table heat map covers

--- a/pymatgen/util/plotting.py
+++ b/pymatgen/util/plotting.py
@@ -31,7 +31,7 @@ def pretty_plot(width=8, height=None, plt=None, dpi=None, color_cycle=("qualitat
     Returns:
         Matplotlib plot object with properly sized fonts.
     """
-    ticksize = int(width * 2.5)
+    tick_size = int(width * 2.5)
 
     golden_ratio = (math.sqrt(5) - 1) / 2
 
@@ -53,16 +53,16 @@ def pretty_plot(width=8, height=None, plt=None, dpi=None, color_cycle=("qualitat
     else:
         fig = plt.gcf()
         fig.set_size_inches(width, height)
-    plt.xticks(fontsize=ticksize)
-    plt.yticks(fontsize=ticksize)
+    plt.xticks(fontsize=tick_size)
+    plt.yticks(fontsize=tick_size)
 
     ax = plt.gca()
     ax.set_title(ax.get_title(), size=width * 4)
 
-    labelsize = int(width * 3)
+    label_size = int(width * 3)
 
-    ax.set_xlabel(ax.get_xlabel(), size=labelsize)
-    ax.set_ylabel(ax.get_ylabel(), size=labelsize)
+    ax.set_xlabel(ax.get_xlabel(), size=label_size)
+    ax.set_ylabel(ax.get_ylabel(), size=label_size)
 
     return plt
 
@@ -206,10 +206,10 @@ def periodic_table_heatmap(
             value assigned to it, e.g. surface energy and frequency, etc.
             Elements missing in the elemental_data will be grey by default
             in the final table elemental_data={"Fe": 4.2, "O": 5.0}.
-         cbar_label (str): Label of the colorbar. Default is "".
-         cbar_label_size (float): Font size for the colorbar label. Default is 14.
-         cmap_range (tuple): Minimum and maximum value of the colormap scale.
-            If None, the colormap will automatically scale to the range of the
+         cbar_label (str): Label of the color bar. Default is "".
+         cbar_label_size (float): Font size for the color bar label. Default is 14.
+         cmap_range (tuple): Minimum and maximum value of the color map scale.
+            If None, the color map will automatically scale to the range of the
             data.
          show_plot (bool): Whether to show the heatmap. Default is False.
          value_format (str): Formatting string to show values. If None, no value
@@ -222,12 +222,12 @@ def periodic_table_heatmap(
             elemental_data. Default is "grey".
          edge_color (str): Color assigned for the edge of elements in the
             periodic table. Default is "white".
-         max_row (integer): Maximum number of rows of the periodic table to be
+         max_row (int): Maximum number of rows of the periodic table to be
             shown. Default is 9, which means the periodic table heat map covers
             the standard 7 rows of the periodic table + 2 rows for the lanthanides
             and actinides. Use a value of max_row = 7 to exclude the lanthanides and
             actinides.
-         readable_fontcolor (bool): Whether to use readable fontcolor depending
+         readable_fontcolor (bool): Whether to use readable font color depending
             on background color. Default is False.
     """
 


### PR DESCRIPTION
b3bbaf04f5 replace set methods `(union|intersection|difference)` with arithmetic operators
5f8a9fc3d2 standardize type names in doc strings: `string`->`str`, `integer`->`int`, etc.
6f99428d65 fix `Molecule.insert()` doesn't return what the doc str says