### PR TITLE
Avoid using `eval`, replace manual offset in `enumerate` and rename single letter variables

### DIFF
--- a/pymatgen/analysis/bond_dissociation.py
+++ b/pymatgen/analysis/bond_dissociation.py
@@ -104,8 +104,8 @@ class BondDissociationEnergies(MSONable):
                 " are less reliable! This is a bad idea!"
             )
             self.bond_pairs = []
-            for ii, bond in enumerate(self.ring_bonds):
-                for jj in range(ii + 1, len(self.ring_bonds)):
+            for ii, bond in enumerate(self.ring_bonds, start=1):
+                for jj in range(ii, len(self.ring_bonds)):
                     bond_pair = [bond, self.ring_bonds[jj]]
                     self.bond_pairs += [bond_pair]
             for bond_pair in self.bond_pairs:

--- a/pymatgen/analysis/chemenv/connectivity/connected_components.py
+++ b/pymatgen/analysis/chemenv/connectivity/connected_components.py
@@ -742,7 +742,11 @@ class ConnectedComponent(MSONable):
         check_centered_connected_subgraph = nx.MultiGraph()
         check_centered_connected_subgraph.add_nodes_from(centered_connected_subgraph.nodes())
         check_centered_connected_subgraph.add_edges_from(
-            [e for e in centered_connected_subgraph.edges(data=True) if np.allclose(e[2]["delta"], np.zeros(3))]
+            [
+                edge
+                for edge in centered_connected_subgraph.edges(data=True)
+                if np.allclose(edge[2]["delta"], np.zeros(3))
+            ]
         )
         if not is_connected(check_centered_connected_subgraph):
             raise RuntimeError("Could not find a centered graph.")

--- a/pymatgen/analysis/chemenv/coordination_environments/coordination_geometries.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/coordination_geometries.py
@@ -854,11 +854,11 @@ class CoordinationGeometry:
             elif len(face) == 4:
                 out += "5\n"
             else:
-                for ii, f in enumerate(face):
+                for ii, f in enumerate(face, start=1):
                     out += "4\n"
                     out += f"{len(_vertices) + iface}\n"
                     out += f"{f}\n"
-                    out += f"{face[np.mod(ii + 1, len(face))]}\n"
+                    out += f"{face[np.mod(ii, len(face))]}\n"
                     out += f"{len(_vertices) + iface}\n"
             if len(face) in [3, 4]:
                 for face_vertex in face:

--- a/pymatgen/analysis/chemenv/coordination_environments/coordination_geometries.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/coordination_geometries.py
@@ -797,7 +797,7 @@ class CoordinationGeometry:
         list of its vertices coordinates.
         """
         coords = [site.coords for site in sites] if permutation is None else [sites[ii].coords for ii in permutation]
-        return [[coords[ii] for ii in f] for f in self._faces]
+        return [[coords[ii] for ii in face] for face in self._faces]
 
     def edges(self, sites, permutation=None, input="sites"):
         """
@@ -814,7 +814,7 @@ class CoordinationGeometry:
         #     coords = [sites[ii].coords for ii in permutation]
         if permutation is not None:
             coords = [coords[ii] for ii in permutation]
-        return [[coords[ii] for ii in e] for e in self._edges]
+        return [[coords[ii] for ii in edge] for edge in self._edges]
 
     def solid_angles(self, permutation=None):
         """

--- a/pymatgen/analysis/chemenv/coordination_environments/structure_environments.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/structure_environments.py
@@ -502,7 +502,7 @@ class StructureEnvironments(MSONable):
                     }
                     site_voronoi_indices = [
                         inb
-                        for inb, voro_nb_dict in enumerate(site_voronoi)
+                        for inb, _voro_nb_dict in enumerate(site_voronoi)
                         if (
                             distance_conditions[idp][inb]
                             and angle_conditions[iap][inb]

--- a/pymatgen/analysis/chemenv/coordination_environments/voronoi.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/voronoi.py
@@ -146,8 +146,8 @@ class DetailedVoronoiContainer(MSONable):
             logging.debug("Please consider increasing voronoi_distance_cutoff")
         t1 = time.process_time()
         logging.debug("Setting up Voronoi list :")
-        for jj, isite in enumerate(indices):
-            logging.debug(f"  - Voronoi analysis for site #{isite} ({jj + 1}/{len(indices)})")
+        for jj, isite in enumerate(indices, start=1):
+            logging.debug(f"  - Voronoi analysis for site #{isite} ({jj}/{len(indices)})")
             site = self.structure[isite]
             neighbors1 = [(site, 0.0, isite)]
             neighbors1.extend(struct_neighbors[isite])

--- a/pymatgen/analysis/chemenv/utils/chemenv_config.py
+++ b/pymatgen/analysis/chemenv/utils/chemenv_config.py
@@ -97,7 +97,7 @@ class ChemEnvConfig:
         self.package_options = self.DEFAULT_PACKAGE_OPTIONS
         print("Choose between the following strategies : ")
         strategies = list(strategies_class_lookup)
-        for idx, strategy in enumerate(strategies, 1):
+        for idx, strategy in enumerate(strategies, start=1):
             print(f" <{idx}> : {strategy}")
         test = input(" ... ")
         self.package_options["default_strategy"] = {

--- a/pymatgen/analysis/chemenv/utils/graph_utils.py
+++ b/pymatgen/analysis/chemenv/utils/graph_utils.py
@@ -268,7 +268,7 @@ class SimpleGraphCycle(MSONable):
         order in the list.
         """
         if edges_are_ordered:
-            nodes = [e[0] for e in edges]
+            nodes = [edge[0] for edge in edges]
             if not all(e1e2[0][1] == e1e2[1][0] for e1e2 in zip(edges, edges[1:])) or edges[-1][1] != edges[0][0]:
                 raise ValueError("Could not construct a cycle from edges.")
         else:

--- a/pymatgen/analysis/chemenv/utils/graph_utils.py
+++ b/pymatgen/analysis/chemenv/utils/graph_utils.py
@@ -490,8 +490,8 @@ def get_all_elementary_cycles(graph):
         edge_idx += 1
     cycles_matrix = np.zeros(shape=(len(cycle_basis), edge_idx), dtype=bool)
     for icycle, cycle in enumerate(cycle_basis):
-        for in1, n1 in enumerate(cycle):
-            n2 = cycle[(in1 + 1) % len(cycle)]
+        for in1, n1 in enumerate(cycle, start=1):
+            n2 = cycle[(in1) % len(cycle)]
             iedge = all_edges_dict[(n1, n2)]
             cycles_matrix[icycle, iedge] = True
 

