### PR TITLE
Deprecate `get_string()` methods in favor of `get_str()`

### DIFF
--- a/pymatgen/io/core.py
+++ b/pymatgen/io/core.py
@@ -31,6 +31,7 @@ from collections.abc import MutableMapping
 from pathlib import Path
 from zipfile import ZipFile
 
+import numpy as np
 from monty.io import zopen
 from monty.json import MSONable
 
@@ -67,6 +68,20 @@ class InputFile(MSONable):
         filename = filename if isinstance(filename, Path) else Path(filename)
         with zopen(filename, "wt") as f:
             f.write(self.get_string())
+
+    @np.deprecate(message="Use from_str instead")
+    @classmethod
+    @abc.abstractmethod
+    def from_string(cls, contents: str):
+        """
+        Create an InputFile object from a string.
+
+        Args:
+            contents: The contents of the file as a single string
+
+        Returns:
+            InputFile
+        """
 
     @classmethod
     @abc.abstractmethod

--- a/pymatgen/io/core.py
+++ b/pymatgen/io/core.py
@@ -73,7 +73,7 @@ class InputFile(MSONable):
         """
         filename = filename if isinstance(filename, Path) else Path(filename)
         with zopen(filename, "wt") as file:
-            file.write(self.get_string())
+            file.write(self.get_str())
 
     @np.deprecate(message="Use from_str instead")
     @classmethod
@@ -118,7 +118,7 @@ class InputFile(MSONable):
             return cls.from_str(f.read())
 
     def __str__(self) -> str:
-        return self.get_string()
+        return self.get_str()
 
 
 class InputSet(MSONable, MutableMapping):

--- a/pymatgen/io/core.py
+++ b/pymatgen/io/core.py
@@ -56,6 +56,11 @@ class InputFile(MSONable):
     """
 
     @abc.abstractmethod
+    def get_str(self) -> str:
+        """Return a string representation of an entire input file."""
+
+    @np.deprecate(message="Use get_str instead")
+    @abc.abstractmethod
     def get_string(self) -> str:
         """Return a string representation of an entire input file."""
 

--- a/pymatgen/io/core.py
+++ b/pymatgen/io/core.py
@@ -29,6 +29,7 @@ import abc
 import os
 from collections.abc import MutableMapping
 from pathlib import Path
+from typing import Iterator
 from zipfile import ZipFile
 
 import numpy as np
@@ -66,13 +67,13 @@ class InputFile(MSONable):
             filename: The filename to output to, including path.
         """
         filename = filename if isinstance(filename, Path) else Path(filename)
-        with zopen(filename, "wt") as f:
-            f.write(self.get_string())
+        with zopen(filename, "wt") as file:
+            file.write(self.get_string())
 
     @np.deprecate(message="Use from_str instead")
     @classmethod
     @abc.abstractmethod
-    def from_string(cls, contents: str):
+    def from_string(cls, contents: str) -> InputFile:
         """
         Create an InputFile object from a string.
 
@@ -85,7 +86,7 @@ class InputFile(MSONable):
 
     @classmethod
     @abc.abstractmethod
-    def from_str(cls, contents: str):
+    def from_str(cls, contents: str) -> InputFile:
         """
         Create an InputFile object from a string.
 
@@ -111,7 +112,7 @@ class InputFile(MSONable):
         with zopen(filename, "rt") as f:
             return cls.from_str(f.read())
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.get_string()
 
 
@@ -147,11 +148,11 @@ class InputSet(MSONable, MutableMapping):
         self._kwargs = kwargs
         self.__dict__.update(**kwargs)
 
-    def __getattr__(self, k):
+    def __getattr__(self, key):
         # allow accessing keys as attributes
-        if k in self._kwargs:
-            return self.get(k)
-        raise AttributeError(f"'{type(self).__name__}' object has no attribute {k!r}")
+        if key in self._kwargs:
+            return self.get(key)
+        raise AttributeError(f"'{type(self).__name__}' object has no attribute {key!r}")
 
     def __copy__(self) -> InputSet:
         cls = self.__class__
@@ -174,19 +175,19 @@ class InputSet(MSONable, MutableMapping):
 
         return new_instance
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.inputs)
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[str | Path]:
         return iter(self.inputs)
 
-    def __getitem__(self, key):
+    def __getitem__(self, key) -> str | InputFile | slice:
         return self.inputs[key]
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: str | Path, value: str | InputFile) -> None:
         self.inputs[key] = value
 
-    def __delitem__(self, key):
+    def __delitem__(self, key: str | Path) -> None:
         del self.inputs[key]
 
     def write_input(

--- a/pymatgen/io/core.py
+++ b/pymatgen/io/core.py
@@ -75,8 +75,8 @@ class InputFile(MSONable):
         with zopen(filename, "wt") as file:
             file.write(self.get_str())
 
-    @np.deprecate(message="Use from_str instead")
     @classmethod
+    @np.deprecate(message="Use from_str instead")
     @abc.abstractmethod
     def from_string(cls, contents: str) -> InputFile:
         """

