### PR TITLE
Fix `get_niggli_reduced_lattice` if entering A1 case

### DIFF
--- a/pymatgen/analysis/surface_analysis.py
+++ b/pymatgen/analysis/surface_analysis.py
@@ -293,8 +293,8 @@ class SlabEntry(ComputedStructureEntry):
     @property
     def surface_area(self):
         """Calculates the surface area of the slab."""
-        m = self.structure.lattice.matrix
-        return np.linalg.norm(np.cross(m[0], m[1]))
+        matrix = self.structure.lattice.matrix
+        return np.linalg.norm(np.cross(matrix[0], matrix[1]))
 
     @property
     def cleaned_up_slab(self):

--- a/pymatgen/core/lattice.py
+++ b/pymatgen/core/lattice.py
@@ -1093,6 +1093,9 @@ class Lattice(MSONable):
                 # A1
                 M = [[0, -1, 0], [-1, 0, 0], [0, 0, -1]]
                 G = np.dot(np.transpose(M), np.dot(G, M))
+
+            A, B, C, E, N, Y = G[0, 0], G[1, 1], G[2, 2], 2 * G[1, 2], 2 * G[0, 2], 2 * G[0, 1]
+
             if (C + e < B) or (abs(B - C) < e and abs(N) > abs(Y) + e):
                 # A2
                 M = [[-1, 0, 0], [0, 0, -1], [0, -1, 0]]

--- a/pymatgen/core/lattice.py
+++ b/pymatgen/core/lattice.py
@@ -1093,8 +1093,8 @@ class Lattice(MSONable):
                 # A1
                 M = [[0, -1, 0], [-1, 0, 0], [0, 0, -1]]
                 G = np.dot(np.transpose(M), np.dot(G, M))
-
-            A, B, C, E, N, Y = G[0, 0], G[1, 1], G[2, 2], 2 * G[1, 2], 2 * G[0, 2], 2 * G[0, 1]
+                # update lattice parameters based on new G (gh-3657)
+                A, B, C, E, N, Y = G[0, 0], G[1, 1], G[2, 2], 2 * G[1, 2], 2 * G[0, 2], 2 * G[0, 1]
 
             if (C + e < B) or (abs(B - C) < e and abs(N) > abs(Y) + e):
                 # A2

--- a/pymatgen/core/lattice.py
+++ b/pymatgen/core/lattice.py
@@ -954,9 +954,7 @@ class Lattice(MSONable):
 
             None is returned if no matches are found.
         """
-        for x in self.find_all_mappings(other_lattice, ltol, atol, skip_rotation_matrix=skip_rotation_matrix):
-            return x
-        return None
+        return next(self.find_all_mappings(other_lattice, ltol, atol, skip_rotation_matrix), None)
 
     def get_lll_reduced_lattice(self, delta: float = 0.75) -> Lattice:
         """:param delta: Delta parameter.

--- a/tests/core/test_lattice.py
+++ b/tests/core/test_lattice.py
@@ -247,7 +247,9 @@ class LatticeTestCase(PymatgenTest):
         scale = np.array([[1, 1, 0], [0, 1, 0], [0, 0, 1]])
 
         latt2 = Lattice(np.dot(rot, np.dot(scale, m).T).T)
-        (aligned_out, rot_out, scale_out) = latt2.find_mapping(latt)
+        mapping = latt2.find_mapping(latt)
+        assert isinstance(mapping, tuple)
+        aligned_out, rot_out, scale_out = mapping
         assert abs(np.linalg.det(rot)) == approx(1)
 
         rotated = SymmOp.from_rotation_and_translation(rot_out).operate_multi(latt.matrix)

--- a/tests/core/test_lattice.py
+++ b/tests/core/test_lattice.py
@@ -201,42 +201,42 @@ class LatticeTestCase(PymatgenTest):
             assert reduced_random_latt.volume == approx(random_latt.volume)
 
     def test_get_niggli_reduced_lattice(self):
