### PR TITLE
Unskip and fix `packmol` tests

### DIFF
--- a/pymatgen/core/tests/test_structure.py
+++ b/pymatgen/core/tests/test_structure.py
@@ -6,7 +6,6 @@ import random
 import warnings
 from pathlib import Path
 from shutil import which
-from tempfile import TemporaryDirectory
 from unittest import skipIf
 
 import numpy as np
@@ -1467,8 +1466,7 @@ class StructureTest(PymatgenTest):
     def test_relax_ase_opt_kwargs(self):
         pytest.importorskip("ase")
         structure = self.cu_structure
-        tmp_dir = TemporaryDirectory()
-        traj_file = f"{tmp_dir.name}/testing.traj"
+        traj_file = f"{self.tmp_path}/testing.traj"
         relaxed, traj = structure.relax(
             calculator=EMT(), fmax=0.01, steps=2, return_trajectory=True, opt_kwargs={"trajectory": traj_file}
         )
@@ -2005,8 +2003,7 @@ class MoleculeTest(PymatgenTest):
 
     def test_relax_ase_mol_return_traj(self):
         pytest.importorskip("ase")
-        tmp_dir = TemporaryDirectory()
-        traj_file = f"{tmp_dir.name}/testing.traj"
+        traj_file = f"{self.tmp_path}/testing.traj"
         relaxed, traj = self.mol.relax(
             calculator=EMT(), fmax=0.01, steps=2, return_trajectory=True, opt_kwargs={"trajectory": traj_file}
         )

--- a/pymatgen/io/tests/test_packmol.py
+++ b/pymatgen/io/tests/test_packmol.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import os
-import tempfile
 from pathlib import Path
 from subprocess import TimeoutExpired
 
@@ -20,186 +19,168 @@ if True:  # if which("packmol") is None:
     pytest.skip("packmol executable not present", allow_module_level=True)
 
 
-@pytest.fixture()
-def ethanol():
-    """
-    Returns a Molecule of ethanol
-    """
-    ethanol_coords = [
-        [0.00720, -0.56870, 0.00000],
-        [-1.28540, 0.24990, 0.00000],
-        [1.13040, 0.31470, 0.00000],
-        [0.03920, -1.19720, 0.89000],
-        [0.03920, -1.19720, -0.89000],
-        [-1.31750, 0.87840, 0.89000],
-        [-1.31750, 0.87840, -0.89000],
-        [-2.14220, -0.42390, -0.00000],
-        [1.98570, -0.13650, -0.00000],
-    ]
-    ethanol_atoms = ["C", "C", "O", "H", "H", "H", "H", "H", "H"]
+ethanol_coords = [
+    [0.00720, -0.56870, 0.00000],
+    [-1.28540, 0.24990, 0.00000],
+    [1.13040, 0.31470, 0.00000],
+    [0.03920, -1.19720, 0.89000],
+    [0.03920, -1.19720, -0.89000],
+    [-1.31750, 0.87840, 0.89000],
+    [-1.31750, 0.87840, -0.89000],
+    [-2.14220, -0.42390, -0.00000],
+    [1.98570, -0.13650, -0.00000],
+]
+ethanol_atoms = ["C", "C", "O", "H", "H", "H", "H", "H", "H"]
 
-    return Molecule(ethanol_atoms, ethanol_coords)
+ethanol = Molecule(ethanol_atoms, ethanol_coords)
 
 
-@pytest.fixture()
-def water():
-    """
-    Returns a Molecule of water
-    """
-    water_coords = [
-        [9.626, 6.787, 12.673],
-        [9.626, 8.420, 12.673],
-        [10.203, 7.604, 12.673],
-    ]
-    water_atoms = ["H", "H", "O"]
+water_coords = [
+    [9.626, 6.787, 12.673],
+    [9.626, 8.420, 12.673],
+    [10.203, 7.604, 12.673],
+]
+water_atoms = ["H", "H", "O"]
 
-    return Molecule(water_atoms, water_coords)
+water = Molecule(water_atoms, water_coords)
 
 
-class TestPackmolSet:
-    def test_packmol_with_molecule(self, water, ethanol):
+class TestPackmolSet(PymatgenTest):
+    def test_packmol_with_molecule(self):
         """
         Test coords input as Molecule
         """
