### PR TITLE
Add bold flag to `latexify`

### DIFF
--- a/pymatgen/analysis/chemenv/connectivity/connected_components.py
+++ b/pymatgen/analysis/chemenv/connectivity/connected_components.py
@@ -743,7 +743,7 @@ class ConnectedComponent(MSONable):
         return centered_connected_subgraph
 
     @staticmethod
-    def _edgekey_to_edgedictkey(key):
+    def _edge_key_to_edge_dict_key(key):
         if isinstance(key, int):
             return str(key)
         if isinstance(key, str):
@@ -817,7 +817,7 @@ class ConnectedComponent(MSONable):
                 in2 = node2stringindex[n2]
                 new_dict_of_dicts[in1][in2] = {}
                 for ie, edge_data in edges_dict.items():
-                    ied = self._edgekey_to_edgedictkey(ie)
+                    ied = self._edge_key_to_edge_dict_key(ie)
                     new_dict_of_dicts[in1][in2][ied] = jsanitize(edge_data)
         return {
             "@module": type(self).__module__,

--- a/pymatgen/phonon/bandstructure.py
+++ b/pymatgen/phonon/bandstructure.py
@@ -140,17 +140,17 @@ class PhononBandStructure(MSONable):
         self.nac_frequencies = []
         self.nac_eigendisplacements = []
         if nac_frequencies is not None:
-            for t in nac_frequencies:
-                self.nac_frequencies.append(([i / np.linalg.norm(t[0]) for i in t[0]], t[1]))
+            for freq in nac_frequencies:
+                self.nac_frequencies.append(([idx / np.linalg.norm(freq[0]) for idx in freq[0]], freq[1]))
         if nac_eigendisplacements is not None:
-            for t in nac_eigendisplacements:
-                self.nac_eigendisplacements.append(([i / np.linalg.norm(t[0]) for i in t[0]], t[1]))
+            for freq in nac_eigendisplacements:
+                self.nac_eigendisplacements.append(([idx / np.linalg.norm(freq[0]) for idx in freq[0]], freq[1]))
 
     def min_freq(self) -> tuple[Kpoint, float]:
         """Returns the point where the minimum frequency is reached and its value."""
-        i = np.unravel_index(np.argmin(self.bands), self.bands.shape)
+        idx = np.unravel_index(np.argmin(self.bands), self.bands.shape)
 
-        return self.qpoints[i[1]], self.bands[i]
+        return self.qpoints[idx[1]], self.bands[idx]
 
     def has_imaginary_freq(self, tol: float = 1e-5) -> bool:
         """True if imaginary frequencies are present in the BS."""

--- a/pymatgen/phonon/plotter.py
+++ b/pymatgen/phonon/plotter.py
@@ -274,24 +274,15 @@ class PhononBSPlotter:
     def _make_ticks(self, ax: Axes) -> Axes:
         """Utility private method to add ticks to a band structure."""
         ticks = self.get_ticks()
-        # Sanitize only plot the uniq values
-        uniq_d = []
-        uniq_l = []
-        temp_ticks = list(zip(ticks["distance"], ticks["label"]))
-        for idx, tt in enumerate(temp_ticks):
-            if idx == 0:
-                uniq_d.append(tt[0])
-                uniq_l.append(tt[1])
-            else:
-                uniq_d.append(tt[0])
-                uniq_l.append(tt[1])
 
-        ax.set_xticks(uniq_d)
-        ax.set_xticklabels(uniq_l)
+        # zip to sanitize, only plot the uniq values
+        xs, labels = zip(*zip(ticks["distance"], ticks["label"]))
+        ax.set_xticks(xs)
+        ax.set_xticklabels(labels)
 
         for idx, label in enumerate(ticks["label"]):
             if label is not None:
-                ax.axvline(ticks["distance"][idx], color="k")
+                ax.axvline(ticks["distance"][idx], color="black")
         return ax
 
     def bs_plot_data(self) -> dict[str, Any]:

--- a/pymatgen/phonon/plotter.py
+++ b/pymatgen/phonon/plotter.py
@@ -280,9 +280,10 @@ class PhononBSPlotter:
         ticks = self.get_ticks()
 
         # zip to sanitize, only plot the uniq values
-        xs, labels = zip(*zip(ticks["distance"], ticks["label"]))
-        ax.set_xticks(xs)
-        ax.set_xticklabels(labels)
+        ticks_labels = list(zip(*zip(ticks["distance"], ticks["label"])))
+        if ticks_labels:
+            ax.set_xticks(ticks_labels[0])
+            ax.set_xticklabels(ticks_labels[1])
 
         for idx, label in enumerate(ticks["label"]):
             if label is not None:

--- a/pymatgen/phonon/plotter.py
+++ b/pymatgen/phonon/plotter.py
@@ -268,8 +268,12 @@ class PhononBSPlotter:
                 "not along symmetry lines won't work)"
             )
         self._bs = bs
