### PR TITLE
[BUG] Allow None for Magmom values

### DIFF
--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -722,7 +722,14 @@ class Incar(dict, MSONable):
                 else:
                     # float() to ensure backwards compatibility between
                     # float magmoms and Magmom objects
-                    for m, g in itertools.groupby(self[k], lambda x: float(x)):
+                    # skip if all None
+                    if all(m is None for m in self[k]):
+                        continue
+
+                    def float_or_none(x):
+                        return float(x) if x is not None else None
+
+                    for m, g in itertools.groupby(self[k], lambda x: float_or_none(x)):
                         value.append(f"{len(tuple(g))}*{m}")
 
                 lines.append([k, " ".join(value)])


### PR DESCRIPTION
A possible follow-up to #3179 

Recent changes resulted in some of the structures in my atomate2 workflow that had `[None, ...]` for all the `Magmom` values.  I'm still looking into where these `[None, ...]` values came from (not 100% sure it's related to #3179) but this fix:
- Skips writing Magmom completely if all values are `None`
- Change `None` -> 0 if only some of the values are `None`