### PR TITLE
`Structure/Molecule.to()` now always return same string written to file

### DIFF
--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -3439,7 +3439,8 @@ class IMolecule(SiteCollection, MSONable):
                 OpenBabel. Non-case sensitive.
 
         Returns:
-            (str) if filename is None. None otherwise.
+            str: String representation of molecule in given format. If a filename
+                is provided, the same string is written to the file.
         """
         from pymatgen.io.babel import BabelMolAdaptor
         from pymatgen.io.gaussian import GaussianInput
@@ -3452,25 +3453,24 @@ class IMolecule(SiteCollection, MSONable):
         elif any(fmt == ext or fnmatch(filename.lower(), f"*.{ext}*") for ext in ["gjf", "g03", "g09", "com", "inp"]):
             writer = GaussianInput(self)
         elif fmt == "json" or fnmatch(filename, "*.json*") or fnmatch(filename, "*.mson*"):
+            json_str = json.dumps(self.as_dict())
             if filename:
-                with zopen(filename, "wt", encoding="utf8") as f:
-                    json.dump(self.as_dict(), f)
-                    return None
-            else:
-                return json.dumps(self.as_dict())
+                with zopen(filename, "wt", encoding="utf8") as file:
+                    file.write(json_str)
+            return json_str
         elif fmt == "yaml" or fnmatch(filename, "*.yaml*"):
             yaml = YAML()
+            str_io = StringIO()
+            yaml.dump(self.as_dict(), str_io)
+            yaml_str = str_io.getvalue()
             if filename:
-                with zopen(filename, "wt", encoding="utf8") as f:
-                    return yaml.dump(self.as_dict(), f)
-            else:
-                sio = StringIO()
-                yaml.dump(self.as_dict(), sio)
-                return sio.getvalue()
+                with zopen(filename, "wt", encoding="utf8") as file:
+                    file.write(yaml_str)
+            return yaml_str
         else:
-            m = re.search(r"\.(pdb|mol|mdl|sdf|sd|ml2|sy2|mol2|cml|mrv)", filename.lower())
-            if (not fmt) and m:
-                fmt = m.group(1)
+            match = re.search(r"\.(pdb|mol|mdl|sdf|sd|ml2|sy2|mol2|cml|mrv)", filename.lower())
+            if not fmt and match:
+                fmt = match.group(1)
             writer = BabelMolAdaptor(self)
             return writer.write_file(filename, file_format=fmt)
 

--- a/pymatgen/io/xyz.py
+++ b/pymatgen/io/xyz.py
@@ -11,6 +11,7 @@ import pandas as pd
 from monty.io import zopen
 
 from pymatgen.core import Molecule, Structure
+from pymatgen.core.structure import SiteCollection
 
 if TYPE_CHECKING:
     from git import Sequence
@@ -21,7 +22,7 @@ class XYZ:
     Basic class for importing and exporting Molecules or Structures in XYZ
     format.
 
-    .. note::
+    Note:
         Exporting periodic structures in the XYZ format will lose information
         about the periodicity. Essentially, only Cartesian coordinates are
         written in this format and no information is retained about the
@@ -34,7 +35,7 @@ class XYZ:
             mol (Molecule | Structure): Input molecule or structure or list thereof.
             coord_precision: Precision to be used for coordinates.
         """
-        self._mols = mol if isinstance(mol, list) else [mol]
+        self._mols = [mol] if isinstance(mol, SiteCollection) else mol
         self.precision = coord_precision
 
     @property

--- a/pymatgen/util/convergence.py
+++ b/pymatgen/util/convergence.py
@@ -141,9 +141,7 @@ def exponential(x, a, b, n):
     elif b > 10:
         b = 10
     if isinstance(x, list):
-        y_l = []
-        for x_v in x:
-            y_l.append(a + b * n**-x_v)
+        y_l = [a + b * n**-x_v for x_v in x]
         y = np.array(y_l)
     else:
         y = a + b * n**-x

--- a/tests/analysis/test_reaction_calculator.py
+++ b/tests/analysis/test_reaction_calculator.py
@@ -381,10 +381,10 @@ class TestComputedReaction(unittest.TestCase):
         entries = []
         for e in d:
             entries.append(ComputedEntry.from_dict(e))
-        rcts = list(filter(lambda e: e.composition.reduced_formula in ["Li", "O2"], entries))
+        reactants = list(filter(lambda e: e.composition.reduced_formula in ["Li", "O2"], entries))
         prods = list(filter(lambda e: e.composition.reduced_formula == "Li2O2", entries))
 
