### PR TITLE
Run CI with two different `uv` resolution strategies: `highest` and `lowest-direct`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,19 +25,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # maximize CI coverage of different platforms and python versions while minimizing the
+        # total number of jobs. We run all pytest splits with the oldest supported python
+        # version (currently 3.9) on windows (seems most likely to surface errors) and with
+        # newest version (currently 3.12) on ubuntu (to get complete coverage on unix). We
+        # ignore mac-os, which is assumed to be similar to ubuntu.
+        config:
+          - { os: windows-latest, python: "3.9", resolution: highest }
+          - { os: ubuntu-latest, python: "3.12", resolution: lowest-direct }
         # pytest-split automatically distributes work load so parallel jobs finish in similar time
-        os: [ubuntu-latest, windows-latest]
-        version:
-          - { python: "3.9", resolution: highest }
-          - { python: "3.12", resolution: lowest-direct }
         split: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        # include/exclude is meant to maximize CI coverage of different platforms and python
-        # versions while minimizing the total number of jobs. We run all pytest splits with the
-        # oldest supported python version (currently 3.9) on windows (seems most likely to surface
-        # errors) and with newest version (currently 3.12) on ubuntu (to get complete and speedy
-        # coverage on unix). We ignore mac-os, which is assumed to be similar to ubuntu.
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.config.os }}
 
     env:
       PMG_MAPI_KEY: ${{ secrets.PMG_MAPI_KEY }}
@@ -52,13 +51,13 @@ jobs:
 
       - name: Create mamba environment
         run: |
-          micromamba create -n pmg python=${{ matrix.version.python }} --yes
+          micromamba create -n pmg python=${{ matrix.config.python }} --yes
 
       - name: Install uv
         run: micromamba run -n pmg pip install uv
 
       - name: Install ubuntu-only conda dependencies
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.config.os == 'ubuntu-latest'
         run: |
           micromamba install -n pmg -c conda-forge enumlib packmol bader openbabel openff-toolkit --yes
 
@@ -70,7 +69,7 @@ jobs:
           pip install torch
 
           uv pip install numpy cython
-          uv pip install --editable '.[dev,optional]' --resolution=${{ matrix.version.resolution }}
+          uv pip install --editable '.[dev,optional]' --resolution=${{ matrix.config.resolution }}
 
       - name: pytest split ${{ matrix.split }}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,9 +76,6 @@ jobs:
 
           uv pip install --editable '.[dev,optional]'
 
-          # TODO remove next line installing ase from main branch when FrechetCellFilter is released
-          uv pip install --upgrade 'git+https://gitlab.com/ase/ase'
-
       - name: pytest split ${{ matrix.split }}
         run: |
           micromamba activate pmg

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,18 +27,15 @@ jobs:
       matrix:
         # pytest-split automatically distributes work load so parallel jobs finish in similar time
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.9", "3.12"]
+        version:
+          - { python: "3.9", resolution: highest }
+          - { python: "3.12", resolution: lowest-direct }
         split: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
         # include/exclude is meant to maximize CI coverage of different platforms and python
         # versions while minimizing the total number of jobs. We run all pytest splits with the
         # oldest supported python version (currently 3.9) on windows (seems most likely to surface
         # errors) and with newest version (currently 3.12) on ubuntu (to get complete and speedy
         # coverage on unix). We ignore mac-os, which is assumed to be similar to ubuntu.
-        exclude:
-          - os: windows-latest
-            python-version: "3.12"
-          - os: ubuntu-latest
-            python-version: "3.9"
 
     runs-on: ${{ matrix.os }}
 
@@ -55,7 +52,7 @@ jobs:
 
       - name: Create mamba environment
         run: |
-          micromamba create -n pmg python=${{ matrix.python-version }} --yes
+          micromamba create -n pmg python=${{ matrix.version.python }} --yes
 
       - name: Install uv
         run: micromamba run -n pmg pip install uv
@@ -73,8 +70,7 @@ jobs:
           pip install torch
 
           uv pip install numpy cython
-
-          uv pip install --editable '.[dev,optional]'
+          uv pip install --editable '.[dev,optional]' --resolution=${{ matrix.version.resolution }}
 
       - name: pytest split ${{ matrix.split }}
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ ci:
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.3
+    rev: v0.4.7
     hooks:
       - id: ruff
         args: [--fix, --unsafe-fixes]
@@ -27,7 +27,7 @@ repos:
       - id: mypy
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.6
+    rev: v2.3.0
     hooks:
       - id: codespell
         stages: [commit, commit-msg]
@@ -47,7 +47,7 @@ repos:
       - id: blacken-docs
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.40.0
+    rev: v0.41.0
     hooks:
       - id: markdownlint
         # MD013: line too long
@@ -64,6 +64,6 @@ repos:
         args: [--drop-empty-cells, --keep-output]
 
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.361
+    rev: v1.1.365
     hooks:
       - id: pyright

--- a/pymatgen/alchemy/materials.py
+++ b/pymatgen/alchemy/materials.py
@@ -291,7 +291,7 @@ class TransformedStructure(MSONable):
             TransformedStructure
         """
         parser = CifParser.from_str(cif_string, occupancy_tolerance=occupancy_tolerance)
-        raw_string = re.sub(r"'", '"', cif_string)
+        raw_str = re.sub(r"'", '"', cif_string)
         cif_dict = parser.as_dict()
         cif_keys = list(cif_dict)
         struct = parser.parse_structures(primitive=primitive)[0]
@@ -303,7 +303,7 @@ class TransformedStructure(MSONable):
         source_info = {
             "source": source,
             "datetime": str(datetime.datetime.now()),
-            "original_file": raw_string,
+            "original_file": raw_str,
             "cif_data": cif_dict[cif_keys[0]],
         }
         return cls(struct, transformations, history=[source_info])
@@ -326,12 +326,12 @@ class TransformedStructure(MSONable):
             raise ValueError(
                 "Transformation can be created only from POSCAR strings with proper VASP5 element symbols."
             )
-        raw_string = re.sub(r"'", '"', poscar_string)
+        raw_str = re.sub(r"'", '"', poscar_string)
         struct = poscar.structure
         source_info = {
             "source": "POSCAR",
             "datetime": str(datetime.datetime.now()),
-            "original_file": raw_string,
+            "original_file": raw_str,
         }
         return cls(struct, transformations, history=[source_info])
 

--- a/pymatgen/analysis/chemenv/connectivity/structure_connectivity.py
+++ b/pymatgen/analysis/chemenv/connectivity/structure_connectivity.py
@@ -153,12 +153,12 @@ class StructureConnectivity(MSONable):
         if not isinstance(environments_symbols, collections.abc.Iterable):
             environments_symbols = [environments_symbols]
         environments_symbols = sorted(environments_symbols)
-        envs_string = "-".join(environments_symbols)
+        envs_str = "-".join(environments_symbols)
         if only_atoms is not None:
-            envs_string += "#" + "-".join(sorted(only_atoms))
+            envs_str += "#" + "-".join(sorted(only_atoms))
         # Get it directly if it was already computed
-        if envs_string in self.environment_subgraphs:
-            self._environment_subgraph = self.environment_subgraphs[envs_string]
+        if envs_str in self.environment_subgraphs:
+            self._environment_subgraph = self.environment_subgraphs[envs_str]
             return
 
         # Initialize graph for a subset of environments
@@ -248,7 +248,7 @@ class StructureConnectivity(MSONable):
                         delta=conn,
                         ligands=ligands,
                     )
-        self.environment_subgraphs[envs_string] = self._environment_subgraph
+        self.environment_subgraphs[envs_str] = self._environment_subgraph
 
     def setup_connectivity_description(self):
         pass

--- a/pymatgen/analysis/elasticity/elastic.py
+++ b/pymatgen/analysis/elasticity/elastic.py
@@ -728,8 +728,8 @@ class ElasticTensorExpansion(TensorCollection):
         if not self.order <= 4:
             raise ValueError("Compliance tensor expansion only supported for fourth-order and lower")
         ce_exp = [ElasticTensor(self[0]).compliance_tensor]
-        ein_string = "ijpq,pqrsuv,rskl,uvmn->ijklmn"
-        ce_exp.append(np.einsum(ein_string, -ce_exp[-1], self[1], ce_exp[-1], ce_exp[-1]))
+        ein_str = "ijpq,pqrsuv,rskl,uvmn->ijklmn"
+        ce_exp.append(np.einsum(ein_str, -ce_exp[-1], self[1], ce_exp[-1], ce_exp[-1]))
         if self.order == 4:
             # Four terms in the Fourth-Order compliance tensor
             einstring_1 = "pqab,cdij,efkl,ghmn,abcdefgh"

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -36,7 +36,6 @@ from scipy.cluster.hierarchy import fcluster, linkage
 from scipy.linalg import expm, polar
 from scipy.spatial.distance import squareform
 from tabulate import tabulate
-from typing_extensions import Self
 
 from pymatgen.core.bonds import CovalentBond, get_bond_length
 from pymatgen.core.composition import Composition
@@ -60,6 +59,7 @@ if TYPE_CHECKING:
     from ase.optimize.optimize import Optimizer
     from matgl.ext.ase import TrajectoryObserver
     from numpy.typing import ArrayLike, NDArray
+    from typing_extensions import Self
 
     from pymatgen.util.typing import CompositionLike, MillerIndex, PathLike, PbcLike, SpeciesLike
 
@@ -3363,14 +3363,12 @@ class IMolecule(SiteCollection, MSONable):
         Args:
             ind1 (int): 1st site index
             ind2 (int): 2nd site index
-            tol (float): Relative tolerance to test. Basically, the code
-                checks if the distance between the sites is less than (1 +
-                tol) * typical bond distances. Defaults to 0.2, i.e.,
-                20% longer.
+            tol (float): Relative tolerance to test. Basically, the code checks if the distance
+                between the sites is less than (1 + tol) * typical bond distances.
+                Defaults to 0.2, i.e. 20% longer.
 
         Returns:
-            Two IMolecule representing the clusters formed from
-            breaking the bond.
+            tuple[IMolecule, IMolecule]: The clusters formed from breaking the bond.
         """
         clusters = ([self[ind1]], [self[ind2]])
 
