### PR TITLE
KeyError of Elemental references in pre-computed phase diagram

### DIFF
--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -374,6 +374,8 @@ class PhaseDiagram(MSONable):
         self.qhull_data = computed_data["qhull_data"]
         self.dim = computed_data["dim"]
         self.el_refs = dict(computed_data["el_refs"])
+        # update keys to the Element object, in case they are the str object in pre-computed data
+        self.el_refs = {Element(el):entry for el, entry in self.el_refs.items() if isinstance(el, str)}
         self.qhull_entries = tuple(computed_data["qhull_entries"])
         self._qhull_spaces = tuple(frozenset(e.composition.elements) for e in self.qhull_entries)
         self._stable_entries = tuple({self.qhull_entries[i] for i in set(itertools.chain(*self.facets))})

--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -366,6 +366,8 @@ class PhaseDiagram(MSONable):
             computed_data = self._compute()
         else:
             computed_data = MontyDecoder().process_decoded(computed_data)
+            # update keys to the Element object, in case they are the str object in pre-computed data
+            computed_data["el_refs"] = [(Element(el_str), entry) for (el_str, entry) in computed_data["el_refs"]]
         assert isinstance(computed_data, dict)  # mypy type narrowing
         self.computed_data = computed_data
         self.facets = computed_data["facets"]
@@ -374,8 +376,6 @@ class PhaseDiagram(MSONable):
         self.qhull_data = computed_data["qhull_data"]
         self.dim = computed_data["dim"]
         self.el_refs = dict(computed_data["el_refs"])
-        # update keys to the Element object, in case they are the str object in pre-computed data
-        self.el_refs = {Element(el): entry for el, entry in self.el_refs.items() if isinstance(el, str)}
         self.qhull_entries = tuple(computed_data["qhull_entries"])
         self._qhull_spaces = tuple(frozenset(e.composition.elements) for e in self.qhull_entries)
         self._stable_entries = tuple({self.qhull_entries[i] for i in set(itertools.chain(*self.facets))})

--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -364,11 +364,12 @@ class PhaseDiagram(MSONable):
         self.entries = entries
         if computed_data is None:
             computed_data = self._compute()
+            assert isinstance(computed_data, dict)  # mypy type narrowing
         else:
             computed_data = MontyDecoder().process_decoded(computed_data)
+            assert isinstance(computed_data, dict)
             # update keys to the Element object, in case they are the str object in pre-computed data
             computed_data["el_refs"] = [(Element(el_str), entry) for (el_str, entry) in computed_data["el_refs"]]
-        assert isinstance(computed_data, dict)  # mypy type narrowing
         self.computed_data = computed_data
         self.facets = computed_data["facets"]
         self.simplexes = computed_data["simplexes"]

--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -375,7 +375,7 @@ class PhaseDiagram(MSONable):
         self.dim = computed_data["dim"]
         self.el_refs = dict(computed_data["el_refs"])
         # update keys to the Element object, in case they are the str object in pre-computed data
-        self.el_refs = {Element(el):entry for el, entry in self.el_refs.items() if isinstance(el, str)}
+        self.el_refs = {Element(el): entry for el, entry in self.el_refs.items() if isinstance(el, str)}
         self.qhull_entries = tuple(computed_data["qhull_entries"])
         self._qhull_spaces = tuple(frozenset(e.composition.elements) for e in self.qhull_entries)
         self._stable_entries = tuple({self.qhull_entries[i] for i in set(itertools.chain(*self.facets))})

--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -364,12 +364,11 @@ class PhaseDiagram(MSONable):
         self.entries = entries
         if computed_data is None:
             computed_data = self._compute()
-            assert isinstance(computed_data, dict)  # mypy type narrowing
         else:
             computed_data = MontyDecoder().process_decoded(computed_data)
             assert isinstance(computed_data, dict)