-        self._nb_bands = bs.nb_bands
         self._label = label
+
+    @property
+    def n_bands(self) -> int:
+        """Number of bands."""
+        return self._bs.nb_bands
 
     def _make_ticks(self, ax: Axes) -> Axes:
         """Utility private method to add ticks to a band structure."""
@@ -306,7 +310,7 @@ class PhononBSPlotter:
             frequency.append([])
             distance.append([self._bs.distance[j] for j in range(branch["start_index"], branch["end_index"] + 1)])
 
-            for idx in range(self._nb_bands):
+            for idx in range(self.n_bands):
                 frequency[-1].append(
                     [self._bs.bands[idx][j] for j in range(branch["start_index"], branch["end_index"] + 1)]
                 )
@@ -337,14 +341,14 @@ class PhononBSPlotter:
         data = self.bs_plot_data()
         kwargs.setdefault("color", "blue")
         for dists, freqs in zip(data["distances"], data["frequency"]):
-            for idx in range(self._nb_bands):
+            for idx in range(self.n_bands):
                 ys = [freqs[idx][j] * u.factor for j in range(len(dists))]
                 ax.plot(dists, ys, **kwargs)
 
         self._make_ticks(ax)
 
         # plot y=0 line
-        ax.axhline(0, linewidth=1, color="k")
+        ax.axhline(0, linewidth=1, color="black")
 
         # Main X and Y Labels
         ax.set_xlabel(r"$\mathrm{Wave\ Vector}$", fontsize=30)
@@ -365,7 +369,7 @@ class PhononBSPlotter:
         """Compute the weight for each combination of sites according to the
         eigenvector.
         """
-        num_atom = int(self._nb_bands / 3)
+        num_atom = int(self.n_bands / 3)
         new_vec = np.zeros(num_atom)
         for idx in range(num_atom):
             new_vec[idx] = np.linalg.norm(vec[idx * 3 : idx * 3 + 3])
@@ -452,13 +456,13 @@ class PhononBSPlotter:
         for d in range(1, len(k_dist)):
             # consider 2 k points each time so they connect
             colors = []
-            for idx in range(self._nb_bands):
+            for idx in range(self.n_bands):
                 eigenvec_1 = self._bs.eigendisplacements[idx][d - 1].flatten()
                 eigenvec_2 = self._bs.eigendisplacements[idx][d].flatten()
                 colors1 = self._get_weight(eigenvec_1, indices)
                 colors2 = self._get_weight(eigenvec_2, indices)
                 colors.append(self._make_color((colors1 + colors2) / 2))
-            seg = np.zeros((self._nb_bands, 2, 2))
+            seg = np.zeros((self.n_bands, 2, 2))
             seg[:, :, 1] = self._bs.bands[:, d - 1 : d + 1] * u.factor
             seg[:, 0, 0] = k_dist[d - 1]
             seg[:, 1, 0] = k_dist[d]
@@ -622,10 +626,10 @@ class PhononBSPlotter:
         other_kwargs = other_kwargs or {}
         legend_kwargs.setdefault("fontsize", 20)
 
-        data_orig = self.bs_plot_data()
-        data = other_plotter.bs_plot_data()
+        self_data = self.bs_plot_data()
+        other_data = other_plotter.bs_plot_data()
 
-        if len(data_orig["distances"]) != len(data["distances"]):
+        if len(self_data["distances"]) != len(other_data["distances"]):
             if on_incompatible == "raise":
                 raise ValueError("The two band structures are not compatible.")
             if on_incompatible == "warn":
@@ -638,10 +642,10 @@ class PhononBSPlotter:
 
         kwargs.setdefault("color", "red")  # don't move this line up! it would mess up self.get_plot color
 
