### PR TITLE
Deprecate overlooked `from/as_..._string` methods

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,7 +31,7 @@ jobs:
       - name: ruff
         run: |
           ruff --version
-          ruff . --ignore D
+          ruff .
 
       - name: black
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ ci:
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.286
+    rev: v0.0.287
     hooks:
       - id: ruff
         args: [--fix]

--- a/dev_scripts/update_pt_data.py
+++ b/dev_scripts/update_pt_data.py
@@ -78,16 +78,16 @@ def parse_ionic_radii():
     header = radii_data[0].split(",")
     for idx in range(1, len(radii_data)):
         line = radii_data[idx]
-        toks = line.strip().split(",")
+        tokens = line.strip().split(",")
         suffix = ""
-        name = toks[1]
+        name = tokens[1]
         if len(name.split(" ")) > 1:
             suffix = "_" + name.split(" ")[1]
-        el = toks[2]
+        el = tokens[2]
 
         ionic_radii = {}
-        for j in range(3, len(toks)):
-            m = re.match(r"^\s*([0-9\.]+)", toks[j])
+        for j in range(3, len(tokens)):
+            m = re.match(r"^\s*([0-9\.]+)", tokens[j])
             if m:
                 ionic_radii[int(header[j])] = float(m.group(1))
 
@@ -109,22 +109,22 @@ def parse_radii():
     radii_data = radii_data.split("\r")
 
     for line in radii_data:
-        toks = line.strip().split(",")
-        el = toks[1]
+        tokens = line.strip().split(",")
+        el = tokens[1]
         try:
-            atomic_radii = float(toks[3]) / 100
+            atomic_radii = float(tokens[3]) / 100
         except Exception:
-            atomic_radii = toks[3]
+            atomic_radii = tokens[3]
 
         try:
-            atomic_radii_calc = float(toks[4]) / 100
+            atomic_radii_calc = float(tokens[4]) / 100
         except Exception:
-            atomic_radii_calc = toks[4]
+            atomic_radii_calc = tokens[4]
 
         try:
-            vdw_radii = float(toks[5]) / 100
+            vdw_radii = float(tokens[5]) / 100
         except Exception:
-            vdw_radii = toks[5]
+            vdw_radii = tokens[5]
 
         if el in data:
             data[el]["Atomic radius"] = atomic_radii

--- a/pymatgen/alchemy/transmuters.py
+++ b/pymatgen/alchemy/transmuters.py
@@ -117,9 +117,9 @@ class StandardTransmuter:
             with Pool(self.ncores) as p:
                 # need to condense arguments into single tuple to use map
                 z = ((x, transformation, extend_collection, clear_redo) for x in self.transformed_structures)
-                new_tstructs = p.map(_apply_transformation, z, 1)
+                nrafo_ew_tstructs = p.map(_apply_transformation, z, 1)
                 self.transformed_structures = []
-                for ts in new_tstructs:
+                for ts in nrafo_ew_tstructs:
                     self.transformed_structures.extend(ts)
         else:
             new_structures = []
@@ -188,21 +188,21 @@ class StandardTransmuter:
             output.append(str(x.final_structure))
         return "\n".join(output)
 
-    def append_transformed_structures(self, tstructs_or_transmuter):
+    def append_transformed_structures(self, trafo_structs_or_transmuter):
         """Method is overloaded to accept either a list of transformed structures
         or transmuter, it which case it appends the second transmuter"s
         structures.
 
         Args:
-            tstructs_or_transmuter: A list of transformed structures or a
+            trafo_structs_or_transmuter: A list of transformed structures or a
                 transmuter.
         """
-        if isinstance(tstructs_or_transmuter, self.__class__):
-            self.transformed_structures.extend(tstructs_or_transmuter.transformed_structures)
+        if isinstance(trafo_structs_or_transmuter, self.__class__):
+            self.transformed_structures.extend(trafo_structs_or_transmuter.transformed_structures)
         else:
-            for ts in tstructs_or_transmuter:
+            for ts in trafo_structs_or_transmuter:
                 assert isinstance(ts, TransformedStructure)
-            self.transformed_structures.extend(tstructs_or_transmuter)
+            self.transformed_structures.extend(trafo_structs_or_transmuter)
 
     @staticmethod
     def from_structures(structures, transformations=None, extend_collection=0):
@@ -221,8 +221,8 @@ class StandardTransmuter:
         Returns:
             StandardTransmuter
         """
-        tstruct = [TransformedStructure(s, []) for s in structures]
-        return StandardTransmuter(tstruct, transformations, extend_collection)
+        trafo_struct = [TransformedStructure(s, []) for s in structures]
+        return StandardTransmuter(trafo_struct, transformations, extend_collection)
 
 
 class CifTransmuter(StandardTransmuter):
@@ -255,8 +255,8 @@ class CifTransmuter(StandardTransmuter):
             if read_data:
                 structure_data[-1].append(line)
         for data in structure_data:
-            tstruct = TransformedStructure.from_cif_string("\n".join(data), [], primitive)
-            transformed_structures.append(tstruct)
+            trafo_struct = TransformedStructure.from_cif_string("\n".join(data), [], primitive)
+            transformed_structures.append(trafo_struct)
         super().__init__(transformed_structures, transformations, extend_collection)
 
     @staticmethod
@@ -295,8 +295,8 @@ class PoscarTransmuter(StandardTransmuter):
             extend_collection: Whether to use more than one output structure
                 from one-to-many transformations.
         """
-        tstruct = TransformedStructure.from_poscar_string(poscar_string, [])
-        super().__init__([tstruct], transformations, extend_collection=extend_collection)
+        trafo_struct = TransformedStructure.from_poscar_string(poscar_string, [])
+        super().__init__([trafo_struct], transformations, extend_collection=extend_collection)
 
     @staticmethod
     def from_filenames(poscar_filenames, transformations=None, extend_collection=False):
