### PR TITLE
Normalized DOS

### DIFF
--- a/pymatgen/electronic_structure/dos.py
+++ b/pymatgen/electronic_structure/dos.py
@@ -192,7 +192,9 @@ class Dos(MSONable):
         Fermi level
     """
 
-    def __init__(self, efermi: float, energies: ArrayLike, densities: Mapping[Spin, ArrayLike], norm_vol: float = 1.0):
+    def __init__(
+        self, efermi: float, energies: ArrayLike, densities: Mapping[Spin, ArrayLike], norm_vol: float | None = None
+    ):
         """
         Args:
             efermi: Fermi level energy
@@ -202,7 +204,9 @@ class Dos(MSONable):
         """
         self.efermi = efermi
         self.energies = np.array(energies)
-        self.densities = {k: np.array(d) / norm_vol for k, d in densities.items()}
+        self.norm_vol = norm_vol
+        vol = norm_vol or 1.0
+        self.densities = {k: np.array(d) / vol for k, d in densities.items()}
 
     def get_densities(self, spin: Spin | None = None):
         """

--- a/pymatgen/electronic_structure/dos.py
+++ b/pymatgen/electronic_structure/dos.py
@@ -194,20 +194,20 @@ class Dos(MSONable):
 
     def __init__(
         self, efermi: float, energies: ArrayLike, densities: Mapping[Spin, ArrayLike], norm_vol: float | None = None
-    ):
+    ) -> None:
         """
         Args:
             efermi: Fermi level energy
             energies: A sequences of energies
             densities (dict[Spin: np.array]): representing the density of states for each Spin.
             norm_vol: The volume used to normalize the densities. Defaults to if None which will not perform any
-                normalization.  If not None, the resulting density will have units of states/eV/Angstrom^3, otherwise
+                normalization. If not None, the resulting density will have units of states/eV/Angstrom^3, otherwise
                 the density will be in states/eV.
         """
         self.efermi = efermi
         self.energies = np.array(energies)
         self.norm_vol = norm_vol
-        vol = norm_vol or 1.0
+        vol = norm_vol or 1
         self.densities = {k: np.array(d) / vol for k, d in densities.items()}
 
     def get_densities(self, spin: Spin | None = None):
@@ -656,7 +656,7 @@ class CompleteDos(Dos):
         total_dos: Dos,
         pdoss: Mapping[PeriodicSite, Mapping[Orbital, Mapping[Spin, ArrayLike]]],
         normalize: bool = False,
-    ):
+    ) -> None:
         """
         Args:
             structure: Structure associated with this particular DOS.

--- a/pymatgen/electronic_structure/dos.py
+++ b/pymatgen/electronic_structure/dos.py
@@ -664,11 +664,14 @@ class CompleteDos(Dos):
         vol = None
         if normalize:
             # normalize all the pdos
+            scaled_pdoss: dict = {}
             vol = structure.volume
             for site, pdos in pdoss.items():
-                for orb, pdos in pdos.items():
-                    for spin, pdos in pdos.items():
-                        pdoss[site][orb][spin] = pdos / vol
+                scaled_pdoss[site] = {}
+                for orb, dos in pdos.items():
+                    scaled_pdoss[site][orb] = {}
+                    for spin, d in dos.items():
+                        scaled_pdoss[site][orb][spin] = d / vol
 
         super().__init__(
             total_dos.efermi,

--- a/pymatgen/electronic_structure/dos.py
+++ b/pymatgen/electronic_structure/dos.py
@@ -200,7 +200,9 @@ class Dos(MSONable):
             efermi: Fermi level energy
             energies: A sequences of energies
             densities (dict[Spin: np.array]): representing the density of states for each Spin.
-            norm_vol: The volume used to normalize the densities. Defaults to 1.0.
+            norm_vol: The volume used to normalize the densities. Defaults to if None which will not perform any
+                normalization.  If not None, the resulting density will have units of states/eV/Angstrom^3, otherwise
+                the density will be in states/eV.
         """
         self.efermi = efermi
         self.energies = np.array(energies)
