### PR TITLE
Migrate from `warnings.catch_warnings(record=True)` to `pytest.warns()`

### DIFF
--- a/pymatgen/alchemy/tests/test_materials.py
+++ b/pymatgen/alchemy/tests/test_materials.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import os
-import warnings
 
 import pytest
 
@@ -106,15 +105,15 @@ class TransformedStructureTest(PymatgenTest):
 
     def test_snl(self):
         self.trans.set_parameter("author", "will")
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
+        with pytest.warns(UserWarning) as warns:
             snl = self.trans.to_snl([("will", "will@test.com")])
-            assert len(w) == 1, "Warning not raised on type conversion with other_parameters"
+        assert len(warns) == 1, "Warning not raised on type conversion with other_parameters"
+
         ts = TransformedStructure.from_snl(snl)
         assert ts.history[-1]["@class"] == "SubstitutionTransformation"
 
-        h = ("testname", "testURL", {"test": "testing"})
-        snl = StructureNL(ts.final_structure, [("will", "will@test.com")], history=[h])
+        hist = ("testname", "testURL", {"test": "testing"})
+        snl = StructureNL(ts.final_structure, [("will", "will@test.com")], history=[hist])
         snl = TransformedStructure.from_snl(snl).to_snl([("notwill", "notwill@test.com")])
-        assert snl.history == [h]
+        assert snl.history == [hist]
         assert snl.authors == [("notwill", "notwill@test.com")]

--- a/pymatgen/analysis/chemenv/utils/scripts_utils.py
+++ b/pymatgen/analysis/chemenv/utils/scripts_utils.py
@@ -239,8 +239,8 @@ def compute_environments(chemenv_configuration):
         if source_type == "cif":
             if not found:
                 input_source = input("Enter path to cif file : ")
-            cp = CifParser(input_source)
-            structure = cp.get_structures()[0]
+            parser = CifParser(input_source)
+            structure = parser.get_structures()[0]
         elif source_type == "mp":
             if not found:
                 input_source = input('Enter materials project id (e.g. "mp-1902") : ')

--- a/pymatgen/analysis/elasticity/elastic.py
+++ b/pymatgen/analysis/elasticity/elastic.py
@@ -443,7 +443,7 @@ class ElasticTensor(NthOrderElasticTensor):
     def from_pseudoinverse(cls, strains, stresses):
         """
         Class method to fit an elastic tensor from stress/strain
-        data. Method uses Moore-Penrose pseudoinverse to invert
+        data. Method uses Moore-Penrose pseudo-inverse to invert
         the s = C*e equation with elastic tensor, stress, and
         strain in voigt notation.
 
@@ -453,11 +453,11 @@ class ElasticTensor(NthOrderElasticTensor):
         """
         # convert the stress/strain to Nx6 arrays of voigt-notation
         warnings.warn(
-            "Pseudoinverse fitting of Strain/Stress lists may yield "
+            "Pseudo-inverse fitting of Strain/Stress lists may yield "
             "questionable results from vasp data, use with caution."
         )
         stresses = np.array([Stress(stress).voigt for stress in stresses])
-        with warnings.catch_warnings(record=True):
+        with warnings.catch_warnings():
             strains = np.array([Strain(strain).voigt for strain in strains])
 
         voigt_fit = np.transpose(np.dot(np.linalg.pinv(strains), stresses))
@@ -837,7 +837,7 @@ def diff_fit(strains, stresses, eq_stress=None, order=2, tol: float = 1e-10):
     3. Find first, second .. nth derivatives of each stress
        with respect to scalar variable corresponding to
        the smallest perturbation in the strain.
-    4. Use the pseudoinverse of a matrix-vector expression
+    4. Use the pseudo-inverse of a matrix-vector expression
        corresponding to the parameterized stress-strain
        relationship and multiply that matrix by the respective
        calculated first or second derivatives from the
