### PR TITLE
Add default issue template labels 

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,6 +1,6 @@
 name: Report a Bug
 description: Use this template to report a Pymatgen-related bug
-labels: "bug"
+labels: bug
 body:
   - type: input
     id: python-version

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,5 +1,6 @@
 name: Report a Bug
 description: Use this template to report a Pymatgen-related bug
+labels: "bug"
 body:
   - type: input
     id: python-version

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,6 +1,6 @@
 name: Feature Request
 description: Use this template to request a new feature
-labels: "enhancement"
+labels: enhancement
 body:
   - type: textarea
     id: feature

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,5 +1,6 @@
 name: Feature Request
 description: Use this template to request a new feature
+labels: "enhancement"
 body:
   - type: textarea
     id: feature


### PR DESCRIPTION
# Summary

Add default issue template labels, as I notice most recent issues are not assigned a label by the raiser, and also the prefix was removed as suggested by @janosh in #3528.

- Add default label "bug" for `Report a Bug`.
- Add default label "enhancement" for `Feature Request`.