### PR TITLE
Return `self` from all `SiteCollection/Structure/Molecule` in-place modification methods

### DIFF
--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -232,6 +232,7 @@ class SiteCollection(collections.abc.Sequence, metaclass=ABCMeta):
         Returns:
             Distance between sites at index i and index j.
         """
+        raise NotImplementedError
 
     @property
     def distance_matrix(self) -> np.ndarray:

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -525,6 +525,9 @@ class SiteCollection(collections.abc.Sequence, metaclass=ABCMeta):
                 {Element('Si): {Element('Ge'): 0.75, Element('C'): 0.25} } will have .375 Ge and .125 C.
             in_place (bool): Whether to perform the substitution in place or modify a copy.
                 Defaults to True.
+
+        Returns:
+            SiteCollection: self or new SiteCollection (depending on in_place) with species replaced.
         """
         site_coll = self if in_place else self.copy()
         sp_mapping = {get_el_sp(k): v for k, v in species_mapping.items()}

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -4626,7 +4626,7 @@ class Molecule(IMolecule, collections.abc.MutableSequence):
             properties=properties,
         )
 
-    def set_charge_and_spin(self, charge: float, spin_multiplicity: int | None = None) -> None:
+    def set_charge_and_spin(self, charge: float, spin_multiplicity: int | None = None) -> Molecule:
         """Set the charge and spin multiplicity.
 
         Args:
@@ -4635,6 +4635,9 @@ class Molecule(IMolecule, collections.abc.MutableSequence):
                 Defaults to None, which means that the spin multiplicity is
                 set to 1 if the molecule has no unpaired electrons and to 2
                 if there are unpaired electrons.
+
+        Returns:
+            Molecule: self with new charge and spin multiplicity set.
         """
         self._charge = charge
         n_electrons = 0.0
@@ -4653,6 +4656,8 @@ class Molecule(IMolecule, collections.abc.MutableSequence):
             self._spin_multiplicity = spin_multiplicity
         else:
             self._spin_multiplicity = 1 if n_electrons % 2 == 0 else 2
+
+        return self
 
     def insert(  # type: ignore
         self,
@@ -4686,11 +4691,14 @@ class Molecule(IMolecule, collections.abc.MutableSequence):
 
         return self
 
-    def remove_species(self, species: Sequence[SpeciesLike]) -> None:
+    def remove_species(self, species: Sequence[SpeciesLike]) -> Molecule:
         """Remove all occurrences of a species from a molecule.
 
         Args:
             species: Species to remove.
+
+        Returns:
+            Molecule: self with species removed.
         """
         new_sites = []
         species = [get_el_sp(sp) for sp in species]
@@ -4699,16 +4707,21 @@ class Molecule(IMolecule, collections.abc.MutableSequence):
             if len(new_sp_occu) > 0:
                 new_sites.append(Site(new_sp_occu, site.coords, properties=site.properties, label=site.label))
         self.sites = new_sites
+        return self
 
-    def remove_sites(self, indices: Sequence[int]) -> None:
+    def remove_sites(self, indices: Sequence[int]) -> Molecule:
         """Delete sites with at indices.
 
         Args:
             indices: Sequence of indices of sites to delete.
+
+        Returns:
+            Molecule: self with sites removed.
         """
         self.sites = [self[idx] for idx in range(len(self)) if idx not in indices]
+        return self
 
-    def translate_sites(self, indices: Sequence[int] | None = None, vector: ArrayLike | None = None) -> None:
+    def translate_sites(self, indices: Sequence[int] | None = None, vector: ArrayLike | None = None) -> Molecule:
         """Translate specific sites by some vector, keeping the sites within the
         unit cell.
 
@@ -4716,6 +4729,9 @@ class Molecule(IMolecule, collections.abc.MutableSequence):
             indices (list): List of site indices on which to perform the
                 translation.
             vector (3x1 array): Translation vector for sites.
+
+        Returns:
+            Molecule: self with translated sites.
         """
         if indices is None:
             indices = range(len(self))
@@ -4725,6 +4741,7 @@ class Molecule(IMolecule, collections.abc.MutableSequence):
             site = self[idx]
             new_site = Site(site.species, site.coords + vector, properties=site.properties, label=site.label)
             self[idx] = new_site
+        return self
 
     def rotate_sites(
         self,
@@ -4732,7 +4749,7 @@ class Molecule(IMolecule, collections.abc.MutableSequence):
         theta: float = 0.0,
         axis: ArrayLike | None = None,
         anchor: ArrayLike | None = None,
-    ) -> None:
+    ) -> Molecule:
         """Rotate specific sites by some angle around vector at anchor.
 
         Args:
@@ -4741,6 +4758,9 @@ class Molecule(IMolecule, collections.abc.MutableSequence):
             theta (float): Angle in radians
             axis (3x1 array): Rotation axis vector.
             anchor (3x1 array): Point of rotation.
+
+        Returns:
+            Molecule: self with rotated sites.
         """
         if indices is None:
             indices = range(len(self))
