### PR TITLE
[BugFix] Subclass Construction Locpot<:VolumetricData 

### DIFF
--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -3434,13 +3434,13 @@ class VolumetricData(BaseVolumetricData):
 class Locpot(VolumetricData):
     """Simple object for reading a LOCPOT file."""
 
-    def __init__(self, poscar, data):
+    def __init__(self, poscar, data, **kwargs):
         """
         Args:
             poscar (Poscar): Poscar object containing structure.
             data: Actual data.
         """
-        super().__init__(poscar.structure, data)
+        super().__init__(poscar.structure, data, **kwargs)
         self.name = poscar.comment
 
     @classmethod


### PR DESCRIPTION
## Subclass Construction Locpot<:VolumetricData

The constructor signature for `Locpot` is different from the parent.
This makes it hard to write general code to handle different kinds of `VolumetricData` objects.

Just adding a `**kwarg` there should work.