### PR TITLE
BUG FIX: BSDOSPlotter.get_plot

### DIFF
--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -2285,7 +2285,7 @@ class BSDOSPlotter:
 
         # make sure the user-specified band structure projection is valid
         bs_projection = self.bs_projection
-        if isinstance(dos, CompleteDos): # Dos obj has no structure
+        if isinstance(dos, CompleteDos):  # Dos obj has no structure
             elements = [e.symbol for e in dos.structure.composition.elements]
         elif bs_projection and bs.structure:
             elements = [e.symbol for e in bs.structure.composition.elements]

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -2272,12 +2272,12 @@ class BSDOSPlotter:
         Args:
             bs (BandStructureSymmLine): the bandstructure to plot. Projection
                 data must exist for projected plots.
-            dos (Dos): the Dos to plot. Projection data must exist (i.e.,
-                CompleteDos) for projected plots.
+            dos (Dos | CompleteDos): the Dos to plot. For projected plots, the projection data must
+                exist i.e. you need to pass a CompleteDos.
 
         Returns:
-            matplotlib.pyplot object on which you can call commands like show()
-            and savefig()
+            plt: matplotlib.pyplot on which you can call commands like show()
+                and savefig()
         """
         import matplotlib.lines as mlines
         import matplotlib.pyplot as mplt

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -2285,7 +2285,7 @@ class BSDOSPlotter:
 
         # make sure the user-specified band structure projection is valid
         bs_projection = self.bs_projection
-        if dos:
+        if isinstance(dos, CompleteDos): # Dos obj has no structure
             elements = [e.symbol for e in dos.structure.composition.elements]
         elif bs_projection and bs.structure:
             elements = [e.symbol for e in bs.structure.composition.elements]

--- a/pymatgen/electronic_structure/tests/test_plotter.py
+++ b/pymatgen/electronic_structure/tests/test_plotter.py
@@ -206,39 +206,39 @@ class BSDOSPlotterTest(unittest.TestCase):
     # Minimal baseline testing for get_plot. not a true test. Just checks that
     # it can actually execute.
     def test_methods(self):
-        v = Vasprun(os.path.join(PymatgenTest.TEST_FILES_DIR, "vasprun_Si_bands.xml"))
-        p = BSDOSPlotter()
-        plt = p.get_plot(
-            v.get_band_structure(kpoints_filename=os.path.join(PymatgenTest.TEST_FILES_DIR, "KPOINTS_Si_bands"))
+        vasprun = Vasprun(os.path.join(PymatgenTest.TEST_FILES_DIR, "vasprun_Si_bands.xml"))
+        plotter = BSDOSPlotter()
+        plt = plotter.get_plot(
+            vasprun.get_band_structure(kpoints_filename=os.path.join(PymatgenTest.TEST_FILES_DIR, "KPOINTS_Si_bands"))
         )
         plt.close()
-        plt = p.get_plot(
-            v.get_band_structure(kpoints_filename=os.path.join(PymatgenTest.TEST_FILES_DIR, "KPOINTS_Si_bands")),
-            v.complete_dos,
+        plt = plotter.get_plot(
+            vasprun.get_band_structure(kpoints_filename=os.path.join(PymatgenTest.TEST_FILES_DIR, "KPOINTS_Si_bands")),
+            vasprun.complete_dos,
         )
         plt.close("all")
 
         with open(os.path.join(PymatgenTest.TEST_FILES_DIR, "SrBa2Sn2O7.json")) as f:
-            bandstr_dict = json.load(f)
+            band_struct_dict = json.load(f)
         # generate random projections
         data_structure = [[[[0 for _ in range(12)] for _ in range(9)] for _ in range(70)] for _ in range(90)]
-        bandstr_dict["projections"]["1"] = data_structure
-        d = bandstr_dict["projections"]["1"]
-        for i in range(len(d)):
-            for j in range(len(d[i])):
-                for k in range(len(d[i][j])):
-                    for m in range(len(d[i][j][k])):
-                        d[i][j][k][m] = 0
+        band_struct_dict["projections"]["1"] = data_structure
+        projections = band_struct_dict["projections"]["1"]
+        for i in range(len(projections)):
+            for j in range(len(projections[i])):
+                for k in range(len(projections[i][j])):
+                    for m in range(len(projections[i][j][k])):
+                        projections[i][j][k][m] = 0
                         # d[i][j][k][m] = np.random.rand()
                     # generate random number for two atoms
                     a = np.random.randint(0, 7)
                     b = np.random.randint(0, 7)
                     # c = np.random.randint(0,7)
-                    d[i][j][k][a] = np.random.rand()
-                    d[i][j][k][b] = np.random.rand()
+                    projections[i][j][k][a] = np.random.rand()
+                    projections[i][j][k][b] = np.random.rand()
                     # d[i][j][k][c] = np.random.rand()
-        bandstr = BandStructureSymmLine.from_dict(bandstr_dict)
-        plt = p.get_plot(bandstr)
+        band_struct = BandStructureSymmLine.from_dict(band_struct_dict)
+        plt = plotter.get_plot(band_struct)
         plt.show()
 
 


### PR DESCRIPTION
Line 2288 

```py
if dos:
```

change to

```py
if isinstance(dos, CompleteDos): # Dos obj has no structure
```

The DOS object has no structure property, which causes error if parsing DOS data without projection. 
This modification allows user to plot BS and TDOS at the same time, while keeping the BS+PDOS plotting not affected.

Cheers.