### PR TITLE
Fix OPTIMADE client generated filters and URLs

### DIFF
--- a/pymatgen/ext/optimade.py
+++ b/pymatgen/ext/optimade.py
@@ -172,7 +172,7 @@ class OptimadeRester:
         if elements:
             if isinstance(elements, str):
                 elements = [elements]
-            elements_str = ", ".join(f"{el!r}" for el in elements)
+            elements_str = ", ".join(f'"{el}"' for el in elements)
             filters.append(f"(elements HAS ALL {elements_str})")
 
         if nsites:
@@ -188,10 +188,10 @@ class OptimadeRester:
                 filters.append(f"({nelements=})")
 
         if chemical_formula_anonymous:
-            filters.append(f"(chemical_formula_anonymous={chemical_formula_anonymous!r})")
+            filters.append(f'(chemical_formula_anonymous="{chemical_formula_anonymous}")')
 
         if chemical_formula_hill:
-            filters.append(f"(chemical_formula_hill={chemical_formula_anonymous!r})")
+            filters.append(f'(chemical_formula_hill="{chemical_formula_anonymous}")')
 
         return " AND ".join(filters)
 

--- a/pymatgen/ext/optimade.py
+++ b/pymatgen/ext/optimade.py
@@ -191,7 +191,7 @@ class OptimadeRester:
             filters.append(f'(chemical_formula_anonymous="{chemical_formula_anonymous}")')
 
         if chemical_formula_hill:
-            filters.append(f'(chemical_formula_hill="{chemical_formula_anonymous}")')
+            filters.append(f'(chemical_formula_hill="{chemical_formula_hill}")')
 
         return " AND ".join(filters)
 

--- a/pymatgen/ext/optimade.py
+++ b/pymatgen/ext/optimade.py
@@ -304,7 +304,7 @@ class OptimadeRester:
         response_fields = self._handle_response_fields(additional_response_fields)
 
         for identifier, resource in self.resources.items():
-            url = join(resource, f"v1/structures?filter={optimade_filter}&{response_fields=}")
+            url = join(resource, f'v1/structures?filter={optimade_filter}&response_fields="{response_fields}"')
 
             try:
                 json = self._get_json(url)

--- a/pymatgen/ext/tests/test_optimade.py
+++ b/pymatgen/ext/tests/test_optimade.py
@@ -17,11 +17,11 @@ except requests.exceptions.ConnectionError:
     website_down = True
 
 
-@unittest.skipIf(
-    not SETTINGS.get("PMG_MAPI_KEY") or website_down,
-    "PMG_MAPI_KEY environment variable not set or MP is down.",
-)
 class OptimadeTest(PymatgenTest):
+    @unittest.skipIf(
+        not SETTINGS.get("PMG_MAPI_KEY") or website_down,
+        "PMG_MAPI_KEY environment variable not set or MP is down.",
+    )
     def test_get_structures_mp(self):
         with OptimadeRester("mp") as optimade:
             structs = optimade.get_structures(elements=["Ga", "N"], nelements=2)
@@ -39,6 +39,10 @@ class OptimadeTest(PymatgenTest):
                     raw_filter_structs["mp"]
                 ), f"Raw filter {_filter} did not return the same number of results as the query builder."
 
+    @unittest.skipIf(
+        not SETTINGS.get("PMG_MAPI_KEY") or website_down,
+        "PMG_MAPI_KEY environment variable not set or MP is down.",
+    )
     def test_get_snls_mp(self):
         with OptimadeRester("mp") as optimade:
             structs = optimade.get_snls(elements=["Ga", "N"], nelements=2)
@@ -78,3 +82,33 @@ class OptimadeTest(PymatgenTest):
     #         optimade.refresh_aliases()
     #
     #     self.assertIn("mp", optimade.aliases)
+
+    def test_build_filter(self):
+        with OptimadeRester("mp") as optimade:
+            assert optimade._build_filter(
+                elements=["Ga", "N"],
+                nelements=2,
+                nsites=(1, 100),
+                chemical_formula_anonymous="A2B",
+                chemical_formula_hill="GaN",
+            ) == (
+                '(elements HAS ALL "Ga", "N")'
+                " AND (nsites>=1 AND nsites<=100)"
+                " AND (nelements=2)"
+                ' AND (chemical_formula_anonymous="A2B")'
+                ' AND (chemical_formula_hill="GaN")'
+            )
+
+            assert optimade._build_filter(
+                elements=["C", "H", "O"],
+                nelements=(3, 4),
+                nsites=(1, 100),
+                chemical_formula_anonymous="A4B3C",
+                chemical_formula_hill="C4H3O",
+            ) == (
+                '(elements HAS ALL "C", "H", "O")'
+                " AND (nsites>=1 AND nsites<=100)"
+                " AND (nelements>=3 AND nelements<=4)"
+                ' AND (chemical_formula_anonymous="A4B3C")'
+                ' AND (chemical_formula_hill="C4H3O")'
+            )


### PR DESCRIPTION
Closes #2852 by properly quoting OPTIMADE query URLs without using f-strings.

Also fixes an issue where `chemical_formula_hill` was not queryable.