@@ -969,13 +969,13 @@ def get_strain_state_dict(strains, stresses, eq_stress=None, tol: float = 1e-10,
 
 def generate_pseudo(strain_states, order=3):
     """
-    Generates the pseudoinverse for a given set of strains.
+    Generates the pseudo-inverse for a given set of strains.
 
     Args:
         strain_states (6xN array like): a list of voigt-notation
             "strain-states", i. e. perturbed indices of the strain
             as a function of the smallest strain e. g. (0, 1, 0, 0, 1, 0)
-        order (int): order of pseudoinverse to calculate
+        order (int): order of pseudo-inverse to calculate
 
     Returns:
         mis: pseudo inverses for each order tensor, these can

--- a/pymatgen/analysis/elasticity/elastic.py
+++ b/pymatgen/analysis/elasticity/elastic.py
@@ -7,6 +7,7 @@ stress-strain data.
 from __future__ import annotations
 
 import itertools
+import math
 import warnings
 from typing import TYPE_CHECKING
 
@@ -996,7 +997,7 @@ def generate_pseudo(strain_states, order=3):
             exps = carr.copy()
             for _ in range(degree - 1):
                 exps = np.dot(exps, strain_v)
-            exps /= np.math.factorial(degree - 1)
+            exps /= math.factorial(degree - 1)
             sarr[n] = [sp.diff(exp, s, degree - 1) for exp in exps]
         svec = sarr.ravel()
         present_syms = set.union(*(exp.atoms(sp.Symbol) for exp in svec))

--- a/pymatgen/analysis/elasticity/tests/test_elastic.py
+++ b/pymatgen/analysis/elasticity/tests/test_elastic.py
@@ -169,9 +169,11 @@ class ElasticTensorTest(PymatgenTest):
         self.assert_all_close(self.elastic_tensor_1, ElasticTensor(self.ft))
         non_symm = self.ft
         non_symm[0, 1, 2, 2] += 1.0
-        with warnings.catch_warnings(record=True) as w:
+        with pytest.warns(
+            UserWarning, match="Input elastic tensor does not satisfy standard Voigt symmetries"
+        ) as warns:
             ElasticTensor(non_symm)
-            assert len(w) == 1
+        assert len(warns) == 1
         bad_tensor1 = np.zeros((3, 3, 3))
         bad_tensor2 = np.zeros((3, 3, 3, 2))
         with pytest.raises(ValueError, match="ElasticTensor input must be rank 4"):
@@ -202,8 +204,9 @@ class ElasticTensorTest(PymatgenTest):
     def test_from_independent_strains(self):
         strains = self.toec_dict["strains"]
         stresses = self.toec_dict["stresses"]
-        with warnings.catch_warnings(record=True):
+        with pytest.warns(UserWarning, match="No eq state found, returning zero voigt stress") as warns:
             et = ElasticTensor.from_independent_strains(strains, stresses)
+        assert len(warns) == 2
         self.assert_all_close(et.voigt, self.toec_dict["C2_raw"], decimal=-1)
 
     def test_energy_density(self):
@@ -468,12 +471,11 @@ class DiffFitTest(PymatgenTest):
         reduced = [(e, pk) for e, pk in zip(self.strains, self.pk_stresses) if not (abs(abs(e) - 0.05) < 1e-10).any()]
         # Get reduced dataset
         r_strains, r_pk_stresses = zip(*reduced)
-        with warnings.catch_warnings(record=True):
-            c2 = diff_fit(r_strains, r_pk_stresses, self.data_dict["eq_stress"], order=2)
-            c2, c3, c4 = diff_fit(r_strains, r_pk_stresses, self.data_dict["eq_stress"], order=4)
-            c2, c3 = diff_fit(self.strains, self.pk_stresses, self.data_dict["eq_stress"], order=3)
-            c2_red, c3_red = diff_fit(r_strains, r_pk_stresses, self.data_dict["eq_stress"], order=3)
-            self.assert_all_close(c2.voigt, self.data_dict["C2_raw"])
-            self.assert_all_close(c3.voigt, self.data_dict["C3_raw"], decimal=5)
-            self.assert_all_close(c2, c2_red, decimal=0)
-            self.assert_all_close(c3, c3_red, decimal=-1)
+        c2 = diff_fit(r_strains, r_pk_stresses, self.data_dict["eq_stress"], order=2)
+        c2, c3, c4 = diff_fit(r_strains, r_pk_stresses, self.data_dict["eq_stress"], order=4)
+        c2, c3 = diff_fit(self.strains, self.pk_stresses, self.data_dict["eq_stress"], order=3)
+        c2_red, c3_red = diff_fit(r_strains, r_pk_stresses, self.data_dict["eq_stress"], order=3)
+        self.assert_all_close(c2.voigt, self.data_dict["C2_raw"])
+        self.assert_all_close(c3.voigt, self.data_dict["C3_raw"], decimal=5)
+        self.assert_all_close(c2, c2_red, decimal=0)
+        self.assert_all_close(c3, c3_red, decimal=-1)

--- a/pymatgen/analysis/elasticity/tests/test_elastic.py
+++ b/pymatgen/analysis/elasticity/tests/test_elastic.py
@@ -448,15 +448,7 @@ class DiffFitTest(PymatgenTest):
         self.assert_all_close(forward_13, [-11 / 6, 3, -3 / 2, 1 / 3])
         self.assert_all_close(
             backward_26,
-            [
-                137 / 180,
-                -27 / 5,
-                33 / 2,
-                -254 / 9,
-                117 / 4,
-                -87 / 5,
-                203 / 45,
-            ],
+            [137 / 180, -27 / 5, 33 / 2, -254 / 9, 117 / 4, -87 / 5, 203 / 45],
         )
         self.assert_all_close(central_29, central_diff_weights(9, 2))
 

--- a/pymatgen/analysis/elasticity/tests/test_elastic.py
+++ b/pymatgen/analysis/elasticity/tests/test_elastic.py
@@ -187,7 +187,11 @@ class ElasticTensorTest(PymatgenTest):
     def test_from_pseudoinverse(self):
         strain_list = [Strain.from_deformation(def_matrix) for def_matrix in self.def_stress_dict["deformations"]]
         stress_list = list(self.def_stress_dict["stresses"])
-        with warnings.catch_warnings(record=True):
+        with pytest.warns(
+            UserWarning,
+            match="Pseudo-inverse fitting of Strain/Stress lists may yield questionable results from "
+            "vasp data, use with caution",
+        ):
             et_fl = -0.1 * ElasticTensor.from_pseudoinverse(strain_list, stress_list).voigt
             self.assert_all_close(
                 et_fl.round(2),
@@ -432,9 +436,8 @@ class DiffFitTest(PymatgenTest):
     def test_find_eq_stress(self):
         test_strains = deepcopy(self.strains)
         test_stresses = deepcopy(self.pk_stresses)
-        with warnings.catch_warnings(record=True):
-            no_eq = find_eq_stress(test_strains, test_stresses)
-            self.assert_all_close(no_eq, np.zeros((3, 3)))
+        no_eq = find_eq_stress(test_strains, test_stresses)
+        self.assert_all_close(no_eq, np.zeros((3, 3)))
         test_strains[3] = Strain.from_voigt(np.zeros(6))
         eq_stress = find_eq_stress(test_strains, test_stresses)
         self.assert_all_close(test_stresses[3], eq_stress)

--- a/pymatgen/analysis/elasticity/tests/test_strain.py
+++ b/pymatgen/analysis/elasticity/tests/test_strain.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import warnings
-
 import numpy as np
 import pytest
 
@@ -91,9 +89,7 @@ class StrainTest(PymatgenTest):
 
         self.non_ind_str = Strain.from_deformation([[1, 0.02, 0.02], [0, 1, 0], [0, 0, 1]])
 
-        with warnings.catch_warnings(record=True):
-            warnings.simplefilter("always")
-            self.no_dfm = Strain([[0, 0.01, 0], [0.01, 0.0002, 0], [0, 0, 0]])
+        self.no_dfm = Strain([[0, 0.01, 0], [0.01, 0.0002, 0], [0, 0, 0]])
 
     def test_new(self):
         test_strain = Strain([[0, 0.01, 0], [0.01, 0.0002, 0], [0, 0, 0]])

--- a/pymatgen/analysis/elasticity/tests/test_stress.py
+++ b/pymatgen/analysis/elasticity/tests/test_stress.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 from pytest import approx
 
 from pymatgen.analysis.elasticity.strain import Deformation
@@ -45,6 +46,9 @@ class StressTest(PymatgenTest):
         )
         # voigt
         assert list(self.symm_stress.voigt) == [0.51, 5.14, 5.33, 5.07, 2.42, 2.29]
-        # with warnings.catch_warnings(record=True) as w:
-        #     self.non_symm.voigt
-        #     assert len(w) == 1
+
+        with pytest.warns(
+            UserWarning, match="Tensor is not symmetric, information may be lost in voigt conversion"
+        ) as warns:
+            _ = self.non_symm.voigt
+        assert len(warns) == 1

--- a/pymatgen/analysis/molecule_matcher.py
+++ b/pymatgen/analysis/molecule_matcher.py
@@ -867,7 +867,7 @@ class BruteForceOrderMatcher(KabschMatcher):
         _, count = np.unique(mol.atomic_numbers, return_counts=True)
         total_permutations = 1
         for c in count:
-            total_permutations *= np.math.factorial(c)  # type: ignore
+            total_permutations *= math.factorial(c)
 
         if not ignore_warning and total_permutations > 1_000_000:
             raise ValueError(

--- a/pymatgen/analysis/solar/slme.py
+++ b/pymatgen/analysis/solar/slme.py
@@ -39,8 +39,8 @@ eV_to_recip_cm = 1.0 / (physical_constants["Planck constant in eV s"][0] * speed
 
 def get_dir_indir_gap(run=""):
     """Get direct and indirect bandgaps for a vasprun.xml."""
-    v = Vasprun(run)
-    bandstructure = v.get_band_structure()
+    vasp_run = Vasprun(run)
+    bandstructure = vasp_run.get_band_structure()
     dir_gap = bandstructure.get_direct_band_gap()
     indir_gap = bandstructure.get_band_gap()["energy"]
     return dir_gap, indir_gap

--- a/pymatgen/analysis/tests/test_fragmenter.py
+++ b/pymatgen/analysis/tests/test_fragmenter.py
@@ -72,7 +72,7 @@ class TestFragmentMolecule(PymatgenTest):
     def test_babel_pc_old_defaults(self):
         pytest.importorskip("openbabel")
         fragmenter = Fragmenter(molecule=self.pc, open_rings=True)
-        assert fragmenter.open_rings is True
+        assert fragmenter.open_rings
         assert fragmenter.opt_steps == 10000
         default_mol_graph = MoleculeGraph.with_local_env_strategy(self.pc, OpenBabelNN())
         assert fragmenter.mol_graph == default_mol_graph

--- a/pymatgen/analysis/tests/test_interface_reactions.py
+++ b/pymatgen/analysis/tests/test_interface_reactions.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import unittest
-import warnings
 
 import numpy as np
 import pytest
@@ -163,15 +162,13 @@ class InterfaceReactionTest(unittest.TestCase):
 
     def test_get_entry_energy(self):
         comp = Composition("MnO3")
-        with warnings.catch_warnings(record=True) as record:
-            warnings.simplefilter("always")
+        with pytest.warns(
+            UserWarning,
+            match="The reactant MnO3 has no matching entry with negative formation energy, instead "
+            "convex hull energy for this composition will be used for reaction energy calculation.",
+        ) as warns:
             energy = InterfacialReactivity._get_entry_energy(self.pd, comp)
-            assert len(record) == 1
-            assert (
-                "The reactant MnO3 has no matching entry with negative formation energy, "
-                "instead convex hull energy for this composition will be used"
-                " for reaction energy calculation." in str(record[-1].message)
-            )
+        assert len(warns) == 1
         test1 = np.isclose(energy, -30, atol=1e-03)
         assert test1, f"_get_entry_energy: energy for {comp.reduced_formula} is wrong!"
         # Test normal functionality

--- a/pymatgen/analysis/tests/test_structure_matcher.py
+++ b/pymatgen/analysis/tests/test_structure_matcher.py
@@ -91,7 +91,7 @@ class StructureMatcherTest(PymatgenTest):
 
         with pytest.raises(ValueError, match=r"len\(s1\)=1 must be larger than len\(s2\)=2"):
             sm._cmp_fstruct(s2, s1, frac_tol, mask.T)
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="mask has incorrect shape"):
             sm._cmp_fstruct(s1, s2, frac_tol, mask.T)
 
         assert sm._cmp_fstruct(s1, s2, frac_tol, mask)
@@ -258,7 +258,7 @@ class StructureMatcherTest(PymatgenTest):
         assert not sm.fit(lfp, nfp)
 
         # Test anonymous fit.
-        assert sm.fit_anonymous(lfp, nfp) is True
+        assert sm.fit_anonymous(lfp, nfp)
         assert sm.get_rms_anonymous(lfp, nfp)[0] == approx(0.060895871160262717)
 
         # Test partial occupancies.
@@ -279,7 +279,7 @@ class StructureMatcherTest(PymatgenTest):
             [{"Mn": 0.5}, {"Mn": 0.5}, {"Mn": 0.5}, {"Mn": 0.5}],
             [[0, 0, 0], [0.25, 0.25, 0.25], [0.5, 0.5, 0.5], [0.75, 0.75, 0.75]],
         )
-        assert sm.fit_anonymous(s1, s2) is True
+        assert sm.fit_anonymous(s1, s2)
 
         assert sm.get_rms_anonymous(s1, s2)[0] == approx(0)
 

--- a/pymatgen/analysis/tests/test_xps.py
+++ b/pymatgen/analysis/tests/test_xps.py
@@ -7,8 +7,8 @@ from pymatgen.util.testing import PymatgenTest
 
 class XPSTestCase(PymatgenTest):
     def test_from_dos(self):
-        v = Vasprun(PymatgenTest.TEST_FILES_DIR / "vasprun.xml.LiF")
-        dos = v.complete_dos
+        vasp_run = Vasprun(PymatgenTest.TEST_FILES_DIR / "vasprun.xml.LiF")
+        dos = vasp_run.complete_dos
         xps = XPS.from_dos(dos)
         assert len(xps) == 301
         xps.smear(0.3)

--- a/pymatgen/analysis/xas/spectrum.py
+++ b/pymatgen/analysis/xas/spectrum.py
@@ -82,7 +82,7 @@ class XAS(Spectrum):
         self.absorbing_index = absorbing_index
         # check for empty spectra and negative intensities
         if sum(1 for i in self.y if i <= 0) / len(self.y) > 0.05:
-            raise ValueError("Please double check the intensities. Most of them are non-positive values. ")
+            raise ValueError("Double check the intensities. Most of them are non-positive.")
 
     def __str__(self):
         return (

--- a/pymatgen/apps/borg/hive.py
+++ b/pymatgen/apps/borg/hive.py
@@ -130,12 +130,12 @@ class VaspToComputedEntryDrone(AbstractDrone):
                 warnings.warn(f"{len(vasprun_files)} vasprun.xml.* found. {filepath} is being parsed.")
 
         try:
-            vasprun = Vasprun(filepath)
+            vasp_run = Vasprun(filepath)
         except Exception as exc:
             logger.debug(f"error in {filepath}: {exc}")
             return None
 
-        return vasprun.get_computed_entry(self._inc_structure, parameters=self._parameters, data=self._data)
+        return vasp_run.get_computed_entry(self._inc_structure, parameters=self._parameters, data=self._data)
 
         # entry.parameters["history"] = _get_transformation_history(path)
 

--- a/pymatgen/cli/pmg_plot.py
+++ b/pymatgen/cli/pmg_plot.py
@@ -19,13 +19,13 @@ def get_dos_plot(args):
     Args:
         args (dict): Args from argparse.
     """
-    v = Vasprun(args.dos_file)
-    dos = v.complete_dos
+    vasp_run = Vasprun(args.dos_file)
+    dos = vasp_run.complete_dos
 
     all_dos = {}
     all_dos["Total"] = dos
 
-    structure = v.final_structure
+    structure = vasp_run.final_structure
 
     if args.site:
         for i, site in enumerate(structure):

--- a/pymatgen/command_line/mcsqs_caller.py
+++ b/pymatgen/command_line/mcsqs_caller.py
@@ -190,7 +190,7 @@ def _parse_sqs_path(path) -> Sqs:
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        bestsqs = Structure.from_file(path / "bestsqs.out")
+        best_sqs = Structure.from_file(path / "bestsqs.out")
 
     # Get best SQS objective function
     with open(path / "bestcorr.out") as f:
@@ -221,7 +221,7 @@ def _parse_sqs_path(path) -> Sqs:
     clusters = _parse_clusters(path / "clusters.out")
 
     return Sqs(
-        bestsqs=bestsqs,
+        bestsqs=best_sqs,
         objective_function=objective_function,
         allsqs=allsqs,
         directory=str(path.resolve()),

--- a/pymatgen/core/periodic_table.py
+++ b/pymatgen/core/periodic_table.py
@@ -1262,11 +1262,11 @@ class Species(MSONable, Stringify):
         radii = self._el.data["Shannon radii"]
         radii = radii[str(int(self._oxi_state))][cn]  # type: ignore
         if len(radii) == 1:
-            k, data = list(radii.items())[0]
-            if k != spin:
+            key, data = list(radii.items())[0]
+            if key != spin:
                 warnings.warn(
-                    f"Specified spin state of {spin} not consistent with database "
-                    f"spin of {k}. Only one spin data available, and that value is returned."
+                    f"Specified {spin=} not consistent with database spin of {key}. "
+                    "Only one spin data available, and that value is returned."
                 )
         else:
             data = radii[spin]

--- a/pymatgen/core/tests/test_composition.py
+++ b/pymatgen/core/tests/test_composition.py
@@ -449,7 +449,7 @@ class CompositionTest(PymatgenTest):
         c1 = Composition("LiCl", allow_negative=True)
         c2 = Composition("Li")
         assert c1 - 2 * c2 == Composition({"Li": -1, "Cl": 1}, allow_negative=True)
-        assert (c1 + c2).allow_negative is True
+        assert (c1 + c2).allow_negative
         assert c1 / -1 == Composition("Li-1Cl-1", allow_negative=True)
 
         # test num_atoms

--- a/pymatgen/core/tests/test_periodic_table.py
+++ b/pymatgen/core/tests/test_periodic_table.py
@@ -4,7 +4,6 @@ import math
 import os
 import pickle
 import unittest
-import warnings
 from copy import deepcopy
 
 import numpy as np
@@ -439,14 +438,14 @@ class SpeciesTestCase(PymatgenTest):
         assert mn2.get_shannon_radius("IV", "High Spin") == 0.66
         assert mn2.get_shannon_radius("V", "High Spin") == 0.75
 
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            # Trigger a warning.
-            r = mn2.get_shannon_radius("V")
-            # Verify some things
-            assert len(w) == 1
-            assert w[-1].category is UserWarning
-            assert r == 0.75
+        with pytest.warns(
+            UserWarning,
+            match="Specified spin='' not consistent with database spin of High Spin. Only one "
+            "spin data available, and that value is returned.",
+        ) as warns:
+            radius = mn2.get_shannon_radius("V")
+            assert len(warns) == 1
+            assert radius == 0.75
 
         assert mn2.get_shannon_radius("VI", "Low Spin") == 0.67
         assert mn2.get_shannon_radius("VI", "High Spin") == 0.83

--- a/pymatgen/core/tests/test_tensors.py
+++ b/pymatgen/core/tests/test_tensors.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import math
 import os
-import warnings
 
 import numpy as np
 import pytest
@@ -467,18 +466,16 @@ class TensorCollectionTest(PymatgenTest):
 
     def test_serialization(self):
         # Test base serialize-deserialize
-        d = self.seq_tc.as_dict()
-        new = TensorCollection.from_dict(d)
+        dct = self.seq_tc.as_dict()
+        new = TensorCollection.from_dict(dct)
         for t, t_new in zip(self.seq_tc, new):
             self.assert_all_close(t, t_new)
 
-        # Suppress vsym warnings and test voigt
-        with warnings.catch_warnings(record=True):
-            vsym = self.rand_tc.voigt_symmetrized
-            d = vsym.as_dict(voigt=True)
-            new_vsym = TensorCollection.from_dict(d)
-            for t, t_new in zip(vsym, new_vsym):
-                self.assert_all_close(t, t_new)
+        voigt_symmetrized = self.rand_tc.voigt_symmetrized
+        dct = voigt_symmetrized.as_dict(voigt=True)
+        new_vsym = TensorCollection.from_dict(dct)
+        for t, t_new in zip(voigt_symmetrized, new_vsym):
+            self.assert_all_close(t, t_new)
 
 
 class SquareTensorTest(PymatgenTest):
@@ -575,17 +572,16 @@ class SquareTensorTest(PymatgenTest):
 
     def test_serialization(self):
         # Test base serialize-deserialize
-        d = self.rand_sqtensor.as_dict()
-        new = SquareTensor.from_dict(d)
+        dct = self.rand_sqtensor.as_dict()
+        new = SquareTensor.from_dict(dct)
         self.assert_all_close(new, self.rand_sqtensor)
         assert isinstance(new, SquareTensor)
 
         # Ensure proper object-independent deserialization
-        obj = MontyDecoder().process_decoded(d)
+        obj = MontyDecoder().process_decoded(dct)
         assert isinstance(obj, SquareTensor)
 
-        with warnings.catch_warnings(record=True):
-            vsym = self.rand_sqtensor.voigt_symmetrized
-            d_vsym = vsym.as_dict(voigt=True)
-            new_voigt = Tensor.from_dict(d_vsym)
-            self.assert_all_close(vsym, new_voigt)
+        vsym = self.rand_sqtensor.voigt_symmetrized
+        d_vsym = vsym.as_dict(voigt=True)
+        new_voigt = Tensor.from_dict(d_vsym)
+        self.assert_all_close(vsym, new_voigt)

--- a/pymatgen/electronic_structure/bandstructure.py
+++ b/pymatgen/electronic_structure/bandstructure.py
@@ -871,7 +871,7 @@ class BandStructureSymmLine(BandStructure, MSONable):
             BandStructureSymmLine: with the applied scissor shift
         """
         if self.is_metal():
-            # moves then the highest index band crossing the fermi level find this band...
+            # moves then the highest index band crossing the Fermi level find this band...
             max_index = -1000
             # spin_index = None
             for idx in range(self.nb_bands):

--- a/pymatgen/electronic_structure/boltztrap.py
+++ b/pymatgen/electronic_structure/boltztrap.py
@@ -150,7 +150,7 @@ class BoltztrapRunner(MSONable):
                 increments of factors of 10.
             energy_span_around_fermi:
                 usually the interpolation is not needed on the entire energy
-                range but on a specific range around the fermi level.
+                range but on a specific range around the Fermi level.
                 This energy gives this range in eV. by default it is 1.5 eV.
                 If DOS or BANDS type are selected, this range is automatically
                 set to cover the entire energy range.
@@ -759,18 +759,18 @@ class BoltztrapAnalyzer:
                 relaxation time (sigma/tau) at different temperature and
                 fermi levels.
                 The format is {temperature: [array of 3x3 tensors at each
-                fermi level in mu_steps]}. The units are 1/(Ohm*m*s).
+                Fermi level in mu_steps]}. The units are 1/(Ohm*m*s).
             seebeck: The Seebeck tensor at different temperatures and fermi
                 levels. The format is {temperature: [array of 3x3 tensors at
-                each fermi level in mu_steps]}. The units are V/K
+                each Fermi level in mu_steps]}. The units are V/K
             kappa: The electronic thermal conductivity tensor divided by a
                 constant relaxation time (kappa/tau) at different temperature
                 and fermi levels. The format is {temperature: [array of 3x3
-                tensors at each fermi level in mu_steps]}
+                tensors at each Fermi level in mu_steps]}
                 The units are W/(m*K*s)
             hall: The hall tensor at different temperature and fermi levels
                 The format is {temperature: [array of 27 coefficients list at
-                each fermi level in mu_steps]}
+                each Fermi level in mu_steps]}
                 The units are m^3/C
             doping: The different doping levels that have been given to
                 Boltztrap. The format is {'p':[],'n':[]} with an array of
@@ -779,7 +779,7 @@ class BoltztrapAnalyzer:
                 for a given set of doping.
                 Format is {'p':{temperature: [fermi levels],'n':{temperature:
                 [fermi levels]}}
-                the fermi level array is ordered according to the doping
+                the Fermi level array is ordered according to the doping
                 levels in doping units for doping are in cm^-3 and for Fermi
                 level in eV
             seebeck_doping: The Seebeck tensor at different temperatures and
@@ -905,7 +905,7 @@ class BoltztrapAnalyzer:
         Compare sbs_bz BandStructureSymmLine calculated with boltztrap with
         the sbs_ref BandStructureSymmLine as reference (from MP for
         instance), computing correlation and energy difference for eight bands
-        around the gap (semiconductors) or fermi level (metals).
+        around the gap (semiconductors) or Fermi level (metals).
         warn_thr is a threshold to get a warning in the accuracy of Boltztap
         interpolated bands.
         Return a dictionary with these keys:

--- a/pymatgen/electronic_structure/boltztrap2.py
+++ b/pymatgen/electronic_structure/boltztrap2.py
@@ -417,8 +417,8 @@ class BztInterpolator:
                 default 10 gives 10 time more points in the real space than
                 the number of kpoints given in reciprocal space.
             energy_range: usually the interpolation is not needed on the entire energy
-                range but on a specific range around the fermi level.
-                This energy in eV fix the range around the fermi level
+                range but on a specific range around the Fermi level.
+                This energy in eV fix the range around the Fermi level
                 (E_fermi-energy_range,E_fermi+energy_range) of
                 bands that will be interpolated
                 and taken into account to calculate the transport properties.

--- a/pymatgen/electronic_structure/dos.py
+++ b/pymatgen/electronic_structure/dos.py
@@ -469,7 +469,7 @@ class FermiDos(Dos, MSONable):
     def get_doping(self, fermi_level: float, temperature: float) -> float:
         """
         Calculate the doping (majority carrier concentration) at a given
-        fermi level  and temperature. A simple Left Riemann sum is used for
+        Fermi level  and temperature. A simple Left Riemann sum is used for
         integrating the density of states over energy & equilibrium Fermi-Dirac
         distribution.
 
@@ -503,7 +503,7 @@ class FermiDos(Dos, MSONable):
         """
         Similar to get_fermi except that when get_fermi fails to converge,
         an interpolated or extrapolated fermi is returned with the assumption
-        that the fermi level changes linearly with log(abs(concentration)).
+        that the Fermi level changes linearly with log(abs(concentration)).
 
         Args:
             concentration: The doping concentration in 1/cm^3. Negative values
@@ -546,9 +546,9 @@ class FermiDos(Dos, MSONable):
             f_ref = self.get_fermi_interextrapolated(np.sign(concentration) * c_ref, temperature, warn=False, **kwargs)
             f_new = self.get_fermi_interextrapolated(concentration / 10.0, temperature, warn=False, **kwargs)
             clog = np.sign(concentration) * np.log(abs(concentration))
-            c_newlog = np.sign(concentration) * np.log(abs(self.get_doping(f_new, temperature)))
-            slope = (f_new - f_ref) / (c_newlog - np.sign(concentration) * 10.0)
-            return f_new + slope * (clog - c_newlog)
+            c_new_log = np.sign(concentration) * np.log(abs(self.get_doping(f_new, temperature)))
+            slope = (f_new - f_ref) / (c_new_log - np.sign(concentration) * 10.0)
+            return f_new + slope * (clog - c_new_log)
 
     def get_fermi(
         self,
@@ -560,7 +560,7 @@ class FermiDos(Dos, MSONable):
         precision: int = 8,
     ) -> float:
         """
-        Finds the fermi level at which the doping concentration at the given
+        Finds the Fermi level at which the doping concentration at the given
         temperature (T) is equal to concentration. A greedy algorithm is used
         where the relative error is minimized by calculating the doping at a
         grid which continually becomes finer.
@@ -571,7 +571,7 @@ class FermiDos(Dos, MSONable):
                 doping.
             temperature: The temperature in Kelvin.
             rtol: The maximum acceptable relative error.
-            nstep: THe number of steps checked around a given fermi level.
+            nstep: The number of steps checked around a given Fermi level.
             step: Initial step in energy when searching for the Fermi level.
             precision: Essentially the decimal places of calculated Fermi level.
 
@@ -579,16 +579,16 @@ class FermiDos(Dos, MSONable):
             ValueError: If the Fermi level cannot be found.
 
         Returns:
-            The fermi level in eV. Note that this is different from the default
+            The Fermi level in eV. Note that this is different from the default
             dos.efermi.
         """
         fermi = self.efermi  # initialize target fermi
         relative_error = [float("inf")]
         for _ in range(precision):
-            frange = np.arange(-nstep, nstep + 1) * step + fermi
-            calc_doping = np.array([self.get_doping(f, temperature) for f in frange])
+            f_range = np.arange(-nstep, nstep + 1) * step + fermi
+            calc_doping = np.array([self.get_doping(f, temperature) for f in f_range])
             relative_error = np.abs(calc_doping / concentration - 1.0)  # type: ignore
-            fermi = frange[np.argmin(relative_error)]
+            fermi = f_range[np.argmin(relative_error)]
             step /= 10.0
 
         if min(relative_error) > rtol:
@@ -1491,7 +1491,7 @@ def f0(E, fermi, T) -> float:
 
     Args:
         E (float): energy in eV
-        fermi (float): the fermi level in eV
+        fermi (float): the Fermi level in eV
         T (float): the temperature in kelvin
 
     Returns:

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -428,17 +428,17 @@ class BSPlotter:
             {Spin:[np.array(nb_bands,kpoints),...]} as a list of discontinuous kpath
             of energies. The energy of multiple continuous branches are stored together.
             vbm: A list of tuples (distance,energy) marking the vbms. The
-            energies are shifted with respect to the fermi level is the
+            energies are shifted with respect to the Fermi level is the
             option has been selected.
             cbm: A list of tuples (distance,energy) marking the cbms. The
-            energies are shifted with respect to the fermi level is the
+            energies are shifted with respect to the Fermi level is the
             option has been selected.
             lattice: The reciprocal lattice.
             zero_energy: This is the energy used as zero for the plot.
             band_gap:A string indicating the band gap and its nature (empty if
             it's a metal).
             is_metal: True if the band structure is metallic (i.e., there is at
-            least one band crossing the fermi level).
+            least one band crossing the Fermi level).
         """
         if bs is None:
             # if: BSPlotter, else: BSPlotterProjected
@@ -2375,7 +2375,7 @@ class BSDOSPlotter:
         bs_ax.set_xlabel("Wavevector $k$", fontsize=self.axis_fontsize, family=self.font)
         bs_ax.set_ylabel("$E-E_F$ / eV", fontsize=self.axis_fontsize, family=self.font)
 
-        # add BS fermi level line at E=0 and gridlines
+        # add BS Fermi level line at E=0 and gridlines
         bs_ax.hlines(y=0, xmin=0, xmax=x_distances_list[-1][-1], color="k", lw=2)
         bs_ax.set_yticks(np.arange(emin, emax + 1e-5, self.egrid_interval))
         bs_ax.set_yticklabels(np.arange(emin, emax + 1e-5, self.egrid_interval), size=self.tick_fontsize)

--- a/pymatgen/electronic_structure/tests/test_boltztrap.py
+++ b/pymatgen/electronic_structure/tests/test_boltztrap.py
@@ -261,7 +261,7 @@ class BoltztrapAnalyzerTest(unittest.TestCase):
         x = self.bz.get_extreme("seebeck")
         assert x["best"]["carrier_type"] == "n"
         assert x["p"]["value"] == approx(1255.365, abs=1e-2)
-        assert x["n"]["isotropic"] is True
+        assert x["n"]["isotropic"]
         assert x["n"]["temperature"] == 600
 
         x = self.bz.get_extreme("kappa", maximize=False, min_temp=400, min_doping=1e20)

--- a/pymatgen/electronic_structure/tests/test_boltztrap2.py
+++ b/pymatgen/electronic_structure/tests/test_boltztrap2.py
@@ -77,7 +77,7 @@ class VasprunBSLoaderTest(unittest.TestCase):
         assert len(self.loader.proj_all) == 1
         assert self.loader.proj_all[Spin.up].shape == (120, 20, 2, 9)
 
-        assert self.loader_sp.is_spin_polarized is True
+        assert self.loader_sp.is_spin_polarized
         assert self.loader_sp.ebands_all.shape == (24, 198)
         assert self.loader_sp.ebands_all[10, 100] == approx(0.2543788, abs=1e-4)
         assert self.loader_sp.ebands_all[22, 100] == approx(0.2494617, abs=1e-4)
@@ -243,7 +243,7 @@ class BztTransportPropertiesTest(unittest.TestCase):
             bztInterp, doping=10.0 ** np.arange(20, 22), temp_r=np.arange(300, 600, 100)
         )
         assert self.bztTransp is not None
-        assert self.bztTransp.contain_props_doping is True
+        assert self.bztTransp.contain_props_doping
 
         warnings.simplefilter("ignore")
 
@@ -327,7 +327,7 @@ class BztTransportPropertiesTest(unittest.TestCase):
             self.bztTransp.Power_Factor_doping,
         ]:
             assert p["n"].shape == (3, 2, 3, 3)