@@ -310,11 +310,11 @@ class PoscarTransmuter(StandardTransmuter):
             extend_collection:
                 Same meaning as in __init__.
         """
-        tstructs = []
+        trafo_structs = []
         for filename in poscar_filenames:
             with open(filename) as f:
-                tstructs.append(TransformedStructure.from_poscar_string(f.read(), []))
-        return StandardTransmuter(tstructs, transformations, extend_collection=extend_collection)
+                trafo_structs.append(TransformedStructure.from_poscar_string(f.read(), []))
+        return StandardTransmuter(trafo_structs, transformations, extend_collection=extend_collection)
 
 
 def batch_write_vasp_input(

--- a/pymatgen/cli/pmg_structure.py
+++ b/pymatgen/cli/pmg_structure.py
@@ -54,9 +54,9 @@ def analyze_localenv(args):
     """
     bonds = {}
     for bond in args.localenv:
-        toks = bond.split("=")
-        species = toks[0].split("-")
-        bonds[(species[0], species[1])] = float(toks[1])
+        tokens = bond.split("=")
+        species = tokens[0].split("-")
+        bonds[(species[0], species[1])] = float(tokens[1])
     for filename in args.filenames:
         print(f"Analyzing {filename}...")
         data = []

--- a/pymatgen/core/operations.py
+++ b/pymatgen/core/operations.py
@@ -418,9 +418,14 @@ class SymmOp(MSONable):
             "tolerance": self.tol,
         }
 
-    def as_xyz_string(self) -> str:
-        """Returns a string of the form 'x, y, z', '-x, -y, z',
-        '-y+1/2, x+1/2, z+1/2', etc. Only works for integer rotation matrices.
+    @classmethod
+    @np.deprecate(message="Use as_xyz_str instead")
+    def as_xyz_string(cls, *args, **kwargs):  # noqa: D102
+        return cls.as_xyz_str(*args, **kwargs)
+
+    def as_xyz_str(self) -> str:
+        """Returns a string of the form 'x, y, z', '-x, -y, z', '-y+1/2, x+1/2, z+1/2', etc.
+        Only works for integer rotation matrices.
         """
         # test for invalid rotation matrix
         if not np.all(np.isclose(self.rotation_matrix, np.round(self.rotation_matrix))):
@@ -428,19 +433,23 @@ class SymmOp(MSONable):
 
         return transformation_to_string(self.rotation_matrix, translation_vec=self.translation_vector, delim=", ")
 
-    @staticmethod
-    def from_xyz_string(xyz_string: str) -> SymmOp:
+    @classmethod
+    @np.deprecate(message="Use from_xyz_str instead")
+    def from_xyz_string(cls, *args, **kwargs):  # noqa: D102
+        return cls.from_xyz_str(*args, **kwargs)
+
+    @classmethod
+    def from_xyz_str(cls, xyz_str: str) -> SymmOp:
         """
         Args:
-            xyz_string: string of the form 'x, y, z', '-x, -y, z',
-                '-2y+1/2, 3x+1/2, z-y+1/2', etc.
+            xyz_str: string of the form 'x, y, z', '-x, -y, z', '-2y+1/2, 3x+1/2, z-y+1/2', etc.
 
         Returns:
             SymmOp
         """
         rot_matrix = np.zeros((3, 3))
         trans = np.zeros(3)
-        tokens = xyz_string.strip().replace(" ", "").lower().split(",")
+        tokens = xyz_str.strip().replace(" ", "").lower().split(",")
         re_rot = re.compile(r"([+-]?)([\d\.]*)/?([\d\.]*)([x-z])")
         re_trans = re.compile(r"([+-]?)([\d\.]+)/?([\d\.]*)(?![x-z])")
         for i, tok in enumerate(tokens):
@@ -456,7 +465,7 @@ class SymmOp(MSONable):
                 factor = -1 if m.group(1) == "-" else 1
                 num = float(m.group(2)) / float(m.group(3)) if m.group(3) != "" else float(m.group(2))
                 trans[i] = num * factor
-        return SymmOp.from_rotation_and_translation(rot_matrix, trans)
+        return cls.from_rotation_and_translation(rot_matrix, trans)
 
     @classmethod
     def from_dict(cls, d) -> SymmOp:

--- a/pymatgen/core/operations.py
+++ b/pymatgen/core/operations.py
@@ -418,7 +418,6 @@ class SymmOp(MSONable):
             "tolerance": self.tol,
         }
 
-    @classmethod
     @np.deprecate(message="Use as_xyz_str instead")
     def as_xyz_string(cls, *args, **kwargs):  # noqa: D102
         return cls.as_xyz_str(*args, **kwargs)

--- a/pymatgen/core/operations.py
+++ b/pymatgen/core/operations.py
@@ -440,10 +440,10 @@ class SymmOp(MSONable):
         """
         rot_matrix = np.zeros((3, 3))
         trans = np.zeros(3)
-        toks = xyz_string.strip().replace(" ", "").lower().split(",")
+        tokens = xyz_string.strip().replace(" ", "").lower().split(",")
         re_rot = re.compile(r"([+-]?)([\d\.]*)/?([\d\.]*)([x-z])")
         re_trans = re.compile(r"([+-]?)([\d\.]+)/?([\d\.]*)(?![x-z])")
-        for i, tok in enumerate(toks):
+        for i, tok in enumerate(tokens):
             # build the rotation matrix
             for m in re_rot.finditer(tok):
                 factor = -1.0 if m.group(1) == "-" else 1.0

--- a/pymatgen/core/periodic_table.py
+++ b/pymatgen/core/periodic_table.py
@@ -1143,8 +1143,8 @@ class Species(MSONable, Stringify):
             # parse properties (optional)
             properties = {}
             if match.group(4):  # has Spin properties