--- a/pymatgen/analysis/diffraction/tem.py
+++ b/pymatgen/analysis/diffraction/tem.py
@@ -588,7 +588,7 @@ class TEMCalculator(AbstractDiffractionPatternCalculator):
             ),
         ]
         layout = dict(
-            title="2D Diffraction Pattern<br>Beam Direction: " + "".join(str(e) for e in self.beam_direction),
+            title="2D Diffraction Pattern<br>Beam Direction: " + "".join(map(str, self.beam_direction)),
             font={"size": 14, "color": "#7f7f7f"},
             hovermode="closest",
             xaxis={

--- a/pymatgen/analysis/elasticity/elastic.py
+++ b/pymatgen/analysis/elasticity/elastic.py
@@ -276,7 +276,7 @@ class ElasticTensor(NthOrderElasticTensor):
         n_sites = len(structure)
         n_atoms = structure.composition.num_atoms
         site_density = 1e30 * n_sites / structure.volume
-        tot_mass = sum(e.atomic_mass for e in structure.species)
+        tot_mass = sum(spec.atomic_mass for spec in structure.species)
         avg_mass = 1.6605e-27 * tot_mass / n_atoms
         return (
             0.38483
@@ -330,7 +330,7 @@ class ElasticTensor(NthOrderElasticTensor):
             float: Clarke's thermal conductivity (in SI units)
         """
         n_sites = len(structure)
-        tot_mass = sum(e.atomic_mass for e in structure.species)
+        tot_mass = sum(spec.atomic_mass for spec in structure.species)
         n_atoms = structure.composition.num_atoms
         weight = float(structure.composition.weight)
         avg_mass = 1.6605e-27 * tot_mass / n_atoms

--- a/pymatgen/analysis/elasticity/elastic.py
+++ b/pymatgen/analysis/elasticity/elastic.py
@@ -761,8 +761,8 @@ class ElasticTensorExpansion(TensorCollection):
         """
         compl_exp = self.get_compliance_expansion()
         strain = 0
-        for n, compl in enumerate(compl_exp):
-            strain += compl.einsum_sequence([stress] * (n + 1)) / factorial(n + 1)
+        for n, compl in enumerate(compl_exp, start=1):
+            strain += compl.einsum_sequence([stress] * (n)) / factorial(n)
         return strain
 
     def get_effective_ecs(self, strain, order=2):

--- a/pymatgen/analysis/graphs.py
+++ b/pymatgen/analysis/graphs.py
@@ -2156,8 +2156,8 @@ class MoleculeGraph(MSONable):
             unique_frags = []
             for frag in fragments:
                 found = False
-                for f in unique_frags:
-                    if _isomorphic(frag, f):
+                for fragment in unique_frags:
+                    if _isomorphic(frag, fragment):
                         found = True
                         break
                 if not found:

--- a/pymatgen/analysis/graphs.py
+++ b/pymatgen/analysis/graphs.py
@@ -2438,8 +2438,8 @@ class MoleculeGraph(MSONable):
 
         for cycle in cycles_nodes:
             edges = []
-            for idx, itm in enumerate(cycle):
-                edges.append((cycle[idx - 1], itm))
+            for idx, itm in enumerate(cycle, start=-1):
+                edges.append((cycle[idx], itm))
             cycles_edges.append(edges)
 
         return cycles_edges

--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -3337,8 +3337,8 @@ class LocalStructOrderParams:
         if self._geomops2:
             # Compute all (unique) angles and sort the resulting list.
             aij = []
-            for ir, r in enumerate(rij_norm):
-                for j in range(ir + 1, len(rij_norm)):
+            for ir, r in enumerate(rij_norm, start=1):
+                for j in range(ir, len(rij_norm)):
                     aij.append(acos(max(-1.0, min(np.inner(r, rij_norm[j]), 1.0))))
             aijs = sorted(aij)
 

--- a/pymatgen/analysis/magnetism/heisenberg.py
+++ b/pymatgen/analysis/magnetism/heisenberg.py
@@ -187,9 +187,9 @@ class HeisenbergMapper:
         # Keep only up to NNNN and call dists equal if they are within tol
         all_dists = sorted(set(all_dists))
         rm_list = []
-        for idx, d in enumerate(all_dists[:-1]):
-            if abs(d - all_dists[idx + 1]) < tol:
-                rm_list.append(idx + 1)
+        for idx, d in enumerate(all_dists[:-1], start=1):
+            if abs(d - all_dists[idx]) < tol:
+                rm_list.append(idx)
 
         all_dists = [d for idx, d in enumerate(all_dists) if idx not in rm_list]
 
@@ -567,11 +567,10 @@ class HeisenbergMapper:
 
         # Save to a json file if desired
         if filename:
-            if filename.endswith(".json"):
-                dumpfn(igraph, filename)
-            else:
+            if not filename.endswith(".json"):
                 filename += ".json"
-                dumpfn(igraph, filename)
+
+            dumpfn(igraph, filename)
 
         return igraph
 
@@ -729,8 +728,9 @@ class HeisenbergScreener:
         # Check for duplicate / degenerate states (sometimes different initial
         # configs relax to the same state)
         remove_list = []
+        e_tol = 6  # 10^-6 eV/atom tol on energies
+
         for idx, energy in enumerate(energies):
-            e_tol = 6  # 10^-6 eV/atom tol on energies
             energy = round(energy, e_tol)
             if idx not in remove_list:
                 for i_check, e_check in enumerate(energies):
@@ -746,7 +746,7 @@ class HeisenbergScreener:
         #         remove_list.append(idx)
 
         # Remove duplicates
-        if len(remove_list) > 0:
+        if remove_list:
             ordered_structures = [struct for idx, struct in enumerate(ordered_structures) if idx not in remove_list]
             energies = [energy for idx, energy in enumerate(energies) if idx not in remove_list]
 

--- a/pymatgen/analysis/magnetism/heisenberg.py
+++ b/pymatgen/analysis/magnetism/heisenberg.py
@@ -923,7 +923,7 @@ class HeisenbergModel(MSONable):
 
         # Reconstitute the exchange matrix DataFrame
         try:
-            ex_mat = eval(dct["ex_mat"])
+            ex_mat = literal_eval(dct["ex_mat"])
             ex_mat = pd.DataFrame.from_dict(ex_mat)
         except SyntaxError:  # if ex_mat is empty
             ex_mat = pd.DataFrame(columns=["E", "E0"])

--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -2001,9 +2001,9 @@ class ReactionDiagram:
         self.entry2 = entry2
         self.rxn_entries = rxn_entries
         self.labels = {}
-        for idx, entry in enumerate(rxn_entries):
-            self.labels[str(idx + 1)] = entry.attribute
-            entry.name = str(idx + 1)
+        for idx, entry in enumerate(rxn_entries, start=1):
+            self.labels[str(idx)] = entry.attribute
+            entry.name = str(idx)
         self.all_entries = all_entries
         self.pd = pd
 

--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -483,7 +483,7 @@ class PhaseDiagram(MSONable):
                     final_facets.append(facet)
             facets = final_facets
 
-        simplexes = [Simplex(qhull_data[f, :-1]) for f in facets]
+        simplexes = [Simplex(qhull_data[facet, :-1]) for facet in facets]
         self.elements = elements
         return {
             "facets": facets,
@@ -1225,14 +1225,14 @@ class PhaseDiagram(MSONable):
             which each element has a chemical potential set to a given
             value. "absolute" values (i.e., not referenced to element energies)
         """
-        mu_ref = np.array([self.el_refs[e].energy_per_atom for e in self.elements if e != dep_elt])
-        chempot_ranges = self.get_chempot_range_map([e for e in self.elements if e != dep_elt])
+        mu_ref = np.array([self.el_refs[elem].energy_per_atom for elem in self.elements if elem != dep_elt])
+        chempot_ranges = self.get_chempot_range_map([elem for elem in self.elements if elem != dep_elt])
 
         for elem in self.elements:
             if elem not in target_comp.elements:
                 target_comp = target_comp + Composition({elem: 0.0})
 
-        coeff = [-target_comp[e] for e in self.elements if e != dep_elt]
+        coeff = [-target_comp[elem] for elem in self.elements if elem != dep_elt]
 
         for elem, chempots in chempot_ranges.items():
             if elem.composition.reduced_composition == target_comp.reduced_composition:
@@ -1241,7 +1241,7 @@ class PhaseDiagram(MSONable):
                 all_coords = []
                 for simplex in chempots:
                     for v in simplex._coords:
-                        elements = [e for e in self.elements if e != dep_elt]
+                        elements = [elem for elem in self.elements if elem != dep_elt]
                         res = {}
                         for idx, el in enumerate(elements):
                             res[el] = v[idx] + mu_ref[idx]
@@ -1277,26 +1277,26 @@ class PhaseDiagram(MSONable):
             {Element: (mu_min, mu_max)}: Chemical potentials are given in
                 "absolute" values (i.e., not referenced to 0)
         """
-        muref = np.array([self.el_refs[e].energy_per_atom for e in self.elements if e != open_elt])
-        chempot_ranges = self.get_chempot_range_map([e for e in self.elements if e != open_elt])
-        for e in self.elements:
-            if e not in target_comp.elements:
-                target_comp = target_comp + Composition({e: 0.0})
+        mu_ref = np.array([self.el_refs[elem].energy_per_atom for elem in self.elements if elem != open_elt])
+        chempot_ranges = self.get_chempot_range_map([elem for elem in self.elements if elem != open_elt])
+        for elem in self.elements:
+            if elem not in target_comp.elements:
+                target_comp = target_comp + Composition({elem: 0.0})
 
-        coeff = [-target_comp[e] for e in self.elements if e != open_elt]
+        coeff = [-target_comp[elem] for elem in self.elements if elem != open_elt]
         max_open = -float("inf")
         min_open = float("inf")
         max_mus = min_mus = None
 
-        for e, chempots in chempot_ranges.items():
-            if e.composition.reduced_composition == target_comp.reduced_composition:
-                multiplicator = e.composition[open_elt] / target_comp[open_elt]
-                ef = e.energy / multiplicator
+        for elem, chempots in chempot_ranges.items():
+            if elem.composition.reduced_composition == target_comp.reduced_composition:
+                multiplier = elem.composition[open_elt] / target_comp[open_elt]
+                ef = elem.energy / multiplier
                 all_coords = []
                 for s in chempots:
                     for v in s._coords:
                         all_coords.append(v)
-                        test_open = (np.dot(v + muref, coeff) + ef) / target_comp[open_elt]
+                        test_open = (np.dot(v + mu_ref, coeff) + ef) / target_comp[open_elt]
                         if test_open > max_open:
                             max_open = test_open
                             max_mus = v
@@ -1304,11 +1304,11 @@ class PhaseDiagram(MSONable):
                             min_open = test_open
                             min_mus = v
 
-        elems = [e for e in self.elements if e != open_elt]
+        elems = [elem for elem in self.elements if elem != open_elt]
         res = {}
 
         for idx, el in enumerate(elems):
-            res[el] = (min_mus[idx] + muref[idx], max_mus[idx] + muref[idx])
+            res[el] = (min_mus[idx] + mu_ref[idx], max_mus[idx] + mu_ref[idx])
 
         res[open_elt] = (min_open, max_open)
         return res
@@ -1422,12 +1422,14 @@ class GrandPotentialPhaseDiagram(PhaseDiagram):
                 when generated for the first time.
         """
         if elements is None:
-            elements = {els for e in entries for els in e.elements}
+            elements = {els for entry in entries for els in entry.elements}
 
         self.chempots = {get_el_sp(el): u for el, u in chempots.items()}
         elements = set(elements) - set(self.chempots)
 
-        all_entries = [GrandPotPDEntry(e, self.chempots) for e in entries if len(elements.intersection(e.elements)) > 0]
+        all_entries = [
+            GrandPotPDEntry(entry, self.chempots) for entry in entries if len(elements.intersection(entry.elements)) > 0
+        ]
 
         super().__init__(all_entries, elements, computed_data=None)
 
@@ -1450,9 +1452,9 @@ class GrandPotentialPhaseDiagram(PhaseDiagram):
         return {
             "@module": type(self).__module__,
             "@class": type(self).__name__,
-            "all_entries": [e.as_dict() for e in self.all_entries],
+            "all_entries": [entry.as_dict() for entry in self.all_entries],
             "chempots": self.chempots,
-            "elements": [e.as_dict() for e in self.elements],
+            "elements": [entry.as_dict() for entry in self.elements],
         }
 
     @classmethod
@@ -1552,7 +1554,7 @@ class CompoundPhaseDiagram(PhaseDiagram):
         return {
             "@module": type(self).__module__,
             "@class": type(self).__name__,
-            "original_entries": [e.as_dict() for e in self.original_entries],
+            "original_entries": [entry.as_dict() for entry in self.original_entries],
             "terminal_compositions": [c.as_dict() for c in self.terminal_compositions],
             "normalize_terminal_compositions": self.normalize_terminals,
         }
@@ -1616,7 +1618,7 @@ class PatchedPhaseDiagram(PhaseDiagram):
             verbose (bool): Whether to show progress bar during convex hull construction.
         """
         if elements is None:
-            elements = sorted({els for e in entries for els in e.elements})
+            elements = sorted({els for entry in entries for els in entry.elements})
 
         self.dim = len(elements)
 
@@ -1641,7 +1643,10 @@ class PatchedPhaseDiagram(PhaseDiagram):
             raise ValueError(f"There are more terminal elements than dimensions: {extra}")
 
         data = np.array(
-            [[e.composition.get_atomic_fraction(el) for el in elements] + [e.energy_per_atom] for e in min_entries]
+            [
+                [*(entry.composition.get_atomic_fraction(el) for el in elements), entry.energy_per_atom]
+                for entry in min_entries
+            ]
         )
 
         # Use only entries with negative formation energy
@@ -1655,7 +1660,7 @@ class PatchedPhaseDiagram(PhaseDiagram):
         self.qhull_entries = tuple(min_entries[idx] for idx in inds)
         # make qhull spaces frozensets since they become keys to self.pds dict and frozensets are hashable
         # prevent repeating elements in chemical space and avoid the ordering problem (i.e. Fe-O == O-Fe automatically)
-        self._qhull_spaces = tuple(frozenset(e.elements) for e in self.qhull_entries)
+        self._qhull_spaces = tuple(frozenset(entry.elements) for entry in self.qhull_entries)
 
         # Get all unique chemical spaces
         spaces = {s for s in self._qhull_spaces if len(s) > 1}
@@ -1684,7 +1689,7 @@ class PatchedPhaseDiagram(PhaseDiagram):
         # NOTE add el_refs in case no multielement entries are present for el
         _stable_entries = {se for pd in self.pds.values() for se in pd._stable_entries}
         self._stable_entries = tuple(_stable_entries | {*self.el_refs.values()})
-        self._stable_spaces = tuple(frozenset(e.elements) for e in self._stable_entries)
+        self._stable_spaces = tuple(frozenset(entry.elements) for entry in self._stable_entries)
 
     def __repr__(self):
         return f"{type(self).__name__} covering {len(self.spaces)} sub-spaces"
@@ -1715,8 +1720,8 @@ class PatchedPhaseDiagram(PhaseDiagram):
         return {
             "@module": type(self).__module__,
             "@class": type(self).__name__,
-            "all_entries": [e.as_dict() for e in self.all_entries],
-            "elements": [e.as_dict() for e in self.elements],
+            "all_entries": [entry.as_dict() for entry in self.all_entries],
+            "elements": [entry.as_dict() for entry in self.elements],
         }
 
     @classmethod
@@ -1940,7 +1945,7 @@ class ReactionDiagram:
             for face in itertools.combinations(facet, len(facet) - 1):
                 face_entries = [pd.qhull_entries[idx] for idx in face]
 
-                if any(e.reduced_formula in terminal_formulas for e in face_entries):
+                if any(entry.reduced_formula in terminal_formulas for entry in face_entries):
                     continue
 
                 try:
@@ -1993,7 +1998,7 @@ class ReactionDiagram:
                     form_1 = entry1.reduced_formula
                     form_2 = entry2.reduced_formula
                     logger.debug(f"Reactants = {form_1}, {form_2}")
-                    logger.debug(f"Products = {', '.join([e.reduced_formula for e in face_entries])}")
+                    logger.debug(f"Products = {', '.join([entry.reduced_formula for entry in face_entries])}")
 
         rxn_entries = sorted(rxn_entries, key=lambda e: e.name, reverse=True)
 
@@ -2181,7 +2186,7 @@ class PDPlotter:
         self.ternary_style = ternary_style.lower()
 
         self.lines = uniquelines(self._pd.facets) if dim > 1 else [[self._pd.facets[0][0], self._pd.facets[0][0]]]
-        self._min_energy = min(self._pd.get_form_energy_per_atom(e) for e in self._pd.stable_entries)
+        self._min_energy = min(self._pd.get_form_energy_per_atom(entry) for entry in self._pd.stable_entries)
         self._dim = dim
 
         self.plotkwargs = plotkwargs or {
@@ -2726,10 +2731,10 @@ class PDPlotter:
                 c = [e0.composition[el_c], e1.composition[el_c], e2.composition[el_c]]
 
                 e_strs = []
-                for e in (e0, e1, e2):
-                    if hasattr(e, "original_entry"):
-                        e = e.original_entry
-                    e_strs.append(htmlify(e.reduced_formula))
+                for entry in (e0, e1, e2):
+                    if hasattr(entry, "original_entry"):
+                        entry = entry.original_entry
+                    e_strs.append(htmlify(entry.reduced_formula))
 
                 name = f"{e_strs[0]}—{e_strs[1]}—{e_strs[2]}"
 
@@ -2753,7 +2758,7 @@ class PDPlotter:
             coords = np.array(
                 [triangular_coord(c) for c in zip(self._pd.qhull_data[:-1, 0], self._pd.qhull_data[:-1, 1])]
             )
-            energies = np.array([self._pd.get_form_energy_per_atom(e) for e in self._pd.qhull_entries])
+            energies = np.array([self._pd.get_form_energy_per_atom(entry) for entry in self._pd.qhull_entries])
 
             traces.append(
                 go.Mesh3d(
@@ -3481,7 +3486,7 @@ class PDPlotter:
         """
         stable_entry_coords = dict(map(reversed, self.pd_plot_data[1].items()))
 
-        elem_coords = [stable_entry_coords[e] for e in self._pd.el_refs.values()]
+        elem_coords = [stable_entry_coords[entry] for entry in self._pd.el_refs.values()]
 
         # add top and bottom triangle guidelines
         x, y, z = [], [], []

--- a/pymatgen/analysis/pourbaix_diagram.py
+++ b/pymatgen/analysis/pourbaix_diagram.py
@@ -289,7 +289,7 @@ class MultiEntry(PourbaixEntry):
 
         # Attributes that are just lists of entry attributes
         if attr in ["entry_id", "phase_type"]:
-            return [getattr(e, attr) for e in self.entry_list]
+            return [getattr(entry, attr) for entry in self.entry_list]
 
         # normalization_factor, num_atoms should work from superclass
         return self.__getattribute__(attr)
@@ -297,7 +297,7 @@ class MultiEntry(PourbaixEntry):
     @property
     def name(self):
         """MultiEntry name, i. e. the name of each entry joined by ' + '."""
-        return " + ".join(e.name for e in self.entry_list)
+        return " + ".join(entry.name for entry in self.entry_list)
 
     def __repr__(self):
         energy, npH, nPhi, nH2O, entry_id = self.energy, self.npH, self.nPhi, self.nH2O, self.entry_id
@@ -309,7 +309,7 @@ class MultiEntry(PourbaixEntry):
         return {
             "@module": type(self).__module__,
             "@class": type(self).__name__,
-            "entry_list": [e.as_dict() for e in self.entry_list],
+            "entry_list": [entry.as_dict() for entry in self.entry_list],
             "weights": self.weights,
         }
 
@@ -443,7 +443,7 @@ class PourbaixDiagram(MSONable):
         if isinstance(entries[0], MultiEntry):
             self._processed_entries = entries
             # Extract individual entries
-            single_entries = list(set(itertools.chain.from_iterable([e.entry_list for e in entries])))
+            single_entries = list(set(itertools.chain.from_iterable([entry.entry_list for entry in entries])))
             self._unprocessed_entries = single_entries
             self._filtered_entries = single_entries
             self._conc_dict = None
@@ -693,7 +693,7 @@ class PourbaixDiagram(MSONable):
             # Note that we get reduced compositions for solids and non-reduced
             # compositions for ions because ions aren't normalized due to
             # their charge state.
-            entry_comps = [e.composition for e in entry_list]
+            entry_comps = [entry.composition for entry in entry_list]
             rxn = Reaction(entry_comps + dummy_oh, [prod_comp])
             react_coeffs = [-coeff for coeff in rxn.coeffs[: len(entry_list)]]
             all_coeffs = [*react_coeffs, rxn.get_coeff(prod_comp)]
@@ -801,7 +801,7 @@ class PourbaixDiagram(MSONable):
         Returns:
             PourbaixEntry: stable entry at pH, V
         """
-        energies_at_conditions = [e.normalized_energy_at_conditions(pH, V) for e in self.stable_entries]
+        energies_at_conditions = [entry.normalized_energy_at_conditions(pH, V) for entry in self.stable_entries]
         return self.stable_entries[np.argmin(energies_at_conditions)]
 
     def get_decomposition_energy(self, entry, pH, V):
@@ -847,7 +847,7 @@ class PourbaixDiagram(MSONable):
         Returns:
             np.array: minimum Pourbaix energy at conditions
         """
-        all_gs = np.array([e.normalized_energy_at_conditions(pH, V) for e in self.stable_entries])
+        all_gs = np.array([entry.normalized_energy_at_conditions(pH, V) for entry in self.stable_entries])
         return np.min(all_gs, axis=0)
 
     def get_stable_entry(self, pH, V):
@@ -862,7 +862,7 @@ class PourbaixDiagram(MSONable):
             PourbaixEntry | MultiEntry: Pourbaix or multi-entry
                 corresponding to the minimum energy entry at a given pH, V condition
         """
-        all_gs = np.array([e.normalized_energy_at_conditions(pH, V) for e in self.stable_entries])
+        all_gs = np.array([entry.normalized_energy_at_conditions(pH, V) for entry in self.stable_entries])
         return self.stable_entries[np.argmin(all_gs)]
 
     @property
@@ -873,7 +873,7 @@ class PourbaixDiagram(MSONable):
     @property
     def unstable_entries(self):
         """Returns all unstable entries in the Pourbaix diagram."""
-        return [e for e in self.all_entries if e not in self.stable_entries]
+        return [entry for entry in self.all_entries if entry not in self.stable_entries]
 
     @property
     def all_entries(self):
@@ -893,7 +893,7 @@ class PourbaixDiagram(MSONable):
         return {
             "@module": type(self).__module__,
             "@class": type(self).__name__,
-            "entries": [e.as_dict() for e in self._unprocessed_entries],
+            "entries": [entry.as_dict() for entry in self._unprocessed_entries],
             "comp_dict": self._elt_comp,
             "conc_dict": self._conc_dict,
             "filter_solids": self.filter_solids,
@@ -1078,7 +1078,7 @@ def generate_entry_label(entry):
         entry (PourbaixEntry or MultiEntry): entry to get a label for
     """
     if isinstance(entry, MultiEntry):
-        return " + ".join(e.name for e in entry.entry_list)
+        return " + ".join(entry.name for entry in entry.entry_list)
 
     # TODO - a more elegant solution could be added later to Stringify
     # for example, the pattern re.sub(r"([-+][\d\.]*)", r"$^{\1}$", )

--- a/pymatgen/analysis/quasiharmonic.py
+++ b/pymatgen/analysis/quasiharmonic.py
@@ -99,7 +99,7 @@ class QuasiHarmonicDebyeApprox:
                 "The Mie-Gruneisen formulation and anharmonic contribution are circular referenced and "
                 "cannot be used together."
             )
-        self.mass = sum(e.atomic_mass for e in self.structure.species)
+        self.mass = sum(spec.atomic_mass for spec in self.structure.species)
         self.natoms = self.structure.composition.num_atoms
         self.avg_mass = physical_constants["atomic mass constant"][0] * self.mass / self.natoms  # kg
         self.kb = physical_constants["Boltzmann constant in eV/K"][0]

--- a/pymatgen/analysis/quasirrho.py
+++ b/pymatgen/analysis/quasirrho.py
@@ -146,7 +146,7 @@ class QuasiRRHO:
         mult = output.spin_multiplicity
         elec_e = output.final_energy
         mol = output.final_structure
-        vib_freqs = [f["frequency"] for f in output.frequencies[-1]]
+        vib_freqs = [freq["frequency"] for freq in output.frequencies[-1]]
         return cls(mol=mol, frequencies=vib_freqs, energy=elec_e, mult=mult, **kwargs)
 
     @classmethod

--- a/pymatgen/analysis/reaction_calculator.py
+++ b/pymatgen/analysis/reaction_calculator.py
@@ -442,9 +442,9 @@ class ComputedReaction(Reaction):
         self._reactant_entries = reactant_entries
         self._product_entries = product_entries
         self._all_entries = reactant_entries + product_entries
-        reactant_comp = [e.composition.reduced_composition for e in reactant_entries]
+        reactant_comp = [entry.composition.reduced_composition for entry in reactant_entries]
 
-        product_comp = [e.composition.reduced_composition for e in product_entries]
+        product_comp = [entry.composition.reduced_composition for entry in product_entries]
 
         super().__init__(list(reactant_comp), list(product_comp))
 
@@ -455,10 +455,10 @@ class ComputedReaction(Reaction):
         coefficients.
         """
         entries = []
-        for c in self._all_comp:
-            for e in self._all_entries:
-                if e.reduced_formula == c.reduced_formula:
-                    entries.append(e)
+        for comp in self._all_comp:
+            for entry in self._all_entries:
+                if entry.reduced_formula == comp.reduced_formula:
+                    entries.append(entry)
                     break
         return entries
 
@@ -499,8 +499,8 @@ class ComputedReaction(Reaction):
         return {
             "@module": type(self).__module__,
             "@class": type(self).__name__,
-            "reactants": [e.as_dict() for e in self._reactant_entries],
-            "products": [e.as_dict() for e in self._product_entries],
+            "reactants": [entry.as_dict() for entry in self._reactant_entries],
+            "products": [entry.as_dict() for entry in self._product_entries],
         }
 
     @classmethod
@@ -512,6 +512,6 @@ class ComputedReaction(Reaction):
         Returns:
             A ComputedReaction object.
         """
-        reactants = [MontyDecoder().process_decoded(e) for e in dct["reactants"]]
-        products = [MontyDecoder().process_decoded(e) for e in dct["products"]]
+        reactants = [MontyDecoder().process_decoded(entry) for entry in dct["reactants"]]
+        products = [MontyDecoder().process_decoded(entry) for entry in dct["products"]]
         return cls(reactants, products)

--- a/pymatgen/analysis/solar/slme.py
+++ b/pymatgen/analysis/solar/slme.py
@@ -78,7 +78,7 @@ def parse_dielectric_data(data):
         np.array: a Nx3 numpy array. Each row contains the eigenvalues
             for the corresponding row in `data`.
     """
-    return np.array([np.linalg.eig(to_matrix(*e))[0] for e in data])
+    return np.array([np.linalg.eig(to_matrix(*eps))[0] for eps in data])
 
 
 def absorption_coefficient(dielectric):
@@ -116,15 +116,15 @@ def absorption_coefficient(dielectric):
 
 def optics(path=""):
     """Helper function to calculate optical absorption coefficient."""
-    dirgap, indirgap = get_dir_indir_gap(path)
+    dir_gap, indir_gap = get_dir_indir_gap(path)
 
     run = Vasprun(path, occu_tol=1e-2)
     new_en, new_abs = absorption_coefficient(run.dielectric)
     return (
         np.array(new_en, dtype=np.float64),
         np.array(new_abs, dtype=np.float64),
-        dirgap,
-        indirgap,
+        dir_gap,
+        indir_gap,
     )
 
 

--- a/pymatgen/analysis/structure_analyzer.py
+++ b/pymatgen/analysis/structure_analyzer.py
@@ -549,7 +549,7 @@ def sulfide_type(structure):
         neighbors = sorted(neighbors, key=lambda n: n.nn_distance)
         dist = neighbors[0].nn_distance
         coord_elements = [nn.specie for nn in neighbors if nn.nn_distance < dist + 0.4][:4]
-        avg_electroneg = np.mean([e.X for e in coord_elements])
+        avg_electroneg = np.mean([elem.X for elem in coord_elements])
         if avg_electroneg > sulphur.X:
             return "sulfate"
         if avg_electroneg == sulphur.X and sulphur in coord_elements:

--- a/pymatgen/analysis/wulff.py
+++ b/pymatgen/analysis/wulff.py
@@ -450,7 +450,7 @@ class WulffShape:
             cmap = plt.get_cmap(color_set)
             cmap.set_over("0.25")
             cmap.set_under("0.75")
-            bounds = [round(e, 2) for e in e_surf_on_wulff]
+            bounds = [round(ene, 2) for ene in e_surf_on_wulff]
             bounds.append(1.2 * bounds[-1])
             norm = mpl.colors.BoundaryNorm(bounds, cmap.N)
             # display surface energies

--- a/pymatgen/apps/battery/conversion_battery.py
+++ b/pymatgen/apps/battery/conversion_battery.py
@@ -64,11 +64,11 @@ class ConversionElectrode(AbstractElectrode):
         """
         working_ion = Element(working_ion_symbol)
         entry = working_ion_entry = None
-        for e in pd.stable_entries:
-            if e.reduced_formula == comp.reduced_formula:
-                entry = e
-            elif e.is_element and e.reduced_formula == working_ion_symbol:
-                working_ion_entry = e
+        for ent in pd.stable_entries:
+            if ent.reduced_formula == comp.reduced_formula:
+                entry = ent
+            elif ent.is_element and ent.reduced_formula == working_ion_symbol:
+                working_ion_entry = ent
 
         if not allow_unstable and not entry:
             raise ValueError(f"Not stable compound found at composition {comp}.")

--- a/pymatgen/apps/borg/hive.py
+++ b/pymatgen/apps/borg/hive.py
@@ -354,22 +354,22 @@ class GaussianToComputedEntryDrone(AbstractDrone):
             ComputedEntry
         """
         try:
-            gaurun = GaussianOutput(path)
+            gau_run = GaussianOutput(path)
         except Exception as exc:
             logger.debug(f"error in {path}: {exc}")
             return None
         param = {}
         for p in self._parameters:
-            param[p] = getattr(gaurun, p)
+            param[p] = getattr(gau_run, p)
         data = {}
         for d in self._data:
-            data[d] = getattr(gaurun, d)
+            data[d] = getattr(gau_run, d)
         if self._inc_structure:
-            entry = ComputedStructureEntry(gaurun.final_structure, gaurun.final_energy, parameters=param, data=data)
+            entry = ComputedStructureEntry(gau_run.final_structure, gau_run.final_energy, parameters=param, data=data)
         else:
             entry = ComputedEntry(
-                gaurun.final_structure.composition,
-                gaurun.final_energy,
+                gau_run.final_structure.composition,
+                gau_run.final_energy,
                 parameters=param,
                 data=data,
             )
@@ -386,7 +386,7 @@ class GaussianToComputedEntryDrone(AbstractDrone):
             List of valid dir/file paths for assimilation
         """
         parent, _subdirs, files = path
-        return [os.path.join(parent, f) for f in files if os.path.splitext(f)[1] in self._file_extensions]
+        return [os.path.join(parent, file) for file in files if os.path.splitext(file)[1] in self._file_extensions]
 
     def __str__(self):
         return " GaussianToComputedEntryDrone"

--- a/pymatgen/cli/pmg_analyze.py
+++ b/pymatgen/cli/pmg_analyze.py
@@ -104,11 +104,11 @@ def get_magnetizations(dir: str, ion_list: list[int]):
     data = []
     max_row = 0
     for parent, _subdirs, files in os.walk(dir):
-        for f in files:
-            if re.match(r"OUTCAR*", f):
+        for file in files:
+            if re.match(r"OUTCAR*", file):
                 try:
                     row = []
-                    fullpath = os.path.join(parent, f)
+                    fullpath = os.path.join(parent, file)
                     outcar = Outcar(fullpath)
                     mags = outcar.magnetization
                     mags = [m["tot"] for m in mags]

--- a/pymatgen/cli/pmg_potcar.py
+++ b/pymatgen/cli/pmg_potcar.py
@@ -16,11 +16,11 @@ def proc_dir(dirname, proc_file_function):
         dirname (str): Directory name.
         proc_file_function (callable): Callable to execute on directory.
     """
-    for f in os.listdir(dirname):
-        if os.path.isdir(os.path.join(dirname, f)):
-            proc_dir(os.path.join(dirname, f), proc_file_function)
+    for file in os.listdir(dirname):
+        if os.path.isdir(os.path.join(dirname, file)):
+            proc_dir(os.path.join(dirname, file), proc_file_function)
         else:
-            proc_file_function(dirname, f)
+            proc_file_function(dirname, file)
 
 
 def gen_potcar(dirname, filename):

--- a/pymatgen/command_line/enumlib_caller.py
+++ b/pymatgen/command_line/enumlib_caller.py
@@ -243,8 +243,8 @@ class EnumlibAdaptor:
             n_disordered
             * lcm(
                 *(
-                    f.limit_denominator(n_disordered * self.max_cell_size).denominator
-                    for f in map(fractions.Fraction, index_amounts)
+                    fraction.limit_denominator(n_disordered * self.max_cell_size).denominator
+                    for fraction in map(fractions.Fraction, index_amounts)
                 )
             )
         )

--- a/pymatgen/core/interface.py
+++ b/pymatgen/core/interface.py
@@ -563,7 +563,7 @@ class GrainBoundaryGenerator:
 
                 plane = np.matmul(rotation_axis, metric)
                 fractions = [Fraction(x).limit_denominator() for x in plane]
-                least_mul = reduce(lcm, [f.denominator for f in fractions])
+                least_mul = reduce(lcm, [fraction.denominator for fraction in fractions])
                 plane = [int(round(x * least_mul)) for x in plane]
 
         if reduce(gcd, plane) != 1:
@@ -970,7 +970,7 @@ class GrainBoundaryGenerator:
 
                 surface = np.matmul(r_axis, metric)
                 fractions = [Fraction(x).limit_denominator() for x in surface]
-                least_mul = reduce(lcm, [f.denominator for f in fractions])
+                least_mul = reduce(lcm, [fraction.denominator for fraction in fractions])
                 surface = [int(round(x * least_mul)) for x in surface]
 
         if reduce(gcd, surface) != 1:
@@ -1204,7 +1204,7 @@ class GrainBoundaryGenerator:
         # transform surface, r_axis, r_matrix in terms of primitive lattice
         surface = np.matmul(surface, np.transpose(trans_cry))
         fractions = [Fraction(x).limit_denominator() for x in surface]
-        least_mul = reduce(lcm, [f.denominator for f in fractions])
+        least_mul = reduce(lcm, [fraction.denominator for fraction in fractions])
         surface = [int(round(x * least_mul)) for x in surface]
         if reduce(gcd, surface) != 1:
             index = reduce(gcd, surface)
@@ -1227,7 +1227,7 @@ class GrainBoundaryGenerator:
 
         # with the rotation matrix to construct the CSL lattice, check reference for details
         fractions = [Fraction(x).limit_denominator() for x in new_rot[:, kk]]
-        least_mul = reduce(lcm, [f.denominator for f in fractions])
+        least_mul = reduce(lcm, [fraction.denominator for fraction in fractions])
         scale = np.zeros((3, 3))
         scale[hh, hh] = 1
         scale[kk, kk] = least_mul

--- a/pymatgen/core/interface.py
+++ b/pymatgen/core/interface.py
@@ -265,8 +265,8 @@ class GrainBoundary(Structure):
             f"angles: {' '.join(to_str(i) for i in self.lattice.angles)}",
             f"Sites ({len(self)})",
         )
-        for idx, site in enumerate(self):
-            outs.append(f"{idx + 1} {site.species_string} {' '.join(to_str(coord, 12) for coord in site.frac_coords)}")
+        for idx, site in enumerate(self, start=1):
+            outs.append(f"{idx} {site.species_string} {' '.join(to_str(coord, 12) for coord in site.frac_coords)}")
         return "\n".join(outs)
 
     def as_dict(self):

--- a/pymatgen/core/periodic_table.py
+++ b/pymatgen/core/periodic_table.py
@@ -618,10 +618,10 @@ class ElementBase(Enum):
             return 6
         if 89 <= z <= 103:
             return 7
-        for i, size in enumerate(_pt_row_sizes):
+        for i, size in enumerate(_pt_row_sizes, start=1):
             total += size
             if total >= z:
-                return i + 1
+                return i
         return 8
 
     @property

--- a/pymatgen/core/surface.py
+++ b/pymatgen/core/surface.py
@@ -465,8 +465,8 @@ class Slab(Structure):
             f"Sites ({len(self)})",
         ]
 
-        for idx, site in enumerate(self):
-            outs.append(f"{idx + 1} {site.species_string} {' '.join(f'{j:0.6f}'.rjust(12) for j in site.frac_coords)}")
+        for idx, site in enumerate(self, start=1):
+            outs.append(f"{idx} {site.species_string} {' '.join(f'{j:0.6f}'.rjust(12) for j in site.frac_coords)}")
         return "\n".join(outs)
 
     def as_dict(self):

--- a/pymatgen/electronic_structure/boltztrap2.py
+++ b/pymatgen/electronic_structure/boltztrap2.py
@@ -506,9 +506,9 @@ class BztInterpolator:
         if isinstance(kpaths, list) and isinstance(kpoints_lbls_dict, dict):
             kpoints = []
             for kpath in kpaths:
-                for idx, k_pt in enumerate(kpath[:-1]):
+                for idx, k_pt in enumerate(kpath[:-1], start=1):
                     sta = kpoints_lbls_dict[k_pt]
-                    end = kpoints_lbls_dict[kpath[idx + 1]]
+                    end = kpoints_lbls_dict[kpath[idx]]
                     kpoints.append(np.linspace(sta, end, density))
             kpoints = np.concatenate(kpoints)
         else:

--- a/pymatgen/electronic_structure/boltztrap2.py
+++ b/pymatgen/electronic_structure/boltztrap2.py
@@ -108,10 +108,7 @@ class VasprunBSLoader:
 
         self.is_spin_polarized = bs_obj.is_spin_polarized
 
-        if bs_obj.is_spin_polarized:
-            self.dosweight = 1.0
-        else:
-            self.dosweight = 2.0
+        self.dosweight = 1.0 if bs_obj.is_spin_polarized else 2.0
 
         self.lattvec = self.atoms.get_cell().T * units.Angstrom
         self.mommat_all = None  # not implemented yet
@@ -172,7 +169,7 @@ class VasprunBSLoader:
         self.proj = {}
         if self.proj_all:
             if len(self.proj_all) == 2:
-                h = int(len(accepted) / 2)
+                h = len(accepted) // 2
                 self.proj[Spin.up] = self.proj_all[Spin.up][:, accepted[:h], :, :]
                 self.proj[Spin.down] = self.proj_all[Spin.down][:, accepted[h:], :, :]
             elif len(self.proj_all) == 1:
@@ -210,10 +207,7 @@ class BandstructureLoader:
 
         self.kpoints = np.array([kp.frac_coords for kp in bs_obj.kpoints])
 
-        if structure is None:
-            self.structure = bs_obj.structure
-        else:
-            self.structure = structure
+        self.structure = bs_obj.structure if structure is None else structure
 
         self.atoms = AseAtomsAdaptor.get_atoms(self.structure)
         self.proj_all = None
@@ -226,10 +220,7 @@ class BandstructureLoader:
 
         self.is_spin_polarized = bs_obj.is_spin_polarized
 
-        if bs_obj.is_spin_polarized:
-            self.dosweight = 1.0
-        else:
-            self.dosweight = 2.0
+        self.dosweight = 1.0 if bs_obj.is_spin_polarized else 2.0
 
         self.lattvec = self.atoms.get_cell().T * units.Angstrom
         self.mommat_all = mommat  # not implemented yet
@@ -270,7 +261,7 @@ class BandstructureLoader:
         self.proj = {}
         if self.proj_all:
             if len(self.proj_all) == 2:
-                h = int(len(accepted) / 2)
+                h = len(accepted) // 2
                 self.proj[Spin.up] = self.proj_all[Spin.up][:, accepted[:h], :, :]
                 self.proj[Spin.down] = self.proj_all[Spin.down][:, accepted[h:], :, :]
             elif len(self.proj) == 1:

--- a/pymatgen/electronic_structure/boltztrap2.py
+++ b/pymatgen/electronic_structure/boltztrap2.py
@@ -1045,9 +1045,9 @@ class BztPlotter:
         mu = self.bzt_transP.mu_r_eV
 
         if prop_z == "doping" and prop_x == "temp":
-            p_array = eval(f"self.bzt_transP.{props[idx_prop]}_{prop_z}")
+            p_array = getattr(self.bzt_transP, f"{props[idx_prop]}_doping")
         else:
-            p_array = eval(f"self.bzt_transP.{props[idx_prop]}_{prop_x}")
+            p_array = getattr(self.bzt_transP, f"{props[idx_prop]}_{prop_x}")
 
         if ax is None:
             plt.figure(figsize=(10, 8))

--- a/pymatgen/electronic_structure/cohp.py
+++ b/pymatgen/electronic_structure/cohp.py
@@ -441,7 +441,7 @@ class CompleteCohp(Cohp):
         first_cohpobject = self.get_orbital_resolved_cohp(label_list[0], orbital_list[0])
         summed_cohp = first_cohpobject.cohp.copy()
         summed_icohp = first_cohpobject.icohp.copy()
-        for ilabel, label in enumerate(label_list[1:], 1):
+        for ilabel, label in enumerate(label_list[1:], start=1):
             cohp_here = self.get_orbital_resolved_cohp(label, orbital_list[ilabel])
             summed_cohp[Spin.up] = np.sum([summed_cohp[Spin.up], cohp_here.cohp.copy()[Spin.up]], axis=0)
             if Spin.down in summed_cohp:

--- a/pymatgen/electronic_structure/dos.py
+++ b/pymatgen/electronic_structure/dos.py
@@ -558,10 +558,10 @@ class FermiDos(Dos, MSONable):
         fermi = self.efermi  # initialize target fermi
         relative_error = [float("inf")]
         for _ in range(precision):
-            f_range = np.arange(-nstep, nstep + 1) * step + fermi
-            calc_doping = np.array([self.get_doping(f, temperature) for f in f_range])
+            fermi_range = np.arange(-nstep, nstep + 1) * step + fermi
+            calc_doping = np.array([self.get_doping(fermi_lvl, temperature) for fermi_lvl in fermi_range])
             relative_error = np.abs(calc_doping / concentration - 1.0)  # type: ignore
-            fermi = f_range[np.argmin(relative_error)]
+            fermi = fermi_range[np.argmin(relative_error)]
             step /= 10.0
 
         if min(relative_error) > rtol:

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -1048,7 +1048,7 @@ class BSPlotterProjected(BSPlotter):
         e_min, e_max = -4, 4
         if self._bs.is_metal():
             e_min, e_max = -10, 10
-        for idx, el in enumerate(self._bs.structure.elements, 1):
+        for idx, el in enumerate(self._bs.structure.elements, start=1):
             ax = plt.subplot(220 + idx)
             self._make_ticks(ax)
             for b in range(len(data["distances"])):

--- a/pymatgen/entries/mixing_scheme.py
+++ b/pymatgen/entries/mixing_scheme.py
@@ -728,10 +728,10 @@ class MaterialsProjectDFTMixingScheme(Compatibility):
             f"{'entry_id':<12}{'formula':<12}{'spacegroup':<12}{'run_type':<10}{'eV/atom':<8}"
             f"{'corr/atom':<9} {'e_above_hull':<9}"
         )
-        for e in entries:
+        for entry in entries:
             print(
-                f"{e.entry_id:<12}{e.reduced_formula:<12}{e.structure.get_space_group_info()[0]:<12}"
-                f"{e.parameters['run_type']:<10}{e.energy_per_atom:<8.3f}"
-                f"{e.correction / e.composition.num_atoms:<9.3f} {pd.get_e_above_hull(e):<9.3f}"
+                f"{entry.entry_id:<12}{entry.reduced_formula:<12}{entry.structure.get_space_group_info()[0]:<12}"
+                f"{entry.parameters['run_type']:<10}{entry.energy_per_atom:<8.3f}"
+                f"{entry.correction / entry.composition.num_atoms:<9.3f} {pd.get_e_above_hull(entry):<9.3f}"
             )
         return

--- a/pymatgen/ext/matproj_legacy.py
+++ b/pymatgen/ext/matproj_legacy.py
@@ -1220,7 +1220,7 @@ class _MPResterLegacy:
         histories = []
         for e in queen.get_data():
             structures.append(e.structure)
-            m = {
+            meta_dict = {
                 "_vasp": {
                     "parameters": e.parameters,
                     "final_energy": e.energy,
@@ -1231,8 +1231,8 @@ class _MPResterLegacy:
             if "history" in e.parameters:
                 histories.append(e.parameters["history"])
             if master_data is not None:
-                m.update(master_data)
-            metadata.append(m)
+                meta_dict.update(master_data)
+            metadata.append(meta_dict)
         if master_history is not None:
             histories = master_history * len(structures)
 
@@ -1633,8 +1633,8 @@ class _MPResterLegacy:
             n_elements = len(wild_card_els) + len(set(explicit_els))
             parts = re.split(r"(\*|\{.*\})", t)
             parts = [parse_sym(s) for s in parts if s != ""]
-            for f in itertools.product(*parts):
-                comp = Composition("".join(f))
+            for formula in itertools.product(*parts):
+                comp = Composition("".join(formula))
                 if len(comp) == n_elements:
                     # Check for valid Elements in keys.
                     for elem in comp:

--- a/pymatgen/io/abinit/abitimer.py
+++ b/pymatgen/io/abinit/abitimer.py
@@ -69,18 +69,18 @@ class AbinitTimerParser(collections.abc.Iterable):
         Returns:
             parser: the new object
             paths: the list of files found
-            okfiles: list of files that have been parsed successfully.
-                (okfiles == paths) if all files have been parsed.
+            ok_files: list of files that have been parsed successfully.
+                (ok_files == paths) if all files have been parsed.
         """
         paths = []
         for root, _dirs, files in os.walk(top):
-            for f in files:
-                if f.endswith(ext):
-                    paths.append(os.path.join(root, f))
+            for file in files:
+                if file.endswith(ext):
+                    paths.append(os.path.join(root, file))
 
         parser = cls()
-        okfiles = parser.parse(paths)
-        return parser, paths, okfiles
+        ok_files = parser.parse(paths)
+        return parser, paths, ok_files
 
     def __init__(self):
         """Initialize object."""

--- a/pymatgen/io/abinit/inputs.py
+++ b/pymatgen/io/abinit/inputs.py
@@ -550,10 +550,10 @@ def calc_shiftk(structure, symprec: float = 0.01, angle_tolerance=5):
 
         elif lattice_type == "hexagonal":
             # Find the hexagonal axis and set the shift along it.
-            for i, angle in enumerate(structure.lattice.angles):
+            for i, angle in enumerate(structure.lattice.angles, start=1):
                 if abs(angle - 120) < 1.0:
-                    j = (i + 1) % 3
-                    k = (i + 2) % 3
+                    j = i % 3
+                    k = (i + 1) % 3
                     hex_ax = next(ax for ax in range(3) if ax not in [j, k])
                     break
             else:

--- a/pymatgen/io/abinit/pseudos.py
+++ b/pymatgen/io/abinit/pseudos.py
@@ -1560,16 +1560,16 @@ class PseudoTable(collections.abc.Sequence, MSONable):
         pseudos = []
 
         if exts == "all_files":
-            for f in [os.path.join(top, fn) for fn in os.listdir(top)]:
-                if os.path.isfile(f):
+            for filepath in [os.path.join(top, fn) for fn in os.listdir(top)]:
+                if os.path.isfile(filepath):
                     try:
-                        p = Pseudo.from_file(f)
-                        if p:
-                            pseudos.append(p)
+                        pseudo = Pseudo.from_file(filepath)
+                        if pseudo:
+                            pseudos.append(pseudo)
                         else:
-                            logger.info(f"Skipping file {f}")
+                            logger.info(f"Skipping file {filepath}")
                     except Exception:
-                        logger.info(f"Skipping file {f}")
+                        logger.info(f"Skipping file {filepath}")
             if not pseudos:
                 logger.warning(f"No pseudopotentials parsed from folder {top}")
                 return None
@@ -1579,11 +1579,11 @@ class PseudoTable(collections.abc.Sequence, MSONable):
             if exts is None:
                 exts = ("psp8",)
 
-            for p in find_exts(top, exts, exclude_dirs=exclude_dirs):
+            for pseudo in find_exts(top, exts, exclude_dirs=exclude_dirs):
                 try:
-                    pseudos.append(Pseudo.from_file(p))
+                    pseudos.append(Pseudo.from_file(pseudo))
                 except Exception as exc:
-                    logger.critical(f"Error in {p}:\n{exc}")
+                    logger.critical(f"Error in {pseudo}:\n{exc}")
 
         return cls(pseudos).sort_by_z()
 

--- a/pymatgen/io/abinit/pseudos.py
+++ b/pymatgen/io/abinit/pseudos.py
@@ -1092,8 +1092,8 @@ class PseudoParser:
         # Assume file with the abinit header.
         lines = _read_nlines(filename, 80)
 
-        for lineno, line in enumerate(lines):
-            if lineno == 2:
+        for lineno, line in enumerate(lines, start=1):
+            if lineno == 3:
                 try:
                     tokens = line.split()
                     pspcod, _pspxc = map(int, tokens[:2])
@@ -1109,7 +1109,7 @@ class PseudoParser:
 
                 if pspcod == 7:
                     # PAW -> need to know the format pspfmt
-                    tokens = lines[lineno + 1].split()
+                    tokens = lines[lineno].split()
                     pspfmt, _creatorID = tokens[:2]
 
                     ppdesc = ppdesc._replace(format=pspfmt)

--- a/pymatgen/io/abinit/variable.py
+++ b/pymatgen/io/abinit/variable.py
@@ -193,9 +193,9 @@ class InputVariable:
         line = ""
 
         # Format the line declaring the value
-        for i, val in enumerate(values):
-            line += " " + self.format_scalar(val, float_decimal)
-            if self.valperline is not None and (i + 1) % self.valperline == 0:
+        for i, val in enumerate(values, start=1):
+            line += f" {self.format_scalar(val, float_decimal)}"
+            if self.valperline is not None and i % self.valperline == 0:
                 line += "\n"
 
         # Add a carriage return in case of several lines

--- a/pymatgen/io/adf.py
+++ b/pymatgen/io/adf.py
@@ -829,7 +829,7 @@ class AdfOutput:
                         v = list(chunks(map(float, m.group(3).split()), 3))
                         if len(v) != n_next:
                             raise AdfOutputError("Odd Error!")
-                        for i, k in enumerate(range(-n_next, 0, 1)):
+                        for i, k in enumerate(range(-n_next, 0)):
                             self.normal_modes[k].extend(v[i])
                         if int(m.group(1)) == n_atoms:
                             parse_freq = True

--- a/pymatgen/io/common.py
+++ b/pymatgen/io/common.py
@@ -356,9 +356,9 @@ class VolumetricData(MSONable):
                     f"{ang_to_bohr * site.coords[2]} \n"
                 )
 
-            for idx, dat in enumerate(self.data["total"].flatten()):
+            for idx, dat in enumerate(self.data["total"].flatten(), start=1):
                 file.write(f"{' ' if dat > 0 else ''}{dat:.6e} ")
-                if (idx + 1) % 6 == 0:
+                if idx % 6 == 0:
                     file.write("\n")
 
     @classmethod

--- a/pymatgen/io/cp2k/inputs.py
+++ b/pymatgen/io/cp2k/inputs.py
@@ -2404,7 +2404,7 @@ class GaussianTypeOrbitalBasisSet(AtomicMetadata):
     @property
     def nexp(self):
         """Number of exponents."""
-        return [len(e) for e in self.exponents]
+        return [len(exp) for exp in self.exponents]
 
     @typing.no_type_check
     def get_str(self) -> str:

--- a/pymatgen/io/cp2k/inputs.py
+++ b/pymatgen/io/cp2k/inputs.py
@@ -2545,9 +2545,9 @@ class PotentialInfo(MSONable):
             data["nlcc"] = True
         if "GTH" in string:
             data["potential_type"] = "GTH"
-        for idx, char in enumerate(string):
-            if char == "Q" and string[idx + 1].isnumeric():
-                data["electrons"] = int("".join(_ for _ in string[idx + 1 :] if _.isnumeric()))
+        for idx, char in enumerate(string, start=1):
+            if char == "Q" and string[idx].isnumeric():
+                data["electrons"] = int("".join(_ for _ in string[idx:] if _.isnumeric()))
 
         for x in ("LDA", "PADA", "MGGA", "GGA", "HF", "PBE0", "PBE", "BP", "BLYP", "B3LYP", "SCAN"):
             if x in string:

--- a/pymatgen/io/cp2k/outputs.py
+++ b/pymatgen/io/cp2k/outputs.py
@@ -255,9 +255,9 @@ class Cp2kOutput:
                 self.filenames["wfn.bak"].append(w)
             else:
                 self.filenames["wfn"] = w
-        for f in self.filenames.values():
-            if hasattr(f, "sort"):
-                f.sort(key=natural_keys)
+        for filename in self.filenames.values():
+            if hasattr(filename, "sort"):
+                filename.sort(key=natural_keys)
 
     def parse_structures(self, trajectory_file=None, lattice_file=None):
         """

--- a/pymatgen/io/cssr.py
+++ b/pymatgen/io/cssr.py
@@ -47,8 +47,8 @@ class Cssr:
             f"{len(self.structure)} 0",
             f"0 {self.structure.formula}",
         ]
-        for idx, site in enumerate(self.structure):
-            output.append(f"{idx + 1} {site.specie} {site.a:.4f} {site.b:.4f} {site.c:.4f}")
+        for idx, site in enumerate(self.structure, start=1):
+            output.append(f"{idx} {site.specie} {site.a:.4f} {site.b:.4f} {site.c:.4f}")
         return "\n".join(output)
 
     def write_file(self, filename):

--- a/pymatgen/io/feff/inputs.py
+++ b/pymatgen/io/feff/inputs.py
@@ -355,12 +355,12 @@ class Header(MSONable):
 
         output.append(f"TITLE sites: {len(self.struct)}")
 
-        for idx, site in enumerate(self.struct):
+        for idx, site in enumerate(self.struct, start=1):
             if isinstance(self.struct, Structure):
                 coords = [f"{j:0.6f}".rjust(12) for j in site.frac_coords]
             elif isinstance(self.struct, Molecule):
                 coords = [f"{j:0.6f}".rjust(12) for j in site.coords]
-            output.append(f"* {idx + 1} {site.species_string} {' '.join(coords)}")
+            output.append(f"* {idx} {site.species_string} {' '.join(coords)}")
         return "\n".join(output)
 
     def write_file(self, filename="HEADER"):
@@ -493,11 +493,11 @@ class Atoms(MSONable):
                 0,
             ]
         ]
-        for idx, site in enumerate(self._cluster[1:]):
+        for idx, site in enumerate(self._cluster[1:], start=1):
             site_symbol = site.specie.symbol
             ipot = self.pot_dict[site_symbol]
-            dist = self._cluster.get_distance(0, idx + 1)
-            lines += [[f"{site.x}", f"{site.y}", f"{site.z}", ipot, site_symbol, f"{dist}", idx + 1]]
+            dist = self._cluster.get_distance(0, idx)
+            lines += [[f"{site.x}", f"{site.y}", f"{site.z}", ipot, site_symbol, f"{dist}", idx]]
 
         # sort by distance from absorbing atom
         return sorted(lines, key=lambda line: float(line[5]))
@@ -1002,8 +1002,8 @@ def get_atom_map(structure, absorbing_atom=None):
         unique_pot_atoms.remove(absorbing_atom)
 
     atom_map = {}
-    for i, atom in enumerate(unique_pot_atoms):
-        atom_map[atom] = i + 1
+    for i, atom in enumerate(unique_pot_atoms, start=1):
+        atom_map[atom] = i
     return atom_map
 
 

--- a/pymatgen/io/gaussian.py
+++ b/pymatgen/io/gaussian.py
@@ -1138,8 +1138,8 @@ class GaussianOutput:
                     while not re.search(r"^\s-+", line):
                         values = list(map(float, line.split()))
                         data["energies"].append(values[-1])
-                        for i, icname in enumerate(data["coords"]):
-                            data["coords"][icname].append(values[i + 1])
+                        for i, icname in enumerate(data["coords"], start=1):
+                            data["coords"][icname].append(values[i])
                         line = file.readline()
                 else:
                     line = file.readline()

--- a/pymatgen/io/lammps/data.py
+++ b/pymatgen/io/lammps/data.py
@@ -1091,12 +1091,12 @@ class ForceField(MSONable):
             )
 
         index, masses, self.mass_info, atoms_map = [], [], [], {}
-        for idx, m in enumerate(mass_info):
-            index.append(idx + 1)
+        for idx, m in enumerate(mass_info, start=1):
+            index.append(idx)
             mass = map_mass(m[1])
             masses.append(mass)
             self.mass_info.append((m[0], mass))
-            atoms_map[m[0]] = idx + 1
+            atoms_map[m[0]] = idx
         self.masses = pd.DataFrame({"mass": masses}, index=index)
         self.maps = {"Atoms": atoms_map}
 
@@ -1161,9 +1161,9 @@ class ForceField(MSONable):
         atoms = set(np.ravel(list(itertools.chain(*distinct_types))))
         assert atoms.issubset(self.maps["Atoms"]), f"Undefined atom type found in {kw}"
         mapper = {}
-        for i, dt in enumerate(distinct_types):
+        for i, dt in enumerate(distinct_types, start=1):
             for t in dt:
-                mapper[t] = i + 1
+                mapper[t] = i
 
         def process_data(data) -> pd.DataFrame:
             df = pd.DataFrame(data)

--- a/pymatgen/io/lammps/inputs.py
+++ b/pymatgen/io/lammps/inputs.py
@@ -478,9 +478,9 @@ class LammpsInputFile(InputFile):
 
         # Making sure no stage_name of lmp_input_file clash with those from self.
         # If it is the case, we rename them.
-        for i_stage, stage in enumerate(lmp_input_file.stages):
+        for i_stage, stage in enumerate(lmp_input_file.stages, start=1):
             if stage["stage_name"] in self.stages_names:
-                stage["stage_name"] = f"Stage {self.nstages + i_stage + 1} (previously {stage['stage_name']})"
+                stage["stage_name"] = f"Stage {self.nstages + i_stage} (previously {stage['stage_name']})"
 
         # Append the two list of stages
         self.stages += new_list_to_add

--- a/pymatgen/io/lmto.py
+++ b/pymatgen/io/lmto.py
@@ -186,13 +186,13 @@ class LMTOCtrl:
 
         for cat in ["STRUC", "CLASS", "SITE"]:
             fields = struct_lines[cat].split("=")
-            for idx, field in enumerate(fields):
+            for idx, field in enumerate(fields, start=1):
                 token = field.split()[-1]
                 if token == "ALAT":
-                    a_lat = round(float(fields[idx + 1].split()[0]), sigfigs)
+                    a_lat = round(float(fields[idx].split()[0]), sigfigs)
                     structure_tokens["ALAT"] = a_lat
                 elif token == "ATOM":
-                    atom = fields[idx + 1].split()[0]
+                    atom = fields[idx].split()[0]
                     if not bool(re.match("E[0-9]*$", atom)):
                         if cat == "CLASS":
                             structure_tokens["CLASS"].append(atom)
@@ -202,9 +202,9 @@ class LMTOCtrl:
                         pass
                 elif token in ["PLAT", "POS"]:
                     try:
-                        arr = np.array([round(float(i), sigfigs) for i in fields[idx + 1].split()])
+                        arr = np.array([round(float(i), sigfigs) for i in fields[idx].split()])
                     except ValueError:
-                        arr = np.array([round(float(i), sigfigs) for i in fields[idx + 1].split()[:-1]])
+                        arr = np.array([round(float(i), sigfigs) for i in fields[idx].split()[:-1]])
                     if token == "PLAT":
                         structure_tokens["PLAT"] = arr.reshape([3, 3])
                     elif not bool(re.match("E[0-9]*$", atom)):

--- a/pymatgen/io/lobster/outputs.py
+++ b/pymatgen/io/lobster/outputs.py
@@ -1344,8 +1344,8 @@ class Fatband:
                 p_eigenvals[Spin.up] = [
                     [
                         {
-                            str(e): {str(orb): collections.defaultdict(float) for orb in atom_orbital_dict[e]}
-                            for e in atom_names
+                            str(elem): {str(orb): collections.defaultdict(float) for orb in atom_orbital_dict[elem]}
+                            for elem in atom_names
                         }
                         for _ in range(self.number_kpts)
                     ]
@@ -1356,8 +1356,8 @@ class Fatband:
                     p_eigenvals[Spin.down] = [
                         [
                             {
-                                str(e): {str(orb): collections.defaultdict(float) for orb in atom_orbital_dict[e]}
-                                for e in atom_names
+                                str(elem): {str(orb): collections.defaultdict(float) for orb in atom_orbital_dict[elem]}
+                                for elem in atom_names
                             }
                             for _ in range(self.number_kpts)
                         ]

--- a/pymatgen/io/pwmat/outputs.py
+++ b/pymatgen/io/pwmat/outputs.py
@@ -77,7 +77,7 @@ class Movement(MSONable):
         Returns:
             list[Structure]: List of Structure objects for the structure at each ionic step.
         """
-        return [step["atom_config"] for _, step in enumerate(self.ionic_steps)]
+        return [step["atom_config"] for step in self.ionic_steps]
 
     @property
     def e_tots(self) -> np.ndarray:
@@ -87,7 +87,7 @@ class Movement(MSONable):
             np.ndarray: Total energy of of each ionic step structure,
                 with shape of (n_ionic_steps,).
         """
-        return np.array([step["e_tot"] for _, step in enumerate(self.ionic_steps)])
+        return np.array([step["e_tot"] for step in self.ionic_steps])
 
     @property
     def atom_forces(self) -> np.ndarray:
@@ -97,7 +97,7 @@ class Movement(MSONable):
             np.ndarray: The forces on atoms of each ionic step structure,
                 with shape of (n_ionic_steps, n_atoms, 3).
         """
-        return np.array([step["atom_forces"] for _, step in enumerate(self.ionic_steps)])
+        return np.array([step["atom_forces"] for step in self.ionic_steps])
 
     @property
     def e_atoms(self) -> np.ndarray:
@@ -109,7 +109,7 @@ class Movement(MSONable):
             np.ndarray: The individual energy of atoms in each ionic step structure,
                 with shape of (n_ionic_steps, n_atoms).
         """
-        return np.array([step["eatoms"] for _, step in enumerate(self.ionic_steps) if ("eatoms" in step)])
+        return np.array([step["eatoms"] for step in self.ionic_steps if ("eatoms" in step)])
 
     @property
     def virials(self) -> np.ndarray:
@@ -119,7 +119,7 @@ class Movement(MSONable):
             np.ndarray: The virial tensor of each ionic step structure,
                 with shape of (n_ionic_steps, 3, 3)
         """
-        return np.array([step["virial"] for _, step in enumerate(self.ionic_steps) if ("virial" in step)])
+        return np.array([step["virial"] for step in self.ionic_steps if ("virial" in step)])
 
     def _parse_sefv(self) -> list[dict]:
         """

--- a/pymatgen/io/qchem/inputs.py
+++ b/pymatgen/io/qchem/inputs.py
@@ -297,8 +297,8 @@ class QCInput(InputFile):
             (str) String representation of multi job input file.
         """
         multi_job_string = ""
-        for i, job_i in enumerate(job_list):
-            if i < len(job_list) - 1:
+        for i, job_i in enumerate(job_list, start=1):
+            if i < len(job_list):
                 multi_job_string += str(job_i) + "\n@@@\n\n"
             else:
                 multi_job_string += str(job_i)
@@ -682,7 +682,7 @@ class QCInput(InputFile):
         """
         cdft_list = []
         cdft_list.append("$cdft")
-        for ii, state in enumerate(cdft):
+        for ii, state in enumerate(cdft, start=1):
             for constraint in state:
                 types = constraint["types"]
                 cdft_list.append(f"   {constraint['value']}")
@@ -703,7 +703,7 @@ class QCInput(InputFile):
                         cdft_list.append(f"   {coef} {first} {last} {type_string}")
                     else:
                         cdft_list.append(f"   {coef} {first} {last}")
-            if len(cdft) != 1 and ii + 1 < len(state):
+            if len(cdft) != 1 and ii < len(state):
                 cdft_list.append("--------------")
 
         # Ensure that you don't have a line indicating a state that doesn't exist

--- a/pymatgen/io/qchem/utils.py
+++ b/pymatgen/io/qchem/utils.py
@@ -53,7 +53,7 @@ def read_matrix_pattern(header_pattern, footer_pattern, elements_pattern, text, 
     elements = re.findall(elements_pattern, text_between_header_and_footer)
 
     # Apply postprocessing to all the elements
-    return [postprocess(e) for e in elements]
+    return [postprocess(elem) for elem in elements]
 
 
 def read_table_pattern(

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -969,7 +969,7 @@ class Incar(dict, MSONable):
             param_type = incar_params[tag].get("type")
             allowed_values = incar_params[tag].get("values")
 
-            if param_type is not None and not isinstance(val, eval(param_type)):
+            if param_type is not None and type(val).__name__ != param_type:
                 warnings.warn(f"{tag}: {val} is not a {param_type}", BadIncarWarning, stacklevel=2)
 
             # Only check value when it's not None,

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -1420,8 +1420,7 @@ class Kpoints(MSONable):
             patt = re.compile(r"([e0-9.\-]+)\s+([e0-9.\-]+)\s+([e0-9.\-]+)\s*!*\s*(.*)")
             for idx in range(4, len(lines)):
                 line = lines[idx]
-                m = patt.match(line)
-                if m:
+                if m := patt.match(line):
                     _kpts.append([float(m.group(1)), float(m.group(2)), float(m.group(3))])
                     labels.append(m.group(4).strip())
             return cls(
@@ -2167,12 +2166,10 @@ class PotcarSingle:
             if k in ("nentries", "Orbitals", "SHA256", "COPYR"):
                 continue
             hash_str += f"{k}"
-            if isinstance(v, bool):
+            if isinstance(v, (bool, int)):
                 hash_str += f"{v}"
             elif isinstance(v, float):
                 hash_str += f"{v:.3f}"
-            elif isinstance(v, int):
-                hash_str += f"{v}"
             elif isinstance(v, (tuple, list)):
                 for item in v:
                     if isinstance(item, float):
@@ -2465,8 +2462,10 @@ class Potcar(list, MSONable):
         if symbols is not None:
             self.set_symbols(symbols, functional, sym_potcar_map)
 
-    def __iter__(self) -> Iterator[PotcarSingle]:  # boilerplate code. only here to supply
-        # type hint so `for psingle in Potcar()` is correctly inferred as PotcarSingle
+    def __iter__(self) -> Iterator[PotcarSingle]:
+        """Boilerplate code. Only here to supply type hint so
+        `for psingle in Potcar()` is correctly inferred as PotcarSingle
+        """
         return super().__iter__()
 
     def as_dict(self):

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -401,8 +401,8 @@ class Poscar(MSONable):
             except (ValueError, IndexError):
                 # Defaulting to false names.
                 atomic_symbols = []
-                for i, nat in enumerate(n_atoms):
-                    sym = Element.from_Z(i + 1).symbol
+                for i, nat in enumerate(n_atoms, start=1):
+                    sym = Element.from_Z(i).symbol
                     atomic_symbols.extend([sym] * nat)
                 warnings.warn(
                     f"Elements in POSCAR cannot be determined. Defaulting to false names {atomic_symbols}.",

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -4196,8 +4196,8 @@ class Xdatcar:
         format_str = f"{{:.{significant_figures}f}}"
         ionicstep_cnt = 1
         output_cnt = 1
-        for cnt, structure in enumerate(self.structures):
-            ionicstep_cnt = cnt + 1
+        for cnt, structure in enumerate(self.structures, start=1):
+            ionicstep_cnt = cnt
             if ionicstep_end is None:
                 if ionicstep_cnt >= ionicstep_start:
                     lines.append(f"Direct configuration={' ' * (7 - len(str(output_cnt)))}{output_cnt}")

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -118,10 +118,10 @@ def _parse_vasp_array(elem) -> list[list[float]]:
 def _parse_from_incar(filename: str, key: str) -> str | None:
     """Helper function to parse a parameter from the INCAR."""
     dirname = os.path.dirname(filename)
-    for f in os.listdir(dirname):
-        if re.search(r"INCAR", f):
+    for filename in os.listdir(dirname):
+        if re.search(r"INCAR", filename):
             warnings.warn("INCAR found. Using " + key + " from INCAR.")
-            incar = Incar.from_file(os.path.join(dirname, f))
+            incar = Incar.from_file(os.path.join(dirname, filename))
             if key in incar:
                 return incar[key]
             return None
@@ -1383,9 +1383,9 @@ class Vasprun(MSONable):
         lattice = _parse_vasp_array(elem.find("crystal").find("varray"))
         pos = _parse_vasp_array(elem.find("varray"))
         struct = Structure(lattice, self.atomic_symbols, pos)
-        sdyn = elem.find("varray/[@name='selective']")
-        if sdyn:
-            struct.add_site_property("selective_dynamics", _parse_vasp_array(sdyn))
+        selective_dyn = elem.find("varray/[@name='selective']")
+        if selective_dyn:
+            struct.add_site_property("selective_dynamics", _parse_vasp_array(selective_dyn))
         return struct
 
     @staticmethod

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -1014,10 +1014,10 @@ class DictSet(VaspInputSet):
                 wavecar_files = sorted(glob(str(Path(prev_calc_dir) / (fname + "*"))))
                 if wavecar_files:
                     if fname == "WFULL":
-                        for f in wavecar_files:
-                            fname = Path(f).name
+                        for wavecar_file in wavecar_files:
+                            fname = Path(wavecar_file).name
                             fname = fname.split(".")[0]
-                            files_to_transfer[fname] = f
+                            files_to_transfer[fname] = wavecar_file
                     else:
                         files_to_transfer[fname] = str(wavecar_files[-1])
 

--- a/pymatgen/io/xcrysden.py
+++ b/pymatgen/io/xcrysden.py
@@ -90,15 +90,15 @@ class XSF:
         lattice, coords, species = [], [], []
         lines = input_string.splitlines()
 
-        for idx, line in enumerate(lines):
+        for idx, line in enumerate(lines, start=1):
             if "PRIMVEC" in line:
-                for j in range(idx + 1, idx + 4):
+                for j in range(idx, idx + 3):
                     lattice.append([float(c) for c in lines[j].split()])
 
             if "PRIMCOORD" in line:
-                num_sites = int(lines[idx + 1].split()[0])
+                num_sites = int(lines[idx].split()[0])
 
-                for j in range(idx + 2, idx + 2 + num_sites):
+                for j in range(idx + 1, idx + 1 + num_sites):
                     tokens = lines[j].split()
                     Z = Element(tokens[0]).Z if tokens[0].isalpha() else int(tokens[0])
                     species.append(Z)

--- a/pymatgen/io/xr.py
+++ b/pymatgen/io/xr.py
@@ -56,8 +56,8 @@ class Xr:
         ]
         # There are actually 10 more fields per site
         # in a typical xr file from GULP, for example.
-        for idx, site in enumerate(self.structure):
-            output.append(f"{idx + 1} {site.specie} {site.x:.4f} {site.y:.4f} {site.z:.4f}")
+        for idx, site in enumerate(self.structure, start=1):
+            output.append(f"{idx } {site.specie} {site.x:.4f} {site.y:.4f} {site.z:.4f}")
         mat = self.structure.lattice.matrix
         for _ in range(2):
             for j in range(3):

--- a/pymatgen/io/xtb/inputs.py
+++ b/pymatgen/io/xtb/inputs.py
@@ -80,11 +80,11 @@ class CRESTInput(MSONable):
         atoms_for_mtd = [idx for idx in range(1, len(mol) + 1) if idx not in atoms_to_constrain]
         # Write as 1-3,5 instead of 1,2,3,5
         interval_list = [atoms_for_mtd[0]]
-        for idx, val in enumerate(atoms_for_mtd):
+        for idx, val in enumerate(atoms_for_mtd, start=1):
             if val + 1 not in atoms_for_mtd:
                 interval_list.append(val)
-                if idx != len(atoms_for_mtd) - 1:
-                    interval_list.append(atoms_for_mtd[idx + 1])
+                if idx != len(atoms_for_mtd):
+                    interval_list.append(atoms_for_mtd[idx])
         allowed_mtd_string = ",".join(
             [f"{interval_list[i]}-{interval_list[i + 1]}" for i in range(len(interval_list)) if i % 2 == 0]
         )

--- a/pymatgen/io/xtb/outputs.py
+++ b/pymatgen/io/xtb/outputs.py
@@ -72,12 +72,12 @@ class CRESTOutput(MSONable):
             print(f"Input file {split_cmd[0]} not found")
 
         # Get CREST input flags
-        for i, entry in enumerate(split_cmd):
+        for i, entry in enumerate(split_cmd, start=1):
             value = None
             if entry and "-" in entry:
                 option = entry[1:]
-                if i + 1 < len(split_cmd) and "-" not in split_cmd[i + 1]:
-                    value = split_cmd[i + 1]
+                if i < len(split_cmd) and "-" not in split_cmd[i]:
+                    value = split_cmd[i]
                 self.cmd_options[option] = value
         # Get input charge for decorating parsed molecules
         chg = 0

--- a/pymatgen/io/xtb/outputs.py
+++ b/pymatgen/io/xtb/outputs.py
@@ -127,9 +127,9 @@ class CRESTOutput(MSONable):
                 final_rotamer_filename = "crest_rotamers.xyz"
             else:
                 n_rot_files = []
-                for f in os.listdir(self.path):
-                    if "crest_rotamers" in f:
-                        n_rot_file = int(os.path.splitext(f)[0].split("_")[2])
+                for filename in os.listdir(self.path):
+                    if "crest_rotamers" in filename:
+                        n_rot_file = int(os.path.splitext(filename)[0].split("_")[2])
                         n_rot_files.append(n_rot_file)
                 if len(n_rot_files) > 0:
                     final_rotamer_filename = f"crest_rotamers_{max(n_rot_files)}.xyz"

--- a/pymatgen/phonon/plotter.py
+++ b/pymatgen/phonon/plotter.py
@@ -455,7 +455,7 @@ class PhononBSPlotter:
                 the colors will be automatically generated.
         """
         assert self._bs.structure is not None, "Structure is required for get_proj_plot"
-        elements = [e.symbol for e in self._bs.structure.elements]
+        elements = [elem.symbol for elem in self._bs.structure.elements]
         if site_comb == "element":
             assert 2 <= len(elements) <= 4, "the compound must have 2, 3 or 4 unique elements"
             indices: list[list[int]] = [[] for _ in range(len(elements))]
@@ -515,7 +515,7 @@ class PhononBSPlotter:
         if rgb_labels is not None:
             labels = rgb_labels  # type: ignore[assignment]
         elif site_comb == "element":
-            labels = [e.symbol for e in self._bs.structure.elements]
+            labels = [elem.symbol for elem in self._bs.structure.elements]
         else:
             labels = [f"{idx}" for idx in range(len(site_comb))]
         if len(indices) == 2:

--- a/pymatgen/phonon/thermal_displacements.py
+++ b/pymatgen/phonon/thermal_displacements.py
@@ -345,9 +345,9 @@ class ThermalDisplacementMatrices(MSONable):
             file.write("  0.000000   0.000000   0.000000   0.000000   0.000000   0.000000\n")  # error on parameters
             file.write("STRUC\n")
 
-            for isite, site in enumerate(structure):
+            for isite, site in enumerate(structure, start=1):
                 file.write(
-                    f"{isite + 1} {site.species_string} {site.species_string}{isite + 1} 1.0000 {site.frac_coords[0]} "
+                    f"{isite} {site.species_string} {site.species_string}{isite} 1.0000 {site.frac_coords[0]} "
                     f"{site.frac_coords[1]} {site.frac_coords[2]} 1a 1\n"
                 )
                 file.write(" 0.000000 0.000000 0.000000 0.00\n")  # error on positions - zero here

--- a/pymatgen/symmetry/analyzer.py
+++ b/pymatgen/symmetry/analyzer.py
@@ -62,7 +62,7 @@ class SpacegroupAnalyzer:
     Uses spglib to perform various symmetry finding operations.
     """
 
-    def __init__(self, structure: Structure, symprec: float | None = 0.01, angle_tolerance: float = 5.0) -> None:
+    def __init__(self, structure: Structure, symprec: float | None = 0.01, angle_tolerance: float = 5) -> None:
         """
         Args:
             structure (Structure/IStructure): Structure to find symmetry
@@ -73,7 +73,7 @@ class SpacegroupAnalyzer:
                 positions (e.g., structures relaxed with electronic structure
                 codes), a looser tolerance of 0.1 (the value used in Materials
                 Project) is often needed.
-            angle_tolerance (float): Angle tolerance for symmetry finding.
+            angle_tolerance (float): Angle tolerance for symmetry finding. Defaults to 5 degrees.
         """
         self._symprec = symprec
         self._angle_tol = angle_tolerance

--- a/pymatgen/symmetry/kpath.py
+++ b/pymatgen/symmetry/kpath.py
@@ -1507,18 +1507,18 @@ class KPathLatimerMunro(KPathBase):
             # not the face center point (don't need to check it since it's not
             # shared with other facets)
             face_center_ind = facet_as_key_point_inds[-1]
-            for j, ind in enumerate(facet_as_key_point_inds_bndy):
+            for j, ind in enumerate(facet_as_key_point_inds_bndy, start=-1):
                 if (
-                    min(ind, facet_as_key_point_inds_bndy[j - 1]),
-                    max(ind, facet_as_key_point_inds_bndy[j - 1]),
+                    min(ind, facet_as_key_point_inds_bndy[j]),
+                    max(ind, facet_as_key_point_inds_bndy[j]),
                 ) not in key_lines:
                     key_lines.append(
                         (
-                            min(ind, facet_as_key_point_inds_bndy[j - 1]),
-                            max(ind, facet_as_key_point_inds_bndy[j - 1]),
+                            min(ind, facet_as_key_point_inds_bndy[j]),
+                            max(ind, facet_as_key_point_inds_bndy[j]),
                         )
                     )
-                k = j + 1 if j != len(facet_as_key_point_inds_bndy) - 1 else 0
+                k = j + 2 if j != len(facet_as_key_point_inds_bndy) - 2 else 0
                 if (
                     min(ind, facet_as_key_point_inds_bndy[k]),
                     max(ind, facet_as_key_point_inds_bndy[k]),
@@ -2212,7 +2212,7 @@ class KPathLatimerMunro(KPathBase):
                 pop_orbits.append(grouped_inds[idx][worst_next_choice])
                 pop_labels.append(initial_max_cosine_label_inds[grouped_inds[idx][worst_next_choice]])
 
-        if len(unassigned_orbits) != 0:
+        if unassigned_orbits:
             max_cosine_orbits_copy = self._reduce_cosines_array(max_cosine_orbits_copy, pop_orbits, pop_labels)
             unassigned_orbits_labels = self._get_orbit_labels(max_cosine_orbits_copy, key_points_inds_orbits, atol)
             for idx, unassigned_orbit in enumerate(unassigned_orbits):

--- a/pymatgen/util/plotting.py
+++ b/pymatgen/util/plotting.py
@@ -396,12 +396,12 @@ def format_formula(formula: str) -> str:
     """
     formatted_formula = ""
     number_format = ""
-    for idx, char in enumerate(formula):
+    for idx, char in enumerate(formula, start=1):
         if char.isdigit():
             if not number_format:
                 number_format = "_{"
             number_format += char
-            if idx == len(formula) - 1:
+            if idx == len(formula):
                 number_format += "}"
                 formatted_formula += number_format
         else:

--- a/pymatgen/vis/structure_vtk.py
+++ b/pymatgen/vis/structure_vtk.py
@@ -602,11 +602,11 @@ class StructureVis:
                 for site in face:
                     center += site
                 center /= np.float64(len(face))
-                for ii, f in enumerate(face):
+                for ii, f in enumerate(face, start=1):
                     points = vtk.vtkPoints()
                     triangle = vtk.vtkTriangle()
                     points.InsertNextPoint(f[0], f[1], f[2])
-                    ii2 = np.mod(ii + 1, len(face))
+                    ii2 = np.mod(ii, len(face))
                     points.InsertNextPoint(face[ii2][0], face[ii2][1], face[ii2][2])
                     points.InsertNextPoint(center[0], center[1], center[2])
                     for jj in range(3):

--- a/tests/alchemy/test_filters.py
+++ b/tests/alchemy/test_filters.py
@@ -74,7 +74,7 @@ class TestRemoveDuplicatesFilter(TestCase):
     def setUp(self):
         with open(f"{TEST_FILES_DIR}/TiO2_entries.json") as file:
             entries = json.load(file, cls=MontyDecoder)
-        self._struct_list = [e.structure for e in entries]
+        self._struct_list = [entry.structure for entry in entries]
         self._sm = StructureMatcher()
 
     def test_filter(self):
@@ -93,7 +93,7 @@ class TestRemoveExistingFilter(TestCase):
     def setUp(self):
         with open(f"{TEST_FILES_DIR}/TiO2_entries.json") as file:
             entries = json.load(file, cls=MontyDecoder)
-        self._struct_list = [e.structure for e in entries]
+        self._struct_list = [entry.structure for entry in entries]
         self._sm = StructureMatcher()
         self._existing_structures = self._struct_list[:-1]
 

--- a/tests/analysis/chemenv/connectivity/test_connected_components.py
+++ b/tests/analysis/chemenv/connectivity/test_connected_components.py
@@ -122,7 +122,7 @@ class TestConnectedComponent(PymatgenTest):
 
         cc = ConnectedComponent(graph=graph)
         ref_sorted_edges = [[en1, en2], [en1, en3]]
-        sorted_edges = sorted(sorted(e) for e in cc.graph.edges())
+        sorted_edges = sorted(sorted(edge) for edge in cc.graph.edges())
         assert sorted_edges == ref_sorted_edges
 
         cc_from_dict = ConnectedComponent.from_dict(cc.as_dict())
@@ -136,10 +136,10 @@ class TestConnectedComponent(PymatgenTest):
             assert loaded_cc.graph.number_of_nodes() == 3
             assert loaded_cc.graph.number_of_edges() == 2
             assert set(cc.graph.nodes()) == set(loaded_cc.graph.nodes())
-            assert sorted_edges == sorted(sorted(e) for e in loaded_cc.graph.edges())
+            assert sorted_edges == sorted(sorted(edge) for edge in loaded_cc.graph.edges())
 
-            for e in sorted_edges:
-                assert cc.graph[e[0]][e[1]] == loaded_cc.graph[e[0]][e[1]]
+            for edge in sorted_edges:
+                assert cc.graph[edge[0]][edge[1]] == loaded_cc.graph[edge[0]][edge[1]]
 
             for node in loaded_cc.graph.nodes():
                 assert isinstance(node.central_site, PeriodicSite)

--- a/tests/analysis/test_fragmenter.py
+++ b/tests/analysis/test_fragmenter.py
@@ -95,7 +95,7 @@ class TestFragmentMolecule(PymatgenTest):
         )
         assert fragmenter.open_rings is False
         assert fragmenter.opt_steps == 0
-        edges = {(e[0], e[1]): None for e in self.pc_edges}
+        edges = {(edge[0], edge[1]): None for edge in self.pc_edges}
         default_mol_graph = MoleculeGraph.from_edges(self.pc, edges=edges)
         assert fragmenter.mol_graph == default_mol_graph
         assert fragmenter.total_unique_fragments == 20

--- a/tests/analysis/test_graphs.py
+++ b/tests/analysis/test_graphs.py
@@ -569,7 +569,7 @@ class TestMoleculeGraph(TestCase):
 
     def test_construction(self):
         pytest.importorskip("openbabel")
-        edges_frag = {(e[0], e[1]): {"weight": 1.0} for e in self.pc_frag1_edges}
+        edges_frag = {(edge[0], edge[1]): {"weight": 1.0} for edge in self.pc_frag1_edges}
         mol_graph = MoleculeGraph.from_edges(self.pc_frag1, edges_frag)
         # dumpfn(mol_graph.as_dict(), f"{module_dir}/pc_frag1_mg.json")
         ref_mol_graph = loadfn(f"{module_dir}/pc_frag1_mg.json")
@@ -580,7 +580,7 @@ class TestMoleculeGraph(TestCase):
             for ii in range(3):
                 assert mol_graph.graph.nodes[node]["coords"][ii] == ref_mol_graph.graph.nodes[node]["coords"][ii]
 
-        edges_pc = {(e[0], e[1]): {"weight": 1.0} for e in self.pc_edges}
+        edges_pc = {(edge[0], edge[1]): {"weight": 1.0} for edge in self.pc_edges}
         mol_graph = MoleculeGraph.from_edges(self.pc, edges_pc)
         # dumpfn(mol_graph.as_dict(), f"{module_dir}/pc_mg.json")
         ref_mol_graph = loadfn(f"{module_dir}/pc_mg.json")
@@ -784,7 +784,7 @@ class TestMoleculeGraph(TestCase):
                     assert species[j] == str(atom.specie)
 
     def test_build_unique_fragments(self):
-        edges = {(e[0], e[1]): None for e in self.pc_edges}
+        edges = {(edge[0], edge[1]): None for edge in self.pc_edges}
         mol_graph = MoleculeGraph.from_edges(self.pc, edges)
         unique_fragment_dict = mol_graph.build_unique_fragments()
         unique_fragments = [fragment for key in unique_fragment_dict for fragment in unique_fragment_dict[key]]

--- a/tests/analysis/test_phase_diagram.py
+++ b/tests/analysis/test_phase_diagram.py
@@ -351,7 +351,7 @@ class TestPhaseDiagram(PymatgenTest):
     def test_get_phase_separation_energy(self):
         for entry in self.pd.unstable_entries:
             if entry.composition.fractional_composition not in [
-                e.composition.fractional_composition for e in self.pd.stable_entries
+                entry.composition.fractional_composition for entry in self.pd.stable_entries
             ]:
                 assert (
                     self.pd.get_phase_separation_energy(entry) >= 0
@@ -399,7 +399,7 @@ class TestPhaseDiagram(PymatgenTest):
 
         duplicate_entry = PDEntry("Li2O", -14.31361175)
         scaled_dup_entry = PDEntry("Li4O2", -14.31361175 * 2)
-        stable_entry = next(e for e in self.pd.stable_entries if e.name == "Li2O")
+        stable_entry = next(entry for entry in self.pd.stable_entries if entry.name == "Li2O")
 
         assert self.pd.get_phase_separation_energy(duplicate_entry) == self.pd.get_phase_separation_energy(
             stable_entry
@@ -836,11 +836,11 @@ class TestPatchedPhaseDiagram(TestCase):
 class TestReactionDiagram(TestCase):
     def setUp(self):
         self.entries = list(EntrySet.from_csv(f"{module_dir}/reaction_entries_test.csv").entries)
-        for e in self.entries:
-            if e.reduced_formula == "VPO5":
-                entry1 = e
-            elif e.reduced_formula == "H4(CO)3":
-                entry2 = e
+        for entry in self.entries:
+            if entry.reduced_formula == "VPO5":
+                entry1 = entry
+            elif entry.reduced_formula == "H4(CO)3":
+                entry2 = entry
         self.rd = ReactionDiagram(entry1=entry1, entry2=entry2, all_entries=self.entries[2:])
 
     def test_get_compound_pd(self):
@@ -853,7 +853,7 @@ class TestReactionDiagram(TestCase):
             assert Element.C in entry.composition
             assert Element.P in entry.composition
             assert Element.H in entry.composition
-        # formed_formula = [e.reduced_formula for e in self.rd.rxn_entries]
+        # formed_formula = [entry.reduced_formula for entry in self.rd.rxn_entries]
         # expected_formula = [
         #     "V0.12707182P0.12707182H0.0441989C0.03314917O0.66850829",
         #     "V0.125P0.125H0.05C0.0375O0.6625",
@@ -877,11 +877,11 @@ class TestPDPlotter(TestCase):
     def setUp(self):
         entries = list(EntrySet.from_csv(f"{module_dir}/pd_entries_test.csv"))
 
-        elemental_entries = [e for e in entries if e.elements == [Element("Li")]]
+        elemental_entries = [entry for entry in entries if entry.elements == [Element("Li")]]
         self.pd_unary = PhaseDiagram(elemental_entries)
         self.plotter_unary_plotly = PDPlotter(self.pd_unary, backend="plotly")
 
-        entries_LiO = [e for e in entries if "Fe" not in e.composition]
+        entries_LiO = [entry for entry in entries if "Fe" not in entry.composition]
         self.pd_binary = PhaseDiagram(entries_LiO)
         self.plotter_binary_mpl = PDPlotter(self.pd_binary, backend="matplotlib")
         self.plotter_binary_plotly = PDPlotter(self.pd_binary, backend="plotly")

--- a/tests/analysis/test_pourbaix_diagram.py
+++ b/tests/analysis/test_pourbaix_diagram.py
@@ -106,7 +106,7 @@ class TestPourbaixDiagram(TestCase):
         cls.pbx_no_filter = PourbaixDiagram(cls.test_data["Zn"], filter_solids=False)
 
     def test_pourbaix_diagram(self):
-        assert {e.name for e in self.pbx.stable_entries} == {
+        assert {entry.name for entry in self.pbx.stable_entries} == {
             "ZnO(s)",
             "Zn[2+]",
             "ZnHO2[-]",
@@ -114,7 +114,7 @@ class TestPourbaixDiagram(TestCase):
             "Zn(s)",
         }, "List of stable entries does not match"
 
-        assert {e.name for e in self.pbx_no_filter.stable_entries} == {
+        assert {entry.name for entry in self.pbx_no_filter.stable_entries} == {
             "ZnO(s)",
             "Zn[2+]",
             "ZnHO2[-]",
@@ -124,8 +124,8 @@ class TestPourbaixDiagram(TestCase):
             "ZnH(s)",
         }, "List of stable entries for unfiltered pbx does not match"
 
-        pbx_lowconc = PourbaixDiagram(self.test_data["Zn"], conc_dict={"Zn": 1e-8}, filter_solids=True)
-        assert {e.name for e in pbx_lowconc.stable_entries} == {
+        pbx_low_conc = PourbaixDiagram(self.test_data["Zn"], conc_dict={"Zn": 1e-8}, filter_solids=True)
+        assert {entry.name for entry in pbx_low_conc.stable_entries} == {
             "Zn(HO)2(aq)",
             "Zn[2+]",
             "ZnHO2[-]",
@@ -138,9 +138,9 @@ class TestPourbaixDiagram(TestCase):
 
     def test_multicomponent(self):
         # Assure no ions get filtered at high concentration
-        ag_n = [e for e in self.test_data["Ag-Te-N"] if "Te" not in e.composition]
+        ag_n = [entry for entry in self.test_data["Ag-Te-N"] if "Te" not in entry.composition]
         highconc = PourbaixDiagram(ag_n, filter_solids=True, conc_dict={"Ag": 1e-5, "N": 1})
-        entry_sets = [set(e.entry_id) for e in highconc.stable_entries]
+        entry_sets = [set(entry.entry_id) for entry in highconc.stable_entries]
         assert {"mp-124", "ion-17"} in entry_sets
 
         # Binary system
@@ -256,7 +256,7 @@ class TestPourbaixDiagram(TestCase):
     def test_serialization(self):
         dct = self.pbx.as_dict()
         new = PourbaixDiagram.from_dict(dct)
-        assert {e.name for e in new.stable_entries} == {
+        assert {entry.name for entry in new.stable_entries} == {
             "ZnO(s)",
             "Zn[2+]",
             "ZnHO2[-]",
@@ -268,7 +268,7 @@ class TestPourbaixDiagram(TestCase):
         # previously filtered entries being included
         dct = self.pbx_no_filter.as_dict()
         new = PourbaixDiagram.from_dict(dct)
-        assert {e.name for e in new.stable_entries} == {
+        assert {entry.name for entry in new.stable_entries} == {
             "ZnO(s)",
             "Zn[2+]",
             "ZnHO2[-]",

--- a/tests/analysis/test_quasirrho.py
+++ b/tests/analysis/test_quasirrho.py
@@ -50,7 +50,7 @@ class TestQuasiRRHO(TestCase):
         """
         e_final = self.gout.final_energy
         mol = self.gout.final_structure
-        vib_freqs = [f["frequency"] for f in self.gout.frequencies[-1]]
+        vib_freqs = [freq["frequency"] for freq in self.gout.frequencies[-1]]
 
         correct_g = -884.776886
         correct_stot = 141.584080

--- a/tests/analysis/test_reaction_calculator.py
+++ b/tests/analysis/test_reaction_calculator.py
@@ -432,7 +432,7 @@ class TestComputedReaction(TestCase):
                 "correction": -1.864,
             },
         ]
-        entries = [ComputedEntry.from_dict(e) for e in d]
+        entries = [ComputedEntry.from_dict(entry) for entry in d]
         reactants = list(filter(lambda e: e.reduced_formula in ["Li", "O2"], entries))
         prods = list(filter(lambda e: e.reduced_formula == "Li2O2", entries))
 
@@ -447,7 +447,7 @@ class TestComputedReaction(TestCase):
     def test_calculated_reaction_energy_uncertainty_for_nan(self):
         # test that reaction_energy_uncertainty property is nan when the uncertainty
         # for any product/reactant is nan
-        d = [
+        dicts = [
             {
                 "correction": 0,
                 "data": {},
@@ -503,7 +503,7 @@ class TestComputedReaction(TestCase):
                 "correction": -1.864,
             },
         ]
-        entries = [ComputedEntry.from_dict(e) for e in d]
+        entries = [ComputedEntry.from_dict(entry) for entry in dicts]
         reactants = list(filter(lambda e: e.reduced_formula in ["Li", "O2"], entries))
         prods = list(filter(lambda e: e.reduced_formula == "Li2O2", entries))
 

--- a/tests/analysis/test_structure_analyzer.py
+++ b/tests/analysis/test_structure_analyzer.py
@@ -95,11 +95,11 @@ class TestMiscFunction(PymatgenTest):
         assert solid_angle(center, coords) == approx(1.83570965938, abs=1e-7), "Wrong result returned by solid_angle"
 
     def test_contains_peroxide(self):
-        for f in ["LiFePO4", "NaFePO4", "Li3V2(PO4)3", "Li2O"]:
-            assert not contains_peroxide(self.get_structure(f))
+        for formula in ("LiFePO4", "NaFePO4", "Li3V2(PO4)3", "Li2O"):
+            assert not contains_peroxide(self.get_structure(formula))
 
-        for f in ["Li2O2", "K2O2"]:
-            assert contains_peroxide(self.get_structure(f))
+        for formula in ("Li2O2", "K2O2"):
+            assert contains_peroxide(self.get_structure(formula))
 
     def test_oxide_type(self):
         el_li = Element("Li")

--- a/tests/apps/battery/test_conversion_battery.py
+++ b/tests/apps/battery/test_conversion_battery.py
@@ -67,16 +67,18 @@ class TestConversionElectrode(TestCase):
     def test_init(self):
         # both 'LiCoO2' and "FeF3" are using Li+ as working ion; MnO2 is for the multivalent Mg2+ ion
         for formula in self.formulas:
-            c = self.conversion_electrodes[formula]["CE"]
+            conv_electrode = self.conversion_electrodes[formula]["CE"]
 
-            assert len(c.get_sub_electrodes(adjacent_only=True)) == c.num_steps
-            assert len(c.get_sub_electrodes(adjacent_only=False)) == sum(range(1, c.num_steps + 1))
+            assert len(conv_electrode.get_sub_electrodes(adjacent_only=True)) == conv_electrode.num_steps
+            assert len(conv_electrode.get_sub_electrodes(adjacent_only=False)) == sum(
+                range(1, conv_electrode.num_steps + 1)
+            )
             props = self.expected_properties[formula]
 
-            for k, v in props.items():
-                assert getattr(c, f"get_{k}")() == approx(v, abs=1e-2)
+            for key, val in props.items():
+                assert getattr(conv_electrode, f"get_{key}")() == approx(val, abs=1e-2)
 
-            assert {*c.get_summary_dict(print_subelectrodes=True)} == {
+            assert {*conv_electrode.get_summary_dict(print_subelectrodes=True)} == {
                 "adj_pairs",
                 "reactions",
                 "energy_vol",
@@ -98,17 +100,17 @@ class TestConversionElectrode(TestCase):
             }
 
             # try to export/import a voltage pair via a dict
-            pair = c.voltage_pairs[0]
+            pair = conv_electrode.voltage_pairs[0]
             dct = pair.as_dict()
             pair2 = ConversionVoltagePair.from_dict(dct)
             for prop in ["voltage", "mass_charge", "mass_discharge"]:
                 assert getattr(pair, prop) == getattr(pair2, prop), 2
 
             # try to create an electrode from a dict and test methods
-            dct = c.as_dict()
+            dct = conv_electrode.as_dict()
             electrode = ConversionElectrode.from_dict(dct)
-            for k, v in props.items():
-                assert getattr(electrode, "get_" + k)() == approx(v, abs=1e-2)
+            for key, val in props.items():
+                assert getattr(electrode, f"get_{key}")() == approx(val, abs=1e-2)
 
     def test_repr(self):
         conv_electrode = self.conversion_electrodes[self.formulas[0]]["CE"]

--- a/tests/core/test_interface.py
+++ b/tests/core/test_interface.py
@@ -358,8 +358,8 @@ class TestInterface(PymatgenTest):
 
         assert_allclose(interface.gap, 2.0)
 
-        max_sub_c = np.max(np.array([s.frac_coords for s in interface.substrate])[:, 2])
-        min_film_c = np.min(np.array([f.frac_coords for f in interface.film])[:, 2])
+        max_sub_c = np.max(np.array([site.frac_coords for site in interface.substrate])[:, 2])
+        min_film_c = np.min(np.array([site.frac_coords for site in interface.film])[:, 2])
         gap = (min_film_c - max_sub_c) * interface.lattice.c
         assert_allclose(interface.gap, gap)
 
@@ -367,8 +367,8 @@ class TestInterface(PymatgenTest):
 
         assert_allclose(interface.gap, 3.0)
 
-        max_sub_c = np.max(np.array([s.frac_coords for s in interface.substrate])[:, 2])
-        min_film_c = np.min(np.array([f.frac_coords for f in interface.film])[:, 2])
+        max_sub_c = np.max(np.array([site.frac_coords for site in interface.substrate])[:, 2])
+        min_film_c = np.min(np.array([site.frac_coords for site in interface.film])[:, 2])
         gap = (min_film_c - max_sub_c) * interface.lattice.c
         assert_allclose(interface.gap, gap)
 

--- a/tests/core/test_trajectory.py
+++ b/tests/core/test_trajectory.py
@@ -183,7 +183,7 @@ class TestTrajectory(PymatgenTest):
     def test_frame_properties(self):
         lattice, species, coords = self._get_lattice_species_and_coords()
 
-        props = [{"energy_per_atom": e} for e in [-3.0001, -3.0971, -3.0465]]
+        props = [{"energy_per_atom": ene} for ene in [-3.0001, -3.0971, -3.0465]]
 
         traj = Trajectory(lattice=lattice, species=species, coords=coords, frame_properties=props)
 
@@ -196,7 +196,9 @@ class TestTrajectory(PymatgenTest):
 
         species, coords, charge, spin = self._get_species_and_coords()
 
-        props = [{"SCF_energy_in_the_final_basis_set": e} for e in [-113.3256885788, -113.3260019471, -113.326006415]]
+        props = [
+            {"SCF_energy_in_the_final_basis_set": ene} for ene in [-113.3256885788, -113.3260019471, -113.326006415]
+        ]
 
         traj = Trajectory(
             species=species,
@@ -382,7 +384,7 @@ class TestTrajectory(PymatgenTest):
         pressure_2 = [2, 2.5, 2.5]
 
         # energy only properties
-        props_1 = [{"energy": e} for e in energy_1]
+        props_1 = [{"energy": ene} for ene in energy_1]
         traj_1 = Trajectory(lattice=lattice, species=species, coords=coords, frame_properties=props_1)
 
         # energy and pressure properties

--- a/tests/electronic_structure/test_dos.py
+++ b/tests/electronic_structure/test_dos.py
@@ -61,7 +61,7 @@ class TestFermiDos(TestCase):
         T = 300
         fermi0 = self.dos.efermi
         fermi_range = [fermi0 - 0.5, fermi0, fermi0 + 2.0, fermi0 + 2.2]
-        dopings = [self.dos.get_doping(fermi_level=f, temperature=T) for f in fermi_range]
+        dopings = [self.dos.get_doping(fermi_level=fermi_lvl, temperature=T) for fermi_lvl in fermi_range]
         ref_dopings = [3.48077e21, 1.9235e18, -2.6909e16, -4.8723e19]
         for i, c_ref in enumerate(ref_dopings):
             assert abs(dopings[i] / c_ref - 1.0) <= 0.01

--- a/tests/electronic_structure/test_plotter.py
+++ b/tests/electronic_structure/test_plotter.py
@@ -138,7 +138,7 @@ class TestBSPlotter(PymatgenTest):
         assert (
             len(self.plotter.bs_plot_data()["distances"][0]) == 16
         ), "wrong number of distances in the first sequence of branches"
-        assert sum(len(e) for e in self.plotter.bs_plot_data()["distances"]) == 160, "wrong number of distances"
+        assert sum(len(dist) for dist in self.plotter.bs_plot_data()["distances"]) == 160, "wrong number of distances"
 
         length = len(self.plotter.bs_plot_data(split_branches=False)["distances"][0])
         assert length == 144, "wrong number of distances in the first sequence of branches"

--- a/tests/entries/test_entry_tools.py
+++ b/tests/entries/test_entry_tools.py
@@ -70,7 +70,7 @@ class TestEntrySet(PymatgenTest):
 
         # Check if ground states have the lowest energy per atom for each composition
         for gs in ground_states:
-            entries_with_same_comp = [
+            same_comp_entries = [
                 ent for ent in self.entry_set if ent.composition.reduced_formula == gs.composition.reduced_formula
             ]
-            assert gs.energy_per_atom <= min(e.energy_per_atom for e in entries_with_same_comp)
+            assert gs.energy_per_atom <= min(entry.energy_per_atom for entry in same_comp_entries)

--- a/tests/entries/test_mixing_scheme.py
+++ b/tests/entries/test_mixing_scheme.py
@@ -420,7 +420,7 @@ def ms_gga_1_scan(ms_complete):
     ground state of SnBr2 (r2scan-4).
     """
     gga_entries = ms_complete.gga_entries
-    scan_entries = [e for e in ms_complete.scan_entries if e.entry_id == "r2scan-4"]
+    scan_entries = [entry for entry in ms_complete.scan_entries if entry.entry_id == "r2scan-4"]
 
     row_list = [
         ["Br", 64, 4, True, "gga-3", None, "GGA", None, 0.0, np.nan, 0.0, np.nan],
@@ -472,7 +472,7 @@ def ms_gga_2_scan_same(ms_complete):
     ground state and one unstable polymorph of SnBr2 (r2scan-4 and r2scan-6).
     """
     gga_entries = ms_complete.gga_entries
-    scan_entries = [e for e in ms_complete.scan_entries if e.entry_id in ["r2scan-4", "r2scan-6"]]
+    scan_entries = [entry for entry in ms_complete.scan_entries if entry.entry_id in ["r2scan-4", "r2scan-6"]]
 
     row_list = [
         ["Br", 64, 4, True, "gga-3", None, "GGA", None, 0.0, np.nan, 0.0, np.nan],
@@ -496,7 +496,7 @@ def ms_gga_2_scan_diff_match(ms_complete):
     r2scan-4 and r2scan-7.
     """
     gga_entries = ms_complete.gga_entries
-    scan_entries = [e for e in ms_complete.scan_entries if e.entry_id in ["r2scan-4", "r2scan-7"]]
+    scan_entries = [entry for entry in ms_complete.scan_entries if entry.entry_id in ["r2scan-4", "r2scan-7"]]
 
     row_list = [
         ["Br", 64, 4, True, "gga-3", None, "GGA", None, 0.0, np.nan, 0.0, np.nan],
@@ -519,7 +519,7 @@ def ms_gga_2_scan_diff_no_match(ms_complete):
     that does not match any GGA material (r2scan-8).
     """
     gga_entries = ms_complete.gga_entries
-    scan_entries = [e for e in ms_complete.scan_entries if e.entry_id == "r2scan-4"]
+    scan_entries = [entry for entry in ms_complete.scan_entries if entry.entry_id == "r2scan-4"]
     scan_entries.append(
         ComputedStructureEntry(
             Structure(
@@ -560,7 +560,9 @@ def ms_all_gga_scan_gs(ms_complete):
     ground states, but no others.
     """
     gga_entries = ms_complete.gga_entries
-    scan_entries = [e for e in ms_complete.scan_entries if e.entry_id in ["r2scan-1", "r2scan-3", "r2scan-4"]]
+    scan_entries = [
+        entry for entry in ms_complete.scan_entries if entry.entry_id in ["r2scan-1", "r2scan-3", "r2scan-4"]
+    ]
 
     row_list = [
         ["Br", 64, 4, True, "gga-3", "r2scan-3", "GGA", "R2SCAN", 0.0, 0.0, 0.0, 0.0],
@@ -660,7 +662,7 @@ def ms_all_scan_novel(ms_complete):
 @pytest.fixture()
 def ms_incomplete_gga_all_scan(ms_complete):
     """Mixing state with an incomplete GGA phase diagram."""
-    gga_entries = [e for e in ms_complete.gga_entries if e.reduced_formula != "Sn"]
+    gga_entries = [entry for entry in ms_complete.gga_entries if entry.reduced_formula != "Sn"]
     scan_entries = ms_complete.scan_entries
 
     row_list = [
@@ -901,12 +903,12 @@ class TestMaterialsProjectDFTMixingSchemeArgs:
         ]
 
         mixing_scheme_no_compat.process_entries(entries, clean=False)
-        for e in entries:
-            assert e.correction == -20
+        for entry in entries:
+            assert entry.correction == -20
 
         mixing_scheme_no_compat.process_entries(entries, clean=True)
-        for e in entries:
-            assert e.correction == 0
+        for entry in entries:
+            assert entry.correction == 0
 
     def test_no_run_type(self, mixing_scheme_no_compat):
         """
@@ -986,7 +988,7 @@ class TestMaterialsProjectDFTMixingSchemeArgs:
         state_data = mixing_scheme_no_compat.get_mixing_state_data(entries)
         with pytest.raises(CompatibilityError, match="Invalid run_type='LDA'"):
             mixing_scheme_no_compat.get_adjustments(
-                next(e for e in entries if e.parameters["run_type"] == "LDA"),
+                next(entry for entry in entries if entry.parameters["run_type"] == "LDA"),
                 state_data,
             )
 
@@ -1011,19 +1013,13 @@ class TestMaterialsProjectDFTMixingSchemeArgs:
         """
         If process_entries or get_adjustments is called with a populated mixing_state_data
         kwarg and one or more of the entry_ids is not present in the mixing_state_data,
-        raise CompatbilityError.
+        raise CompatibilityError.
         """
         foreign_entry = ComputedStructureEntry(
             Structure(
                 lattice3,
                 ["Sn", "Br", "Br", "Br", "Br"],
-                [
-                    [0, 0, 0],
-                    [0.2, 0.2, 0.2],
-                    [0.4, 0.4, 0.4],
-                    [0.7, 0.7, 0.7],
-                    [1, 1, 1],
-                ],
+                [[0, 0, 0], [0.2, 0.2, 0.2], [0.4, 0.4, 0.4], [0.7, 0.7, 0.7], [1, 1, 1]],
             ),
             -25,
             parameters={"run_type": "R2SCAN"},
@@ -1038,9 +1034,9 @@ class TestMaterialsProjectDFTMixingSchemeArgs:
             [*ms_complete.all_entries, foreign_entry], mixing_state_data=ms_complete.state_data
         )
         assert len(entries) == 7
-        for e in entries:
-            assert e.correction == 0
-            assert e.parameters["run_type"] == "R2SCAN"
+        for entry in entries:
+            assert entry.correction == 0
+            assert entry.parameters["run_type"] == "R2SCAN"
 
     def test_fuzzy_matching(self, ms_complete):
         """
@@ -1294,13 +1290,13 @@ class TestMaterialsProjectDFTMixingSchemeStates:
         state_data = mixing_scheme_no_compat.get_mixing_state_data(ms_gga_only.all_entries)
         pd.testing.assert_frame_equal(state_data, ms_gga_only.state_data)
 
-        for e in ms_gga_only.all_entries:
-            assert mixing_scheme_no_compat.get_adjustments(e, ms_gga_only.state_data) == []
+        for entry in ms_gga_only.all_entries:
+            assert mixing_scheme_no_compat.get_adjustments(entry, ms_gga_only.state_data) == []
         entries = mixing_scheme_no_compat.process_entries(ms_gga_only.all_entries)
         assert len(entries) == 7
-        for e in entries:
-            assert e.correction == 0
-            assert e.parameters["run_type"] == "GGA"
+        for entry in entries:
+            assert entry.correction == 0
+            assert entry.parameters["run_type"] == "GGA"
 
     def test_state_scan_only(self, mixing_scheme_no_compat, ms_scan_only):
         """
@@ -1311,14 +1307,14 @@ class TestMaterialsProjectDFTMixingSchemeStates:
         state_data = mixing_scheme_no_compat.get_mixing_state_data(ms_scan_only.all_entries)
         pd.testing.assert_frame_equal(state_data, ms_scan_only.state_data)
 
-        for e in ms_scan_only.all_entries:
-            assert mixing_scheme_no_compat.get_adjustments(e, ms_scan_only.state_data) == []
+        for entry in ms_scan_only.all_entries:
+            assert mixing_scheme_no_compat.get_adjustments(entry, ms_scan_only.state_data) == []
 
         entries = mixing_scheme_no_compat.process_entries(ms_scan_only.all_entries)
         assert len(entries) == 7
-        for e in entries:
-            assert e.correction == 0
-            assert e.parameters["run_type"] == "R2SCAN"
+        for entry in entries:
+            assert entry.correction == 0
+            assert entry.parameters["run_type"] == "R2SCAN"
 
     def test_state_gga_1_scan(self, mixing_scheme_no_compat, ms_gga_1_scan):
         """
@@ -1331,26 +1327,26 @@ class TestMaterialsProjectDFTMixingSchemeStates:
         state_data = mixing_scheme_no_compat.get_mixing_state_data(ms_gga_1_scan.all_entries)
         pd.testing.assert_frame_equal(state_data, ms_gga_1_scan.state_data)
 
-        for e in ms_gga_1_scan.gga_entries:
-            if e.entry_id == "gga-4":
+        for entry in ms_gga_1_scan.gga_entries:
+            if entry.entry_id == "gga-4":
                 with pytest.raises(CompatibilityError, match="because it is a GGA\\(\\+U\\) ground state"):
-                    mixing_scheme_no_compat.get_adjustments(e, ms_gga_1_scan.state_data)
+                    mixing_scheme_no_compat.get_adjustments(entry, ms_gga_1_scan.state_data)
             else:
-                assert mixing_scheme_no_compat.get_adjustments(e, ms_gga_1_scan.state_data) == []
+                assert mixing_scheme_no_compat.get_adjustments(entry, ms_gga_1_scan.state_data) == []
 
-        for e in ms_gga_1_scan.scan_entries:
+        for entry in ms_gga_1_scan.scan_entries:
             # gga-4 energy is -6 eV/atom, r2scan-4 energy is -7 eV/atom. There are 3 atoms.
-            assert mixing_scheme_no_compat.get_adjustments(e, ms_gga_1_scan.state_data)[0].value == 3
+            assert mixing_scheme_no_compat.get_adjustments(entry, ms_gga_1_scan.state_data)[0].value == 3
 
         entries = mixing_scheme_no_compat.process_entries(ms_gga_1_scan.all_entries)
         assert len(entries) == 7
-        for e in entries:
-            if "4" in e.entry_id:
-                assert e.correction == 3
-                assert e.parameters["run_type"] == "R2SCAN"
+        for entry in entries:
+            if "4" in entry.entry_id:
+                assert entry.correction == 3
+                assert entry.parameters["run_type"] == "R2SCAN"
             else:
-                assert e.correction == 0, f"{e.entry_id}"
-                assert e.parameters["run_type"] == "GGA"
+                assert entry.correction == 0, f"{entry.entry_id}"
+                assert entry.parameters["run_type"] == "GGA"
 
     def test_state_gga_1_scan_plus_novel(self, mixing_scheme_no_compat, ms_gga_1_scan_novel):
         """
@@ -1362,13 +1358,13 @@ class TestMaterialsProjectDFTMixingSchemeStates:
         state_data = mixing_scheme_no_compat.get_mixing_state_data(ms_gga_1_scan_novel.all_entries)
         pd.testing.assert_frame_equal(state_data, ms_gga_1_scan_novel.state_data)
 
-        for e in ms_gga_1_scan_novel.gga_entries:
-            if e.entry_id == "gga-4":
-                assert mixing_scheme_no_compat.get_adjustments(e, ms_gga_1_scan_novel.state_data) == []
+        for entry in ms_gga_1_scan_novel.gga_entries:
+            if entry.entry_id == "gga-4":
+                assert mixing_scheme_no_compat.get_adjustments(entry, ms_gga_1_scan_novel.state_data) == []
 
-        for e in ms_gga_1_scan_novel.scan_entries:
+        for entry in ms_gga_1_scan_novel.scan_entries:
             with pytest.raises(CompatibilityError, match="no R2SCAN ground states at this composition"):
-                mixing_scheme_no_compat.get_adjustments(e, ms_gga_1_scan_novel.state_data)
+                mixing_scheme_no_compat.get_adjustments(entry, ms_gga_1_scan_novel.state_data)
 
         entries = mixing_scheme_no_compat.process_entries(ms_gga_1_scan_novel.all_entries)
         assert len(entries) == 7
@@ -1525,9 +1521,9 @@ class TestMaterialsProjectDFTMixingSchemeStates:
         state_data = mixing_scheme_no_compat.get_mixing_state_data(ms_incomplete_gga_all_scan.all_entries)
         pd.testing.assert_frame_equal(state_data, ms_incomplete_gga_all_scan.state_data)
 
-        for e in ms_incomplete_gga_all_scan.all_entries:
+        for entry in ms_incomplete_gga_all_scan.all_entries:
             with pytest.raises(CompatibilityError, match="do not form a complete PhaseDiagram"):
-                mixing_scheme_no_compat.get_adjustments(e, ms_incomplete_gga_all_scan.state_data)
+                mixing_scheme_no_compat.get_adjustments(entry, ms_incomplete_gga_all_scan.state_data)
 
         # process_entries should discard all entries and issue a warning
         with pytest.warns(UserWarning, match="do not form a complete PhaseDiagram"):

--- a/tests/ext/test_matproj.py
+++ b/tests/ext/test_matproj.py
@@ -108,7 +108,7 @@ class TestMPResterOld(PymatgenTest):
             assert set(Composition(d["unit_cell_formula"]).elements).issubset(elements)
 
         with pytest.raises(MPRestError, match="REST query returned with error status code 404"):
-            self.rester.get_data("Fe2O3", "badmethod")
+            self.rester.get_data("Fe2O3", "bad-method")
 
     def test_get_materials_id_from_task_id(self):
         assert self.rester.get_materials_id_from_task_id("mp-540081") == "mp-19017"
@@ -133,9 +133,9 @@ class TestMPResterOld(PymatgenTest):
         entries = self.rester.get_entries_in_chemsys(syms)
         entries2 = self.rester.get_entries_in_chemsys(syms2)
         elements = {Element(sym) for sym in syms}
-        for e in entries:
-            assert isinstance(e, ComputedEntry)
-            assert set(e.elements).issubset(elements)
+        for entry in entries:
+            assert isinstance(entry, ComputedEntry)
+            assert set(entry.elements).issubset(elements)
 
         e1 = {ent.entry_id for ent in entries}
         e2 = {ent.entry_id for ent in entries2}
@@ -280,10 +280,10 @@ class TestMPResterOld(PymatgenTest):
         for pbx_entry in pbx_entries:
             assert isinstance(pbx_entry, PourbaixEntry)
 
-        # fe_two_plus = [e for e in pbx_entries if e.entry_id == "ion-0"][0]
+        # fe_two_plus = next(entry for entry in pbx_entries if entry.entry_id == "ion-0")
         # assert fe_two_plus.energy == approx(-1.12369, abs=1e-3)
 
-        # feo2 = [e for e in pbx_entries if e.entry_id == "mp-25332"][0]
+        # feo2 = next(entry for entry in pbx_entries if entry.entry_id == "mp-25332")
         # assert feo2.energy == approx(3.56356, abs=1e-3)
 
         # # Test S, which has Na in reference solids
@@ -627,15 +627,15 @@ class TestMPResterNewBasic:
         entries = self.rester.get_entries_in_chemsys(syms)
         entries2 = self.rester.get_entries(syms2)
         elements = {Element(sym) for sym in syms}
-        for e in entries:
-            assert isinstance(e, ComputedEntry)
-            assert set(e.elements).issubset(elements)
+        for entry in entries:
+            assert isinstance(entry, ComputedEntry)
+            assert set(entry.elements).issubset(elements)
 
         assert len(entries) > 1000
 
-        for e in entries2:
-            assert isinstance(e, ComputedEntry)
-            assert set(e.elements).issubset(elements)
+        for entry in entries2:
+            assert isinstance(entry, ComputedEntry)
+            assert set(entry.elements).issubset(elements)
         assert len(entries2) < 1000
 
         e1 = {i.entry_id for i in entries}

--- a/tests/io/test_phonopy.py
+++ b/tests/io/test_phonopy.py
@@ -106,8 +106,8 @@ class TestStructureConversion(PymatgenTest):
         assert struct_pmg_round_trip.matches(struct_pmg)
 
         coords_ph = struct_ph.get_scaled_positions()
-        symbols_pmg = {e.symbol for e in struct_pmg.composition}
-        symbols_pmg2 = {e.symbol for e in struct_pmg_round_trip.composition}
+        symbols_pmg = {*map(str, struct_pmg.composition)}
+        symbols_pmg2 = {*map(str, struct_pmg_round_trip.composition)}
 
         assert struct_ph.get_cell()[1, 1] == approx(struct_pmg.lattice._matrix[1, 1], abs=1e-7)
         assert struct_pmg.lattice._matrix[1, 1] == approx(struct_pmg_round_trip.lattice._matrix[1, 1], abs=1e-7)

--- a/tests/phonon/test_plotter.py
+++ b/tests/phonon/test_plotter.py
@@ -66,7 +66,7 @@ class TestPhononBSPlotter(TestCase):
     def test_bs_plot_data(self):
         assert len(self.plotter.bs_plot_data()["distances"][0]) == 51, "wrong number of distances in the first branch"
         assert len(self.plotter.bs_plot_data()["distances"]) == 4, "wrong number of branches"
-        assert sum(len(e) for e in self.plotter.bs_plot_data()["distances"]) == 204, "wrong number of distances"
+        assert sum(len(dist) for dist in self.plotter.bs_plot_data()["distances"]) == 204, "wrong number of distances"
         assert self.plotter.bs_plot_data()["ticks"]["label"][4] == "Y", "wrong tick label"
         assert len(self.plotter.bs_plot_data()["ticks"]["label"]) == 8, "wrong number of tick labels"
 


### PR DESCRIPTION
## Summary

- Replace `eval` with safer alternatives
- Replace manual offset in `enumerate` with the `start` argument
- Minor format tweaks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved loop logic and simplified conditions in magnetism analysis methods.
	- Enhanced safety by replacing `eval` with `literal_eval` in magnetism analysis.
	- Streamlined code for electronic structure calculations, including conditional assignments and property access.
	- Optimized parameter type checking and assignment operations in VASP inputs handling.
- **Documentation**
	- Updated docstring for better clarity in VASP inputs handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->