@@ -3393,7 +3391,8 @@ class IMolecule(SiteCollection, MSONable):
                 raise ValueError("Not all sites are matched!")
             sites = unmatched
 
-        return cast(tuple[Self, Self], tuple(map(type(self).from_sites, clusters)))
+        from_sites = type(self).from_sites
+        return from_sites(clusters[0]), from_sites(clusters[1])
 
     def get_covalent_bonds(self, tol: float = 0.2) -> list[CovalentBond]:
         """Determine the covalent bonds in a molecule.

--- a/pymatgen/io/abinit/inputs.py
+++ b/pymatgen/io/abinit/inputs.py
@@ -1286,8 +1286,7 @@ class BasicMultiDataset:
         return self[0].to_str(with_pseudos=with_pseudos)
 
     def write(self, filepath="run.abi"):
-        """
-        Write ndset input files to disk. The name of the file
+        """Write ndset input files to disk. The name of the file
         is constructed from the dataset index e.g. run0.abi.
         """
         root, ext = os.path.splitext(filepath)

--- a/pymatgen/io/abinit/netcdf.py
+++ b/pymatgen/io/abinit/netcdf.py
@@ -92,7 +92,7 @@ class NetcdfReader:
         self.ngroups = len(list(self.walk_tree()))
 
         # Always return non-masked numpy arrays.
-        # Slicing a ncvar returns a MaskedArrray and this is really annoying
+        # Slicing a ncvar returns a MaskedArray and this is really annoying
         # because it can lead to unexpected behavior in e.g. calls to np.matmul!
         # See also https://github.com/Unidata/netcdf4-python/issues/785
         self.rootgrp.set_auto_mask(False)

--- a/pymatgen/io/adf.py
+++ b/pymatgen/io/adf.py
@@ -533,8 +533,7 @@ class AdfInput:
         self.task = task
 
     def write_file(self, molecule, inp_file):
-        """
-        Write an ADF input file.
+        """Write an ADF input file.
 
         Args:
             molecule (Molecule): The molecule for this task.

--- a/pymatgen/io/common.py
+++ b/pymatgen/io/common.py
@@ -266,8 +266,7 @@ class VolumetricData(MSONable):
         return total / ng[(ind + 1) % 3] / ng[(ind + 2) % 3]
 
     def to_hdf5(self, filename):
-        """
-        Writes the VolumetricData to a HDF5 format, which is a highly optimized
+        """Write the VolumetricData to a HDF5 format, which is a highly optimized
         format for reading storing large data. The mapping of the VolumetricData
         to this file format is as follows:
 

--- a/pymatgen/io/common.py
+++ b/pymatgen/io/common.py
@@ -322,8 +322,7 @@ class VolumetricData(MSONable):
             return cls(structure, data=data, data_aug=data_aug, **kwargs)
 
     def to_cube(self, filename, comment: str = ""):
-        """
-        Write the total volumetric data to a cube file format, which consists of two comment lines,
+        """Write the total volumetric data to a cube file format, which consists of two comment lines,
         a header section defining the structure IN BOHR, and the data.
 
         Args:

--- a/pymatgen/io/core.py
+++ b/pymatgen/io/core.py
@@ -64,8 +64,7 @@ class InputFile(MSONable):
         """Return a string representation of an entire input file."""
 
     def write_file(self, filename: str | PathLike) -> None:
-        """
-        Write the input file.
+        """Write the input file.
 
         Args:
             filename: The filename to output to, including path.
@@ -186,8 +185,7 @@ class InputSet(MSONable, MutableMapping):
         overwrite: bool = True,
         zip_inputs: bool = False,
     ):
-        """
-        Write Inputs to one or more files.
+        """Write Inputs to one or more files.
 
         Args:
             directory: Directory to write input files to

--- a/pymatgen/io/cssr.py
+++ b/pymatgen/io/cssr.py
@@ -52,8 +52,7 @@ class Cssr:
         return "\n".join(output)
 
     def write_file(self, filename):
-        """
-        Write out a CSSR file.
+        """Write out a CSSR file.
 
         Args:
             filename (str): Filename to write to.

--- a/pymatgen/io/exciting/inputs.py
+++ b/pymatgen/io/exciting/inputs.py
@@ -171,8 +171,7 @@ class ExcitingInput(MSONable):
         return cls.from_str(data)
 
     def write_etree(self, celltype, cartesian=False, bandstr=False, symprec: float = 0.4, angle_tolerance=5, **kwargs):
-        """
-        Writes the exciting input parameters to an xml object.
+        """Write the exciting input parameters to an XML object.
 
         Args:
             celltype (str): Choice of unit cell. Can be either the unit cell
@@ -278,8 +277,7 @@ class ExcitingInput(MSONable):
         return root
 
     def write_string(self, celltype, cartesian=False, bandstr=False, symprec: float = 0.4, angle_tolerance=5, **kwargs):
-        """
-        Writes exciting input.xml as a string.
+        """Write exciting input.xml as a string.
 
         Args:
             celltype (str): Choice of unit cell. Can be either the unit cell