-                toks = match.group(4).replace(",", "").split("=")
-                properties = {toks[0]: ast.literal_eval(toks[1])}
+                tokens = match.group(4).replace(",", "").split("=")
+                properties = {tokens[0]: ast.literal_eval(tokens[1])}
 
             # but we need either an oxidation state or a property
             if oxi is None and properties == {}:
@@ -1422,8 +1422,8 @@ class DummySpecies(Species):
                 oxi = -oxi if m.group(3) == "-" else oxi
             properties = {}
             if m.group(4):  # has Spin property
-                toks = m.group(4).split("=")
-                properties = {toks[0]: float(toks[1])}
+                tokens = m.group(4).split("=")
+                properties = {tokens[0]: float(tokens[1])}
             return DummySpecies(sym, oxi, **properties)
         raise ValueError("Invalid DummySpecies String")
 

--- a/pymatgen/io/cssr.py
+++ b/pymatgen/io/cssr.py
@@ -67,10 +67,10 @@ class Cssr:
             Cssr object.
         """
         lines = string.split("\n")
-        toks = lines[0].split()
-        lengths = [float(tok) for tok in toks]
-        toks = lines[1].split()
-        angles = [float(tok) for tok in toks[0:3]]
+        tokens = lines[0].split()
+        lengths = [float(tok) for tok in tokens]
+        tokens = lines[1].split()
+        angles = [float(tok) for tok in tokens[0:3]]
         latt = Lattice.from_parameters(*lengths, *angles)
         sp = []
         coords = []

--- a/pymatgen/io/feff/inputs.py
+++ b/pymatgen/io/feff/inputs.py
@@ -300,10 +300,10 @@ class Header(MSONable):
         """
         lines = tuple(clean_lines(header_str.split("\n"), False))
         comment1 = lines[0]
-        feffpmg = comment1.find("pymatgen")
-        if feffpmg == -1:
-            feffpmg = False
-        if feffpmg:
+        feff_pmg = comment1.find("pymatgen")
+        if feff_pmg == -1:
+            feff_pmg = False
+        if feff_pmg:
             comment2 = " ".join(lines[1].split()[2:])
 
             source = " ".join(lines[2].split()[2:])
@@ -322,17 +322,17 @@ class Header(MSONable):
 
             lattice = Lattice.from_parameters(*lengths, *angles)
 
-            natoms = int(lines[8].split(":")[-1].split()[0])
+            n_atoms = int(lines[8].split(":")[-1].split()[0])
 
             atomic_symbols = []
-            for i in range(9, 9 + natoms):
+            for i in range(9, 9 + n_atoms):
                 atomic_symbols.append(lines[i].split()[2])
 
             # read the atomic coordinates
             coords = []
-            for i in range(natoms):
-                toks = lines[i + 9].split()
-                coords.append([float(s) for s in toks[3:]])
+            for i in range(n_atoms):
+                tokens = lines[i + 9].split()
+                coords.append([float(s) for s in tokens[3:]])
 
             struct = Structure(lattice, atomic_symbols, coords, False, False, False)
 
@@ -759,9 +759,9 @@ class Tags(dict):
 
             if key in list_type_keys:
                 output = []
-                toks = re.split(r"\s+", val)
+                tokens = re.split(r"\s+", val)
 
-                for tok in toks:
+                for tok in tokens:
                     m = re.match(r"(\d+)\*([\d\.\-\+]+)", tok)
                     if m:
                         output.extend([smart_int_or_float(m.group(2))] * int(m.group(1)))

--- a/pymatgen/io/fiesta.py
+++ b/pymatgen/io/fiesta.py
@@ -591,78 +591,78 @@ $geometry
         # number of atoms and species
         lines.pop(0)
         line = lines.pop(0).strip()
-        toks = line.split()
-        nat = toks[0]
-        nsp = toks[1]
+        tokens = line.split()
+        nat = tokens[0]
+        nsp = tokens[1]
         # number of valence bands
         lines.pop(0)
         line = lines.pop(0).strip()
-        toks = line.split()
+        tokens = line.split()
 
         # correlation_grid
         # number of points and spacing in eV for correlation grid
         lines.pop(0)
         line = lines.pop(0).strip()
-        toks = line.split()
-        correlation_grid["n_grid"] = toks[0]
-        correlation_grid["dE_grid"] = toks[1]
+        tokens = line.split()
+        correlation_grid["n_grid"] = tokens[0]
+        correlation_grid["dE_grid"] = tokens[1]
 
         # Exc DFT
         # relire=1 ou recalculer=0 Exc DFT
         lines.pop(0)
         line = lines.pop(0).strip()
-        toks = line.split()
-        Exc_DFT_option["rdVxcpsi"] = toks[0]
+        tokens = line.split()
+        Exc_DFT_option["rdVxcpsi"] = tokens[0]
 
         # COHSEX
         # number of COHSEX corrected occp and unoccp bands: C=COHSEX  H=HF
         lines.pop(0)
         line = lines.pop(0).strip()
-        toks = line.split()
-        COHSEX_options["nv_cohsex"] = toks[0]
-        COHSEX_options["nc_cohsex"] = toks[1]
-        COHSEX_options["eigMethod"] = toks[2]
+        tokens = line.split()
+        COHSEX_options["nv_cohsex"] = tokens[0]
+        COHSEX_options["nc_cohsex"] = tokens[1]
+        COHSEX_options["eigMethod"] = tokens[2]
         # number of COHSEX iter, scf on wfns, mixing coeff; V=RI-V  I=RI-D
         lines.pop(0)
         line = lines.pop(0).strip()
