### PR TITLE
Fix issues with labels

### DIFF
--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -84,7 +84,7 @@ class Neighbor(Site):
         self.properties = properties or {}
         self.nn_distance = nn_distance
         self.index = index
-        self.label = label if label else self.species_string
+        self.label = label if label is not None else self.species_string
 
     def __len__(self) -> Literal[3]:
         """Make neighbor Tuple-like to retain backwards compatibility."""
@@ -157,7 +157,7 @@ class PeriodicNeighbor(PeriodicSite):
         self.nn_distance = nn_distance
         self.index = index
         self.image = image
-        self.label = label if label else self.species_string
+        self.label = label if label is not None else self.species_string
 
     @property  # type: ignore
     def coords(self) -> np.ndarray:  # type: ignore

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -69,6 +69,7 @@ class Neighbor(Site):
         properties: dict | None = None,
         nn_distance: float = 0.0,
         index: int = 0,
+        label: str | None = None,
     ):
         """
         :param species: Same as Site
@@ -76,12 +77,14 @@ class Neighbor(Site):
         :param properties: Same as Site
         :param nn_distance: Distance to some other Site.
         :param index: Index within structure.
+        :param label: Label for the site. Defaults to None.
         """
         self.coords = coords
         self._species = species
         self.properties = properties or {}
         self.nn_distance = nn_distance
         self.index = index
+        self.label = label
 
     def __len__(self) -> Literal[3]:
         """Make neighbor Tuple-like to retain backwards compatibility."""
@@ -134,6 +137,7 @@ class PeriodicNeighbor(PeriodicSite):
         nn_distance: float = 0.0,
         index: int = 0,
         image: tuple = (0, 0, 0),
+        label: str | None = None,
     ):
         """
         Args:
@@ -144,6 +148,7 @@ class PeriodicNeighbor(PeriodicSite):
             nn_distance (float, optional): Distance to some other Site.. Defaults to 0.0.
             index (int, optional): Index within structure.. Defaults to 0.
             image (tuple, optional): PeriodicImage. Defaults to (0, 0, 0).
+            label (str, optional): Label for the site. Defaults to None.
         """
         self._lattice = lattice
         self._frac_coords = coords
@@ -152,6 +157,7 @@ class PeriodicNeighbor(PeriodicSite):
         self.nn_distance = nn_distance
         self.index = index
         self.image = image
+        self.label = label
 
     @property  # type: ignore
     def coords(self) -> np.ndarray:  # type: ignore

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -84,7 +84,7 @@ class Neighbor(Site):
         self.properties = properties or {}
         self.nn_distance = nn_distance
         self.index = index
-        self.label = label
+        self.label = label if label else self.species_string
 
     def __len__(self) -> Literal[3]:
         """Make neighbor Tuple-like to retain backwards compatibility."""
@@ -157,7 +157,7 @@ class PeriodicNeighbor(PeriodicSite):
         self.nn_distance = nn_distance
         self.index = index
         self.image = image
-        self.label = label
+        self.label = label if label else self.species_string
 
     @property  # type: ignore
     def coords(self) -> np.ndarray:  # type: ignore
@@ -316,7 +316,7 @@ class SiteCollection(collections.abc.Sequence, metaclass=ABCMeta):
         return props
 
     @property
-    def labels(self) -> list[str | None]:
+    def labels(self) -> list[str]:
         """Return site labels as a list."""
         return [site.label for site in self]
 
@@ -2880,7 +2880,7 @@ class IMolecule(SiteCollection, MSONable):
         spin_multiplicity: int | None = None,
         validate_proximity: bool = False,
         site_properties: dict | None = None,
-        labels: list[str | None] | None = None,
+        labels: Sequence[str | None] | None = None,
         charge_spin_check: bool = True,
     ) -> None:
         """
@@ -4298,7 +4298,7 @@ class Molecule(IMolecule, collections.abc.MutableSequence):
         spin_multiplicity: int | None = None,
         validate_proximity: bool = False,
         site_properties: dict | None = None,
-        labels: list[str | None] | None = None,
+        labels: Sequence[str | None] | None = None,
         charge_spin_check: bool = True,
     ) -> None:
         """

--- a/pymatgen/core/tests/test_sites.py
+++ b/pymatgen/core/tests/test_sites.py
@@ -36,33 +36,34 @@ class SiteTest(PymatgenTest):
         assert self.propertied_site.properties["charge"] == 4.2
 
     def test_to_from_dict(self):
-        d = self.disordered_site.as_dict()
-        site = Site.from_dict(d)
+        dct = self.disordered_site.as_dict()
+        site = Site.from_dict(dct)
         assert site == self.disordered_site
         assert site != self.ordered_site
-        d = self.propertied_site.as_dict()
-        site = Site.from_dict(d)
+        dct = self.propertied_site.as_dict()
+        site = Site.from_dict(dct)
         assert site.properties["magmom"] == 5.1
         assert site.properties["charge"] == 4.2
