### PR TITLE
Enable ruff doc rules in CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     rev: v0.0.267
     hooks:
       - id: ruff
-        args: [--fix, --ignore, D]
+        args: [--fix]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0

--- a/docs_rst/conf-normal.py
+++ b/docs_rst/conf-normal.py
@@ -321,8 +321,9 @@ epub_copyright = copyright
 
 
 def linkcode_resolve(domain, info):
-    # Resolve function for the linkcode extension.
-    # Thanks to https://github.com/Lasagne/Lasagne/blob/master/docs/conf.py
+    """Resolve function for the linkcode extension.
+    Thanks to https://github.com/Lasagne/Lasagne/blob/master/docs/conf.py
+    """
 
     def find_source():
         # try to find the file and line number, based on code from numpy:

--- a/docs_rst/conf.py
+++ b/docs_rst/conf.py
@@ -320,9 +320,12 @@ epub_copyright = copyright
 # Allow duplicate toc entries.
 # epub_tocdup = True
 
-# Resolve function for the linkcode extension.
-# Thanks to https://github.com/Lasagne/Lasagne/blob/master/docs/conf.py
+
 def linkcode_resolve(domain, info):
+    """Resolve function for the linkcode extension.
+    Thanks to https://github.com/Lasagne/Lasagne/blob/master/docs/conf.py
+    """
+
     def find_source():
         # try to find the file and line number, based on code from numpy:
         # https://github.com/numpy/numpy/blob/master/doc/source/conf.py#L286

--- a/pymatgen/alchemy/materials.py
+++ b/pymatgen/alchemy/materials.py
@@ -188,12 +188,13 @@ class TransformedStructure(MSONable):
         Returns VASP input as a dict of VASP objects.
 
         Args:
-            vasp_input_set (pymatgen.io.vaspio_set.VaspInputSet): input set
-                to create vasp input files from structures
+            vasp_input_set (pymatgen.io.vasp.sets.VaspInputSet): input set
+                to create VASP input files from structures
+            **kwargs: All keyword args supported by the VASP input set.
         """
-        d = vasp_input_set(self.final_structure, **kwargs).get_vasp_input()
-        d["transformations.json"] = json.dumps(self.as_dict())
-        return d
+        dct = vasp_input_set(self.final_structure, **kwargs).get_vasp_input()
+        dct["transformations.json"] = json.dumps(self.as_dict())
+        return dct
 
     def write_vasp_input(
         self,
@@ -206,7 +207,7 @@ class TransformedStructure(MSONable):
         Writes VASP input to an output_dir.
 
         Args:
-            vasp_input_set: pymatgen.io.vaspio_set.VaspInputSet like object that creates vasp input files from
+            vasp_input_set: pymatgen.io.vasp.sets.VaspInputSet like object that creates vasp input files from
                 structures.
             output_dir: Directory to output files
             create_directory: Create the directory if not present. Defaults to

--- a/pymatgen/analysis/structure_matcher.py
+++ b/pymatgen/analysis/structure_matcher.py
@@ -508,11 +508,13 @@ class StructureMatcher(MSONable):
         fractional translation vector to minimize RMS distance
 
         Args:
-            s1, s2: numpy arrays of fractional coordinates. len(s1) >= len(s2)
+            s1: numpy array of fractional coordinates.
+            s2: numpy array of fractional coordinates. len(s1) >= len(s2)
             avg_lattice: Lattice on which to calculate distances
             mask: numpy array of booleans. mask[i, j] = True indicates
                 that s2[i] cannot be matched to s1[j]
             normalization (float): inverse normalization length
+            lll_frac_tol (float): tolerance for Lenstra-Lenstra-Lovász lattice basis reduction algorithm
 
         Returns:
             Distances from s2 to s1, normalized by (V/atom) ^ 1/3

--- a/pymatgen/apps/battery/analyzer.py
+++ b/pymatgen/apps/battery/analyzer.py
@@ -37,7 +37,7 @@ class BatteryAnalyzer:
             struc_oxid: a Structure object; oxidation states *must* be assigned for this structure; disordered
                 structures should be OK
             working_ion: a String symbol or Element for the working ion.
-            oxy_override: a dict of String element symbol, Integer oxidation state pairs.
+            oxi_override: a dict of String element symbol, Integer oxidation state pairs.
                 by default, H, C, N, O, F, S, Cl, Se, Br, Te, I are considered anions.
         """
         for site in struc_oxid:
@@ -195,10 +195,11 @@ class BatteryAnalyzer:
         This is a helper method for get_removals_int_oxid!
 
         Args:
-            spec_amts_oxi - a dict of species to their amounts in the structure
-            redox_el - the element to oxidize or reduce
-            redox_els - the full list of elements that might be oxidized or reduced
-            numa - a running set of numbers of A ion at integer oxidation steps
+            spec_amts_oxi: a dict of species to their amounts in the structure
+            redox_el: the element to oxidize or reduce
+            redox_els: the full list of elements that might be oxidized or reduced
+            numa: a running set of numbers of A ion at integer oxidation steps
+
         Returns:
             a set of numbers A; steps for oxidizing oxid_el first, then the other oxid_els in this list
         """

--- a/pymatgen/apps/battery/plotter.py
+++ b/pymatgen/apps/battery/plotter.py
@@ -127,16 +127,15 @@ class VoltageProfilePlotter:
     ):
         """
         Return plotly Figure object
+
         Args:
             width: Width of the plot. Defaults to 800 px.
             height: Height of the plot. Defaults to 600 px.
-            font: dictionary that defines the font
+            font_dict: define the font. Defaults to {"family": "Arial", "size": 24, "color": "#000000"}
             term_zero: If True append zero voltage point at the end
-            **kwargs:
-
-        Returns:
+            **kwargs: passed to plotly.graph_objects.Layout
         """
-        font_dict = {"family": "Arial", "size": 24, "color": "#000000"} if font_dict is None else font_dict
+        font_dict = font_dict or {"family": "Arial", "size": 24, "color": "#000000"}
         hover_temp = "Voltage : %{y:.2f} V"
 
         data = []
@@ -210,5 +209,7 @@ class VoltageProfilePlotter:
         Args:
             filename: Filename to save to.
             image_format: Format to save to. Defaults to eps.
+            width: Width of the plot. Defaults to 8 in.
+            height: Height of the plot. Defaults to 6 in.
         """
         self.get_plot(width, height).savefig(filename, format=image_format)

--- a/pymatgen/apps/borg/queen.py
+++ b/pymatgen/apps/borg/queen.py
@@ -32,7 +32,7 @@ class BorgQueen:
             rootpath (str): The root directory to start assimilation. Leave it
                 as None if you want to do assimilation later, or is using the
                 BorgQueen to load previously assimilated data.
-            ndrones (int): Number of drones to parallelize over.
+            number_of_drones (int): Number of drones to parallelize over.
                 Typical machines today have up to four processors. Note that you
                 won't see a 100% improvement with two drones over one, but you
                 will definitely see a significant speedup of at least 50% or so.

--- a/pymatgen/cli/pmg_analyze.py
+++ b/pymatgen/cli/pmg_analyze.py
@@ -102,7 +102,7 @@ def get_magnetizations(dir: str, ion_list: list[int]):
     Get magnetization info from OUTCARs.
 
     Args:
-        mydir (str): Directory name
+        dir (str): Directory name
         ion_list (list[int]): List of ions to obtain magnetization information for.
 
     Returns:

--- a/pymatgen/command_line/chargemol_caller.py
+++ b/pymatgen/command_line/chargemol_caller.py
@@ -367,8 +367,8 @@ class ChargemolAnalysis:
             periodicity (tuple[bool]): Periodicity of the system.
                 Default: (True, True, True).
             method (str): Method to use for the analysis. Options include "ddec6"