-        toks = line.split()
-        COHSEX_options["nit_cohsex"] = toks[0]
-        COHSEX_options["resMethod"] = toks[1]
-        COHSEX_options["scf_cohsex_wf"] = toks[2]
-        COHSEX_options["mix_cohsex"] = toks[3]
+        tokens = line.split()
+        COHSEX_options["nit_cohsex"] = tokens[0]
+        COHSEX_options["resMethod"] = tokens[1]
+        COHSEX_options["scf_cohsex_wf"] = tokens[2]
+        COHSEX_options["mix_cohsex"] = tokens[3]
 
         # GW
         # number of GW corrected occp and unoccp bands
         lines.pop(0)
         line = lines.pop(0).strip()
-        toks = line.split()
-        GW_options["nv_corr"] = toks[0]
-        GW_options["nc_corr"] = toks[1]
+        tokens = line.split()
+        GW_options["nv_corr"] = tokens[0]
+        GW_options["nc_corr"] = tokens[1]
         # number of GW iterations
         lines.pop(0)
         line = lines.pop(0).strip()
-        toks = line.split()
-        GW_options["nit_gw"] = toks[0]
+        tokens = line.split()
+        GW_options["nit_gw"] = tokens[0]
 
         # BSE
         # dumping for BSE and TDDFT
         lines.pop(0)
         line = lines.pop(0).strip()
-        toks = line.split()
-        BSE_TDDFT_options["do_bse"] = toks[0]
-        BSE_TDDFT_options["do_tddft"] = toks[1]
+        tokens = line.split()
+        BSE_TDDFT_options["do_bse"] = tokens[0]
+        BSE_TDDFT_options["do_tddft"] = tokens[1]
         # number of occp. and virtual bands of BSE: nocore and up to 40 eVs
         lines.pop(0)
         line = lines.pop(0).strip()
-        toks = line.split()
-        BSE_TDDFT_options["nv_bse"] = toks[0]
-        BSE_TDDFT_options["nc_bse"] = toks[1]
+        tokens = line.split()
+        BSE_TDDFT_options["nv_bse"] = tokens[0]
+        BSE_TDDFT_options["nc_bse"] = tokens[1]
         # number of excitations needed and number of iterations
         lines.pop(0)
         line = lines.pop(0).strip()
-        toks = line.split()
-        BSE_TDDFT_options["npsi_bse"] = toks[0]
-        BSE_TDDFT_options["nit_bse"] = toks[1]
+        tokens = line.split()
+        BSE_TDDFT_options["npsi_bse"] = tokens[0]
+        BSE_TDDFT_options["nit_bse"] = tokens[1]
 
         # Molecule
         # list of symbols in order
@@ -671,14 +671,14 @@ $geometry
         i = int(nsp)
         while i != 0:
             line = lines.pop(0).strip()
-            toks = line.split()
-            atname.append(toks[0])
+            tokens = line.split()
+            atname.append(tokens[0])
             i -= 1
 
         # scaling factor
         lines.pop(0)
         line = lines.pop(0).strip()
-        toks = line.split()
+        tokens = line.split()
         # atoms x,y,z cartesian .. will be multiplied by scale
         lines.pop(0)
         # Parse geometry
@@ -687,9 +687,9 @@ $geometry
         i = int(nat)
         while i != 0:
             line = lines.pop(0).strip()
-            toks = line.split()
-            coords.append([float(j) for j in toks[0:3]])
-            species.append(atname[int(toks[3]) - 1])
+            tokens = line.split()
+            coords.append([float(j) for j in tokens[0:3]])
+            species.append(atname[int(tokens[3]) - 1])
             i -= 1
 
         mol = Molecule(species, coords)

--- a/pymatgen/io/gaussian.py
+++ b/pymatgen/io/gaussian.py
@@ -191,24 +191,24 @@ class GaussianInput:
             if (not zmode) and GaussianInput._xyz_patt.match(line):
                 m = GaussianInput._xyz_patt.match(line)
                 species.append(m.group(1))
-                toks = re.split(r"[,\s]+", line.strip())
-                if len(toks) > 4:
-                    coords.append([float(i) for i in toks[2:5]])
+                tokens = re.split(r"[,\s]+", line.strip())
+                if len(tokens) > 4:
+                    coords.append([float(i) for i in tokens[2:5]])
                 else:
-                    coords.append([float(i) for i in toks[1:4]])
+                    coords.append([float(i) for i in tokens[1:4]])
             elif GaussianInput._zmat_patt.match(line):
                 zmode = True
-                toks = re.split(r"[,\s]+", line.strip())
-                species.append(toks[0])
-                toks.pop(0)
-                if len(toks) == 0:
+                tokens = re.split(r"[,\s]+", line.strip())
+                species.append(tokens[0])
+                tokens.pop(0)
+                if len(tokens) == 0:
                     coords.append(np.array([0, 0, 0]))
                 else:
                     nn = []
                     parameters = []
-                    while len(toks) > 1:
-                        ind = toks.pop(0)
-                        data = toks.pop(0)
+                    while len(tokens) > 1:
+                        ind = tokens.pop(0)
+                        data = tokens.pop(0)
                         try:
                             nn.append(int(ind))
                         except ValueError:
@@ -321,9 +321,9 @@ class GaussianInput:
             ind += 1
         title = " ".join(title)
         ind += 1
-        toks = re.split(r"[,\s]+", lines[route_index + ind])
-        charge = int(float(toks[0]))
-        spin_mult = int(toks[1])
+        tokens = re.split(r"[,\s]+", lines[route_index + ind])
+        charge = int(float(tokens[0]))
+        spin_mult = int(tokens[1])
         coord_lines = []
         spaces = 0
         input_paras = {}
@@ -833,9 +833,9 @@ class GaussianOutput:
                         sp = []
                         coords = []
                         while set(line.strip()) != {"-"}:
-                            toks = line.split()
-                            sp.append(Element.from_Z(int(toks[1])))
-                            coords.append([float(x) for x in toks[3:6]])
+                            tokens = line.split()
+                            sp.append(Element.from_Z(int(tokens[1])))
+                            coords.append([float(x) for x in tokens[3:6]])
                             line = f.readline()
 
                         read_coord = False

--- a/pymatgen/io/nwchem.py
+++ b/pymatgen/io/nwchem.py
@@ -446,64 +446,64 @@ class NwInput(MSONable):
             if line == "":
                 continue
 
-            toks = line.split()
-            if toks[0].lower() == "geometry":
-                geom_options = toks[1:]
+            tokens = line.split()
+            if tokens[0].lower() == "geometry":
+                geom_options = tokens[1:]
                 line = lines.pop(0).strip()
-                toks = line.split()
-                if toks[0].lower() == "symmetry":
-                    symmetry_options = toks[1:]
+                tokens = line.split()
+                if tokens[0].lower() == "symmetry":
+                    symmetry_options = tokens[1:]
                     line = lines.pop(0).strip()
                 # Parse geometry
                 species = []
                 coords = []
                 while line.lower() != "end":
-                    toks = line.split()
-                    species.append(toks[0])
-                    coords.append([float(i) for i in toks[1:]])
+                    tokens = line.split()
+                    species.append(tokens[0])
+                    coords.append([float(i) for i in tokens[1:]])
                     line = lines.pop(0).strip()
                 mol = Molecule(species, coords)
-            elif toks[0].lower() == "charge":
-                charge = int(toks[1])
-            elif toks[0].lower() == "title":
+            elif tokens[0].lower() == "charge":
+                charge = int(tokens[1])
+            elif tokens[0].lower() == "title":
                 title = line[5:].strip().strip('"')
-            elif toks[0].lower() == "basis":
+            elif tokens[0].lower() == "basis":
                 # Parse basis sets
                 line = lines.pop(0).strip()
                 basis_set = {}
                 while line.lower() != "end":
-                    toks = line.split()
-                    basis_set[toks[0]] = toks[-1].strip('"')
+                    tokens = line.split()
+                    basis_set[tokens[0]] = tokens[-1].strip('"')
                     line = lines.pop(0).strip()
-            elif toks[0].lower() in NwTask.theories:
+            elif tokens[0].lower() in NwTask.theories:
                 # read the basis_set_option
-                if len(toks) > 1:
-                    basis_set_option = toks[1]
+                if len(tokens) > 1:
+                    basis_set_option = tokens[1]
                 # Parse theory directives.
-                theory = toks[0].lower()
+                theory = tokens[0].lower()
                 line = lines.pop(0).strip()
                 theory_directives[theory] = {}
                 while line.lower() != "end":
-                    toks = line.split()
-                    theory_directives[theory][toks[0]] = toks[-1]
-                    if toks[0] == "mult":
-                        spin_multiplicity = float(toks[1])
+                    tokens = line.split()
+                    theory_directives[theory][tokens[0]] = tokens[-1]
+                    if tokens[0] == "mult":
+                        spin_multiplicity = float(tokens[1])
                     line = lines.pop(0).strip()
-            elif toks[0].lower() == "task":
+            elif tokens[0].lower() == "task":
                 tasks.append(
                     NwTask(
                         charge=charge,
                         spin_multiplicity=spin_multiplicity,
                         title=title,
-                        theory=toks[1],
-                        operation=toks[2],
+                        theory=tokens[1],
+                        operation=tokens[2],
                         basis_set=basis_set,
                         basis_set_option=basis_set_option,
-                        theory_directives=theory_directives.get(toks[1]),
+                        theory_directives=theory_directives.get(tokens[1]),
                     )
                 )
-            elif toks[0].lower() == "memory":
-                memory_options = " ".join(toks[1:])
+            elif tokens[0].lower() == "memory":
+                memory_options = " ".join(tokens[1:])
             else:
                 directives.append(line.strip().split())
 
@@ -609,8 +609,8 @@ class NwOutput:
                 state = "triplet"
 
             elif inside and "Root" in line and "eV" in line:
-                toks = line.split()
-                roots[state].append({"energy": float(toks[-2])})
+                tokens = line.split()
+                roots[state].append({"energy": float(tokens[-2])})
 
             elif inside and "Dipole Oscillator Strength" in line:
                 osc = float(line.split()[-1])
@@ -669,9 +669,9 @@ class NwOutput:
     def _parse_preamble(preamble):
         info = {}
         for line in preamble.split("\n"):
-            toks = line.split("=")
-            if len(toks) > 1:
-                info[toks[0].strip()] = toks[-1].strip()
+            tokens = line.split("=")
+            if len(tokens) > 1:
+                info[tokens[0].strip()] = tokens[-1].strip()
         return info
 
     def __iter__(self):
@@ -802,11 +802,11 @@ class NwOutput:
                 if line.strip() == "":
                     parse_bset = False
                 else:
-                    toks = line.split()
-                    if toks[0] != "Tag" and not re.match(r"-+", toks[0]):
-                        basis_set[toks[0]] = dict(zip(bset_header[1:], toks[1:]))
-                    elif toks[0] == "Tag":
-                        bset_header = toks
+                    tokens = line.split()
+                    if tokens[0] != "Tag" and not re.match(r"-+", tokens[0]):
+                        basis_set[tokens[0]] = dict(zip(bset_header[1:], tokens[1:]))
+                    elif tokens[0] == "Tag":
+                        bset_header = tokens
                         bset_header.pop(4)
                         bset_header = [h.lower() for h in bset_header]
 
@@ -816,15 +816,15 @@ class NwOutput:
                 if len(hessian) > 0 and line.find("----------") != -1:
                     parse_hess = False
                     continue
