### PR TITLE
 Corrections for MatPESStaticSet and its tests

### DIFF
--- a/pymatgen/io/vasp/MatPESStaticSet.yaml
+++ b/pymatgen/io/vasp/MatPESStaticSet.yaml
@@ -7,20 +7,77 @@ INCAR:
   EDIFF: 1.e-05
   ENAUG: 1360
   ENCUT: 680
+  GGA: PE # change R2SCAN to PBE as default
   ISMEAR: 0 # change from 2 to 0, included to have some reasonable default
   ISPIN: 2
   KSPACING: 0.22 # included to have some reasonable default
   LAECHG: True
   LASPH: True
   LCHARG: True
-  LELF: False # LELF = True restricts calculation to KPAR = 1
   LMIXTAU: True
   LORBIT: 11
   LREAL: Auto
-  LVTOT: True
   LWAVE: False
-  GGA: PE # change R2SCAN to PBE as default
   NELM: 200
   NSW: 0 # static calculation
   PREC: Accurate
   SIGMA: 0.05 # change from 0.02 to 0.05, included to have some reasonable default
+  LDAU: false
+  LDAUJ:
+    F:
+      Co: 0
+      Cr: 0
+      Fe: 0
+      Mn: 0
+      Mo: 0
+      Ni: 0
+      V: 0
+      W: 0
+    O:
+      Co: 0
+      Cr: 0
+      Fe: 0
+      Mn: 0
+      Mo: 0
+      Ni: 0
+      V: 0
+      W: 0
+  LDAUL:
+    F:
+      Co: 2
+      Cr: 2
+      Fe: 2
+      Mn: 2
+      Mo: 2
+      Ni: 2
+      V: 2
+      W: 2
+    O:
+      Co: 2
+      Cr: 2
+      Fe: 2
+      Mn: 2
+      Mo: 2
+      Ni: 2
+      V: 2
+      W: 2
+  LDAUTYPE: 2
+  LDAUU:
+    F:
+      Co: 3.32
+      Cr: 3.7
+      Fe: 5.3
+      Mn: 3.9
+      Mo: 4.38
+      Ni: 6.2
+      V: 3.25
+      W: 6.2
+    O:
+      Co: 3.32
+      Cr: 3.7
+      Fe: 5.3
+      Mn: 3.9
+      Mo: 4.38
+      Ni: 6.2
+      V: 3.25
+      W: 6.2

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -1226,7 +1226,7 @@ class MatPESStaticSet(DictSet):
         functional: Literal["R2SCAN", "R2SCAN+U", "PBE", "PBE+U"] = "PBE",
         prev_incar=None,
         **kwargs: Any,
