### PR TITLE
Fix breaking changes in cohp module of pymatgen

### DIFF
--- a/pymatgen/electronic_structure/cohp.py
+++ b/pymatgen/electronic_structure/cohp.py
@@ -157,7 +157,7 @@ class Cohp(MSONable):
                 raise ValueError("ICOHP is empty.")
         return inter
 
-    def has_antiband_states_below_efermi(self, spin=None, limit=0.01):
+    def has_antibnd_states_below_efermi(self, spin=None, limit=0.01):
         """Returns dict indicating if there are antibonding states below the Fermi level depending on the spin
         spin: Spin
         limit: -COHP smaller -limit will be considered.

--- a/tests/electronic_structure/test_cohp.py
+++ b/tests/electronic_structure/test_cohp.py
@@ -79,9 +79,9 @@ class TestCohp(TestCase):
         assert str(self.coop).strip().startswith(header)
 
     def test_antibnd_states_below_efermi(self):
-        assert self.cohp.has_antiband_states_below_efermi(spin=None) == {Spin.up: True, Spin.down: True}
-        assert self.cohp.has_antiband_states_below_efermi(spin=None, limit=0.5) == {Spin.up: False, Spin.down: False}
-        assert self.cohp.has_antiband_states_below_efermi(spin=Spin.up, limit=0.5) == {Spin.up: False}
+        assert self.cohp.has_antibnd_states_below_efermi(spin=None) == {Spin.up: True, Spin.down: True}
+        assert self.cohp.has_antibnd_states_below_efermi(spin=None, limit=0.5) == {Spin.up: False, Spin.down: False}
+        assert self.cohp.has_antibnd_states_below_efermi(spin=Spin.up, limit=0.5) == {Spin.up: False}
 
 
 class TestIcohpValue(TestCase):


### PR DESCRIPTION
As described in #3744 , the name of a method was changed in a way that it doesn't make any sense and that LobsterPy stopped working. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Renamed the function to check for antibonding states below the Fermi level for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->