### PR TITLE
Bug fix for ComputedEntry from_dict

### DIFF
--- a/pymatgen/entries/computed_entries.py
+++ b/pymatgen/entries/computed_entries.py
@@ -482,10 +482,9 @@ class ComputedEntry(Entry):
         Returns:
             ComputedEntry
         """
-
         # Must handle cases where some kwargs exist in `dct` but are None
         # include extra logic to ensure these get properly treated
-        energy_adj = dct.get("energy_adjustments",[]) or []
+        energy_adj = dct.get("energy_adjustments", []) or []
 
         if dct["correction"] != 0 and not energy_adj:
             # the first block here is for legacy ComputedEntry that were

--- a/pymatgen/entries/computed_entries.py
+++ b/pymatgen/entries/computed_entries.py
@@ -484,18 +484,17 @@ class ComputedEntry(Entry):
         """
         # Must handle cases where some kwargs exist in `dct` but are None
         # include extra logic to ensure these get properly treated
-        energy_adj = dct.get("energy_adjustments", []) or []
+        energy_adj = [MontyDecoder().process_decoded(e) for e in (dct.get("energy_adjustments", []) or [])]
+
+        # this is the preferred / modern way of instantiating ComputedEntry
+        # we don't pass correction explicitly because it will be calculated
+        # on the fly from energy_adjustments
+        correction = 0
 
         if dct["correction"] != 0 and not energy_adj:
-            # the first block here is for legacy ComputedEntry that were
+            # this block is for legacy ComputedEntry that were
             # serialized before we had the energy_adjustments attribute.
             correction = dct["correction"]
-        else:
-            # this is the preferred / modern way of instantiating ComputedEntry
-            # we don't pass correction explicitly because it will be calculated
-            # on the fly from energy_adjustments
-            correction = 0
-            energy_adj = [MontyDecoder().process_decoded(e) for e in energy_adj]
 
         return cls(
             dct["composition"],

--- a/pymatgen/entries/computed_entries.py
+++ b/pymatgen/entries/computed_entries.py
@@ -490,8 +490,7 @@ class ComputedEntry(Entry):
         # we don't pass correction explicitly because it will be calculated
         # on the fly from energy_adjustments
         correction = 0
-
-        if dct["correction"] != 0 and not energy_adj:
+        if dct["correction"] != 0 and len(energy_adj) == 0:
             # this block is for legacy ComputedEntry that were
             # serialized before we had the energy_adjustments attribute.
             correction = dct["correction"]

--- a/tests/entries/test_computed_entries.py
+++ b/tests/entries/test_computed_entries.py
@@ -238,6 +238,14 @@ class TestComputedEntry(TestCase):
             assert entry == copy
             assert str(entry) == str(copy)
 
+    def test_from_dict_null_fields(self):
+        ce_dict = self.entry.as_dict()
+        for k in ("energy_adjustments","parameters","data",):
+            ce = ce_dict.copy()
+            ce[k] = None
+            new_ce = ComputedEntry.from_dict(ce)
+            assert new_ce == self.entry
+            assert getattr(new_ce,k,None) is not None
 
 class TestComputedStructureEntry(TestCase):
     def setUp(self):

--- a/tests/entries/test_computed_entries.py
+++ b/tests/entries/test_computed_entries.py
@@ -240,12 +240,17 @@ class TestComputedEntry(TestCase):
 
     def test_from_dict_null_fields(self):
         ce_dict = self.entry.as_dict()
-        for k in ("energy_adjustments","parameters","data",):
+        for k in (
+            "energy_adjustments",
+            "parameters",
+            "data",
+        ):
             ce = ce_dict.copy()
             ce[k] = None
             new_ce = ComputedEntry.from_dict(ce)
             assert new_ce == self.entry
-            assert getattr(new_ce,k,None) is not None
+            assert getattr(new_ce, k, None) is not None
+
 
 class TestComputedStructureEntry(TestCase):
     def setUp(self):


### PR DESCRIPTION
In `pymatgen.entries.computed_entries`, `ComputedEntry` takes three optional fields: `energy_adjustments`, `parameters`, `data`, which are not correctly read in by its `from_dict` method. This is because, for example:
```
parameters = {k: MontyDecoder().process_decoded(v) for k, v in (dct.get("parameters", {})}
```
will throw `AttributeError: 'NoneType' object has no attribute 'items'` if the input `ComputedEntry` dict has `parameters = None`.

Because the typing of `ComputedEntry` suggests that these fields can be `None`, this PR ensures that the `from_dict` can properly handle null fields and also ensures correct param defaults (`energy_adjustments` incorrectly defaults to an empty `dict` instead of `list`).

Also added a test for this behavior. cc @tsmathis who found this behavior