### PR TITLE
BUG: fix setting zero magmoms

### DIFF
--- a/pymatgen/symmetry/analyzer.py
+++ b/pymatgen/symmetry/analyzer.py
@@ -85,11 +85,9 @@ class SpacegroupAnalyzer:
                 unique_species.append(species)
                 zs.extend([len(unique_species)] * len(tuple(group)))
 
-        has_explicit_magmoms = False
-        if "magmom" in structure.site_properties or any(
-            hasattr(specie, "spin") for specie in structure.types_of_species
-        ):
-            has_explicit_magmoms = True
+        has_explicit_magmoms = "magmom" in structure.site_properties or any(
+            getattr(specie, "spin", None) is not None for specie in structure.types_of_species
+        )
 
         for site in structure:
             if hasattr(site, "magmom"):

--- a/pymatgen/symmetry/tests/test_analyzer.py
+++ b/pymatgen/symmetry/tests/test_analyzer.py
@@ -9,6 +9,7 @@ from pytest import approx
 
 from pymatgen.core.sites import PeriodicSite
 from pymatgen.core.structure import Molecule, Structure
+from pymatgen.core.periodic_table import Species
 from pymatgen.io.cif import CifParser
 from pymatgen.io.vasp.inputs import Poscar
 from pymatgen.io.vasp.outputs import Vasprun
@@ -122,6 +123,31 @@ class SpacegroupAnalyzerTest(PymatgenTest):
         ds = self.sg.get_symmetry_dataset()
         assert ds["international"] == "Pnma"
 
+    def test_init_cell(self):
+        # see https://github.com/materialsproject/pymatgen/pull/3179
+        li2o = Structure.from_file(os.path.join(PymatgenTest.TEST_FILES_DIR, "Li2O.cif"))
+
+        # test that magmoms are not included in spacegroup analyzer when species have no spin
+        # or no magmom site properties are set
+        assert all(species.spin is None for species in li2o.types_of_species)
+        assert "magmom" not in li2o.site_properties
+        sga = SpacegroupAnalyzer(li2o)
+        assert len(sga._cell) == 3  # no magmoms should be added!
+
+        # give a magmom to random Li site
+        li2o[0].properties["magmom"] = 0
+        sga = SpacegroupAnalyzer(li2o)
+        assert len(sga._cell) == 4  # magmoms should be added!
+        assert sga._cell[3] == 12 * (0, )
+
+        # now set spin for O only
+        li2o = Structure.from_file(os.path.join(PymatgenTest.TEST_FILES_DIR, "Li2O.cif"))
+        li2o.replace_species({"O2-": Species("O", oxidation_state=-2, spin=1)})
+        assert not all(species.spin is None for species in li2o.types_of_species)
+        sga = SpacegroupAnalyzer(li2o)
+        assert len(sga._cell) == 4  # magmoms should be added!
+        assert sga._cell[3] == tuple(8 * [0, ] + 4 * [1, ])
+
     def test_get_symmetry(self):
         # see discussion in https://github.com/materialsproject/pymatgen/pull/2724
         Co8 = Structure.from_file(os.path.join(PymatgenTest.TEST_FILES_DIR, "Co8.cif"))
@@ -129,7 +155,7 @@ class SpacegroupAnalyzerTest(PymatgenTest):
 
         sga = SpacegroupAnalyzer(Co8, symprec=symprec)
         magmoms = [0] * len(Co8)  # bad magmoms, see https://github.com/materialsproject/pymatgen/pull/2727
-        sga._cell = (*sga._cell, magmoms)
+        sga._cell = (*sga._cell , magmoms)
         with pytest.raises(
             ValueError,
             match=f"Symmetry detection failed for structure with formula {Co8.formula}. "

--- a/pymatgen/symmetry/tests/test_analyzer.py
+++ b/pymatgen/symmetry/tests/test_analyzer.py
@@ -7,9 +7,9 @@ import numpy as np
 import pytest
 from pytest import approx
 
+from pymatgen.core.periodic_table import Species
 from pymatgen.core.sites import PeriodicSite
 from pymatgen.core.structure import Molecule, Structure
-from pymatgen.core.periodic_table import Species
 from pymatgen.io.cif import CifParser
 from pymatgen.io.vasp.inputs import Poscar
 from pymatgen.io.vasp.outputs import Vasprun
@@ -138,7 +138,7 @@ class SpacegroupAnalyzerTest(PymatgenTest):
         li2o[0].properties["magmom"] = 0
         sga = SpacegroupAnalyzer(li2o)
         assert len(sga._cell) == 4  # magmoms should be added!
-        assert sga._cell[3] == 12 * (0, )
+        assert sga._cell[3] == 12 * (0,)
 
         # now set spin for O only
         li2o = Structure.from_file(os.path.join(PymatgenTest.TEST_FILES_DIR, "Li2O.cif"))
@@ -146,7 +146,16 @@ class SpacegroupAnalyzerTest(PymatgenTest):
         assert not all(species.spin is None for species in li2o.types_of_species)
         sga = SpacegroupAnalyzer(li2o)
         assert len(sga._cell) == 4  # magmoms should be added!
-        assert sga._cell[3] == tuple(8 * [0, ] + 4 * [1, ])
+        assert sga._cell[3] == tuple(
+            8
+            * [
+                0,
+            ]
+            + 4
+            * [
+                1,
+            ]
+        )
 
     def test_get_symmetry(self):
         # see discussion in https://github.com/materialsproject/pymatgen/pull/2724
@@ -155,7 +164,7 @@ class SpacegroupAnalyzerTest(PymatgenTest):
 
         sga = SpacegroupAnalyzer(Co8, symprec=symprec)
         magmoms = [0] * len(Co8)  # bad magmoms, see https://github.com/materialsproject/pymatgen/pull/2727
-        sga._cell = (*sga._cell , magmoms)
+        sga._cell = (*sga._cell, magmoms)
         with pytest.raises(
             ValueError,
             match=f"Symmetry detection failed for structure with formula {Co8.formula}. "


### PR DESCRIPTION
## Summary

With the new changes that set the default `Sepcies.spin` to `None`, I fixed the logic for setting zero magmoms in `SpacegroupAnalyzer` to check for `None` values as well.

## Checklist

- [X] Google format doc strings added. Check with `ruff`.
- [X] Type annotations included. Check with `mypy`.
- [X] Tests added for new features/fixes.
- [X] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
