### PR TITLE
Avoid adjusting input entries in mixing schemes.

### DIFF
--- a/pymatgen/entries/compatibility.py
+++ b/pymatgen/entries/compatibility.py
@@ -582,7 +582,10 @@ class Compatibility(MSONable, metaclass=abc.ABCMeta):
 
         processed_entry_list: list[AnyComputedEntry] = []
 
-        for entry in tqdm(entries, disable=not verbose):
+        # take operations on a copy, to keep input entries unchanged
+        entries_copy = [entry.copy() for entry in entries]
+        
+        for entry in tqdm(entries_copy, disable=not verbose):
             ignore_entry = False
             # if clean is True, remove all previous adjustments from the entry
             if clean:

--- a/pymatgen/entries/compatibility.py
+++ b/pymatgen/entries/compatibility.py
@@ -584,7 +584,7 @@ class Compatibility(MSONable, metaclass=abc.ABCMeta):
 
         # take operations on a copy, to keep input entries unchanged
         entries_copy = [entry.copy() for entry in entries]
-        
+
         for entry in tqdm(entries_copy, disable=not verbose):
             ignore_entry = False
             # if clean is True, remove all previous adjustments from the entry

--- a/pymatgen/entries/mixing_scheme.py
+++ b/pymatgen/entries/mixing_scheme.py
@@ -164,10 +164,10 @@ class MaterialsProjectDFTMixingScheme(Compatibility):
         if len(entries) == 1:
             warnings.warn(f"{type(self).__name__} cannot process single entries. Supply a list of entries.")
             return processed_entry_list
-        
+
         # take operations on a copy, to keep input entries unchanged
         entries_copy = [entry.copy() for entry in entries]
-        
+
         # if clean is True, remove all previous adjustments from the entry
         # this code must be placed before the next block, because we don't want to remove
         # any corrections added by compat_1 or compat_2.

--- a/pymatgen/entries/mixing_scheme.py
+++ b/pymatgen/entries/mixing_scheme.py
@@ -164,16 +164,19 @@ class MaterialsProjectDFTMixingScheme(Compatibility):
         if len(entries) == 1:
             warnings.warn(f"{type(self).__name__} cannot process single entries. Supply a list of entries.")
             return processed_entry_list
-
+        
+        # take operations on a copy, to keep input entries unchanged
+        entries_copy = [entry.copy() for entry in entries]
+        
         # if clean is True, remove all previous adjustments from the entry
         # this code must be placed before the next block, because we don't want to remove
         # any corrections added by compat_1 or compat_2.
         if clean:
-            for entry in entries:
+            for entry in entries_copy:
                 for ea in entry.energy_adjustments:
                     entry.energy_adjustments.remove(ea)
 
-        entries_type_1, entries_type_2 = self._filter_and_sort_entries(entries, verbose=verbose)
+        entries_type_1, entries_type_2 = self._filter_and_sort_entries(entries_copy, verbose=verbose)
 
         if mixing_state_data is None:
             if verbose:

--- a/pymatgen/entries/tests/test_compatibility.py
+++ b/pymatgen/entries/tests/test_compatibility.py
@@ -1194,6 +1194,13 @@ class MaterialsProjectCompatibility2020Test(unittest.TestCase):
         temp_compat = decoder.process_decoded(compat_dict)
         assert isinstance(temp_compat, MaterialsProject2020Compatibility)
 
+    def test_entries_copy(self):
+        # check that mixing process does not change input entries
+        entries = [self.entry1, self.entry2, self.entry3]
+        entries_copy = [entry.copy() for entry in entries]
+        self.compat.process_entries(entries_copy)
+        assert all([e.correction == e_copy.correction for e, e_copy in zip(entries, entries_copy)])
+
 
 class MITCompatibilityTest(unittest.TestCase):
     def tearDown(self):

--- a/pymatgen/entries/tests/test_mixing_scheme.py
+++ b/pymatgen/entries/tests/test_mixing_scheme.py
@@ -1287,6 +1287,13 @@ class TestMaterialsProjectDFTMixingSchemeArgs:
         entries = compat.process_entries(ms_complete.all_entries)
         assert len(entries) == 8
 
+    def test_entries_copy(self, ms_complete):
+        # check that mixing process does not change input entries themselves
+        entries = ms_complete.all_entries
+        entries_copy = [entry.copy() for entry in entries]
+        MaterialsProjectDFTMixingScheme().process_entries(entries_copy)
+        assert all([e.correction == e_copy.correction for e, e_copy in zip(entries, entries_copy)])
+
 
 class TestMaterialsProjectDFTMixingSchemeStates:
     """


### PR DESCRIPTION
Here to submit changes to avoid change input entries in place.

In both of GGA/GGA+U and GGA/GGA+U/R2SCAN mixing processes, the methods below not only return adjusted entries, but also change input entries in place. Is it necessary? I think this may cause bugs in programming.

MaterialsProjectDFTMixingScheme.process_entries()
entries.compatibility.process_entries()

Thanks!