### PR TITLE
Convert some `staticmethod` to `classmethod`

### DIFF
--- a/pymatgen/alchemy/transmuters.py
+++ b/pymatgen/alchemy/transmuters.py
@@ -294,8 +294,8 @@ class PoscarTransmuter(StandardTransmuter):
         trafo_struct = TransformedStructure.from_poscar_str(poscar_string, [])
         super().__init__([trafo_struct], transformations, extend_collection=extend_collection)
 
-    @staticmethod
-    def from_filenames(poscar_filenames, transformations=None, extend_collection=False):
+    @classmethod
+    def from_filenames(cls, poscar_filenames, transformations=None, extend_collection=False) -> StandardTransmuter:
         """Convenient constructor to generates a POSCAR transmuter from a list of
         POSCAR filenames.
 

--- a/pymatgen/analysis/graphs.py
+++ b/pymatgen/analysis/graphs.py
@@ -196,8 +196,8 @@ class StructureGraph(MSONable):
 
         return cls(structure, graph_data=graph_data)
 
-    @staticmethod
-    def with_edges(structure: Structure, edges: dict) -> StructureGraph:
+    @classmethod
+    def with_edges(cls, structure: Structure, edges: dict) -> Self:
         """
         Constructor for MoleculeGraph, using pre-existing or pre-defined edges
         with optional edge parameters.
@@ -213,9 +213,7 @@ class StructureGraph(MSONable):
         Returns:
             sg, a StructureGraph
         """
-        struct_graph = StructureGraph.with_empty_graph(
-            structure, name="bonds", edge_weight_name="weight", edge_weight_units=""
-        )
+        struct_graph = cls.with_empty_graph(structure, name="bonds", edge_weight_name="weight", edge_weight_units="")
 
         for edge, props in edges.items():
             try:
@@ -252,10 +250,10 @@ class StructureGraph(MSONable):
         struct_graph.set_node_attributes()
         return struct_graph
 
-    @staticmethod
+    @classmethod
     def with_local_env_strategy(
-        structure: Structure, strategy: NearNeighbors, weights: bool = False, edge_properties: bool = False
-    ) -> StructureGraph:
+        cls, structure: Structure, strategy: NearNeighbors, weights: bool = False, edge_properties: bool = False
+    ) -> Self:
         """
         Constructor for StructureGraph, using a strategy
         from pymatgen.analysis.local_env.
@@ -269,7 +267,7 @@ class StructureGraph(MSONable):
         if not strategy.structures_allowed:
             raise ValueError("Chosen strategy is not designed for use with structures! Please choose another strategy.")
 
-        struct_graph = StructureGraph.with_empty_graph(structure, name="bonds")
+        struct_graph = cls.with_empty_graph(structure, name="bonds")
 
         for idx, neighbors in enumerate(strategy.get_all_nn_info(structure)):
             for neighbor in neighbors:
@@ -1627,8 +1625,8 @@ class MoleculeGraph(MSONable):
 
         return cls(molecule, graph_data=graph_data)
 
-    @staticmethod
-    def with_edges(molecule: Molecule, edges: dict[tuple[int, int], None | dict]) -> MoleculeGraph:
+    @classmethod
+    def with_edges(cls, molecule: Molecule, edges: dict[tuple[int, int], None | dict]) -> Self:
         """
         Constructor for MoleculeGraph, using pre-existing or pre-defined edges
         with optional edge parameters.
@@ -1643,7 +1641,7 @@ class MoleculeGraph(MSONable):
         Returns:
             A MoleculeGraph
         """
-        mg = MoleculeGraph.with_empty_graph(molecule, name="bonds", edge_weight_name="weight", edge_weight_units="")
+        mg = cls.with_empty_graph(molecule, name="bonds", edge_weight_name="weight", edge_weight_units="")
 
         for edge, props in edges.items():
             try:
@@ -1671,8 +1669,8 @@ class MoleculeGraph(MSONable):
         mg.set_node_attributes()
         return mg
 
