### PR TITLE
QCInput: add docstrings for svp and pcm_nonels

### DIFF
--- a/pymatgen/io/qchem/inputs.py
+++ b/pymatgen/io/qchem/inputs.py
@@ -152,6 +152,41 @@ class QCInput(InputFile):
                                 (1, 2)
                             ]
                         ]
+            svp (dict): Settings for the ISOSVP solvent model, corresponding to the $svp section
+                of the Q-Chem input file, which is formatted as a FORTRAN namelist. Note that in pymatgen, these
+                parameters are typically not set by the user, but rather are populated automatically by an InputSet.
+
+                An example for water may look like:
+                    {
+                        "RHOISO": "0.001",
+                        "DIELST": "78.36",
+                        "NPTLEB": "1202",
+                        "ITRNGR": "2",
+                        "IROTGR": "2",
+                        "IPNRF": "1",
+                        "IDEFESR": "1",
+                    }
+
+                See https://manual.q-chem.com/6.0/subsec_SS(V)PE.html in the Q-Chem manual for more
+                details.
+            pcm_nonels (dict): Settings for the non-electrostatic part of the CMIRS solvation
+                model, corresponding to the $pcm_nonels section of the Q-Chem input file/ Note that in pymatgen,
+                these parameters are typically not set by the user, but rather are populated automatically by an
+                InputSet.
+
+                An example for water may look like:
+                    {
+                        "a": "-0.006496",
+                        "b": "0.050833",
+                        "c": "-566.7",
+                        "d": "-30.503",
+                        "gamma": "3.2",
+                        "solvrho": "0.05",
+                        "delta": 7,
+                        "gaulag_n": 40,
+                    }
+
+                See https://manual.q-chem.com/6.0/example_CMIRS-water.html in the Q-Chem manual for more details.
         """
         self.molecule = molecule
         self.rem = lower_and_check_unique(rem)


### PR DESCRIPTION
## Summary

Documents the `svp` and `pcm_nonels` kwargs of `QCInput`. Closes #3432 