### PR TITLE
Fix blank line bug in `io.res.ResWriter`

### DIFF
--- a/pymatgen/io/res.py
+++ b/pymatgen/io/res.py
@@ -106,11 +106,9 @@ class Res:
     def __str__(self) -> str:
         lines = ["TITL" if self.TITL is None else str(self.TITL)]
 
-        lines.extend(f"REM {rem}" for rem in self.REMS)
+        lines += (f"REM {rem}" for rem in self.REMS)
 
-        lines.append(str(self.CELL))
-        lines.append("LATT -1")
-        lines.append(str(self.SFAC))
+        lines += (str(self.CELL), "LATT -1", str(self.SFAC))
 
         return "\n".join(lines)
 

--- a/pymatgen/io/res.py
+++ b/pymatgen/io/res.py
@@ -104,15 +104,15 @@ class Res:
     SFAC: ResSFAC
 
     def __str__(self) -> str:
-        return "\n".join(
-            [
-                "TITL" if self.TITL is None else str(self.TITL),
-                "\n".join(f"REM {rem}" for rem in self.REMS),
-                str(self.CELL),
-                "LATT -1",
-                str(self.SFAC),
-            ]
-        )
+        lines = ["TITL" if self.TITL is None else str(self.TITL)]
+
+        lines.extend(f"REM {rem}" for rem in self.REMS)
+
+        lines.append(str(self.CELL))
+        lines.append("LATT -1")
+        lines.append(str(self.SFAC))
+
+        return "\n".join(lines)
 
 
 class ResParseError(ParseError):

--- a/pymatgen/io/res.py
+++ b/pymatgen/io/res.py
@@ -91,7 +91,7 @@ class ResSFAC:
     def __str__(self) -> str:
         species = " ".join(f"{specie:<2s}" for specie in self.species)
         ions = "\n".join(map(str, self.ions))
-        return f"SFAC {species}\n{ions}\nEND"
+        return f"SFAC {species}\n{ions}\nEND\n"
 
 
 @dataclass(frozen=True)

--- a/tests/io/test_res.py
+++ b/tests/io/test_res.py
@@ -78,8 +78,7 @@ class TestAirssProvider:
         entry = provider.entry
         del entry.data["rems"]
         string = ResWriter(entry).string
-
-        assert string.splitlines()[1].startswith("CELL")
+        assert all(string.splitlines())
 
     def test_entry(self, provider: AirssProvider):
         entry1 = provider.entry

--- a/tests/io/test_res.py
+++ b/tests/io/test_res.py
@@ -68,6 +68,11 @@ class TestAirssProvider:
         assert airss_v[0] == "0.9.1"
         assert airss_v[1].year == 2018
 
+    def test_end_of_file_newline(self, provider: AirssProvider):
+        """https://github.com/materialsproject/pymatgen/issues/3636"""
+        string = ResWriter(provider.entry).string
+        assert string.endswith("\n")
+
     def test_entry(self, provider: AirssProvider):
         entry1 = provider.entry
         assert entry1.energy == provider.energy

--- a/tests/io/test_res.py
+++ b/tests/io/test_res.py
@@ -73,6 +73,14 @@ class TestAirssProvider:
         string = ResWriter(provider.entry).string
         assert string.endswith("\n")
 
+    def test_empty_rems_no_blank_line(self, provider: AirssProvider):
+        """https://github.com/materialsproject/pymatgen/issues/3636"""
+        entry = provider.entry
+        del entry.data["rems"]
+        string = ResWriter(entry).string
+
+        assert string.splitlines()[1].startswith("CELL")
+
     def test_entry(self, provider: AirssProvider):
         entry1 = provider.entry
         assert entry1.energy == provider.energy


### PR DESCRIPTION
## Summary

This PR fixes two bugs in the res writer:

- Fix 1: Add a blank line at the end of the file
- Fix 2: Do not write a blank line if REMS is empty

Closes #3636

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
