### PR TITLE
Modify `BadInputSetWarning` logic for relaxations of a likely metal

### DIFF
--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -743,7 +743,11 @@ class DictSet(VaspInputSet):
                 BadInputSetWarning,
             )
 
-        if all(k.is_metal for k in structure.composition) and incar.get("NSW", 0) > 0 and (incar.get("ISMEAR", 1) < 0 or (incar.get("ISMEAR", 1) == 0 and incar.get("SIGMA", 0.2) > 0.05)):
+        if (
+            all(k.is_metal for k in structure.composition)
+            and incar.get("NSW", 0) > 0
+            and (incar.get("ISMEAR", 1) < 0 or (incar.get("ISMEAR", 1) == 0 and incar.get("SIGMA", 0.2) > 0.05))
+        ):
             warnings.warn(
                 "Relaxation of likely metal with ISMEAR < 0 or ISMEAR = 1 with a small SIGMA detected. See VASP "
                 "recommendations on ISMEAR for metals.",

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -743,9 +743,9 @@ class DictSet(VaspInputSet):
                 BadInputSetWarning,
             )
 
-        if all(k.is_metal for k in structure.composition) and incar.get("NSW", 0) > 0 and incar.get("ISMEAR", 1) < 1:
+        if all(k.is_metal for k in structure.composition) and incar.get("NSW", 0) > 0 and (incar.get("ISMEAR", 1) < 0 or (incar.get("ISMEAR", 1) == 1 and incar.get("SIGMA", 0.2) > 0.05)):
             warnings.warn(
-                "Relaxation of likely metal with ISMEAR < 1 detected. See VASP "
+                "Relaxation of likely metal with ISMEAR < 0 or ISMEAR = 1 with a small SIGMA detected. See VASP "
                 "recommendations on ISMEAR for metals.",
                 BadInputSetWarning,
             )

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -743,7 +743,7 @@ class DictSet(VaspInputSet):
                 BadInputSetWarning,
             )
 
-        if all(k.is_metal for k in structure.composition) and incar.get("NSW", 0) > 0 and (incar.get("ISMEAR", 1) < 0 or (incar.get("ISMEAR", 1) == 1 and incar.get("SIGMA", 0.2) > 0.05)):
+        if all(k.is_metal for k in structure.composition) and incar.get("NSW", 0) > 0 and (incar.get("ISMEAR", 1) < 0 or (incar.get("ISMEAR", 1) == 0 and incar.get("SIGMA", 0.2) > 0.05)):
             warnings.warn(
                 "Relaxation of likely metal with ISMEAR < 0 or ISMEAR = 1 with a small SIGMA detected. See VASP "
                 "recommendations on ISMEAR for metals.",

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -743,15 +743,23 @@ class DictSet(VaspInputSet):
                 BadInputSetWarning,
             )
 
+        ismear = incar.get("ISMEAR", 1)
+        sigma = incar.get("SIGMA", 0.2)
         if (
-            all(k.is_metal for k in structure.composition)
+            all(elem.is_metal for elem in structure.composition)
             and incar.get("NSW", 0) > 0
-            and (incar.get("ISMEAR", 1) < 0 or (incar.get("ISMEAR", 1) == 0 and incar.get("SIGMA", 0.2) > 0.05))
+            and (ismear < 0 or (ismear == 0 and sigma > 0.05))
         ):
+            ismear_docs = "https://www.vasp.at/wiki/index.php/ISMEAR"
+            msg = ""
+            if ismear < 0:
+                msg = f"Relaxation of likely metal with ISMEAR < 0 ({ismear})."
+            elif ismear == 0 and sigma > 0.05:
+                msg = f"ISMEAR = 0 with a small SIGMA ({sigma}) detected."
             warnings.warn(
-                "Relaxation of likely metal with ISMEAR < 0 or ISMEAR = 1 with a small SIGMA detected. See VASP "
-                "recommendations on ISMEAR for metals.",
+                f"{msg} See VASP recommendations on ISMEAR for metals ({ismear_docs}).",
                 BadInputSetWarning,
+                stacklevel=1,
             )
 
         return incar

