### PR TITLE
Add `Composition.charge and `charge_balanced` properties

### DIFF
--- a/pymatgen/analysis/structure_prediction/substitutor.py
+++ b/pymatgen/analysis/structure_prediction/substitutor.py
@@ -38,6 +38,8 @@ class Substitutor(MSONable):
     Inorganic Chemistry, 50(2), 656-663. doi:10.1021/ic102031h.
     """
 
+    charge_balanced_tol: float = 1e-9
+
     def __init__(self, threshold=1e-3, symprec: float = 0.1, **kwargs):
         """
         This substitutor uses the substitution probability class to
@@ -158,9 +160,9 @@ class Substitutor(MSONable):
         return transmuter.transformed_structures
 
     @staticmethod
-    def _is_charge_balanced(struct):
+    def _is_charge_balanced(struct) -> bool:
         """Checks if the structure object is charge balanced."""
-        return sum(site.specie.oxi_state for site in struct) == 0.0
+        return abs(sum(site.specie.oxi_state for site in struct)) < Substitutor.charge_balanced_tol
 
     @staticmethod
     def _is_from_chemical_system(chemical_system, struct):
@@ -175,11 +177,9 @@ class Substitutor(MSONable):
         through these possibilities. The brute force method would be::
 
             output = []
-            for p in itertools.product(self._sp.species_list
-                                       , repeat = len(species_list)):
-                if self._sp.conditional_probability_list(p, species_list)
-                                       > self._threshold:
-                    output.append(dict(zip(species_list,p)))
+            for p in itertools.product(self._sp.species_list, repeat=len(species_list)):
+                if self._sp.conditional_probability_list(p, species_list) > self._threshold:
+                    output.append(dict(zip(species_list, p)))
             return output
 
         Instead of that we do a branch and bound.

--- a/tests/analysis/structure_prediction/test_substitution_probability.py
+++ b/tests/analysis/structure_prediction/test_substitution_probability.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
 import unittest
 
 from pytest import approx
@@ -20,14 +19,9 @@ def get_table():
     initialization time, and make unit tests insensitive to changes in the
     default lambda table.
     """
-    data_dir = os.path.join(
-        TEST_FILES_DIR,
-        "struct_predictor",
-    )
-
-    json_file = f"{data_dir}/test_lambda.json"
-    with open(json_file) as f:
-        return json.load(f)
+    json_path = f"{TEST_FILES_DIR}/struct_predictor/test_lambda.json"
+    with open(json_path) as file:
+        return json.load(file)
 
 
 class TestSubstitutionProbability(unittest.TestCase):

--- a/tests/analysis/structure_prediction/test_substitutor.py
+++ b/tests/analysis/structure_prediction/test_substitutor.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
 
 from pymatgen.analysis.structure_prediction.substitutor import Substitutor
 from pymatgen.core import Composition, Species
@@ -14,13 +13,9 @@ def get_table():
     initialization time, and make unit tests insensitive to changes in the
     default lambda table.
     """
-    data_dir = os.path.join(
-        TEST_FILES_DIR,
-        "struct_predictor",
-    )
-    json_file = f"{data_dir}/test_lambda.json"
-    with open(json_file) as f:
-        return json.load(f)
+    json_path = f"{TEST_FILES_DIR}/struct_predictor/test_lambda.json"
+    with open(json_path) as file:
+        return json.load(file)
 
 
 class TestSubstitutor(PymatgenTest):

--- a/tests/analysis/test_local_env.py
+++ b/tests/analysis/test_local_env.py
@@ -59,15 +59,15 @@ class TestValenceIonicRadiusEvaluator(PymatgenTest):
             [0.5, 0.5, 0.5],
         ]
         self._mgo_uc = Structure(mgo_latt, mgo_specie, mgo_frac_cord, validate_proximity=True, to_unit_cell=True)
-        self._mgo_valrad_evaluator = ValenceIonicRadiusEvaluator(self._mgo_uc)
+        self._mgo_val_rad_evaluator = ValenceIonicRadiusEvaluator(self._mgo_uc)
 
     def test_valences_ionic_structure(self):
-        valence_dict = self._mgo_valrad_evaluator.valences
+        valence_dict = self._mgo_val_rad_evaluator.valences
         for val in list(valence_dict.values()):
             assert val in {2, -2}
 
     def test_radii_ionic_structure(self):
-        radii_dict = self._mgo_valrad_evaluator.radii
+        radii_dict = self._mgo_val_rad_evaluator.radii
         for rad in list(radii_dict.values()):
             assert rad in {0.86, 1.26}
 

--- a/tests/core/test_composition.py
+++ b/tests/core/test_composition.py
@@ -712,6 +712,24 @@ class TestComposition(PymatgenTest):
         c_new_4 = Ca2NF_oxi.replace(example_sub_4)
         assert c_new_4 == Composition("Mg2O2").add_charges_from_oxi_state_guesses()
 
+    def test_is_charge_balanced(self):
+        false_dct = dict.fromkeys("FeO FeO2 MgO Mg2O3 Mg2O4".split(), False)
+        true_dct = dict.fromkeys("Fe2O3 FeO CaTiO3 SrTiO3 MgO Mg2O2".split(), True)
+
+        for formula, expected in (false_dct | true_dct).items():
+            comp = Composition(formula)
+            # by default, compositions contain elements, not species and hence have no oxidation states
+            assert comp.charge is None
+
+            # convert elements to species with oxidation states
+            oxi_comp = comp.add_charges_from_oxi_state_guesses()
+            assert oxi_comp.charge_balanced is expected, f"Failed for {formula=}"
+
+            if expected is True:
+                assert abs(oxi_comp.charge) < Composition.charge_balanced_tolerance
+            else:
+                assert oxi_comp.charge is None
+
 
 class TestChemicalPotential(unittest.TestCase):
     def test_init(self):

--- a/tests/transformations/test_advanced_transformations.py
+++ b/tests/transformations/test_advanced_transformations.py
@@ -59,10 +59,9 @@ def get_table():
     initialization time, and make unit tests insensitive to changes in the
     default lambda table.
     """
-    data_dir = f"{TEST_FILES_DIR}/struct_predictor"
-    json_file = f"{data_dir}/test_lambda.json"
-    with open(json_file) as f:
-        return json.load(f)
+    json_path = f"{TEST_FILES_DIR}/struct_predictor/test_lambda.json"
+    with open(json_path) as file:
+        return json.load(file)
 
 
 enum_cmd = which("enum.x") or which("multienum.x")


### PR DESCRIPTION
c47cf6d6c breaking: add `Substitutor.charge_balanced_tol: float = 1e-9` used in `_is_charge_balanced()`, prev had to be strictly 0
5945e95d5 refactor
723a56209 `Composition` add properties `charge` and `charge_balanced`
c5f8c7b71 Add `TestComposition.test_is_charge_balanced`