-            and "ddec3".
-                Default: "ddec6"
+                and "ddec3". Default: "ddec6"
+            compute_bond_orders (bool): Whether to compute bond orders. Default: True.
         """
         self.net_charge = net_charge
         self.periodicity = periodicity

--- a/pymatgen/command_line/gulp_caller.py
+++ b/pymatgen/command_line/gulp_caller.py
@@ -271,7 +271,7 @@ class GulpIO:
         Args:
             structure: pymatgen Structure object
             cell_flg (default = True): Option to use lattice parameters.
-            fractional_flg (default = True): If True, fractional coordinates
+            frac_flg (default = True): If True, fractional coordinates
                 are used. Else, Cartesian coordinates in Angstroms are used.
                 ******
                 GULP convention is to use fractional coordinates for periodic
@@ -530,10 +530,10 @@ class GulpIO:
         return gin
 
     @staticmethod
-    def get_energy(gout):
+    def get_energy(gout: str):
         """
         Args:
-            gout ():
+            gout (str): GULP output string.
 
         Returns:
             Energy
@@ -547,10 +547,10 @@ class GulpIO:
         raise GulpError("Energy not found in Gulp output")
 
     @staticmethod
-    def get_relaxed_structure(gout):
+    def get_relaxed_structure(gout: str):
         """
         Args:
-            gout ():
+            gout (str): GULP output string.
 
         Returns:
             (Structure) relaxed structure.

--- a/pymatgen/core/ion.py
+++ b/pymatgen/core/ion.py
@@ -22,7 +22,7 @@ class Ion(Composition, MSONable, Stringify):
     Mn[+2]. Note the order of the sign and magnitude in each representation.
     """
 
-    def __init__(self, composition, charge=0.0, properties=None):
+    def __init__(self, composition, charge=0.0, _properties=None):
         """
         Flexible Ion construction, similar to Composition.
         For more information, please see pymatgen.core.Composition

--- a/pymatgen/core/libxcfunc.py
+++ b/pymatgen/core/libxcfunc.py
@@ -405,11 +405,10 @@ class LibxcFunc(Enum):
 
     # end_include_dont_touch
 
-    def __init__(self, num):
+    def __init__(self, _num):
         """
-        Init.
-
-        :param num: Number for the xc.
+        Args:
+            num: Number for the xc.
         """
         info = _all_xcfuncs[self.value]
         self.kind = info["Kind"]

--- a/pymatgen/electronic_structure/bandstructure.py
+++ b/pymatgen/electronic_structure/bandstructure.py
@@ -136,21 +136,21 @@ class Kpoint(MSONable):
         }
 
     @classmethod
-    def from_dict(cls, d):
+    def from_dict(cls, dct):
         """
         Create from dict.
 
         Args:
-            A dict with all data for a kpoint object.
+            dct (dict): A dict with all data for a kpoint object.
 
         Returns:
             A Kpoint object
         """
         return cls(
-            coords=d["fcoords"],
-            lattice=Lattice.from_dict(d["lattice"]),
+            coords=dct["fcoords"],
+            lattice=Lattice.from_dict(dct["lattice"]),
             coords_are_cartesian=False,
-            label=d["label"],
+            label=dct["label"],
         )
 
 
@@ -640,40 +640,40 @@ class BandStructure:
         return d
 
     @classmethod
-    def from_dict(cls, d):
+    def from_dict(cls, dct):
         """
         Create from dict.
 
         Args:
-            A dict with all data for a band structure object.
+            dct: A dict with all data for a band structure object.
 
         Returns:
             A BandStructure object
         """
         # Strip the label to recover initial string
         # (see trick used in as_dict to handle $ chars)
-        labels_dict = {k.strip(): v for k, v in d["labels_dict"].items()}
+        labels_dict = {k.strip(): v for k, v in dct["labels_dict"].items()}
         projections = {}
         structure = None
-        if isinstance(list(d["bands"].values())[0], dict):
-            eigenvals = {Spin(int(k)): np.array(d["bands"][k]["data"]) for k in d["bands"]}
+        if isinstance(list(dct["bands"].values())[0], dict):
+            eigenvals = {Spin(int(k)): np.array(dct["bands"][k]["data"]) for k in dct["bands"]}
         else:
-            eigenvals = {Spin(int(k)): d["bands"][k] for k in d["bands"]}
+            eigenvals = {Spin(int(k)): dct["bands"][k] for k in dct["bands"]}
 
-        if "structure" in d:
-            structure = Structure.from_dict(d["structure"])
+        if "structure" in dct:
+            structure = Structure.from_dict(dct["structure"])
 
         try:
-            if d.get("projections"):
-                if isinstance(d["projections"]["1"][0][0], dict):
+            if dct.get("projections"):
+                if isinstance(dct["projections"]["1"][0][0], dict):
                     raise ValueError("Old band structure dict format detected!")
-                projections = {Spin(int(spin)): np.array(v) for spin, v in d["projections"].items()}
+                projections = {Spin(int(spin)): np.array(v) for spin, v in dct["projections"].items()}
 
             return cls(
-                d["kpoints"],
+                dct["kpoints"],
                 eigenvals,
-                Lattice(d["lattice_rec"]["matrix"]),
-                d["efermi"],
+                Lattice(dct["lattice_rec"]["matrix"]),
+                dct["efermi"],
                 labels_dict,
                 structure=structure,
                 projections=projections,
@@ -686,7 +686,7 @@ class BandStructure:
                 "format. The old format will be retired in pymatgen "
                 "5.0."
             )
-            return cls.from_old_dict(d)
+            return cls.from_old_dict(dct)
 
     @classmethod
     def from_old_dict(cls, d):
@@ -764,14 +764,14 @@ class BandStructureSymmLine(BandStructure, MSONable):
                 Pymatgen uses the physics convention of reciprocal lattice vectors
                 WITH a 2*pi coefficient
             efermi: fermi energy
-            label_dict: (dict) of {} this link a kpoint (in frac coords or
+            labels_dict: (dict) of {} this link a kpoint (in frac coords or
                 Cartesian coordinates depending on the coords).
             coords_are_cartesian: Whether coordinates are cartesian.
             structure: The crystal structure (as a pymatgen Structure object)
                 associated with the band structure. This is needed if we
                 provide projections to the band structure.
             projections: dict of orbital projections as {spin: ndarray}. The
-                indices of the ndarrayare [band_index, kpoint_index, orbital_index,
+                indices of the ndarray are [band_index, kpoint_index, orbital_index,
                 ion_index].If the band structure is not spin polarized, we only
                 store one data set under Spin.up.
         """

--- a/pymatgen/electronic_structure/boltztrap.py
+++ b/pymatgen/electronic_structure/boltztrap.py
@@ -548,8 +548,6 @@ class BoltztrapRunner(MSONable):
                 in convergence mode
             min_egrid: (float) minimum egrid value to try before giving up in
                 convergence mode
-
-        Returns:
         """
         # TODO: consider making this a part of custodian rather than pymatgen
         # A lot of this functionality (scratch dirs, handlers, monitors)
@@ -1178,7 +1176,7 @@ class BoltztrapAnalyzer:
 
         return BoltztrapAnalyzer._format_to_output(result, result_doping, output, doping_levels, multi=relaxation_time)
 
-    def get_zt(self, output="eigs", doping_levels=True, relaxation_time=1e-14, kl=1.0):
+    def get_zt(self, output="eigs", doping_levels=True, relaxation_time=1e-14, k_l=1):
         """
         Gives the ZT coefficient (S^2*cond*T/thermal cond) in either a full
         3x3 tensor form,
