### PR TITLE
chore: add get_string alias for Poscar

### DIFF
--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -584,6 +584,8 @@ class Poscar(MSONable):
 
         return "\n".join(lines) + "\n"
 
+    get_string = get_str
+
     def __repr__(self):
         return self.get_str()
 


### PR DESCRIPTION
## Summary

Minor changes:

- add `get_string` alias for `get_str` function in Poscar class for convenience/compatibility purposes with earlier implementation(s)

Major changes:

- none

## Checklist

```bash
(.venv) ➜  pymatgen git:(chore/add-poscar-get-string-alias) pre-commit run --all-files                                           
ruff.....................................................................Passed
ruff-format..............................................................Passed
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
mypy.....................................................................Passed
codespell................................................................Passed
cython-lint..............................................................Passed
double-quote Cython strings..............................................Passed
blacken-docs.............................................................Passed
markdownlint.............................................................Passed
nbstripout...............................................................Passed
```

and

```bash
(.venv) ➜  pymatgen git:(chore/add-poscar-get-string-alias) pip list                  
Package            Version
------------------ -----------
beautifulsoup4     4.12.2
certifi            2024.2.2
cfgv               3.4.0
charset-normalizer 3.3.2
contourpy          1.2.1
cycler             0.12.1
Cython             3.0.2
distlib            0.3.8
filelock           3.13.4
fonttools          4.51.0
future             1.0.0
identify           2.5.35
idna               3.7
joblib             1.3.2
kiwisolver         1.4.5
latexcodec         3.0.0
matplotlib         3.8.0
monty              2024.2.26
mpmath             1.3.0
networkx           3.1
nodeenv            1.8.0
numpy              1.26.0
packaging          24.0
palettable         3.3.3
pandas             2.1.1
pillow             10.3.0
pip                24.0
platformdirs       4.2.0
plotly             5.17.0
pre-commit         3.7.0
pybtex             0.24.0
pyparsing          3.1.2
python-dateutil    2.9.0.post0
pytz               2024.1
PyYAML             6.0.1
requests           2.31.0
ruamel.yaml        0.18.6
ruamel.yaml.clib   0.2.8
scipy              1.11.3
setuptools         69.2.0
six                1.16.0
soupsieve          2.5
spglib             2.1.0
sympy              1.12
tabulate           0.9.0
tenacity           8.2.3
tqdm               4.66.2
tzdata             2024.1
uncertainties      3.1.7
urllib3            2.2.1
virtualenv         20.25.1
wheel              0.43.0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method alias `get_string` for enhanced usability in accessing string representations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->