### PR TITLE
Add a cache to speed up get_el_sp

### DIFF
--- a/pymatgen/core/periodic_table.py
+++ b/pymatgen/core/periodic_table.py
@@ -1562,7 +1562,7 @@ class DummySpecie(DummySpecies):
     to maintain backwards compatibility.
     """
 
-
+@functools.cache
 def get_el_sp(obj) -> Element | Species | DummySpecies:
     """
     Utility method to get an Element or Species from an input obj.

--- a/pymatgen/core/periodic_table.py
+++ b/pymatgen/core/periodic_table.py
@@ -1562,6 +1562,7 @@ class DummySpecie(DummySpecies):
     to maintain backwards compatibility.
     """
 
+
 @functools.cache
 def get_el_sp(obj) -> Element | Species | DummySpecies:
     """

--- a/pymatgen/core/periodic_table.py
+++ b/pymatgen/core/periodic_table.py
@@ -1563,7 +1563,7 @@ class DummySpecie(DummySpecies):
     """
 
 
-@functools.cache
+@functools.lru_cache
 def get_el_sp(obj) -> Element | Species | DummySpecies:
     """
     Utility method to get an Element or Species from an input obj.

--- a/pymatgen/core/sites.py
+++ b/pymatgen/core/sites.py
@@ -61,7 +61,7 @@ class Site(collections.abc.Hashable, MSONable):
         if not skip_checks:
             if not isinstance(species, Composition):
                 try:
-                    species = Composition({get_el_sp(species): 1})
+                    species = Composition({get_el_sp(species): 1})  # type: ignore
                 except TypeError:
                     species = Composition(species)
             total_occu = species.num_atoms
@@ -90,7 +90,7 @@ class Site(collections.abc.Hashable, MSONable):
     def species(self, species: SpeciesLike | CompositionLike):
         if not isinstance(species, Composition):
             try:
-                species = Composition({get_el_sp(species): 1})
+                species = Composition({get_el_sp(species): 1})  # type: ignore
             except TypeError:
                 species = Composition(species)
         total_occu = species.num_atoms
@@ -336,7 +336,7 @@ class PeriodicSite(Site, MSONable):
             frac_coords = np.array(frac_coords)
             if not isinstance(species, Composition):
                 try:
-                    species = Composition({get_el_sp(species): 1})
+                    species = Composition({get_el_sp(species): 1})  # type: ignore
                 except TypeError:
                     species = Composition(species)
 


### PR DESCRIPTION
Uses functools.cache to speed up the conversion of arbitrary objects into Element | Species | DummySpecies.

- One thing to keep in mind is that returned objects are not necessarily unique anymore, they could be returned again through the cache.
- Arguments to `get_el_sp` must be `Hashable`, luckily this seems to be the case

## Summary

Major updates:

- feature 1: massive speed up for get_el_sp

## Checklist

Ensure:

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [x] All tests and linting pass.

Tip: Install `pre-commit` hooks to auto-check before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
