### PR TITLE
Fix `Cp2kOutput.spin_polarized()` likely not doing what author intended

### DIFF
--- a/pymatgen/io/cp2k/outputs.py
+++ b/pymatgen/io/cp2k/outputs.py
@@ -200,9 +200,7 @@ class Cp2kOutput:
     def spin_polarized(self) -> bool:
         """Was the calculation spin polarized"""
         keys = ("UKS", "UNRESTRICTED_KOHN_SHAM", "LSD", "SPIN_POLARIZED")
-        if any(key in self.data["dft"].values() for key in keys):
-            return True
-        return False
+        return any(key in self.data["dft"].values() for key in keys)
 
     @property
     def charge(self) -> float:

--- a/pymatgen/io/cp2k/outputs.py
+++ b/pymatgen/io/cp2k/outputs.py
@@ -190,28 +190,27 @@ class Cp2kOutput:
         return rt
 
     @property
-    def project_name(self):
+    def project_name(self) -> str:
         """
         What project name was used for this calculation
         """
         return self.data.get("global").get("project_name")
 
     @property
-    def spin_polarized(self):
-        """
-        Was the calculation spin polarized
-        """
-        if ("UKS" or "UNRESTRICTED_KOHN_SHAM" or "LSD" or "SPIN_POLARIZED") in self.data["dft"].values():
+    def spin_polarized(self) -> bool:
+        """Was the calculation spin polarized"""
+        keys = ("UKS", "UNRESTRICTED_KOHN_SHAM", "LSD", "SPIN_POLARIZED")
+        if any(key in self.data["dft"].values() for key in keys):
             return True
         return False
 
     @property
-    def charge(self):
+    def charge(self) -> float:
         """Get charge from the input file"""
         return self.input["FORCE_EVAL"]["DFT"].get("CHARGE", Keyword("", 0)).values[0]
 
     @property
-    def multiplicity(self):
+    def multiplicity(self) -> int:
         """Get the spin multiplicity from input file"""
         return self.input["FORCE_EVAL"]["DFT"].get("Multiplicity", Keyword("")).values[0]
 


### PR DESCRIPTION
```py
if ("UKS" or "UNRESTRICTED_KOHN_SHAM" or "LSD" or "SPIN_POLARIZED") in self.data["dft"].values():
            return True
```

`"UKS" or "UNRESTRICTED_KOHN_SHAM" or "LSD" or "SPIN_POLARIZED"` short-circuits to `"UKS"` and so won't return `True` even if `"UNRESTRICTED_KOHN_SHAM"` or `"LSD"` or `"SPIN_POLARIZED"` are present.