### PR TITLE
added cp2k_output cube to pymatgen volume parser

### DIFF
--- a/src/pymatgen/io/cp2k/outputs.py
+++ b/src/pymatgen/io/cp2k/outputs.py
@@ -22,11 +22,11 @@ from pymatgen.core.units import Ha_to_eV
 from pymatgen.electronic_structure.bandstructure import BandStructure, BandStructureSymmLine
 from pymatgen.electronic_structure.core import Orbital, Spin
 from pymatgen.electronic_structure.dos import CompleteDos, Dos
+from pymatgen.io.common import VolumetricData
 from pymatgen.io.cp2k.inputs import Keyword
 from pymatgen.io.cp2k.sets import Cp2kInput
 from pymatgen.io.cp2k.utils import natural_keys, postprocessor
 from pymatgen.io.xyz import XYZ
-from pymatgen.io.common import VolumetricData
 
 __author__ = "Nicholas Winner"
 __version__ = "2.0"
@@ -329,7 +329,9 @@ class Cp2kOutput:
         with zopen(self.filename, mode="rt") as file:
             while True:
                 line = file.readline()
-                if re.search(r"\s*Atom\s+Kind\s+Element\s+X\s+Y\s+Z\s+Z\(eff\)\s+Mass", line) or re.search(r"Atom\s+Kind\s+Element\s+X\s+Y\s+Z\s+Z\(eff\)\s+Mass", line):
+                if re.search(r"\s*Atom\s+Kind\s+Element\s+X\s+Y\s+Z\s+Z\(eff\)\s+Mass", line) or re.search(
+                    r"Atom\s+Kind\s+Element\s+X\s+Y\s+Z\s+Z\(eff\)\s+Mass", line
+                ):
                     for _ in range(self.data["num_atoms"][0][0]):
                         line = file.readline().split()
                         if line == []:
@@ -1594,49 +1596,49 @@ class Cp2kOutput:
         if attribute_name is not None:
             self.data[attribute_name] = retained_data
         return retained_data
+
     def parse_cube(self, cube_filename=None):
         """Parse a cube file .
         Args:
-            cube_filename: Filename containing cube file info. If name is not given, 
-            then the "*hartree*.cube*" will be taken as the default 
+            cube_filename: Filename containing cube file info. If name is not given,
+            then the "*hartree*.cube*" will be taken as the default
         """
         if not cube_filename:
             if self.filenames["v_hartree"]:
                 cube_filename = self.filenames["v_hartree"][0]
             else:
-                return
+                return None
         else:
-            cube_filename=os.path.join(self.dir,cube_filename)      
-        #print(cube_filename)
-        with open(cube_filename, 'r') as file:
+            cube_filename = os.path.join(self.dir, cube_filename)
+        # print(cube_filename)
+        with open(cube_filename) as file:
             lines = file.readlines()
 
-        origin = list(map(float, lines[2].split()[1:4])) 
-        num_atoms = int(lines[2].split()[0])  
+        list(map(float, lines[2].split()[1:4]))
+        num_atoms = int(lines[2].split()[0])
 
         grid_points = []
-        grid_vectors = []
         for i in range(3):
             line = lines[3 + i].split()
             grid_points.append(int(line[0]))
 
         grid_points = np.array(grid_points)
-        dim = tuple(grid_points)  # Dimensions for VolumetricData
+        tuple(grid_points)  # Dimensions for VolumetricData
         data_start = 6 + num_atoms
 
         # Read volumetric data
         data = []
         for line in lines[data_start:]:
             data.extend(map(float, line.split()))
-        data_array = np.array(data).reshape(grid_points[::-1], order='F') # vasp style  
-        volumetric_data = {'total': data_array.transpose((2, 1, 0))}
-        #self.parse_structures()
+        data_array = np.array(data).reshape(grid_points[::-1], order="F")  # vasp style
+        volumetric_data = {"total": data_array.transpose((2, 1, 0))}
+        # self.parse_structures()
         chosen_structure = self.final_structure if self.final_structure else self.initial_structure
 
         patterns = {
             "electron_density": r".*ELECTRON_DENSITY.*\.cube.*",
             "spin_density": r".*SPIN_DENSITY.*\.cube.*",
-            "v_hartree": r".*hartree.*\.cube.*"
+            "v_hartree": r".*hartree.*\.cube.*",
         }
 
         # Initialize a variable to hold the type of the cube file
@@ -1647,13 +1649,9 @@ class Cp2kOutput:
             if re.match(pattern, cube_filename, re.IGNORECASE):
                 cube_type = key
                 break
-        pmg_cube=VolumetricData(
-            structure=chosen_structure,
-            data=volumetric_data,
-            distance_matrix=None,
-            data_aug=None)
+        pmg_cube = VolumetricData(structure=chosen_structure, data=volumetric_data, distance_matrix=None, data_aug=None)
 
-        self.data[cube_type]=pmg_cube 
+        self.data[cube_type] = pmg_cube
         return pmg_cube
 
     def as_dict(self):


### PR DESCRIPTION
## Summary
added a function parse_cube() in pymatgen.io.cp2k.output
slight change in parse_initial_structure() ... cp2k output different ...i used cp2k/cp2k-git-feb-2022 to generate outputs....
I have benchmarked the planar average using pymatgen against cubecruncher(https://www.cp2k.org/tools:cubecruncher)... 
These results are in shown in "https://github.com/Sudo-Raheel/cp2k_to_pymatgen/tree/main/cube_file"
Few more points 
1) the documentation should mention that print level should be at least medium in cp2k ..else it wont be able to parse the structure from cp2k.out
2) allow using the phrase "poisson_periodicity" to find whether is_molecule() works only when default poisson solver in cp2k is used . 