-        latt = Lattice.from_parameters(3, 5.196, 2, 103 + 55 / 60, 109 + 28 / 60, 134 + 53 / 60)
-        reduced_cell = latt.get_niggli_reduced_lattice()
+        lattice = Lattice.from_parameters(3, 5.196, 2, 103 + 55 / 60, 109 + 28 / 60, 134 + 53 / 60)
+        reduced_cell = lattice.get_niggli_reduced_lattice()
         abc = reduced_cell.lengths
         angles = reduced_cell.angles
         assert abc == approx([2, 3, 3], abs=1e-3)
         assert angles == approx([116.382855225, 94.769790287999996, 109.466666667])
 
         mat = [[5.0, 0, 0], [0, 5.0, 0], [5.0, 0, 5.0]]
-        latt = Lattice(np.dot([[1, 1, 1], [1, 1, 0], [0, 1, 1]], mat))
-        reduced_cell = latt.get_niggli_reduced_lattice()
+        lattice = Lattice(np.dot([[1, 1, 1], [1, 1, 0], [0, 1, 1]], mat))
+        reduced_cell = lattice.get_niggli_reduced_lattice()
         assert reduced_cell.lengths == approx([5, 5, 5])
         assert reduced_cell.angles == approx([90, 90, 90])
 
-        latt = Lattice([1.432950, 0.827314, 4.751000, -1.432950, 0.827314, 4.751000, 0.0, -1.654628, 4.751000])
+        lattice = Lattice([1.432950, 0.827314, 4.751000, -1.432950, 0.827314, 4.751000, 0.0, -1.654628, 4.751000])
         expected = [
             [-1.43295, -2.481942, 0.0],
             [-2.8659, 0.0, 0.0],
             [-1.43295, -0.827314, -4.751],
         ]
-        assert_allclose(latt.get_niggli_reduced_lattice().matrix, expected)
+        assert_allclose(lattice.get_niggli_reduced_lattice().matrix, expected)
 
-        latt = Lattice.from_parameters(7.365450, 6.199506, 5.353878, 75.542191, 81.181757, 156.396627)
+        lattice = Lattice.from_parameters(7.365450, 6.199506, 5.353878, 75.542191, 81.181757, 156.396627)
         expected = [
             [2.578932, 0.826965, 0.000000],
             [-0.831059, 2.067413, 1.547813],
             [-0.458407, -2.480895, 1.129126],
         ]
-        assert_allclose(latt.get_niggli_reduced_lattice().matrix, np.array(expected), atol=1e-5)
+        assert_allclose(lattice.get_niggli_reduced_lattice().matrix, np.array(expected), atol=1e-5)
 
-        latt = Lattice([-0.2590, 1.1866, -0.1235, 2.2166, 1.0065, 0.7327, 1.1439, -0.4686, -0.0229])
+        lattice = Lattice([-0.2590, 1.1866, -0.1235, 2.2166, 1.0065, 0.7327, 1.1439, -0.4686, -0.0229])
         expected = [
             [-0.8849, -0.718, 0.1464],
             [0.1878, 0.7571, 0.902],
             [-0.4468, 0.4295, -1.0255],
         ]
-        assert_allclose(latt.get_niggli_reduced_lattice().matrix, np.array(expected), atol=1e-5)
+        assert_allclose(lattice.get_niggli_reduced_lattice().matrix, np.array(expected), atol=1e-5)
 
     def test_find_mapping(self):
         m = np.array([[0.1, 0.2, 0.3], [-0.1, 0.2, 0.7], [0.6, 0.9, 0.2]])

--- a/tests/core/test_lattice.py
+++ b/tests/core/test_lattice.py
@@ -230,6 +230,14 @@ class LatticeTestCase(PymatgenTest):
         ]
         assert_allclose(latt.get_niggli_reduced_lattice().matrix, np.array(expected), atol=1e-5)
 
+        latt = Lattice([-0.2590, 1.1866, -0.1235, 2.2166, 1.0065, 0.7327, 1.1439, -0.4686, -0.0229])
+        expected = [
+            [-0.8849, -0.718, 0.1464],
+            [0.1878, 0.7571, 0.902],
+            [-0.4468, 0.4295, -1.0255],
+        ]
+        assert_allclose(latt.get_niggli_reduced_lattice().matrix, np.array(expected), atol=1e-5)
+
     def test_find_mapping(self):
         m = np.array([[0.1, 0.2, 0.3], [-0.1, 0.2, 0.7], [0.6, 0.9, 0.2]])
         latt = Lattice(m)

