### PR TITLE
Avoid using `exec` in code

### DIFF
--- a/pymatgen/io/lammps/data.py
+++ b/pymatgen/io/lammps/data.py
@@ -475,7 +475,7 @@ class LammpsData(MSONable):
             charge (int): No. of significant figures to output for
                 charges. Default to 4.
         """
-        with open(filename, mode="w") as file:
+        with open(filename, mode="w", encoding="utf-8") as file:
             file.write(self.get_str(distance=distance, velocity=velocity, charge=charge))
 
     def disassemble(
@@ -721,7 +721,7 @@ class LammpsData(MSONable):
                 name in ["Velocities"] + SECTION_KEYWORDS["topology"] and not seen_atoms
             ):  # Atoms must appear earlier than these
                 raise RuntimeError(f"{err_msg}{name} section appears before Atoms section")
-            body.update({name: section})
+            body[name] = section
 
         err_msg += "Nos. of {} do not match between header and {} section"
         assert len(body["Masses"]) == header["types"]["atom"], err_msg.format("atom types", "Masses")
@@ -783,7 +783,7 @@ class LammpsData(MSONable):
             mol_ids.extend([idx + 1] * len(topo.sites))
             labels.extend(topo.type_by_sites)
             coords.append(topo.sites.cart_coords)
-            charges.extend(topo.charges if topo.charges else [0.0] * len(topo.sites))
+            charges.extend(topo.charges or [0.0] * len(topo.sites))
 
         atoms = pd.DataFrame(np.concatenate(coords), columns=["x", "y", "z"])
         atoms["molecule-ID"] = mol_ids
@@ -1116,7 +1116,7 @@ class ForceField(MSONable):
                 ff_dfs.update(coeffs)
                 self.maps.update(mapper)
 
-        self.force_field = None if len(ff_dfs) == 0 else ff_dfs
+        self.force_field = ff_dfs or None
 
     def _process_nonbond(self) -> dict:
         pair_df = pd.DataFrame(self.nonbond_coeffs)
@@ -1190,7 +1190,7 @@ class ForceField(MSONable):
             "nonbond_coeffs": self.nonbond_coeffs,
             "topo_coeffs": self.topo_coeffs,
         }
-        with open(filename, mode="w") as file:
+        with open(filename, mode="w", encoding="utf-8") as file:
             yaml = YAML()
             yaml.dump(dct, file)
 
@@ -1408,28 +1408,33 @@ class CombinedData(LammpsData):
         return df
 
     @classmethod
-    def from_files(cls, coordinate_file: str, list_of_numbers: list, *filenames) -> Self:
+    def from_files(cls, coordinate_file: str, list_of_numbers: list[int], *filenames: str) -> Self:
         """
         Constructor that parse a series of data file.
 
         Args:
             coordinate_file (str): The filename of xyz coordinates.
-            list_of_numbers (list): A list of numbers specifying counts for each
+            list_of_numbers (list[int]): A list of numbers specifying counts for each
                 clusters parsed from files.
             filenames (str): A series of LAMMPS data filenames in string format.
         """
         names = []
         mols = []
         styles = []
-        coordinates = cls.parse_xyz(filename=coordinate_file)
-        for idx in range(1, len(filenames) + 1):
-            exec(f"cluster{idx} = LammpsData.from_file(filenames[{idx - 1}])")
+        clusters = []
+
+        for idx, filename in enumerate(filenames, start=1):
+            cluster = LammpsData.from_file(filename)
+            clusters.append(cluster)
             names.append(f"cluster{idx}")
-            mols.append(eval(f"cluster{idx}"))
-            styles.append(eval(f"cluster{idx}").atom_style)
-        style = set(styles)
-        assert len(style) == 1, "Files have different atom styles."
-        return cls.from_lammpsdata(mols, names, list_of_numbers, coordinates, style.pop())
+            mols.append(cluster)
+            styles.append(cluster.atom_style)
+
+        if len(set(styles)) != 1:
+            raise ValueError("Files have different atom styles.")
+
+        coordinates = cls.parse_xyz(filename=coordinate_file)
+        return cls.from_lammpsdata(mols, names, list_of_numbers, coordinates, styles.pop())
 
     @classmethod
     def from_lammpsdata(
@@ -1448,12 +1453,11 @@ class CombinedData(LammpsData):
                 columns of ["x", "y", "z"] for coordinates of atoms.
             atom_style (str): Output atom_style. Default to "full".
         """
-        styles = []
-        for mol in mols:
-            styles.append(mol.atom_style)
-        style = set(styles)
-        assert len(style) == 1, "Data have different atom_style."
-        style_return = style.pop()
+        styles = [mol.atom_style for mol in mols]
+
+        assert len(set(styles)) == 1, "Data have different atom_style."
+        style_return = styles.pop()
+
         if atom_style:
             assert atom_style == style_return, "Data have different atom_style as specified."
         return cls(mols, names, list_of_numbers, coordinates, style_return)

--- a/pymatgen/io/lammps/data.py
+++ b/pymatgen/io/lammps/data.py
@@ -1455,11 +1455,13 @@ class CombinedData(LammpsData):
         """
         styles = [mol.atom_style for mol in mols]
 
-        assert len(set(styles)) == 1, "Data have different atom_style."
+        if len(set(styles)) != 1:
+            raise ValueError("Data have different atom_style.")
         style_return = styles.pop()
 
-        if atom_style:
-            assert atom_style == style_return, "Data have different atom_style as specified."
+        if atom_style and atom_style != style_return:
+            raise ValueError("Data have different atom_style as specified.")
+
         return cls(mols, names, list_of_numbers, coordinates, style_return)
 
     def get_str(self, distance: int = 6, velocity: int = 8, charge: int = 4, hybrid: bool = True) -> str:

--- a/pymatgen/io/lammps/outputs.py
+++ b/pymatgen/io/lammps/outputs.py
@@ -113,7 +113,7 @@ def parse_lammps_dumps(file_pattern):
     files = glob(file_pattern)
     if len(files) > 1:
         pattern = file_pattern.replace("*", "([0-9]+)").replace("\\", "\\\\")
-        files = sorted(files, key=lambda f: int(re.match(pattern, f).group(1)))
+        files = sorted(files, key=lambda f: int(re.match(pattern, f)[1]))
 
     for filename in files:
         with zopen(filename, mode="rt") as file:
@@ -171,7 +171,7 @@ def parse_lammps_log(filename: str = "log.lammps") -> list[pd.DataFrame]:
                 data = {}
                 step = re.match(multi_pattern, ts[0])
                 assert step is not None
-                data["Step"] = int(step.group(1))
+                data["Step"] = int(step[1])
                 data.update({k: float(v) for k, v in re.findall(kv_pattern, "".join(ts[1:]))})
                 dicts.append(data)
             df = pd.DataFrame(dicts)


### PR DESCRIPTION
## Summary

- Avoid using `exec`, especially from potentially untrusted source (external filename in this case) to avoid potential security issue (alerted by the `xz` backdoor)
- Minor `sourcery` fixes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Refactor**
	- Improved file handling with explicit encoding specification.
	- Enhanced dictionary update syntax for better clarity and performance.
	- Modified handling of topology charges with a more robust default value approach.
	- Updated force field assignment for clearer code comprehension.
	- Revised file parsing and clustering method for efficiency.
	- Enhanced error handling for various atom styles.
	- Optimized file sorting based on a pattern and accessing matched groups in regular expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->