### PR TITLE
Breaking: Overhaul `class PymatgenTest`

### DIFF
--- a/pymatgen/analysis/chemenv/coordination_environments/tests/test_coordination_geometries.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/tests/test_coordination_geometries.py
@@ -106,7 +106,7 @@ class CoordinationGeometriesTest(PymatgenTest):
             [[-1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, -1.0, 0.0]],
             [[-1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, -1.0]],
         ]
-        self.assertArrayAlmostEqual(cg_oct.faces(sites=sites, permutation=[0, 3, 2, 4, 5, 1]), faces)
+        self.assert_all_close(cg_oct.faces(sites=sites, permutation=[0, 3, 2, 4, 5, 1]), faces)
 
         faces = [
             [[0.0, 0.0, 1.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
@@ -118,7 +118,7 @@ class CoordinationGeometriesTest(PymatgenTest):
             [[0.0, 0.0, -1.0], [-1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
             [[0.0, 0.0, -1.0], [-1.0, 0.0, 0.0], [0.0, -1.0, 0.0]],
         ]
-        self.assertArrayAlmostEqual(cg_oct.faces(sites=sites), faces)
+        self.assert_all_close(cg_oct.faces(sites=sites), faces)
 
         edges = [
             [[0.0, 0.0, 1.0], [1.0, 0.0, 0.0]],
@@ -134,7 +134,7 @@ class CoordinationGeometriesTest(PymatgenTest):
             [[0.0, 1.0, 0.0], [0.0, -1.0, 0.0]],
             [[0.0, 1.0, 0.0], [0.0, 0.0, -1.0]],
         ]
-        self.assertArrayAlmostEqual(cg_oct.edges(sites=sites, permutation=[0, 3, 2, 4, 5, 1]), edges)
+        self.assert_all_close(cg_oct.edges(sites=sites, permutation=[0, 3, 2, 4, 5, 1]), edges)
 
         edges = [
             [[0.0, 0.0, 1.0], [1.0, 0.0, 0.0]],
@@ -150,9 +150,9 @@ class CoordinationGeometriesTest(PymatgenTest):
             [[-1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
             [[-1.0, 0.0, 0.0], [0.0, -1.0, 0.0]],
         ]
-        self.assertArrayAlmostEqual(cg_oct.edges(sites=sites), edges)
+        self.assert_all_close(cg_oct.edges(sites=sites), edges)
 
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             cg_oct.solid_angles(),
             [2.0943951, 2.0943951, 2.0943951, 2.0943951, 2.0943951, 2.0943951],
         )

--- a/pymatgen/analysis/chemenv/coordination_environments/tests/test_coordination_geometry_finder.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/tests/test_coordination_geometry_finder.py
@@ -39,9 +39,9 @@ class CoordinationGeometryFinderTest(PymatgenTest):
         cg_ts3 = self.lgf.allcg["TS:3"]
         cg_tet = self.lgf.allcg["T:4"]
         abstract_geom = AbstractGeometry.from_cg(cg=cg_ts3, centering_type="central_site")
-        self.assertArrayAlmostEqual(abstract_geom.centre, [0.0, 0.0, 0.0])
+        self.assert_all_close(abstract_geom.centre, [0.0, 0.0, 0.0])
         abstract_geom = AbstractGeometry.from_cg(cg=cg_ts3, centering_type="centroid")
-        self.assertArrayAlmostEqual(abstract_geom.centre, [0.0, 0.0, 0.33333333333])
+        self.assert_all_close(abstract_geom.centre, [0.0, 0.0, 0.33333333333])
         with pytest.raises(ValueError) as exc_info:
             AbstractGeometry.from_cg(
                 cg=cg_ts3,
@@ -55,7 +55,7 @@ class CoordinationGeometryFinderTest(PymatgenTest):
         abstract_geom = AbstractGeometry.from_cg(
             cg=cg_ts3, centering_type="centroid", include_central_site_in_centroid=True
         )
-        self.assertArrayAlmostEqual(abstract_geom.centre, [0.0, 0.0, 0.25])
+        self.assert_all_close(abstract_geom.centre, [0.0, 0.0, 0.25])
 
         # WHY ARE WE TESTING STRINGS????
         # self.assertEqual(str(abstract_geom)),

--- a/pymatgen/analysis/chemenv/coordination_environments/tests/test_read_write.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/tests/test_read_write.py
@@ -7,6 +7,7 @@ import unittest
 
 import numpy as np
 import pytest
+from numpy.testing import assert_array_almost_equal
 
 from pymatgen.analysis.chemenv.coordination_environments.chemenv_strategies import (
     AngleNbSetWeight,
@@ -115,8 +116,8 @@ class ReadWriteChemenvTest(unittest.TestCase):
 
         neighb_coords = nb_set.coords
 
-        np.testing.assert_array_almost_equal(coords, neighb_coords[1:])
-        np.testing.assert_array_almost_equal(nb_set.structure[nb_set.isite].coords, neighb_coords[0])
+        assert_array_almost_equal(coords, neighb_coords[1:])
+        assert_array_almost_equal(nb_set.structure[nb_set.isite].coords, neighb_coords[0])
 
         norm_dist = nb_set.normalized_distances
         assert sorted(norm_dist) == pytest.approx(sorted([1.001792, 1.001792, 1, 1.0]))

--- a/pymatgen/analysis/chemenv/coordination_environments/tests/test_structure_environments.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/tests/test_structure_environments.py
@@ -7,6 +7,7 @@ import unittest
 import numpy as np
 import pytest
 from monty.tempfile import ScratchDir
+from numpy.testing import assert_array_almost_equal
 
 from pymatgen.analysis.chemenv.coordination_environments.chemenv_strategies import (
     MultiWeightsChemenvStrategy,
@@ -39,18 +40,12 @@ class StructureEnvironmentsTest(PymatgenTest):
             se = StructureEnvironments.from_dict(dd)
             isite = 6
             csm_and_maps_fig, csm_and_maps_subplot = se.get_csm_and_maps(isite=isite)
-            np.testing.assert_array_almost_equal(
-                csm_and_maps_subplot.lines[0].get_xydata().flatten(), [0.0, 0.53499332]
-            )
-            np.testing.assert_array_almost_equal(
-                csm_and_maps_subplot.lines[1].get_xydata().flatten(), [1.0, 0.47026441]
-            )
-            np.testing.assert_array_almost_equal(
-                csm_and_maps_subplot.lines[2].get_xydata().flatten(), [2.0, 0.00988778]
-            )
+            assert_array_almost_equal(csm_and_maps_subplot.lines[0].get_xydata().flatten(), [0.0, 0.53499332])
+            assert_array_almost_equal(csm_and_maps_subplot.lines[1].get_xydata().flatten(), [1.0, 0.47026441])
+            assert_array_almost_equal(csm_and_maps_subplot.lines[2].get_xydata().flatten(), [2.0, 0.00988778])
 
             environments_figure, environments_subplot = se.get_environments_figure(isite=isite)
-            np.testing.assert_array_almost_equal(
+            assert_array_almost_equal(
                 np.array(environments_subplot.patches[0].get_xy()),
                 [
                     [1.0, 1.0],
@@ -60,7 +55,7 @@ class StructureEnvironmentsTest(PymatgenTest):
                     [1.0, 1.0],
                 ],
             )
-            np.testing.assert_array_almost_equal(
+            assert_array_almost_equal(
                 np.array(environments_subplot.patches[1].get_xy()),
                 [
                     [1.0, 0.99301365],
@@ -70,7 +65,7 @@ class StructureEnvironmentsTest(PymatgenTest):
                     [1.0, 0.99301365],
                 ],
             )
-            np.testing.assert_array_almost_equal(
+            assert_array_almost_equal(
                 np.array(environments_subplot.patches[2].get_xy()),
                 [
                     [1.00179228, 1.0],
@@ -80,7 +75,7 @@ class StructureEnvironmentsTest(PymatgenTest):
                     [1.00179228, 1.0],
                 ],
             )
-            np.testing.assert_array_almost_equal(
+            assert_array_almost_equal(
                 np.array(environments_subplot.patches[3].get_xy()),
                 [
                     [1.00179228, 0.99301365],
@@ -92,7 +87,7 @@ class StructureEnvironmentsTest(PymatgenTest):
                     [1.00179228, 0.99301365],
                 ],
             )
-            np.testing.assert_array_almost_equal(
+            assert_array_almost_equal(
                 np.array(environments_subplot.patches[4].get_xy()),
                 [
                     [2.22376156, 0.0060837],
@@ -118,7 +113,7 @@ class StructureEnvironmentsTest(PymatgenTest):
             assert symbol == "T:4"
             assert min_geometry["symmetry_measure"] == pytest.approx(0.00988778424054)
 
-            np.testing.assert_array_almost_equal(
+            assert_array_almost_equal(
                 min_geometry["other_symmetry_measures"]["rotation_matrix_wcs_csc"],
                 [
                     [-0.8433079817973094, -0.19705747216466898, 0.5000000005010193],
@@ -175,13 +170,13 @@ class StructureEnvironmentsTest(PymatgenTest):
             neighb_indices = [0, 3, 5, 1]
             neighb_images = [[0, 0, -1], [0, 0, 0], [0, 0, -1], [0, 0, 0]]
 
-            np.testing.assert_array_almost_equal(neighb_coords, nb_set.neighb_coords)
-            np.testing.assert_array_almost_equal(neighb_coords, [s.coords for s in nb_set.neighb_sites])
+            assert_array_almost_equal(neighb_coords, nb_set.neighb_coords)
+            assert_array_almost_equal(neighb_coords, [s.coords for s in nb_set.neighb_sites])
             nb_sai = nb_set.neighb_sites_and_indices
-            np.testing.assert_array_almost_equal(neighb_coords, [sai["site"].coords for sai in nb_sai])
-            np.testing.assert_array_almost_equal(neighb_indices, [sai["index"] for sai in nb_sai])
+            assert_array_almost_equal(neighb_coords, [sai["site"].coords for sai in nb_sai])
+            assert_array_almost_equal(neighb_indices, [sai["index"] for sai in nb_sai])
             nb_iai = nb_set.neighb_indices_and_images
-            np.testing.assert_array_almost_equal(neighb_indices, [iai["index"] for iai in nb_iai])
+            assert_array_almost_equal(neighb_indices, [iai["index"] for iai in nb_iai])
             np.testing.assert_array_equal(neighb_images, [iai["image_cell"] for iai in nb_iai])
 
             assert len(nb_set) == 4
@@ -218,8 +213,8 @@ class StructureEnvironmentsTest(PymatgenTest):
             assert stats["fraction_atom_coordination_environments_present"] == {"Si": {"T:4": 1.0}}
 
             site_info_ce = lse.get_site_info_for_specie_ce(specie=Species("Si", 4), ce_symbol="T:4")
-            np.testing.assert_array_almost_equal(site_info_ce["fractions"], [1.0, 1.0, 1.0])
-            np.testing.assert_array_almost_equal(
+            assert_array_almost_equal(site_info_ce["fractions"], [1.0, 1.0, 1.0])
+            assert_array_almost_equal(
                 site_info_ce["csms"],
                 [0.009887784240541068, 0.009887786546730826, 0.009887787384385317],
             )

--- a/pymatgen/analysis/chemenv/coordination_environments/tests/test_structure_environments.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/tests/test_structure_environments.py
@@ -23,7 +23,7 @@ from pymatgen.util.testing import PymatgenTest
 
 __author__ = "waroquiers"
 
-se_files_dir = os.path.join(
+struct_env_files_dir = os.path.join(
     PymatgenTest.TEST_FILES_DIR,
     "chemenv",
     "structure_environments_files",
@@ -33,7 +33,7 @@ se_files_dir = os.path.join(
 class StructureEnvironmentsTest(PymatgenTest):
     def test_structure_environments(self):
         with ScratchDir("."):
-            with open(f"{se_files_dir}/se_mp-7000.json") as f:
+            with open(f"{struct_env_files_dir}/se_mp-7000.json") as f:
                 dd = json.load(f)
 
             se = StructureEnvironments.from_dict(dd)
@@ -155,7 +155,7 @@ class StructureEnvironmentsTest(PymatgenTest):
 
     def test_light_structure_environments(self):
         with ScratchDir("."):
-            with open(f"{se_files_dir}/se_mp-7000.json") as f:
+            with open(f"{struct_env_files_dir}/se_mp-7000.json") as f:
                 dd = json.load(f)
 
             se = StructureEnvironments.from_dict(dd)
@@ -198,20 +198,20 @@ class StructureEnvironmentsTest(PymatgenTest):
             stats = lse.get_statistics()
 
             neighbors = lse.strategy.get_site_neighbors(site=lse.structure[isite])
-            self.assertArrayAlmostEqual(neighbors[0].coords, np.array([0.2443798, 1.80409653, -1.13218359]))
-            self.assertArrayAlmostEqual(neighbors[1].coords, np.array([1.44020353, 1.11368738, 1.13218359]))
-            self.assertArrayAlmostEqual(neighbors[2].coords, np.array([2.75513098, 2.54465207, -0.70467298]))
-            self.assertArrayAlmostEqual(neighbors[3].coords, np.array([0.82616785, 3.65833945, 0.70467298]))
+            self.assert_all_close(neighbors[0].coords, np.array([0.2443798, 1.80409653, -1.13218359]))
+            self.assert_all_close(neighbors[1].coords, np.array([1.44020353, 1.11368738, 1.13218359]))
+            self.assert_all_close(neighbors[2].coords, np.array([2.75513098, 2.54465207, -0.70467298]))
+            self.assert_all_close(neighbors[3].coords, np.array([0.82616785, 3.65833945, 0.70467298]))
 
             equiv_site_index_and_transform = lse.strategy.equivalent_site_index_and_transform(neighbors[0])
             assert equiv_site_index_and_transform[0] == 0
-            self.assertArrayAlmostEqual(equiv_site_index_and_transform[1], [0.0, 0.0, 0.0])
-            self.assertArrayAlmostEqual(equiv_site_index_and_transform[2], [0.0, 0.0, -1.0])
+            self.assert_all_close(equiv_site_index_and_transform[1], [0.0, 0.0, 0.0])
+            self.assert_all_close(equiv_site_index_and_transform[2], [0.0, 0.0, -1.0])
 
             equiv_site_index_and_transform = lse.strategy.equivalent_site_index_and_transform(neighbors[1])
             assert equiv_site_index_and_transform[0] == 3
-            self.assertArrayAlmostEqual(equiv_site_index_and_transform[1], [0.0, 0.0, 0.0])
-            self.assertArrayAlmostEqual(equiv_site_index_and_transform[2], [0.0, 0.0, 0.0])
+            self.assert_all_close(equiv_site_index_and_transform[1], [0.0, 0.0, 0.0])
+            self.assert_all_close(equiv_site_index_and_transform[2], [0.0, 0.0, 0.0])
 
             assert stats["atom_coordination_environments_present"] == {"Si": {"T:4": 3.0}}
             assert stats["coordination_environments_atom_present"] == {"T:4": {"Si": 3.0}}

--- a/pymatgen/analysis/chemenv/utils/tests/test_coordination_geometry_utils.py
+++ b/pymatgen/analysis/chemenv/utils/tests/test_coordination_geometry_utils.py
@@ -24,7 +24,7 @@ class PlanesUtilsTest(PymatgenTest):
 
     def test_factors_abcd_normal_vector(self):
         factors = self.plane.coefficients / self.expected_coefficients
-        self.assertArrayAlmostEqual([factors[0]] * 4, list(factors))
+        self.assert_all_close([factors[0]] * 4, list(factors))
         assert np.allclose([2.0 / 3.0, 1.0 / 3.0, -2.0 / 3.0], self.plane.normal_vector)
 
     def test_from_npoints_plane(self):
@@ -244,7 +244,7 @@ class PlanesUtilsTest(PymatgenTest):
         point_8 = np.array([100.0, 0.0, 0.0], np.float_)
         plist = [point_1, point_2, point_4, point_6, point_7, point_8]
         distances, indices_sorted = self.plane.distances_indices_sorted(plist)
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             distances,
             [
                 0.5,
@@ -260,23 +260,23 @@ class PlanesUtilsTest(PymatgenTest):
         plane = Plane.from_coefficients(0, 2, 0, 1)
         plist = [point_1, point_5, point_6, point_7]
         distances, indices_sorted = plane.distances_indices_sorted(plist)
-        self.assertArrayAlmostEqual(distances, [0.5, -1.0, 2.5, 10.5])
+        self.assert_all_close(distances, [0.5, -1.0, 2.5, 10.5])
         assert indices_sorted == [0, 1, 2, 3]
         plist = [point_1, point_5, point_6, point_7]
         distances, indices_sorted = plane.distances_indices_sorted(plist)
-        self.assertArrayAlmostEqual(distances, [0.5, -1.0, 2.5, 10.5])
+        self.assert_all_close(distances, [0.5, -1.0, 2.5, 10.5])
         assert indices_sorted == [0, 1, 2, 3]
         distances, indices_sorted = plane.distances_indices_sorted(plist, sign=True)
-        self.assertArrayAlmostEqual(distances, [0.5, -1.0, 2.5, 10.5])
+        self.assert_all_close(distances, [0.5, -1.0, 2.5, 10.5])
         assert indices_sorted == [(0, 1), (1, -1), (2, 1), (3, 1)]
         plist = [point_5, point_1, point_6, point_7]
         distances, indices_sorted, groups = plane.distances_indices_groups(plist)
-        self.assertArrayAlmostEqual(distances, [-1.0, 0.5, 2.5, 10.5])
+        self.assert_all_close(distances, [-1.0, 0.5, 2.5, 10.5])
         assert indices_sorted == [1, 0, 2, 3]
         assert groups == [[1, 0], [2], [3]]
         plist = [point_1, point_2, point_3, point_4, point_5, point_6, point_7, point_8]
         distances, indices_sorted = plane.distances_indices_sorted(plist)
-        self.assertArrayAlmostEqual(distances, [0.5, 0.5, 0.5, 0.5, -1.0, 2.5, 10.5, 0.5])
+        self.assert_all_close(distances, [0.5, 0.5, 0.5, 0.5, -1.0, 2.5, 10.5, 0.5])
         assert set(indices_sorted[:5]) == {0, 1, 2, 3, 7}
         # Plane z=0 (plane xy)
         plane = Plane.from_coefficients(0, 0, 1, 0)
@@ -287,11 +287,11 @@ class PlanesUtilsTest(PymatgenTest):
         distances, indices_sorted, groups = plane.distances_indices_groups(points=plist, delta=0.25)
         assert indices_sorted == [5, 0, 1, 2, 6, 7, 9, 4, 3, 8]
         assert groups == [[5, 0, 1], [2, 6, 7], [9, 4, 3], [8]]
-        self.assertArrayAlmostEqual(distances, zzs)
+        self.assert_all_close(distances, zzs)
         distances, indices_sorted, groups = plane.distances_indices_groups(points=plist, delta_factor=0.1)
         assert indices_sorted == [5, 0, 1, 2, 6, 7, 9, 4, 3, 8]
         assert groups == [[5, 0, 1, 2, 6, 7], [9, 4, 3], [8]]
-        self.assertArrayAlmostEqual(distances, zzs)
+        self.assert_all_close(distances, zzs)
         distances, indices_sorted, groups = plane.distances_indices_groups(points=plist, delta_factor=0.1, sign=True)
         assert indices_sorted == [(5, 0), (0, 1), (1, -1), (2, 1), (6, -1), (7, -1), (9, 1), (4, -1), (3, -1), (8, -1)]
         assert groups == [
@@ -299,7 +299,7 @@ class PlanesUtilsTest(PymatgenTest):
             [(9, 1), (4, -1), (3, -1)],
             [(8, -1)],
         ]
-        self.assertArrayAlmostEqual(distances, zzs)
+        self.assert_all_close(distances, zzs)
 
     def test_projections(self):
         # Projections of points that are already on the plane

--- a/pymatgen/analysis/chemenv/utils/tests/test_coordination_geometry_utils.py
+++ b/pymatgen/analysis/chemenv/utils/tests/test_coordination_geometry_utils.py
@@ -293,18 +293,7 @@ class PlanesUtilsTest(PymatgenTest):
         assert groups == [[5, 0, 1, 2, 6, 7], [9, 4, 3], [8]]
         self.assertArrayAlmostEqual(distances, zzs)
         distances, indices_sorted, groups = plane.distances_indices_groups(points=plist, delta_factor=0.1, sign=True)
-        assert indices_sorted == [
-            (5, 0),
-            (0, 1),
-            (1, -1),
-            (2, 1),
-            (6, -1),
-            (7, -1),
-            (9, 1),
-            (4, -1),
-            (3, -1),
-            (8, -1),
-        ]
+        assert indices_sorted == [(5, 0), (0, 1), (1, -1), (2, 1), (6, -1), (7, -1), (9, 1), (4, -1), (3, -1), (8, -1)]
         assert groups == [
             [(5, 0), (0, 1), (1, -1), (2, 1), (6, -1), (7, -1)],
             [(9, 1), (4, -1), (3, -1)],

--- a/pymatgen/analysis/chemenv/utils/tests/test_math_utils.py
+++ b/pymatgen/analysis/chemenv/utils/tests/test_math_utils.py
@@ -128,7 +128,7 @@ class MathUtilsTest(PymatgenTest):
     def test_cosinus_step(self):
         vals = np.linspace(5.0, 12.0, num=8)
         assert cosinus_step(vals, edges=[0.0, 1.0]).tolist() == [1.0] * 8
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             cosinus_step(vals, edges=[7.0, 11.0]).tolist(),
             [0.0, 0.0, 0.0, 0.14644660940672616, 0.5, 0.8535533905932737, 1.0, 1.0],
             5,

--- a/pymatgen/analysis/diffraction/tests/test_tem.py
+++ b/pymatgen/analysis/diffraction/tests/test_tem.py
@@ -224,7 +224,7 @@ class TEMCalculatorTest(PymatgenTest):
         # Test if x * p1 + y * p2 yields p3.
         c = TEMCalculator()
         coeffs = c.get_plot_coeffs((1, 1, 0), (1, -1, 0), (2, 0, 0))
-        self.assertArrayAlmostEqual(np.array([1.0, 1.0]), coeffs)
+        self.assert_all_close(np.array([1.0, 1.0]), coeffs)
 
     def test_get_positions(self):
         c = TEMCalculator()
@@ -234,7 +234,7 @@ class TEMCalculatorTest(PymatgenTest):
         assert [0, 0] == positions[(0, 0, 0)].tolist()
         # Test silicon diffraction data spot rough positions:
         # see https://www.doitpoms.ac.uk/tlplib/diffraction-patterns/printall.php
-        self.assertArrayAlmostEqual([1, 0], positions[(-1, 0, 0)], 0)
+        self.assert_all_close([1, 0], positions[(-1, 0, 0)], 0)
 
     def test_TEM_dots(self):
         # All dependencies in TEM_dots method are tested. Only make sure each object created is

--- a/pymatgen/analysis/elasticity/tests/test_elastic.py
+++ b/pymatgen/analysis/elasticity/tests/test_elastic.py
@@ -77,7 +77,7 @@ class ElasticTensorTest(PymatgenTest):
     def test_properties(self):
         # compliance tensor
         ct = ComplianceTensor.from_voigt(np.linalg.inv(self.elastic_tensor_1.voigt))
-        self.assertArrayAlmostEqual(ct, self.elastic_tensor_1.compliance_tensor)
+        self.assert_all_close(ct, self.elastic_tensor_1.compliance_tensor)
         # KG average properties
         assert self.elastic_tensor_1.k_voigt == pytest.approx(38.49111111111)
         assert self.elastic_tensor_1.g_voigt == pytest.approx(22.05866666666)
@@ -91,7 +91,7 @@ class ElasticTensorTest(PymatgenTest):
         # homogeneous Poisson
         assert self.elastic_tensor_1.homogeneous_poisson == pytest.approx(0.26579965576472)
         # voigt notation tensor
-        self.assertArrayAlmostEqual(self.elastic_tensor_1.voigt, self.voigt_1)
+        self.assert_all_close(self.elastic_tensor_1.voigt, self.voigt_1)
         # young's modulus
         assert self.elastic_tensor_1.y_mod == pytest.approx(54087787667.160583)
 
@@ -111,7 +111,7 @@ class ElasticTensorTest(PymatgenTest):
         stress = self.elastic_tensor_1.calculate_stress([0.01] + [0] * 5)
         comp = self.elastic_tensor_1.compliance_tensor
         strain = Strain(comp.einsum_sequence([stress]))
-        self.assertArrayAlmostEqual(strain.voigt, [0.01] + [0] * 5)
+        self.assert_all_close(strain.voigt, [0.01] + [0] * 5)
 
     def test_directional_poisson_ratio(self):
         v_12 = self.elastic_tensor_1.directional_poisson_ratio([1, 0, 0], [0, 1, 0])
@@ -166,25 +166,25 @@ class ElasticTensorTest(PymatgenTest):
         assert noval_sprop_dict["snyder_ac"] is None
 
     def test_new(self):
-        self.assertArrayAlmostEqual(self.elastic_tensor_1, ElasticTensor(self.ft))
-        nonsymm = self.ft
-        nonsymm[0, 1, 2, 2] += 1.0
+        self.assert_all_close(self.elastic_tensor_1, ElasticTensor(self.ft))
+        non_symm = self.ft
+        non_symm[0, 1, 2, 2] += 1.0
         with warnings.catch_warnings(record=True) as w:
-            ElasticTensor(nonsymm)
+            ElasticTensor(non_symm)
             assert len(w) == 1
-        badtensor1 = np.zeros((3, 3, 3))
-        badtensor2 = np.zeros((3, 3, 3, 2))
+        bad_tensor1 = np.zeros((3, 3, 3))
+        bad_tensor2 = np.zeros((3, 3, 3, 2))
         with pytest.raises(ValueError):
-            ElasticTensor(badtensor1)
+            ElasticTensor(bad_tensor1)
         with pytest.raises(ValueError):
-            ElasticTensor(badtensor2)
+            ElasticTensor(bad_tensor2)
 
     def test_from_pseudoinverse(self):
         strain_list = [Strain.from_deformation(def_matrix) for def_matrix in self.def_stress_dict["deformations"]]
         stress_list = list(self.def_stress_dict["stresses"])
         with warnings.catch_warnings(record=True):
             et_fl = -0.1 * ElasticTensor.from_pseudoinverse(strain_list, stress_list).voigt
-            self.assertArrayAlmostEqual(
+            self.assert_all_close(
                 et_fl.round(2),
                 [
                     [59.29, 24.36, 22.46, 0, 0, 0],
@@ -201,7 +201,7 @@ class ElasticTensorTest(PymatgenTest):
         stresses = self.toec_dict["stresses"]
         with warnings.catch_warnings(record=True):
             et = ElasticTensor.from_independent_strains(strains, stresses)
-        self.assertArrayAlmostEqual(et.voigt, self.toec_dict["C2_raw"], decimal=-1)
+        self.assert_all_close(et.voigt, self.toec_dict["C2_raw"], decimal=-1)
 
     def test_energy_density(self):
         film_elac = ElasticTensor.from_voigt(
@@ -276,7 +276,7 @@ class ElasticTensorExpansionTest(PymatgenTest):
 
     def test_calculate_stress(self):
         calc_stress = self.exp.calculate_stress(self.strains[0])
-        self.assertArrayAlmostEqual(self.pk_stresses[0], calc_stress, decimal=2)
+        self.assert_all_close(self.pk_stresses[0], calc_stress, decimal=2)
 
     def test_energy_density(self):
         e_density = self.exp.energy_density(self.strains[0])
@@ -285,10 +285,10 @@ class ElasticTensorExpansionTest(PymatgenTest):
     def test_gruneisen(self):
         # Get GGT
         ggt = self.exp_cu.get_ggt([1, 0, 0], [0, 1, 0])
-        self.assertArrayAlmostEqual(np.eye(3) * np.array([4.92080537, 4.2852349, -0.7147651]), ggt)
+        self.assert_all_close(np.eye(3) * np.array([4.92080537, 4.2852349, -0.7147651]), ggt)
         # Get TGT
         tgt = self.exp_cu.get_tgt()
-        self.assertArrayAlmostEqual(tgt, np.eye(3) * 2.59631832)
+        self.assert_all_close(tgt, np.eye(3) * 2.59631832)
 
         # Get heat capacity
         c0 = self.exp_cu.get_heat_capacity(0, self.cu, [1, 0, 0], [0, 1, 0])
@@ -306,12 +306,12 @@ class ElasticTensorExpansionTest(PymatgenTest):
         alpha_dp = self.exp_cu.thermal_expansion_coeff(self.cu, 300, mode="dulong-petit")
         alpha_dp_ground_truth = 6.3471959e-07 * np.ones((3, 3))
         alpha_dp_ground_truth[np.diag_indices(3)] = 2.2875769e-7
-        self.assertArrayAlmostEqual(alpha_dp_ground_truth, alpha_dp, decimal=4)
+        self.assert_all_close(alpha_dp_ground_truth, alpha_dp, decimal=4)
 
         alpha_debye = self.exp_cu.thermal_expansion_coeff(self.cu, 300, mode="debye")
         alpha_comp = 5.9435148e-7 * np.ones((3, 3))
         alpha_comp[np.diag_indices(3)] = 21.4533472e-06
-        self.assertArrayAlmostEqual(alpha_comp, alpha_debye)
+        self.assert_all_close(alpha_comp, alpha_debye)
 
     def test_get_compliance_expansion(self):
         ce_exp = self.exp_cu.get_compliance_expansion()
@@ -319,27 +319,27 @@ class ElasticTensorExpansionTest(PymatgenTest):
         strain_orig = Strain.from_voigt([0.01, 0, 0, 0, 0, 0])
         stress = self.exp_cu.calculate_stress(strain_orig)
         strain_revert = et_comp.calculate_stress(stress)
-        self.assertArrayAlmostEqual(strain_orig, strain_revert, decimal=4)
+        self.assert_all_close(strain_orig, strain_revert, decimal=4)
 
     def test_get_effective_ecs(self):
         # Ensure zero strain is same as SOEC
         test_zero = self.exp_cu.get_effective_ecs(np.zeros((3, 3)))
-        self.assertArrayAlmostEqual(test_zero, self.exp_cu[0])
+        self.assert_all_close(test_zero, self.exp_cu[0])
         s = np.zeros((3, 3))
         s[0, 0] = 0.02
         test_2percent = self.exp_cu.get_effective_ecs(s)
         diff = test_2percent - test_zero
-        self.assertArrayAlmostEqual(self.exp_cu[1].einsum_sequence([s]), diff)
+        self.assert_all_close(self.exp_cu[1].einsum_sequence([s]), diff)
 
     def test_get_strain_from_stress(self):
         strain = Strain.from_voigt([0.05, 0, 0, 0, 0, 0])
         stress3 = self.exp_cu.calculate_stress(strain)
         strain_revert3 = self.exp_cu.get_strain_from_stress(stress3)
-        self.assertArrayAlmostEqual(strain, strain_revert3, decimal=2)
+        self.assert_all_close(strain, strain_revert3, decimal=2)
         # fourth order
         stress4 = self.exp_cu_4.calculate_stress(strain)
         strain_revert4 = self.exp_cu_4.get_strain_from_stress(stress4)
-        self.assertArrayAlmostEqual(strain, strain_revert4, decimal=2)
+        self.assert_all_close(strain, strain_revert4, decimal=2)
 
     def test_get_yield_stress(self):
         self.exp_cu_4.get_yield_stress([1, 0, 0])
@@ -370,11 +370,11 @@ class NthOrderElasticTensorTest(PymatgenTest):
             eq_stress=self.data_dict["eq_stress"],
             order=3,
         )
-        self.assertArrayAlmostEqual(c3.voigt, self.data_dict["C3_raw"], decimal=2)
+        self.assert_all_close(c3.voigt, self.data_dict["C3_raw"], decimal=2)
 
     def test_calculate_stress(self):
         calc_stress = self.c2.calculate_stress(self.strains[0])
-        self.assertArrayAlmostEqual(self.pk_stresses[0], calc_stress, decimal=0)
+        self.assert_all_close(self.pk_stresses[0], calc_stress, decimal=0)
         # Test calculation from voigt strain
         self.c2.calculate_stress(self.strains[0].voigt)
 
@@ -418,33 +418,33 @@ class DiffFitTest(PymatgenTest):
         for data in ss_dict.values():
             # Check correspondence of strains/stresses
             for strain, stress in zip(data["strains"], data["stresses"]):
-                self.assertArrayAlmostEqual(
+                self.assert_all_close(
                     Stress.from_voigt(stress),
                     strain_dict[Strain.from_voigt(strain).tobytes()],
                 )
         # Add test to ensure zero strain state doesn't cause issue
         strains, stresses = [Strain.from_voigt([-0.01] + [0] * 5)], [Stress(np.eye(3))]
         ss_dict = get_strain_state_dict(strains, stresses)
-        self.assertArrayAlmostEqual(list(ss_dict), [[1, 0, 0, 0, 0, 0]])
+        self.assert_all_close(list(ss_dict), [[1, 0, 0, 0, 0, 0]])
 
     def test_find_eq_stress(self):
         test_strains = deepcopy(self.strains)
         test_stresses = deepcopy(self.pk_stresses)
         with warnings.catch_warnings(record=True):
             no_eq = find_eq_stress(test_strains, test_stresses)
-            self.assertArrayAlmostEqual(no_eq, np.zeros((3, 3)))
+            self.assert_all_close(no_eq, np.zeros((3, 3)))
         test_strains[3] = Strain.from_voigt(np.zeros(6))
         eq_stress = find_eq_stress(test_strains, test_stresses)
-        self.assertArrayAlmostEqual(test_stresses[3], eq_stress)
+        self.assert_all_close(test_stresses[3], eq_stress)
 
     def test_get_diff_coeff(self):
         forward_11 = get_diff_coeff([0, 1], 1)
         forward_13 = get_diff_coeff([0, 1, 2, 3], 1)
         backward_26 = get_diff_coeff(np.arange(-6, 1), 2)
         central_29 = get_diff_coeff(np.arange(-4, 5), 2)
-        self.assertArrayAlmostEqual(forward_11, [-1, 1])
-        self.assertArrayAlmostEqual(forward_13, [-11.0 / 6, 3, -3.0 / 2, 1.0 / 3])
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(forward_11, [-1, 1])
+        self.assert_all_close(forward_13, [-11.0 / 6, 3, -3.0 / 2, 1.0 / 3])
+        self.assert_all_close(
             backward_26,
             [
                 137.0 / 180,
@@ -456,7 +456,7 @@ class DiffFitTest(PymatgenTest):
                 203.0 / 45,
             ],
         )
-        self.assertArrayAlmostEqual(central_29, central_diff_weights(9, 2))
+        self.assert_all_close(central_29, central_diff_weights(9, 2))
 
     def test_generate_pseudo(self):
         strain_states = np.eye(6).tolist()
@@ -474,10 +474,10 @@ class DiffFitTest(PymatgenTest):
             c2, c3, c4 = diff_fit(r_strains, r_pk_stresses, self.data_dict["eq_stress"], order=4)
             c2, c3 = diff_fit(self.strains, self.pk_stresses, self.data_dict["eq_stress"], order=3)
             c2_red, c3_red = diff_fit(r_strains, r_pk_stresses, self.data_dict["eq_stress"], order=3)
-            self.assertArrayAlmostEqual(c2.voigt, self.data_dict["C2_raw"])
-            self.assertArrayAlmostEqual(c3.voigt, self.data_dict["C3_raw"], decimal=5)
-            self.assertArrayAlmostEqual(c2, c2_red, decimal=0)
-            self.assertArrayAlmostEqual(c3, c3_red, decimal=-1)
+            self.assert_all_close(c2.voigt, self.data_dict["C2_raw"])
+            self.assert_all_close(c3.voigt, self.data_dict["C3_raw"], decimal=5)
+            self.assert_all_close(c2, c2_red, decimal=0)
+            self.assert_all_close(c3, c3_red, decimal=-1)
 
 
 if __name__ == "__main__":

--- a/pymatgen/analysis/elasticity/tests/test_strain.py
+++ b/pymatgen/analysis/elasticity/tests/test_strain.py
@@ -29,11 +29,11 @@ class DeformationTest(PymatgenTest):
 
     def test_properties(self):
         # green_lagrange_strain
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             self.ind_defo.green_lagrange_strain,
             [[0.0, 0.01, 0.0], [0.01, 0.0002, 0.0], [0.0, 0.0, 0.0]],
         )
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             self.non_ind_defo.green_lagrange_strain,
             [[0.0, 0.01, 0.01], [0.01, 0.0002, 0.0002], [0.01, 0.0002, 0.0002]],
         )
@@ -47,7 +47,7 @@ class DeformationTest(PymatgenTest):
         strained_ind = self.ind_defo.apply_to_structure(self.structure)
         strained_non = self.non_ind_defo.apply_to_structure(self.structure)
         # Check lattices
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             strained_norm.lattice.matrix,
             [
                 [3.9170018886, 0, 0],
@@ -55,7 +55,7 @@ class DeformationTest(PymatgenTest):
                 [0, -2.21713849, 3.13550906],
             ],
         )
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             strained_ind.lattice.matrix,
             [
                 [3.84019793, 0, 0],
@@ -63,7 +63,7 @@ class DeformationTest(PymatgenTest):
                 [-0.04434277, -2.21713849, 3.13550906],
             ],
         )
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             strained_non.lattice.matrix,
             [
                 [3.84019793, 0, 0],
@@ -72,17 +72,17 @@ class DeformationTest(PymatgenTest):
             ],
         )
         # Check coordinates
-        self.assertArrayAlmostEqual(strained_norm.sites[1].coords, [3.91700189, 1.224e-06, 2.3516318])
-        self.assertArrayAlmostEqual(strained_ind.sites[1].coords, [3.84019793, 1.224e-6, 2.3516318])
-        self.assertArrayAlmostEqual(strained_non.sites[1].coords, [3.8872306, 1.224e-6, 2.3516318])
+        self.assert_all_close(strained_norm.sites[1].coords, [3.91700189, 1.224e-06, 2.3516318])
+        self.assert_all_close(strained_ind.sites[1].coords, [3.84019793, 1.224e-6, 2.3516318])
+        self.assert_all_close(strained_non.sites[1].coords, [3.8872306, 1.224e-6, 2.3516318])
 
         # Check convention for applying transformation
         for vec, defo_vec in zip(self.structure.lattice.matrix, strained_non.lattice.matrix):
             new_vec = np.dot(self.non_ind_defo, np.transpose(vec))
-            self.assertArrayAlmostEqual(new_vec, defo_vec)
+            self.assert_all_close(new_vec, defo_vec)
         for coord, defo_coord in zip(self.structure.cart_coords, strained_non.cart_coords):
             new_coord = np.dot(self.non_ind_defo, np.transpose(coord))
-            self.assertArrayAlmostEqual(new_coord, defo_coord)
+            self.assert_all_close(new_coord, defo_coord)
 
 
 class StrainTest(PymatgenTest):
@@ -98,14 +98,14 @@ class StrainTest(PymatgenTest):
 
     def test_new(self):
         test_strain = Strain([[0.0, 0.01, 0.0], [0.01, 0.0002, 0.0], [0.0, 0.0, 0.0]])
-        self.assertArrayAlmostEqual(test_strain, test_strain.get_deformation_matrix().green_lagrange_strain)
+        self.assert_all_close(test_strain, test_strain.get_deformation_matrix().green_lagrange_strain)
         with pytest.raises(ValueError):
             Strain([[0.1, 0.1, 0], [0, 0, 0], [0, 0, 0]])
 
     def test_from_deformation(self):
-        self.assertArrayAlmostEqual(self.norm_str, [[0.0202, 0, 0], [0, 0, 0], [0, 0, 0]])
-        self.assertArrayAlmostEqual(self.ind_str, [[0.0, 0.01, 0.0], [0.01, 0.0002, 0.0], [0.0, 0.0, 0.0]])
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(self.norm_str, [[0.0202, 0, 0], [0, 0, 0], [0, 0, 0]])
+        self.assert_all_close(self.ind_str, [[0.0, 0.01, 0.0], [0.01, 0.0002, 0.0], [0.0, 0.0, 0.0]])
+        self.assert_all_close(
             self.non_ind_str,
             [[0.0, 0.01, 0.01], [0.01, 0.0002, 0.0002], [0.01, 0.0002, 0.0002]],
         )
@@ -115,22 +115,22 @@ class StrainTest(PymatgenTest):
         test = Strain.from_index_amount(2, 0.01)
         should_be = np.zeros((3, 3))
         should_be[2, 2] = 0.01
-        self.assertArrayAlmostEqual(test, should_be)
+        self.assert_all_close(test, should_be)
         # from full-tensor index
         test = Strain.from_index_amount((1, 2), 0.01)
         should_be = np.zeros((3, 3))
         should_be[1, 2] = should_be[2, 1] = 0.01
-        self.assertArrayAlmostEqual(test, should_be)
+        self.assert_all_close(test, should_be)
 
     def test_properties(self):
         # deformation matrix
-        self.assertArrayAlmostEqual(self.ind_str.get_deformation_matrix(), [[1, 0.02, 0], [0, 1, 0], [0, 0, 1]])
+        self.assert_all_close(self.ind_str.get_deformation_matrix(), [[1, 0.02, 0], [0, 1, 0], [0, 0, 1]])
         symm_dfm = Strain(self.no_dfm).get_deformation_matrix(shape="symmetric")
-        self.assertArrayAlmostEqual(symm_dfm, [[0.99995, 0.0099995, 0], [0.0099995, 1.00015, 0], [0, 0, 1]])
-        self.assertArrayAlmostEqual(self.no_dfm.get_deformation_matrix(), [[1, 0.02, 0], [0, 1, 0], [0, 0, 1]])
+        self.assert_all_close(symm_dfm, [[0.99995, 0.0099995, 0], [0.0099995, 1.00015, 0], [0, 0, 1]])
+        self.assert_all_close(self.no_dfm.get_deformation_matrix(), [[1, 0.02, 0], [0, 1, 0], [0, 0, 1]])
 
         # voigt
-        self.assertArrayAlmostEqual(self.non_ind_str.voigt, [0, 0.0002, 0.0002, 0.0004, 0.02, 0.02])
+        self.assert_all_close(self.non_ind_str.voigt, [0, 0.0002, 0.0002, 0.0004, 0.02, 0.02])
 
     def test_convert_strain_to_deformation(self):
         strain = Tensor(np.random.random((3, 3))).symmetrized
@@ -138,10 +138,10 @@ class StrainTest(PymatgenTest):
             strain = Tensor(np.random.random((3, 3))).symmetrized
         upper = convert_strain_to_deformation(strain, shape="upper")
         symm = convert_strain_to_deformation(strain, shape="symmetric")
-        self.assertArrayAlmostEqual(np.triu(upper), upper)
+        self.assert_all_close(np.triu(upper), upper)
         assert Tensor(symm).is_symmetric()
         for defo in upper, symm:
-            self.assertArrayAlmostEqual(defo.green_lagrange_strain, strain)
+            self.assert_all_close(defo.green_lagrange_strain, strain)
 
 
 class DeformedStructureSetTest(PymatgenTest):

--- a/pymatgen/analysis/elasticity/tests/test_stress.py
+++ b/pymatgen/analysis/elasticity/tests/test_stress.py
@@ -23,25 +23,25 @@ class StressTest(PymatgenTest):
         )
         assert self.symm_stress.mean_stress == pytest.approx(3.66)
         # deviator_stress
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             self.symm_stress.deviator_stress,
             Stress([[-3.15, 2.29, 2.42], [2.29, 1.48, 5.07], [2.42, 5.07, 1.67]]),
         )
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             self.non_symm.deviator_stress,
             [[-0.2666666667, 0.2, 0.3], [0.4, 0.133333333, 0.6], [0.2, 0.5, 0.133333333]],
         )
         # deviator_principal_invariants
-        self.assertArrayAlmostEqual(self.symm_stress.dev_principal_invariants, [0, 44.2563, 111.953628])
+        self.assert_all_close(self.symm_stress.dev_principal_invariants, [0, 44.2563, 111.953628])
         # von_mises
         assert self.symm_stress.von_mises == pytest.approx(11.52253878275)
         # piola_kirchoff 1, 2
         f = Deformation.from_index_amount((0, 1), 0.03)
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             self.symm_stress.piola_kirchoff_1(f),
             [[0.4413, 2.29, 2.42], [2.1358, 5.14, 5.07], [2.2679, 5.07, 5.33]],
         )
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             self.symm_stress.piola_kirchoff_2(f),
             [[0.377226, 2.1358, 2.2679], [2.1358, 5.14, 5.07], [2.2679, 5.07, 5.33]],
         )

--- a/pymatgen/analysis/elasticity/tests/test_stress.py
+++ b/pymatgen/analysis/elasticity/tests/test_stress.py
@@ -46,7 +46,7 @@ class StressTest(PymatgenTest):
             [[0.377226, 2.1358, 2.2679], [2.1358, 5.14, 5.07], [2.2679, 5.07, 5.33]],
         )
         # voigt
-        self.assertArrayEqual(self.symm_stress.voigt, [0.51, 5.14, 5.33, 5.07, 2.42, 2.29])
+        assert list(self.symm_stress.voigt) == [0.51, 5.14, 5.33, 5.07, 2.42, 2.29]
         # with warnings.catch_warnings(record=True) as w:
         #     self.non_symm.voigt
         #     self.assertEqual(len(w), 1)

--- a/pymatgen/analysis/ferroelectricity/tests/test_polarization.py
+++ b/pymatgen/analysis/ferroelectricity/tests/test_polarization.py
@@ -53,7 +53,7 @@ class UtilsTest(PymatgenTest):
 
     def test_get_total_ionic_dipole(self):
         p_ion = get_total_ionic_dipole(self.structures[-1], self.zval_dict)
-        self.assertArrayAlmostEqual(p_ion, self.ions[-1].ravel().tolist())
+        self.assert_all_close(p_ion, self.ions[-1].ravel().tolist())
 
 
 class PolarizationTest(PymatgenTest):
@@ -161,65 +161,65 @@ class PolarizationTest(PymatgenTest):
     def test_from_outcars_and_structures(self):
         polarization = Polarization.from_outcars_and_structures(self.outcars, self.structures)
         p_elecs, p_ions = polarization.get_pelecs_and_pions(convert_to_muC_per_cm2=False)
-        self.assertArrayAlmostEqual(p_elecs[0].ravel().tolist(), self.p_elecs[0].ravel().tolist())
-        self.assertArrayAlmostEqual(p_elecs[-1].ravel().tolist(), self.p_elecs[-1].ravel().tolist())
-        self.assertArrayAlmostEqual(p_ions[0].ravel().tolist(), self.p_ions_outcar[0].ravel().tolist())
-        self.assertArrayAlmostEqual(p_ions[-1].ravel().tolist(), self.p_ions_outcar[-1].ravel().tolist())
+        self.assert_all_close(p_elecs[0].ravel().tolist(), self.p_elecs[0].ravel().tolist())
+        self.assert_all_close(p_elecs[-1].ravel().tolist(), self.p_elecs[-1].ravel().tolist())
+        self.assert_all_close(p_ions[0].ravel().tolist(), self.p_ions_outcar[0].ravel().tolist())
+        self.assert_all_close(p_ions[-1].ravel().tolist(), self.p_ions_outcar[-1].ravel().tolist())
         # Test for calc_ionic_from_zval=True
         polarization = Polarization.from_outcars_and_structures(
             self.outcars, self.structures, calc_ionic_from_zval=True
         )
         p_elecs, p_ions = polarization.get_pelecs_and_pions(convert_to_muC_per_cm2=False)
-        self.assertArrayAlmostEqual(p_elecs[0].ravel().tolist(), self.p_elecs[0].ravel().tolist())
-        self.assertArrayAlmostEqual(p_elecs[-1].ravel().tolist(), self.p_elecs[-1].ravel().tolist())
-        self.assertArrayAlmostEqual(p_ions[0].ravel().tolist(), self.p_ions[0].ravel().tolist())
-        self.assertArrayAlmostEqual(p_ions[-1].ravel().tolist(), self.p_ions[-1].ravel().tolist())
+        self.assert_all_close(p_elecs[0].ravel().tolist(), self.p_elecs[0].ravel().tolist())
+        self.assert_all_close(p_elecs[-1].ravel().tolist(), self.p_elecs[-1].ravel().tolist())
+        self.assert_all_close(p_ions[0].ravel().tolist(), self.p_ions[0].ravel().tolist())
+        self.assert_all_close(p_ions[-1].ravel().tolist(), self.p_ions[-1].ravel().tolist())
 
     def test_get_same_branch_polarization_data(self):
         same_branch = self.polarization.get_same_branch_polarization_data(
             convert_to_muC_per_cm2=True, all_in_polar=False
         )
-        self.assertArrayAlmostEqual(same_branch[0].ravel().tolist(), self.same_branch[0].ravel().tolist())
-        self.assertArrayAlmostEqual(same_branch[1].ravel().tolist(), self.same_branch[1].ravel().tolist())
-        self.assertArrayAlmostEqual(same_branch[3].ravel().tolist(), self.same_branch[3].ravel().tolist())
-        self.assertArrayAlmostEqual(same_branch[-1].ravel().tolist(), self.same_branch[-1].ravel().tolist())
+        self.assert_all_close(same_branch[0].ravel().tolist(), self.same_branch[0].ravel().tolist())
+        self.assert_all_close(same_branch[1].ravel().tolist(), self.same_branch[1].ravel().tolist())
+        self.assert_all_close(same_branch[3].ravel().tolist(), self.same_branch[3].ravel().tolist())
+        self.assert_all_close(same_branch[-1].ravel().tolist(), self.same_branch[-1].ravel().tolist())
         # This will differ only slightly
         same_branch = self.polarization.get_same_branch_polarization_data(
             convert_to_muC_per_cm2=True, all_in_polar=True
         )
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             same_branch[0].ravel().tolist(),
             self.same_branch_all_in_polar[0].ravel().tolist(),
         )
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             same_branch[1].ravel().tolist(),
             self.same_branch_all_in_polar[1].ravel().tolist(),
         )
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             same_branch[3].ravel().tolist(),
             self.same_branch_all_in_polar[3].ravel().tolist(),
         )
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             same_branch[-1].ravel().tolist(),
             self.same_branch_all_in_polar[-1].ravel().tolist(),
         )
 
     def test_get_lattice_quanta(self):
         quanta = self.polarization.get_lattice_quanta(convert_to_muC_per_cm2=True, all_in_polar=False)
-        self.assertArrayAlmostEqual(quanta[0].ravel().tolist(), self.quanta[0].ravel().tolist())
-        self.assertArrayAlmostEqual(quanta[-1].ravel().tolist(), self.quanta[-1].ravel().tolist())
+        self.assert_all_close(quanta[0].ravel().tolist(), self.quanta[0].ravel().tolist())
+        self.assert_all_close(quanta[-1].ravel().tolist(), self.quanta[-1].ravel().tolist())
         # For all_in_polar=True, quanta should be identical to polar quantum
         quanta = self.polarization.get_lattice_quanta(convert_to_muC_per_cm2=True, all_in_polar=True)
-        self.assertArrayAlmostEqual(quanta[0].ravel().tolist(), self.quanta[-1].ravel().tolist())
-        self.assertArrayAlmostEqual(quanta[-1].ravel().tolist(), self.quanta[-1].ravel().tolist())
+        self.assert_all_close(quanta[0].ravel().tolist(), self.quanta[-1].ravel().tolist())
+        self.assert_all_close(quanta[-1].ravel().tolist(), self.quanta[-1].ravel().tolist())
 
     def test_get_polarization_change(self):
         change = self.polarization.get_polarization_change(convert_to_muC_per_cm2=True, all_in_polar=False)
-        self.assertArrayAlmostEqual(change, self.change)
+        self.assert_all_close(change, self.change)
         # Because nonpolar polarization is (0, 0, 0), all_in_polar should have no effect on polarization change
         change = self.polarization.get_polarization_change(convert_to_muC_per_cm2=True, all_in_polar=True)
         # No change up to 5 decimal
-        self.assertArrayAlmostEqual(change, self.change, self.decimal_tol)
+        self.assert_all_close(change, self.change, self.decimal_tol)
 
     def test_get_polarization_change_norm(self):
         change_norm = self.polarization.get_polarization_change_norm(convert_to_muC_per_cm2=True, all_in_polar=False)
@@ -227,21 +227,21 @@ class PolarizationTest(PymatgenTest):
         # Because nonpolar polarization is (0, 0, 0), all_in_polar should have no effect on polarization change norm
         change = self.polarization.get_polarization_change(convert_to_muC_per_cm2=True, all_in_polar=True)
         # No change up to 5 decimal
-        self.assertArrayAlmostEqual(change, self.change, self.decimal_tol)
+        self.assert_all_close(change, self.change, self.decimal_tol)
 
     def test_max_spline_jumps(self):
         max_jumps = self.polarization.max_spline_jumps(convert_to_muC_per_cm2=True, all_in_polar=False)
-        self.assertArrayAlmostEqual(self.max_jumps, max_jumps)
+        self.assert_all_close(self.max_jumps, max_jumps)
         # This will differ slightly
         max_jumps = self.polarization.max_spline_jumps(convert_to_muC_per_cm2=True, all_in_polar=True)
-        self.assertArrayAlmostEqual(self.max_jumps_all_in_polar, max_jumps)
+        self.assert_all_close(self.max_jumps_all_in_polar, max_jumps)
 
     def test_smoothness(self):
         smoothness = self.polarization.smoothness(convert_to_muC_per_cm2=True, all_in_polar=False)
-        self.assertArrayAlmostEqual(self.smoothness, smoothness)
+        self.assert_all_close(self.smoothness, smoothness)
         # This will differ slightly
         smoothness = self.polarization.smoothness(convert_to_muC_per_cm2=True, all_in_polar=True)
-        self.assertArrayAlmostEqual(self.smoothness_all_in_polar, smoothness)
+        self.assert_all_close(self.smoothness_all_in_polar, smoothness)
 
 
 class EnergyTrendTest(PymatgenTest):

--- a/pymatgen/analysis/gb/tests/test_grain.py
+++ b/pymatgen/analysis/gb/tests/test_grain.py
@@ -51,11 +51,11 @@ class TestGrainBoundary(PymatgenTest):
         assert self.Cu_GB1.rotation_angle == approx(123.74898859588858)
         assert self.Cu_GB1.vacuum_thickness == approx(1.5)
         assert self.Cu_GB2.rotation_axis == [1, 2, 3]
-        self.assertArrayAlmostEqual(np.array(self.Cu_GB1.ab_shift), np.array([0.0, 0.0]))
-        self.assertArrayAlmostEqual(np.array(self.Cu_GB2.ab_shift), np.array([0.2, 0.2]))
+        self.assert_all_close(np.array(self.Cu_GB1.ab_shift), np.array([0.0, 0.0]))
+        self.assert_all_close(np.array(self.Cu_GB2.ab_shift), np.array([0.2, 0.2]))
         assert self.Cu_GB1.gb_plane == [1, 3, 1]
         assert self.Cu_GB2.gb_plane == [1, 2, 3]
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             np.array(self.Cu_GB1.init_cell.lattice.matrix),
             np.array(self.Cu_conv.lattice.matrix),
         )
@@ -66,12 +66,12 @@ class TestGrainBoundary(PymatgenTest):
         assert Cu_GB1_copy.rotation_angle == approx(self.Cu_GB1.rotation_angle)
         assert Cu_GB1_copy.rotation_axis == self.Cu_GB1.rotation_axis
         assert Cu_GB1_copy.gb_plane == self.Cu_GB1.gb_plane
-        self.assertArrayAlmostEqual(Cu_GB1_copy.init_cell.lattice.matrix, self.Cu_GB1.init_cell.lattice.matrix)
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(Cu_GB1_copy.init_cell.lattice.matrix, self.Cu_GB1.init_cell.lattice.matrix)
+        self.assert_all_close(
             Cu_GB1_copy.oriented_unit_cell.lattice.matrix,
             self.Cu_GB1.oriented_unit_cell.lattice.matrix,
         )
-        self.assertArrayAlmostEqual(Cu_GB1_copy.lattice.matrix, self.Cu_GB1.lattice.matrix)
+        self.assert_all_close(Cu_GB1_copy.lattice.matrix, self.Cu_GB1.lattice.matrix)
 
     def test_sigma(self):
         assert self.Cu_GB1.sigma == approx(9)
@@ -79,11 +79,11 @@ class TestGrainBoundary(PymatgenTest):
 
     def test_top_grain(self):
         assert self.Cu_GB1.num_sites == approx(self.Cu_GB1.top_grain.num_sites * 2)
-        self.assertArrayAlmostEqual(self.Cu_GB1.lattice.matrix, self.Cu_GB1.top_grain.lattice.matrix)
+        self.assert_all_close(self.Cu_GB1.lattice.matrix, self.Cu_GB1.top_grain.lattice.matrix)
 
     def test_bottom_grain(self):
         assert self.Cu_GB1.num_sites == approx(self.Cu_GB1.bottom_grain.num_sites * 2)
-        self.assertArrayAlmostEqual(self.Cu_GB1.lattice.matrix, self.Cu_GB1.bottom_grain.lattice.matrix)
+        self.assert_all_close(self.Cu_GB1.lattice.matrix, self.Cu_GB1.bottom_grain.lattice.matrix)
 
     def test_coincidents(self):
         assert self.Cu_GB1.num_sites / self.Cu_GB1.sigma == approx(len(self.Cu_GB1.coincidents))
@@ -98,22 +98,22 @@ class TestGrainBoundary(PymatgenTest):
         assert Cu_GB1_new.rotation_angle == approx(self.Cu_GB1.rotation_angle)
         assert Cu_GB1_new.rotation_axis == self.Cu_GB1.rotation_axis
         assert Cu_GB1_new.gb_plane == self.Cu_GB1.gb_plane
-        self.assertArrayAlmostEqual(Cu_GB1_new.init_cell.lattice.matrix, self.Cu_GB1.init_cell.lattice.matrix)
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(Cu_GB1_new.init_cell.lattice.matrix, self.Cu_GB1.init_cell.lattice.matrix)
+        self.assert_all_close(
             Cu_GB1_new.oriented_unit_cell.lattice.matrix,
             self.Cu_GB1.oriented_unit_cell.lattice.matrix,
         )
-        self.assertArrayAlmostEqual(Cu_GB1_new.lattice.matrix, self.Cu_GB1.lattice.matrix)
+        self.assert_all_close(Cu_GB1_new.lattice.matrix, self.Cu_GB1.lattice.matrix)
         assert Cu_GB2_new.sigma == approx(self.Cu_GB2.sigma)
         assert Cu_GB2_new.rotation_angle == approx(self.Cu_GB2.rotation_angle)
         assert Cu_GB2_new.rotation_axis == self.Cu_GB2.rotation_axis
         assert Cu_GB2_new.gb_plane == self.Cu_GB2.gb_plane
-        self.assertArrayAlmostEqual(Cu_GB2_new.init_cell.lattice.matrix, self.Cu_GB2.init_cell.lattice.matrix)
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(Cu_GB2_new.init_cell.lattice.matrix, self.Cu_GB2.init_cell.lattice.matrix)
+        self.assert_all_close(
             Cu_GB2_new.oriented_unit_cell.lattice.matrix,
             self.Cu_GB2.oriented_unit_cell.lattice.matrix,
         )
-        self.assertArrayAlmostEqual(Cu_GB2_new.lattice.matrix, self.Cu_GB2.lattice.matrix)
+        self.assert_all_close(Cu_GB2_new.lattice.matrix, self.Cu_GB2.lattice.matrix)
 
 
 class GrainBoundaryGeneratorTest(PymatgenTest):
@@ -342,10 +342,10 @@ class GrainBoundaryGeneratorTest(PymatgenTest):
     def test_get_rotation_angle_from_sigma(self):
         true_angle = [12.680383491819821, 167.3196165081802]
         angle = GrainBoundaryGenerator.get_rotation_angle_from_sigma(41, [1, 0, 0], lat_type="o", ratio=[270, 30, 29])
-        self.assertArrayAlmostEqual(true_angle, angle)
+        self.assert_all_close(true_angle, angle)
         close_angle = [36.86989764584403, 143.13010235415598]
         angle = GrainBoundaryGenerator.get_rotation_angle_from_sigma(6, [1, 0, 0], lat_type="o", ratio=[270, 30, 29])
-        self.assertArrayAlmostEqual(close_angle, angle)
+        self.assert_all_close(close_angle, angle)
 
 
 if __name__ == "__main__":

--- a/pymatgen/analysis/interfaces/tests/test_coherent_interface.py
+++ b/pymatgen/analysis/interfaces/tests/test_coherent_interface.py
@@ -21,9 +21,9 @@ class InterfaceBuilderTest(PymatgenTest):
         cls.sio2_conventional = SpacegroupAnalyzer(sio2_struct).get_conventional_standard_structure()
 
     def test_utils(self):
-        self.assertArrayAlmostEqual(from_2d_to_3d([[1, 2], [3, 4]]), [[1, 2, 0], [3, 4, 0], [0, 0, 1]])
-        self.assertArrayAlmostEqual(get_2d_transform([[1, 0], [0, 1]], [[1, 2], [3, 4]]), [[1, 2], [3, 4]])
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(from_2d_to_3d([[1, 2], [3, 4]]), [[1, 2, 0], [3, 4, 0], [0, 0, 1]])
+        self.assert_all_close(get_2d_transform([[1, 0], [0, 1]], [[1, 2], [3, 4]]), [[1, 2], [3, 4]])
+        self.assert_all_close(
             get_rot_3d_for_2d([[1, 0, 0], [0, 1, 0]], [[1, 1, 0], [0, 1, 1]]),
             [
                 [0.78867513, -0.21132487, 0.57735027],

--- a/pymatgen/analysis/interfaces/tests/test_zsl.py
+++ b/pymatgen/analysis/interfaces/tests/test_zsl.py
@@ -4,6 +4,7 @@ import unittest
 
 import numpy as np
 import pytest
+from numpy.testing import assert_array_equal
 
 from pymatgen.analysis.interfaces.zsl import (
     ZSLGenerator,
@@ -35,14 +36,12 @@ class ZSLGenTest(PymatgenTest):
         ).get_conventional_standard_structure()
 
     def test_zsl(self):
-        z = ZSLGenerator()
+        zsl_gen = ZSLGenerator()
 
         assert fast_norm(np.array([3.0, 2.0, 1.0])) == pytest.approx(3.74165738)
-        self.assertArrayEqual(
-            reduce_vectors(np.array([1.0, 0.0, 0.0]), np.array([2.0, 2.0, 0.0])), [[1, 0, 0], [0, 2, 0]]
-        )
+        assert_array_equal(reduce_vectors(np.array([1.0, 0.0, 0.0]), np.array([2.0, 2.0, 0.0])), [[1, 0, 0], [0, 2, 0]])
         assert vec_area(np.array([1.0, 0.0, 0.0]), np.array([0.0, 2.0, 0.0])) == 2
-        self.assertArrayEqual(list(get_factors(18)), [1, 2, 3, 6, 9, 18])
+        assert_array_equal(list(get_factors(18)), [1, 2, 3, 6, 9, 18])
         assert is_same_vectors(
             np.array([[1.01, 0, 0], [0, 2, 0]], dtype=float), np.array([[1, 0, 0], [0, 2.01, 0]], dtype=float)
         )
@@ -50,7 +49,7 @@ class ZSLGenTest(PymatgenTest):
             np.array([[1.01, 2, 0], [0, 2, 0]], dtype=float), np.array([[1, 0, 0], [0, 2.01, 0]], dtype=float)
         )
 
-        matches = list(z(self.film.lattice.matrix[:2], self.substrate.lattice.matrix[:2]))
+        matches = list(zsl_gen(self.film.lattice.matrix[:2], self.substrate.lattice.matrix[:2]))
         assert len(matches) == 8
 
     def test_bidirectional(self):

--- a/pymatgen/analysis/tests/test_adsorption.py
+++ b/pymatgen/analysis/tests/test_adsorption.py
@@ -92,7 +92,7 @@ class AdsorbateSiteFinderTest(PymatgenTest):
             self.asf_111.slab
         )
         for n, structure in enumerate(structures):
-            self.assertArrayAlmostEqual(structure[-2].coords, sites["all"][n])
+            self.assert_all_close(structure[-2].coords, sites["all"][n])
         find_args = {"positions": ["hollow"]}
         structures_hollow = self.asf_111.generate_adsorption_structures(co, find_args=find_args)
         assert len(structures_hollow) == len(sites["hollow"])
@@ -107,14 +107,14 @@ class AdsorbateSiteFinderTest(PymatgenTest):
         ads_site_coords = sites["all"][0]
         c_site = structures[0][-2]
         assert str(c_site.specie) == "C"
-        self.assertArrayAlmostEqual(c_site.coords, sites["all"][0])
+        self.assert_all_close(c_site.coords, sites["all"][0])
         # Check no translation
         structures = self.asf_111.generate_adsorption_structures(co, translate=False)
         assert co == Molecule("CO", [[1.0, -0.5, 3], [0.8, 0.46, 3.75]])
         sites = self.asf_111.find_adsorption_sites()
         ads_site_coords = sites["all"][0]
         c_site = structures[0][-2]
-        self.assertArrayAlmostEqual(c_site.coords, ads_site_coords + np.array([1.0, -0.5, 3]))
+        self.assert_all_close(c_site.coords, ads_site_coords + np.array([1.0, -0.5, 3]))
 
     def test_adsorb_both_surfaces(self):
         # Test out for monatomic adsorption

--- a/pymatgen/analysis/tests/test_eos.py
+++ b/pymatgen/analysis/tests/test_eos.py
@@ -129,7 +129,7 @@ class EOSTest(PymatgenTest):
             for param in ("b0", "b1", "e0", "b0"):
                 # TODO: solutions only stable to 2 decimal places
                 # between different machines, this seems far too low?
-                self.assertArrayAlmostEqual(_.results[param], test_output[eos_name][param], decimal=1)
+                self.assert_all_close(_.results[param], test_output[eos_name][param], decimal=1)
 
     def test_fitting(self):
         # courtesy of @katherinelatimer2013
@@ -417,7 +417,7 @@ class EOSTest(PymatgenTest):
         assert float(numerical_eos.v0) == approx(self.num_eos_fit.v0, abs=1e-3)
         assert float(numerical_eos.b0) == approx(self.num_eos_fit.b0, abs=1e-3)
         assert float(numerical_eos.b1) == approx(self.num_eos_fit.b1, abs=1e-3)
-        self.assertArrayAlmostEqual(numerical_eos.eos_params, self.num_eos_fit.eos_params)
+        self.assert_all_close(numerical_eos.eos_params, self.num_eos_fit.eos_params)
 
     def test_numerical_eos_values(self):
         np.testing.assert_almost_equal(self.num_eos_fit.e0, -10.84749, decimal=3)

--- a/pymatgen/analysis/tests/test_eos.py
+++ b/pymatgen/analysis/tests/test_eos.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import unittest
 
 import numpy as np
+from numpy.testing import assert_array_almost_equal
 from pytest import approx
 
 from pymatgen.analysis.eos import EOS, NumericalEOS
@@ -218,7 +219,7 @@ class EOSTest(PymatgenTest):
 
         fit = eos.fit(mp153_volumes, mp153_energies)
 
-        np.testing.assert_array_almost_equal(fit.func(mp153_volumes), mp153_known_energies_vinet, decimal=5)
+        assert_array_almost_equal(fit.func(mp153_volumes), mp153_known_energies_vinet, decimal=5)
 
         assert mp153_known_e0_vinet == approx(fit.e0, abs=1e-4)
         assert mp153_known_v0_vinet == approx(fit.v0, abs=1e-4)
@@ -309,7 +310,7 @@ class EOSTest(PymatgenTest):
 
         fit = eos.fit(mp149_volumes, mp149_energies)
 
-        np.testing.assert_array_almost_equal(fit.func(mp149_volumes), mp149_known_energies_vinet, decimal=5)
+        assert_array_almost_equal(fit.func(mp149_volumes), mp149_known_energies_vinet, decimal=5)
 
         assert mp149_known_e0_vinet == approx(fit.e0, abs=1e-4)
         assert mp149_known_v0_vinet == approx(fit.v0, abs=1e-4)
@@ -400,7 +401,7 @@ class EOSTest(PymatgenTest):
 
         fit = eos.fit(mp72_volumes, mp72_energies)
 
-        np.testing.assert_array_almost_equal(fit.func(mp72_volumes), mp72_known_energies_vinet, decimal=5)
+        assert_array_almost_equal(fit.func(mp72_volumes), mp72_known_energies_vinet, decimal=5)
 
         assert mp72_known_e0_vinet == approx(fit.e0, abs=1e-4)
         assert mp72_known_v0_vinet == approx(fit.v0, abs=1e-4)

--- a/pymatgen/analysis/tests/test_graphs.py
+++ b/pymatgen/analysis/tests/test_graphs.py
@@ -288,8 +288,8 @@ from    to  to_image      bond_length (A)
         # don't care about testing Py 2.7 unicode support,
         # change Å to A
         self.mos2_sg.graph.graph["edge_weight_units"] = "A"
-        self.assertStrContentEqual(str(self.square_sg), square_sg_str_ref)
-        self.assertStrContentEqual(str(self.mos2_sg), mos2_sg_str_ref)
+        self.assert_str_content_equal(str(self.square_sg), square_sg_str_ref)
+        self.assert_str_content_equal(str(self.mos2_sg), mos2_sg_str_ref)
 
     def test_mul(self):
         square_sg_mul = self.square_sg * (2, 1, 1)
@@ -323,7 +323,7 @@ from    to  to_image
         square_sg_mul_ref_str = "\n".join(square_sg_mul_ref_str.splitlines()[11:])
         square_sg_mul_actual_str = "\n".join(square_sg_mul_actual_str.splitlines()[11:])
 
-        self.assertStrContentEqual(square_sg_mul_actual_str, square_sg_mul_ref_str)
+        self.assert_str_content_equal(square_sg_mul_actual_str, square_sg_mul_ref_str)
 
         # test sequential multiplication
         sq_sg_1 = self.square_sg * (2, 2, 1)

--- a/pymatgen/analysis/tests/test_local_env.py
+++ b/pymatgen/analysis/tests/test_local_env.py
@@ -130,14 +130,14 @@ class VoronoiNNTest(PymatgenTest):
         # Test the 2nd NN shell
         nns = self.nn.get_nn_shell_info(s, 0, 2)
         assert len(nns) == 18
-        self.assertArrayAlmostEqual([1] * 6, [x["weight"] for x in nns if max(np.abs(x["image"])) == 2])
-        self.assertArrayAlmostEqual([2] * 12, [x["weight"] for x in nns if max(np.abs(x["image"])) == 1])
+        self.assert_all_close([1] * 6, [x["weight"] for x in nns if max(np.abs(x["image"])) == 2])
+        self.assert_all_close([2] * 12, [x["weight"] for x in nns if max(np.abs(x["image"])) == 1])
 
         # Test the 3rd NN shell
         nns = self.nn.get_nn_shell_info(s, 0, 3)
         for nn in nns:
             #  Check that the coordinates were set correctly
-            self.assertArrayAlmostEqual(nn["site"].frac_coords, nn["image"])
+            self.assert_all_close(nn["site"].frac_coords, nn["image"])
 
         # Test with a structure that has unequal faces
         cscl = Structure(
@@ -189,7 +189,7 @@ class VoronoiNNTest(PymatgenTest):
             all_coords = np.sort([x["site"].coords for x in site.values()], axis=0)
             by_one_coords = np.sort([x["site"].coords for x in by_one.values()], axis=0)
 
-            self.assertArrayAlmostEqual(all_coords, by_one_coords)
+            self.assert_all_close(all_coords, by_one_coords)
 
         # Test the nn_info operation
         all_nn_info = self.nn.get_all_nn_info(self.s)
@@ -201,7 +201,7 @@ class VoronoiNNTest(PymatgenTest):
             all_weights = sorted(x["weight"] for x in info)
             by_one_weights = sorted(x["weight"] for x in by_one)
 
-            self.assertArrayAlmostEqual(all_weights, by_one_weights)
+            self.assert_all_close(all_weights, by_one_weights)
 
     def test_Cs2O(self):
         """A problematic structure in the Materials Project"""
@@ -1296,7 +1296,7 @@ class CrystalNNTest(PymatgenTest):
         for idx, _ in enumerate(self.lifepo4):
             cn_array.append(cnn.get_cn(self.lifepo4, idx, use_weights=True))
 
-        self.assertArrayAlmostEqual(expected_array, cn_array, 2)
+        self.assert_all_close(expected_array, cn_array, 2)
 
     def test_weighted_cn_no_oxid(self):
         cnn = CrystalNN(weighted_cn=True)
@@ -1313,7 +1313,7 @@ class CrystalNNTest(PymatgenTest):
         for idx, _ in enumerate(s):
             cn_array.append(cnn.get_cn(s, idx, use_weights=True))
 
-        self.assertArrayAlmostEqual(expected_array, cn_array, 2)
+        self.assert_all_close(expected_array, cn_array, 2)
 
     def test_fixed_length(self):
         cnn = CrystalNN(fingerprint_length=30)

--- a/pymatgen/analysis/tests/test_nmr.py
+++ b/pymatgen/analysis/tests/test_nmr.py
@@ -24,7 +24,7 @@ class TestChemicalShieldingNotation(PymatgenTest):
         assert_array_equal(cs.principal_axis_system, cs)
 
         cs = ChemicalShielding(np.arange(9).reshape((3, 3)))
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             np.diag(cs.principal_axis_system),
             [-1.74596669e00, -1.53807726e-15, 1.37459667e01],
             decimal=5,
@@ -61,7 +61,7 @@ class TestElectricFieldGradient(PymatgenTest):
         assert_array_equal(efg.principal_axis_system, efg)
 
         efg = ElectricFieldGradient(np.arange(9).reshape((3, 3)))
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             np.diag(efg.principal_axis_system),
             [-1.3484692e00, -1.1543332e-15, 1.3348469e01],
             decimal=5,

--- a/pymatgen/analysis/tests/test_nmr.py
+++ b/pymatgen/analysis/tests/test_nmr.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import unittest
 
 import numpy as np
+from numpy.testing import assert_array_equal
 from pytest import approx
 
 from pymatgen.analysis.nmr import ChemicalShielding, ElectricFieldGradient
@@ -16,11 +17,11 @@ class TestChemicalShieldingNotation(PymatgenTest):
 
         cs = ChemicalShielding([1, 2, 3])
         assert cs.shape == (3, 3)
-        self.assertArrayEqual(np.diag(cs), [1, 2, 3])
+        assert_array_equal(np.diag(cs), [1, 2, 3])
 
     def test_principal_axis_system(self):
         cs = ChemicalShielding([1, 2, 3])
-        self.assertArrayEqual(cs.principal_axis_system, cs)
+        assert_array_equal(cs.principal_axis_system, cs)
 
         cs = ChemicalShielding(np.arange(9).reshape((3, 3)))
         self.assertArrayAlmostEqual(
@@ -57,7 +58,7 @@ class TestElectricFieldGradient(PymatgenTest):
 
     def test_principal_axis_system(self):
         efg = ElectricFieldGradient([1, 2, 3])
-        self.assertArrayEqual(efg.principal_axis_system, efg)
+        assert_array_equal(efg.principal_axis_system, efg)
 
         efg = ElectricFieldGradient(np.arange(9).reshape((3, 3)))
         self.assertArrayAlmostEqual(

--- a/pymatgen/analysis/tests/test_piezo.py
+++ b/pymatgen/analysis/tests/test_piezo.py
@@ -45,7 +45,7 @@ class PiezoTest(PymatgenTest):
 
     def test_new(self):
         pt = PiezoTensor(self.full_tensor_array)
-        self.assertArrayAlmostEqual(pt, self.full_tensor_array)
+        self.assert_all_close(pt, self.full_tensor_array)
         bad_dim_array = np.zeros((3, 3))
         with pytest.raises(ValueError):
             PiezoTensor(bad_dim_array)

--- a/pymatgen/analysis/tests/test_piezo.py
+++ b/pymatgen/analysis/tests/test_piezo.py
@@ -1,13 +1,13 @@
 """
 Test for the piezo tensor class
 """
-
 from __future__ import annotations
 
 import unittest
 
 import numpy as np
 import pytest
+from numpy.testing import assert_array_equal
 
 from pymatgen.analysis.piezo import PiezoTensor
 from pymatgen.util.testing import PymatgenTest
@@ -53,18 +53,18 @@ class PiezoTest(PymatgenTest):
     def test_from_voigt(self):
         bad_voigt = np.zeros((3, 7))
         pt = PiezoTensor.from_voigt(self.voigt_matrix)
-        self.assertArrayEqual(pt, self.full_tensor_array)
+        assert_array_equal(pt, self.full_tensor_array)
         with pytest.raises(ValueError):
             PiezoTensor.from_voigt(bad_voigt)
-        self.assertArrayEqual(self.voigt_matrix, pt.voigt)
+        assert_array_equal(self.voigt_matrix, pt.voigt)
 
     def test_from_vasp_voigt(self):
         bad_voigt = np.zeros((3, 7))
         pt = PiezoTensor.from_vasp_voigt(self.vasp_matrix)
-        self.assertArrayEqual(pt, self.full_tensor_array)
+        assert_array_equal(pt, self.full_tensor_array)
         with pytest.raises(ValueError):
             PiezoTensor.from_voigt(bad_voigt)
-        self.assertArrayEqual(self.voigt_matrix, pt.voigt)
+        assert_array_equal(self.voigt_matrix, pt.voigt)
 
 
 if __name__ == "__main__":

--- a/pymatgen/analysis/tests/test_piezo_sensitivity.py
+++ b/pymatgen/analysis/tests/test_piezo_sensitivity.py
@@ -70,15 +70,15 @@ class PiezoSensitivityTest(PymatgenTest):
 
     def test_BornEffectiveChargeTensor(self):
         bec = BornEffectiveCharge(self.piezo_struc, self.BEC, self.pointops)
-        self.assertArrayAlmostEqual(self.BEC, bec.bec)
+        self.assert_all_close(self.BEC, bec.bec)
 
     def test_InternalStrainTensor(self):
         ist = InternalStrainTensor(self.piezo_struc, self.IST, self.pointops)
-        self.assertArrayAlmostEqual(ist.ist, self.IST)
+        self.assert_all_close(ist.ist, self.IST)
 
     def test_ForceConstantMatrix(self):
         fcmt = ForceConstantMatrix(self.piezo_struc, self.FCM, self.pointops, self.sharedops)
-        self.assertArrayAlmostEqual(fcmt.fcm, self.FCM)
+        self.assert_all_close(fcmt.fcm, self.FCM)
 
     def test_get_BEC_operations(self):
         bec = BornEffectiveCharge(self.piezo_struc, self.BEC, self.pointops)

--- a/pymatgen/analysis/tests/test_structure_matcher.py
+++ b/pymatgen/analysis/tests/test_structure_matcher.py
@@ -806,7 +806,7 @@ class StructureMatcherTest(PymatgenTest):
         sp = ["Si", "Si", "Al"]
         s1 = Structure(latt, sp, [[0.5, 0, 0], [0, 0, 0], [0, 0, 0.5]])
         s2 = Structure(latt, sp, [[0.5, 0, 0], [0, 0, 0], [0, 0, 0.6]])
-        self.assertArrayAlmostEqual(sm.get_rms_dist(s1, s2), (0.32**0.5 / 2, 0.4))
+        self.assert_all_close(sm.get_rms_dist(s1, s2), (0.32**0.5 / 2, 0.4))
 
         assert sm.fit(s1, s2) is False
         assert sm.fit_anonymous(s1, s2) is False

--- a/pymatgen/analysis/tests/test_surface_analysis.py
+++ b/pymatgen/analysis/tests/test_surface_analysis.py
@@ -107,7 +107,7 @@ class SlabEntryTest(PymatgenTest):
             all_se.append(se)
             # Manually calculate surface energy
             manual_se = (slab_entry.energy - ECu * len(slab_entry.structure)) / (2 * slab_entry.surface_area)
-            self.assertArrayAlmostEqual(float(se), manual_se, 10)
+            self.assert_all_close(float(se), manual_se, 10)
 
         # The (111) facet should be the most stable
         clean111_entry = list(self.Cu_entry_dict[(1, 1, 1)])[0]

--- a/pymatgen/analysis/tests/test_transition_state.py
+++ b/pymatgen/analysis/tests/test_transition_state.py
@@ -38,29 +38,29 @@ class NEBAnalysisTest(PymatgenTest):
         neb_dict = json.loads(json_data)
         neb_analysis1_from_json_data = NEBAnalysis.from_dict(neb_dict)
 
-        self.assertArrayAlmostEqual(neb_analysis1.energies[0], -255.97992669000001)
-        self.assertArrayAlmostEqual(neb_analysis1.energies[3], -255.84261996000001)
-        self.assertArrayAlmostEqual(neb_analysis1.r, neb_analysis1_from_dict.r)
-        self.assertArrayAlmostEqual(neb_analysis1.energies, neb_analysis1_from_dict.energies)
-        self.assertArrayAlmostEqual(neb_analysis1.forces, neb_analysis1_from_dict.forces)
+        self.assert_all_close(neb_analysis1.energies[0], -255.97992669000001)
+        self.assert_all_close(neb_analysis1.energies[3], -255.84261996000001)
+        self.assert_all_close(neb_analysis1.r, neb_analysis1_from_dict.r)
+        self.assert_all_close(neb_analysis1.energies, neb_analysis1_from_dict.energies)
+        self.assert_all_close(neb_analysis1.forces, neb_analysis1_from_dict.forces)
         assert neb_analysis1.structures == neb_analysis1_from_dict.structures
 
-        self.assertArrayAlmostEqual(neb_analysis1.r, neb_analysis1_from_json_data.r)
-        self.assertArrayAlmostEqual(neb_analysis1.energies, neb_analysis1_from_json_data.energies)
-        self.assertArrayAlmostEqual(neb_analysis1.forces, neb_analysis1_from_json_data.forces)
+        self.assert_all_close(neb_analysis1.r, neb_analysis1_from_json_data.r)
+        self.assert_all_close(neb_analysis1.energies, neb_analysis1_from_json_data.energies)
+        self.assert_all_close(neb_analysis1.forces, neb_analysis1_from_json_data.forces)
         assert neb_analysis1.structures == neb_analysis1_from_json_data.structures
 
-        self.assertArrayAlmostEqual(neb_analysis1.get_extrema()[1][0], (0.50023335723480078, 325.20043063935128))
+        self.assert_all_close(neb_analysis1.get_extrema()[1][0], (0.50023335723480078, 325.20043063935128))
 
         neb_analysis1.setup_spline(spline_options={"saddle_point": "zero_slope"})
-        self.assertArrayAlmostEqual(neb_analysis1.get_extrema()[1][0], (0.50023335723480078, 325.20003984140203))
+        self.assert_all_close(neb_analysis1.get_extrema()[1][0], (0.50023335723480078, 325.20003984140203))
         with open(os.path.join(test_dir, "neb2", "neb_analysis2.json")) as f:
             neb_analysis2_dict = json.load(f)
         neb_analysis2 = NEBAnalysis.from_dict(neb_analysis2_dict)
-        self.assertArrayAlmostEqual(neb_analysis2.get_extrema()[1][0], (0.37255257367467326, 562.40825334519991))
+        self.assert_all_close(neb_analysis2.get_extrema()[1][0], (0.37255257367467326, 562.40825334519991))
 
         neb_analysis2.setup_spline(spline_options={"saddle_point": "zero_slope"})
-        self.assertArrayAlmostEqual(neb_analysis2.get_extrema()[1][0], (0.30371133723478794, 528.46229631648691))
+        self.assert_all_close(neb_analysis2.get_extrema()[1][0], (0.30371133723478794, 528.46229631648691))
 
     def test_combine_neb_plots(self):
         neb_dir = os.path.join(test_dir, "neb1", "neb")

--- a/pymatgen/analysis/tests/test_wulff.py
+++ b/pymatgen/analysis/tests/test_wulff.py
@@ -5,6 +5,7 @@ import os
 import unittest
 
 from mpl_toolkits.mplot3d import Axes3D
+from numpy.testing import assert_array_equal
 from pytest import approx
 
 from pymatgen.analysis.wulff import WulffShape
@@ -172,10 +173,10 @@ class WulffShapeTest(PymatgenTest):
 
     def test_corner_and_edges(self):
         # Test if it is returning the correct number of corner and edges
-        self.assertArrayEqual(self.cube.tot_corner_sites, 8)
-        self.assertArrayEqual(self.cube.tot_edges, 12)
-        self.assertArrayEqual(self.hex_prism.tot_corner_sites, 12)
-        self.assertArrayEqual(self.hex_prism.tot_edges, 18)
+        assert_array_equal(self.cube.tot_corner_sites, 8)
+        assert_array_equal(self.cube.tot_edges, 12)
+        assert_array_equal(self.hex_prism.tot_corner_sites, 12)
+        assert_array_equal(self.hex_prism.tot_edges, 18)
 
 
 if __name__ == "__main__":

--- a/pymatgen/analysis/xas/tests/test_spectrum.py
+++ b/pymatgen/analysis/xas/tests/test_spectrum.py
@@ -60,7 +60,7 @@ class XASTest(PymatgenTest):
 
     def test_to_from_dict(self):
         s = XAS.from_dict(self.k_xanes.as_dict())
-        self.assertArrayAlmostEqual(s.y, self.k_xanes.y)
+        self.assert_all_close(s.y, self.k_xanes.y)
 
     def test_attributes(self):
         assert_array_equal(self.k_xanes.energy, self.k_xanes.x)

--- a/pymatgen/analysis/xas/tests/test_spectrum.py
+++ b/pymatgen/analysis/xas/tests/test_spectrum.py
@@ -8,6 +8,7 @@ import warnings
 import numpy as np
 import pytest
 from monty.json import MontyDecoder
+from numpy.testing import assert_array_equal
 from pytest import approx
 
 from pymatgen.analysis.xas.spectrum import XAS, site_weighted_spectrum
@@ -62,8 +63,8 @@ class XASTest(PymatgenTest):
         self.assertArrayAlmostEqual(s.y, self.k_xanes.y)
 
     def test_attributes(self):
-        self.assertArrayEqual(self.k_xanes.energy, self.k_xanes.x)
-        self.assertArrayEqual(self.k_xanes.intensity, self.k_xanes.y)
+        assert_array_equal(self.k_xanes.energy, self.k_xanes.x)
+        assert_array_equal(self.k_xanes.intensity, self.k_xanes.y)
 
     def test_str(self):
         assert str(self.k_xanes) is not None

--- a/pymatgen/core/tests/test_composition.py
+++ b/pymatgen/core/tests/test_composition.py
@@ -261,7 +261,7 @@ class CompositionTest(PymatgenTest):
             82.41634,
         ]
         all_weights = [c.weight for c in self.comp]
-        self.assertArrayAlmostEqual(all_weights, correct_weights, 5)
+        self.assert_all_close(all_weights, correct_weights, 5)
 
     def test_get_atomic_fraction(self):
         correct_at_frac = {"Li": 0.15, "Fe": 0.1, "P": 0.15, "O": 0.6}

--- a/pymatgen/core/tests/test_composition.py
+++ b/pymatgen/core/tests/test_composition.py
@@ -3,7 +3,6 @@ Created on Nov 10, 2012
 
 @author: Shyue Ping Ong
 """
-
 from __future__ import annotations
 
 import random

--- a/pymatgen/core/tests/test_lattice.py
+++ b/pymatgen/core/tests/test_lattice.py
@@ -4,7 +4,7 @@ import itertools
 
 import numpy as np
 import pytest
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_almost_equal, assert_array_equal
 
 from pymatgen.core.lattice import Lattice, get_points_in_spheres
 from pymatgen.core.operations import SymmOp
@@ -582,17 +582,17 @@ class LatticeTestCase(PymatgenTest):
 
     def test_selling_vector(self):
         a1 = 10
-        np.testing.assert_array_almost_equal(
+        assert_array_almost_equal(
             Lattice.cubic(a1).selling_vector.round(4),
             np.array([0, 0, 0, -(a1**2), -(a1**2), -(a1**2)]),
         )
         a2, c2 = 5, 8
-        np.testing.assert_array_almost_equal(
+        assert_array_almost_equal(
             Lattice.tetragonal(a2, c2).selling_vector.round(4),
             np.array([0, 0, 0, -(a2**2), -(a2**2), -(c2**2)]),
         )
         a3, b3, c3 = 4, 6, 7
-        np.testing.assert_array_almost_equal(
+        assert_array_almost_equal(
             Lattice.orthorhombic(a3, b3, c3).selling_vector.round(4),
             np.array([0, 0, 0, -(a3**2), -(b3**2), -(c3**2)]),
         )

--- a/pymatgen/core/tests/test_lattice.py
+++ b/pymatgen/core/tests/test_lattice.py
@@ -79,8 +79,8 @@ class LatticeTestCase(PymatgenTest):
 
     def test_get_cartesian_or_frac_coord(self):
         coord = self.lattice.get_cartesian_coords([0.15, 0.3, 0.4])
-        self.assertArrayAlmostEqual(coord, [1.5, 3.0, 4.0])
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(coord, [1.5, 3.0, 4.0])
+        self.assert_all_close(
             self.tetragonal.get_fractional_coords([12.12312, 45.2134, 1.3434]),
             [1.212312, 4.52134, 0.06717],
         )
@@ -89,7 +89,7 @@ class LatticeTestCase(PymatgenTest):
         rand_coord = np.random.random_sample(3)
         coord = self.tetragonal.get_cartesian_coords(rand_coord)
         fcoord = self.tetragonal.get_fractional_coords(coord)
-        self.assertArrayAlmostEqual(fcoord, rand_coord)
+        self.assert_all_close(fcoord, rand_coord)
 
     def test_get_vector_along_lattice_directions(self):
         lattice_mat = np.array([[0.5, 0.0, 0.0], [0.5, np.sqrt(3) / 2.0, 0.0], [0.0, 0.0, 1.0]])
@@ -97,8 +97,8 @@ class LatticeTestCase(PymatgenTest):
         cart_coord = np.array([0.5, np.sqrt(3) / 4.0, 0.5])
         latt_coord = np.array([0.25, 0.5, 0.5])
         from_direct = lattice.get_fractional_coords(cart_coord) * lattice.lengths
-        self.assertArrayAlmostEqual(lattice.get_vector_along_lattice_directions(cart_coord), from_direct)
-        self.assertArrayAlmostEqual(lattice.get_vector_along_lattice_directions(cart_coord), latt_coord)
+        self.assert_all_close(lattice.get_vector_along_lattice_directions(cart_coord), from_direct)
+        self.assert_all_close(lattice.get_vector_along_lattice_directions(cart_coord), latt_coord)
         assert_array_equal(
             lattice.get_vector_along_lattice_directions(cart_coord).shape,
             [
@@ -118,8 +118,8 @@ class LatticeTestCase(PymatgenTest):
 
     def test_reciprocal_lattice(self):
         recip_latt = self.lattice.reciprocal_lattice
-        self.assertArrayAlmostEqual(recip_latt.matrix, 0.628319 * np.eye(3), 5)
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(recip_latt.matrix, 0.628319 * np.eye(3), 5)
+        self.assert_all_close(
             self.tetragonal.reciprocal_lattice.matrix,
             [[0.628319, 0.0, 0.0], [0.0, 0.628319, 0], [0.0, 0.0, 0.3141590]],
             5,
@@ -127,7 +127,7 @@ class LatticeTestCase(PymatgenTest):
 
         # Test the crystallographic version.
         recip_latt_xtal = self.lattice.reciprocal_lattice_crystallographic
-        self.assertArrayAlmostEqual(recip_latt.matrix, recip_latt_xtal.matrix * 2 * np.pi, 5)
+        self.assert_all_close(recip_latt.matrix, recip_latt_xtal.matrix * 2 * np.pi, 5)
 
     def test_static_methods(self):
         lengths_c = [3.840198, 3.84019885, 3.8401976]
@@ -188,7 +188,7 @@ class LatticeTestCase(PymatgenTest):
 
         expected_ans = Lattice([[0, 1, 0], [1, 0, 1], [-2, 0, 1]])
         assert round(abs(np.linalg.det(np.linalg.solve(expected_ans.matrix, reduced_latt.matrix)) - 1), 7) == 0
-        self.assertArrayAlmostEqual(sorted(reduced_latt.abc), sorted(expected_ans.abc))
+        self.assert_all_close(sorted(reduced_latt.abc), sorted(expected_ans.abc))
         assert round(abs(reduced_latt.volume - lattice.volume), 7) == 0
         latt = [7.164750, 2.481942, 0.000000, -4.298850, 2.481942, 0.000000, 0.000000, 0.000000, 14.253000]
         expected_ans = Lattice(
@@ -196,7 +196,7 @@ class LatticeTestCase(PymatgenTest):
         )
         reduced_latt = Lattice(latt).get_lll_reduced_lattice()
         assert round(abs(np.linalg.det(np.linalg.solve(expected_ans.matrix, reduced_latt.matrix)) - 1), 7) == 0
-        self.assertArrayAlmostEqual(sorted(reduced_latt.abc), sorted(expected_ans.abc))
+        self.assert_all_close(sorted(reduced_latt.abc), sorted(expected_ans.abc))
 
         expected_ans = Lattice([0.0, 10.0, 10.0, 10.0, 10.0, 0.0, 30.0, -30.0, 40.0])
 
@@ -205,7 +205,7 @@ class LatticeTestCase(PymatgenTest):
         lattice = Lattice(lattice.T)
         reduced_latt = lattice.get_lll_reduced_lattice()
         assert round(abs(np.linalg.det(np.linalg.solve(expected_ans.matrix, reduced_latt.matrix)) - 1), 7) == 0
-        self.assertArrayAlmostEqual(sorted(reduced_latt.abc), sorted(expected_ans.abc))
+        self.assert_all_close(sorted(reduced_latt.abc), sorted(expected_ans.abc))
 
         random_latt = Lattice(np.random.random((3, 3)))
         if np.linalg.det(random_latt.matrix) > 1e-8:
@@ -255,7 +255,7 @@ class LatticeTestCase(PymatgenTest):
             [-2.8659, 0.0, 0.0],
             [-1.43295, -0.827314, -4.751],
         ]
-        self.assertArrayAlmostEqual(latt.get_niggli_reduced_lattice().matrix, ans)
+        self.assert_all_close(latt.get_niggli_reduced_lattice().matrix, ans)
 
         latt = Lattice.from_parameters(7.365450, 6.199506, 5.353878, 75.542191, 81.181757, 156.396627)
         ans = [
@@ -263,7 +263,7 @@ class LatticeTestCase(PymatgenTest):
             [-0.831059, 2.067413, 1.547813],
             [-0.458407, -2.480895, 1.129126],
         ]
-        self.assertArrayAlmostEqual(latt.get_niggli_reduced_lattice().matrix, np.array(ans), 5)
+        self.assert_all_close(latt.get_niggli_reduced_lattice().matrix, np.array(ans), 5)
 
     def test_find_mapping(self):
         m = np.array([[0.1, 0.2, 0.3], [-0.1, 0.2, 0.7], [0.6, 0.9, 0.2]])
@@ -279,9 +279,9 @@ class LatticeTestCase(PymatgenTest):
 
         rotated = SymmOp.from_rotation_and_translation(rot_out).operate_multi(latt.matrix)
 
-        self.assertArrayAlmostEqual(rotated, aligned_out.matrix)
-        self.assertArrayAlmostEqual(np.dot(scale_out, latt2.matrix), aligned_out.matrix)
-        self.assertArrayAlmostEqual(aligned_out.parameters, latt.parameters)
+        self.assert_all_close(rotated, aligned_out.matrix)
+        self.assert_all_close(np.dot(scale_out, latt2.matrix), aligned_out.matrix)
+        self.assert_all_close(aligned_out.parameters, latt.parameters)
         assert not np.allclose(aligned_out.parameters, latt2.parameters)
 
     def test_find_all_mappings(self):
@@ -295,9 +295,9 @@ class LatticeTestCase(PymatgenTest):
         latt2 = Lattice(np.dot(rot, np.dot(scale, m).T).T)
 
         for aligned_out, rot_out, scale_out in lattice.find_all_mappings(latt2):
-            self.assertArrayAlmostEqual(np.inner(latt2.matrix, rot_out), aligned_out.matrix, 5)
-            self.assertArrayAlmostEqual(np.dot(scale_out, lattice.matrix), aligned_out.matrix)
-            self.assertArrayAlmostEqual(aligned_out.parameters, latt2.parameters)
+            self.assert_all_close(np.inner(latt2.matrix, rot_out), aligned_out.matrix, 5)
+            self.assert_all_close(np.dot(scale_out, lattice.matrix), aligned_out.matrix)
+            self.assert_all_close(aligned_out.parameters, latt2.parameters)
             assert not np.allclose(aligned_out.parameters, lattice.parameters)
 
         lattice = Lattice.orthorhombic(9, 9, 5)
@@ -336,7 +336,7 @@ class LatticeTestCase(PymatgenTest):
         for lattice in self.families.values():
             new_lattice = lattice.scale(new_volume)
             assert round(abs(new_lattice.volume - new_volume), 7) == 0
-            self.assertArrayAlmostEqual(new_lattice.angles, lattice.angles)
+            self.assert_all_close(new_lattice.angles, lattice.angles)
 
     def test_get_wigner_seitz_cell(self):
         ws_cell = Lattice([[10, 0, 0], [0, 5, 0], [0, 0, 1]]).get_wigner_seitz_cell()
@@ -349,11 +349,11 @@ class LatticeTestCase(PymatgenTest):
 
         for lattice in self.families.values():
             # print(family_name)
-            self.assertArrayAlmostEqual(lattice.norm(lattice.matrix, frac_coords=False), lattice.abc, 5)
-            self.assertArrayAlmostEqual(lattice.norm(frac_basis), lattice.abc, 5)
+            self.assert_all_close(lattice.norm(lattice.matrix, frac_coords=False), lattice.abc, 5)
+            self.assert_all_close(lattice.norm(frac_basis), lattice.abc, 5)
             for i, vec in enumerate(frac_basis):
                 length = lattice.norm(vec)
-                self.assertArrayAlmostEqual(length[0], lattice.abc[i], 5)
+                self.assert_all_close(length[0], lattice.abc[i], 5)
                 # We always get a ndarray.
                 assert hasattr(length, "shape")
 
@@ -415,10 +415,10 @@ class LatticeTestCase(PymatgenTest):
             ]
         )
         output = lattice.get_all_distances(fcoords, fcoords)
-        self.assertArrayAlmostEqual(output, expected, 3)
+        self.assert_all_close(output, expected, 3)
         # test just one input point
         output2 = lattice.get_all_distances(fcoords[0], fcoords)
-        self.assertArrayAlmostEqual(output2, [expected[0]], 2)
+        self.assert_all_close(output2, [expected[0]], 2)
         # test distance when initial points are not in unit cell
         f1 = [0, 0, 17]
         f2 = [0, 0, 10]
@@ -435,7 +435,7 @@ class LatticeTestCase(PymatgenTest):
             ]
         )
         output3 = lattice_pbc.get_all_distances(fcoords[:-1], fcoords)
-        self.assertArrayAlmostEqual(output3, expected_pbc, 3)
+        self.assert_all_close(output3, expected_pbc, 3)
 
     def test_monoclinic(self):
         a, b, c, alpha, beta, gamma = self.monoclinic.parameters
@@ -454,7 +454,7 @@ class LatticeTestCase(PymatgenTest):
     def test_get_distance_and_image(self):
         dist, image = self.cubic.get_distance_and_image([0, 0, 0.1], [0, 0.0, 0.9])
         assert round(abs(dist - 2), 7) == 0
-        self.assertArrayAlmostEqual(image, [0, 0, -1])
+        self.assert_all_close(image, [0, 0, -1])
 
     def test_get_distance_and_image_strict(self):
         for _ in range(10):
@@ -476,7 +476,7 @@ class LatticeTestCase(PymatgenTest):
             pmg_result = lattice.get_distance_and_image(f1, f2)
             assert min_image_dist[0] + 1e-7 >= pmg_result[0]
             if abs(min_image_dist[0] - pmg_result[0]) < 1e-12:
-                self.assertArrayAlmostEqual(min_image_dist[1], pmg_result[1])
+                self.assert_all_close(min_image_dist[1], pmg_result[1])
 
     def test_lll_basis(self):
         a = np.array([1.0, 0.1, 0.0])
@@ -490,17 +490,17 @@ class LatticeTestCase(PymatgenTest):
         l1_fcoords = l1.get_fractional_coords(ccoords)
         l2_fcoords = l2.get_fractional_coords(ccoords)
 
-        self.assertArrayAlmostEqual(l1.matrix, l2.lll_matrix)
-        self.assertArrayAlmostEqual(np.dot(l2.lll_mapping, l2.matrix), l1.matrix)
+        self.assert_all_close(l1.matrix, l2.lll_matrix)
+        self.assert_all_close(np.dot(l2.lll_mapping, l2.matrix), l1.matrix)
 
-        self.assertArrayAlmostEqual(np.dot(l2_fcoords, l2.matrix), np.dot(l1_fcoords, l1.matrix))
+        self.assert_all_close(np.dot(l2_fcoords, l2.matrix), np.dot(l1_fcoords, l1.matrix))
 
         lll_fcoords = l2.get_lll_frac_coords(l2_fcoords)
 
-        self.assertArrayAlmostEqual(lll_fcoords, l1_fcoords)
-        self.assertArrayAlmostEqual(l1.get_cartesian_coords(lll_fcoords), np.dot(lll_fcoords, l2.lll_matrix))
+        self.assert_all_close(lll_fcoords, l1_fcoords)
+        self.assert_all_close(l1.get_cartesian_coords(lll_fcoords), np.dot(lll_fcoords, l2.lll_matrix))
 
-        self.assertArrayAlmostEqual(l2.get_frac_coords_from_lll(lll_fcoords), l2_fcoords)
+        self.assert_all_close(l2.get_frac_coords_from_lll(lll_fcoords), l2_fcoords)
 
     def test_get_miller_index_from_sites(self):
         # test on a cubic system

--- a/pymatgen/core/tests/test_lattice.py
+++ b/pymatgen/core/tests/test_lattice.py
@@ -4,6 +4,7 @@ import itertools
 
 import numpy as np
 import pytest
+from numpy.testing import assert_array_equal
 
 from pymatgen.core.lattice import Lattice, get_points_in_spheres
 from pymatgen.core.operations import SymmOp
@@ -61,14 +62,14 @@ class LatticeTestCase(PymatgenTest):
         a = 9.026
         lattice = Lattice.cubic(a)
         assert lattice is not None, "Initialization from new_cubic failed"
-        self.assertArrayEqual(lattice.pbc, (True, True, True))
+        assert_array_equal(lattice.pbc, (True, True, True))
         lattice2 = Lattice([[a, 0, 0], [0, a, 0], [0, 0, a]])
         for i in range(0, 3):
             for j in range(0, 3):
                 assert (
                     round(abs(lattice.matrix[i][j] - lattice2.matrix[i][j]), 5) == 0
                 ), "Inconsistent matrix from two inits!"
-        self.assertArrayEqual(self.cubic_partial_pbc.pbc, (True, True, False))
+        assert_array_equal(self.cubic_partial_pbc.pbc, (True, True, False))
 
     def test_copy(self):
         cubic_copy = self.cubic.copy()
@@ -98,13 +99,13 @@ class LatticeTestCase(PymatgenTest):
         from_direct = lattice.get_fractional_coords(cart_coord) * lattice.lengths
         self.assertArrayAlmostEqual(lattice.get_vector_along_lattice_directions(cart_coord), from_direct)
         self.assertArrayAlmostEqual(lattice.get_vector_along_lattice_directions(cart_coord), latt_coord)
-        self.assertArrayEqual(
+        assert_array_equal(
             lattice.get_vector_along_lattice_directions(cart_coord).shape,
             [
                 3,
             ],
         )
-        self.assertArrayEqual(
+        assert_array_equal(
             lattice.get_vector_along_lattice_directions(cart_coord.reshape([1, 3])).shape,
             [1, 3],
         )
@@ -381,7 +382,7 @@ class LatticeTestCase(PymatgenTest):
         assert np.isclose(dists, 0.2).sum() == 6  # 6 are at 0.2
         assert np.isclose(dists, 0).sum() == 1  # 1 is at 0
         assert len(set(inds)) == 7  # They have unique indices
-        self.assertArrayEqual(images[np.isclose(dists, 0)], [[0, 0, 0]])
+        assert_array_equal(images[np.isclose(dists, 0)], [[0, 0, 0]])
 
         # More complicated case, using the zip output
         result = latt.get_points_in_sphere(pts, [0.5, 0.5, 0.5], 1.0001)

--- a/pymatgen/core/tests/test_libxcfunc.py
+++ b/pymatgen/core/tests/test_libxcfunc.py
@@ -24,4 +24,4 @@ class LibxcFuncTest(PymatgenTest):
         self.serialize_with_pickle(xc, test_eq=True)
 
         # Test if object supports MSONable
-        self.assertMSONable(xc, test_if_subclass=False)
+        self.assert_msonable(xc, test_if_subclass=False)

--- a/pymatgen/core/tests/test_operations.py
+++ b/pymatgen/core/tests/test_operations.py
@@ -14,25 +14,25 @@ class SymmOpTestCase(PymatgenTest):
     def test_properties(self):
         rot = self.op.rotation_matrix
         vec = self.op.translation_vector
-        self.assertArrayAlmostEqual(rot, [[0.8660254, -0.5, 0.0], [0.5, 0.8660254, 0.0], [0.0, 0.0, 1.0]], 2)
-        self.assertArrayAlmostEqual(vec, [0, 0, 1], 2)
+        self.assert_all_close(rot, [[0.8660254, -0.5, 0.0], [0.5, 0.8660254, 0.0], [0.0, 0.0, 1.0]], 2)
+        self.assert_all_close(vec, [0, 0, 1], 2)
 
     def test_operate(self):
         point = np.array([1, 2, 3])
         newcoord = self.op.operate(point)
-        self.assertArrayAlmostEqual(newcoord, [-0.1339746, 2.23205081, 4.0], 2)
+        self.assert_all_close(newcoord, [-0.1339746, 2.23205081, 4.0], 2)
 
     def test_operate_multi(self):
         point = np.array([1, 2, 3])
         newcoords = self.op.operate_multi([point, point])
-        self.assertArrayAlmostEqual(newcoords, [[-0.1339746, 2.23205081, 4.0]] * 2, 2)
+        self.assert_all_close(newcoords, [[-0.1339746, 2.23205081, 4.0]] * 2, 2)
         newcoords = self.op.operate_multi([[point, point]] * 2)
-        self.assertArrayAlmostEqual(newcoords, [[[-0.1339746, 2.23205081, 4.0]] * 2] * 2, 2)
+        self.assert_all_close(newcoords, [[[-0.1339746, 2.23205081, 4.0]] * 2] * 2, 2)
 
     def test_inverse(self):
         point = np.random.rand(3)
         newcoord = self.op.operate(point)
-        self.assertArrayAlmostEqual(self.op.inverse.operate(newcoord), point, 2)
+        self.assert_all_close(self.op.inverse.operate(newcoord), point, 2)
 
     def test_reflection(self):
         normal = np.random.rand(3)
@@ -47,13 +47,13 @@ class SymmOpTestCase(PymatgenTest):
         point = np.random.rand(3)
         newcoord = self.op.operate(point)
         rotate_only = self.op.apply_rotation_only(point)
-        self.assertArrayAlmostEqual(rotate_only + self.op.translation_vector, newcoord, 2)
+        self.assert_all_close(rotate_only + self.op.translation_vector, newcoord, 2)
 
     def test_transform_tensor(self):
         # Rank 2
         tensor = np.arange(0, 9).reshape(3, 3)
         new_tensor = self.op.transform_tensor(tensor)
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             new_tensor,
             [
                 [-0.73205, -1.73205, -0.76794],
@@ -66,7 +66,7 @@ class SymmOpTestCase(PymatgenTest):
         # Rank 3
         tensor = np.arange(0, 27).reshape(3, 3, 3)
         new_tensor = self.op.transform_tensor(tensor)
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             new_tensor,
             [
                 [
@@ -90,7 +90,7 @@ class SymmOpTestCase(PymatgenTest):
         # Rank 4
         tensor = np.arange(0, 81).reshape(3, 3, 3, 3)
         new_tensor = self.op.transform_tensor(tensor)
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             new_tensor,
             [
                 [
@@ -184,7 +184,7 @@ class SymmOpTestCase(PymatgenTest):
         op = SymmOp.inversion(origin)
         pt = np.random.rand(3)
         inv_pt = op.operate(pt)
-        self.assertArrayAlmostEqual(pt - origin, origin - inv_pt)
+        self.assert_all_close(pt - origin, origin - inv_pt)
 
     def test_xyz(self):
         op = SymmOp([[1, -1, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1]])
@@ -224,9 +224,9 @@ class SymmOpTestCase(PymatgenTest):
         # self.assertWarns(UserWarning, self.op.as_xyz_string)
 
         o = SymmOp.from_xyz_string("0.5+x, 0.25+y, 0.75+z")
-        self.assertArrayAlmostEqual(o.translation_vector, [0.5, 0.25, 0.75])
+        self.assert_all_close(o.translation_vector, [0.5, 0.25, 0.75])
         o = SymmOp.from_xyz_string("x + 0.5, y + 0.25, z + 0.75")
-        self.assertArrayAlmostEqual(o.translation_vector, [0.5, 0.25, 0.75])
+        self.assert_all_close(o.translation_vector, [0.5, 0.25, 0.75])
 
 
 class MagSymmOpTestCase(PymatgenTest):

--- a/pymatgen/core/tests/test_sites.py
+++ b/pymatgen/core/tests/test_sites.py
@@ -181,13 +181,13 @@ class PeriodicSiteTest(PymatgenTest):
         site = PeriodicSite("Fe", np.array([1.25, 2.35, 4.46]), self.lattice)
         site.to_unit_cell(in_place=True)
         val = [0.25, 0.35, 0.46]
-        self.assertArrayAlmostEqual(site.frac_coords, val)
+        self.assert_all_close(site.frac_coords, val)
 
         lattice_pbc = Lattice(self.lattice.matrix, pbc=(True, True, False))
         site = PeriodicSite("Fe", np.array([1.25, 2.35, 4.46]), lattice_pbc)
         site.to_unit_cell(in_place=True)
         val = [0.25, 0.35, 4.46]
-        self.assertArrayAlmostEqual(site.frac_coords, val)
+        self.assert_all_close(site.frac_coords, val)
 
     def test_setters(self):
         site = self.propertied_site
@@ -209,9 +209,9 @@ class PeriodicSiteTest(PymatgenTest):
             set_bad_species()
 
         site.frac_coords = [0, 0, 0.1]
-        self.assertArrayAlmostEqual(site.coords, [0, 0, 10])
+        self.assert_all_close(site.coords, [0, 0, 10])
         site.coords = [1.5, 3.25, 5]
-        self.assertArrayAlmostEqual(site.frac_coords, [0.015, 0.0325, 0.05])
+        self.assert_all_close(site.frac_coords, [0.015, 0.0325, 0.05])
 
     def test_repr(self):
         assert repr(self.propertied_site) == "PeriodicSite: Fe2+ (2.5000, 3.5000, 4.5000) [0.2500, 0.3500, 0.4500]"

--- a/pymatgen/core/tests/test_spectrum.py
+++ b/pymatgen/core/tests/test_spectrum.py
@@ -44,7 +44,7 @@ class SpectrumTest(PymatgenTest):
 
         scaled_spect = 3 * self.multi_spec1 + self.multi_spec2
         assert np.allclose(scaled_spect.y, 3 * self.multi_spec1.y + self.multi_spec2.y)
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             self.multi_spec1.get_interpolated_value(0.05),
             (self.multi_spec1.y[0, :] + self.multi_spec1.y[1, :]) / 2,
         )
@@ -72,7 +72,7 @@ class SpectrumTest(PymatgenTest):
         y = np.array(self.multi_spec1.y)
         self.multi_spec1.smear(0.2)
         assert not np.allclose(y, self.multi_spec1.y)
-        self.assertArrayAlmostEqual(np.sum(y, axis=0), np.sum(self.multi_spec1.y, axis=0))
+        self.assert_all_close(np.sum(y, axis=0), np.sum(self.multi_spec1.y, axis=0))
 
     def test_str(self):
         # Just make sure that these methods work.

--- a/pymatgen/core/tests/test_structure.py
+++ b/pymatgen/core/tests/test_structure.py
@@ -341,8 +341,8 @@ class IStructureTest(PymatgenTest):
         random.shuffle(s2)
 
         for s in s1.interpolate(s2, autosort_tol=0.5):
-            self.assertArrayAlmostEqual(s1[0].frac_coords, s[0].frac_coords)
-            self.assertArrayAlmostEqual(s1[2].frac_coords, s[2].frac_coords)
+            self.assert_all_close(s1[0].frac_coords, s[0].frac_coords)
+            self.assert_all_close(s1[2].frac_coords, s[2].frac_coords)
 
         # Make sure autosort has no effect on simpler interpolations,
         # and with shuffled sites.
@@ -352,9 +352,9 @@ class IStructureTest(PymatgenTest):
         random.shuffle(s2)
 
         for s in s1.interpolate(s2, autosort_tol=0.5):
-            self.assertArrayAlmostEqual(s1[1].frac_coords, s[1].frac_coords)
-            self.assertArrayAlmostEqual(s1[2].frac_coords, s[2].frac_coords)
-            self.assertArrayAlmostEqual(s1[3].frac_coords, s[3].frac_coords)
+            self.assert_all_close(s1[1].frac_coords, s[1].frac_coords)
+            self.assert_all_close(s1[2].frac_coords, s[2].frac_coords)
+            self.assert_all_close(s1[3].frac_coords, s[3].frac_coords)
 
         # Test non-hexagonal setting.
         lattice = Lattice.rhombohedral(4.0718, 89.459)
@@ -369,7 +369,7 @@ class IStructureTest(PymatgenTest):
         struct_pbc = IStructure(self.lattice_pbc, ["Si"], coords)
         struct2_pbc = IStructure(self.lattice_pbc, ["Si"], coords2)
         int_s_pbc = struct_pbc.interpolate(struct2_pbc, nimages=2)
-        self.assertArrayAlmostEqual(int_s_pbc[1][0].frac_coords, [1.05, 1.05, 0.55])
+        self.assert_all_close(int_s_pbc[1][0].frac_coords, [1.05, 1.05, 0.55])
 
     def test_interpolate_lattice(self):
         coords = []
@@ -382,12 +382,12 @@ class IStructureTest(PymatgenTest):
         l2 = Lattice.from_parameters(3, 4, 4, 100, 100, 70)
         struct2 = IStructure(l2, ["Si"] * 2, coords2)
         int_s = struct.interpolate(struct2, 2, interpolate_lattices=True)
-        self.assertArrayAlmostEqual(struct.lattice.abc, int_s[0].lattice.abc)
-        self.assertArrayAlmostEqual(struct.lattice.angles, int_s[0].lattice.angles)
-        self.assertArrayAlmostEqual(struct2.lattice.abc, int_s[2].lattice.abc)
-        self.assertArrayAlmostEqual(struct2.lattice.angles, int_s[2].lattice.angles)
+        self.assert_all_close(struct.lattice.abc, int_s[0].lattice.abc)
+        self.assert_all_close(struct.lattice.angles, int_s[0].lattice.angles)
+        self.assert_all_close(struct2.lattice.abc, int_s[2].lattice.abc)
+        self.assert_all_close(struct2.lattice.angles, int_s[2].lattice.angles)
         int_angles = [110.3976469, 94.5359731, 64.5165856]
-        self.assertArrayAlmostEqual(int_angles, int_s[1].lattice.angles)
+        self.assert_all_close(int_angles, int_s[1].lattice.angles)
 
         # Assert that volume is monotonic
         assert struct2.lattice.volume >= int_s[1].lattice.volume
@@ -432,7 +432,7 @@ class IStructureTest(PymatgenTest):
         sp = ["Ag", "Ag", "Be", "Be"]
         struct = Structure(latt, sp, coords)
         dm = struct.get_primitive_structure().distance_matrix
-        self.assertArrayAlmostEqual(dm, [[0, 2.5], [2.5, 0]])
+        self.assert_all_close(dm, [[0, 2.5], [2.5, 0]])
 
     def test_primitive_on_large_supercell(self):
         coords = [[0, 0, 0], [0.5, 0.5, 0], [0, 0.5, 0.5], [0.5, 0, 0.5]]
@@ -544,7 +544,7 @@ Direct
         s = self.struct
         c_indices1, c_indices2, c_offsets, c_distances = s.get_neighbor_list(3)
         p_indices1, p_indices2, p_offsets, p_distances = s._get_neighbor_list_py(3)
-        self.assertArrayAlmostEqual(sorted(c_distances), sorted(p_distances))
+        self.assert_all_close(sorted(c_distances), sorted(p_distances))
 
     # @unittest.skipIf(not os.getenv("CI"), "Only run this in CI tests.")
     # def test_get_all_neighbors_crosscheck_old(self):
@@ -681,7 +681,7 @@ Direct
 
     def test_get_dist_matrix(self):
         ans = [[0.0, 2.3516318], [2.3516318, 0.0]]
-        self.assertArrayAlmostEqual(self.struct.distance_matrix, ans)
+        self.assert_all_close(self.struct.distance_matrix, ans)
 
     def test_to_from_file_string(self):
         with ScratchDir("."):
@@ -689,8 +689,8 @@ Direct
                 struct = self.struct.to(fmt=fmt)
                 assert struct is not None
                 ss = IStructure.from_str(struct, fmt=fmt)
-                self.assertArrayAlmostEqual(ss.lattice.parameters, self.struct.lattice.parameters, decimal=5)
-                self.assertArrayAlmostEqual(ss.frac_coords, self.struct.frac_coords)
+                self.assert_all_close(ss.lattice.parameters, self.struct.lattice.parameters, decimal=5)
+                self.assert_all_close(ss.frac_coords, self.struct.frac_coords)
                 assert isinstance(ss, IStructure)
 
             assert "Fd-3m" in self.struct.to(fmt="CIF", symprec=0.1)
@@ -753,10 +753,10 @@ class StructureTest(PymatgenTest):
         assert s.formula == "Fe1 Si1"
         s[0] = "Fe", [0.5, 0.5, 0.5]
         assert s.formula == "Fe1 Si1"
-        self.assertArrayAlmostEqual(s[0].frac_coords, [0.5, 0.5, 0.5])
+        self.assert_all_close(s[0].frac_coords, [0.5, 0.5, 0.5])
         s.reverse()
         assert s[0].specie == Element("Si")
-        self.assertArrayAlmostEqual(s[0].frac_coords, [0.75, 0.5, 0.75])
+        self.assert_all_close(s[0].frac_coords, [0.75, 0.5, 0.75])
         s[0] = {"Mn": 0.5}
         assert s.formula == "Mn0.5 Fe1"
         del s[1]
@@ -935,7 +935,7 @@ class StructureTest(PymatgenTest):
         op = SymmOp.from_axis_angle_and_translation([0, 0, 1], 90)
         s = self.structure.copy()
         s.apply_operation(op)
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             s.lattice.matrix,
             [
                 [0.000000, 3.840198, 0.000000],
@@ -948,7 +948,7 @@ class StructureTest(PymatgenTest):
         op = SymmOp([[1, 1, 0, 0.5], [1, 0, 0, 0.5], [0, 0, 1, 0.5], [0, 0, 0, 1]])
         s = self.structure.copy()
         s.apply_operation(op, fractional=True)
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             s.lattice.matrix,
             [
                 [5.760297, 3.325710, 0.000000],
@@ -963,7 +963,7 @@ class StructureTest(PymatgenTest):
         initial_coord = s[1].coords
         s.apply_strain(0.01)
         assert pytest.approx(s.lattice.abc) == (3.8785999130369997, 3.878600984287687, 3.8785999130549516)
-        self.assertArrayAlmostEqual(s[1].coords, initial_coord * 1.01)
+        self.assert_all_close(s[1].coords, initial_coord * 1.01)
         a1, b1, c1 = s.lattice.abc
         s.apply_strain([0.1, 0.2, 0.3])
         a2, b2, c2 = s.lattice.abc
@@ -974,26 +974,26 @@ class StructureTest(PymatgenTest):
     def test_scale_lattice(self):
         initial_coord = self.structure[1].coords
         self.structure.scale_lattice(self.structure.volume * 1.01**3)
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             self.structure.lattice.abc,
             (3.8785999130369997, 3.878600984287687, 3.8785999130549516),
         )
-        self.assertArrayAlmostEqual(self.structure[1].coords, initial_coord * 1.01)
+        self.assert_all_close(self.structure[1].coords, initial_coord * 1.01)
 
     def test_translate_sites(self):
         self.structure.translate_sites([0, 1], [0.5, 0.5, 0.5], frac_coords=True)
-        self.assertArrayAlmostEqual(self.structure.frac_coords[0], [0.5, 0.5, 0.5])
+        self.assert_all_close(self.structure.frac_coords[0], [0.5, 0.5, 0.5])
 
         self.structure.translate_sites([0], [0.5, 0.5, 0.5], frac_coords=False)
-        self.assertArrayAlmostEqual(self.structure.cart_coords[0], [3.38014845, 1.05428585, 2.06775453])
+        self.assert_all_close(self.structure.cart_coords[0], [3.38014845, 1.05428585, 2.06775453])
 
         self.structure.translate_sites([0], [0.5, 0.5, 0.5], frac_coords=True, to_unit_cell=False)
-        self.assertArrayAlmostEqual(self.structure.frac_coords[0], [1.00187517, 1.25665291, 1.15946374])
+        self.assert_all_close(self.structure.frac_coords[0], [1.00187517, 1.25665291, 1.15946374])
 
         lattice_pbc = Lattice(self.structure.lattice.matrix, pbc=(True, True, False))
         struct_pbc = Structure(lattice_pbc, ["Si"], [[0.75, 0.75, 0.75]])
         struct_pbc.translate_sites([0], [0.5, 0.5, 0.5], frac_coords=True, to_unit_cell=True)
-        self.assertArrayAlmostEqual(struct_pbc.frac_coords[0], [0.25, 0.25, 1.25])
+        self.assert_all_close(struct_pbc.frac_coords[0], [0.25, 0.25, 1.25])
 
     def test_rotate_sites(self):
         self.structure.rotate_sites(
@@ -1002,14 +1002,14 @@ class StructureTest(PymatgenTest):
             anchor=self.structure[0].coords,
             to_unit_cell=False,
         )
-        self.assertArrayAlmostEqual(self.structure.frac_coords[1], [-1.25, 1.5, 0.75], decimal=6)
+        self.assert_all_close(self.structure.frac_coords[1], [-1.25, 1.5, 0.75], decimal=6)
         self.structure.rotate_sites(
             indices=[1],
             theta=2.0 * np.pi / 3.0,
             anchor=self.structure[0].coords,
             to_unit_cell=True,
         )
-        self.assertArrayAlmostEqual(self.structure.frac_coords[1], [0.75, 0.5, 0.75], decimal=6)
+        self.assert_all_close(self.structure.frac_coords[1], [0.75, 0.5, 0.75], decimal=6)
 
     def test_mul(self):
         self.structure *= [2, 1, 1]
@@ -1019,7 +1019,7 @@ class StructureTest(PymatgenTest):
         assert isinstance(s, Structure)
         s = self.structure * [[1, 0, 0], [2, 1, 0], [0, 0, 2]]
         assert s.formula == "Si8"
-        self.assertArrayAlmostEqual(s.lattice.abc, [7.6803959, 17.5979979, 7.6803959])
+        self.assert_all_close(s.lattice.abc, [7.6803959, 17.5979979, 7.6803959])
 
     def test_make_supercell(self):
         self.structure.make_supercell([2, 1, 1])
@@ -1028,7 +1028,7 @@ class StructureTest(PymatgenTest):
         assert self.structure.formula == "Si4"
         self.structure.make_supercell(2)
         assert self.structure.formula == "Si32"
-        self.assertArrayAlmostEqual(self.structure.lattice.abc, [15.360792, 35.195996, 7.680396], 5)
+        self.assert_all_close(self.structure.lattice.abc, [15.360792, 35.195996, 7.680396], 5)
 
     def test_disordered_supercell_primitive_cell(self):
         latt = Lattice.cubic(2)
@@ -1071,8 +1071,8 @@ class StructureTest(PymatgenTest):
                 s = self.structure.to(fmt=fmt)
                 assert s is not None
                 ss = Structure.from_str(s, fmt=fmt)
-                self.assertArrayAlmostEqual(ss.lattice.parameters, self.structure.lattice.parameters, decimal=5)
-                self.assertArrayAlmostEqual(ss.frac_coords, self.structure.frac_coords)
+                self.assert_all_close(ss.lattice.parameters, self.structure.lattice.parameters, decimal=5)
+                self.assert_all_close(ss.frac_coords, self.structure.frac_coords)
                 assert isinstance(ss, Structure)
 
             # to/from file
@@ -1177,7 +1177,7 @@ class StructureTest(PymatgenTest):
         s.merge_sites(mode="s")
         assert s[0].specie.symbol == "Ag"
         assert s[1].species == Composition({"Cl": 0.35, "F": 0.25})
-        self.assertArrayAlmostEqual(s[1].frac_coords, [0.5, 0.5, 0.5005])
+        self.assert_all_close(s[1].frac_coords, [0.5, 0.5, 0.5005])
 
         # Test for TaS2 with spacegroup 166 in 160 setting.
         latt = Lattice.hexagonal(3.374351, 20.308941)
@@ -1474,8 +1474,8 @@ Site: H (-0.5134, 0.8892, -0.3630)"""
     def test_get_boxed_structure(self):
         s = self.mol.get_boxed_structure(9, 9, 9)
         # C atom should be in center of box.
-        self.assertArrayAlmostEqual(s[4].frac_coords, [0.50000001, 0.5, 0.5])
-        self.assertArrayAlmostEqual(s[1].frac_coords, [0.6140799, 0.5, 0.45966667])
+        self.assert_all_close(s[4].frac_coords, [0.50000001, 0.5, 0.5])
+        self.assert_all_close(s[1].frac_coords, [0.6140799, 0.5, 0.45966667])
         with pytest.raises(ValueError):
             self.mol.get_boxed_structure(1, 1, 1)
         s2 = self.mol.get_boxed_structure(5, 5, 5, (2, 3, 4))
@@ -1484,7 +1484,7 @@ Site: H (-0.5134, 0.8892, -0.3630)"""
 
         # Test offset option
         s3 = self.mol.get_boxed_structure(9, 9, 9, offset=[0.5, 0.5, 0.5])
-        self.assertArrayAlmostEqual(s3[4].coords, [5, 5, 5])
+        self.assert_all_close(s3[4].coords, [5, 5, 5])
         # Test no_cross option
         with pytest.raises(ValueError):
             self.mol.get_boxed_structure(
@@ -1527,7 +1527,7 @@ Site: H (-0.5134, 0.8892, -0.3630)"""
             [1.08900040717, 1.7783298026, 1.77833003783, 0.0, 1.77833],
             [1.08900040717, 1.7783298026, 1.77833003783, 1.77833, 0.0],
         ]
-        self.assertArrayAlmostEqual(self.mol.distance_matrix, ans)
+        self.assert_all_close(self.mol.distance_matrix, ans)
 
     def test_break_bond(self):
         (mol1, mol2) = self.mol.break_bond(0, 1)
@@ -1538,7 +1538,7 @@ Site: H (-0.5134, 0.8892, -0.3630)"""
         assert self.mol.charge == 0
         assert self.mol.spin_multiplicity == 1
         assert self.mol.nelectrons == 10
-        self.assertArrayAlmostEqual(self.mol.center_of_mass, [0, 0, 0])
+        self.assert_all_close(self.mol.center_of_mass, [0, 0, 0])
         with pytest.raises(ValueError):
             Molecule(
                 ["C", "H", "H", "H", "H"],
@@ -1574,7 +1574,7 @@ Site: H (-0.5134, 0.8892, -0.3630)"""
     def test_get_centered_molecule(self):
         mol = IMolecule(["O"] * 2, [[0, 0, 0], [0, 0, 1.2]], spin_multiplicity=3)
         centered = mol.get_centered_molecule()
-        self.assertArrayAlmostEqual(centered.center_of_mass, [0, 0, 0])
+        self.assert_all_close(centered.center_of_mass, [0, 0, 0])
 
     def test_to_from_dict(self):
         d = self.mol.as_dict()
@@ -1636,10 +1636,10 @@ class MoleculeTest(PymatgenTest):
         s = self.mol
         s[1] = ("F", [0.5, 0.5, 0.5])
         assert s.formula == "H3 C1 F1"
-        self.assertArrayAlmostEqual(s[1].coords, [0.5, 0.5, 0.5])
+        self.assert_all_close(s[1].coords, [0.5, 0.5, 0.5])
         s.reverse()
         assert s[0].specie == Element("H")
-        self.assertArrayAlmostEqual(s[0].coords, [-0.513360, 0.889165, -0.363000])
+        self.assert_all_close(s[0].coords, [-0.513360, 0.889165, -0.363000])
         del s[1]
         assert s.formula == "H2 C1 F1"
         s[3] = "N", [0, 0, 0], {"charge": 4}
@@ -1667,7 +1667,7 @@ class MoleculeTest(PymatgenTest):
 
     def test_rotate_sites(self):
         self.mol.rotate_sites(theta=np.radians(30))
-        self.assertArrayAlmostEqual(self.mol.cart_coords[2], [0.889164737, 0.513359500, -0.363000000])
+        self.assert_all_close(self.mol.cart_coords[2], [0.889164737, 0.513359500, -0.363000000])
 
     def test_replace(self):
         self.mol[0] = "Ge"
@@ -1710,7 +1710,7 @@ class MoleculeTest(PymatgenTest):
     def test_apply_operation(self):
         op = SymmOp.from_axis_angle_and_translation([0, 0, 1], 90)
         self.mol.apply_operation(op)
-        self.assertArrayAlmostEqual(self.mol[2].coords, [0.000000, 1.026719, -0.363000])
+        self.assert_all_close(self.mol[2].coords, [0.000000, 1.026719, -0.363000])
 
     def test_substitute(self):
         coords = [

--- a/pymatgen/core/tests/test_structure.py
+++ b/pymatgen/core/tests/test_structure.py
@@ -12,6 +12,7 @@ import numpy as np
 import pytest
 from monty.json import MontyDecoder, MontyEncoder
 from monty.tempfile import ScratchDir
+from numpy.testing import assert_array_equal
 
 from pymatgen.core.composition import Composition
 from pymatgen.core.lattice import Lattice
@@ -311,14 +312,14 @@ class IStructureTest(PymatgenTest):
         for s in int_s:
             assert s is not None, "Interpolation Failed!"
             assert int_s[0].lattice == s.lattice
-        self.assertArrayEqual(int_s[1][1].frac_coords, [0.725, 0.5, 0.725])
+        assert_array_equal(int_s[1][1].frac_coords, [0.725, 0.5, 0.725])
 
         # test ximages
         int_s = struct.interpolate(struct2, nimages=np.linspace(0.0, 1.0, 3))
         for s in int_s:
             assert s is not None, "Interpolation Failed!"
             assert int_s[0].lattice == s.lattice
-        self.assertArrayEqual(int_s[1][1].frac_coords, [0.625, 0.5, 0.625])
+        assert_array_equal(int_s[1][1].frac_coords, [0.625, 0.5, 0.625])
 
         badlattice = [[1, 0.00, 0.00], [0, 1, 0.00], [0.00, 0, 1]]
         struct2 = IStructure(badlattice, ["Si"] * 2, coords2)
@@ -725,10 +726,10 @@ Direct
             assert struct.formula == "Ni32 O32"
 
     def test_pbc(self):
-        self.assertArrayEqual(self.struct.pbc, (True, True, True))
+        assert_array_equal(self.struct.pbc, (True, True, True))
         assert self.struct.is_3d_periodic
         struct_pbc = Structure(self.lattice_pbc, ["Si"] * 2, self.struct.frac_coords)
-        self.assertArrayEqual(struct_pbc.pbc, (True, True, False))
+        assert_array_equal(struct_pbc.pbc, (True, True, False))
         assert not struct_pbc.is_3d_periodic
 
 
@@ -1662,7 +1663,7 @@ class MoleculeTest(PymatgenTest):
 
     def test_translate_sites(self):
         self.mol.translate_sites([0, 1], [0.5, 0.5, 0.5])
-        self.assertArrayEqual(self.mol.cart_coords[0], [0.5, 0.5, 0.5])
+        assert_array_equal(self.mol.cart_coords[0], [0.5, 0.5, 0.5])
 
     def test_rotate_sites(self):
         self.mol.rotate_sites(theta=np.radians(30))

--- a/pymatgen/core/tests/test_structure.py
+++ b/pymatgen/core/tests/test_structure.py
@@ -1705,7 +1705,7 @@ class MoleculeTest(PymatgenTest):
         d = self.mol.as_dict()
         mol2 = Molecule.from_dict(d)
         assert isinstance(mol2, Molecule)
-        self.assertMSONable(self.mol)
+        self.assert_msonable(self.mol)
 
     def test_apply_operation(self):
         op = SymmOp.from_axis_angle_and_translation([0, 0, 1], 90)

--- a/pymatgen/core/tests/test_surface.py
+++ b/pymatgen/core/tests/test_surface.py
@@ -109,9 +109,9 @@ class SlabTest(PymatgenTest):
             coords_are_cartesian=True,
             reorient_lattice=True,
         )
-        self.assertArrayAlmostEqual(zno_slab.frac_coords, zno_slab_cart.frac_coords)
+        self.assert_all_close(zno_slab.frac_coords, zno_slab_cart.frac_coords)
         c = zno_slab_cart.lattice.matrix[2]
-        self.assertArrayAlmostEqual([0, 0, np.linalg.norm(c)], c)
+        self.assert_all_close([0, 0, np.linalg.norm(c)], c)
 
     def test_add_adsorbate_atom(self):
         zno_slab = Slab(
@@ -148,7 +148,7 @@ class SlabTest(PymatgenTest):
         assert obj.miller_index == (1, 0, 0)
 
     def test_dipole_and_is_polar(self):
-        self.assertArrayAlmostEqual(self.zno55.dipole, [0, 0, 0])
+        self.assert_all_close(self.zno55.dipole, [0, 0, 0])
         assert not self.zno55.is_polar()
         cscl = self.get_structure("CsCl")
         cscl.add_oxidation_state_by_element({"Cs": 1, "Cl": -1})
@@ -161,7 +161,7 @@ class SlabTest(PymatgenTest):
             lll_reduce=False,
             center_slab=False,
         ).get_slab()
-        self.assertArrayAlmostEqual(slab.dipole, [-4.209, 0, 0])
+        self.assert_all_close(slab.dipole, [-4.209, 0, 0])
         assert slab.is_polar()
 
     def test_surface_sites_and_symmetry(self):
@@ -187,7 +187,7 @@ class SlabTest(PymatgenTest):
             surf_sites_dict = slab.get_surface_sites()
             total_surf_sites = sum(len(surf_sites_dict[key]) for key in surf_sites_dict)
             r2 = total_surf_sites / (2 * slab.surface_area)
-            self.assertArrayAlmostEqual(r1, r2)
+            self.assert_all_close(r1, r2)
 
     def test_symmetrization(self):
         # Restricted to primitive_elemental materials due to the risk of

--- a/pymatgen/core/tests/test_tensors.py
+++ b/pymatgen/core/tests/test_tensors.py
@@ -136,7 +136,7 @@ class TensorTest(PymatgenTest):
         symm_op = SymmOp.from_axis_angle_and_translation([0, 0, 1], 30, False, [0, 0, 1])
         new_tensor = tensor.transform(symm_op)
 
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             new_tensor,
             [
                 [
@@ -160,7 +160,7 @@ class TensorTest(PymatgenTest):
 
     def test_rotate(self):
         assert_array_equal(self.vec.rotate([[0, -1, 0], [1, 0, 0], [0, 0, 1]]), [0, 1, 0])
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             self.non_symm.rotate(self.rotation),
             SquareTensor([[0.531, 0.485, 0.271], [0.700, 0.5, 0.172], [0.171, 0.233, 0.068]]),
             decimal=3,
@@ -171,7 +171,7 @@ class TensorTest(PymatgenTest):
     def test_einsum_sequence(self):
         x = [1, 0, 0]
         test = Tensor(np.arange(0, 3**4).reshape((3, 3, 3, 3)))
-        self.assertArrayAlmostEqual([0, 27, 54], test.einsum_sequence([x] * 3))
+        self.assert_all_close([0, 27, 54], test.einsum_sequence([x] * 3))
         assert test.einsum_sequence([np.eye(3)] * 2) == 360
         with pytest.raises(ValueError):
             test.einsum_sequence(Tensor(np.zeros(3)))
@@ -191,7 +191,7 @@ class TensorTest(PymatgenTest):
 
     def test_fit_to_structure(self):
         new_fit = self.unfit4.fit_to_structure(self.structure)
-        self.assertArrayAlmostEqual(new_fit, self.fit_r4, 1)
+        self.assert_all_close(new_fit, self.fit_r4, 1)
 
     def test_is_fit_to_structure(self):
         assert not self.unfit4.is_fit_to_structure(self.structure)
@@ -207,17 +207,17 @@ class TensorTest(PymatgenTest):
             diff = np.max(abs(ieee - orig.convert_to_ieee(struct)))
             err_msg = f"{xtal} IEEE conversion failed with max diff {diff}. Numpy version: {np.__version__}"
             converted = orig.convert_to_ieee(struct, refine_rotation=False)
-            self.assertArrayAlmostEqual(ieee, converted, err_msg=err_msg, decimal=3)
+            self.assert_all_close(ieee, converted, err_msg=err_msg, decimal=3)
             converted_refined = orig.convert_to_ieee(struct, refine_rotation=True)
             err_msg = (
                 f"{xtal} IEEE conversion with refinement failed with max diff {diff}. Numpy version: {np.__version__}"
             )
-            self.assertArrayAlmostEqual(ieee, converted_refined, err_msg=err_msg, decimal=2)
+            self.assert_all_close(ieee, converted_refined, err_msg=err_msg, decimal=2)
 
     def test_structure_transform(self):
         # Test trivial case
         trivial = self.fit_r4.structure_transform(self.structure, self.structure.copy())
-        self.assertArrayAlmostEqual(trivial, self.fit_r4)
+        self.assert_all_close(trivial, self.fit_r4)
 
         # Test simple rotation
         rot_symm_op = SymmOp.from_axis_angle_and_translation([1, 1, 1], 55.5)
@@ -225,13 +225,13 @@ class TensorTest(PymatgenTest):
         rot_struct.apply_operation(rot_symm_op)
         rot_tensor = self.fit_r4.rotate(rot_symm_op.rotation_matrix)
         trans_tensor = self.fit_r4.structure_transform(self.structure, rot_struct)
-        self.assertArrayAlmostEqual(rot_tensor, trans_tensor)
+        self.assert_all_close(rot_tensor, trans_tensor)
 
         # Test supercell
         bigcell = self.structure.copy()
         bigcell.make_supercell([2, 2, 3])
         trans_tensor = self.fit_r4.structure_transform(self.structure, bigcell)
-        self.assertArrayAlmostEqual(self.fit_r4, trans_tensor)
+        self.assert_all_close(self.fit_r4, trans_tensor)
 
         # Test rotated primitive to conventional for fcc structure
         sn = self.get_structure("Sn")
@@ -239,7 +239,7 @@ class TensorTest(PymatgenTest):
         sn_prim.apply_operation(rot_symm_op)
         rotated = self.fit_r4.rotate(rot_symm_op.rotation_matrix)
         transformed = self.fit_r4.structure_transform(sn, sn_prim)
-        self.assertArrayAlmostEqual(rotated, transformed)
+        self.assert_all_close(rotated, transformed)
 
     def test_from_voigt(self):
         with pytest.raises(ValueError):
@@ -279,7 +279,7 @@ class TensorTest(PymatgenTest):
         for k, v in reduced.items():
             reconstructed.extend([k.voigt] + [k.transform(op).voigt for op in v])
         reconstructed = sorted(reconstructed, key=lambda x: np.argmax(x))
-        self.assertArrayAlmostEqual(list(reconstructed), np.eye(6) * 0.01)
+        self.assert_all_close(list(reconstructed), np.eye(6) * 0.01)
 
     def test_tensor_mapping(self):
         # Test get
@@ -337,7 +337,7 @@ class TensorTest(PymatgenTest):
         for idx in indices:
             new[idx] = et.voigt[idx]
         new = Tensor.from_voigt(new).populate(sn)
-        self.assertArrayAlmostEqual(new, et, decimal=2)
+        self.assert_all_close(new, et, decimal=2)
 
     def test_from_values_indices(self):
         sn = self.get_structure("Sn")
@@ -355,17 +355,17 @@ class TensorTest(PymatgenTest):
         # Test base serialize-deserialize
         d = self.symm_rank2.as_dict()
         new = Tensor.from_dict(d)
-        self.assertArrayAlmostEqual(new, self.symm_rank2)
+        self.assert_all_close(new, self.symm_rank2)
 
         d = self.symm_rank3.as_dict(voigt=True)
         new = Tensor.from_dict(d)
-        self.assertArrayAlmostEqual(new, self.symm_rank3)
+        self.assert_all_close(new, self.symm_rank3)
 
     def test_projection_methods(self):
         assert round(abs(self.rand_rank2.project([1, 0, 0]) - self.rand_rank2[0, 0]), 7) == 0
         assert round(abs(self.rand_rank2.project([1, 1, 1]) - np.sum(self.rand_rank2) / 3), 7) == 0
         # Test integration
-        self.assertArrayAlmostEqual(self.ones.average_over_unit_sphere(), 1)
+        self.assert_all_close(self.ones.average_over_unit_sphere(), 1)
 
     def test_summary_methods(self):
         assert set(self.ones.get_grouped_indices()[0]) == set(itertools.product(range(3), range(3)))
@@ -376,7 +376,7 @@ class TensorTest(PymatgenTest):
     def test_round(self):
         test = self.non_symm + 0.01
         rounded = test.round(1)
-        self.assertArrayAlmostEqual(rounded, self.non_symm)
+        self.assert_all_close(rounded, self.non_symm)
         assert isinstance(rounded, Tensor)
 
 
@@ -406,7 +406,7 @@ class TensorCollectionTest(PymatgenTest):
             if callable(this_mod):
                 this_mod = this_mod(*args, **kwargs)
             if isinstance(this_mod, np.ndarray):
-                self.assertArrayAlmostEqual(this_mod, t_mod)
+                self.assert_all_close(this_mod, t_mod)
 
     def test_list_based_functions(self):
         # zeroed
@@ -460,14 +460,14 @@ class TensorCollectionTest(PymatgenTest):
         tc_input = list(np.random.random((3, 6, 6)))
         tc = TensorCollection.from_voigt(tc_input)
         for t_input, t in zip(tc_input, tc):
-            self.assertArrayAlmostEqual(Tensor.from_voigt(t_input), t)
+            self.assert_all_close(Tensor.from_voigt(t_input), t)
 
     def test_serialization(self):
         # Test base serialize-deserialize
         d = self.seq_tc.as_dict()
         new = TensorCollection.from_dict(d)
         for t, t_new in zip(self.seq_tc, new):
-            self.assertArrayAlmostEqual(t, t_new)
+            self.assert_all_close(t, t_new)
 
         # Suppress vsym warnings and test voigt
         with warnings.catch_warnings(record=True):
@@ -475,7 +475,7 @@ class TensorCollectionTest(PymatgenTest):
             d = vsym.as_dict(voigt=True)
             new_vsym = TensorCollection.from_dict(d)
             for t, t_new in zip(vsym, new_vsym):
-                self.assertArrayAlmostEqual(t, t_new)
+                self.assert_all_close(t, t_new)
 
 
 class SquareTensorTest(PymatgenTest):
@@ -523,7 +523,7 @@ class SquareTensorTest(PymatgenTest):
         # symmetrized
         assert self.rand_sqtensor.symmetrized == approx(0.5 * (self.rand_sqtensor + self.rand_sqtensor.trans))
         assert self.symm_sqtensor == approx(self.symm_sqtensor.symmetrized)
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             self.non_symm.symmetrized,
             SquareTensor([[0.1, 0.3, 0.25], [0.3, 0.5, 0.55], [0.25, 0.55, 0.5]]),
         )
@@ -539,7 +539,7 @@ class SquareTensorTest(PymatgenTest):
             - self.rand_sqtensor[2, 1] * self.rand_sqtensor[1, 2]
         )
         i3 = np.linalg.det(self.rand_sqtensor)
-        self.assertArrayAlmostEqual([i1, i2, i3], self.rand_sqtensor.principal_invariants)
+        self.assert_all_close([i1, i2, i3], self.rand_sqtensor.principal_invariants)
 
     def test_is_rotation(self):
         assert self.rotation.is_rotation()
@@ -548,27 +548,27 @@ class SquareTensorTest(PymatgenTest):
         assert not self.low_val_2.is_rotation(tol=1e-8)
 
     def test_refine_rotation(self):
-        self.assertArrayAlmostEqual(self.rotation, self.rotation.refine_rotation())
+        self.assert_all_close(self.rotation, self.rotation.refine_rotation())
         new = self.rotation.copy()
         new[2, 2] += 0.02
         assert not new.is_rotation()
-        self.assertArrayAlmostEqual(self.rotation, new.refine_rotation())
+        self.assert_all_close(self.rotation, new.refine_rotation())
         new[1] *= 1.05
-        self.assertArrayAlmostEqual(self.rotation, new.refine_rotation())
+        self.assert_all_close(self.rotation, new.refine_rotation())
 
     def test_get_scaled(self):
         assert self.non_symm.get_scaled(10.0) == approx(SquareTensor([[1, 2, 3], [4, 5, 6], [2, 5, 5]]))
 
     def test_polar_decomposition(self):
         u, p = self.rand_sqtensor.polar_decomposition()
-        self.assertArrayAlmostEqual(np.dot(u, p), self.rand_sqtensor)
-        self.assertArrayAlmostEqual(np.eye(3), np.dot(u, np.conjugate(np.transpose(u))))
+        self.assert_all_close(np.dot(u, p), self.rand_sqtensor)
+        self.assert_all_close(np.eye(3), np.dot(u, np.conjugate(np.transpose(u))))
 
     def test_serialization(self):
         # Test base serialize-deserialize
         d = self.rand_sqtensor.as_dict()
         new = SquareTensor.from_dict(d)
-        self.assertArrayAlmostEqual(new, self.rand_sqtensor)
+        self.assert_all_close(new, self.rand_sqtensor)
         assert isinstance(new, SquareTensor)
 
         # Ensure proper object-independent deserialization
@@ -579,7 +579,7 @@ class SquareTensorTest(PymatgenTest):
             vsym = self.rand_sqtensor.voigt_symmetrized
             d_vsym = vsym.as_dict(voigt=True)
             new_voigt = Tensor.from_dict(d_vsym)
-            self.assertArrayAlmostEqual(vsym, new_voigt)
+            self.assert_all_close(vsym, new_voigt)
 
 
 if __name__ == "__main__":

--- a/pymatgen/core/tests/test_tensors.py
+++ b/pymatgen/core/tests/test_tensors.py
@@ -8,6 +8,7 @@ import warnings
 import numpy as np
 import pytest
 from monty.serialization import MontyDecoder, loadfn
+from numpy.testing import assert_array_equal
 from pytest import approx
 
 from pymatgen.core.operations import SymmOp
@@ -158,7 +159,7 @@ class TensorTest(PymatgenTest):
         )
 
     def test_rotate(self):
-        self.assertArrayEqual(self.vec.rotate([[0, -1, 0], [1, 0, 0], [0, 0, 1]]), [0, 1, 0])
+        assert_array_equal(self.vec.rotate([[0, -1, 0], [1, 0, 0], [0, 0, 1]]), [0, 1, 0])
         self.assertArrayAlmostEqual(
             self.non_symm.rotate(self.rotation),
             SquareTensor([[0.531, 0.485, 0.271], [0.700, 0.5, 0.172], [0.171, 0.233, 0.068]]),

--- a/pymatgen/core/tests/test_units.py
+++ b/pymatgen/core/tests/test_units.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+from numpy.testing import assert_array_equal
 
 from pymatgen.core.units import (
     ArrayWithUnit,
@@ -257,7 +258,7 @@ class ArrayWithFloatWithUnitTest(PymatgenTest):
 
     def test_as_base_units(self):
         x = ArrayWithUnit([5, 10], "MPa")
-        self.assertArrayEqual(ArrayWithUnit([5000000, 10000000], "Pa"), x.as_base_units)
+        assert_array_equal(ArrayWithUnit([5000000, 10000000], "Pa"), x.as_base_units)
 
 
 class DataPersistenceTest(PymatgenTest):

--- a/pymatgen/electronic_structure/tests/test_bandstructure.py
+++ b/pymatgen/electronic_structure/tests/test_bandstructure.py
@@ -81,8 +81,8 @@ class BandStructureSymmLineTest(PymatgenTest):
         warnings.simplefilter("default")
 
     def test_basic(self):
-        self.assertArrayAlmostEqual(self.bs.projections[Spin.up][10][12][0], [0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(self.bs.projections[Spin.up][10][12][0], [0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+        self.assert_all_close(
             self.bs.projections[Spin.up][25][0][Orbital.dyz.value],
             [0.0, 0.0, 0.0011, 0.0219, 0.0219, 0.069],
         )

--- a/pymatgen/electronic_structure/tests/test_cohp.py
+++ b/pymatgen/electronic_structure/tests/test_cohp.py
@@ -5,6 +5,7 @@ import os
 import unittest
 
 import pytest
+from numpy.testing import assert_array_equal
 from pytest import approx
 
 from pymatgen.electronic_structure.cohp import (
@@ -1035,13 +1036,13 @@ class CompleteCohpTest(PymatgenTest):
         )
         cohp_label3 = self.cohp_orb.get_summed_cohp_by_label_and_orbital_list(["1", "1"], ["4px-4pz", "4s-4px"])
 
-        self.assertArrayEqual(cohp_label.cohp[Spin.up], ref["COHP"][Spin.up])
-        self.assertArrayEqual(cohp_label2.cohp[Spin.up], ref["COHP"][Spin.up] * 2.0)
-        self.assertArrayEqual(cohp_label3.cohp[Spin.up], ref["COHP"][Spin.up] + ref2["COHP"][Spin.up])
-        self.assertArrayEqual(cohp_label.icohp[Spin.up], ref["ICOHP"][Spin.up])
-        self.assertArrayEqual(cohp_label2.icohp[Spin.up], ref["ICOHP"][Spin.up] * 2.0)
-        self.assertArrayEqual(cohp_label2x.icohp[Spin.up], ref["ICOHP"][Spin.up])
-        self.assertArrayEqual(cohp_label3.icohp[Spin.up], ref["ICOHP"][Spin.up] + ref2["ICOHP"][Spin.up])
+        assert_array_equal(cohp_label.cohp[Spin.up], ref["COHP"][Spin.up])
+        assert_array_equal(cohp_label2.cohp[Spin.up], ref["COHP"][Spin.up] * 2.0)
+        assert_array_equal(cohp_label3.cohp[Spin.up], ref["COHP"][Spin.up] + ref2["COHP"][Spin.up])
+        assert_array_equal(cohp_label.icohp[Spin.up], ref["ICOHP"][Spin.up])
+        assert_array_equal(cohp_label2.icohp[Spin.up], ref["ICOHP"][Spin.up] * 2.0)
+        assert_array_equal(cohp_label2x.icohp[Spin.up], ref["ICOHP"][Spin.up])
+        assert_array_equal(cohp_label3.icohp[Spin.up], ref["ICOHP"][Spin.up] + ref2["ICOHP"][Spin.up])
         with pytest.raises(ValueError):
             self.cohp_orb.get_summed_cohp_by_label_and_orbital_list(["1"], ["4px-4pz", "4s-4px"])
         with pytest.raises(ValueError):
@@ -1063,13 +1064,13 @@ class CompleteCohpTest(PymatgenTest):
             ["1", "1"], ["4px-4pz", "4s-4px"], summed_spin_channels=True
         )
 
-        self.assertArrayEqual(cohp_label.cohp[Spin.up], ref["COHP"][Spin.up])
-        self.assertArrayEqual(cohp_label2.cohp[Spin.up], ref["COHP"][Spin.up] * 2.0)
-        self.assertArrayEqual(cohp_label3.cohp[Spin.up], ref["COHP"][Spin.up] + ref2["COHP"][Spin.up])
-        self.assertArrayEqual(cohp_label.icohp[Spin.up], ref["ICOHP"][Spin.up])
-        self.assertArrayEqual(cohp_label2.icohp[Spin.up], ref["ICOHP"][Spin.up] * 2.0)
-        self.assertArrayEqual(cohp_label2x.icohp[Spin.up], ref["ICOHP"][Spin.up])
-        self.assertArrayEqual(cohp_label3.icohp[Spin.up], ref["ICOHP"][Spin.up] + ref2["ICOHP"][Spin.up])
+        assert_array_equal(cohp_label.cohp[Spin.up], ref["COHP"][Spin.up])
+        assert_array_equal(cohp_label2.cohp[Spin.up], ref["COHP"][Spin.up] * 2.0)
+        assert_array_equal(cohp_label3.cohp[Spin.up], ref["COHP"][Spin.up] + ref2["COHP"][Spin.up])
+        assert_array_equal(cohp_label.icohp[Spin.up], ref["ICOHP"][Spin.up])
+        assert_array_equal(cohp_label2.icohp[Spin.up], ref["ICOHP"][Spin.up] * 2.0)
+        assert_array_equal(cohp_label2x.icohp[Spin.up], ref["ICOHP"][Spin.up])
+        assert_array_equal(cohp_label3.icohp[Spin.up], ref["ICOHP"][Spin.up] + ref2["ICOHP"][Spin.up])
         with pytest.raises(ValueError):
             self.cohp_orb.get_summed_cohp_by_label_and_orbital_list(
                 ["1"], ["4px-4pz", "4s-4px"], summed_spin_channels=True

--- a/pymatgen/electronic_structure/tests/test_cohp.py
+++ b/pymatgen/electronic_structure/tests/test_cohp.py
@@ -876,7 +876,7 @@ class CompleteCohpTest(PymatgenTest):
         # with a very small number of matrix elements, which would cause the
         # test to fail
         for key in ["COHP", "ICOHP"]:
-            self.assertArrayAlmostEqual(
+            self.assert_all_close(
                 self.cohp_lmto.as_dict()[key]["average"]["1"],
                 self.cohp_lmto_dict.as_dict()[key]["average"]["1"],
                 5,
@@ -1111,12 +1111,12 @@ class CompleteCohpTest(PymatgenTest):
         # the total COHP calculated by LOBSTER. Due to numerical errors in
         # the LOBSTER calculation, the precision is not very high though.
 
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             self.cohp_orb.all_cohps["1"].cohp[Spin.up],
             self.cohp_notot.all_cohps["1"].cohp[Spin.up],
             decimal=3,
         )
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             self.cohp_orb.all_cohps["1"].icohp[Spin.up],
             self.cohp_notot.all_cohps["1"].icohp[Spin.up],
             decimal=3,

--- a/pymatgen/electronic_structure/tests/test_dos.py
+++ b/pymatgen/electronic_structure/tests/test_dos.py
@@ -305,16 +305,16 @@ class DOSTest(PymatgenTest):
         assert dos.get_gap() == approx(2.0589, abs=1e-4)
         assert len(dos.x) == 301
         assert dos.get_interpolated_gap(tol=0.001, abs_tol=False, spin=None)[0] == approx(2.16815942458015, abs=1e-7)
-        self.assertArrayAlmostEqual(dos.get_cbm_vbm(), (3.8729, 1.8140000000000001))
+        self.assert_all_close(dos.get_cbm_vbm(), (3.8729, 1.8140000000000001))
 
         assert dos.get_interpolated_value(9.9)[0] == approx(1.744588888888891, abs=1e-7)
         assert dos.get_interpolated_value(9.9)[1] == approx(1.756888888888886, abs=1e-7)
         with pytest.raises(ValueError):
             dos.get_interpolated_value(1000)
 
-        self.assertArrayAlmostEqual(dos.get_cbm_vbm(spin=Spin.up), (3.8729, 1.2992999999999999))
+        self.assert_all_close(dos.get_cbm_vbm(spin=Spin.up), (3.8729, 1.2992999999999999))
 
-        self.assertArrayAlmostEqual(dos.get_cbm_vbm(spin=Spin.down), (4.645, 1.8140000000000001))
+        self.assert_all_close(dos.get_cbm_vbm(spin=Spin.down), (4.645, 1.8140000000000001))
 
 
 class SpinPolarizationTest(unittest.TestCase):

--- a/pymatgen/electronic_structure/tests/test_plotter.py
+++ b/pymatgen/electronic_structure/tests/test_plotter.py
@@ -534,8 +534,8 @@ class CohpPlotterTest(PymatgenTest):
         cohp_fe_fe = self.cohp.all_cohps["1"]
         for s, spin in enumerate([Spin.up, Spin.down]):
             lines = ax_cohp.lines[2 * linesindex + s]
-            self.assertArrayAlmostEqual(lines.get_xdata(), -cohp_fe_fe.cohp[spin])
-            self.assertArrayAlmostEqual(lines.get_ydata(), self.cohp.energies)
+            self.assert_all_close(lines.get_xdata(), -cohp_fe_fe.cohp[spin])
+            self.assert_all_close(lines.get_ydata(), self.cohp.energies)
             assert lines.get_linestyle() == linestyles[spin]
         plt_cohp.close()
 
@@ -545,8 +545,8 @@ class CohpPlotterTest(PymatgenTest):
         assert ax_cohp.get_ylabel() == "COHP"
         for s, spin in enumerate([Spin.up, Spin.down]):
             lines = ax_cohp.lines[2 * linesindex + s]
-            self.assertArrayAlmostEqual(lines.get_xdata(), self.cohp.energies)
-            self.assertArrayAlmostEqual(lines.get_ydata(), cohp_fe_fe.cohp[spin])
+            self.assert_all_close(lines.get_xdata(), self.cohp.energies)
+            self.assert_all_close(lines.get_ydata(), cohp_fe_fe.cohp[spin])
         plt_cohp.close()
 
         plt_cohp = self.cohp_plot.get_plot(integrated=True)
@@ -554,7 +554,7 @@ class CohpPlotterTest(PymatgenTest):
         assert ax_cohp.get_xlabel() == "-ICOHP (eV)"
         for s, spin in enumerate([Spin.up, Spin.down]):
             lines = ax_cohp.lines[2 * linesindex + s]
-            self.assertArrayAlmostEqual(lines.get_xdata(), -cohp_fe_fe.icohp[spin])
+            self.assert_all_close(lines.get_xdata(), -cohp_fe_fe.icohp[spin])
 
         coop_dict = {"Bi5-Bi6": self.coop.all_cohps["10"]}
         self.coop_plot.add_cohp_dict(coop_dict)
@@ -563,9 +563,9 @@ class CohpPlotterTest(PymatgenTest):
         assert ax_coop.get_xlabel() == "COOP"
         assert ax_coop.get_ylabel() == "$E - E_f$ (eV)"
         lines_coop = ax_coop.get_lines()[0]
-        self.assertArrayAlmostEqual(lines_coop.get_ydata(), self.coop.energies - self.coop.efermi)
+        self.assert_all_close(lines_coop.get_ydata(), self.coop.energies - self.coop.efermi)
         coop_bi_bi = self.coop.all_cohps["10"].cohp[Spin.up]
-        self.assertArrayAlmostEqual(lines_coop.get_xdata(), coop_bi_bi)
+        self.assert_all_close(lines_coop.get_xdata(), coop_bi_bi)
 
         # Cleanup.
         plt_cohp.close()

--- a/pymatgen/ext/tests/test_matproj.py
+++ b/pymatgen/ext/tests/test_matproj.py
@@ -371,7 +371,7 @@ class MPResterOldTest(PymatgenTest):
         data = self.rester.get_surface_data("mp-126")  # Pt
         one_surf = self.rester.get_surface_data("mp-129", miller_index=[-2, -3, 1])
         assert one_surf["surface_energy"] == pytest.approx(2.99156963)
-        self.assertArrayAlmostEqual(one_surf["miller_index"], [3, 2, 1])
+        self.assert_all_close(one_surf["miller_index"], [3, 2, 1])
         assert "surfaces" in data
         surfaces = data["surfaces"]
         assert len(surfaces) > 0
@@ -403,7 +403,7 @@ class MPResterOldTest(PymatgenTest):
         )
         assert len(mo_s3_112) == 1
         gb_f = mo_s3_112[0]["final_structure"]
-        self.assertArrayAlmostEqual(gb_f.rotation_axis, [1, 1, 0])
+        self.assert_all_close(gb_f.rotation_axis, [1, 1, 0])
         assert gb_f.rotation_angle == pytest.approx(109.47122)
         assert mo_s3_112[0]["gb_energy"] == pytest.approx(0.47965, rel=1e-4)
         assert mo_s3_112[0]["work_of_separation"] == pytest.approx(6.318144)

--- a/pymatgen/io/abinit/tests/test_abiobjects.py
+++ b/pymatgen/io/abinit/tests/test_abiobjects.py
@@ -125,8 +125,8 @@ class SpinModeTest(PymatgenTest):
         self.serialize_with_pickle(polarized)
 
         # Test dict methods
-        self.assertMSONable(polarized)
-        self.assertMSONable(unpolarized)
+        self.assert_msonable(polarized)
+        self.assert_msonable(unpolarized)
 
 
 class SmearingTest(PymatgenTest):
@@ -145,7 +145,7 @@ class SmearingTest(PymatgenTest):
 
         assert not nosmear
         assert nosmear != fd1ev
-        self.assertMSONable(nosmear)
+        self.assert_msonable(nosmear)
 
         new_fd1ev = Smearing.from_dict(fd1ev.as_dict())
         assert new_fd1ev == fd1ev
@@ -154,7 +154,7 @@ class SmearingTest(PymatgenTest):
         self.serialize_with_pickle(fd1ev)
 
         # Test dict methods
-        self.assertMSONable(fd1ev)
+        self.assert_msonable(fd1ev)
 
 
 class ElectronsAlgorithmTest(PymatgenTest):
@@ -166,7 +166,7 @@ class ElectronsAlgorithmTest(PymatgenTest):
         self.serialize_with_pickle(algo)
 
         # Test dict methods
-        self.assertMSONable(algo)
+        self.assert_msonable(algo)
 
 
 class ElectronsTest(PymatgenTest):
@@ -193,7 +193,7 @@ class ElectronsTest(PymatgenTest):
         )
 
         # Test dict methods
-        self.assertMSONable(custom_electrons)
+        self.assert_msonable(custom_electrons)
 
 
 class KSamplingTest(PymatgenTest):
@@ -204,8 +204,8 @@ class KSamplingTest(PymatgenTest):
         monkhorst.to_abivars()
 
         # Test dict methods
-        self.assertMSONable(monkhorst)
-        self.assertMSONable(gamma_centered)
+        self.assert_msonable(monkhorst)
+        self.assert_msonable(gamma_centered)
 
 
 class RelaxationTest(PymatgenTest):
@@ -216,8 +216,8 @@ class RelaxationTest(PymatgenTest):
         atoms_and_cell.to_abivars()
 
         # Test dict methods
-        self.assertMSONable(atoms_and_cell)
-        self.assertMSONable(atoms_only)
+        self.assert_msonable(atoms_and_cell)
+        self.assert_msonable(atoms_only)
 
 
 class PPModelTest(PymatgenTest):
@@ -242,4 +242,4 @@ class PPModelTest(PymatgenTest):
         self.serialize_with_pickle(godby)
 
         # Test dict methods
-        self.assertMSONable(godby)
+        self.assert_msonable(godby)

--- a/pymatgen/io/abinit/tests/test_abiobjects.py
+++ b/pymatgen/io/abinit/tests/test_abiobjects.py
@@ -50,7 +50,7 @@ class LatticeFromAbivarsTest(PymatgenTest):
             )
             * bohr_to_ang
         )
-        self.assertArrayAlmostEqual(l2.matrix, abi_rprimd)
+        self.assert_all_close(l2.matrix, abi_rprimd)
 
         l3 = lattice_from_abivars(acell=[3, 6, 9], angdeg=(30, 40, 50))
         abi_rprimd = (
@@ -70,7 +70,7 @@ class LatticeFromAbivarsTest(PymatgenTest):
             )
             * bohr_to_ang
         )
-        self.assertArrayAlmostEqual(l3.matrix, abi_rprimd)
+        self.assert_all_close(l3.matrix, abi_rprimd)
 
         with pytest.raises(ValueError):
             lattice_from_abivars(acell=[1, 1, 1], angdeg=(90, 90, 90), rprim=np.eye(3))

--- a/pymatgen/io/abinit/tests/test_abiobjects.py
+++ b/pymatgen/io/abinit/tests/test_abiobjects.py
@@ -4,6 +4,7 @@ import os
 
 import numpy as np
 import pytest
+from numpy.testing import assert_array_equal
 from pytest import approx
 
 from pymatgen.core.structure import Structure
@@ -87,17 +88,17 @@ class LatticeFromAbivarsTest(PymatgenTest):
         # By default, znucl is filled using the first new type found in sites.
         def_vars = structure_to_abivars(gan)
         def_znucl = def_vars["znucl"]
-        self.assertArrayEqual(def_znucl, [31, 7])
+        assert_array_equal(def_znucl, [31, 7])
         def_typat = def_vars["typat"]
-        self.assertArrayEqual(def_typat, [1, 1, 2, 2])
+        assert_array_equal(def_typat, [1, 1, 2, 2])
 
         # But it's possible to enforce a particular value of typat and znucl.
         enforce_znucl = [7, 31]
         enforce_typat = [2, 2, 1, 1]
         enf_vars = structure_to_abivars(gan, enforce_znucl=enforce_znucl, enforce_typat=enforce_typat)
-        self.assertArrayEqual(enf_vars["znucl"], enforce_znucl)
-        self.assertArrayEqual(enf_vars["typat"], enforce_typat)
-        self.assertArrayEqual(def_vars["xred"], enf_vars["xred"])
+        assert_array_equal(enf_vars["znucl"], enforce_znucl)
+        assert_array_equal(enf_vars["typat"], enforce_typat)
+        assert_array_equal(def_vars["xred"], enf_vars["xred"])
 
         assert [s.symbol for s in species_by_znucl(gan)] == ["Ga", "N"]
 

--- a/pymatgen/io/abinit/tests/test_inputs.py
+++ b/pymatgen/io/abinit/tests/test_inputs.py
@@ -5,6 +5,7 @@ import tempfile
 
 import numpy as np
 import pytest
+from numpy.testing import assert_array_equal
 
 from pymatgen.core.structure import Structure
 from pymatgen.io.abinit.inputs import (
@@ -51,7 +52,7 @@ class AbinitInputTestCase(PymatgenTest):
         inp = BasicAbinitInput(structure=unit_cell, pseudos=abiref_file("14si.pspnc"))
 
         shiftk = [[0.5, 0.5, 0.5], [0.5, 0.0, 0.0], [0.0, 0.5, 0.0], [0.0, 0.0, 0.5]]
-        self.assertArrayEqual(calc_shiftk(inp.structure), shiftk)
+        assert_array_equal(calc_shiftk(inp.structure), shiftk)
         assert num_valence_electrons(inp.structure, inp.pseudos) == 8
 
         repr(inp), str(inp)
@@ -274,7 +275,7 @@ class FactoryTest(PymatgenTest):
         str(inp)
         assert inp["nsppol"] == 2
         assert inp["nband"] == 14
-        self.assertArrayEqual(inp["ngkpt"], [2, 2, 2])
+        assert_array_equal(inp["ngkpt"], [2, 2, 2])
 
     def test_ebands_input(self):
         """Testing ebands_input factory."""

--- a/pymatgen/io/abinit/tests/test_netcdf.py
+++ b/pymatgen/io/abinit/tests/test_netcdf.py
@@ -65,7 +65,7 @@ class ETSF_Reader_TestCase(PymatgenTest):
             for varname, float_ref in ref_float_values.items():
                 value = data.read_value(varname)
                 print(varname, value)
-                self.assertArrayAlmostEqual(value, float_ref)
+                self.assert_all_close(value, float_ref)
             # assert 0
 
             # Reading non-existent variables or dims should raise

--- a/pymatgen/io/abinit/tests/test_netcdf.py
+++ b/pymatgen/io/abinit/tests/test_netcdf.py
@@ -5,6 +5,7 @@ import unittest
 
 import numpy as np
 import pytest
+from numpy.testing import assert_array_equal
 
 from pymatgen.core.structure import Structure
 from pymatgen.io.abinit import ETSF_Reader
@@ -52,13 +53,13 @@ class ETSF_Reader_TestCase(PymatgenTest):
             # Test dimensions.
             for dimname, int_ref in ref_dims.items():
                 value = data.read_dimvalue(dimname)
-                self.assertArrayEqual(value, int_ref)
+                assert_array_equal(value, int_ref)
 
             # Test int variables
             for varname, int_ref in ref_int_values.items():
                 value = data.read_value(varname)
                 print(varname, value)
-                self.assertArrayEqual(value, int_ref)
+                assert_array_equal(value, int_ref)
 
             # Test float variables
             for varname, float_ref in ref_float_values.items():

--- a/pymatgen/io/abinit/tests/test_pseudos.py
+++ b/pymatgen/io/abinit/tests/test_pseudos.py
@@ -58,7 +58,7 @@ class PseudoTestCase(PymatgenTest):
                 self.serialize_with_pickle(pseudo, test_eq=False)
 
                 # Test MSONable
-                self.assertMSONable(pseudo)
+                self.assert_msonable(pseudo)
 
         # HGH pseudos
         pseudo = self.Si_hgh
@@ -119,7 +119,7 @@ class PseudoTestCase(PymatgenTest):
         # Test pickle
         new_objs = self.serialize_with_pickle(oxygen, test_eq=False)
         # Test MSONable
-        self.assertMSONable(oxygen)
+        self.assert_msonable(oxygen)
 
         for o in new_objs:
             assert o.ispaw
@@ -150,7 +150,7 @@ class PseudoTestCase(PymatgenTest):
 
         # Data persistence
         self.serialize_with_pickle(ger, test_eq=False)
-        self.assertMSONable(ger)
+        self.assert_msonable(ger)
 
     def test_oncvpsp_pseudo_fr(self):
         """
@@ -162,7 +162,7 @@ class PseudoTestCase(PymatgenTest):
 
         # Data persistence
         self.serialize_with_pickle(pb, test_eq=False)
-        self.assertMSONable(pb)
+        self.assert_msonable(pb)
 
         assert pb.symbol == "Pb"
         assert pb.Z == 82.0
@@ -191,7 +191,7 @@ class PseudoTableTest(PymatgenTest):
 
         d = table.as_dict()
         PseudoTable.from_dict(d)
-        self.assertMSONable(table)
+        self.assert_msonable(table)
 
         selected = table.select_symbols("Si")
         assert len(selected) == len(table)

--- a/pymatgen/io/cp2k/tests/test_inputs.py
+++ b/pymatgen/io/cp2k/tests/test_inputs.py
@@ -105,7 +105,7 @@ class BasisAndPotentialTest(PymatgenTest):
         # Basis file can read from strings
         bf = BasisFile.from_string(basis)
         for obj in [molopt, bf.objects[0]]:
-            self.assertArrayAlmostEqual(
+            self.assert_all_close(
                 obj.exponents[0],
                 [
                     11.478000339908,
@@ -134,7 +134,7 @@ class BasisAndPotentialTest(PymatgenTest):
         assert pot.potential == "Pseudopotential"
         assert pot.r_loc == approx(0.2)
         assert pot.nexp_ppl == approx(2)
-        self.assertArrayAlmostEqual(pot.c_exp_ppl, [-4.17890044, 0.72446331])
+        self.assert_all_close(pot.c_exp_ppl, [-4.17890044, 0.72446331])
 
         # Basis file can read from strings
         pf = PotentialFile.from_string(pot_H)

--- a/pymatgen/io/cp2k/tests/test_inputs.py
+++ b/pymatgen/io/cp2k/tests/test_inputs.py
@@ -4,6 +4,7 @@ import unittest
 from pathlib import Path
 
 import numpy as np
+from numpy.testing import assert_array_equal
 from pytest import approx
 
 from pymatgen.core.structure import Molecule, Structure
@@ -122,7 +123,7 @@ class BasisAndPotentialTest(PymatgenTest):
         assert kw.values[0] == "SZV-MOLOPT-GTH"
         molopt.info.admm = True
         kw = molopt.get_keyword()
-        self.assertArrayEqual(kw.values, ["AUX_FIT", "SZV-MOLOPT-GTH"])
+        assert_array_equal(kw.values, ["AUX_FIT", "SZV-MOLOPT-GTH"])
         molopt.info.admm = False
 
     def test_potentials(self):

--- a/pymatgen/io/cp2k/tests/test_inputs.py
+++ b/pymatgen/io/cp2k/tests/test_inputs.py
@@ -162,7 +162,7 @@ class InputTest(PymatgenTest):
         ci = Cp2kInput.from_string(s)
         assert ci["GLOBAL"]["RUN_TYPE"] == Keyword("RUN_TYPE", "energy")
         assert ci["GLOBAL"]["PROJECT_NAME"].description == "default name"
-        self.assertMSONable(ci)
+        self.assert_msonable(ci)
 
     def test_sectionlist(self):
         s1 = Section("TEST")

--- a/pymatgen/io/cp2k/tests/test_outputs.py
+++ b/pymatgen/io/cp2k/tests/test_outputs.py
@@ -36,7 +36,7 @@ class SetTest(PymatgenTest):
     def energy_force(self):
         """Can get energy and forces"""
         assert self.out.final_energy == -197.40000341992783
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             self.out.data["forces"][0], [[-0.00000001, -0.00000001, -0.00000001], [0.00000002, 0.00000002, 0.00000002]]
         )
 
@@ -58,16 +58,16 @@ class SetTest(PymatgenTest):
         assert self.out.data["PV3"][0] == approx(0.4582)
         assert self.out.data["ISO"][0] == approx(0.3584)
         assert self.out.data["ANISO"][0] == approx(0.1498)
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             self.out.data["chi_soft"][0],
             [[5.9508, -1.6579, -1.6579], [-1.6579, 5.9508, -1.6579], [-1.6579, -1.6579, 5.9508]],
         )
-        self.assertArrayAlmostEqual(self.out.data["chi_local"][0], [[0, 0, 0], [0, 0, 0], [0, 0, 0]])
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(self.out.data["chi_local"][0], [[0, 0, 0], [0, 0, 0], [0, 0, 0]])
+        self.assert_all_close(
             self.out.data["chi_total"][0],
             [[5.9508, -1.6579, -1.6579], [-1.6579, 5.9508, -1.6579], [-1.6579, -1.6579, 5.9508]],
         )
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             self.out.data["chi_total_ppm_cgs"][0],
             [[0.3584, -0.0998, -0.0998], [-0.0998, 0.3584, -0.0998], [-0.0998, -0.0998, 0.3584]],
         )
@@ -75,18 +75,18 @@ class SetTest(PymatgenTest):
     def test_gtensor(self):
         self.out.parse_gtensor()
         assert len(self.out.data["gtensor_total"]) == 1
-        self.assertArrayAlmostEqual(self.out.data["gmatrix_zke"][0], [[0, 0, 0], [0, 0, 0], [0, 0, 0]])
-        self.assertArrayAlmostEqual(self.out.data["gmatrix_so"][0], [[0, 0, 0], [0, 0, 0], [0, 0, 0]])
-        self.assertArrayAlmostEqual(self.out.data["gmatrix_soo"][0], [[0, 0, 0], [0, 0, 0], [0, 0, 0]])
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(self.out.data["gmatrix_zke"][0], [[0, 0, 0], [0, 0, 0], [0, 0, 0]])
+        self.assert_all_close(self.out.data["gmatrix_so"][0], [[0, 0, 0], [0, 0, 0], [0, 0, 0]])
+        self.assert_all_close(self.out.data["gmatrix_soo"][0], [[0, 0, 0], [0, 0, 0], [0, 0, 0]])
+        self.assert_all_close(
             self.out.data["gmatrix_total"][0],
             [[2.0023193044, 0.0, 0.0], [0.0, 2.0023193044, 0.0], [0.0, 0.0, 2.0023193044]],
         )
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             self.out.data["gtensor_total"][0],
             [[2.0023193044, 0.0, 0.0], [0.0, 2.0023193044, 0.0], [0.0, 0.0, 2.0023193044]],
         )
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             self.out.data["delta_g"][0],
             [
                 [0.7158445077, -0.6982592888, 0.0007786468],
@@ -110,7 +110,7 @@ class SetTest(PymatgenTest):
                 [-0.0000001288, -0.0000001288, 0.0000000000],
             ],
         ]
-        self.assertArrayAlmostEqual(dat[0], ref)
+        self.assert_all_close(dat[0], ref)
 
 
 if __name__ == "__main__":

--- a/pymatgen/io/exciting/tests/test_inputs.py
+++ b/pymatgen/io/exciting/tests/test_inputs.py
@@ -30,7 +30,7 @@ class ExcitingInputTest(PymatgenTest):
         lattice = [[0.0, 2.81, 2.81], [2.81, 0.0, 2.81], [2.81, 2.81, 0.0]]
         atoms = ["Na", "Cl"]
         fraccoords = [[0.0, 0.0, 0.0], [0.5, 0.5, 0.5]]
-        self.assertArrayAlmostEqual(lattice, excin.structure.lattice.matrix.tolist())
+        self.assert_all_close(lattice, excin.structure.lattice.matrix.tolist())
         assert atoms == [site.specie.symbol for site in excin.structure]
         assert fraccoords == [site.frac_coords.tolist() for site in excin.structure]
 

--- a/pymatgen/io/lammps/tests/test_data.py
+++ b/pymatgen/io/lammps/tests/test_data.py
@@ -10,6 +10,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from monty.json import MontyDecoder, MontyEncoder
+from numpy.testing import assert_array_almost_equal
 from pytest import approx
 from ruamel.yaml import YAML
 
@@ -61,16 +62,16 @@ class LammpsBoxTest(PymatgenTest):
         assert peptide.get_box_shift([1, 0, 0])[0] == 64.211560 - 36.840194
         assert peptide.get_box_shift([0, 0, -1])[-1] == 29.768095 - 57.139462
         quartz = self.quartz
-        np.testing.assert_array_almost_equal(quartz.get_box_shift([0, 0, 1]), [0, 0, 5.4052], 4)
-        np.testing.assert_array_almost_equal(quartz.get_box_shift([0, 1, -1]), [-2.4567, 4.2551, -5.4052], 4)
-        np.testing.assert_array_almost_equal(quartz.get_box_shift([1, -1, 0]), [4.9134 + 2.4567, -4.2551, 0], 4)
+        assert_array_almost_equal(quartz.get_box_shift([0, 0, 1]), [0, 0, 5.4052], 4)
+        assert_array_almost_equal(quartz.get_box_shift([0, 1, -1]), [-2.4567, 4.2551, -5.4052], 4)
+        assert_array_almost_equal(quartz.get_box_shift([1, -1, 0]), [4.9134 + 2.4567, -4.2551, 0], 4)
 
     def test_to_lattice(self):
         peptide = self.peptide.to_lattice()
-        np.testing.assert_array_almost_equal(peptide.abc, [27.371367] * 3)
+        assert_array_almost_equal(peptide.abc, [27.371367] * 3)
         assert peptide.is_orthogonal
         quartz = self.quartz.to_lattice()
-        np.testing.assert_array_almost_equal(
+        assert_array_almost_equal(
             quartz.matrix,
             [[4.913400, 0, 0], [-2.456700, 4.255129, 0], [0, 0, 5.405200]],
         )
@@ -91,7 +92,7 @@ class LammpsDataTest(unittest.TestCase):
 
     def test_structure(self):
         quartz = self.quartz.structure
-        np.testing.assert_array_almost_equal(
+        assert_array_almost_equal(
             quartz.lattice.matrix,
             [[4.913400, 0, 0], [-2.456700, 4.255129, 0], [0, 0, 5.405200]],
         )
@@ -99,15 +100,15 @@ class LammpsDataTest(unittest.TestCase):
         assert "molecule-ID" not in self.quartz.atoms.columns
 
         ethane = self.ethane.structure
-        np.testing.assert_array_almost_equal(ethane.lattice.matrix, np.diag([10.0] * 3))
+        assert_array_almost_equal(ethane.lattice.matrix, np.diag([10.0] * 3))
         lbounds = np.array(self.ethane.box.bounds)[:, 0]
         coords = self.ethane.atoms[["x", "y", "z"]].values - lbounds
-        np.testing.assert_array_almost_equal(ethane.cart_coords, coords)
-        np.testing.assert_array_almost_equal(ethane.site_properties["charge"], self.ethane.atoms["q"])
+        assert_array_almost_equal(ethane.cart_coords, coords)
+        assert_array_almost_equal(ethane.site_properties["charge"], self.ethane.atoms["q"])
         tatb = self.tatb.structure
         frac_coords = tatb.frac_coords[381]
         real_frac_coords = frac_coords - np.floor(frac_coords)
-        np.testing.assert_array_almost_equal(real_frac_coords, [0.01553397, 0.71487872, 0.14134139])
+        assert_array_almost_equal(real_frac_coords, [0.01553397, 0.71487872, 0.14134139])
 
         co = Structure.from_spacegroup(194, Lattice.hexagonal(2.50078, 4.03333), ["Co"], [[1 / 3, 2 / 3, 1 / 4]])
         ld_co = LammpsData.from_structure(co)
@@ -318,7 +319,7 @@ class LammpsDataTest(unittest.TestCase):
             np.testing.assert_array_equal(sample_coeff["coeffs"], c.force_field[ff_kw].iloc[i].values, ff_kw)
         topo = topos[-1]
         atoms = c.atoms[c.atoms["molecule-ID"] == 46]
-        np.testing.assert_array_almost_equal(topo.sites.cart_coords, atoms[["x", "y", "z"]])
+        assert_array_almost_equal(topo.sites.cart_coords, atoms[["x", "y", "z"]])
         np.testing.assert_array_equal(topo.charges, atoms["q"])
         atom_labels = [m[0] for m in mass_info]
         assert topo.sites.site_properties["ff_map"] == [atom_labels[i - 1] for i in atoms["type"]]
@@ -496,7 +497,7 @@ class LammpsDataTest(unittest.TestCase):
         va = velocities[i].dot(a) / np.linalg.norm(a)
         assert va == approx(ld.velocities.loc[i + 1, "vx"])
         assert velocities[i, 1] == approx(ld.velocities.loc[i + 1, "vy"])
-        np.testing.assert_array_almost_equal(ld.masses["mass"], [22.989769, 190.23, 15.9994])
+        assert_array_almost_equal(ld.masses["mass"], [22.989769, 190.23, 15.9994])
         np.testing.assert_array_equal(ld.atoms["type"], [2] * 4 + [3] * 16)
 
     def test_set_charge_atom(self):
@@ -790,11 +791,11 @@ class FuncTest(unittest.TestCase):
         origin = np.random.rand(3) * 10 - 5
         box, symmop = lattice_2_lmpbox(lattice=init_latt, origin=origin)
         boxed_latt = box.to_lattice()
-        np.testing.assert_array_almost_equal(init_latt.abc, boxed_latt.abc)
-        np.testing.assert_array_almost_equal(init_latt.angles, boxed_latt.angles)
+        assert_array_almost_equal(init_latt.abc, boxed_latt.abc)
+        assert_array_almost_equal(init_latt.angles, boxed_latt.angles)
         cart_coords = symmop.operate_multi(init_structure.cart_coords) - origin
         boxed_structure = Structure(boxed_latt, ["H"] * 10, cart_coords, coords_are_cartesian=True)
-        np.testing.assert_array_almost_equal(boxed_structure.frac_coords, frac_coords)
+        assert_array_almost_equal(boxed_structure.frac_coords, frac_coords)
         tetra_latt = Lattice.tetragonal(5, 5)
         tetra_box, _ = lattice_2_lmpbox(tetra_latt)
         assert tetra_box.tilt is None
@@ -803,7 +804,7 @@ class FuncTest(unittest.TestCase):
         assert ortho_box.tilt is None
         rot_tetra_latt = Lattice([[5, 0, 0], [0, 2, 2], [0, -2, 2]])
         _, rotop = lattice_2_lmpbox(rot_tetra_latt)
-        np.testing.assert_array_almost_equal(
+        assert_array_almost_equal(
             rotop.rotation_matrix,
             [
                 [1, 0, 0],
@@ -1021,22 +1022,22 @@ class CombinedDataTest(unittest.TestCase):
 
     def test_structure(self):
         li_ec_structure = self.li_ec.structure
-        np.testing.assert_array_almost_equal(
+        assert_array_almost_equal(
             li_ec_structure.lattice.matrix,
             [[38.698274, 0, 0], [0, 38.698274, 0], [0, 0, 38.698274]],
         )
-        np.testing.assert_array_almost_equal(
+        assert_array_almost_equal(
             li_ec_structure.lattice.angles,
             (90.0, 90.0, 90.0),
         )
         assert li_ec_structure.formula == "Li1 H4 C3 O3"
         lbounds = np.array(self.li_ec.box.bounds)[:, 0]
         coords = self.li_ec.atoms[["x", "y", "z"]].values - lbounds
-        np.testing.assert_array_almost_equal(li_ec_structure.cart_coords, coords)
-        np.testing.assert_array_almost_equal(li_ec_structure.site_properties["charge"], self.li_ec.atoms["q"])
+        assert_array_almost_equal(li_ec_structure.cart_coords, coords)
+        assert_array_almost_equal(li_ec_structure.site_properties["charge"], self.li_ec.atoms["q"])
         frac_coords = li_ec_structure.frac_coords[0]
         real_frac_coords = frac_coords - np.floor(frac_coords)
-        np.testing.assert_array_almost_equal(real_frac_coords, [0.01292047, 0.01292047, 0.01292047])
+        assert_array_almost_equal(real_frac_coords, [0.01292047, 0.01292047, 0.01292047])
 
     def test_from_ff_and_topologies(self):
         with pytest.raises(AttributeError):
@@ -1059,7 +1060,7 @@ class CombinedDataTest(unittest.TestCase):
 
         topo = topos[-1]
         atoms = ld.atoms[ld.atoms["molecule-ID"] == 1]
-        np.testing.assert_array_almost_equal(topo.sites.cart_coords, atoms[["x", "y", "z"]])
+        assert_array_almost_equal(topo.sites.cart_coords, atoms[["x", "y", "z"]])
         np.testing.assert_array_equal(topo.charges, atoms["q"])
         atom_labels = [m[0] for m in mass_info]
         assert topo.sites.site_properties["ff_map"] == [atom_labels[i - 1] for i in atoms["type"]]

--- a/pymatgen/io/lammps/tests/test_outputs.py
+++ b/pymatgen/io/lammps/tests/test_outputs.py
@@ -6,6 +6,7 @@ import unittest
 
 import numpy as np
 import pandas as pd
+from numpy.testing import assert_array_almost_equal
 
 from pymatgen.io.lammps.outputs import LammpsDump, parse_lammps_dumps, parse_lammps_log
 from pymatgen.util.testing import PymatgenTest
@@ -30,18 +31,18 @@ class LammpsDumpTest(unittest.TestCase):
         np.testing.assert_array_equal(self.rdx.data.columns, ["id", "type", "xs", "ys", "zs"])
         rdx_data = self.rdx.data.iloc[-1]
         rdx_data_target = [19, 2, 0.42369, 0.47347, 0.555425]
-        np.testing.assert_array_almost_equal(rdx_data, rdx_data_target)
+        assert_array_almost_equal(rdx_data, rdx_data_target)
 
         assert self.tatb.timestep == 0
         assert self.tatb.natoms == 384
         bounds = [[0, 13.624], [0, 17.1149153805], [0, 15.1826391451]]
-        np.testing.assert_array_almost_equal(self.tatb.box.bounds, bounds)
+        assert_array_almost_equal(self.tatb.box.bounds, bounds)
         tilt = [-5.75315630927, -6.325466, 7.4257288]
-        np.testing.assert_array_almost_equal(self.tatb.box.tilt, tilt)
+        assert_array_almost_equal(self.tatb.box.tilt, tilt)
         np.testing.assert_array_equal(self.tatb.data.columns, ["id", "type", "q", "x", "y", "z"])
         tatb_data = self.tatb.data.iloc[-1]
         tatb_data_target = [356, 3, -0.482096, 2.58647, 12.9577, 14.3143]
-        np.testing.assert_array_almost_equal(tatb_data, tatb_data_target)
+        assert_array_almost_equal(tatb_data, tatb_data_target)
 
     def test_json_dict(self):
         encoded = json.dumps(self.rdx.as_dict())
@@ -80,7 +81,7 @@ class FuncTest(unittest.TestCase):
             [0, 1, -4.6295947, -4.6297237, -4.6297237, 0],
             [5, 1, -4.6295965, -4.6297255, -4.6297255, 0],
         ]
-        np.testing.assert_array_almost_equal(comb0.iloc[[0, -1]], comb0_data)
+        assert_array_almost_equal(comb0.iloc[[0, -1]], comb0_data)
         # final comb run
         comb_1 = comb[-1]
         np.testing.assert_array_equal(
@@ -103,7 +104,7 @@ class FuncTest(unittest.TestCase):
         )
         assert len(comb_1) == 11
         comb_1_data = [[36, 5.1293854e-06], [46, 2192.8256]]
-        np.testing.assert_array_almost_equal(comb_1.iloc[[0, -1], [0, -3]], comb_1_data)
+        assert_array_almost_equal(comb_1.iloc[[0, -1], [0, -3]], comb_1_data)
 
         ehex_file = "log.13Oct16.ehex.g++.8.gz"
         ehex = parse_lammps_log(filename=os.path.join(test_dir, ehex_file))
@@ -116,7 +117,7 @@ class FuncTest(unittest.TestCase):
             [0, 1.35, -4.1241917, 0, -2.0994448, -3.1961612],
             [1000, 1.3732017, -3.7100044, 0, -1.6504594, 0.83982701],
         ]
-        np.testing.assert_array_almost_equal(ehex0.iloc[[0, -1]], ehex0_data)
+        assert_array_almost_equal(ehex0.iloc[[0, -1]], ehex0_data)
         # ehex run #2
         np.testing.assert_array_equal(["Step", "Temp", "c_Thot", "c_Tcold"], ehex1.columns)
         assert len(ehex1) == 11
@@ -124,7 +125,7 @@ class FuncTest(unittest.TestCase):
             [1000, 1.35, 1.431295, 1.2955644],
             [11000, 1.3794051, 1.692299, 1.0515688],
         ]
-        np.testing.assert_array_almost_equal(ehex1.iloc[[0, -1]], ehex1_data)
+        assert_array_almost_equal(ehex1.iloc[[0, -1]], ehex1_data)
         # ehex run #3
         np.testing.assert_array_equal(["Step", "Temp", "c_Thot", "c_Tcold", "v_tdiff", "f_ave"], ehex2.columns)
         assert len(ehex2) == 21
@@ -132,7 +133,7 @@ class FuncTest(unittest.TestCase):
             [11000, 1.3794051, 1.6903393, 1.0515688, 0, 0],
             [31000, 1.3822489, 1.8220413, 1.0322271, -0.7550338, -0.76999077],
         ]
-        np.testing.assert_array_almost_equal(ehex2.iloc[[0, -1]], ehex2_data)
+        assert_array_almost_equal(ehex2.iloc[[0, -1]], ehex2_data)
 
         peptide_file = "log.5Oct16.peptide.g++.1.gz"
         peptide = parse_lammps_log(filename=os.path.join(test_dir, peptide_file))
@@ -158,7 +159,7 @@ class FuncTest(unittest.TestCase):
         assert len(peptide0) == 7
         peptide0_select = peptide0.loc[[0, 6], ["Step", "TotEng", "Press"]]
         peptide0_data = [[0, -5237.4580, -837.0112], [300, -5251.3637, -471.5505]]
-        np.testing.assert_array_almost_equal(peptide0_select, peptide0_data)
+        assert_array_almost_equal(peptide0_select, peptide0_data)
 
 
 if __name__ == "__main__":

--- a/pymatgen/io/lobster/tests/test_lobster.py
+++ b/pymatgen/io/lobster/tests/test_lobster.py
@@ -8,6 +8,7 @@ import warnings
 
 import numpy as np
 import pytest
+from numpy.testing import assert_array_equal
 from pytest import approx
 
 from pymatgen.core.structure import Structure
@@ -853,11 +854,11 @@ class ChargeTest(PymatgenTest):
         atomlist = ["O1", "Mn2"]
         types = ["O", "Mn"]
         num_atoms = 2
-        self.assertArrayEqual(charge_Mulliken, self.charge2.Mulliken)
-        self.assertArrayEqual(charge_Loewdin, self.charge2.Loewdin)
-        self.assertArrayEqual(atomlist, self.charge2.atomlist)
-        self.assertArrayEqual(types, self.charge2.types)
-        self.assertArrayEqual(num_atoms, self.charge2.num_atoms)
+        assert_array_equal(charge_Mulliken, self.charge2.Mulliken)
+        assert_array_equal(charge_Loewdin, self.charge2.Loewdin)
+        assert_array_equal(atomlist, self.charge2.atomlist)
+        assert_array_equal(types, self.charge2.types)
+        assert_array_equal(num_atoms, self.charge2.num_atoms)
 
     def test_get_structure_with_charges(self):
         structure_dict2 = {
@@ -2450,7 +2451,7 @@ class WavefunctionTest(PymatgenTest):
                 "LCAOWaveFunctionAfterLSO1PlotOfSpin1Kpoint1band1.gz",
             )
         )
-        self.assertArrayEqual([41, 41, 41], grid)
+        assert_array_equal([41, 41, 41], grid)
         assert points[4][0] == approx(0.0000)
         assert points[4][1] == approx(0.0000)
         assert points[4][2] == approx(0.4000)

--- a/pymatgen/io/lobster/tests/test_lobster.py
+++ b/pymatgen/io/lobster/tests/test_lobster.py
@@ -368,12 +368,12 @@ class CohpcarTest(PymatgenTest):
             [self.orb.orb_res_cohp["1"][orbs]["COHP"][Spin.up] for orbs in self.orb.orb_res_cohp["1"]],
             axis=0,
         )
-        self.assertArrayAlmostEqual(tot, cohp, decimal=3)
+        self.assert_all_close(tot, cohp, decimal=3)
         tot = np.sum(
             [self.orb.orb_res_cohp["1"][orbs]["ICOHP"][Spin.up] for orbs in self.orb.orb_res_cohp["1"]],
             axis=0,
         )
-        self.assertArrayAlmostEqual(tot, icohp, decimal=3)
+        self.assert_all_close(tot, icohp, decimal=3)
 
         # Lobster 3.1
         cohp_KF = self.cohp_KF.cohp_data["1"]["COHP"][Spin.up]
@@ -382,12 +382,12 @@ class CohpcarTest(PymatgenTest):
             [self.cohp_KF.orb_res_cohp["1"][orbs]["COHP"][Spin.up] for orbs in self.cohp_KF.orb_res_cohp["1"]],
             axis=0,
         )
-        self.assertArrayAlmostEqual(tot_KF, cohp_KF, decimal=3)
+        self.assert_all_close(tot_KF, cohp_KF, decimal=3)
         tot_KF = np.sum(
             [self.cohp_KF.orb_res_cohp["1"][orbs]["ICOHP"][Spin.up] for orbs in self.cohp_KF.orb_res_cohp["1"]],
             axis=0,
         )
-        self.assertArrayAlmostEqual(tot_KF, icohp_KF, decimal=3)
+        self.assert_all_close(tot_KF, icohp_KF, decimal=3)
 
         # d and f orbitals
         cohp_Na2UO4 = self.cohp_Na2UO4.cohp_data["49"]["COHP"][Spin.up]
@@ -399,7 +399,7 @@ class CohpcarTest(PymatgenTest):
             ],
             axis=0,
         )
-        self.assertArrayAlmostEqual(tot_Na2UO4, cohp_Na2UO4, decimal=3)
+        self.assert_all_close(tot_Na2UO4, cohp_Na2UO4, decimal=3)
         tot_Na2UO4 = np.sum(
             [
                 self.cohp_Na2UO4.orb_res_cohp["49"][orbs]["ICOHP"][Spin.up]
@@ -407,7 +407,7 @@ class CohpcarTest(PymatgenTest):
             ],
             axis=0,
         )
-        self.assertArrayAlmostEqual(tot_Na2UO4, icohp_Na2UO4, decimal=3)
+        self.assert_all_close(tot_Na2UO4, icohp_Na2UO4, decimal=3)
 
 
 class IcohplistTest(unittest.TestCase):

--- a/pymatgen/io/qchem/tests/test_outputs.py
+++ b/pymatgen/io/qchem/tests/test_outputs.py
@@ -4,6 +4,7 @@ import os
 import unittest
 
 from monty.serialization import dumpfn, loadfn
+from numpy.testing import assert_array_equal
 from pytest import approx
 
 from pymatgen.core.structure import Molecule
@@ -279,7 +280,7 @@ class TestQCOutput(PymatgenTest):
                 assert outdata.get(key) == single_job_dict[name].get(key)
             except ValueError:
                 try:
-                    self.assertArrayEqual(outdata.get(key), single_job_dict[name].get(key))
+                    assert_array_equal(outdata.get(key), single_job_dict[name].get(key))
                 except AssertionError:
                     raise RuntimeError("Issue with file: " + name + " Exiting...")
             except AssertionError:
@@ -289,7 +290,7 @@ class TestQCOutput(PymatgenTest):
                 try:
                     assert sub_output.data.get(key) == multi_job_dict[name][ii].get(key)
                 except ValueError:
-                    self.assertArrayEqual(sub_output.data.get(key), multi_job_dict[name][ii].get(key))
+                    assert_array_equal(sub_output.data.get(key), multi_job_dict[name][ii].get(key))
 
     @unittest.skipIf(openbabel is None, "OpenBabel not installed.")
     def test_all(self):

--- a/pymatgen/io/tests/test_atat.py
+++ b/pymatgen/io/tests/test_atat.py
@@ -94,7 +94,7 @@ class AtatTest(PymatgenTest):
         struc_from_out = Structure.from_file(os.path.join(test_dir, "bestsqs_nacl.out"))
 
         assert struc_from_cif.matches(struc_from_out)
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             struc_from_out.lattice.parameters,
             struc_from_cif.lattice.parameters,
             decimal=4,
@@ -108,7 +108,7 @@ class AtatTest(PymatgenTest):
         struc_from_out = Structure.from_file(os.path.join(test_dir, "bestsqs_pzt.out"))
 
         assert struc_from_cif.matches(struc_from_out)
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             struc_from_out.lattice.parameters,
             struc_from_cif.lattice.parameters,
             decimal=4,

--- a/pymatgen/io/tests/test_lmto.py
+++ b/pymatgen/io/tests/test_lmto.py
@@ -4,6 +4,7 @@ import os
 import unittest
 
 import numpy as np
+from numpy.testing import assert_array_equal
 
 from pymatgen.core.structure import Structure
 from pymatgen.core.units import Ry_to_eV
@@ -92,11 +93,11 @@ class CoplTest(PymatgenTest):
             [round_to_sigfigs(energy, 5) for energy in self.copl_bise.energies * Ry_to_eV],
             dtype=float,
         )
-        self.assertArrayEqual(ener_eV, self.copl_bise_eV.energies)
+        assert_array_equal(ener_eV, self.copl_bise_eV.energies)
         copl_icohp = self.copl_bise.cohp_data["Bi1-Se7"]["ICOHP"][Spin.up]
         icohp = np.array([round_to_sigfigs(i, 5) for i in copl_icohp * Ry_to_eV], dtype=float)
         icohp_eV = self.copl_bise_eV.cohp_data["Bi1-Se7"]["ICOHP"][Spin.up]
-        self.assertArrayEqual(icohp, icohp_eV)
+        assert_array_equal(icohp, icohp_eV)
 
 
 if __name__ == "__main__":

--- a/pymatgen/io/tests/test_phonopy.py
+++ b/pymatgen/io/tests/test_phonopy.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 from monty.tempfile import ScratchDir
+from numpy.testing import assert_array_equal
 from pytest import approx
 
 from pymatgen.core.periodic_table import Element
@@ -46,14 +47,14 @@ class PhonopyParserTest(PymatgenTest):
 
         assert ph_bs.bands[1][10] == approx(0.7753555184)
         assert ph_bs.bands[5][100] == approx(5.2548379776)
-        self.assertArrayEqual(ph_bs.bands.shape, (6, 204))
-        self.assertArrayEqual(ph_bs.eigendisplacements.shape, (6, 204, 2, 3))
+        assert_array_equal(ph_bs.bands.shape, (6, 204))
+        assert_array_equal(ph_bs.eigendisplacements.shape, (6, 204, 2, 3))
         self.assertArrayAlmostEqual(
             ph_bs.eigendisplacements[3][50][0],
             [0.0 + 0.0j, 0.14166569 + 0.04098339j, -0.14166569 - 0.04098339j],
         )
         assert ph_bs.has_eigendisplacements, True
-        self.assertArrayEqual(ph_bs.min_freq()[0].frac_coords, [0, 0, 0])
+        assert_array_equal(ph_bs.min_freq()[0].frac_coords, [0, 0, 0])
         assert ph_bs.min_freq()[1] == approx(-0.03700895020)
         assert ph_bs.has_imaginary_freq()
         assert not ph_bs.has_imaginary_freq(tol=0.5)

--- a/pymatgen/io/tests/test_phonopy.py
+++ b/pymatgen/io/tests/test_phonopy.py
@@ -49,7 +49,7 @@ class PhonopyParserTest(PymatgenTest):
         assert ph_bs.bands[5][100] == approx(5.2548379776)
         assert_array_equal(ph_bs.bands.shape, (6, 204))
         assert_array_equal(ph_bs.eigendisplacements.shape, (6, 204, 2, 3))
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             ph_bs.eigendisplacements[3][50][0],
             [0.0 + 0.0j, 0.14166569 + 0.04098339j, -0.14166569 - 0.04098339j],
         )
@@ -58,14 +58,14 @@ class PhonopyParserTest(PymatgenTest):
         assert ph_bs.min_freq()[1] == approx(-0.03700895020)
         assert ph_bs.has_imaginary_freq()
         assert not ph_bs.has_imaginary_freq(tol=0.5)
-        self.assertArrayAlmostEqual(ph_bs.asr_breaking(), [-0.0370089502, -0.0370089502, -0.0221388897])
+        self.assert_all_close(ph_bs.asr_breaking(), [-0.0370089502, -0.0370089502, -0.0221388897])
         assert ph_bs.nb_bands == 6
         assert ph_bs.nb_qpoints == 204
-        self.assertArrayAlmostEqual(ph_bs.qpoints[1].frac_coords, [0.01, 0, 0])
+        self.assert_all_close(ph_bs.qpoints[1].frac_coords, [0.01, 0, 0])
         assert ph_bs.has_nac
         assert ph_bs.get_nac_frequencies_along_dir([1, 1, 0])[3] == approx(4.6084532143)
         assert ph_bs.get_nac_frequencies_along_dir([1, 0, 1]) is None
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             ph_bs.get_nac_eigendisplacements_along_dir([1, 1, 0])[3][1],
             [(0.1063906409128248 + 0j), 0j, 0j],
         )
@@ -111,8 +111,8 @@ class StructureConversionTest(PymatgenTest):
         assert s_pmg.lattice._matrix[1, 1] == approx(s_pmg2.lattice._matrix[1, 1], abs=1e-7)
         assert symbols_pmg == set(s_ph.symbols)
         assert symbols_pmg == symbols_pmg2
-        self.assertArrayAlmostEqual(coords_ph[3], s_pmg.frac_coords[3])
-        self.assertArrayAlmostEqual(s_pmg.frac_coords[3], s_pmg2.frac_coords[3])
+        self.assert_all_close(coords_ph[3], s_pmg.frac_coords[3])
+        self.assert_all_close(s_pmg.frac_coords[3], s_pmg2.frac_coords[3])
         assert s_ph.get_number_of_atoms() == s_pmg.num_sites
         assert s_pmg.num_sites == s_pmg2.num_sites
 
@@ -125,19 +125,19 @@ class GetDisplacedStructuresTest(PymatgenTest):
         structures = get_displaced_structures(pmg_structure=pmg_s, atom_disp=0.01, supercell_matrix=supercell_matrix)
 
         assert len(structures) == 49
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             structures[4].frac_coords[0],
             np.array([0.10872682, 0.21783039, 0.12595286]),
             7,
         )
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             structures[-1].frac_coords[9],
             np.array([0.89127318, 0.78130015, 0.37404715]),
             7,
         )
         assert structures[0].num_sites == 128
         assert structures[10].num_sites == 128
-        self.assertArrayAlmostEqual(structures[0].lattice._matrix, structures[8].lattice._matrix, 8)
+        self.assert_all_close(structures[0].lattice._matrix, structures[8].lattice._matrix, 8)
 
         # test writing output
         with ScratchDir("."):
@@ -249,20 +249,20 @@ class TestThermalDisplacementMatrices(PymatgenTest):
             os.path.join(PymatgenTest.TEST_FILES_DIR, "thermal_displacement_matrices", "POSCAR"),
         )
 
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             list(list_matrices[0].thermal_displacement_matrix_cart[0]),
             [0.00516, 0.00613, 0.00415, -0.00011, -0.00158, -0.00081],
         )
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             list(list_matrices[0].thermal_displacement_matrix_cart[21]),
             [0.00488, 0.00497, 0.00397, -0.00070, -0.00070, 0.00144],
         )
 
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             list(list_matrices[0].thermal_displacement_matrix_cif[0]),
             [0.00457, 0.00613, 0.00415, -0.00011, -0.00081, -0.00082],
         )
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             list(list_matrices[0].thermal_displacement_matrix_cif[21]),
             [0.00461, 0.00497, 0.00397, -0.00070, 0.00002, 0.00129],
         )

--- a/pymatgen/io/tests/test_shengbte.py
+++ b/pymatgen/io/tests/test_shengbte.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import os
 import unittest
 
+from numpy.testing import assert_array_equal
+
 from pymatgen.io.shengbte import Control
 from pymatgen.util.testing import PymatgenTest
 
@@ -47,7 +49,7 @@ class TestShengBTE(PymatgenTest):
         io = Control.from_file(self.filename)
         assert io["nelements"] == 1
         assert io["natoms"] == 2
-        self.assertArrayEqual(io["ngrid"], [25, 25, 25])
+        assert_array_equal(io["ngrid"], [25, 25, 25])
         assert io["norientations"] == 0
         assert io["lfactor"] == 0.1
         assert io["lattvec"][0] == [0.0, 2.734363999, 2.734363999]
@@ -61,8 +63,8 @@ class TestShengBTE(PymatgenTest):
         if isinstance(io["types"], list):
             all_ints = all(isinstance(item, int) for item in io["types"])
             assert all_ints
-        self.assertArrayEqual(io["positions"], [[0.0, 0.0, 0.0], [0.25, 0.25, 0.25]])
-        self.assertArrayEqual(io["scell"], [5, 5, 5])
+        assert_array_equal(io["positions"], [[0.0, 0.0, 0.0], [0.25, 0.25, 0.25]])
+        assert_array_equal(io["scell"], [5, 5, 5])
         assert io["t"] == 500
         assert io["scalebroad"] == 0.5
         assert not io["isotopes"]

--- a/pymatgen/io/vasp/tests/test_inputs.py
+++ b/pymatgen/io/vasp/tests/test_inputs.py
@@ -182,7 +182,7 @@ cart
 """
         p = Poscar.from_string(poscar_string)
         site = p.structure[1]
-        self.assertArrayAlmostEqual(site.coords, np.array([3.840198, 1.5, 2.35163175]) * 1.1)
+        self.assert_all_close(site.coords, np.array([3.840198, 1.5, 2.35163175]) * 1.1)
 
     def test_significant_figures(self):
         si = 14
@@ -283,9 +283,9 @@ direct
         p.write_file(tempfname)
         p3 = Poscar.from_file(tempfname)
 
-        self.assertArrayAlmostEqual(p.structure.lattice.abc, p3.structure.lattice.abc, 5)
-        self.assertArrayAlmostEqual(p.velocities, p3.velocities, 5)
-        self.assertArrayAlmostEqual(p.predictor_corrector, p3.predictor_corrector, 5)
+        self.assert_all_close(p.structure.lattice.abc, p3.structure.lattice.abc, 5)
+        self.assert_all_close(p.velocities, p3.velocities, 5)
+        self.assert_all_close(p.predictor_corrector, p3.predictor_corrector, 5)
         assert p.predictor_corrector_preamble == p3.predictor_corrector_preamble
         tempfname.unlink()
 
@@ -369,7 +369,7 @@ direct
         tempfname = Path("POSCAR.testing")
         poscar.write_file(tempfname)
         p = Poscar.from_file(tempfname)
-        self.assertArrayAlmostEqual(poscar.structure.lattice.abc, p.structure.lattice.abc, 5)
+        self.assert_all_close(poscar.structure.lattice.abc, p.structure.lattice.abc, 5)
         tempfname.unlink()
 
     def test_selective_dynamics(self):
@@ -820,7 +820,7 @@ G
 0.5 0.5 0.5
 """
         )
-        self.assertArrayAlmostEqual(kpoints.kpts_shift, [0.5, 0.5, 0.5])
+        self.assert_all_close(kpoints.kpts_shift, [0.5, 0.5, 0.5])
 
     def test_as_dict_from_dict(self):
         k = Kpoints.monkhorst_automatic([2, 2, 2], [0, 0, 0])
@@ -862,7 +862,7 @@ direct
 0.000000 0.000000 0.000000 Al"""
         )
         kpoints = Kpoints.automatic_density(p.structure, 1000)
-        self.assertArrayAlmostEqual(kpoints.kpts[0], [10, 10, 10])
+        self.assert_all_close(kpoints.kpts[0], [10, 10, 10])
 
 
 class PotcarSingleTest(PymatgenTest):

--- a/pymatgen/io/vasp/tests/test_outputs.py
+++ b/pymatgen/io/vasp/tests/test_outputs.py
@@ -949,8 +949,8 @@ class OutcarTest(PymatgenTest):
         )
 
         plasma_freq = outcar.plasma_frequencies
-        self.assertArrayAlmostEqual(plasma_freq["intraband"], np.zeros((3, 3)))
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(plasma_freq["intraband"], np.zeros((3, 3)))
+        self.assert_all_close(
             plasma_freq["interband"],
             [
                 [367.49, 63.939, 11.976],
@@ -1110,7 +1110,7 @@ class OutcarTest(PymatgenTest):
 
         assert len(outcar.data["chemical_shielding"]["valence_only"][20:28]) == approx(len(expected_chemical_shielding))
 
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             outcar.data["chemical_shielding"]["valence_and_core"][20:28],
             expected_chemical_shielding,
             decimal=5,
@@ -1200,7 +1200,7 @@ class OutcarTest(PymatgenTest):
 
         assert len(outcar.data["unsym_efg_tensor"][2:10]) == len(exepected_tensors)
         for e1, e2 in zip(outcar.data["unsym_efg_tensor"][2:10], exepected_tensors):
-            self.assertArrayAlmostEqual(e1, e2)
+            self.assert_all_close(e1, e2)
 
     def test_read_fermi_contact_shift(self):
         filepath = self.TEST_FILES_DIR / "OUTCAR_fc"
@@ -1565,10 +1565,10 @@ class ChgcarTest(PymatgenTest):
         import h5py
 
         with h5py.File("chgcar_test.hdf5", "r") as f:
-            self.assertArrayAlmostEqual(np.array(f["vdata"]["total"]), chgcar.data["total"])
-            self.assertArrayAlmostEqual(np.array(f["vdata"]["diff"]), chgcar.data["diff"])
-            self.assertArrayAlmostEqual(np.array(f["lattice"]), chgcar.structure.lattice.matrix)
-            self.assertArrayAlmostEqual(np.array(f["fcoords"]), chgcar.structure.frac_coords)
+            self.assert_all_close(np.array(f["vdata"]["total"]), chgcar.data["total"])
+            self.assert_all_close(np.array(f["vdata"]["diff"]), chgcar.data["diff"])
+            self.assert_all_close(np.array(f["lattice"]), chgcar.structure.lattice.matrix)
+            self.assert_all_close(np.array(f["fcoords"]), chgcar.structure.frac_coords)
             for z in f["Z"]:
                 assert z in [Element.Ni.Z, Element.O.Z]
 
@@ -1576,7 +1576,7 @@ class ChgcarTest(PymatgenTest):
                 assert sp in [b"Ni", b"O"]
 
         chgcar2 = Chgcar.from_hdf5("chgcar_test.hdf5")
-        self.assertArrayAlmostEqual(chgcar2.data["total"], chgcar.data["total"])
+        self.assert_all_close(chgcar2.data["total"], chgcar.data["total"])
         os.remove("chgcar_test.hdf5")
 
     def test_spin_data(self):
@@ -1585,7 +1585,7 @@ class ChgcarTest(PymatgenTest):
 
     def test_add(self):
         chgcar_sum = self.chgcar_spin + self.chgcar_spin
-        self.assertArrayAlmostEqual(chgcar_sum.data["total"], self.chgcar_spin.data["total"] * 2)
+        self.assert_all_close(chgcar_sum.data["total"], self.chgcar_spin.data["total"] * 2)
         chgcar_copy = self.chgcar_spin.copy()
         chgcar_copy.structure = self.get_structure("Li2O")
         with warnings.catch_warnings(record=True) as w:
@@ -1604,8 +1604,8 @@ class ChgcarTest(PymatgenTest):
     def test_as_dict_and_from_dict(self):
         d = self.chgcar_NiO_SOC.as_dict()
         chgcar_from_dict = Chgcar.from_dict(d)
-        self.assertArrayAlmostEqual(self.chgcar_NiO_SOC.data["total"], chgcar_from_dict.data["total"])
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(self.chgcar_NiO_SOC.data["total"], chgcar_from_dict.data["total"])
+        self.assert_all_close(
             self.chgcar_NiO_SOC.structure.lattice.matrix,
             chgcar_from_dict.structure.lattice.matrix,
         )

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -431,7 +431,7 @@ class MITMPRelaxSetTest(PymatgenTest):
         assert incar["ISMEAR"] == 1
         assert incar["SIGMA"] == 0.2
         kpoints = mp_metal_set.kpoints
-        self.assertArrayAlmostEqual(kpoints.kpts[0], [5, 5, 5])
+        self.assert_all_close(kpoints.kpts[0], [5, 5, 5])
 
     def test_as_from_dict(self):
         mitset = MITRelaxSet(self.structure)
@@ -1130,7 +1130,7 @@ class MVLSlabSetTest(PymatgenTest):
         # Test auto-dipole
         dipole_incar = self.d_dipole["INCAR"]
         assert dipole_incar["LDIPOL"]
-        self.assertArrayAlmostEqual(dipole_incar["DIPOL"], [0.2323, 0.2323, 0.2165], decimal=4)
+        self.assert_all_close(dipole_incar["DIPOL"], [0.2323, 0.2323, 0.2165], decimal=4)
         assert dipole_incar["IDIPOL"] == 3
 
     def test_kpoints(self):

--- a/pymatgen/phonon/tests/test_bandstructure.py
+++ b/pymatgen/phonon/tests/test_bandstructure.py
@@ -79,8 +79,8 @@ class PhononBandStructureSymmLineTest(PymatgenTest):
         s = self.bs2.as_phononwebsite()
         assert s is not None
         assert json.dumps(s) is not None
-        self.assertMSONable(self.bs)
-        self.assertMSONable(self.bs2)
+        self.assert_msonable(self.bs)
+        self.assert_msonable(self.bs2)
 
     def test_write_methods(self):
         self.bs2.write_phononwebsite("test.json")

--- a/pymatgen/phonon/tests/test_bandstructure.py
+++ b/pymatgen/phonon/tests/test_bandstructure.py
@@ -4,6 +4,7 @@ import json
 import os
 import unittest
 
+from numpy.testing import assert_array_equal
 from pytest import approx
 
 from pymatgen.phonon.bandstructure import PhononBandStructureSymmLine
@@ -29,15 +30,15 @@ class PhononBandStructureSymmLineTest(PymatgenTest):
     def test_basic(self):
         assert self.bs.bands[1][10] == approx(0.7753555184)
         assert self.bs.bands[5][100] == approx(5.2548379776)
-        self.assertArrayEqual(self.bs.bands.shape, (6, 204))
-        self.assertArrayEqual(self.bs.eigendisplacements.shape, (6, 204, 2, 3))
+        assert_array_equal(self.bs.bands.shape, (6, 204))
+        assert_array_equal(self.bs.eigendisplacements.shape, (6, 204, 2, 3))
         self.assertArrayAlmostEqual(
             self.bs.eigendisplacements[3][50][0],
             [0.0 + 0.0j, 0.14166569 + 0.04098339j, -0.14166569 - 0.04098339j],
         )
         assert self.bs.has_eigendisplacements, True
 
-        self.assertArrayEqual(self.bs.min_freq()[0].frac_coords, [0, 0, 0])
+        assert_array_equal(self.bs.min_freq()[0].frac_coords, [0, 0, 0])
         assert self.bs.min_freq()[1] == approx(-0.03700895020)
         assert self.bs.has_imaginary_freq()
         assert not self.bs.has_imaginary_freq(tol=0.5)

--- a/pymatgen/phonon/tests/test_bandstructure.py
+++ b/pymatgen/phonon/tests/test_bandstructure.py
@@ -32,7 +32,7 @@ class PhononBandStructureSymmLineTest(PymatgenTest):
         assert self.bs.bands[5][100] == approx(5.2548379776)
         assert_array_equal(self.bs.bands.shape, (6, 204))
         assert_array_equal(self.bs.eigendisplacements.shape, (6, 204, 2, 3))
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             self.bs.eigendisplacements[3][50][0],
             [0.0 + 0.0j, 0.14166569 + 0.04098339j, -0.14166569 - 0.04098339j],
         )
@@ -42,12 +42,12 @@ class PhononBandStructureSymmLineTest(PymatgenTest):
         assert self.bs.min_freq()[1] == approx(-0.03700895020)
         assert self.bs.has_imaginary_freq()
         assert not self.bs.has_imaginary_freq(tol=0.5)
-        self.assertArrayAlmostEqual(self.bs.asr_breaking(), [-0.0370089502, -0.0370089502, -0.0221388897])
+        self.assert_all_close(self.bs.asr_breaking(), [-0.0370089502, -0.0370089502, -0.0221388897])
 
         assert self.bs.nb_bands == 6
         assert self.bs.nb_qpoints == 204
 
-        self.assertArrayAlmostEqual(self.bs.qpoints[1].frac_coords, [0.01, 0, 0])
+        self.assert_all_close(self.bs.qpoints[1].frac_coords, [0.01, 0, 0])
 
     def test_nac(self):
         assert self.bs.has_nac
@@ -55,7 +55,7 @@ class PhononBandStructureSymmLineTest(PymatgenTest):
         assert self.bs.get_nac_frequencies_along_dir([1, 1, 0])[3] == approx(4.6084532143)
         assert self.bs.get_nac_frequencies_along_dir([0, 1, 1]) is None
         assert self.bs2.get_nac_frequencies_along_dir([0, 0, 1]) is None
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             self.bs.get_nac_eigendisplacements_along_dir([1, 1, 0])[3][1],
             [(0.1063906409128248 + 0j), 0j, 0j],
         )

--- a/pymatgen/phonon/tests/test_dos.py
+++ b/pymatgen/phonon/tests/test_dos.py
@@ -34,7 +34,7 @@ class DosTest(PymatgenTest):
     def test_dict_methods(self):
         s = json.dumps(self.dos.as_dict())
         assert s is not None
-        self.assertMSONable(self.dos)
+        self.assert_msonable(self.dos)
 
     def test_thermodynamic_functions(self):
         assert self.dos.cv(300, structure=self.structure) == approx(48.049366665412485, abs=1e-4)
@@ -68,7 +68,7 @@ class CompleteDosTest(PymatgenTest):
     def test_dict_methods(self):
         s = json.dumps(self.cdos.as_dict())
         assert s is not None
-        self.assertMSONable(self.cdos)
+        self.assert_msonable(self.cdos)
 
     def test_str(self):
         assert str(self.cdos) is not None

--- a/pymatgen/phonon/tests/test_dos.py
+++ b/pymatgen/phonon/tests/test_dos.py
@@ -62,8 +62,8 @@ class CompleteDosTest(PymatgenTest):
         assert Element.Cl in self.cdos.get_element_dos()
 
         sum_dos = self.cdos.get_element_dos()[Element.Na] + self.cdos.get_element_dos()[Element.Cl]
-        self.assertArrayAlmostEqual(sum_dos.frequencies, self.cdos.frequencies)
-        self.assertArrayAlmostEqual(sum_dos.densities, self.cdos.densities)
+        assert sum_dos.frequencies == approx(self.cdos.frequencies)
+        assert sum_dos.densities == approx(self.cdos.densities)
 
     def test_dict_methods(self):
         s = json.dumps(self.cdos.as_dict())

--- a/pymatgen/phonon/tests/test_thermal_displacements.py
+++ b/pymatgen/phonon/tests/test_thermal_displacements.py
@@ -106,12 +106,12 @@ class ThermalDisplacementTest(PymatgenTest):
     def test_Ucart(self):
         assert self.thermal.thermal_displacement_matrix_cart[0][0] == approx(0.00516)
         # U11, U22, U33, U23, U13, U12
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             self.thermal.thermal_displacement_matrix_cart_matrixform[0],
             [[5.16e-03, -8.10e-04, -1.58e-03], [-8.10e-04, 6.13e-03, -1.10e-04], [-1.58e-03, -1.10e-04, 4.15e-03]],
             5,
         )
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             self.thermal_with_cif.thermal_displacement_matrix_cart_matrixform[0],
             [[5.16e-03, -8.10e-04, -1.58e-03], [-8.10e-04, 6.13e-03, -1.10e-04], [-1.58e-03, -1.10e-04, 4.15e-03]],
             5,
@@ -122,7 +122,7 @@ class ThermalDisplacementTest(PymatgenTest):
 
     def test_Ustar(self):
         Ustar = self.thermal.Ustar
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             Ustar[0],
             ThermalDisplacementMatrices.get_full_matrix(
                 [[1.664527e-04, 2.287923e-04, 1.858146e-05, -1.421950e-06, -1.040138e-05, -3.009800e-05]]
@@ -132,7 +132,7 @@ class ThermalDisplacementTest(PymatgenTest):
 
     def test_Ucif(self):
         Ucif = self.thermal.Ucif
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             Ucif[0],
             ThermalDisplacementMatrices.get_full_matrix(
                 [[0.004574, 0.006130, 0.004150, -0.000110, -0.000815, -0.000817]]
@@ -142,7 +142,7 @@ class ThermalDisplacementTest(PymatgenTest):
 
     def test_B(self):
         B = self.thermal.B
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             B[0],
             ThermalDisplacementMatrices.get_full_matrix(
                 [[0.361112, 0.484005, 0.327672, -0.008685, -0.064335, -0.064479]]
@@ -152,14 +152,14 @@ class ThermalDisplacementTest(PymatgenTest):
 
     def test_beta(self):
         beta = self.thermal.beta
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             beta[0],
             ThermalDisplacementMatrices.get_full_matrix(
                 [[3.285645e-03, 4.516179e-03, 3.667833e-04, -2.806818e-05, -2.053151e-04, -5.941107e-04]]
             )[0],
             5,
         )
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             beta[-1],
             ThermalDisplacementMatrices.get_full_matrix(
                 [[3.308590e-03, 3.661568e-03, 3.508740e-04, -1.786229e-04, 4.787484e-06, 9.400372e-04]]
@@ -209,7 +209,7 @@ class ThermalDisplacementTest(PymatgenTest):
             ),
             temperature=0.0,
         )
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             thermal.thermal_displacement_matrix_cart,
             [
                 [5.16e-03, 6.13e-03, 4.15e-03, -1.10e-04, -1.58e-03, -8.10e-04],
@@ -239,12 +239,12 @@ class ThermalDisplacementTest(PymatgenTest):
         )
 
     def test_compute_directionality_quality_criterion(self):
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             self.thermal.compute_directionality_quality_criterion(self.thermal)[0]["vector0"],
             [-0.6502072, 0.67306922, 0.35243215],
         )
 
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             self.thermal.compute_directionality_quality_criterion(self.thermal)[0]["vector1"],
             [-0.6502072, 0.67306922, 0.35243215],
         )
@@ -280,7 +280,7 @@ class ThermalDisplacementTest(PymatgenTest):
             temperature=0.0,
         )
         assert self.thermal.compute_directionality_quality_criterion(self.thermal)[0]["angle"] == approx(0.0)
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             self.thermal.compute_directionality_quality_criterion(thermal)[0]["vector0"],
             self.thermal.compute_directionality_quality_criterion(thermal)[1]["vector1"],
         )
@@ -297,11 +297,11 @@ class ThermalDisplacementTest(PymatgenTest):
         structure = self.thermal.to_structure_with_site_properties_Ucif()
         # test reading of structure with site properties
         new_thermals = ThermalDisplacementMatrices.from_structure_with_site_properties_Ucif(structure)
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             self.thermal.thermal_displacement_matrix_cart, new_thermals.thermal_displacement_matrix_cart
         )
-        self.assertArrayAlmostEqual(self.thermal.structure.frac_coords, new_thermals.structure.frac_coords)
-        self.assertArrayAlmostEqual(self.thermal.structure.lattice.volume, new_thermals.structure.lattice.volume)
+        self.assert_all_close(self.thermal.structure.frac_coords, new_thermals.structure.frac_coords)
+        self.assert_all_close(self.thermal.structure.lattice.volume, new_thermals.structure.lattice.volume)
 
     def test_visualization_directionality_criterion(self):
         # test file creation for VESTA
@@ -321,6 +321,6 @@ class ThermalDisplacementTest(PymatgenTest):
         with tempfile.TemporaryDirectory() as tmp_dir:
             self.thermal.write_cif(os.path.join(tmp_dir, "U.cif"))
             new_thermals = ThermalDisplacementMatrices.from_cif_P1(os.path.join(tmp_dir, "U.cif"))
-            self.assertArrayAlmostEqual(new_thermals[0].thermal_displacement_matrix_cif_matrixform, self.thermal.Ucif)
-            self.assertArrayAlmostEqual(new_thermals[0].structure.frac_coords, self.thermal.structure.frac_coords)
-            self.assertArrayAlmostEqual(new_thermals[0].structure.lattice.volume, self.thermal.structure.lattice.volume)
+            self.assert_all_close(new_thermals[0].thermal_displacement_matrix_cif_matrixform, self.thermal.Ucif)
+            self.assert_all_close(new_thermals[0].structure.frac_coords, self.thermal.structure.frac_coords)
+            self.assert_all_close(new_thermals[0].structure.lattice.volume, self.thermal.structure.lattice.volume)

--- a/pymatgen/phonon/tests/test_thermal_displacements.py
+++ b/pymatgen/phonon/tests/test_thermal_displacements.py
@@ -306,11 +306,11 @@ class ThermalDisplacementTest(PymatgenTest):
     def test_visualization_directionality_criterion(self):
         # test file creation for VESTA
         printed = False
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory() as tmp_dir:
             self.thermal.visualize_directionality_quality_criterion(
-                filename=os.path.join(tmpdirname, "U.vesta"), other=self.thermal, which_structure=0
+                filename=os.path.join(tmp_dir, "U.vesta"), other=self.thermal, which_structure=0
             )
-            with open(os.path.join(tmpdirname, "U.vesta")) as file:
+            with open(os.path.join(tmp_dir, "U.vesta")) as file:
                 file.seek(0)  # set position to start of file
                 lines = file.read().splitlines()  # now we won't have those newlines
                 if "VECTR" in lines:
@@ -318,9 +318,9 @@ class ThermalDisplacementTest(PymatgenTest):
         assert printed
 
     def test_from_cif_P1(self):
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            self.thermal.write_cif(os.path.join(tmpdirname, "U.cif"))
-            new_thermals = ThermalDisplacementMatrices.from_cif_P1(os.path.join(tmpdirname, "U.cif"))
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            self.thermal.write_cif(os.path.join(tmp_dir, "U.cif"))
+            new_thermals = ThermalDisplacementMatrices.from_cif_P1(os.path.join(tmp_dir, "U.cif"))
             self.assertArrayAlmostEqual(new_thermals[0].thermal_displacement_matrix_cif_matrixform, self.thermal.Ucif)
             self.assertArrayAlmostEqual(new_thermals[0].structure.frac_coords, self.thermal.structure.frac_coords)
             self.assertArrayAlmostEqual(new_thermals[0].structure.lattice.volume, self.thermal.structure.lattice.volume)

--- a/pymatgen/symmetry/tests/test_analyzer.py
+++ b/pymatgen/symmetry/tests/test_analyzer.py
@@ -88,9 +88,9 @@ class SpacegroupAnalyzerTest(PymatgenTest):
             for fop, op, pgop in zip(frac_symm_ops, symm_ops, pg_ops):
                 # translation vector values should all be 0 or 0.5
                 t = fop.translation_vector * 2
-                self.assertArrayAlmostEqual(t - np.round(t), 0)
+                self.assert_all_close(t - np.round(t), 0)
 
-                self.assertArrayAlmostEqual(fop.rotation_matrix, pgop.rotation_matrix)
+                self.assert_all_close(fop.rotation_matrix, pgop.rotation_matrix)
                 for site in structure:
                     new_frac = fop.operate(site.frac_coords)
                     new_cart = op.operate(site.coords)

--- a/pymatgen/symmetry/tests/test_maggroups.py
+++ b/pymatgen/symmetry/tests/test_maggroups.py
@@ -109,7 +109,7 @@ x+1/2, -y+5/4, -z+3/4, -1
 -x+5/4, y+1/2, -z+3/4, -1
 -x+1/2, y+3/4, z+1/4, -1
 x+3/4, -y+1/2, z+1/4, -1"""
-        self.assertStrContentEqual(msg_1_symmops, msg_1_symmops_ref)
+        self.assert_str_content_equal(msg_1_symmops, msg_1_symmops_ref)
 
         msg_2_symmops = "\n".join(map(str, self.msg_2.symmetry_ops))
         msg_2_symmops_ref = """x, y, z, +1
@@ -120,7 +120,7 @@ x+1/2, -y+1/2, -z+1/2, -1
 -x+1/2, -y, z+1/2, -1
 -x+1/2, y+1/2, z+1/2, -1
 x+1/2, y, -z+1/2, -1"""
-        self.assertStrContentEqual(msg_2_symmops, msg_2_symmops_ref)
+        self.assert_str_content_equal(msg_2_symmops, msg_2_symmops_ref)
 
         msg_3_symmops = "\n".join(map(str, self.msg_3.symmetry_ops))
         msg_3_symmops_ref = """x, y, z, +1
@@ -200,8 +200,8 @@ Wyckoff Positions (OG): (1,0,0)+ (0,2,0)+ (0,0,1)+
 2b  (0,y,1/2;mx,0,mz) (0,y+1,-1/2;-mx,0,-mz)
 2a  (0,y,0;mx,0,mz) (0,y+1,0;-mx,0,-mz)"""
 
-        self.assertStrContentEqual(str(msg), ref_string)
-        self.assertStrContentEqual(msg.data_str(), ref_string_all)
+        self.assert_str_content_equal(str(msg), ref_string)
+        self.assert_str_content_equal(msg.data_str(), ref_string_all)
 
 
 if __name__ == "__main__":

--- a/pymatgen/transformations/tests/test_advanced_transformations.py
+++ b/pymatgen/transformations/tests/test_advanced_transformations.py
@@ -8,6 +8,7 @@ from shutil import which
 
 import numpy as np
 from monty.serialization import loadfn
+from numpy.testing import assert_array_equal
 from pytest import approx
 
 from pymatgen.analysis.energy_models import IsingModel
@@ -715,7 +716,7 @@ class CubicSupercellTransformationTest(PymatgenTest):
             [3.69130000e-02, 4.09320200e-02, 5.90830153e01],
         )
         assert superstructure.num_sites == 448
-        self.assertArrayEqual(
+        assert_array_equal(
             supercell_generator.transformation_matrix,
             np.array([[4, 0, 0], [1, 4, -4], [0, 0, 1]]),
         )
@@ -731,7 +732,7 @@ class CubicSupercellTransformationTest(PymatgenTest):
             force_diagonal=True,
         )
         _ = diagonal_supercell_generator.apply_transformation(structure2)
-        self.assertArrayEqual(diagonal_supercell_generator.transformation_matrix, np.eye(3) * 4)
+        assert_array_equal(diagonal_supercell_generator.transformation_matrix, np.eye(3) * 4)
 
         # test force_90_degrees
         structure2 = self.get_structure("Si")

--- a/pymatgen/transformations/tests/test_advanced_transformations.py
+++ b/pymatgen/transformations/tests/test_advanced_transformations.py
@@ -372,8 +372,8 @@ class MagOrderingTransformationTest(PymatgenTest):
         trans = MagOrderingTransformation({"Ni": 5})
         alls = trans.apply_transformation(self.NiO.get_primitive_structure(), return_ranked_list=10)
 
-        self.assertArrayAlmostEqual(self.NiO_AFM_111.lattice.parameters, alls[0]["structure"].lattice.parameters)
-        self.assertArrayAlmostEqual(self.NiO_AFM_001.lattice.parameters, alls[1]["structure"].lattice.parameters)
+        self.assert_all_close(self.NiO_AFM_111.lattice.parameters, alls[0]["structure"].lattice.parameters)
+        self.assert_all_close(self.NiO_AFM_001.lattice.parameters, alls[1]["structure"].lattice.parameters)
 
     def test_ferrimagnetic(self):
         trans = MagOrderingTransformation({"Fe": 5}, order_parameter=0.75, max_cell_size=1)
@@ -612,16 +612,16 @@ class SlabTransformationTest(PymatgenTest):
         gen = SlabGenerator(s, [0, 0, 1], 10, 10)
         slab_from_gen = gen.get_slab(0.25)
         slab_from_trans = trans.apply_transformation(s)
-        self.assertArrayAlmostEqual(slab_from_gen.lattice.matrix, slab_from_trans.lattice.matrix)
-        self.assertArrayAlmostEqual(slab_from_gen.cart_coords, slab_from_trans.cart_coords)
+        self.assert_all_close(slab_from_gen.lattice.matrix, slab_from_trans.lattice.matrix)
+        self.assert_all_close(slab_from_gen.cart_coords, slab_from_trans.cart_coords)
 
         fcc = Structure.from_spacegroup("Fm-3m", Lattice.cubic(3), ["Fe"], [[0, 0, 0]])
         trans = SlabTransformation([1, 1, 1], 10, 10)
         slab_from_trans = trans.apply_transformation(fcc)
         gen = SlabGenerator(fcc, [1, 1, 1], 10, 10)
         slab_from_gen = gen.get_slab()
-        self.assertArrayAlmostEqual(slab_from_gen.lattice.matrix, slab_from_trans.lattice.matrix)
-        self.assertArrayAlmostEqual(slab_from_gen.cart_coords, slab_from_trans.cart_coords)
+        self.assert_all_close(slab_from_gen.lattice.matrix, slab_from_trans.lattice.matrix)
+        self.assert_all_close(slab_from_gen.cart_coords, slab_from_trans.cart_coords)
 
 
 class GrainBoundaryTransformationTest(PymatgenTest):
@@ -642,8 +642,8 @@ class GrainBoundaryTransformationTest(PymatgenTest):
             gb_from_generator = gbg.gb_from_parameters(**gb_gen_params_s5)
             gbt_s5 = GrainBoundaryTransformation(**gb_gen_params_s5)
             gb_from_trans = gbt_s5.apply_transformation(Al_bulk)
-            self.assertArrayAlmostEqual(gb_from_generator.lattice.matrix, gb_from_trans.lattice.matrix)
-            self.assertArrayAlmostEqual(gb_from_generator.cart_coords, gb_from_trans.cart_coords)
+            self.assert_all_close(gb_from_generator.lattice.matrix, gb_from_trans.lattice.matrix)
+            self.assert_all_close(gb_from_generator.cart_coords, gb_from_trans.cart_coords)
 
 
 class DisorderedOrderedTransformationTest(PymatgenTest):
@@ -706,12 +706,12 @@ class CubicSupercellTransformationTest(PymatgenTest):
         num_atoms = superstructure.num_sites
         assert num_atoms >= min_atoms
         assert num_atoms <= max_atoms
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             superstructure.lattice.matrix[0],
             [1.49656087e01, -1.11448000e-03, 9.04924836e00],
         )
-        self.assertArrayAlmostEqual(superstructure.lattice.matrix[1], [-0.95005506, 14.95766342, 10.01819773])
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(superstructure.lattice.matrix[1], [-0.95005506, 14.95766342, 10.01819773])
+        self.assert_all_close(
             superstructure.lattice.matrix[2],
             [3.69130000e-02, 4.09320200e-02, 5.90830153e01],
         )
@@ -745,7 +745,7 @@ class CubicSupercellTransformationTest(PymatgenTest):
             force_90_degrees=True,
         )
         transformed_structure = diagonal_supercell_generator.apply_transformation(structure2)
-        self.assertArrayAlmostEqual(list(transformed_structure.lattice.angles), [90.0, 90.0, 90.0])
+        self.assert_all_close(list(transformed_structure.lattice.angles), [90.0, 90.0, 90.0])
 
         structure = self.get_structure("BaNiO3")
         min_atoms = 100
@@ -756,7 +756,7 @@ class CubicSupercellTransformationTest(PymatgenTest):
             min_atoms=min_atoms, max_atoms=max_atoms, min_length=10.0, force_90_degrees=True
         )
         transformed_structure = supercell_generator.apply_transformation(structure)
-        self.assertArrayAlmostEqual(list(transformed_structure.lattice.angles), [90.0, 90.0, 90.0])
+        self.assert_all_close(list(transformed_structure.lattice.angles), [90.0, 90.0, 90.0])
 
 
 class AddAdsorbateTransformationTest(PymatgenTest):

--- a/pymatgen/transformations/tests/test_site_transformations.py
+++ b/pymatgen/transformations/tests/test_site_transformations.py
@@ -64,7 +64,7 @@ class TranslateSitesTransformationTest(PymatgenTest):
         inv_t = t.inverse
         s = inv_t.apply_transformation(s)
         assert s[0].distance_and_image_from_frac_coords([0, 0, 0])[0] == approx(0)
-        self.assertArrayAlmostEqual(s[1].frac_coords, [0.375, 0.375, 0.375])
+        self.assert_all_close(s[1].frac_coords, [0.375, 0.375, 0.375])
 
     def test_to_from_dict(self):
         d1 = TranslateSitesTransformation([0], [0.1, 0.2, 0.3]).as_dict()
@@ -271,7 +271,7 @@ class AddSitePropertyTransformationTest(PymatgenTest):
             manually_set.add_site_property(prop, value)
         trans_set = trans.apply_transformation(s)
         for prop in site_props:
-            self.assertArrayAlmostEqual(trans_set.site_properties[prop], manually_set.site_properties[prop])
+            self.assert_all_close(trans_set.site_properties[prop], manually_set.site_properties[prop])
 
 
 class RadialSiteDistortionTransformationTest(PymatgenTest):

--- a/pymatgen/util/testing.py
+++ b/pymatgen/util/testing.py
@@ -13,9 +13,9 @@ import tempfile
 import unittest
 from pathlib import Path
 
-import numpy.testing as nptu
 from monty.json import MontyDecoder, MSONable
 from monty.serialization import loadfn
+from numpy.testing import assert_allclose
 
 from pymatgen.core import SETTINGS, Structure
 
@@ -49,18 +49,21 @@ class PymatgenTest(unittest.TestCase):
         """
         Get a structure from the template directories.
 
-        :param name: Name of a structure.
-        :return: Structure
+        Args:
+            name (str): Name of structure file.
+
+        Returns:
+            Structure
         """
         return cls.TEST_STRUCTURES[name].copy()
 
     @staticmethod
-    def assertArrayAlmostEqual(actual, desired, decimal=7, err_msg="", verbose=True):
+    def assert_all_close(actual, desired, decimal=7, err_msg="", verbose=True):
         """
-        Tests if two arrays are almost equal to a tolerance. The CamelCase
-        naming is so that it is consistent with standard unittest methods.
+        Tests if two arrays are almost equal up to some relative or absolute tolerance.
         """
-        return nptu.assert_almost_equal(actual, desired, decimal, err_msg, verbose)
+        # TODO (janosh): replace the decimal kwarg with assert_allclose() atol and rtol kwargs
+        return assert_allclose(actual, desired, atol=10**-decimal, err_msg=err_msg, verbose=verbose)
 
     @staticmethod
     def assertStrContentEqual(actual, desired, err_msg="", verbose=True):

--- a/pymatgen/util/testing.py
+++ b/pymatgen/util/testing.py
@@ -150,7 +150,7 @@ class PymatgenTest(unittest.TestCase):
             return [o[0] for o in objects_by_protocol]
         return objects_by_protocol
 
-    def assertMSONable(self, obj, test_if_subclass=True):
+    def assert_msonable(self, obj, test_if_subclass=True):
         """
         Test if obj is MSONable and verify the contract is fulfilled.
 

--- a/pymatgen/util/testing.py
+++ b/pymatgen/util/testing.py
@@ -66,7 +66,7 @@ class PymatgenTest(unittest.TestCase):
         return assert_allclose(actual, desired, atol=10**-decimal, err_msg=err_msg, verbose=verbose)
 
     @staticmethod
-    def assertStrContentEqual(actual, desired, err_msg="", verbose=True):
+    def assert_str_content_equal(actual, desired, err_msg="", verbose=True):
         """
         Tests if two strings are equal, ignoring things like trailing spaces, etc.
         """

--- a/pymatgen/util/testing.py
+++ b/pymatgen/util/testing.py
@@ -14,13 +14,11 @@ import unittest
 from pathlib import Path
 
 import numpy.testing as nptu
-from monty.dev import requires
 from monty.json import MontyDecoder, MSONable
 from monty.serialization import loadfn
 from pytest import approx
 
 from pymatgen.core import SETTINGS, Structure
-from pymatgen.ext.matproj import _MPResterLegacy as MPRester
 
 
 class PymatgenTest(unittest.TestCase):
@@ -56,18 +54,6 @@ class PymatgenTest(unittest.TestCase):
         :return: Structure
         """
         return cls.TEST_STRUCTURES[name].copy()
-
-    @classmethod
-    @requires(SETTINGS.get("PMG_MAPI_KEY"), "PMG_MAPI_KEY needs to be set.")
-    def get_mp_structure(cls, mpid: str) -> Structure:
-        """
-        Get a structure from MP.
-
-        :param mpid: Materials Project id.
-        :return: Structure
-        """
-        m = MPRester()
-        return m.get_structure_by_material_id(mpid)
 
     @staticmethod
     def assertArrayAlmostEqual(actual, desired, decimal=7, err_msg="", verbose=True):
@@ -197,11 +183,10 @@ class PymatgenTest(unittest.TestCase):
 
     def assertMSONable(self, obj, test_if_subclass=True):
         """
-        Tests if obj is MSONable and tries to verify whether the contract is
-        fulfilled.
+        Test if obj is MSONable and verify the contract is fulfilled.
 
         By default, the method tests whether obj is an instance of MSONable.
-        This check can be deactivated by setting test_if_subclass to False.
+        This check can be deactivated by setting test_if_subclass=False.
         """
         if test_if_subclass:
             assert isinstance(obj, MSONable)

--- a/pymatgen/util/testing.py
+++ b/pymatgen/util/testing.py
@@ -63,14 +63,6 @@ class PymatgenTest(unittest.TestCase):
         return nptu.assert_almost_equal(actual, desired, decimal, err_msg, verbose)
 
     @staticmethod
-    def assertArrayEqual(actual, desired, err_msg="", verbose=True):
-        """
-        Tests if two arrays are equal. The CamelCase naming is so that it is
-         consistent with standard unittest methods.
-        """
-        return nptu.assert_equal(actual, desired, err_msg=err_msg, verbose=verbose)
-
-    @staticmethod
     def assertStrContentEqual(actual, desired, err_msg="", verbose=True):
         """
         Tests if two strings are equal, ignoring things like trailing spaces, etc.

--- a/pymatgen/util/testing.py
+++ b/pymatgen/util/testing.py
@@ -16,7 +16,6 @@ from pathlib import Path
 import numpy.testing as nptu
 from monty.json import MontyDecoder, MSONable
 from monty.serialization import loadfn
-from pytest import approx
 
 from pymatgen.core import SETTINGS, Structure
 
@@ -62,31 +61,6 @@ class PymatgenTest(unittest.TestCase):
         naming is so that it is consistent with standard unittest methods.
         """
         return nptu.assert_almost_equal(actual, desired, decimal, err_msg, verbose)
-
-    @staticmethod
-    def assertDictsAlmostEqual(actual, desired, decimal=7, err_msg="", verbose=True) -> bool:
-        """
-        Tests if two arrays are almost equal to a tolerance. The CamelCase
-        naming is so that it is consistent with standard unittest methods.
-        """
-        for k, v in actual.items():
-            if k not in desired:
-                return False
-            v2 = desired[k]
-            if isinstance(v, dict):
-                pass_test = PymatgenTest.assertDictsAlmostEqual(
-                    v, v2, decimal=decimal, err_msg=err_msg, verbose=verbose
-                )
-                if not pass_test:
-                    return False
-            elif isinstance(v, (list, tuple)):
-                nptu.assert_almost_equal(v, v2, decimal, err_msg, verbose)
-                return True
-            elif isinstance(v, (int, float)):
-                assert v == approx(v2, abs=decimal)
-            else:
-                assert v == v2
-        return True
 
     @staticmethod
     def assertArrayEqual(actual, desired, err_msg="", verbose=True):

--- a/pymatgen/util/tests/test_coord.py
+++ b/pymatgen/util/tests/test_coord.py
@@ -4,6 +4,7 @@ import random
 
 import numpy as np
 import pytest
+from numpy.testing import assert_array_equal
 from pytest import approx
 
 from pymatgen.core.lattice import Lattice
@@ -78,7 +79,7 @@ class CoordUtilsTest(PymatgenTest):
         assert coord.find_in_coord_list(coords, test_coord, atol=0.15)[0] == 0
         assert coord.find_in_coord_list([0.99, 0.99, 0.99], test_coord, atol=0.15).size == 0
         coords = [[0, 0, 0], [0.5, 0.5, 0.5], [0.1, 0.1, 0.1]]
-        self.assertArrayEqual(coord.find_in_coord_list(coords, test_coord, atol=0.15), [0, 2])
+        assert_array_equal(coord.find_in_coord_list(coords, test_coord, atol=0.15), [0, 2])
 
     def test_all_distances(self):
         coords1 = [[0, 0, 0], [0.5, 0.5, 0.5]]

--- a/pymatgen/util/tests/test_coord.py
+++ b/pymatgen/util/tests/test_coord.py
@@ -85,17 +85,17 @@ class CoordUtilsTest(PymatgenTest):
         coords1 = [[0, 0, 0], [0.5, 0.5, 0.5]]
         coords2 = [[1, 2, -1], [1, 0, 0], [1, 0, 0]]
         result = [[2.44948974, 1, 1], [2.17944947, 0.8660254, 0.8660254]]
-        self.assertArrayAlmostEqual(coord.all_distances(coords1, coords2), result, 4)
+        self.assert_all_close(coord.all_distances(coords1, coords2), result, 4)
 
     def test_pbc_diff(self):
-        self.assertArrayAlmostEqual(coord.pbc_diff([0.1, 0.1, 0.1], [0.3, 0.5, 0.9]), [-0.2, -0.4, 0.2])
-        self.assertArrayAlmostEqual(coord.pbc_diff([0.9, 0.1, 1.01], [0.3, 0.5, 0.9]), [-0.4, -0.4, 0.11])
-        self.assertArrayAlmostEqual(coord.pbc_diff([0.1, 0.6, 1.01], [0.6, 0.1, 0.9]), [-0.5, 0.5, 0.11])
-        self.assertArrayAlmostEqual(coord.pbc_diff([100.1, 0.2, 0.3], [0123123.4, 0.5, 502312.6]), [-0.3, -0.3, -0.3])
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(coord.pbc_diff([0.1, 0.1, 0.1], [0.3, 0.5, 0.9]), [-0.2, -0.4, 0.2])
+        self.assert_all_close(coord.pbc_diff([0.9, 0.1, 1.01], [0.3, 0.5, 0.9]), [-0.4, -0.4, 0.11])
+        self.assert_all_close(coord.pbc_diff([0.1, 0.6, 1.01], [0.6, 0.1, 0.9]), [-0.5, 0.5, 0.11])
+        self.assert_all_close(coord.pbc_diff([100.1, 0.2, 0.3], [0123123.4, 0.5, 502312.6]), [-0.3, -0.3, -0.3])
+        self.assert_all_close(
             coord.pbc_diff([0.1, 0.1, 0.1], [0.3, 0.5, 0.9], pbc=(True, True, False)), [-0.2, -0.4, -0.8]
         )
-        self.assertArrayAlmostEqual(
+        self.assert_all_close(
             coord.pbc_diff([0.9, 0.1, 1.01], [0.3, 0.5, 0.9], pbc=(True, True, False)), [-0.4, -0.4, 0.11]
         )
 
@@ -212,14 +212,14 @@ class CoordUtilsTest(PymatgenTest):
 
         vectors = coord.pbc_shortest_vectors(lattice, fcoords[:-1], fcoords)
         dists = np.sum(vectors**2, axis=-1) ** 0.5
-        self.assertArrayAlmostEqual(dists, expected, 3)
+        self.assert_all_close(dists, expected, 3)
 
         prev_threshold = coord.LOOP_THRESHOLD
         coord.LOOP_THRESHOLD = 0
 
         vectors = coord.pbc_shortest_vectors(lattice, fcoords[:-1], fcoords)
         dists = np.sum(vectors**2, axis=-1) ** 0.5
-        self.assertArrayAlmostEqual(dists, expected, 3)
+        self.assert_all_close(dists, expected, 3)
 
         coord.LOOP_THRESHOLD = prev_threshold
 
@@ -234,7 +234,7 @@ class CoordUtilsTest(PymatgenTest):
         )
         vectors = coord.pbc_shortest_vectors(lattice_pbc, fcoords[:-1], fcoords)
         dists = np.sum(vectors**2, axis=-1) ** 0.5
-        self.assertArrayAlmostEqual(dists, expected_pbc, 3)
+        self.assert_all_close(dists, expected_pbc, 3)
 
     def test_get_angle(self):
         v1 = (1, 0, 0)
@@ -266,10 +266,10 @@ class SimplexTest(PymatgenTest):
 
     def test_2dtriangle(self):
         s = coord.Simplex([[0, 1], [1, 1], [1, 0]])
-        self.assertArrayAlmostEqual(s.bary_coords([0.5, 0.5]), [0.5, 0, 0.5])
-        self.assertArrayAlmostEqual(s.bary_coords([0.5, 1]), [0.5, 0.5, 0])
-        self.assertArrayAlmostEqual(s.bary_coords([0.5, 0.75]), [0.5, 0.25, 0.25])
-        self.assertArrayAlmostEqual(s.bary_coords([0.75, 0.75]), [0.25, 0.5, 0.25])
+        self.assert_all_close(s.bary_coords([0.5, 0.5]), [0.5, 0, 0.5])
+        self.assert_all_close(s.bary_coords([0.5, 1]), [0.5, 0.5, 0])
+        self.assert_all_close(s.bary_coords([0.5, 0.75]), [0.5, 0.25, 0.25])
+        self.assert_all_close(s.bary_coords([0.75, 0.75]), [0.25, 0.5, 0.25])
 
         s = coord.Simplex([[1, 1], [1, 0]])
         with pytest.raises(ValueError):
@@ -287,9 +287,9 @@ class SimplexTest(PymatgenTest):
         s = coord.Simplex([[0, 2], [3, 1], [1, 0]])
         point = [0.7, 0.5]
         bc = s.bary_coords(point)
-        self.assertArrayAlmostEqual(bc, [0.26, -0.02, 0.76])
+        self.assert_all_close(bc, [0.26, -0.02, 0.76])
         new_point = s.point_from_bary_coords(bc)
-        self.assertArrayAlmostEqual(point, new_point)
+        self.assert_all_close(point, new_point)
 
     def test_intersection(self):
         # simple test, with 2 intersections at faces
@@ -298,56 +298,56 @@ class SimplexTest(PymatgenTest):
         point2 = [0.5, 0.7]
         intersections = s.line_intersection(point1, point2)
         expected = np.array([[1.13333333, 0.06666667], [0.8, 0.4]])
-        self.assertArrayAlmostEqual(intersections, expected)
+        self.assert_all_close(intersections, expected)
 
         # intersection through point and face
         point1 = [0, 2]  # simplex point
         point2 = [1, 1]  # inside simplex
         expected = np.array([[1.66666667, 0.33333333], [0, 2]])
         intersections = s.line_intersection(point1, point2)
-        self.assertArrayAlmostEqual(intersections, expected)
+        self.assert_all_close(intersections, expected)
 
         # intersection through point only
         point1 = [0, 2]  # simplex point
         point2 = [0.5, 0.7]
         expected = np.array([[0, 2]])
         intersections = s.line_intersection(point1, point2)
-        self.assertArrayAlmostEqual(intersections, expected)
+        self.assert_all_close(intersections, expected)
 
         # 3d intersection through edge and face
         point1 = [0.5, 0, 0]  # edge point
         point2 = [0.5, 0.5, 0.5]  # in simplex
         expected = np.array([[0.5, 0.25, 0.25], [0.5, 0.0, 0.0]])
         intersections = self.simplex.line_intersection(point1, point2)
-        self.assertArrayAlmostEqual(intersections, expected)
+        self.assert_all_close(intersections, expected)
 
         # 3d intersection through edge only
         point1 = [0.5, 0, 0]  # edge point
         point2 = [0.5, 0.5, -0.5]  # outside simplex
         expected = np.array([[0.5, 0.0, 0.0]])
         intersections = self.simplex.line_intersection(point1, point2)
-        self.assertArrayAlmostEqual(intersections, expected)
+        self.assert_all_close(intersections, expected)
 
         # coplanar to face (no intersection)
         point1 = [-1, 2]
         point2 = [0, 0]
         expected = np.array([])
         intersections = s.line_intersection(point1, point2)
-        self.assertArrayAlmostEqual(intersections, expected)
+        self.assert_all_close(intersections, expected)
 
         # coplanar to face (with intersection line)
         point1 = [0, 2]  # simplex point
         point2 = [1, 0]
         expected = np.array([[1, 0], [0, 2]])
         intersections = s.line_intersection(point1, point2)
-        self.assertArrayAlmostEqual(intersections, expected)
+        self.assert_all_close(intersections, expected)
 
         # coplanar to face (with intersection points)
         point1 = [0.1, 2]
         point2 = [1.1, 0]
         expected = np.array([[1.08, 0.04], [0.12, 1.96]])
         intersections = s.line_intersection(point1, point2)
-        self.assertArrayAlmostEqual(intersections, expected)
+        self.assert_all_close(intersections, expected)
 
     def test_to_json(self):
         assert isinstance(self.simplex.to_json(), str)


### PR DESCRIPTION
Drop unused `PymatgenTest` methods, rename existing ones from camel to snake case and replace `assert_almost_equal` with `assert_allclose`  as recommended by numpy docs.

 8ad0792d4 breaking: drop internally unused PymatgenTest.get_mp_structure()
 868179215 breaking: drop internally unused PymatgenTest.assertDictsAlmostEqual()
 62e9afc38 replace all PymatgenTest.assertArrayEqual with numpy.testing.assert_array_equal
 9a1dfc179 remove PymatgenTest.assertArrayEqual() method
 1462805c7 replace numpy.testing.assert_almost_equal() with numpy.testing.assert_allclose()
 8a0e76e38 refactor import: from numpy.testing import assert_array_almost_equal
 91013e1ad breaking: snake_case assertStrContentEqual to assert_str_content_equal
 729a5dfba breaking: snake_case assertMSONable to assert_msonable

Many of the commits here are breaking but since `PymatgenTest` is only for internal use, it shouldn't matter.