### PR TITLE
Fix overlayed subplots in `BSPlotterProjected.get_projected_plots_dots()`

### DIFF
--- a/pymatgen/apps/borg/queen.py
+++ b/pymatgen/apps/borg/queen.py
@@ -79,7 +79,7 @@ class BorgQueen:
             valid_paths.extend(self._drone.get_valid_paths((parent, subdirs, files)))
         data: list[str] = []
         total = len(valid_paths)
-        for idx, path in enumerate(valid_paths, 1):
+        for idx, path in enumerate(valid_paths, start=1):
             new_data = self._drone.assimilate(path)
             self._data.append(new_data)
             logger.info(f"{idx}/{total} ({idx / total:.1%}) done")

--- a/pymatgen/electronic_structure/bandstructure.py
+++ b/pymatgen/electronic_structure/bandstructure.py
@@ -810,13 +810,13 @@ class BandStructureSymmLine(BandStructure, MSONable):
         """
         to_return = []
         for idx in self.get_equivalent_kpoints(index):
-            for b in self.branches:
-                if b["start_index"] <= idx <= b["end_index"]:
+            for branch in self.branches:
+                if branch["start_index"] <= idx <= branch["end_index"]:
                     to_return.append(
                         {
-                            "name": b["name"],
-                            "start_index": b["start_index"],
-                            "end_index": b["end_index"],
+                            "name": branch["name"],
+                            "start_index": branch["start_index"],
+                            "end_index": branch["end_index"],
                             "index": idx,
                         }
                     )

--- a/pymatgen/electronic_structure/bandstructure.py
+++ b/pymatgen/electronic_structure/bandstructure.py
@@ -243,25 +243,22 @@ class BandStructure:
             returns an empty dict
         """
         result = {}
-        structure = self.structure
         for spin, v in self.projections.items():
             result[spin] = [[defaultdict(float) for i in range(len(self.kpoints))] for j in range(self.nb_bands)]
             for i, j, k in itertools.product(
                 range(self.nb_bands),
                 range(len(self.kpoints)),
-                range(len(structure)),
+                range(len(self.structure)),
             ):
-                result[spin][i][j][str(structure[k].specie)] += np.sum(v[i, j, :, k])
+                result[spin][i][j][str(self.structure[k].specie)] += np.sum(v[i, j, :, k])
         return result
 
-    def get_projections_on_elements_and_orbitals(self, el_orb_spec):
-        """Method returning a dictionary of projections on elements and specific
-        orbitals.
+    def get_projections_on_elements_and_orbitals(self, el_orb_spec: dict[str, list[str]]):
+        """Method returning a dictionary of projections on elements and specific orbitals.
 
         Args:
-            el_orb_spec: A dictionary of Elements and Orbitals for which we want
-                to have projections on. It is given as: {Element:[orbitals]},
-                e.g. {'Cu':['d','s']}
+            el_orb_spec (dict[str, list[str]]): A dictionary of elements and orbitals which
+                to project onto. Format is {Element: [orbitals]}, e.g. {'Cu':['d','s']}.
 
         Returns:
             A dictionary of projections on elements in the
