### PR TITLE
fix recursion error by adding copy and deepcopy dunder methods

### DIFF
--- a/pymatgen/analysis/chemenv/coordination_environments/tests/test_read_write.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/tests/test_read_write.py
@@ -33,16 +33,8 @@ from pymatgen.util.testing import PymatgenTest
 
 __author__ = "waroquiers"
 
-json_files_dir = os.path.join(
-    PymatgenTest.TEST_FILES_DIR,
-    "chemenv",
-    "json_test_files",
-)
-se_files_dir = os.path.join(
-    PymatgenTest.TEST_FILES_DIR,
-    "chemenv",
-    "structure_environments_files",
-)
+json_files_dir = os.path.join(PymatgenTest.TEST_FILES_DIR, "chemenv", "json_test_files")
+se_files_dir = os.path.join(PymatgenTest.TEST_FILES_DIR, "chemenv", "structure_environments_files")
 
 
 class ReadWriteChemenvTest(unittest.TestCase):

--- a/pymatgen/io/core.py
+++ b/pymatgen/io/core.py
@@ -140,6 +140,31 @@ class InputSet(MSONable, MutableMapping):
             return self.get(k)
         raise AttributeError(f"'{type(self).__name__}' object has no attribute {k!r}")
 
+    def __copy__(self):
+        cls = self.__class__
+        new_instance = cls.__new__(cls)
+
+        # Copy over all attributes. For a shallow copy, we don't need to worry
+        # about deep copying complex structures, hence a simple assignment is used.
+        for k, v in self.__dict__.items():
+            setattr(new_instance, k, v)
+
+        return new_instance
+
+    def __deepcopy__(self, memo):
+        import copy
+
+        cls = self.__class__
+        new_instance = cls.__new__(cls)
+        memo[id(self)] = new_instance
+
+        # Copy over all attributes. You might need to customize this if you have
+        # complex attributes that don't copy well this way.
+        for k, v in self.__dict__.items():
+            setattr(new_instance, k, copy.deepcopy(v, memo))
+
+        return new_instance
+
     def __len__(self):
         return len(self.inputs)
 

--- a/pymatgen/io/core.py
+++ b/pymatgen/io/core.py
@@ -144,8 +144,6 @@ class InputSet(MSONable, MutableMapping):
         cls = self.__class__
         new_instance = cls.__new__(cls)
 
-        # Copy over all attributes. For a shallow copy, we don't need to worry
-        # about deep copying complex structures, hence a simple assignment is used.
         for k, v in self.__dict__.items():
             setattr(new_instance, k, v)
 
@@ -158,8 +156,6 @@ class InputSet(MSONable, MutableMapping):
         new_instance = cls.__new__(cls)
         memo[id(self)] = new_instance
 
-        # Copy over all attributes. You might need to customize this if you have
-        # complex attributes that don't copy well this way.
         for k, v in self.__dict__.items():
             setattr(new_instance, k, copy.deepcopy(v, memo))
 

--- a/pymatgen/io/core.py
+++ b/pymatgen/io/core.py
@@ -140,7 +140,7 @@ class InputSet(MSONable, MutableMapping):
             return self.get(k)
         raise AttributeError(f"'{type(self).__name__}' object has no attribute {k!r}")
 
-    def __copy__(self):
+    def __copy__(self) -> InputSet:
         cls = self.__class__
         new_instance = cls.__new__(cls)
 
@@ -149,7 +149,7 @@ class InputSet(MSONable, MutableMapping):
 
         return new_instance
 
-    def __deepcopy__(self, memo):
+    def __deepcopy__(self, memo: dict[int, InputSet]) -> InputSet:
         import copy
 
         cls = self.__class__

--- a/pymatgen/io/tests/test_core.py
+++ b/pymatgen/io/tests/test_core.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import os
 
 import pytest
@@ -229,3 +230,35 @@ class TestInputSet:
             with open(os.path.join("input_dir", "file_from_strcast")) as f:
                 file_from_strcast = f.read()
                 assert file_from_strcast == "Aha\nBeh"
