### PR TITLE
Improve `PhononBandStructure.has_imaginary_gamma_freq()` by checking for negative freqs at all q-points close to Gamma

### DIFF
--- a/pymatgen/io/exciting/inputs.py
+++ b/pymatgen/io/exciting/inputs.py
@@ -243,8 +243,8 @@ class ExcitingInput(MSONable):
                     symbol = kpath.kpath["path"][idx][j]
                     coords = kpath.kpath["kpoints"][symbol]
                     coord = f"{coords[0]:16.8f} {coords[1]:16.8f} {coords[2]:16.8f}"
-                    if symbol == "\\Gamma":
-                        symbol = "GAMMA"
+                    symbol_map = {"\\Gamma": "GAMMA", "\\Sigma": "SIGMA", "\\Delta": "DELTA", "\\Lambda": "LAMBDA"}
+                    symbol = symbol_map.get(symbol, symbol)
                     _ = ET.SubElement(path, "point", coord=coord, label=symbol)
         elif bandstr and celltype != "primitive":
             raise ValueError("Bandstructure is only implemented for the standard primitive unit cell!")

--- a/pymatgen/phonon/bandstructure.py
+++ b/pymatgen/phonon/bandstructure.py
@@ -142,6 +142,14 @@ class PhononBandStructure(MSONable):
             for freq in nac_eigendisplacements:
                 self.nac_eigendisplacements.append(([idx / np.linalg.norm(freq[0]) for idx in freq[0]], freq[1]))
 
+    def get_gamma_point(self) -> Kpoint | None:
+        """Returns the Gamma q-point as a Kpoint object (or None if not found)."""
+        for q_point in self.qpoints:
+            if np.allclose(q_point.frac_coords, (0, 0, 0)):
+                return q_point
+
+        return None
+
     def min_freq(self) -> tuple[Kpoint, float]:
         """Returns the q-point where the minimum frequency is reached and its value."""
         idx = np.unravel_index(np.argmin(self.bands), self.bands.shape)

--- a/pymatgen/phonon/bandstructure.py
+++ b/pymatgen/phonon/bandstructure.py
@@ -385,22 +385,22 @@ class PhononBandStructureSymmLine(PhononBandStructure):
         previous_qpoint = self.qpoints[0]
         previous_distance = 0.0
         previous_label = self.qpoints[0].label
-        for i in range(self.nb_qpoints):
-            label = self.qpoints[i].label
+        for idx in range(self.nb_qpoints):
+            label = self.qpoints[idx].label
             if label is not None and previous_label is not None:
                 self.distance.append(previous_distance)
             else:
                 self.distance.append(
-                    np.linalg.norm(self.qpoints[i].cart_coords - previous_qpoint.cart_coords) + previous_distance
+                    np.linalg.norm(self.qpoints[idx].cart_coords - previous_qpoint.cart_coords) + previous_distance
                 )
-            previous_qpoint = self.qpoints[i]
-            previous_distance = self.distance[i]
+            previous_qpoint = self.qpoints[idx]
+            previous_distance = self.distance[idx]
             if label and previous_label:
                 if len(one_group) != 0:
                     branches_tmp.append(one_group)
                 one_group = []
             previous_label = label
-            one_group.append(i)
+            one_group.append(idx)
         if len(one_group) != 0:
             branches_tmp.append(one_group)
         for branch in branches_tmp:
@@ -415,22 +415,22 @@ class PhononBandStructureSymmLine(PhononBandStructure):
         if has_nac:
             naf = []
             nac_eigendisplacements = []
-            for i in range(self.nb_qpoints):
+            for idx in range(self.nb_qpoints):
                 # get directions with nac irrespectively of the label_dict. NB: with labels
                 # the gamma point is expected to appear twice consecutively.
-                if np.allclose(qpoints[i], (0, 0, 0)):
-                    if i > 0 and not np.allclose(qpoints[i - 1], (0, 0, 0)):
-                        q_dir = self.qpoints[i - 1]
+                if np.allclose(qpoints[idx], (0, 0, 0)):
+                    if idx > 0 and not np.allclose(qpoints[idx - 1], (0, 0, 0)):
+                        q_dir = self.qpoints[idx - 1]
                         direction = q_dir.frac_coords / np.linalg.norm(q_dir.frac_coords)
