### PR TITLE
Add type annotations to io/lammps

### DIFF
--- a/pymatgen/core/spectrum.py
+++ b/pymatgen/core/spectrum.py
@@ -118,7 +118,7 @@ class Spectrum(MSONable):
             self.y = np.array([convolve1d(self.y[:, k], weights) for k in range(self.ydim[1])]).T
             self.y *= total / np.sum(self.y, axis=0)  # renormalize to maintain the same integrated sum as before.
 
-    def get_interpolated_value(self, x: float) -> list[float]:
+    def get_interpolated_value(self, x: float) -> float | list[float]:
         """Returns an interpolated y value for a particular x value.
 
         Args:

--- a/pymatgen/io/lammps/data.py
+++ b/pymatgen/io/lammps/data.py
@@ -36,7 +36,6 @@ from pymatgen.core.structure import Molecule, Structure
 from pymatgen.util.io_utils import clean_lines
 
 if TYPE_CHECKING:
-    # your code here
     from collections.abc import Sequence
     from typing import Any, Self
 

--- a/pymatgen/io/lammps/data.py
+++ b/pymatgen/io/lammps/data.py
@@ -938,9 +938,7 @@ class Topology(MSONable):
         if not isinstance(sites, (Molecule, Structure)):
             sites = Molecule.from_sites(sites)
 
-        type_by_sites = (
-            list(*sites.site_properties.get(ff_label)) if ff_label else [site.specie.symbol for site in sites]
-        )
+        type_by_sites = sites.site_properties.get(ff_label) if ff_label else [site.specie.symbol for site in sites]
         # search for site property if not override
         if charges is None:
             charges = sites.site_properties.get("charge")

--- a/pymatgen/io/lammps/data.py
+++ b/pymatgen/io/lammps/data.py
@@ -804,7 +804,7 @@ class LammpsData(MSONable):
 
         topology = {key: None for key, values in topo_labels.items() if len(values) > 0}
         for key in topology:
-            df = pd.DataFrame(np.concatenate(topo_collector[key]), columns=SECTION_HEADERS[k][1:])
+            df = pd.DataFrame(np.concatenate(topo_collector[key]), columns=SECTION_HEADERS[key][1:])
             df["type"] = list(map(ff.maps[key].get, topo_labels[key]))
             if any(pd.isna(df["type"])):  # Throw away undefined topologies
                 warnings.warn(f"Undefined {key.lower()} detected and removed")

--- a/pymatgen/io/lammps/generators.py
+++ b/pymatgen/io/lammps/generators.py
@@ -112,7 +112,7 @@ class LammpsMinimization(BaseLammpsGenerator):
         read_data: str = "system.data",
         force_field: str = "Unspecified force field!",
         keep_stages: bool = False,
-    ):
+    ) -> None:
         r"""
         Args:
             template: Path (string) to the template file used to create the InputFile for LAMMPS.
@@ -143,31 +143,31 @@ class LammpsMinimization(BaseLammpsGenerator):
         super().__init__(template=template, settings=settings, calc_type="minimization", keep_stages=keep_stages)
 
     @property
-    def units(self):
+    def units(self) -> str:
         """Return the argument of the command 'units' passed to the generator."""
         return self.settings["units"]
 
     @property
-    def atom_style(self):
+    def atom_style(self) -> str:
         """Return the argument of the command 'atom_style' passed to the generator."""
         return self.settings["atom_style"]
 
     @property
-    def dimension(self):
+    def dimension(self) -> int:
         """Return the argument of the command 'dimension' passed to the generator."""
         return self.settings["dimension"]
 
     @property
-    def boundary(self):
+    def boundary(self) -> str:
         """Return the argument of the command 'boundary' passed to the generator."""
         return self.settings["boundary"]
 
     @property
-    def read_data(self):
+    def read_data(self) -> str:
         """Return the argument of the command 'read_data' passed to the generator."""
         return self.settings["read_data"]
 
     @property
-    def force_field(self):
+    def force_field(self) -> str:
         """Return the details of the force field commands passed to the generator."""
         return self.settings["force_field"]

