### PR TITLE
[Hot Fix] Fix `setuptools` for pymatgen packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,7 @@ get_environment = "pymatgen.cli.get_environment:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]
-include = ["pymatgen"]
+include = ["pymatgen", "pymatgen.*"]
 
 [tool.setuptools.package-data]
 "pymatgen.analysis" = ["*.yaml", "*.json", "*.csv"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,9 @@ feff_plot_cross_section = "pymatgen.cli.feff_plot_cross_section:main"
 feff_plot_dos = "pymatgen.cli.feff_plot_dos:main"
 get_environment = "pymatgen.cli.get_environment:main"
 
+[tool.setuptools]
+include-package-data = false
+
 [tool.setuptools.packages.find]
 where = ["src"]
 include = ["pymatgen", "pymatgen.*"]

--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -1768,7 +1768,6 @@ class TestStructure(PymatgenTest):
         assert traj[0] != traj[-1]
         assert os.path.isfile(traj_file)
 
-    @pytest.mark.skip("TODO remove skip once https://github.com/materialsvirtuallab/matgl/issues/238 is resolved")
     def test_calculate_m3gnet(self):
         pytest.importorskip("matgl")
         calculator = self.get_structure("Si").calculate()
@@ -1780,7 +1779,6 @@ class TestStructure(PymatgenTest):
         assert np.linalg.norm(calculator.results["forces"]) == approx(7.8123485e-06, abs=0.2)
         assert np.linalg.norm(calculator.results["stress"]) == approx(1.7861567, abs=2)
 
-    @pytest.mark.skip("TODO remove skip once https://github.com/materialsvirtuallab/matgl/issues/238 is resolved")
     def test_relax_m3gnet(self):
         matgl = pytest.importorskip("matgl")
         struct = self.get_structure("Si")
@@ -1791,7 +1789,6 @@ class TestStructure(PymatgenTest):
             actual = relaxed.dynamics[key]
             assert actual == val, f"expected {key} to be {val}, {actual=}"
 
-    @pytest.mark.skip("TODO remove skip once https://github.com/materialsvirtuallab/matgl/issues/238 is resolved")
     def test_relax_m3gnet_fixed_lattice(self):
         matgl = pytest.importorskip("matgl")
         struct = self.get_structure("Si")
@@ -1800,7 +1797,6 @@ class TestStructure(PymatgenTest):
         assert isinstance(relaxed.calc, matgl.ext.ase.M3GNetCalculator)
         assert relaxed.dynamics["optimizer"] == "BFGS"
 
-    @pytest.mark.skip("TODO remove skip once https://github.com/materialsvirtuallab/matgl/issues/238 is resolved")
     def test_relax_m3gnet_with_traj(self):
         pytest.importorskip("matgl")
         struct = self.get_structure("Si")
@@ -2406,8 +2402,6 @@ class TestMolecule(PymatgenTest):
         assert traj[0] != traj[-1]
         assert os.path.isfile(traj_file)
 
-    # TODO remove skip once https://github.com/tblite/tblite/issues/110 is fixed
-    @pytest.mark.skip("Pytorch and TBLite clash. https://github.com/materialsproject/pymatgen/pull/3060")
     def test_calculate_gfnxtb(self):
         pytest.importorskip("tblite")
         mol_copy = self.mol.copy()


### PR DESCRIPTION
### Summary

- A hot fix for #3928, where the `setuptools` in not configured to include the complete `pymatgen` package (all subpackages are missing) after moving to the src layout.
- Turn off `include-package-data`, which [is `true` by default](https://setuptools.pypa.io/en/latest/userguide/datafiles.html), meaning `package-data` is not having any effect and all data files would be included into the package.
- Remove resolved skip tag: https://github.com/materialsproject/pymatgen/blob/02341828b94a001b4f3cbdae6b24eaeeb0df7d7d/tests/core/test_structure.py#L1771

#### Site note

To reliably recreate this issue, one might need to [completely clear build cache](https://setuptools.pypa.io/en/latest/userguide/miscellaneous.html#caching-and-troubleshooting) (removing `build/`, `dist/` and `*.egg-info`), otherwise you might find yourself (me for example) modifying the `pyproject.toml` file but the wheel remains the unchanged.