### PR TITLE
Fix Incar `check_params` for `Union` type 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,10 +75,9 @@ jobs:
       - name: Install pymatgen and dependencies
         run: |
           micromamba activate pmg
-          # TODO1: remove temporary fix. added since uv install torch is flaky.
+          # TODO remove temporary fix. added since uv install torch is flaky.
           # track https://github.com/astral-sh/uv/issues/1921 for resolution
-          # TODO2: remove touch version pin upon new matgl release
-          pip install torch==2.2.1 --upgrade
+          pip install torch --upgrade
 
           uv pip install numpy cython
           uv pip install --editable '.[${{ matrix.config.extras }}]' --resolution=${{ matrix.config.resolution }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,9 +75,10 @@ jobs:
       - name: Install pymatgen and dependencies
         run: |
           micromamba activate pmg
-          # TODO remove temporary fix. added since uv install torch is flaky.
+          # TODO1: remove temporary fix. added since uv install torch is flaky.
           # track https://github.com/astral-sh/uv/issues/1921 for resolution
-          pip install torch --upgrade
+          # TODO2: remove touch version pin upon new matgl release
+          pip install torch==2.2.1 --upgrade
 
           uv pip install numpy cython
           uv pip install --editable '.[${{ matrix.config.extras }}]' --resolution=${{ matrix.config.resolution }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ classifiers = [
 ]
 dependencies = [
     "matplotlib>=3.8",
-    "monty>=2024.5.24",
+    "monty>=2024.7.29",
     "networkx>=2.2",
     'numpy>=1.25.0,<2.0 ; platform_system == "Windows"',
     'numpy>=1.25.0 ; platform_system != "Windows"',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [
     "networkx>=2.2",
     'numpy>=1.25.0,<2.0 ; platform_system == "Windows"',
     'numpy>=1.25.0 ; platform_system != "Windows"',
-    "palettable>=3.1.1",
+    "palettable>=3.3.3",
     "pandas>=2",
     "plotly>=4.5.0",
     "pybtex>=0.24.0",

--- a/src/pymatgen/io/vasp/incar_parameters.json
+++ b/src/pymatgen/io/vasp/incar_parameters.json
@@ -650,7 +650,7 @@
     "type": "bool"
  },
  "LREAL": {
-   "type": "Union[bool, str]",
+   "type": "(bool, str)",
    "values": [
       false,
       true,

--- a/src/pymatgen/io/vasp/inputs.py
+++ b/src/pymatgen/io/vasp/inputs.py
@@ -1015,10 +1015,6 @@ class Incar(dict, MSONable):
         If a tag doesn't exist, calculation will still run, however VASP
         will ignore the tag and set it as default without letting you know.
         """
-        # Need to import Union to support type checking of "LREAL"
-        # TODO: Use "X | Y" after moving to Python 3.10+, see #3958
-        from typing import Union  # noqa: F401
-
         # Load INCAR tag/value check reference file
         with open(os.path.join(module_dir, "incar_parameters.json"), encoding="utf-8") as json_file:
             incar_params = json.loads(json_file.read())

--- a/src/pymatgen/io/vasp/inputs.py
+++ b/src/pymatgen/io/vasp/inputs.py
@@ -1015,6 +1015,31 @@ class Incar(dict, MSONable):
         If a tag doesn't exist, calculation will still run, however VASP
         will ignore the tag and set it as default without letting you know.
         """
+
+        def check_param_type(val: Any, expected_type: str) -> bool:
+            """Check if the type of a VASP tag matches its expected type.
+
+            Args:
+                val (Any): The values of the VASP tag to check.
+                expected_type (str): Expected type of the tag.
+
+            Returns:
+                bool
+            """
+            current_type: str = type(val).__name__
+
+            if expected_type in {"int", "float", "str", "list", "bool"}:
+                return current_type == expected_type
+
+            if expected_type.startswith("Union"):
+                return current_type in expected_type.removeprefix("Union[").removesuffix("]").replace(" ", "").split(
+                    ","
+                )
+
+            # Let unrecored type pass the test
+            warnings.warn(f"Update the code to handle composite type {expected_type}.", stacklevel=2)
+            return True
+
         # Load INCAR tag/value check reference file
         with open(os.path.join(module_dir, "incar_parameters.json"), encoding="utf-8") as json_file:
             incar_params = json.loads(json_file.read())
@@ -1029,7 +1054,7 @@ class Incar(dict, MSONable):
             param_type = incar_params[tag].get("type")
             allowed_values = incar_params[tag].get("values")
 
-            if param_type is not None and type(val).__name__ != param_type:
+            if param_type is not None and not check_param_type(val, param_type):
                 warnings.warn(f"{tag}: {val} is not a {param_type}", BadIncarWarning, stacklevel=2)
 
             # Only check value when it's not None,

--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -1768,6 +1768,7 @@ class TestStructure(PymatgenTest):
         assert traj[0] != traj[-1]
         assert os.path.isfile(traj_file)
 
+    @pytest.mark.skip("TODO: #3958 wait for matgl resolve of torch dependency")
     def test_calculate_m3gnet(self):
         pytest.importorskip("matgl")
         calculator = self.get_structure("Si").calculate()
@@ -1779,6 +1780,7 @@ class TestStructure(PymatgenTest):
         assert np.linalg.norm(calculator.results["forces"]) == approx(7.8123485e-06, abs=0.2)
         assert np.linalg.norm(calculator.results["stress"]) == approx(1.7861567, abs=2)
 
+    @pytest.mark.skip("TODO: #3958 wait for matgl resolve of torch dependency")
     def test_relax_m3gnet(self):
         matgl = pytest.importorskip("matgl")
         struct = self.get_structure("Si")
@@ -1789,6 +1791,7 @@ class TestStructure(PymatgenTest):
             actual = relaxed.dynamics[key]
             assert actual == val, f"expected {key} to be {val}, {actual=}"
 
+    @pytest.mark.skip("TODO: #3958 wait for matgl resolve of torch dependency")
     def test_relax_m3gnet_fixed_lattice(self):
         matgl = pytest.importorskip("matgl")
         struct = self.get_structure("Si")
@@ -1797,6 +1800,7 @@ class TestStructure(PymatgenTest):
         assert isinstance(relaxed.calc, matgl.ext.ase.M3GNetCalculator)
         assert relaxed.dynamics["optimizer"] == "BFGS"
 
+    @pytest.mark.skip("TODO: #3958 wait for matgl resolve of torch dependency")
     def test_relax_m3gnet_with_traj(self):
         pytest.importorskip("matgl")
         struct = self.get_structure("Si")

--- a/tests/io/vasp/test_inputs.py
+++ b/tests/io/vasp/test_inputs.py
@@ -784,7 +784,7 @@ SIGMA = 0.1"""
             )
             incar.check_params()
 
-        assert record[0].message.args[0] == "Cannot find NBAND in the list of INCAR tags", record[0].message.args[0]
+        assert record[0].message.args[0] == "Cannot find NBAND in the list of INCAR tags"
         assert record[1].message.args[0] == "METAGGA: Cannot find SCAM in the list of values"
         assert record[2].message.args[0] == "EDIFF: (5+1j) is not a float"
         assert record[3].message.args[0] == "ISIF: Cannot find 9 in the list of values"

--- a/tests/io/vasp/test_inputs.py
+++ b/tests/io/vasp/test_inputs.py
@@ -773,7 +773,7 @@ SIGMA = 0.1"""
                     "AMIN": 0.01,
                     "ICHARG": 1,
                     "MAGMOM": [1, 2, 4, 5],
-                    "LREAL": True,
+                    "LREAL": True,  # special case: Union type
                     "NBAND": 250,  # typo in tag
                     "METAGGA": "SCAM",  # typo in value
                     "EDIFF": 5 + 1j,  # value should be a float

--- a/tests/io/vasp/test_inputs.py
+++ b/tests/io/vasp/test_inputs.py
@@ -773,6 +773,7 @@ SIGMA = 0.1"""
                     "AMIN": 0.01,
                     "ICHARG": 1,
                     "MAGMOM": [1, 2, 4, 5],
+                    "LREAL": True,
                     "NBAND": 250,  # typo in tag
                     "METAGGA": "SCAM",  # typo in value
                     "EDIFF": 5 + 1j,  # value should be a float
@@ -783,7 +784,7 @@ SIGMA = 0.1"""
             )
             incar.check_params()
 
-        assert record[0].message.args[0] == "Cannot find NBAND in the list of INCAR tags"
+        assert record[0].message.args[0] == "Cannot find NBAND in the list of INCAR tags", record[0].message.args[0]
         assert record[1].message.args[0] == "METAGGA: Cannot find SCAM in the list of values"
         assert record[2].message.args[0] == "EDIFF: (5+1j) is not a float"
         assert record[3].message.args[0] == "ISIF: Cannot find 9 in the list of values"


### PR DESCRIPTION
### Summary

- Fix Incar `check_params` for `Union` type, to fix #3957, changed `incar_parameters.json` of Union type to use `isinstance` syntax directly. Otherwise Python 3.9 Windows don't support type checking with `isinstance(data, Union[str, float])`.

    **Would appreciate it if anyone has smarted way to resolve this!**

- Bump `palettable` version to remove dependency of `setuptools` https://github.com/jiffyclub/palettable/pull/46



