### PR TITLE
Replace `codecs.open` with `io.open` for reading `PotcarSingle`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ ci:
 
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.254
+    rev: v0.0.255
     hooks:
       - id: ruff
         args: [--fix, --ignore, 'D,SIM']

--- a/pymatgen/analysis/interfaces/zsl.py
+++ b/pymatgen/analysis/interfaces/zsl.py
@@ -184,7 +184,6 @@ class ZSLGenerator(MSONable):
         Runs the ZSL algorithm to generate all possible matching
         :return:
         """
-
         film_area = vec_area(*film_vectors)
         substrate_area = vec_area(*substrate_vectors)
 

--- a/pymatgen/analysis/structure_matcher.py
+++ b/pymatgen/analysis/structure_matcher.py
@@ -347,7 +347,7 @@ class StructureMatcher(MSONable):
         comparator: AbstractComparator | None = None,
         supercell_size: Literal["num_sites", "num_atoms", "volume"] = "num_sites",
         ignored_species: Sequence[SpeciesLike] = (),
-    ):
+    ) -> None:
         """
         Args:
             ltol (float): Fractional length tolerance. Default is 0.2.
@@ -403,9 +403,8 @@ class StructureMatcher(MSONable):
 
     def _get_supercell_size(self, s1, s2):
         """
-        Returns the supercell size, and whether the supercell should
-        be applied to s1. If fu == 1, s1_supercell is returned as
-        true, to avoid ambiguity.
+        Returns the supercell size, and whether the supercell should be applied to s1.
+        If fu == 1, s1_supercell is returned as true, to avoid ambiguity.
         """
         if self._supercell_size == "num_sites":
             fu = s2.num_sites / s1.num_sites
@@ -699,7 +698,7 @@ class StructureMatcher(MSONable):
         s1_supercell=True,
         use_rms=False,
         break_on_match=False,
-    ):
+    ) -> tuple[float, float, np.ndarray, float, Mapping] | None:
         """
         Matches one struct onto the other
         """
@@ -742,6 +741,10 @@ class StructureMatcher(MSONable):
             s1_supercell (bool): whether to create the supercell of struct1 (vs struct2)
             use_rms (bool): whether to minimize the rms of the matching
             break_on_match (bool): whether to stop search at first match
+
+        Returns:
+            tuple[float, float, np.ndarray, float, Mapping]: (rms, max_dist, mask, cost, mapping)
+                if a match is found, else None
         """
         if fu < 1:
             raise ValueError("fu cannot be less than 1")
@@ -1054,7 +1057,7 @@ class StructureMatcher(MSONable):
 
     def fit_anonymous(
         self, struct1: Structure, struct2: Structure, niggli: bool = True, skip_structure_reduction: bool = False
-    ):
+    ) -> bool:
         """
         Performs an anonymous fitting, which allows distinct species in one
         structure to map to another. E.g., to compare if the Li2O and Na2O
@@ -1077,7 +1080,7 @@ class StructureMatcher(MSONable):
 
         return bool(matches)
 