--- a/pymatgen/io/cp2k/inputs.py
+++ b/pymatgen/io/cp2k/inputs.py
@@ -134,7 +134,11 @@ class Keyword(MSONable):
         dct["verbose"] = self.verbose
         return dct
 
-    def get_string(self):
+    @np.deprecate(message="Use get_str instead")
+    def get_string(self, *args, **kwargs) -> str:
+        return self.get_str(*args, **kwargs)
+
+    def get_str(self) -> str:
         """String representation of Keyword."""
         return str(self)
 
@@ -228,7 +232,11 @@ class KeywordList(MSONable):
         """Extend the keyword list."""
         self.keywords.extend(lst)
 
-    def get_string(self, indent=0):
+    @np.deprecate(message="Use get_str instead")
+    def get_string(self, *args, **kwargs) -> str:
+        return self.get_str(*args, **kwargs)
+
+    def get_str(self, indent: int = 0) -> str:
         """String representation of Keyword."""
         return " \n".join("\t" * indent + str(k) for k in self.keywords)
 
@@ -552,7 +560,11 @@ class Section(MSONable):
             s = s.get_section(p)
         return s
 
-    def get_string(self):
+    @np.deprecate(message="Use get_str instead")
+    def get_string(self, *args, **kwargs) -> str:
+        return self.get_str(*args, **kwargs)
+
+    def get_str(self) -> str:
         """Get string representation of Section."""
         return Section._get_string(self)
 
@@ -646,7 +658,11 @@ class SectionList(MSONable):
     def _get_string(d, indent=0):
         return " \n".join(s._get_string(s, indent) for s in d)
 
-    def get_string(self):
+    @np.deprecate(message="Use get_str instead")
+    def get_string(self, *args, **kwargs) -> str:
+        return self.get_str(*args, **kwargs)
+
+    def get_str(self) -> str:
         """Return string representation of section list."""
         return SectionList._get_string(self.sections)
 
@@ -2361,7 +2377,11 @@ class AtomicMetadata(MSONable):
         md5.update(self.get_string().lower().encode("utf-8"))
         return md5.hexdigest()
 
-    def get_string(self):
+    @np.deprecate(message="Use get_str instead")
+    def get_string(self, *args, **kwargs) -> str:
+        return self.get_str(*args, **kwargs)
+
+    def get_str(self) -> str:
         """Get string representation."""
         return str(self)
 
@@ -2426,11 +2446,21 @@ class GaussianTypeOrbitalBasisSet(AtomicMetadata):
         return [len(e) for e in self.exponents]
 
     @typing.no_type_check
-    def get_string(self) -> str:
+    @np.deprecate(message="Use get_str instead")
+    def get_string(self, *args, **kwargs) -> str:
+        return self.get_str(*args, **kwargs)
+
+    def get_str(self) -> str:
         """Get standard cp2k GTO formatted string."""
