### PR TITLE
Support writing structures to compressed JSON (.json.gz .json.bz2 .json.xz .json.lzma)

### DIFF
--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -2493,19 +2493,19 @@ class IStructure(SiteCollection, MSONable):
             from pymatgen.io.cssr import Cssr
 
             writer = Cssr(self)  # type: ignore
-        elif fmt == "json" or fnmatch(filename.lower(), "*.json"):
-            s = json.dumps(self.as_dict())
+        elif fmt == "json" or fnmatch(filename.lower(), "*.json*"):
+            dct = json.dumps(self.as_dict())
             if filename:
-                with zopen(filename, "wt") as f:
-                    f.write(s)
-            return s
+                with zopen(filename, "wt") as file:
+                    file.write(dct)
+            return dct
         elif fmt == "xsf" or fnmatch(filename.lower(), "*.xsf*"):
             from pymatgen.io.xcrysden import XSF
 
             s = XSF(self).to_string()
             if filename:
-                with zopen(filename, "wt", encoding="utf8") as f:
-                    f.write(s)
+                with zopen(filename, "wt", encoding="utf8") as file:
+                    file.write(s)
             return s
         elif (
             fmt == "mcsqs"
@@ -2517,8 +2517,8 @@ class IStructure(SiteCollection, MSONable):
 
             s = Mcsqs(self).to_string()
             if filename:
-                with zopen(filename, "wt", encoding="ascii") as f:
-                    f.write(s)
+                with zopen(filename, "wt", encoding="ascii") as file:
+                    file.write(s)
             return s
         elif fmt == "prismatic" or fnmatch(filename, "*prismatic*"):
             from pymatgen.io.prismatic import Prismatic
@@ -2528,8 +2528,8 @@ class IStructure(SiteCollection, MSONable):
         elif fmt == "yaml" or fnmatch(filename, "*.yaml*") or fnmatch(filename, "*.yml*"):
             yaml = YAML()
             if filename:
-                with zopen(filename, "wt") as f:
-                    yaml.dump(self.as_dict(), f)
+                with zopen(filename, "wt") as file:
+                    yaml.dump(self.as_dict(), file)
                 return None
             sio = StringIO()
             yaml.dump(self.as_dict(), sio)
@@ -2543,8 +2543,8 @@ class IStructure(SiteCollection, MSONable):
 
             s = ResIO.structure_to_str(self)
             if filename:
-                with zopen(filename, "wt", encoding="utf8") as f:
-                    f.write(s)
+                with zopen(filename, "wt", encoding="utf8") as file:
+                    file.write(s)
                 return None
             return s
         else:

--- a/pymatgen/core/tests/test_structure.py
+++ b/pymatgen/core/tests/test_structure.py
@@ -701,10 +701,10 @@ Direct
             assert "Fd-3m" in self.struct.to(fmt="CIF", symprec=0.1)
 
             self.struct.to(filename="POSCAR.testing")
-            assert os.path.exists("POSCAR.testing")
+            assert os.path.isfile("POSCAR.testing")
 
             self.struct.to(filename="Si_testing.yaml")
-            assert os.path.exists("Si_testing.yaml")
+            assert os.path.isfile("Si_testing.yaml")
             struct = Structure.from_file("Si_testing.yaml")
             assert struct == self.struct
             # Test Path support
@@ -1071,6 +1071,7 @@ class StructureTest(PymatgenTest):
 
     def test_to_from_file_string(self):
         with ScratchDir("."):
+            # to/from string
             for fmt in ["cif", "json", "poscar", "cssr", "yaml", "xsf", "res"]:
                 s = self.structure.to(fmt=fmt)
                 assert s is not None
@@ -1079,11 +1080,14 @@ class StructureTest(PymatgenTest):
                 self.assertArrayAlmostEqual(ss.frac_coords, self.structure.frac_coords)
                 assert isinstance(ss, Structure)
 
+            # to/from file
             self.structure.to(filename="POSCAR.testing")
-            assert os.path.exists("POSCAR.testing")
+            assert os.path.isfile("POSCAR.testing")
 
-            self.structure.to(filename="structure_testing.json")
-            assert Structure.from_file("structure_testing.json") == self.structure
+            for ext in (".json", ".json.gz", ".json.bz2", ".json.xz", ".json.lzma"):
+                self.structure.to(filename=f"json-struct{ext}")
+                assert os.path.isfile(f"json-struct{ext}")
+                assert Structure.from_file(f"json-struct{ext}") == self.structure
 
     def test_from_spacegroup(self):
         s1 = Structure.from_spacegroup("Fm-3m", Lattice.cubic(3), ["Li", "O"], [[0.25, 0.25, 0.25], [0, 0, 0]])
@@ -1611,10 +1615,10 @@ Site: H (-0.5134, 0.8892, -0.3630)"""
             assert isinstance(m, IMolecule)
 
         self.mol.to(filename="CH4_testing.xyz")
-        assert os.path.exists("CH4_testing.xyz")
+        assert os.path.isfile("CH4_testing.xyz")
         os.remove("CH4_testing.xyz")
         self.mol.to(filename="CH4_testing.yaml")
-        assert os.path.exists("CH4_testing.yaml")
+        assert os.path.isfile("CH4_testing.yaml")
         mol = Molecule.from_file("CH4_testing.yaml")
         assert self.mol == mol
         os.remove("CH4_testing.yaml")
@@ -1769,7 +1773,7 @@ class MoleculeTest(PymatgenTest):
             assert isinstance(m, Molecule)
 
         self.mol.to(filename="CH4_testing.xyz")
-        assert os.path.exists("CH4_testing.xyz")
+        assert os.path.isfile("CH4_testing.xyz")
         os.remove("CH4_testing.xyz")
 
     def test_extract_cluster(self):

--- a/pymatgen/ext/tests/test_optimade.py
+++ b/pymatgen/ext/tests/test_optimade.py
@@ -51,16 +51,18 @@ class OptimadeTest(PymatgenTest):
             response_field_structs_set = optimade.get_snls(
                 elements=["Ga", "N"], nelements=2, additional_response_fields={"nsites", "nelements"}
             )
-            if ("mp" in response_field_structs_single) and ("mp" in response_field_structs_set):
+            if "mp" in response_field_structs_single:
                 assert len(structs["mp"]) == len(response_field_structs_single["mp"])
+                struct_nl = list(response_field_structs_single["mp"].values())[0]
+                assert "nsites" in struct_nl.data["_optimade"]
+
+            if "mp" in response_field_structs_set:
                 assert len(structs["mp"]) == len(response_field_structs_set["mp"])
 
                 # Check that the requested response fields appear in the SNL metadata
-                s = list(response_field_structs_single["mp"].values())[0]
-                sp = list(response_field_structs_set["mp"].values())[0]
-                assert "nsites" in s.data["_optimade"]
-                assert "nsites" in sp.data["_optimade"]
-                assert "nelements" in sp.data["_optimade"]
+                struct_nl_set = list(response_field_structs_set["mp"].values())[0]
+                assert "nsites" in struct_nl_set.data["_optimade"]
+                assert "nelements" in struct_nl_set.data["_optimade"]
 
     # Tests fail in CI for unknown reason, use for development only.
     # def test_get_structures_mcloud_2dstructures(self):


### PR DESCRIPTION
 ffae4ea4e support writing structures to compressed JSON files
 ba9918395 check structure equality writing and reading from .json.gz .json.bz2 .json.xz .json.lzma

Related: #2994 helps with reducing test file sizes