-            # update keys to the Element object, in case they are the str object in pre-computed data
-            computed_data["el_refs"] = [(Element(el_str), entry) for (el_str, entry) in computed_data["el_refs"]]
+            # update keys to be Element objects in case they are strings in pre-computed data
+            computed_data["el_refs"] = [(Element(el_str), entry) for el_str, entry in computed_data["el_refs"]]
         self.computed_data = computed_data
         self.facets = computed_data["facets"]
         self.simplexes = computed_data["simplexes"]
@@ -409,7 +408,7 @@ class PhaseDiagram(MSONable):
         computed_data = d.get("computed_data")
         return cls(entries, elements, computed_data=computed_data)
 
-    def _compute(self):
+    def _compute(self) -> dict[str, Any]:
         if self.elements == ():
             self.elements = sorted({els for e in self.entries for els in e.composition.elements})
 
@@ -418,23 +417,21 @@ class PhaseDiagram(MSONable):
 
         entries = sorted(self.entries, key=lambda e: e.composition.reduced_composition)
 
-        el_refs = {}
-        min_entries = []
-        all_entries = []
-        for composition, group in itertools.groupby(entries, key=lambda e: e.composition.reduced_composition):
-            group = list(group)
+        el_refs: dict[Element, PDEntry] = {}
+        min_entries: list[PDEntry] = []
+        all_entries: list[PDEntry] = []
+        for composition, group_iter in itertools.groupby(entries, key=lambda e: e.composition.reduced_composition):
+            group = list(group_iter)
             min_entry = min(group, key=lambda e: e.energy_per_atom)
             if composition.is_element:
                 el_refs[composition.elements[0]] = min_entry
             min_entries.append(min_entry)
             all_entries.extend(group)
 
-        if len(el_refs) < dim:
-            missing = set(elements) - set(el_refs)
+        if missing := set(elements) - set(el_refs):
             raise ValueError(f"Missing terminal entries for elements {sorted(map(str, missing))}")