-        for band_idx in range(other_plotter._nb_bands):
-            for dist_idx, dists in enumerate(data_orig["distances"]):
+        for band_idx in range(other_plotter.n_bands):
+            for dist_idx, dists in enumerate(self_data["distances"]):
                 xs = dists
-                ys = [data["frequency"][dist_idx][band_idx][j] * unit.factor for j in range(len(dists))]
+                ys = [other_data["frequency"][dist_idx][band_idx][j] * unit.factor for j in range(len(dists))]
                 ax.plot(xs, ys, **(kwargs | other_kwargs))
 
         # add legend showing which color corresponds to which band structure
@@ -989,7 +993,7 @@ class GruneisenPhononBSPlotter(PhononBSPlotter):
             gruneisen.append([])
             distance.append([self._bs.distance[j] for j in range(branch["start_index"], branch["end_index"] + 1)])
 
-            for idx in range(self._nb_bands):
+            for idx in range(self.n_bands):
                 frequency[-1].append(
                     [self._bs.bands[idx][j] for j in range(branch["start_index"], branch["end_index"] + 1)]
                 )
@@ -1021,7 +1025,7 @@ class GruneisenPhononBSPlotter(PhononBSPlotter):
 
         data = self.bs_plot_data()
         for dist_idx in range(len(data["distances"])):
-            for band_idx in range(self._nb_bands):
+            for band_idx in range(self.n_bands):
                 ys = [data["gruneisen"][dist_idx][band_idx][idx] for idx in range(len(data["distances"][dist_idx]))]
 
                 ax.plot(data["distances"][dist_idx], ys, "b-", **kwargs)
@@ -1029,7 +1033,7 @@ class GruneisenPhononBSPlotter(PhononBSPlotter):
         self._make_ticks(ax)
 
         # plot y=0 line
-        ax.axhline(0, linewidth=1, color="k")
+        ax.axhline(0, linewidth=1, color="black")
 
         # Main X and Y Labels
         ax.set_xlabel(r"$\mathrm{Wave\ Vector}$", fontsize=30)
@@ -1096,7 +1100,7 @@ class GruneisenPhononBSPlotter(PhononBSPlotter):
 
         ax = self.get_plot()
         band_linewidth = 1
