### PR TITLE
MPAqueousCompatiblity: compute hydrate correction using reduced rather than full composition

### DIFF
--- a/pymatgen/entries/compatibility.py
+++ b/pymatgen/entries/compatibility.py
@@ -1357,8 +1357,8 @@ class MaterialsProjectAqueousCompatibility(Compatibility):
         # TODO - detection of embedded water molecules is not very sophisticated
         # Should be replaced with some kind of actual structure detection
 
-        # For any compound except water, check to see if it is a hydrate (contains)
-        # H2O in its structure. If so, adjust the energy to remove MU_H2O ev per
+        # For any compound except water, check to see if it is a hydrate (contains
+        # H2O in its structure). If so, adjust the energy to remove MU_H2O eV per
         # embedded water molecule.
         # in other words, we assume that the DFT energy of such a compound is really
         # a superposition of the "real" solid DFT energy (FeO in this case) and the free
@@ -1369,11 +1369,14 @@ class MaterialsProjectAqueousCompatibility(Compatibility):
         # with
         # g_FeO = E_FeO.nH2O + dE_Fe + dE_O + n g_H2O
         # where E is DFT energy, dE is an energy correction, and g is Gibbs free energy
-        # This means we have to 1) remove energy corrections associated with H and O in water
-        # and then 2) remove the free energy of the water molecules
+        # of formation
+        # This means we have to 1) reverse any energy corrections that have already been
+        # applied to H and O in water and then 2) remove the free energy of the water
+        # molecules from the hydrated solid energy.
         if rform != "H2O":
             # count the number of whole water molecules in the composition
-            nH2O = int(min(comp.reduced_composition["H"] / 2.0, comp.reduced_composition["O"]))
+            rcomp, factor = comp.get_reduced_composition_and_factor()
+            nH2O = int(min(rcomp["H"] / 2.0, rcomp["O"])) * factor
             if nH2O > 0:
                 # first, remove any H or O corrections already applied to H2O in the
                 # formation energy so that we don't double count them

--- a/pymatgen/entries/compatibility.py
+++ b/pymatgen/entries/compatibility.py
@@ -1373,7 +1373,7 @@ class MaterialsProjectAqueousCompatibility(Compatibility):
         # and then 2) remove the free energy of the water molecules
         if rform != "H2O":
             # count the number of whole water molecules in the composition
-            nH2O = int(min(comp["H"] / 2.0, comp["O"]))
+            nH2O = int(min(comp.reduced_composition["H"] / 2.0, comp.reduced_composition["O"]))
             if nH2O > 0:
                 # first, remove any H or O corrections already applied to H2O in the
                 # formation energy so that we don't double count them

--- a/pymatgen/entries/tests/test_compatibility.py
+++ b/pymatgen/entries/tests/test_compatibility.py
@@ -2128,13 +2128,15 @@ class TestMaterialsProjectAqueousCompatibility:
             o2_energy=-10, h2o_energy=-20, h2o_adjustments=-0.5, solid_compat=None
         )
 
-        hydrate_entry = ComputedEntry(Composition("FeH4O2"), -10)
+        hydrate_entry = ComputedEntry(Composition("FeH4O2"), -10)  # nH2O = 2
+        hydrate_entry2 = ComputedEntry(Composition("Li2O2H2"), -10)  # nH2O = 0
 
-        initial_energy = hydrate_entry.energy
-        hydrate_entry = compat.process_entries(hydrate_entry)[0]
-        processed_energy = hydrate_entry.energy
+        compat.process_entries([hydrate_entry, hydrate_entry2])
 
-        assert initial_energy - processed_energy == pytest.approx(2 * (compat.h2o_adjustments * 3 + MU_H2O))
+        assert hydrate_entry.uncorrected_energy - hydrate_entry.energy == pytest.approx(
+            2 * (compat.h2o_adjustments * 3 + MU_H2O)
+        )
+        assert hydrate_entry2.uncorrected_energy - hydrate_entry2.energy == 0
 
     def test_processing_entries_inplace(self):
         h2o_entry = ComputedEntry(Composition("H2O"), (-5.195 + 0.234) * 3, correction=-0.234 * 3)  # -5.195 eV/atom


### PR DESCRIPTION
## Summary

Small change to the way `MaterialsProjectAqueousCompatibility` corrects energies for materials containing `H2O`.

As [described by a user on MatSci](https://matsci.org/t/mpaqueouscompatibility-applies-hydrate-correction-to-non-hydrate-materials/47360/2), the current way of detecting whether a material contains 'H2O' can lead to false positives for formulas like `Li2O2H2`, causing this material to be corrected as if it were a hydrate when in fact it is not.

Here, I change the detection of hydrates to be based on `reduced_composition` instead of `composition` to avoid such false positives.

Tests appear to pass, but flagging @montoyjh and @as2362 in case there are concerns about how this will impact Pourbaix Diagrams. This should cause the energies of some -OH phases to change a bit because they won't receive the hydrate correction.