-        if any(
-            getattr(self, x, None) is None
-            for x in ("info", "nset", "n", "lmax", "lmin", "nshell", "exponents", "coefficients")
+        if (
+            self.info is None
+            or self.nset is None
+            or self.n is None
+            or self.lmax is None
+            or self.lmin is None
+            or self.nshell is None
+            or self.exponents is None
+            or self.coefficients is None
         ):
             raise ValueError("Must have all attributes defined to get string representation")
 
@@ -2663,18 +2693,22 @@ class GthPotential(AtomicMetadata):
         s = "\n".join(s)
         return cls.from_str(s)
 
-    def get_string(self):
+    @np.deprecate(message="Use get_str instead")
+    def get_string(self, *args, **kwargs) -> str:
+        return self.get_str(*args, **kwargs)
+
+    def get_str(self) -> str:
         """Convert model to a GTH-formatted string."""
-        if None in (
-            self.info,
-            self.n_elecs,
-            self.r_loc,
-            self.nexp_ppl,
-            self.c_exp_ppl,
-            self.radii,
-            self.nprj,
-            self.nprj_ppnl,
-            self.hprj_ppnl,
+        if (  # written verbosely so mypy can perform type narrowing
+            self.info is None
+            or self.n_elecs is None
+            or self.r_loc is None
+            or self.nexp_ppl is None
+            or self.c_exp_ppl is None
+            or self.radii is None
+            or self.nprj is None
+            or self.nprj_ppnl is None
+            or self.hprj_ppnl is None
         ):
             raise ValueError("Must initialize all attributes in order to get string")
 
@@ -2801,9 +2835,13 @@ class DataFile(MSONable):
         with open(fn, "w") as f:
             f.write(self.get_string())
 
-    def get_string(self):
+    @np.deprecate(message="Use get_str instead")
+    def get_string(self, *args, **kwargs) -> str:
+        return self.get_str(*args, **kwargs)
+
+    def get_str(self) -> str:
         """Get string representation."""
-        return "\n".join(b.get_string() for b in self.objects)
+        return "\n".join(b.get_string() for b in self.objects or [])
 
     def __str__(self):
         return self.get_string()

--- a/pymatgen/io/cp2k/inputs.py
+++ b/pymatgen/io/cp2k/inputs.py
@@ -710,7 +710,7 @@ class Cp2kInput(Section):
             **kwargs,
         )
 
-    def get_string(self):
+    def get_str(self):
         """Get string representation of the Cp2kInput."""
         s = ""
         for v in self.subsections.values():

--- a/pymatgen/io/feff/inputs.py
+++ b/pymatgen/io/feff/inputs.py
@@ -613,7 +613,11 @@ class Tags(dict):
                 i[k] = v
         return i
 
-    def get_string(self, sort_keys=False, pretty=False):
+    @np.deprecate(message="Use get_str instead")
+    def get_string(self, *args, **kwargs) -> str:
+        return self.get_str(*args, **kwargs)
+
+    def get_str(self, sort_keys: bool = False, pretty: bool = False) -> str:
         """
         Returns a string representation of the Tags. The reason why this
         method is different from the __str__ method is to provide options

--- a/pymatgen/io/feff/inputs.py
+++ b/pymatgen/io/feff/inputs.py
@@ -670,7 +670,7 @@ class Tags(dict):
         return str(val)
 
     def __str__(self):
-        return self.get_string()
+        return self.get_str()
 
     def write_file(self, filename="PARAMETERS"):
         """

--- a/pymatgen/io/lammps/data.py
+++ b/pymatgen/io/lammps/data.py
@@ -147,7 +147,11 @@ class LammpsBox(MSONable):
         m = self._matrix
         return np.dot(np.cross(m[0], m[1]), m[2])
 
-    def get_string(self, significant_figures=6):
+    @np.deprecate(message="Use get_str instead")
+    def get_string(self, *args, **kwargs) -> str:
+        return self.get_str(*args, **kwargs)
+
+    def get_str(self, significant_figures: int = 6) -> str:
         """
         Returns the string representation of simulation box in LAMMPS
         data file format.
@@ -318,7 +322,11 @@ class LammpsData(MSONable):
             site_properties=site_properties,
         )
 
-    def get_string(self, distance=6, velocity=8, charge=4, hybrid=True):
+    @np.deprecate(message="Use get_str instead")
+    def get_string(self, *args, **kwargs) -> str:
+        return self.get_str(*args, **kwargs)
+
+    def get_str(self, distance: int = 6, velocity: int = 8, charge: int = 4, hybrid: bool = True) -> str:
         """
         Returns the string representation of LammpsData, essentially
         the string to be written to a file. Support hybrid style
@@ -402,12 +410,12 @@ class LammpsData(MSONable):
             "q": map_charges,
         }
         coeffsdatatype = loadfn(str(MODULE_DIR / "CoeffsDataType.yaml"))
