### PR TITLE
Raise `DeprecationWarning` as errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,6 +83,8 @@ jobs:
           uv pip install --editable '.[${{ matrix.config.extras }}]' --resolution=${{ matrix.config.resolution }}
 
       - name: pytest split ${{ matrix.split }}
+        env:
+          PYTHONWARNINGS: "error::DeprecationWarning"
         run: |
           micromamba activate pmg
           pytest --splits 10 --group ${{ matrix.split }} --durations-path tests/files/.pytest-split-durations tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [
     "networkx>=2.2",
     'numpy>=1.25.0,<2.0 ; platform_system == "Windows"',
     'numpy>=1.25.0 ; platform_system != "Windows"',
-    "palettable>=3.1.1",
+    "palettable>=3.3.3",
     "pandas>=2",
     "plotly>=4.5.0",
     "pybtex>=0.24.0",


### PR DESCRIPTION
### Summary 

- Raise `DeprecationWarning` as errors, which might help us [adapt earlier for deprecation](https://numpy.org/devdocs/dev/depending_on_numpy.html#runtime-dependency-version-ranges)
> Furthermore, we recommend to raise errors on warnings in CI for this job, either all warnings or otherwise at least DeprecationWarning and FutureWarning. This gives you an early warning about changes in NumPy to adapt your code.


- [ ] `Pybtex` would need a new release to fully fix this https://bitbucket.org/pybtex-devs/pybtex/issues/169/replace-pkg_resources-with