### PR TITLE
Hide all type-hint-only imports behind `if TYPE_CHECKING`

### DIFF
--- a/dev_scripts/chemenv/plane_multiplicity.py
+++ b/dev_scripts/chemenv/plane_multiplicity.py
@@ -32,8 +32,7 @@ if __name__ == "__main__":
             equiv_plane.extend(opposite_edge)
             equiv_plane.sort()
             all_plane_points.append(tuple(equiv_plane))
-        all_plane_points = list(set(all_plane_points))
-        all_plane_points = [list(equiv_plane) for equiv_plane in all_plane_points]
+        all_plane_points = [tuple(equiv_plane) for equiv_plane in set(all_plane_points)]
 
     print(f"All plane points ({len(all_plane_points):d}) for {cg_symbol} : ")
     print(all_plane_points)

--- a/dev_scripts/chemenv/test_algos.py
+++ b/dev_scripts/chemenv/test_algos.py
@@ -87,7 +87,7 @@ if __name__ == "__main__":
             algos_results.append(min(results[0]))
 
             if not np.isclose(min(results[0]), 0):
-                print("Following is not 0.0 ...")
+                print("Following is not 0 ...")
                 input(results)
         print("   => ", algos_results)
         idx_perm += 1

--- a/dev_scripts/chemenv/test_algos_all_geoms.py
+++ b/dev_scripts/chemenv/test_algos_all_geoms.py
@@ -118,7 +118,7 @@ if __name__ == "__main__":
                     algos_results.append(min(results[0]))
 
                     if not min(results[0]) < 1.5:
-                        print("Following is not close to 0.0 ...")
+                        print("Following is not close to 0 ...")
                         input(results)
                 print("   => ", algos_results)
                 i_perm += 1

