### PR TITLE
Return `self` from `Structure` methods `replace`, `substitute`, `remove_species`, `remove_sites`

### DIFF
--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -3930,7 +3930,7 @@ class Structure(IStructure, collections.abc.MutableSequence):
         coords_are_cartesian: bool = False,
         properties: dict | None = None,
         label: str | None = None,
-    ) -> None:
+    ) -> Self:
         """Replace a single site. Takes either a species or a dict of species and
         occupations.
 
@@ -3943,6 +3943,9 @@ class Structure(IStructure, collections.abc.MutableSequence):
                 Defaults to False.
             properties (dict): Properties associated with the site.
             label (str): Label associated with the site.
+
+        Returns:
+            Structure: self with replaced site.
         """
         if coords is None:
             frac_coords = self[idx].frac_coords
@@ -3954,7 +3957,9 @@ class Structure(IStructure, collections.abc.MutableSequence):
         new_site = PeriodicSite(species, frac_coords, self._lattice, properties=properties, label=label)
         self.sites[idx] = new_site
 
-    def substitute(self, index: int, func_group: IMolecule | Molecule | str, bond_order: int = 1) -> None:
+        return self
+
+    def substitute(self, index: int, func_group: IMolecule | Molecule | str, bond_order: int = 1) -> Self:
         """Substitute atom at index with a functional group.
 
         Args:
@@ -3975,6 +3980,9 @@ class Structure(IStructure, collections.abc.MutableSequence):
             bond_order (int): A specified bond order to calculate the bond
                 length between the attached functional group and the nearest
                 neighbor site. Defaults to 1.
+
+        Returns:
+            Structure: self with functional group attached.
         """
         # Find the nearest neighbor that is not a terminal atom.
         all_non_terminal_nn = []
@@ -4000,7 +4008,9 @@ class Structure(IStructure, collections.abc.MutableSequence):
         if not isinstance(func_group, Molecule):
             # Check to see whether the functional group is in database.
             if func_group not in FunctionalGroups:
-                raise RuntimeError("Can't find functional group in list. Provide explicit coordinate instead")
+                raise ValueError(
+                    f"Can't find functional group {func_group!r} in list. Provide explicit coordinates instead"
+                )
             fgroup = FunctionalGroups[func_group]
         else:
             fgroup = func_group
@@ -4048,11 +4058,16 @@ class Structure(IStructure, collections.abc.MutableSequence):
             s_new = PeriodicSite(site.species, site.coords, self.lattice, coords_are_cartesian=True, label=site.label)
             self._sites.append(s_new)
 
-    def remove_species(self, species: Sequence[SpeciesLike]) -> None:
+        return self
+
+    def remove_species(self, species: Sequence[SpeciesLike]) -> Self:
         """Remove all occurrences of several species from a structure.
 
         Args:
             species: Sequence of species to remove, e.g., ["Li", "Na"].
+
+        Returns:
+            Structure: self with species removed.
         """
         new_sites = []
         species = [get_el_sp(s) for s in species]
@@ -4071,15 +4086,22 @@ class Structure(IStructure, collections.abc.MutableSequence):
                 )
         self.sites = new_sites
 
-    def remove_sites(self, indices: Sequence[int | None]) -> None:
+        return self
+
+    def remove_sites(self, indices: Sequence[int | None]) -> Self:
         """Delete sites with at indices.
 
         Args:
             indices: Sequence of indices of sites to delete.
+
+        Returns:
+            Structure: self with sites removed.
         """
         self.sites = [site for idx, site in enumerate(self) if idx not in indices]
 
-    def apply_operation(self, symmop: SymmOp, fractional: bool = False) -> Structure:
+        return self
+
+    def apply_operation(self, symmop: SymmOp, fractional: bool = False) -> Self:
         """Apply a symmetry operation to the structure in place and return the modified
         structure. The lattice is operated on by the rotation matrix only.
         Coords are operated in full and then transformed to the new lattice.

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -2132,7 +2132,7 @@ class IStructure(SiteCollection, MSONable):
             )
         return self.copy()
 
-    def copy(self, site_properties=None, sanitize=False, properties=None) -> Structure:
+    def copy(self, site_properties=None, sanitize=False, properties=None) -> Self:
         """Convenience method to get a copy of the structure, with options to add
         site properties.
 
@@ -4148,7 +4148,7 @@ class Structure(IStructure, collections.abc.MutableSequence):
 
         return self
 
