### PR TITLE
`np.(arange->linspace)` in `io/vasp/optics.py` `get_delta`, `get_setp` and `epsilon_imag`

### DIFF
--- a/pymatgen/io/vasp/optics.py
+++ b/pymatgen/io/vasp/optics.py
@@ -310,7 +310,7 @@ def get_delta(x0: float, sigma: float, nx: int, dx: float, ismear: int = 3):
         np.array: Array of size `nx` with delta function on the desired outputgrid.
 
     """
-    xgrid = np.linspace(0, nx * dx, nx,endpoint=False)
+    xgrid = np.linspace(0, nx * dx, nx, endpoint=False)
     xgrid -= x0
     x_scaled = (xgrid + (dx / 2)) / sigma
     sfun = step_func(x_scaled, ismear)
@@ -334,7 +334,7 @@ def get_step(x0, sigma, nx, dx, ismear):
     Return:
         np.array: Array of size `nx` with step function on the desired outputgrid.
     """
-    xgrid = np.linspace(0, nx * dx, nx,endpoint=False)
+    xgrid = np.linspace(0, nx * dx, nx, endpoint=False)
     xgrid -= x0
     x_scaled = (xgrid + (dx / 2)) / sigma
     return step_func(x_scaled, ismear)
@@ -373,7 +373,7 @@ def epsilon_imag(
 
     """
     norm_kweights = np.array(kweights) / np.sum(kweights)
-    egrid = np.linspace(0, nedos * deltae, nedos,endpoint=False)
+    egrid = np.linspace(0, nedos * deltae, nedos, endpoint=False)
     eigs_shifted = eigs - efermi
     # np.subtract.outer results in a matrix of shape (nband, nband)
     rspin = 3 - cder.shape[3]

--- a/tests/analysis/chemenv/coordination_environments/test_read_write.py
+++ b/tests/analysis/chemenv/coordination_environments/test_read_write.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
-import unittest
 
 from numpy.testing import assert_allclose, assert_array_almost_equal
 from pytest import approx
@@ -24,7 +22,7 @@ from pymatgen.analysis.chemenv.coordination_environments.structure_environments 
 )
 from pymatgen.analysis.chemenv.coordination_environments.voronoi import DetailedVoronoiContainer
 from pymatgen.core.structure import Structure
-from pymatgen.util.testing import TEST_FILES_DIR
+from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
 
 __author__ = "waroquiers"
 
@@ -32,12 +30,11 @@ json_dir = f"{TEST_FILES_DIR}/chemenv/json"
 struct_env_dir = f"{TEST_FILES_DIR}/chemenv/structure_environments"
 
 
-class TestReadWriteChemenv(unittest.TestCase):
+class TestReadWriteChemenv(PymatgenTest):
     @classmethod
     def setUpClass(cls):
         cls.lgf = LocalGeometryFinder()
         cls.lgf.setup_parameters(centering_type="standard")
-        os.makedirs("tmp_dir", exist_ok=True)
 
     def test_read_write_structure_environments(self):
         with open(f"{json_dir}/test_T--4_FePO4_icsd_4266.json") as file:
@@ -51,10 +48,10 @@ class TestReadWriteChemenv(unittest.TestCase):
             only_indices=atom_indices, maximum_distance_factor=2.25, get_from_hints=True
         )
 
-        with open("tmp_dir/se.json", "w") as file:
+        with open(f"{self.tmp_path}/se.json", "w") as file:
             json.dump(se.as_dict(), file)
 
-        with open("tmp_dir/se.json") as file:
+        with open(f"{self.tmp_path}/se.json") as file:
             dd = json.load(file)
 
         se2 = StructureEnvironments.from_dict(dd)
@@ -66,10 +63,10 @@ class TestReadWriteChemenv(unittest.TestCase):
             structure_environments=se, strategy=strategy, valences="undefined"
         )
 
-        with open("tmp_dir/lse.json", "w") as file:
+        with open(f"{self.tmp_path}/lse.json", "w") as file:
             json.dump(lse.as_dict(), file, default=lambda obj: getattr(obj, "tolist", lambda: obj)())
 
-        with open("tmp_dir/lse.json") as file:
+        with open(f"{self.tmp_path}/lse.json") as file:
             LightStructureEnvironments.from_dict(json.load(file))
 
         # assert lse == lse2
@@ -229,10 +226,10 @@ class TestReadWriteChemenv(unittest.TestCase):
 
         detailed_voronoi_container = DetailedVoronoiContainer(structure=struct, valences=valences)
 
-        with open("tmp_dir/se.json", "w") as file:
+        with open(f"{self.tmp_path}/se.json", "w") as file:
             json.dump(detailed_voronoi_container.as_dict(), file)
 
-        with open("tmp_dir/se.json") as file:
+        with open(f"{self.tmp_path}/se.json") as file:
             dd = json.load(file)
 
         detailed_voronoi_container2 = DetailedVoronoiContainer.from_dict(dd)


### PR DESCRIPTION
`np.linspace` ensures the array size is numerically stable. See the [`numpy.arange` warning](https://numpy.org/doc/stable/reference/generated/numpy.arange.html).