--- a/tests/files/.pytest-split-durations
+++ b/tests/files/.pytest-split-durations
@@ -2210,7 +2210,7 @@
     "tests/io/vasp/test_sets.py::TestMITMPRelaxSet::test_hubbard_off_and_ediff_override": 0.004546375945210457,
     "tests/io/vasp/test_sets.py::TestMITMPRelaxSet::test_incar_lmaxmix": 0.008337250037584454,
     "tests/io/vasp/test_sets.py::TestMITMPRelaxSet::test_lda_potcar": 0.035044250020291656,
-    "tests/io/vasp/test_sets.py::TestMITMPRelaxSet::test_metal_check": 0.006276416010223329,
+    "tests/io/vasp/test_sets.py::TestMITMPRelaxSet::test_warnings": 0.006276416010223329,
     "tests/io/vasp/test_sets.py::TestMITMPRelaxSet::test_nelect": 1.6427247499814257,
     "tests/io/vasp/test_sets.py::TestMITMPRelaxSet::test_poscar": 0.006406874977983534,
     "tests/io/vasp/test_sets.py::TestMITMPRelaxSet::test_potcar_special_defaults": 0.008440207981038839,

--- a/tests/io/vasp/test_sets.py
+++ b/tests/io/vasp/test_sets.py
@@ -198,22 +198,33 @@ class TestMITMPRelaxSet(PymatgenTest):
         assert vis.as_dict()["structure"] is not None
         assert "structure" not in vis.as_dict(verbosity=1)
 
-    def test_metal_check(self):
+    def test_warnings(self):
         structure = Structure.from_spacegroup("Fm-3m", Lattice.cubic(3), ["Cu"], [[0, 0, 0]])
 
-        with pytest.warns(
-            BadInputSetWarning,
-            match="Relaxation of likely metal with ISMEAR",
-        ) as warns_metal:
-            vis = self.set(structure)
+        vis = self.set(structure)
+        with pytest.warns(BadInputSetWarning) as warns_metal:
             _ = vis.incar
         assert len(warns_metal) == 1
+        vasp_docs_link = "See VASP recommendations on ISMEAR for metals (https://www.vasp.at/wiki/index.php/ISMEAR)."
+        assert (
+            str(warns_metal[0].message)
+            == f"Relaxation of likely metal with ISMEAR < 0 ({vis.incar['ISMEAR']}). {vasp_docs_link}"
+        )
+
+        # test different warning for ismear == 0 and sigma > 0.05
+        vis = self.set(structure, user_incar_settings={"ISMEAR": 0, "SIGMA": 0.1})
+        with pytest.warns(BadInputSetWarning) as warns_metal:
+            _ = vis.incar
+        assert len(warns_metal) == 1
+        assert (
+            str(warns_metal[0].message)
+            == f"ISMEAR = 0 with a small SIGMA ({vis.incar['SIGMA']}) detected. {vasp_docs_link}"
+        )
 
         with pytest.warns(
             BadInputSetWarning,
             match="Large KSPACING value detected with ISMEAR = -5. Ensure that VASP "
-            "generates an adequate number of KPOINTS, lower KSPACING, or "
-            "set ISMEAR = 0",
+            "generates an adequate number of KPOINTS, lower KSPACING, or set ISMEAR = 0",
         ) as warns_kspacing:
             vis = self.set(structure, user_incar_settings={"KSPACING": 1, "ISMEAR": -5})
             _ = vis.incar

--- a/tests/io/vasp/test_sets.py
+++ b/tests/io/vasp/test_sets.py
@@ -203,8 +203,7 @@ class TestMITMPRelaxSet(PymatgenTest):
 
         with pytest.warns(
             BadInputSetWarning,
-            match="Relaxation of likely metal with ISMEAR < 1 detected. "
-            "See VASP recommendations on ISMEAR for metals.",
+            match="Relaxation of likely metal with ISMEAR",
         ) as warns_metal:
             vis = self.set(structure)
             _ = vis.incar


### PR DESCRIPTION
Closes #3633. Relaxing a metal with ISMEAR = 0 is fine, as noted in the VASP manual, provided SIGMA is sufficiently small (< 0.05 is the recommendation in the VASP manual).

> If you have no a priori knowledge of your system, for instance, if you do not know whether your system is an insulator, semiconductor or metal then always use Gaussian smearing ISMEAR=0 in combination with a small [SIGMA](https://www.vasp.at/wiki/index.php/SIGMA)=0.03-0.05.