### PR TITLE
Add `is_radioactive` property to Element class

### DIFF
--- a/pymatgen/core/composition.py
+++ b/pymatgen/core/composition.py
@@ -508,7 +508,7 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
             category (str): one of "noble_gas", "transition_metal",
                 "post_transition_metal", "rare_earth_metal", "metal", "metalloid",
                 "alkali", "alkaline", "halogen", "chalcogen", "lanthanoid",
-                "actinoid", "quadrupolar", "s-block", "p-block", "d-block", "f-block"
+                "actinoid", "radioactive", "quadrupolar", "s-block", "p-block", "d-block", "f-block"
 
         Returns:
             bool: True if any elements in Composition match category, otherwise False

--- a/pymatgen/core/periodic_table.py
+++ b/pymatgen/core/periodic_table.py
@@ -740,8 +740,8 @@ class ElementBase(Enum):
 
     @property
     def is_radioactive(self) -> bool:
-        """True if element is a radioactive element."""
-        return self.Z in (43, 61) or self.Z > 83
+        """True if element is radioactive."""
+        return self.Z in (43, 61) or self.Z >= 84
 
     @property
     def is_quadrupolar(self) -> bool:

--- a/pymatgen/core/periodic_table.py
+++ b/pymatgen/core/periodic_table.py
@@ -739,6 +739,11 @@ class ElementBase(Enum):
         return 88 < self.Z < 104
 
     @property
+    def is_radioactive(self) -> bool:
+        """True if element is a radioactive element."""
+        return self.Z in (43, 61) or self.Z > 83
+
+    @property
     def is_quadrupolar(self) -> bool:
         """Check if this element can be quadrupolar."""
         return len(self.data.get("NMR Quadrupole Moment", {})) > 0
@@ -1512,6 +1517,7 @@ class ElementType(Enum):
     chalcogen = "chalcogen"  # O, S, Se, Te, Po
     lanthanoid = "lanthanoid"  # La-Lu
     actinoid = "actinoid"  # Ac-Lr
+    radioactive = "radioactive"  # Tc, Pm, Po-Lr
     quadrupolar = "quadrupolar"
     s_block = "s-block"
     p_block = "p-block"

--- a/tests/core/test_periodic_table.py
+++ b/tests/core/test_periodic_table.py
@@ -227,22 +227,25 @@ class TestElement(PymatgenTest):
             assert Element(key).ground_state_term_symbol == val
 
     def test_attributes(self):
-        is_true = {
-            ("Xe", "Kr"): "is_noble_gas",
-            ("Fe", "Ni"): "is_transition_metal",
-            ("Li", "Cs"): "is_alkali",
-            ("Ca", "Mg"): "is_alkaline",
-            ("F", "Br", "I"): "is_halogen",
-            ("La",): "is_lanthanoid",
-            ("U", "Pu"): "is_actinoid",
-            ("Si", "Ge"): "is_metalloid",
-            ("O", "Te"): "is_chalcogen",
-            ("Tc", "Po"): "is_radioactive",
+        bool_attrs = {
+            ("Xe", "Kr"): ("is_noble_gas", True),
+            ("H", "Cl"): ("is_noble_gas", False),
+            ("Fe", "Ni"): ("is_transition_metal", True),
+            ("Li", "Cs"): ("is_alkali", True),
+            ("Ca", "Mg"): ("is_alkaline", True),
+            ("F", "Br", "I"): ("is_halogen", True),
+            ("La", "Ce", "Lu"): ("is_lanthanoid", True),
+            ("U", "Pu"): ("is_actinoid", True),
+            ("Si", "Ge"): ("is_metalloid", True),
+            ("O", "Te"): ("is_chalcogen", True),
+            ("N", "Sb", "Ta"): ("is_chalcogen", False),
+            ("Tc", "Po"): ("is_radioactive", True),
+            ("H", "Li", "Bi"): ("is_radioactive", False),
         }
 
-        for key, val in is_true.items():
-            for sym in key:
-                assert getattr(Element(sym), val), f"{sym=} is false"
+        for elements, (attr, expected) in bool_attrs.items():
+            for elem in elements:
+                assert getattr(Element(elem), attr) is expected, f"{elem=} {attr=}, {expected=}"
 
         keys = (
             "atomic_mass",
@@ -289,15 +292,15 @@ class TestElement(PymatgenTest):
         # Test all elements up to Uranium
         for idx in range(1, 104):
             el = Element.from_Z(idx)
-            for key in keys:
-                key_str = key.capitalize().replace("_", " ")
+            for elements in keys:
+                key_str = elements.capitalize().replace("_", " ")
                 if key_str in el.data and (not str(el.data[key_str]).startswith("no data")):
-                    assert getattr(el, key) is not None
-                elif key == "long_name":
+                    assert getattr(el, elements) is not None
+                elif elements == "long_name":
                     assert el.long_name == el.data["Name"]
-                elif key == "iupac_ordering":
+                elif elements == "iupac_ordering":
                     assert "IUPAC ordering" in el.data
-                    assert getattr(el, key) is not None
+                    assert getattr(el, elements) is not None
 
             if len(el.oxidation_states) > 0:
                 assert max(el.oxidation_states) == el.max_oxidation_state

--- a/tests/core/test_periodic_table.py
+++ b/tests/core/test_periodic_table.py
@@ -608,4 +608,4 @@ def test_get_el_sp():
 def test_element_type():
     assert isinstance(ElementType.actinoid, Enum)
     assert isinstance(ElementType.metalloid, Enum)
-    assert len(ElementType) == 17
+    assert len(ElementType) == 18

--- a/tests/core/test_periodic_table.py
+++ b/tests/core/test_periodic_table.py
@@ -237,6 +237,7 @@ class TestElement(PymatgenTest):
             ("U", "Pu"): "is_actinoid",
             ("Si", "Ge"): "is_metalloid",
             ("O", "Te"): "is_chalcogen",
+            ("Tc", "Po"): "is_radioactive",
         }
 
         for key, val in is_true.items():


### PR DESCRIPTION
## Summary

Major changes:
* This PR adds an `is_radioactive` property to the `Element` class which allows users to check if an Element is radioactive.
* The `contains_element_type` method in the `Composition` class has radioactive as a possible category added, so users can check if a composition contains radioactive elements.

Feature motivation:
Motivated by a recent publication (https://pubs.acs.org/doi/10.1021/acs.chemmater.4c00643) which identifies that some of the discovered compounds in the GNoME database (https://github.com/google-deepmind/materials_discovery) contain radioactive elements, it would be useful to be able to screen out compositions containing radioactive elements or to be able to characterise how many radioactive compositions exist in a dataset of compositions/structures.


## Todos
* Agree upon which elements are considered radioactive. Currently, my PR has the following elements considered radioactive: Tc, Pm, and all elements with atomic number greater than 83 (Z>83) i.e. Po-Lr (Og).


## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