-        coeffs = {}
+        coeffs: dict[str, dict] = {}
         for style, types in coeffsdatatype.items():
             coeffs[style] = {}
             for type, formatter in types.items():
                 coeffs[style][type] = {}
-                for coeff, datatype in formatter.items():
+                for coeff, datatype in formatter.items():  # type: ignore
                     if datatype == "int_format":
                         coeffs[style][type][coeff] = int_format
                     elif datatype == "float_format_2":
@@ -1415,7 +1423,11 @@ class CombinedData(LammpsData):
             assert atom_style == style_return, "Data have different atom_style as specified."
         return cls(mols, names, list_of_numbers, coordinates, style_return)
 
-    def get_string(self, distance=6, velocity=8, charge=4, hybrid=True):
+    @np.deprecate(message="Use get_str instead")
+    def get_string(self, *args, **kwargs) -> str:
+        return self.get_str(*args, **kwargs)
+
+    def get_str(self, distance=6, velocity=8, charge=4, hybrid=True) -> str:
         """
         Returns the string representation of CombinedData, essentially
         the string to be written to a file. Combination info is included

--- a/pymatgen/io/lammps/data.py
+++ b/pymatgen/io/lammps/data.py
@@ -136,10 +136,10 @@ class LammpsBox(MSONable):
         self._matrix = matrix
 
     def __str__(self):
-        return self.get_string()
+        return self.get_str()
 
     def __repr__(self):
-        return self.get_string()
+        return self.get_str()
 
     @property
     def volume(self):
@@ -284,10 +284,10 @@ class LammpsData(MSONable):
         self.atom_style = atom_style
 
     def __str__(self):
-        return self.get_string()
+        return self.get_str()
 
     def __repr__(self):
-        return self.get_string()
+        return self.get_str()
 
     @property
     def structure(self):
@@ -357,7 +357,7 @@ class LammpsData(MSONable):
 
 {body}
 """
-        box = self.box.get_string(distance)
+        box = self.box.get_str(distance)
 
         body_dict = {}
         body_dict["Masses"] = self.masses
@@ -409,9 +409,9 @@ class LammpsData(MSONable):
             "vz": map_velos,
             "q": map_charges,
         }
-        coeffsdatatype = loadfn(str(MODULE_DIR / "CoeffsDataType.yaml"))
+        coeffs_data_type = loadfn(str(MODULE_DIR / "CoeffsDataType.yaml"))
         coeffs: dict[str, dict] = {}
-        for style, types in coeffsdatatype.items():
+        for style, types in coeffs_data_type.items():
             coeffs[style] = {}
             for type, formatter in types.items():
                 coeffs[style][type] = {}
@@ -479,7 +479,7 @@ class LammpsData(MSONable):
                 charges. Default to 4.
         """
         with open(filename, "w") as f:
-            f.write(self.get_string(distance=distance, velocity=velocity, charge=charge))
+            f.write(self.get_str(distance=distance, velocity=velocity, charge=charge))
 
     def disassemble(self, atom_labels=None, guess_element=True, ff_label="ff_map"):
         """
