### PR TITLE
Fix filter condition for warn msg of unphysical site occupancy in `io.cif`

### DIFF
--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -1073,7 +1073,7 @@ class CifParser:
 
         if any(occu > 1 for occu in _sum_occupancies):
             msg = (
-                f"Some occupancies ({filter(lambda x: x<=1, _sum_occupancies)}) sum to > 1! If they are within "
+                f"Some occupancies ({list(filter(lambda x: x>1, _sum_occupancies))}) sum to > 1! If they are within "
                 "the occupancy_tolerance, they will be rescaled. "
                 f"The current occupancy_tolerance is set to: {self._occupancy_tolerance}"
             )

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     python_requires=">=3.9",
     install_requires=[
         "matplotlib>=1.5",
-        "monty>=2024.2.2",
+        "monty>=2024.5.24",
         "networkx>=2.2",
         "numpy>=1.25.0",
         "palettable>=3.1.1",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     python_requires=">=3.9",
     install_requires=[
         "matplotlib>=1.5",
-        "monty>=2024.5.24",
+        "monty>=2024.2.2",
         "networkx>=2.2",
         "numpy>=1.25.0",
         "palettable>=3.1.1",

--- a/tests/io/test_cif.py
+++ b/tests/io/test_cif.py
@@ -748,7 +748,10 @@ loop_
             cif_str = cif_file.read()
         cif_str = cif_str.replace("Te    Te 1.0000", "Te_label    Te 10.0", 1)
 
-        structs = CifParser.from_str(cif_str).parse_structures(check_occu=False)
+        with pytest.warns(
+            UserWarning, match=r"Issues encountered while parsing CIF: Some occupancies \(\[10\.0\]\) sum to > 1!"
+        ):
+            structs = CifParser.from_str(cif_str).parse_structures(check_occu=False)
 
         assert len(structs) > 0
         assert set(structs[0].labels) == {"Te_label", "Ge"}


### PR DESCRIPTION
## Summary

- Fix a mistake in #3819, where the `filter` condition is incorrect, and also cast `filter` to `list`.
- Add unit test for this error message


