### PR TITLE
Fix `typing_extension` `ImportError` in downstream packages

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ ci:
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.5
+    rev: v0.3.7
     hooks:
       - id: ruff
         args: [--fix, --unsafe-fixes]

--- a/pymatgen/analysis/elasticity/stress.py
+++ b/pymatgen/analysis/elasticity/stress.py
@@ -6,11 +6,14 @@ calculate relevant properties of the stress tensor.
 from __future__ import annotations
 
 import math
+from typing import TYPE_CHECKING
 
 import numpy as np
-from typing_extensions import Self
 
 from pymatgen.core.tensors import SquareTensor
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
 
 __author__ = "Joseph Montoya"
 __copyright__ = "Copyright 2012, The Materials Project"

--- a/pymatgen/core/__init__.py
+++ b/pymatgen/core/__init__.py
@@ -1,4 +1,3 @@
-# ruff: noqa: PLC0414
 """This package contains core modules and classes for representing structures and operations on them."""
 
 from __future__ import annotations
@@ -10,25 +9,13 @@ from typing import Any
 
 from ruamel.yaml import YAML
 
-from pymatgen.core.composition import Composition as Composition
-from pymatgen.core.lattice import Lattice as Lattice
-from pymatgen.core.operations import SymmOp as SymmOp
-from pymatgen.core.periodic_table import DummySpecie as DummySpecie
-from pymatgen.core.periodic_table import DummySpecies as DummySpecies
-from pymatgen.core.periodic_table import Element as Element
-from pymatgen.core.periodic_table import Species as Species
-from pymatgen.core.periodic_table import get_el_sp as get_el_sp
-from pymatgen.core.sites import PeriodicSite as PeriodicSite
-from pymatgen.core.sites import Site as Site
-from pymatgen.core.structure import IMolecule as IMolecule
-from pymatgen.core.structure import IStructure as IStructure
-from pymatgen.core.structure import Molecule as Molecule
-from pymatgen.core.structure import PeriodicNeighbor as PeriodicNeighbor
-from pymatgen.core.structure import SiteCollection as SiteCollection
-from pymatgen.core.structure import Structure as Structure
-from pymatgen.core.units import ArrayWithUnit as ArrayWithUnit
-from pymatgen.core.units import FloatWithUnit as FloatWithUnit
-from pymatgen.core.units import Unit as Unit
+from pymatgen.core.composition import Composition
+from pymatgen.core.lattice import Lattice
+from pymatgen.core.operations import SymmOp
+from pymatgen.core.periodic_table import DummySpecie, DummySpecies, Element, Species, get_el_sp
+from pymatgen.core.sites import PeriodicSite, Site
+from pymatgen.core.structure import IMolecule, IStructure, Molecule, PeriodicNeighbor, SiteCollection, Structure
+from pymatgen.core.units import ArrayWithUnit, FloatWithUnit, Unit
 
 __author__ = "Pymatgen Development Team"
 __email__ = "pymatgen@googlegroups.com"

--- a/pymatgen/ext/optimade.py
+++ b/pymatgen/ext/optimade.py
@@ -5,15 +5,18 @@ from __future__ import annotations
 import logging
 import sys
 from collections import namedtuple
+from typing import TYPE_CHECKING
 from urllib.parse import urljoin, urlparse
 
 import requests
 from tqdm import tqdm
-from typing_extensions import Self
 
 from pymatgen.core import DummySpecies, Structure
 from pymatgen.util.due import Doi, due
 from pymatgen.util.provenance import StructureNL
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
 
 # TODO: importing optimade-python-tool's data structures will make more sense
 Provider = namedtuple("Provider", ["name", "base_url", "description", "homepage", "prefix"])

--- a/pymatgen/io/abinit/netcdf.py
+++ b/pymatgen/io/abinit/netcdf.py
@@ -7,17 +7,20 @@ from __future__ import annotations
 import logging
 import os.path
 import warnings
+from typing import TYPE_CHECKING
 
 import numpy as np
 from monty.collections import AttrDict
 from monty.dev import requires
 from monty.functools import lazy_property
 from monty.string import marquee