@@ -1453,7 +1453,7 @@ class CombinedData(LammpsData):
         Returns:
             String representation
         """
-        lines = LammpsData.get_string(self, distance, velocity, charge, hybrid).splitlines()
+        lines = LammpsData.get_str(self, distance, velocity, charge, hybrid).splitlines()
         info = "# " + " + ".join(
             (str(a) + " " + b) if c == 1 else (str(a) + "(" + str(c) + ") " + b)
             for a, b, c in zip(self.nums, self.names, self.mols_per_data)

--- a/pymatgen/io/lammps/inputs.py
+++ b/pymatgen/io/lammps/inputs.py
@@ -470,7 +470,11 @@ class LammpsInputFile(InputFile):
         # Append the two list of stages
         self.stages += new_list_to_add
 
-    def get_string(self, ignore_comments: bool = False, keep_stages: bool = True) -> str:
+    @np.deprecate(message="Use get_str instead")
+    def get_string(self, *args, **kwargs) -> str:
+        return self.get_str(*args, **kwargs)
+
+    def get_str(self, ignore_comments: bool = False, keep_stages: bool = True) -> str:
         """
         Generates and ² the string representation of the LammpsInputFile.
         Stages are separated by empty lines.

--- a/pymatgen/io/lammps/inputs.py
+++ b/pymatgen/io/lammps/inputs.py
@@ -523,7 +523,7 @@ class LammpsInputFile(InputFile):
         """
         filename = filename if isinstance(filename, Path) else Path(filename)
         with zopen(filename, "wt") as f:
-            f.write(self.get_string(ignore_comments=ignore_comments, keep_stages=keep_stages))
+            f.write(self.get_str(ignore_comments=ignore_comments, keep_stages=keep_stages))
 
     @classmethod
     @np.deprecate(message="Use from_str instead")
@@ -629,7 +629,7 @@ class LammpsInputFile(InputFile):
             return cls.from_str(f.read(), ignore_comments=ignore_comments, keep_stages=keep_stages)
 
     def __repr__(self):
-        return self.get_string()
+        return self.get_str()
 
     def _initialize_stage(self, stage_name: str | None = None, stage_index: int | None = None):
         """

--- a/pymatgen/io/lmto.py
+++ b/pymatgen/io/lmto.py
@@ -50,15 +50,15 @@ class LMTOCtrl:
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, type(self)):
             return NotImplemented
-        return self.get_string() == other.get_string()
+        return self.get_str() == other.get_str()
 
     def __repr__(self):
         """Representation of the CTRL file is as a string."""
-        return self.get_string()
+        return self.get_str()
 
     def __str__(self):
         """String representation of the CTRL file."""
-        return self.get_string()
+        return self.get_str()
 
     @np.deprecate(message="Use get_str instead")
     def get_string(self, *args, **kwargs) -> str:
@@ -140,7 +140,7 @@ class LMTOCtrl:
         used as input for lmhart.run.
         """
         with zopen(filename, "wt") as f:
-            f.write(self.get_string(**kwargs))
+            f.write(self.get_str(**kwargs))
 
     @classmethod
     def from_file(cls, filename="CTRL", **kwargs):

--- a/pymatgen/io/lmto.py
+++ b/pymatgen/io/lmto.py
@@ -89,7 +89,7 @@ class LMTOCtrl:
                         lst.append("POS=" + " ".join(str(round(p, sigfigs)) for p in val))
                     else:
                         lst.append(f"{token}={val}")
-                line = " ".join(line)
+                line = " ".join(lst)
                 lines.append(line)
 
         return "\n".join(lines) + "\n"

--- a/pymatgen/io/qchem/inputs.py
+++ b/pymatgen/io/qchem/inputs.py
@@ -6,6 +6,7 @@ import logging
 import re
 from typing import TYPE_CHECKING, Literal
 
+import numpy as np
 from monty.io import zopen
 
 from pymatgen.core import Molecule
@@ -202,7 +203,11 @@ class QCInput(InputFile):
         #   - Validity checks specific to job type?
         #   - Check OPT and PCM sections?
 
-    def get_string(self):
+    @np.deprecate(message="Use get_str instead")
+    def get_string(self, *args, **kwargs) -> str:
+        return self.get_str(*args, **kwargs)
+
+    def get_str(self) -> str:
         """Return a string representation of an entire input file."""
         return str(self)
 

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -466,7 +466,11 @@ class Poscar(MSONable):
             predictor_corrector_preamble=predictor_corrector_preamble,
         )
 
-    def get_string(self, direct: bool = True, vasp4_compatible: bool = False, significant_figures: int = 16) -> str:
+    @np.deprecate(message="Use get_str instead")
+    def get_string(self, *args, **kwargs) -> str:
+        return self.get_str(*args, **kwargs)
+
+    def get_str(self, direct: bool = True, vasp4_compatible: bool = False, significant_figures: int = 16) -> str:
         """
         Returns a string to be written as a POSCAR file. By default, site
         symbols are written, which means compatibility is for vasp >= 5.