-    @staticmethod
-    def with_local_env_strategy(molecule, strategy) -> MoleculeGraph:
+    @classmethod
+    def with_local_env_strategy(cls, molecule, strategy) -> Self:
         """
         Constructor for MoleculeGraph, using a strategy
         from pymatgen.analysis.local_env.
@@ -1688,7 +1686,7 @@ class MoleculeGraph(MSONable):
             raise ValueError(f"{strategy=} is not designed for use with molecules! Choose another strategy.")
         extend_structure = strategy.extend_structure_molecules
 
-        mg = MoleculeGraph.with_empty_graph(molecule, name="bonds", edge_weight_name="weight", edge_weight_units="")
+        mg = cls.with_empty_graph(molecule, name="bonds", edge_weight_name="weight", edge_weight_units="")
 
         # NearNeighbor classes only (generally) work with structures
         # molecules have to be boxed first

--- a/pymatgen/core/operations.py
+++ b/pymatgen/core/operations.py
@@ -54,12 +54,13 @@ class SymmOp(MSONable):
         self.affine_matrix = affine_transformation_matrix
         self.tol = tol
 
-    @staticmethod
+    @classmethod
     def from_rotation_and_translation(
+        cls,
         rotation_matrix: ArrayLike = ((1, 0, 0), (0, 1, 0), (0, 0, 1)),
         translation_vec: ArrayLike = (0, 0, 0),
         tol: float = 0.1,
-    ) -> SymmOp:
+    ) -> Self:
         """Creates a symmetry operation from a rotation matrix and a translation
         vector.
 
@@ -80,7 +81,7 @@ class SymmOp(MSONable):
         affine_matrix = np.eye(4)
         affine_matrix[0:3][:, 0:3] = rotation_matrix
         affine_matrix[0:3][:, 3] = translation_vec
-        return SymmOp(affine_matrix, tol)
+        return cls(affine_matrix, tol)
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, SymmOp):

--- a/pymatgen/core/operations.py
+++ b/pymatgen/core/operations.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from typing import Any
 
     from numpy.typing import ArrayLike
+    from typing_extensions import Self
 
 __author__ = "Shyue Ping Ong, Shyam Dwaraknath, Matthew Horton"
 

--- a/pymatgen/io/abinit/pseudos.py
+++ b/pymatgen/io/abinit/pseudos.py
@@ -108,8 +108,8 @@ class Pseudo(MSONable, abc.ABC):
         """
         return obj if isinstance(obj, cls) else cls.from_file(obj)
 
-    @staticmethod
-    def from_file(filename) -> Pseudo:
+    @classmethod
+    def from_file(cls, filename: str) -> Self:
         """
         Build an instance of a concrete Pseudo subclass from filename.
         Note: the parser knows the concrete class that should be instantiated

--- a/pymatgen/io/babel.py
+++ b/pymatgen/io/babel.py
@@ -333,8 +333,8 @@ class BabelMolAdaptor:
 
         return cls(next(mols).OBMol)
 
-    @staticmethod
-    def from_molecule_graph(mol: MoleculeGraph) -> BabelMolAdaptor:
+    @classmethod
+    def from_molecule_graph(cls, mol: MoleculeGraph) -> Self:
         """
         Read a molecule from a pymatgen MoleculeGraph object.
 
@@ -344,7 +344,7 @@ class BabelMolAdaptor:
         Returns:
             BabelMolAdaptor object
         """
-        return BabelMolAdaptor(mol.molecule)
+        return cls(mol.molecule)
 
     @needs_openbabel
     @classmethod

--- a/pymatgen/io/cp2k/inputs.py
+++ b/pymatgen/io/cp2k/inputs.py
@@ -2129,8 +2129,8 @@ class Band_Structure(Section):
 
     # TODO kpoints objects are defined in the vasp module instead of a code agnostic module
     # if this changes in the future as other codes are added, then this will need to change
