### PR TITLE
BUG: force contiguous calling find_points_in_spheres

### DIFF
--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -1522,10 +1522,10 @@ class IStructure(SiteCollection, MSONable):
         else:
             if sites is None:
                 sites = self.sites
-            site_coords = np.array([site.coords for site in sites], dtype=float)
-            cart_coords = np.array(self.cart_coords, dtype=float)
-            lattice_matrix = np.array(self.lattice.matrix, dtype=float)
-            pbc = np.array(self.pbc, dtype=int)
+            site_coords = np.ascontiguousarray([site.coords for site in sites], dtype=float)
+            cart_coords = np.ascontiguousarray(self.cart_coords, dtype=float)
+            lattice_matrix = np.ascontiguousarray(self.lattice.matrix, dtype=float)
+            pbc = np.ascontiguousarray(self.pbc, dtype=int)
             center_indices, points_indices, images, distances = find_points_in_spheres(
                 cart_coords,
                 site_coords,

--- a/pymatgen/core/tests/test_structure.py
+++ b/pymatgen/core/tests/test_structure.py
@@ -538,6 +538,12 @@ Direct
         p_indices1, p_indices2, p_offsets, p_distances = s._get_neighbor_list_py(3)
         self.assert_all_close(sorted(c_distances), sorted(p_distances))
 
+        s = Structure(s.lattice, s.species, s.frac_coords)
+        s.apply_strain(0.01)
+        c_indices1, c_indices2, c_offsets, c_distances = s.get_neighbor_list(3)
+        p_indices1, p_indices2, p_offsets, p_distances = s._get_neighbor_list_py(3)
+        self.assert_all_close(sorted(c_distances), sorted(p_distances))
+
     # @skipIf(not os.getenv("CI"), "Only run this in CI tests")
     # def test_get_all_neighbors_crosscheck_old(self):
     #     warnings.simplefilter("ignore")


### PR DESCRIPTION
## Checklist

- [X] Google format doc strings added. Check with `ruff`.
- [X] Type annotations included. Check with `mypy`.
- [X] Tests added for new features/fixes.

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
