### PR TITLE
Remove BadPoscarWarning when POSCAR elements set by POTCAR

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ ci:
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.1
+    rev: v0.3.0
     hooks:
       - id: ruff
         args: [--fix, --unsafe-fixes]

--- a/dev_scripts/potcar_scrambler.py
+++ b/dev_scripts/potcar_scrambler.py
@@ -15,7 +15,6 @@ from pymatgen.io.vasp.sets import _load_yaml_config
 
 
 class PotcarScrambler:
-
     """
     Takes a POTCAR and replaces its values with completely random values
     Does type matching and attempts precision matching on floats to ensure

--- a/pymatgen/analysis/chemenv/utils/scripts_utils.py
+++ b/pymatgen/analysis/chemenv/utils/scripts_utils.py
@@ -1,6 +1,5 @@
 """This module contains some script utils that are used in the chemenv package."""
 
-
 from __future__ import annotations
 
 import re

--- a/pymatgen/analysis/ferroelectricity/polarization.py
+++ b/pymatgen/analysis/ferroelectricity/polarization.py
@@ -43,7 +43,6 @@ of polarization can only be zero or 1/2. We use a nonpolar structure to help
 determine the spontaneous polarization because it serves as a reference point.
 """
 
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/pymatgen/analysis/functional_groups.py
+++ b/pymatgen/analysis/functional_groups.py
@@ -1,6 +1,5 @@
 """Determine functional groups present in a Molecule."""
 
-
 from __future__ import annotations
 
 import copy

--- a/pymatgen/analysis/thermochemistry.py
+++ b/pymatgen/analysis/thermochemistry.py
@@ -1,6 +1,5 @@
 """A module to perform experimental thermochemical data analysis."""
 
-
 from __future__ import annotations
 
 from pymatgen.core.composition import Composition

--- a/pymatgen/apps/battery/plotter.py
+++ b/pymatgen/apps/battery/plotter.py
@@ -1,6 +1,5 @@
 """This module provides plotting capabilities for battery related applications."""
 
-
 from __future__ import annotations
 
 import matplotlib.pyplot as plt

--- a/pymatgen/cli/pmg_potcar.py
+++ b/pymatgen/cli/pmg_potcar.py
@@ -2,7 +2,6 @@
 
 """Implementation for `pmg potcar` CLI."""
 
-
 from __future__ import annotations
 
 import os

--- a/pymatgen/io/aims/outputs.py
+++ b/pymatgen/io/aims/outputs.py
@@ -1,4 +1,5 @@
 """A representation of FHI-aims output (based on ASE output parser)."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any

--- a/pymatgen/io/aims/parsers.py
+++ b/pymatgen/io/aims/parsers.py
@@ -1,4 +1,5 @@
 """AIMS output parser, taken from ASE with modifications."""
+
 from __future__ import annotations
 
 import gzip

--- a/pymatgen/io/aims/sets/base.py
+++ b/pymatgen/io/aims/sets/base.py
@@ -1,4 +1,5 @@
 """Module defining base FHI-aims input set and generator."""
+
 from __future__ import annotations
 
 import copy

--- a/pymatgen/io/aims/sets/bs.py
+++ b/pymatgen/io/aims/sets/bs.py
@@ -1,4 +1,5 @@
 """Input sets for band structure calculations."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/pymatgen/io/aims/sets/core.py
+++ b/pymatgen/io/aims/sets/core.py
@@ -1,4 +1,5 @@
 """Module defining core FHI-aims input set generators."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -445,9 +445,9 @@ class CifParser:
                         # Extract element name and its occupancy from the
                         # string, and store it as a
                         # key-value pair in "els_occ".
-                        els_occu[
-                            str(re.findall(r"\D+", symbol_str_lst[elocc_idx].strip())[1]).replace("<sup>", "")
-                        ] = float("0" + re.findall(r"\.?\d+", symbol_str_lst[elocc_idx].strip())[1])
+                        els_occu[str(re.findall(r"\D+", symbol_str_lst[elocc_idx].strip())[1]).replace("<sup>", "")] = (
+                            float("0" + re.findall(r"\.?\d+", symbol_str_lst[elocc_idx].strip())[1])
+                        )
 
                     x = str2float(data["_atom_site_fract_x"][idx])
                     y = str2float(data["_atom_site_fract_y"][idx])

--- a/pymatgen/io/feff/outputs.py
+++ b/pymatgen/io/feff/outputs.py
@@ -4,7 +4,6 @@ This module defines classes for parsing the FEFF output files.
 Currently supports the xmu.dat, ldos.dat output files are for non-spin case.
 """
 
-
 from __future__ import annotations
 
 import re

--- a/pymatgen/io/lammps/utils.py
+++ b/pymatgen/io/lammps/utils.py
@@ -309,9 +309,10 @@ class PackmolRunner:
         """
         with tempfile.TemporaryDirectory() as scratch_dir:
             self._write_input(input_dir=scratch_dir)
-            with open(os.path.join(scratch_dir, self.input_file)) as packmol_input, Popen(
-                self.packmol_bin, stdin=packmol_input, stdout=PIPE, stderr=PIPE
-            ) as proc:
+            with (
+                open(os.path.join(scratch_dir, self.input_file)) as packmol_input,
+                Popen(self.packmol_bin, stdin=packmol_input, stdout=PIPE, stderr=PIPE) as proc,
+            ):
                 stdout, stderr = proc.communicate()
             output_file = self.control_params["output"]
             if os.path.isfile(output_file):

--- a/pymatgen/io/lmto.py
+++ b/pymatgen/io/lmto.py
@@ -4,7 +4,6 @@ LMTO-ASA code. It will primarily be used to generate a pymatgen
 Structure object in the pymatgen.electronic_structure.cohp.py module.
 """
 
