### PR TITLE
Fix text formatting in `bug_report.yaml`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -40,7 +40,6 @@ body:
     attributes:
       label: Current behavior
       description: What bad behavior do you see?
-      render: Python
     validations:
       required: true
 


### PR DESCRIPTION
The "Current behavior" section is formatted as Python code by default, which is super annoying since it should be text (and you don't see the Python formatting until after you post). I fixed it.