### PR TITLE
Improve Keep Redundant Spaces algorithm for PatchedPhaseDiagram

### DIFF
--- a/src/pymatgen/analysis/phase_diagram.py
+++ b/src/pymatgen/analysis/phase_diagram.py
@@ -1665,18 +1665,18 @@ class PatchedPhaseDiagram(PhaseDiagram):
 
     def as_dict(self) -> dict[str, Any]:
         """Write the entries and elements used to construct the PatchedPhaseDiagram
-        to a dictionary. 
+        to a dictionary.
 
-        NOTE unlike PhaseDiagram the computation involved in constructing the 
+        NOTE unlike PhaseDiagram the computation involved in constructing the
         PatchedPhaseDiagram is not saved on serialisation. This is done because
         hierachically calling the `PhaseDiagram.as_dict()` method would break the
         link in memory between entries in overlapping patches leading to a
         ballooning of the amount of memory used.
-        
+
         NOTE For memory efficiency the best way to store patched phase diagrams is
         via pickling. As this allows all the entries in overlapping patches to share
         the same id in memory when unpickling.
-        
+
         Returns:
             dict[str, Any]: MSONable dictionary representation of PatchedPhaseDiagram.
         """
@@ -1691,11 +1691,11 @@ class PatchedPhaseDiagram(PhaseDiagram):
     def from_dict(cls, dct: dict) -> Self:
         """Reconstruct PatchedPhaseDiagram from dictionary serialisation.
 
-        NOTE unlike PhaseDiagram the computation involved in constructing the 
+        NOTE unlike PhaseDiagram the computation involved in constructing the
         PatchedPhaseDiagram is not saved on serialisation. This is done because
         hierachically calling the `PhaseDiagram.as_dict()` method would break the
         link in memory between entries in overlapping patches leading to a
-        ballooning of the amount of memory used. 
+        ballooning of the amount of memory used.
 
         NOTE For memory efficiency the best way to store patched phase diagrams is
         via pickling. As this allows all the entries in overlapping patches to share

--- a/src/pymatgen/analysis/phase_diagram.py
+++ b/src/pymatgen/analysis/phase_diagram.py
@@ -1669,7 +1669,7 @@ class PatchedPhaseDiagram(PhaseDiagram):
 
         NOTE unlike PhaseDiagram the computation involved in constructing the
         PatchedPhaseDiagram is not saved on serialisation. This is done because
-        hierachically calling the `PhaseDiagram.as_dict()` method would break the
+        hierarchically calling the `PhaseDiagram.as_dict()` method would break the
         link in memory between entries in overlapping patches leading to a
         ballooning of the amount of memory used.
 
@@ -1693,7 +1693,7 @@ class PatchedPhaseDiagram(PhaseDiagram):
 
         NOTE unlike PhaseDiagram the computation involved in constructing the
         PatchedPhaseDiagram is not saved on serialisation. This is done because
-        hierachically calling the `PhaseDiagram.as_dict()` method would break the
+        hierarchically calling the `PhaseDiagram.as_dict()` method would break the
         link in memory between entries in overlapping patches leading to a
         ballooning of the amount of memory used.
 

--- a/tests/analysis/test_phase_diagram.py
+++ b/tests/analysis/test_phase_diagram.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import collections
 import unittest
 import unittest.mock
+from itertools import combinations
 from numbers import Number
 from unittest import TestCase
 
@@ -835,6 +836,19 @@ class TestPatchedPhaseDiagram(TestCase):
         assert unlikely_chem_space in self.ppd
         assert self.ppd[unlikely_chem_space] == self.pd
         del self.ppd[unlikely_chem_space]  # test __delitem__() and restore original state
+
+    def test_remove_redundant_spaces(self):
+        spaces = tuple(frozenset(entry.elements) for entry in self.ppd.qhull_entries)
+        # NOTE this is 5 not 4 as "He" is a non redundant space that gets dropped for other reasons
+        assert len(self.ppd.remove_redundant_spaces(spaces)) == 5
+
+        test = (
+            list(combinations(range(1, 7), 4))
+            + list(combinations(range(1, 10), 2))
+            + list(combinations([1, 4, 7, 9, 2], 5))
+        )
+        test = [frozenset(t) for t in test]
+        assert len(self.ppd.remove_redundant_spaces(test)) == 30
 
 
 class TestReactionDiagram(TestCase):

--- a/tests/analysis/test_phase_diagram.py
+++ b/tests/analysis/test_phase_diagram.py
@@ -709,6 +709,7 @@ class TestPatchedPhaseDiagram(TestCase):
 
         self.pd = PhaseDiagram(entries=self.entries)
         self.ppd = PatchedPhaseDiagram(entries=self.entries)
+        self.ppd_all = PatchedPhaseDiagram(entries=self.entries, keep_all_spaces=True)
 
         # novel entries not in any of the patches
         self.novel_comps = [Composition("H5C2OP"), Composition("V2PH4C")]
@@ -756,7 +757,11 @@ class TestPatchedPhaseDiagram(TestCase):
 
         # test dims of sub PDs
         dim_counts = collections.Counter(pd.dim for pd in self.ppd.pds.values())
-        assert dim_counts == {3: 7, 2: 6, 4: 2}
+        assert dim_counts == {4: 2, 3: 2}
+
+        # test dims of sub PDs
+        dim_counts = collections.Counter(pd.dim for pd in self.ppd_all.pds.values())
+        assert dim_counts == {2: 8, 3: 7, 4: 2}
 
     def test_get_hull_energy(self):
         for comp in self.novel_comps:
@@ -772,7 +777,7 @@ class TestPatchedPhaseDiagram(TestCase):
             assert np.isclose(e_above_hull_pd, e_above_hull_ppd)
 
     def test_repr(self):
-        assert repr(self.ppd) == str(self.ppd) == "PatchedPhaseDiagram covering 15 sub-spaces"
+        assert repr(self.ppd) == str(self.ppd) == "PatchedPhaseDiagram covering 4 sub-spaces"
 
     def test_as_from_dict(self):
         ppd_dict = self.ppd.as_dict()
@@ -810,7 +815,8 @@ class TestPatchedPhaseDiagram(TestCase):
         pd = self.ppd[chem_space]
         assert isinstance(pd, PhaseDiagram)
         assert chem_space in pd._qhull_spaces
-        assert str(pd) == "V-C phase diagram\n4 stable phases: \nC, V, V6C5, V2C"
+        assert len(str(pd)) == 186
+        assert str(pd).startswith("V-H-C-O phase diagram\n25 stable phases:")
 
         with pytest.raises(KeyError, match="frozenset"):
             self.ppd[frozenset(map(Element, "HBCNOFPS"))]


### PR DESCRIPTION
## Summary
- modularize the keep redundant spaces code, and fix the algorithm which previously didn't get rid of all the redundant spaces.

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))
