### PR TITLE
Add `pymatgen.io.openmm` package to `addons.rst`

### DIFF
--- a/docs_rst/addons.rst
+++ b/docs_rst/addons.rst
@@ -31,6 +31,9 @@ Add-ons for Input/Output
 * `pymatgen-io-fleur <http://pypi.org/project/pymatgen-io-fleur>`_: Provides modules for reading and writing
   files used by the `fleur <https://www.flapw.de/rel>`_ DFT code. This package is maintained by the juDFT team.
 
+* `pymatgen-io-openmm <https://github.com/orionarcher/pymatgen-io-openmm>`_: Provides easy IO for performing 
+  molecular dynamics on solutions with OpenMM. This package is maintained by Orion Archer Cohen.
+
 Add-ons for External Services
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
The core functionality of [pymatgen.io.openmm](https://github.com/orionarcher/pymatgen-io-openmm) is in place so I thought I'd add it to the the add ons page.