### PR TITLE
Fix `phonopy.get_pmg_structure` `site_properties` key for magmoms

### DIFF
--- a/pymatgen/io/phonopy.py
+++ b/pymatgen/io/phonopy.py
@@ -33,15 +33,10 @@ def get_pmg_structure(phonopy_structure: PhonopyAtoms) -> Structure:
     lattice = phonopy_structure.cell
     frac_coords = phonopy_structure.scaled_positions
     symbols = phonopy_structure.symbols
-    masses = phonopy_structure.masses
     magmoms = getattr(phonopy_structure, "magnetic_moments", [0] * len(symbols))
+    site_props = {"phonopy_masses": phonopy_structure.masses, "magmom": magmoms}
 
-    return Structure(
-        lattice,
-        symbols,
-        frac_coords,
-        site_properties={"phonopy_masses": masses, "magmom": magmoms},
-    )
+    return Structure(lattice, symbols, frac_coords, site_properties=site_props)
 
 
 @requires(Phonopy, "phonopy not installed!")

--- a/pymatgen/io/phonopy.py
+++ b/pymatgen/io/phonopy.py
@@ -40,7 +40,7 @@ def get_pmg_structure(phonopy_structure: PhonopyAtoms) -> Structure:
         lattice,
         symbols,
         frac_coords,
-        site_properties={"phonopy_masses": masses, "magnetic_moments": magmoms},
+        site_properties={"phonopy_masses": masses, "magmom": magmoms},
     )
 
 

--- a/tests/io/test_phonopy.py
+++ b/tests/io/test_phonopy.py
@@ -120,6 +120,7 @@ class TestStructureConversion(PymatgenTest):
 
         # https://github.com/materialsproject/pymatgen/pull/3555
         assert list(struct_ph.magnetic_moments) == magmoms
+        assert struct_pmg_round_trip.site_properties['magmom'] == struct_pmg.site_properties['magmom']
 
 
 @unittest.skipIf(Phonopy is None, "Phonopy not present")

--- a/tests/io/test_phonopy.py
+++ b/tests/io/test_phonopy.py
@@ -120,7 +120,7 @@ class TestStructureConversion(PymatgenTest):
 
         # https://github.com/materialsproject/pymatgen/pull/3555
         assert list(struct_ph.magnetic_moments) == magmoms
-        assert struct_pmg_round_trip.site_properties['magmom'] == struct_pmg.site_properties['magmom']
+        assert struct_pmg_round_trip.site_properties["magmom"] == struct_pmg.site_properties["magmom"]
 
 
 @unittest.skipIf(Phonopy is None, "Phonopy not present")


### PR DESCRIPTION
## Summary

Major changes:
- fix 1: Change key in  get_pmg_structure from magnetic_moments to magmom
- fix 2:  add unit test `assert struct_pmg_round_trip.site_properties["magmom"] == struct_pmg.site_properties["magmom"]`

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
