### PR TITLE
Adding FHI-aims inputs developers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ ci:
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.14
+    rev: v0.1.15
     hooks:
       - id: ruff
         args: [--fix, --unsafe-fixes]
@@ -47,7 +47,7 @@ repos:
       - id: blacken-docs
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.38.0
+    rev: v0.39.0
     hooks:
       - id: markdownlint
         # MD013: line too long

--- a/docs/assets/metadata.yml
+++ b/docs/assets/metadata.yml
@@ -671,6 +671,13 @@ developers:
     first_name: Maarten
     last_name: de Jong
     orcid: 0000-0001-9945-1941
+  - affiliations: [MS1P]
+    first_name: Andrey
+    last_name: Sobolev
+  - affiliations: [University of Arizona]
+    first_name: Thomas
+    last_name: Purcell
+    orcid: 0000-0003-4564-7206
 contributors: []
 sponsoring_organizations: []
 contributing_organizations: [University of California, San Diego]

--- a/pymatgen/analysis/bond_valence.py
+++ b/pymatgen/analysis/bond_valence.py
@@ -181,7 +181,7 @@ class BVAnalyzer:
         try:
             prob = {k: v / sum(prob.values()) for k, v in prob.items()}
         except ZeroDivisionError:
-            prob = {key: 0 for key in prob}
+            prob = dict.fromkeys(prob, 0)
         return prob
 
     def _calc_site_probabilities_unordered(self, site, nn):
@@ -202,7 +202,7 @@ class BVAnalyzer:
             try:
                 prob[el] = {k: v / sum(prob[el].values()) for k, v in prob[el].items()}
             except ZeroDivisionError:
-                prob[el] = {key: 0 for key in prob[el]}
+                prob[el] = dict.fromkeys(prob[el], 0)
         return prob
 
     def get_valences(self, structure: Structure):

--- a/pymatgen/analysis/elasticity/elastic.py
+++ b/pymatgen/analysis/elasticity/elastic.py
@@ -450,7 +450,7 @@ class ElasticTensor(NthOrderElasticTensor):
         )
         sp_dict: dict[str, float | Structure | None]
         if ignore_errors and (self.k_vrh < 0 or self.g_vrh < 0):
-            sp_dict = {prop: None for prop in s_props}
+            sp_dict = dict.fromkeys(s_props)
         else:
             sp_dict = {prop: getattr(self, prop)(structure) for prop in s_props}
         sp_dict["structure"] = structure

--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -1175,7 +1175,7 @@ class PhaseDiagram(MSONable):
         if referenced:
             el_energies = {el: self.el_refs[el].energy_per_atom for el in elements}
         else:
-            el_energies = {el: 0 for el in elements}
+            el_energies = dict.fromkeys(elements, 0)
 
         chempot_ranges = collections.defaultdict(list)
         vertices = [list(range(len(self.elements)))]

--- a/pymatgen/io/abinit/netcdf.py
+++ b/pymatgen/io/abinit/netcdf.py
@@ -344,7 +344,7 @@ def structure_from_ncdata(ncdata, site_properties=None, cls=Structure):
 
 
 class _H:
-    __slots__ = ("name", "doc", "etsf_name")
+    __slots__ = ("doc", "etsf_name", "name")
 
     def __init__(self, name, doc, etsf_name=None):
         self.name, self.doc, self.etsf_name = name, doc, etsf_name

--- a/pymatgen/io/aims/sets/base.py
+++ b/pymatgen/io/aims/sets/base.py
@@ -76,7 +76,7 @@ class AimsInputSet(InputSet):
         }
         updated_params = dict(**self._parameters)
         for prop in self._properties:
-            aims_name = property_flags.get(prop, None)
+            aims_name = property_flags.get(prop)
             if aims_name is not None:
                 updated_params[aims_name] = True
 

--- a/pymatgen/io/aims/sets/core.py
+++ b/pymatgen/io/aims/sets/core.py
@@ -10,8 +10,6 @@ from pymatgen.io.aims.sets.base import AimsInputGenerator
 if TYPE_CHECKING:
     from pymatgen.core import Molecule
 
-__all__ = ["StaticSetGenerator", "RelaxSetGenerator", "SocketIOSetGenerator"]
-
 
 @dataclass
 class StaticSetGenerator(AimsInputGenerator):

--- a/pymatgen/io/cp2k/utils.py
+++ b/pymatgen/io/cp2k/utils.py
@@ -167,7 +167,7 @@ def get_unique_site_indices(struct: Structure | Molecule):
     for i, itm in enumerate(items):
         _sites[itm].append(i)
     sites = {}