@@ -315,8 +313,7 @@ class ExcitingInput(MSONable):
     def write_file(
         self, celltype, filename, cartesian=False, bandstr=False, symprec: float = 0.4, angle_tolerance=5, **kwargs
     ):
-        """
-        Writes exciting input file.
+        """Write exciting input file.
 
         Args:
             celltype (str): Choice of unit cell. Can be either the unit cell

--- a/pymatgen/io/feff/inputs.py
+++ b/pymatgen/io/feff/inputs.py
@@ -978,10 +978,7 @@ def get_atom_map(structure, absorbing_atom=None):
     if absorbing_atom and len(structure.indices_from_symbol(absorbing_atom)) == 1:
         unique_pot_atoms.remove(absorbing_atom)
 
-    atom_map = {}
-    for idx, atom in enumerate(unique_pot_atoms, start=1):
-        atom_map[atom] = idx
-    return atom_map
+    return dict(enumerate(unique_pot_atoms, start=1))
 
 
 def get_absorbing_atom_symbol_index(absorbing_atom, structure):

--- a/pymatgen/io/feff/inputs.py
+++ b/pymatgen/io/feff/inputs.py
@@ -506,8 +506,7 @@ class Atoms(MSONable):
         return f"ATOMS\n{atom_list}\nEND\n"
 
     def write_file(self, filename="ATOMS"):
-        """
-        Write Atoms list to file.
+        """Write Atoms list to file.
 
         Args:
             filename: path for file to be written
@@ -626,8 +625,7 @@ class Tags(dict):
         return self.get_str()
 
     def write_file(self, filename="PARAMETERS"):
-        """
-        Write Tags to a Feff parameter tag file.
+        """Write Tags to a Feff parameter tag file.
 
         Args:
             filename: filename and path to write to.
@@ -907,8 +905,7 @@ class Potential(MSONable):
         return f"POTENTIALS \n{ipotlist}"
 
     def write_file(self, filename="POTENTIALS"):
-        """
-        Write to file.
+        """Write to file.
 
         Args:
             filename: filename and path to write potential file to.

--- a/pymatgen/io/feff/inputs.py
+++ b/pymatgen/io/feff/inputs.py
@@ -978,7 +978,7 @@ def get_atom_map(structure, absorbing_atom=None):
     if absorbing_atom and len(structure.indices_from_symbol(absorbing_atom)) == 1:
         unique_pot_atoms.remove(absorbing_atom)
 
-    return dict(enumerate(unique_pot_atoms, start=1))
+    return {atom: idx for idx, atom in enumerate(unique_pot_atoms, start=1)}
 
 
 def get_absorbing_atom_symbol_index(absorbing_atom, structure):

--- a/pymatgen/io/feff/inputs.py
+++ b/pymatgen/io/feff/inputs.py
@@ -360,8 +360,7 @@ class Header(MSONable):
         return "\n".join(output)
 
     def write_file(self, filename="HEADER"):
-        """
-        Writes Header into filename on disk.
+        """Write Header to file.
 
         Args:
             filename: Filename and path for file to be written to disk

--- a/pymatgen/io/feff/sets.py
+++ b/pymatgen/io/feff/sets.py
@@ -86,8 +86,7 @@ class AbstractFeffInputSet(MSONable, abc.ABC):
         return dct
 
     def write_input(self, output_dir=".", make_dir_if_not_present=True):
-        """
-        Writes a set of FEFF input to a directory.
+        """Write a FEFF input set to a directory.
 
         Args:
             output_dir: Directory to output the FEFF input files

--- a/pymatgen/io/fiesta.py
+++ b/pymatgen/io/fiesta.py
@@ -528,8 +528,7 @@ $geometry
         )
 
     def write_file(self, filename: str | Path) -> None:
-        """
-        Write FiestaInput to a file
+        """Write FiestaInput to a file
 
         Args:
             filename: Filename.

--- a/pymatgen/io/gaussian.py
+++ b/pymatgen/io/gaussian.py
@@ -436,8 +436,7 @@ class GaussianInput:
         return "\n".join(output)
 
     def write_file(self, filename, cart_coords=False):
-        """
-        Write the input string into a file.
+        """Write the input string into a file.
 
         Option: see __str__ method
         """

--- a/pymatgen/io/lammps/data.py
+++ b/pymatgen/io/lammps/data.py
@@ -451,8 +451,7 @@ class LammpsData(MSONable):
         return file_template.format(stats=stats, box=box, body=body)
 
     def write_file(self, filename: str, distance: int = 6, velocity: int = 8, charge: int = 4) -> None:
-        """
-        Writes LammpsData to file.
+        """Write LammpsData to file.
 
         Args:
             filename (str): Filename.

--- a/pymatgen/io/lammps/inputs.py
+++ b/pymatgen/io/lammps/inputs.py
@@ -518,8 +518,7 @@ class LammpsInputFile(InputFile):
         return lammps_input
 
     def write_file(self, filename: str | PathLike, ignore_comments: bool = False, keep_stages: bool = True) -> None:
-        """
-        Writes the input file.
+        """Write LAMMPS input file.
 
         Args:
             filename (str or path): The filename to output to, including path.
@@ -871,8 +870,7 @@ class LammpsRun(MSONable):
         self.script_filename = script_filename
 
     def write_inputs(self, output_dir: str, **kwargs) -> None:
-        """
-        Writes all input files (input script, and data if needed).
+        """Write all input files (input script, and data if needed).
         Other supporting files are not handled at this moment.
 
         Args:

--- a/pymatgen/io/lammps/utils.py
+++ b/pymatgen/io/lammps/utils.py
@@ -258,8 +258,7 @@ class PackmolRunner:
             self.param_list[idx]["inside box"] = f"0.0 0.0 0.0 {length} {length} {length}"
 
     def _write_input(self, input_dir: str = ".") -> None:
-        """
-        Write the packmol input file to the input directory.
+        """Write the packmol input file to the input directory.
 
         Args:
             input_dir (str): path to the input directory
@@ -292,8 +291,7 @@ class PackmolRunner:
                 inp.write("end structure\n")
 
     def run(self, site_property: str | None = None) -> Molecule:
-        """
-        Write the input file to the scratch directory, run packmol and return
+        """Write the input file to the scratch directory, run packmol and return
         the packed molecule to the current working directory.
 
         Args:

--- a/pymatgen/io/lmto.py
+++ b/pymatgen/io/lmto.py
@@ -130,8 +130,7 @@ class LMTOCtrl:
         return {**ctrl_dict, **update}
 
     def write_file(self, filename="CTRL", **kwargs):
-        """
-        Writes a CTRL file with structure, HEADER, and VERS that can be
+        """Write a CTRL file with structure, HEADER, and VERS that can be
         used as input for lmhart.run.
         """
         with zopen(filename, mode="wt") as file:

--- a/pymatgen/io/lobster/inputs.py
+++ b/pymatgen/io/lobster/inputs.py
@@ -251,8 +251,7 @@ class Lobsterin(UserDict, MSONable):
         return int(no_basis_functions)
 
     def write_lobsterin(self, path="lobsterin", overwritedict=None):
-        """
-        Writes a lobsterin file.
+        """Write a lobsterin file.
 
         Args:
             path (str): filename of the lobsterin file that will be written
@@ -418,8 +417,7 @@ class Lobsterin(UserDict, MSONable):
     def write_POSCAR_with_standard_primitive(
         POSCAR_input="POSCAR", POSCAR_output="POSCAR.lobster", symprec: float = 0.01
     ):
-        """
-        Writes a POSCAR with the standard primitive cell.
+        """Write a POSCAR with the standard primitive cell.
         This is needed to arrive at the correct kpath.
 
         Args:
@@ -444,8 +442,7 @@ class Lobsterin(UserDict, MSONable):
         kpoints_line_density: int = 20,
         symprec: float = 0.01,
     ):
-        """
-        Writes a KPOINT file for lobster (only ISYM=-1 and ISYM=0 are possible), grids are gamma centered.
+        """Write a KPOINT file for lobster (only ISYM=-1 and ISYM=0 are possible), grids are Gamma-centered.
 
         Args:
             POSCAR_input (str): path to POSCAR

--- a/pymatgen/io/pwscf.py
+++ b/pymatgen/io/pwscf.py
@@ -214,8 +214,7 @@ class PWInput:
         )
 
     def write_file(self, filename):
-        """
-        Write the PWSCF input file.
+        """Write the PWSCF input file.
 
         Args:
             filename (str): The string filename to output to.

--- a/pymatgen/io/qchem/inputs.py
+++ b/pymatgen/io/qchem/inputs.py
@@ -370,8 +370,7 @@ class QCInput(InputFile):
 
     @staticmethod
     def write_multi_job_file(job_list: list[QCInput], filename: str):
-        """
-        Write a multijob file.
+        """Write a multijob file.
 
         Args:
             job_list (): List of jobs.

--- a/pymatgen/io/shengbte.py
+++ b/pymatgen/io/shengbte.py
@@ -152,8 +152,7 @@ class Control(MSONable, dict):
 
     @classmethod
     def from_dict(cls, control_dict: dict) -> Self:
-        """
-        Write a CONTROL file from a Python dictionary. Description and default
+        """Write a CONTROL file from a Python dictionary. Description and default
         parameters can be found at
         https://bitbucket.org/sousaw/shengbte/src/master/.
         Note some parameters are mandatory. Optional parameters default here to

--- a/pymatgen/io/shengbte.py
+++ b/pymatgen/io/shengbte.py
@@ -169,8 +169,7 @@ class Control(MSONable, dict):
         "ShengBTE Control object requires f90nml to be installed. Please get it at https://pypi.org/project/f90nml.",
     )
     def to_file(self, filename: str = "CONTROL") -> None:
-        """
-        Writes ShengBTE CONTROL file from 'Control' object.
+        """Write ShengBTE CONTROL file from 'Control' object.
 
         Args:
             filename: A file name.

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -619,8 +619,7 @@ class Poscar(MSONable):
     get_string = get_str
 
     def write_file(self, filename: PathLike, **kwargs) -> None:
-        """
-        Write POSCAR to a file. The supported kwargs are the same as those for
+        """Write POSCAR to a file. The supported kwargs are the same as those for
         the Poscar.get_str method and are passed through directly.
         """
         with zopen(filename, mode="wt") as file:
@@ -1630,8 +1629,7 @@ class Kpoints(MSONable):
         )
 
     def write_file(self, filename: str) -> None:
-        """
-        Write Kpoints to a file.
+        """Write Kpoints to a file.
 
         Args:
             filename (str): Filename to write to.
@@ -2690,8 +2688,7 @@ class Potcar(list, MSONable):
         return potcar
 
     def write_file(self, filename: PathLike) -> None:
-        """
-        Write Potcar to a file.
+        """Write Potcar to a file.
 
         Args:
             filename (PathLike): filename to write to.
@@ -2804,8 +2801,7 @@ class VaspInput(dict, MSONable):
         zip_name: str | None = None,
         files_to_transfer: dict | None = None,
     ) -> None:
-        """
-        Write VASP inputs to a directory.
+        """Write VASP inputs to a directory.
 
         Args:
             output_dir (PathLike): Directory to write to.
@@ -2900,8 +2896,7 @@ class VaspInput(dict, MSONable):
         output_file: PathLike = "vasp.out",
         err_file: PathLike = "vasp.err",
     ) -> None:
-        """
-        Write input files and run VASP.
+        """Write input files and run VASP.
 
         Args:
             run_dir: Where to write input files and do the run.

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -3224,10 +3224,7 @@ class Outcar:
 
             micro_pyawk(self.filename, search, self)
 
-            zval_dict = {}
-            for x, y in zip(self.atom_symbols, self.zvals):  # type: ignore[attr-defined]
-                zval_dict[x] = y
-            self.zval_dict = zval_dict
+            self.zval_dict = dict(zip(self.atom_symbols, self.zvals))  # type: ignore[attr-defined]
 
             # Clean up
             del self.atom_symbols  # type: ignore[attr-defined]
@@ -4174,8 +4171,7 @@ class Xdatcar:
             assert preamble is not None
             poscar = Poscar.from_str("\n".join([*preamble, "Direct", *coords_str]))
             if (
-                ionicstep_end is None
-                and ionicstep_cnt >= ionicstep_start
+                (ionicstep_end is None and ionicstep_cnt >= ionicstep_start)
                 or ionicstep_start <= ionicstep_cnt < ionicstep_end  # type: ignore[operator]
             ):
                 structures.append(poscar.structure)
@@ -4248,10 +4244,8 @@ class Xdatcar:
                 elif line == "" or "Direct configuration=" in line:
                     poscar = Poscar.from_str("\n".join([*preamble, "Direct", *coords_str]))
                     if (
-                        ionicstep_end is None
-                        and ionicstep_cnt >= ionicstep_start
-                        or ionicstep_start <= ionicstep_cnt < ionicstep_end
-                    ):
+                        ionicstep_end is None and ionicstep_cnt >= ionicstep_start
+                    ) or ionicstep_start <= ionicstep_cnt < ionicstep_end:
                         structures.append(poscar.structure)
                     ionicstep_cnt += 1
                     coords_str = []
@@ -4262,8 +4256,7 @@ class Xdatcar:
             poscar = Poscar.from_str("\n".join([*preamble, "Direct", *coords_str]))
 
             if (
-                ionicstep_end is None
-                and ionicstep_cnt >= ionicstep_start
+                (ionicstep_end is None and ionicstep_cnt >= ionicstep_start)
                 or ionicstep_start <= ionicstep_cnt < ionicstep_end  # type: ignore[operator]
             ):
                 structures.append(poscar.structure)
@@ -4299,8 +4292,7 @@ class Xdatcar:
         for cnt, structure in enumerate(self.structures, start=1):
             ionicstep_cnt = cnt
             if (
-                ionicstep_end is None
-                and ionicstep_cnt >= ionicstep_start
+                (ionicstep_end is None and ionicstep_cnt >= ionicstep_start)
                 or ionicstep_start <= ionicstep_cnt < ionicstep_end  # type: ignore[operator]
             ):
                 lines.append(f"Direct configuration={' ' * (7 - len(str(output_cnt)))}{output_cnt}")

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -330,8 +330,7 @@ class VaspInputSet(InputGenerator, abc.ABC):
         potcar_spec: bool = False,
         zip_output: bool | str = False,
     ) -> None:
-        """
-        Writes a set of VASP input to a directory.
+        """Write a set of VASP input to a directory.
 
         Args:
             output_dir (str): Directory to output the VASP input files

--- a/pymatgen/io/wannier90.py
+++ b/pymatgen/io/wannier90.py
@@ -127,8 +127,7 @@ class Unk:
         return cls(ik, data)
 
     def write_file(self, filename: str) -> None:
-        """
-        Write the UNK file.
+        """Write the UNK file.
 
         Args:
             filename (str): path to UNK file to write, the name should have the

--- a/pymatgen/io/xr.py
+++ b/pymatgen/io/xr.py
@@ -64,8 +64,7 @@ class Xr:
         return "\n".join(output)
 
     def write_file(self, filename: str | Path) -> None:
-        """
-        Write out an xr file.
+        """Write out an xr file.
 
         Args:
             filename (str): name of the file to write to.

--- a/pymatgen/io/xyz.py
+++ b/pymatgen/io/xyz.py
@@ -137,8 +137,7 @@ class XYZ:
         return "\n".join(self._frame_str(mol) for mol in self._mols)
 
     def write_file(self, filename: str) -> None:
-        """
-        Writes XYZ to file.
+        """Write XYZ file.
 
         Args:
             filename (str): File name of output file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,8 +137,9 @@ ignore_missing_imports = true
 
 [tool.codespell]
 ignore-words-list = """
