### PR TITLE
Bug fix: SpectrumPlotter.add_spectra

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -32,7 +32,7 @@ body:
     attributes:
       label: Current behavior
       description: What bad behavior do you see?
-      render: python
+      render: Python
     validations:
       required: true
 
@@ -49,7 +49,7 @@ body:
     attributes:
       label: Minimal example
       description: Please provide a minimal code snippet to reproduce this bug.
-      render: python
+      render: Python
     validations:
       required: false
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,4 +1,4 @@
-name: Feature Reqest
+name: Feature Request
 description: Use this template to request a new feature
 body:
   - type: textarea

--- a/docs/apidoc/conf.py
+++ b/docs/apidoc/conf.py
@@ -320,7 +320,7 @@ epub_copyright = copyright
 # The format is a list of tuples containing the path and title.
 # epub_pre_files = []
 
-# HTML files shat should be inserted after the pages created by sphinx.
+# HTML files that should be inserted after the pages created by sphinx.
 # The format is a list of tuples containing the path and title.
 # epub_post_files = []
 

--- a/pymatgen/apps/battery/plotter.py
+++ b/pymatgen/apps/battery/plotter.py
@@ -194,13 +194,12 @@ class VoltageProfilePlotter:
         """
         self.get_plot(width, height).show()
 
-    def save(self, filename, image_format="eps", width=8, height=6):
+    def save(self, filename: str, width: float = 8, height: float = 6) -> None:
         """Save the plot to an image file.
 
         Args:
-            filename: Filename to save to.
-            image_format: Format to save to. Defaults to eps.
+            filename (str): Filename to save to. Must include extension to specify image format.
             width: Width of the plot. Defaults to 8 in.
             height: Height of the plot. Defaults to 6 in.
         """
-        self.get_plot(width, height).savefig(filename, format=image_format)
+        self.get_plot(width, height).savefig(filename)

--- a/pymatgen/apps/battery/plotter.py
+++ b/pymatgen/apps/battery/plotter.py
@@ -106,7 +106,7 @@ class VoltageProfilePlotter:
             ax.plot(x, y, "-", linewidth=2, label=label)
 
         ax.legend()
-        ax.set_xlabel(self._choose_best_x_label(formula=formula, wion_symbol=working_ion_symbols))
+        ax.set_xlabel(self._choose_best_x_label(formula=formula, work_ion_symbol=working_ion_symbols))
         ax.set_ylabel("Voltage (V)")
         plt.tight_layout()
         return ax
@@ -155,7 +155,7 @@ class VoltageProfilePlotter:
                 width=width,
                 height=height,
                 font=font_dict,
-                xaxis={"title": self._choose_best_x_label(formula=formula, wion_symbol=working_ion_symbols)},
+                xaxis={"title": self._choose_best_x_label(formula=formula, work_ion_symbol=working_ion_symbols)},
                 yaxis={"title": "Voltage (V)"},
                 **kwargs,
             ),
@@ -164,7 +164,7 @@ class VoltageProfilePlotter:
         fig.update_layout(template="plotly_white", title_x=0.5)
         return fig
 
-    def _choose_best_x_label(self, formula, wion_symbol):
+    def _choose_best_x_label(self, formula, work_ion_symbol):
         if self.xaxis in {"capacity", "capacity_grav"}:
             return "Capacity (mAh/g)"
         if self.xaxis == "capacity_vol":
@@ -172,16 +172,16 @@ class VoltageProfilePlotter:
 
         formula = formula.pop() if len(formula) == 1 else None
 
-        wion_symbol = wion_symbol.pop() if len(wion_symbol) == 1 else None
+        work_ion_symbol = work_ion_symbol.pop() if len(work_ion_symbol) == 1 else None
 
         if self.xaxis == "x_form":
-            if formula and wion_symbol:
-                return f"x in {wion_symbol}<sub>x</sub>{formula}"
-            return "x Workion Ion per Host F.U."
+            if formula and work_ion_symbol:
+                return f"x in {work_ion_symbol}<sub>x</sub>{formula}"
+            return "x Work Ion per Host F.U."
 
         if self.xaxis == "frac_x":
-            if wion_symbol:
-                return f"Atomic Fraction of {wion_symbol}"
+            if work_ion_symbol:
+                return f"Atomic Fraction of {work_ion_symbol}"
             return "Atomic Fraction of Working Ion"
         raise RuntimeError("No xaxis label can be determined")
 

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -239,12 +239,11 @@ class DosPlotter:
         plt.tight_layout()
         return ax
 
-    def save_plot(self, filename, img_format="eps", xlim=None, ylim=None, invert_axes=False, beta_dashed=False) -> None:
+    def save_plot(self, filename: str, xlim=None, ylim=None, invert_axes=False, beta_dashed=False) -> None:
         """Save matplotlib plot to a file.
 
         Args:
-            filename: Filename to write to.
-            img_format: Image format to use. Defaults to EPS.
+            filename (str): Filename to write to. Must include extension to specify image format.
             xlim: Specifies the x-axis limits. Set to None for automatic
                 determination.
             ylim: Specifies the y-axis limits.
@@ -253,7 +252,7 @@ class DosPlotter:
             beta_dashed (bool): Plots the beta spin channel with a dashed line. Defaults to False.
         """
         self.get_plot(xlim, ylim, invert_axes, beta_dashed)
-        plt.savefig(filename, format=img_format)
+        plt.savefig(filename)
 
     def show(self, xlim=None, ylim=None, invert_axes=False, beta_dashed=False) -> None:
         """Show the plot using matplotlib.
@@ -732,19 +731,18 @@ class BSPlotter:
         self.get_plot(zero_to_efermi, ylim, smooth)
         plt.show()
 
-    def save_plot(self, filename, img_format="eps", ylim=None, zero_to_efermi=True, smooth=False) -> None:
+    def save_plot(self, filename: str, ylim=None, zero_to_efermi=True, smooth=False) -> None:
         """Save matplotlib plot to a file.
 
         Args:
-            filename: Filename to write to.
-            img_format: Image format to use. Defaults to EPS.
+            filename (str): Filename to write to. Must include extension to specify image format.
             ylim: Specifies the y-axis limits.
             zero_to_efermi: Automatically set the Fermi level as the plot's origin (i.e. subtract E - E_f).
                 Defaults to True.
             smooth: Cubic spline interpolation of the bands.
         """
         self.get_plot(ylim=ylim, zero_to_efermi=zero_to_efermi, smooth=smooth)
-        plt.savefig(filename, format=img_format)
+        plt.savefig(filename)
         plt.close()
 
     def get_ticks(self):
@@ -3791,19 +3789,18 @@ class CohpPlotter:
         plt.tight_layout()
         return ax
 
-    def save_plot(self, filename, img_format="eps", xlim=None, ylim=None) -> None:
+    def save_plot(self, filename: str, xlim=None, ylim=None) -> None:
         """Save matplotlib plot to a file.
 
         Args:
-            filename: File name to write to.
-            img_format: Image format to use. Defaults to EPS.
+            filename (str): File name to write to. Must include extension to specify image format.
             xlim: Specifies the x-axis limits. Defaults to None for
                 automatic determination.
             ylim: Specifies the y-axis limits. Defaults to None for
                 automatic determination.
         """
         self.get_plot(xlim, ylim)
-        plt.savefig(filename, format=img_format)
+        plt.savefig(filename)
 
     def show(self, xlim=None, ylim=None) -> None:
         """Show the plot using matplotlib.

--- a/pymatgen/vis/plotters.py
+++ b/pymatgen/vis/plotters.py
@@ -63,6 +63,7 @@ class SpectrumPlotter:
                 a dashed black line. If None, a color will be chosen based on
                 the default color cycle.
         """
+        assert hasattr(spectrum, 'x') and hasattr(spectrum, 'y'), f"{type(spectrum)} has no attribute x and y, please check!"
         self._spectra[label] = spectrum
         self.colors.append(color or self.colors_cycle[len(self._spectra) % len(self.colors_cycle)])
 