@@ -1231,7 +1229,7 @@ class BoltztrapAnalyzer:
                         result_doping[doping][t].append(
                             np.dot(
                                 pf_tensor * relaxation_time * t,
-                                np.linalg.inv(thermal_conduct + kl * np.eye(3, 3)),
+                                np.linalg.inv(thermal_conduct + k_l * np.eye(3, 3)),
                             )
                         )
         else:
@@ -1246,7 +1244,7 @@ class BoltztrapAnalyzer:
                     result[t].append(
                         np.dot(
                             pf_tensor * relaxation_time * t,
-                            np.linalg.inv(thermal_conduct + kl * np.eye(3, 3)),
+                            np.linalg.inv(thermal_conduct + k_l * np.eye(3, 3)),
                         )
                     )
 
@@ -1609,9 +1607,8 @@ class BoltztrapAnalyzer:
         Gives a CompleteDos object with the DOS from the interpolated projected band structure
 
         Args:
-            the structure (necessary to identify sites for projection)
-            analyzer_for_second_spin must be specified to have a
-            CompleteDos with both Spin components
+            structure: necessary to identify sites for projection
+            analyzer_for_second_spin: must be specified to have a CompleteDos with both Spin components
 
         Returns:
             a CompleteDos object

--- a/pymatgen/electronic_structure/boltztrap2.py
+++ b/pymatgen/electronic_structure/boltztrap2.py
@@ -198,7 +198,7 @@ class BandstructureLoader:
             bs_obj: BandStructure object.
             structure: Structure object. It is needed if it is not contained in the BandStructure obj.
             nelect: Number of electrons in the calculation.
-            momat: Matrix of derivatives of energy eigenvalues. Not implemented yet.
+            mommat: Matrix of derivatives of energy eigenvalues. TODO Not implemented yet.
             magmom: Matrix of magnetic moments in non collinear calculations. Not implemented yet.
 
         Example:
@@ -684,6 +684,8 @@ class BztTransportProperties:
                 compute_properties_doping() method for details.
             npts_mu: number of energy points at which to calculate transport properties
             CRTA: constant value of the relaxation time
+            margin: The energy range of the interpolation is extended by this value on both sides.
+                Defaults to 9 * units.BOLTZMANN * temp_r.max().
             save_bztTranspProps: Default False. If True all computed transport properties
                 will be stored in fname file.
             load_bztTranspProps: Default False. If True all computed transport properties
@@ -714,7 +716,7 @@ class BztTransportProperties:
         self.efermi = BztInterpolator.data.fermi / units.eV
 
         if margin is None:
-            margin = 9.0 * units.BOLTZMANN * temp_r.max()
+            margin = 9 * units.BOLTZMANN * temp_r.max()
 
         if load_bztTranspProps:
             self.load(fname)
@@ -735,7 +737,7 @@ class BztTransportProperties:
                 self.epsilon < self.epsilon.max() - margin,
             )
 