-titel,alls,ans,nd,mater,nwo,te,hart,ontop,ist,ot,fo,nax,coo,coul,ser,leary,thre,fase,
-rute,reson,titels,ges,scalr,strat,struc,hda,nin,ons,pres,kno,loos,lamda,lew,atomate
+titel,alls,ans,nd,mater,nwo,te,hart,ontop,ist,ot,fo,nax,coo,
+coul,ser,leary,thre,fase,rute,reson,titels,ges,scalr,strat,
+struc,hda,nin,ons,pres,kno,loos,lamda,lew,atomate,nempty
 """
 skip = "pymatgen/analysis/aflow_prototypes.json"
 check-filenames = true

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,4 +1,4 @@
-ase>=3.22.1
+ase>=3.23.0
 beautifulsoup4==4.12.2
 BoltzTraP2>=22.3.2
 chemview>=0.6

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -5,7 +5,7 @@ chemview>=0.6
 f90nml>=1.4.3
 fdint>=2.0.2
 galore>=0.7.0
-h5py==3.9.0
+h5py==3.11.0
 # hiphive>=0.6
 icet>=2.2
 jarvis-tools>=2022.9.16

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -11,5 +11,5 @@ icet>=2.2
 jarvis-tools>=2022.9.16
 matgl==1.1.1
 netCDF4>=1.5.8
-phonopy==2.20.0
+phonopy==2.23.1
 seekpath>=2.0.1

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
             "chgnet==0.3.5",
             "f90nml>=1.1.2",
             "galore>=0.6.1",
-            "h5py>=3.9.0",
+            "h5py>=3.11.0",
             "jarvis-tools>=2020.7.14",
             "matgl>=1.1.1",
             "netCDF4>=1.6.5",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     python_requires=">=3.9",
     install_requires=[
         "matplotlib>=1.5",
-        "monty>=2024.2.2",
+        "monty>=2024.5.24",
         "networkx>=2.2",
         "numpy>=1.25.0",
         "palettable>=3.1.1",

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         "pybtex>=0.24.0",
         "requests>=2.20",
         "ruamel.yaml>=0.17.0",
-        "scipy>=1.5.0",
+        "scipy>=1.13.0",
         "spglib>=2.0.2",
         "sympy>=1.2",
         "tabulate>=0.9",

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         # don't depend on tblite above 3.11 since unsupported https://github.com/tblite/tblite/issues/175
         "tblite": ["tblite[ase]>=0.3.0; python_version<'3.12'"],
         "vis": ["vtk>=6.0.0"],
-        "abinit": ["netcdf4>=1.6"],
+        "abinit": ["netcdf4>=1.6.5"],
         "relaxation": ["matgl>=1.1.1", "chgnet==0.3.5"],
         "electronic_structure": ["fdint>=2.0.2"],
         "dev": [
@@ -78,7 +78,7 @@ setup(
             "chgnet==0.3.5",
             "f90nml>=1.1.2",
             "galore>=0.6.1",
-            "h5py>=3.8.0",
+            "h5py>=3.9.0",
             "jarvis-tools>=2020.7.14",
             "matgl>=1.1.1",
             "netCDF4>=1.6.5",

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ extra_link_args = ["-Wl,--allow-multiple-definition"] if is_win_64 else []
 with open("README.md") as file:
     long_description = file.read()
 
-# unlike GitHub readme's, PyPI doesn't support <picture> tags used for responsive images
+# unlike GitHub readmes, PyPI doesn't support <picture> tags used for responsive images
 # (i.e. adaptive to OS light/dark mode)
 # NOTE this manual fix won't work once we migrate to pyproject.toml
 logo_url = "https://raw.githubusercontent.com/materialsproject/pymatgen/master/docs/_images/pymatgen.svg"
@@ -33,18 +33,18 @@ setup(
         "networkx>=2.2",
         "numpy>=1.25.0",
         "palettable>=3.1.1",
-        "pandas",
+        "pandas>=2",
         "plotly>=4.5.0",
-        "pybtex",
-        "requests",
+        "pybtex>=0.24.0",
+        "requests>=2.20",
         "ruamel.yaml>=0.17.0",
         "scipy>=1.5.0",
         "spglib>=2.0.2",
-        "sympy",
-        "tabulate",
-        "tqdm",
+        "sympy>=1.2",
+        "tabulate>=0.9",
+        "tqdm>=4.60",
         "uncertainties>=3.1.4",
-        "joblib",
+        "joblib>=1",
     ],
     extras_require={
         "ase": ["ase>=3.23.0"],
@@ -55,13 +55,13 @@ setup(
         "relaxation": ["matgl", "chgnet>=0.3.0"],
         "electronic_structure": ["fdint>=2.0.2"],
         "dev": [
-            "mypy",
-            "pre-commit",
-            "pytest-cov",
-            "pytest-split",
-            "pytest",
-            "ruff",
-            "typing-extensions",
+            "mypy>=1.10.0",
+            "pre-commit>=3",
+            "pytest-cov>=4",
+            "pytest-split>=0.8",
+            "pytest>8",
+            "ruff>=0.4",
+            "typing-extensions>=4",
         ],
         "docs": [
             "sphinx",
@@ -80,7 +80,7 @@ setup(
             "galore>=0.6.1",
             "h5py>=3.8.0",
             "jarvis-tools>=2020.7.14",
-            "matgl",
+            "matgl>=1.1.1",
             "netCDF4>=1.5.8",
             "phonopy>=2.4.2",
             "seekpath>=1.9.4",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         "pandas>=2",
         "plotly>=4.5.0",
         "pybtex>=0.24.0",
-        "requests>=2.20",
+        "requests>=2.32",
         "ruamel.yaml>=0.17.0",
         "scipy>=1.13.0",
         "spglib>=2.0.2",

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         "joblib",
     ],
     extras_require={
-        "ase": ["ase>=3.3"],
+        "ase": ["ase>=3.23.0"],
         # don't depend on tblite above 3.11 since unsupported https://github.com/tblite/tblite/issues/175
         "tblite": ["tblite[ase]>=0.3.0; python_version<'3.12'"],
         "vis": ["vtk>=6.0.0"],
@@ -69,7 +69,7 @@ setup(
             "doc2dash",
         ],
         "optional": [
-            "ase>=3.22.1",
+            "ase>=3.23.0",
             # TODO restore BoltzTraP2 when install fixed, hopefully following merge of
             # https://gitlab.com/sousaw/BoltzTraP2/-/merge_requests/18
             # caused CI failure due to ModuleNotFoundError: No module named 'packaging'

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         "tblite": ["tblite[ase]>=0.3.0; python_version<'3.12'"],
         "vis": ["vtk>=6.0.0"],
         "abinit": ["netcdf4>=1.6"],
-        "relaxation": ["matgl", "chgnet==0.3.5"],
+        "relaxation": ["matgl>=1.1.1", "chgnet==0.3.5"],
         "electronic_structure": ["fdint>=2.0.2"],
         "dev": [
             "mypy>=1.10.0",
@@ -81,7 +81,7 @@ setup(
             "h5py>=3.8.0",
             "jarvis-tools>=2020.7.14",
             "matgl>=1.1.1",
-            "netCDF4>=1.5.8",
+            "netCDF4>=1.6",
             "phonopy>=2.4.2",
             "seekpath>=1.9.4",
             # don't depend on tblite above 3.11 since unsupported https://github.com/tblite/tblite/issues/175
@@ -89,7 +89,7 @@ setup(
             # "hiphive>=0.6",
             # "openbabel>=3.1.1; platform_system=='Linux'",
         ],
-        "numba": ["numba"],
+        "numba": ["numba>=0.55"],
     },
     # All package data has to be explicitly defined. Do not use automated codes like last time. It adds
     # all sorts of useless files like test files and is prone to path errors.

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         # don't depend on tblite above 3.11 since unsupported https://github.com/tblite/tblite/issues/175
         "tblite": ["tblite[ase]>=0.3.0; python_version<'3.12'"],
         "vis": ["vtk>=6.0.0"],
-        "abinit": ["netcdf4"],
+        "abinit": ["netcdf4>=1.6"],
         "relaxation": ["matgl", "chgnet>=0.3.0"],
         "electronic_structure": ["fdint>=2.0.2"],
         "dev": [

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         "tblite": ["tblite[ase]>=0.3.0; python_version<'3.12'"],
         "vis": ["vtk>=6.0.0"],
         "abinit": ["netcdf4>=1.6"],
-        "relaxation": ["matgl", "chgnet>=0.3.0"],
+        "relaxation": ["matgl", "chgnet==0.3.6"],
         "electronic_structure": ["fdint>=2.0.2"],
         "dev": [
             "mypy>=1.10.0",
@@ -75,7 +75,7 @@ setup(
             # caused CI failure due to ModuleNotFoundError: No module named 'packaging'
             # "BoltzTraP2>=22.3.2; platform_system!='Windows'",
             "chemview>=0.6",
-            "chgnet>=0.3.0",
+            "chgnet==0.3.6",
             "f90nml>=1.1.2",
             "galore>=0.6.1",
             "h5py>=3.8.0",

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     version="2024.5.31",
     python_requires=">=3.9",
     install_requires=[
-        "matplotlib>=1.5",
+        "matplotlib>=3.8",
         "monty>=2024.5.24",
         "networkx>=2.2",
         "numpy>=1.25.0",

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         "tblite": ["tblite[ase]>=0.3.0; python_version<'3.12'"],
         "vis": ["vtk>=6.0.0"],
         "abinit": ["netcdf4>=1.6"],
-        "relaxation": ["matgl", "chgnet==0.3.6"],
+        "relaxation": ["matgl", "chgnet==0.3.5"],
         "electronic_structure": ["fdint>=2.0.2"],
         "dev": [
             "mypy>=1.10.0",
@@ -75,7 +75,7 @@ setup(
             # caused CI failure due to ModuleNotFoundError: No module named 'packaging'
             # "BoltzTraP2>=22.3.2; platform_system!='Windows'",
             "chemview>=0.6",
-            "chgnet==0.3.6",
+            "chgnet==0.3.5",
             "f90nml>=1.1.2",
             "galore>=0.6.1",
             "h5py>=3.8.0",

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
             "jarvis-tools>=2020.7.14",
             "matgl>=1.1.1",
             "netCDF4>=1.6.5",
-            "phonopy>=2.4.2",
+            "phonopy>=2.23",
             "seekpath>=1.9.4",
             # don't depend on tblite above 3.11 since unsupported https://github.com/tblite/tblite/issues/175
             "tblite[ase]>=0.3.0; platform_system=='Linux' and python_version<'3.12'",

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
             "h5py>=3.8.0",
             "jarvis-tools>=2020.7.14",
             "matgl>=1.1.1",
-            "netCDF4>=1.6",
+            "netCDF4>=1.6.5",
             "phonopy>=2.4.2",
             "seekpath>=1.9.4",
             # don't depend on tblite above 3.11 since unsupported https://github.com/tblite/tblite/issues/175

--- a/tests/io/exciting/test_inputs.py
+++ b/tests/io/exciting/test_inputs.py
@@ -132,11 +132,11 @@ class TestExcitingInput(PymatgenTest):
         assert label == label_ref
         assert coord == coord_ref
 
-    def test_paramdict(self):
+    def test_param_dict(self):
         coords = [[0.0, 0.0, 0.0], [0.75, 0.5, 0.75]]
         lattice = Lattice.from_parameters(a=3.84, b=3.84, c=3.84, alpha=120, beta=90, gamma=60)
         struct = Structure(lattice, ["Si", "Si"], coords)
-        paradir = {
+        param_dict = {
             "grst": {
                 "do": "fromscratch",
                 "ngridk": "8 8 8",
@@ -158,12 +158,12 @@ class TestExcitingInput(PymatgenTest):
         }
 
         test_input = ExcitingInput(struct)
-        test_string = test_input.write_string("unchanged", **paradir)
+        test_str = test_input.write_string("unchanged", **param_dict)
 
         # read reference file
         filepath = f"{TEST_DIR}/input_exciting2.xml"
         tree = ElementTree.parse(filepath)
         root = tree.getroot()
-        ref_string = ElementTree.tostring(root, encoding="unicode")
+        ref_str = ElementTree.tostring(root, encoding="unicode")
 
-        assert ref_string.strip() == test_string.strip()
+        assert ref_str.strip() == test_str.strip()

--- a/tests/io/test_atat.py
+++ b/tests/io/test_atat.py
@@ -12,7 +12,7 @@ TEST_DIR = f"{TEST_FILES_DIR}/io/atat/mcsqs"
 
 class TestAtat(PymatgenTest):
     def test_mcsqs_import(self):
-        test_string = """1.000000 0.000000 0.000000
+        test_str = """1.000000 0.000000 0.000000
 0.000000 1.000000 0.000000
 0.000000 0.000000 1.000000
 0.000000 -1.000000 -2.000000
@@ -60,7 +60,7 @@ class TestAtat(PymatgenTest):
 0.000000 -1.000000 -1.500000 O
 """
 