-        with tempfile.TemporaryDirectory() as scratch_dir:
-            pw = PackmolBoxGen().get_input_set(
-                molecules=[
-                    {"name": "water", "number": 10, "coords": water},
-                    {"name": "ethanol", "number": 20, "coords": ethanol},
-                ],
-            )
-            pw.write_input(scratch_dir)
-            pw.run(scratch_dir)
-            assert os.path.exists(os.path.join(scratch_dir, "packmol_out.xyz"))
-            out = Molecule.from_file(os.path.join(scratch_dir, "packmol_out.xyz"))
-            assert out.composition.num_atoms == 10 * 3 + 20 * 9
+        pw = PackmolBoxGen().get_input_set(
+            molecules=[
+                {"name": "water", "number": 10, "coords": water},
+                {"name": "ethanol", "number": 20, "coords": ethanol},
+            ],
+        )
+        pw.write_input(self.tmp_path)
+        pw.run(self.tmp_path)
+        assert os.path.exists(os.path.join(self.tmp_path, "packmol_out.xyz"))
+        out = Molecule.from_file(os.path.join(self.tmp_path, "packmol_out.xyz"))
+        assert out.composition.num_atoms == 10 * 3 + 20 * 9
 
     def test_packmol_with_str(self):
         """
         Test coords input as strings
         """
-        with tempfile.TemporaryDirectory() as scratch_dir:
-            pw = PackmolBoxGen().get_input_set(
-                molecules=[
-                    {"name": "EMC", "number": 10, "coords": os.path.join(test_dir, "subdir with spaces", "EMC.xyz.gz")},
-                    {"name": "LiTFSi", "number": 20, "coords": os.path.join(test_dir, "LiTFSi.xyz.gz")},
-                ],
-            )
-            pw.write_input(scratch_dir)
-            pw.run(scratch_dir)
-            assert os.path.exists(os.path.join(scratch_dir, "packmol_out.xyz"))
-            out = Molecule.from_file(os.path.join(scratch_dir, "packmol_out.xyz"))
-            assert out.composition.num_atoms == 10 * 15 + 20 * 16
+        pw = PackmolBoxGen().get_input_set(
+            molecules=[
+                {"name": "EMC", "number": 10, "coords": os.path.join(test_dir, "subdir with spaces", "EMC.xyz")},
+                {"name": "LiTFSi", "number": 20, "coords": os.path.join(test_dir, "LiTFSi.xyz")},
+            ],
+        )
+        pw.write_input(self.tmp_path)
+        pw.run(self.tmp_path)
+        assert os.path.exists(os.path.join(self.tmp_path, "packmol_out.xyz"))
+        out = Molecule.from_file(os.path.join(self.tmp_path, "packmol_out.xyz"))
+        assert out.composition.num_atoms == 10 * 15 + 20 * 16
 
     def test_packmol_with_path(self):
         """
         Test coords input as Path. Use a subdirectory with spaces.
         """
-        p1 = Path(os.path.join(test_dir, "subdir with spaces", "EMC.xyz.gz"))
-        p2 = Path(os.path.join(test_dir, "LiTFSi.xyz.gz"))
-        with tempfile.TemporaryDirectory() as scratch_dir:
-            pw = PackmolBoxGen().get_input_set(
-                molecules=[
-                    {"name": "EMC", "number": 10, "coords": p1},
-                    {"name": "LiTFSi", "number": 20, "coords": p2},
-                ],
-            )
-            pw.write_input(scratch_dir)
-            pw.run(scratch_dir)
-            assert os.path.exists(os.path.join(scratch_dir, "packmol_out.xyz"))
-            out = Molecule.from_file(os.path.join(scratch_dir, "packmol_out.xyz"))
-            assert out.composition.num_atoms == 10 * 15 + 20 * 16
+        p1 = Path(os.path.join(test_dir, "subdir with spaces", "EMC.xyz"))
+        p2 = Path(os.path.join(test_dir, "LiTFSi.xyz"))
+        pw = PackmolBoxGen().get_input_set(
+            molecules=[
+                {"name": "EMC", "number": 10, "coords": p1},
+                {"name": "LiTFSi", "number": 20, "coords": p2},
+            ],
+        )
+        pw.write_input(self.tmp_path)
+        pw.run(self.tmp_path)
+        assert os.path.exists(os.path.join(self.tmp_path, "packmol_out.xyz"))
+        out = Molecule.from_file(os.path.join(self.tmp_path, "packmol_out.xyz"))
+        assert out.composition.num_atoms == 10 * 15 + 20 * 16
 