-    @staticmethod
-    def from_kpoints(kpoints: VaspKpoints, kpoints_line_density=20):
+    @classmethod
+    def from_kpoints(cls, kpoints: VaspKpoints, kpoints_line_density: int = 20) -> Self:
         """
         Initialize band structure section from a line-mode Kpoint object.
 
@@ -2167,7 +2167,7 @@ class Band_Structure(Section):
             raise ValueError(
                 "Unsupported k-point style. Must be line-mode or explicit k-points (reciprocal/cartesian)."
             )
-        return Band_Structure(kpoint_sets=kpoint_sets, filename="BAND.bs")
+        return cls(kpoint_sets=kpoint_sets, filename="BAND.bs")
 
 
 @dataclass

--- a/pymatgen/io/cp2k/inputs.py
+++ b/pymatgen/io/cp2k/inputs.py
@@ -113,7 +113,7 @@ class Keyword(MSONable):
         if self.name.upper() == other.name.upper():
             v1 = [val.upper() if isinstance(val, str) else val for val in self.values]
             v2 = [val.upper() if isinstance(val, str) else val for val in other.values]  # noqa: PD011
-            if v1 == v2 and self.units == self.units:
+            if v1 == v2 and self.units == other.units:
                 return True
         return False
 

--- a/pymatgen/io/feff/inputs.py
+++ b/pymatgen/io/feff/inputs.py
@@ -197,10 +197,10 @@ class Header(MSONable):
             raise ValueError("'struct' argument must be a Structure or Molecule!")
         self.comment = comment or "None given"
 
-    @staticmethod
-    def from_cif_file(cif_file, source="", comment=""):
+    @classmethod
+    def from_cif_file(cls, cif_file: str, source: str = "", comment: str = "") -> Self:
         """
-        Static method to create Header object from cif_file.
+        Create Header object from cif_file.
 
         Args:
             cif_file: cif_file path and name
@@ -213,7 +213,7 @@ class Header(MSONable):
         """
         parser = CifParser(cif_file)
         structure = parser.parse_structures(primitive=True)[0]
-        return Header(structure, source, comment)
+        return cls(structure, source, comment)
 
     @property
     def structure_symmetry(self):

--- a/pymatgen/io/pwmat/inputs.py
+++ b/pymatgen/io/pwmat/inputs.py
@@ -499,8 +499,8 @@ class GenKpt(MSONable):
         self.kpath.update({"path": path})
         self.density = density
 
-    @staticmethod
-    def from_structure(structure: Structure, dim: int, density: float = 0.01) -> GenKpt:
+    @classmethod
+    def from_structure(cls, structure: Structure, dim: int, density: float = 0.01) -> Self:
         """Obtain a AtomConfig object from Structure object.
 
         Args:
@@ -530,7 +530,7 @@ class GenKpt(MSONable):
             kpts = kpath_set.kpath["kpoints"]
             path = kpath_set.kpath["path"]
         rec_lattice: np.ndarray = structure.lattice.reciprocal_lattice.matrix  # with 2*pi
-        return GenKpt(rec_lattice, kpts, path, density * 2 * np.pi)
+        return cls(rec_lattice, kpts, path, density * 2 * np.pi)
 
     def get_str(self):
         """Returns a string to be written as a gen.kpt file."""
@@ -601,8 +601,8 @@ class HighSymmetryPoint(MSONable):
         self.kpath.update({"path": path})
         self.density = density
 
-    @staticmethod
-    def from_structure(structure: Structure, dim: int, density: float = 0.01) -> HighSymmetryPoint:
+    @classmethod
+    def from_structure(cls, structure: Structure, dim: int, density: float = 0.01) -> Self:
         """Obtain HighSymmetry object from Structure object.
 
         Args:
@@ -613,9 +613,7 @@ class HighSymmetryPoint(MSONable):
         """
         reciprocal_lattice: np.ndarray = structure.lattice.reciprocal_lattice.matrix
         gen_kpt = GenKpt.from_structure(structure=structure, dim=dim, density=density)