--- a/docs_rst/conf-normal.py
+++ b/docs_rst/conf-normal.py
@@ -204,7 +204,7 @@ html_context = {
 
 # -- Options for LaTeX output ------------------------------------------------
 
-latex_elements = {
+latex_elements: dict[str, str] = {
     # The paper size ('letterpaper' or 'a4paper').
     # 'papersize': 'letterpaper',
     # The font size ('10pt', '11pt' or '12pt').

--- a/pymatgen/alchemy/filters.py
+++ b/pymatgen/alchemy/filters.py
@@ -6,13 +6,16 @@ from __future__ import annotations
 
 import abc
 from collections import defaultdict
+from typing import TYPE_CHECKING
 
 from monty.json import MSONable
 
 from pymatgen.analysis.structure_matcher import ElementComparator, StructureMatcher
 from pymatgen.core.periodic_table import get_el_sp
-from pymatgen.core.structure import Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
+
+if TYPE_CHECKING:
+    from pymatgen.core.structure import Structure
 
 
 class AbstractStructureFilter(MSONable, metaclass=abc.ABCMeta):

--- a/pymatgen/alchemy/materials.py
+++ b/pymatgen/alchemy/materials.py
@@ -10,18 +10,20 @@ import datetime
 import json
 import os
 import re
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from warnings import warn
 
 from monty.json import MSONable, jsanitize
 
-from pymatgen.alchemy.filters import AbstractStructureFilter
 from pymatgen.core.structure import Structure
 from pymatgen.io.cif import CifParser
 from pymatgen.io.vasp.inputs import Poscar
 from pymatgen.io.vasp.sets import MPRelaxSet, VaspInputSet
-from pymatgen.transformations.transformation_abc import AbstractTransformation
 from pymatgen.util.provenance import StructureNL
+
+if TYPE_CHECKING:
+    from pymatgen.alchemy.filters import AbstractStructureFilter
+    from pymatgen.transformations.transformation_abc import AbstractTransformation
 
 
 class TransformedStructure(MSONable):

--- a/pymatgen/analysis/bond_valence.py
+++ b/pymatgen/analysis/bond_valence.py
@@ -181,7 +181,7 @@ class BVAnalyzer:
         try:
             prob = {k: v / sum(prob.values()) for k, v in prob.items()}
         except ZeroDivisionError:
-            prob = {k: 0.0 for k in prob}
+            prob = {key: 0 for key in prob}
         return prob
 
     def _calc_site_probabilities_unordered(self, site, nn):
@@ -202,7 +202,7 @@ class BVAnalyzer:
             try:
                 prob[el] = {k: v / sum(prob[el].values()) for k, v in prob[el].items()}
             except ZeroDivisionError:
-                prob[el] = {k: 0.0 for k in prob[el]}
+                prob[el] = {key: 0 for key in prob[el]}
         return prob
 
     def get_valences(self, structure):

--- a/pymatgen/analysis/chemenv/utils/defs_utils.py
+++ b/pymatgen/analysis/chemenv/utils/defs_utils.py
@@ -4,10 +4,15 @@ This module contains the definition of some objects used in the chemenv package.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from pymatgen.analysis.chemenv.utils.coordination_geometry_utils import (
     is_anion_cation_bond,
 )
-from pymatgen.core.structure import Structure
+
+if TYPE_CHECKING:
+    from pymatgen.core.structure import Structure
+
 
 __author__ = "David Waroquiers"
 __copyright__ = "Copyright 2012, The Materials Project"

--- a/pymatgen/analysis/chempot_diagram.py
+++ b/pymatgen/analysis/chempot_diagram.py
@@ -27,6 +27,7 @@ import os
 import warnings
 from functools import lru_cache
 from itertools import groupby
+from typing import TYPE_CHECKING
 
 import numpy as np
 import plotly.express as px
@@ -36,9 +37,11 @@ from scipy.spatial import ConvexHull, HalfspaceIntersection
 
 from pymatgen.analysis.phase_diagram import PDEntry, PhaseDiagram
 from pymatgen.core.composition import Composition, Element
-from pymatgen.entries.computed_entries import ComputedEntry
 from pymatgen.util.coord import Simplex
 from pymatgen.util.string import htmlify
+
+if TYPE_CHECKING:
+    from pymatgen.entries.computed_entries import ComputedEntry
 
 with open(os.path.join(os.path.dirname(__file__), "..", "util", "plotly_chempot_layouts.json")) as f:
     plotly_layouts = json.load(f)

--- a/pymatgen/analysis/diffraction/core.py
+++ b/pymatgen/analysis/diffraction/core.py
@@ -6,12 +6,15 @@ from __future__ import annotations
 
 import abc
 import collections
+from typing import TYPE_CHECKING
 
 import numpy as np
 
 from pymatgen.core.spectrum import Spectrum
-from pymatgen.core.structure import Structure
 from pymatgen.util.plotting import add_fig_kwargs
+
+if TYPE_CHECKING:
+    from pymatgen.core.structure import Structure
 
 
 class DiffractionPattern(Spectrum):

--- a/pymatgen/analysis/diffraction/neutron.py
+++ b/pymatgen/analysis/diffraction/neutron.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import json
 import os
 from math import asin, cos, degrees, pi, radians, sin
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -15,8 +16,10 @@ from pymatgen.analysis.diffraction.core import (
     DiffractionPattern,
     get_unique_families,
 )
-from pymatgen.core.structure import Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
+
+if TYPE_CHECKING:
+    from pymatgen.core.structure import Structure
 
 __author__ = "Yuta Suzuki"
 __copyright__ = "Copyright 2018, The Materials Project"

--- a/pymatgen/analysis/diffraction/tem.py
+++ b/pymatgen/analysis/diffraction/tem.py
@@ -11,7 +11,7 @@ import os
 from collections import namedtuple
 from fractions import Fraction
 from functools import lru_cache
-from typing import List, Tuple, cast
+from typing import TYPE_CHECKING, List, Tuple, cast
 
 import numpy as np
 import pandas as pd
@@ -19,9 +19,11 @@ import plotly.graph_objs as go
 import scipy.constants as sc
 
 from pymatgen.analysis.diffraction.core import AbstractDiffractionPatternCalculator
-from pymatgen.core.structure import Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.util.string import latexify_spacegroup, unicodeify_spacegroup
+
+if TYPE_CHECKING:
+    from pymatgen.core.structure import Structure
 
 with open(os.path.join(os.path.dirname(__file__), "atomic_scattering_params.json")) as f:
     ATOMIC_SCATTERING_PARAMS = json.load(f)

--- a/pymatgen/analysis/diffraction/xrd.py
+++ b/pymatgen/analysis/diffraction/xrd.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import json
 import os
 from math import asin, cos, degrees, pi, radians, sin
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -15,8 +16,10 @@ from pymatgen.analysis.diffraction.core import (
     DiffractionPattern,
     get_unique_families,
 )
-from pymatgen.core.structure import Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
+
+if TYPE_CHECKING:
+    from pymatgen.core.structure import Structure
 
 # XRD wavelengths in angstroms
 WAVELENGTHS = {

--- a/pymatgen/analysis/disorder.py
+++ b/pymatgen/analysis/disorder.py
@@ -6,8 +6,10 @@ from __future__ import annotations
 
 import collections
 import itertools
+from typing import TYPE_CHECKING
 
-from pymatgen.core.structure import Structure
+if TYPE_CHECKING:
+    from pymatgen.core.structure import Structure
 
 
 def get_warren_cowley_parameters(structure: Structure, r: float, dr: float) -> dict[tuple, float]:

--- a/pymatgen/analysis/elasticity/elastic.py
+++ b/pymatgen/analysis/elasticity/elastic.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import itertools
 import warnings
+from typing import TYPE_CHECKING
 
 import numpy as np
 import sympy as sp
@@ -17,7 +18,6 @@ from scipy.special import factorial
 
 from pymatgen.analysis.elasticity.strain import Strain
 from pymatgen.analysis.elasticity.stress import Stress
-from pymatgen.core.structure import Structure
 from pymatgen.core.tensors import (
     DEFAULT_QUAD,
     SquareTensor,
@@ -26,6 +26,10 @@ from pymatgen.core.tensors import (
     get_uvec,
 )
 from pymatgen.core.units import Unit
+
+if TYPE_CHECKING:
+    from pymatgen.core.structure import Structure
+
 
 __author__ = "Joseph Montoya"
 __copyright__ = "Copyright 2012, The Materials Project"

--- a/pymatgen/analysis/elasticity/elastic.py
+++ b/pymatgen/analysis/elasticity/elastic.py
@@ -308,7 +308,7 @@ class ElasticTensor(NthOrderElasticTensor):
             0.38483
             * avg_mass
             * ((self.long_v(structure) + 2.0 * self.trans_v(structure)) / 3.0) ** 3.0
-            / (300.0 * num_density ** (-2.0 / 3.0) * nsites ** (1.0 / 3.0))
+            / (300.0 * num_density ** (-2.0 / 3.0) * nsites ** (1 / 3))
         )
 
     @raise_error_if_unphysical
@@ -329,7 +329,7 @@ class ElasticTensor(NthOrderElasticTensor):
             * (self.long_v(structure) + 2.0 * self.trans_v(structure))
             / 3.0
             / num_density ** (-2.0 / 3.0)
-            * (1 - nsites ** (-1.0 / 3.0))
+            * (1 - nsites ** (-1 / 3))
         )
 
     @raise_error_if_unphysical
@@ -391,8 +391,8 @@ class ElasticTensor(NthOrderElasticTensor):
         """
         v0 = structure.volume * 1e-30 / structure.num_sites
         vl, vt = self.long_v(structure), self.trans_v(structure)
-        vm = 3 ** (1.0 / 3.0) * (1 / vl**3 + 2 / vt**3) ** (-1.0 / 3.0)
-        td = 1.05457e-34 / 1.38065e-23 * vm * (6 * np.pi**2 / v0) ** (1.0 / 3.0)
+        vm = 3 ** (1 / 3) * (1 / vl**3 + 2 / vt**3) ** (-1 / 3)
+        td = 1.05457e-34 / 1.38065e-23 * vm * (6 * np.pi**2 / v0) ** (1 / 3)
         return td
 
     @property

--- a/pymatgen/analysis/elasticity/strain.py
+++ b/pymatgen/analysis/elasticity/strain.py
@@ -8,15 +8,18 @@ from __future__ import annotations
 
 import collections
 import itertools
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 import scipy
 
 from pymatgen.core.lattice import Lattice
-from pymatgen.core.structure import Structure
 from pymatgen.core.tensors import SquareTensor, symmetry_reduce
-from pymatgen.util.typing import ArrayLike
+
+if TYPE_CHECKING:
+    from numpy.typing import ArrayLike
+
+    from pymatgen.core.structure import Structure
 
 __author__ = "Joseph Montoya"
 __copyright__ = "Copyright 2012, The Materials Project"

--- a/pymatgen/analysis/elasticity/stress.py
+++ b/pymatgen/analysis/elasticity/stress.py
@@ -55,7 +55,7 @@ class Stress(SquareTensor):
     @property
     def von_mises(self):
         """
-        Returns the von mises stress
+        Returns the von Mises stress
         """
         if not self.is_symmetric():
             raise ValueError(
@@ -68,7 +68,7 @@ class Stress(SquareTensor):
         """
         Returns the mean stress
         """
-        return 1.0 / 3.0 * self.trace()
+        return 1 / 3 * self.trace()
 
     @property
     def deviator_stress(self):

--- a/pymatgen/analysis/elasticity/tests/test_stress.py
+++ b/pymatgen/analysis/elasticity/tests/test_stress.py
@@ -19,7 +19,7 @@ class StressTest(PymatgenTest):
     def test_properties(self):
         # mean_stress
         assert self.rand_stress.mean_stress == pytest.approx(
-            1.0 / 3.0 * (self.rand_stress[0, 0] + self.rand_stress[1, 1] + self.rand_stress[2, 2])
+            (self.rand_stress[0, 0] + self.rand_stress[1, 1] + self.rand_stress[2, 2]) / 3
         )
         assert self.symm_stress.mean_stress == pytest.approx(3.66)
         # deviator_stress
@@ -29,11 +29,7 @@ class StressTest(PymatgenTest):
         )
         self.assertArrayAlmostEqual(
             self.non_symm.deviator_stress,
-            [
-                [-0.2666666667, 0.2, 0.3],
-                [0.4, 0.133333333, 0.6],
-                [0.2, 0.5, 0.133333333],
-            ],
+            [[-0.2666666667, 0.2, 0.3], [0.4, 0.133333333, 0.6], [0.2, 0.5, 0.133333333]],
         )
         # deviator_principal_invariants
         self.assertArrayAlmostEqual(self.symm_stress.dev_principal_invariants, [0, 44.2563, 111.953628])

--- a/pymatgen/analysis/eos.py
+++ b/pymatgen/analysis/eos.py
@@ -306,8 +306,8 @@ class Birch(EOSBase):
         e0, b0, b1, v0 = tuple(params)
         return (
             e0
-            + 9.0 / 8.0 * b0 * v0 * ((v0 / volume) ** (2.0 / 3.0) - 1.0) ** 2
-            + 9.0 / 16.0 * b0 * v0 * (b1 - 4.0) * ((v0 / volume) ** (2.0 / 3.0) - 1.0) ** 3
+            + 9 / 8 * b0 * v0 * ((v0 / volume) ** (2 / 3.0) - 1.0) ** 2
+            + 9 / 16 * b0 * v0 * (b1 - 4.0) * ((v0 / volume) ** (2 / 3.0) - 1.0) ** 3
         )
 
 
@@ -321,8 +321,8 @@ class BirchMurnaghan(EOSBase):
         BirchMurnaghan equation from PRB 70, 224107
         """
         e0, b0, b1, v0 = tuple(params)
-        eta = (v0 / volume) ** (1.0 / 3.0)
-        return e0 + 9.0 * b0 * v0 / 16.0 * (eta**2 - 1) ** 2 * (6 + b1 * (eta**2 - 1.0) - 4.0 * eta**2)
+        eta = (v0 / volume) ** (1 / 3)
+        return e0 + 9 * b0 * v0 / 16 * (eta**2 - 1) ** 2 * (6 + b1 * (eta**2 - 1.0) - 4 * eta**2)
 
 
 class PourierTarantola(EOSBase):
@@ -335,9 +335,9 @@ class PourierTarantola(EOSBase):
         Pourier-Tarantola equation from PRB 70, 224107
         """
         e0, b0, b1, v0 = tuple(params)
-        eta = (volume / v0) ** (1.0 / 3.0)
-        squiggle = -3.0 * np.log(eta)
-        return e0 + b0 * v0 * squiggle**2 / 6.0 * (3.0 + squiggle * (b1 - 2))
+        eta = (volume / v0) ** (1 / 3)
+        squiggle = -3 * np.log(eta)
+        return e0 + b0 * v0 * squiggle**2 / 6 * (3 + squiggle * (b1 - 2))
 
 
 class Vinet(EOSBase):
@@ -350,9 +350,9 @@ class Vinet(EOSBase):
         Vinet equation from PRB 70, 224107
         """
         e0, b0, b1, v0 = tuple(params)
-        eta = (volume / v0) ** (1.0 / 3.0)
-        return e0 + 2.0 * b0 * v0 / (b1 - 1.0) ** 2 * (
-            2.0 - (5.0 + 3.0 * b1 * (eta - 1.0) - 3.0 * eta) * np.exp(-3.0 * (b1 - 1.0) * (eta - 1.0) / 2.0)
+        eta = (volume / v0) ** (1 / 3)
+        return e0 + 2 * b0 * v0 / (b1 - 1.0) ** 2 * (
+            2 - (5 + 3 * b1 * (eta - 1.0) - 3 * eta) * np.exp(-3 * (b1 - 1.0) * (eta - 1.0) / 2.0)
         )
 
 
@@ -402,14 +402,14 @@ class DeltaFactor(PolynomialEOS):
     """
 
     def _func(self, volume, params):
-        x = volume ** (-2.0 / 3.0)
+        x = volume ** (-2 / 3.0)
         return np.poly1d(list(params))(x)
 
     def fit(self, order=3):
         """
         Overridden since this eos works with volume**(2/3) instead of volume.
         """
-        x = self.volumes ** (-2.0 / 3.0)
+        x = self.volumes ** (-2 / 3.0)
         self.eos_params = np.polyfit(x, self.energies, order)
         self._set_params()
 
@@ -425,18 +425,18 @@ class DeltaFactor(PolynomialEOS):
 
         for x in np.roots(deriv1):
             if x > 0 and deriv2(x) > 0:
-                v0 = x ** (-3.0 / 2.0)
+                v0 = x ** (-3 / 2.0)
                 break
         else:
             raise EOSError("No minimum could be found")
 
-        derivV2 = 4.0 / 9.0 * x**5.0 * deriv2(x)
-        derivV3 = -20.0 / 9.0 * x ** (13.0 / 2.0) * deriv2(x) - 8.0 / 27.0 * x ** (15.0 / 2.0) * deriv3(x)
-        b0 = derivV2 / x ** (3.0 / 2.0)
-        b1 = -1 - x ** (-3.0 / 2.0) * derivV3 / derivV2
+        derivV2 = 4 / 9 * x**5 * deriv2(x)
+        derivV3 = -20 / 9 * x ** (13 / 2.0) * deriv2(x) - 8 / 27 * x ** (15 / 2.0) * deriv3(x)
+        b0 = derivV2 / x ** (3 / 2.0)
+        b1 = -1 - x ** (-3 / 2.0) * derivV3 / derivV2
 
         # e0, b0, b1, v0
-        self._params = [deriv0(v0 ** (-2.0 / 3.0)), b0, b1, v0]
+        self._params = [deriv0(v0 ** (-2 / 3.0)), b0, b1, v0]
 
 
 class NumericalEOS(PolynomialEOS):

--- a/pymatgen/analysis/ewald.py
+++ b/pymatgen/analysis/ewald.py
@@ -371,7 +371,7 @@ class EwaldSummation(MSONable):
         Determines the self energy -(eta/pi)**(1/2) * sum_{i=1}^{N} q_i**2
         """
         fcoords = self._s.frac_coords
-        forcepf = 2.0 * self._sqrt_eta / sqrt(pi)
+        forcepf = 2 * self._sqrt_eta / sqrt(pi)
         coords = self._coords
         numsites = self._s.num_sites
         ereal = np.empty((numsites, numsites), dtype=np.float_)

--- a/pymatgen/analysis/interface_reactions.py
+++ b/pymatgen/analysis/interface_reactions.py
@@ -266,7 +266,7 @@ class InterfacialReactivity(MSONable):
             return 1
         c1_coeff = reaction.get_coeff(self.c1_original) if self.c1_original in reaction.reactants else 0
         c2_coeff = reaction.get_coeff(self.c2_original) if self.c2_original in reaction.reactants else 0
-        return c1_coeff * 1.0 / (c1_coeff + c2_coeff)
+        return c1_coeff * 1 / (c1_coeff + c2_coeff)
 
     def _get_energy(self, x):
         """
@@ -586,9 +586,9 @@ class InterfacialReactivity(MSONable):
         """
         Returns a dictionary containing kink information:
         {index: 'x= mixing_ratio energy= reaction_energy reaction_equation'}.
-        E.g., {1: 'x= 0.0 energy = 0.0 Mn -> Mn',
-               2: 'x= 0.5 energy = -15.0 O2 + Mn -> MnO2',
-               3: 'x= 1.0 energy = 0.0 O2 -> O2'}.
+        E.g., {1: 'x= 0 energy = 0 Mn -> Mn',
+               2: 'x= 0.5 energy = -15 O2 + Mn -> MnO2',
+               3: 'x= 1 energy = 0 O2 -> O2'}.
         """
         return {
             j: "x= " + str(round(x, 4)) + " energy in eV/atom = " + str(round(energy, 4)) + " " + str(reaction)

--- a/pymatgen/analysis/interfaces/coherent_interfaces.py
+++ b/pymatgen/analysis/interfaces/coherent_interfaces.py
@@ -5,16 +5,18 @@ This module provides classes to store, generate, and manipulate material interfa
 from __future__ import annotations
 
 from itertools import product
-from typing import Iterator, Sequence
+from typing import TYPE_CHECKING, Iterator, Sequence
 
 import numpy as np
 from scipy.linalg import polar
 
 from pymatgen.analysis.elasticity.strain import Deformation
 from pymatgen.analysis.interfaces.zsl import ZSLGenerator, fast_norm
-from pymatgen.core import Structure
 from pymatgen.core.interface import Interface, label_termination
 from pymatgen.core.surface import SlabGenerator
+
+if TYPE_CHECKING:
+    from pymatgen.core.structure import Structure
 
 
 class CoherentInterfaceBuilder:

--- a/pymatgen/analysis/interfaces/substrate_analyzer.py
+++ b/pymatgen/analysis/interfaces/substrate_analyzer.py
@@ -5,14 +5,14 @@ This module provides classes to identify optimal substrates for film growth
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from pymatgen.analysis.elasticity.strain import Deformation, Strain
 from pymatgen.analysis.interfaces.zsl import ZSLGenerator, ZSLMatch, reduce_vectors
-from pymatgen.core import Structure
-from pymatgen.core.surface import (
-    SlabGenerator,
-    get_symmetrically_distinct_miller_indices,
-)
+from pymatgen.core.surface import SlabGenerator, get_symmetrically_distinct_miller_indices
+
+if TYPE_CHECKING:
+    from pymatgen.core.structure import Structure
 
 
 @dataclass

--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -1386,7 +1386,7 @@ class MinimumDistanceNN(NearNeighbors):
             min_dist = min(nn.nn_distance for nn in neighs_dists)
             for nn in neighs_dists:
                 dist = nn.nn_distance
-                if dist < (1.0 + self.tol) * min_dist:
+                if dist < (1 + self.tol) * min_dist:
                     weight = min_dist / dist
                     siw.append(
                         {
@@ -1790,7 +1790,7 @@ class MinimumOKeeffeNN(NearNeighbors):
         siw = []
         min_reldist = min(reldist for reldist, neigh in reldists_neighs)
         for reldist, s in reldists_neighs:
-            if reldist < (1.0 + self.tol) * min_reldist:
+            if reldist < (1 + self.tol) * min_reldist:
                 w = min_reldist / reldist
                 siw.append(
                     {
@@ -1868,7 +1868,7 @@ class MinimumVIRENN(NearNeighbors):
         siw = []
         min_reldist = min(reldist for reldist, neigh in reldists_neighs)
         for reldist, s in reldists_neighs:
-            if reldist < (1.0 + self.tol) * min_reldist:
+            if reldist < (1 + self.tol) * min_reldist:
                 w = min_reldist / reldist
                 siw.append(
                     {
@@ -2456,8 +2456,8 @@ class LocalStructOrderParams:
         nnn = len(self._pow_sin_t[1])
         nnn_range = range(nnn)
 
-        sqrt_15_2pi = sqrt(15.0 / (2 * pi))
-        sqrt_5_pi = sqrt(5.0 / pi)
+        sqrt_15_2pi = sqrt(15 / (2 * pi))
+        sqrt_5_pi = sqrt(5 / pi)
 
         pre_y_2_2 = [0.25 * sqrt_15_2pi * val for val in self._pow_sin_t[2]]
         pre_y_2_1 = [0.5 * sqrt_15_2pi * val[0] * val[1] for val in zip(self._pow_sin_t[1], self._pow_cos_t[1])]
@@ -2522,14 +2522,14 @@ class LocalStructOrderParams:
         nnn = len(self._pow_sin_t[1])
         nnn_range = range(nnn)
 
-        i16_3 = 3.0 / 16.0
-        i8_3 = 3.0 / 8.0
+        i16_3 = 3 / 16.0
+        i8_3 = 3 / 8.0
 
-        sqrt_35_pi = sqrt(35.0 / pi)
-        sqrt_35_2pi = sqrt(35.0 / (2 * pi))
-        sqrt_5_pi = sqrt(5.0 / pi)
-        sqrt_5_2pi = sqrt(5.0 / (2 * pi))
-        sqrt_1_pi = sqrt(1.0 / pi)
+        sqrt_35_pi = sqrt(35 / pi)
+        sqrt_35_2pi = sqrt(35 / (2 * pi))
+        sqrt_5_pi = sqrt(5 / pi)
+        sqrt_5_2pi = sqrt(5 / (2 * pi))
+        sqrt_1_pi = sqrt(1 / pi)
 
         pre_y_4_4 = [i16_3 * sqrt_35_2pi * val for val in self._pow_sin_t[4]]
         pre_y_4_3 = [i8_3 * sqrt_35_pi * val[0] * val[1] for val in zip(self._pow_sin_t[3], self._pow_cos_t[1])]
@@ -2629,17 +2629,17 @@ class LocalStructOrderParams:
         nnn = len(self._pow_sin_t[1])
         nnn_range = range(nnn)
 
-        i64 = 1.0 / 64.0
-        i32 = 1.0 / 32.0
-        i32_3 = 3.0 / 32.0
-        i16 = 1.0 / 16.0
+        i64 = 1 / 64.0
+        i32 = 1 / 32.0
+        i32_3 = 3 / 32.0
+        i16 = 1 / 16.0
 
-        sqrt_3003_pi = sqrt(3003.0 / pi)
-        sqrt_1001_pi = sqrt(1001.0 / pi)
-        sqrt_91_2pi = sqrt(91.0 / (2 * pi))
-        sqrt_1365_pi = sqrt(1365.0 / pi)
-        sqrt_273_2pi = sqrt(273.0 / (2 * pi))
-        sqrt_13_pi = sqrt(13.0 / pi)
+        sqrt_3003_pi = sqrt(3003 / pi)
+        sqrt_1001_pi = sqrt(1001 / pi)
+        sqrt_91_2pi = sqrt(91 / (2 * pi))
+        sqrt_1365_pi = sqrt(1365 / pi)
+        sqrt_273_2pi = sqrt(273 / (2 * pi))
+        sqrt_13_pi = sqrt(13 / pi)
 
         pre_y_6_6 = [i64 * sqrt_3003_pi * val for val in self._pow_sin_t[6]]
         pre_y_6_5 = [i32_3 * sqrt_1001_pi * val[0] * val[1] for val in zip(self._pow_sin_t[5], self._pow_cos_t[1])]
@@ -2874,10 +2874,10 @@ class LocalStructOrderParams:
         if tol < 0.0:
             raise ValueError("Negative tolerance for weighted solid angle!")
 
-        left_of_unity = 1.0 - 1.0e-12
+        left_of_unity = 1 - 1.0e-12
         # The following threshold has to be adapted to non-Angstrom units.
         very_small = 1.0e-12
-        fac_bcc = 1.0 / exp(-0.5)
+        fac_bcc = 1 / exp(-0.5)
 
         # Find central site and its neighbors.
         # Note that we adopt the same way of accessing sites here as in
@@ -2932,7 +2932,7 @@ class LocalStructOrderParams:
                         rjknorm[j].append(rjk[j][kk] / distjk[j][kk])
                         kk = kk + 1
         # Initialize OP list and, then, calculate OPs.
-        ops = [0.0 for t in self._types]
+        ops = [0 for t in self._types]
         # norms = [[[] for j in range(nneigh)] for t in self._types]
 
         # First, coordination number and distance-based OPs.
@@ -2944,7 +2944,7 @@ class LocalStructOrderParams:
                 if len(dist_sorted) == 1:
                     ops[i] = 1.0
                 elif len(dist_sorted) > 1:
-                    ops[i] = 1.0 - dist_sorted[0] / dist_sorted[1]
+                    ops[i] = 1 - dist_sorted[0] / dist_sorted[1]
 
         # Then, bond orientational OPs based on spherical harmonics
         # according to Steinhardt et al., Phys. Rev. B, 28, 784-805, 1983.
@@ -2987,13 +2987,13 @@ class LocalStructOrderParams:
         # (Peters, J. Chem. Phys., 131, 244103, 2009;
         #  Zimmermann et al., J. Am. Chem. Soc., under revision, 2015).
         if self._geomops:
-            gaussthetak = [0.0 for t in self._types]  # not used by all OPs
+            gaussthetak = [0 for t in self._types]  # not used by all OPs
             qsptheta = [[[] for j in range(nneigh)] for t in self._types]  # type: ignore
             norms = [[[] for j in range(nneigh)] for t in self._types]  # type: ignore
-            ipi = 1.0 / pi
+            ipi = 1 / pi
             piover2 = pi / 2.0
-            onethird = 1.0 / 3.0
-            twothird = 2.0 / 3.0
+            onethird = 1 / 3
+            twothird = 2 / 3.0
             for j in range(nneigh):  # Neighbor j is put to the North pole.
                 zaxis = rij_norm[j]
                 kc = 0
@@ -3191,7 +3191,7 @@ class LocalStructOrderParams:
                                                 norms[i][j][kc] += 1
                                         elif t == "bcc" and j < k:
                                             if thetak < self._params[i]["min_SPP"]:
-                                                fac = 1.0 if thetak > piover2 else -1.0
+                                                fac = 1 if thetak > piover2 else -1
                                                 tmp = (thetam - piover2) / asin(1 / 3)
                                                 qsptheta[i][j][kc] += (
                                                     fac * cos(3 * phi) * fac_bcc * tmp * exp(-0.5 * tmp * tmp)
@@ -3349,7 +3349,7 @@ class LocalStructOrderParams:
                 neighscent = neighscent / float(nneigh)
             h = np.linalg.norm(neighscent - centvec)
             b = min(distjk_unique) if len(distjk_unique) > 0 else 0
-            dhalf = max(distjk_unique) / 2.0 if len(distjk_unique) > 0 else 0
+            dhalf = max(distjk_unique) / 2 if len(distjk_unique) > 0 else 0
 
             for i, t in enumerate(self._types):
                 if t in ("reg_tri", "sq"):
@@ -3423,7 +3423,7 @@ class BrunnerNN_reciprocal(NearNeighbors):
         neighs_dists = structure.get_neighbors(site, self.cutoff)
         ds = sorted(i.nn_distance for i in neighs_dists)
 
-        ns = [1.0 / ds[i] - 1.0 / ds[i + 1] for i in range(len(ds) - 1)]
+        ns = [1 / ds[i] - 1 / ds[i + 1] for i in range(len(ds) - 1)]
 
         d_max = ds[ns.index(max(ns))]
         siw = []
@@ -3791,7 +3791,7 @@ class CrystalNN(NearNeighbors):
         Initialize CrystalNN with desired parameters. Default parameters assume
         "chemical bond" type behavior is desired. For geometric neighbor
         finding (e.g., structural framework), set (i) distance_cutoffs=None,
-        (ii) x_diff_weight=0.0 and (optionally) (iii) porous_adjustment=False
+        (ii) x_diff_weight=0 and (optionally) (iii) porous_adjustment=False
         which will disregard the atomic identities and perform best for a purely
         geometric match.
 
@@ -3998,7 +3998,7 @@ class CrystalNN(NearNeighbors):
                 cn_weights[cn] = self._semicircle_integral(dist_bins, idx)
 
         # add zero coord
-        cn0_weight = 1.0 - sum(cn_weights.values())
+        cn0_weight = 1 - sum(cn_weights.values())
         if cn0_weight > 0:
             cn_nninfo[0] = []
             cn_weights[0] = cn0_weight
@@ -4173,7 +4173,7 @@ class CutOffDictNN(NearNeighbors):
         Args:
             cut_off_dict (dict[str, float]): a dictionary
             of cut-off distances, e.g. {('Fe','O'): 2.0} for
-            a maximum Fe-O bond length of 2.0 Angstroms.
+            a maximum Fe-O bond length of 2 Angstroms.
             Bonds will only be created between pairs listed
             in the cut-off dictionary.
             If your structure is oxidation state decorated,

--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -15,7 +15,7 @@ from collections import defaultdict, namedtuple
 from copy import deepcopy
 from functools import lru_cache
 from math import acos, asin, atan2, cos, exp, fabs, pi, pow, sin, sqrt
-from typing import Any, Literal, get_args
+from typing import TYPE_CHECKING, Any, Literal, get_args
 
 import numpy as np
 from monty.dev import requires
@@ -26,7 +26,6 @@ from scipy.spatial import Voronoi
 from pymatgen.analysis.bond_valence import BV_PARAMS, BVAnalyzer
 from pymatgen.analysis.graphs import MoleculeGraph, StructureGraph
 from pymatgen.analysis.molecule_structure_comparator import CovalentRadius
-from pymatgen.core.composition import SpeciesLike
 from pymatgen.core.periodic_table import Element, Species
 from pymatgen.core.sites import PeriodicSite, Site
 from pymatgen.core.structure import IStructure, PeriodicNeighbor, Structure
@@ -35,6 +34,10 @@ try:
     from openbabel import openbabel
 except Exception:
     openbabel = None
+
+if TYPE_CHECKING:
+    from pymatgen.core.composition import SpeciesLike
+
 
 __author__ = "Shyue Ping Ong, Geoffroy Hautier, Sai Jayaraman, "
 __author__ += "Nils E. R. Zimmermann, Bharat Medasani, Evan Spotte-Smith"

--- a/pymatgen/analysis/magnetism/analyzer.py
+++ b/pymatgen/analysis/magnetism/analyzer.py
@@ -10,7 +10,7 @@ import os
 import warnings
 from collections import namedtuple
 from enum import Enum, unique
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from monty.serialization import loadfn
@@ -28,7 +28,9 @@ from pymatgen.transformations.advanced_transformations import (
 from pymatgen.transformations.standard_transformations import (
     AutoOxiStateDecorationTransformation,
 )
-from pymatgen.util.typing import VectorLike
+
+if TYPE_CHECKING:
+    from pymatgen.util.typing import VectorLike
 
 __author__ = "Matthew Horton"
 __copyright__ = "Copyright 2017, The Materials Project"

--- a/pymatgen/analysis/magnetism/analyzer.py
+++ b/pymatgen/analysis/magnetism/analyzer.py
@@ -1096,6 +1096,6 @@ def magnetic_deformation(structure_A: Structure, structure_B: Structure) -> Magn
     p = np.dot(lattice_a_inv, lattice_b)
     eta = 0.5 * (np.dot(p.T, p) - np.identity(3))
     w, v = np.linalg.eig(eta)
-    deformation = 100 * (1.0 / 3.0) * np.sqrt(w[0] ** 2 + w[1] ** 2 + w[2] ** 2)
+    deformation = 100 * (1 / 3) * np.sqrt(w[0] ** 2 + w[1] ** 2 + w[2] ** 2)
 
     return MagneticDeformation(deformation=deformation, type=type_str)

--- a/pymatgen/analysis/magnetism/jahnteller.py
+++ b/pymatgen/analysis/magnetism/jahnteller.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import os
 import warnings
-from typing import Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import numpy as np
 
@@ -16,8 +16,10 @@ from pymatgen.analysis.local_env import (
     get_neighbors_of_site_with_index,
 )
 from pymatgen.core.periodic_table import Species, get_el_sp
-from pymatgen.core.structure import Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
+
+if TYPE_CHECKING:
+    from pymatgen.core.structure import Structure
 
 MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
 

--- a/pymatgen/analysis/nmr.py
+++ b/pymatgen/analysis/nmr.py
@@ -103,7 +103,7 @@ class ChemicalShielding(SquareTensor):
         omega = np.diag(pas)[2] - np.diag(pas)[0]
         # There is a typo in equation 20 from Magn. Resonance Chem. 2008, 46, 582-598, the sign is wrong.
         # There correct order is presented in Solid State Nucl. Magn. Resonance 1993, 2, 285-288.
-        kappa = 3.0 * (np.diag(pas)[1] - sigma_iso) / omega
+        kappa = 3 * (np.diag(pas)[1] - sigma_iso) / omega
         return self.MarylandNotation(sigma_iso, omega, kappa)
 
     @classmethod
@@ -119,9 +119,9 @@ class ChemicalShielding(SquareTensor):
         Returns:
             ChemicalShielding
         """
-        sigma_22 = sigma_iso + kappa * omega / 3.0
-        sigma_11 = (3.0 * sigma_iso - omega - sigma_22) / 2.0
-        sigma_33 = 3.0 * sigma_iso - sigma_22 - sigma_11
+        sigma_22 = sigma_iso + kappa * omega / 3
+        sigma_11 = (3 * sigma_iso - omega - sigma_22) / 2
+        sigma_33 = 3 * sigma_iso - sigma_22 - sigma_11
         return cls(np.diag([sigma_11, sigma_22, sigma_33]))
 
 

--- a/pymatgen/analysis/path_finder.py
+++ b/pymatgen/analysis/path_finder.py
@@ -195,7 +195,7 @@ class NEBPathfinder:
         # logger.debug(f"Getting path from {start} to {end} (coords wrt V grid)")
 
         # Set parameters
-        dr = np.array([1.0 / V.shape[0], 1.0 / V.shape[1], 1.0 / V.shape[2]]) if not dr else np.array(dr, dtype=float)
+        dr = np.array([1 / V.shape[0], 1 / V.shape[1], 1 / V.shape[2]]) if not dr else np.array(dr, dtype=float)
         keff = k * dr * n_images
         h0 = h
 
@@ -224,7 +224,7 @@ class NEBPathfinder:
         # Evolve string
         for step in range(0, max_iter):
             # Gradually decay step size to prevent oscillations
-            h = h0 * np.exp(-2.0 * (step - min_iter) / max_iter) if step > min_iter else h0
+            h = h0 * np.exp(-2 * (step - min_iter) / max_iter) if step > min_iter else h0
             # Calculate forces acting on string
             d = V.shape
             s0 = s.copy()  # store copy for endpoint fixing below (fixes GH 2732)
@@ -390,9 +390,9 @@ class StaticPotential:
         # Apply smearing
         # Gaussian filter
         gauss_dist = np.zeros((r_disc[0] * 4 + 1, r_disc[1] * 4 + 1, r_disc[2] * 4 + 1))
-        for g_a in np.arange(-2.0 * r_disc[0], 2.0 * r_disc[0] + 1, 1.0):
-            for g_b in np.arange(-2.0 * r_disc[1], 2.0 * r_disc[1] + 1, 1.0):
-                for g_c in np.arange(-2.0 * r_disc[2], 2.0 * r_disc[2] + 1, 1.0):
+        for g_a in np.arange(-2 * r_disc[0], 2 * r_disc[0] + 1, 1):
+            for g_b in np.arange(-2 * r_disc[1], 2 * r_disc[1] + 1, 1):
+                for g_c in np.arange(-2 * r_disc[2], 2 * r_disc[2] + 1, 1):
                     g = np.array([g_a / v_dim[0], g_b / v_dim[1], g_c / v_dim[2]]).T
                     gauss_dist[int(g_a + r_disc[0])][int(g_b + r_disc[1])][int(g_c + r_disc[2])] = (
                         la.norm(np.dot(self.__s.lattice.matrix, g)) / r
@@ -426,7 +426,7 @@ class ChgcarPotential(StaticPotential):
         v = v / (v.shape[0] * v.shape[1] * v.shape[2])
         StaticPotential.__init__(self, chgcar.structure, v)
         if smear:
-            self.gaussian_smear(2.0)
+            self.gaussian_smear(2)
         if normalize:
             self.normalize()
 
@@ -451,16 +451,16 @@ class FreeVolumePotential(StaticPotential):
         v = FreeVolumePotential.__add_gaussians(struct, dim)
         StaticPotential.__init__(self, struct, v)
         if smear:
-            self.gaussian_smear(2.0)
+            self.gaussian_smear(2)
         if normalize:
             self.normalize()
 
     @staticmethod
     def __add_gaussians(s, dim, r=1.5):
         gauss_dist = np.zeros(dim)
-        for a_d in np.arange(0.0, dim[0], 1.0):
-            for b_d in np.arange(0.0, dim[1], 1.0):
-                for c_d in np.arange(0.0, dim[2], 1.0):
+        for a_d in np.arange(0, dim[0], 1):
+            for b_d in np.arange(0, dim[1], 1):
+                for c_d in np.arange(0, dim[2], 1):
                     coords_f = np.array([a_d / dim[0], b_d / dim[1], c_d / dim[2]])
                     d_f = sorted(s.get_sites_in_sphere(coords_f, s.lattice.a), key=lambda x: x[1])[0][1]
                     # logger.debug(d_f)
@@ -489,6 +489,6 @@ class MixedPotential(StaticPotential):
             v += potentials[i].get_v() * coefficients[i]
         StaticPotential.__init__(self, s, v)
         if smear:
-            self.gaussian_smear(2.0)
+            self.gaussian_smear(2)
         if normalize:
             self.normalize()

--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -13,8 +13,7 @@ import os
 import re
 import warnings
 from functools import lru_cache
-from io import StringIO
-from typing import Any, Iterator, Literal, Sequence
+from typing import TYPE_CHECKING, Any, Iterator, Literal, Sequence
 
 import numpy as np
 import plotly.graph_objs as go
@@ -30,7 +29,11 @@ from pymatgen.entries import Entry
 from pymatgen.util.coord import Simplex, in_coord_list
 from pymatgen.util.plotting import pretty_plot
 from pymatgen.util.string import htmlify, latexify
-from pymatgen.util.typing import ArrayLike
+
+if TYPE_CHECKING:
+    from io import StringIO
+
+    from numpy.typing import ArrayLike
 
 logger = logging.getLogger(__name__)
 

--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -1150,7 +1150,7 @@ class PhaseDiagram(MSONable):
         if referenced:
             el_energies = {el: self.el_refs[el].energy_per_atom for el in elements}
         else:
-            el_energies = {el: 0.0 for el in elements}
+            el_energies = {el: 0 for el in elements}
 
         chempot_ranges = collections.defaultdict(list)
         vertices = [list(range(len(self.elements)))]
@@ -2383,7 +2383,7 @@ class PDPlotter:
             norm = Normalize(vmin=vmin, vmax=vmax)
             _map = ScalarMappable(norm=norm, cmap=cmap)
             _energies = [self._pd.get_equilibrium_reaction_energy(entry) for coord, entry in labels.items()]
-            energies = [en if en < 0.0 else -0.00000001 for en in _energies]
+            energies = [en if en < 0 else -0.00000001 for en in _energies]
             vals_stable = _map.to_rgba(energies)
             ii = 0
             if process_attributes:
@@ -2531,7 +2531,7 @@ class PDPlotter:
         fig = plt.figure()
         ax = fig.add_subplot(111, projection="3d")
         font = FontProperties(weight="bold", size=13)
-        (lines, labels, unstable) = self.pd_plot_data
+        lines, labels, unstable = self.pd_plot_data
         count = 1
         newlabels = []
         for x, y, z in lines:
@@ -3311,7 +3311,7 @@ def tet_coord(coord):
         [
             [1, 0, 0],
             [0.5, math.sqrt(3) / 2, 0],
-            [0.5, 1.0 / 3.0 * math.sqrt(3) / 2, math.sqrt(6) / 3],
+            [0.5, 1 / 3 * math.sqrt(3) / 2, math.sqrt(6) / 3],
         ]
     )
     result = np.dot(np.array(coord), unitvec)
@@ -3372,14 +3372,14 @@ def order_phase_diagram(lines, stable_entries, unstable_entries, ordering):
             # The coordinates were already in the user ordering
             return lines, stable_entries, unstable_entries
 
-        newlines = [[np.array(1.0 - x), y] for x, y in lines]
-        newstable_entries = {(1.0 - c[0], c[1]): entry for c, entry in stable_entries.items()}
-        newunstable_entries = {entry: (1.0 - c[0], c[1]) for entry, c in unstable_entries.items()}
+        newlines = [[np.array(1 - x), y] for x, y in lines]
+        newstable_entries = {(1 - c[0], c[1]): entry for c, entry in stable_entries.items()}
+        newunstable_entries = {entry: (1 - c[0], c[1]) for entry, c in unstable_entries.items()}
         return newlines, newstable_entries, newunstable_entries
     if nameup == ordering[1]:
         if nameleft == ordering[2]:
-            c120 = np.cos(2.0 * np.pi / 3.0)
-            s120 = np.sin(2.0 * np.pi / 3.0)
+            c120 = np.cos(2 * np.pi / 3.0)
+            s120 = np.sin(2 * np.pi / 3.0)
             newlines = []
             for x, y in lines:
                 newx = np.zeros_like(x)
@@ -3403,8 +3403,8 @@ def order_phase_diagram(lines, stable_entries, unstable_entries, ordering):
                 for entry, c in unstable_entries.items()
             }
             return newlines, newstable_entries, newunstable_entries
-        c120 = np.cos(2.0 * np.pi / 3.0)
-        s120 = np.sin(2.0 * np.pi / 3.0)
+        c120 = np.cos(2 * np.pi / 3.0)
+        s120 = np.sin(2 * np.pi / 3.0)
         newlines = []
         for x, y in lines:
             newx = np.zeros_like(x)
@@ -3430,8 +3430,8 @@ def order_phase_diagram(lines, stable_entries, unstable_entries, ordering):
         return newlines, newstable_entries, newunstable_entries
     if nameup == ordering[2]:
         if nameleft == ordering[0]:
-            c240 = np.cos(4.0 * np.pi / 3.0)
-            s240 = np.sin(4.0 * np.pi / 3.0)
+            c240 = np.cos(4 * np.pi / 3.0)
+            s240 = np.sin(4 * np.pi / 3.0)
             newlines = []
             for x, y in lines:
                 newx = np.zeros_like(x)
@@ -3455,8 +3455,8 @@ def order_phase_diagram(lines, stable_entries, unstable_entries, ordering):
                 for entry, c in unstable_entries.items()
             }
             return newlines, newstable_entries, newunstable_entries
-        c240 = np.cos(4.0 * np.pi / 3.0)
-        s240 = np.sin(4.0 * np.pi / 3.0)
+        c240 = np.cos(4 * np.pi / 3.0)
+        s240 = np.sin(4 * np.pi / 3.0)
         newlines = []
         for x, y in lines:
             newx = np.zeros_like(x)

--- a/pymatgen/analysis/piezo_sensitivity.py
+++ b/pymatgen/analysis/piezo_sensitivity.py
@@ -5,11 +5,11 @@ Piezo sensitivity analysis module.
 from __future__ import annotations
 
 import warnings
+from typing import TYPE_CHECKING
 
 import numpy as np
 from monty.dev import requires
 
-from pymatgen.core.structure import Structure
 from pymatgen.core.tensors import Tensor
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer as sga
 
@@ -18,6 +18,10 @@ try:
     from phonopy.harmonic import dynmat_to_fc as dyntofc
 except ImportError:
     Phonopy = None
+
+
+if TYPE_CHECKING:
+    from pymatgen.core.structure import Structure
 
 __author__ = "Handong Ling"
 __copyright__ = "Copyright 2019, The Materials Project"

--- a/pymatgen/analysis/pourbaix_diagram.py
+++ b/pymatgen/analysis/pourbaix_diagram.py
@@ -492,7 +492,7 @@ class PourbaixDiagram(MSONable):
         else:
             # Set default conc/comp dicts
             if not comp_dict:
-                comp_dict = {elt.symbol: 1.0 / len(self.pbx_elts) for elt in self.pbx_elts}
+                comp_dict = {elt.symbol: 1 / len(self.pbx_elts) for elt in self.pbx_elts}
             if not conc_dict:
                 conc_dict = {elt.symbol: 1e-6 for elt in self.pbx_elts}
             self._conc_dict = conc_dict

--- a/pymatgen/analysis/quasiharmonic.py
+++ b/pymatgen/analysis/quasiharmonic.py
@@ -91,7 +91,7 @@ class QuasiharmonicDebyeApprox:
         self.avg_mass = physical_constants["atomic mass constant"][0] * self.mass / self.natoms  # kg
         self.kb = physical_constants["Boltzmann constant in eV/K"][0]
         self.hbar = physical_constants["Planck constant over 2 pi in eV s"][0]
-        self.gpa_to_ev_ang = 1.0 / 160.21766208  # 1 GPa in ev/Ang^3
+        self.gpa_to_ev_ang = 1 / 160.21766208  # 1 GPa in ev/Ang^3
         self.gibbs_free_energy: list[float] = []  # optimized values, eV
         # list of temperatures for which the optimized values are available, K
         self.temperatures: list[float] = []
@@ -218,8 +218,8 @@ class QuasiharmonicDebyeApprox:
             float: debye temperature in K
         """
         term1 = (2.0 / 3.0 * (1.0 + self.poisson) / (1.0 - 2.0 * self.poisson)) ** 1.5
-        term2 = (1.0 / 3.0 * (1.0 + self.poisson) / (1.0 - self.poisson)) ** 1.5
-        f = (3.0 / (2.0 * term1 + term2)) ** (1.0 / 3.0)
+        term2 = (1 / 3 * (1.0 + self.poisson) / (1.0 - self.poisson)) ** 1.5
+        f = (3.0 / (2.0 * term1 + term2)) ** (1 / 3)
         debye = 2.9772e-11 * (volume / self.natoms) ** (-1.0 / 6.0) * f * np.sqrt(self.bulk_modulus / self.avg_mass)
         if self.anharmonic_contribution:
             gamma = self.gruneisen_parameter(0, self.ev_eos_fit.v0)  # 0K equilibrium Gruneisen parameter
@@ -312,14 +312,14 @@ class QuasiharmonicDebyeApprox:
         """
         gamma = self.gruneisen_parameter(temperature, volume)
         theta_d = self.debye_temperature(volume)  # K
-        theta_a = theta_d * self.natoms ** (-1.0 / 3.0)  # K
-        prefactor = (0.849 * 3 * 4 ** (1.0 / 3.0)) / (20.0 * np.pi**3)
+        theta_a = theta_d * self.natoms ** (-1 / 3)  # K
+        prefactor = (0.849 * 3 * 4 ** (1 / 3)) / (20.0 * np.pi**3)
         # kg/K^3/s^3
         prefactor = prefactor * (self.kb / self.hbar) ** 3 * self.avg_mass
         kappa = prefactor / (gamma**2 - 0.514 * gamma + 0.228)
         # kg/K/s^3 * Ang = (kg m/s^2)/(Ks)*1e-10
         # = N/(Ks)*1e-10 = Nm/(Kms)*1e-10 = W/K/m*1e-10
-        kappa = kappa * theta_a**2 * volume ** (1.0 / 3.0) * 1e-10
+        kappa = kappa * theta_a**2 * volume ** (1 / 3) * 1e-10
         return kappa
 
     def get_summary_dict(self):

--- a/pymatgen/analysis/structure_analyzer.py
+++ b/pymatgen/analysis/structure_analyzer.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import collections
 import itertools
 from math import acos, pi
+from typing import TYPE_CHECKING
 from warnings import warn
 
 import numpy as np
@@ -16,9 +17,11 @@ from pymatgen.analysis.local_env import JmolNN, VoronoiNN
 from pymatgen.core.composition import Composition
 from pymatgen.core.periodic_table import Element, Species
 from pymatgen.core.sites import PeriodicSite
-from pymatgen.core.structure import Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.util.num import abs_cap
+
+if TYPE_CHECKING:
+    from pymatgen.core.structure import Structure
 
 __author__ = "Shyue Ping Ong, Geoffroy Hautier, Sai Jayaraman"
 __copyright__ = "Copyright 2011, The Materials Project"

--- a/pymatgen/analysis/surface_analysis.py
+++ b/pymatgen/analysis/surface_analysis.py
@@ -38,6 +38,7 @@ import copy
 import itertools
 import random
 import warnings
+from typing import TYPE_CHECKING
 
 import numpy as np
 from sympy import Symbol
@@ -45,12 +46,14 @@ from sympy.solvers import linsolve, solve
 
 from pymatgen.analysis.wulff import WulffShape
 from pymatgen.core.composition import Composition
-from pymatgen.core.structure import Structure
 from pymatgen.core.surface import get_slab_regions
 from pymatgen.entries.computed_entries import ComputedStructureEntry
 from pymatgen.io.vasp.outputs import Locpot, Outcar, Poscar
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.util.plotting import pretty_plot
+
+if TYPE_CHECKING:
+    from pymatgen.core.structure import Structure
 
 EV_PER_ANG2_TO_JOULES_PER_M2 = 16.0217656
 

--- a/pymatgen/analysis/wulff.py
+++ b/pymatgen/analysis/wulff.py
@@ -19,15 +19,18 @@ from __future__ import annotations
 import itertools
 import logging
 import warnings
+from typing import TYPE_CHECKING
 
 import numpy as np
 import plotly.graph_objs as go
 from scipy.spatial import ConvexHull
 
-from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Structure
 from pymatgen.util.coord import get_angle
 from pymatgen.util.string import unicodeify_spacegroup
+
+if TYPE_CHECKING:
+    from pymatgen.core.lattice import Lattice
 
 __author__ = "Zihan Xu, Richard Tran, Shyue Ping Ong"
 __copyright__ = "Copyright 2013, The Materials Virtual Lab"

--- a/pymatgen/analysis/xps.py
+++ b/pymatgen/analysis/xps.py
@@ -21,13 +21,16 @@ from __future__ import annotations
 import collections
 import warnings
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
 
 from pymatgen.core.periodic_table import Element
 from pymatgen.core.spectrum import Spectrum
-from pymatgen.electronic_structure.dos import CompleteDos
+
+if TYPE_CHECKING:
+    from pymatgen.electronic_structure.dos import CompleteDos
 
 
 def _load_cross_sections(fname):

--- a/pymatgen/apps/battery/battery_abc.py
+++ b/pymatgen/apps/battery/battery_abc.py
@@ -10,12 +10,15 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from monty.json import MSONable
 from scipy.constants import N_A
 
 from pymatgen.core import Composition, Element
-from pymatgen.entries.computed_entries import ComputedEntry
+
+if TYPE_CHECKING:
+    from pymatgen.entries.computed_entries import ComputedEntry
 
 __author__ = "Anubhav Jain, Shyue Ping Ong"
 __copyright__ = "Copyright 2012, The Materials Project"

--- a/pymatgen/apps/battery/conversion_battery.py
+++ b/pymatgen/apps/battery/conversion_battery.py
@@ -5,7 +5,7 @@ This module contains the classes to build a ConversionElectrode.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Iterable
+from typing import TYPE_CHECKING, Iterable
 
 from scipy.constants import N_A
 
@@ -15,7 +15,9 @@ from pymatgen.apps.battery.battery_abc import AbstractElectrode, AbstractVoltage
 from pymatgen.core.composition import Composition
 from pymatgen.core.periodic_table import Element
 from pymatgen.core.units import Charge, Time
-from pymatgen.entries.computed_entries import ComputedEntry
+
+if TYPE_CHECKING:
+    from pymatgen.entries.computed_entries import ComputedEntry
 
 
 @dataclass
@@ -23,7 +25,7 @@ class ConversionElectrode(AbstractElectrode):
     """
     Class representing a ConversionElectrode, since it is dataclass
     this object can be constructed for the attributes.
-    However, it is usually easier to construct a ConversionElectrode using one of the classmethods
+    However, it is usually easier to construct a ConversionElectrode using one of the classmethod
     constructors provided.
 
     Attribute:

--- a/pymatgen/cli/pmg_config.py
+++ b/pymatgen/cli/pmg_config.py
@@ -9,14 +9,16 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
-from argparse import Namespace
 from glob import glob
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 from urllib.request import urlretrieve
 
 from monty.serialization import dumpfn, loadfn
 
 from pymatgen.core import OLD_SETTINGS_FILE, SETTINGS_FILE
+
+if TYPE_CHECKING:
+    from argparse import Namespace
 
 
 def setup_cp2k_data(cp2k_data_dirs: list[str]) -> None:

--- a/pymatgen/command_line/critic2_caller.py
+++ b/pymatgen/command_line/critic2_caller.py
@@ -46,6 +46,7 @@ import warnings
 from enum import Enum
 from glob import glob
 from shutil import which
+from typing import TYPE_CHECKING
 
 import numpy as np
 from monty.dev import requires
@@ -56,9 +57,11 @@ from scipy.spatial import KDTree
 
 from pymatgen.analysis.graphs import StructureGraph
 from pymatgen.core.periodic_table import DummySpecies
-from pymatgen.core.structure import Structure
 from pymatgen.io.vasp.inputs import Potcar
 from pymatgen.io.vasp.outputs import Chgcar, VolumetricData
+
+if TYPE_CHECKING:
+    from pymatgen.core.structure import Structure
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/pymatgen/core/bonds.py
+++ b/pymatgen/core/bonds.py
@@ -9,10 +9,13 @@ import collections
 import json
 import os
 import warnings
+from typing import TYPE_CHECKING
 
 from pymatgen.core.periodic_table import Element
-from pymatgen.core.sites import Site
-from pymatgen.util.typing import SpeciesLike
+
+if TYPE_CHECKING:
+    from pymatgen.core.sites import Site
+    from pymatgen.util.typing import SpeciesLike
 
 
 def _load_bond_length_data():

--- a/pymatgen/core/lattice.py
+++ b/pymatgen/core/lattice.py
@@ -10,7 +10,7 @@ import math
 import warnings
 from fractions import Fraction
 from functools import reduce
-from typing import Iterator, Sequence
+from typing import TYPE_CHECKING, Iterator, Sequence
 
 import numpy as np
 from monty.dev import deprecated
@@ -20,7 +20,9 @@ from numpy.linalg import inv
 
 from pymatgen.util.coord import pbc_shortest_vectors
 from pymatgen.util.num import abs_cap
-from pymatgen.util.typing import ArrayLike
+
+if TYPE_CHECKING:
+    from numpy.typing import ArrayLike
 
 __author__ = "Shyue Ping Ong, Michael Kocher"
 __copyright__ = "Copyright 2011, The Materials Project"

--- a/pymatgen/core/operations.py
+++ b/pymatgen/core/operations.py
@@ -9,14 +9,16 @@ import string
 import typing
 import warnings
 from math import cos, pi, sin, sqrt
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from monty.json import MSONable
 
 from pymatgen.electronic_structure.core import Magmom
 from pymatgen.util.string import transformation_to_string
-from pymatgen.util.typing import ArrayLike
+
+if TYPE_CHECKING:
+    from numpy.typing import ArrayLike
 
 __author__ = "Shyue Ping Ong, Shyam Dwaraknath, Matthew Horton"
 

--- a/pymatgen/core/sites.py
+++ b/pymatgen/core/sites.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import collections
 import json
+from typing import TYPE_CHECKING
 
 import numpy as np
 from monty.json import MontyDecoder, MontyEncoder, MSONable
@@ -14,7 +15,11 @@ from pymatgen.core.composition import Composition
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.periodic_table import DummySpecies, Element, Species, get_el_sp
 from pymatgen.util.coord import pbc_diff
-from pymatgen.util.typing import ArrayLike, CompositionLike, SpeciesLike
+
+if TYPE_CHECKING:
+    from numpy.typing import ArrayLike
+
+    from pymatgen.util.typing import CompositionLike, SpeciesLike
 
 
 class Site(collections.abc.Hashable, MSONable):

--- a/pymatgen/core/spectrum.py
+++ b/pymatgen/core/spectrum.py
@@ -5,7 +5,7 @@ x y value pairs.
 
 from __future__ import annotations
 
-from typing import Callable, Literal
+from typing import TYPE_CHECKING, Callable, Literal
 
 import numpy as np
 from monty.json import MSONable
@@ -13,7 +13,9 @@ from scipy import stats
 from scipy.ndimage import convolve1d
 
 from pymatgen.util.coord import get_linear_interpolated_value
-from pymatgen.util.typing import ArrayLike
+
+if TYPE_CHECKING:
+    from numpy.typing import ArrayLike
 
 
 def lorentzian(x, x_0: float = 0, sigma: float = 1.0):

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -46,10 +46,12 @@ from pymatgen.core.units import Length, Mass
 from pymatgen.electronic_structure.core import Magmom
 from pymatgen.symmetry.maggroups import MagneticSpaceGroup
 from pymatgen.util.coord import all_distances, get_angle, lattice_points_in_supercell
-from pymatgen.util.typing import ArrayLike, CompositionLike, SpeciesLike
 
 if TYPE_CHECKING:
     from m3gnet.models._dynamics import TrajectoryObserver
+    from numpy.typing import ArrayLike
+
+    from pymatgen.util.typing import CompositionLike, SpeciesLike
 
 
 class Neighbor(Site):

--- a/pymatgen/core/tensors.py
+++ b/pymatgen/core/tensors.py
@@ -11,7 +11,7 @@ import itertools
 import os
 import string
 import warnings
-from typing import Sequence
+from typing import TYPE_CHECKING, Sequence
 
 import numpy as np
 from monty.json import MSONable
@@ -21,8 +21,10 @@ from scipy.linalg import polar
 from pymatgen.analysis.structure_matcher import StructureMatcher
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.operations import SymmOp
-from pymatgen.core.structure import Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
+
+if TYPE_CHECKING:
+    from pymatgen.core.structure import Structure
 
 __author__ = "Joseph Montoya"
 __credits__ = "Maarten de Jong, Shyam Dwaraknath, Wei Chen, Mark Asta, Anubhav Jain, Terence Lew"

--- a/pymatgen/core/tests/test_settings.py
+++ b/pymatgen/core/tests/test_settings.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
-from pathlib import Path
+from typing import TYPE_CHECKING
 
-from pytest import MonkeyPatch
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest import MonkeyPatch
 
 from pymatgen.core import _load_pmg_settings
 

--- a/pymatgen/electronic_structure/boltztrap.py
+++ b/pymatgen/electronic_structure/boltztrap.py
@@ -26,6 +26,7 @@ import subprocess
 import tempfile
 import time
 from shutil import which
+from typing import TYPE_CHECKING
 
 import numpy as np
 from monty.dev import requires
@@ -35,15 +36,18 @@ from scipy import constants
 from scipy.spatial import distance
 
 from pymatgen.core.lattice import Lattice
-from pymatgen.core.sites import PeriodicSite
-from pymatgen.core.structure import Structure
 from pymatgen.core.units import Energy, Length
 from pymatgen.electronic_structure.bandstructure import BandStructureSymmLine, Kpoint
 from pymatgen.electronic_structure.core import Orbital
 from pymatgen.electronic_structure.dos import CompleteDos, Dos, Spin
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.symmetry.bandstructure import HighSymmKpath
-from pymatgen.util.typing import ArrayLike
+
+if TYPE_CHECKING:
+    from numpy.typing import ArrayLike
+
+    from pymatgen.core.sites import PeriodicSite
+    from pymatgen.core.structure import Structure
 
 __author__ = "Geoffroy Hautier, Zachary Gibbs, Francesco Ricci, Anubhav Jain"
 __copyright__ = "Copyright 2013, The Materials Project"

--- a/pymatgen/electronic_structure/dos.py
+++ b/pymatgen/electronic_structure/dos.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import functools
 import warnings
 from collections import namedtuple
-from typing import Mapping, NamedTuple
+from typing import TYPE_CHECKING, Mapping, NamedTuple
 
 import numpy as np
 from monty.json import MSONable
@@ -15,12 +15,16 @@ from scipy.constants import value as _cd
 from scipy.signal import hilbert
 
 from pymatgen.core.periodic_table import get_el_sp
-from pymatgen.core.sites import PeriodicSite
 from pymatgen.core.spectrum import Spectrum
 from pymatgen.core.structure import Structure
 from pymatgen.electronic_structure.core import Orbital, OrbitalType, Spin
 from pymatgen.util.coord import get_linear_interpolated_value
-from pymatgen.util.typing import ArrayLike, SpeciesLike
+
+if TYPE_CHECKING:
+    from numpy.typing import ArrayLike
+
+    from pymatgen.core.sites import PeriodicSite
+    from pymatgen.util.typing import SpeciesLike
 
 
 class DOS(Spectrum):

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -11,7 +11,7 @@ import math
 import typing
 import warnings
 from collections import Counter
-from typing import List, Literal, Sequence, cast
+from typing import TYPE_CHECKING, List, Literal, Sequence, cast
 
 import matplotlib.lines as mlines
 import numpy as np
@@ -23,14 +23,18 @@ from pymatgen.core.periodic_table import Element
 from pymatgen.electronic_structure.bandstructure import BandStructureSymmLine
 from pymatgen.electronic_structure.boltztrap import BoltztrapError
 from pymatgen.electronic_structure.core import OrbitalType, Spin
-from pymatgen.electronic_structure.dos import CompleteDos, Dos
 from pymatgen.util.plotting import add_fig_kwargs, get_ax3d_fig_plt, pretty_plot
-from pymatgen.util.typing import ArrayLike
 
 try:
     from mayavi import mlab
 except ImportError:
     mlab = None
+
+if TYPE_CHECKING:
+    from numpy.typing import ArrayLike
+
+    from pymatgen.electronic_structure.dos import CompleteDos, Dos
+
 
 __author__ = "Shyue Ping Ong, Geoffroy Hautier, Anubhav Jain"
 __copyright__ = "Copyright 2012, The Materials Project"

--- a/pymatgen/entries/computed_entries.py
+++ b/pymatgen/entries/computed_entries.py
@@ -14,7 +14,7 @@ import math
 import os
 import warnings
 from itertools import combinations
-from typing import Literal, cast
+from typing import TYPE_CHECKING, Literal, cast
 
 import numpy as np
 from monty.json import MontyDecoder, MontyEncoder, MSONable
@@ -22,8 +22,10 @@ from scipy.interpolate import interp1d
 from uncertainties import ufloat
 
 from pymatgen.core.composition import Composition
-from pymatgen.core.structure import Structure
 from pymatgen.entries import Entry
+
+if TYPE_CHECKING:
+    from pymatgen.core.structure import Structure
 
 __author__ = "Ryan Kingsbury, Matt McDermott, Shyue Ping Ong, Anubhav Jain"
 __copyright__ = "Copyright 2011-2020, The Materials Project"

--- a/pymatgen/entries/entry_tools.py
+++ b/pymatgen/entries/entry_tools.py
@@ -12,7 +12,7 @@ import itertools
 import json
 import logging
 import re
-from typing import Iterable, Literal
+from typing import TYPE_CHECKING, Iterable, Literal
 
 from monty.json import MontyDecoder, MontyEncoder, MSONable
 from monty.string import unicode2str
@@ -21,8 +21,10 @@ from pymatgen.analysis.phase_diagram import PDEntry
 from pymatgen.analysis.structure_matcher import SpeciesComparator, StructureMatcher
 from pymatgen.core.composition import Composition
 from pymatgen.core.periodic_table import Element
-from pymatgen.entries import Entry
-from pymatgen.entries.computed_entries import ComputedEntry, ComputedStructureEntry
+
+if TYPE_CHECKING:
+    from pymatgen.entries import Entry
+    from pymatgen.entries.computed_entries import ComputedEntry, ComputedStructureEntry
 
 logger = logging.getLogger(__name__)
 

--- a/pymatgen/ext/matproj.py
+++ b/pymatgen/ext/matproj.py
@@ -21,7 +21,7 @@ import sys
 import warnings
 from enum import Enum, unique
 from time import sleep
-from typing import Any, Literal, Sequence
+from typing import TYPE_CHECKING, Any, Literal, Sequence
 
 import requests
 from monty.json import MontyDecoder, MontyEncoder
@@ -37,9 +37,11 @@ from pymatgen.core.structure import Structure
 from pymatgen.core.surface import get_symmetrically_equivalent_miller_indices
 from pymatgen.entries.computed_entries import ComputedEntry, ComputedStructureEntry
 from pymatgen.entries.exp_entries import ExpEntry
-from pymatgen.phonon.bandstructure import PhononBandStructureSymmLine
-from pymatgen.phonon.dos import CompletePhononDos
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
+
+if TYPE_CHECKING:
+    from pymatgen.phonon.bandstructure import PhononBandStructureSymmLine
+    from pymatgen.phonon.dos import CompletePhononDos
 
 logger = logging.getLogger(__name__)
 

--- a/pymatgen/io/cp2k/inputs.py
+++ b/pymatgen/io/cp2k/inputs.py
@@ -32,18 +32,20 @@ import typing
 from dataclasses import dataclass, field
 from hashlib import md5
 from pathlib import Path
-from typing import Any, Iterable, Literal, Sequence
+from typing import TYPE_CHECKING, Any, Iterable, Literal, Sequence
 
 from monty.io import zopen
 from monty.json import MSONable
 
-from pymatgen.core.lattice import Lattice
 from pymatgen.core.periodic_table import Element
-from pymatgen.core.structure import Molecule, Structure
 from pymatgen.io.cp2k.utils import chunk, postprocessor, preprocessor
 from pymatgen.io.vasp.inputs import Kpoints as VaspKpoints
 from pymatgen.io.vasp.inputs import Kpoints_supported_modes
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
+
+if TYPE_CHECKING:
+    from pymatgen.core.lattice import Lattice
+    from pymatgen.core.structure import Molecule, Structure
 
 __author__ = "Nicholas Winner"
 __version__ = "2.0"

--- a/pymatgen/io/cp2k/utils.py
+++ b/pymatgen/io/cp2k/utils.py
@@ -6,11 +6,13 @@ from __future__ import annotations
 
 import os
 import re
+from typing import TYPE_CHECKING
 
 import numpy as np
 from monty.io import zopen
 
-from pymatgen.core import Molecule, Structure
+if TYPE_CHECKING:
+    from pymatgen.core import Molecule, Structure
 
 
 def postprocessor(data: str) -> str | int | float | bool | None:

--- a/pymatgen/io/lammps/sets.py
+++ b/pymatgen/io/lammps/sets.py
@@ -11,11 +11,14 @@ from __future__ import annotations
 
 import logging
 import os
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from pymatgen.io.core import InputSet
 from pymatgen.io.lammps.data import CombinedData, LammpsData
 from pymatgen.io.lammps.inputs import LammpsInputFile
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 __author__ = "Ryan Kingsbury, Guillaume Brunin (Matgenix)"
 __copyright__ = "Copyright 2021, The Materials Project"

--- a/pymatgen/io/lammps/utils.py
+++ b/pymatgen/io/lammps/utils.py
@@ -257,7 +257,7 @@ class PackmolRunner:
         for idx, mol in enumerate(self.mols):
             length = max(np.max(mol.cart_coords[:, i]) - np.min(mol.cart_coords[:, i]) for i in range(3)) + 2.0
             net_volume += (length**3.0) * float(self.param_list[idx]["number"])
-        length = net_volume ** (1.0 / 3.0)
+        length = net_volume ** (1 / 3)
         for idx, _mol in enumerate(self.mols):
             self.param_list[idx]["inside box"] = f"0.0 0.0 0.0 {length} {length} {length}"
 

--- a/pymatgen/io/lobster/inputs.py
+++ b/pymatgen/io/lobster/inputs.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import itertools
 import os
 import warnings
-from typing import Any, Sequence
+from typing import TYPE_CHECKING, Any, Sequence
 
 import numpy as np
 import spglib
@@ -18,11 +18,14 @@ from monty.io import zopen
 from monty.json import MSONable
 from monty.serialization import loadfn
 
-from pymatgen.core.composition import Composition
 from pymatgen.core.structure import Structure
 from pymatgen.io.vasp import Vasprun
 from pymatgen.io.vasp.inputs import Incar, Kpoints, Potcar
 from pymatgen.symmetry.bandstructure import HighSymmKpath
+
+if TYPE_CHECKING:
+    from pymatgen.core.composition import Composition
+
 
 __author__ = "Janine George, Marco Esters"
 __copyright__ = "Copyright 2017, The Materials Project"

--- a/pymatgen/io/lobster/lobsterenv.py
+++ b/pymatgen/io/lobster/lobsterenv.py
@@ -10,22 +10,21 @@ import collections
 import copy
 import math
 import os
+from typing import TYPE_CHECKING
 
 import numpy as np
 
 from pymatgen.analysis.bond_valence import BVAnalyzer
-from pymatgen.analysis.chemenv.coordination_environments.coordination_geometry_finder import (
-    LocalGeometryFinder,
-)
-from pymatgen.analysis.chemenv.coordination_environments.structure_environments import (
-    LightStructureEnvironments,
-)
+from pymatgen.analysis.chemenv.coordination_environments.coordination_geometry_finder import LocalGeometryFinder
+from pymatgen.analysis.chemenv.coordination_environments.structure_environments import LightStructureEnvironments
 from pymatgen.analysis.local_env import NearNeighbors
-from pymatgen.core.structure import Structure
 from pymatgen.electronic_structure.cohp import CompleteCohp
 from pymatgen.electronic_structure.core import Spin
 from pymatgen.electronic_structure.plotter import CohpPlotter
 from pymatgen.io.lobster import Charge, Icohplist
+
+if TYPE_CHECKING:
+    from pymatgen.core.structure import Structure
 
 __author__ = "Janine George"
 __copyright__ = "Copyright 2021, The Materials Project"

--- a/pymatgen/io/packmol.py
+++ b/pymatgen/io/packmol.py
@@ -194,7 +194,7 @@ class PackmolBoxGen(InputGenerator):
                     + self.tolerance
                 )
                 net_volume += (length**3.0) * float(d["number"])
-            box_length = net_volume ** (1.0 / 3.0)
+            box_length = net_volume ** (1 / 3)
             print(f"Auto determined box size is {box_length:.1f} Å per side.")
             box_list = f"0.0 0.0 0.0 {box_length:.1f} {box_length:.1f} {box_length:.1f}"
 

--- a/pymatgen/io/prismatic.py
+++ b/pymatgen/io/prismatic.py
@@ -4,7 +4,10 @@ Write Prismatic (http://prism-em.com) input files.
 
 from __future__ import annotations
 
-from pymatgen.core.structure import Structure
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pymatgen.core.structure import Structure
 
 
 class Prismatic:

--- a/pymatgen/io/qchem/inputs.py
+++ b/pymatgen/io/qchem/inputs.py
@@ -6,8 +6,7 @@ from __future__ import annotations
 
 import logging
 import re
-from pathlib import Path
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from monty.io import zopen
 
@@ -15,6 +14,9 @@ from pymatgen.core import Molecule
 from pymatgen.io.core import InputFile
 
 from .utils import lower_and_check_unique, read_pattern, read_table_pattern
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 __author__ = "Brandon Wood, Samuel Blau, Shyam Dwaraknath, Julian Self, Evan Spotte-Smith, Ryan Kingsbury"
 __copyright__ = "Copyright 2018-2022, The Materials Project"

--- a/pymatgen/io/qchem/sets.py
+++ b/pymatgen/io/qchem/sets.py
@@ -7,13 +7,15 @@ from __future__ import annotations
 import logging
 import os
 import warnings
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from monty.io import zopen
 
-from pymatgen.core.structure import Molecule
 from pymatgen.io.qchem.inputs import QCInput
 from pymatgen.io.qchem.utils import lower_and_check_unique
+
+if TYPE_CHECKING:
+    from pymatgen.core.structure import Molecule
 
 __author__ = "Samuel Blau, Brandon Wood, Shyam Dwaraknath, Evan Spotte-Smith, Ryan Kingsbury"
 __copyright__ = "Copyright 2018-2022, The Materials Project"

--- a/pymatgen/io/res.py
+++ b/pymatgen/io/res.py
@@ -11,11 +11,9 @@ REM entries.
 
 from __future__ import annotations
 
-import datetime
 import re
-from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import Any, Callable, Literal
+from typing import TYPE_CHECKING, Any, Callable, Literal
 
 import dateutil.parser  # type: ignore
 from monty.io import zopen
@@ -26,6 +24,10 @@ from pymatgen.core.periodic_table import Element
 from pymatgen.core.sites import PeriodicSite
 from pymatgen.core.structure import Structure
 from pymatgen.entries.computed_entries import ComputedStructureEntry
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from datetime import date
 
 __all__ = ["ResProvider", "AirssProvider", "ResIO", "ResWriter", "ParseError", "ResError"]
 
@@ -426,7 +428,7 @@ class AirssProvider(ResProvider):
         return cls(ResParser._parse_file(filename), parse_rems)
 
     @classmethod
-    def _parse_date(cls, string: str) -> datetime.date:
+    def _parse_date(cls, string: str) -> date:
         """Parses a date from a string where the date is in the format typically used by CASTEP."""
         match = cls._date_fmt.search(string)
         if match is None:
@@ -439,7 +441,7 @@ class AirssProvider(ResProvider):
             return None
         raise err
 
-    def get_run_start_info(self) -> tuple[datetime.date, str] | None:
+    def get_run_start_info(self) -> tuple[date, str] | None:
         """
         Retrieves the run start date and the path it was started in from the REM entries.
 
@@ -510,7 +512,7 @@ class AirssProvider(ResProvider):
                 return (p, q, r), (po, qo, ro), int(srem[11]), float(srem[13])
         return self._raise_or_none(ParseError("Could not find line with MP grid."))  # type: ignore
 
-    def get_airss_version(self) -> tuple[str, datetime.date] | None:
+    def get_airss_version(self) -> tuple[str, date] | None:
         """
         Retrieves the version of AIRSS that was used along with the build date (not compile date).
 

--- a/pymatgen/io/template.py
+++ b/pymatgen/io/template.py
@@ -5,12 +5,15 @@ used to facilitate writing large numbers of input files based on a template.
 
 from __future__ import annotations
 
-from pathlib import Path
 from string import Template
+from typing import TYPE_CHECKING
 
 from monty.io import zopen
 
 from pymatgen.io.core import InputGenerator, InputSet
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 __author__ = "Ryan Kingsbury"
 __email__ = "RKingsbury@lbl.gov"

--- a/pymatgen/io/tests/test_common.py
+++ b/pymatgen/io/tests/test_common.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from pymatgen.io.common import VolumetricData
 from pymatgen.util.testing import PymatgenTest
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def test_cube_io_faithful(tmp_path: Path) -> None:

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -17,7 +17,7 @@ from collections import namedtuple
 from enum import Enum
 from glob import glob
 from hashlib import md5, sha256
-from typing import Any, Literal, Sequence
+from typing import TYPE_CHECKING, Any, Literal, Sequence
 
 import numpy as np
 import scipy.constants as const
@@ -35,7 +35,12 @@ from pymatgen.core.structure import Structure
 from pymatgen.electronic_structure.core import Magmom
 from pymatgen.util.io_utils import clean_lines
 from pymatgen.util.string import str_delimited
-from pymatgen.util.typing import ArrayLike, PathLike
+
+if TYPE_CHECKING:
+    from numpy.typing import ArrayLike
+
+    from pymatgen.util.typing import PathLike
+
 
 __author__ = "Shyue Ping Ong, Geoffroy Hautier, Rickard Armiento, Vincent L Chevrier, Stephen Dacek"
 __copyright__ = "Copyright 2011, The Materials Project"

--- a/pymatgen/io/vasp/optics.py
+++ b/pymatgen/io/vasp/optics.py
@@ -3,18 +3,11 @@
 from __future__ import annotations
 
 import itertools
-
-__author__ = "Jimmy-Xuan Shen"
-__copyright__ = "Copyright 2022, The Materials Project"
-__maintainer__ = "Jimmy-Xuan Shen"
-__email__ = "jmmshn@gmail.com"
-
-
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import numpy as np
-import numpy.typing as npt
 import scipy.constants
 import scipy.special
 from monty.json import MSONable
@@ -22,6 +15,14 @@ from tqdm import tqdm
 
 from pymatgen.electronic_structure.core import Spin
 from pymatgen.io.vasp.outputs import Vasprun, Waveder
+
+if TYPE_CHECKING:
+    from numpy.typing import ArrayLike, NDArray
+
+__author__ = "Jimmy-Xuan Shen"
+__copyright__ = "Copyright 2022, The Materials Project"
+__maintainer__ = "Jimmy-Xuan Shen"
+__email__ = "jmmshn@gmail.com"
 
 au2ang = scipy.constants.physical_constants["atomic unit of length"][0] / 1e-10
 ryd2ev = scipy.constants.physical_constants["Rydberg constant times hc in eV"][0]
@@ -54,10 +55,10 @@ class DielectricFunctionCalculator(MSONable):
     we can dramatically speed up the calculations here by considering only the irreducible kpoints.
     """
 
-    cder_real: npt.NDArray
-    cder_imag: npt.NDArray
-    eigs: npt.NDArray
-    kweights: npt.NDArray
+    cder_real: NDArray
+    cder_imag: NDArray
+    eigs: NDArray
+    kweights: NDArray
     nedos: int
     deltae: float
     ismear: int
@@ -146,8 +147,8 @@ class DielectricFunctionCalculator(MSONable):
         ismear: int | None = None,
         sigma: float | None = None,
         cshift: float | None = None,
-        mask: npt.NDArray | None = None,
-    ) -> tuple[npt.NDArray, npt.NDArray]:
+        mask: NDArray | None = None,
+    ) -> tuple[NDArray, NDArray]:
         """Compute the frequency dependent dielectric function.
 
         Args:
@@ -192,9 +193,7 @@ class DielectricFunctionCalculator(MSONable):
             eps += 1.0 + 0.0j
         return egrid, eps
 
-    def plot_weighted_transition_data(
-        self, idir: int, jdir: int, mask: npt.NDArray | None = None, min_val: float = 0.0
-    ):
+    def plot_weighted_transition_data(self, idir: int, jdir: int, mask: NDArray | None = None, min_val: float = 0.0):
         """Data for plotting the weight matrix elements as a scatter plot.
 
         Since the computation of the final spectrum (especially the smearing part)