-                toks = line.strip().split()
-                if len(toks) > 1:
+                tokens = line.strip().split()
+                if len(tokens) > 1:
                     try:
-                        row = int(toks[0])
+                        row = int(tokens[0])
                     except Exception:
                         continue
-                    if isfloatstring(toks[1]):
+                    if isfloatstring(tokens[1]):
                         continue
-                    vals = [float(fort2py(x)) for x in toks[1:]]
+                    vals = [float(fort2py(x)) for x in tokens[1:]]
                     if len(hessian) < row:
                         hessian.append(vals)
                     else:
@@ -834,15 +834,15 @@ class NwOutput:
                 if line.strip() == "":
                     continue
                 nat3 = len(hessian)
-                toks = line.strip().split()
-                if len(toks) > 1:
+                tokens = line.strip().split()
+                if len(tokens) > 1:
                     try:
-                        row = int(toks[0])
+                        row = int(tokens[0])
                     except Exception:
                         continue
-                    if isfloatstring(toks[1]):
+                    if isfloatstring(tokens[1]):
                         continue
-                    vals = [float(fort2py(x)) for x in toks[1:]]
+                    vals = [float(fort2py(x)) for x in tokens[1:]]
                     if len(projected_hessian) < row:
                         projected_hessian.append(vals)
                     else:
@@ -884,12 +884,12 @@ class NwOutput:
                     parse_projected_freq = True
                     if frequencies is None:
                         frequencies = []
-                    toks = line.strip().split()[1:]
-                    frequencies.extend([(float(freq), []) for freq in toks])
+                    tokens = line.strip().split()[1:]
+                    frequencies.extend([(float(freq), []) for freq in tokens])
 
                 elif line.find("Frequency") != -1:
-                    toks = line.strip().split()
-                    if len(toks) > 1 and toks[0] == "Frequency":
+                    tokens = line.strip().split()
+                    if len(tokens) > 1 and tokens[0] == "Frequency":
                         parse_freq = True
                         if normal_frequencies is None:
                             normal_frequencies = []

--- a/pymatgen/io/packmol.py
+++ b/pymatgen/io/packmol.py
@@ -38,8 +38,7 @@ __date__ = "Nov 2021"
 
 class PackmolSet(InputSet):
     """
-    InputSet for the Packmol software. This class defines several attributes related
-    to.
+    InputSet for the Packmol software. This class defines several attributes related to.
     """
 
     def run(self, path: str | Path, timeout=30):
@@ -56,11 +55,9 @@ class PackmolSet(InputSet):
         wd = os.getcwd()
         if not which("packmol"):
             raise RuntimeError(
-                "Running a PackmolSet requires the executable 'packmol' to be in "
-                "the path. Please download packmol from "
-                "https://github.com/leandromartinez98/packmol "
-                "and follow the instructions in the README to compile. "
-                "Don't forget to add the packmol binary to your path"
+                "Running a PackmolSet requires the executable 'packmol' to be in the path. Please "
+                "download packmol from https://github.com/leandromartinez98/packmol and follow the "
+                "instructions in the README to compile. Don't forget to add the packmol binary to your path"
             )
         try:
             os.chdir(path)

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -862,8 +862,8 @@ class Incar(dict, MSONable):
         try:
             if key in list_keys:
                 output = []
-                toks = re.findall(r"(-?\d+\.?\d*)\*?(-?\d+\.?\d*)?\*?(-?\d+\.?\d*)?", val)
-                for tok in toks:
+                tokens = re.findall(r"(-?\d+\.?\d*)\*?(-?\d+\.?\d*)?\*?(-?\d+\.?\d*)?", val)
+                for tok in tokens:
                     if tok[2] and "3" in tok[0]:
                         output.extend([smart_int_or_float(tok[2])] * int(tok[0]) * int(tok[1]))
                     elif tok[1]:
@@ -1452,23 +1452,23 @@ class Kpoints(MSONable):
         tet_connections = None
 
         for i in range(3, 3 + num_kpts):
-            toks = lines[i].split()
-            kpts.append([float(j) for j in toks[0:3]])
-            kpts_weights.append(float(toks[3]))
-            if len(toks) > 4:
-                labels.append(toks[4])
+            tokens = lines[i].split()
+            kpts.append([float(j) for j in tokens[0:3]])
+            kpts_weights.append(float(tokens[3]))
+            if len(tokens) > 4:
+                labels.append(tokens[4])
             else:
                 labels.append(None)
         try:
             # Deal with tetrahedron method
             if lines[3 + num_kpts].strip().lower()[0] == "t":
-                toks = lines[4 + num_kpts].split()
-                tet_number = int(toks[0])
-                tet_weight = float(toks[1])
+                tokens = lines[4 + num_kpts].split()
+                tet_number = int(tokens[0])
+                tet_weight = float(tokens[1])
                 tet_connections = []
                 for i in range(5 + num_kpts, 5 + num_kpts + tet_number):
-                    toks = lines[i].split()
-                    tet_connections.append((int(toks[0]), [int(toks[j]) for j in range(1, 5)]))
+                    tokens = lines[i].split()
+                    tet_connections.append((int(tokens[0]), [int(tokens[j]) for j in range(1, 5)]))
         except IndexError:
             pass
 

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -1306,13 +1306,13 @@ class Vasprun(MSONable):
         k.style = Kpoints.supported_modes.from_str(e.attrib["param"] if "param" in e.attrib else "Reciprocal")
         for v in e.findall("v"):
             name = v.attrib.get("name")
-            toks = v.text.split()
+            tokens = v.text.split()
             if name == "divisions":
-                k.kpts = [[int(i) for i in toks]]
+                k.kpts = [[int(i) for i in tokens]]
             elif name == "usershift":
