### PR TITLE
Add new `.pmgrc.yaml` setting `PMG_VASP_PSP_SUB_DIRS: dict[str, str]`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,7 @@ jobs:
         # maximize CI coverage of different platforms and python versions while minimizing the
         # total number of jobs. We run all pytest splits with the oldest supported python
         # version (currently 3.9) on windows (seems most likely to surface errors) and with
-        # newest version (currently 3.12) on ubuntu (to get complete coverage on unix). We
-        # ignore mac-os, which is assumed to be similar to ubuntu.
+        # newest version (currently 3.12) on ubuntu (to get complete coverage on unix).
         config:
           - os: windows-latest
             python: "3.9"
@@ -39,11 +38,10 @@ jobs:
             python: "3.12"
             resolution: lowest-direct
             extras: ci,optional
-          # test with lowest resolution and only required dependencies installed
           - os: macos-latest
             python: "3.10"
             resolution: lowest-direct
-            extras: ci
+            extras: ci # test with only required dependencies installed
 
         # pytest-split automatically distributes work load so parallel jobs finish in similar time
         split: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -2126,13 +2126,8 @@ class PotcarSingle:
                 if self.TITEL.replace(" ", "") == titel_no_spc:
                     for potcar_subvariant in self._potcar_summary_stats[func][titel_no_spc]:
                         if self.VRHFIN.replace(" ", "") == potcar_subvariant["VRHFIN"]:
