### PR TITLE
Propagate labels through various Structure operations

### DIFF
--- a/pymatgen/analysis/gb/grain.py
+++ b/pymatgen/analysis/gb/grain.py
@@ -21,6 +21,7 @@ from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 if TYPE_CHECKING:
     from numpy.typing import ArrayLike
 
+    from pymatgen.core.trajectory import Vector3D
     from pymatgen.util.typing import CompositionLike
 
 # This module implements representations of grain boundaries, as well as
@@ -55,10 +56,10 @@ class GrainBoundary(Structure):
         lattice: np.ndarray | Lattice,
         species: Sequence[CompositionLike],
         coords: Sequence[ArrayLike],
-        rotation_axis: tuple[float, float, float],
+        rotation_axis: Vector3D,
         rotation_angle: float,
-        gb_plane: tuple[float, float, float],
-        join_plane: tuple[float, float, float],
+        gb_plane: Vector3D,
+        join_plane: Vector3D,
         init_cell: Structure,
         vacuum_thickness: float,
         ab_shift: tuple[float, float],

--- a/pymatgen/core/lattice.py
+++ b/pymatgen/core/lattice.py
@@ -23,6 +23,8 @@ from pymatgen.util.num import abs_cap
 if TYPE_CHECKING:
     from numpy.typing import ArrayLike
 
+    from pymatgen.core.trajectory import Vector3D
+
 __author__ = "Shyue Ping Ong, Michael Kocher"
 __copyright__ = "Copyright 2011, The Materials Project"
 __maintainer__ = "Shyue Ping Ong"
@@ -67,7 +69,7 @@ class Lattice(MSONable):
         self._pbc = tuple(pbc)
 
     @property
-    def lengths(self) -> tuple[float, float, float]:
+    def lengths(self) -> Vector3D:
         """
         Lattice lengths.
 
@@ -76,7 +78,7 @@ class Lattice(MSONable):
         return tuple(np.sqrt(np.sum(self._matrix**2, axis=1)).tolist())  # type: ignore
 
     @property
-    def angles(self) -> tuple[float, float, float]:
+    def angles(self) -> Vector3D:
         """
         Lattice angles.
 
@@ -414,7 +416,7 @@ class Lattice(MSONable):
         return self.lengths[2]
 
     @property
-    def abc(self) -> tuple[float, float, float]:
+    def abc(self) -> Vector3D:
         """Lengths of the lattice vectors, i.e. (a, b, c)."""
         return self.lengths
 

--- a/pymatgen/core/sites.py
+++ b/pymatgen/core/sites.py
@@ -455,7 +455,7 @@ class PeriodicSite(Site, MSONable):
         if in_place:
             self.frac_coords = np.array(frac_coords)
             return None
