### PR TITLE
fix reciprocal_density in MPHSEBSSet and tests

### DIFF
--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -1457,10 +1457,10 @@ class MPHSEBSSet(MPHSERelaxSet):
         self.added_kpoints = added_kpoints if added_kpoints is not None else []
         self.mode = mode
 
-        if not reciprocal_density or "reciprocal_density" not in self.user_kpoints_settings:
-            self.reciprocal_density = 50
-        else:
+        if reciprocal_density or "reciprocal_density" in self.user_kpoints_settings:
             self.reciprocal_density = reciprocal_density or self.user_kpoints_settings["reciprocal_density"]
+        else:
+            self.reciprocal_density = 50
 
         self.kpoints_line_density = kpoints_line_density
         self.copy_chgcar = copy_chgcar

--- a/tests/io/vasp/test_sets.py
+++ b/tests/io/vasp/test_sets.py
@@ -1425,11 +1425,11 @@ class TestMPHSEBS(PymatgenTest):
 
         vis = self.set.from_prev_calc(prev_calc_dir=prev_run, mode="uniform", reciprocal_density=50)
         assert vis.reciprocal_density == 50
-        
+
         vis = self.set.from_prev_calc(prev_calc_dir=prev_run, mode="uniform", reciprocal_density=100)
         assert vis.reciprocal_density == 100
 
-        uks={"reciprocal_density":100}
+        uks = {"reciprocal_density": 100}
         vis = self.set.from_prev_calc(prev_calc_dir=prev_run, mode="uniform", user_kpoints_settings=uks)
         assert vis.reciprocal_density == 100
 

--- a/tests/io/vasp/test_sets.py
+++ b/tests/io/vasp/test_sets.py
@@ -1423,6 +1423,16 @@ class TestMPHSEBS(PymatgenTest):
         assert vis.incar["ISYM"] == 3
         assert len(vis.kpoints.kpts) == 180
 
+        vis = self.set.from_prev_calc(prev_calc_dir=prev_run, mode="uniform", reciprocal_density=50)
+        assert vis.reciprocal_density == 50
+        
+        vis = self.set.from_prev_calc(prev_calc_dir=prev_run, mode="uniform", reciprocal_density=100)
+        assert vis.reciprocal_density == 100
+
+        uks={"reciprocal_density":100}
+        vis = self.set.from_prev_calc(prev_calc_dir=prev_run, mode="uniform", user_kpoints_settings=uks)
+        assert vis.reciprocal_density == 100
+
         with pytest.warns(BadInputSetWarning, match=r"Hybrid functionals"):
             vis = self.set(PymatgenTest.get_structure("Li2O"), user_incar_settings={"ALGO": "Fast"})
             vis.incar.items()


### PR DESCRIPTION
This implements the fix proposed in and closes #3492.