### PR TITLE
Revert `openbabel.OBAlign()` in `molecule_matcher.py` to use positional args for `includeH`, `symmetry`

### DIFF
--- a/pymatgen/analysis/molecule_matcher.py
+++ b/pymatgen/analysis/molecule_matcher.py
@@ -143,7 +143,7 @@ class IsomorphismMolAtomMapper(AbstractMolAtomMapper):
         label2_list = tuple(tuple(p[1] + 1 for p in x) for x in sorted_isomorph)
 
         vmol1 = ob_mol1
-        aligner = openbabel.OBAlign(includeH=True, symmetry=False)
+        aligner = openbabel.OBAlign(True, False)  # meaning includeH=True, symmetry=False  # noqa: FBT003
         aligner.SetRefMol(vmol1)
         least_rmsd = float("Inf")
         best_label2 = None
@@ -647,7 +647,7 @@ class MoleculeMatcher(MSONable):
             a2.SetAtomicNum(oa2.GetAtomicNum())
             a2.SetVector(oa2.GetVector())
 
-        aligner = openbabel.OBAlign(includeH=True, symmetry=False)
+        aligner = openbabel.OBAlign(True, False)  # meaning includeH=True, symmetry=False  # noqa: FBT003
         aligner.SetRefMol(cmol1)
         aligner.SetTargetMol(cmol2)
         aligner.Align()


### PR DESCRIPTION
Thanks @munrojm for reporting. [This change](https://github.com/materialsproject/pymatgen/blame/4bff21d33625bc9f7077c7b4eb06098d1f50277c/pymatgen/analysis/molecule_matcher.py#L146) (although it improved code readability) caused errors in emmet CI.