-        return HighSymmetryPoint(
-            reciprocal_lattice, gen_kpt.kpath["kpoints"], gen_kpt.kpath["path"], density * 2 * np.pi
-        )
+        return cls(reciprocal_lattice, gen_kpt.kpath["kpoints"], gen_kpt.kpath["path"], density * 2 * np.pi)
 
     def get_str(self) -> str:
         """Returns a string describing high symmetry points in HIGH_SYMMETRY_POINTS format."""

--- a/pymatgen/io/pwmat/inputs.py
+++ b/pymatgen/io/pwmat/inputs.py
@@ -13,6 +13,8 @@ from pymatgen.core import Lattice, Structure
 from pymatgen.symmetry.kpath import KPathSeek
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from pymatgen.util.typing import PathLike
 
 __author__ = "Hanyu Liu"

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -1126,10 +1126,10 @@ class Kpoints(MSONable):
 
         self._style = style
 
-    @staticmethod
-    def automatic(subdivisions):
+    @classmethod
+    def automatic(cls, subdivisions) -> Self:
         """
-        Convenient static constructor for a fully automatic Kpoint grid, with
+        Constructor for a fully automatic Kpoint grid, with
         gamma centered Monkhorst-Pack grids and the number of subdivisions
         along each reciprocal lattice vector determined by the scheme in the
         VASP manual.
@@ -1141,15 +1141,12 @@ class Kpoints(MSONable):
         Returns:
             Kpoints object
         """
-        return Kpoints(
-            "Fully automatic kpoint scheme", 0, style=Kpoints.supported_modes.Automatic, kpts=[[subdivisions]]
-        )
+        return cls("Fully automatic kpoint scheme", 0, style=Kpoints.supported_modes.Automatic, kpts=[[subdivisions]])
 
-    @staticmethod
-    def gamma_automatic(kpts: tuple[int, int, int] = (1, 1, 1), shift: Vector3D = (0, 0, 0)):
+    @classmethod
+    def gamma_automatic(cls, kpts: tuple[int, int, int] = (1, 1, 1), shift: Vector3D = (0, 0, 0)) -> Self:
         """
-        Convenient static constructor for an automatic Gamma centered Kpoint
-        grid.
+        Constructor for an automatic Gamma centered Kpoint grid.
 
         Args:
             kpts: Subdivisions N_1, N_2 and N_3 along reciprocal lattice
@@ -1159,10 +1156,10 @@ class Kpoints(MSONable):
         Returns:
             Kpoints object
         """
-        return Kpoints("Automatic kpoint scheme", 0, Kpoints.supported_modes.Gamma, kpts=[kpts], kpts_shift=shift)
+        return cls("Automatic kpoint scheme", 0, Kpoints.supported_modes.Gamma, kpts=[kpts], kpts_shift=shift)
 
-    @staticmethod
-    def monkhorst_automatic(kpts: tuple[int, int, int] = (2, 2, 2), shift: Vector3D = (0, 0, 0)):
+    @classmethod
+    def monkhorst_automatic(cls, kpts: tuple[int, int, int] = (2, 2, 2), shift: Vector3D = (0, 0, 0)) -> Self:
         """
         Convenient static constructor for an automatic Monkhorst pack Kpoint
         grid.
@@ -1175,10 +1172,10 @@ class Kpoints(MSONable):
         Returns:
             Kpoints object
         """
-        return Kpoints("Automatic kpoint scheme", 0, Kpoints.supported_modes.Monkhorst, kpts=[kpts], kpts_shift=shift)
+        return cls("Automatic kpoint scheme", 0, Kpoints.supported_modes.Monkhorst, kpts=[kpts], kpts_shift=shift)
 
