### PR TITLE
allowed frac_tolerance to be passed as an argument to structure.from_file()

### DIFF
--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -300,7 +300,7 @@ class CifParser:
                 occupancies will be scaled down to 1.
             site_tolerance (float): This tolerance is used to determine if two sites are sitting in the same position,
                 in which case they will be combined to a single disordered site. Defaults to 1e-4.
-            frac_tolerance (float): This tolerance is used to determine is a coordinate should be rounded to an ideal
+            frac_tolerance (float): This tolerance is used to determine if a coordinate should be rounded to an ideal
                 value. E.g., 0.6667 is rounded to 2/3. This is desired if symmetry operations are going to be applied.
                 However, for very large CIF files, this may need to be set to 0.
         """


### PR DESCRIPTION
## Summary

Include a summary of major changes in bullet points:

- added frac_tolerance as an argument to from_file, to be passed to the CifParser init
- fixed a very minor typo

- Feature 1 supports A, but not B.

## Checklist

Work-in-progress pull requests are encouraged, but please put \[WIP\] in the pull request title.

Before a pull request can be merged, the following items must be checked:

- [ ] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html). Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [ ] Type annotations are *highly* encouraged. Run [`mypy path/to/file.py`](https://github.com/python/mypy) to type check your code.
- [ ] Tests have been added for any new functionality or bug fixes.
- [ ] All linting and tests pass.

Note that the CI system will run all the above checks. But it will be much more efficient if you already fix most errors prior to submitting the PR. We highly recommended installing `pre-commit` hooks. Simply Run

```sh
pip install -U pre-commit
pre-commit install
```

in the repo's root directory. Afterwards linters will run before every commit and abort if any issues pop up.
