### PR TITLE
Add `SymmetryUndetermined(ValueError)` exception type

### DIFF
--- a/pymatgen/core/structure.py
+++ b/pymatgen/core/structure.py
@@ -1522,6 +1522,11 @@ class IStructure(SiteCollection, MSONable):
 
         Returns:
             spacegroup_symbol, international_number
+
+        Raises:
+            pymatgen.symmetry.analyzer.SymmetryUndetermined if symmetry cannot
+            be determined. This can happen for numerical reasons, for example if
+            atoms are placed unphysically close together.
         """
         # Avoid circular import
         from pymatgen.symmetry.analyzer import SpacegroupAnalyzer

--- a/pymatgen/symmetry/analyzer.py
+++ b/pymatgen/symmetry/analyzer.py
@@ -51,12 +51,22 @@ cite_conventional_cell_algo = due.dcite(
 )
 
 
+class SymmetryUndetermined(ValueError):
+    """
+    An Exception for when symmetry cannot be determined. This might happen
+    when, for example, atoms are very close together.
+    """
+
+
 @lru_cache(maxsize=32)
 def _get_symmetry_dataset(cell, symprec, angle_tolerance):
     """Simple wrapper to cache results of spglib.get_symmetry_dataset since this call is
     expensive.
     """
-    return spglib.get_symmetry_dataset(cell, symprec=symprec, angle_tolerance=angle_tolerance)
+    dataset = spglib.get_symmetry_dataset(cell, symprec=symprec, angle_tolerance=angle_tolerance)
+    if dataset is None:
+        raise SymmetryUndetermined
+    return dataset
 
 
 class SpacegroupAnalyzer:

--- a/tests/symmetry/test_analyzer.py
+++ b/tests/symmetry/test_analyzer.py
@@ -5,11 +5,17 @@ from unittest import TestCase
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
-from pytest import approx
+from pytest import approx, raises
 
-from pymatgen.core import Molecule, PeriodicSite, Site, Species, Structure
+from pymatgen.core import Lattice, Molecule, PeriodicSite, Site, Species, Structure
 from pymatgen.io.vasp.outputs import Vasprun
-from pymatgen.symmetry.analyzer import PointGroupAnalyzer, SpacegroupAnalyzer, cluster_sites, iterative_symmetrize
+from pymatgen.symmetry.analyzer import (
+    PointGroupAnalyzer,
+    SpacegroupAnalyzer,
+    SymmetryUndetermined,
+    cluster_sites,
+    iterative_symmetrize,
+)
 from pymatgen.symmetry.structure import SymmetrizedStructure
 from pymatgen.util.testing import TEST_FILES_DIR, VASP_IN_DIR, VASP_OUT_DIR, PymatgenTest
 
@@ -367,6 +373,11 @@ class TestSpacegroupAnalyzer(PymatgenTest):
         assert spg_analyzer.get_point_group_symbol() == "4/mmm"
         assert spg_analyzer.get_crystal_system() == "tetragonal"
         assert spg_analyzer.get_hall() == "-I 4 2"
+
+    def test_bad_structure(self):
+        struct = Structure(Lattice.cubic(5), ["H", "H"], [[0.0, 0.0, 0.0], [0.001, 0.0, 0.0]])
+        with raises(SymmetryUndetermined):
+            SpacegroupAnalyzer(struct, 0.1)
 
 
 class TestSpacegroup(TestCase):


### PR DESCRIPTION
## Summary

`spglib` will not raise if symmetry cannot be determined, but will instead return `None`. This is not currently handled in `SpacegroupAnalyzer`.

As a result, a common issue encountered is calling `Structure.get_space_group_info` for a structure  where symmetry cannot be determined leading to an opaque `ValueError` from a non-sensical subscript (`None["international"]`). With this change, an error will now be raised which can be handled appropriately by the end user.