-            assert self.bztTransp.contain_props_doping is True
+            assert self.bztTransp.contain_props_doping
 
         self.bztTransp_sp.compute_properties_doping(doping=10.0 ** np.arange(20, 22))
         for p in [
@@ -338,7 +338,7 @@ class BztTransportPropertiesTest(unittest.TestCase):
             self.bztTransp_sp.Power_Factor_doping,
         ]:
             assert p["n"].shape == (3, 2, 3, 3)
-            assert self.bztTransp_sp.contain_props_doping is True
+            assert self.bztTransp_sp.contain_props_doping
 
 
 @unittest.skipIf(not BOLTZTRAP2_PRESENT, "No boltztrap2, skipping tests...")

--- a/pymatgen/electronic_structure/tests/test_cohp.py
+++ b/pymatgen/electronic_structure/tests/test_cohp.py
@@ -130,13 +130,13 @@ class IcohpValueTest(unittest.TestCase):
         # without spin polarization
         assert self.icohpvalue_sp.num_bonds == 1
         assert self.icohpvalue_sp.are_coops is False
-        assert self.icohpvalue_sp.is_spin_polarized is True
+        assert self.icohpvalue_sp.is_spin_polarized
         assert self.icohpvalue.icohp == {Spin.up: -2.0}
 
         # with spin polarization
         assert self.icohpvalue_sp.num_bonds == 1
         assert self.icohpvalue_sp.are_coops is False
-        assert self.icohpvalue_sp.is_spin_polarized is True
+        assert self.icohpvalue_sp.is_spin_polarized
         assert self.icohpvalue_sp.icohp == {Spin.up: -1.1, Spin.down: -1.0}
 
     def test_icohpvalue(self):

--- a/pymatgen/electronic_structure/tests/test_core.py
+++ b/pymatgen/electronic_structure/tests/test_core.py
@@ -96,7 +96,7 @@ class MagmomTest(unittest.TestCase):
             [[2, 2, 2], [-2, -2, -2], [2, 2, 2]],
         ]
         for magmoms in magmoms_list:
-            assert Magmom.are_collinear(magmoms) is True
+            assert Magmom.are_collinear(magmoms)
         ncl_magmoms = [[[0, 0, 1], [0, 0, 1], [1, 2, 3]]]
         assert Magmom.are_collinear(ncl_magmoms) is False
 

--- a/pymatgen/electronic_structure/tests/test_plotter.py
+++ b/pymatgen/electronic_structure/tests/test_plotter.py
@@ -233,15 +233,15 @@ class BSDOSPlotterTest(unittest.TestCase):
     # Minimal baseline testing for get_plot. not a true test. Just checks that
     # it can actually execute.
     def test_methods(self):
-        v = Vasprun(os.path.join(PymatgenTest.TEST_FILES_DIR, "vasprun_Si_bands.xml"))
+        vasp_run = Vasprun(os.path.join(PymatgenTest.TEST_FILES_DIR, "vasprun_Si_bands.xml"))
         p = BSDOSPlotter()
         plt = p.get_plot(
-            v.get_band_structure(kpoints_filename=os.path.join(PymatgenTest.TEST_FILES_DIR, "KPOINTS_Si_bands"))
+            vasp_run.get_band_structure(kpoints_filename=os.path.join(PymatgenTest.TEST_FILES_DIR, "KPOINTS_Si_bands"))
         )
         plt.close()
         plt = p.get_plot(
-            v.get_band_structure(kpoints_filename=os.path.join(PymatgenTest.TEST_FILES_DIR, "KPOINTS_Si_bands")),
-            v.complete_dos,
+            vasp_run.get_band_structure(kpoints_filename=os.path.join(PymatgenTest.TEST_FILES_DIR, "KPOINTS_Si_bands")),
+            vasp_run.complete_dos,
         )
         plt.close("all")
 

--- a/pymatgen/entries/correction_calculator.py
+++ b/pymatgen/entries/correction_calculator.py
@@ -228,9 +228,8 @@ class CorrectionCalculator:
         sigma[sigma == 0] = np.nan
 
         with warnings.catch_warnings():
-            warnings.simplefilter(
-                "ignore", category=RuntimeWarning
-            )  # numpy raises warning if the entire array is nan values
+            # numpy raises warning if the entire array is nan values
+            warnings.simplefilter("ignore", category=RuntimeWarning)
             mean_uncer = np.nanmean(sigma)
 
         sigma = np.where(np.isnan(sigma), mean_uncer, sigma)

--- a/pymatgen/entries/tests/test_computed_entries.py
+++ b/pymatgen/entries/tests/test_computed_entries.py
@@ -25,7 +25,7 @@ from pymatgen.io.vasp.outputs import Vasprun
 from pymatgen.util.testing import PymatgenTest
 
 filepath = os.path.join(PymatgenTest.TEST_FILES_DIR, "vasprun.xml")
-vasprun = Vasprun(filepath)
+vasp_run = Vasprun(filepath)
 
 
 def test_energyadjustment():