-        return PeriodicSite(self.species, frac_coords, self.lattice, properties=self.properties)
+        return PeriodicSite(self.species, frac_coords, self.lattice, properties=self.properties, label=self.label)
 
     def is_periodic_image(self, other: PeriodicSite, tolerance: float = 1e-8, check_lattice: bool = True) -> bool:
         """

--- a/pymatgen/core/sites.py
+++ b/pymatgen/core/sites.py
@@ -86,7 +86,7 @@ class Site(collections.abc.Hashable, MSONable):
         return self._species
 
     @species.setter
-    def species(self, species: SpeciesLike | CompositionLike):
+    def species(self, species: SpeciesLike | CompositionLike) -> None:
         if not isinstance(species, Composition):
             try:
                 species = Composition({get_el_sp(species): 1})  # type: ignore
@@ -98,12 +98,12 @@ class Site(collections.abc.Hashable, MSONable):
         self._species = species
 
     @property
-    def label(self):
+    def label(self) -> str:
         """Site label."""
         return self._label if self._label is not None else self.species_string
 
     @label.setter
-    def label(self, label: str):
+    def label(self, label: str) -> None:
         self._label = label
 
     @property
@@ -112,7 +112,7 @@ class Site(collections.abc.Hashable, MSONable):
         return self.coords[0]
 
     @x.setter
-    def x(self, x: float):
+    def x(self, x: float) -> None:
         self.coords[0] = x
 
     @property
@@ -121,7 +121,7 @@ class Site(collections.abc.Hashable, MSONable):
         return self.coords[1]
 
     @y.setter
-    def y(self, y: float):
+    def y(self, y: float) -> None:
         self.coords[1] = y
 
     @property
@@ -130,7 +130,7 @@ class Site(collections.abc.Hashable, MSONable):
         return self.coords[2]
 
     @z.setter
-    def z(self, z: float):
+    def z(self, z: float) -> None:
         self.coords[2] = z
 
     def distance(self, other) -> float:
@@ -369,7 +369,7 @@ class PeriodicSite(Site, MSONable):
         return self._lattice
 
     @lattice.setter
-    def lattice(self, lattice: Lattice):
+    def lattice(self, lattice: Lattice) -> None:
         """Sets Lattice associated with PeriodicSite."""
         self._lattice = lattice
         self._coords = self._lattice.get_cartesian_coords(self._frac_coords)
@@ -382,7 +382,7 @@ class PeriodicSite(Site, MSONable):
         return self._coords
 
     @coords.setter
-    def coords(self, coords):
+    def coords(self, coords) -> None:
         """Set Cartesian coordinates."""
         self._coords = np.array(coords)
         self._frac_coords = self._lattice.get_fractional_coords(self._coords)
@@ -393,7 +393,7 @@ class PeriodicSite(Site, MSONable):
         return self._frac_coords
 
     @frac_coords.setter
-    def frac_coords(self, frac_coords):
+    def frac_coords(self, frac_coords) -> None:
         """Set fractional coordinates."""
         self._frac_coords = np.array(frac_coords)
         self._coords = self._lattice.get_cartesian_coords(self._frac_coords)
@@ -404,7 +404,7 @@ class PeriodicSite(Site, MSONable):
         return self._frac_coords[0]
 
     @a.setter
-    def a(self, a: float):
+    def a(self, a: float) -> None:
         self._frac_coords[0] = a
         self._coords = self._lattice.get_cartesian_coords(self._frac_coords)
 
@@ -414,7 +414,7 @@ class PeriodicSite(Site, MSONable):
         return self._frac_coords[1]
 
     @b.setter
-    def b(self, b: float):
+    def b(self, b: float) -> None:
         self._frac_coords[1] = b
         self._coords = self._lattice.get_cartesian_coords(self._frac_coords)
 
@@ -424,7 +424,7 @@ class PeriodicSite(Site, MSONable):
         return self._frac_coords[2]
 
     @c.setter
-    def c(self, c: float):
+    def c(self, c: float) -> None:
         self._frac_coords[2] = c
         self._coords = self._lattice.get_cartesian_coords(self._frac_coords)
 
@@ -434,7 +434,7 @@ class PeriodicSite(Site, MSONable):
         return self.coords[0]
 
     @x.setter
-    def x(self, x: float):
+    def x(self, x: float) -> None:
         self.coords[0] = x
         self._frac_coords = self._lattice.get_fractional_coords(self.coords)
 
@@ -444,7 +444,7 @@ class PeriodicSite(Site, MSONable):
         return self.coords[1]
 
     @y.setter
-    def y(self, y: float):
+    def y(self, y: float) -> None:
         self.coords[1] = y
         self._frac_coords = self._lattice.get_fractional_coords(self.coords)
 
@@ -454,7 +454,7 @@ class PeriodicSite(Site, MSONable):
         return self.coords[2]
 
     @z.setter
-    def z(self, z: float):
+    def z(self, z: float) -> None:
         self.coords[2] = z
         self._frac_coords = self._lattice.get_fractional_coords(self.coords)
 

--- a/pymatgen/core/sites.py
+++ b/pymatgen/core/sites.py
@@ -71,7 +71,7 @@ class Site(collections.abc.Hashable, MSONable):
         self._species: Composition = species  # type: ignore
         self.coords: np.ndarray = coords  # type: ignore
         self.properties: dict = properties or {}
-        self.label = label if label else self.species_string
+        self._label = label
 
     def __getattr__(self, attr):
         # overriding getattr doesn't play nicely with pickle, so we can't use self._properties
@@ -96,6 +96,15 @@ class Site(collections.abc.Hashable, MSONable):
         if total_occu > 1 + Composition.amount_tolerance:
             raise ValueError("Species occupancies sum to more than 1!")
         self._species = species
+
+    @property
+    def label(self):
+        """Site label."""
+        return self._label if self._label is not None else self.species_string
+
+    @label.setter
+    def label(self, label: str):
+        self._label = label
 
     @property
     def x(self) -> float:
@@ -345,7 +354,7 @@ class PeriodicSite(Site, MSONable):
         self._species: Composition = species  # type: ignore
         self._coords: np.ndarray | None = None
         self.properties: dict = properties or {}
-        self.label = label if label else self.species_string
+        self._label = label
 
     def __hash__(self) -> int:
         """

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -3317,7 +3317,7 @@ class IMolecule(SiteCollection, MSONable):
         if a <= x_range or b <= y_range or c <= z_range:
             raise ValueError("Box is not big enough to contain Molecule.")
         lattice = Lattice.from_parameters(a * images[0], b * images[1], c * images[2], 90, 90, 90)  # type: ignore