--- a/pymatgen/io/lammps/inputs.py
+++ b/pymatgen/io/lammps/inputs.py
@@ -994,7 +994,7 @@ def write_lammps_inputs(
     output_dir: str,
     script_template: str,
     settings: dict | None = None,
-    data: LammpsData | str = None,
+    data: LammpsData | str | None = None,
     script_filename: str = "in.lammps",
     make_dir_if_not_present: bool = True,
     **kwargs,

--- a/pymatgen/io/lammps/inputs.py
+++ b/pymatgen/io/lammps/inputs.py
@@ -13,6 +13,7 @@ import shutil
 import warnings
 from pathlib import Path
 from string import Template
+from typing import TYPE_CHECKING
 
 import numpy as np
 from monty.dev import deprecated
@@ -23,6 +24,12 @@ from pymatgen.core import __version__ as CURRENT_VER
 from pymatgen.io.core import InputFile
 from pymatgen.io.lammps.data import CombinedData, LammpsData
 from pymatgen.io.template import TemplateInputGen
+
+if TYPE_CHECKING:
+    from typing import Self
+
+    from pymatgen.io.core import InputSet
+
 
 __author__ = "Kiran Mathew, Brandon Wood, Zhi Deng, Manas Likhit, Guillaume Brunin (Matgenix)"
 __copyright__ = "Copyright 2018, The Materials Virtual Lab"
@@ -57,7 +64,7 @@ class LammpsInputFile(InputFile):
     "Stage 1" and "Stage 2" are examples of stage names.
     """
 
-    def __init__(self, stages: list | None = None):
+    def __init__(self, stages: list | None = None) -> None:
         """
         Args:
             stages: list of LAMMPS input settings.
@@ -139,7 +146,9 @@ class LammpsInputFile(InputFile):
         """
         return bool(self.get_args(command, stage_name))
 
-    def set_args(self, command: str, argument: str, stage_name: str | None = None, how: str | int | list[int] = "all"):
+    def set_args(
+        self, command: str, argument: str, stage_name: str | None = None, how: str | int | list[int] = "all"
+    ) -> None:
         """
         Sets the arguments for the given command to the given string.
         If the command is not found, nothing is done. Use LammpsInputFile.add_commands instead.
@@ -187,7 +196,7 @@ class LammpsInputFile(InputFile):
         commands: str | list[str] | dict[str, str | float] | None = None,
         stage_name: str | None = None,
         after_stage: str | int | None = None,
-    ):
+    ) -> None:
         r"""
         Adds a new stage to the LammpsInputFile, either from a whole stage (dict) or
         from a stage_name and commands. Both ways are mutually exclusive.
@@ -280,7 +289,7 @@ class LammpsInputFile(InputFile):
                 # Adds the commands to the created stage
                 self.add_commands(stage_name=self.stages_names[index_insert], commands=commands)
 
-    def remove_stage(self, stage_name: str):
+    def remove_stage(self, stage_name: str) -> None:
         """
         Removes a whole stage from the LammpsInputFile.
 
@@ -293,7 +302,7 @@ class LammpsInputFile(InputFile):
         else:
             raise LookupError("The given stage name is not present in this LammpsInputFile.")
 
-    def rename_stage(self, stage_name: str, new_name: str):
+    def rename_stage(self, stage_name: str, new_name: str) -> None:
         """
         Renames a stage `stage_name` from LammpsInputFile into `new_name`.
         First checks that the stage to rename is present, and that
@@ -311,7 +320,7 @@ class LammpsInputFile(InputFile):
         else:
             raise LookupError("The given stage name is not present in this LammpsInputFile.")
 
-    def merge_stages(self, stage_names: list[str]):
+    def merge_stages(self, stage_names: list[str]) -> None:
         """
         Merges multiple stages of a LammpsInputFile together.
         The merged stage will be at the same index as the first of the stages to be merged.
@@ -347,7 +356,7 @@ class LammpsInputFile(InputFile):
 
         self.stages = stages
 
-    def add_commands(self, stage_name: str, commands: str | list[str] | dict):
+    def add_commands(self, stage_name: str, commands: str | list[str] | dict) -> None:
         """
         Method to add a LAMMPS commands and their arguments to a stage of
         the LammpsInputFile. The stage name should be provided: a default behavior
@@ -402,7 +411,9 @@ class LammpsInputFile(InputFile):
         else:
             raise TypeError("The command should be a string, list of strings or dictionary.")
 
-    def remove_command(self, command: str, stage_name: str | list[str] | None = None, remove_empty_stages: bool = True):
+    def remove_command(
+        self, command: str, stage_name: str | list[str] | None = None, remove_empty_stages: bool = True
+    ) -> None:
         """
         Removes a given command from a given stage. If no stage is given, removes all occurrences of the command.
         In case removing a command completely empties a stage, the choice whether to keep this stage in the
@@ -442,7 +453,7 @@ class LammpsInputFile(InputFile):
         if n_removed == 0:
             warnings.warn(f"{command} not found in the LammpsInputFile.")
 
-    def append(self, lmp_input_file: LammpsInputFile):
+    def append(self, lmp_input_file: LammpsInputFile) -> None:
         """
         Appends a LammpsInputFile to another. The `stages` are merged,
         and the numbering of stages/comments is either kept the same or updated.
@@ -528,7 +539,7 @@ class LammpsInputFile(InputFile):
 
     @classmethod
     @np.deprecate(message="Use from_str instead")
-    def from_string(cls, *args, **kwargs):
+    def from_string(cls, *args, **kwargs) -> Self:
         return cls.from_str(*args, **kwargs)
 
     @classmethod
@@ -629,10 +640,10 @@ class LammpsInputFile(InputFile):
         with zopen(filename, "rt") as f:
             return cls.from_str(f.read(), ignore_comments=ignore_comments, keep_stages=keep_stages)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return self.get_str()
 
-    def _initialize_stage(self, stage_name: str | None = None, stage_index: int | None = None):
+    def _initialize_stage(self, stage_name: str | None = None, stage_index: int | None = None) -> None:
         """
         Initialize an empty stage with the given name in the LammpsInputFile.
 