@@ -82,9 +82,9 @@ def test_temp_energy_adjustment():
 class ComputedEntryTest(unittest.TestCase):
     def setUp(self):
         self.entry = ComputedEntry(
-            vasprun.final_structure.composition,
-            vasprun.final_energy,
-            parameters=vasprun.incar,
+            vasp_run.final_structure.composition,
+            vasp_run.final_energy,
+            parameters=vasp_run.incar,
         )
         self.entry2 = ComputedEntry({"Fe": 2, "O": 3}, 2.3)
         self.entry3 = ComputedEntry("Fe2O3", 2.3)
@@ -224,7 +224,7 @@ class ComputedEntryTest(unittest.TestCase):
 
 class ComputedStructureEntryTest(unittest.TestCase):
     def setUp(self):
-        self.entry = ComputedStructureEntry(vasprun.final_structure, vasprun.final_energy, parameters=vasprun.incar)
+        self.entry = ComputedStructureEntry(vasp_run.final_structure, vasp_run.final_energy, parameters=vasp_run.incar)
 
     def test_energy(self):
         assert self.entry.energy == approx(-269.38319884)
@@ -418,7 +418,7 @@ class ComputedStructureEntryTest(unittest.TestCase):
 class GibbsComputedStructureEntryTest(unittest.TestCase):
     def setUp(self):
         self.temps = [300, 600, 900, 1200, 1500, 1800]
-        self.struct = vasprun.final_structure
+        self.struct = vasp_run.final_structure
         self.num_atoms = self.struct.composition.num_atoms
         self.entries_with_temps = {
             temp: GibbsComputedStructureEntry(
@@ -426,7 +426,7 @@ class GibbsComputedStructureEntryTest(unittest.TestCase):
                 -2.436,
                 temp=temp,
                 gibbs_model="SISSO",
-                parameters=vasprun.incar,
+                parameters=vasp_run.incar,
                 entry_id="test",
             )
             for temp in self.temps

--- a/pymatgen/ext/tests/test_matproj.py
+++ b/pymatgen/ext/tests/test_matproj.py
@@ -420,10 +420,12 @@ class MPResterOldTest(PymatgenTest):
         assert isinstance(kink["rxn"], Reaction)
         kinks_open_O = self.rester.get_interface_reactions("LiCoO2", "Li3PS4", open_el="O", relative_mu=-1)
         assert len(kinks_open_O) > 0
-        with warnings.catch_warnings(record=True) as w:
-            warnings.filterwarnings("always", message="The reactant.+")
+        with pytest.warns(
+            UserWarning,
+            match="The reactant MnO9 has no matching entry with negative formation energy, "
+            "instead convex hull energy for this composition will be used for reaction energy calculation.",
+        ):
             self.rester.get_interface_reactions("LiCoO2", "MnO9")
-            assert "The reactant" in str(w[-1].message)
 
     def test_download_info(self):
         material_ids = ["mvc-2970"]

--- a/pymatgen/io/cp2k/outputs.py
+++ b/pymatgen/io/cp2k/outputs.py
@@ -1780,7 +1780,7 @@ def parse_pdos(dos_file=None, spin_channel=None, total=False):
                 break
             vbmtop = i
 
-        # set fermi level to be vbm plus tolerance for
+        # set Fermi level to be vbm plus tolerance for
         # PMG compatibility
         # *not* middle of the gap, which pdos might report
         efermi = energies[vbmtop] + 1e-6

--- a/pymatgen/io/cp2k/tests/test_inputs.py
+++ b/pymatgen/io/cp2k/tests/test_inputs.py
@@ -68,11 +68,11 @@ class BasisAndPotentialTest(PymatgenTest):
         # Ensure basis metadata can be read from string
         b = BasisInfo.from_string("cc-pc-DZVP-MOLOPT-q1-SCAN")
         assert b.valence == 2
-        assert b.molopt is True
+        assert b.molopt
         assert b.electrons == 1
         assert b.polarization == 1
-        assert b.cc is True
-        assert b.pc is True
+        assert b.cc
+        assert b.pc
         assert b.xc == "SCAN"
 
         # Ensure one-way softmatching works
@@ -90,7 +90,7 @@ class BasisAndPotentialTest(PymatgenTest):
         p = PotentialInfo.from_string("GTH-PBE-q1-NLCC")
         assert p.potential_type == "GTH"
         assert p.xc == "PBE"
-        assert p.nlcc is True
+        assert p.nlcc
 
         # Ensure one-way softmatching works
         p2 = PotentialInfo.from_string("GTH-q1-NLCC")

--- a/pymatgen/io/cp2k/tests/test_outputs.py
+++ b/pymatgen/io/cp2k/tests/test_outputs.py
@@ -25,8 +25,8 @@ class SetTest(PymatgenTest):
 
     def test_run_info(self):
         """Can extract run info from out file"""
-        assert self.out.spin_polarized is True
-        assert self.out.completed is True
+        assert self.out.spin_polarized
+        assert self.out.completed
         assert self.out.num_warnings == [[2]]
         assert self.out.charge == 0
         assert self.out.cp2k_version == "2022.1"

--- a/pymatgen/io/feff/outputs.py
+++ b/pymatgen/io/feff/outputs.py
@@ -317,7 +317,7 @@ class Xmu(MSONable):
     @property
     def relative_energies(self):
         """
-        Returns energy with respect to the fermi level.
+        Returns energy with respect to the Fermi level.
         E - E_f.
         """
         return self.data[:, 1]
@@ -348,7 +348,7 @@ class Xmu(MSONable):
 
     @property
     def e_fermi(self):
-        """Returns the fermi level in eV."""
+        """Returns the Fermi level in eV."""
         return self.energies[0] - self.relative_energies[0]
 
     @property

--- a/pymatgen/io/lobster/outputs.py
+++ b/pymatgen/io/lobster/outputs.py
@@ -1061,7 +1061,7 @@ class Fatband:
         warnings.warn("Make sure all relevant FATBAND files were generated and read in!")
         warnings.warn("Use Lobster 3.2.0 or newer for fatband calculations!")
 
-        VASPRUN = Vasprun(
+        vasp_run = Vasprun(
             filename=vasprun,
             ionic_step_skip=None,
             ionic_step_offset=0,
@@ -1072,9 +1072,9 @@ class Fatband:
             occu_tol=1e-8,
             exception_on_bad_xml=True,
         )
-        self.structure = VASPRUN.final_structure
+        self.structure = vasp_run.final_structure
         self.lattice = self.structure.lattice.reciprocal_lattice
-        self.efermi = VASPRUN.efermi
+        self.efermi = vasp_run.efermi
         kpoints_object = Kpoints.from_file(Kpointsfile)
 
         atomtype = []

--- a/pymatgen/io/lobster/tests/test_lobster.py
+++ b/pymatgen/io/lobster/tests/test_lobster.py
@@ -1279,9 +1279,9 @@ class LobsteroutTest(PymatgenTest):
 
         assert self.lobsterout_onethread.number_of_threads == 1
         # Test lobsterout of lobster-4.1.0
-        assert self.lobsterout_cobi_madelung.has_cobicar is True
-        assert self.lobsterout_cobi_madelung.has_cohpcar is True
-        assert self.lobsterout_cobi_madelung.has_madelung is True
+        assert self.lobsterout_cobi_madelung.has_cobicar
+        assert self.lobsterout_cobi_madelung.has_cohpcar
+        assert self.lobsterout_cobi_madelung.has_madelung
         assert not self.lobsterout_cobi_madelung.has_doscar_lso
 
         assert self.lobsterout_doscar_lso.has_doscar_lso
@@ -1433,7 +1433,7 @@ class FatbandTest(PymatgenTest):
             assert lattice1["matrix"][idx] == approx(lattice2["matrix"][idx])
         assert self.fatband_SiO2_spin.eigenvals[Spin.up][1][1] - self.fatband_SiO2_spin.efermi == -18.245
         assert self.fatband_SiO2_spin.eigenvals[Spin.down][1][1] - self.fatband_SiO2_spin.efermi == -18.245
-        assert self.fatband_SiO2_spin.is_spinpolarized is True
+        assert self.fatband_SiO2_spin.is_spinpolarized
         assert self.fatband_SiO2_spin.kpoints_array[3] == approx([0.03409091, 0, 0])
         assert self.fatband_SiO2_spin.nbands == 36
 
@@ -1601,11 +1601,11 @@ class LobsterinTest(unittest.TestCase):
         assert self.Lobsterinfromfile["gaussiansmearingwidth"] == approx(0.1)
         assert self.Lobsterinfromfile["basisfunctions"][0] == "Fe 3d 4p 4s"
         assert self.Lobsterinfromfile["basisfunctions"][1] == "Co 3d 4p 4s"
-        assert self.Lobsterinfromfile["skipdos"] is True
-        assert self.Lobsterinfromfile["skipcohp"] is True
-        assert self.Lobsterinfromfile["skipcoop"] is True
-        assert self.Lobsterinfromfile["skippopulationanalysis"] is True
-        assert self.Lobsterinfromfile["skipgrosspopulation"] is True
+        assert self.Lobsterinfromfile["skipdos"]
+        assert self.Lobsterinfromfile["skipcohp"]
+        assert self.Lobsterinfromfile["skipcoop"]
+        assert self.Lobsterinfromfile["skippopulationanalysis"]
+        assert self.Lobsterinfromfile["skipgrosspopulation"]
 
         # test if comments are correctly removed
         assert self.Lobsterinfromfile == self.Lobsterinfromfile2
@@ -1641,11 +1641,11 @@ class LobsterinTest(unittest.TestCase):
         assert lobsterin1["gaussiansmearingwidth"] == approx(0.1)
         assert lobsterin1["basisfunctions"][0] == "Fe 3d 4p 4s"
         assert lobsterin1["basisfunctions"][1] == "Co 3d 4p 4s"
-        assert lobsterin1["skipdos"] is True
-        assert lobsterin1["skipcohp"] is True
-        assert lobsterin1["skipcoop"] is True
-        assert lobsterin1["skippopulationanalysis"] is True
-        assert lobsterin1["skipgrosspopulation"] is True
+        assert lobsterin1["skipdos"]
+        assert lobsterin1["skipcohp"]
+        assert lobsterin1["skipcoop"]
+        assert lobsterin1["skippopulationanalysis"]
+        assert lobsterin1["skipgrosspopulation"]
         with pytest.raises(IOError):
             lobsterin2 = Lobsterin({"cohpstartenergy": -15.0, "cohpstartEnergy": -20.0})
         lobsterin2 = Lobsterin({"cohpstartenergy": -15.0})
@@ -1688,7 +1688,7 @@ class LobsterinTest(unittest.TestCase):
                 "onlycoop",
                 "onlycohpcoop",
             ]:
-                assert lobsterin1["saveProjectiontoFile"] is True
+                assert lobsterin1["saveProjectiontoFile"]
             if option in [
                 "standard",
                 "standard_with_fatband",
@@ -1698,14 +1698,14 @@ class LobsterinTest(unittest.TestCase):
             ]:
                 assert lobsterin1["cohpGenerator"] == "from 0.1 to 6.0 orbitalwise"
             if option in ["standard"]:
-                assert ("skipdos" not in lobsterin1) is True
-                assert ("skipcohp" not in lobsterin1) is True
-                assert ("skipcoop" not in lobsterin1) is True
+                assert "skipdos" not in lobsterin1
+                assert "skipcohp" not in lobsterin1
+                assert "skipcoop" not in lobsterin1
             if option in ["standard_with_fatband"]:
                 assert lobsterin1["createFatband"] == ["Fe 3d 4p 4s ", "O 2p 2s "]
-                assert ("skipdos" not in lobsterin1) is True
-                assert ("skipcohp" not in lobsterin1) is True
-                assert ("skipcoop" not in lobsterin1) is True
+                assert "skipdos" not in lobsterin1
+                assert "skipcohp" not in lobsterin1
+                assert "skipcoop" not in lobsterin1
             if option in ["standard_from_projection"]:
                 assert lobsterin1["loadProjectionFromFile"], True
             if option in [

--- a/pymatgen/io/qchem/tests/test_outputs.py
+++ b/pymatgen/io/qchem/tests/test_outputs.py
@@ -459,7 +459,7 @@ class TestQCOutput(PymatgenTest):
         ).data
         assert data["solvent_method"] == "ISOSVP"
         assert data["solvent_data"]["isosvp"]["isosvp_dielectric"] == 2.28
-        assert data["solvent_data"]["cmirs"]["CMIRS_enabled"] is True
+        assert data["solvent_data"]["cmirs"]["CMIRS_enabled"]
         assert data["solvent_data"]["cmirs"]["dispersion_e"] == 0.6955542829
         assert data["solvent_data"]["cmirs"]["exchange_e"] == 0.2654553686
         assert data["solvent_data"]["cmirs"]["min_neg_field_e"] == 0.0006019665
@@ -471,7 +471,7 @@ class TestQCOutput(PymatgenTest):
         ).data
         assert data["solvent_method"] == "ISOSVP"
         assert data["solvent_data"]["isosvp"]["isosvp_dielectric"] == 10
-        assert data["solvent_data"]["cmirs"]["CMIRS_enabled"] is True
+        assert data["solvent_data"]["cmirs"]["CMIRS_enabled"]
         assert data["solvent_data"]["cmirs"]["dispersion_e"] == 0.6955550107
         assert data["solvent_data"]["cmirs"]["exchange_e"] == 0.2652679507
         assert data["solvent_data"]["cmirs"]["min_neg_field_e"] == 0.0005235850
@@ -492,7 +492,7 @@ class TestQCOutput(PymatgenTest):
         assert data["solvent_data"]["isosvp"]["total_solvation_free_e"] == 0.0037602703
 
         # CMIRS parameters
-        assert data["solvent_data"]["cmirs"]["CMIRS_enabled"] is True
+        assert data["solvent_data"]["cmirs"]["CMIRS_enabled"]
         assert data["solvent_data"]["cmirs"]["dispersion_e"] == 0.6722278965
         assert data["solvent_data"]["cmirs"]["exchange_e"] == 0.2652032616
         assert data["solvent_data"]["cmirs"]["min_neg_field_e"] == 0.0004967767

