### PR TITLE
Improve `Structure` tests

### DIFF
--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -3649,12 +3649,13 @@ class EconNN(NearNeighbors):
         site = structure[n]
         neighbors = structure.get_neighbors(site, self.cutoff)
 
-        if self.cation_anion and hasattr(site.specie, "oxi_state"):
+        oxi_state = getattr(site.specie, "oxi_state", None)
+        if self.cation_anion and oxi_state is not None:
             # filter out neighbor of like charge (except for neutral sites)
-            if site.specie.oxi_state >= 0:
+            if oxi_state >= 0:
                 neighbors = [n for n in neighbors if n.oxi_state <= 0]
-            elif site.specie.oxi_state <= 0:
-                neighbors = [n for n in neighbors if n.oxi_state >= 0]
+            elif oxi_state < 0:
+                neighbors = [nghbr for nghbr in neighbors if nghbr.oxi_state >= 0]
 
         if self.use_fictive_radius:
             # calculate fictive ionic radii
@@ -3882,7 +3883,8 @@ class CrystalNN(NearNeighbors):
             target = []
             m_oxi = structure[n].specie.oxi_state
             for site in structure:
-                if site.specie.oxi_state * m_oxi <= 0:  # opposite charge
+                oxi_state = getattr(site.specie, "oxi_state", None)
+                if oxi_state is not None and oxi_state * m_oxi <= 0:  # opposite charge
                     target.append(site.specie)
             if not target:
                 raise ValueError("No valid targets for site within cation_anion constraint!")

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -222,8 +222,8 @@ class SiteCollection(collections.abc.Sequence, metaclass=ABCMeta):
         Returns distance between sites at index i and j.
 
         Args:
-            i: Index of first site
-            j: Index of second site
+            i: 1st site index
+            j: 2nd site index
 
         Returns:
             Distance between sites at index i and index j.
@@ -396,9 +396,9 @@ class SiteCollection(collections.abc.Sequence, metaclass=ABCMeta):
         Returns angle specified by three sites.
 
         Args:
-            i: Index of first site.
-            j: Index of second site.
-            k: Index of third site.
+            i: 1st site index
+            j: 2nd site index
+            k: 3rd site index
 
         Returns:
             Angle in degrees.
@@ -412,10 +412,10 @@ class SiteCollection(collections.abc.Sequence, metaclass=ABCMeta):
         Returns dihedral angle specified by four sites.
 
         Args:
-            i: Index of first site
-            j: Index of second site
-            k: Index of third site
-            l: Index of fourth site
+            i: 1st site index
+            j: 2nd site index
+            k: 3rd site index
+            l: 4th site index
 
         Returns:
             Dihedral angle in degrees.
@@ -1368,8 +1368,8 @@ class IStructure(SiteCollection, MSONable):
         atom and the specified jimage atom.
 
         Args:
-            i (int): Index of first site
-            j (int): Index of second site
+            i (int): 1st site index
+            j (int): 2nd site index
             jimage: Number of lattice translations in each lattice direction.
                 Default is None for nearest image.
 
@@ -3042,8 +3042,8 @@ class IMolecule(SiteCollection, MSONable):
         ind1 and ind2.
 
         Args:
-            ind1 (int): Index of first site.
-            ind2 (int): Index of second site.
+            ind1 (int): 1st site index
+            ind2 (int): 2nd site index
             tol (float): Relative tolerance to test. Basically, the code
                 checks if the distance between the sites is less than (1 +
                 tol) * typical bond distances. Defaults to 0.2, i.e.,
@@ -3203,8 +3203,8 @@ class IMolecule(SiteCollection, MSONable):
         Get distance between site i and j.
 
         Args:
-            i (int): Index of first site
-            j (int): Index of second site
+            i (int): 1st site index
+            j (int): 2nd site index
 
         Returns:
             Distance between the two sites.
@@ -3770,7 +3770,7 @@ class Structure(IStructure, collections.abc.MutableSequence):
         occupations.
 
         Args:
-            idx (int): Index of the site in the _sites list.
+            idx (int): Index of the site in the sites list.
             species (species-like): Species of replacement site
             coords (3x1 array): Coordinates of replacement site. If None,
                 the current coordinates are assumed.

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -332,8 +332,9 @@ class SiteCollection(collections.abc.Sequence, metaclass=ABCMeta):
     def __iter__(self) -> Iterator[Site]:
         return self.sites.__iter__()
 
-    def __getitem__(self, ind):
-        return self.sites[ind]
+    # TODO return type needs fixing (can be list[Site] but raises lots of mypy errors)
+    def __getitem__(self, ind: int | slice) -> Site:
+        return self.sites[ind]  # type: ignore[return-value]
 
     def __len__(self) -> int:
         return len(self.sites)
