### PR TITLE
Reduce the lower-bound pin on numpy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         "matplotlib>=1.5",
         "monty>=3.0.2",
         "networkx>=2.2",
-        "numpy>=1.25.0",
+        "numpy>=1.23.0",
         "palettable>=3.1.1",
         "pandas",
         "plotly>=4.5.0",


### PR DESCRIPTION
This is a test to see if the >=1.25.0 is actually needed.