### PR TITLE
Remove duplicate ruff rule in `pyproject.toml`

### DIFF
--- a/pymatgen/analysis/chemenv/connectivity/connected_components.py
+++ b/pymatgen/analysis/chemenv/connectivity/connected_components.py
@@ -241,17 +241,16 @@ class ConnectedComponent(MSONable):
                 if links_data is None:
                     edge_data = None
 
+                elif (env_node1, env_node2, key) in links_data:
+                    edge_data = links_data[(env_node1, env_node2, key)]
+                elif (env_node2, env_node1, key) in links_data:
+                    edge_data = links_data[(env_node2, env_node1, key)]
+                elif (env_node1, env_node2) in links_data:
+                    edge_data = links_data[(env_node1, env_node2)]
+                elif (env_node2, env_node1) in links_data:
+                    edge_data = links_data[(env_node2, env_node1)]
                 else:
-                    if (env_node1, env_node2, key) in links_data:
-                        edge_data = links_data[(env_node1, env_node2, key)]
-                    elif (env_node2, env_node1, key) in links_data:
-                        edge_data = links_data[(env_node2, env_node1, key)]
-                    elif (env_node1, env_node2) in links_data:
-                        edge_data = links_data[(env_node1, env_node2)]
-                    elif (env_node2, env_node1) in links_data:
-                        edge_data = links_data[(env_node2, env_node1)]
-                    else:
-                        edge_data = None
+                    edge_data = None
 
                 if edge_data:
                     self._connected_subgraph.add_edge(env_node1, env_node2, key, **edge_data)

--- a/pymatgen/electronic_structure/cohp.py
+++ b/pymatgen/electronic_structure/cohp.py
@@ -772,57 +772,52 @@ class CompleteCohp(Cohp):
                     # LMTO COHPs have 5 significant figures
                     avg_data[i].update({spin: np.array([round_to_sigfigs(a, 5) for a in avg], dtype=float)})
             avg_cohp = Cohp(efermi, energies, avg_data["COHP"], icohp=avg_data["ICOHP"])
+        elif not are_multi_center_cobis:
+            avg_cohp = Cohp(
+                efermi,
+                energies,
+                cohp_data["average"]["COHP"],
+                icohp=cohp_data["average"]["ICOHP"],
+                are_coops=are_coops,
+                are_cobis=are_cobis,
+                are_multi_center_cobis=are_multi_center_cobis,
+            )
+            del cohp_data["average"]
         else:
-            if not are_multi_center_cobis:
-                avg_cohp = Cohp(
-                    efermi,
-                    energies,
-                    cohp_data["average"]["COHP"],
-                    icohp=cohp_data["average"]["ICOHP"],
-                    are_coops=are_coops,
-                    are_cobis=are_cobis,
-                    are_multi_center_cobis=are_multi_center_cobis,
-                )
-                del cohp_data["average"]
-            else:
-                # only include two-center cobis in average
-                # do this for both spin channels
-                cohp = {}
-                cohp[Spin.up] = np.array(
-                    [np.array(c["COHP"][Spin.up]) for c in cohp_file.cohp_data.values() if len(c["sites"]) <= 2]
+            # only include two-center cobis in average
+            # do this for both spin channels
+            cohp = {}
+            cohp[Spin.up] = np.array(
+                [np.array(c["COHP"][Spin.up]) for c in cohp_file.cohp_data.values() if len(c["sites"]) <= 2]
+            ).mean(axis=0)
+            try:
+                cohp[Spin.down] = np.array(
+                    [np.array(c["COHP"][Spin.down]) for c in cohp_file.cohp_data.values() if len(c["sites"]) <= 2]
+                ).mean(axis=0)
+            except KeyError:
+                pass
+            try:
+                icohp = {}
+                icohp[Spin.up] = np.array(
+                    [np.array(c["ICOHP"][Spin.up]) for c in cohp_file.cohp_data.values() if len(c["sites"]) <= 2]
                 ).mean(axis=0)
                 try:
-                    cohp[Spin.down] = np.array(
-                        [np.array(c["COHP"][Spin.down]) for c in cohp_file.cohp_data.values() if len(c["sites"]) <= 2]
+                    icohp[Spin.down] = np.array(
+                        [np.array(c["ICOHP"][Spin.down]) for c in cohp_file.cohp_data.values() if len(c["sites"]) <= 2]
                     ).mean(axis=0)
                 except KeyError:
                     pass
-                try:
-                    icohp = {}
-                    icohp[Spin.up] = np.array(
-                        [np.array(c["ICOHP"][Spin.up]) for c in cohp_file.cohp_data.values() if len(c["sites"]) <= 2]
-                    ).mean(axis=0)
-                    try:
-                        icohp[Spin.down] = np.array(
-                            [
-                                np.array(c["ICOHP"][Spin.down])
-                                for c in cohp_file.cohp_data.values()
-                                if len(c["sites"]) <= 2
-                            ]
-                        ).mean(axis=0)
-                    except KeyError:
-                        pass
-                except KeyError:
-                    icohp = None
-                avg_cohp = Cohp(
-                    efermi,
-                    energies,
-                    cohp,
-                    icohp=icohp,
-                    are_coops=are_coops,
-                    are_cobis=are_cobis,
-                    are_multi_center_cobis=are_multi_center_cobis,
-                )
+            except KeyError:
+                icohp = None
+            avg_cohp = Cohp(
+                efermi,
+                energies,
+                cohp,
+                icohp=icohp,
+                are_coops=are_coops,
+                are_cobis=are_cobis,
+                are_multi_center_cobis=are_multi_center_cobis,
+            )
 
         cohp_dict = {
             key: Cohp(

--- a/pymatgen/io/aims/sets/bs.py
+++ b/pymatgen/io/aims/sets/bs.py
@@ -45,9 +45,8 @@ def prepare_band_input(structure: Structure, density: float = 20):
                 current_segment["length"] += 1
                 lines_and_labels.append(current_segment)
                 current_segment = None
-        else:
-            if current_segment is not None:
-                current_segment["length"] += 1
+        elif current_segment is not None:
+            current_segment["length"] += 1
 
     bands = []
     for segment in lines_and_labels:

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -1114,11 +1114,10 @@ class DictSet(VaspInputSet):
 
         if custom_encut is not None:
             encut = custom_encut
+        elif self.incar.get("ENCUT", 0) > 0:
+            encut = self.incar["ENCUT"]  # get the ENCUT val
         else:
-            if self.incar.get("ENCUT", 0) > 0:
-                encut = self.incar["ENCUT"]  # get the ENCUT val
-            else:
-                encut = max(i_species.enmax for i_species in self.get_vasp_input()["POTCAR"])
+            encut = max(i_species.enmax for i_species in self.get_vasp_input()["POTCAR"])
 
         # PREC=Normal is VASP default
         PREC = self.incar.get("PREC", "Normal") if custom_prec is None else custom_prec

--- a/pymatgen/phonon/plotter.py
+++ b/pymatgen/phonon/plotter.py
@@ -205,15 +205,14 @@ class PhononDosPlotter:
             ax.set_xlim(xlim)
         if ylim:
             ax.set_ylim(ylim)
+        elif invert_axes:
+            _ylim = ax.get_ylim()
+            relevant_x = [p[1] for p in all_pts if _ylim[0] < p[0] < _ylim[1]] or ax.get_xlim()
+            ax.set_xlim((min(relevant_x), max(relevant_x)))
         else:
-            if invert_axes:
-                _ylim = ax.get_ylim()
-                relevant_x = [p[1] for p in all_pts if _ylim[0] < p[0] < _ylim[1]] or ax.get_xlim()
-                ax.set_xlim((min(relevant_x), max(relevant_x)))
-            else:
-                _xlim = ax.get_xlim()
-                relevant_y = [p[1] for p in all_pts if _xlim[0] < p[0] < _xlim[1]] or ax.get_ylim()
-                ax.set_ylim((min(relevant_y), max(relevant_y)))
+            _xlim = ax.get_xlim()
+            relevant_y = [p[1] for p in all_pts if _xlim[0] < p[0] < _xlim[1]] or ax.get_ylim()
+            ax.set_ylim((min(relevant_y), max(relevant_y)))
 
         if invert_axes:
             ax.axhline(0, linewidth=2, color="black", linestyle="--")

--- a/pymatgen/util/provenance.py
+++ b/pymatgen/util/provenance.py
@@ -93,11 +93,10 @@ class HistoryNode(namedtuple("HistoryNode", ["name", "url", "description"])):
         """Parses a History Node object from either a dict or a tuple.
 
         Args:
-            h_node: A dict with name/url/description fields or a 3-element
-                tuple.
+            h_node: A dict with name/url/description fields or a 3-element tuple.
 
         Returns:
-            History node.
+            HistoryNode
         """
         if isinstance(h_node, dict):
             return cls.from_dict(h_node)

--- a/pymatgen/vis/structure_vtk.py
+++ b/pymatgen/vis/structure_vtk.py
@@ -988,7 +988,7 @@ class MultiStructuresVis(StructureVis):
         tags = {}
         for tag in self.tags:
             istruct = tag.get("istruct", "all")
-            if istruct != "all" and istruct != self.istruct:
+            if istruct not in ("all", self.istruct):
                 continue
             site_index = tag["site_index"]
             color = tag.get("color", [0.5, 0.5, 0.5])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,35 +23,38 @@ repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest
 target-version = "py39"
 line-length = 120
 lint.select = [
-  "B",      # flake8-bugbear
-  "C4",     # flake8-comprehensions
-  "D",      # pydocstyle
-  "E",      # pycodestyle error
-  "EXE",    # flake8-executable
-  "F",      # pyflakes
-  "FA",     # flake8-future-annotations
-  "FBT003", # boolean-positional-value-in-call
-  "FLY",    # flynt
-  "I",      # isort
-  "ICN",    # flake8-import-conventions
-  "ISC",    # flake8-implicit-str-concat
-  "PD",     # pandas-vet
-  "PERF",   # perflint
-  "PIE",    # flake8-pie
-  "PL",     # pylint
-  "PT",     # flake8-pytest-style
-  "PYI",    # flakes8-pyi
-  "Q",      # flake8-quotes
-  "RET",    # flake8-return
-  "RSE",    # flake8-raise
-  "RUF",    # Ruff-specific rules
-  "SIM",    # flake8-simplify
-  "SLOT",   # flake8-slots
-  "TCH",    # flake8-type-checking
-  "TID",    # flake8-tidy-imports
-  "UP",     # pyupgrade
-  "W",      # pycodestyle warning
-  "YTT",    # flake8-2020
+  "B",       # flake8-bugbear
+  "C4",      # flake8-comprehensions
+  "D",       # pydocstyle
+  "E",       # pycodestyle error
+  "EXE",     # flake8-executable
+  "F",       # pyflakes
+  "FA",      # flake8-future-annotations
+  "FBT003",  # boolean-positional-value-in-call
+  "FLY",     # flynt
+  "I",       # isort
+  "ICN",     # flake8-import-conventions
+  "ISC",     # flake8-implicit-str-concat
+  "PD",      # pandas-vet
+  "PERF",    # perflint
+  "PIE",     # flake8-pie
+  "PL",      # pylint
+  "PLR0402",
+  "PLR1714",
+  "PLR5501",
+  "PT",      # flake8-pytest-style
+  "PYI",     # flakes8-pyi
+  "Q",       # flake8-quotes
+  "RET",     # flake8-return
+  "RSE",     # flake8-raise
+  "RUF",     # Ruff-specific rules
+  "SIM",     # flake8-simplify
+  "SLOT",    # flake8-slots
+  "TCH",     # flake8-type-checking
+  "TID",     # flake8-tidy-imports
+  "UP",      # pyupgrade
+  "W",       # pycodestyle warning
+  "YTT",     # flake8-2020
 ]
 lint.ignore = [
   "B023",    # Function definition does not bind loop variable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,6 @@ lint.ignore = [
   "PERF401", # manual-list-comprehension (TODO fix these or wait for autofix)
   "PLC1901", # can be simplified to ... as empty is falsey
   "PLR",     # pylint refactor
-  "PLW1514", # open() without explicit encoding argument
   "PLW2901", # Outer for loop variable overwritten by inner assignment target
   "PT013",   # pytest-incorrect-pytest-import
   "PTH",     # prefer pathlib to os.path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ lint.select = [
   "SIM",    # flake8-simplify
   "SLOT",   # flake8-slots
   "TCH",    # flake8-type-checking
-  "TID",    # tidy imports
   "TID",    # flake8-tidy-imports
   "UP",     # pyupgrade
   "W",      # pycodestyle warning

--- a/tests/io/vasp/test_outputs.py
+++ b/tests/io/vasp/test_outputs.py
@@ -4,10 +4,10 @@ import gzip
 import json
 import os
 import sys
-import xml.etree.ElementTree as ElementTree
 from io import StringIO
 from pathlib import Path
 from shutil import copyfile, copyfileobj
+from xml.etree import ElementTree
 
 import numpy as np
 import pytest

--- a/tests/phonon/test_init.py
+++ b/tests/phonon/test_init.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 import pymatgen.phonon as ph
 import pymatgen.phonon.bandstructure as bs
-import pymatgen.phonon.dos as dos
 import pymatgen.phonon.gruneisen as gru
-import pymatgen.phonon.plotter as plotter
+from pymatgen.phonon import dos, plotter
 
 
 def test_convenience_imports():


### PR DESCRIPTION
"TID" was listed twice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Updated the linting tool from "TID" to "flake8-tidy-imports" for improved code quality checks.
- **Refactor**
    - Restructured the logic for setting y-axis limits in the `get_plot` function of `plotter.py`.
    - Simplified the logic for updating the length of `current_segment` in the `prepare_band_input` function in `bs.py`.
    - Consolidated the edge data retrieval logic in the `connected_components.py` file for a more structured approach.
    - Refactored the logic related to parsing eigenvalues in VASP output files for improved organization.
    - Simplified the logic for determining the `encut` value in the `calculate_ng` function of `sets.py`.
    - Modified the logic for checking `istruct` in the `apply_tags` method of `structure_vtk.py`.
- **Documentation**
    - Updated the return type annotation from `History node` to `HistoryNode` in the `parse_history_node` method.
- **Tests**
    - Reorganized imports in the `test_outputs.py` file by switching to import `ElementTree` from `xml.etree`.
    - Streamlined import statements in the `test_init.py` file related to `pymatgen.phonon` module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->