-    ) -> None:
+    ):
         """
         Args:
             structure (Structure): Structure from previous run.
@@ -1239,10 +1239,8 @@ class MatPESStaticSet(DictSet):
         super().__init__(structure, MatPESStaticSet.CONFIG, **kwargs)
         if isinstance(prev_incar, str):
             prev_incar = Incar.from_file(prev_incar)
-            updates = {}
-            for k, v in prev_incar.items():
-                if k not in self._config_dict["INCAR"]:
-                    updates[k] = v
+        if prev_incar:
+            updates = {k: v for k, v in prev_incar.items() if k not in self._config_dict["INCAR"]}
             self._config_dict["INCAR"].update(updates)
         if functional.startswith("R2SCAN"):
             self.user_incar_settings.setdefault("METAGGA", "R2SCAN")

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -1231,9 +1231,10 @@ class MatPESStaticSet(DictSet):
         Args:
             structure (Structure): Structure from previous run.
             functional ('R2SCAN'|'PBE'): Which functional to use. Defaults to 'PBE'.
-            prev_incar (Incar): Incar file from previous run. Only input parameter not included
+            prev_incar (Incar|str): Incar file from previous run. Only input parameter not included
                 in default settings of MatPESStaticSet are used.
-            **kwargs: Passed to MPStaticSet.
+            **kwargs: Passed to DictSet. For example, Hubbard U can be enabled with
+                user_incar_settings={"LDAU": True}
         """
         super().__init__(structure, MatPESStaticSet.CONFIG, **kwargs)
         if isinstance(prev_incar, str):

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -1223,14 +1223,14 @@ class MatPESStaticSet(DictSet):
     def __init__(
         self,
         structure: Structure,
-        functional: Literal["R2SCAN", "PBE"] = "PBE",
+        functional: Literal["R2SCAN", "PBE_54"] = "PBE_54",
         prev_incar=None,
         **kwargs: Any,
     ):
         """
         Args:
             structure (Structure): Structure from previous run.
-            functional ('R2SCAN'|'PBE'): Which functional to use. Defaults to 'PBE'.
+            functional ('R2SCAN'|'PBE_54'): Which functional to use. Defaults to 'PBE_54'.
             prev_incar (Incar|str): Incar file from previous run. Only input parameter not included
                 in default settings of MatPESStaticSet are used.
             **kwargs: Passed to DictSet. For example, Hubbard U can be enabled with
@@ -1247,11 +1247,9 @@ class MatPESStaticSet(DictSet):
             self.user_incar_settings.setdefault("METAGGA", "R2SCAN")
             self.user_incar_settings.setdefault("ALGO", "ALL")
             self.user_incar_settings.setdefault("GGA", None)
-        elif functional.upper() == "PBE":
-            self.user_incar_settings.setdefault("GGA", "PE")
-        else:
-            raise ValueError(
-                f"{functional} is not supported. The supported functionals are PBE and R2SCAN."
+        elif functional.upper() != "PBE_54":
+            raise Warning(
+                f"{functional} is not supported. The supported functionals are PBE_54 and R2SCAN."
             )
 
         self.kwargs = kwargs

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -1232,6 +1232,8 @@ class MatPESStaticSet(DictSet):
             structure (Structure): Structure from previous run.
             functional ('R2SCAN' | 'R2SCAN+U' | 'PBE' | 'PBE+U'): Which functional to use and whether to include
                 Hubbard U corrections. Defaults to 'PBE'.
+            prev_incar (Incar): Incar file from previous run. We do not want to update the current INCAR
+            settings except the new settings added by Custodian.
             **kwargs: Passed to MPStaticSet.
         """
         super().__init__(structure, MatPESStaticSet.CONFIG, **kwargs)

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -1249,9 +1249,7 @@ class MatPESStaticSet(DictSet):
             self.user_incar_settings.setdefault("ALGO", "ALL")
             self.user_incar_settings.setdefault("GGA", None)
         elif functional.upper() != "PBE_54":
-            raise Warning(
-                f"{functional} is not supported. The supported functionals are PBE_54 and R2SCAN."
-            )
+            raise Warning(f"{functional} is not supported. The supported functionals are PBE_54 and R2SCAN.")
 
         self.kwargs = kwargs
         self.functional = functional

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -1223,17 +1223,16 @@ class MatPESStaticSet(DictSet):
     def __init__(
         self,
         structure: Structure,
-        functional: Literal["R2SCAN", "R2SCAN+U", "PBE", "PBE+U"] = "PBE",
+        functional: Literal["R2SCAN", "PBE"] = "PBE",
         prev_incar=None,
         **kwargs: Any,
     ):
         """
         Args:
             structure (Structure): Structure from previous run.
-            functional ('R2SCAN' | 'R2SCAN+U' | 'PBE' | 'PBE+U'): Which functional to use and whether to include
-                Hubbard U corrections. Defaults to 'PBE'.
-            prev_incar (Incar): Incar file from previous run. We do not want to update the current INCAR
-            settings except the new settings added by Custodian.
+            functional ('R2SCAN'|'PBE'): Which functional to use. Defaults to 'PBE'.
+            prev_incar (Incar): Incar file from previous run. Only input parameter not included
+                in default settings of MatPESStaticSet are used.
             **kwargs: Passed to MPStaticSet.
         """
         super().__init__(structure, MatPESStaticSet.CONFIG, **kwargs)
@@ -1242,14 +1241,17 @@ class MatPESStaticSet(DictSet):
         if prev_incar:
             updates = {k: v for k, v in prev_incar.items() if k not in self._config_dict["INCAR"]}
             self._config_dict["INCAR"].update(updates)
-        if functional.startswith("R2SCAN"):
+
+        if functional.upper() == "R2SCAN":
             self.user_incar_settings.setdefault("METAGGA", "R2SCAN")
             self.user_incar_settings.setdefault("ALGO", "ALL")
             self.user_incar_settings.setdefault("GGA", None)
-        if functional.startswith("PBE"):
+        elif functional.upper() == "PBE":
             self.user_incar_settings.setdefault("GGA", "PE")
