### PR TITLE
Replace hard coded class names, add types for `io.vasp.sets`

### DIFF
--- a/pymatgen/analysis/cost.py
+++ b/pymatgen/analysis/cost.py
@@ -75,10 +75,7 @@ class CostDB(abc.ABC):
 
 
 class CostDBCSV(CostDB):
-    """
-    Read a CSV file to get costs
-    Format is formula,cost_per_kg,name,BibTeX.
-    """
+    """Read a CSV file to get costs. Format is formula,cost_per_kg,name,BibTeX."""
 
     def __init__(self, filename):
         """

--- a/pymatgen/analysis/graphs.py
+++ b/pymatgen/analysis/graphs.py
@@ -206,7 +206,7 @@ class StructureGraph(MSONable):
         return cls(structure, graph_data=graph_data)
 
     @classmethod
-    @deprecated(from_empty_graph, deadline=(2025, 3, 20))
+    @deprecated(from_empty_graph, "Deprecated on 2024-03-29.", deadline=(2025, 3, 20))
     def with_empty_graph(cls, *args, **kwargs):
         return cls.from_empty_graph(*args, **kwargs)
 
@@ -265,7 +265,7 @@ class StructureGraph(MSONable):
         return struct_graph
 
     @classmethod
-    @deprecated(from_edges, deadline=(2025, 3, 20))
+    @deprecated(from_edges, "Deprecated on 2024-03-29.", deadline=(2025, 3, 20))
     def with_edges(cls, *args, **kwargs):
         return cls.from_edges(*args, **kwargs)
 
@@ -307,7 +307,7 @@ class StructureGraph(MSONable):
         return struct_graph
 
     @classmethod
-    @deprecated(from_local_env_strategy, deadline=(2025, 3, 20))
+    @deprecated(from_local_env_strategy, "Deprecated on 2024-03-29.", deadline=(2025, 3, 20))
     def with_local_env_strategy(cls, *args, **kwargs):
         return cls.from_local_env_strategy(*args, **kwargs)
 
@@ -1641,7 +1641,7 @@ class MoleculeGraph(MSONable):
         return cls(molecule, graph_data=graph_data)
 
     @classmethod
-    @deprecated(from_empty_graph, deadline=(2025, 3, 20))
+    @deprecated(from_empty_graph, "Deprecated on 2024-03-29.", deadline=(2025, 3, 20))
     def with_empty_graph(cls, *args, **kwargs):
         return cls.from_empty_graph(*args, **kwargs)
 
@@ -1690,7 +1690,7 @@ class MoleculeGraph(MSONable):
         return mg
 
     @classmethod
-    @deprecated(from_edges, deadline=(2025, 3, 20))
+    @deprecated(from_edges, "Deprecated on 2024-03-29.", deadline=(2025, 3, 20))
     def with_edges(cls, *args, **kwargs):
         return cls.from_edges(*args, **kwargs)
 
@@ -1762,7 +1762,7 @@ class MoleculeGraph(MSONable):
         return mg
 
     @classmethod
-    @deprecated(from_local_env_strategy, deadline=(2025, 3, 20))
+    @deprecated(from_local_env_strategy, "Deprecated on 2024-03-29.", deadline=(2025, 3, 20))
     def with_local_env_strategy(cls, *args, **kwargs):
         return cls.from_local_env_strategy(*args, **kwargs)
 

--- a/pymatgen/analysis/graphs.py
+++ b/pymatgen/analysis/graphs.py
@@ -205,10 +205,7 @@ class StructureGraph(MSONable):
         return cls(structure, graph_data=graph_data)
 
     @classmethod
-    @deprecated(
-        from_empty_graph,
-        "Deprecated on 2024-03-29, to be removed on 2025-03-20.",
-    )
+    @deprecated(from_empty_graph, "Deprecated on 2024-03-29.", deadline=(2025, 3, 20))
     def with_empty_graph(cls, *args, **kwargs):
         return cls.from_empty_graph(*args, **kwargs)
 
@@ -267,10 +264,7 @@ class StructureGraph(MSONable):
         return struct_graph
 
     @classmethod
-    @deprecated(
-        from_edges,
-        "Deprecated on 2024-03-29, to be removed on 2025-03-20.",
-    )
+    @deprecated(from_edges, "Deprecated on 2024-03-29.", deadline=(2025, 3, 20))
     def with_edges(cls, *args, **kwargs):
         return cls.from_edges(*args, **kwargs)
 
@@ -312,10 +306,7 @@ class StructureGraph(MSONable):
         return struct_graph
 
     @classmethod
-    @deprecated(
-        from_local_env_strategy,
-        "Deprecated on 2024-03-29, to be removed on 2025-03-20.",
-    )
+    @deprecated(from_local_env_strategy, "Deprecated on 2024-03-29.", deadline=(2025, 3, 20))
     def with_local_env_strategy(cls, *args, **kwargs):
         return cls.from_local_env_strategy(*args, **kwargs)
 
@@ -1649,10 +1640,7 @@ class MoleculeGraph(MSONable):
         return cls(molecule, graph_data=graph_data)
 
     @classmethod
-    @deprecated(
-        from_empty_graph,
-        "Deprecated on 2024-03-29, to be removed on 2025-03-20.",
-    )
+    @deprecated(from_empty_graph, "Deprecated on 2024-03-29.", deadline=(2025, 3, 20))
     def with_empty_graph(cls, *args, **kwargs):
         return cls.from_empty_graph(*args, **kwargs)
 
@@ -1701,10 +1689,7 @@ class MoleculeGraph(MSONable):
         return mg
 
     @classmethod
-    @deprecated(
-        from_edges,
-        "Deprecated on 2024-03-29, to be removed on 2025-03-20.",
-    )
+    @deprecated(from_edges, "Deprecated on 2024-03-29.", deadline=(2025, 3, 20))
     def with_edges(cls, *args, **kwargs):
         return cls.from_edges(*args, **kwargs)
 
@@ -1776,10 +1761,7 @@ class MoleculeGraph(MSONable):
         return mg
 
     @classmethod
-    @deprecated(
-        from_local_env_strategy,
-        "Deprecated on 2024-03-29, to be removed on 2025-03-20.",
-    )
+    @deprecated(from_local_env_strategy, "Deprecated on 2024-03-29.", deadline=(2025, 3, 20))
     def with_local_env_strategy(cls, *args, **kwargs):
         return cls.from_local_env_strategy(*args, **kwargs)
 

--- a/pymatgen/analysis/graphs.py
+++ b/pymatgen/analysis/graphs.py
@@ -206,7 +206,7 @@ class StructureGraph(MSONable):
         return cls(structure, graph_data=graph_data)
 
     @classmethod
-    @deprecated(from_empty_graph, "Deprecated on 2024-03-29.", deadline=(2025, 3, 20))
+    @deprecated(from_empty_graph, deadline=(2025, 3, 20))
     def with_empty_graph(cls, *args, **kwargs):
         return cls.from_empty_graph(*args, **kwargs)
 
@@ -265,7 +265,7 @@ class StructureGraph(MSONable):
         return struct_graph
 
     @classmethod
-    @deprecated(from_edges, "Deprecated on 2024-03-29.", deadline=(2025, 3, 20))
+    @deprecated(from_edges, deadline=(2025, 3, 20))
     def with_edges(cls, *args, **kwargs):
         return cls.from_edges(*args, **kwargs)
 
@@ -307,7 +307,7 @@ class StructureGraph(MSONable):
         return struct_graph
 
     @classmethod
-    @deprecated(from_local_env_strategy, "Deprecated on 2024-03-29.", deadline=(2025, 3, 20))
+    @deprecated(from_local_env_strategy, deadline=(2025, 3, 20))
     def with_local_env_strategy(cls, *args, **kwargs):
         return cls.from_local_env_strategy(*args, **kwargs)
 
@@ -1641,7 +1641,7 @@ class MoleculeGraph(MSONable):
         return cls(molecule, graph_data=graph_data)
 
     @classmethod
-    @deprecated(from_empty_graph, "Deprecated on 2024-03-29.", deadline=(2025, 3, 20))
+    @deprecated(from_empty_graph, deadline=(2025, 3, 20))
     def with_empty_graph(cls, *args, **kwargs):
         return cls.from_empty_graph(*args, **kwargs)
 
@@ -1690,7 +1690,7 @@ class MoleculeGraph(MSONable):
         return mg
 
     @classmethod
-    @deprecated(from_edges, "Deprecated on 2024-03-29.", deadline=(2025, 3, 20))
+    @deprecated(from_edges, deadline=(2025, 3, 20))
     def with_edges(cls, *args, **kwargs):
         return cls.from_edges(*args, **kwargs)
 
@@ -1762,7 +1762,7 @@ class MoleculeGraph(MSONable):
         return mg
 
     @classmethod
-    @deprecated(from_local_env_strategy, "Deprecated on 2024-03-29.", deadline=(2025, 3, 20))
+    @deprecated(from_local_env_strategy, deadline=(2025, 3, 20))
     def with_local_env_strategy(cls, *args, **kwargs):
         return cls.from_local_env_strategy(*args, **kwargs)
 

--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -3417,7 +3417,7 @@ class BrunnerNNReciprocal(NearNeighbors):
         return siw
 
 
-@deprecated(BrunnerNNReciprocal, deadline=(2025, 3, 29))
+@deprecated(BrunnerNNReciprocal, "Deprecated on 2024-03-29.", deadline=(2025, 3, 29))
 class BrunnerNN_reciprocal(BrunnerNNReciprocal):
     pass
 
@@ -3493,7 +3493,7 @@ class BrunnerNNRelative(NearNeighbors):
         return siw
 
 
-@deprecated(BrunnerNNRelative, deadline=(2025, 3, 29))
+@deprecated(BrunnerNNRelative, "Deprecated on 2024-03-29.", deadline=(2025, 3, 29))
 class BrunnerNN_relative(BrunnerNNRelative):
     pass
 
@@ -3569,7 +3569,7 @@ class BrunnerNNReal(NearNeighbors):
         return siw
 
 
-@deprecated(BrunnerNNReal, deadline=(2025, 3, 29))
+@deprecated(BrunnerNNReal, "Deprecated on 2024-03-29.", deadline=(2025, 3, 29))
 class BrunnerNN_real(BrunnerNNReal):
     pass
 

--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -3416,10 +3416,7 @@ class BrunnerNNReciprocal(NearNeighbors):
         return siw
 
 
-@deprecated(
-    BrunnerNNReciprocal,
-    "Deprecated on 2024-03-29, to be removed on 2025-03-29.",
-)
+@deprecated(BrunnerNNReciprocal, "Deprecated on 2024-03-29.", deadline=(2025, 3, 29))
 class BrunnerNN_reciprocal(BrunnerNNReciprocal):
     pass
 
@@ -3495,10 +3492,7 @@ class BrunnerNNRelative(NearNeighbors):
         return siw
 
 
-@deprecated(
-    BrunnerNNRelative,
-    "Deprecated on 2024-03-29, to be removed on 2025-03-29.",
-)
+@deprecated(BrunnerNNRelative, "Deprecated on 2024-03-29.", deadline=(2025, 3, 29))
 class BrunnerNN_relative(BrunnerNNRelative):
     pass
 
@@ -3574,10 +3568,7 @@ class BrunnerNNReal(NearNeighbors):
         return siw
 
 
-@deprecated(
-    BrunnerNNReal,
-    "Deprecated on 2024-03-29, to be removed on 2025-03-29.",
-)
+@deprecated(BrunnerNNReal, "Deprecated on 2024-03-29.", deadline=(2025, 3, 29))
 class BrunnerNN_real(BrunnerNNReal):
     pass
 

--- a/pymatgen/analysis/local_env.py
+++ b/pymatgen/analysis/local_env.py
@@ -3417,7 +3417,7 @@ class BrunnerNNReciprocal(NearNeighbors):
         return siw
 
 
-@deprecated(BrunnerNNReciprocal, "Deprecated on 2024-03-29.", deadline=(2025, 3, 29))
+@deprecated(BrunnerNNReciprocal, deadline=(2025, 3, 29))
 class BrunnerNN_reciprocal(BrunnerNNReciprocal):
     pass
 
@@ -3493,7 +3493,7 @@ class BrunnerNNRelative(NearNeighbors):
         return siw
 
 
-@deprecated(BrunnerNNRelative, "Deprecated on 2024-03-29.", deadline=(2025, 3, 29))
+@deprecated(BrunnerNNRelative, deadline=(2025, 3, 29))
 class BrunnerNN_relative(BrunnerNNRelative):
     pass
 
@@ -3569,7 +3569,7 @@ class BrunnerNNReal(NearNeighbors):
         return siw
 
 
-@deprecated(BrunnerNNReal, "Deprecated on 2024-03-29.", deadline=(2025, 3, 29))
+@deprecated(BrunnerNNReal, deadline=(2025, 3, 29))
 class BrunnerNN_real(BrunnerNNReal):
     pass
 

--- a/pymatgen/analysis/quasiharmonic.py
+++ b/pymatgen/analysis/quasiharmonic.py
@@ -357,6 +357,6 @@ class QuasiHarmonicDebyeApprox:
         return dct
 
 
-@deprecated(replacement=QuasiHarmonicDebyeApprox, message="Deprecated on 2024-03-27.", deadline=(2025, 3, 27))
+@deprecated(QuasiHarmonicDebyeApprox, message="Deprecated on 2024-03-27.", deadline=(2025, 3, 27))
 class QuasiharmonicDebyeApprox(QuasiHarmonicDebyeApprox):
     pass

--- a/pymatgen/analysis/quasiharmonic.py
+++ b/pymatgen/analysis/quasiharmonic.py
@@ -357,6 +357,6 @@ class QuasiHarmonicDebyeApprox:
         return dct
 
 
-@deprecated(QuasiHarmonicDebyeApprox, deadline=(2025, 3, 27))
+@deprecated(QuasiHarmonicDebyeApprox, message="Deprecated on 2024-03-27.", deadline=(2025, 3, 27))
 class QuasiharmonicDebyeApprox(QuasiHarmonicDebyeApprox):
     pass

--- a/pymatgen/analysis/quasiharmonic.py
+++ b/pymatgen/analysis/quasiharmonic.py
@@ -357,6 +357,6 @@ class QuasiHarmonicDebyeApprox:
         return dct
 
 
-@deprecated(QuasiHarmonicDebyeApprox, message="Deprecated on 2024-03-27.", deadline=(2025, 3, 27))
+@deprecated(QuasiHarmonicDebyeApprox, deadline=(2025, 3, 27))
 class QuasiharmonicDebyeApprox(QuasiHarmonicDebyeApprox):
     pass

--- a/pymatgen/analysis/quasiharmonic.py
+++ b/pymatgen/analysis/quasiharmonic.py
@@ -357,9 +357,6 @@ class QuasiHarmonicDebyeApprox:
         return dct
 
 
-@deprecated(
-    replacement=QuasiHarmonicDebyeApprox,
-    message="Deprecated on 2024-03-27, to be removed on 2025-03-27.",
-)
+@deprecated(replacement=QuasiHarmonicDebyeApprox, message="Deprecated on 2024-03-27.", deadline=(2025, 3, 27))
 class QuasiharmonicDebyeApprox(QuasiHarmonicDebyeApprox):
     pass

--- a/pymatgen/analysis/structure_prediction/substitution_probability.py
+++ b/pymatgen/analysis/structure_prediction/substitution_probability.py
@@ -1,6 +1,5 @@
 """
