### PR TITLE
Breaking: Have plot methods return `plt.Axes` object, not `matplotlib` module

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ ci:
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.284
+    rev: v0.0.285
     hooks:
       - id: ruff
         args: [--fix]
@@ -27,7 +27,7 @@ repos:
       - id: black
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.4.1
+    rev: v1.5.1
     hooks:
       - id: mypy
 

--- a/dev_scripts/chemenv/strategies/multi_weights_strategy_parameters.py
+++ b/dev_scripts/chemenv/strategies/multi_weights_strategy_parameters.py
@@ -121,16 +121,16 @@ class CoordinationEnvironmentMorphing:
         fig_height = fig_height_cm / 2.54
 
         fig = plt.figure(num=1, figsize=(fig_width, fig_height))
-        subplot = fig.add_subplot(111)
+        ax = fig.add_subplot(111)
 
-        subplot.plot(
+        ax.plot(
             morphing_factors,
             fractions_initial_environment,
             "b-",
             label=self.initial_environment_symbol,
             linewidth=1.5,
         )
-        subplot.plot(
+        ax.plot(
             morphing_factors,
             fractions_final_environment,
             "g--",
@@ -301,16 +301,16 @@ if __name__ == "__main__":
         self_weight_max_csms_per_cn[ce1.split(":")[1]].append(params["self_weight_max_csm"])
 
     fig = plt.figure(1)
-    subplot = fig.add_subplot(111)
+    ax = fig.add_subplot(111)
 
     for idx, cn_pair in enumerate(all_cn_pairs):
         if len(self_weight_max_csms[cn_pair]) == 0:
             continue
-        subplot.plot(idx * np.ones_like(self_weight_max_csms[cn_pair]), self_weight_max_csms[cn_pair], "rx")
-        subplot.plot(idx * np.ones_like(delta_csm_mins[cn_pair]), delta_csm_mins[cn_pair], "b+")
+        ax.plot(idx * np.ones_like(self_weight_max_csms[cn_pair]), self_weight_max_csms[cn_pair], "rx")
+        ax.plot(idx * np.ones_like(delta_csm_mins[cn_pair]), delta_csm_mins[cn_pair], "b+")
 
-    subplot.set_xticks(range(len(all_cn_pairs)))
-    subplot.set_xticklabels(all_cn_pairs, rotation="vertical")
+    ax.set_xticks(range(len(all_cn_pairs)))
+    ax.set_xticklabels(all_cn_pairs, rotation="vertical")
     fig.savefig("self_delta_params.pdf")
 
     fig2 = plt.figure(2)

--- a/pymatgen/analysis/adsorption.py
+++ b/pymatgen/analysis/adsorption.py
@@ -717,6 +717,5 @@ def plot_slab(
     lim_array = [center - extent * window, center + extent * window]
     x_lim = [ele[0] for ele in lim_array]
     y_lim = [ele[1] for ele in lim_array]
-    ax.set_xlim(x_lim)
-    ax.set_ylim(y_lim)
+    ax.set(xlim=x_lim, ylim=y_lim)
     return ax

--- a/pymatgen/analysis/chemenv/coordination_environments/structure_environments.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/structure_environments.py
@@ -8,6 +8,8 @@ and possibly some fraction corresponding to these.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 from monty.json import MontyDecoder, MSONable, jsanitize
 
@@ -18,6 +20,9 @@ from pymatgen.analysis.chemenv.utils.defs_utils import AdditionalConditions
 from pymatgen.core.periodic_table import Element, Species
 from pymatgen.core.sites import PeriodicSite
 from pymatgen.core.structure import PeriodicNeighbor, Structure
+
+if TYPE_CHECKING:
+    import matplotlib.pyplot as plt
 
 __author__ = "David Waroquiers"
 __copyright__ = "Copyright 2012, The Materials Project"
@@ -653,7 +658,9 @@ class StructureEnvironments(MSONable):
         plt.show()
         return
 
-    def get_csm_and_maps(self, isite, max_csm=8.0, figsize=None, symmetry_measure_type=None):
+    def get_csm_and_maps(
+        self, isite, max_csm=8.0, figsize=None, symmetry_measure_type=None
+    ) -> tuple[plt.Figure, plt.Axes] | None:
         """
         Plotting of the coordination numbers of a given site for all the distfactor/angfactor parameters. If the
         chemical environments are given, a color map is added to the plot, with the lowest continuous symmetry measure
@@ -666,7 +673,7 @@ class StructureEnvironments(MSONable):
             symmetry_measure_type: Type of continuous symmetry measure to be used.
 
         Returns:
-            Matplotlib figure and axes representing the csm and maps.
+            Matplotlib figure and axes representing the CSM and maps.
         """
         try:
             import matplotlib.pyplot as plt
@@ -819,7 +826,7 @@ class StructureEnvironments(MSONable):
             strategy: Whether to plot information about one of the Chemenv Strategies.
 
         Returns:
-            Matplotlib figure and axes representing the environments.
+            tuple[plt.Figure, plt.Axes]: matplotlib figure and axes representing the environments.
         """
         try:
             import matplotlib.pyplot as plt
@@ -831,8 +838,8 @@ class StructureEnvironments(MSONable):
             return None
 
         # Initializes the figure
-        fig = plt.figure() if figsize is None else plt.figure(figsize=figsize)
-        subplot = fig.add_subplot(111)
+        fig = plt.figure(figsize=figsize)
+        ax = fig.add_subplot(111)
 
         # Initializes the distance and angle parameters
         if plot_type is None:
@@ -922,7 +929,7 @@ class StructureEnvironments(MSONable):
                     facecolor=mycolor,
                     linewidth=1.2,
                 )
-                subplot.add_patch(polygon)
+                ax.add_patch(polygon)
                 myipt = len(nb_set_surface_pts) / 2
                 ipt = int(myipt)
                 if myipt != ipt:
@@ -940,7 +947,7 @@ class StructureEnvironments(MSONable):
                         (min(nb_set_surface_pts[-1][0], dist_limits[1]) + nb_set_surface_pts[0][0]) / 2,
                         (nb_set_surface_pts[-1][1] + nb_set_surface_pts[-2][1]) / 2,
                     )
-                    subplot.annotate(
+                    ax.annotate(
                         mytext,
                         xy=xytext,
                         ha="center",
@@ -953,7 +960,7 @@ class StructureEnvironments(MSONable):
                     and np.abs(min(nb_set_surface_pts[ipt][0], dist_limits[1]) - nb_set_surface_pts[0][0]) > 0.125
                 ):
                     xytext = patch_center
-                    subplot.annotate(
+                    ax.annotate(
                         mytext,
                         xy=xytext,
                         ha="center",
@@ -962,26 +969,26 @@ class StructureEnvironments(MSONable):
                         fontsize="x-small",
                     )
 
-        subplot.set_title(title)
-        subplot.set_xlabel(xlabel)
-        subplot.set_ylabel(ylabel)
+        ax.set_title(title)
+        ax.set_xlabel(xlabel)
+        ax.set_ylabel(ylabel)
 
         dist_limits.sort()
         ang_limits.sort()
-        subplot.set_xlim(dist_limits)
-        subplot.set_ylim(ang_limits)
+        ax.set_xlim(dist_limits)
+        ax.set_ylim(ang_limits)
         if strategy is not None:
             try:
-                strategy.add_strategy_visualization_to_subplot(subplot=subplot)
+                strategy.add_strategy_visualization_to_subplot(subplot=ax)
             except Exception:
                 pass
         if plot_type["angle_parameter"][0] == "initial_normalized_inverted":
-            subplot.axes.invert_yaxis()
+            ax.axes.invert_yaxis()
 
         scalarmap.set_array([mymin, mymax])
-        cb = fig.colorbar(scalarmap, ax=subplot, extend="max")
+        cb = fig.colorbar(scalarmap, ax=ax, extend="max")
         cb.set_label("Continuous symmetry measure")
-        return fig, subplot
+        return fig, ax
 
     def plot_environments(
         self,

--- a/pymatgen/analysis/chemenv/coordination_environments/structure_environments.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/structure_environments.py
@@ -687,8 +687,8 @@ class StructureEnvironments(MSONable):
         # Initializes the figure
         fig = plt.figure() if figsize is None else plt.figure(figsize=figsize)
         gs = GridSpec(2, 1, hspace=0.0, wspace=0.0)
-        subplot = fig.add_subplot(gs[:])
-        subplot_distang = subplot.twinx()
+        ax = fig.add_subplot(gs[:])
+        ax_distang = ax.twinx()
 
         idx = 0
         cn_maps = []
@@ -709,8 +709,8 @@ class StructureEnvironments(MSONable):
                 all_was.append(nb_set.normalized_angles)
                 for mp_symbol, cg_dict in min_geoms:
                     csm = cg_dict["other_symmetry_measures"][symmetry_measure_type]
-                    subplot.plot(idx, csm, "ob")
-                    subplot.annotate(mp_symbol, xy=(idx, csm))
+                    ax.plot(idx, csm, "ob")
+                    ax.annotate(mp_symbol, xy=(idx, csm))
                 cn_maps.append((cn, inb_set))
                 idx += 1
 
@@ -756,9 +756,9 @@ class StructureEnvironments(MSONable):
             return (np.array(wd) - 1.0) / (ymax_wd - 1.0) * (ydmax - ydmin) + ydmin
 
         for idx, was in enumerate(all_was):
-            subplot_distang.plot(0.2 + idx * np.ones_like(was), yang(was), "<g")
+            ax_distang.plot(0.2 + idx * np.ones_like(was), yang(was), "<g")
             alpha = 0.3 if np.mod(idx, 2) == 0 else 0.1
-            subplot_distang.fill_between(
+            ax_distang.fill_between(
                 [-0.5 + idx, 0.5 + idx],
                 [1.0, 1.0],
                 0.0,
@@ -767,16 +767,16 @@ class StructureEnvironments(MSONable):
                 zorder=-1000,
             )
         for idx, wds in enumerate(all_wds):
-            subplot_distang.plot(0.2 + idx * np.ones_like(wds), ydist(wds), "sm")
+            ax_distang.plot(0.2 + idx * np.ones_like(wds), ydist(wds), "sm")
 
-        subplot_distang.plot([-0.5, len(cn_maps)], [0.5, 0.5], "k--", alpha=0.5)
+        ax_distang.plot([-0.5, len(cn_maps)], [0.5, 0.5], "k--", alpha=0.5)
 
         yticks = yang(yticks_wa).tolist()
         yticks.extend(ydist(yticks_wd).tolist())
         yticklabels = yticks_wa.tolist()
         yticklabels.extend(yticks_wd.tolist())
-        subplot_distang.set_yticks(yticks)
-        subplot_distang.set_yticklabels(yticklabels)
+        ax_distang.set_yticks(yticks)
+        ax_distang.set_yticklabels(yticklabels)
 
         fake_subplot_ang = fig.add_subplot(gs[1], frame_on=False)
         fake_subplot_dist = fig.add_subplot(gs[0], frame_on=False)
@@ -789,14 +789,14 @@ class StructureEnvironments(MSONable):
         fake_subplot_ang.yaxis.set_label_position("right")
         fake_subplot_dist.yaxis.set_label_position("right")
 
-        subplot_distang.set_ylim([0.0, 1.0])
-        subplot.set_xticks(range(len(cn_maps)))
-        subplot.set_ylabel("Continuous symmetry measure")
-        subplot.set_xlim([-0.5, len(cn_maps) - 0.5])
-        subplot_distang.set_xlim([-0.5, len(cn_maps) - 0.5])
-        subplot.set_xticklabels([str(cn_map) for cn_map in cn_maps])
+        ax_distang.set_ylim([0.0, 1.0])
+        ax.set_xticks(range(len(cn_maps)))
+        ax.set_ylabel("Continuous symmetry measure")
+        ax.set_xlim([-0.5, len(cn_maps) - 0.5])
+        ax_distang.set_xlim([-0.5, len(cn_maps) - 0.5])
+        ax.set_xticklabels([str(cn_map) for cn_map in cn_maps])
 
-        return fig, subplot
+        return fig, ax
 
     def get_environments_figure(
         self,
@@ -1015,7 +1015,7 @@ class StructureEnvironments(MSONable):
             figsize: Size of the figure.
             strategy: Whether to plot information about one of the Chemenv Strategies.
         """
-        fig, subplot = self.get_environments_figure(
+        fig, _ax = self.get_environments_figure(
             isite=isite,
             plot_type=plot_type,
             title=title,
@@ -1050,7 +1050,7 @@ class StructureEnvironments(MSONable):
                 distance while in the second case, the real distance is used).
             figsize: Size of the figure.
         """
-        fig, subplot = self.get_environments_figure(
+        fig, _ax = self.get_environments_figure(
             isite=isite,
             plot_type=plot_type,
             title=title,

--- a/pymatgen/analysis/chemenv/coordination_environments/voronoi.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/voronoi.py
@@ -800,7 +800,7 @@ class DetailedVoronoiContainer(MSONable):
 
         # Initializes the figure
         fig = plt.figure() if figsize is None else plt.figure(figsize=figsize)
-        subplot = fig.add_subplot(111)
+        ax = fig.add_subplot(111)
         dists = self.neighbors_normalized_distances[isite] if normalized else self.neighbors_distances[isite]
 
         if step_function["type"] == "step_function":
@@ -826,7 +826,7 @@ class DetailedVoronoiContainer(MSONable):
                 yy += mydcns[idist] * normal_cdf_step(xx, mean=dist, scale=scale)
         else:
             raise ValueError(f"Step function of type {step_function['type']!r} is not allowed")
-        subplot.plot(xx, yy)
+        ax.plot(xx, yy)
 
         return fig
 
@@ -854,7 +854,7 @@ class DetailedVoronoiContainer(MSONable):
 
         # Initializes the figure
         fig = plt.figure() if figsize is None else plt.figure(figsize=figsize)
-        subplot = fig.add_subplot(111)
+        ax = fig.add_subplot(111)
         angs = self.neighbors_normalized_angles[isite] if normalized else self.neighbors_angles[isite]
 
         if step_function["type"] == "step_function":
@@ -880,7 +880,7 @@ class DetailedVoronoiContainer(MSONable):
                 yy += mydcns[iang] * normal_cdf_step(xx, mean=ang, scale=scale)
         else:
             raise ValueError(f"Step function of type {step_function['type']!r} is not allowed")
-        subplot.plot(xx, yy)
+        ax.plot(xx, yy)
 
         return fig
 

--- a/pymatgen/analysis/chemenv/coordination_environments/voronoi.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/voronoi.py
@@ -787,7 +787,7 @@ class DetailedVoronoiContainer(MSONable):
             step_function: Type of step function to be used for the RDF.
 
         Returns:
-            Matplotlib figure.
+            plt.figure: Matplotlib figure.
         """
 
         def dp_func(dp):
@@ -841,7 +841,7 @@ class DetailedVoronoiContainer(MSONable):
             step_function: Type of step function to be used for the SADF.
 
         Returns:
-            Matplotlib figure.
+            plt.figure: matplotlib figure.
         """
 
         def ap_func(ap):

--- a/pymatgen/analysis/diffraction/core.py
+++ b/pymatgen/analysis/diffraction/core.py
@@ -7,9 +7,10 @@ import collections
 from typing import TYPE_CHECKING
 
 import numpy as np
+from matplotlib import pyplot as plt
 
 from pymatgen.core.spectrum import Spectrum
-from pymatgen.util.plotting import add_fig_kwargs
+from pymatgen.util.plotting import add_fig_kwargs, pretty_plot
 
 if TYPE_CHECKING:
     from pymatgen.core import Structure
@@ -72,21 +73,20 @@ class AbstractDiffractionPatternCalculator(abc.ABC):
 
     def get_plot(
         self,
-        structure,
-        two_theta_range=(0, 90),
+        structure: Structure,
+        two_theta_range: tuple[float, float] = (0, 90),
         annotate_peaks="compact",
-        ax=None,
+        ax: plt.Axes = None,
         with_labels=True,
         fontsize=16,
-    ):
+    ) -> plt.Axes:
         """
-        Returns the diffraction plot as a matplotlib.pyplot.
+        Returns the diffraction plot as a matplotlib Axes.
 
         Args:
             structure: Input structure
-            two_theta_range ([float of length 2]): Tuple for range of
-                two_thetas to calculate in degrees. Defaults to (0, 90). Set to
-                None if you want all diffracted beams within the limiting
+            two_theta_range (tuple[float, float]): Range of two_thetas to calculate in degrees.
+                Defaults to (0, 90). Set to None if you want all diffracted beams within the limiting
                 sphere of radius 2 / wavelength.
             annotate_peaks (str or None): Whether and how to annotate the peaks
                 with hkl indices. Default is 'compact', i.e. show short
@@ -98,16 +98,9 @@ class AbstractDiffractionPatternCalculator(abc.ABC):
             fontsize: (int) fontsize for peak labels.
 
         Returns:
-            (matplotlib.pyplot)
+            plt.Axes: matplotlib Axes object
         """
-        if ax is None:
-            from pymatgen.util.plotting import pretty_plot
-
-            plt = pretty_plot(16, 10)
-            ax = plt.gca()
-        else:
-            # This to maintain the type of the return value.
-            import matplotlib.pyplot as plt
+        ax = ax or pretty_plot(16, 10)
 
         xrd = self.get_pattern(structure, two_theta_range=two_theta_range)
         imax = max(xrd.y)
@@ -155,10 +148,9 @@ class AbstractDiffractionPatternCalculator(abc.ABC):
             ax.set_xlabel(r"$2\theta$ ($^\circ$)")
             ax.set_ylabel("Intensities (scaled)")
 
-        if hasattr(ax, "tight_layout"):
-            ax.tight_layout()
+        plt.tight_layout()
 
-        return plt
+        return ax
 
     def show_plot(self, structure: Structure, **kwargs):
         """

--- a/pymatgen/analysis/eos.py
+++ b/pymatgen/analysis/eos.py
@@ -11,12 +11,16 @@ import logging
 import warnings
 from abc import ABCMeta, abstractmethod
 from copy import deepcopy
+from typing import TYPE_CHECKING
 
 import numpy as np
 from scipy.optimize import leastsq, minimize
 
 from pymatgen.core.units import FloatWithUnit
 from pymatgen.util.plotting import add_fig_kwargs, get_ax_fig_plt, pretty_plot
+
+if TYPE_CHECKING:
+    from matplotlib import pyplot as plt
 
 __author__ = "Kiran Mathew, gmatteo"
 __credits__ = "Cormac Toher"
@@ -42,7 +46,7 @@ class EOSBase(metaclass=ABCMeta):
         # derivative of bulk modulus wrt pressure(b1), minimum volume(v0)
         self._params = None
         # the eos function parameters. It is the same as _params except for
-        # equation of states that uses polynomial fits(deltafactor and
+        # equation of states that uses polynomial fits(delta_factor and
         # numerical_eos)
         self.eos_params = None
 
@@ -163,7 +167,7 @@ class EOSBase(metaclass=ABCMeta):
         """
         return {"e0": self.e0, "b0": self.b0, "b1": self.b1, "v0": self.v0}
 
-    def plot(self, width=8, height=None, plt=None, dpi=None, **kwargs):
+    def plot(self, width=8, height=None, ax: plt.Axes = None, dpi=None, **kwargs):
         """
         Plot the equation of state.
 
@@ -171,17 +175,16 @@ class EOSBase(metaclass=ABCMeta):
             width (float): Width of plot in inches. Defaults to 8in.
             height (float): Height of plot in inches. Defaults to width *
                 golden ratio.
-            plt (matplotlib.pyplot): If plt is supplied, changes will be made
-                to an existing plot. Otherwise, a new plot will be created.
+            ax (plt.Axes): If supplied, changes will be made to the existing Axes.
+                Otherwise, new Axes will be created.
             dpi:
             kwargs (dict): additional args fed to pyplot.plot.
                 supported keys: style, color, text, label
 
         Returns:
-            Matplotlib plot object.
+            plt.Axes: The matplotlib axes.
         """
-        # pylint: disable=E1307
-        plt = pretty_plot(width=width, height=height, plt=plt, dpi=dpi)
+        ax = pretty_plot(width=width, height=height, ax=ax, dpi=dpi)
 
         color = kwargs.get("color", "r")
         label = kwargs.get("label", f"{type(self).__name__} fit")
@@ -196,26 +199,26 @@ class EOSBase(metaclass=ABCMeta):
         text = kwargs.get("text", text)
 
         # Plot input data.
-        plt.plot(self.volumes, self.energies, linestyle="None", marker="o", color=color)
+        ax.plot(self.volumes, self.energies, linestyle="None", marker="o", color=color)
 
         # Plot eos fit.
         vmin, vmax = min(self.volumes), max(self.volumes)
         vmin, vmax = (vmin - 0.01 * abs(vmin), vmax + 0.01 * abs(vmax))
         vfit = np.linspace(vmin, vmax, 100)
 
-        plt.plot(vfit, self.func(vfit), linestyle="dashed", color=color, label=label)
+        ax.plot(vfit, self.func(vfit), linestyle="dashed", color=color, label=label)
 
-        plt.grid(True)
-        plt.xlabel("Volume $\\AA^3$")
-        plt.ylabel("Energy (eV)")
-        plt.legend(loc="best", shadow=True)
+        ax.grid(True)
+        ax.set_xlabel("Volume $\\AA^3$")
+        ax.set_ylabel("Energy (eV)")
+        ax.legend(loc="best", shadow=True)
         # Add text with fit parameters.
-        plt.text(0.4, 0.5, text, transform=plt.gca().transAxes)
+        ax.text(0.4, 0.5, text, transform=ax.transAxes)
 
-        return plt
+        return ax
 
     @add_fig_kwargs
-    def plot_ax(self, ax=None, fontsize=12, **kwargs):
+    def plot_ax(self, ax: plt.Axes = None, fontsize=12, **kwargs):
         """
         Plot the equation of state on axis `ax`.
 

--- a/pymatgen/analysis/eos.py
+++ b/pymatgen/analysis/eos.py
@@ -230,7 +230,7 @@ class EOSBase(metaclass=ABCMeta):
             text (str): Legend text (options)
 
         Returns:
-            Matplotlib figure object.
+            plt.Figure: matplotlib figure.
         """
         # pylint: disable=E1307
         ax, fig, plt = get_ax_fig_plt(ax=ax)

--- a/pymatgen/analysis/interface_reactions.py
+++ b/pymatgen/analysis/interface_reactions.py
@@ -395,7 +395,7 @@ class InterfacialReactivity(MSONable):
 
     def _get_matplotlib_figure(self) -> plt.Figure:
         """Returns a matplotlib figure of reaction kinks diagram."""
-        pretty_plot(8, 5)
+        ax = pretty_plot(8, 5)
         plt.xlim([-0.05, 1.05])  # plot boundary is 5% wider on each side
 
         kinks = list(zip(*self.get_kinks()))
@@ -418,17 +418,13 @@ class InterfacialReactivity(MSONable):
                 arrowprops={"arrowstyle": "->", "connectionstyle": "arc3,rad=0"},
             )
 
-        if self.norm:
-            plt.ylabel("Energy (eV/atom)")
-        else:
-            plt.ylabel("Energy (eV/f.u.)")
+        plt.ylabel(f"Energy (eV/{'atom' if self.norm else 'f.u.'})")
 
         plt.xlabel(self._get_xaxis_title())
         plt.ylim(self.minimum[1] + 0.05 * self.minimum[1])  # plot boundary is 5% lower
 
-        fig = plt.gcf()
+        fig = ax.figure
         plt.close(fig)
-
         return fig
 
     def _get_xaxis_title(self, latex: bool = True) -> str:

--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -11,11 +11,14 @@ import os
 import re
 import warnings
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, Collection, Iterator, Literal, Sequence
+from typing import TYPE_CHECKING, Any, Collection, Iterator, Literal, Sequence, no_type_check
 
+import matplotlib.pyplot as plt
 import numpy as np
 import plotly.graph_objs as go
+from matplotlib import cm
 from monty.json import MontyDecoder, MSONable
+from scipy import interpolate
 from scipy.optimize import minimize
 from scipy.spatial import ConvexHull
 from tqdm import tqdm
@@ -1309,10 +1312,10 @@ class PhaseDiagram(MSONable):
         ordering: Sequence[str] | None = None,
         energy_colormap=None,
         process_attributes: bool = False,
-        plt=None,
+        ax: plt.Axes = None,
         label_uncertainties: bool = False,
         fill: bool = True,
-        **plotkwargs,
+        **kwargs,
     ):
         """
         Convenient wrapper for PDPlotter. Initializes a PDPlotter object and calls
@@ -1337,22 +1340,15 @@ class PhaseDiagram(MSONable):
             energy_colormap: Colormap for coloring energy (matplotlib backend only).
             process_attributes: Whether to process the attributes (matplotlib
                 backend only).
-            plt: Existing plt object if plotting multiple phase diagrams (
-                matplotlib backend only).
+            ax: Existing Axes object if plotting multiple phase diagrams (matplotlib backend only).
             label_uncertainties: Whether to add error bars to the hull (plotly
                 backend only). For binaries, this also shades the hull with the
                 uncertainty window.
             fill: Whether to shade the hull. For ternary_2d and quaternary plots, this
                 colors facets arbitrarily for visual clarity. For ternary_3d plots, this
                 shades the hull by formation energy (plotly backend only).
-            **plotkwargs (dict): Keyword args passed to matplotlib.pyplot.plot (only
-                applies when backend="matplotlib"). Can be used to customize markers
-                etc. If not set, the default is:
-                    {
-                        "markerfacecolor": "#4daf4a",
-                        "markersize": 10,
-                        "linewidth": 3
-                    }
+            **kwargs (dict): Keyword args passed to PDPlotter.get_plot(). Can be used to customize markers
+                etc. If not set, the default is { "markerfacecolor": "#4daf4a", "markersize": 10, "linewidth": 3 }
         """
         plotter = PDPlotter(self, show_unstable=show_unstable, backend=backend, ternary_style=ternary_style)
         return plotter.get_plot(
@@ -1361,10 +1357,10 @@ class PhaseDiagram(MSONable):
             ordering=ordering,
             energy_colormap=energy_colormap,
             process_attributes=process_attributes,
-            plt=plt,
+            ax=ax,
             label_uncertainties=label_uncertainties,
             fill=fill,
-            **plotkwargs,
+            **kwargs,
         )
 
 
@@ -2192,11 +2188,11 @@ class PDPlotter:
         ordering: Sequence[str] | None = None,
         energy_colormap=None,
         process_attributes: bool = False,
-        plt=None,
+        ax: plt.Axes = None,
         label_uncertainties: bool = False,
         fill: bool = True,
         highlight_entries: Collection[PDEntry] | None = None,
-    ):
+    ) -> go.Figure | plt.Axes:
         """
         Args:
             label_stable: Whether to label stable compounds.
@@ -2205,7 +2201,7 @@ class PDPlotter:
                 'Left','Right'] (matplotlib only).
             energy_colormap: Colormap for coloring energy (matplotlib only).
             process_attributes: Whether to process the attributes (matplotlib only).
-            plt: Existing matplotlib.pyplot object if plotting multiple phase diagrams
+            ax: Existing matplotlib Axes object if plotting multiple phase diagrams
                 (matplotlib only).
             label_uncertainties: Whether to add error bars to the hull.
                 For binaries, this also shades the hull with the uncertainty window.
@@ -2217,7 +2213,7 @@ class PDPlotter:
                 create a new marker trace that is separate from the other entries.
 
         Returns:
-            go.Figure (backend="plotly") or matplotlib.pyplot (backend="matplotlib")
+            go.Figure | plt.Axes: Plotly figure or matplotlib axes object depending on backend.
         """
         fig = None
         data = []
@@ -2259,11 +2255,11 @@ class PDPlotter:
                     label_unstable,
                     ordering,
                     energy_colormap,
-                    plt=plt,
+                    ax=ax,
                     process_attributes=process_attributes,
                 )
             elif self._dim == 4:
-                fig = self._get_matplotlib_3d_plot(label_stable)
+                fig = self._get_matplotlib_3d_plot(label_stable, ax=ax)
 
         return fig
 
@@ -2328,7 +2324,7 @@ class PDPlotter:
             Plot of element profile evolution by varying the chemical potential
             of an element.
         """
-        plt = pretty_plot(12, 8)
+        ax = pretty_plot(12, 8)
         pd = self._pd
         evolution = pd.get_element_profile(element, comp)
         num_atoms = evolution[0]["reaction"].reactants[0].num_atoms
@@ -2337,7 +2333,7 @@ class PDPlotter:
         for i, d in enumerate(evolution):
             v = -(d["chempot"] - element_energy)
             if i != 0:
-                plt.plot([x2, x2], [y1, d["evolution"] / num_atoms], "k", linewidth=2.5)
+                ax.plot([x2, x2], [y1, d["evolution"] / num_atoms], "k", linewidth=2.5)
             x1 = v
             y1 = d["evolution"] / num_atoms
 
@@ -2348,21 +2344,21 @@ class PDPlotter:
                     for p in d["reaction"].products
                     if p.reduced_formula != element.symbol
                 ]
-                plt.annotate(
+                ax.annotate(
                     ", ".join(products),
                     xy=(v + 0.05, y1 + 0.05),
                     fontsize=24,
                     color="r",
                 )
-                plt.plot([x1, x2], [y1, y1], "r", linewidth=3)
+                ax.plot([x1, x2], [y1, y1], "r", linewidth=3)
             else:
-                plt.plot([x1, x2], [y1, y1], "k", linewidth=2.5)
+                ax.plot([x1, x2], [y1, y1], "k", linewidth=2.5)
 
-        plt.xlim((0, xlim))
-        plt.xlabel("-$\\Delta{\\mu}$ (eV)")
-        plt.ylabel("Uptake per atom")
+        ax.set_xlim((0, xlim))
+        ax.set_xlabel("-$\\Delta{\\mu}$ (eV)")
+        ax.set_ylabel("Uptake per atom")
 
-        return plt
+        return ax
 
     def plot_chempot_range_map(self, elements, referenced=True) -> None:
         """
@@ -2396,12 +2392,12 @@ class PDPlotter:
                 all Li-Co-O phases wrt to uLi and uO, you will supply
                 [Element("Li"), Element("O")]
             referenced: if True, gives the results with a reference being the
-                        energy of the elemental phase. If False, gives absolute values.
+                energy of the elemental phase. If False, gives absolute values.
 
         Returns:
-            A matplotlib plot object.
+            plt.Axes: matplotlib axes object.
         """
-        plt = pretty_plot(12, 8)
+        ax_main = pretty_plot(12, 8)
         chempot_ranges = self._pd.get_chempot_range_map(elements, referenced=referenced)
         missing_lines = {}
         excluded_region = []
@@ -2431,9 +2427,9 @@ class PDPlotter:
                 xy = (center_x / len(coords), center_y / len(coords))
                 plt.annotate(latexify(entry.name), xy, fontsize=22)
 
-        ax = plt.gca()
-        xlim = ax.get_xlim()
-        ylim = ax.get_ylim()
+            ax = ax_main
+            xlim = ax.get_xlim()
+            ylim = ax.get_ylim()
 
         # Shade the forbidden chemical potential regions.
         excluded_region.append([xlim[1], ylim[1]])
@@ -2476,7 +2472,7 @@ class PDPlotter:
                 center_y = sum(coord[1] for coord in coords) + ylim[0]
                 xy = (center_x / (n + 1), center_y / (n + 1))
 
-            plt.annotate(
+            ax.annotate(
                 latexify(entry.name),
                 xy,
                 horizontalalignment="center",
@@ -2484,10 +2480,10 @@ class PDPlotter:
                 fontsize=22,
             )
 
-        plt.xlabel(f"$\\mu_{{{el0.symbol}}} - \\mu_{{{el0.symbol}}}^0$ (eV)")
-        plt.ylabel(f"$\\mu_{{{el1.symbol}}} - \\mu_{{{el1.symbol}}}^0$ (eV)")
+        ax.set_xlabel(f"$\\mu_{{{el0.symbol}}} - \\mu_{{{el0.symbol}}}^0$ (eV)")
+        ax.set_ylabel(f"$\\mu_{{{el1.symbol}}} - \\mu_{{{el1.symbol}}}^0$ (eV)")
         plt.tight_layout()
-        return plt
+        return ax_main
 
     def get_contour_pd_plot(self):
         """
@@ -2498,14 +2494,11 @@ class PDPlotter:
         Returns:
             A matplotlib plot object.
         """
-        from matplotlib import cm
-        from scipy import interpolate
-
         pd = self._pd
         entries = pd.qhull_entries
         data = np.array(pd.qhull_data)
 
-        plt = self._get_matplotlib_2d_plot()
+        ax = self._get_matplotlib_2d_plot()
         data[:, 0:2] = triangular_coord(data[:, 0:2]).transpose()
         for i, e in enumerate(entries):
             data[i, 2] = self._pd.get_e_above_hull(e)
@@ -2520,11 +2513,11 @@ class PDPlotter:
             for j, yval in enumerate(ynew):
                 znew[j, i] = f(xval, yval)
 
-        # pylint: disable=no-member
-        plt.contourf(xnew, ynew, znew, 1000, cmap=cm.autumn_r)
+        contourf = ax.contourf(xnew, ynew, znew, 1000, cmap=cm.autumn_r)
 
-        plt.colorbar()
-        return plt
+        plt.colorbar(contourf)
+
+        return ax
 
     @property  # type: ignore
     @lru_cache(1)  # noqa: B019
@@ -3520,6 +3513,7 @@ class PDPlotter:
             showlegend=False,
         )
 
+    @no_type_check
     def _get_matplotlib_2d_plot(
         self,
         label_stable=True,
@@ -3530,15 +3524,14 @@ class PDPlotter:
         vmax_mev=60.0,
         show_colorbar=True,
         process_attributes=False,
-        plt=None,
+        ax: plt.Axes = None,
     ):
         """
         Shows the plot using matplotlib.
 
         Imports are done within the function as matplotlib is no longer the default.
         """
-        if plt is None:
-            plt = pretty_plot(8, 6)
+        ax = ax or pretty_plot(8, 6)
         from matplotlib.font_manager import FontProperties
 
         if ordering is None:
@@ -3718,22 +3711,27 @@ class PDPlotter:
                 ha="center",
                 va="bottom",
             )
-        f = plt.gcf()
-        f.set_size_inches((8, 6))
+        fig = plt.gcf()
+        fig.set_size_inches((8, 6))
         plt.subplots_adjust(left=0.09, right=0.98, top=0.98, bottom=0.07)
-        return plt
+        return ax
 
-    def _get_matplotlib_3d_plot(self, label_stable=True):
+    @no_type_check
+    def _get_matplotlib_3d_plot(self, label_stable=True, ax: plt.Axes = None):
         """
         Shows the plot using matplotlib.
 
-        Imports are done within the function as matplotlib is no longer the default.
+        Args:
+            label_stable (bool): Whether to label stable compounds.
+            ax (plt.Axes): An existing axes object (optional). If not provided, a new one will be created.
+
+        Returns:
+            plt.Axes: The axes object with the plot.
         """
-        import matplotlib.pyplot as plt
         from matplotlib.font_manager import FontProperties
 
-        fig = plt.figure()
-        ax = fig.add_subplot(111, projection="3d")
+        ax = ax or plt.figure().add_subplot(111, projection="3d")
+
         font = FontProperties(weight="bold", size=13)
         lines, labels, _ = self.pd_plot_data
         count = 1
@@ -3764,7 +3762,7 @@ class PDPlotter:
         ax.set_xlim(-0.1, 0.72)
         ax.set_ylim(0, 0.66)
         ax.set_zlim(0, 0.56)  # pylint: disable=no-member
-        return plt
+        return ax
 
 
 def uniquelines(q):

--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -2397,7 +2397,7 @@ class PDPlotter:
         Returns:
             plt.Axes: matplotlib axes object.
         """
-        ax_main = pretty_plot(12, 8)
+        ax = pretty_plot(12, 8)
         chempot_ranges = self._pd.get_chempot_range_map(elements, referenced=referenced)
         missing_lines = {}
         excluded_region = []
@@ -2427,9 +2427,8 @@ class PDPlotter:
                 xy = (center_x / len(coords), center_y / len(coords))
                 plt.annotate(latexify(entry.name), xy, fontsize=22)
 
-            ax = ax_main
-            xlim = ax.get_xlim()
-            ylim = ax.get_ylim()
+        xlim = ax.get_xlim()
+        ylim = ax.get_ylim()
 
         # Shade the forbidden chemical potential regions.
         excluded_region.append([xlim[1], ylim[1]])
@@ -2483,7 +2482,7 @@ class PDPlotter:
         ax.set_xlabel(f"$\\mu_{{{el0.symbol}}} - \\mu_{{{el0.symbol}}}^0$ (eV)")
         ax.set_ylabel(f"$\\mu_{{{el1.symbol}}} - \\mu_{{{el1.symbol}}}^0$ (eV)")
         plt.tight_layout()
-        return ax_main
+        return ax
 
     def get_contour_pd_plot(self):
         """

--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -3757,9 +3757,7 @@ class PDPlotter:
                     count += 1
         plt.figtext(0.01, 0.01, "\n".join(newlabels), fontproperties=font)
         ax.axis("off")
-        ax.set_xlim(-0.1, 0.72)
-        ax.set_ylim(0, 0.66)
-        ax.set_zlim(0, 0.56)  # pylint: disable=no-member
+        ax.set(xlim=(-0.1, 0.72), ylim=(0, 0.66), zlim=(0, 0.56))
         return ax
 
 

--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -2287,10 +2287,9 @@ class PDPlotter:
             **kwargs: Optinoal kwargs passed to the get_plot function.
         """
         if self.backend == "matplotlib":
-            plt = self.get_plot(**kwargs)
-            f = plt.gcf()
-            f.set_size_inches((12, 10))
-            plt.savefig(stream, format=image_format)
+            ax = self.get_plot(**kwargs)
+            ax.figure.set_size_inches((12, 10))
+            ax.figure.savefig(stream, format=image_format)
         elif self.backend == "plotly":
             fig = self.get_plot(**kwargs)
             fig.write_image(stream, format=image_format)

--- a/pymatgen/analysis/pourbaix_diagram.py
+++ b/pymatgen/analysis/pourbaix_diagram.py
@@ -22,6 +22,8 @@ try:
 except ImportError:
     from scipy.misc import comb
 
+from typing import TYPE_CHECKING, Any, no_type_check
+
 from pymatgen.analysis.phase_diagram import PDEntry, PhaseDiagram
 from pymatgen.analysis.reaction_calculator import Reaction, ReactionError
 from pymatgen.core.composition import Composition
@@ -33,6 +35,9 @@ from pymatgen.util.coord import Simplex
 from pymatgen.util.due import Doi, due
 from pymatgen.util.plotting import pretty_plot
 from pymatgen.util.string import Stringify
+
+if TYPE_CHECKING:
+    import matplotlib.pyplot as plt
 
 __author__ = "Sai Jayaraman"
 __copyright__ = "Copyright 2012, The Materials Project"
@@ -942,16 +947,17 @@ class PourbaixPlotter:
         plt = self.get_pourbaix_plot(*args, **kwargs)
         plt.show()
 
+    @no_type_check
     def get_pourbaix_plot(
         self,
-        limits=None,
-        title="",
-        label_domains=True,
-        label_fontsize=20,
-        show_water_lines=True,
-        show_neutral_axes=True,
-        plt=None,
-    ):
+        limits: tuple[float, float] | None = None,
+        title: str = "",
+        label_domains: bool = True,
+        label_fontsize: int = 20,
+        show_water_lines: bool = True,
+        show_neutral_axes: bool = True,
+        ax: plt.Axes = None,
+    ) -> plt.Axes:
         """
         Plot Pourbaix diagram.
 
@@ -965,43 +971,38 @@ class PourbaixPlotter:
                 of water stability.
             show_neutral_axes; whether to show dashed horizontal and vertical lines
                 at 0 V and pH 7, respectively.
-            plt (pyplot): Pyplot instance for plotting
+            ax (Axes): Matplotlib Axes instance for plotting
 
         Returns:
-            plt (pyplot) - matplotlib plot object with Pourbaix diagram
+            Axes: matplotlib Axes object with Pourbaix diagram
         """
         if limits is None:
             limits = [[-2, 16], [-3, 3]]
 
-        plt = plt or pretty_plot(16)
+        ax = ax or pretty_plot(16)
 
-        xlim = limits[0]
-        ylim = limits[1]
-
-        ax = plt.gca()
-        ax.set_xlim(xlim)
-        ax.set_ylim(ylim)
+        xlim, ylim = limits
         lw = 3
 
         if show_water_lines:
             h_line = np.transpose([[xlim[0], -xlim[0] * PREFAC], [xlim[1], -xlim[1] * PREFAC]])
             o_line = np.transpose([[xlim[0], -xlim[0] * PREFAC + 1.23], [xlim[1], -xlim[1] * PREFAC + 1.23]])
-            plt.plot(h_line[0], h_line[1], "r--", linewidth=lw)
-            plt.plot(o_line[0], o_line[1], "r--", linewidth=lw)
+            ax.plot(h_line[0], h_line[1], "r--", linewidth=lw)
+            ax.plot(o_line[0], o_line[1], "r--", linewidth=lw)
 
         if show_neutral_axes:
             neutral_line = np.transpose([[7, ylim[0]], [7, ylim[1]]])
             V0_line = np.transpose([[xlim[0], 0], [xlim[1], 0]])
-            plt.plot(neutral_line[0], neutral_line[1], "k-.", linewidth=lw)
-            plt.plot(V0_line[0], V0_line[1], "k-.", linewidth=lw)
+            ax.plot(neutral_line[0], neutral_line[1], "k-.", linewidth=lw)
+            ax.plot(V0_line[0], V0_line[1], "k-.", linewidth=lw)
 
         for entry, vertices in self._pbx._stable_domain_vertices.items():
             center = np.average(vertices, axis=0)
             x, y = np.transpose(np.vstack([vertices, vertices[0]]))
-            plt.plot(x, y, "k-", linewidth=lw)
+            ax.plot(x, y, "k-", linewidth=lw)
 
             if label_domains:
-                plt.annotate(
+                ax.annotate(
                     generate_entry_label(entry),
                     center,
                     ha="center",
@@ -1010,42 +1011,47 @@ class PourbaixPlotter:
                     color="b",
                 ).draggable()
 
-        plt.xlabel("pH")
-        plt.ylabel("E (V)")
-        plt.title(title, fontsize=20, fontweight="bold")
-        return plt
+        ax.set_title(title, fontsize=20, fontweight="bold")
+        ax.set(xlabel="pH", ylabel="E (V)", xlim=xlim, ylim=ylim)
+        return ax
 
+    @no_type_check
     def plot_entry_stability(
         self,
-        entry,
-        pH_range=None,
-        pH_resolution=100,
-        V_range=None,
-        V_resolution=100,
-        e_hull_max=1,
-        cmap="RdYlBu_r",
-        **kwargs,
-    ):
+        entry: Any,
+        pH_range: tuple[float, float] | None = None,
+        pH_resolution: int = 100,
+        V_range: tuple[float, float] | None = None,
+        V_resolution: int = 100,
+        e_hull_max: float = 1,
+        cmap: str = "RdYlBu_r",
+        ax: plt.Axes | None = None,
+        **kwargs: Any,
+    ) -> plt.Axes:
         """
+        Plots the stability of an entry in the Pourbaix diagram.
+
         Args:
-            entry ():
-            pH_range ():
-            pH_resolution ():
-            V_range ():
-            V_resolution ():
-            e_hull_max ():
-            cmap ():
-            **kwargs ():
+            entry (Any): The entry to plot stability for.
+            pH_range (Tuple[float, float], optional): pH range for the plot. Defaults to [-2, 16].
+            pH_resolution (int, optional): pH resolution. Defaults to 100.
+            V_range (Tuple[float, float], optional): Voltage range for the plot. Defaults to [-3, 3].
+            V_resolution (int, optional): Voltage resolution. Defaults to 100.
+            e_hull_max (float, optional): Maximum energy above the hull. Defaults to 1.
+            cmap (str, optional): Colormap for the plot. Defaults to "RdYlBu_r".
+            ax (Axes, optional): Existing matplotlib Axes object for plotting. Defaults to None.
+            **kwargs (Any): Additional keyword arguments passed to `get_pourbaix_plot`.
 
         Returns:
+            plt.Axes: Matplotlib Axes object with the plotted stability.
         """
         if pH_range is None:
             pH_range = [-2, 16]
         if V_range is None:
             V_range = [-3, 3]
 
-        # plot the Pourbaix diagram
-        plt = self.get_pourbaix_plot(**kwargs)
+        # Plot the Pourbaix diagram
+        ax = self.get_pourbaix_plot(ax=ax, **kwargs)
         pH, V = np.mgrid[
             pH_range[0] : pH_range[1] : pH_resolution * 1j,
             V_range[0] : V_range[1] : V_resolution * 1j,
@@ -1054,8 +1060,8 @@ class PourbaixPlotter:
         stability = self._pbx.get_decomposition_energy(entry, pH, V)
 
         # Plot stability map
-        plt.pcolor(pH, V, stability, cmap=cmap, vmin=0, vmax=e_hull_max)
-        cbar = plt.colorbar()
+        cax = ax.pcolor(pH, V, stability, cmap=cmap, vmin=0, vmax=e_hull_max)
+        cbar = ax.figure.colorbar(cax)
         cbar.set_label(f"Stability of {generate_entry_label(entry)} (eV/atom)")
 
         # Set ticklabels
@@ -1063,7 +1069,7 @@ class PourbaixPlotter:
         # ticklabels[-1] = f">={ticklabels[-1]}"
         # cbar.ax.set_yticklabels(ticklabels)
 
-        return plt
+        return ax
 
     def domain_vertices(self, entry):
         """

--- a/pymatgen/analysis/structure_analyzer.py
+++ b/pymatgen/analysis/structure_analyzer.py
@@ -148,8 +148,7 @@ class VoronoiAnalyzer:
 
     @staticmethod
     def plot_vor_analysis(voronoi_ensemble: list[tuple[str, float]]) -> plt.Axes:
-        """
-        Plot the Voronoi analysis.
+        """Plot the Voronoi analysis.
 
         Args:
             voronoi_ensemble (list[tuple[str, float]]): List of tuples containing labels and
@@ -159,63 +158,63 @@ class VoronoiAnalyzer:
             plt.Axes: Matplotlib Axes object with the plotted Voronoi analysis.
         """
         labels, val = zip(*voronoi_ensemble)
-        val = np.array(val, dtype=float)
-        val /= np.sum(val)
-        pos = np.arange(len(val)) + 0.5  # the bar centers on the y axis
+        arr = np.array(val, dtype=float)
+        arr /= np.sum(arr)
+        pos = np.arange(len(arr)) + 0.5  # the bar centers on the y axis
 
         fig, ax = plt.subplots()
-        ax.barh(pos, val, align="center", alpha=0.5)
+        ax.barh(pos, arr, align="center", alpha=0.5)
         ax.set_yticks(pos)
         ax.set_yticklabels(labels)
         ax.set(title="Voronoi Spectra", xlabel="Count")
         ax.grid(True)
-
         return ax
 
 
 class RelaxationAnalyzer:
     """This class analyzes the relaxation in a calculation."""
 
-    def __init__(self, initial_structure, final_structure):
-        """
-        Please note that the input and final structures should have the same
-        ordering of sites. This is typically the case for most computational
-        codes.
+    def __init__(self, initial_structure: Structure, final_structure: Structure) -> None:
+        """Please note that the input and final structures should have the same
+        ordering of sites. This is typically the case for most computational codes.
 
         Args:
             initial_structure (Structure): Initial input structure to
                 calculation.
             final_structure (Structure): Final output structure from
                 calculation.
+
+        Raises:
+            ValueError: If initial and final structures have different formulas.
         """
         if final_structure.formula != initial_structure.formula:
             raise ValueError("Initial and final structures have different formulas!")
         self.initial = initial_structure
         self.final = final_structure
 
-    def get_percentage_volume_change(self):
+    def get_percentage_volume_change(self) -> float:
         """
         Returns the percentage volume change.
 
         Returns:
-            Volume change in percentage, e.g., 0.055 implies a 5.5% increase.
+            float: Volume change in percent. 0.055 means a 5.5% increase.
         """
         return self.final.volume / self.initial.volume - 1
 
-    def get_percentage_lattice_parameter_changes(self):
+    def get_percentage_lattice_parameter_changes(self) -> dict[str, float]:
         """
         Returns the percentage lattice parameter changes.
 
         Returns:
-            A dict of the percentage change in lattice parameter, e.g.,
-            {'a': 0.012, 'b': 0.021, 'c': -0.031} implies a change of 1.2%,
-            2.1% and -3.1% in the a, b and c lattice parameters respectively.
+            dict[str, float]: Percent changes in lattice parameter, e.g.,
+                {'a': 0.012, 'b': 0.021, 'c': -0.031} implies a change of 1.2%,
+                2.1% and -3.1% in the a, b and c lattice parameters respectively.
         """
         initial_latt = self.initial.lattice
         final_latt = self.final.lattice
         return {length: getattr(final_latt, length) / getattr(initial_latt, length) - 1 for length in ["a", "b", "c"]}
 
-    def get_percentage_bond_dist_changes(self, max_radius=3.0):
+    def get_percentage_bond_dist_changes(self, max_radius: float = 3.0) -> dict[int, dict[int, float]]:
         """
         Returns the percentage bond distance changes for each site up to a
         maximum radius for nearest neighbors.
@@ -226,13 +225,12 @@ class RelaxationAnalyzer:
                not the final structure.
 
         Returns:
-            Bond distance changes as a dict of dicts. E.g.,
-            {index1: {index2: 0.011, ...}}. For economy of representation, the
-            index1 is always less than index2, i.e., since bonding between
-            site1 and site_n is the same as bonding between site_n and site1,
-            there is no reason to duplicate the information or computation.
+            dict[int, dict[int, float]]: Bond distance changes in the form {index1: {index2: 0.011, ...}}.
+                For economy of representation, the index1 is always less than index2, i.e., since bonding
+                between site1 and site_n is the same as bonding between site_n and site1, there is no
+                reason to duplicate the information or computation.
         """
-        data = collections.defaultdict(dict)
+        data: dict[int, dict[int, float]] = collections.defaultdict(dict)
         for inds in itertools.combinations(list(range(len(self.initial))), 2):
             (i, j) = sorted(inds)
             initial_dist = self.initial[i].distance(self.initial[j])

--- a/pymatgen/analysis/structure_analyzer.py
+++ b/pymatgen/analysis/structure_analyzer.py
@@ -8,6 +8,7 @@ from math import acos, pi
 from typing import TYPE_CHECKING
 from warnings import warn
 
+import matplotlib.pyplot as plt
 import numpy as np
 from scipy.spatial import Voronoi
 
@@ -146,28 +147,30 @@ class VoronoiAnalyzer:
         return sorted(voro_dict.items(), key=lambda x: (x[1], x[0]), reverse=True)[:most_frequent_polyhedra]
 
     @staticmethod
-    def plot_vor_analysis(voronoi_ensemble):
+    def plot_vor_analysis(voronoi_ensemble: list[tuple[str, float]]) -> plt.Axes:
         """
         Plot the Voronoi analysis.
 
-        :param voronoi_ensemble:
-        :return: matplotlib.pyplot
-        """
-        t = list(zip(*voronoi_ensemble))
-        labels = t[0]
-        val = list(t[1])
-        tot = np.sum(val)
-        val = [float(j) / tot for j in val]
-        pos = np.arange(len(val)) + 0.5  # the bar centers on the y axis
-        import matplotlib.pyplot as plt
+        Args:
+            voronoi_ensemble (list[tuple[str, float]]): List of tuples containing labels and
+                values for Voronoi analysis.
 
-        plt.figure()
-        plt.barh(pos, val, align="center", alpha=0.5)
-        plt.yticks(pos, labels)
-        plt.xlabel("Count")
-        plt.title("Voronoi Spectra")
-        plt.grid(True)
-        return plt
+        Returns:
+            plt.Axes: Matplotlib Axes object with the plotted Voronoi analysis.
+        """
+        labels, val = zip(*voronoi_ensemble)
+        val = np.array(val, dtype=float)
+        val /= np.sum(val)
+        pos = np.arange(len(val)) + 0.5  # the bar centers on the y axis
+
+        fig, ax = plt.subplots()
+        ax.barh(pos, val, align="center", alpha=0.5)
+        ax.set_yticks(pos)
+        ax.set_yticklabels(labels)
+        ax.set(title="Voronoi Spectra", xlabel="Count")
+        ax.grid(True)
+
+        return ax
 
 
 class RelaxationAnalyzer:

--- a/pymatgen/analysis/surface_analysis.py
+++ b/pymatgen/analysis/surface_analysis.py
@@ -1059,10 +1059,9 @@ class SurfaceEnergyPlotter:
 
         adsorbates = tuple(ads_entry.ads_entries_dict)
         ax.set_xlabel(f"{' '.join(adsorbates)} Coverage (ML)")
-        ax.set_ylabel("Adsorption Energy (eV)") if plot_eads else ax.ylabel("Binding Energy (eV)")
+        ax.set_ylabel("Adsorption Energy (eV)" if plot_eads else "Binding Energy (eV)")
         ax.legend()
         plt.tight_layout()
-
         return ax
 
     @staticmethod
@@ -1145,8 +1144,8 @@ class SurfaceEnergyPlotter:
                         if annotate_monolayer:
                             ax.annotate(f"{ml:.2f}", xy=[se, be], xytext=[se, be])
 
-        ax.set_xlabel(r"Surface energy ($J/m^2$)") if JPERM2 else ax.xlabel(r"Surface energy ($eV/\AA^2$)")
-        ax.set_ylabel("Adsorption Energy (eV)") if plot_eads else ax.ylabel("Binding Energy (eV)")
+        ax.set_xlabel(r"Surface energy ($J/m^2$)" if JPERM2 else r"Surface energy ($eV/\AA^2$)")
+        ax.set_ylabel("Adsorption Energy (eV)" if plot_eads else "Binding Energy (eV)")
         plt.tight_layout()
         ax.set_xticks(rotation=60)
         return ax

--- a/pymatgen/analysis/surface_analysis.py
+++ b/pymatgen/analysis/surface_analysis.py
@@ -1058,10 +1058,10 @@ class SurfaceEnergyPlotter:
             ax.plot(monolayers, BEs, "-o", c=self.color_dict[clean_entry], label=hkl)
 
         adsorbates = tuple(ads_entry.ads_entries_dict)
-        ax.xlabel(f"{' '.join(adsorbates)} Coverage (ML)")
-        ax.ylabel("Adsorption Energy (eV)") if plot_eads else ax.ylabel("Binding Energy (eV)")
+        ax.set_xlabel(f"{' '.join(adsorbates)} Coverage (ML)")
+        ax.set_ylabel("Adsorption Energy (eV)") if plot_eads else ax.ylabel("Binding Energy (eV)")
         ax.legend()
-        ax.tight_layout()
+        plt.tight_layout()
 
         return ax
 

--- a/pymatgen/analysis/surface_analysis.py
+++ b/pymatgen/analysis/surface_analysis.py
@@ -1129,7 +1129,7 @@ class SurfaceEnergyPlotter:
             (Plot): Plot of clean surface energy vs binding energy for
                 all facets.
         """
-        plt = pretty_plot(width=8, height=7)
+        ax = pretty_plot(width=8, height=7)
         for hkl in self.all_slab_entries:
             for clean_entry in self.all_slab_entries[hkl]:
                 all_delu_dict = self.set_all_variables(delu_dict, delu_default)
@@ -1141,16 +1141,15 @@ class SurfaceEnergyPlotter:
                         be = ads_entry.gibbs_binding_energy(eads=plot_eads)
 
                         # Now plot the surface energy vs binding energy
-                        plt.scatter(se, be)
+                        ax.scatter(se, be)
                         if annotate_monolayer:
-                            plt.annotate(f"{ml:.2f}", xy=[se, be], xytext=[se, be])
+                            ax.annotate(f"{ml:.2f}", xy=[se, be], xytext=[se, be])
 
-        plt.xlabel(r"Surface energy ($J/m^2$)") if JPERM2 else plt.xlabel(r"Surface energy ($eV/\AA^2$)")
-        plt.ylabel("Adsorption Energy (eV)") if plot_eads else plt.ylabel("Binding Energy (eV)")
+        ax.set_xlabel(r"Surface energy ($J/m^2$)") if JPERM2 else ax.xlabel(r"Surface energy ($eV/\AA^2$)")
+        ax.set_ylabel("Adsorption Energy (eV)") if plot_eads else ax.ylabel("Binding Energy (eV)")
         plt.tight_layout()
-        plt.xticks(rotation=60)
-
-        return plt
+        ax.set_xticks(rotation=60)
+        return ax
 
     def surface_chempot_range_map(
         self,

--- a/pymatgen/analysis/surface_analysis.py
+++ b/pymatgen/analysis/surface_analysis.py
@@ -1282,8 +1282,7 @@ class SurfaceEnergyPlotter:
                 ax.annotate(label, xy=[x, y], xytext=[x, y], fontsize=fontsize)
 
         # Label plot
-        ax.set_xlim(range1)
-        ax.set_ylim(range2)
+        ax.set(xlim=range1, ylim=range2)
         ax.set_xlabel(rf"$\Delta\mu_{{{el1}}} (eV)$", fontsize=25)
         ax.set_ylabel(rf"$\Delta\mu_{{{el2}}} (eV)$", fontsize=25)
         ax.set_xticks(rotation=60)

--- a/pymatgen/analysis/surface_analysis.py
+++ b/pymatgen/analysis/surface_analysis.py
@@ -1161,11 +1161,11 @@ class SurfaceEnergyPlotter:
         no_doped=False,
         no_clean=False,
         delu_dict=None,
-        plt=None,
+        ax=None,
         annotate=True,
         show_unphyiscal_only=False,
         fontsize=10,
-    ):
+    ) -> plt.Axes:
         """
         Adapted from the get_chempot_range_map() method in the PhaseDiagram
             class. Plot the chemical potential range map based on surface
@@ -1190,7 +1190,7 @@ class SurfaceEnergyPlotter:
             delu_dict (dict): Dictionary of the chemical potentials to be set as
                 constant. Note the key should be a sympy Symbol object of the
                 format: Symbol("delu_el") where el is the name of the element.
-            plt (Plot): Plot object to plot on. If None, will create a new plot.
+            ax (plt.Axes): Axes object to plot on. If None, will create a new plot.
             annotate (bool): Whether to annotate each "phase" with the label of
                 the entry. If no label, uses the reduced formula
             show_unphyiscal_only (bool): Whether to only show the shaded region where
@@ -1199,7 +1199,7 @@ class SurfaceEnergyPlotter:
         """
         # Set up
         delu_dict = delu_dict or {}
-        plt = plt if plt else pretty_plot(12, 8)
+        ax = ax if ax else pretty_plot(12, 8)
         el1, el2 = str(elements[0]), str(elements[1])
         delu1 = Symbol(f"delu_{elements[0]}")
         delu2 = Symbol(f"delu_{elements[1]}")
@@ -1208,7 +1208,7 @@ class SurfaceEnergyPlotter:
 
         # Find a range map for each entry (surface). This part is very slow, will
         # need to implement a more sophisticated method of getting the range map
-        vertices_dict = {}
+        vertices_dict: dict[SlabEntry, list] = {}
         for dmu1 in np.linspace(range1[0], range1[1], incr):
             # Get chemical potential range of dmu2 for each increment of dmu1
             new_delu_dict = delu_dict.copy()
@@ -1248,17 +1248,17 @@ class SurfaceEnergyPlotter:
                     else:
                         neg_dmu_range = [pt1[delu2][0][1], pt1[delu2][0][2]]
                     # Shade the threshold and region at which se<=0
-                    plt.plot([pt1[delu1], pt1[delu1]], neg_dmu_range, "k--")
+                    ax.plot([pt1[delu1], pt1[delu1]], neg_dmu_range, "k--")
                 elif pt1[delu2][1][0] < 0 and pt1[delu2][1][1] < 0 and not show_unphyiscal_only:
                     # Any chempot at this point will result
                     # in se<0, shade the entire y range
-                    plt.plot([pt1[delu1], pt1[delu1]], range2, "k--")
+                    ax.plot([pt1[delu1], pt1[delu1]], range2, "k--")
 
                 if ii == len(v) - 1:
                     break
                 pt2 = v[ii + 1]
                 if not show_unphyiscal_only:
-                    plt.plot(
+                    ax.plot(
                         [pt1[delu1], pt2[delu1]],
                         [pt1[delu2][0][0], pt2[delu2][0][0]],
                         "k",
@@ -1274,23 +1274,23 @@ class SurfaceEnergyPlotter:
             xvals.extend([pt[delu1], pt[delu1]])
             yvals.extend(pt[delu2][0])
             if not show_unphyiscal_only:
-                plt.plot([pt[delu1], pt[delu1]], [pt[delu2][0][0], pt[delu2][0][-1]], "k")
+                ax.plot([pt[delu1], pt[delu1]], [pt[delu2][0][0], pt[delu2][0][-1]], "k")
 
             if annotate:
                 # Label the phases
                 x = np.mean([max(xvals), min(xvals)])
                 y = np.mean([max(yvals), min(yvals)])
                 label = entry.label if entry.label else entry.composition.reduced_formula
-                plt.annotate(label, xy=[x, y], xytext=[x, y], fontsize=fontsize)
+                ax.annotate(label, xy=[x, y], xytext=[x, y], fontsize=fontsize)
 
         # Label plot
-        plt.xlim(range1)
-        plt.ylim(range2)
-        plt.xlabel(rf"$\Delta\mu_{{{el1}}} (eV)$", fontsize=25)
-        plt.ylabel(rf"$\Delta\mu_{{{el2}}} (eV)$", fontsize=25)
-        plt.xticks(rotation=60)
+        ax.set_xlim(range1)
+        ax.set_ylim(range2)
+        ax.set_xlabel(rf"$\Delta\mu_{{{el1}}} (eV)$", fontsize=25)
+        ax.set_ylabel(rf"$\Delta\mu_{{{el2}}} (eV)$", fontsize=25)
+        ax.set_xticks(rotation=60)
 
-        return plt
+        return ax
 
     def set_all_variables(self, delu_dict, delu_default):
         """

--- a/pymatgen/analysis/transition_state.py
+++ b/pymatgen/analysis/transition_state.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import os
 from glob import glob
 
+import matplotlib.pyplot as plt
 import numpy as np
 from monty.json import MSONable, jsanitize
 from scipy.interpolate import CubicSpline
@@ -150,7 +151,7 @@ class NEBAnalysis(MSONable):
                 max_extrema.append((x[i] * scale, y[i]))
         return min_extrema, max_extrema
 
-    def get_plot(self, normalize_rxn_coordinate=True, label_barrier=True):
+    def get_plot(self, normalize_rxn_coordinate: bool = True, label_barrier: bool = True) -> plt.Axes:
         """
         Returns the NEB plot. Uses Henkelman's approach of spline fitting
         each section of the reaction path based on tangent force and energies.
@@ -161,14 +162,14 @@ class NEBAnalysis(MSONable):
             label_barrier (bool): Whether to label the maximum barrier.
 
         Returns:
-            matplotlib.pyplot object.
+            plt.Axes: matplotlib axes object.
         """
-        plt = pretty_plot(12, 8)
+        ax = pretty_plot(12, 8)
         scale = 1 if not normalize_rxn_coordinate else 1 / self.r[-1]
         x = np.arange(0, np.max(self.r), 0.01)
         y = self.spline(x) * 1000
         relative_energies = self.energies - self.energies[0]
-        plt.plot(
+        ax.plot(
             self.r * scale,
             relative_energies * 1000,
             "ro",
@@ -178,21 +179,21 @@ class NEBAnalysis(MSONable):
             linewidth=2,
             markersize=10,
         )
-        plt.xlabel("Reaction coordinate")
-        plt.ylabel("Energy (meV)")
-        plt.ylim((np.min(y) - 10, np.max(y) * 1.02 + 20))
+        ax.set_xlabel("Reaction coordinate")
+        ax.set_ylabel("Energy (meV)")
+        ax.set_ylim((np.min(y) - 10, np.max(y) * 1.02 + 20))
         if label_barrier:
             data = zip(x * scale, y)
             barrier = max(data, key=lambda d: d[1])
-            plt.plot([0, barrier[0]], [barrier[1], barrier[1]], "k--")
-            plt.annotate(
+            ax.plot([0, barrier[0]], [barrier[1], barrier[1]], "k--")
+            ax.annotate(
                 f"{np.max(y) - np.min(y):.0f} meV",
                 xy=(barrier[0] / 2, barrier[1] * 1.02),
                 xytext=(barrier[0] / 2, barrier[1] * 1.02),
                 horizontalalignment="center",
             )
         plt.tight_layout()
-        return plt
+        return ax
 
     @classmethod
     def from_dir(cls, root_dir, relaxation_dirs=None, **kwargs):

--- a/pymatgen/apps/battery/plotter.py
+++ b/pymatgen/apps/battery/plotter.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import matplotlib.pyplot as plt
 import plotly.graph_objects as go
 
 from pymatgen.util.plotting import pretty_plot
@@ -85,7 +86,7 @@ class VoltageProfilePlotter:
             y.append(0)
         return x, y
 
-    def get_plot(self, width=8, height=8, term_zero=True):
+    def get_plot(self, width=8, height=8, term_zero=True, ax: plt.Axes = None):
         """
         Returns a plot object.
 
@@ -93,11 +94,12 @@ class VoltageProfilePlotter:
             width: Width of the plot. Defaults to 8 in.
             height: Height of the plot. Defaults to 6 in.
             term_zero: If True append zero voltage point at the end
+            ax (plt.Axes): matplotlib axes object. Defaults to None.
 
         Returns:
-            A matplotlib plot object.
+            plt.Axes: matplotlib axes object.
         """
-        plt = pretty_plot(width, height)
+        ax = ax or pretty_plot(width, height)
         wion_symbol = set()
         formula = set()
 
@@ -105,13 +107,13 @@ class VoltageProfilePlotter:
             (x, y) = self.get_plot_data(electrode, term_zero=term_zero)
             wion_symbol.add(electrode.working_ion.symbol)
             formula.add(electrode.framework_formula)
-            plt.plot(x, y, "-", linewidth=2, label=label)
+            ax.plot(x, y, "-", linewidth=2, label=label)
 
-        plt.legend()
-        plt.xlabel(self._choose_best_x_lable(formula=formula, wion_symbol=wion_symbol))
-        plt.ylabel("Voltage (V)")
+        ax.legend()
+        ax.set_xlabel(self._choose_best_x_lable(formula=formula, wion_symbol=wion_symbol))
+        ax.set_ylabel("Voltage (V)")
         plt.tight_layout()
-        return plt
+        return ax
 
     def get_plotly_figure(
         self,

--- a/pymatgen/cli/feff_plot_cross_section.py
+++ b/pymatgen/cli/feff_plot_cross_section.py
@@ -47,9 +47,9 @@ def main():
 
     data = xmu.as_dict()
 
-    ax.title(data["calc"] + " Feff9.6 Calculation for " + data["atom"] + " in " + data["formula"] + " unit cell")
-    ax.xlabel("Energies (eV)")
-    ax.ylabel("Absorption Cross-section")
+    ax.set_title(data["calc"] + " Feff9.6 Calculation for " + data["atom"] + " in " + data["formula"] + " unit cell")
+    ax.set_xlabel("Energies (eV)")
+    ax.set_ylabel("Absorption Cross-section")
 
     x = data["energies"]
     y = data["scross"]

--- a/pymatgen/cli/feff_plot_cross_section.py
+++ b/pymatgen/cli/feff_plot_cross_section.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 import argparse
 
+import matplotlib.pyplot as plt
+
 from pymatgen.io.feff.outputs import Xmu
 from pymatgen.util.plotting import pretty_plot
 
@@ -37,7 +39,7 @@ def main():
         help="feff.inp filename to import",
     )
 
-    plt = pretty_plot(12, 8)
+    ax = pretty_plot(12, 8)
     color_order = ["r", "b", "g", "c", "k", "m", "y"]
 
     args = parser.parse_args()
@@ -45,22 +47,21 @@ def main():
 
     data = xmu.as_dict()
 
-    plt.title(data["calc"] + " Feff9.6 Calculation for " + data["atom"] + " in " + data["formula"] + " unit cell")
-    plt.xlabel("Energies (eV)")
-    plt.ylabel("Absorption Cross-section")
+    ax.title(data["calc"] + " Feff9.6 Calculation for " + data["atom"] + " in " + data["formula"] + " unit cell")
+    ax.xlabel("Energies (eV)")
+    ax.ylabel("Absorption Cross-section")
 
     x = data["energies"]
     y = data["scross"]
     tle = "Single " + data["atom"] + " " + data["edge"] + " edge"
-    plt.plot(x, y, color_order[1 % 7], label=tle)
+    ax.plot(x, y, color_order[1 % 7], label=tle)
 
     y = data["across"]
     tle = data["atom"] + " " + data["edge"] + " edge in " + data["formula"]
-    plt.plot(x, y, color_order[2 % 7], label=tle)
+    ax.plot(x, y, color_order[2 % 7], label=tle)
 
-    plt.legend()
-    leg = plt.gca().get_legend()
-    legend_text = leg.get_texts()  # all the text.Text instance in the legend
+    ax.legend()
+    legend_text = ax.get_legend().get_texts()  # all the text.Text instance in the legend
     plt.setp(legend_text, fontsize=15)
     plt.tight_layout()
     plt.show()

--- a/pymatgen/cli/feff_plot_cross_section.py
+++ b/pymatgen/cli/feff_plot_cross_section.py
@@ -60,8 +60,8 @@ def main():
 
     plt.legend()
     leg = plt.gca().get_legend()
-    ltext = leg.get_texts()  # all the text.Text instance in the legend
-    plt.setp(ltext, fontsize=15)
+    legend_text = leg.get_texts()  # all the text.Text instance in the legend
+    plt.setp(legend_text, fontsize=15)
     plt.tight_layout()
     plt.show()
 

--- a/pymatgen/cli/pmg_plot.py
+++ b/pymatgen/cli/pmg_plot.py
@@ -2,14 +2,16 @@
 
 """Implementation for `pmg plot` CLI."""
 
-
 from __future__ import annotations
+
+import matplotlib.pyplot as plt
 
 from pymatgen.analysis.diffraction.xrd import XRDCalculator
 from pymatgen.core.structure import Structure
 from pymatgen.electronic_structure.plotter import DosPlotter
 from pymatgen.io.vasp import Chgcar, Vasprun
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
+from pymatgen.util.plotting import pretty_plot
 
 
 def get_dos_plot(args):
@@ -45,12 +47,16 @@ def get_dos_plot(args):
     return plotter.get_plot()
 
 
-def get_chgint_plot(args):
+def get_chgint_plot(args, ax: plt.Axes = None) -> plt.Axes:
     """
     Plot integrated charge.
 
     Args:
         args (dict): args from argparse.
+        ax (plt.Axes): Matplotlib Axes object for plotting.
+
+    Returns:
+        plt.Axes: Matplotlib Axes object.
     """
     chgcar = Chgcar.from_file(args.chgcar_file)
     struct = chgcar.structure
@@ -62,17 +68,15 @@ def get_chgint_plot(args):
         sites = [sites[0] for sites in finder.get_symmetrized_structure().equivalent_sites]
         atom_ind = [struct.index(site) for site in sites]
 
-    from pymatgen.util.plotting import pretty_plot
-
-    plt = pretty_plot(12, 8)
-    for i in atom_ind:
-        d = chgcar.get_integrated_diff(i, args.radius, 30)
-        plt.plot(d[:, 0], d[:, 1], label=f"Atom {i} - {struct[i].species_string}")
-    plt.legend(loc="upper left")
-    plt.xlabel("Radius (A)")
-    plt.ylabel("Integrated charge (e)")
+    ax = ax or pretty_plot(12, 8)
+    for idx in atom_ind:
+        d = chgcar.get_integrated_diff(idx, args.radius, 30)
+        ax.plot(d[:, 0], d[:, 1], label=f"Atom {idx} - {struct[idx].species_string}")
+    ax.legend(loc="upper left")
+    ax.set_xlabel("Radius (A)")
+    ax.set_ylabel("Integrated charge (e)")
     plt.tight_layout()
-    return plt
+    return ax
 
 
 def get_xrd_plot(args):

--- a/pymatgen/electronic_structure/boltztrap2.py
+++ b/pymatgen/electronic_structure/boltztrap2.py
@@ -1031,7 +1031,7 @@ class BztPlotter:
         doping=None,
         temps=None,
         xlim=(-2, 2),
-        ax=None,
+        ax: plt.Axes = None,
     ):
         """
         Function to plot the transport properties.

--- a/pymatgen/electronic_structure/boltztrap2.py
+++ b/pymatgen/electronic_structure/boltztrap2.py
@@ -1126,7 +1126,7 @@ class BztPlotter:
                 for temp in temps:
                     ti = temps_all.index(temp)
                     prop_out = p_array[ti] if idx_prop == 6 else np.abs(p_array[ti])
-                    plt.semilogy(mu, prop_out, label=str(temp) + " K")
+                    plt.semilogy(mu, prop_out, label=f"{temp} K")
 
                 plt.xlabel(r"$\mu$ (eV)", fontsize=30)
                 plt.xlim(xlim)
@@ -1141,7 +1141,7 @@ class BztPlotter:
                 ti = temps_all.index(temp)
                 prop_out = np.linalg.eigh(p_array[ti])[0]
                 if output == "avg_eigs":
-                    plt.plot(mu, prop_out.mean(axis=1), label=str(temp) + " K")
+                    plt.plot(mu, prop_out.mean(axis=1), label=f"{temp} K")
                 elif output == "eigs":
                     for i in range(3):
                         plt.plot(
@@ -1158,7 +1158,7 @@ class BztPlotter:
                 ti = temps_all.index(temp)
                 prop_out = np.linalg.eigh(p_array[dop_type][ti])[0]
                 if output == "avg_eigs":
-                    plt.semilogx(doping_all, prop_out.mean(axis=1), "s-", label=str(temp) + " K")
+                    plt.semilogx(doping_all, prop_out.mean(axis=1), "s-", label=f"{temp} K")
                 elif output == "eigs":
                     for i in range(3):
                         plt.plot(

--- a/pymatgen/electronic_structure/boltztrap2.py
+++ b/pymatgen/electronic_structure/boltztrap2.py
@@ -1191,7 +1191,7 @@ class BztPlotter:
                         )
 
             plt.xlabel(r"Temperature (K)", fontsize=30)
-            leg_title = dop_type + "-type"
+            leg_title = f"{dop_type}-type"
 
         plt.ylabel(props_lbl[idx_prop] + " " + props_unit[idx_prop], fontsize=30)
         plt.xticks(fontsize=25)

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -2261,8 +2261,7 @@ class BSDOSPlotter:
                 CompleteDos) for projected plots.
 
         Returns:
-            matplotlib.pyplot object on which you can call commands like show()
-            and savefig()
+            tuple[plt.Axes, plt.Axes]: matplotlib axes for the band structure and DOS, resp.
         """
         import matplotlib.lines as mlines
         import matplotlib.pyplot as plt
@@ -3055,9 +3054,9 @@ class BoltztrapPlotter:
         output: str = "eig",
         relaxation_time: float = 1e-14,
         xlim: Sequence[float] | None = None,
-    ):
+    ) -> plt.Axes:
         """
-        Plot the ZT in function of Fermi level.
+        Plot the ZT as function of Fermi level.
 
         Args:
             temp (float): the temperature
@@ -3067,7 +3066,7 @@ class BoltztrapPlotter:
             xlim (tuple[float, float]): a 2-tuple of min and max fermi energy. Defaults to (0, band gap)
 
         Returns:
-            matplotlib.pyplot module
+            plt.Axes: matplotlib axes object
         """
         ax = pretty_plot(9, 7)
         zt = self._bz.get_zt(relaxation_time=relaxation_time, output=output, doping_levels=False)[temp]

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -230,7 +230,7 @@ class DosPlotter:
                 ax.xlabel("Density of states (states/eV)")
             ax.axvline(x=0, color="k", linestyle="--", linewidth=2)
         else:
-            ax.xlabel("Energies (eV)")
+            ax.set_xlabel("Energies (eV)")
             if self._norm_val:
                 ax.set_ylabel("Density of states (states/eV/Å³)")
             else:
@@ -261,7 +261,7 @@ class DosPlotter:
                 Defaults to False.
             beta_dashed (bool): Plots the beta spin channel with a dashed line. Defaults to False.
         """
-        plt = self.get_plot(xlim, ylim, invert_axes, beta_dashed)
+        self.get_plot(xlim, ylim, invert_axes, beta_dashed)
         plt.savefig(filename, format=img_format)
 
     def show(self, xlim=None, ylim=None, invert_axes=False, beta_dashed=False):
@@ -276,7 +276,7 @@ class DosPlotter:
                 Defaults to False.
             beta_dashed (bool): Plots the beta spin channel with a dashed line. Defaults to False.
         """
-        plt = self.get_plot(xlim, ylim, invert_axes, beta_dashed)
+        self.get_plot(xlim, ylim, invert_axes, beta_dashed)
         plt.show()
 
 
@@ -745,7 +745,7 @@ class BSPlotter:
             smooth_tol (float) : tolerance for fitting spline to band data.
                 Default is None such that no tolerance will be used.
         """
-        plt = self.get_plot(zero_to_efermi, ylim, smooth)
+        self.get_plot(zero_to_efermi, ylim, smooth)
         plt.show()
 
     def save_plot(self, filename, img_format="eps", ylim=None, zero_to_efermi=True, smooth=False):
@@ -760,7 +760,7 @@ class BSPlotter:
                 Defaults to True.
             smooth: Cubic spline interpolation of the bands.
         """
-        plt = self.get_plot(ylim=ylim, zero_to_efermi=zero_to_efermi, smooth=smooth)
+        self.get_plot(ylim=ylim, zero_to_efermi=zero_to_efermi, smooth=smooth)
         plt.savefig(filename, format=img_format)
         plt.close()
 
@@ -843,7 +843,7 @@ class BSPlotter:
                 previous_branch = this_branch
         return {"distance": tick_distance, "label": tick_labels}
 
-    def plot_compare(self, other_plotter, legend=True):
+    def plot_compare(self, other_plotter, legend=True) -> plt.Axes:
         """
         Plot two band structure for comparison. One is in red the other in blue
         (no difference in spins). The two band structures need to be defined
@@ -855,27 +855,27 @@ class BSPlotter:
             legend: True to add a legend to the plot
 
         Returns:
-            a matplotlib object with both band structures
+            plt.Axes: matplotlib Axes object with both band structures
         """
         warnings.warn("Deprecated method. Use BSPlotter([sbs1,sbs2,...]).get_plot() instead.")
 
         # TODO: add exception if the band structures are not compatible
         import matplotlib.lines as mlines
 
-        plt = self.get_plot()
+        ax = self.get_plot()
         data_orig = self.bs_plot_data()
         data = other_plotter.bs_plot_data()
         band_linewidth = 1
         for i in range(other_plotter._nb_bands):
             for d in range(len(data_orig["distances"])):
-                plt.plot(
+                ax.plot(
                     data_orig["distances"][d],
                     [e[str(Spin.up)][i] for e in data["energy"]][d],
                     "c-",
                     linewidth=band_linewidth,
                 )
                 if other_plotter._bs.is_spin_polarized:
-                    plt.plot(
+                    ax.plot(
                         data_orig["distances"][d],
                         [e[str(Spin.down)][i] for e in data["energy"]][d],
                         "m--",
@@ -889,8 +889,8 @@ class BSPlotter:
                 mlines.Line2D([], [], linewidth=2, color="m", linestyle="--", label="bs 2 down"),
             ]
 
-            plt.legend(handles=handles)
-        return plt
+            ax.legend(handles=handles)
+        return ax
 
     def plot_brillouin(self):
         """Plot the Brillouin zone."""
@@ -3888,7 +3888,7 @@ class CohpPlotter:
             ylim: Specifies the y-axis limits. Defaults to None for
                 automatic determination.
         """
-        plt = self.get_plot(xlim, ylim)
+        self.get_plot(xlim, ylim)
         plt.savefig(filename, format=img_format)
 
     def show(self, xlim=None, ylim=None):
@@ -3901,7 +3901,7 @@ class CohpPlotter:
             ylim: Specifies the y-axis limits. Defaults to None for
                 automatic determination.
         """
-        plt = self.get_plot(xlim, ylim)
+        self.get_plot(xlim, ylim)
         plt.show()
 
 

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -3792,10 +3792,9 @@ class CohpPlotter:
 
         import palettable
 
-        # pylint: disable=E1101
         colors = palettable.colorbrewer.qualitative.Set1_9.mpl_colors
 
-        plt = pretty_plot(12, 8)
+        ax = pretty_plot(12, 8)
 
         allpts = []
         keys = list(self._cohps)
@@ -3812,7 +3811,7 @@ class CohpPlotter:
                         y = -populations[spin] if plot_negative else populations[spin]
                     allpts.extend(list(zip(x, y)))
                     if spin == Spin.up:
-                        plt.plot(
+                        ax.plot(
                             x,
                             y,
                             color=colors[i % ncolors],
@@ -3821,29 +3820,29 @@ class CohpPlotter:
                             linewidth=3,
                         )
                     else:
-                        plt.plot(x, y, color=colors[i % ncolors], linestyle="--", linewidth=3)
+                        ax.plot(x, y, color=colors[i % ncolors], linestyle="--", linewidth=3)
 
         if xlim:
-            plt.xlim(xlim)
+            ax.xlim(xlim)
         if ylim:
-            plt.ylim(ylim)
+            ax.ylim(ylim)
         elif not invert_axes:
-            xlim = plt.xlim()
+            xlim = ax.get_xlim()
             relevanty = [p[1] for p in allpts if xlim[0] < p[0] < xlim[1]]
-            plt.ylim((min(relevanty), max(relevanty)))
+            ax.ylim((min(relevanty), max(relevanty)))
         if not xlim and invert_axes:
-            ylim = plt.ylim()
+            ylim = ax.get_ylim()
             relevanty = [p[0] for p in allpts if ylim[0] < p[1] < ylim[1]]
-            plt.xlim((min(relevanty), max(relevanty)))
+            ax.xlim((min(relevanty), max(relevanty)))
 
-        xlim = plt.xlim()
-        ylim = plt.ylim()
+        xlim = ax.get_xlim()
+        ylim = ax.get_ylim()
         if not invert_axes:
-            plt.axhline(y=0, color="k", linewidth=2)
+            ax.axhline(y=0, color="k", linewidth=2)
             if self.zero_at_efermi:
-                plt.plot([0, 0], ylim, "k--", linewidth=2)
+                ax.plot([0, 0], ylim, "k--", linewidth=2)
             else:
-                plt.plot(
+                ax.plot(
                     [self._cohps[key]["efermi"], self._cohps[key]["efermi"]],
                     ylim,
                     color=colors[i % ncolors],
@@ -3851,11 +3850,11 @@ class CohpPlotter:
                     linewidth=2,
                 )
         else:
-            plt.axvline(x=0, color="k", linewidth=2)
+            ax.axvline(x=0, color="k", linewidth=2)
             if self.zero_at_efermi:
-                plt.plot(xlim, [0, 0], "k--", linewidth=2)
+                ax.plot(xlim, [0, 0], "k--", linewidth=2)
             else:
-                plt.plot(
+                ax.plot(
                     xlim,
                     [self._cohps[key]["efermi"], self._cohps[key]["efermi"]],
                     color=colors[i % ncolors],
@@ -3864,18 +3863,18 @@ class CohpPlotter:
                 )
 
         if invert_axes:
-            plt.xlabel(cohp_label)
-            plt.ylabel(energy_label)
+            ax.set_xlabel(cohp_label)
+            ax.set_ylabel(energy_label)
         else:
-            plt.xlabel(energy_label)
-            plt.ylabel(cohp_label)
+            ax.set_xlabel(energy_label)
+            ax.set_ylabel(cohp_label)
 
-        plt.legend()
-        leg = plt.gca().get_legend()
-        ltext = leg.get_texts()
-        plt.setp(ltext, fontsize=30)
+        ax.legend()
+        leg = ax.get_legend()
+        legend_text = leg.get_texts()
+        ax.setp(legend_text, fontsize=30)
         plt.tight_layout()
-        return plt
+        return ax
 
     def save_plot(self, filename, img_format="eps", xlim=None, ylim=None):
         """

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -179,8 +179,7 @@ class DosPlotter:
             all_energies.append(energies)
             all_densities.append(new_dens)
 
-        keys = list(self._doses)
-        keys.reverse()
+        keys = list(reversed(self._doses))
         all_densities.reverse()
         all_energies.reverse()
         all_pts = []
@@ -241,8 +240,7 @@ class DosPlotter:
         handles, labels = ax.get_gca().get_legend_handles_labels()
         label_dict = dict(zip(labels, handles))
         ax.legend(label_dict.values(), label_dict.keys())
-        leg = ax.get_legend()
-        legend_text = leg.get_texts()  # all the text.Text instance in the legend
+        legend_text = ax.get_legend().get_texts()  # all the text.Text instance in the legend
         plt.setp(legend_text, fontsize=30)
         plt.tight_layout()
         return ax
@@ -3866,8 +3864,7 @@ class CohpPlotter:
             ax.set_ylabel(cohp_label)
 
         ax.legend()
-        leg = ax.get_legend()
-        legend_text = leg.get_texts()
+        legend_text = ax.legend().get_texts()
         plt.setp(legend_text, fontsize=30)
         plt.tight_layout()
         return ax

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -1602,16 +1602,12 @@ class BSPlotterProjected(BSPlotter):
                 f"The number of sub-figures {number_figs} might be too manny and the implementation might take a long "
                 f"time.\n A smaller number or a plot with selected symmetry lines (selected_branches) might be better."
             )
-        from pymatgen.util.plotting import pretty_plot
 
         band_linewidth = 0.5
         plt = pretty_plot(w_h_size[0], w_h_size[1])
-        (
-            proj_br_d,
-            dictio_d,
-            dictpa_d,
-            branches,
-        ) = self._get_projections_by_branches_patom_pmorb(dictio, dictpa, sum_atoms, sum_morbs, selected_branches)
+        proj_br_d, dictio_d, dictpa_d, branches = self._get_projections_by_branches_patom_pmorb(
+            dictio, dictpa, sum_atoms, sum_morbs, selected_branches
+        )
         data = self.bs_plot_data(zero_to_efermi)
         e_min = -4
         e_max = 4

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -9,7 +9,7 @@ import math
 import typing
 import warnings
 from collections import Counter
-from typing import TYPE_CHECKING, List, Literal, Sequence, cast
+from typing import TYPE_CHECKING, List, Literal, Sequence, cast, no_type_check
 
 import matplotlib.lines as mlines
 import matplotlib.pyplot as plt
@@ -1058,7 +1058,8 @@ class BSPlotterProjected(BSPlotter):
                 count += 1
         return plt
 
-    def get_elt_projected_plots(self, zero_to_efermi=True, ylim=None, vbm_cbm_marker=False):
+    @no_type_check
+    def get_elt_projected_plots(self, zero_to_efermi: bool = True, ylim=None, vbm_cbm_marker: bool = False) -> plt.Axes:
         """
         Method returning a plot composed of subplots along different elements.
 
@@ -1071,7 +1072,7 @@ class BSPlotterProjected(BSPlotter):
         band_linewidth = 1.0
         proj = self._get_projections_by_branches({e.symbol: ["s", "p", "d"] for e in self._bs.structure.elements})
         data = self.bs_plot_data(zero_to_efermi)
-        plt = pretty_plot(12, 8)
+        ax = pretty_plot(12, 8)
         e_min = -4
         e_max = 4
         if self._bs.is_metal():
@@ -1080,10 +1081,10 @@ class BSPlotterProjected(BSPlotter):
         count = 1
         for el in self._bs.structure.elements:
             plt.subplot(220 + count)
-            self._maketicks(plt)
+            self._maketicks(ax)
             for b in range(len(data["distances"])):
                 for i in range(self._nb_bands):
-                    plt.plot(
+                    ax.plot(
                         data["distances"][b],
                         data["energy"][str(Spin.up)][b][i],
                         "-",
@@ -1091,7 +1092,7 @@ class BSPlotterProjected(BSPlotter):
                         linewidth=band_linewidth,
                     )
                     if self._bs.is_spin_polarized:
-                        plt.plot(
+                        ax.plot(
                             data["distances"][b],
                             data["energy"][str(Spin.down)][b][i],
                             "--",
@@ -1103,7 +1104,7 @@ class BSPlotterProjected(BSPlotter):
                                 proj[b][str(Spin.down)][i][j][str(el)][o]
                                 for o in proj[b][str(Spin.down)][i][j][str(el)]
                             )
-                            plt.plot(
+                            ax.plot(
                                 data["distances"][b][j],
                                 data["energy"][str(Spin.down)][b][i][j],
                                 "bo",
@@ -1118,7 +1119,7 @@ class BSPlotterProjected(BSPlotter):
                         markerscale = sum(
                             proj[b][str(Spin.up)][i][j][str(el)][o] for o in proj[b][str(Spin.up)][i][j][str(el)]
                         )
-                        plt.plot(
+                        ax.plot(
                             data["distances"][b][j],
                             data["energy"][str(Spin.up)][b][i][j],
                             "o",
@@ -1128,24 +1129,24 @@ class BSPlotterProjected(BSPlotter):
             if ylim is None:
                 if self._bs.is_metal():
                     if zero_to_efermi:
-                        plt.ylim(e_min, e_max)
+                        ax.set_ylim(e_min, e_max)
                     else:
-                        plt.ylim(self._bs.efermi + e_min, self._bs.efermi + e_max)
+                        ax.set_ylim(self._bs.efermi + e_min, self._bs.efermi + e_max)
                 else:
                     if vbm_cbm_marker:
                         for cbm in data["cbm"]:
-                            plt.scatter(cbm[0], cbm[1], color="r", marker="o", s=100)
+                            ax.scatter(cbm[0], cbm[1], color="r", marker="o", s=100)
 
                         for vbm in data["vbm"]:
-                            plt.scatter(vbm[0], vbm[1], color="g", marker="o", s=100)
+                            ax.scatter(vbm[0], vbm[1], color="g", marker="o", s=100)
 
-                    plt.ylim(data["vbm"][0][1] + e_min, data["cbm"][0][1] + e_max)
+                    ax.set_ylim(data["vbm"][0][1] + e_min, data["cbm"][0][1] + e_max)
             else:
-                plt.ylim(ylim)
-            plt.title(str(el))
+                ax.set_ylim(ylim)
+            ax.set_title(str(el))
             count += 1
 
-        return plt
+        return ax
 
     def get_elt_projected_plots_color(self, zero_to_efermi=True, elt_ordered=None):
         """

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -1599,7 +1599,7 @@ class BSPlotterProjected(BSPlotter):
             )
 
         band_linewidth = 0.5
-        plt = pretty_plot(w_h_size[0], w_h_size[1])
+        ax = pretty_plot(w_h_size[0], w_h_size[1])
         proj_br_d, dictio_d, dictpa_d, branches = self._get_projections_by_branches_patom_pmorb(
             dictio, dictpa, sum_atoms, sum_morbs, selected_branches
         )
@@ -1633,12 +1633,12 @@ class BSPlotterProjected(BSPlotter):
                     else:
                         raise ValueError("The invalid 'num_column' is assigned. It should be an integer.")
 
-                    plt, shift = self._maketicks_selected(plt, branches)
+                    ax, shift = self._maketicks_selected(ax, branches)
                     br = -1
                     for b in branches:
                         br += 1
                         for i in range(self._nb_bands):
-                            plt.plot(
+                            ax.plot(
                                 [x - shift[br] for x in data["distances"][b]],
                                 [data["energy"][str(Spin.up)][b][i][j] for j in range(len(data["distances"][b]))],
                                 "b-",
@@ -1646,14 +1646,14 @@ class BSPlotterProjected(BSPlotter):
                             )
 
                             if self._bs.is_spin_polarized:
-                                plt.plot(
+                                ax.plot(
                                     [x - shift[br] for x in data["distances"][b]],
                                     [data["energy"][str(Spin.down)][b][i][j] for j in range(len(data["distances"][b]))],
                                     "r--",
                                     linewidth=band_linewidth,
                                 )
                                 for j in range(len(data["energy"][str(Spin.up)][b][i])):
-                                    plt.plot(
+                                    ax.plot(
                                         data["distances"][b][j] - shift[br],
                                         data["energy"][str(Spin.down)][b][i][j],
                                         "co",
@@ -1661,7 +1661,7 @@ class BSPlotterProjected(BSPlotter):
                                     )
 
                             for j in range(len(data["energy"][str(Spin.up)][b][i])):
-                                plt.plot(
+                                ax.plot(
                                     data["distances"][b][j] - shift[br],
                                     data["energy"][str(Spin.up)][b][i][j],
                                     "go",
@@ -1671,23 +1671,23 @@ class BSPlotterProjected(BSPlotter):
                     if ylim is None:
                         if self._bs.is_metal():
                             if zero_to_efermi:
-                                plt.ylim(e_min, e_max)
+                                ax.set_ylim(e_min, e_max)
                             else:
-                                plt.ylim(self._bs.efermi + e_min, self._bs._efermi + e_max)
+                                ax.set_ylim(self._bs.efermi + e_min, self._bs._efermi + e_max)
                         else:
                             if vbm_cbm_marker:
                                 for cbm in data["cbm"]:
-                                    plt.scatter(cbm[0], cbm[1], color="r", marker="o", s=100)
+                                    ax.scatter(cbm[0], cbm[1], color="r", marker="o", s=100)
 
                                 for vbm in data["vbm"]:
-                                    plt.scatter(vbm[0], vbm[1], color="g", marker="o", s=100)
+                                    ax.scatter(vbm[0], vbm[1], color="g", marker="o", s=100)
 
-                            plt.ylim(data["vbm"][0][1] + e_min, data["cbm"][0][1] + e_max)
+                            ax.set_ylim(data["vbm"][0][1] + e_min, data["cbm"][0][1] + e_max)
                     else:
-                        plt.ylim(ylim)
-                    plt.title(f"{elt} {numa} {o}")
+                        ax.set_ylim(ylim)
+                    ax.set_title(f"{elt} {numa} {o}")
 
-        return plt
+        return ax
 
     @classmethod
     def _Orbitals_SumOrbitals(cls, dictio, sum_morbs):
@@ -2836,12 +2836,12 @@ class BoltztrapPlotter:
         Returns:
             a matplotlib object
         """
-        plt = pretty_plot(9, 7)
-        for T in temps:
-            sbk_mass = self._bz.get_seebeck_eff_mass(output=output, temp=T, Lambda=0.5)
+        ax = pretty_plot(9, 7)
+        for temp in temps:
+            sbk_mass = self._bz.get_seebeck_eff_mass(output=output, temp=temp, Lambda=0.5)
             # remove noise inside the gap
-            start = self._bz.mu_doping["p"][T][0]
-            stop = self._bz.mu_doping["n"][T][0]
+            start = self._bz.mu_doping["p"][temp][0]
+            stop = self._bz.mu_doping["n"][temp][0]
             mu_steps_1 = []
             mu_steps_2 = []
             sbk_mass_1 = []
@@ -2854,28 +2854,28 @@ class BoltztrapPlotter:
                     mu_steps_2.append(mu)
                     sbk_mass_2.append(sbk_mass[i])
 
-            plt.plot(mu_steps_1, sbk_mass_1, label=str(T) + "K", linewidth=3.0)
-            plt.plot(mu_steps_2, sbk_mass_2, linewidth=3.0)
+            ax.plot(mu_steps_1, sbk_mass_1, label=f"{temp}K", linewidth=3)
+            ax.plot(mu_steps_2, sbk_mass_2, linewidth=3.0)
             if output == "average":
-                plt.gca().get_lines()[1].set_c(plt.gca().get_lines()[0].get_c())
+                ax.get_lines()[1].set_c(ax.get_lines()[0].get_c())
             elif output == "tensor":
-                plt.gca().get_lines()[3].set_c(plt.gca().get_lines()[0].get_c())
-                plt.gca().get_lines()[4].set_c(plt.gca().get_lines()[1].get_c())
-                plt.gca().get_lines()[5].set_c(plt.gca().get_lines()[2].get_c())
+                ax.get_lines()[3].set_c(ax.get_lines()[0].get_c())
+                ax.get_lines()[4].set_c(ax.get_lines()[1].get_c())
+                ax.get_lines()[5].set_c(ax.get_lines()[2].get_c())
 
-        plt.xlabel("E-E$_f$ (eV)", fontsize=30)
-        plt.ylabel("Seebeck effective mass", fontsize=30)
-        plt.xticks(fontsize=25)
-        plt.yticks(fontsize=25)
+        ax.set_xlabel("E-E$_f$ (eV)", fontsize=30)
+        ax.set_ylabel("Seebeck effective mass", fontsize=30)
+        ax.set_xticks(fontsize=25)
+        ax.set_yticks(fontsize=25)
         if output == "tensor":
-            plt.legend(
+            ax.legend(
                 [f"{dim}_{T}K" for T in temps for dim in ("x", "y", "z")],
                 fontsize=20,
             )
         elif output == "average":
-            plt.legend(fontsize=20)
+            ax.legend(fontsize=20)
         plt.tight_layout()
-        return plt
+        return ax
 
     def plot_complexity_factor_mu(self, temps=(300,), output="average", Lambda=0.5):
         """
@@ -2897,7 +2897,7 @@ class BoltztrapPlotter:
         Returns:
             a matplotlib object
         """
-        plt = pretty_plot(9, 7)
+        ax = pretty_plot(9, 7)
         for T in temps:
             cmplx_fact = self._bz.get_complexity_factor(output=output, temp=T, Lambda=Lambda)
             start = self._bz.mu_doping["p"][T][0]
@@ -2914,28 +2914,28 @@ class BoltztrapPlotter:
                     mu_steps_2.append(mu)
                     cmplx_fact_2.append(cmplx_fact[i])
 
-            plt.plot(mu_steps_1, cmplx_fact_1, label=str(T) + "K", linewidth=3.0)
-            plt.plot(mu_steps_2, cmplx_fact_2, linewidth=3.0)
+            ax.plot(mu_steps_1, cmplx_fact_1, label=str(T) + "K", linewidth=3.0)
+            ax.plot(mu_steps_2, cmplx_fact_2, linewidth=3.0)
             if output == "average":
-                plt.gca().get_lines()[1].set_c(plt.gca().get_lines()[0].get_c())
+                ax.gca().get_lines()[1].set_c(ax.gca().get_lines()[0].get_c())
             elif output == "tensor":
-                plt.gca().get_lines()[3].set_c(plt.gca().get_lines()[0].get_c())
-                plt.gca().get_lines()[4].set_c(plt.gca().get_lines()[1].get_c())
-                plt.gca().get_lines()[5].set_c(plt.gca().get_lines()[2].get_c())
+                ax.gca().get_lines()[3].set_c(ax.gca().get_lines()[0].get_c())
+                ax.gca().get_lines()[4].set_c(ax.gca().get_lines()[1].get_c())
+                ax.gca().get_lines()[5].set_c(ax.gca().get_lines()[2].get_c())
 
-        plt.xlabel("E-E$_f$ (eV)", fontsize=30)
-        plt.ylabel("Complexity Factor", fontsize=30)
-        plt.xticks(fontsize=25)
-        plt.yticks(fontsize=25)
+        ax.set_xlabel("E-E$_f$ (eV)", fontsize=30)
+        ax.ylabel("Complexity Factor", fontsize=30)
+        ax.set_xticks(fontsize=25)
+        ax.set_yticks(fontsize=25)
         if output == "tensor":
-            plt.legend(
+            ax.legend(
                 [f"{dim}_{T}K" for T in temps for dim in ("x", "y", "z")],
                 fontsize=20,
             )
         elif output == "average":
-            plt.legend(fontsize=20)
+            ax.legend(fontsize=20)
         plt.tight_layout()
-        return plt
+        return ax
 
     def plot_seebeck_mu(self, temp: float = 600, output: str = "eig", xlim: Sequence[float] | None = None):
         """
@@ -2950,24 +2950,24 @@ class BoltztrapPlotter:
         Returns:
             a matplotlib object
         """
-        plt = pretty_plot(9, 7)
+        ax = pretty_plot(9, 7)
         seebeck = self._bz.get_seebeck(output=output, doping_levels=False)[temp]
-        plt.plot(self._bz.mu_steps, seebeck, linewidth=3.0)
+        ax.plot(self._bz.mu_steps, seebeck, linewidth=3.0)
 
-        self._plot_bg_limits(plt)
-        self._plot_doping(plt, temp)
+        self._plot_bg_limits(ax)
+        self._plot_doping(ax, temp)
         if output == "eig":
-            plt.legend(["S$_1$", "S$_2$", "S$_3$"])
+            ax.legend(["S$_1$", "S$_2$", "S$_3$"])
         if xlim is None:
-            plt.xlim(-0.5, self._bz.gap + 0.5)
+            ax.set_xlim(-0.5, self._bz.gap + 0.5)
         else:
-            plt.xlim(xlim[0], xlim[1])
-        plt.ylabel("Seebeck \n coefficient  ($\\mu$V/K)", fontsize=30.0)
-        plt.xlabel("E-E$_f$ (eV)", fontsize=30)
-        plt.xticks(fontsize=25)
-        plt.yticks(fontsize=25)
+            ax.set_xlim(xlim[0], xlim[1])
+        ax.set_ylabel("Seebeck \n coefficient  ($\\mu$V/K)", fontsize=30.0)
+        ax.set_xlabel("E-E$_f$ (eV)", fontsize=30)
+        ax.set_xticks(fontsize=25)
+        ax.set_yticks(fontsize=25)
         plt.tight_layout()
-        return plt
+        return ax
 
     def plot_conductivity_mu(
         self,
@@ -2991,23 +2991,23 @@ class BoltztrapPlotter:
             a matplotlib object
         """
         cond = self._bz.get_conductivity(relaxation_time=relaxation_time, output=output, doping_levels=False)[temp]
-        plt = pretty_plot(9, 7)
-        plt.semilogy(self._bz.mu_steps, cond, linewidth=3.0)
-        self._plot_bg_limits(plt)
-        self._plot_doping(plt, temp)
+        ax = pretty_plot(9, 7)
+        ax.semilogy(self._bz.mu_steps, cond, linewidth=3.0)
+        self._plot_bg_limits(ax)
+        self._plot_doping(ax, temp)
         if output == "eig":
-            plt.legend(["$\\Sigma_1$", "$\\Sigma_2$", "$\\Sigma_3$"])
+            ax.legend(["$\\Sigma_1$", "$\\Sigma_2$", "$\\Sigma_3$"])
         if xlim is None:
-            plt.xlim(-0.5, self._bz.gap + 0.5)
+            ax.xlim(-0.5, self._bz.gap + 0.5)
         else:
-            plt.xlim(xlim)
-        plt.ylim([1e13 * relaxation_time, 1e20 * relaxation_time])
-        plt.ylabel("conductivity,\n $\\Sigma$ (1/($\\Omega$ m))", fontsize=30.0)
-        plt.xlabel("E-E$_f$ (eV)", fontsize=30.0)
-        plt.xticks(fontsize=25)
-        plt.yticks(fontsize=25)
+            ax.xlim(xlim)
+        ax.ylim([1e13 * relaxation_time, 1e20 * relaxation_time])
+        ax.ylabel("conductivity,\n $\\Sigma$ (1/($\\Omega$ m))", fontsize=30.0)
+        ax.set_xlabel("E-E$_f$ (eV)", fontsize=30.0)
+        ax.set_xticks(fontsize=25)
+        ax.set_yticks(fontsize=25)
         plt.tight_layout()
-        return plt
+        return ax
 
     def plot_power_factor_mu(
         self,
@@ -3030,23 +3030,23 @@ class BoltztrapPlotter:
         Returns:
             a matplotlib object
         """
-        plt = pretty_plot(9, 7)
+        ax = pretty_plot(9, 7)
         pf = self._bz.get_power_factor(relaxation_time=relaxation_time, output=output, doping_levels=False)[temp]
-        plt.semilogy(self._bz.mu_steps, pf, linewidth=3.0)
-        self._plot_bg_limits(plt)
-        self._plot_doping(plt, temp)
+        ax.semilogy(self._bz.mu_steps, pf, linewidth=3.0)
+        self._plot_bg_limits(ax)
+        self._plot_doping(ax, temp)
         if output == "eig":
-            plt.legend(["PF$_1$", "PF$_2$", "PF$_3$"])
+            ax.legend(["PF$_1$", "PF$_2$", "PF$_3$"])
         if xlim is None:
-            plt.xlim(-0.5, self._bz.gap + 0.5)
+            ax.set_xlim(-0.5, self._bz.gap + 0.5)
         else:
-            plt.xlim(xlim)
-        plt.ylabel("Power factor, ($\\mu$W/(mK$^2$))", fontsize=30.0)
-        plt.xlabel("E-E$_f$ (eV)", fontsize=30.0)
-        plt.xticks(fontsize=25)
-        plt.yticks(fontsize=25)
+            ax.set_xlim(xlim)
+        ax.set_ylabel("Power factor, ($\\mu$W/(mK$^2$))", fontsize=30.0)
+        ax.set_xlabel("E-E$_f$ (eV)", fontsize=30.0)
+        ax.set_xticks(fontsize=25)
+        ax.set_yticks(fontsize=25)
         plt.tight_layout()
-        return plt
+        return ax
 
     def plot_zt_mu(
         self,
@@ -3068,23 +3068,23 @@ class BoltztrapPlotter:
         Returns:
             matplotlib.pyplot module
         """
-        plt = pretty_plot(9, 7)
+        ax = pretty_plot(9, 7)
         zt = self._bz.get_zt(relaxation_time=relaxation_time, output=output, doping_levels=False)[temp]
-        plt.plot(self._bz.mu_steps, zt, linewidth=3.0)
-        self._plot_bg_limits(plt)
-        self._plot_doping(plt, temp)
+        ax.plot(self._bz.mu_steps, zt, linewidth=3.0)
+        self._plot_bg_limits(ax)
+        self._plot_doping(ax, temp)
         if output == "eig":
-            plt.legend(["ZT$_1$", "ZT$_2$", "ZT$_3$"])
+            ax.legend(["ZT$_1$", "ZT$_2$", "ZT$_3$"])
         if xlim is None:
-            plt.xlim(-0.5, self._bz.gap + 0.5)
+            ax.xlim(-0.5, self._bz.gap + 0.5)
         else:
-            plt.xlim(xlim)
-        plt.ylabel("ZT", fontsize=30.0)
-        plt.xlabel("E-E$_f$ (eV)", fontsize=30.0)
-        plt.xticks(fontsize=25)
-        plt.yticks(fontsize=25)
+            ax.xlim(xlim)
+        ax.ylabel("ZT", fontsize=30.0)
+        ax.set_xlabel("E-E$_f$ (eV)", fontsize=30.0)
+        ax.set_xticks(fontsize=25)
+        ax.set_yticks(fontsize=25)
         plt.tight_layout()
-        return plt
+        return ax
 
     def plot_seebeck_temp(self, doping="all", output="average"):
         """
@@ -3105,7 +3105,7 @@ class BoltztrapPlotter:
         elif output == "eigs":
             sbk = self._bz.get_seebeck(output="eigs")
 
-        plt = pretty_plot(22, 14)
+        ax = pretty_plot(22, 14)
         tlist = sorted(sbk["n"])
         doping = self._bz.doping["n"] if doping == "all" else doping
         for i, dt in enumerate(["n", "p"]):
@@ -3116,29 +3116,29 @@ class BoltztrapPlotter:
                 for temp in tlist:
                     sbk_temp.append(sbk[dt][temp][d])
                 if output == "average":
-                    plt.plot(tlist, sbk_temp, marker="s", label=str(dop) + " $cm^{-3}$")
+                    ax.plot(tlist, sbk_temp, marker="s", label=str(dop) + " $cm^{-3}$")
                 elif output == "eigs":
                     for xyz in range(3):
-                        plt.plot(
+                        ax.plot(
                             tlist,
                             list(zip(*sbk_temp))[xyz],
                             marker="s",
                             label=f"{xyz} {dop} $cm^{{-3}}$",
                         )
-            plt.title(dt + "-type", fontsize=20)
+            ax.set_title(dt + "-type", fontsize=20)
             if i == 0:
-                plt.ylabel("Seebeck \n coefficient  ($\\mu$V/K)", fontsize=30.0)
-            plt.xlabel("Temperature (K)", fontsize=30.0)
+                ax.set_ylabel("Seebeck \n coefficient  ($\\mu$V/K)", fontsize=30.0)
+            ax.set_xlabel("Temperature (K)", fontsize=30.0)
 
             p = "lower right" if i == 0 else "best"
-            plt.legend(loc=p, fontsize=15)
-            plt.grid()
-            plt.xticks(fontsize=25)
-            plt.yticks(fontsize=25)
+            ax.legend(loc=p, fontsize=15)
+            ax.grid()
+            ax.set_xticks(fontsize=25)
+            ax.set_yticks(fontsize=25)
 
         plt.tight_layout()
 
-        return plt
+        return ax
 
     def plot_conductivity_temp(self, doping="all", output="average", relaxation_time=1e-14):
         """
@@ -3159,7 +3159,7 @@ class BoltztrapPlotter:
         elif output == "eigs":
             cond = self._bz.get_conductivity(relaxation_time=relaxation_time, output="eigs")
 
-        plt = pretty_plot(22, 14)
+        ax = pretty_plot(22, 14)
         tlist = sorted(cond["n"])
         doping = self._bz.doping["n"] if doping == "all" else doping
         for i, dt in enumerate(["n", "p"]):
@@ -3170,30 +3170,30 @@ class BoltztrapPlotter:
                 for temp in tlist:
                     cond_temp.append(cond[dt][temp][d])
                 if output == "average":
-                    plt.plot(tlist, cond_temp, marker="s", label=str(dop) + " $cm^{-3}$")
+                    ax.plot(tlist, cond_temp, marker="s", label=str(dop) + " $cm^{-3}$")
                 elif output == "eigs":
                     for xyz in range(3):
-                        plt.plot(
+                        ax.plot(
                             tlist,
                             list(zip(*cond_temp))[xyz],
                             marker="s",
                             label=f"{xyz} {dop} $cm^{{-3}}$",
                         )
-            plt.title(dt + "-type", fontsize=20)
+            ax.set_title(dt + "-type", fontsize=20)
             if i == 0:
-                plt.ylabel("conductivity $\\sigma$ (1/($\\Omega$ m))", fontsize=30.0)
-            plt.xlabel("Temperature (K)", fontsize=30.0)
+                ax.ylabel("conductivity $\\sigma$ (1/($\\Omega$ m))", fontsize=30.0)
+            ax.set_xlabel("Temperature (K)", fontsize=30.0)
 
             p = "best"  # 'lower right' if i == 0 else ''
-            plt.legend(loc=p, fontsize=15)
-            plt.grid()
-            plt.xticks(fontsize=25)
-            plt.yticks(fontsize=25)
-            plt.ticklabel_format(style="sci", axis="y", scilimits=(0, 0))
+            ax.legend(loc=p, fontsize=15)
+            ax.grid()
+            ax.set_xticks(fontsize=25)
+            ax.set_yticks(fontsize=25)
+            ax.ticklabel_format(style="sci", axis="y", scilimits=(0, 0))
 
         plt.tight_layout()
 
-        return plt
+        return ax
 
     def plot_power_factor_temp(self, doping="all", output="average", relaxation_time=1e-14):
         """
@@ -3214,7 +3214,7 @@ class BoltztrapPlotter:
         elif output == "eigs":
             pf = self._bz.get_power_factor(relaxation_time=relaxation_time, output="eigs")
 
-        plt = pretty_plot(22, 14)
+        ax = pretty_plot(22, 14)
         tlist = sorted(pf["n"])
         doping = self._bz.doping["n"] if doping == "all" else doping
         for i, dt in enumerate(["n", "p"]):
@@ -3225,29 +3225,29 @@ class BoltztrapPlotter:
                 for temp in tlist:
                     pf_temp.append(pf[dt][temp][d])
                 if output == "average":
-                    plt.plot(tlist, pf_temp, marker="s", label=str(dop) + " $cm^{-3}$")
+                    ax.plot(tlist, pf_temp, marker="s", label=str(dop) + " $cm^{-3}$")
                 elif output == "eigs":
                     for xyz in range(3):
-                        plt.plot(
+                        ax.plot(
                             tlist,
                             list(zip(*pf_temp))[xyz],
                             marker="s",
                             label=f"{xyz} {dop} $cm^{{-3}}$",
                         )
-            plt.title(dt + "-type", fontsize=20)
+            ax.set_title(dt + "-type", fontsize=20)
             if i == 0:
-                plt.ylabel("Power Factor ($\\mu$W/(mK$^2$))", fontsize=30.0)
-            plt.xlabel("Temperature (K)", fontsize=30.0)
+                ax.ylabel("Power Factor ($\\mu$W/(mK$^2$))", fontsize=30.0)
+            ax.set_xlabel("Temperature (K)", fontsize=30.0)
 
             p = "best"  # 'lower right' if i == 0 else ''
-            plt.legend(loc=p, fontsize=15)
-            plt.grid()
-            plt.xticks(fontsize=25)
-            plt.yticks(fontsize=25)
-            plt.ticklabel_format(style="sci", axis="y", scilimits=(0, 0))
+            ax.legend(loc=p, fontsize=15)
+            ax.grid()
+            ax.set_xticks(fontsize=25)
+            ax.set_yticks(fontsize=25)
+            ax.ticklabel_format(style="sci", axis="y", scilimits=(0, 0))
 
         plt.tight_layout()
-        return plt
+        return ax
 
     def plot_zt_temp(self, doping="all", output: Literal["average", "eigs"] = "average", relaxation_time=1e-14):
         """
@@ -3270,7 +3270,7 @@ class BoltztrapPlotter:
             raise ValueError(f"{output=} must be 'average' or 'eigs'")
         zt = self._bz.get_zt(relaxation_time=relaxation_time, output=output)
 
-        plt = pretty_plot(22, 14)
+        ax = pretty_plot(22, 14)
         tlist = sorted(zt["n"])
         doping = self._bz.doping["n"] if doping == "all" else doping
         for i, dt in enumerate(["n", "p"]):
@@ -3281,28 +3281,28 @@ class BoltztrapPlotter:
                 for temp in tlist:
                     zt_temp.append(zt[dt][temp][d])
                 if output == "average":
-                    plt.plot(tlist, zt_temp, marker="s", label=str(dop) + " $cm^{-3}$")
+                    ax.plot(tlist, zt_temp, marker="s", label=str(dop) + " $cm^{-3}$")
                 elif output == "eigs":
                     for xyz in range(3):
-                        plt.plot(
+                        ax.plot(
                             tlist,
                             list(zip(*zt_temp))[xyz],
                             marker="s",
                             label=f"{xyz} {dop} $cm^{{-3}}$",
                         )
-            plt.title(dt + "-type", fontsize=20)
+            ax.set_title(dt + "-type", fontsize=20)
             if i == 0:
-                plt.ylabel("zT", fontsize=30.0)
-            plt.xlabel("Temperature (K)", fontsize=30.0)
+                ax.ylabel("zT", fontsize=30.0)
+            ax.set_xlabel("Temperature (K)", fontsize=30.0)
 
             p = "best"  # 'lower right' if i == 0 else ''
-            plt.legend(loc=p, fontsize=15)
-            plt.grid()
-            plt.xticks(fontsize=25)
-            plt.yticks(fontsize=25)
+            ax.legend(loc=p, fontsize=15)
+            ax.grid()
+            ax.set_xticks(fontsize=25)
+            ax.set_yticks(fontsize=25)
 
         plt.tight_layout()
-        return plt
+        return ax
 
     def plot_eff_mass_temp(self, doping="all", output: Literal["average", "eigs"] = "average"):
         """
@@ -3368,36 +3368,31 @@ class BoltztrapPlotter:
             sbk = self._bz.get_seebeck(output="eigs")
 
         tlist = sorted(sbk["n"]) if temps == "all" else temps
-        plt = pretty_plot(22, 14)
+        ax = pretty_plot(22, 14)
         for i, dt in enumerate(["n", "p"]):
             plt.subplot(121 + i)
             for temp in tlist:
                 if output == "eigs":
                     for xyz in range(3):
-                        plt.semilogx(
+                        ax.semilogx(
                             self._bz.doping[dt], list(zip(*sbk[dt][temp]))[xyz], marker="s", label=f"{xyz} {temp} K"
                         )
                 elif output == "average":
-                    plt.semilogx(
-                        self._bz.doping[dt],
-                        sbk[dt][temp],
-                        marker="s",
-                        label=str(temp) + " K",
-                    )
-            plt.title(dt + "-type", fontsize=20)
+                    ax.semilogx(self._bz.doping[dt], sbk[dt][temp], marker="s", label=f"{temp} K")
+            ax.set_title(dt + "-type", fontsize=20)
             if i == 0:
-                plt.ylabel("Seebeck coefficient ($\\mu$V/K)", fontsize=30.0)
-            plt.xlabel("Doping concentration (cm$^{-3}$)", fontsize=30.0)
+                ax.set_ylabel("Seebeck coefficient ($\\mu$V/K)", fontsize=30.0)
+            ax.set_xlabel("Doping concentration (cm$^{-3}$)", fontsize=30.0)
 
             p = "lower right" if i == 0 else "best"
-            plt.legend(loc=p, fontsize=15)
-            plt.grid()
-            plt.xticks(fontsize=25)
-            plt.yticks(fontsize=25)
+            ax.legend(loc=p, fontsize=15)
+            ax.grid()
+            ax.set_xticks(fontsize=25)
+            ax.set_yticks(fontsize=25)
 
         plt.tight_layout()
 
-        return plt
+        return ax
 
     def plot_conductivity_dop(self, temps="all", output="average", relaxation_time=1e-14):
         """
@@ -3420,35 +3415,35 @@ class BoltztrapPlotter:
             cond = self._bz.get_conductivity(relaxation_time=relaxation_time, output="eigs")
 
         tlist = sorted(cond["n"]) if temps == "all" else temps
-        plt = pretty_plot(22, 14)
+        ax = pretty_plot(22, 14)
         for i, dt in enumerate(["n", "p"]):
             plt.subplot(121 + i)
             for temp in tlist:
                 if output == "eigs":
                     for xyz in range(3):
-                        plt.semilogx(
+                        ax.semilogx(
                             self._bz.doping[dt], list(zip(*cond[dt][temp]))[xyz], marker="s", label=f"{xyz} {temp} K"
                         )
                 elif output == "average":
-                    plt.semilogx(
+                    ax.semilogx(
                         self._bz.doping[dt],
                         cond[dt][temp],
                         marker="s",
-                        label=str(temp) + " K",
+                        label=f"{temp} K",
                     )
-            plt.title(dt + "-type", fontsize=20)
+            ax.set_title(dt + "-type", fontsize=20)
             if i == 0:
-                plt.ylabel("conductivity $\\sigma$ (1/($\\Omega$ m))", fontsize=30.0)
-            plt.xlabel("Doping concentration ($cm^{-3}$)", fontsize=30.0)
-            plt.ticklabel_format(style="sci", axis="y", scilimits=(0, 0))
-            plt.legend(fontsize=15)
-            plt.grid()
-            plt.xticks(fontsize=25)
-            plt.yticks(fontsize=25)
+                ax.ylabel("conductivity $\\sigma$ (1/($\\Omega$ m))", fontsize=30.0)
+            ax.set_xlabel("Doping concentration ($cm^{-3}$)", fontsize=30.0)
+            ax.ticklabel_format(style="sci", axis="y", scilimits=(0, 0))
+            ax.legend(fontsize=15)
+            ax.grid()
+            ax.set_xticks(fontsize=25)
+            ax.set_yticks(fontsize=25)
 
         plt.tight_layout()
 
-        return plt
+        return ax
 
     def plot_power_factor_dop(self, temps="all", output="average", relaxation_time=1e-14):
         """
@@ -3470,31 +3465,31 @@ class BoltztrapPlotter:
             pf = self._bz.get_power_factor(relaxation_time=relaxation_time, output="eigs")
 
         tlist = sorted(pf["n"]) if temps == "all" else temps
-        plt = pretty_plot(22, 14)
+        ax = pretty_plot(22, 14)
         for i, dt in enumerate(["n", "p"]):
             plt.subplot(121 + i)
             for temp in tlist:
                 if output == "eigs":
                     for xyz in range(3):
-                        plt.semilogx(
+                        ax.semilogx(
                             self._bz.doping[dt], list(zip(*pf[dt][temp]))[xyz], marker="s", label=f"{xyz} {temp} K"
                         )
                 elif output == "average":
-                    plt.semilogx(self._bz.doping[dt], pf[dt][temp], marker="s", label=f"{temp} K")
-            plt.title(dt + "-type", fontsize=20)
+                    ax.semilogx(self._bz.doping[dt], pf[dt][temp], marker="s", label=f"{temp} K")
+            ax.set_title(dt + "-type", fontsize=20)
             if i == 0:
-                plt.ylabel("Power Factor  ($\\mu$W/(mK$^2$))", fontsize=30.0)
-            plt.xlabel("Doping concentration ($cm^{-3}$)", fontsize=30.0)
-            plt.ticklabel_format(style="sci", axis="y", scilimits=(0, 0))
+                ax.ylabel("Power Factor  ($\\mu$W/(mK$^2$))", fontsize=30.0)
+            ax.set_xlabel("Doping concentration ($cm^{-3}$)", fontsize=30.0)
+            ax.ticklabel_format(style="sci", axis="y", scilimits=(0, 0))
             p = "best"  # 'lower right' if i == 0 else ''
-            plt.legend(loc=p, fontsize=15)
-            plt.grid()
-            plt.xticks(fontsize=25)
-            plt.yticks(fontsize=25)
+            ax.legend(loc=p, fontsize=15)
+            ax.grid()
+            ax.set_xticks(fontsize=25)
+            ax.set_yticks(fontsize=25)
 
         plt.tight_layout()
 
-        return plt
+        return ax
 
     def plot_zt_dop(self, temps="all", output="average", relaxation_time=1e-14):
         """
@@ -3517,36 +3512,36 @@ class BoltztrapPlotter:
             zt = self._bz.get_zt(relaxation_time=relaxation_time, output="eigs")
 
         tlist = sorted(zt["n"]) if temps == "all" else temps
-        plt = pretty_plot(22, 14)
+        ax = pretty_plot(22, 14)
         for i, dt in enumerate(["n", "p"]):
             plt.subplot(121 + i)
             for temp in tlist:
                 if output == "eigs":
                     for xyz in range(3):
-                        plt.semilogx(
+                        ax.semilogx(
                             self._bz.doping[dt], list(zip(*zt[dt][temp]))[xyz], marker="s", label=f"{xyz} {temp} K"
                         )
                 elif output == "average":
-                    plt.semilogx(
+                    ax.semilogx(
                         self._bz.doping[dt],
                         zt[dt][temp],
                         marker="s",
-                        label=str(temp) + " K",
+                        label=f"{temp} K",
                     )
-            plt.title(dt + "-type", fontsize=20)
+            ax.set_title(dt + "-type", fontsize=20)
             if i == 0:
-                plt.ylabel("zT", fontsize=30.0)
-            plt.xlabel("Doping concentration ($cm^{-3}$)", fontsize=30.0)
+                ax.ylabel("zT", fontsize=30.0)
+            ax.set_xlabel("Doping concentration ($cm^{-3}$)", fontsize=30.0)
 
             p = "lower right" if i == 0 else "best"
-            plt.legend(loc=p, fontsize=15)
-            plt.grid()
-            plt.xticks(fontsize=25)
-            plt.yticks(fontsize=25)
+            ax.legend(loc=p, fontsize=15)
+            ax.grid()
+            ax.set_xticks(fontsize=25)
+            ax.set_yticks(fontsize=25)
 
         plt.tight_layout()
 
-        return plt
+        return ax
 
     def plot_eff_mass_dop(self, temps="all", output="average"):
         """
@@ -3569,36 +3564,36 @@ class BoltztrapPlotter:
             em = self._bz.get_average_eff_mass(output="eigs")
 
         tlist = sorted(em["n"]) if temps == "all" else temps
-        plt = pretty_plot(22, 14)
+        ax = pretty_plot(22, 14)
         for i, dt in enumerate(["n", "p"]):
             plt.subplot(121 + i)
             for temp in tlist:
                 if output == "eigs":
                     for xyz in range(3):
-                        plt.semilogx(
+                        ax.semilogx(
                             self._bz.doping[dt], list(zip(*em[dt][temp]))[xyz], marker="s", label=f"{xyz} {temp} K"
                         )
                 elif output == "average":
-                    plt.semilogx(
+                    ax.semilogx(
                         self._bz.doping[dt],
                         em[dt][temp],
                         marker="s",
-                        label=str(temp) + " K",
+                        label=f"{temp} K",
                     )
-            plt.title(dt + "-type", fontsize=20)
+            ax.set_title(dt + "-type", fontsize=20)
             if i == 0:
-                plt.ylabel("Effective mass (m$_e$)", fontsize=30.0)
-            plt.xlabel("Doping concentration ($cm^{-3}$)", fontsize=30.0)
+                ax.ylabel("Effective mass (m$_e$)", fontsize=30.0)
+            ax.set_xlabel("Doping concentration ($cm^{-3}$)", fontsize=30.0)
 
             p = "lower right" if i == 0 else "best"
-            plt.legend(loc=p, fontsize=15)
-            plt.grid()
-            plt.xticks(fontsize=25)
-            plt.yticks(fontsize=25)
+            ax.legend(loc=p, fontsize=15)
+            ax.grid()
+            ax.set_xticks(fontsize=25)
+            ax.set_yticks(fontsize=25)
 
         plt.tight_layout()
 
-        return plt
+        return ax
 
     def plot_dos(self, sigma=0.05):
         """Plot dos.
@@ -3623,19 +3618,19 @@ class BoltztrapPlotter:
         Returns:
             a matplotlib object
         """
-        plt = pretty_plot(9, 7)
+        ax = pretty_plot(9, 7)
         carriers = [abs(c / (self._bz.vol * 1e-24)) for c in self._bz._carrier_conc[temp]]
-        plt.semilogy(self._bz.mu_steps, carriers, linewidth=3.0, color="r")
-        self._plot_bg_limits(plt)
-        self._plot_doping(plt, temp)
-        plt.xlim(-0.5, self._bz.gap + 0.5)
-        plt.ylim(1e14, 1e22)
-        plt.ylabel("carrier concentration (cm-3)", fontsize=30.0)
-        plt.xlabel("E-E$_f$ (eV)", fontsize=30)
-        plt.xticks(fontsize=25)
-        plt.yticks(fontsize=25)
+        ax.semilogy(self._bz.mu_steps, carriers, linewidth=3.0, color="r")
+        self._plot_bg_limits(ax)
+        self._plot_doping(ax, temp)
+        ax.xlim(-0.5, self._bz.gap + 0.5)
+        ax.ylim(1e14, 1e22)
+        ax.ylabel("carrier concentration (cm-3)", fontsize=30.0)
+        ax.set_xlabel("E-E$_f$ (eV)", fontsize=30)
+        ax.set_xticks(fontsize=25)
+        ax.set_yticks(fontsize=25)
         plt.tight_layout()
-        return plt
+        return ax
 
     def plot_hall_carriers(self, temp=300):
         """
@@ -3647,19 +3642,19 @@ class BoltztrapPlotter:
         Returns:
             a matplotlib object
         """
-        plt = pretty_plot(9, 7)
+        ax = pretty_plot(9, 7)
         hall_carriers = [abs(i) for i in self._bz.get_hall_carrier_concentration()[temp]]
-        plt.semilogy(self._bz.mu_steps, hall_carriers, linewidth=3.0, color="r")
-        self._plot_bg_limits(plt)
-        self._plot_doping(plt, temp)
-        plt.xlim(-0.5, self._bz.gap + 0.5)
-        plt.ylim(1e14, 1e22)
-        plt.ylabel("Hall carrier concentration (cm-3)", fontsize=30.0)
-        plt.xlabel("E-E$_f$ (eV)", fontsize=30)
-        plt.xticks(fontsize=25)
-        plt.yticks(fontsize=25)
+        ax.semilogy(self._bz.mu_steps, hall_carriers, linewidth=3.0, color="r")
+        self._plot_bg_limits(ax)
+        self._plot_doping(ax, temp)
+        ax.xlim(-0.5, self._bz.gap + 0.5)
+        ax.ylim(1e14, 1e22)
+        ax.ylabel("Hall carrier concentration (cm-3)", fontsize=30.0)
+        ax.set_xlabel("E-E$_f$ (eV)", fontsize=30)
+        ax.set_xticks(fontsize=25)
+        ax.set_yticks(fontsize=25)
         plt.tight_layout()
-        return plt
+        return ax
 
 
 class CohpPlotter:

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -1067,7 +1067,7 @@ class BSPlotterProjected(BSPlotter):
         proj = self._get_projections_by_branches({e.symbol: ["s", "p", "d"] for e in self._bs.structure.elements})
         data = self.bs_plot_data(zero_to_efermi)
         _fig, axs = plt.subplots(2, 2, figsize=(12, 8))  # Adjust the layout as needed
-        ax = pretty_plot(12, 8, ax=axs[0])
+        ax = pretty_plot(12, 8, ax=axs[0][0])
         e_min, e_max = -4, 4
         if self._bs.is_metal():
             e_min, e_max = -10, 10
@@ -2250,7 +2250,9 @@ class BSDOSPlotter:
         self.rgb_legend = rgb_legend
         self.fig_size = fig_size
 
-    def get_plot(self, bs: BandStructureSymmLine, dos: Dos | CompleteDos | None = None) -> tuple[plt.Axes, plt.Axes]:
+    def get_plot(
+        self, bs: BandStructureSymmLine, dos: Dos | CompleteDos | None = None
+    ) -> plt.Axes | tuple[plt.Axes, plt.Axes]:
         """
         Get a matplotlib plot object.
 
@@ -2261,7 +2263,7 @@ class BSDOSPlotter:
                 CompleteDos) for projected plots.
 
         Returns:
-            tuple[plt.Axes, plt.Axes]: matplotlib axes for the band structure and DOS, resp.
+            plt.Axes | tuple[plt.Axes, plt.Axes]: matplotlib axes for the band structure and DOS, resp.
         """
         import matplotlib.lines as mlines
         import matplotlib.pyplot as plt
@@ -2518,7 +2520,9 @@ class BSDOSPlotter:
             )
 
         plt.subplots_adjust(wspace=0.1)
-        return bs_ax, dos_ax
+        if dos:
+            return bs_ax, dos_ax
+        return bs_ax
 
     @staticmethod
     def _rgbline(ax, k, e, red, green, blue, alpha=1, linestyles="solid"):

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -2107,7 +2107,7 @@ class BSPlotterProjected(BSPlotter):
 
         return dictio_d, dictpa_d
 
-    def _maketicks_selected(self, plt, branches):
+    def _maketicks_selected(self, ax: plt.Axes, branches: list[int]) -> tuple[plt.Axes, list[float]]:
         """Utility private method to add ticks to a band structure with selected branches."""
         ticks = self.get_ticks()
         distance = []
@@ -2174,8 +2174,8 @@ class BSPlotterProjected(BSPlotter):
                 uniq_l.append(t[1])
 
         logger.debug(f"Unique labels are {list(zip(uniq_d, uniq_l))}")
-        plt.gca().set_xticks(uniq_d)
-        plt.gca().set_xticklabels(uniq_l)
+        ax.set_xticks(uniq_d)
+        ax.set_xticklabels(uniq_l)
 
         for i in range(len(n_ticks["label"])):
             if n_ticks["label"][i] is not None:
@@ -2185,10 +2185,10 @@ class BSPlotterProjected(BSPlotter):
                         logger.debug(f"already print label... skipping label {n_ticks['label'][i]}")
                     else:
                         logger.debug(f"Adding a line at {n_ticks['distance'][i]} for label {n_ticks['label'][i]}")
-                        plt.axvline(n_ticks["distance"][i], color="k")
+                        ax.axvline(n_ticks["distance"][i], color="k")
                 else:
                     logger.debug(f"Adding a line at {n_ticks['distance'][i]} for label {n_ticks['label'][i]}")
-                    plt.axvline(n_ticks["distance"][i], color="k")
+                    ax.axvline(n_ticks["distance"][i], color="k")
 
         shift = []
         br = -1
@@ -2196,7 +2196,7 @@ class BSPlotterProjected(BSPlotter):
             br += 1
             shift.append(distance[branch] - rf_distance[br])
 
-        return plt, shift
+        return ax, shift
 
 
 class BSDOSPlotter:

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -1066,7 +1066,8 @@ class BSPlotterProjected(BSPlotter):
         band_linewidth = 1.0
         proj = self._get_projections_by_branches({e.symbol: ["s", "p", "d"] for e in self._bs.structure.elements})
         data = self.bs_plot_data(zero_to_efermi)
-        ax = pretty_plot(12, 8)
+        _fig, axs = plt.subplots(2, 2, figsize=(12, 8))  # Adjust the layout as needed
+        ax = pretty_plot(12, 8, ax=axs[0])
         e_min, e_max = -4, 4
         if self._bs.is_metal():
             e_min, e_max = -10, 10
@@ -2249,7 +2250,7 @@ class BSDOSPlotter:
         self.rgb_legend = rgb_legend
         self.fig_size = fig_size
 
-    def get_plot(self, bs: BandStructureSymmLine, dos: Dos | CompleteDos | None = None):
+    def get_plot(self, bs: BandStructureSymmLine, dos: Dos | CompleteDos | None = None) -> tuple[plt.Axes, plt.Axes]:
         """
         Get a matplotlib plot object.
 
@@ -2518,7 +2519,7 @@ class BSDOSPlotter:
             )
 
         plt.subplots_adjust(wspace=0.1)
-        return plt
+        return bs_ax, dos_ax
 
     @staticmethod
     def _rgbline(ax, k, e, red, green, blue, alpha=1, linestyles="solid"):

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -2924,7 +2924,7 @@ class BoltztrapPlotter:
                 ax.gca().get_lines()[5].set_c(ax.gca().get_lines()[2].get_c())
 
         ax.set_xlabel("E-E$_f$ (eV)", fontsize=30)
-        ax.ylabel("Complexity Factor", fontsize=30)
+        ax.set_ylabel("Complexity Factor", fontsize=30)
         ax.set_xticks(fontsize=25)
         ax.set_yticks(fontsize=25)
         if output == "tensor":
@@ -2998,11 +2998,11 @@ class BoltztrapPlotter:
         if output == "eig":
             ax.legend(["$\\Sigma_1$", "$\\Sigma_2$", "$\\Sigma_3$"])
         if xlim is None:
-            ax.xlim(-0.5, self._bz.gap + 0.5)
+            ax.set_xlim(-0.5, self._bz.gap + 0.5)
         else:
-            ax.xlim(xlim)
-        ax.ylim([1e13 * relaxation_time, 1e20 * relaxation_time])
-        ax.ylabel("conductivity,\n $\\Sigma$ (1/($\\Omega$ m))", fontsize=30.0)
+            ax.set_xlim(xlim)
+        ax.set_ylim([1e13 * relaxation_time, 1e20 * relaxation_time])
+        ax.set_ylabel("conductivity,\n $\\Sigma$ (1/($\\Omega$ m))", fontsize=30.0)
         ax.set_xlabel("E-E$_f$ (eV)", fontsize=30.0)
         ax.set_xticks(fontsize=25)
         ax.set_yticks(fontsize=25)
@@ -3076,10 +3076,10 @@ class BoltztrapPlotter:
         if output == "eig":
             ax.legend(["ZT$_1$", "ZT$_2$", "ZT$_3$"])
         if xlim is None:
-            ax.xlim(-0.5, self._bz.gap + 0.5)
+            ax.set_xlim(-0.5, self._bz.gap + 0.5)
         else:
-            ax.xlim(xlim)
-        ax.ylabel("ZT", fontsize=30.0)
+            ax.set_xlim(xlim)
+        ax.set_ylabel("ZT", fontsize=30.0)
         ax.set_xlabel("E-E$_f$ (eV)", fontsize=30.0)
         ax.set_xticks(fontsize=25)
         ax.set_yticks(fontsize=25)
@@ -3181,7 +3181,7 @@ class BoltztrapPlotter:
                         )
             ax.set_title(dt + "-type", fontsize=20)
             if i == 0:
-                ax.ylabel("conductivity $\\sigma$ (1/($\\Omega$ m))", fontsize=30.0)
+                ax.set_ylabel("conductivity $\\sigma$ (1/($\\Omega$ m))", fontsize=30.0)
             ax.set_xlabel("Temperature (K)", fontsize=30.0)
 
             p = "best"  # 'lower right' if i == 0 else ''
@@ -3236,7 +3236,7 @@ class BoltztrapPlotter:
                         )
             ax.set_title(dt + "-type", fontsize=20)
             if i == 0:
-                ax.ylabel("Power Factor ($\\mu$W/(mK$^2$))", fontsize=30.0)
+                ax.set_ylabel("Power Factor ($\\mu$W/(mK$^2$))", fontsize=30.0)
             ax.set_xlabel("Temperature (K)", fontsize=30.0)
 
             p = "best"  # 'lower right' if i == 0 else ''
@@ -3292,7 +3292,7 @@ class BoltztrapPlotter:
                         )
             ax.set_title(dt + "-type", fontsize=20)
             if i == 0:
-                ax.ylabel("zT", fontsize=30.0)
+                ax.set_ylabel("zT", fontsize=30.0)
             ax.set_xlabel("Temperature (K)", fontsize=30.0)
 
             p = "best"  # 'lower right' if i == 0 else ''
@@ -3433,7 +3433,7 @@ class BoltztrapPlotter:
                     )
             ax.set_title(dt + "-type", fontsize=20)
             if i == 0:
-                ax.ylabel("conductivity $\\sigma$ (1/($\\Omega$ m))", fontsize=30.0)
+                ax.set_ylabel("conductivity $\\sigma$ (1/($\\Omega$ m))", fontsize=30.0)
             ax.set_xlabel("Doping concentration ($cm^{-3}$)", fontsize=30.0)
             ax.ticklabel_format(style="sci", axis="y", scilimits=(0, 0))
             ax.legend(fontsize=15)
@@ -3478,7 +3478,7 @@ class BoltztrapPlotter:
                     ax.semilogx(self._bz.doping[dt], pf[dt][temp], marker="s", label=f"{temp} K")
             ax.set_title(dt + "-type", fontsize=20)
             if i == 0:
-                ax.ylabel("Power Factor  ($\\mu$W/(mK$^2$))", fontsize=30.0)
+                ax.set_ylabel("Power Factor  ($\\mu$W/(mK$^2$))", fontsize=30.0)
             ax.set_xlabel("Doping concentration ($cm^{-3}$)", fontsize=30.0)
             ax.ticklabel_format(style="sci", axis="y", scilimits=(0, 0))
             p = "best"  # 'lower right' if i == 0 else ''
@@ -3530,7 +3530,7 @@ class BoltztrapPlotter:
                     )
             ax.set_title(dt + "-type", fontsize=20)
             if i == 0:
-                ax.ylabel("zT", fontsize=30.0)
+                ax.set_ylabel("zT", fontsize=30.0)
             ax.set_xlabel("Doping concentration ($cm^{-3}$)", fontsize=30.0)
 
             p = "lower right" if i == 0 else "best"
@@ -3582,7 +3582,7 @@ class BoltztrapPlotter:
                     )
             ax.set_title(dt + "-type", fontsize=20)
             if i == 0:
-                ax.ylabel("Effective mass (m$_e$)", fontsize=30.0)
+                ax.set_ylabel("Effective mass (m$_e$)", fontsize=30.0)
             ax.set_xlabel("Doping concentration ($cm^{-3}$)", fontsize=30.0)
 
             p = "lower right" if i == 0 else "best"
@@ -3623,9 +3623,9 @@ class BoltztrapPlotter:
         ax.semilogy(self._bz.mu_steps, carriers, linewidth=3.0, color="r")
         self._plot_bg_limits(ax)
         self._plot_doping(ax, temp)
-        ax.xlim(-0.5, self._bz.gap + 0.5)
-        ax.ylim(1e14, 1e22)
-        ax.ylabel("carrier concentration (cm-3)", fontsize=30.0)
+        ax.set_xlim(-0.5, self._bz.gap + 0.5)
+        ax.set_ylim(1e14, 1e22)
+        ax.set_ylabel("carrier concentration (cm-3)", fontsize=30.0)
         ax.set_xlabel("E-E$_f$ (eV)", fontsize=30)
         ax.set_xticks(fontsize=25)
         ax.set_yticks(fontsize=25)
@@ -3647,9 +3647,9 @@ class BoltztrapPlotter:
         ax.semilogy(self._bz.mu_steps, hall_carriers, linewidth=3.0, color="r")
         self._plot_bg_limits(ax)
         self._plot_doping(ax, temp)
-        ax.xlim(-0.5, self._bz.gap + 0.5)
-        ax.ylim(1e14, 1e22)
-        ax.ylabel("Hall carrier concentration (cm-3)", fontsize=30.0)
+        ax.set_xlim(-0.5, self._bz.gap + 0.5)
+        ax.set_ylim(1e14, 1e22)
+        ax.set_ylabel("Hall carrier concentration (cm-3)", fontsize=30.0)
         ax.set_xlabel("E-E$_f$ (eV)", fontsize=30)
         ax.set_xticks(fontsize=25)
         ax.set_yticks(fontsize=25)

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -3823,17 +3823,17 @@ class CohpPlotter:
                         ax.plot(x, y, color=colors[i % ncolors], linestyle="--", linewidth=3)
 
         if xlim:
-            ax.xlim(xlim)
+            ax.set_xlim(xlim)
         if ylim:
-            ax.ylim(ylim)
+            ax.set_ylim(ylim)
         elif not invert_axes:
             xlim = ax.get_xlim()
-            relevanty = [p[1] for p in allpts if xlim[0] < p[0] < xlim[1]]
-            ax.ylim((min(relevanty), max(relevanty)))
+            relevant_y = [p[1] for p in allpts if xlim[0] < p[0] < xlim[1]]
+            ax.set_ylim((min(relevant_y), max(relevant_y)))
         if not xlim and invert_axes:
             ylim = ax.get_ylim()
-            relevanty = [p[0] for p in allpts if ylim[0] < p[1] < ylim[1]]
-            ax.xlim((min(relevanty), max(relevanty)))
+            relevant_y = [p[0] for p in allpts if ylim[0] < p[1] < ylim[1]]
+            ax.set_xlim((min(relevant_y), max(relevant_y)))
 
         xlim = ax.get_xlim()
         ylim = ax.get_ylim()

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -223,10 +223,7 @@ class DosPlotter:
 
         if invert_axes:
             ax.set_ylabel("Energies (eV)")
-            if self._norm_val:
-                ax.xlabel("Density of states (states/eV/Å³)")
-            else:
-                ax.xlabel("Density of states (states/eV)")
+            ax.set_xlabel(f"Density of states (states/eV{'/Å³' if self._norm_val else ''})")
             ax.axvline(x=0, color="k", linestyle="--", linewidth=2)
         else:
             ax.set_xlabel("Energies (eV)")
@@ -237,7 +234,7 @@ class DosPlotter:
             ax.axhline(y=0, color="k", linestyle="--", linewidth=2)
 
         # Remove duplicate labels with a dictionary
-        handles, labels = ax.get_gca().get_legend_handles_labels()
+        handles, labels = ax.get_legend_handles_labels()
         label_dict = dict(zip(labels, handles))
         ax.legend(label_dict.values(), label_dict.keys())
         legend_text = ax.get_legend().get_texts()  # all the text.Text instance in the legend

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -243,7 +243,7 @@ class DosPlotter:
         ax.legend(label_dict.values(), label_dict.keys())
         leg = ax.get_legend()
         legend_text = leg.get_texts()  # all the text.Text instance in the legend
-        ax.setp(legend_text, fontsize=30)
+        plt.setp(legend_text, fontsize=30)
         plt.tight_layout()
         return ax
 
@@ -3872,7 +3872,7 @@ class CohpPlotter:
         ax.legend()
         leg = ax.get_legend()
         legend_text = leg.get_texts()
-        ax.setp(legend_text, fontsize=30)
+        plt.setp(legend_text, fontsize=30)
         plt.tight_layout()
         return ax
 

--- a/pymatgen/io/abinit/abitimer.py
+++ b/pymatgen/io/abinit/abitimer.py
@@ -9,6 +9,7 @@ import collections
 import logging
 import os
 import sys
+from typing import TYPE_CHECKING
 
 import numpy as np
 from monty.string import is_string, list_strings
@@ -16,6 +17,9 @@ from monty.string import is_string, list_strings
 from pymatgen.io.core import ParseError
 from pymatgen.util.num import minloc
 from pymatgen.util.plotting import add_fig_kwargs, get_ax_fig_plt
+
+if TYPE_CHECKING:
+    import matplotlib.pyplot as plt
 
 logger = logging.getLogger(__name__)
 
@@ -315,7 +319,7 @@ class AbinitTimerParser(collections.abc.Iterable):
         return frame
 
     @add_fig_kwargs
-    def plot_efficiency(self, key="wall_time", what="good+bad", nmax=5, ax=None, **kwargs):
+    def plot_efficiency(self, key="wall_time", what="good+bad", nmax=5, ax: plt.Axes = None, **kwargs):
         """
         Plot the parallel efficiency.
 
@@ -418,7 +422,7 @@ class AbinitTimerParser(collections.abc.Iterable):
         return fig
 
     @add_fig_kwargs
-    def plot_stacked_hist(self, key="wall_time", nmax=5, ax=None, **kwargs):
+    def plot_stacked_hist(self, key="wall_time", nmax=5, ax: plt.Axes = None, **kwargs):
         """
         Plot stacked histogram of the different timers.
 
@@ -790,7 +794,7 @@ class AbinitTimer:
         return sorted(self.sections, key=lambda s: s.__dict__[key], reverse=reverse)
 
     @add_fig_kwargs
-    def cpuwall_histogram(self, ax=None, **kwargs):
+    def cpuwall_histogram(self, ax: plt.Axes = None, **kwargs):
         """
         Plot histogram with cpu- and wall-time on axis `ax`.
 
@@ -824,7 +828,7 @@ class AbinitTimer:
         return fig
 
     @add_fig_kwargs
-    def pie(self, key="wall_time", minfract=0.05, ax=None, **kwargs):
+    def pie(self, key="wall_time", minfract=0.05, ax: plt.Axes = None, **kwargs):
         """
         Plot pie chart for this timer.
 
@@ -844,7 +848,7 @@ class AbinitTimer:
         return fig
 
     @add_fig_kwargs
-    def scatter_hist(self, ax=None, **kwargs):
+    def scatter_hist(self, ax: plt.Axes = None, **kwargs):
         """
         Scatter plot + histogram.
 

--- a/pymatgen/io/abinit/pseudos.py
+++ b/pymatgen/io/abinit/pseudos.py
@@ -1673,7 +1673,7 @@ class PseudoTable(collections.abc.Sequence, MSONable):
     @property
     def zlist(self):
         """Ordered list with the atomic numbers available in the table."""
-        return sorted(list(self._pseudos_with_z))
+        return sorted(self._pseudos_with_z)
 
     # def max_ecut_pawecutdg(self, accuracy):
     # """Return the maximum value of ecut and pawecutdg based on the hints available in the pseudos."""

--- a/pymatgen/io/abinit/pseudos.py
+++ b/pymatgen/io/abinit/pseudos.py
@@ -28,6 +28,8 @@ from pymatgen.io.core import ParseError
 from pymatgen.util.plotting import add_fig_kwargs, get_ax_fig_plt
 
 if TYPE_CHECKING:
+    import matplotlib.pyplot as plt
+
     from pymatgen.core import Structure
 
 logger = logging.getLogger(__name__)
@@ -1412,7 +1414,7 @@ class PawXmlSetup(Pseudo, PawPseudo):
         # yield self.plot_potentials(title="potentials", show=False)
 
     @add_fig_kwargs
-    def plot_densities(self, ax=None, **kwargs):
+    def plot_densities(self, ax: plt.Axes = None, **kwargs):
         """
         Plot the PAW densities.
 
@@ -1438,7 +1440,7 @@ class PawXmlSetup(Pseudo, PawPseudo):
         return fig
 
     @add_fig_kwargs
-    def plot_waves(self, ax=None, fontsize=12, **kwargs):
+    def plot_waves(self, ax: plt.Axes = None, fontsize=12, **kwargs):
         """
         Plot the AE and the pseudo partial waves.
 
@@ -1469,7 +1471,7 @@ class PawXmlSetup(Pseudo, PawPseudo):
         return fig
 
     @add_fig_kwargs
-    def plot_projectors(self, ax=None, fontsize=12, **kwargs):
+    def plot_projectors(self, ax: plt.Axes = None, fontsize=12, **kwargs):
         """
         Plot the PAW projectors.
 

--- a/pymatgen/io/cp2k/inputs.py
+++ b/pymatgen/io/cp2k/inputs.py
@@ -92,7 +92,7 @@ class Keyword(MSONable):
             repeats: Whether or not this keyword may be repeated. Default=False.
         """
         self.name = name
-        self.values = values  # noqa: PD011
+        self.values = values
         self.description = description
         self.repeats = repeats
         self.units = units
@@ -109,8 +109,8 @@ class Keyword(MSONable):
         if not isinstance(other, Keyword):
             return NotImplemented
         if self.name.upper() == other.name.upper():
-            v1 = [_.upper() if isinstance(_, str) else _ for _ in self.values]  # noqa: PD011
-            v2 = [_.upper() if isinstance(_, str) else _ for _ in other.values]  # noqa: PD011
+            v1 = [val.upper() if isinstance(val, str) else val for val in self.values]
+            v2 = [val.upper() if isinstance(val, str) else val for val in other.values]  # noqa: PD011
             if v1 == v2 and self.units == self.units:
                 return True
         return False
@@ -119,7 +119,7 @@ class Keyword(MSONable):
         return KeywordList(keywords=[self, other])
 
     def __getitem__(self, item):
-        return self.values[item]  # noqa: PD011
+        return self.values[item]
 
     def as_dict(self):
         """Get a dictionary representation of the Keyword."""
@@ -127,7 +127,7 @@ class Keyword(MSONable):
         dct["@module"] = type(self).__module__
         dct["@class"] = type(self).__name__
         dct["name"] = self.name
-        dct["values"] = self.values  # noqa: PD011
+        dct["values"] = self.values
         dct["description"] = self.description
         dct["repeats"] = self.repeats
         dct["units"] = self.units

--- a/pymatgen/io/gaussian.py
+++ b/pymatgen/io/gaussian.py
@@ -1339,7 +1339,7 @@ class GaussianOutput:
         """
         from scipy.stats import norm
 
-        plt = pretty_plot(12, 8)
+        ax = pretty_plot(12, 8)
 
         transitions = self.read_excitation_energies()
 
@@ -1355,12 +1355,12 @@ class GaussianOutput:
         for trans in transitions:
             spectre += trans[2] * norm(eneval, trans[0], sigma)
         spectre /= spectre.max()
-        plt.plot(lambdaval, spectre, "r-", label="spectre")
+        ax.plot(lambdaval, spectre, "r-", label="spectre")
 
         data = {"energies": eneval, "lambda": lambdaval, "xas": spectre}
 
         # plot transitions as vlines
-        plt.vlines(
+        ax.vlines(
             [val[1] for val in transitions],
             0.0,
             [val[2] for val in transitions],
@@ -1369,11 +1369,11 @@ class GaussianOutput:
             linewidth=2,
         )
 
-        plt.xlabel("$\\lambda$ (nm)")
-        plt.ylabel("Arbitrary unit")
-        plt.legend()
+        ax.set_xlabel("$\\lambda$ (nm)")
+        ax.set_ylabel("Arbitrary unit")
+        ax.legend()
 
-        return data, plt
+        return data, ax
 
     def save_spectre_plot(self, filename="spectre.pdf", img_format="pdf", sigma=0.05, step=0.01):
         """

--- a/pymatgen/io/gaussian.py
+++ b/pymatgen/io/gaussian.py
@@ -16,6 +16,7 @@ from pymatgen.core.structure import Molecule
 from pymatgen.core.units import Ha_to_eV
 from pymatgen.electronic_structure.core import Spin
 from pymatgen.util.coord import get_angle
+from pymatgen.util.plotting import pretty_plot
 
 __author__ = "Shyue Ping Ong, Germain Salvato-Vallverdu, Xin Chen"
 __copyright__ = "Copyright 2013, The Materials Virtual Lab"
@@ -1263,26 +1264,25 @@ class GaussianOutput:
         Args:
             coords: internal coordinate name to use as abscissa.
         """
-        from pymatgen.util.plotting import pretty_plot
 
-        plt = pretty_plot(12, 8)
+        ax = pretty_plot(12, 8)
 
         d = self.read_scan()
 
         if coords and coords in d["coords"]:
             x = d["coords"][coords]
-            plt.xlabel(coords)
+            ax.set_xlabel(coords)
         else:
             x = range(len(d["energies"]))
-            plt.xlabel("points")
+            ax.set_xlabel("points")
 
-        plt.ylabel("Energy (eV)")
+        ax.set_ylabel("Energy (eV)")
 
         e_min = min(d["energies"])
         y = [(e - e_min) * Ha_to_eV for e in d["energies"]]
 
-        plt.plot(x, y, "ro--")
-        return plt
+        ax.plot(x, y, "ro--")
+        return ax
 
     def save_scan_plot(self, filename="scan.pdf", img_format="pdf", coords=None):
         """
@@ -1338,8 +1338,6 @@ class GaussianOutput:
             A matplotlib plot.
         """
         from scipy.stats import norm
-
-        from pymatgen.util.plotting import pretty_plot
 
         plt = pretty_plot(12, 8)
 

--- a/pymatgen/io/lobster/lobsterenv.py
+++ b/pymatgen/io/lobster/lobsterenv.py
@@ -450,14 +450,14 @@ class LobsterNeighbors(NearNeighbors):
         )
 
         cp.add_cohp(plotlabel, summed_cohp)
-        plot = cp.get_plot(integrated=integrated)
+        ax = cp.get_plot(integrated=integrated)
         if xlim is not None:
-            plot.xlim(xlim)
+            ax.set_xlim(xlim)
 
         if ylim is not None:
-            plot.ylim(ylim)
+            ax.set_ylim(ylim)
 
-        return plot
+        return ax
 
     def get_info_cohps_to_neighbors(
         self,

--- a/pymatgen/phonon/ir_spectra.py
+++ b/pymatgen/phonon/ir_spectra.py
@@ -132,14 +132,14 @@ class IRDielectricTensor(MSONable):
             kwargs: keyword arguments passed to the plotter
         """
         plotter = self.get_plotter(components=components, reim=reim, **kwargs)
-        plt = plotter.get_plot(xlim=xlim, ylim=ylim)
+        ax = plotter.get_plot(xlim=xlim, ylim=ylim)
 
         if show_phonon_frequencies:
             ph_freqs_gamma = self.ph_freqs_gamma[3:]
-            plt.scatter(ph_freqs_gamma * 1000, np.zeros_like(ph_freqs_gamma))
-        plt.xlabel(r"$\epsilon(\omega)$")
-        plt.xlabel(r"Frequency (meV)")
-        return plt
+            ax.scatter(ph_freqs_gamma * 1000, np.zeros_like(ph_freqs_gamma))
+        ax.set_xlabel(r"$\epsilon(\omega)$")
+        ax.set_xlabel(r"Frequency (meV)")
+        return ax
 
     def get_spectrum(self, component, reim, broad=0.00005, emin=0, emax=None, divs=500, label=None):
         """

--- a/pymatgen/phonon/plotter.py
+++ b/pymatgen/phonon/plotter.py
@@ -208,7 +208,7 @@ class PhononDosPlotter:
             ylim: Specifies the y-axis limits.
             units: units for the frequencies. Accepted values thz, ev, mev, ha, cm-1, cm^-1
         """
-        plt = self.get_plot(xlim, ylim, units=units)
+        self.get_plot(xlim, ylim, units=units)
         plt.savefig(filename, format=img_format)
         plt.close()
 
@@ -222,7 +222,7 @@ class PhononDosPlotter:
             ylim: Specifies the y-axis limits.
             units: units for the frequencies. Accepted values thz, ev, mev, ha, cm-1, cm^-1.
         """
-        plt = self.get_plot(xlim, ylim, units=units)
+        self.get_plot(xlim, ylim, units=units)
         plt.show()
 
 
@@ -505,7 +505,7 @@ class PhononBSPlotter:
                 the code choose.
             units: units for the frequencies. Accepted values thz, ev, mev, ha, cm-1, cm^-1.
         """
-        plt = self.get_plot(ylim, units=units)
+        self.get_plot(ylim, units=units)
         plt.show()
 
     def save_plot(self, filename, img_format="eps", ylim=None, units="thz"):
@@ -518,7 +518,7 @@ class PhononBSPlotter:
             ylim: Specifies the y-axis limits.
             units: units for the frequencies. Accepted values thz, ev, mev, ha, cm-1, cm^-1.
         """
-        plt = self.get_plot(ylim=ylim, units=units)
+        self.get_plot(ylim=ylim, units=units)
         plt.savefig(filename, format=img_format)
         plt.close()
 
@@ -608,7 +608,7 @@ class PhononBSPlotter:
         if len(data_orig["distances"]) != len(data["distances"]):
             raise ValueError("The two objects are not compatible.")
 
-        plt = self.get_plot(units=units)
+        self.get_plot(units=units)
         band_linewidth = 1
         for i in range(other_plotter._nb_bands):
             for d in range(len(data_orig["distances"])):
@@ -894,7 +894,7 @@ class GruneisenPlotter:
 
         Returns: plot
         """
-        plt = self.get_plot(units=units)
+        self.get_plot(units=units)
         plt.show()
 
     def save_plot(self, filename, img_format="pdf", units="thz"):
@@ -905,7 +905,7 @@ class GruneisenPlotter:
             img_format: format of the saved plot
             units: accepted units: thz, ev, mev, ha, cm-1, cm^-1.
         """
-        plt = self.get_plot(units=units)
+        self.get_plot(units=units)
         plt.savefig(filename, format=img_format)
         plt.close()
 
@@ -1014,7 +1014,7 @@ class GruneisenPhononBSPlotter(PhononBSPlotter):
         Args:
             ylim: Specifies the y-axis limits.
         """
-        plt = self.get_plot_gs(ylim)
+        self.get_plot_gs(ylim)
         plt.show()
 
     def save_plot_gs(self, filename, img_format="eps", ylim=None):
@@ -1026,7 +1026,7 @@ class GruneisenPhononBSPlotter(PhononBSPlotter):
             img_format: Image format to use. Defaults to EPS.
             ylim: Specifies the y-axis limits.
         """
-        plt = self.get_plot_gs(ylim=ylim)
+        self.get_plot_gs(ylim=ylim)
         plt.savefig(filename, format=img_format)
         plt.close()
 
@@ -1050,7 +1050,7 @@ class GruneisenPhononBSPlotter(PhononBSPlotter):
         if len(data_orig["distances"]) != len(data["distances"]):
             raise ValueError("The two objects are not compatible.")
 
-        plt = self.get_plot()
+        self.get_plot()
         band_linewidth = 1
         for i in range(other_plotter._nb_bands):
             for d in range(len(data_orig["distances"])):

--- a/pymatgen/phonon/plotter.py
+++ b/pymatgen/phonon/plotter.py
@@ -446,7 +446,7 @@ class PhononBSPlotter:
 
         u = freq_units(units)
         fig, ax = plt.subplots(figsize=(12, 8), dpi=300)
-        self._maketicks(plt)
+        self._maketicks(ax)
 
         data = self.bs_plot_data()
         k_dist = np.array(data["distances"]).flatten()

--- a/pymatgen/phonon/plotter.py
+++ b/pymatgen/phonon/plotter.py
@@ -190,7 +190,7 @@ class PhononDosPlotter:
         ax.ylabel(r"$\mathrm{Density\ of\ states}$")
 
         ax.legend()
-        leg = ax.gca().get_legend()
+        leg = ax.get_legend()
         legend_text = leg.get_texts()  # all the text.Text instance in the legend
         ax.setp(legend_text, fontsize=30)
         plt.tight_layout()
@@ -243,7 +243,7 @@ class PhononBSPlotter:
         self._bs = bs
         self._nb_bands = self._bs.nb_bands
 
-    def _maketicks(self, plt):
+    def _maketicks(self, ax: plt.Axes) -> plt.Axes:
         """Utility private method to add ticks to a band structure."""
         ticks = self.get_ticks()
         # Sanitize only plot the uniq values
@@ -263,8 +263,8 @@ class PhononBSPlotter:
                 uniq_l.append(tt[1])
 
         logger.debug(f"Unique labels are {list(zip(uniq_d, uniq_l))}")
-        plt.gca().set_xticks(uniq_d)
-        plt.gca().set_xticklabels(uniq_l)
+        ax.set_xticks(uniq_d)
+        ax.set_xticklabels(uniq_l)
 
         for i in range(len(ticks["label"])):
             if ticks["label"][i] is not None:
@@ -274,11 +274,11 @@ class PhononBSPlotter:
                         logger.debug(f"already print label... skipping label {ticks['label'][i]}")
                     else:
                         logger.debug(f"Adding a line at {ticks['distance'][i]} for label {ticks['label'][i]}")
-                        plt.axvline(ticks["distance"][i], color="k")
+                        ax.axvline(ticks["distance"][i], color="k")
                 else:
                     logger.debug(f"Adding a line at {ticks['distance'][i]} for label {ticks['label'][i]}")
-                    plt.axvline(ticks["distance"][i], color="k")
-        return plt
+                    ax.axvline(ticks["distance"][i], color="k")
+        return ax
 
     def bs_plot_data(self):
         """

--- a/pymatgen/phonon/plotter.py
+++ b/pymatgen/phonon/plotter.py
@@ -657,7 +657,9 @@ class ThermoPlotter:
         self.dos = dos
         self.structure = structure
 
-    def _plot_thermo(self, func, temperatures, factor=1, ax=None, ylabel=None, label=None, ylim=None, **kwargs):
+    def _plot_thermo(
+        self, func, temperatures, factor=1, ax: plt.Axes = None, ylabel=None, label=None, ylim=None, **kwargs
+    ):
         """
         Plots a thermodynamic property for a generic function from a PhononDos instance.
 

--- a/pymatgen/phonon/plotter.py
+++ b/pymatgen/phonon/plotter.py
@@ -312,7 +312,7 @@ class PhononBSPlotter:
             "lattice": self._bs.lattice_rec.as_dict(),
         }
 
-    def get_plot(self, ylim=None, units="thz"):
+    def get_plot(self, ylim=None, units="thz") -> plt.Axes:
         """
         Get a matplotlib object for the bandstructure plot.
 
@@ -323,41 +323,41 @@ class PhononBSPlotter:
         """
         u = freq_units(units)
 
-        plt = pretty_plot(12, 8)
+        ax = pretty_plot(12, 8)
 
         band_linewidth = 1
 
         data = self.bs_plot_data()
         for d in range(len(data["distances"])):
             for i in range(self._nb_bands):
-                plt.plot(
+                ax.plot(
                     data["distances"][d],
                     [data["frequency"][d][i][j] * u.factor for j in range(len(data["distances"][d]))],
                     "b-",
                     linewidth=band_linewidth,
                 )
 
-        self._maketicks(plt)
+        self._maketicks(ax)
 
         # plot y=0 line
-        plt.axhline(0, linewidth=1, color="k")
+        ax.axhline(0, linewidth=1, color="k")
 
         # Main X and Y Labels
-        plt.xlabel(r"$\mathrm{Wave\ Vector}$", fontsize=30)
+        ax.set_xlabel(r"$\mathrm{Wave\ Vector}$", fontsize=30)
         ylabel = rf"$\mathrm{{Frequencies\ ({u.label})}}$"
-        plt.ylabel(ylabel, fontsize=30)
+        ax.set_ylabel(ylabel, fontsize=30)
 
         # X range (K)
         # last distance point
         x_max = data["distances"][-1][-1]
-        plt.xlim(0, x_max)
+        ax.set_xlim(0, x_max)
 
         if ylim is not None:
-            plt.ylim(ylim)
+            ax.set_ylim(ylim)
 
         plt.tight_layout()
 
-        return plt
+        return ax
 
     def _get_weight(self, vec: np.ndarray, indices: list[list[int]]) -> np.ndarray:
         """
@@ -608,18 +608,21 @@ class PhononBSPlotter:
         if len(data_orig["distances"]) != len(data["distances"]):
             raise ValueError("The two objects are not compatible.")
 
-        self.get_plot(units=units)
+        ax = self.get_plot(units=units)
         band_linewidth = 1
-        for i in range(other_plotter._nb_bands):
-            for d in range(len(data_orig["distances"])):
-                plt.plot(
-                    data_orig["distances"][d],
-                    [data["frequency"][d][i][j] * u.factor for j in range(len(data_orig["distances"][d]))],
+        for band_idx in range(other_plotter._nb_bands):
+            for dist_idx in range(len(data_orig["distances"])):
+                ax.plot(
+                    data_orig["distances"][dist_idx],
+                    [
+                        data["frequency"][dist_idx][band_idx][j] * u.factor
+                        for j in range(len(data_orig["distances"][dist_idx]))
+                    ],
                     "r-",
                     linewidth=band_linewidth,
                 )
 
-        return plt
+        return ax
 
     def plot_brillouin(self):
         """Plot the Brillouin zone."""
@@ -868,23 +871,22 @@ class GruneisenPlotter:
         xs = self._gruneisen.frequencies.flatten() * u.factor
         ys = self._gruneisen.gruneisen.flatten()
 
-        plt = pretty_plot(12, 8)
+        ax = pretty_plot(12, 8)
 
-        plt.xlabel(rf"$\mathrm{{Frequency\ ({u.label})}}$")
-        plt.ylabel(r"$\mathrm{Grüneisen\ parameter}$")
+        ax.set_xlabel(rf"$\mathrm{{Frequency\ ({u.label})}}$")
+        ax.set_ylabel(r"$\mathrm{Grüneisen\ parameter}$")
 
         n = len(ys) - 1
         for i, (x, y) in enumerate(zip(xs, ys)):
             color = (1.0 / n * i, 0, 1.0 / n * (n - i))
 
             if markersize:
-                plt.plot(x, y, marker, color=color, markersize=markersize)
+                ax.plot(x, y, marker, color=color, markersize=markersize)
             else:
-                plt.plot(x, y, marker, color=color)
+                ax.plot(x, y, marker, color=color)
 
         plt.tight_layout()
-
-        return plt
+        return ax
 
     def show(self, units="thz"):
         """
@@ -969,14 +971,14 @@ class GruneisenPhononBSPlotter(PhononBSPlotter):
             ylim: Specify the y-axis (gruneisen) limits; by default None let
                 the code choose.
         """
-        plt = pretty_plot(12, 8)
+        ax = pretty_plot(12, 8)
 
         # band_linewidth = 1
 
         data = self.bs_plot_data()
         for d in range(len(data["distances"])):
             for i in range(self._nb_bands):
-                plt.plot(
+                ax.plot(
                     data["distances"][d],
                     [data["gruneisen"][d][i][j] for j in range(len(data["distances"][d]))],
                     "b-",
@@ -986,26 +988,26 @@ class GruneisenPhononBSPlotter(PhononBSPlotter):
                     linewidth=2,
                 )
 
-        self._maketicks(plt)
+        self._maketicks(ax)
 
         # plot y=0 line
-        plt.axhline(0, linewidth=1, color="k")
+        ax.axhline(0, linewidth=1, color="k")
 
         # Main X and Y Labels
-        plt.xlabel(r"$\mathrm{Wave\ Vector}$", fontsize=30)
-        plt.ylabel(r"$\mathrm{Grüneisen\ Parameter}$", fontsize=30)
+        ax.set_xlabel(r"$\mathrm{Wave\ Vector}$", fontsize=30)
+        ax.set_ylabel(r"$\mathrm{Grüneisen\ Parameter}$", fontsize=30)
 
         # X range (K)
         # last distance point
         x_max = data["distances"][-1][-1]
-        plt.xlim(0, x_max)
+        ax.set_xlim(0, x_max)
 
         if ylim is not None:
-            plt.ylim(ylim)
+            ax.set_ylim(ylim)
 
         plt.tight_layout()
 
-        return plt
+        return ax
 
     def show_gs(self, ylim=None):
         """
@@ -1057,15 +1059,15 @@ class GruneisenPhononBSPlotter(PhononBSPlotter):
                 f"The two plotters are incompatible, plotting data have different lengths ({len_orig} vs {len_other})."
             )
 
-        self.get_plot()
+        ax = self.get_plot()
         band_linewidth = 1
-        for i in range(other_plotter._nb_bands):
-            for d in range(len(data_orig["distances"])):
-                plt.plot(
-                    data_orig["distances"][d],
-                    [data["gruneisen"][d][i][j] for j in range(len(data_orig["distances"][d]))],
+        for band_idx in range(other_plotter._nb_bands):
+            for dist_idx in range(len(data_orig["distances"])):
+                ax.plot(
+                    data_orig["distances"][dist_idx],
+                    [data["gruneisen"][dist_idx][band_idx][j] for j in range(len(data_orig["distances"][dist_idx]))],
                     "r-",
                     linewidth=band_linewidth,
                 )
 
-        return plt
+        return ax

--- a/pymatgen/phonon/plotter.py
+++ b/pymatgen/phonon/plotter.py
@@ -676,7 +676,7 @@ class ThermoPlotter:
             kwargs: kwargs passed to the matplotlib function 'plot'.
 
         Returns:
-            matplotlib figure
+            plt.figure: matplotlib figure
         """
         ax, fig, plt = get_ax_fig_plt(ax)
 
@@ -714,7 +714,7 @@ class ThermoPlotter:
             kwargs: kwargs passed to the matplotlib function 'plot'.
 
         Returns:
-            matplotlib figure
+            plt.figure: matplotlib figure
         """
         temperatures = np.linspace(tmin, tmax, ntemp)
 
@@ -735,7 +735,7 @@ class ThermoPlotter:
             kwargs: kwargs passed to the matplotlib function 'plot'.
 
         Returns:
-            matplotlib figure
+            plt.figure: matplotlib figure
         """
         temperatures = np.linspace(tmin, tmax, ntemp)
 
@@ -756,7 +756,7 @@ class ThermoPlotter:
             kwargs: kwargs passed to the matplotlib function 'plot'.
 
         Returns:
-            matplotlib figure
+            plt.figure: matplotlib figure
         """
         temperatures = np.linspace(tmin, tmax, ntemp)
 
@@ -779,7 +779,7 @@ class ThermoPlotter:
             kwargs: kwargs passed to the matplotlib function 'plot'.
 
         Returns:
-            matplotlib figure
+            plt.figure: matplotlib figure
         """
         temperatures = np.linspace(tmin, tmax, ntemp)
 
@@ -802,7 +802,7 @@ class ThermoPlotter:
             kwargs: kwargs passed to the matplotlib function 'plot'.
 
         Returns:
-            matplotlib figure
+            plt.figure: matplotlib figure
         """
         temperatures = np.linspace(tmin, tmax, ntemp)
 

--- a/pymatgen/phonon/plotter.py
+++ b/pymatgen/phonon/plotter.py
@@ -156,8 +156,7 @@ class PhononDosPlotter:
             all_frequencies.append(frequencies)
             all_densities.append(new_dens)
 
-        keys = list(self._doses)
-        keys.reverse()
+        keys = list(reversed(self._doses))
         all_densities.reverse()
         all_frequencies.reverse()
         all_pts = []
@@ -175,23 +174,22 @@ class PhononDosPlotter:
                 )
 
         if xlim:
-            ax.xlim(xlim)
+            ax.set_xlim(xlim)
         if ylim:
-            ax.ylim(ylim)
+            ax.set_ylim(ylim)
         else:
-            xlim = ax.xlim()
+            xlim = ax.set_xlim()
             relevant_y = [p[1] for p in all_pts if xlim[0] < p[0] < xlim[1]]
-            ax.ylim((min(relevant_y), max(relevant_y)))
+            ax.set_ylim((min(relevant_y), max(relevant_y)))
 
         ylim = ax.ylim()
         ax.plot([0, 0], ylim, "k--", linewidth=2)
 
-        ax.xlabel(rf"$\mathrm{{Frequencies\ ({unit.label})}}$")
-        ax.ylabel(r"$\mathrm{Density\ of\ states}$")
+        ax.set_xlabel(rf"$\mathrm{{Frequencies\ ({unit.label})}}$")
+        ax.set_ylabel(r"$\mathrm{Density\ of\ states}$")
 
         ax.legend()
-        leg = ax.get_legend()
-        legend_text = leg.get_texts()  # all the text.Text instance in the legend
+        legend_text = ax.get_legend().get_texts()  # all the text.Text instance in the legend
         plt.setp(legend_text, fontsize=30)
         plt.tight_layout()
         return ax

--- a/pymatgen/phonon/plotter.py
+++ b/pymatgen/phonon/plotter.py
@@ -192,7 +192,7 @@ class PhononDosPlotter:
         ax.legend()
         leg = ax.get_legend()
         legend_text = leg.get_texts()  # all the text.Text instance in the legend
-        ax.setp(legend_text, fontsize=30)
+        plt.setp(legend_text, fontsize=30)
         plt.tight_layout()
         return ax
 

--- a/pymatgen/phonon/plotter.py
+++ b/pymatgen/phonon/plotter.py
@@ -182,7 +182,7 @@ class PhononDosPlotter:
             relevant_y = [p[1] for p in all_pts if xlim[0] < p[0] < xlim[1]]
             ax.set_ylim((min(relevant_y), max(relevant_y)))
 
-        ylim = ax.ylim()
+        ylim = ax.set_ylim()
         ax.plot([0, 0], ylim, "k--", linewidth=2)
 
         ax.set_xlabel(rf"$\mathrm{{Frequencies\ ({unit.label})}}$")

--- a/pymatgen/phonon/plotter.py
+++ b/pymatgen/phonon/plotter.py
@@ -127,74 +127,74 @@ class PhononDosPlotter:
             ylim: Specifies the y-axis limits.
             units: units for the frequencies. Accepted values thz, ev, mev, ha, cm-1, cm^-1.
         """
-        u = freq_units(units)
+        unit = freq_units(units)
 
-        ncolors = max(3, len(self._doses))
-        ncolors = min(9, ncolors)
+        n_colors = max(3, len(self._doses))
+        n_colors = min(9, n_colors)
 
         import palettable
 
         colors = palettable.colorbrewer.qualitative.Set1_9.mpl_colors  # pylint: disable=E1101
 
         y = None
-        alldensities = []
-        allfrequencies = []
-        plt = pretty_plot(12, 8)
+        all_densities = []
+        all_frequencies = []
+        ax = pretty_plot(12, 8)
 
         # Note that this complicated processing of frequencies is to allow for
         # stacked plots in matplotlib.
         for dos in self._doses.values():
-            frequencies = dos["frequencies"] * u.factor
+            frequencies = dos["frequencies"] * unit.factor
             densities = dos["densities"]
             if y is None:
                 y = np.zeros(frequencies.shape)
             if self.stack:
                 y += densities
-                newdens = y.copy()
+                new_dens = y.copy()
             else:
-                newdens = densities
-            allfrequencies.append(frequencies)
-            alldensities.append(newdens)
+                new_dens = densities
+            all_frequencies.append(frequencies)
+            all_densities.append(new_dens)
 
         keys = list(self._doses)
         keys.reverse()
-        alldensities.reverse()
-        allfrequencies.reverse()
-        allpts = []
-        for i, (key, frequencies, densities) in enumerate(zip(keys, allfrequencies, alldensities)):
-            allpts.extend(list(zip(frequencies, densities)))
+        all_densities.reverse()
+        all_frequencies.reverse()
+        all_pts = []
+        for i, (key, frequencies, densities) in enumerate(zip(keys, all_frequencies, all_densities)):
+            all_pts.extend(list(zip(frequencies, densities)))
             if self.stack:
-                plt.fill(frequencies, densities, color=colors[i % ncolors], label=str(key))
+                ax.fill(frequencies, densities, color=colors[i % n_colors], label=str(key))
             else:
-                plt.plot(
+                ax.plot(
                     frequencies,
                     densities,
-                    color=colors[i % ncolors],
+                    color=colors[i % n_colors],
                     label=str(key),
                     linewidth=3,
                 )
 
         if xlim:
-            plt.xlim(xlim)
+            ax.xlim(xlim)
         if ylim:
-            plt.ylim(ylim)
+            ax.ylim(ylim)
         else:
-            xlim = plt.xlim()
-            relevanty = [p[1] for p in allpts if xlim[0] < p[0] < xlim[1]]
-            plt.ylim((min(relevanty), max(relevanty)))
+            xlim = ax.xlim()
+            relevant_y = [p[1] for p in all_pts if xlim[0] < p[0] < xlim[1]]
+            ax.ylim((min(relevant_y), max(relevant_y)))
 
-        ylim = plt.ylim()
-        plt.plot([0, 0], ylim, "k--", linewidth=2)
+        ylim = ax.ylim()
+        ax.plot([0, 0], ylim, "k--", linewidth=2)
 
-        plt.xlabel(rf"$\mathrm{{Frequencies\ ({u.label})}}$")
-        plt.ylabel(r"$\mathrm{Density\ of\ states}$")
+        ax.xlabel(rf"$\mathrm{{Frequencies\ ({unit.label})}}$")
+        ax.ylabel(r"$\mathrm{Density\ of\ states}$")
 
-        plt.legend()
-        leg = plt.gca().get_legend()
-        ltext = leg.get_texts()  # all the text.Text instance in the legend
-        plt.setp(ltext, fontsize=30)
+        ax.legend()
+        leg = ax.gca().get_legend()
+        legend_text = leg.get_texts()  # all the text.Text instance in the legend
+        ax.setp(legend_text, fontsize=30)
         plt.tight_layout()
-        return plt
+        return ax
 
     def save_plot(self, filename, img_format="eps", xlim=None, ylim=None, units="thz"):
         """

--- a/pymatgen/phonon/plotter.py
+++ b/pymatgen/phonon/plotter.py
@@ -1041,14 +1041,21 @@ class GruneisenPhononBSPlotter(PhononBSPlotter):
             other_plotter (GruneisenPhononBSPlotter): another phonon DOS plotter defined along
                 the same symmetry lines.
 
+        Raises:
+            ValueError: if the two plotters are incompatible (due to different data lengths)
+
         Returns:
             a matplotlib object with both band structures
         """
         data_orig = self.bs_plot_data()
         data = other_plotter.bs_plot_data()
 
-        if len(data_orig["distances"]) != len(data["distances"]):
-            raise ValueError("The two objects are not compatible.")
+        len_orig = len(data_orig["distances"])
+        len_other = len(data["distances"])
+        if len_orig != len_other:
+            raise ValueError(
+                f"The two plotters are incompatible, plotting data have different lengths ({len_orig} vs {len_other})."
+            )
 
         self.get_plot()
         band_linewidth = 1

--- a/pymatgen/symmetry/bandstructure.py
+++ b/pymatgen/symmetry/bandstructure.py
@@ -302,17 +302,13 @@ class HighSymmKpath(KPathBase):
         for more details.
 
         Args:
-        bandstructure (BandstructureSymmLine): BandstructureSymmLine object.
+            bandstructure (BandstructureSymmLine): BandstructureSymmLine object.
 
         Returns:
-        bandstructure (BandstructureSymmLine): New BandstructureSymmLine object with continuous path.
+            bandstructure (BandstructureSymmLine): New BandstructureSymmLine object with continuous path.
         """
         G = nx.Graph()
-
-        labels = []
-        for point in bandstructure.kpoints:
-            if point.label is not None:
-                labels.append(point.label)
+        labels = [point.label for point in bandstructure.kpoints if point.label is not None]
 
         plot_axis = []
         for i in range(int(len(labels) / 2)):

--- a/pymatgen/util/plotting.py
+++ b/pymatgen/util/plotting.py
@@ -164,15 +164,15 @@ def pretty_polyfit_plot(x, y, deg=1, xlabel=None, ylabel=None, **kwargs):
     Returns:
         matplotlib.pyplot object.
     """
-    plt = pretty_plot(**kwargs)
+    ax = pretty_plot(**kwargs)
     pp = np.polyfit(x, y, deg)
     xp = np.linspace(min(x), max(x), 200)
-    plt.plot(xp, np.polyval(pp, xp), "k--", x, y, "o")
+    ax.plot(xp, np.polyval(pp, xp), "k--", x, y, "o")
     if xlabel:
-        plt.xlabel(xlabel)
+        ax.set_xlabel(xlabel)
     if ylabel:
-        plt.ylabel(ylabel)
-    return plt
+        ax.set_ylabel(ylabel)
+    return ax
 
 
 def _decide_fontcolor(rgba: tuple) -> Literal["black", "white"]:

--- a/pymatgen/util/plotting.py
+++ b/pymatgen/util/plotting.py
@@ -5,13 +5,20 @@ from __future__ import annotations
 import math
 from typing import Literal
 
+import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib import cm, colors
 
 from pymatgen.core.periodic_table import Element
 
 
-def pretty_plot(width=8, height=None, plt=None, dpi=None, color_cycle=("qualitative", "Set1_9")):
+def pretty_plot(
+    width: float = 8,
+    height: float | None = None,
+    ax: plt.Axes = None,
+    dpi: float | None = None,
+    color_cycle: tuple[str, str] = ("qualitative", "Set1_9"),
+) -> plt.Axes:
     """
     Provides a publication quality plot, with nice defaults for font sizes etc.
 
@@ -19,26 +26,23 @@ def pretty_plot(width=8, height=None, plt=None, dpi=None, color_cycle=("qualitat
         width (float): Width of plot in inches. Defaults to 8in.
         height (float): Height of plot in inches. Defaults to width * golden
             ratio.
-        plt (matplotlib.pyplot): If plt is supplied, changes will be made to an
+        ax (plt.Axes): If ax is supplied, changes will be made to an
             existing plot. Otherwise, a new plot will be created.
         dpi (int): Sets dot per inch for figure. Defaults to 300.
         color_cycle (tuple): Set the color cycle for new plots to one of the
             color sets in palettable. Defaults to a qualitative Set1_9.
 
     Returns:
-        Matplotlib plot object with properly sized fonts.
+        plt.Axes: matplotlib axes object with properly sized fonts.
     """
     tick_size = int(width * 2.5)
-
     golden_ratio = (math.sqrt(5) - 1) / 2
 
     if not height:
         height = int(width * golden_ratio)
 
-    if plt is None:
+    if ax is None:
         import importlib
-
-        import matplotlib.pyplot as plt
 
         mod = importlib.import_module(f"palettable.colorbrewer.{color_cycle[0]}")
         colors = getattr(mod, color_cycle[1]).mpl_colors
@@ -50,18 +54,17 @@ def pretty_plot(width=8, height=None, plt=None, dpi=None, color_cycle=("qualitat
     else:
         fig = plt.gcf()
         fig.set_size_inches(width, height)
+
     plt.xticks(fontsize=tick_size)
     plt.yticks(fontsize=tick_size)
 
-    ax = plt.gca()
     ax.set_title(ax.get_title(), size=width * 4)
 
     label_size = int(width * 3)
-
     ax.set_xlabel(ax.get_xlabel(), size=label_size)
     ax.set_ylabel(ax.get_ylabel(), size=label_size)
 
-    return plt
+    return ax
 
 
 def pretty_plot_two_axis(
@@ -537,7 +540,7 @@ def van_arkel_triangle(list_of_materials, annotate=True):
     return plt
 
 
-def get_ax_fig_plt(ax=None, **kwargs):
+def get_ax_fig_plt(ax: plt.Axes = None, **kwargs):
     """
     Helper function used in plot functions supporting an optional Axes argument.
     If ax is None, we build the `matplotlib` figure and create the Axes else
@@ -563,7 +566,7 @@ def get_ax_fig_plt(ax=None, **kwargs):
     return ax, fig, plt
 
 
-def get_ax3d_fig_plt(ax=None, **kwargs):
+def get_ax3d_fig_plt(ax: plt.Axes = None, **kwargs):
     """
     Helper function used in plot functions supporting an optional Axes3D
     argument. If ax is None, we build the `matplotlib` figure and create the

--- a/pymatgen/vis/plotters.py
+++ b/pymatgen/vis/plotters.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import importlib
 
+import matplotlib.pyplot as plt
+
 from pymatgen.util.plotting import pretty_plot
 
 
@@ -132,10 +134,10 @@ class SpectrumPlotter:
             filename: Filename to write to.
             img_format: Image format to use. Defaults to EPS.
         """
-        plt = self.get_plot(**kwargs)
+        self.get_plot(**kwargs)
         plt.savefig(filename, format=img_format)
 
     def show(self, **kwargs):
         """Show the plot using matplotlib."""
-        plt = self.get_plot(**kwargs)
+        self.get_plot(**kwargs)
         plt.show()

--- a/pymatgen/vis/plotters.py
+++ b/pymatgen/vis/plotters.py
@@ -88,43 +88,43 @@ class SpectrumPlotter:
                 determination.
             ylim: Specifies the y-axis limits.
         """
-        plt = pretty_plot(12, 8)
+        ax = pretty_plot(12, 8)
         base = 0.0
-        i = 0
+        idx = 0
         for key, sp in self._spectra.items():
             if not self.stack:
-                plt.plot(
+                ax.plot(
                     sp.x,
-                    sp.y + self.yshift * i,
-                    color=self.colors[i],
+                    sp.y + self.yshift * idx,
+                    color=self.colors[idx],
                     label=str(key),
                     linewidth=3,
                 )
             else:
-                plt.fill_between(
+                ax.fill_between(
                     sp.x,
                     base,
-                    sp.y + self.yshift * i,
-                    color=self.colors[i],
+                    sp.y + self.yshift * idx,
+                    color=self.colors[idx],
                     label=str(key),
                     linewidth=3,
                 )
                 base = sp.y + base
-            plt.xlabel(sp.XLABEL)
-            plt.ylabel(sp.YLABEL)
-            i += 1
+            ax.xlabel(sp.XLABEL)
+            ax.ylabel(sp.YLABEL)
+            idx += 1
 
         if xlim:
-            plt.xlim(xlim)
+            ax.set_xlim(xlim)
         if ylim:
-            plt.ylim(ylim)
+            ax.set_ylim(ylim)
 
-        plt.legend()
-        leg = plt.gca().get_legend()
+        ax.legend()
+        leg = ax.get_legend()
         legend_text = leg.get_texts()  # all the text.Text instance in the legend
-        plt.setp(legend_text, fontsize=30)
+        ax.setp(legend_text, fontsize=30)
         plt.tight_layout()
-        return plt
+        return ax
 
     def save_plot(self, filename, img_format="eps", **kwargs):
         """

--- a/pymatgen/vis/plotters.py
+++ b/pymatgen/vis/plotters.py
@@ -122,7 +122,7 @@ class SpectrumPlotter:
         ax.legend()
         leg = ax.get_legend()
         legend_text = leg.get_texts()  # all the text.Text instance in the legend
-        ax.setp(legend_text, fontsize=30)
+        plt.setp(legend_text, fontsize=30)
         plt.tight_layout()
         return ax
 

--- a/pymatgen/vis/plotters.py
+++ b/pymatgen/vis/plotters.py
@@ -110,8 +110,8 @@ class SpectrumPlotter:
                     linewidth=3,
                 )
                 base = sp.y + base
-            ax.xlabel(sp.XLABEL)
-            ax.ylabel(sp.YLABEL)
+            ax.set_xlabel(sp.XLABEL)
+            ax.set_ylabel(sp.YLABEL)
             idx += 1
 
         if xlim:

--- a/pymatgen/vis/plotters.py
+++ b/pymatgen/vis/plotters.py
@@ -120,8 +120,7 @@ class SpectrumPlotter:
             ax.set_ylim(ylim)
 
         ax.legend()
-        leg = ax.get_legend()
-        legend_text = leg.get_texts()  # all the text.Text instance in the legend
+        legend_text = ax.get_legend().get_texts()  # all the text.Text instance in the legend
         plt.setp(legend_text, fontsize=30)
         plt.tight_layout()
         return ax

--- a/pymatgen/vis/plotters.py
+++ b/pymatgen/vis/plotters.py
@@ -119,8 +119,8 @@ class SpectrumPlotter:
 
         plt.legend()
         leg = plt.gca().get_legend()
-        ltext = leg.get_texts()  # all the text.Text instance in the legend
-        plt.setp(ltext, fontsize=30)
+        legend_text = leg.get_texts()  # all the text.Text instance in the legend
+        plt.setp(legend_text, fontsize=30)
         plt.tight_layout()
         return plt
 

--- a/tests/analysis/chemenv/connectivity/test_connected_components.py
+++ b/tests/analysis/chemenv/connectivity/test_connected_components.py
@@ -487,9 +487,7 @@ class TestConnectedComponent(PymatgenTest):
         cc = ccs[0]
         assert len(cc) == 12
         assert cc.periodicity == "3D"
-        assert (
-            cc.description()
-            == """Connected component with environment nodes :
+        expected_desc = """Connected component with environment nodes :
 Node #0 Li (O:6)
 Node #1 Li (O:6)
 Node #2 Li (O:6)
@@ -502,10 +500,9 @@ Node #8 P (T:4)
 Node #9 P (T:4)
 Node #10 P (T:4)
 Node #11 P (T:4)"""
-        )
-        assert (
-            cc.description(full=True)
-            == """Connected component with environment nodes :
+        assert cc.description() == expected_desc
+
+        expected_full_desc = """Connected component with environment nodes :
 Node #0 Li (O:6), connected to :
   - Node #1 Li (O:6) with delta image cells
      (-1 0 1)
@@ -742,7 +739,7 @@ Node #11 P (T:4), connected to :
   - Node #7 Fe (O:6) with delta image cells
      (0 -1 0)
      (0 0 0)"""
-        )
+        assert cc.description(full=True) == expected_full_desc
         # Get the connectivity for T:4 and O:6 separately and check results
         # Only tetrahedral
         sc.setup_environment_subgraph(environments_symbols=["T:4"])
@@ -810,9 +807,7 @@ Node #11 P (T:4), connected to :
         # come in a different order depending on
         # the algorithm used to get them.
         sorted_ccs = sorted(ccs, key=lambda x: sorted(x.graph.nodes())[0])
-        assert (
-            sorted_ccs[0].description(full=True)
-            == """Connected component with environment nodes :
+        expected_full_desc_0 = """Connected component with environment nodes :
 Node #0 Li (O:6), connected to :
   - Node #1 Li (O:6) with delta image cells
      (1 -1 1)
@@ -821,10 +816,9 @@ Node #1 Li (O:6), connected to :
   - Node #0 Li (O:6) with delta image cells
      (-1 0 -1)
      (-1 1 -1)"""
-        )
-        assert (
-            sorted_ccs[1].description(full=True)
-            == """Connected component with environment nodes :
+        assert sorted_ccs[0].description(full=True) == expected_full_desc_0
+
+        expected_full_desc_1 = """Connected component with environment nodes :
 Node #2 Li (O:6), connected to :
   - Node #3 Li (O:6) with delta image cells
      (0 -1 0)
@@ -833,7 +827,7 @@ Node #3 Li (O:6), connected to :
   - Node #2 Li (O:6) with delta image cells
      (0 0 0)
      (0 1 0)"""
-        )
+        assert sorted_ccs[1].description(full=True) == expected_full_desc_1
         # Get the connectivity for Mn octahedral only
         ccs = sc.get_connected_components(environments_symbols=["O:6"], only_atoms=["Mn"])
         assert list(sc.environment_subgraphs) == ["O:6-T:4", "O:6#Li", "O:6#Mn"]

--- a/tests/analysis/chemenv/coordination_environments/test_coordination_geometries.py
+++ b/tests/analysis/chemenv/coordination_environments/test_coordination_geometries.py
@@ -14,7 +14,7 @@ from pymatgen.util.testing import PymatgenTest
 
 __author__ = "waroquiers"
 
-allcg = AllCoordinationGeometries()
+all_cg = AllCoordinationGeometries()
 
 
 class FakeSite:
@@ -28,40 +28,37 @@ class TestCoordinationGeometries(PymatgenTest):
         expl_algo2 = ExplicitPermutationsAlgorithm.from_dict(expl_algo.as_dict)
         assert expl_algo.permutations == expl_algo2.permutations
 
-        sepplane_algos_oct = allcg["O:6"].algorithms
-        assert len(sepplane_algos_oct[0].safe_separation_permutations()) == 24
-        assert len(sepplane_algos_oct[1].safe_separation_permutations()) == 36
+        sep_plane_algos_oct = all_cg["O:6"].algorithms
+        assert len(sep_plane_algos_oct[0].safe_separation_permutations()) == 24
+        assert len(sep_plane_algos_oct[1].safe_separation_permutations()) == 36
 
-        sepplane_algos_oct_0 = SeparationPlane.from_dict(sepplane_algos_oct[0].as_dict)
-        assert sepplane_algos_oct[0].plane_points == sepplane_algos_oct_0.plane_points
-        assert sepplane_algos_oct[0].mirror_plane == sepplane_algos_oct_0.mirror_plane
-        assert sepplane_algos_oct[0].ordered_plane == sepplane_algos_oct_0.ordered_plane
-        assert sepplane_algos_oct[0].point_groups == sepplane_algos_oct_0.point_groups
-        assert sepplane_algos_oct[0].ordered_point_groups == sepplane_algos_oct_0.ordered_point_groups
+        sep_plane_algos_oct_0 = SeparationPlane.from_dict(sep_plane_algos_oct[0].as_dict)
+        assert sep_plane_algos_oct[0].plane_points == sep_plane_algos_oct_0.plane_points
+        assert sep_plane_algos_oct[0].mirror_plane == sep_plane_algos_oct_0.mirror_plane
+        assert sep_plane_algos_oct[0].ordered_plane == sep_plane_algos_oct_0.ordered_plane
+        assert sep_plane_algos_oct[0].point_groups == sep_plane_algos_oct_0.point_groups
+        assert sep_plane_algos_oct[0].ordered_point_groups == sep_plane_algos_oct_0.ordered_point_groups
         assert all(
-            np.array_equal(
-                perm,
-                sepplane_algos_oct_0.explicit_optimized_permutations[idx],
-            )
-            for idx, perm in enumerate(sepplane_algos_oct[0].explicit_optimized_permutations)
+            np.array_equal(perm, sep_plane_algos_oct_0.explicit_optimized_permutations[idx])
+            for idx, perm in enumerate(sep_plane_algos_oct[0].explicit_optimized_permutations)
         )
 
-        assert (
-            str(sepplane_algos_oct[0])
-            == "Separation plane algorithm with the following reference separation :\n[[4]] | [[0, 2, 1, 3]] | [[5]]"
+        expected_str = (
+            "Separation plane algorithm with the following reference separation :\n[[4]] | [[0, 2, 1, 3]] | [[5]]"
         )
+        assert str(sep_plane_algos_oct[0]) == expected_str
 
     def test_hints(self):
         hints = CoordinationGeometry.NeighborsSetsHints(hints_type="single_cap", options={"cap_index": 2, "csm_max": 8})
-        myhints = hints.hints({"csm": 12.0})
-        assert myhints == []
+        csm_hints = hints.hints({"csm": 12.0})
+        assert csm_hints == []
 
         hints2 = CoordinationGeometry.NeighborsSetsHints.from_dict(hints.as_dict())
         assert hints.hints_type == hints2.hints_type
         assert hints.options == hints2.options
 
     def test_coordination_geometry(self):
-        cg_oct = allcg["O:6"]
+        cg_oct = all_cg["O:6"]
         cg_oct2 = CoordinationGeometry.from_dict(cg_oct.as_dict())
 
         assert cg_oct.central_site == approx(cg_oct2.central_site)
@@ -185,13 +182,13 @@ class TestCoordinationGeometries(PymatgenTest):
             "  - coordination number : 1\n"
             "  - list of points :\n"
             "    - [0.0, 0.0, 1.0]\n"
-            "------------------------------------------------------------\n\n" in str(allcg)
+            "------------------------------------------------------------\n\n" in str(all_cg)
         )
 
         assert (
             "Coordination geometry type : Trigonal plane (IUPAC: TP-3 || IUCr: [3l])\n\n"
             "  - coordination number : 3\n"
-            "  - list of points :\n" in str(allcg)
+            "  - list of points :\n" in str(all_cg)
         )
 
         all_symbols = [
@@ -265,24 +262,24 @@ class TestCoordinationGeometries(PymatgenTest):
             "UNCLEAR",
         ]
 
-        assert len(allcg.get_geometries()) == 68
-        assert len(allcg.get_geometries(coordination=3)) == 3
-        assert sorted(allcg.get_geometries(returned="mp_symbol")) == sorted(all_symbols)
-        assert sorted(allcg.get_geometries(returned="mp_symbol", coordination=3)) == ["TL:3", "TS:3", "TY:3"]
+        assert len(all_cg.get_geometries()) == 68
+        assert len(all_cg.get_geometries(coordination=3)) == 3
+        assert sorted(all_cg.get_geometries(returned="mp_symbol")) == sorted(all_symbols)
+        assert sorted(all_cg.get_geometries(returned="mp_symbol", coordination=3)) == ["TL:3", "TS:3", "TY:3"]
 
-        assert allcg.get_symbol_name_mapping(coordination=3) == {
+        assert all_cg.get_symbol_name_mapping(coordination=3) == {
             "TY:3": "Triangular non-coplanar",
             "TL:3": "Trigonal plane",
             "TS:3": "T-shaped",
         }
-        assert allcg.get_symbol_cn_mapping(coordination=3) == {"TY:3": 3, "TL:3": 3, "TS:3": 3}
-        assert sorted(allcg.get_implemented_geometries(coordination=4, returned="mp_symbol")) == [
+        assert all_cg.get_symbol_cn_mapping(coordination=3) == {"TY:3": 3, "TL:3": 3, "TS:3": 3}
+        assert sorted(all_cg.get_implemented_geometries(coordination=4, returned="mp_symbol")) == [
             "S:4",
             "SS:4",
             "SY:4",
             "T:4",
         ]
-        assert sorted(allcg.get_not_implemented_geometries(returned="mp_symbol")) == [
+        assert sorted(all_cg.get_not_implemented_geometries(returned="mp_symbol")) == [
             "CO:11",
             "H:10",
             "S:10",
@@ -291,27 +288,27 @@ class TestCoordinationGeometries(PymatgenTest):
             "UNKNOWN",
         ]
 
-        assert allcg.get_geometry_from_name("Octahedron").mp_symbol == cg_oct.mp_symbol
+        assert all_cg.get_geometry_from_name("Octahedron").mp_symbol == cg_oct.mp_symbol
         with pytest.raises(LookupError) as exc:
-            allcg.get_geometry_from_name("Octahedran")
+            all_cg.get_geometry_from_name("Octahedran")
         assert str(exc.value) == "No coordination geometry found with name 'Octahedran'"
 
-        assert allcg.get_geometry_from_IUPAC_symbol("OC-6").mp_symbol == cg_oct.mp_symbol
+        assert all_cg.get_geometry_from_IUPAC_symbol("OC-6").mp_symbol == cg_oct.mp_symbol
         with pytest.raises(LookupError) as exc:
-            allcg.get_geometry_from_IUPAC_symbol("OC-7")
+            all_cg.get_geometry_from_IUPAC_symbol("OC-7")
         assert str(exc.value) == "No coordination geometry found with IUPAC symbol 'OC-7'"
 
-        assert allcg.get_geometry_from_IUCr_symbol("[6o]").mp_symbol == cg_oct.mp_symbol
+        assert all_cg.get_geometry_from_IUCr_symbol("[6o]").mp_symbol == cg_oct.mp_symbol
         with pytest.raises(LookupError) as exc:
-            allcg.get_geometry_from_IUCr_symbol("[6oct]")
+            all_cg.get_geometry_from_IUCr_symbol("[6oct]")
         assert str(exc.value) == "No coordination geometry found with IUCr symbol '[6oct]'"
 
         with pytest.raises(LookupError) as exc:
-            allcg.get_geometry_from_mp_symbol("O:7")
+            all_cg.get_geometry_from_mp_symbol("O:7")
         assert str(exc.value) == "No coordination geometry found with mp_symbol 'O:7'"
 
         assert (
-            allcg.pretty_print(maxcn=4)
+            all_cg.pretty_print(maxcn=4)
             == "+-------------------------+\n| Coordination geometries |\n+-------------------------+\n"
             "\n==>> CN = 1 <<==\n - S:1 : Single neighbor\n\n"
             "==>> CN = 2 <<==\n"
@@ -322,7 +319,7 @@ class TestCoordinationGeometries(PymatgenTest):
             " - SY:4 : Square non-coplanar\n - SS:4 : See-saw\n\n"
         )
         assert (
-            allcg.pretty_print(maxcn=2, type="all_geometries_latex")
+            all_cg.pretty_print(maxcn=2, type="all_geometries_latex")
             == "\\subsection*{Coordination 1}\n\n\\begin{itemize}\n"
             "\\item S:1 $\\rightarrow$ Single neighbor (IUPAC : None - IUCr : $[$1l$]$)\n"
             "\\end{itemize}\n\n\\subsection*{Coordination 2}\n\n\\begin{itemize}\n"
@@ -331,7 +328,7 @@ class TestCoordinationGeometries(PymatgenTest):
             "\\end{itemize}\n\n"
         )
         assert (
-            allcg.pretty_print(maxcn=2, type="all_geometries_latex_images")
+            all_cg.pretty_print(maxcn=2, type="all_geometries_latex_images")
             == "\\section*{Coordination 1}\n\n\\subsubsection*{S:1 : Single neighbor}\n\n"
             "IUPAC : None\n\nIUCr : [1l]\n\n\\begin{center}\n"
             "\\includegraphics[scale=0.15]{images/S_1.png}\n"
@@ -341,10 +338,10 @@ class TestCoordinationGeometries(PymatgenTest):
             "\\end{center}\n\n\\subsubsection*{A:2 : Angular}\n\nIUPAC : A-2\n\nIUCr : [2n]\n\n"
             "\\begin{center}\n\\includegraphics[scale=0.15]{images/A_2.png}\n\\end{center}\n\n"
         )
-        assert allcg.minpoints == {6: 2, 7: 2, 8: 2, 9: 2, 10: 2, 11: 2, 12: 2, 13: 3, 20: 2}
-        assert allcg.maxpoints == {6: 5, 7: 5, 8: 6, 9: 7, 10: 6, 11: 5, 12: 8, 13: 6, 20: 10}
-        assert allcg.maxpoints_inplane == {6: 5, 7: 5, 8: 6, 9: 7, 10: 6, 11: 5, 12: 8, 13: 6, 20: 10}
-        assert allcg.separations_cg == {
+        assert all_cg.minpoints == {6: 2, 7: 2, 8: 2, 9: 2, 10: 2, 11: 2, 12: 2, 13: 3, 20: 2}
+        assert all_cg.maxpoints == {6: 5, 7: 5, 8: 6, 9: 7, 10: 6, 11: 5, 12: 8, 13: 6, 20: 10}
+        assert all_cg.maxpoints_inplane == {6: 5, 7: 5, 8: 6, 9: 7, 10: 6, 11: 5, 12: 8, 13: 6, 20: 10}
+        assert all_cg.separations_cg == {
             6: {
                 (0, 3, 3): ["O:6", "T:6"],
                 (1, 4, 1): ["O:6"],

--- a/tests/analysis/chemenv/coordination_environments/test_structure_environments.py
+++ b/tests/analysis/chemenv/coordination_environments/test_structure_environments.py
@@ -32,26 +32,26 @@ class TestStructureEnvironments(PymatgenTest):
 
         struct_envs = StructureEnvironments.from_dict(dd)
         isite = 6
-        csm_and_maps_fig, csm_and_maps_subplot = struct_envs.get_csm_and_maps(isite=isite)
-        assert_array_almost_equal(csm_and_maps_subplot.lines[0].get_xydata().flatten(), [0, 0.53499332])
-        assert_array_almost_equal(csm_and_maps_subplot.lines[1].get_xydata().flatten(), [1, 0.47026441])
-        assert_array_almost_equal(csm_and_maps_subplot.lines[2].get_xydata().flatten(), [2, 0.00988778])
+        _csm_and_maps_fig, csm_and_maps_ax = struct_envs.get_csm_and_maps(isite=isite)
+        assert_array_almost_equal(csm_and_maps_ax.lines[0].get_xydata().flatten(), [0, 0.53499332])
+        assert_array_almost_equal(csm_and_maps_ax.lines[1].get_xydata().flatten(), [1, 0.47026441])
+        assert_array_almost_equal(csm_and_maps_ax.lines[2].get_xydata().flatten(), [2, 0.00988778])
 
-        environments_figure, environments_subplot = struct_envs.get_environments_figure(isite=isite)
+        _envs_fig, envs_ax = struct_envs.get_environments_figure(isite=isite)
         assert_array_almost_equal(
-            np.array(environments_subplot.patches[0].get_xy()),
+            np.array(envs_ax.patches[0].get_xy()),
             [[1, 1], [1, 0.99301365], [1.00179228, 0.99301365], [1.00179228, 1], [1, 1]],
         )
         assert_array_almost_equal(
-            np.array(environments_subplot.patches[1].get_xy()),
+            np.array(envs_ax.patches[1].get_xy()),
             [[1, 0.99301365], [1, 0], [1.00179228, 0], [1.00179228, 0.99301365], [1, 0.99301365]],
         )
         assert_array_almost_equal(
-            np.array(environments_subplot.patches[2].get_xy()),
+            np.array(envs_ax.patches[2].get_xy()),
             [[1.00179228, 1], [1.00179228, 0.99301365], [2.25, 0.99301365], [2.25, 1], [1.00179228, 1]],
         )
         assert_array_almost_equal(
-            np.array(environments_subplot.patches[3].get_xy()),
+            np.array(envs_ax.patches[3].get_xy()),
             [
                 [1.00179228, 0.99301365],
                 [1.00179228, 0],
@@ -63,7 +63,7 @@ class TestStructureEnvironments(PymatgenTest):
             ],
         )
         assert_array_almost_equal(
-            np.array(environments_subplot.patches[4].get_xy()),
+            np.array(envs_ax.patches[4].get_xy()),
             [[2.22376156, 0.0060837], [2.22376156, 0], [2.25, 0], [2.25, 0.0060837], [2.22376156, 0.0060837]],
         )
 

--- a/tests/analysis/test_phase_diagram.py
+++ b/tests/analysis/test_phase_diagram.py
@@ -39,28 +39,28 @@ class TestPDEntry(unittest.TestCase):
     def setUp(self):
         comp = Composition("LiFeO2")
         self.entry = PDEntry(comp, 53, name="mp-757614")
-        self.gpentry = GrandPotPDEntry(self.entry, {Element("O"): 1.5})
+        self.gp_entry = GrandPotPDEntry(self.entry, {Element("O"): 1.5})
 
     def test_get_energy(self):
         assert self.entry.energy == 53, "Wrong energy!"
-        assert self.gpentry.energy == 50, "Wrong energy!"
+        assert self.gp_entry.energy == 50, "Wrong energy!"
 
     def test_get_chemical_energy(self):
-        assert self.gpentry.chemical_energy == 3, "Wrong energy!"
+        assert self.gp_entry.chemical_energy == 3, "Wrong energy!"
 
     def test_get_energy_per_atom(self):
         assert self.entry.energy_per_atom == 53.0 / 4, "Wrong energy per atom!"
-        assert self.gpentry.energy_per_atom == 50.0 / 2, "Wrong energy per atom!"
+        assert self.gp_entry.energy_per_atom == 50.0 / 2, "Wrong energy per atom!"
 
     def test_get_name(self):
         assert self.entry.name == "mp-757614"
-        assert self.gpentry.name == "mp-757614"
+        assert self.gp_entry.name == "mp-757614"
 
     def test_composition(self):
         comp = self.entry.composition
         expected_comp = Composition("LiFeO2")
         assert comp == expected_comp
-        comp = self.gpentry.composition
+        comp = self.gp_entry.composition
         expected_comp = Composition("LiFe")
         assert comp == expected_comp
 
@@ -70,11 +70,11 @@ class TestPDEntry(unittest.TestCase):
 
     def test_is_element(self):
         assert not self.entry.is_element
-        assert not self.gpentry.is_element
+        assert not self.gp_entry.is_element
 
     def test_to_from_dict(self):
         d = self.entry.as_dict()
-        gpd = self.gpentry.as_dict()
+        gpd = self.gp_entry.as_dict()
         entry = PDEntry.from_dict(d)
 
         assert entry.name == "mp-757614"
@@ -917,12 +917,12 @@ class TestPDPlotter(unittest.TestCase):
 
     def test_mpl_plots(self):
         # Some very basic ("non")-tests. Just to make sure the methods are callable.
-        self.plotter_binary_mpl.get_plot().close()
-        self.plotter_ternary_mpl.get_plot().close()
-        self.plotter_quaternary_mpl.get_plot().close()
-        self.plotter_ternary_mpl.get_contour_pd_plot().close()
-        self.plotter_ternary_mpl.get_chempot_range_map_plot([Element("Li"), Element("O")]).close()
-        self.plotter_ternary_mpl.plot_element_profile(Element("O"), Composition("Li2O")).close()
+        self.plotter_binary_mpl.get_plot()
+        self.plotter_ternary_mpl.get_plot()
+        self.plotter_quaternary_mpl.get_plot()
+        self.plotter_ternary_mpl.get_contour_pd_plot()
+        self.plotter_ternary_mpl.get_chempot_range_map_plot([Element("Li"), Element("O")])
+        self.plotter_ternary_mpl.plot_element_profile(Element("O"), Composition("Li2O"))
 
     def test_plotly_plots(self):
         # Also very basic tests. Ensures callability and 2D vs 3D properties.

--- a/tests/analysis/test_pourbaix_diagram.py
+++ b/tests/analysis/test_pourbaix_diagram.py
@@ -5,6 +5,7 @@ import multiprocessing
 import unittest
 import warnings
 
+import matplotlib.pyplot as plt
 import numpy as np
 from monty.serialization import dumpfn, loadfn
 from pytest import approx
@@ -310,5 +311,5 @@ class TestPourbaixPlotter(unittest.TestCase):
         # binary system
         pd_binary = PourbaixDiagram(self.test_data["Ag-Te"], comp_dict={"Ag": 0.5, "Te": 0.5})
         binary_plotter = PourbaixPlotter(pd_binary)
-        plt = binary_plotter.plot_entry_stability(self.test_data["Ag-Te"][53])
-        plt.close()
+        ax = binary_plotter.plot_entry_stability(self.test_data["Ag-Te"][53])
+        assert isinstance(ax, plt.Axes)

--- a/tests/core/test_lattice.py
+++ b/tests/core/test_lattice.py
@@ -51,12 +51,10 @@ class LatticeTestCase(PymatgenTest):
         assert (
             format(self.lattice, ".3fl") == "[[10.000, 0.000, 0.000], [0.000, 10.000, 0.000], [0.000, 0.000, 10.000]]"
         )
-        assert (
-            format(self.lattice, ".3f")
-            == """10.000 0.000 0.000
+        lattice_str = """10.000 0.000 0.000
 0.000 10.000 0.000
 0.000 0.000 10.000"""
-        )
+        assert format(self.lattice, ".3f") == lattice_str
         assert format(self.lattice, ".1fp") == "{10.0, 10.0, 10.0, 90.0, 90.0, 90.0}"
 
     def test_init(self):

--- a/tests/electronic_structure/test_cohp.py
+++ b/tests/electronic_structure/test_cohp.py
@@ -159,10 +159,8 @@ class TestIcohpValue(unittest.TestCase):
         assert str(self.icohpvalue) == "ICOHP 1 between K1 and F2 ([-1, 0, 0]): -2.0 eV (Spin up)"
 
         # with spin polarization
-        assert (
-            str(self.icohpvalue_sp)
-            == "ICOHP 1 between K1 and F2 ([-1, 0, 0]): -1.1 eV (Spin up) and -1.0 eV (Spin down)"
-        )
+        expected = "ICOHP 1 between K1 and F2 ([-1, 0, 0]): -1.1 eV (Spin up) and -1.0 eV (Spin down)"
+        assert str(self.icohpvalue_sp) == expected
 
 
 class TestCombinedIcohp(unittest.TestCase):

--- a/tests/electronic_structure/test_plotter.py
+++ b/tests/electronic_structure/test_plotter.py
@@ -6,6 +6,7 @@ import unittest
 import warnings
 from shutil import which
 
+import matplotlib.pyplot as plt
 import numpy as np
 import scipy
 from pytest import approx
@@ -235,9 +236,9 @@ class TestBSDOSPlotter(unittest.TestCase):
     def test_methods(self):
         vasp_run = Vasprun(f"{TEST_FILES_DIR}/vasprun_Si_bands.xml")
         plotter = BSDOSPlotter()
-        plt = plotter.get_plot(vasp_run.get_band_structure(kpoints_filename=f"{TEST_FILES_DIR}/KPOINTS_Si_bands"))
+        ax = plotter.get_plot(vasp_run.get_band_structure(kpoints_filename=f"{TEST_FILES_DIR}/KPOINTS_Si_bands"))
         plt.close()
-        plt = plotter.get_plot(
+        ax = plotter.get_plot(
             vasp_run.get_band_structure(kpoints_filename=f"{TEST_FILES_DIR}/KPOINTS_Si_bands"),
             vasp_run.complete_dos,
         )
@@ -263,8 +264,8 @@ class TestBSDOSPlotter(unittest.TestCase):
                     d[i][j][k][b] = np.random.rand()
                     # d[i][j][k][c] = np.random.rand()
         band_struct = BandStructureSymmLine.from_dict(band_struct_dict)
-        plt = plotter.get_plot(band_struct)
-        plt.show()
+        ax = plotter.get_plot(band_struct)
+        assert isinstance(ax, plt.Axes)
 
 
 class TestPlotBZ(unittest.TestCase):

--- a/tests/electronic_structure/test_plotter.py
+++ b/tests/electronic_structure/test_plotter.py
@@ -313,10 +313,7 @@ class TestPlotBZ(unittest.TestCase):
         )
 
 
-x_trans = which("x_trans")
-
-
-@unittest.skipIf(not x_trans, "No x_trans.")
+@unittest.skipIf(not which("x_trans"), "No x_trans executable found")
 class TestBoltztrapPlotter(unittest.TestCase):
     def setUp(self):
         bz = BoltztrapAnalyzer.from_files(f"{TEST_FILES_DIR}/boltztrap/transp/")

--- a/tests/electronic_structure/test_plotter.py
+++ b/tests/electronic_structure/test_plotter.py
@@ -62,11 +62,11 @@ class TestDosPlotter(PymatgenTest):
 
         rc("text", usetex=False)
         self.plotter.add_dos_dict(self.dos.get_element_dos(), key_sort_func=lambda x: x.X)
-        plt = self.plotter.get_plot()
+        ax = self.plotter.get_plot()
+        assert len(ax.lines) == 2
         out_path = f"{self.tmp_path}/dosplot.png"
         self.plotter.save_plot(out_path)
         assert os.path.isfile(out_path)
-        plt.close("all")
 
     def test_get_plot_limits(self):
         # Tests limit determination and if inverted_axes case

--- a/tests/electronic_structure/test_plotter.py
+++ b/tests/electronic_structure/test_plotter.py
@@ -177,7 +177,7 @@ class TestBSPlotter(unittest.TestCase):
         rc("text", usetex=False)
 
         ax = self.plotter.get_plot()
-        assert ax.ylim() == (-4.0, 7.6348), "wrong ylim"
+        assert ax.get_ylim() == (-4.0, 7.6348), "wrong ylim"
         ax = self.plotter.get_plot(smooth=True)
         ax = self.plotter.get_plot(vbm_cbm_marker=True)
         self.plotter.save_plot("bsplot.png")
@@ -188,9 +188,9 @@ class TestBSPlotter(unittest.TestCase):
         # test plotter with 2 bandstructures
         ax = self.plotter_multi.get_plot()
         assert len(ax.get_lines()) == 874, "wrong number of lines"
-        assert ax.ylim() == (-10.0, 10.0), "wrong ylim"
+        assert ax.get_ylim() == (-10.0, 10.0), "wrong ylim"
         ax = self.plotter_multi.get_plot(zero_to_efermi=False)
-        assert ax.ylim() == (-15.2379, 12.67141266), "wrong ylim"
+        assert ax.get_ylim() == (-15.2379, 12.67141266), "wrong ylim"
         ax = self.plotter_multi.get_plot(smooth=True)
         self.plotter_multi.save_plot("bsplot.png")
         assert os.path.isfile("bsplot.png")

--- a/tests/electronic_structure/test_plotter.py
+++ b/tests/electronic_structure/test_plotter.py
@@ -80,8 +80,8 @@ class TestDosPlotter(PymatgenTest):
             limits_results = json.load(f)
 
         for item in limits_results:
-            plt = self.plotter.get_plot(xlim=item["energy_limit"], ylim=item["DOS_limit"])
-            param_dict = self.get_plot_attributes(plt)
+            ax = self.plotter.get_plot(xlim=item["energy_limit"], ylim=item["DOS_limit"])
+            param_dict = self.get_plot_attributes(ax)
             ax_invert = self.plotter.get_plot(invert_axes=True, xlim=item["DOS_limit"], ylim=item["energy_limit"])
             param_dict_invert = self.get_plot_attributes(ax_invert)
             assert item["energy_result"] == approx(param_dict["xaxis_limits"])
@@ -176,22 +176,22 @@ class TestBSPlotter(unittest.TestCase):
 
         rc("text", usetex=False)
 
-        plt = self.plotter.get_plot()
-        assert plt.ylim() == (-4.0, 7.6348), "wrong ylim"
-        plt = self.plotter.get_plot(smooth=True)
-        plt = self.plotter.get_plot(vbm_cbm_marker=True)
+        ax = self.plotter.get_plot()
+        assert ax.ylim() == (-4.0, 7.6348), "wrong ylim"
+        ax = self.plotter.get_plot(smooth=True)
+        ax = self.plotter.get_plot(vbm_cbm_marker=True)
         self.plotter.save_plot("bsplot.png")
         assert os.path.isfile("bsplot.png")
         os.remove("bsplot.png")
         plt.close("all")
 
         # test plotter with 2 bandstructures
-        plt = self.plotter_multi.get_plot()
-        assert len(plt.gca().get_lines()) == 874, "wrong number of lines"
-        assert plt.ylim() == (-10.0, 10.0), "wrong ylim"
-        plt = self.plotter_multi.get_plot(zero_to_efermi=False)
-        assert plt.ylim() == (-15.2379, 12.67141266), "wrong ylim"
-        plt = self.plotter_multi.get_plot(smooth=True)
+        ax = self.plotter_multi.get_plot()
+        assert len(ax.get_lines()) == 874, "wrong number of lines"
+        assert ax.ylim() == (-10.0, 10.0), "wrong ylim"
+        ax = self.plotter_multi.get_plot(zero_to_efermi=False)
+        assert ax.ylim() == (-15.2379, 12.67141266), "wrong ylim"
+        ax = self.plotter_multi.get_plot(smooth=True)
         self.plotter_multi.save_plot("bsplot.png")
         assert os.path.isfile("bsplot.png")
         os.remove("bsplot.png")
@@ -326,136 +326,136 @@ class TestBoltztrapPlotter(unittest.TestCase):
         warnings.simplefilter("default")
 
     def test_plot_carriers(self):
-        plt = self.plotter.plot_carriers()
-        assert len(plt.gca().get_lines()) == 7, "wrong number of lines"
-        assert plt.gca().get_lines()[0].get_data()[0][0] == -2.0702422655947665, "wrong 0 data in line 0"
-        assert plt.gca().get_lines()[0].get_data()[1][0] == 6.525490122298364e22, "wrong 1 data in line 0"
+        ax = self.plotter.plot_carriers()
+        assert len(ax.get_lines()) == 7, "wrong number of lines"
+        assert ax.get_lines()[0].get_data()[0][0] == -2.0702422655947665, "wrong 0 data in line 0"
+        assert ax.get_lines()[0].get_data()[1][0] == 6.525490122298364e22, "wrong 1 data in line 0"
         plt.close()
 
     def test_plot_complexity_factor_mu(self):
-        plt = self.plotter.plot_complexity_factor_mu()
-        assert len(plt.gca().get_lines()) == 2, "wrong number of lines"
-        assert plt.gca().get_lines()[0].get_data()[0][0] == -2.0702422655947665, "wrong 0 data in line 0"
-        assert plt.gca().get_lines()[0].get_data()[1][0] == 0.004708835456903449, "wrong 1 data in line 0"
+        ax = self.plotter.plot_complexity_factor_mu()
+        assert len(ax.get_lines()) == 2, "wrong number of lines"
+        assert ax.get_lines()[0].get_data()[0][0] == -2.0702422655947665, "wrong 0 data in line 0"
+        assert ax.get_lines()[0].get_data()[1][0] == 0.004708835456903449, "wrong 1 data in line 0"
         plt.close()
 
     def test_plot_conductivity_dop(self):
-        plt = self.plotter.plot_conductivity_dop()
-        assert len(plt.gca().get_lines()) == 8, "wrong number of lines"
-        assert plt.gca().get_lines()[0].get_data()[0][0] == 1000000000000000.0, "wrong 0 data in line 0"
-        assert plt.gca().get_lines()[0].get_data()[1][0] == 0.3801957596666667, "wrong 1 data in line 0"
+        ax = self.plotter.plot_conductivity_dop()
+        assert len(ax.get_lines()) == 8, "wrong number of lines"
+        assert ax.get_lines()[0].get_data()[0][0] == 1000000000000000.0, "wrong 0 data in line 0"
+        assert ax.get_lines()[0].get_data()[1][0] == 0.3801957596666667, "wrong 1 data in line 0"
         plt.close()
 
     def test_plot_conductivity_mu(self):
-        plt = self.plotter.plot_conductivity_mu()
-        assert len(plt.gca().get_lines()) == 9, "wrong number of lines"
-        assert plt.gca().get_lines()[0].get_data()[0][0] == -2.0702422655947665, "wrong 0 data in line 0"
-        assert plt.gca().get_lines()[0].get_data()[1][0] == 1965.1306, "wrong 1 data in line 0"
+        ax = self.plotter.plot_conductivity_mu()
+        assert len(ax.get_lines()) == 9, "wrong number of lines"
+        assert ax.get_lines()[0].get_data()[0][0] == -2.0702422655947665, "wrong 0 data in line 0"
+        assert ax.get_lines()[0].get_data()[1][0] == 1965.1306, "wrong 1 data in line 0"
         plt.close()
 
     def test_plot_conductivity_temp(self):
-        plt = self.plotter.plot_conductivity_temp()
-        assert len(plt.gca().get_lines()) == 6, "wrong number of lines"
-        assert plt.gca().get_lines()[0].get_data()[0][0] == 100, "wrong 0 data in line 0"
-        assert plt.gca().get_lines()[0].get_data()[1][0] == 0.3801957596666667, "wrong 1 data in line 0"
+        ax = self.plotter.plot_conductivity_temp()
+        assert len(ax.get_lines()) == 6, "wrong number of lines"
+        assert ax.get_lines()[0].get_data()[0][0] == 100, "wrong 0 data in line 0"
+        assert ax.get_lines()[0].get_data()[1][0] == 0.3801957596666667, "wrong 1 data in line 0"
         plt.close()
 
     def test_plot_dos(self):
-        plt = self.plotter.plot_dos()
-        assert len(plt.gca().get_lines()) == 3, "wrong number of lines"
-        assert plt.gca().get_lines()[0].get_data()[0][0] == -2.4197044934588674, "wrong 0 data in line 0"
-        assert plt.gca().get_lines()[0].get_data()[1][0] == 0.0, "wrong 1 data in line 0"
+        ax = self.plotter.plot_dos()
+        assert len(ax.get_lines()) == 3, "wrong number of lines"
+        assert ax.get_lines()[0].get_data()[0][0] == -2.4197044934588674, "wrong 0 data in line 0"
+        assert ax.get_lines()[0].get_data()[1][0] == 0.0, "wrong 1 data in line 0"
         plt.close()
 
     def test_plot_eff_mass_dop(self):
-        plt = self.plotter.plot_eff_mass_dop()
-        assert len(plt.gca().get_lines()) == 8, "wrong number of lines"
-        assert plt.gca().get_lines()[0].get_data()[0][0] == 1000000000000000.0, "wrong 0 data in line 0"
-        assert plt.gca().get_lines()[0].get_data()[1][0] == 1.4231240011719886, "wrong 1 data in line 0"
+        ax = self.plotter.plot_eff_mass_dop()
+        assert len(ax.get_lines()) == 8, "wrong number of lines"
+        assert ax.get_lines()[0].get_data()[0][0] == 1000000000000000.0, "wrong 0 data in line 0"
+        assert ax.get_lines()[0].get_data()[1][0] == 1.4231240011719886, "wrong 1 data in line 0"
         plt.close()
 
     def test_plot_eff_mass_temp(self):
-        plt = self.plotter.plot_eff_mass_temp()
-        assert len(plt.gca().get_lines()) == 6, "wrong number of lines"
-        assert plt.gca().get_lines()[0].get_data()[0][0] == 100, "wrong 0 data in line 0"
-        assert plt.gca().get_lines()[0].get_data()[1][0] == 1.4231240011719886, "wrong 1 data in line 0"
+        ax = self.plotter.plot_eff_mass_temp()
+        assert len(ax.get_lines()) == 6, "wrong number of lines"
+        assert ax.get_lines()[0].get_data()[0][0] == 100, "wrong 0 data in line 0"
+        assert ax.get_lines()[0].get_data()[1][0] == 1.4231240011719886, "wrong 1 data in line 0"
         plt.close()
 
     def test_plot_hall_carriers(self):
-        plt = self.plotter.plot_hall_carriers()
-        assert len(plt.gca().get_lines()) == 7, "wrong number of lines"
-        assert plt.gca().get_lines()[0].get_data()[0][0] == -2.0702422655947665, "wrong 0 data in line 0"
-        assert plt.gca().get_lines()[0].get_data()[1][0] == 9.538187273102463e17, "wrong 1 data in line 0"
+        ax = self.plotter.plot_hall_carriers()
+        assert len(ax.get_lines()) == 7, "wrong number of lines"
+        assert ax.get_lines()[0].get_data()[0][0] == -2.0702422655947665, "wrong 0 data in line 0"
+        assert ax.get_lines()[0].get_data()[1][0] == 9.538187273102463e17, "wrong 1 data in line 0"
         plt.close()
 
     def test_plot_power_factor_dop(self):
-        plt = self.plotter.plot_power_factor_dop()
-        assert len(plt.gca().get_lines()) == 8, "wrong number of lines"
-        assert plt.gca().get_lines()[0].get_data()[0][0] == 1000000000000000.0, "wrong 0 data in line 0"
-        assert plt.gca().get_lines()[0].get_data()[1][0] == 0.40606868935796925, "wrong 1 data in line 0"
+        ax = self.plotter.plot_power_factor_dop()
+        assert len(ax.get_lines()) == 8, "wrong number of lines"
+        assert ax.get_lines()[0].get_data()[0][0] == 1000000000000000.0, "wrong 0 data in line 0"
+        assert ax.get_lines()[0].get_data()[1][0] == 0.40606868935796925, "wrong 1 data in line 0"
         plt.close()
 
     def test_plot_power_factor_mu(self):
-        plt = self.plotter.plot_power_factor_mu()
-        assert len(plt.gca().get_lines()) == 9, "wrong number of lines"
-        assert plt.gca().get_lines()[0].get_data()[0][0] == -2.0702422655947665, "wrong 0 data in line 0"
-        assert plt.gca().get_lines()[0].get_data()[1][0] == 365.5514594136157, "wrong 1 data in line 0"
+        ax = self.plotter.plot_power_factor_mu()
+        assert len(ax.get_lines()) == 9, "wrong number of lines"
+        assert ax.get_lines()[0].get_data()[0][0] == -2.0702422655947665, "wrong 0 data in line 0"
+        assert ax.get_lines()[0].get_data()[1][0] == 365.5514594136157, "wrong 1 data in line 0"
         plt.close()
 
     def test_plot_power_factor_temp(self):
-        plt = self.plotter.plot_power_factor_temp()
-        assert len(plt.gca().get_lines()) == 6, "wrong number of lines"
-        assert plt.gca().get_lines()[0].get_data()[0][0] == 100, "wrong 0 data in line 0"
-        assert plt.gca().get_lines()[0].get_data()[1][0] == 0.40606868935796925, "wrong 1 data in line 0"
+        ax = self.plotter.plot_power_factor_temp()
+        assert len(ax.get_lines()) == 6, "wrong number of lines"
+        assert ax.get_lines()[0].get_data()[0][0] == 100, "wrong 0 data in line 0"
+        assert ax.get_lines()[0].get_data()[1][0] == 0.40606868935796925, "wrong 1 data in line 0"
         plt.close()
 
     def test_plot_seebeck_dop(self):
-        plt = self.plotter.plot_seebeck_dop()
-        assert len(plt.gca().get_lines()) == 8, "wrong number of lines"
-        assert plt.gca().get_lines()[0].get_data()[0][0] == 1000000000000000.0, "wrong 0 data in line 0"
-        assert plt.gca().get_lines()[0].get_data()[1][0] == 1050.8197666666667, "wrong 1 data in line 0"
+        ax = self.plotter.plot_seebeck_dop()
+        assert len(ax.get_lines()) == 8, "wrong number of lines"
+        assert ax.get_lines()[0].get_data()[0][0] == 1000000000000000.0, "wrong 0 data in line 0"
+        assert ax.get_lines()[0].get_data()[1][0] == 1050.8197666666667, "wrong 1 data in line 0"
         plt.close()
 
     def test_plot_seebeck_eff_mass_mu(self):
-        plt = self.plotter.plot_seebeck_eff_mass_mu()
-        assert len(plt.gca().get_lines()) == 2, "wrong number of lines"
-        assert plt.gca().get_lines()[0].get_data()[0][0] == -2.0702422655947665, "wrong 0 data in line 0"
-        assert plt.gca().get_lines()[0].get_data()[1][0] == 6412.881888198197, "wrong 1 data in line 0"
+        ax = self.plotter.plot_seebeck_eff_mass_mu()
+        assert len(ax.get_lines()) == 2, "wrong number of lines"
+        assert ax.get_lines()[0].get_data()[0][0] == -2.0702422655947665, "wrong 0 data in line 0"
+        assert ax.get_lines()[0].get_data()[1][0] == 6412.881888198197, "wrong 1 data in line 0"
         plt.close()
 
     def test_plot_seebeck_mu(self):
-        plt = self.plotter.plot_seebeck_mu()
-        assert len(plt.gca().get_lines()) == 9, "wrong number of lines"
-        assert plt.gca().get_lines()[0].get_data()[0][0] == -2.0702422655947665, "wrong 0 data in line 0"
-        assert plt.gca().get_lines()[0].get_data()[1][0] == -433.11096000000003, "wrong 1 data in line 0"
+        ax = self.plotter.plot_seebeck_mu()
+        assert len(ax.get_lines()) == 9, "wrong number of lines"
+        assert ax.get_lines()[0].get_data()[0][0] == -2.0702422655947665, "wrong 0 data in line 0"
+        assert ax.get_lines()[0].get_data()[1][0] == -433.11096000000003, "wrong 1 data in line 0"
         plt.close()
 
     def test_plot_seebeck_temp(self):
-        plt = self.plotter.plot_seebeck_temp()
-        assert len(plt.gca().get_lines()) == 6, "wrong number of lines"
-        assert plt.gca().get_lines()[0].get_data()[0][0] == 100, "wrong 0 data in line 0"
-        assert plt.gca().get_lines()[0].get_data()[1][0] == 1050.8197666666667, "wrong 1 data in line 0"
+        ax = self.plotter.plot_seebeck_temp()
+        assert len(ax.get_lines()) == 6, "wrong number of lines"
+        assert ax.get_lines()[0].get_data()[0][0] == 100, "wrong 0 data in line 0"
+        assert ax.get_lines()[0].get_data()[1][0] == 1050.8197666666667, "wrong 1 data in line 0"
         plt.close()
 
     def test_plot_zt_dop(self):
-        plt = self.plotter.plot_zt_dop()
-        assert len(plt.gca().get_lines()) == 8, "wrong number of lines"
-        assert plt.gca().get_lines()[0].get_data()[0][0] == 1000000000000000.0, "wrong 0 data in line 0"
-        assert plt.gca().get_lines()[0].get_data()[1][0] == 4.060682863129955e-05, "wrong 1 data in line 0"
+        ax = self.plotter.plot_zt_dop()
+        assert len(ax.get_lines()) == 8, "wrong number of lines"
+        assert ax.get_lines()[0].get_data()[0][0] == 1000000000000000.0, "wrong 0 data in line 0"
+        assert ax.get_lines()[0].get_data()[1][0] == 4.060682863129955e-05, "wrong 1 data in line 0"
         plt.close()
 
     def test_plot_zt_mu(self):
-        plt = self.plotter.plot_zt_mu()
-        assert len(plt.gca().get_lines()) == 9, "wrong number of lines"
-        assert plt.gca().get_lines()[0].get_data()[0][0] == -2.0702422655947665, "wrong 0 data in line 0"
-        assert plt.gca().get_lines()[0].get_data()[1][0] == 0.2153839699235254, "wrong 1 data in line 0"
+        ax = self.plotter.plot_zt_mu()
+        assert len(ax.get_lines()) == 9, "wrong number of lines"
+        assert ax.get_lines()[0].get_data()[0][0] == -2.0702422655947665, "wrong 0 data in line 0"
+        assert ax.get_lines()[0].get_data()[1][0] == 0.2153839699235254, "wrong 1 data in line 0"
         plt.close()
 
     def test_plot_zt_temp(self):
-        plt = self.plotter.plot_zt_temp()
-        assert len(plt.gca().get_lines()) == 6, "wrong number of lines"
-        assert plt.gca().get_lines()[0].get_data()[0][0] == 100, "wrong 0 data in line 0"
-        assert plt.gca().get_lines()[0].get_data()[1][0] == 4.060682863129955e-05, "wrong 1 data in line 0"
+        ax = self.plotter.plot_zt_temp()
+        assert len(ax.get_lines()) == 6, "wrong number of lines"
+        assert ax.get_lines()[0].get_data()[0][0] == 100, "wrong 0 data in line 0"
+        assert ax.get_lines()[0].get_data()[1][0] == 4.060682863129955e-05, "wrong 1 data in line 0"
         plt.close()
 
 

--- a/tests/io/feff/test_sets.py
+++ b/tests/io/feff/test_sets.py
@@ -186,15 +186,15 @@ TITLE sites: 4
         assert "TARGET" not in elnes.tags
 
     def test_postfeffset(self):
-        self.mp_xanes.write_input(os.path.join(".", "xanes_3"))
-        feff_dict_input = FEFFDictSet.from_directory(os.path.join(".", "xanes_3"))
-        assert feff_dict_input.tags == Tags.from_file(os.path.join(".", "xanes_3/feff.inp"))
-        assert str(feff_dict_input.header()) == str(Header.from_file(os.path.join(".", "xanes_3/HEADER")))
+        self.mp_xanes.write_input("xanes_3")
+        feff_dict_input = FEFFDictSet.from_directory("xanes_3")
+        assert feff_dict_input.tags == Tags.from_file("xanes_3/feff.inp")
+        assert str(feff_dict_input.header()) == str(Header.from_file("xanes_3/HEADER"))
         feff_dict_input.write_input("xanes_3_regen")
-        origin_tags = Tags.from_file(os.path.join(".", "xanes_3/PARAMETERS"))
-        output_tags = Tags.from_file(os.path.join(".", "xanes_3_regen/PARAMETERS"))
-        origin_mole = Atoms.cluster_from_file(os.path.join(".", "xanes_3/feff.inp"))
-        output_mole = Atoms.cluster_from_file(os.path.join(".", "xanes_3_regen/feff.inp"))
+        origin_tags = Tags.from_file("xanes_3/PARAMETERS")
+        output_tags = Tags.from_file("xanes_3_regen/PARAMETERS")
+        origin_mole = Atoms.cluster_from_file("xanes_3/feff.inp")
+        output_mole = Atoms.cluster_from_file("xanes_3_regen/feff.inp")
         original_mole_dist = np.array(origin_mole.distance_matrix[0, :]).astype(np.float64)
         output_mole_dist = np.array(output_mole.distance_matrix[0, :]).astype(np.float64)
         original_mole_shell = [x.species_string for x in origin_mole]
@@ -204,31 +204,31 @@ TITLE sites: 4
         assert origin_tags == output_tags
         assert original_mole_shell == output_mole_shell
 
-        shutil.rmtree(os.path.join(".", "xanes_3"))
-        shutil.rmtree(os.path.join(".", "xanes_3_regen"))
+        shutil.rmtree("xanes_3")
+        shutil.rmtree("xanes_3_regen")
 
         reci_mp_xanes = MPXANESSet(self.absorbing_atom, self.structure, user_tag_settings={"RECIPROCAL": ""})
         reci_mp_xanes.write_input("xanes_reci")
-        feff_reci_input = FEFFDictSet.from_directory(os.path.join(".", "xanes_reci"))
+        feff_reci_input = FEFFDictSet.from_directory("xanes_reci")
         assert "RECIPROCAL" in feff_reci_input.tags
 
         feff_reci_input.write_input("Dup_reci")
-        assert os.path.exists(os.path.join(".", "Dup_reci", "HEADER"))
-        assert os.path.exists(os.path.join(".", "Dup_reci", "feff.inp"))
-        assert os.path.exists(os.path.join(".", "Dup_reci", "PARAMETERS"))
-        assert not os.path.exists(os.path.join(".", "Dup_reci", "ATOMS"))
-        assert not os.path.exists(os.path.join(".", "Dup_reci", "POTENTIALS"))
+        assert os.path.exists("Dup_reci/HEADER")
+        assert os.path.exists("Dup_reci/feff.inp")
+        assert os.path.exists("Dup_reci/PARAMETERS")
+        assert not os.path.exists("Dup_reci/ATOMS")
+        assert not os.path.exists("Dup_reci/POTENTIALS")
 
-        tags_original = Tags.from_file(os.path.join(".", "xanes_reci/feff.inp"))
-        tags_output = Tags.from_file(os.path.join(".", "Dup_reci/feff.inp"))
+        tags_original = Tags.from_file("xanes_reci/feff.inp")
+        tags_output = Tags.from_file("Dup_reci/feff.inp")
         assert tags_original == tags_output
 
-        stru_orig = Structure.from_file(os.path.join(".", "xanes_reci/Co2O2.cif"))
-        stru_reci = Structure.from_file(os.path.join(".", "Dup_reci/Co2O2.cif"))
-        assert stru_orig == stru_reci
+        struct_orig = Structure.from_file("xanes_reci/Co2O2.cif")
+        struct_reci = Structure.from_file("Dup_reci/Co2O2.cif")
+        assert struct_orig == struct_reci
 
-        shutil.rmtree(os.path.join(".", "Dup_reci"))
-        shutil.rmtree(os.path.join(".", "xanes_reci"))
+        shutil.rmtree("Dup_reci")
+        shutil.rmtree("xanes_reci")
 
     def test_post_distdiff(self):
         feff_dict_input = FEFFDictSet.from_directory(f"{TEST_FILES_DIR}/feff_dist_test")
@@ -236,9 +236,9 @@ TITLE sites: 4
         assert str(feff_dict_input.header()) == str(Header.from_file(f"{TEST_FILES_DIR}/feff_dist_test/HEADER"))
         feff_dict_input.write_input("feff_dist_regen")
         origin_tags = Tags.from_file(f"{TEST_FILES_DIR}/feff_dist_test/PARAMETERS")
-        output_tags = Tags.from_file(os.path.join(".", "feff_dist_regen/PARAMETERS"))
+        output_tags = Tags.from_file("feff_dist_regen/PARAMETERS")
         origin_mole = Atoms.cluster_from_file(f"{TEST_FILES_DIR}/feff_dist_test/feff.inp")
-        output_mole = Atoms.cluster_from_file(os.path.join(".", "feff_dist_regen/feff.inp"))
+        output_mole = Atoms.cluster_from_file("feff_dist_regen/feff.inp")
         original_mole_dist = np.array(origin_mole.distance_matrix[0, :]).astype(np.float64)
         output_mole_dist = np.array(output_mole.distance_matrix[0, :]).astype(np.float64)
         original_mole_shell = [x.species_string for x in origin_mole]
@@ -248,7 +248,7 @@ TITLE sites: 4
         assert origin_tags == output_tags
         assert original_mole_shell == output_mole_shell
 
-        shutil.rmtree(os.path.join(".", "feff_dist_regen"))
+        shutil.rmtree("feff_dist_regen")
 
     def test_big_radius(self):
         struct = Structure.from_spacegroup("Pm-3m", Lattice.cubic(3.033043), ["Ti", "O"], [[0, 0, 0], [0.5, 0.5, 0.5]])

--- a/tests/io/lobster/test_lobsterenv.py
+++ b/tests/io/lobster/test_lobsterenv.py
@@ -786,15 +786,13 @@ class TestLobsterNeighbors(unittest.TestCase):
             only_bonds_to=["Na"],
         )
         assert plot_label == "1 x Na-Si (per bond)"
-        assert (
-            self.chemenvlobster0_NaSi.get_info_cohps_to_neighbors(
-                path_to_COHPCAR=f"{test_dir_env}/COHPCAR.lobster.NaSi.gz",
-                isites=[8],
-                onlycation_isites=False,
-                only_bonds_to=["Si"],
-            )[0]
-            == "3 x Si-Si (per bond)"
-        )
+        info = self.chemenvlobster0_NaSi.get_info_cohps_to_neighbors(
+            path_to_COHPCAR=f"{test_dir_env}/COHPCAR.lobster.NaSi.gz",
+            isites=[8],
+            onlycation_isites=False,
+            only_bonds_to=["Si"],
+        )[0]
+        assert info == "3 x Si-Si (per bond)"
 
         chemenvlobster1.plot_cohps_of_neighbors(
             path_to_COHPCAR=cohpcar_lobster_mp_190,

--- a/tests/io/test_xcrysden.py
+++ b/tests/io/test_xcrysden.py
@@ -25,9 +25,9 @@ class TestXSF(PymatgenTest):
     def test_to_string(self):
         structure = self.get_structure("Li2O")
         xsf = XSF(structure)
-        s = xsf.to_str()
+        xsf_str = xsf.to_str()
         assert (
-            s
+            xsf_str
             == """CRYSTAL
 # Primitive lattice vectors in Angstrom
 PRIMVEC
@@ -41,9 +41,9 @@ O     0.00000000000000     0.00000000000000     0.00000000000000
 Li     3.01213761017484     2.21364440998406     4.74632330032018
 Li     1.00309136982516     0.73718000001594     1.58060372967982"""
         )
-        s = xsf.to_str(atom_symbol=False)
+        xsf_str = xsf.to_str(atom_symbol=False)
         assert (
-            s
+            xsf_str
             == """CRYSTAL
 # Primitive lattice vectors in Angstrom
 PRIMVEC

--- a/tests/io/vasp/test_inputs.py
+++ b/tests/io/vasp/test_inputs.py
@@ -759,16 +759,14 @@ class TestKpoints:
         filepath = f"{TEST_FILES_DIR}/KPOINTS.explicit"
         kpoints = Kpoints.from_file(filepath)
         assert kpoints.kpts_weights is not None
-        assert (
-            str(kpoints).strip()
-            == """Example file
+        expected_kpt_str = """Example file
 4
 Cartesian
 0.0 0.0 0.0 1 None
 0.0 0.0 0.5 1 None
 0.0 0.5 0.5 2 None
 0.5 0.5 0.5 4 None"""
-        )
+        assert str(kpoints).strip() == expected_kpt_str
 
         filepath = f"{TEST_FILES_DIR}/KPOINTS.explicit_tet"
         kpoints = Kpoints.from_file(filepath)

--- a/tests/phonon/test_gruneisen.py
+++ b/tests/phonon/test_gruneisen.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import unittest
 
+import matplotlib.pyplot as plt
 from pytest import approx
 
 from pymatgen.util.testing import TEST_FILES_DIR
@@ -29,15 +30,15 @@ class TestGruneisenPhononBandStructureSymmLine(PymatgenTest):
 
     def test_plot(self):
         plotter = GruneisenPhononBSPlotter(bs=self.bs_symm_line)
-        plt = plotter.get_plot_gs()
-        assert str(type(plt)) == "<class 'module'>"
+        ax = plotter.get_plot_gs()
+        assert isinstance(ax, plt.Axes)
 
     def test_as_dict_from_dict(self):
         new_dict = self.bs_symm_line.as_dict()
         self.new_bs_symm_line = GruneisenPhononBandStructureSymmLine.from_dict(new_dict)
         plotter = GruneisenPhononBSPlotter(bs=self.new_bs_symm_line)
-        plt = plotter.get_plot_gs()
-        assert str(type(plt)) == "<class 'module'>"
+        ax = plotter.get_plot_gs()
+        assert isinstance(ax, plt.Axes)
 
 
 @unittest.skipIf(TotalDos is None, "Phonopy not present")
@@ -58,8 +59,8 @@ class TestGruneisenParameter(PymatgenTest):
 
     def test_plot(self):
         plotter = GruneisenPlotter(self.gruneisen_obj)
-        plt = plotter.get_plot(units="mev")
-        assert str(type(plt)) == "<class 'module'>"
+        ax = plotter.get_plot(units="mev")
+        assert isinstance(ax, plt.Axes)
 
     def test_fromdict_asdict(self):
         new_dict = self.gruneisen_obj.as_dict()

--- a/tests/phonon/test_plotter.py
+++ b/tests/phonon/test_plotter.py
@@ -37,9 +37,7 @@ class TestPhononDosPlotter(unittest.TestCase):
         self.plotter.add_dos("Total", self.dos)
         self.plotter.get_plot(units="mev")
         self.plotter_nostack.add_dos("Total", self.dos)
-        plt = self.plotter_nostack.get_plot(units="mev")
-
-        ax = plt.gca()
+        ax = self.plotter_nostack.get_plot(units="mev")
         assert isinstance(ax, axes.Axes)
         assert ax.get_ylabel() == "$\\mathrm{Density\\ of\\ states}$"
         assert ax.get_xlabel() == "$\\mathrm{Frequencies\\ (meV)}$"

--- a/tests/vis/test_plotters.py
+++ b/tests/vis/test_plotters.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 
+import matplotlib.pyplot as plt
 import numpy as np
 from monty.json import MontyDecoder
 
@@ -27,10 +28,11 @@ class TestSpectrumPlotter(PymatgenTest):
         xanes.y += np.random.randn(len(xanes.y)) * 0.005
         self.plotter.add_spectrum("LiCoO2 + noise", xanes)
         self.plotter.add_spectrum("LiCoO2 - replot", xanes, "k")
-        plt = self.plotter.get_plot()
-        self.plotter.save_plot("spectrum_plotter_test.eps")
-        os.remove("spectrum_plotter_test.eps")
-        plt.close("all")
+        ax = self.plotter.get_plot()
+        assert len(ax.lines) == 3
+        img_path = f"{self.tmp_path}/spectrum_plotter_test.png"
+        self.plotter.save_plot(img_path)
+        assert os.path.isfile(img_path)
 
     def test_get_stacked_plot(self):
         self.plotter = SpectrumPlotter(yshift=0.2, stack=True)
@@ -38,5 +40,6 @@ class TestSpectrumPlotter(PymatgenTest):
         xanes = self.xanes.copy()
         xanes.y += np.random.randn(len(xanes.y)) * 0.005
         self.plotter.add_spectrum("LiCoO2 + noise", xanes, "r")
-        plt = self.plotter.get_plot()
-        plt.close("all")
+        ax = self.plotter.get_plot()
+        assert isinstance(ax, plt.Axes)
+        assert len(ax.lines) == 0


### PR DESCRIPTION
Closes #3138.

`pymatgen` plotting methods using the `matplotlib` backend return the `matplotlib.pyplot` module (`plt`), rather than an object related to the plot itself, such as the `Figure` or `Axes`. This is suboptimal API design and inconsistent with the `plotly` backend, where a `go.Figure` object is returned.

This PR changes all plotting methods to return a `plt.Axes` object (same as [`pymatviz`](https://github.com/janosh/pymatviz)) instead of `plt`.

Reasons:
- **More Intuitive** as `Axes` actually contains the plot attributes (lines, legend, labels, etc.), and is more in line with what users may expect and what they typically interact with when customizing plots.
- **Consistency** with `pymatviz` and `pymatgen`'s own `plotly` backend.
