### PR TITLE
Fix import order for `if TYPE_CHECKING:` block

### DIFF
--- a/pymatgen/analysis/chemenv/coordination_environments/voronoi.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/voronoi.py
@@ -11,9 +11,6 @@ import numpy as np
 from monty.json import MSONable
 from scipy.spatial import Voronoi
 
-if TYPE_CHECKING:
-    from typing_extensions import Self
-
 from pymatgen.analysis.chemenv.utils.coordination_geometry_utils import (
     get_lower_and_upper_f,
     rectangle_surface_intersection,
@@ -23,6 +20,9 @@ from pymatgen.analysis.chemenv.utils.defs_utils import AdditionalConditions
 from pymatgen.analysis.chemenv.utils.math_utils import normal_cdf_step
 from pymatgen.core.sites import PeriodicSite
 from pymatgen.core.structure import Structure
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
 
 __author__ = "David Waroquiers"
 __copyright__ = "Copyright 2012, The Materials Project"

--- a/pymatgen/analysis/molecule_matcher.py
+++ b/pymatgen/analysis/molecule_matcher.py
@@ -27,15 +27,15 @@ from scipy.spatial.distance import cdist
 
 from pymatgen.core.structure import Molecule
 
-if TYPE_CHECKING:
-    from typing_extensions import Self
-
 try:
     from openbabel import openbabel
 
     from pymatgen.io.babel import BabelMolAdaptor
 except ImportError:
     openbabel = None
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
 
 
 __author__ = "Xiaohui Qu, Adam Fekete"

--- a/pymatgen/electronic_structure/boltztrap2.py
+++ b/pymatgen/electronic_structure/boltztrap2.py
@@ -49,6 +49,7 @@ try:
 except ImportError:
     raise BoltztrapError("BoltzTraP2 has to be installed and working")
 
+
 __author__ = "Francesco Ricci"
 __copyright__ = "Copyright 2018, The Materials Project"
 __version__ = "1.0"

--- a/pymatgen/io/ase.py
+++ b/pymatgen/io/ase.py
@@ -15,13 +15,6 @@ from monty.json import MontyDecoder, MSONable, jsanitize
 
 from pymatgen.core.structure import Molecule, Structure
 
-if TYPE_CHECKING:
-    from typing import Any
-
-    from numpy.typing import ArrayLike
-
-    from pymatgen.core.structure import SiteCollection
-
 try:
     from ase.atoms import Atoms
     from ase.calculators.singlepoint import SinglePointDFTCalculator
@@ -37,6 +30,13 @@ except ImportError:
         def __init__(self, *args, **kwargs):
             raise no_ase_err
 
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from numpy.typing import ArrayLike
+
+    from pymatgen.core.structure import SiteCollection
 
 __author__ = "Shyue Ping Ong, Andrew S. Rosen"
 __copyright__ = "Copyright 2012, The Materials Project"

--- a/pymatgen/io/lammps/utils.py
+++ b/pymatgen/io/lammps/utils.py
@@ -18,15 +18,16 @@ from pymatgen.io.babel import BabelMolAdaptor
 from pymatgen.io.packmol import PackmolBoxGen
 from pymatgen.util.coord import get_angle
 
+try:
+    from openbabel import pybel
+except ImportError:
+    pybel = None
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from numpy.typing import ArrayLike
 
-try:
-    from openbabel import pybel
-except ImportError:
-    pybel = None
 
 __author__ = "Kiran Mathew, Brandon Wood, Michael Humbert"
 __email__ = "kmathew@lbl.gov"

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -42,10 +42,10 @@ from pymatgen.io.wannier90 import Unk
 from pymatgen.util.io_utils import clean_lines, micro_pyawk
 from pymatgen.util.num import make_symmetric_matrix_from_upper_tri
 
-logger = logging.getLogger(__name__)
-
 if TYPE_CHECKING:
     from typing_extensions import Self
+
+logger = logging.getLogger(__name__)
 
 
 def _parse_parameters(val_type, val):

--- a/pymatgen/phonon/thermal_displacements.py
+++ b/pymatgen/phonon/thermal_displacements.py
@@ -26,7 +26,6 @@ if TYPE_CHECKING:
     from numpy.typing import ArrayLike
     from typing_extensions import Self
 
-
 __author__ = "J. George"
 __copyright__ = "Copyright 2022, The Materials Project"
 __version__ = "0.1"

--- a/pymatgen/symmetry/analyzer.py
+++ b/pymatgen/symmetry/analyzer.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
     from pymatgen.symmetry.groups import CrystalSystem
 
 logger = logging.getLogger(__name__)
+
 LatticeType = Literal["cubic", "hexagonal", "monoclinic", "orthorhombic", "rhombohedral", "tetragonal", "triclinic"]
 
 cite_conventional_cell_algo = due.dcite(

--- a/pymatgen/util/provenance.py
+++ b/pymatgen/util/provenance.py
@@ -14,16 +14,17 @@ from monty.json import MontyDecoder, MontyEncoder
 
 from pymatgen.core.structure import Molecule, Structure
 
-if TYPE_CHECKING:
-    from collections.abc import Sequence
-
-    from typing_extensions import Self
-
 try:
     from pybtex import errors
     from pybtex.database.input import bibtex
 except ImportError:
     pybtex = bibtex = None
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from typing_extensions import Self
+
 
 __author__ = "Anubhav Jain, Shyue Ping Ong"
 __credits__ = "Dan Gunter"

--- a/pymatgen/vis/structure_vtk.py
+++ b/pymatgen/vis/structure_vtk.py
@@ -16,9 +16,6 @@ from monty.serialization import loadfn
 from pymatgen.core import PeriodicSite, Species, Structure
 from pymatgen.util.coord import in_coord_list
 
-if TYPE_CHECKING:
-    from collections.abc import Sequence
-
 try:
     import vtk
     from vtk import vtkInteractorStyleTrackballCamera as TrackballCamera
@@ -26,6 +23,9 @@ except ImportError:
     # VTK not present. The Camera is to set object to avoid errors in unittest.
     vtk = None
     TrackballCamera = object
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 module_dir = os.path.dirname(os.path.abspath(__file__))
 EL_COLORS = loadfn(f"{module_dir}/ElementColorSchemes.yaml")

--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from pymatgen.core import _load_pmg_settings
+
 if TYPE_CHECKING:
     from pathlib import Path
 
     from pytest import MonkeyPatch
 
-from pymatgen.core import _load_pmg_settings
 
 __author__ = "Janosh Riebesell"
 __date__ = "2022-10-21"


### PR DESCRIPTION
## Summary

Major changes:

- Fix import order for `if TYPE_CHECKING:` block: put this type checking import block at the end



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Adjusted import statements and order related to `TYPE_CHECKING` across multiple modules for better code organization.
	- Removed unnecessary lines and added new lines for clarity in file formatting.

- **Chores**
	- Updated import statements for type hints and external libraries in several modules.

- **Style**
	- Improved code style by reorganizing import statements and modifying whitespace.

- **Tests**
	- Enhanced testing capabilities by adding an import statement for settings loading in the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->