### PR TITLE
Fix installation.md formatting

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -167,6 +167,7 @@ potpaw_PBE.54
 │   ├── POTCAR
 │   └── PSCTR
 ...
+```
 
 If you have done it correctly, your newly generated directory given by `<MY_PSP>` should
 have the following directory structure:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -94,12 +94,11 @@ bash Miniconda3-latest-MacOSX-x86_64.sh
 bash Miniconda3-latest-Linux-x86_64.sh
 ```
 
-Note that you may need to create a new terminal after this step in order for
-the environmental variables added by conda to be loaded.
+Note that you may need to create a new terminal after this step for the environmental variables added by `conda` to be loaded.
 
 ### Step 2b: (Optional) Create a conda environment
 
-If you are working with many python packages, it is generally recommended you
+If you are working with many Python packages, it is generally recommended you
 create a separate environment for each of your packages. For example:
 
 ```shell
@@ -125,10 +124,10 @@ conda install --yes numpy scipy matplotlib
 pip install pymatgen
 ```
 
-### Step 4: (Optional) Install enumlib and bader (only for OSX and Linux)
+### Step 4: (Optional) Install `enumlib` and `bader` (only for OSX and Linux)
 
 If you would like to use the enumeration capabilities powered by Gus Hart's
-enumlib or perform Bader charge analysis powered by the Bader analysis code
+`enumlib` or perform Bader charge analysis powered by the Bader analysis code
 of the Henkelmann group, please try installing these from source using the pmg
 command line tool as follows::
 
@@ -153,12 +152,11 @@ After installation, do
 pmg config -p <EXTRACTED_VASP_POTCAR> <MY_PSP>
 ```
 
-In the above, `<EXTRACTED_VASP_POTCAR>` is the path to the extracted VASP pseudopotential
-files as-obtained from VASP, and `<MY_PSP>` is the desired path where you would like to
+In the above, `<EXTRACTED_VASP_POTCAR>` is the path to the extracted VASP pseudopotential files as obtained from VASP, and `<MY_PSP>` is the desired path where you would like to
 store the reformatted, Pymatgen-compatible pseudopotential files. Typically, the
 `<EXTRACTED_VASP_POTCAR>` directory has the following format:
 
-```
+```txt
 potpaw_PBE.54
 ├── Ac
 │   ├── POTCAR
@@ -172,7 +170,7 @@ potpaw_PBE.54
 If you have done it correctly, your newly generated directory given by `<MY_PSP>` should
 have the following directory structure:
 
-```
+```txt
 <MY_PSP>
 ├── POT_GGA_PAW_PBE_54
 │   ├── POTCAR.Ac.gz
@@ -202,232 +200,17 @@ pmg config --add PMG_DEFAULT_FUNCTIONAL PBE_52
 ```
 
 For additional options, run the help command:
-
-```bash
-pmg potcar -h
-```
-
-to see full list of choices.
+to see the full list of choices.
 
 **Note:** The Materials Project currently uses older versions of the VASP pseudopotentials
     for maximum compatibility with historical data, rather than the current 52/54
     pseudopotentials. This setting can be overridden by the user if desired.
     As such, current versions of pymatgen will check the hashes of your pseudopotentials
-    when constructing input sets to ensure the correct, compatible pseudopotential sets are
-    used, so that total energies can be compared to those in the Materials Project database.
+    when constructing input sets to ensure the correct, compatible pseudopotential sets are used so that total energies can be compared to those in the Materials Project database.
     If you use any functional other than PBE, note that you should not be combining results
     from these other functionals with Materials Project data. For up-to-date information
     on this, please consult the Materials Project documentation.
 
-## PyPy Support
+## Contributing to `pymatgen`
 
