### PR TITLE
Fix coordination number bug

### DIFF
--- a/src/pymatgen/analysis/graphs.py
+++ b/src/pymatgen/analysis/graphs.py
@@ -2478,8 +2478,7 @@ class MoleculeGraph(MSONable):
         Returns:
             int: the number of neighbors of site n.
         """
-        n_self_loops = sum(1 for n, v in self.graph.edges(n) if n == v)
-        return self.graph.degree(n) - n_self_loops
+        return self.graph.degree(n)
 
     def draw_graph_to_file(
         self,

--- a/src/pymatgen/analysis/graphs.py
+++ b/src/pymatgen/analysis/graphs.py
@@ -808,8 +808,7 @@ class StructureGraph(MSONable):
         Returns:
             int: number of neighbors of site n.
         """
-        n_self_loops = sum(1 for n, v in self.graph.edges(n) if n == v)
-        return self.graph.degree(n) - n_self_loops
+        return self.graph.degree(n)
 
     def draw_graph_to_file(
         self,

--- a/tests/analysis/test_graphs.py
+++ b/tests/analysis/test_graphs.py
@@ -409,7 +409,7 @@ from    to  to_image
         diff = struct_graph.diff(sg2)
         assert diff["dist"] == 0
 
-        assert self.square_sg.get_coordination_of_site(0) == 2
+        assert self.square_sg.get_coordination_of_site(0) == 4
 
     def test_from_edges(self):
         edges = {


### PR DESCRIPTION
# `StructureGraph.get_coordination_of_site` gives wrong number for small unit cells

Refer to #3888 

The `StructureGraph` object assumes that periodic images of the edges will added twice in the graph so the coordination number algorithm assumes that all self-connections are double-counted.

However, we have updated the definition of the graph such that periodic images of the same edge will only appear once (ie. if `SiteA[0,0,0]--SiteA[0,0,1]` is an edge, we should not see another edge from  `SiteA[0,0,0]--SiteA[0,0,-1]`)

I have also removed the double counting from MoleculeGraph under the assumption that self-connection should never show up in a molecule.

## Modified test assertion value

The two of the edges added here are redundant:
https://github.com/materialsproject/pymatgen/blob/98c57888cc4f17ef4d8692d777ad0d1806ee7ae9/tests/analysis/test_graphs.py#L53-L56

But the coordination number should still be `4` since we have a square lattice.



