### PR TITLE
Fix ruff `FURB` violations

### DIFF
--- a/pymatgen/alchemy/materials.py
+++ b/pymatgen/alchemy/materials.py
@@ -212,12 +212,10 @@ class TransformedStructure(MSONable):
 
     def __str__(self) -> str:
         output = ["Current structure", "------------", str(self.final_structure), "\nHistory", "------------"]
-        for h in self.history:
-            h.pop("input_structure", None)
-            output.append(str(h))
-        output.append("\nOther parameters")
-        output.append("------------")
-        output.append(str(self.other_parameters))
+        for hist in self.history:
+            hist.pop("input_structure", None)
+            output.append(str(hist))
+        output.extend(("\nOther parameters", "------------", str(self.other_parameters)))
         return "\n".join(output)
 
     def set_parameter(self, key: str, value: Any) -> None:

--- a/pymatgen/analysis/adsorption.py
+++ b/pymatgen/analysis/adsorption.py
@@ -159,7 +159,7 @@ class AdsorbateSiteFinder:
         sites.
 
         Args:
-            site_list (list): list of sites from which to select surface sites
+            slab (Slab): slab for which to find surface sites
             height (float): threshold in angstroms of distance from topmost
                 site in slab along the slab c-vector to include in surface
                 site determination
@@ -170,7 +170,7 @@ class AdsorbateSiteFinder:
             list of sites selected to be within a threshold of the highest
         """
         # Get projection of coordinates along the miller index
-        m_projs = np.array([np.dot(site.coords, self.mvec) for site in slab.sites])
+        m_projs = np.array([np.dot(site.coords, self.mvec) for site in slab])
 
         # Mask based on window threshold along the miller index.
         mask = (m_projs - np.amax(m_projs)) >= -height
@@ -196,7 +196,7 @@ class AdsorbateSiteFinder:
             return slab
 
         surf_sites = self.find_surface_sites_by_height(slab, height)
-        surf_props = ["surface" if site in surf_sites else "subsurface" for site in slab.sites]
+        surf_props = ["surface" if site in surf_sites else "subsurface" for site in slab]
         return slab.copy(site_properties={"surface_properties": surf_props})
 
     def get_extended_surface_mesh(self, repeat=(5, 5, 1)):
@@ -213,11 +213,11 @@ class AdsorbateSiteFinder:
     @property
     def surface_sites(self):
         """Convenience method to return a list of surface sites."""
-        return [site for site in self.slab.sites if site.properties["surface_properties"] == "surface"]
+        return [site for site in self.slab if site.properties["surface_properties"] == "surface"]
 
     def subsurface_sites(self):
         """Convenience method to return list of subsurface sites."""
-        return [site for site in self.slab.sites if site.properties["surface_properties"] == "subsurface"]
+        return [site for site in self.slab if site.properties["surface_properties"] == "subsurface"]
 
     def find_adsorption_sites(
         self,
@@ -378,7 +378,7 @@ class AdsorbateSiteFinder:
             # Translate the molecule so that the center of mass of the atoms
             # that have the most negative z coordinate is at (0, 0, 0)
             front_atoms = molecule.copy()
-            front_atoms._sites = [s for s in molecule.sites if s.coords[2] == min(s.coords[2] for s in molecule.sites)]
+            front_atoms._sites = [s1 for s1 in molecule if s1.coords[2] == min(s2.coords[2] for s2 in molecule)]
             x, y, z = front_atoms.center_of_mass
             molecule.translate_sites(vector=[-x, -y, -z])
         if reorient:
@@ -412,7 +412,7 @@ class AdsorbateSiteFinder:
         sd_list = []
         sd_list = [
             [False, False, False] if site.properties["surface_properties"] == "subsurface" else [True, True, True]
-            for site in slab.sites
+            for site in slab
         ]
         new_sp = slab.site_properties
         new_sp["selective_dynamics"] = sd_list
@@ -501,7 +501,7 @@ class AdsorbateSiteFinder:
         for ad_slab in ad_slabs:
             # Find the adsorbate sites and indices in each slab
             _, adsorbates, indices = False, [], []
-            for idx, site in enumerate(ad_slab.sites):
+            for idx, site in enumerate(ad_slab):
                 if site.surface_properties == "adsorbate":
                     adsorbates.append(site)
                     indices.append(idx)

--- a/pymatgen/analysis/chemenv/connectivity/connected_components.py
+++ b/pymatgen/analysis/chemenv/connectivity/connected_components.py
@@ -234,11 +234,9 @@ class ConnectedComponent(MSONable):
                 env_node1 = edge[0]
                 env_node2 = edge[1]
                 key = None if len(edge) == 2 else edge[2]
-                if (not self._connected_subgraph.has_node(env_node1)) or (
-                    not self._connected_subgraph.has_node(env_node2)
-                ):
+                if not self._connected_subgraph.has_node(env_node1) or not self._connected_subgraph.has_node(env_node2):
                     raise ChemenvError(
-                        self.__class__,
+                        type(self).__name__,
                         "__init__",
                         "Trying to add edge with some unexistent node ...",
                     )

--- a/pymatgen/analysis/chemenv/coordination_environments/chemenv_strategies.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/chemenv_strategies.py
@@ -2610,7 +2610,7 @@ class WeightedNbSetChemenvStrategy(AbstractChemenvStrategy):
             return None
         cn_maps = []
         for cn, nb_sets in site_nb_sets.items():
-            for inb_set, _ in enumerate(nb_sets):
+            for inb_set in range(len(nb_sets)):
                 # CHECK THE ADDITIONAL CONDITION HERE ?
                 cn_maps.append((cn, inb_set))
         weights_additional_info = {"weights": {isite: {}}}

--- a/pymatgen/analysis/chemenv/coordination_environments/coordination_geometries.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/coordination_geometries.py
@@ -651,8 +651,7 @@ class CoordinationGeometry:
             outs.append("  - list of points :")
             for pp in self.points:
                 outs.append(f"    - {pp}")
-        outs.append("------------------------------------------------------------")
-        outs.append("")
+        outs.extend(("------------------------------------------------------------", ""))
 
         return "\n".join(outs)
 
@@ -670,8 +669,7 @@ class CoordinationGeometry:
             f"Coordination geometry type : {self.name}{symbol}\n",
             f"  - coordination number : {self.coordination}",
         ]
-        outs.append("------------------------------------------------------------")
-        outs.append("")
+        outs.extend(("------------------------------------------------------------", ""))
         return "\n".join(outs)
 
     def __len__(self):

--- a/pymatgen/analysis/chemenv/coordination_environments/structure_environments.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/structure_environments.py
@@ -459,14 +459,14 @@ class StructureEnvironments(MSONable):
         distance_conditions = []
         for idp, dp_dict in enumerate(site_distance_parameters):
             distance_conditions.append([])
-            for inb, _ in enumerate(site_voronoi):
+            for inb in range(len(site_voronoi)):
                 cond = inb in dp_dict["nb_indices"]
                 distance_conditions[idp].append(cond)
         # Precompute angle conditions
         angle_conditions = []
         for iap, ap_dict in enumerate(site_angle_parameters):
             angle_conditions.append([])
-            for inb, _ in enumerate(site_voronoi):
+            for inb in range(len(site_voronoi)):
                 cond = inb in ap_dict["nb_indices"]
                 angle_conditions[iap].append(cond)
         # Precompute additional conditions
@@ -1073,19 +1073,16 @@ class StructureEnvironments(MSONable):
         """
         differences = []
         if self.structure != other.structure:
-            differences.append(
-                {
-                    "difference": "structure",
-                    "comparison": "__eq__",
-                    "self": self.structure,
-                    "other": other.structure,
-                }
-            )
-            differences.append(
-                {
-                    "difference": "PREVIOUS DIFFERENCE IS DISMISSIVE",
-                    "comparison": "differences_wrt",
-                }
+            differences.extend(
+                (
+                    {
+                        "difference": "structure",
+                        "comparison": "__eq__",
+                        "self": self.structure,
+                        "other": other.structure,
+                    },
+                    {"difference": "PREVIOUS DIFFERENCE IS DISMISSIVE", "comparison": "differences_wrt"},
+                )
             )
             return differences
         if self.valences != other.valences:
@@ -1108,36 +1105,24 @@ class StructureEnvironments(MSONable):
             )
         if self.voronoi != other.voronoi:
             if self.voronoi.is_close_to(other.voronoi):
