### PR TITLE
auto version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,10 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
+[tool.versioningit.vcs]
+method = "git"
+default-tag = "0.0.1"
+
 [tool.black]
 line-length = 120
 


### PR DESCRIPTION
## Allow proper versioning for forked repos

I'm not 100% sure how the current version numbering is updated for `pymatgen` but it's not able to update the number properly for forks.  The forks seem to keep a much older version number (from before the forking)
This creates problems if you have the forked repo as a dependency in a requirement.txt file.

This should fix that issue.