### PR TITLE
Rename `PMG_DISABLE_POTCAR_CHECKS` to `PMG_POTCAR_CHECKS`

### DIFF
--- a/docs_rst/usage.rst
+++ b/docs_rst/usage.rst
@@ -609,8 +609,8 @@ to add your desired values to the `.pmgrc.yaml` file.
      - Specifies the API Key to be used for MPRester.
    * - PMG_VASP_PSP_DIR
      - Specifies the path in which to look for VASP pseudopotential files.
-   * - PMG_DISABLE_POTCAR_CHECKS
-     - A system-wide setting to disable all POTCAR checks. This includes the compatibility checks as well as checking
+   * - PMG_POTCAR_CHECKS
+     - A system-wide setting that if false, disables all POTCAR checks. This includes the compatibility checks as well as checking
        for the existence of POTCARS when performing VASP io.
    * - PMG_DEFAULT_FUNCTIONAL
      - Sets the default functional to be used for VASP input files. Defaults to PBE.

--- a/pymatgen/cli/pmg_config.py
+++ b/pymatgen/cli/pmg_config.py
@@ -260,27 +260,28 @@ def install_software(install: Literal["enumlib", "bader"]):
 
 def add_config_var(tokens: list[str], backup_suffix: str) -> None:
     """Add/update keys in .pmgrc.yaml config file."""
-    if os.path.exists(SETTINGS_FILE):
-        # read and write new config file if exists
-        fpath = SETTINGS_FILE
-    elif os.path.exists(OLD_SETTINGS_FILE):
-        # else use old config file if exists
-        fpath = OLD_SETTINGS_FILE
-    else:
-        # if neither exists, create new config file
-        fpath = SETTINGS_FILE
-    dct = {}
-    if os.path.exists(fpath):
-        if backup_suffix:
-            shutil.copy(fpath, fpath + backup_suffix)
-            print(f"Existing {fpath} backed up to {fpath}{backup_suffix}")
-        dct = loadfn(fpath)
     if len(tokens) % 2 != 0:
         raise ValueError(f"Uneven number {len(tokens)} of tokens passed to pmg config. Needs a value for every key.")
+    if os.path.exists(SETTINGS_FILE):
+        # read and write new config file if exists
+        rc_path = SETTINGS_FILE
+    elif os.path.exists(OLD_SETTINGS_FILE):
+        # else use old config file if exists
+        rc_path = OLD_SETTINGS_FILE
+    else:
+        # if neither exists, create new config file
+        rc_path = SETTINGS_FILE
+    dct = {}
+    if os.path.exists(rc_path):
+        if backup_suffix:
+            shutil.copy(rc_path, rc_path + backup_suffix)
+            print(f"Existing {rc_path} backed up to {rc_path}{backup_suffix}")
+        dct = loadfn(rc_path)
+    special_vals = {"true": True, "false": False, "none": None, "null": None}
     for key, val in zip(tokens[0::2], tokens[1::2]):
-        dct[key] = val
-    dumpfn(dct, fpath)
-    print(f"New {fpath} written!")
+        dct[key] = special_vals.get(val.lower(), val)
+    dumpfn(dct, rc_path)
+    print(f"New {rc_path} written!")
 
 
 def configure_pmg(args: Namespace):

--- a/pymatgen/entries/compatibility.py
+++ b/pymatgen/entries/compatibility.py
@@ -157,7 +157,7 @@ class PotcarCorrection(Correction):
         Returns:
             ufloat: 0.0 +/- 0.0 (from uncertainties package)
         """
-        if SETTINGS.get("PMG_DISABLE_POTCAR_CHECKS", False) or not self.check_potcar:
+        if not SETTINGS.get("PMG_POTCAR_CHECKS") or not self.check_potcar:
             return ufloat(0.0, 0.0)
 
         potcar_spec = entry.parameters.get("potcar_spec")

--- a/pymatgen/entries/compatibility.py
+++ b/pymatgen/entries/compatibility.py
@@ -158,7 +158,7 @@ class PotcarCorrection(Correction):
         Returns:
             ufloat: 0.0 +/- 0.0 (from uncertainties package)
         """
-        if not SETTINGS.get("PMG_POTCAR_CHECKS") or not self.check_potcar:
+        if SETTINGS.get("PMG_POTCAR_CHECKS") is False or not self.check_potcar:
             return ufloat(0.0, 0.0)
 
         potcar_spec = entry.parameters.get("potcar_spec")

