### PR TITLE
Breaking: return sum of `Species` with matching `Element` in `Composition.__getitem__`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ ci:
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.2
+    rev: v0.1.3
     hooks:
       - id: ruff
         args: [--fix]

--- a/pymatgen/core/composition.py
+++ b/pymatgen/core/composition.py
@@ -138,7 +138,12 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
     def __getitem__(self, key: SpeciesLike) -> float:
         try:
             sp = get_el_sp(key)
-            return self._data.get(sp, 0)
+            if isinstance(sp, Species):
+                return self._data.get(sp, 0)
+            # sp is Element or str
+            return sum(
+                val for key, val in self._data.items() if getattr(key, "symbol", key) == getattr(sp, "symbol", sp)
+            )
         except ValueError as exc:
             raise KeyError(f"Invalid {key=}") from exc
 
@@ -153,7 +158,7 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
             sp = get_el_sp(key)
             if isinstance(sp, Species):
                 return sp in self._data
-            # Element or str
+            # key is Element or str
             return any(sp.symbol == s.symbol for s in self._data)
         except ValueError as exc:
             raise TypeError(f"Invalid {key=} for Composition") from exc

--- a/tests/core/test_composition.py
+++ b/tests/core/test_composition.py
@@ -105,6 +105,15 @@ class TestComposition(PymatgenTest):
         assert Element("Fe") not in comp
         assert Species("Fe2+") not in comp
 
+    def test_getitem(self):
+        comp = Composition({"Li+": 1, "Mn3+": 2, "O2-": 4, "Li": 1})
+        assert comp["Li"] == 2
+        assert comp["Li+"] == 1
+        assert comp["Mn3+"] == 2
+        assert comp["Mn"] == 2
+        assert comp["O2-"] == 4
+        assert comp["O"] == 4
+
     def test_hill_formula(self):
         c = Composition("CaCO3")
         assert c.hill_formula == "C Ca O3"
@@ -269,8 +278,8 @@ class TestComposition(PymatgenTest):
         assert Composition("H6CN").get_integer_formula_and_factor(iupac_ordering=True)[0] == "CNH6"
 
         # test rounding