-                        naf.append((direction, frequencies[:, i]))
+                        naf.append((direction, frequencies[:, idx]))
                         if self.has_eigendisplacements:
-                            nac_eigendisplacements.append((direction, eigendisplacements[:, i]))
-                    if i < len(qpoints) - 1 and not np.allclose(qpoints[i + 1], (0, 0, 0)):
-                        q_dir = self.qpoints[i + 1]
+                            nac_eigendisplacements.append((direction, eigendisplacements[:, idx]))
+                    if idx < len(qpoints) - 1 and not np.allclose(qpoints[idx + 1], (0, 0, 0)):
+                        q_dir = self.qpoints[idx + 1]
                         direction = q_dir.frac_coords / np.linalg.norm(q_dir.frac_coords)
-                        naf.append((direction, frequencies[:, i]))
+                        naf.append((direction, frequencies[:, idx]))
                         if self.has_eigendisplacements:
-                            nac_eigendisplacements.append((direction, eigendisplacements[:, i]))
+                            nac_eigendisplacements.append((direction, eigendisplacements[:, idx]))
 
             self.nac_frequencies = np.array(naf, dtype=object)
             self.nac_eigendisplacements = np.array(nac_eigendisplacements, dtype=object)

--- a/pymatgen/phonon/bandstructure.py
+++ b/pymatgen/phonon/bandstructure.py
@@ -172,13 +172,21 @@ class PhononBandStructure(MSONable):
         return self.min_freq()[1] + tol < 0
 
     def has_imaginary_gamma_freq(self, tol: float = 1e-3) -> bool:
-        """Checks if there are imaginary modes at the gamma point.
+        """Checks if there are imaginary modes at the gamma point and all close points.
 
         Args:
             tol: Tolerance for determining if a frequency is imaginary. Defaults to 1e-3.
         """
-        gamma_freqs = self.bands[:, 0]  # frequencies at the Gamma point
-        return any(freq < -tol for freq in gamma_freqs)
+        # Calculate the radial distance from the gamma point for each q-point
+        close_points = [q_pt for q_pt in self.qpoints if np.linalg.norm(q_pt.frac_coords) < tol]
+
+        # check for negative frequencies at all q-points close to the gamma point
+        for qpoint in close_points:
+            idx = self.qpoints.index(qpoint)
+            if any(freq < -tol for freq in self.bands[:, idx]):
+                return True
+
+        return False
 
     @property
     def has_nac(self) -> bool:

--- a/pymatgen/phonon/bandstructure.py
+++ b/pymatgen/phonon/bandstructure.py
@@ -172,20 +172,20 @@ class PhononBandStructure(MSONable):
         mask_pos = self.bands >= 0
         return self.bands[mask_pos].max() - self.bands[mask_pos].min()
 
-    def has_imaginary_freq(self, tol: float = 1e-3) -> bool:
+    def has_imaginary_freq(self, tol: float = 0.01) -> bool:
         """True if imaginary frequencies are present anywhere in the band structure. Always True if
         has_imaginary_gamma_freq is True.
 
         Args:
-            tol: Tolerance for determining if a frequency is imaginary. Defaults to 1e-3.
+            tol: Tolerance for determining if a frequency is imaginary. Defaults to 0.01.
         """
         return self.min_freq()[1] + tol < 0
 
-    def has_imaginary_gamma_freq(self, tol: float = 1e-3) -> bool:
+    def has_imaginary_gamma_freq(self, tol: float = 0.01) -> bool:
         """Checks if there are imaginary modes at the gamma point and all close points.
 
         Args:
-            tol: Tolerance for determining if a frequency is imaginary. Defaults to 1e-3.
+            tol: Tolerance for determining if a frequency is imaginary. Defaults to 0.01.
         """
         # Calculate the radial distance from the gamma point for each q-point
         close_points = [q_pt for q_pt in self.qpoints if np.linalg.norm(q_pt.frac_coords) < tol]

--- a/pymatgen/phonon/bandstructure.py
+++ b/pymatgen/phonon/bandstructure.py
@@ -147,8 +147,14 @@ class PhononBandStructure(MSONable):
                 self.nac_eigendisplacements.append(([idx / np.linalg.norm(freq[0]) for idx in freq[0]], freq[1]))
 
     def min_freq(self) -> tuple[Kpoint, float]:
-        """Returns the point where the minimum frequency is reached and its value."""
+        """Returns the q-point where the minimum frequency is reached and its value."""
         idx = np.unravel_index(np.argmin(self.bands), self.bands.shape)
+
+        return self.qpoints[idx[1]], self.bands[idx]
+
+    def max_freq(self) -> tuple[Kpoint, float]:
+        """Returns the q-point where the maximum frequency is reached and its value."""
+        idx = np.unravel_index(np.argmax(self.bands), self.bands.shape)
 
         return self.qpoints[idx[1]], self.bands[idx]
 

--- a/pymatgen/phonon/bandstructure.py
+++ b/pymatgen/phonon/bandstructure.py
@@ -162,6 +162,16 @@ class PhononBandStructure(MSONable):
 
         return self.qpoints[idx[1]], self.bands[idx]
 
+    def width(self, with_imaginary: bool = False) -> float:
+        """Returns the difference between the maximum and minimum frequencies anywhere in the
+        band structure, not necessarily at identical same q-points. If with_imaginary is False,
+        only positive frequencies are considered.
+        """
+        if with_imaginary:
+            return np.max(self.bands) - np.min(self.bands)
+        mask_pos = self.bands >= 0
+        return self.bands[mask_pos].max() - self.bands[mask_pos].min()
+
     def has_imaginary_freq(self, tol: float = 1e-3) -> bool:
         """True if imaginary frequencies are present anywhere in the band structure. Always True if
         has_imaginary_gamma_freq is True.

--- a/pymatgen/phonon/bandstructure.py
+++ b/pymatgen/phonon/bandstructure.py
@@ -120,16 +120,12 @@ class PhononBandStructure(MSONable):
             labels_dict = {}
 
         for q_pt in qpoints:
-            # let see if this qpoint has been assigned a label
-            label = None
-            for c in labels_dict:
-                if np.linalg.norm(q_pt - np.array(labels_dict[c])) < 0.0001:
-                    label = c
+            label = None  # check below if this qpoint has an assigned label
+            for key in labels_dict:
+                if np.linalg.norm(q_pt - np.array(labels_dict[key])) < 0.0001:
+                    label = key
                     self.labels_dict[label] = Kpoint(
-                        q_pt,
-                        lattice,
-                        label=label,
-                        coords_are_cartesian=coords_are_cartesian,
+                        q_pt, lattice, label=label, coords_are_cartesian=coords_are_cartesian
                     )
             self.qpoints.append(Kpoint(q_pt, lattice, label=label, coords_are_cartesian=coords_are_cartesian))
         self.bands = frequencies

--- a/pymatgen/phonon/dos.py
+++ b/pymatgen/phonon/dos.py
@@ -354,7 +354,7 @@ class PhononDos(MSONable):
 
         return self_mae
 
-    def get_last_peak(self, threshold: float = 0.1) -> float:
+    def get_last_peak(self, threshold: float = 0.05) -> float:
         """Find the last peak in the phonon DOS defined as the highest frequency with a DOS
         value at least threshold * height of the overall highest DOS peak.
         A peak is any local maximum of the DOS as a function of frequency.
@@ -365,7 +365,7 @@ class PhononDos(MSONable):
 
         Args:
             threshold (float, optional): Minimum ratio of the height of the last peak
-                to the height of the highest peak. Defaults to 0.1 = 10%. In case no peaks
+                to the height of the highest peak. Defaults to 0.05 = 5%. In case no peaks
                 are high enough to match, the threshold is reset to half the height of the
                 second-highest peak.
 

--- a/pymatgen/phonon/plotter.py
+++ b/pymatgen/phonon/plotter.py
@@ -561,8 +561,8 @@ class PhononBSPlotter:
         """
         tick_distance = []
         tick_labels: list[str] = []