--- a/pymatgen/vis/plotters.py
+++ b/pymatgen/vis/plotters.py
@@ -77,7 +77,7 @@ class SpectrumPlotter:
         """
         keys = sorted(spectra_dict, key=key_sort_func) if key_sort_func else list(spectra_dict)
         for label in keys:
-            self.add_spectra(label, spectra_dict[label])
+            self.add_spectrum(label, spectra_dict[label])
 
     def get_plot(self, xlim=None, ylim=None):
         """

--- a/pymatgen/vis/plotters.py
+++ b/pymatgen/vis/plotters.py
@@ -68,11 +68,11 @@ class SpectrumPlotter:
 
     def add_spectra(self, spectra_dict, key_sort_func=None):
         """
-        Add a dictionary of doses, with an optional sorting function for the
+        Add a dictionary of Spectrum, with an optional sorting function for the
         keys.
 
         Args:
-            dos_dict: dict of {label: Dos}
+            dos_dict: dict of {label: Spectrum}
             key_sort_func: function used to sort the dos_dict keys.
         """
         keys = sorted(spectra_dict, key=key_sort_func) if key_sort_func else list(spectra_dict)

--- a/pymatgen/vis/plotters.py
+++ b/pymatgen/vis/plotters.py
@@ -63,7 +63,8 @@ class SpectrumPlotter:
                 a dashed black line. If None, a color will be chosen based on
                 the default color cycle.
         """
-        assert hasattr(spectrum, 'x') and hasattr(spectrum, 'y'), f"{type(spectrum)} has no attribute x and y, please check!"
+        assert hasattr(spectrum, 'x'), f"{type(spectrum)} has no attribute x, please check!"
+        assert hasattr(spectrum, 'y'), f"{type(spectrum)} has no attribute y, please check!"
         self._spectra[label] = spectrum
         self.colors.append(color or self.colors_cycle[len(self._spectra) % len(self.colors_cycle)])
 

--- a/pymatgen/vis/plotters.py
+++ b/pymatgen/vis/plotters.py
@@ -63,8 +63,8 @@ class SpectrumPlotter:
                 a dashed black line. If None, a color will be chosen based on
                 the default color cycle.
         """
-        assert hasattr(spectrum, 'x'), f"{type(spectrum)} has no attribute x, please check!"
-        assert hasattr(spectrum, 'y'), f"{type(spectrum)} has no attribute y, please check!"
+        assert hasattr(spectrum, "x"), f"{type(spectrum)} has no attribute x, please check!"
+        assert hasattr(spectrum, "y"), f"{type(spectrum)} has no attribute y, please check!"
         self._spectra[label] = spectrum
         self.colors.append(color or self.colors_cycle[len(self._spectra) % len(self.colors_cycle)])
 

--- a/pymatgen/vis/plotters.py
+++ b/pymatgen/vis/plotters.py
@@ -127,16 +127,15 @@ class SpectrumPlotter:
         plt.tight_layout()
         return ax
 
-    def save_plot(self, filename, img_format="eps", **kwargs):
+    def save_plot(self, filename: str, **kwargs):
         """
         Save matplotlib plot to a file.
 
         Args:
-            filename: Filename to write to.
-            img_format: Image format to use. Defaults to EPS.
+            filename (str): Filename to write to. Must include extension to specify image format.
         """
         self.get_plot(**kwargs)
-        plt.savefig(filename, format=img_format)
+        plt.savefig(filename)
 
     def show(self, **kwargs):
         """Show the plot using matplotlib."""

--- a/pymatgen/vis/plotters.py
+++ b/pymatgen/vis/plotters.py
@@ -72,7 +72,7 @@ class SpectrumPlotter:
         keys.
 
         Args:
-            dos_dict: dict of {label: Spectrum}
+            spectra_dict: dict of {label: Spectrum}
             key_sort_func: function used to sort the dos_dict keys.
         """
         keys = sorted(spectra_dict, key=key_sort_func) if key_sort_func else list(spectra_dict)

--- a/pymatgen/vis/plotters.py
+++ b/pymatgen/vis/plotters.py
@@ -63,8 +63,9 @@ class SpectrumPlotter:
                 a dashed black line. If None, a color will be chosen based on
                 the default color cycle.
         """