-        c = Composition({"Na": 2 - Composition.amount_tolerance / 2, "Cl": 2})
-        assert c.reduced_formula == "NaCl"
+        comp = Composition({"Na": 2 - Composition.amount_tolerance / 2, "Cl": 2})
+        assert comp.reduced_formula == "NaCl"
 
     def test_integer_formula(self):
         correct_reduced_formulas = [
@@ -299,8 +308,8 @@ class TestComposition(PymatgenTest):
     def test_num_atoms(self):
         correct_num_atoms = [20, 10, 7, 8, 20, 75, 2, 3]
 
-        all_natoms = [c.num_atoms for c in self.comps]
-        assert all_natoms == correct_num_atoms
+        all_n_atoms = [c.num_atoms for c in self.comps]
+        assert all_n_atoms == correct_num_atoms
 
     def test_weight(self):
         correct_weights = [
@@ -360,7 +369,7 @@ class TestComposition(PymatgenTest):
             for el in c1.elements:
                 assert c1[el] == approx(c2[el], abs=1e-3)
 
-    def test_tofrom_weight_dict(self):
+    def test_to_from_weight_dict(self):
         for comp in self.comps:
             c2 = Composition().from_weight_dict(comp.to_weight_dict)
             comp.almost_equals(c2)
@@ -520,8 +529,8 @@ class TestComposition(PymatgenTest):
         # test species
         c1 = Composition({"Mg": 1, "Mg2+": -1}, allow_negative=True)
         assert c1.num_atoms == 2
-        assert c1.element_composition == Composition()
-        assert c1.average_electroneg == 1.31
+        assert c1.element_composition == Composition("Mg-1", allow_negative=True)
+        assert c1.average_electroneg == 0.655
 
     def test_special_formulas(self):
         special_formulas = {

--- a/tests/core/test_sites.py
+++ b/tests/core/test_sites.py
@@ -141,9 +141,9 @@ class TestPeriodicSite(PymatgenTest):
         dist_old, jimage_old = get_distance_and_image_old(site1, site2)
         dist_new, jimage_new = site1.distance_and_image(site2)
         assert dist_old - dist_new > -1e-8, "New distance algo should give smaller answers!"
-        assert not (abs(dist_old - dist_new) < 1e-8) ^ (
-            jimage_old == jimage_new
-        ).all(), "If old dist == new dist, images must be the same!"
+        assert (
+            not (abs(dist_old - dist_new) < 1e-8) ^ (jimage_old == jimage_new).all()
+        ), "If old dist == new dist, images must be the same!"
         latt = Lattice.from_parameters(3.0, 3.1, 10.0, 2.96, 2.0, 1.0)
         site = PeriodicSite("Fe", [0.1, 0.1, 0.1], latt)
         site2 = PeriodicSite("Fe", [0.99, 0.99, 0.99], latt)

--- a/tests/io/exciting/test_inputs.py
+++ b/tests/io/exciting/test_inputs.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import xml.etree.ElementTree as ET
+from xml.etree import ElementTree
 
 from numpy.testing import assert_allclose
 
@@ -121,7 +121,7 @@ class TestExcitingInput(PymatgenTest):
             "S",
             "R",
         ]
-        root = ET.fromstring(bandstr)
+        root = ElementTree.fromstring(bandstr)
         for plot1d in root.iter("plot1d"):
             for point in plot1d.iter("point"):
                 coord.append([float(i) for i in point.get("coord").split()])
@@ -159,8 +159,8 @@ class TestExcitingInput(PymatgenTest):
 
         # read reference file
         filepath = f"{TEST_FILES_DIR}/input_exciting2.xml"
-        tree = ET.parse(filepath)
+        tree = ElementTree.parse(filepath)
         root = tree.getroot()
-        ref_string = ET.tostring(root, encoding="unicode")
+        ref_string = ElementTree.tostring(root, encoding="unicode")
 
         assert ref_string.strip() == test_string.strip()

--- a/tests/transformations/test_standard_transformations.py
+++ b/tests/transformations/test_standard_transformations.py
@@ -338,21 +338,10 @@ class TestOrderDisorderedStructureTransformation(unittest.TestCase):
 
     def test_symmetrized_structure(self):
         trafo = OrderDisorderedStructureTransformation(symmetrized_structures=True)
-        c = []
-        sp = []
-        c.append([0.5, 0.5, 0.5])
-        sp.append("Si4+")
-        c.append([0.45, 0.45, 0.45])
-        sp.append({"Si4+": 0.5})
-        c.append([0.56, 0.56, 0.56])
-        sp.append({"Si4+": 0.5})
-        c.append([0.25, 0.75, 0.75])
-        sp.append({"Si4+": 0.5})
-        c.append([0.75, 0.25, 0.25])
-        sp.append({"Si4+": 0.5})
         latt = Lattice.cubic(5)
-        struct = Structure(latt, sp, c)
-        test_site = PeriodicSite("Si4+", c[2], latt)
+        coords = [[0.5, 0.5, 0.5], [0.45, 0.45, 0.45], [0.56, 0.56, 0.56], [0.25, 0.75, 0.75], [0.75, 0.25, 0.25]]
+        struct = Structure(latt, [{"Si4+": 1}, *[{"Si4+": 0.5}] * 4], coords)
+        test_site = PeriodicSite("Si4+", coords[2], latt)
         struct = SymmetrizedStructure(struct, "not_real", [0, 1, 1, 2, 2], ["a", "b", "b", "c", "c"])
         output = trafo.apply_transformation(struct)
         assert test_site in output


### PR DESCRIPTION
Closes #3425.

Follow up to https://github.com/materialsproject/pymatgen/pull/3184 since that turns out to only have been a partial fix for not applying anion corrections to `ComputedEntries` with oxidation states.

The bug comes from `Composition` indexing behaving differently for `Elements`/`str` vs. `Species`. Currently:

```py
comp = Composition({"Li+": 2, "Mn3+": 2, "O2-": 4})
comp["Li"] == 0
```

This PR changes `comp["Li"]` to return 2 instead, i.e. return all species with matching symbol, regardless of oxidation state. Currently `comp["O"]` returns 0 and so no oxide correction is applied.

This is breaking. E.g. currently

```py
comp = Composition({"Mg": 1, "Mg2+": -1}, allow_negative=True)
comp["Mg"] == 1
```

which will change to return 0.