### PR TITLE
`pandas.read_csv`: replace deprecated `delim_whitespace=True` with `sep="\s+"`

### DIFF
--- a/pymatgen/io/lammps/data.py
+++ b/pymatgen/io/lammps/data.py
@@ -664,7 +664,7 @@ class LammpsData(MSONable):
         def parse_section(sec_lines) -> tuple[str, pd.DataFrame]:
             title_info = sec_lines[0].split("#", 1)
             kw = title_info[0].strip()
-            sio = StringIO("".join(sec_lines[2:]))  # skip the 2nd line
+            str_io = StringIO("".join(sec_lines[2:]))  # skip the 2nd line
             if kw.endswith("Coeffs") and not kw.startswith("PairIJ"):
                 df_list = [
                     pd.read_csv(StringIO(line), header=None, comment="#", sep=r"\s+")
@@ -674,7 +674,7 @@ class LammpsData(MSONable):
                 df = pd.concat(df_list, ignore_index=True)
                 names = ["id"] + [f"coeff{i}" for i in range(1, df.shape[1])]
             else:
-                df = pd.read_csv(sio, header=None, comment="#", sep=r"\s+")
+                df = pd.read_csv(str_io, header=None, comment="#", sep=r"\s+")
                 if kw == "PairIJ Coeffs":
                     names = ["id1", "id2"] + [f"coeff{i}" for i in range(1, df.shape[1] - 1)]
                     df.index.name = None
@@ -1381,9 +1381,9 @@ class CombinedData(LammpsData):
         with zopen(filename, mode="rt") as file:
             lines = file.readlines()
 
-        sio = StringIO("".join(lines[2:]))  # skip the 2nd line
+        str_io = StringIO("".join(lines[2:]))  # skip the 2nd line
         df = pd.read_csv(
-            sio,
+            str_io,
             header=None,
             comment="#",
             sep=r"\s+",

--- a/pymatgen/io/lammps/data.py
+++ b/pymatgen/io/lammps/data.py
@@ -667,14 +667,14 @@ class LammpsData(MSONable):
             sio = StringIO("".join(sec_lines[2:]))  # skip the 2nd line
             if kw.endswith("Coeffs") and not kw.startswith("PairIJ"):
                 df_list = [
-                    pd.read_csv(StringIO(line), header=None, comment="#", delim_whitespace=True)
+                    pd.read_csv(StringIO(line), header=None, comment="#", sep="\s+")
                     for line in sec_lines[2:]
                     if line.strip()
                 ]
                 df = pd.concat(df_list, ignore_index=True)
                 names = ["id"] + [f"coeff{i}" for i in range(1, df.shape[1])]
             else:
-                df = pd.read_csv(sio, header=None, comment="#", delim_whitespace=True)
+                df = pd.read_csv(sio, header=None, comment="#", sep="\s+")
                 if kw == "PairIJ Coeffs":
                     names = ["id1", "id2"] + [f"coeff{i}" for i in range(1, df.shape[1] - 1)]
                     df.index.name = None
@@ -1386,7 +1386,7 @@ class CombinedData(LammpsData):
             sio,
             header=None,
             comment="#",
-            delim_whitespace=True,
+            sep="\s+",
             names=["atom", "x", "y", "z"],
         )
         df.index += 1

--- a/pymatgen/io/lammps/data.py
+++ b/pymatgen/io/lammps/data.py
@@ -667,14 +667,14 @@ class LammpsData(MSONable):
             sio = StringIO("".join(sec_lines[2:]))  # skip the 2nd line
             if kw.endswith("Coeffs") and not kw.startswith("PairIJ"):
                 df_list = [
-                    pd.read_csv(StringIO(line), header=None, comment="#", sep="\s+")
+                    pd.read_csv(StringIO(line), header=None, comment="#", sep=r"\s+")
                     for line in sec_lines[2:]
                     if line.strip()
                 ]
                 df = pd.concat(df_list, ignore_index=True)
                 names = ["id"] + [f"coeff{i}" for i in range(1, df.shape[1])]
             else:
-                df = pd.read_csv(sio, header=None, comment="#", sep="\s+")
+                df = pd.read_csv(sio, header=None, comment="#", sep=r"\s+")
                 if kw == "PairIJ Coeffs":
                     names = ["id1", "id2"] + [f"coeff{i}" for i in range(1, df.shape[1] - 1)]
                     df.index.name = None
@@ -1386,7 +1386,7 @@ class CombinedData(LammpsData):
             sio,
             header=None,
             comment="#",
-            sep="\s+",
+            sep=r"\s+",
             names=["atom", "x", "y", "z"],
         )
         df.index += 1

