### PR TITLE
Fix for memory leak in pbc_shortest_vectors

### DIFF
--- a/pymatgen/util/coord_cython.pyx
+++ b/pymatgen/util/coord_cython.pyx
@@ -93,7 +93,7 @@ def pbc_shortest_vectors(lattice, fcoords1, fcoords2, mask=None, return_d2=False
     cdef int n_pbc_im = 3 ** n_pbc
     
     cdef np.float_t[:, ::1] frac_im
-    cdef int i, j, k, l, I, J, bestK
+    cdef int i, j, k, l, I, J
 
     if n_pbc == 3:
         fcoords1 = lattice.get_lll_frac_coords(fcoords1)

--- a/pymatgen/util/coord_cython.pyx
+++ b/pymatgen/util/coord_cython.pyx
@@ -91,9 +91,9 @@ def pbc_shortest_vectors(lattice, fcoords1, fcoords2, mask=None, return_d2=False
     pbc = lattice.pbc
     cdef int n_pbc = sum(pbc)
     cdef int n_pbc_im = 3 ** n_pbc
-    cdef np.float_t[:, ::1] frac_im = <np.float_t[:n_pbc_im, :3]> malloc(3 * n_pbc_im * sizeof(np.float_t))
-
-    cdef int i, j, k, l, I, J
+    
+    cdef np.float_t[:, ::1] frac_im
+    cdef int i, j, k, l, I, J, bestK
 
     if n_pbc == 3:
         fcoords1 = lattice.get_lll_frac_coords(fcoords1)
@@ -101,6 +101,7 @@ def pbc_shortest_vectors(lattice, fcoords1, fcoords2, mask=None, return_d2=False
         matrix = lattice.lll_matrix
         frac_im = images_view
     else:
+        frac_im = <np.float_t[:n_pbc_im, :3]> malloc(3 * n_pbc_im * sizeof(np.float_t))
         matrix = lattice.matrix.copy()
         k = 0
         for i in range(27):
@@ -178,6 +179,8 @@ def pbc_shortest_vectors(lattice, fcoords1, fcoords2, mask=None, return_d2=False
                 for l in range(3):
                     vs[i, j, l] = 1e20
 
+    if not (n_pbc == 3):
+        free(&frac_im[0,0])
     free(&cart_f1[0,0])
     free(&cart_f2[0,0])
     free(&cart_im[0,0])

--- a/pymatgen/util/coord_cython.pyx
+++ b/pymatgen/util/coord_cython.pyx
@@ -91,7 +91,7 @@ def pbc_shortest_vectors(lattice, fcoords1, fcoords2, mask=None, return_d2=False
     pbc = lattice.pbc
     cdef int n_pbc = sum(pbc)
     cdef int n_pbc_im = 3 ** n_pbc
-    
+
     cdef np.float_t[:, ::1] frac_im
     cdef int i, j, k, l, I, J
 


### PR DESCRIPTION
## Summary

The `pbc_shortest_vectors` function leaks all memory allocated to store the fractional coordinates of surrounding periodic sites. As a result, memory consumption keeps creeping up when (heavily) calling the function, see [this memory profile](https://github.com/materialsproject/pymatgen/files/11433457/v2023.5.8.pdf) of a script of mine which made me aware of the problem. The suggested modifications completely eliminate the issue, [curtailing the memory consumption](https://github.com/materialsproject/pymatgen/files/11433643/fixed.pdf) of the same script.

With the suggested minimal modifications, additional memory is only allocated (and freed accordingly) when needed - that is, when periodic boundary conditions are applied selectively.

### Before

![v2023 5 8](https://github.com/materialsproject/pymatgen/assets/30958850/624cfad9-02c4-4cbf-bc30-a7cb083b1bb9)

### After

![fixed](https://github.com/materialsproject/pymatgen/assets/30958850/e65e021d-8006-4f2c-964e-9f72e984a374)