-                differences.append(
-                    {
-                        "difference": "voronoi",
-                        "comparison": "__eq__",
-                        "self": self.voronoi,
-                        "other": other.voronoi,
-                    }
-                )
-                differences.append(
-                    {
-                        "difference": "PREVIOUS DIFFERENCE IS DISMISSIVE",
-                        "comparison": "differences_wrt",
-                    }
+                differences.extend(
+                    (
+                        {"difference": "voronoi", "comparison": "__eq__", "self": self.voronoi, "other": other.voronoi},
+                        {"difference": "PREVIOUS DIFFERENCE IS DISMISSIVE", "comparison": "differences_wrt"},
+                    )
                 )
                 return differences
 
-            differences.append(
-                {
-                    "difference": "voronoi",
-                    "comparison": "is_close_to",
-                    "self": self.voronoi,
-                    "other": other.voronoi,
-                }
-            )
-            # TODO: make it possible to have "close" voronoi's
-            differences.append(
-                {
-                    "difference": "PREVIOUS DIFFERENCE IS DISMISSIVE",
-                    "comparison": "differences_wrt",
-                }
+            differences.extend(
+                (
+                    {
+                        "difference": "voronoi",
+                        "comparison": "is_close_to",
+                        "self": self.voronoi,
+                        "other": other.voronoi,
+                    },
+                    {"difference": "PREVIOUS DIFFERENCE IS DISMISSIVE", "comparison": "differences_wrt"},
+                )
             )
             return differences
         for isite, self_site_nb_sets in enumerate(self.neighbors_sets):

--- a/pymatgen/analysis/chemenv/coordination_environments/voronoi.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/voronoi.py
@@ -810,10 +810,8 @@ class DetailedVoronoiContainer(MSONable):
             xx = [0.0]
             yy = [0.0]
             for idist, dist in enumerate(sorted_dists):
-                xx.append(dist)
-                xx.append(dist)
-                yy.append(yy[-1])
-                yy.append(yy[-1] + dnb_dists[idist])
+                xx.extend((dist, dist))
+                yy.extend((yy[-1], yy[-1] + dnb_dists[idist]))
             xx.append(1.1 * xx[-1])
             yy.append(yy[-1])
         elif step_function["type"] == "normal_cdf":
@@ -864,10 +862,8 @@ class DetailedVoronoiContainer(MSONable):
             xx = [0.0]
             yy = [0.0]
             for iang, ang in enumerate(sorted_angs):
-                xx.append(ang)
-                xx.append(ang)
-                yy.append(yy[-1])
-                yy.append(yy[-1] + dnb_angs[iang])
+                xx.extend((ang, ang))
+                yy.extend((yy[-1], yy[-1] + dnb_angs[iang]))
             xx.append(1.1 * xx[-1])
             yy.append(yy[-1])
         elif step_function["type"] == "normal_cdf":

--- a/pymatgen/analysis/chemenv/utils/chemenv_errors.py
+++ b/pymatgen/analysis/chemenv/utils/chemenv_errors.py
@@ -64,7 +64,7 @@ class SolidAngleError(AbstractChemenvError):
 class ChemenvError(Exception):
     """Chemenv error."""
 
-    def __init__(self, cls, method, msg):
+    def __init__(self, cls: str, method: str, msg: str):
         """
         :param cls:
         :param method:

--- a/pymatgen/analysis/chemenv/utils/coordination_geometry_utils.py
+++ b/pymatgen/analysis/chemenv/utils/coordination_geometry_utils.py
@@ -681,14 +681,11 @@ class Plane:
         Returns:
             String representation of the Plane object.
         """
-        outs = ["Plane object"]
-        outs.append(f"  => Normal vector : {self.normal_vector}")
-        outs.append("  => Equation of the plane ax + by + cz + d = 0")
-        outs.append(f"     with a = {self._coefficients[0]}")
-        outs.append(f"          b = {self._coefficients[1]}")
-        outs.append(f"          c = {self._coefficients[2]}")
-        outs.append(f"          d = {self._coefficients[3]}")
-        return "\n".join(outs)
+        return (
+            f"Plane object\n  => Normal vector : {self.normal_vector}\n  => Equation of the plane"
+            f" ax + by + cz + d = 0\n     with a = {self._coefficients[0]}\n          "
+            f"b = {self._coefficients[1]}\n          c = {self._coefficients[2]}\n          d = {self._coefficients[3]}"
+        )
 
     def is_in_plane(self, pp, dist_tolerance) -> bool:
         """

--- a/pymatgen/analysis/gb/grain.py
+++ b/pymatgen/analysis/gb/grain.py
@@ -254,19 +254,15 @@ class GrainBoundary(Structure):
         def to_s(x, rjust=10):
             return (f"{x:0.6f}").rjust(rjust)
 
-        outs.append("abc   : " + " ".join(to_s(i) for i in self.lattice.abc))
-        outs.append("angles: " + " ".join(to_s(i) for i in self.lattice.angles))
-        outs.append(f"Sites ({len(self)})")
-        for i, site in enumerate(self):
-            outs.append(
-                " ".join(
-                    [
-                        str(i + 1),
-                        site.species_string,
-                        " ".join(to_s(j, 12) for j in site.frac_coords),
-                    ]
-                )
+        outs.extend(
+            (
+                "abc   : " + " ".join(to_s(i) for i in self.lattice.abc),
+                "angles: " + " ".join(to_s(i) for i in self.lattice.angles),
+                f"Sites ({len(self)})",
             )
+        )
+        for idx, site in enumerate(self):
+            outs.append(f"{idx + 1} {site.species_string} {' '.join(to_s(coord, 12) for coord in site.frac_coords)}")
         return "\n".join(outs)
 
     def as_dict(self):

--- a/pymatgen/analysis/gb/grain.py
+++ b/pymatgen/analysis/gb/grain.py
@@ -757,7 +757,7 @@ class GrainBoundaryGenerator:
         range_c_len = abs(bond_length / cos_c_norm_plane / whole_lat.c)
         sites_near_gb = []
         sites_away_gb: list[PeriodicSite] = []
-        for site in gb_with_vac.sites:
+        for site in gb_with_vac:
             if (
                 site.frac_coords[2] < range_c_len
                 or site.frac_coords[2] > 1 - range_c_len

--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -1294,10 +1294,10 @@ class PhaseDiagram(MSONable):
                             min_open = test_open
                             min_mus = v
 
-        elts = [e for e in self.elements if e != open_elt]
+        elems = [e for e in self.elements if e != open_elt]
         res = {}
 
-        for i, el in enumerate(elts):
+        for i, el in enumerate(elems):
             res[el] = (min_mus[i] + muref[i], max_mus[i] + muref[i])
 
         res[open_elt] = (min_open, max_open)

--- a/pymatgen/analysis/quasirrho.py
+++ b/pymatgen/analysis/quasirrho.py
@@ -189,7 +189,7 @@ class QuasiRRHO:
         """
         # Calculate mass in kg
         mass: float = 0
-        for site in mol.sites:
+        for site in mol:
             mass += site.specie.atomic_mass
         mass *= amu_to_kg
 

--- a/pymatgen/analysis/wulff.py
+++ b/pymatgen/analysis/wulff.py
@@ -332,8 +332,7 @@ class WulffShape:
                         break
             # make sure the lines are connected one by one.
             # find the way covering all pts and facets
-            pt.append(self.wulff_pt_list[line[0]].tolist())
-            pt.append(self.wulff_pt_list[line[1]].tolist())
+            pt.extend((self.wulff_pt_list[line[0]].tolist(), self.wulff_pt_list[line[1]].tolist()))
             prev = line[1]
 
         return pt
@@ -732,7 +731,7 @@ class WulffShape:
             pt = self.get_line_in_facet(facet)
 
             lines = []
-            for idx, _ in enumerate(pt):
+            for idx in range(len(pt)):
                 if idx == len(pt) / 2:
                     break
                 lines.append(tuple(sorted((tuple(pt[idx * 2]), tuple(pt[idx * 2 + 1])))))

--- a/pymatgen/apps/battery/conversion_battery.py
+++ b/pymatgen/apps/battery/conversion_battery.py
@@ -236,11 +236,10 @@ class ConversionElectrode(AbstractElectrode):
         dct["reactions"] = []
         dct["reactant_compositions"] = []
         comps = []
-        frac = []
+        frac: list[float] = []
         for pair in self.voltage_pairs:
             rxn = pair.rxn
-            frac.append(pair.frac_charge)
-            frac.append(pair.frac_discharge)
+            frac.extend((pair.frac_charge, pair.frac_discharge))
             dct["reactions"].append(str(rxn))
             for i, v in enumerate(rxn.coeffs):
                 if abs(v) > 1e-5 and rxn.all_comp[i] not in comps:

--- a/pymatgen/apps/battery/insertion_battery.py
+++ b/pymatgen/apps/battery/insertion_battery.py
@@ -346,14 +346,14 @@ class InsertionElectrode(AbstractElectrode):
         return dct
 
     def __repr__(self):
-        output = []
         chg_form = self.fully_charged_entry.composition.reduced_formula
         dischg_form = self.fully_discharged_entry.composition.reduced_formula
-        output.append(f"InsertionElectrode with endpoints at {chg_form} and {dischg_form}")
-        output.append(f"Avg. volt. = {self.get_average_voltage()} V")
-        output.append(f"Grav. cap. = {self.get_capacity_grav()} mAh/g")
-        output.append(f"Vol. cap. = {self.get_capacity_vol()}")
-        return "\n".join(output)
+        return (
+            f"InsertionElectrode with endpoints at {chg_form} and {dischg_form}\n"
+            f"Avg. volt. = {self.get_average_voltage()} V\n"
+            f"Grav. cap. = {self.get_capacity_grav()} mAh/g\n"
+            f"Vol. cap. = {self.get_capacity_vol()}"
+        )
 
     @classmethod
     def from_dict_legacy(cls, d):

--- a/pymatgen/apps/battery/plotter.py
+++ b/pymatgen/apps/battery/plotter.py
@@ -71,11 +71,9 @@ class VoltageProfilePlotter:
                 cap += sub_electrode.get_capacity_vol()
                 x.append(cap)
             elif self.xaxis == "x_form":
-                x.append(sub_electrode.x_charge)
-                x.append(sub_electrode.x_discharge)
+                x.extend((sub_electrode.x_charge, sub_electrode.x_discharge))
             elif self.xaxis == "frac_x":
-                x.append(sub_electrode.voltage_pairs[0].frac_charge)
-                x.append(sub_electrode.voltage_pairs[0].frac_discharge)
+                x.extend((sub_electrode.voltage_pairs[0].frac_charge, sub_electrode.voltage_pairs[0].frac_discharge))
             else:
                 raise NotImplementedError("x_axis must be capacity_grav/capacity_vol/x_form/frac_x")
             y.extend([sub_electrode.get_average_voltage()] * 2)

--- a/pymatgen/command_line/enumlib_caller.py
+++ b/pymatgen/command_line/enumlib_caller.py
@@ -235,13 +235,10 @@ class EnumlibAdaptor:
         output = [self.structure.formula, "bulk"]
         for vec in lattice.matrix:
             output.append(coord_format.format(*vec))
-        output.append(f"{len(index_species)}")
-        output.append(f"{len(coord_str)}")
+        output.extend((f"{len(index_species)}", f"{len(coord_str)}"))
         output.extend(coord_str)
 
-        output.append(f"{self.min_cell_size} {self.max_cell_size}")
-        output.append(str(self.enum_precision_parameter))
-        output.append("full")
+        output.extend((f"{self.min_cell_size} {self.max_cell_size}", str(self.enum_precision_parameter), "full"))
 
         n_disordered = sum(len(s) for s in disordered_sites)
         base = int(

--- a/pymatgen/core/composition.py
+++ b/pymatgen/core/composition.py
@@ -1171,27 +1171,26 @@ def reduce_formula(sym_amt, iupac_ordering: bool = False) -> tuple[str, float]:
     if all(int(i) == i for i in sym_amt.values()):
         factor = abs(gcd(*(int(i) for i in sym_amt.values())))
 
-    polyanion = []
+    poly_anions = []
     # if the composition contains a poly anion
     if len(syms) >= 3 and get_el_sp(syms[-1]).X - get_el_sp(syms[-2]).X < 1.65:
         poly_sym_amt = {syms[i]: sym_amt[syms[i]] / factor for i in [-2, -1]}
         (poly_form, poly_factor) = reduce_formula(poly_sym_amt, iupac_ordering=iupac_ordering)
 
         if poly_factor != 1:
-            polyanion.append(f"({poly_form}){poly_factor}")
+            poly_anions.append(f"({poly_form}){poly_factor}")
 
-    syms = syms[: len(syms) - 2 if polyanion else len(syms)]
+    syms = syms[: len(syms) - 2 if poly_anions else len(syms)]
 
     if iupac_ordering:
         syms = sorted(syms, key=lambda x: [get_el_sp(x).iupac_ordering, x])
 
-    reduced_form = []
+    reduced_form: list[str] = []
     for sym in syms:
         norm_amt = sym_amt[sym] * 1.0 / factor
-        reduced_form.append(sym)
-        reduced_form.append(str(formula_double_format(norm_amt)))
+        reduced_form.extend((sym, str(formula_double_format(norm_amt))))
 
-    return "".join([*reduced_form, *polyanion]), factor
+    return "".join([*reduced_form, *poly_anions]), factor
 
 
 class ChemicalPotential(dict, MSONable):

--- a/pymatgen/core/lattice.py
+++ b/pymatgen/core/lattice.py
@@ -1279,7 +1279,7 @@ class Lattice(MSONable):
             cart_a = np.reshape([self.get_cartesian_coords(vec) for vec in coords_a], (-1, 3))
             cart_b = np.reshape([self.get_cartesian_coords(vec) for vec in coords_b], (-1, 3))
 
-        return np.array([dot(a, b) for a, b in zip(cart_a, cart_b)])
+        return np.array(list(itertools.starmap(dot, zip(cart_a, cart_b))))
 
     def norm(self, coords: ArrayLike, frac_coords: bool = True) -> np.ndarray:
         """Compute the norm of vector(s).

--- a/pymatgen/core/lattice.py
+++ b/pymatgen/core/lattice.py
@@ -907,14 +907,14 @@ class Lattice(MSONable):
         beta_b = np.abs(get_angles(c_a, c_c, l_a, l_c) - beta) < atol
         gamma_b = np.abs(get_angles(c_a, c_b, l_a, l_b) - gamma) < atol
 
-        for i, all_j in enumerate(gamma_b):
-            inds = np.logical_and(all_j[:, None], np.logical_and(alpha_b, beta_b[i][None, :]))
+        for idx, all_j in enumerate(gamma_b):
+            inds = np.logical_and(all_j[:, None], np.logical_and(alpha_b, beta_b[idx][None, :]))
             for j, k in np.argwhere(inds):
-                scale_m = np.array((f_a[i], f_b[j], f_c[k]), dtype=int)  # type: ignore
+                scale_m = np.array((f_a[idx], f_b[j], f_c[k]), dtype=int)  # type: ignore
                 if abs(np.linalg.det(scale_m)) < 1e-8:  # type: ignore
                     continue
 
-                aligned_m = np.array((c_a[i], c_b[j], c_c[k]))
+                aligned_m = np.array((c_a[idx], c_b[j], c_c[k]))
 
                 rotation_m = None if skip_rotation_matrix else np.linalg.solve(aligned_m, other_lattice.matrix)
 
@@ -973,7 +973,7 @@ class Lattice(MSONable):
     def _calculate_lll(self, delta: float = 0.75) -> tuple[np.ndarray, np.ndarray]:
         """Performs a Lenstra-Lenstra-Lovasz lattice basis reduction to obtain a
         c-reduced basis. This method returns a basis which is as "good" as
-        possible, with "good" defined by orthongonality of the lattice vectors.
+        possible, with "good" defined by orthogonality of the lattice vectors.
 
         This basis is used for all the periodic boundary condition calculations.
 
@@ -1021,8 +1021,7 @@ class Lattice(MSONable):
                 # Increment k if the Lovasz condition holds.
                 k += 1
             else:
-                # If the Lovasz condition fails,
-                # swap the k-th and (k-1)-th basis vector
+                # If the Lovasz condition fails, swap the k-th and (k-1)-th basis vector
                 v = a[:, k - 1].copy()
                 a[:, k - 1] = a[:, k - 2].copy()
                 a[:, k - 2] = v

--- a/pymatgen/core/surface.py
+++ b/pymatgen/core/surface.py
@@ -450,20 +450,20 @@ class Slab(Structure):
         self.append(specie, coords, coords_are_cartesian=True)
 
     def __str__(self):
+        def to_s(x):
+            return f"{x:0.6f}"
+
         comp = self.composition
         outs = [
             f"Slab Summary ({comp.formula})",
             f"Reduced Formula: {comp.reduced_formula}",
             f"Miller index: {self.miller_index}",
             f"Shift: {self.shift:.4f}, Scale Factor: {self.scale_factor}",
+            "abc   : " + " ".join(to_s(i).rjust(10) for i in self.lattice.abc),
+            "angles: " + " ".join(to_s(i).rjust(10) for i in self.lattice.angles),
+            f"Sites ({len(self)})",
         ]
 
-        def to_s(x):
-            return f"{x:0.6f}"
-
-        outs.append("abc   : " + " ".join(to_s(i).rjust(10) for i in self.lattice.abc))
-        outs.append("angles: " + " ".join(to_s(i).rjust(10) for i in self.lattice.angles))
-        outs.append(f"Sites ({len(self)})")
         for i, site in enumerate(self):
             outs.append(
                 " ".join(
@@ -1031,13 +1031,11 @@ class SlabGenerator:
                             if c_range[1] > 1:
                                 # Takes care of PBC when c coordinate of site
                                 # goes beyond the upper boundary of the cell
-                                c_ranges.append((c_range[0], 1))
-                                c_ranges.append((0, c_range[1] - 1))
+                                c_ranges.extend(((c_range[0], 1), (0, c_range[1] - 1)))
                             elif c_range[0] < 0:
                                 # Takes care of PBC when c coordinate of site
                                 # is below the lower boundary of the unit cell
-                                c_ranges.append((0, c_range[1]))
-                                c_ranges.append((c_range[0] + 1, 1))
+                                c_ranges.extend(((0, c_range[1]), (c_range[0] + 1, 1)))
                             elif c_range[0] != c_range[1]:
                                 c_ranges.append((c_range[0], c_range[1]))
         return c_ranges

--- a/pymatgen/core/trajectory.py
+++ b/pymatgen/core/trajectory.py
@@ -431,8 +431,7 @@ class Trajectory(MSONable):
                 for latt_vec in _lattice:
                     lines.append(f'{" ".join(map(str, latt_vec))}')
 
-                lines.append(" ".join(site_symbols))
-                lines.append(" ".join(map(str, n_atoms)))
+                lines.extend((" ".join(site_symbols), " ".join(map(str, n_atoms))))
 
             lines.append(f"Direct configuration=     {si + 1}")
 

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -2111,22 +2111,17 @@ class BSPlotterProjected(BSPlotter):
             else:
                 n_label.append([label[branch].split("$")[-1], label[branch + 1].split("$")[0]])
 
-        f_distance = []
-        rf_distance = []
-        f_label = []
-        f_label.append(n_label[0][0])
-        f_label.append(n_label[0][1])
-        f_distance.append(0.0)
-        f_distance.append(n_distance[0])
-        rf_distance.append(0.0)
-        rf_distance.append(n_distance[0])
+        f_distance: list[float] = []
+        rf_distance: list[float] = []
+        f_label: list[str] = []
+        f_label.extend((n_label[0][0], n_label[0][1]))
+        f_distance.extend((0.0, n_distance[0]))
+        rf_distance.extend((0.0, n_distance[0]))
         length = n_distance[0]
         for i in range(1, len(n_distance)):
             if n_label[i][0] == n_label[i - 1][1]:
-                f_distance.append(length)
-                f_distance.append(length + n_distance[i])
-                f_label.append(n_label[i][0])
-                f_label.append(n_label[i][1])
+                f_distance.extend((length, length + n_distance[i]))
+                f_label.extend((n_label[i][0], n_label[i][1]))
             else:
                 f_distance.append(length + n_distance[i])
                 f_label[-1] = n_label[i - 1][1] + "$\\mid$" + n_label[i][0]
@@ -2134,10 +2129,9 @@ class BSPlotterProjected(BSPlotter):
             rf_distance.append(length + n_distance[i])
             length += n_distance[i]
 
-        n_ticks = {"distance": f_distance, "label": f_label}
         uniq_d = []
         uniq_l = []
-        temp_ticks = list(zip(n_ticks["distance"], n_ticks["label"]))
+        temp_ticks = list(zip(f_distance, f_label))
         for i, t in enumerate(temp_ticks):
             if i == 0:
                 uniq_d.append(t[0])
@@ -2154,18 +2148,18 @@ class BSPlotterProjected(BSPlotter):
         ax.set_xticks(uniq_d)
         ax.set_xticklabels(uniq_l)
 
-        for i in range(len(n_ticks["label"])):
-            if n_ticks["label"][i] is not None:
+        for i in range(len(f_label)):
+            if f_label[i] is not None:
                 # don't print the same label twice
                 if i != 0:
-                    if n_ticks["label"][i] == n_ticks["label"][i - 1]:
-                        logger.debug(f"already print label... skipping label {n_ticks['label'][i]}")
+                    if f_label[i] == f_label[i - 1]:
+                        logger.debug(f"already print label... skipping label {f_label[i]}")
                     else:
-                        logger.debug(f"Adding a line at {n_ticks['distance'][i]} for label {n_ticks['label'][i]}")
-                        ax.axvline(n_ticks["distance"][i], color="k")
+                        logger.debug(f"Adding a line at {f_distance[i]} for label {f_label[i]}")
+                        ax.axvline(f_distance[i], color="k")
                 else:
-                    logger.debug(f"Adding a line at {n_ticks['distance'][i]} for label {n_ticks['label'][i]}")
-                    ax.axvline(n_ticks["distance"][i], color="k")
+                    logger.debug(f"Adding a line at {f_distance[i]} for label {f_label[i]}")
+                    ax.axvline(f_distance[i], color="k")
 
         shift = []
         br = -1

--- a/pymatgen/ext/matproj.py
+++ b/pymatgen/ext/matproj.py
@@ -144,8 +144,7 @@ class _MPResterBasic:
             params.append("_all_fields=True")
         else:
             fields = ",".join(kwargs["_fields"]) if isinstance(kwargs["_fields"], list) else kwargs["_fields"]
-            params.append(f"_fields={fields}")
-            params.append("_all_fields=False")
+            params.extend((f"_fields={fields}", "_all_fields=False"))
         get = "&".join(params)
         logger.info(f"query={get}")
         return self.request(f"materials/summary?{get}", payload=criteria)

--- a/pymatgen/ext/matproj_legacy.py
+++ b/pymatgen/ext/matproj_legacy.py
@@ -1447,7 +1447,7 @@ class _MPResterLegacy:
 
         if include_work_of_separation and material_id:
             list_of_gbs = self._make_request("/grain_boundaries", payload=payload)
-            for _, gb_dict in enumerate(list_of_gbs):
+            for gb_dict in list_of_gbs:
                 gb_energy = gb_dict["gb_energy"]
                 gb_plane_int = gb_dict["gb_plane"]
                 surface_energy = self.get_surface_data(material_id=material_id, miller_index=gb_plane_int)[

--- a/pymatgen/io/abinit/inputs.py
+++ b/pymatgen/io/abinit/inputs.py
@@ -1260,9 +1260,7 @@ class BasicMultiDataset:
 
             w = 92
             if global_vars:
-                lines.append(w * "#")
-                lines.append("### Global Variables.")
-                lines.append(w * "#")
+                lines.extend((w * "#", "### Global Variables.", w * "#"))
                 for key in global_vars:
                     vname = key
                     lines.append(str(InputVariable(vname, self[0][key])))
@@ -1270,9 +1268,7 @@ class BasicMultiDataset:
             has_same_structures = self.has_same_structures
             if has_same_structures:
                 # Write structure here and disable structure output in input.to_str
-                lines.append(w * "#")
-                lines.append("#" + ("STRUCTURE").center(w - 1))
-                lines.append(w * "#")
+                lines.extend((w * "#", "#" + "STRUCTURE".center(w - 1), w * "#"))
                 for key, value in aobj.structure_to_abivars(self[0].structure).items():
                     vname = key
                     lines.append(str(InputVariable(vname, value)))

--- a/pymatgen/io/atat.py
+++ b/pymatgen/io/atat.py
@@ -44,9 +44,7 @@ class Mcsqs:
         output = [f"{vec[0]:6f} {vec[1]:6f} {vec[2]:6f}" for vec in mat]
 
         # define coord system, use Cartesian
-        output.append("1.0 0.0 0.0")
-        output.append("0.0 1.0 0.0")
-        output.append("0.0 0.0 1.0")
+        output.extend(("1.0 0.0 0.0", "0.0 1.0 0.0", "0.0 0.0 1.0"))
 
         # add species
         for site in self.structure:

--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -1078,7 +1078,7 @@ class CifParser:
                 all_labels.extend(new_labels)
 
             # rescale occupancies if necessary
-            all_species_noedit = all_species[:]  # save copy before scaling in case of check_occu=False, used below
+            all_species_noedit = all_species.copy()  # save copy before scaling in case of check_occu=False, used below
             for idx, species in enumerate(all_species):
                 total_occu = sum(species.values())
                 if 1 < total_occu <= self._occupancy_tolerance:

--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -354,9 +354,9 @@ class CifParser:
 
         self.feature_flags["magcif_incommensurate"] = is_magcif_incommensurate()
 
-        for k in self._cif.data:
+        for key in self._cif.data:
             # pass individual CifBlocks to _sanitize_data
-            self._cif.data[k] = self._sanitize_data(self._cif.data[k])
+            self._cif.data[key] = self._sanitize_data(self._cif.data[key])
 
     @classmethod
     @np.deprecate(message="Use from_str instead")
@@ -557,7 +557,8 @@ class CifParser:
                             fracs_to_change[(label, idx)] = str(comparison_frac)
         if fracs_to_change:
             self.warnings.append(
-                "Some fractional coordinates rounded to ideal values to avoid issues with finite precision."
+                f"{len(fracs_to_change)} fractional coordinates rounded to ideal values to avoid issues with "
+                "finite precision."
             )
             for (label, idx), val in fracs_to_change.items():
                 data.data[label][idx] = val

--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -487,11 +487,8 @@ class CifParser:
                 data.data["_atom_site_fract_x"] += new_fract_x
                 data.data["_atom_site_fract_y"] += new_fract_y
                 data.data["_atom_site_fract_z"] += new_fract_z
-        """
-        This fixes inconsistencies in naming of several magCIF tags
-        as a result of magCIF being in widespread use prior to
-        specification being finalized (on advice of Branton Campbell).
-        """
+        # This fixes inconsistencies in naming of several magCIF tags as a result of magCIF
+        # being in widespread use prior to specification being finalized (on advice of Branton Campbell).
         if self.feature_flags["magcif"]:
             # CIF-1 style has all underscores, interim standard
             # had period before magn instead of before the final

--- a/pymatgen/io/cp2k/outputs.py
+++ b/pymatgen/io/cp2k/outputs.py
@@ -314,8 +314,8 @@ class Cp2kOutput:
                     self.structures.append(
                         Structure(
                             lattice=latt,
-                            coords=[s.coords for s in mol.sites],
-                            species=[s.specie for s in mol.sites],
+                            coords=[s.coords for s in mol],
+                            species=[s.specie for s in mol],
                             coords_are_cartesian=True,
                             site_properties={"ghost": gs} if gs else {},
                             charge=self.charge,

--- a/pymatgen/io/feff/inputs.py
+++ b/pymatgen/io/feff/inputs.py
@@ -639,8 +639,7 @@ class Tags(dict):
                     beam_energy = self._stringify_val(self[k]["BEAM_ENERGY"])
                     beam_energy_list = beam_energy.split()
                     if int(beam_energy_list[1]) == 0:  # aver=0, specific beam direction
-                        lines.append([beam_energy])
-                        lines.append([self._stringify_val(self[k]["BEAM_DIRECTION"])])
+                        lines.extend(([beam_energy], [self._stringify_val(self[k]["BEAM_DIRECTION"])]))
                     else:
                         # no cross terms for orientation averaged spectrum
                         beam_energy_list[2] = str(0)
@@ -991,8 +990,7 @@ class Paths(MSONable):
         # max possible, to avoid name collision count down from max value.
         path_index = 9999
         for i, legs in enumerate(self.paths):
-            lines.append(f"{path_index} {len(legs)} {self.degeneracies[i]}")
-            lines.append("x y z ipot label")
+            lines.extend((f"{path_index} {len(legs)} {self.degeneracies[i]}", "x y z ipot label"))
             for leg in legs:
                 coords = self.atoms.cluster[leg].coords.tolist()
 

--- a/pymatgen/io/fiesta.py
+++ b/pymatgen/io/fiesta.py
@@ -263,7 +263,7 @@ class BasisSetReader:
 
     def set_n_nlmo(self):
         """the number of nlm orbitals for the basis set"""
-        nnlmo = 0
+        n_nlm_orbs = 0
 
         data_tmp = self.data
         data_tmp.pop("lmax")
@@ -272,23 +272,21 @@ class BasisSetReader:
 
         for l_zeta_ng in data_tmp:
             n_l = l_zeta_ng.split("_")[0]
-            nnlmo = nnlmo + (2 * int(n_l) + 1)
+            n_nlm_orbs = n_nlm_orbs + (2 * int(n_l) + 1)
 
-        return str(nnlmo)
+        return str(n_nlm_orbs)
 
     def infos_on_basis_set(self):
-        """Infos on the basis set as in Fiesta log."""
-        o = []
-        o.append("=========================================")
-        o.append("Reading basis set:")
-        o.append("")
-        o.append(f" Basis set for {self.filename} atom ")
-        o.append(f" Maximum angular momentum = {self.data['lmax']}")
-        o.append(f" Number of atomics orbitals = {self.data['n_nlo']}")
-        o.append(f" Number of nlm orbitals = {self.data['n_nlmo']}")
-        o.append("=========================================")
-
-        return str(0)
+        return (
+            f"=========================================\n"
+            f"Reading basis set:\n"
+            f"\n"
+            f"Basis set for {self.filename} atom \n"
+            f"Maximum angular momentum = {self.data['lmax']}\n"
+            f"Number of atomics orbitals = {self.data['n_nlo']}\n"
+            f"Number of nlm orbitals = {self.data['n_nlmo']}\n"
+            f"========================================="
+        )
 
 
 class FiestaInput(MSONable):

--- a/pymatgen/io/gaussian.py
+++ b/pymatgen/io/gaussian.py
@@ -422,10 +422,9 @@ class GaussianInput:
             # don't use the slash if either or both are set as empty
             func_bset_str = f" {func_str}{bset_str}".rstrip()
 
-        output.append(f"{self.dieze_tag}{func_bset_str} {para_dict_to_string(self.route_parameters)}")
-        output.append("")
-        output.append(self.title)
-        output.append("")
+        output.extend(
+            (f"{self.dieze_tag}{func_bset_str} {para_dict_to_string(self.route_parameters)}", "", self.title, "")
+        )
 
         charge_str = "" if self.charge is None else f"{self.charge:.0f}"
         multip_str = "" if self.spin_multiplicity is None else f" {self.spin_multiplicity:.0f}"
@@ -441,8 +440,7 @@ class GaussianInput:
         output.append("")
         if self.gen_basis is not None:
             output.append(f"{self.gen_basis}\n")
-        output.append(para_dict_to_string(self.input_parameters, "\n"))
-        output.append("\n")
+        output.extend((para_dict_to_string(self.input_parameters, "\n"), "\n"))
         return "\n".join(output)
 
     def write_file(self, filename, cart_coords=False):

--- a/pymatgen/io/lobster/lobsterenv.py
+++ b/pymatgen/io/lobster/lobsterenv.py
@@ -1281,7 +1281,7 @@ class LobsterLightStructureEnvironments(LightStructureEnvironments):
         all_nbs_sites_indices = []
         neighbors_sets = []
         counter = 0
-        for isite, _site in enumerate(structure):
+        for isite in range(len(structure)):
             # all_nbs_sites_here=[]
             all_nbs_sites_indices_here = []
             # Coordination environment

--- a/pymatgen/io/nwchem.py
+++ b/pymatgen/io/nwchem.py
@@ -364,21 +364,20 @@ class NwInput(MSONable):
         return self._mol
 
     def __str__(self):
-        o = []
+        out = []
         if self.memory_options:
-            o.append("memory " + self.memory_options)
+            out.append("memory " + self.memory_options)
         for d in self.directives:
-            o.append(f"{d[0]} {d[1]}")
-        o.append("geometry " + " ".join(self.geometry_options))
+            out.append(f"{d[0]} {d[1]}")
+        out.append("geometry " + " ".join(self.geometry_options))
         if self.symmetry_options:
-            o.append(" symmetry " + " ".join(self.symmetry_options))
+            out.append(" symmetry " + " ".join(self.symmetry_options))
         for site in self._mol:
-            o.append(f" {site.specie.symbol} {site.x} {site.y} {site.z}")
-        o.append("end\n")
+            out.append(f" {site.specie.symbol} {site.x} {site.y} {site.z}")
+        out.append("end\n")
         for t in self.tasks:
-            o.append(str(t))
-            o.append("")
-        return "\n".join(o)
+            out.extend((str(t), ""))
+        return "\n".join(out)
 
     def write_file(self, filename):
         """

--- a/pymatgen/io/qchem/inputs.py
+++ b/pymatgen/io/qchem/inputs.py
@@ -403,7 +403,7 @@ class QCInput(InputFile):
                 raise ValueError('The only acceptable text value for molecule is "read"')
         elif isinstance(molecule, Molecule):
             mol_list.append(f" {int(molecule.charge)} {molecule.spin_multiplicity}")
-            for site in molecule.sites:
+            for site in molecule:
                 mol_list.append(f" {site.species_string}     {site.x: .10f}     {site.y: .10f}     {site.z: .10f}")
         else:
             overall_charge = sum(x.charge for x in molecule)
@@ -414,7 +414,7 @@ class QCInput(InputFile):
 
             for fragment in molecule:
                 mol_list.extend(("--", f" {int(fragment.charge)} {fragment.spin_multiplicity}"))
-                for site in fragment.sites:
+                for site in fragment:
                     mol_list.append(f" {site.species_string}     {site.x: .10f}     {site.y: .10f}     {site.z: .10f}")
 
         mol_list.append("$end")

--- a/pymatgen/io/qchem/inputs.py
+++ b/pymatgen/io/qchem/inputs.py
@@ -214,58 +214,42 @@ class QCInput(InputFile):
     def __str__(self):
         combined_list = []
         # molecule section
-        combined_list.append(self.molecule_template(self.molecule))
-        combined_list.append("")
-        # rem section
-        combined_list.append(self.rem_template(self.rem))
-        combined_list.append("")
+        combined_list.extend((self.molecule_template(self.molecule), "", self.rem_template(self.rem), ""))
         # opt section
         if self.opt:
-            combined_list.append(self.opt_template(self.opt))
-            combined_list.append("")
+            combined_list.extend((self.opt_template(self.opt), ""))
         # pcm section
         if self.pcm:
-            combined_list.append(self.pcm_template(self.pcm))
-            combined_list.append("")
+            combined_list.extend((self.pcm_template(self.pcm), ""))
         # solvent section
         if self.solvent:
-            combined_list.append(self.solvent_template(self.solvent))
-            combined_list.append("")
+            combined_list.extend((self.solvent_template(self.solvent), ""))
         if self.smx:
-            combined_list.append(self.smx_template(self.smx))
-            combined_list.append("")
+            combined_list.extend((self.smx_template(self.smx), ""))
         # section for pes_scan
         if self.scan:
-            combined_list.append(self.scan_template(self.scan))
-            combined_list.append("")
+            combined_list.extend((self.scan_template(self.scan), ""))
         # section for van_der_waals radii
         if self.van_der_waals:
-            combined_list.append(self.van_der_waals_template(self.van_der_waals, self.vdw_mode))
-            combined_list.append("")
+            combined_list.extend((self.van_der_waals_template(self.van_der_waals, self.vdw_mode), ""))
         # plots section
         if self.plots:
-            combined_list.append(self.plots_template(self.plots))
-            combined_list.append("")
+            combined_list.extend((self.plots_template(self.plots), ""))
         # nbo section
         if self.nbo is not None:
-            combined_list.append(self.nbo_template(self.nbo))
-            combined_list.append("")
+            combined_list.extend((self.nbo_template(self.nbo), ""))
         # geom_opt section
         if self.geom_opt is not None:
-            combined_list.append(self.geom_opt_template(self.geom_opt))
-            combined_list.append("")
+            combined_list.extend((self.geom_opt_template(self.geom_opt), ""))
         # cdft section
         if self.cdft is not None:
-            combined_list.append(self.cdft_template(self.cdft))
-            combined_list.append("")
+            combined_list.extend((self.cdft_template(self.cdft), ""))
         # almo section
         if self.almo_coupling is not None:
-            combined_list.append(self.almo_template(self.almo_coupling))
-            combined_list.append("")
+            combined_list.extend((self.almo_template(self.almo_coupling), ""))
         # svp section
         if self.svp:
-            combined_list.append(self.svp_template(self.svp))
-            combined_list.append("")
+            combined_list.extend((self.svp_template(self.svp), ""))
         # pcm_nonels section
         if self.pcm_nonels:
             combined_list.append(self.pcm_nonels_template(self.pcm_nonels))
@@ -429,8 +413,7 @@ class QCInput(InputFile):
             mol_list.append(f" {int(overall_charge)} {int(overall_spin)}")
 
             for fragment in molecule:
-                mol_list.append("--")
-                mol_list.append(f" {int(fragment.charge)} {fragment.spin_multiplicity}")
+                mol_list.extend(("--", f" {int(fragment.charge)} {fragment.spin_multiplicity}"))
                 for site in fragment.sites:
                     mol_list.append(f" {site.species_string}     {site.x: .10f}     {site.y: .10f}     {site.z: .10f}")
 
@@ -472,8 +455,7 @@ class QCInput(InputFile):
             # loops over all values within the section
             for i in value:
                 opt_list.append(f"   {i}")
-            opt_list.append(f"END{key}")
-            opt_list.append("")
+            opt_list.extend((f"END{key}", ""))
         # this deletes the empty space after the last section
         del opt_list[-1]
         opt_list.append("$end")
@@ -639,8 +621,7 @@ class QCInput(InputFile):
         svp_list = []
         svp_list.append("$svp")
         param_list = [f"{_key}={value}" for _key, value in svp.items()]
-        svp_list.append(", ".join(param_list))
-        svp_list.append("$end")
+        svp_list.extend((", ".join(param_list), "$end"))
         return "\n".join(svp_list)
 
     @staticmethod

--- a/pymatgen/io/qchem/outputs.py
+++ b/pymatgen/io/qchem/outputs.py
@@ -968,7 +968,7 @@ class QCOutput(MSONable):
                     total[ii] = float(val[0])
                 self.data["dipoles"]["total"] = total
                 dipole = np.zeros(shape=(len(temp_dipole_total), 3))
-                for ii, _entry in enumerate(temp_dipole):
+                for ii in range(len(temp_dipole)):
                     for jj, _val in enumerate(temp_dipole[ii]):
                         dipole[ii][jj] = temp_dipole[ii][jj]
                 self.data["dipoles"]["dipole"] = dipole
@@ -1040,7 +1040,7 @@ class QCOutput(MSONable):
                         RESP_total[ii] = float(val[0])
                     self.data["dipoles"]["RESP_total"] = RESP_total
                     RESP_dipole = np.zeros(shape=(len(temp_RESP_dipole_total), 3))
-                    for ii, _entry in enumerate(temp_RESP_dipole):
+                    for ii in range(len(temp_RESP_dipole)):
                         for jj, _val in enumerate(temp_RESP_dipole[ii]):
                             RESP_dipole[ii][jj] = temp_RESP_dipole[ii][jj]
                     self.data["dipoles"]["RESP_dipole"] = RESP_dipole
@@ -2396,7 +2396,7 @@ def parse_hybridization_character(lines: list[str]) -> list[pd.DataFrame]:
     orbitals = ["s", "p", "d", "f"]
 
     no_failures = True
-    lp_and_bd_and_tc_dfs = []
+    lp_and_bd_and_tc_dfs: list[pd.DataFrame] = []
 
     while no_failures:
         # NBO Analysis
@@ -2607,9 +2607,9 @@ def parse_hybridization_character(lines: list[str]) -> list[pd.DataFrame]:
                     tc_data.append(TCentry)
 
             # Store values in a dataframe
-            lp_and_bd_and_tc_dfs.append(pd.DataFrame(data=lp_data))
-            lp_and_bd_and_tc_dfs.append(pd.DataFrame(data=bd_data))
-            lp_and_bd_and_tc_dfs.append(pd.DataFrame(data=tc_data))
+            lp_and_bd_and_tc_dfs.extend(
+                (pd.DataFrame(data=lp_data), pd.DataFrame(data=bd_data), pd.DataFrame(data=tc_data))
+            )
 
     return lp_and_bd_and_tc_dfs
 

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -1472,8 +1472,7 @@ class Kpoints(MSONable):
 
         # Print tetrahedron parameters if the number of tetrahedrons > 0
         if style not in "lagm" and self.tet_number > 0:
-            lines.append("Tetrahedron")
-            lines.append(f"{self.tet_number} {self.tet_weight:f}")
+            lines.extend(("Tetrahedron", f"{self.tet_number} {self.tet_weight:f}"))
             for sym_weight, vertices in self.tet_connections:
                 a, b, c, d = vertices
                 lines.append(f"{sym_weight} {a} {b} {c} {d}")
@@ -2481,9 +2480,7 @@ class VaspInput(dict, MSONable):
     def __str__(self):
         output = []
         for k, v in self.items():
-            output.append(k)
-            output.append(str(v))
-            output.append("")
+            output.extend((k, str(v), ""))
         return "\n".join(output)
 
     def as_dict(self):

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -792,16 +792,7 @@ class Incar(dict, MSONable):
             key: INCAR parameter key
             val: Actual value of INCAR parameter.
         """
-        list_keys = (
-            "LDAUU",
-            "LDAUL",
-            "LDAUJ",
-            "MAGMOM",
-            "DIPOL",
-            "LANGEVIN_GAMMA",
-            "QUAD_EFG",
-            "EINT",
-        )
+        list_keys = ("LDAUU", "LDAUL", "LDAUJ", "MAGMOM", "DIPOL", "LANGEVIN_GAMMA", "QUAD_EFG", "EINT")
         bool_keys = (
             "LDAU",
             "LWAVE",
@@ -814,18 +805,7 @@ class Incar(dict, MSONable):
             "LSORBIT",
             "LNONCOLLINEAR",
         )
-        float_keys = (
-            "EDIFF",
-            "SIGMA",
-            "TIME",
-            "ENCUTFOCK",
-            "HFSCREEN",
-            "POTIM",
-            "EDIFFG",
-            "AGGAC",
-            "PARAM1",
-            "PARAM2",
-        )
+        float_keys = ("EDIFF", "SIGMA", "TIME", "ENCUTFOCK", "HFSCREEN", "POTIM", "EDIFFG", "AGGAC", "PARAM1", "PARAM2")
         int_keys = (
             "NSW",
             "NBANDS",
@@ -848,10 +828,10 @@ class Incar(dict, MSONable):
             "IVDW",
         )
 
-        def smart_int_or_float(numstr):
-            if numstr.find(".") != -1 or numstr.lower().find("e") != -1:
-                return float(numstr)
-            return int(numstr)
+        def smart_int_or_float(num_str):
+            if num_str.find(".") != -1 or num_str.lower().find("e") != -1:
+                return float(num_str)
+            return int(num_str)
 
         try:
             if key in list_keys:

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -2996,8 +2996,7 @@ class Outcar:
                 results.zvals = map(float, re.findall(r"-?\d+\.\d*", zvals))
 
             search = []
-            search.append([r"(?<=VRHFIN =)(.*)(?=:)", None, atom_symbols])
-            search.append([r"^\s+ZVAL.*=(.*)", None, zvals])
+            search.extend((["(?<=VRHFIN =)(.*)(?=:)", None, atom_symbols], ["^\\s+ZVAL.*=(.*)", None, zvals]))
 
             micro_pyawk(self.filename, search, self)
 
@@ -4010,8 +4009,7 @@ class Xdatcar:
         if np.linalg.det(latt.matrix) < 0:
             latt = Lattice(-latt.matrix)
         lines = [self.comment, "1.0", str(latt)]
-        lines.append(" ".join(self.site_symbols))
-        lines.append(" ".join(str(x) for x in self.natoms))
+        lines.extend((" ".join(self.site_symbols), " ".join(str(x) for x in self.natoms)))
         format_str = f"{{:.{significant_figures}f}}"
         ionicstep_cnt = 1
         output_cnt = 1

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -2525,7 +2525,7 @@ class MITNEBSet(DictSet):
         if write_path_cif:
             sites = set()
             lat = self.structures[0].lattice
-            for site in chain(*(s.sites for s in self.structures)):
+            for site in chain(*(struct for struct in self.structures)):
                 sites.add(PeriodicSite(site.species, site.frac_coords, lat))
             nebpath = Structure.from_sites(sorted(sites))
             nebpath.to(filename=str(output_dir / "path.cif"))

--- a/pymatgen/io/zeopp.py
+++ b/pymatgen/io/zeopp.py
@@ -262,7 +262,7 @@ def get_voronoi_nodes(structure, rad_dict=None, probe_rad=0.1):
     species = ["X"] * len(voro_node_mol)
     coords = []
     prop = []
-    for site in voro_node_mol.sites:
+    for site in voro_node_mol:
         coords.append(list(site.coords))
         prop.append(site.properties["voronoi_radius"])
 
@@ -349,7 +349,7 @@ def get_high_accuracy_voronoi_nodes(structure, rad_dict, probe_rad=0.1):
     species = ["X"] * len(voro_node_mol)
     coords = []
     prop = []
-    for site in voro_node_mol.sites:
+    for site in voro_node_mol:
         coords.append(list(site.coords))
         prop.append(site.properties["voronoi_radius"])
 

--- a/pymatgen/symmetry/analyzer.py
+++ b/pymatgen/symmetry/analyzer.py
@@ -60,7 +60,7 @@ class SpacegroupAnalyzer:
     Uses spglib to perform various symmetry finding operations.
     """
 
-    def __init__(self, structure: Structure, symprec: float | None = 0.01, angle_tolerance=5.0):
+    def __init__(self, structure: Structure, symprec: float | None = 0.01, angle_tolerance: float = 5.0) -> None:
         """
         Args:
             structure (Structure/IStructure): Structure to find symmetry
@@ -476,7 +476,7 @@ class SpacegroupAnalyzer:
 
     @cite_conventional_cell_algo
     def get_primitive_standard_structure(self, international_monoclinic=True, keep_site_properties=False):
-        """Gives a structure with a primitive cell according to certain standards the
+        """Gives a structure with a primitive cell according to certain standards. The
         standards are defined in Setyawan, W., & Curtarolo, S. (2010). High-throughput
         electronic band structure calculations: Challenges and tools. Computational
         Materials Science, 49(2), 299-312. doi:10.1016/j.commatsci.2010.05.010.

--- a/pymatgen/symmetry/bandstructure.py
+++ b/pymatgen/symmetry/bandstructure.py
@@ -352,8 +352,7 @@ class HighSymmKpath(KPathBase):
                         "end_index": next_branch["end_index"],
                         "name": f"{branch['name'].split('-')[0]}-{next_branch['name'].split('-')[1]}",
                     }
-                    processed.append(branch["name"])
-                    processed.append(next_branch["name"])
+                    processed.extend((branch["name"], next_branch["name"]))
 
                     new_branches.append(combined)
 

--- a/pymatgen/symmetry/groups.py
+++ b/pymatgen/symmetry/groups.py
@@ -311,8 +311,7 @@ class SpaceGroup(SymmetryGroup):
 
         for spg in SpaceGroup.SYMM_OPS:
             if int_number == spg["number"]:
-                symbols.append(spg["hermann_mauguin"])
-                symbols.append(spg["universal_h_m"])
+                symbols.extend((spg["hermann_mauguin"], spg["universal_h_m"]))
         return set(symbols)
 
     @property

--- a/pymatgen/symmetry/structure.py
+++ b/pymatgen/symmetry/structure.py
@@ -95,18 +95,18 @@ class SymmetrizedStructure(Structure):
         return str(self)
 
     def __str__(self) -> str:
+        def to_str(x):
+            return f"{x:>10.6f}"
+
         outs = [
             "SymmetrizedStructure",
             f"Full Formula ({self.composition.formula})",
             f"Reduced Formula: {self.composition.reduced_formula}",
             f"Spacegroup: {self.spacegroup.int_symbol} ({self.spacegroup.int_number})",
+            f"abc   : {' '.join(to_str(val) for val in self.lattice.abc)}",
+            f"angles: {' '.join(to_str(val) for val in self.lattice.angles)}",
         ]
 
-        def to_str(x):
-            return f"{x:>10.6f}"
-
-        outs.append(f"abc   : {' '.join(to_str(val) for val in self.lattice.abc)}")
-        outs.append(f"angles: {' '.join(to_str(val) for val in self.lattice.angles)}")
         if self._charge:
             outs.append(f"Overall Charge: {self._charge:+}")
         outs.append(f"Sites ({len(self)})")

--- a/pymatgen/transformations/advanced_transformations.py
+++ b/pymatgen/transformations/advanced_transformations.py
@@ -322,7 +322,7 @@ class EnumerateStructureTransformation(AbstractTransformation):
             n_jobs (int): Number of parallel jobs used to compute energy criteria. This is used only when the Ewald
                 or m3gnet or callable sort_criteria is used. Default is -1, which uses all available CPUs.
         """
-        self.sym_prec = symm_prec
+        self.symm_prec = symm_prec
         self.min_cell_size = min_cell_size
         self.max_cell_size = max_cell_size
         self.refine_structure = refine_structure
@@ -362,7 +362,7 @@ class EnumerateStructureTransformation(AbstractTransformation):
             num_to_return = 1
 
         if self.refine_structure:
-            finder = SpacegroupAnalyzer(structure, self.sym_prec)
+            finder = SpacegroupAnalyzer(structure, self.symm_prec)
             structure = finder.get_refined_structure()
 
         contains_oxidation_state = all(hasattr(sp, "oxi_state") and sp.oxi_state != 0 for sp in structure.elements)
@@ -391,7 +391,7 @@ class EnumerateStructureTransformation(AbstractTransformation):
                 structure,
                 min_cell_size=self.min_cell_size,
                 max_cell_size=max_cell_size,
-                symm_prec=self.sym_prec,
+                symm_prec=self.symm_prec,
                 refine_structure=False,
                 enum_precision_parameter=self.enum_precision_parameter,
                 check_ordered_symmetry=self.check_ordered_symmetry,
@@ -881,7 +881,7 @@ class MagOrderingTransformation(AbstractTransformation):
             alls = self._remove_dummy_species(alls)
             alls = self._add_spin_magnitudes(alls)
         else:
-            for idx, _ in enumerate(alls):
+            for idx in range(len(alls)):
                 alls[idx]["structure"] = self._remove_dummy_species(alls[idx]["structure"])
                 alls[idx]["structure"] = self._add_spin_magnitudes(alls[idx]["structure"])
 

--- a/pymatgen/transformations/advanced_transformations.py
+++ b/pymatgen/transformations/advanced_transformations.py
@@ -322,7 +322,7 @@ class EnumerateStructureTransformation(AbstractTransformation):
             n_jobs (int): Number of parallel jobs used to compute energy criteria. This is used only when the Ewald
                 or m3gnet or callable sort_criteria is used. Default is -1, which uses all available CPUs.
         """
-        self.symm_prec = symm_prec
+        self.sym_prec = symm_prec
         self.min_cell_size = min_cell_size
         self.max_cell_size = max_cell_size
         self.refine_structure = refine_structure
@@ -362,7 +362,7 @@ class EnumerateStructureTransformation(AbstractTransformation):
             num_to_return = 1
 
         if self.refine_structure:
-            finder = SpacegroupAnalyzer(structure, self.symm_prec)
+            finder = SpacegroupAnalyzer(structure, self.sym_prec)
             structure = finder.get_refined_structure()
 
         contains_oxidation_state = all(hasattr(sp, "oxi_state") and sp.oxi_state != 0 for sp in structure.elements)
@@ -391,7 +391,7 @@ class EnumerateStructureTransformation(AbstractTransformation):
                 structure,
                 min_cell_size=self.min_cell_size,
                 max_cell_size=max_cell_size,
-                symm_prec=self.symm_prec,
+                symm_prec=self.sym_prec,
                 refine_structure=False,
                 enum_precision_parameter=self.enum_precision_parameter,
                 check_ordered_symmetry=self.check_ordered_symmetry,

--- a/tests/alchemy/test_materials.py
+++ b/tests/alchemy/test_materials.py
@@ -30,9 +30,7 @@ class TestTransformedStructure(PymatgenTest):
         self.trans.append_transformation(trafo)
         assert self.trans.final_structure.composition.reduced_formula == "NaMnPO4"
         assert len(self.trans.structures) == 3
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0.75, 0.5, 0.75])
+        coords = [[0, 0, 0], [0.75, 0.5, 0.75]]
         lattice = [
             [3.8401979337, 0, 0],
             [1.9200989668, 3.3257101909, 0],

--- a/tests/analysis/test_local_env.py
+++ b/tests/analysis/test_local_env.py
@@ -1408,16 +1408,16 @@ class TestMetalEdgeExtender(PymatgenTest):
 
         # potassium + 7 H2O. 4 at ~2.5 Ang and 3 more within 4.25 Ang
         uncharged_K_cluster = Molecule.from_file(f"{test_dir}/water_cluster_K.xyz")
-        K_sites = [s.coords for s in uncharged_K_cluster.sites]
-        K_species = [s.species for s in uncharged_K_cluster.sites]
+        K_sites = [s.coords for s in uncharged_K_cluster]
+        K_species = [s.species for s in uncharged_K_cluster]
         charged_K_cluster = Molecule(K_species, K_sites, charge=1)
         self.water_cluster_K = MoleculeGraph.with_empty_graph(charged_K_cluster)
         assert len(self.water_cluster_K.graph.edges) == 0
 
         # Mg + 6 H2O at 1.94 Ang from Mg
         uncharged_Mg_cluster = Molecule.from_file(f"{test_dir}/water_cluster_Mg.xyz")
-        Mg_sites = [s.coords for s in uncharged_Mg_cluster.sites]
-        Mg_species = [s.species for s in uncharged_Mg_cluster.sites]
+        Mg_sites = [s.coords for s in uncharged_Mg_cluster]
+        Mg_species = [s.species for s in uncharged_Mg_cluster]
         charged_Mg_cluster = Molecule(Mg_species, Mg_sites, charge=2)
         self.water_cluster_Mg = MoleculeGraph.with_empty_graph(charged_Mg_cluster)
 

--- a/tests/analysis/test_local_env.py
+++ b/tests/analysis/test_local_env.py
@@ -1231,7 +1231,7 @@ class TestCrystalNN(PymatgenTest):
         # fmt: on
         s = self.lifepo4.copy()
         s.remove_oxidation_states()
-        for idx, _ in enumerate(s):
+        for idx in range(len(s)):
             cn_array.append(cnn.get_cn(s, idx, use_weights=True))
 
         assert_allclose(expected_array, cn_array, 2)

--- a/tests/analysis/test_molecule_matcher.py
+++ b/tests/analysis/test_molecule_matcher.py
@@ -55,7 +55,7 @@ def perturb(mol, scale, seed):
     rng = np.random.default_rng(seed=seed)
 
     dV = rng.normal(scale=scale, size=(len(mol), 3))
-    for site, dv in zip(mol.sites, dV):
+    for site, dv in zip(mol, dV):
         site.coords += dv
 
 

--- a/tests/analysis/test_piezo_sensitivity.py
+++ b/tests/analysis/test_piezo_sensitivity.py
@@ -35,7 +35,7 @@ test_dir = f"{TEST_FILES_DIR}/piezo_sensitivity"
 
 class TestPiezoSensitivity(PymatgenTest):
     def setUp(self):
-        self.piezo_struc = self.get_structure("Pb2TiZrO6")
+        self.piezo_struct = self.get_structure("Pb2TiZrO6")
         self.IST = np.load(f"{test_dir}/pztist.npy", allow_pickle=True)
         self.BEC = np.load(f"{test_dir}/pztborn.npy", allow_pickle=True)
         self.FCM = np.load(f"{test_dir}/pztfcm.npy", allow_pickle=True)
@@ -67,19 +67,19 @@ class TestPiezoSensitivity(PymatgenTest):
         )
 
     def test_born_effective_charge_tensor(self):
-        bec = BornEffectiveCharge(self.piezo_struc, self.BEC, self.pointops)
+        bec = BornEffectiveCharge(self.piezo_struct, self.BEC, self.pointops)
         assert_allclose(self.BEC, bec.bec)
 
     def test_internal_strain_tensor(self):
-        ist = InternalStrainTensor(self.piezo_struc, self.IST, self.pointops)
+        ist = InternalStrainTensor(self.piezo_struct, self.IST, self.pointops)
         assert_allclose(ist.ist, self.IST)
 
     def test_force_constant_matrix(self):
-        fcmt = ForceConstantMatrix(self.piezo_struc, self.FCM, self.pointops, self.sharedops)
+        fcmt = ForceConstantMatrix(self.piezo_struct, self.FCM, self.pointops, self.sharedops)
         assert_allclose(fcmt.fcm, self.FCM)
 
     def test_get_bec_operations(self):
-        bec = BornEffectiveCharge(self.piezo_struc, self.BEC, self.pointops)
+        bec = BornEffectiveCharge(self.piezo_struct, self.BEC, self.pointops)
         # update test file
         # with open(f"{test_dir}/becops.pkl", "wb") as file:
         #     pickle.dump(bec.get_BEC_operations(), file)
@@ -87,7 +87,7 @@ class TestPiezoSensitivity(PymatgenTest):
         assert np.all(self.BEC_operations == bec.BEC_operations)
 
     def test_get_rand_bec(self):
-        bec = BornEffectiveCharge(self.piezo_struc, self.BEC, self.pointops)
+        bec = BornEffectiveCharge(self.piezo_struct, self.BEC, self.pointops)
         bec.get_BEC_operations()
         rand_BEC = bec.get_rand_BEC()
         for i in range(len(self.BEC_operations)):
@@ -99,7 +99,7 @@ class TestPiezoSensitivity(PymatgenTest):
                 )
 
     def test_get_rand_ist(self):
-        ist = InternalStrainTensor(self.piezo_struc, self.IST, self.pointops)
+        ist = InternalStrainTensor(self.piezo_struct, self.IST, self.pointops)
         ist.get_IST_operations()
         rand_IST = ist.get_rand_IST()
         for i in range(len(self.IST_operations)):
@@ -111,7 +111,7 @@ class TestPiezoSensitivity(PymatgenTest):
                 )
 
     def test_get_fcm_operations(self):
-        fcm = ForceConstantMatrix(self.piezo_struc, self.FCM, self.pointops, self.sharedops)
+        fcm = ForceConstantMatrix(self.piezo_struct, self.FCM, self.pointops, self.sharedops)
         # update test file
         # with open(f"{test_dir}/fcmops.pkl", "wb") as file:
         #     pickle.dump(fcm.get_FCM_operations(), file)
@@ -119,7 +119,7 @@ class TestPiezoSensitivity(PymatgenTest):
         assert np.all(fcm.FCM_operations == self.FCM_operations)
 
     def test_get_unstable_fcm(self):
-        fcm = ForceConstantMatrix(self.piezo_struc, self.FCM, self.pointops, self.sharedops)
+        fcm = ForceConstantMatrix(self.piezo_struct, self.FCM, self.pointops, self.sharedops)
         fcm.get_FCM_operations()
         rand_FCM = fcm.get_unstable_FCM()
         rand_FCM = np.reshape(rand_FCM, (10, 3, 10, 3)).swapaxes(1, 2)
@@ -134,7 +134,7 @@ class TestPiezoSensitivity(PymatgenTest):
                 )
 
     def test_get_fcm_symmetry(self):
-        fcm = ForceConstantMatrix(self.piezo_struc, self.FCM, self.pointops, self.sharedops)
+        fcm = ForceConstantMatrix(self.piezo_struct, self.FCM, self.pointops, self.sharedops)
         fcm.get_FCM_operations()
 
         fcm = fcm.get_symmetrized_FCM(np.random.rand(30, 30))
@@ -150,7 +150,7 @@ class TestPiezoSensitivity(PymatgenTest):
                 )
 
     def test_get_asum_fcm(self):
-        fcm = ForceConstantMatrix(self.piezo_struc, self.FCM, self.pointops, self.sharedops)
+        fcm = ForceConstantMatrix(self.piezo_struct, self.FCM, self.pointops, self.sharedops)
         fcm.get_FCM_operations()
         rand_FCM = fcm.get_unstable_FCM()
         rand_FCM = fcm.get_asum_FCM(rand_FCM)
@@ -176,7 +176,7 @@ class TestPiezoSensitivity(PymatgenTest):
             assert_allclose(asum2, np.zeros([3, 3]), atol=1e-5)
 
     def test_get_stable_fcm(self):
-        fcm = ForceConstantMatrix(self.piezo_struc, self.FCM, self.pointops, self.sharedops)
+        fcm = ForceConstantMatrix(self.piezo_struct, self.FCM, self.pointops, self.sharedops)
         fcm.get_FCM_operations()
         rand_FCM = fcm.get_unstable_FCM()
         rand_FCM1 = fcm.get_stable_FCM(rand_FCM)
@@ -209,18 +209,18 @@ class TestPiezoSensitivity(PymatgenTest):
 
     def test_rand_fcm(self):
         pytest.importorskip("phonopy")
-        fcm = ForceConstantMatrix(self.piezo_struc, self.FCM, self.pointops, self.sharedops)
+        fcm = ForceConstantMatrix(self.piezo_struct, self.FCM, self.pointops, self.sharedops)
         fcm.get_FCM_operations()
         rand_FCM = fcm.get_rand_FCM()
-        structure = pymatgen.io.phonopy.get_phonopy_structure(self.piezo_struc)
+        structure = pymatgen.io.phonopy.get_phonopy_structure(self.piezo_struct)
         pn_struct = Phonopy(structure, np.eye(3), np.eye(3))
 
         pn_struct.set_force_constants(rand_FCM)
         dyn = pn_struct.get_dynamical_matrix_at_q([0, 0, 0])
         dyn = np.reshape(dyn, (10, 3, 10, 3)).swapaxes(1, 2)
         dyn = np.real(dyn)
-        n_sites = len(self.piezo_struc)
-        masses = [site.specie.atomic_mass for site in self.piezo_struc.sites]
+        n_sites = len(self.piezo_struct)
+        masses = [site.specie.atomic_mass for site in self.piezo_struct]
         dyn_mass = np.zeros([n_sites, n_sites, 3, 3])
         for m in range(n_sites):
             for n in range(n_sites):
@@ -260,7 +260,7 @@ class TestPiezoSensitivity(PymatgenTest):
     def test_rand_piezo(self):
         pytest.importorskip("phonopy")
         rand_BEC, rand_IST, rand_FCM, piezo = rand_piezo(
-            self.piezo_struc, self.pointops, self.sharedops, self.BEC, self.IST, self.FCM
+            self.piezo_struct, self.pointops, self.sharedops, self.BEC, self.IST, self.FCM
         )
 
         for i in range(len(self.BEC_operations)):
@@ -279,25 +279,25 @@ class TestPiezoSensitivity(PymatgenTest):
                     atol=1e-3,
                 )
 