-    def test_control_params(self, water, ethanol):
+    def test_control_params(self):
         """
         Check that custom control_params work and that ValueError
         is raised when 'ERROR' appears in stdout (even if return code is 0)
         """
-        with tempfile.TemporaryDirectory() as scratch_dir:
-            input_set = PackmolBoxGen(
-                control_params={"maxit": 0, "nloop": 0},
-            ).get_input_set(
-                molecules=[
-                    {"name": "water", "number": 1000, "coords": water},
-                    {"name": "ethanol", "number": 2000, "coords": ethanol},
-                ],
-            )
-            input_set.write_input(scratch_dir)
-            with open(os.path.join(scratch_dir, "packmol.inp")) as f:
-                input_string = f.read()
-                assert "maxit 0" in input_string
-                assert "nloop 0" in input_string
-            with pytest.raises(ValueError):
-                input_set.run(scratch_dir)
+        input_set = PackmolBoxGen(
+            control_params={"maxit": 0, "nloop": 0},
+        ).get_input_set(
+            molecules=[
+                {"name": "water", "number": 1000, "coords": water},
+                {"name": "ethanol", "number": 2000, "coords": ethanol},
+            ],
+        )
+        input_set.write_input(self.tmp_path)
+        with open(os.path.join(self.tmp_path, "packmol.inp")) as f:
+            input_string = f.read()
+            assert "maxit 0" in input_string
+            assert "nloop 0" in input_string
+        with pytest.raises(ValueError):
+            input_set.run(self.tmp_path)
 
-    def test_timeout(self, water, ethanol):
+    def test_timeout(self):
         """
         Check that the timeout works
         """
-        with tempfile.TemporaryDirectory() as scratch_dir:
-            pw = PackmolBoxGen().get_input_set(
-                molecules=[
-                    {"name": "water", "number": 1000, "coords": water},
-                    {"name": "ethanol", "number": 2000, "coords": ethanol},
-                ],
-            )
-            pw.write_input(scratch_dir)
-            with pytest.raises(TimeoutExpired):
-                pw.run(scratch_dir, 1)
+        pw = PackmolBoxGen().get_input_set(
+            molecules=[
+                {"name": "water", "number": 1000, "coords": water},
+                {"name": "ethanol", "number": 2000, "coords": ethanol},
+            ],
+        )
+        pw.write_input(self.tmp_path)
+        with pytest.raises(TimeoutExpired):
+            pw.run(self.tmp_path, 1)
 
-    def test_no_return_and_box(self, water, ethanol):
+    def test_no_return_and_box(self):
         """
         Make sure the code raises an error if packmol doesn't
         exit cleanly. Also verify the box arg works properly.
         """
-        with tempfile.TemporaryDirectory() as scratch_dir:
-            pw = PackmolBoxGen().get_input_set(
-                molecules=[
-                    {"name": "water", "number": 1000, "coords": water},
-                    {"name": "ethanol", "number": 2000, "coords": ethanol},
-                ],
-                box=[0, 0, 0, 2, 2, 2],
-            )
-            pw.write_input(scratch_dir)
-            with open(os.path.join(scratch_dir, "packmol.inp")) as f:
-                input_string = f.read()
-                assert "inside box 0 0 0 2 2 2" in input_string
-            with pytest.raises(ValueError):
-                pw.run(scratch_dir)
+        pw = PackmolBoxGen().get_input_set(
+            molecules=[
+                {"name": "water", "number": 1000, "coords": water},
+                {"name": "ethanol", "number": 2000, "coords": ethanol},
+            ],
+            box=[0, 0, 0, 2, 2, 2],
+        )
+        pw.write_input(self.tmp_path)
+        with open(os.path.join(self.tmp_path, "packmol.inp")) as f:
+            input_string = f.read()
+            assert "inside box 0 0 0 2 2 2" in input_string
+        with pytest.raises(ValueError):
+            pw.run(self.tmp_path)
 
