### PR TITLE
Migrate GHA release job to PyPI trusted publishing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -162,6 +162,9 @@ jobs:
     needs: [build_wheels, build_sdist]
     if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.task == 'release')
     runs-on: ubuntu-latest
+    permissions:
+      # For pypi trusted publishing
+      id-token: write
     steps:
       - name: Set up Python 3.11
         uses: actions/setup-python@v4
@@ -171,9 +174,8 @@ jobs:
         with:
           name: artifact
           path: dist
-      - name: Release
-        env:
-          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-        run: |
-          pipx run twine upload --skip-existing dist/*.whl dist/*.tar.gz
+      - name: Publish to PyPi
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
+          verbose: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ ci:
 
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.271
+    rev: v0.0.272
     hooks:
       - id: ruff
         args: [--fix]


### PR DESCRIPTION
Closes #3054.