-        structure = pymatgen.io.phonopy.get_phonopy_structure(self.piezo_struc)
+        structure = pymatgen.io.phonopy.get_phonopy_structure(self.piezo_struct)
         pn_struct = Phonopy(structure, np.eye(3), np.eye(3))
 
         pn_struct.set_force_constants(rand_FCM)
         dyn = pn_struct.get_dynamical_matrix_at_q([0, 0, 0])
         dyn = np.reshape(dyn, (10, 3, 10, 3)).swapaxes(1, 2)
         dyn = np.real(dyn)
-        n_sites = len(self.piezo_struc)
-        masses = [site.specie.atomic_mass for site in self.piezo_struc.sites]
+        n_sites = len(self.piezo_struct)
+        masses = [site.specie.atomic_mass for site in self.piezo_struct]
         dyn_mass = np.zeros([n_sites, n_sites, 3, 3])
         for m in range(n_sites):
             for n in range(n_sites):
                 dyn_mass[m][n] = dyn[m][n] / np.sqrt(masses[m]) / np.sqrt(masses[n])
 
         dyn_mass = np.reshape(np.swapaxes(dyn_mass, 1, 2), (10 * 3, 10 * 3))
-        eigs, vecs = np.linalg.eig(dyn_mass)
-        eigsort = np.argsort(np.abs(eigs))
+        eigs, _eig_vecs = np.linalg.eig(dyn_mass)
+        eig_sorted = np.argsort(np.abs(eigs))
         for i in range(3, len(eigs)):