-    def get_supercell_matrix(self, supercell, struct):
+    def get_supercell_matrix(self, supercell, struct) -> np.ndarray | None:
         """
         Returns the matrix for transforming struct to supercell. This
         can be used for very distorted 'supercells' where the primitive cell

--- a/pymatgen/analysis/tests/test_ewald.py
+++ b/pymatgen/analysis/tests/test_ewald.py
@@ -129,9 +129,9 @@ class EwaldMinimizerTest(unittest.TestCase):
 
         # Comparison to LAMMPS result
         ham = EwaldSummation(s, compute_forces=True)
-        assert -1226.3335 == approx(ham.total_energy, abs=1e-3)
-        assert -45.8338 == approx(ham.get_site_energy(0), abs=1e-3)
-        assert -27.2978 == approx(ham.get_site_energy(8), abs=1e-3)
+        assert approx(ham.total_energy, abs=1e-3) == -1226.3335
+        assert approx(ham.get_site_energy(0), abs=1e-3) == -45.8338
+        assert approx(ham.get_site_energy(8), abs=1e-3) == -27.2978
 
 
 if __name__ == "__main__":

--- a/pymatgen/analysis/tests/test_structure_analyzer.py
+++ b/pymatgen/analysis/tests/test_structure_analyzer.py
@@ -56,10 +56,10 @@ class RelaxationAnalyzerTest(unittest.TestCase):
 
     def test_vol_and_para_changes(self):
         for v in self.analyzer.get_percentage_lattice_parameter_changes().values():
-            assert -0.0092040921155279731 == approx(v)
+            assert approx(v) == -0.0092040921155279731
             latt_change = v
         vol_change = self.analyzer.get_percentage_volume_change()
-        assert -0.0273589101391 == approx(vol_change)
+        assert approx(vol_change) == -0.0273589101391
         # This is a simple cubic cell, so the latt and vol change are simply
         # Related. So let's test that.
         assert (1 + latt_change) ** 3 - 1 == approx(vol_change)
@@ -67,7 +67,7 @@ class RelaxationAnalyzerTest(unittest.TestCase):
     def test_get_percentage_bond_dist_changes(self):
         for v in self.analyzer.get_percentage_bond_dist_changes().values():
             for v2 in v.values():
-                assert -0.009204092115527862 == approx(v2)
+                assert approx(v2) == -0.009204092115527862
 
 
 class VoronoiConnectivityTest(PymatgenTest):

--- a/pymatgen/core/__init__.py
+++ b/pymatgen/core/__init__.py
@@ -46,7 +46,7 @@ def _load_pmg_settings() -> dict[str, Any]:
     yaml = YAML()
     for file_path in (SETTINGS_FILE, OLD_SETTINGS_FILE):
         try:
-            with open(file_path, "rt", encoding="utf-8") as yml_file:
+            with open(file_path, encoding="utf-8") as yml_file:
                 settings = yaml.load(yml_file) or {}
             break
         except FileNotFoundError:

--- a/pymatgen/io/lobster/tests/test_lobster.py
+++ b/pymatgen/io/lobster/tests/test_lobster.py
@@ -640,9 +640,9 @@ class IcohplistTest(unittest.TestCase):
         }
 
         assert icohplist_bise == self.icohp_bise.icohplist
-        assert -2.38796 == self.icohp_bise.icohpcollection.extremum_icohpvalue()
+        assert self.icohp_bise.icohpcollection.extremum_icohpvalue() == -2.38796
         assert icooplist_fe == self.icoop_fe.icohplist
-        assert -0.29919 == self.icoop_fe.icohpcollection.extremum_icohpvalue()
+        assert self.icoop_fe.icohpcollection.extremum_icohpvalue() == -0.29919
         assert icooplist_bise == self.icoop_bise.icohplist
         assert self.icoop_bise.icohpcollection.extremum_icohpvalue() == 0.24714
         assert self.icobi.icohplist["1"]["icohp"][Spin.up] == approx(0.58649)

--- a/pymatgen/io/tests/test_gaussian.py
+++ b/pymatgen/io/tests/test_gaussian.py
@@ -368,14 +368,14 @@ class GaussianOutputTest(unittest.TestCase):
     def test_scan(self):
         gau = GaussianOutput(os.path.join(test_dir, "so2_scan.log"))
         d = gau.read_scan()
-        assert -548.02102 == approx(d["energies"][-1])
+        assert approx(d["energies"][-1]) == -548.02102
         assert len(d["coords"]) == 1
         assert len(d["energies"]) == len(gau.energies)
         assert len(d["energies"]) == 21
         gau = GaussianOutput(os.path.join(test_dir, "so2_scan_opt.log"))
         assert len(gau.opt_structures) == 21
         d = gau.read_scan()
-        assert -548.02336 == approx(d["energies"][-1])
+        assert approx(d["energies"][-1]) == -548.02336
         assert len(d["coords"]) == 2
         assert len(d["energies"]) == 21
         assert approx(d["coords"]["DSO"][6]) == 1.60000
@@ -389,7 +389,7 @@ class GaussianOutputTest(unittest.TestCase):
         ]
         assert gau.opt_structures[-1].cart_coords.tolist() == coords
         d = gau.read_scan()
-        assert -0.00523 == approx(d["energies"][-1])
+        assert approx(d["energies"][-1]) == -0.00523
         assert len(d["coords"]) == 3
         assert len(d["energies"]) == 21
         assert approx(d["coords"]["R1"][6]) == 0.94710
@@ -400,7 +400,7 @@ class GaussianOutputTest(unittest.TestCase):
         Test an optimization where no "input orientation" is outputted
         """
         gau = GaussianOutput(os.path.join(test_dir, "acene-n_gaussian09_opt.out"))
