### PR TITLE
Update ENCUT type to float in  incar_parameters.json

### DIFF
--- a/pymatgen/io/vasp/incar_parameters.json
+++ b/pymatgen/io/vasp/incar_parameters.json
@@ -156,7 +156,7 @@
     "type": "float"
  },
  "ENCUT": {
-    "type": "int"
+    "type": "float"
  },
  "ENCUTFOCK": {
     "type": "float"


### PR DESCRIPTION
ENCUT in VASP INCAR settings should be float



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the data type for the `ENCUT` parameter to enhance precision in calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->