-            assert eigs[eigsort[i]] < 1e-6
+            assert eigs[eig_sorted[i]] < 1e-6
         # rand_FCM1 = np.reshape(rand_FCM1, (10,3,10,3)).swapaxes(1,2)
 
         dyn_mass = np.reshape(dyn_mass, (10, 3, 10, 3)).swapaxes(1, 2)

--- a/tests/analysis/test_structure_analyzer.py
+++ b/tests/analysis/test_structure_analyzer.py
@@ -110,20 +110,21 @@ class TestMiscFunction(PymatgenTest):
         el_li = Element("Li")
         el_o = Element("O")
         latt = Lattice([[3.985034, 0, 0], [0, 4.881506, 0], [0, 0, 2.959824]])
-        elts = [el_li, el_li, el_o, el_o, el_o, el_o]
-        coords = []
-        coords.append([0.500000, 0.500000, 0.500000])
-        coords.append([0, 0, 0])
-        coords.append([0.632568, 0.085090, 0.500000])
-        coords.append([0.367432, 0.914910, 0.500000])
-        coords.append([0.132568, 0.414910, 0.000000])
-        coords.append([0.867432, 0.585090, 0.000000])
-        struct = Structure(latt, elts, coords)
+        elems = [el_li, el_li, el_o, el_o, el_o, el_o]
+        coords = [
+            [0.5, 0.5, 0.5],
+            [0, 0, 0],
+            [0.632568, 0.085090, 0.5],
+            [0.367432, 0.914910, 0.5],
+            [0.132568, 0.414910, 0],
+            [0.867432, 0.585090, 0],
+        ]
+        struct = Structure(latt, elems, coords)
         assert oxide_type(struct, 1.1) == "superoxide"
 
         el_li = Element("Li")
         el_o = Element("O")
