### PR TITLE
Fix `_get_dipole_info` for DDEC6 `ChargemolAnalysis` and add test case

### DIFF
--- a/pymatgen/command_line/chargemol_caller.py
+++ b/pymatgen/command_line/chargemol_caller.py
@@ -416,8 +416,8 @@ class ChargemolAnalysis:
         idx = 0
         start = False
         dipoles = []
-        with open(filepath) as r:
-            for line in r:
+        with open(filepath) as file:
+            for line in file:
                 if "The following XYZ" in line:
                     start = True
                     idx += 1
@@ -425,7 +425,7 @@ class ChargemolAnalysis:
                 if start and line.strip() == "":
                     break
                 if idx >= 2:
-                    dipoles.append([float(d) for d in line.strip().split()[6:9]])
+                    dipoles.append(list(map(float, line.strip().split()[6:9])))
                 if start:
                     idx += 1
 
@@ -441,9 +441,9 @@ class ChargemolAnalysis:
         # Get where relevant info for each atom starts
         bond_order_info = {}
 
-        with open(filename, encoding="utf-8") as r:
+        with open(filename, encoding="utf-8") as file:
             start_idx = 0
-            for line in r:
+            for line in file:
                 split = line.strip().split()
                 if "Printing BOs" in line:
                     start_idx = int(split[5]) - 1
@@ -543,8 +543,8 @@ class ChargemolAnalysis:
         """
         props = []
         if os.path.isfile(xyz_path):
-            with open(xyz_path) as r:
-                for idx, line in enumerate(r):
+            with open(xyz_path) as file:
+                for idx, line in enumerate(file):
                     if idx <= 1:
                         continue
                     if line.strip() == "":
@@ -568,8 +568,8 @@ class ChargemolAnalysis:
         props = []
         if os.path.isfile(ddec_analysis_path):
             start = False
-            with open(ddec_analysis_path) as r:
-                for line in r:
+            with open(ddec_analysis_path) as file:
+                for line in file:
                     if "computed CM5" in line:
                         start = True
                         continue

--- a/pymatgen/command_line/chargemol_caller.py
+++ b/pymatgen/command_line/chargemol_caller.py
@@ -425,7 +425,7 @@ class ChargemolAnalysis:
                 if start and line.strip() == "":
                     break
                 if idx >= 2:
-                    dipoles.append([float(d) for d in line.strip().split()[7:10]])
+                    dipoles.append([float(d) for d in line.strip().split()[6:9]])
                 if start:
                     idx += 1
 

--- a/tests/command_line/test_chargemol_caller.py
+++ b/tests/command_line/test_chargemol_caller.py
@@ -51,6 +51,7 @@ class TestChargemolAnalysis:
         test_dir = f"{TEST_DIR}/spin_polarized"
         ca = ChargemolAnalysis(path=test_dir, run_chargemol=False)
         assert ca.ddec_spin_moments == [0.201595, 0.399203, 0.399203]
+        assert ca.dipoles == [[-0.0, 0.0, -0.127251], [0.0, -0.027857, -0.010944], [0.0, 0.027857, -0.010944]]
         assert ca.summary["ddec"]["bond_order_dict"][0]["bonded_to"][0]["spin_polarization"] == 0.0490
         assert ca.summary["ddec"]["spin_moments"] == ca.ddec_spin_moments
         assert ca.natoms is None


### PR DESCRIPTION
## Summary

Major changes:
- fix 1: _get_dipole_info was previously getting the y and z component and the magnitude instead of x,y and z. The only test case was 0,0,0 so it was never noticed.

Previously the dipole was only checked for the spin unpolarized structure with no dipoles (I added some extra spaces to make it more readable what is dipole and what is dipole_magn):
```
atom number,   atomic symbol,      x,           y,           z,     _ net_charge,     dipole_x,   dipole_y,     dipole_z, dipole_mag, Qxy, Qxz, Qyz,Q(x^2-y^2), Q(3z^2 - R^2), three eigenvalues of traceless quadrupole moment tensor
     1                     Na     0.000000     0.000000     0.000000     0.843200     0.000000     0.000000    -0.000000     0.000000    -0.000003    -0.000003    -0.000003     0.000000     0.000000    -0.000000     0.000000     0.000000
     2                     Cl     2.829447     2.829447     2.829447    -0.843200    -0.000000    -0.000000    -0.000000    0.000000    -0.000020    -0.000020    -0.000020    -0.000000    -0.000000    -0.000041     0.000020     0.000020
```


New test case for dipole:
```
atom number, atomic symbol,     x,          y,            z,          net_charge,  dipole_x,     dipole_y,   dipole_z,    dipole_mag, Qxy, Qxz, Qyz,Q(x^2-y^2), Q(3z^2 - R^2), three eigenvalues of traceless quadrupole moment tensor
          1              O      0.000000    -0.000000     0.319088     0.482714    -0.000000     0.000000    -0.127251     _0.127251_    -0.000000    -0.000000    -0.000000     0.040943    -0.162587    -0.050728     0.003219     0.047509
          2              O      0.000000     1.135186    -0.159544     0.258643     0.000000    -0.027857    -0.010944     _0.029929_     0.000000     0.000000    -0.096730    -0.074725    -0.273919    -0.128456     0.008578     0.119878
          3              O      0.000000    -1.135186    -0.159544     0.258643     0.000000     0.027857    -0.010944     _0.029929_    -0.000000     0.000000     0.096730    -0.074725    -0.273919    -0.128456     0.008578     0.119878
```
 
output of previous function:
`[[0.0, -0.127251, 0.127251], [-0.027857, -0.010944, 0.029929], [0.027857, -0.010944, 0.029929]]`
new output:
`[[-0.0, 0.0, -0.127251], [0.0, -0.027857, -0.010944], [0.0, 0.027857, -0.010944]]`


## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.

Only thing left to do is that someone else confirms that it's correct now.