@@ -669,7 +680,7 @@ class LammpsInputFile(InputFile):
             self.stages.insert(stage_index, {"stage_name": stage_name, "commands": []})
 
     @staticmethod
-    def _check_stage_format(stage: dict):
+    def _check_stage_format(stage: dict) -> None:
         if list(stage) != ["stage_name", "commands"]:
             raise KeyError(
                 "The provided stage does not have the correct keys. It should be 'stage_name' and 'commands'."
@@ -684,7 +695,7 @@ class LammpsInputFile(InputFile):
         ):
             raise ValueError("The provided commands should be a list of 2-strings tuples.")
 
-    def _add_command(self, stage_name: str, command: str, args: str | float | None = None):
+    def _add_command(self, stage_name: str, command: str, args: str | float | None = None) -> None:
         """
         Helper method to add a single LAMMPS command and its arguments to
         the LammpsInputFile. The stage name should be provided: a default behavior
@@ -728,7 +739,7 @@ class LammpsInputFile(InputFile):
 
     def _add_comment(
         self, comment: str, inline: bool = False, stage_name: str | None = None, index_comment: bool = False
-    ):
+    ) -> None:
         """
         Method to add a comment inside a stage (between actual commands)
         or as a whole stage (which will do nothing when LAMMPS runs).
@@ -860,7 +871,7 @@ class LammpsRun(MSONable):
 
     template_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "templates")
 
-    def __init__(self, script_template, settings, data, script_filename):
+    def __init__(self, script_template: str, settings: dict, data: LammpsData | str, script_filename: str) -> None:
         """
         Base constructor.
 
@@ -881,7 +892,7 @@ class LammpsRun(MSONable):
         self.data = data
         self.script_filename = script_filename
 
-    def write_inputs(self, output_dir, **kwargs):
+    def write_inputs(self, output_dir: str, **kwargs) -> None:
         """
         Writes all input files (input script, and data if needed).
         Other supporting files are not handled at this moment.
@@ -900,7 +911,14 @@ class LammpsRun(MSONable):
         )
 
     @classmethod
-    def md(cls, data, force_field, temperature, nsteps, other_settings=None):
+    def md(
+        cls,
+        data: LammpsData | str,
+        force_field: str,
+        temperature: float,
+        nsteps: int,
+        other_settings: dict | None = None,
+    ) -> Self:
         r"""
         Example for a simple MD run based on template md.template.
 
@@ -949,7 +967,7 @@ class LammpsTemplateGen(TemplateInputGen):
         script_filename: str = "in.lammps",
         data: LammpsData | CombinedData | None = None,
         data_filename: str = "system.data",
-    ):
+    ) -> InputSet:
         """
         Args:
             script_template: String template for input script with
@@ -973,14 +991,14 @@ class LammpsTemplateGen(TemplateInputGen):
 
 @deprecated(LammpsTemplateGen, "This method will be retired in the future. Consider using LammpsTemplateSet instead.")
 def write_lammps_inputs(
-    output_dir,
-    script_template,
-    settings=None,
-    data=None,
-    script_filename="in.lammps",
-    make_dir_if_not_present=True,
+    output_dir: str,
+    script_template: str,
+    settings: dict | None = None,
+    data: LammpsData | str = None,
+    script_filename: str = "in.lammps",
+    make_dir_if_not_present: bool = True,
     **kwargs,
-):
+) -> None:
     """
     Writes input files for a LAMMPS run. Input script is constructed
     from a str template with placeholders to be filled by custom

--- a/pymatgen/io/lammps/outputs.py
+++ b/pymatgen/io/lammps/outputs.py
@@ -18,7 +18,6 @@ from monty.json import MSONable
 from pymatgen.io.lammps.data import LammpsBox
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
     from typing import Any, Self
 
 __author__ = "Kiran Mathew, Zhi Deng"
@@ -102,7 +101,7 @@ class LammpsDump(MSONable):
         return dct
 
 
-def parse_lammps_dumps(file_pattern: str) -> Generator:
+def parse_lammps_dumps(file_pattern):
     """
     Generator that parses dump file(s).
 
@@ -121,7 +120,7 @@ def parse_lammps_dumps(file_pattern: str) -> Generator:
 
     for fname in files:
         with zopen(fname, "rt") as f:
-            dump_cache: list = []
+            dump_cache = []
             for line in f:
                 if line.startswith("ITEM: TIMESTEP"):
                     if len(dump_cache) > 0:

