### PR TITLE
Fix TypeError: a bytes-like object is required, not 'list' when passing triplet of bools to `find_points_in_spheres()` `pbc` kwarg 

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,7 +31,7 @@ jobs:
       - name: ruff
         run: |
           ruff --version
-          ruff check . --ignore 'D,SIM'
+          ruff . --ignore D
 
       - name: black
         run: |


### PR DESCRIPTION
Closes #2887.