### PR TITLE
`MatPESStaticSet.yaml` set `LMAXMIX: 6`

### DIFF
--- a/pymatgen/io/vasp/MatPESStaticSet.yaml
+++ b/pymatgen/io/vasp/MatPESStaticSet.yaml
@@ -23,6 +23,7 @@ INCAR:
   PREC: Accurate
   SIGMA: 0.05 # change from 0.02 to 0.05, included to have some reasonable default
   LDAU: false
+  LMAXMIX: 6
   LDAUJ:
     F:
       Co: 0

--- a/tests/io/vasp/test_sets.py
+++ b/tests/io/vasp/test_sets.py
@@ -96,9 +96,10 @@ class TestSetChangeCheck(PymatgenTest):
     def test_sets_changed(self):
         msg = (
             "WARNING! These tests will fail when you change an input set. They are included "
-            "as a sanity check: if you want to change an input set, please make sure to "
+            "as a sanity check. When changing an input set, please make sure to "
             "notify the users for that set. For sets starting with 'MVL' this is @shyuep, for "
-            "sets starting with 'MP' this is @shyuep and @mkhorton. "
+            "sets starting with 'MP' this is @shyuep and @mkhorton. For sets starting with 'MatPES' "
+            "this is @shyuep and @janosh."
         )
 
         input_sets = glob(f"{MODULE_DIR}/*.yaml")
@@ -110,22 +111,21 @@ class TestSetChangeCheck(PymatgenTest):
                 hashes[name] = hashlib.sha1(text).hexdigest()
 
         known_hashes = {
+            "MatPESStaticSet.yaml": "8789f974913c935f21ff2fbffc0502714ca39470",
+            "MITRelaxSet.yaml": "1a0970f8cad9417ec810f7ab349dc854eaa67010",
+            "MPAbsorptionSet.yaml": "5931e1cb3cf8ba809b3d4f4a5960d728c682adf1",
+            "MPHSERelaxSet.yaml": "0d0d96a620461071cfd416ec9d5d6a8d2dfd0855",
+            "MPRelaxSet.yaml": "f2949cdc5dc8cd0bee6d39a5df0d6a6b7c144821",
+            "MPSCANRelaxSet.yaml": "2d31ee637cb5d4d96f2e0aba3772a52cbcceb348",
             "MVLGWSet.yaml": "104ae93c3b3be19a13b0ee46ebdd0f40ceb96597",
             "MVLRelax52Set.yaml": "4cfc6b1bd0548e45da3bde4a9c65b3249da13ecd",
-            "MPHSERelaxSet.yaml": "0d0d96a620461071cfd416ec9d5d6a8d2dfd0855",
-            "VASPIncarBase.yaml": "19762515f8deefb970f2968fca48a0d67f7964d4",
-            "MPSCANRelaxSet.yaml": "2d31ee637cb5d4d96f2e0aba3772a52cbcceb348",
-            "MPRelaxSet.yaml": "f2949cdc5dc8cd0bee6d39a5df0d6a6b7c144821",
-            "MITRelaxSet.yaml": "1a0970f8cad9417ec810f7ab349dc854eaa67010",
-            "vdW_parameters.yaml": "04bb09bb563d159565bcceac6a11e8bdf0152b79",
-            "MPAbsorptionSet.yaml": "5931e1cb3cf8ba809b3d4f4a5960d728c682adf1",
-            "MatPESStaticSet.yaml": "3a7cfef8143dbe32d3856c6945eb9ac9bd8b85c6",
             "PBE54Base.yaml": "ec317781a7f344beb54c17a228db790c0eb49282",
+            "VASPIncarBase.yaml": "19762515f8deefb970f2968fca48a0d67f7964d4",
+            "vdW_parameters.yaml": "04bb09bb563d159565bcceac6a11e8bdf0152b79",
         }
 
-        assert hashes == known_hashes, msg
         for input_set in hashes:
-            assert hashes[input_set] == known_hashes[input_set], msg
+            assert hashes[input_set] == known_hashes[input_set], f"{input_set} got {hashes[input_set]}\n\n{msg}"
 
 
 class TestDictSet(PymatgenTest):
@@ -775,6 +775,7 @@ class TestMatPESStaticSet(PymatgenTest):
         assert incar["NSW"] == 0
         assert incar["PREC"] == "Accurate"
         assert incar["SIGMA"] == 0.05
+        assert incar["LMAXMIX"] == 6
         # test POTCAR files are default PBE_54 PSPs and functional
         assert input_set.potcar_symbols == ["Fe_pv", "P", "O"]
         assert input_set.potcar.functional == "PBE_54"
@@ -785,7 +786,7 @@ class TestMatPESStaticSet(PymatgenTest):
     def test_with_prev_incar(self):
         default_prev = MatPESStaticSet(structure=self.struct, prev_incar=self.prev_incar)
         incar = default_prev.incar
-        # test if prev_incar is used.
+        # check that prev_incar is used.
         assert incar["NPAR"] == 8
         assert incar["LMAXMIX"] == 4
         # test some incar parameters from prev_incar are not inherited


### PR DESCRIPTION
`LMAXMIX` is used to expand the charge densities up to spherical harmonics of order $Y_{lm}$ with $l$ = LMAXMIX, $l$ = 2 for p-block, 4 for d-block, 6 for f-block, etc.

Internal benchmarking by @esoteric-ephemera found little run time cost but improved energies from `LMAXMIX = 6`. See pages 7 and 8 in [2023-09-27-kaplan-bench-vasp-params.pdf](https://github.com/materialsproject/pymatgen/files/12873823/2023-09-27-kaplan-bench-vasp-params.pdf).