-This module provides classes for representing species substitution
-probabilities.
+This module provides classes for representing species substitution probabilities.
 """
 
 from __future__ import annotations

--- a/pymatgen/command_line/bader_caller.py
+++ b/pymatgen/command_line/bader_caller.py
@@ -233,9 +233,7 @@ class BaderAnalysis:
         return data
 
     @deprecated(
-        message="parse_atomic_densities was deprecated on 2024-02-26."
-        "\nSee https://"
-        "github.com/materialsproject/pymatgen/issues/3652 for details.",
+        message="See issue #3652 for details.",
         deadline=(2025, 2, 26),
     )
     def _parse_atomic_densities(self) -> list[dict]:

--- a/pymatgen/command_line/bader_caller.py
+++ b/pymatgen/command_line/bader_caller.py
@@ -233,9 +233,10 @@ class BaderAnalysis:
         return data
 
     @deprecated(
-        message="parse_atomic_densities was deprecated on 2024-02-26 "
-        "and will be removed on 2025-02-26.\nSee https://"
-        "github.com/materialsproject/pymatgen/issues/3652 for details."
+        message="parse_atomic_densities was deprecated on 2024-02-26."
+        "\nSee https://"
+        "github.com/materialsproject/pymatgen/issues/3652 for details.",
+        deadline=(2025, 2, 26),
     )
     def _parse_atomic_densities(self) -> list[dict]:
         """Parse atom-centered charge densities with excess zeros removed.

--- a/pymatgen/core/composition.py
+++ b/pymatgen/core/composition.py
@@ -317,7 +317,7 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
 
     def copy(self) -> Self:
         """A copy of the composition."""
-        return Composition(self, allow_negative=self.allow_negative)
+        return type(self)(self, allow_negative=self.allow_negative)
 
     @property
     def formula(self) -> str:
@@ -338,7 +338,7 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
 
     @property
     def iupac_formula(self) -> str:
-        """A formula string, with elements sorted by the iupac
+        """A formula string, with elements sorted by the IUPAC
         electronegativity ordering defined in Table VI of "Nomenclature of
         Inorganic Chemistry (IUPAC Recommendations 2005)". This ordering
         effectively follows the groups and rows of the periodic table, except
@@ -354,7 +354,7 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
     @property
     def element_composition(self) -> Self:
         """The composition replacing any species by the corresponding element."""
-        return Composition(self.get_el_amt_dict(), allow_negative=self.allow_negative)
+        return type(self)(self.get_el_amt_dict(), allow_negative=self.allow_negative)
 
     @property
     def fractional_composition(self) -> Self:

--- a/pymatgen/core/composition.py
+++ b/pymatgen/core/composition.py
@@ -25,7 +25,7 @@ from pymatgen.util.string import Stringify, formula_double_format
 
 if TYPE_CHECKING:
     from collections.abc import Generator, Iterator
-    from typing import ClassVar
+    from typing import Any, ClassVar
 
     from typing_extensions import Self
 
@@ -125,20 +125,20 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
         self.allow_negative = kwargs.pop("allow_negative", False)
         # it's much faster to recognize a composition and use the el_map than
         # to pass the composition to {}
-        if len(args) == 1 and isinstance(args[0], Composition):
+        if len(args) == 1 and isinstance(args[0], type(self)):
             elem_map = args[0]
         elif len(args) == 1 and isinstance(args[0], str):
             elem_map = self._parse_formula(args[0])  # type: ignore[assignment]
         elif len(args) == 1 and isinstance(args[0], float) and isnan(args[0]):
             raise ValueError("float('NaN') is not a valid Composition, did you mean 'NaN'?")
         else:
-            elem_map = dict(*args, **kwargs)  # type: ignore
+            elem_map = dict(*args, **kwargs)  # type: ignore[assignment]
         elem_amt = {}
         self._n_atoms = 0
         for key, val in elem_map.items():
-            if val < -Composition.amount_tolerance and not self.allow_negative:
+            if val < -type(self).amount_tolerance and not self.allow_negative:
                 raise ValueError("Amounts in Composition cannot be negative!")
-            if abs(val) >= Composition.amount_tolerance:
+            if abs(val) >= type(self).amount_tolerance:
                 elem_amt[get_el_sp(key)] = val
                 self._n_atoms += abs(val)
         self._data = elem_amt
@@ -263,6 +263,21 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
         """Hash based on the chemical system."""
         return hash(frozenset(self._data))
 
+    def __repr__(self) -> str:
+        formula = " ".join(f"{key}{':' if hasattr(key, 'oxi_state') else ''}{val:g}" for key, val in self.items())
+        cls_name = type(self).__name__
+        return f"{cls_name}({formula!r})"
+
+    def __str__(self) -> str:
+        return " ".join(f"{key}{formula_double_format(val, ignore_ones=False)}" for key, val in self.as_dict().items())
+
+    def to_pretty_string(self) -> str:
+        """
+        Returns:
+            str: Same output as __str__() but without spaces.
+        """
+        return re.sub(r"\s+", "", str(self))
+
     @property
     def average_electroneg(self) -> float:
         """Average electronegativity of the composition."""
@@ -302,7 +317,7 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
 
     def copy(self) -> Self:
         """A copy of the composition."""
-        return Composition(self, allow_negative=self.allow_negative)
+        return type(self)(self, allow_negative=self.allow_negative)
 
     @property
     def formula(self) -> str:
@@ -339,7 +354,7 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
     @property
     def element_composition(self) -> Self:
         """The composition replacing any species by the corresponding element."""
-        return Composition(self.get_el_amt_dict(), allow_negative=self.allow_negative)
+        return type(self)(self.get_el_amt_dict(), allow_negative=self.allow_negative)
 
     @property
     def fractional_composition(self) -> Self:
@@ -462,16 +477,6 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
         """List of elements in Composition."""
         return list(self)
 
-    def __str__(self) -> str:
-        return " ".join(f"{key}{formula_double_format(val, ignore_ones=False)}" for key, val in self.as_dict().items())
-
-    def to_pretty_string(self) -> str:
-        """
-        Returns:
-            str: Same output as __str__() but without spaces.
-        """
-        return re.sub(r"\s+", "", str(self))
-
     @property
     def num_atoms(self) -> float:
         """Total number of atoms in Composition. For negative amounts, sum
@@ -543,12 +548,13 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
             In the case of Metallofullerene formula (e.g. Y3N@C80),
             the @ mark will be dropped and passed to parser.
         """
-        # throw if formula contains special characters or only spaces and/or numbers
+        # Raise error if formula contains special characters or only spaces and/or numbers
         if strict and re.match(r"[\s\d.*/]*$", formula):
             raise ValueError(f"Invalid {formula=}")
-        # for Metallofullerene like "Y3N@C80"
+
+        # For Metallofullerene like "Y3N@C80"
         formula = formula.replace("@", "")
-        # square brackets are used in formulas to denote coordination complexes (gh-3583)
+        # Square brackets are used in formulas to denote coordination complexes (gh-3583)
         formula = formula.replace("[", "(")
         formula = formula.replace("]", ")")
 
@@ -614,11 +620,6 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
         False if the Composition contains any dummy species.
         """
         return not any(isinstance(el, DummySpecies) for el in self.elements)
-
-    def __repr__(self) -> str:
-        formula = " ".join(f"{key}{':' if hasattr(key, 'oxi_state') else ''}{val:g}" for key, val in self.items())
-        cls_name = type(self).__name__
-        return f"{cls_name}({formula!r})"
 
     @classmethod
     def from_dict(cls, dct: dict) -> Self:
@@ -692,7 +693,7 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
         return {str(el): self.get_wt_fraction(el) for el in self.elements}
 
     @property
-    def to_data_dict(self) -> dict:
+    def to_data_dict(self) -> dict[str, Any]:
         """
         Returns:
             A dict with many keys and values relating to Composition/Formula,
@@ -794,7 +795,7 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
         Returns:
             Composition: New object with elements remapped according to elem_map.
         """
-        # drop inapplicable substitutions
+        # Drop inapplicable substitutions
         invalid_elems = [key for key in elem_map if key not in self]
         if invalid_elems:
             warnings.warn(
@@ -804,13 +805,13 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
         for elem in invalid_elems:
             elem_map.pop(elem)
 
-        # start with elements that remain unchanged (not in elem_map)
+        # Start with elements that remain unchanged (not in elem_map)
         new_comp = {elem: amount for elem, amount in self.as_dict().items() if elem not in elem_map}
 
         for old_elem, new_elem in elem_map.items():
             amount = self[old_elem]
 
-            # build a dictionary of substitutions to be made
+            # Build a dictionary of substitutions to be made
             subs = {}
             if isinstance(new_elem, dict):
                 for el, factor in new_elem.items():
@@ -818,14 +819,14 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
             else:
                 subs = {new_elem: amount}
 
-            # and apply the substitutions to the new composition
+            # Apply the substitutions to the new composition
             for el, amt in subs.items():
                 if el in new_comp:
                     new_comp[el] += amt
                 else:
                     new_comp[el] = amt
 
-                # check for ambiguous input (see issue #2553)
+                # Check for ambiguous input (see issue #2553)
                 if el in self:
                     warnings.warn(
                         f"Same element ({el}) in both the keys and values of the substitution!"
@@ -934,7 +935,7 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
                 If the composition is not charge balanced, an empty list is returned.
         """
         comp = self.copy()
