### PR TITLE
Raise ValueError when trying to create PhaseDiagram without entries

### DIFF
--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -416,6 +416,8 @@ class PhaseDiagram(MSONable):
         dim = len(elements)
 
         entries = sorted(self.entries, key=lambda e: e.composition.reduced_composition)
+        if len(entries) == 0:
+            raise ValueError("Unable to build phase diagram without entries.")
 
         el_refs: dict[Element, PDEntry] = {}
         min_entries: list[PDEntry] = []

--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -360,6 +360,9 @@ class PhaseDiagram(MSONable):
                 PhaseDiagram._compute() method and is stored in PhaseDiagram.computed_data
                 when generated for the first time.
         """
+        if not entries:
+            raise ValueError("Unable to build phase diagram without entries.")
+
         self.elements = elements
         self.entries = entries
         if computed_data is None:
@@ -416,8 +419,6 @@ class PhaseDiagram(MSONable):
         dim = len(elements)
 
         entries = sorted(self.entries, key=lambda e: e.composition.reduced_composition)
-        if len(entries) == 0:
-            raise ValueError("Unable to build phase diagram without entries.")
 
         el_refs: dict[Element, PDEntry] = {}
         min_entries: list[PDEntry] = []

--- a/pymatgen/analysis/tests/test_phase_diagram.py
+++ b/pymatgen/analysis/tests/test_phase_diagram.py
@@ -635,7 +635,8 @@ class PhaseDiagramTest(unittest.TestCase):
         entriesList = []
         with pytest.raises(ValueError, match="Unable to build phase diagram without entries."):
             PhaseDiagram(entriesList)
-        
+
+
 class GrandPotentialPhaseDiagramTest(unittest.TestCase):
     def setUp(self):
         self.entries = EntrySet.from_csv(module_dir / "pdentries_test.csv")

--- a/pymatgen/analysis/tests/test_phase_diagram.py
+++ b/pymatgen/analysis/tests/test_phase_diagram.py
@@ -630,11 +630,11 @@ class PhaseDiagramTest(unittest.TestCase):
         # Check the keys in el_refs dict have been updated to Element object via PhaseDiagram class.
         assert all(isinstance(el, Element) for el in pd.el_refs)
 
-    def test_entries_length(self):
-        # Assert PhaseDiagram class raises ValueError when building phase diagram with no entries
-        entriesList = []
-        with pytest.raises(ValueError, match="Unable to build phase diagram without entries."):
-            PhaseDiagram(entriesList)
+    def test_val_err_on_no_entries(self):
+        # check that PhaseDiagram raises ValueError when building phase diagram with no entries
+        for entries in [None, [], set(), tuple()]:
+            with pytest.raises(ValueError, match="Unable to build phase diagram without entries."):
+                PhaseDiagram(entries=entries)
 
 
 class GrandPotentialPhaseDiagramTest(unittest.TestCase):

--- a/pymatgen/analysis/tests/test_phase_diagram.py
+++ b/pymatgen/analysis/tests/test_phase_diagram.py
@@ -630,7 +630,12 @@ class PhaseDiagramTest(unittest.TestCase):
         # Check the keys in el_refs dict have been updated to Element object via PhaseDiagram class.
         assert all(isinstance(el, Element) for el in pd.el_refs)
 
-
+    def test_entries_length(self):
+        # Assert PhaseDiagram class raises ValueError when building phase diagram with no entries
+        entriesList = []
+        with pytest.raises(ValueError, match="Unable to build phase diagram without entries."):
+            PhaseDiagram(entriesList)
+        
 class GrandPotentialPhaseDiagramTest(unittest.TestCase):
     def setUp(self):
         self.entries = EntrySet.from_csv(module_dir / "pdentries_test.csv")


### PR DESCRIPTION
I committed some codes to raise a specific ValueError exception and hint a specific reason message for the attempt to build a phase diagram with no entries. A corresponding unittest was also added.

Scenario:
In the cases that there are not enough entries to form a complete phase diagram, the processing operation of the mixing scheme would fail and might return an empty list, i.e., entryList = []. That would cause an error in PhaseDiagram class when computing data, as shown below. To raise a specific exception is necessary.

Run:
> entryList = MaterialsProjectDFTMixingScheme().process_entries(entryList, clean=True)
> phase_diagram = PhaseDiagram(entryList)

Errors:
>Generating mixing state data from provided entries.
D:\Anaconda\envs\pymatgen2023\Lib\site-packages\pymatgen\entries\mixing_scheme.py:508: UserWarning: GGA(+U) entries do not form a complete PhaseDiagram.
warnings.warn(f"{self.run_type_1} entries do not form a complete PhaseDiagram.")
Entries contain R2SCAN calculations for 0 of 0 GGA(+U) hull entries.
GGA(+U) energies will be adjusted to the R2SCAN scale
D:\Anaconda\envs\pymatgen2023\Lib\site-packages\pymatgen\entries\mixing_scheme.py:215: UserWarning: WARNING! GGA(+U) entries do not form a complete PhaseDiagram. No energy adjustments will be applied.
warnings.warn(str(exc))
Processing complete. Mixed entries contain 0 GGA(+U) and 0 R2SCAN entries.

>Traceback (most recent call last):
    phase_diagram = PhaseDiagram(entryList)
                    ^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\Anaconda\envs\pymatgen2023\Lib\site-packages\pymatgen\analysis\phase_diagram.py", line 366, in __init__
    computed_data = self._compute()
                    ^^^^^^^^^^^^^^^
  File "D:\Anaconda\envs\pymatgen2023\Lib\site-packages\pymatgen\analysis\phase_diagram.py", line 445, in _compute
    form_e = -np.dot(data, vec)
              ^^^^^^^^^^^^^^^^^
  File "<__array_function__ internals>", line 180, in dot
ValueError: shapes (0,) and (1,) not aligned: 0 (dim 0) != 1 (dim 0)