-        d = self.propertied_magmom_vec_site.as_dict()
-        site = Site.from_dict(d)
+        dct = self.propertied_magmom_vec_site.as_dict()
+        site = Site.from_dict(dct)
         assert site.properties["magmom"] == Magmom([2.6, 2.6, 3.5])
         assert site.properties["charge"] == 4.2
-        d = self.dummy_site.as_dict()
-        site = Site.from_dict(d)
+        dct = self.dummy_site.as_dict()
+        site = Site.from_dict(dct)
         assert site.species == self.dummy_site.species
 
     def test_hash(self):
         assert hash(self.ordered_site) == 26
         assert hash(self.disordered_site) == 51
 
-    def test_cmp(self):
+    def test_gt_lt(self):
         assert self.ordered_site > self.disordered_site
+        assert self.disordered_site < self.ordered_site
 
     def test_distance(self):
-        osite = self.ordered_site
-        assert np.linalg.norm([0.25, 0.35, 0.45]) == osite.distance_from_point([0, 0, 0])
-        assert osite.distance(self.disordered_site) == 0
+        ord_site = self.ordered_site
+        assert np.linalg.norm([0.25, 0.35, 0.45]) == ord_site.distance_from_point([0, 0, 0])
+        assert ord_site.distance(self.disordered_site) == 0
 
     def test_pickle(self):
         o = pickle.dumps(self.propertied_site)
@@ -170,21 +171,21 @@ class PeriodicSiteTest(PymatgenTest):
         assert self.labeled_site == site
 
     def test_as_from_dict(self):
-        d = self.site2.as_dict()
-        site = PeriodicSite.from_dict(d)
+        dct = self.site2.as_dict()
+        site = PeriodicSite.from_dict(dct)
         assert site == self.site2
         assert site != self.site
         assert site.label == self.site2.label
 
-        d = self.propertied_site.as_dict()
+        dct = self.propertied_site.as_dict()
         site3 = PeriodicSite({"Si": 0.5, "Fe": 0.5}, [0, 0, 0], self.lattice)
-        d = site3.as_dict()
-        site = PeriodicSite.from_dict(d)
+        dct = site3.as_dict()
+        site = PeriodicSite.from_dict(dct)
         assert site.species == site3.species
         assert site.label == site3.label
 
-        d = self.dummy_site.as_dict()
-        site = PeriodicSite.from_dict(d)
+        dct = self.dummy_site.as_dict()
+        site = PeriodicSite.from_dict(dct)
         assert site.species == self.dummy_site.species
         assert site.label == self.dummy_site.label
 

--- a/pymatgen/core/tests/test_sites.py
+++ b/pymatgen/core/tests/test_sites.py
@@ -105,7 +105,7 @@ class PeriodicSiteTest(PymatgenTest):
         assert self.site.y == 3.5
         assert self.site.z == 4.5
         assert self.site.is_ordered
-        assert self.site.label is None
+        assert self.site.label == "Fe"
         assert not self.site2.is_ordered
         assert self.propertied_site.properties["magmom"] == 5.1
         assert self.propertied_site.properties["charge"] == 4.2
@@ -174,16 +174,19 @@ class PeriodicSiteTest(PymatgenTest):
         site = PeriodicSite.from_dict(d)
         assert site == self.site2
         assert site != self.site
-        assert site.label == self.site.label
+        assert site.label == self.site2.label
+
         d = self.propertied_site.as_dict()
         site3 = PeriodicSite({"Si": 0.5, "Fe": 0.5}, [0, 0, 0], self.lattice)
         d = site3.as_dict()
         site = PeriodicSite.from_dict(d)
         assert site.species == site3.species
+        assert site.label == site3.label
 
         d = self.dummy_site.as_dict()
         site = PeriodicSite.from_dict(d)
         assert site.species == self.dummy_site.species
+        assert site.label == self.dummy_site.label
 
     def test_to_unit_cell(self):
         site = PeriodicSite("Fe", np.array([1.25, 2.35, 4.46]), self.lattice)

--- a/pymatgen/core/tests/test_structure.py
+++ b/pymatgen/core/tests/test_structure.py
@@ -54,17 +54,19 @@ class NeighborTest(PymatgenTest):
         assert isinstance(nn[0], PeriodicNeighbor)
 
     def test_neighbor_labels(self):
-        neighbor1 = Neighbor("C", [0, 0, 0])
-        assert neighbor1.label is None
+        comp = Composition("C")
 
-        neighbor2 = Neighbor("C", [0, 0, 0], label="C1")
-        assert neighbor2.label == "C1"
+        neighbor1 = Neighbor(comp, [0, 0, 0])
+        assert neighbor1.label == "C"
 