-        assert hasattr(spectrum, "x"), f"{type(spectrum)} has no attribute x, please check!"
-        assert hasattr(spectrum, "y"), f"{type(spectrum)} has no attribute y, please check!"
+        for attribute in "xy":
+            if not hasattr(spectrum, attribute):
+                raise ValueError(f"spectrum of type={type(spectrum)} missing required {attribute=}")
         self._spectra[label] = spectrum
         self.colors.append(color or self.colors_cycle[len(self._spectra) % len(self.colors_cycle)])
 

--- a/tests/apps/battery/test_plotter.py
+++ b/tests/apps/battery/test_plotter.py
@@ -17,13 +17,13 @@ class TestVoltageProfilePlotter(unittest.TestCase):
     def setUp(self):
         entry_Li = ComputedEntry("Li", -1.90753119)
 
-        with open(f"{TEST_FILES_DIR}/LiTiO2_batt.json") as f:
-            entries_LTO = json.load(f, cls=MontyDecoder)
-            self.ie_LTO = InsertionElectrode.from_entries(entries_LTO, entry_Li)
+        with open(f"{TEST_FILES_DIR}/LiTiO2_batt.json") as file:
+            entries_LTO = json.load(file, cls=MontyDecoder)
+        self.ie_LTO = InsertionElectrode.from_entries(entries_LTO, entry_Li)
 
-        with open(f"{TEST_FILES_DIR}/FeF3_batt.json") as fid:
-            entries = json.load(fid, cls=MontyDecoder)
-            self.ce_FF = ConversionElectrode.from_composition_and_entries(Composition("FeF3"), entries)
+        with open(f"{TEST_FILES_DIR}/FeF3_batt.json") as file:
+            entries = json.load(file, cls=MontyDecoder)
+        self.ce_FF = ConversionElectrode.from_composition_and_entries(Composition("FeF3"), entries)
 
     def test_name(self):
         plotter = VoltageProfilePlotter(xaxis="frac_x")
@@ -45,4 +45,4 @@ class TestVoltageProfilePlotter(unittest.TestCase):
 
         plotter.add_electrode(self.ie_LTO, "LTO insertion")
         fig = plotter.get_plotly_figure()
-        assert fig.layout.xaxis.title.text == "x Workion Ion per Host F.U."
+        assert fig.layout.xaxis.title.text == "x Work Ion per Host F.U."

--- a/tests/vis/test_plotters.py
+++ b/tests/vis/test_plotters.py
@@ -11,9 +11,7 @@ from pymatgen.analysis.xas.spectrum import XAS
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
 from pymatgen.vis.plotters import SpectrumPlotter
 
-test_dir = f"{TEST_FILES_DIR}/spectrum_test"
-
-with open(f"{test_dir}/LiCoO2_k_xanes.json") as fp:
+with open(f"{TEST_FILES_DIR}/spectrum_test/LiCoO2_k_xanes.json") as fp:
     spect_data_dict = json.load(fp, cls=MontyDecoder)
 
 
@@ -46,17 +44,16 @@ class TestSpectrumPlotter(PymatgenTest):
 
     def test_get_plot_with_add_spectrum(self):
         # create spectra_dict
-        spectra_dict = dict()
-        spectra_dict["LiCoO2"] = self.xanes
+        spectra_dict = {"LiCoO2": self.xanes}
         xanes = self.xanes.copy()
         xanes.y += np.random.randn(len(xanes.y)) * 0.005
-        spectra_dict["LiCoO2 + noise"] = xanes
-        spectra_dict["LiCoO2 - replot"] = xanes
+        spectra_dict["LiCoO2 + noise"] = spectra_dict["LiCoO2 - replot"] = xanes
 
         self.plotter = SpectrumPlotter(yshift=0.2)
         self.plotter.add_spectra(spectra_dict)
         ax = self.plotter.get_plot()
+        assert isinstance(ax, plt.Axes)
         assert len(ax.lines) == 3
-        img_path = f"{self.tmp_path}/spectrum_plotter_test2.png"
+        img_path = f"{self.tmp_path}/spectrum_plotter_test2.pdf"
         self.plotter.save_plot(img_path)
         assert os.path.isfile(img_path)