-        previous_label = self._bs.qpoints[0].label
-        previous_branch = self._bs.branches[0]["name"]
+        prev_label = self._bs.qpoints[0].label
+        prev_branch = self._bs.branches[0]["name"]
         for idx, point in enumerate(self._bs.qpoints):
             if point.label is not None:
                 tick_distance.append(self._bs.distance[idx])
@@ -571,11 +571,11 @@ class PhononBSPlotter:
                     if b["start_index"] <= idx <= b["end_index"]:
                         this_branch = b["name"]
                         break
-                if point.label != previous_label and previous_branch != this_branch:
+                if point.label != prev_label and prev_branch != this_branch:
                     label1 = point.label
                     if label1.startswith("\\") or label1.find("_") != -1:
                         label1 = f"${label1}$"
-                    label0 = previous_label or ""
+                    label0 = prev_label or ""
                     if label0.startswith("\\") or label0.find("_") != -1:
                         label0 = f"${label0}$"
                     tick_labels.pop()
@@ -585,8 +585,8 @@ class PhononBSPlotter:
                     tick_labels.append(f"${point.label}$")
                 else:
                     tick_labels.append(point.label)
-                previous_label = point.label
-                previous_branch = this_branch
+                prev_label = point.label
+                prev_branch = this_branch
         # map atomate2 all-upper-case labels like GAMMA/DELTA to pretty symbols
         tick_labels = [label.replace("GAMMA", "Γ").replace("DELTA", "Δ").replace("SIGMA", "Σ") for label in tick_labels]
         return {"distance": tick_distance, "label": tick_labels}

--- a/tests/phonon/test_bandstructure.py
+++ b/tests/phonon/test_bandstructure.py
@@ -112,3 +112,10 @@ class TestPhononBandStructureSymmLine(PymatgenTest):
         max_qpoint2, max_freq2 = self.bs2.max_freq()
         assert list(max_qpoint2.frac_coords) == [0, 0, 0]
         assert max_freq2 == approx(15.2873634264)
+
+    def test_get_gamma_point(self):
+        for bs in (self.bs, self.bs2):
+            g_point = bs.get_gamma_point()
+            assert isinstance(g_point, Kpoint)
+            assert list(g_point.frac_coords) == [0, 0, 0]
+            assert g_point.label in ("Gamma", "$\\Gamma$")

--- a/tests/phonon/test_bandstructure.py
+++ b/tests/phonon/test_bandstructure.py
@@ -119,3 +119,10 @@ class TestPhononBandStructureSymmLine(PymatgenTest):
             assert isinstance(g_point, Kpoint)
             assert list(g_point.frac_coords) == [0, 0, 0]
             assert g_point.label in ("Gamma", "$\\Gamma$")
+
+    def test_width(self):
+        assert self.bs.width() == approx(7.4284347482)
+        assert self.bs2.width() == approx(15.2945892153)
+
+        assert self.bs.width(with_imaginary=False) == approx(7.3227137833)
+        assert self.bs2.width(with_imaginary=False) == approx(14.7108925878)

--- a/tests/phonon/test_bandstructure.py
+++ b/tests/phonon/test_bandstructure.py
@@ -5,6 +5,7 @@ import json
 from numpy.testing import assert_allclose, assert_array_equal
 from pytest import approx
 
+from pymatgen.electronic_structure.bandstructure import Kpoint
 from pymatgen.phonon.bandstructure import PhononBandStructureSymmLine
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
 
@@ -36,8 +37,6 @@ class TestPhononBandStructureSymmLine(PymatgenTest):
         )
         assert self.bs.has_eigendisplacements, True
 
-        assert list(self.bs.min_freq()[0].frac_coords) == [0, 0, 0]
-        assert self.bs.min_freq()[1] == approx(-0.03700895020)
         assert_allclose(self.bs.asr_breaking(), [-0.0370089502, -0.0370089502, -0.0221388897])
 
         assert self.bs.nb_bands == 6
@@ -94,3 +93,22 @@ class TestPhononBandStructureSymmLine(PymatgenTest):
 
     def test_write_methods(self):
         self.bs2.write_phononwebsite(f"{self.tmp_path}/test.json")