-        if functional.endswith("+U"):
-            self.user_incar_settings.setdefault("LDAU", True)
+        else:
+            raise ValueError(
+                f"{functional} is not supported. The supported functionals are PBE and R2SCAN."
+            )
 
         self.kwargs = kwargs
         self.functional = functional

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -1229,14 +1229,15 @@ class MatPESStaticSet(DictSet):
     ):
         """
         Args:
-            structure (Structure): Structure from previous run.
+            structure (Structure): Structure for static calculation.
             functional ('R2SCAN'|'PBE_54'): Which functional to use. Defaults to 'PBE_54'.
-            prev_incar (Incar|str): Incar file from previous run. Only input parameter not included
-                in default settings of MatPESStaticSet are used.
+            prev_incar (Incar|str): Incar file from previous run. Default settings of MatPESStaticSet
+                are prioritized over inputs from previous runs.
             **kwargs: Passed to DictSet. For example, Hubbard U can be enabled with
                 user_incar_settings={"LDAU": True}
         """
         super().__init__(structure, MatPESStaticSet.CONFIG, **kwargs)
+
         if isinstance(prev_incar, str):
             prev_incar = Incar.from_file(prev_incar)
         if prev_incar:

--- a/tests/io/vasp/test_sets.py
+++ b/tests/io/vasp/test_sets.py
@@ -165,8 +165,8 @@ class TestMITMPRelaxSet(PymatgenTest):
         structure = Structure.from_spacegroup("Fm-3m", Lattice.cubic(3), ["Cu"], [[0, 0, 0]])
 
         with pytest.warns(
-                BadInputSetWarning,
-                match="Relaxation of likely metal with ISMEAR < 1 detected. See VASP recommendations on ISMEAR for metals.",
+            BadInputSetWarning,
+            match="Relaxation of likely metal with ISMEAR < 1 detected. See VASP recommendations on ISMEAR for metals.",
         ) as warns:
             vis = self.set(structure)
             _ = vis.incar
@@ -213,9 +213,9 @@ class TestMITMPRelaxSet(PymatgenTest):
                     structure=struct, user_potcar_functional="PBE_54", user_potcar_settings=user_potcar_settings
                 )
                 expected = {  # noqa: SIM222
-                               **({"W": "W_sv"} if "W" in struct.symbol_set else {}),
-                               **(user_potcar_settings or {}),
-                           } or None
+                    **({"W": "W_sv"} if "W" in struct.symbol_set else {}),
+                    **(user_potcar_settings or {}),
+                } or None
                 assert relax_set.user_potcar_settings == expected
 
     @skip_if_no_psp_dir
@@ -763,8 +763,8 @@ class TestMatPESStaticSet(PymatgenTest):
         prev_incar = Incar.from_file(f"{TEST_FILES_DIR}/INCAR")
         default_prev = MatPESStaticSet(structure=self.struct, prev_incar=prev_incar)
         incar = default_prev.incar
-        assert incar["NPAR"] == 8 # test if prev_incar is used.
-        assert incar["NSW"] == 0 # test if default in MatPESStaticSet is prioritized.
+        assert incar["NPAR"] == 8  # test if prev_incar is used.
+        assert incar["NSW"] == 0  # test if default in MatPESStaticSet is prioritized.
 
     def test_init_r2scan(self):
         scan = MatPESStaticSet(self.struct, functional="R2SCAN")
@@ -1482,7 +1482,7 @@ class TestMPScanRelaxSet(PymatgenTest):
         assert test_potcar_set_1.potcar.functional == "PBE_54"
 
         with pytest.raises(
-                ValueError, match=r"Invalid user_potcar_functional='PBE', must be one of \('PBE_52', 'PBE_54'\)"
+            ValueError, match=r"Invalid user_potcar_functional='PBE', must be one of \('PBE_52', 'PBE_54'\)"
         ):
             MPScanRelaxSet(self.struct, user_potcar_functional="PBE")
 
@@ -1655,7 +1655,7 @@ class TestMVLRelax52Set(PymatgenTest):
         assert test_potcar_set_1.potcar.functional == "PBE_52"
 
         with pytest.raises(
-                ValueError, match=r"Invalid user_potcar_functional='PBE', must be one of \('PBE_52', 'PBE_54'\)"
+            ValueError, match=r"Invalid user_potcar_functional='PBE', must be one of \('PBE_52', 'PBE_54'\)"
         ):
             self.set(self.struct, user_potcar_functional="PBE")
 