-from typing_extensions import Self
 
 from pymatgen.core.structure import Structure
 from pymatgen.core.units import ArrayWithUnit
 from pymatgen.core.xcfunc import XcFunc
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
 
 try:
     import netCDF4

--- a/tests/io/test_packmol.py
+++ b/tests/io/test_packmol.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import re
 from pathlib import Path
 from shutil import which
 from subprocess import TimeoutExpired
@@ -12,11 +13,8 @@ from pymatgen.core import Molecule
 from pymatgen.io.packmol import PackmolBoxGen
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
 
-# ruff: noqa: PT011
-
-
 TEST_DIR = f"{TEST_FILES_DIR}/packmol"
-
+ERR_MSG_173 = re.escape("Packmol failed with error code 173 and stderr: b'STOP 173\\n'")
 
 if which("packmol") is None:
     pytest.skip("packmol executable not present", allow_module_level=True)
@@ -110,7 +108,7 @@ class TestPackmolSet(PymatgenTest):
             input_string = file.read()
             assert "maxit 0" in input_string
             assert "nloop 0" in input_string
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=ERR_MSG_173):
             input_set.run(self.tmp_path)
 
     def test_timeout(self):
@@ -141,7 +139,7 @@ class TestPackmolSet(PymatgenTest):
         with open(f"{self.tmp_path}/packmol.inp") as file:
             input_string = file.read()
             assert "inside box 0 0 0 2 2 2" in input_string
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=ERR_MSG_173):
             pw.run(self.tmp_path)
 
     def test_chdir_behavior(self):
@@ -159,7 +157,8 @@ class TestPackmolSet(PymatgenTest):
             box=[0, 0, 0, 2, 2, 2],
         )
         pw.write_input(self.tmp_path)
-        with pytest.raises(ValueError):
+
+        with pytest.raises(ValueError, match=ERR_MSG_173):
             pw.run(self.tmp_path)
         assert str(Path.cwd()) == start_dir
 

--- a/tests/io/test_packmol.py
+++ b/tests/io/test_packmol.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import re
 from pathlib import Path
 from shutil import which
 from subprocess import TimeoutExpired
@@ -14,7 +13,7 @@ from pymatgen.io.packmol import PackmolBoxGen
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
 
 TEST_DIR = f"{TEST_FILES_DIR}/packmol"
-ERR_MSG_173 = re.escape("Packmol failed with error code 173 and stderr: b'STOP 173\\n'")
+ERR_MSG_173 = "Packmol failed with error code 173 and stderr"
 
 if which("packmol") is None:
     pytest.skip("packmol executable not present", allow_module_level=True)

--- a/tests/io/test_packmol.py
+++ b/tests/io/test_packmol.py
@@ -13,7 +13,11 @@ from pymatgen.io.packmol import PackmolBoxGen
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
 
 TEST_DIR = f"{TEST_FILES_DIR}/packmol"
-ERR_MSG_173 = "Packmol failed with error code 173 and stderr"
+# error message is different in CI for unknown reasons (as of 2024-04-12)
+# macOS: "Packmol failed with error code 173 and stderr: b'STOP 173\\n'"
+# CI: "Packmol failed with return code 0 and stdout: Packmol was unable to
+# put the molecules in the desired regions even without"
+ERR_MSG_173 = "Packmol failed with "
 
 if which("packmol") is None:
     pytest.skip("packmol executable not present", allow_module_level=True)

--- a/tests/transformations/test_standard_transformations.py
+++ b/tests/transformations/test_standard_transformations.py
@@ -1,4 +1,3 @@
-# ruff: noqa: N806
 from __future__ import annotations
 
 import functools


### PR DESCRIPTION
closes #3751

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved code readability by consolidating imports in core modules.
	- Enhanced type hinting and conditional type checking across various modules.

- **Tests**
	- Updated test functions with specific error messages for better clarity.

- **Chores**
	- Updated revision of pre-commit hooks to ensure code quality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->