### PR TITLE
Remove warning in cohp module

### DIFF
--- a/pymatgen/electronic_structure/cohp.py
+++ b/pymatgen/electronic_structure/cohp.py
@@ -152,8 +152,6 @@ class Cohp(MSONable):
         spin: Spin
         limit: -COHP smaller -limit will be considered.
         """
-        warnings.warn("This method has not been tested on many examples. Check the parameter limit, pls!")
-
         populations = self.cohp
         number_energies_below_efermi = len([x for x in self.energies if x <= self.efermi])
 


### PR DESCRIPTION
This PR removes an out-dated warning from the cohp module.  It would be great if this could be merged. Thanks!