### PR TITLE
Fix `TestMPResterNewBasic` + `AseAtomsAdaptor` test errors and `TransformedStructure.from_snl` overwriting `hist` variable

### DIFF
--- a/pymatgen/alchemy/materials.py
+++ b/pymatgen/alchemy/materials.py
@@ -376,9 +376,9 @@ class TransformedStructure(MSONable):
         Returns:
             TransformedStructure
         """
-        hist = []
+        history: list[dict] = []
         for hist in snl.history:
             dct = hist.description
             dct["_snl"] = {"url": hist.url, "name": hist.name}
             hist.append(dct)
-        return cls(snl.structure, history=hist)
+        return cls(snl.structure, history=history)

--- a/pymatgen/alchemy/materials.py
+++ b/pymatgen/alchemy/materials.py
@@ -128,10 +128,10 @@ class TransformedStructure(MSONable):
                 h_dict["input_structure"] = input_structure
                 h_dict["output_parameters"] = x
                 self.final_structure = struct
-                d = self.as_dict()
-                d["history"].append(h_dict)
-                d["final_structure"] = struct.as_dict()
-                alts.append(TransformedStructure.from_dict(d))
+                dct = self.as_dict()
+                dct["history"].append(h_dict)
+                dct["final_structure"] = struct.as_dict()
+                alts.append(TransformedStructure.from_dict(dct))
 
             x = ranked_list[0]
             struct = x.pop("structure")
@@ -337,10 +337,10 @@ class TransformedStructure(MSONable):
         return dct
 
     @classmethod
-    def from_dict(cls, d) -> TransformedStructure:
+    def from_dict(cls, dct) -> TransformedStructure:
         """Creates a TransformedStructure from a dict."""
-        struct = Structure.from_dict(d)
-        return cls(struct, history=d["history"], other_parameters=d.get("other_parameters"))
+        struct = Structure.from_dict(dct)
+        return cls(struct, history=dct["history"], other_parameters=dct.get("other_parameters"))
 
     def to_snl(self, authors, **kwargs) -> StructureNL:
         """Generate SNL from TransformedStructure.
@@ -377,8 +377,8 @@ class TransformedStructure(MSONable):
             TransformedStructure
         """
         hist = []
-        for h in snl.history:
-            d = h.description
-            d["_snl"] = {"url": h.url, "name": h.name}
-            hist.append(d)
+        for hist in snl.history:
+            dct = hist.description
+            dct["_snl"] = {"url": hist.url, "name": hist.name}
+            hist.append(dct)
         return cls(snl.structure, history=hist)

--- a/pymatgen/alchemy/materials.py
+++ b/pymatgen/alchemy/materials.py
@@ -353,18 +353,18 @@ class TransformedStructure(MSONable):
         """
         if self.other_parameters:
             warn("Data in TransformedStructure.other_parameters discarded during type conversion to SNL")
-        hist = []
-        for h in self.history:
-            snl_metadata = h.pop("_snl", {})
-            hist.append(
+        history = []
+        for hist in self.history:
+            snl_metadata = hist.pop("_snl", {})
+            history.append(
                 {
                     "name": snl_metadata.pop("name", "pymatgen"),
                     "url": snl_metadata.pop("url", "http://pypi.python.org/pypi/pymatgen"),
-                    "description": h,
+                    "description": hist,
                 }
             )
 
-        return StructureNL(self.final_structure, authors, history=hist, **kwargs)
+        return StructureNL(self.final_structure, authors, history=history, **kwargs)
 
     @classmethod
     def from_snl(cls, snl: StructureNL) -> TransformedStructure:
@@ -380,5 +380,5 @@ class TransformedStructure(MSONable):
         for hist in snl.history:
             dct = hist.description
             dct["_snl"] = {"url": hist.url, "name": hist.name}
-            hist.append(dct)
+            history.append(dct)
         return cls(snl.structure, history=history)

--- a/pymatgen/electronic_structure/boltztrap2.py
+++ b/pymatgen/electronic_structure/boltztrap2.py
@@ -899,7 +899,7 @@ class BztTransportProperties:
 
     def load(self, fname="bztTranspProps.json.gz"):
         """Load the transport properties from fname file."""
-        d = loadfn(fname)
+        lst = loadfn(fname)
         (
             self.temp_r,
             self.CRTA,
@@ -916,8 +916,8 @@ class BztTransportProperties:
             self.Hall_carrier_conc_trace_mu,
             self.Power_Factor_mu,
             self.Effective_mass_mu,
-        ) = d[:15]
-        if len(d) > 15:
+        ) = lst[:15]
+        if len(lst) > 15:
             (
                 self.Conductivity_doping,
                 self.Seebeck_doping,
@@ -928,7 +928,7 @@ class BztTransportProperties:
                 self.doping,
                 self.mu_doping,
                 self.mu_doping_eV,
-            ) = d[15:]
+            ) = lst[15:]
             self.contains_doping_props = True
 
         return True

