### PR TITLE
Fix GitHub language statistics after test files migration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 # declare HTML, rST and test files as vendored/docs to exclude them when calculating repo languages on GitHub
-**/test/files/**/* linguist-vendored
+tests/files/**/* linguist-vendored
 cmd_line/* linguist-vendored
 docs/**/* linguist-generated
 docs_rst/**/* linguist-documentation

--- a/pymatgen/analysis/chemenv/coordination_environments/voronoi.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/voronoi.py
@@ -11,8 +11,8 @@ from scipy.spatial import Voronoi
 
 from pymatgen.analysis.chemenv.utils.coordination_geometry_utils import (
     get_lower_and_upper_f,
-    my_solid_angle,
     rectangle_surface_intersection,
+    solid_angle,
 )
 from pymatgen.analysis.chemenv.utils.defs_utils import AdditionalConditions
 from pymatgen.analysis.chemenv.utils.math_utils import normal_cdf_step
@@ -164,7 +164,7 @@ class DetailedVoronoiContainer(MSONable):
 
                     ridge_point2 = max(ridge_points)
                     facets = [all_vertices[i] for i in ridge_vertices_indices]
-                    sa = my_solid_angle(site.coords, facets)
+                    sa = solid_angle(site.coords, facets)
                     maxangle = max([sa, maxangle])
 
                     mindist = min([mindist, distances[ridge_point2]])

--- a/pymatgen/analysis/dimensionality.py
+++ b/pymatgen/analysis/dimensionality.py
@@ -475,10 +475,10 @@ def find_clusters(struct, connected_matrix):
                 atom_cluster = visit(new_atom, atom_cluster)
         return atom_cluster
 
-    for i in range(n_atoms):
-        if not visited[i]:
+    for idx in range(n_atoms):
+        if not visited[idx]:
             atom_cluster = set()
-            cluster = visit(i, atom_cluster)
+            cluster = visit(idx, atom_cluster)
             clusters.append(cluster)
             cluster_sizes.append(len(cluster))
 

--- a/pymatgen/analysis/eos.py
+++ b/pymatgen/analysis/eos.py
@@ -459,11 +459,11 @@ class NumericalEOS(PolynomialEOS):
         # sort by volume
         e_v = sorted(e_v, key=lambda x: x[1])
         # index of minimum energy tuple in the volume sorted list
-        emin_idx = e_v.index(e_min)
+        e_min_idx = e_v.index(e_min)
         # the volume lower than the volume corresponding to minimum energy
-        v_before = e_v[emin_idx - 1][1]
+        v_before = e_v[e_min_idx - 1][1]
         # the volume higher than the volume corresponding to minimum energy
-        v_after = e_v[emin_idx + 1][1]
+        v_after = e_v[e_min_idx + 1][1]
         e_v_work = deepcopy(e_v)
 
         # loop over the data points.
@@ -472,18 +472,18 @@ class NumericalEOS(PolynomialEOS):
             e = [ei[0] for ei in e_v_work]
             v = [ei[1] for ei in e_v_work]
             # loop over polynomial order
-            for i in range(min_poly_order, max_poly_order + 1):
-                coeffs = np.polyfit(v, e, i)
+            for idx in range(min_poly_order, max_poly_order + 1):
+                coeffs = np.polyfit(v, e, idx)
                 pder = np.polyder(coeffs)
                 a = np.poly1d(pder)(v_before)
                 b = np.poly1d(pder)(v_after)
                 if a * b < 0:
                     rms = get_rms(e, np.poly1d(coeffs)(v))
-                    rms_min = min(rms_min, rms * i / ndata_fit)
-                    all_coeffs[(i, ndata_fit)] = [coeffs.tolist(), rms]
+                    rms_min = min(rms_min, rms * idx / ndata_fit)
+                    all_coeffs[(idx, ndata_fit)] = [coeffs.tolist(), rms]
                     # store the fit coefficients small to large,
                     # i.e a0, a1, .. an
-                    all_coeffs[(i, ndata_fit)][0].reverse()
+                    all_coeffs[(idx, ndata_fit)][0].reverse()
             # remove 1 data point from each end.
             e_v_work.pop()
             e_v_work.pop(0)

--- a/pymatgen/analysis/graphs.py
+++ b/pymatgen/analysis/graphs.py
@@ -683,8 +683,8 @@ class StructureGraph(MSONable):
             atoms = len(grp) - 1
             offset = len(self.structure) - atoms
 
-            for i in range(atoms):
-                grp_map[i] = i + offset
+            for idx in range(atoms):
+                grp_map[idx] = idx + offset
 
             return grp_map
 

--- a/pymatgen/analysis/reaction_calculator.py
+++ b/pymatgen/analysis/reaction_calculator.py
@@ -37,10 +37,8 @@ class BalancedReaction(MSONable):
         Reactants and products to be specified as dict of {Composition: coeff}.
 
         Args:
-            reactants_coeffs ({Composition: float}): Reactants as dict of
-                {Composition: amt}.
-            products_coeffs ({Composition: float}): Products as dict of
-                {Composition: amt}.
+            reactants_coeffs (dict[Composition, float]): Reactants as dict of {Composition: amt}.
+            products_coeffs (dict[Composition, float]): Products as dict of {Composition: amt}.
         """
         # sum reactants and products
         all_reactants = sum((k * v for k, v in reactants_coeffs.items()), Composition({}))
@@ -58,11 +56,11 @@ class BalancedReaction(MSONable):
         self._coeffs = []
         self._els = []
         self._all_comp = []
-        for c in set(list(reactants_coeffs) + list(products_coeffs)):
-            coeff = products_coeffs.get(c, 0) - reactants_coeffs.get(c, 0)
+        for key in {*reactants_coeffs, *products_coeffs}:
+            coeff = products_coeffs.get(key, 0) - reactants_coeffs.get(key, 0)
 
             if abs(coeff) > self.TOLERANCE:
-                self._all_comp.append(c)
+                self._all_comp.append(key)
                 self._coeffs.append(coeff)
 
     def calculate_energy(self, energies):

--- a/tests/analysis/test_graphs.py
+++ b/tests/analysis/test_graphs.py
@@ -4,6 +4,7 @@ import copy
 import os
 import unittest
 import warnings
+from glob import glob
 from shutil import which
 
 import networkx as nx
@@ -350,36 +351,37 @@ from    to  to_image
     @unittest.skipIf(pygraphviz is None or not (which("neato") and which("fdp")), "graphviz executables not present")
     def test_draw(self):
         # draw MoS2 graph
-        self.mos2_sg.draw_graph_to_file("MoS2_single.pdf", image_labels=True, hide_image_edges=False)
+        self.mos2_sg.draw_graph_to_file(f"{self.tmp_path}/MoS2_single.pdf", image_labels=True, hide_image_edges=False)
         mos2_sg = self.mos2_sg * (9, 9, 1)
-        mos2_sg.draw_graph_to_file("MoS2.pdf", algo="neato")
+        mos2_sg.draw_graph_to_file(f"{self.tmp_path}/MoS2.pdf", algo="neato")
 
         # draw MoS2 graph that's been successively multiplied
         mos2_sg_2 = self.mos2_sg * (3, 3, 1)
         mos2_sg_2 = mos2_sg_2 * (3, 3, 1)
-        mos2_sg_2.draw_graph_to_file("MoS2_twice_mul.pdf", algo="neato", hide_image_edges=True)
+        mos2_sg_2.draw_graph_to_file(f"{self.tmp_path}/MoS2_twice_mul.pdf", algo="neato", hide_image_edges=True)
 
         # draw MoS2 graph that's generated from a pre-multiplied Structure
         mos2_sg_premul = StructureGraph.with_local_env_strategy(self.structure * (3, 3, 1), MinimumDistanceNN())
-        mos2_sg_premul.draw_graph_to_file("MoS2_premul.pdf", algo="neato", hide_image_edges=True)
+        mos2_sg_premul.draw_graph_to_file(f"{self.tmp_path}/MoS2_premul.pdf", algo="neato", hide_image_edges=True)
 
         # draw graph for a square lattice
-        self.square_sg.draw_graph_to_file("square_single.pdf", hide_image_edges=False)
+        self.square_sg.draw_graph_to_file(f"{self.tmp_path}/square_single.pdf", hide_image_edges=False)
         square_sg = self.square_sg * (5, 5, 1)
-        square_sg.draw_graph_to_file("square.pdf", algo="neato", image_labels=True, node_labels=False)
+        square_sg.draw_graph_to_file(f"{self.tmp_path}/square.pdf", algo="neato", image_labels=True, node_labels=False)
 
         # draw graph for a body-centered square lattice
-        self.bc_square_sg.draw_graph_to_file("bc_square_single.pdf", hide_image_edges=False)
+        self.bc_square_sg.draw_graph_to_file(f"{self.tmp_path}/bc_square_single.pdf", hide_image_edges=False)
         bc_square_sg = self.bc_square_sg * (9, 9, 1)
-        bc_square_sg.draw_graph_to_file("bc_square.pdf", algo="neato", image_labels=False)
+        bc_square_sg.draw_graph_to_file(f"{self.tmp_path}/bc_square.pdf", algo="neato", image_labels=False)
 
         # draw graph for a body-centered square lattice defined in an alternative way
-        self.bc_square_sg_r.draw_graph_to_file("bc_square_r_single.pdf", hide_image_edges=False)
+        self.bc_square_sg_r.draw_graph_to_file(f"{self.tmp_path}/bc_square_r_single.pdf", hide_image_edges=False)
         bc_square_sg_r = self.bc_square_sg_r * (9, 9, 1)
-        bc_square_sg_r.draw_graph_to_file("bc_square_r.pdf", algo="neato", image_labels=False)
+        bc_square_sg_r.draw_graph_to_file(f"{self.tmp_path}/bc_square_r.pdf", algo="neato", image_labels=False)
 
-        # delete generated test files
-        test_files = (
+        # ensure PDF files were created
+        pdfs = {path.split("/") for path in glob(f"{self.tmp_path}/*.pdf")}
+        expected_pdfs = {
             "bc_square_r_single.pdf",
             "bc_square_r.pdf",
             "bc_square_single.pdf",
@@ -390,9 +392,8 @@ from    to  to_image
             "MoS2.pdf",
             "square_single.pdf",
             "square.pdf",
-        )
-        for test_file in test_files:
-            os.remove(test_file)
+        }
+        assert pdfs == expected_pdfs
 
     def test_to_from_dict(self):
         d = self.mos2_sg.as_dict()


### PR DESCRIPTION
8039195ac refactor TestStructureGraph.test_draw use PymatgenTest.tmp_path
824296fff BalancedReaction don't create unnecessary lists
874baa587 .gitattributes fix tests/files/ path causing wrong repo language statistics

Should say 100% Python. GH linguist misclassifies our test files. This PR ignores test files altogether.