-        # reduce Composition if necessary
+        # Reduce Composition if necessary
         if max_sites and max_sites < 0:
             comp = self.reduced_composition
 
@@ -950,15 +951,15 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
                 raise ValueError(f"Composition {comp} cannot accommodate max_sites setting!")
 
         # Load prior probabilities of oxidation states, used to rank solutions
-        if not Composition.oxi_prob:
+        if not type(self).oxi_prob:
             all_data = loadfn(f"{module_dir}/../analysis/icsd_bv.yaml")
             type(self).oxi_prob = {Species.from_str(sp): data for sp, data in all_data["occurrence"].items()}
         oxi_states_override = oxi_states_override or {}
-        # assert: Composition only has integer amounts
+        # Assert Composition only has integer amounts
         if not all(amt == int(amt) for amt in comp.values()):
             raise ValueError("Charge balance analysis requires integer values in Composition!")
 
-        # for each element, determine all possible sum of oxidations
+        # For each element, determine all possible sum of oxidations
         # (taking into account nsites for that particular element)
         el_amt = comp.get_el_amt_dict()
         elements = list(el_amt)
@@ -976,7 +977,7 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
             else:
                 oxids = Element(el).icsd_oxidation_states or Element(el).oxidation_states
 
-            # get all possible combinations of oxidation states
+            # Get all possible combinations of oxidation states
             # and sum each combination
             for oxid_combo in combinations_with_replacement(oxids, int(el_amt[el])):
                 # List this sum as a possible option
@@ -988,7 +989,7 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
                 score = sum(type(self).oxi_prob.get(Species(el, o), 0) for o in oxid_combo)  # type: ignore[union-attr]
 
                 # If it is the most probable combo for a certain sum,
-                #   store the combination
+                # store the combination
                 if oxid_sum not in el_sum_scores[idx] or score > el_sum_scores[idx].get(oxid_sum, 0):
                     el_sum_scores[idx][oxid_sum] = score
                     el_best_oxid_combo[idx][oxid_sum] = oxid_combo
@@ -999,24 +1000,24 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
         all_oxid_combo = []  # will contain the best combination of oxidation states for each site
         all_scores = []  # will contain a score for each solution
         for x in product(*el_sums):
-            # each x is a trial of one possible oxidation sum for each element
+            # Each x is a trial of one possible oxidation sum for each element
             if sum(x) == target_charge:  # charge balance condition
                 el_sum_sol = dict(zip(elements, x))  # element->oxid_sum
-                # normalize oxid_sum by amount to get avg oxid state
+                # Normalize oxid_sum by amount to get avg oxid state
                 sol = {el: v / el_amt[el] for el, v in el_sum_sol.items()}
-                # add the solution to the list of solutions
+                # Add the solution to the list of solutions
                 all_sols.append(sol)
 
-                # determine the score for this solution
+                # Determine the score for this solution
                 score = 0
                 for idx, v in enumerate(x):
                     score += el_sum_scores[idx][v]
                 all_scores.append(score)
 
-                # collect the combination of oxidation states for each site
+                # Collect the combination of oxidation states for each site
                 all_oxid_combo.append({e: el_best_oxid_combo[idx][v] for idx, (e, v) in enumerate(zip(elements, x))})
 