@@ -695,7 +699,11 @@ class Incar(dict, MSONable):
             d["MAGMOM"] = [Magmom.from_dict(m) for m in d["MAGMOM"]]
         return Incar({k: v for k, v in d.items() if k not in ("@module", "@class")})
 
-    def get_string(self, sort_keys: bool = False, pretty: bool = False) -> str:
+    @np.deprecate(message="Use get_str instead")
+    def get_string(self, *args, **kwargs) -> str:
+        return self.get_str(*args, **kwargs)
+
+    def get_str(self, sort_keys: bool = False, pretty: bool = False) -> str:
         """
         Returns a string representation of the INCAR. The reason why this
         method is different from the __str__ method is to provide options for

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -542,11 +542,11 @@ class Poscar(MSONable):
         return "\n".join(lines) + "\n"
 
     def __repr__(self):
-        return self.get_string()
+        return self.get_str()
 
     def __str__(self):
         """String representation of Poscar file."""
-        return self.get_string()
+        return self.get_str()
 
     def write_file(self, filename: PathLike, **kwargs):
         """
@@ -554,7 +554,7 @@ class Poscar(MSONable):
         the Poscar.get_string method and are passed through directly.
         """
         with zopen(filename, "wt") as f:
-            f.write(self.get_string(**kwargs))
+            f.write(self.get_str(**kwargs))
 
     def as_dict(self) -> dict:
         """MSONable dict."""
@@ -745,7 +745,7 @@ class Incar(dict, MSONable):
         return str_delimited(lines, None, " = ") + "\n"
 
     def __str__(self):
-        return self.get_string(sort_keys=True, pretty=False)
+        return self.get_str(sort_keys=True, pretty=False)
 
     def write_file(self, filename: PathLike):
         """

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -4236,7 +4236,11 @@ class Xdatcar:
                 structures.append(p.structure)
         self.structures = structures
 
-    def get_string(self, ionicstep_start=1, ionicstep_end=None, significant_figures=8):
+    @np.deprecate(message="Use get_str instead")
+    def get_string(self, *args, **kwargs) -> str:
+        return self.get_str(*args, **kwargs)
+
+    def get_str(self, ionicstep_start: int = 1, ionicstep_end: int | None = None, significant_figures: int = 8) -> str:
         """
         Write  Xdatcar class to a string.
 

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -4291,10 +4291,10 @@ class Xdatcar:
                 Xdatcar.get_string method and are passed through directly.
         """
         with zopen(filename, "wt") as f:
-            f.write(self.get_string(**kwargs))
+            f.write(self.get_str(**kwargs))
 
     def __str__(self):
-        return self.get_string()
+        return self.get_str()
 
 
 class Dynmat:

--- a/tests/io/cp2k/test_inputs.py
+++ b/tests/io/cp2k/test_inputs.py
@@ -178,7 +178,7 @@ class TestInput(PymatgenTest):
         assert kwd.values == ([1, 2, 3],)  # noqa: PD011
         kwd = Keyword("TEST3", "xyz", description="testing", units="Ha")
         assert kwd.description == "testing"
-        assert "[Ha]" in kwd.get_string()
+        assert "[Ha]" in kwd.get_str()
 
     def test_coords(self):
         for strucs in [nonsense_Structure, Si_structure, molecule]:
@@ -205,7 +205,7 @@ class TestInput(PymatgenTest):
 
     def test_odd_file(self):
         scramble = ""
-        for s in self.ci.get_string():
+        for s in self.ci.get_str():
             if np.random.rand(1) > 0.5:
                 if s == "\t":
                     scramble += " "