-        mcsqs = Mcsqs.structure_from_str(test_string)
+        mcsqs = Mcsqs.structure_from_str(test_str)
 
         assert mcsqs.formula == "Sr3 Ca5 Mn7 Fe1 O24"
         assert mcsqs.lattice.a == approx(2.2360679775)
@@ -71,7 +71,7 @@ class TestAtat(PymatgenTest):
         struct = self.get_structure("SrTiO3")
         struct.replace_species({"Sr2+": {"Sr2+": 0.5, "Ca2+": 0.5}})
 
-        ref_string = """3.905000 0.000000 0.000000
+        ref_str = """3.905000 0.000000 0.000000
 -0.000000 3.905000 0.000000
 0.000000 0.000000 3.905000
 1.0 0.0 0.0
@@ -83,7 +83,7 @@ class TestAtat(PymatgenTest):
 0.000000 0.500000 0.000000 O2-=1.0
 0.500000 0.000000 0.000000 O2-=1.0"""
 
-        assert Mcsqs(struct).to_str() == ref_string
+        assert Mcsqs(struct).to_str() == ref_str
 
     def test_mcsqs_cif_nacl(self):
         # CIF file from str2cif (utility distributed with atat)

--- a/tests/io/test_cif.py
+++ b/tests/io/test_cif.py
@@ -1041,11 +1041,11 @@ Gd1 5.05 5.05 0.0"""
 
     def test_write(self):
         with open(f"{MCIF_TEST_DIR}/GdB4-writer-ref.mcif") as file:
-            cw_ref_string = file.read()
+            cw_ref_str = file.read()
         s_ncl = self.mcif_ncl.parse_structures(primitive=False)[0]
 
         cw = CifWriter(s_ncl, write_magmoms=True)
