### PR TITLE
Slightly more robust `MSONAtoms` handling

### DIFF
--- a/pymatgen/io/ase.py
+++ b/pymatgen/io/ase.py
@@ -72,7 +72,7 @@ class MSONAtoms(Atoms, MSONable):
         # to be used in a round-trip fashion and does not work properly with constraints.
         # See ASE issue #1387.
         mson_atoms = cls(decode(dct["atoms_json"]))
-        atoms_info = MontyDecoder().process_decoded(dct["atoms_info"])
+        atoms_info = MontyDecoder().process_decoded(dct.get("atoms_info", {}))
         mson_atoms.info = atoms_info
         return mson_atoms
 


### PR DESCRIPTION
Broader context: This PR basically impacts nobody and is just a marginally safer way to index the `MSONAtoms` info key when parsing the dictionary representation.

Technical details: As noted by @samblau, if for some reason your `MSONAtoms.as_dict()` representation no longer has an `atoms_info` key, then doing `MSONAtoms.from_dict()` will crash. In virtually all cases, the user will have an `atoms_info` key, but it's pretty trivial to fix this by doing `.get(dct["atoms_info"], {})` instead of `dct["atoms_info"]`, so I've done that here.
