### PR TITLE
Fix ValueError: not enough values to unpack in PDPlotter if no unstable entries in PD

### DIFF
--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -3018,8 +3018,8 @@ class PDPlotter:
 
         stable_coords = list(self.pd_plot_data[1])
         stable_entries = self.pd_plot_data[1].values()
-        unstable_coords = list(self.pd_plot_data[2])
-        unstable_entries = self.pd_plot_data[2].values()
+        unstable_entries = list(self.pd_plot_data[2])
+        unstable_coords = self.pd_plot_data[2].values()
 
         stable_props = get_marker_props(stable_coords, stable_entries)
 

--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -3014,17 +3014,12 @@ class PDPlotter:
                 elif self._dim == 4:
                     z.append(coord[2])
 
-            return {
-                "x": x,
-                "y": y,
-                "z": z,
-                "texts": texts,
-                "energies": energies,
-                "uncertainties": uncertainties,
-            }
+            return {"x": x, "y": y, "z": z, "texts": texts, "energies": energies, "uncertainties": uncertainties}
 
-        stable_coords, stable_entries = zip(*self.pd_plot_data[1].items())
-        unstable_entries, unstable_coords = zip(*self.pd_plot_data[2].items())
+        stable_coords = list(self.pd_plot_data[1])
+        stable_entries = self.pd_plot_data[1].values()
+        unstable_coords = list(self.pd_plot_data[2])
+        unstable_entries = self.pd_plot_data[2].values()
 
         stable_props = get_marker_props(stable_coords, stable_entries)
 

--- a/pymatgen/analysis/tests/test_phase_diagram.py
+++ b/pymatgen/analysis/tests/test_phase_diagram.py
@@ -878,6 +878,13 @@ class PDPlotterTest(unittest.TestCase):
         self.plotter_quaternary_mpl = PDPlotter(self.pd_quaternary, backend="matplotlib")
         self.plotter_quaternary_plotly = PDPlotter(self.pd_quaternary, backend="plotly")
 
+    def test_plot_pd_with_no_unstable(self):
+        # https://github.com/materialsproject/pymatgen/issues/2885
+        pd_entries = [PDEntry(comp, 0) for comp in ["Li", "Co", "O"]]
+        pd = PhaseDiagram(pd_entries)
+        plotter = PDPlotter(pd, backend="plotly", show_unstable=False)
+        plotter.get_plot()
+
     def test_pd_plot_data(self):
         lines, labels, unstable_entries = self.plotter_ternary_mpl.pd_plot_data
         assert len(lines) == 22


### PR DESCRIPTION
Closes #2885.

 933d3eb2e4 fix ValueError: not enough values to unpack (expected 2, got 0)
 f654d9f32c add test to prevent regression