### PR TITLE
Fix type annotations in phonon/ and lammps/

### DIFF
--- a/pymatgen/io/lammps/data.py
+++ b/pymatgen/io/lammps/data.py
@@ -37,7 +37,7 @@ from pymatgen.util.io_utils import clean_lines
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-    from typing import Any, Self
+    from typing import Any
 
     from pymatgen.core.sites import Site
     from pymatgen.core.structure import SiteCollection
@@ -639,7 +639,7 @@ class LammpsData(MSONable):
         return self.box, ff, topo_list
 
     @classmethod
-    def from_file(cls, filename: str, atom_style: str = "full", sort_id: bool = False) -> Self:
+    def from_file(cls, filename: str, atom_style: str = "full", sort_id: bool = False) -> LammpsData:
         """
         Constructor that parses a file.
 
@@ -1204,7 +1204,7 @@ class ForceField(MSONable):
             yaml.dump(d, f)
 
     @classmethod
-    def from_file(cls, filename: str) -> Self:
+    def from_file(cls, filename: str) -> ForceField:
         """
         Constructor that reads in a file in YAML format.
 
@@ -1217,7 +1217,7 @@ class ForceField(MSONable):
         return cls.from_dict(d)
 
     @classmethod
-    def from_dict(cls, d: dict) -> Self:
+    def from_dict(cls, d: dict) -> ForceField:
         """
         Constructor that reads in a dictionary.
 
@@ -1416,7 +1416,7 @@ class CombinedData(LammpsData):
         return df
 
     @classmethod
-    def from_files(cls, coordinate_file: str, list_of_numbers: list, *filenames) -> Self:
+    def from_files(cls, coordinate_file: str, list_of_numbers: list, *filenames) -> CombinedData:
         """
         Constructor that parse a series of data file.
 
@@ -1442,7 +1442,7 @@ class CombinedData(LammpsData):
     @classmethod
     def from_lammpsdata(
         cls, mols: list, names: list, list_of_numbers: list, coordinates: pd.DataFrame, atom_style: str | None = None
-    ) -> Self:
+    ) -> CombinedData:
         """
         Constructor that can infer atom_style.
         The input LammpsData objects are used non-destructively.

--- a/pymatgen/io/lammps/inputs.py
+++ b/pymatgen/io/lammps/inputs.py
@@ -27,7 +27,6 @@ from pymatgen.io.template import TemplateInputGen
 
 if TYPE_CHECKING:
     from os import PathLike
-    from typing import Self
 
     from pymatgen.io.core import InputSet
 
@@ -539,7 +538,7 @@ class LammpsInputFile(InputFile):
 
     @classmethod
     @np.deprecate(message="Use from_str instead")
-    def from_string(cls, *args, **kwargs) -> Self:
+    def from_string(cls, *args, **kwargs) -> LammpsInputFile:
         return cls.from_str(*args, **kwargs)
 
     @classmethod
@@ -918,7 +917,7 @@ class LammpsRun(MSONable):
         temperature: float,
         nsteps: int,
         other_settings: dict | None = None,
-    ) -> Self:
+    ) -> LammpsRun:
         r"""
         Example for a simple MD run based on template md.template.
 

--- a/pymatgen/io/lammps/outputs.py
+++ b/pymatgen/io/lammps/outputs.py
@@ -18,7 +18,7 @@ from monty.json import MSONable
 from pymatgen.io.lammps.data import LammpsBox
 
 if TYPE_CHECKING:
-    from typing import Any, Self
+    from typing import Any
 
 __author__ = "Kiran Mathew, Zhi Deng"
 __copyright__ = "Copyright 2018, The Materials Virtual Lab"
@@ -48,11 +48,11 @@ class LammpsDump(MSONable):
 
     @classmethod
     @np.deprecate(message="Use from_str instead")
-    def from_string(cls, *args, **kwargs) -> Self:
+    def from_string(cls, *args, **kwargs) -> LammpsDump:
         return cls.from_str(*args, **kwargs)
 
     @classmethod
-    def from_str(cls, string: str) -> Self:
+    def from_str(cls, string: str) -> LammpsDump:
         """
         Constructor from string parsing.
 
@@ -76,7 +76,7 @@ class LammpsDump(MSONable):
         return cls(timestep, n_atoms, box, data)
 
     @classmethod
-    def from_dict(cls, d: dict) -> Self:
+    def from_dict(cls, d: dict) -> LammpsDump:
         """
         Args:
             d (dict): Dict representation.

--- a/pymatgen/io/lammps/sets.py
+++ b/pymatgen/io/lammps/sets.py
@@ -19,7 +19,6 @@ from pymatgen.io.lammps.inputs import LammpsInputFile
 
 if TYPE_CHECKING:
     from pathlib import Path
-    from typing import Self
 
 __author__ = "Ryan Kingsbury, Guillaume Brunin (Matgenix)"
 __copyright__ = "Copyright 2021, The Materials Project"
@@ -73,7 +72,7 @@ class LammpsInputSet(InputSet):
         super().__init__(inputs={"in.lammps": self.inputfile, "system.data": self.data})
 
     @classmethod
