### PR TITLE
`CifParser` only warn about `primitive` default value change to `False` if not passed to `parse_structures` explicitly

### DIFF
--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -1177,11 +1177,9 @@ class IStructure(SiteCollection, MSONable):
                 f"{msg.sg_symbol}!"
             )
 
-        if len(species) != len(coords):
-            raise ValueError(f"Supplied species and coords lengths ({len(species)} vs {len(coords)}) are different!")
-
-        if len(species) != len(magmoms):
-            raise ValueError(f"Supplied species and magmom lengths ({len(species)} vs {len(magmoms)}) are different!")
+        for name, var in (("coords", coords), ("magmoms", magmoms)):
+            if len(var) != len(species):
+                raise ValueError(f"Length mismatch: len({name})={len(var)} != {len(species)=}")
 
         frac_coords = coords if not coords_are_cartesian else latt.get_fractional_coords(coords)
 

--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -1152,7 +1152,7 @@ class CifParser:
 
     def parse_structures(
         self,
-        primitive: bool = False,
+        primitive: bool | None = None,
         symmetrized: bool = False,
         check_occu: bool = True,
         on_error: Literal["ignore", "warn", "raise"] = "warn",
@@ -1183,12 +1183,14 @@ class CifParser:
         """
         if os.getenv("CI") and datetime.now() > datetime(2024, 3, 1):  # March 2024 seems long enough # pragma: no cover
             raise RuntimeError("remove the change of default primitive=True to False made on 2023-10-24")
-        warnings.warn(
-            "The default value of primitive was changed from True to False in "
-            "https://github.com/materialsproject/pymatgen/pull/3419. CifParser now returns the cell "
-            "in the CIF file as is. If you want the primitive cell, please set primitive=True explicitly.",
-            UserWarning,
-        )
+        if primitive is None:
+            primitive = False
+            warnings.warn(
+                "The default value of primitive was changed from True to False in "
+                "https://github.com/materialsproject/pymatgen/pull/3419. CifParser now returns the cell "
+                "in the CIF file as is. If you want the primitive cell, please set primitive=True explicitly.",
+                UserWarning,
+            )
         if not check_occu:  # added in https://github.com/materialsproject/pymatgen/pull/2836
             warnings.warn("Structures with unphysical site occupancies are not compatible with many pymatgen features.")
         if primitive and symmetrized:


### PR DESCRIPTION
This gets rid of unnecessary warnings where the user or `pymatgen` internal code is passing in `primitive=True` or `False` to `CifParser.parse_structures` explicitly and so doesn't need to be warned about a change in default value.