-    @staticmethod
-    def automatic_density(structure: Structure, kppa: float, force_gamma: bool = False):
+    @classmethod
+    def automatic_density(cls, structure: Structure, kppa: float, force_gamma: bool = False) -> Self:
         """
         Returns an automatic Kpoint object based on a structure and a kpoint
         density. Uses Gamma centered meshes for hexagonal cells and face-centered cells,
@@ -1215,10 +1212,10 @@ class Kpoints(MSONable):
         else:
             style = Kpoints.supported_modes.Monkhorst
 
-        return Kpoints(comment, 0, style, [num_div], (0, 0, 0))
+        return cls(comment, 0, style, [num_div], (0, 0, 0))
 
-    @staticmethod
-    def automatic_gamma_density(structure: Structure, kppa: float):
+    @classmethod
+    def automatic_gamma_density(cls, structure: Structure, kppa: float) -> Self:
         """
         Returns an automatic Kpoint object based on a structure and a kpoint
         density. Uses Gamma centered meshes always. For GW.
@@ -1249,10 +1246,10 @@ class Kpoints(MSONable):
         comment = f"pymatgen with grid density = {kppa:.0f} / number of atoms"
 
         n_kpts = 0
-        return Kpoints(comment, n_kpts, style, [n_div], (0, 0, 0))
+        return cls(comment, n_kpts, style, [n_div], (0, 0, 0))
 
-    @staticmethod
-    def automatic_density_by_vol(structure: Structure, kppvol: int, force_gamma: bool = False) -> Kpoints:
+    @classmethod
+    def automatic_density_by_vol(cls, structure: Structure, kppvol: int, force_gamma: bool = False) -> Self:
         """
         Returns an automatic Kpoint object based on a structure and a kpoint
         density per inverse Angstrom^3 of reciprocal cell.
@@ -1270,12 +1267,12 @@ class Kpoints(MSONable):
         """
         vol = structure.lattice.reciprocal_lattice.volume
         kppa = kppvol * vol * len(structure)
-        return Kpoints.automatic_density(structure, kppa, force_gamma=force_gamma)
+        return cls.automatic_density(structure, kppa, force_gamma=force_gamma)
 
-    @staticmethod
+    @classmethod
     def automatic_density_by_lengths(
-        structure: Structure, length_densities: Sequence[float], force_gamma: bool = False
-    ):
+        cls, structure: Structure, length_densities: Sequence[float], force_gamma: bool = False
+    ) -> Self:
         """
         Returns an automatic Kpoint object based on a structure and a k-point
         density normalized by lattice constants.
@@ -1309,10 +1306,10 @@ class Kpoints(MSONable):
         else:
             style = Kpoints.supported_modes.Monkhorst
 
-        return Kpoints(comment, 0, style, [num_div], (0, 0, 0))
+        return cls(comment, 0, style, [num_div], (0, 0, 0))
 
-    @staticmethod
-    def automatic_linemode(divisions, ibz):
+    @classmethod
+    def automatic_linemode(cls, divisions, ibz) -> Self:
         """
         Convenient static constructor for a KPOINTS in mode line_mode.
         gamma centered Monkhorst-Pack grids and the number of subdivisions
@@ -1340,7 +1337,7 @@ class Kpoints(MSONable):
             kpoints.append(ibz.kpath["kpoints"][path[-1]])
             labels.append(path[-1])
 
