### PR TITLE
Remove exception printing when importing phonopy

### DIFF
--- a/pymatgen/phonon/gruneisen.py
+++ b/pymatgen/phonon/gruneisen.py
@@ -19,8 +19,7 @@ from pymatgen.phonon.dos import PhononDos
 try:
     import phonopy
     from phonopy.phonon.dos import TotalDos
-except ImportError as exc:
-    print(exc)
+except ImportError:
     phonopy = None
 
 if TYPE_CHECKING:

--- a/pymatgen/phonon/thermal_displacements.py
+++ b/pymatgen/phonon/thermal_displacements.py
@@ -22,8 +22,7 @@ if TYPE_CHECKING:
 
 try:
     import phonopy
-except ImportError as exc:
-    print(exc)
+except ImportError:
     phonopy = None
 
 __author__ = "J. George"


### PR DESCRIPTION
## Summary

Removes stdout printing when trying to import phonopy for tidiness. These printing appeared in some downstream packages. For example
```shell
pip install mp_api
python -c "from mp_api.client import MPRester"
```
resulted in
```
No module named 'phonopy'
No module named 'phonopy'
```


## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
