### PR TITLE
Fix bug in VASP parameter parsing

### DIFF
--- a/pymatgen/io/vasp/outputs.py
+++ b/pymatgen/io/vasp/outputs.py
@@ -722,6 +722,10 @@ class Vasprun(MSONable):
 
         Hubbard U terms and vdW corrections are detected automatically as well.
         """
+
+        # Care should be taken: if a GGA tag is not specified, VASP will default
+        # to the functional specified by the POTCAR. It is not clear how
+        # VASP handles the "--" value.
         GGA_TYPES = {
             "RE": "revPBE",
             "PE": "PBE",
@@ -1356,7 +1360,9 @@ class Vasprun(MSONable):
         """Parse INCAR parameters."""
         params: dict = {}
         for c in elem:
-            name = c.attrib.get("name", "")
+            # VASP 6.4.3 can add trailing whitespace
+            # for example, <i type="string" name="GGA    ">PE</i>
+            name = c.attrib.get("name", "").strip()
             if c.tag not in {"i", "v"}:
                 p = self._parse_params(c)
                 if name == "response functions":


### PR DESCRIPTION
VASP 6.4.3 introduced additional white space in the values of some parameters in the vasprun.xml, for example ` <i type="string" name="GGA    ">PE</I>`. This leads to incorrect determination of `run_type`.