### PR TITLE
Bug fix: change CifWriter to save only the element symbol, and not the entire species string

### DIFF
--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -1326,7 +1326,7 @@ class CifWriter:
         if symprec is None:
             for site in struct:
                 for sp, occu in sorted(site.species.items()):
-                    atom_site_type_symbol.append(str(sp))
+                    atom_site_type_symbol.append(str(sp.symbol))
                     atom_site_symmetry_multiplicity.append("1")
                     atom_site_fract_x.append(format_str.format(site.a))
                     atom_site_fract_y.append(format_str.format(site.b))
@@ -1363,7 +1363,7 @@ class CifWriter:
                 ),
             ):
                 for sp, occu in site.species.items():
-                    atom_site_type_symbol.append(str(sp))
+                    atom_site_type_symbol.append(str(sp.symbol))
                     atom_site_symmetry_multiplicity.append(f"{mult}")
                     atom_site_fract_x.append(format_str.format(site.a))
                     atom_site_fract_y.append(format_str.format(site.b))


### PR DESCRIPTION
Change the "atom site type symbol", such that the element symbol is saved instead of the full species string (which includes site properties). This fixes Issue #3065, allowing for accurate writing of structures containing species properties to CIF and MCIF files.

## Summary

Major updates:

Change the "atom site type symbol", such that the element symbol is saved instead of the full species string (which includes site properties).

## Todos

## Checklist

Ensure:

- [ ] Google format doc strings added. Check with `ruff`.
- [ ] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] All tests and linting pass.
