### PR TITLE
Remove `pylint: disable` comments

### DIFF
--- a/pymatgen/analysis/chemenv/coordination_environments/chemenv_strategies.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/chemenv_strategies.py
@@ -2774,7 +2774,7 @@ class WeightedNbSetChemenvStrategy(AbstractChemenvStrategy):
         if isite is None or dequivsite is None or dthissite is None or mysym is None:
             isite, dequivsite, dthissite, mysym = self.equivalent_site_index_and_transform(site)
         return [
-            self.get_site_coordination_environment(  # pylint: disable=E1123
+            self.get_site_coordination_environment(
                 site=site,
                 isite=isite,
                 dequivsite=dequivsite,

--- a/pymatgen/analysis/chemenv/coordination_environments/coordination_geometries.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/coordination_geometries.py
@@ -699,7 +699,7 @@ class CoordinationGeometry:
             else:
                 min_dist_anions = 1000000.0
                 min_dist_cation_anion = 1000000.0
-                for ipt1 in range(len(self.points)):  # pylint: disable=C0200
+                for ipt1 in range(len(self.points)):
                     pt1 = np.array(self.points[ipt1])
                     min_dist_cation_anion = min(min_dist_cation_anion, np.linalg.norm(pt1 - self.central_site))
                     for ipt2 in range(ipt1 + 1, len(self.points)):
@@ -757,9 +757,9 @@ class CoordinationGeometry:
         """Returns the number of permutations of this coordination geometry."""
         if self.permutations_safe_override:
             return factorial(self.coordination)
-        if self.permutations is None:  # pylint: disable=E1101
+        if self.permutations is None:
             return factorial(self.coordination)
-        return len(self.permutations)  # pylint: disable=E1101
+        return len(self.permutations)
 
     def ref_permutation(self, permutation):
         """

--- a/pymatgen/analysis/chemenv/coordination_environments/voronoi.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/voronoi.py
@@ -559,7 +559,7 @@ class DetailedVoronoiContainer(MSONable):
             max_dist=max_dist,
         )
         maps_and_surfaces = []
-        for cn, value in self._unique_coordinated_neighbors_parameters_indices[isite].items():  # pylint: disable=E1101
+        for cn, value in self._unique_coordinated_neighbors_parameters_indices[isite].items():
             for imap, list_parameters_indices in enumerate(value):
                 thissurf = 0.0
                 for idp, iap, iacb in list_parameters_indices:
@@ -593,7 +593,7 @@ class DetailedVoronoiContainer(MSONable):
             additional_conditions = [self.AC.ONLY_ACB]
         surfaces = self.neighbors_surfaces_bounded(isite=isite, surface_calculation_options=surface_calculation_options)
         maps_and_surfaces = []
-        for cn, value in self._unique_coordinated_neighbors_parameters_indices[isite].items():  # pylint: disable=E1101
+        for cn, value in self._unique_coordinated_neighbors_parameters_indices[isite].items():
             for imap, list_parameters_indices in enumerate(value):
                 thissurf = 0.0
                 for idp, iap, iacb in list_parameters_indices:

--- a/pymatgen/analysis/chemenv/utils/math_utils.py
+++ b/pymatgen/analysis/chemenv/utils/math_utils.py
@@ -292,7 +292,7 @@ def power2_tangent_decreasing(xx, edges=None, prefactor=None):
     """
     if edges is None:
         aa = 1.0 / np.power(-1.0, 2) if prefactor is None else prefactor
-        return -aa * np.power(xx - 1.0, 2) * np.tan((xx - 1.0) * np.pi / 2.0)  # pylint: disable=E1130
+        return -aa * np.power(xx - 1.0, 2) * np.tan((xx - 1.0) * np.pi / 2.0)
 
     xx_scaled_and_clamped = scale_and_clamp(xx, edges[0], edges[1], 0.0, 1.0)
     return power2_tangent_decreasing(xx_scaled_and_clamped, prefactor=prefactor)

--- a/pymatgen/analysis/dimensionality.py
+++ b/pymatgen/analysis/dimensionality.py
@@ -407,7 +407,6 @@ def find_connected_atoms(struct, tolerance=0.45, ldict=None):
     if ldict is None:
         ldict = JmolNN().el_radius
 
-    # pylint: disable=E1136
     n_atoms = len(struct.species)
     fc = np.array(struct.frac_coords)
     fc_copy = np.repeat(fc[:, :, np.newaxis], 27, axis=2)

--- a/pymatgen/analysis/elasticity/elastic.py
+++ b/pymatgen/analysis/elasticity/elastic.py
@@ -722,7 +722,7 @@ class ElasticTensorExpansion(TensorCollection):
         ce_exp.append(np.einsum(ein_string, -ce_exp[-1], self[1], ce_exp[-1], ce_exp[-1]))
         if self.order == 4:
             # Four terms in the Fourth-Order compliance tensor
-            # pylint: disable=E1130
+
             einstring_1 = "pqab,cdij,efkl,ghmn,abcdefgh"
             tensors_1 = [ce_exp[0]] * 4 + [self[-1]]
             temp = -np.einsum(einstring_1, *tensors_1)
@@ -935,8 +935,8 @@ def get_strain_state_dict(strains, stresses, eq_stress=None, tol: float = 1e-10,
         dict: strain state keys and dictionaries with stress-strain data corresponding to strain state
     """
     # Recast stress/strains
-    vstrains = np.array([Strain(s).zeroed(tol).voigt for s in strains])  # pylint: disable=E1101
-    vstresses = np.array([Stress(s).zeroed(tol).voigt for s in stresses])  # pylint: disable=E1101
+    vstrains = np.array([Strain(s).zeroed(tol).voigt for s in strains])
+    vstresses = np.array([Stress(s).zeroed(tol).voigt for s in stresses])
     # Collect independent strain states:
     independent = {tuple(np.nonzero(vstrain)[0].tolist()) for vstrain in vstrains}
     strain_state_dict = {}

--- a/pymatgen/analysis/eos.py
+++ b/pymatgen/analysis/eos.py
@@ -232,7 +232,6 @@ class EOSBase(metaclass=ABCMeta):
         Returns:
             plt.Figure: matplotlib figure.
         """
-        # pylint: disable=E1307
         ax, fig = get_ax_fig(ax=ax)
 
         color = kwargs.get("color", "r")

--- a/pymatgen/analysis/ewald.py
+++ b/pymatgen/analysis/ewald.py
@@ -638,7 +638,7 @@ class EwaldMinimizer:
         Returns an index that should have the most negative effect on the
         matrix sum.
         """
-        # pylint: disable=E1126
+
         f = manipulation[0]
         indices = list(indices_left.intersection(manipulation[2]))
         sums = np.sum(matrix[indices], axis=1)

--- a/pymatgen/analysis/functional_groups.py
+++ b/pymatgen/analysis/functional_groups.py
@@ -328,7 +328,7 @@ class FunctionalGroupExtractor:
         """
         categories = {}
 
-        em = iso.numerical_edge_match("weight", 1)  # pylint: disable=E1102
+        em = iso.numerical_edge_match("weight", 1)
         nm = iso.categorical_node_match("specie", "C")
 
         for group in groups:

--- a/pymatgen/analysis/graphs.py
+++ b/pymatgen/analysis/graphs.py
@@ -1988,7 +1988,7 @@ class MoleculeGraph(MSONable):
             # in order to be used for Molecule instantiation
             for k, v in properties.items():
                 if len(v) != len(species):
-                    del properties[k]  # pylint: disable=R1733
+                    del properties[k]
 
             new_mol = Molecule(species, coords, charge=charge, site_properties=properties)
             graph_data = json_graph.adjacency_data(new_graph)

--- a/pymatgen/analysis/magnetism/heisenberg.py
+++ b/pymatgen/analysis/magnetism/heisenberg.py
@@ -171,7 +171,7 @@ class HeisenbergMapper:
         all_dists = []
 
         # Loop over unique sites and get neighbor distances up to NNNN
-        for k in unique_site_ids:  # pylint: disable=C0206
+        for k in unique_site_ids:
             i = k[0]
             i_key = unique_site_ids[k]
             connected_sites = sgraph.get_connected_sites(i)
@@ -198,7 +198,7 @@ class HeisenbergMapper:
         dists = dict(zip(labels, all_dists))
 
         # Get dictionary keys for interactions
-        for k in unique_site_ids:  # pylint: disable=C0206
+        for k in unique_site_ids:
             i = k[0]
             i_key = unique_site_ids[k]
             connected_sites = sgraph.get_connected_sites(i)

--- a/pymatgen/analysis/molecule_matcher.py
+++ b/pymatgen/analysis/molecule_matcher.py
@@ -21,6 +21,10 @@ import re
 import numpy as np
 from monty.dev import requires
 from monty.json import MSONable
+from scipy.optimize import linear_sum_assignment
+from scipy.spatial.distance import cdist
+
+from pymatgen.core.structure import Molecule
 
 try:
     from openbabel import openbabel
@@ -29,10 +33,6 @@ try:
 except ImportError:
     openbabel = None
 
-from scipy.optimize import linear_sum_assignment
-from scipy.spatial.distance import cdist
-
-from pymatgen.core.structure import Molecule  # pylint: disable=ungrouped-imports
 
 __author__ = "Xiaohui Qu, Adam Fekete"
 __version__ = "1.0"
@@ -84,7 +84,7 @@ class AbstractMolAtomMapper(MSONable, metaclass=abc.ABCMeta):
     def from_dict(cls, d):
         """
         Args:
-            d (): Dict.
+            d (dict): Dict representation.
 
         Returns:
             AbstractMolAtomMapper

--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -1943,7 +1943,7 @@ class ReactionDiagram:
                     coeffs = np.linalg.solve(matrix, comp_vec2)
 
                     x = coeffs[-1]
-                    # pylint: disable=R1716
+
                     if all(c >= -tol for c in coeffs) and (abs(sum(coeffs[:-1]) - 1) < tol) and (tol < x < 1 - tol):
                         c1 = x / r1.num_atoms
                         c2 = (1 - x) / r2.num_atoms
@@ -3433,7 +3433,7 @@ class PDPlotter:
             error = stable_marker_plot.error_y["array"]
 
             points = np.append(x, [y, error]).reshape(3, -1).T
-            points = points[points[:, 0].argsort()]  # sort by composition  # pylint: disable=E1136
+            points = points[points[:, 0].argsort()]  # sort by composition
 
             # these steps trace out the boundary pts of the uncertainty window
             outline = points[:, :2].copy()

--- a/pymatgen/analysis/piezo_sensitivity.py
+++ b/pymatgen/analysis/piezo_sensitivity.py
@@ -211,7 +211,7 @@ class InternalStrainTensor:
                     uniq_point_ops.append(op)
 
         IST_operations = []
-        for atom in range(len(self.ist)):  # pylint: disable=C0200
+        for atom in range(len(self.ist)):
             IST_operations.append([])
             for j in range(atom):
                 for op in uniq_point_ops:
@@ -304,7 +304,7 @@ class ForceConstantMatrix:
 
         passed = []
         relations = []
-        for atom1 in range(len(self.fcm)):  # pylint: disable=C0200
+        for atom1 in range(len(self.fcm)):
             for atom2 in range(atom1, len(self.fcm)):
                 unique = 1
                 eig1, _vecs1 = np.linalg.eig(self.fcm[atom1][atom2])

--- a/pymatgen/analysis/quasiharmonic.py
+++ b/pymatgen/analysis/quasiharmonic.py
@@ -287,7 +287,7 @@ class QuasiharmonicDebyeApprox:
             float: unitless
         """
         if isinstance(self.eos, PolynomialEOS):
-            p = np.poly1d(self.eos.eos_params)  # pylint: disable=E1101
+            p = np.poly1d(self.eos.eos_params)
             # first derivative of energy at 0K wrt volume evaluated at the
             # given volume, in eV/Ang^3
             dEdV = np.polyder(p, 1)(volume)

--- a/pymatgen/analysis/structure_matcher.py
+++ b/pymatgen/analysis/structure_matcher.py
@@ -518,7 +518,7 @@ class StructureMatcher(MSONable):
         # vectors are from s2 to s1
         vecs, d_2 = pbc_shortest_vectors(avg_lattice, s2, s1, mask, return_d2=True, lll_frac_tol=lll_frac_tol)
         lin = LinearAssignment(d_2)
-        sol = lin.solution  # pylint: disable=E1101
+        sol = lin.solution
         short_vecs = vecs[np.arange(len(sol)), sol]
         translation = np.average(short_vecs, axis=0)
         f_translation = avg_lattice.get_fractional_coords(translation)
@@ -744,7 +744,7 @@ class StructureMatcher(MSONable):
         if (not self._subset) and mask.shape[1] != mask.shape[0]:
             return None
 
-        if LinearAssignment(mask).min_cost > 0:  # pylint: disable=E1101
+        if LinearAssignment(mask).min_cost > 0:
             return None
 
         best_match = None
@@ -763,7 +763,7 @@ class StructureMatcher(MSONable):
                     lll_frac_tol = inv_lll_abc * self.stol / (np.pi * normalization)
                     dist, t_adj, mapping = self._cart_dists(s1fc, t_s2fc, avg_l, mask, normalization, lll_frac_tol)
                     val = np.linalg.norm(dist) / len(dist) ** 0.5 if use_rms else max(dist)
-                    # pylint: disable=E1136
+
                     if best_match is None or val < best_match[0]:
                         total_t = t + t_adj
                         total_t -= np.round(total_t)

--- a/pymatgen/analysis/wulff.py
+++ b/pymatgen/analysis/wulff.py
@@ -420,7 +420,7 @@ class WulffShape:
         r_range = max(np.linalg.norm(x) for x in wulff_pt_list)
         ax_3d.set_xlim([-r_range * 1.1, r_range * 1.1])
         ax_3d.set_ylim([-r_range * 1.1, r_range * 1.1])
-        ax_3d.set_zlim([-r_range * 1.1, r_range * 1.1])  # pylint: disable=E1101
+        ax_3d.set_zlim([-r_range * 1.1, r_range * 1.1])
         # add legend
         if legend_on:
             if show_area:
@@ -522,7 +522,7 @@ class WulffShape:
 
             # remove duplicate x y z pts to save time
             all_xyz = []
-            # pylint: disable=E1133,E1136
+
             [all_xyz.append(list(coord)) for coord in np.array([x_pts, y_pts, z_pts]).T if list(coord) not in all_xyz]
             all_xyz = np.array(all_xyz).T
             x_pts, y_pts, z_pts = all_xyz[0], all_xyz[1], all_xyz[2]

--- a/pymatgen/apps/battery/conversion_battery.py
+++ b/pymatgen/apps/battery/conversion_battery.py
@@ -92,7 +92,7 @@ class ConversionElectrode(AbstractElectrode):
             for i in range(len(profile) - 1)
         ]
 
-        return ConversionElectrode(  # pylint: disable=E1123
+        return ConversionElectrode(
             voltage_pairs=v_pairs,
             working_ion_entry=working_ion_entry,
             initial_comp_formula=comp.reduced_formula,
@@ -137,7 +137,7 @@ class ConversionElectrode(AbstractElectrode):
         # _initial_comp_formula = comp.reduced_formula, framework_formula = framework.reduced_formula
         if adjacent_only:
             return [
-                ConversionElectrode(  # pylint: disable=E1123
+                ConversionElectrode(
                     voltage_pairs=self.voltage_pairs[i : i + 1],
                     working_ion_entry=self.working_ion_entry,
                     initial_comp_formula=self.initial_comp_formula,
@@ -149,7 +149,7 @@ class ConversionElectrode(AbstractElectrode):
         for i in range(len(self.voltage_pairs)):
             for j in range(i, len(self.voltage_pairs)):
                 sub_electrodes.append(
-                    ConversionElectrode(  # pylint: disable=E1123
+                    ConversionElectrode(
                         voltage_pairs=self.voltage_pairs[i : j + 1],
                         working_ion_entry=self.working_ion_entry,
                         initial_comp_formula=self.initial_comp_formula,
@@ -354,7 +354,7 @@ class ConversionVoltagePair(AbstractVoltagePair):
         entries_charge = step1["entries"]
         entries_discharge = step2["entries"]
 
-        return ConversionVoltagePair(  # pylint: disable=E1123
+        return ConversionVoltagePair(
             rxn=rxn,
             voltage=voltage,
             mAh=mAh,

--- a/pymatgen/apps/battery/insertion_battery.py
+++ b/pymatgen/apps/battery/insertion_battery.py
@@ -107,7 +107,7 @@ class InsertionElectrode(AbstractElectrode):
             for i in range(len(_stable_entries) - 1)
         )
         framework = _vpairs[0].framework
-        return cls(  # pylint: disable=E1123
+        return cls(
             voltage_pairs=_vpairs,
             working_ion_entry=_working_ion_entry,
             stable_entries=_stable_entries,
@@ -367,7 +367,7 @@ class InsertionElectrode(AbstractElectrode):
         from monty.json import MontyDecoder
 
         dec = MontyDecoder()
-        return InsertionElectrode(  # pylint: disable=E1120
+        return InsertionElectrode(
             dec.process_decoded(d["entries"]),
             dec.process_decoded(d["working_ion_entry"]),
         )
@@ -475,7 +475,7 @@ class InsertionVoltagePair(AbstractVoltagePair):
         _frac_charge = comp_charge.get_atomic_fraction(working_element)
         _frac_discharge = comp_discharge.get_atomic_fraction(working_element)
 
-        vpair = InsertionVoltagePair(  # pylint: disable=E1123
+        vpair = InsertionVoltagePair(
             voltage=_voltage,
             mAh=_mAh,
             mass_charge=_mass_charge,

--- a/pymatgen/command_line/critic2_caller.py
+++ b/pymatgen/command_line/critic2_caller.py
@@ -602,7 +602,6 @@ class Critic2Analysis(MSONable):
         Returns:
             dict: with "volume" and "charge" keys, or None if YT integration not performed
         """
-        # pylint: disable=E1101
         if not self._node_values:
             return None
         return self._node_values[idx]

--- a/pymatgen/command_line/enumlib_caller.py
+++ b/pymatgen/command_line/enumlib_caller.py
@@ -351,7 +351,7 @@ class EnumlibAdaptor:
             )
             inv_org_latt = np.linalg.inv(original_latt.matrix)
         else:
-            ordered_structure = None  # to fix pylint E0601
+            ordered_structure = None
             inv_org_latt = None
 
         for file in glob("vasp.*"):

--- a/pymatgen/command_line/mcsqs_caller.py
+++ b/pymatgen/command_line/mcsqs_caller.py
@@ -123,12 +123,12 @@ def run_mcsqs(
         for i in range(instances):
             instance_cmd = [f"-ip {i + 1}"]
             cmd = mcsqs_find_sqs_cmd + add_ons + instance_cmd
-            process = Popen(cmd)  # pylint: disable=R1732
+            process = Popen(cmd)
             mcsqs_find_sqs_processes.append(process)
     else:
         # run normal mcsqs command
         cmd = mcsqs_find_sqs_cmd + add_ons
-        process = Popen(cmd)  # pylint: disable=R1732
+        process = Popen(cmd)
         mcsqs_find_sqs_processes.append(process)
 
     try:
@@ -136,7 +136,7 @@ def run_mcsqs(
             process.communicate(timeout=search_time * 60)
 
         if instances and instances > 1:
-            process = Popen(["mcsqs", "-best"])  # pylint: disable=R1732
+            process = Popen(["mcsqs", "-best"])
             process.communicate()
 
         if os.path.exists("bestsqs.out") and os.path.exists("bestcorr.out"):
@@ -157,7 +157,7 @@ def run_mcsqs(
                     "is search_time sufficient or are number of instances too high?"
                 )
 
-            process = Popen(["mcsqs", "-best"])  # pylint: disable=R1732
+            process = Popen(["mcsqs", "-best"])
             process.communicate()
 
         if os.path.exists("bestsqs.out") and os.path.exists("bestcorr.out"):

--- a/pymatgen/core/__init__.py
+++ b/pymatgen/core/__init__.py
@@ -1,4 +1,3 @@
-# pylint: disable=C0414,W0718,C0301
 # ruff: noqa: PLC0414
 """This package contains core modules and classes for representing structures and operations on them."""
 

--- a/pymatgen/core/lattice.py
+++ b/pymatgen/core/lattice.py
@@ -374,7 +374,6 @@ class Lattice(MSONable):
             Lattice.from_dict(fmt="abivars", acell=3*[10], rprim=np.eye(3))
         """
         if fmt == "abivars":
-            # pylint: disable=C0415
             from pymatgen.io.abinit.abiobjects import lattice_from_abivars
 
             kwargs.update(d)
@@ -986,7 +985,7 @@ class Lattice(MSONable):
         """
         # Transpose the lattice matrix first so that basis vectors are columns.
         # Makes life easier.
-        # pylint: disable=E1136,E1137,E1126
+
         a = self._matrix.copy().T
 
         b = np.zeros((3, 3))  # Vectors after the Gram-Schmidt process
@@ -1042,7 +1041,7 @@ class Lattice(MSONable):
                     # We have to do p/q, so do lstsq(q.T, p.T).T instead.
                     p = dot(a[:, k:3].T, b[:, (k - 2) : k])
                     q = np.diag(m[(k - 2) : k])  # type: ignore
-                    # pylint: disable=E1101
+
                     result = np.linalg.lstsq(q.T, p.T, rcond=None)[0].T  # type: ignore
                     u[k:3, (k - 2) : k] = result
 
@@ -1229,7 +1228,7 @@ class Lattice(MSONable):
         list_k_points = []
         for ii, jj, kk in itertools.product([-1, 0, 1], [-1, 0, 1], [-1, 0, 1]):
             list_k_points.append(ii * vec1 + jj * vec2 + kk * vec3)
-        # pylint: disable=C0415
+
         from scipy.spatial import Voronoi
 
         tess = Voronoi(list_k_points)
@@ -1334,7 +1333,6 @@ class Lattice(MSONable):
                 fcoords, dists, inds, image
         """
         try:
-            # pylint: disable=C0415
             from pymatgen.optimization.neighbors import find_points_in_spheres
         except ImportError:
             return self.get_points_in_sphere_py(frac_points=frac_points, center=center, r=r, zip_results=zip_results)
@@ -1499,7 +1497,7 @@ class Lattice(MSONable):
         # Determine distance from `center`
         cart_coords = self.get_cartesian_coords(fcoords)
         cart_images = self.get_cartesian_coords(images)
-        coords = cart_coords[:, None, None, None, :] + cart_images[None, :, :, :, :]  # pylint: disable=E1126
+        coords = cart_coords[:, None, None, None, :] + cart_images[None, :, :, :, :]
         coords -= center[None, None, None, None, :]
         coords **= 2
         d_2 = np.sum(coords, axis=4)
@@ -1664,7 +1662,7 @@ class Lattice(MSONable):
         recp_lattice = recp_lattice.scale(1)
         # need a localized import of structure to build a
         # pseudo empty lattice for SpacegroupAnalyzer
-        # pylint: disable=C0415
+
         from pymatgen.core.structure import Structure
         from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 

--- a/pymatgen/core/molecular_orbitals.py
+++ b/pymatgen/core/molecular_orbitals.py
@@ -49,10 +49,7 @@ class MolecularOrbitals:
                 raise ValueError("composition subscripts must be integers")
 
         self.elec_neg = self.max_electronegativity()
-        self.aos = {
-            str(el): [[str(el), k, v] for k, v in Element(el).atomic_orbitals.items()]  # pylint: disable=E1101
-            for el in self.elements
-        }
+        self.aos = {str(el): [[str(el), k, v] for k, v in Element(el).atomic_orbitals.items()] for el in self.elements}
         self.band_edges = self.obtain_band_edges()
 
     def max_electronegativity(self):

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -96,7 +96,7 @@ class Neighbor(Site):
 
     def as_dict(self) -> dict:  # type: ignore
         """Note that method calls the super of Site, which is MSONable itself."""
-        return super(Site, self).as_dict()  # pylint: disable=E1003
+        return super(Site, self).as_dict()
 
     @classmethod
     def from_dict(cls, dct: dict) -> Neighbor:  # type: ignore
@@ -108,7 +108,7 @@ class Neighbor(Site):
         Returns:
             Neighbor
         """
-        return super(Site, cls).from_dict(dct)  # pylint: disable=E1003
+        return super(Site, cls).from_dict(dct)
 
 
 class PeriodicNeighbor(PeriodicSite):
@@ -168,7 +168,7 @@ class PeriodicNeighbor(PeriodicSite):
 
     def as_dict(self) -> dict:  # type: ignore
         """Note that method calls the super of Site, which is MSONable itself."""
-        return super(Site, self).as_dict()  # pylint: disable=E1003
+        return super(Site, self).as_dict()
 
     @classmethod
     def from_dict(cls, d: dict) -> PeriodicNeighbor:  # type: ignore
@@ -180,7 +180,7 @@ class PeriodicNeighbor(PeriodicSite):
         Returns:
             PeriodicNeighbor
         """
-        return super(Site, cls).from_dict(d)  # pylint: disable=E1003
+        return super(Site, cls).from_dict(d)
 
 
 class SiteCollection(collections.abc.Sequence, metaclass=ABCMeta):

--- a/pymatgen/core/surface.py
+++ b/pymatgen/core/surface.py
@@ -775,7 +775,6 @@ class SlabGenerator:
             reorient_lattice (bool): reorients the lattice parameters such that
                 the c direction is the third vector of the lattice matrix
         """
-        # pylint: disable=E1130
         # Add Wyckoff symbols of the bulk, will help with
         # identifying types of sites in the slab system
         if (

--- a/pymatgen/core/tensors.py
+++ b/pymatgen/core/tensors.py
@@ -471,7 +471,6 @@ class Tensor(np.ndarray, MSONable):
         rotation = self.get_ieee_rotation(structure, refine_rotation)
         result = self.copy()
         if initial_fit:
-            # pylint: disable=E1101
             result = result.fit_to_structure(structure)
         return result.rotate(rotation, tol=1e-2)
 
@@ -615,7 +614,7 @@ class Tensor(np.ndarray, MSONable):
         converged = False
         test_new, test_old = [guess.copy()] * 2
         for idx in range(maxiter):
-            test_new = test_old.fit_to_structure(structure)  # pylint: disable=no-member
+            test_new = test_old.fit_to_structure(structure)
             if vsym:
                 test_new = test_new.voigt_symmetrized
             diff = np.abs(test_old - test_new)

--- a/pymatgen/core/units.py
+++ b/pymatgen/core/units.py
@@ -512,7 +512,6 @@ class ArrayWithUnit(np.ndarray):
         return tuple(reduce)
 
     def __setstate__(self, state):
-        # pylint: disable=E1101
         super().__setstate__(state["np_state"])
         self._unit = state["_unit"]
 
@@ -564,7 +563,6 @@ class ArrayWithUnit(np.ndarray):
         return self.__class__(np.array(self).__mul__(np.array(other)), unit=self.unit * other.unit)
 
     def __rmul__(self, other):
-        # pylint: disable=E1101
         if not hasattr(other, "unit_type"):
             return self.__class__(
                 np.array(self) * np.array(other),
@@ -574,7 +572,6 @@ class ArrayWithUnit(np.ndarray):
         return self.__class__(np.array(self) * np.array(other), unit=self.unit * other.unit)
 
     def __div__(self, other):
-        # pylint: disable=E1101
         if not hasattr(other, "unit_type"):
             return self.__class__(
                 np.array(self) / np.array(other),
@@ -584,7 +581,6 @@ class ArrayWithUnit(np.ndarray):
         return self.__class__(np.array(self) / np.array(other), unit=self.unit / other.unit)
 
     def __truediv__(self, other):
-        # pylint: disable=E1101
         if not hasattr(other, "unit_type"):
             return self.__class__(np.array(self) / np.array(other), unit_type=self._unit_type, unit=self._unit)
         return self.__class__(np.array(self) / np.array(other), unit=self.unit / other.unit)

--- a/pymatgen/electronic_structure/boltztrap.py
+++ b/pymatgen/electronic_structure/boltztrap.py
@@ -2169,7 +2169,7 @@ def read_cube_file(filename):
         energy_data = np.genfromtxt(filename, skip_header=natoms + 6, skip_footer=1)
         nlines_data = len(energy_data)
         last_line = np.genfromtxt(filename, skip_header=nlines_data + natoms + 6)
-        energy_data = np.append(energy_data.flatten(), last_line).reshape(n1, n2, n3)  # pylint: disable=E1121
+        energy_data = np.append(energy_data.flatten(), last_line).reshape(n1, n2, n3)
     elif "boltztrap_BZ.cube" in filename:
         energy_data = np.loadtxt(filename, skiprows=natoms + 6).reshape(n1, n2, n3)
 

--- a/pymatgen/electronic_structure/cohp.py
+++ b/pymatgen/electronic_structure/cohp.py
@@ -707,7 +707,7 @@ class CompleteCohp(Cohp):
             # may not be present when the cohpgenerator keyword is used
             # in LOBSTER versions 2.2.0 and earlier.
             # TODO: Test this more extensively
-            # pylint: disable=E1133,E1136
+
             for label in orb_res_cohp:
                 if cohp_file.cohp_data[label]["COHP"] is None:
                     cohp_data[label]["COHP"] = {
@@ -730,7 +730,7 @@ class CompleteCohp(Cohp):
             # Calculate the average COHP for the LMTO file to be
             # consistent with LOBSTER output.
             avg_data = {"COHP": {}, "ICOHP": {}}
-            for i in avg_data:  # pylint: disable=C0206
+            for i in avg_data:
                 for spin in spins:
                     rows = np.array([v[i][spin] for v in cohp_data.values()])
                     avg = np.average(rows, axis=0)

--- a/pymatgen/electronic_structure/core.py
+++ b/pymatgen/electronic_structure/core.py
@@ -71,7 +71,6 @@ class Orbital(Enum):
     @property
     def orbital_type(self):
         """Returns OrbitalType of an orbital."""
-        # pylint: disable=E1136
         return OrbitalType[self.name[0]]
 
 

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -147,7 +147,6 @@ class DosPlotter:
 
         import palettable
 
-        # pylint: disable=E1101
         colors = palettable.colorbrewer.qualitative.Set1_9.mpl_colors
 
         ys = None
@@ -1841,7 +1840,7 @@ class BSPlotterProjected(BSPlotter):
                         raise ValueError(f"The dictpa[{elt}] is empty. We cannot do anything")
                     _sites = self._bs.structure.sites
                     indices = []
-                    for i in range(len(_sites)):  # pylint: disable=C0200
+                    for i in range(len(_sites)):
                         if next(iter(_sites[i]._species)) == Element(elt):
                             indices.append(i + 1)
                     for number in dictpa[elt]:
@@ -1888,7 +1887,7 @@ class BSPlotterProjected(BSPlotter):
                             raise ValueError(f"The sum_atoms[{elt}] is empty. We cannot do anything")
                         _sites = self._bs.structure.sites
                         indices = []
-                        for i in range(len(_sites)):  # pylint: disable=C0200
+                        for i in range(len(_sites)):
                             if next(iter(_sites[i]._species)) == Element(elt):
                                 indices.append(i + 1)
                         for number in sum_atoms[elt]:
@@ -2012,7 +2011,7 @@ class BSPlotterProjected(BSPlotter):
                 if elt in sum_atoms:
                     _sites = self._bs.structure.sites
                     indices = []
-                    for i in range(len(_sites)):  # pylint: disable=C0200
+                    for i in range(len(_sites)):
                         if next(iter(_sites[i]._species)) == Element(elt):
                             indices.append(i + 1)
                     flag_1 = len(set(dictpa[elt]).intersection(indices))
@@ -2061,7 +2060,7 @@ class BSPlotterProjected(BSPlotter):
                 if elt in sum_atoms:
                     _sites = self._bs.structure.sites
                     indices = []
-                    for i in range(len(_sites)):  # pylint: disable=C0200
+                    for i in range(len(_sites)):
                         if next(iter(_sites[i]._species)) == Element(elt):
                             indices.append(i + 1)
                     flag_1 = len(set(dictpa[elt]).intersection(indices))
@@ -2518,7 +2517,7 @@ class BSDOSPlotter:
         """
         from matplotlib.collections import LineCollection
 
-        pts = np.array([k, e]).T.reshape(-1, 1, 2)  # pylint: disable=E1121
+        pts = np.array([k, e]).T.reshape(-1, 1, 2)
         seg = np.concatenate([pts[:-1], pts[1:]], axis=1)
 
         nseg = len(k) - 1
@@ -2664,12 +2663,12 @@ class BSDOSPlotter:
         # x = [n + 0.25 for n in x]  # nudge x coordinates
         # y = [n + (max_y - 1) for n in y]  # shift y coordinates to top
         # plot the triangle
-        inset_ax.scatter(x, y, s=7, marker=".", edgecolor=color)  # pylint: disable=E1101
-        inset_ax.set_xlim([-0.35, 1.00])  # pylint: disable=E1101
-        inset_ax.set_ylim([-0.35, 1.00])  # pylint: disable=E1101
+        inset_ax.scatter(x, y, s=7, marker=".", edgecolor=color)
+        inset_ax.set_xlim([-0.35, 1.00])
+        inset_ax.set_ylim([-0.35, 1.00])
 
         # add the labels
-        inset_ax.text(  # pylint: disable=E1101
+        inset_ax.text(
             0.70,
             -0.2,
             g_label,
@@ -2678,7 +2677,7 @@ class BSDOSPlotter:
             color=(0, 0, 0),
             horizontalalignment="left",
         )
-        inset_ax.text(  # pylint: disable=E1101
+        inset_ax.text(
             0.325,
             0.70,
             r_label,
@@ -2687,7 +2686,7 @@ class BSDOSPlotter:
             color=(0, 0, 0),
             horizontalalignment="center",
         )
-        inset_ax.text(  # pylint: disable=E1101
+        inset_ax.text(
             -0.05,
             -0.2,
             b_label,
@@ -2718,7 +2717,7 @@ class BSDOSPlotter:
             color.append([math.sqrt(c) for c in [1 - (i / 1000) ** 2, 0, (i / 1000) ** 2]])
 
         # plot the bar
-        # pylint: disable=E1101
+
         inset_ax.scatter(x, y, s=250.0, marker="s", c=color)
         inset_ax.set_xlim([-0.1, 1.7])
         inset_ax.text(
@@ -3935,9 +3934,9 @@ def plot_fermi_surface(
 
     if mlab_figure is None and not multiple_figure:
         fig = mlab.figure(size=(1024, 768), bgcolor=(1, 1, 1))
-        for iface in range(len(bz)):  # pylint: disable=C0200
+        for iface in range(len(bz)):
             for line in itertools.combinations(bz[iface], 2):
-                for jface in range(len(bz)):  # pylint: disable=C0200
+                for jface in range(len(bz)):
                     if (
                         iface < jface
                         and any(np.all(line[0] == x) for x in bz[jface])
@@ -3971,7 +3970,7 @@ def plot_fermi_surface(
         if multiple_figure:
             fig = mlab.figure(size=(1024, 768), bgcolor=(1, 1, 1))
 
-            for iface in range(len(bz)):  # pylint: disable=C0200
+            for iface in range(len(bz)):
                 for line in itertools.combinations(bz[iface], 2):
                     for jface in range(len(bz)):
                         if (
@@ -4047,7 +4046,7 @@ def plot_wigner_seitz(lattice, ax: plt.Axes = None, **kwargs):
     kwargs.setdefault("linewidth", 1)
 
     bz = lattice.get_wigner_seitz_cell()
-    for iface in range(len(bz)):  # pylint: disable=C0200
+    for iface in range(len(bz)):
         for line in itertools.combinations(bz[iface], 2):
             for jface in range(len(bz)):
                 if (

--- a/pymatgen/entries/computed_entries.py
+++ b/pymatgen/entries/computed_entries.py
@@ -655,7 +655,7 @@ class ComputedStructureEntry(ComputedEntry):
         dct = super().normalize(mode).as_dict()
         dct["structure"] = self.structure.as_dict()
         entry = self.from_dict(dct)
-        entry._composition /= factor  # pylint: disable=E1101
+        entry._composition /= factor
         return entry
 
     def copy(self) -> ComputedStructureEntry:

--- a/pymatgen/entries/mixing_scheme.py
+++ b/pymatgen/entries/mixing_scheme.py
@@ -319,7 +319,7 @@ class MaterialsProjectDFTMixingScheme(Compatibility):
         # run_type_1 entries that already exist in run_type_2 and correct other run_type_1
         # energies to have the same e_above_hull on the run_type_2 hull as they had on the run_type_1 hull
         if all(mixing_state_data[mixing_state_data["is_stable_1"]]["entry_id_2"].notna()):
-            if run_type in self.valid_rtypes_2:  # pylint: disable=R1705
+            if run_type in self.valid_rtypes_2:
                 # For run_type_2 entries, there is no correction
                 return adjustments
 
@@ -362,7 +362,7 @@ class MaterialsProjectDFTMixingScheme(Compatibility):
         # stable entries. Here, we can correct run_type_2 energies at certain compositions
         # to preserve their e_above_hull on the run_type_1 hull
         if any(mixing_state_data[mixing_state_data["is_stable_1"]]["entry_id_2"].notna()):
-            if run_type in self.valid_rtypes_1:  # pylint: disable=R1705
+            if run_type in self.valid_rtypes_1:
                 df_slice = mixing_state_data[mixing_state_data["entry_id_1"] == entry.entry_id]
 
                 if df_slice["entry_id_2"].notna().item():
@@ -441,7 +441,7 @@ class MaterialsProjectDFTMixingScheme(Compatibility):
                 f"because there are no {self.run_type_2} ground states at this composition."
             )
 
-        # this statement is here to make pylint happy by guaranteeing a return or raise
+        # this statement is here to guarantee a return or raise
         raise CompatibilityError(
             "WARNING! If you see this Exception it means you have encountered"
             f"an edge case in {type(self).__name__}. Inspect your input carefully and post a bug report."

--- a/pymatgen/ext/matproj_legacy.py
+++ b/pymatgen/ext/matproj_legacy.py
@@ -1016,7 +1016,6 @@ class _MPResterLegacy:
                     )
                     break
                 except MPRestError as e:
-                    # pylint: disable=E1101
                     match = re.search(r"error status code (\d+)", str(e))
                     if match:
                         if not match.group(1).startswith("5"):

--- a/pymatgen/io/abinit/abiobjects.py
+++ b/pymatgen/io/abinit/abiobjects.py
@@ -1,5 +1,5 @@
 #
-# pylint: disable=no-member, chained-comparison
+
 """Low-level objects providing an abstraction for the objects involved in the calculation."""
 
 from __future__ import annotations

--- a/pymatgen/io/abinit/abitimer.py
+++ b/pymatgen/io/abinit/abitimer.py
@@ -168,7 +168,7 @@ class AbinitTimerParser(collections.abc.Iterable):
             elif line.startswith(self.END_TAG):
                 inside = 0
                 timer = AbinitTimer(sections, info, cpu_time, wall_time)
-                mpi_rank = info["mpi_rank"]  # pylint: disable=E1136
+                mpi_rank = info["mpi_rank"]
                 data[mpi_rank] = timer
 
             elif inside:

--- a/pymatgen/io/abinit/netcdf.py
+++ b/pymatgen/io/abinit/netcdf.py
@@ -1,5 +1,5 @@
 #
-# pylint: disable=no-member
+
 """Wrapper for netCDF readers."""
 
 from __future__ import annotations

--- a/pymatgen/io/abinit/pseudos.py
+++ b/pymatgen/io/abinit/pseudos.py
@@ -138,7 +138,7 @@ class Pseudo(MSONable, metaclass=abc.ABCMeta):
 
     def to_str(self, verbose=0) -> str:
         """String representation."""
-        # pylint: disable=E1101
+
         lines: list[str] = []
         app = lines.append
         app(f"<{type(self).__name__}: {self.basename}>")
@@ -230,7 +230,7 @@ class Pseudo(MSONable, metaclass=abc.ABCMeta):
 
     def compute_md5(self):
         """Compute and return MD5 hash value."""
-        # pylint: disable=E1101
+
         import hashlib
 
         with open(self.path) as fh:
@@ -287,7 +287,7 @@ class Pseudo(MSONable, metaclass=abc.ABCMeta):
             tmpdir: If None, a new temporary directory is created and files are copied here
                 else tmpdir is used.
         """
-        # pylint: disable=E1101
+
         import shutil
         import tempfile
 
@@ -311,13 +311,13 @@ class Pseudo(MSONable, metaclass=abc.ABCMeta):
     @property
     def has_dojo_report(self):
         """True if the pseudo has an associated `DOJO_REPORT` section."""
-        # pylint: disable=E1101
+
         return hasattr(self, "dojo_report") and self.dojo_report
 
     @property
     def djrepo_path(self):
         """The path of the djrepo file. None if file does not exist."""
-        # pylint: disable=E1101
+
         root, ext = os.path.splitext(self.filepath)
         return root + ".djrepo"
         # if os.path.exists(path): return path
@@ -332,7 +332,7 @@ class Pseudo(MSONable, metaclass=abc.ABCMeta):
         Args:
             accuracy: ["low", "normal", "high"]
         """
-        # pylint: disable=E1101
+
         if not self.has_dojo_report:
             return Hint(ecut=0.0, pawecutdg=0.0)
 
@@ -490,28 +490,24 @@ class AbinitPseudo(Pseudo):
 
     @property
     def Z(self):
-        # pylint: disable=E1101
         return self._zatom
 
     @property
     def Z_val(self):
-        # pylint: disable=E1101
         return self._zion
 
     @property
     def l_max(self):
-        # pylint: disable=E1101
         return self._lmax
 
     @property
     def l_local(self):
-        # pylint: disable=E1101
         return self._lloc
 
     @property
     def supports_soc(self):
         # Treat ONCVPSP pseudos
-        # pylint: disable=E1101
+
         if self._pspcod == 8:
             switch = self.header["extension_switch"]
             if switch in (0, 1):
@@ -535,28 +531,24 @@ class NcAbinitPseudo(NcPseudo, AbinitPseudo):
 
     @property
     def Z(self):
-        # pylint: disable=E1101
         return self._zatom
 
     @property
     def Z_val(self):
         """Number of valence electrons."""
-        # pylint: disable=E1101
+
         return self._zion
 
     @property
     def l_max(self):
-        # pylint: disable=E1101
         return self._lmax
 
     @property
     def l_local(self):
-        # pylint: disable=E1101
         return self._lloc
 
     @property
     def nlcc_radius(self):
-        # pylint: disable=E1101
         return self._rchrg
 
 
@@ -565,7 +557,6 @@ class PawAbinitPseudo(PawPseudo, AbinitPseudo):
 
     @property
     def paw_radius(self):
-        # pylint: disable=E1101
         return self._r_cut
 
     # def orbitals(self):
@@ -1200,7 +1191,7 @@ class PawXmlSetup(Pseudo, PawPseudo):
         Args:
             filepath (str): Path to the XML file.
         """
-        # pylint: disable=E1101
+
         self.path = os.path.abspath(filepath)
 
         # Get the XML root (this trick is used to that the object is pickleable).
@@ -1347,7 +1338,7 @@ class PawXmlSetup(Pseudo, PawPseudo):
 
     def _parse_radfunc(self, func_name):
         """Parse the first occurrence of func_name in the XML file."""
-        # pylint: disable=E1101
+
         node = self.root.find(func_name)
         grid = node.attrib["grid"]
         values = np.array([float(s) for s in node.text.split()])
@@ -1356,7 +1347,7 @@ class PawXmlSetup(Pseudo, PawPseudo):
 
     def _parse_all_radfuncs(self, func_name):
         """Parse all the nodes with tag func_name in the XML file."""
-        # pylint: disable=E1101
+
         for node in self.root.findall(func_name):
             grid = node.attrib["grid"]
             values = np.array([float(s) for s in node.text.split()])
@@ -1453,7 +1444,7 @@ class PawXmlSetup(Pseudo, PawPseudo):
         Returns:
             plt.Figure: matplotlib figure
         """
-        # pylint: disable=E1101
+
         ax, fig = get_ax_fig(ax)
 
         ax.grid(visible=True)
@@ -1484,7 +1475,7 @@ class PawXmlSetup(Pseudo, PawPseudo):
         Returns:
             plt.Figure: matplotlib figure
         """
-        # pylint: disable=E1101
+
         ax, fig = get_ax_fig(ax)
         ax.grid(visible=True)
         ax.set_xlabel("r [Bohr]")

--- a/pymatgen/io/fiesta.py
+++ b/pymatgen/io/fiesta.py
@@ -226,7 +226,7 @@ class BasisSetReader:
         parse_preamble = False
         parse_lmax_nnlo = False
         parse_nl_orbital = False
-        nnlo = None  # fix pylint E0601: Using variable 'nnlo' before assignment
+        nnlo = None
         lmax = None
 
         for line in input.split("\n"):

--- a/pymatgen/io/lammps/data.py
+++ b/pymatgen/io/lammps/data.py
@@ -696,14 +696,14 @@ class LammpsData(MSONable):
                 df = pd.read_csv(sio, header=None, comment="#", delim_whitespace=True)
                 if kw == "PairIJ Coeffs":
                     names = ["id1", "id2"] + [f"coeff{i}" for i in range(1, df.shape[1] - 1)]
-                    df.index.name = None  # pylint: disable=E1101
+                    df.index.name = None
                 elif kw in SECTION_HEADERS:
                     names = ["id"] + SECTION_HEADERS[kw]
                 elif kw == "Atoms":
                     names = ["id"] + ATOMS_HEADERS[atom_style]
-                    if df.shape[1] == len(names):  # pylint: disable=E1101
+                    if df.shape[1] == len(names):
                         pass
-                    elif df.shape[1] == len(names) + 3:  # pylint: disable=E1101
+                    elif df.shape[1] == len(names) + 3:
                         names += ["nx", "ny", "nz"]
                     else:
                         raise ValueError(f"Format in Atoms section inconsistent with {atom_style=}")

--- a/pymatgen/io/lammps/generators.py
+++ b/pymatgen/io/lammps/generators.py
@@ -64,9 +64,7 @@ class BaseLammpsGenerator(InputGenerator):
     def __post_init__(self):
         self.settings = self.settings or {}
 
-    def get_input_set(  # type: ignore
-        self, structure: Structure | LammpsData | CombinedData | None  # pylint: disable=E1131
-    ) -> LammpsInputSet:
+    def get_input_set(self, structure: Structure | LammpsData | CombinedData | None) -> LammpsInputSet:  # type: ignore
         """Generate a LammpsInputSet from the structure/data, tailored to the template file."""
         data = LammpsData.from_structure(structure) if isinstance(structure, Structure) else structure
 

--- a/pymatgen/io/lammps/sets.py
+++ b/pymatgen/io/lammps/sets.py
@@ -45,8 +45,8 @@ class LammpsInputSet(InputSet):
 
     def __init__(
         self,
-        inputfile: LammpsInputFile | str,  # pylint: disable=E1131
-        data: LammpsData | CombinedData,  # pylint: disable=E1131
+        inputfile: LammpsInputFile | str,
+        data: LammpsData | CombinedData,
         calc_type: str = "",
         template_file: str = "",
         keep_stages: bool = False,
@@ -73,7 +73,7 @@ class LammpsInputSet(InputSet):
         super().__init__(inputs={"in.lammps": self.inputfile, "system.data": self.data})
 
     @classmethod
-    def from_directory(cls, directory: str | Path, keep_stages: bool = False) -> Self:  # pylint: disable=E1131
+    def from_directory(cls, directory: str | Path, keep_stages: bool = False) -> Self:
         """
         Construct a LammpsInputSet from a directory of two or more files.
         TODO: accept directories with only the input file, that should include the structure as well.

--- a/pymatgen/io/lmto.py
+++ b/pymatgen/io/lmto.py
@@ -190,7 +190,7 @@ class LMTOCtrl:
         structure_tokens = {"ALAT": None, "PLAT": [], "CLASS": [], "SITE": []}
 
         for cat in ["STRUC", "CLASS", "SITE"]:
-            fields = struct_lines[cat].split("=")  # pylint: disable=E1101
+            fields = struct_lines[cat].split("=")
             for f, field in enumerate(fields):
                 token = field.split()[-1]
                 if token == "ALAT":

--- a/pymatgen/io/nwchem.py
+++ b/pymatgen/io/nwchem.py
@@ -265,7 +265,7 @@ $theory_spec
         title = title if title is not None else f"{formula} {theory} {operation}"
 
         charge = charge if charge is not None else mol.charge
-        n_electrons = -charge + mol.charge + mol.nelectrons  # pylint: disable=E1130
+        n_electrons = -charge + mol.charge + mol.nelectrons
         if spin_multiplicity is not None:
             if (n_electrons + spin_multiplicity) % 2 != 1:
                 raise ValueError(f"{charge=} and {spin_multiplicity=} is not possible for this molecule")
@@ -738,7 +738,6 @@ class NwOutput:
         time = 0
 
         for line in output.split("\n"):
-            # pylint: disable=E1136
             for e, v in error_defs.items():
                 if line.find(e) != -1:
                     errors.append(v)

--- a/pymatgen/io/qchem/outputs.py
+++ b/pymatgen/io/qchem/outputs.py
@@ -1176,7 +1176,7 @@ class QCOutput(MSONable):
             )
             table_pattern = r"\s*\d+\s+[a-zA-Z]+\s*([\d\-\.]+)\s*([\d\-\.]+)\s*([\d\-\.]+)\s*"
             footer_pattern = r"\s*-+"
-        else:  # pylint: disable=line-too-long
+        else:
             header_pattern = (
                 r"Finished Iterative Coordinate Back-Transformation\s+-+\s+Standard Nuclear Orientation "
                 r"\(Angstroms\)\s+I\s+Atom\s+X\s+Y\s+Z\s+-+"

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -2982,7 +2982,7 @@ class Outcar:
 
     def read_pseudo_zval(self):
         """Create pseudopotential ZVAL dictionary."""
-        # pylint: disable=E1101
+
         try:
 
             def atom_symbols(results, match):
@@ -3248,7 +3248,7 @@ class VolumetricData(BaseVolumetricData):
         Returns:
             (poscar, data)
         """
-        # pylint: disable=E1136,E1126
+
         poscar_read = False
         poscar_string = []
         dataset = []
@@ -3576,7 +3576,7 @@ class Procar:
             done = False
             spin = Spin.down
             weights = None
-            # pylint: disable=E1137
+
             for line in file_handle:
                 line = line.strip()
                 if bandexpr.match(line):
@@ -3855,7 +3855,6 @@ class Xdatcar:
         if ionicstep_end is not None and ionicstep_start < 1:
             raise Exception("End ionic step cannot be less than 1")
 
-        # pylint: disable=E1136
         ionicstep_cnt = 1
         with zopen(filename, "rt") as file:
             for line in file:
@@ -3950,7 +3949,6 @@ class Xdatcar:
         if ionicstep_end is not None and ionicstep_start < 1:
             raise Exception("End ionic step cannot be less than 1")
 
-        # pylint: disable=E1136
         ionicstep_cnt = 1
         with zopen(filename, "rt") as f:
             for line in f:

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -93,7 +93,7 @@ class VaspInputSet(MSONable, metaclass=abc.ABCMeta):
     @property
     def potcar_symbols(self):
         """List of POTCAR symbols."""
-        # pylint: disable=E1101
+
         elements = self.poscar.site_symbols
         potcar_symbols = []
         settings = self._config_dict["POTCAR"]

--- a/pymatgen/phonon/plotter.py
+++ b/pymatgen/phonon/plotter.py
@@ -128,7 +128,7 @@ class PhononDosPlotter:
 
         import palettable
 
-        colors = palettable.colorbrewer.qualitative.Set1_9.mpl_colors  # pylint: disable=E1101
+        colors = palettable.colorbrewer.qualitative.Set1_9.mpl_colors
 
         y = None
         all_densities = []

--- a/pymatgen/symmetry/site_symmetries.py
+++ b/pymatgen/symmetry/site_symmetries.py
@@ -33,7 +33,7 @@ def get_site_symmetries(struct: Structure, precision: float = 0.1) -> list[list[
         # Place the origin of the cell at each atomic site
         point_ops.append([])
 
-        for idx2, site2 in enumerate(struct):  # pylint: disable=C0200
+        for idx2, site2 in enumerate(struct):
             temp_struct.replace(
                 idx2,
                 site2.specie,

--- a/pymatgen/transformations/advanced_transformations.py
+++ b/pymatgen/transformations/advanced_transformations.py
@@ -2163,7 +2163,7 @@ class MonteCarloRattleTransformation(AbstractTransformation):
             # we store that the original seed was None
             seed = np.random.randint(1, 1000000000)
 
-        self.random_state = np.random.RandomState(seed)  # pylint: disable=E1101
+        self.random_state = np.random.RandomState(seed)
         self.kwargs = kwargs
 
     def apply_transformation(self, structure: Structure) -> Structure:

--- a/pymatgen/util/coord.py
+++ b/pymatgen/util/coord.py
@@ -113,7 +113,6 @@ def coord_list_mapping_pbc(subset, superset, atol=1e-8, pbc=(True, True, True)):
     Returns:
         list of indices such that superset[indices] = subset
     """
-    # pylint: disable=I1101
     atol = np.ones(3) * atol
     return coord_cython.coord_list_mapping_pbc(subset, superset, atol, pbc)
 
@@ -203,7 +202,6 @@ def pbc_shortest_vectors(lattice, fcoords1, fcoords2, mask=None, return_d2: bool
         array of displacement vectors from fcoords1 to fcoords2
         first index is fcoords1 index, second is fcoords2 index
     """
-    # pylint: disable=I1101
     return coord_cython.pbc_shortest_vectors(lattice, fcoords1, fcoords2, mask, return_d2)
 
 
@@ -262,7 +260,6 @@ def is_coord_subset_pbc(subset, superset, atol=1e-8, mask=None, pbc: tuple = (Tr
     Returns:
         bool: True if all of subset is in superset.
     """
-    # pylint: disable=I1101
     c1 = np.array(subset, dtype=np.float64)
     c2 = np.array(superset, dtype=np.float64)
     m = np.array(mask, dtype=int) if mask is not None else np.zeros((len(subset), len(superset)), dtype=int)

--- a/pymatgen/util/num.py
+++ b/pymatgen/util/num.py
@@ -33,6 +33,6 @@ def make_symmetric_matrix_from_upper_tri(val):
     mask = ~np.tri(3, k=-1, dtype=bool)
     out = np.zeros((3, 3), dtype=val.dtype)
     out[mask] = val
-    # pylint: disable=E1137
+
     out.T[mask] = val
     return out

--- a/pymatgen/util/plotting.py
+++ b/pymatgen/util/plotting.py
@@ -94,7 +94,6 @@ def pretty_plot_two_axis(
     Returns:
         matplotlib.pyplot
     """
-    # pylint: disable=E1101
     import palettable.colorbrewer.diverging
 
     colors = palettable.colorbrewer.diverging.RdYlBu_4.mpl_colors

--- a/tasks.py
+++ b/tasks.py
@@ -246,5 +246,5 @@ def open_doc(ctx):
 
 @task
 def lint(ctx):
-    for cmd in ["ruff", "mypy", "black", "pylint"]:
+    for cmd in ["ruff", "mypy", "black"]:
         ctx.run(f"{cmd} pymatgen")

--- a/tests/analysis/test_surface_analysis.py
+++ b/tests/analysis/test_surface_analysis.py
@@ -404,7 +404,7 @@ def load_O_adsorption():
         entries = json.loads(entries.read())
     for key in entries:
         entry = ComputedStructureEntry.from_dict(entries[key])
-        for el in metals_O_entry_dict:  # pylint: disable=C0206
+        for el in metals_O_entry_dict:
             if el in key:
                 if "111" in key:
                     clean = SlabEntry(entry.structure, entry.energy, (1, 1, 1), label=key + "_clean")

--- a/tests/core/test_composition.py
+++ b/tests/core/test_composition.py
@@ -392,7 +392,7 @@ class TestComposition(PymatgenTest):
         assert (self.comps[3] + {"Fe": 4, "O": 4}).formula == "Li4 Fe4 O8", "Incorrect composition after addition!"
 
         Fe = Element("Fe")
-        assert self.comps[0].__add__(Fe) == NotImplemented  # pylint: disable=C2801
+        assert self.comps[0].__add__(Fe) == NotImplemented
 
     def test_sub(self):
         assert (
@@ -409,7 +409,7 @@ class TestComposition(PymatgenTest):
         assert len((c1 - c2).elements) == 1
 
         Fe = Element("Fe")
-        assert self.comps[0].__add__(Fe) == NotImplemented  # pylint: disable=C2801
+        assert self.comps[0].__add__(Fe) == NotImplemented
 
     def test_mul(self):
         assert (self.comps[0] * 4).formula == "Li12 Fe8 P12 O48"


### PR DESCRIPTION
Since we're no longer using `pylint`. All handled by `ruff` now.