### PR TITLE
Fix label propagation in `Symmetry.from_spacegroup`

### DIFF
--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -1097,7 +1097,7 @@ class IStructure(SiteCollection, MSONable):
             for k, v in props.items():
                 all_site_properties[k].extend([v[idx]] * len(cc))
 
-        return cls(latt, all_sp, all_coords, site_properties=all_site_properties)
+        return cls(latt, all_sp, all_coords, site_properties=all_site_properties, labels=all_labels)
 
     @classmethod
     def from_magnetic_spacegroup(

--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -1307,8 +1307,10 @@ class TestStructure(PymatgenTest):
             ["Li", "O"],
             [[0.25, 0.25, 0.25], [0, 0, 0]],
             site_properties={"charge": [1, -2]},
+            labels=["A", "B"],
         )
         assert sum(s2.site_properties["charge"]) == 0
+        assert s2.labels == ["A", "A", "A", "A", "A", "A", "A", "A", "B", "B", "B", "B"]
 
         struct = Structure.from_spacegroup("Pm-3m", Lattice.cubic(3), ["Cs", "Cl"], [[0, 0, 0], [0.5, 0.5, 0.5]])
         assert struct.formula == "Cs1 Cl1"


### PR DESCRIPTION
Hi all, another small PR that makes sure labels are passed when a `Symmetry.from_spacegroup` is used. This follows-up on an earlier PR: https://github.com/materialsproject/pymatgen/pull/3183

## Summary

Major changes:

- fix 1: Fix label propagation in `Symmetry.from_spacegroup`

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [x] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
