### PR TITLE
Fix OPTIMADE rester URL contruction and improve testing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,6 @@
 * @shyuep @janosh @mkhorton
 pymatgen/io/ase.py @Andrew-S-Rosen
-pymatgen/io/abinit/* @gmatteo
+pymatgen/io/abinit/*@gmatteo
 pymatgen/io/lobster/* @JaGeo
+pymatgen/ext/* @ml-evs
+tests/ext/* @ml-evs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 * @shyuep @janosh @mkhorton
 pymatgen/io/ase.py @Andrew-S-Rosen
-pymatgen/io/abinit/*@gmatteo
+pymatgen/io/abinit/* @gmatteo
 pymatgen/io/lobster/* @JaGeo
 pymatgen/ext/* @ml-evs
 tests/ext/* @ml-evs

--- a/pymatgen/ext/optimade.py
+++ b/pymatgen/ext/optimade.py
@@ -447,7 +447,6 @@ class OptimadeRester:
         TODO: careful reading of OPTIMADE specification required
         TODO: add better exception handling, intentionally permissive currently
         """
-
         # Add trailing slash to all URLs if missing; prevents urljoin from scrubbing
         # sections of the path
         if urlparse(provider_url).path is not None and not provider_url.endswith("/"):

--- a/pymatgen/ext/optimade.py
+++ b/pymatgen/ext/optimade.py
@@ -133,6 +133,11 @@ class OptimadeRester:
         # and values as the corresponding URL
         self.resources = {}
 
+        # preprocess aliases to ensure they have a trailing slash where appropriate
+        for alias, url in self.aliases.items():
+            if urlparse(url).path is not None and not url.endswith("/"):
+                self.aliases[alias] += "/"
+
         if not aliases_or_resource_urls:
             aliases_or_resource_urls = list(self.aliases)
             _logger.warning(
@@ -443,6 +448,11 @@ class OptimadeRester:
         TODO: add better exception handling, intentionally permissive currently
         """
 
+        # Add trailing slash to all URLs if missing; prevents urljoin from scrubbing
+        # sections of the path
+        if urlparse(provider_url).path is not None and not provider_url.endswith("/"):
+            provider_url += "/"
+
         def is_url(url) -> bool:
             """Basic URL validation thanks to https://stackoverflow.com/a/52455972."""
             try:
@@ -492,6 +502,9 @@ class OptimadeRester:
             A dictionary of keys (in format of "provider.database") to
             Provider objects.
         """
+        # Add trailing slash to all URLs if missing; prevents urljoin from scrubbing
+        if urlparse(provider_url).path is not None and not provider_url.endswith("/"):
+            provider_url += "/"
         try:
             url = urljoin(provider_url, "v1/links")
             provider_link_json = self._get_json(url)
@@ -551,6 +564,11 @@ class OptimadeRester:
             structure_providers.update(self._parse_provider(provider, provider_link))
 
         self.aliases = {alias: provider.base_url for alias, provider in structure_providers.items()}
+
+        # Add missing trailing slashes to any aliases with a path that need them
+        for alias, url in self.aliases.items():
+            if urlparse(url).path is not None and not url.endswith("/"):
+                self.aliases[alias] += "/"
 
     # TODO: revisit context manager logic here and in MPRester
     def __enter__(self) -> Self:

--- a/tests/ext/test_optimade.py
+++ b/tests/ext/test_optimade.py
@@ -9,15 +9,19 @@ from pymatgen.util.testing import PymatgenTest
 
 try:
     # 403 is returned when server detects bot-like behavior
-    website_down = requests.get("https://materialsproject.org").status_code not in (200, 403)
+    website_down = requests.get("https://optimade.materialsproject.org").status_code not in (200, 403)
 except requests.exceptions.ConnectionError:
     website_down = True
 
+try:
+    # 403 is returned when server detects bot-like behavior
+    optimade_providers_down = requests.get("https://providers.optimade.org").status_code not in (200, 403)
+except requests.exceptions.ConnectionError:
+    optimade_providers_down = True
+
 
 class TestOptimade(PymatgenTest):
-    @pytest.mark.skipif(
-        not SETTINGS.get("PMG_MAPI_KEY") or website_down, reason="PMG_MAPI_KEY env var not set or MP is down."
-    )
+    @pytest.mark.skipif(website_down, reason="MP OPTIMADE is down.")
     def test_get_structures_mp(self):
         with OptimadeRester("mp") as optimade:
             structs = optimade.get_structures(elements=["Ga", "N"], nelements=2)
@@ -35,9 +39,7 @@ class TestOptimade(PymatgenTest):
                     raw_filter_structs["mp"]
                 ), f"Raw filter {_filter} did not return the same number of results as the query builder."
 
-    @pytest.mark.skipif(
-        not SETTINGS.get("PMG_MAPI_KEY") or website_down, reason="PMG_MAPI_KEY env var not set or MP is down."
-    )
+    @pytest.mark.skipif(website_down, reason="MP OPTIMADE is down.")
     def test_get_snls_mp(self):
         base_query = dict(elements=["Ga", "N"], nelements=2, nsites=[2, 6])
         with OptimadeRester("mp") as optimade:
@@ -60,48 +62,46 @@ class TestOptimade(PymatgenTest):
             struct_nl_set = next(iter(extra_fields_set["mp"].values()))
             assert field_set <= {*struct_nl_set.data["_optimade"]}
 
-    # Tests fail in CI for unknown reason, use for development only.
-    # def test_get_structures_mcloud_2dstructures(self):
-    #     with OptimadeRester("mcloud.2dstructures") as optimade:
-    #         structs = optimade.get_structures(elements=["B", "N"], nelements=2)
+    def test_get_structures_mcloud_2dstructures(self):
+        with OptimadeRester("mcloud.2dstructures") as optimade:
+            structs = optimade.get_structures(elements=["B", "N"], nelements=2)
 
-    #     test_struct = next(iter(structs["mcloud.2dstructures"].values()))
+        test_struct = next(iter(structs["mcloud.2dstructures"].values()))
 
-    #     assert [str(el) for el in test_struct.types_of_species] == ["B", "N"]
+        assert [str(el) for el in test_struct.types_of_species] == ["B", "N"]
 
-    # def test_update_aliases(self):
-    #
-    #     with OptimadeRester() as optimade:
-    #         optimade.refresh_aliases()
-    #
-    #     self.assertIn("mp", optimade.aliases)
+    @pytest.mark.skipif(optimade_providers_down, reason="OPTIMADE providers list is down.")
+    def test_update_aliases(self):
+        with OptimadeRester() as optimade:
+            optimade.refresh_aliases()
+
+        assert "mp" in optimade.aliases
 
     def test_build_filter(self):
-        with OptimadeRester("mp") as optimade:
-            assert optimade._build_filter(
-                elements=["Ga", "N"],
-                nelements=2,
-                nsites=(1, 100),
-                chemical_formula_anonymous="A2B",
-                chemical_formula_hill="GaN",
-            ) == (
-                '(elements HAS ALL "Ga", "N")'
-                " AND (nsites>=1 AND nsites<=100)"
-                " AND (nelements=2)"
-                " AND (chemical_formula_anonymous='A2B')"
-                " AND (chemical_formula_hill='GaN')"
-            )
+        assert OptimadeRester._build_filter(
+            elements=["Ga", "N"],
+            nelements=2,
+            nsites=(1, 100),
+            chemical_formula_anonymous="A2B",
+            chemical_formula_hill="GaN",
+        ) == (
+            '(elements HAS ALL "Ga", "N")'
+            " AND (nsites>=1 AND nsites<=100)"
+            " AND (nelements=2)"
+            " AND (chemical_formula_anonymous='A2B')"
+            " AND (chemical_formula_hill='GaN')"
+        )
 
-            assert optimade._build_filter(
-                elements=["C", "H", "O"],
-                nelements=(3, 4),
-                nsites=(1, 100),
-                chemical_formula_anonymous="A4B3C",
-                chemical_formula_hill="C4H3O",
-            ) == (
-                '(elements HAS ALL "C", "H", "O")'
-                " AND (nsites>=1 AND nsites<=100)"
-                " AND (nelements>=3 AND nelements<=4)"
-                " AND (chemical_formula_anonymous='A4B3C')"
-                " AND (chemical_formula_hill='C4H3O')"
-            )
+        assert OptimadeRester._build_filter(
+            elements=["C", "H", "O"],
+            nelements=(3, 4),
+            nsites=(1, 100),
+            chemical_formula_anonymous="A4B3C",
+            chemical_formula_hill="C4H3O",
+        ) == (
+            '(elements HAS ALL "C", "H", "O")'
+            " AND (nsites>=1 AND nsites<=100)"
+            " AND (nelements>=3 AND nelements<=4)"
+            " AND (chemical_formula_anonymous='A4B3C')"
+            " AND (chemical_formula_hill='C4H3O')"
+        )


### PR DESCRIPTION
Closes #3753.

URLs with paths need to have trailing slashes otherwise `urljoin` mangles them. OPTIMADE base URLs do not need to have trailing slashes, hence an issue arises for any provider that serves multiple databases from different URL paths.

This PR dynamically fixes these URLs when they occur (so that the aliases still match those given by providers).

I also tweaked re-enabled some tests that were disabled for some reason:

- Run MP OPTIMADE tests even without API key (not necessary)
- Run filter builder without needing to make any network calls
- Test alias refresher when OPTIMADE providers list is accessible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Enhanced URL handling in the application to ensure all URLs correctly include a trailing slash, improving consistency and reliability in accessing external resources.

- **Tests**
  - Updated tests to accommodate new URL formatting rules and improved error handling.
  - Added new tests for OPTIMADE providers to ensure robust service integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->