### PR TITLE
Bug fix: handle non-integer oxidation states in `Species`

### DIFF
--- a/pymatgen/core/periodic_table.py
+++ b/pymatgen/core/periodic_table.py
@@ -984,7 +984,7 @@ class Species(MSONable, Stringify):
             )
         if isinstance(symbol, str) and symbol.endswith(("+", "-")):
             # Extract oxidation state from symbol
-            symbol, oxi = re.match(r"([A-Za-z]+)([0-9]*[\+\-])", symbol).groups()  # type: ignore[union-attr]
+            symbol, oxi = re.match(r"([A-Za-z]+)([0-9\.0-9]*[\+\-])", symbol).groups()  # type: ignore[union-attr]
             self._oxi_state: float | None = (1 if "+" in oxi else -1) * float(oxi[:-1] or 1)
         else:
             self._oxi_state = oxidation_state

--- a/pymatgen/core/periodic_table.py
+++ b/pymatgen/core/periodic_table.py
@@ -19,6 +19,7 @@ from monty.dev import deprecated
 from monty.json import MSONable
 
 from pymatgen.core.units import SUPPORTED_UNIT_NAMES, FloatWithUnit, Ha_to_eV, Length, Mass, Unit
+from pymatgen.io.core import ParseError
 from pymatgen.util.string import Stringify, formula_double_format
 
 if TYPE_CHECKING:
@@ -982,8 +983,11 @@ class Species(MSONable, Stringify):
             )
         if isinstance(symbol, str) and symbol.endswith(("+", "-")):
             # Extract oxidation state from symbol
-            symbol, oxi = re.match(r"([A-Za-z]+)([0-9\.0-9]*[\+\-])", symbol).groups()  # type: ignore[union-attr]
-            self._oxi_state: float | None = (1 if "+" in oxi else -1) * float(oxi[:-1] or 1)
+            try:
+                symbol, oxi = re.match(r"([A-Za-z]+)([0-9\.0-9]*[\+\-])", symbol).groups()  # type: ignore[union-attr]
+                self._oxi_state: float | None = (1 if "+" in oxi else -1) * float(oxi[:-1] or 1)
+            except AttributeError:
+                raise ParseError(f"Failed to parse {symbol=}")
         else:
             self._oxi_state = oxidation_state
 

--- a/tests/core/test_periodic_table.py
+++ b/tests/core/test_periodic_table.py
@@ -529,14 +529,14 @@ class TestSpecies(PymatgenTest):
         ("P5+", "P", 5),
         ("Na0+", "Na", 0),
         ("Na0-", "Na", 0),
-        ("C0.53-","C",-0.53),
-        ("Tc3.498+","Tc",3.498)
+        ("C0.53-", "C", -0.53),
+        ("Tc3.498+", "Tc", 3.498),
     ],
 )
 def test_symbol_oxi_state_str(symbol_oxi, expected_element, expected_oxi_state):
     species = Species(symbol_oxi)
     assert species._el.symbol == expected_element
-    assert species._oxi_state == pytest.approx(expected_oxi_state,rel=1.e-6)
+    assert species._oxi_state == pytest.approx(expected_oxi_state, rel=1.0e-6)
 
 
 class TestDummySpecies:

--- a/tests/core/test_periodic_table.py
+++ b/tests/core/test_periodic_table.py
@@ -529,12 +529,14 @@ class TestSpecies(PymatgenTest):
         ("P5+", "P", 5),
         ("Na0+", "Na", 0),
         ("Na0-", "Na", 0),
+        ("C0.53-","C",-0.53),
+        ("Tc3.498+","Tc",3.498)
     ],
 )
 def test_symbol_oxi_state_str(symbol_oxi, expected_element, expected_oxi_state):
     species = Species(symbol_oxi)
     assert species._el.symbol == expected_element
-    assert species._oxi_state == expected_oxi_state
+    assert species._oxi_state == pytest.approx(expected_oxi_state,rel=1.e-6)
 
 
 class TestDummySpecies:

--- a/tests/core/test_periodic_table.py
+++ b/tests/core/test_periodic_table.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import math
 import pickle
+import re
 from copy import deepcopy
 from enum import Enum
 
@@ -12,6 +13,7 @@ from pytest import approx
 from pymatgen.core import DummySpecies, Element, Species, get_el_sp
 from pymatgen.core.periodic_table import ElementBase, ElementType
 from pymatgen.core.units import Ha_to_eV
+from pymatgen.io.core import ParseError
 from pymatgen.util.testing import PymatgenTest
 
 
@@ -537,6 +539,12 @@ def test_symbol_oxi_state_str(symbol_oxi, expected_element, expected_oxi_state):
     species = Species(symbol_oxi)
     assert species._el.symbol == expected_element
     assert species._oxi_state == pytest.approx(expected_oxi_state, rel=1.0e-6)
+
+
+def test_symbol_oxi_state_str_raises():
+    symbol = "Fe2.5f2123+"  # invalid oxidation state
+    with pytest.raises(ParseError, match=re.escape(f"Failed to parse {symbol=}")):
+        _ = Species(symbol)
 
 
 class TestDummySpecies:


### PR DESCRIPTION
Simple bug fix for when elements have non-integer oxidation states assigned to them. Pymatgen can assign non-integer charges to sites, but when trying to initialize `Species` with non-integer oxidation state:
```
from pymatgen.core import Species
Species("C0.25+")._oxi_state
```
this raises an `AttributeError`.

This PR fixes that bug and adds test cases to `tests/core/test_periodic_table.test_symbol_oxi_state_str`.