### PR TITLE
Breaking: bump minimum Python version to 3.9

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,29 +24,8 @@ jobs:
       fail-fast: false
       matrix:
         # pytest-split automatically distributes work load so parallel jobs finish in similar time
-        os: [ubuntu-latest, windows-latest]
-        python-version: ["3.9", "3.11"]
-        split: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        # include/exclude is meant to maximize CI coverage of different platforms and python
-        # versions while minimizing the total number of jobs. We run all pytest splits with the
-        # oldest supported python version (currently 3.9) on windows (seems most likely to surface
-        # errors) and with newest version (currently 3.11) on ubuntu (to get complete and speedy
-        # coverage on unix). Also sample some splits on macos for all python versions
-        exclude:
-          - os: windows-latest
-            python-version: "3.11"
-          - os: ubuntu-latest
-            python-version: "3.9"
-        include:
-          - os: macos-latest
-            python-version: "3.9"
-            split: 1
-          - os: macos-latest
-            python-version: "3.10"
-            split: 2
-          - os: macos-latest
-            python-version: "3.11"
-            split: 3
+        os: [ubuntu-latest]
+        python-version: ["3.11"]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # pytest-split automatically distributes work load so parallel jobs finish in similar time
         os: [ubuntu-latest]
         python-version: ["3.11"]
 

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -41,20 +41,17 @@ jobs:
           - os: windows-latest
             python-version: "3.11"
           - os: ubuntu-latest
-            python-version: "3.8"
+            python-version: "3.9"
         include:
           - os: macos-latest
-            python-version: "3.8"
+            python-version: "3.9"
             split: 1
           - os: macos-latest
-            python-version: "3.9"
+            python-version: "3.10"
             split: 2
           - os: macos-latest
-            python-version: "3.10"
-            split: 3
-          - os: macos-latest
             python-version: "3.11"
-            split: 4
+            split: 3
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,10 +27,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.8", "3.11"]
+        python-version: ["3.9", "3.11"]
         # include/exclude is meant to maximize CI coverage of different platforms and python
         # versions while minimizing the total number of jobs. We run all tests with the
-        # oldest supported python version (currently 3.8) on windows (seems most likely to surface
+        # oldest supported python version (currently 3.9) on windows (seems most likely to surface
         # errors) and with newest version (currently 3.11) on ubuntu (to get complete and speedy
         # coverage on unix).
         exclude:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ For developers interested in expanding `pymatgen` for their own purposes, we rec
 
 Given that `pymatgen` is intended to be a long-term code base, we adopt very strict quality control and coding guidelines for all contributions to `pymatgen`. The following must be satisfied for your contributions to be accepted into `pymatgen`.
 