-    def apply_strain(self, strain: ArrayLike, inplace: bool = True) -> Structure:
+    def apply_strain(self, strain: ArrayLike, inplace: bool = True) -> Self:
         """Apply a strain to the lattice.
 
         Args:
@@ -4161,7 +4161,7 @@ class Structure(IStructure, collections.abc.MutableSequence):
                 Structure copy. Defaults to True.
 
         Returns:
-            Structure: Structure with strain applied.
+            Structure: self if inplace=True else new structure with strain applied.
         """
         strain_matrix = (1 + np.array(strain)) * np.eye(3)
         new_lattice = Lattice(np.dot(self._lattice.matrix.T, strain_matrix).T)
@@ -4169,7 +4169,7 @@ class Structure(IStructure, collections.abc.MutableSequence):
         struct.lattice = new_lattice
         return struct
 
-    def sort(self, key: Callable | None = None, reverse: bool = False) -> Structure:
+    def sort(self, key: Callable | None = None, reverse: bool = False) -> Self:
         """Sort a structure in place. The parameters have the same meaning as in
         list.sort(). By default, sites are sorted by the electronegativity of
         the species. The difference between this method and
@@ -4184,14 +4184,14 @@ class Structure(IStructure, collections.abc.MutableSequence):
                 as if each comparison were reversed.
 
         Returns:
-            Structure: Sorted structure.
+            Structure: self sorted.
         """
         self._sites.sort(key=key, reverse=reverse)
         return self
 
     def translate_sites(
         self, indices: int | Sequence[int], vector: ArrayLike, frac_coords: bool = True, to_unit_cell: bool = True
-    ) -> Structure:
+    ) -> Self:
         """Translate specific sites by some vector, keeping the sites within the
         unit cell. Modifies the structure in place.
 
@@ -4229,7 +4229,7 @@ class Structure(IStructure, collections.abc.MutableSequence):
         axis: ArrayLike | None = None,
         anchor: ArrayLike | None = None,
         to_unit_cell: bool = True,
-    ) -> Structure:
+    ) -> Self:
         """Rotate specific sites by some angle around vector at anchor. Modifies
         the structure in place.
 
@@ -4276,7 +4276,7 @@ class Structure(IStructure, collections.abc.MutableSequence):
 
         return self
 
-    def perturb(self, distance: float, min_distance: float | None = None) -> Structure:
+    def perturb(self, distance: float, min_distance: float | None = None) -> Self:
         """Performs a random perturbation of the sites in a structure to break
         symmetries. Modifies the structure in place.
 
@@ -4306,7 +4306,7 @@ class Structure(IStructure, collections.abc.MutableSequence):
 
         return self
 
-    def make_supercell(self, scaling_matrix: ArrayLike, to_unit_cell: bool = True, in_place: bool = True) -> Structure:
+    def make_supercell(self, scaling_matrix: ArrayLike, to_unit_cell: bool = True, in_place: bool = True) -> Self:
         """Create a supercell.
 
         Args:
@@ -4342,7 +4342,7 @@ class Structure(IStructure, collections.abc.MutableSequence):
 
         return struct
 
-    def scale_lattice(self, volume: float) -> Structure:
+    def scale_lattice(self, volume: float) -> Self:
         """Performs a scaling of the lattice vectors so that length proportions
         and angles are preserved.
 
@@ -4356,7 +4356,7 @@ class Structure(IStructure, collections.abc.MutableSequence):
 
         return self
 
-    def merge_sites(self, tol: float = 0.01, mode: Literal["sum", "delete", "average"] = "sum") -> Structure:
+    def merge_sites(self, tol: float = 0.01, mode: Literal["sum", "delete", "average"] = "sum") -> Self:
         """Merges sites (adding occupancies) within tol of each other.
         Removes site properties.
 
@@ -4400,7 +4400,7 @@ class Structure(IStructure, collections.abc.MutableSequence):
         self._sites = sites
         return self
 
-    def set_charge(self, new_charge: float = 0.0) -> Structure:
+    def set_charge(self, new_charge: float = 0.0) -> Self:
         """Sets the overall structure charge.
 
         Args:
@@ -4471,7 +4471,7 @@ class Structure(IStructure, collections.abc.MutableSequence):
         return self._calculate(calculator, verbose=verbose)
 
     @classmethod
-    def from_prototype(cls, prototype: str, species: Sequence, **kwargs) -> Structure:
+    def from_prototype(cls, prototype: str, species: Sequence, **kwargs) -> Self:
         """Method to rapidly construct common prototype structures.
 
         Args:

