### PR TITLE
Ion: handle dissolved gas formulas

### DIFF
--- a/pymatgen/core/ion.py
+++ b/pymatgen/core/ion.py
@@ -166,6 +166,12 @@ class Ion(Composition, MSONable, Stringify):
         # butanol
         elif formula == "H10C4O":
             formula = "C4H9OH"
+        elif formula == "O" and factor % 3 == 0:
+            formula = "O3"
+            factor /= 3
+        elif formula in ["O", "N", "F", "Cl", "H"] and factor % 2 == 0:
+            formula += "2"
+            factor /= 2
 
         return formula, factor
 

--- a/pymatgen/core/ion.py
+++ b/pymatgen/core/ion.py
@@ -75,8 +75,9 @@ class Ion(Composition, MSONable, Stringify):
 
     @property
     def formula(self) -> str:
-        """Returns a formula string, with elements sorted by electronegativity,
-        e.g., Li4 Fe4 P4 O16.
+        """Returns a formula string with appended charge. The
+        charge is written with the sign preceding the magnitude, e.g.,
+        'Ca1 +2'. Uncharged species have "(aq)" appended, e.g. "O2 (aq)".
         """
         formula = super().formula
         return f"{formula} {charge_string(self.charge, brackets=False)}"
@@ -179,7 +180,7 @@ class Ion(Composition, MSONable, Stringify):
     def reduced_formula(self) -> str:
         """Returns a reduced formula string with appended charge. The
         charge is placed in brackets with the sign preceding the magnitude, e.g.,
-        'Ca[+2]'.
+        'Ca[+2]'. Uncharged species have "(aq)" appended, e.g. "O2(aq)".
         """
         reduced_formula = super().reduced_formula
         charge = self._charge / self.get_reduced_composition_and_factor()[1]

--- a/tests/core/test_ion.py
+++ b/tests/core/test_ion.py
@@ -56,6 +56,11 @@ class TestIon(unittest.TestCase):
             ("Cl-", "Cl[-1]"),
             ("H+", "H[+1]"),
             ("F-", "F[-1]"),
+            ("F2", "F2(aq)"),
+            ("H2", "H2(aq)"),
+            ("O3", "O3(aq)"),
+            ("O2", "O2(aq)"),
+            ("N2", "N2(aq)"),
             ("H4O4", "H2O2(aq)"),
             ("OH-", "OH[-1]"),
             ("CH3COO-", "CH3COO[-1]"),
@@ -74,6 +79,12 @@ class TestIon(unittest.TestCase):
 
         assert Ion.from_formula("Fe(OH)4+").get_reduced_formula_and_factor(hydrates=False) == ("Fe(OH)4", 1)
         assert Ion.from_formula("Zr(OH)4").get_reduced_formula_and_factor(hydrates=False) == ("Zr(OH)4", 1)
+        assert Ion.from_formula("Zr(OH)4").get_reduced_formula_and_factor(hydrates=True) == ("ZrO2.2H2O", 1)
+        assert Ion.from_formula("O").get_reduced_formula_and_factor(hydrates=False) == ("O", 1)
+        assert Ion.from_formula("O2").get_reduced_formula_and_factor(hydrates=False) == ("O2", 1)
+        assert Ion.from_formula("O3").get_reduced_formula_and_factor(hydrates=False) == ("O3", 1)
+        assert Ion.from_formula("O6").get_reduced_formula_and_factor(hydrates=False) == ("O3", 2)
+        assert Ion.from_formula("N8").get_reduced_formula_and_factor(hydrates=False) == ("N2", 4)
 
     def test_formula(self):
         correct_formulas = [


### PR DESCRIPTION
## Summary

`Ion.reduced_formula` does not correctly handle dissolved gas molecules, such as `O2`, for example:

```
>>> Ion.from_formula('O2').get_reduced_formula_and_factor()
('O', 2)
>>> Ion.from_formula('O2').formula
'O2 (aq)'
>>> Ion.from_formula('O2').reduced_formula
'O(aq)'
```
 
This PR modifies `Ion.get_reduced_formula_and_factor` to correctly report dissolved formulas of dissolved gases H2, N2, O2, F2, Cl2, and O3. It also updates the docstrings of `formula` and `reduced_formula`.

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
