### PR TITLE
MatPESStaticSet restore GGA tag removal if xc_functional.upper() == "R2SCAN"

### DIFF
--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -1234,9 +1234,9 @@ class MatPESStaticSet(DictSet):
         Args:
             structure (Structure): Structure for static calculation.
             xc_functional ('R2SCAN'|'PBE'): Exchange-correlation functional to use. Defaults to 'PBE'.
-            user_potcar_functional: Choice of VASP POTCAR functional and version. Defaults to 'PBE_54'.
-            prev_incar (Incar|str): Incar file from previous run. Default settings of MatPESStaticSet
-                are prioritized over inputs from previous runs.
+            potcar_functional: Choice of VASP POTCAR functional and version. Defaults to 'PBE_54'.
+            prev_incar (Incar | dict): Incar file from previous run. Default settings of MatPESStaticSet
+                are prioritized over inputs from previous runs. Defaults to None.
             **kwargs: Passed to DictSet.
         """
         valid_xc_functionals = ("R2SCAN", "PBE", "PBE+U")
@@ -1268,9 +1268,8 @@ class MatPESStaticSet(DictSet):
         """Incar"""
         incar = super().incar
 
-        for p in MatPESStaticSet.INHERITED_INCAR_PARAMS:
-            if p in self.prev_incar:
-                incar[p] = self.prev_incar[p]
+        for key in set(self.INHERITED_INCAR_PARAMS) & set(self.prev_incar):
+            incar[key] = self.prev_incar[key]
         return incar
 
 

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -1215,27 +1215,9 @@ class MatPESStaticSet(DictSet):
     # These are parameters that we will inherit from any previous INCAR supplied. They are mostly parameters related
     # to symmetry and convergence set by Custodian when errors are encountered in a previous run. Given that our goal
     # is to have a strictly homogeneous PES data, all other parameters (e.g., ISMEAR, ALGO, etc.) are not inherited.
-    INHERITED_INCAR_PARAMS = (
-        "LPEAD",
-        "NGX",
-        "NGY",
-        "NGZ",
-        "SYMPREC",
-        "IMIX",
-        "LMAXMIX",
-        "KGAMMA",
-        "ISYM",
-        "NCORE",
-        "NPAR",
-        "NELMIN",
-        "IOPT",
-        "NBANDS",
-        "KPAR",
-        "AMIN",
-        "NELMDL",
-        "BMIX",
-        "AMIX_MAG",
-        "BMIX_MAG",
+    INHERITED_INCAR_PARAMS = tuple(
+        "LPEAD NGX NGY NGZ SYMPREC ISTART IMIX LMAXMIX KGAMMA ISYM NCORE NPAR NELMIN IOPT NBANDS "
+        "IALGO KPAR AMIN NELMDL BMIX AMIX_MAG BMIX_MAG".split()
     )
 
     def __init__(

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -1201,13 +1201,15 @@ class MPStaticSet(MPRelaxSet):
 class MatPESStaticSet(DictSet):
     """Creates input files for a MatPES static calculation.
 
-    The goal of MatPES is to generate PES data. This is a distinctly different from the objectives of the MP static
-    calculations, which aims to obtain accurate energies and electronic structure (DOS) primarily. For PES data,
-    force accuracy (and to some extent, stress accuracy) is of paramount importance.
+    The goal of MatPES is to generate potential energy surface data. This is a distinctly different
+    from the objectives of the MP static calculations, which aims to obtain primarily accurate
+    energies and also electronic structure (DOS). For PES data, force accuracy (and to some extent,
+    stress accuracy) is of paramount importance.
 
-    It should be noted that the default POTCAR versions have been updated to PBE_54, rather than the old PBE set used
-    in the MPStaticSet. However, **U values** are still based on PBE. The implicit assumption here is that the PBE_54
-    and PBE POTCARs are sufficiently similar that the U values fitted to the old PBE functional still applies.
+    The default POTCAR versions have been updated to PBE_54 from the old PBE set used in the
+    MPStaticSet. However, **U values** are still based on PBE. The implicit assumption here is that
+    the PBE_54 and PBE POTCARs are sufficiently similar that the U values fitted to the old PBE
+    functional still applies.
     """
 
     CONFIG = _load_yaml_config("MatPESStaticSet")
@@ -1224,10 +1226,10 @@ class MatPESStaticSet(DictSet):
         self,
         structure: Structure,
         xc_functional: Literal["R2SCAN", "PBE", "PBE+U"] = "PBE",
-        user_potcar_functional="PBE_54",
-        prev_incar=None,
+        user_potcar_functional: Literal["PBE_54", "PBE_52"] = "PBE_54",
+        prev_incar: Incar | dict | None = None,
         **kwargs: Any,
-    ):
+    ) -> None:
         """
         Args:
             structure (Structure): Structure for static calculation.
@@ -1254,7 +1256,7 @@ class MatPESStaticSet(DictSet):
                 f"POTCAR version ({user_potcar_functional}) is inconsistent with the recommended PBE_54.", UserWarning
             )
 
-        self.user_potcar_functional = user_potcar_functional.upper()
+        self.user_potcar_functional = user_potcar_functional
 
         self.kwargs = kwargs
         self.xc_functional = xc_functional

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -1249,8 +1249,9 @@ class MatPESStaticSet(DictSet):
 
         if xc_functional.upper() == "R2SCAN":
             self.user_incar_settings["METAGGA"] = "R2SCAN"