-                k.kpts_shift = [float(i) for i in toks]
+                k.kpts_shift = [float(i) for i in tokens]
             elif name in {"genvec1", "genvec2", "genvec3", "shift"}:
-                setattr(k, name, [float(i) for i in toks])
+                setattr(k, name, [float(i) for i in tokens])
         for va in elem.findall("varray"):
             name = va.attrib["name"]
             if name == "kpointlist":
@@ -1896,16 +1896,16 @@ class Outcar:
                 else:
                     m = re.match(r"\s*(\d+)\s+(([\d\.\-]+)\s+)+", clean)
                     if m:
-                        toks = [float(i) for i in re.findall(r"[\d\.\-]+", clean)]
-                        toks.pop(0)
+                        tokens = [float(i) for i in re.findall(r"[\d\.\-]+", clean)]
+                        tokens.pop(0)
                         if read_charge:
-                            charge.append(dict(zip(header, toks)))
+                            charge.append(dict(zip(header, tokens)))
                         elif read_mag_x:
-                            mag_x.append(dict(zip(header, toks)))
+                            mag_x.append(dict(zip(header, tokens)))
                         elif read_mag_y:
-                            mag_y.append(dict(zip(header, toks)))
+                            mag_y.append(dict(zip(header, tokens)))
                         elif read_mag_z:
-                            mag_z.append(dict(zip(header, toks)))
+                            mag_z.append(dict(zip(header, tokens)))
                     elif clean.startswith("tot"):
                         read_charge = False
                         read_mag_x = False
@@ -2288,18 +2288,18 @@ class Outcar:
                 elif read_plasma and Outcar._parse_sci_notation(line):
                     plasma_frequencies[read_plasma].append(Outcar._parse_sci_notation(line))
                 elif read_dielectric:
-                    toks = None
+                    tokens = None
                     if re.match(row_pattern, line.strip()):
-                        toks = line.strip().split()
+                        tokens = line.strip().split()
                     elif Outcar._parse_sci_notation(line.strip()):
-                        toks = Outcar._parse_sci_notation(line.strip())
+                        tokens = Outcar._parse_sci_notation(line.strip())
                     elif re.match(r"\s*-+\s*", line):
                         count += 1
 
-                    if toks:
+                    if tokens:
                         if component == "IMAGINARY":
-                            energies.append(float(toks[0]))
-                        xx, yy, zz, xy, yz, xz = (float(t) for t in toks[1:])
+                            energies.append(float(tokens[0]))
+                        xx, yy, zz, xy, yz, xz = (float(t) for t in tokens[1:])
                         matrix = [[xx, xy, xz], [xy, yy, yz], [xz, yz, zz]]
                         data[component].append(matrix)
 
@@ -3814,14 +3814,14 @@ class Procar:
                         )
                     )
                 elif expr.match(line):
-                    toks = line.split()
-                    index = int(toks.pop(0)) - 1
-                    num_data = np.array([float(t) for t in toks[: len(headers)]])
+                    tokens = line.split()
+                    index = int(tokens.pop(0)) - 1
+                    num_data = np.array([float(t) for t in tokens[: len(headers)]])
                     if not done:
                         data[spin][current_kpoint, current_band, index, :] = num_data
-                    elif len(toks) > len(headers):
+                    elif len(tokens) > len(headers):
                         # new format of PROCAR (vasp 5.4.4)