@@ -660,19 +662,11 @@ class CompleteDos(Dos):
             structure: Structure associated with this particular DOS.
             total_dos: total Dos for structure
             pdoss: The pdoss are supplied as an {Site: {Orbital: {Spin:Densities}}}
+            normalize: Whether to normalize the densities by the volume of the structure.
+                If True, the units of the densities are states/eV/Angstrom^3. Otherwise,
+                the units are states/eV.
         """
-        vol = None
-        if normalize:
-            # normalize all the pdos
-            scaled_pdoss: dict = {}
-            vol = structure.volume
-            for site, pdos in pdoss.items():
-                scaled_pdoss[site] = {}
-                for orb, dos in pdos.items():
-                    scaled_pdoss[site][orb] = {}
-                    for spin, d in dos.items():
-                        scaled_pdoss[site][orb][spin] = d / vol
-
+        vol = structure.volume if normalize else None
         super().__init__(
             total_dos.efermi,
             energies=total_dos.energies,

--- a/pymatgen/electronic_structure/dos.py
+++ b/pymatgen/electronic_structure/dos.py
@@ -200,7 +200,7 @@ class Dos(MSONable):
             efermi: Fermi level energy
             energies: A sequences of energies
             densities (dict[Spin: np.array]): representing the density of states for each Spin.
-            norm_vol: The volume used to normalize the densities. Defaults to if None which will not perform any
+            norm_vol: The volume used to normalize the densities. Defaults to 1 if None which will not perform any
                 normalization. If not None, the resulting density will have units of states/eV/Angstrom^3, otherwise
                 the density will be in states/eV.
         """

--- a/pymatgen/electronic_structure/dos.py
+++ b/pymatgen/electronic_structure/dos.py
@@ -661,7 +661,15 @@ class CompleteDos(Dos):
             total_dos: total Dos for structure
             pdoss: The pdoss are supplied as an {Site: {Orbital: {Spin:Densities}}}
         """
-        vol = structure.volume if normalize else 1.0
+        vol = None
+        if normalize:
+            # normalize all the pdos
+            vol = structure.volume
+            for site, pdos in pdoss.items():
+                for orb, pdos in pdos.items():
+                    for spin, pdos in pdos.items():
+                        pdoss[site][orb][spin] = pdos / vol
+
         super().__init__(
             total_dos.efermi,
             energies=total_dos.energies,

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -700,7 +700,7 @@ class Vasprun(MSONable):
         The resulting dos is in units of states/eV/unit cell volume.
         """
         final_struct = self.final_structure
-        pdoss = {final_struct[i]: pdos for i, pdos in enumerate(self.pdos_normalized)}
+        pdoss = {final_struct[i]: pdos for i, pdos in enumerate(self.pdos)}
         return CompleteDos(self.final_structure, self.tdos_normalized, pdoss, normalize=True)
 
     @property

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -693,6 +693,17 @@ class Vasprun(MSONable):
         return CompleteDos(self.final_structure, self.tdos, pdoss)
 
     @property
+    def complete_dos_normalized(self):
+        """
+        A complete dos object which incorporates the total dos and all
+        projected dos. Normalized by the volume of the unit cell.
+        The resulting dos is in units of states/eV/unit cell volume.
+        """
+        final_struct = self.final_structure
+        pdoss = {final_struct[i]: pdos for i, pdos in enumerate(self.pdos_normalized)}
+        return CompleteDos(self.final_structure, self.tdos_normalized, pdoss, normalize=True)
+
+    @property
     def hubbards(self):
         """
         Hubbard U values used if a vasprun is a GGA+U run. {} otherwise.

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -701,7 +701,7 @@ class Vasprun(MSONable):
         """
         final_struct = self.final_structure
         pdoss = {final_struct[i]: pdos for i, pdos in enumerate(self.pdos)}