-            self.mu_r = self.epsilon[mur_indices]
+            self.mu_r = self.epsilon[mur_indices]  # mu range
             self.mu_r_eV = self.mu_r / units.eV - self.efermi
 
             N, L0, L1, L2, Lm11 = BL.fermiintegrals(
@@ -803,6 +805,7 @@ class BztTransportProperties:
 
         Args:
             doping: numpy array specifying the doping levels
+            temp_r: numpy array specifying the temperatures
 
         When executed, it add the following variable at the BztTransportProperties
         object:

--- a/pymatgen/electronic_structure/cohp.py
+++ b/pymatgen/electronic_structure/cohp.py
@@ -139,6 +139,7 @@ class Cohp(MSONable):
 
         Args:
             energy: Energy to return the COHP value for.
+            integrated: Return COHP (False) or ICOHP (True)
         """
         inter = {}
         for spin in self.cohp:
@@ -254,7 +255,7 @@ class CompleteCohp(Cohp):
         Args:
             structure: Structure associated with this COHP.
             avg_cohp: The average cohp as a COHP object.
-            cohps: A dict of COHP objects for individual bonds of the form
+            cohp_dict: A dict of COHP objects for individual bonds of the form
                 {label: COHP}
             bonds: A dict containing information on the bonds of the form
                 {label: {key: val}}. The key-val pair can be any information
@@ -682,22 +683,18 @@ class CompleteCohp(Cohp):
         LMTO-ASA code) or LOBSTER (for the LOBSTER code).
 
         Args:
-            cohp_file: Name of the COHP output file. Defaults to COPL
-                for LMTO and COHPCAR.lobster/COOPCAR.lobster for LOBSTER.
-
-            are_coops: Indicates whether the populations are COOPs or
-                COHPs. Defaults to False for COHPs.
-
-            are_cobis: Indicates whether the populations are COBIs or
-                COHPs. Defaults to False for COHPs.
-
             fmt: A string for the code that was used to calculate
                 the COHPs so that the output file can be handled
                 correctly. Can take the values "LMTO" or "LOBSTER".
-
+            filename: Name of the COHP output file. Defaults to COPL
+                for LMTO and COHPCAR.lobster/COOPCAR.lobster for LOBSTER.
             structure_file: Name of the file containing the structure.
                 If no file name is given, use CTRL for LMTO and POSCAR
                 for LOBSTER.
+            are_coops: Indicates whether the populations are COOPs or
+                COHPs. Defaults to False for COHPs.
+            are_cobis: Indicates whether the populations are COBIs or
+                COHPs. Defaults to False for COHPs.
 
         Returns:
             A CompleteCohp object.

--- a/pymatgen/electronic_structure/dos.py
+++ b/pymatgen/electronic_structure/dos.py
@@ -1192,10 +1192,12 @@ class CompleteDos(Dos):
         Args:
             type (str): Specify fingerprint type needed can accept '{s/p/d/f/}summed_{pdos/tdos}'
             (default is summed_pdos)
+            binning (bool): If true, the DOS fingerprint is binned using np.linspace and n_bins.
+                Default is True.
             min_e (float): The minimum mode energy to include in the fingerprint (default is None)
             max_e (float): The maximum mode energy to include in the fingerprint (default is None)
             n_bins (int): Number of bins to be used in the fingerprint (default is 256)
-            normalize (bool): If true, normalizes the area under fp to equal to 1 (default is True)
+            normalize (bool): If true, normalizes the area under fp to equal to 1. Default is True.
 
         Raises:
             ValueError: If type is not one of the accepted values {s/p/d/f/}summed_{pdos/tdos}.

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -11,7 +11,7 @@ import math
 import typing
 import warnings
 from collections import Counter
-from typing import List, Literal, cast
+from typing import List, Literal, Sequence, cast
 
 import matplotlib.lines as mlines
 import numpy as np
@@ -253,6 +253,9 @@ class DosPlotter:
             xlim: Specifies the x-axis limits. Set to None for automatic
                 determination.
             ylim: Specifies the y-axis limits.
+            invert_axes (bool): Whether to invert the x and y axes. Enables chemist style DOS plotting.
+                Defaults to False.
+            beta_dashed (bool): Plots the beta spin channel with a dashed line. Defaults to False.
         """
         plt = self.get_plot(xlim, ylim, invert_axes, beta_dashed)
         plt.savefig(filename, format=img_format)
@@ -265,6 +268,9 @@ class DosPlotter:
             xlim: Specifies the x-axis limits. Set to None for automatic
                 determination.
             ylim: Specifies the y-axis limits.
+            invert_axes (bool): Whether to invert the x and y axes. Enables chemist style DOS plotting.
+                Defaults to False.
+            beta_dashed (bool): Plots the beta spin channel with a dashed line. Defaults to False.
         """
         plt = self.get_plot(xlim, ylim, invert_axes, beta_dashed)
         plt.show()
@@ -412,8 +418,8 @@ class BSPlotter:
         Get the data nicely formatted for a plot
 
         Args:
-            zero_to_efermi: Automatically subtract off the Fermi energy from the
-                eigenvalues and plot.
+            zero_to_efermi: Automatically set the Fermi level as the plot's origin (i.e. subtract E - E_f).
+                Defaults to True.
             bs: the bandstructure to get the data from. If not provided, the first
                 one in the self._bs list will be used.
             bs_ref: is the bandstructure of reference when a rescale of the distances
@@ -596,8 +602,8 @@ class BSPlotter:
         same high symm path.
 
         Args:
-            zero_to_efermi: Automatically subtract off the Fermi energy from
-                the eigenvalues and plot (E-Ef).
+            zero_to_efermi: Automatically set the Fermi level as the plot's origin (i.e. subtract E - E_f).
+                Defaults to True.
             ylim: Specify the y-axis (energy) limits; by default None let
                 the code choose. It is vbm-4 and cbm+4 if insulator
                 efermi-10 and efermi+10 if metal
@@ -738,8 +744,8 @@ class BSPlotter:
         Show the plot using matplotlib.
 
         Args:
-            zero_to_efermi: Automatically subtract off the Fermi energy from
-                the eigenvalues and plot (E-Ef).
+            zero_to_efermi: Automatically set the Fermi level as the plot's origin (i.e. subtract E - E_f).
+                Defaults to True.
             ylim: Specify the y-axis (energy) limits; by default None let
                 the code choose. It is vbm-4 and cbm+4 if insulator
                 efermi-10 and efermi+10 if metal
@@ -758,7 +764,8 @@ class BSPlotter:
             filename: Filename to write to.
             img_format: Image format to use. Defaults to EPS.
             ylim: Specifies the y-axis limits.
-            zero_to_efermi: Automatically the Fermi level as the origin.
+            zero_to_efermi: Automatically set the Fermi level as the plot's origin (i.e. subtract E - E_f).
+                Defaults to True.
             smooth: Cubic spline interpolation of the bands.
         """
         plt = self.get_plot(ylim=ylim, zero_to_efermi=zero_to_efermi, smooth=smooth)
@@ -980,6 +987,10 @@ class BSPlotterProjected(BSPlotter):
                 If you use this class to plot LobsterBandStructureSymmLine,
                 the orbitals are named as in the FATBAND filename, e.g.
                 "2p" or "2p_x"
+            zero_to_efermi: Automatically set the Fermi level as the plot's origin (i.e. subtract E - E_f).
+                Defaults to True.
+            ylim: Specify the y-axis limits. Defaults to None.
+            vbm_cbm_marker: Add markers for the VBM and CBM. Defaults to False.
 
         Returns:
             a pylab object with different subfigures for each projection
@@ -1156,6 +1167,8 @@ class BSPlotterProjected(BSPlotter):
         spin up and spin down are differientiated by a '-' and a '--' line
 
         Args:
+            zero_to_efermi: Automatically set the Fermi level as the plot's origin (i.e. subtract E - E_f).
+                Defaults to True.
             elt_ordered: A list of Element ordered. The first one is red,
                 second green, last blue
 
@@ -1539,63 +1552,49 @@ class BSPlotterProjected(BSPlotter):
         Args:
             dictio: The elements and the orbitals you need to project on. The
                 format is {Element:[Orbitals]}, for instance:
-                {'Cu':['dxy','s','px'],'O':['px','py','pz']} will give
-                projections for Cu on orbitals dxy, s, px and
-                for O on orbitals px, py, pz. If you want to sum over all
-                individual orbitals of subshell orbitals,
-                for example, 'px', 'py' and 'pz' of O, just simply set
-                {'Cu':['dxy','s','px'],'O':['p']} and set sum_morbs (see
-                explanations below) as {'O':[p],...}.
-                Otherwise, you will get an error.
+                {'Cu':['dxy','s','px'],'O':['px','py','pz']} will give projections for Cu on
+                orbitals dxy, s, px and for O on orbitals px, py, pz. If you want to sum over all
+                individual orbitals of subshell orbitals, for example, 'px', 'py' and 'pz' of O,
+                just simply set {'Cu':['dxy','s','px'],'O':['p']} and set sum_morbs (see
+                explanations below) as {'O':[p],...}. Otherwise, you will get an error.
             dictpa: The elements and their sites (defined by site numbers) you
-                need to project on. The format is
-                {Element: [Site numbers]}, for instance: {'Cu':[1,5],'O':[3,4]}
-                will give projections for Cu on site-1
-                and on site-5, O on site-3 and on site-4 in the cell.
-
-        Attention:
-                The correct site numbers of atoms are consistent with
-                themselves in the structure computed. Normally,
-                the structure should be totally similar with POSCAR file,
-                however, sometimes VASP can rotate or
-                translate the cell. Thus, it would be safe if using Vasprun
-                class to get the final_structure and as a
+                need to project on. The format is {Element: [Site numbers]}, for instance:
+                {'Cu':[1,5],'O':[3,4]} will give projections for Cu on site-1 and on site-5, O on
+                site-3 and on site-4 in the cell. The correct site numbers of atoms are consistent
+                with themselves in the structure computed. Normally, the structure should be totally
+                similar with POSCAR file, however, sometimes VASP can rotate or translate the cell.
+                Thus, it would be safe if using Vasprun class to get the final_structure and as a
                 result, correct index numbers of atoms.
             sum_atoms: Sum projection of the similar atoms together (e.g.: Cu
-                on site-1 and Cu on site-5). The format is
-                {Element: [Site numbers]}, for instance:
-                 {'Cu': [1,5], 'O': [3,4]} means summing projections over Cu on
-                 site-1 and Cu on site-5 and O on site-3
-                 and on site-4. If you do not want to use this functional, just
-                 turn it off by setting sum_atoms = None.
+                on site-1 and Cu on site-5). The format is {Element: [Site numbers]}, for instance:
+                 {'Cu': [1,5], 'O': [3,4]} means summing projections over Cu on site-1 and Cu on
+                 site-5 and O on site-3 and on site-4. If you do not want to use this functional,
+                 just turn it off by setting sum_atoms = None.
             sum_morbs: Sum projections of individual orbitals of similar atoms
-                together (e.g.: 'dxy' and 'dxz'). The
-                format is {Element: [individual orbitals]}, for instance:
-                {'Cu': ['dxy', 'dxz'], 'O': ['px', 'py']} means summing
-                projections over 'dxy' and 'dxz' of Cu and 'px'
-                and 'py' of O. If you do not want to use this functional, just
-                turn it off by setting sum_morbs = None.
+                together (e.g.: 'dxy' and 'dxz'). The format is {Element: [individual orbitals]},
+                for instance: {'Cu': ['dxy', 'dxz'], 'O': ['px', 'py']} means summing projections
+                over 'dxy' and 'dxz' of Cu and 'px' and 'py' of O. If you do not want to use this
+                functional, just turn it off by setting sum_morbs = None.
+            zero_to_efermi: Automatically set the Fermi level as the plot's origin (i.e. subtract E - E_f).
+                Defaults to True.
+            ylim: The y-axis limit. Defaults to None.
+            vbm_cbm_marker: Whether to plot points to indicate valence band maxima and conduction
+                band minima positions. Defaults to False.
             selected_branches: The index of symmetry lines you chose for
