### PR TITLE
Support `magmoms` in `get_phonopy_structure()`

### DIFF
--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -927,7 +927,7 @@ class IStructure(SiteCollection, MSONable):
         for idx, specie in enumerate(species):
             prop = None
             if site_properties:
-                prop = {key: val[idx] for key, val in site_properties.items()}
+                prop = {key: val[idx] for key, val in site_properties.items() if val is not None}
 
             label = labels[idx] if labels else None
 

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -943,7 +943,7 @@ class IStructure(SiteCollection, MSONable):
             sites.append(site)
         self._sites: tuple[PeriodicSite, ...] = tuple(sites)
         if validate_proximity and not self.is_valid():
-            raise StructureError("Structure contains sites that are less than 0.01 Angstrom apart!")
+            raise StructureError(f"sites are less than {self.DISTANCE_TOLERANCE} Angstrom apart!")
         self._charge = charge
         self._properties = properties or {}
 

--- a/pymatgen/io/phonopy.py
+++ b/pymatgen/io/phonopy.py
@@ -58,6 +58,7 @@ def get_phonopy_structure(pmg_structure: Structure) -> PhonopyAtoms:
         symbols=symbols,
         cell=pmg_structure.lattice.matrix,
         scaled_positions=pmg_structure.frac_coords,
+        magnetic_moments=pmg_structure.site_properties.get("magmom"),
     )
 
 

--- a/pymatgen/io/phonopy.py
+++ b/pymatgen/io/phonopy.py
@@ -34,13 +34,13 @@ def get_pmg_structure(phonopy_structure: PhonopyAtoms) -> Structure:
     frac_coords = phonopy_structure.scaled_positions
     symbols = phonopy_structure.symbols
     masses = phonopy_structure.masses
-    mms = getattr(phonopy_structure, "magnetic_moments", None) or [0] * len(symbols)
+    magmoms = getattr(phonopy_structure, "magnetic_moments", [0] * len(symbols))
 
     return Structure(
         lattice,
         symbols,
         frac_coords,
-        site_properties={"phonopy_masses": masses, "magnetic_moments": mms},
+        site_properties={"phonopy_masses": masses, "magnetic_moments": magmoms},
     )
 
 

--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -73,7 +73,9 @@ class TestIStructure(PymatgenTest):
         assert self.struct.is_ordered
         assert self.struct.ntypesp == 1
         coords = [[0, 0, 0], [0.0, 0, 0.0000001]]
-        with pytest.raises(StructureError, match="Structure contains sites that are less than 0.01 Angstrom apart"):
+        with pytest.raises(
+            StructureError, match=f"sites are less than {self.struct.DISTANCE_TOLERANCE} Angstrom apart"
+        ):
             IStructure(self.lattice, ["Si"] * 2, coords, validate_proximity=True)
         self.propertied_structure = IStructure(
             self.lattice, ["Si"] * 2, coords, site_properties={"magmom": [5, -5]}, properties={"test_property": "test"}
@@ -104,7 +106,7 @@ class TestIStructure(PymatgenTest):
 
     def test_as_dataframe(self):
         df = self.propertied_structure.as_dataframe()
-        assert df.attrs["Reduced Formula"] == "Si"
+        assert df.attrs["Reduced Formula"] == self.propertied_structure.composition.reduced_formula
         assert df.shape == (2, 8)
 
     def test_equal(self):
@@ -130,7 +132,7 @@ class TestIStructure(PymatgenTest):
 
     def test_bad_structure(self):
         coords = [[0, 0, 0], [0.75, 0.5, 0.75], [0.75, 0.5, 0.75]]
-        with pytest.raises(StructureError, match="Structure contains sites that are less than 0.01 Angstrom apart"):
+        with pytest.raises(StructureError, match=f"sites are less than {Structure.DISTANCE_TOLERANCE} Angstrom apart"):
             IStructure(self.lattice, ["Si"] * 3, coords, validate_proximity=True)
         # these shouldn't raise an error
         IStructure(self.lattice, ["Si"] * 2, coords[:2], validate_proximity=True)

--- a/tests/io/test_ase.py
+++ b/tests/io/test_ase.py
@@ -147,7 +147,7 @@ def test_get_structure():
     atoms = read(f"{TEST_FILES_DIR}/POSCAR_overlap")
     struct = AseAtomsAdaptor.get_structure(atoms)
     assert [s.species_string for s in struct] == atoms.get_chemical_symbols()
-    with pytest.raises(StructureError, match="Structure contains sites that are less than 0.01 Angstrom apart"):
+    with pytest.raises(StructureError, match=f"sites are less than {struct.DISTANCE_TOLERANCE} Angstrom apart"):
         struct = AseAtomsAdaptor.get_structure(atoms, validate_proximity=True)
 
 


### PR DESCRIPTION
## Summary

Phonopy needs magnetic moments to calculate the symmetry etc, currently pymatgen does not send it.

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.

python -m pytest tests/io/test_phonopy.py fails with "ImportError: cannot import name 'coord_cython' from 'pymatgen.util'", any ideas?