-    def test_chdir_behavior(self, water, ethanol):
+    def test_chdir_behavior(self):
         """
         Make sure the code returns to the starting directory whether
         or not packmol exits cleanly.
         """
         startdir = str(Path.cwd())
-        with tempfile.TemporaryDirectory() as scratch_dir:
-            # this one will not exit cleanly b/c the box is too small
-            pw = PackmolBoxGen().get_input_set(
-                molecules=[
-                    {"name": "water", "number": 1000, "coords": water},
-                    {"name": "ethanol", "number": 2000, "coords": ethanol},
-                ],
-                box=[0, 0, 0, 2, 2, 2],
-            )
-            pw.write_input(scratch_dir)
-            with pytest.raises(ValueError):
-                pw.run(scratch_dir)
-            assert str(Path.cwd()) == startdir
+        # this one will not exit cleanly b/c the box is too small
+        pw = PackmolBoxGen().get_input_set(
+            molecules=[
+                {"name": "water", "number": 1000, "coords": water},
+                {"name": "ethanol", "number": 2000, "coords": ethanol},
+            ],
+            box=[0, 0, 0, 2, 2, 2],
+        )
+        pw.write_input(self.tmp_path)
+        with pytest.raises(ValueError):
+            pw.run(self.tmp_path)
+        assert str(Path.cwd()) == startdir
 
-        with tempfile.TemporaryDirectory() as scratch_dir:
-            # this one will exit cleanly
-            pw = PackmolBoxGen().get_input_set(
-                molecules=[
-                    {"name": "water", "number": 1000, "coords": water},
-                    {"name": "ethanol", "number": 2000, "coords": ethanol},
-                ],
-            )
-            pw.write_input(scratch_dir)
-            pw.run(scratch_dir)
-            assert str(Path.cwd()) == startdir
+        # this one will exit cleanly
+        pw = PackmolBoxGen().get_input_set(
+            molecules=[
+                {"name": "water", "number": 1000, "coords": water},
+                {"name": "ethanol", "number": 2000, "coords": ethanol},
+            ],
+        )
+        pw.write_input(self.tmp_path)
+        pw.run(self.tmp_path)
+        assert str(Path.cwd()) == startdir
 
