### PR TITLE
Fix a bug in pwscf.py. The proc_val function modifies string values.

### DIFF
--- a/pymatgen/io/pwscf.py
+++ b/pymatgen/io/pwscf.py
@@ -371,7 +371,7 @@ class PWInput:
             "conv_thr",
             "Hubbard_U",
             "Hubbard_J0",
-            "defauss",
+            "degauss",
             "starting_magnetization",
         )
 

--- a/pymatgen/io/pwscf.py
+++ b/pymatgen/io/pwscf.py
@@ -482,9 +482,7 @@ class PWInput:
             pass
 
         try:
-            # use local variable to avoid modifications to a string value
-            val_replace = val.replace("d", "e")
-            return smart_int_or_float(val_replace)
+            return smart_int_or_float(val.replace("d", "e"))
         except ValueError:
             pass
 

--- a/pymatgen/io/pwscf.py
+++ b/pymatgen/io/pwscf.py
@@ -482,8 +482,9 @@ class PWInput:
             pass
 
         try:
-            val = val.replace("d", "e")
-            return smart_int_or_float(val)
+            # use local variable to avoid modifications to a string value
+            val_replace = val.replace("d", "e")
+            return smart_int_or_float(val_replace)
         except ValueError:
             pass
 

--- a/pymatgen/io/tests/test_pwscf.py
+++ b/pymatgen/io/tests/test_pwscf.py
@@ -208,6 +208,17 @@ CELL_PARAMETERS angstrom
 """
         assert str(pw).strip() == expected.strip()
 
+    def test_proc_val(self):
+        inputs={
+            "degauss": ("7.3498618000d-03",7.3498618000e-03)
+            , "nat": ("2",2)
+            , "nosym": (".TRUE.",True)
+            , "smearing": ("'cold'","cold")
+        }
+        for key,(input_str,expected) in inputs.items():
+            value=PWInput.proc_val(key,input_str)
+            assert value == expected
+
     def test_read_str(self):
         string = """
 &CONTROL
@@ -223,6 +234,7 @@ CELL_PARAMETERS angstrom
   ecutwfc = 80
   nspin = 1
   nbnd = 280
+  smearing = 'cold'
 /
 &ELECTRONS
 /
@@ -364,6 +376,7 @@ CELL_PARAMETERS angstrom
         np.testing.assert_allclose(sites, pw_sites)
 
         np.testing.assert_allclose(lattice, pwin.structure.lattice.matrix)
+        assert pwin.sections["system"]["smearing"] == "cold"
 
 
 class PWOuputTest(PymatgenTest):

--- a/pymatgen/io/tests/test_pwscf.py
+++ b/pymatgen/io/tests/test_pwscf.py
@@ -209,14 +209,14 @@ CELL_PARAMETERS angstrom
         assert str(pw).strip() == expected.strip()
 
     def test_proc_val(self):
-        inputs={
-            "degauss": ("7.3498618000d-03",7.3498618000e-03)
-            , "nat": ("2",2)
-            , "nosym": (".TRUE.",True)
-            , "smearing": ("'cold'","cold")
+        inputs = {
+            "degauss": ("7.3498618000d-03", 7.3498618000e-03),
+            "nat": ("2", 2),
+            "nosym": (".TRUE.", True),
+            "smearing": ("'cold'", "cold"),
         }
-        for key,(input_str,expected) in inputs.items():
-            value=PWInput.proc_val(key,input_str)
+        for key, (input_str, expected) in inputs.items():
+            value = PWInput.proc_val(key, input_str)
             assert value == expected
 
     def test_read_str(self):


### PR DESCRIPTION
## Summary

The proc_val function modifies the value of string variables (changes 'd' for 'e'). For example, smearing = 'cold' becomes smearing = 'cole'. It is solved by using a local variable.

Major changes:

Added  a local variable
```
    val_replace = val.replace("d", "e")
    return smart_int_or_float(val_replace)
```
## Todos


## Checklist

- [ ] Google format doc strings added. Check with `ruff`.
- [ ] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
