### PR TITLE
Enable `flake8-pytest-style` via `ruff`

### DIFF
--- a/pymatgen/analysis/chemenv/coordination_environments/tests/test_coordination_geometry_finder.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/tests/test_coordination_geometry_finder.py
@@ -242,8 +242,7 @@ class CoordinationGeometryFinderTest(PymatgenTest):
             get_from_hints=True,
         )
         with pytest.raises(KeyError):
-            abc = se_nohints.ce_list[0][12]
-            abc.minimum_geometries()
+            se_nohints.ce_list[0][12]
         assert se_hints.ce_list[0][13][0] == se_nohints.ce_list[0][13][0]
         assert set(se_nohints.ce_list[0]).issubset(set(se_hints.ce_list[0]))
 

--- a/pymatgen/analysis/chemenv/utils/tests/test_graph_utils.py
+++ b/pymatgen/analysis/chemenv/utils/tests/test_graph_utils.py
@@ -80,17 +80,12 @@ class GraphUtilsTest(PymatgenTest):
         assert np.allclose(get_delta(n1, n2, edge_data), [2, 6, 4])
         edge_data = {"start": 7, "end": 3, "delta": [2, 6, 4]}
         assert np.allclose(get_delta(n1, n2, edge_data), [-2, -6, -4])
-        with pytest.raises(
-            ValueError,
-            match="Trying to find a delta between two nodes with an edge that seems not to link these nodes.",
-        ):
-            edge_data = {"start": 6, "end": 3, "delta": [2, 6, 4]}
+        edge_data = {"start": 6, "end": 3, "delta": [2, 6, 4]}
+        err_msg = "Trying to find a delta between two nodes with an edge that seems not to link these nodes."
+        with pytest.raises(ValueError, match=err_msg):
             get_delta(n1, n2, edge_data)
-        with pytest.raises(
-            ValueError,
-            match="Trying to find a delta between two nodes with an edge that seems not to link these nodes.",
-        ):
-            edge_data = {"start": 7, "end": 2, "delta": [2, 6, 4]}
+        edge_data = {"start": 7, "end": 2, "delta": [2, 6, 4]}
+        with pytest.raises(ValueError, match=err_msg):
             get_delta(n1, n2, edge_data)
 
     def test_simple_graph_cycle(self):
@@ -153,21 +148,21 @@ class GraphUtilsTest(PymatgenTest):
         assert sg_cycle == SimpleGraphCycle([2, 7, 4, 5, 0])
 
         #   two identical 3-nodes cycles
+        edges = [(0, 2), (4, 2), (0, 4), (0, 2), (4, 2), (0, 4)]
         with pytest.raises(ValueError, match="SimpleGraphCycle is not valid : Duplicate nodes."):
-            edges = [(0, 2), (4, 2), (0, 4), (0, 2), (4, 2), (0, 4)]
             SimpleGraphCycle.from_edges(edges=edges, edges_are_ordered=False)
 
         #   two cycles in from_edges
+        edges = [(0, 2), (4, 2), (0, 4), (1, 3), (6, 7), (3, 6), (1, 7)]
         with pytest.raises(ValueError, match="Could not construct a cycle from edges."):
-            edges = [(0, 2), (4, 2), (0, 4), (1, 3), (6, 7), (3, 6), (1, 7)]
             SimpleGraphCycle.from_edges(edges=edges, edges_are_ordered=False)
 
+        edges = [(0, 2), (4, 6), (2, 7), (4, 5), (5, 0)]
         with pytest.raises(ValueError, match="Could not construct a cycle from edges."):
-            edges = [(0, 2), (4, 6), (2, 7), (4, 5), (5, 0)]
             SimpleGraphCycle.from_edges(edges=edges, edges_are_ordered=False)
 
+        edges = [(0, 2), (4, 7), (2, 7), (4, 10), (5, 0)]
         with pytest.raises(ValueError, match="Could not construct a cycle from edges."):
-            edges = [(0, 2), (4, 7), (2, 7), (4, 10), (5, 0)]
             SimpleGraphCycle.from_edges(edges=edges, edges_are_ordered=False)
 
         # Test as_dict from_dict and len method

