### PR TITLE
Minor modification for symmetrically distinct Miller index generation

### DIFF
--- a/pymatgen/core/surface.py
+++ b/pymatgen/core/surface.py
@@ -1672,6 +1672,10 @@ def get_symmetrically_distinct_miller_indices(structure, max_index, return_hkil=
     # First we get a list of all hkls for conventional (including equivalent)
     conv_hkl_list = [miller for miller in itertools.product(r, r, r) if any(i != 0 for i in miller)]
 
+    # Sort by the maximum of the absolute values of individual Miller indices so that
+    # low-index planes are first. This is important for trigonal systems.
+    conv_hkl_list = sorted(conv_hkl_list, key=lambda x: max(np.abs(x)))
+
     sg = SpacegroupAnalyzer(structure)
     # Get distinct hkl planes from the rhombohedral setting if trigonal
     if sg.get_crystal_system() == "trigonal":

--- a/pymatgen/core/tests/test_surface.py
+++ b/pymatgen/core/tests/test_surface.py
@@ -794,6 +794,12 @@ class MillerIndexFinderTests(PymatgenTest):
         assert len(indices) == 17
         assert all(len(hkl) == 4 for hkl in indices)
 
+        # Test to see if the output with max_index i is a subset of the output with max_index i+1
+        for i in range(1, 4):
+            assert set(get_symmetrically_distinct_miller_indices(self.trigBi, i)) <= set(
+                get_symmetrically_distinct_miller_indices(self.trigBi, i + 1)
+            )
+
     def test_get_symmetrically_equivalent_miller_indices(self):
         # Tests to see if the function obtains all equivalent hkl for cubic (100)
         indices001 = [


### PR DESCRIPTION
## Summary

Follows: https://github.com/materialsproject/pymatgen/issues/2944

- Fix: `conv_hkl_list` is now sorted with respect to the maximum of the absolute values of the individual Miller indices it contains, before it is iterated over, ensuring that the unique Miller indices returned contain the lowest indices possible.