### PR TITLE
Breaking: remove deprecated keyword `properties` from `Species` 

### DIFF
--- a/pymatgen/analysis/chemenv/utils/scripts_utils.py
+++ b/pymatgen/analysis/chemenv/utils/scripts_utils.py
@@ -204,7 +204,7 @@ def compute_environments(chemenv_configuration):
     questions["m"] = "mp"
     lgf = LocalGeometryFinder()
     lgf.setup_parameters()
-    allcg = AllCoordinationGeometries()
+    all_cg = AllCoordinationGeometries()
     strategy_class = strategies_class_lookup[chemenv_configuration.package_options["default_strategy"]["strategy"]]
     # TODO: Add the possibility to change the parameters and save them in the chemenv_configuration
     default_strategy = strategy_class()
@@ -280,7 +280,7 @@ def compute_environments(chemenv_configuration):
                         ce = ces[0]
                         if ce is None:
                             continue
-                        the_cg = allcg.get_geometry_from_mp_symbol(ce[0])
+                        the_cg = all_cg.get_geometry_from_mp_symbol(ce[0])
                         msg = (
                             f"Environment for site #{site_idx} {reduced_formula}"
                             f" ({comp}) : {the_cg.name} ({ce[0]})\n"
@@ -288,7 +288,7 @@ def compute_environments(chemenv_configuration):
                     else:
                         msg = f"Environments for site #{site_idx} {reduced_formula} ({comp}) : \n"
                         for ce in ces:
-                            cg = allcg.get_geometry_from_mp_symbol(ce[0])
+                            cg = all_cg.get_geometry_from_mp_symbol(ce[0])
                             csm = ce[1]["other_symmetry_measures"]["csm_wcs_ctwcc"]
                             msg += f" - {cg.name} ({cg.mp_symbol}): {ce[2]:.2%} (csm : {csm:2f})\n"
                     if (

--- a/pymatgen/analysis/structure_prediction/substitutor.py
+++ b/pymatgen/analysis/structure_prediction/substitutor.py
@@ -90,12 +90,11 @@ class Substitutor(MSONable):
         Args:
             target_species:
                 a list of species with oxidation states
-                e.g., [Species('Li',1),Species('Ni',2), Species('O',-2)]
+                e.g., [Species('Li+'), Species('Ni2+'), Species('O-2')]
 
             structures_list:
-                a list of dictionary of the form {'structure':Structure object
-                ,'id':some id where it comes from}
-                the id can for instance refer to an ICSD id.
+                list of dictionary of the form {'structure': Structure object, 'id': some id where it comes from}
+                The id can for instance refer to an ICSD id.
 
             remove_duplicates:
                 if True, the duplicates in the predicted structures will
@@ -114,17 +113,17 @@ class Substitutor(MSONable):
         if len(list(set(target_species) & set(self.get_allowed_species()))) != len(target_species):
             raise ValueError("the species in target_species are not allowed for the probability model you are using")
 
-        for permut in itertools.permutations(target_species):
+        for permutation in itertools.permutations(target_species):
             for s in structures_list:
                 # check if: species are in the domain,
                 # and the probability of subst. is above the threshold
                 els = s["structure"].elements
                 if (
-                    len(els) == len(permut)
+                    len(els) == len(permutation)
                     and len(list(set(els) & set(self.get_allowed_species()))) == len(els)
-                    and self._sp.cond_prob_list(permut, els) > self._threshold
+                    and self._sp.cond_prob_list(permutation, els) > self._threshold
                 ):
-                    clean_subst = {els[i]: permut[i] for i in range(0, len(els)) if els[i] != permut[i]}
+                    clean_subst = {els[i]: permutation[i] for i in range(0, len(els)) if els[i] != permutation[i]}
 
                     if len(clean_subst) == 0:
                         continue
@@ -138,7 +137,7 @@ class Substitutor(MSONable):
                             history=[{"source": s["id"]}],
                             other_parameters={
                                 "type": "structure_prediction",
-                                "proba": self._sp.cond_prob_list(permut, els),
+                                "proba": self._sp.cond_prob_list(permutation, els),
                             },
                         )
                         result.append(ts)

--- a/pymatgen/core/periodic_table.py
+++ b/pymatgen/core/periodic_table.py
@@ -290,28 +290,28 @@ class ElementBase(Enum):
                 try:
                     val = float(val)
                 except ValueError:
-                    nobracket = re.sub(r"\(.*\)", "", val)
-                    toks = nobracket.replace("about", "").strip().split(" ", 1)
-                    if len(toks) == 2:
+                    no_bracket = re.sub(r"\(.*\)", "", val)
+                    tokens = no_bracket.replace("about", "").strip().split(" ", 1)
+                    if len(tokens) == 2:
                         try:
-                            if "10<sup>" in toks[1]:
-                                base_power = re.findall(r"([+-]?\d+)", toks[1])
+                            if "10<sup>" in tokens[1]:
+                                base_power = re.findall(r"([+-]?\d+)", tokens[1])
                                 factor = "e" + base_power[1]
-                                if toks[0] in ["&gt;", "high"]:
-                                    toks[0] = "1"  # return the border value
-                                toks[0] += factor
+                                if tokens[0] in ["&gt;", "high"]:
+                                    tokens[0] = "1"  # return the border value
+                                tokens[0] += factor
                                 if item == "electrical_resistivity":
                                     unit = "ohm m"
                                 elif item == "coefficient_of_linear_thermal_expansion":
                                     unit = "K^-1"
                                 else:
-                                    unit = toks[1]
-                                val = FloatWithUnit(toks[0], unit)
+                                    unit = tokens[1]
+                                val = FloatWithUnit(tokens[0], unit)
                             else:
-                                unit = toks[1].replace("<sup>", "^").replace("</sup>", "").replace("&Omega;", "ohm")
+                                unit = tokens[1].replace("<sup>", "^").replace("</sup>", "").replace("&Omega;", "ohm")
                                 units = Unit(unit)
                                 if set(units).issubset(SUPPORTED_UNIT_NAMES):
-                                    val = FloatWithUnit(toks[0], unit)
+                                    val = FloatWithUnit(tokens[0], unit)
                         except ValueError:
                             # Ignore error. val will just remain a string.
                             pass

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -617,8 +617,7 @@ class SiteCollection(collections.abc.Sequence, metaclass=ABCMeta):
             for sp, occu in site.species.items():
                 sym = sp.symbol
                 oxi_state = getattr(sp, "oxi_state", None)
-                props = {"spin": spins.get(str(sp), spins.get(sym))}
-                species = Species(sym, oxidation_state=oxi_state, properties=props)
+                species = Species(sym, oxidation_state=oxi_state, spin=spins.get(str(sp), spins.get(sym)))
                 new_species[species] = occu
             site.species = Composition(new_species)
 
@@ -638,7 +637,7 @@ class SiteCollection(collections.abc.Sequence, metaclass=ABCMeta):
             for sp, occu in site.species.items():
                 sym = sp.symbol
                 oxi_state = getattr(sp, "oxi_state", None)
-                new_species[Species(sym, oxidation_state=oxi_state, properties={"spin": spin})] = occu
+                new_species[Species(sym, oxidation_state=oxi_state, spin=spin)] = occu
             site.species = Composition(new_species)
 
     def remove_spin(self) -> None:
@@ -3648,7 +3647,7 @@ class Structure(IStructure, collections.abc.MutableSequence):
             s[0] = "Fe", [0.5, 0.5, 0.5]
             Replaces site and *fractional* coordinates. Any properties
             are inherited from current site.
-            s[0] = "Fe", [0.5, 0.5, 0.5], {"spin": 2}
+            s[0] = "Fe", [0.5, 0.5, 0.5], spin=2
             Replaces site and *fractional* coordinates and properties.
 
             s[(0, 2, 3)] = "Fe"

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -5308,11 +5308,11 @@ class WSWQ(MSONable):
         return self.me_real + 1j * self.me_imag
 
     @classmethod
-    def from_file(cls, filename) -> WSWQ:
+    def from_file(cls, filename: str) -> WSWQ:
         """Constructs a WSWQ object from a file.
 
         Args:
-            filename: Name of WSWQ file.
+            filename (str): Name of WSWQ file.
 
         Returns:
             WSWQ object.

--- a/pymatgen/transformations/advanced_transformations.py
+++ b/pymatgen/transformations/advanced_transformations.py
@@ -768,8 +768,8 @@ class MagOrderingTransformation(AbstractTransformation):
         dummy_species_symbols = [next(dummy_species_gen) for i in range(len(order_parameters))]
         dummy_species = [
             {
-                DummySpecies(symbol, properties={"spin": Spin.up}): constraint.order_parameter,
-                DummySpecies(symbol, properties={"spin": Spin.down}): 1 - constraint.order_parameter,
+                DummySpecies(symbol, spin=Spin.up): constraint.order_parameter,
+                DummySpecies(symbol, spin=Spin.down): 1 - constraint.order_parameter,
             }
             for symbol, constraint in zip(dummy_species_symbols, order_parameters)
         ]

--- a/tests/alchemy/test_filters.py
+++ b/tests/alchemy/test_filters.py
@@ -25,23 +25,23 @@ class TestContainsSpecieFilter(PymatgenTest):
         lattice = Lattice([[3.0, 0.0, 0.0], [1.0, 3.0, 0], [0, -2.0, 3.0]])
         struct = Structure(lattice, [{"Si4+": 0.5, "O2-": 0.25, "P5+": 0.25}] * 4, coords)
 
-        species1 = [Species("Si", 5), Species("Mg", 2)]
+        species1 = [Species("Si5+"), Species("Mg2+")]
         f1 = ContainsSpecieFilter(species1, strict_compare=True, AND=False)
         assert not f1.test(struct), "Incorrect filter"
         f2 = ContainsSpecieFilter(species1, strict_compare=False, AND=False)
         assert f2.test(struct), "Incorrect filter"
-        species2 = [Species("Si", 4), Species("Mg", 2)]
+        species2 = [Species("Si4+"), Species("Mg2+")]
         f3 = ContainsSpecieFilter(species2, strict_compare=True, AND=False)
         assert f3.test(struct), "Incorrect filter"
         f4 = ContainsSpecieFilter(species2, strict_compare=False, AND=False)
         assert f4.test(struct), "Incorrect filter"
 
-        species3 = [Species("Si", 5), Species("O", -2)]
+        species3 = [Species("Si5+"), Species("O2-")]
         f5 = ContainsSpecieFilter(species3, strict_compare=True, AND=True)
         assert not f5.test(struct), "Incorrect filter"
         f6 = ContainsSpecieFilter(species3, strict_compare=False, AND=True)
         assert f6.test(struct), "Incorrect filter"
-        species4 = [Species("Si", 4), Species("Mg", 2)]
+        species4 = [Species("Si4+"), Species("Mg2+")]
         f7 = ContainsSpecieFilter(species4, strict_compare=True, AND=True)
         assert not f7.test(struct), "Incorrect filter"
         f8 = ContainsSpecieFilter(species4, strict_compare=False, AND=True)

--- a/tests/analysis/chemenv/coordination_environments/test_structure_environments.py
+++ b/tests/analysis/chemenv/coordination_environments/test_structure_environments.py
@@ -180,7 +180,7 @@ class TestStructureEnvironments(PymatgenTest):
         assert stats["coordination_environments_atom_present"] == {"T:4": {"Si": 3}}
         assert stats["fraction_atom_coordination_environments_present"] == {"Si": {"T:4": 1}}
 
-        site_info_ce = lse.get_site_info_for_specie_ce(specie=Species("Si", 4), ce_symbol="T:4")
+        site_info_ce = lse.get_site_info_for_specie_ce(specie=Species("Si4+"), ce_symbol="T:4")
         assert_array_almost_equal(site_info_ce["fractions"], [1, 1, 1])
         assert_array_almost_equal(
             site_info_ce["csms"],
@@ -188,7 +188,7 @@ class TestStructureEnvironments(PymatgenTest):
         )
         assert site_info_ce["isites"] == [6, 7, 8]
 
-        site_info_allces = lse.get_site_info_for_specie_allces(specie=Species("Si", 4))
+        site_info_allces = lse.get_site_info_for_specie_allces(specie=Species("Si4+"))
 
         assert site_info_allces["T:4"] == site_info_ce
 

--- a/tests/analysis/magnetism/test_analyzer.py
+++ b/tests/analysis/magnetism/test_analyzer.py
@@ -90,10 +90,7 @@ class TestCollinearMagneticStructureAnalyzer(unittest.TestCase):
         assert "magmom" not in Fe_spin.site_properties
 
         # test with disorder on magnetic site
-        self.Fe[0] = {
-            Species("Fe", oxidation_state=0, properties={"spin": 5}): 0.5,
-            "Ni": 0.5,
-        }
+        self.Fe[0] = {Species("Fe", 0, spin=5): 0.5, "Ni": 0.5}
         with pytest.raises(
             NotImplementedError,
             match="CollinearMagneticStructureAnalyzer not implemented for disordered structures,"

--- a/tests/analysis/test_bond_valence.py
+++ b/tests/analysis/test_bond_valence.py
@@ -37,8 +37,8 @@ class TestBVAnalyzer(PymatgenTest):
     def test_get_oxi_state_structure(self):
         struct = Structure.from_file(f"{TEST_FILES_DIR}/LiMn2O4.json")
         oxi_struct = self.analyzer.get_oxi_state_decorated_structure(struct)
-        assert Species("Mn", 3) in oxi_struct.composition.elements
-        assert Species("Mn", 4) in oxi_struct.composition.elements
+        assert Species("Mn3+") in oxi_struct.composition.elements
+        assert Species("Mn4+") in oxi_struct.composition.elements
 
 
 class TestBondValenceSum(PymatgenTest):

--- a/tests/analysis/test_energy_models.py
+++ b/tests/analysis/test_energy_models.py
@@ -64,10 +64,10 @@ class TestIsingModel(unittest.TestCase):
         from pymatgen.core.periodic_table import Species
 
         struct = Structure.from_file(f"{TEST_FILES_DIR}/LiFePO4.cif")
-        struct.replace_species({"Fe": Species("Fe", 2, {"spin": 4})})
+        struct.replace_species({"Fe": Species("Fe", 2, spin=4)})
         assert m.get_energy(struct) == approx(172.81260515787977)
-        struct[4] = Species("Fe", 2, {"spin": -4})
-        struct[5] = Species("Fe", 2, {"spin": -4})
+        struct[4] = Species("Fe", 2, spin=-4)
+        struct[5] = Species("Fe", 2, spin=-4)
         assert m.get_energy(struct) == approx(51.97424405382921)
 
     def test_to_from_dict(self):

--- a/tests/core/test_periodic_table.py
+++ b/tests/core/test_periodic_table.py
@@ -359,8 +359,10 @@ class SpeciesTestCase(PymatgenTest):
         self.specie4 = Species("Fe", 2, spin=5)
 
     def test_init(self):
-        with pytest.raises(ValueError, match="magmom is not a supported property"):
-            Species("Fe", 2, {"magmom": 5})
+        assert Species("Fe", 2) == Species("Fe2+")
+        assert Species("Fe", 2, spin=2) == Species("Fe2+", spin=2)
+        assert Species("O2-") == Species("O", -2)
+        assert Species("O0+", spin=2) == Species("O", 0, spin=2)
 
     def test_ionic_radius(self):
         assert self.specie2.ionic_radius == 78.5 / 100
@@ -547,7 +549,6 @@ class DummySpeciesTestCase(unittest.TestCase):
         assert r == [DummySpecies("X"), Element.Fe]
         assert DummySpecies("X", 3) < DummySpecies("X", 4)
 
-    def test_immutable(self):
         sp = Species("Fe", 2, spin=5)
         with pytest.raises(AttributeError) as exc:
             sp.spin = 6
@@ -555,7 +556,6 @@ class DummySpeciesTestCase(unittest.TestCase):
         assert "can't set attribute" in str(exc.value) or "property 'spin' of 'Species' object has no setter" in str(
             exc.value
         )  # 'can't set attribute' on Linux, for some reason different message on Windows and Mac
-        sp.properties["spin"] = 7
         assert sp.spin == 5
 
 

--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -214,8 +214,8 @@ class TestIStructure(PymatgenTest):
         struct = IStructure(
             self.lattice,
             [
-                {Species("O", -2, properties={"spin": 3}): 1.0},
-                {Species("Mg", 2, properties={"spin": 2}): 0.8},
+                {Species("O", -2, spin=3): 1.0},
+                {Species("Mg", 2, spin=2): 0.8},
             ],
             coords,
             site_properties={"magmom": [5, -5]},
@@ -260,7 +260,7 @@ class TestIStructure(PymatgenTest):
                         {
                             "occu": 1.0,
                             "oxidation_state": -2,
-                            "properties": {"spin": 3},
+                            "spin": 3,
                             "element": "O",
                         }
                     ],
@@ -275,7 +275,7 @@ class TestIStructure(PymatgenTest):
                         {
                             "occu": 0.8,
                             "oxidation_state": 2,
-                            "properties": {"spin": 2},
+                            "spin": 2,
                             "element": "Mg",
                         }
                     ],
@@ -613,7 +613,7 @@ Direct
     #         },
     #         "sites": [
     #             {
-    #                "species": [{"element": "Mn", "oxidation_state": 0, "properties": {"spin": Spin.down}, "occu": 1}],
+    #                "species": [{"element": "Mn", "oxidation_state": 0, "spin": Spin.down, "occu": 1}],
     #                 "abc": [0.0, 0.5, 0.5],
     #                 "xyz": [2.8730499999999997, 3.83185, 4.1055671618015446e-16],
     #                 "label": "Mn0+,spin=-1",

--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -222,7 +222,7 @@ class TestIStructure(PymatgenTest):
         )
         d = struct.as_dict()
         assert d["sites"][0]["properties"]["magmom"] == 5
-        assert d["sites"][0]["species"][0]["properties"]["spin"] == 3
+        assert d["sites"][0]["species"][0]["spin"] == 3
 
         d = struct.as_dict(0)
         assert "volume" not in d["lattice"]

--- a/tests/io/vasp/test_sets.py
+++ b/tests/io/vasp/test_sets.py
@@ -346,7 +346,7 @@ class TestMITMPRelaxSet(PymatgenTest):
         incar = MITRelaxSet(struct, sort_structure=False).incar
         assert incar["MAGMOM"] == [5.2, -4.5]
 
-        struct = Structure(lattice, [Species("Fe", 2, {"spin": 4.1}), "Mn"], coords)
+        struct = Structure(lattice, [Species("Fe2+", spin=4.1), "Mn"], coords)
         incar = MPRelaxSet(struct).incar
         assert incar["MAGMOM"] == [5, 4.1]
 


### PR DESCRIPTION
4b9033a0e remove deprecated kwarg `properties` from `Species`+`DummySpecies`
38b30a340 snake_case vars
48b8f1678 fix `Structure.add_spin_by_element` and `add_spin_by_site`
4ffc37130 fix tests that used `Species(properties={...})`
33283b0fb update `Substitutor.pred_from_structures` doc str
7ba3245f5 fix `MagOrderingTransformation._add_dummy_species`