### PR TITLE
add option to color phonon bands as per gruneisen parameter value

### DIFF
--- a/tests/phonon/test_gruneisen.py
+++ b/tests/phonon/test_gruneisen.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import matplotlib.pyplot as plt
+import numpy as np
 import pytest
+from matplotlib import colors
 from pymatgen.io.phonopy import get_gruneisen_ph_bs_symm_line, get_gruneisenparameter
 from pymatgen.phonon.gruneisen import GruneisenParameter
 from pymatgen.phonon.plotter import GruneisenPhononBandStructureSymmLine, GruneisenPhononBSPlotter, GruneisenPlotter
@@ -29,6 +31,39 @@ class TestGruneisenPhononBandStructureSymmLine(PymatgenTest):
     def test_plot(self):
         plotter = GruneisenPhononBSPlotter(bs=self.bs_symm_line)
         ax = plotter.get_plot_gs()
+        assert isinstance(ax, plt.Axes)
+
+    def test_ph_plot_w_gruneisen(self):
+        plotter = GruneisenPhononBSPlotter(bs=self.bs_symm_line)
+        ax = plotter.get_plot_gs(plot_ph_bs_with_gruneisen=True, units="THz", cmap=["red", "royalblue"])
+        assert ax.get_ylabel() == "Frequencies (THz)"
+        assert ax.get_xlabel() == "$\\mathrm{Wave\\ Vector}$"
+        assert ax.get_figure()._localaxes[-1].get_ylabel() == "$\\gamma \\ \\mathrm{(logarithmized)}$"
+        assert len(ax._children) == plotter.n_bands + 1  # check for number of bands
+        # check for x and y data is really the band-structure data
+        for inx, band in enumerate(plotter._bs.bands):
+            xy_data = {
+                "x": [point[0] for point in ax._children[inx].get_offsets().data],
+                "y": [point[1] for point in ax._children[inx].get_offsets().data],
+            }
+            assert band == pytest.approx(xy_data["y"])
+            assert plotter._bs.distance == pytest.approx(xy_data["x"])
+
+        # check if color bar max value matches maximum gruneisen parameter value
+        data = plotter.bs_plot_data()
+
+        # get reference min and max Grüneisen parameter values
+        max_gruneisen = np.array(data["gruneisen"]).max()
+        min_gruneisen = np.array(data["gruneisen"]).min()
+
+        norm = colors.SymLogNorm(
+            vmin=min_gruneisen,
+            vmax=max_gruneisen,
+            linthresh=1e-2,
+            linscale=1,
+        )
+
+        assert max(norm.inverse(ax.get_figure()._localaxes[-1].get_yticks())) == pytest.approx(max_gruneisen)
         assert isinstance(ax, plt.Axes)
 
     def test_as_dict_from_dict(self):


### PR DESCRIPTION
# Note

This new functionality was initially implemented as part of ongoing workflow development for computing the Grüneisen parameter in atomate2, see https://github.com/materialsproject/atomate2/pull/752

As it mainly relies on the pymatgen code with minor additions, I think it would be appropriate if the code resides here. 

## Changes

1. Added an option to get phonon bandstructure colored based on Grüneisen parameter values along the K-path in `GruneisenPhononBSPlotter`. 
2. Added `plot_ph_bs_with_gruneisen`  arg to `save_plot_gs `and `get_plot_gs` methods
3. Added tests to ensure the functionality works as expected


## Example output for Si with new functionality
![Si_grun_band](https://github.com/materialsproject/pymatgen/assets/91958822/37f68166-121e-4a05-80ce-17bfee807ef8)


