### PR TITLE
Suspected Typo Fix in `pymatgen.io.vasp.optics`

### DIFF
--- a/pymatgen/io/vasp/optics.py
+++ b/pymatgen/io/vasp/optics.py
@@ -48,9 +48,9 @@ class DielectricFunctionCalculator(MSONable):
         - Perform symmetry operations (this is not implemented here)
         - Calculate the real part
 
-    Currently, this Calculator only works for ``ISYM=0`` calculations since we cannot gauranttee that our
-    externally defined symmetry operations are the same as VASP's.  This can be fixed by printing the
-    symmetry operators into the vasprun.xml file.  If this happens in future versions of VASP,
+    Currently, this Calculator only works for ``ISYM=0`` calculations since we cannot guarantee that our
+    externally defined symmetry operations are the same as VASP's. This can be fixed by printing the
+    symmetry operators into the vasprun.xml file. If this happens in future versions of VASP,
     we can dramatically speed up the calculations here by considering only the irreducible kpoints.
     """
 

--- a/pymatgen/io/vasp/optics.py
+++ b/pymatgen/io/vasp/optics.py
@@ -279,7 +279,7 @@ def delta_func(x, ismear):
         raise ValueError("Delta function not implemented for ismear < -1")
     if ismear == -1:
         return step_func(x, -1) * (1 - step_func(x, -1))
-    if ismear < 0:
+    if ismear == 0:
         return np.exp(-(x * x)) / np.sqrt(np.pi)
     return delta_methfessel_paxton(x, ismear)
 
@@ -290,7 +290,7 @@ def step_func(x, ismear):
         raise ValueError("Delta function not implemented for ismear < -1")
     if ismear == -1:
         return 1 / (1.0 + np.exp(-x))
-    if ismear < 0:
+    if ismear == 0:
         return 0.5 + 0.5 * scipy.special.erf(x)
     return step_methfessel_paxton(x, ismear)
 

--- a/pymatgen/io/vasp/tests/test_optics.py
+++ b/pymatgen/io/vasp/tests/test_optics.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
+import scipy.special
 
-from pymatgen.io.vasp.optics import DielectricFunctionCalculator
+from pymatgen.io.vasp.optics import DielectricFunctionCalculator, delta_func, delta_methfessel_paxton, step_func
 from pymatgen.io.vasp.outputs import Vasprun
 from pymatgen.util.testing import PymatgenTest
 
@@ -17,6 +19,10 @@ class VasprunTest(PymatgenTest):
         vrun = Vasprun(eps_data_path / "vasprun.xml")
         dfc = DielectricFunctionCalculator.from_directory(eps_data_path)
         egrid, eps = dfc.get_epsilon(0, 0)
+
+        assert egrid[0] == 0
+        assert egrid[-1] == 59.3802
+        assert len(egrid) == len(eps) == 3000
 
         _, eps_real_ref, eps_imag_ref = vrun.dielectric
         eps_real_ref = np.array(eps_real_ref)[:, 0]
@@ -40,3 +46,39 @@ class VasprunTest(PymatgenTest):
         mask = np.ones_like(dfc.cder, dtype=float)
         x_val, y_val, text = dfc.plot_weighted_transition_data(0, 0, mask=mask, min_val=0.001)
         assert len(x_val) == len(y_val) == len(text)
+
+
+def test_delta_func():
+    x = np.array([0, 1, 2, 3, 4, 5])
+
+    # ismear < -1
+    with pytest.raises(ValueError, match="Delta function not implemented for ismear < -1"):
+        delta_func(x, -2)
+
+    # ismear == -1
+    assert np.all(delta_func(x, -1) == step_func(x, -1) * (1 - step_func(x, -1)))
+
+    # ismear == 0
+    assert np.all(delta_func(x, 0) == np.exp(-(x * x)) / np.sqrt(np.pi))
+
+    # ismear > 0
+    for ismear in [1, 2, 3]:
+        assert np.all(delta_func(x, ismear) == delta_methfessel_paxton(x, ismear))
+
+
+def test_step_func():
+    # array of positive values
+    x = np.array([1, 2, 3, 4, 5])
+    assert np.allclose(step_func(x, -1), 1 / (1.0 + np.exp(-x)))
+
+    # array of negative values
+    x = np.array([-1, -2, -3, -4, -5])
+    assert np.allclose(step_func(x, -1), 1 / (1.0 + np.exp(-x)))
+
+    # array that includes zero
+    x = np.array([-1, 0, 1])
+    assert np.allclose(step_func(x, -1), 1 / (1.0 + np.exp(-x)))
+
+    # ismear == 0
+    x = np.array([1, 2, 3, 4, 5])
+    assert np.allclose(step_func(x, 0), 0.5 + 0.5 * scipy.special.erf(x))


### PR DESCRIPTION
Hi!
Firstly, thanks to the developers for the recent addition of the `pymatgen.io.vasp.optics` module, it's been very very useful! 🙌

This is just a small fix for a suspected typo in handling `ismear` in the `delta_func()` and `step_func()` functions. `ISMEAR` is zero for Gaussian smearing, and indeed in the docstrings for `get_epsilon()` it states: `ismear: Smearing method (only has 0:gaussian, >0:Methfessel-Paxton)`. However, in the current version of the code:
```python
def delta_func(x, ismear):
    """Replication of VASP's delta function"""
    if ismear < -1:
        raise ValueError("Delta function not implemented for ismear < -1")
    if ismear == -1:
        return step_func(x, -1) * (1 - step_func(x, -1))
    if ismear < 0:
        return np.exp(-(x * x)) / np.sqrt(np.pi)
    return delta_methfessel_paxton(x, ismear)
```

`ismear = 0` ends up returning the Methfessel-Paxton smearing (`delta_methfessel_paxton`), however the function under `if ismear < 0` is the Gaussian smearing. `ismear` should be an integer anyway, so having `ismear < -1` raise an error and `ismear == -1` return something else, it means that the `ismear < 0` line is always skipped. This is also the case for the `step_func()` function.

I believe this is likely a small typo, and should instead by `if ismear == 0:`. I have changed it to this in this PR, and tests are passing.