### PR TITLE
Deprecate `CifParser.get_structures()` in favor of new `parse_structures` in which `primitive`  defaults to `False`

### DIFF
--- a/pymatgen/alchemy/materials.py
+++ b/pymatgen/alchemy/materials.py
@@ -269,7 +269,7 @@ class TransformedStructure(MSONable):
                 extracted. Defaults to True. However, there are certain
                 instances where you might want to use a non-primitive cell,
                 e.g., if you are trying to generate all possible orderings of
-                partial removals or order a disordered structure.
+                partial removals or order a disordered structure. Defaults to True.
             occupancy_tolerance (float): If total occupancy of a site is
                 between 1 and occupancy_tolerance, the occupancies will be
                 scaled down to 1.
@@ -281,7 +281,7 @@ class TransformedStructure(MSONable):
         raw_string = re.sub(r"'", '"', cif_string)
         cif_dict = parser.as_dict()
         cif_keys = list(cif_dict)
-        struct = parser.get_structures(primitive)[0]
+        struct = parser.parse_structures(primitive=primitive)[0]
         partial_cif = cif_dict[cif_keys[0]]
         if "_database_code_ICSD" in partial_cif:
             source = partial_cif["_database_code_ICSD"] + "-ICSD"

--- a/pymatgen/analysis/chemenv/utils/scripts_utils.py
+++ b/pymatgen/analysis/chemenv/utils/scripts_utils.py
@@ -240,7 +240,7 @@ def compute_environments(chemenv_configuration):
             if not found:
                 input_source = input("Enter path to CIF file : ")
             parser = CifParser(input_source)
