### PR TITLE
Don't do a hard `bandgap==0` check in the r2SCAN workflow

### DIFF
--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -948,7 +948,6 @@ class MPScanRelaxSet(DictSet):
         self.bandgap = bandgap
         self.kwargs = kwargs
 
-        # self.kwargs.get("user_incar_settings", {
         updates = {}
         # select the KSPACING and smearing parameters based on the bandgap
         if self.bandgap < 1e-4:

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -951,7 +951,7 @@ class MPScanRelaxSet(DictSet):
         # self.kwargs.get("user_incar_settings", {
         updates = {}
         # select the KSPACING and smearing parameters based on the bandgap
-        if self.bandgap == 0:
+        if self.bandgap < 1e-4:
             updates["KSPACING"] = 0.22
             updates["SIGMA"] = 0.2
             updates["ISMEAR"] = 2

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -1386,6 +1386,15 @@ class MPScanRelaxSetTest(PymatgenTest):
         assert incar["ISMEAR"] == 2
         assert incar["SIGMA"] == 0.2
 
+        # https://github.com/materialsproject/pymatgen/pull/3036
+        for bandgap in (-1e-12, 1e-5, 1e-3):
+            set_near_0_bandgap = MPScanRelaxSet(self.struct, bandgap=bandgap)
+            expected = (
+                {"KSPACING": 0.22, "SIGMA": 0.2, "ISMEAR": 2} if bandgap < 1e-4 else {"ISMEAR": -5, "SIGMA": 0.05}
+            )
+            for key, val in expected.items():
+                assert set_near_0_bandgap.incar.get(key) == val
+
     def test_scan_substitute(self):
         mp_scan_sub = MPScanRelaxSet(
             self.struct,


### PR DESCRIPTION
Closes #3023. CC'ing @janosh and @munrojm.