### PR TITLE
Add GitHub Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,6 +1,5 @@
 name: Report a Bug
 description: Use this template to report a Pymatgen-related bug
-title: "[BUG]: "
 body:
   - type: input
     id: Python

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -2,16 +2,16 @@ name: Report a Bug
 description: Use this template to report a Pymatgen-related bug
 body:
   - type: input
-    id: Python
+    id: python-version
     attributes:
       label: Python version
-      description: Use `python -V` to get Python version
+      description: Use `python --version` to get Python version
       placeholder: ex. Python 3.11.5
     validations:
       required: true
 
   - type: input
-    id: pmgversion
+    id: pmg-version
     attributes:
       label: Pymatgen version
       description: Use `pip show pymatgen | grep Version` to get Pymatgen version
@@ -28,11 +28,11 @@ body:
       required: false
 
   - type: textarea
-    id: current-output
+    id: current-behavior
     attributes:
-      label: Current output
-      description: What current terminal output or log shows?
-      render: shell
+      label: Current behavior
+      description: What bad behavior do you see?
+      render: python
     validations:
       required: true
 
@@ -41,16 +41,14 @@ body:
     attributes:
       label: Expected Behavior
       description: What did you expect to see?
-      placeholder: e.g., an atomic structure should be generated.
     validations:
       required: true
 
   - type: textarea
     id: code-snippet
     attributes:
-      label: Minimal code snippet to reproduce this bug
+      label: Minimal example
       description: Please provide a minimal code snippet that could reproduce this bug.
-      placeholder: Show us your code please.
       render: python
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -32,7 +32,6 @@ body:
     attributes:
       label: Current output
       description: What current terminal output or log shows?
-      value:
       render: shell
     validations:
       required: true
@@ -43,7 +42,6 @@ body:
       label: Expected Behavior
       description: What did you expect to see?
       placeholder: e.g., an atomic structure should be generated.
-      value:
     validations:
       required: true
 
@@ -53,7 +51,6 @@ body:
       label: Minimal code snippet to reproduce this bug
       description: Please provide a minimal code snippet that could reproduce this bug.
       placeholder: Show us your code please.
-      value:
       render: python
     validations:
       required: false
@@ -64,6 +61,5 @@ body:
       label: Relevant files to reproduce this bug
       description: Please upload relevant files to help reproduce this bug, or logs if necessary.
       placeholder: Show us your file please.
-      value:
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,70 @@
+name: Report a Bug
+description: Use this template to report a Pymatgen-related bug
+title: "[BUG]: "
+body:
+  - type: input
+    id: Python
+    attributes:
+      label: Python version
+      description: Use `python -V` to get Python version
+      placeholder: ex. Python 3.11.5
+    validations:
+      required: true
+
+  - type: input
+    id: pmgversion
+    attributes:
+      label: Pymatgen version
+      description: Use `pip show pymatgen | grep Version` to get Pymatgen version
+      placeholder: ex. 2023.12.18
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system version
+      placeholder: ex. Ubuntu 22.04 LTS
+    validations:
+      required: false
+
+  - type: textarea
+    id: current-output
+    attributes:
+      label: Current output
+      description: What current terminal output or log shows?
+      value:
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to see?
+      placeholder: e.g., an atomic structure should be generated.
+      value:
+    validations:
+      required: true
+
+  - type: textarea
+    id: code-snippet
+    attributes:
+      label: Minimal code snippet to reproduce this bug
+      description: Please provide a minimal code snippet that could reproduce this bug.
+      placeholder: Show us your code please.
+      value:
+      render: python
+    validations:
+      required: false
+
+  - type: textarea
+    id: files
+    attributes:
+      label: Relevant files to reproduce this bug
+      description: Please upload relevant files to help reproduce this bug, or logs if necessary.
+      placeholder: Show us your file please.
+      value:
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -48,7 +48,7 @@ body:
     id: code-snippet
     attributes:
       label: Minimal example
-      description: Please provide a minimal code snippet that could reproduce this bug.
+      description: Please provide a minimal code snippet to reproduce this bug.
       render: python
     validations:
       required: false
@@ -57,7 +57,6 @@ body:
     id: files
     attributes:
       label: Relevant files to reproduce this bug
-      description: Please upload relevant files to help reproduce this bug, or logs if necessary.
-      placeholder: Show us your file please.
+      description: Please upload relevant files to help reproduce this bug, or logs if helpful.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,6 +1,5 @@
 name: Request a Feature
 description: Use this template to request a new feature