-        self.rxn = ComputedReaction(rcts, prods)
+        self.rxn = ComputedReaction(reactants, prods)
 
     def test_calculated_reaction_energy(self):
         assert self.rxn.calculated_reaction_energy == approx(-5.60748821935)
@@ -449,10 +449,10 @@ class TestComputedReaction(unittest.TestCase):
         entries = []
         for e in d:
             entries.append(ComputedEntry.from_dict(e))
-        rcts = list(filter(lambda e: e.composition.reduced_formula in ["Li", "O2"], entries))
+        reactants = list(filter(lambda e: e.composition.reduced_formula in ["Li", "O2"], entries))
         prods = list(filter(lambda e: e.composition.reduced_formula == "Li2O2", entries))
 
-        rxn_with_uncertainty = ComputedReaction(rcts, prods)
+        rxn_with_uncertainty = ComputedReaction(reactants, prods)
         assert rxn_with_uncertainty.calculated_reaction_energy_uncertainty == approx(0.5 * 0.0744)
 
     def test_calculated_reaction_energy_uncertainty_for_no_uncertainty(self):
@@ -519,13 +519,11 @@ class TestComputedReaction(unittest.TestCase):
                 "correction": -1.864,
             },
         ]
-        entries = []
-        for e in d:
-            entries.append(ComputedEntry.from_dict(e))
-        rcts = list(filter(lambda e: e.composition.reduced_formula in ["Li", "O2"], entries))
+        entries = [ComputedEntry.from_dict(e) for e in d]
+        reactants = list(filter(lambda e: e.composition.reduced_formula in ["Li", "O2"], entries))
         prods = list(filter(lambda e: e.composition.reduced_formula == "Li2O2", entries))
 
-        rxn_with_uncertainty = ComputedReaction(rcts, prods)
+        rxn_with_uncertainty = ComputedReaction(reactants, prods)
         assert isnan(rxn_with_uncertainty.calculated_reaction_energy_uncertainty)
 
     def test_init(self):

--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -740,21 +740,26 @@ Direct
 
         assert "Fd-3m" in self.struct.to(fmt="CIF", symprec=0.1)
 
-        self.struct.to(filename="POSCAR.testing")
-        assert os.path.isfile("POSCAR.testing")
+        poscar_path = f"{self.tmp_path}/POSCAR.testing"
+        poscar_str = self.struct.to(filename=poscar_path)
+        with open(poscar_path) as file:
+            assert file.read() == poscar_str
+        assert Structure.from_file(poscar_path) == self.struct
 
-        self.struct.to(filename="Si_testing.yaml")
-        assert os.path.isfile("Si_testing.yaml")
-        struct = Structure.from_file("Si_testing.yaml")
-        assert struct == self.struct
+        yaml_path = f"{self.tmp_path}/Si_testing.yaml"
+        yaml_str = self.struct.to(filename=yaml_path)
+        with open(yaml_path) as file:
+            assert file.read() == yaml_str
+        assert Structure.from_file(yaml_path) == self.struct
+
         # Test Path support
-        struct = Structure.from_file(Path("Si_testing.yaml"))
+        struct = Structure.from_file(Path(yaml_path))
         assert struct == self.struct
 
         # Test .yml extension works too.
-        os.replace("Si_testing.yaml", "Si_testing.yml")
-        struct = Structure.from_file("Si_testing.yml")
-        assert struct == self.struct
+        yml_path = yaml_path.replace(".yaml", ".yml")
+        os.replace(yaml_path, yml_path)
+        assert Structure.from_file(yml_path) == self.struct
 
         with pytest.raises(ValueError, match="Format not specified and could not infer from filename='whatever'"):
             self.struct.to(filename="whatever")