--- a/tests/io/feff/test_inputs.py
+++ b/tests/io/feff/test_inputs.py
@@ -40,7 +40,7 @@ class TestHeader(unittest.TestCase):
         header = Header.from_str(header_string)
         assert header.struct.composition.reduced_formula == "CoO", "Failed to generate structure from HEADER string"
 
-    def test_get_string(self):
+    def test_get_str(self):
         cif_file = f"{TEST_FILES_DIR}/CoO19128.cif"
         h = Header.from_cif_file(cif_file)
         head = str(h)
@@ -112,7 +112,7 @@ class TestFeffAtoms(unittest.TestCase):
         atoms = Atoms.atoms_string_from_file(filepath)
         assert atoms.splitlines()[3].split()[4] == "O", "failed to read ATOMS file"
 
-    def test_get_string(self):
+    def test_get_str(self):
         header = Header.from_str(header_string)
         struct = header.struct
         central_atom = "O"

--- a/tests/io/lammps/test_data.py
+++ b/tests/io/lammps/test_data.py
@@ -44,13 +44,13 @@ class TestLammpsBox(PymatgenTest):
         assert self.peptide.volume == ov
         assert self.quartz.volume == approx(113.007331)
 
-    def test_get_string(self):
-        peptide = self.peptide.get_string(5)
+    def test_get_str(self):
+        peptide = self.peptide.get_str(5)
         peptide_5 = """36.84019 64.21156  xlo xhi
 41.01369 68.38506  ylo yhi
 29.76809 57.13946  zlo zhi"""
         assert peptide == peptide_5