-                plotting. This can be useful when the number of
-                symmetry lines (in KPOINTS file) are manny while you only want
-                to show for certain ones. The format is
-                [index of line], for instance:
-                [1, 3, 4] means you just need to do projection along lines
-                number 1, 3 and 4 while neglecting lines
-                number 2 and so on. By default, this is None type and all
-                symmetry lines will be plotted.
+                plotting. This can be useful when the number of symmetry lines (in KPOINTS file) are
+                manny while you only want to show for certain ones. The format is [index of line],
+                for instance: [1, 3, 4] means you just need to do projection along lines number 1, 3
+                and 4 while neglecting lines number 2 and so on. By default, this is None type and
+                all symmetry lines will be plotted.
             w_h_size: This variable help you to control the width and height
-                of figure. By default, width = 12 and
-                height = 8 (inches). The width/height ratio is kept the same
-                for subfigures and the size of each depends
-                on how many number of subfigures are plotted.
+                of figure. By default, width = 12 and height = 8 (inches). The width/height ratio is
+                kept the same for subfigures and the size of each depends on how many number of
+                subfigures are plotted.
             num_column: This variable help you to manage how the subfigures are
-                arranged in the figure by setting
-                up the number of columns of subfigures. The value should be an
-                int number. For example, num_column = 3
-                means you want to plot subfigures in 3 columns. By default,
-                num_column = None and subfigures are
-                aligned in 2 columns.
+                arranged in the figure by setting up the number of columns of subfigures. The value
+                should be an int number. For example, num_column = 3 means you want to plot
+                subfigures in 3 columns. By default, num_column = None and subfigures are aligned in
+                2 columns.
 
         Returns:
             A pylab object with different subfigures for different projections.
@@ -2972,15 +2971,15 @@ class BoltztrapPlotter:
         plt.tight_layout()
         return plt
 
-    def plot_seebeck_mu(self, temp=600, output="eig", xlim=None):
+    def plot_seebeck_mu(self, temp: float = 600, output: str = "eig", xlim: Sequence[float] = None):
         """
         Plot the seebeck coefficient in function of Fermi level
 
         Args:
-            temp:
-                the temperature
-            xlim:
-                a list of min and max fermi energy by default (0, and band gap)
+            temp (float): the temperature
+            output (str): "eig" or "average"
+            xlim (tuple[float, float]): a 2-tuple of min and max fermi energy. Defaults to (0, band gap)
+
 
         Returns:
             a matplotlib object
@@ -3004,16 +3003,19 @@ class BoltztrapPlotter:
         plt.tight_layout()
         return plt
 
-    def plot_conductivity_mu(self, temp=600, output="eig", relaxation_time=1e-14, xlim=None):
+    def plot_conductivity_mu(
+        self, temp: float = 600, output: str = "eig", relaxation_time: float = 1e-14, xlim: Sequence[float] = None
+    ):
         """
         Plot the conductivity in function of Fermi level. Semi-log plot
 
         Args:
-            temp: the temperature
-            xlim: a list of min and max fermi energy by default (0, and band
-                gap)
-            tau: A relaxation time in s. By default none and the plot is by
+            temp (float): the temperature
+            output (str): "eig" or "average"
+            relaxation_time (float): A relaxation time in s. Defaults to 1e-14 and the plot is in
                units of relaxation time
+            xlim (tuple[float, float]): a 2-tuple of min and max fermi energy. Defaults to (0, band gap)
+
 
         Returns:
             a matplotlib object
@@ -3037,16 +3039,19 @@ class BoltztrapPlotter:
         plt.tight_layout()
         return plt
 
-    def plot_power_factor_mu(self, temp=600, output="eig", relaxation_time=1e-14, xlim=None):
+    def plot_power_factor_mu(
+        self, temp: float = 600, output: str = "eig", relaxation_time: float = 1e-14, xlim: Sequence[float] = None
+    ):
         """
         Plot the power factor in function of Fermi level. Semi-log plot
 
         Args:
-            temp: the temperature
-            xlim: a list of min and max fermi energy by default (0, and band
-                gap)
-            tau: A relaxation time in s. By default none and the plot is by
+            temp (float): the temperature
+            output (str): "eig" or "average"
+            relaxation_time (float): A relaxation time in s. Defaults to 1e-14 and the plot is in
                units of relaxation time
+            xlim (tuple[float, float]): a 2-tuple of min and max fermi energy. Defaults to (0, band gap)
+
 
         Returns:
             a matplotlib object
@@ -3069,19 +3074,21 @@ class BoltztrapPlotter:
         plt.tight_layout()
         return plt
 
-    def plot_zt_mu(self, temp=600, output="eig", relaxation_time=1e-14, xlim=None):
+    def plot_zt_mu(
+        self, temp: float = 600, output: str = "eig", relaxation_time: float = 1e-14, xlim: Sequence[float] = None
+    ):
         """
         Plot the ZT in function of Fermi level.
 
         Args:
-            temp: the temperature
-            xlim: a list of min and max fermi energy by default (0, and band
-                gap)
-            tau: A relaxation time in s. By default none and the plot is by
+            temp (float): the temperature
+            output (str): "eig" or "average"
+            relaxation_time (float): A relaxation time in s. Defaults to 1e-14 and the plot is in
                units of relaxation time
+            xlim (tuple[float, float]): a 2-tuple of min and max fermi energy. Defaults to (0, band gap)
 
         Returns:
-            a matplotlib object
+            matplotlib.pyplot module
         """
         plt = pretty_plot(9, 7)
         zt = self._bz.get_zt(relaxation_time=relaxation_time, output=output, doping_levels=False)[temp]
@@ -3107,10 +3114,10 @@ class BoltztrapPlotter:
         doping levels.
 
         Args:
-            dopings: the default 'all' plots all the doping levels in the analyzer.
-                     Specify a list of doping levels if you want to plot only some.
+            doping (str): the default 'all' plots all the doping levels in the analyzer.
+                Specify a list of doping levels if you want to plot only some.
             output: with 'average' you get an average of the three directions
-                    with 'eigs' you get all the three directions.
+                with 'eigs' you get all the three directions.
 
         Returns:
             a matplotlib object
@@ -3160,10 +3167,10 @@ class BoltztrapPlotter:
         Plot the conductivity in function of temperature for different doping levels.
 
         Args:
-            dopings: the default 'all' plots all the doping levels in the analyzer.
-                     Specify a list of doping levels if you want to plot only some.
+            doping (str): the default 'all' plots all the doping levels in the analyzer.
+                Specify a list of doping levels if you want to plot only some.
             output: with 'average' you get an average of the three directions
-                    with 'eigs' you get all the three directions.
+                with 'eigs' you get all the three directions.
             relaxation_time: specify a constant relaxation time value
 
         Returns:
@@ -3215,10 +3222,10 @@ class BoltztrapPlotter:
         Plot the Power Factor in function of temperature for different doping levels.
 
         Args:
-            dopings: the default 'all' plots all the doping levels in the analyzer.
-                     Specify a list of doping levels if you want to plot only some.
+            doping (str): the default 'all' plots all the doping levels in the analyzer.
+                Specify a list of doping levels if you want to plot only some.
             output: with 'average' you get an average of the three directions
-                    with 'eigs' you get all the three directions.
+                with 'eigs' you get all the three directions.
             relaxation_time: specify a constant relaxation time value
 
         Returns:
@@ -3269,10 +3276,10 @@ class BoltztrapPlotter:
         Plot the figure of merit zT in function of temperature for different doping levels.
 
         Args:
-            dopings: the default 'all' plots all the doping levels in the analyzer.
-                     Specify a list of doping levels if you want to plot only some.
+            doping (str): the default 'all' plots all the doping levels in the analyzer.
+                Specify a list of doping levels if you want to plot only some.
             output: with 'average' you get an average of the three directions
-                    with 'eigs' you get all the three directions.
+                with 'eigs' you get all the three directions.
             relaxation_time: specify a constant relaxation time value
 
         Returns:
@@ -3323,10 +3330,10 @@ class BoltztrapPlotter:
         for different doping levels.
 
         Args:
-            dopings: the default 'all' plots all the doping levels in the analyzer.
-                     Specify a list of doping levels if you want to plot only some.
+            doping (str): the default 'all' plots all the doping levels in the analyzer.
+                Specify a list of doping levels if you want to plot only some.
             output: with 'average' you get an average of the three directions
-                    with 'eigs' you get all the three directions.
+                with 'eigs' you get all the three directions.
 
         Returns:
             a matplotlib object
@@ -3378,7 +3385,7 @@ class BoltztrapPlotter:
             temps: the default 'all' plots all the temperatures in the analyzer.
                    Specify a list of temperatures if you want to plot only some.
             output: with 'average' you get an average of the three directions
-                    with 'eigs' you get all the three directions.
+                with 'eigs' you get all the three directions.
 
         Returns:
             a matplotlib object
@@ -3432,7 +3439,7 @@ class BoltztrapPlotter:
             temps: the default 'all' plots all the temperatures in the analyzer.
                    Specify a list of temperatures if you want to plot only some.
             output: with 'average' you get an average of the three directions
-                    with 'eigs' you get all the three directions.
+                with 'eigs' you get all the three directions.
             relaxation_time: specify a constant relaxation time value
 
         Returns:
@@ -3485,7 +3492,7 @@ class BoltztrapPlotter:
             temps: the default 'all' plots all the temperatures in the analyzer.
                    Specify a list of temperatures if you want to plot only some.
             output: with 'average' you get an average of the three directions
-                    with 'eigs' you get all the three directions.
+                with 'eigs' you get all the three directions.
             relaxation_time: specify a constant relaxation time value
 
         Returns:
@@ -3540,7 +3547,7 @@ class BoltztrapPlotter:
             temps: the default 'all' plots all the temperatures in the analyzer.
                    Specify a list of temperatures if you want to plot only some.
             output: with 'average' you get an average of the three directions
-                    with 'eigs' you get all the three directions.
+                with 'eigs' you get all the three directions.
             relaxation_time: specify a constant relaxation time value
 
         Returns:
@@ -3595,7 +3602,7 @@ class BoltztrapPlotter:
             temps: the default 'all' plots all the temperatures in the analyzer.
                    Specify a list of temperatures if you want to plot only some.
             output: with 'average' you get an average of the three directions
-                    with 'eigs' you get all the three directions.
+                with 'eigs' you get all the three directions.
             relaxation_time: specify a constant relaxation time value
 
         Returns:
@@ -3986,7 +3993,7 @@ def plot_fermi_surface(
             Should be the same length as the number of surfaces being plotted.
             Example (3 surfaces): colors=[(1,0,0), (0,1,0), (0,0,1)]
             Example (2 surfaces): colors=[(0, 0.5, 0.5)]
-        transparency_factor [float]: Values in the range [0,1] to tune the
+        transparency_factor (float): Values in the range [0,1] to tune the
             opacity of each surface. Should be one transparency_factor per
             surface.
         labels_scale_factor (float): factor to tune size of the kpoint labels
@@ -4466,10 +4473,11 @@ def plot_ellipsoid(
         rescale: factor for size scaling of the ellipsoid
         ax: matplotlib :class:`Axes` or None if a new figure should be created.
         coords_are_cartesian: Set to True if you are providing a center in
-                              Cartesian coordinates. Defaults to False.
-        kwargs: kwargs passed to the matplotlib function 'plot_wireframe'.
-                Color defaults to blue, rstride and cstride
-                default to 4, alpha defaults to 0.2.
+            Cartesian coordinates. Defaults to False.
+        arrows: whether to plot arrows for the principal axes of the ellipsoid. Defaults to False.
+        **kwargs: passed to the matplotlib function 'plot_wireframe'.
+            Color defaults to blue, rstride and cstride
+            default to 4, alpha defaults to 0.2.
 
     Returns:
         matplotlib figure and matplotlib ax

--- a/pymatgen/electronic_structure/tests/test_boltztrap.py
+++ b/pymatgen/electronic_structure/tests/test_boltztrap.py
@@ -182,7 +182,7 @@ class BoltztrapAnalyzerTest(unittest.TestCase):
         ref = [0.097408810215, 0.29335112354, 0.614673998089]
         for i in range(0, 3):
             assert self.bz.get_zt()["n"][800][4][i] == approx(ref[i])
-        assert self.bz.get_zt(output="average", kl=0.5)["p"][700][2] == approx(0.0170001879916)
+        assert self.bz.get_zt(output="average", k_l=0.5)["p"][700][2] == approx(0.0170001879916)
         assert self.bz.get_zt(output="average", doping_levels=False, relaxation_time=1e-15)[300][240] == approx(
             0.0041923533238348342
         )

--- a/pymatgen/entries/compatibility.py
+++ b/pymatgen/entries/compatibility.py
@@ -770,7 +770,7 @@ class MaterialsProjectCompatibility(CorrectionsList):
     """
     This class implements the GGA/GGA+U mixing scheme, which allows mixing of
     entries. Note that this should only be used for VASP calculations using the
-    MaterialsProject parameters (see pymatgen.io.vaspio_set.MPVaspInputSet).
+    MaterialsProject parameters (see pymatgen.io.vasp.sets.MPVaspInputSet).
     Using this compatibility scheme on runs with different parameters is not
     valid.
     """
@@ -1100,7 +1100,7 @@ class MITCompatibility(CorrectionsList):
     """
     This class implements the GGA/GGA+U mixing scheme, which allows mixing of
     entries. Note that this should only be used for VASP calculations using the
-    MIT parameters (see pymatgen.io.vaspio_set MITVaspInputSet). Using
+    MIT parameters (see pymatgen.io.vasp.sets MITVaspInputSet). Using
     this compatibility scheme on runs with different parameters is not valid.
     """
 
@@ -1141,7 +1141,7 @@ class MITAqueousCompatibility(CorrectionsList):
     """
     This class implements the GGA/GGA+U mixing scheme, which allows mixing of
     entries. Note that this should only be used for VASP calculations using the