-            self.user_incar_settings["ALGO"] = "ALL"
-        elif xc_functional.upper() == "PBE+U":
+            self.user_incar_settings.setdefault("ALGO", "ALL")  # leave user-defined ALGO if set
+            self.user_incar_settings.pop("GGA", None)
+        if xc_functional.upper().endswith("+U"):
             self.user_incar_settings["LDAU"] = True
         if user_potcar_functional.upper() != "PBE_54":
             warnings.warn(

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -1217,9 +1217,27 @@ class MatPESStaticSet(DictSet):
     # These are parameters that we will inherit from any previous INCAR supplied. They are mostly parameters related
     # to symmetry and convergence set by Custodian when errors are encountered in a previous run. Given that our goal
     # is to have a strictly homogeneous PES data, all other parameters (e.g., ISMEAR, ALGO, etc.) are not inherited.
-    INHERITED_INCAR_PARAMS = tuple(
-        "LPEAD NGX NGY NGZ SYMPREC ISTART IMIX LMAXMIX KGAMMA ISYM NCORE NPAR NELMIN IOPT NBANDS "
-        "IALGO KPAR AMIN NELMDL BMIX AMIX_MAG BMIX_MAG".split()
+    INHERITED_INCAR_PARAMS = (
+        "LPEAD",
+        "NGX",
+        "NGY",
+        "NGZ",
+        "SYMPREC",
+        "IMIX",
+        "LMAXMIX",
+        "KGAMMA",
+        "ISYM",
+        "NCORE",
+        "NPAR",
+        "NELMIN",
+        "IOPT",
+        "NBANDS",
+        "KPAR",
+        "AMIN",
+        "NELMDL",
+        "BMIX",
+        "AMIX_MAG",
+        "BMIX_MAG",
     )
 
     def __init__(
@@ -1247,14 +1265,13 @@ class MatPESStaticSet(DictSet):
 
         if xc_functional.upper() == "R2SCAN":
             self._config_dict["INCAR"]["METAGGA"] = "R2SCAN"
-            self._config_dict["INCAR"].setdefault("ALGO", "ALL")  # leave user-defined ALGO if set
+            self._config_dict["INCAR"]["ALGO"] = "ALL"
             self._config_dict["INCAR"].pop("GGA", None)
         if xc_functional.upper().endswith("+U"):
             self._config_dict["INCAR"]["LDAU"] = True
-        if kwargs.get("user_potcar_functional", "PBE_54").upper() != "PBE_54":
-            warnings.warn(
-                f"POTCAR ({kwargs['user_potcar_functional']}) is inconsistent with the recommended PBE_54.", UserWarning
-            )
+        user_potcar_functional = kwargs.get("user_potcar_functional", "PBE_54")
+        if user_potcar_functional.upper() != "PBE_54":
+            warnings.warn(f"{user_potcar_functional=} is inconsistent with the recommended PBE_54.", UserWarning)
 
         self.kwargs = kwargs
         self.xc_functional = xc_functional

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -1239,6 +1239,12 @@ class MatPESStaticSet(DictSet):
                 are prioritized over inputs from previous runs.
             **kwargs: Passed to DictSet.
         """
+        valid_xc_functionals = ("R2SCAN", "PBE", "PBE+U")
+        if xc_functional.upper() not in valid_xc_functionals:
+            raise ValueError(
+                f"Unrecognized {xc_functional=}. Supported exchange-correlation functionals are {valid_xc_functionals}"
+            )
+
         super().__init__(structure, MatPESStaticSet.CONFIG, **kwargs)
 
         if xc_functional.upper() == "R2SCAN":
@@ -1246,11 +1252,6 @@ class MatPESStaticSet(DictSet):
             self.user_incar_settings["ALGO"] = "ALL"
         elif xc_functional.upper() == "PBE+U":
             self.user_incar_settings["LDAU"] = True
-        elif xc_functional.upper() != "PBE":
-            raise ValueError(
-                f"{xc_functional} is not supported."
-                " The supported exchange-correlation functionals are PBE, PBE+U and R2SCAN."
-            )
         if user_potcar_functional.upper() != "PBE_54":
             warnings.warn(
                 f"POTCAR version ({user_potcar_functional}) is inconsistent with the recommended PBE_54.", UserWarning

--- a/tests/io/vasp/test_sets.py
+++ b/tests/io/vasp/test_sets.py
@@ -836,13 +836,13 @@ class TestMatPESStaticSet(PymatgenTest):
         assert default_u.kpoints is None
 
     def test_functionals(self):
-        functional = "LDA"
-        with pytest.raises(ValueError, match=f"{functional} is not supported"):
-            MatPESStaticSet(self.struct, xc_functional=functional)
-        with pytest.warns(
-            UserWarning,
-            match="inconsistent with the recommended PBE_54",
+        xc_functional = "LDA"
+        with pytest.raises(
+            ValueError, match=f"Unrecognized {xc_functional=}. Supported exchange-correlation functionals are "
         ):
+            MatPESStaticSet(self.struct, xc_functional=xc_functional)
+
+        with pytest.warns(UserWarning, match="inconsistent with the recommended PBE_54"):
             diff_potcar = MatPESStaticSet(self.struct, user_potcar_functional="PBE")
             assert str(diff_potcar.potcar[0]) == str(PotcarSingle.from_symbol_and_functional("Fe_pv", "PBE"))
 


### PR DESCRIPTION
13883af9c use str.split for INHERITED_INCAR_PARAMS
9d6ee83cb add MatPESStaticSet init type hints
a89090aaf move ValueError Unrecognized {xc_functional=} to top
aeebf008f refactor MatPESStaticSet def incar(self) -> Incar:
bfd947676 leave user-defined ALGO if set, always apply LADU if xc_functional.upper().endswith("+U") and restore removing GGA tag if xc_functional.upper() == "R2SCAN"
5b7ab3fa3 fix test_functionals