-        # sort the solutions from highest to lowest score
+        # Sort the solutions from highest to lowest score
         if all_scores:
             all_sols, all_oxid_combo = zip(
                 *(

--- a/pymatgen/core/composition.py
+++ b/pymatgen/core/composition.py
@@ -317,7 +317,7 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
 
     def copy(self) -> Self:
         """A copy of the composition."""
-        return type(self)(self, allow_negative=self.allow_negative)
+        return Composition(self, allow_negative=self.allow_negative)
 
     @property
     def formula(self) -> str:
@@ -354,7 +354,7 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
     @property
     def element_composition(self) -> Self:
         """The composition replacing any species by the corresponding element."""
-        return type(self)(self.get_el_amt_dict(), allow_negative=self.allow_negative)
+        return Composition(self.get_el_amt_dict(), allow_negative=self.allow_negative)
 
     @property
     def fractional_composition(self) -> Self:

--- a/pymatgen/core/ion.py
+++ b/pymatgen/core/ion.py
@@ -22,11 +22,11 @@ class Ion(Composition, MSONable, Stringify):
     Mn[+2]. Note the order of the sign and magnitude in each representation.
     """
 
-    def __init__(self, composition: Composition, charge: float = 0.0) -> None:
+    def __init__(self, composition: Composition, charge: float = 0.0, **kwargs) -> None:
         """Flexible Ion construction, similar to Composition.
         For more information, please see pymatgen.core.Composition.
         """
-        super().__init__(composition)
+        super().__init__(composition, **kwargs)
         self._charge = charge
 
     def __eq__(self, other: object) -> bool:

--- a/pymatgen/core/ion.py
+++ b/pymatgen/core/ion.py
@@ -30,7 +30,7 @@ class Ion(Composition, MSONable, Stringify):
         self._charge = charge
 
     def __eq__(self, other: object) -> bool:
-        if not isinstance(other, Ion):
+        if not isinstance(other, type(self)):
             return NotImplemented
         if self.composition != other.composition:
             return False
@@ -164,7 +164,7 @@ class Ion(Composition, MSONable, Stringify):
         comp = self.composition
         nH2O = 0
         if hydrates:
-            # detect hydrated metal complexes
+            # Detect hydrated metal complexes
             nH = comp.get("H", 0)
             nO = comp.get("O", 0)
             if nO > 0 and any(e.is_metal for e in comp):

--- a/pymatgen/core/ion.py
+++ b/pymatgen/core/ion.py
@@ -279,7 +279,7 @@ class Ion(Composition, MSONable, Stringify):
         all_oxi_states: bool = False,
         max_sites: int | None = None,
     ) -> list[dict[str, float]]:
-        """Check if the composition is charge-balanced and returns back all
+        """Check if the composition is charge-balanced and returns all
         charge-balanced oxidation state combinations. Composition must have
         integer values. Note that more num_atoms in the composition gives
         more degrees of freedom. e.g. if possible oxidation states of

--- a/pymatgen/core/lattice.py
+++ b/pymatgen/core/lattice.py
@@ -620,7 +620,7 @@ class Lattice(MSONable):
 
         return selling_vector
 
-    def selling_dist(self, other: Lattice) -> float:
+    def selling_dist(self, other: Self) -> float:
         """Get the minimum Selling distance between two lattices."""
         vcp_matrices = [
             [
@@ -904,7 +904,7 @@ class Lattice(MSONable):
 
     def find_all_mappings(
         self,
-        other_lattice: Lattice,
+        other_lattice: Self,
         ltol: float = 1e-5,
         atol: float = 1,
         skip_rotation_matrix: bool = False,
@@ -969,11 +969,11 @@ class Lattice(MSONable):
 
                 rotation_m = None if skip_rotation_matrix else np.linalg.solve(aligned_m, other_lattice.matrix)
 
-                yield Lattice(aligned_m), rotation_m, scale_m
+                yield type(self)(aligned_m), rotation_m, scale_m
 
     def find_mapping(
         self,
-        other_lattice: Lattice,
+        other_lattice: Self,
         ltol: float = 1e-5,
         atol: float = 1,
         skip_rotation_matrix: bool = False,
@@ -1042,7 +1042,7 @@ class Lattice(MSONable):
 
         b = np.zeros((3, 3))  # Vectors after the Gram-Schmidt process
         u = np.zeros((3, 3))  # Gram-Schmidt coefficients
-        m = np.zeros(3)  # These are the norm squared of each vec.
+        m = np.zeros(3)  # These are the norm squared of each vec
 
         b[:, 0] = a[:, 0]
         m[0] = np.dot(b[:, 0], b[:, 0])
@@ -1055,23 +1055,23 @@ class Lattice(MSONable):
 
         mapping = np.identity(3, dtype=np.double)
         while k <= 3:
-            # Size reduction.
+            # Size reduction
             for i in range(k - 1, 0, -1):
                 q = round(u[k - 1, i - 1])
                 if q != 0:
-                    # Reduce the k-th basis vector.
+                    # Reduce the k-th basis vector
                     a[:, k - 1] = a[:, k - 1] - q * a[:, i - 1]
                     mapping[:, k - 1] = mapping[:, k - 1] - q * mapping[:, i - 1]
                     uu = list(u[i - 1, 0 : (i - 1)])
                     uu.append(1)
-                    # Update the GS coefficients.
+                    # Update the GS coefficients
                     u[k - 1, 0:i] = u[k - 1, 0:i] - q * np.array(uu)
 
-            # Check the Lovasz condition.
+            # Check the Lovasz condition
             if np.dot(b[:, k - 1], b[:, k - 1]) >= (delta - abs(u[k - 1, k - 2]) ** 2) * np.dot(
                 b[:, (k - 2)], b[:, (k - 2)]
             ):
-                # Increment k if the Lovasz condition holds.
+                # Increment k if the Lovasz condition holds
                 k += 1
             else:
                 # If the Lovasz condition fails, swap the k-th and (k-1)-th basis vector
@@ -1092,11 +1092,11 @@ class Lattice(MSONable):
                 if k > 2:
                     k -= 1
                 else:
-                    # We have to do p/q, so do lstsq(q.T, p.T).T instead.
+                    # We have to do p/q, so do lstsq(q.T, p.T).T instead
                     p = np.dot(a[:, k:3].T, b[:, (k - 2) : k])
-                    q = np.diag(m[(k - 2) : k])  # type: ignore
+                    q = np.diag(m[(k - 2) : k])
 
-                    result = np.linalg.lstsq(q.T, p.T, rcond=None)[0].T  # type: ignore
+                    result = np.linalg.lstsq(q.T, p.T, rcond=None)[0].T
                     u[k:3, (k - 2) : k] = result
 
         return a.T, mapping.T
@@ -1885,7 +1885,7 @@ def get_points_in_spheres(
     return neighbors
 
 
-# The following internal methods are used in the get_points_in_sphere method
+# The following internal functions are used in the get_points_in_sphere method
 def _compute_cube_index(
     coords: np.ndarray,
     global_min: float,

--- a/pymatgen/core/operations.py
+++ b/pymatgen/core/operations.py
@@ -59,7 +59,7 @@ class SymmOp(MSONable):
         self.tol = tol
 
     def __eq__(self, other: object) -> bool:
-        if not isinstance(other, SymmOp):
+        if not isinstance(other, type(self)):
             return NotImplemented
         return np.allclose(self.affine_matrix, other.affine_matrix, atol=self.tol)
 

--- a/pymatgen/core/periodic_table.py
+++ b/pymatgen/core/periodic_table.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import ast
 import functools
 import json
+import operator
 import re
 import warnings
 from collections import Counter
@@ -461,8 +462,6 @@ class ElementBase(Enum):
         if self.is_noble_gas:
             return [["1S0"]]
 
-        L_symbols = "SPDFGHIKLMNOQRTUVWXYZ"
-
         L, v_e = self.valence
 
         # for one electron in subshell L
@@ -483,6 +482,7 @@ class ElementBase(Enum):
         comb_counter = Counter(zip(TL, TS))
 
         term_symbols = []
+        L_symbols = "SPDFGHIKLMNOQRTUVWXYZ"
         while sum(comb_counter.values()) > 0:
             # Start from the lowest freq combination,
             # which corresponds to largest abs(L) and smallest abs(S)
@@ -508,13 +508,13 @@ class ElementBase(Enum):
         L_symbols = "SPDFGHIKLMNOQRTUVWXYZ"
 
         term_symbols = self.term_symbols
-        term_symbol_flat = {
+        term_symbol_flat = {  # type: ignore[var-annotated]
             term: {
                 "multiplicity": int(term[0]),
                 "L": L_symbols.index(term[1]),
                 "J": float(term[2:]),
             }
-            for term in sum(term_symbols, [])  # noqa: RUF017
+            for term in functools.reduce(operator.iadd, term_symbols, [])
         }
 
         multi = [int(item["multiplicity"]) for _terms, item in term_symbol_flat.items()]
@@ -729,27 +729,27 @@ class ElementBase(Enum):
     @property
     def is_metalloid(self) -> bool:
         """True if element is a metalloid."""
-        return self.symbol in ("B", "Si", "Ge", "As", "Sb", "Te", "Po")
+        return self.symbol in {"B", "Si", "Ge", "As", "Sb", "Te", "Po"}
 
     @property
     def is_alkali(self) -> bool:
         """True if element is an alkali metal."""
-        return self.Z in (3, 11, 19, 37, 55, 87)
+        return self.Z in {3, 11, 19, 37, 55, 87}
 
     @property
     def is_alkaline(self) -> bool:
         """True if element is an alkaline earth metal (group II)."""
-        return self.Z in (4, 12, 20, 38, 56, 88)
+        return self.Z in {4, 12, 20, 38, 56, 88}
 
     @property
     def is_halogen(self) -> bool:
         """True if element is a halogen."""
-        return self.Z in (9, 17, 35, 53, 85)
+        return self.Z in {9, 17, 35, 53, 85}
 
     @property
     def is_chalcogen(self) -> bool:
         """True if element is a chalcogen."""
-        return self.Z in (8, 16, 34, 52, 84)
+        return self.Z in {8, 16, 34, 52, 84}
 
     @property
     def is_lanthanoid(self) -> bool:
@@ -764,7 +764,7 @@ class ElementBase(Enum):
     @property
     def is_radioactive(self) -> bool:
         """True if element is radioactive."""
-        return self.Z in (43, 61) or self.Z >= 84
+        return self.Z in {43, 61} or self.Z >= 84
 
     @property
     def is_quadrupolar(self) -> bool:
@@ -1443,7 +1443,7 @@ class DummySpecies(Species):
             return cls(sym, oxi, **properties)
         raise ValueError("Invalid DummySpecies String")
 
-    def as_dict(self) -> dict:
+    def as_dict(self) -> dict[str, Any]:
         """MSONable dict representation."""
         return {
             "@module": type(self).__module__,

--- a/pymatgen/core/periodic_table.py
+++ b/pymatgen/core/periodic_table.py
@@ -697,22 +697,20 @@ class ElementBase(Enum):
         return self.symbol in ("Al", "Ga", "In", "Tl", "Sn", "Pb", "Bi")
 
     @property
-    @deprecated(
-        message="Please use is_rare_earth instead, which is corrected to include Y and Sc.", deadline=(2025, 1, 1)
-    )
+    def is_rare_earth(self) -> bool:
+        """True if element is a rare earth element, including Lanthanides (La)
+        series, Actinides (Ac) series, Scandium (Sc) and Yttrium (Y).
+        """
+        return self.is_lanthanoid or self.is_actinoid or self.symbol in {"Sc", "Y"}
+
+    @property
+    @deprecated(is_rare_earth, message="is_rare_earth is corrected to include Y and Sc.", deadline=(2025, 1, 1))
     def is_rare_earth_metal(self) -> bool:
         """True if element is a rare earth metal, Lanthanides (La) series and Actinides (Ac) series.
 
         This property is Deprecated, and scheduled for removal after 2025-01-01.
         """
         return self.is_lanthanoid or self.is_actinoid
-
-    @property
-    def is_rare_earth(self) -> bool:
-        """True if element is a rare earth element, including Lanthanides (La)
-        series, Actinides (Ac) series, Scandium (Sc) and Yttrium (Y).
-        """
-        return self.is_lanthanoid or self.is_actinoid or self.symbol in {"Sc", "Y"}
 
     @property
     def is_metal(self) -> bool:

--- a/pymatgen/core/periodic_table.py
+++ b/pymatgen/core/periodic_table.py
@@ -176,8 +176,8 @@ class ElementBase(Enum):
             "ionization_energies",
             "metallic_radius",
         }:
-            kstr = item.capitalize().replace("_", " ")
-            val = self._data.get(kstr)
+            key = item.capitalize().replace("_", " ")
+            val = self._data.get(key)
             if val is None or str(val).startswith("no data"):
                 warnings.warn(f"No data available for {item} for {self.symbol}")
                 val = None

--- a/pymatgen/core/sites.py
+++ b/pymatgen/core/sites.py
@@ -119,7 +119,7 @@ class Site(collections.abc.Hashable, MSONable):
 
         return f"Site: {name} ({self.coords[0]:.4f}, {self.coords[1]:.4f}, {self.coords[2]:.4f})"
 
-    def __lt__(self, other: Site) -> bool:
+    def __lt__(self, other: Self) -> bool:
         """Set a default sort order for atomic species by electronegativity. Very
         useful for getting correct formulas. For example, FeO4PLi is
         automatically sorted in LiFePO4.
@@ -249,6 +249,7 @@ class Site(collections.abc.Hashable, MSONable):
             del spec_dct["@class"]
             spec_dct["occu"] = occu
             species.append(spec_dct)
+
         dct = {
             "name": self.species_string,
             "species": species,
@@ -256,11 +257,10 @@ class Site(collections.abc.Hashable, MSONable):
             "properties": self.properties,
             "@module": type(self).__module__,
             "@class": type(self).__name__,
+            "label": self.label,
         }
         if self.properties:
             dct["properties"] = self.properties
-
-        dct["label"] = self.label
 
         return dct
 
@@ -473,7 +473,7 @@ class PeriodicSite(Site, MSONable):
         self.coords[2] = z
         self._frac_coords = self._lattice.get_fractional_coords(self.coords)
 
-    def to_unit_cell(self, in_place: bool = False) -> PeriodicSite | None:
+    def to_unit_cell(self, in_place: bool = False) -> Self | None:
         """Move frac coords to within the unit cell."""
         frac_coords = [np.mod(f, 1) if p else f for p, f in zip(self.lattice.pbc, self.frac_coords)]
         if in_place:
@@ -483,7 +483,7 @@ class PeriodicSite(Site, MSONable):
 
     def is_periodic_image(
         self,
-        other: PeriodicSite,
+        other: Self,
         tolerance: float = 1e-8,
         check_lattice: bool = True,
     ) -> bool:
@@ -534,7 +534,7 @@ class PeriodicSite(Site, MSONable):
 
     def distance_and_image(
         self,
-        other: PeriodicSite,
+        other: Self,
         jimage: ArrayLike | None = None,
     ) -> tuple[float, np.ndarray]:
         """Get distance and instance between two sites assuming periodic boundary
@@ -559,7 +559,7 @@ class PeriodicSite(Site, MSONable):
 
     def distance(
         self,
-        other: PeriodicSite,
+        other: Self,
         jimage: ArrayLike | None = None,
     ) -> float:
         """Get distance between two sites assuming periodic boundary conditions.
@@ -597,13 +597,12 @@ class PeriodicSite(Site, MSONable):
             "lattice": self._lattice.as_dict(verbosity=verbosity),
             "@module": type(self).__module__,
             "@class": type(self).__name__,
+            "properties": self.properties,
+            "label": self.label,
         }
 
         if verbosity > 0:
             dct["xyz"] = [float(c) for c in self.coords]
-
-        dct["properties"] = self.properties
-        dct["label"] = self.label
 
         return dct
 

--- a/pymatgen/core/spectrum.py
+++ b/pymatgen/core/spectrum.py
@@ -79,7 +79,7 @@ class Spectrum(MSONable):
     def __len__(self) -> int:
         return self.ydim[0]
 
-    def __add__(self, other: Spectrum) -> Self:
+    def __add__(self, other: Self) -> Self:
         """Add two Spectrum object together. Checks that x scales are the same.
         Otherwise, a ValueError is thrown.
 
@@ -94,7 +94,7 @@ class Spectrum(MSONable):
 
         return type(self)(self.x, self.y + other.y, *self._args, **self._kwargs)
 
-    def __sub__(self, other: Spectrum) -> Self:
+    def __sub__(self, other: Self) -> Self:
         """Subtract one Spectrum object from another. Checks that x scales are
         the same.
         Otherwise, a ValueError is thrown.
@@ -110,7 +110,7 @@ class Spectrum(MSONable):
 
         return type(self)(self.x, self.y - other.y, *self._args, **self._kwargs)
 
-    def __mul__(self, other: Spectrum) -> Self:
+    def __mul__(self, other: Self) -> Self:
         """Scale the Spectrum's y values.
 
         Args:
@@ -123,7 +123,7 @@ class Spectrum(MSONable):
 
     __rmul__ = __mul__
 
-    def __truediv__(self, other: Spectrum) -> Self:
+    def __truediv__(self, other: Self) -> Self:
         """True division of y.
 
         Args:
@@ -134,7 +134,7 @@ class Spectrum(MSONable):
         """
         return type(self)(self.x, self.y.__truediv__(other), *self._args, **self._kwargs)
 
-    def __floordiv__(self, other: Spectrum) -> Self:
+    def __floordiv__(self, other: Self) -> Self:
         """True division of y.
 
         Args:

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -284,15 +284,15 @@ class SiteCollection(collections.abc.Sequence, ABC):
         return [site.species for site in self]
 
     @property
-    @deprecated(message="Use n_elems instead")
-    def ntypesp(self) -> int:
-        """Number of types of atoms."""
-        return self.n_elems
-
-    @property
     def n_elems(self) -> int:
         """Number of types of atoms."""
         return len(self.types_of_species)
+
+    @property
+    @deprecated(n_elems, deadline=(2025, 6, 7))
+    def ntypesp(self) -> int:
+        """Number of types of atoms."""
+        return self.n_elems
 
     @property
     def types_of_species(self) -> tuple[Element | Species | DummySpecies, ...]:

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -284,10 +284,10 @@ class SiteCollection(collections.abc.Sequence, ABC):
         return [site.species for site in self]
 
     @property
-    @deprecated(message="Use n_type_sp instead")  # DEBUG: no such property
+    @deprecated(message="Use n_elems instead")
     def ntypesp(self) -> int:
         """Number of types of atoms."""
-        return len(self.types_of_species)
+        return self.n_elems
 
     @property
     def n_elems(self) -> int:

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -2206,7 +2206,7 @@ class IStructure(SiteCollection, MSONable):
         inner = r - dr
         return [t for t in outer if t.nn_distance > inner]
 
-    def get_sorted_structure(self, key: Callable | None = None, reverse: bool = False) -> IStructure | Structure:
+    def get_sorted_structure(self, key: Callable | None = None, reverse: bool = False) -> Self | Structure:
         """Get a sorted copy of the structure. The parameters have the same
         meaning as in list.sort. By default, sites are sorted by the
         electronegativity of the species.
@@ -2315,7 +2315,7 @@ class IStructure(SiteCollection, MSONable):
 
     def interpolate(
         self,
-        end_structure: IStructure | Structure,
+        end_structure: Self | Structure,
         nimages: int | Iterable = 10,
         interpolate_lattices: bool = False,
         pbc: bool = True,
@@ -2929,7 +2929,7 @@ class IStructure(SiteCollection, MSONable):
         sort: bool = False,
         merge_tol: float = 0.0,
         **kwargs,
-    ) -> Structure | IStructure:
+    ) -> Structure | Self:
         """Read a structure from a string.
 
         Args:
@@ -3012,7 +3012,7 @@ class IStructure(SiteCollection, MSONable):
         sort: bool = False,
         merge_tol: float = 0.0,
         **kwargs,
-    ) -> Structure | IStructure:
+    ) -> Structure | Self:
         """Read a structure from a file. For example, anything ending in
         a "cif" is assumed to be a Crystallographic Information Format file.
         Supported formats include CIF, POSCAR/CONTCAR, CHGCAR, LOCPOT,
@@ -3111,7 +3111,7 @@ class IStructure(SiteCollection, MSONable):
         """
         from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 
