### PR TITLE
Ensure `MSONAtoms` is indeed `MSONable` when `Atoms.info` is loaded with goodies

### DIFF
--- a/pymatgen/io/ase.py
+++ b/pymatgen/io/ase.py
@@ -55,7 +55,7 @@ class MSONAtoms(Atoms, MSONable):
         # to be used in a round-trip fashion and does not work properly with constraints.
         # See ASE issue #1387.
         atoms_no_info = atoms.copy()
-        atoms_no_info.info: dict = {}
+        atoms_no_info.info = {}
         return {
             "@module": "pymatgen.io.ase",
             "@class": "MSONAtoms",

--- a/pymatgen/io/ase.py
+++ b/pymatgen/io/ase.py
@@ -54,13 +54,13 @@ class MSONAtoms(Atoms, MSONable):
         # @class key-value pairs inserted. However, atoms.todict()/atoms.fromdict() is not meant
         # to be used in a round-trip fashion and does not work properly with constraints.
         # See ASE issue #1387.
-        atoms_info = atoms.info.copy()
-        atoms.info: dict = {}
+        atoms_no_info = atoms.copy()
+        atoms_no_info.info: dict = {}
         return {
             "@module": "pymatgen.io.ase",
             "@class": "MSONAtoms",
-            "atoms_json": encode(atoms),
-            "atoms_info": jsanitize(atoms_info, strict=True),
+            "atoms_json": encode(atoms_no_info),
+            "atoms_info": jsanitize(atoms.info, strict=True),
         }
 
     def from_dict(dct: dict[str, Any]) -> MSONAtoms:

--- a/pymatgen/io/ase.py
+++ b/pymatgen/io/ase.py
@@ -55,7 +55,7 @@ class MSONAtoms(Atoms, MSONable):
         # to be used in a round-trip fashion and does not work properly with constraints.
         # See ASE issue #1387.
         atoms_info = atoms.info.copy()
-        atoms.info = {}
+        atoms.info: dict = {}
         return {
             "@module": "pymatgen.io.ase",
             "@class": "MSONAtoms",

--- a/pymatgen/io/ase.py
+++ b/pymatgen/io/ase.py
@@ -4,13 +4,14 @@ Atoms object and pymatgen Structure objects.
 """
 
 from __future__ import annotations
+
 import warnings
 from collections.abc import Iterable
 from importlib.metadata import PackageNotFoundError
 from typing import TYPE_CHECKING
 
 import numpy as np
-from monty.json import MSONable, jsanitize, MontyDecoder
+from monty.json import MontyDecoder, MSONable, jsanitize
 
 from pymatgen.core.structure import Molecule, Structure
 
@@ -55,7 +56,12 @@ class MSONAtoms(Atoms, MSONable):
         # See ASE issue #1387.
         atoms_info = atoms.info.copy()
         atoms.info = {}
-        return {"@module": "pymatgen.io.ase", "@class": "MSONAtoms", "atoms_json": encode(atoms), "atoms_info": jsanitize(atoms_info, strict=True)}
+        return {
+            "@module": "pymatgen.io.ase",
+            "@class": "MSONAtoms",
+            "atoms_json": encode(atoms),
+            "atoms_info": jsanitize(atoms_info, strict=True),
+        }
 
     def from_dict(dct: dict[str, Any]) -> MSONAtoms:
         # Normally, we would want to this to be a wrapper around atoms.fromdict() with @module and
@@ -66,6 +72,7 @@ class MSONAtoms(Atoms, MSONable):
         atoms_info = MontyDecoder().process_decoded(dct["atoms_info"])
         mson_atoms.info = atoms_info
         return mson_atoms
+
 
 # NOTE: If making notable changes to this class, please ping @Andrew-S-Rosen on GitHub.
 # There are some subtleties in here, particularly related to spins/charges.

--- a/tests/io/test_ase.py
+++ b/tests/io/test_ase.py
@@ -316,6 +316,8 @@ def test_back_forth_v4():
 
 @skip_if_no_ase
 def test_msonable_atoms():
+    structure = Structure.from_file(f"{TEST_FILES_DIR}/POSCAR")
+
     atoms = ase.io.read(f"{TEST_FILES_DIR}/OUTCAR")
     atoms_info = {"test": "hi", "structure": structure}
     atoms.info = atoms_info
@@ -327,19 +329,12 @@ def test_msonable_atoms():
     msonable_atoms = MSONAtoms(atoms)
     assert atoms == msonable_atoms
 
-    ref = {
-        "@module": "pymatgen.io.ase",
-        "@class": "MSONAtoms",
-        "atoms_json": ase.io.jsonio.encode(ref_atoms),
-        "atoms_info": atoms_info,
-    }
-    assert msonable_atoms.as_dict() == ref
+    msonable_atoms_dict = msonable_atoms.as_dict()
+    assert msonable_atoms_dict == {"@module": "pymatgen.io.ase", "@class": "MSONAtoms", "atoms_json": ase.io.jsonio.encode(ref_atoms), "atoms_info": jsanitize(atoms_info, strict=True)}
 
-    atoms_back = MSONAtoms.from_dict(ref)
+    atoms_back = MSONAtoms.from_dict(msonable_atoms_dict)
     assert atoms_back == atoms
     assert atoms_back.info == atoms.info
-
-    structure = Structure.from_file(f"{TEST_FILES_DIR}/POSCAR")
 
     atoms = AseAtomsAdaptor.get_atoms(structure, msonable=True)
     assert callable(atoms.as_dict)

--- a/tests/io/test_ase.py
+++ b/tests/io/test_ase.py
@@ -317,12 +317,22 @@ def test_back_forth_v4():
 @skip_if_no_ase
 def test_msonable_atoms():
     atoms = ase.io.read(f"{TEST_FILES_DIR}/OUTCAR")
+    atoms_info = {"test": "hi"}
+    atoms.info = atoms_info
     assert not isinstance(atoms, MSONAtoms)
-    ref = {"@module": "pymatgen.io.ase", "@class": "MSONAtoms", "atoms_json": ase.io.jsonio.encode(atoms)}
+
+    ref_atoms = atoms.copy()
+    ref_atoms.info = {}
+    
     msonable_atoms = MSONAtoms(atoms)
     assert atoms == msonable_atoms
+
+    ref = {"@module": "pymatgen.io.ase", "@class": "MSONAtoms", "atoms_json": ase.io.jsonio.encode(ref_atoms), "atoms_info": atoms_info}
     assert msonable_atoms.as_dict() == ref
-    assert MSONAtoms.from_dict(ref) == atoms
+
+    atoms_back = MSONAtoms.from_dict(ref)
+    assert atoms_back == atoms
+    assert atoms_back.info == atoms_info
 
     structure = Structure.from_file(f"{TEST_FILES_DIR}/POSCAR")
 

--- a/tests/io/test_ase.py
+++ b/tests/io/test_ase.py
@@ -316,8 +316,9 @@ def test_back_forth_v4():
 
 @skip_if_no_ase
 def test_msonable_atoms():
+
     atoms = ase.io.read(f"{TEST_FILES_DIR}/OUTCAR")
-    atoms_info = {"test": "hi"}
+    atoms_info = {"test": "hi", "structure": structure}
     atoms.info = atoms_info
     assert not isinstance(atoms, MSONAtoms)
 

--- a/tests/io/test_ase.py
+++ b/tests/io/test_ase.py
@@ -337,7 +337,7 @@ def test_msonable_atoms():
 
     atoms_back = MSONAtoms.from_dict(ref)
     assert atoms_back == atoms
-    assert atoms_back.info == atoms_info
+    assert atoms_back.info == atoms.info
 
     structure = Structure.from_file(f"{TEST_FILES_DIR}/POSCAR")
 

--- a/tests/io/test_ase.py
+++ b/tests/io/test_ase.py
@@ -316,7 +316,6 @@ def test_back_forth_v4():
 
 @skip_if_no_ase
 def test_msonable_atoms():
-
     atoms = ase.io.read(f"{TEST_FILES_DIR}/OUTCAR")
     atoms_info = {"test": "hi", "structure": structure}
     atoms.info = atoms_info

--- a/tests/io/test_ase.py
+++ b/tests/io/test_ase.py
@@ -330,7 +330,12 @@ def test_msonable_atoms():
     assert atoms == msonable_atoms
 
     msonable_atoms_dict = msonable_atoms.as_dict()
-    assert msonable_atoms_dict == {"@module": "pymatgen.io.ase", "@class": "MSONAtoms", "atoms_json": ase.io.jsonio.encode(ref_atoms), "atoms_info": jsanitize(atoms_info, strict=True)}
+    assert msonable_atoms_dict == {
+        "@module": "pymatgen.io.ase",
+        "@class": "MSONAtoms",
+        "atoms_json": ase.io.jsonio.encode(ref_atoms),
+        "atoms_info": jsanitize(atoms_info, strict=True),
+    }
 
     atoms_back = MSONAtoms.from_dict(msonable_atoms_dict)
     assert atoms_back == atoms

--- a/tests/io/test_ase.py
+++ b/tests/io/test_ase.py
@@ -323,11 +323,16 @@ def test_msonable_atoms():
 
     ref_atoms = atoms.copy()
     ref_atoms.info = {}
-    
+
     msonable_atoms = MSONAtoms(atoms)
     assert atoms == msonable_atoms
 
-    ref = {"@module": "pymatgen.io.ase", "@class": "MSONAtoms", "atoms_json": ase.io.jsonio.encode(ref_atoms), "atoms_info": atoms_info}
+    ref = {
+        "@module": "pymatgen.io.ase",
+        "@class": "MSONAtoms",
+        "atoms_json": ase.io.jsonio.encode(ref_atoms),
+        "atoms_info": atoms_info,
+    }
     assert msonable_atoms.as_dict() == ref
 
     atoms_back = MSONAtoms.from_dict(ref)


### PR DESCRIPTION
## Summary

Closes https://github.com/materialsproject/pymatgen/issues/3668.

The `Atoms.info` dictionary can be populated with all kinds of goodies that are challenging to deal with from a (de)serialization perspective. Oftentimes, this is from users hacking things into `Atoms.info`. For instance, in #3668, I put a `Structure` object in the `Atoms.info` dictionary, which then broke things during serialization. In order to ensure `MSONAtoms` plays nice with the (de)serialization routines in `monty`, it is better to split off the `Atoms.info` metadata into its own entry in the `.as_dict()` dictionary that we can sanitize ourselves. That's what I've done in this PR.

The following toy example now works in a round-trip fashion:

```python
from pymatgen.core import Structure
from monty.serialization import dumpfn, loadfn

structure = Structure(
    lattice=[[0, 2.13, 2.13], [2.13, 0, 2.13], [2.13, 2.13, 0]],
    species=["Mg", "O"],
    coords=[[0, 0, 0], [0.5, 0.5, 0.5]],
)
mson_atoms = structure.to_ase_atoms()
mson_atoms.info = {"test": "hi", "s": structure}
dumpfn(mson_atoms, "test.json")
loadfn("test.json")