-    def test_random_seed(self, water, ethanol):
+    def test_random_seed(self):
         """
         Confirm that seed = -1 generates random structures
         while seed = 1 is deterministic
@@ -207,67 +188,56 @@ class TestPackmolSet:
         mm = MoleculeMatcher()
 
         # deterministic output
-        with tempfile.TemporaryDirectory() as scratch_dir:
-            pw = PackmolBoxGen(
-                seed=1,
-                inputfile="input.in",
-                outputfile="output.xyz",
-            ).get_input_set(
-                # scratch_dir,
-                molecules=[
-                    {"name": "water", "number": 10, "coords": water},
-                    {"name": "ethanol", "number": 20, "coords": ethanol},
-                ],
-            )
-            pw.write_input(scratch_dir)
-            pw.run(scratch_dir)
-            out1 = Molecule.from_file(os.path.join(scratch_dir, "output.xyz"))
-            pw.run(scratch_dir)
-            out2 = Molecule.from_file(os.path.join(scratch_dir, "output.xyz"))
-            assert mm.fit(out1, out2)
+        pw = PackmolBoxGen(seed=1, inputfile="input.in", outputfile="output.xyz").get_input_set(
+            # self.tmp_path,
+            molecules=[
+                {"name": "water", "number": 10, "coords": water},
+                {"name": "ethanol", "number": 20, "coords": ethanol},
+            ],
+        )
+        pw.write_input(self.tmp_path)
+        pw.run(self.tmp_path)
+        out1 = Molecule.from_file(os.path.join(self.tmp_path, "output.xyz"))
+        pw.run(self.tmp_path)
+        out2 = Molecule.from_file(os.path.join(self.tmp_path, "output.xyz"))
+        assert mm.fit(out1, out2)
 
         # randomly generated structures
-        with tempfile.TemporaryDirectory() as scratch_dir:
-            pw = PackmolBoxGen(
-                seed=-1,
-                inputfile="input.in",
-                outputfile="output.xyz",
-            ).get_input_set(
-                molecules=[
-                    {"name": "water", "number": 10, "coords": water},
-                    {"name": "ethanol", "number": 20, "coords": ethanol},
-                ],
-            )
-            pw.write_input(scratch_dir)
-            pw.run(scratch_dir)
-            out1 = Molecule.from_file(os.path.join(scratch_dir, "output.xyz"))
-            pw.run(scratch_dir)
-            out2 = Molecule.from_file(os.path.join(scratch_dir, "output.xyz"))
-            assert not mm.fit(out1, out2)
+        pw = PackmolBoxGen(seed=-1, inputfile="input.in", outputfile="output.xyz").get_input_set(
+            molecules=[
+                {"name": "water", "number": 10, "coords": water},
+                {"name": "ethanol", "number": 20, "coords": ethanol},
+            ],
+        )
+        pw.write_input(self.tmp_path)
+        pw.run(self.tmp_path)
+        out1 = Molecule.from_file(os.path.join(self.tmp_path, "output.xyz"))
+        pw.run(self.tmp_path)
+        out2 = Molecule.from_file(os.path.join(self.tmp_path, "output.xyz"))
+        assert not mm.fit(out1, out2)
 
-    def test_arbitrary_filenames(self, water, ethanol):
+    def test_arbitrary_filenames(self):
         """
         Make sure custom input and output filenames work.
         Use a subdirectory with spaces.
         """
-        with tempfile.TemporaryDirectory() as scratch_dir:
-            os.mkdir(os.path.join(scratch_dir, "subdirectory with spaces"))
-            pw = PackmolBoxGen(
-                inputfile="input.in", outputfile=Path("output.xyz"), stdoutfile=Path("stdout.txt")
-            ).get_input_set(
-                molecules=[
-                    {"name": "water", "number": 10, "coords": water},
-                    {"name": "ethanol", "number": 20, "coords": ethanol},
-                ],
-            )
-            pw.write_input(
-                os.path.join(scratch_dir, "subdirectory with spaces"),
-            )
-            assert os.path.exists(os.path.join(scratch_dir, "subdirectory with spaces", "input.in"))
-            pw.run(
-                os.path.join(scratch_dir, "subdirectory with spaces"),
-            )
-            assert os.path.exists(os.path.join(scratch_dir, "subdirectory with spaces", "output.xyz"))
-            assert os.path.exists(os.path.join(scratch_dir, "subdirectory with spaces", "stdout.txt"))
-            out = Molecule.from_file(os.path.join(scratch_dir, "subdirectory with spaces", "output.xyz"))
-            assert out.composition.num_atoms == 10 * 3 + 20 * 9
+        os.mkdir(os.path.join(self.tmp_path, "subdirectory with spaces"))
+        pw = PackmolBoxGen(
+            inputfile="input.in", outputfile=Path("output.xyz"), stdoutfile=Path("stdout.txt")
+        ).get_input_set(
+            molecules=[
+                {"name": "water", "number": 10, "coords": water},
+                {"name": "ethanol", "number": 20, "coords": ethanol},
+            ],
+        )
+        pw.write_input(
+            os.path.join(self.tmp_path, "subdirectory with spaces"),
+        )
+        assert os.path.exists(os.path.join(self.tmp_path, "subdirectory with spaces", "input.in"))
+        pw.run(
+            os.path.join(self.tmp_path, "subdirectory with spaces"),
+        )
+        assert os.path.exists(os.path.join(self.tmp_path, "subdirectory with spaces", "output.xyz"))
+        assert os.path.exists(os.path.join(self.tmp_path, "subdirectory with spaces", "stdout.txt"))
+        out = Molecule.from_file(os.path.join(self.tmp_path, "subdirectory with spaces", "output.xyz"))
+        assert out.composition.num_atoms == 10 * 3 + 20 * 9

--- a/pymatgen/io/tests/test_packmol.py
+++ b/pymatgen/io/tests/test_packmol.py
@@ -185,6 +185,7 @@ class TestPackmolSet(PymatgenTest):
         Confirm that seed = -1 generates random structures
         while seed = 1 is deterministic
         """
