### PR TITLE
Add `properties` @property/docstring to `IStructure`

### DIFF
--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -1181,13 +1181,14 @@ class IStructure(SiteCollection, MSONable):
     @property
     def properties(self) -> dict:
         """Properties associated with the whole structure. Note that this information is only
-        guaranteed to be saved if serializing to native pymatgen output formats (JSON/YAML)."""
+        guaranteed to be saved if serializing to native pymatgen output formats (JSON/YAML).
+        """
         # getattr() check for backwards compatibility:
         # IStructure.properties is a recent addition and so any pickled Structure objects from an
         # older pymatgen version may have issues when de-serialized. Note that pickle is *not*
         # recommended as an archival format. Nevertheless, since this is a core pymatgen class,
         # additional effort has been made to retain compatibility.
-        if properties := getattr(self, "properties"):
+        if properties := self.properties:
             return properties
         else:
             self.properties = {}

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -1188,11 +1188,10 @@ class IStructure(SiteCollection, MSONable):
         # older pymatgen version may have issues when de-serialized. Note that pickle is *not*
         # recommended as an archival format. Nevertheless, since this is a core pymatgen class,
         # additional effort has been made to retain compatibility.
-        if properties := self.properties:
+        if properties := getattr(self, "properties"):  # noqa: B009
             return properties
-        else:
-            self.properties = {}
-            return self.properties
+        self.properties = {}
+        return self.properties
 
     @property
     def charge(self) -> float:

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -1180,8 +1180,8 @@ class IStructure(SiteCollection, MSONable):
 
     @property
     def properties(self) -> dict:
-        """Properties associated with the whole structure. Note that this information is only
-        guaranteed to be saved if serializing to native pymatgen output formats (JSON/YAML).
+        """Properties associated with the whole Structure. Note that this information is
+        only guaranteed to be saved if serializing to native pymatgen output formats (JSON/YAML).
         """
         # getattr() check for backwards compatibility:
         # IStructure.properties is a recent addition and so any pickled Structure objects from an
@@ -1192,6 +1192,11 @@ class IStructure(SiteCollection, MSONable):
             return properties
         self._properties = {}
         return self._properties
+
+    @properties.setter
+    def properties(self, properties: dict) -> None:
+        """Sets properties associated with the whole Structure."""
+        self._properties = properties
 
     @property
     def charge(self) -> float:

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -914,7 +914,7 @@ class IStructure(SiteCollection, MSONable):
         if validate_proximity and not self.is_valid():
             raise StructureError("Structure contains sites that are less than 0.01 Angstrom apart!")
         self._charge = charge
-        self.properties = properties or {}
+        self._properties = properties or {}
 
     @classmethod
     def from_sites(
@@ -1188,10 +1188,10 @@ class IStructure(SiteCollection, MSONable):
         # older pymatgen version may have issues when de-serialized. Note that pickle is *not*
         # recommended as an archival format. Nevertheless, since this is a core pymatgen class,
         # additional effort has been made to retain compatibility.
-        if properties := getattr(self, "properties"):  # noqa: B009
+        if properties := getattr(self, "_properties"):  # noqa: B009
             return properties
-        self.properties = {}
-        return self.properties
+        self._properties = {}
+        return self._properties
 
     @property
     def charge(self) -> float:

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -1179,6 +1179,21 @@ class IStructure(SiteCollection, MSONable):
         self._charge = None
 
     @property
+    def properties(self) -> dict:
+        """Properties associated with the whole structure. Note that this information is only
+        guaranteed to be saved if serializing to native pymatgen output formats (JSON/YAML)."""
+        # getattr() check for backwards compatibility:
+        # IStructure.properties is a recent addition and so any pickled Structure objects from an
+        # older pymatgen version may have issues when de-serialized. Note that pickle is *not*
+        # recommended as an archival format. Nevertheless, since this is a core pymatgen class,
+        # additional effort has been made to retain compatibility.
+        if properties := getattr(self, "properties"):
+            return properties
+        else:
+            self.properties = {}
+            return self.properties
+
+    @property
     def charge(self) -> float:
         """Overall charge of the structure."""
         formal_charge = super().charge

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -191,7 +191,7 @@ class SiteCollection(collections.abc.Sequence, metaclass=ABCMeta):
 
     # Tolerance in Angstrom for determining if sites are too close.
     DISTANCE_TOLERANCE = 0.5
-    properties: dict
+    _properties: dict
 
     @property
     def sites(self) -> list[Site]:

--- a/pymatgen/io/ase.py
+++ b/pymatgen/io/ase.py
@@ -161,7 +161,7 @@ class AseAtomsAdaptor:
 
         # Atoms.info <---> Structure.properties
         # Atoms.calc <---> Structure.calc
-        if properties := getattr(structure, "properties"):
+        if properties := structure.properties:
             atoms.info = properties
         if calc := getattr(structure, "calc", None):
             atoms.calc = calc

--- a/pymatgen/io/ase.py
+++ b/pymatgen/io/ase.py
@@ -161,7 +161,7 @@ class AseAtomsAdaptor:
 
         # Atoms.info <---> Structure.properties
         # Atoms.calc <---> Structure.calc
-        if properties := structure.properties:
+        if properties := getattr(structure, "properties"):  # noqa: B009
             atoms.info = properties
         if calc := getattr(structure, "calc", None):
             atoms.calc = calc

--- a/pymatgen/io/ase.py
+++ b/pymatgen/io/ase.py
@@ -161,7 +161,7 @@ class AseAtomsAdaptor:
 
         # Atoms.info <---> Structure.properties
         # Atoms.calc <---> Structure.calc
-        if properties := hasattr(structure, "properties"):
+        if properties := getattr(structure, "properties"):
             atoms.info = properties
         if calc := getattr(structure, "calc", None):
             atoms.calc = calc

--- a/pymatgen/io/ase.py
+++ b/pymatgen/io/ase.py
@@ -161,8 +161,8 @@ class AseAtomsAdaptor:
 
         # Atoms.info <---> Structure.properties
         # Atoms.calc <---> Structure.calc
-        if structure.properties:
-            atoms.info = structure.properties
+        if properties := hasattr(structure, "properties"):
+            atoms.info = properties
         if calc := getattr(structure, "calc", None):
             atoms.calc = calc
 


### PR DESCRIPTION
Addendum to #3264, notifying @gpetretto, @janosh.

Two things I think we missed in #3264:

* A formal `@property` so that we get a docstring for the new `IStructure.properties`
* An edge-case for backwards compatibility. While I strongly recommend people _do not_ use pickle as an archival format, nevertheless this is a very core pymatgen class, and I don't want to break people's workflows if they upgrade. Specifically, if you pickle a `Structure` from a previous pymatgen version, and then un-pickle it with the new pymatgen version, the `__init__` will not be called, so the `.properties` instance variable is never set: this will then break code that relies upon it, like `as_dict()`. Luckily, adding the `@property` interface allows us to trivially catch this edge case.