--- a/pymatgen/io/tests/test_cif.py
+++ b/pymatgen/io/tests/test_cif.py
@@ -752,8 +752,8 @@ loop_
   O  O24  1  0.956628  0.250000  0.292862  1
 
 """
-        cp = CifParser.from_string(cif_structure)
-        s_test = cp.get_structures(False)[0]
+        parser = CifParser.from_string(cif_structure)
+        s_test = parser.get_structures(False)[0]
         filepath = self.TEST_FILES_DIR / "POSCAR"
         poscar = Poscar.from_file(filepath)
         s_ref = poscar.structure
@@ -775,41 +775,40 @@ loop_
 
     def test_bad_cif(self):
         f = self.TEST_FILES_DIR / "bad_occu.cif"
-        p = CifParser(f)
+        parser = CifParser(f)
         with pytest.raises(ValueError):
-            p.get_structures()
-        p = CifParser(f, occupancy_tolerance=2)
-        s = p.get_structures()[0]
+            parser.get_structures()
+        parser = CifParser(f, occupancy_tolerance=2)
+        s = parser.get_structures()[0]
         assert s[0].species["Al3+"] == approx(0.5)
 
     def test_one_line_symm(self):
         f = self.TEST_FILES_DIR / "OneLineSymmP1.cif"
-        p = CifParser(f)
-        s = p.get_structures()[0]
+        parser = CifParser(f)
+        s = parser.get_structures()[0]
         assert s.formula == "Ga4 Pb2 O8"
 
     def test_no_symmops(self):
         f = self.TEST_FILES_DIR / "nosymm.cif"
-        p = CifParser(f)
-        s = p.get_structures()[0]
+        parser = CifParser(f)
+        s = parser.get_structures()[0]
         assert s.formula == "H96 C60 O8"
 
     def test_dot_positions(self):
         f = self.TEST_FILES_DIR / "ICSD59959.cif"
-        p = CifParser(f)
-        s = p.get_structures()[0]
+        parser = CifParser(f)
+        s = parser.get_structures()[0]
         assert s.formula == "K1 Mn1 F3"
 
     def test_replacing_finite_precision_frac_coords(self):
-        f = self.TEST_FILES_DIR / "cif_finite_precision_frac_coord_error.cif"
-        with warnings.catch_warnings():
-            p = CifParser(f)
-            s = p.get_structures()[0]
-            assert str(s.composition) == "N5+24"
-            assert (
-                "Some fractional coordinates rounded to ideal values to avoid issues with finite precision."
-                in p.warnings
-            )
+        cif = self.TEST_FILES_DIR / "cif_finite_precision_frac_coord_error.cif"
+        parser = CifParser(cif)
+        struct = parser.get_structures()[0]
+        assert str(struct.composition) == "N5+24"
+        assert (
+            "Some fractional coordinates rounded to ideal values to avoid issues with finite precision."
+            in parser.warnings
+        )
 
     def test_empty_deque(self):
         s = """data_1526655
@@ -845,8 +844,8 @@ loop_
   3  -x,-y,-z
   4  x-1/2,-y-1/2,z-1/2
 ;"""
-        p = CifParser.from_string(s)
-        assert p.get_structures()[0].formula == "Si1"
+        parser = CifParser.from_string(s)
+        assert parser.get_structures()[0].formula == "Si1"
         cif = """
 data_1526655
 _journal_name_full
@@ -876,9 +875,9 @@ _atom_site_occupancy
 _atom_site_U_iso_or_equiv
 Si1 Si 0 0 0 1 0.0
 """
-        p = CifParser.from_string(cif)
+        parser = CifParser.from_string(cif)
         with pytest.raises(ValueError):
-            p.get_structures()
+            parser.get_structures()
 
 
 class MagCifTest(PymatgenTest):

--- a/pymatgen/io/tests/test_core.py
+++ b/pymatgen/io/tests/test_core.py
@@ -26,8 +26,8 @@ class StructInputFile(InputFile):
 
     @classmethod
     def from_string(cls, contents: str):
-        cp = CifParser.from_string(contents)
-        struct = cp.get_structures()[0]
+        parser = CifParser.from_string(contents)
+        struct = parser.get_structures()[0]
         return cls(structure=struct)
 
 
@@ -184,8 +184,8 @@ class TestInputSet(PymatgenTest):
         assert os.path.exists(os.path.join("input_dir", "file_from_str"))
         assert os.path.exists(os.path.join("input_dir", "file_from_strcast"))
         assert len(os.listdir("input_dir")) == 3
-        cp = CifParser(filename=os.path.join("input_dir", "cif1"))
-        assert cp.get_structures()[0] == self.sif1.structure
+        parser = CifParser(filename=os.path.join("input_dir", "cif1"))
+        assert parser.get_structures()[0] == self.sif1.structure
         with open(os.path.join("input_dir", "file_from_str")) as file:
             file_from_str = file.read()
             assert file_from_str == "hello you"

--- a/pymatgen/io/tests/test_gaussian.py
+++ b/pymatgen/io/tests/test_gaussian.py
@@ -340,7 +340,7 @@ class GaussianOutputTest(unittest.TestCase):
         gau = GaussianOutput(os.path.join(test_dir, "H2O_gau.out"))
         assert gau.num_basis_func == 13
         assert gau.electrons == (5, 5)
-        assert gau.is_spin is True
+        assert gau.is_spin
         assert gau.eigenvalues[Spin.down] == [
             -20.55343,
             -1.35264,

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -2330,14 +2330,17 @@ class VaspInput(dict, MSONable):
 
     def __init__(self, incar, kpoints, poscar, potcar, optional_files=None, **kwargs):
         """
+        Initializes a VaspInput object with the given input files.
+
         Args:
-            incar: Incar object.
-            kpoints: Kpoints object.
-            poscar: Poscar object.
-            potcar: Potcar object.
-            optional_files: Other input files supplied as a dict of {
-                filename: object}. The object should follow standard pymatgen
-                conventions in implementing a as_dict() and from_dict method.
+            incar (Incar): The Incar object.
+            kpoints (Kpoints): The Kpoints object.
+            poscar (Poscar): The Poscar object.
+            potcar (Potcar): The Potcar object.
+            optional_files (dict): Other input files supplied as a dict of {filename: object}.
+                The object should follow standard pymatgen conventions in implementing a
+                as_dict() and from_dict method.
+            **kwargs: Additional keyword arguments to be stored in the VaspInput object.
         """
         super().__init__(**kwargs)
         self.update({"INCAR": incar, "KPOINTS": kpoints, "POSCAR": poscar, "POTCAR": potcar})

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -1046,7 +1046,7 @@ class Vasprun(MSONable):
             return np.max(all_eigs[all_eigs < fermi]), np.min(all_eigs[all_eigs > fermi])
 
         if not crosses_band(self.efermi):
-            # Fermi doesn't cross a band; safe to use VASP fermi level
+            # Fermi doesn't cross a band; safe to use VASP Fermi level
             return self.efermi
 
         # if the Fermi level crosses a band, check if we are very close to band gap;
@@ -4276,12 +4276,12 @@ class Xdatcar:
 
     def write_file(self, filename, **kwargs):
         """
-        Write  Xdatcar class into a file.
+        Write Xdatcar class into a file.
 
         Args:
             filename (str): Filename of output XDATCAR file.
-            The supported kwargs are the same as those for the
-            Xdatcar.get_string method and are passed through directly.
+            **kwargs: Supported kwargs are the same as those for the
+                Xdatcar.get_string method and are passed through directly.
         """
         with zopen(filename, "wt") as f:
             f.write(self.get_string(**kwargs))
@@ -4365,24 +4365,24 @@ class Dynmat:
 
 def get_adjusted_fermi_level(efermi, cbm, band_structure):
     """
-    When running a band structure computations the fermi level needs to be
+    When running a band structure computations the Fermi level needs to be
     take from the static run that gave the charge density used for the non-self
-    consistent band structure run. Sometimes this fermi level is however a
+    consistent band structure run. Sometimes this Fermi level is however a
     little too low because of the mismatch between the uniform grid used in
     the static run and the band structure k-points (e.g., the VBM is on Gamma
     and the Gamma point is not in the uniform mesh). Here we use a procedure
-    consisting in looking for energy levels higher than the static fermi level
+    consisting in looking for energy levels higher than the static Fermi level
     (but lower than the LUMO) if any of these levels make the band structure
     appears insulating and not metallic anymore, we keep this adjusted fermi
     level. This procedure has shown to detect correctly most insulators.
 
     Args:
-        efermi (float): Fermi energy of the static run
-        cbm (float): Conduction band minimum of the static run
-        run_bandstructure: a band_structure object
+        efermi (float): The Fermi energy of the static run.
+        cbm (float): The conduction band minimum of the static run.
+        band_structure (BandStructureSymmLine): A band structure object.
 
     Returns:
-        a new adjusted fermi level
+        float: A new adjusted Fermi level.
     """
     # make a working copy of band_structure
     bs_working = BandStructureSymmLine.from_dict(band_structure.as_dict())

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -302,7 +302,7 @@ class DictSet(VaspInputSet):
             user_kpoints_settings (dict or Kpoints): Allow user to override kpoints
                 setting by supplying a dict E.g., {"reciprocal_density": 1000}.
                 User can also supply Kpoints object. Default is None.
-            user_potcar_settings (dict): Allow user to override POTCARs. E.g.,
+            user_potcar_settings (dict: Allow user to override POTCARs. E.g.,
                 {"Gd": "Gd_3"}. This is generally not recommended. Default is None.
             constrain_total_magmom (bool): Whether to constrain the total magmom
                 (NUPDOWN in INCAR) to be the sum of the expected MAGMOM for all
@@ -588,7 +588,7 @@ class DictSet(VaspInputSet):
 
         if all(k.is_metal for k in structure.composition) and incar.get("NSW", 0) > 0 and incar.get("ISMEAR", 1) < 1:
             warnings.warn(
-                "Relaxation of likely metal with ISMEAR < 1 detected. Please see VASP "
+                "Relaxation of likely metal with ISMEAR < 1 detected. See VASP "
                 "recommendations on ISMEAR for metals.",
                 BadInputSetWarning,
             )

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -302,7 +302,7 @@ class DictSet(VaspInputSet):
             user_kpoints_settings (dict or Kpoints): Allow user to override kpoints
                 setting by supplying a dict E.g., {"reciprocal_density": 1000}.
                 User can also supply Kpoints object. Default is None.
-            user_potcar_settings (dict: Allow user to override POTCARs. E.g.,
+            user_potcar_settings (dict): Allow user to override POTCARs. E.g.,
                 {"Gd": "Gd_3"}. This is generally not recommended. Default is None.
             constrain_total_magmom (bool): Whether to constrain the total magmom
                 (NUPDOWN in INCAR) to be the sum of the expected MAGMOM for all
@@ -602,6 +602,7 @@ class DictSet(VaspInputSet):
 
     @property
     def potcar_functional(self) -> UserPotcarFunctional:
+        """Returns the functional used for POTCAR generation."""
         return self.user_potcar_functional
 
     @property
@@ -1940,13 +1941,12 @@ class MVLElasticSet(MPRelaxSet):
     elastic constants.
     """
 
-    def __init__(self, structure: Structure, potim=0.015, **kwargs):
+    def __init__(self, structure: Structure, potim: float = 0.015, **kwargs):
         """
         Args:
-            scale (float): POTIM parameter. The default of 0.015 is usually fine,
+            structure (pymatgen.Structure): Input structure.
+            potim (float): POTIM parameter. The default of 0.015 is usually fine,
                 but some structures may require a smaller step.
-            user_incar_settings (dict): A dict specifying additional incar
-                settings.
             kwargs:
                 Parameters supported by MPRelaxSet.
         """
@@ -2003,6 +2003,8 @@ class MVLGWSet(DictSet):
             nbands_factor (int): Multiplicative factor for NBANDS when starting
                 from a previous calculation. Only applies if mode=="DIAG".
                 Need to be tested for convergence.
+            reciprocal_density (int): Density of k-mesh by reciprocal atom. Only
+                applies if mode=="STATIC". Defaults to 100.
             ncores (int): Numbers of cores used for the calculation. VASP will alter
                 NBANDS if it was not dividable by ncores. Only applies if
                 mode=="DIAG".
@@ -3060,6 +3062,7 @@ class MPAbsorptionSet(MPRelaxSet):
             structure (Structure): Input structure.
             prev_incar (Incar/string): Incar file from previous run.
             mode (str): Supported modes are "IPA", "RPA"
+            copy_wavecar (bool): Whether to copy the WAVECAR from a previous run. Defaults to True.
             nbands (int): For subsequent calculations, it is generally
                 recommended to perform NBANDS convergence starting from the
                 NBANDS of the previous run for DIAG, and to use the exact same

--- a/pymatgen/io/vasp/tests/test_outputs.py
+++ b/pymatgen/io/vasp/tests/test_outputs.py
@@ -56,20 +56,20 @@ class VasprunTest(PymatgenTest):
         warnings.simplefilter("default")
 
     def test_vasprun_ml(self):
-        v = Vasprun(self.TEST_FILES_DIR / "vasprun.xml.ml_md")
-        assert len(v.md_data) == 100
-        for d in v.md_data:
+        vasp_run = Vasprun(self.TEST_FILES_DIR / "vasprun.xml.ml_md")
+        assert len(vasp_run.md_data) == 100
+        for d in vasp_run.md_data:
             assert "structure" in d
             assert "forces" in d
             assert "energy" in d
-        assert v.md_data[-1]["energy"]["total"] == approx(-491.51831988)
+        assert vasp_run.md_data[-1]["energy"]["total"] == approx(-491.51831988)
 
     def test_bad_random_seed(self):
         _ = Vasprun(self.TEST_FILES_DIR / "vasprun.bad_random_seed.xml")
 
     def test_multiple_dielectric(self):
-        v = Vasprun(self.TEST_FILES_DIR / "vasprun.GW0.xml")
-        assert len(v.other_dielectric) == 3
+        vasp_run = Vasprun(self.TEST_FILES_DIR / "vasprun.GW0.xml")
+        assert len(vasp_run.other_dielectric) == 3
 
     def test_charge_charge_dielectric(self):
         """
@@ -77,17 +77,17 @@ class VasprunTest(PymatgenTest):
         These are the "density-density" and "velocity-velocity" linear response functions.
         See the comments in `linear_optics.F` for details.
         """