--- a/pymatgen/entries/computed_entries.py
+++ b/pymatgen/entries/computed_entries.py
@@ -652,9 +652,9 @@ class ComputedStructureEntry(ComputedEntry):
         )
         # TODO: find a better solution for creating copies instead of as/from dict
         factor = self._normalization_factor(mode)
-        d = super().normalize(mode).as_dict()
-        d["structure"] = self.structure.as_dict()
-        entry = self.from_dict(d)
+        dct = super().normalize(mode).as_dict()
+        dct["structure"] = self.structure.as_dict()
+        entry = self.from_dict(dct)
         entry._composition /= factor  # pylint: disable=E1101
         return entry
 

--- a/pymatgen/ext/optimade.py
+++ b/pymatgen/ext/optimade.py
@@ -459,7 +459,7 @@ class OptimadeRester:
             _logger.warning(f"Failed to extract required information from {url}: {exc}")
             return None
 
-    def _parse_provider(self, provider, provider_url) -> dict[str, Provider]:
+    def _parse_provider(self, provider: str, provider_url: str) -> dict[str, Provider]:
         """Used internally to update the list of providers or to
         check a given URL is valid.
 

--- a/pymatgen/io/ase.py
+++ b/pymatgen/io/ase.py
@@ -8,10 +8,10 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Iterable
+from importlib.metadata import PackageNotFoundError
 from typing import TYPE_CHECKING
 
 import numpy as np
-from monty.dev import requires
 
 from pymatgen.core.structure import Molecule, Structure
 
@@ -40,7 +40,6 @@ __date__ = "Mar 8, 2012"
 
 # NOTE: If making notable changes to this class, please ping @Andrew-S-Rosen on GitHub.
 # There are some subtleties in here, particularly related to spins/charges.
-@requires(ase_loaded, "ASE needs to be installed.")
 class AseAtomsAdaptor:
     """Adaptor serves as a bridge between ASE Atoms and pymatgen objects."""
 
@@ -56,6 +55,8 @@ class AseAtomsAdaptor:
         Returns:
             Atoms: ASE Atoms object
         """
