### PR TITLE
Fix typo in OPTIMADE client: remove quotes in response fields

### DIFF
--- a/pymatgen/ext/optimade.py
+++ b/pymatgen/ext/optimade.py
@@ -313,7 +313,7 @@ class OptimadeRester:
         response_fields = self._handle_response_fields(additional_response_fields)
 
         for identifier, resource in self.resources.items():
-            url = join(resource, f'v1/structures?filter={optimade_filter}&response_fields="{response_fields}"')
+            url = join(resource, f"v1/structures?filter={optimade_filter}&response_fields={response_fields}")
 
             try:
                 json = self._get_json(url)


### PR DESCRIPTION
## Summary

One more fix related to #2852 -- response fields also should not have quotes around the entire field. This was caught by a test that directly queries MP, which was (also incorrectly) returning data that didn't quite match rather than an error, e.g.:

https://optimade.materialsproject.org/v1/structures?filter=(elements%20HAS%20ALL%20%22Ga%22,%20%22N%22)%20AND%20(nelements=2)&response_fields=%22species_at_sites,cartesian_site_positions,species,lattice_vectors,nsites%22

vs what should happen if you incorrectly format the response fields:

[https://optimade.odbx.science/v1/structures?response_fields="id"](https://optimade.odbx.science/v1/structures?response_fields=%22id%22)