### PR TITLE
[WIP] revise MatPESStaticSet, inherit from DictSet 

### DIFF
--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -1232,6 +1232,8 @@ class MatPESStaticSet(DictSet):
             structure (Structure): Structure from previous run.
             functional ('R2SCAN' | 'R2SCAN+U' | 'PBE' | 'PBE+U'): Which functional to use and whether to include
                 Hubbard U corrections. Defaults to 'PBE'.
+            prev_incar (Incar): Incar file from previous run. We do not want to update the current INCAR
+            settings except the new settings added by Custodian.
             **kwargs: Passed to MPStaticSet.
         """
         super().__init__(structure, MatPESStaticSet.CONFIG, **kwargs)

--- a/tests/io/vasp/test_sets.py
+++ b/tests/io/vasp/test_sets.py
@@ -744,7 +744,6 @@ class TestMatPESStaticSet(PymatgenTest):
         incar = default.incar
         assert incar["GGA"] == "Pe"
         assert incar["ALGO"] == "Normal"
-        assert incar["EDIFF"] == 1.0e-05
         assert incar["KSPACING"] == 0.22
         assert incar["ISMEAR"] == 0
         assert incar["SIGMA"] == 0.05
@@ -764,7 +763,6 @@ class TestMatPESStaticSet(PymatgenTest):
         incar_fd = default_from_dict.incar
         assert incar_fd["GGA"] == "Pe"
         assert incar_fd["ALGO"] == "Normal"
-        assert incar_fd["EDIFF"] == 1.0e-05
         assert incar_fd["KSPACING"] == 0.22
         assert incar_fd["ISMEAR"] == 0
         assert incar_fd["SIGMA"] == 0.05
@@ -787,7 +785,6 @@ class TestMatPESStaticSet(PymatgenTest):
         incar_prev = default_prev.incar
         assert incar_prev["GGA"] == "Pe"
         assert incar_prev["ALGO"] == "Normal"
-        assert incar_prev["EDIFF"] == 1.0e-05
         assert incar_prev["KSPACING"] == 0.22
         assert incar_prev["ISMEAR"] == 0
         assert incar_prev["SIGMA"] == 0.05


### PR DESCRIPTION
## Summary
Related PR: #3254 
Major changes:

- feature 1: Revise MatPESStaticSet, inherit from DictSet 


## Todos

Check if the previous Incar will override the default MatPESStaticSet Incar.
Check if the new settings added by Custodian will be updated.


## Checklist

- [ ] Google format doc strings added. Check with `ruff`.
- [ ] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