-                        num_data = np.array([float(t) for t in toks[: 2 * len(headers)]])
+                        num_data = np.array([float(t) for t in tokens[: 2 * len(headers)]])
                         for orb in range(len(headers)):
                             phase_factors[spin][current_kpoint, current_band, index, orb] = complex(
                                 num_data[2 * orb], num_data[2 * orb + 1]
@@ -3944,9 +3944,9 @@ class Oszicar:
             for line in fid:
                 m = electronic_pattern.match(line.strip())
                 if m:
-                    toks = m.group(1).split()
-                    data = {header[i]: smart_convert(header[i], toks[i]) for i in range(len(toks))}
-                    if toks[0] == "1":
+                    tokens = m.group(1).split()
+                    data = {header[i]: smart_convert(header[i], tokens[i]) for i in range(len(tokens))}
+                    if tokens[0] == "1":
                         electronic_steps.append([data])
                     else:
                         electronic_steps[-1].append(data)

--- a/pymatgen/io/zeopp.py
+++ b/pymatgen/io/zeopp.py
@@ -108,10 +108,10 @@ class ZeoCssr(Cssr):
             ZeoCssr object.
         """
         lines = string.split("\n")
-        toks = lines[0].split()
-        lengths = [float(i) for i in toks]
-        toks = lines[1].split()
-        angles = [float(i) for i in toks[0:3]]
+        tokens = lines[0].split()
+        lengths = [float(i) for i in tokens]
+        tokens = lines[1].split()
+        angles = [float(i) for i in tokens[0:3]]
         # Zeo++ takes x-axis along a and pymatgen takes z-axis along c
         a = lengths.pop(-1)
         lengths.insert(0, a)

--- a/pymatgen/symmetry/settings.py
+++ b/pymatgen/symmetry/settings.py
@@ -55,7 +55,12 @@ class JonesFaithfulTransformation:
         self._P, self._p = P, p
 
     @classmethod
-    def from_transformation_string(cls, transformation_string="a,b,c;0,0,0"):
+    @np.deprecate(message="Use from_transformation_str instead")
+    def from_transformation_string(cls, *args, **kwargs):  # noqa: D102
+        return cls.from_transformation_str(*args, **kwargs)
+
+    @classmethod
+    def from_transformation_str(cls, transformation_string="a,b,c;0,0,0"):
         """Construct SpaceGroupTransformation from its transformation string.
 
         Args:

--- a/tasks.py
+++ b/tasks.py
@@ -47,8 +47,17 @@ def make_doc(ctx):
             if fn == "pymatgen.md":
                 preamble = ["---", "layout: default", "title: API Documentation", "nav_order: 6", "---", ""]
             else:
-                preamble = ["---", "layout: default", f"title: {fn}" , "nav_exclude: true", "---", "",
-                            "1. TOC", "{:toc}", ""]
+                preamble = [
+                    "---",
+                    "layout: default",
+                    f"title: {fn}",
+                    "nav_exclude: true",
+                    "---",
+                    "",
+                    "1. TOC",
+                    "{:toc}",
+                    "",
+                ]
             with open(fn, "w") as f:
                 f.write("\n".join(preamble + lines))
         ctx.run("rm -r markdown", warn=True)
@@ -193,10 +202,10 @@ def post_discourse(version):
     """
     with open("CHANGES.rst") as file:
         contents = file.read()
-    toks = re.split(r"\-+", contents)
-    desc = toks[1].strip()
-    toks = desc.split("\n")
-    desc = "\n".join(toks[:-1]).strip()
+    tokens = re.split(r"\-+", contents)
+    desc = tokens[1].strip()
+    tokens = desc.split("\n")
+    desc = "\n".join(tokens[:-1]).strip()
     raw = f"v{version}\n\n{desc}"
     payload = {
         "topic_id": 36,

--- a/tests/core/test_operations.py
+++ b/tests/core/test_operations.py
@@ -189,44 +189,37 @@ class SymmOpTestCase(PymatgenTest):
 
     def test_xyz(self):
         op = SymmOp([[1, -1, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1]])
-        s = op.as_xyz_string()
-        assert s == "x-y, -y, -z"
-        assert op == SymmOp.from_xyz_string(s)
+        xyz_str = op.as_xyz_str()
+        assert xyz_str == "x-y, -y, -z"
+        assert op == SymmOp.from_xyz_str(xyz_str)
 
         op2 = SymmOp([[0, -1, 0, 0.5], [1, 0, 0, 0.5], [0, 0, 1, 0.5 + 1e-7], [0, 0, 0, 1]])
-        s2 = op2.as_xyz_string()
+        s2 = op2.as_xyz_str()
         assert s2 == "-y+1/2, x+1/2, z+1/2"
-        assert op2 == SymmOp.from_xyz_string(s2)
+        assert op2 == SymmOp.from_xyz_str(s2)
 
-        op2 = SymmOp(
-            [
-                [3, -2, -1, 0.5],
-                [-1, 0, 0, 12.0 / 13],
-                [0, 0, 1, 0.5 + 1e-7],
-                [0, 0, 0, 1],
-            ]
-        )
-        s2 = op2.as_xyz_string()
+        op2 = SymmOp([[3, -2, -1, 0.5], [-1, 0, 0, 12.0 / 13], [0, 0, 1, 0.5 + 1e-7], [0, 0, 0, 1]])
+        s2 = op2.as_xyz_str()
         assert s2 == "3x-2y-z+1/2, -x+12/13, z+1/2"
-        assert op2 == SymmOp.from_xyz_string(s2)
+        assert op2 == SymmOp.from_xyz_str(s2)
 
-        op3 = SymmOp.from_xyz_string("3x - 2y - z+1 /2 , -x+12/ 13, z+1/2")
+        op3 = SymmOp.from_xyz_str("3x - 2y - z+1 /2 , -x+12/ 13, z+1/2")
         assert op2 == op3
 
         # Ensure strings can be read in any order
-        op4 = SymmOp.from_xyz_string("1 /2 + 3X - 2y - z , 12/ 13-x, z+1/2")
-        op5 = SymmOp.from_xyz_string("+1 /2 + 3x - 2y - z , 12/ 13-x, +1/2+z")
+        op4 = SymmOp.from_xyz_str("1 /2 + 3X - 2y - z , 12/ 13-x, z+1/2")
+        op5 = SymmOp.from_xyz_str("+1 /2 + 3x - 2y - z , 12/ 13-x, +1/2+z")
         assert op4 == op3
         assert op4 == op5
         assert op3 == op5
 
         # TODO: assertWarns not in Python 2.x unittest
         # update PymatgenTest for unittest2?
-        # self.assertWarns(UserWarning, self.op.as_xyz_string)
+        # self.assertWarns(UserWarning, self.op.as_xyz_str)
 
-        o = SymmOp.from_xyz_string("0.5+x, 0.25+y, 0.75+z")
+        o = SymmOp.from_xyz_str("0.5+x, 0.25+y, 0.75+z")
         assert_allclose(o.translation_vector, [0.5, 0.25, 0.75])
-        o = SymmOp.from_xyz_string("x + 0.5, y + 0.25, z + 0.75")
+        o = SymmOp.from_xyz_str("x + 0.5, y + 0.25, z + 0.75")
         assert_allclose(o.translation_vector, [0.5, 0.25, 0.75])
 
 

--- a/tests/io/test_gaussian.py
+++ b/tests/io/test_gaussian.py
@@ -105,8 +105,8 @@ EPS=12
         filepath = f"{test_dir}/g305_hb.txt"
         with open(filepath) as f:
             txt = f.read()
-        toks = txt.split("--link1--")
-        for idx, tok in enumerate(toks):
+        tokens = txt.split("--link1--")
+        for idx, tok in enumerate(tokens):
             lines = [line.strip() for line in tok.strip().split("\n")]
             gau = GaussianInput.from_str("\n".join(lines))
             assert gau.molecule is not None


### PR DESCRIPTION
f01d38d14 rename variables: `toks->tokens`
42b7451e1 deprecate overlooked `from/as_..._string` methods (these were missed in https://github.com/materialsproject/pymatgen/issues/3230 and https://github.com/materialsproject/pymatgen/pull/3158 due to extra characters between `from_..._str`.