### PR TITLE
bugfix: chargemol runtime directory and `os.path.exists` fix

### DIFF
--- a/pymatgen/command_line/chargemol_caller.py
+++ b/pymatgen/command_line/chargemol_caller.py
@@ -385,7 +385,7 @@ class ChargemolAnalysis:
                 "The DDEC6_ATOMIC_DENSITIES_DIR environment variable must be set or the atomic_densities_path must"
                 " be specified"
             )
-        if not os.path.isfile(atomic_densities_path):
+        if not os.path.exists(atomic_densities_path):
             raise FileNotFoundError(f"{atomic_densities_path=} does not exist")
 
         # This is to fix a Chargemol filepath nuance


### PR DESCRIPTION
## Summary

- Improve path logic
- Allow Chargemol to run in different directory (previously the code has implemented but is not working)
- Fix `os.path.isfile` bug. Change it into `os.path.exists`

## Todos

- add test

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
