### PR TITLE
Read site labels from cif file (2)

### DIFF
--- a/pymatgen/core/sites.py
+++ b/pymatgen/core/sites.py
@@ -467,11 +467,14 @@ class PeriodicSite(Site, MSONable):
         if not isinstance(other, Site):
             return NotImplemented
 
+        self_props = {k: v for k, v in self.properties.items() if k != "label"}
+        other_props = {k: v for k, v in self.properties.items() if k != "label"}
+
         return (
             self.species == other.species
             and self.lattice == other.lattice
             and np.allclose(self.coords, other.coords, atol=Site.position_atol)
-            and self.properties == other.properties
+            and self_props == other_props
         )
 
     def distance_and_image_from_frac_coords(

--- a/pymatgen/core/sites.py
+++ b/pymatgen/core/sites.py
@@ -468,7 +468,7 @@ class PeriodicSite(Site, MSONable):
             return NotImplemented
 
         self_props = {k: v for k, v in self.properties.items() if k != "label"}
-        other_props = {k: v for k, v in self.properties.items() if k != "label"}
+        other_props = {k: v for k, v in other.properties.items() if k != "label"}
 
         return (
             self.species == other.species

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -299,10 +299,7 @@ class SiteCollection(collections.abc.Sequence, metaclass=ABCMeta):
 
     @property
     def site_properties(self) -> dict[str, Sequence]:
-        """
-        Returns the site properties as a dict of sequences. E.g.,
-        {"magmom": (5,-5), "charge": (-4,4)}.
-        """
+        """Returns the site properties as a dict of sequences. E.g. {"magmom": (5,-5), "charge": (-4,4)}."""
         props: dict[str, Sequence] = {}
         prop_keys: set[str] = set()
         for site in self:
@@ -315,7 +312,7 @@ class SiteCollection(collections.abc.Sequence, metaclass=ABCMeta):
     @property
     def labels(self) -> list[str | None]:
         """Return site labels as a list."""
-        return [site.label for site in self.sites]
+        return [site.label for site in self]
 
     def __contains__(self, site: object) -> bool:
         return site in self.sites

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -907,9 +907,7 @@ class IStructure(SiteCollection, MSONable):
             if site_properties:
                 prop = {key: val[idx] for key, val in site_properties.items()}
 
-            label = None
-            if labels:
-                label = labels[idx]
+            label = labels[idx] if labels else None
 
             site = PeriodicSite(
                 specie,

--- a/pymatgen/core/tests/test_sites.py
+++ b/pymatgen/core/tests/test_sites.py
@@ -93,6 +93,7 @@ class PeriodicSiteTest(PymatgenTest):
             self.lattice,
             properties={"magmom": 5.1, "charge": 4.2},
         )
+        self.labeled_site = PeriodicSite("Fe", [0.25, 0.35, 0.45], self.lattice, label="Fe2")
         self.dummy_site = PeriodicSite("X", [0, 0, 0], self.lattice)
 
     def test_properties(self):
@@ -104,9 +105,11 @@ class PeriodicSiteTest(PymatgenTest):
         assert self.site.y == 3.5
         assert self.site.z == 4.5
         assert self.site.is_ordered
+        assert self.site.label is None
         assert not self.site2.is_ordered
         assert self.propertied_site.properties["magmom"] == 5.1
         assert self.propertied_site.properties["charge"] == 4.2
+        assert self.labeled_site.label == "Fe2"
 
     def test_distance(self):
         other_site = PeriodicSite("Fe", np.array([0, 0, 0]), self.lattice)
@@ -159,11 +162,19 @@ class PeriodicSiteTest(PymatgenTest):
         other_site = PeriodicSite("Fe", np.array([1, 1, 1]), self.lattice)
         assert other_site != self.site
 
+    def test_equality_with_label(self):
+        site = PeriodicSite("Fe", [0.25, 0.35, 0.45], self.lattice, label="Fe3")
+        assert site == self.site
+
+        assert self.labeled_site.label != site.label
+        assert self.labeled_site == site
+
     def test_as_from_dict(self):
         d = self.site2.as_dict()
         site = PeriodicSite.from_dict(d)
         assert site == self.site2
         assert site != self.site
+        assert site.label == self.site.label
         d = self.propertied_site.as_dict()
         site3 = PeriodicSite({"Si": 0.5, "Fe": 0.5}, [0, 0, 0], self.lattice)
         d = site3.as_dict()
@@ -209,6 +220,7 @@ class PeriodicSiteTest(PymatgenTest):
 
     def test_repr(self):
         assert repr(self.propertied_site) == "PeriodicSite: Fe2+ (2.5000, 3.5000, 4.5000) [0.2500, 0.3500, 0.4500]"
+        assert repr(self.labeled_site) == "PeriodicSite: Fe2 (Fe) (2.5000, 3.5000, 4.5000) [0.2500, 0.3500, 0.4500]"
 
 
 def get_distance_and_image_old(site1, site2, jimage=None):

--- a/pymatgen/core/tests/test_structure.py
+++ b/pymatgen/core/tests/test_structure.py
@@ -66,6 +66,7 @@ class IStructureTest(PymatgenTest):
         with pytest.raises(StructureError, match="Structure contains sites that are less than 0.01 Angstrom apart"):
             IStructure(self.lattice, ["Si"] * 2, coords, validate_proximity=True)
         self.propertied_structure = IStructure(self.lattice, ["Si"] * 2, coords, site_properties={"magmom": [5, -5]})
+        self.labeled_structure = IStructure(self.lattice, ["Si"] * 2, coords, labels=["Si1", "Si2"])
 
         self.lattice_pbc = Lattice(
             [
@@ -167,6 +168,10 @@ class IStructureTest(PymatgenTest):
         struct = IStructure(self.lattice, [{"O": 1.0}, {"Mg": 0.8}], coords)
         assert struct.composition.formula == "Mg0.8 O1"
         assert not struct.is_ordered
+
+    def test_labeled_structure(self):
+        assert self.labeled_structure.labels == ["Si1", "Si2"]
+        assert self.struct.labels == [None, None]
 
     def test_get_distance(self):
         assert self.struct.get_distance(0, 1) == approx(2.35, abs=1e-2), "Distance calculated wrongly!"

--- a/pymatgen/electronic_structure/tests/test_cohp.py
+++ b/pymatgen/electronic_structure/tests/test_cohp.py
@@ -881,10 +881,18 @@ class CompleteCohpTest(PymatgenTest):
         # The json files are dict representations of the COHPs from the LMTO
         # and LOBSTER calculations and should thus be the same.
 
-        assert self.cohp_lobster.as_dict() == self.cohp_lobster_dict.as_dict()
-        assert self.cohp_orb.as_dict() == self.cohp_orb_dict.as_dict()
+        def is_equal(a, b):
+            a_dict = a.as_dict()
+            b_dict = b.as_dict()
+            del a_dict["structure"]
+            del b_dict["structure"]
+            return (a_dict == b_dict) and (a.structure == b.structure)
+
+        assert is_equal(self.cohp_lobster, self.cohp_lobster_dict)
+        assert is_equal(self.cohp_orb, self.cohp_orb_dict)
         # Lobster 3.0, including f orbitals
-        assert self.cohp_lobster_forb.as_dict() == self.cohp_lobster_forb_dict.as_dict()
+
+        assert is_equal(self.cohp_lobster_forb, self.cohp_lobster_forb_dict)
 
         # Testing the LMTO dicts will be more involved. Since the average
         # is calculated and not read, there may be differences in rounding

--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -1052,14 +1052,15 @@ class CifParser:
             if self.feature_flags["magcif"]:
                 site_properties["magmom"] = all_magmoms
 
-            if any(all_labels):
-                assert len(all_labels) == len(all_species)
-                site_properties["label"] = all_labels
-
             if len(site_properties) == 0:
                 site_properties = None
 
-            struct = Structure(lattice, all_species, all_coords, site_properties=site_properties)
+            if any(all_labels):
+                assert len(all_labels) == len(all_species)
+            else:
+                all_labels = None
+
+            struct = Structure(lattice, all_species, all_coords, site_properties=site_properties, labels=all_labels)
 
             if symmetrized:
                 # Wyckoff labels not currently parsed, note that not all CIFs will contain Wyckoff labels

--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -1054,7 +1054,7 @@ class CifParser:
 
             if any(all_labels):
                 assert len(all_labels) == len(all_species)
-                site_properties["labels"] = all_labels
+                site_properties["label"] = all_labels
 
             if len(site_properties) == 0:
                 site_properties = None

--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -909,12 +909,12 @@ class CifParser:
                     return keys[inds[0]]
             return False
 
-        for i, label in enumerate(data["_atom_site_label"]):
+        for idx, label in enumerate(data["_atom_site_label"]):
             try:
                 # If site type symbol exists, use it. Otherwise, we use the
                 # label.
-                symbol = self._parse_symbol(data["_atom_site_type_symbol"][i])
-                num_h = get_num_implicit_hydrogens(data["_atom_site_type_symbol"][i])
+                symbol = self._parse_symbol(data["_atom_site_type_symbol"][idx])
+                num_h = get_num_implicit_hydrogens(data["_atom_site_type_symbol"][idx])
             except KeyError:
                 symbol = self._parse_symbol(label)
                 num_h = get_num_implicit_hydrogens(label)
@@ -925,7 +925,7 @@ class CifParser:
                 o_s = oxi_states.get(symbol, 0)
                 # use _atom_site_type_symbol if possible for oxidation state
                 if "_atom_site_type_symbol" in data.data:
-                    oxi_symbol = data["_atom_site_type_symbol"][i]
+                    oxi_symbol = data["_atom_site_type_symbol"][idx]
                     o_s = oxi_states.get(oxi_symbol, o_s)
                 try:
                     el = Species(symbol, o_s)
@@ -934,13 +934,13 @@ class CifParser:
             else:
                 el = get_el_sp(symbol)
 
-            x = str2float(data["_atom_site_fract_x"][i])
-            y = str2float(data["_atom_site_fract_y"][i])
-            z = str2float(data["_atom_site_fract_z"][i])
+            x = str2float(data["_atom_site_fract_x"][idx])
+            y = str2float(data["_atom_site_fract_y"][idx])
+            z = str2float(data["_atom_site_fract_z"][idx])
             magmom = magmoms.get(label, np.array([0, 0, 0]))
 
             try:
-                occu = str2float(data["_atom_site_occupancy"][i])
+                occu = str2float(data["_atom_site_occupancy"][idx])
             except (KeyError, ValueError):
                 occu = 1
 
@@ -1038,10 +1038,10 @@ class CifParser:
                 all_labels.extend(len(coords) * [labels[tmp_coords[0]]])
 
             # rescale occupancies if necessary
-            for i, species in enumerate(all_species):
+            for idx, species in enumerate(all_species):
                 total_occu = sum(species.values())
                 if 1 < total_occu <= self._occupancy_tolerance:
-                    all_species[i] = species / total_occu
+                    all_species[idx] = species / total_occu
 
         if all_species and len(all_species) == len(all_coords) and len(all_species) == len(all_magmoms):
             site_properties = {}

--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -895,7 +895,6 @@ class CifParser:
 
         coord_to_species = {}
         coord_to_magmoms = {}
-        labels = {}
 
         def get_matching_coord(coord):
             keys = list(coord_to_species)
@@ -909,15 +908,15 @@ class CifParser:
                     return keys[inds[0]]
             return False
 
-        for i, label in enumerate(data["_atom_site_label"]):
+        for i in range(len(data["_atom_site_label"])):
             try:
                 # If site type symbol exists, use it. Otherwise, we use the
                 # label.
                 symbol = self._parse_symbol(data["_atom_site_type_symbol"][i])
                 num_h = get_num_implicit_hydrogens(data["_atom_site_type_symbol"][i])
             except KeyError:
-                symbol = self._parse_symbol(label)
-                num_h = get_num_implicit_hydrogens(label)
+                symbol = self._parse_symbol(data["_atom_site_label"][i])
+                num_h = get_num_implicit_hydrogens(data["_atom_site_label"][i])
             if not symbol:
                 continue
 
@@ -937,7 +936,7 @@ class CifParser:
             x = str2float(data["_atom_site_fract_x"][i])
             y = str2float(data["_atom_site_fract_y"][i])
             z = str2float(data["_atom_site_fract_z"][i])
-            magmom = magmoms.get(label, np.array([0, 0, 0]))
+            magmom = magmoms.get(data["_atom_site_label"][i], np.array([0, 0, 0]))
 
             try:
                 occu = str2float(data["_atom_site_occupancy"][i])
@@ -956,16 +955,13 @@ class CifParser:
                         "in calculations unless hydrogens added."
                     )
                 comp = Composition(comp_d)
-
                 if not match:
                     coord_to_species[coord] = comp
                     coord_to_magmoms[coord] = magmom
-                    labels[coord] = label
                 else:
                     coord_to_species[match] += comp
                     # disordered magnetic not currently supported
                     coord_to_magmoms[match] = None
-                    labels[match] = label
 
         sum_occu = [
             sum(c.values()) for c in coord_to_species.values() if set(c.elements) != {Element("O"), Element("H")}
@@ -984,7 +980,6 @@ class CifParser:
         all_magmoms = []
         all_hydrogens = []
         equivalent_indices = []
-        all_labels = []
 
         # check to see if magCIF file is disordered
         if self.feature_flags["magcif"]:
@@ -1035,7 +1030,6 @@ class CifParser:
                 all_coords.extend(coords)
                 all_species.extend(len(coords) * [species])
                 all_magmoms.extend(magmoms)
-                all_labels.extend(len(coords) * [labels[tmp_coords[0]]])
 
             # rescale occupancies if necessary
             for i, species in enumerate(all_species):
@@ -1051,10 +1045,6 @@ class CifParser:
 
             if self.feature_flags["magcif"]:
                 site_properties["magmom"] = all_magmoms
-
-            if any(all_labels):
-                assert len(all_labels) == len(all_species)
-                site_properties["labels"] = all_labels
 
             if len(site_properties) == 0:
                 site_properties = None

--- a/pymatgen/io/lobster/tests/test_lobster.py
+++ b/pymatgen/io/lobster/tests/test_lobster.py
@@ -745,7 +745,8 @@ class DoscarTest(unittest.TestCase):
         assert tdos_nonspin == self.DOSCAR_nonspin_pol.completedos.densities[Spin.up].tolist()
 
         assert fermi == approx(self.DOSCAR_nonspin_pol.completedos.efermi)
-        assert self.DOSCAR_nonspin_pol.completedos.structure.as_dict() == self.structure.as_dict()
+
+        assert self.DOSCAR_nonspin_pol.completedos.structure == self.structure
 
         assert self.DOSCAR_nonspin_pol.completedos.pdos[self.structure[0]]["2s"][Spin.up].tolist() == PDOS_F_2s
         assert self.DOSCAR_nonspin_pol.completedos.pdos[self.structure[0]]["2p_y"][Spin.up].tolist() == PDOS_F_2py

--- a/pymatgen/io/tests/test_cif.py
+++ b/pymatgen/io/tests/test_cif.py
@@ -318,11 +318,11 @@ loop_
 
     def test_site_labels(self):
         parser = CifParser(f"{self.TEST_FILES_DIR}/garnet.cif")
-        s = parser.get_structures()[0]
+        struct = parser.get_structures()[0]
 
-        assert "labels" in s.site_properties
+        assert "labels" in struct.site_properties
 
-        for label, specie in zip(s.site_properties["labels"], s.species):
+        for label, specie in zip(struct.site_properties["labels"], struct.species):
             assert label.startswith(specie.name)
 
     def test_CifParserSpringerPauling(self):

--- a/pymatgen/io/tests/test_cif.py
+++ b/pymatgen/io/tests/test_cif.py
@@ -321,6 +321,10 @@ loop_
         struct = parser.get_structures()[0]
 
         assert "labels" in struct.site_properties
+        assert (
+            len(struct.site_properties["labels"]) == len(struct) == 80
+        ), "Mismatch between number of labels and sites."
+        assert len(set(struct.site_properties["labels"])) == 4, "Expecting only 4 unique labels"
 
         for label, specie in zip(struct.site_properties["labels"], struct.species):
             assert label.startswith(specie.name)

--- a/pymatgen/io/tests/test_cif.py
+++ b/pymatgen/io/tests/test_cif.py
@@ -316,6 +316,15 @@ loop_
             "in calculations unless hydrogens added." in parser.warnings
         )
 
+    def test_site_labels(self):
+        parser = CifParser(f"{self.TEST_FILES_DIR}/garnet.cif")
+        s = parser.get_structures()[0]
+
+        assert "labels" in s.site_properties
+
+        for label, specie in zip(s.site_properties["labels"], s.species):
+            assert label.startswith(specie.name)
+
     def test_CifParserSpringerPauling(self):
         # Below are 10 tests for CIFs from the Springer Materials/Pauling file DBs.
 

--- a/pymatgen/io/tests/test_cif.py
+++ b/pymatgen/io/tests/test_cif.py
@@ -324,7 +324,7 @@ loop_
         assert len(struct.labels) == len(struct) == 80, "Mismatch between number of labels and sites."
         assert len(set(struct.labels)) == 4, "Expecting only 4 unique labels"
 
-        for site in struct.sites:
+        for site in struct:
             assert site.label.startswith(site.specie.name)
 
     def test_cif_parser_springer_pauling(self):

--- a/pymatgen/io/tests/test_cif.py
+++ b/pymatgen/io/tests/test_cif.py
@@ -316,19 +316,6 @@ loop_
             "in calculations unless hydrogens added." in parser.warnings
         )
 
-    def test_site_labels(self):
-        parser = CifParser(f"{self.TEST_FILES_DIR}/garnet.cif")
-        struct = parser.get_structures()[0]
-
-        assert "labels" in struct.site_properties
-        assert (
-            len(struct.site_properties["labels"]) == len(struct) == 80
-        ), "Mismatch between number of labels and sites."
-        assert len(set(struct.site_properties["labels"])) == 4, "Expecting only 4 unique labels"
-
-        for label, specie in zip(struct.site_properties["labels"], struct.species):
-            assert label.startswith(specie.name)
-
     def test_CifParserSpringerPauling(self):
         # Below are 10 tests for CIFs from the Springer Materials/Pauling file DBs.
 

--- a/pymatgen/io/tests/test_cif.py
+++ b/pymatgen/io/tests/test_cif.py
@@ -318,14 +318,14 @@ loop_
 
     def test_site_labels(self):
         parser = CifParser(f"{self.TEST_FILES_DIR}/garnet.cif")
-        struct = parser.get_structures()[0]
+        struct = parser.get_structures(primitive=True)[0]
 
-        assert "label" in struct.site_properties
-        assert len(struct.site_properties["label"]) == len(struct) == 80, "Mismatch between number of labels and sites."
-        assert len(set(struct.site_properties["label"])) == 4, "Expecting only 4 unique labels"
+        assert struct.labels
+        assert len(struct.labels) == len(struct) == 80, "Mismatch between number of labels and sites."
+        assert len(set(struct.labels)) == 4, "Expecting only 4 unique labels"
 
-        for label, specie in zip(struct.site_properties["label"], struct.species):
-            assert label.startswith(specie.name)
+        for site in struct.sites:
+            assert site.label.startswith(site.specie.name)
 
     def test_CifParserSpringerPauling(self):
         # Below are 10 tests for CIFs from the Springer Materials/Pauling file DBs.

--- a/pymatgen/io/tests/test_cif.py
+++ b/pymatgen/io/tests/test_cif.py
@@ -320,11 +320,17 @@ loop_
         parser = CifParser(f"{self.TEST_FILES_DIR}/garnet.cif")
         struct = parser.get_structures(primitive=True)[0]
 
-        assert struct.labels
-        assert len(struct.labels) == len(struct) == 80, "Mismatch between number of labels and sites."
-        assert len(set(struct.labels)) == 4, "Expecting only 4 unique labels"
+        # ensure structure has correct number of labels
+        assert len(struct.labels) == len(struct)
 
-        for site in struct:
+        # ensure the labels are unique and match the expected site names
+        expected_site_names = {"Al1", "Ca1", "O1", "Si1"}
+        assert {*struct.labels} == expected_site_names
+
+        # check label of each site
+        for site, label in zip(struct, struct.labels):
+            assert site.label == label
+            # Ensure the site label starts with the site species name
             assert site.label.startswith(site.specie.name)
 
     def test_cif_parser_springer_pauling(self):

--- a/pymatgen/io/tests/test_cif.py
+++ b/pymatgen/io/tests/test_cif.py
@@ -320,13 +320,11 @@ loop_
         parser = CifParser(f"{self.TEST_FILES_DIR}/garnet.cif")
         struct = parser.get_structures()[0]
 
-        assert "labels" in struct.site_properties
-        assert (
-            len(struct.site_properties["labels"]) == len(struct) == 80
-        ), "Mismatch between number of labels and sites."
-        assert len(set(struct.site_properties["labels"])) == 4, "Expecting only 4 unique labels"
+        assert "label" in struct.site_properties
+        assert len(struct.site_properties["label"]) == len(struct) == 80, "Mismatch between number of labels and sites."
+        assert len(set(struct.site_properties["label"])) == 4, "Expecting only 4 unique labels"
 
-        for label, specie in zip(struct.site_properties["labels"], struct.species):
+        for label, specie in zip(struct.site_properties["label"], struct.species):
             assert label.startswith(specie.name)
 
     def test_CifParserSpringerPauling(self):


### PR DESCRIPTION
## Summary

This PR follows up from #3136 which was reverted because of CI test failures, see https://github.com/materialsproject/pymatgen/pull/3136#issuecomment-1624198814 . This PR addresses these issues.

Major changes:

- feature 1: Read site labels from cif file and store these under `Structure.site_properties`.

Closes #3135

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [x] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```