+        if not ase_loaded:
+            raise PackageNotFoundError("AseAtomsAdaptor requires the ASE package. Use `pip install ase`")
         if not structure.is_ordered:
             raise ValueError("ASE Atoms only supports ordered structures")
 

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -1040,7 +1040,7 @@ class Vasprun(MSONable):
         """
         if potcar := self.get_potcars(path):
             self.potcar_spec = [
-                {"titel": sym, "hash": ps.md5_computed_file_hash}
+                {"titel": sym, "hash": ps.md5_header_hash}
                 for sym in self.potcar_symbols
                 for ps in potcar
                 if ps.symbol == sym.split()[1]

--- a/tests/alchemy/test_filters.py
+++ b/tests/alchemy/test_filters.py
@@ -50,8 +50,8 @@ class TestContainsSpecieFilter(PymatgenTest):
     def test_as_from_dict(self):
         species1 = ["Si5+", "Mg2+"]
         f1 = ContainsSpecieFilter(species1, strict_compare=True, AND=False)
-        d = f1.as_dict()
-        assert isinstance(ContainsSpecieFilter.from_dict(d), ContainsSpecieFilter)
+        dct = f1.as_dict()
+        assert isinstance(ContainsSpecieFilter.from_dict(dct), ContainsSpecieFilter)
 
 
 class TestSpecieProximityFilter(PymatgenTest):
@@ -68,8 +68,8 @@ class TestSpecieProximityFilter(PymatgenTest):
 
     def test_as_from_dict(self):
         sf = SpecieProximityFilter({"Li": 1})
-        d = sf.as_dict()
-        assert isinstance(SpecieProximityFilter.from_dict(d), SpecieProximityFilter)
+        dct = sf.as_dict()
+        assert isinstance(SpecieProximityFilter.from_dict(dct), SpecieProximityFilter)
 
 
 class TestRemoveDuplicatesFilter(unittest.TestCase):
@@ -87,8 +87,8 @@ class TestRemoveDuplicatesFilter(unittest.TestCase):
 
     def test_as_from_dict(self):
         fil = RemoveDuplicatesFilter()
-        d = fil.as_dict()
-        assert isinstance(RemoveDuplicatesFilter().from_dict(d), RemoveDuplicatesFilter)
+        dct = fil.as_dict()
+        assert isinstance(RemoveDuplicatesFilter().from_dict(dct), RemoveDuplicatesFilter)
 
 
 class TestRemoveExistingFilter(unittest.TestCase):
@@ -97,10 +97,10 @@ class TestRemoveExistingFilter(unittest.TestCase):
             entries = json.load(fp, cls=MontyDecoder)
         self._struct_list = [e.structure for e in entries]
         self._sm = StructureMatcher()
-        self._exisiting_structures = self._struct_list[:-1]
+        self._existing_structures = self._struct_list[:-1]
 
     def test_filter(self):
-        fil = RemoveExistingFilter(self._exisiting_structures)
+        fil = RemoveExistingFilter(self._existing_structures)
         transmuter = StandardTransmuter.from_structures(self._struct_list)
         transmuter.apply_filter(fil)
         assert len(transmuter.transformed_structures) == 1

--- a/tests/command_line/test_gulp_caller.py
+++ b/tests/command_line/test_gulp_caller.py
@@ -256,7 +256,7 @@ class TestGulpIO(unittest.TestCase):
         assert struct.lattice.alpha == 90
 
     @unittest.skip("Test later")
-    def test_tersoff_inpt(self):
+    def test_tersoff_input(self):
         self.gio.tersoff_input(self.structure)
 
 
@@ -319,7 +319,7 @@ class TestBuckinghamPotentialLewis(unittest.TestCase):
         assert "O_core" in self.bpl.species_dict
         assert "O_shel" in self.bpl.species_dict
 
-    def test_non_exisitng_element(self):
+    def test_non_existing_element(self):
         assert "Li_1+" not in self.bpl.pot_dict
         assert "Li_1+" not in self.bpl.species_dict
 
@@ -346,7 +346,7 @@ class TestBuckinghamPotentialBush(unittest.TestCase):
         assert "O" in self.bpb.pot_dict
         assert "O" in self.bpb.species_dict
 
-    def test_non_exisitng_element(self):
+    def test_non_existing_element(self):
         assert "Mn" not in self.bpb.pot_dict
         assert "Mn" not in self.bpb.species_dict
 

--- a/tests/ext/test_matproj.py
+++ b/tests/ext/test_matproj.py
@@ -530,10 +530,6 @@ class TestMPResterNewBasic:
     def setup(self):
         self.rester = _MPResterBasic()
 
-    def test_attr_error(self):
-        with pytest.raises(AttributeError, match="summary is not an attribute"):
-            _ = self.rester.summary
-
     def test_get_summary(self):
         docs = self.rester.get_summary({"formula": "Fe2O3"})
         assert len(docs) > 3

--- a/tests/files/.pytest-split-durations
+++ b/tests/files/.pytest-split-durations
@@ -741,7 +741,7 @@
     "tests/command_line/test_gulp_caller.py::TestGulpIO::test_structure_lines_default_options": 0.00011916703078895807,
     "tests/command_line/test_gulp_caller.py::TestGulpIO::test_structure_lines_no_frac_coords": 0.0001177079975605011,
     "tests/command_line/test_gulp_caller.py::TestGulpIO::test_structure_lines_no_unitcell": 0.0003102489863522351,
-    "tests/command_line/test_gulp_caller.py::TestGulpIO::test_tersoff_inpt": 0.00012333301128819585,
+    "tests/command_line/test_gulp_caller.py::TestGulpIO::test_tersoff_input": 0.00012333301128819585,
     "tests/command_line/test_gulp_caller.py::TestGulpIO::test_tersoff_potential": 0.0001610000035725534,
     "tests/command_line/test_mcsqs_caller.py::TestMcsqsCaller::test_mcsqs_caller_parallel": 0.00015433301450684667,
     "tests/command_line/test_mcsqs_caller.py::TestMcsqsCaller::test_mcsqs_caller_runtime_error": 0.00018695800099521875,

--- a/tests/io/test_ase.py
+++ b/tests/io/test_ase.py
@@ -6,7 +6,6 @@ from ase.constraints import FixAtoms
 from ase.io import read
 from monty.json import MontyDecoder, jsanitize
 
-import pymatgen.io.ase as aio
 from pymatgen.core import Composition, Lattice, Molecule, Structure
 from pymatgen.core.structure import StructureError
 from pymatgen.io.ase import AseAtomsAdaptor
@@ -19,7 +18,7 @@ ase = pytest.importorskip("ase")
 
 def test_get_atoms_from_structure():
     structure = poscar.structure
-    atoms = aio.AseAtomsAdaptor.get_atoms(structure)
+    atoms = AseAtomsAdaptor.get_atoms(structure)
     ase_composition = Composition(atoms.get_chemical_formula())
     assert ase_composition == structure.composition
     assert atoms.cell is not None
@@ -34,7 +33,7 @@ def test_get_atoms_from_structure():
     structure = poscar.structure
     prop = [3.14] * len(structure)
     structure.add_site_property("prop", prop)
-    atoms = aio.AseAtomsAdaptor.get_atoms(structure)
+    atoms = AseAtomsAdaptor.get_atoms(structure)
     assert atoms.get_array("prop").tolist() == prop
 
 
@@ -42,14 +41,14 @@ def test_get_atoms_from_structure_mags():
     structure = poscar.structure
     mags = [1.0] * len(structure)
     structure.add_site_property("final_magmom", mags)
-    atoms = aio.AseAtomsAdaptor.get_atoms(structure)
+    atoms = AseAtomsAdaptor.get_atoms(structure)
     assert not atoms.has("initial_magmoms")
     assert atoms.get_magnetic_moments().tolist() == mags
 
     structure = poscar.structure
     initial_mags = [0.5] * len(structure)
     structure.add_site_property("magmom", initial_mags)
-    atoms = aio.AseAtomsAdaptor.get_atoms(structure)
+    atoms = AseAtomsAdaptor.get_atoms(structure)
     assert atoms.get_initial_magnetic_moments().tolist() == initial_mags
 
     structure = poscar.structure
@@ -57,7 +56,7 @@ def test_get_atoms_from_structure_mags():
     structure.add_site_property("final_magmom", mags)
     initial_mags = [2.0] * len(structure)
     structure.add_site_property("magmom", initial_mags)
-    atoms = aio.AseAtomsAdaptor.get_atoms(structure)
+    atoms = AseAtomsAdaptor.get_atoms(structure)
     assert atoms.get_initial_magnetic_moments().tolist(), initial_mags
     assert atoms.get_magnetic_moments().tolist(), mags
 
@@ -66,14 +65,14 @@ def test_get_atoms_from_structure_charge():
     structure = poscar.structure
     charges = [1.0] * len(structure)
     structure.add_site_property("final_charge", charges)
-    atoms = aio.AseAtomsAdaptor.get_atoms(structure)
+    atoms = AseAtomsAdaptor.get_atoms(structure)
     assert not atoms.has("initial_charges")
     assert atoms.get_charges().tolist() == charges
 
     structure = poscar.structure
     charges = [0.5] * len(structure)
     structure.add_site_property("charge", charges)
-    atoms = aio.AseAtomsAdaptor.get_atoms(structure)
+    atoms = AseAtomsAdaptor.get_atoms(structure)
     assert atoms.get_initial_charges().tolist() == charges
 
     structure = poscar.structure
@@ -81,7 +80,7 @@ def test_get_atoms_from_structure_charge():
     structure.add_site_property("final_charge", charges)
     initial_charges = [2.0] * len(structure)
     structure.add_site_property("charge", initial_charges)
-    atoms = aio.AseAtomsAdaptor.get_atoms(structure)
+    atoms = AseAtomsAdaptor.get_atoms(structure)
     assert atoms.get_initial_charges().tolist(), initial_charges
     assert atoms.get_charges().tolist(), charges
 
@@ -90,20 +89,20 @@ def test_get_atoms_from_structure_oxi_states():
     structure = poscar.structure
     oxi_states = [1.0] * len(structure)
     structure.add_oxidation_state_by_site(oxi_states)
-    atoms = aio.AseAtomsAdaptor.get_atoms(structure)
+    atoms = AseAtomsAdaptor.get_atoms(structure)
     assert atoms.get_array("oxi_states").tolist() == oxi_states
 
 
 def test_get_atoms_from_structure_dyn():
     structure = poscar.structure
     structure.add_site_property("selective_dynamics", [[False] * 3] * len(structure))
-    atoms = aio.AseAtomsAdaptor.get_atoms(structure)
+    atoms = AseAtomsAdaptor.get_atoms(structure)
     assert atoms.constraints[0].get_indices().tolist() == [atom.index for atom in atoms]
 
 
 def test_get_atoms_from_molecule():
     m = Molecule.from_file(TEST_FILES_DIR / "acetylene.xyz")
-    atoms = aio.AseAtomsAdaptor.get_atoms(m)
+    atoms = AseAtomsAdaptor.get_atoms(m)
     ase_composition = Composition(atoms.get_chemical_formula())
     assert ase_composition == m.composition
     assert atoms.cell is None or not atoms.cell.any()
@@ -114,23 +113,23 @@ def test_get_atoms_from_molecule():
 
 def test_get_atoms_from_molecule_mags():
     molecule = Molecule.from_file(TEST_FILES_DIR / "acetylene.xyz")
-    atoms = aio.AseAtomsAdaptor.get_atoms(molecule)
+    atoms = AseAtomsAdaptor.get_atoms(molecule)
     mags = [1.0] * len(molecule)
     molecule.add_site_property("final_magmom", mags)
-    atoms = aio.AseAtomsAdaptor.get_atoms(molecule)
+    atoms = AseAtomsAdaptor.get_atoms(molecule)
     assert not atoms.has("initial_magmoms")
     assert atoms.get_magnetic_moments().tolist() == mags
 
     molecule = Molecule.from_file(TEST_FILES_DIR / "acetylene.xyz")
-    atoms = aio.AseAtomsAdaptor.get_atoms(molecule)
+    atoms = AseAtomsAdaptor.get_atoms(molecule)
     initial_mags = [0.5] * len(molecule)
     molecule.add_site_property("magmom", initial_mags)
-    atoms = aio.AseAtomsAdaptor.get_atoms(molecule)
+    atoms = AseAtomsAdaptor.get_atoms(molecule)
     assert atoms.get_initial_magnetic_moments().tolist() == initial_mags
 
     molecule = Molecule.from_file(TEST_FILES_DIR / "acetylene.xyz")
     molecule.set_charge_and_spin(-2, spin_multiplicity=3)
-    atoms = aio.AseAtomsAdaptor.get_atoms(molecule)
+    atoms = AseAtomsAdaptor.get_atoms(molecule)
     assert atoms.calc is None
     assert atoms.get_initial_magnetic_moments().tolist() == [0] * len(molecule)
     assert atoms.charge == -2
@@ -140,40 +139,40 @@ def test_get_atoms_from_molecule_mags():
 def test_get_atoms_from_molecule_dyn():
     molecule = Molecule.from_file(TEST_FILES_DIR / "acetylene.xyz")
     molecule.add_site_property("selective_dynamics", [[False] * 3] * len(molecule))
-    atoms = aio.AseAtomsAdaptor.get_atoms(molecule)
+    atoms = AseAtomsAdaptor.get_atoms(molecule)
     assert atoms.constraints[0].get_indices().tolist() == [atom.index for atom in atoms]
 
 
 def test_get_structure():
     atoms = read(TEST_FILES_DIR / "POSCAR")
-    struct = aio.AseAtomsAdaptor.get_structure(atoms)
+    struct = AseAtomsAdaptor.get_structure(atoms)
     assert struct.formula == "Fe4 P4 O16"
     assert [s.species_string for s in struct] == atoms.get_chemical_symbols()
 
     atoms = read(TEST_FILES_DIR / "POSCAR")
     prop = np.array([3.14] * len(atoms))
     atoms.set_array("prop", prop)
-    struct = aio.AseAtomsAdaptor.get_structure(atoms)
+    struct = AseAtomsAdaptor.get_structure(atoms)
     assert struct.site_properties["prop"] == prop.tolist()
 
     atoms = read(TEST_FILES_DIR / "POSCAR_overlap")
-    struct = aio.AseAtomsAdaptor.get_structure(atoms)
+    struct = AseAtomsAdaptor.get_structure(atoms)
     assert [s.species_string for s in struct] == atoms.get_chemical_symbols()
     with pytest.raises(StructureError, match="Structure contains sites that are less than 0.01 Angstrom apart"):
-        struct = aio.AseAtomsAdaptor.get_structure(atoms, validate_proximity=True)
+        struct = AseAtomsAdaptor.get_structure(atoms, validate_proximity=True)
 
 
 def test_get_structure_mag():
     atoms = read(TEST_FILES_DIR / "POSCAR")
     mags = [1.0] * len(atoms)
     atoms.set_initial_magnetic_moments(mags)
-    structure = aio.AseAtomsAdaptor.get_structure(atoms)
+    structure = AseAtomsAdaptor.get_structure(atoms)
     assert structure.site_properties["magmom"] == mags
     assert "final_magmom" not in structure.site_properties
     assert "initial_magmoms" not in structure.site_properties
 
     atoms = read(TEST_FILES_DIR / "OUTCAR")
-    structure = aio.AseAtomsAdaptor.get_structure(atoms)
+    structure = AseAtomsAdaptor.get_structure(atoms)
     assert structure.site_properties["final_magmom"] == atoms.get_magnetic_moments().tolist()
     assert "magmom" not in structure.site_properties
     assert "initial_magmoms" not in structure.site_properties
@@ -186,7 +185,7 @@ def test_get_structure_mag():
 def test_get_structure_dyn(select_dyn):
     atoms = read(TEST_FILES_DIR / "POSCAR")
     atoms.set_constraint(FixAtoms(mask=[True] * len(atoms)))
-    structure = aio.AseAtomsAdaptor.get_structure(atoms)
+    structure = AseAtomsAdaptor.get_structure(atoms)
     assert structure.site_properties["selective_dynamics"][-1][0] is False
 
     structure = Structure(
@@ -205,7 +204,7 @@ def test_get_structure_dyn(select_dyn):
 
 def test_get_molecule():
     atoms = read(TEST_FILES_DIR / "acetylene.xyz")
-    molecule = aio.AseAtomsAdaptor.get_molecule(atoms)
+    molecule = AseAtomsAdaptor.get_molecule(atoms)
     assert molecule.formula == "H2 C2"
     assert [s.species_string for s in molecule] == atoms.get_chemical_symbols()
     assert molecule.charge == 0
@@ -216,7 +215,7 @@ def test_get_molecule():
     initial_mags = [1.0] * len(atoms)
     atoms.set_initial_charges(initial_charges)
     atoms.set_initial_magnetic_moments(initial_mags)
-    molecule = aio.AseAtomsAdaptor.get_molecule(atoms)
+    molecule = AseAtomsAdaptor.get_molecule(atoms)
     assert molecule.charge == np.sum(initial_charges)
     assert molecule.spin_multiplicity == np.sum(initial_mags) + 1
     assert molecule.site_properties.get("charge") == initial_charges
@@ -225,7 +224,7 @@ def test_get_molecule():
     atoms = read(TEST_FILES_DIR / "acetylene.xyz")
     atoms.spin_multiplicity = 3
     atoms.charge = 2
-    molecule = aio.AseAtomsAdaptor.get_molecule(atoms)
+    molecule = AseAtomsAdaptor.get_molecule(atoms)
     assert molecule.charge == 2
     assert molecule.spin_multiplicity == 3
 
@@ -240,9 +239,9 @@ def test_back_forth(structure_file):
     atoms.set_initial_charges([1.0] * len(atoms))
     atoms.set_initial_magnetic_moments([2.0] * len(atoms))
     atoms.set_array("prop", np.array([3.0] * len(atoms)))
-    structure = aio.AseAtomsAdaptor.get_structure(atoms)
-    atoms_back = aio.AseAtomsAdaptor.get_atoms(structure)
-    structure_back = aio.AseAtomsAdaptor.get_structure(atoms_back)
+    structure = AseAtomsAdaptor.get_structure(atoms)
+    atoms_back = AseAtomsAdaptor.get_atoms(structure)
+    structure_back = AseAtomsAdaptor.get_structure(atoms_back)
     assert structure_back == structure
     for k, v in atoms.todict().items():
         assert str(atoms_back.todict()[k]) == str(v)
@@ -257,9 +256,9 @@ def test_back_forth_v2():
     structure.add_site_property("charge", [4.0] * len(structure))
     structure.add_site_property("prop", [5.0] * len(structure))
     structure.properties = {"test": "hi"}
-    atoms = aio.AseAtomsAdaptor.get_atoms(structure)
-    structure_back = aio.AseAtomsAdaptor.get_structure(atoms)
-    atoms_back = aio.AseAtomsAdaptor.get_atoms(structure_back)
+    atoms = AseAtomsAdaptor.get_atoms(structure)
+    structure_back = AseAtomsAdaptor.get_structure(atoms)
+    atoms_back = AseAtomsAdaptor.get_atoms(structure_back)
     assert structure_back == structure
     for k, v in atoms.todict().items():
         assert str(atoms_back.todict()[k]) == str(v)
@@ -278,9 +277,9 @@ def test_back_forth_v3():
     atoms.set_initial_magnetic_moments([2.0] * len(atoms))
     atoms.set_array("prop", np.array([3.0] * len(atoms)))
     atoms.set_tags([1] * len(atoms))
-    molecule = aio.AseAtomsAdaptor.get_molecule(atoms)
-    atoms_back = aio.AseAtomsAdaptor.get_atoms(molecule)
-    molecule_back = aio.AseAtomsAdaptor.get_molecule(atoms_back)
+    molecule = AseAtomsAdaptor.get_molecule(atoms)
+    atoms_back = AseAtomsAdaptor.get_atoms(molecule)
+    molecule_back = AseAtomsAdaptor.get_molecule(atoms_back)
     for k, v in atoms.todict().items():
         assert str(atoms_back.todict()[k]) == str(v)
     assert molecule_back == molecule
@@ -291,9 +290,9 @@ def test_back_forth_v4():
     molecule = Molecule.from_file(TEST_FILES_DIR / "acetylene.xyz")
     molecule.set_charge_and_spin(-2, spin_multiplicity=3)
     molecule.properties = {"test": "hi"}
-    atoms = aio.AseAtomsAdaptor.get_atoms(molecule)
-    molecule_back = aio.AseAtomsAdaptor.get_molecule(atoms)
-    atoms_back = aio.AseAtomsAdaptor.get_atoms(molecule_back)
+    atoms = AseAtomsAdaptor.get_atoms(molecule)
+    molecule_back = AseAtomsAdaptor.get_molecule(atoms)
+    atoms_back = AseAtomsAdaptor.get_atoms(molecule_back)
     for k, v in atoms.todict().items():
         assert str(atoms_back.todict()[k]) == str(v)
     assert molecule_back == molecule

--- a/tests/io/vasp/test_inputs.py
+++ b/tests/io/vasp/test_inputs.py
@@ -811,21 +811,21 @@ Cartesian
         assert kpoints.style == Kpoints.supported_modes.Gamma
         kpoints = Kpoints.from_str(
             """k-point mesh