@@ -1375,7 +1376,8 @@ class IStructure(SiteCollection, MSONable):
         Returns:
             distance
         """
-        return self[i].distance(self[j], jimage)
+        site: PeriodicSite = self[i]
+        return site.distance(self[j], jimage)
 
     def get_sites_in_sphere(
         self,

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -206,9 +206,15 @@ class SiteCollection(collections.abc.Sequence, metaclass=ABCMeta):
     DISTANCE_TOLERANCE = 0.5
 
     @property
-    @abstractmethod
-    def sites(self) -> tuple[Site, ...]:
-        """Returns a tuple of sites."""
+    def sites(self) -> Sequence[Site]:
+        """Returns an iterator for the sites in the Structure."""
+        return self._sites
+
+    @sites.setter
+    def sites(self, sites: Sequence[PeriodicSite]) -> None:
+        """Sets the sites in the Structure."""
+        # use tuple for immutable IStructure/IMolecule, else use list
+        self._sites = tuple(sites) if isinstance(self, (IStructure, IMolecule)) else list(sites)
 
     @abstractmethod
     def get_distance(self, i: int, j: int) -> float:
@@ -1204,11 +1210,6 @@ class IStructure(SiteCollection, MSONable):
         periodic structures, this should return the nearest image distance.
         """
         return self.lattice.get_all_distances(self.frac_coords, self.frac_coords)
-
-    @property
-    def sites(self) -> tuple[PeriodicSite, ...]:
-        """Returns an iterator for the sites in the Structure."""
-        return self._sites
 
     @property
     def lattice(self) -> Lattice:

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -208,13 +208,14 @@ class SiteCollection(collections.abc.Sequence, metaclass=ABCMeta):
     @property
     def sites(self) -> list[Site]:
         """Returns an iterator for the sites in the Structure."""
-        return self._sites  # type: ignore[return-value]
+        return self._sites  # type: ignore[has-type]
 
     @sites.setter
     def sites(self, sites: Sequence[PeriodicSite]) -> None:
         """Sets the sites in the Structure."""
-        # use tuple for immutable IStructure/IMolecule, else use list
-        self._sites = tuple(sites) if isinstance(self, (IStructure, IMolecule)) else list(sites)
+        # if self is mutable Structure or Molecule, set _sites as list
+        is_mutable = isinstance(self._sites, list)  # type: ignore[has-type]
+        self._sites = list(sites) if is_mutable else tuple(sites)
 
     @abstractmethod
     def get_distance(self, i: int, j: int) -> float:

--- a/pymatgen/core/tests/test_structure.py
+++ b/pymatgen/core/tests/test_structure.py
@@ -1068,13 +1068,23 @@ class StructureTest(PymatgenTest):
         self.assert_all_close(struct.lattice.abc, [7.6803959, 17.5979979, 7.6803959])
 
     def test_make_supercell(self):
-        self.struct.make_supercell([2, 1, 1])
-        assert self.struct.formula == "Si4"
-        self.struct.make_supercell([[1, 0, 0], [2, 1, 0], [0, 0, 1]])
-        assert self.struct.formula == "Si4"
-        self.struct.make_supercell(2)
-        assert self.struct.formula == "Si32"
-        self.assert_all_close(self.struct.lattice.abc, [15.360792, 35.195996, 7.680396], 5)
+        supercell = self.struct.make_supercell([2, 1, 1])
+        assert supercell.formula == "Si4"
+        # test that make_supercell modified the original structure
+        assert len(self.struct) == len(supercell)
+
+        supercell.make_supercell([[1, 0, 0], [2, 1, 0], [0, 0, 1]])
+        assert supercell.formula == "Si4"
+        supercell.make_supercell(2)
+        assert supercell.formula == "Si32"
+        self.assert_all_close(supercell.lattice.abc, [15.360792, 35.195996, 7.680396], 5)
+
+        # test in_place=False leaves original structure unchanged
+        orig_len = len(self.struct)
+        # test that make_supercell casts floats to ints
+        supercell = self.struct.make_supercell([2.5, 1, 1], in_place=False)
+        assert len(self.struct) == orig_len
+        assert len(supercell) == 2 * orig_len
 
     def test_make_supercell_labeled(self):
         struct = self.labeled_structure.copy()

--- a/pymatgen/core/tests/test_structure.py
+++ b/pymatgen/core/tests/test_structure.py
@@ -1032,6 +1032,12 @@ class StructureTest(PymatgenTest):
         with pytest.raises(IndexError, match="list index out of range"):
             self.struct.translate_sites([5], [0.5, 0.5, 0.5])
 
