### PR TITLE
Fix breaking change to `CoherentInterfaceBuilder.get_interfaces`

### DIFF
--- a/pymatgen/analysis/interfaces/coherent_interfaces.py
+++ b/pymatgen/analysis/interfaces/coherent_interfaces.py
@@ -199,10 +199,10 @@ class CoherentInterfaceBuilder:
             film_sl_slab = film_slab.copy()
             film_sl_slab.make_supercell(super_film_transform)
             assert_allclose(
-                film_sl_slab.lattice.matrix[2], film_slab.lattice.matrix[2]
+                film_sl_slab.lattice.matrix[2], film_slab.lattice.matrix[2], atol=1e-08
             ), "2D transformation affected C-axis for Film transformation"
             assert_allclose(
-                film_sl_slab.lattice.matrix[:2], match.film_sl_vectors
+                film_sl_slab.lattice.matrix[:2], match.film_sl_vectors, atol=1e-08
             ), "Transformation didn't make proper supercell for film"
 
             # Build substrate superlattice
@@ -212,10 +212,10 @@ class CoherentInterfaceBuilder:
             sub_sl_slab = sub_slab.copy()
             sub_sl_slab.make_supercell(super_sub_transform)
             assert_allclose(
-                sub_sl_slab.lattice.matrix[2], sub_slab.lattice.matrix[2]
+                sub_sl_slab.lattice.matrix[2], sub_slab.lattice.matrix[2], atol=1e-08
             ), "2D transformation affected C-axis for Film transformation"
             assert_allclose(
-                sub_sl_slab.lattice.matrix[:2], match.substrate_sl_vectors
+                sub_sl_slab.lattice.matrix[:2], match.substrate_sl_vectors, atol=1e-08
             ), "Transformation didn't make proper supercell for substrate"
 
             # Add extra info
@@ -231,14 +231,12 @@ class CoherentInterfaceBuilder:
             interface_properties["film_thickness"] = film_thickness
             interface_properties["substrate_thickness"] = substrate_thickness
 
-            yield (
-                Interface.from_slabs(
-                    substrate_slab=sub_sl_slab,
-                    film_slab=film_sl_slab,
-                    gap=gap,
-                    vacuum_over_film=vacuum_over_film,
-                    interface_properties=interface_properties,
-                )
+            yield Interface.from_slabs(
+                substrate_slab=sub_sl_slab,
+                film_slab=film_sl_slab,
+                gap=gap,
+                vacuum_over_film=vacuum_over_film,
+                interface_properties=interface_properties,
             )
 
 

--- a/tests/analysis/interfaces/test_coherent_interface.py
+++ b/tests/analysis/interfaces/test_coherent_interface.py
@@ -41,6 +41,6 @@ class TestInterfaceBuilder(PymatgenTest):
         )
 
         assert len(builder.terminations) == 2
-        # SP: I am commenting out this test which is super fragile and the result fluctuates between 6 and 30 for
+        # SP: this test is super fragile and the result fluctuates between 6 and 30 for
         # no apparent reason. The author should fix this.
-        # assert len(list(builder.get_interfaces(termination=("O2_Pmmm_1", "Si_R-3m_1")))) == 30
+        assert len(list(builder.get_interfaces(termination=("O2_Pmmm_1", "Si_R-3m_1")))) == 6

--- a/tests/analysis/interfaces/test_coherent_interface.py
+++ b/tests/analysis/interfaces/test_coherent_interface.py
@@ -41,6 +41,6 @@ class TestInterfaceBuilder(PymatgenTest):
         )
 
         assert len(builder.terminations) == 2
-        # SP: this test is super fragile and the result fluctuates between 6 and 30 for
+        # SP: this test is super fragile and the result fluctuates between 6, 30 and 42 for
         # no apparent reason. The author should fix this.
-        assert len(list(builder.get_interfaces(termination=("O2_Pmmm_1", "Si_R-3m_1")))) == 6
+        assert len(list(builder.get_interfaces(termination=("O2_Pmmm_1", "Si_R-3m_1")))) >= 6


### PR DESCRIPTION
Closes #3334.

Fix accidental breaking change introduced in https://github.com/materialsproject/pymatgen/pull/3253 by reinstating explicit `atol=1e-08` (default for `np.allclose` whereas `np.testing.assert_allclose` sets this to 0).