### PR TITLE
Bugfix: `io.pwscf.PWInput.from_str()`

### DIFF
--- a/src/pymatgen/io/pwscf.py
+++ b/src/pymatgen/io/pwscf.py
@@ -291,7 +291,7 @@ class PWInput:
                 if match := re.match(r"(\w+)\(?(\d*?)\)?\s*=\s*(.*)", line):
                     key = match[1].strip()
                     key_ = match[2].strip()
-                    val = match[3].strip()
+                    val = match[3].strip().rstrip(",")
                     if key_ != "":
                         if sections[section].get(key) is None:
                             val_ = [0.0] * 20  # MAX NTYP DEFINITION
@@ -305,7 +305,7 @@ class PWInput:
                         sections[section][key] = PWInput.proc_val(key, val)
 
             elif mode[0] == "pseudo":
-                if match := re.match(r"(\w+)\s+(\d*.\d*)\s+(.*)", line):
+                if match := re.match(r"(\w+\d*\+?-?)\s+(\d*.\d*)\s+(.*)", line):
                     pseudo[match[1].strip()] = match[3].strip()
 
             elif mode[0] == "kpoints":
@@ -317,7 +317,7 @@ class PWInput:
 
             elif mode[0] == "structure":
                 m_l = re.match(r"(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)", line)
-                m_p = re.match(r"(\w+)\s+(-?\d+\.\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)", line)
+                m_p = re.match(r"(\w+\d*\+?-?)\s+(-?\d+\.\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)", line)
                 if m_l:
                     lattice += [
                         float(m_l[1]),

--- a/tests/io/test_pwscf.py
+++ b/tests/io/test_pwscf.py
@@ -375,6 +375,32 @@ CELL_PARAMETERS angstrom
         assert_allclose(lattice, pw_in.structure.lattice.matrix)
         assert pw_in.sections["system"]["smearing"] == "cold"
 
+    def test_write_and_read_str(self):
+        struct = self.get_structure("Graphite")
+        struct.remove_oxidation_states()
+        pw = PWInput(
+            struct,
+            pseudo={"C": "C.pbe-n-kjpaw_psl.1.0.0.UPF"},
+            control={"calculation": "scf", "pseudo_dir": "./"},
+            system={"ecutwfc": 45},
+        )
+        pw_str = str(pw)
+        assert pw_str.strip() == str(PWInput.from_str(pw_str)).strip()
+
+    def test_write_and_read_str_with_oxidation(self):
+        struct = self.get_structure("Li2O")
+        pw = PWInput(
+            struct,
+            control={"calculation": "scf", "pseudo_dir": "./"},
+            pseudo={
+                "Li+": "Li.pbe-n-kjpaw_psl.0.1.UPF",
+                "O2-": "O.pbe-n-kjpaw_psl.0.1.UPF",
+            },
+            system={"ecutwfc": 50},
+        )
+        pw_str = str(pw)
+        assert pw_str.strip() == str(PWInput.from_str(pw_str)).strip()
+
 
 class TestPWOutput(PymatgenTest):
     def setUp(self):


### PR DESCRIPTION
## Summary

Fix wrong parsing in `io.pwscf.PWInput.from_str()` of
- Namelist options ending with comma (`,`), and
- `ATOMIC_SPECIES` and `ATOMIC_POSITIONS` cards for structures with oxidation states,

to close https://github.com/materialsproject/pymatgen/issues/3930