### PR TITLE
`Composition` raise `ValueError` if `formula` string is only numbers and spaces

### DIFF
--- a/pymatgen/core/composition.py
+++ b/pymatgen/core/composition.py
@@ -522,10 +522,12 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
             return any(category[0] in el.block for el in self.elements)
         return any(getattr(el, f"is_{category}") for el in self.elements)
 
-    def _parse_formula(self, formula: str) -> dict[str, float]:
+    def _parse_formula(self, formula: str, strict: bool = True) -> dict[str, float]:
         """
         Args:
             formula (str): A string formula, e.g. Fe2O3, Li3Fe2(PO4)3.
+            strict (bool): Whether to throw an error if formula string is invalid (e.g. empty).
+                Defaults to True.
 
         Returns:
             Composition with that formula.
@@ -534,6 +536,9 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
             In the case of Metallofullerene formula (e.g. Y3N@C80),
             the @ mark will be dropped and passed to parser.
         """
+        # throw if formula contains special characters or only spaces and/or numbers
+        if strict and re.match(r"[\s\d]*$", formula):
+            raise ValueError(f"Invalid {formula=}")
         # for Metallofullerene like "Y3N@C80"
         formula = formula.replace("@", "")
 

--- a/pymatgen/core/composition.py
+++ b/pymatgen/core/composition.py
@@ -537,7 +537,7 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
             the @ mark will be dropped and passed to parser.
         """
         # throw if formula contains special characters or only spaces and/or numbers
-        if strict and re.match(r"[\s\d]*$", formula):
+        if strict and re.match(r"[\s\d.*/]*$", formula):
             raise ValueError(f"Invalid {formula=}")
         # for Metallofullerene like "Y3N@C80"
         formula = formula.replace("@", "")

--- a/tests/core/test_composition.py
+++ b/tests/core/test_composition.py
@@ -186,6 +186,11 @@ class TestComposition(PymatgenTest):
 
         assert Composition("Na 3 Zr (PO 4) 3").reduced_formula == "Na3Zr(PO4)3"
 
+        # test bad formulas raise ValueError
+        for bad_formula in ("", " ", "  2", "4 2", "6123", "1.2", "1/2", "1.2.3"):
+            with pytest.raises(ValueError, match=f"Invalid formula={bad_formula!r}"):
+                Composition(bad_formula)
+
     def test_to_latex_html_unicode(self):
         assert self.comps[0].to_latex_string() == "Li$_{3}$Fe$_{2}$P$_{3}$O$_{12}$"
         assert self.comps[0].to_html_string() == "Li<sub>3</sub>Fe<sub>2</sub>P<sub>3</sub>O<sub>12</sub>"


### PR DESCRIPTION
Controlled by new `strict: bool = True` parameter to `_parse_formula`.