-        assert str(cw) == cw_ref_string
+        assert str(cw) == cw_ref_str
 
         # from list-type magmoms
         list_magmoms = [list(m) for m in s_ncl.site_properties["magmom"]]
@@ -1055,15 +1055,15 @@ Gd1 5.05 5.05 0.0"""
 
         s_ncl.add_site_property("magmom", list_magmoms)
         cw = CifWriter(s_ncl, write_magmoms=True)
-        assert str(cw) == cw_ref_string
+        assert str(cw) == cw_ref_str
 
         s_ncl.add_site_property("magmom", float_magmoms)
         cw = CifWriter(s_ncl, write_magmoms=True)
 
         with open(f"{MCIF_TEST_DIR}/GdB4-str-magnitudes-ref.mcif") as file:
-            cw_ref_string_magnitudes = file.read()
+            cw_ref_str_magnitudes = file.read()
 
-        assert str(cw).strip() == cw_ref_string_magnitudes.strip()
+        assert str(cw).strip() == cw_ref_str_magnitudes.strip()
         # test we're getting correct magmoms in ncl case
         s_ncl2 = self.mcif_ncl2.parse_structures()[0]
         list_magmoms = [list(m) for m in s_ncl2.site_properties["magmom"]]

--- a/tests/io/test_shengbte.py
+++ b/tests/io/test_shengbte.py
@@ -70,19 +70,19 @@ class TestShengBTE(PymatgenTest):
         io.to_file(filename=f"{self.tmp_path}/test_control")
 
         with open(f"{self.tmp_path}/test_control") as file:
-            test_string = file.read()
+            test_str = file.read()
         with open(f"{TEST_DIR}/CONTROL-CSLD_Si") as reference_file:
             reference_string = reference_file.read()
-        assert test_string == reference_string
+        assert test_str == reference_string
 
     def test_from_dict(self):
         io = Control.from_dict(self.test_dict)
         io.to_file(filename=f"{self.tmp_path}/test_control")
         with open(f"{self.tmp_path}/test_control") as file:
-            test_string = file.read()
+            test_str = file.read()
         with open(f"{TEST_DIR}/CONTROL-CSLD_Si") as reference_file:
             reference_string = reference_file.read()
-        assert test_string == reference_string
+        assert test_str == reference_string
 
     def test_as_from_dict(self):
         # tests as dict and from dict methods

--- a/tests/io/test_xcrysden.py
+++ b/tests/io/test_xcrysden.py
@@ -72,7 +72,7 @@ PRIMCOORD
         even if the atomic symbol / number convention
         is different.
         """
-        test_string = """
+        test_str = """
 CRYSTAL
 PRIMVEC
        11.45191956     0.00000000     0.00000000
@@ -82,7 +82,7 @@ PRIMCOORD
 1 1
 H     -0.71644986    -0.41364333     1.19898200     0.00181803     0.00084718     0.00804832
 """
-        structure = XSF.from_str(test_string).structure
+        structure = XSF.from_str(test_str).structure
         assert str(structure.species[0]) == "H"
         test_string2 = """
 CRYSTAL

--- a/tests/io/vasp/test_inputs.py
+++ b/tests/io/vasp/test_inputs.py
@@ -64,7 +64,7 @@ class TestPoscar(PymatgenTest):
         assert comp == Composition("Fe4P4O16")
 
         # VASP 4 type with symbols at the end.
-        poscar_string = """Test1
+        poscar_str = """Test1
 1.0
 3.840198 0.000000 0.000000
 1.920099 3.325710 0.000000
@@ -74,15 +74,15 @@ direct
 0.000000 0.000000 0.000000 Si
 0.750000 0.500000 0.750000 F
 """
-        poscar = Poscar.from_str(poscar_string)
+        poscar = Poscar.from_str(poscar_str)
         assert poscar.structure.composition == Composition("SiF")
 
-        poscar_string = ""
+        poscar_str = ""
         with pytest.raises(ValueError, match="Empty POSCAR"):
-            Poscar.from_str(poscar_string)
+            Poscar.from_str(poscar_str)
 
         # VASP 4 style file with default names, i.e. no element symbol found.
-        poscar_string = """Test2
+        poscar_str = """Test2
 1.0
 3.840198 0.000000 0.000000
 1.920099 3.325710 0.000000
@@ -92,10 +92,10 @@ direct
 0.000000 0.000000 0.000000
 0.750000 0.500000 0.750000
 """
-        poscar = Poscar.from_str(poscar_string)
+        poscar = Poscar.from_str(poscar_str)
         assert poscar.structure.composition == Composition("HHe")
         # VASP 4 style file with default names, i.e. no element symbol found.
-        poscar_string = """Test3
+        poscar_str = """Test3
 1.0
 3.840198 0.000000 0.000000
 1.920099 3.325710 0.000000
@@ -106,7 +106,7 @@ direct
 0.000000 0.000000 0.000000 T T T Si
 0.750000 0.500000 0.750000 F F F O
 """
-        poscar = Poscar.from_str(poscar_string)
+        poscar = Poscar.from_str(poscar_str)
         selective_dynamics = [list(x) for x in poscar.selective_dynamics]
 
         assert selective_dynamics == [[True, True, True], [False, False, False]]
@@ -173,7 +173,7 @@ direct
         assert [site.specie.symbol for site in poscar.structure] == ordered_expected_elements
 
     def test_as_from_dict(self):
-        poscar_string = """Test3
+        poscar_str = """Test3
 1.0
 3.840198 0.000000 0.000000
 1.920099 3.325710 0.000000
@@ -184,7 +184,7 @@ direct
 0.000000 0.000000 0.000000 T T T Si
 0.750000 0.500000 0.750000 F F F O
 """
-        poscar = Poscar.from_str(poscar_string)
+        poscar = Poscar.from_str(poscar_str)
         dct = poscar.as_dict()
         poscar2 = Poscar.from_dict(dct)
         assert poscar2.comment == "Test3"
@@ -192,7 +192,7 @@ direct
         assert not all(poscar2.selective_dynamics[1])
 
     def test_cart_scale(self):
-        poscar_string = """Test1
+        poscar_str = """Test1
 1.1
 3.840198 0.000000 0.000000
 1.920099 3.325710 0.000000
@@ -203,7 +203,7 @@ cart
 0.000000   0.00000000   0.00000000
 3.840198   1.50000000   2.35163175
 """
-        poscar = Poscar.from_str(poscar_string)
+        poscar = Poscar.from_str(poscar_str)
         site = poscar.structure[1]
         assert_allclose(site.coords, np.array([3.840198, 1.5, 2.35163175]) * 1.1)
 
@@ -261,7 +261,7 @@ direct
         assert str(poscar) == expected_str, "Wrong POSCAR output!"
 
         # VASP 4 type with symbols at the end.
-        poscar_string = """Test1
+        poscar_str = """Test1
 1.0
 -3.840198 0.000000 0.000000
 1.920099 3.325710 0.000000
@@ -283,7 +283,7 @@ direct
    0.0000000000000000    0.0000000000000000    0.0000000000000000 Si
    0.7500000000000000    0.5000000000000000    0.7500000000000000 F
 """
-        poscar = Poscar.from_str(poscar_string)
+        poscar = Poscar.from_str(poscar_str)
         assert str(poscar) == expected
 
     def test_from_md_run(self):

--- a/tests/io/vasp/test_outputs.py
+++ b/tests/io/vasp/test_outputs.py
@@ -1645,34 +1645,34 @@ class TestProcar(PymatgenTest):
         assert d2[Spin.up][2][2] == approx({"Na": 0.688, "Li": 0.042})
 
 