@@ -4764,13 +4784,17 @@ class Molecule(IMolecule, collections.abc.MutableSequence):
             new_site = Site(site.species, s, properties=site.properties, label=site.label)
             self[idx] = new_site
 
-    def perturb(self, distance: float) -> None:
+        return self
+
+    def perturb(self, distance: float) -> Molecule:
         """Performs a random perturbation of the sites in a structure to break
         symmetries.
 
         Args:
-            distance (float): Distance in angstroms by which to perturb each
-                site.
+            distance (float): Distance in angstroms by which to perturb each site.
+
+        Returns:
+            Molecule: self with perturbed sites.
         """
 
         def get_rand_vec():
@@ -4782,11 +4806,16 @@ class Molecule(IMolecule, collections.abc.MutableSequence):
         for idx in range(len(self)):
             self.translate_sites([idx], get_rand_vec())
 
-    def apply_operation(self, symmop: SymmOp) -> None:
+        return self
+
+    def apply_operation(self, symmop: SymmOp) -> Molecule:
         """Apply a symmetry operation to the molecule.
 
         Args:
             symmop (SymmOp): Symmetry operation to apply.
+
+        Returns:
+            Molecule: self after symmetry operation.
         """
 
         def operate_site(site):
@@ -4795,7 +4824,9 @@ class Molecule(IMolecule, collections.abc.MutableSequence):
 
         self.sites = [operate_site(site) for site in self]
 
-    def substitute(self, index: int, func_group: IMolecule | Molecule | str, bond_order: int = 1) -> None:
+        return self
+
+    def substitute(self, index: int, func_group: IMolecule | Molecule | str, bond_order: int = 1) -> Molecule:
         """Substitute atom at index with a functional group.
 
         Args:
@@ -4816,6 +4847,9 @@ class Molecule(IMolecule, collections.abc.MutableSequence):
             bond_order (int): A specified bond order to calculate the bond
                 length between the attached functional group and the nearest
                 neighbor site. Defaults to 1.
+
+        Returns:
+            Molecule: self after substitution.
         """
         # Find the nearest neighbor that is not a terminal atom.
         all_non_terminal_nn = []
@@ -4881,6 +4915,7 @@ class Molecule(IMolecule, collections.abc.MutableSequence):
         # group.
         del self[index]
         self._sites += list(functional_group[1:])