-        assert -1812.58399675 == approx(gau.energies[-1])
+        assert approx(gau.energies[-1]) == -1812.58399675
         assert len(gau.structures) == 6
         # Test the first 3 atom coordinates
         coords = [

--- a/pymatgen/io/tests/test_nwchem.py
+++ b/pymatgen/io/tests/test_nwchem.py
@@ -407,19 +407,19 @@ class NwOutputTest(unittest.TestCase):
         nwo_cosmo = NwOutput(os.path.join(test_dir, "N2O4.nwout"))
 
         assert nwo[0]["charge"] == 0
-        assert -1 == nwo[-1]["charge"]
+        assert nwo[-1]["charge"] == -1
         assert len(nwo) == 5
-        assert -1102.6224491715582 == approx(nwo[0]["energies"][-1], abs=1e-2)
-        assert -1102.9986291578023 == approx(nwo[2]["energies"][-1], abs=1e-3)
-        assert -11156.354030653656 == approx(nwo_cosmo[5]["energies"][0]["cosmo scf"], abs=1e-3)
-        assert -11153.374133394364 == approx(nwo_cosmo[5]["energies"][0]["gas phase"], abs=1e-3)
-        assert -11156.353632962995 == approx(nwo_cosmo[5]["energies"][0]["sol phase"], abs=1e-2)
-        assert -11168.818934311605 == approx(nwo_cosmo[6]["energies"][0]["cosmo scf"], abs=1e-2)
-        assert -11166.3624424611462 == approx(nwo_cosmo[6]["energies"][0]["gas phase"], abs=1e-2)
-        assert -11168.818934311605 == approx(nwo_cosmo[6]["energies"][0]["sol phase"], abs=1e-2)
-        assert -11165.227959110889 == approx(nwo_cosmo[7]["energies"][0]["cosmo scf"], abs=1e-2)
-        assert -11165.025443612385 == approx(nwo_cosmo[7]["energies"][0]["gas phase"], abs=1e-2)
-        assert -11165.227959110154 == approx(nwo_cosmo[7]["energies"][0]["sol phase"], abs=1e-2)
+        assert approx(nwo[0]["energies"][-1], abs=1e-2) == -1102.6224491715582
+        assert approx(nwo[2]["energies"][-1], abs=1e-3) == -1102.9986291578023
+        assert approx(nwo_cosmo[5]["energies"][0]["cosmo scf"], abs=1e-3) == -11156.354030653656
+        assert approx(nwo_cosmo[5]["energies"][0]["gas phase"], abs=1e-3) == -11153.374133394364
+        assert approx(nwo_cosmo[5]["energies"][0]["sol phase"], abs=1e-2) == -11156.353632962995
+        assert approx(nwo_cosmo[6]["energies"][0]["cosmo scf"], abs=1e-2) == -11168.818934311605
+        assert approx(nwo_cosmo[6]["energies"][0]["gas phase"], abs=1e-2) == -11166.3624424611462
+        assert approx(nwo_cosmo[6]["energies"][0]["sol phase"], abs=1e-2) == -11168.818934311605
+        assert approx(nwo_cosmo[7]["energies"][0]["cosmo scf"], abs=1e-2) == -11165.227959110889
+        assert approx(nwo_cosmo[7]["energies"][0]["gas phase"], abs=1e-2) == -11165.025443612385
+        assert approx(nwo_cosmo[7]["energies"][0]["sol phase"], abs=1e-2) == -11165.227959110154
 
         assert nwo[1]["hessian"][0][0] == approx(4.60187e01)
         assert nwo[1]["hessian"][1][2] == approx(-1.14030e-08)
@@ -439,7 +439,7 @@ class NwOutputTest(unittest.TestCase):
         ie = nwo[4]["energies"][-1] - nwo[2]["energies"][-1]
         ea = nwo[2]["energies"][-1] - nwo[3]["energies"][-1]
         assert approx(ie) == 0.7575358648355177
-        assert -14.997877958701338 == approx(ea, abs=1e-3)
+        assert approx(ea, abs=1e-3) == -14.997877958701338
         assert nwo[4]["basis_set"]["C"]["description"] == "6-311++G**"
 
         nwo = NwOutput(os.path.join(test_dir, "H4C3O3_1.nwout"))

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -1878,9 +1878,8 @@ class PotcarSingle:
                 return PotcarSingle(f.read(), symbol=symbol or None)
         except UnicodeDecodeError:
             warnings.warn("POTCAR contains invalid unicode errors. We will attempt to read it by ignoring errors.")
-            import codecs
 
-            with codecs.open(filename, "r", encoding="utf-8", errors="ignore") as f:
+            with open(filename, encoding="utf-8", errors="ignore") as f:
                 return PotcarSingle(f.read(), symbol=symbol or None)
 
     @staticmethod

--- a/pymatgen/io/vasp/tests/test_outputs.py
+++ b/pymatgen/io/vasp/tests/test_outputs.py
@@ -1507,7 +1507,7 @@ class LocpotTest(PymatgenTest):
     def test_init(self):
         filepath = self.TEST_FILES_DIR / "LOCPOT"
         locpot = Locpot.from_file(filepath)
-        assert -217.05226954 == approx(sum(locpot.get_average_along_axis(0)))
+        assert approx(sum(locpot.get_average_along_axis(0))) == -217.05226954
         assert locpot.get_axis_grid(0)[-1] == approx(2.87629, abs=1e-2)
         assert locpot.get_axis_grid(1)[-1] == approx(2.87629, abs=1e-2)
         assert locpot.get_axis_grid(2)[-1] == approx(2.87629, abs=1e-2)

--- a/pymatgen/symmetry/analyzer.py
+++ b/pymatgen/symmetry/analyzer.py
@@ -40,7 +40,8 @@ logger = logging.getLogger(__name__)
 @lru_cache(maxsize=32)
 def _get_symmetry_dataset(cell, symprec, angle_tolerance):
     """Simple wrapper to cache results of spglib.get_symmetry_dataset since this call is
-    expensive."""
+    expensive.
+    """
     return spglib.get_symmetry_dataset(cell, symprec=symprec, angle_tolerance=angle_tolerance)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ target-version = "py38"
 line-length = 120
 select = [
   "B",   # flake8-bugbear
-  "C4",  # flake8-comprehensions
+  "C40", # flake8-comprehensions
   "D",   # pydocstyle
   "E",   # pycodestyle
   "F",   # pyflakes


### PR DESCRIPTION
Following private discussion about unicode issues when reading POTCARs and @mkhorton mentioning `codecs.open` is potentially.