-        v = Vasprun(
+        vasp_run = Vasprun(
             self.TEST_FILES_DIR / "vasprun.xml.dielectric_5.4.4",
             parse_potcar_file=False,
         )
-        assert v.dielectric is not None
-        assert "density" in v.dielectric_data
-        assert "velocity" in v.dielectric_data
+        assert vasp_run.dielectric is not None
+        assert "density" in vasp_run.dielectric_data
+        assert "velocity" in vasp_run.dielectric_data
 
     def test_optical_absorption_coeff(self):
-        v = Vasprun(self.TEST_FILES_DIR / "vasprun.BSE.xml.gz")
-        absorption_coeff = v.optical_absorption_coeff
+        vasp_run = Vasprun(self.TEST_FILES_DIR / "vasprun.BSE.xml.gz")
+        absorption_coeff = vasp_run.optical_absorption_coeff
         assert absorption_coeff[1] == 0.8327903762077188
 
     def test_vasprun_with_more_than_two_unlabelled_dielectric_functions(self):
@@ -102,61 +102,61 @@ class VasprunTest(PymatgenTest):
             UserWarning,
             match="XML is malformed. Parsing has stopped but partial data is available",
         ) as warns:
-            v = Vasprun(self.TEST_FILES_DIR / "bad_vasprun.xml", exception_on_bad_xml=False)
-            assert len(v.ionic_steps) == 1
-            assert v.final_energy == approx(-269.00551374)
+            vasp_run = Vasprun(self.TEST_FILES_DIR / "bad_vasprun.xml", exception_on_bad_xml=False)
+            assert len(vasp_run.ionic_steps) == 1
+            assert vasp_run.final_energy == approx(-269.00551374)
         assert len(warns) == 13
 
     def test_runtype(self):
-        v = Vasprun(self.TEST_FILES_DIR / "vasprun.GW0.xml")
-        assert v.run_type in "HF"
+        vasp_run = Vasprun(self.TEST_FILES_DIR / "vasprun.GW0.xml")
+        assert vasp_run.run_type in "HF"
 
-        v = Vasprun(self.TEST_FILES_DIR / "vasprun.xml.pbesol_vdw")
-        assert v.run_type in "PBEsol+vdW-DFT-D3-BJ"
+        vasp_run = Vasprun(self.TEST_FILES_DIR / "vasprun.xml.pbesol_vdw")
+        assert vasp_run.run_type in "PBEsol+vdW-DFT-D3-BJ"
 
-        v = Vasprun(self.TEST_FILES_DIR / "vasprun.xml.hse06")
-        assert v.run_type in "HSE06"
+        vasp_run = Vasprun(self.TEST_FILES_DIR / "vasprun.xml.hse06")
+        assert vasp_run.run_type in "HSE06"
 
-        v = Vasprun(self.TEST_FILES_DIR / "vasprun.xml.scan_rvv10")
-        assert v.run_type in "SCAN+rVV10"
+        vasp_run = Vasprun(self.TEST_FILES_DIR / "vasprun.xml.scan_rvv10")
+        assert vasp_run.run_type in "SCAN+rVV10"
 
-        v = Vasprun(self.TEST_FILES_DIR / "vasprun.xml.dfpt.ionic")
-        assert v.run_type in "GGA"
+        vasp_run = Vasprun(self.TEST_FILES_DIR / "vasprun.xml.dfpt.ionic")
+        assert vasp_run.run_type in "GGA"
 
-        v = Vasprun(self.TEST_FILES_DIR / "vasprun.xml.dfpt")
-        assert v.run_type in "GGA+U"
+        vasp_run = Vasprun(self.TEST_FILES_DIR / "vasprun.xml.dfpt")
+        assert vasp_run.run_type in "GGA+U"
 
-        v = Vasprun(self.TEST_FILES_DIR / "vasprun.xml.r2scan")
-        assert v.run_type in "R2SCAN"
+        vasp_run = Vasprun(self.TEST_FILES_DIR / "vasprun.xml.r2scan")
+        assert vasp_run.run_type in "R2SCAN"
 
-        v = Vasprun(self.TEST_FILES_DIR / "vasprun.xml.scan")
-        assert v.run_type in "SCAN"
+        vasp_run = Vasprun(self.TEST_FILES_DIR / "vasprun.xml.scan")
+        assert vasp_run.run_type in "SCAN"
 
-        v = Vasprun(self.TEST_FILES_DIR / "vasprun.xml.pbesol")
-        assert v.run_type in "PBEsol"
+        vasp_run = Vasprun(self.TEST_FILES_DIR / "vasprun.xml.pbesol")
+        assert vasp_run.run_type in "PBEsol"
 
-        v = Vasprun(self.TEST_FILES_DIR / "vasprun.xml.rscan")
-        assert v.run_type in "RSCAN"
+        vasp_run = Vasprun(self.TEST_FILES_DIR / "vasprun.xml.rscan")
+        assert vasp_run.run_type in "RSCAN"
 
-        v = Vasprun(self.TEST_FILES_DIR / "vasprun.xml.random")
-        assert v.run_type in "RANDOMFUNCTIONAL"
+        vasp_run = Vasprun(self.TEST_FILES_DIR / "vasprun.xml.random")
+        assert vasp_run.run_type in "RANDOMFUNCTIONAL"
 
-        v = Vasprun(self.TEST_FILES_DIR / "vasprun.xml.unknown")
+        vasp_run = Vasprun(self.TEST_FILES_DIR / "vasprun.xml.unknown")
         with pytest.warns(UserWarning, match="Unknown run type!"):
-            assert v.run_type in "unknown"
+            assert vasp_run.run_type in "unknown"
 
     def test_vdw(self):
-        v = Vasprun(self.TEST_FILES_DIR / "vasprun.xml.vdw")
-        assert v.final_energy == approx(-9.78310677)
+        vasp_run = Vasprun(self.TEST_FILES_DIR / "vasprun.xml.vdw")
+        assert vasp_run.final_energy == approx(-9.78310677)
 
     def test_energies(self):
         # VASP 5.4.1
-        v = Vasprun(self.TEST_FILES_DIR / "vasprun.xml.etest1.gz")
-        assert v.final_energy == approx(-11.18981538)
+        vasp_run = Vasprun(self.TEST_FILES_DIR / "vasprun.xml.etest1.gz")
+        assert vasp_run.final_energy == approx(-11.18981538)
 
         # VASP 6.2.1
-        v = Vasprun(self.TEST_FILES_DIR / "vasprun.xml.etest2.gz")
-        assert v.final_energy == approx(-11.18986774)
+        vasp_run = Vasprun(self.TEST_FILES_DIR / "vasprun.xml.etest2.gz")
+        assert vasp_run.final_energy == approx(-11.18986774)
 
         # VASP 5.4.1
         o = Vasprun(self.TEST_FILES_DIR / "vasprun.xml.etest3.gz")
@@ -368,8 +368,8 @@ class VasprunTest(PymatgenTest):
         assert len(vasprun_diel.other_dielectric) == 0
 
     def test_indirect_vasprun(self):
-        v = Vasprun(self.TEST_FILES_DIR / "vasprun.xml.indirect.gz")
-        (gap, cbm, vbm, direct) = v.eigenvalue_band_properties
+        vasp_run = Vasprun(self.TEST_FILES_DIR / "vasprun.xml.indirect.gz")
+        (gap, cbm, vbm, direct) = vasp_run.eigenvalue_band_properties
         assert not direct
 
     def test_optical_vasprun(self):

--- a/pymatgen/io/vasp/tests/test_outputs.py
+++ b/pymatgen/io/vasp/tests/test_outputs.py
@@ -167,113 +167,113 @@ class VasprunTest(PymatgenTest):
 
     def test_nonlmn(self):
         filepath = self.TEST_FILES_DIR / "vasprun.xml.nonlm"
-        vasprun = Vasprun(filepath, parse_potcar_file=False)
-        orbs = list(vasprun.complete_dos.pdos[vasprun.final_structure[0]])
+        vasp_run = Vasprun(filepath, parse_potcar_file=False)
+        orbs = list(vasp_run.complete_dos.pdos[vasp_run.final_structure[0]])
         assert OrbitalType.s in orbs
 
     def test_standard(self):
         filepath = self.TEST_FILES_DIR / "vasprun.xml"
-        vasprun = Vasprun(filepath, parse_potcar_file=False)
+        vasp_run = Vasprun(filepath, parse_potcar_file=False)
 
         # Test NELM parsing.
-        assert vasprun.parameters["NELM"] == 60
+        assert vasp_run.parameters["NELM"] == 60
         # test pdos parsing
 
-        assert vasprun.complete_dos.spin_polarization == 1.0
+        assert vasp_run.complete_dos.spin_polarization == 1.0
         assert Vasprun(self.TEST_FILES_DIR / "vasprun.xml.etest1.gz").complete_dos.spin_polarization is None
 
-        pdos0 = vasprun.complete_dos.pdos[vasprun.final_structure[0]]
+        pdos0 = vasp_run.complete_dos.pdos[vasp_run.final_structure[0]]
         assert pdos0[Orbital.s][Spin.up][16] == approx(0.0026)
         assert pdos0[Orbital.pz][Spin.down][16] == approx(0.0012)
         assert pdos0[Orbital.s][Spin.up].shape == (301,)
 
-        pdos0_norm = vasprun.complete_dos_normalized.pdos[vasprun.final_structure[0]]
+        pdos0_norm = vasp_run.complete_dos_normalized.pdos[vasp_run.final_structure[0]]
         assert pdos0_norm[Orbital.s][Spin.up][16] == approx(0.0026)  # the site data should not change
         assert pdos0_norm[Orbital.s][Spin.up].shape == (301,)
 
-        cdos_norm, cdos = vasprun.complete_dos_normalized, vasprun.complete_dos
+        cdos_norm, cdos = vasp_run.complete_dos_normalized, vasp_run.complete_dos
         ratio = np.nanmax(cdos.densities[Spin.up] / cdos_norm.densities[Spin.up])
-        assert ratio == approx(vasprun.final_structure.volume)  # the site data should not change
+        assert ratio == approx(vasp_run.final_structure.volume)  # the site data should not change
 
         # check you can normalize an existing DOS
         cdos_norm2 = cdos.get_normalized()
         ratio = np.nanmax(cdos.densities[Spin.up] / cdos_norm2.densities[Spin.up])
-        assert ratio == approx(vasprun.final_structure.volume)  # the site data should not change
+        assert ratio == approx(vasp_run.final_structure.volume)  # the site data should not change
 
         # but doing so twice should not change the data
         cdos_norm3 = cdos_norm2.get_normalized()
         ratio = np.nanmax(cdos.densities[Spin.up] / cdos_norm3.densities[Spin.up])
-        assert ratio == approx(vasprun.final_structure.volume)  # the site data should not change
+        assert ratio == approx(vasp_run.final_structure.volume)  # the site data should not change
 
-        pdos0_norm = vasprun.complete_dos_normalized.pdos[vasprun.final_structure[0]]
+        pdos0_norm = vasp_run.complete_dos_normalized.pdos[vasp_run.final_structure[0]]
         assert pdos0_norm[Orbital.s][Spin.up][16] == approx(0.0026)  # the site data should not change
         assert pdos0_norm[Orbital.s][Spin.up].shape == (301,)
 
-        cdos_norm, cdos = vasprun.complete_dos_normalized, vasprun.complete_dos
+        cdos_norm, cdos = vasp_run.complete_dos_normalized, vasp_run.complete_dos
         ratio = np.nanmax(cdos.densities[Spin.up] / cdos_norm.densities[Spin.up])
-        assert ratio == approx(vasprun.final_structure.volume)  # the site data should not change
+        assert ratio == approx(vasp_run.final_structure.volume)  # the site data should not change
 
         filepath2 = self.TEST_FILES_DIR / "lifepo4.xml"
         vasprun_ggau = Vasprun(filepath2, parse_projected_eigen=True, parse_potcar_file=False)
-        totalscsteps = sum(len(i["electronic_steps"]) for i in vasprun.ionic_steps)
-        assert len(vasprun.ionic_steps) == 29
-        assert len(vasprun.structures) == len(vasprun.ionic_steps)
+        totalscsteps = sum(len(i["electronic_steps"]) for i in vasp_run.ionic_steps)
+        assert len(vasp_run.ionic_steps) == 29
+        assert len(vasp_run.structures) == len(vasp_run.ionic_steps)
 
-        trajectory = vasprun.get_trajectory()
-        assert len(trajectory) == len(vasprun.ionic_steps)
+        trajectory = vasp_run.get_trajectory()
+        assert len(trajectory) == len(vasp_run.ionic_steps)
         assert "forces" in trajectory[0].site_properties
 
-        for i, step in enumerate(vasprun.ionic_steps):
-            assert vasprun.structures[i] == step["structure"]
+        for i, step in enumerate(vasp_run.ionic_steps):
+            assert vasp_run.structures[i] == step["structure"]
 
         assert all(
-            vasprun.structures[i] == vasprun.ionic_steps[i]["structure"] for i in range(len(vasprun.ionic_steps))
+            vasp_run.structures[i] == vasp_run.ionic_steps[i]["structure"] for i in range(len(vasp_run.ionic_steps))
         )
 
         assert totalscsteps == 308, "Incorrect number of energies read from vasprun.xml"
 
-        assert ["Li"] + 4 * ["Fe"] + 4 * ["P"] + 16 * ["O"] == vasprun.atomic_symbols
-        assert vasprun.final_structure.composition.reduced_formula == "LiFe4(PO4)4"
-        assert vasprun.incar is not None, "Incar cannot be read"
-        assert vasprun.kpoints is not None, "Kpoints cannot be read"
-        assert vasprun.eigenvalues is not None, "Eigenvalues cannot be read"
-        assert vasprun.final_energy == approx(-269.38319884, abs=1e-7)
-        assert vasprun.tdos.get_gap() == approx(2.0589, abs=1e-4)
+        assert ["Li"] + 4 * ["Fe"] + 4 * ["P"] + 16 * ["O"] == vasp_run.atomic_symbols
+        assert vasp_run.final_structure.composition.reduced_formula == "LiFe4(PO4)4"
+        assert vasp_run.incar is not None, "Incar cannot be read"
+        assert vasp_run.kpoints is not None, "Kpoints cannot be read"
+        assert vasp_run.eigenvalues is not None, "Eigenvalues cannot be read"
+        assert vasp_run.final_energy == approx(-269.38319884, abs=1e-7)
+        assert vasp_run.tdos.get_gap() == approx(2.0589, abs=1e-4)
         expectedans = (2.539, 4.0906, 1.5516, False)
