### PR TITLE
Don't run `issue-metrics` on forks

### DIFF
--- a/.github/workflows/issue-metrics.yml
+++ b/.github/workflows/issue-metrics.yml
@@ -9,6 +9,8 @@ permissions:
 
 jobs:
   build:
+    # prevent this action from running on forks
+    if: github.repository == 'materialsproject/pymatgen'
     name: issue metrics
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

Major changes:

- `issue-metrics` should not be run on forks because it can't create a new issue on the fork anyway.