### PR TITLE
Add a CI run that only tests non-optional deps (optimistically)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,26 +66,38 @@ jobs:
         run: |
           sudo cp cmd_line/gulp/Linux_64bit/* /usr/local/bin/
 
+      - name: Install pymatgen and mandatory testing dependencies only
+        run: |
+          micromamba activate pmg
+
+          uv pip install -e '.[dev]'
+
+      - name: pytest split ${{ matrix.split }}
+        run: |
+          micromamba activate pmg
+          pytest --splits 10 --group ${{ matrix.split }} --durations-path tests/files/.pytest-split-durations tests
+
       - name: Install ubuntu-only conda dependencies
         if: matrix.os == 'ubuntu-latest'
         run: |
           micromamba install -n pmg -c conda-forge enumlib packmol bader openbabel openff-toolkit --yes
 
-      - name: Install pymatgen and dependencies
+      - name: Install all optional dependencies with workarounds
         run: |
-          micromamba activate pmg
-          # TODO remove temporary fix. added since uv install torch is flaky.
-          # track https://github.com/astral-sh/uv/issues/1921 for resolution
-          pip install torch
+            micromamba activate pmg
 
-          uv pip install numpy cython
+            # TODO remove temporary fix. added since uv install torch is flaky.
+            # track https://github.com/astral-sh/uv/issues/1921 for resolution
+            pip install torch
 
-          uv pip install --editable '.[dev,optional]'
+            uv pip install numpy cython
 
-          # TODO remove next line installing ase from main branch when FrechetCellFilter is released
-          uv pip install --upgrade 'git+https://gitlab.com/ase/ase'
+            uv pip install --editable '.[dev,optional]'
 
-      - name: pytest split ${{ matrix.split }}
+            # TODO remove next line installing ase from main branch when FrechetCellFilter is released
+            uv pip install --upgrade 'git+https://gitlab.com/ase/ase'
+
+      - name: Optional deps - pytest split ${{ matrix.split }}
         run: |
           micromamba activate pmg
           pytest --splits 10 --group ${{ matrix.split }} --durations-path tests/files/.pytest-split-durations tests


### PR DESCRIPTION
New version of #3646.

This PR adds a separate test suite run for the case that only mandatory dependencies have been installed (directly via `pip install -e .[dev]`), attempting to mimic what a user will actually have when they just `pip install pymatgen`. This will then hopefully catch errors where either optional imports are not properly guarded, or main functionality is rendered broken by optional dependency updates.

Not sure if this is something that you would actually want to merge given the potential maintenance overhead, but this might be able to spot more issues before they arise now that #3757 is merged.

Someone will need to carefully look at how I am invoking the tests, as I'm not sure if there is any coverage/durations magic going on that needs to be separated between the two runs (the comments to that effect at the top of `test.yml` might now be out of date).