### PR TITLE
Fix Vasprun not interpreting float overflow as nan

### DIFF
--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -1302,7 +1302,7 @@ class Vasprun(MSONable):
 
     def _parse_calculation(self, elem):
         try:
-            istep = {i.attrib["name"]: float(i.text) for i in elem.find("energy").findall("i")}
+            istep = {i.attrib["name"]: _vasprun_float(i.text) for i in elem.find("energy").findall("i")}
         except AttributeError:  # not all calculations have an energy
             istep = {}
         esteps = []

--- a/tests/files/.pytest-split-durations
+++ b/tests/files/.pytest-split-durations
@@ -2169,7 +2169,7 @@
     "tests/io/vasp/test_outputs.py::TestVasprun::test_potcar_not_found": 0.1334625000017695,
     "tests/io/vasp/test_outputs.py::TestVasprun::test_projected_magnetisation": 4.4185712080216035,
     "tests/io/vasp/test_outputs.py::TestVasprun::test_runtype": 14.43198950093938,
-    "tests/io/vasp/test_outputs.py::TestVasprun::test_sc_step_overflow": 1.980604083975777,
+    "tests/io/vasp/test_outputs.py::TestVasprun::test_float_overflow": 1.980604083975777,
     "tests/io/vasp/test_outputs.py::TestVasprun::test_search_for_potcar": 0.2289056670269929,
     "tests/io/vasp/test_outputs.py::TestVasprun::test_selective_dynamics": 1.798271125066094,
     "tests/io/vasp/test_outputs.py::TestVasprun::test_smart_efermi": 2.6953831250430085,

--- a/tests/io/vasp/test_outputs.py
+++ b/tests/io/vasp/test_outputs.py
@@ -586,6 +586,14 @@ class TestVasprun(PymatgenTest):
         estep = vasp_run.ionic_steps[0]["electronic_steps"][29]
         assert np.isnan(estep["e_wo_entrp"])
 
+        filepath = f"{TEST_FILES_DIR}/vasprun.xml.force_overflow"
+        with pytest.warns(UserWarning, match="Float overflow .* encountered in vasprun"):
+            vasp_run = Vasprun(filepath)
+        vasp_run = Vasprun(filepath)
+        step = vasp_run.ionic_steps[0]
+        assert np.isnan(step['e_fr_energy'])
+        assert np.isnan(step['forces']).any()
+
     def test_update_potcar(self):
         filepath = f"{TEST_FILES_DIR}/vasprun.xml"
         potcar_path = f"{TEST_FILES_DIR}/POTCAR.LiFePO4.gz"

--- a/tests/io/vasp/test_outputs.py
+++ b/tests/io/vasp/test_outputs.py
@@ -591,8 +591,8 @@ class TestVasprun(PymatgenTest):
             vasp_run = Vasprun(filepath)
         vasp_run = Vasprun(filepath)
         step = vasp_run.ionic_steps[0]
-        assert np.isnan(step['e_fr_energy'])
-        assert np.isnan(step['forces']).any()
+        assert np.isnan(step["e_fr_energy"])
+        assert np.isnan(step["forces"]).any()
 
     def test_update_potcar(self):
         filepath = f"{TEST_FILES_DIR}/vasprun.xml"

--- a/tests/io/vasp/test_outputs.py
+++ b/tests/io/vasp/test_outputs.py
@@ -578,21 +578,17 @@ class TestVasprun(PymatgenTest):
         smart_fermi = vrun.calculate_efermi()
         assert smart_fermi == approx(6.0165)
 
-    def test_sc_step_overflow(self):
+    def test_float_overflow(self):
+        # test we interpret VASP's *********** for overflowed values as NaNs
+        # https://github.com/materialsproject/pymatgen/pull/3452
         filepath = f"{TEST_FILES_DIR}/vasprun.xml.sc_overflow"
         with pytest.warns(UserWarning, match="Float overflow .* encountered in vasprun"):
             vasp_run = Vasprun(filepath)
-        vasp_run = Vasprun(filepath)
-        estep = vasp_run.ionic_steps[0]["electronic_steps"][29]
-        assert np.isnan(estep["e_wo_entrp"])
-
-        filepath = f"{TEST_FILES_DIR}/vasprun.xml.force_overflow"
-        with pytest.warns(UserWarning, match="Float overflow .* encountered in vasprun"):
-            vasp_run = Vasprun(filepath)
-        vasp_run = Vasprun(filepath)
-        step = vasp_run.ionic_steps[0]
-        assert np.isnan(step["e_fr_energy"])
-        assert np.isnan(step["forces"]).any()
+        first_ionic_step = vasp_run.ionic_steps[0]
+        elec_step = first_ionic_step["electronic_steps"][29]
+        assert np.isnan(elec_step["e_wo_entrp"])
+        assert np.isnan(elec_step["e_fr_energy"])
+        assert np.isnan(first_ionic_step["forces"]).any()
 
     def test_update_potcar(self):
         filepath = f"{TEST_FILES_DIR}/vasprun.xml"


### PR DESCRIPTION
VASP will sometimes print "***********" when there's a float overflow. There's already a function in here to interpret these as `np.nan`, but it looks like it wasn't applied everywhere. I found one place where it wasn't used (ie just using Python's `float` function) that helped me process a large batch of `vasprun.xml`s correctly, but maybe the same function can be used elsewhere. 