### PR TITLE
Fix hill_formula Composition property

### DIFF
--- a/pymatgen/core/composition.py
+++ b/pymatgen/core/composition.py
@@ -440,10 +440,16 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
         """
         c = self.element_composition
         elements = sorted(el.symbol for el in c)
+        hill_elements = []
         if "C" in elements:
-            elements = ["C"] + [el for el in elements if el != "C"]
+            hill_elements.append("C")
+            elements.remove("C")
+            if "H" in elements:
+                hill_elements.append("H")
+                elements.remove("H")
+        hill_elements += elements
 
-        formula = [f"{el}{formula_double_format(c[el]) if c[el] != 1 else ''}" for el in elements]
+        formula = [f"{el}{formula_double_format(c[el]) if c[el] != 1 else ''}" for el in hill_elements]
         return " ".join(formula)
 
     @property

--- a/pymatgen/core/tests/test_composition.py
+++ b/pymatgen/core/tests/test_composition.py
@@ -68,12 +68,11 @@ class CompositionTest(PymatgenTest):
         c = Composition("C2H5OH")
         assert c.hill_formula == "C2 H6 O"
         # A test case with both C and H, but not one after another (mp-1228185)
-        c = Composition('Ga8 As16 H102 C32 S36 O3')
-        assert c.hill_formula == 'C32 H102 As16 Ga8 O3 S36'
+        c = Composition("Ga8 As16 H102 C32 S36 O3")
+        assert c.hill_formula == "C32 H102 As16 Ga8 O3 S36"
         # A test case with H but no C
-        c = Composition('Ga8 As16 H102 S36 O3')
-        assert c.hill_formula == 'As16 Ga8 H102 O3 S36'
-
+        c = Composition("Ga8 As16 H102 S36 O3")
+        assert c.hill_formula == "As16 Ga8 H102 O3 S36"
 
     def test_init_(self):
         with pytest.raises(ValueError):

--- a/pymatgen/core/tests/test_composition.py
+++ b/pymatgen/core/tests/test_composition.py
@@ -67,6 +67,13 @@ class CompositionTest(PymatgenTest):
         assert c.hill_formula == "C Ca O3"
         c = Composition("C2H5OH")
         assert c.hill_formula == "C2 H6 O"
+        # A test case with both C and H, but not one after another (mp-1228185)
+        c = Composition('Ga8 As16 H102 C32 S36 O3')
+        assert c.hill_formula == 'C32 H102 As16 Ga8 O3 S36'
+        # A test case with H but no C
+        c = Composition('Ga8 As16 H102 S36 O3')
+        assert c.hill_formula == 'As16 Ga8 H102 O3 S36'
+
 
     def test_init_(self):
         with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary

This PR fixes an error in the **hill_formula** property of the Composition object, which occurs in cases where C, H, and other element/s with symbol ordering alphabetically before H are present at the same time. In such a case, H should be placed directly after C, but this is not implemented nor tested in the current version.

- Fixed the property to match the description.
- Implemented additional tests.

Sidenote: @ml-evs This fix should help eliminate compatibility issues with the OPTIMADE _chemical_formula_hill_ field (except for the presence/lack of empty spaces).
