### PR TITLE
Define `ElementType` enum in `core/periodic_table.py`

### DIFF
--- a/dev_scripts/chemenv/get_plane_permutations_optimized.py
+++ b/dev_scripts/chemenv/get_plane_permutations_optimized.py
@@ -279,7 +279,7 @@ if __name__ == "__main__":
                 f"Get the explicit optimized permutations for geometry {cg.name!r} (symbol : "
                 f'{cg_symbol!r}) ? ("y" to confirm, "q" to quit)\n'
             )
-            if test not in ["y", "q"]:
+            if test not in ("y", "q"):
                 print("Wrong key, try again")
                 continue
             if test == "y":

--- a/dev_scripts/update_pt_data.py
+++ b/dev_scripts/update_pt_data.py
@@ -162,8 +162,7 @@ def parse_shannon_radii():
             radii[el][charge] = {}
         if sheet[f"C{i}"].value:
             cn = sheet[f"C{i}"].value
-            if cn not in radii[el][charge]:
-                radii[el][charge][cn] = {}
+            radii[el][charge].setdefault(cn, {})
 
         spin = sheet[f"D{i}"].value if sheet[f"D{i}"].value is not None else ""
 

--- a/pymatgen/core/composition.py
+++ b/pymatgen/core/composition.py
@@ -18,7 +18,7 @@ from monty.fractions import gcd, gcd_float
 from monty.json import MSONable
 from monty.serialization import loadfn
 
-from pymatgen.core.periodic_table import DummySpecies, Element, Species, get_el_sp
+from pymatgen.core.periodic_table import DummySpecies, Element, ElementType, Species, get_el_sp
 from pymatgen.core.units import Mass
 from pymatgen.util.string import Stringify, formula_double_format
 