-
 from __future__ import annotations
 
 import re

--- a/pymatgen/io/pwmat/__init__.py
+++ b/pymatgen/io/pwmat/__init__.py
@@ -1,4 +1,5 @@
 """This package implements modules for input and output to and from PWmat."""
+
 from __future__ import annotations
 
 from .inputs import AtomConfig

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -2711,7 +2711,9 @@ class VaspInput(dict, MSONable):
         if not vasp_cmd:
             raise RuntimeError("You need to supply vasp_cmd or set the PMG_VASP_EXE in .pmgrc.yaml to run VASP.")
 
-        with cd(run_dir), open(output_file, mode="w", encoding="utf-8") as stdout_file, open(
-            err_file, mode="w", encoding="utf-8", buffering=1
-        ) as stderr_file:
+        with (
+            cd(run_dir),
+            open(output_file, mode="w", encoding="utf-8") as stdout_file,
+            open(err_file, mode="w", encoding="utf-8", buffering=1) as stderr_file,
+        ):
             subprocess.check_call(vasp_cmd, stdout=stdout_file, stderr=stderr_file)

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -263,9 +263,6 @@ class Poscar(MSONable):
                     potcar = Potcar.from_file(sorted(potcars)[0])
                     names = [sym.split("_")[0] for sym in potcar.symbols]
                     [get_el_sp(n) for n in names]  # ensure valid names
-                    warnings.warn(
-                        "Cannot determine elements in POSCAR. Falling back to manual assignment.", BadPoscarWarning
-                    )
                 except Exception:
                     names = None
         with zopen(filename, mode="rt") as file:

--- a/pymatgen/symmetry/groups.py
+++ b/pymatgen/symmetry/groups.py
@@ -53,12 +53,10 @@ class SymmetryGroup(Sequence, Stringify, metaclass=ABCMeta):
         return len(self)
 
     @overload
-    def __getitem__(self, item: int) -> SymmOp:
-        ...
+    def __getitem__(self, item: int) -> SymmOp: ...
 
     @overload
-    def __getitem__(self, item: slice) -> Sequence[SymmOp]:
-        ...
+    def __getitem__(self, item: slice) -> Sequence[SymmOp]: ...
 
     def __getitem__(self, item: int | slice) -> SymmOp | Sequence[SymmOp]:
         return list(self.symmetry_ops)[item]

--- a/pymatgen/util/io_utils.py
+++ b/pymatgen/util/io_utils.py
@@ -1,6 +1,5 @@
 """This module provides utility classes for io operations."""
 
-
 from __future__ import annotations
 
 import os

--- a/tests/analysis/diffraction/__init__.py
+++ b/tests/analysis/diffraction/__init__.py
@@ -1,6 +1,5 @@
 """TODO: Modify module doc."""
 
-
 from __future__ import annotations
 
 __author__ = "Shyue Ping Ong"

--- a/tests/apps/borg/test_queen.py
+++ b/tests/apps/borg/test_queen.py
@@ -1,6 +1,5 @@
 """Created on Mar 18, 2012."""
 
-
 from __future__ import annotations
 
 import unittest

--- a/tests/command_line/test_bader_caller.py
+++ b/tests/command_line/test_bader_caller.py
@@ -133,7 +133,10 @@ class TestBaderAnalysis(PymatgenTest):
     def test_missing_file_bader_exe_path(self):
         pytest.skip("doesn't reliably raise RuntimeError")
         # mock which("bader") to return None so we always fall back to use bader_exe_path
-        with patch("shutil.which", return_value=None), pytest.raises(
-            RuntimeError, match="BaderAnalysis requires the executable bader be in the PATH or the full path "
+        with (
+            patch("shutil.which", return_value=None),
+            pytest.raises(
+                RuntimeError, match="BaderAnalysis requires the executable bader be in the PATH or the full path "
+            ),
         ):
             BaderAnalysis(chgcar_filename=f"{TEST_FILES_DIR}/CHGCAR.Fe3O4", bader_exe_path="")

--- a/tests/io/aims/test_sets/test_bs_generator.py
+++ b/tests/io/aims/test_sets/test_bs_generator.py
@@ -1,4 +1,5 @@
 """Tests the band structure input set generator"""
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/tests/io/aims/test_sets/test_gw_generator.py
+++ b/tests/io/aims/test_sets/test_gw_generator.py
@@ -1,4 +1,5 @@
 """Tests the GW input set generator"""
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/tests/io/aims/test_sets/test_static_restart_from_relax_generator.py
+++ b/tests/io/aims/test_sets/test_static_restart_from_relax_generator.py
@@ -1,4 +1,5 @@
 """The test of input sets generating from restart information"""
+
 from __future__ import annotations
 
 from pathlib import Path


### PR DESCRIPTION
A `BadPoscarWarning` was recently added to `pymatgen.io.vasp.inputs.Poscar` when the elements in the POSCAR are identified by the order of elements in the POTCAR file. Reading in the element names from POTCAR is valid VASP input, and it's [even permitted to omit the species names in POSCAR](https://www.vasp.at/wiki/index.php/POSCAR) because VASP reads them from POTCAR:
```This line lists the species of the present ions. The given order should match the order of species appearing in the POTCAR file. This line is optional, if omitted the species names are taken from the POTCAR file.```

This PR just removes the warning.