### PR TITLE
Update `addons.rst`

### DIFF
--- a/docs_rst/addons.rst
+++ b/docs_rst/addons.rst
@@ -42,16 +42,12 @@ External Tools
 If you would like your own tool to be listed here, please `submit a PR <https://github.com/materialsproject/pymatgen/edit/master/docs_rst/addons.rst>`_! For a more complete but less curated list, have a
 look at `pymatgen dependents <https://github.com/materialsproject/pymatgen/network/dependents>`_.
 
-* `QuAcc <https://github.com/arosen93/quacc>`_: A platform to enable high-throughput, database-driven quantum
-  chemistry and computational materials science.
+* `Atomate2 <https://github.com/materialsproject/atomate2>`_: atomate2 is a library of computational materials science workflows.
 
 * `LobsterPy <https://github.com/JaGeo/LobsterPy>`_: Automatically analyze `Lobster runs <https://cohp.de>_`.
 
 * `pymatviz <https://github.com/janosh/pymatviz>`_: Complements ``pymatgen`` with additional plotting
   functionality for larger datasets common in materials informatics.
-
-* `M3GNet <https://github.com/materialsvirtuallab/m3gnet>`_: Materials graph network with 3-body interactions featuring
-  a DFT surrogate crystal relaxer and property predictor.
 
 * `DiSCoVeR <https://github.com/sparks-baird/mat_discover>`_: A materials discovery algorithm geared towards exploring
   high-performance candidates in new chemical spaces.


### PR DESCRIPTION
Closes #3102.

Changes:
- I added [Atomate2](https://github.com/materialsproject/atomate2), which seemed like a clear one to have included.
- I removed [`m3gnet`](https://github.com/materialsvirtuallab/m3gnet) in place of [`matgl`](https://github.com/materialsvirtuallab/matgl) since the former is archived and to be replaced with the latter
- I removed Quacc since it's not as dependent on Pymatgen as most of the other tools listed