### PR TITLE
`PourbaixDiagram` wrong composition bug fix

### DIFF
--- a/pymatgen/analysis/pourbaix_diagram.py
+++ b/pymatgen/analysis/pourbaix_diagram.py
@@ -732,7 +732,7 @@ class PourbaixDiagram(MSONable):
             # their charge state.
             entry_comps = [e.composition for e in entry_list]
             rxn = Reaction(entry_comps + dummy_oh, [prod_comp])
-            react_coeffs = [-coeff for coeff in rxn.coeffs[:len(entry_list)]]
+            react_coeffs = [-coeff for coeff in rxn.coeffs[: len(entry_list)]]
             all_coeffs = [*react_coeffs, rxn.get_coeff(prod_comp)]
 
             # Check if reaction coeff threshold met for Pourbaix compounds

--- a/pymatgen/analysis/pourbaix_diagram.py
+++ b/pymatgen/analysis/pourbaix_diagram.py
@@ -732,7 +732,7 @@ class PourbaixDiagram(MSONable):
             # their charge state.
             entry_comps = [e.composition for e in entry_list]
             rxn = Reaction(entry_comps + dummy_oh, [prod_comp])
-            react_coeffs = [-rxn.get_coeff(comp) for comp in entry_comps]
+            react_coeffs = [-coeff for coeff in rxn.coeffs[:len(entry_list)]]
             all_coeffs = [*react_coeffs, rxn.get_coeff(prod_comp)]
 
             # Check if reaction coeff threshold met for Pourbaix compounds

--- a/pymatgen/analysis/tests/test_pourbaix_diagram.py
+++ b/pymatgen/analysis/tests/test_pourbaix_diagram.py
@@ -12,8 +12,8 @@ from monty.tempfile import ScratchDir
 from pytest import approx
 
 from pymatgen.analysis.pourbaix_diagram import IonEntry, MultiEntry, PourbaixDiagram, PourbaixEntry, PourbaixPlotter
-from pymatgen.core.ion import Ion
 from pymatgen.core.composition import Composition
+from pymatgen.core.ion import Ion
 from pymatgen.entries.computed_entries import ComputedEntry
 from pymatgen.util.testing import PymatgenTest
 
@@ -187,8 +187,7 @@ class PourbaixDiagramTest(unittest.TestCase):
             PourbaixEntry(IonEntry(Ion.from_formula("Fe[2+]"), -0.7683100214319288), entry_id="ion-0"),
             PourbaixEntry(IonEntry(Ion.from_formula("Li[1+]"), -3.0697590542787156), entry_id="ion-12"),
         ]
-        comp_dict = Composition({"Fe": 1, "Ir": 1,
-                                 "Li": 2, "Si": 1, "V": 2}).fractional_composition
+        comp_dict = Composition({"Fe": 1, "Ir": 1, "Li": 2, "Si": 1, "V": 2}).fractional_composition
 
         multi_entry = PourbaixDiagram.process_multientry(entries, prod_comp=comp_dict)
         assert multi_entry is None

--- a/pymatgen/analysis/tests/test_pourbaix_diagram.py
+++ b/pymatgen/analysis/tests/test_pourbaix_diagram.py
@@ -13,6 +13,7 @@ from pytest import approx
 
 from pymatgen.analysis.pourbaix_diagram import IonEntry, MultiEntry, PourbaixDiagram, PourbaixEntry, PourbaixPlotter
 from pymatgen.core.ion import Ion
+from pymatgen.core.composition import Composition
 from pymatgen.entries.computed_entries import ComputedEntry
 from pymatgen.util.testing import PymatgenTest
 
@@ -176,6 +177,21 @@ class PourbaixDiagramTest(unittest.TestCase):
         assert new_ternary.get_decomposition_energy(ag_te_n, 2, -1) == approx(2.767822855765)
         assert new_ternary.get_decomposition_energy(ag_te_n, 10, -2) == approx(3.756840056890625)
         assert new_ternary.get_decomposition_energy(ground_state_ag_with_ions, 2, -1) == approx(0)
+
+        # Test processing of multi-entries with degenerate reaction, produced
+        # a bug in a prior implementation
+        entries = [
+            PourbaixEntry(ComputedEntry("VFe2Si", -1.8542253150000008), entry_id="mp-4595"),
+            PourbaixEntry(ComputedEntry("Fe", 0), entry_id="mp-13"),
+            PourbaixEntry(ComputedEntry("V2Ir2", -2.141851640000006), entry_id="mp-569250"),
+            PourbaixEntry(IonEntry(Ion.from_formula("Fe[2+]"), -0.7683100214319288), entry_id="ion-0"),
+            PourbaixEntry(IonEntry(Ion.from_formula("Li[1+]"), -3.0697590542787156), entry_id="ion-12"),
+        ]
+        comp_dict = Composition({"Fe": 1, "Ir": 1,
+                                 "Li": 2, "Si": 1, "V": 2}).fractional_composition
+
+        multi_entry = PourbaixDiagram.process_multientry(entries, prod_comp=comp_dict)
+        assert multi_entry is None
 
     def test_get_pourbaix_domains(self):
         domains = PourbaixDiagram.get_pourbaix_domains(self.test_data["Zn"])


### PR DESCRIPTION
Closes #2943.

The Pourbaix diagram was generating multi-entries with the wrong composition because of Reaction coefficient handling. This fixes the issue by using the explicit list of reaction coefficients, rather than the hash retrieval, and adds a regression test that fails previously but passes now.