@@ -343,9 +342,9 @@ def get_step(x0, sigma, nx, dx, ismear):
 
 
 def epsilon_imag(
-    cder: npt.NDArray,
-    eigs: npt.NDArray,
-    kweights: npt.ArrayLike,
+    cder: NDArray,
+    eigs: NDArray,
+    kweights: ArrayLike,
     efermi: float,
     nedos: int,
     deltae: float,
@@ -353,7 +352,7 @@ def epsilon_imag(
     sigma: float,
     idir: int,
     jdir: int,
-    mask: npt.NDArray | None = None,
+    mask: NDArray | None = None,
 ):
     """Replicate the EPSILON_IMAG function of VASP.
 
@@ -424,7 +423,7 @@ def kramers_kronig(
     nedos: int,
     deltae: float,
     cshift: float = 0.1,
-) -> npt.NDArray:
+) -> NDArray:
     """Perform the Kramers-Kronig transformation.
 
     Perform the Kramers-Kronig transformation exactly as VASP does it.

--- a/pymatgen/io/xtb/inputs.py
+++ b/pymatgen/io/xtb/inputs.py
@@ -6,10 +6,12 @@ from __future__ import annotations
 
 import logging
 import os
+from typing import TYPE_CHECKING
 
 from monty.json import MSONable
 
-from pymatgen.core import Molecule
+if TYPE_CHECKING:
+    from pymatgen.core import Molecule
 
 __author__ = "Alex Epstein"
 __copyright__ = "Copyright 2020, The Materials Project"

--- a/pymatgen/phonon/gruneisen.py
+++ b/pymatgen/phonon/gruneisen.py
@@ -146,9 +146,9 @@ class GruneisenParameter(MSONable):
             theta_d = self.acoustic_debye_temp
         mean_g = self.average_gruneisen(t=theta_d, squared=squared, limit_frequencies=limit_frequencies)
 
-        f1 = 0.849 * 3 * (4 ** (1.0 / 3.0)) / (20 * np.pi**3 * (1 - 0.514 * mean_g**-1 + 0.228 * mean_g**-2))
+        f1 = 0.849 * 3 * (4 ** (1 / 3)) / (20 * np.pi**3 * (1 - 0.514 * mean_g**-1 + 0.228 * mean_g**-2))
         f2 = (const.k * theta_d / const.hbar) ** 2
-        f3 = const.k * average_mass * self.structure.volume ** (1.0 / 3.0) * 1e-10 / (const.hbar * mean_g**2)
+        f3 = const.k * average_mass * self.structure.volume ** (1 / 3) * 1e-10 / (const.hbar * mean_g**2)
         k = f1 * f2 * f3
 
         if t is not None:

--- a/pymatgen/symmetry/analyzer.py
+++ b/pymatgen/symmetry/analyzer.py
@@ -19,18 +19,20 @@ from collections import defaultdict
 from fractions import Fraction
 from functools import lru_cache
 from math import cos, sin
-from typing import Any, Literal, Sequence
+from typing import TYPE_CHECKING, Any, Literal, Sequence
 
 import numpy as np
 import spglib
 
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.operations import SymmOp
-from pymatgen.core.periodic_table import Element, Species
-from pymatgen.core.sites import Site
 from pymatgen.core.structure import Molecule, PeriodicSite, Structure
 from pymatgen.symmetry.structure import SymmetrizedStructure
 from pymatgen.util.coord import find_in_coord_list, pbc_diff
+
+if TYPE_CHECKING:
+    from pymatgen.core.periodic_table import Element, Species
+    from pymatgen.core.sites import Site
 
 logger = logging.getLogger(__name__)
 

--- a/pymatgen/symmetry/groups.py
+++ b/pymatgen/symmetry/groups.py
@@ -23,9 +23,11 @@ from pymatgen.util.string import Stringify
 
 if TYPE_CHECKING:
     # don't import at runtime to avoid circular import
+    from numpy.typing import ArrayLike
+
     from pymatgen.core.lattice import Lattice
-    from pymatgen.core.operations import SymmOp
-    from pymatgen.util.typing import ArrayLike
+    from pymatgen.core.operations import SymmOp  # noqa: TCH004
+
 
 SYMM_DATA = None
 

--- a/pymatgen/symmetry/kpath.py
+++ b/pymatgen/symmetry/kpath.py
@@ -607,8 +607,8 @@ class KPathSetyawanCurtarolo(KPathBase):
         kpoints = {
             "\\Gamma": np.array([0.0, 0.0, 0.0]),
             "A": np.array([0.0, 0.0, 0.5]),
-            "H": np.array([1.0 / 3.0, 1.0 / 3.0, 0.5]),
-            "K": np.array([1.0 / 3.0, 1.0 / 3.0, 0.0]),
+            "H": np.array([1 / 3, 1 / 3, 0.5]),
+            "K": np.array([1 / 3, 1 / 3, 0.0]),
             "L": np.array([0.5, 0.0, 0.5]),
             "M": np.array([0.5, 0.0, 0.0]),
         }
@@ -625,18 +625,18 @@ class KPathSetyawanCurtarolo(KPathBase):
         """
         self.name = "RHL1"
         eta = (1 + 4 * cos(alpha)) / (2 + 4 * cos(alpha))
-        nu = 3.0 / 4.0 - eta / 2.0
+        nu = 3 / 4 - eta / 2.0
         kpoints = {
             "\\Gamma": np.array([0.0, 0.0, 0.0]),
-            "B": np.array([eta, 0.5, 1.0 - eta]),
-            "B_1": np.array([1.0 / 2.0, 1.0 - eta, eta - 1.0]),
+            "B": np.array([eta, 0.5, 1 - eta]),
+            "B_1": np.array([1 / 2.0, 1 - eta, eta - 1.0]),
             "F": np.array([0.5, 0.5, 0.0]),
             "L": np.array([0.5, 0.0, 0.0]),
             "L_1": np.array([0.0, 0.0, -0.5]),
             "P": np.array([eta, nu, nu]),
-            "P_1": np.array([1.0 - nu, 1.0 - nu, 1.0 - eta]),
+            "P_1": np.array([1 - nu, 1 - nu, 1 - eta]),
             "P_2": np.array([nu, nu, eta - 1.0]),
-            "Q": np.array([1.0 - nu, nu, 0.0]),
+            "Q": np.array([1 - nu, nu, 0.0]),
             "X": np.array([nu, 0.0, -nu]),
             "Z": np.array([0.5, 0.5, 0.5]),
         }
@@ -654,7 +654,7 @@ class KPathSetyawanCurtarolo(KPathBase):
         """
         self.name = "RHL2"
         eta = 1 / (2 * tan(alpha / 2.0) ** 2)
-        nu = 3.0 / 4.0 - eta / 2.0
+        nu = 3 / 4 - eta / 2.0
         kpoints = {
             "\\Gamma": np.array([0.0, 0.0, 0.0]),
             "F": np.array([0.5, -0.5, 0.0]),
@@ -662,7 +662,7 @@ class KPathSetyawanCurtarolo(KPathBase):
             "P": np.array([1 - nu, -nu, 1 - nu]),
             "P_1": np.array([nu, nu - 1.0, nu - 1.0]),
             "Q": np.array([eta, eta, eta]),
-            "Q_1": np.array([1.0 - eta, -eta, -eta]),
+            "Q_1": np.array([1 - eta, -eta, -eta]),
             "Z": np.array([0.5, -0.5, 0.5]),
         }
         path = [["\\Gamma", "P", "Z", "Q", "\\Gamma", "F", "P_1", "Q_1", "L", "Z"]]
@@ -682,10 +682,10 @@ class KPathSetyawanCurtarolo(KPathBase):
             "D": np.array([0.5, 0.0, 0.5]),
             "D_1": np.array([0.5, 0.5, -0.5]),
             "E": np.array([0.5, 0.5, 0.5]),
-            "H": np.array([0.0, eta, 1.0 - nu]),
-            "H_1": np.array([0.0, 1.0 - eta, nu]),
+            "H": np.array([0.0, eta, 1 - nu]),
+            "H_1": np.array([0.0, 1 - eta, nu]),
             "H_2": np.array([0.0, eta, -nu]),
-            "M": np.array([0.5, eta, 1.0 - nu]),
+            "M": np.array([0.5, eta, 1 - nu]),
             "M_1": np.array([0.5, 1 - eta, nu]),
             "M_2": np.array([0.5, 1 - eta, nu]),
             "X": np.array([0.0, 0.5, 0.0]),
@@ -1483,7 +1483,7 @@ class KPathLatimerMunro(KPathBase):
         for i, facet in enumerate(bz):
             bz_as_key_point_inds.append([])
             for j, vert in enumerate(facet):
-                edge_center = (vert + facet[j + 1]) / 2.0 if j != len(facet) - 1 else (vert + facet[0]) / 2.0
+                edge_center = (vert + facet[j + 1]) / 2 if j != len(facet) - 1 else (vert + facet[0]) / 2.0
                 duplicatevert = False
                 duplicateedge = False
                 for k, point in enumerate(key_points):
@@ -1807,7 +1807,7 @@ class KPathLatimerMunro(KPathBase):
         if len(pos1) != len(pos2):
             return False
         for idx, p1 in enumerate(pos1):
-            if abs(p1 - pos2[idx]) > tolerance[idx] and abs(p1 - pos2[idx]) < 1.0 - tolerance[idx]:
+            if abs(p1 - pos2[idx]) > tolerance[idx] and abs(p1 - pos2[idx]) < 1 - tolerance[idx]:
                 return False
         return True
 

--- a/pymatgen/symmetry/kpath.py
+++ b/pymatgen/symmetry/kpath.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import abc
 import itertools
 from math import ceil, cos, e, pi, sin, tan
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from warnings import warn
 
 import networkx as nx
@@ -18,14 +18,16 @@ from scipy.linalg import sqrtm
 
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.operations import MagSymmOp, SymmOp
-from pymatgen.core.structure import Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
-from pymatgen.util.typing import SpeciesLike
 
 try:
     from seekpath import get_path
 except ImportError:
     get_path = None
+
+if TYPE_CHECKING:
+    from pymatgen.core.structure import Structure
+    from pymatgen.util.typing import SpeciesLike
 
 __author__ = "Geoffroy Hautier, Katherine Latimer, Jason Munro"
 __copyright__ = "Copyright 2020, The Materials Project"

--- a/pymatgen/symmetry/maggroups.py
+++ b/pymatgen/symmetry/maggroups.py
@@ -9,20 +9,21 @@ import sqlite3
 import textwrap
 from array import array
 from fractions import Fraction
-from typing import Sequence
+from typing import TYPE_CHECKING, Sequence
 
 import numpy as np
 from monty.design_patterns import cached_class
 
-from pymatgen.core.lattice import Lattice
 from pymatgen.core.operations import MagSymmOp
 from pymatgen.electronic_structure.core import Magmom
 from pymatgen.symmetry.groups import SymmetryGroup, in_array_list
 from pymatgen.symmetry.settings import JonesFaithfulTransformation
 from pymatgen.util.string import transformation_to_string
 
-__author__ = "Matthew Horton, Shyue Ping Ong"
+if TYPE_CHECKING:
+    from pymatgen.core.lattice import Lattice
 
+__author__ = "Matthew Horton, Shyue Ping Ong"
 
 MAGSYMM_DATA = os.path.join(os.path.dirname(__file__), "symm_data_magnetic.sqlite")
 

--- a/pymatgen/symmetry/site_symmetries.py
+++ b/pymatgen/symmetry/site_symmetries.py
@@ -4,11 +4,15 @@ Provides analysis of site symmetries.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 
 from pymatgen.core.operations import SymmOp
-from pymatgen.core.structure import Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
+
+if TYPE_CHECKING:
+    from pymatgen.core.structure import Structure
 
 
 def get_site_symmetries(struct: Structure, precision: float = 0.1) -> list[list[SymmOp]]:

--- a/pymatgen/transformations/site_transformations.py
+++ b/pymatgen/transformations/site_transformations.py
@@ -11,16 +11,19 @@ import itertools
 import logging
 import math
 import time
+from typing import TYPE_CHECKING
 
 import numpy as np
 from monty.json import MSONable
 
 from pymatgen.analysis.ewald import EwaldMinimizer, EwaldSummation
 from pymatgen.analysis.local_env import MinimumDistanceNN
-from pymatgen.core.sites import PeriodicSite
-from pymatgen.core.structure import Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.transformations.transformation_abc import AbstractTransformation
+
+if TYPE_CHECKING:
+    from pymatgen.core.sites import PeriodicSite
+    from pymatgen.core.structure import Structure
 
 
 class InsertSitesTransformation(AbstractTransformation):

--- a/pymatgen/transformations/standard_transformations.py
+++ b/pymatgen/transformations/standard_transformations.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 from fractions import Fraction
+from typing import TYPE_CHECKING
 
 from numpy import around
 
@@ -19,14 +20,16 @@ from pymatgen.analysis.structure_matcher import StructureMatcher
 from pymatgen.core.composition import Composition
 from pymatgen.core.operations import SymmOp
 from pymatgen.core.periodic_table import get_el_sp
-from pymatgen.core.sites import PeriodicSite
 from pymatgen.core.structure import Lattice, Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.transformations.site_transformations import (
     PartialRemoveSitesTransformation,
 )
 from pymatgen.transformations.transformation_abc import AbstractTransformation
-from pymatgen.util.typing import SpeciesLike
+
+if TYPE_CHECKING:
+    from pymatgen.core.sites import PeriodicSite
+    from pymatgen.util.typing import SpeciesLike
 
 logger = logging.getLogger(__name__)
 
@@ -316,7 +319,7 @@ class SubstitutionTransformation(AbstractTransformation):
         self._species_map = dict(species_map)
         for k, v in self._species_map.items():
             if isinstance(v, (tuple, list)):
-                self._species_map[k] = dict(v)  # type: ignore
+                self._species_map[k] = dict(v)  # type: ignore[assignment]
 
     def apply_transformation(self, structure: Structure) -> Structure:
         """

--- a/pymatgen/transformations/transformation_abc.py
+++ b/pymatgen/transformations/transformation_abc.py
@@ -5,10 +5,12 @@ Defines an abstract base class contract for Transformation object.
 from __future__ import annotations
 
 import abc
+from typing import TYPE_CHECKING
 
 from monty.json import MSONable
 
-from pymatgen.core import Structure
+if TYPE_CHECKING:
+    from pymatgen.core import Structure
 
 __author__ = "Shyue Ping Ong"
 __copyright__ = "Copyright 2011, The Materials Project"

--- a/pymatgen/util/coord.py
+++ b/pymatgen/util/coord.py
@@ -16,7 +16,7 @@ from monty.json import MSONable
 from pymatgen.util import coord_cython as cuc
 
 if typing.TYPE_CHECKING:
-    from pymatgen.util.typing import ArrayLike
+    from numpy.typing import ArrayLike
 
 
 # array size threshold for looping instead of broadcasting

--- a/pymatgen/util/typing.py
+++ b/pymatgen/util/typing.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Sequence, Union
 
 import numpy as np
-from numpy.typing import ArrayLike as ArrayLike
 
 from pymatgen.core.composition import Composition
 from pymatgen.core.periodic_table import DummySpecies, Element, Species

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ select = [
   "RSE", # flake8-raise
   "RUF", # Ruff-specific rules
   "SIM", # flake8-simplify
+  "TCH", # flake8-type-checking
   "TID", # tidy imports
   "UP",  # pyupgrade
   "W",   # pycodestyle warning


### PR DESCRIPTION
Significantly reduces the chance of circular imports.