### PR TITLE
Fixed Wulff shape for new versions of matplotlib

### DIFF
--- a/pymatgen/analysis/wulff.py
+++ b/pymatgen/analysis/wulff.py
@@ -439,7 +439,8 @@ class WulffShape:
         wulff_pt_list = self.wulff_pt_list
 
         ax = mpl3.Axes3D(fig, azim=azim, elev=elev)
-
+        fig.add_axes(ax)
+        
         for plane in self.facets:
             # check whether [pts] is empty
             if len(plane.points) < 1:

--- a/pymatgen/analysis/wulff.py
+++ b/pymatgen/analysis/wulff.py
@@ -440,7 +440,7 @@ class WulffShape:
 
         ax = mpl3.Axes3D(fig, azim=azim, elev=elev)
         fig.add_axes(ax)
-        
+
         for plane in self.facets:
             # check whether [pts] is empty
             if len(plane.points) < 1:


### PR DESCRIPTION
Closes #2900.

Since matplotlib does not allow us to set auto_add_to_figure=True in Axes3D anymore passed ver. 3.6.0, I had to add the ax object to the Figure in order for it to properly display. Should now be backward/forward compatible for all versions of matplotlib.