-        pneighbor1 = PeriodicNeighbor("C", [0, 0, 0], (10, 10, 10))
-        assert pneighbor1.label is None
+        neighbor2 = Neighbor(comp, [0, 0, 0], label="my label")
+        assert neighbor2.label == "my label"
 
-        pneighbor2 = PeriodicNeighbor("C", [0, 0, 0], (10, 10, 10), label="C1")
-        assert pneighbor2.label == "C1"
+        pneighbor1 = PeriodicNeighbor(comp, [0, 0, 0], (10, 10, 10))
+        assert pneighbor1.label == "C"
+
+        pneighbor2 = PeriodicNeighbor(comp, [0, 0, 0], (10, 10, 10), label="my label")
+        assert pneighbor2.label == "my label"
 
 
 class IStructureTest(PymatgenTest):
@@ -192,7 +194,7 @@ class IStructureTest(PymatgenTest):
 
     def test_labeled_structure(self):
         assert self.labeled_structure.labels == ["Si1", "Si2"]
-        assert self.struct.labels == [None, None]
+        assert self.struct.labels == ["Si", "Si"]
 
     def test_get_distance(self):
         assert self.struct.get_distance(0, 1) == approx(2.35, abs=1e-2), "Distance calculated wrongly!"

--- a/pymatgen/core/tests/test_structure.py
+++ b/pymatgen/core/tests/test_structure.py
@@ -55,29 +55,19 @@ class NeighborTest(PymatgenTest):
 
     def test_neighbor_labels(self):
         comp = Composition("C")
+        for label in (None, "", "str label", ("tuple", "label")):
+            neighbor = Neighbor(comp, (0, 0, 0), label=label)
+            assert neighbor.label == label if label is not None else str(comp)
 
-        neighbor1 = Neighbor(comp, [0, 0, 0])
-        assert neighbor1.label == "C"
-
-        neighbor2 = Neighbor(comp, [0, 0, 0], label="my label")
-        assert neighbor2.label == "my label"
-
-        pneighbor1 = PeriodicNeighbor(comp, [0, 0, 0], (10, 10, 10))
-        assert pneighbor1.label == "C"
-
-        pneighbor2 = PeriodicNeighbor(comp, [0, 0, 0], (10, 10, 10), label="my label")
-        assert pneighbor2.label == "my label"
+            p_neighbor = PeriodicNeighbor(comp, (0, 0, 0), (10, 10, 10), label=label)
+            assert p_neighbor.label == label if label is not None else str(comp)
 
 
 class IStructureTest(PymatgenTest):
     def setUp(self):
         coords = [[0, 0, 0], [0.75, 0.5, 0.75]]
         self.lattice = Lattice(
-            [
-                [3.8401979337, 0.00, 0.00],
-                [1.9200989668, 3.3257101909, 0.00],
-                [0.00, -2.2171384943, 3.1355090603],
-            ]
+            [[3.8401979337, 0, 0], [1.9200989668, 3.3257101909, 0], [0, -2.2171384943, 3.1355090603]]
         )
         self.struct = IStructure(self.lattice, ["Si"] * 2, coords)
         assert len(self.struct) == 2, "Wrong number of sites in structure!"
@@ -92,11 +82,7 @@ class IStructureTest(PymatgenTest):
         self.labeled_structure = IStructure(self.lattice, ["Si"] * 2, coords, labels=["Si1", "Si2"])
 
         self.lattice_pbc = Lattice(
-            [
-                [3.8401979337, 0.00, 0.00],
-                [1.9200989668, 3.3257101909, 0.00],
-                [0.00, -2.2171384943, 3.1355090603],
-            ],
+            [[3.8401979337, 0, 0], [1.9200989668, 3.3257101909, 0], [0, -2.2171384943, 3.1355090603]],
             pbc=(True, True, False),
         )
 
@@ -341,7 +327,7 @@ class IStructureTest(PymatgenTest):
             assert interpolated_structs[0].lattice == inter_struct.lattice
         assert_array_equal(interpolated_structs[1][1].frac_coords, [0.625, 0.5, 0.625])
 
-        bad_lattice = [[1, 0.00, 0.00], [0, 1, 0.00], [0.00, 0, 1]]
+        bad_lattice = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
         struct2 = IStructure(bad_lattice, ["Si"] * 2, coords2)
         with pytest.raises(ValueError, match="Structures with different lattices"):
             struct.interpolate(struct2)
@@ -787,9 +773,7 @@ class StructureTest(PymatgenTest):
         coords = []
         coords.append([0, 0, 0])
         coords.append([0.75, 0.5, 0.75])