@@ -269,24 +266,25 @@ class BandStructure:
             Spin.down:[][{Element:{orb:values}}]} format
             if there is no projections in the band structure returns an empty dict.
         """
-        result = {}
-        structure = self.structure
-        el_orb_spec = {get_el_sp(el): orbs for el, orbs in el_orb_spec.items()}
+        if self.structure is None:
+            raise ValueError("Structure is required for this method")
+        result: dict[Spin, list] = {}
+        species_orb_spec = {get_el_sp(el): orbs for el, orbs in el_orb_spec.items()}
         for spin, v in self.projections.items():
             result[spin] = [
-                [{str(e): defaultdict(float) for e in el_orb_spec} for i in range(len(self.kpoints))]
+                [{str(e): defaultdict(float) for e in species_orb_spec} for i in range(len(self.kpoints))]
                 for j in range(self.nb_bands)
             ]
 
             for i, j, k in itertools.product(
                 range(self.nb_bands),
                 range(len(self.kpoints)),
-                range(len(structure)),
+                range(len(self.structure)),
             ):
-                sp = structure[k].specie
+                sp = self.structure[k].specie
                 for orb_i in range(len(v[i][j])):
                     o = Orbital(orb_i).name[0]
-                    if sp in el_orb_spec and o in el_orb_spec[sp]:
+                    if sp in species_orb_spec and o in species_orb_spec[sp]:
                         result[spin][i][j][str(sp)][o] += v[i][j][orb_i][k]
         return result
 

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -909,7 +909,7 @@ class BSPlotterProjected(BSPlotter):
             bs = bs[0]
 
         if len(bs.projections) == 0:
-            raise ValueError("try to plot projections on a band structure without any")
+            raise ValueError("Can't plot projections on a band structure without any projections data")
 
         self._bs = bs
         self._nb_bands = bs.nb_bands

--- a/pymatgen/electronic_structure/plotter.py
+++ b/pymatgen/electronic_structure/plotter.py
@@ -9,7 +9,7 @@ import math
 import typing
 import warnings
 from collections import Counter
-from typing import TYPE_CHECKING, cast, no_type_check
+from typing import TYPE_CHECKING, cast
 
 import matplotlib.lines as mlines
 import matplotlib.pyplot as plt
@@ -51,7 +51,7 @@ __date__ = "May 1, 2012"
 
 
 class DosPlotter:
-    """Class for plotting phonon DOSs. The interface is extremely flexible given there are many
+    """Plot DOSs. The interface is extremely flexible given there are many
     different ways in which people want to view DOS.
     Typical usage is:
         # Initializes plotter with some optional args. Defaults are usually fine
@@ -85,10 +85,10 @@ class DosPlotter:
         ] = {}
 
     def add_dos(self, label: str, dos: Dos) -> None:
-        """Add a dos for plotting.
+        """Add a DOS for plotting.
 
         Args:
-            label: label for the DOS. Must be unique.
+            label: a unique label for the DOS.
             dos: Dos object
         """
         if dos.norm_vol is None:
@@ -103,8 +103,8 @@ class DosPlotter:
         }
 
     def add_dos_dict(self, dos_dict, key_sort_func=None) -> None:
-        """Add a dictionary of doses, with an optional sorting function for the
-        keys.
+        """Add a dictionary of DOSs, with an optional sorting
+        function for the keys.
 
         Args:
             dos_dict: dict of {label: Dos}
@@ -270,7 +270,7 @@ class DosPlotter:
 
 
 class BSPlotter:
-    """Class to plot or get data to facilitate the plot of band structure objects."""
+    """Plot or get data to facilitate the plotting of band structure."""
 
     def __init__(self, bs: BandStructureSymmLine) -> None:
         """
@@ -400,7 +400,7 @@ class BSPlotter:
         """Get the data nicely formatted for a plot.
 
         Args:
-            zero_to_efermi: Automatically set the Fermi level as the plot's origin (i.e. subtract E - E_f).
+            zero_to_efermi: Automatically set the Fermi level as the plot's origin (i.e. subtract E_f).
                 Defaults to True.
             bs: the bandstructure to get the data from. If not provided, the first
                 one in the self._bs list will be used.
@@ -585,7 +585,7 @@ class BSPlotter:
         same high symm path.
 
         Args:
-            zero_to_efermi: Automatically set the Fermi level as the plot's origin (i.e. subtract E - E_f).
+            zero_to_efermi: Automatically set the Fermi level as the plot's origin (i.e. subtract E_f).
                 Defaults to True.
             ylim: Specify the y-axis (energy) limits; by default None let
                 the code choose. It is vbm-4 and cbm+4 if insulator