+
+    def test_min_max_freq(self):
+        min_qpoint, min_freq = self.bs.min_freq()
+        assert isinstance(min_qpoint, Kpoint)
+        assert list(min_qpoint.frac_coords) == [0, 0, 0]
+        assert min_freq == approx(-0.03700895020)
+
+        max_qpoint, max_freq = self.bs.max_freq()
+        assert isinstance(max_qpoint, Kpoint)
+        assert list(max_qpoint.frac_coords) == [0, 0, 0]
+        assert max_freq == approx(7.391425798)
+
+        min_qpoint2, min_freq2 = self.bs2.min_freq()
+        assert list(min_qpoint2.frac_coords) == [0, 0, 0]
+        assert min_freq2 == approx(-0.0072257889)
+
+        max_qpoint2, max_freq2 = self.bs2.max_freq()
+        assert list(max_qpoint2.frac_coords) == [0, 0, 0]
+        assert max_freq2 == approx(15.2873634264)

--- a/tests/phonon/test_bandstructure.py
+++ b/tests/phonon/test_bandstructure.py
@@ -46,17 +46,17 @@ class TestPhononBandStructureSymmLine(PymatgenTest):
 
     def test_has_imaginary_freq(self):
         for tol in (0, 0.01, 0.02, 0.03, 0.04, 0.05):
-            assert self.bs.has_imaginary_freq(tol=tol) == (tol < 0.04)
+            assert self.bs.has_imaginary_freq(tol=tol) == (tol < 0.04), f"{tol=}"
 
         for tol in (0, 0.01, 0.02, 0.03, 0.04, 0.05):
-            assert self.bs2.has_imaginary_freq(tol=tol) == (tol < 0.01)
+            assert self.bs2.has_imaginary_freq(tol=tol) == (tol < 0.01), f"{tol=}"
 
         # test Gamma point imaginary frequency detection
         for tol in (0, 0.01, 0.02, 0.03, 0.04, 0.05):
-            assert self.bs.has_imaginary_gamma_freq(tol=tol) == (tol < 0.04)
+            assert self.bs.has_imaginary_gamma_freq(tol=tol) == (tol in (0.01, 0.02, 0.03)), f"{tol=}"
 
-        for tol in (0, 0.01, 0.02, 0.03, 0.04, 0.05):
-            assert self.bs2.has_imaginary_gamma_freq(tol=tol) == (tol < 0.01)
+        for tol in (0, 0.01, 0.02, 0.03, 0.04, 0.05, 1, 10):
+            assert self.bs2.has_imaginary_gamma_freq(tol=tol) is False, f"{tol=}"
 
     def test_nac(self):
         assert self.bs.has_nac

--- a/tests/phonon/test_bandstructure.py
+++ b/tests/phonon/test_bandstructure.py
@@ -121,8 +121,8 @@ class TestPhononBandStructureSymmLine(PymatgenTest):
             assert g_point.label in ("Gamma", "$\\Gamma$")
 
     def test_width(self):
-        assert self.bs.width() == approx(7.4284347482)
-        assert self.bs2.width() == approx(15.2945892153)
+        assert self.bs.width() == approx(7.3227137833)
+        assert self.bs2.width() == approx(14.7108925878)
 
-        assert self.bs.width(with_imaginary=False) == approx(7.3227137833)
-        assert self.bs2.width(with_imaginary=False) == approx(14.7108925878)
+        assert self.bs.width(with_imaginary=True) == approx(7.4284347482)
+        assert self.bs2.width(with_imaginary=True) == approx(15.2945892153)


### PR DESCRIPTION
6087d5d90 PhononDos.get_last_peak reduce threshold value from 10% to 5%
8649e793a PhononBandStructure add max_freq() equivalent to min_freq() method
0dd35274e i->idx
d92f0e748 test_bandstructure.py add new test cases for (min|max)_freq
f77779c25 refactor symbol mapping in ExcitingInput and PhononBandStructure
dddd81e8b add get_gamma_point() method to PhononBandStructure
d16e6efa2 add test_get_gamma_point
878ef99b9 big improvement to has_imaginary_gamma_freq: check for negative frequencies at all q-points close to the gamma point, not just the gamma point itself
141679141 fix test_has_imaginary_freq in test_bandstructure.py
ac38d6572 PhononBandStructure add width() method
2b70e03d4 add test_width for PhononBandStructure