### PR TITLE
Bug fix: fixed the leading capitalized ALGO in Vasprun

### DIFF
--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -1219,7 +1219,7 @@ class Vasprun(MSONable):
         """
         potcar = self.get_potcars(path)
 
-        if potcar and self.incar.get("ALGO", "") not in {"GW0", "G0W0", "GW", "BSE"}:
+        if potcar and self.incar.get("ALGO", "").upper() not in {"GW0", "G0W0", "GW", "BSE"}:
             nelect = self.parameters["NELECT"]
             if len(potcar) == len(self.initial_structure.composition.element_composition):
                 potcar_nelect = sum(


### PR DESCRIPTION
## Summary

Major changes:

- This PR solved the issue in #3780 

`pymatgen` automatically converts the input `ALGO` to the leading capitalized format, e.g. `GW0` will be converted to `Gw0` and written to `vasprun.xml`. In such case, `Vasprun` would fail to parse the results. In this PR, I fixed this bug. 

Tagging @mkhorton for awareness.
