### PR TITLE
Speeding up `get_nn_info` in local_env.py

### DIFF
--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -574,12 +574,12 @@ class NearNeighbors:
             return site.index
 
         if isinstance(structure, (IStructure, Structure)):
-            for idx, site in enumerate(structure):
-                if site.is_periodic_image(site):
+            for idx, struc_site in enumerate(structure):
+                if site.is_periodic_image(struc_site):
                     return idx
         else:
-            for idx, site in enumerate(structure):
-                if site == site:
+            for idx, struc_site in enumerate(structure):
+                if site == struc_site:
                     return idx
         raise ValueError("Site not found in structure")
 

--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -560,7 +560,7 @@ class NearNeighbors:
         """
         if isinstance(site, PeriodicNeighbor):
             return site.image
-        
+
         original_site = structure[NearNeighbors._get_original_site(structure, site)]
         image = np.around(np.subtract(site.frac_coords, original_site.frac_coords))
         return tuple(image.astype(int))
@@ -572,7 +572,7 @@ class NearNeighbors:
         """
         if isinstance(site, PeriodicNeighbor):
             return site.index
-        
+
         if isinstance(structure, (IStructure, Structure)):
             for i, s in enumerate(structure):
                 if site.is_periodic_image(s):

--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -558,6 +558,9 @@ class NearNeighbors:
         Returns:
             image: ((int)*3) Lattice image
         """
+        if isinstance(site, PeriodicNeighbor):
+            return site.image
+        
         original_site = structure[NearNeighbors._get_original_site(structure, site)]
         image = np.around(np.subtract(site.frac_coords, original_site.frac_coords))
         return tuple(image.astype(int))
@@ -567,6 +570,9 @@ class NearNeighbors:
         """Private convenience method for get_nn_info,
         gives original site index from ProvidedPeriodicSite.
         """
+        if isinstance(site, PeriodicNeighbor):
+            return site.index
+        
         if isinstance(structure, (IStructure, Structure)):
             for i, s in enumerate(structure):
                 if site.is_periodic_image(s):

--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -543,7 +543,7 @@ class NearNeighbors:
         return list(all_sites.values())
 
     @staticmethod
-    def _get_image(structure, site):
+    def _get_image(structure: Structure, site: Site) -> tuple[int, int, int]:
         """Private convenience method for get_nn_info,
         gives lattice image from provided PeriodicSite and Structure.
 
@@ -552,11 +552,11 @@ class NearNeighbors:
         Note that this method takes O(number of sites) due to searching an original site.
 
         Args:
-            structure: Structure Object
-            site: PeriodicSite Object
+            structure (Structure): Structure Object
+            site (Site): PeriodicSite Object
 
         Returns:
-            image: ((int)*3) Lattice image
+            tuple[int, int , int] Lattice image
         """
         if isinstance(site, PeriodicNeighbor):
             return site.image
@@ -566,7 +566,7 @@ class NearNeighbors:
         return tuple(image.astype(int))
 
     @staticmethod
-    def _get_original_site(structure, site):
+    def _get_original_site(structure: Structure, site: Site) -> int:
         """Private convenience method for get_nn_info,
         gives original site index from ProvidedPeriodicSite.
         """
@@ -574,14 +574,14 @@ class NearNeighbors:
             return site.index
 
         if isinstance(structure, (IStructure, Structure)):
-            for i, s in enumerate(structure):
-                if site.is_periodic_image(s):
-                    return i
+            for idx, site in enumerate(structure):
+                if site.is_periodic_image(site):
+                    return idx
         else:
-            for i, s in enumerate(structure):
-                if site == s:
-                    return i
-        raise Exception("Site not found!")
+            for idx, site in enumerate(structure):
+                if site == site:
+                    return idx
+        raise ValueError("Site not found in structure")
 
     def get_bonded_structure(
         self,

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -1501,9 +1501,8 @@ class IStructure(SiteCollection, MSONable):
         Returns:
             PeriodicNeighbor
         """
-        site_fcoords = np.mod(self.frac_coords, 1)
         neighbors: list[PeriodicNeighbor] = []
-        for frac_coord, dist, i, img in self._lattice.get_points_in_sphere(site_fcoords, pt, r):
+        for frac_coord, dist, i, img in self._lattice.get_points_in_sphere(self.frac_coords, pt, r):
             nn_site = PeriodicNeighbor(
                 self[i].species,
                 frac_coord,

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -1492,26 +1492,26 @@ class IStructure(SiteCollection, MSONable):
 
         Args:
             pt (3x1 array): Cartesian coordinates of center of sphere.
-            r (float): Radius of sphere.
+            r (float): Radius of sphere in Angstrom.
             include_index (bool): Whether the non-supercell site index
-                is included in the returned data
+                is included in the returned data.
             include_image (bool): Whether to include the supercell image
-                is included in the returned data
+                is included in the returned data.
 
         Returns:
             PeriodicNeighbor
         """
         neighbors: list[PeriodicNeighbor] = []
-        for frac_coord, dist, i, img in self._lattice.get_points_in_sphere(self.frac_coords, pt, r):
+        for frac_coord, dist, idx, img in self._lattice.get_points_in_sphere(self.frac_coords, pt, r):
             nn_site = PeriodicNeighbor(
-                self[i].species,
+                self[idx].species,
                 frac_coord,
                 self._lattice,
-                properties=self[i].properties,
+                properties=self[idx].properties,
                 nn_distance=dist,
                 image=img,  # type: ignore
-                index=i,
-                label=self[i].label,
+                index=idx,
+                label=self[idx].label,
             )
             neighbors.append(nn_site)
         return neighbors


### PR DESCRIPTION
`_get_image` and `_get_original_site` do not need to recompute site and index when `site` is a `PeriodicNeighbor` which has them as attributes.

When there are several sites, this makes a significant difference on speed for `get_nn_info`

Alternative implementation would have been `try/except` and `hasattr`. `try/except` is much slower when most of the sites are not `PeriodicNeighbor`.

## Summary

Major changes:

- feature: image and site index are not recomputed when they are already an attribute of the site