-    nums = {s: 1 for s in struct.symbol_set}
+    nums = dict.fromkeys(struct.symbol_set, 1)
     for s in _sites:
         sites[f"{s[0]}_{nums[s[0]]}"] = _sites[s]
         nums[s[0]] += 1

--- a/pymatgen/io/nwchem.py
+++ b/pymatgen/io/nwchem.py
@@ -276,7 +276,7 @@ $theory_spec
 
         elements = set(mol.composition.get_el_amt_dict())
         if isinstance(basis_set, str):
-            basis_set = {el: basis_set for el in elements}
+            basis_set = dict.fromkeys(elements, basis_set)
 
         return NwTask(
             charge,

--- a/pymatgen/io/qchem/outputs.py
+++ b/pymatgen/io/qchem/outputs.py
@@ -2513,7 +2513,7 @@ def parse_hybridization_character(lines: list[str]) -> list[pd.DataFrame]:
 
                 # Lone pair
                 if "LP" in line or "LV" in line:
-                    LPentry: dict[str, str | float] = {orbital: 0.0 for orbital in orbitals}
+                    LPentry: dict[str, str | float] = dict.fromkeys(orbitals, 0.0)
                     LPentry["bond index"] = line[0:4].strip()
                     LPentry["occupancy"] = line[7:14].strip()
                     LPentry["type"] = line[16:19].strip()

--- a/pymatgen/transformations/site_transformations.py
+++ b/pymatgen/transformations/site_transformations.py
@@ -303,7 +303,7 @@ class PartialRemoveSitesTransformation(AbstractTransformation):
         to_delete = []
 
         total_removals = sum(num_remove_dict.values())
-        removed = {k: 0 for k in num_remove_dict}
+        removed = dict.fromkeys(num_remove_dict, 0)
         for _ in range(total_removals):
             max_idx = None
             max_ene = float("-inf")

--- a/pymatgen/util/graph_hashing.py
+++ b/pymatgen/util/graph_hashing.py
@@ -54,7 +54,7 @@ def _init_node_labels(G, edge_attr, node_attr):
     if node_attr:
         return {u: str(dd[node_attr]) for u, dd in G.nodes(data=True)}
     if edge_attr:
-        return {u: "" for u in G}
+        return dict.fromkeys(G, "")
     return {u: str(deg) for u, deg in G.degree()}
 
 

--- a/pymatgen/util/testing/__init__.py
+++ b/pymatgen/util/testing/__init__.py
@@ -36,7 +36,7 @@ class PymatgenTest(unittest.TestCase):
     """Extends unittest.TestCase with several assert methods for array and str comparison."""
 
     # dict of lazily-loaded test structures (initialized to None)
-    TEST_STRUCTURES: ClassVar[dict[str | Path, Structure | None]] = {key: None for key in STRUCTURES_DIR.glob("*")}
+    TEST_STRUCTURES: ClassVar[dict[str | Path, Structure | None]] = dict.fromkeys(STRUCTURES_DIR.glob("*"))
 
     @pytest.fixture(autouse=True)  # make all tests run a in a temporary directory accessible via self.tmp_path
     def _tmp_dir(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/analysis/chemenv/coordination_environments/test_weights.py
+++ b/tests/analysis/chemenv/coordination_environments/test_weights.py
@@ -221,18 +221,14 @@ class StrategyWeights(PymatgenTest):
             assert bias_weight4.cn_weights[idx] == approx(2 * idx)
 
         bias_weight5 = CNBiasNbSetWeight.from_description(
-            {
-                "type": "geometrically_equidistant",
-                "weight_cn1": 1,
-                "weight_cn13": 13,
-            }
+            {"type": "geometrically_equidistant", "weight_cn1": 1, "weight_cn13": 13}
         )
         assert bias_weight5.cn_weights[1] == approx(1)
         assert bias_weight5.cn_weights[3] == approx(1.5334062370163877)
         assert bias_weight5.cn_weights[9] == approx(5.5287748136788739)
         assert bias_weight5.cn_weights[12] == approx(10.498197520079623)
 
-        cn_weights = {cn: 0 for cn in range(1, 14)}
+        cn_weights = dict.fromkeys(range(1, 14), 0)
         cn_weights[6] = 2
         cn_weights[4] = 1
         bias_weight6 = CNBiasNbSetWeight.from_description({"type": "explicit", "cn_weights": cn_weights})
@@ -249,7 +245,7 @@ class StrategyWeights(PymatgenTest):
 
         # Get neighbors sets for which we get the weights
         cn_maps = [(12, 3), (12, 2), (13, 2), (12, 0), (12, 1)]
-        nbsets = {cn_map: struct_envs.neighbors_sets[0][cn_map[0]][cn_map[1]] for cn_map in cn_maps}
+        nb_sets = {cn_map: struct_envs.neighbors_sets[0][cn_map[0]][cn_map[1]] for cn_map in cn_maps}
 
         effective_csm_estimator = {
             "function": "power2_inverse_decreasing",
@@ -279,7 +275,7 @@ class StrategyWeights(PymatgenTest):
         additional_info = {}
         cn_map = (12, 3)
         self_w = self_weight.weight(
-            nb_set=nbsets[cn_map],
+            nb_set=nb_sets[cn_map],
             structure_environments=struct_envs,
             cn_map=cn_map,
             additional_info=additional_info,
@@ -287,7 +283,7 @@ class StrategyWeights(PymatgenTest):
         assert abs(self_w - 0.11671945916431022) < 1e-8
         cn_map = (12, 2)
         self_w = self_weight.weight(
-            nb_set=nbsets[cn_map],
+            nb_set=nb_sets[cn_map],
             structure_environments=struct_envs,
             cn_map=cn_map,
             additional_info=additional_info,
@@ -295,7 +291,7 @@ class StrategyWeights(PymatgenTest):
         assert abs(self_w - 0) < 1e-8
         cn_map = (12, 0)
         self_w = self_weight.weight(
-            nb_set=nbsets[cn_map],
+            nb_set=nb_sets[cn_map],
             structure_environments=struct_envs,
             cn_map=cn_map,
             additional_info=additional_info,
@@ -303,7 +299,7 @@ class StrategyWeights(PymatgenTest):
         assert abs(self_w - 0) < 1e-8
         cn_map = (12, 1)
         self_w = self_weight.weight(
-            nb_set=nbsets[cn_map],
+            nb_set=nb_sets[cn_map],
             structure_environments=struct_envs,
             cn_map=cn_map,
             additional_info=additional_info,
@@ -311,7 +307,7 @@ class StrategyWeights(PymatgenTest):
         assert abs(self_w - 0) < 1e-8
         cn_map = (13, 2)
         self_w = self_weight.weight(
-            nb_set=nbsets[cn_map],
+            nb_set=nb_sets[cn_map],
             structure_environments=struct_envs,
             cn_map=cn_map,
             additional_info=additional_info,
@@ -325,7 +321,7 @@ class StrategyWeights(PymatgenTest):
 
         # Get neighbors sets for which we get the weights
         cn_maps = [(2, 0), (4, 0)]
-        nbsets = {cn_map: struct_envs.neighbors_sets[6][cn_map[0]][cn_map[1]] for cn_map in cn_maps}
+        nb_sets = {cn_map: struct_envs.neighbors_sets[6][cn_map[0]][cn_map[1]] for cn_map in cn_maps}
 
         effective_csm_estimator = {
             "function": "power2_inverse_decreasing",
@@ -346,7 +342,7 @@ class StrategyWeights(PymatgenTest):
         additional_info = {}
         cn_map = (2, 0)
         self_w = self_weight.weight(
-            nb_set=nbsets[cn_map],
+            nb_set=nb_sets[cn_map],
             structure_environments=struct_envs,
             cn_map=cn_map,
             additional_info=additional_info,
@@ -354,7 +350,7 @@ class StrategyWeights(PymatgenTest):
         assert abs(self_w - 0.8143992162836029) < 1e-8
         cn_map = (4, 0)
         self_w = self_weight.weight(
-            nb_set=nbsets[cn_map],
+            nb_set=nb_sets[cn_map],
             structure_environments=struct_envs,
             cn_map=cn_map,
             additional_info=additional_info,
@@ -369,7 +365,7 @@ class StrategyWeights(PymatgenTest):
 
         # Get neighbors sets for which we get the weights
         cn_maps = [(12, 3), (12, 2), (13, 2), (12, 0), (12, 1), (13, 0), (13, 1)]
-        nbsets = {cn_map: struct_envs.neighbors_sets[0][cn_map[0]][cn_map[1]] for cn_map in cn_maps}
+        nb_sets = {cn_map: struct_envs.neighbors_sets[0][cn_map[0]][cn_map[1]] for cn_map in cn_maps}
 
         effective_csm_estimator = {
             "function": "power2_inverse_decreasing",
@@ -389,7 +385,7 @@ class StrategyWeights(PymatgenTest):
         additional_info = {}
         cn_map = (12, 3)
         delta_w = delta_weight.weight(
-            nb_set=nbsets[cn_map],
+            nb_set=nb_sets[cn_map],
             structure_environments=struct_envs,
             cn_map=cn_map,
             additional_info=additional_info,
@@ -397,7 +393,7 @@ class StrategyWeights(PymatgenTest):
         assert abs(delta_w - 0) < 1e-8
         cn_map = (12, 2)
         delta_w = delta_weight.weight(
-            nb_set=nbsets[cn_map],
+            nb_set=nb_sets[cn_map],
             structure_environments=struct_envs,
             cn_map=cn_map,
             additional_info=additional_info,
@@ -405,7 +401,7 @@ class StrategyWeights(PymatgenTest):
         assert abs(delta_w - 0) < 1e-8
         cn_map = (12, 0)
         delta_w = delta_weight.weight(
-            nb_set=nbsets[cn_map],
+            nb_set=nb_sets[cn_map],
             structure_environments=struct_envs,
             cn_map=cn_map,
             additional_info=additional_info,
@@ -413,7 +409,7 @@ class StrategyWeights(PymatgenTest):
         assert abs(delta_w - 0) < 1e-8
         cn_map = (12, 1)
         delta_w = delta_weight.weight(
-            nb_set=nbsets[cn_map],
+            nb_set=nb_sets[cn_map],
             structure_environments=struct_envs,
             cn_map=cn_map,
             additional_info=additional_info,
@@ -421,7 +417,7 @@ class StrategyWeights(PymatgenTest):
         assert abs(delta_w - 0) < 1e-8
         cn_map = (13, 2)
         delta_w = delta_weight.weight(
-            nb_set=nbsets[cn_map],
+            nb_set=nb_sets[cn_map],
             structure_environments=struct_envs,
             cn_map=cn_map,
             additional_info=additional_info,
@@ -429,7 +425,7 @@ class StrategyWeights(PymatgenTest):
         assert abs(delta_w - 1) < 1e-8
         cn_map = (13, 0)
         delta_w = delta_weight.weight(
-            nb_set=nbsets[cn_map],
+            nb_set=nb_sets[cn_map],
             structure_environments=struct_envs,
             cn_map=cn_map,
             additional_info=additional_info,
@@ -437,7 +433,7 @@ class StrategyWeights(PymatgenTest):
         assert abs(delta_w - 0) < 1e-8
         cn_map = (13, 1)
         delta_w = delta_weight.weight(
-            nb_set=nbsets[cn_map],
+            nb_set=nb_sets[cn_map],
             structure_environments=struct_envs,
             cn_map=cn_map,
             additional_info=additional_info,
@@ -463,7 +459,7 @@ class StrategyWeights(PymatgenTest):
         additional_info = {}
         cn_map = (12, 3)
         delta_w = delta_weight.weight(
-            nb_set=nbsets[cn_map],
+            nb_set=nb_sets[cn_map],
             structure_environments=struct_envs,
             cn_map=cn_map,
             additional_info=additional_info,
@@ -471,7 +467,7 @@ class StrategyWeights(PymatgenTest):
         assert abs(delta_w - 0.040830741048481355) < 1e-8
         cn_map = (13, 2)
         delta_w = delta_weight.weight(
-            nb_set=nbsets[cn_map],
+            nb_set=nb_sets[cn_map],
             structure_environments=struct_envs,
             cn_map=cn_map,
             additional_info=additional_info,
@@ -479,7 +475,7 @@ class StrategyWeights(PymatgenTest):
         assert abs(delta_w - 1) < 1e-8
         cn_map = (13, 0)
         delta_w = delta_weight.weight(
-            nb_set=nbsets[cn_map],
+            nb_set=nb_sets[cn_map],
             structure_environments=struct_envs,
             cn_map=cn_map,
             additional_info=additional_info,
@@ -487,7 +483,7 @@ class StrategyWeights(PymatgenTest):
         assert abs(delta_w - 0.103515625) < 1e-8
         cn_map = (13, 1)
         delta_w = delta_weight.weight(
-            nb_set=nbsets[cn_map],
+            nb_set=nb_sets[cn_map],
             structure_environments=struct_envs,
             cn_map=cn_map,
             additional_info=additional_info,
@@ -501,7 +497,7 @@ class StrategyWeights(PymatgenTest):
 
         # Get neighbors sets for which we get the weights
         cn_maps = [(2, 0), (4, 0)]
-        nbsets = {cn_map: struct_envs.neighbors_sets[6][cn_map[0]][cn_map[1]] for cn_map in cn_maps}
+        nb_sets = {cn_map: struct_envs.neighbors_sets[6][cn_map[0]][cn_map[1]] for cn_map in cn_maps}
 
         effective_csm_estimator = {
             "function": "power2_inverse_decreasing",
@@ -522,7 +518,7 @@ class StrategyWeights(PymatgenTest):
         additional_info = {}
         cn_map = (2, 0)
         delta_w = delta_weight.weight(
-            nb_set=nbsets[cn_map],
+            nb_set=nb_sets[cn_map],
             structure_environments=struct_envs,
             cn_map=cn_map,
             additional_info=additional_info,
@@ -530,7 +526,7 @@ class StrategyWeights(PymatgenTest):
         assert abs(delta_w - 0) < 1e-8
         cn_map = (4, 0)
         delta_w = delta_weight.weight(
-            nb_set=nbsets[cn_map],
+            nb_set=nb_sets[cn_map],
             structure_environments=struct_envs,
             cn_map=cn_map,
             additional_info=additional_info,

--- a/tests/io/aims/test_aims_parsers.py
+++ b/tests/io/aims/test_aims_parsers.py
@@ -132,7 +132,7 @@ def test_header_initial_structure(header_chunk, initial_lattice):
     assert len(header_chunk.initial_structure) == 2
     assert_allclose(header_chunk.initial_structure.lattice.matrix, initial_lattice)
     assert_allclose(header_chunk.initial_structure.cart_coords, initial_positions, atol=1e-12)
-    assert ["Na", "Cl"] == [sp.symbol for sp in header_chunk.initial_structure.species]
+    assert [sp.symbol for sp in header_chunk.initial_structure.species] == ["Na", "Cl"]
 
 
 def test_header_initial_lattice(header_chunk, initial_lattice):
@@ -235,7 +235,7 @@ def test_header_transfer_initial_structure(empty_calc_chunk, initial_lattice):
     assert len(empty_calc_chunk.initial_structure) == 2
     assert_allclose(empty_calc_chunk.initial_structure.lattice.matrix, initial_lattice)
     assert_allclose(empty_calc_chunk.initial_structure.cart_coords, initial_positions, atol=1e-12)
-    assert ["Na", "Cl"] == [sp.symbol for sp in empty_calc_chunk.initial_structure.species]
+    assert [sp.symbol for sp in empty_calc_chunk.initial_structure.species] == ["Na", "Cl"]
 
 
 def test_header_transfer_electronic_temperature(empty_calc_chunk):
@@ -314,7 +314,7 @@ def test_calc_structure(calc_chunk, initial_lattice):
     assert len(calc_chunk.structure.species) == 2
     assert_allclose(calc_chunk.structure.lattice.matrix, initial_lattice)
     assert_allclose(calc_chunk.structure.cart_coords, initial_positions, atol=1e-12)
-    assert ["Na", "Cl"] == [sp.symbol for sp in calc_chunk.structure.species]
+    assert [sp.symbol for sp in calc_chunk.structure.species] == ["Na", "Cl"]
 
 
 def test_calc_forces(calc_chunk):
@@ -444,7 +444,7 @@ def test_molecular_header_n_bands(molecular_header_chunk):
 
 def test_molecular_header_initial_structure(molecular_header_chunk, molecular_positions):
     assert len(molecular_header_chunk.initial_structure) == 3
-    assert ["O", "H", "H"] == [sp.symbol for sp in molecular_header_chunk.initial_structure.species]
+    assert [sp.symbol for sp in molecular_header_chunk.initial_structure.species] == ["O", "H", "H"]
     assert_allclose(
         molecular_header_chunk.initial_structure.cart_coords,
         [[0, 0, 0], [0.95840000, 0, 0], [-0.24000000, 0.92790000, 0]],
@@ -469,7 +469,7 @@ def molecular_positions():
 def test_molecular_calc_atoms(molecular_calc_chunk, molecular_positions):
     assert len(molecular_calc_chunk.structure.species) == 3
     assert_allclose(molecular_calc_chunk.structure.cart_coords, molecular_positions)
-    assert ["O", "H", "H"] == [sp.symbol for sp in molecular_calc_chunk.structure.species]
+    assert [sp.symbol for sp in molecular_calc_chunk.structure.species] == ["O", "H", "H"]
 
 
 def test_molecular_calc_forces(molecular_calc_chunk):


### PR DESCRIPTION
## Summary

Adding the FHI-aims developers to the developers list

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [x] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