-    def from_directory(cls, directory: str | Path, keep_stages: bool = False) -> Self:
+    def from_directory(cls, directory: str | Path, keep_stages: bool = False) -> LammpsInputSet:
         """
         Construct a LammpsInputSet from a directory of two or more files.
         TODO: accept directories with only the input file, that should include the structure as well.

--- a/pymatgen/phonon/bandstructure.py
+++ b/pymatgen/phonon/bandstructure.py
@@ -14,7 +14,6 @@ from pymatgen.electronic_structure.bandstructure import Kpoint
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from os import PathLike
-    from typing import Self
 
     from numpy.typing import ArrayLike
 
@@ -263,7 +262,7 @@ class PhononBandStructure(MSONable):
         return dct
 
     @classmethod
-    def from_dict(cls, dct) -> Self:
+    def from_dict(cls, dct) -> PhononBandStructure:
         """
         Args:
             dct (dict): Dict representation.
@@ -592,7 +591,7 @@ class PhononBandStructureSymmLine(PhononBandStructure):
         return dct
 
     @classmethod
-    def from_dict(cls, dct: dict) -> Self:
+    def from_dict(cls, dct: dict) -> PhononBandStructureSymmLine:
         """
         Args:
             dct: Dict representation.

--- a/pymatgen/phonon/dos.py
+++ b/pymatgen/phonon/dos.py
@@ -14,7 +14,6 @@ from pymatgen.util.coord import get_linear_interpolated_value
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-    from typing import Self
 
 BOLTZ_THZ_PER_K = const.value("Boltzmann constant in Hz/K") / const.tera  # Boltzmann constant in THz/K
 THZ_TO_J = const.value("hertz-joule relationship") * const.tera
@@ -63,7 +62,7 @@ class PhononDos(MSONable):
 
         return gaussian_filter1d(self.densities, sigma / avgdiff)
 
-    def __add__(self, other: Self) -> Self:
+    def __add__(self, other: PhononDos) -> PhononDos:
         """Adds two DOS together. Checks that frequency scales are the same.
         Otherwise, a ValueError is thrown.
 
@@ -78,7 +77,7 @@ class PhononDos(MSONable):
         densities = self.densities + other.densities
         return PhononDos(self.frequencies, densities)
 
-    def __radd__(self, other: Self) -> Self:
+    def __radd__(self, other: PhononDos) -> PhononDos:
         """Reflected addition of two DOS objects.
 
         Args:
@@ -105,7 +104,7 @@ class PhononDos(MSONable):
         return "\n".join(stringarray)
 
     @classmethod
-    def from_dict(cls, d: dict[str, Sequence]) -> Self:
+    def from_dict(cls, d: dict[str, Sequence]) -> PhononDos:
         """Returns PhononDos object from dict representation of PhononDos."""
         return cls(d["frequencies"], d["densities"])
 
@@ -344,7 +343,7 @@ class CompletePhononDos(PhononDos):
         return {el: PhononDos(self.frequencies, densities) for el, densities in el_dos.items()}
 
     @classmethod
-    def from_dict(cls, dct: dict) -> Self:
+    def from_dict(cls, dct: dict) -> CompletePhononDos:
         """Returns CompleteDos object from dict representation."""
         tdos = PhononDos.from_dict(dct)
         struct = Structure.from_dict(dct["structure"])

--- a/pymatgen/phonon/ir_spectra.py
+++ b/pymatgen/phonon/ir_spectra.py
@@ -19,7 +19,6 @@ from pymatgen.vis.plotters import SpectrumPlotter
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from os import PathLike
-    from typing import Self
 
     from matplotlib.axes import Axes
     from numpy.typing import ArrayLike
@@ -59,7 +58,7 @@ class IRDielectricTensor(MSONable):
         self.epsilon_infinity = np.array(epsilon_infinity)
 
     @classmethod
-    def from_dict(cls, dct: dict) -> Self:
+    def from_dict(cls, dct: dict) -> IRDielectricTensor:
         """Returns IRDielectricTensor from dict representation."""
         structure = Structure.from_dict(dct["structure"])
         oscillator_strength = dct["oscillator_strength"]

--- a/pymatgen/phonon/thermal_displacements.py
+++ b/pymatgen/phonon/thermal_displacements.py
@@ -17,7 +17,6 @@ from pymatgen.util.due import Doi, due
 
 if TYPE_CHECKING:
     from os import PathLike
-    from typing import Self
 
     from numpy.typing import ArrayLike
 
@@ -250,7 +249,9 @@ class ThermalDisplacementMatrices(MSONable):
         description="Angle: A new tool for validating theoretically derived anisotropic displacement "
         "parameters with experiment.",
     )
-    def compute_directionality_quality_criterion(self, other: Self) -> list:
+    def compute_directionality_quality_criterion(
+        self, other: ThermalDisplacementMatrices
+    ) -> list[dict[str, ArrayLike]]:
         """Will compute directionality of prolate displacement ellipsoids as described in
         https://doi.org/10.1039/C9CE00794F with the earlier implementation: https://github.com/damMroz/Angle/.
 


### PR DESCRIPTION
## Summary

Major changes:

- Revert `Self` usage from #3393 and #3379 as mentioned by @janosh 

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