-        return CompleteDos(self.final_structure, self.tdos_normalized, pdoss, normalize=True)
+        return CompleteDos(self.final_structure, self.tdos, pdoss, normalize=True)
 
     @property
     def hubbards(self):

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -693,11 +693,11 @@ class Vasprun(MSONable):
         return CompleteDos(self.final_structure, self.tdos, pdoss)
 
     @property
-    def complete_dos_normalized(self):
+    def complete_dos_normalized(self) -> CompleteDos:
         """
-        A complete dos object which incorporates the total dos and all
-        projected dos. Normalized by the volume of the unit cell.
-        The resulting dos is in units of states/eV/unit cell volume.
+        A CompleteDos object which incorporates the total DOS and all
+        projected DOS. Normalized by the volume of the unit cell with
+        units of states/eV/unit cell volume.
         """
         final_struct = self.final_structure
         pdoss = {final_struct[i]: pdos for i, pdos in enumerate(self.pdos)}

--- a/pymatgen/io/vasp/tests/test_outputs.py
+++ b/pymatgen/io/vasp/tests/test_outputs.py
@@ -199,13 +199,12 @@ class VasprunTest(PymatgenTest):
         self.assertEqual(pdos0[Orbital.s][Spin.up].shape, (301,))
 
         pdos0_norm = vasprun.complete_dos_normalized.pdos[vasprun.final_structure[0]]
-        self.assertAlmostEqual(
-            pdos0_norm[Orbital.s][Spin.up][16], pdos0[Orbital.s][Spin.up][16] / vasprun.final_structure.volume
-        )
-        self.assertAlmostEqual(
-            pdos0_norm[Orbital.pz][Spin.down][16], pdos0[Orbital.pz][Spin.down][16] / vasprun.final_structure.volume
-        )
+        self.assertAlmostEqual(pdos0_norm[Orbital.s][Spin.up][16], 0.0026)  # the site data should not change
         self.assertEqual(pdos0_norm[Orbital.s][Spin.up].shape, (301,))
+
+        cdos_norm, cdos = vasprun.complete_dos_normalized, vasprun.complete_dos
+        ratio = np.nanmax(cdos.densities[Spin.up] / cdos_norm.densities[Spin.up])
+        self.assertAlmostEqual(ratio, vasprun.final_structure.volume)  # the site data should not change
 
         filepath2 = self.TEST_FILES_DIR / "lifepo4.xml"
         vasprun_ggau = Vasprun(filepath2, parse_projected_eigen=True, parse_potcar_file=False)

--- a/pymatgen/io/vasp/tests/test_outputs.py
+++ b/pymatgen/io/vasp/tests/test_outputs.py
@@ -198,6 +198,15 @@ class VasprunTest(PymatgenTest):
         self.assertAlmostEqual(pdos0[Orbital.pz][Spin.down][16], 0.0012)
         self.assertEqual(pdos0[Orbital.s][Spin.up].shape, (301,))
 
+        pdos0_norm = vasprun.complete_dos_normalized.pdos[vasprun.final_structure[0]]
+        self.assertAlmostEqual(
+            pdos0_norm[Orbital.s][Spin.up][16], pdos0[Orbital.s][Spin.up][16] / vasprun.final_structure.volume
+        )
+        self.assertAlmostEqual(
+            pdos0_norm[Orbital.pz][Spin.down][16], pdos0[Orbital.pz][Spin.down][16] / vasprun.final_structure.volume
+        )
+        self.assertEqual(pdos0_norm[Orbital.s][Spin.up].shape, (301,))
+
         filepath2 = self.TEST_FILES_DIR / "lifepo4.xml"
         vasprun_ggau = Vasprun(filepath2, parse_projected_eigen=True, parse_potcar_file=False)
         totalscsteps = sum(len(i["electronic_steps"]) for i in vasprun.ionic_steps)


### PR DESCRIPTION
## Normalize Density of States

Currently the Density of states data is extensive (at lease when you use `Vasprun.complete_dos`).
This proposed change allow you to use call `Vasprun.complete_dos_normalized` to get the density of states in units of states $/ \text{eV} / \mathbb A^3$

