### PR TITLE
Use self-documenting f-strings instead of hard-coding var names

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ jobs:
     # prevent this action from running on forks
     if: github.repository == 'materialsproject/pymatgen'
     strategy:
+      fail-fast: false
       matrix:
         # pytest-split automatically distributes work load so parallel jobs finish in similar time
         os: [ubuntu-latest, windows-latest]

--- a/dev_scripts/chemenv/get_plane_permutations_optimized.py
+++ b/dev_scripts/chemenv/get_plane_permutations_optimized.py
@@ -409,7 +409,7 @@ if __name__ == "__main__":
             for perm, number in perms_used.items():
                 print(f" - permutation {'-'.join(map(str, perm))} : {number:d}")
             print(
-                f"For ialgo {ialgo} (plane_points : [{', '.join(map(str, algo.plane_points))}], "
+                f"For {ialgo=} (plane_points : [{', '.join(map(str, algo.plane_points))}], "
                 f"side_0 : [{', '.join(map(str, algo.point_groups[0]))}] and "
                 f"side_1 : [{', '.join(map(str, algo.point_groups[1]))}]),\n"
                 f"Optimized perturbations {len(perms_used)}/{len(algo.permutations)} (old : "

--- a/dev_scripts/chemenv/test_algos_all_geoms.py
+++ b/dev_scripts/chemenv/test_algos_all_geoms.py
@@ -22,7 +22,7 @@ __email__ = "david.waroquiers@gmail.com"
 __date__ = "Feb 20, 2016"
 
 if __name__ == "__main__":
-    allcg = AllCoordinationGeometries()
+    all_coord_geoms = AllCoordinationGeometries()
 
     test = input('Standard ("s", all permutations for cn <= 6, 500 random permutations for cn > 6) or on demand')
     if test == "s":
@@ -38,7 +38,7 @@ if __name__ == "__main__":
 
     for coordination in range(1, 13):
         print(f"IN COORDINATION {coordination}")
-        symbol_name_mapping = allcg.get_symbol_name_mapping(coordination=coordination)
+        symbol_name_mapping = all_coord_geoms.get_symbol_name_mapping(coordination=coordination)
 
         if perms_def == "standard":
             test = "500" if coordination > 6 else "all"
@@ -67,13 +67,13 @@ if __name__ == "__main__":
                 perms_iterator.append(list(indices))  # type: ignore[attr-defined]
 
         for cg_symbol, cg_name in symbol_name_mapping.items():
-            cg = allcg[cg_symbol]
+            cg = all_coord_geoms[cg_symbol]
             if cg.deactivate:
                 continue
 
             print(f"Testing {cg_symbol} ({cg_name})")
 
-            cg = allcg[cg_symbol]
+            cg = all_coord_geoms[cg_symbol]
             if cg.points is None:
                 continue
 

--- a/pymatgen/analysis/chemenv/coordination_environments/tests/test_coordination_geometry_finder.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/tests/test_coordination_geometry_finder.py
@@ -203,15 +203,15 @@ class CoordinationGeometryFinderTest(PymatgenTest):
                 )
                 assert (
                     abs(se.get_csm(0, mp_symbol)["symmetry_measure"] - 0.0) < 1e-8
-                ), f"Failed to get perfect environment with mp_symbol {mp_symbol}"
+                ), f"Failed to get perfect environment with {mp_symbol=}"
 
     def test_disable_hints(self):
         allcg = AllCoordinationGeometries()
         mp_symbol = "SH:13"
         mp_symbols = ["SH:13", "HP:12"]
         cg = allcg.get_geometry_from_mp_symbol(mp_symbol=mp_symbol)
