### PR TITLE
Refresh OPTIMADE aliases and update docstrings

### DIFF
--- a/pymatgen/ext/optimade.py
+++ b/pymatgen/ext/optimade.py
@@ -16,9 +16,6 @@ from pymatgen.core.structure import Structure
 from pymatgen.util.due import Doi, due
 from pymatgen.util.provenance import StructureNL
 
-# from retrying import retry
-
-
 # TODO: importing optimade-python-tool's data structures will make more sense
 Provider = namedtuple("Provider", ["name", "base_url", "description", "homepage", "prefix"])
 
@@ -46,7 +43,9 @@ class OptimadeRester:
     # these aliases are provided as a convenient shortcut for users of the OptimadeRester class
     aliases = {
         "aflow": "http://aflow.org/API/optimade/",
+        "alexandria": "https://alexandria.odbx.science",
         "cod": "https://www.crystallography.net/cod/optimade",
+        "cmr": "https://cmr-optimade.fysik.dtu.dk",
         "mcloud.mc3d": "https://aiida.materialscloud.org/mc3d/optimade",
         "mcloud.mc2d": "https://aiida.materialscloud.org/mc2d/optimade",
         "mcloud.2dtopo": "https://aiida.materialscloud.org/2dtopo/optimade",
@@ -58,6 +57,7 @@ class OptimadeRester:
         "mcloud.tin-antimony-sulfoiodide": "https://aiida.materialscloud.org/tin-antimony-sulfoiodide/optimade",
         "mcloud.optimade-sample": "https://aiida.materialscloud.org/optimade-sample/optimade",
         "mp": "https://optimade.materialsproject.org",
+        "mpdd": "http://mpddoptimade.phaseslab.org",
         "mpds": "https://api.mpds.io",
         "nmd": "https://nomad-lab.eu/prod/rae/optimade/",
         "odbx": "https://optimade.odbx.science",
@@ -154,11 +154,8 @@ class OptimadeRester:
         provider_text = "\n".join(map(str, (provider for provider in self._providers.values() if provider)))
         return f"OptimadeRester connected to:\n{provider_text}"
 
-    # @retry(stop_max_attempt_number=3, wait_random_min=1000, wait_random_max=2000)
     def _get_json(self, url):
-        """Retrieves JSON, will attempt to (politely) try again on failure subject to a
-        random delay and a maximum number of attempts.
-        """
+        """Retrieves and returns JSON resource from given url."""
         return self.session.get(url, timeout=self._timeout).json()
 
     @staticmethod
@@ -215,8 +212,11 @@ class OptimadeRester:
             elements: List of elements
             nelements: Number of elements, e.g. 4 or [2, 5] for the range >=2 and <=5
             nsites: Number of sites, e.g. 4 or [2, 5] for the range >=2 and <=5
-            chemical_formula_anonymous: Anonymous chemical formula
-            chemical_formula_hill: Chemical formula following Hill convention
+            chemical_formula_anonymous: The desired chemical formula in OPTIMADE anonymous formula format
+            (NB. The ordering is reversed from the pymatgen format, e.g., pymatgen "ABC2" should become "A2BC").
+            chemical_formula_hill: The desired chemical formula in the OPTIMADE take on the Hill formula format.
+            (NB. Again, this is different from the pymatgen format, as the OPTIMADE version is a reduced chemical
+            formula simply using the IUPAC/Hill ordering.)
 
         Returns:
             dict[str, Structure]: keyed by that database provider's id system
@@ -253,8 +253,11 @@ class OptimadeRester:
             elements: List of elements
             nelements: Number of elements, e.g. 4 or [2, 5] for the range >=2 and <=5
             nsites: Number of sites, e.g. 4 or [2, 5] for the range >=2 and <=5
-            chemical_formula_anonymous: Anonymous chemical formula
-            chemical_formula_hill: Chemical formula following Hill convention
+            chemical_formula_anonymous: The desired chemical formula in OPTIMADE anonymous formula format
+            (NB. The ordering is reversed from the pymatgen format, e.g., pymatgen "ABC2" should become "A2BC").
+            chemical_formula_hill: The desired chemical formula in the OPTIMADE take on the Hill formula format.
+            (NB. Again, this is different from the pymatgen format, as the OPTIMADE version is a reduced chemical
+            formula simply using the IUPAC/Hill ordering.)
             additional_response_fields: Any additional fields desired from the OPTIMADE API,
             these will be stored under the `'_optimade'` key in each `StructureNL.data` dictionary.
 


### PR DESCRIPTION
## Summary

*Apropos* of nothing in particular... here is PR that makes some updates to the OPTIMADE client (and maybe starts a discussion about its future).

Major changes:

- Refreshes the baked-in OPTIMADE providers list with the latest new APIs
- Expands upon some of the docstrings

Happy to talk about how we could integrate the models and client at optimade-python-tools if that would be preferable. It would allow for async pulling data from all databases, pre-flight validating filters and validating responses (dangerous stuff for some databases...) and the code here could focus on just making sure the returned objects work with pymatgen. Should be releasing o-p-t v1.0 (https://github.com/Materials-Consortia/optimade-python-tools/issues/1831) before the end of the year which will support pydantic v2 and hopefully have better isolation, so wouldn't require many additional deps (httpx for async requests, Lark for parsing filters: see [here](https://github.com/Materials-Consortia/optimade-python-tools/blob/master/requirements.txt))

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [x] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))