-        (gap, cbm, vbm, direct) = vasprun.eigenvalue_band_properties
+        (gap, cbm, vbm, direct) = vasp_run.eigenvalue_band_properties
         assert gap == approx(expectedans[0])
         assert cbm == approx(expectedans[1])
         assert vbm == approx(expectedans[2])
         assert direct == expectedans[3]
-        assert not vasprun.is_hubbard
-        assert vasprun.potcar_symbols == [
+        assert not vasp_run.is_hubbard
+        assert vasp_run.potcar_symbols == [
             "PAW_PBE Li 17Jan2003",
             "PAW_PBE Fe 06Sep2000",
             "PAW_PBE Fe 06Sep2000",
             "PAW_PBE P 17Jan2003",
             "PAW_PBE O 08Apr2002",
         ]
-        assert vasprun.kpoints is not None, "Kpoints cannot be read"
-        assert vasprun.actual_kpoints is not None, "Actual kpoints cannot be read"
-        assert vasprun.actual_kpoints_weights is not None, "Actual kpoints weights cannot be read"
-        for atomdoses in vasprun.pdos:
+        assert vasp_run.kpoints is not None, "Kpoints cannot be read"
+        assert vasp_run.actual_kpoints is not None, "Actual kpoints cannot be read"
+        assert vasp_run.actual_kpoints_weights is not None, "Actual kpoints weights cannot be read"
+        for atomdoses in vasp_run.pdos:
             for orbitaldos in atomdoses:
                 assert orbitaldos is not None, "Partial Dos cannot be read"
 
         # test skipping ionic steps.
         vasprun_skip = Vasprun(filepath, 3, parse_potcar_file=False)
         assert vasprun_skip.nionic_steps == 29
-        assert len(vasprun_skip.ionic_steps) == int(vasprun.nionic_steps / 3) + 1
+        assert len(vasprun_skip.ionic_steps) == int(vasp_run.nionic_steps / 3) + 1
         assert len(vasprun_skip.ionic_steps) == len(vasprun_skip.structures)
-        assert len(vasprun_skip.ionic_steps) == int(vasprun.nionic_steps / 3) + 1
+        assert len(vasprun_skip.ionic_steps) == int(vasp_run.nionic_steps / 3) + 1
         # Check that nionic_steps is preserved no matter what.
-        assert vasprun_skip.nionic_steps == vasprun.nionic_steps
+        assert vasprun_skip.nionic_steps == vasp_run.nionic_steps
 
-        assert vasprun_skip.final_energy != approx(vasprun.final_energy)
+        assert vasprun_skip.final_energy != approx(vasp_run.final_energy)
 
         # Test with ionic_step_offset
         vasprun_offset = Vasprun(filepath, 3, 6, parse_potcar_file=False)
-        assert len(vasprun_offset.ionic_steps) == int(len(vasprun.ionic_steps) / 3) - 1
+        assert len(vasprun_offset.ionic_steps) == int(len(vasp_run.ionic_steps) / 3) - 1
         assert vasprun_offset.structures[0] == vasprun_skip.structures[2]
 
         assert vasprun_ggau.is_hubbard
@@ -283,7 +283,7 @@ class VasprunTest(PymatgenTest):
         assert d["elements"] == ["Fe", "Li", "O", "P"]
         assert d["nelements"] == 4
 
-        entry = vasprun.get_computed_entry(inc_structure=True)
+        entry = vasp_run.get_computed_entry(inc_structure=True)
         assert entry.entry_id.startswith("vasprun")
         assert entry.parameters["run_type"] == "PBEO or other Hybrid Functional"
 
@@ -460,16 +460,16 @@ class VasprunTest(PymatgenTest):
 
     def test_as_dict(self):
         filepath = self.TEST_FILES_DIR / "vasprun.xml"
-        vasprun = Vasprun(filepath, parse_potcar_file=False)
+        vasp_run = Vasprun(filepath, parse_potcar_file=False)
         # Test that as_dict() is json-serializable
-        assert json.dumps(vasprun.as_dict()) is not None
-        assert vasprun.as_dict()["input"]["potcar_type"] == ["PAW_PBE", "PAW_PBE", "PAW_PBE", "PAW_PBE", "PAW_PBE"]
-        assert vasprun.as_dict()["input"]["nkpoints"] == 24
+        assert json.dumps(vasp_run.as_dict()) is not None
+        assert vasp_run.as_dict()["input"]["potcar_type"] == ["PAW_PBE", "PAW_PBE", "PAW_PBE", "PAW_PBE", "PAW_PBE"]
+        assert vasp_run.as_dict()["input"]["nkpoints"] == 24
 
     def test_get_band_structure(self):
         filepath = self.TEST_FILES_DIR / "vasprun_Si_bands.xml"
-        vasprun = Vasprun(filepath, parse_projected_eigen=True, parse_potcar_file=False)
-        bs = vasprun.get_band_structure(kpoints_filename=self.TEST_FILES_DIR / "KPOINTS_Si_bands")
+        vasp_run = Vasprun(filepath, parse_projected_eigen=True, parse_potcar_file=False)
+        bs = vasp_run.get_band_structure(kpoints_filename=self.TEST_FILES_DIR / "KPOINTS_Si_bands")
         cbm = bs.get_cbm()
         vbm = bs.get_vbm()
         assert cbm["kpoint_index"] == [13], "wrong cbm kpoint index"
@@ -490,16 +490,16 @@ class VasprunTest(PymatgenTest):
         copyfile(self.TEST_FILES_DIR / "vasprun_Si_bands.xml", "vasprun.xml")
 
         # Check for error if no KPOINTS file
-        vasprun = Vasprun("vasprun.xml", parse_projected_eigen=True, parse_potcar_file=False)
+        vasp_run = Vasprun("vasprun.xml", parse_projected_eigen=True, parse_potcar_file=False)
         with pytest.raises(
             VaspParserError, match="KPOINTS not found but needed to obtain band structure along symmetry lines"
         ):
-            _ = vasprun.get_band_structure(line_mode=True)
+            _ = vasp_run.get_band_structure(line_mode=True)
 
         # Check KPOINTS.gz successfully inferred and used if present
         with open(self.TEST_FILES_DIR / "KPOINTS_Si_bands", "rb") as f_in, gzip.open("KPOINTS.gz", "wb") as f_out:
             copyfileobj(f_in, f_out)
-        bs_kpts_gzip = vasprun.get_band_structure()
+        bs_kpts_gzip = vasp_run.get_band_structure()
         assert bs.efermi == bs_kpts_gzip.efermi
         assert bs.as_dict() == bs_kpts_gzip.as_dict()
 
@@ -510,18 +510,18 @@ class VasprunTest(PymatgenTest):
             os.path.join("deeper", "vasprun.xml.gz"), "wb"
         ) as f_out:
             copyfileobj(f_in, f_out)