-1. **Unit tests** are required for all new modules and methods. The only way to minimize code regression is to ensure that all code is well tested. Untested contributions will not be accepted.
+1. **Unit tests** are required for all new modules and methods. The only way to minimize code regression is to ensure that all code is well-tested. Untested contributions will not be accepted.
 1. **Python PEP 8** [code style](https://python.org/dev/peps/pep-0008). We allow a few exceptions when they are well-justified (e.g., Element's atomic number is given a variable name of capital Z, in line with accepted scientific convention), but generally, PEP 8 must be observed. Code style will be automatically checked for all PRs and must pass before any PR is merged. To aid you, you can install and run the same set of formatters and linters that will run in CI using
 
    ```sh
@@ -78,7 +78,7 @@ Given that `pymatgen` is intended to be a long-term code base, we adopt very str
     pre-commit run --all-files  # ensure your entire codebase passes linters
    ```
 
-1. **Python 3**. We only support Python 3.8+.
+1. **Python 3**. We only support Python 3.9+.
 1. **Documentation** is required for all modules, classes and methods. In particular, the method doc strings should make clear the arguments expected and the return values. For complex algorithms (e.g., an Ewald summation), a summary of the algorithm should be provided and preferably with a link to a publication outlining the method in detail.
 
 For the above, if in doubt, please refer to the core classes in `pymatgen` for examples of what is expected.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ If you'd like to use the latest unreleased changes on the main branch, you can i
 pip install -U git+https://github.com/materialsproject/pymatgen
 ```
 
-The minimum Python version is 3.8. Some extra functionality (e.g., generation of POTCARs) does require additional setup (see the [`pymatgen` docs]).
+The minimum Python version is 3.9. Some extra functionality (e.g., generation of POTCARs) does require additional setup (see the [`pymatgen` docs]).
 
 ## Change Log
 

--- a/dev_scripts/chemenv/strategies/multi_weights_strategy_parameters.py
+++ b/dev_scripts/chemenv/strategies/multi_weights_strategy_parameters.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import copy
 import json
-from typing import Sequence
+from typing import TYPE_CHECKING
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -25,6 +25,9 @@ from pymatgen.analysis.chemenv.coordination_environments.coordination_geometry_f
 )
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Structure
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 __author__ = "David Waroquiers"
 __copyright__ = "Copyright 2012, The Materials Project"

--- a/pymatgen/alchemy/transmuters.py
+++ b/pymatgen/alchemy/transmuters.py
@@ -12,10 +12,13 @@ from __future__ import annotations
 import os
 import re
 from multiprocessing import Pool
-from typing import Callable, Sequence
+from typing import TYPE_CHECKING, Callable
 
 from pymatgen.alchemy.materials import TransformedStructure
 from pymatgen.io.vasp.sets import MPRelaxSet, VaspInputSet
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 __author__ = "Shyue Ping Ong, Will Richards"
 __copyright__ = "Copyright 2012, The Materials Project"

--- a/pymatgen/analysis/diffraction/tem.py
+++ b/pymatgen/analysis/diffraction/tem.py
@@ -6,7 +6,7 @@ import json
 import os
 from collections import namedtuple
 from fractions import Fraction
-from typing import TYPE_CHECKING, List, Tuple, cast
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
 import pandas as pd
@@ -121,7 +121,7 @@ class TEMCalculator(AbstractDiffractionPatternCalculator):
             return []
         filtered = np.where(np.dot(np.array(self.beam_direction), np.transpose(points)) == laue_zone)
         result = points[filtered]  # type: ignore
-        return cast(List[Tuple[int, int, int]], [tuple(x) for x in result.tolist()])
+        return cast(list[tuple[int, int, int]], [tuple(x) for x in result.tolist()])
 
     def get_interplanar_spacings(
         self, structure: Structure, points: list[tuple[int, int, int]] | np.ndarray

--- a/pymatgen/analysis/gb/grain.py
+++ b/pymatgen/analysis/gb/grain.py
@@ -8,7 +8,7 @@ import warnings
 from fractions import Fraction
 from functools import reduce
 from math import cos, floor, gcd
-from typing import TYPE_CHECKING, Any, Sequence
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from monty.fractions import lcm
@@ -19,6 +19,8 @@ from pymatgen.core.structure import Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from numpy.typing import ArrayLike
 
     from pymatgen.core.trajectory import Vector3D

--- a/pymatgen/analysis/interfaces/coherent_interfaces.py
+++ b/pymatgen/analysis/interfaces/coherent_interfaces.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from itertools import product
-from typing import TYPE_CHECKING, Iterator, Sequence
+from typing import TYPE_CHECKING
 
 import numpy as np
 from numpy.testing import assert_allclose
@@ -15,6 +15,8 @@ from pymatgen.core.interface import Interface, label_termination
 from pymatgen.core.surface import SlabGenerator
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator, Sequence
+
     from pymatgen.core import Structure
 
 

--- a/pymatgen/analysis/interfaces/zsl.py
+++ b/pymatgen/analysis/interfaces/zsl.py
@@ -4,13 +4,16 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from itertools import product
-from typing import Iterator
+from typing import TYPE_CHECKING
 
 import numpy as np
 from monty.json import MSONable
 
 from pymatgen.util.due import Doi, due
 from pymatgen.util.numba import njit
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 @dataclass

--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -11,7 +11,7 @@ import os
 import re
 import warnings
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, Collection, Iterator, Literal, Sequence, no_type_check
+from typing import TYPE_CHECKING, Any, Literal, no_type_check
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -33,6 +33,7 @@ from pymatgen.util.plotting import pretty_plot
 from pymatgen.util.string import htmlify, latexify
 
 if TYPE_CHECKING:
+    from collections.abc import Collection, Iterator, Sequence
     from io import StringIO
 
     from numpy.typing import ArrayLike

--- a/pymatgen/analysis/structure_matcher.py
+++ b/pymatgen/analysis/structure_matcher.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import abc
 import itertools
-from typing import Literal, Mapping, Sequence
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 from monty.json import MSONable
@@ -16,6 +16,9 @@ from pymatgen.core.structure import Structure
 from pymatgen.optimization.linear_assignment import LinearAssignment
 from pymatgen.util.coord import lattice_points_in_supercell
 from pymatgen.util.coord_cython import is_coord_subset_pbc, pbc_shortest_vectors
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
 
 __author__ = "William Davidson Richards, Stephen Dacek, Shyue Ping Ong"
 __copyright__ = "Copyright 2011, The Materials Project"

--- a/pymatgen/apps/battery/conversion_battery.py
+++ b/pymatgen/apps/battery/conversion_battery.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Iterable
+from typing import TYPE_CHECKING
 
 from scipy.constants import N_A
 
@@ -15,6 +15,8 @@ from pymatgen.core.periodic_table import Element
 from pymatgen.core.units import Charge, Time
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from pymatgen.entries.computed_entries import ComputedEntry
 
 

--- a/pymatgen/apps/battery/insertion_battery.py
+++ b/pymatgen/apps/battery/insertion_battery.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import itertools
 from dataclasses import dataclass
-from typing import Iterable
+from typing import TYPE_CHECKING
 
 from scipy.constants import N_A
 
@@ -16,6 +16,9 @@ from pymatgen.core.composition import Composition
 from pymatgen.core.periodic_table import Element
 from pymatgen.core.units import Charge, Time
 from pymatgen.entries.computed_entries import ComputedEntry, ComputedStructureEntry
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 __author__ = "Anubhav Jain, Shyue Ping Ong"
 __copyright__ = "Copyright 2012, The Materials Project"

--- a/pymatgen/core/composition.py
+++ b/pymatgen/core/composition.py
@@ -11,7 +11,7 @@ import string
 import warnings
 from functools import total_ordering
 from itertools import combinations_with_replacement, product
-from typing import Generator, Iterator, Union, cast
+from typing import TYPE_CHECKING, Union, cast
 
 from monty.fractions import gcd, gcd_float
 from monty.json import MSONable
@@ -20,6 +20,9 @@ from monty.serialization import loadfn
 from pymatgen.core.periodic_table import DummySpecies, Element, Species, get_el_sp
 from pymatgen.core.units import Mass
 from pymatgen.util.string import Stringify, formula_double_format
+
+if TYPE_CHECKING:
+    from collections.abc import Generator, Iterator
 
 SpeciesLike = Union[str, Element, Species, DummySpecies]
 

--- a/pymatgen/core/lattice.py
+++ b/pymatgen/core/lattice.py
@@ -8,7 +8,7 @@ import math
 import warnings
 from fractions import Fraction
 from functools import reduce
-from typing import TYPE_CHECKING, Iterator, Sequence
+from typing import TYPE_CHECKING
 
 import numpy as np
 from monty.dev import deprecated
@@ -21,6 +21,8 @@ from pymatgen.util.due import Doi, due
 from pymatgen.util.num import abs_cap
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator, Sequence
+
     from numpy.typing import ArrayLike
 
     from pymatgen.core.trajectory import Vector3D

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -21,7 +21,7 @@ from abc import ABCMeta, abstractmethod
 from fnmatch import fnmatch
 from inspect import isclass
 from io import StringIO
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Iterator, Literal, Sequence, SupportsIndex, cast
+from typing import TYPE_CHECKING, Any, Callable, Literal, SupportsIndex, cast
 
 import numpy as np
 from monty.dev import deprecated
@@ -42,6 +42,8 @@ from pymatgen.symmetry.maggroups import MagneticSpaceGroup
 from pymatgen.util.coord import all_distances, get_angle, lattice_points_in_supercell
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator, Sequence
+
     from ase.calculators.calculator import Calculator
     from ase.io.trajectory import Trajectory
     from ase.optimize.optimize import Optimizer

--- a/pymatgen/core/tensors.py
+++ b/pymatgen/core/tensors.py
@@ -10,7 +10,7 @@ import itertools
 import os
 import string
 import warnings
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
 
 import numpy as np
 from monty.json import MSONable
@@ -23,6 +23,8 @@ from pymatgen.core.operations import SymmOp
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from pymatgen.core import Structure
 
 __author__ = "Joseph Montoya"

--- a/pymatgen/core/trajectory.py
+++ b/pymatgen/core/trajectory.py
@@ -6,9 +6,10 @@ from __future__ import annotations
 
 import itertools
 import warnings
+from collections.abc import Iterator, Sequence
 from fnmatch import fnmatch
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Sequence, Tuple, Union
+from typing import Any, Union
 
 import numpy as np
 from monty.io import zopen
@@ -21,9 +22,9 @@ __author__ = "Eric Sivonxay, Shyam Dwaraknath, Mingjian Wen, Evan Spotte-Smith"
 __version__ = "0.1"
 __date__ = "Jun 29, 2022"
 
-Vector3D = Tuple[float, float, float]
-Matrix3D = Tuple[Vector3D, Vector3D, Vector3D]
-SitePropsType = Union[List[Dict[Any, Sequence[Any]]], Dict[Any, Sequence[Any]]]
+Vector3D = tuple[float, float, float]
+Matrix3D = tuple[Vector3D, Vector3D, Vector3D]
+SitePropsType = Union[list[dict[Any, Sequence[Any]]], dict[Any, Sequence[Any]]]
 
 
 class Trajectory(MSONable):

--- a/pymatgen/electronic_structure/dos.py
+++ b/pymatgen/electronic_structure/dos.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import functools
 import warnings
 from collections import namedtuple
-from typing import TYPE_CHECKING, Mapping, NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
 
 import numpy as np
 from monty.json import MSONable
@@ -19,6 +19,8 @@ from pymatgen.electronic_structure.core import Orbital, OrbitalType, Spin
 from pymatgen.util.coord import get_linear_interpolated_value
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from numpy.typing import ArrayLike
 
     from pymatgen.core.sites import PeriodicSite

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -9,7 +9,7 @@ import math
 import typing
 import warnings
 from collections import Counter
-from typing import TYPE_CHECKING, List, Literal, Sequence, cast, no_type_check
+from typing import TYPE_CHECKING, Literal, cast, no_type_check
 
 import matplotlib.lines as mlines
 import matplotlib.pyplot as plt
@@ -30,6 +30,8 @@ except ImportError:
     mlab = None
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from numpy.typing import ArrayLike
 
     from pymatgen.electronic_structure.dos import CompleteDos, Dos
@@ -2359,7 +2361,7 @@ class BSDOSPlotter:
             if spin in bs.bands:
                 band_energies[spin] = []
                 for band in bs.bands[spin]:
-                    band = cast(List[float], band)
+                    band = cast(list[float], band)
                     band_energies[spin].append([e - bs.efermi for e in band])  # type: ignore
 
         # renormalize the DOS energies to Fermi level

--- a/pymatgen/entries/compatibility.py
+++ b/pymatgen/entries/compatibility.py
@@ -9,7 +9,7 @@ import copy
 import os
 import warnings
 from collections import defaultdict
-from typing import Literal, Sequence, Union
+from typing import TYPE_CHECKING, Literal, Union
 
 import numpy as np
 from monty.design_patterns import cached_class
@@ -31,6 +31,9 @@ from pymatgen.entries.computed_entries import (
 )
 from pymatgen.io.vasp.sets import MITRelaxSet, MPRelaxSet, VaspInputSet
 from pymatgen.util.due import Doi, due
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 __author__ = "Amanda Wang, Ryan Kingsbury, Shyue Ping Ong, Anubhav Jain, Stephen Dacek, Sai Jayaraman"
 __copyright__ = "Copyright 2012-2020, The Materials Project"

--- a/pymatgen/entries/entry_tools.py
+++ b/pymatgen/entries/entry_tools.py
@@ -11,7 +11,7 @@ import itertools
 import json
 import logging
 import re
-from typing import TYPE_CHECKING, Iterable, Literal
+from typing import TYPE_CHECKING, Literal
 
 from monty.json import MontyDecoder, MontyEncoder, MSONable
 from monty.string import unicode2str
@@ -22,6 +22,8 @@ from pymatgen.core.composition import Composition
 from pymatgen.core.periodic_table import Element
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from pymatgen.entries import Entry
     from pymatgen.entries.computed_entries import ComputedEntry, ComputedStructureEntry
 

--- a/pymatgen/ext/matproj.py
+++ b/pymatgen/ext/matproj.py
@@ -20,7 +20,7 @@ import sys
 import warnings
 from enum import Enum, unique
 from time import sleep
-from typing import TYPE_CHECKING, Any, Literal, Sequence
+from typing import TYPE_CHECKING, Any, Literal
 
 import requests
 from monty.json import MontyDecoder, MontyEncoder
@@ -40,6 +40,8 @@ from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.util.due import Doi, due
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from pymatgen.phonon.bandstructure import PhononBandStructureSymmLine
     from pymatgen.phonon.dos import CompletePhononDos
 

--- a/pymatgen/io/abinit/abiobjects.py
+++ b/pymatgen/io/abinit/abiobjects.py
@@ -6,9 +6,10 @@ from __future__ import annotations
 
 import abc
 from collections import namedtuple
+from collections.abc import Iterable
 from enum import Enum
 from pprint import pformat
-from typing import Iterable, cast
+from typing import cast
 
 import numpy as np
 from monty.collections import AttrDict

--- a/pymatgen/io/abinit/variable.py
+++ b/pymatgen/io/abinit/variable.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import collections
 import collections.abc
 import string
-from typing import Iterable
+from collections.abc import Iterable
 
 import numpy as np
 

--- a/pymatgen/io/adf.py
+++ b/pymatgen/io/adf.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 import re
-from typing import Generator
+from typing import TYPE_CHECKING
 
 import numpy as np
 from monty.io import reverse_readline
@@ -13,6 +13,9 @@ from monty.json import MSONable
 from monty.serialization import zopen
 
 from pymatgen.core.structure import Molecule
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 __author__ = "Xin Chen, chenxin13@mails.tsinghua.edu.cn"
 

--- a/pymatgen/io/core.py
+++ b/pymatgen/io/core.py
@@ -27,9 +27,8 @@ from __future__ import annotations
 
 import abc
 import os
-from collections.abc import MutableMapping
+from collections.abc import Iterator, MutableMapping
 from pathlib import Path
-from typing import Iterator
 from zipfile import ZipFile
 
 import numpy as np

--- a/pymatgen/io/cp2k/inputs.py
+++ b/pymatgen/io/cp2k/inputs.py
@@ -30,9 +30,10 @@ import os
 import re
 import textwrap
 import typing
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Iterable, Literal, Sequence
+from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 from monty.io import zopen

--- a/pymatgen/io/lammps/data.py
+++ b/pymatgen/io/lammps/data.py
@@ -1250,19 +1250,19 @@ class CombinedData(LammpsData):
         mol_count = 0
         type_count = 0
         self.mols_per_data = []
-        for i, mol in enumerate(self.mols):
+        for idx, mol in enumerate(self.mols):
             atoms_df = mol.atoms.copy()
             atoms_df["molecule-ID"] += mol_count
             atoms_df["type"] += type_count
             mols_in_data = len(atoms_df["molecule-ID"].unique())
             self.mols_per_data.append(mols_in_data)
-            for _ in range(self.nums[i]):
+            for _ in range(self.nums[idx]):
                 self.atoms = pd.concat([self.atoms, atoms_df], ignore_index=True)
                 atoms_df["molecule-ID"] += mols_in_data
             type_count += len(mol.masses)
-            mol_count += self.nums[i] * mols_in_data
+            mol_count += self.nums[idx] * mols_in_data
         self.atoms.index += 1
-        assert len(self.atoms) == len(self._coordinates), "Wrong number of coordinates."
+        assert len(self.atoms) == len(self._coordinates), "Wrong number of coordinates"
         self.atoms.update(self._coordinates)
 
         self.velocities = None
@@ -1271,7 +1271,7 @@ class CombinedData(LammpsData):
         self.topology = {}
         atom_count = 0
         count = {"Bonds": 0, "Angles": 0, "Dihedrals": 0, "Impropers": 0}
-        for i, mol in enumerate(self.mols):
+        for idx, mol in enumerate(self.mols):
             for kw in SECTION_KEYWORDS["topology"]:
                 if mol.topology and kw in mol.topology:
                     if kw not in self.topology:
@@ -1280,12 +1280,12 @@ class CombinedData(LammpsData):
                     topo_df["type"] += count[kw]
                     for col in topo_df.columns[1:]:
                         topo_df[col] += atom_count
-                    for _ in range(self.nums[i]):
+                    for _ in range(self.nums[idx]):
                         self.topology[kw] = pd.concat([self.topology[kw], topo_df], ignore_index=True)
                         for col in topo_df.columns[1:]:
                             topo_df[col] += len(mol.atoms)
                     count[kw] += len(mol.force_field[kw[:-1] + " Coeffs"])
-            atom_count += len(mol.atoms) * self.nums[i]
+            atom_count += len(mol.atoms) * self.nums[idx]
         for kw in SECTION_KEYWORDS["topology"]:
             if kw in self.topology:
                 self.topology[kw].index += 1
@@ -1386,11 +1386,11 @@ class CombinedData(LammpsData):
         mols = []
         styles = []
         coordinates = cls.parse_xyz(filename=coordinate_file)
-        for i in range(len(filenames)):
-            exec(f"cluster{i + 1} = LammpsData.from_file(filenames[i])")
-            names.append(f"cluster{i + 1}")
-            mols.append(eval(f"cluster{i + 1}"))
-            styles.append(eval(f"cluster{i + 1}").atom_style)
+        for idx in range(1, len(filenames) + 1):
+            exec(f"cluster{idx} = LammpsData.from_file(filenames[{idx - 1}])")
+            names.append(f"cluster{idx}")
+            mols.append(eval(f"cluster{idx}"))
+            styles.append(eval(f"cluster{idx}").atom_style)
         style = set(styles)
         assert len(style) == 1, "Files have different atom styles."
         return cls.from_lammpsdata(mols, names, list_of_numbers, coordinates, style.pop())

--- a/pymatgen/io/lobster/inputs.py
+++ b/pymatgen/io/lobster/inputs.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import itertools
 import os
 import warnings
-from typing import TYPE_CHECKING, Any, Sequence
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import spglib
@@ -28,6 +28,8 @@ from pymatgen.symmetry.bandstructure import HighSymmKpath
 from pymatgen.util.due import Doi, due
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from pymatgen.core.composition import Composition
 
 

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -18,7 +18,7 @@ from collections import namedtuple
 from enum import Enum
 from glob import glob
 from hashlib import sha256
-from typing import TYPE_CHECKING, Any, Literal, Sequence
+from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 import scipy.constants as const
@@ -39,6 +39,8 @@ from pymatgen.util.io_utils import clean_lines
 from pymatgen.util.string import str_delimited
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from numpy.typing import ArrayLike
 
     from pymatgen.core.trajectory import Vector3D

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -47,7 +47,7 @@ from copy import deepcopy
 from glob import glob
 from itertools import chain
 from pathlib import Path
-from typing import Any, Literal, Sequence, Union
+from typing import TYPE_CHECKING, Any, Literal, Union
 from zipfile import ZipFile
 
 import numpy as np
@@ -64,6 +64,9 @@ from pymatgen.io.vasp.outputs import Outcar, Vasprun
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.symmetry.bandstructure import HighSymmKpath
 from pymatgen.util.due import Doi, due
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 MODULE_DIR = Path(__file__).resolve().parent
 # TODO (janosh): replace with following line once PMG is py3.9+ only

--- a/pymatgen/io/wannier90.py
+++ b/pymatgen/io/wannier90.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
-from typing import Sequence
+from typing import TYPE_CHECKING
 
 import numpy as np
 from scipy.io import FortranEOFError, FortranFile
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 __author__ = "Mark Turiansky"
 __copyright__ = "Copyright 2011, The Materials Project"

--- a/pymatgen/symmetry/analyzer.py
+++ b/pymatgen/symmetry/analyzer.py
@@ -16,10 +16,11 @@ import logging
 import math
 import warnings
 from collections import defaultdict
+from collections.abc import Sequence
 from fractions import Fraction
 from functools import lru_cache
 from math import cos, sin
-from typing import TYPE_CHECKING, Any, Literal, Sequence
+from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 import spglib

--- a/pymatgen/symmetry/maggroups.py
+++ b/pymatgen/symmetry/maggroups.py
@@ -7,7 +7,7 @@ import sqlite3
 import textwrap
 from array import array
 from fractions import Fraction
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
 
 import numpy as np
 from monty.design_patterns import cached_class
@@ -19,6 +19,8 @@ from pymatgen.symmetry.settings import JonesFaithfulTransformation
 from pymatgen.util.string import transformation_to_string
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from pymatgen.core.lattice import Lattice
 
 __author__ = "Matthew Horton, Shyue Ping Ong"

--- a/pymatgen/symmetry/structure.py
+++ b/pymatgen/symmetry/structure.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
 
 import numpy as np
 from tabulate import tabulate
@@ -10,6 +10,8 @@ from tabulate import tabulate
 from pymatgen.core.structure import PeriodicSite, Structure
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from pymatgen.symmetry.analyzer import SpacegroupOperations
 
 

--- a/pymatgen/transformations/advanced_transformations.py
+++ b/pymatgen/transformations/advanced_transformations.py
@@ -9,7 +9,7 @@ from fractions import Fraction
 from itertools import groupby, product
 from math import gcd
 from string import ascii_lowercase
-from typing import Callable, Iterable
+from typing import TYPE_CHECKING, Callable
 
 import numpy as np
 from monty.dev import requires
@@ -38,6 +38,9 @@ from pymatgen.transformations.standard_transformations import (
     SupercellTransformation,
 )
 from pymatgen.transformations.transformation_abc import AbstractTransformation
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 try:
     import hiphive

--- a/pymatgen/util/provenance.py
+++ b/pymatgen/util/provenance.py
@@ -8,7 +8,6 @@ import re
 import sys
 from collections import namedtuple
 from io import StringIO
-from typing import Sequence
 
 from monty.json import MontyDecoder, MontyEncoder
 from monty.string import remove_non_ascii
@@ -19,7 +18,12 @@ try:
 except ImportError:
     pybtex = bibtex = None
 
+from typing import TYPE_CHECKING
+
 from pymatgen.core.structure import Molecule, Structure
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 __author__ = "Anubhav Jain, Shyue Ping Ong"
 __credits__ = "Dan Gunter"

--- a/pymatgen/util/typing.py
+++ b/pymatgen/util/typing.py
@@ -5,11 +5,8 @@ change until best practices are established.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Union
-
-import numpy as np
 
 from pymatgen.core.composition import Composition
 from pymatgen.core.periodic_table import DummySpecies, Element, Species
@@ -21,7 +18,6 @@ if TYPE_CHECKING:  # needed to avoid circular imports
     from pymatgen.entries.computed_entries import ComputedEntry, ComputedStructureEntry, GibbsComputedStructureEntry
     from pymatgen.entries.exp_entries import ExpEntry
 
-MatrixLike = Union[Sequence[Sequence[float]], Sequence[np.ndarray], np.ndarray]
 
 PathLike = Union[str, Path]
 

--- a/pymatgen/util/typing.py
+++ b/pymatgen/util/typing.py
@@ -5,8 +5,9 @@ change until best practices are established.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Sequence, Union
+from typing import TYPE_CHECKING, Any, Union
 
 import numpy as np
 
@@ -32,7 +33,7 @@ CompositionLike = Union[str, Element, Species, DummySpecies, dict, Composition]
 
 # Entry or any of its subclasses or dicts that can be unpacked into any of them
 EntryLike = Union[
-    Dict[str, Any],
+    dict[str, Any],
     "Entry",
     "PDEntry",
     "ComputedEntry",

--- a/pymatgen/vis/structure_vtk.py
+++ b/pymatgen/vis/structure_vtk.py
@@ -7,7 +7,7 @@ import math
 import os
 import subprocess
 import time
-from typing import Sequence
+from typing import TYPE_CHECKING
 
 import numpy as np
 from monty.dev import requires
@@ -17,6 +17,9 @@ from pymatgen.core.periodic_table import Species
 from pymatgen.core.sites import PeriodicSite
 from pymatgen.core.structure import Structure
 from pymatgen.util.coord import in_coord_list
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 try:
     import vtk

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ before-all = "ln -s /usr/lib64/libgfortran.so.5 /usr/lib64/libgfortran.so.3"
 repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel} --ignore-missing-dependencies"
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py39"
 line-length = 120
 select = [
   "B",    # flake8-bugbear

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         exclude=["pymatgen.*.tests", "pymatgen.*.*.tests", "pymatgen.*.*.*.tests"],
     ),
     version="2023.08.10",
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     install_requires=[
         "matplotlib>=1.5",
         "monty>=3.0.2",

--- a/tests/util/test_typing.py
+++ b/tests/util/test_typing.py
@@ -5,7 +5,7 @@ from typing import Any
 # pymatgen.entries needs to be imported before pymatgen.util.typing
 # to avoid circular import.
 from pymatgen.entries import Entry
-from pymatgen.util.typing import CompositionLike, EntryLike, MatrixLike, PathLike, SpeciesLike
+from pymatgen.util.typing import CompositionLike, EntryLike, PathLike, SpeciesLike
 
 # This module tests types are as expected and can be imported without circular ImportError.
 
@@ -45,10 +45,6 @@ def test_composition_like():
         _type_str(CompositionLike)
         == "Union[str, Element, Species, DummySpecies, dict, pymatgen.core.composition.Composition]"
     )
-
-
-def test_matrix_like():
-    assert _type_str(MatrixLike) == "Union[Sequence[Sequence[float]], Sequence[numpy.ndarray], numpy.ndarray]"
 
 
 def test_path_like():


### PR DESCRIPTION
Following suit with [`numpy` v1.25.0](https://numpy.org/doc/stable/release/1.25.0-notes.html) and [`pandas` v 2.1.0](https://pandas.pydata.org/pandas-docs/version/2.1.0/whatsnew/v2.1.0.html).