### PR TITLE
Test figure returned by WulffShape.get_plot() contains single Axes3D

### DIFF
--- a/pymatgen/analysis/tests/test_wulff.py
+++ b/pymatgen/analysis/tests/test_wulff.py
@@ -4,6 +4,7 @@ import json
 import os
 import unittest
 
+from mpl_toolkits.mplot3d import Axes3D
 from pytest import approx
 
 from pymatgen.analysis.wulff import WulffShape
@@ -70,14 +71,13 @@ class WulffShapeTest(PymatgenTest):
 
         self.surface_properties = surface_properties
 
-    @unittest.skipIf("DISPLAY" not in os.environ, "Need display")
     def test_get_plot(self):
-        # Basic test, not really a unittest.
-        self.wulff_Ti.get_plot()
-        self.wulff_Nb.get_plot()
-        self.wulff_Ir.get_plot()
+        # Basic test to check figure contains a single Axes3D object
+        for wulff in (self.wulff_Nb, self.wulff_Ir, self.wulff_Ti):
+            plt = wulff.get_plot()
+            assert len(plt.gcf().get_axes()) == 1
+            assert isinstance(plt.gcf().get_axes()[0], Axes3D)
 
-    @unittest.skipIf("DISPLAY" not in os.environ, "Need display")
     def test_get_plotly(self):
         # Basic test, not really a unittest.
         self.wulff_Ti.get_plotly()

--- a/pymatgen/analysis/wulff.py
+++ b/pymatgen/analysis/wulff.py
@@ -422,7 +422,7 @@ class WulffShape:
         """
         import matplotlib as mpl
         import matplotlib.pyplot as plt
-        import mpl_toolkits.mplot3d as mpl3
+        from mpl_toolkits.mplot3d import Axes3D, art3d
 
         colors = self._get_colors(color_set, alpha, off_color, custom_colors=custom_colors or {})
         color_list, color_proxy, color_proxy_on_wulff, miller_on_wulff, e_surf_on_wulff = colors
@@ -438,7 +438,7 @@ class WulffShape:
 
         wulff_pt_list = self.wulff_pt_list
 
-        ax = mpl3.Axes3D(fig, azim=azim, elev=elev)
+        ax = Axes3D(fig, azim=azim, elev=elev)
         fig.add_axes(ax)
 
         for plane in self.facets:
@@ -451,7 +451,7 @@ class WulffShape:
             plane_color = color_list[plane.index]
             pt = self.get_line_in_facet(plane)
             # plot from the sorted pts from [simpx]
-            tri = mpl3.art3d.Poly3DCollection([pt])
+            tri = art3d.Poly3DCollection([pt])
             tri.set_color(plane_color)
             tri.set_edgecolor("#808080")
             ax.add_collection3d(tri)


### PR DESCRIPTION
Follow-up to #2950. Improves the `get_plot()` test to make sure a regression causing an empty figure doesn't go unnoticed again.