--- a/pymatgen/io/lammps/outputs.py
+++ b/pymatgen/io/lammps/outputs.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import re
 from glob import glob
 from io import StringIO
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -15,6 +16,10 @@ from monty.io import zopen
 from monty.json import MSONable
 
 from pymatgen.io.lammps.data import LammpsBox
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from typing import Self
 
 __author__ = "Kiran Mathew, Zhi Deng"
 __copyright__ = "Copyright 2018, The Materials Virtual Lab"
@@ -27,7 +32,7 @@ __date__ = "Aug 1, 2018"
 class LammpsDump(MSONable):
     """Object for representing dump data for a single snapshot."""
 
-    def __init__(self, timestep, natoms, box, data):
+    def __init__(self, timestep: int, natoms: int, box: LammpsBox, data: pd.DataFrame) -> None:
         """
         Base constructor.
 
@@ -44,11 +49,11 @@ class LammpsDump(MSONable):
 
     @classmethod
     @np.deprecate(message="Use from_str instead")
-    def from_string(cls, *args, **kwargs):
+    def from_string(cls, *args, **kwargs) -> Self:
         return cls.from_str(*args, **kwargs)
 
     @classmethod
-    def from_str(cls, string):
+    def from_str(cls, string: str) -> Self:
         """
         Constructor from string parsing.
 
@@ -72,7 +77,7 @@ class LammpsDump(MSONable):
         return cls(timestep, n_atoms, box, data)
 
     @classmethod
-    def from_dict(cls, d):
+    def from_dict(cls, d: dict) -> Self:
         """
         Args:
             d (dict): Dict representation.
@@ -85,7 +90,7 @@ class LammpsDump(MSONable):
         items["data"] = pd.read_json(d["data"], orient="split")
         return cls(**items)
 
-    def as_dict(self):
+    def as_dict(self) -> dict:
         """Returns: MSONable dict."""
         dct = {}
         dct["@module"] = type(self).__module__
@@ -97,7 +102,7 @@ class LammpsDump(MSONable):
         return dct
 
 
-def parse_lammps_dumps(file_pattern):
+def parse_lammps_dumps(file_pattern: str) -> Generator:
     """
     Generator that parses dump file(s).
 
@@ -127,7 +132,7 @@ def parse_lammps_dumps(file_pattern):
             yield LammpsDump.from_str("".join(dump_cache))
 
 
-def parse_lammps_log(filename="log.lammps"):
+def parse_lammps_log(filename: str = "log.lammps") -> list[pd.DataFrame]:
     """
     Parses log file with focus on thermo data. Both one and multi line
     formats are supported. Any incomplete runs (no "Loop time" marker)
@@ -158,7 +163,7 @@ def parse_lammps_log(filename="log.lammps"):
         elif line.startswith(end_flag):
             ends.append(idx)
 
-    def _parse_thermo(lines):
+    def _parse_thermo(lines: list[str]) -> pd.DataFrame:
         multi_pattern = r"-+\s+Step\s+([0-9]+)\s+-+"
         # multi line thermo data
         if re.match(multi_pattern, lines[0]):

--- a/pymatgen/io/lammps/outputs.py
+++ b/pymatgen/io/lammps/outputs.py
@@ -19,7 +19,7 @@ from pymatgen.io.lammps.data import LammpsBox
 
 if TYPE_CHECKING:
     from collections.abc import Generator
-    from typing import Self
+    from typing import Any, Self
 
 __author__ = "Kiran Mathew, Zhi Deng"
 __copyright__ = "Copyright 2018, The Materials Virtual Lab"
@@ -90,9 +90,9 @@ class LammpsDump(MSONable):
         items["data"] = pd.read_json(d["data"], orient="split")
         return cls(**items)
 
-    def as_dict(self) -> dict:
+    def as_dict(self) -> dict[str, Any]:
         """Returns: MSONable dict."""
-        dct = {}
+        dct: dict[str, Any] = {}
         dct["@module"] = type(self).__module__
         dct["@class"] = type(self).__name__
         dct["timestep"] = self.timestep

--- a/pymatgen/io/lammps/outputs.py
+++ b/pymatgen/io/lammps/outputs.py
@@ -121,7 +121,7 @@ def parse_lammps_dumps(file_pattern: str) -> Generator:
 
     for fname in files:
         with zopen(fname, "rt") as f:
-            dump_cache = []
+            dump_cache: list = []
             for line in f:
                 if line.startswith("ITEM: TIMESTEP"):
                     if len(dump_cache) > 0:

--- a/pymatgen/io/lammps/outputs.py
+++ b/pymatgen/io/lammps/outputs.py
@@ -102,7 +102,7 @@ class LammpsDump(MSONable):
         return dct
 
 
-def parse_lammps_dumps(file_pattern: str) -> Generator:
+def parse_lammps_dumps(file_pattern) -> Generator:
     """
     Generator that parses dump file(s).
 
