### PR TITLE
switch to attr access interface for transformation matrix

### DIFF
--- a/src/pymatgen/core/tensors.py
+++ b/src/pymatgen/core/tensors.py
@@ -413,7 +413,7 @@ class Tensor(np.ndarray, MSONable):
         # Check conventional setting:
         sga = SpacegroupAnalyzer(structure)
         dataset = sga.get_symmetry_dataset()
-        trans_mat = dataset["transformation_matrix"]
+        trans_mat = dataset.transformation_matrix
         conv_latt = Lattice(np.transpose(np.dot(np.transpose(structure.lattice.matrix), np.linalg.inv(trans_mat))))
         xtal_sys = sga.get_crystal_system()
 


### PR DESCRIPTION
an attr access interface change was missed in Tensor when spglib was upgraded to >=2.5.0 (#3923)

spglib throws the following deprecation warning currently:
`DeprecationWarning: dict interface (SpglibDataset['transformation_matrix']) is deprecated.Use attribute interface ({self.__class__.__name__}.{key}) instead`