-        nimages = images[0] * images[1] * images[2]  # type: ignore
+        nimages: int = images[0] * images[1] * images[2]  # type: ignore
         all_coords: list[ArrayLike] = []
 
         centered_coords = self.cart_coords - self.center_of_mass + offset
@@ -3366,7 +3366,7 @@ class IMolecule(SiteCollection, MSONable):
         if reorder:
             return cls(
                 lattice,
-                self.species * nimages,  # type: ignore
+                self.species * nimages,
                 all_coords,
                 coords_are_cartesian=True,
                 site_properties=sprops,
@@ -3375,7 +3375,7 @@ class IMolecule(SiteCollection, MSONable):
 
         return cls(
             lattice,
-            self.species * nimages,  # type: ignore
+            self.species * nimages,
             coords,
             coords_are_cartesian=True,
             site_properties=sprops,

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -84,7 +84,7 @@ class Neighbor(Site):
         self.properties = properties or {}
         self.nn_distance = nn_distance
         self.index = index
-        self.label = label if label is not None else self.species_string
+        self._label = label
 
     def __len__(self) -> Literal[3]:
         """Make neighbor Tuple-like to retain backwards compatibility."""
@@ -157,7 +157,7 @@ class PeriodicNeighbor(PeriodicSite):
         self.nn_distance = nn_distance
         self.index = index
         self.image = image
-        self.label = label if label is not None else self.species_string
+        self._label = label
 
     @property  # type: ignore
     def coords(self) -> np.ndarray:  # type: ignore

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -858,7 +858,7 @@ class IStructure(SiteCollection, MSONable):
         to_unit_cell: bool = False,
         coords_are_cartesian: bool = False,
         site_properties: dict | None = None,
-        labels: list | None = None,
+        labels: Sequence[str | None] | None = None,
     ) -> None:
         """
         Create a periodic structure.
@@ -988,7 +988,7 @@ class IStructure(SiteCollection, MSONable):
         site_properties: dict[str, Sequence] | None = None,
         coords_are_cartesian: bool = False,
         tol: float = 1e-5,
-        labels: list | None = None,
+        labels: Sequence[str | None] | None = None,
     ) -> IStructure | Structure:
         """
         Generate a structure using a spacegroup. Note that only symmetrically
@@ -1083,7 +1083,7 @@ class IStructure(SiteCollection, MSONable):
         site_properties: dict[str, Sequence],
         coords_are_cartesian: bool = False,
         tol: float = 1e-5,
-        labels: list | None = None,
+        labels: Sequence[str | None] | None = None,
     ) -> IStructure | Structure:
         """
         Generate a structure using a magnetic spacegroup. Note that only
@@ -3549,7 +3549,7 @@ class Structure(IStructure, collections.abc.MutableSequence):
         to_unit_cell: bool = False,
         coords_are_cartesian: bool = False,
         site_properties: dict | None = None,
-        labels: list | None = None,
+        labels: Sequence[str | None] | None = None,
     ):
         """
         Create a periodic structure.

--- a/pymatgen/core/tests/test_structure.py
+++ b/pymatgen/core/tests/test_structure.py
@@ -57,10 +57,10 @@ class NeighborTest(PymatgenTest):
         comp = Composition("C")
         for label in (None, "", "str label", ("tuple", "label")):
             neighbor = Neighbor(comp, (0, 0, 0), label=label)
-            assert neighbor.label == label if label is not None else str(comp)
+            assert neighbor.label == label if label is not None else "C"
 
             p_neighbor = PeriodicNeighbor(comp, (0, 0, 0), (10, 10, 10), label=label)
-            assert p_neighbor.label == label if label is not None else str(comp)
+            assert p_neighbor.label == label if label is not None else "C"
 
 
 class IStructureTest(PymatgenTest):