@@ -173,7 +173,9 @@ def parse_lammps_log(filename: str = "log.lammps") -> list[pd.DataFrame]:
             kv_pattern = r"([0-9A-Za-z_\[\]]+)\s+=\s+([0-9eE\.+-]+)"
             for ts in timesteps:
                 data = {}
-                data["Step"] = int(re.match(multi_pattern, ts[0]).group(1))
+                step = re.match(multi_pattern, ts[0])
+                assert step is not None
+                data["Step"] = int(step.group(1))
                 data.update({k: float(v) for k, v in re.findall(kv_pattern, "".join(ts[1:]))})
                 dicts.append(data)
             df = pd.DataFrame(dicts)

--- a/pymatgen/io/lammps/outputs.py
+++ b/pymatgen/io/lammps/outputs.py
@@ -102,7 +102,7 @@ class LammpsDump(MSONable):
         return dct
 
 
-def parse_lammps_dumps(file_pattern) -> Generator:
+def parse_lammps_dumps(file_pattern: str) -> Generator:
     """
     Generator that parses dump file(s).
 

--- a/pymatgen/io/lammps/sets.py
+++ b/pymatgen/io/lammps/sets.py
@@ -85,6 +85,8 @@ class LammpsInputSet(InputSet):
         """
         input_file = LammpsInputFile.from_file(f"{directory}/in.lammps", keep_stages=keep_stages)
         atom_style = input_file.get_args("atom_style")
+        if isinstance(atom_style, list):
+            raise ValueError("Variable atom_style is specified multiple times in the input file.")
         data_file = LammpsData.from_file(f"{directory}/system.data", atom_style=atom_style)
         return LammpsInputSet(inputfile=input_file, data=data_file, calc_type="read_from_dir")
 

--- a/pymatgen/io/lammps/sets.py
+++ b/pymatgen/io/lammps/sets.py
@@ -19,6 +19,7 @@ from pymatgen.io.lammps.inputs import LammpsInputFile
 
 if TYPE_CHECKING:
     from pathlib import Path
+    from typing import Self
 
 __author__ = "Ryan Kingsbury, Guillaume Brunin (Matgenix)"
 __copyright__ = "Copyright 2021, The Materials Project"
@@ -49,7 +50,7 @@ class LammpsInputSet(InputSet):
         calc_type: str = "",
         template_file: str = "",
         keep_stages: bool = False,
-    ):
+    ) -> None:
         """
         Args:
             inputfile: The input file containing settings.
@@ -72,7 +73,7 @@ class LammpsInputSet(InputSet):
         super().__init__(inputs={"in.lammps": self.inputfile, "system.data": self.data})
 
     @classmethod
-    def from_directory(cls, directory: str | Path, keep_stages: bool = False):  # pylint: disable=E1131
+    def from_directory(cls, directory: str | Path, keep_stages: bool = False) -> Self:  # pylint: disable=E1131
         """
         Construct a LammpsInputSet from a directory of two or more files.
         TODO: accept directories with only the input file, that should include the structure as well.

--- a/pymatgen/io/lammps/utils.py
+++ b/pymatgen/io/lammps/utils.py
@@ -321,7 +321,7 @@ class PackmolRunner:
                 if site_property:
                     packed_mol = self.restore_site_properties(site_property=site_property, filename=output_file)
                 return packed_mol
-            raise RuntimeError(f"Packmol execution failed. {stdout}\n{stderr}")
+            raise RuntimeError(f"Packmol execution failed. {stdout.decode}\n{stderr.decode}")
 
     @staticmethod
     def write_pdb(mol: Molecule, filename: str, name: str | None = None, num=None) -> None:
@@ -368,9 +368,8 @@ class PackmolRunner:
         Returns:
             Molecule object
         """
-        restore_site_props = residue_name is not None
 
-        if restore_site_props and not hasattr(self, "map_residue_to_mol"):
+        if residue_name is not None and not hasattr(self, "map_residue_to_mol"):
             self._set_residue_map()
 
         coords = []
@@ -381,7 +380,7 @@ class PackmolRunner:
 
         mol = Molecule(zs, coords)
 
-        if restore_site_props:
+        if residue_name is not None:
             props = []
 
             ref = self.map_residue_to_mol[residue_name].copy()

--- a/pymatgen/io/lammps/utils.py
+++ b/pymatgen/io/lammps/utils.py
@@ -6,6 +6,7 @@ import os
 import tempfile
 from shutil import which
 from subprocess import PIPE, Popen
+from typing import TYPE_CHECKING
 
 import numpy as np
 from monty.dev import deprecated
@@ -16,6 +17,11 @@ from pymatgen.core.structure import Molecule
 from pymatgen.io.babel import BabelMolAdaptor
 from pymatgen.io.packmol import PackmolBoxGen
 from pymatgen.util.coord import get_angle
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from numpy.typing import ArrayLike
 
 try:
     from openbabel import pybel
@@ -34,19 +40,19 @@ class Polymer:
 
     def __init__(
         self,
-        start_monomer,
-        s_head,
-        s_tail,
-        monomer,
-        head,
-        tail,
-        end_monomer,
-        e_head,
-        e_tail,
-        n_units,
-        link_distance=1.0,
-        linear_chain=False,
-    ):
+        start_monomer: Molecule,
+        s_head: int,
+        s_tail: int,
+        monomer: Molecule,
+        head: int,
+        tail: int,
+        end_monomer: Molecule,
+        e_head: int,
+        e_tail: int,
+        n_units: int,
+        link_distance: float = 1.0,
+        linear_chain: bool = False,
+    ) -> None:
         """
         Args:
             start_monomer (Molecule): Starting molecule
