### PR TITLE
Improve doc strings substitution_probability.py

### DIFF
--- a/pymatgen/analysis/structure_prediction/substitution_probability.py
+++ b/pymatgen/analysis/structure_prediction/substitution_probability.py
@@ -85,8 +85,8 @@ class SubstitutionProbability:
     def get_lambda(self, s1, s2):
         """
         Args:
-            s1 (Structure): 1st Structure
-            s2 (Structure): 2nd Structure.
+            s1 (Element|Specie|str): Describes Ion in 1st Structure
+            s2 (Element|Specie|str): Describes Ion in 2nd Structure.
 
         Returns:
             Lambda values

--- a/pymatgen/analysis/structure_prediction/substitution_probability.py
+++ b/pymatgen/analysis/structure_prediction/substitution_probability.py
@@ -85,8 +85,8 @@ class SubstitutionProbability:
     def get_lambda(self, s1, s2):
         """
         Args:
-            s1 (Element|Specie|str): Describes Ion in 1st Structure
-            s2 (Element|Specie|str): Describes Ion in 2nd Structure.
+            s1 (Element/Species/str/int): Describes Ion in 1st Structure
+            s2 (Element/Species/str/int): Describes Ion in 2nd Structure.
 
         Returns:
             Lambda values


### PR DESCRIPTION
## Summary

Just saw this inconsistency by chance. The doc string claims the input are structures but then `get_el_sp` is used on the object.