-[PyPy](https://www.pypy.org) is an alternative Python interpreter for running Python code
-and comes with significant speed improvements for common applications. However, historically,
-fewer packages offer PyPy support.
-
-It is possible to install and use pymatgen with the PyPy interpreter
-but it comes with some important caveats:
-
-* While it is usable, PyPy is not officially supported by pymatgen. We do not run our
-  full test suite on PyPy and it's possible some parts of pymatgen will be broken.
-* All of pymatgen's dependencies now support PyPy including numpy, scipy, and pandas,
-  however matplotlib is difficult to install. If trying PyPy, the current advice
-  is to remove the matplotlib dependency, however this means any modules using matplotlib
-  will not be importable. The easiest way to install dependencies is using the
-  [PyPy builds on conda-forge](https://conda-forge.org/blog/2020/03/10/pypy). For spglib,
-  cloning the repository and running ``python setup.py install`` manually is advised.
-* Performance improvements are unpredictable. Since pymatgen makes heavy use of numpy
-  and custom extensions where appropriate, many code hot spots have already been optimized.
-
-We welcome any developers interested in expanding our PyPy support.
-
-## Setup for Developers (using GitHub)
-
-### Step 1: Preparing your system
-
-#### Windows
-
-1. Download Microsoft Visual Studio 2015 (the free Community Edition) is fine.
-2. Install Visual Studio 2015, but *make sure that you select More Options ->
-   Programming Languages -> Visual C++ during the installation process*. By
-   default, Visual Studio does not install Visual C++, which is needed.
-
-#### Mac OSX
-
-1. Download and install Xcode. Afterwards, install the XCode command line
-   tools by typing the following in a terminal::
-
-      xcode-select --install
-
-2. (Optional) Install gfortran. Get an installer at
-   <http://gcc.gnu.org/wiki/GFortranBinaries#MacOS>.
-
-#### Linux
-
-1. Usually no preparation is needed as most of the standard compilers should
-   already be available.
-
-### Step 2: Install pymatgen in developmental mode
-
-1. Make sure you have git and [git-lfs](https://git-lfs.github.com) installed.
-   Clone the repo at <https://github.com/materialsproject/pymatgen>.
-
-2. Run `git lfs install` in the cloned repo first.
-
-3. In your root pymatgen repo directory, type (you may need to do this with root
-   privileges)::
-
-      pip install -e .
-
-4. Install any missing python libraries that are necessary.
-
-I recommend that you start by reading some of the unittests in the tests
-subdirectory for each package. The unittests demonstrate the expected behavior
-and functionality of the code.
-
-Please read up on pymatgen's :doc:`coding guidelines </contributing>` before
-you start coding. It will make integration much easier.
-
-## Installation tips for optional libraries
-
-This section provides a guide for installing various optional libraries used in
-pymatgen. Some of the python libraries are rather tricky to build in certain
-operating systems, especially for users unfamiliar with building C/C++ code.
-Please feel free to send in suggestions to update the instructions based on
-your experiences. In all the instructions, it is assumed that you have standard
-gcc and other compilers (e.g., Xcode on Macs) already installed.
-
-### VTK on Mac OS X (tested on v7.0)
-
-The easiest is to install cmake from
-<http://cmake.org/cmake/resources/software.html>.
-
-Type the following::
-
-    cd VTK (this is the directory you expanded VTK into)
-    mkdir build
-    cd build
-    ccmake .. (this uses cmake in an interactive manner)
-
-Press "t" to toggle advanced mode. Then press "c" to do an initial
-configuration. After the list of parameters come out, ensure that the
-PYTHON_VERSION is set to 3, the VTK_WRAP_PYTHON is set to ON, and
-BUILD_SHARED_LIBS is set to ON. You may also need to modify the python
-paths and library paths if they are in non-standard locations. For example, if
-you have installed the official version of Python instead of using the
-Mac-provided version, you will probably need to edit the CMakeCache Python
-links. Example configuration for Python 3.5 installed using conda is given
-below (only variables that need to be modified/checked are shown)::
-
-    PYTHON_EXECUTABLE:FILEPATH=/Users/<username>/miniconda3/bin/python3
-    PYTHON_INCLUDE_DIR:PATH=/Users/<username>/miniconda3/include/python3.5m
-    PYTHON_LIBRARY:FILEPATH=/Users/<username>/miniconda3/lib/libpython3.5m.dylib
-    VTK_INSTALL_PYTHON_MODULE_DIR:PATH=/Users/<username>/miniconda3/lib/python3.5/site-packages
-    VTK_PYTHON_VERSION:STRING=3
-    VTK_WRAP_PYTHON:BOOL=ON
-
-Then press "c" again to configure and finally "g" to generate the required
-make files After the CMakeCache.txt file is generated, type::
-
-    make -j 4
-    sudo make install
-
-With any luck, you should have vtk with the necessary python wrappers
-installed. You can test this by going into a python terminal and trying::
-
-    import vtk
-
-### OpenBabel Mac OS X (tested on v2.3.2)
-
-**Anaconda install**
-
-If you are using anaconda (and have pymatgen installed in your anaconda environment), you should be
-able to install openbabel with a single command::
-
-    conda install -c openbabel openbabel
-
-**Manual install**
-
-Openbabel must be compiled with python bindings for integration with pymatgen.
-Here are the steps that I took to make it work:
-
-1. Install cmake from <http://cmake.org/cmake/resources/software.html>.
-
-2. Install pcre-8.33 from
-   ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre-8.33.tar.gz.
-
-3. Install pkg-config-0.28 using MacPorts or from
-   <http://pkgconfig.freedesktop.org/releases/pkg-config-0.28.tar.gz>.
-
-4. Install SWIG from
-   <http://prdownloads.sourceforge.net/swig/swig-2.0.10.tar.gz>.
-
-5. Download openbabel 2.3.2 *source code* from
-   <https://sourceforge.net/projects/openbabel/files/openbabel/2.3.2/>.
-
-6. Download Eigen version 3.1.2 from
-   <http://bitbucket.org/eigen/eigen/get/3.1.2.tar.gz>.
-
-7. Extract your Eigen and openbabel source distributions::
-
-    tar -zxvf openbabel-2.3.2.tar.gz
-    tar -zxvf eigen3.tar.gz
-
-8. Now you should have two directories. Assuming that your openbabel src is in
-   a directory called "openbabel-2.3.2" and your eigen source is in a directory
-   called "eigen3", do the following steps::
-
-    mv openbabel-2.3.2 ob-src
-    cd ob-src/scripts/python; rm openbabel.py openbabel-python.cpp; cd ../../..
-
-9. Edit ob-src/scripts/CMakeLists.txt, jump to line 70, change “eigen2_define”
-   to “eigen_define”.
-
-10. Let's create a build directory::
-
-        mkdir ob-build
-        cd ob-build
-        cmake -DPYTHON_BINDINGS=ON -DRUN_SWIG=ON -DEIGEN3_INCLUDE_DIR=../eigen3 ../ob-src 2>&1 | tee cmake.out
-
-11. Before proceeding further, similar to the VTK installation process in the
-    previous section, you may also need to modify the CMakeCache.txt
-    file by hand if your python paths and library paths if they are in
-    non-standard locations. For example, if you have installed the official
-    version of Python instead of using the Mac-provided version,
-    you will probably need to edit the CMakeCache Python links. Example
-    configuration for Python 2.7 is given below (only variables that need to
-    be modified are shown)::
-
-        //Path to a program.
-        PYTHON_EXECUTABLE:FILEPATH=/Library/Frameworks/Python.framework/Versions/2.7/bin/python
-
-        //Path to a file.
-        PYTHON_INCLUDE_DIR:PATH=/Library/Frameworks/Python.framework/Versions/2.7/Headers
-
-        //Path to a library.
-        PYTHON_LIBRARY:FILEPATH=/Library/Frameworks/Python.framework/Versions/2.7/lib/libpython2.7.dylib
-
-12. If you are using Mavericks (OSX 10.9) and encounter errors relating to <tr1/memory>, you might also need to include
-    the following flag in your CMakeCache.txt::
-
-        CMAKE_CXX_FLAGS:STRING=-stdlib=libstdc++
-
-13. Run make and install as follows::
-
-        make -j2
-        sudo make install
-
-14. With any luck, you should have openbabel with python bindings installed.
-    You can test your installation by trying to import openbabel from the
-    python command line. Please note that despite best efforts,
-    openbabel seems to install the python bindings into /usr/local/lib even
-    if your Python is not the standard Mac version. In that case,
-    you may need to add the following into your .bash_profile::
-
-        export PYTHONPATH=/usr/local/lib:$PYTHONPATH
-
-### Zeo++
-
-If you use the defects analysis package, you will need to install Zeo++.
-
-The download and installation instructions for Zeo++ can be found here: <http://www.zeoplusplus.org/>
+See [pymatgen.org/contributing](https://pymatgen.org/contributing).


### PR DESCRIPTION
## Summary

There was a missing ```, making the public docs look awful. I was the culprit. Oops. All patched!