-title: "[Feature Request]: "
 body:
   - type: textarea
     id: feature

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -7,7 +7,6 @@ body:
       label: Feature Requested
       description: Specify the feature and provide examples or use cases.
       placeholder: e.g., Generate atomic structures with specific symmetry constraints ...
-      value:
     validations:
       required: true
 
@@ -17,7 +16,6 @@ body:
       label: Proposed Solution
       description: Share your thoughts on how the feature could be implemented.
       placeholder: e.g., Implement through a new method ...
-      value:
     validations:
       required: true
 
@@ -27,6 +25,5 @@ body:
       label: Relevant Information
       description: Include additional context or links helpful for understanding or implementing the feature.
       placeholder: e.g., Context about use cases, related discussions, or relevant literature ...
-      value:
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -5,8 +5,8 @@ body:
     id: feature
     attributes:
       label: Feature Requested
-      description: Tell us what you want to achieve with Pymatgen. Provide specific examples or use cases.
-      placeholder: e.g., I would like to generate atomic structures with specific symmetry constraints...
+      description: Specify the feature and provide examples or use cases.
+      placeholder: e.g., Generate atomic structures with specific symmetry constraints ...
       value:
     validations:
       required: true
@@ -15,9 +15,8 @@ body:
     id: solution
     attributes:
       label: Proposed Solution
-      description: Do you already have any proposed solution in mind? Share your thoughts on how this feature could be implemented.
-      placeholder: e.g., I would like to achieve this through a new method in the Structure class...
-      value:
+      description: Share your thoughts on how the feature could be implemented.
+      placeholder: e.g., Implement through a new method ...
       value:
     validations:
       required: true
@@ -26,8 +25,8 @@ body:
     id: relevant
     attributes:
       label: Relevant Information
-      description: Do you have any other relevant information that might be helpful for understanding or implementing this feature?
-      placeholder: e.g., Additional context about specific use cases, related discussions, or links to relevant literature...
+      description: Include additional context or links helpful for understanding or implementing the feature.
+      placeholder: e.g., Context about use cases, related discussions, or relevant literature ...
       value:
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,34 @@
+name: Request a Feature
+description: Use this template to request a new feature
+title: "[Feature Request]: "
+body:
+  - type: textarea
+    id: feature
+    attributes:
+      label: Feature Requested
+      description: Tell us what you want to achieve with Pymatgen. Provide specific examples or use cases.
+      placeholder: e.g., I would like to generate atomic structures with specific symmetry constraints...
+      value:
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Do you already have any proposed solution in mind? Share your thoughts on how this feature could be implemented.
+      placeholder: e.g., I would like to achieve this through a new method in the Structure class...
+      value:
+      value:
+    validations:
+      required: true
+
+  - type: textarea
+    id: relevant
+    attributes:
+      label: Relevant Information
+      description: Do you have any other relevant information that might be helpful for understanding or implementing this feature?
+      placeholder: e.g., Additional context about specific use cases, related discussions, or links to relevant literature...
+      value:
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,4 +1,4 @@
-name: Request a Feature
+name: Feature Reqest
 description: Use this template to request a new feature
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -6,7 +6,6 @@ body:
     attributes:
       label: Feature Requested
       description: Specify the feature and provide examples or use cases.
-      placeholder: e.g., Generate atomic structures with specific symmetry constraints ...
     validations:
       required: true
 
@@ -15,7 +14,7 @@ body:
     attributes:
       label: Proposed Solution
       description: Share your thoughts on how the feature could be implemented.
-      placeholder: e.g., Implement through a new method ...
+      placeholder: Implement a new method that ...
     validations:
       required: true
 
@@ -23,7 +22,7 @@ body:
     id: relevant
     attributes:
       label: Relevant Information
-      description: Include additional context or links helpful for understanding or implementing the feature.
-      placeholder: e.g., Context about use cases, related discussions, or relevant literature ...
+      description: Additional context or links for understanding or implementing the feature.
+      placeholder: Use cases, related discussions, relevant literature, ...
     validations:
       required: false


### PR DESCRIPTION
# Summary

This pull request addresses suggestions made in issue #3449 by adding two new issue templates.

Major changes:

- Added a new issue template for "Bug Report."
- Included an issue template for "Feature Request," aligning it with the original issue template format.

Please feel free to provide any suggestions or feedback.