--- a/pymatgen/io/lammps/outputs.py
+++ b/pymatgen/io/lammps/outputs.py
@@ -69,7 +69,7 @@ class LammpsDump(MSONable):
             bounds -= np.array([[min(x), max(x)], [min(y), max(y)], [0, 0]])
         box = LammpsBox(bounds, tilt)
         data_head = lines[8].replace("ITEM: ATOMS", "").split()
-        data = pd.read_csv(StringIO("\n".join(lines[9:])), names=data_head, delim_whitespace=True)
+        data = pd.read_csv(StringIO("\n".join(lines[9:])), names=data_head, sep="\s+")
         return cls(time_step, n_atoms, box, data)
 
     @classmethod
@@ -180,7 +180,7 @@ def parse_lammps_log(filename: str = "log.lammps") -> list[pd.DataFrame]:
             df = df[columns]
         # one line thermo data
         else:
-            df = pd.read_csv(StringIO("".join(lines)), delim_whitespace=True)
+            df = pd.read_csv(StringIO("".join(lines)), sep="\s+")
         return df
 
     runs = []

--- a/pymatgen/io/lammps/outputs.py
+++ b/pymatgen/io/lammps/outputs.py
@@ -69,7 +69,7 @@ class LammpsDump(MSONable):
             bounds -= np.array([[min(x), max(x)], [min(y), max(y)], [0, 0]])
         box = LammpsBox(bounds, tilt)
         data_head = lines[8].replace("ITEM: ATOMS", "").split()
-        data = pd.read_csv(StringIO("\n".join(lines[9:])), names=data_head, sep="\s+")
+        data = pd.read_csv(StringIO("\n".join(lines[9:])), names=data_head, sep=r"\s+")
         return cls(time_step, n_atoms, box, data)
 
     @classmethod
@@ -180,7 +180,7 @@ def parse_lammps_log(filename: str = "log.lammps") -> list[pd.DataFrame]:
             df = df[columns]
         # one line thermo data
         else:
-            df = pd.read_csv(StringIO("".join(lines)), sep="\s+")
+            df = pd.read_csv(StringIO("".join(lines)), sep=r"\s+")
         return df
 
     runs = []

--- a/pymatgen/io/xyz.py
+++ b/pymatgen/io/xyz.py
@@ -119,7 +119,7 @@ class XYZ:
         """
         lines = str(self)
         sio = StringIO(lines)
-        df_xyz = pd.read_csv(sio, header=None, skiprows=(0, 1), comment="#", sep="\s+", names=("atom", "x", "y", "z"))
+        df_xyz = pd.read_csv(sio, header=None, skiprows=(0, 1), comment="#", sep=r"\s+", names=("atom", "x", "y", "z"))
         df_xyz.index += 1
         return df_xyz
 

--- a/pymatgen/io/xyz.py
+++ b/pymatgen/io/xyz.py
@@ -118,8 +118,10 @@ class XYZ:
             pandas.DataFrame
         """
         lines = str(self)
-        sio = StringIO(lines)
-        df_xyz = pd.read_csv(sio, header=None, skiprows=(0, 1), comment="#", sep=r"\s+", names=("atom", "x", "y", "z"))
+        str_io = StringIO(lines)
+        df_xyz = pd.read_csv(
+            str_io, header=None, skiprows=(0, 1), comment="#", sep=r"\s+", names=("atom", "x", "y", "z")
+        )
         df_xyz.index += 1
         return df_xyz
 

--- a/pymatgen/io/xyz.py
+++ b/pymatgen/io/xyz.py
@@ -119,9 +119,7 @@ class XYZ:
         """
         lines = str(self)
         sio = StringIO(lines)
-        df_xyz = pd.read_csv(
-            sio, header=None, skiprows=(0, 1), comment="#", delim_whitespace=True, names=("atom", "x", "y", "z")
-        )
+        df_xyz = pd.read_csv(sio, header=None, skiprows=(0, 1), comment="#", sep="\s+", names=("atom", "x", "y", "z"))
         df_xyz.index += 1
         return df_xyz
 

--- a/pymatgen/util/provenance.py
+++ b/pymatgen/util/provenance.py
@@ -46,10 +46,10 @@ def is_valid_bibtex(reference: str) -> bool:
     """
     # str is necessary since pybtex seems to have an issue with unicode. The
     # filter expression removes all non-ASCII characters.
-    sio = StringIO(reference.encode("ascii", "ignore").decode("ascii"))
+    str_io = StringIO(reference.encode("ascii", "ignore").decode("ascii"))
     parser = bibtex.Parser()
     errors.set_strict_mode(enable=False)
-    bib_data = parser.parse_stream(sio)
+    bib_data = parser.parse_stream(str_io)
     return len(bib_data.entries) > 0
 
 


### PR DESCRIPTION
## Summary

Major changes:

- fix 1: Replace deprecated `delim_whitespace=True` with `sep="\s+"` (see https://pandas.pydata.org/docs/reference/api/pandas.read_csv.html)

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [x] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))