+        pytest.importorskip("openbabel")
         mm = MoleculeMatcher()
 
         # deterministic output

--- a/pymatgen/io/tests/test_packmol.py
+++ b/pymatgen/io/tests/test_packmol.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from shutil import which
 from subprocess import TimeoutExpired
 
 import pytest
@@ -14,8 +15,7 @@ from pymatgen.util.testing import PymatgenTest
 
 test_dir = os.path.join(PymatgenTest.TEST_FILES_DIR, "packmol")
 
-# Just skip this whole test for now since packmol is problematic.
-if True:  # if which("packmol") is None:
+if which("packmol") is None:
     pytest.skip("packmol executable not present", allow_module_level=True)
 
 

--- a/pymatgen/io/tests/test_template_input.py
+++ b/pymatgen/io/tests/test_template_input.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import tempfile
 
 import pytest
 
@@ -11,42 +10,41 @@ from pymatgen.util.testing import PymatgenTest
 test_dir = os.path.join(PymatgenTest.TEST_FILES_DIR)
 
 
-class TestTemplateInputGen:
+class TestTemplateInputGen(PymatgenTest):
     def test_write_inputs(self):
-        with tempfile.TemporaryDirectory() as scratch_dir:
-            tis = TemplateInputGen().get_input_set(
-                template=os.path.join(test_dir, "template_input_file.txt"),
-                variables={"TEMPERATURE": 298},
-                filename="hello_world.in",
-            )
-            tis.write_input(scratch_dir)
-            with open(os.path.join(scratch_dir, "hello_world.in")) as f:
-                assert "298" in f.read()
+        tis = TemplateInputGen().get_input_set(
+            template=os.path.join(test_dir, "template_input_file.txt"),
+            variables={"TEMPERATURE": 298},
+            filename="hello_world.in",
+        )
+        tis.write_input(self.tmp_path)
+        with open(os.path.join(self.tmp_path, "hello_world.in")) as f:
+            assert "298" in f.read()
 
-            with pytest.raises(FileNotFoundError, match="No such file or directory:"):
-                tis.write_input(os.path.join(scratch_dir, "temp"), make_dir=False)
+        with pytest.raises(FileNotFoundError, match="No such file or directory:"):
+            tis.write_input(os.path.join(self.tmp_path, "temp"), make_dir=False)
 
-            tis.write_input(os.path.join(scratch_dir, "temp"), make_dir=True)
+        tis.write_input(os.path.join(self.tmp_path, "temp"), make_dir=True)
 
-            tis = TemplateInputGen().get_input_set(
-                template=os.path.join(test_dir, "template_input_file.txt"),
-                variables={"TEMPERATURE": 400},
-                filename="hello_world.in",
-            )
+        tis = TemplateInputGen().get_input_set(
+            template=os.path.join(test_dir, "template_input_file.txt"),
+            variables={"TEMPERATURE": 400},
+            filename="hello_world.in",
+        )
 
-            # test len, iter, getitem
-            assert len(tis.inputs) == 1
-            assert len(list(tis.inputs)) == 1
-            assert isinstance(tis.inputs["hello_world.in"], str)
+        # test len, iter, getitem
+        assert len(tis.inputs) == 1
+        assert len(list(tis.inputs)) == 1
+        assert isinstance(tis.inputs["hello_world.in"], str)
 
-            with pytest.raises(FileExistsError, match="hello_world.in"):
-                tis.write_input(scratch_dir, overwrite=False)
+        with pytest.raises(FileExistsError, match="hello_world.in"):
+            tis.write_input(self.tmp_path, overwrite=False)
 
-            tis.write_input(scratch_dir, overwrite=True)
+        tis.write_input(self.tmp_path, overwrite=True)
 