-    MIT parameters (see pymatgen.io.vaspio_set MITVaspInputSet). Using
+    MIT parameters (see pymatgen.io.vasp.sets MITVaspInputSet). Using
     this compatibility scheme on runs with different parameters is not valid.
     """
 

--- a/pymatgen/ext/matproj.py
+++ b/pymatgen/ext/matproj.py
@@ -1491,19 +1491,16 @@ class _MPResterLegacy:
         Args:
             material_id (str): Materials Project material_id, e.g., 'mp-129'.
             pretty_formula (str): The formula of metals. e.g., 'Fe'
-            sigma(int): The sigma value of a certain type of grain boundary
-            gb_plane(list of integer): The Miller index of grain
-            boundary plane. e.g., [1, 1, 1]
-            rotation_axis(list of integer): The Miller index of rotation
-            axis. e.g., [1, 0, 0], [1, 1, 0], and [1, 1, 1]
-            Sigma value is determined by the combination of rotation axis and
-            rotation angle. The five degrees of freedom (DOF) of one grain boundary
-            include: rotation axis (2 DOFs), rotation angle (1 DOF), and grain
-            boundary plane (2 DOFs).
+            chemsys (str): The chemical system. e.g., 'Fe-O'
+            sigma (int): The sigma value of a certain type of grain boundary
+            gb_plane (list of integer): The Miller index of grain boundary plane. e.g., [1, 1, 1]
+            rotation_axis (list of integer): The Miller index of rotation axis. e.g.,
+                [1, 0, 0], [1, 1, 0], and [1, 1, 1] Sigma value is determined by the combination of
+                rotation axis and rotation angle. The five degrees of freedom (DOF) of one grain boundary
+                include: rotation axis (2 DOFs), rotation angle (1 DOF), and grain boundary plane (2 DOFs).
             include_work_of_separation (bool): whether to include the work of separation
-            (in unit of (J/m^2)). If you want to query the work of separation, please
-            specify the material_id.
-
+                (in unit of (J/m^2)). If you want to query the work of separation, please
+                specify the material_id.
 
         Returns:
             A list of grain boundaries that satisfy the query conditions (sigma, gb_plane).

--- a/pymatgen/ext/matproj.py
+++ b/pymatgen/ext/matproj.py
@@ -1568,7 +1568,7 @@ class _MPResterLegacy:
                 `pymatgen.analysis.reaction_calculator.Reaction`.
         """
         payload = {
-            "reactants": " ".join([reactant1, reactant2]),
+            "reactants": f"{reactant1} {reactant2}",
             "open_el": open_el,
             "relative_mu": relative_mu,
             "use_hull_energy": use_hull_energy,

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -2660,7 +2660,7 @@ class Outcar:
             search.append(
                 [
                     r"^ *e<r>_bp=\( *([-0-9.Ee+]*) *([-0-9.Ee+]*) *([-0-9.Ee+]*) *\)",
-                    lambda results, line: results.context == 2,
+                    lambda results, _line: results.context == 2,
                     er_bp,
                 ]
             )
@@ -2690,7 +2690,7 @@ class Outcar:
             search.append(
                 [
                     r"^ *e<r>_bp=\( *([-0-9.Ee+]*) *([-0-9.Ee+]*) *([-0-9.Ee+]*) *\)",
-                    lambda results, line: results.context == Spin.up,
+                    lambda results, _line: results.context == Spin.up,
                     er_bp_up,
                 ]
             )
@@ -2719,7 +2719,7 @@ class Outcar:
             search.append(
                 [
                     r"^ *e<r>_bp=\( *([-0-9.Ee+]*) *([-0-9.Ee+]*) *([-0-9.Ee+]*) *\)",
-                    lambda results, line: results.context == Spin.down,
+                    lambda results, _line: results.context == Spin.down,
                     er_bp_dn,
                 ]
             )
@@ -2803,7 +2803,7 @@ class Outcar:
         search.append(
             [
                 r"^\s+([x,y,z])\s+" + r"([-]?\d+\.\d+)\s+" * 6,
-                lambda results, line: results.internal_strain_ion is not None,
+                lambda results, _line: results.internal_strain_ion is not None,
                 internal_strain_data,
             ]
         )
@@ -2838,7 +2838,7 @@ class Outcar:
             search.append(
                 [
                     r"-------------------------------------",
-                    lambda results, line: results.dielectric_index == -1,
+                    lambda results, _line: results.dielectric_index == -1,
                     dielectric_section_start2,
                 ]
             )
@@ -2852,7 +2852,7 @@ class Outcar:
             search.append(
                 [
                     r"^ *([-0-9.Ee+]+) +([-0-9.Ee+]+) +([-0-9.Ee+]+) *$",
-                    lambda results, line: results.dielectric_index >= 0
+                    lambda results, _line: results.dielectric_index >= 0
                     if results.dielectric_index is not None
                     else None,
                     dielectric_data,
@@ -2865,7 +2865,7 @@ class Outcar:
             search.append(
                 [
                     r"-------------------------------------",
-                    lambda results, line: results.dielectric_index >= 1
+                    lambda results, _line: results.dielectric_index >= 1
                     if results.dielectric_index is not None
                     else None,
                     dielectric_section_stop,
@@ -2875,7 +2875,7 @@ class Outcar:
             self.dielectric_index = None
             self.dielectric_tensor = np.zeros((3, 3))
 
-            def piezo_section_start(results, match):
+            def piezo_section_start(results, _match):
                 results.piezo_index = 0
 
             search.append(
@@ -2894,18 +2894,18 @@ class Outcar:
                 [
                     r"^ *[xyz] +([-0-9.Ee+]+) +([-0-9.Ee+]+)"
                     r" +([-0-9.Ee+]+) *([-0-9.Ee+]+) +([-0-9.Ee+]+) +([-0-9.Ee+]+)*$",
-                    lambda results, line: results.piezo_index >= 0 if results.piezo_index is not None else None,
+                    lambda results, _line: results.piezo_index >= 0 if results.piezo_index is not None else None,
                     piezo_data,
                 ]
             )
 
-            def piezo_section_stop(results, match):
+            def piezo_section_stop(results, _match):
                 results.piezo_index = None
 
             search.append(
                 [
                     r"-------------------------------------",
-                    lambda results, line: results.piezo_index >= 1 if results.piezo_index is not None else None,
+                    lambda results, _line: results.piezo_index >= 1 if results.piezo_index is not None else None,
                     piezo_section_stop,
                 ]
             )
@@ -2913,7 +2913,7 @@ class Outcar:
             self.piezo_index = None
             self.piezo_tensor = np.zeros((3, 6))
 
-            def born_section_start(results, match):
+            def born_section_start(results, _match):
                 results.born_ion = -1
 
             search.append([r"BORN EFFECTIVE CHARGES ", None, born_section_start])
@@ -2925,7 +2925,7 @@ class Outcar:
             search.append(
                 [
                     r"ion +([0-9]+)",
-                    lambda results, line: results.born_ion is not None,
+                    lambda results, _line: results.born_ion is not None,
                     born_ion,
                 ]
             )
@@ -2938,18 +2938,18 @@ class Outcar:
             search.append(
                 [
                     r"^ *([1-3]+) +([-0-9.Ee+]+) +([-0-9.Ee+]+) +([-0-9.Ee+]+)$",
-                    lambda results, line: results.born_ion >= 0 if results.born_ion is not None else results.born_ion,
+                    lambda results, _line: results.born_ion >= 0 if results.born_ion is not None else results.born_ion,
                     born_data,
                 ]
             )
 
-            def born_section_stop(results, match):
+            def born_section_stop(results, _match):
                 results.born_ion = None
 
             search.append(
                 [
                     r"-------------------------------------",
-                    lambda results, line: results.born_ion >= 1 if results.born_ion is not None else results.born_ion,
+                    lambda results, _line: results.born_ion >= 1 if results.born_ion is not None else results.born_ion,
                     born_section_stop,
                 ]
             )
@@ -2976,7 +2976,7 @@ class Outcar:
         try:
             search = []
 
-            def dielectric_section_start(results, match):
+            def dielectric_section_start(results, _match):
                 results.dielectric_ionic_index = -1
 
             search.append(
@@ -2987,13 +2987,13 @@ class Outcar:
                 ]
             )
 
-            def dielectric_section_start2(results, match):
+            def dielectric_section_start2(results, _match):
                 results.dielectric_ionic_index = 0
 
             search.append(
                 [
                     r"-------------------------------------",
-                    lambda results, line: results.dielectric_ionic_index == -1
+                    lambda results, _line: results.dielectric_ionic_index == -1
                     if results.dielectric_ionic_index is not None
                     else results.dielectric_ionic_index,
                     dielectric_section_start2,
@@ -3009,20 +3009,20 @@ class Outcar:
             search.append(
                 [
                     r"^ *([-0-9.Ee+]+) +([-0-9.Ee+]+) +([-0-9.Ee+]+) *$",
-                    lambda results, line: results.dielectric_ionic_index >= 0
+                    lambda results, _line: results.dielectric_ionic_index >= 0
                     if results.dielectric_ionic_index is not None
                     else results.dielectric_ionic_index,
                     dielectric_data,
                 ]
             )
 
-            def dielectric_section_stop(results, match):
+            def dielectric_section_stop(results, _match):
                 results.dielectric_ionic_index = None
 
             search.append(
                 [
                     r"-------------------------------------",
-                    lambda results, line: results.dielectric_ionic_index >= 1
+                    lambda results, _line: results.dielectric_ionic_index >= 1
                     if results.dielectric_ionic_index is not None
                     else results.dielectric_ionic_index,
                     dielectric_section_stop,
@@ -3032,7 +3032,7 @@ class Outcar:
             self.dielectric_ionic_index = None
             self.dielectric_ionic_tensor = np.zeros((3, 3))
 
-            def piezo_section_start(results, match):
+            def piezo_section_start(results, _match):
                 results.piezo_ionic_index = 0
 
             search.append(
@@ -3053,20 +3053,20 @@ class Outcar:
                 [
                     r"^ *[xyz] +([-0-9.Ee+]+) +([-0-9.Ee+]+)"
                     r" +([-0-9.Ee+]+) *([-0-9.Ee+]+) +([-0-9.Ee+]+) +([-0-9.Ee+]+)*$",
-                    lambda results, line: results.piezo_ionic_index >= 0
+                    lambda results, _line: results.piezo_ionic_index >= 0
                     if results.piezo_ionic_index is not None
                     else results.piezo_ionic_index,
                     piezo_data,
                 ]
             )
 
-            def piezo_section_stop(results, match):
+            def piezo_section_stop(results, _match):
                 results.piezo_ionic_index = None
 
             search.append(
                 [
                     "-------------------------------------",
-                    lambda results, line: results.piezo_ionic_index >= 1
+                    lambda results, _line: results.piezo_ionic_index >= 1
                     if results.piezo_ionic_index is not None
                     else results.piezo_ionic_index,
                     piezo_section_stop,

--- a/pymatgen/symmetry/analyzer.py
+++ b/pymatgen/symmetry/analyzer.py
@@ -1536,7 +1536,7 @@ def cluster_sites(mol: Molecule, tol: float, give_only_index: bool = False) -> t
     """
     # Cluster works for dim > 2 data. We just add a dummy 0 for second
     # coordinate.
-    dists: list[list[float]] = [[np.linalg.norm(site.coords), 0] for site in mol]
+    dists: list[list[float]] = [[float(np.linalg.norm(site.coords)), 0] for site in mol]
     import scipy.cluster
 
     f = scipy.cluster.hierarchy.fclusterdata(dists, tol, criterion="distance")

--- a/pymatgen/symmetry/analyzer.py
+++ b/pymatgen/symmetry/analyzer.py
@@ -1536,11 +1536,11 @@ def cluster_sites(mol: Molecule, tol: float, give_only_index: bool = False) -> t
     """
     # Cluster works for dim > 2 data. We just add a dummy 0 for second
     # coordinate.
-    dists = [[np.linalg.norm(site.coords), 0] for site in mol]
+    dists: list[list[float]] = [[np.linalg.norm(site.coords), 0] for site in mol]
     import scipy.cluster
 
     f = scipy.cluster.hierarchy.fclusterdata(dists, tol, criterion="distance")
-    clustered_dists = defaultdict(list)
+    clustered_dists: dict[str, list[list[float]]] = defaultdict(list)
     for idx in range(len(mol)):
         clustered_dists[f[idx]].append(dists[idx])
     avg_dist = {label: np.mean(val) for label, val in clustered_dists.items()}

--- a/pymatgen/symmetry/groups.py
+++ b/pymatgen/symmetry/groups.py
@@ -476,14 +476,13 @@ class SpaceGroup(SymmetryGroup):
         return "cubic"
 
     def is_subgroup(self, supergroup: SymmetryGroup) -> bool:
-        """
-        True if this space group is a subgroup of the supplied group.
+        """Check if space group is a subgroup of the supplied symmetry group.
 
         Args:
-            group (Spacegroup): Supergroup to test.
+            supergroup (Spacegroup): Supergroup to test.
 
         Returns:
-            True if this space group is a subgroup of the supplied group.
+            bool: True if this space group is a subgroup of the supplied group.
         """
         if not isinstance(supergroup, SpaceGroup):
             return NotImplemented
@@ -588,9 +587,8 @@ def in_array_list(array_list: list[np.ndarray] | np.ndarray, arr: np.ndarray, to
 
     Args:
         array_list ([array]): A list of arrays to compare to.
-        a (array): The test array for comparison.
-        tol (float): The tolerance. Defaults to 1e-5. If 0, an exact match is
-            done.
+        arr (array): The test array for comparison.
+        tol (float): The tolerance. Defaults to 1e-5. If 0, an exact match is done.
 
     Returns:
         (bool)

--- a/pymatgen/symmetry/kpath.py
+++ b/pymatgen/symmetry/kpath.py
@@ -50,8 +50,9 @@ class KPathBase(metaclass=abc.ABCMeta):
         symprec (float): Tolerance for symmetry finding.
         angle_tolerance (float): Angle tolerance for symmetry finding.
         atol (float): Absolute tolerance used to compare structures
-            and determine symmetric equivalence of points and lines
-            in the BZ.
+            and determine symmetric equivalence of points and lines in the BZ.
+        *args: Other arguments supported by subclasses.
+        **kwargs: Other keyword arguments supported by subclasses.
         """
         self._structure = structure
         self._latt = self._structure.lattice

--- a/pymatgen/symmetry/maggroups.py
+++ b/pymatgen/symmetry/maggroups.py
@@ -372,8 +372,7 @@ class MagneticSpaceGroup(SymmetryGroup):
 
         Args:
             p: Point as a 3x1 array.
-            m: A magnetic moment, compatible with
-            :class:`pymatgen.electronic_structure.core.Magmom`
+            magmom: A magnetic moment, compatible with :class:`pymatgen.electronic_structure.core.Magmom`
             tol: Tolerance for determining if sites are the same. 1e-5 should
                 be sufficient for most purposes. Set to 0 for exact matching
                 (and also needed for symbolic orbits).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,11 @@ isort.required-imports = ["from __future__ import annotations"]
 "__init__.py" = ["F401"]
 "*/tests/*" = ["D"]
 "tasks.py" = ["D"]
+"pymatgen/analysis/*" = ["D"]
+"pymatgen/vis/*" = ["D"]
+"pymatgen/util/*" = ["D"]
+"pymatgen/io/*" = ["D"]
+"dev_scripts/*" = ["D"]
 
 [tool.pytest.ini_options]
 addopts = "-x --durations=30 --quiet -rxXs --color=yes -p no:warnings"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ select = [
   "D",   # pydocstyle
   "E",   # pycodestyle error
   "F",   # pyflakes
+  "FLY", # flynt
   "I",   # isort
   "ICN", # flake8-import-conventions
   "ISC", # flake8-implicit-str-concat


### PR DESCRIPTION
 1273014de ignore some `ruff` doc string errors and fix all remaining
 a6dd53e72 `ruff` enable doc rules in pre-commit
 c349a806c fix `mypy` error
 dea2aa043 2nd try fix `mypy`
 d3e4d2b57 prefix unused func args with underscore
 f7b4a5006 `ruff` enable `flynt` rules