-        valid_cell_types = get_args(IStructure.CellType)
+        valid_cell_types = get_args(type(self).CellType)
         if cell_type not in valid_cell_types:
             raise ValueError(f"Invalid {cell_type=}, valid values are {valid_cell_types}")
 
@@ -3236,7 +3236,7 @@ class IMolecule(SiteCollection, MSONable):
         if not all(hasattr(other, attr) for attr in needed_attrs):
             return NotImplemented
 
-        other = cast(IMolecule, other)  # TODO @DanielYang59: fix type
+        other = cast((IMolecule | Molecule), other)
 
         if len(self) != len(other):
             return False
@@ -4628,37 +4628,33 @@ class Structure(IStructure, collections.abc.MutableSequence):
         prototype = prototype.lower()
         try:
             if prototype == "fcc":
-                return Structure.from_spacegroup("Fm-3m", Lattice.cubic(kwargs["a"]), species, [[0, 0, 0]])
+                return cls.from_spacegroup("Fm-3m", Lattice.cubic(kwargs["a"]), species, [[0, 0, 0]])
             if prototype == "bcc":
-                return Structure.from_spacegroup("Im-3m", Lattice.cubic(kwargs["a"]), species, [[0, 0, 0]])
+                return cls.from_spacegroup("Im-3m", Lattice.cubic(kwargs["a"]), species, [[0, 0, 0]])
             if prototype == "hcp":
