### PR TITLE
Add support for parsing orbital moments from OUTCAR

### DIFF
--- a/src/pymatgen/io/vasp/outputs.py
+++ b/src/pymatgen/io/vasp/outputs.py
@@ -1862,6 +1862,8 @@ class Outcar:
     Attributes:
         magnetization (tuple): Magnetization on each ion as a tuple of dict, e.g.
             ({"d": 0.0, "p": 0.003, "s": 0.002, "tot": 0.005}, ... )
+        orbital_moment (tuple): Orbital moments on each ion as a tuple of dict, e.g.,
+            ({"d": 0.109, "p": -0.001, "tot": 0.108}, ... )
         chemical_shielding (dict): Chemical shielding on each ion as a dictionary with core and valence contributions.
         unsym_cs_tensor (list): Unsymmetrized chemical shielding tensor matrixes on each ion as a list.
             e.g. [[[sigma11, sigma12, sigma13], [sigma21, sigma22, sigma23], [sigma31, sigma32, sigma33]], ...]

--- a/tests/io/vasp/test_outputs.py
+++ b/tests/io/vasp/test_outputs.py
@@ -932,9 +932,32 @@ class TestOutcar(PymatgenTest):
                 "tot": Magmom([0.0, 0.0, 0.0]),
             },
         )
+        expected_orbmom = (
+            {
+                "p": Magmom([0.0, 0.0, 0.0]),
+                "d": Magmom([0.109, 0.109, 0.109]),
+                "tot": Magmom([0.108, 0.108, 0.108]),
+            },
+            {
+                "p": Magmom([0.0, 0.0, 0.0]),
+                "d": Magmom([-0.109, -0.109, -0.109]),
+                "tot": Magmom([-0.108, -0.108, -0.108]),
+            },
+            {
+                "p": Magmom([0.0, 0.0, 0.0]),
+                "d": Magmom([0.0, 0.0, 0.0]),
+                "tot": Magmom([0.0, 0.0, 0.0]),
+            },
+            {
+                "p": Magmom([0.0, 0.0, 0.0]),
+                "d": Magmom([0.0, 0.0, 0.0]),
+                "tot": Magmom([0.0, 0.0, 0.0]),
+            },
+        )
         # test note: Magmom class uses np.allclose() when testing for equality
         # so fine to use == operator here
         assert outcar.magnetization == expected_mag, "Wrong vector magnetization read from Outcar for SOC calculation"
+        assert outcar.orbital_moment == expected_orbmom, "Wrong orbital moments read from Outcar for SOC calculation"
 
         assert outcar.noncollinear is True
 


### PR DESCRIPTION
## Summary

Major changes:

- Add support for parsing orbital moments from OUTCAR
- Update the magnetization parsing test to check orbital moments from `OUTCAR.NiO_SOC.gz`.

## Todos

I opened this as a WIP since I have not contributed to `pymatgen` before, but it's technically complete. As far as I know, VASP does not write orbital moments anywhere besides `OUTCAR`, but if it does, I'd be happy to implement a parser if there's interest.

To minimize changes, I kept the code style consistent with the magnetization parsing in the `Outcar` class. However, it's a bit ugly due to the three extra boolean variables. I'm happy to rewrite that entire part to make it more compact.

The final thing to note is that the spin contribution to the magnetization is always with respect to `SAXIS` (there's a `#TODO` comment for that in the code), whereas orbital magnetization is always in Cartesian coordinates. Thus, the `saxis` property of the resultant `Magmom` objects for the orbital moments (the default `[0 0 1]`) is correct, but it's not generally correct for the spin contribution to the magnetic moments.

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] ~Type annotations included. Check with `mypy`.~ *(none needed)*
- [x] Tests added for new features/fixes.
- [x] ~If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))~ *(not applicable)*