-        return Kpoints(
+        return cls(
             "Line_mode KPOINTS file",
             style=Kpoints.supported_modes.Line_mode,
             coord_type="Reciprocal",

--- a/pymatgen/phonon/thermal_displacements.py
+++ b/pymatgen/phonon/thermal_displacements.py
@@ -15,15 +15,17 @@ from pymatgen.io.cif import CifFile, CifParser, CifWriter, str2float
 from pymatgen.symmetry.groups import SYMM_DATA
 from pymatgen.util.due import Doi, due
 
-if TYPE_CHECKING:
-    from os import PathLike
-
-    from numpy.typing import ArrayLike
-
 try:
     import phonopy
 except ImportError:
     phonopy = None
+
+if TYPE_CHECKING:
+    from os import PathLike
+
+    from numpy.typing import ArrayLike
+    from typing_extensions import Self
+
 
 __author__ = "J. George"
 __copyright__ = "Copyright 2022, The Materials Project"

--- a/pymatgen/phonon/thermal_displacements.py
+++ b/pymatgen/phonon/thermal_displacements.py
@@ -409,10 +409,13 @@ class ThermalDisplacementMatrices(MSONable):
 
         return np.array(ratios)
 
-    @staticmethod
+    @classmethod
     def from_Ucif(
-        thermal_displacement_matrix_cif: ArrayLike[ArrayLike], structure: Structure, temperature: float | None = None
-    ) -> ThermalDisplacementMatrices:
+        cls,
+        thermal_displacement_matrix_cif: ArrayLike[ArrayLike],
+        structure: Structure,
+        temperature: float | None = None,
+    ) -> Self:
         """Starting from a numpy array, it will convert Ucif values into Ucart values and initialize the class.
 
         Args:
@@ -445,7 +448,7 @@ class ThermalDisplacementMatrices(MSONable):
 
         # get ThermalDisplacementMatrices Object
 
-        return ThermalDisplacementMatrices(
+        return cls(
             thermal_displacement_matrix_cart=thermal_displacement_matrix_cart,
             thermal_displacement_matrix_cif=thermal_displacement_matrix_cif,
             structure=structure,

--- a/pymatgen/transformations/advanced_transformations.py
+++ b/pymatgen/transformations/advanced_transformations.py
@@ -40,14 +40,15 @@ from pymatgen.transformations.standard_transformations import (
 )
 from pymatgen.transformations.transformation_abc import AbstractTransformation
 
-if TYPE_CHECKING:
-    from collections.abc import Iterable, Sequence
-    from typing import Any
-
 try:
     import hiphive
 except ImportError:
     hiphive = None
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+    from typing import Any
+
 
 __author__ = "Shyue Ping Ong, Stephen Dacek, Anubhav Jain, Matthew Horton, Alex Ganose"
 

--- a/pymatgen/transformations/standard_transformations.py
+++ b/pymatgen/transformations/standard_transformations.py
@@ -243,7 +243,7 @@ class SupercellTransformation(AbstractTransformation):
                 number of atoms than the SupercellTransformation with unchanged lattice angles
                 can possibly be found. If such a SupercellTransformation cannot be found easily,
                 the SupercellTransformation with unchanged lattice angles will be returned.
-            max_atoms (int): Maximum number of atoms allowed in the supercell. Defaults to infinity.
+            max_atoms (int): Maximum number of atoms allowed in the supercell. Defaults to -1 for infinity.
 
         Returns:
             SupercellTransformation.

--- a/pymatgen/transformations/standard_transformations.py
+++ b/pymatgen/transformations/standard_transformations.py
@@ -25,6 +25,8 @@ from pymatgen.transformations.site_transformations import PartialRemoveSitesTran
 from pymatgen.transformations.transformation_abc import AbstractTransformation
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from pymatgen.core.sites import PeriodicSite
     from pymatgen.util.typing import SpeciesLike
 

--- a/pymatgen/transformations/standard_transformations.py
+++ b/pymatgen/transformations/standard_transformations.py
@@ -225,10 +225,10 @@ class SupercellTransformation(AbstractTransformation):
         """
         return cls([[scale_a, 0, 0], [0, scale_b, 0], [0, 0, scale_c]])
 
-    @staticmethod
+    @classmethod
     def from_boundary_distance(
-        structure: Structure, min_boundary_dist: float = 6, allow_rotation: bool = False, max_atoms: float = -1
-    ) -> SupercellTransformation:
+        cls, structure: Structure, min_boundary_dist: float = 6, allow_rotation: bool = False, max_atoms: float = -1
+    ) -> Self:
         """Get a SupercellTransformation according to the desired minimum distance between periodic
         boundaries of the resulting supercell.
 
@@ -262,12 +262,12 @@ class SupercellTransformation(AbstractTransformation):
                 min_boundary_dist / np.array([struct_scaled.lattice.d_hkl(plane) for plane in np.eye(3)])
             )
             if sum(min_expand_scaled != 0) == 0 and len(struct_scaled) <= max_atoms:
-                return SupercellTransformation(scaling_matrix)
+                return cls(scaling_matrix)
 
         scaling_matrix = np.eye(3) + np.diag(min_expand)  # type: ignore[assignment]
         struct_scaled = structure.make_supercell(scaling_matrix, in_place=False)
         if len(struct_scaled) <= max_atoms:
-            return SupercellTransformation(scaling_matrix)
+            return cls(scaling_matrix)
 
         msg = f"{max_atoms=} exceeded while trying to solve for supercell. You can try lowering {min_boundary_dist=}"
         if not allow_rotation:

--- a/pymatgen/util/provenance.py
+++ b/pymatgen/util/provenance.py
@@ -76,8 +76,8 @@ class HistoryNode(namedtuple("HistoryNode", ["name", "url", "description"])):
         """Returns: Dict."""
         return {"name": self.name, "url": self.url, "description": self.description}
 
-    @staticmethod
-    def from_dict(dct: dict[str, str]) -> HistoryNode:
+    @classmethod
+    def from_dict(cls, dct: dict[str, str]) -> Self:
         """
         Args:
             dct (dict): Dict representation.