-                return Structure.from_spacegroup(
+                return cls.from_spacegroup(
                     "P6_3/mmc", Lattice.hexagonal(kwargs["a"], kwargs["c"]), species, [[1 / 3, 2 / 3, 1 / 4]]
                 )
             if prototype == "diamond":
-                return Structure.from_spacegroup("Fd-3m", Lattice.cubic(kwargs["a"]), species, [[0, 0, 0]])
+                return cls.from_spacegroup("Fd-3m", Lattice.cubic(kwargs["a"]), species, [[0, 0, 0]])
             if prototype == "rocksalt":
-                return Structure.from_spacegroup(
-                    "Fm-3m", Lattice.cubic(kwargs["a"]), species, [[0, 0, 0], [0.5, 0.5, 0]]
-                )
+                return cls.from_spacegroup("Fm-3m", Lattice.cubic(kwargs["a"]), species, [[0, 0, 0], [0.5, 0.5, 0]])
             if prototype == "perovskite":
-                return Structure.from_spacegroup(
+                return cls.from_spacegroup(
                     "Pm-3m", Lattice.cubic(kwargs["a"]), species, [[0, 0, 0], [0.5, 0.5, 0.5], [0.5, 0.5, 0]]
                 )
             if prototype == "cscl":
-                return Structure.from_spacegroup(
-                    "Pm-3m", Lattice.cubic(kwargs["a"]), species, [[0, 0, 0], [0.5, 0.5, 0.5]]
-                )
+                return cls.from_spacegroup("Pm-3m", Lattice.cubic(kwargs["a"]), species, [[0, 0, 0], [0.5, 0.5, 0.5]])
             if prototype in {"fluorite", "caf2"}:
-                return Structure.from_spacegroup(
+                return cls.from_spacegroup(
                     "Fm-3m", Lattice.cubic(kwargs["a"]), species, [[0, 0, 0], [1 / 4, 1 / 4, 1 / 4]]
                 )
             if prototype == "antifluorite":
-                return Structure.from_spacegroup(
+                return cls.from_spacegroup(
                     "Fm-3m", Lattice.cubic(kwargs["a"]), species, [[1 / 4, 1 / 4, 1 / 4], [0, 0, 0]]
                 )
             if prototype == "zincblende":
-                return Structure.from_spacegroup(
+                return cls.from_spacegroup(
                     "F-43m", Lattice.cubic(kwargs["a"]), species, [[0, 0, 0], [1 / 4, 1 / 4, 3 / 4]]
                 )
 
@@ -4801,7 +4797,11 @@ class Molecule(IMolecule, collections.abc.MutableSequence):
             properties=properties,
         )
 
-    def set_charge_and_spin(self, charge: float, spin_multiplicity: int | None = None) -> Self:
+    def set_charge_and_spin(
+        self,
+        charge: float,
+        spin_multiplicity: int | None = None,
+    ) -> Self:
         """Set the charge and spin multiplicity.
 
         Args:
@@ -4896,7 +4896,11 @@ class Molecule(IMolecule, collections.abc.MutableSequence):
         self.sites = [self[idx] for idx in range(len(self)) if idx not in indices]
         return self
 
-    def translate_sites(self, indices: Sequence[int] | None = None, vector: ArrayLike | None = None) -> Self:
+    def translate_sites(
+        self,
+        indices: Sequence[int] | None = None,
+        vector: ArrayLike | None = None,
+    ) -> Self:
         """Translate specific sites by some vector, keeping the sites within the
         unit cell.
 
@@ -5004,7 +5008,7 @@ class Molecule(IMolecule, collections.abc.MutableSequence):
     def substitute(
         self,
         index: int,
-        func_group: IMolecule | Molecule | str,
+        func_group: IMolecule | Self | str,
         bond_order: int = 1,
     ) -> Self:
         """Substitute atom at index with a functional group.
@@ -5052,7 +5056,7 @@ class Molecule(IMolecule, collections.abc.MutableSequence):
 
         # Pass value of functional group--either from user-defined or from
         # functional.json
-        if isinstance(func_group, Molecule):
+        if isinstance(func_group, type(self)):
             functional_group = func_group
         else:
             # Check whether the functional group is in database.
@@ -5106,7 +5110,7 @@ class Molecule(IMolecule, collections.abc.MutableSequence):
         opt_kwargs: dict | None = None,
         return_trajectory: bool = False,
         verbose: bool = False,
-    ) -> Molecule | tuple[Molecule, TrajectoryObserver]:
+    ) -> Self | tuple[Self, TrajectoryObserver]:
         """Perform a molecule relaxation using an ASE calculator.
 
         Args:
@@ -5136,7 +5140,11 @@ class Molecule(IMolecule, collections.abc.MutableSequence):
             verbose=verbose,
         )
 
-    def calculate(self, calculator: Literal["gfn2-xtb"] | Calculator = "gfn2-xtb", verbose: bool = False) -> Calculator:
+    def calculate(
+        self,
+        calculator: Literal["gfn2-xtb"] | Calculator = "gfn2-xtb",
+        verbose: bool = False,
+    ) -> Calculator:
         """Perform an ASE calculation.
 
         Args:

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -3248,7 +3248,7 @@ class IMolecule(SiteCollection, MSONable):
         if not all(hasattr(other, attr) for attr in needed_attrs):
             return NotImplemented
 
-        other = cast((IMolecule | Molecule), other)
+        other = cast(Union[IMolecule, Molecule], other)
 
         if len(self) != len(other):
             return False

--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -284,7 +284,7 @@ class SiteCollection(collections.abc.Sequence, ABC):
         return [site.species for site in self]
 
     @property
-    @deprecated(message="Use n_type_sp instead")
+    @deprecated(message="Use n_type_sp instead")  # DEBUG: no such property
     def ntypesp(self) -> int:
         """Number of types of atoms."""
         return len(self.types_of_species)

--- a/pymatgen/core/surface.py
+++ b/pymatgen/core/surface.py
@@ -229,7 +229,7 @@ class Slab(Structure):
         sites = [PeriodicSite.from_dict(sd, lattice) for sd in dct["sites"]]
         struct = Structure.from_sites(sites)
 
-        return Slab(
+        return cls(
             lattice=lattice,
             species=struct.species_and_occu,
             coords=struct.frac_coords,
@@ -269,7 +269,7 @@ class Slab(Structure):
         if site_properties:
             props.update(site_properties)
 
-        return Slab(
+        return type(self)(
             self.lattice,
             self.species_and_occu,
             self.frac_coords,
@@ -443,7 +443,7 @@ class Slab(Structure):
 
         return site_other
 
-    def get_orthogonal_c_slab(self) -> Slab:
+    def get_orthogonal_c_slab(self) -> Self:
         """Generate a Slab where the normal (c lattice vector) is
         forced to be orthogonal to the surface a and b lattice vectors.
 
@@ -460,7 +460,7 @@ class Slab(Structure):
         new_c = np.dot(c, _new_c) * _new_c
         new_latt = Lattice([a, b, new_c])
 
-        return Slab(
+        return type(self)(
             lattice=new_latt,
             species=self.species_and_occu,
             coords=self.cart_coords,
@@ -478,7 +478,7 @@ class Slab(Structure):
         self,
         tol: float = 0.01,
         same_species_only: bool = True,
-    ) -> list[Slab]:
+    ) -> list[Self]:
         """Get a list of slabs that have been Tasker 2 corrected.
 
         Args:
@@ -559,7 +559,7 @@ class Slab(Structure):
                 sp_fcoord = sorted(zip(species, frac_coords), key=lambda x: x[0])
                 species = [x[0] for x in sp_fcoord]
                 frac_coords = [x[1] for x in sp_fcoord]
-                slab = Slab(
+                slab = type(self)(
                     self.lattice,
                     species,
                     frac_coords,
@@ -574,7 +574,7 @@ class Slab(Structure):
         struct_matcher = StructureMatcher()
         return [ss[0] for ss in struct_matcher.group_structures(slabs)]
 
-    def get_sorted_structure(self, key=None, reverse: bool = False) -> Slab:
+    def get_sorted_structure(self, key=None, reverse: bool = False) -> Self:
         """Get a sorted copy of the structure. The parameters have the same
         meaning as in list.sort. By default, sites are sorted by the
         electronegativity of the species. Note that Slab has to override this
@@ -589,7 +589,7 @@ class Slab(Structure):
         """
         sites = sorted(self, key=key, reverse=reverse)
         struct = Structure.from_sites(sites)
-        return Slab(
+        return type(self)(
             struct.lattice,
             struct.species_and_occu,
             struct.frac_coords,

--- a/pymatgen/core/tensors.py
+++ b/pymatgen/core/tensors.py
@@ -1129,6 +1129,5 @@ class TensorMapping(collections.abc.MutableMapping):
         indices = np.where(mask)[0]
         if len(indices) > 1:
             raise ValueError("Tensor key collision.")
-        if len(indices) == 0:
-            return None
-        return indices[0]
+
+        return None if len(indices) == 0 else indices[0]

--- a/pymatgen/core/trajectory.py
+++ b/pymatgen/core/trajectory.py
@@ -331,7 +331,7 @@ class Trajectory(MSONable):
         self.coords = displacements
         self.coords_are_displacement = True
 
-    def extend(self, trajectory: Trajectory) -> None:
+    def extend(self, trajectory: Self) -> None:
         """Append a trajectory to the current one.
 
         The lattice, coords, and all other properties are combined.

--- a/pymatgen/core/units.py
+++ b/pymatgen/core/units.py
@@ -34,7 +34,7 @@ __maintainer__ = "Shyue Ping Ong, Matteo Giantomassi"
 __status__ = "Production"
 __date__ = "Aug 30, 2013"
 
-"""Some conversion factors"""
+# Some conversion factors
 Ha_to_eV = 1 / const.physical_constants["electron volt-hartree relationship"][0]
 eV_to_Ha = 1 / Ha_to_eV
 Ry_to_eV = Ha_to_eV / 2
@@ -46,11 +46,9 @@ ang_to_bohr = 1 / bohr_to_ang
 kCal_to_kJ = const.calorie
 kb = const.physical_constants["Boltzmann constant in eV/K"][0]
 
-"""
-Definitions of supported units. Values below are essentially scaling and
-conversion factors. What matters is the relative values, not the absolute.
-The SI units must have factor 1.
-"""
+# Definitions of supported units. Values below are essentially scaling and
+# conversion factors. What matters is the relative values, not the absolute.
+# The SI units must have factor 1.
 BASE_UNITS: dict[str, dict] = {
     "length": {
         "m": 1,

--- a/pymatgen/electronic_structure/cohp.py
+++ b/pymatgen/electronic_structure/cohp.py
@@ -1104,10 +1104,10 @@ class IcohpCollection(MSONable):
             )
 
     def __str__(self) -> str:
-        joinstr = []
+        lst = []
         for value in self._icohplist.values():
-            joinstr.append(str(value))
-        return "\n".join(joinstr)
+            lst.append(str(value))
+        return "\n".join(lst)
 
     def get_icohp_by_label(self, label, summed_spin_channels=True, spin=Spin.up, orbitals=None) -> float:
         """Get an icohp value for a certain bond as indicated by the label (bond labels starting by "1" as in

--- a/pymatgen/io/abinit/__init__.py
+++ b/pymatgen/io/abinit/__init__.py
@@ -29,5 +29,4 @@ from .pseudos import (
     RadialFunction,
     l2str,
     str2l,
-    straceback,
 )

--- a/pymatgen/io/abinit/netcdf.py
+++ b/pymatgen/io/abinit/netcdf.py
@@ -273,30 +273,31 @@ class EtsfReader(NetcdfReader):
         Return AbinitHeader
         """
         dct = {}
-        for hvar in _HDR_VARIABLES.values():
-            ncname = hvar.etsf_name if hvar.etsf_name is not None else hvar.name
-            if ncname in self.rootgrp.variables:
-                dct[hvar.name] = self.read_value(ncname)
-            elif ncname in self.rootgrp.dimensions:
-                dct[hvar.name] = self.read_dimvalue(ncname)
+        for hdr_var in _HDR_VARIABLES.values():
+            nc_name = hdr_var.etsf_name if hdr_var.etsf_name is not None else hdr_var.name
+            if nc_name in self.rootgrp.variables:
+                dct[hdr_var.name] = self.read_value(nc_name)
+            elif nc_name in self.rootgrp.dimensions:
+                dct[hdr_var.name] = self.read_dimvalue(nc_name)
             else:
-                raise ValueError(f"Cannot find `{ncname}` in `{self.path}`")
+                raise ValueError(f"Cannot find `{nc_name}` in `{self.path}`")
             # Convert scalars to (well) scalars.
-            if hasattr(dct[hvar.name], "shape") and not dct[hvar.name].shape:
-                dct[hvar.name] = np.asarray(dct[hvar.name]).item()
-            if hvar.name in ("title", "md5_pseudos", "codvsn"):
+            if hasattr(dct[hdr_var.name], "shape") and not dct[hdr_var.name].shape:
+                dct[hdr_var.name] = np.asarray(dct[hdr_var.name]).item()
+            if hdr_var.name in ("title", "md5_pseudos", "codvsn"):
                 # Convert array of numpy bytes to list of strings
-                if hvar.name == "codvsn":
-                    dct[hvar.name] = "".join(bs.decode("utf-8").strip() for bs in dct[hvar.name])
+                if hdr_var.name == "codvsn":
+                    dct[hdr_var.name] = "".join(bs.decode("utf-8").strip() for bs in dct[hdr_var.name])
                 else:
-                    dct[hvar.name] = ["".join(bs.decode("utf-8") for bs in astr).strip() for astr in dct[hvar.name]]
+                    dct[hdr_var.name] = [
+                        "".join(bs.decode("utf-8") for bs in astr).strip() for astr in dct[hdr_var.name]
+                    ]
 
         return AbinitHeader(dct)
 
 
 def structure_from_ncdata(ncdata, site_properties=None, cls=Structure):
-    """
-    Reads and returns a pymatgen structure from a NetCDF file
+    """Read and return a pymatgen structure from a NetCDF file
     containing crystallographic data in the ETSF-IO format.
 
     Args:

--- a/pymatgen/io/abinit/pseudos.py
+++ b/pymatgen/io/abinit/pseudos.py
@@ -52,17 +52,8 @@ __maintainer__ = "Matteo Giantomassi"
 # Tools and helper functions.
 
 
-def straceback():
-    """Get a string with the traceback."""
-
-    return "\n".join((traceback.format_exc(), str(sys.exc_info()[0])))
-
-
 def _read_nlines(filename: str, n_lines: int) -> list[str]:
-    """
-    Read at most nlines lines from file filename.
-    If nlines is < 0, the entire file is read.
-    """
+    """Read at most nlines from filename. If nlines is < 0, the entire file is read."""
     if n_lines < 0:
         with open(filename, encoding="utf-8") as file:
             return file.readlines()
@@ -1155,7 +1146,9 @@ class PseudoParser:
         try:
             header = parsers[ppdesc.name](path, ppdesc)
         except Exception:
-            raise self.Error(f"{path}:\n{straceback()}")
+            str_traceback = "\n".join((traceback.format_exc(), str(sys.exc_info()[0])))
+
+            raise self.Error(f"{path}:\n{str_traceback}")
 
         if psp_type == "NC":
             pseudo = NcAbinitPseudo(path, header)

--- a/pymatgen/io/cif.py
+++ b/pymatgen/io/cif.py
@@ -1223,25 +1223,6 @@ class CifParser:
             return struct
         return None
 
-    @deprecated(
-        message="get_structures is deprecated and will be removed in 2024. Use parse_structures instead."
-        "The only difference is that primitive defaults to False in the new parse_structures method."
-        "So parse_structures(primitive=True) is equivalent to the old behavior of get_structures().",
-    )
-    def get_structures(self, *args, **kwargs) -> list[Structure]:
-        """
-        Deprecated, use parse_structures instead. Only difference between
-        these two methods is the default primitive=False in parse_structures.
-        So parse_structures(primitive=True) is equivalent to the default
-        behaviour of get_structures().
-        """
-        # Extract primitive if passed as arg
-        if len(args) > 0:
-            kwargs["primitive"] = args[0]
-            args = args[1:]
-        kwargs.setdefault("primitive", True)
-        return self.parse_structures(*args, **kwargs)
-
     def parse_structures(
         self,
         primitive: bool | None = None,
@@ -1308,6 +1289,25 @@ class CifParser:
         if not structures:
             raise ValueError("Invalid CIF file with no structures!")
         return structures
+
+    @deprecated(
+        parse_structures,
+        message="The only difference is that primitive defaults to False in the new parse_structures method."
+        "So parse_structures(primitive=True) is equivalent to the old behavior of get_structures().",
+    )
+    def get_structures(self, *args, **kwargs) -> list[Structure]:
+        """
+        Deprecated, use parse_structures instead. Only difference between
+        these two methods is the default primitive=False in parse_structures.
+        So parse_structures(primitive=True) is equivalent to the default
+        behaviour of get_structures().
+        """
+        # Extract primitive if passed as arg
+        if len(args) > 0:
+            kwargs["primitive"] = args[0]
+            args = args[1:]
+        kwargs.setdefault("primitive", True)
+        return self.parse_structures(*args, **kwargs)
 
     def get_bibtex_string(self) -> str:
         """Get BibTeX reference from CIF file.

--- a/pymatgen/io/cp2k/inputs.py
+++ b/pymatgen/io/cp2k/inputs.py
@@ -1590,7 +1590,7 @@ class VHartreeCube(Section):
         )
 
 
-@deprecated(VHartreeCube, "Deprecated on 2024-03-29, to be removed on 2025-03-29.")
+@deprecated(VHartreeCube, "Deprecated on 2024-03-29.", deadline=(2025, 3, 29))
 class V_Hartree_Cube(VHartreeCube):
     pass
 
@@ -1634,7 +1634,7 @@ class MOCubes(Section):
         )
 
 
-@deprecated(MOCubes, "Deprecated on 2024-03-29, to be removed on 2025-03-29.")
+@deprecated(MOCubes, "Deprecated on 2024-03-29.", deadline=(2025, 3, 29))
 class MO_Cubes(MOCubes):
     pass
 
@@ -1659,7 +1659,7 @@ class EDensityCube(Section):
         )
 
 
-@deprecated(EDensityCube, "Deprecated on 2024-03-29, to be removed on 2025-03-29.")
+@deprecated(EDensityCube, "Deprecated on 2024-03-29.", deadline=(2025, 3, 29))
 class E_Density_Cube(EDensityCube):
     pass
 
@@ -1858,7 +1858,7 @@ class XCFunctional(Section):
         )
 
 
-@deprecated(XCFunctional, "Deprecated on 2024-03-29, to be removed on 2025-03-29.")
+@deprecated(XCFunctional, "Deprecated on 2024-03-29.", deadline=(2025, 3, 29))
 class Xc_Functional(XCFunctional):
     pass
 
@@ -2089,7 +2089,7 @@ class KpointSet(Section):
         )
 
 
-@deprecated(KpointSet, "Kpoint_Set has been deprecated in favor of KpointSet on 2024-03-16")
+@deprecated(KpointSet, "Kpoint_Set has been deprecated in favor of KpointSet on 2024-03-16", deadline=(2025, 3, 16))
 class Kpoint_Set(KpointSet):
     pass
 
@@ -2173,7 +2173,7 @@ class BandStructure(Section):
         return cls(kpoint_sets=kpoint_sets, filename="BAND.bs")
 
 
-@deprecated(BandStructure, "Deprecated on 2024-03-29, to be removed on 2025-03-29.")
+@deprecated(BandStructure, "Deprecated on 2024-03-29.", deadline=(2025, 3, 29))
 class Band_Structure(BandStructure):
     pass
 

--- a/pymatgen/io/cp2k/inputs.py
+++ b/pymatgen/io/cp2k/inputs.py
@@ -2089,7 +2089,7 @@ class KpointSet(Section):
         )
 
 
-@deprecated(KpointSet, "Kpoint_Set has been deprecated in favor of KpointSet on 2024-03-16", deadline=(2025, 3, 16))
+@deprecated(KpointSet, "Kpoint_Set has been deprecated on 2024-03-16", deadline=(2025, 3, 16))
 class Kpoint_Set(KpointSet):
     pass
 

--- a/pymatgen/io/cp2k/inputs.py
+++ b/pymatgen/io/cp2k/inputs.py
@@ -1590,7 +1590,7 @@ class VHartreeCube(Section):
         )
 
 
-@deprecated(VHartreeCube, deadline=(2025, 3, 29))
+@deprecated(VHartreeCube, "Deprecated on 2024-03-29.", deadline=(2025, 3, 29))
 class V_Hartree_Cube(VHartreeCube):
     pass
 
@@ -1634,7 +1634,7 @@ class MOCubes(Section):
         )
 
 
-@deprecated(MOCubes, deadline=(2025, 3, 29))
+@deprecated(MOCubes, "Deprecated on 2024-03-29.", deadline=(2025, 3, 29))
 class MO_Cubes(MOCubes):
     pass
 
@@ -1659,7 +1659,7 @@ class EDensityCube(Section):
         )
 
 
-@deprecated(EDensityCube, deadline=(2025, 3, 29))
+@deprecated(EDensityCube, "Deprecated on 2024-03-29.", deadline=(2025, 3, 29))
 class E_Density_Cube(EDensityCube):
     pass
 
@@ -1858,7 +1858,7 @@ class XCFunctional(Section):
         )
 
 
-@deprecated(XCFunctional, deadline=(2025, 3, 29))
+@deprecated(XCFunctional, "Deprecated on 2024-03-29.", deadline=(2025, 3, 29))
 class Xc_Functional(XCFunctional):
     pass
 
@@ -2089,7 +2089,7 @@ class KpointSet(Section):
         )
 
 
-@deprecated(KpointSet, deadline=(2025, 3, 16))
+@deprecated(KpointSet, "Kpoint_Set has been deprecated on 2024-03-16", deadline=(2025, 3, 16))
 class Kpoint_Set(KpointSet):
     pass
 
@@ -2173,7 +2173,7 @@ class BandStructure(Section):
         return cls(kpoint_sets=kpoint_sets, filename="BAND.bs")
 
 
-@deprecated(BandStructure, deadline=(2025, 3, 29))
+@deprecated(BandStructure, "Deprecated on 2024-03-29.", deadline=(2025, 3, 29))
 class Band_Structure(BandStructure):
     pass
 

--- a/pymatgen/io/cp2k/inputs.py
+++ b/pymatgen/io/cp2k/inputs.py
@@ -1590,7 +1590,7 @@ class VHartreeCube(Section):
         )
 
 
-@deprecated(VHartreeCube, "Deprecated on 2024-03-29.", deadline=(2025, 3, 29))
+@deprecated(VHartreeCube, deadline=(2025, 3, 29))
 class V_Hartree_Cube(VHartreeCube):
     pass
 
@@ -1634,7 +1634,7 @@ class MOCubes(Section):
         )
 
 
-@deprecated(MOCubes, "Deprecated on 2024-03-29.", deadline=(2025, 3, 29))
+@deprecated(MOCubes, deadline=(2025, 3, 29))
 class MO_Cubes(MOCubes):
     pass
 
@@ -1659,7 +1659,7 @@ class EDensityCube(Section):
         )
 
 
-@deprecated(EDensityCube, "Deprecated on 2024-03-29.", deadline=(2025, 3, 29))
+@deprecated(EDensityCube, deadline=(2025, 3, 29))
 class E_Density_Cube(EDensityCube):
     pass
 
@@ -1858,7 +1858,7 @@ class XCFunctional(Section):
         )
 
 
-@deprecated(XCFunctional, "Deprecated on 2024-03-29.", deadline=(2025, 3, 29))
+@deprecated(XCFunctional, deadline=(2025, 3, 29))
 class Xc_Functional(XCFunctional):
     pass
 
@@ -2089,7 +2089,7 @@ class KpointSet(Section):
         )
 
 
-@deprecated(KpointSet, "Kpoint_Set has been deprecated on 2024-03-16", deadline=(2025, 3, 16))
+@deprecated(KpointSet, deadline=(2025, 3, 16))
 class Kpoint_Set(KpointSet):
     pass
 
@@ -2173,7 +2173,7 @@ class BandStructure(Section):
         return cls(kpoint_sets=kpoint_sets, filename="BAND.bs")
 
 
-@deprecated(BandStructure, "Deprecated on 2024-03-29.", deadline=(2025, 3, 29))
+@deprecated(BandStructure, deadline=(2025, 3, 29))
 class Band_Structure(BandStructure):
     pass
 

--- a/pymatgen/io/cp2k/outputs.py
+++ b/pymatgen/io/cp2k/outputs.py
@@ -1,7 +1,6 @@
 """
-This module defines the Cp2k output parser along with a few other functions for parsing cp2k-related
-outputs.
-
+This module defines the CP2K output parser along with a few other functions
+for parsing CP2K-related outputs.
 """
 
 from __future__ import annotations

--- a/pymatgen/io/lammps/inputs.py
+++ b/pymatgen/io/lammps/inputs.py
@@ -963,7 +963,7 @@ class LammpsTemplateGen(TemplateInputGen):
         return input_set
 
 
-@deprecated(LammpsTemplateGen)
+@deprecated(LammpsTemplateGen, "This function will be removed in the future.")
 def write_lammps_inputs(
     output_dir: str,
     script_template: str,

--- a/pymatgen/io/lammps/inputs.py
+++ b/pymatgen/io/lammps/inputs.py
@@ -963,7 +963,7 @@ class LammpsTemplateGen(TemplateInputGen):
         return input_set
 
 
-@deprecated(LammpsTemplateGen, "This method will be retired in the future. Consider using LammpsTemplateSet instead.")
+@deprecated(LammpsTemplateGen, "This function will be removed in the future.")
 def write_lammps_inputs(
     output_dir: str,
     script_template: str,

--- a/pymatgen/io/lammps/inputs.py
+++ b/pymatgen/io/lammps/inputs.py
@@ -963,7 +963,7 @@ class LammpsTemplateGen(TemplateInputGen):
         return input_set
 
 
-@deprecated(LammpsTemplateGen, "This function will be removed in the future.")
+@deprecated(LammpsTemplateGen)
 def write_lammps_inputs(
     output_dir: str,
     script_template: str,

--- a/pymatgen/io/lammps/utils.py
+++ b/pymatgen/io/lammps/utils.py
@@ -173,7 +173,7 @@ class Polymer:
             self.end += len(self.monomer)
 
 
-@deprecated(PackmolBoxGen, "PackmolRunner is being phased out in favor of the packmol I/O class.")
+@deprecated(PackmolBoxGen)
 class PackmolRunner:
     """
     Wrapper for the Packmol software that can be used to pack various types of

--- a/pymatgen/io/lobster/lobsterenv.py
+++ b/pymatgen/io/lobster/lobsterenv.py
@@ -249,7 +249,7 @@ class LobsterNeighbors(NearNeighbors):
 
         return set(anion_species)
 
-    @deprecated(replacement=anion_types)
+    @deprecated(anion_types)
     def get_anion_types(self):
         return self.anion_types
 

--- a/pymatgen/io/lobster/outputs.py
+++ b/pymatgen/io/lobster/outputs.py
@@ -1188,8 +1188,7 @@ class Lobsterout(MSONable):
 
 
 class Fatband:
-    """
-    Reads in FATBAND_x_y.lobster files.
+    """Read in FATBAND_x_y.lobster files.
 
     Attributes:
         efermi (float): Fermi energy read in from vasprun.xml.

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -2581,10 +2581,7 @@ def _gen_potcar_summary_stats(
 
 
 class Potcar(list, MSONable):
-    """
-    Read and write POTCAR files for calculations. Consists of a
-    list of PotcarSingle.
-    """
+    """Read and write POTCAR files for calculations. Consists of a list of PotcarSingle."""
 
     FUNCTIONAL_CHOICES = tuple(PotcarSingle.functional_dir)
 

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -2178,7 +2178,7 @@ class Outcar:
 
         # Store the individual contributions to the final total energy
         final_energy_contribs = {}
-        for key in [
+        for key in (
             "PSCENC",
             "TEWEN",
             "DENC",
@@ -2189,7 +2189,7 @@ class Outcar:
             "EBANDS",
             "EATOM",
             "Ediel_sol",
-        ]:
+        ):
             if key == "PAW double counting":
                 self.read_pattern({key: rf"{key}\s+=\s+([\.\-\d]+)\s+([\.\-\d]+)"})
             else:
@@ -2385,14 +2385,14 @@ class Outcar:
 
                 if read_plasma and re.match(row_pattern, line):
                     plasma_frequencies[read_plasma].append([float(t) for t in line.strip().split()])
-                elif read_plasma and Outcar._parse_sci_notation(line):
-                    plasma_frequencies[read_plasma].append(Outcar._parse_sci_notation(line))
+                elif read_plasma and type(self)._parse_sci_notation(line):
+                    plasma_frequencies[read_plasma].append(type(self)._parse_sci_notation(line))
                 elif read_dielectric:
                     tokens = None
                     if re.match(row_pattern, line.strip()):
                         tokens = line.strip().split()
-                    elif Outcar._parse_sci_notation(line.strip()):
-                        tokens = Outcar._parse_sci_notation(line.strip())
+                    elif type(self)._parse_sci_notation(line.strip()):
+                        tokens = type(self)._parse_sci_notation(line.strip())
                     elif re.match(r"\s*-+\s*", line):
                         count += 1
 
@@ -2707,10 +2707,10 @@ class Outcar:
             p_ion = spin up + spin down summed.
         """
         # Variables to be filled
-        self.er_ev = {}  # will  be  dict (Spin.up/down) of array(3*float)
-        self.er_bp = {}  # will  be  dics (Spin.up/down) of array(3*float)
-        self.er_ev_tot = None  # will be array(3*float)
-        self.er_bp_tot = None  # will be array(3*float)
+        self.er_ev = {}  # dict (Spin.up/down) of array(3*float)
+        self.er_bp = {}  # dict (Spin.up/down) of array(3*float)
+        self.er_ev_tot = None  # array(3*float)
+        self.er_bp_tot = None  # array(3*float)
         self.p_elec: int | None = None
         self.p_ion: int | None = None
         try:
@@ -2788,8 +2788,8 @@ class Outcar:
             if self.er_bp[Spin.up] is not None and self.er_bp[Spin.down] is not None:
                 self.er_bp_tot = self.er_bp[Spin.up] + self.er_bp[Spin.down]  # type: ignore[operator]
 
-        except Exception:
-            raise RuntimeError("IGPAR OUTCAR could not be parsed.")
+        except Exception as exc:
+            raise RuntimeError("IGPAR OUTCAR could not be parsed.") from exc
 
     def read_internal_strain_tensor(self):
         """Read the internal strain tensor and populates
@@ -2840,7 +2840,7 @@ class Outcar:
     def read_lepsilon(self) -> None:
         """Read a LEPSILON run.
 
-        # TODO: Document the actual variables.
+        TODO: Document the actual variables.
         """
         try:
             search = []
@@ -2986,13 +2986,13 @@ class Outcar:
             self.dielectric_tensor = self.dielectric_tensor.tolist()
             self.piezo_tensor = self.piezo_tensor.tolist()
 
-        except Exception:
-            raise RuntimeError("LEPSILON OUTCAR could not be parsed.")
+        except Exception as exc:
+            raise RuntimeError("LEPSILON OUTCAR could not be parsed.") from exc
 
     def read_lepsilon_ionic(self) -> None:
         """Read the ionic component of a LEPSILON run.
 
-        # TODO: Document the actual variables.
+        TODO: Document the actual variables.
         """
         try:
             search = []
@@ -3096,8 +3096,8 @@ class Outcar:
             self.dielectric_ionic_tensor = self.dielectric_ionic_tensor.tolist()
             self.piezo_ionic_tensor = self.piezo_ionic_tensor.tolist()
 
-        except Exception:
-            raise RuntimeError("ionic part of LEPSILON OUTCAR could not be parsed.")
+        except Exception as exc:
+            raise RuntimeError("ionic part of LEPSILON OUTCAR could not be parsed.") from exc
 
     def read_lcalcpol(self) -> None:
         """Read the LCALCPOL.

--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -3725,8 +3725,7 @@ class Chgcar(VolumetricData):
 
 
 class Elfcar(VolumetricData):
-    """
-    Read an ELFCAR file which contains the Electron Localization Function (ELF).
+    """Read an ELFCAR file which contains the Electron Localization Function (ELF).
 
     For ELF, "total" key refers to Spin.up, and "diff" refers to Spin.down.
 

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -901,9 +901,6 @@ class VaspInputSet(InputGenerator, abc.ABC):
                 " or 'zero_weighted_line_density' for a zero weighted line mode mesh."
             )
 
-        assert base_kpoints is not None
-        assert zero_weighted_kpoints is not None
-        assert added_kpoints is not None
         return _combine_kpoints(base_kpoints, zero_weighted_kpoints, added_kpoints)
 
     @property
@@ -3078,7 +3075,7 @@ def _get_recommended_lreal(structure: Structure) -> str | bool:
     return "Auto" if structure.num_sites > 16 else False
 
 
-def _combine_kpoints(*kpoints_objects: Kpoints) -> Kpoints:
+def _combine_kpoints(*kpoints_objects: Kpoints | None) -> Kpoints:
     """Combine multiple Kpoints objects."""
     _labels: list[list[str]] = []
     _kpoints: list[Sequence[Kpoint]] = []

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -1030,7 +1030,7 @@ class VaspInputSet(InputGenerator, abc.ABC):
 
         Args:
             prev_calc_dir (PathLike): Directory containing the outputs(
-                vasprun.xml and OUTCAR) of previous vasp run.
+                vasprun.xml and OUTCAR) of previous VASP run.
             **kwargs: All kwargs supported by MPStaticSet, other than prev_incar
                 and prev_structure and prev_kpoints which are determined from
                 the prev_calc_dir.
@@ -2095,7 +2095,7 @@ class MVLGWSet(VaspInputSet):
 
         Args:
             prev_calc_dir (PathLike): The directory contains the outputs(
-                vasprun.xml of previous vasp run.
+                vasprun.xml of previous VASP run.
             mode (str): Supported modes are "STATIC", "DIAG" (default), "GW",
                 and "BSE".
             **kwargs: All kwargs supported by MVLGWSet, other than structure,
@@ -2108,7 +2108,7 @@ class MVLGWSet(VaspInputSet):
 
 @dataclass
 class MVLSlabSet(VaspInputSet):
-    """Write a set of slab vasp runs, including both slabs (along the c direction)
+    """Write a set of slab VASP runs, including both slabs (along the c direction)
     and orient unit cells (bulk), to ensure the same KPOINTS, POTCAR and INCAR criterion.
 
     Args:
@@ -2261,7 +2261,7 @@ class MVLRelax52Set(VaspInputSet):
     POTCAR.
 
     Keynotes from VASP manual:
-        1. Recommended potentials for calculations using vasp.5.2+
+        1. Recommended potentials for calculations using VASP.5.2+
         2. If dimers with short bonds are present in the compound (O2, CO,
             N2, F2, P2, S2, Cl2), it is recommended to use the h potentials.
             Specifically, C_h, O_h, N_h, F_h, P_h, S_h, Cl_h
@@ -2868,13 +2868,13 @@ def batch_write_input(
     **kwargs,
 ):
     """
-    Batch write vasp input for a sequence of structures to
+    Batch write VASP input for a sequence of structures to
     output_dir, following the format output_dir/{group}/{formula}_{number}.
 
     Args:
         structures ([Structure]): Sequence of Structures.
         vasp_input_set (VaspInputSet): VaspInputSet class that creates
-            vasp input files from structures. Note that a class should be
+            VASP input files from structures. Note that a class should be
             supplied. Defaults to MPRelaxSet.
         output_dir (str): Directory to output files. Defaults to current
             directory ".".

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -316,7 +316,9 @@ class VaspInputSet(InputGenerator, abc.ABC):
     def __repr__(self) -> str:
         return type(self).__name__
 
-    @deprecated(message="get_vasp_input will be removed in a future version of pymatgen. Use get_input_set instead.")
+    @deprecated(
+        message="get_vasp_input will be removed in 2026-06-06. Use get_input_set instead.", deadline=(2026, 6, 6)
+    )
     def get_vasp_input(self, structure: Structure | None = None) -> Self:
         """Get a VaspInput object.
 
@@ -1154,16 +1156,9 @@ class VaspInputSet(InputGenerator, abc.ABC):
 VaspInputGenerator = VaspInputSet
 
 
+@deprecated(replacement=VaspInputSet, deadline=(2025, 12, 31))
 class DictSet(VaspInputSet):
     """Alias for VaspInputSet."""
-
-    def __post_init__(self) -> None:
-        super().__post_init__()
-        warnings.warn(
-            "DictSet is deprecated, and will be removed on 2025-12-31\n; use VaspInputSet",
-            category=FutureWarning,
-            stacklevel=2,
-        )
 
 
 # Helper functions to determine valid FFT grids for VASP

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -316,15 +316,6 @@ class VaspInputSet(InputGenerator, abc.ABC):
     def __repr__(self) -> str:
         return type(self).__name__
 
-    @deprecated(message="Use get_input_set instead.", deadline=(2026, 6, 6))
-    def get_vasp_input(self, structure: Structure | None = None) -> Self:
-        """Get a VaspInput object.
-
-        Returns:
-            VaspInput.
-        """
-        return self.get_input_set(structure=structure)
-
     def write_input(
         self,
         output_dir: str,
@@ -460,6 +451,15 @@ class VaspInputSet(InputGenerator, abc.ABC):
             potcar="\n".join(self.potcar_symbols) if potcar_spec else self.potcar,
             potcar_spec=potcar_spec,
         )
+
+    @deprecated(get_input_set, deadline=(2026, 6, 6))
+    def get_vasp_input(self, structure: Structure | None = None) -> Self:
+        """Get a VaspInput object.
+
+        Returns:
+            VaspInput.
+        """
+        return self.get_input_set(structure=structure)
 
     @property
     def incar_updates(self) -> dict:
@@ -1154,7 +1154,7 @@ class VaspInputSet(InputGenerator, abc.ABC):
 VaspInputGenerator = VaspInputSet
 
 
-@deprecated(replacement=VaspInputSet, deadline=(2025, 12, 31))
+@deprecated(VaspInputSet, deadline=(2025, 12, 31))
 class DictSet(VaspInputSet):
     """Alias for VaspInputSet."""
 

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -316,9 +316,7 @@ class VaspInputSet(InputGenerator, abc.ABC):
     def __repr__(self) -> str:
         return type(self).__name__
 
-    @deprecated(
-        message="get_vasp_input will be removed in 2026-06-06. Use get_input_set instead.", deadline=(2026, 6, 6)
-    )
+    @deprecated(message="Use get_input_set instead.", deadline=(2026, 6, 6))
     def get_vasp_input(self, structure: Structure | None = None) -> Self:
         """Get a VaspInput object.
 

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -71,7 +71,7 @@ MODULE_DIR = os.path.dirname(__file__)
 
 
 def _load_yaml_config(fname):
-    config = loadfn(MODULE_DIR / (f"{fname}.yaml"))
+    config = loadfn(f"{MODULE_DIR}/{fname}.yaml")
     if "PARENT" in config:
         parent_config = _load_yaml_config(config["PARENT"])
         for k, v in parent_config.items():
@@ -258,7 +258,7 @@ class VaspInputSet(InputGenerator, abc.ABC):
             )
 
         if self.vdw:
-            vdw_par = loadfn(MODULE_DIR / "vdW_parameters.yaml")
+            vdw_par = loadfn(f"{MODULE_DIR}/vdW_parameters.yaml")
             if vdw_param := vdw_par.get(self.vdw):
                 self._config_dict["INCAR"].update(vdw_param)
             else:
@@ -1317,7 +1317,7 @@ class MPScanRelaxSet(VaspInputSet):
         if self.vdw and self.vdw != "rvv10":
             warnings.warn("Use of van der waals functionals other than rVV10 with SCAN is not supported at this time. ")
             # delete any vdw parameters that may have been added to the INCAR
-            vdw_par = loadfn(str(MODULE_DIR / "vdW_parameters.yaml"))
+            vdw_par = loadfn(f"{MODULE_DIR}/vdW_parameters.yaml")
             for k in vdw_par[self.vdw]:
                 self._config_dict["INCAR"].pop(k, None)
 

--- a/pymatgen/io/vasp/sets.py
+++ b/pymatgen/io/vasp/sets.py
@@ -365,7 +365,7 @@ class VaspInputSet(InputGenerator, abc.ABC):
             files_to_transfer=self.files_to_transfer,
         )
 
-    def as_dict(self, verbosity: int = 2) -> dict:  # TODO: redefine verbosity?
+    def as_dict(self, verbosity: int = 2) -> dict:
         """
         Args:
             verbosity: Verbosity for generated dict. If 1, structure is

--- a/pymatgen/phonon/ir_spectra.py
+++ b/pymatgen/phonon/ir_spectra.py
@@ -217,11 +217,11 @@ class IRDielectricTensor(MSONable):
         plotter = SpectrumPlotter()
         for component in components:
             i, j = (directions_map[direction] for direction in component)
-            for fstr in ("re", "im"):
-                if fstr in reim:
-                    label = rf"{reim_label[fstr]}{{$\epsilon_{{{'xyz'[i]}{'xyz'[j]}}}$}}"
+            for re_im in ("re", "im"):
+                if re_im in reim:
+                    label = rf"{reim_label[re_im]}{{$\epsilon_{{{'xyz'[i]}{'xyz'[j]}}}$}}"
                     spectrum = self.get_spectrum(
-                        component, fstr, broad=broad, emin=emin, emax=emax, divs=divs, **kwargs
+                        component, re_im, broad=broad, emin=emin, emax=emax, divs=divs, **kwargs
                     )
                     spectrum.XLABEL = r"Frequency (meV)"
                     spectrum.YLABEL = r"$\epsilon(\omega)$"

--- a/tests/io/exciting/test_inputs.py
+++ b/tests/io/exciting/test_inputs.py
@@ -8,11 +8,6 @@ from pymatgen.core import Lattice, Structure
 from pymatgen.io.exciting import ExcitingInput
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
 
-"""
-Tests the module to parse exciting input
-Created 1st of December, 2016
-"""
-
 __author__ = "Christian Vorwerk"
 __copyright__ = "Copyright 2016"
 __version__ = "0.1"
@@ -74,17 +69,17 @@ class TestExcitingInput(PymatgenTest):
                 [0.5, 0.5, 0.5],
             ],
         )
-        excin = ExcitingInput(structure)
-        for l1, l2 in zip(input_string.split("\n"), excin.write_string("unchanged").split("\n")):
+        exc_in = ExcitingInput(structure)
+        for l1, l2 in zip(input_string.split("\n"), exc_in.write_string("unchanged").split("\n")):
             if not l1.strip().startswith("<crystal scale"):
                 assert l1.strip() == l2.strip()
 
     def test_writebandstr(self):
         filepath = f"{TEST_FILES_DIR}/cif/CsI3Pb.cif"
         structure = Structure.from_file(filepath)
-        excin = ExcitingInput(structure)
-        string = excin.write_string("primitive", bandstr=True)
-        bandstr = string.split("<properties>")[1].split("</properties>")[0]
+        exc_in = ExcitingInput(structure)
+        string = exc_in.write_string("primitive", bandstr=True)
+        band_str = string.split("<properties>")[1].split("</properties>")[0]
 
         coord = []
         label = []
@@ -106,25 +101,8 @@ class TestExcitingInput(PymatgenTest):
             [0.5, 0.5, 0.0],
             [0.5, 0.5, 0.5],
         ]
-        label_ref = [
-            "GAMMA",
-            "X",
-            "S",
-            "Y",
-            "GAMMA",
-            "Z",
-            "U",
-            "R",
-            "T",
-            "Z",
-            "Y",
-            "T",
-            "U",
-            "X",
-            "S",
-            "R",
-        ]
-        root = ElementTree.fromstring(bandstr)
+        label_ref = ["GAMMA", "X", "S", "Y", "GAMMA", "Z", "U", "R", "T", "Z", "Y", "T", "U", "X", "S", "R"]
+        root = ElementTree.fromstring(band_str)
         for plot1d in root.iter("plot1d"):
             for point in plot1d.iter("point"):
                 coord.append([float(i) for i in point.get("coord").split()])

--- a/tests/io/vasp/test_sets.py
+++ b/tests/io/vasp/test_sets.py
@@ -440,7 +440,7 @@ class TestMITMPRelaxSet(PymatgenTest):
 
         # test that van-der-Waals parameters are parsed correctly
 
-        vdw_par = loadfn(MODULE_DIR / "vdW_parameters.yaml")
+        vdw_par = loadfn(f"{MODULE_DIR}/vdW_parameters.yaml")
         with pytest.raises(
             KeyError,
             match=f"Invalid or unsupported van-der-Waals functional. Supported functionals are {', '.join(vdw_par)}.",
@@ -1118,7 +1118,7 @@ class TestMagmomLdau(PymatgenTest):
         assert magmom == magmom_ans
 
     def test_ln_magmom(self):
-        yaml_path = MODULE_DIR / "VASPIncarBase.yaml"
+        yaml_path = f"{MODULE_DIR}/VASPIncarBase.yaml"
         magmom_setting = loadfn(yaml_path)["INCAR"]["MAGMOM"]
         structure = Structure.from_file(f"{TEST_FILES_DIR}/cif/La4Fe4O12.cif")
         structure.add_oxidation_state_by_element({"La": +3, "Fe": +3, "O": -2})

--- a/tests/io/vasp/test_sets.py
+++ b/tests/io/vasp/test_sets.py
@@ -2122,7 +2122,7 @@ def test_vasp_input_set_alias():
 
 def test_dict_set_alias():
     with pytest.warns(
-        FutureWarning, match="DictSet is deprecated, and will be removed on 2025-12-31\n; use VaspInputSet"
+        FutureWarning, match="DictSet is deprecated, and will be removed on 2025-12-31\nUse VaspInputSet"
     ):
         DictSet()
     assert isinstance(DictSet(), VaspInputSet)


### PR DESCRIPTION
## Summary

- Improve types for `io.vasp.sets` and comment tweaks
- Replace hard coded class names
- Use `deadline` in `deprecated` decorator for easier tracking of deprecated functions