--- a/tests/io/vasp/test_sets.py
+++ b/tests/io/vasp/test_sets.py
@@ -737,7 +737,7 @@ class TestMatPESStaticSet(PymatgenTest):
         poscar = Poscar.from_file(file_path)
         self.struct = poscar.structure
 
-    def test_init(self):
+    def test_init_default(self):
         # check if default INCAR settings are loaded
         default = MatPESStaticSet(self.struct)
         incar = default.incar
@@ -763,6 +763,7 @@ class TestMatPESStaticSet(PymatgenTest):
         assert incar["SIGMA"] == 0.05
         assert default.kpoints is None
 
+    def test_init_with_prev_incar(self):
         # check if prev_run settings will NOT override the default settings
         prev_incar = Incar.from_file(f"{TEST_FILES_DIR}/INCAR")
         default_prev = MatPESStaticSet(structure=self.struct, prev_incar=prev_incar)
@@ -788,15 +789,7 @@ class TestMatPESStaticSet(PymatgenTest):
         assert incar["NSW"] == 0
         assert incar["PREC"] == "Accurate"
         assert incar["SIGMA"] == 0.05
-        assert default.kpoints is None
-
-        # check if user_incar_settings will override the default settings
-        default_non_prev = MatPESStaticSet(self.struct, user_incar_settings={"ENCUT": 800, "LORBIT": 12, "LWAVE": True})
-        incar_non_prev = default_non_prev.incar
-        assert incar_non_prev["ENCUT"] == 800
-        assert incar_non_prev["LORBIT"] == 12
-        assert incar_non_prev["LWAVE"]
-        assert default_non_prev.kpoints is None
+        assert default_prev.kpoints is None
 
         # check if PBE+U functional can be applied
         default_u = MatPESStaticSet(self.struct, functional="PBE+U")

--- a/tests/io/vasp/test_sets.py
+++ b/tests/io/vasp/test_sets.py
@@ -763,27 +763,8 @@ class TestMatPESStaticSet(PymatgenTest):
         prev_incar = Incar.from_file(f"{TEST_FILES_DIR}/INCAR")
         default_prev = MatPESStaticSet(structure=self.struct, prev_incar=prev_incar)
         incar = default_prev.incar
-        assert incar["ALGO"] == "Normal"
-        assert incar["EDIFF"] == 1.0e-05
-        assert incar["ENAUG"] == 1360
-        assert incar["ENCUT"] == 680
-        assert incar["GGA"] == "Pe"
-        assert incar["ISMEAR"] == 0
-        assert incar["ISPIN"] == 2
-        assert incar["KSPACING"] == 0.22
-        assert incar["LAECHG"]
-        assert incar["LASPH"]
-        assert incar["LCHARG"]
-        assert incar["LMIXTAU"]
-        assert incar.get("LDAU") is None
-        assert incar["LORBIT"] == 11
-        assert incar["LREAL"] == "Auto"
-        assert not incar["LWAVE"]
         assert incar["NPAR"] == 8 # test if prev_incar is loaded
-        assert incar["NELM"] == 200
         assert incar["NSW"] == 0
-        assert incar["PREC"] == "Accurate"
-        assert incar["SIGMA"] == 0.05
 
     def test_init_r2scan(self):
         scan = MatPESStaticSet(self.struct, functional="R2SCAN")

--- a/tests/io/vasp/test_sets.py
+++ b/tests/io/vasp/test_sets.py
@@ -763,31 +763,6 @@ class TestMatPESStaticSet(PymatgenTest):
         assert incar["SIGMA"] == 0.05
         assert default.kpoints is None
 
-        # check from_dict method
-        default_from_dict = MatPESStaticSet.from_dict(default.as_dict())
-        incar = default_from_dict.incar
-        assert incar["ALGO"] == "Normal"
-        assert incar["EDIFF"] == 1.0e-05
-        assert incar["ENAUG"] == 1360
-        assert incar["ENCUT"] == 680
-        assert incar["GGA"] == "Pe"
-        assert incar["ISMEAR"] == 0
-        assert incar["ISPIN"] == 2
-        assert incar["KSPACING"] == 0.22
-        assert incar["LAECHG"]
-        assert incar["LASPH"]
-        assert incar["LCHARG"]
-        assert incar["LMIXTAU"]
-        assert incar.get("LDAU") is None
-        assert incar["LORBIT"] == 11
-        assert incar["LREAL"] == "Auto"
-        assert not incar["LWAVE"]
-        assert incar["NELM"] == 200
-        assert incar["NSW"] == 0
-        assert incar["PREC"] == "Accurate"
-        assert incar["SIGMA"] == 0.05
-        assert default.kpoints is None
-
         # check if prev_run settings will NOT override the default settings
         prev_incar = Incar.from_file(f"{TEST_FILES_DIR}/INCAR")
         default_prev = MatPESStaticSet(structure=self.struct, prev_incar=prev_incar)

