### PR TITLE
Add cell_filter_kwargs to relax method that is passed to ExpCellFilter

### DIFF
--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -3993,6 +3993,7 @@ class Structure(IStructure, collections.abc.MutableSequence):
         steps: int = 500,
         fmax: float = 0.1,
         return_trajectory: bool = False,
+        cell_filter_kwargs: dict = None,
         verbose: bool = False,
     ) -> Structure | tuple[Structure, TrajectoryObserver]:
         """
@@ -4008,6 +4009,7 @@ class Structure(IStructure, collections.abc.MutableSequence):
             return_trajectory (bool): Whether to return the trajectory of relaxation.
                 Defaults to False.
             verbose (bool): whether to print out relaxation steps. Defaults to False.
+            cell_filter_kwargs (dict): passed to ExpCellFilter as keyword args.
 
         Returns:
             Structure: IAP-relaxed structure
@@ -4037,8 +4039,9 @@ class Structure(IStructure, collections.abc.MutableSequence):
         atoms.set_calculator(calculator)
         stream = sys.stdout if verbose else io.StringIO()
         with contextlib.redirect_stdout(stream):
+            cell_filter_kwargs = cell_filter_kwargs or {}
             if relax_cell:
-                atoms = ExpCellFilter(atoms)
+                atoms = ExpCellFilter(atoms, **cell_filter_kwargs)
             optimizer = FIRE(atoms)
             optimizer.run(fmax=fmax, steps=steps)
         if isinstance(atoms, ExpCellFilter):


### PR DESCRIPTION
## Summary

Add cell_filter_kwargs to relax method that is passed to ExpCellFilter
This extension allows us to e.g. relax lattice constant along particular directions, e.g.,
```
structure.relax(cell_filter_kwargs={"mask": (1,1,0,0,0,1)}))
```
Then, the lattice is optimized only in xy-plane.

Because the change is tiny, I didn't add a unittest for it.

## Checklist
Before a pull request can be merged, the following items must be checked:

- [x] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html). Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [x] Type annotations are *highly* encouraged. Run [`mypy path/to/file.py`](https://github.com/python/mypy) to type check your code.
- [ ] Tests have been added for any new functionality or bug fixes.
- [x] All linting and tests pass.