-            with open(os.path.join(scratch_dir, "hello_world.in")) as f:
-                assert "400" in f.read()
+        with open(os.path.join(self.tmp_path, "hello_world.in")) as f:
+            assert "400" in f.read()
 
-            tis.write_input(scratch_dir, zip_inputs=True)
+        tis.write_input(self.tmp_path, zip_inputs=True)
 
-            assert "InputSet.zip" in list(os.listdir(scratch_dir))
+        assert "InputSet.zip" in list(os.listdir(self.tmp_path))

--- a/pymatgen/phonon/tests/test_thermal_displacements.py
+++ b/pymatgen/phonon/tests/test_thermal_displacements.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import tempfile
 
 import numpy as np
 from pytest import approx
@@ -167,13 +166,12 @@ class ThermalDisplacementTest(PymatgenTest):
 
     def test_write_file(self):
         printed = False
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            self.thermal.write_cif(os.path.join(tmpdirname, "U.cif"))
-            with open(os.path.join(tmpdirname, "U.cif")) as file:
-                file.seek(0)  # set position to start of file
-                lines = file.read().splitlines()  # now we won't have those newlines
-                if "_atom_site_aniso_U_12" in lines:
-                    printed = True
+        self.thermal.write_cif(f"{self.tmp_path}/U.cif")
+        with open(f"{self.tmp_path}/U.cif") as file:
+            file.seek(0)  # set position to start of file
+            lines = file.read().splitlines()  # now we won't have those newlines
+            if "_atom_site_aniso_U_12" in lines:
+                printed = True
         assert printed
 
     def test_from_ucif(self):
@@ -304,21 +302,19 @@ class ThermalDisplacementTest(PymatgenTest):
     def test_visualization_directionality_criterion(self):
         # test file creation for VESTA
         printed = False
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            self.thermal.visualize_directionality_quality_criterion(
-                filename=os.path.join(tmp_dir, "U.vesta"), other=self.thermal, which_structure=0
-            )
-            with open(os.path.join(tmp_dir, "U.vesta")) as file:
-                file.seek(0)  # set position to start of file
-                lines = file.read().splitlines()  # now we won't have those newlines
-                if "VECTR" in lines:
-                    printed = True
+        self.thermal.visualize_directionality_quality_criterion(
+            filename=f"{self.tmp_path}/U.vesta", other=self.thermal, which_structure=0
+        )
+        with open(f"{self.tmp_path}/U.vesta") as file:
+            file.seek(0)  # set position to start of file
+            lines = file.read().splitlines()  # now we won't have those newlines
+            if "VECTR" in lines:
+                printed = True
         assert printed
 
     def test_from_cif_P1(self):
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            self.thermal.write_cif(os.path.join(tmp_dir, "U.cif"))
-            new_thermals = ThermalDisplacementMatrices.from_cif_P1(os.path.join(tmp_dir, "U.cif"))
-            self.assert_all_close(new_thermals[0].thermal_displacement_matrix_cif_matrixform, self.thermal.Ucif)
-            self.assert_all_close(new_thermals[0].structure.frac_coords, self.thermal.structure.frac_coords)
-            self.assert_all_close(new_thermals[0].structure.volume, self.thermal.structure.volume)
+        self.thermal.write_cif(f"{self.tmp_path}/U.cif")
+        new_thermals = ThermalDisplacementMatrices.from_cif_P1(f"{self.tmp_path}/U.cif")
+        self.assert_all_close(new_thermals[0].thermal_displacement_matrix_cif_matrixform, self.thermal.Ucif)
+        self.assert_all_close(new_thermals[0].structure.frac_coords, self.thermal.structure.frac_coords)
+        self.assert_all_close(new_thermals[0].structure.volume, self.thermal.structure.volume)


### PR DESCRIPTION
60ff0cbb3 don't use tempfile.TemporaryDirectory() in tests, prefer PymatgenTest.tmp_path auto-used fixture
b8a0f633c fix broken test_files paths in TestPackmolSet
2013d15b4 skip failing TestPackmolSet.test_random_seed due to openbabel not installed
b3c6150c3 only skip pymatgen/io/tests/test_packmol.py if packmol not installed