--- a/tests/io/vasp/test_sets.py
+++ b/tests/io/vasp/test_sets.py
@@ -763,8 +763,8 @@ class TestMatPESStaticSet(PymatgenTest):
         prev_incar = Incar.from_file(f"{TEST_FILES_DIR}/INCAR")
         default_prev = MatPESStaticSet(structure=self.struct, prev_incar=prev_incar)
         incar = default_prev.incar
-        assert incar["NPAR"] == 8 # test if prev_incar is loaded
-        assert incar["NSW"] == 0
+        assert incar["NPAR"] == 8 # test if prev_incar is used.
+        assert incar["NSW"] == 0 # test if default in MatPESStaticSet is prioritized.
 
     def test_init_r2scan(self):
         scan = MatPESStaticSet(self.struct, functional="R2SCAN")
@@ -779,8 +779,14 @@ class TestMatPESStaticSet(PymatgenTest):
         assert default.potcar.functional == "PBE_54"
         scan = MatPESStaticSet(self.struct, functional="R2SCAN")
         assert scan.potcar.functional == "PBE_54"
-        pbe_52 = MatPESStaticSet(self.struct, user_potcar_functional="PBE_52")
-        assert pbe_52.potcar.functional == "PBE_52"
+
+        functional = "PBE_52"
+        with pytest.raises(
+            Warning,
+            match=f"{functional} is not supported. The supported functionals are PBE_54 and R2SCAN.",
+        ):
+            pbe_52 = MatPESStaticSet(self.struct, functional=functional)
+            assert pbe_52.potcar.functional == functional
 
 
 class TestMPNonSCFSet(PymatgenTest):

--- a/tests/io/vasp/test_sets.py
+++ b/tests/io/vasp/test_sets.py
@@ -59,7 +59,6 @@ MODULE_DIR = Path(pymatgen.io.vasp.__file__).parent
 
 dec = MontyDecoder()
 
-
 NO_PSP_DIR = SETTINGS.get("PMG_VASP_PSP_DIR") is None
 skip_if_no_psp_dir = mark.skipif(NO_PSP_DIR, reason="PMG_VASP_PSP_DIR is not set.")
 
@@ -166,8 +165,8 @@ class TestMITMPRelaxSet(PymatgenTest):
         structure = Structure.from_spacegroup("Fm-3m", Lattice.cubic(3), ["Cu"], [[0, 0, 0]])
 
         with pytest.warns(
-            BadInputSetWarning,
-            match="Relaxation of likely metal with ISMEAR < 1 detected. See VASP recommendations on ISMEAR for metals.",
+                BadInputSetWarning,
+                match="Relaxation of likely metal with ISMEAR < 1 detected. See VASP recommendations on ISMEAR for metals.",
         ) as warns:
             vis = self.set(structure)
             _ = vis.incar
@@ -214,9 +213,9 @@ class TestMITMPRelaxSet(PymatgenTest):
                     structure=struct, user_potcar_functional="PBE_54", user_potcar_settings=user_potcar_settings
                 )
                 expected = {  # noqa: SIM222
-                    **({"W": "W_sv"} if "W" in struct.symbol_set else {}),
-                    **(user_potcar_settings or {}),
-                } or None
+                               **({"W": "W_sv"} if "W" in struct.symbol_set else {}),
+                               **(user_potcar_settings or {}),
+                           } or None
                 assert relax_set.user_potcar_settings == expected
 
     @skip_if_no_psp_dir
@@ -740,67 +739,81 @@ class TestMatPESStaticSet(PymatgenTest):
 
     def test_init(self):
         # check if default INCAR settings are loaded
-        default = MPStaticSet(self.struct)
+        default = MatPESStaticSet(self.struct)
         incar = default.incar
-        assert incar["GGA"] == "Pe"
         assert incar["ALGO"] == "Normal"
         assert incar["EDIFF"] == 1.0e-05
-        assert incar["KSPACING"] == 0.22
-        assert incar["ISMEAR"] == 0
-        assert incar["SIGMA"] == 0.05
         assert incar["ENAUG"] == 1360
         assert incar["ENCUT"] == 680