--- a/tests/vis/test_plotters.py
+++ b/tests/vis/test_plotters.py
@@ -45,7 +45,6 @@ class TestSpectrumPlotter(PymatgenTest):
         assert len(ax.lines) == 0
 
     def test_get_plot_with_add_spectrum(self):
-        
         # create spectra_dict
         spectra_dict = dict()
         spectra_dict["LiCoO2"] = self.xanes

--- a/tests/vis/test_plotters.py
+++ b/tests/vis/test_plotters.py
@@ -43,3 +43,21 @@ class TestSpectrumPlotter(PymatgenTest):
         ax = self.plotter.get_plot()
         assert isinstance(ax, plt.Axes)
         assert len(ax.lines) == 0
+
+    def test_get_plot_with_add_spectrum(self):
+        
+        # create spectra_dict
+        spectra_dict = dict()
+        spectra_dict["LiCoO2"] = self.xanes
+        xanes = self.xanes.copy()
+        xanes.y += np.random.randn(len(xanes.y)) * 0.005
+        spectra_dict["LiCoO2 + noise"] = xanes
+        spectra_dict["LiCoO2 - replot"] = xanes
+
+        self.plotter = SpectrumPlotter(yshift=0.2)
+        self.plotter.add_spectra(spectra_dict)
+        ax = self.plotter.get_plot()
+        assert len(ax.lines) == 3
+        img_path = f"{self.tmp_path}/spectrum_plotter_test2.png"
+        self.plotter.save_plot(img_path)
+        assert os.path.isfile(img_path)


### PR DESCRIPTION
**Original `SpectrumPlotter` in `pymatgen.vis.plotters`**
```python
def add_spectra(self, spectra_dict, key_sort_func=None):
    """
    Add a dictionary of doses, with an optional sorting function for the
    keys.

    Args:
        dos_dict: dict of {label: Dos}
        key_sort_func: function used to sort the dos_dict keys.
    """
    keys = sorted(spectra_dict, key=key_sort_func) if key_sort_func else list(spectra_dict)
    for label in keys:
        self.add_spectra(label, spectra_dict[label])
```

**Issue 1:** 
The original docstring suggests using the Dos object, but attributes x and y were already overridden to energies and densities in Dos, which caused the error:
```
AttributeError: 'Dos' object has no attribute 'x'
```
Although the `DosPlotter` is available to plot DOS, I think this function shouldn't be deprecated because it can still parse `Spectrum`.

**Suggestion 1:**
Update the docstring to reflect Spectrum support.

**Issue 2:** 
When I passed in `Spectrum`, it resulted in the error:
```
in add_spectra
    keys = sorted(spectra_dict, key=key_sort_func) if key_sort_func else list(spectra_dict)
TypeError: 'XAS' object is not callable
```
**Reason:** Recursive call within the function.

**Suggestion 2:**
Modify:
```python
self.add_spectra(label, spectra_dict[label])
```
to:
```python
self.add_spectrum(label, spectra_dict[label])
```

**Note:**
1. I used similar codes with `pymatgen.tests.vis.test_plotters.py` to test.
```python
from __future__ import annotations

import json
import os

import matplotlib.pyplot as plt
import numpy as np
from monty.json import MontyDecoder

from pymatgen.analysis.xas.spectrum import XAS
from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
from pymatgen.vis.plotters import SpectrumPlotter

from pymatgen.electronic_structure.dos import DOS

test_dir = f"{TEST_FILES_DIR}/spectrum_test"

with open(f"{test_dir}/LiCoO2_k_xanes.json") as fp:
    spect_data_dict = json.load(fp, cls=MontyDecoder)

xanes = XAS.from_dict(spect_data_dict)
plotter = SpectrumPlotter(yshift=0.2)

xanes_dict = dict()
xanes_dict["LiCoO2"] = xanes
xanes = xanes.copy()
xanes.y += np.random.randn(len(xanes.y)) * 0.005
xanes_dict["LiCoO2 + noise"] = xanes
xanes_dict["LiCoO2 - replot"] = xanes

plotter.add_spectra(xanes_dict)
ax = plotter.get_plot()
plotter.save_plot('test3.png', img_format='png')
```
2. This is my first time submitting a pull request at Pymatgen. Please let me know if anything is incorrectly formatted or needs improvement. Thank you :)