-        for band_idx in range(other_plotter._nb_bands):
+        for band_idx in range(other_plotter.n_bands):
             for dist_idx in range(len(data_orig["distances"])):
                 ax.plot(
                     data_orig["distances"][dist_idx],

--- a/pymatgen/util/string.py
+++ b/pymatgen/util/string.py
@@ -145,7 +145,7 @@ def charge_string(charge, brackets=True, explicit_one=True):
     return chg_str
 
 
-def latexify(formula):
+def latexify(formula: str, bold: bool = False):
     """Generates a LaTeX formatted formula. E.g., Fe2O3 is transformed to
     Fe$_{2}$O$_{3}$.
 
@@ -154,11 +154,12 @@ def latexify(formula):
 
     Args:
         formula (str): Input formula.
+        bold (bool): Whether to make the subscripts bold. Defaults to False.
 
     Returns:
         Formula suitable for display as in LaTeX with proper subscripts.
     """
-    return re.sub(r"([A-Za-z\(\)])([\d\.]+)", r"\1$_{\2}$", formula)
+    return re.sub(r"([A-Za-z\(\)])([\d\.]+)", r"\1$_{\\mathbf{\2}}$" if bold else r"\1$_{\2}$", formula)
 
 
 def htmlify(formula):

--- a/tests/analysis/chemenv/connectivity/test_connected_components.py
+++ b/tests/analysis/chemenv/connectivity/test_connected_components.py
@@ -125,13 +125,13 @@ class TestConnectedComponent(PymatgenTest):
         sorted_edges = sorted(sorted(e) for e in cc.graph.edges())
         assert sorted_edges == ref_sorted_edges
 
-        ccfromdict = ConnectedComponent.from_dict(cc.as_dict())
-        ccfromjson = ConnectedComponent.from_dict(json.loads(json.dumps(cc.as_dict())))
-        loaded_cc_list = [ccfromdict, ccfromjson]
+        cc_from_dict = ConnectedComponent.from_dict(cc.as_dict())
+        cc_from_json = ConnectedComponent.from_dict(json.loads(json.dumps(cc.as_dict())))
+        loaded_cc_list = [cc_from_dict, cc_from_json]
         if bson is not None:
             bson_data = bson.BSON.encode(cc.as_dict())
-            ccfrombson = ConnectedComponent.from_dict(bson_data.decode())
-            loaded_cc_list.append(ccfrombson)
+            cc_from_bson = ConnectedComponent.from_dict(bson_data.decode())
+            loaded_cc_list.append(cc_from_bson)
         for loaded_cc in loaded_cc_list:
             assert loaded_cc.graph.number_of_nodes() == 3
             assert loaded_cc.graph.number_of_edges() == 2
@@ -145,18 +145,18 @@ class TestConnectedComponent(PymatgenTest):
                 assert isinstance(node.central_site, PeriodicSite)
 
     def test_serialization_private_methods(self):
-        # Testing _edgekey_to_edgedictkey
-        key = ConnectedComponent._edgekey_to_edgedictkey(3)
+        # Testing _edge_key_to_edge_dict_key
+        key = ConnectedComponent._edge_key_to_edge_dict_key(3)
         assert key == "3"
         with pytest.raises(
             RuntimeError,
             match=r"Cannot pass an edge key which is a str representation of an int\x2E",
         ):
-            key = ConnectedComponent._edgekey_to_edgedictkey("5")
-        key = ConnectedComponent._edgekey_to_edgedictkey("some-key")
+            key = ConnectedComponent._edge_key_to_edge_dict_key("5")
+        key = ConnectedComponent._edge_key_to_edge_dict_key("some-key")
         assert key == "some-key"
         with pytest.raises(ValueError, match=r"Edge key should be either a str or an int\x2E"):
-            key = ConnectedComponent._edgekey_to_edgedictkey(0.2)
+            key = ConnectedComponent._edge_key_to_edge_dict_key(0.2)
 
     def test_periodicity(self):
         env_node1 = EnvironmentNode(central_site="Si", i_central_site=3, ce_symbol="T:4")

--- a/tests/files/.pytest-split-durations
+++ b/tests/files/.pytest-split-durations
@@ -2306,7 +2306,7 @@
     "tests/phonon/test_gruneisen.py::TestGruneisenParameter::test_average_gruneisen": 7.851578625966795,
     "tests/phonon/test_gruneisen.py::TestGruneisenParameter::test_debye_temp_phonopy": 7.661829167045653,
     "tests/phonon/test_gruneisen.py::TestGruneisenParameter::test_frequencies": 7.70038720802404,
-    "tests/phonon/test_gruneisen.py::TestGruneisenParameter::test_fromdict_asdict": 7.64449966698885,
+    "tests/phonon/test_gruneisen.py::TestGruneisenParameter::test_as_from_dict": 7.64449966698885,
     "tests/phonon/test_gruneisen.py::TestGruneisenParameter::test_gruneisen": 7.717112623970024,
     "tests/phonon/test_gruneisen.py::TestGruneisenParameter::test_multi": 6.107562876015436,
     "tests/phonon/test_gruneisen.py::TestGruneisenParameter::test_phdos": 7.646594374033157,

--- a/tests/phonon/test_gruneisen.py
+++ b/tests/phonon/test_gruneisen.py
@@ -60,7 +60,7 @@ class TestGruneisenParameter(PymatgenTest):
         ax = plotter.get_plot(units="mev")
         assert isinstance(ax, plt.Axes)
 
-    def test_fromdict_asdict(self):
+    def test_as_from_dict(self):
         new_dict = self.gruneisen_obj.as_dict()
         self.gruneisen_obj2 = GruneisenParameter.from_dict(new_dict)
 


### PR DESCRIPTION
LaTeX ignores bold surrounding text for subscripts in math mode so need to specify `\mathbf` explicitly to get bold subscripts.

**Before**
![Screenshot 2023-12-14 at 4 22 55 PM](https://github.com/materialsproject/pymatgen/assets/30958850/94de5078-6b62-4726-a331-d1d2b8b4df61)
**After (with `bold=True`)**
![Screenshot 2023-12-14 at 4 21 03 PM](https://github.com/materialsproject/pymatgen/assets/30958850/80edbea2-f86e-4a0a-8f56-6f18ee590149)


f91c0195c7 better var names
97cb2efc9b add bold flag to latexify to support bold subscripts
8952c923ab simplify tick generation in PhononBSPlotter._make_ticks
44233e327b add n_bands property to PhononBSPlotter