-        vasprun = Vasprun(
+        vasp_run = Vasprun(
             os.path.join("deeper", "vasprun.xml.gz"),
             parse_projected_eigen=True,
             parse_potcar_file=False,
         )
-        bs_vasprun_gzip = vasprun.get_band_structure(line_mode=True)
+        bs_vasprun_gzip = vasp_run.get_band_structure(line_mode=True)
         assert bs.efermi == bs_vasprun_gzip.efermi
         assert bs.as_dict() == bs_vasprun_gzip.as_dict()
 
         # test hybrid band structures
-        vasprun.actual_kpoints_weights[-1] = 0.0
-        bs = vasprun.get_band_structure(kpoints_filename=self.TEST_FILES_DIR / "KPOINTS_Si_bands")
+        vasp_run.actual_kpoints_weights[-1] = 0.0
+        bs = vasp_run.get_band_structure(kpoints_filename=self.TEST_FILES_DIR / "KPOINTS_Si_bands")
         cbm = bs.get_cbm()
         vbm = bs.get_vbm()
         assert cbm["kpoint_index"] == [0]
@@ -532,12 +532,12 @@ class VasprunTest(PymatgenTest):
         assert vbm["kpoint"].label is None
 
         # test self-consistent band structure calculation for non-hybrid functionals
-        vasprun = Vasprun(
+        vasp_run = Vasprun(
             self.TEST_FILES_DIR / "vasprun.xml.forcehybridlikecalc",
             parse_projected_eigen=True,
             parse_potcar_file=False,
         )
-        bs = vasprun.get_band_structure(
+        bs = vasp_run.get_band_structure(
             kpoints_filename=self.TEST_FILES_DIR / "KPOINTS.forcehybridlikecalc",
             force_hybrid_mode=True,
             line_mode=True,
@@ -553,10 +553,10 @@ class VasprunTest(PymatgenTest):
 
     def test_projected_magnetisation(self):
         filepath = self.TEST_FILES_DIR / "vasprun.lvel.Si2H.xml"
-        vasprun = Vasprun(filepath, parse_projected_eigen=True)
-        assert vasprun.projected_magnetisation is not None
-        assert vasprun.projected_magnetisation.shape == (76, 240, 4, 9, 3)
-        assert vasprun.projected_magnetisation[0, 0, 0, 0, 0] == approx(-0.0712)
+        vasp_run = Vasprun(filepath, parse_projected_eigen=True)
+        assert vasp_run.projected_magnetisation is not None
+        assert vasp_run.projected_magnetisation.shape == (76, 240, 4, 9, 3)
+        assert vasp_run.projected_magnetisation[0, 0, 0, 0, 0] == approx(-0.0712)
 
     def test_smart_efermi(self):
         # branch 1 - E_fermi does not cross a band
@@ -592,19 +592,18 @@ class VasprunTest(PymatgenTest):
 
     def test_sc_step_overflow(self):
         filepath = self.TEST_FILES_DIR / "vasprun.xml.sc_overflow"
-        with pytest.warns(UserWarning, match="Float overflow .* encountered in vasprun") as warns:
-            vasprun = Vasprun(filepath)
-            assert len(warns) == 15
-        vasprun = Vasprun(filepath)
-        estep = vasprun.ionic_steps[0]["electronic_steps"][29]
+        with pytest.warns(UserWarning, match="Float overflow .* encountered in vasprun"):
+            vasp_run = Vasprun(filepath)
+        vasp_run = Vasprun(filepath)
+        estep = vasp_run.ionic_steps[0]["electronic_steps"][29]
         assert np.isnan(estep["e_wo_entrp"])
 
     def test_update_potcar(self):
         filepath = self.TEST_FILES_DIR / "vasprun.xml"
         potcar_path = self.TEST_FILES_DIR / "POTCAR.LiFePO4.gz"
         potcar_path2 = self.TEST_FILES_DIR / "POTCAR2.LiFePO4.gz"
-        vasprun = Vasprun(filepath, parse_potcar_file=False)
-        assert vasprun.potcar_spec == [
+        vasp_run = Vasprun(filepath, parse_potcar_file=False)
+        assert vasp_run.potcar_spec == [
             {"titel": "PAW_PBE Li 17Jan2003", "hash": None},
             {"titel": "PAW_PBE Fe 06Sep2000", "hash": None},
             {"titel": "PAW_PBE Fe 06Sep2000", "hash": None},
@@ -612,8 +611,8 @@ class VasprunTest(PymatgenTest):
             {"titel": "PAW_PBE O 08Apr2002", "hash": None},
         ]
 
-        vasprun.update_potcar_spec(potcar_path)
-        assert vasprun.potcar_spec == [
+        vasp_run.update_potcar_spec(potcar_path)
+        assert vasp_run.potcar_spec == [
             {"titel": "PAW_PBE Li 17Jan2003", "hash": "65e83282d1707ec078c1012afbd05be8"},
             {"titel": "PAW_PBE Fe 06Sep2000", "hash": "9530da8244e4dac17580869b4adab115"},
             {"titel": "PAW_PBE Fe 06Sep2000", "hash": "9530da8244e4dac17580869b4adab115"},
@@ -624,9 +623,9 @@ class VasprunTest(PymatgenTest):
         vasprun2 = Vasprun(filepath, parse_potcar_file=False)
         with pytest.raises(ValueError, match="Potcar TITELs do not match Vasprun"):
             vasprun2.update_potcar_spec(potcar_path2)
-        vasprun = Vasprun(filepath, parse_potcar_file=potcar_path)
+        vasp_run = Vasprun(filepath, parse_potcar_file=potcar_path)
 
-        assert vasprun.potcar_spec == [
+        assert vasp_run.potcar_spec == [
             {"titel": "PAW_PBE Li 17Jan2003", "hash": "65e83282d1707ec078c1012afbd05be8"},
             {"titel": "PAW_PBE Fe 06Sep2000", "hash": "9530da8244e4dac17580869b4adab115"},
             {"titel": "PAW_PBE Fe 06Sep2000", "hash": "9530da8244e4dac17580869b4adab115"},
@@ -639,8 +638,8 @@ class VasprunTest(PymatgenTest):
 
     def test_search_for_potcar(self):
         filepath = self.TEST_FILES_DIR / "vasprun.xml"
-        vasprun = Vasprun(filepath, parse_potcar_file=True)
-        assert [spec["titel"] for spec in vasprun.potcar_spec] == [
+        vasp_run = Vasprun(filepath, parse_potcar_file=True)
+        assert [spec["titel"] for spec in vasp_run.potcar_spec] == [
             "PAW_PBE Li 17Jan2003",
             "PAW_PBE Fe 06Sep2000",
             "PAW_PBE Fe 06Sep2000",
@@ -652,9 +651,9 @@ class VasprunTest(PymatgenTest):
         filepath = self.TEST_FILES_DIR / "vasprun.xml"
         # Ensure no potcar is found and nothing is updated
         with pytest.warns(UserWarning, match="No POTCAR file with matching TITEL fields was found in") as warns:
-            vasprun = Vasprun(filepath, parse_potcar_file=".")
+            vasp_run = Vasprun(filepath, parse_potcar_file=".")
         assert len(warns) == 2
-        assert vasprun.potcar_spec == [
+        assert vasp_run.potcar_spec == [
             {"titel": "PAW_PBE Li 17Jan2003", "hash": None},
             {"titel": "PAW_PBE Fe 06Sep2000", "hash": None},
             {"titel": "PAW_PBE Fe 06Sep2000", "hash": None},
@@ -664,41 +663,41 @@ class VasprunTest(PymatgenTest):
 
     def test_parsing_chemical_shift_calculations(self):
         filepath = self.TEST_FILES_DIR / "nmr" / "cs" / "basic" / "vasprun.xml.chemical_shift.scstep"
-        vasprun = Vasprun(filepath)
-        nestep = len(vasprun.ionic_steps[-1]["electronic_steps"])
+        vasp_run = Vasprun(filepath)
+        nestep = len(vasp_run.ionic_steps[-1]["electronic_steps"])
         assert nestep == 10
-        assert vasprun.converged
+        assert vasp_run.converged
 
     def test_parsing_efg_calcs(self):
         filepath = self.TEST_FILES_DIR / "nmr" / "efg" / "AlPO4" / "vasprun.xml"
-        vasprun = Vasprun(filepath)
-        nestep = len(vasprun.ionic_steps[-1]["electronic_steps"])
+        vasp_run = Vasprun(filepath)
+        nestep = len(vasp_run.ionic_steps[-1]["electronic_steps"])
         assert nestep == 18
-        assert vasprun.converged
+        assert vasp_run.converged
 
     def test_charged_structure(self):
         vpath = self.TEST_FILES_DIR / "vasprun.charged.xml"
         potcar_path = self.TEST_FILES_DIR / "POT_GGA_PAW_PBE" / "POTCAR.Si.gz"
-        vasprun = Vasprun(vpath, parse_potcar_file=False)
-        vasprun.update_charge_from_potcar(potcar_path)
-        assert vasprun.parameters.get("NELECT", 8) == 9
-        assert vasprun.structures[0].charge == -1
-        assert vasprun.initial_structure.charge == -1
-        assert vasprun.final_structure.charge == -1
+        vasp_run = Vasprun(vpath, parse_potcar_file=False)
+        vasp_run.update_charge_from_potcar(potcar_path)
+        assert vasp_run.parameters.get("NELECT", 8) == 9
+        assert vasp_run.structures[0].charge == -1
+        assert vasp_run.initial_structure.charge == -1
+        assert vasp_run.final_structure.charge == -1
 
         vpath = self.TEST_FILES_DIR / "vasprun.split.charged.xml"
         potcar_path = self.TEST_FILES_DIR / "POTCAR.split.charged.gz"
-        vasprun = Vasprun(vpath, parse_potcar_file=False)
-        vasprun.update_charge_from_potcar(potcar_path)
-        assert vasprun.parameters.get("NELECT", 0) == 7
-        assert vasprun.structures[-1].charge == -1
-        assert vasprun.initial_structure.charge == -1
-        assert vasprun.final_structure.charge == -1
+        vasp_run = Vasprun(vpath, parse_potcar_file=False)
+        vasp_run.update_charge_from_potcar(potcar_path)
+        assert vasp_run.parameters.get("NELECT", 0) == 7
+        assert vasp_run.structures[-1].charge == -1
+        assert vasp_run.initial_structure.charge == -1
+        assert vasp_run.final_structure.charge == -1
 
     def test_kpointset_electronvelocities(self):
         vpath = self.TEST_FILES_DIR / "vasprun.lvel.Si2H.xml"
-        vasprun = Vasprun(vpath, parse_potcar_file=False)
-        assert vasprun.eigenvalues[Spin.up].shape[0] == len(vasprun.actual_kpoints)
+        vasp_run = Vasprun(vpath, parse_potcar_file=False)
+        assert vasp_run.eigenvalues[Spin.up].shape[0] == len(vasp_run.actual_kpoints)
 
     def test_eigenvalue_band_properties_separate_spins(self):
         eig = Vasprun(self.TEST_FILES_DIR / "vasprun_eig_separate_spins.xml.gz", separate_spins=True)

--- a/pymatgen/io/vasp/tests/test_outputs.py
+++ b/pymatgen/io/vasp/tests/test_outputs.py
@@ -81,9 +81,9 @@ class VasprunTest(PymatgenTest):
             self.TEST_FILES_DIR / "vasprun.xml.dielectric_5.4.4",
             parse_potcar_file=False,
         )
-        assert (v.dielectric is not None) is True
-        assert ("density" in v.dielectric_data) is True
-        assert ("velocity" in v.dielectric_data) is True
+        assert v.dielectric is not None
+        assert "density" in v.dielectric_data
+        assert "velocity" in v.dielectric_data
 
     def test_optical_absorption_coeff(self):
         v = Vasprun(self.TEST_FILES_DIR / "vasprun.BSE.xml.gz")
@@ -720,8 +720,8 @@ class VasprunTest(PymatgenTest):
         assert props[2][0] == approx(0.7969, abs=1e-4)
         assert props[2][1] == approx(0.3415, abs=1e-4)
         assert props2[0] == approx(np.min(props[1]) - np.max(props[2]), abs=1e-4)
-        assert props[3][0] is True
-        assert props[3][1] is True
+        assert props[3][0]
+        assert props[3][1]
 
 
 class OutcarTest(PymatgenTest):
@@ -871,7 +871,7 @@ class OutcarTest(PymatgenTest):
     def test_polarization(self):
         filepath = self.TEST_FILES_DIR / "OUTCAR.BaTiO3.polar"
         outcar = Outcar(filepath)
-        assert outcar.spin is True
+        assert outcar.spin
         assert outcar.noncollinear is False
         assert outcar.p_ion == approx([0.0, 0.0, -5.56684])
         assert outcar.p_elec == approx([0.00024, 0.00019, 3.61674])
@@ -1989,8 +1989,8 @@ class EigenvalTest(PymatgenTest):
 
         assert np.array(props)[:3, :2].flat == approx([2.8772, 1.2810, 3.6741, 1.6225, 0.7969, 0.3415], abs=1e-4)
         assert props2[0] == approx(np.min(props[1]) - np.max(props[2]), abs=1e-4)
-        assert props[3][0] is True
-        assert props[3][1] is True
+        assert props[3][0]
+        assert props[3][1]
 
 
 class WavederTest(PymatgenTest):

--- a/pymatgen/io/vasp/tests/test_outputs.py
+++ b/pymatgen/io/vasp/tests/test_outputs.py
@@ -101,11 +101,10 @@ class VasprunTest(PymatgenTest):
         with pytest.warns(
             UserWarning,
             match="XML is malformed. Parsing has stopped but partial data is available",
-        ) as warns:
+        ):
             vasp_run = Vasprun(self.TEST_FILES_DIR / "bad_vasprun.xml", exception_on_bad_xml=False)
-            assert len(vasp_run.ionic_steps) == 1
-            assert vasp_run.final_energy == approx(-269.00551374)
-        assert len(warns) == 13
+        assert len(vasp_run.ionic_steps) == 1
+        assert vasp_run.final_energy == approx(-269.00551374)
 
     def test_runtype(self):
         vasp_run = Vasprun(self.TEST_FILES_DIR / "vasprun.GW0.xml")
@@ -290,8 +289,9 @@ class VasprunTest(PymatgenTest):
 
     def test_unconverged(self):
         filepath = self.TEST_FILES_DIR / "vasprun.xml.unconverged"
-        with pytest.warns(UnconvergedVASPWarning, match=f"{filepath} is an unconverged VASP run") as warns:
+        with pytest.warns(UnconvergedVASPWarning) as warns:
             vasprun_unconverged = Vasprun(filepath, parse_potcar_file=False)
+        assert f"{filepath} is an unconverged VASP run" in str(warns[0])
         assert len(warns) == 1
 
         assert vasprun_unconverged.converged_ionic

--- a/pymatgen/io/vasp/tests/test_outputs.py
+++ b/pymatgen/io/vasp/tests/test_outputs.py
@@ -289,9 +289,8 @@ class VasprunTest(PymatgenTest):
 
     def test_unconverged(self):
         filepath = self.TEST_FILES_DIR / "vasprun.xml.unconverged"
-        with pytest.warns(UnconvergedVASPWarning) as warns:
+        with pytest.warns(UnconvergedVASPWarning, match="vasprun.xml.unconverged is an unconverged VASP run") as warns:
             vasprun_unconverged = Vasprun(filepath, parse_potcar_file=False)
-        assert f"{filepath} is an unconverged VASP run" in str(warns[0])
         assert len(warns) == 1
 
         assert vasprun_unconverged.converged_ionic

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -167,14 +167,13 @@ class MITMPRelaxSetTest(PymatgenTest):
     def test_metal_check(self):
         structure = Structure.from_spacegroup("Fm-3m", Lattice.cubic(3), ["Cu"], [[0, 0, 0]])
 
-        with warnings.catch_warnings(record=True) as w:
-            # Cause all warnings to always be triggered.
-            warnings.simplefilter("always")
-            # Trigger a warning.
+        with pytest.warns(
+            BadInputSetWarning,
+            match="Relaxation of likely metal with ISMEAR < 1 detected. See VASP recommendations on ISMEAR for metals.",
+        ) as warns:
             vis = MITRelaxSet(structure)
             _ = vis.incar
-            # Verify some things
-            assert "ISMEAR" in str(w[-1].message)
+        assert len(warns) == 1
 
     def test_poscar(self):
         structure = Structure(self.lattice, ["Fe", "Mn"], self.coords)

--- a/pymatgen/io/vasp/tests/test_sets.py
+++ b/pymatgen/io/vasp/tests/test_sets.py
@@ -382,7 +382,7 @@ class MITMPRelaxSetTest(PymatgenTest):
         # test that van-der-Waals parameters are parsed correctly
         incar = MITRelaxSet(struct, vdw="optB86b").incar
         assert incar["GGA"] == "Mk"
-        assert incar["LUSE_VDW"] is True
+        assert incar["LUSE_VDW"]
         assert incar["PARAM1"] == 0.1234
 
         # Test that NELECT is updated when a charge is present
@@ -1421,7 +1421,7 @@ class MPScanRelaxSetTest(PymatgenTest):
     def test_incar(self):
         incar = self.mp_scan_set.incar
         assert incar["METAGGA"] == "R2scan"
-        assert incar["LASPH"] is True
+        assert incar["LASPH"]
         assert incar["ENAUG"] == 1360
         assert incar["ENCUT"] == 680
         assert incar["NSW"] == 500
@@ -1540,7 +1540,7 @@ class MPScanStaticSetTest(PymatgenTest):
         assert vis.incar["NSW"] == 0
         assert vis.incar["LREAL"] is False
         assert vis.incar["LORBIT"] == 11
-        assert vis.incar["LVHAR"] is True
+        assert vis.incar["LVHAR"]
         assert vis.incar["ISMEAR"] == -5
         # Check that ENCUT and other INCAR settings were inherited.
         assert vis.incar["ENCUT"] == 680
@@ -1552,7 +1552,7 @@ class MPScanStaticSetTest(PymatgenTest):
         assert vis.incar["NSW"] == 0
         assert vis.incar["LREAL"] is False
         assert vis.incar["LORBIT"] == 11
-        assert vis.incar["LVHAR"] is True
+        assert vis.incar["LVHAR"]
         # Check that ENCUT and KSPACING were inherited.
         assert vis.incar["ENCUT"] == 680
         assert vis.incar["METAGGA"] == "R2scan"
@@ -1565,7 +1565,7 @@ class MPScanStaticSetTest(PymatgenTest):
         # check that StaticSet settings were applied
         assert non_prev_vis.incar["NSW"] == 0
         assert non_prev_vis.incar["LREAL"] is False
-        assert non_prev_vis.incar["LVHAR"] is True
+        assert non_prev_vis.incar["LVHAR"]
         assert vis.incar["ISMEAR"] == -5
         # Check that ENCUT and other INCAR settings were inherited.
         assert non_prev_vis.incar["METAGGA"] == "R2scan"
@@ -1604,7 +1604,7 @@ class MPScanStaticSetTest(PymatgenTest):
         assert vis.incar["NSW"] == 0
         assert vis.incar["LREAL"] is False
         assert vis.incar["LORBIT"] == 11
-        assert vis.incar["LVHAR"] is True
+        assert vis.incar["LVHAR"]
         assert vis.incar["ISMEAR"] == -5
         # Check that ENCUT and other INCAR settings were inherited.
         assert vis.incar["ENCUT"] == 680

--- a/pymatgen/symmetry/tests/test_analyzer.py
+++ b/pymatgen/symmetry/tests/test_analyzer.py
@@ -671,11 +671,11 @@ class PointGroupAnalyzerTest(PymatgenTest):
             for i, w in zip(weights, spga.get_kpoint_weights([i[0] for i in ir_mesh])):
                 assert i == approx(w)
 
-        v = Vasprun(os.path.join(PymatgenTest.TEST_FILES_DIR, "vasprun.xml"))
-        spga = SpacegroupAnalyzer(v.final_structure)
-        wts = spga.get_kpoint_weights(v.actual_kpoints)
+        vasp_run = Vasprun(os.path.join(PymatgenTest.TEST_FILES_DIR, "vasprun.xml"))
+        spga = SpacegroupAnalyzer(vasp_run.final_structure)
+        wts = spga.get_kpoint_weights(vasp_run.actual_kpoints)
 
-        for w1, w2 in zip(v.actual_kpoints_weights, wts):
+        for w1, w2 in zip(vasp_run.actual_kpoints_weights, wts):
             assert w1 == approx(w2)
 
         kpts = [[0, 0, 0], [0.15, 0.15, 0.15], [0.2, 0.2, 0.2]]


### PR DESCRIPTION
Reason: more concise + `pytest.warns(match='msg')` encourages testing warning message for added test precision.