-0
-G
-10 10 10
-0.5 0.5 0.5
-"""
+            0
+            G
+            10 10 10
+            0.5 0.5 0.5
+            """
         )
         assert_allclose(kpoints.kpts_shift, [0.5, 0.5, 0.5])
 
     def test_as_dict_from_dict(self):
-        k = Kpoints.monkhorst_automatic([2, 2, 2], [0, 0, 0])
-        d = k.as_dict()
-        k2 = Kpoints.from_dict(d)
-        assert k.kpts == k2.kpts
-        assert k.style == k2.style
-        assert k.kpts_shift == k2.kpts_shift
+        kpts = Kpoints.monkhorst_automatic([2, 2, 2], [0, 0, 0])
+        dct = kpts.as_dict()
+        kpts_from_dict = Kpoints.from_dict(dct)
+        assert kpts.kpts == kpts_from_dict.kpts
+        assert kpts.style == kpts_from_dict.style
+        assert kpts.kpts_shift == kpts_from_dict.kpts_shift
 
     def test_kpt_bands_as_dict_from_dict(self):
         file_name = f"{TEST_FILES_DIR}/KPOINTS.band"
@@ -1208,6 +1208,6 @@ class TestVaspInput(PymatgenTest):
         vi = VaspInput.from_directory(TEST_FILES_DIR, optional_files={"CONTCAR.Li2O": Poscar})
         assert vi["INCAR"]["ALGO"] == "Damped"
         assert "CONTCAR.Li2O" in vi