-        if len(el_refs) > dim:
-            extra = set(el_refs) - set(elements)
-            raise ValueError(f"There are more terminal elements than dimensions: {extra}")
+        if extra := set(el_refs) - set(elements):
+            raise ValueError(f"There are more terminal elements than dimensions: {sorted(map(str, extra))}")
 
         data = np.array(
             [[e.composition.get_atomic_fraction(el) for el in elements] + [e.energy_per_atom] for e in min_entries]

--- a/pymatgen/analysis/tests/test_phase_diagram.py
+++ b/pymatgen/analysis/tests/test_phase_diagram.py
@@ -13,7 +13,6 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-from monty.json import MontyDecoder
 from monty.serialization import dumpfn, loadfn
 from monty.tempfile import ScratchDir
 
@@ -624,13 +623,14 @@ class PhaseDiagramTest(unittest.TestCase):
             loadfn("pd.json")
 
     def test_el_refs(self):
-        # load a pre_computed phase diagram,
-        # which was retrieved via new API and serialized to the MSONable object
-        with open(module_dir / "pre_computed_phase_diagram_Li-Fe-O.json") as pd:
-            phaseDiagram = json.load(pd, cls=MontyDecoder)
-        # check the keys in el_refs dict have been updated to Element object
-        assert str not in [type(el) for el in phaseDiagram.el_refs.keys()]
-
+        # Creat an imitation of pre_computed phase diagram, which currently exists an issue 
+        # that el_refs is dict[str, PDEntry] object, instead of dict[Element, PDEntry].
+        computed_data_imitation = self.pd.computed_data
+        el_refs_imitation = [(str(el), entry) for el, entry in self.pd.el_refs.items()]
+        computed_data_imitation.update({'el_refs': el_refs_imitation})
+        phase_diagram_imitation = PhaseDiagram(self.entries, computed_data=computed_data_imitation)
+        # Check the keys in el_refs dict have been updated to Element object via PhaseDiagram class.
+        assert all(isinstance(el, Element) for el in phase_diagram_imitation.el_refs)
 
 class GrandPotentialPhaseDiagramTest(unittest.TestCase):
     def setUp(self):

--- a/pymatgen/analysis/tests/test_phase_diagram.py
+++ b/pymatgen/analysis/tests/test_phase_diagram.py
@@ -622,14 +622,15 @@ class PhaseDiagramTest(unittest.TestCase):
         with ScratchDir("."):
             dumpfn(self.pd, "pd.json")
             loadfn("pd.json")
-    
+
     def test_el_refs(self):
-        # load a pre_computed phase diagram, 
+        # load a pre_computed phase diagram,
         # which was retrieved via new API and serialized to the MSONable object
-        with open(module_dir / 'pre_computed_phase_diagram_Li-Fe-O.json', 'r') as pd:
+        with open(module_dir / "pre_computed_phase_diagram_Li-Fe-O.json") as pd:
             phaseDiagram = json.load(pd, cls=MontyDecoder)
         # check the keys in el_refs dict have been updated to Element object
         assert str not in [type(el) for el in phaseDiagram.el_refs.keys()]
+
 
 class GrandPotentialPhaseDiagramTest(unittest.TestCase):
     def setUp(self):

--- a/pymatgen/analysis/tests/test_phase_diagram.py
+++ b/pymatgen/analysis/tests/test_phase_diagram.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import collections
+import json
 import os
 import unittest
 import warnings
@@ -12,6 +13,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+from monty.json import MontyDecoder
 from monty.serialization import dumpfn, loadfn
 from monty.tempfile import ScratchDir
 
@@ -620,7 +622,14 @@ class PhaseDiagramTest(unittest.TestCase):
         with ScratchDir("."):
             dumpfn(self.pd, "pd.json")
             loadfn("pd.json")
-
+    
+    def test_el_refs(self):
+        # load a pre_computed phase diagram, 
+        # which was retrieved via new API and serialized to the MSONable object
+        with open(module_dir / 'pre_computed_phase_diagram_Li-Fe-O.json', 'r') as pd:
+            phaseDiagram = json.load(pd, cls=MontyDecoder)
+        # check the keys in el_refs dict have been updated to Element object
+        assert str not in [type(el) for el in phaseDiagram.el_refs.keys()]
 
 class GrandPotentialPhaseDiagramTest(unittest.TestCase):
     def setUp(self):

--- a/pymatgen/analysis/tests/test_phase_diagram.py
+++ b/pymatgen/analysis/tests/test_phase_diagram.py
@@ -622,14 +622,13 @@ class PhaseDiagramTest(unittest.TestCase):
             loadfn("pd.json")
 
     def test_el_refs(self):
-        # Creat an imitation of pre_computed phase diagram, which currently exists an issue
-        # that el_refs is dict[str, PDEntry] object, instead of dict[Element, PDEntry].
-        computed_data_imitation = self.pd.computed_data
-        el_refs_imitation = [(str(el), entry) for el, entry in self.pd.el_refs.items()]
-        computed_data_imitation.update({"el_refs": el_refs_imitation})
-        phase_diagram_imitation = PhaseDiagram(self.entries, computed_data=computed_data_imitation)
+        # Create an imitation of pre_computed phase diagram with el_refs keys being
+        # tuple[str, PDEntry] instead of tuple[Element, PDEntry].
+        mock_el_refs = [(str(el), entry) for el, entry in self.pd.el_refs.items()]
+        mock_computed_data = {**self.pd.computed_data, "el_refs": mock_el_refs}
+        pd = PhaseDiagram(self.entries, computed_data=mock_computed_data)
         # Check the keys in el_refs dict have been updated to Element object via PhaseDiagram class.
-        assert all(isinstance(el, Element) for el in phase_diagram_imitation.el_refs)
+        assert all(isinstance(el, Element) for el in pd.el_refs)
 
 
 class GrandPotentialPhaseDiagramTest(unittest.TestCase):

--- a/pymatgen/analysis/tests/test_phase_diagram.py
+++ b/pymatgen/analysis/tests/test_phase_diagram.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import collections
-import json
 import os
 import unittest
 import warnings
@@ -623,14 +622,15 @@ class PhaseDiagramTest(unittest.TestCase):
             loadfn("pd.json")
 
     def test_el_refs(self):
-        # Creat an imitation of pre_computed phase diagram, which currently exists an issue 
+        # Creat an imitation of pre_computed phase diagram, which currently exists an issue
         # that el_refs is dict[str, PDEntry] object, instead of dict[Element, PDEntry].
         computed_data_imitation = self.pd.computed_data
         el_refs_imitation = [(str(el), entry) for el, entry in self.pd.el_refs.items()]
-        computed_data_imitation.update({'el_refs': el_refs_imitation})
+        computed_data_imitation.update({"el_refs": el_refs_imitation})
         phase_diagram_imitation = PhaseDiagram(self.entries, computed_data=computed_data_imitation)
         # Check the keys in el_refs dict have been updated to Element object via PhaseDiagram class.
         assert all(isinstance(el, Element) for el in phase_diagram_imitation.el_refs)
+
 
 class GrandPotentialPhaseDiagramTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## 

When I try to plot a pre-computed phase diagrams that are retrieved via get_phase_diagram_from_chemsys() method,

> phaseDiagram = mpr.get_phase_diagram_from_chemsys('Li-Fe-O')
> plotter = PDPlotter(phaseDiagram)

a KeyError raises as shown below, which arises from the inconsistence on object stored in el_refs dictionary, i.e., the keys stored in phaseDiagram.el_refs are **str** object (_dict_keys(['O', 'Fe', 'Li'])_), instead of the **Element** object (_dict_keys([Element O, Element Fe, Element Li])_).

The pre-computed phase diagrams in database might not be updated conveniently. So, I add some codes in pymatgen.analysis.phase_diagram.PhaseDiagram class, to update keys in elemental reference dictionary to Element object, in case it loads a pre-computed phase diagram. A corresponding test unit is also added to check the keys in el_refs dictionary,

KeyError message:

>Traceback (most recent call last):
  File "D:\Seafile\peikai\My Libraries\Repos\Volume-Planning-for-Anodes\phase_diagram_mixscheme.py", line 37, in <module>
    plotter = PDPlotter(phase_diagram, show_unstable=0, backend='matplotlib')
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\Anaconda\envs\pymatgen2023\Lib\site-packages\pymatgen\analysis\phase_diagram.py", line 2111, in __init__
    self._min_energy = min(self._pd.get_form_energy_per_atom(e) for e in self._pd.stable_entries)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\Anaconda\envs\pymatgen2023\Lib\site-packages\pymatgen\analysis\phase_diagram.py", line 2111, in <genexpr>
    self._min_energy = min(self._pd.get_form_energy_per_atom(e) for e in self._pd.stable_entries)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\Anaconda\envs\pymatgen2023\Lib\site-packages\pymatgen\analysis\phase_diagram.py", line 577, in get_form_energy_per_atom
    return self.get_form_energy(entry) / entry.composition.num_atoms
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\Anaconda\envs\pymatgen2023\Lib\site-packages\pymatgen\analysis\phase_diagram.py", line 564, in get_form_energy
    return entry.energy - sum(comp[el] * self.el_refs[el].energy_per_atom for el in comp.elements)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\Anaconda\envs\pymatgen2023\Lib\site-packages\pymatgen\analysis\phase_diagram.py", line 564, in <genexpr>
    return entry.energy - sum(comp[el] * self.el_refs[el].energy_per_atom for el in comp.elements)
                                         ~~~~~~~~~~~~^^^^
KeyError: Element Li
