### PR TITLE
Use `ax = fig.add_subplot(projection='3d')` to create `Axes3D`

### DIFF
--- a/pymatgen/analysis/wulff.py
+++ b/pymatgen/analysis/wulff.py
@@ -380,7 +380,7 @@ class WulffShape:
         Return:
             (matplotlib.pyplot)
         """
-        from mpl_toolkits.mplot3d import Axes3D, art3d
+        from mpl_toolkits.mplot3d import art3d
 
         colors = self._get_colors(color_set, alpha, off_color, custom_colors=custom_colors or {})
         color_list, color_proxy, color_proxy_on_wulff, miller_on_wulff, e_surf_on_wulff = colors
@@ -396,8 +396,9 @@ class WulffShape:
 
         wulff_pt_list = self.wulff_pt_list
 
-        ax = Axes3D(fig, azim=azim, elev=elev)
-        fig.add_axes(ax)
+        ax_3d = fig.add_subplot(projection="3d")
+        ax_3d.view_init(azim=azim, elev=elev)
+        fig.add_axes(ax_3d)
 
         for plane in self.facets:
             # check whether [pts] is empty
@@ -412,19 +413,19 @@ class WulffShape:
             tri = art3d.Poly3DCollection([pt])
             tri.set_color(plane_color)
             tri.set_edgecolor("#808080")
-            ax.add_collection3d(tri)
+            ax_3d.add_collection3d(tri)
 
         # set ranges of x, y, z
         # find the largest distance between on_wulff pts and the origin,
         # to ensure complete and consistent display for all directions
         r_range = max(np.linalg.norm(x) for x in wulff_pt_list)
-        ax.set_xlim([-r_range * 1.1, r_range * 1.1])
-        ax.set_ylim([-r_range * 1.1, r_range * 1.1])
-        ax.set_zlim([-r_range * 1.1, r_range * 1.1])  # pylint: disable=E1101
+        ax_3d.set_xlim([-r_range * 1.1, r_range * 1.1])
+        ax_3d.set_ylim([-r_range * 1.1, r_range * 1.1])
+        ax_3d.set_zlim([-r_range * 1.1, r_range * 1.1])  # pylint: disable=E1101
         # add legend
         if legend_on:
             if show_area:
-                ax.legend(
+                ax_3d.legend(
                     color_proxy,
                     self.miller_area,
                     loc="upper left",
@@ -433,7 +434,7 @@ class WulffShape:
                     shadow=False,
                 )
             else:
-                ax.legend(
+                ax_3d.legend(
                     color_proxy_on_wulff,
                     miller_on_wulff,
                     loc="upper center",
@@ -442,7 +443,7 @@ class WulffShape:
                     fancybox=True,
                     shadow=False,
                 )
-        ax.set(xlabel="x", ylabel="y", zlabel="z")
+        ax_3d.set(xlabel="x", ylabel="y", zlabel="z")
 
         # Add color bar
         if bar_on:
@@ -468,9 +469,9 @@ class WulffShape:
             cbar.set_label(f"Surface Energies ({units})", fontsize=25)
 
         if grid_off:
-            ax.grid("off")
+            ax_3d.grid("off")
         if axis_off:
-            ax.axis("off")
+            ax_3d.axis("off")
         return plt
 
     def get_plotly(

--- a/pymatgen/util/plotting.py
+++ b/pymatgen/util/plotting.py
@@ -570,11 +570,9 @@ def get_ax3d_fig(ax: plt.Axes = None, **kwargs) -> tuple[Axes3D, plt.Figure]:
     Returns:
         tuple[Axes3D, Figure]: matplotlib Axes3D and corresponding figure objects
     """
-    from mpl_toolkits.mplot3d.axes3d import Axes3D
-
     if ax is None:
         fig = plt.figure(**kwargs)
-        ax = Axes3D(fig)
+        ax = fig.add_subplot(projection="3d")
     else:
         fig = plt.gcf()
 

--- a/tests/analysis/test_wulff.py
+++ b/tests/analysis/test_wulff.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 import os
 
-from mpl_toolkits.mplot3d import Axes3D
 from numpy.testing import assert_array_equal
 from pytest import approx
 
@@ -72,6 +71,8 @@ class TestWulffShape(PymatgenTest):
         self.surface_properties = surface_properties
 
     def test_get_plot(self):
+        from mpl_toolkits.mplot3d import Axes3D
+
         # Basic test to check figure contains a single Axes3D object
         for wulff in (self.wulff_Nb, self.wulff_Ir, self.wulff_Ti):
             plt = wulff.get_plot()


### PR DESCRIPTION
Closes #3328.

As suggested by @goodwilling in https://github.com/materialsproject/pymatgen/issues/3328#issuecomment-1722076836. Thanks! 👍 

Applies to `BSPlotter.plot_brillouin()` and `WulffShape.get_plot()`.