--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -2186,7 +2186,7 @@ class TestMolecule(PymatgenTest):
         assert returned is self.mol
         assert_allclose(self.mol.cart_coords[2], [0.889164737, 0.513359500, -0.363000000])
 
-    def test_replace(self):
+    def test_replace_species(self):
         self.mol[0] = "Ge"
         assert self.mol.formula == "Ge1 H4"
 

--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -959,8 +959,9 @@ class TestStructure(PymatgenTest):
         assert self.struct[1].species_string == "F"
 
     def test_replace_species(self):
-        struct = self.struct
-        struct.replace_species({"Si": "Na"})
+        assert self.struct.formula == "Si2"
+        struct = self.struct.replace_species({"Si": "Na"})
+        assert struct is self.struct
         assert struct.formula == "Na2"
 
         # test replacement with a dictionary
@@ -1022,18 +1023,25 @@ class TestStructure(PymatgenTest):
         assert struct.n_elems == 4
 
         struct.replace_species({"Ge": "Si"})
-        struct.substitute(1, "hydroxyl")
+        substituted = struct.substitute(1, "hydroxyl")
+        assert substituted is struct
         assert struct.formula == "Si1 H1 N1 O1"
         assert struct.symbol_set == ("H", "N", "O", "Si")
+        with pytest.raises(
+            ValueError, match="Can't find functional group 'OH' in list. Provide explicit coordinates instead"
+        ):
+            substituted = struct.substitute(2, "OH")
         # Distance between O and H
         assert struct.get_distance(2, 3) == approx(0.96)
         # Distance between Si and H
         assert struct.get_distance(0, 3) == approx(2.09840889)
 
-        struct.remove_species(["H"])
+        h_removed = struct.remove_species(["H"])
+        assert h_removed is struct
         assert struct.formula == "Si1 N1 O1"
 
-        struct.remove_sites([1, 2])
+        sites_removed = struct.remove_sites([1, 2])
+        assert sites_removed is struct
         assert struct.formula == "Si1"
 
     def test_add_remove_site_property(self):

--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -958,6 +958,23 @@ class TestStructure(PymatgenTest):
         assert self.struct[0].species_string == "Si"
         assert self.struct[1].species_string == "F"
 
+    def test_replace(self):
+        assert self.struct.formula == "Si2"
+        struct = self.struct.replace(0, "O")
+        assert struct is self.struct
+        assert struct.formula == "Si1 O1"
+        assert_allclose(struct[0].frac_coords, [0, 0, 0])
+        struct.replace(0, "O", coords=[0.25, 0.25, 0.25])
+        assert struct.formula == "Si1 O1"
+        assert_allclose(struct[0].frac_coords, [0.25, 0.25, 0.25])
+        struct.replace(0, "O", properties={"magmom": 1})
+        assert struct.formula == "Si1 O1"
+        assert struct[0].magmom == 1
+        struct.replace(0, "O", properties={"magmom": 2}, coords=[0.9, 0.9, 0.9])
+        assert struct.formula == "Si1 O1"
+        assert struct[0].magmom == 2
+        assert_allclose(struct[0].frac_coords, [0.9, 0.9, 0.9])
+
     def test_replace_species(self):
         assert self.struct.formula == "Si2"
         struct = self.struct.replace_species({"Si": "Na"})

--- a/tests/files/.pytest-split-durations
+++ b/tests/files/.pytest-split-durations
@@ -1028,7 +1028,7 @@
     "tests/core/test_structure.py::TestMolecule::test_relax_ase_mol": 0.00900712498696521,
     "tests/core/test_structure.py::TestMolecule::test_relax_ase_mol_return_traj": 0.006231041974388063,
     "tests/core/test_structure.py::TestMolecule::test_relax_gfnxtb": 0.00013875000877305865,
-    "tests/core/test_structure.py::TestMolecule::test_replace": 0.0018936669803224504,
+    "tests/core/test_structure.py::TestMolecule::test_replace_species": 0.0018936669803224504,
     "tests/core/test_structure.py::TestMolecule::test_rotate_sites": 0.0017342490027658641,
     "tests/core/test_structure.py::TestMolecule::test_substitute": 0.005597625044174492,
     "tests/core/test_structure.py::TestMolecule::test_as_from_dict": 0.0021212499705143273,


### PR DESCRIPTION
allows chaining these methods which returned `None` before. updated tests to `assert returned is self` and added a new test for `Structure.replace()` which was missing coverage