-        elts = [el_li, el_o, el_o, el_o]
+        elems = [el_li, el_o, el_o, el_o]
         latt = Lattice.from_parameters(3.999911, 3.999911, 3.999911, 133.847504, 102.228244, 95.477342)
         coords = [
             [0.513004, 0.513004, 1.000000],
@@ -131,13 +132,13 @@ class TestMiscFunction(PymatgenTest):
             [0.649993, 0.874790, 0.775203],
             [0.099587, 0.874790, 0.224797],
         ]
-        struct = Structure(latt, elts, coords)
+        struct = Structure(latt, elems, coords)
         assert oxide_type(struct, 1.1) == "ozonide"
 
         latt = Lattice.from_parameters(3.159597, 3.159572, 7.685205, 89.999884, 89.999674, 60.000510)
         el_li = Element("Li")
         el_o = Element("O")
-        elts = [el_li, el_li, el_li, el_li, el_o, el_o, el_o, el_o]
+        elems = [el_li, el_li, el_li, el_li, el_o, el_o, el_o, el_o]
         coords = [
             [0.666656, 0.666705, 0.750001],
             [0.333342, 0.333378, 0.250001],
@@ -148,14 +149,14 @@ class TestMiscFunction(PymatgenTest):
             [0.666666, 0.666686, 0.350813],
             [0.666665, 0.666684, 0.149189],
         ]
-        struct = Structure(latt, elts, coords)
+        struct = Structure(latt, elems, coords)
         assert oxide_type(struct, 1.1) == "peroxide"
 
         el_li = Element("Li")
         el_o = Element("O")
         el_h = Element("H")
         latt = Lattice.from_parameters(3.565276, 3.565276, 4.384277, 90.000000, 90.000000, 90.000000)
-        elts = [el_h, el_h, el_li, el_li, el_o, el_o]
+        elems = [el_h, el_h, el_li, el_li, el_o, el_o]
         coords = [
             [0.000000, 0.500000, 0.413969],
             [0.500000, 0.000000, 0.586031],
@@ -164,14 +165,14 @@ class TestMiscFunction(PymatgenTest):
             [0.000000, 0.500000, 0.192672],
             [0.500000, 0.000000, 0.807328],
         ]
-        struct = Structure(latt, elts, coords)
+        struct = Structure(latt, elems, coords)
         assert oxide_type(struct, 1.1) == "hydroxide"
 
         el_li = Element("Li")
         el_n = Element("N")
         el_h = Element("H")
         latt = Lattice.from_parameters(3.565276, 3.565276, 4.384277, 90.000000, 90.000000, 90.000000)
-        elts = [el_h, el_h, el_li, el_li, el_n, el_n]
+        elems = [el_h, el_h, el_li, el_li, el_n, el_n]
         coords = [
             [0.000000, 0.500000, 0.413969],
             [0.500000, 0.000000, 0.586031],
@@ -180,12 +181,12 @@ class TestMiscFunction(PymatgenTest):
             [0.000000, 0.500000, 0.192672],
             [0.500000, 0.000000, 0.807328],
         ]
-        struct = Structure(latt, elts, coords)
+        struct = Structure(latt, elems, coords)
         assert oxide_type(struct, 1.1) == "None"
 
         el_o = Element("O")
         latt = Lattice.from_parameters(4.389828, 5.369789, 5.369789, 70.786622, 69.244828, 69.244828)
-        elts = [el_o, el_o, el_o, el_o, el_o, el_o, el_o, el_o]
+        elems = [el_o, el_o, el_o, el_o, el_o, el_o, el_o, el_o]
         coords = [
             [0.844609, 0.273459, 0.786089],
             [0.155391, 0.213911, 0.726541],
@@ -196,7 +197,7 @@ class TestMiscFunction(PymatgenTest):
             [0.132641, 0.148222, 0.148222],
             [0.867359, 0.851778, 0.851778],
         ]
-        struct = Structure(latt, elts, coords)
+        struct = Structure(latt, elems, coords)
         assert oxide_type(struct, 1.1) == "None"
 
     def test_sulfide_type(self):

--- a/tests/command_line/test_gulp_caller.py
+++ b/tests/command_line/test_gulp_caller.py
@@ -278,7 +278,7 @@ class TestGlobalFunctions(unittest.TestCase):
         self.mgo_uc = Structure(mgo_latt, mgo_specie, mgo_frac_cord, validate_proximity=True, to_unit_cell=True)
         bv = BVAnalyzer()
         val = bv.get_valences(self.mgo_uc)
-        el = [site.species_string for site in self.mgo_uc.sites]
+        el = [site.species_string for site in self.mgo_uc]
         self.val_dict = dict(zip(el, val))
 
     def test_get_energy_tersoff(self):

--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -127,10 +127,7 @@ class TestIStructure(PymatgenTest):
         assert supercell.matches(self.struct)
 
     def test_bad_structure(self):
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0.75, 0.5, 0.75])
-        coords.append([0.75, 0.5, 0.75])
+        coords = [[0, 0, 0], [0.75, 0.5, 0.75], [0.75, 0.5, 0.75]]
         with pytest.raises(StructureError, match="Structure contains sites that are less than 0.01 Angstrom apart"):
             IStructure(self.lattice, ["Si"] * 3, coords, validate_proximity=True)
         # these shouldn't raise an error
@@ -153,16 +150,12 @@ class TestIStructure(PymatgenTest):
         assert self.propertied_structure.elements == [Element("Si")]
 
     def test_specie_init(self):
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0.75, 0.5, 0.75])
+        coords = [[0, 0, 0], [0.75, 0.5, 0.75]]
         struct = IStructure(self.lattice, [{Species("O", -2): 1.0}, {Species("Mg", 2): 0.8}], coords)
         assert struct.composition.formula == "Mg0.8 O1"
 
     def test_get_sorted_structure(self):
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0.75, 0.5, 0.75])
+        coords = [[0, 0, 0], [0.75, 0.5, 0.75]]
         struct = IStructure(self.lattice, ["O", "Li"], coords, site_properties={"charge": [-2, 1]})
         sorted_s = struct.get_sorted_structure()
         assert sorted_s[0].species == Composition("Li")
@@ -180,9 +173,7 @@ class TestIStructure(PymatgenTest):
         assert self.struct.get_space_group_info() == ("Fd-3m", 227)
 
     def test_fractional_occupations(self):
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0.75, 0.5, 0.75])
+        coords = [[0, 0, 0], [0.75, 0.5, 0.75]]
         struct = IStructure(self.lattice, [{"O": 1.0}, {"Mg": 0.8}], coords)
         assert struct.composition.formula == "Mg0.8 O1"
         assert not struct.is_ordered
@@ -199,9 +190,7 @@ class TestIStructure(PymatgenTest):
     def test_as_dict(self):
         si = Species("Si", 4)
         mn = Element("Mn")
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0.75, 0.5, 0.75])
+        coords = [[0, 0, 0], [0.75, 0.5, 0.75]]
         struct = IStructure(self.lattice, [{si: 0.5, mn: 0.5}, {si: 0.5}], coords)
         assert "lattice" in struct.as_dict()
         assert "sites" in struct.as_dict()
@@ -312,9 +301,7 @@ class TestIStructure(PymatgenTest):
         assert new_struct.properties["another_prop"] == "test"
         assert new_struct.properties["test_property"] == "test"
 
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0.0, 0, 0.0000001])
+        coords = [[0, 0, 0], [0.0, 0, 1e-07]]
 
         struct = IStructure(
             self.lattice, ["O", "Si"], coords, site_properties={"magmom": [5, -5]}, properties={"test_property": "test"}
@@ -330,13 +317,10 @@ class TestIStructure(PymatgenTest):
         assert new_struct.properties["test_property"] == "test"
 
     def test_interpolate(self):
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0.75, 0.5, 0.75])
+        coords = [[0, 0, 0], [0.75, 0.5, 0.75]]
         struct = IStructure(self.lattice, ["Si"] * 2, coords)
         coords2 = []
-        coords2.append([0, 0, 0])
-        coords2.append([0.5, 0.5, 0.5])
+        coords2.extend(([0, 0, 0], [0.5, 0.5, 0.5]))
         struct2 = IStructure(self.struct.lattice, ["Si"] * 2, coords2)
         interpolated_structs = struct.interpolate(struct2, 10)
         for inter_struct in interpolated_structs:
@@ -402,13 +386,9 @@ class TestIStructure(PymatgenTest):
         assert_allclose(int_s_pbc[1][0].frac_coords, [1.05, 1.05, 0.55])
 
     def test_interpolate_lattice(self):
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0.75, 0.5, 0.75])
+        coords = [[0, 0, 0], [0.75, 0.5, 0.75]]
         struct = IStructure(self.lattice, ["Si"] * 2, coords)
-        coords2 = []
-        coords2.append([0, 0, 0])
-        coords2.append([0.5, 0.5, 0.5])
+        coords2 = [[0, 0, 0], [0.5, 0.5, 0.5]]
         l2 = Lattice.from_parameters(3, 4, 4, 100, 100, 70)
         struct2 = IStructure(l2, ["Si"] * 2, coords2)
         int_s = struct.interpolate(struct2, 2, interpolate_lattices=True)
@@ -825,9 +805,7 @@ Direct
 
 class TestStructure(PymatgenTest):
     def setUp(self):
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0.75, 0.5, 0.75])
+        coords = [[0, 0, 0], [0.75, 0.5, 0.75]]
         lattice = Lattice([[3.8401979337, 0, 0], [1.9200989668, 3.3257101909, 0], [0, -2.2171384943, 3.1355090603]])
         self.struct = Structure(lattice, ["Si", "Si"], coords)
         self.cu_structure = Structure(lattice, ["Cu", "Cu"], coords)
@@ -1023,9 +1001,7 @@ class TestStructure(PymatgenTest):
         o_elem = Element("O")
         co_specie = Species("Co", 2)
         o_specie = Species("O", -2)
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0.75, 0.5, 0.75])
+        coords = [[0, 0, 0], [0.75, 0.5, 0.75]]
         lattice = Lattice.cubic(10)
         s_elem = Structure(lattice, [co_elem, o_elem], coords)
         s_specie = Structure(lattice, [co_specie, o_specie], coords)
@@ -1706,11 +1682,7 @@ class TestIMolecule(PymatgenTest):
         assert self.mol.get_angle(3, 1, 2) == approx(60.00001388659683)
         assert self.mol.get_dihedral(0, 1, 2, 3) == approx(-35.26438851071765)
 
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0, 0, 1])
-        coords.append([0, 1, 1])
-        coords.append([1, 1, 1])
+        coords = [[0, 0, 0], [0, 0, 1], [0, 1, 1], [1, 1, 1]]
         self.mol2 = Molecule(["C", "O", "N", "S"], coords)
         assert self.mol2.get_dihedral(0, 1, 2, 3) == approx(-90)
 

--- a/tests/core/test_surface.py
+++ b/tests/core/test_surface.py
@@ -511,9 +511,9 @@ class TestSlabGenerator(PymatgenTest):
         TeI_slabs = triclinic_TeI.get_slabs()
         slab = TeI_slabs[0]
         # Add site property to slab
-        sd_list = [[True, True, True] for site in slab.sites]
+        selective_dynamics = [[True, True, True] for _ in slab]
         new_sp = slab.site_properties
-        new_sp["selective_dynamics"] = sd_list
+        new_sp["selective_dynamics"] = selective_dynamics
         slab_with_site_props = slab.copy(site_properties=new_sp)
 
         # Get orthogonal slab

--- a/tests/entries/test_compatibility.py
+++ b/tests/entries/test_compatibility.py
@@ -1322,13 +1322,14 @@ class TestOxideTypeCorrection(unittest.TestCase):
         el_o = Element("O")
         latt = Lattice([[3.985034, 0.0, 0.0], [0.0, 4.881506, 0.0], [0.0, 0.0, 2.959824]])
         elems = [el_li, el_li, el_o, el_o, el_o, el_o]
