### PR TITLE
Prevent GitHub Actions from running document related CIs on forks

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -24,6 +24,8 @@ concurrency:
 jobs:
   # Build job
   build:
+    # prevent this action from running on forks
+    if: github.repository == 'materialsproject/pymatgen'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Install Enumlib
         if: matrix.os == 'ubuntu-latest'
         run: |
-          git clone --recursive https://github.com/msg-byu/enumlib.git
+          git clone --recursive https://github.com/msg-byu/enumlib
           cd enumlib/symlib/src
           export F90=gfortran
           make
@@ -100,6 +100,10 @@ jobs:
 
       - name: Install dependencies
         run: |
+          # TODO remove temporary fix. added since uv install torch is flaky.
+          # track https://github.com/astral-sh/uv/issues/1921 for resolution
+          pip install torch
+
           uv pip install numpy cython --system
 
           uv pip install -e '.[dev,optional]' --system

--- a/pymatgen/cli/pmg_config.py
+++ b/pymatgen/cli/pmg_config.py
@@ -175,7 +175,7 @@ def build_enum(fortran_command: str = "gfortran") -> bool:
     cwd = os.getcwd()
     state = True
     try:
-        subprocess.call(["git", "clone", "--recursive", "https://github.com/msg-byu/enumlib.git"])
+        subprocess.call(["git", "clone", "--recursive", "https://github.com/msg-byu/enumlib"])
         os.chdir(f"{cwd}/enumlib/symlib/src")
         os.environ["F90"] = fortran_command
         subprocess.call(["make"])


### PR DESCRIPTION
`.github/workflows/jekyll-gh-pages.yml` run on forked repository, and caused CI fails if the forked repository is not set up  for GitHub Pages (e.g. https://github.com/lan496/pymatgen/actions/runs/8325702971).
As the CI for testing is already disabled on forked (https://github.com/materialsproject/pymatgen/commit/531561d8d1dd55b3104d923c585861340c2223f0), I think it will be reasonable to disable CI for Github Pages as well.