@@ -95,7 +101,7 @@ class Polymer:
         self._create(end_monomer, end_mon_vector)
         self.molecule = Molecule.from_sites(self.molecule.sites)
 
-    def _create(self, monomer, mon_vector):
+    def _create(self, monomer: Molecule, mon_vector: ArrayLike) -> None:
         """
         create the polymer from the monomer.
 
@@ -111,7 +117,7 @@ class Polymer:
                 move_direction = self._next_move_direction()
             self._add_monomer(monomer.copy(), mon_vector, move_direction)
 
-    def _next_move_direction(self):
+    def _next_move_direction(self) -> np.ndarray:
         """Pick a move at random from the list of moves."""
         nmoves = len(self.moves)
         move = np.random.randint(1, nmoves + 1)
@@ -120,7 +126,7 @@ class Polymer:
         self.prev_move = move
         return np.array(self.moves[move])
 
-    def _align_monomer(self, monomer, mon_vector, move_direction):
+    def _align_monomer(self, monomer: Molecule, mon_vector: ArrayLike, move_direction: ArrayLike) -> None:
         """
         rotate the monomer so that it is aligned along the move direction.
 
@@ -137,7 +143,7 @@ class Polymer:
         op = SymmOp.from_origin_axis_angle(origin, axis, angle)
         monomer.apply_operation(op)
 
-    def _add_monomer(self, monomer, mon_vector, move_direction):
+    def _add_monomer(self, monomer: Molecule, mon_vector: ArrayLike, move_direction: ArrayLike) -> None:
         """
         extend the polymer molecule by adding a monomer along mon_vector direction.
 
@@ -175,16 +181,16 @@ class PackmolRunner:
 
     def __init__(
         self,
-        mols,
-        param_list,
-        input_file="pack.inp",
-        tolerance=2.0,
-        filetype="xyz",
-        control_params=None,
-        auto_box=True,
-        output_file="packed.xyz",
-        bin="packmol",
-    ):
+        mols: list,
+        param_list: list,
+        input_file: str = "pack.inp",
+        tolerance: float = 2.0,
+        filetype: str = "xyz",
+        control_params: dict | None = None,
+        auto_box: bool = True,
+        output_file: str = "packed.xyz",
+        bin: str = "packmol",
+    ) -> None:
         """
         Args:
             mols:
@@ -230,7 +236,7 @@ class PackmolRunner:
             self._set_box()
 
     @staticmethod
-    def _format_param_val(param_val):
+    def _format_param_val(param_val) -> str:
         """
         Internal method to format values in the packmol parameter dictionaries.
 
@@ -245,7 +251,7 @@ class PackmolRunner:
             return " ".join(str(x) for x in param_val)
         return str(param_val)
 
-    def _set_box(self):
+    def _set_box(self) -> None:
         """Set the box size for the molecular assembly."""
         net_volume = 0.0
         for idx, mol in enumerate(self.mols):
@@ -255,7 +261,7 @@ class PackmolRunner:
         for idx, _mol in enumerate(self.mols):
             self.param_list[idx]["inside box"] = f"0.0 0.0 0.0 {length} {length} {length}"
 
-    def _write_input(self, input_dir="."):
+    def _write_input(self, input_dir: str = ".") -> None:
         """
         Write the packmol input file to the input directory.
 
@@ -289,7 +295,7 @@ class PackmolRunner:
                     inp.write(f"  {k} {self._format_param_val(v)}\n")
                 inp.write("end structure\n")
 
