### PR TITLE
Bug fix: `CollinearMagneticAnalyzer` should not fail when `Species.spin = None`

### DIFF
--- a/pymatgen/analysis/magnetism/analyzer.py
+++ b/pymatgen/analysis/magnetism/analyzer.py
@@ -21,10 +21,8 @@ from pymatgen.core.structure import DummySpecies, Element, Species, Structure
 from pymatgen.electronic_structure.core import Magmom
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.symmetry.groups import SpaceGroup
-from pymatgen.transformations.advanced_transformations import (
-    MagOrderingTransformation, MagOrderParameterConstraint)
-from pymatgen.transformations.standard_transformations import \
-    AutoOxiStateDecorationTransformation
+from pymatgen.transformations.advanced_transformations import MagOrderingTransformation, MagOrderParameterConstraint
+from pymatgen.transformations.standard_transformations import AutoOxiStateDecorationTransformation
 from pymatgen.util.due import Doi, due
 
 if TYPE_CHECKING:
@@ -189,7 +187,7 @@ class CollinearMagneticStructureAnalyzer:
                 )
             magmoms = [m or 0 for m in structure.site_properties["magmom"]]
         elif has_spin:
-            magmoms = [getattr(sp, "spin") or 0 for sp in structure.species]
+            magmoms = [sp.spin or 0 for sp in structure.species]
             structure.remove_spin()
         else:
             # no magmoms present, add zero magmoms for now

--- a/pymatgen/analysis/magnetism/analyzer.py
+++ b/pymatgen/analysis/magnetism/analyzer.py
@@ -21,8 +21,10 @@ from pymatgen.core.structure import DummySpecies, Element, Species, Structure
 from pymatgen.electronic_structure.core import Magmom
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.symmetry.groups import SpaceGroup
-from pymatgen.transformations.advanced_transformations import MagOrderingTransformation, MagOrderParameterConstraint
-from pymatgen.transformations.standard_transformations import AutoOxiStateDecorationTransformation
+from pymatgen.transformations.advanced_transformations import (
+    MagOrderingTransformation, MagOrderParameterConstraint)
+from pymatgen.transformations.standard_transformations import \
+    AutoOxiStateDecorationTransformation
 from pymatgen.util.due import Doi, due
 
 if TYPE_CHECKING:
@@ -187,7 +189,7 @@ class CollinearMagneticStructureAnalyzer:
                 )
             magmoms = [m or 0 for m in structure.site_properties["magmom"]]
         elif has_spin:
-            magmoms = [getattr(sp, "spin", 0) for sp in structure.species]
+            magmoms = [getattr(sp, "spin") or 0 for sp in structure.species]
             structure.remove_spin()
         else:
             # no magmoms present, add zero magmoms for now

--- a/pymatgen/analysis/magnetism/tests/test_analyzer.py
+++ b/pymatgen/analysis/magnetism/tests/test_analyzer.py
@@ -10,9 +10,12 @@ import pytest
 from monty.serialization import loadfn
 from pytest import approx
 
-from pymatgen.analysis.magnetism import (CollinearMagneticStructureAnalyzer,
-                                         MagneticStructureEnumerator, Ordering,
-                                         magnetic_deformation)
+from pymatgen.analysis.magnetism import (
+    CollinearMagneticStructureAnalyzer,
+    MagneticStructureEnumerator,
+    Ordering,
+    magnetic_deformation,
+)
 from pymatgen.core import Element, Lattice, Species, Structure
 from pymatgen.io.cif import CifParser
 from pymatgen.util.testing import PymatgenTest
@@ -244,7 +247,8 @@ Magmoms Sites
         struct = Structure(latt, species, coords)
 
         msa = CollinearMagneticStructureAnalyzer(struct, round_magmoms=0.001, make_primitive=False)
-        assert msa.structure.site_properties['magmom'] == [-5, 5, 0, 0]
+        assert msa.structure.site_properties["magmom"] == [-5, 5, 0, 0]
+
 
 class MagneticStructureEnumeratorTest(unittest.TestCase):
     @unittest.skipIf(not enumlib_present, "enumlib not present")


### PR DESCRIPTION
## Summary

Fixes bug briefly mentioned in #3070, where recent spin property changes resulted in the `MagneticStructureEnumerator` failing. This is apparently due to creating structures where only some `Species.spin` properties are defined, causing `CollinearMagneticStructureEnumerator` to fail. For example, if you input this structure into the analyzer right now, it would fail:
```
Structure Summary
Lattice
    abc : 2.948635277547903 2.948635277547903 5.107186113702927
 angles : 73.22134511903964 90.0 120.00000000000001
 volume : 36.2558565
      A : 2.085 2.085 0.0
      B : 0.0 -2.085 -2.085
      C : -2.085 2.085 -4.17
    pbc : True True True
PeriodicSite: Ni,spin=-5 (0.0000, 2.0850, -2.0850) [0.5000, 0.0000, 0.5000]
PeriodicSite: Ni,spin=5 (0.0000, 0.0000, 0.0000) [0.0000, 0.0000, 0.0000]
PeriodicSite: O (0.0000, 0.0000, -2.0850) [0.2500, 0.5000, 0.2500]
PeriodicSite: O (0.0000, 2.0850, -4.1700) [0.7500, 0.5000, 0.7500]
```

and yield this error:

```python
/Users/mcdermott/code/github/pymatgen/pymatgen/analysis/magnetism/analyzer.py:205: UserWarning: This class is not designed to be used with non-collinear structures. If your structure is only slightly non-collinear (e.g. canted) may still give useful results, but use with caution.
  warnings.warn(
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[5], line 8
      5 coords = [[0.5, 0, 0.5], [0, 0, 0], [0.25, 0.5, 0.25], [0.75, 0.5, 0.75]]
      6 struct = Structure(latt, species, coords)
----> 8 msa = CollinearMagneticStructureAnalyzer(struct, round_magmoms=0.001, make_primitive=False)

File ~/code/github/pymatgen/pymatgen/analysis/magnetism/analyzer.py:214, in CollinearMagneticStructureAnalyzer.__init__(self, structure, overwrite_magmom_mode, round_magmoms, detect_valences, make_primitive, default_magmoms, set_net_positive, threshold, threshold_nonmag)
    205     warnings.warn(
    206         "This class is not designed to be used with "
    207         "non-collinear structures. If your structure is "
    208         "only slightly non-collinear (e.g. canted) may still "
    209         "give useful results, but use with caution."
    210     )
    212 # this is for collinear structures only, make sure magmoms
    213 # are all floats
--> 214 magmoms = list(map(float, magmoms))
    216 # set properties that should be done /before/ we process input magmoms
    217 self.total_magmoms = sum(magmoms)

TypeError: float() argument must be a string or a real number, not 'NoneType'
```

## Fix:
This was fixed by changing one line of code. https://github.com/materialsproject/pymatgen/commit/d8f395670c77bb626773dc9e5e8c62988f1a66cc 

A test was added for this example structure that would fail with the old line.

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [x] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))
