### PR TITLE
Make the POTCAR setup instructions clearer

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -191,7 +191,7 @@ In practice, this entire process might look something like the following:
 ```bash
 pmg config -p /path/to/pseudos/potcar_PBE.54/ /path/to/pseudos/pmg_potcars/
 pmg config -p /path/to/pseudos/potcar_LDA.54/ /path/to/pseudos/pmg_potcars/
-pmg config --add PMG_VASP_PSP_DIR pmg_potcars
+pmg config --add PMG_VASP_PSP_DIR /path/to/pseudos/pmg_potcars/pmg_potcars
 ```
 
 If desired, you may specify a default version and type of pseudopotentials as follows:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -153,10 +153,10 @@ After installation, do
 pmg config -p <EXTRACTED_VASP_POTCAR> <MY_PSP>
 ```
 
-In the above, `<EXTRACTED_VASP_POTCAR>` is the location of the directory that
-you extracted the downloaded VASP pseudopotential files, and `<MY_PSP>` is the
-desired location where you would like to store the Pymatgen-compatible pseudopotential
-files. Typically, the `<EXTRACTED_VASP_POTCAR>` directory has the following format:
+In the above, `<EXTRACTED_VASP_POTCAR>` is the path to the extracted VASP pseudopotential
+files, and `<MY_PSP>` is the desired path where you would like to store the newly generated
+Pymatgen-compatible pseudopotential files. Typically, the `<EXTRACTED_VASP_POTCAR>`
+directory has the following format:
 
 ```
 potpaw_PBE.54

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -154,9 +154,9 @@ pmg config -p <EXTRACTED_VASP_POTCAR> <MY_PSP>
 ```
 
 In the above, `<EXTRACTED_VASP_POTCAR>` is the path to the extracted VASP pseudopotential
-files, and `<MY_PSP>` is the desired path where you would like to store the newly generated
-Pymatgen-compatible pseudopotential files. Typically, the `<EXTRACTED_VASP_POTCAR>`
-directory has the following format:
+files as-obtained from VASP, and `<MY_PSP>` is the desired path where you would like to
+store the reformatted, Pymatgen-compatible pseudopotential files. Typically, the
+`<EXTRACTED_VASP_POTCAR>` directory has the following format:
 
 ```
 potpaw_PBE.54

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -154,52 +154,39 @@ pmg config -p <EXTRACTED_VASP_POTCAR> <MY_PSP>
 ```
 
 In the above, `<EXTRACTED_VASP_POTCAR>` is the location of the directory that
-you extracted the downloaded VASP pseudopotential files. Typically, it has
-the following format:
+you extracted the downloaded VASP pseudopotential files, and `<MY_PSP>` is the
+desired location where you would like to store the Pymatgen-compatible pseudopotential
+files. Typically, the `<EXTRACTED_VASP_POTCAR>` directory has the following format:
 
 ```
- - <EXTRACTED_VASP_POTCAR>
- |- POT_GGA_PAW_PBE
- ||- Ac_s
- |||-POTCAR
- |||-...
-```
-
-or:
-
-```
- - <EXTRACTED_VASP_POTCAR>
- |- potpaw_PBE
- ||- Ac_s
- |||-POTCAR
- |||-...
-```
-
-and follow the instructions. If you have done it correctly, you should get a
-resources directory with the following directory structure::
-
-```
-- psp_resources
-|- POT_GGA_PAW_PBE
-||- POTCAR.Ac_s.gz
-||- POTCAR.Ac.gz
-||- POTCAR.Ag.gz
+potpaw_PBE.54
+├── Ac
+│   ├── POTCAR
+│   └── PSCTR
+├── Ag
+│   ├── POTCAR
+│   └── PSCTR
 ...
-|- POT_GGA_PAW_PW91
-...
+
+If you have done it correctly, your newly generated directory given by `<MY_PSP>` shoul
+have the following directory structure:
+
+```
+<MY_PSP>
+├── POT_GGA_PAW_PBE_54
+│   ├── POTCAR.Ac.gz
+│   ├── POTCAR.Ag.gz
+    ...
 ```
 
-After generating the resources directory, you should add a VASP_PSP_DIR config
-variable pointing to the generated directory and you should then be
-able to generate POTCARs:
+After generating the resources directory, you should add the directory
+to your Pymatgen configuration file as follows:
 
 ```bash
 pmg config --add PMG_VASP_PSP_DIR <MY_PSP>
 ```
 
-If you are using newer sets of pseudopotential files from VASP, the directory
-names may be different, e.g., POT_GGA_PAW_PBE_52. For such cases, please also
-add a default functional specification as follows:
+If desired, you may specify a default functional specification as follows:
 
 ```bash
 pmg config --add PMG_DEFAULT_FUNCTIONAL PBE_52

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -168,7 +168,7 @@ potpaw_PBE.54
 │   └── PSCTR
 ...
 
-If you have done it correctly, your newly generated directory given by `<MY_PSP>` shoul
+If you have done it correctly, your newly generated directory given by `<MY_PSP>` should
 have the following directory structure:
 
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -179,8 +179,8 @@ have the following directory structure:
     ...
 ```
 
-After generating the resources directory, you should add the directory
-to your Pymatgen configuration file as follows:
+After the `<MY_PSP>` directory is generated, you should add it to your Pymatgen configuration
+file as follows:
 
 ```bash
 pmg config --add PMG_VASP_PSP_DIR <MY_PSP>

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -186,14 +186,21 @@ to your Pymatgen configuration file as follows:
 pmg config --add PMG_VASP_PSP_DIR <MY_PSP>
 ```
 
-If desired, you may specify a default functional specification as follows:
+In practice, this entire process might look something like the following:
+
+```bash
+pmg config -p /path/to/pseudos/potcar_PBE.54/ /path/to/pseudos/pmg_potcars/
+pmg config -p /path/to/pseudos/potcar_LDA.54/ /path/to/pseudos/pmg_potcars/
+pmg config --add PMG_VASP_PSP_DIR pmg_potcars
+```
+
+If desired, you may specify a default version and type of pseudopotentials as follows:
 
 ```bash
 pmg config --add PMG_DEFAULT_FUNCTIONAL PBE_52
 ```
 
-You can also use this to specify whatever functional you would like to use by
-default in pymatgen, e.g., LDA_52, PW91, etc. Type::
+For additional options, run the help command:
 
 ```bash
 pmg potcar -h


### PR DESCRIPTION
Closes #3629. I have always found the POTCAR setup instructions to be incredibly confusing, in part because some parts were never defined (e.g. `<MY_PSP>`) and in other parts because things are quite out-of-sync with the POTCAR structure offered by VASP as of the last several years. This is an attempt to make it clearer.
