### PR TITLE
[Breaking] Fix comparision for `core.Composition`

### DIFF
--- a/pymatgen/core/composition.py
+++ b/pymatgen/core/composition.py
@@ -203,7 +203,7 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
         if not isinstance(other, type(self)):
             return NotImplemented
 
-        if not set(self.elements).issuperset(other.elements):
+        if not set(self.elements).issuperset(set(other.elements)):
             # TODO: revise warning message
             warnings.warn("Elements is not a superset.")
             return False

--- a/pymatgen/core/composition.py
+++ b/pymatgen/core/composition.py
@@ -197,16 +197,16 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
         if all elements in B are in A and the amount of each element in A is
         greater than or equal to the amount of the element in B within
         Composition.amount_tolerance.
-
-        Should ONLY be used for defining a sort order (the behavior is probably not what you'd expect).
         """
         if not isinstance(other, type(self)):
             return NotImplemented
 
+        # if not set(self.elements).issuperset(other.elements):
+        #     return False
+
         for el in sorted(set(self.elements + other.elements)):
             if other[el] - self[el] >= type(self).amount_tolerance:
                 return False
-            # TODO @janosh 2024-04-29: is this a bug? why would we return True early?
             if self[el] - other[el] >= type(self).amount_tolerance:
                 return True
         return True

--- a/pymatgen/core/composition.py
+++ b/pymatgen/core/composition.py
@@ -197,18 +197,20 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
         if all elements in B are in A and the amount of each element in A is
         greater than or equal to the amount of the element in B within
         Composition.amount_tolerance.
+
+        Should ONLY be used for sorting purpose (the behavior is probably not what you'd expect).
         """
         if not isinstance(other, type(self)):
             return NotImplemented
 
-        # if not set(self.elements).issuperset(other.elements):
-        #     return False
+        if not set(self.elements).issuperset(other.elements):
+            # TODO: revise warning message
+            warnings.warn("Elements is not a superset.")
+            return False
 
         for el in sorted(set(self.elements + other.elements)):
             if other[el] - self[el] >= type(self).amount_tolerance:
                 return False
-            if self[el] - other[el] >= type(self).amount_tolerance:
-                return True
         return True
 
     def __add__(self, other: object) -> Self:

--- a/tests/core/test_composition.py
+++ b/tests/core/test_composition.py
@@ -516,8 +516,10 @@ class TestComposition(PymatgenTest):
 
         # Test single different element
         comp_o1 = Composition({"O": 1})
-        assert comp_s1 > comp_o1
-        assert comp_o1 < comp_s1
+        with pytest.warns(match="Elements is not a superset."):
+            assert not comp_s1 > comp_o1
+        with pytest.warns(match="Elements is not a superset."):
+            assert not comp_o1 > comp_s1
 
         # Test superset
         comp_s1o1 = Composition({"O": 1, "S": 1})
@@ -544,8 +546,10 @@ class TestComposition(PymatgenTest):
         # Test different elements
         comp_co2 = Composition({"C": 1, "O": 2})
         comp_fe2o3 = Composition({"Fe": 2, "O": 3})
-        assert not comp_co2 > comp_fe2o3
-        assert not comp_fe2o3 > comp_co2
+        with pytest.warns(match="Elements is not a superset."):
+            assert not comp_co2 > comp_fe2o3
+        with pytest.warns(match="Elements is not a superset."):
+            assert not comp_fe2o3 > comp_co2
 
         # Not implemented comparison between Composition and Element
         Fe = Element("Fe")


### PR DESCRIPTION
## Summary

- Fix #3815.

### Unchanged behavior
```python
# Single element
print(Composition({"O": 2}) > Composition({"O": 1}))   # True

# Multiple shared elements
print(Composition({"Fe": 3, "O": 4}) > Composition({"Fe": 2, "O": 3}))   # True

# Superset
print(Composition({"C":1, "O": 2}) > Composition({"O": 2}))   # True
```

### Breaking change (fix)

As per the docstring: https://github.com/materialsproject/pymatgen/blob/fbf8ec0a5a9c0fb649975d66dedb31b17bcc9dfc/pymatgen/core/composition.py#L195-L202

```python
# The followings would now be False (with a warning)
# Single element
print(Composition({"S": 1}) > Composition({"O": 1}))   # False, with a warning
print(Composition({"O": 1}) > Composition({"S": 1}))   # False, with a warning

# Multiple elements but not superset
print(Composition({"S": 1, "O": 2}) > Composition({"C": 1, "O": 2}))   # False, with a warning
print(Composition({"C": 1, "O": 2}) > Composition({"S": 1, "O": 2}))   # False, with a warning
```