--- a/pymatgen/entries/compatibility.py
+++ b/pymatgen/entries/compatibility.py
@@ -124,7 +124,8 @@ class PotcarCorrection(Correction):
         Args:
             input_set (InputSet): object used to generate the runs (used to check
                 for correct potcar symbols).
-            check_potcar (bool): If False, bypass the POTCAR check altogether. Defaults to True
+            check_potcar (bool): If False, bypass the POTCAR check altogether. Defaults to True.
+                Can also be disabled globally by running `pmg config --add PMG_POTCAR_CHECKS false`.
             check_hash (bool): If True, uses the potcar hash to check for valid
                 potcars. If false, uses the potcar symbol (less reliable). Defaults to False.
 
@@ -869,18 +870,16 @@ class MaterialsProject2020Compatibility(Compatibility):
                 entry.parameters["hubbards"] = {"Fe": 5.3}. If the "hubbards" key
                 is missing, a GGA run is assumed. Entries obtained from the
                 MaterialsProject database will automatically have these fields
-                populated.
-
-                (Default: "Advanced")
+                populated. Default: "Advanced"
             correct_peroxide: Specify whether peroxide/superoxide/ozonide
                 corrections are to be applied or not. If false, all oxygen-containing
-                compounds are assigned the 'oxide' correction. (Default: True)
-            check_potcar (bool): Check that the POTCARs used in the calculation
-                are consistent with the Materials Project parameters. False bypasses this
-                check altogether. (Default: True)
+                compounds are assigned the 'oxide' correction. Default: True
+            check_potcar (bool): Check that the POTCARs used in the calculation are consistent
+                with the Materials Project parameters. False bypasses this check altogether. Default: True
+                Can also be disabled globally by running `pmg config --add PMG_POTCAR_CHECKS false`.
             check_potcar_hash (bool): Use potcar hash to verify POTCAR settings are
                 consistent with MPRelaxSet. If False, only the POTCAR symbols will
-                be used. (Default: False)
+                be used. Default: False
             config_file (Path): Path to the selected compatibility.yaml config file.
                 If None, defaults to `MP2020Compatibility.yaml` distributed with
                 pymatgen.

--- a/pymatgen/entries/mixing_scheme.py
+++ b/pymatgen/entries/mixing_scheme.py
@@ -94,11 +94,11 @@ class MaterialsProjectDFTMixingScheme(Compatibility):
                 space group are all identical. If there are multiple materials of run_type_2
                 that satisfy these criteria, the one with lowest energy is considered to
                 match.
-            check_potcar: Whether to perform additional checks to ensure that the POTCARs
-                used for the run_type_1 and run_type_2 calculations are the same. This is
-                useful for ensuring that the mixing scheme is not used on calculations that
-                used different POTCARs, which can lead to unphysical results. Defaults to True.
+            check_potcar: Whether to ensure the POTCARs used for the run_type_1 and run_type_2 calculations
+                are the same. This is useful for ensuring that the mixing scheme is not used on calculations
+                that used different POTCARs, which can lead to unphysical results. Defaults to True.
                 Has no effect if neither compat_1 nor compat_2 have a check_potcar attribute.
+                Can also be disabled globally by running `pmg config --add PMG_POTCAR_CHECKS false`.
         """
         self.name = "MP DFT mixing scheme"
         self.structure_matcher = structure_matcher or StructureMatcher()

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -249,7 +249,7 @@ class Poscar(MSONable):
         """
         dirname = os.path.dirname(os.path.abspath(filename))
         names = None
-        if check_for_POTCAR and (not SETTINGS.get("PMG_DISABLE_POTCAR_CHECKS", False)):
+        if check_for_POTCAR and (not SETTINGS.get("PMG_POTCAR_CHECKS", False)):
             potcars = glob(os.path.join(dirname, "*POTCAR*"))
             if potcars:
                 try:

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -249,7 +249,7 @@ class Poscar(MSONable):
         """
         dirname = os.path.dirname(os.path.abspath(filename))
         names = None
-        if check_for_POTCAR and (not SETTINGS.get("PMG_POTCAR_CHECKS", False)):
+        if check_for_POTCAR and SETTINGS.get("PMG_POTCAR_CHECKS") is not False:
             potcars = glob(os.path.join(dirname, "*POTCAR*"))
             if potcars:
                 try:


### PR DESCRIPTION
Closes #3152

90a7c076d rename `PMG_DISABLE_POTCAR_CHECKS` to `PMG_POTCAR_CHECKS`
0729fc3f9 fix setting `bool` and `None` through `pmg` config CLI
0ef9ae7d2 document existence of `PMG_POTCAR_CHECKS` in all doc strings for `check_potcar: bool = True`