-class TestXdatcar(PymatgenTest):
+class TestXdatcar:
     def test_init(self):
         filepath = f"{VASP_OUT_DIR}/XDATCAR_4"
-        x = Xdatcar(filepath)
-        structures = x.structures
+        xdatcar = Xdatcar(filepath)
+        structures = xdatcar.structures
         assert len(structures) == 4
         for struct in structures:
             assert struct.formula == "Li2 O1"
 
         filepath = f"{VASP_OUT_DIR}/XDATCAR_5"
-        x = Xdatcar(filepath)
-        structures = x.structures
+        xdatcar = Xdatcar(filepath)
+        structures = xdatcar.structures
         assert len(structures) == 4
         for struct in structures:
             assert struct.formula == "Li2 O1"
 
-        x.concatenate(f"{VASP_OUT_DIR}/XDATCAR_4")
-        assert len(x.structures) == 8
-        assert x.get_str() is not None
+        xdatcar.concatenate(f"{VASP_OUT_DIR}/XDATCAR_4")
+        assert len(xdatcar.structures) == 8
+        assert xdatcar.get_str() is not None
 
         filepath = f"{VASP_OUT_DIR}/XDATCAR_6"
-        x = Xdatcar(filepath)
-        structures = x.structures
+        xdatcar = Xdatcar(filepath)
+        structures = xdatcar.structures
 
         assert structures[0].lattice != structures[-1].lattice
 
 
-class TestDynmat(PymatgenTest):
+class TestDynmat:
     def test_init(self):
         filepath = f"{VASP_OUT_DIR}/DYNMAT"
         dct = Dynmat(filepath)
@@ -1687,7 +1687,7 @@ class TestDynmat(PymatgenTest):
         # TODO: test get_phonon_frequencies once cross-checked
 
 
-class TestWavecar(PymatgenTest):
+class TestWavecar:
     def setUp(self):
         a = np.array(np.eye(3) * 10, dtype=float)  # lattice vectors
         self.vol = np.dot(a[0, :], np.cross(a[1, :], a[2, :]))  # unit cell volume

--- a/tests/io/vasp/test_outputs.py
+++ b/tests/io/vasp/test_outputs.py
@@ -1687,14 +1687,18 @@ class TestDynmat:
         # TODO: test get_phonon_frequencies once cross-checked
 
 
-class TestWavecar:
+class TestWavecar(PymatgenTest):
     def setUp(self):
-        a = np.array(np.eye(3) * 10, dtype=float)  # lattice vectors
-        self.vol = np.dot(a[0, :], np.cross(a[1, :], a[2, :]))  # unit cell volume
+        latt_mat = np.array(np.eye(3) * 10, dtype=float)  # lattice vectors
+        self.vol = np.dot(latt_mat[0, :], np.cross(latt_mat[1, :], latt_mat[2, :]))  # unit cell volume
         # reciprocal lattice vectors
-        b = np.array([np.cross(a[1, :], a[2, :]), np.cross(a[2, :], a[0, :]), np.cross(a[0, :], a[1, :])])
-        self.b = 2 * np.pi * b / self.vol
-        self.a = a
+        recip_latt_mat = [
+            np.cross(latt_mat[1, :], latt_mat[2, :]),
+            np.cross(latt_mat[2, :], latt_mat[0, :]),
+            np.cross(latt_mat[0, :], latt_mat[1, :]),
+        ]
+        self.recip_latt_mat = 2 * np.pi * np.array(recip_latt_mat) / self.vol
+        self.latt_mat = latt_mat
         self.wavecar = Wavecar(f"{VASP_OUT_DIR}/WAVECAR.N2")
         self.wH2 = Wavecar(f"{VASP_OUT_DIR}/WAVECAR.H2_low_symm")
         self.wH2_gamma = Wavecar(f"{VASP_OUT_DIR}/WAVECAR.H2_low_symm.gamma")
@@ -1758,8 +1762,8 @@ class TestWavecar:
         assert wavecar.encut == 25.0
         assert wavecar.nb == 9
         assert wavecar.nk == 1
-        assert_allclose(wavecar.a, self.a)
-        assert_allclose(wavecar.b, self.b)
+        assert_allclose(wavecar.a, self.latt_mat)
+        assert_allclose(wavecar.b, self.recip_latt_mat)
         assert wavecar.vol == approx(self.vol)
         assert len(wavecar.kpoints) == wavecar.nk
         assert len(wavecar.coeffs) == wavecar.nk

--- a/tests/symmetry/test_maggroups.py
+++ b/tests/symmetry/test_maggroups.py
@@ -169,7 +169,7 @@ x+1/2, y, z, -1
     def test_str(self):
         msg = MagneticSpaceGroup([4, 11])
 
-        ref_string = """BNS: 4.11 P_b2_1
+        ref_str = """BNS: 4.11 P_b2_1
 Operators: (1|0,0,0) (2y|0,1/2,0) (1|0,1/2,0)' (2y|0,0,0)'
 Wyckoff Positions:
 4e  (x,y,z;mx,my,mz) (-x,y+1/2,-z;-mx,my,-mz) (x,y+1/2,z;-mx,-my,-mz)
@@ -180,7 +180,7 @@ Wyckoff Positions:
 2a  (0,y,0;mx,0,mz) (0,y+1/2,0;-mx,0,-mz)
 Alternative OG setting exists for this space group."""
 
-        ref_string_all = """BNS: 4.11 P_b2_1		OG: 3.7.14 P_2b2'
+        ref_str_all = """BNS: 4.11 P_b2_1		OG: 3.7.14 P_2b2'
 OG-BNS Transform: (a,2b,c;0,0,0)
 Operators (BNS): (1|0,0,0) (2y|0,1/2,0) (1|0,1/2,0)' (2y|0,0,0)'
 Wyckoff Positions (BNS):
@@ -199,5 +199,5 @@ Wyckoff Positions (OG): (1,0,0)+ (0,2,0)+ (0,0,1)+
 2b  (0,y,1/2;mx,0,mz) (0,y+1,-1/2;-mx,0,-mz)
 2a  (0,y,0;mx,0,mz) (0,y+1,0;-mx,0,-mz)"""
 
-        self.assert_str_content_equal(str(msg), ref_string)
-        self.assert_str_content_equal(msg.data_str(), ref_string_all)
+        self.assert_str_content_equal(str(msg), ref_str)
+        self.assert_str_content_equal(msg.data_str(), ref_str_all)

--- a/tests/symmetry/test_settings.py
+++ b/tests/symmetry/test_settings.py
@@ -32,13 +32,13 @@ class TestJonesFaithfulTransformation(TestCase):
         ]
 
     def test_init(self):
-        for test_string, test_Pp in zip(self.test_strings, self.test_Pps):
-            jft = JonesFaithfulTransformation.from_transformation_str(test_string)
+        for test_str, test_Pp in zip(self.test_strings, self.test_Pps):
+            jft = JonesFaithfulTransformation.from_transformation_str(test_str)
             jft2 = JonesFaithfulTransformation(test_Pp[0], test_Pp[1])
             assert_allclose(jft.P, jft2.P)
             assert_allclose(jft.p, jft2.p)
-            assert test_string == jft.transformation_string
-            assert test_string == jft2.transformation_string
+            assert test_str == jft.transformation_string
+            assert test_str == jft2.transformation_string
 
     def test_inverse(self):
         for test_string in self.test_strings:


### PR DESCRIPTION
this ensures pymatgen is compatible with both the oldest and newest dependency versions it allows in `setup.py`

also fix `typing_extensions` `ImportError` reported in https://github.com/materialsproject/pymatgen/pull/3752#issuecomment-2142954988 by @kavanase @Andrew-S-Rosen