-        d = vi.as_dict()
-        vasp_input = VaspInput.from_dict(d)
+        dct = vi.as_dict()
+        vasp_input = VaspInput.from_dict(dct)
         assert "CONTCAR.Li2O" in vasp_input

--- a/tests/io/vasp/test_sets.py
+++ b/tests/io/vasp/test_sets.py
@@ -1063,10 +1063,10 @@ class TestMITMDSet(PymatgenTest):
         filepath = f"{TEST_FILES_DIR}/POSCAR"
         poscar = Poscar.from_file(filepath)
         self.struct = poscar.structure
-        self.mitmdparam = self.set(self.struct, 300, 1200, 10000)
+        self.mit_md_param = self.set(self.struct, 300, 1200, 10000)
 
     def test_params(self):
-        param = self.mitmdparam
+        param = self.mit_md_param
         syms = param.potcar_symbols
         assert syms == ["Fe", "P", "O"]
         incar = param.incar
@@ -1077,11 +1077,11 @@ class TestMITMDSet(PymatgenTest):
         assert kpoints.style == Kpoints.supported_modes.Gamma
 
     def test_as_from_dict(self):
-        d = self.mitmdparam.as_dict()
-        v = dec.process_decoded(d)
-        assert isinstance(v, self.set)
-        assert v._config_dict["INCAR"]["TEBEG"] == 300
-        assert v._config_dict["INCAR"]["PREC"] == "Low"
+        dct = self.mit_md_param.as_dict()
+        input_set = dec.process_decoded(dct)
+        assert isinstance(input_set, self.set)
+        assert input_set._config_dict["INCAR"]["TEBEG"] == 300
+        assert input_set._config_dict["INCAR"]["PREC"] == "Low"
 
 
 @skip_if_no_psp_dir


### PR DESCRIPTION
d919b591a fix typos
c1c9a1041 fix for loop overwriting hist variable in TransformedStructure.from_snl
596a56eea fix TestVasprun.test_update_potcar using wrong PotcarSingle hash: md5_computed_file_hash should be md5_header_hash