--- a/pymatgen/core/tests/test_structure.py
+++ b/pymatgen/core/tests/test_structure.py
@@ -777,6 +777,7 @@ class StructureTest(PymatgenTest):
         self.structure = Structure(lattice, ["Si", "Si"], coords)
         self.cu_structure = Structure(lattice, ["Cu", "Cu"], coords)
         self.disordered = Structure.from_spacegroup("Im-3m", Lattice.cubic(3), [Composition("Fe0.5Mn0.5")], [[0, 0, 0]])
+        self.labeled_structure = Structure(lattice, ["Si", "Si"], coords, labels=["Si1", "Si2"])
 
     def test_mutable_sequence_methods(self):
         struct = self.structure
@@ -1063,6 +1064,11 @@ class StructureTest(PymatgenTest):
         self.structure.make_supercell(2)
         assert self.structure.formula == "Si32"
         self.assert_all_close(self.structure.lattice.abc, [15.360792, 35.195996, 7.680396], 5)
+
+    def test_make_supercell_labeled(self):
+        struct = self.labeled_structure.copy()
+        struct.make_supercell([1, 1, 2])
+        assert set(struct.labels) == {"Si1", "Si2"}
 
     def test_disordered_supercell_primitive_cell(self):
         latt = Lattice.cubic(2)

--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -1044,8 +1044,6 @@ class CifParser:
                 else:
                     coords, magmoms, new_labels = self._unique_coords(tmp_coords, labels=labels)
 
-                assert len(new_labels) == len(coords)
-
                 if set(comp.elements) == {Element("O"), Element("H")}:
                     # O with implicit hydrogens
                     im_h = comp["H"]