--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -1844,19 +1844,22 @@ Site: H (-0.5134, 0.8892, -0.3630)"""
     def test_to_from_file_string(self):
         for fmt in ["xyz", "json", "g03", "yaml"]:
             mol = self.mol.to(fmt=fmt)
-            assert mol is not None
-            m = IMolecule.from_str(mol, fmt=fmt)
-            assert m == self.mol
-            assert isinstance(m, IMolecule)
+            assert isinstance(mol, str)
+            mol = IMolecule.from_str(mol, fmt=fmt)
+            assert mol == self.mol
+            assert isinstance(mol, IMolecule)
 
-        self.mol.to(filename="CH4_testing.xyz")
-        assert os.path.isfile("CH4_testing.xyz")
-        os.remove("CH4_testing.xyz")
-        self.mol.to(filename="CH4_testing.yaml")
-        assert os.path.isfile("CH4_testing.yaml")
-        mol = Molecule.from_file("CH4_testing.yaml")
-        assert self.mol == mol
-        os.remove("CH4_testing.yaml")
+        ch4_xyz_str = self.mol.to(filename=f"{self.tmp_path}/CH4_testing.xyz")
+        with open("CH4_testing.xyz") as xyz_file:
+            assert xyz_file.read() == ch4_xyz_str
+        ch4_mol = IMolecule.from_file(f"{self.tmp_path}/CH4_testing.xyz")
+        assert self.mol == ch4_mol
+        ch4_yaml_str = self.mol.to(filename=f"{self.tmp_path}/CH4_testing.yaml")
+
+        with open("CH4_testing.yaml") as yaml_file:
+            assert yaml_file.read() == ch4_yaml_str
+        ch4_mol = Molecule.from_file(f"{self.tmp_path}/CH4_testing.yaml")
+        assert self.mol == ch4_mol
 
 
 class TestMolecule(PymatgenTest):

--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -1409,18 +1409,15 @@ class TestStructure(PymatgenTest):
         coords = [
             [0, 0, 0],
             [0, 0, 1.089000],
-            [1.026719, 0, -0.363000],
-            [-0.513360, -0.889165, -0.363000],
-            [-0.513360, 0.889165, -0.363000],
+            [1.026719, 0, -0.363],
+            [-0.513360, -0.889165, -0.363],
+            [-0.513360, 0.889165, -0.363],
         ]
         ch4 = ["C", "H", "H", "H", "H"]
 
-        species = []
-        all_coords = []
-        for vec in ([0, 0, 0], [4, 0, 0], [0, 4, 0], [4, 4, 0]):
-            species.extend(ch4)
-            for c in coords:
-                all_coords.append(np.array(c) + vec)
+        vectors = [[0, 0, 0], [4, 0, 0], [0, 4, 0], [4, 4, 0]]
+        species = [atom for vec in vectors for atom in ch4]
+        all_coords = [np.array(c) + vec for vec in vectors for c in coords]
 
         structure = Structure(Lattice.cubic(10), species, all_coords, coords_are_cartesian=True)
 

--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -1468,7 +1468,7 @@ class TestStructure(PymatgenTest):
         calculator = struct.calculate(calculator="chgnet")
         assert isinstance(calculator, Calculator)
         preds = calculator.results
-        assert {*preds} == {"stress", "energy", "free_energy", "magmoms", "forces"}
+        assert {*preds} >= {"stress", "energy", "free_energy", "magmoms", "forces"}
         assert preds["energy"] == approx(-10.7400808334, abs=1e-5)
         assert preds["magmoms"] == approx([0.00262399, 0.00262396], abs=1e-5)
         assert np.linalg.norm(preds["forces"]) == approx(1.998941843e-5, abs=1e-3)

--- a/tests/io/qchem/test_utils.py
+++ b/tests/io/qchem/test_utils.py
@@ -35,18 +35,11 @@ class TestUtil(PymatgenTest):
             lower_and_check_unique(d4)
 
     def test_process_parsed_HESS(self):
-        data_132 = []
-        with zopen(f"{test_dir}/parse_hess/132.0", mode="rb") as file:
-            binary = file.read()
-            for ii in range(int(len(binary) / 8)):
-                data_132.append(struct.unpack("d", binary[ii * 8 : (ii + 1) * 8])[0])
+        with zopen(f"{test_dir}/parse_hess/132.0", mode="rb") as f:
+            binary = f.read()
+            data_132 = [struct.unpack("d", binary[ii * 8 : (ii + 1) * 8])[0] for ii in range(int(len(binary) / 8))]
 
-        data_HESS = []
-        with zopen(
-            f"{test_dir}/parse_hess/HESS",
-            mode="rt",
-            encoding="ISO-8859-1",
-        ) as f:
+        with zopen(f"{test_dir}/parse_hess/HESS", mode="rt", encoding="ISO-8859-1") as f:
             data_HESS = f.readlines()
 
         processed_data_HESS = process_parsed_HESS(data_HESS)


### PR DESCRIPTION
Previously if `filename` was passed, `Structure/Molecule.to(filename="some/file.json|cif|yaml|poscar|...")` would return `None`. No performance cost from always returning the same string that was written to file. Simplifies implementation and testing, and can be useful in rare cases.

96f7084f5 fix some ruff PERF401
580b76099 fix test_calculate_chgnet() for next chgnet release
2781937fd always return string from Structure.to() regardless of filename kwarg
a6f960956 update TestIStructure.test_to_from_file_string
3d4b3065d same for Molecule.to()
98b6ba999 update TestIMolecule.test_to_from_file_string
2ee87bb3c improve class XYZ logic for setting self._mols