@@ -722,8 +722,8 @@ class BSPlotter:
         """Show the plot using matplotlib.
 
         Args:
-            zero_to_efermi: Automatically set the Fermi level as the plot's origin (i.e. subtract E - E_f).
-                Defaults to True.
+            zero_to_efermi: Set the Fermi level as the plot's origin
+                (i.e. subtract E_f). Defaults to True.
             ylim: Specify the y-axis (energy) limits; by default None let
                 the code choose. It is vbm-4 and cbm+4 if insulator
                 efermi-10 and efermi+10 if metal
@@ -893,14 +893,15 @@ class BSPlotter:
 
 
 class BSPlotterProjected(BSPlotter):
-    """Class to plot or get data to facilitate the plot of band structure objects
-    projected along orbitals, elements or sites.
+    """Plot or get data to facilitate plotting of projected
+    band structure along orbitals, elements or sites.
     """
 
     def __init__(self, bs: BandStructureSymmLine) -> None:
         """
         Args:
-            bs: A BandStructureSymmLine object with projections e.g. from a VASP calculation.
+            bs: A BandStructureSymmLine object with projections
+            e.g. from a VASP calculation.
         """
         if isinstance(bs, list):
             warnings.warn(
@@ -950,30 +951,36 @@ class BSPlotterProjected(BSPlotter):
         return proj_br
 
     def get_projected_plots_dots(
-        self, dictio, zero_to_efermi=True, ylim=None, vbm_cbm_marker=False, band_linewidth: float = 1.0
-    ):
-        """Method returning a plot composed of subplots along different elements
-        and orbitals.
+        self,
+        dictio: dict[str, list],
+        zero_to_efermi: bool = True,
+        ylim: tuple[float, float] | None = None,
+        vbm_cbm_marker: bool = False,
+        band_linewidth: float = 1.0,
+        marker_size: float = 15.0,
+    ) -> plt.Axes:
+        """Generate a plot with subplots for each element-orbital pair.
+
+        The orbitals are named as in the FATBAND file, e.g. "2p" or "2p_x".
+
+        he blue and red colors are for spin up and spin down
+        The size of the dot in the plot corresponds to the value
+        for the specific point.
 
         Args:
             dictio: The element and orbitals you want a projection on. The
-                format is {Element:[Orbitals]} for instance
-                {'Cu':['d','s'],'O':['p']} will give projections for Cu on
-                d and s orbitals and on oxygen p.
-                If you use this class to plot LobsterBandStructureSymmLine,
-                the orbitals are named as in the FATBAND filename, e.g.
-                "2p" or "2p_x"
-            zero_to_efermi: Automatically set the Fermi level as the plot's origin (i.e. subtract E - E_f).
-                Defaults to True.
-            ylim: Specify the y-axis limits. Defaults to None.
-            vbm_cbm_marker: Add markers for the VBM and CBM. Defaults to False.
-            band_linewidth (float): The linewidth of the bands. Defaults to 1.0.
+                format is {Element: [*Orbitals]} for instance
+                {"Cu":["d", "s"], "O":["p"]} will yield projections for
+                Cu on d and s orbitals and oxygen on p.
+            zero_to_efermi: Set the Fermi level as the plot's origin
+                (i.e. subtract E_f). Defaults to True.
+            ylim: The y-axis limits. Defaults to None.
+            vbm_cbm_marker (bool): Add markers for the VBM and CBM. Defaults to False.
+            band_linewidth (float): The width of the lines. Defaults to 1.0.
+            marker_size (float): The size of the markers. Defaults to 15.0.
 
         Returns:
-            list[plt.Axes]: A list with different subfigures for each projection
-            The blue and red colors are for spin up and spin down.
-            The bigger the red or blue dot in the band structure the higher
-            character for the corresponding element and orbital.
+            plt.Axes
         """
         n_rows = max(map(len, dictio.values()))  # largest number of orbitals for an element
         n_cols = len(dictio)  # number of elements
@@ -983,12 +990,29 @@ class BSPlotterProjected(BSPlotter):
 
         fig, axs = plt.subplots(n_rows, n_cols, figsize=(12, 8), constrained_layout=True)
 
-        for col_idx, el in enumerate(dictio):
-            for row_idx, key in enumerate(dictio[el]):
-                ax = axs[col_idx] if n_rows == 1 else axs[row_idx, col_idx]
+        for col_idx, element in enumerate(dictio):
+            for row_idx in range(n_rows):
+                if n_cols == 1 and n_cols == 1:
+                    ax = axs
+                elif n_rows == 1:
+                    ax = axs[col_idx]
+                else:
+                    ax = axs[row_idx, col_idx]
+
+                # Skip empty orbitals
+                try:
+                    orbital = dictio[element][row_idx]
+                except IndexError:
+                    ax.set_visible(False)
+                    continue
 
                 self._make_ticks(ax)
-                # loop symmetry line segments of the band structure (Gamma->X, X->M, ...)
+
+                # Set title (with orbital name as subscript)
+                ax.set_title(rf"${{\mathrm{{{element}}}}}_{{\mathrm{{{orbital}}}}}$", fontsize=18)
+
+                # Walk through high symmetry points of the band structure
+                # (Gamma->X, X->M, ...)
                 for k_path_idx in range(len(data["distances"])):
                     for band_idx in range(self._nb_bands):
                         ax.plot(
@@ -997,6 +1021,16 @@ class BSPlotterProjected(BSPlotter):
                             "b-",
                             linewidth=band_linewidth,
                         )
+                        for j in range(len(data["energy"][str(Spin.up)][k_path_idx][band_idx])):
+                            ax.plot(
+                                data["distances"][k_path_idx][j],
+                                data["energy"][str(Spin.up)][k_path_idx][band_idx][j],
+                                "bo",
+                                markersize=proj[k_path_idx][str(Spin.up)][band_idx][j][str(element)][orbital]
+                                * marker_size,
+                            )
+
+                        # Plot spin-down if spin polarized
                         if self._bs.is_spin_polarized:
                             ax.plot(
                                 data["distances"][k_path_idx],
@@ -1009,15 +1043,14 @@ class BSPlotterProjected(BSPlotter):
                                     data["distances"][k_path_idx][j],
                                     data["energy"][str(Spin.down)][k_path_idx][band_idx][j],
                                     "ro",
-                                    markersize=proj[k_path_idx][str(Spin.down)][band_idx][j][str(el)][key] * 15.0,
+                                    markersize=proj[k_path_idx][str(Spin.down)][band_idx][j][str(element)][orbital]
+                                    * marker_size,
                                 )
-                        for j in range(len(data["energy"][str(Spin.up)][k_path_idx][band_idx])):
-                            ax.plot(
-                                data["distances"][k_path_idx][j],
-                                data["energy"][str(Spin.up)][k_path_idx][band_idx][j],
-                                "bo",
-                                markersize=proj[k_path_idx][str(Spin.up)][band_idx][j][str(el)][key] * 15.0,
-                            )
+
+                # Set x range
+                ax.set_xlim(np.min(data["distances"]), np.max(data["distances"]))
+
+                # Set y range
                 if ylim is None:
                     if self._bs.is_metal():
                         if zero_to_efermi:
@@ -1034,31 +1067,41 @@ class BSPlotterProjected(BSPlotter):
 
                         ax.set_ylim(data["vbm"][0][1] + e_min, data["cbm"][0][1] + e_max)
                 else:
-                    ax.set_ylim(ylim)
-                ax.set_title(f"{el} {key}")
+                    ax.set_ylim(*ylim)
 
         return fig.axes
 
-    @no_type_check
-    def get_elt_projected_plots(self, zero_to_efermi: bool = True, ylim=None, vbm_cbm_marker: bool = False) -> plt.Axes:
-        """Method returning a plot composed of subplots along different elements.
+    def get_elt_projected_plots(
+        self,
+        zero_to_efermi: bool = True,
+        ylim: tuple[float, float] | None = None,
+        vbm_cbm_marker: bool = False,
+        band_linewidth: float = 1.0,
+    ) -> plt.Axes:
+        """Generate a plot with subplots for different elements.
+
+        The blue and red colors are for spin up and spin down
+        The size of the dot in the plot corresponds to the value
+        for the specific point.
 
         Returns:
-            np.ndarray[plt.Axes]: 2x2 array of plt.Axes with different subfigures for each projection
-                The blue and red colors are for spin up and spin down
-                The bigger the red or blue dot in the band structure the higher
-                character for the corresponding element and orbital
+            np.ndarray[plt.Axes]: 2x2 array of plt.Axes with different
+                subplots for each projection.
         """
-        band_linewidth = 1.0
-        proj = self._get_projections_by_branches({e.symbol: ["s", "p", "d"] for e in self._bs.structure.elements})
+        if self._bs.structure is None:
+            raise RuntimeError("Band structure cannot be None.")
+        proj = self._get_projections_by_branches({el.symbol: ["s", "p", "d"] for el in self._bs.structure.elements})
+
         data = self.bs_plot_data(zero_to_efermi)
         _fig, axs = plt.subplots(2, 2, figsize=(12, 8))  # Adjust the layout as needed
         e_min, e_max = (-10, 10) if self._bs.is_metal() else (-4, 4)
 
-        for idx, el in enumerate(self._bs.structure.elements, start=1):
-            ax = pretty_plot(12, 8, ax=axs.flat[idx - 1])
+        for idx, el in enumerate(self._bs.structure.elements):
+            ax = pretty_plot(12, 8, ax=axs.flat[idx])
 
             self._make_ticks(ax)
+            ax.set_title(str(el))
+
             for b in range(len(data["distances"])):
                 for band_idx in range(self._nb_bands):
                     ax.plot(
@@ -1104,6 +1147,8 @@ class BSPlotterProjected(BSPlotter):
                             markersize=markerscale * 15.0,
                             color=[markerscale, 0.3 * markerscale, 0.4 * markerscale],
                         )
+
+            # Set ylim
             if ylim is None:
                 if self._bs.is_metal():
                     if zero_to_efermi:
@@ -1121,31 +1166,40 @@ class BSPlotterProjected(BSPlotter):
                     ax.set_ylim(data["vbm"][0][1] + e_min, data["cbm"][0][1] + e_max)
             else:
                 ax.set_ylim(ylim)
-            ax.set_title(str(el))
 
         return axs
 
-    def get_elt_projected_plots_color(self, zero_to_efermi=True, elt_ordered=None):
-        """Returns a pyplot plot object with one plot where the band structure
-        line color depends on the character of the band (along different
-        elements). Each element is associated with red, green or blue
-        and the corresponding rgb color depending on the character of the band
-        is used. The method can only deal with binary and ternary compounds.
+    def get_elt_projected_plots_color(
+        self,
+        zero_to_efermi: bool = True,
+        elt_ordered: list | None = None,
+        band_linewidth: float = 3,
+    ) -> plt.Axes:
+        """Generate a pyplot plot where the band structure
+        line color depends on the element of the band. where each
+        element is associated with red, green or blue.
+
+        The method can only deal with binary and ternary compounds.
 
         Spin up and spin down are differentiated by a '-' and a '--' line.
 
         Args:
-            zero_to_efermi: Automatically set the Fermi level as the plot's origin (i.e. subtract E - E_f).
-                Defaults to True.
-            elt_ordered: A list of Element ordered. The first one is red, second green, last blue.
+            zero_to_efermi: set the Fermi level as the plot's origin
+                (i.e. subtract E_f). Defaults to True.
+            elt_ordered: A list of ordered Elements.
+                The first one is red, second green, last blue.
+            band_linewidth (float): width of the line.
 
         Raises:
+            RuntimeError: if the band structure is None.
             ValueError: if the number of elements is not 2 or 3.
 
         Returns:
             a pyplot object
         """
-        band_linewidth = 3
+        if self._bs.structure is None:
+            raise RuntimeError("Band structure cannot be None.")
+
         n_elems = len(self._bs.structure.elements)
         if n_elems > 3:
             raise ValueError(f"Can only plot binary and ternary compounds, got {n_elems} elements")
@@ -1184,9 +1238,9 @@ class BSPlotterProjected(BSPlotter):
                             color.append(0.0)
                             color[2] = color[1]
                             color[1] = 0.0
-                        sign = "-"
-                        if spin == Spin.down:
-                            sign = "--"
+
+                        sign = "--" if spin == Spin.down else "-"
+
                         ax.plot(
                             [data["distances"][b][j], data["distances"][b][j + 1]],
                             [data["energy"][str(spin)][b][band_idx][j], data["energy"][str(spin)][b][band_idx][j + 1]],
@@ -1285,7 +1339,7 @@ class BSPlotterProjected(BSPlotter):
                                     edict[f"{elt}{anum}"][morb] = proj[Spin.up][band_idx][j][setos[morb]][anum - 1]
                         proj_br[-1][str(Spin.down)][band_idx].append(edict)
 
-        # Adjusting  projections for plot
+        # Adjust projections for plot
         dictio_d, dictpa_d = self._summarize_keys_for_plot(dictio, dictpa, sum_atoms, sum_morbs)
 
         if (sum_atoms is None) and (sum_morbs is None):
@@ -1544,7 +1598,7 @@ class BSPlotterProjected(BSPlotter):
                 for instance: {'Cu': ['dxy', 'dxz'], 'O': ['px', 'py']} means summing projections
                 over 'dxy' and 'dxz' of Cu and 'px' and 'py' of O. If you do not want to use this
                 functional, just turn it off by setting sum_morbs = None.
-            zero_to_efermi: Automatically set the Fermi level as the plot's origin (i.e. subtract E - E_f).
+            zero_to_efermi: Automatically set the Fermi level as the plot's origin (i.e. subtract E_f).
                 Defaults to True.
             ylim: The y-axis limit. Defaults to None.
             vbm_cbm_marker: Whether to plot points to indicate valence band maxima and conduction

--- a/pymatgen/io/adf.py
+++ b/pymatgen/io/adf.py
@@ -821,7 +821,7 @@ class AdfOutput:
                         v = list(chunks(map(float, match.group(3).split()), 3))
                         if len(v) != n_next:
                             raise AdfOutputError("Odd Error!")
-                        for i, k in enumerate(range(-n_next, start=0)):
+                        for i, k in enumerate(range(-n_next, 0)):
                             self.normal_modes[k].extend(v[i])
                         if int(match.group(1)) == n_atoms:
                             parse_freq = True

--- a/pymatgen/io/adf.py
+++ b/pymatgen/io/adf.py
@@ -821,7 +821,7 @@ class AdfOutput:
                         v = list(chunks(map(float, match.group(3).split()), 3))
                         if len(v) != n_next:
                             raise AdfOutputError("Odd Error!")
-                        for i, k in enumerate(range(-n_next, 0)):
+                        for i, k in enumerate(range(-n_next, start=0)):
                             self.normal_modes[k].extend(v[i])
                         if int(match.group(1)) == n_atoms:
                             parse_freq = True

--- a/pymatgen/phonon/plotter.py
+++ b/pymatgen/phonon/plotter.py
@@ -498,8 +498,8 @@ class PhononBSPlotter:
             ls = LineCollection(seg, colors=colors, linestyles="-", linewidths=2.5)
             ax.add_collection(ls)
         if ylim is None:
-            y_max: float = max(max(b) for b in self._bs.bands) * u.factor
-            y_min: float = min(min(b) for b in self._bs.bands) * u.factor
+            y_max: float = max(max(band) for band in self._bs.bands) * u.factor
+            y_min: float = min(min(band) for band in self._bs.bands) * u.factor
             y_margin = (y_max - y_min) * 0.05
             ylim = (y_min - y_margin, y_max + y_margin)
         ax.set_ylim(ylim)
@@ -594,9 +594,9 @@ class PhononBSPlotter:
             if point.label is not None:
                 tick_distance.append(self._bs.distance[idx])
                 this_branch = None
-                for b in self._bs.branches:
-                    if b["start_index"] <= idx <= b["end_index"]:
-                        this_branch = b["name"]
+                for branch in self._bs.branches:
+                    if branch["start_index"] <= idx <= branch["end_index"]:
+                        this_branch = branch["name"]
                         break
                 if point.label != prev_label and prev_branch != this_branch:
                     label1 = point.label

--- a/pymatgen/symmetry/kpath.py
+++ b/pymatgen/symmetry/kpath.py
@@ -85,17 +85,17 @@ class KPathBase(abc.ABC):
         """Get kpoints along the path in Cartesian coordinates together with the critical-point labels."""
         list_k_points = []
         sym_point_labels = []
-        for b in self.kpath["path"]:
-            for i in range(1, len(b)):
-                start = np.array(self.kpath["kpoints"][b[i - 1]])
-                end = np.array(self.kpath["kpoints"][b[i]])
+        for k_path in self.kpath["path"]:
+            for path_step in range(1, len(k_path)):
+                start = np.array(self.kpath["kpoints"][k_path[path_step - 1]])
+                end = np.array(self.kpath["kpoints"][k_path[path_step]])
                 distance = np.linalg.norm(
                     self._rec_lattice.get_cartesian_coords(start) - self._rec_lattice.get_cartesian_coords(end)
                 )
                 nb = int(ceil(distance * line_density))
                 if nb == 0:
                     continue
-                sym_point_labels.extend([b[i - 1]] + [""] * (nb - 1) + [b[i]])
+                sym_point_labels.extend([k_path[path_step - 1]] + [""] * (nb - 1) + [k_path[path_step]])
                 list_k_points += [
                     self._rec_lattice.get_cartesian_coords(start)
                     + float(i)

--- a/pymatgen/transformations/site_transformations.py
+++ b/pymatgen/transformations/site_transformations.py
@@ -338,7 +338,7 @@ class PartialRemoveSitesTransformation(AbstractTransformation):
 
         all_combis = [list(itertools.combinations(ind, num)) for ind, num in num_remove_dict.items()]
 
-        for idx, all_indices in enumerate(itertools.product(*all_combis), 1):
+        for idx, all_indices in enumerate(itertools.product(*all_combis), start=1):
             sites_to_remove = []
             indices_list = []
             for indices in all_indices:

--- a/tests/electronic_structure/test_bandstructure.py
+++ b/tests/electronic_structure/test_bandstructure.py
@@ -360,7 +360,8 @@ class TestLobsterBandStructureSymmLine(PymatgenTest):
         axs = BSPlotterProjected(self.bs_spin).get_projected_plots_dots({"Si": ["3s"]})
         assert isinstance(axs, list)
         assert len(axs) == 1
-        assert axs[0].get_title() == "Si 3s"
+        print(axs[0].get_title())
+        assert axs[0].get_title() == r"${\mathrm{Si}}_{\mathrm{3s}}$"
 
     def test_get_branch(self):
         branch = self.bs_p.get_branch(0)[0]

--- a/tests/electronic_structure/test_plotter.py
+++ b/tests/electronic_structure/test_plotter.py
@@ -206,8 +206,8 @@ class TestBSPlotterProjected(TestCase):
         assert len(ax.get_lines()) == 44_127
         assert ax.get_ylim() == pytest.approx((-4.0, 4.5047))
 
-        with pytest.raises(ValueError, match="try to plot projections on a band structure without any"):
-            self.plotter_PbTe = BSPlotterProjected(self.bs_PbTe)
+        with pytest.raises(ValueError, match="Can't plot projections on a band structure without projections data"):
+            BSPlotterProjected(self.bs_PbTe)
 
 
 class TestBSDOSPlotter:

--- a/tests/electronic_structure/test_plotter.py
+++ b/tests/electronic_structure/test_plotter.py
@@ -184,20 +184,21 @@ class TestBSPlotter(PymatgenTest):
 class TestBSPlotterProjected(TestCase):
     def setUp(self):
         with open(f"{BAND_TEST_DIR}/Cu2O_361_bandstructure.json") as file:
-            dct = json.load(file)
-        self.bs_Cu2O = BandStructureSymmLine.from_dict(dct)
+            self.bs_Cu2O = BandStructureSymmLine.from_dict(json.load(file))
         self.plotter_Cu2O = BSPlotterProjected(self.bs_Cu2O)
 
         with open(f"{TEST_FILES_DIR}/electronic_structure/boltztrap2/PbTe_bandstructure.json") as file:
-            dct = json.load(file)
-        self.bs_PbTe = BandStructureSymmLine.from_dict(dct)
+            self.bs_PbTe = BandStructureSymmLine.from_dict(json.load(file))
 
     def test_methods(self):
         # Minimal baseline testing for get_plot. not a true test. Just checks that
         # it can actually execute.
         self.plotter_Cu2O.get_elt_projected_plots()
         self.plotter_Cu2O.get_elt_projected_plots_color()
-        self.plotter_Cu2O.get_projected_plots_dots({"Cu": ["d", "s"], "O": ["p"]})
+        axes = self.plotter_Cu2O.get_projected_plots_dots({"Cu": ["d", "s"], "O": ["p"]})
+        assert len(axes) == 4, f"{len(axes)=}"
+        assert len(axes[0].get_lines()) == 4903, f"{len(axes[0].get_lines())=}"
+        assert len(axes[-1].get_lines()) == 0, f"{len(axes[-1].get_lines())=}"
         ax = self.plotter_Cu2O.get_projected_plots_dots_patom_pmorb(
             {"Cu": ["dxy", "s", "px"], "O": ["px", "py", "pz"]},
             {"Cu": [3, 5], "O": [1]},


### PR DESCRIPTION
closes #3760

**before**

![before-3760-fix](https://github.com/materialsproject/pymatgen/assets/30958850/70763b1e-cc19-4b3a-859b-7290b84c93e4)

**after**

![after-3760-fix](https://github.com/materialsproject/pymatgen/assets/30958850/60adfabf-530b-4f84-bb5a-3cd213f277b0)

there were multiple issues in `BSPlotterProjected.get_projected_plots_dots`: all subplots were plotted into the 1st axes. the large axis labels from `pretty_plot` were applied to the whole figure, not the individual subplots

ran out of time on this fix but noticed that the fat lines in the `Cu d` still look off. like it's still overlaying multiple band structures. maybe someone else has time to take a look @DanielYang59 @JaGeo? also @HERTZCAI could you comment on what output you're expecting and share the `vasprun.xml` file you were plotting in #3760