-            structure = parser.get_structures()[0]
+            structure = parser.parse_structures(primitive=True)[0]
         elif source_type == "mp":
             if not found:
                 input_source = input('Enter materials project id (e.g. "mp-1902") : ')

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -2346,11 +2346,14 @@ class IStructure(SiteCollection, MSONable):
                 for a in factors(det):
                     for e in factors(det // a):
                         g = det // a // e
-                        yield det, np.array(
-                            [
-                                [[a, b, c], [0, e, f], [0, 0, g]]
-                                for b, c, f in itertools.product(range(a), range(a), range(e))
-                            ]
+                        yield (
+                            det,
+                            np.array(
+                                [
+                                    [[a, b, c], [0, e, f], [0, 0, g]]
+                                    for b, c, f in itertools.product(range(a), range(a), range(e))
+                                ]
+                            ),
                         )
 
         # we can't let sites match to their neighbors in the supercell
@@ -2764,7 +2767,7 @@ class IStructure(SiteCollection, MSONable):
             from pymatgen.io.cif import CifParser
 
             parser = CifParser.from_str(input_string, **kwargs)
-            struct = parser.get_structures(primitive=primitive)[0]
+            struct = parser.parse_structures(primitive=primitive)[0]
         elif fmt_low == "poscar":
             from pymatgen.io.vasp import Poscar
 
@@ -3391,7 +3394,9 @@ class IMolecule(SiteCollection, MSONable):
         centered_coords = self.cart_coords - self.center_of_mass + offset
 
         for i, j, k in itertools.product(
-            list(range(images[0])), list(range(images[1])), list(range(images[2]))  # type: ignore
+            list(range(images[0])),
+            list(range(images[1])),
+            list(range(images[2])),  # type: ignore
         ):
             box_center = [(i + 0.5) * a, (j + 0.5) * b, (k + 0.5) * c]
             if random_rotation:

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -43,6 +43,7 @@ from pymatgen.util.coord import all_distances, get_angle, lattice_points_in_supe
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator, Sequence
+    from pathlib import Path
 
     from ase import Atoms
     from ase.calculators.calculator import Calculator
@@ -2811,7 +2812,9 @@ class IStructure(SiteCollection, MSONable):
         return cls.from_sites(struct, properties=struct.properties)
 
     @classmethod
-    def from_file(cls, filename, primitive=False, sort=False, merge_tol=0.0, **kwargs) -> Structure | IStructure:
+    def from_file(
+        cls, filename: str | Path, primitive: bool = False, sort: bool = False, merge_tol: float = 0.0, **kwargs
+    ) -> Structure | IStructure:
         """Reads a structure from a file. For example, anything ending in
         a "cif" is assumed to be a Crystallographic Information Format file.
         Supported formats include CIF, POSCAR/CONTCAR, CHGCAR, LOCPOT,
@@ -2819,7 +2822,7 @@ class IStructure(SiteCollection, MSONable):
 
         Args:
             filename (str): The filename to read from.
-            primitive (bool): Whether to convert to a primitive cell. Only available for CIFs. Defaults to False.
+            primitive (bool): Whether to convert to a primitive cell. Defaults to False.
             sort (bool): Whether to sort sites. Default to False.
             merge_tol (float): If this is some positive number, sites that are within merge_tol from each other will be
                 merged. Usually 0.01 should be enough to deal with common numerical issues.

--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -1139,7 +1139,7 @@ class CifParser:
 
     def get_structures(
         self,
-        primitive: bool = True,
+        primitive: bool = False,
         symmetrized: bool = False,
         check_occu: bool = True,
         on_error: Literal["ignore", "warn", "raise"] = "warn",
@@ -1147,8 +1147,8 @@ class CifParser:
         """Return list of structures in CIF file.
 
         Args:
-            primitive (bool): Set to False to return conventional unit cells.
-                Defaults to True. With magnetic CIF files, will return primitive
+            primitive (bool): Set to True to return primitive unit cells.
+                Defaults to False. With magnetic CIF files, True will return primitive
                 magnetic cell which may be larger than nuclear primitive cell.
             symmetrized (bool): If True, return a SymmetrizedStructure which will
                 include the equivalent indices and symmetry operations used to
@@ -1331,18 +1331,18 @@ class CifWriter:
                 # primitive to conventional structures, the standard for CIF.
                 struct = sf.get_refined_structure()
 
-        latt = struct.lattice
+        lattice = struct.lattice
         comp = struct.composition
         no_oxi_comp = comp.element_composition
         block["_symmetry_space_group_name_H-M"] = spacegroup[0]
         for cell_attr in ["a", "b", "c"]:
-            block["_cell_length_" + cell_attr] = format_str.format(getattr(latt, cell_attr))
+            block["_cell_length_" + cell_attr] = format_str.format(getattr(lattice, cell_attr))
         for cell_attr in ["alpha", "beta", "gamma"]:
-            block["_cell_angle_" + cell_attr] = format_str.format(getattr(latt, cell_attr))
+            block["_cell_angle_" + cell_attr] = format_str.format(getattr(lattice, cell_attr))
         block["_symmetry_Int_Tables_number"] = spacegroup[1]
         block["_chemical_formula_structural"] = no_oxi_comp.reduced_formula
         block["_chemical_formula_sum"] = no_oxi_comp.formula
-        block["_cell_volume"] = format_str.format(latt.volume)
+        block["_cell_volume"] = format_str.format(lattice.volume)
 
         reduced_comp, fu = no_oxi_comp.get_reduced_composition_and_factor()
         block["_cell_formula_units_Z"] = str(int(fu))
@@ -1408,7 +1408,7 @@ class CifWriter:
 
                     magmom = Magmom(mag)
                     if write_magmoms and abs(magmom) > 0:
-                        moment = Magmom.get_moment_relative_to_crystal_axes(magmom, latt)
+                        moment = Magmom.get_moment_relative_to_crystal_axes(magmom, lattice)
                         atom_site_moment_label.append(f"{sp.symbol}{count}")
                         atom_site_moment_crystalaxis_x.append(format_str.format(moment[0]))
                         atom_site_moment_crystalaxis_y.append(format_str.format(moment[1]))

--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -1141,12 +1141,13 @@ class CifParser:
     @np.deprecate(
         message="get_structures is deprecated and will be removed in 2024. Use parse_structures instead."
         "The only difference is that primitive defaults to False in the new parse_structures method."
-        "So parse_structures(primitive=True) is equivalent to get_structures().",
+        "So parse_structures(primitive=True) is equivalent to the old behavior of get_structures().",
     )
     def get_structures(self, *args, **kwargs) -> list[Structure]:
         """
         Deprecated. Use parse_structures instead. Only difference between the two methods is the
         default primitive=False in parse_structures.
+        So parse_structures(primitive=True) is equivalent to the old behavior of get_structures().
         """
         if len(args) > 0:  # extract primitive if passed as arg
             kwargs["primitive"] = args[0]

--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -8,6 +8,7 @@ import re
 import textwrap
 import warnings
 from collections import deque
+from datetime import datetime
 from functools import partial
 from inspect import getfullargspec as getargspec
 from io import StringIO
@@ -1168,6 +1169,14 @@ class CifParser:
         Returns:
             list[Structure]: All structures in CIF file.
         """
+        if os.getenv("CI") and datetime.now() > datetime(2024, 3, 1):  # March 2024 seems long enough # pragma: no cover
+            raise RuntimeError("remove the change of default primitive=True to False made on 2023-10-24")
+        warnings.warn(
+            "The default value of primitive was changed from True to False in "
+            "https://github.com/materialsproject/pymatgen/pull/3419. CifParser now returns the cell "
+            "in the CIF file as is. If you want the primitive cell, please set primitive=True explicitly.",
+            UserWarning,
+        )
         if not check_occu:  # added in https://github.com/materialsproject/pymatgen/pull/2836
             warnings.warn("Structures with unphysical site occupancies are not compatible with many pymatgen features.")
         if primitive and symmetrized:

--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -1148,6 +1148,9 @@ class CifParser:
         Deprecated. Use parse_structures instead. Only difference between the two methods is the
         default primitive=False in parse_structures.
         """
+        if len(args) > 0:  # extract primitive if passed as arg
+            kwargs["primitive"] = args[0]
+            args = args[1:]
         kwargs.setdefault("primitive", True)
         return self.parse_structures(*args, **kwargs)
 

--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -54,7 +54,7 @@ class CifBlock:
     attribute.
     """
 
-    maxlen = 70  # not quite 80 so we can deal with semicolons and things
+    max_len = 70  # not quite 80 so we can deal with semicolons and things
 
     def __init__(self, data, loops, header):
         """
@@ -95,7 +95,7 @@ class CifBlock:
             if key not in written:
                 # k didn't belong to a loop
                 v = self._format_field(self.data[key])
-                if len(key) + len(v) + 3 < self.maxlen:
+                if len(key) + len(v) + 3 < self.max_len:
                     out.append(f"{key}   {v}")
                 else:
                     out.extend([key, v])
@@ -111,7 +111,7 @@ class CifBlock:
                 if val[0] == ";":
                     out += line + "\n" + val
                     line = "\n"
-                elif len(line) + len(val) + 2 < self.maxlen:
+                elif len(line) + len(val) + 2 < self.max_len:
                     line += "  " + val
                 else:
                     out += line
@@ -121,8 +121,8 @@ class CifBlock:
 
     def _format_field(self, v):
         v = str(v).strip()
-        if len(v) > self.maxlen:
-            return ";\n" + textwrap.fill(v, self.maxlen) + "\n;"
+        if len(v) > self.max_len:
+            return ";\n" + textwrap.fill(v, self.max_len) + "\n;"
         # add quotes if necessary
         if v == "":
             return '""'
@@ -1138,7 +1138,20 @@ class CifParser:
             return struct
         return None
 
-    def get_structures(
+    @np.deprecate(
+        message="get_structures is deprecated and will be removed in 2024. Use parse_structures instead."
+        "The only difference is that primitive defaults to False in the new parse_structures method."
+        "So parse_structures(primitive=True) is equivalent to get_structures().",
+    )
+    def get_structures(self, *args, **kwargs) -> list[Structure]:
+        """
+        Deprecated. Use parse_structures instead. Only difference between the two methods is the
+        default primitive=False in parse_structures.
+        """
+        kwargs.setdefault("primitive", True)
+        return self.parse_structures(*args, **kwargs)
+
+    def parse_structures(
         self,
         primitive: bool = False,
         symmetrized: bool = False,

--- a/pymatgen/io/feff/inputs.py
+++ b/pymatgen/io/feff/inputs.py
@@ -209,8 +209,8 @@ class Header(MSONable):
         Returns:
             Header Object
         """
-        r = CifParser(cif_file)
-        structure = r.get_structures()[0]
+        parser = CifParser(cif_file)
+        structure = parser.parse_structures(primitive=True)[0]
         return Header(structure, source, comment)
 
     @property

--- a/tests/analysis/magnetism/test_analyzer.py
+++ b/tests/analysis/magnetism/test_analyzer.py
@@ -15,7 +15,6 @@ from pymatgen.analysis.magnetism import (
     magnetic_deformation,
 )
 from pymatgen.core import Element, Lattice, Species, Structure
-from pymatgen.io.cif import CifParser
 from pymatgen.util.testing import TEST_FILES_DIR
 
 enum_cmd = which("enum.x") or which("multienum.x")
@@ -25,45 +24,40 @@ enumlib_present = enum_cmd and makestr_cmd
 
 class TestCollinearMagneticStructureAnalyzer(unittest.TestCase):
     def setUp(self):
-        parser = CifParser(f"{TEST_FILES_DIR}/Fe.cif")
-        self.Fe = parser.get_structures()[0]
+        self.Fe = Structure.from_file(f"{TEST_FILES_DIR}/Fe.cif", primitive=True)
 
-        parser = CifParser(f"{TEST_FILES_DIR}/LiFePO4.cif")
-        self.LiFePO4 = parser.get_structures()[0]
+        self.LiFePO4 = Structure.from_file(f"{TEST_FILES_DIR}/LiFePO4.cif", primitive=True)
 
-        parser = CifParser(f"{TEST_FILES_DIR}/Fe3O4.cif")
-        self.Fe3O4 = parser.get_structures()[0]
+        self.Fe3O4 = Structure.from_file(f"{TEST_FILES_DIR}/Fe3O4.cif", primitive=True)
 
-        parser = CifParser(f"{TEST_FILES_DIR}/magnetic.ncl.example.GdB4.mcif")
-        self.GdB4 = parser.get_structures()[0]
+        self.GdB4 = Structure.from_file(f"{TEST_FILES_DIR}/magnetic.ncl.example.GdB4.mcif", primitive=True)
 
-        parser = CifParser(f"{TEST_FILES_DIR}/magnetic.example.NiO.mcif")
-        self.NiO_expt = parser.get_structures()[0]
+        self.NiO_expt = Structure.from_file(f"{TEST_FILES_DIR}/magnetic.example.NiO.mcif", primitive=True)
 
-        latt = Lattice.cubic(4.17)
+        lattice = Lattice.cubic(4.17)
         species = ["Ni", "O"]
         coords = [[0, 0, 0], [0.5, 0.5, 0.5]]
-        self.NiO = Structure.from_spacegroup(225, latt, species, coords)
+        self.NiO = Structure.from_spacegroup(225, lattice, species, coords)
 
-        latt = Lattice([[2.085, 2.085, 0.0], [0.0, -2.085, -2.085], [-2.085, 2.085, -4.17]])
+        lattice = Lattice([[2.085, 2.085, 0.0], [0.0, -2.085, -2.085], [-2.085, 2.085, -4.17]])
         species = ["Ni", "Ni", "O", "O"]
         coords = [[0.5, 0, 0.5], [0, 0, 0], [0.25, 0.5, 0.25], [0.75, 0.5, 0.75]]
-        self.NiO_AFM_111 = Structure(latt, species, coords, site_properties={"magmom": [-5, 5, 0, 0]})
+        self.NiO_AFM_111 = Structure(lattice, species, coords, site_properties={"magmom": [-5, 5, 0, 0]})
 
-        latt = Lattice([[2.085, 2.085, 0], [0, 0, -4.17], [-2.085, 2.085, 0]])
+        lattice = Lattice([[2.085, 2.085, 0], [0, 0, -4.17], [-2.085, 2.085, 0]])
         species = ["Ni", "Ni", "O", "O"]
         coords = [[0.5, 0.5, 0.5], [0, 0, 0], [0, 0.5, 0], [0.5, 0, 0.5]]
-        self.NiO_AFM_001 = Structure(latt, species, coords, site_properties={"magmom": [-5, 5, 0, 0]})
+        self.NiO_AFM_001 = Structure(lattice, species, coords, site_properties={"magmom": [-5, 5, 0, 0]})
 
-        latt = Lattice([[2.085, 2.085, 0], [0, 0, -4.17], [-2.085, 2.085, 0]])
+        lattice = Lattice([[2.085, 2.085, 0], [0, 0, -4.17], [-2.085, 2.085, 0]])
         species = ["Ni", "Ni", "O", "O"]
         coords = [[0.5, 0.5, 0.5], [0, 0, 0], [0, 0.5, 0], [0.5, 0, 0.5]]
-        self.NiO_AFM_001_opposite = Structure(latt, species, coords, site_properties={"magmom": [5, -5, 0, 0]})
+        self.NiO_AFM_001_opposite = Structure(lattice, species, coords, site_properties={"magmom": [5, -5, 0, 0]})
 
-        latt = Lattice([[2.085, 2.085, 0], [0, 0, -4.17], [-2.085, 2.085, 0]])
+        lattice = Lattice([[2.085, 2.085, 0], [0, 0, -4.17], [-2.085, 2.085, 0]])
         species = ["Ni", "Ni", "O", "O"]
         coords = [[0.5, 0.5, 0.5], [0, 0, 0], [0, 0.5, 0], [0.5, 0, 0.5]]
-        self.NiO_unphysical = Structure(latt, species, coords, site_properties={"magmom": [-3, 0, 0, 0]})
+        self.NiO_unphysical = Structure(lattice, species, coords, site_properties={"magmom": [-3, 0, 0, 0]})
 
     def test_get_representations(self):
         # tests to convert between storing magnetic moment information

--- a/tests/analysis/magnetism/test_jahnteller.py
+++ b/tests/analysis/magnetism/test_jahnteller.py
@@ -6,7 +6,7 @@ import numpy as np
 from pytest import approx
 
 from pymatgen.analysis.magnetism.jahnteller import JahnTellerAnalyzer, Species
-from pymatgen.io.cif import CifParser
+from pymatgen.core import Structure
 from pymatgen.util.testing import TEST_FILES_DIR
 
 
@@ -82,11 +82,9 @@ class TestJahnTeller(unittest.TestCase):
         assert m == "none"
 
     def test_jahn_teller_structure_analysis(self):
-        parser = CifParser(f"{TEST_FILES_DIR}/LiFePO4.cif")
-        LiFePO4 = parser.get_structures()[0]
+        LiFePO4 = Structure.from_file(f"{TEST_FILES_DIR}/LiFePO4.cif", primitive=True)
 
-        parser = CifParser(f"{TEST_FILES_DIR}/Fe3O4.cif")
-        Fe3O4 = parser.get_structures()[0]
+        Fe3O4 = Structure.from_file(f"{TEST_FILES_DIR}/Fe3O4.cif", primitive=True)
 
         assert self.jt.is_jahn_teller_active(LiFePO4)
         assert self.jt.is_jahn_teller_active(Fe3O4)

--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -781,7 +781,7 @@ Direct
         struct = Structure.from_file(f"{TEST_FILES_DIR}/bad-unicode-gh-2947.mcif")
         assert struct.formula == "Ni32 O32"
 
-        # make sure CIfParser.get_structures() and Structure.from_file() are consistent
+        # make sure CIfParser.parse_structures() and Structure.from_file() are consistent
         # i.e. uses same merge_tol for site merging, same primitive=False, etc.
         assert struct == CifParser(f"{TEST_FILES_DIR}/bad-unicode-gh-2947.mcif").parse_structures()[0]
 

--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -28,6 +28,7 @@ from pymatgen.core.structure import (
 )
 from pymatgen.electronic_structure.core import Magmom
 from pymatgen.io.ase import AseAtomsAdaptor
+from pymatgen.io.cif import CifParser
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
 
@@ -779,6 +780,10 @@ Direct
         # https://github.com/materialsproject/pymatgen/issues/2947
         struct = Structure.from_file(f"{TEST_FILES_DIR}/bad-unicode-gh-2947.mcif")
         assert struct.formula == "Ni32 O32"
+
+        # make sure CIfParser.get_structures() and Structure.from_file() are consistent
+        # i.e. uses same merge_tol for site merging, same primitive=False, etc.
+        assert struct == CifParser(f"{TEST_FILES_DIR}/bad-unicode-gh-2947.mcif").get_structures()[0]
 
     def test_to_file_alias(self):
         out_path = f"{self.tmp_path}/POSCAR"

--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -783,7 +783,7 @@ Direct
 
         # make sure CIfParser.get_structures() and Structure.from_file() are consistent
         # i.e. uses same merge_tol for site merging, same primitive=False, etc.
-        assert struct == CifParser(f"{TEST_FILES_DIR}/bad-unicode-gh-2947.mcif").get_structures()[0]
+        assert struct == CifParser(f"{TEST_FILES_DIR}/bad-unicode-gh-2947.mcif").parse_structures()[0]
 
     def test_to_file_alias(self):
         out_path = f"{self.tmp_path}/POSCAR"

--- a/tests/ext/test_matproj.py
+++ b/tests/ext/test_matproj.py
@@ -23,7 +23,6 @@ from pymatgen.entries.compatibility import MaterialsProject2020Compatibility
 from pymatgen.entries.computed_entries import ComputedEntry
 from pymatgen.ext.matproj import MP_LOG_FILE, MPRestError, _MPResterBasic
 from pymatgen.ext.matproj_legacy import TaskType, _MPResterLegacy
-from pymatgen.io.cif import CifParser
 from pymatgen.phonon.bandstructure import PhononBandStructureSymmLine
 from pymatgen.phonon.dos import CompletePhononDos
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
@@ -129,8 +128,8 @@ class TestMPResterOld(PymatgenTest):
         cif_file = f"{TEST_FILES_DIR}/Fe3O4.cif"
         data = mpr.find_structure(str(cif_file))
         assert len(data) > 1
-        s = CifParser(cif_file).get_structures()[0]
-        data = mpr.find_structure(s)
+        struct = Structure.from_file(cif_file, primitive=True)
+        data = mpr.find_structure(struct)
         assert len(data) > 1
 
     def test_get_entries_in_chemsys(self):
@@ -623,15 +622,6 @@ class TestMPResterNewBasic:
     #     mpr = _MPResterLegacy()
     #     data = mpr.get_materials_id_references("mp-123")
     #     assert len(data) > 1000
-
-    # def test_find_structure(self):
-    #     mpr = _MPResterLegacy()
-    #     cif_file = f"{TEST_FILES_DIR}/Fe3O4.cif"
-    #     data = mpr.find_structure(str(cif_file))
-    #     assert len(data) > 1
-    #     s = CifParser(cif_file).get_structures()[0]
-    #     data = mpr.find_structure(s)
-    #     assert len(data) > 1
 
     def test_get_entries_and_in_chemsys(self):
         # One large system test.

--- a/tests/io/feff/test_inputs.py
+++ b/tests/io/feff/test_inputs.py
@@ -7,7 +7,6 @@ from numpy.testing import assert_allclose
 from pytest import approx
 
 from pymatgen.core import Molecule, Structure
-from pymatgen.io.cif import CifParser
 from pymatgen.io.feff.inputs import Atoms, Header, Paths, Potential, Tags
 from pymatgen.util.testing import TEST_FILES_DIR
 
@@ -59,8 +58,7 @@ class TestHeader(unittest.TestCase):
 class TestFeffAtoms(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        r = CifParser(f"{TEST_FILES_DIR}/CoO19128.cif")
-        cls.structure = r.get_structures()[0]
+        cls.structure = Structure.from_file(f"{TEST_FILES_DIR}/CoO19128.cif")
         cls.atoms = Atoms(cls.structure, "O", 12.0)
 
     def test_absorbing_atom(self):

--- a/tests/io/feff/test_sets.py
+++ b/tests/io/feff/test_sets.py
@@ -7,7 +7,6 @@ import pytest
 from numpy.testing import assert_allclose
 
 from pymatgen.core.structure import Lattice, Molecule, Structure
-from pymatgen.io.cif import CifParser
 from pymatgen.io.feff.inputs import Atoms, Header, Potential, Tags
 from pymatgen.io.feff.sets import FEFFDictSet, MPELNESSet, MPEXAFSSet, MPXANESSet
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
@@ -30,7 +29,7 @@ TITLE sites: 4
 * 3 O     0.333333     0.666667     0.121324
 * 4 O     0.666667     0.333333     0.621325"""
         cif_file = f"{TEST_FILES_DIR}/CoO19128.cif"
-        cls.structure = CifParser(cif_file).get_structures()[0]
+        cls.structure = Structure.from_file(cif_file, primitive=True)
         cls.absorbing_atom = "O"
         cls.mp_xanes = MPXANESSet(cls.absorbing_atom, cls.structure)
 
@@ -262,6 +261,6 @@ TITLE sites: 4
     def test_cluster_index(self):
         # https://github.com/materialsproject/pymatgen/pull/3256
         cif_file = f"{TEST_FILES_DIR}/Fe3O4.cif"
-        structure = CifParser(cif_file).get_structures()[0]
+        structure = Structure.from_file(cif_file)
         for idx in range(len(structure.species)):
             assert Atoms(structure, idx, 3).cluster

--- a/tests/io/test_cif.py
+++ b/tests/io/test_cif.py
@@ -185,7 +185,7 @@ class TestCifIO(PymatgenTest):
 
         parser = CifParser(f"{TEST_FILES_DIR}/Li2O.cif")
         prim = parser.get_structures()[0]
-        assert prim.formula == "Li2 O1"
+        assert prim.formula == "Li8 O4"
         conv = parser.get_structures(primitive=False)[0]
         assert conv.formula == "Li8 O4"
 
@@ -207,7 +207,7 @@ class TestCifIO(PymatgenTest):
         assert struct.lattice.gamma == approx(93)
 
         parser = CifParser(f"{TEST_FILES_DIR}/srycoo.cif")
-        assert parser.get_structures()[0].formula == "Sr5.6 Y2.4 Co8 O21"
+        assert parser.get_structures()[0].formula == "Sr11.2 Y4.8 Co16 O42"
 
         # Test with a decimal Xyz. This should parse as two atoms in
         # conventional cell if it is correct, one if not.
@@ -225,7 +225,7 @@ class TestCifIO(PymatgenTest):
 
     def test_site_symbol_preference(self):
         parser = CifParser(f"{TEST_FILES_DIR}/site_type_symbol_test.cif")
-        assert parser.get_structures()[0].formula == "Ge0.4 Sb0.4 Te1"
+        assert parser.get_structures()[0].formula == "Ge1.6 Sb1.6 Te4"
 
     def test_implicit_hydrogen(self):
         parser = CifParser(f"{TEST_FILES_DIR}/Senegalite_implicit_hydrogen.cif")
@@ -293,13 +293,16 @@ class TestCifIO(PymatgenTest):
         # Partial occupancy on sites, previously parsed as an ordered structure
         parser = CifParser(f"{TEST_FILES_DIR}/PF_sd_1011081.cif")
         for struct in parser.get_structures():
-            assert struct.formula == "Zr0.2 Nb0.8"
+            assert struct.formula == "Zr0.4 Nb1.6"
         assert parser.has_errors
 
         # Partial occupancy on sites, incorrect label, previously unparsable
         parser = CifParser(f"{TEST_FILES_DIR}/PF_sd_1615854.cif")
-        for struct in parser.get_structures():
-            assert struct.formula == "Na2 Al2 Si6 O16"
+        for idx, struct in enumerate(parser.get_structures()):
+            if idx == 0:
+                assert struct.formula == "Na2 Al2 Si6 O16"
+            else:
+                assert struct.formula == "Na4 Al4 Si12 O32"
         assert parser.has_errors
 
         # Partial occupancy on sites, incorrect label, previously unparsable
@@ -311,13 +314,13 @@ class TestCifIO(PymatgenTest):
         # Partial occupancy on sites, previously parsed as an ordered structure
         parser = CifParser(f"{TEST_FILES_DIR}/PF_sd_1908491.cif")
         for struct in parser.get_structures():
-            assert struct.formula == "Mn0.48 Zn0.52 Ga2 Se4"
+            assert struct.formula == "Mn0.96 Zn1.04 Ga4 Se8"
         assert parser.has_errors
 
         # Partial occupancy on sites, incorrect label, previously unparsable
         parser = CifParser(f"{TEST_FILES_DIR}/PF_sd_1811457.cif")
         for struct in parser.get_structures():
-            assert struct.formula == "Ba2 Mg0.6 Zr0.2 Ta1.2 O6"
+            assert struct.formula == "Ba8 Mg2.4 Zr0.8 Ta4.8 O24"
         assert parser.has_errors
 
         # Incomplete powder diffraction data, previously unparsable
@@ -327,8 +330,8 @@ class TestCifIO(PymatgenTest):
         # in CIFs from Springer Materials/Pauling file DBs, CifParser parses the
         # element as "Nh" (Nihonium).
         parser = CifParser(f"{TEST_FILES_DIR}/PF_sd_1002871.cif")
-        assert parser.get_structures()[0].formula == "Cu1 Br2 Nh6"
-        assert parser.get_structures()[1].formula == "Cu1 Br4 Nh6"
+        assert parser.get_structures()[0].formula == "Cu2 Br4 Nh12"
+        assert parser.get_structures()[1].formula == "Cu2 Br8 Nh12"
         assert parser.has_errors
 
         # Incomplete powder diffraction data, previously unparsable
@@ -346,7 +349,7 @@ class TestCifIO(PymatgenTest):
         # Unparsable species 'OH/OH2', previously parsed as "O"
         parser = CifParser(f"{TEST_FILES_DIR}/PF_sd_1601634.cif")
         for struct in parser.get_structures():
-            assert struct.formula == "Zn1.29 Fe0.69 As2 Pb1.02 O8"
+            assert struct.formula == "Zn2.58 Fe1.38 As4 Pb2.04 O16"
 
     def test_cif_parser_cod(self):
         """Parsing problematic CIF files from the COD database."""
@@ -358,7 +361,7 @@ class TestCifIO(PymatgenTest):
         # Label in capital letters
         parser = CifParser(f"{TEST_FILES_DIR}/Cod_4115344.cif")
         for struct in parser.get_structures():
-            assert struct.formula == "Mo4 P2 H60 C60 I4 O4"
+            assert struct.formula == "Mo8 P4 H120 C120 I8 O8"
 
     def test_parse_symbol(self):
         """
@@ -741,7 +744,7 @@ loop_
             parser.get_structures(on_error="raise")
         parser = CifParser(filepath, occupancy_tolerance=2)
         struct = parser.get_structures()[0]
-        assert struct[0].species["Al3+"] == approx(0.5)
+        assert struct[0].species["Al3+"] == approx(0.778)
 
     def test_one_line_symm(self):
         f = f"{TEST_FILES_DIR}/OneLineSymmP1.cif"
@@ -767,7 +770,7 @@ loop_
         warn_msg = "4 fractional coordinates rounded to ideal values to avoid issues with finite precision."
         with pytest.warns(UserWarning, match=warn_msg):
             struct = parser.get_structures()[0]
-        assert str(struct.composition) == "N5+24"
+        assert str(struct.composition) == "N5+72"
         assert warn_msg in parser.warnings
 
     def test_empty_deque(self):

--- a/tests/io/test_cif.py
+++ b/tests/io/test_cif.py
@@ -164,11 +164,11 @@ loop_
 class TestCifIO(PymatgenTest):
     def test_cif_parser(self):
         parser = CifParser(f"{TEST_FILES_DIR}/LiFePO4.cif")
-        for struct in parser.get_structures():
+        for struct in parser.parse_structures():
             assert struct.formula == "Li4 Fe4 P4 O16", "Incorrectly parsed cif."
 
         parser = CifParser(f"{TEST_FILES_DIR}/V2O3.cif")
-        for struct in parser.get_structures():
+        for struct in parser.parse_structures():
             assert struct.formula == "V4 O6"
 
         bibtex_str = """
@@ -184,20 +184,20 @@ class TestCifIO(PymatgenTest):
         assert parser.get_bibtex_string().strip() == bibtex_str.strip()
 
         parser = CifParser(f"{TEST_FILES_DIR}/Li2O.cif")
-        prim = parser.get_structures()[0]
+        prim = parser.parse_structures()[0]
         assert prim.formula == "Li8 O4"
-        conv = parser.get_structures(primitive=False)[0]
+        conv = parser.parse_structures(primitive=False)[0]
         assert conv.formula == "Li8 O4"
 
         # test for disordered structures
         parser = CifParser(f"{TEST_FILES_DIR}/Li10GeP2S12.cif")
-        for struct in parser.get_structures():
+        for struct in parser.parse_structures():
             assert struct.formula == "Li20.2 Ge2.06 P3.94 S24", "Incorrectly parsed cif."
 
         with open(f"{TEST_FILES_DIR}/FePO4.cif") as cif_file:
             cif_str = cif_file.read()
         parser = CifParser.from_str(cif_str)
-        struct = parser.get_structures(primitive=False)[0]
+        struct = parser.parse_structures(primitive=False)[0]
         assert struct.formula == "Fe4 P4 O16"
         assert struct.lattice.a == approx(10.4117668699)
         assert struct.lattice.b == approx(6.06717187997)
@@ -207,29 +207,29 @@ class TestCifIO(PymatgenTest):
         assert struct.lattice.gamma == approx(93)
 
         parser = CifParser(f"{TEST_FILES_DIR}/srycoo.cif")
-        assert parser.get_structures()[0].formula == "Sr11.2 Y4.8 Co16 O42"
+        assert parser.parse_structures()[0].formula == "Sr11.2 Y4.8 Co16 O42"
 
         # Test with a decimal Xyz. This should parse as two atoms in
         # conventional cell if it is correct, one if not.
         parser = CifParser(f"{TEST_FILES_DIR}/Fe.cif")
-        assert len(parser.get_structures(primitive=False)[0]) == 2
+        assert len(parser.parse_structures(primitive=False)[0]) == 2
         assert not parser.has_errors
 
     def test_get_symmetrized_structure(self):
         parser = CifParser(f"{TEST_FILES_DIR}/Li2O.cif")
-        sym_structure = parser.get_structures(primitive=False, symmetrized=True)[0]
-        structure = parser.get_structures(primitive=False, symmetrized=False)[0]
+        sym_structure = parser.parse_structures(primitive=False, symmetrized=True)[0]
+        structure = parser.parse_structures(primitive=False, symmetrized=False)[0]
         assert isinstance(sym_structure, SymmetrizedStructure)
         assert structure == sym_structure
         assert sym_structure.equivalent_indices == [[0, 1, 2, 3], [4, 5, 6, 7, 8, 9, 10, 11]]
 
     def test_site_symbol_preference(self):
         parser = CifParser(f"{TEST_FILES_DIR}/site_type_symbol_test.cif")
-        assert parser.get_structures()[0].formula == "Ge1.6 Sb1.6 Te4"
+        assert parser.parse_structures()[0].formula == "Ge1.6 Sb1.6 Te4"
 
     def test_implicit_hydrogen(self):
         parser = CifParser(f"{TEST_FILES_DIR}/Senegalite_implicit_hydrogen.cif")
-        for struct in parser.get_structures():
+        for struct in parser.parse_structures():
             assert struct.formula == "Al8 P4 O32"
             assert sum(struct.site_properties["implicit_hydrogens"]) == 20
         assert (
@@ -238,7 +238,7 @@ class TestCifIO(PymatgenTest):
             "in calculations unless hydrogens added." in parser.warnings
         )
         parser = CifParser(f"{TEST_FILES_DIR}/cif_implicit_hydrogens_cod_1011130.cif")
-        struct = parser.get_structures()[0]
+        struct = parser.parse_structures()[0]
         assert (
             "Structure has implicit hydrogens defined, "
             "parsed structure unlikely to be suitable for use "
@@ -247,7 +247,7 @@ class TestCifIO(PymatgenTest):
 
     def test_site_labels(self):
         parser = CifParser(f"{TEST_FILES_DIR}/garnet.cif")
-        struct = parser.get_structures(primitive=True)[0]
+        struct = parser.parse_structures(primitive=True)[0]
 
         # ensure structure has correct number of labels
         assert len(struct.labels) == len(struct)
@@ -264,20 +264,20 @@ class TestCifIO(PymatgenTest):
 
         # ensure multiple species with different names have correct labels
         parser2 = CifParser(f"{TEST_FILES_DIR}/Fe3O4.cif")
-        struct2 = parser2.get_structures(primitive=False)[0]
+        struct2 = parser2.parse_structures(primitive=False)[0]
 
         expected_site_names2 = {*"O1 O2 O3 O4 O5 O6 O7 O8 Fe9 Fe10 Fe11 Fe12 Fe13 Fe14".split()}
         assert set(struct2.labels) == expected_site_names2
 
     def test_cif_writer_labeled(self):
         parser = CifParser(f"{TEST_FILES_DIR}/garnet.cif")
-        struct = parser.get_structures()[0]
+        struct = parser.parse_structures()[0]
         for idx, site in enumerate(struct):
             site.label = f"my_{site.specie.name}{idx}"
         writer = CifWriter(struct)
 
         parser2 = CifParser.from_str(str(writer))
-        struct2 = parser2.get_structures()[0]
+        struct2 = parser2.parse_structures()[0]
 
         assert set(struct.labels) == set(struct2.labels)
 
@@ -286,19 +286,19 @@ class TestCifIO(PymatgenTest):
 
         # Partial occupancy on sites, incorrect label, previously unparsable
         parser = CifParser(f"{TEST_FILES_DIR}/PF_sd_1928405.cif")
-        for struct in parser.get_structures():
+        for struct in parser.parse_structures():
             assert struct.formula == "Er1 Mn3.888 Fe2.112 Sn6"
         assert parser.has_errors
 
         # Partial occupancy on sites, previously parsed as an ordered structure
         parser = CifParser(f"{TEST_FILES_DIR}/PF_sd_1011081.cif")
-        for struct in parser.get_structures():
+        for struct in parser.parse_structures():
             assert struct.formula == "Zr0.4 Nb1.6"
         assert parser.has_errors
 
         # Partial occupancy on sites, incorrect label, previously unparsable
         parser = CifParser(f"{TEST_FILES_DIR}/PF_sd_1615854.cif")
-        for idx, struct in enumerate(parser.get_structures()):
+        for idx, struct in enumerate(parser.parse_structures()):
             if idx == 0:
                 assert struct.formula == "Na2 Al2 Si6 O16"
             else:
@@ -307,19 +307,19 @@ class TestCifIO(PymatgenTest):
 
         # Partial occupancy on sites, incorrect label, previously unparsable
         parser = CifParser(f"{TEST_FILES_DIR}/PF_sd_1622133.cif")
-        for struct in parser.get_structures():
+        for struct in parser.parse_structures():
             assert struct.formula == "Ca0.184 Mg13.016 Fe2.8 Si16 O48"
         assert parser.has_errors
 
         # Partial occupancy on sites, previously parsed as an ordered structure
         parser = CifParser(f"{TEST_FILES_DIR}/PF_sd_1908491.cif")
-        for struct in parser.get_structures():
+        for struct in parser.parse_structures():
             assert struct.formula == "Mn0.96 Zn1.04 Ga4 Se8"
         assert parser.has_errors
 
         # Partial occupancy on sites, incorrect label, previously unparsable
         parser = CifParser(f"{TEST_FILES_DIR}/PF_sd_1811457.cif")
-        for struct in parser.get_structures():
+        for struct in parser.parse_structures():
             assert struct.formula == "Ba8 Mg2.4 Zr0.8 Ta4.8 O24"
         assert parser.has_errors
 
@@ -330,37 +330,37 @@ class TestCifIO(PymatgenTest):
         # in CIFs from Springer Materials/Pauling file DBs, CifParser parses the
         # element as "Nh" (Nihonium).
         parser = CifParser(f"{TEST_FILES_DIR}/PF_sd_1002871.cif")
-        assert parser.get_structures()[0].formula == "Cu2 Br4 Nh12"
-        assert parser.get_structures()[1].formula == "Cu2 Br8 Nh12"
+        assert parser.parse_structures()[0].formula == "Cu2 Br4 Nh12"
+        assert parser.parse_structures()[1].formula == "Cu2 Br8 Nh12"
         assert parser.has_errors
 
         # Incomplete powder diffraction data, previously unparsable
         parser = CifParser(f"{TEST_FILES_DIR}/PF_sd_1704003.cif")
-        for struct in parser.get_structures():
+        for struct in parser.parse_structures():
             assert struct.formula == "Rb4 Mn2 F12"
         assert parser.has_errors
 
         # Unparsable species 'OH/OH2', previously parsed as "O"
         parser = CifParser(f"{TEST_FILES_DIR}/PF_sd_1500382.cif")
-        for struct in parser.get_structures():
+        for struct in parser.parse_structures():
             assert struct.formula == "Mg6 B2 O6 F1.764"
         assert parser.has_errors
 
         # Unparsable species 'OH/OH2', previously parsed as "O"
         parser = CifParser(f"{TEST_FILES_DIR}/PF_sd_1601634.cif")
-        for struct in parser.get_structures():
+        for struct in parser.parse_structures():
             assert struct.formula == "Zn2.58 Fe1.38 As4 Pb2.04 O16"
 
     def test_cif_parser_cod(self):
         """Parsing problematic CIF files from the COD database."""
         # Symbol in capital letters
         parser = CifParser(f"{TEST_FILES_DIR}/Cod_2100513.cif")
-        for struct in parser.get_structures():
+        for struct in parser.parse_structures():
             assert struct.formula == "Ca4 Nb2.0 Al2 O12"
 
         # Label in capital letters
         parser = CifParser(f"{TEST_FILES_DIR}/Cod_4115344.cif")
-        for struct in parser.get_structures():
+        for struct in parser.parse_structures():
             assert struct.formula == "Mo8 P4 H120 C120 I8 O8"
 
     def test_parse_symbol(self):
@@ -474,20 +474,20 @@ loop_
         cif = CifParser.from_str(str(writer))
         m = StructureMatcher()
 
-        assert m.fit(cif.get_structures()[0], struct)
+        assert m.fit(cif.parse_structures()[0], struct)
 
         # for l1, l2 in zip(str(writer).split("\n"), answer.split("\n")):
         #     assert l1.strip() == l2.strip()
 
         struct = Structure.from_file(f"{TEST_FILES_DIR}/LiFePO4.cif")
         writer = CifWriter(struct, symprec=0.1)
-        s2 = CifParser.from_str(str(writer)).get_structures()[0]
+        s2 = CifParser.from_str(str(writer)).parse_structures()[0]
 
         assert m.fit(struct, s2)
 
         struct = self.get_structure("Li2O")
         writer = CifWriter(struct, symprec=0.1)
-        s2 = CifParser.from_str(str(writer)).get_structures()[0]
+        s2 = CifParser.from_str(str(writer)).parse_structures()[0]
         assert m.fit(struct, s2)
 
         # test angle tolerance.
@@ -553,7 +553,7 @@ loop_
         writer = CifWriter(si2, symprec=1e-3, significant_figures=10, refine_struct=False)
         cif_str = str(writer)
         assert "Fd-3m" in cif_str
-        same_si2 = CifParser.from_str(cif_str).get_structures()[0]
+        same_si2 = CifParser.from_str(cif_str).parse_structures()[0]
         assert len(si2) == len(same_si2)
 
     def test_specie_cif_writer(self):
@@ -617,13 +617,13 @@ loop_
 
     def test_primes(self):
         parser = CifParser(f"{TEST_FILES_DIR}/C26H16BeN2O2S2.cif")
-        for struct in parser.get_structures(primitive=False):
+        for struct in parser.parse_structures(primitive=False):
             assert struct.composition == 8 * Composition("C26H16BeN2O2S2")
 
     def test_missing_atom_site_type_with_oxi_states(self):
         parser = CifParser(f"{TEST_FILES_DIR}/P24Ru4H252C296S24N16.cif")
         comp = Composition({"S0+": 24, "Ru0+": 4, "H0+": 252, "C0+": 296, "N0+": 16, "P0+": 24})
-        for struct in parser.get_structures(primitive=False):
+        for struct in parser.parse_structures(primitive=False):
             assert struct.composition == comp
 
     def test_no_coords_or_species(self):
@@ -663,7 +663,7 @@ loop_
     """
         parser = CifParser.from_str(string)
         with pytest.raises(ValueError, match="Invalid CIF file with no structures"):
-            parser.get_structures()
+            parser.parse_structures()
 
     def test_get_lattice_from_lattice_type(self):
         cif_structure = """#generated using pymatgen
@@ -716,7 +716,7 @@ loop_
 
 """
         parser = CifParser.from_str(cif_structure)
-        s_test = parser.get_structures(primitive=False)[0]
+        s_test = parser.parse_structures(primitive=False)[0]
         filepath = f"{TEST_FILES_DIR}/POSCAR"
         struct = Structure.from_file(filepath)
 
@@ -741,27 +741,27 @@ loop_
         with pytest.raises(
             ValueError, match="No structure parsed for section 1 in CIF.\nSpecies occupancies sum to more than 1!"
         ):
-            parser.get_structures(on_error="raise")
+            parser.parse_structures(on_error="raise")
         parser = CifParser(filepath, occupancy_tolerance=2)
-        struct = parser.get_structures()[0]
+        struct = parser.parse_structures()[0]
         assert struct[0].species["Al3+"] == approx(0.778)
 
     def test_one_line_symm(self):
         f = f"{TEST_FILES_DIR}/OneLineSymmP1.cif"
         parser = CifParser(f)
-        struct = parser.get_structures()[0]
+        struct = parser.parse_structures()[0]
         assert struct.formula == "Ga4 Pb2 O8"
 
     def test_no_symmops(self):
         f = f"{TEST_FILES_DIR}/nosymm.cif"
         parser = CifParser(f)
-        struct = parser.get_structures()[0]
+        struct = parser.parse_structures()[0]
         assert struct.formula == "H96 C60 O8"
 
     def test_dot_positions(self):
         f = f"{TEST_FILES_DIR}/ICSD59959.cif"
         parser = CifParser(f)
-        struct = parser.get_structures()[0]
+        struct = parser.parse_structures()[0]
         assert struct.formula == "K1 Mn1 F3"
 
     def test_replacing_finite_precision_frac_coords(self):
@@ -769,7 +769,7 @@ loop_
         parser = CifParser(cif)
         warn_msg = "4 fractional coordinates rounded to ideal values to avoid issues with finite precision."
         with pytest.warns(UserWarning, match=warn_msg):
-            struct = parser.get_structures()[0]
+            struct = parser.parse_structures()[0]
         assert str(struct.composition) == "N5+72"
         assert warn_msg in parser.warnings
 
@@ -808,7 +808,7 @@ loop_
   4  x-1/2,-y-1/2,z-1/2
 ;"""
         parser = CifParser.from_str(cif_str)
-        assert parser.get_structures()[0].formula == "Si1"
+        assert parser.parse_structures()[0].formula == "Si1"
         cif = """
 data_1526655
 _journal_name_full
@@ -840,7 +840,7 @@ Si1 Si 0 0 0 1 0.0
 """
         parser = CifParser.from_str(cif)
         with pytest.raises(ValueError, match="Invalid CIF file with no structures"):
-            parser.get_structures()
+            parser.parse_structures()
 
     def test_no_check_occu(self):
         with open(f"{TEST_FILES_DIR}/site_type_symbol_test.cif") as cif_file:
@@ -849,18 +849,18 @@ Si1 Si 0 0 0 1 0.0
 
         with pytest.raises(ValueError, match="Invalid CIF file with no structures"):
             # should fail without setting custom occupancy tolerance
-            CifParser.from_str(cif_str).get_structures()
+            CifParser.from_str(cif_str).parse_structures()
 
         for tol in (1.5, 10):
             parser = CifParser.from_str(cif_str, occupancy_tolerance=tol)
-            structs = parser.get_structures(primitive=False, check_occu=False)[0]
+            structs = parser.parse_structures(primitive=False, check_occu=False)[0]
             assert structs[0].species.as_dict()["Te"] == 1.5
 
     def test_cif_writer_write_file(self):
         struct1 = Structure.from_file(f"{TEST_FILES_DIR}/POSCAR")
         out_path = f"{self.tmp_path}/test.cif"
         CifWriter(struct1).write_file(out_path)
-        read_structs = CifParser(out_path).get_structures()
+        read_structs = CifParser(out_path).parse_structures()
         assert len(read_structs) == 1
         assert struct1.matches(read_structs[0])
 
@@ -868,7 +868,7 @@ Si1 Si 0 0 0 1 0.0
         struct2 = Structure.from_file(f"{TEST_FILES_DIR}/Graphite.cif")
         CifWriter(struct2).write_file(out_path, mode="a")
 
-        read_structs = CifParser(out_path).get_structures()
+        read_structs = CifParser(out_path).parse_structures()
         assert len(read_structs) == 2
         assert [x.formula for x in read_structs] == ["Fe4 P4 O16", "C4"]
 
@@ -891,14 +891,14 @@ class TestMagCif(PymatgenTest):
         assert self.mcif_incommensurate.feature_flags["magcif_incommensurate"]
         assert not self.mcif_disordered.feature_flags["magcif_incommensurate"]
 
-    def test_get_structures(self):
+    def test_parse_structures(self):
         # incommensurate structures not currently supported
         with pytest.raises(NotImplementedError, match="Incommensurate structures not currently supported"):
-            self.mcif_incommensurate.get_structures()
+            self.mcif_incommensurate.parse_structures()
 
         # disordered magnetic structures not currently supported
         with pytest.raises(NotImplementedError, match="Disordered magnetic structures not currently supported"):
-            self.mcif_disordered.get_structures()
+            self.mcif_disordered.parse_structures()
 
         # taken from self.mcif_ncl, removing explicit magnetic symmops
         # so that MagneticSymmetryGroup() has to be invoked
@@ -932,13 +932,13 @@ _atom_site_moment_crystalaxis_y
 _atom_site_moment_crystalaxis_z
 Gd1 5.05 5.05 0.0"""
 
-        struct = self.mcif.get_structures(primitive=False)[0]
+        struct = self.mcif.parse_structures(primitive=False)[0]
         assert struct.formula == "Ni32 O32"
         assert Magmom.are_collinear(struct.site_properties["magmom"])
 
         # example with non-collinear spin
-        s_ncl = self.mcif_ncl.get_structures(primitive=False)[0]
-        s_ncl_from_msg = CifParser.from_str(mag_cif_str).get_structures(primitive=False)[0]
+        s_ncl = self.mcif_ncl.parse_structures(primitive=False)[0]
+        s_ncl_from_msg = CifParser.from_str(mag_cif_str).parse_structures(primitive=False)[0]
         assert s_ncl.formula == "Gd4 B16"
         assert not Magmom.are_collinear(s_ncl.site_properties["magmom"])
 
@@ -947,7 +947,7 @@ Gd1 5.05 5.05 0.0"""
     def test_write(self):
         with open(f"{TEST_FILES_DIR}/GdB4-writer-ref.mcif") as file:
             cw_ref_string = file.read()
-        s_ncl = self.mcif_ncl.get_structures(primitive=False)[0]
+        s_ncl = self.mcif_ncl.parse_structures(primitive=False)[0]
 
         cw = CifWriter(s_ncl, write_magmoms=True)
         assert str(cw) == cw_ref_string
@@ -970,7 +970,7 @@ Gd1 5.05 5.05 0.0"""
 
         assert str(cw).strip() == cw_ref_string_magnitudes.strip()
         # test we're getting correct magmoms in ncl case
-        s_ncl2 = self.mcif_ncl2.get_structures()[0]
+        s_ncl2 = self.mcif_ncl2.parse_structures()[0]
         list_magmoms = [list(m) for m in s_ncl2.site_properties["magmom"]]
         assert list_magmoms[0][0] == 0.0
         assert list_magmoms[0][1] == approx(5.9160793408726366)

--- a/tests/io/test_core.py
+++ b/tests/io/test_core.py
@@ -29,8 +29,7 @@ class StructInputFile(InputFile):
 
     @classmethod
     def from_str(cls, contents: str):
-        parser = CifParser.from_str(contents)
-        struct = parser.get_structures()[0]
+        struct = Structure.from_str(contents, fmt="cif")
         return cls(structure=struct)
 
 
@@ -55,7 +54,7 @@ class TestInputFile(PymatgenTest):
         assert isinstance(sif.structure, Structure)
 
         sif.write_file("newLi.cif")
-        assert os.path.exists("newLi.cif")
+        assert os.path.isfile("newLi.cif")
 
     def test_msonable(self):
         sif = StructInputFile.from_file(f"{TEST_FILES_DIR}/Li.cif")
@@ -142,14 +141,14 @@ class TestInputSet(PymatgenTest):
     def test_write(self):
         inp_set = InputSet({"cif1": self.sif1, "cif2": self.sif2}, kwarg1=1, kwarg2="hello")
         inp_set.write_input(directory="input_dir", make_dir=True, overwrite=True, zip_inputs=False)
-        assert os.path.exists("input_dir/cif1")
-        assert os.path.exists("input_dir/cif2")
+        assert os.path.isfile("input_dir/cif1")
+        assert os.path.isfile("input_dir/cif2")
         assert len(os.listdir("input_dir")) == 2
         with pytest.raises(FileExistsError, match="cif1"):
             inp_set.write_input(directory="input_dir", make_dir=True, overwrite=False, zip_inputs=False)
         inp_set.write_input(directory="input_dir", make_dir=True, overwrite=True, zip_inputs=True)
         assert len(os.listdir("input_dir")) == 1
-        assert os.path.exists(f"input_dir/{type(inp_set).__name__}.zip")
+        assert os.path.isfile(f"input_dir/{type(inp_set).__name__}.zip")
         with pytest.raises(FileNotFoundError, match="input_dir2"):
             inp_set.write_input(directory="input_dir2", make_dir=False, overwrite=True, zip_inputs=False)
 
@@ -158,12 +157,12 @@ class TestInputSet(PymatgenTest):
             {"cif1": self.sif1, "file_from_str": "hello you", "file_from_str_cast": FakeClass(a="Aha", b="Beh")}
         )
         inp_set.write_input(directory="input_dir", make_dir=True, overwrite=True, zip_inputs=False)
-        assert os.path.exists("input_dir/cif1")
-        assert os.path.exists("input_dir/file_from_str")
-        assert os.path.exists("input_dir/file_from_str_cast")
+        assert os.path.isfile("input_dir/cif1")
+        assert os.path.isfile("input_dir/file_from_str")
+        assert os.path.isfile("input_dir/file_from_str_cast")
         assert len(os.listdir("input_dir")) == 3
         parser = CifParser(filename="input_dir/cif1")
-        assert parser.get_structures()[0] == self.sif1.structure
+        assert parser.parse_structures()[0] == self.sif1.structure
         with open("input_dir/file_from_str") as file:
             file_from_str = file.read()
             assert file_from_str == "hello you"

--- a/tests/transformations/test_advanced_transformations.py
+++ b/tests/transformations/test_advanced_transformations.py
@@ -16,7 +16,6 @@ from pymatgen.core.lattice import Lattice
 from pymatgen.core.periodic_table import Species
 from pymatgen.core.structure import Molecule, Structure
 from pymatgen.core.surface import SlabGenerator
-from pymatgen.io.cif import CifParser
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.transformations.advanced_transformations import (
     AddAdsorbateTransformation,
@@ -302,13 +301,11 @@ class TestMagOrderingTransformation(PymatgenTest):
         self.NiO_AFM_001 = Structure(latt, species, coords)
         self.NiO_AFM_001.add_spin_by_site([-5, 5, 0, 0])
 
-        parser = CifParser(f"{TEST_FILES_DIR}/Fe3O4.cif")
-        self.Fe3O4 = parser.get_structures()[0]
+        self.Fe3O4 = Structure.from_file(f"{TEST_FILES_DIR}/Fe3O4.cif")
         trans = AutoOxiStateDecorationTransformation()
         self.Fe3O4_oxi = trans.apply_transformation(self.Fe3O4)
 
-        parser = CifParser(f"{TEST_FILES_DIR}/Li8Fe2NiCoO8.cif")
-        self.Li8Fe2NiCoO8 = parser.get_structures()[0]
+        self.Li8Fe2NiCoO8 = Structure.from_file(f"{TEST_FILES_DIR}/Li8Fe2NiCoO8.cif")
         self.Li8Fe2NiCoO8.remove_oxidation_states()
 
     def test_apply_transformation(self):


### PR DESCRIPTION
### Motivation

`CifParser.get_structures('some.cif')[0]` and `Structure.from_file('some.cif')` currently return different cells. And `primitive=True` seems like a bad default. Cell reduction seems like something the user should request explicitly.

### Context

This came up in the MP ingestion of new ICSD structures added since 2019 with @esoteric-ephemera.

@shyuep @mkhorton Let me know if you disagree.