-        mypoints = cg.points
-        mypoints[-1] = [0.9 * cc for cc in mypoints[-1]]
+        my_points = cg.points
+        my_points[-1] = [0.9 * cc for cc in my_points[-1]]
         self.lgf.allcg = AllCoordinationGeometries(only_symbols=[mp_symbol])
         self.lgf.setup_test_perfect_environment(
             mp_symbol,
@@ -220,7 +220,7 @@ class CoordinationGeometryFinderTest(PymatgenTest):
             random_translation="NONE",
             random_rotation="NONE",
             random_scale="NONE",
-            points=mypoints,
+            points=my_points,
         )
         se_nohints = self.lgf.compute_structure_environments(
             only_indices=[0],

--- a/pymatgen/analysis/chemenv/utils/chemenv_config.py
+++ b/pymatgen/analysis/chemenv/utils/chemenv_config.py
@@ -127,7 +127,7 @@ class ChemEnvConfig:
                         self.package_options["default_strategy"]["strategy_options"][option] = option_dict["type"](test)
                         break
                     except ValueError:
-                        print(f"Wrong input for option {option}")
+                        print(f"Wrong input for {option=}")
 
     def package_options_description(self):
         """

--- a/pymatgen/analysis/interface_reactions.py
+++ b/pymatgen/analysis/interface_reactions.py
@@ -553,7 +553,7 @@ class InterfacialReactivity(MSONable):
             phase at given temperature and pressure.
         """
         if element not in ["O", "N", "Cl", "F", "H"]:
-            warnings.warn(f"Element {element} not one of valid options: ['O', 'N', 'Cl', 'F', 'H']")
+            warnings.warn(f"{element=} not one of valid options: ['O', 'N', 'Cl', 'F', 'H']")
             return 0
 
         std_temp = 298.15

--- a/pymatgen/analysis/path_finder.py
+++ b/pymatgen/analysis/path_finder.py
@@ -255,7 +255,7 @@ class NEBPathfinder:
             s[0] = s0[0]
             s[-1] = s0[-1]
 
-            # Reparametrize string
+            # Re-parametrize string
             ds = s - np.roll(s, 1, axis=0)
             ds[0] = ds[0] - ds[0]
             ls = np.cumsum(la.norm(ds, axis=1))
@@ -269,11 +269,11 @@ class NEBPathfinder:
                 raise ValueError("Pathfinding failed, path diverged! Consider reducing h to avoid divergence.")
 
             if step > min_iter and tol < max_tol:
-                logger.debug(f"Converged at step {step}")
+                logger.debug(f"Converged at {step=}")
                 break
 
             if step % 100 == 0:
-                logger.debug(f"Step {step} - ds = {tol}")
+                logger.debug(f"{step=} - ds = {tol}")
         return s
 
     @staticmethod
@@ -283,13 +283,7 @@ class NEBPathfinder:
         the grid size of v
         """
         # frac_coords = frac_coords % 1
-        return np.array(
-            [
-                int(frac_coords[0] * v.shape[0]),
-                int(frac_coords[1] * v.shape[1]),
-                int(frac_coords[2] * v.shape[2]),
-            ]
-        )
+        return (np.array(frac_coords) * np.array(v.shape)).astype(int)
 
     @staticmethod
     def __d2f(disc_coords, v):

--- a/pymatgen/core/periodic_table.py
+++ b/pymatgen/core/periodic_table.py
@@ -602,7 +602,7 @@ class ElementBase(Enum):
         for sym, data in _pt_data.items():
             if data["Atomic no"] == Z:
                 return Element(sym)
-        raise ValueError(f"No element with this atomic number {Z}")
+        raise ValueError(f"Unexpected atomic number {Z=}")
 
     @staticmethod
     def from_name(name: str) -> Element:
@@ -619,7 +619,7 @@ class ElementBase(Enum):
         for sym, data in _pt_data.items():
             if data["Name"] == name.capitalize():
                 return Element(sym)
-        raise ValueError(f"No element with the name {name}")
+        raise ValueError(f"No element with the {name=}")
 
     @staticmethod
     def from_row_and_group(row: int, group: int) -> Element:
@@ -1256,7 +1256,7 @@ class Species(MSONable, Stringify):
             return quad_mom.get(isotopes[0], 0.0)
 
         if isotope not in quad_mom:
-            raise ValueError(f"No quadrupole moment for isotope {isotope}")
+            raise ValueError(f"No quadrupole moment for {isotope=}")
         return quad_mom.get(isotope, 0.0)
 
     def get_shannon_radius(

--- a/pymatgen/core/spectrum.py
+++ b/pymatgen/core/spectrum.py
@@ -89,7 +89,7 @@ class Spectrum(MSONable):
         elif mode.lower() == "max":
             factor = np.max(self.y, axis=0)
         else:
-            raise ValueError(f"Unsupported normalization mode {mode}!")
+            raise ValueError(f"Unsupported normalization {mode=}!")
 
         self.y /= factor / value
 
@@ -110,7 +110,7 @@ class Spectrum(MSONable):
         elif func.lower() == "lorentzian":
             weights = lorentzian(points, sigma=sigma)
         else:
-            raise ValueError(f"Invalid func {func}")
+            raise ValueError(f"Invalid {func=}")
         weights /= np.sum(weights)
         if len(self.ydim) == 1:
             total = np.sum(self.y)

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -4276,7 +4276,7 @@ class Structure(IStructure, collections.abc.MutableSequence):
                 )
         except KeyError as ex:
             raise ValueError(f"Required parameter {ex} not specified as a kwargs!")
-        raise ValueError(f"Unsupported prototype {prototype}!")
+        raise ValueError(f"Unsupported {prototype=}!")
 
 
 class Molecule(IMolecule, collections.abc.MutableSequence):

--- a/pymatgen/core/tests/test_tensors.py
+++ b/pymatgen/core/tests/test_tensors.py
@@ -204,13 +204,11 @@ class TensorTest(PymatgenTest):
             orig = Tensor(entry["original_tensor"])
             ieee = Tensor(entry["ieee_tensor"])
             diff = np.max(abs(ieee - orig.convert_to_ieee(struct)))
-            err_msg = f"{xtal} IEEE conversion failed with max diff {diff}. Numpy version: {np.__version__}"
+            err_msg = f"{xtal} IEEE conversion failed with max {diff=}. Numpy version: {np.__version__}"
             converted = orig.convert_to_ieee(struct, refine_rotation=False)
             self.assert_all_close(ieee, converted, err_msg=err_msg, decimal=3)
             converted_refined = orig.convert_to_ieee(struct, refine_rotation=True)
-            err_msg = (
-                f"{xtal} IEEE conversion with refinement failed with max diff {diff}. Numpy version: {np.__version__}"
-            )
+            err_msg = f"{xtal} IEEE conversion with refinement failed with max {diff=}. Numpy version: {np.__version__}"
             self.assert_all_close(ieee, converted_refined, err_msg=err_msg, decimal=2)
 
     def test_structure_transform(self):

--- a/pymatgen/entries/compatibility.py
+++ b/pymatgen/entries/compatibility.py
@@ -443,7 +443,7 @@ class UCorrection(Correction):
             error_file: Path to the selected compatibilityErrors.yaml config file.
         """
         if compat_type not in ["GGA", "Advanced"]:
-            raise CompatibilityError(f"Invalid compat_type {compat_type}")
+            raise CompatibilityError(f"Invalid {compat_type=}")
 
         c = loadfn(config_file)
 
@@ -891,7 +891,7 @@ class MaterialsProject2020Compatibility(Compatibility):
                 Phys. Rev. B - Condens. Matter Mater. Phys. 84, 1-10 (2011).
         """
         if compat_type not in ["GGA", "Advanced"]:
-            raise CompatibilityError(f"Invalid compat_type {compat_type}")
+            raise CompatibilityError(f"Invalid {compat_type=}")
 
         self.compat_type = compat_type
         self.correct_peroxide = correct_peroxide

--- a/pymatgen/entries/correction_calculator.py
+++ b/pymatgen/entries/correction_calculator.py
@@ -149,7 +149,7 @@ class CorrectionCalculator:
             for anion in self.exclude_polyanions:
                 if anion in name or anion in cmpd_info["formula"]:
                     allow = False
-                    warnings.warn(f"Compound {name} contains the polyanion {anion} and is excluded from the fit")
+                    warnings.warn(f"Compound {name} contains the poly{anion=} and is excluded from the fit")
                     break
 
             # filter out compounds that are unstable

--- a/pymatgen/entries/mixing_scheme.py
+++ b/pymatgen/entries/mixing_scheme.py
@@ -583,24 +583,27 @@ class MaterialsProjectDFTMixingScheme(Compatibility):
         filtered_entries = []
 
         for entry in entries:
+            entry_id = entry.entry_id
             if not entry.parameters.get("run_type"):
                 warnings.warn(
-                    f"Entry {entry.entry_id} is missing parameters.run_type! This field"
+                    f"Entry {entry_id} is missing parameters.run_type! This field"
                     "is required. This entry will be ignored."
                 )
                 continue
 
-            if entry.parameters.get("run_type") not in self.valid_rtypes_1 + self.valid_rtypes_2:
+            run_type = entry.parameters.get("run_type")
+            if run_type not in [*self.valid_rtypes_1, *self.valid_rtypes_2]:
                 warnings.warn(
-                    f"Invalid run_type {entry.parameters.get('run_type')} for entry {entry.entry_id}. Must be one of "
+                    f"Invalid {run_type=} for entry {entry_id}. Must be one of "
                     f"{self.valid_rtypes_1 + self.valid_rtypes_2}. This entry will be ignored."
                 )
                 continue
 
-            if entry.entry_id is None:
+            formula = entry.composition.reduced_formula
+            if entry_id is None:
                 warnings.warn(
-                    f"Entry_id for {entry.composition.reduced_formula} entry {entry.entry_id} is invalid. "
-                    "Unique entry_ids are required for every ComputedStructureEntry. This entry will be ignored."
+                    f"{entry_id=} for {formula=}. Unique entry_ids are required for every ComputedStructureEntry."
+                    " This entry will be ignored."
                 )
                 continue
 

--- a/pymatgen/entries/mixing_scheme.py
+++ b/pymatgen/entries/mixing_scheme.py
@@ -292,7 +292,7 @@ class MaterialsProjectDFTMixingScheme(Compatibility):
 
         if run_type not in self.valid_rtypes_1 + self.valid_rtypes_2:
             raise CompatibilityError(
-                f"WARNING! Invalid run_type {run_type} for entry {entry.entry_id}. Must be one of "
+                f"WARNING! Invalid {run_type=} for entry {entry.entry_id}. Must be one of "
                 f"{self.valid_rtypes_1 + self.valid_rtypes_2}. This entry will be ignored."
             )
 

--- a/pymatgen/entries/tests/test_mixing_scheme.py
+++ b/pymatgen/entries/tests/test_mixing_scheme.py
@@ -1021,13 +1021,7 @@ class TestMaterialsProjectDFTMixingSchemeArgs:
                 Structure(
                     lattice,
                     ["Sn", "Br", "Br", "Br", "Br"],
-                    [
-                        [0, 0, 0],
-                        [0.2, 0.2, 0.2],
-                        [0.4, 0.4, 0.4],
-                        [0.7, 0.7, 0.7],
-                        [1, 1, 1],
-                    ],
+                    [[0, 0, 0], [0.2, 0.2, 0.2], [0.4, 0.4, 0.4], [0.7, 0.7, 0.7], [1, 1, 1]],
                 ),
                 0,
                 parameters={"run_type": "GGA"},
@@ -1035,17 +1029,14 @@ class TestMaterialsProjectDFTMixingSchemeArgs:
             ),
         ]
 
-        with pytest.warns(UserWarning, match="Invalid run_type LDA"):
+        with pytest.warns(UserWarning, match="Invalid run_type='LDA'"):
             assert len(mixing_scheme_no_compat.process_entries(entries)) == 4
 
         state_data = mixing_scheme_no_compat.get_mixing_state_data(entries)
-        with pytest.raises(CompatibilityError, match="Invalid run_type LDA"):
-            assert (
-                mixing_scheme_no_compat.get_adjustments(
-                    [e for e in entries if e.parameters["run_type"] == "LDA"][0],
-                    state_data,
-                )
-                == []
+        with pytest.raises(CompatibilityError, match="Invalid run_type='LDA'"):
+            mixing_scheme_no_compat.get_adjustments(
+                [e for e in entries if e.parameters["run_type"] == "LDA"][0],
+                state_data,
             )
 
     def test_no_single_entry(self, mixing_scheme_no_compat):

--- a/pymatgen/ext/matproj.py
+++ b/pymatgen/ext/matproj.py
@@ -737,7 +737,7 @@ class _MPResterLegacy:
                 return self.get_structure_by_material_id(new_material_id)
             except MPRestError:
                 raise MPRestError(
-                    f"material_id {material_id} unknown, if this seems like an error "
+                    f"{material_id=} unknown, if this seems like an error "
                     "please let us know at matsci.org/materials-project"
                 )
 

--- a/pymatgen/ext/optimade.py
+++ b/pymatgen/ext/optimade.py
@@ -339,9 +339,7 @@ class OptimadeRester:
             except Exception as exc:
                 # TODO: manually inspect failures to either (a) correct a bug or (b) raise more appropriate error
 
-                _logger.error(
-                    f"Could not retrieve required information from provider {identifier} and url {url}: {exc}"
-                )
+                _logger.error(f"Could not retrieve required information from provider {identifier} and {url=}: {exc}")
 
         return all_snls
 

--- a/pymatgen/io/abinit/abiobjects.py
+++ b/pymatgen/io/abinit/abiobjects.py
@@ -779,7 +779,7 @@ class KSampling(AbivarAble, MSONable):
             )
 
         else:
-            raise ValueError(f"Unknown mode {mode}")
+            raise ValueError(f"Unknown {mode=}")
 
         self.abivars = abivars
         # self.abivars["#comment"] = comment

--- a/pymatgen/io/abinit/inputs.py
+++ b/pymatgen/io/abinit/inputs.py
@@ -1112,7 +1112,7 @@ class BasicMultiDataset:
 
         # Build the list of BasicAbinitInput objects.
         if ndtset <= 0:
-            raise ValueError(f"ndtset {ndtset} cannot be <=0")
+            raise ValueError(f"{ndtset=} cannot be <=0")
 
         if not isinstance(structure, (list, tuple)):
             self._inputs = [BasicAbinitInput(structure=structure, pseudos=pseudos) for i in range(ndtset)]

--- a/pymatgen/io/abinit/netcdf.py
+++ b/pymatgen/io/abinit/netcdf.py
@@ -202,7 +202,7 @@ class NetcdfReader:
         assert var.shape[-1] == 2
         if cmode == "c":
             return var[..., 0] + 1j * var[..., 1]
-        raise ValueError(f"Wrong value for cmode {cmode}")
+        raise ValueError(f"Wrong value for {cmode=}")
 
     def read_variable(self, varname, path="/"):
         """Returns the variable with name varname in the group specified by path."""

--- a/pymatgen/io/abinit/pseudos.py
+++ b/pymatgen/io/abinit/pseudos.py
@@ -730,7 +730,7 @@ class NcAbinitHeader(AbinitHeader):
                 try:
                     value = astype(value)
                 except Exception:
-                    raise RuntimeError(f"Conversion Error for key {key}, value {value}")
+                    raise RuntimeError(f"Conversion Error for {key=}, {value=}")
 
             self[key] = value
 
@@ -929,7 +929,7 @@ class PawAbinitHeader(AbinitHeader):
                 try:
                     value = astype(value)
                 except Exception:
-                    raise RuntimeError(f"Conversion Error for key {key}, with value {value}")
+                    raise RuntimeError(f"Conversion Error for {key=}, with {value=}")
 
             self[key] = value
 
@@ -1131,7 +1131,7 @@ class PseudoParser:
                     return None
 
                 if pspcod not in self._PSPCODES:
-                    raise self.Error(f"{filename}: Don't know how to handle pspcod {pspcod}\n")
+                    raise self.Error(f"{filename}: Don't know how to handle {pspcod=}\n")
 
                 ppdesc = self._PSPCODES[pspcod]
 
@@ -1766,7 +1766,7 @@ class PseudoTable(collections.abc.Sequence, MSONable):
         """
         pseudos = self.select_symbols(symbol, ret_list=True)
         if not pseudos or (len(pseudos) > 1 and not allow_multi):
-            raise ValueError(f"Found {len(pseudos)} occurrences of symbol {symbol}")
+            raise ValueError(f"Found {len(pseudos)} occurrences of {symbol=}")
 
         if not allow_multi:
             return pseudos[0]

--- a/pymatgen/io/adf.py
+++ b/pymatgen/io/adf.py
@@ -827,7 +827,7 @@ class AdfOutput:
                     if m:
                         cycle = int(m.group(1))
                         if cycle <= 0:
-                            raise AdfOutputError(f"Wrong cycle {cycle}")
+                            raise AdfOutputError(f"Wrong {cycle=}")
                         if cycle > last_cycle:
                             parse_cycle = True
                             last_cycle = cycle

--- a/pymatgen/io/babel.py
+++ b/pymatgen/io/babel.py
@@ -182,7 +182,7 @@ class BabelMolAdaptor:
         ff = openbabel.OBForceField_FindType(forcefield)
         if ff == 0:
             warnings.warn(
-                f"This input forcefield {forcefield} is not supported "
+                f"This input {forcefield=} is not supported "
                 "in openbabel. The forcefield will be reset as "
                 "default 'mmff94' for now."
             )
@@ -263,10 +263,7 @@ class BabelMolAdaptor:
 
         ff = openbabel.OBForceField_FindType(forcefield)
         if ff == 0:
-            print(
-                f"Could not find forcefield {forcefield} in openbabel, the forcefield "
-                "will be reset as default 'mmff94'"
-            )
+            print(f"Could not find {forcefield=} in openbabel, the forcefield will be reset as default 'mmff94'")
             ff = openbabel.OBForceField_FindType("mmff94")
 
         if freeze_atoms:

--- a/pymatgen/io/lammps/data.py
+++ b/pymatgen/io/lammps/data.py
@@ -693,7 +693,7 @@ class LammpsData(MSONable):
                     elif df.shape[1] == len(names) + 3:  # pylint: disable=E1101
                         names += ["nx", "ny", "nz"]
                     else:
-                        raise ValueError(f"Format in Atoms section inconsistent with atom_style {atom_style}")
+                        raise ValueError(f"Format in Atoms section inconsistent with {atom_style=}")
                 else:
                     raise NotImplementedError(f"Parser for {kw} section not implemented")
             df.columns = names

--- a/pymatgen/io/nwchem.py
+++ b/pymatgen/io/nwchem.py
@@ -121,10 +121,10 @@ class NwTask(MSONable):
         """
         # Basic checks.
         if theory.lower() not in NwTask.theories:
-            raise NwInputError(f"Invalid theory {theory}")
+            raise NwInputError(f"Invalid {theory=}")
 
         if operation.lower() not in NwTask.operations:
-            raise NwInputError(f"Invalid operation {operation}")
+            raise NwInputError(f"Invalid {operation=}")
         self.charge = charge
         self.spin_multiplicity = spin_multiplicity
         self.title = title if title is not None else f"{theory} {operation}"

--- a/pymatgen/io/qchem/outputs.py
+++ b/pymatgen/io/qchem/outputs.py
@@ -2215,14 +2215,14 @@ def jump_to_header(lines: list[str], header: str) -> list[str]:
     of the new list contains the header.
 
     Args:
-            lines: List of lines.
-            header: Substring to match.
+        lines: List of lines.
+        header: Substring to match.
 
     Returns:
-            Truncated lines.
+        Truncated lines.
 
     Raises:
-            RuntimeError
+        RuntimeError
     """
     # Search for the header
     for i, line in enumerate(lines):
@@ -2230,7 +2230,7 @@ def jump_to_header(lines: list[str], header: str) -> list[str]:
             return lines[i:]
 
     # Search failed
-    raise RuntimeError(f"Header {header} could not be found in the lines.")
+    raise RuntimeError(f"{header=} could not be found in the lines.")
 
 
 def get_percentage(line: str, orbital: str) -> str:
@@ -2238,14 +2238,14 @@ def get_percentage(line: str, orbital: str) -> str:
     Retrieve the percent character of an orbital.
 
     Args:
-            line: Line containing orbital and percentage.
-            orbital: Type of orbital (s, p, d, f).
+        line: Line containing orbital and percentage.
+        orbital: Type of orbital (s, p, d, f).
 
     Returns:
-            Percentage of character.
+        Percentage of character.
 
     Raises:
-            n/a
+        n/a
     """
     # Locate orbital in line
     index = line.find(orbital)
@@ -2265,13 +2265,13 @@ def z_int(string: str) -> int:
     If string empty, return -1.
 
     Args:
-            string: Input to be cast to int.
+        string: Input to be cast to int.
 
     Returns:
-            Int representation.
+        Int representation.
 
     Raises:
-            n/a
+        n/a
     """
     try:
         return int(string)
@@ -2284,13 +2284,13 @@ def parse_natural_populations(lines: list[str]) -> list[pd.DataFrame]:
     Parse the natural populations section of NBO output.
 
     Args:
-            lines: QChem output lines.
+        lines: QChem output lines.
 
     Returns:
-            Data frame of formatted output.
+        Data frame of formatted output.
 
     Raises:
-            RuntimeError
+        RuntimeError
     """
     no_failures = True
     pop_dfs = []
@@ -2344,13 +2344,13 @@ def parse_hyperbonds(lines: list[str]) -> list[pd.DataFrame]:
     Parse the natural populations section of NBO output.
 
     Args:
-            lines: QChem output lines.
+        lines: QChem output lines.
 
     Returns:
-            Data frame of formatted output.
+        Data frame of formatted output.
 
     Raises:
-            RuntimeError
+        RuntimeError
     """
     no_failures = True
     hyperbond_dfs = []
@@ -2425,13 +2425,13 @@ def parse_hybridization_character(lines: list[str]) -> list[pd.DataFrame]:
     Parse the hybridization character section of NBO output.
 
     Args:
-            lines: QChem output lines.
+        lines: QChem output lines.
 
     Returns:
-            Data frames of formatted output.
+        Data frames of formatted output.
 
     Raises:
-            RuntimeError
+        RuntimeError
     """
     # Orbitals
     orbitals = ["s", "p", "d", "f"]
@@ -2809,13 +2809,13 @@ def nbo_parser(filename: str) -> dict[str, list[pd.DataFrame]]:
     Parse all the important sections of NBO output.
 
     Args:
-            filename: Path to QChem NBO output.
+        filename: Path to QChem NBO output.
 
     Returns:
-            Data frames of formatted output.
+        Data frames of formatted output.
 
     Raises:
-            RuntimeError
+        RuntimeError
     """
     # Open the lines
     with zopen(filename, mode="rt", encoding="ISO-8859-1") as f:

--- a/pymatgen/io/res.py
+++ b/pymatgen/io/res.py
@@ -168,7 +168,7 @@ class ResParser:
         """Parses the CELL entry."""
         fields = line.split()
         if len(fields) != 7:
-            raise ParseError(f"Failed to parse CELL line {line}, expected 7 fields.")
+            raise ParseError(f"Failed to parse CELL {line=}, expected 7 fields.")
         field_1, a, b, c, alpha, beta, gamma = map(float, fields)
         return ResCELL(field_1, a, b, c, alpha, beta, gamma)
 
@@ -232,7 +232,7 @@ class ResParser:
                 elif first == "SFAC":
                     _SFAC = self._parse_sfac(rest, it)
                 else:
-                    raise Warning(f"Skipping line {line}, tag {first} not recognized.")
+                    raise Warning(f"Skipping {line=}, tag {first} not recognized.")
         except StopIteration:
             pass
         if _CELL is None or _SFAC is None:
@@ -432,7 +432,7 @@ class AirssProvider(ResProvider):
         """Parses a date from a string where the date is in the format typically used by CASTEP."""
         match = cls._date_fmt.search(string)
         if match is None:
-            raise ParseError(f"Could not parse the date from string {string}.")
+            raise ParseError(f"Could not parse the date from {string=}.")
         date_string = match.group(0)
         return dateutil.parser.parse(date_string)  # type: ignore
 

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -1911,7 +1911,7 @@ class PotcarSingle:
         d = SETTINGS.get("PMG_VASP_PSP_DIR")
         if d is None:
             raise ValueError(
-                f"No POTCAR for {symbol} with functional {functional} found. Please set the PMG_VASP_PSP_DIR "
+                f"No POTCAR for {symbol} with {functional=} found. Please set the PMG_VASP_PSP_DIR "
                 "environment in .pmgrc.yaml, or you may need to set PMG_DEFAULT_FUNCTIONAL to PBE_52 or "
                 "PBE_54 if you are using newer psps from VASP."
             )
@@ -1926,7 +1926,7 @@ class PotcarSingle:
                 psingle = PotcarSingle.from_file(p)
                 return psingle
         raise OSError(
-            f"You do not have the right POTCAR with functional {functional} and label {symbol} "
+            f"You do not have the right POTCAR with {functional=} and label {symbol} "
             f"in your VASP_PSP_DIR. Paths tried: {paths_to_try}"
         )
 

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -4571,7 +4571,7 @@ class Wavecar:
         """
         self.filename = filename
         if not (vasp_type is None or vasp_type.lower()[0] in ["s", "g", "n"]):
-            raise ValueError(f"invalid vasp_type {vasp_type}")
+            raise ValueError(f"invalid {vasp_type=}")
         self.vasp_type = vasp_type
 
         # c = 0.26246582250210965422

--- a/pymatgen/util/coord.py
+++ b/pymatgen/util/coord.py
@@ -350,7 +350,7 @@ def get_angle(v1, v2, units="degrees"):
         return math.degrees(angle)
     if units == "radians":
         return angle
-    raise ValueError(f"Invalid units {units}")
+    raise ValueError(f"Invalid {units=}")
 
 
 class Simplex(MSONable):

--- a/pymatgen/util/testing.py
+++ b/pymatgen/util/testing.py
@@ -124,14 +124,14 @@ class PymatgenTest(unittest.TestCase):
                 with open(tmpfile, mode) as fh:
                     pickle.dump(objects, fh, protocol=protocol)
             except Exception as exc:
-                errors.append(f"pickle.dump with protocol {protocol} raised:\n{exc}")
+                errors.append(f"pickle.dump with {protocol=} raised:\n{exc}")
                 continue
 
             try:
                 with open(tmpfile, "rb") as fh:
                     new_objects = pickle.load(fh)
             except Exception as exc:
-                errors.append(f"pickle.load with protocol {protocol} raised:\n{exc}")
+                errors.append(f"pickle.load with {protocol=} raised:\n{exc}")
                 continue
 
             # Test for equality


### PR DESCRIPTION
Also set `fail-fast: false` on `pytest` matrix jobs. This means we finish all tests even if one fails but still report the matrix as failed. This was originally intended when setting  `continue-on-error: true` which also keeps going on test errors but doesn't report the matrix as failed. See 60757b8c50c4ba6fc774ade4b05a3afe6dd509c5.