### PR TITLE
lots of `from_string` should be `classmethod`

### DIFF
--- a/pymatgen/core/units.py
+++ b/pymatgen/core/units.py
@@ -309,6 +309,7 @@ class FloatWithUnit(float):
 
     Error = UnitError
 
+    @classmethod
     @np.deprecate(message="Use from_str instead")
     def from_string(cls, *args, **kwargs):
         """Use from_str instead."""

--- a/pymatgen/io/adf.py
+++ b/pymatgen/io/adf.py
@@ -354,6 +354,7 @@ class AdfKey(MSONable):
         subkeys = [AdfKey.from_dict(k) for k in subkey_list] or None
         return cls(key, options, subkeys)
 
+    @classmethod
     @np.deprecate(message="Use from_str instead")
     def from_string(cls, *args, **kwargs):
         return cls.from_str(*args, **kwargs)

--- a/pymatgen/io/babel.py
+++ b/pymatgen/io/babel.py
@@ -337,6 +337,7 @@ class BabelMolAdaptor:
         """
         return BabelMolAdaptor(mol.molecule)
 
+    @classmethod
     @np.deprecate(message="Use from_str instead")
     def from_string(cls, *args, **kwargs):
         return cls.from_str(*args, **kwargs)

--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -165,6 +165,7 @@ class CifBlock:
                     q.append(tuple(s))
         return q
 
+    @classmethod
     @np.deprecate(message="Use from_str instead")
     def from_string(cls, *args, **kwargs):
         return cls.from_str(*args, **kwargs)
@@ -233,6 +234,7 @@ class CifFile:
         out = "\n".join(map(str, self.data.values()))
         return f"{self.comment}\n{out}\n"
 
+    @classmethod
     @np.deprecate(message="Use from_str instead")
     def from_string(cls, *args, **kwargs):
         return cls.from_str(*args, **kwargs)

--- a/pymatgen/io/cp2k/inputs.py
+++ b/pymatgen/io/cp2k/inputs.py
@@ -150,6 +150,7 @@ class Keyword(MSONable):
             verbose=d["verbose"],
         )
 
+    @classmethod
     @np.deprecate(message="Use from_str instead")
     def from_string(cls, *args, **kwargs):
         return cls.from_str(*args, **kwargs)
@@ -720,6 +721,7 @@ class Cp2kInput(Section):
             txt = preprocessor(f.read(), os.path.dirname(f.name))
             return Cp2kInput.from_str(txt)
 
+    @classmethod
     @np.deprecate(message="Use from_str instead")
     def from_string(cls, *args, **kwargs):
         return cls.from_str(*args, **kwargs)
@@ -2247,6 +2249,7 @@ class BasisInfo(MSONable):
         d2 = other.as_dict()
         return all(not (v is not None and v != d2[k]) for k, v in d1.items())
 
+    @classmethod
     @np.deprecate(message="Use from_str instead")
     def from_string(cls, *args, **kwargs):
         return cls.from_str(*args, **kwargs)
@@ -2551,6 +2554,7 @@ class PotentialInfo(MSONable):
         d2 = other.as_dict()
         return all(not (v is not None and v != d2[k]) for k, v in d1.items())
 
+    @classmethod
     @np.deprecate(message="Use from_str instead")
     def from_string(cls, *args, **kwargs):
         return cls.from_str(*args, **kwargs)
@@ -2692,6 +2696,7 @@ class GthPotential(AtomicMetadata):
                 out += "\n"
         return out
 
+    @classmethod
     @np.deprecate(message="Use from_str instead")
     def from_string(cls, *args, **kwargs):
         return cls.from_str(*args, **kwargs)
@@ -2781,6 +2786,7 @@ class DataFile(MSONable):
                 obj.filename = fn
             return data
 
+    @classmethod
     @np.deprecate(message="Use from_str instead")
     def from_string(cls, *args, **kwargs):
         return cls.from_str(*args, **kwargs)

--- a/pymatgen/io/exciting/inputs.py
+++ b/pymatgen/io/exciting/inputs.py
@@ -73,6 +73,7 @@ class ExcitingInput(MSONable):
     def lockxyz(self, lockxyz):
         self.structure.add_site_property("selective_dynamics", lockxyz)
 
+    @classmethod
     @np.deprecate(message="Use from_str instead")
     def from_string(cls, *args, **kwargs):
         return cls.from_str(*args, **kwargs)

--- a/pymatgen/io/feff/inputs.py
+++ b/pymatgen/io/feff/inputs.py
@@ -278,6 +278,7 @@ class Header(MSONable):
 
         return "".join(feff_header_str)
 
+    @classmethod
     @np.deprecate(message="Use from_str instead")
     def from_string(cls, *args, **kwargs):
         return cls.from_str(*args, **kwargs)

--- a/pymatgen/io/fiesta.py
+++ b/pymatgen/io/fiesta.py
@@ -554,6 +554,7 @@ $geometry
             BSE_TDDFT_options=d["memory_options"],
         )
 
+    @classmethod
     @np.deprecate(message="Use from_str instead")
     def from_string(cls, *args, **kwargs):
         return cls.from_str(*args, **kwargs)

--- a/pymatgen/io/gaussian.py
+++ b/pymatgen/io/gaussian.py
@@ -274,6 +274,7 @@ class GaussianInput:
 
         return Molecule(species, coords)
 
+    @classmethod
     @np.deprecate(message="Use from_str instead")
     def from_string(cls, *args, **kwargs):
         return cls.from_str(*args, **kwargs)

--- a/pymatgen/io/lammps/inputs.py
+++ b/pymatgen/io/lammps/inputs.py
@@ -521,6 +521,7 @@ class LammpsInputFile(InputFile):
         with zopen(filename, "wt") as f:
             f.write(self.get_string(ignore_comments=ignore_comments, keep_stages=keep_stages))
 
+    @classmethod
     @np.deprecate(message="Use from_str instead")
     def from_string(cls, *args, **kwargs):
         return cls.from_str(*args, **kwargs)

--- a/pymatgen/io/lammps/outputs.py
+++ b/pymatgen/io/lammps/outputs.py
@@ -42,6 +42,7 @@ class LammpsDump(MSONable):
         self.box = box
         self.data = data
 
+    @classmethod
     @np.deprecate(message="Use from_str instead")
     def from_string(cls, *args, **kwargs):
         return cls.from_str(*args, **kwargs)

--- a/pymatgen/io/lmto.py
+++ b/pymatgen/io/lmto.py
@@ -166,6 +166,7 @@ class LMTOCtrl:
             contents = f.read()
         return LMTOCtrl.from_str(contents, **kwargs)
 
+    @classmethod
     @np.deprecate(message="Use from_str instead")
     def from_string(cls, *args, **kwargs):
         return cls.from_str(*args, **kwargs)

--- a/pymatgen/io/nwchem.py
+++ b/pymatgen/io/nwchem.py
@@ -419,6 +419,7 @@ class NwInput(MSONable):
             memory_options=d["memory_options"],
         )
 
+    @classmethod
     @np.deprecate(message="Use from_str instead")
     def from_string(cls, *args, **kwargs):
         return cls.from_str(*args, **kwargs)

--- a/pymatgen/io/pwscf.py
+++ b/pymatgen/io/pwscf.py
@@ -234,6 +234,7 @@ class PWInput:
         with zopen(filename, "rt") as f:
             return PWInput.from_str(f.read())
 
+    @classmethod
     @np.deprecate(message="Use from_str instead")
     def from_string(cls, *args, **kwargs):
         return cls.from_str(*args, **kwargs)

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -761,6 +761,7 @@ class Incar(dict, MSONable):
         with zopen(filename, "rt") as f:
             return Incar.from_str(f.read())
 
+    @classmethod
     @np.deprecate(message="Use from_str instead")
     def from_string(cls, *args, **kwargs):
         return cls.from_str(*args, **kwargs)

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -1005,6 +1005,7 @@ class KpointsSupportedModes(Enum):
     def __str__(self):
         return str(self.name)
 
+    @classmethod
     @np.deprecate(message="Use from_str instead")
     def from_string(cls, *args, **kwargs):
         return cls.from_str(*args, **kwargs)
@@ -1385,6 +1386,7 @@ class Kpoints(MSONable):
         with zopen(filename, "rt") as f:
             return Kpoints.from_str(f.read())
 
+    @classmethod
     @np.deprecate(message="Use from_str instead")
     def from_string(cls, *args, **kwargs):
         return cls.from_str(*args, **kwargs)

--- a/pymatgen/io/xcrysden.py
+++ b/pymatgen/io/xcrysden.py
@@ -61,6 +61,7 @@ class XSF:
 
         return "\n".join(lines)
 
+    @classmethod
     @np.deprecate(message="Use from_str instead")
     def from_string(cls, *args, **kwargs):
         return cls.from_str(*args, **kwargs)

--- a/pymatgen/io/xr.py
+++ b/pymatgen/io/xr.py
@@ -68,6 +68,7 @@ class Xr:
         with zopen(filename, "wt") as f:
             f.write(str(self) + "\n")
 
+    @classmethod
     @np.deprecate(message="Use from_str instead")
     def from_string(cls, *args, **kwargs):
         return cls.from_str(*args, **kwargs)

--- a/pymatgen/io/xyz.py
+++ b/pymatgen/io/xyz.py
@@ -69,6 +69,7 @@ class XYZ:
                 coords.append([float(val) for val in xyz])
         return Molecule(sp, coords)
 
+    @classmethod
     @np.deprecate(message="Use from_str instead")
     def from_string(cls, *args, **kwargs):
         return cls.from_str(*args, **kwargs)

--- a/pymatgen/io/zeopp.py
+++ b/pymatgen/io/zeopp.py
@@ -91,6 +91,7 @@ class ZeoCssr(Cssr):
 
         return "\n".join(output)
 
+    @classmethod
     @np.deprecate(message="Use from_str instead")
     def from_string(cls, *args, **kwargs):
         return cls.from_str(*args, **kwargs)


### PR DESCRIPTION
## Summary

Fix a bug introduced in #3158. A lot of `from_string` methods should be `classmethod`.

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [ ] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
