### PR TITLE
Fix URL joining in OptimadeRester

### DIFF
--- a/pymatgen/ext/optimade.py
+++ b/pymatgen/ext/optimade.py
@@ -5,9 +5,7 @@ from __future__ import annotations
 import logging
 import sys
 from collections import namedtuple
-from urllib.parse import urljoin
-from os.path import join
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 
 import requests
 from tqdm import tqdm

--- a/pymatgen/ext/optimade.py
+++ b/pymatgen/ext/optimade.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import sys
 from collections import namedtuple
+from urllib.parse import urljoin
 from os.path import join
 from urllib.parse import urlparse
 
@@ -316,7 +317,7 @@ class OptimadeRester:
         response_fields = self._handle_response_fields(additional_response_fields)
 
         for identifier, resource in self.resources.items():
-            url = join(resource, f"v1/structures?filter={optimade_filter}&{response_fields=!s}")
+            url = urljoin(resource, f"v1/structures?filter={optimade_filter}&{response_fields=!s}")
 
             try:
                 json = self._get_json(url)
@@ -450,7 +451,7 @@ class OptimadeRester:
             return None
 
         try:
-            url = join(provider_url, "v1/info")
+            url = urljoin(provider_url, "v1/info")
             provider_info_json = self._get_json(url)
         except Exception as exc:
             _logger.warning(f"Failed to parse {url} when validating: {exc}")
@@ -487,7 +488,7 @@ class OptimadeRester:
             Provider objects.
         """
         try:
-            url = join(provider_url, "v1/links")
+            url = urljoin(provider_url, "v1/links")
             provider_link_json = self._get_json(url)
         except Exception as exc:
             _logger.error(f"Failed to parse {url} when following links: {exc}")

--- a/tests/ext/test_optimade.py
+++ b/tests/ext/test_optimade.py
@@ -9,16 +9,14 @@ from pymatgen.ext.optimade import OptimadeRester
 from pymatgen.util.testing import PymatgenTest
 
 try:
-    website_down = requests.get("https://materialsproject.org").status_code != 200
+    # 403 is returned when server detects bot-like behavior
+    website_down = requests.get("https://materialsproject.org").status_code not in (200, 403)
 except requests.exceptions.ConnectionError:
     website_down = True
 
 
 class TestOptimade(PymatgenTest):
-    @unittest.skipIf(
-        not SETTINGS.get("PMG_MAPI_KEY") or website_down,
-        "PMG_MAPI_KEY environment variable not set or MP is down.",
-    )
+    @unittest.skipIf(not SETTINGS.get("PMG_MAPI_KEY") or website_down, "PMG_MAPI_KEY env var not set or MP is down.")
     def test_get_structures_mp(self):
         with OptimadeRester("mp") as optimade:
             structs = optimade.get_structures(elements=["Ga", "N"], nelements=2)
@@ -36,10 +34,7 @@ class TestOptimade(PymatgenTest):
                     raw_filter_structs["mp"]
                 ), f"Raw filter {_filter} did not return the same number of results as the query builder."
 
-    @unittest.skipIf(
-        not SETTINGS.get("PMG_MAPI_KEY") or website_down,
-        "PMG_MAPI_KEY environment variable not set or MP is down.",
-    )
+    @unittest.skipIf(not SETTINGS.get("PMG_MAPI_KEY") or website_down, "PMG_MAPI_KEY env var not set or MP is down.")
     def test_get_snls_mp(self):
         base_query = dict(elements=["Ga", "N"], nelements=2, nsites=[2, 6])
         with OptimadeRester("mp") as optimade:


### PR DESCRIPTION
## Summary

Major changes:

- fix 1: 
  - Fix URL joining in OptimadeRester. The original os.path.join function is not the correct function to use for joining URLs. It's designed for joining file paths, and its behavior depends on the operating system. On Windows, it uses a backslash (\) as the separator, while on Unix-based systems, it uses a forward slash (/). 
  - This is a small fix, so no tests were added to 'test_optimade.py'
  - This fix should resolve the issue reported at: https://matsci.org/t/could-not-retrieve-information-from-optimade/39469

## Todos

None

## Checklist

- [N/A] Google format doc strings added. Check with `ruff`.
- [N/A] Type annotations included. Check with `mypy`.
- [N/A] Tests added for new features/fixes.
- [N/A] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