-    def run(self, site_property=None):
+    def run(self, site_property: str | None = None) -> Molecule:
         """
         Write the input file to the scratch directory, run packmol and return
         the packed molecule to the current working directory.
@@ -318,7 +324,7 @@ class PackmolRunner:
             raise RuntimeError(f"Packmol execution failed. {stdout}\n{stderr}")
 
     @staticmethod
-    def write_pdb(mol, filename, name=None, num=None):
+    def write_pdb(mol: Molecule, filename: str, name: str | None = None, num=None) -> None:
         """Dump the molecule into pdb file with custom residue name and number."""
         # ugly hack to get around the openbabel issues with inconsistent
         # residue labelling.
@@ -337,7 +343,7 @@ class PackmolRunner:
 
         pbm.write(format="pdb", filename=filename, overwrite=True)
 
-    def _set_residue_map(self):
+    def _set_residue_map(self) -> None:
         """Map each residue to the corresponding molecule."""
         self.map_residue_to_mol = {}
         lookup = {}
@@ -347,9 +353,11 @@ class PackmolRunner:
                 lookup[mol.formula] = mol.copy()
             self.map_residue_to_mol[f"ml{idx + 1}"] = lookup[mol.formula]
 
-    def convert_obatoms_to_molecule(self, atoms, residue_name=None, site_property="ff_map"):
+    def convert_obatoms_to_molecule(
+        self, atoms: Sequence, residue_name: str | None = None, site_property: str = "ff_map"
+    ) -> Molecule:
         """
-        Convert list of openbabel atoms to MOlecule.
+        Convert list of openbabel atoms to Molecule.
 
         Args:
             atoms ([OBAtom]): list of OBAtom objects
@@ -391,7 +399,7 @@ class PackmolRunner:
 
         return mol
 
-    def restore_site_properties(self, site_property="ff_map", filename=None):
+    def restore_site_properties(self, site_property: str = "ff_map", filename: str | None = None) -> Molecule:
         """
         Restore the site properties for the final packed molecule.
 
@@ -428,7 +436,7 @@ class PackmolRunner:
 class LammpsRunner:
     """LAMMPS wrapper."""
 
-    def __init__(self, input_filename="lammps.in", bin="lammps"):
+    def __init__(self, input_filename: str = "lammps.in", bin: str = "lammps") -> None:
         """
         Args:
             input_filename (str): input file name
@@ -444,7 +452,7 @@ class LammpsRunner:
             )
         self.input_filename = input_filename
 
-    def run(self):
+    def run(self) -> tuple[bytes, bytes]:
         """Write the input/data files and run LAMMPS."""
         lammps_cmd = [*self.lammps_bin, "-in", self.input_filename]
         print(f"Running: {' '.join(lammps_cmd)}")