+
+    def test_deepcopy(self):
+        sif1 = StructInputFile.from_file(os.path.join(test_dir, "Li.cif"))
+        sif2 = StructInputFile.from_file(os.path.join(test_dir, "LiFePO4.cif"))
+
+        inp_set = InputSet(
+            {
+                "cif1": sif1,
+                "cif2": sif2,
+            },
+            kwarg1=1,
+            kwarg2="hello",
+        )
+        inp_set2 = copy.deepcopy(inp_set)
+
+        assert inp_set.as_dict() == inp_set2.as_dict()
+
+    def test_copy(self):
+        sif1 = StructInputFile.from_file(os.path.join(test_dir, "Li.cif"))
+        sif2 = StructInputFile.from_file(os.path.join(test_dir, "LiFePO4.cif"))
+
+        inp_set = InputSet(
+            {
+                "cif1": sif1,
+                "cif2": sif2,
+            },
+            kwarg1=1,
+            kwarg2="hello",
+        )
+        inp_set2 = copy.copy(inp_set)
+
+        assert inp_set.as_dict() == inp_set2.as_dict()

--- a/pymatgen/io/tests/test_core.py
+++ b/pymatgen/io/tests/test_core.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import os
+import unittest
 
 import pytest
 from monty.serialization import MontyDecoder
@@ -65,17 +66,17 @@ class TestInputFile:
         assert sif.structure == temp_sif.structure
 
 