--- a/pymatgen/analysis/tests/test_interface_reactions.py
+++ b/pymatgen/analysis/tests/test_interface_reactions.py
@@ -346,11 +346,10 @@ class InterfaceReactionTest(unittest.TestCase):
                 relative_vectors_2 = [(x - x_kink[-1], e - energy_kink[-1]) for x, e in points]
                 relative_vectors = zip(relative_vectors_1, relative_vectors_2)
                 positions = [np.cross(v1, v2) for v1, v2 in relative_vectors]
-                test1 = np.all(np.array(positions) <= 0)
+                assert np.all(np.array(positions) <= 0)
 
                 hull = ConvexHull(points)
-                test2 = len(hull.vertices) == len(points)
-                assert test1 and test2, "Error: Generating non-convex plot!"
+                assert len(hull.vertices) == len(points), "Error: Generating non-convex plot!"
 
         for ir in self.ir:
             test_convexity_helper(ir)

--- a/pymatgen/analysis/tests/test_local_env.py
+++ b/pymatgen/analysis/tests/test_local_env.py
@@ -1265,12 +1265,12 @@ class CrystalNNTest(PymatgenTest):
         warnings.filters = self.prev_warnings
 
     def test_sanity(self):
+        cnn = CrystalNN()
         with pytest.raises(ValueError):
-            cnn = CrystalNN()
             cnn.get_cn(self.lifepo4, 0, use_weights=True)
 
+        cnn = CrystalNN(weighted_cn=True)
         with pytest.raises(ValueError):
-            cnn = CrystalNN(weighted_cn=True)
             cnn.get_cn(self.lifepo4, 0, use_weights=False)
 
     def test_discrete_cn(self):

--- a/pymatgen/analysis/tests/test_phase_diagram.py
+++ b/pymatgen/analysis/tests/test_phase_diagram.py
@@ -389,13 +389,14 @@ class PhaseDiagramTest(unittest.TestCase):
             ), "Stable composition should have only 1 decomposition!"
         dim = len(self.pd.elements)
         for entry in self.pd.all_entries:
-            ndecomp = len(self.pd.get_decomposition(entry.composition))
+            n_decomp = len(self.pd.get_decomposition(entry.composition))
+            assert n_decomp > 0
             assert (
-                ndecomp > 0 and ndecomp <= dim
+                n_decomp <= dim
             ), "The number of decomposition phases can at most be equal to the number of components."
 
         # Just to test decomposition for a fictitious composition
-        ansdict = {
+        ans_dict = {
             entry.composition.formula: amt for entry, amt in self.pd.get_decomposition(Composition("Li3Fe7O11")).items()
         }
         expected_ans = {
@@ -404,7 +405,7 @@ class PhaseDiagramTest(unittest.TestCase):
             "Fe6 O8": 0.33333333333333393,
         }
         for k, v in expected_ans.items():
-            assert ansdict[k] == pytest.approx(v)
+            assert ans_dict[k] == pytest.approx(v)
 
     def test_get_transition_chempots(self):
         for el in self.pd.elements:

--- a/pymatgen/core/tests/test_composition.py
+++ b/pymatgen/core/tests/test_composition.py
@@ -41,15 +41,15 @@ class CompositionTest(PymatgenTest):
         ]
 
     def test_immutable(self):
-        try:
+        with pytest.raises(TypeError) as exc_info:
             self.comp[0]["Fe"] = 1
-        except Exception as ex:
-            assert isinstance(ex, TypeError)
 
-        try:
+        assert "'Composition' object does not support item assignment" in str(exc_info.value)
+
+        with pytest.raises(TypeError) as exc_info:
             del self.comp[0]["Fe"]
-        except Exception as ex:
-            assert isinstance(ex, TypeError)
+
+        assert "'Composition' object does not support item deletion" in str(exc_info.value)
 
     def test_in(self):
         assert "Fe" in self.comp[0]

--- a/pymatgen/core/tests/test_lattice.py
+++ b/pymatgen/core/tests/test_lattice.py
@@ -568,19 +568,15 @@ class LatticeTestCase(PymatgenTest):
     def test_selling_dist(self):
         # verification process described here
         # https://github.com/materialsproject/pymatgen/pull/1888#issuecomment-818072164
-        np.testing.assert_(Lattice.selling_dist(Lattice.cubic(5), Lattice.cubic(5)) == 0)
+        assert Lattice.selling_dist(Lattice.cubic(5), Lattice.cubic(5)) == 0
         hex_lattice = Lattice.hexagonal(5, 8)
         triclinic_lattice = Lattice.from_parameters(4, 10, 11, 100, 110, 80)