--- a/pymatgen/util/coord.py
+++ b/pymatgen/util/coord.py
@@ -207,7 +207,7 @@ def pbc_shortest_vectors(lattice, fcoords1, fcoords2, mask=None, return_d2: bool
     return coord_cython.pbc_shortest_vectors(lattice, fcoords1, fcoords2, mask, return_d2)
 
 
-def find_in_coord_list_pbc(fcoord_list, fcoord, atol:float=1e-8, pbc=(True, True, True)) -> list[int]:
+def find_in_coord_list_pbc(fcoord_list, fcoord, atol: float = 1e-8, pbc=(True, True, True)) -> list[int]:
     """Get the indices of all points in a fractional coord list that are
     equal to a fractional coord (with a tolerance), taking into account
     periodic boundary conditions.
@@ -230,7 +230,7 @@ def find_in_coord_list_pbc(fcoord_list, fcoord, atol:float=1e-8, pbc=(True, True
     return np.where(np.all(np.abs(fdist) < atol, axis=1))[0]
 
 
-def in_coord_list_pbc(fcoord_list, fcoord, atol:float=1e-8, pbc=(True, True, True)) -> bool:
+def in_coord_list_pbc(fcoord_list, fcoord, atol: float = 1e-8, pbc=(True, True, True)) -> bool:
     """Tests if a particular fractional coord is within a fractional coord_list.
 
     Args:

--- a/pymatgen/util/coord.py
+++ b/pymatgen/util/coord.py
@@ -7,14 +7,16 @@ from __future__ import annotations
 
 import itertools
 import math
-import typing
+from typing import TYPE_CHECKING
 
 import numpy as np
 from monty.json import MSONable
 
 from pymatgen.util import coord_cython
 
-if typing.TYPE_CHECKING:
+if TYPE_CHECKING:
+    from typing import Literal
+
     from numpy.typing import ArrayLike
 
 
@@ -40,7 +42,7 @@ def find_in_coord_list(coord_list, coord, atol=1e-8):
     return np.where(np.all(np.abs(diff) < atol, axis=1))[0]
 
 
-def in_coord_list(coord_list, coord, atol=1e-8):
+def in_coord_list(coord_list, coord, atol=1e-8) -> bool:
     """Tests if a particular coord is within a coord_list.
 
     Args:
@@ -116,7 +118,7 @@ def coord_list_mapping_pbc(subset, superset, atol=1e-8, pbc=(True, True, True)):
     return coord_cython.coord_list_mapping_pbc(subset, superset, atol, pbc)
 
 
-def get_linear_interpolated_value(x_values, y_values, x):
+def get_linear_interpolated_value(x_values: ArrayLike, y_values: ArrayLike, x: float) -> float:
     """Returns an interpolated value by linear interpolation between two values.
     This method is written to avoid dependency on scipy, which causes issues on
     threading servers.
@@ -143,7 +145,7 @@ def get_linear_interpolated_value(x_values, y_values, x):
     return y1 + (y2 - y1) / (x2 - x1) * (x - x1)
 
 
-def all_distances(coords1, coords2):
+def all_distances(coords1: ArrayLike, coords2: ArrayLike):
     """Returns the distances between two lists of coordinates.
 
     Args:
@@ -182,7 +184,7 @@ def pbc_diff(fcoords1: ArrayLike, fcoords2: ArrayLike, pbc: tuple[bool, bool, bo
     return fdist - np.round(fdist) * pbc
 
 
-def pbc_shortest_vectors(lattice, fcoords1, fcoords2, mask=None, return_d2=False):
+def pbc_shortest_vectors(lattice, fcoords1, fcoords2, mask=None, return_d2: bool = False):
     """Returns the shortest vectors between two lists of coordinates taking into
     account periodic boundary conditions and the lattice.
 
@@ -205,7 +207,7 @@ def pbc_shortest_vectors(lattice, fcoords1, fcoords2, mask=None, return_d2=False
     return coord_cython.pbc_shortest_vectors(lattice, fcoords1, fcoords2, mask, return_d2)
 
 
-def find_in_coord_list_pbc(fcoord_list, fcoord, atol=1e-8, pbc=(True, True, True)):
+def find_in_coord_list_pbc(fcoord_list, fcoord, atol:float=1e-8, pbc=(True, True, True)) -> list[int]:
     """Get the indices of all points in a fractional coord list that are
     equal to a fractional coord (with a tolerance), taking into account
     periodic boundary conditions.
@@ -228,7 +230,7 @@ def find_in_coord_list_pbc(fcoord_list, fcoord, atol=1e-8, pbc=(True, True, True
     return np.where(np.all(np.abs(fdist) < atol, axis=1))[0]
 
 
-def in_coord_list_pbc(fcoord_list, fcoord, atol=1e-8, pbc=(True, True, True)):
+def in_coord_list_pbc(fcoord_list, fcoord, atol:float=1e-8, pbc=(True, True, True)) -> bool:
     """Tests if a particular fractional coord is within a fractional coord_list.
 
     Args:
@@ -244,7 +246,7 @@ def in_coord_list_pbc(fcoord_list, fcoord, atol=1e-8, pbc=(True, True, True)):
     return len(find_in_coord_list_pbc(fcoord_list, fcoord, atol=atol, pbc=pbc)) > 0
 
 
-def is_coord_subset_pbc(subset, superset, atol=1e-8, mask=None, pbc=(True, True, True)):
+def is_coord_subset_pbc(subset, superset, atol=1e-8, mask=None, pbc: tuple = (True, True, True)) -> bool:
     """Tests if all fractional coords in subset are contained in superset.
 
     Args:
@@ -309,7 +311,7 @@ def barycentric_coords(coords, simplex):
             (d+1, d)
 
     Returns:
-        a LIST of barycentric coordinates (even if the original input was 1d)
+        a list of barycentric coordinates (even if the original input was 1d)
     """
     coords = np.atleast_2d(coords)
 
@@ -319,7 +321,7 @@ def barycentric_coords(coords, simplex):
     return np.append(all_but_one, last_coord, axis=-1)
 
 
-def get_angle(v1, v2, units="degrees"):
+def get_angle(v1: ArrayLike, v2: ArrayLike, units: Literal["degrees", "radians"] = "degrees") -> float:
     """Calculates the angle between two vectors.
 
     Args:
@@ -349,7 +351,7 @@ class Simplex(MSONable):
         simplex_dim (int): Dimension of the simplex coordinate space.
     """
 
-    def __init__(self, coords):
+    def __init__(self, coords) -> None:
         """Initializes a Simplex from vertex coordinates.
 
         Args:
@@ -365,7 +367,7 @@ class Simplex(MSONable):
             self._aug_inv = np.linalg.inv(self._aug)
 
     @property
-    def volume(self):
+    def volume(self) -> float:
         """Volume of the simplex."""
         return abs(np.linalg.det(self._aug)) / math.factorial(self.simplex_dim)
 
@@ -382,7 +384,7 @@ class Simplex(MSONable):
         except AttributeError as exc:
             raise ValueError("Simplex is not full-dimensional") from exc
 
-    def point_from_bary_coords(self, bary_coords):
+    def point_from_bary_coords(self, bary_coords: ArrayLike):
         """
         Args:
             bary_coords (): Barycentric coordinates.
@@ -454,7 +456,7 @@ class Simplex(MSONable):
     def __hash__(self) -> int:
         return len(self._coords)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         output = [f"{self.simplex_dim}-simplex in {self.space_dim}D space\nVertices:"]
         output += [f"\t({', '.join(map(str, coord))})" for coord in self._coords]
         return "\n".join(output)


### PR DESCRIPTION
## Summary

Major changes:

- Added (some) type annotations to `io/lammps` and fixed some typos.

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
