### PR TITLE
fix reduced formula in Ion

### DIFF
--- a/pymatgen/core/ion.py
+++ b/pymatgen/core/ion.py
@@ -147,7 +147,7 @@ class Ion(Composition, MSONable, Stringify):
         d = {k: int(round(v)) for k, v in comp.get_el_amt_dict().items()}
         (formula, factor) = reduce_formula(d, iupac_ordering=iupac_ordering)
 
-        if "HO" in formula and self.composition['H'] == self.composition['O']:
+        if "HO" in formula and self.composition["H"] == self.composition["O"]:
             formula = formula.replace("HO", "OH")
 
         if nH2O > 0:

--- a/pymatgen/core/ion.py
+++ b/pymatgen/core/ion.py
@@ -147,7 +147,7 @@ class Ion(Composition, MSONable, Stringify):
         d = {k: int(round(v)) for k, v in comp.get_el_amt_dict().items()}
         (formula, factor) = reduce_formula(d, iupac_ordering=iupac_ordering)
 
-        if "HO" in formula:
+        if "HO" in formula and self.composition['H'] == self.composition['O']:
             formula = formula.replace("HO", "OH")
 
         if nH2O > 0:


### PR DESCRIPTION
Fixed the handling of O-H containing compositions, where the string 'HO' was replaced by 'OH' directly in the reduced formula. This will cause certain materials, e.g. HSbO2, to have the wrong reduced formula of SbOH2.

This fix then adds a condition that the composition must have an equal number of H and O to be handled that way. 
