### PR TITLE
Add atomic concentrations to hovertext on ternary graphs

### DIFF
--- a/src/pymatgen/analysis/phase_diagram.py
+++ b/src/pymatgen/analysis/phase_diagram.py
@@ -3007,21 +3007,29 @@ class PDPlotter:
                     uncertainties.append(uncertainty)
                     energies.append(energy)
 
-                if self._dim == 3 and self.ternary_style == "2d":
+               if self._dim == 3 and self.ternary_style == "2d":
+                    label += "<br>"
                     total_sum_el = sum(entry.composition[el] for el, axis in zip(self._pd.elements, [x, y, z]))
                     for el, axis in zip(self._pd.elements, [x, y, z]):
                         axis.append(entry.composition[el])
-                        label += f"<br> {el}: {round(entry.composition[el]/total_sum_el, 4)}"
+                        label += f"<br> {el}: {round(entry.composition[el]/total_sum_el, 6)}"
+                elif self._dim == 3 and self.ternary_style =="3d":
+                    label += "<br>"
+                    x.append(coord[0])
+                    y.append(coord[1])
+                    z.append(energy)
+                    
+                    total_sum_el = sum(entry.composition[el] for el, axis2 in zip(self._pd.elements, [x, y, z]))
+                    for el, axis in zip(self._pd.elements, [x, y, z]):
+                        label += f"<br> {el}: {round(entry.composition[el]/total_sum_el, 6)}"
                 else:
                     x.append(coord[0])
                     y.append(coord[1])
 
-                    if self._dim == 3:
-                        z.append(energy)
-                    elif self._dim == 4:
+                    if self._dim == 4: # This check might not be necessary
                         z.append(coord[2])
-
-                texts.append(label)
+                
+                texts.append(label) 
             return {"x": x, "y": y, "z": z, "texts": texts, "energies": energies, "uncertainties": uncertainties}
 
         if highlight_entries is None:

--- a/src/pymatgen/analysis/phase_diagram.py
+++ b/src/pymatgen/analysis/phase_diagram.py
@@ -3020,7 +3020,7 @@ class PDPlotter:
                         z.append(energy)
                     elif self._dim == 4:
                         z.append(coord[2])
-                        
+
                 texts.append(label)
             return {"x": x, "y": y, "z": z, "texts": texts, "energies": energies, "uncertainties": uncertainties}
 

--- a/src/pymatgen/analysis/phase_diagram.py
+++ b/src/pymatgen/analysis/phase_diagram.py
@@ -3018,7 +3018,7 @@ class PDPlotter:
                     x.append(coord[0])
                     y.append(coord[1])
                     z.append(energy)
-                    
+
                     total_sum_el = sum(entry.composition[el] for el, axis2 in zip(self._pd.elements, [x, y, z]))
                     for el, axis in zip(self._pd.elements, [x, y, z]):
                         label += f"<br> {el}: {round(entry.composition[el]/total_sum_el, 6)}"
@@ -3028,8 +3028,8 @@ class PDPlotter:
 
                     if self._dim == 4: # This check might not be necessary
                         z.append(coord[2])
-                
-                texts.append(label) 
+
+                texts.append(label)
             return {"x": x, "y": y, "z": z, "texts": texts, "energies": energies, "uncertainties": uncertainties}
 
         if highlight_entries is None:

--- a/src/pymatgen/analysis/phase_diagram.py
+++ b/src/pymatgen/analysis/phase_diagram.py
@@ -3008,11 +3008,9 @@ class PDPlotter:
                     energies.append(energy)
 
                 if self._dim == 3 and self.ternary_style == "2d":
+                    total_sum_el = sum(entry.composition[el] for el, axis in zip(self._pd.elements, [x, y, z]))
                     for el, axis in zip(self._pd.elements, [x, y, z]):
                         axis.append(entry.composition[el])
-                        total_sum_el = 0
-                        for el2, axis2 in zip(self._pd.elements, [x, y, z]):
-                            total_sum_el += entry.composition[el2]
                         label += f"<br> {el}: {round(entry.composition[el]/total_sum_el, 4)}"
                 else:
                     x.append(coord[0])

--- a/src/pymatgen/analysis/phase_diagram.py
+++ b/src/pymatgen/analysis/phase_diagram.py
@@ -3007,11 +3007,13 @@ class PDPlotter:
                     uncertainties.append(uncertainty)
                     energies.append(energy)
 
-                texts.append(label)
-
                 if self._dim == 3 and self.ternary_style == "2d":
                     for el, axis in zip(self._pd.elements, [x, y, z]):
                         axis.append(entry.composition[el])
+                        total_sum_el = 0
+                        for el2, axis2 in zip(self._pd.elements, [x, y, z]):
+                            total_sum_el += entry.composition[el2]
+                        label += f"<br> {el}: {round(entry.composition[el]/total_sum_el, 4)}"
                 else:
                     x.append(coord[0])
                     y.append(coord[1])
@@ -3020,7 +3022,8 @@ class PDPlotter:
                         z.append(energy)
                     elif self._dim == 4:
                         z.append(coord[2])
-
+                        
+                texts.append(label)
             return {"x": x, "y": y, "z": z, "texts": texts, "energies": energies, "uncertainties": uncertainties}
 
         if highlight_entries is None:


### PR DESCRIPTION
## Summary

- The atomic concentrations of each material in the ternary graph are added to the 2D and 3D ternary graphs for readability.

