### PR TITLE
Pymatgen test autoused tmp path fixture

### DIFF
--- a/pymatgen/analysis/chemenv/coordination_environments/tests/test_structure_environments.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/tests/test_structure_environments.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import json
 import os
+from tempfile import TemporaryDirectory
 
 import numpy as np
 import pytest
-from monty.tempfile import ScratchDir
 from numpy.testing import assert_array_almost_equal
 
 from pymatgen.analysis.chemenv.coordination_environments.chemenv_strategies import (
@@ -32,54 +32,37 @@ struct_env_files_dir = os.path.join(
 
 class StructureEnvironmentsTest(PymatgenTest):
     def test_structure_environments(self):
-        with ScratchDir("."):
+        with TemporaryDirectory() as tmp_dir:
+            os.chdir(tmp_dir)
             with open(f"{struct_env_files_dir}/se_mp-7000.json") as f:
                 dd = json.load(f)
 
             struct_envs = StructureEnvironments.from_dict(dd)
             isite = 6
             csm_and_maps_fig, csm_and_maps_subplot = struct_envs.get_csm_and_maps(isite=isite)
-            assert_array_almost_equal(csm_and_maps_subplot.lines[0].get_xydata().flatten(), [0.0, 0.53499332])
-            assert_array_almost_equal(csm_and_maps_subplot.lines[1].get_xydata().flatten(), [1.0, 0.47026441])
-            assert_array_almost_equal(csm_and_maps_subplot.lines[2].get_xydata().flatten(), [2.0, 0.00988778])
+            assert_array_almost_equal(csm_and_maps_subplot.lines[0].get_xydata().flatten(), [0, 0.53499332])
+            assert_array_almost_equal(csm_and_maps_subplot.lines[1].get_xydata().flatten(), [1, 0.47026441])
+            assert_array_almost_equal(csm_and_maps_subplot.lines[2].get_xydata().flatten(), [2, 0.00988778])
 
             environments_figure, environments_subplot = struct_envs.get_environments_figure(isite=isite)
             assert_array_almost_equal(
                 np.array(environments_subplot.patches[0].get_xy()),
-                [
-                    [1.0, 1.0],
-                    [1.0, 0.99301365],
-                    [1.00179228, 0.99301365],
-                    [1.00179228, 1.0],
-                    [1.0, 1.0],
-                ],
+                [[1, 1], [1, 0.99301365], [1.00179228, 0.99301365], [1.00179228, 1], [1, 1]],
             )
             assert_array_almost_equal(
                 np.array(environments_subplot.patches[1].get_xy()),
-                [
-                    [1.0, 0.99301365],
-                    [1.0, 0.0],
-                    [1.00179228, 0.0],
-                    [1.00179228, 0.99301365],
-                    [1.0, 0.99301365],
-                ],
+                [[1, 0.99301365], [1, 0], [1.00179228, 0], [1.00179228, 0.99301365], [1, 0.99301365]],
             )
             assert_array_almost_equal(
                 np.array(environments_subplot.patches[2].get_xy()),
-                [
-                    [1.00179228, 1.0],
-                    [1.00179228, 0.99301365],
-                    [2.25, 0.99301365],
-                    [2.25, 1.0],
-                    [1.00179228, 1.0],
-                ],
+                [[1.00179228, 1], [1.00179228, 0.99301365], [2.25, 0.99301365], [2.25, 1], [1.00179228, 1]],
             )
             assert_array_almost_equal(
                 np.array(environments_subplot.patches[3].get_xy()),
                 [
                     [1.00179228, 0.99301365],
-                    [1.00179228, 0.0],
-                    [2.22376156, 0.0],
+                    [1.00179228, 0],
+                    [2.22376156, 0],
                     [2.22376156, 0.0060837],
                     [2.25, 0.0060837],
                     [2.25, 0.99301365],
@@ -88,13 +71,7 @@ class StructureEnvironmentsTest(PymatgenTest):
             )
             assert_array_almost_equal(
                 np.array(environments_subplot.patches[4].get_xy()),
-                [
-                    [2.22376156, 0.0060837],
-                    [2.22376156, 0.0],
-                    [2.25, 0.0],
-                    [2.25, 0.0060837],
-                    [2.22376156, 0.0060837],
-                ],
+                [[2.22376156, 0.0060837], [2.22376156, 0], [2.25, 0], [2.25, 0.0060837], [2.22376156, 0.0060837]],
             )
 
             struct_envs.save_environments_figure(isite=isite, imagename="image.png")
@@ -132,9 +109,9 @@ class StructureEnvironmentsTest(PymatgenTest):
             assert "csm1 (with central site) : 34.644" in str(ce)
             assert "csm2 (without central site) : 32.466" in str(ce)
 
-            min_geoms = ce.minimum_geometries(symmetry_measure_type="csm_wocs_ctwocc", max_csm=12.0)
+            min_geoms = ce.minimum_geometries(symmetry_measure_type="csm_wocs_ctwocc", max_csm=12)
             assert len(min_geoms) == 2
-            min_geoms = ce.minimum_geometries(symmetry_measure_type="csm_wocs_ctwcc", max_csm=12.0)
+            min_geoms = ce.minimum_geometries(symmetry_measure_type="csm_wocs_ctwcc", max_csm=12)
             assert len(min_geoms) == 1
             min_geoms = ce.minimum_geometries(n=3)
             assert len(min_geoms) == 3
@@ -142,109 +119,108 @@ class StructureEnvironmentsTest(PymatgenTest):
             ce2 = struct_envs.ce_list[7][4][0]
 
             assert ce.is_close_to(ce2, rtol=0.01, atol=1e-4)
-            assert not ce.is_close_to(ce2, rtol=0.0, atol=1e-8)
+            assert not ce.is_close_to(ce2, rtol=0, atol=1e-8)
 
             assert ce != ce2
             assert ce != ce2
 
     def test_light_structure_environments(self):
-        with ScratchDir("."):
-            with open(f"{struct_env_files_dir}/se_mp-7000.json") as f:
-                dd = json.load(f)
+        with open(f"{struct_env_files_dir}/se_mp-7000.json") as f:
+            dd = json.load(f)
 
-            struct_envs = StructureEnvironments.from_dict(dd)
+        struct_envs = StructureEnvironments.from_dict(dd)
 
-            strategy = SimplestChemenvStrategy()
-            lse = LightStructureEnvironments.from_structure_environments(
-                structure_environments=struct_envs, strategy=strategy, valences="undefined"
-            )
-            isite = 6
-            nb_set = lse.neighbors_sets[isite][0]
-            neighb_coords = [
-                np.array([0.2443798, 1.80409653, -1.13218359]),
-                np.array([1.44020353, 1.11368738, 1.13218359]),
-                np.array([2.75513098, 2.54465207, -0.70467298]),
-                np.array([0.82616785, 3.65833945, 0.70467298]),
-            ]
-            neighb_indices = [0, 3, 5, 1]
-            neighb_images = [[0, 0, -1], [0, 0, 0], [0, 0, -1], [0, 0, 0]]
+        strategy = SimplestChemenvStrategy()
+        lse = LightStructureEnvironments.from_structure_environments(
+            structure_environments=struct_envs, strategy=strategy, valences="undefined"
+        )
+        isite = 6
+        nb_set = lse.neighbors_sets[isite][0]
+        neighb_coords = [
+            np.array([0.2443798, 1.80409653, -1.13218359]),
+            np.array([1.44020353, 1.11368738, 1.13218359]),
+            np.array([2.75513098, 2.54465207, -0.70467298]),
+            np.array([0.82616785, 3.65833945, 0.70467298]),
+        ]
+        neighb_indices = [0, 3, 5, 1]
+        neighb_images = [[0, 0, -1], [0, 0, 0], [0, 0, -1], [0, 0, 0]]
 
-            assert_array_almost_equal(neighb_coords, nb_set.neighb_coords)
-            assert_array_almost_equal(neighb_coords, [s.coords for s in nb_set.neighb_sites])
-            nb_sai = nb_set.neighb_sites_and_indices
-            assert_array_almost_equal(neighb_coords, [sai["site"].coords for sai in nb_sai])
-            assert_array_almost_equal(neighb_indices, [sai["index"] for sai in nb_sai])
-            nb_iai = nb_set.neighb_indices_and_images
-            assert_array_almost_equal(neighb_indices, [iai["index"] for iai in nb_iai])
-            np.testing.assert_array_equal(neighb_images, [iai["image_cell"] for iai in nb_iai])
+        assert_array_almost_equal(neighb_coords, nb_set.neighb_coords)
+        assert_array_almost_equal(neighb_coords, [s.coords for s in nb_set.neighb_sites])
+        nb_sai = nb_set.neighb_sites_and_indices
+        assert_array_almost_equal(neighb_coords, [sai["site"].coords for sai in nb_sai])
+        assert_array_almost_equal(neighb_indices, [sai["index"] for sai in nb_sai])
+        nb_iai = nb_set.neighb_indices_and_images
+        assert_array_almost_equal(neighb_indices, [iai["index"] for iai in nb_iai])
+        np.testing.assert_array_equal(neighb_images, [iai["image_cell"] for iai in nb_iai])
 
-            assert len(nb_set) == 4
-            assert hash(nb_set) == 4
+        assert len(nb_set) == 4
+        assert hash(nb_set) == 4
 
-            assert nb_set == nb_set
+        assert nb_set == nb_set
 
-            assert (
-                str(nb_set) == "Neighbors Set for site #6 :\n"
-                " - Coordination number : 4\n"
-                " - Neighbors sites indices : 0, 1, 2, 3\n"
-            )
+        assert (
+            str(nb_set) == "Neighbors Set for site #6 :\n"
+            " - Coordination number : 4\n"
+            " - Neighbors sites indices : 0, 1, 2, 3\n"
+        )
 
-            stats = lse.get_statistics()
+        stats = lse.get_statistics()
 
-            neighbors = lse.strategy.get_site_neighbors(site=lse.structure[isite])
-            self.assert_all_close(neighbors[0].coords, np.array([0.2443798, 1.80409653, -1.13218359]))
-            self.assert_all_close(neighbors[1].coords, np.array([1.44020353, 1.11368738, 1.13218359]))
-            self.assert_all_close(neighbors[2].coords, np.array([2.75513098, 2.54465207, -0.70467298]))
-            self.assert_all_close(neighbors[3].coords, np.array([0.82616785, 3.65833945, 0.70467298]))
+        neighbors = lse.strategy.get_site_neighbors(site=lse.structure[isite])
+        self.assert_all_close(neighbors[0].coords, np.array([0.2443798, 1.80409653, -1.13218359]))
+        self.assert_all_close(neighbors[1].coords, np.array([1.44020353, 1.11368738, 1.13218359]))
+        self.assert_all_close(neighbors[2].coords, np.array([2.75513098, 2.54465207, -0.70467298]))
+        self.assert_all_close(neighbors[3].coords, np.array([0.82616785, 3.65833945, 0.70467298]))
 
-            equiv_site_index_and_transform = lse.strategy.equivalent_site_index_and_transform(neighbors[0])
-            assert equiv_site_index_and_transform[0] == 0
-            self.assert_all_close(equiv_site_index_and_transform[1], [0.0, 0.0, 0.0])
-            self.assert_all_close(equiv_site_index_and_transform[2], [0.0, 0.0, -1.0])
+        equiv_site_index_and_transform = lse.strategy.equivalent_site_index_and_transform(neighbors[0])
+        assert equiv_site_index_and_transform[0] == 0
+        self.assert_all_close(equiv_site_index_and_transform[1], [0, 0, 0])
+        self.assert_all_close(equiv_site_index_and_transform[2], [0, 0, -1])
 
-            equiv_site_index_and_transform = lse.strategy.equivalent_site_index_and_transform(neighbors[1])
-            assert equiv_site_index_and_transform[0] == 3
-            self.assert_all_close(equiv_site_index_and_transform[1], [0.0, 0.0, 0.0])
-            self.assert_all_close(equiv_site_index_and_transform[2], [0.0, 0.0, 0.0])
+        equiv_site_index_and_transform = lse.strategy.equivalent_site_index_and_transform(neighbors[1])
+        assert equiv_site_index_and_transform[0] == 3
+        self.assert_all_close(equiv_site_index_and_transform[1], [0, 0, 0])
+        self.assert_all_close(equiv_site_index_and_transform[2], [0, 0, 0])
 
-            assert stats["atom_coordination_environments_present"] == {"Si": {"T:4": 3.0}}
-            assert stats["coordination_environments_atom_present"] == {"T:4": {"Si": 3.0}}
-            assert stats["fraction_atom_coordination_environments_present"] == {"Si": {"T:4": 1.0}}
+        assert stats["atom_coordination_environments_present"] == {"Si": {"T:4": 3}}
+        assert stats["coordination_environments_atom_present"] == {"T:4": {"Si": 3}}
+        assert stats["fraction_atom_coordination_environments_present"] == {"Si": {"T:4": 1}}
 
-            site_info_ce = lse.get_site_info_for_specie_ce(specie=Species("Si", 4), ce_symbol="T:4")
-            assert_array_almost_equal(site_info_ce["fractions"], [1.0, 1.0, 1.0])
-            assert_array_almost_equal(
-                site_info_ce["csms"],
-                [0.009887784240541068, 0.009887786546730826, 0.009887787384385317],
-            )
-            assert site_info_ce["isites"] == [6, 7, 8]
+        site_info_ce = lse.get_site_info_for_specie_ce(specie=Species("Si", 4), ce_symbol="T:4")
+        assert_array_almost_equal(site_info_ce["fractions"], [1, 1, 1])
+        assert_array_almost_equal(
+            site_info_ce["csms"],
+            [0.009887784240541068, 0.009887786546730826, 0.009887787384385317],
+        )
+        assert site_info_ce["isites"] == [6, 7, 8]
 
-            site_info_allces = lse.get_site_info_for_specie_allces(specie=Species("Si", 4))
+        site_info_allces = lse.get_site_info_for_specie_allces(specie=Species("Si", 4))
 
-            assert site_info_allces["T:4"] == site_info_ce
+        assert site_info_allces["T:4"] == site_info_ce
 
-            assert not lse.contains_only_one_anion("I-")
-            assert not lse.contains_only_one_anion_atom("I")
-            assert lse.site_contains_environment(isite=isite, ce_symbol="T:4")
-            assert not lse.site_contains_environment(isite=isite, ce_symbol="S:4")
-            assert not lse.structure_contains_atom_environment(atom_symbol="Si", ce_symbol="S:4")
-            assert lse.structure_contains_atom_environment(atom_symbol="Si", ce_symbol="T:4")
-            assert not lse.structure_contains_atom_environment(atom_symbol="O", ce_symbol="T:4")
-            assert lse.uniquely_determines_coordination_environments
-            assert lse == lse
+        assert not lse.contains_only_one_anion("I-")
+        assert not lse.contains_only_one_anion_atom("I")
+        assert lse.site_contains_environment(isite=isite, ce_symbol="T:4")
+        assert not lse.site_contains_environment(isite=isite, ce_symbol="S:4")
+        assert not lse.structure_contains_atom_environment(atom_symbol="Si", ce_symbol="S:4")
+        assert lse.structure_contains_atom_environment(atom_symbol="Si", ce_symbol="T:4")
+        assert not lse.structure_contains_atom_environment(atom_symbol="O", ce_symbol="T:4")
+        assert lse.uniquely_determines_coordination_environments
+        assert lse == lse
 
-            envs = lse.strategy.get_site_coordination_environments(lse.structure[6])
-            assert len(envs) == 1
-            assert envs[0][0] == "T:4"
+        envs = lse.strategy.get_site_coordination_environments(lse.structure[6])
+        assert len(envs) == 1
+        assert envs[0][0] == "T:4"
 
-            multi_strategy = MultiWeightsChemenvStrategy.stats_article_weights_parameters()
+        multi_strategy = MultiWeightsChemenvStrategy.stats_article_weights_parameters()
 
-            lse_multi = LightStructureEnvironments.from_structure_environments(
-                strategy=multi_strategy, structure_environments=struct_envs, valences="undefined"
-            )
-            assert lse_multi.coordination_environments[isite][0]["csm"] == pytest.approx(0.009887784240541068)
-            assert lse_multi.coordination_environments[isite][0]["ce_fraction"] == pytest.approx(1.0)
-            assert lse_multi.coordination_environments[isite][0]["ce_symbol"] == "T:4"
+        lse_multi = LightStructureEnvironments.from_structure_environments(
+            strategy=multi_strategy, structure_environments=struct_envs, valences="undefined"
+        )
+        assert lse_multi.coordination_environments[isite][0]["csm"] == pytest.approx(0.009887784240541068)
+        assert lse_multi.coordination_environments[isite][0]["ce_fraction"] == pytest.approx(1)
+        assert lse_multi.coordination_environments[isite][0]["ce_symbol"] == "T:4"
 
     def test_from_structure_environments(self):
         # https://github.com/materialsproject/pymatgen/issues/2756

--- a/pymatgen/analysis/chemenv/coordination_environments/tests/test_voronoi.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/tests/test_voronoi.py
@@ -4,7 +4,6 @@ import os
 import random
 
 import numpy as np
-from monty.tempfile import ScratchDir
 
 from pymatgen.analysis.chemenv.coordination_environments.voronoi import DetailedVoronoiContainer
 from pymatgen.core.lattice import Lattice
@@ -13,201 +12,191 @@ from pymatgen.util.testing import PymatgenTest
 
 __author__ = "waroquiers"
 
-json_files_dir = os.path.join(
-    PymatgenTest.TEST_FILES_DIR,
-    "chemenv",
-    "json_test_files",
-)
-img_files_dir = os.path.join(
-    PymatgenTest.TEST_FILES_DIR,
-    "chemenv",
-    "images",
-)
+json_files_dir = os.path.join(PymatgenTest.TEST_FILES_DIR, "chemenv", "json_test_files")
+img_files_dir = os.path.join(PymatgenTest.TEST_FILES_DIR, "chemenv", "images")
 
 
 class VoronoiContainerTest(PymatgenTest):
     def test_voronoi(self):
-        with ScratchDir("."):
-            # Define a cubic lattice and a list of species (to be used for the fake structures)
-            cubic_lattice = Lattice.cubic(10.0)
-            species = ["Cu", "O", "O", "O", "O", "O", "O"]
-            valences = "undefined"
+        # Define a cubic lattice and a list of species (to be used for the fake structures)
+        cubic_lattice = Lattice.cubic(10.0)
+        species = ["Cu", "O", "O", "O", "O", "O", "O"]
+        valences = "undefined"
 
-            # First fake structure
-            coords = [[5.0, 5.0, 5.0]]
-            order_and_coords = [
-                (1, [4.0, 5.0, 5.0]),
-                (2, [6.01, 5.0, 5.0]),
-                (3, [5.0, 3.98, 5.0]),
-                (4, [5.0, 6.03, 5.0]),
-                (5, [5.0, 5.0, 3.96]),
-                (6, [5.0, 5.0, 6.05]),
-            ]
-            random.shuffle(order_and_coords)
-            sorted = np.argsort([oc[0] for oc in order_and_coords]) + 1
-            coords.extend([oc[1] for oc in order_and_coords])
-            fake_structure = Structure(cubic_lattice, species, coords, coords_are_cartesian=True)
+        # First fake structure
+        coords = [[5.0, 5.0, 5.0]]
+        order_and_coords = [
+            (1, [4.0, 5.0, 5.0]),
+            (2, [6.01, 5.0, 5.0]),
+            (3, [5.0, 3.98, 5.0]),
+            (4, [5.0, 6.03, 5.0]),
+            (5, [5.0, 5.0, 3.96]),
+            (6, [5.0, 5.0, 6.05]),
+        ]
+        random.shuffle(order_and_coords)
+        sorted = np.argsort([oc[0] for oc in order_and_coords]) + 1
+        coords.extend([oc[1] for oc in order_and_coords])
+        fake_structure = Structure(cubic_lattice, species, coords, coords_are_cartesian=True)
 
-            # First fake structure with a given normalized_distance_tolerance of 0.0100001
-            detailed_voronoi_container = DetailedVoronoiContainer(
-                structure=fake_structure,
-                valences=valences,
-                normalized_distance_tolerance=0.0100001,
-                isites=[0],
-            )
-            assert len(detailed_voronoi_container.voronoi_list2[0]) == 6
-            neighbors = detailed_voronoi_container.neighbors(0, 1.0, 0.5, True)
-            assert len(neighbors) == 6
-            neighbors = detailed_voronoi_container.neighbors(0, 1.02, 0.5, True)
-            assert len(neighbors) == 6
-            neighbors = detailed_voronoi_container.neighbors(0, 1.026, 0.5, True)
-            assert len(neighbors) == 6
-            neighbors = detailed_voronoi_container.neighbors(0, 1.5, 0.5, True)
-            assert len(neighbors) == 6
+        # First fake structure with a given normalized_distance_tolerance of 0.0100001
+        detailed_voronoi_container = DetailedVoronoiContainer(
+            structure=fake_structure,
+            valences=valences,
+            normalized_distance_tolerance=0.0100001,
+            isites=[0],
+        )
+        assert len(detailed_voronoi_container.voronoi_list2[0]) == 6
+        neighbors = detailed_voronoi_container.neighbors(0, 1.0, 0.5, True)
+        assert len(neighbors) == 6
+        neighbors = detailed_voronoi_container.neighbors(0, 1.02, 0.5, True)
+        assert len(neighbors) == 6
+        neighbors = detailed_voronoi_container.neighbors(0, 1.026, 0.5, True)
+        assert len(neighbors) == 6
+        neighbors = detailed_voronoi_container.neighbors(0, 1.5, 0.5, True)
+        assert len(neighbors) == 6
 
-            # First fake structure with a given normalized_distance_tolerance of 0.001
-            detailed_voronoi_container = DetailedVoronoiContainer(
-                structure=fake_structure,
-                valences=valences,
-                normalized_distance_tolerance=0.001,
-                isites=[0],
-            )
-            assert len(detailed_voronoi_container.voronoi_list2[0]) == 6
-            neighbors = detailed_voronoi_container.neighbors(0, 1.0, 0.5, True)
-            assert len(neighbors) == 1
-            assert neighbors[0]["site"] == fake_structure[sorted[0]]
-            neighbors = detailed_voronoi_container.neighbors(0, 1.02, 0.5, True)
-            nbs = [nb["site"] for nb in neighbors]
-            assert len(neighbors) == 3
-            assert fake_structure[sorted[0]] in nbs
-            assert fake_structure[sorted[1]] in nbs
-            assert fake_structure[sorted[2]] in nbs
-            neighbors = detailed_voronoi_container.neighbors(0, 1.026, 0.5, True)
-            nbs = [nb["site"] for nb in neighbors]
-            assert len(neighbors) == 3
-            assert fake_structure[sorted[0]] in nbs
-            assert fake_structure[sorted[1]] in nbs
-            assert fake_structure[sorted[2]] in nbs
-            neighbors = detailed_voronoi_container.neighbors(0, 1.5, 0.5, True)
-            assert len(neighbors) == 6
+        # First fake structure with a given normalized_distance_tolerance of 0.001
+        detailed_voronoi_container = DetailedVoronoiContainer(
+            structure=fake_structure,
+            valences=valences,
+            normalized_distance_tolerance=0.001,
+            isites=[0],
+        )
+        assert len(detailed_voronoi_container.voronoi_list2[0]) == 6
+        neighbors = detailed_voronoi_container.neighbors(0, 1.0, 0.5, True)
+        assert len(neighbors) == 1
+        assert neighbors[0]["site"] == fake_structure[sorted[0]]
+        neighbors = detailed_voronoi_container.neighbors(0, 1.02, 0.5, True)
+        nbs = [nb["site"] for nb in neighbors]
+        assert len(neighbors) == 3
+        assert fake_structure[sorted[0]] in nbs
+        assert fake_structure[sorted[1]] in nbs
+        assert fake_structure[sorted[2]] in nbs
+        neighbors = detailed_voronoi_container.neighbors(0, 1.026, 0.5, True)
+        nbs = [nb["site"] for nb in neighbors]
+        assert len(neighbors) == 3
+        assert fake_structure[sorted[0]] in nbs
+        assert fake_structure[sorted[1]] in nbs
+        assert fake_structure[sorted[2]] in nbs
+        neighbors = detailed_voronoi_container.neighbors(0, 1.5, 0.5, True)
+        assert len(neighbors) == 6
 
-            # Second fake structure
-            coords2 = [[5.0, 5.0, 5.0]]
-            order_and_coords = [
-                (1, [4.0, 5.0, 5.0]),
-                (2, [6.01, 5.0, 5.0]),
-                (3, [5.0, 3.98, 5.0]),
-                (4, [5.0, 6.07, 5.0]),
-                (5, [5.0, 5.0, 3.92]),
-                (6, [5.0, 5.0, 6.09]),
-            ]
-            random.shuffle(order_and_coords)
-            sorted = np.argsort([oc[0] for oc in order_and_coords]) + 1
-            coords2.extend([oc[1] for oc in order_and_coords])
-            fake_structure2 = Structure(cubic_lattice, species, coords2, coords_are_cartesian=True)
+        # Second fake structure
+        coords2 = [[5.0, 5.0, 5.0]]
+        order_and_coords = [
+            (1, [4.0, 5.0, 5.0]),
+            (2, [6.01, 5.0, 5.0]),
+            (3, [5.0, 3.98, 5.0]),
+            (4, [5.0, 6.07, 5.0]),
+            (5, [5.0, 5.0, 3.92]),
+            (6, [5.0, 5.0, 6.09]),
+        ]
+        random.shuffle(order_and_coords)
+        sorted = np.argsort([oc[0] for oc in order_and_coords]) + 1
+        coords2.extend([oc[1] for oc in order_and_coords])
+        fake_structure2 = Structure(cubic_lattice, species, coords2, coords_are_cartesian=True)
 
-            # Second fake structure with a given normalized_distance_tolerance of 0.0100001
-            detailed_voronoi_container = DetailedVoronoiContainer(
-                structure=fake_structure2,
-                valences=valences,
-                normalized_distance_tolerance=0.0100001,
-                isites=[0],
-            )
-            assert len(detailed_voronoi_container.voronoi_list2[0]) == 6
-            neighbors = detailed_voronoi_container.neighbors(0, 1.0, 0.5, True)
-            nbs = [nb["site"] for nb in neighbors]
-            assert len(neighbors) == 3
-            assert fake_structure2[sorted[0]] in nbs
-            assert fake_structure2[sorted[1]] in nbs
-            assert fake_structure2[sorted[2]] in nbs
-            neighbors = detailed_voronoi_container.neighbors(0, 1.02, 0.5, True)
-            nbs = [nb["site"] for nb in neighbors]
-            assert len(neighbors) == 3
-            assert fake_structure2[sorted[0]] in nbs
-            assert fake_structure2[sorted[1]] in nbs
-            assert fake_structure2[sorted[2]] in nbs
-            neighbors = detailed_voronoi_container.neighbors(0, 1.026, 0.5, True)
-            nbs = [nb["site"] for nb in neighbors]
-            assert len(neighbors) == 3
-            assert fake_structure2[sorted[0]] in nbs
-            assert fake_structure2[sorted[1]] in nbs
-            assert fake_structure2[sorted[2]] in nbs
-            neighbors = detailed_voronoi_container.neighbors(0, 1.5, 0.5, True)
-            assert len(neighbors) == 6
+        # Second fake structure with a given normalized_distance_tolerance of 0.0100001
+        detailed_voronoi_container = DetailedVoronoiContainer(
+            structure=fake_structure2,
+            valences=valences,
+            normalized_distance_tolerance=0.0100001,
+            isites=[0],
+        )
+        assert len(detailed_voronoi_container.voronoi_list2[0]) == 6
+        neighbors = detailed_voronoi_container.neighbors(0, 1.0, 0.5, True)
+        nbs = [nb["site"] for nb in neighbors]
+        assert len(neighbors) == 3
+        assert fake_structure2[sorted[0]] in nbs
+        assert fake_structure2[sorted[1]] in nbs
+        assert fake_structure2[sorted[2]] in nbs
+        neighbors = detailed_voronoi_container.neighbors(0, 1.02, 0.5, True)
+        nbs = [nb["site"] for nb in neighbors]
+        assert len(neighbors) == 3
+        assert fake_structure2[sorted[0]] in nbs
+        assert fake_structure2[sorted[1]] in nbs
+        assert fake_structure2[sorted[2]] in nbs
+        neighbors = detailed_voronoi_container.neighbors(0, 1.026, 0.5, True)
+        nbs = [nb["site"] for nb in neighbors]
+        assert len(neighbors) == 3
+        assert fake_structure2[sorted[0]] in nbs
+        assert fake_structure2[sorted[1]] in nbs
+        assert fake_structure2[sorted[2]] in nbs
+        neighbors = detailed_voronoi_container.neighbors(0, 1.5, 0.5, True)
+        assert len(neighbors) == 6
 
-            species = ["Cu", "Cu", "O", "O", "O", "Cu", "O"]
-            valences = [2, 2, -2, -2, -2, 2, -2]
+        species = ["Cu", "Cu", "O", "O", "O", "Cu", "O"]
+        valences = [2, 2, -2, -2, -2, 2, -2]
 
-            # Third fake structure (test of the only_anion_cation_bonds)
-            coords = [
-                [5.0, 5.0, 5.0],
-                [6.01, 5.0, 5.0],
-                [5.0, 5.0, 3.96],
-                [4.0, 5.0, 5.0],
-                [5.0, 6.03, 5.0],
-                [5.0, 3.98, 5.0],
-                [5.0, 5.0, 6.05],
-            ]
-            fake_structure3 = Structure(cubic_lattice, species, coords, coords_are_cartesian=True)
-            detailed_voronoi_container = DetailedVoronoiContainer(
-                structure=fake_structure3,
-                valences=valences,
-                normalized_distance_tolerance=0.0100001,
-                isites=[0],
-                additional_conditions=[DetailedVoronoiContainer.AC.ONLY_ACB],
-            )
-            assert len(detailed_voronoi_container.voronoi_list2[0]) == 6
-            neighbors = detailed_voronoi_container.neighbors(0, 1.01, 0.5, True)
-            nbs = [nb["site"] for nb in neighbors]
-            assert len(neighbors) == 6
-            assert fake_structure3[1] in nbs
-            assert fake_structure3[2] in nbs
-            assert fake_structure3[3] in nbs
-            assert fake_structure3[4] in nbs
-            assert fake_structure3[5] in nbs
-            assert fake_structure3[6] in nbs
+        # Third fake structure (test of the only_anion_cation_bonds)
+        coords = [
+            [5.0, 5.0, 5.0],
+            [6.01, 5.0, 5.0],
+            [5.0, 5.0, 3.96],
+            [4.0, 5.0, 5.0],
+            [5.0, 6.03, 5.0],
+            [5.0, 3.98, 5.0],
+            [5.0, 5.0, 6.05],
+        ]
+        fake_structure3 = Structure(cubic_lattice, species, coords, coords_are_cartesian=True)
+        detailed_voronoi_container = DetailedVoronoiContainer(
+            structure=fake_structure3,
+            valences=valences,
+            normalized_distance_tolerance=0.0100001,
+            isites=[0],
+            additional_conditions=[DetailedVoronoiContainer.AC.ONLY_ACB],
+        )
+        assert len(detailed_voronoi_container.voronoi_list2[0]) == 6
+        neighbors = detailed_voronoi_container.neighbors(0, 1.01, 0.5, True)
+        nbs = [nb["site"] for nb in neighbors]
+        assert len(neighbors) == 6
+        assert fake_structure3[1] in nbs
+        assert fake_structure3[2] in nbs
+        assert fake_structure3[3] in nbs
+        assert fake_structure3[4] in nbs
+        assert fake_structure3[5] in nbs
+        assert fake_structure3[6] in nbs
 
-            # Test of the as_dict() and from_dict() methods as well as __eq__ method
-            other_detailed_voronoi_container = DetailedVoronoiContainer.from_dict(detailed_voronoi_container.as_dict())
-            assert detailed_voronoi_container, other_detailed_voronoi_container
+        # Test of the as_dict() and from_dict() methods as well as __eq__ method
+        other_detailed_voronoi_container = DetailedVoronoiContainer.from_dict(detailed_voronoi_container.as_dict())
+        assert detailed_voronoi_container, other_detailed_voronoi_container
 
     def test_get_vertices_dist_ang_indices(self):
-        with ScratchDir("."):
-            cubic_lattice = Lattice.cubic(10.0)
-            species = ["Cu", "O", "O", "O", "O", "O", "O"]
-            valences = "undefined"
+        cubic_lattice = Lattice.cubic(10.0)
+        species = ["Cu", "O", "O", "O", "O", "O", "O"]
+        valences = "undefined"
 
-            # First fake structure
-            coords = [
-                [5.0, 5.0, 5.0],
-                [6.01, 5.0, 5.0],
-                [5.0, 5.0, 3.96],
-                [4.0, 5.0, 5.0],
-                [5.0, 6.03, 5.0],
-                [5.0, 3.98, 5.0],
-                [5.0, 5.0, 6.05],
-            ]
-            fake_structure = Structure(cubic_lattice, species, coords, coords_are_cartesian=True)
+        # First fake structure
+        coords = [
+            [5.0, 5.0, 5.0],
+            [6.01, 5.0, 5.0],
+            [5.0, 5.0, 3.96],
+            [4.0, 5.0, 5.0],
+            [5.0, 6.03, 5.0],
+            [5.0, 3.98, 5.0],
+            [5.0, 5.0, 6.05],
+        ]
+        fake_structure = Structure(cubic_lattice, species, coords, coords_are_cartesian=True)
 
-            # First fake structure with a given normalized_distance_tolerance of 0.0100001
-            detailed_voronoi_container = DetailedVoronoiContainer(
-                structure=fake_structure,
-                valences=valences,
-                normalized_distance_tolerance=0.0100001,
-                isites=[0],
-            )
-            fake_parameter_indices_list = []
-            for ii in range(2, 5):
-                for jj in range(7, 14):
-                    fake_parameter_indices_list.append((ii, jj))
-            for ii in range(5, 7):
-                for jj in range(10, 14):
-                    fake_parameter_indices_list.append((ii, jj))
+        # First fake structure with a given normalized_distance_tolerance of 0.0100001
+        detailed_voronoi_container = DetailedVoronoiContainer(
+            structure=fake_structure,
+            valences=valences,
+            normalized_distance_tolerance=0.0100001,
+            isites=[0],
+        )
+        fake_parameter_indices_list = []
+        for ii in range(2, 5):
+            for jj in range(7, 14):
+                fake_parameter_indices_list.append((ii, jj))
+        for ii in range(5, 7):
+            for jj in range(10, 14):
+                fake_parameter_indices_list.append((ii, jj))
 
-            points = detailed_voronoi_container._get_vertices_dist_ang_indices(fake_parameter_indices_list)
-            assert points[0] == (2, 7)
-            assert points[1] == (4, 7)
-            assert points[2] == (4, 10)
-            assert points[3] == (6, 10)
-            assert points[4] == (6, 13)
-            assert points[5] == (2, 13)
+        points = detailed_voronoi_container._get_vertices_dist_ang_indices(fake_parameter_indices_list)
+        assert points[0] == (2, 7)
+        assert points[1] == (4, 7)
+        assert points[2] == (4, 10)
+        assert points[3] == (6, 10)
+        assert points[4] == (6, 13)
+        assert points[5] == (2, 13)

--- a/pymatgen/analysis/chemenv/utils/tests/test_chemenv_config.py
+++ b/pymatgen/analysis/chemenv/utils/tests/test_chemenv_config.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import os
 import unittest
 
-from monty.tempfile import ScratchDir
-
 from pymatgen.analysis.chemenv.utils.chemenv_config import ChemEnvConfig
 from pymatgen.core import SETTINGS
 from pymatgen.util.testing import PymatgenTest
@@ -16,36 +14,35 @@ config_file_dir = os.path.join(PymatgenTest.TEST_FILES_DIR, "chemenv", "config")
 
 class ChemenvConfigTest(unittest.TestCase):
     def test_chemenv_config(self):
-        with ScratchDir("."):
-            config = ChemEnvConfig()
+        config = ChemEnvConfig()
 
-            if SETTINGS.get("PMG_MAPI_KEY"):
-                assert config.has_materials_project_access
-            else:
-                assert not config.has_materials_project_access
+        if SETTINGS.get("PMG_MAPI_KEY"):
+            assert config.has_materials_project_access
+        else:
+            assert not config.has_materials_project_access
 
-            package_options = ChemEnvConfig.DEFAULT_PACKAGE_OPTIONS
-            package_options["default_max_distance_factor"] = 1.8
+        package_options = ChemEnvConfig.DEFAULT_PACKAGE_OPTIONS
+        package_options["default_max_distance_factor"] = 1.8
 
-            config = ChemEnvConfig(package_options=package_options)
+        config = ChemEnvConfig(package_options=package_options)
 
-            assert (
-                config.package_options_description() == "Package options :\n"
-                " - Maximum distance factor : 1.8000\n"
-                ' - Default strategy is "SimplestChemenvStrategy" :\n'
-                "    Simplest ChemenvStrategy using fixed angle and distance parameters \n"
-                "    for the definition of neighbors in the Voronoi approach. \n"
-                "    The coordination environment is then given as the one with the \n"
-                "    lowest continuous symmetry measure.\n"
-                "   with options :\n"
-                "     - distance_cutoff : 1.4\n"
-                "     - angle_cutoff : 0.3\n"
-                "     - additional_condition : 1\n"
-                "     - continuous_symmetry_measure_cutoff : 10.0\n"
-            )
+        assert (
+            config.package_options_description() == "Package options :\n"
+            " - Maximum distance factor : 1.8000\n"
+            ' - Default strategy is "SimplestChemenvStrategy" :\n'
+            "    Simplest ChemenvStrategy using fixed angle and distance parameters \n"
+            "    for the definition of neighbors in the Voronoi approach. \n"
+            "    The coordination environment is then given as the one with the \n"
+            "    lowest continuous symmetry measure.\n"
+            "   with options :\n"
+            "     - distance_cutoff : 1.4\n"
+            "     - angle_cutoff : 0.3\n"
+            "     - additional_condition : 1\n"
+            "     - continuous_symmetry_measure_cutoff : 10.0\n"
+        )
 
-            config.save(root_dir="tmp_dir")
+        config.save(root_dir="tmp_dir")
 
-            config = config.auto_load(root_dir="tmp_dir")
+        config = config.auto_load(root_dir="tmp_dir")
 
-            assert config.package_options == package_options
+        assert config.package_options == package_options

--- a/pymatgen/analysis/tests/test_phase_diagram.py
+++ b/pymatgen/analysis/tests/test_phase_diagram.py
@@ -10,7 +10,6 @@ from pathlib import Path
 import numpy as np
 import pytest
 from monty.serialization import dumpfn, loadfn
-from monty.tempfile import ScratchDir
 
 from pymatgen.analysis.phase_diagram import (
     CompoundPhaseDiagram,
@@ -596,9 +595,8 @@ class PhaseDiagramTest(unittest.TestCase):
         assert isinstance(pd.to_json(), str)
 
     def test_read_json(self):
-        with ScratchDir("."):
-            dumpfn(self.pd, "pd.json")
-            loadfn("pd.json")
+        dumpfn(self.pd, "pd.json")
+        loadfn("pd.json")
 
     def test_el_refs(self):
         # Create an imitation of pre_computed phase diagram with el_refs keys being

--- a/pymatgen/analysis/tests/test_pourbaix_diagram.py
+++ b/pymatgen/analysis/tests/test_pourbaix_diagram.py
@@ -8,7 +8,6 @@ import warnings
 
 import numpy as np
 from monty.serialization import dumpfn, loadfn
-from monty.tempfile import ScratchDir
 from pytest import approx
 
 from pymatgen.analysis.pourbaix_diagram import IonEntry, MultiEntry, PourbaixDiagram, PourbaixEntry, PourbaixPlotter
@@ -20,7 +19,7 @@ from pymatgen.util.testing import PymatgenTest
 logger = logging.getLogger(__name__)
 
 
-class PourbaixEntryTest(unittest.TestCase):
+class PourbaixEntryTest(PymatgenTest):
     _multiprocess_shared_ = True
     """
     Test all functions using a fictitious entry
@@ -28,11 +27,11 @@ class PourbaixEntryTest(unittest.TestCase):
 
     def setUp(self):
         # comp = Composition("Mn2O3")
-        self.solentry = ComputedEntry("Mn2O3", 49)
+        self.sol_entry = ComputedEntry("Mn2O3", 49)
         ion = Ion.from_formula("MnO4-")
-        self.ionentry = IonEntry(ion, 25)
-        self.PxIon = PourbaixEntry(self.ionentry)
-        self.PxSol = PourbaixEntry(self.solentry)
+        self.ion_entry = IonEntry(ion, 25)
+        self.PxIon = PourbaixEntry(self.ion_entry)
+        self.PxSol = PourbaixEntry(self.sol_entry)
         self.PxIon.concentration = 1e-4
 
     def test_pourbaix_entry(self):
@@ -66,9 +65,8 @@ class PourbaixEntryTest(unittest.TestCase):
         # Ensure computed entry data persists
         entry = ComputedEntry("TiO2", energy=-20, data={"test": "test"})
         pbx_entry = PourbaixEntry(entry=entry)
-        with ScratchDir("."):
-            dumpfn(pbx_entry, "pbx_entry.json")
-            reloaded = loadfn("pbx_entry.json")
+        dumpfn(pbx_entry, "pbx_entry.json")
+        reloaded = loadfn("pbx_entry.json")
         assert isinstance(reloaded.entry, ComputedEntry)
         assert reloaded.entry.data is not None
 

--- a/pymatgen/command_line/bader_caller.py
+++ b/pymatgen/command_line/bader_caller.py
@@ -20,11 +20,11 @@ import subprocess
 import warnings
 from glob import glob
 from shutil import which
+from tempfile import TemporaryDirectory
 
 import numpy as np
 from monty.dev import requires
 from monty.io import zopen
-from monty.tempfile import ScratchDir
 
 from pymatgen.io.common import VolumetricData
 from pymatgen.io.vasp.inputs import Potcar
@@ -156,107 +156,104 @@ class BaderAnalysis:
             chgrefpath = os.path.abspath(chgref_filename) if chgref_filename else None
             self.reference_used = bool(chgref_filename)
 
-        with ScratchDir("."):
-            tmpfile = "CHGCAR" if chgcar_filename else "CUBE"
-            with zopen(fpath, "rt") as f_in, open(tmpfile, "w") as f_out:
+        tmpfile = "CHGCAR" if chgcar_filename else "CUBE"
+        with zopen(fpath, "rt") as f_in, open(tmpfile, "w") as f_out:
+            shutil.copyfileobj(f_in, f_out)
+        args = [BADEREXE, tmpfile]
+        if chgref_filename:
+            with zopen(chgrefpath, "rt") as f_in, open("CHGCAR_ref", "w") as f_out:
                 shutil.copyfileobj(f_in, f_out)
-            args = [BADEREXE, tmpfile]
-            if chgref_filename:
-                with zopen(chgrefpath, "rt") as f_in, open("CHGCAR_ref", "w") as f_out:
-                    shutil.copyfileobj(f_in, f_out)
-                args += ["-ref", "CHGCAR_ref"]
-            if parse_atomic_densities:
-                args += ["-p", "all_atom"]
-            with subprocess.Popen(args, stdout=subprocess.PIPE, stdin=subprocess.PIPE, close_fds=True) as rs:
-                stdout, _ = rs.communicate()
-            if rs.returncode != 0:
-                raise RuntimeError(
-                    f"bader exited with return code {rs.returncode}. Please check your bader installation."
-                )
+            args += ["-ref", "CHGCAR_ref"]
+        if parse_atomic_densities:
+            args += ["-p", "all_atom"]
+        with subprocess.Popen(args, stdout=subprocess.PIPE, stdin=subprocess.PIPE, close_fds=True) as rs:
+            stdout, _ = rs.communicate()
+        if rs.returncode != 0:
+            raise RuntimeError(f"bader exited with return code {rs.returncode}. Please check your bader installation.")
 
-            try:
-                self.version = float(stdout.split()[5])
-            except ValueError:
-                self.version = -1  # Unknown
-            if self.version < 1.0:
-                warnings.warn(
-                    "Your installed version of Bader is outdated, calculation of vacuum charge may be incorrect.",
-                    UserWarning,
-                )
+        try:
+            self.version = float(stdout.split()[5])
+        except ValueError:
+            self.version = -1  # Unknown
+        if self.version < 1.0:
+            warnings.warn(
+                "Your installed version of Bader is outdated, calculation of vacuum charge may be incorrect.",
+                UserWarning,
+            )
 
-            data = []
-            with open("ACF.dat") as f:
-                raw = f.readlines()
-                headers = ("x", "y", "z", "charge", "min_dist", "atomic_vol")
-                raw.pop(0)
-                raw.pop(0)
-                while True:
-                    line = raw.pop(0).strip()
-                    if line.startswith("-"):
-                        break
-                    vals = map(float, line.split()[1:])
-                    data.append(dict(zip(headers, vals)))
-                for line in raw:
-                    toks = line.strip().split(":")
-                    if toks[0] == "VACUUM CHARGE":
-                        self.vacuum_charge = float(toks[1])
-                    elif toks[0] == "VACUUM VOLUME":
-                        self.vacuum_volume = float(toks[1])
-                    elif toks[0] == "NUMBER OF ELECTRONS":
-                        self.nelectrons = float(toks[1])
-            self.data = data
+        data = []
+        with open("ACF.dat") as f:
+            raw = f.readlines()
+            headers = ("x", "y", "z", "charge", "min_dist", "atomic_vol")
+            raw.pop(0)
+            raw.pop(0)
+            while True:
+                line = raw.pop(0).strip()
+                if line.startswith("-"):
+                    break
+                vals = map(float, line.split()[1:])
+                data.append(dict(zip(headers, vals)))
+            for line in raw:
+                tokens = line.strip().split(":")
+                if tokens[0] == "VACUUM CHARGE":
+                    self.vacuum_charge = float(tokens[1])
+                elif tokens[0] == "VACUUM VOLUME":
+                    self.vacuum_volume = float(tokens[1])
+                elif tokens[0] == "NUMBER OF ELECTRONS":
+                    self.nelectrons = float(tokens[1])
+        self.data = data
 
-            if self.parse_atomic_densities:
-                # convert the charge density for each atom spit out by Bader into Chgcar objects for easy parsing
-                atom_chgcars = [
-                    Chgcar.from_file(f"BvAt{str(i).zfill(4)}.dat") for i in range(1, len(self.chgcar.structure) + 1)
-                ]
+        if self.parse_atomic_densities:
+            # convert the charge density for each atom spit out by Bader into Chgcar objects for easy parsing
+            atom_chgcars = [
+                Chgcar.from_file(f"BvAt{str(i).zfill(4)}.dat") for i in range(1, len(self.chgcar.structure) + 1)
+            ]
 
-                atomic_densities = []
-                # For each atom in the structure
-                for _, loc, chg in zip(
-                    self.chgcar.structure,
-                    self.chgcar.structure.frac_coords,
-                    atom_chgcars,
-                ):
-                    # Find the index of the atom in the charge density atom
-                    index = np.round(np.multiply(loc, chg.dim))
+            atomic_densities = []
+            # For each atom in the structure
+            for _, loc, chg in zip(
+                self.chgcar.structure,
+                self.chgcar.structure.frac_coords,
+                atom_chgcars,
+            ):
+                # Find the index of the atom in the charge density atom
+                index = np.round(np.multiply(loc, chg.dim))
 
-                    data = chg.data["total"]
-                    # Find the shift vector in the array
-                    shift = (np.divide(chg.dim, 2) - index).astype(int)
+                data = chg.data["total"]
+                # Find the shift vector in the array
+                shift = (np.divide(chg.dim, 2) - index).astype(int)
 
-                    # Shift the data so that the atomic charge density to the center for easier manipulation
-                    shifted_data = np.roll(data, shift, axis=(0, 1, 2))
+                # Shift the data so that the atomic charge density to the center for easier manipulation
+                shifted_data = np.roll(data, shift, axis=(0, 1, 2))
 
-                    # Slices a central window from the data array
-                    def slice_from_center(data, xwidth, ywidth, zwidth):
-                        x, y, z = data.shape
-                        startx = x // 2 - (xwidth // 2)
-                        starty = y // 2 - (ywidth // 2)
-                        startz = z // 2 - (zwidth // 2)
-                        return data[
-                            startx : startx + xwidth,
-                            starty : starty + ywidth,
-                            startz : startz + zwidth,
-                        ]
+                # Slices a central window from the data array
+                def slice_from_center(data, xwidth, ywidth, zwidth):
+                    x, y, z = data.shape
+                    startx = x // 2 - (xwidth // 2)
+                    starty = y // 2 - (ywidth // 2)
+                    startz = z // 2 - (zwidth // 2)
+                    return data[
+                        startx : startx + xwidth,
+                        starty : starty + ywidth,
+                        startz : startz + zwidth,
+                    ]
 
-                    # Finds the central encompassing volume which holds all the data within a precision
-                    def find_encompassing_vol(data):
-                        total = np.sum(data)
-                        for i in range(np.max(data.shape)):
-                            sliced_data = slice_from_center(data, i, i, i)
-                            if total - np.sum(sliced_data) < 0.1:
-                                return sliced_data
-                        return None
+                # Finds the central encompassing volume which holds all the data within a precision
+                def find_encompassing_vol(data):
+                    total = np.sum(data)
+                    for i in range(np.max(data.shape)):
+                        sliced_data = slice_from_center(data, i, i, i)
+                        if total - np.sum(sliced_data) < 0.1:
+                            return sliced_data
+                    return None
 
-                    d = {
-                        "data": find_encompassing_vol(shifted_data),
-                        "shift": shift,
-                        "dim": self.chgcar.dim,
-                    }
-                    atomic_densities.append(d)
-                self.atomic_densities = atomic_densities
+                d = {
+                    "data": find_encompassing_vol(shifted_data),
+                    "shift": shift,
+                    "dim": self.chgcar.dim,
+                }
+                atomic_densities.append(d)
+            self.atomic_densities = atomic_densities
 
     def get_charge(self, atom_index):
         """
@@ -525,21 +522,21 @@ def bader_analysis_from_objects(chgcar, potcar=None, aeccar0=None, aeccar2=None)
     :param aeccar2: (optional) Chgcar object from aeccar2 file
     :return: summary dict
     """
-    with ScratchDir(".") as temp_dir:
+    with TemporaryDirectory() as tmp_dir:
         if aeccar0 and aeccar2:
             # construct reference file
             chgref = aeccar0.linear_add(aeccar2)
-            chgref_path = os.path.join(temp_dir, "CHGCAR_ref")
+            chgref_path = os.path.join(tmp_dir, "CHGCAR_ref")
             chgref.write_file(chgref_path)
         else:
             chgref_path = None
 
         chgcar.write_file("CHGCAR")
-        chgcar_path = os.path.join(temp_dir, "CHGCAR")
+        chgcar_path = os.path.join(tmp_dir, "CHGCAR")
 
         if potcar:
             potcar.write_file("POTCAR")
-            potcar_path = os.path.join(temp_dir, "POTCAR")
+            potcar_path = os.path.join(tmp_dir, "POTCAR")
         else:
             potcar_path = None
 
@@ -569,7 +566,7 @@ def bader_analysis_from_objects(chgcar, potcar=None, aeccar0=None, aeccar2=None)
             chgcar.is_spin_polarized = False
             chgcar.write_file("CHGCAR_mag")
 
-            chgcar_mag_path = os.path.join(temp_dir, "CHGCAR_mag")
+            chgcar_mag_path = os.path.join(tmp_dir, "CHGCAR_mag")
             ba = BaderAnalysis(
                 chgcar_filename=chgcar_mag_path,
                 potcar_filename=potcar_path,

--- a/pymatgen/command_line/critic2_caller.py
+++ b/pymatgen/command_line/critic2_caller.py
@@ -216,9 +216,7 @@ class Critic2Caller:
 
         input_script = "\n".join(input_script)
 
-        with ScratchDir(".") as temp_dir:
-            os.chdir(temp_dir)
-
+        with ScratchDir("."):
             structure.to(filename="POSCAR")
 
             if chgcar and isinstance(chgcar, VolumetricData):

--- a/pymatgen/command_line/enumlib_caller.py
+++ b/pymatgen/command_line/enumlib_caller.py
@@ -135,8 +135,8 @@ class EnumlibAdaptor:
         Run the enumeration.
         """
         # Create a temporary directory for working.
-        with ScratchDir(".") as d:
-            logger.debug(f"Temp dir : {d}")
+        with ScratchDir(".") as tmp_dir:
+            logger.debug(f"Temp dir : {tmp_dir}")
             # Generate input files
             self._gen_input_file()
             # Perform the actual enumeration

--- a/pymatgen/command_line/vampire_caller.py
+++ b/pymatgen/command_line/vampire_caller.py
@@ -123,9 +123,9 @@ class VampireCaller:
         self.mat_name = hm.formula
 
         # Switch to scratch dir which automatically cleans up vampire inputs files unless user specifies to save them
-        # with ScratchDir('/scratch', copy_from_current_on_enter=self.save_inputs,
-        #                 copy_to_current_on_exit=self.save_inputs) as temp_dir:
-        #     os.chdir(temp_dir)
+        # with ScratchDir(
+        #     "/scratch", copy_from_current_on_enter=self.save_inputs, copy_to_current_on_exit=self.save_inputs
+        # ):
 
         # Create input files
         self._create_mat()

--- a/pymatgen/core/tests/test_structure.py
+++ b/pymatgen/core/tests/test_structure.py
@@ -12,7 +12,6 @@ from unittest import skipIf
 import numpy as np
 import pytest
 from monty.json import MontyDecoder, MontyEncoder
-from monty.tempfile import ScratchDir
 from numpy.testing import assert_array_equal
 
 from pymatgen.core.composition import Composition
@@ -681,46 +680,45 @@ Direct
         self.assert_all_close(self.struct.distance_matrix, ans)
 
     def test_to_from_file_string(self):
-        with ScratchDir("."):
-            for fmt in ["cif", "json", "poscar", "cssr"]:
-                struct = self.struct.to(fmt=fmt)
-                assert struct is not None
-                ss = IStructure.from_str(struct, fmt=fmt)
-                self.assert_all_close(ss.lattice.parameters, self.struct.lattice.parameters, decimal=5)
-                self.assert_all_close(ss.frac_coords, self.struct.frac_coords)
-                assert isinstance(ss, IStructure)
+        for fmt in ["cif", "json", "poscar", "cssr"]:
+            struct = self.struct.to(fmt=fmt)
+            assert struct is not None
+            ss = IStructure.from_str(struct, fmt=fmt)
+            self.assert_all_close(ss.lattice.parameters, self.struct.lattice.parameters, decimal=5)
+            self.assert_all_close(ss.frac_coords, self.struct.frac_coords)
+            assert isinstance(ss, IStructure)
 
-            assert "Fd-3m" in self.struct.to(fmt="CIF", symprec=0.1)
+        assert "Fd-3m" in self.struct.to(fmt="CIF", symprec=0.1)
 
-            self.struct.to(filename="POSCAR.testing")
-            assert os.path.isfile("POSCAR.testing")
+        self.struct.to(filename="POSCAR.testing")
+        assert os.path.isfile("POSCAR.testing")
 
-            self.struct.to(filename="Si_testing.yaml")
-            assert os.path.isfile("Si_testing.yaml")
-            struct = Structure.from_file("Si_testing.yaml")
-            assert struct == self.struct
-            # Test Path support
-            struct = Structure.from_file(Path("Si_testing.yaml"))
-            assert struct == self.struct
+        self.struct.to(filename="Si_testing.yaml")
+        assert os.path.isfile("Si_testing.yaml")
+        struct = Structure.from_file("Si_testing.yaml")
+        assert struct == self.struct
+        # Test Path support
+        struct = Structure.from_file(Path("Si_testing.yaml"))
+        assert struct == self.struct
 
-            # Test .yml extension works too.
-            os.replace("Si_testing.yaml", "Si_testing.yml")
-            struct = Structure.from_file("Si_testing.yml")
-            assert struct == self.struct
+        # Test .yml extension works too.
+        os.replace("Si_testing.yaml", "Si_testing.yml")
+        struct = Structure.from_file("Si_testing.yml")
+        assert struct == self.struct
 
-            with pytest.raises(ValueError):
-                self.struct.to(filename="whatever")
-            with pytest.raises(ValueError):
-                self.struct.to(fmt="badformat")
+        with pytest.raises(ValueError):
+            self.struct.to(filename="whatever")
+        with pytest.raises(ValueError):
+            self.struct.to(fmt="badformat")
 
-            self.struct.to(filename="POSCAR.testing.gz")
-            struct = Structure.from_file("POSCAR.testing.gz")
-            assert struct == self.struct
+        self.struct.to(filename="POSCAR.testing.gz")
+        struct = Structure.from_file("POSCAR.testing.gz")
+        assert struct == self.struct
 
-            # test CIF file with unicode error
-            # https://github.com/materialsproject/pymatgen/issues/2947
-            struct = Structure.from_file(os.path.join(self.TEST_FILES_DIR, "bad-unicode-gh-2947.mcif"))
-            assert struct.formula == "Ni32 O32"
+        # test CIF file with unicode error
+        # https://github.com/materialsproject/pymatgen/issues/2947
+        struct = Structure.from_file(os.path.join(self.TEST_FILES_DIR, "bad-unicode-gh-2947.mcif"))
+        assert struct.formula == "Ni32 O32"
 
     def test_pbc(self):
         assert_array_equal(self.struct.pbc, (True, True, True))
@@ -1064,24 +1062,23 @@ class StructureTest(PymatgenTest):
         assert isinstance(s2, Structure)
 
     def test_to_from_file_string(self):
-        with ScratchDir("."):
-            # to/from string
-            for fmt in ["cif", "json", "poscar", "cssr", "yaml", "xsf", "res"]:
-                s = self.structure.to(fmt=fmt)
-                assert s is not None
-                ss = Structure.from_str(s, fmt=fmt)
-                self.assert_all_close(ss.lattice.parameters, self.structure.lattice.parameters, decimal=5)
-                self.assert_all_close(ss.frac_coords, self.structure.frac_coords)
-                assert isinstance(ss, Structure)
+        # to/from string
+        for fmt in ["cif", "json", "poscar", "cssr", "yaml", "xsf", "res"]:
+            s = self.structure.to(fmt=fmt)
+            assert s is not None
+            ss = Structure.from_str(s, fmt=fmt)
+            self.assert_all_close(ss.lattice.parameters, self.structure.lattice.parameters, decimal=5)
+            self.assert_all_close(ss.frac_coords, self.structure.frac_coords)
+            assert isinstance(ss, Structure)
 
-            # to/from file
-            self.structure.to(filename="POSCAR.testing")
-            assert os.path.isfile("POSCAR.testing")
+        # to/from file
+        self.structure.to(filename="POSCAR.testing")
+        assert os.path.isfile("POSCAR.testing")
 
-            for ext in (".json", ".json.gz", ".json.bz2", ".json.xz", ".json.lzma"):
-                self.structure.to(filename=f"json-struct{ext}")
-                assert os.path.isfile(f"json-struct{ext}")
-                assert Structure.from_file(f"json-struct{ext}") == self.structure
+        for ext in (".json", ".json.gz", ".json.bz2", ".json.xz", ".json.lzma"):
+            self.structure.to(filename=f"json-struct{ext}")
+            assert os.path.isfile(f"json-struct{ext}")
+            assert Structure.from_file(f"json-struct{ext}") == self.structure
 
     def test_from_spacegroup(self):
         s1 = Structure.from_spacegroup("Fm-3m", Lattice.cubic(3), ["Li", "O"], [[0.25, 0.25, 0.25], [0, 0, 0]])

--- a/pymatgen/io/lammps/utils.py
+++ b/pymatgen/io/lammps/utils.py
@@ -330,8 +330,7 @@ class PackmolRunner:
         """
         # ugly hack to get around the openbabel issues with inconsistent
         # residue labelling.
-        scratch = tempfile.gettempdir()
-        with ScratchDir(scratch, copy_to_current_on_exit=False) as _:
+        with ScratchDir("."):
             mol.to(fmt="pdb", filename="tmp.pdb")
             bma = BabelMolAdaptor.from_file("tmp.pdb", "pdb")
 

--- a/pymatgen/io/tests/test_phonopy.py
+++ b/pymatgen/io/tests/test_phonopy.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-from monty.tempfile import ScratchDir
 from numpy.testing import assert_array_equal
 from pytest import approx
 
@@ -140,14 +139,13 @@ class GetDisplacedStructuresTest(PymatgenTest):
         self.assert_all_close(structures[0].lattice._matrix, structures[8].lattice._matrix, 8)
 
         # test writing output
-        with ScratchDir("."):
-            structures = get_displaced_structures(
-                pmg_structure=pmg_s,
-                atom_disp=0.01,
-                supercell_matrix=supercell_matrix,
-                yaml_fname="test.yaml",
-            )
-            assert os.path.exists("test.yaml")
+        structures = get_displaced_structures(
+            pmg_structure=pmg_s,
+            atom_disp=0.01,
+            supercell_matrix=supercell_matrix,
+            yaml_fname="test.yaml",
+        )
+        assert os.path.exists("test.yaml")
 
 
 @unittest.skipIf(Phonopy is None, "Phonopy not present")

--- a/pymatgen/io/tests/test_wannier90.py
+++ b/pymatgen/io/tests/test_wannier90.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
-from monty.tempfile import ScratchDir
 from pytest import approx
 
 from pymatgen.io.wannier90 import Unk
@@ -80,28 +79,24 @@ class UnkTest(PymatgenTest):
         assert unk.data[0, 1, 0, 0, 0].real == approx(0.0)
 
     def test_write_file(self):
-        with ScratchDir("."):
-            self.unk_std.write_file("UNK00001.1")
-            temp_unk = Unk.from_file("UNK00001.1")
-            assert self.unk_std == temp_unk
+        self.unk_std.write_file("UNK00001.1")
+        temp_unk = Unk.from_file("UNK00001.1")
+        assert self.unk_std == temp_unk
 
-        with ScratchDir("."):
-            self.unk_ncl.write_file("UNK00001.NC")
-            temp_unk = Unk.from_file("UNK00001.NC")
-            assert self.unk_ncl == temp_unk
+        self.unk_ncl.write_file("UNK00001.NC")
+        temp_unk = Unk.from_file("UNK00001.NC")
+        assert self.unk_ncl == temp_unk
 
     def test_read_write(self):
         unk0 = Unk.from_file(self.TEST_FILES_DIR / "UNK.std")
-        with ScratchDir("."):
-            unk0.write_file("UNK00001.1")
-            unk1 = Unk.from_file("UNK00001.1")
-            assert unk0 == unk1
+        unk0.write_file("UNK00001.1")
+        unk1 = Unk.from_file("UNK00001.1")
+        assert unk0 == unk1
 
         unk0 = Unk.from_file(self.TEST_FILES_DIR / "UNK.ncl")
-        with ScratchDir("."):
-            unk0.write_file("UNK00001.NC")
-            unk1 = Unk.from_file("UNK00001.NC")
-            assert unk0 == unk1
+        unk0.write_file("UNK00001.NC")
+        unk1 = Unk.from_file("UNK00001.NC")
+        assert unk0 == unk1
 
     def test_repr(self):
         assert repr(self.unk_std) != ""

--- a/pymatgen/io/vasp/tests/test_inputs.py
+++ b/pymatgen/io/vasp/tests/test_inputs.py
@@ -10,7 +10,6 @@ import pytest
 import scipy.constants as const
 from monty.io import zopen
 from monty.serialization import loadfn
-from monty.tempfile import ScratchDir
 from pytest import approx
 
 from pymatgen.core import SETTINGS
@@ -1136,12 +1135,10 @@ class VaspInputTest(PymatgenTest):
         tmp_dir.rmdir()
 
     def test_run_vasp(self):
-        # To add some test.
-        with ScratchDir(".") as d:
-            self.vasp_input.run_vasp(d, vasp_cmd=["cat", "INCAR"])
-            with open(os.path.join(d, "vasp.out")) as f:
-                output = f.read()
-                assert output.split("\n")[0] == "ALGO = Damped"
+        self.vasp_input.run_vasp(".", vasp_cmd=["cat", "INCAR"])
+        with open("vasp.out") as f:
+            output = f.read()
+            assert output.split("\n")[0] == "ALGO = Damped"
 
     def test_from_directory(self):
         vi = VaspInput.from_directory(PymatgenTest.TEST_FILES_DIR, optional_files={"CONTCAR.Li2O": Poscar})

--- a/pymatgen/io/vasp/tests/test_outputs.py
+++ b/pymatgen/io/vasp/tests/test_outputs.py
@@ -11,7 +11,6 @@ from shutil import copyfile, copyfileobj
 
 import numpy as np
 import pytest
-from monty.tempfile import ScratchDir
 from pytest import approx
 
 from pymatgen.core import Element
@@ -493,39 +492,35 @@ class VasprunTest(PymatgenTest):
             assert projected[Spin.up][0][0]["Si"]["s"] == approx(0.4238)
 
             # Test compressed files case 1: compressed KPOINTS in current dir
-            with ScratchDir("./"):
-                copyfile(self.TEST_FILES_DIR / "vasprun_Si_bands.xml", "vasprun.xml")
+            copyfile(self.TEST_FILES_DIR / "vasprun_Si_bands.xml", "vasprun.xml")
 
-                # Check for error if no KPOINTS file
-                vasprun = Vasprun("vasprun.xml", parse_projected_eigen=True, parse_potcar_file=False)
-                with pytest.raises(VaspParserError):
-                    _ = vasprun.get_band_structure(line_mode=True)
+            # Check for error if no KPOINTS file
+            vasprun = Vasprun("vasprun.xml", parse_projected_eigen=True, parse_potcar_file=False)
+            with pytest.raises(VaspParserError):
+                _ = vasprun.get_band_structure(line_mode=True)
 
-                # Check KPOINTS.gz successfully inferred and used if present
-                with open(self.TEST_FILES_DIR / "KPOINTS_Si_bands", "rb") as f_in, gzip.open(
-                    "KPOINTS.gz", "wb"
-                ) as f_out:
-                    copyfileobj(f_in, f_out)
-                bs_kpts_gzip = vasprun.get_band_structure()
-                assert bs.efermi == bs_kpts_gzip.efermi
-                assert bs.as_dict() == bs_kpts_gzip.as_dict()
+            # Check KPOINTS.gz successfully inferred and used if present
+            with open(self.TEST_FILES_DIR / "KPOINTS_Si_bands", "rb") as f_in, gzip.open("KPOINTS.gz", "wb") as f_out:
+                copyfileobj(f_in, f_out)
+            bs_kpts_gzip = vasprun.get_band_structure()
+            assert bs.efermi == bs_kpts_gzip.efermi
+            assert bs.as_dict() == bs_kpts_gzip.as_dict()
 
             # Test compressed files case 2: compressed vasprun in another dir
-            with ScratchDir("./"):
-                os.mkdir("deeper")
-                copyfile(self.TEST_FILES_DIR / "KPOINTS_Si_bands", Path("deeper") / "KPOINTS")
-                with open(self.TEST_FILES_DIR / "vasprun_Si_bands.xml", "rb") as f_in, gzip.open(
-                    os.path.join("deeper", "vasprun.xml.gz"), "wb"
-                ) as f_out:
-                    copyfileobj(f_in, f_out)
-                vasprun = Vasprun(
-                    os.path.join("deeper", "vasprun.xml.gz"),
-                    parse_projected_eigen=True,
-                    parse_potcar_file=False,
-                )
-                bs_vasprun_gzip = vasprun.get_band_structure(line_mode=True)
-                assert bs.efermi == bs_vasprun_gzip.efermi
-                assert bs.as_dict() == bs_vasprun_gzip.as_dict()
+            os.mkdir("deeper")
+            copyfile(self.TEST_FILES_DIR / "KPOINTS_Si_bands", Path("deeper") / "KPOINTS")
+            with open(self.TEST_FILES_DIR / "vasprun_Si_bands.xml", "rb") as f_in, gzip.open(
+                os.path.join("deeper", "vasprun.xml.gz"), "wb"
+            ) as f_out:
+                copyfileobj(f_in, f_out)
+            vasprun = Vasprun(
+                os.path.join("deeper", "vasprun.xml.gz"),
+                parse_projected_eigen=True,
+                parse_potcar_file=False,
+            )
+            bs_vasprun_gzip = vasprun.get_band_structure(line_mode=True)
+            assert bs.efermi == bs_vasprun_gzip.efermi
+            assert bs.as_dict() == bs_vasprun_gzip.as_dict()
 
             # test hybrid band structures
             vasprun.actual_kpoints_weights[-1] = 0.0
@@ -1978,24 +1973,21 @@ class WavecarTest(PymatgenTest):
             self.w.write_unks(self.TEST_FILES_DIR / "UNK.N2.std")
 
         # different grids
-        with ScratchDir("."):
-            self.w.write_unks("./unk_dir")
-            assert len(list(Path("./unk_dir").glob("UNK*"))) == 1
-            unk = Unk.from_file("./unk_dir/UNK00001.1")
-            assert unk != unk_std
+        self.w.write_unks("./unk_dir")
+        assert len(list(Path("./unk_dir").glob("UNK*"))) == 1
+        unk = Unk.from_file("./unk_dir/UNK00001.1")
+        assert unk != unk_std
 
         # correct grid
         self.w.ng = np.array([12, 12, 12])
-        with ScratchDir("."):
-            self.w.write_unks(".")
-            unk = Unk.from_file("UNK00001.1")
-            assert unk == unk_std
+        self.w.write_unks(".")
+        unk = Unk.from_file("UNK00001.1")
+        assert unk == unk_std
 
         # ncl test
-        with ScratchDir("."):
-            self.w_ncl.write_unks(".")
-            unk = Unk.from_file("UNK00001.NC")
-            assert unk == unk_ncl
+        self.w_ncl.write_unks(".")
+        unk = Unk.from_file("UNK00001.NC")
+        assert unk == unk_ncl
 
 
 class EigenvalTest(PymatgenTest):

--- a/pymatgen/util/testing.py
+++ b/pymatgen/util/testing.py
@@ -13,6 +13,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
+import pytest
 from monty.json import MontyDecoder, MSONable
 from monty.serialization import loadfn
 from numpy.testing import assert_allclose
@@ -43,6 +44,12 @@ class PymatgenTest(unittest.TestCase):
     TEST_STRUCTURES = {}  # Dict for test structures to aid testing.
     for fn in STRUCTURES_DIR.iterdir():
         TEST_STRUCTURES[fn.name.rsplit(".", 1)[0]] = loadfn(str(fn))
+
+    @pytest.fixture(autouse=True)  # make all tests run a in a temporary directory accessible via self.tmp_path
+    def _tmp_dir(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # https://pytest.org/en/latest/how-to/unittest.html#using-autouse-fixtures-and-accessing-other-fixtures
+        monkeypatch.chdir(tmp_path)  # change to pytest-provided temporary directory
+        self.tmp_path = tmp_path
 
     @classmethod
     def get_structure(cls, name: str) -> Structure:


### PR DESCRIPTION
 534af3078 `PymatgenTest` add `@pytest.fixture(autouse=True)     def _tmp_dir(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:`
 a18903217 remove many no longer needed `monty.tempfile.ScratchDir(".")`

@shyuep It's a bit more magical since people who don't look at `PymatgenTest` won't know that their tests now run in a temporary directory by default due to [this new fixture](https://github.com/materialsproject/pymatgen/compare/PymatgenTest-autoused-tmp-path-fixture?expand=1#diff-e9cfd9b89de7ff172f8b6e26e92bb559f6f61ae34d0ee3c08c8b06954e1f69c1R48-R53). But the code is cleaner now imo and less chance of failing tests leaving behind undeleted files in the repo that litter `git status`.