-        coords = []
-        coords.append([0.500000, 0.500000, 0.500000])
-        coords.append([0.0, 0.0, 0.0])
-        coords.append([0.632568, 0.085090, 0.500000])
-        coords.append([0.367432, 0.914910, 0.500000])
-        coords.append([0.132568, 0.414910, 0.000000])
-        coords.append([0.867432, 0.585090, 0.000000])
+        coords = [
+            [0.5, 0.5, 0.5],
+            [0.0, 0.0, 0.0],
+            [0.632568, 0.08509, 0.5],
+            [0.367432, 0.91491, 0.5],
+            [0.132568, 0.41491, 0.0],
+            [0.867432, 0.58509, 0.0],
+        ]
         struct = Structure(latt, elems, coords)
         lio2_entry = ComputedStructureEntry(
             struct,

--- a/tests/entries/test_compatibility.py
+++ b/tests/entries/test_compatibility.py
@@ -1321,7 +1321,7 @@ class TestOxideTypeCorrection(unittest.TestCase):
         el_li = Element("Li")
         el_o = Element("O")
         latt = Lattice([[3.985034, 0.0, 0.0], [0.0, 4.881506, 0.0], [0.0, 0.0, 2.959824]])
-        elts = [el_li, el_li, el_o, el_o, el_o, el_o]
+        elems = [el_li, el_li, el_o, el_o, el_o, el_o]
         coords = []
         coords.append([0.500000, 0.500000, 0.500000])
         coords.append([0.0, 0.0, 0.0])
@@ -1329,7 +1329,7 @@ class TestOxideTypeCorrection(unittest.TestCase):
         coords.append([0.367432, 0.914910, 0.500000])
         coords.append([0.132568, 0.414910, 0.000000])
         coords.append([0.867432, 0.585090, 0.000000])
-        struct = Structure(latt, elts, coords)
+        struct = Structure(latt, elems, coords)
         lio2_entry = ComputedStructureEntry(
             struct,
             -3,
@@ -1351,7 +1351,7 @@ class TestOxideTypeCorrection(unittest.TestCase):
         latt = Lattice.from_parameters(3.159597, 3.159572, 7.685205, 89.999884, 89.999674, 60.000510)
         el_li = Element("Li")
         el_o = Element("O")
-        elts = [el_li, el_li, el_li, el_li, el_o, el_o, el_o, el_o]
+        elems = [el_li, el_li, el_li, el_li, el_o, el_o, el_o, el_o]
         coords = [
             [0.666656, 0.666705, 0.750001],
             [0.333342, 0.333378, 0.250001],
@@ -1362,7 +1362,7 @@ class TestOxideTypeCorrection(unittest.TestCase):
             [0.666666, 0.666686, 0.350813],
             [0.666665, 0.666684, 0.149189],
         ]
-        struct = Structure(latt, elts, coords)
+        struct = Structure(latt, elems, coords)
         li2o2_entry = ComputedStructureEntry(
             struct,
             -3,
@@ -1383,7 +1383,7 @@ class TestOxideTypeCorrection(unittest.TestCase):
     def test_process_entry_ozonide(self):
         el_li = Element("Li")
         el_o = Element("O")
-        elts = [el_li, el_o, el_o, el_o]
+        elems = [el_li, el_o, el_o, el_o]
         latt = Lattice.from_parameters(3.999911, 3.999911, 3.999911, 133.847504, 102.228244, 95.477342)
         coords = [
             [0.513004, 0.513004, 1.000000],
@@ -1391,7 +1391,7 @@ class TestOxideTypeCorrection(unittest.TestCase):
             [0.649993, 0.874790, 0.775203],
             [0.099587, 0.874790, 0.224797],
         ]
-        struct = Structure(latt, elts, coords)
+        struct = Structure(latt, elems, coords)
         lio3_entry = ComputedStructureEntry(
             struct,
             -3,
@@ -1412,10 +1412,10 @@ class TestOxideTypeCorrection(unittest.TestCase):
     def test_process_entry_oxide(self):
         el_li = Element("Li")
         el_o = Element("O")
-        elts = [el_li, el_li, el_o]
+        elems = [el_li, el_li, el_o]
         latt = Lattice.from_parameters(3.278, 3.278, 3.278, 60, 60, 60)
         coords = [[0.25, 0.25, 0.25], [0.75, 0.75, 0.75], [0.0, 0.0, 0.0]]
-        struct = Structure(latt, elts, coords)
+        struct = Structure(latt, elems, coords)
         li2o_entry = ComputedStructureEntry(
             struct,
             -3,
@@ -1602,10 +1602,10 @@ class TestOxideTypeCorrectionNoPeroxideCorr(unittest.TestCase):
     def test_oxide_energy_corr(self):
         el_li = Element("Li")
         el_o = Element("O")
-        elts = [el_li, el_li, el_o]
+        elems = [el_li, el_li, el_o]
         latt = Lattice.from_parameters(3.278, 3.278, 3.278, 60, 60, 60)
         coords = [[0.25, 0.25, 0.25], [0.75, 0.75, 0.75], [0.0, 0.0, 0.0]]
-        struct = Structure(latt, elts, coords)
+        struct = Structure(latt, elems, coords)
         li2o_entry = ComputedStructureEntry(
             struct,
             -3,
@@ -1627,7 +1627,7 @@ class TestOxideTypeCorrectionNoPeroxideCorr(unittest.TestCase):
         latt = Lattice.from_parameters(3.159597, 3.159572, 7.685205, 89.999884, 89.999674, 60.000510)
         el_li = Element("Li")
         el_o = Element("O")
-        elts = [el_li, el_li, el_li, el_li, el_o, el_o, el_o, el_o]
+        elems = [el_li, el_li, el_li, el_li, el_o, el_o, el_o, el_o]
         coords = [
             [0.666656, 0.666705, 0.750001],
             [0.333342, 0.333378, 0.250001],
@@ -1638,7 +1638,7 @@ class TestOxideTypeCorrectionNoPeroxideCorr(unittest.TestCase):
             [0.666666, 0.666686, 0.350813],
             [0.666665, 0.666684, 0.149189],
         ]
-        struct = Structure(latt, elts, coords)
+        struct = Structure(latt, elems, coords)
         cse_params = {
             "is_hubbard": False,
             "hubbards": None,
@@ -1656,7 +1656,7 @@ class TestOxideTypeCorrectionNoPeroxideCorr(unittest.TestCase):
     def test_ozonide(self):
         el_li = Element("Li")
         el_o = Element("O")
-        elts = [el_li, el_o, el_o, el_o]
+        elems = [el_li, el_o, el_o, el_o]
         latt = Lattice.from_parameters(3.999911, 3.999911, 3.999911, 133.847504, 102.228244, 95.477342)
         coords = [
             [0.513004, 0.513004, 1.000000],
@@ -1664,7 +1664,7 @@ class TestOxideTypeCorrectionNoPeroxideCorr(unittest.TestCase):
             [0.649993, 0.874790, 0.775203],
             [0.099587, 0.874790, 0.224797],
         ]
-        struct = Structure(latt, elts, coords)
+        struct = Structure(latt, elems, coords)
         lio3_entry = ComputedStructureEntry(
             struct,
             -3,
@@ -1867,7 +1867,7 @@ class TestMITAqueousCompatibility(unittest.TestCase):
         el_o = Element("O")
         el_h = Element("H")
         latt = Lattice.from_parameters(3.565276, 3.565276, 4.384277, 90.000000, 90.000000, 90.000000)
-        elts = [el_h, el_h, el_li, el_li, el_o, el_o]
+        elems = [el_h, el_h, el_li, el_li, el_o, el_o]
         coords = [
             [0.000000, 0.500000, 0.413969],
             [0.500000, 0.000000, 0.586031],
@@ -1876,7 +1876,7 @@ class TestMITAqueousCompatibility(unittest.TestCase):
             [0.000000, 0.500000, 0.192672],
             [0.500000, 0.000000, 0.807328],
         ]
-        struct = Structure(latt, elts, coords)
+        struct = Structure(latt, elems, coords)
         lioh_entry = ComputedStructureEntry(
             struct,
             -3,
@@ -1902,7 +1902,7 @@ class TestMITAqueousCompatibility(unittest.TestCase):
         el_o = Element("O")
         el_h = Element("H")
         latt = Lattice.from_parameters(3.565276, 3.565276, 4.384277, 90.000000, 90.000000, 90.000000)
-        elts = [el_h, el_h, el_li, el_li, el_o, el_o]
+        elems = [el_h, el_h, el_li, el_li, el_o, el_o]
         coords = [
             [0.000000, 0.500000, 0.413969],
             [0.500000, 0.000000, 0.586031],
@@ -1911,7 +1911,7 @@ class TestMITAqueousCompatibility(unittest.TestCase):
             [0.000000, 0.500000, 0.192672],
             [0.500000, 0.000000, 0.807328],
         ]
-        struct = Structure(latt, elts, coords)
+        struct = Structure(latt, elems, coords)
 
         lioh_entry = ComputedStructureEntry(
             struct,

--- a/tests/io/test_cif.py
+++ b/tests/io/test_cif.py
@@ -838,12 +838,11 @@ loop_
     def test_replacing_finite_precision_frac_coords(self):
         cif = f"{TEST_FILES_DIR}/cif_finite_precision_frac_coord_error.cif"
         parser = CifParser(cif)
-        struct = parser.get_structures()[0]
+        warn_msg = "4 fractional coordinates rounded to ideal values to avoid issues with finite precision."
+        with pytest.warns(UserWarning, match=warn_msg):
+            struct = parser.get_structures()[0]
         assert str(struct.composition) == "N5+24"
-        assert (
-            "Some fractional coordinates rounded to ideal values to avoid issues with finite precision."
-            in parser.warnings
-        )
+        assert warn_msg in parser.warnings
 
     def test_empty_deque(self):
         cif_str = """data_1526655

--- a/tests/io/test_cif.py
+++ b/tests/io/test_cif.py
@@ -571,8 +571,7 @@ loop_
         si = Element("Si")
         n = Element("N")
         coords = []
-        coords.append(np.array([0, 0, 0]))
-        coords.append(np.array([0.75, 0.5, 0.75]))
+        coords.extend((np.array([0, 0, 0]), np.array([0.75, 0.5, 0.75])))
         lattice = Lattice(
             [
                 [3.8401979337, 0.00, 0.00],
@@ -629,9 +628,7 @@ loop_
         si3 = Species("Si", 3)
         n = DummySpecies("X", -3)
         coords = []
-        coords.append(np.array([0.5, 0.5, 0.5]))
-        coords.append(np.array([0.75, 0.5, 0.75]))
-        coords.append(np.array([0, 0, 0]))
+        coords.extend((np.array([0.5, 0.5, 0.5]), np.array([0.75, 0.5, 0.75]), np.array([0, 0, 0])))
         lattice = Lattice(
             [
                 [3.8401979337, 0.00, 0.00],

--- a/tests/io/test_xcrysden.py
+++ b/tests/io/test_xcrysden.py
@@ -8,9 +8,7 @@ from pymatgen.util.testing import PymatgenTest
 
 class TestXSF(PymatgenTest):
     def test_xsf(self):
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0.75, 0.5, 0.75])
+        coords = [[0, 0, 0], [0.75, 0.5, 0.75]]
         lattice = Lattice(
             [
                 [3.8401979337, 0.00, 0.00],

--- a/tests/io/vasp/test_inputs.py
+++ b/tests/io/vasp/test_inputs.py
@@ -186,9 +186,7 @@ cart
 
     def test_significant_figures(self):
         si = 14
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0.75, 0.5, 0.75])
+        coords = [[0, 0, 0], [0.75, 0.5, 0.75]]
 
         # Silicon structure for testing.
         latt = [
@@ -215,9 +213,7 @@ direct
 
     def test_str(self):
         si = 14
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0.75, 0.5, 0.75])
+        coords = [[0, 0, 0], [0.75, 0.5, 0.75]]
 
         # Silicon structure for testing.
         latt = [
@@ -335,9 +331,7 @@ direct
 
     def test_velocities(self):
         si = 14
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0.75, 0.5, 0.75])
+        coords = [[0, 0, 0], [0.75, 0.5, 0.75]]
 
         # Silicon structure for testing.
         latt = [

--- a/tests/io/vasp/test_sets.py
+++ b/tests/io/vasp/test_sets.py
@@ -294,8 +294,7 @@ class TestMITMPRelaxSet(PymatgenTest):
 
         si = 14
         coords = []
-        coords.append(np.array([0, 0, 0]))
-        coords.append(np.array([0.75, 0.5, 0.75]))
+        coords.extend((np.array([0, 0, 0]), np.array([0.75, 0.5, 0.75])))
 
         # Silicon structure for testing.
         lattice = Lattice(

--- a/tests/io/vasp/test_sets.py
+++ b/tests/io/vasp/test_sets.py
@@ -196,10 +196,7 @@ class TestMITMPRelaxSet(PymatgenTest):
         assert s_sorted[0].specie.symbol == "Mn"
 
     def test_potcar_symbols(self):
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0.75, 0.5, 0.75])
-        coords.append([0.75, 0.25, 0.75])
+        coords = [[0, 0, 0], [0.75, 0.5, 0.75], [0.75, 0.25, 0.75]]
         lattice = Lattice([[3.8401979337, 0, 0], [1.9200989668, 3.3257101909, 0], [0, -2.2171384943, 3.1355090603]])
         structure = Structure(lattice, ["P", "Fe", "O"], coords)
         mit_param_set = self.set(structure)
@@ -308,9 +305,7 @@ class TestMITMPRelaxSet(PymatgenTest):
         incar = MPRelaxSet(struct).incar
         assert "LDAU" not in incar
 
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0.75, 0.5, 0.75])
+        coords = [[0, 0, 0], [0.75, 0.5, 0.75]]
         lattice = Lattice(
             [[3.8401979337, 0.00, 0.00], [1.9200989668, 3.3257101909, 0.00], [0.00, -2.2171384943, 3.1355090603]]
         )
@@ -363,11 +358,7 @@ class TestMITMPRelaxSet(PymatgenTest):
         assert "ENCUT" not in no_encut_set.incar
 
         # sulfide vs sulfate test
-
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0.75, 0.5, 0.75])
-        coords.append([0.25, 0.5, 0])
+        coords = [[0, 0, 0], [0.75, 0.5, 0.75], [0.25, 0.5, 0]]
 
         struct = Structure(lattice, ["Fe", "Fe", "S"], coords)
         incar = self.set(struct).incar

--- a/tests/symmetry/test_analyzer.py
+++ b/tests/symmetry/test_analyzer.py
@@ -10,7 +10,6 @@ from pytest import approx
 from pymatgen.core.periodic_table import Species
 from pymatgen.core.sites import PeriodicSite
 from pymatgen.core.structure import Molecule, Structure
-from pymatgen.io.cif import CifParser
 from pymatgen.io.vasp.inputs import Poscar
 from pymatgen.io.vasp.outputs import Vasprun
 from pymatgen.symmetry.analyzer import PointGroupAnalyzer, SpacegroupAnalyzer, cluster_sites, iterative_symmetrize
@@ -230,8 +229,7 @@ class TestSpacegroupAnalyzer(PymatgenTest):
 
     def test_find_primitive(self):
         """F m -3 m Li2O testing of converting to primitive cell."""
-        parser = CifParser(f"{TEST_FILES_DIR}/Li2O.cif")
-        structure = parser.get_structures(primitive=False)[0]
+        structure = Structure.from_file(f"{TEST_FILES_DIR}/Li2O.cif")
         spga = SpacegroupAnalyzer(structure)
         primitive_structure = spga.find_primitive()
         assert primitive_structure.formula == "Li2 O1"
@@ -242,13 +240,11 @@ class TestSpacegroupAnalyzer(PymatgenTest):
         assert primitive_structure.lattice.gamma == approx(60)
         assert primitive_structure.volume == approx(structure.volume / 4.0)
 
-        structure = parser.get_structures(primitive=False)[0]
         structure.add_site_property("magmom", [1.0] * len(structure))
         spga = SpacegroupAnalyzer(structure)
         primitive_structure = spga.find_primitive(keep_site_properties=True)
         assert primitive_structure.site_properties["magmom"] == [1.0] * len(primitive_structure)
 
-        structure = parser.get_structures(primitive=False)[0]
         structure.add_site_property("magmom", [1.0] * len(structure))
         spga = SpacegroupAnalyzer(structure)
         primitive_structure = spga.find_primitive(keep_site_properties=False)
@@ -267,21 +263,20 @@ class TestSpacegroupAnalyzer(PymatgenTest):
         grid = self.sg.get_ir_reciprocal_mesh(mesh=mesh)
         full_grid, mapping = self.sg.get_ir_reciprocal_mesh_map(mesh=mesh)
         assert len(np.unique(mapping)) == len(grid)
-        for _, i in enumerate(np.unique(mapping)):
-            assert full_grid[i][0] == approx(grid[_][0][0])
-            assert full_grid[i][1] == approx(grid[_][0][1])
-            assert full_grid[i][2] == approx(grid[_][0][2])
+        for _, idx in enumerate(np.unique(mapping)):
+            assert full_grid[idx][0] == approx(grid[_][0][0])
+            assert full_grid[idx][1] == approx(grid[_][0][1])
+            assert full_grid[idx][2] == approx(grid[_][0][2])
 
     def test_get_conventional_standard_structure(self):
-        parser = CifParser(f"{TEST_FILES_DIR}/bcc_1927.cif")
-        structure = parser.get_structures(primitive=False)[0]
+        structure = Structure.from_file(f"{TEST_FILES_DIR}/bcc_1927.cif")
+        assert structure == structure
         spga = SpacegroupAnalyzer(structure, symprec=1e-2)
         conv = spga.get_conventional_standard_structure()
         assert conv.lattice.angles == (90, 90, 90)
         assert conv.lattice.lengths == approx([9.1980270633769461] * 3)
 
-        parser = CifParser(f"{TEST_FILES_DIR}/btet_1915.cif")
-        structure = parser.get_structures(primitive=False)[0]
+        structure = Structure.from_file(f"{TEST_FILES_DIR}/btet_1915.cif")
         spga = SpacegroupAnalyzer(structure, symprec=1e-2)
         conv = spga.get_conventional_standard_structure()
         assert conv.lattice.angles == (90, 90, 90)
@@ -289,8 +284,7 @@ class TestSpacegroupAnalyzer(PymatgenTest):
         assert conv.lattice.b == approx(5.0615106678044235)
         assert conv.lattice.c == approx(4.2327080177761687)
 
-        parser = CifParser(f"{TEST_FILES_DIR}/orci_1010.cif")
-        structure = parser.get_structures(primitive=False)[0]
+        structure = Structure.from_file(f"{TEST_FILES_DIR}/orci_1010.cif")
         spga = SpacegroupAnalyzer(structure, symprec=1e-2)
         conv = spga.get_conventional_standard_structure()
         assert conv.lattice.angles == (90, 90, 90)
@@ -298,8 +292,7 @@ class TestSpacegroupAnalyzer(PymatgenTest):
         assert conv.lattice.b == approx(4.6330325651443296)
         assert conv.lattice.c == approx(5.373703587040775)
 
-        parser = CifParser(f"{TEST_FILES_DIR}/orcc_1003.cif")
-        structure = parser.get_structures(primitive=False)[0]
+        structure = Structure.from_file(f"{TEST_FILES_DIR}/orcc_1003.cif")
         spga = SpacegroupAnalyzer(structure, symprec=1e-2)
         conv = spga.get_conventional_standard_structure()
         assert conv.lattice.angles == (90, 90, 90)
@@ -307,21 +300,18 @@ class TestSpacegroupAnalyzer(PymatgenTest):
         assert conv.lattice.b == approx(31.437979757624728)
         assert conv.lattice.c == approx(3.99648651)
 
-        parser = CifParser(f"{TEST_FILES_DIR}/orac_632475.cif")
-        structure = parser.get_structures(primitive=False)[0]
+        structure = Structure.from_file(f"{TEST_FILES_DIR}/orac_632475.cif")
         spga = SpacegroupAnalyzer(structure, symprec=1e-2)
         conv = spga.get_conventional_standard_structure()
         assert conv.lattice.angles == (90, 90, 90)
         assert conv.lattice.lengths == approx([3.1790663399999999, 9.9032878699999998, 3.5372412099999999])
 
-        parser = CifParser(f"{TEST_FILES_DIR}/monoc_1028.cif")
-        structure = parser.get_structures(primitive=False)[0]
+        structure = Structure.from_file(f"{TEST_FILES_DIR}/monoc_1028.cif")
         spga = SpacegroupAnalyzer(structure, symprec=1e-2)
         conv = spga.get_conventional_standard_structure()
         assert conv.lattice.angles == approx([90, 117.53832420192903, 90])
         assert conv.lattice.lengths == approx([14.033435583000625, 3.96052850731, 6.8743926325200002])
-        parser = CifParser(f"{TEST_FILES_DIR}/hex_1170.cif")
-        structure = parser.get_structures(primitive=False)[0]
+        structure = Structure.from_file(f"{TEST_FILES_DIR}/hex_1170.cif")
         spga = SpacegroupAnalyzer(structure, symprec=1e-2)
         conv = spga.get_conventional_standard_structure()
         assert conv.lattice.angles == approx([90, 90, 120])
@@ -350,8 +340,7 @@ class TestSpacegroupAnalyzer(PymatgenTest):
         assert conv.site_properties.get("magmom") is None
 
     def test_get_primitive_standard_structure(self):
-        parser = CifParser(f"{TEST_FILES_DIR}/bcc_1927.cif")
-        structure = parser.get_structures(primitive=False)[0]
+        structure = Structure.from_file(f"{TEST_FILES_DIR}/bcc_1927.cif")
         spga = SpacegroupAnalyzer(structure, symprec=1e-2)
         prim = spga.get_primitive_standard_structure()
         assert prim.lattice.alpha == approx(109.47122063400001)
@@ -361,8 +350,7 @@ class TestSpacegroupAnalyzer(PymatgenTest):
         assert prim.lattice.b == approx(7.9657251015812145)
         assert prim.lattice.c == approx(7.9657251015812145)
 
-        parser = CifParser(f"{TEST_FILES_DIR}/btet_1915.cif")
-        structure = parser.get_structures(primitive=False)[0]
+        structure = Structure.from_file(f"{TEST_FILES_DIR}/btet_1915.cif")
         spga = SpacegroupAnalyzer(structure, symprec=1e-2)
         prim = spga.get_primitive_standard_structure()
         assert prim.lattice.alpha == approx(105.015053349)
@@ -372,8 +360,7 @@ class TestSpacegroupAnalyzer(PymatgenTest):
         assert prim.lattice.b == approx(4.1579321075608791)
         assert prim.lattice.c == approx(4.1579321075608791)
 
-        parser = CifParser(f"{TEST_FILES_DIR}/orci_1010.cif")
-        structure = parser.get_structures(primitive=False)[0]
+        structure = Structure.from_file(f"{TEST_FILES_DIR}/orci_1010.cif")
         spga = SpacegroupAnalyzer(structure, symprec=1e-2)
         prim = spga.get_primitive_standard_structure()
         assert prim.lattice.alpha == approx(134.78923546600001)
@@ -383,8 +370,7 @@ class TestSpacegroupAnalyzer(PymatgenTest):
         assert prim.lattice.b == approx(3.8428217771014852)
         assert prim.lattice.c == approx(3.8428217771014852)
 
-        parser = CifParser(f"{TEST_FILES_DIR}/orcc_1003.cif")
-        structure = parser.get_structures(primitive=False)[0]
+        structure = Structure.from_file(f"{TEST_FILES_DIR}/orcc_1003.cif")
         spga = SpacegroupAnalyzer(structure, symprec=1e-2)
         prim = spga.get_primitive_standard_structure()
         assert prim.lattice.alpha == approx(90)
@@ -394,8 +380,7 @@ class TestSpacegroupAnalyzer(PymatgenTest):
         assert prim.lattice.b == approx(15.854897098324196)
         assert prim.lattice.c == approx(3.99648651)
 
-        parser = CifParser(f"{TEST_FILES_DIR}/orac_632475.cif")
-        structure = parser.get_structures(primitive=False)[0]
+        structure = Structure.from_file(f"{TEST_FILES_DIR}/orac_632475.cif")
         spga = SpacegroupAnalyzer(structure, symprec=1e-2)
         prim = spga.get_primitive_standard_structure()
         assert prim.lattice.alpha == approx(90)
@@ -405,8 +390,7 @@ class TestSpacegroupAnalyzer(PymatgenTest):
         assert prim.lattice.b == approx(5.2005185662155391)
         assert prim.lattice.c == approx(3.5372412099999999)
 
-        parser = CifParser(f"{TEST_FILES_DIR}/monoc_1028.cif")
-        structure = parser.get_structures(primitive=False)[0]
+        structure = Structure.from_file(f"{TEST_FILES_DIR}/monoc_1028.cif")
         spga = SpacegroupAnalyzer(structure, symprec=1e-2)
         prim = spga.get_primitive_standard_structure()
         assert prim.lattice.alpha == approx(63.579155761999999)
@@ -416,8 +400,7 @@ class TestSpacegroupAnalyzer(PymatgenTest):
         assert prim.lattice.b == approx(7.2908007159612325)
         assert prim.lattice.c == approx(6.8743926325200002)
 
-        parser = CifParser(f"{TEST_FILES_DIR}/hex_1170.cif")
-        structure = parser.get_structures(primitive=False)[0]
+        structure = Structure.from_file(f"{TEST_FILES_DIR}/hex_1170.cif")
         spga = SpacegroupAnalyzer(structure, symprec=1e-2)
         prim = spga.get_primitive_standard_structure()
         assert prim.lattice.alpha == approx(90)
@@ -427,8 +410,7 @@ class TestSpacegroupAnalyzer(PymatgenTest):
         assert prim.lattice.b == approx(3.699919902005897)
         assert prim.lattice.c == approx(6.9779585500000003)
 
-        parser = CifParser(f"{TEST_FILES_DIR}/rhomb_3478_conv.cif")
-        structure = parser.get_structures(primitive=False)[0]
+        structure = Structure.from_file(f"{TEST_FILES_DIR}/rhomb_3478_conv.cif")
         spga = SpacegroupAnalyzer(structure, symprec=1e-2)
         prim = spga.get_primitive_standard_structure()
         assert prim.lattice.alpha == approx(28.049186140546812)
@@ -438,15 +420,13 @@ class TestSpacegroupAnalyzer(PymatgenTest):
         assert prim.lattice.b == approx(5.9352627428399982)
         assert prim.lattice.c == approx(5.9352627428399982)
 
-        parser = CifParser(f"{TEST_FILES_DIR}/rhomb_3478_conv.cif")
-        structure = parser.get_structures(primitive=False)[0]
+        structure = Structure.from_file(f"{TEST_FILES_DIR}/rhomb_3478_conv.cif")
         structure.add_site_property("magmom", [1.0] * len(structure))
         spga = SpacegroupAnalyzer(structure, symprec=1e-2)
         prim = spga.get_primitive_standard_structure(keep_site_properties=True)
         assert prim.site_properties["magmom"] == [1.0] * len(prim)
 
-        parser = CifParser(f"{TEST_FILES_DIR}/rhomb_3478_conv.cif")
-        structure = parser.get_structures(primitive=False)[0]
+        structure = Structure.from_file(f"{TEST_FILES_DIR}/rhomb_3478_conv.cif")
         structure.add_site_property("magmom", [1.0] * len(structure))
         spga = SpacegroupAnalyzer(structure, symprec=1e-2)
         prim = spga.get_primitive_standard_structure(keep_site_properties=False)

--- a/tests/transformations/test_advanced_transformations.py
+++ b/tests/transformations/test_advanced_transformations.py
@@ -375,13 +375,13 @@ class TestMagOrderingTransformation(PymatgenTest):
         # Ensure s does not have a spin property
         assert struct[Li_site].specie.spin is None
         # ensure sites are assigned a spin property in alls
-        # assert "spin" in alls.sites[Li_site].specie.properties
+        # assert "spin" in alls[Li_site].specie.properties
         assert alls.sites[Li_site].specie.spin == 0
 
     def test_advanced_usage(self):
         # test spin on just one oxidation state
-        magtypes = {"Fe2+": 5}
-        trans = MagOrderingTransformation(magtypes)
+        mag_types = {"Fe2+": 5}
+        trans = MagOrderingTransformation(mag_types)
         alls = trans.apply_transformation(self.Fe3O4_oxi)
         assert isinstance(alls, Structure)
         assert str(alls[0].specie) == "Fe2+,spin=5"
@@ -389,12 +389,12 @@ class TestMagOrderingTransformation(PymatgenTest):
 
         # test multiple order parameters
         # this should only order on Fe3+ site, but assign spin to both
-        magtypes = {"Fe2+": 5, "Fe3+": 5}
+        mag_types = {"Fe2+": 5, "Fe3+": 5}
         order_parameters = [
             MagOrderParameterConstraint(1, species_constraints="Fe2+"),
             MagOrderParameterConstraint(0.5, species_constraints="Fe3+"),
         ]
-        trans = MagOrderingTransformation(magtypes, order_parameter=order_parameters)
+        trans = MagOrderingTransformation(mag_types, order_parameter=order_parameters)
         alls = trans.apply_transformation(self.Fe3O4_oxi)
         # using this 'sorted' syntax because exact order of sites in first
         # returned structure varies between machines: we just want to ensure
@@ -407,12 +407,12 @@ class TestMagOrderingTransformation(PymatgenTest):
 
         # this should give same results as previously
         # but with opposite sign on Fe2+ site
-        magtypes = {"Fe2+": -5, "Fe3+": 5}
+        mag_types = {"Fe2+": -5, "Fe3+": 5}
         order_parameters = [
             MagOrderParameterConstraint(1, species_constraints="Fe2+"),
             MagOrderParameterConstraint(0.5, species_constraints="Fe3+"),
         ]
-        trans = MagOrderingTransformation(magtypes, order_parameter=order_parameters)
+        trans = MagOrderingTransformation(mag_types, order_parameter=order_parameters)
         alls = trans.apply_transformation(self.Fe3O4_oxi)
         assert sorted(str(alls[idx].specie) for idx in range(2)) == sorted(["Fe2+,spin=-5", "Fe2+,spin=-5"])
         assert sorted(str(alls[idx].specie) for idx in range(2, 6)) == sorted(
@@ -420,12 +420,12 @@ class TestMagOrderingTransformation(PymatgenTest):
         )
 
         # while this should order on both sites
-        magtypes = {"Fe2+": 5, "Fe3+": 5}
+        mag_types = {"Fe2+": 5, "Fe3+": 5}
         order_parameters = [
             MagOrderParameterConstraint(0.5, species_constraints="Fe2+"),
             MagOrderParameterConstraint(0.25, species_constraints="Fe3+"),
         ]
-        trans = MagOrderingTransformation(magtypes, order_parameter=order_parameters)
+        trans = MagOrderingTransformation(mag_types, order_parameter=order_parameters)
         alls = trans.apply_transformation(self.Fe3O4_oxi)
         assert sorted(str(alls[idx].specie) for idx in range(2)) == sorted(["Fe2+,spin=5", "Fe2+,spin=-5"])
         assert sorted(str(alls[idx].specie) for idx in range(2, 6)) == sorted(
@@ -438,7 +438,7 @@ class TestMagOrderingTransformation(PymatgenTest):
         self.Fe3O4.add_site_property("cn", cns)
 
         # this should give FM ordering on cn=4 sites, and AFM ordering on cn=6 sites
-        magtypes = {"Fe": 5}
+        mag_types = {"Fe": 5}
         order_parameters = [
             MagOrderParameterConstraint(
                 0.5,
@@ -453,7 +453,7 @@ class TestMagOrderingTransformation(PymatgenTest):
                 site_constraints=4,
             ),
         ]
-        trans = MagOrderingTransformation(magtypes, order_parameter=order_parameters)
+        trans = MagOrderingTransformation(mag_types, order_parameter=order_parameters)
         alls = trans.apply_transformation(self.Fe3O4)
         alls.sort(key=lambda x: x.properties["cn"], reverse=True)
         assert sorted(str(alls[idx].specie) for idx in range(4)) == sorted(
@@ -462,12 +462,12 @@ class TestMagOrderingTransformation(PymatgenTest):
         assert sorted(str(alls[idx].specie) for idx in range(4, 6)) == sorted(["Fe,spin=5", "Fe,spin=5"])
 
         # now ordering on both sites, equivalent to order_parameter = 0.5
-        magtypes = {"Fe2+": 5, "Fe3+": 5}
+        mag_types = {"Fe2+": 5, "Fe3+": 5}
         order_parameters = [
             MagOrderParameterConstraint(0.5, species_constraints="Fe2+"),
             MagOrderParameterConstraint(0.5, species_constraints="Fe3+"),
         ]
-        trans = MagOrderingTransformation(magtypes, order_parameter=order_parameters)
+        trans = MagOrderingTransformation(mag_types, order_parameter=order_parameters)
         alls = trans.apply_transformation(self.Fe3O4_oxi, return_ranked_list=10)
         struct = alls[0]["structure"]
         assert sorted(str(struct[idx].specie) for idx in range(2)) == sorted(["Fe2+,spin=5", "Fe2+,spin=-5"])
@@ -477,12 +477,12 @@ class TestMagOrderingTransformation(PymatgenTest):
         assert len(alls) == 4
 
         # now mixed orderings where neither are equal or 1
-        magtypes = {"Fe2+": 5, "Fe3+": 5}
+        mag_types = {"Fe2+": 5, "Fe3+": 5}
         order_parameters = [
             MagOrderParameterConstraint(0.5, species_constraints="Fe2+"),
             MagOrderParameterConstraint(0.25, species_constraints="Fe3+"),
         ]
-        trans = MagOrderingTransformation(magtypes, order_parameter=order_parameters)
+        trans = MagOrderingTransformation(mag_types, order_parameter=order_parameters)
         alls = trans.apply_transformation(self.Fe3O4_oxi, return_ranked_list=100)
         struct = alls[0]["structure"]
         assert sorted(str(struct[idx].specie) for idx in range(2)) == sorted(["Fe2+,spin=5", "Fe2+,spin=-5"])
@@ -492,9 +492,9 @@ class TestMagOrderingTransformation(PymatgenTest):
         assert len(alls) == 2
 
         # now order on multiple species
-        magtypes = {"Fe2+": 5, "Fe3+": 5}
+        mag_types = {"Fe2+": 5, "Fe3+": 5}
         order_parameters = [MagOrderParameterConstraint(0.5, species_constraints=["Fe2+", "Fe3+"])]
-        trans = MagOrderingTransformation(magtypes, order_parameter=order_parameters)
+        trans = MagOrderingTransformation(mag_types, order_parameter=order_parameters)
         alls = trans.apply_transformation(self.Fe3O4_oxi, return_ranked_list=10)
         struct = alls[0]["structure"]
         assert sorted(str(struct[idx].specie) for idx in range(2)) == sorted(["Fe2+,spin=5", "Fe2+,spin=-5"])

--- a/tests/transformations/test_advanced_transformations.py
+++ b/tests/transformations/test_advanced_transformations.py
@@ -259,7 +259,7 @@ class TestEnumerateStructureTransformation(unittest.TestCase):
         trans = EnumerateStructureTransformation()
         dct = trans.as_dict()
         trans = EnumerateStructureTransformation.from_dict(dct)
-        assert trans.sym_prec == 0.1
+        assert trans.symm_prec == 0.1
 
 
 class TestSubstitutionPredictorTransformation(unittest.TestCase):

--- a/tests/transformations/test_advanced_transformations.py
+++ b/tests/transformations/test_advanced_transformations.py
@@ -80,15 +80,16 @@ class TestSuperTransformation(unittest.TestCase):
         trafo = SuperTransformation(
             [SubstitutionTransformation({"Li+": "Na+"}), SubstitutionTransformation({"Li+": "K+"})]
         )
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0.375, 0.375, 0.375])
-        coords.append([0.5, 0.5, 0.5])
-        coords.append([0.875, 0.875, 0.875])
-        coords.append([0.125, 0.125, 0.125])
-        coords.append([0.25, 0.25, 0.25])
-        coords.append([0.625, 0.625, 0.625])
-        coords.append([0.75, 0.75, 0.75])
+        coords = [
+            [0, 0, 0],
+            [0.375, 0.375, 0.375],
+            [0.5, 0.5, 0.5],
+            [0.875, 0.875, 0.875],
+            [0.125, 0.125, 0.125],
+            [0.25, 0.25, 0.25],
+            [0.625, 0.625, 0.625],
+            [0.75, 0.75, 0.75],
+        ]
 
         lattice = Lattice(
             [
@@ -127,11 +128,7 @@ class TestMultipleSubstitutionTransformation(unittest.TestCase):
     def test_apply_transformation(self):
         sub_dict = {1: ["Na", "K"]}
         trafo = MultipleSubstitutionTransformation("Li+", 0.5, sub_dict, None)
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0.75, 0.75, 0.75])
-        coords.append([0.5, 0.5, 0.5])
-        coords.append([0.25, 0.25, 0.25])
+        coords = [[0, 0, 0], [0.75, 0.75, 0.75], [0.5, 0.5, 0.5], [0.25, 0.25, 0.25]]
         lattice = Lattice(
             [
                 [3.8401979337, 0.00, 0.00],
@@ -146,15 +143,16 @@ class TestMultipleSubstitutionTransformation(unittest.TestCase):
 class TestChargeBalanceTransformation(unittest.TestCase):
     def test_apply_transformation(self):
         trafo = ChargeBalanceTransformation("Li+")
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0.375, 0.375, 0.375])
-        coords.append([0.5, 0.5, 0.5])
-        coords.append([0.875, 0.875, 0.875])
-        coords.append([0.125, 0.125, 0.125])
-        coords.append([0.25, 0.25, 0.25])
-        coords.append([0.625, 0.625, 0.625])
-        coords.append([0.75, 0.75, 0.75])
+        coords = [
+            [0, 0, 0],
+            [0.375, 0.375, 0.375],
+            [0.5, 0.5, 0.5],
+            [0.875, 0.875, 0.875],
+            [0.125, 0.125, 0.125],
+            [0.25, 0.25, 0.25],
+            [0.625, 0.625, 0.625],
+            [0.75, 0.75, 0.75],
+        ]
 
         lattice = Lattice(
             [
@@ -261,16 +259,13 @@ class TestEnumerateStructureTransformation(unittest.TestCase):
         trans = EnumerateStructureTransformation()
         dct = trans.as_dict()
         trans = EnumerateStructureTransformation.from_dict(dct)
-        assert trans.symm_prec == 0.1
+        assert trans.sym_prec == 0.1
 
 
 class TestSubstitutionPredictorTransformation(unittest.TestCase):
     def test_apply_transformation(self):
         trafo = SubstitutionPredictorTransformation(threshold=1e-3, alpha=-5, lambda_table=get_table())
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0.75, 0.75, 0.75])
-        coords.append([0.5, 0.5, 0.5])
+        coords = [[0, 0, 0], [0.75, 0.75, 0.75], [0.5, 0.5, 0.5]]
         lattice = Lattice(
             [
                 [3.8401979337, 0.00, 0.00],

--- a/tests/transformations/test_site_transformations.py
+++ b/tests/transformations/test_site_transformations.py
@@ -27,15 +27,16 @@ enumlib_present = enum_cmd and makestr_cmd
 
 class TestTranslateSitesTransformation(PymatgenTest):
     def setUp(self):
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0.375, 0.375, 0.375])
-        coords.append([0.5, 0.5, 0.5])
-        coords.append([0.875, 0.875, 0.875])
-        coords.append([0.125, 0.125, 0.125])
-        coords.append([0.25, 0.25, 0.25])
-        coords.append([0.625, 0.625, 0.625])
-        coords.append([0.75, 0.75, 0.75])
+        coords = [
+            [0, 0, 0],
+            [0.375, 0.375, 0.375],
+            [0.5, 0.5, 0.5],
+            [0.875, 0.875, 0.875],
+            [0.125, 0.125, 0.125],
+            [0.25, 0.25, 0.25],
+            [0.625, 0.625, 0.625],
+            [0.75, 0.75, 0.75],
+        ]
 
         lattice = Lattice(
             [
@@ -82,15 +83,16 @@ class TestTranslateSitesTransformation(PymatgenTest):
 
 class TestReplaceSiteSpeciesTransformation(unittest.TestCase):
     def setUp(self):
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0.375, 0.375, 0.375])
-        coords.append([0.5, 0.5, 0.5])
-        coords.append([0.875, 0.875, 0.875])
-        coords.append([0.125, 0.125, 0.125])
-        coords.append([0.25, 0.25, 0.25])
-        coords.append([0.625, 0.625, 0.625])
-        coords.append([0.75, 0.75, 0.75])
+        coords = [
+            [0, 0, 0],
+            [0.375, 0.375, 0.375],
+            [0.5, 0.5, 0.5],
+            [0.875, 0.875, 0.875],
+            [0.125, 0.125, 0.125],
+            [0.25, 0.25, 0.25],
+            [0.625, 0.625, 0.625],
+            [0.75, 0.75, 0.75],
+        ]
 
         lattice = Lattice(
             [
@@ -115,15 +117,16 @@ class TestReplaceSiteSpeciesTransformation(unittest.TestCase):
 
 class TestRemoveSitesTransformation(unittest.TestCase):
     def setUp(self):
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0.375, 0.375, 0.375])
-        coords.append([0.5, 0.5, 0.5])
-        coords.append([0.875, 0.875, 0.875])
-        coords.append([0.125, 0.125, 0.125])
-        coords.append([0.25, 0.25, 0.25])
-        coords.append([0.625, 0.625, 0.625])
-        coords.append([0.75, 0.75, 0.75])
+        coords = [
+            [0, 0, 0],
+            [0.375, 0.375, 0.375],
+            [0.5, 0.5, 0.5],
+            [0.875, 0.875, 0.875],
+            [0.125, 0.125, 0.125],
+            [0.25, 0.25, 0.25],
+            [0.625, 0.625, 0.625],
+            [0.75, 0.75, 0.75],
+        ]
 
         lattice = Lattice(
             [
@@ -148,15 +151,16 @@ class TestRemoveSitesTransformation(unittest.TestCase):
 
 class TestInsertSitesTransformation(unittest.TestCase):
     def setUp(self):
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0.375, 0.375, 0.375])
-        coords.append([0.5, 0.5, 0.5])
-        coords.append([0.875, 0.875, 0.875])
-        coords.append([0.125, 0.125, 0.125])
-        coords.append([0.25, 0.25, 0.25])
-        coords.append([0.625, 0.625, 0.625])
-        coords.append([0.75, 0.75, 0.75])
+        coords = [
+            [0, 0, 0],
+            [0.375, 0.375, 0.375],
+            [0.5, 0.5, 0.5],
+            [0.875, 0.875, 0.875],
+            [0.125, 0.125, 0.125],
+            [0.25, 0.25, 0.25],
+            [0.625, 0.625, 0.625],
+            [0.75, 0.75, 0.75],
+        ]
 
         lattice = Lattice(
             [
@@ -186,15 +190,16 @@ class TestInsertSitesTransformation(unittest.TestCase):
 
 class TestPartialRemoveSitesTransformation(unittest.TestCase):
     def setUp(self):
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0.375, 0.375, 0.375])
-        coords.append([0.5, 0.5, 0.5])
-        coords.append([0.875, 0.875, 0.875])
-        coords.append([0.125, 0.125, 0.125])
-        coords.append([0.25, 0.25, 0.25])
-        coords.append([0.625, 0.625, 0.625])
-        coords.append([0.75, 0.75, 0.75])
+        coords = [
+            [0, 0, 0],
+            [0.375, 0.375, 0.375],
+            [0.5, 0.5, 0.5],
+            [0.875, 0.875, 0.875],
+            [0.125, 0.125, 0.125],
+            [0.25, 0.25, 0.25],
+            [0.625, 0.625, 0.625],
+            [0.75, 0.75, 0.75],
+        ]
 
         lattice = Lattice(
             [

--- a/tests/transformations/test_standard_transformations.py
+++ b/tests/transformations/test_standard_transformations.py
@@ -44,9 +44,7 @@ enumlib_present = which("enum.x") and which("makestr.x")
 
 class TestRotationTransformations(unittest.TestCase):
     def setUp(self):
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0.75, 0.5, 0.75])
+        coords = [[0, 0, 0], [0.75, 0.5, 0.75]]
         lattice = Lattice(
             [
                 [3.8401979337, 0.00, 0.00],
@@ -71,11 +69,7 @@ class TestRotationTransformations(unittest.TestCase):
 class TestRemoveSpeciesTransformation(unittest.TestCase):
     def test_apply_transformation(self):
         trafo = RemoveSpeciesTransformation(["Li+"])
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0.75, 0.75, 0.75])
-        coords.append([0.5, 0.5, 0.5])
-        coords.append([0.25, 0.25, 0.25])
+        coords = [[0, 0, 0], [0.75, 0.75, 0.75], [0.5, 0.5, 0.5], [0.25, 0.25, 0.25]]
         lattice = Lattice(
             [
                 [3.8401979337, 0.00, 0.00],
@@ -94,11 +88,7 @@ class TestRemoveSpeciesTransformation(unittest.TestCase):
 class TestSubstitutionTransformation(unittest.TestCase):
     def test_apply_transformation(self):
         trafo = SubstitutionTransformation({"Li+": "Na+", "O2-": "S2-"})
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0.75, 0.75, 0.75])
-        coords.append([0.5, 0.5, 0.5])
-        coords.append([0.25, 0.25, 0.25])
+        coords = [[0, 0, 0], [0.75, 0.75, 0.75], [0.5, 0.5, 0.5], [0.25, 0.25, 0.25]]
         lattice = Lattice(
             [
                 [3.8401979337, 0.00, 0.00],
@@ -114,11 +104,7 @@ class TestSubstitutionTransformation(unittest.TestCase):
         trafo = SubstitutionTransformation({"Li+": "Na+", "O2-": {"S2-": 0.5, "Se2-": 0.5}})
         # test the to and from dict on the nested dictionary
         trafo = SubstitutionTransformation.from_dict(trafo.as_dict())
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0.75, 0.75, 0.75])
-        coords.append([0.5, 0.5, 0.5])
-        coords.append([0.25, 0.25, 0.25])
+        coords = [[0, 0, 0], [0.75, 0.75, 0.75], [0.5, 0.5, 0.5], [0.25, 0.25, 0.25]]
         lattice = Lattice(
             [
                 [3.8401979337, 0.00, 0.00],
@@ -133,11 +119,7 @@ class TestSubstitutionTransformation(unittest.TestCase):
 
 class TestSupercellTransformation(unittest.TestCase):
     def setUp(self):
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0.75, 0.75, 0.75])
-        coords.append([0.5, 0.5, 0.5])
-        coords.append([0.25, 0.25, 0.25])
+        coords = [[0, 0, 0], [0.75, 0.75, 0.75], [0.5, 0.5, 0.5], [0.25, 0.25, 0.25]]
         lattice = Lattice(
             [
                 [3.8401979337, 0.00, 0.00],
@@ -199,11 +181,7 @@ class TestSupercellTransformation(unittest.TestCase):
 class TestOxidationStateDecorationTransformation(unittest.TestCase):
     def test_apply_transformation(self):
         trafo = OxidationStateDecorationTransformation({"Li": 1, "O": -2})
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0.75, 0.75, 0.75])
-        coords.append([0.5, 0.5, 0.5])
-        coords.append([0.25, 0.25, 0.25])
+        coords = [[0, 0, 0], [0.75, 0.75, 0.75], [0.5, 0.5, 0.5], [0.25, 0.25, 0.25]]
         lattice = Lattice(
             [
                 [3.8401979337, 0.00, 0.00],
@@ -238,11 +216,7 @@ class TestAutoOxiStateDecorationTransformation(unittest.TestCase):
 class TestOxidationStateRemovalTransformation(unittest.TestCase):
     def test_apply_transformation(self):
         trafo = OxidationStateRemovalTransformation()
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0.75, 0.75, 0.75])
-        coords.append([0.5, 0.5, 0.5])
-        coords.append([0.25, 0.25, 0.25])
+        coords = [[0, 0, 0], [0.75, 0.75, 0.75], [0.5, 0.5, 0.5], [0.25, 0.25, 0.25]]
         lattice = Lattice(
             [
                 [3.8401979337, 0.00, 0.00],
@@ -263,11 +237,7 @@ class TestOxidationStateRemovalTransformation(unittest.TestCase):
 class TestPartialRemoveSpecieTransformation(unittest.TestCase):
     def test_apply_transformation(self):
         trafo = PartialRemoveSpecieTransformation("Li+", 1.0 / 3, 3)
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0.75, 0.75, 0.75])
-        coords.append([0.5, 0.5, 0.5])
-        coords.append([0.25, 0.25, 0.25])
+        coords = [[0, 0, 0], [0.75, 0.75, 0.75], [0.5, 0.5, 0.5], [0.25, 0.25, 0.25]]
         lattice = Lattice(
             [
                 [3.8401979337, 0.00, 0.00],
@@ -283,13 +253,7 @@ class TestPartialRemoveSpecieTransformation(unittest.TestCase):
 
     def test_apply_transformation_fast(self):
         trafo = PartialRemoveSpecieTransformation("Li+", 0.5)
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0.75, 0.75, 0.75])
-        coords.append([0.5, 0.5, 0.5])
-        coords.append([0.25, 0.25, 0.25])
-        coords.append([0.1, 0.1, 0.1])
-        coords.append([0.3, 0.75, 0.3])
+        coords = [[0, 0, 0], [0.75, 0.75, 0.75], [0.5, 0.5, 0.5], [0.25, 0.25, 0.25], [0.1, 0.1, 0.1], [0.3, 0.75, 0.3]]
         lattice = Lattice([[10, 0.00, 0.00], [0, 10, 0.00], [0.00, 0, 10]])
         struct = Structure(lattice, ["Li+"] * 6, coords)
         fast_opt_s = trafo.apply_transformation(struct)
@@ -316,11 +280,7 @@ class TestPartialRemoveSpecieTransformation(unittest.TestCase):
 class TestOrderDisorderedStructureTransformation(unittest.TestCase):
     def test_apply_transformation(self):
         trafo = OrderDisorderedStructureTransformation()
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0.75, 0.75, 0.75])
-        coords.append([0.5, 0.5, 0.5])
-        coords.append([0.25, 0.25, 0.25])
+        coords = [[0, 0, 0], [0.75, 0.75, 0.75], [0.5, 0.5, 0.5], [0.25, 0.25, 0.25]]
         lattice = Lattice(
             [
                 [3.8401979337, 0.00, 0.00],
@@ -403,8 +363,7 @@ class TestOrderDisorderedStructureTransformation(unittest.TestCase):
 
     def test_too_small_cell(self):
         trafo = OrderDisorderedStructureTransformation()
-        coords = []
-        coords.append([0.5, 0.5, 0.5])
+        coords = [[0.5, 0.5, 0.5]]
         lattice = Lattice(
             [
                 [3.8401979337, 0.00, 0.00],
@@ -418,11 +377,7 @@ class TestOrderDisorderedStructureTransformation(unittest.TestCase):
 
     def test_best_first(self):
         trafo = OrderDisorderedStructureTransformation(algo=2)
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0.75, 0.75, 0.75])
-        coords.append([0.5, 0.5, 0.5])
-        coords.append([0.25, 0.25, 0.25])
+        coords = [[0, 0, 0], [0.75, 0.75, 0.75], [0.5, 0.5, 0.5], [0.25, 0.25, 0.25]]
         lattice = Lattice(
             [
                 [3.8401979337, 0.00, 0.00],
@@ -448,15 +403,16 @@ class TestOrderDisorderedStructureTransformation(unittest.TestCase):
 class TestPrimitiveCellTransformation(unittest.TestCase):
     def test_apply_transformation(self):
         trafo = PrimitiveCellTransformation()
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0.375, 0.375, 0.375])
-        coords.append([0.5, 0.5, 0.5])
-        coords.append([0.875, 0.875, 0.875])
-        coords.append([0.125, 0.125, 0.125])
-        coords.append([0.25, 0.25, 0.25])
-        coords.append([0.625, 0.625, 0.625])
-        coords.append([0.75, 0.75, 0.75])
+        coords = [
+            [0, 0, 0],
+            [0.375, 0.375, 0.375],
+            [0.5, 0.5, 0.5],
+            [0.875, 0.875, 0.875],
+            [0.125, 0.125, 0.125],
+            [0.25, 0.25, 0.25],
+            [0.625, 0.625, 0.625],
+            [0.75, 0.75, 0.75],
+        ]
 
         lattice = Lattice(
             [
@@ -481,11 +437,7 @@ class TestPrimitiveCellTransformation(unittest.TestCase):
 class TestConventionalCellTransformation(unittest.TestCase):
     def test_apply_transformation(self):
         trafo = ConventionalCellTransformation()
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0.75, 0.75, 0.75])
-        coords.append([0.5, 0.5, 0.5])
-        coords.append([0.25, 0.25, 0.25])
+        coords = [[0, 0, 0], [0.75, 0.75, 0.75], [0.5, 0.5, 0.5], [0.25, 0.25, 0.25]]
         lattice = Lattice(
             [
                 [3.8401979337, 0.00, 0.00],
@@ -501,15 +453,16 @@ class TestConventionalCellTransformation(unittest.TestCase):
 class TestPerturbStructureTransformation(unittest.TestCase):
     def test_apply_transformation(self):
         trafo = PerturbStructureTransformation(0.05)
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0.375, 0.375, 0.375])
-        coords.append([0.5, 0.5, 0.5])
-        coords.append([0.875, 0.875, 0.875])
-        coords.append([0.125, 0.125, 0.125])
-        coords.append([0.25, 0.25, 0.25])
-        coords.append([0.625, 0.625, 0.625])
-        coords.append([0.75, 0.75, 0.75])
+        coords = [
+            [0, 0, 0],
+            [0.375, 0.375, 0.375],
+            [0.5, 0.5, 0.5],
+            [0.875, 0.875, 0.875],
+            [0.125, 0.125, 0.125],
+            [0.25, 0.25, 0.25],
+            [0.625, 0.625, 0.625],
+            [0.75, 0.75, 0.75],
+        ]
 
         lattice = [
             [3.8401979337, 0.00, 0.00],
@@ -537,15 +490,16 @@ class TestPerturbStructureTransformation(unittest.TestCase):
 class TestDeformStructureTransformation(unittest.TestCase):
     def test_apply_transformation(self):
         trafo = DeformStructureTransformation([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.05, 1.0]])
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0.375, 0.375, 0.375])
-        coords.append([0.5, 0.5, 0.5])
-        coords.append([0.875, 0.875, 0.875])
-        coords.append([0.125, 0.125, 0.125])
-        coords.append([0.25, 0.25, 0.25])
-        coords.append([0.625, 0.625, 0.625])
-        coords.append([0.75, 0.75, 0.75])
+        coords = [
+            [0, 0, 0],
+            [0.375, 0.375, 0.375],
+            [0.5, 0.5, 0.5],
+            [0.875, 0.875, 0.875],
+            [0.125, 0.125, 0.125],
+            [0.25, 0.25, 0.25],
+            [0.625, 0.625, 0.625],
+            [0.75, 0.75, 0.75],
+        ]
 
         lattice = [
             [3.8401979337, 0.00, 0.00],

--- a/tests/transformations/test_standard_transformations.py
+++ b/tests/transformations/test_standard_transformations.py
@@ -359,7 +359,7 @@ class TestOrderDisorderedStructureTransformation(unittest.TestCase):
         test_site = PeriodicSite("Si4+", c[2], latt)
         struct = SymmetrizedStructure(struct, "not_real", [0, 1, 1, 2, 2], ["a", "b", "b", "c", "c"])
         output = trafo.apply_transformation(struct)
-        assert test_site in output.sites
+        assert test_site in output
 
     def test_too_small_cell(self):
         trafo = OrderDisorderedStructureTransformation()

--- a/tests/util/test_coord.py
+++ b/tests/util/test_coord.py
@@ -238,11 +238,7 @@ class TestCoordUtils:
 
 class TestSimplex(unittest.TestCase):
     def setUp(self):
-        coords = []
-        coords.append([0, 0, 0])
-        coords.append([0, 1, 0])
-        coords.append([0, 0, 1])
-        coords.append([1, 0, 0])
+        coords = [[0, 0, 0], [0, 1, 0], [0, 0, 1], [1, 0, 0]]
         self.simplex = coord.Simplex(coords)
 
     def test_equal(self):


### PR DESCRIPTION
170a5da74 include count in `CifParser` "rounded fractional coordinates" warning msg
dcea6b6bb rename single-letter vars
5289fe2c6 prefer list literal over verbose `coords.append`
250632044 fix typo
476617e9e `test_analyzer.py` use `Structure.from_file()` over verbose `CifParser.from_file()`