### PR TITLE
Breaking: rename VaspInputSet.(potcar_functional->user_potcar_functional) and start testing `DictSet`

### DIFF
--- a/pymatgen/core/tests/test_structure.py
+++ b/pymatgen/core/tests/test_structure.py
@@ -1229,6 +1229,9 @@ class StructureTest(PymatgenTest):
         assert sites[-1].specie.symbol == "C"
         self.structure.add_oxidation_state_by_element({"Si": 4, "C": 2})
         assert self.structure.charge == 62
+        species = self.structure.species
+        assert isinstance(species, list)
+        assert len(species) == len(self.structure)
 
     def test_set_item(self):
         s = self.structure.copy()

--- a/pymatgen/ext/tests/test_optimade.py
+++ b/pymatgen/ext/tests/test_optimade.py
@@ -50,7 +50,7 @@ class OptimadeTest(PymatgenTest):
             extra_fields_single = optimade.get_snls(**base_query, additional_response_fields="nsites")
             extra_fields_set = optimade.get_snls(**base_query, additional_response_fields=field_set)
 
-        if "mp" in extra_fields_single:
+        if "mp" in extra_fields_single and "mp" in structs:
             assert len(structs["mp"]) == len(extra_fields_single["mp"])
             struct_nl = list(extra_fields_single["mp"].values())[0]
             assert "nsites" in struct_nl.data["_optimade"]

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -385,6 +385,7 @@ class DictSet(VaspInputSet):
         self.standardize = standardize
         self.sym_prec = sym_prec
         self.international_monoclinic = international_monoclinic
+        self.validate_magmom = validate_magmom
 
         if self.user_incar_settings.get("KSPACING") and user_kpoints_settings is not None:
             warnings.warn(
@@ -405,10 +406,10 @@ class DictSet(VaspInputSet):
                     f"Invalid or unsupported van-der-Waals functional. Supported functionals are {', '.join(vdw_par)}."
                 )
         # 'or' case reads the POTCAR_FUNCTIONAL from the .yaml
-        self.potcar_functional = user_potcar_functional or self._config_dict.get("POTCAR_FUNCTIONAL", "PBE")
+        self.user_potcar_functional = user_potcar_functional or self._config_dict.get("POTCAR_FUNCTIONAL", "PBE")
 
         # warn if a user is overriding POTCAR_FUNCTIONAL
