### PR TITLE
Unignore `ruff` `PD011`

### DIFF
--- a/pymatgen/entries/mixing_scheme.py
+++ b/pymatgen/entries/mixing_scheme.py
@@ -297,8 +297,8 @@ class MaterialsProjectDFTMixingScheme(Compatibility):
             )
 
         # Verify that the entry is included in the mixing state data
-        if (entry.entry_id not in mixing_state_data["entry_id_1"]) and (
-            entry.entry_id not in mixing_state_data["entry_id_2"]
+        if (entry.entry_id not in mixing_state_data["entry_id_1"].values) and (  # noqa: PD011
+            entry.entry_id not in mixing_state_data["entry_id_2"].values  # noqa: PD011
         ):
             raise CompatibilityError(
                 f"WARNING! Discarding {run_type} entry {entry.entry_id} for {entry.composition.formula} "
@@ -308,8 +308,8 @@ class MaterialsProjectDFTMixingScheme(Compatibility):
             )
 
         # Verify that the entry's energy has not been modified since mixing state data was generated
-        if (entry.energy_per_atom not in mixing_state_data["energy_1"]) and (
-            entry.energy_per_atom not in mixing_state_data["energy_2"]
+        if (entry.energy_per_atom not in mixing_state_data["energy_1"].values) and (  # noqa: PD011
+            entry.energy_per_atom not in mixing_state_data["energy_2"].values  # noqa: PD011
         ):
             raise CompatibilityError(
                 f"WARNING! Discarding {run_type} entry {entry.entry_id} for {entry.composition.formula} "

--- a/pymatgen/entries/mixing_scheme.py
+++ b/pymatgen/entries/mixing_scheme.py
@@ -297,8 +297,8 @@ class MaterialsProjectDFTMixingScheme(Compatibility):
             )
 
         # Verify that the entry is included in the mixing state data
-        if (entry.entry_id not in mixing_state_data["entry_id_1"].values) and (
-            entry.entry_id not in mixing_state_data["entry_id_2"].values
+        if (entry.entry_id not in mixing_state_data["entry_id_1"]) and (
+            entry.entry_id not in mixing_state_data["entry_id_2"]
         ):
             raise CompatibilityError(
                 f"WARNING! Discarding {run_type} entry {entry.entry_id} for {entry.composition.formula} "
@@ -308,8 +308,8 @@ class MaterialsProjectDFTMixingScheme(Compatibility):
             )
 
         # Verify that the entry's energy has not been modified since mixing state data was generated
-        if (entry.energy_per_atom not in mixing_state_data["energy_1"].values) and (
-            entry.energy_per_atom not in mixing_state_data["energy_2"].values
+        if (entry.energy_per_atom not in mixing_state_data["energy_1"]) and (
+            entry.energy_per_atom not in mixing_state_data["energy_2"]
         ):
             raise CompatibilityError(
                 f"WARNING! Discarding {run_type} entry {entry.entry_id} for {entry.composition.formula} "

--- a/pymatgen/io/abinit/abitimer.py
+++ b/pymatgen/io/abinit/abitimer.py
@@ -304,24 +304,17 @@ class AbinitTimerParser(collections.abc.Iterable):
         """
         import pandas as pd
 
-        colnames = [
-            "fname",
-            "wall_time",
-            "cpu_time",
-            "mpi_nprocs",
-            "omp_nthreads",
-            "mpi_rank",
-        ]
+        col_names = ["fname", "wall_time", "cpu_time", "mpi_nprocs", "omp_nthreads", "mpi_rank"]
 
-        frame = pd.DataFrame(columns=colnames)
+        frame = pd.DataFrame(columns=col_names)
         for timer in self.timers():
-            frame = frame.append({k: getattr(timer, k) for k in colnames}, ignore_index=True)
+            frame = frame.append({key: getattr(timer, key) for key in col_names}, ignore_index=True)
         frame["tot_ncpus"] = frame["mpi_nprocs"] * frame["omp_nthreads"]
 
         # Compute parallel efficiency (use the run with min number of cpus to normalize).
-        i = frame["tot_ncpus"].values.argmin()
-        ref_wtime = frame.iloc[i]["wall_time"]
-        ref_ncpus = frame.iloc[i]["tot_ncpus"]
+        idx = frame["tot_ncpus"].argmin()
+        ref_wtime = frame.iloc[idx]["wall_time"]
+        ref_ncpus = frame.iloc[idx]["tot_ncpus"]
         frame["peff"] = (ref_ncpus * ref_wtime) / (frame["wall_time"] * frame["tot_ncpus"])
 
         return frame

--- a/pymatgen/io/abinit/pseudos.py
+++ b/pymatgen/io/abinit/pseudos.py
@@ -1451,7 +1451,7 @@ class PawXmlSetup(Pseudo, PawPseudo):
         for i, den_name in enumerate(["ae_core_density", "pseudo_core_density"]):
             rden = getattr(self, den_name)
             label = "$n_c$" if i == 1 else r"$\tilde{n}_c$"
-            ax.plot(rden.mesh, rden.mesh * rden.values, label=label, lw=2)
+            ax.plot(rden.mesh, rden.mesh * rden.values, label=label, lw=2)  # noqa: PD011
 
         ax.legend(loc="best")
 
@@ -1479,10 +1479,10 @@ class PawXmlSetup(Pseudo, PawPseudo):
         # ax.annotate("$r_c$", xy=(self.paw_radius + 0.1, 0.1))
 
         for state, rfunc in self.pseudo_partial_waves.items():
-            ax.plot(rfunc.mesh, rfunc.mesh * rfunc.values, lw=2, label="PS-WAVE: " + state)
+            ax.plot(rfunc.mesh, rfunc.mesh * rfunc.values, lw=2, label="PS-WAVE: " + state)  # noqa: PD011
 
         for state, rfunc in self.ae_partial_waves.items():
-            ax.plot(rfunc.mesh, rfunc.mesh * rfunc.values, lw=2, label="AE-WAVE: " + state)
+            ax.plot(rfunc.mesh, rfunc.mesh * rfunc.values, lw=2, label="AE-WAVE: " + state)  # noqa: PD011
 
         ax.legend(loc="best", shadow=True, fontsize=fontsize)
 
@@ -1508,7 +1508,7 @@ class PawXmlSetup(Pseudo, PawPseudo):
         # ax.annotate("$r_c$", xy=(self.paw_radius + 0.1, 0.1))
 
         for state, rfunc in self.projector_functions.items():
-            ax.plot(rfunc.mesh, rfunc.mesh * rfunc.values, label="TPROJ: " + state)
+            ax.plot(rfunc.mesh, rfunc.mesh * rfunc.values, label="TPROJ: " + state)  # noqa: PD011
 
         ax.legend(loc="best", shadow=True, fontsize=fontsize)
 

--- a/pymatgen/io/cp2k/inputs.py
+++ b/pymatgen/io/cp2k/inputs.py
@@ -91,7 +91,7 @@ class Keyword(MSONable):
             repeats: Whether or not this keyword may be repeated. Default=False.
         """
         self.name = name
-        self.values = values
+        self.values = values  # noqa: PD011
         self.description = description
         self.repeats = repeats
         self.units = units
@@ -110,8 +110,8 @@ class Keyword(MSONable):
         if not isinstance(other, Keyword):
             return NotImplemented
         if self.name.upper() == other.name.upper():
-            v1 = [_.upper() if isinstance(_, str) else _ for _ in self.values]
-            v2 = [_.upper() if isinstance(_, str) else _ for _ in other.values]
+            v1 = [_.upper() if isinstance(_, str) else _ for _ in self.values]  # noqa: PD011
+            v2 = [_.upper() if isinstance(_, str) else _ for _ in other.values]  # noqa: PD011
             if v1 == v2 and self.units == self.units:
                 return True
         return False
@@ -120,7 +120,7 @@ class Keyword(MSONable):
         return KeywordList(keywords=[self, other])
 
     def __getitem__(self, item):
-        return self.values[item]
+        return self.values[item]  # noqa: PD011
 
     def as_dict(self):
         """
@@ -130,7 +130,7 @@ class Keyword(MSONable):
         dct["@module"] = type(self).__module__
         dct["@class"] = type(self).__name__
         dct["name"] = self.name
-        dct["values"] = self.values
+        dct["values"] = self.values  # noqa: PD011
         dct["description"] = self.description
         dct["repeats"] = self.repeats
         dct["units"] = self.units

--- a/pymatgen/io/cp2k/outputs.py
+++ b/pymatgen/io/cp2k/outputs.py
@@ -202,12 +202,12 @@ class Cp2kOutput:
     @property
     def charge(self) -> float:
         """Get charge from the input file"""
-        return self.input["FORCE_EVAL"]["DFT"].get("CHARGE", Keyword("", 0)).values[0]
+        return self.input["FORCE_EVAL"]["DFT"].get("CHARGE", Keyword("", 0)).values[0]  # noqa: PD011
 
     @property
     def multiplicity(self) -> int:
         """Get the spin multiplicity from input file"""
-        return self.input["FORCE_EVAL"]["DFT"].get("Multiplicity", Keyword("")).values[0]
+        return self.input["FORCE_EVAL"]["DFT"].get("Multiplicity", Keyword("")).values[0]  # noqa: PD011
 
     @property
     def is_molecule(self) -> bool:
@@ -757,9 +757,9 @@ class Cp2kOutput:
             cell = self.input["force_eval"]["subsys"]["cell"]
             if cell.get("abc"):
                 return [
-                    [cell["abc"].values[0], 0, 0],
-                    [0, cell["abc"].values[1], 0],
-                    [0, 0, cell["abc"].values[2]],
+                    [cell["abc"].values[0], 0, 0],  # noqa: PD011
+                    [0, cell["abc"].values[1], 0],  # noqa: PD011
+                    [0, 0, cell["abc"].values[2]],  # noqa: PD011
                 ]
             return [
                 list(cell.get("A").values),

--- a/pymatgen/io/cp2k/sets.py
+++ b/pymatgen/io/cp2k/sets.py
@@ -1009,11 +1009,8 @@ class DftSet(Cp2kInput):
         if not self.check("MOTION"):
             self.insert(Section("MOTION", subsections={}))
 
-        run_type = self["global"].get("run_type", Keyword("run_type", "energy")).values[0].upper()
-        if run_type == "GEOMETRY_OPTIMIZATION":
-            run_type = "GEO_OPT"
-        if run_type == "MOLECULAR_DYNAMICS":
-            run_type = "MD"
+        run_type = self["global"].get("run_type", Keyword("run_type", "energy")).values[0].upper()  # noqa: PD011
+        run_type = {"GEOMETRY_OPTIMIZATION": "GEO_OPT", "MOLECULAR_DYNAMICS": "MD"}.get(run_type, run_type)
 
         self["MOTION"].insert(Section("PRINT", subsections={}))
         self["MOTION"]["PRINT"].insert(Section("TRAJECTORY", section_parameters=["ON"], subsections={}))
@@ -1332,7 +1329,7 @@ class DftSet(Cp2kInput):
                 no: do not explicitly include the last iteration
         """
         assert add_last.lower() in ["no", "numeric", "symbolic"]
-        run_type = self["global"].get("run_type", Keyword("run_type", "energy")).values[0].upper()
+        run_type = self["global"].get("run_type", Keyword("run_type", "energy")).values[0].upper()  # noqa: PD011
         if run_type not in ["ENERGY_FORCE", "ENERGY", "WAVEFUNCTION_OPTIMIZATION", "WFN_OPT"] and self.check(
             "FORCE_EVAL/DFT/PRINT"
         ):
@@ -1358,8 +1355,8 @@ class DftSet(Cp2kInput):
         for _, v in self["force_eval"]["subsys"].subsections.items():
             if (
                 v.name.upper() == "KIND"
-                and v["POTENTIAL"].values[0].upper() == "ALL"
-                and self["force_eval"]["dft"]["qs"]["method"].values[0].upper() != "GAPW"
+                and v["POTENTIAL"].values[0].upper() == "ALL"  # noqa: PD011
+                and self["force_eval"]["dft"]["qs"]["method"].values[0].upper() != "GAPW"  # noqa: PD011
             ):
                 raise Cp2kValidationError("All electron basis sets require GAPW method")
 

--- a/pymatgen/io/cp2k/tests/test_inputs.py
+++ b/pymatgen/io/cp2k/tests/test_inputs.py
@@ -100,11 +100,11 @@ class BasisAndPotentialTest(PymatgenTest):
 
     def test_basis(self):
         # Ensure cp2k formatted string can be read for data correctly
-        molopt = GaussianTypeOrbitalBasisSet.from_string(basis)
-        assert molopt.nexp == [7]
+        mol_opt = GaussianTypeOrbitalBasisSet.from_string(basis)
+        assert mol_opt.nexp == [7]
         # Basis file can read from strings
         bf = BasisFile.from_string(basis)
-        for obj in [molopt, bf.objects[0]]:
+        for obj in [mol_opt, bf.objects[0]]:
             self.assert_all_close(
                 obj.exponents[0],
                 [
@@ -119,12 +119,12 @@ class BasisAndPotentialTest(PymatgenTest):
             )
 
         # Ensure keyword can be properly generated
-        kw = molopt.get_keyword()
-        assert kw.values[0] == "SZV-MOLOPT-GTH"
-        molopt.info.admm = True
-        kw = molopt.get_keyword()
+        kw = mol_opt.get_keyword()
+        assert kw.values[0] == "SZV-MOLOPT-GTH"  # noqa: PD011
+        mol_opt.info.admm = True
+        kw = mol_opt.get_keyword()
         assert_array_equal(kw.values, ["AUX_FIT", "SZV-MOLOPT-GTH"])
-        molopt.info.admm = False
+        mol_opt.info.admm = False
 
     def test_potentials(self):
         # Ensure cp2k formatted string can be read for data correctly
@@ -142,9 +142,9 @@ class BasisAndPotentialTest(PymatgenTest):
 
         # Ensure keyword can be properly generated
         kw = pot.get_keyword()
-        assert kw.values[0] == "GTH-PBE-q1"
+        assert kw.values[0] == "GTH-PBE-q1"  # noqa: PD011
         kw = all.get_keyword()
-        assert kw.values[0] == "ALL"
+        assert kw.values[0] == "ALL"  # noqa: PD011
 
 
 class InputTest(PymatgenTest):
@@ -177,9 +177,9 @@ class InputTest(PymatgenTest):
 
     def test_basic_keywords(self):
         kwd = Keyword("TEST1", 1, 2)
-        assert kwd.values == (1, 2)
+        assert kwd.values == (1, 2)  # noqa: PD011
         kwd = Keyword("TEST2", [1, 2, 3])
-        assert kwd.values == ([1, 2, 3],)
+        assert kwd.values == ([1, 2, 3],)  # noqa: PD011
         kwd = Keyword("TEST3", "xyz", description="testing", units="Ha")
         assert kwd.description == "testing"
         assert "[Ha]" in kwd.get_string()
@@ -197,9 +197,9 @@ class InputTest(PymatgenTest):
 
     def test_ci_file(self):
         # proper type retrieval
-        assert isinstance(self.ci["FORCE_EVAL"]["DFT"]["MGRID"]["NGRIDS"].values[0], int)
-        assert isinstance(self.ci["FORCE_EVAL"]["DFT"]["UKS"].values[0], bool)
-        assert isinstance(self.ci["FORCE_EVAL"]["DFT"]["QS"]["EPS_DEFAULT"].values[0], float)
+        assert isinstance(self.ci["FORCE_EVAL"]["DFT"]["MGRID"]["NGRIDS"].values[0], int)  # noqa: PD011
+        assert isinstance(self.ci["FORCE_EVAL"]["DFT"]["UKS"].values[0], bool)  # noqa: PD011
+        assert isinstance(self.ci["FORCE_EVAL"]["DFT"]["QS"]["EPS_DEFAULT"].values[0], float)  # noqa: PD011
 
         # description retrieval
         assert self.ci["FORCE_EVAL"]["SUBSYS"]["CELL"].description == "Input parameters needed to set up the CELL."

--- a/pymatgen/io/cp2k/tests/test_sets.py
+++ b/pymatgen/io/cp2k/tests/test_sets.py
@@ -43,8 +43,8 @@ class SetTest(PymatgenTest):
         basis_and_potential = {"Si": {"basis": "SZV-GTH-q4", "potential": "GTH-PBE-q4", "aux_basis": "cFIT3"}}
         ss = DftSet(Si_structure, basis_and_potential=basis_and_potential, xc_functionals="PBE")
         basis_sets = ss["force_eval"]["subsys"]["Si_1"].get("basis_set")
-        assert any("AUX_FIT" in b.values for b in basis_sets)
-        assert any("cFIT3" in b.values for b in basis_sets)
+        assert any("AUX_FIT" in b.values for b in basis_sets)  # noqa: PD011
+        assert any("cFIT3" in b.values for b in basis_sets)  # noqa: PD011
 
         # Basis sets / potentials by hash value
         basis_and_potential = {
@@ -118,7 +118,7 @@ class SetTest(PymatgenTest):
 
         ss = DftSet(molecule, basis_and_potential=basis_and_potential, xc_functionals="PBE")
         assert ss.check("force_eval/dft/poisson")
-        assert ss["force_eval"]["dft"]["poisson"].get("periodic").values[0].upper() == "NONE"
+        assert ss["force_eval"]["dft"]["poisson"].get("periodic").to_numpy()[0].upper() == "NONE"
 
 
 if __name__ == "__main__":

--- a/pymatgen/io/cp2k/tests/test_sets.py
+++ b/pymatgen/io/cp2k/tests/test_sets.py
@@ -118,7 +118,7 @@ class SetTest(PymatgenTest):
 
         ss = DftSet(molecule, basis_and_potential=basis_and_potential, xc_functionals="PBE")
         assert ss.check("force_eval/dft/poisson")
-        assert ss["force_eval"]["dft"]["poisson"].get("periodic").values()[0].upper() == "NONE"
+        assert ss["force_eval"]["dft"]["poisson"].get("periodic").values[0].upper() == "NONE"  # noqa: PD011
 
 
 if __name__ == "__main__":

--- a/pymatgen/io/cp2k/tests/test_sets.py
+++ b/pymatgen/io/cp2k/tests/test_sets.py
@@ -118,7 +118,7 @@ class SetTest(PymatgenTest):
 
         ss = DftSet(molecule, basis_and_potential=basis_and_potential, xc_functionals="PBE")
         assert ss.check("force_eval/dft/poisson")
-        assert ss["force_eval"]["dft"]["poisson"].get("periodic").to_numpy()[0].upper() == "NONE"
+        assert ss["force_eval"]["dft"]["poisson"].get("periodic").values()[0].upper() == "NONE"
 
 
 if __name__ == "__main__":

--- a/pymatgen/io/lammps/data.py
+++ b/pymatgen/io/lammps/data.py
@@ -313,9 +313,9 @@ class LammpsData(MSONable):
         latt = self.box.to_lattice()
         site_properties = {}
         if "q" in atoms:
-            site_properties["charge"] = atoms["q"].values
+            site_properties["charge"] = atoms["q"].to_numpy()
         if self.velocities is not None:
-            site_properties["velocities"] = self.velocities.values
+            site_properties["velocities"] = self.velocities.to_numpy()
         return Structure(
             latt,
             species,
@@ -605,7 +605,7 @@ class LammpsData(MSONable):
             species = masses.loc[type_ids, "element"]
             labels = masses.loc[type_ids, "label"]
             coords = atoms[["x", "y", "z"]]
-            m = Molecule(species.values, coords.values, site_properties={ff_label: labels.values})
+            m = Molecule(species.values, coords.values, site_properties={ff_label: labels.to_numpy()})
             charges = atoms.get("q")
             velocities = atoms[["vx", "vy", "vz"]] if "vx" in atoms.columns else None
             topologies = {}
@@ -870,7 +870,7 @@ class LammpsData(MSONable):
         for iat, q in charges.items():
             if isinstance(iat, str):
                 mass_iat = Element(iat).atomic_mass
-                iat = self.masses.loc[self.masses["mass"] == mass_iat].index.values[0]
+                iat = self.masses.loc[self.masses["mass"] == mass_iat].index[0]
             self.atoms.loc[self.atoms["type"] == iat, "q"] = q
 
 
@@ -1009,7 +1009,7 @@ class ForceField(MSONable):
 
     @staticmethod
     def _is_valid(df):
-        return not pd.isna(df).values.any()
+        return not pd.isna(df).to_numpy().any()
 
     def __init__(self, mass_info, nonbond_coeffs=None, topo_coeffs=None):
         """

--- a/pymatgen/io/lammps/tests/test_data.py
+++ b/pymatgen/io/lammps/tests/test_data.py
@@ -101,8 +101,8 @@ class LammpsDataTest(unittest.TestCase):
 
         ethane = self.ethane.structure
         assert_array_almost_equal(ethane.lattice.matrix, np.diag([10.0] * 3))
-        lbounds = np.array(self.ethane.box.bounds)[:, 0]
-        coords = self.ethane.atoms[["x", "y", "z"]].values - lbounds
+        l_bounds = np.array(self.ethane.box.bounds)[:, 0]
+        coords = self.ethane.atoms[["x", "y", "z"]] - l_bounds
         assert_array_almost_equal(ethane.cart_coords, coords)
         assert_array_almost_equal(ethane.site_properties["charge"], self.ethane.atoms["q"])
         tatb = self.tatb.structure
@@ -126,13 +126,13 @@ class LammpsDataTest(unittest.TestCase):
         # internally element:type will be {Fe: 1, S: 2},
         # therefore without sorting the atom types in structure
         # will be [2, 1], i.e., (S, Fe)
-        assert lmp2.atoms["type"].values.tolist() == [2, 1]
+        assert lmp2.atoms["type"].tolist() == [2, 1]
 
         # with sorting the atom types in structures will be [1, 2]
         lmp = LammpsData.from_structure(s, is_sort=True)
         lmp.write_file("test1.data")
         lmp2 = LammpsData.from_file("test1.data", atom_style="charge")
-        assert lmp2.atoms["type"].values.tolist() == [1, 2]
+        assert lmp2.atoms["type"].tolist() == [1, 2]
 
     def test_get_string(self):
         pep = self.peptide.get_string(distance=7, velocity=5, charge=4)
@@ -330,19 +330,19 @@ class LammpsDataTest(unittest.TestCase):
             topo_kw = kw + "s"
             topos_df = c.topology[topo_kw]
             topo_df = topos_df[topos_df["atom1"] >= shift]
-            topo_arr = topo_df.drop("type", axis=1).values
+            topo_arr = topo_df.drop("type", axis=1)
             np.testing.assert_array_equal(topo.topologies[topo_kw], topo_arr - shift, topo_kw)
             sample_topo = random.sample(list(topo_df.itertuples(False, None)), 1)[0]
             topo_type_idx = sample_topo[0] - 1
             topo_type = tuple(atom_labels[i - 1] for i in atoms.loc[list(sample_topo[1:])]["type"])
 
             assert topo_type in ff_coeffs[topo_type_idx]["types"], ff_kw
-        # test no guessing element and pairij as nonbond coeffs
+        # test no guessing element and pairij as non-bond coeffs
         v = self.virus
         _, v_ff, _ = v.disassemble(guess_element=False)
         assert v_ff.maps["Atoms"] == {"Qa1": 1, "Qb1": 2, "Qc1": 3, "Qa2": 4}
-        pairij_coeffs = v.force_field["PairIJ Coeffs"].drop(["id1", "id2"], axis=1)
-        np.testing.assert_array_equal(v_ff.nonbond_coeffs, pairij_coeffs.values)
+        pair_ij_coeffs = v.force_field["PairIJ Coeffs"].drop(["id1", "id2"], axis=1)
+        np.testing.assert_array_equal(v_ff.nonbond_coeffs, pair_ij_coeffs.values)
         # test class2 ff
         _, e_ff, _ = self.ethane.disassemble()
         e_topo_coeffs = e_ff.topo_coeffs
@@ -1032,7 +1032,7 @@ class CombinedDataTest(unittest.TestCase):
         )
         assert li_ec_structure.formula == "Li1 H4 C3 O3"
         lbounds = np.array(self.li_ec.box.bounds)[:, 0]
-        coords = self.li_ec.atoms[["x", "y", "z"]].values - lbounds
+        coords = self.li_ec.atoms[["x", "y", "z"]] - lbounds
         assert_array_almost_equal(li_ec_structure.cart_coords, coords)
         assert_array_almost_equal(li_ec_structure.site_properties["charge"], self.li_ec.atoms["q"])
         frac_coords = li_ec_structure.frac_coords[0]

--- a/pymatgen/io/lammps/tests/test_generators.py
+++ b/pymatgen/io/lammps/tests/test_generators.py
@@ -19,10 +19,10 @@ class LammpsMinimizationTest(PymatgenTest):
 
     def test_get_input_set(self):
         lmp_min = LammpsMinimization(keep_stages=False).get_input_set(self.structure)
-        assert list(lmp_min.data.as_dict().keys()) == list(LammpsData.from_structure(self.structure).as_dict().keys())
+        assert list(lmp_min.data.as_dict()) == list(LammpsData.from_structure(self.structure).as_dict())
         assert (
-            lmp_min.data.as_dict()["atoms"].values
-            == LammpsData.from_structure(self.structure).as_dict()["atoms"].values
+            lmp_min.data.as_dict()["atoms"].to_numpy()
+            == LammpsData.from_structure(self.structure).as_dict()["atoms"].to_numpy()
         ).all()
         assert lmp_min.inputfile.stages == [
             {
@@ -52,10 +52,10 @@ class LammpsMinimizationTest(PymatgenTest):
         ]
 
         lmp_min = LammpsMinimization(units="atomic", dimension=2, keep_stages=False).get_input_set(self.structure)
-        assert list(lmp_min.data.as_dict().keys()) == list(LammpsData.from_structure(self.structure).as_dict().keys())
+        assert list(lmp_min.data.as_dict()) == list(LammpsData.from_structure(self.structure).as_dict())
         assert (
-            lmp_min.data.as_dict()["atoms"].values
-            == LammpsData.from_structure(self.structure).as_dict()["atoms"].values
+            lmp_min.data.as_dict()["atoms"].to_numpy()
+            == LammpsData.from_structure(self.structure).as_dict()["atoms"].to_numpy()
         ).all()
         assert lmp_min.inputfile.stages == [
             {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,6 @@ ignore = [
   "D205",    # 1 blank line required between summary line and description
   "D212",    # Multi-line docstring summary should start at the first line
   "D415",    # First line should end with a period, question mark, or exclamation point
-  "PD011",   # pandas-use-of-dot-values
   "PD901",   # pandas-df-variable-name
   "PLC0414", # useless-import-alias
   "PLC1901", # compare-to-empty-string


### PR DESCRIPTION
 c535f4979 ruff unignore PD011 (pandas-use-of-dot-values)
 7d3eba415 drop .values where not needed, else replace with .to_numpy(), noqa false positives

`pandas.DataFrame().values` is deprecated and slated for removal in a future `pandas` version.