-        np.testing.assert_allclose(Lattice.selling_dist(hex_lattice, triclinic_lattice), 76, rtol=0.1)
-        np.testing.assert_allclose(
-            Lattice.selling_dist(Lattice.tetragonal(10, 12), Lattice.tetragonal(10.1, 11.9)),
-            3.7,
-            rtol=0.1,
+        assert Lattice.selling_dist(hex_lattice, triclinic_lattice) == pytest.approx(76, abs=0.1)
+        assert Lattice.selling_dist(Lattice.tetragonal(10, 12), Lattice.tetragonal(10.1, 11.9)) == pytest.approx(
+            3.7, abs=0.1
         )
-        np.testing.assert_allclose(
-            Lattice.selling_dist(Lattice.cubic(5), Lattice.from_parameters(8, 10, 12, 80, 90, 95)),
-            115.6,
-            rtol=0.1,
+        assert Lattice.selling_dist(Lattice.cubic(5), Lattice.from_parameters(8, 10, 12, 80, 90, 95)) == pytest.approx(
+            125.99, abs=0.1
         )
 
     def test_selling_vector(self):

--- a/pymatgen/core/tests/test_libxcfunc.py
+++ b/pymatgen/core/tests/test_libxcfunc.py
@@ -10,8 +10,11 @@ class LibxcFuncTest(PymatgenTest):
         # LDA correlation: Hedin & Lundqvist
         xc = LibxcFunc.LDA_C_HL
         print(xc)
-        assert not xc.is_x_kind and xc.is_c_kind and not xc.is_xc_kind
-        assert xc.is_lda_family and not xc.is_gga_family
+        assert not xc.is_x_kind
+        assert xc.is_c_kind
+        assert not xc.is_xc_kind
+        assert xc.is_lda_family
+        assert not xc.is_gga_family
         print(xc.info_dict)
 
         assert xc.family in LibxcFunc.all_families()

--- a/pymatgen/core/tests/test_trajectory.py
+++ b/pymatgen/core/tests/test_trajectory.py
@@ -237,7 +237,8 @@ class TrajectoryTest(PymatgenTest):
         except Exception:
             incompatible_test_success = True
 
-        assert compatible_success and incompatible_test_success
+        assert compatible_success
+        assert incompatible_test_success
 
         traj = copy.deepcopy(self.traj_mols)
 

--- a/pymatgen/core/xcfunc.py
+++ b/pymatgen/core/xcfunc.py
@@ -142,7 +142,8 @@ class XcFunc(MSONable):
         x, c = LibxcFunc(int(first)), LibxcFunc(int(last))
         if not x.is_x_kind:
             x, c = c, x  # Swap
-        assert x.is_x_kind and c.is_c_kind
+        assert x.is_x_kind
+        assert c.is_c_kind
         return cls(x=x, c=c)
 
     @classmethod

--- a/pymatgen/electronic_structure/tests/test_plotter.py
+++ b/pymatgen/electronic_structure/tests/test_plotter.py
@@ -84,10 +84,10 @@ class DosPlotterTest(unittest.TestCase):
             param_dict = self.get_plot_attributes(plt)
             plt_invert = self.plotter.get_plot(invert_axes=True, xlim=item["DOS_limit"], ylim=item["energy_limit"])
             param_dict_invert = self.get_plot_attributes(plt_invert)
-            self.assertEqual(item["energy_result"], param_dict["xaxis_limits"])
-            self.assertEqual(item["energy_result"], param_dict_invert["yaxis_limits"])
-            self.assertEqual(item["DOS_result"], param_dict["yaxis_limits"])
-            self.assertEqual(item["DOS_result"], param_dict_invert["xaxis_limits"])
+            assert item["energy_result"] == param_dict["xaxis_limits"]
+            assert item["energy_result"] == param_dict_invert["yaxis_limits"]
+            assert item["DOS_result"] == param_dict["yaxis_limits"]
+            assert item["DOS_result"] == param_dict_invert["xaxis_limits"]
 
     @staticmethod
     def get_plot_attributes(plt):

--- a/pymatgen/entries/tests/test_compatibility.py
+++ b/pymatgen/entries/tests/test_compatibility.py
@@ -1941,29 +1941,18 @@ class OxideTypeCorrectionNoPeroxideCorrTest(unittest.TestCase):
             [0.666665, 0.666684, 0.149189],
         ]
         struct = Structure(latt, elts, coords)
-        li2o2_entry = ComputedStructureEntry(
-            struct,
-            -3,
-            parameters={
-                "is_hubbard": False,
-                "hubbards": None,
-                "run_type": "GGA",
-                "potcar_spec": [
-                    {
-                        "titel": "PAW_PBE Li 17Jan2003",
-                        "hash": "65e83282d1707ec078c1012afbd05be8",
-                    },
-                    {
-                        "titel": "PAW_PBE O 08Apr2002",
-                        "hash": "7a25bc5b9a5393f46600a4939d357982",
-                    },
-                ],
-            },
-        )
+        cse_params = {
+            "is_hubbard": False,
+            "hubbards": None,
+            "run_type": "GGA",
+            "potcar_spec": [
+                {"titel": "PAW_PBE Li 17Jan2003", "hash": "65e83282d1707ec078c1012afbd05be8"},
+                {"titel": "PAW_PBE O 08Apr2002", "hash": "7a25bc5b9a5393f46600a4939d357982"},
+            ],
+        }
+        li2o2_entry = ComputedStructureEntry(struct, -3, parameters=cse_params)
 
         li2o2_entry_corrected = self.compat.process_entry(li2o2_entry)
-        with pytest.raises(AssertionError):
-            self.assertAlmostEqual(*(li2o2_entry_corrected.energy, -3 - 0.44317 * 4, 4))
         assert li2o2_entry_corrected.energy == pytest.approx(-3 - 0.66975 * 4)
 
     def test_ozonide(self):

--- a/pymatgen/entries/tests/test_mixing_scheme.py
+++ b/pymatgen/entries/tests/test_mixing_scheme.py
@@ -162,7 +162,7 @@ class MixingState:
         return self.gga_entries + self.scan_entries
 
 
-@pytest.fixture
+@pytest.fixture()
 def mixing_scheme_no_compat():
     """
     Return an instance of MaterialsProjectDFTMixingScheme with no additional
@@ -212,7 +212,7 @@ lattice_br_r2scan = Lattice.from_dict(
 )
 
 
-@pytest.fixture
+@pytest.fixture()
 def ms_complete():
     """
     Mixing state where we have R2SCAN for all GGA
@@ -383,7 +383,7 @@ def ms_complete():
     return MixingState(gga_entries, scan_entries, mixing_state)
 
 
-@pytest.fixture
+@pytest.fixture()
 def ms_scan_only(ms_complete):
     """
     Mixing state with only R2SCAN entries
@@ -408,7 +408,7 @@ def ms_scan_only(ms_complete):
     return MixingState(gga_entries, scan_entries, mixing_state)
 
 
-@pytest.fixture
+@pytest.fixture()
 def ms_gga_only(ms_complete):
     """
     Mixing state with only GGA entries
@@ -433,7 +433,7 @@ def ms_gga_only(ms_complete):
     return MixingState(gga_entries, scan_entries, mixing_state)
 
 
-@pytest.fixture
+@pytest.fixture()
 def ms_gga_1_scan(ms_complete):
     """
     Mixing state with all GGA entries and one R2SCAN, corresponding to the GGA
@@ -457,7 +457,7 @@ def ms_gga_1_scan(ms_complete):
     return MixingState(gga_entries, scan_entries, mixing_state)
 
 
-@pytest.fixture
+@pytest.fixture()
 def ms_gga_1_scan_novel(ms_complete):
     """
     Mixing state with all GGA entries and 1 R2SCAN, corresponding to a composition
@@ -498,7 +498,7 @@ def ms_gga_1_scan_novel(ms_complete):
     return MixingState(gga_entries, scan_entries, mixing_state)
 
 
-@pytest.fixture
+@pytest.fixture()
 def ms_gga_2_scan_same(ms_complete):
     """
     Mixing state with all GGA entries and 2 R2SCAN, corresponding to the GGA
@@ -522,7 +522,7 @@ def ms_gga_2_scan_same(ms_complete):
     return MixingState(gga_entries, scan_entries, mixing_state)
 
 
-@pytest.fixture
+@pytest.fixture()
 def ms_gga_2_scan_diff_match(ms_complete):
     """
     Mixing state with all GGA entries and 2 R2SCAN entries corresponding to
@@ -548,7 +548,7 @@ def ms_gga_2_scan_diff_match(ms_complete):
     return MixingState(gga_entries, scan_entries, mixing_state)
 
 
-@pytest.fixture
+@pytest.fixture()
 def ms_gga_2_scan_diff_no_match(ms_complete):
     """
     Mixing state with all GGA entries and 2 R2SCAN, corresponding to the GGA
@@ -592,7 +592,7 @@ def ms_gga_2_scan_diff_no_match(ms_complete):
     return MixingState(gga_entries, scan_entries, mixing_state)
 
 
-@pytest.fixture
+@pytest.fixture()
 def ms_all_gga_scan_gs(ms_complete):
     """
     Mixing state with all GGA entries and R2SCAN entries corresponding to all GGA
@@ -616,7 +616,7 @@ def ms_all_gga_scan_gs(ms_complete):
     return MixingState(gga_entries, scan_entries, mixing_state)
 
 
-@pytest.fixture
+@pytest.fixture()
 def ms_all_gga_scan_gs_plus_novel(ms_all_gga_scan_gs):
     """
     Mixing state with all GGA entries and R2SCAN entries corresponding to all GGA
@@ -659,7 +659,7 @@ def ms_all_gga_scan_gs_plus_novel(ms_all_gga_scan_gs):
     return MixingState(gga_entries, scan_entries, mixing_state)
 
 
-@pytest.fixture
+@pytest.fixture()
 def ms_all_scan_novel(ms_complete):
     """
     Mixing state with all GGA entries and all R2SCAN, with an additional unstable
@@ -702,7 +702,7 @@ def ms_all_scan_novel(ms_complete):
     return MixingState(gga_entries, scan_entries, mixing_state)
 
 
-@pytest.fixture
+@pytest.fixture()
 def ms_incomplete_gga_all_scan(ms_complete):
     """
     Mixing state with an incomplete GGA phase diagram
@@ -726,7 +726,7 @@ def ms_incomplete_gga_all_scan(ms_complete):
     return MixingState(gga_entries, scan_entries, mixing_state)
 
 
-@pytest.fixture
+@pytest.fixture()
 def ms_scan_chemsys_superset(ms_complete):
     """
     Mixing state where we have R2SCAN for all GGA, and there is an additional R2SCAN
@@ -757,7 +757,7 @@ def ms_scan_chemsys_superset(ms_complete):
     return MixingState(gga_entries, scan_entries, mixing_state)
 
 
-@pytest.fixture
+@pytest.fixture()
 def ms_complete_duplicate_structs(ms_complete):
     """
     Mixing state where we have R2SCAN for all GGA, plus extra entries that duplicate

--- a/pymatgen/io/abinit/tests/test_pseudos.py
+++ b/pymatgen/io/abinit/tests/test_pseudos.py
@@ -107,7 +107,8 @@ class PseudoTestCase(PymatgenTest):
         assert isinstance(oxygen.as_dict(), dict)
 
         assert oxygen.ispaw
-        assert oxygen.symbol == "O" and (oxygen.Z, oxygen.core, oxygen.valence) == (8, 2, 6), oxygen.Z_val == 6
+        assert oxygen.symbol == "O"
+        assert (oxygen.Z, oxygen.core, oxygen.valence) == (8, 2, 6), oxygen.Z_val == 6
 
         assert oxygen.xc.type == "GGA"
         assert oxygen.xc.name == "PBE"
@@ -122,7 +123,8 @@ class PseudoTestCase(PymatgenTest):
 
         for o in new_objs:
             assert o.ispaw
-            assert o.symbol == "O" and (o.Z, o.core, o.valence) == (8, 2, 6), o.Z_val == 6
+            assert o.symbol == "O"
+            assert (o.Z, o.core, o.valence) == (8, 2, 6), o.Z_val == 6
 
             assert o.paw_radius == approx(1.4146523028)
 

--- a/pymatgen/io/lammps/tests/test_data.py
+++ b/pymatgen/io/lammps/tests/test_data.py
@@ -756,7 +756,7 @@ class ForceFieldTest(unittest.TestCase):
         yaml = YAML()
         with open(filename) as f:
             d = yaml.load(f)
-        # self.assertListEqual(d["mass_info"], [list(m) for m in v.mass_info])
+        # assert d["mass_info"] == [list(m) for m in v.mass_info]
         assert d["nonbond_coeffs"] == v.nonbond_coeffs
 
     def test_from_file(self):

--- a/pymatgen/io/qchem/tests/test_inputs.py
+++ b/pymatgen/io/qchem/tests/test_inputs.py
@@ -1154,10 +1154,10 @@ $end
         ]
 
         parsed = QCInput.read_cdft(str_cdft)
-        self.assertDictEqual(parsed[0][0], result[0][0])
-        self.assertDictEqual(parsed[0][1], result[0][1])
-        self.assertDictEqual(parsed[1][0], result[1][0])
-        self.assertDictEqual(parsed[1][1], result[1][1])
+        assert parsed[0][0] == result[0][0]
+        assert parsed[0][1] == result[0][1]
+        assert parsed[1][0] == result[1][0]
+        assert parsed[1][1] == result[1][1]
 
     def test_read_almo(self):
         str_almo = """I remain resolute in trying to break you!

--- a/pymatgen/io/qchem/tests/test_outputs.py
+++ b/pymatgen/io/qchem/tests/test_outputs.py
@@ -4,6 +4,7 @@ import os
 import unittest
 
 from monty.serialization import dumpfn, loadfn
+from pytest import approx
 
 from pymatgen.core.structure import Molecule
 from pymatgen.io.qchem.outputs import QCOutput, check_for_structure_changes
@@ -409,9 +410,9 @@ class TestQCOutput(PymatgenTest):
 
     def test_almo_msdft2_parsing(self):
         data = QCOutput(os.path.join(PymatgenTest.TEST_FILES_DIR, "molecules", "new_qchem_files", "almo.out")).data
-        self.assertListEqual(data["almo_coupling_states"], [[[1, 2], [0, 1]], [[0, 1], [1, 2]]])
+        assert data["almo_coupling_states"] == [[[1, 2], [0, 1]], [[0, 1], [1, 2]]]
         assert data["almo_hamiltonian"][0][0] == -156.62929
-        self.assertAlmostEqual(data["almo_coupling_eV"], 0.26895)
+        assert data["almo_coupling_eV"] == approx(0.26895)
 
     def test_pod_parsing(self):
         data = QCOutput(os.path.join(PymatgenTest.TEST_FILES_DIR, "molecules", "new_qchem_files", "pod2_gs.out")).data

--- a/pymatgen/io/tests/test_packmol.py
+++ b/pymatgen/io/tests/test_packmol.py
@@ -20,7 +20,7 @@ if True:  # if which("packmol") is None:
     pytest.skip("packmol executable not present", allow_module_level=True)
 
 
-@pytest.fixture
+@pytest.fixture()
 def ethanol():
     """
     Returns a Molecule of ethanol
@@ -41,7 +41,7 @@ def ethanol():
     return Molecule(ethanol_atoms, ethanol_coords)
 
 
-@pytest.fixture
+@pytest.fixture()
 def water():
     """
     Returns a Molecule of water

--- a/pymatgen/io/tests/test_wannier90.py
+++ b/pymatgen/io/tests/test_wannier90.py
@@ -34,13 +34,13 @@ class UnkTest(PymatgenTest):
         assert not self.unk_std.is_noncollinear
 
         # too small data
+        data_bad_shape = np.random.rand(2, 2, 2).astype(np.complex128)
         with pytest.raises(ValueError):
-            data_bad_shape = np.random.rand(2, 2, 2).astype(np.complex128)
             Unk(1, data_bad_shape)
 
         # too big data
+        data_bad_shape = np.random.rand(2, 2, 2, 2, 2, 2).astype(np.complex128)
         with pytest.raises(ValueError):
-            data_bad_shape = np.random.rand(2, 2, 2, 2, 2, 2).astype(np.complex128)
             Unk(1, data_bad_shape)
 
         # noncollinear unk file
@@ -54,8 +54,8 @@ class UnkTest(PymatgenTest):
         assert self.unk_ncl.is_noncollinear
 
         # too big data
+        data_bad_ncl = np.random.rand(2, 3, 2, 2, 2).astype(np.complex128)
         with pytest.raises(ValueError):
-            data_bad_ncl = np.random.rand(2, 3, 2, 2, 2).astype(np.complex128)
             Unk(1, data_bad_ncl)
 
     def test_from_file(self):

--- a/pymatgen/io/vasp/tests/test_outputs.py
+++ b/pymatgen/io/vasp/tests/test_outputs.py
@@ -212,12 +212,12 @@ class VasprunTest(PymatgenTest):
         assert ratio == approx(vasprun.final_structure.volume)  # the site data should not change
 
         pdos0_norm = vasprun.complete_dos_normalized.pdos[vasprun.final_structure[0]]
-        self.assertAlmostEqual(pdos0_norm[Orbital.s][Spin.up][16], 0.0026)  # the site data should not change
+        assert pdos0_norm[Orbital.s][Spin.up][16] == approx(0.0026)  # the site data should not change
         assert pdos0_norm[Orbital.s][Spin.up].shape == (301,)
 
         cdos_norm, cdos = vasprun.complete_dos_normalized, vasprun.complete_dos
         ratio = np.nanmax(cdos.densities[Spin.up] / cdos_norm.densities[Spin.up])
-        self.assertAlmostEqual(ratio, vasprun.final_structure.volume)  # the site data should not change
+        assert ratio == approx(vasprun.final_structure.volume)  # the site data should not change
 
         filepath2 = self.TEST_FILES_DIR / "lifepo4.xml"
         vasprun_ggau = Vasprun(filepath2, parse_projected_eigen=True, parse_potcar_file=False)

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -663,8 +663,8 @@ class MPStaticSetTest(PymatgenTest):
         os.remove("MPStaticSet.zip")
 
     def test_conflicting_arguments(self):
+        si = self.get_structure("Si")
         with pytest.raises(ValueError, match="deprecated"):
-            si = self.get_structure("Si")
             MPStaticSet(si, potcar_functional="PBE", user_potcar_functional="PBE")
 
     def test_grid_size_from_struct(self):
@@ -1545,8 +1545,8 @@ class MPScanStaticSetTest(PymatgenTest):
         assert lepsilon_vis.incar.get("NPAR") is None
 
     def test_conflicting_arguments(self):
+        si = self.get_structure("Si")
         with pytest.raises(ValueError, match="deprecated"):
-            si = self.get_structure("Si")
             MPScanStaticSet(si, potcar_functional="PBE", user_potcar_functional="PBE")
 
     def tearDown(self):

--- a/pymatgen/util/testing.py
+++ b/pymatgen/util/testing.py
@@ -17,6 +17,7 @@ import numpy.testing as nptu
 from monty.dev import requires
 from monty.json import MontyDecoder, MSONable
 from monty.serialization import loadfn
+from pytest import approx
 
 from pymatgen.core import SETTINGS, Structure
 from pymatgen.ext.matproj import _MPResterLegacy as MPRester
@@ -96,7 +97,7 @@ class PymatgenTest(unittest.TestCase):
                 nptu.assert_almost_equal(v, v2, decimal, err_msg, verbose)
                 return True
             elif isinstance(v, (int, float)):
-                PymatgenTest().assertAlmostEqual(v, v2)  # pylint: disable=E1120
+                assert v == approx(v2, abs=decimal)
             else:
                 assert v == v2
         return True

--- a/pymatgen/util/tests/test_string.py
+++ b/pymatgen/util/tests/test_string.py
@@ -64,8 +64,9 @@ class FuncTest(unittest.TestCase):
 
     def test_unicodeify(self):
         assert unicodeify("Li3Fe2(PO4)3") == "Li₃Fe₂(PO₄)₃"
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError) as exc_info:
             unicodeify("Li0.2Na0.8Cl")
+        assert "unicode character exists for subscript period." in str(exc_info.value)
         assert unicodeify_species("O2+") == "O²⁺"
         assert unicodeify_spacegroup("F-3m") == "F3̅m"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ select = [
   "PIE", # flake8-pie
   "PLE", # pylint error
   "PLW", # pylint warning
+  "PT",  # flake8-pytest-style
   "Q",   # flake8-quotes
   "RUF", # Ruff-specific rules
   "SIM", # flake8-simplify
@@ -60,6 +61,8 @@ ignore = [
   "PLR2004", # Magic number
   "PLW0603", # Using the global statement to update variables is discouraged
   "PLW2901", # Outer for loop variable overwritten by inner assignment target
+  "PT011",   # pytest-raises-too-broad
+  "PT013",   # pytest-incorrect-pytest-import
   "SIM105",  # Use contextlib.suppress(OSError) instead of try-except-pass
   "SIM115",  # Use context handler for opening files
 ]


### PR DESCRIPTION
Another small step in a larger overhaul of the testing side of `pymatgen`.