+        return self
 
     def relax(
         self,

--- a/pymatgen/core/surface.py
+++ b/pymatgen/core/surface.py
@@ -415,8 +415,8 @@ class Slab(Structure):
     @property
     def surface_area(self):
         """Calculates the surface area of the slab."""
-        m = self.lattice.matrix
-        return np.linalg.norm(np.cross(m[0], m[1]))
+        matrix = self.lattice.matrix
+        return np.linalg.norm(np.cross(matrix[0], matrix[1]))
 
     @property
     def center_of_mass(self):
@@ -424,7 +424,7 @@ class Slab(Structure):
         weights = [s.species.weight for s in self]
         return np.average(self.frac_coords, weights=weights, axis=0)
 
-    def add_adsorbate_atom(self, indices, specie, distance) -> None:
+    def add_adsorbate_atom(self, indices, specie, distance) -> Slab:
         """Gets the structure of single atom adsorption.
         slab structure from the Slab class(in [0, 0, 1]).
 
@@ -435,13 +435,18 @@ class Slab(Structure):
             specie (Species/Element/str): adsorbed atom species
             distance (float): between centers of the adsorbed atom and the
                 given site in Angstroms.
+
+        Returns:
+            Slab: self with adsorbed atom.
         """
-        # Let's do the work in Cartesian coords
-        center = np.sum([self[i].coords for i in indices], axis=0) / len(indices)
+        # Let's work in Cartesian coords
+        center = np.sum([self[idx].coords for idx in indices], axis=0) / len(indices)
 
         coords = center + self.normal * distance / np.linalg.norm(self.normal)
 
         self.append(specie, coords, coords_are_cartesian=True)
+
+        return self
 
     def __str__(self) -> str:
         def to_str(x) -> str:

--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -1116,7 +1116,7 @@ class TestStructure(PymatgenTest):
         assert returned is struct_specie
         assert struct_elem == struct_specie, "Oxidation state remover failed"
 
-    def test_add_oxidation_states_by_guess(self):
+    def test_add_oxidation_state_by_guess(self):
         struct = PymatgenTest.get_structure("Li2O")
         returned = struct.add_oxidation_state_by_guess()
         assert returned is struct

--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -946,17 +946,17 @@ class TestStructure(PymatgenTest):
             _ = {self.struct: 1}
 
     def test_sort(self):
-        struct = self.struct
-        struct[0] = "F"
-        struct.sort()
-        assert struct[0].species_string == "Si"
-        assert struct[1].species_string == "F"
-        struct.sort(key=lambda site: site.species_string)
-        assert struct[0].species_string == "F"
-        assert struct[1].species_string == "Si"
-        struct.sort(key=lambda site: site.species_string, reverse=True)
-        assert struct[0].species_string == "Si"
-        assert struct[1].species_string == "F"
+        self.struct[0] = "F"
+        returned = self.struct.sort()
+        assert returned is self.struct
+        assert self.struct[0].species_string == "Si"
+        assert self.struct[1].species_string == "F"
+        self.struct.sort(key=lambda site: site.species_string)
+        assert self.struct[0].species_string == "F"
+        assert self.struct[1].species_string == "Si"
+        self.struct.sort(key=lambda site: site.species_string, reverse=True)
+        assert self.struct[0].species_string == "Si"
+        assert self.struct[1].species_string == "F"
 
     def test_replace_species(self):
         struct = self.struct
@@ -1027,13 +1027,15 @@ class TestStructure(PymatgenTest):
 
     def test_add_remove_site_property(self):
         struct = self.struct
-        struct.add_site_property("charge", [4.1, -5])
+        returned = struct.add_site_property("charge", [4.1, -5])
+        assert returned is struct
         assert struct[0].charge == 4.1
         assert struct[1].charge == -5
         struct.add_site_property("magmom", [3, 2])
         assert struct[0].charge == 4.1
         assert struct[0].magmom == 3
-        struct.remove_site_property("magmom")
+        returned = struct.remove_site_property("magmom")
+        assert returned is struct
         with pytest.raises(AttributeError, match="attr='magmom' not found on PeriodicSite"):
             _ = struct[0].magmom
 
@@ -1066,7 +1068,8 @@ class TestStructure(PymatgenTest):
     def test_perturb(self):
         dist = 0.1
         pre_perturbation_sites = self.struct.copy()
-        self.struct.perturb(distance=dist)
+        returned = self.struct.perturb(distance=dist)
+        assert returned is self.struct
         post_perturbation_sites = self.struct.sites
 
         for idx, site in enumerate(pre_perturbation_sites):
@@ -1080,9 +1083,10 @@ class TestStructure(PymatgenTest):
             assert site.distance(post_perturbation_sites2[idx]) <= dist
             assert site.distance(post_perturbation_sites2[idx]) >= 0
 
-    def test_add_oxidation_states_by_element(self):
+    def test_add_oxidation_state_by_element(self):
         oxidation_states = {"Si": -4}
-        self.struct.add_oxidation_state_by_element(oxidation_states)
+        returned = self.struct.add_oxidation_state_by_element(oxidation_states)
+        assert returned is self.struct
         for site in self.struct:
             for specie in site.species:
                 assert specie.oxi_state == oxidation_states[specie.symbol], "Wrong oxidation state assigned!"
@@ -1091,7 +1095,8 @@ class TestStructure(PymatgenTest):
             self.struct.add_oxidation_state_by_element(oxidation_states)
 
     def test_add_oxidation_states_by_site(self):
-        self.struct.add_oxidation_state_by_site([2, -4])
+        returned = self.struct.add_oxidation_state_by_site([2, -4])
+        assert returned is self.struct
         assert self.struct[0].specie.oxi_state == 2
         with pytest.raises(
             ValueError, match="Oxidation states of all sites must be specified, expected 2 values, got 1"
@@ -1107,14 +1112,14 @@ class TestStructure(PymatgenTest):
         lattice = Lattice.cubic(10)
         struct_elem = Structure(lattice, [co_elem, o_elem], coords)
         struct_specie = Structure(lattice, [co_specie, o_specie], coords)
-        struct_out = struct_specie.remove_oxidation_states()
-        assert struct_out is struct_specie
+        returned = struct_specie.remove_oxidation_states()
+        assert returned is struct_specie
         assert struct_elem == struct_specie, "Oxidation state remover failed"
 
     def test_add_oxidation_states_by_guess(self):
         struct = PymatgenTest.get_structure("Li2O")
-        struct_with_oxi = struct.add_oxidation_state_by_guess()
-        assert struct_with_oxi is struct
+        returned = struct.add_oxidation_state_by_guess()
+        assert returned is struct
         expected = [Species("Li", 1), Species("O", -2)]
         for site in struct:
             assert site.specie in expected
@@ -1146,7 +1151,8 @@ class TestStructure(PymatgenTest):
     def test_apply_operation(self):
         op = SymmOp.from_axis_angle_and_translation([0, 0, 1], 90)
         struct = self.struct.copy()
-        struct.apply_operation(op)
+        returned = struct.apply_operation(op)
+        assert returned is struct
         assert_allclose(
             struct.lattice.matrix,
             [[0, 3.840198, 0], [-3.325710, 1.920099, 0], [2.217138, -0, 3.135509]],
@@ -1161,7 +1167,8 @@ class TestStructure(PymatgenTest):
     def test_apply_strain(self):
         struct = self.struct
         initial_coord = struct[1].coords
-        struct.apply_strain(0.01)
+        returned = struct.apply_strain(0.01)
+        assert returned is struct
         assert approx(struct.lattice.abc) == (3.8785999130369997, 3.878600984287687, 3.8785999130549516)
         assert_allclose(struct[1].coords, initial_coord * 1.01)
         a1, b1, c1 = struct.lattice.abc
@@ -1182,7 +1189,8 @@ class TestStructure(PymatgenTest):
 
     def test_scale_lattice(self):
         initial_coord = self.struct[1].coords
-        self.struct.scale_lattice(self.struct.volume * 1.01**3)
+        returned = self.struct.scale_lattice(self.struct.volume * 1.01**3)
+        assert returned is self.struct
         assert_allclose(
             self.struct.lattice.abc,
             (3.8785999130369997, 3.878600984287687, 3.8785999130549516),
@@ -1190,7 +1198,8 @@ class TestStructure(PymatgenTest):
         assert_allclose(self.struct[1].coords, initial_coord * 1.01)
 
     def test_translate_sites(self):
-        self.struct.translate_sites([0, 1], [0.5, 0.5, 0.5], frac_coords=True)
+        returned = self.struct.translate_sites([0, 1], [0.5, 0.5, 0.5], frac_coords=True)
+        assert returned is self.struct
         assert_allclose(self.struct.frac_coords[0], [0.5, 0.5, 0.5])
 
         self.struct.translate_sites([0], [0.5, 0.5, 0.5], frac_coords=False)
@@ -1214,12 +1223,13 @@ class TestStructure(PymatgenTest):
         assert self.struct == original_struct
 
     def test_rotate_sites(self):
-        self.struct.rotate_sites(
+        returned = self.struct.rotate_sites(
             indices=[1],
             theta=2.0 * np.pi / 3.0,
             anchor=self.struct[0].coords,
             to_unit_cell=False,
         )
+        assert returned is self.struct
         assert_allclose(self.struct.frac_coords[1], [-1.25, 1.5, 0.75], atol=1e-6)
         self.struct.rotate_sites(
             indices=[1],

--- a/tests/core/test_surface.py
+++ b/tests/core/test_surface.py
@@ -109,7 +109,8 @@ class TestSlab(PymatgenTest):
             0,
             self.zno55.scale_factor,
         )
-        zno_slab.add_adsorbate_atom([1], "H", 1)
+        returned = zno_slab.add_adsorbate_atom([1], "H", 1)
+        assert returned == zno_slab
 
         assert len(zno_slab) == 9
         assert str(zno_slab[8].specie) == "H"

--- a/tests/files/.pytest-split-durations
+++ b/tests/files/.pytest-split-durations
@@ -1036,7 +1036,7 @@
     "tests/core/test_structure.py::TestMolecule::test_translate_sites": 0.0019293749937787652,
     "tests/core/test_structure.py::TestNeighbor::test_msonable": 0.0021466249600052834,
     "tests/core/test_structure.py::TestNeighbor::test_neighbor_labels": 0.0014545419835485518,
-    "tests/core/test_structure.py::TestStructure::test_add_oxidation_states_by_element": 0.06694620900088921,
+    "tests/core/test_structure.py::TestStructure::test_add_oxidation_state_by_element": 0.06694620900088921,
     "tests/core/test_structure.py::TestStructure::test_add_oxidation_states_by_guess": 0.002574582991655916,
     "tests/core/test_structure.py::TestStructure::test_add_oxidation_states_by_site": 0.0022316250251606107,
     "tests/core/test_structure.py::TestStructure::test_add_remove_site_property": 0.002218457986600697,


### PR DESCRIPTION
Non-breaking change but makes for a more functional API since modification methods can now be chained.

E.g. frequent use case of loading a file from disk/memory and directly applying an in-place modification previously required 2 lines:

```py
struct = Structure.from_file("path/to/file")
struct.add_oxidation_state_by_guess()
```

but can now be shortened to

```py
struct = Structure.from_file("path/to/file").add_oxidation_state_by_guess()
```