-        assert incar["NELM"] == 200
-        assert incar["NSW"] == 0
-        assert incar["LORBIT"] == 11
+        assert incar["GGA"] == "Pe"
+        assert incar["ISMEAR"] == 0
+        assert incar["ISPIN"] == 2
+        assert incar["KSPACING"] == 0.22
+        assert incar["LAECHG"]
         assert incar["LASPH"]
         assert incar["LCHARG"]
-        assert incar["LAECHG"]
-        assert incar["LDAU"] is None
+        assert incar["LMIXTAU"]
+        assert incar.get("LDAU") is None
+        assert incar["LORBIT"] == 11
+        assert incar["LREAL"] == "Auto"
+        assert not incar["LWAVE"]
+        assert incar["NELM"] == 200
+        assert incar["NSW"] == 0
+        assert incar["PREC"] == "Accurate"
+        assert incar["SIGMA"] == 0.05
         assert default.kpoints is None
 
         # check from_dict method
-        default_from_dict = MPStaticSet.from_dict(default.structure)
-        incar_fd = default_from_dict.incar
-        assert incar_fd["GGA"] == "Pe"
-        assert incar_fd["ALGO"] == "Normal"
-        assert incar_fd["EDIFF"] == 1.0e-05
-        assert incar_fd["KSPACING"] == 0.22
-        assert incar_fd["ISMEAR"] == 0
-        assert incar_fd["SIGMA"] == 0.05
-        assert incar_fd["ENAUG"] == 1360
-        assert incar_fd["ENCUT"] == 680
-        assert incar_fd["NELM"] == 200
-        assert incar_fd["NSW"] == 0
-        assert incar_fd["LORBIT"] == 11
-        assert incar_fd["LASPH"]
-        assert incar_fd["LCHARG"]
-        assert incar_fd["LAECHG"]
-        assert incar_fd["LWAVE"] is None
-        assert incar_fd["LDAU"] is None
+        default_from_dict = MatPESStaticSet.from_dict(default.as_dict())
+        incar = default_from_dict.incar
+        assert incar["ALGO"] == "Normal"
+        assert incar["EDIFF"] == 1.0e-05
+        assert incar["ENAUG"] == 1360
+        assert incar["ENCUT"] == 680
+        assert incar["GGA"] == "Pe"
+        assert incar["ISMEAR"] == 0
+        assert incar["ISPIN"] == 2
+        assert incar["KSPACING"] == 0.22
+        assert incar["LAECHG"]
+        assert incar["LASPH"]
+        assert incar["LCHARG"]
+        assert incar["LMIXTAU"]
+        assert incar.get("LDAU") is None
+        assert incar["LORBIT"] == 11
+        assert incar["LREAL"] == "Auto"
+        assert not incar["LWAVE"]
+        assert incar["NELM"] == 200
+        assert incar["NSW"] == 0
+        assert incar["PREC"] == "Accurate"
+        assert incar["SIGMA"] == 0.05
         assert default.kpoints is None
 
         # check if prev_run settings will NOT override the default settings
-        prev_incar = Incar.from_file(f"{TEST_FILES_DIR}/relaxation/INCAR")
-        prev_struc = Poscar.from_file(f"{TEST_FILES_DIR}/relaxation/POSCAR").structure
-        default_prev = MPStaticSet(structure=prev_struc, prev_incar=prev_incar)
-        incar_prev = default_prev.incar
-        assert incar_prev["GGA"] == "Pe"
-        assert incar_prev["ALGO"] == "Normal"
-        assert incar_prev["EDIFF"] == 1.0e-05
-        assert incar_prev["KSPACING"] == 0.22
-        assert incar_prev["ISMEAR"] == 0
-        assert incar_prev["SIGMA"] == 0.05
-        assert incar_prev["ENAUG"] == 1360
-        assert incar_prev["ENCUT"] == 680
-        assert incar_prev["NELM"] == 200
-        assert incar_prev["NSW"] == 0
-        assert incar_prev["LASPH"]
-        assert incar_prev["LCHARG"]
-        assert incar_prev["LAECHG"]
-        assert incar_prev["LWAVE"] is None
-        assert incar_prev["LDAU"] is None
-        assert default_prev.kpoints is None
+        prev_incar = Incar.from_file(f"{TEST_FILES_DIR}/INCAR")
+        default_prev = MatPESStaticSet(structure=self.struct, prev_incar=prev_incar)
+        incar = default_prev.incar
+        assert incar["ALGO"] == "Normal"
+        assert incar["EDIFF"] == 1.0e-05
+        assert incar["ENAUG"] == 1360
+        assert incar["ENCUT"] == 680
+        assert incar["GGA"] == "Pe"
+        assert incar["ISMEAR"] == 0
+        assert incar["ISPIN"] == 2
+        assert incar["KSPACING"] == 0.22
+        assert incar["LAECHG"]
+        assert incar["LASPH"]
+        assert incar["LCHARG"]
+        assert incar["LMIXTAU"]
+        assert incar.get("LDAU") is None
+        assert incar["LORBIT"] == 11
+        assert incar["LREAL"] == "Auto"
+        assert not incar["LWAVE"]
+        assert incar["NPAR"] == 8 # test if prev_incar is loaded
+        assert incar["NELM"] == 200
+        assert incar["NSW"] == 0
+        assert incar["PREC"] == "Accurate"
+        assert incar["SIGMA"] == 0.05
+        assert default.kpoints is None
 
         # check if user_incar_settings will override the default settings
         default_non_prev = MatPESStaticSet(self.struct, user_incar_settings={"ENCUT": 800, "LORBIT": 12, "LWAVE": True})