@@ -85,10 +85,10 @@ class HistoryNode(namedtuple("HistoryNode", ["name", "url", "description"])):
         Returns:
             HistoryNode
         """
-        return HistoryNode(dct["name"], dct["url"], dct["description"])
+        return cls(dct["name"], dct["url"], dct["description"])
 
-    @staticmethod
-    def parse_history_node(h_node):
+    @classmethod
+    def parse_history_node(cls, h_node) -> Self:
         """Parses a History Node object from either a dict or a tuple.
 
         Args:
@@ -99,11 +99,11 @@ class HistoryNode(namedtuple("HistoryNode", ["name", "url", "description"])):
             History node.
         """
         if isinstance(h_node, dict):
-            return HistoryNode.from_dict(h_node)
+            return cls.from_dict(h_node)
 
         if len(h_node) != 3:
             raise ValueError(f"Invalid History node, should be dict or (name, version, description) tuple: {h_node}")
-        return HistoryNode(h_node[0], h_node[1], h_node[2])
+        return cls(h_node[0], h_node[1], h_node[2])
 
 
 class Author(namedtuple("Author", ["name", "email"])):
@@ -132,8 +132,8 @@ class Author(namedtuple("Author", ["name", "email"])):
         """
         return cls(dct["name"], dct["email"])
 
-    @staticmethod
-    def parse_author(author):
+    @classmethod
+    def parse_author(cls, author) -> Self:
         """Parses an Author object from either a String, dict, or tuple.
 
         Args:
@@ -149,12 +149,12 @@ class Author(namedtuple("Author", ["name", "email"])):
             m = re.match(r"\s*(.*?)\s*<(.*?@.*?)>\s*", author)
             if not m or m.start() != 0 or m.end() != len(author):
                 raise ValueError(f"Invalid author format! {author}")
-            return Author(m.groups()[0], m.groups()[1])
+            return cls(m.groups()[0], m.groups()[1])
         if isinstance(author, dict):
-            return Author.from_dict(author)
+            return cls.from_dict(author)
         if len(author) != 2:
             raise ValueError(f"Invalid author, should be String or (name, email) tuple: {author}")
-        return Author(author[0], author[1])
+        return cls(author[0], author[1])
 
 
 class StructureNL:


### PR DESCRIPTION
## Summary

Major changes:

- Converted some `staticmethod` to `classmethod`, partially address #3708

Rationale:

These methods create an instance of the Class itself, and should be a `classmethod`, not `staticmethod`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
  - Enhanced class method flexibility across various modules by converting static methods to class methods and updating method signatures for improved inheritance and extensibility.
  - Introduced type hints for return types to ensure type safety and clarity in method definitions.
  - Streamlined code by leveraging class inheritance, making the codebase more extensible and maintainable.
- **Documentation**
  - Updated method signatures in documentation to reflect changes from static to class methods and the introduction of type hints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->