### PR TITLE
Generate SupercellTransformation from minimum boundary distance

### DIFF
--- a/pymatgen/transformations/standard_transformations.py
+++ b/pymatgen/transformations/standard_transformations.py
@@ -209,7 +209,7 @@ class OxidationStateRemovalTransformation(AbstractTransformation):
 
 
 class SupercellTransformation(AbstractTransformation):
-    """The RotationTransformation applies a rotation to a structure."""
+    """The SupercellTransformation replicates an unitcell to a supercell."""
 
     def __init__(self, scaling_matrix=((1, 0, 0), (0, 1, 0), (0, 0, 1))):
         """


### PR DESCRIPTION
## Summary
Added a method `from_boundary_distance` to `SupercellTransformation`, which can automatically find a `SupercellTransformation` that guarantee minimum distance periodic boundaries to be larger than a desired value (`min_boundary_dist`). This method allows high throughput generation of supercells for all 15,718 MP structures within 5 minutes.

## Major feature
Instead of simply expand lattice parameters with fixed lattice angles, this method also provides the option to rotate lattice angle (`allow_rotation`) to find potential supercell satisfying `min_boundary_dist` with a smaller number of atoms. Related evaluations have been done to all MP relaxed structures and listed below.

## Evaluation
All 15,718 MP ground-state structures are screened through with this implementation. As shown below, setting `allow_rotation=True` leads to noticeable decrease of supercell size for all three `min_boundary_dist` values of 6, 8, and 10 Å.
<img width="500" alt="Screenshot 2023-08-13 at 6 58 51 PM" src="https://github.com/materialsproject/pymatgen/assets/54908836/90c23485-de92-4fdf-8fa2-2eebc280d9b3">
<img width="500" alt="Screenshot 2023-08-13 at 6 59 33 PM" src="https://github.com/materialsproject/pymatgen/assets/54908836/9e5365c7-3ba7-4f47-9903-d7e86f722463">
<img width="500" alt="Screenshot 2023-08-13 at 7 06 51 PM" src="https://github.com/materialsproject/pymatgen/assets/54908836/9e699082-30b3-4018-8cad-d62afb7e5022">


## Todos
1. Unittests are not yet added.
2. Though this implementation tries to find smaller supercell with some lattice rotation, it does not guarantee to find the smallest possible supercell satisfying `min_boundary_dist`. Automatically identifying the smallest possible supercell seems a non-trivial task. Exhaustive enumeration needs more sophisticated scripts and more loops, while I expect the improvements to be small.