-        lattice = Lattice(
-            [[3.8401979337, 0.00, 0.00], [1.9200989668, 3.3257101909, 0.00], [0.00, -2.2171384943, 3.1355090603]]
-        )
+        lattice = Lattice([[3.8401979337, 0, 0], [1.9200989668, 3.3257101909, 0], [0, -2.2171384943, 3.1355090603]])
         self.structure = Structure(lattice, ["Si", "Si"], coords)
         self.cu_structure = Structure(lattice, ["Cu", "Cu"], coords)
         self.disordered = Structure.from_spacegroup("Im-3m", Lattice.cubic(3), [Composition("Fe0.5Mn0.5")], [[0, 0, 0]])
@@ -1180,7 +1164,7 @@ class StructureTest(PymatgenTest):
             "P4_2'/mnm'",
             Lattice.tetragonal(4.87, 3.30),
             ["Mn", "F"],
-            [[0, 0, 0], [0.30, 0.30, 0.00]],
+            [[0, 0, 0], [0.30, 0.30, 0]],
             {"magmom": [4, 0]},
         )
 
@@ -1196,7 +1180,7 @@ class StructureTest(PymatgenTest):
             ["La", "Mn", "O", "O"],
             [
                 [0.05, 0.25, 0.99],
-                [0.00, 0.00, 0.50],
+                [0, 0, 0.50],
                 [0.48, 0.25, 0.08],
                 [0.31, 0.04, 0.72],
             ],

--- a/pymatgen/core/tests/test_structure.py
+++ b/pymatgen/core/tests/test_structure.py
@@ -19,7 +19,15 @@ from pymatgen.core.composition import Composition
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.operations import SymmOp
 from pymatgen.core.periodic_table import Element, Species
-from pymatgen.core.structure import IMolecule, IStructure, Molecule, PeriodicNeighbor, Structure, StructureError
+from pymatgen.core.structure import (
+    IMolecule,
+    IStructure,
+    Molecule,
+    Neighbor,
+    PeriodicNeighbor,
+    Structure,
+    StructureError,
+)
 from pymatgen.electronic_structure.core import Magmom
 from pymatgen.io.ase import AseAtomsAdaptor
 from pymatgen.util.testing import PymatgenTest
@@ -44,6 +52,19 @@ class NeighborTest(PymatgenTest):
         str_ = json.dumps(nn, cls=MontyEncoder)
         nn = json.loads(str_, cls=MontyDecoder)
         assert isinstance(nn[0], PeriodicNeighbor)
+
+    def test_neighbor_labels(self):
+        neighbor1 = Neighbor("C", [0, 0, 0])
+        assert neighbor1.label is None
+
+        neighbor2 = Neighbor("C", [0, 0, 0], label="C1")
+        assert neighbor2.label == "C1"
+
+        pneighbor1 = PeriodicNeighbor("C", [0, 0, 0], (10, 10, 10))
+        assert pneighbor1.label is None
+
+        pneighbor2 = PeriodicNeighbor("C", [0, 0, 0], (10, 10, 10), label="C1")
+        assert pneighbor2.label == "C1"
 
 
 class IStructureTest(PymatgenTest):

--- a/pymatgen/ext/optimade.py
+++ b/pymatgen/ext/optimade.py
@@ -310,7 +310,7 @@ class OptimadeRester:
         response_fields = self._handle_response_fields(additional_response_fields)
 
         for identifier, resource in self.resources.items():
-            url = join(resource, f"v1/structures?filter={optimade_filter}&response_fields={response_fields}")
+            url = join(resource, f"v1/structures?filter={optimade_filter}&{response_fields=!s}")
 
             try:
                 json = self._get_json(url)

--- a/test_files/.pytest-split-durations
+++ b/test_files/.pytest-split-durations
@@ -944,7 +944,7 @@
     "pymatgen/core/tests/test_sites.py::PeriodicSiteTest::test_repr": 0.0002163760073017329,
     "pymatgen/core/tests/test_sites.py::PeriodicSiteTest::test_setters": 0.0005762910150224343,
     "pymatgen/core/tests/test_sites.py::PeriodicSiteTest::test_to_unit_cell": 0.0004528739955276251,
-    "pymatgen/core/tests/test_sites.py::SiteTest::test_cmp": 0.00041866599349305034,
+    "pymatgen/core/tests/test_sites.py::SiteTest::test_gt_lt": 0.00041866599349305034,
     "pymatgen/core/tests/test_sites.py::SiteTest::test_distance": 0.0005102920113131404,
     "pymatgen/core/tests/test_sites.py::SiteTest::test_hash": 0.00025291601195931435,
     "pymatgen/core/tests/test_sites.py::SiteTest::test_pickle": 0.00037470700044650584,


### PR DESCRIPTION
## Summary

This PR fixes some issues with labels and adds new tests for previously unspecified behaviour.

Major changes:

- `Site.label` (and derivatives) defaults to `.species_string` instead of `None`
- Add label attribute to `Neighbor` and `PeriodicNeighbor`

Closes #3166
Closes #3160

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [x] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
