### PR TITLE
DOC: remove "structure" from init

### DIFF
--- a/pymatgen/transformations/advanced_transformations.py
+++ b/pymatgen/transformations/advanced_transformations.py
@@ -1972,7 +1972,6 @@ class SQSTransformation(AbstractTransformation):
     ):
         """
         Args:
-            structure (Structure): Disordered pymatgen Structure object
             scaling (int or list): Scaling factor to determine supercell. Two options are possible:
                     a. (preferred) Scales number of atoms, e.g., for a structure with 8 atoms,
                        scaling=4 would lead to a 32 atom supercell


### PR DESCRIPTION
Remove superfluous structure argument docstring from `SQSTransformation` init

Ensure:

- [X] Google format doc strings added. Check with `ruff`.
- [X] Type annotations included. Check with `mypy`.
- [X] Tests added for new features/fixes.
- [X] All tests and linting pass.

Tip: Install `pre-commit` hooks to auto-check before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
