### PR TITLE
Accept `Path` objects as `filename` in `IStructure.to()`

### DIFF
--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -2653,7 +2653,7 @@ class IStructure(SiteCollection, MSONable):
         charge = d.get("charge")
         return cls.from_sites(sites, charge=charge, properties=d.get("properties"))
 
-    def to(self, filename: str = "", fmt: str = "", **kwargs) -> str:
+    def to(self, filename: str | Path = "", fmt: str = "", **kwargs) -> str:
         """Outputs the structure to a file or string.
 
         Args:
@@ -2673,7 +2673,7 @@ class IStructure(SiteCollection, MSONable):
             str: String representation of molecule in given format. If a filename
                 is provided, the same string is written to the file.
         """
-        fmt = fmt.lower()
+        filename, fmt = str(filename), fmt.lower()
 
         if fmt == "cif" or fnmatch(filename.lower(), "*.cif*"):
             from pymatgen.io.cif import CifWriter

--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -868,6 +868,11 @@ Direct
         # i.e. uses same merge_tol for site merging, same primitive=False, etc.
         assert struct == CifParser(f"{TEST_FILES_DIR}/bad-unicode-gh-2947.mcif").parse_structures()[0]
 
+        # https://github.com/materialsproject/pymatgen/issues/3551
+        json_path = Path("test-with-path.json")
+        self.struct.to(filename=json_path)
+        assert os.path.isfile(json_path)
+
     def test_to_file_alias(self):
         out_path = f"{self.tmp_path}/POSCAR"
         assert self.struct.to(out_path) == self.struct.to_file(out_path)


### PR DESCRIPTION
Closes #3551.

1a39d626f accept Path objects as filename in IStructure.to()
5afdf01c7 add test case for saving structure to pathlib.Path