+        # test inverse operation leaves structure unchanged
+        original_struct = self.struct.copy()
+        self.struct.translate_sites([0], [0.5, 0.5, 0.5], frac_coords=True, to_unit_cell=False)
+        self.struct.translate_sites([0], [-0.5, -0.5, -0.5], frac_coords=True, to_unit_cell=False)
+        assert self.struct == original_struct
+
     def test_rotate_sites(self):
         self.struct.rotate_sites(
             indices=[1],

--- a/pymatgen/core/tests/test_structure.py
+++ b/pymatgen/core/tests/test_structure.py
@@ -1029,6 +1029,9 @@ class StructureTest(PymatgenTest):
         struct_pbc.translate_sites([0], [0.5, 0.5, 0.5], frac_coords=True, to_unit_cell=True)
         self.assert_all_close(struct_pbc.frac_coords[0], [0.25, 0.25, 1.25])
 
+        with pytest.raises(IndexError, match="list index out of range"):
+            self.struct.translate_sites([5], [0.5, 0.5, 0.5])
+
     def test_rotate_sites(self):
         self.struct.rotate_sites(
             indices=[1],
@@ -1044,6 +1047,9 @@ class StructureTest(PymatgenTest):
             to_unit_cell=True,
         )
         self.assert_all_close(self.struct.frac_coords[1], [0.75, 0.5, 0.75], decimal=6)
+
+        with pytest.raises(IndexError, match="list index out of range"):
+            self.struct.rotate_sites([5], 2.0 * np.pi / 3.0, self.struct[0].coords, to_unit_cell=False)
 
     def test_mul(self):
         self.struct *= [2, 1, 1]

--- a/pymatgen/core/tests/test_structure.py
+++ b/pymatgen/core/tests/test_structure.py
@@ -773,13 +773,13 @@ class StructureTest(PymatgenTest):
         coords.append([0, 0, 0])
         coords.append([0.75, 0.5, 0.75])
         lattice = Lattice([[3.8401979337, 0, 0], [1.9200989668, 3.3257101909, 0], [0, -2.2171384943, 3.1355090603]])
-        self.structure = Structure(lattice, ["Si", "Si"], coords)
+        self.struct = Structure(lattice, ["Si", "Si"], coords)
         self.cu_structure = Structure(lattice, ["Cu", "Cu"], coords)
         self.disordered = Structure.from_spacegroup("Im-3m", Lattice.cubic(3), [Composition("Fe0.5Mn0.5")], [[0, 0, 0]])
         self.labeled_structure = Structure(lattice, ["Si", "Si"], coords, labels=["Si1", "Si2"])
 
     def test_mutable_sequence_methods(self):
-        struct = self.structure
+        struct = self.struct
         struct[0] = "Fe"
         assert struct.formula == "Fe1 Si1"
         struct[0] = "Fe", [0.5, 0.5, 0.5]
@@ -807,10 +807,10 @@ class StructureTest(PymatgenTest):
 
     def test_not_hashable(self):
         with pytest.raises(TypeError, match="unhashable type: 'Structure'"):
-            _ = {self.structure: 1}
+            _ = {self.struct: 1}
 
     def test_sort(self):
-        struct = self.structure
+        struct = self.struct
         struct[0] = "F"
         struct.sort()
         assert struct[0].species_string == "Si"
@@ -823,7 +823,7 @@ class StructureTest(PymatgenTest):
         assert struct[1].species_string == "F"
 
     def test_append_insert_remove_replace_substitute(self):
-        struct = self.structure
+        struct = self.struct
         struct.insert(1, "O", [0.5, 0.5, 0.5])
         assert struct.formula == "Si2 O1"
         assert struct.ntypesp == 2
@@ -872,7 +872,7 @@ class StructureTest(PymatgenTest):
         assert struct.formula == "Si1"
 
     def test_add_remove_site_property(self):
-        struct = self.structure
+        struct = self.struct
         struct.add_site_property("charge", [4.1, -5])
         assert struct[0].charge == 4.1
         assert struct[1].charge == -5
@@ -885,15 +885,15 @@ class StructureTest(PymatgenTest):
 
     def test_propertied_structure(self):
         # Make sure that site properties are set to None for missing values.
-        self.structure.add_site_property("charge", [4.1, -5])
-        self.structure.append("Li", [0.3, 0.3, 0.3])
-        assert len(self.structure.site_properties["charge"]) == 3
+        self.struct.add_site_property("charge", [4.1, -5])
+        self.struct.append("Li", [0.3, 0.3, 0.3])
+        assert len(self.struct.site_properties["charge"]) == 3
 
     def test_perturb(self):
         dist = 0.1
-        pre_perturbation_sites = self.structure.copy()
-        self.structure.perturb(distance=dist)
-        post_perturbation_sites = self.structure.sites
+        pre_perturbation_sites = self.struct.copy()
+        self.struct.perturb(distance=dist)
+        post_perturbation_sites = self.struct.sites
 
         for idx, site in enumerate(pre_perturbation_sites):
             assert site.distance(post_perturbation_sites[idx]) == approx(dist), "Bad perturbation distance"
@@ -908,21 +908,21 @@ class StructureTest(PymatgenTest):
 
     def test_add_oxidation_states_by_element(self):
         oxidation_states = {"Si": -4}
-        self.structure.add_oxidation_state_by_element(oxidation_states)
-        for site in self.structure:
+        self.struct.add_oxidation_state_by_element(oxidation_states)
+        for site in self.struct:
             for specie in site.species:
                 assert specie.oxi_state == oxidation_states[specie.symbol], "Wrong oxidation state assigned!"
         oxidation_states = {"Fe": 2}
         with pytest.raises(ValueError, match="Oxidation states not specified for all elements, missing={'Si'}"):
-            self.structure.add_oxidation_state_by_element(oxidation_states)
+            self.struct.add_oxidation_state_by_element(oxidation_states)
 
     def test_add_oxidation_states_by_site(self):
-        self.structure.add_oxidation_state_by_site([2, -4])
-        assert self.structure[0].specie.oxi_state == 2
+        self.struct.add_oxidation_state_by_site([2, -4])
+        assert self.struct[0].specie.oxi_state == 2
         with pytest.raises(
             ValueError, match="Oxidation states of all sites must be specified, expected 2 values, got 1"
         ):
-            self.structure.add_oxidation_state_by_site([1])
+            self.struct.add_oxidation_state_by_site([1])
 
     def test_remove_oxidation_states(self):
         co_elem = Element("Co")
@@ -967,33 +967,27 @@ class StructureTest(PymatgenTest):
 
     def test_apply_operation(self):
         op = SymmOp.from_axis_angle_and_translation([0, 0, 1], 90)
-        struct = self.structure.copy()
+        struct = self.struct.copy()
         struct.apply_operation(op)
         self.assert_all_close(
             struct.lattice.matrix,
             [
-                [0.000000, 3.840198, 0.000000],
-                [-3.325710, 1.920099, 0.000000],
-                [2.217138, -0.000000, 3.135509],
+                [0, 3.840198, 0],
+                [-3.325710, 1.920099, 0],
+                [2.217138, -0, 3.135509],
             ],
             5,
         )
 
         op = SymmOp([[1, 1, 0, 0.5], [1, 0, 0, 0.5], [0, 0, 1, 0.5], [0, 0, 0, 1]])
-        struct = self.structure.copy()
+        struct = self.struct.copy()
         struct.apply_operation(op, fractional=True)
         self.assert_all_close(
-            struct.lattice.matrix,
-            [
-                [5.760297, 3.325710, 0.000000],
-                [3.840198, 0.000000, 0.000000],
-                [0.000000, -2.217138, 3.135509],
-            ],
-            5,
+            struct.lattice.matrix, [[5.760297, 3.325710, 0], [3.840198, 0, 0], [0, -2.217138, 3.135509]], 5
         )
 
     def test_apply_strain(self):
-        struct = self.structure
+        struct = self.struct
         initial_coord = struct[1].coords
         struct.apply_strain(0.01)
         assert approx(struct.lattice.abc) == (3.8785999130369997, 3.878600984287687, 3.8785999130549516)
@@ -1006,63 +1000,63 @@ class StructureTest(PymatgenTest):
         assert c2 / c1 == approx(1.3)
 
     def test_scale_lattice(self):
-        initial_coord = self.structure[1].coords
-        self.structure.scale_lattice(self.structure.volume * 1.01**3)
+        initial_coord = self.struct[1].coords
+        self.struct.scale_lattice(self.struct.volume * 1.01**3)
         self.assert_all_close(
-            self.structure.lattice.abc,
+            self.struct.lattice.abc,
             (3.8785999130369997, 3.878600984287687, 3.8785999130549516),
         )
-        self.assert_all_close(self.structure[1].coords, initial_coord * 1.01)
+        self.assert_all_close(self.struct[1].coords, initial_coord * 1.01)
 
     def test_translate_sites(self):
-        self.structure.translate_sites([0, 1], [0.5, 0.5, 0.5], frac_coords=True)
-        self.assert_all_close(self.structure.frac_coords[0], [0.5, 0.5, 0.5])
+        self.struct.translate_sites([0, 1], [0.5, 0.5, 0.5], frac_coords=True)
+        self.assert_all_close(self.struct.frac_coords[0], [0.5, 0.5, 0.5])
 
-        self.structure.translate_sites([0], [0.5, 0.5, 0.5], frac_coords=False)
-        self.assert_all_close(self.structure.cart_coords[0], [3.38014845, 1.05428585, 2.06775453])
+        self.struct.translate_sites([0], [0.5, 0.5, 0.5], frac_coords=False)
+        self.assert_all_close(self.struct.cart_coords[0], [3.38014845, 1.05428585, 2.06775453])
 
-        self.structure.translate_sites([0], [0.5, 0.5, 0.5], frac_coords=True, to_unit_cell=False)
-        self.assert_all_close(self.structure.frac_coords[0], [1.00187517, 1.25665291, 1.15946374])
+        self.struct.translate_sites([0], [0.5, 0.5, 0.5], frac_coords=True, to_unit_cell=False)
+        self.assert_all_close(self.struct.frac_coords[0], [1.00187517, 1.25665291, 1.15946374])
 
-        lattice_pbc = Lattice(self.structure.lattice.matrix, pbc=(True, True, False))
+        lattice_pbc = Lattice(self.struct.lattice.matrix, pbc=(True, True, False))
         struct_pbc = Structure(lattice_pbc, ["Si"], [[0.75, 0.75, 0.75]])
         struct_pbc.translate_sites([0], [0.5, 0.5, 0.5], frac_coords=True, to_unit_cell=True)
         self.assert_all_close(struct_pbc.frac_coords[0], [0.25, 0.25, 1.25])
 
     def test_rotate_sites(self):
-        self.structure.rotate_sites(
+        self.struct.rotate_sites(
             indices=[1],
             theta=2.0 * np.pi / 3.0,
-            anchor=self.structure[0].coords,
+            anchor=self.struct[0].coords,
             to_unit_cell=False,
         )
-        self.assert_all_close(self.structure.frac_coords[1], [-1.25, 1.5, 0.75], decimal=6)
-        self.structure.rotate_sites(
+        self.assert_all_close(self.struct.frac_coords[1], [-1.25, 1.5, 0.75], decimal=6)
+        self.struct.rotate_sites(
             indices=[1],
             theta=2.0 * np.pi / 3.0,
-            anchor=self.structure[0].coords,
+            anchor=self.struct[0].coords,
             to_unit_cell=True,
         )
-        self.assert_all_close(self.structure.frac_coords[1], [0.75, 0.5, 0.75], decimal=6)
+        self.assert_all_close(self.struct.frac_coords[1], [0.75, 0.5, 0.75], decimal=6)
 
     def test_mul(self):
-        self.structure *= [2, 1, 1]
-        assert self.structure.formula == "Si4"
-        struct = [2, 1, 1] * self.structure
+        self.struct *= [2, 1, 1]
+        assert self.struct.formula == "Si4"
+        struct = [2, 1, 1] * self.struct
         assert struct.formula == "Si8"
         assert isinstance(struct, Structure)
-        struct = self.structure * [[1, 0, 0], [2, 1, 0], [0, 0, 2]]
+        struct = self.struct * [[1, 0, 0], [2, 1, 0], [0, 0, 2]]
         assert struct.formula == "Si8"
         self.assert_all_close(struct.lattice.abc, [7.6803959, 17.5979979, 7.6803959])
 
     def test_make_supercell(self):
-        self.structure.make_supercell([2, 1, 1])
-        assert self.structure.formula == "Si4"
-        self.structure.make_supercell([[1, 0, 0], [2, 1, 0], [0, 0, 1]])
-        assert self.structure.formula == "Si4"
-        self.structure.make_supercell(2)
-        assert self.structure.formula == "Si32"
-        self.assert_all_close(self.structure.lattice.abc, [15.360792, 35.195996, 7.680396], 5)
+        self.struct.make_supercell([2, 1, 1])
+        assert self.struct.formula == "Si4"
+        self.struct.make_supercell([[1, 0, 0], [2, 1, 0], [0, 0, 1]])
+        assert self.struct.formula == "Si4"
+        self.struct.make_supercell(2)
+        assert self.struct.formula == "Si32"
+        self.assert_all_close(self.struct.lattice.abc, [15.360792, 35.195996, 7.680396], 5)
 
     def test_make_supercell_labeled(self):
         struct = self.labeled_structure.copy()
@@ -1080,47 +1074,47 @@ class StructureTest(PymatgenTest):
 
     def test_another_supercell(self):
         # this is included b/c for some reason the old algo was failing on it
-        struct = self.structure.copy()
+        struct = self.struct.copy()
         struct.make_supercell([[0, 2, 2], [2, 0, 2], [2, 2, 0]])
         assert struct.formula == "Si32"
-        struct = self.structure.copy()
+        struct = self.struct.copy()
         struct.make_supercell([[0, 2, 0], [1, 0, 0], [0, 0, 1]])
         assert struct.formula == "Si4"
 
     def test_to_from_dict(self):
-        d = self.structure.as_dict()
+        d = self.struct.as_dict()
         s2 = Structure.from_dict(d)
         assert isinstance(s2, Structure)
 
     def test_default_dict_attrs(self):
-        d = self.structure.as_dict()
+        d = self.struct.as_dict()
         assert d["charge"] == 0
 
     def test_to_from_abivars(self):
         """Test as_dict, from_dict with fmt == abivars."""
-        d = self.structure.as_dict(fmt="abivars")
+        d = self.struct.as_dict(fmt="abivars")
         s2 = Structure.from_dict(d, fmt="abivars")
-        assert s2 == self.structure
+        assert s2 == self.struct
         assert isinstance(s2, Structure)
 
     def test_to_from_file_string(self):
         # to/from string
         for fmt in ["cif", "json", "poscar", "cssr", "yaml", "xsf", "res"]:
-            struct = self.structure.to(fmt=fmt)
+            struct = self.struct.to(fmt=fmt)
             assert struct is not None
             ss = Structure.from_str(struct, fmt=fmt)
-            self.assert_all_close(ss.lattice.parameters, self.structure.lattice.parameters, decimal=5)
-            self.assert_all_close(ss.frac_coords, self.structure.frac_coords)
+            self.assert_all_close(ss.lattice.parameters, self.struct.lattice.parameters, decimal=5)
+            self.assert_all_close(ss.frac_coords, self.struct.frac_coords)
             assert isinstance(ss, Structure)
 
         # to/from file
-        self.structure.to(filename="POSCAR.testing")
+        self.struct.to(filename="POSCAR.testing")
         assert os.path.isfile("POSCAR.testing")
 
         for ext in (".json", ".json.gz", ".json.bz2", ".json.xz", ".json.lzma"):
-            self.structure.to(filename=f"json-struct{ext}")
+            self.struct.to(filename=f"json-struct{ext}")
             assert os.path.isfile(f"json-struct{ext}")
-            assert Structure.from_file(f"json-struct{ext}") == self.structure
+            assert Structure.from_file(f"json-struct{ext}") == self.struct
 
     def test_from_spacegroup(self):
         s1 = Structure.from_spacegroup("Fm-3m", Lattice.cubic(3), ["Li", "O"], [[0.25, 0.25, 0.25], [0, 0, 0]])
@@ -1224,7 +1218,7 @@ class StructureTest(PymatgenTest):
         latt = Lattice.hexagonal(3.374351, 20.308941)
         species = ["Ta", "S", "S"]
         coords = [
-            [0.000000, 0.000000, 0.944333],
+            [0, 0, 0.944333],
             [0.333333, 0.666667, 0.353424],
             [0.666667, 0.333333, 0.535243],
         ]
@@ -1237,7 +1231,7 @@ class StructureTest(PymatgenTest):
         species = ["Na", "V", "S", "S"]
         coords = [
             [0.333333, 0.666667, 0.165000],
-            [0.000000, 0.000000, 0.998333],
+            [0, 0, 0.998333],
             [0.333333, 0.666667, 0.399394],
             [0.666667, 0.333333, 0.597273],
         ]
@@ -1251,7 +1245,7 @@ class StructureTest(PymatgenTest):
         species = ["Na", "V", "S", "S"]
         coords = [
             [0.333333, 0.666667, 0.165000],
-            [0.000000, 0.000000, 0.998333],
+            [0, 0, 0.998333],
             [0.333333, 0.666667, 0.399394],
             [0.666667, 0.333333, 0.597273],
         ]
@@ -1263,24 +1257,24 @@ class StructureTest(PymatgenTest):
         assert 51.5 in [itr.properties["prop1"] for itr in navs2.sites]
 
     def test_properties(self):
-        assert self.structure.num_sites == len(self.structure)
-        self.structure.make_supercell(2)
-        self.structure[1] = "C"
-        sites = list(self.structure.group_by_types())
+        assert self.struct.num_sites == len(self.struct)
+        self.struct.make_supercell(2)
+        self.struct[1] = "C"
+        sites = list(self.struct.group_by_types())
         assert sites[-1].specie.symbol == "C"
-        self.structure.add_oxidation_state_by_element({"Si": 4, "C": 2})
-        assert self.structure.charge == 62
+        self.struct.add_oxidation_state_by_element({"Si": 4, "C": 2})
+        assert self.struct.charge == 62
 
     def test_species(self):
-        assert {*map(str, self.structure.species)} == {"Si"}
-        assert len(self.structure.species) == len(self.structure)
+        assert {*map(str, self.struct.species)} == {"Si"}
+        assert len(self.struct.species) == len(self.struct)
 
         # https://github.com/materialsproject/pymatgen/issues/3033
         with pytest.raises(AttributeError, match="species property only supports ordered structures!"):
             _ = self.disordered.species
 
     def test_set_item(self):
-        struct = self.structure.copy()
+        struct = self.struct.copy()
         struct[0] = "C"
         assert struct.formula == "Si1 C1"
         struct[(0, 1)] = "Ge"
@@ -1288,7 +1282,7 @@ class StructureTest(PymatgenTest):
         struct[0:2] = "Sn"
         assert struct.formula == "Sn2"
 
-        struct = self.structure.copy()
+        struct = self.struct.copy()
         struct["Si"] = "C"
         assert struct.formula == "C2"
         struct["C"] = "C0.25Si0.5"
@@ -1305,12 +1299,12 @@ class StructureTest(PymatgenTest):
             )
 
     def test_from_sites(self):
-        self.structure.add_site_property("hello", [1, 2])
-        struct = Structure.from_sites(self.structure, to_unit_cell=True)
+        self.struct.add_site_property("hello", [1, 2])
+        struct = Structure.from_sites(self.struct, to_unit_cell=True)
         assert struct.site_properties["hello"][1] == 2
 
     def test_charge(self):
-        struct = Structure.from_sites(self.structure)
+        struct = Structure.from_sites(self.struct)
         assert struct.charge == 0, "Initial Structure not defaulting to behavior in SiteCollection"
         struct.add_oxidation_state_by_site([1, 1])
         assert struct.charge == 2, "Initial Structure not defaulting to behavior in SiteCollection"
@@ -1356,9 +1350,9 @@ class StructureTest(PymatgenTest):
 
     def test_extract_cluster(self):
         coords = [
-            [0.000000, 0.000000, 0.000000],
-            [0.000000, 0.000000, 1.089000],
-            [1.026719, 0.000000, -0.363000],
+            [0, 0, 0],
+            [0, 0, 1.089000],
+            [1.026719, 0, -0.363000],
             [-0.513360, -0.889165, -0.363000],
             [-0.513360, 0.889165, -0.363000],
         ]
@@ -1553,9 +1547,9 @@ Sites (8)
 class IMoleculeTest(PymatgenTest):
     def setUp(self):
         coords = [
-            [0.000000, 0.000000, 0.000000],
-            [0.000000, 0.000000, 1.089000],
-            [1.026719, 0.000000, -0.363000],
+            [0, 0, 0],
+            [0, 0, 1.089000],
+            [1.026719, 0, -0.363000],
             [-0.513360, -0.889165, -0.363000],
             [-0.513360, 0.889165, -0.363000],
         ]
@@ -1581,9 +1575,9 @@ class IMoleculeTest(PymatgenTest):
 
     def test_bad_molecule(self):
         coords = [
-            [0.000000, 0.000000, 0.000000],
-            [0.000000, 0.000000, 1.089000],
-            [1.026719, 0.000000, -0.363000],
+            [0, 0, 0],
+            [0, 0, 1.089000],
+            [1.026719, 0, -0.363000],
             [-0.513360, -0.889165, -0.363000],
             [-0.513360, 0.889165, -0.363000],
             [-0.513360, 0.889165, -0.36301],
@@ -1743,9 +1737,9 @@ Site: H (-0.5134, 0.8892, -0.3630)"""
 
     def test_no_spin_check(self):
         coords = [
-            [0.000000, 0.000000, 0.000000],
-            [0.000000, 0.000000, 1.089000],
-            [1.026719, 0.000000, -0.363000],
+            [0, 0, 0],
+            [0, 0, 1.089000],
+            [1.026719, 0, -0.363000],
             [-0.513360, -0.889165, -0.363000],
         ]
         with pytest.raises(
@@ -1766,8 +1760,8 @@ Site: H (-0.5134, 0.8892, -0.3630)"""
         self.assert_all_close(centered.center_of_mass, [0, 0, 0])
 
     def test_to_from_dict(self):
-        d = self.mol.as_dict()
-        mol2 = IMolecule.from_dict(d)
+        dct = self.mol.as_dict()
+        mol2 = IMolecule.from_dict(dct)
         assert isinstance(mol2, IMolecule)
         propertied_mol = Molecule(
             ["C", "H", "H", "H", "H"],
@@ -1775,9 +1769,9 @@ Site: H (-0.5134, 0.8892, -0.3630)"""
             charge=1,
             site_properties={"magmom": [0.5, -0.5, 1, 2, 3]},
         )
-        d = propertied_mol.as_dict()
-        assert d["sites"][0]["properties"]["magmom"] == 0.5
-        mol = Molecule.from_dict(d)
+        dct = propertied_mol.as_dict()
+        assert dct["sites"][0]["properties"]["magmom"] == 0.5
+        mol = Molecule.from_dict(dct)
         assert propertied_mol == mol
         assert mol[0].magmom == 0.5
         assert mol.formula == "H4 C1"
@@ -1809,9 +1803,9 @@ Site: H (-0.5134, 0.8892, -0.3630)"""
 class MoleculeTest(PymatgenTest):
     def setUp(self):
         coords = [
-            [0.000000, 0.000000, 0.000000],
-            [0.000000, 0.000000, 1.089000],
-            [1.026719, 0.000000, -0.363000],
+            [0, 0, 0],
+            [0, 0, 1.089000],
+            [1.026719, 0, -0.363000],
             [-0.513360, -0.889165, -0.363000],
             [-0.513360, 0.889165, -0.363000],
         ]
@@ -1899,13 +1893,13 @@ class MoleculeTest(PymatgenTest):
     def test_apply_operation(self):
         op = SymmOp.from_axis_angle_and_translation([0, 0, 1], 90)
         self.mol.apply_operation(op)
-        self.assert_all_close(self.mol[2].coords, [0.000000, 1.026719, -0.363000])
+        self.assert_all_close(self.mol[2].coords, [0, 1.026719, -0.363000])
 
     def test_substitute(self):
         coords = [
-            [0.000000, 0.000000, 1.08],
-            [0.000000, 0.000000, 0.000000],
-            [1.026719, 0.000000, -0.363000],
+            [0, 0, 1.08],
+            [0, 0, 0],
+            [1.026719, 0, -0.363000],
             [-0.513360, -0.889165, -0.363000],
             [-0.513360, 0.889165, -0.363000],
         ]
@@ -1967,12 +1961,7 @@ class MoleculeTest(PymatgenTest):
         assert cluster.formula == "H4 C1"
 
     def test_no_spin_check(self):
-        coords = [
-            [0.000000, 0.000000, 0.000000],
-            [0.000000, 0.000000, 1.089000],
-            [1.026719, 0.000000, -0.363000],
-            [-0.513360, -0.889165, -0.363000],
-        ]
+        coords = [[0, 0, 0], [0, 0, 1.089000], [1.026719, 0, -0.363000], [-0.513360, -0.889165, -0.363000]]
         expected_msg = "Charge of 0 and spin multiplicity of 1 is not possible for this molecule"
         with pytest.raises(ValueError, match=expected_msg):
             mol = Molecule(["C", "H", "H", "H"], coords, charge=0, spin_multiplicity=1)

--- a/pymatgen/core/tests/test_structure.py
+++ b/pymatgen/core/tests/test_structure.py
@@ -766,6 +766,12 @@ Direct
         assert_array_equal(struct_pbc.pbc, (True, True, False))
         assert not struct_pbc.is_3d_periodic
 
+    def test_sites_setter(self):
+        struct = self.struct.copy()
+        new_sites = struct.sites[::-1]  # reverse order of sites
+        struct.sites = new_sites
+        assert struct.sites == new_sites
+
 
 class StructureTest(PymatgenTest):
     def setUp(self):


### PR DESCRIPTION
Most notable user-facing change: add `in_place: bool = True` keyword to `Structure.make_supercell()` and return the supercell.

a70f4c4c5 add `Structure/Molecule.sites` setter, move `@property` to SiteCollection
7f510ca35 don't use implementation detail `(Structure|Molecule)._sites`
c5052a223 rename `StructureTest.structure` attr to `struct`
28a895fcb add `IStructureTest.test_sites_setter`
185d2cb7c fix mypy
94f4413a7 test `translate/rotate_sites` `IndexError` if "list index out of range"
2ffd3bb67 tweak doc strings
f482ba0f3 test inverse `translate_sites` operations leave structure unchanged
7197592b6 `Structure.make_supercell()` add `in_place: bool = True` keyword and return supercell structure
638c095de test `make_supercell` `in_place=True` and `False`