-                            possible_potcar_matches.append(
-                                {
-                                    "POTCAR_FUNCTIONAL": func,
-                                    "TITEL": titel_no_spc,
-                                    **potcar_subvariant,
-                                }
-                            )
+                            possible_match = {"POTCAR_FUNCTIONAL": func, "TITEL": titel_no_spc, **potcar_subvariant}
+                            possible_potcar_matches.append(possible_match)
 
         def parse_fortran_style_str(input_str: str) -> str | bool | float | int:
             """Parse any input string as bool, int, float, or failing that, str.
@@ -2284,26 +2279,29 @@ class PotcarSingle:
         if functional is None:
             raise ValueError("Cannot get functional.")
 
-        funcdir = cls.functional_dir[functional]
+        functional_subdir = SETTINGS.get("PMG_VASP_PSP_SUB_DIRS", {}).get(functional, cls.functional_dir[functional])
         PMG_VASP_PSP_DIR = SETTINGS.get("PMG_VASP_PSP_DIR")
         if PMG_VASP_PSP_DIR is None:
             raise ValueError(
                 f"No POTCAR for {symbol} with {functional=} found. Please set the PMG_VASP_PSP_DIR in .pmgrc.yaml."
             )
+        if not os.path.isdir(PMG_VASP_PSP_DIR):
+            raise FileNotFoundError(f"{PMG_VASP_PSP_DIR=} does not exist.")
 
         paths_to_try: list[str] = [
-            os.path.join(PMG_VASP_PSP_DIR, funcdir, f"POTCAR.{symbol}"),
-            os.path.join(PMG_VASP_PSP_DIR, funcdir, symbol, "POTCAR"),
+            os.path.join(PMG_VASP_PSP_DIR, functional_subdir, f"POTCAR.{symbol}"),
+            os.path.join(PMG_VASP_PSP_DIR, functional_subdir, symbol, "POTCAR"),
         ]
+        path = paths_to_try[0]
         for path in paths_to_try:
             path = os.path.expanduser(path)
             path = zpath(path)
             if os.path.isfile(path):
                 return cls.from_file(path)
 
-        raise RuntimeError(
-            f"You do not have the right POTCAR with {functional=} and {symbol=} "
-            f"in your {PMG_VASP_PSP_DIR=}. Paths tried: {paths_to_try}"
+        raise FileNotFoundError(
+            f"You do not have the right POTCAR with {functional=} and {symbol=}\n"
+            f"in your {PMG_VASP_PSP_DIR=}.\nPaths tried:\n- " + "\n- ".join(paths_to_try)
         )
 
     def verify_potcar(self) -> tuple[bool, bool]:

--- a/tests/io/vasp/test_inputs.py
+++ b/tests/io/vasp/test_inputs.py
@@ -1183,13 +1183,14 @@ class TestPotcarSingle(TestCase):
             else:
                 assert psingle.is_valid
 
-    # def test_default_functional(self):
-    #     potcar = PotcarSingle.from_symbol_and_functional("Fe")
-    #     assert potcar.functional_class == "GGA"
-    #     SETTINGS["PMG_DEFAULT_FUNCTIONAL"] = "LDA"
-    #     potcar = PotcarSingle.from_symbol_and_functional("Fe")
-    #     assert potcar.functional_class == "LDA"
-    #     SETTINGS["PMG_DEFAULT_FUNCTIONAL"] = "PBE"
+    def test_default_functional(self):
+        with patch.dict(SETTINGS, PMG_DEFAULT_FUNCTIONAL="PBE"):
+            potcar = PotcarSingle.from_symbol_and_functional("Fe")
+            assert potcar.functional_class == "GGA"
+        with patch.dict(SETTINGS, PMG_DEFAULT_FUNCTIONAL="LDA"):
+            SETTINGS["PMG_DEFAULT_FUNCTIONAL"] = "LDA"
+            potcar = PotcarSingle.from_symbol_and_functional("Fe")
+            assert potcar.functional_class == "LDA"
 
     def test_from_symbol_and_functional_raises(self):
         # test FileNotFoundError on non-existent PMG_VASP_PSP_DIR in SETTINGS

--- a/tests/io/vasp/test_sets.py
+++ b/tests/io/vasp/test_sets.py
@@ -851,8 +851,8 @@ class TestMatPESStaticSet(PymatgenTest):
 
         assert input_set.potcar_functional == "PBE_64"  # test POTCARs default to PBE_64
         assert input_set.kpoints is None
-        # only runs if POTCAR files to compare against are available
-        if os.path.isdir(f"{FAKE_POTCAR_DIR}/POT_GGA_PAW_PBE_64"):
+        if os.path.isdir(f"{FAKE_POTCAR_DIR}/POT_PAW_PBE_64"):
+            # this part only runs if POTCAR files are available
             assert str(input_set.potcar[0]) == str(PotcarSingle.from_symbol_and_functional("Fe_pv", "PBE_64"))
 
     def test_with_prev_incar(self):
@@ -1980,12 +1980,13 @@ class TestLobsterSet(PymatgenTest):
     @skip_if_no_psp_dir
     def test_potcar(self):
         # PBE_54 is preferred at the moment
-        assert self.lobsterset1.user_potcar_functional == "PBE_54"
+        functional, symbol = "PBE_54", "K_sv"
+        assert self.lobsterset1.user_potcar_functional == functional
         # test if potcars selected are consistent with PBE_54
         assert self.lobsterset2.potcar.symbols == ["Fe_pv", "P", "O"]
         # test if error raised contains correct potcar symbol for K element as PBE_54 set
         with pytest.raises(
-            RuntimeError, match="You do not have the right POTCAR with functional='PBE_54' and symbol='K_sv'"
+            FileNotFoundError, match=f"You do not have the right POTCAR with {functional=} and {symbol=}"
         ):
             _ = self.lobsterset9.potcar.symbols
 


### PR DESCRIPTION
the current `PotcarSingle.functional_dir` hard-codes the subfolder structure of `PMG_VASP_PSP_DIR`. e.g. the subfolder containing the `PBE_64` POTCARs _must_ be named `POT_PAW_PBE_64`. this causes problems e.g. in cases where the POTCARs are shared across an HPC cluster and users don't have permissions to rename shared files (just happened to me).

https://github.com/materialsproject/pymatgen/blob/232fa1f842d1078dd69d8d1631b4dd19a9b35c2f/pymatgen/io/vasp/inputs.py#L1757-L1779

the new setting is read from `.pmgrc.yaml` and overrides the `PotcarSingle.functional_dir` names (leaving unspecified ones as is). example:

```yaml
# .pmgrc.yaml
PMG_VASP_PSP_DIR: /path/to/pseudo-potentials
PMG_VASP_PSP_SUB_DIRS:
  PBE_64: MY_PBE_64_DIR
  LDA_64: MY_LDA_64_DIR
```

this PR implement the new setting, adds tests for it and restores (uncomments) + fixes an existing `PotcarSingle` test
also improves `FileNotFoundError` messages on missing POTCARs