### PR TITLE
Fix RuntimeError triggered in CI of downstream packages

### DIFF
--- a/pymatgen/analysis/chemenv/coordination_environments/coordination_geometry_finder.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/coordination_geometry_finder.py
@@ -120,9 +120,9 @@ class AbstractGeometry:
                     if central_site is None:
                         raise ValueError("The centroid includes the central site but no central site is given")
                     total += self.bare_centre
-                    self.centre = total / (np.float_(len(bare_coords)) + 1.0)
+                    self.centre = total / (np.float64(len(bare_coords)) + 1.0)
                 else:
-                    self.centre = total / np.float_(len(bare_coords))
+                    self.centre = total / np.float64(len(bare_coords))
         elif centering_type == "central_site":
             if include_central_site_in_centroid:
                 raise ValueError(
@@ -138,9 +138,9 @@ class AbstractGeometry:
                 if central_site is None:
                     raise ValueError("The centroid includes the central site but no central site is given")
                 total += self.bare_centre
-                self.centre = total / (np.float_(len(bare_coords)) + 1.0)
+                self.centre = total / (np.float64(len(bare_coords)) + 1.0)
             else:
-                self.centre = total / np.float_(len(bare_coords))
+                self.centre = total / np.float64(len(bare_coords))
         self._bare_coords = self.bare_points_without_centre
         self._coords = self._bare_coords - self.centre
         self.central_site = self.bare_central_site - self.centre

--- a/pymatgen/analysis/chemenv/utils/coordination_geometry_utils.py
+++ b/pymatgen/analysis/chemenv/utils/coordination_geometry_utils.py
@@ -631,12 +631,12 @@ class Plane:
             raise ValueError("Normal vector is equal to 0.0")
         if self.normal_vector[non_zeros[0]] < 0.0:
             self.normal_vector = -self.normal_vector
-            dd = -np.float_(coefficients[3]) / norm_v
+            dd = -np.float64(coefficients[3]) / norm_v
         else:
-            dd = np.float_(coefficients[3]) / norm_v
+            dd = np.float64(coefficients[3]) / norm_v
         self._coefficients = np.array(
             [self.normal_vector[0], self.normal_vector[1], self.normal_vector[2], dd],
-            np.float_,
+            np.float64,
         )
         self._crosses_origin = np.isclose(dd, 0.0, atol=1e-7, rtol=0.0)
         self.p1 = p1

--- a/pymatgen/analysis/elasticity/elastic.py
+++ b/pymatgen/analysis/elasticity/elastic.py
@@ -1080,7 +1080,7 @@ def get_diff_coeff(hvec, n=1):
         hvec (1D array-like): sampling stencil
         n (int): degree of derivative to find
     """
-    hvec = np.array(hvec, dtype=np.float_)
+    hvec = np.array(hvec, dtype=np.float64)
     acc = len(hvec)
     exp = np.column_stack([np.arange(acc)] * acc)
     a = np.vstack([hvec] * acc) ** exp

--- a/pymatgen/analysis/ewald.py
+++ b/pymatgen/analysis/ewald.py
@@ -317,8 +317,8 @@ class EwaldSummation(MSONable):
         """
         n_sites = len(self._struct)
         prefactor = 2 * pi / self._vol
-        e_recip = np.zeros((n_sites, n_sites), dtype=np.float_)
-        forces = np.zeros((n_sites, 3), dtype=np.float_)
+        e_recip = np.zeros((n_sites, n_sites), dtype=np.float64)
+        forces = np.zeros((n_sites, 3), dtype=np.float64)
         coords = self._coords
         rcp_latt = self._struct.lattice.reciprocal_lattice
         recip_nn = rcp_latt.get_points_in_sphere([[0, 0, 0]], [0, 0, 0], self._gmax)
@@ -363,9 +363,9 @@ class EwaldSummation(MSONable):
         force_pf = 2 * self._sqrt_eta / sqrt(pi)
         coords = self._coords
         n_sites = len(self._struct)
-        e_real = np.empty((n_sites, n_sites), dtype=np.float_)
+        e_real = np.empty((n_sites, n_sites), dtype=np.float64)
 
-        forces = np.zeros((n_sites, 3), dtype=np.float_)
+        forces = np.zeros((n_sites, 3), dtype=np.float64)
 
         qs = np.array(self._oxi_states)
 

--- a/pymatgen/analysis/graphs.py
+++ b/pymatgen/analysis/graphs.py
@@ -654,8 +654,8 @@ class StructureGraph(MSONable):
             atoms = len(grp) - 1
             offset = len(self.structure) - atoms
 
-            for i in range(atoms):
-                grp_map[i] = i + offset
+            for idx in range(atoms):
+                grp_map[idx] = idx + offset
 
             return grp_map
 
@@ -1011,7 +1011,7 @@ class StructureGraph(MSONable):
 
             if anonymous:
                 mapping = {centre_sp: "A"}
-                available_letters = [chr(66 + i) for i in range(25)]
+                available_letters = [chr(66 + idx) for idx in range(25)]
                 for label in labels:
                     sp = label[1]
                     if sp not in mapping:
@@ -2164,8 +2164,8 @@ class MoleculeGraph(MSONable):
             atoms = len(grp) - 1
             offset = len(self.molecule) - atoms
 
-            for i in range(atoms):
-                grp_map[i] = i + offset
+            for idx in range(atoms):
+                grp_map[idx] = idx + offset
 
             return grp_map
 
@@ -2298,9 +2298,9 @@ class MoleculeGraph(MSONable):
                 sizes[neighbor[2]] = len(nx.descendants(disconnected, neighbor[2]))
 
             keep = max(sizes, key=lambda x: sizes[x])
-            for i in sizes:
-                if i != keep:
-                    to_remove.add(i)
+            for idx in sizes:
+                if idx != keep:
+                    to_remove.add(idx)
 
             self.remove_nodes(list(to_remove))
             self.substitute_group(

--- a/pymatgen/analysis/interface_reactions.py
+++ b/pymatgen/analysis/interface_reactions.py
@@ -155,30 +155,30 @@ class InterfacialReactivity(MSONable):
             react_kink = [self._get_reaction(x) for x in x_kink]
             num_atoms = [(x * self.comp1.num_atoms + (1 - x) * self.comp2.num_atoms) for x in x_kink]
             energy_per_rxt_formula = [
-                energy_kink[i]
-                * self._get_elem_amt_in_rxn(react_kink[i])
-                / num_atoms[i]
+                energy_kink[idx]
+                * self._get_elem_amt_in_rxn(react_kink[idx])
+                / num_atoms[idx]
                 * InterfacialReactivity.EV_TO_KJ_PER_MOL
-                for i in range(2)
+                for idx in range(2)
             ]
         else:
-            for i in reversed(critical_comp):
+            for idx in reversed(critical_comp):
                 # Gets mixing ratio x at kinks.
-                c = self.pd.pd_coords(i)
-                x = float(np.linalg.norm(c - c2_coord) / np.linalg.norm(c1_coord - c2_coord))
+                coords = self.pd.pd_coords(idx)
+                mixing_ratio = float(np.linalg.norm(coords - c2_coord) / np.linalg.norm(c1_coord - c2_coord))
                 # Modifies mixing ratio in case compositions self.comp1 and
                 # self.comp2 are not normalized.
-                x = x * n2 / (n1 + x * (n2 - n1))
-                n_atoms = x * self.comp1.num_atoms + (1 - x) * self.comp2.num_atoms
+                mixing_ratio = mixing_ratio * n2 / (n1 + mixing_ratio * (n2 - n1))
+                n_atoms = mixing_ratio * self.comp1.num_atoms + (1 - mixing_ratio) * self.comp2.num_atoms
                 # Converts mixing ratio in comp1 - comp2 tie line to that in
                 # c1 - c2 tie line.
-                x_converted = self._convert(x, self.factor1, self.factor2)
+                x_converted = self._convert(mixing_ratio, self.factor1, self.factor2)
                 x_kink.append(x_converted)
                 # Gets reaction energy at kinks
-                normalized_energy = self._get_energy(x)
+                normalized_energy = self._get_energy(mixing_ratio)
                 energy_kink.append(normalized_energy)
                 # Gets balanced reaction at kinks
-                rxt = self._get_reaction(x)
+                rxt = self._get_reaction(mixing_ratio)
                 react_kink.append(rxt)
                 rxt_energy = normalized_energy * self._get_elem_amt_in_rxn(rxt) / n_atoms
                 energy_per_rxt_formula.append(rxt_energy * self.EV_TO_KJ_PER_MOL)

--- a/pymatgen/analysis/molecule_matcher.py
+++ b/pymatgen/analysis/molecule_matcher.py
@@ -154,8 +154,8 @@ class IsomorphismMolAtomMapper(AbstractMolAtomMapper):
             if elements1 != elements2:
                 continue
             vmol2 = openbabel.OBMol()
-            for i in label2:
-                vmol2.AddAtom(ob_mol2.GetAtom(i))
+            for idx in label2:
+                vmol2.AddAtom(ob_mol2.GetAtom(idx))
             aligner.SetTargetMol(vmol2)
             aligner.Align()
             rmsd = aligner.GetRMSD()
@@ -255,11 +255,11 @@ class InchiMolAtomMapper(AbstractMolAtomMapper):
         inchi = match.group("inchi")
         label_text = match.group("labels")
         eq_atom_text = match.group("eq_atoms")
-        heavy_atom_labels = tuple(int(i) for i in label_text.replace(";", ",").split(","))
+        heavy_atom_labels = tuple(int(idx) for idx in label_text.replace(";", ",").split(","))
         eq_atoms = []
         if eq_atom_text is not None:
             eq_tokens = re.findall(r"\(((?:[0-9]+,)+[0-9]+)\)", eq_atom_text.replace(";", ","))
-            eq_atoms = tuple(tuple(int(i) for i in t.split(",")) for t in eq_tokens)
+            eq_atoms = tuple(tuple(int(idx) for idx in t.split(",")) for t in eq_tokens)
         return heavy_atom_labels, eq_atoms, inchi
 
     @staticmethod
@@ -275,8 +275,8 @@ class InchiMolAtomMapper(AbstractMolAtomMapper):
             Centroid. Tuple (x, y, z)
         """
         c1x, c1y, c1z = 0.0, 0.0, 0.0
-        for i in group_atoms:
-            orig_idx = ilabels[i - 1]
+        for idx in group_atoms:
+            orig_idx = ilabels[idx - 1]
             oa1 = mol.GetAtom(orig_idx)
             c1x += float(oa1.x())
             c1y += float(oa1.y())
@@ -309,8 +309,8 @@ class InchiMolAtomMapper(AbstractMolAtomMapper):
         unique_atom_labels = sorted(all_atoms - non_unique_atoms)
 
         # try to align molecules using unique atoms
-        for i in unique_atom_labels:
-            orig_idx = ilabels[i - 1]
+        for idx in unique_atom_labels:
+            orig_idx = ilabels[idx - 1]
             oa1 = mol.GetAtom(orig_idx)
             a1 = vmol.NewAtom()
             a1.SetAtomicNum(oa1.GetAtomicNum())
@@ -321,8 +321,8 @@ class InchiMolAtomMapper(AbstractMolAtomMapper):
             for symm in eq_atoms:
                 c1x, c1y, c1z = self._group_centroid(mol, ilabels, symm)
                 min_distance = float("inf")
-                for i in range(1, vmol.NumAtoms() + 1):
-                    va = vmol.GetAtom(i)
+                for idx in range(1, vmol.NumAtoms() + 1):
+                    va = vmol.GetAtom(idx)
                     distance = math.sqrt((c1x - va.x()) ** 2 + (c1y - va.y()) ** 2 + (c1z - va.z()) ** 2)
                     if distance < min_distance:
                         min_distance = distance
@@ -434,14 +434,14 @@ class InchiMolAtomMapper(AbstractMolAtomMapper):
         label2 = heavy_indices2 + tuple(hydrogen_atoms2)
 
         cmol1 = openbabel.OBMol()
-        for i in label1:
-            oa1 = mol1.GetAtom(i)
+        for idx in label1:
+            oa1 = mol1.GetAtom(idx)
             a1 = cmol1.NewAtom()
             a1.SetAtomicNum(oa1.GetAtomicNum())
             a1.SetVector(oa1.GetVector())
         cmol2 = openbabel.OBMol()
-        for i in label2:
-            oa2 = mol2.GetAtom(i)
+        for idx in label2:
+            oa2 = mol2.GetAtom(idx)
             a2 = cmol2.NewAtom()
             a2.SetAtomicNum(oa2.GetAtomicNum())
             a2.SetVector(oa2.GetVector())
@@ -489,7 +489,7 @@ class InchiMolAtomMapper(AbstractMolAtomMapper):
         Returns:
             Elements. List of integers.
         """
-        return [int(mol.GetAtom(i).GetAtomicNum()) for i in label]
+        return [int(mol.GetAtom(idx).GetAtomicNum()) for idx in label]
 
     def _is_molecule_linear(self, mol):
         """
@@ -505,8 +505,8 @@ class InchiMolAtomMapper(AbstractMolAtomMapper):
             return True
         a1 = mol.GetAtom(1)
         a2 = mol.GetAtom(2)
-        for i in range(3, mol.NumAtoms() + 1):
-            angle = float(mol.GetAtom(i).GetAngle(a2, a1))
+        for idx in range(3, mol.NumAtoms() + 1):
+            angle = float(mol.GetAtom(idx).GetAngle(a2, a1))
             if angle < 0.0:
                 angle = -angle
             if angle > 90.0:
@@ -633,14 +633,14 @@ class MoleculeMatcher(MSONable):
         ob_mol2 = BabelMolAdaptor(mol2).openbabel_mol
 
         cmol1 = openbabel.OBMol()
-        for i in clabel1:
-            oa1 = ob_mol1.GetAtom(i)
+        for idx in clabel1:
+            oa1 = ob_mol1.GetAtom(idx)
             a1 = cmol1.NewAtom()
             a1.SetAtomicNum(oa1.GetAtomicNum())
             a1.SetVector(oa1.GetVector())
         cmol2 = openbabel.OBMol()
-        for i in clabel2:
-            oa2 = ob_mol2.GetAtom(i)
+        for idx in clabel2:
+            oa2 = ob_mol2.GetAtom(idx)
             a2 = cmol2.NewAtom()
             a2.SetAtomicNum(oa2.GetAtomicNum())
             a2.SetVector(oa2.GetVector())
@@ -691,7 +691,7 @@ class MoleculeMatcher(MSONable):
                 group_indices.append(sorted(current_group))
 
         group_indices.sort(key=lambda x: (len(x), -x[0]), reverse=True)
-        return [[mol_list[i] for i in g] for g in group_indices]
+        return [[mol_list[idx] for idx in g] for g in group_indices]
 
     def as_dict(self):
         """
@@ -925,7 +925,7 @@ class BruteForceOrderMatcher(KabschMatcher):
         """
         inds, U, V, rmsd = self.match(p, ignore_warning=ignore_warning)
 
-        p_prime = Molecule.from_sites([p[i] for i in inds])
+        p_prime = Molecule.from_sites([p[idx] for idx in inds])
         for site in p_prime:
             site.coords = np.dot(site.coords, U) + V
 
@@ -1016,7 +1016,7 @@ class HungarianOrderMatcher(KabschMatcher):
         inds, U, V, rmsd = self.match(p)
 
         # Translate and rotate `mol1` unto `mol2` using Kabsch algorithm.
-        p_prime = Molecule.from_sites([p[i] for i in inds])
+        p_prime = Molecule.from_sites([p[idx] for idx in inds])
         for site in p_prime:
             site.coords = np.dot(site.coords, U) + V
 
@@ -1025,7 +1025,7 @@ class HungarianOrderMatcher(KabschMatcher):
     @staticmethod
     def permutations(p_atoms, p_centroid, p_weights, q_atoms, q_centroid, q_weights):
         """Generates two possible permutations of atom order. This method uses the principle component
-        of the inertia tensor to prealign the molecules and hungarian method to determine the order.
+        of the inertia tensor to pre-align the molecules and hungarian method to determine the order.
         There are always two possible permutation depending on the way to pre-aligning the molecules.
 
         Args:
@@ -1204,7 +1204,7 @@ class GeneticOrderMatcher(KabschMatcher):
         out = []
         for inds in self.permutations(p):
             p_prime = p.copy()
-            p_prime._sites = [p_prime[i] for i in inds]
+            p_prime._sites = [p_prime[idx] for idx in inds]
 
             U, V, rmsd = super().match(p_prime)
 
@@ -1220,14 +1220,14 @@ class GeneticOrderMatcher(KabschMatcher):
             p: a `Molecule` object what will be matched with the target one.
 
         Returns:
-            Array of the possible matches where the elements are:
+            list[tuple[Molecule, float]]: possible matches where the elements are:
                 p_prime: Rotated and translated of the `p` `Molecule` object
                 rmsd: Root-mean-square-deviation between `p_prime` and the `target`
         """
-        out = []
+        out: list[tuple[Molecule, float]] = []
         for inds in self.permutations(p):
             p_prime = p.copy()
-            p_prime._sites = [p_prime[i] for i in inds]
+            p_prime._sites = [p_prime[idx] for idx in inds]
 
             U, V, rmsd = super().match(p_prime)
 
@@ -1236,7 +1236,7 @@ class GeneticOrderMatcher(KabschMatcher):
             for site in p_prime:
                 site.coords = np.dot(site.coords, U) + V
 
-            out.append((p_prime, rmsd))
+            out += [(p_prime, rmsd)]
 
         return out
 

--- a/pymatgen/analysis/molecule_structure_comparator.py
+++ b/pymatgen/analysis/molecule_structure_comparator.py
@@ -216,7 +216,7 @@ class MoleculeStructureComparator(MSONable):
         num_atoms = len(mol)
         # index starting from 0
         if self.ignore_ionic_bond:
-            covalent_atoms = [i for i in range(num_atoms) if mol.species[i].symbol not in self.ionic_element_list]
+            covalent_atoms = [idx for idx in range(num_atoms) if mol.species[idx].symbol not in self.ionic_element_list]
         else:
             covalent_atoms = list(range(num_atoms))
         all_pairs = list(itertools.combinations(covalent_atoms, 2))

--- a/pymatgen/command_line/bader_caller.py
+++ b/pymatgen/command_line/bader_caller.py
@@ -203,7 +203,11 @@ class BaderAnalysis:
     )
     def _parse_atomic_densities(self):
         # Deprecation tracker
-        if datetime(2025, 2, 26) < datetime.now() and "CI" in os.environ:
+        if (
+            datetime(2025, 2, 26) < datetime.now()
+            and os.getenv("CI")
+            and os.getenv("GITHUB_REPOSITORY") == "materialsproject/pymatgen"
+        ):
             raise RuntimeError("This method should have been removed, see #3656.")
 
         def slice_from_center(data, x_width, y_width, z_width):

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -1131,7 +1131,7 @@ class IStructure(SiteCollection, MSONable):
             raise ValueError(f"Supplied species and coords lengths ({len(species)} vs {len(coords)}) are different!")
 
         frac_coords = (
-            np.array(coords, dtype=np.float_) if not coords_are_cartesian else latt.get_fractional_coords(coords)
+            np.array(coords, dtype=np.float64) if not coords_are_cartesian else latt.get_fractional_coords(coords)
         )
 
         props = {} if site_properties is None else site_properties
@@ -1754,7 +1754,7 @@ class IStructure(SiteCollection, MSONable):
         # expand the output tuple by symmetry_indices and symmetry_ops.
         n_bonds = len(bonds[0])
         symmetry_indices = np.empty(n_bonds)
-        symmetry_indices[:] = np.NaN
+        symmetry_indices[:] = np.nan
         symmetry_ops = np.empty(len(symmetry_indices), dtype=object)
         symmetry_identity = SymmOp.from_rotation_and_translation(np.eye(3), np.zeros(3))
         symmetry_index = 0

--- a/pymatgen/entries/computed_entries.py
+++ b/pymatgen/entries/computed_entries.py
@@ -416,7 +416,7 @@ class ComputedEntry(Entry):
     def __repr__(self) -> str:
         n_atoms = self.composition.num_atoms
         output = [
-            f"{self.entry_id} {type(self).__name__:<10} " f"- {self.formula:<12} ({self.reduced_formula})",
+            f"{self.entry_id} {type(self).__name__:<10} - {self.formula:<12} ({self.reduced_formula})",
             f"{'Energy (Uncorrected)':<24} = {self._energy:<9.4f} eV ({self._energy / n_atoms:<8.4f} eV/atom)",
             f"{'Correction':<24} = {self.correction:<9.4f} eV ({self.correction / n_atoms:<8.4f} eV/atom)",
             f"{'Energy (Final)':<24} = {self.energy:<9.4f} eV ({self.energy_per_atom:<8.4f} eV/atom)",

--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -16,6 +16,7 @@ from itertools import groupby
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
+import monty
 import numpy as np
 from monty.io import zopen
 from monty.serialization import loadfn
@@ -1136,7 +1137,7 @@ class CifParser:
             return struct
         return None
 
-    @np.deprecate(
+    @monty.dev.deprecate(
         message="get_structures is deprecated and will be removed in 2024. Use parse_structures instead."
         "The only difference is that primitive defaults to False in the new parse_structures method."
         "So parse_structures(primitive=True) is equivalent to the old behavior of get_structures().",

--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -16,8 +16,8 @@ from itertools import groupby
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
-import monty
 import numpy as np
+from monty.dev import deprecated
 from monty.io import zopen
 from monty.serialization import loadfn
 
@@ -1137,7 +1137,7 @@ class CifParser:
             return struct
         return None
 
-    @monty.dev.deprecate(
+    @deprecated(
         message="get_structures is deprecated and will be removed in 2024. Use parse_structures instead."
         "The only difference is that primitive defaults to False in the new parse_structures method."
         "So parse_structures(primitive=True) is equivalent to the old behavior of get_structures().",

--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -34,11 +34,11 @@ if TYPE_CHECKING:
 
 __author__ = "Shyue Ping Ong, Will Richards, Matthew Horton"
 
-sub_spgrp = partial(re.sub, r"[\s_]", "")
+sub_space_group = partial(re.sub, r"[\s_]", "")
 
-space_groups = {sub_spgrp(key): key for key in SYMM_DATA["space_group_encoding"]}  # type: ignore
+space_groups = {sub_space_group(key): key for key in SYMM_DATA["space_group_encoding"]}  # type: ignore
 
-space_groups.update({sub_spgrp(key): key for key in SYMM_DATA["space_group_encoding"]})  # type: ignore
+space_groups.update({sub_space_group(key): key for key in SYMM_DATA["space_group_encoding"]})  # type: ignore
 
 
 class CifBlock:
@@ -711,7 +711,7 @@ class CifParser:
                 msg_template = "No _symmetry_equiv_pos_as_xyz type key found. Spacegroup from {} used."
 
                 if sg:
-                    sg = sub_spgrp(sg)
+                    sg = sub_space_group(sg)
                     try:
                         spg = space_groups.get(sg)
                         if spg:
@@ -1184,8 +1184,8 @@ class CifParser:
         Returns:
             list[Structure]: All structures in CIF file.
         """
-        if os.getenv("CI") and datetime.now() > datetime(2024, 3, 1):  # March 2024 seems long enough # pragma: no cover
-            raise RuntimeError("remove the change of default primitive=True to False made on 2023-10-24")
+        if os.getenv("CI") and datetime.now() > datetime(2024, 10, 1):  # pragma: no cover
+            raise RuntimeError("remove the warning about changing default primitive=True to False on 2023-10-24")
         if primitive is None:
             primitive = False
             warnings.warn(

--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -1184,7 +1184,11 @@ class CifParser:
         Returns:
             list[Structure]: All structures in CIF file.
         """
-        if os.getenv("CI") and datetime.now() > datetime(2024, 10, 1):  # pragma: no cover
+        if (
+            os.getenv("CI")
+            and os.getenv("GITHUB_REPOSITORY") == "materialsproject/pymatgen"
+            and datetime.now() > datetime(2024, 10, 1)
+        ):  # pragma: no cover
             raise RuntimeError("remove the warning about changing default primitive=True to False on 2023-10-24")
         if primitive is None:
             primitive = False

--- a/pymatgen/io/cp2k/utils.py
+++ b/pymatgen/io/cp2k/utils.py
@@ -46,7 +46,7 @@ def postprocessor(data: str) -> str | float | bool | None:
         except ValueError as exc:
             raise ValueError(f"Error parsing {data!r} as float in CP2K file.") from exc
     if re.match(r"\*+", data):
-        return np.NaN
+        return np.nan
     return data
 
 

--- a/pymatgen/io/lobster/outputs.py
+++ b/pymatgen/io/lobster/outputs.py
@@ -1003,9 +1003,9 @@ class Lobsterout(MSONable):
             splitrow = row.split()
             if len(splitrow) > 2 and splitrow[2] == "spilling:":
                 if splitrow[1] == "charge":
-                    charge_spilling.append(np.float_(splitrow[3].replace("%", "")) / 100.0)
+                    charge_spilling.append(np.float64(splitrow[3].replace("%", "")) / 100.0)
                 if splitrow[1] == "total":
-                    total_spilling.append(np.float_(splitrow[3].replace("%", "")) / 100.0)
+                    total_spilling.append(np.float64(splitrow[3].replace("%", "")) / 100.0)
 
             if len(charge_spilling) == number_of_spins and len(total_spilling) == number_of_spins:
                 break

--- a/pymatgen/io/vasp/optics.py
+++ b/pymatgen/io/vasp/optics.py
@@ -388,7 +388,7 @@ def epsilon_imag(
         min_band1, max_band1 = np.min(np.where(cderm)[1]), np.max(np.where(cderm)[1])
     except ValueError as exc:
         if "zero-size array" in str(exc):
-            return egrid, np.zeros_like(egrid, dtype=np.complex_)
+            return egrid, np.zeros_like(egrid, dtype=np.complex128)
         raise exc
     _, _, nk, nspin = cderm.shape[:4]
     iter_idx = [

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -3792,7 +3792,7 @@ class Procar:
                     phase_factors = defaultdict(
                         lambda: np.full(
                             (n_kpoints, n_bands, n_ions, len(headers)),
-                            np.NaN,
+                            np.nan,
                             dtype=np.complex128,
                         )
                     )
@@ -4731,7 +4731,7 @@ class Wavecar:
         else:
             tcoeffs = self.coeffs[kpoint][band]
 
-        mesh = np.zeros(tuple(self.ng), dtype=np.complex_)
+        mesh = np.zeros(tuple(self.ng), dtype=np.complex128)
         for gp, coeff in zip(self.Gpoints[kpoint], tcoeffs):
             t = tuple(gp.astype(int) + (self.ng / 2).astype(int))
             mesh[t] = coeff
@@ -5081,8 +5081,8 @@ class Waveder(MSONable):
                 return np.frombuffer(data, dtype=dtype)
 
             nbands, nelect, nk, ispin = read_data(np.int32)
-            _ = read_data(np.float_)  # nodes_in_dielectric_function
-            _ = read_data(np.float_)  # wplasmon
+            _ = read_data(np.float64)  # nodes_in_dielectric_function
+            _ = read_data(np.float64)  # wplasmon
             me_datatype = np.dtype(data_type)
             cder = read_data(me_datatype)
 

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -1814,9 +1814,8 @@ class MPSOCSet(DictSet):
             and not isinstance(self.structure[0].magmom, list)
         ):
             raise ValueError(
-                "The structure must have the 'magmom' site "
-                "property and each magnetic moment value must have 3 "
-                "components. eg:- magmom = [0,0,2]"
+                "The structure must have the 'magmom' site property and each magnetic "
+                "moment value must have 3 components. e.g. magmom = [0,0,2]"
             )
 
     @property
@@ -1866,6 +1865,7 @@ class MPSOCSet(DictSet):
             # magmom has to be 3D for SOC calculation.
             if hasattr(structure[0], "magmom"):
                 if not isinstance(structure[0].magmom, list):
+                    # project magmom to z-axis
                     structure = structure.copy(site_properties={"magmom": [[0, 0, site.magmom] for site in structure]})
             else:
                 raise ValueError("Neither the previous structure has magmom property nor magmom provided")
@@ -2755,7 +2755,7 @@ def get_vasprun_outcar(path: str | Path, parse_dos: bool = True, parse_eigen: bo
     )
 
 
-def get_structure_from_prev_run(vasprun, outcar=None):
+def get_structure_from_prev_run(vasprun, outcar=None) -> Structure:
     """
     Process structure from previous run.
 
@@ -2764,8 +2764,8 @@ def get_structure_from_prev_run(vasprun, outcar=None):
         outcar (Outcar): Outcar that contains the magnetization info from previous run.
 
     Returns:
-        The magmom-decorated structure that can be passed to get VASP input files, e.g.
-        get_kpoints.
+        Structure: The magmom-decorated structure that can be passed to get VASP input files, e.g.
+            get_kpoints().
     """
     structure = vasprun.final_structure
 
@@ -2776,7 +2776,7 @@ def get_structure_from_prev_run(vasprun, outcar=None):
             site_properties["magmom"] = [i["tot"] for i in outcar.magnetization]
         else:
             site_properties["magmom"] = vasprun.parameters["MAGMOM"]
-    # ldau
+    # LDAU
     if vasprun.parameters.get("LDAU", False):
         for k in ("LDAUU", "LDAUJ", "LDAUL"):
             vals = vasprun.incar[k]

--- a/pymatgen/symmetry/analyzer.py
+++ b/pymatgen/symmetry/analyzer.py
@@ -459,17 +459,17 @@ class SpacegroupAnalyzer:
             if abs(lengths[0] - lengths[2]) < 0.0001:
                 transf = np.eye
             else:
-                transf = np.array([[-1, 1, 1], [2, 1, 1], [-1, -2, 1]], dtype=np.float_) / 3
+                transf = np.array([[-1, 1, 1], [2, 1, 1], [-1, -2, 1]], dtype=np.float64) / 3
 
         elif "I" in self.get_space_group_symbol():
-            transf = np.array([[-1, 1, 1], [1, -1, 1], [1, 1, -1]], dtype=np.float_) / 2
+            transf = np.array([[-1, 1, 1], [1, -1, 1], [1, 1, -1]], dtype=np.float64) / 2
         elif "F" in self.get_space_group_symbol():
-            transf = np.array([[0, 1, 1], [1, 0, 1], [1, 1, 0]], dtype=np.float_) / 2
+            transf = np.array([[0, 1, 1], [1, 0, 1], [1, 1, 0]], dtype=np.float64) / 2
         elif "C" in self.get_space_group_symbol() or "A" in self.get_space_group_symbol():
             if self.get_crystal_system() == "monoclinic":
-                transf = np.array([[1, 1, 0], [-1, 1, 0], [0, 0, 2]], dtype=np.float_) / 2
+                transf = np.array([[1, 1, 0], [-1, 1, 0], [0, 0, 2]], dtype=np.float64) / 2
             else:
-                transf = np.array([[1, -1, 0], [1, 1, 0], [0, 0, 2]], dtype=np.float_) / 2
+                transf = np.array([[1, -1, 0], [1, 1, 0], [0, 0, 2]], dtype=np.float64) / 2
         else:
             transf = np.eye(3)
 

--- a/pymatgen/transformations/advanced_transformations.py
+++ b/pymatgen/transformations/advanced_transformations.py
@@ -1518,8 +1518,8 @@ class CubicSupercellTransformation(AbstractTransformation):
                 please use max_atoms
             angle_tolerance: tolerance to determine the 90 degree angles.
         """
-        self.min_atoms = min_atoms or -np.Inf
-        self.max_atoms = max_atoms or np.Inf
+        self.min_atoms = min_atoms or -np.inf
+        self.max_atoms = max_atoms or np.inf
         self.min_length = min_length
         self.force_diagonal = force_diagonal
         self.force_90_degrees = force_90_degrees

--- a/pymatgen/vis/structure_vtk.py
+++ b/pymatgen/vis/structure_vtk.py
@@ -601,7 +601,7 @@ class StructureVis:
                 center = np.zeros(3, float)
                 for site in face:
                     center += site
-                center /= np.float_(len(face))
+                center /= np.float64(len(face))
                 for ii, f in enumerate(face):
                     points = vtk.vtkPoints()
                     triangle = vtk.vtkTriangle()

--- a/tests/analysis/test_interface_reactions.py
+++ b/tests/analysis/test_interface_reactions.py
@@ -7,7 +7,7 @@ import pytest
 from matplotlib.figure import Figure as mpl_figure
 from numpy.testing import assert_allclose
 from pandas import DataFrame
-from plotly.graph_objects import Figure as plotly_figure
+from plotly.graph_objects import Figure
 from scipy.spatial import ConvexHull
 
 from pymatgen.analysis.interface_reactions import GrandPotentialInterfacialReactivity, InterfacialReactivity
@@ -391,7 +391,7 @@ class TestInterfaceReaction(unittest.TestCase):
             assert fig, isinstance(fig, mpl_figure)
 
             fig = ir.plot(backend="plotly")
-            assert isinstance(fig, plotly_figure)
+            assert isinstance(fig, Figure)
 
     def test_get_dataframe(self):
         for ir in self.irs:
@@ -415,14 +415,8 @@ class TestInterfaceReaction(unittest.TestCase):
             (0.3333333, -3.333333),
             (0.3333333, -4.0),
         ]
-        for i, j in zip(self.irs, answer):
-            (
-                assert_allclose(i.minimum, j, atol=1e-7),
-                (
-                    f"minimum: the system with {i.c1_original.reduced_formula} and {i.c2_original.reduced_formula} "
-                    f"gets error!{j} expected, but gets {i.minimum}"
-                ),
-            )
+        for inter_react, expected in zip(self.irs, answer):
+            assert_allclose(inter_react.minimum, expected, atol=1e-7)
 
     def test_get_no_mixing_energy(self):
         answer = [

--- a/tests/command_line/test_bader_caller.py
+++ b/tests/command_line/test_bader_caller.py
@@ -48,8 +48,8 @@ class TestBaderAnalysis(PymatgenTest):
             1.021523,
             1.024357,
         ]
-        for i in range(14):
-            assert ans[i] == approx(analysis.get_charge_transfer(i), abs=1e-3)
+        for idx in range(14):
+            assert ans[idx] == approx(analysis.get_charge_transfer(idx), abs=1e-3)
         assert analysis.get_partial_charge(0) == -analysis.get_charge_transfer(0)
         struct = analysis.get_oxidation_state_decorated_structure()
         assert struct[0].specie.oxi_state == approx(1.3863218, abs=1e-3)

--- a/tests/io/vasp/test_outputs.py
+++ b/tests/io/vasp/test_outputs.py
@@ -1767,13 +1767,13 @@ class TestWavecar(PymatgenTest):
         assert len(w.coeffs[0][0]) == w.nb
         assert len(w.band_energy[0]) == w.nk
 
-        temp_ggp = Wavecar._generate_G_points
+        orig_gen_g_points = Wavecar._generate_G_points
         try:
-            Wavecar._generate_G_points = lambda _x, _y, _gamma: []
+            Wavecar._generate_G_points = lambda _x, _y, gamma: []
             with pytest.raises(ValueError, match=r"not enough values to unpack \(expected 3, got 0\)"):
                 Wavecar(f"{TEST_FILES_DIR}/WAVECAR.N2")
         finally:
-            Wavecar._generate_G_points = temp_ggp
+            Wavecar._generate_G_points = orig_gen_g_points
 
     def test_generate_nbmax(self):
         self.wavecar._generate_nbmax()

--- a/tests/io/vasp/test_outputs.py
+++ b/tests/io/vasp/test_outputs.py
@@ -1769,7 +1769,7 @@ class TestWavecar(PymatgenTest):
 
         temp_ggp = Wavecar._generate_G_points
         try:
-            Wavecar._generate_G_points = lambda x, y, gamma: []
+            Wavecar._generate_G_points = lambda _x, _y, _gamma: []
             with pytest.raises(ValueError, match=r"not enough values to unpack \(expected 3, got 0\)"):
                 Wavecar(f"{TEST_FILES_DIR}/WAVECAR.N2")
         finally:


### PR DESCRIPTION
we have a major problem with how deprecation removal reminders are currently setup for CI causing other package CI runs to fail. [in this case with](https://github.com/CederGroupHub/chgnet/actions/runs/8105153971/job/22153023416)

```py
E   RuntimeError: remove the change of default primitive=True to False made on 2023-10-24
```

this will affect any package using `pymatgen` in CI.

this PR solves the issue in two places `CifParser.parse_structures()` and `BaderAnalysis._parse_atomic_densities()`.
i'll make a hot-fix release right after this is merged. thanks @BowenD-UCB for reporting!

this poorly written code was added by me in https://github.com/materialsproject/pymatgen/commit/9e27ca89b01de23c0088b3d631f85f489a4a5fb7 and released in  [v2023.11.10](https://github.com/materialsproject/pymatgen/releases/tag/v2023.11.10). given this affects all intermediate releases, it's probably too much to yank them all from PyPI:

- [v2023.11.12](https://github.com/materialsproject/pymatgen/releases/tag/v2023.11.12)
- [v2023.12.18](https://github.com/materialsproject/pymatgen/releases/tag/v2023.12.18)
- [v2024.1.26](https://github.com/materialsproject/pymatgen/releases/tag/v2024.1.26)
- [v2024.1.27](https://github.com/materialsproject/pymatgen/releases/tag/v2024.1.27)
- [v2024.2.1](https://github.com/materialsproject/pymatgen/releases/tag/v2024.2.1)
- [v2024.2.20](https://github.com/materialsproject/pymatgen/releases/tag/v2024.2.20)
- [v2024.2.23](https://github.com/materialsproject/pymatgen/releases/tag/v2024.2.23) 
- [v2024.2.8](https://github.com/materialsproject/pymatgen/releases/tag/v2024.2.8)

luckily, the error will only show up in CI runs, not in user-facing code.