### PR TITLE
Add `strict_anions` option to `MaterialsProject2020Compatibility`

### DIFF
--- a/tests/entries/test_compatibility.py
+++ b/tests/entries/test_compatibility.py
@@ -551,6 +551,20 @@ class TestMaterialsProjectCompatibility2020(TestCase):
         self.compat = MaterialsProject2020Compatibility(check_potcar_hash=False)
         self.gga_compat = MaterialsProject2020Compatibility("GGA", check_potcar_hash=False)
 
+        self.entry_many_anions = ComputedEntry(
+            "CuI9",
+            -1,
+            0.0,
+            parameters={
+                "is_hubbard": False,
+                "run_type": "GGA",
+                "potcar_spec": [
+                    {"titel": "PAW_PBE Cu_pv 06Sep2000", "hash": "2d718b6be91068094207c9e861e11a89"},
+                    {"titel": "PAW_PBE I 08Apr2002", "hash": "f4ff16a495dd361ff5824ee61b418bb0"},
+                ],
+            },
+        )
+
     def test_process_entry(self):
         # Correct parameters
         assert self.compat.process_entry(self.entry1) is not None
@@ -1047,6 +1061,15 @@ class TestMaterialsProjectCompatibility2020(TestCase):
         assert processed_entry.energy_adjustments[1].name == "MP2020 GGA/GGA+U mixing correction (Mn)"
         assert processed_entry.correction == approx(-6.084)
         assert processed_entry.energy == approx(-58.97 + -6.084)
+
+    def test_many_anions(self):
+        compat = MaterialsProject2020Compatibility(strict_anions=True)
+        processed_entry = compat.process_entry(self.entry_many_anions)
+        assert processed_entry.energy == -1
+
+        compat = MaterialsProject2020Compatibility(strict_anions=False)
+        processed_entry = compat.process_entry(self.entry_many_anions)
+        assert processed_entry.energy == approx(-4.411)
 
 
 class TestMITCompatibility(TestCase):

--- a/tests/entries/test_compatibility.py
+++ b/tests/entries/test_compatibility.py
@@ -1063,13 +1063,17 @@ class TestMaterialsProjectCompatibility2020(TestCase):
         assert processed_entry.energy == approx(-58.97 + -6.084)
 
     def test_many_anions(self):
-        compat = MaterialsProject2020Compatibility(strict_anions=True)
+        compat = MaterialsProject2020Compatibility(strict_anions="require_bound")
         processed_entry = compat.process_entry(self.entry_many_anions)
         assert processed_entry.energy == -1
 
-        compat = MaterialsProject2020Compatibility(strict_anions=False)
+        compat = MaterialsProject2020Compatibility(strict_anions="no_check")
         processed_entry = compat.process_entry(self.entry_many_anions)
         assert processed_entry.energy == approx(-4.411)
+
+        compat = MaterialsProject2020Compatibility(strict_anions="require_exact")
+        processed_entry = compat.process_entry(self.entry_many_anions)
+        assert processed_entry.energy == -1
 
 
 class TestMITCompatibility(TestCase):


### PR DESCRIPTION
## Issue

This PR relates to the `MaterialsProject2020Compatibility` scheme, and cases in which structures might be heavily over-stabilized in error, leading to unrealistic structures potentially being placed on the convex hull.

In brief,

* Anion corrections are applied in cases where an element may not be an anion.
* This can happen either because (1) oxidation states are not known, and it is assumed to be an anion based on the element being the most electronegative element present or (2) `oxi_state_guesses` might give a very small fractional oxidation state in the range (-1, 0).
    * Case (1) was decided as a conservative choice due to unreliability of oxidation state guessing.
    * Case (2) I think was not considered, since this is not typically encountered in realistic materials.

During exploratory materials discovery, hypothetical structures might be generated that will encounter these cases. As an example, consider the composition CuI9, which results in the oxidation state guess of `{'Cu': 3.0, 'I': -0.33333}`. This becomes heavily over-stabilized by the correction scheme. This might lead to the hypothetical structure then being placed on the convex hull in error.

The experimental data used to fit the correction scheme did not consider any oxidation state in the domain (-1, 0), and so the corrections should be presumed invalid unless appropriately benchmarked. I want to acknowledge cases of anions which are > -1 such as suboxides, metal-rich pnictides, chacogenides, etc. do exist but as far as I can tell we did not have these in the experimental data used to fit the correction scheme.

## Suggested Resolution

This PR adds a `strict_anion` keyword argument which is set to **True** by default. This is a breaking change. This will skip applying the anion correction if oxidation state is supplied and the oxidation state is > -1, i.e. the element is not present as an anion that is included in the experimental data used for fitting, and might not be acting as an anion at all. 

However, this does not resolve the case where oxidation states could not be determined. Therefore, I also suggest we might consider a more significant breaking change to only apply the anion corrections where oxidation state is supplied.

## Request for Comment

Notifying MP correction folks for option to comment: @awvio, @rkingsbury, @mattmcdermott, @computron, @shyamd 