@@ -811,28 +824,28 @@ class TestMatPESStaticSet(PymatgenTest):
         assert default_non_prev.kpoints is None
 
         # check if PBE+U functional can be applied
-        default_u = MPStaticSet(self.struct, functional="PBE+U")
+        default_u = MatPESStaticSet(self.struct, functional="PBE+U")
         incar_u = default_u.incar
         assert incar_u["GGA"] == "Pe"
-        assert incar["ALGO"] == "Normal"
-        assert incar["LDAU"]
+        assert incar_u["ALGO"] == "Normal"
+        assert incar_u["LDAU"]
         assert default.kpoints is None
 
         # check if R2SCAN functional can be applied
-        scan = MPStaticSet(self.struct, functional="R2SCAN")
+        scan = MatPESStaticSet(self.struct, functional="R2SCAN")
         incar_scan = scan.incar
-        assert incar_scan["METAGGA"] == "R2SCAN"
-        assert incar_scan["GGA"] is None
-        assert incar_scan["ALGO"] == "ALL"
-        assert incar["LDAU"] is None
+        assert incar_scan["METAGGA"] == "R2scan"
+        assert incar_scan.get("GGA") is None
+        assert incar_scan["ALGO"] == "All"
+        assert incar_scan.get("LDAU") is None
         assert scan.kpoints is None
 
         # check if R2SCAN+U functional can be applied
-        scan_u = MPStaticSet(self.struct, functional="R2SCAN+U")
+        scan_u = MatPESStaticSet(self.struct, functional="R2SCAN+U")
         incar_scan_u = scan_u.incar
-        assert incar_scan_u["METAGGA"] == "R2SCAN"
-        assert incar_scan_u["GGA"] is None
-        assert incar_scan_u["ALGO"] == "ALL"
+        assert incar_scan_u["METAGGA"] == "R2scan"
+        assert incar_scan_u.get("GGA") is None
+        assert incar_scan_u["ALGO"] == "All"
         assert incar_scan_u["LDAU"]
         assert scan_u.kpoints is None
 
@@ -1530,7 +1543,7 @@ class TestMPScanRelaxSet(PymatgenTest):
         assert test_potcar_set_1.potcar.functional == "PBE_54"
 
         with pytest.raises(
-            ValueError, match=r"Invalid user_potcar_functional='PBE', must be one of \('PBE_52', 'PBE_54'\)"
+                ValueError, match=r"Invalid user_potcar_functional='PBE', must be one of \('PBE_52', 'PBE_54'\)"
         ):
             MPScanRelaxSet(self.struct, user_potcar_functional="PBE")
 
@@ -1703,7 +1716,7 @@ class TestMVLRelax52Set(PymatgenTest):
         assert test_potcar_set_1.potcar.functional == "PBE_52"
 
         with pytest.raises(
-            ValueError, match=r"Invalid user_potcar_functional='PBE', must be one of \('PBE_52', 'PBE_54'\)"
+                ValueError, match=r"Invalid user_potcar_functional='PBE', must be one of \('PBE_52', 'PBE_54'\)"
         ):
             self.set(self.struct, user_potcar_functional="PBE")
 

