### PR TITLE
Fix `ValueError` when `structure.selective_dynamics` has type `np.array`

### DIFF
--- a/pymatgen/io/ase.py
+++ b/pymatgen/io/ase.py
@@ -14,14 +14,12 @@ from pymatgen.core.structure import Molecule, Structure
 
 try:
     from ase import Atoms
+    from ase.calculators.singlepoint import SinglePointDFTCalculator
+    from ase.constraints import FixAtoms
 
     ase_loaded = True
 except ImportError:
     ase_loaded = False
-
-if ase_loaded:
-    from ase.calculators.singlepoint import SinglePointDFTCalculator
-    from ase.constraints import FixAtoms
 
 __author__ = "Shyue Ping Ong, Andrew S. Rosen"
 __copyright__ = "Copyright 2012, The Materials Project"
@@ -52,18 +50,16 @@ class AseAtomsAdaptor:
             raise ValueError("ASE Atoms only supports ordered structures")
         if not ase_loaded:
             raise ImportError(
-                "AseAtomsAdaptor requires the ASE package.\nUse `pip install ase` or `conda install ase -c conda-forge`"
+                "AseAtomsAdaptor requires the ASE package.\n"
+                "Use `pip install ase` or `conda install ase -c conda-forge`"
             )
 
         # Construct the base ASE Atoms object
         symbols = [str(site.specie.symbol) for site in structure]
         positions = [site.coords for site in structure]
-        if hasattr(structure, "lattice"):
-            cell = structure.lattice.matrix
-            pbc = True
-        else:
-            cell = None
-            pbc = None
+        is_struct = hasattr(structure, "lattice")
+        pbc = True if is_struct else None
+        cell = structure.lattice.matrix if is_struct else None
 
         atoms = Atoms(symbols=symbols, positions=positions, pbc=pbc, cell=cell, **kwargs)
 

--- a/pymatgen/io/ase.py
+++ b/pymatgen/io/ase.py
@@ -7,10 +7,15 @@ Atoms object and pymatgen Structure objects.
 from __future__ import annotations
 
 import warnings
+from typing import TYPE_CHECKING
 
 import numpy as np
 
 from pymatgen.core.structure import Molecule, Structure
+
+if TYPE_CHECKING:
+    from numpy.typing import ArrayLike
+
 
 try:
     from ase import Atoms
@@ -99,11 +104,11 @@ class AseAtomsAdaptor:
         if "selective_dynamics" in structure.site_properties:
             fix_atoms = []
             for site in structure:
-                selective_dynamics = site.properties.get("selective_dynamics")
-                if not np.all(selective_dynamics) and not np.any(selective_dynamics):
+                selective_dynamics: ArrayLike = site.properties.get("selective_dynamics")  # type: ignore[assignment]
+                if not (np.all(selective_dynamics) or not np.any(selective_dynamics)):
                     # should be [True, True, True] or [False, False, False]
                     raise ValueError(
-                        "ASE FixAtoms constraint does not support selective dynamics in only some dimensions."
+                        "ASE FixAtoms constraint does not support selective dynamics in only some dimensions. "
                         f"Remove the {selective_dynamics=} and try again if you do not need them."
                     )
                 is_fixed = bool(~np.all(site.properties["selective_dynamics"]))

--- a/pymatgen/io/ase.py
+++ b/pymatgen/io/ase.py
@@ -99,11 +99,12 @@ class AseAtomsAdaptor:
         if "selective_dynamics" in structure.site_properties:
             fix_atoms = []
             for site in structure:
-                site_prop = site.properties["selective_dynamics"]
-                if site_prop not in [[True, True, True], [False, False, False]]:
+                selective_dynamics = site.properties.get("selective_dynamics")
+                if not np.all(selective_dynamics) and not np.any(selective_dynamics):
+                    # should be [True, True, True] or [False, False, False]
                     raise ValueError(
                         "ASE FixAtoms constraint does not support selective dynamics in only some dimensions."
-                        "Remove the selective dynamics and try again if you do not need them."
+                        f"Remove the {selective_dynamics=} and try again if you do not need them."
                     )
                 is_fixed = bool(~np.all(site.properties["selective_dynamics"]))
                 fix_atoms.append(is_fixed)


### PR DESCRIPTION
Closes #3011.

 71e888dd9 refactor LammpsData.get_string()
 a1d3509b6 refactor ase import, AseAtomsAdaptor.get_atoms() check is_struct
 a21543c71 fix ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all() when structure.selective_dynamics has type np.array
 bf56232bb add cases testing selective_dynamics as list and array to test_get_structure_dyn()