-        quartz = self.quartz.get_string(4)
+        quartz = self.quartz.get_str(4)
         quartz_4 = """0.0000 4.9134  xlo xhi
 0.0000 4.2551  ylo yhi
 0.0000 5.4052  zlo zhi
@@ -134,8 +134,8 @@ class TestLammpsData(unittest.TestCase):
         lmp2 = LammpsData.from_file("test1.data", atom_style="charge")
         assert lmp2.atoms["type"].tolist() == [1, 2]
 
-    def test_get_string(self):
-        pep = self.peptide.get_string(distance=7, velocity=5, charge=4)
+    def test_get_str(self):
+        pep = self.peptide.get_str(distance=7, velocity=5, charge=4)
         pep_lines = pep.split("\n")
         pep_kws = [
             "Masses",
@@ -188,7 +188,7 @@ class TestLammpsData(unittest.TestCase):
         pep_topos = "\n".join(pep_lines[kw_inds["Bonds"] :])
         assert "." not in pep_topos
 
-        c2h6 = self.ethane.get_string(distance=5, charge=3)
+        c2h6 = self.ethane.get_str(distance=5, charge=3)
         c2h6_lines = c2h6.split("\n")
         c2h6_kws = [
             "Masses",
@@ -242,7 +242,7 @@ class TestLammpsData(unittest.TestCase):
         c2h6_topos = "\n".join(c2h6_lines[kw_inds["Bonds"] :])
         assert "." not in c2h6_topos
 
-        quartz = self.quartz.get_string(distance=4)
+        quartz = self.quartz.get_str(distance=4)
         quartz_lines = quartz.split("\n")
         quartz_kws = ["Masses", "Atoms"]
         kw_inds = {line: idx for idx, line in enumerate(quartz_lines) if line in quartz_kws}
@@ -264,7 +264,7 @@ class TestLammpsData(unittest.TestCase):
         quartz_atom = quartz_lines[kw_inds["Atoms"] + 2]
         assert quartz_atom == "1  1  2.3088  0.0000  3.6035"
 
-        virus = self.virus.get_string()
+        virus = self.virus.get_str()
         virus_lines = virus.split("\n")
         pairij_coeff = virus_lines[virus_lines.index("PairIJ Coeffs") + 5]
         assert pairij_coeff.strip().split() == ["1", "4", "1", "1.000", "1.12250"]
@@ -997,10 +997,10 @@ class TestCombinedData(unittest.TestCase):
         assert li_2_minimal.force_field is None, "Empty ff info should be none"
         assert li_2_minimal.topology is None, "Empty topo info should be none"
 
-    def test_get_string(self):
+    def test_get_str(self):
         # general tests
-        ec_fec_lines = self.ec_fec1.get_string().splitlines()
-        ec_fec_double_lines = self.ec_fec3.get_string().splitlines()
+        ec_fec_lines = self.ec_fec1.get_str().splitlines()
+        ec_fec_double_lines = self.ec_fec3.get_str().splitlines()
         # header information
         assert ec_fec_lines[1] == "# 1200 cluster1 + 300 cluster2"
         assert ec_fec_double_lines[1] == "# 2(1500) EC_FEC"
@@ -1146,7 +1146,7 @@ class TestCombinedData(unittest.TestCase):
         assert topo["Dihedrals"].loc[41991, "type"] == 30
         assert topo["Dihedrals"].loc[41991, "atom2"] == 14994
         assert topo["Impropers"].loc[4, "atom4"] == 34
-        ec_fec_lines = self.ec_fec_ld.get_string().splitlines()
+        ec_fec_lines = self.ec_fec_ld.get_str().splitlines()
         # header information
         assert ec_fec_lines[1] == ""
         # data type consistency tests

--- a/tests/io/lammps/test_inputs.py
+++ b/tests/io/lammps/test_inputs.py
@@ -65,9 +65,9 @@ class TestLammpsInputFile(PymatgenTest):
             }
         ]
 
-    def test_get_string(self):
+    def test_get_str(self):
         lmp_input = LammpsInputFile().from_file(self.filename)
-        string = lmp_input.get_string()
+        string = lmp_input.get_str()
         assert "# LAMMPS input generated from LammpsInputFile with pymatgen v" in string
         assert "\nunits metal\natom_style full\ndimension 3\npair_style hybrid/overlay morse 15 coul/long" in string
         assert "15\nkspace_style ewald 1e-4\nboundary p p p\n# 2) System definition" in string

--- a/tests/io/test_core.py
+++ b/tests/io/test_core.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import os
 
+import numpy as np
 import pytest
 from monty.serialization import MontyDecoder
 
@@ -20,7 +21,11 @@ class StructInputFile(InputFile):
     def __init__(self, structure: Structure):
         self.structure = structure
 
-    def get_string(self) -> str:
+    @np.deprecate(message="Use get_str instead")
+    def get_string(self, *args, **kwargs) -> str:
+        return self.get_str(*args, **kwargs)
+
+    def get_str(self) -> str:
         cw = CifWriter(self.structure)
         return str(cw)
 

--- a/tests/io/vasp/test_inputs.py
+++ b/tests/io/vasp/test_inputs.py
@@ -206,7 +206,7 @@ direct
    0.75    0.50    0.75 Si
 """
 
-        actual_str = poscar.get_string(significant_figures=2)
+        actual_str = poscar.get_str(significant_figures=2)
         assert actual_str == expected_str, "Wrong POSCAR output!"
 
     def test_str(self):
@@ -574,8 +574,8 @@ class TestIncar:
         assert i == self.incar
         tempfname.unlink()
 
-    def test_get_string(self):
-        s = self.incar.get_string(pretty=True, sort_keys=True)
+    def test_get_str(self):
+        s = self.incar.get_str(pretty=True, sort_keys=True)
         expected = """ALGO       =  Damped
 EDIFF      =  0.0001
 ENCUT      =  500

--- a/tests/io/vasp/test_outputs.py
+++ b/tests/io/vasp/test_outputs.py
@@ -1640,7 +1640,7 @@ class TestXdatcar(PymatgenTest):
 
         x.concatenate(f"{TEST_FILES_DIR}/XDATCAR_4")
         assert len(x.structures) == 8
-        assert x.get_string() is not None
+        assert x.get_str() is not None
 
         filepath = f"{TEST_FILES_DIR}/XDATCAR_6"
         x = Xdatcar(filepath)


### PR DESCRIPTION
Closes #3230.

e703c43f0 restore accidentally deleted io.core.InputFile.from_string (fixes #3230)
2b52712f8 add io.core type hints
ded857431 deprecate get_string methods in favor of get_str