--- a/tests/core/test_lattice.py
+++ b/tests/core/test_lattice.py
@@ -208,8 +208,7 @@ class LatticeTestCase(PymatgenTest):
         assert abc == approx([2, 3, 3], abs=1e-3)
         assert angles == approx([116.382855225, 94.769790287999996, 109.466666667])
 
-        mat = [[5.0, 0, 0], [0, 5.0, 0], [5.0, 0, 5.0]]
-        lattice = Lattice(np.dot([[1, 1, 1], [1, 1, 0], [0, 1, 1]], mat))
+        lattice = Lattice(np.dot([[1, 1, 1], [1, 1, 0], [0, 1, 1]], 5 * np.eye(3)))
         reduced_cell = lattice.get_niggli_reduced_lattice()
         assert reduced_cell.lengths == approx([5, 5, 5])
         assert reduced_cell.angles == approx([90, 90, 90])
@@ -239,14 +238,14 @@ class LatticeTestCase(PymatgenTest):
         assert_allclose(lattice.get_niggli_reduced_lattice().matrix, np.array(expected), atol=1e-5)
 
     def test_find_mapping(self):
-        m = np.array([[0.1, 0.2, 0.3], [-0.1, 0.2, 0.7], [0.6, 0.9, 0.2]])
-        latt = Lattice(m)
+        matrix = [[0.1, 0.2, 0.3], [-0.1, 0.2, 0.7], [0.6, 0.9, 0.2]]
+        latt = Lattice(matrix)
 
         op = SymmOp.from_origin_axis_angle([0, 0, 0], [2, 3, 3], 35)
         rot = op.rotation_matrix
         scale = np.array([[1, 1, 0], [0, 1, 0], [0, 0, 1]])
 
-        latt2 = Lattice(np.dot(rot, np.dot(scale, m).T).T)
+        latt2 = Lattice(np.dot(rot, np.dot(scale, matrix).T).T)
         mapping = latt2.find_mapping(latt)
         assert isinstance(mapping, tuple)
         aligned_out, rot_out, scale_out = mapping
@@ -260,14 +259,14 @@ class LatticeTestCase(PymatgenTest):
         assert not np.allclose(aligned_out.parameters, latt2.parameters)
 
     def test_find_all_mappings(self):
-        m = np.array([[0.1, 0.2, 0.3], [-0.1, 0.2, 0.7], [0.6, 0.9, 0.2]])
-        lattice = Lattice(m)
+        matrix = [[0.1, 0.2, 0.3], [-0.1, 0.2, 0.7], [0.6, 0.9, 0.2]]
+        lattice = Lattice(matrix)
 
         op = SymmOp.from_origin_axis_angle([0, 0, 0], [2, -1, 3], 40)
         rot = op.rotation_matrix
         scale = np.array([[0, 2, 0], [1, 1, 0], [0, 0, 1]])
 
-        latt2 = Lattice(np.dot(rot, np.dot(scale, m).T).T)
+        latt2 = Lattice(np.dot(rot, np.dot(scale, matrix).T).T)
 
         for aligned_out, rot_out, scale_out in lattice.find_all_mappings(latt2):
             assert_allclose(np.inner(latt2.matrix, rot_out), aligned_out.matrix, atol=1e-12)


### PR DESCRIPTION
## Summary

Major changes:

- fix 1: I found a bug at `pymatgen/core/lattice.py::Lattice::get_niggli_reduced_lattice`.
  - After updating lattice parameters at A1, variables `A, B, ...` also need to be updated.
  - Otherwise, condition checking would be wrong at A2 or later.
  - Therefore, I added a line for updating `A, B, C, E, N, Y`.
    - This is not minimal, but the simplest I think.
  - Also, added a test that fails before the fix and succeeds after the fix.
    - Correct values were calculated by spglib.

## Todos

If this is work in progress, what else needs to be done?

## Checklist

- [ ] Google format doc strings added. Check with `ruff`.
- [ ] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