--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -557,7 +557,7 @@ class CifParser:
 
     def _unique_coords(
         self,
-        coords: list[np.ndarray],
+        coords: list[Vector3D],
         magmoms: list[Magmom] | None = None,
         lattice: Lattice | None = None,
         labels: dict[Vector3D, str] | None = None,
@@ -590,7 +590,7 @@ class CifParser:
                     if not in_coord_list_pbc(coords_out, coord, atol=self._site_tolerance):
                         coords_out.append(coord)
                         magmoms_out.append(magmom)
-                        labels_out.append(labels[tmp_coord])
+                        labels_out.append(labels.get(tmp_coord))
             return coords_out, magmoms_out, labels_out
 
         for tmp_coord in coords:
@@ -599,7 +599,7 @@ class CifParser:
                 coord = np.array([i - math.floor(i) for i in coord])
                 if not in_coord_list_pbc(coords_out, coord, atol=self._site_tolerance):
                     coords_out.append(coord)
-                    labels_out.append(labels[tmp_coord])
+                    labels_out.append(labels.get(tmp_coord))
 
         dummy_magmoms = [Magmom(0)] * len(coords_out)
         return coords_out, dummy_magmoms, labels_out

--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -13,7 +13,7 @@ from inspect import getfullargspec as getargspec
 from io import StringIO
 from itertools import groupby
 from pathlib import Path
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 from monty.io import zopen
@@ -31,6 +31,9 @@ from pymatgen.symmetry.groups import SYMM_DATA, SpaceGroup
 from pymatgen.symmetry.maggroups import MagneticSpaceGroup
 from pymatgen.symmetry.structure import SymmetrizedStructure
 from pymatgen.util.coord import find_in_coord_list_pbc, in_coord_list_pbc
+
+if TYPE_CHECKING:
+    from pymatgen.core.trajectory import Vector3D
 
 __author__ = "Shyue Ping Ong, Will Richards, Matthew Horton"
 
@@ -552,9 +555,7 @@ class CifParser:
 
         return data
 
-    def _unique_coords(
-        self, coords_in, magmoms_in=None, lattice=None, labels_in: dict[tuple[float, float, float], str] | None = None
-    ):
+    def _unique_coords(self, coords_in, magmoms_in=None, lattice=None, labels_in: dict[Vector3D, str] | None = None):
         """
         Generate unique coordinates using coord and symmetry positions
         and also their corresponding magnetic moments, if supplied.

--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -1362,15 +1362,19 @@ class CifWriter:
                     atom_site_fract_x.append(format_str.format(site.a))
                     atom_site_fract_y.append(format_str.format(site.b))
                     atom_site_fract_z.append(format_str.format(site.c))
-                    atom_site_label.append(f"{sp.symbol}{count}")
                     atom_site_occupancy.append(str(occu))
+                    site_label = f"{sp.symbol}{count}"
 
                     if "magmom" in site.properties:
                         mag = site.properties["magmom"]
                     elif getattr(sp, "spin", None) is not None:
                         mag = sp.spin
                     else:
+                        # Use site label if available for regular sites
+                        site_label = site.label if site.label != site.species_string else site_label
                         mag = 0
+
+                    atom_site_label.append(site_label)
 
                     magmom = Magmom(mag)
                     if write_magmoms and abs(magmom) > 0:
@@ -1406,7 +1410,8 @@ class CifWriter:
                     atom_site_fract_x.append(format_str.format(site.a))
                     atom_site_fract_y.append(format_str.format(site.b))
                     atom_site_fract_z.append(format_str.format(site.c))
-                    atom_site_label.append(f"{sp.symbol}{count}")
+                    site_label = site.label if site.label != site.species_string else f"{sp.symbol}{count}"
+                    atom_site_label.append(site_label)
                     atom_site_occupancy.append(str(occu))
                     count += 1
 

--- a/pymatgen/io/res.py
+++ b/pymatgen/io/res.py
@@ -490,9 +490,7 @@ class AirssProvider(ResProvider):
         self._raise_or_none(ResParseError("Could not find line with cut-off energy."))
         return None
 
-    def get_mpgrid_offset_nkpts_spacing(
-        self,
-    ) -> tuple[tuple[int, int, int], Vector3D, int, float] | None:
+    def get_mpgrid_offset_nkpts_spacing(self) -> tuple[tuple[int, int, int], Vector3D, int, float] | None:
         """
         Retrieves the MP grid, the grid offsets, number of kpoints, and maximum kpoint spacing.
 

--- a/pymatgen/io/res.py
+++ b/pymatgen/io/res.py
@@ -30,6 +30,8 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
     from datetime import date
 
+    from pymatgen.core.trajectory import Vector3D
+
 __all__ = ["ResProvider", "AirssProvider", "ResIO", "ResWriter", "ResParseError", "ResError"]
 
 
@@ -73,7 +75,7 @@ class ResCELL:
 class Ion:
     specie: str
     specie_num: int
-    pos: tuple[float, float, float]
+    pos: Vector3D
     occupancy: float
     spin: float | None
 
@@ -490,7 +492,7 @@ class AirssProvider(ResProvider):
 
     def get_mpgrid_offset_nkpts_spacing(
         self,
-    ) -> tuple[tuple[int, int, int], tuple[float, float, float], int, float] | None:
+    ) -> tuple[tuple[int, int, int], Vector3D, int, float] | None:
         """
         Retrieves the MP grid, the grid offsets, number of kpoints, and maximum kpoint spacing.
 

--- a/pymatgen/io/tests/test_cif.py
+++ b/pymatgen/io/tests/test_cif.py
@@ -355,6 +355,18 @@ loop_
         }
         assert set(struct2.labels) == expected_site_names2
 
+    def test_cif_writer_labeled(self):
+        parser = CifParser(f"{self.TEST_FILES_DIR}/garnet.cif")
+        struct = parser.get_structures()[0]
+        for i, site in enumerate(struct):
+            site.label = f"my_{site.specie.name}{i}"
+        writer = CifWriter(struct)
+
+        parser2 = CifParser.from_str(str(writer))
+        struct2 = parser2.get_structures()[0]
+
+        assert set(struct.labels) == set(struct2.labels)
+
     def test_cif_parser_springer_pauling(self):
         # Below are 10 tests for CIFs from the Springer Materials/Pauling file DBs.
 

--- a/pymatgen/io/tests/test_cif.py
+++ b/pymatgen/io/tests/test_cif.py
@@ -333,7 +333,7 @@ loop_
             # Ensure the site label starts with the site species name
             assert site.label.startswith(site.specie.name)
 
-        # ensure multiple species with different names have coorect labels
+        # ensure multiple species with different names have correct labels
         parser2 = CifParser(f"{self.TEST_FILES_DIR}/Fe3O4.cif")
         struct2 = parser2.get_structures(primitive=False)[0]
 

--- a/pymatgen/io/tests/test_cif.py
+++ b/pymatgen/io/tests/test_cif.py
@@ -358,8 +358,8 @@ loop_
     def test_cif_writer_labeled(self):
         parser = CifParser(f"{self.TEST_FILES_DIR}/garnet.cif")
         struct = parser.get_structures()[0]
-        for i, site in enumerate(struct):
-            site.label = f"my_{site.specie.name}{i}"
+        for idx, site in enumerate(struct):
+            site.label = f"my_{site.specie.name}{idx}"
         writer = CifWriter(struct)
 
         parser2 = CifParser.from_str(str(writer))

--- a/pymatgen/io/tests/test_cif.py
+++ b/pymatgen/io/tests/test_cif.py
@@ -333,6 +333,28 @@ loop_
             # Ensure the site label starts with the site species name
             assert site.label.startswith(site.specie.name)
 
+        # ensure multiple species with different names have coorect labels
+        parser2 = CifParser(f"{self.TEST_FILES_DIR}/Fe3O4.cif")
+        struct2 = parser2.get_structures(primitive=False)[0]
+
+        expected_site_names2 = {
+            "O1",
+            "O2",
+            "O3",
+            "O4",
+            "O5",
+            "O6",
+            "O7",
+            "O8",
+            "Fe9",
+            "Fe10",
+            "Fe11",
+            "Fe12",
+            "Fe13",
+            "Fe14",
+        }
+        assert set(struct2.labels) == expected_site_names2
+
     def test_cif_parser_springer_pauling(self):
         # Below are 10 tests for CIFs from the Springer Materials/Pauling file DBs.
 

--- a/pymatgen/io/tests/test_cif.py
+++ b/pymatgen/io/tests/test_cif.py
@@ -337,22 +337,7 @@ loop_
         parser2 = CifParser(f"{self.TEST_FILES_DIR}/Fe3O4.cif")
         struct2 = parser2.get_structures(primitive=False)[0]
 
-        expected_site_names2 = {
-            "O1",
-            "O2",
-            "O3",
-            "O4",
-            "O5",
-            "O6",
-            "O7",
-            "O8",
-            "Fe9",
-            "Fe10",
-            "Fe11",
-            "Fe12",
-            "Fe13",
-            "Fe14",
-        }
+        expected_site_names2 = {*"O1 O2 O3 O4 O5 O6 O7 O8 Fe9 Fe10 Fe11 Fe12 Fe13 Fe14".split()}
         assert set(struct2.labels) == expected_site_names2
 
     def test_cif_writer_labeled(self):

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -40,6 +40,7 @@ from pymatgen.util.string import str_delimited
 if TYPE_CHECKING:
     from numpy.typing import ArrayLike
 
+    from pymatgen.core.trajectory import Vector3D
     from pymatgen.util.typing import PathLike
 
 
@@ -1034,7 +1035,7 @@ class Kpoints(MSONable):
         num_kpts: int = 0,
         style: KpointsSupportedModes = supported_modes.Gamma,
         kpts: Sequence[float | int | Sequence] = ((1, 1, 1),),
-        kpts_shift: tuple[float, float, float] = (0, 0, 0),
+        kpts_shift: Vector3D = (0, 0, 0),
         kpts_weights=None,
         coord_type=None,
         labels=None,
@@ -1155,7 +1156,7 @@ class Kpoints(MSONable):
         )
 
     @staticmethod
-    def gamma_automatic(kpts: tuple[int, int, int] = (1, 1, 1), shift: tuple[float, float, float] = (0, 0, 0)):
+    def gamma_automatic(kpts: tuple[int, int, int] = (1, 1, 1), shift: Vector3D = (0, 0, 0)):
         """
         Convenient static constructor for an automatic Gamma centered Kpoint
         grid.
@@ -1177,7 +1178,7 @@ class Kpoints(MSONable):
         )
 
     @staticmethod
-    def monkhorst_automatic(kpts: tuple[int, int, int] = (2, 2, 2), shift: tuple[float, float, float] = (0, 0, 0)):
+    def monkhorst_automatic(kpts: tuple[int, int, int] = (2, 2, 2), shift: Vector3D = (0, 0, 0)):
         """
         Convenient static constructor for an automatic Monkhorst pack Kpoint
         grid.


### PR DESCRIPTION
## Summary

This PR follows up from #3137 and makes sure that labels are propagated correctly throughout structure, for example, when making supercells, inserting/deleting sites, applying translations/rotations, etc.

This PR also fixes a bug where the labels were incorrectly assigned when the CIF contains multiple species with different names.

Major changes:

- feature 1: Propagate labels in operations on structure
- fix 1: Correctly generate labels when cif contains multiple species with same name

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [x] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