-class TestInputSet:
+class TestInputSet(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.sif1 = StructInputFile.from_file(os.path.join(test_dir, "Li.cif"))
+        cls.sif2 = StructInputFile.from_file(os.path.join(test_dir, "LiFePO4.cif"))
+        cls.sif3 = StructInputFile.from_file(os.path.join(test_dir, "Li2O.cif"))
+
     def test_mapping(self):
-        sif1 = StructInputFile.from_file(os.path.join(test_dir, "Li.cif"))
-        sif2 = StructInputFile.from_file(os.path.join(test_dir, "LiFePO4.cif"))
-        sif3 = StructInputFile.from_file(os.path.join(test_dir, "Li2O.cif"))
+        sif1, sif2, sif3 = self.sif1, self.sif2, self.sif3
         inp_set = InputSet(
-            {
-                "cif1": sif1,
-                "cif2": sif2,
-                "cif3": sif3,
-            },
+            {"cif1": sif1, "cif2": sif2, "cif3": sif3},
             kwarg1=1,
             kwarg2="hello",
         )
@@ -110,52 +111,34 @@ class TestInputSet:
             assert contents is exp_contents
 
     def test_equality(self):
-        sif1 = StructInputFile.from_file(os.path.join(test_dir, "Li.cif"))
-        sif2 = StructInputFile.from_file(os.path.join(test_dir, "LiFePO4.cif"))
-        sif3 = StructInputFile.from_file(os.path.join(test_dir, "Li2O.cif"))
+        sif1, sif2, sif3 = self.sif1, self.sif2, self.sif3
 
         inp_set = InputSet(
-            {
-                "cif1": sif1,
-                "cif2": sif2,
-            },
+            {"cif1": sif1, "cif2": sif2},
             kwarg1=1,
             kwarg2="hello",
         )
 
         inp_set2 = InputSet(
-            {
-                "cif1": sif1,
-                "cif2": sif2,
-            },
+            {"cif1": sif1, "cif2": sif2},
             kwarg1=1,
             kwarg2="hello",
         )
 
         inp_set3 = InputSet(
-            {
-                "cif1": sif1,
-                "cif2": sif2,
-                "cif3": sif3,
-            },
+            {"cif1": sif1, "cif2": sif2, "cif3": sif3},
             kwarg1=1,
             kwarg2="hello",
         )
 
         inp_set4 = InputSet(
-            {
-                "cif1": sif1,
-                "cif2": sif2,
-            },
+            {"cif1": sif1, "cif2": sif2},
             kwarg1=1,
             kwarg2="goodbye",
         )
 
         inp_set5 = InputSet(
-            {
-                "cif1": sif1,
-                "cif2": sif2,
-            },
+            {"cif1": sif1, "cif2": sif2},
             kwarg1=1,
             kwarg2="hello",
             kwarg3="goodbye",
@@ -167,13 +150,9 @@ class TestInputSet:
         assert inp_set.as_dict() != inp_set5.as_dict()
 
     def test_msonable(self):
-        sif1 = StructInputFile.from_file(os.path.join(test_dir, "Li.cif"))
-        sif2 = StructInputFile.from_file(os.path.join(test_dir, "Li2O.cif"))
+        sif1, sif2 = self.sif1, self.sif2
         inp_set = InputSet(
-            {
-                "cif1": sif1,
-                "cif2": sif2,
-            },
+            {"cif1": sif1, "cif2": sif2},
             kwarg1=1,
             kwarg2="hello",
         )
@@ -190,13 +169,9 @@ class TestInputSet:
             assert contents.structure == contents2.structure
 
     def test_write(self):
-        sif1 = StructInputFile.from_file(os.path.join(test_dir, "Li.cif"))
-        sif2 = StructInputFile.from_file(os.path.join(test_dir, "Li2O.cif"))
+        sif1, sif2 = self.sif1, self.sif2
         inp_set = InputSet(
-            {
-                "cif1": sif1,
-                "cif2": sif2,
-            },
+            {"cif1": sif1, "cif2": sif2},
             kwarg1=1,
             kwarg2="hello",
         )
@@ -231,34 +206,26 @@ class TestInputSet:
                 file_from_strcast = f.read()
                 assert file_from_strcast == "Aha\nBeh"
 
-    def test_deepcopy(self):
-        sif1 = StructInputFile.from_file(os.path.join(test_dir, "Li.cif"))
-        sif2 = StructInputFile.from_file(os.path.join(test_dir, "LiFePO4.cif"))
-
-        inp_set = InputSet(
-            {
-                "cif1": sif1,
-                "cif2": sif2,
-            },
-            kwarg1=1,
-            kwarg2="hello",
-        )
-        inp_set2 = copy.deepcopy(inp_set)
-
-        assert inp_set.as_dict() == inp_set2.as_dict()
-
     def test_copy(self):
-        sif1 = StructInputFile.from_file(os.path.join(test_dir, "Li.cif"))
-        sif2 = StructInputFile.from_file(os.path.join(test_dir, "LiFePO4.cif"))
+        sif1, sif2 = self.sif1, self.sif2
 
         inp_set = InputSet(
-            {
-                "cif1": sif1,
-                "cif2": sif2,
-            },
+            {"cif1": sif1, "cif2": sif2},
             kwarg1=1,
             kwarg2="hello",
         )
         inp_set2 = copy.copy(inp_set)
+
+        assert inp_set.as_dict() == inp_set2.as_dict()
+
+    def test_deepcopy(self):
+        sif1, sif2 = self.sif1, self.sif2
+
+        inp_set = InputSet(
+            {"cif1": sif1, "cif2": sif2},
+            kwarg1=1,
+            kwarg2="hello",
+        )
+        inp_set2 = copy.deepcopy(inp_set)
 
         assert inp_set.as_dict() == inp_set2.as_dict()


### PR DESCRIPTION
## Summary

Both copy and deepcopy are currently broken for the `InputSet` object. This PR implements dunder methods to fix both. There very well may be a more elegant solution but I couldn't find it!

- Feature 1: `__copy__` and `__deepcopy__` dunder methods

## Checklist

- [x] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html). Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [x] Type annotations are *highly* encouraged. Run [`mypy path/to/file.py`](https://github.com/python/mypy) to type check your code.
- [x] Tests have been added for any new functionality or bug fixes.
- [x] All linting and tests pass.