### PR TITLE
Replace unnecessary usage of `len` for iterable existence check

### DIFF
--- a/pymatgen/analysis/bond_valence.py
+++ b/pymatgen/analysis/bond_valence.py
@@ -160,7 +160,7 @@ class BVAnalyzer:
         forbidden_species = [get_el_sp(sp) for sp in forbidden_species] if forbidden_species else []
         self.icsd_bv_data = (
             {get_el_sp(specie): data for specie, data in ICSD_BV_DATA.items() if specie not in forbidden_species}
-            if len(forbidden_species) > 0
+            if forbidden_species
             else ICSD_BV_DATA
         )
 

--- a/pymatgen/analysis/chemenv/coordination_environments/chemenv_strategies.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/chemenv_strategies.py
@@ -2227,7 +2227,7 @@ class DistanceAngleAreaNbSetWeight(NbSetWeight):
             for src in nb_set.sources
             if src["origin"] == "dist_ang_ac_voronoi" and src["ac"] == self.additional_condition
         ]
-        if len(dist_ang_sources) > 0:
+        if dist_ang_sources:
             for src in dist_ang_sources:
                 d1 = src["dp_dict"]["min"]
                 d2 = src["dp_dict"]["next"]
@@ -2767,7 +2767,7 @@ class WeightedNbSetChemenvStrategy(AbstractChemenvStrategy):
                 if site_ce_nb_set is None:
                     continue
                 mingeoms = site_ce_nb_set.minimum_geometries(symmetry_measure_type=self.symmetry_measure_type)
-                if len(mingeoms) > 0:
+                if mingeoms:
                     csms = [
                         ce_dict["other_symmetry_measures"][self.symmetry_measure_type]
                         for ce_symbol, ce_dict in mingeoms

--- a/pymatgen/analysis/chemenv/coordination_environments/coordination_geometry_finder.py
+++ b/pymatgen/analysis/chemenv/coordination_environments/coordination_geometry_finder.py
@@ -1209,7 +1209,7 @@ class LocalGeometryFinder:
             )
             result, permutations, algos, local2perfect_maps, perfect2local_maps = cgsm
             if only_minimum:
-                if len(result) > 0:
+                if result:
                     imin = np.argmin([rr["symmetry_measure"] for rr in result])
                     algo = algos[imin] if geometry.algorithms is not None else algos
                     result_dict[geometry.mp_symbol] = {
@@ -1878,7 +1878,7 @@ class LocalGeometryFinder:
                 permutations_symmetry_measures.append(sm_info)
             if plane_found:
                 break
-        if len(permutations_symmetry_measures) > 0:
+        if permutations_symmetry_measures:
             if testing:
                 return (
                     permutations_symmetry_measures,
@@ -1957,7 +1957,7 @@ class LocalGeometryFinder:
 
             permutations_symmetry_measures.append(sm_info)
 
-        if len(permutations_symmetry_measures) > 0:
+        if permutations_symmetry_measures:
             return (
                 permutations_symmetry_measures,
                 permutations,
@@ -2031,7 +2031,7 @@ class LocalGeometryFinder:
 
             permutations_symmetry_measures.append(sm_info)
 
-        if len(permutations_symmetry_measures) > 0:
+        if permutations_symmetry_measures:
             return (
                 permutations_symmetry_measures,
                 permutations,

--- a/pymatgen/analysis/chemenv/utils/chemenv_config.py
+++ b/pymatgen/analysis/chemenv/utils/chemenv_config.py
@@ -105,7 +105,7 @@ class ChemEnvConfig:
             "strategy_options": {},
         }
         strategy_class = strategies_class_lookup[strategies[int(test) - 1]]
-        if len(strategy_class.STRATEGY_OPTIONS) > 0:
+        if strategy_class.STRATEGY_OPTIONS:
             for option, option_dict in strategy_class.STRATEGY_OPTIONS.items():
                 while True:
                     print(f"  => Enter value for option {option!r} (<ENTER> for default = {option_dict['default']})\n")

--- a/pymatgen/analysis/chemenv/utils/func_utils.py
+++ b/pymatgen/analysis/chemenv/utils/func_utils.py
@@ -51,7 +51,7 @@ class AbstractRatioFunction:
             options_dict: Dictionary containing the parameters for the ratio function.
         """
         function_options = self.ALLOWED_FUNCTIONS[self.function]
-        if len(function_options) > 0:
+        if function_options:
             # Check if there are missing options
             if options_dict is None:
                 missing_options = True

--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -176,7 +176,7 @@ class ValenceIonicRadiusEvaluator:
             except Exception:
                 valences = []
                 for site in self._structure:
-                    if len(site.specie.common_oxidation_states) > 0:
+                    if site.specie.common_oxidation_states:
                         valences.append(site.specie.common_oxidation_states[0])
                     # Handle noble gas species
                     # which have no entries in common_oxidation_states.
@@ -2967,11 +2967,11 @@ class LocalStructOrderParams:
             # for calculating BOOPS.
             for idx, typ in enumerate(self._types):
                 if typ == "q2":
-                    ops[idx] = self.get_q2(thetas, phis) if len(thetas) > 0 else None
+                    ops[idx] = self.get_q2(thetas, phis) if thetas else None
                 elif typ == "q4":
-                    ops[idx] = self.get_q4(thetas, phis) if len(thetas) > 0 else None
+                    ops[idx] = self.get_q4(thetas, phis) if thetas else None
                 elif typ == "q6":
-                    ops[idx] = self.get_q6(thetas, phis) if len(thetas) > 0 else None
+                    ops[idx] = self.get_q6(thetas, phis) if thetas else None
 
         # Then, deal with the Peters-style OPs that are tailor-made
         # to recognize common structural motifs
@@ -3349,8 +3349,8 @@ class LocalStructOrderParams:
             if n_neighbors > 0:
                 neighscent = neighscent / float(n_neighbors)
             h = np.linalg.norm(neighscent - centvec)
-            b = min(distjk_unique) if len(distjk_unique) > 0 else 0
-            dhalf = max(distjk_unique) / 2 if len(distjk_unique) > 0 else 0
+            b = min(distjk_unique) if distjk_unique else 0
+            dhalf = max(distjk_unique) / 2 if distjk_unique else 0
 
             for idx, typ in enumerate(self._types):
                 if typ in ("reg_tri", "sq"):

--- a/pymatgen/analysis/molecule_structure_comparator.py
+++ b/pymatgen/analysis/molecule_structure_comparator.py
@@ -226,7 +226,7 @@ class MoleculeStructureComparator(MSONable):
         all_pairs = list(itertools.combinations(covalent_atoms, 2))
         pair_dists = [mol.get_distance(*p) for p in all_pairs]
         unavailable_elements = set(mol.composition.as_dict()) - set(self.covalent_radius)
-        if len(unavailable_elements) > 0:
+        if unavailable_elements:
             raise ValueError(f"The covalent radius for element {unavailable_elements} is not available")
         bond_13 = self.get_13_bonds(self.priority_bonds)
         max_length = [

--- a/pymatgen/analysis/phase_diagram.py
+++ b/pymatgen/analysis/phase_diagram.py
@@ -1428,7 +1428,7 @@ class GrandPotentialPhaseDiagram(PhaseDiagram):
         elements = set(elements) - set(self.chempots)
 
         all_entries = [
-            GrandPotPDEntry(entry, self.chempots) for entry in entries if len(elements.intersection(entry.elements)) > 0
+            GrandPotPDEntry(entry, self.chempots) for entry in entries if elements.intersection(entry.elements)
         ]
 
         super().__init__(all_entries, elements, computed_data=None)

--- a/pymatgen/analysis/wulff.py
+++ b/pymatgen/analysis/wulff.py
@@ -402,7 +402,7 @@ class WulffShape:
 
         for plane in self.facets:
             # check whether [pts] is empty
-            if len(plane.points) < 1:
+            if not plane.points:
                 # empty, plane is not on_wulff.
                 continue
             # assign the color for on_wulff facets according to its
@@ -507,7 +507,7 @@ class WulffShape:
 
         planes_data, color_scale, ticktext, tickvals = [], [], [], []
         for plane in self.facets:
-            if len(plane.points) < 1:
+            if not plane.points:
                 # empty, plane is not on_wulff.
                 continue
 

--- a/pymatgen/apps/battery/battery_abc.py
+++ b/pymatgen/apps/battery/battery_abc.py
@@ -198,7 +198,7 @@ class AbstractElectrode(Sequence, MSONable):
             self.voltage_pairs[i].voltage - self.voltage_pairs[i + 1].voltage
             for i in range(len(self.voltage_pairs) - 1)
         ]
-        return max(steps) if len(steps) > 0 else 0
+        return max(steps) if steps else 0
 
     @property
     def normalization_mass(self):

--- a/pymatgen/apps/battery/insertion_battery.py
+++ b/pymatgen/apps/battery/insertion_battery.py
@@ -193,7 +193,7 @@ class InsertionElectrode(AbstractElectrode):
                 data.append(pair.decomp_e_charge)
             if getattr(pair, "decomp_e_discharge", None) is not None:
                 data.append(pair.decomp_e_discharge)
-        return max(data) if len(data) > 0 else None
+        return max(data) if data else None
 
     def get_min_instability(self, min_voltage=None, max_voltage=None):
         """The minimum instability along a path for a specific voltage range.
@@ -212,7 +212,7 @@ class InsertionElectrode(AbstractElectrode):
                 data.append(pair.decomp_e_charge)
             if getattr(pair, "decomp_e_discharge", None) is not None:
                 data.append(pair.decomp_e_discharge)
-        return min(data) if len(data) > 0 else None
+        return min(data) if data else None
 
     def get_max_muO2(self, min_voltage=None, max_voltage=None):
         """Maximum critical oxygen chemical potential along path.
@@ -232,7 +232,7 @@ class InsertionElectrode(AbstractElectrode):
                 data.extend([d["chempot"] for d in pair.muO2_discharge])
             if pair.muO2_charge is not None:
                 data.extend([d["chempot"] for d in pair.muO2_discharge])
-        return max(data) if len(data) > 0 else None
+        return max(data) if data else None
 
     def get_min_muO2(self, min_voltage=None, max_voltage=None):
         """Minimum critical oxygen chemical potential along path.
@@ -253,7 +253,7 @@ class InsertionElectrode(AbstractElectrode):
                 data.extend([d["chempot"] for d in pair.muO2_discharge])
             if pair.muO2_charge is not None:
                 data.extend([d["chempot"] for d in pair.muO2_discharge])
-        return min(data) if len(data) > 0 else None
+        return min(data) if data else None
 
     def get_sub_electrodes(self, adjacent_only=True, include_myself=True):
         """If this electrode contains multiple voltage steps, then it is possible

--- a/pymatgen/cli/pmg_analyze.py
+++ b/pymatgen/cli/pmg_analyze.py
@@ -80,7 +80,7 @@ def get_energies(rootdir, reanalyze, verbose, quick, sort, fmt):
                 delta_vol,
             )
         )
-    if len(all_data) > 0:
+    if all_data:
         headers = ("Directory", "Formula", "Energy", "E/Atom", "% vol chg")
         print(tabulate(all_data, headers=headers, tablefmt=fmt))
         print()

--- a/pymatgen/cli/pmg_config.py
+++ b/pymatgen/cli/pmg_config.py
@@ -136,7 +136,7 @@ def setup_potcars(potcar_dirs: list[str]):
         basename = name_mappings.get(basename, basename)
         for subdir in subdirs:
             filenames = glob(os.path.join(parent, subdir, "POTCAR*"))
-            if len(filenames) > 0:
+            if filenames:
                 try:
                     base_dir = os.path.join(target_dir, basename)
                     os.makedirs(base_dir, exist_ok=True)

--- a/pymatgen/command_line/enumlib_caller.py
+++ b/pymatgen/command_line/enumlib_caller.py
@@ -328,7 +328,7 @@ class EnumlibAdaptor:
         # disordered structure, and retrieving correct site properties
         disordered_site_properties = {}
 
-        if len(self.ordered_sites) > 0:
+        if self.ordered_sites:
             original_latt = self.ordered_sites[0].lattice
             # Need to strip sites of site_properties, which would otherwise
             # result in an index error. Hence Structure is reconstructed in
@@ -366,7 +366,7 @@ class EnumlibAdaptor:
 
                 sites = []
 
-                if len(self.ordered_sites) > 0:
+                if self.ordered_sites:
                     transformation = np.dot(new_latt.matrix, inv_org_latt)
                     transformation = [[int(round(cell)) for cell in row] for row in transformation]
                     logger.debug(f"Supercell matrix: {transformation}")

--- a/pymatgen/core/lattice.py
+++ b/pymatgen/core/lattice.py
@@ -1340,7 +1340,7 @@ class Lattice(MSONable):
             _, indices, images, distances = find_points_in_spheres(
                 all_coords=cart_coords, center_coords=center_coords, r=float(r), pbc=pbc, lattice=latt_matrix, tol=1e-8
             )
-            if not indices:
+            if len(indices) < 1:
                 return [] if zip_results else [()] * 4
             frac_coords = frac_points[indices] + images
             if zip_results:

--- a/pymatgen/core/lattice.py
+++ b/pymatgen/core/lattice.py
@@ -1340,7 +1340,7 @@ class Lattice(MSONable):
             _, indices, images, distances = find_points_in_spheres(
                 all_coords=cart_coords, center_coords=center_coords, r=float(r), pbc=pbc, lattice=latt_matrix, tol=1e-8
             )
-            if len(indices) < 1:
+            if not indices:
                 return [] if zip_results else [()] * 4
             frac_coords = frac_points[indices] + images
             if zip_results:
@@ -1394,7 +1394,7 @@ class Lattice(MSONable):
             lattice=self,
             return_fcoords=True,
         )[0]
-        if len(neighbors) < 1:
+        if not neighbors:
             return [] if zip_results else [()] * 4  # type: ignore
         if zip_results:
             return neighbors
@@ -1769,7 +1769,7 @@ def get_points_in_spheres(
                 valid_coords.append(coords[valid_index_bool])
                 valid_images.append(np.tile(image, [np.sum(valid_index_bool), 1]) - image_offsets[valid_index_bool])
                 valid_indices.extend([k for k in ind if valid_index_bool[k]])
-        if len(valid_coords) < 1:
+        if not valid_coords:
             return [[]] * len(center_coords)
         valid_coords = np.concatenate(valid_coords, axis=0)
         valid_images = np.concatenate(valid_images, axis=0)

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -1602,7 +1602,7 @@ class IStructure(SiteCollection, MSONable):
         offsets = []
         distances = []
         for idx, nns in enumerate(neighbors):
-            if len(nns) > 0:
+            if nns:
                 for nn in nns:
                     if exclude_self and idx == nn.index and nn.nn_distance <= numerical_tol:
                         continue
@@ -1874,7 +1874,7 @@ class IStructure(SiteCollection, MSONable):
         center_indices, points_indices, images, distances = self.get_neighbor_list(
             r=r, sites=sites, numerical_tol=numerical_tol
         )
-        if len(points_indices) < 1:
+        if not points_indices:
             return [[]] * len(sites)
         f_coords = self.frac_coords[points_indices] + images
         neighbor_dict: dict[int, list] = collections.defaultdict(list)
@@ -1971,7 +1971,7 @@ class IStructure(SiteCollection, MSONable):
         neighbors: list[list[PeriodicNeighbor]] = []
         for point_neighbor, site in zip(point_neighbors, sites):
             nns: list[PeriodicNeighbor] = []
-            if len(point_neighbor) < 1:
+            if not point_neighbor:
                 neighbors.append([])
                 continue
             for n in point_neighbor:
@@ -3192,7 +3192,7 @@ class IMolecule(SiteCollection, MSONable):
         Returns:
             Molecule
         """
-        if len(sites) < 1:
+        if not sites:
             raise ValueError(f"You need at least 1 site to make a {cls.__name__}")
         props = collections.defaultdict(list)
         for site in sites:
@@ -4077,7 +4077,7 @@ class Structure(IStructure, collections.abc.MutableSequence):
 
         for site in self:
             new_sp_occu = {sp: amt for sp, amt in site.species.items() if sp not in species}
-            if len(new_sp_occu) > 0:
+            if new_sp_occu:
                 new_sites.append(
                     PeriodicSite(
                         new_sp_occu,
@@ -4734,7 +4734,7 @@ class Molecule(IMolecule, collections.abc.MutableSequence):
         species = [get_el_sp(sp) for sp in species]
         for site in self:
             new_sp_occu = {sp: amt for sp, amt in site.species.items() if sp not in species}
-            if len(new_sp_occu) > 0:
+            if new_sp_occu:
                 new_sites.append(Site(new_sp_occu, site.coords, properties=site.properties, label=site.label))
         self.sites = new_sites
         return self

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -1874,7 +1874,7 @@ class IStructure(SiteCollection, MSONable):
         center_indices, points_indices, images, distances = self.get_neighbor_list(
             r=r, sites=sites, numerical_tol=numerical_tol
         )
-        if not points_indices:
+        if len(points_indices) < 1:
             return [[]] * len(sites)
         f_coords = self.frac_coords[points_indices] + images
         neighbor_dict: dict[int, list] = collections.defaultdict(list)

--- a/pymatgen/core/surface.py
+++ b/pymatgen/core/surface.py
@@ -1764,7 +1764,7 @@ def generate_all_slabs(
             repair=repair,
         )
 
-        if len(slabs) > 0:
+        if slabs:
             logger.debug(f"{miller} has {len(slabs)} slabs... ")
             all_slabs.extend(slabs)
 

--- a/pymatgen/electronic_structure/core.py
+++ b/pymatgen/electronic_structure/core.py
@@ -356,7 +356,7 @@ class Magmom(MSONable):
         # filter only non-zero magmoms
         magmoms = [magmom for magmom in magmoms if abs(magmom)]
         magmoms.sort(reverse=True)
-        if len(magmoms) > 0:
+        if magmoms:
             return magmoms[0].get_00t_magmom_with_xyz_saxis().saxis
         return np.array([0, 0, 1], dtype="d")
 

--- a/pymatgen/electronic_structure/dos.py
+++ b/pymatgen/electronic_structure/dos.py
@@ -1274,7 +1274,7 @@ class CompleteDos(Dos):
             "densities": {str(spin): dens.tolist() for spin, dens in self.densities.items()},
             "pdos": [],
         }
-        if len(self.pdos) > 0:
+        if self.pdos:
             for at in self.structure:
                 dd = {}
                 for orb, pdos in self.pdos[at].items():

--- a/pymatgen/entries/compatibility.py
+++ b/pymatgen/entries/compatibility.py
@@ -627,7 +627,7 @@ class Compatibility(MSONable, abc.ABC):
             f"({entry.uncorrected_energy / entry.composition.num_atoms:.3f} eV/atom)."
         )
 
-        if len(entry.energy_adjustments) > 0:
+        if entry.energy_adjustments:
             print("The following energy adjustments have been applied to this entry:")
             for adj in entry.energy_adjustments:
                 print(f"\t\t{adj.name}: {adj.value:.3f} eV ({adj.value / entry.composition.num_atoms:.3f} eV/atom)")

--- a/pymatgen/entries/mixing_scheme.py
+++ b/pymatgen/entries/mixing_scheme.py
@@ -182,7 +182,7 @@ class MaterialsProjectDFTMixingScheme(Compatibility):
             # how many stable entries from run_type_1 do we have in run_type_2?
             hull_entries_2 = 0
             stable_df = mixing_state_data[mixing_state_data["is_stable_1"]]
-            if stable_df:
+            if not stable_df.empty:
                 hull_entries_2 = sum(stable_df["energy_2"].notna())
             print(
                 f"  Entries contain {self.run_type_2} calculations for {hull_entries_2} of {len(stable_df)} "

--- a/pymatgen/entries/mixing_scheme.py
+++ b/pymatgen/entries/mixing_scheme.py
@@ -182,7 +182,7 @@ class MaterialsProjectDFTMixingScheme(Compatibility):
             # how many stable entries from run_type_1 do we have in run_type_2?
             hull_entries_2 = 0
             stable_df = mixing_state_data[mixing_state_data["is_stable_1"]]
-            if len(stable_df) > 0:
+            if stable_df:
                 hull_entries_2 = sum(stable_df["energy_2"].notna())
             print(
                 f"  Entries contain {self.run_type_2} calculations for {hull_entries_2} of {len(stable_df)} "
@@ -635,7 +635,7 @@ class MaterialsProjectDFTMixingScheme(Compatibility):
 
         # make sure both sets of entries belong to the same chemical system
         # assuming there are any gga entries at all
-        if len(entries_type_1.chemsys) > 0:
+        if entries_type_1.chemsys:
             chemsys = entries_type_1.chemsys
             if not entries_type_2.chemsys <= entries_type_1.chemsys:
                 warnings.warn(
@@ -667,7 +667,7 @@ class MaterialsProjectDFTMixingScheme(Compatibility):
             ),
             key=lambda x: x.energy_per_atom,
         )
-        first_entry = entries_type_1[0] if len(entries_type_1) > 0 else None
+        first_entry = entries_type_1[0] if entries_type_1 else None
 
         entries_type_2 = sorted(
             (
@@ -677,7 +677,7 @@ class MaterialsProjectDFTMixingScheme(Compatibility):
             ),
             key=lambda x: x.energy_per_atom,
         )
-        second_entry = entries_type_2[0] if len(entries_type_2) > 0 else None
+        second_entry = entries_type_2[0] if entries_type_2 else None
 
         # generate info for the DataFrame
         stable_1 = False

--- a/pymatgen/ext/matproj.py
+++ b/pymatgen/ext/matproj.py
@@ -382,7 +382,7 @@ class MPRester:
            *args: Pass through to either legacy or new MPRester.
            **kwargs: Pass through to either legacy or new MPRester.
         """
-        api_key = args[0] if len(args) > 0 else None
+        api_key = args[0] if args else None
 
         if api_key is None:
             api_key = kwargs.get("api_key", SETTINGS.get("PMG_MAPI_KEY"))

--- a/pymatgen/io/adf.py
+++ b/pymatgen/io/adf.py
@@ -98,17 +98,17 @@ class AdfKey(MSONable):
         self.name = name
         self.options = options if options is not None else []
         self.subkeys = subkeys if subkeys is not None else []
-        if len(self.subkeys) > 0:
+        if self.subkeys:
             for k in subkeys:
                 if not isinstance(k, AdfKey):
                     raise ValueError("Not all subkeys are ``AdfKey`` objects!")
         self._sized_op = None
-        if len(self.options) > 0:
+        if self.options:
             self._sized_op = isinstance(self.options[0], (list, tuple))
 
     def _options_string(self):
         """Return the option string."""
-        if len(self.options) > 0:
+        if self.options:
             opt_str = ""
             for op in self.options:
                 if self._sized_op:
@@ -141,10 +141,10 @@ class AdfKey(MSONable):
             a different string format will be used.
         """
         adf_str = f"{self.key}"
-        if len(self.options) > 0:
+        if self.options:
             adf_str += f" {self._options_string()}"
         adf_str += "\n"
-        if len(self.subkeys) > 0:
+        if self.subkeys:
             if self.key.lower() == "atoms":
                 for subkey in self.subkeys:
                     adf_str += (
@@ -183,7 +183,7 @@ class AdfKey(MSONable):
             key = subkey.key
         else:
             raise ValueError("The subkey should be an AdfKey or a string!")
-        if len(self.subkeys) > 0 and key in (k.key for k in self.subkeys):
+        if self.subkeys and key in (k.key for k in self.subkeys):
             return True
         return False
 
@@ -207,7 +207,7 @@ class AdfKey(MSONable):
         Args:
             subkey (str or AdfKey): The subkey to remove.
         """
-        if len(self.subkeys) > 0:
+        if self.subkeys:
             key = subkey if isinstance(subkey, str) else subkey.key
             for idx, subkey in enumerate(self.subkeys):
                 if subkey.key == key:
@@ -244,7 +244,7 @@ class AdfKey(MSONable):
         Raises:
             TypeError: If the option has a wrong type.
         """
-        if len(self.options) > 0:
+        if self.options:
             if self._sized_op:
                 if not isinstance(option, str):
                     raise TypeError("``option`` should be a name string!")
@@ -279,7 +279,7 @@ class AdfKey(MSONable):
             "name": self.name,
             "options": self.options,
         }
-        if len(self.subkeys) > 0:
+        if self.subkeys:
             subkeys = []
             for subkey in self.subkeys:
                 subkeys.append(subkey.as_dict())
@@ -747,7 +747,7 @@ class AdfOutput:
 
         if not self.is_failed:
             if self.run_type == "GeometryOptimization":
-                if len(self.structures) > 0:
+                if self.structures:
                     self.final_structure = self.structures[-1]
                 if self.final_energy is None:
                     raise AdfOutputError("The final energy can not be read!")

--- a/pymatgen/io/aims/inputs.py
+++ b/pymatgen/io/aims/inputs.py
@@ -53,9 +53,7 @@ class AimsGeometryIn(MSONable):
         Returns:
             The AimsGeometryIn file for the string contents
         """
-        content_lines = [
-            line.strip() for line in contents.split("\n") if len(line.strip()) > 0 and line.strip()[0] != "#"
-        ]
+        content_lines = [line.strip() for line in contents.split("\n") if line.strip() and line.strip()[0] != "#"]
 
         species, coords, is_frac, lattice_vectors = [], [], [], []
         charges_dct, moments_dct = {}, {}

--- a/pymatgen/io/aims/parsers.py
+++ b/pymatgen/io/aims/parsers.py
@@ -489,7 +489,7 @@ class AimsOutCalcChunk(AimsOutChunk):
         species, coords, velocities, lattice = self._parse_lattice_atom_pos()
 
         site_properties: dict[str, Sequence[Any]] = dict()
-        if len(velocities) > 0:
+        if velocities:
             site_properties["velocity"] = np.array(velocities)
 
         results = self.results

--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -949,7 +949,7 @@ class CifParser:
             for op in self.symmetry_operations:
                 frac_coord = op.operate(coord)
                 indices = find_in_coord_list_pbc(coords, frac_coord, atol=self._site_tolerance)
-                if indices:
+                if len(indices) > 0:
                     return keys[indices[0]]
             return False
 

--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -401,7 +401,7 @@ class CifParser:
         # check for implicit hydrogens, warn if any present
         if "_atom_site_attached_hydrogens" in data.data:
             attached_hydrogens = [str2float(x) for x in data.data["_atom_site_attached_hydrogens"] if str2float(x) != 0]
-            if len(attached_hydrogens) > 0:
+            if attached_hydrogens:
                 self.warnings.append(
                     "Structure has implicit hydrogens defined, parsed structure unlikely to be "
                     "suitable for use in calculations unless hydrogens added."
@@ -480,7 +480,7 @@ class CifParser:
                     for idx in sorted(idxs_to_remove, reverse=True):
                         del data.data[original_key][idx]
 
-            if len(idxs_to_remove) > 0:
+            if idxs_to_remove:
                 self.warnings.append("Pauling file corrections applied.")
 
                 data.data["_atom_site_label"] += new_atom_site_label
@@ -533,7 +533,7 @@ class CifParser:
                 if data.data.get(interim_key):
                     changes_to_make[final_key] = interim_key
 
-            if len(changes_to_make) > 0:
+            if changes_to_make:
                 self.warnings.append("Keys changed to match new magCIF specification.")
 
             for final_key, interim_key in changes_to_make.items():
@@ -949,7 +949,7 @@ class CifParser:
             for op in self.symmetry_operations:
                 frac_coord = op.operate(coord)
                 indices = find_in_coord_list_pbc(coords, frac_coord, atol=self._site_tolerance)
-                if len(indices) > 0:
+                if indices:
                     return keys[indices[0]]
             return False
 
@@ -1154,7 +1154,7 @@ class CifParser:
         default primitive=False in parse_structures.
         So parse_structures(primitive=True) is equivalent to the old behavior of get_structures().
         """
-        if len(args) > 0:  # extract primitive if passed as arg
+        if args:  # extract primitive if passed as arg
             kwargs["primitive"] = args[0]
             args = args[1:]
         kwargs.setdefault("primitive", True)

--- a/pymatgen/io/cp2k/outputs.py
+++ b/pymatgen/io/cp2k/outputs.py
@@ -1603,7 +1603,7 @@ class Cp2kOutput:
                 if ml is None:
                     continue
                 d = ml.groupdict()
-                if len(d) > 0:
+                if d:
                     processed_line = {k: postprocess(v) for k, v in d.items()}
                 else:
                     processed_line = [postprocess(v) for v in ml.groups()]

--- a/pymatgen/io/cp2k/utils.py
+++ b/pymatgen/io/cp2k/utils.py
@@ -91,7 +91,7 @@ def preprocessor(data: str, dir: str = ".") -> str:
 
     c1 = re.findall(r"@IF", data, re.IGNORECASE)
     c2 = re.findall(r"@ELIF", data, re.IGNORECASE)
-    if len(c1) > 0 or len(c2) > 0:
+    if c1 or c2:
         raise NotImplementedError("This cp2k input processor does not currently support conditional blocks.")
     return data
 

--- a/pymatgen/io/feff/inputs.py
+++ b/pymatgen/io/feff/inputs.py
@@ -838,7 +838,7 @@ class Potential(MSONable):
                         ln = 0
                     if pot_tag >= 0 and ln > 0 and pot_data_over > 0:
                         try:
-                            if len(sep_line_pattern[0].findall(line)) > 0 or len(sep_line_pattern[1].findall(line)) > 0:
+                            if sep_line_pattern[0].findall(line) or sep_line_pattern[1].findall(line):
                                 pot_str.append(line)
                             elif int(line.split()[0]) == pot_data:
                                 pot_data += 1

--- a/pymatgen/io/feff/outputs.py
+++ b/pymatgen/io/feff/outputs.py
@@ -72,7 +72,7 @@ class LDos(MSONable):
 
             with zopen(pot_inp, mode="r") as potfile:
                 for line in potfile:
-                    if len(pot_readend.findall(line)) > 0:
+                    if pot_readend.findall(line):
                         break
 
                     if begin == 1:
@@ -88,7 +88,7 @@ class LDos(MSONable):
                             pot_dict[ele_name] = min(dos_index, pot_dict[ele_name])
                         dos_index += 1
 
-                    if len(pot_readstart.findall(line)) > 0:
+                    if pot_readstart.findall(line):
                         begin = 1
         else:
             pot_string = Potential.pot_string_from_file(feff_inp_file)
@@ -176,15 +176,16 @@ class LDos(MSONable):
             pot_readend = re.compile(".*ExternalPot.*switch.*")
             with zopen(pot_inp, mode="r") as potfile:
                 for line in potfile:
-                    if len(pot_readend.findall(line)) > 0:
+                    if pot_readend.findall(line):
                         break
                     if begin == 1:
                         z_number = int(line.strip().split()[0])
                         ele_name = Element.from_Z(z_number).name
-                        if len(pot_dict) == 0:
-                            pot_dict[0] = ele_name
-                        elif len(pot_dict) > 0:
+                        if pot_dict:
                             pot_dict[max(pot_dict) + 1] = ele_name
+                        else:
+                            pot_dict[0] = ele_name
+
                         begin += 1
                         continue
                     if begin == 2:
@@ -192,11 +193,12 @@ class LDos(MSONable):
                         ele_name = Element.from_Z(z_number).name
                         dicts[0][ele_name] = dos_index
                         dos_index += 1
-                        if len(pot_dict) == 0:
-                            pot_dict[0] = ele_name
-                        elif len(pot_dict) > 0:
+                        if pot_dict:
                             pot_dict[max(pot_dict) + 1] = ele_name
-                    if len(pot_readstart.findall(line)) > 0:
+                        else:
+                            pot_dict[0] = ele_name
+
+                    if pot_readstart.findall(line):
                         begin = 1
         else:
             pot_string = Potential.pot_string_from_file(feff_inp_file)

--- a/pymatgen/io/icet.py
+++ b/pymatgen/io/icet.py
@@ -120,7 +120,7 @@ class IcetSQS:
         self.sqs_kwargs.update(sqs_kwargs or {})
 
         unrecognized_kwargs = {key for key in self.sqs_kwargs if key not in self.sqs_kwarg_names[sqs_method]}
-        if len(unrecognized_kwargs) > 0:
+        if unrecognized_kwargs:
             warnings.warn(f"Ignoring unrecognized icet {sqs_method} kwargs: {', '.join(unrecognized_kwargs)}")
 
         self.sqs_kwargs = {

--- a/pymatgen/io/lammps/data.py
+++ b/pymatgen/io/lammps/data.py
@@ -797,7 +797,7 @@ class LammpsData(MSONable):
             velocities = pd.DataFrame(np.concatenate(v_collector), columns=SECTION_HEADERS["Velocities"])
             velocities.index += 1
 
-        topology = {key: pd.DataFrame([]) for key, values in topo_labels.items() if len(values) > 0}
+        topology = {key: pd.DataFrame([]) for key, values in topo_labels.items() if values}
         for key in topology:
             df = pd.DataFrame(np.concatenate(topo_collector[key]), columns=SECTION_HEADERS[key][1:])
             df["type"] = list(map(ff.maps[key].get, topo_labels[key]))
@@ -997,7 +997,7 @@ class Topology(MSONable):
         dests, freq = np.unique(bond_list, return_counts=True)
         hubs = dests[np.where(freq > 1)].tolist()
         bond_arr = np.array(bond_list)
-        if len(hubs) > 0:
+        if hubs:
             hub_spokes = {}
             for hub in hubs:
                 ix = np.any(np.isin(bond_arr, hub), axis=1)
@@ -1019,7 +1019,7 @@ class Topology(MSONable):
                 dihedral_list.extend([[ki, ii, jj, li] for ki, li in itertools.product(ks, ls) if ki != li])
 
         topologies = {
-            k: v for k, v in zip(SECTION_KEYWORDS["topology"][:3], [bond_list, angle_list, dihedral_list]) if len(v) > 0
+            k: v for k, v in zip(SECTION_KEYWORDS["topology"][:3], [bond_list, angle_list, dihedral_list]) if v
         } or None
         return cls(sites=molecule, topologies=topologies, **kwargs)
 

--- a/pymatgen/io/lammps/outputs.py
+++ b/pymatgen/io/lammps/outputs.py
@@ -120,7 +120,7 @@ def parse_lammps_dumps(file_pattern):
             dump_cache = []
             for line in file:
                 if line.startswith("ITEM: TIMESTEP"):
-                    if len(dump_cache) > 0:
+                    if dump_cache:
                         yield LammpsDump.from_str("".join(dump_cache))
                     dump_cache = [line]
                 else:

--- a/pymatgen/io/lobster/inputs.py
+++ b/pymatgen/io/lobster/inputs.py
@@ -603,7 +603,7 @@ class Lobsterin(UserDict, MSONable):
                             Lobsterindict[key_word[0].lower()] = [" ".join(key_word[1:])]
                         else:
                             Lobsterindict[key_word[0].lower()].append(" ".join(key_word[1:]))
-                    elif len(key_word) > 0:
+                    elif key_word:
                         Lobsterindict[key_word[0].lower()] = True
 
         return cls(Lobsterindict)

--- a/pymatgen/io/lobster/lobsterenv.py
+++ b/pymatgen/io/lobster/lobsterenv.py
@@ -857,7 +857,7 @@ class LobsterNeighbors(NearNeighbors):
             additional_conds = self._find_relevant_atoms_additional_condition(idx, icohps, additional_condition)
             keys_from_ICOHPs, lengths_from_ICOHPs, neighbors_from_ICOHPs, selected_ICOHPs = additional_conds
 
-            if len(neighbors_from_ICOHPs) > 0:
+            if neighbors_from_ICOHPs:
                 centralsite = self.structure[idx]
 
                 neighbors_by_distance_start = self.structure.get_sites_in_sphere(

--- a/pymatgen/io/lobster/outputs.py
+++ b/pymatgen/io/lobster/outputs.py
@@ -1181,7 +1181,7 @@ class Lobsterout(MSONable):
         ws = []
         for row in data:
             splitrow = row.split()
-            if len(splitrow) > 0 and splitrow[0] == "WARNING:":
+            if splitrow and splitrow[0] == "WARNING:":
                 ws += [" ".join(splitrow[1:])]
         return ws
 
@@ -1190,7 +1190,7 @@ class Lobsterout(MSONable):
         infos = []
         for row in data:
             splitrow = row.split()
-            if len(splitrow) > 0 and splitrow[0] == "INFO:":
+            if splitrow and splitrow[0] == "INFO:":
                 infos += [" ".join(splitrow[1:])]
         return infos
 
@@ -1615,7 +1615,7 @@ class Grosspop(MSONable):
                     small_dict["element"] = cleanline[1]
                     small_dict["Mulliken GP"][cleanline[2]] = float(cleanline[3])
                     small_dict["Loewdin GP"][cleanline[2]] = float(cleanline[4])
-                elif len(cleanline) > 0:
+                elif cleanline:
                     small_dict["Mulliken GP"][cleanline[0]] = float(cleanline[1])
                     small_dict["Loewdin GP"][cleanline[0]] = float(cleanline[2])
                     if "total" in cleanline[0]:

--- a/pymatgen/io/nwchem.py
+++ b/pymatgen/io/nwchem.py
@@ -770,7 +770,7 @@ class NwOutput:
                 m = force_patt.search(line)
                 if m:
                     forces.extend(map(float, m.groups()[5:]))
-                elif len(forces) > 0:
+                elif forces:
                     all_forces.append(forces)
                     forces = []
                     parse_force = False
@@ -812,7 +812,7 @@ class NwOutput:
             elif parse_hess:
                 if line.strip() == "":
                     continue
-                if len(hessian) > 0 and line.find("----------") != -1:
+                if hessian and line.find("----------") != -1:
                     parse_hess = False
                     continue
                 tokens = line.strip().split()

--- a/pymatgen/io/qchem/utils.py
+++ b/pymatgen/io/qchem/utils.py
@@ -108,10 +108,7 @@ def read_table_pattern(
         table_contents = []
         for ml in rp.finditer(table_body_text):
             d = ml.groupdict()
-            if len(d) > 0:
-                processed_line = {k: postprocess(v) for k, v in d.items()}
-            else:
-                processed_line = [postprocess(v) for v in ml.groups()]
+            processed_line = {k: postprocess(v) for k, v in d.items()} if d else [postprocess(v) for v in ml.groups()]
             table_contents.append(processed_line)
         tables.append(table_contents)
     retained_data = tables[-1] if last_one_only else tables

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -2290,7 +2290,7 @@ class PotcarSingle:
                     tmp_str += parsed_val.strip()
                 elif isinstance(parsed_val, (float, int)):
                     psp_vals.append(parsed_val)
-            if len(tmp_str) > 0:
+            if tmp_str:
                 psp_keys.append(tmp_str.lower())
 
         keyword_vals = []

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -2214,7 +2214,7 @@ class Outcar:
                 if not ml:
                     continue
                 d = ml.groupdict()
-                if len(d) > 0:
+                if d:
                     processed_line = {k: postprocess(v) for k, v in d.items()}
                 else:
                     processed_line = [postprocess(v) for v in ml.groups()]
@@ -4559,7 +4559,7 @@ class Wavecar:
                             np.fromfile(file, dtype=np.float64, count=recl8 - 2 * nplane)
 
                         extra_coeffs = []
-                        if len(extra_coeff_inds) > 0:
+                        if extra_coeff_inds:
                             # reconstruct extra coefficients missing from gamma-only executable WAVECAR
                             for G_ind in extra_coeff_inds:
                                 # no idea where this factor of sqrt(2) comes from, but empirically

--- a/pymatgen/io/xtb/outputs.py
+++ b/pymatgen/io/xtb/outputs.py
@@ -131,7 +131,7 @@ class CRESTOutput(MSONable):
                     if "crest_rotamers" in filename:
                         n_rot_file = int(os.path.splitext(filename)[0].split("_")[2])
                         n_rot_files.append(n_rot_file)
-                if len(n_rot_files) > 0:
+                if n_rot_files:
                     final_rotamer_filename = f"crest_rotamers_{max(n_rot_files)}.xyz"
             try:
                 rotamers_path = os.path.join(self.path, final_rotamer_filename)

--- a/pymatgen/phonon/dos.py
+++ b/pymatgen/phonon/dos.py
@@ -478,7 +478,7 @@ class CompletePhononDos(PhononDos):
             "densities": list(self.densities),
             "pdos": [],
         }
-        if len(self.pdos) > 0:
+        if self.pdos:
             for site in self.structure:
                 dct["pdos"].append(list(self.pdos[site]))
         return dct

--- a/pymatgen/symmetry/analyzer.py
+++ b/pymatgen/symmetry/analyzer.py
@@ -105,7 +105,7 @@ class SpacegroupAnalyzer:
         self._unique_species = unique_species
         self._numbers = zs
 
-        if len(magmoms) > 0:
+        if magmoms:
             self._cell: tuple[Any, ...] = (
                 tuple(map(tuple, structure.lattice.matrix.tolist())),
                 tuple(map(tuple, structure.frac_coords.tolist())),
@@ -1048,7 +1048,7 @@ class PointGroupAnalyzer:
         unique_axis = self.principal_axes[ind]
         self._check_rot_sym(unique_axis)
         logger.debug(f"Rotation symmetries = {self.rot_sym}")
-        if len(self.rot_sym) > 0:
+        if self.rot_sym:
             self._check_perpendicular_r2_axis(unique_axis)
 
         if len(self.rot_sym) >= 2:
@@ -1159,7 +1159,7 @@ class PointGroupAnalyzer:
         _origin_site, dist_el_sites = cluster_sites(self.centered_mol, self.tol)
         for test_set in dist_el_sites.values():
             valid_set = list(filter(not_on_axis, test_set))
-            if len(valid_set) > 0:
+            if valid_set:
                 valid_sets.append(valid_set)
 
         return min(valid_sets, key=len)

--- a/pymatgen/util/string.py
+++ b/pymatgen/util/string.py
@@ -385,7 +385,7 @@ def disordered_formula(disordered_struct, symbols=("x", "y", "z"), fmt="plain"):
         species = str(sp)
         if species not in disordered_species:
             disordered_comp.append((species, formula_double_format(occu / factor)))
-        elif len(symbols) > 0:
+        elif symbols:
             symbol = symbols.pop(0)
             disordered_comp.append((species, symbol))
             variable_map[symbol] = occu / total_disordered_occu / factor

--- a/pymatgen/util/testing/aims.py
+++ b/pymatgen/util/testing/aims.py
@@ -43,10 +43,10 @@ def compare_files(test_name: str, work_dir: Path, ref_dir: Path) -> None:
     """
     for file in glob(f"{work_dir / test_name}/*in"):
         with open(file) as test_file:
-            test_lines = [line.strip() for line in test_file.readlines() if len(line.strip()) > 0 and line[0] != "#"]
+            test_lines = [line.strip() for line in test_file.readlines() if line.strip() and line[0] != "#"]
 
         with gzip.open(f"{ref_dir / test_name / Path(file).name}.gz", "rt") as ref_file:
-            ref_lines = [line.strip() for line in ref_file.readlines() if len(line.strip()) > 0 and line[0] != "#"]
+            ref_lines = [line.strip() for line in ref_file.readlines() if line.strip() and line[0] != "#"]
 
         for test_line, ref_line in zip(test_lines, ref_lines):
             if "output" in test_line and "band" in test_line:

--- a/tests/core/test_periodic_table.py
+++ b/tests/core/test_periodic_table.py
@@ -298,7 +298,7 @@ class TestElement(PymatgenTest):
                     assert "IUPAC ordering" in el.data
                     assert getattr(el, key) is not None
 
-            if len(el.oxidation_states) > 0:
+            if el.oxidation_states:
                 assert max(el.oxidation_states) == el.max_oxidation_state
                 assert min(el.oxidation_states) == el.min_oxidation_state
 

--- a/tests/io/aims/test_sets/test_input_set.py
+++ b/tests/io/aims/test_sets/test_input_set.py
@@ -241,8 +241,8 @@ infile_dir = Path(__file__).parent / "input_files"
 
 
 def check_file(ref: str, test: str) -> bool:
-    ref_lines = [line.strip() for line in ref.split("\n") if len(line.strip()) > 0 and line[0] != "#"]
-    test_lines = [line.strip() for line in test.split("\n") if len(line.strip()) > 0 and line[0] != "#"]
+    ref_lines = [line.strip() for line in ref.split("\n") if line.strip() and line[0] != "#"]
+    test_lines = [line.strip() for line in test.split("\n") if line.strip() and line[0] != "#"]
 
     return ref_lines == test_lines
 


### PR DESCRIPTION
## Summary

Replace unnecessary usage of `len` for iterable existence check:

- `if len(x) > 0` replaced with `if x`
- `if len(x) < 1` replaced with `if not x`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Streamlined logic in lattice module for improved efficiency.
	- Enhanced readability by replacing length checks with boolean evaluations.
	- Simplified conditional checks in structure module for better readability.
	- Improved initialization logic for bond valence calculations, enhancing compatibility with specific species.
	- Simplified conditional checks in mixing scheme module for streamlined logic.
	- Simplified condition checks for data presence in CIF module.
	- Updated method in CIF module to use boolean evaluation for argument extraction.
	- Appended various warnings based on data processing conditions.
- **Tests**
	- Simplified conditions in test cases for oxidation states and file line processing for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->