-        if self.potcar_functional != self._config_dict.get("POTCAR_FUNCTIONAL", "PBE"):
+        if self.user_potcar_functional != self._config_dict.get("POTCAR_FUNCTIONAL", "PBE"):
             warnings.warn(
                 "Overriding the POTCAR functional is generally not recommended "
                 " as it significantly affect the results of calculations and "
@@ -2712,7 +2713,7 @@ class MVLScanRelaxSet(MPRelaxSet):
 
         super().__init__(structure, **kwargs)
 
-        if self.potcar_functional not in ("PBE_52", "PBE_54"):
+        if self.user_potcar_functional not in ("PBE_52", "PBE_54"):
             raise ValueError("SCAN calculations required PBE_52 or PBE_54!")
 
         updates = {

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -119,18 +119,17 @@ class VaspInputSet(MSONable, metaclass=abc.ABCMeta):
         """
         Potcar object.
         """
-        # pylint: disable=E1101
-        potcar = Potcar(self.potcar_symbols, functional=self.potcar_functional)
+        user_potcar_functional = self.user_potcar_functional
+        potcar = Potcar(self.potcar_symbols, functional=user_potcar_functional)
 
-        # warn if the selected POTCARs do not correspond to the chosen
-        # potcar_functional
-        for psingle in potcar:
-            if self.potcar_functional not in psingle.identify_potcar()[0]:
+        # warn if the selected POTCARs do not correspond to the chosen user_potcar_functional
+        for p_single in potcar:
+            if user_potcar_functional not in p_single.identify_potcar()[0]:
                 warnings.warn(
-                    f"POTCAR data with symbol {psingle.symbol} is not known by pymatgen to\
-                    correspond with the selected potcar_functional {self.potcar_functional}. This POTCAR\
-                    is known to correspond with functionals {psingle.identify_potcar(mode='data')[0]}. "
-                    f"Please verify that you are using the right POTCARs!",
+                    f"POTCAR data with symbol {p_single.symbol} is not known by pymatgen to "
+                    f"correspond with the selected {user_potcar_functional=}. This POTCAR "
+                    f"is known to correspond with functionals {p_single.identify_potcar(mode='data')[0]}. "
+                    "Please verify that you are using the right POTCARs!",
                     BadInputSetWarning,
                 )
 

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -47,7 +47,7 @@ from copy import deepcopy
 from glob import glob
 from itertools import chain
 from pathlib import Path
-from typing import Any, Literal, Sequence
+from typing import Any, Literal, Sequence, Union
 from zipfile import ZipFile
 
 import numpy as np
@@ -231,7 +231,9 @@ def _load_yaml_config(fname):
     return config
 
 
-UserPotcarFunctional = Literal["PBE", "PBE_52", "PBE_54", "LDA", "LDA_52", "LDA_54", "PW91", "LDA_US", "PW91_US"] | None
+UserPotcarFunctional = Union[
+    Literal["PBE", "PBE_52", "PBE_54", "LDA", "LDA_52", "LDA_54", "PW91", "LDA_US", "PW91_US"], None
+]
 
 
 class DictSet(VaspInputSet):

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -127,7 +127,7 @@ class DictSetTest(PymatgenTest):
 
     def test_as_dict(self):
         # https://github.com/materialsproject/pymatgen/pull/3031
-        dict_set = DictSet(self.structure, config_dict={"INCAR": {}})
+        dict_set = DictSet(self.structure, config_dict={"INCAR": {}}, user_potcar_functional="PBE_54")
         assert {*dict_set.as_dict()} >= {
             "structure",
             "config_dict",
@@ -135,6 +135,7 @@ class DictSetTest(PymatgenTest):
             "user_kpoints_settings",
             "user_potcar_settings",
         }
+        assert dict_set.potcar_functional == dict_set.user_potcar_functional
 
 
 class MITMPRelaxSetTest(PymatgenTest):

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -25,6 +25,7 @@ from pymatgen.io.vasp.inputs import Kpoints, Poscar
 from pymatgen.io.vasp.outputs import Vasprun
 from pymatgen.io.vasp.sets import (
     BadInputSetWarning,
+    DictSet,
     LobsterSet,
     MITMDSet,
     MITNEBSet,
@@ -115,6 +116,25 @@ class SetChangeCheckTest(PymatgenTest):
         assert hashes == known_hashes, msg
         for input_set in hashes:
             assert hashes[input_set] == known_hashes[input_set], msg
+
+
+class DictSetTest(PymatgenTest):
+    @classmethod
+    def setUpClass(cls):
+        filepath = cls.TEST_FILES_DIR / "POSCAR"
+        poscar = Poscar.from_file(filepath)
+        cls.structure = poscar.structure
+
+    def test_as_dict(self):
+        # https://github.com/materialsproject/pymatgen/pull/3031
+        dict_set = DictSet(self.structure, config_dict={"INCAR": {}})
+        assert {*dict_set.as_dict()} >= {
+            "structure",
+            "config_dict",
+            "user_incar_settings",
+            "user_kpoints_settings",
+            "user_potcar_settings",
+        }
 
 
 class MITMPRelaxSetTest(PymatgenTest):
@@ -1717,7 +1737,7 @@ class LobsterSetTest(PymatgenTest):
     @skip_if_no_psp_dir
     def test_potcar(self):
         # PBE_54 is preferred at the moment
-        assert self.lobsterset1.potcar_functional == "PBE_54"
+        assert self.lobsterset1.user_potcar_functional == "PBE_54"
 
     def test_as_from_dict(self):
         dict_here = self.lobsterset1.as_dict()
@@ -1734,7 +1754,7 @@ class LobsterSetTest(PymatgenTest):
         assert incar1["ALGO"] == "Normal"
         kpoints1 = lobsterset_new.kpoints
         assert kpoints1.comment.split(" ")[6], 6138
-        assert lobsterset_new.potcar_functional == "PBE_54"
+        assert lobsterset_new.user_potcar_functional == "PBE_54"
 
 
 @skip_if_no_psp_dir

--- a/pymatgen/util/string.py
+++ b/pymatgen/util/string.py
@@ -6,18 +6,7 @@ from __future__ import annotations
 import re
 from fractions import Fraction
 
-SUBSCRIPT_UNICODE = {
-    "0": "₀",
-    "1": "₁",
-    "2": "₂",
-    "3": "₃",
-    "4": "₄",
-    "5": "₅",
-    "6": "₆",
-    "7": "₇",
-    "8": "₈",
-    "9": "₉",
-}
+SUBSCRIPT_UNICODE = {"0": "₀", "1": "₁", "2": "₂", "3": "₃", "4": "₄", "5": "₅", "6": "₆", "7": "₇", "8": "₈", "9": "₉"}
 
 SUPERSCRIPT_UNICODE = {
     "0": "⁰",
@@ -113,10 +102,10 @@ def str_delimited(results, header=None, delimiter="\t"):
     Returns:
         Aligned string output in a table-like format.
     """
-    returnstr = ""
+    out = ""
     if header is not None:
-        returnstr += delimiter.join(header) + "\n"
-    return returnstr + "\n".join(delimiter.join([str(m) for m in result]) for result in results)
+        out += delimiter.join(header) + "\n"
+    return out + "\n".join(delimiter.join([str(m) for m in result]) for result in results)
 
 
 def formula_double_format(afloat, ignore_ones=True, tol: float = 1e-8):


### PR DESCRIPTION
Follow up to #3031 adding a test to make sure we don't regress again. I just realized we had 0 tests for `DictSet` before. While writing some, I noticed `DictSet.as_dict()` is also broken. Not only since https://github.com/materialsproject/pymatgen/pull/2972, even before due to not storing the `validate_magmons` init kwarg on instances.

### The breaking part

`VaspInputSet.potcar_functional` was renamed to `VaspInputSet.user_potcar_functional` to fix `DictSet.as_dict()` which otherwise errors

```py
NotImplementedError: Unable to automatically determine as_dict format from class. MSONAble requires all args to be present as either self.argname or self._argname
```

@shyuep Is this justifiable? `DictSet.as_dict()` is not very important and renaming `potcar_functional` -> `user_potcar_functional` might incur a lot of breaking changes in downstream code. (Auto-merge disabled until further discussion)