### PR TITLE
Minor update to avoid deprecation warning

### DIFF
--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -186,7 +186,7 @@ class VaspInputSet(InputGenerator, metaclass=abc.ABCMeta):
                     with zopen(os.path.join(output_dir, key), mode="wt") as file:
                         file.write(str(val))
         else:
-            vasp_input = self.get_vasp_input()
+            vasp_input = self.get_input_set()
             vasp_input.write_input(output_dir, make_dir_if_not_present=make_dir_if_not_present)
 
         cif_name = ""


### PR DESCRIPTION
This is just a _tiny_ update to avoid the newly-added deprecation warnings for `get_vasp_input()`.
`get_vasp_input()` is still used in `DictSet.write_input()`, but should be changed to `get_input_set()` in line with the deprection warning (as implemented here).

PS: The recent updates to the VASP sets code is very nice @utf!