@@ -501,28 +501,10 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
         Returns:
             bool: True if any elements in Composition match category, otherwise False
         """
-        allowed_categories = (
-            "noble_gas",
-            "transition_metal",
-            "post_transition_metal",
-            "rare_earth_metal",
-            "metal",
-            "metalloid",
-            "alkali",
-            "alkaline",
-            "halogen",
-            "chalcogen",
-            "lanthanoid",
-            "actinoid",
-            "quadrupolar",
-            "s-block",
-            "p-block",
-            "d-block",
-            "f-block",
-        )
+        allowed_categories = [category.value for category in ElementType]
 
         if category not in allowed_categories:
-            raise ValueError(f"Please pick a category from: {allowed_categories}")
+            raise ValueError(f"Invalid {category=}, pick from {allowed_categories}")
 
         if "block" in category:
             return any(category[0] in el.block for el in self.elements)

--- a/pymatgen/core/periodic_table.py
+++ b/pymatgen/core/periodic_table.py
@@ -1498,3 +1498,26 @@ def get_el_sp(obj: int | SpeciesLike) -> Element | Species | DummySpecies:
         return DummySpecies.from_str(obj)  # type: ignore
     except Exception:
         raise ValueError(f"Can't parse Element or Species from {obj!r}")
+
+
+@unique
+class ElementType(Enum):
+    """Enum for element types."""
+
+    noble_gas = "noble_gas"  # He, Ne, Ar, Kr, Xe, Rn
+    transition_metal = "transition_metal"  # Sc-Zn, Y-Cd, La-Hg, Ac-Cn
+    post_transition_metal = "post_transition_metal"  # Al, Ga, In, Tl, Sn, Pb, Bi, Po
+    rare_earth_metal = "rare_earth_metal"  # Ce-Lu, Th-Lr
+    metal = "metal"
+    metalloid = "metalloid"  # B, Si, Ge, As, Sb, Te, Po
+    alkali = "alkali"  # Li, Na, K, Rb, Cs, Fr
+    alkaline = "alkaline"  # Be, Mg, Ca, Sr, Ba, Ra
+    halogen = "halogen"  # F, Cl, Br, I, At
+    chalcogen = "chalcogen"  # O, S, Se, Te, Po
+    lanthanoid = "lanthanoid"  # La-Lu
+    actinoid = "actinoid"  # Ac-Lr
+    quadrupolar = "quadrupolar"
+    s_block = "s-block"
+    p_block = "p-block"
+    d_block = "d-block"
+    f_block = "f-block"

--- a/tests/core/test_composition.py
+++ b/tests/core/test_composition.py
@@ -673,11 +673,9 @@ class TestComposition(PymatgenTest):
 
     def test_metallofullerene(self):
         # Test: Parse Metallofullerene formula (e.g. Y3N@C80)
-        formula = "Y3N@C80"
-        sym_dict = {"Y": 3, "N": 1, "C": 80}
-        cmp = Composition(formula)
-        cmp2 = Composition.from_dict(sym_dict)
-        assert cmp == cmp2
+        comp1 = Composition("Y3N@C80")
+        comp2 = Composition({"Y": 3, "N": 1, "C": 80})
+        assert comp1 == comp2
 
     def test_contains_element_type(self):
         formula = "EuTiO3"
@@ -693,34 +691,34 @@ class TestComposition(PymatgenTest):
 
     def test_is_valid(self):
         formula = "NaCl"
-        cmp = Composition(formula)
-        assert cmp.valid
+        comp = Composition(formula)
+        assert comp.valid
 
         formula = "NaClX"
-        cmp = Composition(formula)
-        assert not cmp.valid
+        comp = Composition(formula)
+        assert not comp.valid
 
         with pytest.raises(ValueError, match="Composition is not valid, contains: Na, Cl, X0+"):
             Composition("NaClX", strict=True)
 
     def test_remove_charges(self):
-        cmp1 = Composition({"Al3+": 2.0, "O2-": 3.0})
+        comp1 = Composition({"Al3+": 2.0, "O2-": 3.0})
 
-        cmp2 = Composition({"Al": 2.0, "O": 3.0})
-        assert str(cmp1) != str(cmp2)
+        comp2 = Composition({"Al": 2.0, "O": 3.0})
+        assert str(comp1) != str(comp2)
 
-        cmp1 = cmp1.remove_charges()
-        assert str(cmp1) == str(cmp2)
+        comp1 = comp1.remove_charges()
+        assert str(comp1) == str(comp2)
 
-        cmp1 = cmp1.remove_charges()
-        assert str(cmp1) == str(cmp2)
+        comp1 = comp1.remove_charges()
+        assert str(comp1) == str(comp2)
 
-        cmp1 = Composition({"Fe3+": 2.0, "Fe2+": 3.0, "O2-": 6.0})
-        cmp2 = Composition({"Fe": 5.0, "O": 6.0})
-        assert str(cmp1) != str(cmp2)
+        comp1 = Composition({"Fe3+": 2.0, "Fe2+": 3.0, "O2-": 6.0})
+        comp2 = Composition({"Fe": 5.0, "O": 6.0})
+        assert str(comp1) != str(comp2)
 
-        cmp1 = cmp1.remove_charges()
-        assert str(cmp1) == str(cmp2)
+        comp1 = comp1.remove_charges()
+        assert str(comp1) == str(comp2)
 
     def test_replace(self):
         Fe2O3 = Composition("Fe2O3")

--- a/tests/core/test_composition.py
+++ b/tests/core/test_composition.py
@@ -678,12 +678,22 @@ class TestComposition(PymatgenTest):
         assert comp1 == comp2
 
     def test_contains_element_type(self):
-        formula = "EuTiO3"
-        cmp = Composition(formula)
-        assert cmp.contains_element_type("lanthanoid")
-        assert not cmp.contains_element_type("noble_gas")
-        assert cmp.contains_element_type("f-block")
-        assert not cmp.contains_element_type("s-block")
+        EuTiO3 = Composition("EuTiO3")
+        assert EuTiO3.contains_element_type("lanthanoid") is True
+        assert EuTiO3.contains_element_type("noble_gas") is False
+        assert EuTiO3.contains_element_type("f-block") is True
+        assert EuTiO3.contains_element_type("s-block") is False
+        assert EuTiO3.contains_element_type("alkali") is False
+        NaCl = Composition("NaCl")
+        assert NaCl.contains_element_type("halogen") is True
+        assert NaCl.contains_element_type("alkali") is True
+        assert NaCl.contains_element_type("s-block") is True
+        assert NaCl.contains_element_type("p-block") is True
+        assert NaCl.contains_element_type("d-block") is False
+        assert NaCl.contains_element_type("f-block") is False
+
+        with pytest.raises(ValueError, match="Invalid category='invalid', pick from"):
+            EuTiO3.contains_element_type("invalid")
 
     def test_chemical_system(self):
         assert Composition({"Na": 1, "Cl": 1}).chemical_system == "Cl-Na"

--- a/tests/core/test_periodic_table.py
+++ b/tests/core/test_periodic_table.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import math
 import pickle
 from copy import deepcopy
+from enum import Enum
 
 import numpy as np
 import pytest
 from pytest import approx
 
 from pymatgen.core import DummySpecies, Element, Species, get_el_sp
-from pymatgen.core.periodic_table import ElementBase
+from pymatgen.core.periodic_table import ElementBase, ElementType
 from pymatgen.core.units import Ha_to_eV
 from pymatgen.util.testing import PymatgenTest
 
@@ -603,3 +604,9 @@ def test_get_el_sp():
 
     with pytest.raises(ValueError, match="Can't parse Element or Species from None"):
         get_el_sp(None)
+
+
+def test_element_type():
+    assert isinstance(ElementType.actinoid, Enum)
+    assert isinstance(ElementType.metalloid, Enum)
+    assert len(ElementType) == 17


### PR DESCRIPTION


```py
@unique
class ElementType(Enum):
    """Enum for element types."""

    noble_gas = "noble_gas"  # He, Ne, Ar, Kr, Xe, Rn
    transition_metal = "transition_metal"  # Sc-Zn, Y-Cd, La-Hg, Ac-Cn
    post_transition_metal = "post_transition_metal"  # Al, Ga, In, Tl, Sn, Pb, Bi, Po
    rare_earth_metal = "rare_earth_metal"  # Ce-Lu, Th-Lr
    metal = "metal"
    metalloid = "metalloid"  # B, Si, Ge, As, Sb, Te, Po
    alkali = "alkali"  # Li, Na, K, Rb, Cs, Fr
    alkaline = "alkaline"  # Be, Mg, Ca, Sr, Ba, Ra
    halogen = "halogen"  # F, Cl, Br, I, At
    chalcogen = "chalcogen"  # O, S, Se, Te, Po
    lanthanoid = "lanthanoid"  # La-Lu
    actinoid = "actinoid"  # Ac-Lr
    quadrupolar = "quadrupolar"
    s_block = "s-block"
    p_block = "p-block"
    d_block = "d-block"
    f_block = "f-block"
```

defined as above to avoid breaking changes in `Composition.contains_element_type`

https://github.com/materialsproject/pymatgen/blob/3a49dd918db2b64c48493ac6e1eb837d65930d86/pymatgen/core/composition.py#L492-L512