### PR TITLE
Propagate site labels in `SymmetrizedStructure()`

### DIFF
--- a/pymatgen/symmetry/structure.py
+++ b/pymatgen/symmetry/structure.py
@@ -50,6 +50,7 @@ class SymmetrizedStructure(Structure):
             structure.frac_coords,
             site_properties=structure.site_properties,
             properties=structure.properties,
+            labels=structure.labels,
         )
 
         equivalent_indices: list[list[int]] = [[] for _ in range(len(uniq))]

--- a/tests/io/test_cif.py
+++ b/tests/io/test_cif.py
@@ -222,6 +222,7 @@ class TestCifIO(PymatgenTest):
         assert isinstance(sym_structure, SymmetrizedStructure)
         assert structure == sym_structure
         assert sym_structure.equivalent_indices == [[0, 1, 2, 3], [4, 5, 6, 7, 8, 9, 10, 11]]
+        assert set(sym_structure.labels) == {"O1", "Li1"}
 
     def test_site_symbol_preference(self):
         parser = CifParser(f"{TEST_FILES_DIR}/site_type_symbol_test.cif")


### PR DESCRIPTION
Hi all, this is a small PR that makes sure labels are passed when a `SymmetrizedStructure` is initialized. This follows-up on earlier work in #3183 

## Summary

Major changes:

- fix 1: Propagate site labels through `SymmetrizedStructure()`

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [x] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