--- a/tests/io/vasp/test_sets.py
+++ b/tests/io/vasp/test_sets.py
@@ -761,7 +761,6 @@ class TestMatPESStaticSet(PymatgenTest):
         assert incar["NSW"] == 0
         assert incar["PREC"] == "Accurate"
         assert incar["SIGMA"] == 0.05
-        assert default.kpoints is None
 
     def test_init_with_prev_incar(self):
         # check if prev_run settings will NOT override the default settings
@@ -789,33 +788,14 @@ class TestMatPESStaticSet(PymatgenTest):
         assert incar["NSW"] == 0
         assert incar["PREC"] == "Accurate"
         assert incar["SIGMA"] == 0.05
-        assert default_prev.kpoints is None
 
-        # check if PBE+U functional can be applied
-        default_u = MatPESStaticSet(self.struct, functional="PBE+U")
-        incar_u = default_u.incar
-        assert incar_u["GGA"] == "Pe"
-        assert incar_u["ALGO"] == "Normal"
-        assert incar_u["LDAU"]
-        assert default.kpoints is None
-
-        # check if R2SCAN functional can be applied
+    def test_init_r2scan(self):
         scan = MatPESStaticSet(self.struct, functional="R2SCAN")
         incar_scan = scan.incar
         assert incar_scan["METAGGA"] == "R2scan"
         assert incar_scan.get("GGA") is None
         assert incar_scan["ALGO"] == "All"
         assert incar_scan.get("LDAU") is None
-        assert scan.kpoints is None
-
-        # check if R2SCAN+U functional can be applied
-        scan_u = MatPESStaticSet(self.struct, functional="R2SCAN+U")
-        incar_scan_u = scan_u.incar
-        assert incar_scan_u["METAGGA"] == "R2scan"
-        assert incar_scan_u.get("GGA") is None
-        assert incar_scan_u["ALGO"] == "All"
-        assert incar_scan_u["LDAU"]
-        assert scan_u.kpoints is None
 
 
 class TestMPNonSCFSet(PymatgenTest):

--- a/tests/io/vasp/test_sets.py
+++ b/tests/io/vasp/test_sets.py
@@ -733,12 +733,9 @@ class TestMPStaticSet(PymatgenTest):
 
 class TestMatPESStaticSet(PymatgenTest):
     def setUp(self):
-        file_path = f"{TEST_FILES_DIR}/POSCAR"
-        poscar = Poscar.from_file(file_path)
-        self.struct = poscar.structure
+        self.struct = Structure.from_file(f"{TEST_FILES_DIR}/POSCAR")
 
     def test_init_default(self):
-        # check if default INCAR settings are loaded
         default = MatPESStaticSet(self.struct)
         incar = default.incar
         assert incar["ALGO"] == "Normal"
@@ -763,7 +760,6 @@ class TestMatPESStaticSet(PymatgenTest):
         assert incar["SIGMA"] == 0.05
 
     def test_init_with_prev_incar(self):
-        # check if prev_run settings will NOT override the default settings
         prev_incar = Incar.from_file(f"{TEST_FILES_DIR}/INCAR")
         default_prev = MatPESStaticSet(structure=self.struct, prev_incar=prev_incar)
         incar = default_prev.incar

--- a/tests/io/vasp/test_sets.py
+++ b/tests/io/vasp/test_sets.py
@@ -793,6 +793,14 @@ class TestMatPESStaticSet(PymatgenTest):
         assert incar_scan["ALGO"] == "All"
         assert incar_scan.get("LDAU") is None
 
+    def test_potcar(self):
+        default = MatPESStaticSet(self.struct)
+        assert default.potcar.functional == "PBE_54"
+        scan = MatPESStaticSet(self.struct, functional="R2SCAN")
+        assert scan.potcar.functional == "PBE_54"
+        pbe_52 = MatPESStaticSet(self.struct, user_potcar_functional="PBE_52")
+        assert pbe_52.potcar.functional == "PBE_52"
+
 
 class TestMPNonSCFSet(PymatgenTest):
     def setUp(self):


### PR DESCRIPTION
Related PR: #3278 #3254 

Tests now covers all MatPESStaticSet parameters. 

Remaining question: While the default setting of MatPESStaticSet is without Hubbard U, when +U is enabled, the Hubbard U related parameters will be the same as MPRelaxSet. As I have noticed that MITRelaxSet and MPRelaxSet have different default parameters, I'm not sure if setting the defaults same as MPRelaxSet is the most correct.
