### PR TITLE
Add an input arg check for `Kpoints.automatic_density_by_lengths`

### DIFF
--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -1298,6 +1298,9 @@ class Kpoints(MSONable):
         Returns:
             Kpoints
         """
+        if len(length_densities) != 3:
+            msg = f"The dimensions of length_densities must be 3, not {len(length_densities)}"
+            raise ValueError(msg)
         comment = f"k-point density of {length_densities}/[a, b, c]"
         lattice = structure.lattice
         abc = lattice.abc

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -2028,7 +2028,7 @@ class MPNMRSet(MPStaticSet):
     Doi("10.1149/2.0061602jes"),
     description="Elastic Properties of Alkali Superionic Conductor Electrolytes from First Principles Calculations",
 )
-class MVLElasticSet(MPRelaxSet):
+class MVLElasticSet(DictSet):
     """
     MVL denotes VASP input sets that are implemented by the Materials Virtual
     Lab (http://materialsvirtuallab.org) for various research.
@@ -2054,7 +2054,7 @@ class MVLElasticSet(MPRelaxSet):
             kwargs:
                 Parameters supported by MPRelaxSet.
         """
-        super().__init__(structure, **kwargs)
+        super().__init__(structure, MPRelaxSet.CONFIG, **kwargs)
         self._config_dict["INCAR"].update({"IBRION": 6, "NFREE": 2, "POTIM": potim})
         self._config_dict["INCAR"].pop("NPAR", None)
 
@@ -2226,7 +2226,7 @@ class MVLGWSet(DictSet):
         return input_set.override_from_prev_calc(prev_calc_dir=prev_calc_dir)
 
 
-class MVLSlabSet(MPRelaxSet):
+class MVLSlabSet(DictSet):
     """
     Class for writing a set of slab vasp runs,
     including both slabs (along the c direction) and orient unit cells (bulk),
@@ -2253,7 +2253,7 @@ class MVLSlabSet(MPRelaxSet):
         :param sort_structure:
         :param kwargs: Other kwargs supported by :class:`DictSet`.
         """
-        super().__init__(structure, sort_structure=sort_structure, **kwargs)
+        super().__init__(structure, MPRelaxSet.CONFIG, sort_structure=sort_structure, **kwargs)
 
         self.k_product = k_product
         self.bulk = bulk
@@ -2453,7 +2453,7 @@ class MVLRelax52Set(DictSet):
         self.kwargs = kwargs
 
 
-class MITNEBSet(MITRelaxSet):
+class MITNEBSet(DictSet):
     """
     Class for writing NEB inputs. Note that EDIFF is not on a per atom
     basis for this input set.
@@ -2469,7 +2469,7 @@ class MITNEBSet(MITRelaxSet):
         if len(structures) < 3:
             raise ValueError("You need at least 3 structures for an NEB.")
         kwargs["sort_structure"] = False
-        super().__init__(structures[0], **kwargs)
+        super().__init__(structures[0], MITRelaxSet.CONFIG, **kwargs)
         self.structures = self._process_structures(structures)
 
         self.unset_encut = False
@@ -2559,7 +2559,7 @@ class MITNEBSet(MITRelaxSet):
             nebpath.to(filename=str(output_dir / "path.cif"))
 
 
-class MITMDSet(MITRelaxSet):
+class MITMDSet(DictSet):
     """
     Class for writing a vasp md run. This DOES NOT do multiple stage
     runs.
@@ -2616,7 +2616,7 @@ class MITMDSet(MITRelaxSet):
             "LDAU": False,
         }
 
-        super().__init__(structure, **kwargs)
+        super().__init__(structure, MITRelaxSet.CONFIG, **kwargs)
 
         self.start_temp = start_temp
         self.end_temp = end_temp

--- a/tests/io/vasp/test_inputs.py
+++ b/tests/io/vasp/test_inputs.py
@@ -879,7 +879,7 @@ direct
 
             assert kpoints.style == expected_style
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="The dimensions of length_densities must be 3, not 2"):
             Kpoints.automatic_density_by_lengths(structure, [50, 50])
 
     def test_automatic_monkhorst_vs_gamma_style_selection(self):

--- a/tests/io/vasp/test_inputs.py
+++ b/tests/io/vasp/test_inputs.py
@@ -879,6 +879,9 @@ direct
 
             assert kpoints.style == expected_style
 
+        with pytest.raises(ValueError):
+            kpoints = Kpoints.automatic_density_by_lengths(structure, [50, 50])
+
     def test_automatic_monkhorst_vs_gamma_style_selection(self):
         structs = {key: Structure.from_file(f"{TEST_FILES_DIR}/POSCAR_{key}") for key in ("bcc", "fcc", "hcp")}
 

--- a/tests/io/vasp/test_inputs.py
+++ b/tests/io/vasp/test_inputs.py
@@ -880,7 +880,7 @@ direct
             assert kpoints.style == expected_style
 
         with pytest.raises(ValueError):
-            kpoints = Kpoints.automatic_density_by_lengths(structure, [50, 50])
+            Kpoints.automatic_density_by_lengths(structure, [50, 50])
 
     def test_automatic_monkhorst_vs_gamma_style_selection(self):
         structs = {key: Structure.from_file(f"{TEST_FILES_DIR}/POSCAR_{key}") for key in ("bcc", "fcc", "hcp")}


### PR DESCRIPTION
## Summary

The function `Kpoints.automatic_density_by_length()` takes in a sequence of values, e.g. `[50, 50, 1]`, to set the k-point density for each dimension. However, the function does not raise any kind of error if a sequence of dimensions != 3 is supplied.

This PR adds a `ValueError` if the `len` is != 3, along with a test for it.

## Checklist

- [X] Google format doc strings added. Check with `ruff`.
- [X] Type annotations included. Check with `mypy`.
- [X] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
