### PR TITLE
fix on reading multiple route in Gaussian input file

### DIFF
--- a/pymatgen/io/gaussian.py
+++ b/pymatgen/io/gaussian.py
@@ -314,7 +314,7 @@ class GaussianInput:
             elif (line == "" or line.isspace()) and route_index:
                 break
             if route_index:
-                route += " " + line
+                route += f" {line}"
                 route_index = idx
         functional, basis_set, route_paras, dieze_tag = read_route_line(route)
         ind = 2

--- a/pymatgen/io/gaussian.py
+++ b/pymatgen/io/gaussian.py
@@ -313,6 +313,9 @@ class GaussianInput:
             # This condition allows for route cards spanning multiple lines
             elif (line == "" or line.isspace()) and route_index:
                 break
+            if route_index:
+                route += " " + line
+                route_index = idx
         functional, basis_set, route_paras, dieze_tag = read_route_line(route)
         ind = 2
         title = []

--- a/pymatgen/io/tests/test_gaussian.py
+++ b/pymatgen/io/tests/test_gaussian.py
@@ -127,6 +127,7 @@ Sites (6)
         gau_str = """%mem=5000000
         %chk=filename
         # mp2/6-31g* scf=direct
+        opt freq
 
         SIH4+ H2---SIH2+ CS //MP2(full)/6-31G* MP2=-290.9225259
 
@@ -149,6 +150,7 @@ Sites (6)
 
         gau = GaussianInput.from_string(gau_str)
         assert gau.molecule.composition.reduced_formula == "X3SiH4"
+        assert set(gau.route_parameters.keys()) == {"opt", "freq", "nosymm", "scf", "geom", "pseudo"}
 
     def test_gen_basis(self):
         gau_str = """#N B3LYP/Gen Pseudo=Read

--- a/pymatgen/io/tests/test_gaussian.py
+++ b/pymatgen/io/tests/test_gaussian.py
@@ -150,7 +150,7 @@ Sites (6)
 
         gau = GaussianInput.from_string(gau_str)
         assert gau.molecule.composition.reduced_formula == "X3SiH4"
-        assert set(gau.route_parameters.keys()) == {"opt", "freq", "scf"}
+        assert set(gau.route_parameters) == {"opt", "freq", "scf"}
 
     def test_gen_basis(self):
         gau_str = """#N B3LYP/Gen Pseudo=Read

--- a/pymatgen/io/tests/test_gaussian.py
+++ b/pymatgen/io/tests/test_gaussian.py
@@ -150,7 +150,7 @@ Sites (6)
 
         gau = GaussianInput.from_string(gau_str)
         assert gau.molecule.composition.reduced_formula == "X3SiH4"
-        assert set(gau.route_parameters.keys()) == {"opt", "freq", "nosymm", "scf", "geom", "pseudo"}
+        assert set(gau.route_parameters.keys()) == {"opt", "freq", "scf"}
 
     def test_gen_basis(self):
         gau_str = """#N B3LYP/Gen Pseudo=Read


### PR DESCRIPTION
## Summary

This fixes the issue that the Gaussian input file fails to read multiple lines. 
- When the route input has multiple lines as below, GaussianInput.from_string() fails around the parsing of the route. This was due to inappropriate line counting when the route is separated in multiple lines.
- few lines of code were added to parse the route and route_index.
- test files for routes with multiple lines.

Example of Gaussian input (header only) with multiple lines of the route that failed.
```
%nprocshared=28
%mem=60GB
%chk=test.chk
# opt freq wb97xd/gen nosymm scf=(qc,maxcycle=1024) geom=connectivity
pseudo=read
```

## Todo (if any)

## Checklist

Before a pull request can be merged, the following items must be checked:

- [x] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html). Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [ ] Type annotations are *highly* encouraged. Run [`mypy path/to/file.py`](https://github.com/python/mypy) to type check your code. Should I also rewrite the other part of the codes?
- [x] Tests have been added for any new functionality or bug fixes.
- [ ] All linting and tests pass. 

Note that the CI system will run all the above checks. But it will be much more efficient if you already fix most errors prior to submitting the PR. We highly recommended installing `pre-commit` hooks. Simply Run

```sh
pip install -U pre-commit
pre-commit install
```

in the repo's root directory. Afterwards linters will run before every commit and abort if any issues pop up.
