### PR TITLE
Fix import sorting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ ci:
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.4
+    rev: v0.5.6
     hooks:
       - id: ruff
         args: [ --fix, --unsafe-fixes ]
@@ -22,7 +22,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.0
+    rev: v1.11.1
     hooks:
       - id: mypy
 
@@ -65,6 +65,6 @@ repos:
         args: [ --drop-empty-cells, --keep-output ]
 
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.373
+    rev: v1.1.374
     hooks:
       - id: pyright

--- a/dev_scripts/chemenv/explicit_permutations.py
+++ b/dev_scripts/chemenv/explicit_permutations.py
@@ -10,6 +10,7 @@ import json
 import os
 
 import numpy as np
+
 from pymatgen.analysis.chemenv.coordination_environments.coordination_geometries import (
     AllCoordinationGeometries,
     ExplicitPermutationsAlgorithm,

--- a/dev_scripts/chemenv/explicit_permutations_plane_algorithm.py
+++ b/dev_scripts/chemenv/explicit_permutations_plane_algorithm.py
@@ -9,6 +9,7 @@ import itertools
 import json
 
 import numpy as np
+
 from pymatgen.analysis.chemenv.coordination_environments.coordination_geometries import AllCoordinationGeometries
 from pymatgen.analysis.chemenv.coordination_environments.coordination_geometry_finder import (
     AbstractGeometry,

--- a/dev_scripts/chemenv/get_plane_permutations_optimized.py
+++ b/dev_scripts/chemenv/get_plane_permutations_optimized.py
@@ -15,6 +15,7 @@ from random import shuffle
 
 import numpy as np
 import tabulate
+
 from pymatgen.analysis.chemenv.coordination_environments.coordination_geometries import AllCoordinationGeometries
 from pymatgen.analysis.chemenv.coordination_environments.coordination_geometry_finder import (
     AbstractGeometry,

--- a/dev_scripts/chemenv/strategies/multi_weights_strategy_parameters.py
+++ b/dev_scripts/chemenv/strategies/multi_weights_strategy_parameters.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 import matplotlib.pyplot as plt
 import numpy as np
+
 from pymatgen.analysis.chemenv.coordination_environments.chemenv_strategies import (
     AngleNbSetWeight,
     CNBiasNbSetWeight,

--- a/dev_scripts/chemenv/test_algos.py
+++ b/dev_scripts/chemenv/test_algos.py
@@ -8,6 +8,7 @@ from math import factorial
 from random import shuffle
 
 import numpy as np
+
 from pymatgen.analysis.chemenv.coordination_environments.coordination_geometries import AllCoordinationGeometries
 from pymatgen.analysis.chemenv.coordination_environments.coordination_geometry_finder import (
     AbstractGeometry,

--- a/dev_scripts/chemenv/view_environment.py
+++ b/dev_scripts/chemenv/view_environment.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import numpy as np
+
 from pymatgen.analysis.chemenv.coordination_environments.coordination_geometries import (
     SEPARATION_PLANE,
     AllCoordinationGeometries,

--- a/dev_scripts/potcar_scrambler.py
+++ b/dev_scripts/potcar_scrambler.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 from monty.os.path import zpath
 from monty.serialization import zopen
+
 from pymatgen.core import SETTINGS
 from pymatgen.io.vasp import Potcar, PotcarSingle
 from pymatgen.io.vasp.sets import _load_yaml_config

--- a/dev_scripts/update_pt_data.py
+++ b/dev_scripts/update_pt_data.py
@@ -11,8 +11,9 @@ from itertools import product
 import requests
 from monty.dev import requires
 from monty.serialization import dumpfn, loadfn
-from pymatgen.core import Element, get_el_sp
 from ruamel import yaml
+
+from pymatgen.core import Element, get_el_sp
 
 try:
     from bs4 import BeautifulSoup

--- a/dev_scripts/update_spacegroup_data.py
+++ b/dev_scripts/update_spacegroup_data.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import sys
 
 from monty.serialization import dumpfn, loadfn
+
 from pymatgen.symmetry.groups import PointGroup
 
 __author__ = "Katharina Ueltzen @kaueltzen"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,13 +10,11 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pymatgen"
-authors = [
-    { name = "Pymatgen Development Team", email = "ongsp@ucsd.edu" },
-]
+authors = [{ name = "Pymatgen Development Team", email = "ongsp@ucsd.edu" }]
 maintainers = [
-    { name = "Shyue Ping Ong", email = "ongsp@ucsd.edu" },
-    { name = "Matthew Horton", email = "m.k.horton@gmail.com" },
     { name = "Janosh Riebesell", email = "janosh.riebesell@gmail.com" },
+    { name = "Matthew Horton", email = "m.k.horton@gmail.com" },
+    { name = "Shyue Ping Ong", email = "ongsp@ucsd.edu" },
 ]
 description = """
 Python Materials Genomics is a robust materials analysis code that defines core object representations for structures
@@ -26,6 +24,7 @@ readme = "README.md"
 requires-python = ">=3.9"
 keywords = [
     "ABINIT",
+    "VASP",
     "analysis",
     "crystal",
     "diagrams",
@@ -38,7 +37,6 @@ keywords = [
     "qchem",
     "science",
     "structure",
-    "VASP",
 ]
 license = { text = "MIT" }
 classifiers = [
@@ -46,22 +44,21 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
     "Topic :: Scientific/Engineering :: Chemistry",
     "Topic :: Scientific/Engineering :: Information Analysis",
     "Topic :: Scientific/Engineering :: Physics",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
+    "joblib>=1",
     "matplotlib>=3.8",
     "monty>=2024.5.24",
     "networkx>=2.2",
-    'numpy>=1.25.0,<2.0 ; platform_system == "Windows"',
-    'numpy>=1.25.0 ; platform_system != "Windows"',
     "palettable>=3.1.1",
     "pandas>=2",
     "plotly>=4.5.0",
@@ -74,7 +71,8 @@ dependencies = [
     "tabulate>=0.9",
     "tqdm>=4.60",
     "uncertainties>=3.1.4",
-    "joblib>=1",
+    'numpy>=1.25.0 ; platform_system != "Windows"',
+    'numpy>=1.25.0,<2.0 ; platform_system == "Windows"',
 ]
 version = "2024.7.18"
 
@@ -91,17 +89,10 @@ ase = ["ase>=3.23.0"]
 tblite = ["tblite[ase]>=0.3.0; python_version<'3.12'"]
 vis = ["vtk>=6.0.0"]
 abinit = ["netcdf4>=1.6.5"]
-mlp = ["matgl>=1.1.1", "chgnet>=0.3.8"]
+mlp = ["chgnet>=0.3.8", "matgl>=1.1.1"]
 electronic_structure = ["fdint>=2.0.2"]
-ci = [
-    "pytest>=8",
-    "pytest-cov>=4",
-    "pytest-split>=0.8",
-]
-docs = [
-    "sphinx",
-    "sphinx_rtd_theme",
-]
+ci = ["pytest-cov>=4", "pytest-split>=0.8", "pytest>=8"]
+docs = ["sphinx", "sphinx_rtd_theme"]
 optional = [
     "ase>=3.23.0",
     # TODO restore BoltzTraP2 when install fixed, hopefully following merge of
@@ -139,7 +130,7 @@ where = ["src"]
 include = ["pymatgen", "pymatgen.*"]
 
 [tool.setuptools.package-data]
-"pymatgen.analysis" = ["*.yaml", "*.json", "*.csv"]
+"pymatgen.analysis" = ["*.csv", "*.json", "*.yaml"]
 "pymatgen.analysis.chemenv" = [
     "coordination_environments/coordination_geometries_files/*.json",
     "coordination_environments/coordination_geometries_files/*.txt",
@@ -152,27 +143,19 @@ include = ["pymatgen", "pymatgen.*"]
 "pymatgen.entries" = ["*.json.gz", "*.yaml", "data/*.json"]
 "pymatgen.core" = ["*.json"]
 "pymatgen" = ["py.typed"]
-"pymatgen.io.vasp" = ["*.yaml", "*.json", "*.json.gz", "*.json.bz2"]
+"pymatgen.io.vasp" = ["*.json", "*.json.bz2", "*.json.gz", "*.yaml"]
 "pymatgen.io.feff" = ["*.yaml"]
 "pymatgen.io.cp2k" = ["*.yaml"]
 "pymatgen.io.lobster" = ["lobster_basis/*.yaml"]
 "pymatgen.command_line" = ["*"]
-"pymatgen.util" = ["structures/*.json", "*.json"]
+"pymatgen.util" = ["*.json", "structures/*.json"]
 "pymatgen.vis" = ["*.yaml"]
 "pymatgen.io.lammps" = ["CoeffsDataType.yaml", "templates/*.template"]
-"pymatgen.symmetry" = ["*.yaml", "*.json", "*.sqlite"]
+"pymatgen.symmetry" = ["*.json", "*.sqlite", "*.yaml"]
 
 [tool.pdm.dev-dependencies]
-lint = [
-    "mypy>=1.10.0",
-    "ruff>=0.4.9",
-    "pre-commit>=3.7.1",
-]
-test = [
-    "pytest>=8.2.2",
-    "pytest-cov>=5.0.0",
-    "pytest-split>=0.9.0",
-]
+lint = ["mypy>=1.10.0", "pre-commit>=3.7.1", "ruff>=0.4.9"]
+test = ["pytest-cov>=5.0.0", "pytest-split>=0.9.0", "pytest>=8.2.2"]
 
 [tool.versioningit.vcs]
 method = "git"
@@ -193,56 +176,57 @@ line-length = 120
 [tool.ruff.lint]
 select = ["ALL"]
 ignore = [
-  # Rule families
-  "ANN",  # flake8-annotations (not ready, require types for ALL args)
-  "ARG",  # Check for unused function arguments
-  "BLE",  # General catch of Exception
-  "C90",  # Check for functions with a high McCabe complexity
-  "COM",  # flake8-commas (conflict with line wrapper)
-  "CPY",  # Missing copyright notice at top of file (need preview mode)
-  "EM",   # Format nice error messages
-  "ERA",  # Check for commented-out code
-  "FIX",  # Check for FIXME, TODO and other developer notes
-  "FURB", # refurb (need preview mode, too many preview errors)
-  "G",    # validate logging format strings
-  "INP",  # Ban PEP-420 implicit namespace packages
-  "N",    # pep8-naming (many var/arg names are intended)
-  "NPY",  # NumPy-specific rules (TODO: enable this)
-  "PTH",  # Prefer pathlib over os.path
-  "S",    # flake8-bandit (TODO: enable this)
-  "SLF",  # Access "private" class members
-  "T20",  # Check for print/pprint
-  "TD",   # TODO tags related
+    # Rule families
+    "ANN",  # flake8-annotations (not ready, require types for ALL args)
+    "ARG",  # Check for unused function arguments
+    "BLE",  # General catch of Exception
+    "C90",  # Check for functions with a high McCabe complexity
+    "COM",  # flake8-commas (conflict with line wrapper)
+    "CPY",  # Missing copyright notice at top of file (need preview mode)
+    "EM",   # Format nice error messages
+    "ERA",  # Check for commented-out code
+    "FIX",  # Check for FIXME, TODO and other developer notes
+    "FURB", # refurb (need preview mode, too many preview errors)
+    "G",    # validate logging format strings
+    "INP",  # Ban PEP-420 implicit namespace packages
+    "N",    # pep8-naming (many var/arg names are intended)
+    "NPY",  # NumPy-specific rules (TODO: enable this)
+    "PTH",  # Prefer pathlib over os.path
+    "S",    # flake8-bandit (TODO: enable this)
+    "SLF",  # Access "private" class members
+    "T20",  # Check for print/pprint
+    "TD",   # TODO tags related
 
-  # Single rules
-  "B023",    # Function definition does not bind loop variable
-  "B028",    # No explicit stacklevel keyword argument found
-  "B904",    # Within an except clause, raise exceptions with ...
-  "C408",    # unnecessary-collection-call
-  "D105",    # Missing docstring in magic method
-  "D205",    # 1 blank line required between summary line and description
-  "D212",    # Multi-line docstring summary should start at the first line
-  "DTZ003",  # TODO: fix this (issue #3791)
-  "FBT001",  # Boolean-typed positional argument in function definition
-  "FBT002",  # Boolean default positional argument in function
-  "PD901",   # pandas-df-variable-name
-  "PERF203", # try-except-in-loop
-  "PERF401", # manual-list-comprehension
-  "PLR0911", # too many return statements
-  "PLR0912", # too many branches
-  "PLR0913", # too many arguments
-  "PLR0915", # too many statements
-  "PLR2004", # magic values in comparison
-  "PLW2901", # Outer for loop variable overwritten by inner assignment target
-  "PT013",   # pytest-incorrect-pytest-import
-  "SIM105",  # Use contextlib.suppress() instead of try-except-pass
-  "TRY003",  # Avoid specifying long messages outside the exception class
-  "TRY300",  # Checks for return statements in try blocks
-  "TRY301",  # Checks for raise statements within try blocks
+    # Single rules
+    "B023",    # Function definition does not bind loop variable
+    "B028",    # No explicit stacklevel keyword argument found
+    "B904",    # Within an except clause, raise exceptions with ...
+    "C408",    # unnecessary-collection-call
+    "D105",    # Missing docstring in magic method
+    "D205",    # 1 blank line required between summary line and description
+    "D212",    # Multi-line docstring summary should start at the first line
+    "DTZ003",  # TODO: fix this (issue #3791)
+    "FBT001",  # Boolean-typed positional argument in function definition
+    "FBT002",  # Boolean default positional argument in function
+    "PD901",   # pandas-df-variable-name
+    "PERF203", # try-except-in-loop
+    "PERF401", # manual-list-comprehension
+    "PLR0911", # too many return statements
+    "PLR0912", # too many branches
+    "PLR0913", # too many arguments
+    "PLR0915", # too many statements
+    "PLR2004", # magic values in comparison
+    "PLW2901", # Outer for loop variable overwritten by inner assignment target
+    "PT013",   # pytest-incorrect-pytest-import
+    "SIM105",  # Use contextlib.suppress() instead of try-except-pass
+    "TRY003",  # Avoid specifying long messages outside the exception class
+    "TRY300",  # Checks for return statements in try blocks
+    "TRY301",  # Checks for raise statements within try blocks
 ]
 pydocstyle.convention = "google"
 isort.required-imports = ["from __future__ import annotations"]
 isort.split-on-trailing-comma = false
+isort.known-first-party = ["pymatgen"]
 
 [tool.ruff.format]
 docstring-code-format = true

--- a/src/pymatgen/alchemy/filters.py
+++ b/src/pymatgen/alchemy/filters.py
@@ -7,13 +7,15 @@ from collections import defaultdict
 from typing import TYPE_CHECKING
 
 from monty.json import MSONable
+
 from pymatgen.analysis.structure_matcher import ElementComparator, StructureMatcher
 from pymatgen.core import get_el_sp
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 
 if TYPE_CHECKING:
-    from pymatgen.core import Structure
     from typing_extensions import Self
+
+    from pymatgen.core import Structure
 
 
 class AbstractStructureFilter(MSONable, abc.ABC):

--- a/src/pymatgen/alchemy/materials.py
+++ b/src/pymatgen/alchemy/materials.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 from warnings import warn
 
 from monty.json import MSONable, jsanitize
+
 from pymatgen.core.structure import Structure
 from pymatgen.io.cif import CifParser
 from pymatgen.io.vasp.inputs import Poscar
@@ -23,8 +24,9 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
     from typing import Any
 
-    from pymatgen.alchemy.filters import AbstractStructureFilter
     from typing_extensions import Self
+
+    from pymatgen.alchemy.filters import AbstractStructureFilter
 
 
 class TransformedStructure(MSONable):

--- a/src/pymatgen/alchemy/transmuters.py
+++ b/src/pymatgen/alchemy/transmuters.py
@@ -21,8 +21,9 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
     from typing import Callable
 
-    from pymatgen.alchemy.filters import AbstractStructureFilter
     from typing_extensions import Self
+
+    from pymatgen.alchemy.filters import AbstractStructureFilter
 
 __author__ = "Shyue Ping Ong, Will Richards"
 __copyright__ = "Copyright 2012, The Materials Project"

--- a/src/pymatgen/analysis/adsorption.py
+++ b/src/pymatgen/analysis/adsorption.py
@@ -12,6 +12,8 @@ import numpy as np
 from matplotlib import patches
 from matplotlib.path import Path
 from monty.serialization import loadfn
+from scipy.spatial import Delaunay
+
 from pymatgen import vis
 from pymatgen.analysis.local_env import VoronoiNN
 from pymatgen.analysis.structure_matcher import StructureMatcher
@@ -20,13 +22,13 @@ from pymatgen.core.operations import SymmOp
 from pymatgen.core.surface import generate_all_slabs
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.util.coord import in_coord_list_pbc
-from scipy.spatial import Delaunay
 
 if TYPE_CHECKING:
     import matplotlib.pyplot as plt
     from numpy.typing import ArrayLike
-    from pymatgen.core.surface import Slab
     from typing_extensions import Self
+
+    from pymatgen.core.surface import Slab
 
 __author__ = "Joseph Montoya"
 __copyright__ = "Copyright 2016, The Materials Project"

--- a/src/pymatgen/analysis/bond_dissociation.py
+++ b/src/pymatgen/analysis/bond_dissociation.py
@@ -8,6 +8,7 @@ from typing import cast
 
 import networkx as nx
 from monty.json import MSONable
+
 from pymatgen.analysis.fragmenter import open_ring
 from pymatgen.analysis.graphs import MoleculeGraph, MolGraphSplitError
 from pymatgen.analysis.local_env import OpenBabelNN

--- a/src/pymatgen/analysis/bond_valence.py
+++ b/src/pymatgen/analysis/bond_valence.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from monty.serialization import loadfn
+
 from pymatgen.core import Element, Species, get_el_sp
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 

--- a/src/pymatgen/analysis/chemenv/connectivity/connected_components.py
+++ b/src/pymatgen/analysis/chemenv/connectivity/connected_components.py
@@ -13,6 +13,7 @@ from matplotlib.patches import Circle, FancyArrowPatch
 from monty.json import MSONable, jsanitize
 from networkx.algorithms.components import is_connected
 from networkx.algorithms.traversal import bfs_tree
+
 from pymatgen.analysis.chemenv.connectivity.environment_nodes import EnvironmentNode
 from pymatgen.analysis.chemenv.utils.chemenv_errors import ChemenvError
 from pymatgen.analysis.chemenv.utils.graph_utils import get_delta

--- a/src/pymatgen/analysis/chemenv/connectivity/connectivity_finder.py
+++ b/src/pymatgen/analysis/chemenv/connectivity/connectivity_finder.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 
 import numpy as np
+
 from pymatgen.analysis.chemenv.connectivity.structure_connectivity import StructureConnectivity
 
 __author__ = "David Waroquiers"

--- a/src/pymatgen/analysis/chemenv/connectivity/structure_connectivity.py
+++ b/src/pymatgen/analysis/chemenv/connectivity/structure_connectivity.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 import networkx as nx
 import numpy as np
 from monty.json import MSONable, jsanitize
+
 from pymatgen.analysis.chemenv.connectivity.connected_components import ConnectedComponent
 from pymatgen.analysis.chemenv.connectivity.environment_nodes import get_environment_node
 from pymatgen.analysis.chemenv.coordination_environments.structure_environments import LightStructureEnvironments

--- a/src/pymatgen/analysis/chemenv/coordination_environments/chemenv_strategies.py
+++ b/src/pymatgen/analysis/chemenv/coordination_environments/chemenv_strategies.py
@@ -13,6 +13,8 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from monty.json import MSONable
+from scipy.stats import gmean
+
 from pymatgen.analysis.chemenv.coordination_environments.coordination_geometries import AllCoordinationGeometries
 from pymatgen.analysis.chemenv.coordination_environments.voronoi import DetailedVoronoiContainer
 from pymatgen.analysis.chemenv.utils.chemenv_errors import EquivalentSiteSearchError
@@ -27,7 +29,6 @@ from pymatgen.analysis.chemenv.utils.func_utils import (
 from pymatgen.core.operations import SymmOp
 from pymatgen.core.sites import PeriodicSite
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
-from scipy.stats import gmean
 
 if TYPE_CHECKING:
     from typing import ClassVar

--- a/src/pymatgen/analysis/chemenv/coordination_environments/coordination_geometry_finder.py
+++ b/src/pymatgen/analysis/chemenv/coordination_environments/coordination_geometry_finder.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from numpy.linalg import norm, svd
+
 from pymatgen.analysis.bond_valence import BVAnalyzer
 from pymatgen.analysis.chemenv.coordination_environments.chemenv_strategies import MultiWeightsChemenvStrategy
 from pymatgen.analysis.chemenv.coordination_environments.coordination_geometries import (

--- a/src/pymatgen/analysis/chemenv/coordination_environments/structure_environments.py
+++ b/src/pymatgen/analysis/chemenv/coordination_environments/structure_environments.py
@@ -17,6 +17,7 @@ from matplotlib.colors import Normalize
 from matplotlib.gridspec import GridSpec
 from matplotlib.patches import Polygon
 from monty.json import MontyDecoder, MSONable, jsanitize
+
 from pymatgen.analysis.chemenv.coordination_environments.coordination_geometries import AllCoordinationGeometries
 from pymatgen.analysis.chemenv.coordination_environments.voronoi import DetailedVoronoiContainer
 from pymatgen.analysis.chemenv.utils.chemenv_errors import ChemenvError

--- a/src/pymatgen/analysis/chemenv/coordination_environments/voronoi.py
+++ b/src/pymatgen/analysis/chemenv/coordination_environments/voronoi.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING
 import matplotlib.pyplot as plt
 import numpy as np
 from monty.json import MSONable
+from scipy.spatial import Voronoi
+
 from pymatgen.analysis.chemenv.utils.coordination_geometry_utils import (
     get_lower_and_upper_f,
     rectangle_surface_intersection,
@@ -18,7 +20,6 @@ from pymatgen.analysis.chemenv.utils.defs_utils import AdditionalConditions
 from pymatgen.analysis.chemenv.utils.math_utils import normal_cdf_step
 from pymatgen.core.sites import PeriodicSite
 from pymatgen.core.structure import Structure
-from scipy.spatial import Voronoi
 
 if TYPE_CHECKING:
     from typing_extensions import Self

--- a/src/pymatgen/analysis/chemenv/utils/coordination_geometry_utils.py
+++ b/src/pymatgen/analysis/chemenv/utils/coordination_geometry_utils.py
@@ -7,10 +7,11 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from numpy.linalg import norm
-from pymatgen.analysis.chemenv.utils.chemenv_errors import SolidAngleError
 from scipy.integrate import quad
 from scipy.interpolate import UnivariateSpline
 from scipy.spatial import ConvexHull
+
+from pymatgen.analysis.chemenv.utils.chemenv_errors import SolidAngleError
 
 if TYPE_CHECKING:
     from typing import Callable

--- a/src/pymatgen/analysis/chemenv/utils/func_utils.py
+++ b/src/pymatgen/analysis/chemenv/utils/func_utils.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import numpy as np
+
 from pymatgen.analysis.chemenv.utils.math_utils import (
     power2_decreasing_exp,
     power2_inverse_decreasing,

--- a/src/pymatgen/analysis/chemenv/utils/scripts_utils.py
+++ b/src/pymatgen/analysis/chemenv/utils/scripts_utils.py
@@ -6,6 +6,7 @@ import re
 from typing import TYPE_CHECKING
 
 import numpy as np
+
 from pymatgen.analysis.chemenv.coordination_environments.chemenv_strategies import (
     SimpleAbundanceChemenvStrategy,
     SimplestChemenvStrategy,

--- a/src/pymatgen/analysis/chempot_diagram.py
+++ b/src/pymatgen/analysis/chempot_diagram.py
@@ -33,12 +33,13 @@ import numpy as np
 import plotly.express as px
 from monty.json import MSONable
 from plotly.graph_objects import Figure, Mesh3d, Scatter, Scatter3d
+from scipy.spatial import ConvexHull, HalfspaceIntersection
+
 from pymatgen.analysis.phase_diagram import PDEntry, PhaseDiagram
 from pymatgen.core.composition import Composition, Element
 from pymatgen.util.coord import Simplex
 from pymatgen.util.due import Doi, due
 from pymatgen.util.string import htmlify
-from scipy.spatial import ConvexHull, HalfspaceIntersection
 
 if TYPE_CHECKING:
     from pymatgen.entries.computed_entries import ComputedEntry

--- a/src/pymatgen/analysis/cost.py
+++ b/src/pymatgen/analysis/cost.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING
 
 import scipy.constants as const
 from monty.design_patterns import singleton
+
 from pymatgen.analysis.phase_diagram import PDEntry, PhaseDiagram
 from pymatgen.core import Composition, Element
 from pymatgen.util.provenance import is_valid_bibtex

--- a/src/pymatgen/analysis/diffraction/core.py
+++ b/src/pymatgen/analysis/diffraction/core.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 import matplotlib.pyplot as plt
 import numpy as np
+
 from pymatgen.core.spectrum import Spectrum
 from pymatgen.util.plotting import add_fig_kwargs, pretty_plot
 

--- a/src/pymatgen/analysis/diffraction/neutron.py
+++ b/src/pymatgen/analysis/diffraction/neutron.py
@@ -8,6 +8,7 @@ from math import asin, cos, degrees, pi, radians, sin
 from typing import TYPE_CHECKING
 
 import numpy as np
+
 from pymatgen.analysis.diffraction.core import (
     AbstractDiffractionPatternCalculator,
     DiffractionPattern,

--- a/src/pymatgen/analysis/diffraction/tem.py
+++ b/src/pymatgen/analysis/diffraction/tem.py
@@ -11,6 +11,7 @@ import numpy as np
 import pandas as pd
 import plotly.graph_objects as go
 import scipy.constants as sc
+
 from pymatgen.analysis.diffraction.core import AbstractDiffractionPatternCalculator
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.util.string import latexify_spacegroup, unicodeify_spacegroup
@@ -18,6 +19,7 @@ from pymatgen.util.typing import Tuple3Ints
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
+
     from pymatgen.core import Structure
 
 __author__ = "Frank Wan, Jason Liang"

--- a/src/pymatgen/analysis/diffraction/xrd.py
+++ b/src/pymatgen/analysis/diffraction/xrd.py
@@ -8,6 +8,7 @@ from math import asin, cos, degrees, pi, radians, sin
 from typing import TYPE_CHECKING
 
 import numpy as np
+
 from pymatgen.analysis.diffraction.core import (
     AbstractDiffractionPatternCalculator,
     DiffractionPattern,

--- a/src/pymatgen/analysis/dimensionality.py
+++ b/src/pymatgen/analysis/dimensionality.py
@@ -29,6 +29,7 @@ from collections import defaultdict
 import networkx as nx
 import numpy as np
 from networkx.readwrite import json_graph
+
 from pymatgen.analysis.graphs import MoleculeGraph, StructureGraph
 from pymatgen.analysis.local_env import JmolNN
 from pymatgen.analysis.structure_analyzer import get_max_bond_lengths

--- a/src/pymatgen/analysis/elasticity/elastic.py
+++ b/src/pymatgen/analysis/elasticity/elastic.py
@@ -13,22 +13,24 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import sympy as sp
+from scipy.integrate import quad
+from scipy.optimize import root
+from scipy.special import factorial
+
 from pymatgen.analysis.elasticity.strain import Strain
 from pymatgen.analysis.elasticity.stress import Stress
 from pymatgen.core.tensors import DEFAULT_QUAD, SquareTensor, Tensor, TensorCollection, get_uvec
 from pymatgen.core.units import Unit
 from pymatgen.util.due import Doi, due
-from scipy.integrate import quad
-from scipy.optimize import root
-from scipy.special import factorial
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from typing import Literal
 
     from numpy.typing import ArrayLike
-    from pymatgen.core import Structure
     from typing_extensions import Self
+
+    from pymatgen.core import Structure
 
 
 __author__ = "Joseph Montoya"

--- a/src/pymatgen/analysis/elasticity/strain.py
+++ b/src/pymatgen/analysis/elasticity/strain.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import scipy
+
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.tensors import SquareTensor, symmetry_reduce
 
@@ -20,8 +21,9 @@ if TYPE_CHECKING:
     from typing import Literal
 
     from numpy.typing import ArrayLike
-    from pymatgen.core.structure import Structure
     from typing_extensions import Self
+
+    from pymatgen.core.structure import Structure
 
 __author__ = "Joseph Montoya"
 __copyright__ = "Copyright 2012, The Materials Project"

--- a/src/pymatgen/analysis/elasticity/stress.py
+++ b/src/pymatgen/analysis/elasticity/stress.py
@@ -9,6 +9,7 @@ import math
 from typing import TYPE_CHECKING
 
 import numpy as np
+
 from pymatgen.core.tensors import SquareTensor
 
 if TYPE_CHECKING:

--- a/src/pymatgen/analysis/energy_models.py
+++ b/src/pymatgen/analysis/energy_models.py
@@ -10,12 +10,14 @@ import abc
 from typing import TYPE_CHECKING
 
 from monty.json import MSONable
+
 from pymatgen.analysis.ewald import EwaldSummation
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 
 if TYPE_CHECKING:
-    from pymatgen.core import Structure
     from typing_extensions import Self
+
+    from pymatgen.core import Structure
 
 __version__ = "0.1"
 

--- a/src/pymatgen/analysis/eos.py
+++ b/src/pymatgen/analysis/eos.py
@@ -13,9 +13,10 @@ from copy import deepcopy
 from typing import TYPE_CHECKING
 
 import numpy as np
+from scipy.optimize import leastsq, minimize
+
 from pymatgen.core.units import FloatWithUnit
 from pymatgen.util.plotting import add_fig_kwargs, get_ax_fig, pretty_plot
-from scipy.optimize import leastsq, minimize
 
 if TYPE_CHECKING:
     from typing import ClassVar

--- a/src/pymatgen/analysis/ewald.py
+++ b/src/pymatgen/analysis/ewald.py
@@ -11,10 +11,11 @@ from warnings import warn
 
 import numpy as np
 from monty.json import MSONable
-from pymatgen.core.structure import Structure
-from pymatgen.util.due import Doi, due
 from scipy import constants
 from scipy.special import comb, erfc
+
+from pymatgen.core.structure import Structure
+from pymatgen.util.due import Doi, due
 
 if TYPE_CHECKING:
     from typing import Any

--- a/src/pymatgen/analysis/ferroelectricity/polarization.py
+++ b/src/pymatgen/analysis/ferroelectricity/polarization.py
@@ -48,15 +48,17 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import numpy as np
+from scipy.interpolate import UnivariateSpline
+
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Structure
-from scipy.interpolate import UnivariateSpline
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from pymatgen.core.sites import PeriodicSite
     from typing_extensions import Self
+
+    from pymatgen.core.sites import PeriodicSite
 
 
 __author__ = "Tess Smidt"

--- a/src/pymatgen/analysis/fragmenter.py
+++ b/src/pymatgen/analysis/fragmenter.py
@@ -7,6 +7,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from monty.json import MSONable
+
 from pymatgen.analysis.graphs import MoleculeGraph, MolGraphSplitError
 from pymatgen.analysis.local_env import OpenBabelNN, metal_edge_extender
 from pymatgen.io.babel import BabelMolAdaptor

--- a/src/pymatgen/analysis/graphs.py
+++ b/src/pymatgen/analysis/graphs.py
@@ -20,12 +20,13 @@ from monty.dev import deprecated
 from monty.json import MSONable
 from networkx.drawing.nx_agraph import write_dot
 from networkx.readwrite import json_graph
+from scipy.spatial import KDTree
+from scipy.stats import describe
+
 from pymatgen.core import Lattice, Molecule, PeriodicSite, Structure
 from pymatgen.core.structure import FunctionalGroups
 from pymatgen.util.coord import lattice_points_in_supercell
 from pymatgen.vis.structure_vtk import EL_COLORS
-from scipy.spatial import KDTree
-from scipy.stats import describe
 
 try:
     import igraph
@@ -38,10 +39,11 @@ if TYPE_CHECKING:
 
     from igraph import Graph
     from numpy.typing import ArrayLike
+    from typing_extensions import Self
+
     from pymatgen.analysis.local_env import NearNeighbors
     from pymatgen.core import Species
     from pymatgen.util.typing import Tuple3Ints
-    from typing_extensions import Self
 
 
 logger = logging.getLogger(__name__)

--- a/src/pymatgen/analysis/hhi.py
+++ b/src/pymatgen/analysis/hhi.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import os
 
 from monty.design_patterns import singleton
+
 from pymatgen.core import Composition, Element
 
 __author__ = "Anubhav Jain"

--- a/src/pymatgen/analysis/interface_reactions.py
+++ b/src/pymatgen/analysis/interface_reactions.py
@@ -15,6 +15,7 @@ import numpy as np
 from monty.json import MSONable
 from pandas import DataFrame
 from plotly.graph_objects import Figure, Scatter
+
 from pymatgen.analysis.phase_diagram import GrandPotentialPhaseDiagram, PhaseDiagram
 from pymatgen.analysis.reaction_calculator import Reaction
 from pymatgen.core.composition import Composition

--- a/src/pymatgen/analysis/interfaces/coherent_interfaces.py
+++ b/src/pymatgen/analysis/interfaces/coherent_interfaces.py
@@ -7,11 +7,12 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from numpy.testing import assert_allclose
+from scipy.linalg import polar
+
 from pymatgen.analysis.elasticity.strain import Deformation
 from pymatgen.analysis.interfaces.zsl import ZSLGenerator, fast_norm
 from pymatgen.core.interface import Interface, label_termination
 from pymatgen.core.surface import SlabGenerator
-from scipy.linalg import polar
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence

--- a/src/pymatgen/analysis/interfaces/substrate_analyzer.py
+++ b/src/pymatgen/analysis/interfaces/substrate_analyzer.py
@@ -11,9 +11,10 @@ from pymatgen.core.surface import SlabGenerator, get_symmetrically_distinct_mill
 
 if TYPE_CHECKING:
     from numpy.typing import ArrayLike
+    from typing_extensions import Self
+
     from pymatgen.core import Structure
     from pymatgen.util.typing import Tuple3Ints
-    from typing_extensions import Self
 
 
 @dataclass

--- a/src/pymatgen/analysis/interfaces/zsl.py
+++ b/src/pymatgen/analysis/interfaces/zsl.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from monty.json import MSONable
+
 from pymatgen.util.due import Doi, due
 from pymatgen.util.numba import njit
 

--- a/src/pymatgen/analysis/local_env.py
+++ b/src/pymatgen/analysis/local_env.py
@@ -19,12 +19,13 @@ from typing import TYPE_CHECKING, Literal, NamedTuple, get_args
 import numpy as np
 from monty.dev import deprecated, requires
 from monty.serialization import loadfn
+from ruamel.yaml import YAML
+from scipy.spatial import Voronoi
+
 from pymatgen.analysis.bond_valence import BV_PARAMS, BVAnalyzer
 from pymatgen.analysis.graphs import MoleculeGraph, StructureGraph
 from pymatgen.analysis.molecule_structure_comparator import CovalentRadius
 from pymatgen.core import Element, IStructure, PeriodicNeighbor, PeriodicSite, Site, Species, Structure
-from ruamel.yaml import YAML
-from scipy.spatial import Voronoi
 
 try:
     from openbabel import openbabel
@@ -34,9 +35,10 @@ except Exception:
 if TYPE_CHECKING:
     from typing import Any
 
+    from typing_extensions import Self
+
     from pymatgen.core.composition import SpeciesLike
     from pymatgen.util.typing import Tuple3Ints
-    from typing_extensions import Self
 
 
 __author__ = "Shyue Ping Ong, Geoffroy Hautier, Sai Jayaraman, "

--- a/src/pymatgen/analysis/magnetism/analyzer.py
+++ b/src/pymatgen/analysis/magnetism/analyzer.py
@@ -13,6 +13,10 @@ from typing import TYPE_CHECKING, NamedTuple
 
 import numpy as np
 from monty.serialization import loadfn
+from ruamel.yaml.error import MarkedYAMLError
+from scipy.signal import argrelextrema
+from scipy.stats import gaussian_kde
+
 from pymatgen.core.structure import DummySpecies, Element, Species, Structure
 from pymatgen.electronic_structure.core import Magmom
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
@@ -20,9 +24,6 @@ from pymatgen.symmetry.groups import SpaceGroup
 from pymatgen.transformations.advanced_transformations import MagOrderingTransformation, MagOrderParameterConstraint
 from pymatgen.transformations.standard_transformations import AutoOxiStateDecorationTransformation
 from pymatgen.util.due import Doi, due
-from ruamel.yaml.error import MarkedYAMLError
-from scipy.signal import argrelextrema
-from scipy.stats import gaussian_kde
 
 if TYPE_CHECKING:
     from typing import Any

--- a/src/pymatgen/analysis/magnetism/heisenberg.py
+++ b/src/pymatgen/analysis/magnetism/heisenberg.py
@@ -15,6 +15,7 @@ import numpy as np
 import pandas as pd
 from monty.json import MSONable, jsanitize
 from monty.serialization import dumpfn
+
 from pymatgen.analysis.graphs import StructureGraph
 from pymatgen.analysis.local_env import MinimumDistanceNN
 from pymatgen.analysis.magnetism import CollinearMagneticStructureAnalyzer, Ordering

--- a/src/pymatgen/analysis/magnetism/jahnteller.py
+++ b/src/pymatgen/analysis/magnetism/jahnteller.py
@@ -7,6 +7,7 @@ import warnings
 from typing import TYPE_CHECKING, Literal, cast
 
 import numpy as np
+
 from pymatgen.analysis.bond_valence import BVAnalyzer
 from pymatgen.analysis.local_env import LocalStructOrderParams, get_neighbors_of_site_with_index
 from pymatgen.core import Species, get_el_sp

--- a/src/pymatgen/analysis/molecule_matcher.py
+++ b/src/pymatgen/analysis/molecule_matcher.py
@@ -22,12 +22,14 @@ from typing import TYPE_CHECKING
 import numpy as np
 from monty.dev import requires
 from monty.json import MSONable
-from pymatgen.core.structure import Molecule
 from scipy.optimize import linear_sum_assignment
 from scipy.spatial.distance import cdist
 
+from pymatgen.core.structure import Molecule
+
 try:
     from openbabel import openbabel
+
     from pymatgen.io.babel import BabelMolAdaptor
 except ImportError:
     openbabel = BabelMolAdaptor = None  # type: ignore[misc]

--- a/src/pymatgen/analysis/molecule_structure_comparator.py
+++ b/src/pymatgen/analysis/molecule_structure_comparator.py
@@ -14,6 +14,7 @@ import itertools
 from typing import TYPE_CHECKING
 
 from monty.json import MSONable
+
 from pymatgen.util.due import Doi, due
 
 if TYPE_CHECKING:

--- a/src/pymatgen/analysis/nmr.py
+++ b/src/pymatgen/analysis/nmr.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, NamedTuple
 
 import numpy as np
+
 from pymatgen.core import Site, Species
 from pymatgen.core.tensors import SquareTensor
 from pymatgen.core.units import FloatWithUnit

--- a/src/pymatgen/analysis/phase_diagram.py
+++ b/src/pymatgen/analysis/phase_diagram.py
@@ -21,6 +21,11 @@ from matplotlib.cm import ScalarMappable
 from matplotlib.colors import LinearSegmentedColormap, Normalize
 from matplotlib.font_manager import FontProperties
 from monty.json import MontyDecoder, MSONable
+from scipy import interpolate
+from scipy.optimize import minimize
+from scipy.spatial import ConvexHull
+from tqdm import tqdm
+
 from pymatgen.analysis.reaction_calculator import Reaction, ReactionError
 from pymatgen.core import DummySpecies, Element, get_el_sp
 from pymatgen.core.composition import Composition
@@ -29,10 +34,6 @@ from pymatgen.util.coord import Simplex, in_coord_list
 from pymatgen.util.due import Doi, due
 from pymatgen.util.plotting import pretty_plot
 from pymatgen.util.string import htmlify, latexify
-from scipy import interpolate
-from scipy.optimize import minimize
-from scipy.spatial import ConvexHull
-from tqdm import tqdm
 
 if TYPE_CHECKING:
     from collections.abc import Collection, Iterator, Sequence

--- a/src/pymatgen/analysis/piezo.py
+++ b/src/pymatgen/analysis/piezo.py
@@ -6,6 +6,7 @@ import warnings
 from typing import TYPE_CHECKING
 
 import numpy as np
+
 from pymatgen.core.tensors import Tensor
 
 if TYPE_CHECKING:

--- a/src/pymatgen/analysis/piezo_sensitivity.py
+++ b/src/pymatgen/analysis/piezo_sensitivity.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from monty.dev import requires
+
 from pymatgen.core.tensors import Tensor
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 

--- a/src/pymatgen/analysis/pourbaix_diagram.py
+++ b/src/pymatgen/analysis/pourbaix_diagram.py
@@ -16,6 +16,9 @@ from typing import TYPE_CHECKING, no_type_check
 
 import numpy as np
 from monty.json import MontyDecoder, MSONable
+from scipy.spatial import ConvexHull, HalfspaceIntersection
+from scipy.special import comb
+
 from pymatgen.analysis.phase_diagram import PDEntry, PhaseDiagram
 from pymatgen.analysis.reaction_calculator import Reaction, ReactionError
 from pymatgen.core import Composition, Element
@@ -26,8 +29,6 @@ from pymatgen.util.coord import Simplex
 from pymatgen.util.due import Doi, due
 from pymatgen.util.plotting import pretty_plot
 from pymatgen.util.string import Stringify
-from scipy.spatial import ConvexHull, HalfspaceIntersection
-from scipy.special import comb
 
 if TYPE_CHECKING:
     from typing import Any

--- a/src/pymatgen/analysis/prototypes.py
+++ b/src/pymatgen/analysis/prototypes.py
@@ -17,6 +17,7 @@ import os
 from typing import TYPE_CHECKING
 
 from monty.serialization import loadfn
+
 from pymatgen.analysis.structure_matcher import StructureMatcher
 from pymatgen.util.due import Doi, due
 

--- a/src/pymatgen/analysis/quasiharmonic.py
+++ b/src/pymatgen/analysis/quasiharmonic.py
@@ -15,13 +15,14 @@ from collections import defaultdict
 
 import numpy as np
 from monty.dev import deprecated
-from pymatgen.analysis.eos import EOS, PolynomialEOS
-from pymatgen.core.units import FloatWithUnit
-from pymatgen.util.due import Doi, due
 from scipy.constants import physical_constants
 from scipy.integrate import quadrature
 from scipy.misc import derivative
 from scipy.optimize import minimize
+
+from pymatgen.analysis.eos import EOS, PolynomialEOS
+from pymatgen.core.units import FloatWithUnit
+from pymatgen.util.due import Doi, due
 
 __author__ = "Kiran Mathew, Brandon Bocklund"
 __credits__ = "Cormac Toher"

--- a/src/pymatgen/analysis/quasirrho.py
+++ b/src/pymatgen/analysis/quasirrho.py
@@ -15,14 +15,16 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import scipy.constants as const
+
 from pymatgen.core.units import kb as kb_ev
 from pymatgen.util.due import Doi, due
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from pymatgen.core import Molecule
     from pymatgen.io.gaussian import GaussianOutput
     from pymatgen.io.qchem.outputs import QCOutput
-    from typing_extensions import Self
 
 __author__ = "Alex Epstein"
 __copyright__ = "Copyright 2020, The Materials Project"

--- a/src/pymatgen/analysis/reaction_calculator.py
+++ b/src/pymatgen/analysis/reaction_calculator.py
@@ -10,16 +10,18 @@ from typing import TYPE_CHECKING, no_type_check, overload
 import numpy as np
 from monty.fractions import gcd_float
 from monty.json import MontyDecoder, MSONable
+from uncertainties import ufloat
+
 from pymatgen.core.composition import Composition
 from pymatgen.entries.computed_entries import ComputedEntry
-from uncertainties import ufloat
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
+    from typing_extensions import Self
+
     from pymatgen.core import Element, Species
     from pymatgen.util.typing import CompositionLike
-    from typing_extensions import Self
 
 __author__ = "Shyue Ping Ong, Anubhav Jain"
 __copyright__ = "Copyright 2011, The Materials Project"

--- a/src/pymatgen/analysis/solar/slme.py
+++ b/src/pymatgen/analysis/solar/slme.py
@@ -22,9 +22,10 @@ try:
     from scipy.integrate import simpson
 except ImportError:
     from scipy.integrate import simps as simpson
+from scipy.interpolate import interp1d
+
 from pymatgen.io.vasp.outputs import Vasprun
 from pymatgen.util.due import Doi, due
-from scipy.interpolate import interp1d
 
 due.cite(
     Doi("10.1021/acs.chemmater.9b02166"),

--- a/src/pymatgen/analysis/structure_analyzer.py
+++ b/src/pymatgen/analysis/structure_analyzer.py
@@ -10,10 +10,11 @@ from warnings import warn
 
 import matplotlib.pyplot as plt
 import numpy as np
+from scipy.spatial import Voronoi
+
 from pymatgen.analysis.local_env import JmolNN, VoronoiNN
 from pymatgen.core import Composition, Element, PeriodicSite, Species
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
-from scipy.spatial import Voronoi
 
 if TYPE_CHECKING:
     from pymatgen.core import Structure

--- a/src/pymatgen/analysis/structure_matcher.py
+++ b/src/pymatgen/analysis/structure_matcher.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from monty.json import MSONable
+
 from pymatgen.core import Composition, Lattice, Structure, get_el_sp
 from pymatgen.optimization.linear_assignment import LinearAssignment
 from pymatgen.util.coord import lattice_points_in_supercell
@@ -17,8 +18,9 @@ if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
     from typing import Literal
 
-    from pymatgen.util.typing import SpeciesLike
     from typing_extensions import Self
+
+    from pymatgen.util.typing import SpeciesLike
 
 __author__ = "William Davidson Richards, Stephen Dacek, Shyue Ping Ong"
 __copyright__ = "Copyright 2011, The Materials Project"

--- a/src/pymatgen/analysis/structure_prediction/dopant_predictor.py
+++ b/src/pymatgen/analysis/structure_prediction/dopant_predictor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import warnings
 
 import numpy as np
+
 from pymatgen.analysis.structure_prediction.substitution_probability import SubstitutionPredictor
 from pymatgen.core import Element, Species
 

--- a/src/pymatgen/analysis/structure_prediction/substitution_probability.py
+++ b/src/pymatgen/analysis/structure_prediction/substitution_probability.py
@@ -13,6 +13,7 @@ from operator import mul
 from typing import TYPE_CHECKING
 
 from monty.design_patterns import cached_class
+
 from pymatgen.core import Species, get_el_sp
 from pymatgen.util.due import Doi, due
 

--- a/src/pymatgen/analysis/structure_prediction/substitutor.py
+++ b/src/pymatgen/analysis/structure_prediction/substitutor.py
@@ -9,6 +9,7 @@ from operator import mul
 from typing import TYPE_CHECKING
 
 from monty.json import MSONable
+
 from pymatgen.alchemy.filters import RemoveDuplicatesFilter, RemoveExistingFilter
 from pymatgen.alchemy.materials import TransformedStructure
 from pymatgen.alchemy.transmuters import StandardTransmuter

--- a/src/pymatgen/analysis/structure_prediction/volume_predictor.py
+++ b/src/pymatgen/analysis/structure_prediction/volume_predictor.py
@@ -7,6 +7,7 @@ import warnings
 
 import numpy as np
 from monty.serialization import loadfn
+
 from pymatgen.analysis.bond_valence import BVAnalyzer
 from pymatgen.analysis.structure_matcher import StructureMatcher
 from pymatgen.core import Structure

--- a/src/pymatgen/analysis/surface_analysis.py
+++ b/src/pymatgen/analysis/surface_analysis.py
@@ -42,6 +42,9 @@ from typing import TYPE_CHECKING
 
 import matplotlib.pyplot as plt
 import numpy as np
+from sympy import Symbol
+from sympy.solvers import linsolve, solve
+
 from pymatgen.analysis.wulff import WulffShape
 from pymatgen.core import Structure
 from pymatgen.core.composition import Composition
@@ -51,12 +54,11 @@ from pymatgen.io.vasp.outputs import Locpot, Outcar
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.util.due import Doi, due
 from pymatgen.util.plotting import pretty_plot
-from sympy import Symbol
-from sympy.solvers import linsolve, solve
 
 if TYPE_CHECKING:
-    from pymatgen.util.typing import Tuple3Ints
     from typing_extensions import Self
+
+    from pymatgen.util.typing import Tuple3Ints
 
 EV_PER_ANG2_TO_JOULES_PER_M2 = 16.0217656
 

--- a/src/pymatgen/analysis/topological/spillage.py
+++ b/src/pymatgen/analysis/topological/spillage.py
@@ -8,6 +8,7 @@ https://www.nature.com/articles/s41524-020-0319-4.
 from __future__ import annotations
 
 import numpy as np
+
 from pymatgen.io.vasp.outputs import Wavecar
 
 

--- a/src/pymatgen/analysis/transition_state.py
+++ b/src/pymatgen/analysis/transition_state.py
@@ -15,11 +15,12 @@ from typing import TYPE_CHECKING
 import matplotlib.pyplot as plt
 import numpy as np
 from monty.json import MSONable, jsanitize
+from scipy.interpolate import CubicSpline
+
 from pymatgen.analysis.structure_matcher import StructureMatcher
 from pymatgen.core import Structure
 from pymatgen.io.vasp import Outcar
 from pymatgen.util.plotting import pretty_plot
-from scipy.interpolate import CubicSpline
 
 if TYPE_CHECKING:
     from typing_extensions import Self

--- a/src/pymatgen/analysis/wulff.py
+++ b/src/pymatgen/analysis/wulff.py
@@ -25,10 +25,11 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 import plotly.graph_objects as go
+from scipy.spatial import ConvexHull
+
 from pymatgen.core.structure import Structure
 from pymatgen.util.coord import get_angle
 from pymatgen.util.string import unicodeify_spacegroup
-from scipy.spatial import ConvexHull
 
 if TYPE_CHECKING:
     from pymatgen.core.lattice import Lattice

--- a/src/pymatgen/analysis/xas/spectrum.py
+++ b/src/pymatgen/analysis/xas/spectrum.py
@@ -7,10 +7,11 @@ import warnings
 from typing import TYPE_CHECKING
 
 import numpy as np
+from scipy.interpolate import interp1d
+
 from pymatgen.analysis.structure_matcher import StructureMatcher
 from pymatgen.core.spectrum import Spectrum
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
-from scipy.interpolate import interp1d
 
 if TYPE_CHECKING:
     from typing import Literal

--- a/src/pymatgen/analysis/xps.py
+++ b/src/pymatgen/analysis/xps.py
@@ -25,13 +25,15 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
+
 from pymatgen.core import Element
 from pymatgen.core.spectrum import Spectrum
 from pymatgen.util.due import Doi, due
 
 if TYPE_CHECKING:
-    from pymatgen.electronic_structure.dos import CompleteDos
     from typing_extensions import Self
+
+    from pymatgen.electronic_structure.dos import CompleteDos
 
 
 due.cite(

--- a/src/pymatgen/apps/battery/analyzer.py
+++ b/src/pymatgen/apps/battery/analyzer.py
@@ -6,6 +6,7 @@ import math
 from collections import defaultdict
 
 import scipy.constants as const
+
 from pymatgen.core import Composition, Element, Species
 
 __author__ = "Anubhav Jain"

--- a/src/pymatgen/apps/battery/battery_abc.py
+++ b/src/pymatgen/apps/battery/battery_abc.py
@@ -12,8 +12,9 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from monty.json import MSONable
-from pymatgen.core import Composition, Element
 from scipy.constants import N_A
+
+from pymatgen.core import Composition, Element
 
 if TYPE_CHECKING:
     from pymatgen.entries.computed_entries import ComputedEntry

--- a/src/pymatgen/apps/battery/conversion_battery.py
+++ b/src/pymatgen/apps/battery/conversion_battery.py
@@ -5,18 +5,20 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from scipy.constants import N_A
+
 from pymatgen.analysis.phase_diagram import PhaseDiagram
 from pymatgen.analysis.reaction_calculator import BalancedReaction
 from pymatgen.apps.battery.battery_abc import AbstractElectrode, AbstractVoltagePair
 from pymatgen.core import Composition, Element
 from pymatgen.core.units import Charge, Time
-from scipy.constants import N_A
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
-    from pymatgen.entries.computed_entries import ComputedEntry
     from typing_extensions import Self
+
+    from pymatgen.entries.computed_entries import ComputedEntry
 
 
 @dataclass

--- a/src/pymatgen/apps/battery/insertion_battery.py
+++ b/src/pymatgen/apps/battery/insertion_battery.py
@@ -9,12 +9,13 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from monty.json import MontyDecoder
+from scipy.constants import N_A
+
 from pymatgen.analysis.phase_diagram import PDEntry, PhaseDiagram
 from pymatgen.apps.battery.battery_abc import AbstractElectrode, AbstractVoltagePair
 from pymatgen.core import Composition, Element
 from pymatgen.core.units import Charge, Time
 from pymatgen.entries.computed_entries import ComputedEntry, ComputedStructureEntry
-from scipy.constants import N_A
 
 if TYPE_CHECKING:
     from collections.abc import Iterable

--- a/src/pymatgen/apps/battery/plotter.py
+++ b/src/pymatgen/apps/battery/plotter.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 import matplotlib.pyplot as plt
 import plotly.graph_objects as go
+
 from pymatgen.util.plotting import pretty_plot
 
 if TYPE_CHECKING:

--- a/src/pymatgen/apps/borg/hive.py
+++ b/src/pymatgen/apps/borg/hive.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 
 from monty.io import zopen
 from monty.json import MSONable
+
 from pymatgen.entries.computed_entries import ComputedEntry, ComputedStructureEntry
 from pymatgen.io.gaussian import GaussianOutput
 from pymatgen.io.vasp.inputs import Incar, Poscar, Potcar

--- a/src/pymatgen/cli/feff_plot_cross_section.py
+++ b/src/pymatgen/cli/feff_plot_cross_section.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import argparse
 
 import matplotlib.pyplot as plt
+
 from pymatgen.io.feff.outputs import Xmu
 from pymatgen.util.plotting import pretty_plot
 

--- a/src/pymatgen/cli/pmg.py
+++ b/src/pymatgen/cli/pmg.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 import argparse
 import itertools
 
+from tabulate import tabulate, tabulate_formats
+
 from pymatgen.cli.pmg_analyze import analyze
 from pymatgen.cli.pmg_config import configure_pmg
 from pymatgen.cli.pmg_plot import plot
@@ -15,7 +17,6 @@ from pymatgen.cli.pmg_structure import analyze_structures
 from pymatgen.core import SETTINGS
 from pymatgen.core.structure import Structure
 from pymatgen.io.vasp import Incar, Potcar
-from tabulate import tabulate, tabulate_formats
 
 
 def parse_view(args):

--- a/src/pymatgen/cli/pmg_analyze.py
+++ b/src/pymatgen/cli/pmg_analyze.py
@@ -7,10 +7,11 @@ import multiprocessing
 import os
 import re
 
+from tabulate import tabulate
+
 from pymatgen.apps.borg.hive import SimpleVaspToComputedEntryDrone, VaspToComputedEntryDrone
 from pymatgen.apps.borg.queen import BorgQueen
 from pymatgen.io.vasp import Outcar
-from tabulate import tabulate
 
 __author__ = "Shyue Ping Ong"
 __copyright__ = "Copyright 2012, The Materials Project"

--- a/src/pymatgen/cli/pmg_config.py
+++ b/src/pymatgen/cli/pmg_config.py
@@ -13,10 +13,11 @@ from urllib.request import urlretrieve
 
 from monty.json import jsanitize
 from monty.serialization import dumpfn, loadfn
+from ruamel import yaml
+
 from pymatgen.core import OLD_SETTINGS_FILE, SETTINGS_FILE, Element
 from pymatgen.io.cp2k.inputs import GaussianTypeOrbitalBasisSet, GthPotential
 from pymatgen.io.cp2k.utils import chunk
-from ruamel import yaml
 
 if TYPE_CHECKING:
     from argparse import Namespace

--- a/src/pymatgen/cli/pmg_plot.py
+++ b/src/pymatgen/cli/pmg_plot.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import matplotlib.pyplot as plt
+
 from pymatgen.analysis.diffraction.xrd import XRDCalculator
 from pymatgen.core.structure import Structure
 from pymatgen.electronic_structure.plotter import DosPlotter

--- a/src/pymatgen/cli/pmg_structure.py
+++ b/src/pymatgen/cli/pmg_structure.py
@@ -4,10 +4,11 @@
 
 from __future__ import annotations
 
+from tabulate import tabulate
+
 from pymatgen.analysis.structure_matcher import ElementComparator, StructureMatcher
 from pymatgen.core.structure import Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
-from tabulate import tabulate
 
 __author__ = "Shyue Ping Ong"
 __copyright__ = "Copyright 2012, The Materials Project"

--- a/src/pymatgen/command_line/bader_caller.py
+++ b/src/pymatgen/command_line/bader_caller.py
@@ -27,6 +27,7 @@ import numpy as np
 from monty.dev import deprecated
 from monty.shutil import decompress_file
 from monty.tempfile import ScratchDir
+
 from pymatgen.io.common import VolumetricData
 from pymatgen.io.vasp.inputs import Potcar
 from pymatgen.io.vasp.outputs import Chgcar
@@ -34,8 +35,9 @@ from pymatgen.io.vasp.outputs import Chgcar
 if TYPE_CHECKING:
     from typing import Any
 
-    from pymatgen.core import Structure
     from typing_extensions import Self
+
+    from pymatgen.core import Structure
 
 __author__ = "shyuepingong"
 __version__ = "0.1"

--- a/src/pymatgen/command_line/chargemol_caller.py
+++ b/src/pymatgen/command_line/chargemol_caller.py
@@ -51,6 +51,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from monty.tempfile import ScratchDir
+
 from pymatgen.core import Element
 from pymatgen.io.vasp.inputs import Potcar
 from pymatgen.io.vasp.outputs import Chgcar

--- a/src/pymatgen/command_line/critic2_caller.py
+++ b/src/pymatgen/command_line/critic2_caller.py
@@ -52,16 +52,18 @@ from monty.dev import requires
 from monty.json import MSONable
 from monty.serialization import loadfn
 from monty.tempfile import ScratchDir
+from scipy.spatial import KDTree
+
 from pymatgen.analysis.graphs import StructureGraph
 from pymatgen.core import DummySpecies
 from pymatgen.io.vasp.inputs import Potcar
 from pymatgen.io.vasp.outputs import Chgcar, VolumetricData
 from pymatgen.util.due import Doi, due
-from scipy.spatial import KDTree
 
 if TYPE_CHECKING:
-    from pymatgen.core import Structure
     from typing_extensions import Self
+
+    from pymatgen.core import Structure
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/src/pymatgen/command_line/enumlib_caller.py
+++ b/src/pymatgen/command_line/enumlib_caller.py
@@ -39,6 +39,7 @@ import numpy as np
 from monty.dev import requires
 from monty.fractions import lcm
 from monty.tempfile import ScratchDir
+
 from pymatgen.core import DummySpecies, PeriodicSite, Structure
 from pymatgen.io.vasp.inputs import Poscar
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer

--- a/src/pymatgen/command_line/gulp_caller.py
+++ b/src/pymatgen/command_line/gulp_caller.py
@@ -10,6 +10,7 @@ import re
 import subprocess
 
 from monty.tempfile import ScratchDir
+
 from pymatgen.analysis.bond_valence import BVAnalyzer
 from pymatgen.core import Element, Lattice, Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer

--- a/src/pymatgen/command_line/mcsqs_caller.py
+++ b/src/pymatgen/command_line/mcsqs_caller.py
@@ -13,6 +13,7 @@ from subprocess import Popen, TimeoutExpired
 from typing import TYPE_CHECKING, NamedTuple
 
 from monty.dev import requires
+
 from pymatgen.core.structure import Structure
 
 if TYPE_CHECKING:

--- a/src/pymatgen/command_line/vampire_caller.py
+++ b/src/pymatgen/command_line/vampire_caller.py
@@ -21,6 +21,7 @@ from shutil import which
 import pandas as pd
 from monty.dev import requires
 from monty.json import MSONable
+
 from pymatgen.analysis.magnetism.heisenberg import HeisenbergMapper
 
 __author__ = "ncfrey"

--- a/src/pymatgen/core/__init__.py
+++ b/src/pymatgen/core/__init__.py
@@ -7,6 +7,8 @@ import warnings
 from importlib.metadata import PackageNotFoundError, version
 from typing import Any
 
+from ruamel.yaml import YAML
+
 from pymatgen.core.composition import Composition
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.operations import SymmOp
@@ -14,7 +16,6 @@ from pymatgen.core.periodic_table import DummySpecie, DummySpecies, Element, Spe
 from pymatgen.core.sites import PeriodicSite, Site
 from pymatgen.core.structure import IMolecule, IStructure, Molecule, PeriodicNeighbor, SiteCollection, Structure
 from pymatgen.core.units import ArrayWithUnit, FloatWithUnit, Unit
-from ruamel.yaml import YAML
 
 __author__ = "Pymatgen Development Team"
 __email__ = "pymatgen@googlegroups.com"

--- a/src/pymatgen/core/composition.py
+++ b/src/pymatgen/core/composition.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, cast
 from monty.fractions import gcd, gcd_float
 from monty.json import MSONable
 from monty.serialization import loadfn
+
 from pymatgen.core.periodic_table import DummySpecies, Element, ElementType, Species, get_el_sp
 from pymatgen.core.units import Mass
 from pymatgen.util.string import Stringify, formula_double_format
@@ -26,8 +27,9 @@ if TYPE_CHECKING:
     from collections.abc import Generator, Iterator
     from typing import Any, ClassVar
 
-    from pymatgen.util.typing import SpeciesLike
     from typing_extensions import Self
+
+    from pymatgen.util.typing import SpeciesLike
 
 module_dir = os.path.dirname(os.path.abspath(__file__))
 

--- a/src/pymatgen/core/interface.py
+++ b/src/pymatgen/core/interface.py
@@ -15,6 +15,9 @@ from typing import TYPE_CHECKING, Literal, Union, cast
 import numpy as np
 from monty.fractions import lcm
 from numpy.testing import assert_allclose
+from scipy.cluster.hierarchy import fcluster, linkage
+from scipy.spatial.distance import squareform
+
 from pymatgen.analysis.adsorption import AdsorbateSiteFinder
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.sites import PeriodicSite, Site
@@ -22,17 +25,16 @@ from pymatgen.core.structure import Structure
 from pymatgen.core.surface import Slab
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.util.typing import Tuple3Ints
-from scipy.cluster.hierarchy import fcluster, linkage
-from scipy.spatial.distance import squareform
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from typing import Any, Callable
 
     from numpy.typing import ArrayLike, NDArray
+    from typing_extensions import Self
+
     from pymatgen.core import Element
     from pymatgen.util.typing import CompositionLike, Matrix3D, MillerIndex, Tuple3Floats, Vector3D
-    from typing_extensions import Self
 
 Tuple4Ints = tuple[int, int, int, int]
 logger = logging.getLogger(__name__)

--- a/src/pymatgen/core/ion.py
+++ b/src/pymatgen/core/ion.py
@@ -7,6 +7,7 @@ from copy import deepcopy
 from typing import TYPE_CHECKING
 
 from monty.json import MSONable
+
 from pymatgen.core.composition import Composition, reduce_formula
 from pymatgen.util.string import Stringify, charge_string, formula_double_format
 

--- a/src/pymatgen/core/lattice.py
+++ b/src/pymatgen/core/lattice.py
@@ -16,17 +16,19 @@ from typing import TYPE_CHECKING, cast
 import numpy as np
 from monty.dev import deprecated
 from monty.json import MSONable
+from scipy.spatial import Voronoi
+
 from pymatgen.util.coord import pbc_shortest_vectors
 from pymatgen.util.due import Doi, due
-from scipy.spatial import Voronoi
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
     from numpy.typing import ArrayLike
+    from typing_extensions import Self
+
     from pymatgen.core.operations import SymmOp
     from pymatgen.util.typing import MillerIndex, PbcLike, Vector3D
-    from typing_extensions import Self
 
 __author__ = "Shyue Ping Ong, Michael Kocher"
 __copyright__ = "Copyright 2011, The Materials Project"

--- a/src/pymatgen/core/operations.py
+++ b/src/pymatgen/core/operations.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Literal, cast
 
 import numpy as np
 from monty.json import MSONable
+
 from pymatgen.electronic_structure.core import Magmom
 from pymatgen.util.due import Doi, due
 from pymatgen.util.string import transformation_to_string

--- a/src/pymatgen/core/periodic_table.py
+++ b/src/pymatgen/core/periodic_table.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 from monty.dev import deprecated
 from monty.json import MSONable
+
 from pymatgen.core.units import SUPPORTED_UNIT_NAMES, FloatWithUnit, Ha_to_eV, Length, Mass, Unit
 from pymatgen.io.core import ParseError
 from pymatgen.util.string import Stringify, formula_double_format
@@ -24,8 +25,9 @@ from pymatgen.util.string import Stringify, formula_double_format
 if TYPE_CHECKING:
     from typing import Any, Callable, Literal
 
-    from pymatgen.util.typing import SpeciesLike
     from typing_extensions import Self
+
+    from pymatgen.util.typing import SpeciesLike
 
 # Load element data from JSON file
 with open(Path(__file__).absolute().parent / "periodic_table.json", encoding="utf-8") as ptable_json:

--- a/src/pymatgen/core/sites.py
+++ b/src/pymatgen/core/sites.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, cast
 
 import numpy as np
 from monty.json import MontyDecoder, MontyEncoder, MSONable
+
 from pymatgen.core.composition import Composition
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.periodic_table import DummySpecies, Element, Species, get_el_sp
@@ -17,8 +18,9 @@ if TYPE_CHECKING:
     from typing import Any
 
     from numpy.typing import ArrayLike
-    from pymatgen.util.typing import CompositionLike, SpeciesLike, Vector3D
     from typing_extensions import Self
+
+    from pymatgen.util.typing import CompositionLike, SpeciesLike, Vector3D
 
 
 class Site(collections.abc.Hashable, MSONable):

--- a/src/pymatgen/core/spectrum.py
+++ b/src/pymatgen/core/spectrum.py
@@ -8,9 +8,10 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from monty.json import MSONable
-from pymatgen.util.coord import get_linear_interpolated_value
 from scipy import stats
 from scipy.ndimage import convolve1d
+
+from pymatgen.util.coord import get_linear_interpolated_value
 
 if TYPE_CHECKING:
     from typing import Callable, Literal

--- a/src/pymatgen/core/structure.py
+++ b/src/pymatgen/core/structure.py
@@ -31,6 +31,12 @@ from monty.io import zopen
 from monty.json import MSONable
 from numpy import cross, eye
 from numpy.linalg import norm
+from ruamel.yaml import YAML
+from scipy.cluster.hierarchy import fcluster, linkage
+from scipy.linalg import expm, polar
+from scipy.spatial.distance import squareform
+from tabulate import tabulate
+
 from pymatgen.core.bonds import CovalentBond, get_bond_length
 from pymatgen.core.composition import Composition
 from pymatgen.core.lattice import Lattice, get_points_in_spheres
@@ -41,11 +47,6 @@ from pymatgen.core.units import Length, Mass
 from pymatgen.electronic_structure.core import Magmom
 from pymatgen.symmetry.maggroups import MagneticSpaceGroup
 from pymatgen.util.coord import all_distances, get_angle, lattice_points_in_supercell
-from ruamel.yaml import YAML
-from scipy.cluster.hierarchy import fcluster, linkage
-from scipy.linalg import expm, polar
-from scipy.spatial.distance import squareform
-from tabulate import tabulate
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator, Sequence
@@ -58,8 +59,9 @@ if TYPE_CHECKING:
     from ase.optimize.optimize import Optimizer
     from matgl.ext.ase import TrajectoryObserver
     from numpy.typing import ArrayLike, NDArray
-    from pymatgen.util.typing import CompositionLike, MillerIndex, PathLike, PbcLike, SpeciesLike
     from typing_extensions import Self
+
+    from pymatgen.util.typing import CompositionLike, MillerIndex, PathLike, PbcLike, SpeciesLike
 
 FileFormats = Literal["cif", "poscar", "cssr", "json", "yaml", "yml", "xsf", "mcsqs", "res", "pwmat", ""]
 StructureSources = Literal["Materials Project", "COD"]
@@ -827,6 +829,7 @@ class SiteCollection(collections.abc.Sequence, ABC):
         from ase.constraints import ExpCellFilter
         from ase.io import read
         from ase.optimize.optimize import Optimizer
+
         from pymatgen.io.ase import AseAtomsAdaptor
 
         opt_kwargs = opt_kwargs or {}

--- a/src/pymatgen/core/surface.py
+++ b/src/pymatgen/core/surface.py
@@ -27,24 +27,26 @@ from typing import TYPE_CHECKING, cast
 
 import numpy as np
 from monty.fractions import lcm
+from scipy.cluster.hierarchy import fcluster, linkage
+from scipy.spatial.distance import squareform
+
 from pymatgen.analysis.structure_matcher import StructureMatcher
 from pymatgen.core import Lattice, PeriodicSite, Structure, get_el_sp
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.util.coord import in_coord_list
 from pymatgen.util.due import Doi, due
 from pymatgen.util.typing import Tuple3Ints
-from scipy.cluster.hierarchy import fcluster, linkage
-from scipy.spatial.distance import squareform
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from typing import Any
 
     from numpy.typing import ArrayLike, NDArray
+    from typing_extensions import Self
+
     from pymatgen.core.composition import Element, Species
     from pymatgen.symmetry.groups import CrystalSystem
     from pymatgen.util.typing import MillerIndex
-    from typing_extensions import Self
 
 __author__ = "Richard Tran, Wenhao Sun, Zihan Xu, Shyue Ping Ong"
 

--- a/src/pymatgen/core/tensors.py
+++ b/src/pymatgen/core/tensors.py
@@ -15,19 +15,21 @@ from typing import TYPE_CHECKING
 import numpy as np
 from monty.json import MSONable
 from monty.serialization import loadfn
+from scipy.linalg import polar
+
 from pymatgen.analysis.structure_matcher import StructureMatcher
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.operations import SymmOp
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
-from scipy.linalg import polar
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from typing import Any
 
     from numpy.typing import NDArray
-    from pymatgen.core import Structure
     from typing_extensions import Self
+
+    from pymatgen.core import Structure
 
 __author__ = "Joseph Montoya"
 __credits__ = "Maarten de Jong, Shyam Dwaraknath, Wei Chen, Mark Asta, Anubhav Jain, Terence Lew"

--- a/src/pymatgen/core/trajectory.py
+++ b/src/pymatgen/core/trajectory.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Union, cast
 import numpy as np
 from monty.io import zopen
 from monty.json import MSONable
+
 from pymatgen.core.structure import Composition, DummySpecies, Element, Lattice, Molecule, Species, Structure
 from pymatgen.io.ase import AseAtomsAdaptor
 
@@ -20,8 +21,9 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
     from typing import Any
 
-    from pymatgen.util.typing import Matrix3D, PathLike, SitePropsType, Vector3D
     from typing_extensions import Self
+
+    from pymatgen.util.typing import Matrix3D, PathLike, SitePropsType, Vector3D
 
 
 __author__ = "Eric Sivonxay, Shyam Dwaraknath, Mingjian Wen, Evan Spotte-Smith"

--- a/src/pymatgen/core/xcfunc.py
+++ b/src/pymatgen/core/xcfunc.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, NamedTuple
 
 from monty.functools import lazy_property
 from monty.json import MSONable
+
 from pymatgen.core.libxcfunc import LibxcFunc
 
 if TYPE_CHECKING:

--- a/src/pymatgen/electronic_structure/bandstructure.py
+++ b/src/pymatgen/electronic_structure/bandstructure.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from monty.json import MSONable
+
 from pymatgen.core import Element, Lattice, Structure, get_el_sp
 from pymatgen.electronic_structure.core import Orbital, Spin
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer

--- a/src/pymatgen/electronic_structure/boltztrap.py
+++ b/src/pymatgen/electronic_structure/boltztrap.py
@@ -28,6 +28,10 @@ import numpy as np
 from monty.dev import requires
 from monty.json import MSONable, jsanitize
 from monty.os import cd
+from scipy import constants
+from scipy.optimize import fsolve
+from scipy.spatial import distance
+
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.units import Energy, Length
 from pymatgen.electronic_structure.bandstructure import BandStructureSymmLine, Kpoint
@@ -35,17 +39,15 @@ from pymatgen.electronic_structure.core import Orbital
 from pymatgen.electronic_structure.dos import CompleteDos, Dos, Spin
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.symmetry.bandstructure import HighSymmKpath
-from scipy import constants
-from scipy.optimize import fsolve
-from scipy.spatial import distance
 
 if TYPE_CHECKING:
     from typing import Literal
 
     from numpy.typing import ArrayLike
+    from typing_extensions import Self
+
     from pymatgen.core.sites import PeriodicSite
     from pymatgen.core.structure import Structure
-    from typing_extensions import Self
 
 __author__ = "Geoffroy Hautier, Zachary Gibbs, Francesco Ricci, Anubhav Jain"
 __copyright__ = "Copyright 2013, The Materials Project"

--- a/src/pymatgen/electronic_structure/boltztrap2.py
+++ b/src/pymatgen/electronic_structure/boltztrap2.py
@@ -34,6 +34,8 @@ from typing import TYPE_CHECKING
 import matplotlib.pyplot as plt
 import numpy as np
 from monty.serialization import dumpfn, loadfn
+from tqdm import tqdm
+
 from pymatgen.electronic_structure.bandstructure import BandStructure, BandStructureSymmLine, Spin
 from pymatgen.electronic_structure.boltztrap import BoltztrapError
 from pymatgen.electronic_structure.dos import CompleteDos, Dos, Orbital
@@ -41,7 +43,6 @@ from pymatgen.electronic_structure.plotter import BSPlotter, DosPlotter
 from pymatgen.io.ase import AseAtomsAdaptor
 from pymatgen.io.vasp import Vasprun
 from pymatgen.symmetry.bandstructure import HighSymmKpath
-from tqdm import tqdm
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/src/pymatgen/electronic_structure/cohp.py
+++ b/src/pymatgen/electronic_structure/cohp.py
@@ -17,6 +17,8 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from monty.json import MSONable
+from scipy.interpolate import InterpolatedUnivariateSpline
+
 from pymatgen.core.sites import PeriodicSite
 from pymatgen.core.structure import Structure
 from pymatgen.electronic_structure.core import Orbital, Spin
@@ -25,7 +27,6 @@ from pymatgen.io.lobster import Cohpcar
 from pymatgen.util.coord import get_linear_interpolated_value
 from pymatgen.util.due import Doi, due
 from pymatgen.util.num import round_to_sigfigs
-from scipy.interpolate import InterpolatedUnivariateSpline
 
 if TYPE_CHECKING:
     from typing import Any

--- a/src/pymatgen/electronic_structure/core.py
+++ b/src/pymatgen/electronic_structure/core.py
@@ -13,8 +13,9 @@ from monty.json import MSONable
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from pymatgen.core import Lattice
     from typing_extensions import Self
+
+    from pymatgen.core import Lattice
 
 
 @unique

--- a/src/pymatgen/electronic_structure/dos.py
+++ b/src/pymatgen/electronic_structure/dos.py
@@ -8,21 +8,23 @@ from typing import TYPE_CHECKING, NamedTuple
 
 import numpy as np
 from monty.json import MSONable
+from scipy.constants import value as _cd
+from scipy.ndimage import gaussian_filter1d
+from scipy.signal import hilbert
+
 from pymatgen.core import Structure, get_el_sp
 from pymatgen.core.spectrum import Spectrum
 from pymatgen.electronic_structure.core import Orbital, OrbitalType, Spin
 from pymatgen.util.coord import get_linear_interpolated_value
-from scipy.constants import value as _cd
-from scipy.ndimage import gaussian_filter1d
-from scipy.signal import hilbert
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
     from numpy.typing import ArrayLike, NDArray
+    from typing_extensions import Self
+
     from pymatgen.core.sites import PeriodicSite
     from pymatgen.util.typing import SpeciesLike, Tuple3Floats
-    from typing_extensions import Self
 
 
 class DOS(Spectrum):

--- a/src/pymatgen/electronic_structure/plotter.py
+++ b/src/pymatgen/electronic_structure/plotter.py
@@ -20,6 +20,7 @@ from matplotlib.collections import LineCollection
 from matplotlib.gridspec import GridSpec
 from monty.dev import requires
 from monty.json import jsanitize
+
 from pymatgen.core import Element
 from pymatgen.electronic_structure.bandstructure import BandStructureSymmLine
 from pymatgen.electronic_structure.boltztrap import BoltztrapError
@@ -36,6 +37,7 @@ if TYPE_CHECKING:
     from typing import Literal
 
     from numpy.typing import ArrayLike
+
     from pymatgen.electronic_structure.dos import CompleteDos, Dos
 
 logger = logging.getLogger(__name__)

--- a/src/pymatgen/entries/__init__.py
+++ b/src/pymatgen/entries/__init__.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from monty.json import MSONable
+
 from pymatgen.core.composition import Composition
 
 if TYPE_CHECKING:

--- a/src/pymatgen/entries/compatibility.py
+++ b/src/pymatgen/entries/compatibility.py
@@ -15,6 +15,9 @@ import numpy as np
 from monty.design_patterns import cached_class
 from monty.json import MSONable
 from monty.serialization import loadfn
+from tqdm import tqdm
+from uncertainties import ufloat
+
 from pymatgen.analysis.structure_analyzer import oxide_type, sulfide_type
 from pymatgen.core import SETTINGS, Composition, Element
 from pymatgen.entries.computed_entries import (
@@ -27,8 +30,6 @@ from pymatgen.entries.computed_entries import (
 )
 from pymatgen.io.vasp.sets import MITRelaxSet, MPRelaxSet, VaspInputSet
 from pymatgen.util.due import Doi, due
-from tqdm import tqdm
-from uncertainties import ufloat
 
 if TYPE_CHECKING:
     from collections.abc import Sequence

--- a/src/pymatgen/entries/computed_entries.py
+++ b/src/pymatgen/entries/computed_entries.py
@@ -17,17 +17,19 @@ from typing import TYPE_CHECKING, cast
 
 import numpy as np
 from monty.json import MontyDecoder, MontyEncoder, MSONable
+from scipy.interpolate import interp1d
+from uncertainties import ufloat
+
 from pymatgen.core.composition import Composition
 from pymatgen.entries import Entry
 from pymatgen.util.due import Doi, due
-from scipy.interpolate import interp1d
-from uncertainties import ufloat
 
 if TYPE_CHECKING:
     from typing import Literal
 
-    from pymatgen.core import Structure
     from typing_extensions import Self
+
+    from pymatgen.core import Structure
 
 __author__ = "Ryan Kingsbury, Matt McDermott, Shyue Ping Ong, Anubhav Jain"
 __copyright__ = "Copyright 2011-2020, The Materials Project"

--- a/src/pymatgen/entries/correction_calculator.py
+++ b/src/pymatgen/entries/correction_calculator.py
@@ -10,11 +10,12 @@ import warnings
 import numpy as np
 import plotly.graph_objects as go
 from monty.serialization import loadfn
+from ruamel import yaml
+from scipy.optimize import curve_fit
+
 from pymatgen.analysis.reaction_calculator import ComputedReaction
 from pymatgen.analysis.structure_analyzer import sulfide_type
 from pymatgen.core import Composition, Element
-from ruamel import yaml
-from scipy.optimize import curve_fit
 
 
 class CorrectionCalculator:

--- a/src/pymatgen/entries/entry_tools.py
+++ b/src/pymatgen/entries/entry_tools.py
@@ -16,6 +16,7 @@ from collections import defaultdict
 from typing import TYPE_CHECKING
 
 from monty.json import MontyDecoder, MontyEncoder, MSONable
+
 from pymatgen.analysis.phase_diagram import PDEntry
 from pymatgen.analysis.structure_matcher import SpeciesComparator, StructureMatcher
 from pymatgen.core import Composition, Element
@@ -24,9 +25,10 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
     from typing import Literal
 
+    from typing_extensions import Self
+
     from pymatgen.entries import Entry
     from pymatgen.entries.computed_entries import ComputedEntry, ComputedStructureEntry
-    from typing_extensions import Self
 
 logger = logging.getLogger(__name__)
 

--- a/src/pymatgen/entries/exp_entries.py
+++ b/src/pymatgen/entries/exp_entries.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from monty.json import MSONable
+
 from pymatgen.analysis.phase_diagram import PDEntry
 from pymatgen.analysis.thermochemistry import ThermoData
 from pymatgen.core.composition import Composition

--- a/src/pymatgen/entries/mixing_scheme.py
+++ b/src/pymatgen/entries/mixing_scheme.py
@@ -11,6 +11,7 @@ from itertools import groupby
 
 import numpy as np
 import pandas as pd
+
 from pymatgen.analysis.phase_diagram import PhaseDiagram
 from pymatgen.analysis.structure_matcher import StructureMatcher
 from pymatgen.entries.compatibility import (

--- a/src/pymatgen/ext/cod.py
+++ b/src/pymatgen/ext/cod.py
@@ -34,6 +34,7 @@ from shutil import which
 
 import requests
 from monty.dev import requires
+
 from pymatgen.core.composition import Composition
 from pymatgen.core.structure import Structure
 

--- a/src/pymatgen/ext/matproj.py
+++ b/src/pymatgen/ext/matproj.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, NamedTuple
 
 import requests
 from monty.json import MontyDecoder
+
 from pymatgen.core import SETTINGS
 from pymatgen.core import __version__ as PMG_VERSION
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
@@ -28,10 +29,11 @@ if TYPE_CHECKING:
     from typing import Callable
 
     from mp_api.client import MPRester as _MPResterNew
+    from typing_extensions import Self
+
     from pymatgen.core.structure import Structure
     from pymatgen.entries.computed_entries import ComputedStructureEntry
     from pymatgen.ext.matproj_legacy import _MPResterLegacy
-    from typing_extensions import Self
 
 logger = logging.getLogger(__name__)
 

--- a/src/pymatgen/ext/matproj_legacy.py
+++ b/src/pymatgen/ext/matproj_legacy.py
@@ -20,6 +20,9 @@ from typing import TYPE_CHECKING
 
 import requests
 from monty.json import MontyDecoder, MontyEncoder
+from ruamel.yaml import YAML
+from tqdm import tqdm
+
 from pymatgen.core import SETTINGS, Composition, Element, Structure
 from pymatgen.core import __version__ as PMG_VERSION
 from pymatgen.core.surface import get_symmetrically_equivalent_miller_indices
@@ -28,16 +31,15 @@ from pymatgen.entries.computed_entries import ComputedEntry, ComputedStructureEn
 from pymatgen.entries.exp_entries import ExpEntry
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.util.due import Doi, due
-from ruamel.yaml import YAML
-from tqdm import tqdm
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from typing import Any, Literal
 
+    from typing_extensions import Self
+
     from pymatgen.phonon.bandstructure import PhononBandStructureSymmLine
     from pymatgen.phonon.dos import CompletePhononDos
-    from typing_extensions import Self
 
 logger = logging.getLogger(__name__)
 MP_LOG_FILE = os.path.join(os.path.expanduser("~"), ".mprester.log.yaml")

--- a/src/pymatgen/ext/optimade.py
+++ b/src/pymatgen/ext/optimade.py
@@ -8,10 +8,11 @@ from typing import TYPE_CHECKING, NamedTuple
 from urllib.parse import urljoin, urlparse
 
 import requests
+from tqdm import tqdm
+
 from pymatgen.core import DummySpecies, Structure
 from pymatgen.util.due import Doi, due
 from pymatgen.util.provenance import StructureNL
-from tqdm import tqdm
 
 if TYPE_CHECKING:
     from typing import ClassVar

--- a/src/pymatgen/io/abinit/abiobjects.py
+++ b/src/pymatgen/io/abinit/abiobjects.py
@@ -13,6 +13,7 @@ import numpy as np
 from monty.collections import AttrDict
 from monty.design_patterns import singleton
 from monty.json import MontyDecoder, MontyEncoder, MSONable
+
 from pymatgen.core import ArrayWithUnit, Lattice, Species, Structure, units
 
 if TYPE_CHECKING:

--- a/src/pymatgen/io/abinit/abitimer.py
+++ b/src/pymatgen/io/abinit/abitimer.py
@@ -14,6 +14,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from matplotlib.gridspec import GridSpec
+
 from pymatgen.io.core import ParseError
 from pymatgen.util.plotting import add_fig_kwargs, get_ax_fig
 

--- a/src/pymatgen/io/abinit/inputs.py
+++ b/src/pymatgen/io/abinit/inputs.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, NamedTuple
 import numpy as np
 from monty.collections import AttrDict
 from monty.json import MSONable
+
 from pymatgen.core.structure import Structure
 from pymatgen.io.abinit import abiobjects as aobj
 from pymatgen.io.abinit.pseudos import Pseudo, PseudoTable

--- a/src/pymatgen/io/abinit/netcdf.py
+++ b/src/pymatgen/io/abinit/netcdf.py
@@ -12,6 +12,7 @@ from monty.collections import AttrDict
 from monty.dev import requires
 from monty.functools import lazy_property
 from monty.string import marquee
+
 from pymatgen.core.structure import Structure
 from pymatgen.core.units import ArrayWithUnit
 from pymatgen.core.xcfunc import XcFunc

--- a/src/pymatgen/io/abinit/pseudos.py
+++ b/src/pymatgen/io/abinit/pseudos.py
@@ -24,11 +24,12 @@ from monty.functools import lazy_property
 from monty.itertools import iterator_from_slice
 from monty.json import MontyDecoder, MSONable
 from monty.os.path import find_exts
+from tabulate import tabulate
+
 from pymatgen.core import Element
 from pymatgen.core.xcfunc import XcFunc
 from pymatgen.io.core import ParseError
 from pymatgen.util.plotting import add_fig_kwargs, get_ax_fig
-from tabulate import tabulate
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
@@ -36,8 +37,9 @@ if TYPE_CHECKING:
 
     import matplotlib.pyplot as plt
     from numpy.typing import NDArray
-    from pymatgen.core import Structure
     from typing_extensions import Self
+
+    from pymatgen.core import Structure
 
 logger = logging.getLogger(__name__)
 

--- a/src/pymatgen/io/adf.py
+++ b/src/pymatgen/io/adf.py
@@ -10,6 +10,7 @@ from monty.io import reverse_readline
 from monty.itertools import chunks
 from monty.json import MSONable
 from monty.serialization import zopen
+
 from pymatgen.core.structure import Molecule
 
 if TYPE_CHECKING:

--- a/src/pymatgen/io/aims/inputs.py
+++ b/src/pymatgen/io/aims/inputs.py
@@ -17,14 +17,16 @@ import numpy as np
 from monty.io import zopen
 from monty.json import MontyDecoder, MSONable
 from monty.os.path import zpath
+
 from pymatgen.core import SETTINGS, Element, Lattice, Molecule, Structure
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from typing import Any
 
-    from pymatgen.util.typing import Tuple3Floats, Tuple3Ints
     from typing_extensions import Self
+
+    from pymatgen.util.typing import Tuple3Floats, Tuple3Ints
 
 __author__ = "Thomas A. R. Purcell"
 __version__ = "1.0"

--- a/src/pymatgen/io/aims/outputs.py
+++ b/src/pymatgen/io/aims/outputs.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from monty.json import MontyDecoder, MSONable
+
 from pymatgen.io.aims.parsers import (
     read_aims_header_info,
     read_aims_header_info_from_content,
@@ -18,9 +19,10 @@ if TYPE_CHECKING:
     from pathlib import Path
     from typing import Any
 
+    from typing_extensions import Self
+
     from pymatgen.core import Molecule, Structure
     from pymatgen.util.typing import Matrix3D, Vector3D
-    from typing_extensions import Self
 
 __author__ = "Andrey Sobolev and Thomas A. R. Purcell"
 __version__ = "1.0"

--- a/src/pymatgen/io/aims/parsers.py
+++ b/src/pymatgen/io/aims/parsers.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 import numpy as np
+
 from pymatgen.core import Lattice, Molecule, Structure
 from pymatgen.core.tensors import Tensor
 from pymatgen.util.typing import Tuple3Floats

--- a/src/pymatgen/io/aims/sets/base.py
+++ b/src/pymatgen/io/aims/sets/base.py
@@ -12,6 +12,7 @@ from warnings import warn
 
 import numpy as np
 from monty.json import MontyDecoder, MontyEncoder
+
 from pymatgen.core import Molecule, Structure
 from pymatgen.io.aims.inputs import AimsControlIn, AimsGeometryIn
 from pymatgen.io.aims.parsers import AimsParseError, read_aims_output

--- a/src/pymatgen/io/ase.py
+++ b/src/pymatgen/io/ase.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from monty.json import MontyDecoder, MSONable, jsanitize
+
 from pymatgen.core.structure import Molecule, Structure
 
 try:
@@ -35,8 +36,9 @@ if TYPE_CHECKING:
     from typing import Any
 
     from numpy.typing import ArrayLike
-    from pymatgen.core.structure import SiteCollection
     from typing_extensions import Self
+
+    from pymatgen.core.structure import SiteCollection
 
 __author__ = "Shyue Ping Ong, Andrew S. Rosen"
 __copyright__ = "Copyright 2012, The Materials Project"

--- a/src/pymatgen/io/atat.py
+++ b/src/pymatgen/io/atat.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import numpy as np
+
 from pymatgen.core import Lattice, Structure, get_el_sp
 
 __author__ = "Matthew Horton"

--- a/src/pymatgen/io/babel.py
+++ b/src/pymatgen/io/babel.py
@@ -11,6 +11,7 @@ import warnings
 from typing import TYPE_CHECKING
 
 from monty.dev import requires
+
 from pymatgen.core.structure import IMolecule, Molecule
 
 try:
@@ -19,8 +20,9 @@ except Exception:
     openbabel = pybel = None
 
 if TYPE_CHECKING:
-    from pymatgen.analysis.graphs import MoleculeGraph
     from typing_extensions import Self
+
+    from pymatgen.analysis.graphs import MoleculeGraph
 
 
 __author__ = "Shyue Ping Ong, Qi Wang"

--- a/src/pymatgen/io/cif.py
+++ b/src/pymatgen/io/cif.py
@@ -19,6 +19,7 @@ import numpy as np
 from monty.dev import deprecated
 from monty.io import zopen
 from monty.serialization import loadfn
+
 from pymatgen.core import Composition, DummySpecies, Element, Lattice, PeriodicSite, Species, Structure, get_el_sp
 from pymatgen.core.operations import MagSymmOp, SymmOp
 from pymatgen.electronic_structure.core import Magmom
@@ -32,8 +33,9 @@ if TYPE_CHECKING:
     from typing import Any
 
     from numpy.typing import NDArray
-    from pymatgen.util.typing import PathLike, Vector3D
     from typing_extensions import Self
+
+    from pymatgen.util.typing import PathLike, Vector3D
 
 __author__ = "Shyue Ping Ong, Will Richards, Matthew Horton"
 

--- a/src/pymatgen/io/common.py
+++ b/src/pymatgen/io/common.py
@@ -11,10 +11,11 @@ from typing import TYPE_CHECKING
 import numpy as np
 from monty.io import zopen
 from monty.json import MSONable
+from scipy.interpolate import RegularGridInterpolator
+
 from pymatgen.core import Element, Site, Structure
 from pymatgen.core.units import ang_to_bohr, bohr_to_angstrom
 from pymatgen.electronic_structure.core import Spin
-from scipy.interpolate import RegularGridInterpolator
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/src/pymatgen/io/core.py
+++ b/src/pymatgen/io/core.py
@@ -37,8 +37,9 @@ from monty.io import zopen
 from monty.json import MSONable
 
 if TYPE_CHECKING:
-    from pymatgen.util.typing import PathLike
     from typing_extensions import Self
+
+    from pymatgen.util.typing import PathLike
 
 
 __author__ = "Ryan Kingsbury"

--- a/src/pymatgen/io/cp2k/inputs.py
+++ b/src/pymatgen/io/cp2k/inputs.py
@@ -37,6 +37,7 @@ from typing import TYPE_CHECKING
 from monty.dev import deprecated
 from monty.io import zopen
 from monty.json import MSONable
+
 from pymatgen.core import Element
 from pymatgen.io.cp2k.utils import chunk, postprocessor, preprocessor
 from pymatgen.io.vasp.inputs import Kpoints as VaspKpoints
@@ -47,10 +48,11 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
     from typing import Any, Literal
 
+    from typing_extensions import Self
+
     from pymatgen.core.lattice import Lattice
     from pymatgen.core.structure import Molecule, Structure
     from pymatgen.util.typing import Kpoint, Tuple3Ints
-    from typing_extensions import Self
 
 __author__ = "Nicholas Winner"
 __version__ = "2.0"

--- a/src/pymatgen/io/cp2k/outputs.py
+++ b/src/pymatgen/io/cp2k/outputs.py
@@ -17,6 +17,7 @@ import pandas as pd
 from monty.io import zopen
 from monty.json import MSONable, jsanitize
 from monty.re import regrep
+
 from pymatgen.core.structure import Molecule, Structure
 from pymatgen.core.units import Ha_to_eV
 from pymatgen.electronic_structure.bandstructure import BandStructure, BandStructureSymmLine

--- a/src/pymatgen/io/cp2k/sets.py
+++ b/src/pymatgen/io/cp2k/sets.py
@@ -24,6 +24,8 @@ import os
 import warnings
 
 import numpy as np
+from ruamel.yaml import YAML
+
 from pymatgen.core import SETTINGS
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Element, Molecule, Structure
@@ -65,7 +67,6 @@ from pymatgen.io.cp2k.inputs import (
 from pymatgen.io.cp2k.utils import get_truncated_coulomb_cutoff, get_unique_site_indices
 from pymatgen.io.vasp.inputs import Kpoints as VaspKpoints
 from pymatgen.io.vasp.inputs import KpointsSupportedModes
-from ruamel.yaml import YAML
 
 __author__ = "Nicholas Winner"
 __version__ = "2.0"

--- a/src/pymatgen/io/cssr.py
+++ b/src/pymatgen/io/cssr.py
@@ -6,6 +6,7 @@ import re
 from typing import TYPE_CHECKING
 
 from monty.io import zopen
+
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Structure
 

--- a/src/pymatgen/io/exciting/inputs.py
+++ b/src/pymatgen/io/exciting/inputs.py
@@ -10,6 +10,7 @@ import numpy as np
 import scipy.constants as const
 from monty.io import zopen
 from monty.json import MSONable
+
 from pymatgen.core import Element, Lattice, Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.symmetry.bandstructure import HighSymmKpath

--- a/src/pymatgen/io/feff/inputs.py
+++ b/src/pymatgen/io/feff/inputs.py
@@ -15,13 +15,14 @@ from typing import TYPE_CHECKING
 import numpy as np
 from monty.io import zopen
 from monty.json import MSONable
+from tabulate import tabulate
+
 from pymatgen.core import Element, Lattice, Molecule, Structure
 from pymatgen.io.cif import CifParser
 from pymatgen.io.core import ParseError
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.util.io_utils import clean_lines
 from pymatgen.util.string import str_delimited
-from tabulate import tabulate
 
 if TYPE_CHECKING:
     from typing_extensions import Self

--- a/src/pymatgen/io/feff/outputs.py
+++ b/src/pymatgen/io/feff/outputs.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 from monty.io import zopen
 from monty.json import MSONable
+
 from pymatgen.core import Element
 from pymatgen.electronic_structure.core import Orbital, Spin
 from pymatgen.electronic_structure.dos import CompleteDos, Dos

--- a/src/pymatgen/io/feff/sets.py
+++ b/src/pymatgen/io/feff/sets.py
@@ -20,6 +20,7 @@ import numpy as np
 from monty.json import MSONable
 from monty.os.path import zpath
 from monty.serialization import loadfn
+
 from pymatgen.core.structure import Molecule, Structure
 from pymatgen.io.feff.inputs import Atoms, Header, Potential, Tags
 

--- a/src/pymatgen/io/fiesta.py
+++ b/src/pymatgen/io/fiesta.py
@@ -17,13 +17,15 @@ from typing import TYPE_CHECKING
 
 from monty.io import zopen
 from monty.json import MSONable
+
 from pymatgen.core.structure import Molecule
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from pymatgen.util.typing import Tuple3Ints
     from typing_extensions import Self
+
+    from pymatgen.util.typing import Tuple3Ints
 
 __author__ = "ndardenne"
 __copyright__ = "Copyright 2012, The Materials Project"

--- a/src/pymatgen/io/gaussian.py
+++ b/src/pymatgen/io/gaussian.py
@@ -9,13 +9,14 @@ from typing import TYPE_CHECKING
 import numpy as np
 import scipy.constants as cst
 from monty.io import zopen
+from scipy.stats import norm
+
 from pymatgen.core import Composition, Element, Molecule
 from pymatgen.core.operations import SymmOp
 from pymatgen.core.units import Ha_to_eV
 from pymatgen.electronic_structure.core import Spin
 from pymatgen.util.coord import get_angle
 from pymatgen.util.plotting import pretty_plot
-from scipy.stats import norm
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/src/pymatgen/io/lammps/data.py
+++ b/src/pymatgen/io/lammps/data.py
@@ -27,18 +27,20 @@ import pandas as pd
 from monty.io import zopen
 from monty.json import MSONable
 from monty.serialization import loadfn
+from ruamel.yaml import YAML
+
 from pymatgen.core import Element, Lattice, Molecule, Structure
 from pymatgen.core.operations import SymmOp
 from pymatgen.util.io_utils import clean_lines
-from ruamel.yaml import YAML
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from typing import Any, Literal
 
+    from typing_extensions import Self
+
     from pymatgen.core.sites import Site
     from pymatgen.core.structure import SiteCollection
-    from typing_extensions import Self
 
 __author__ = "Kiran Mathew, Zhi Deng, Tingzheng Hou"
 __copyright__ = "Copyright 2018, The Materials Virtual Lab"

--- a/src/pymatgen/io/lammps/generators.py
+++ b/src/pymatgen/io/lammps/generators.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, field
 from string import Template
 
 from monty.io import zopen
+
 from pymatgen.core import Structure
 from pymatgen.io.core import InputGenerator
 from pymatgen.io.lammps.data import CombinedData, LammpsData

--- a/src/pymatgen/io/lammps/inputs.py
+++ b/src/pymatgen/io/lammps/inputs.py
@@ -19,6 +19,7 @@ import numpy as np
 from monty.dev import deprecated
 from monty.io import zopen
 from monty.json import MSONable
+
 from pymatgen.core import __version__ as CURRENT_VER
 from pymatgen.io.core import InputFile
 from pymatgen.io.lammps.data import CombinedData, LammpsData
@@ -27,8 +28,9 @@ from pymatgen.io.template import TemplateInputGen
 if TYPE_CHECKING:
     from os import PathLike
 
-    from pymatgen.io.core import InputSet
     from typing_extensions import Self
+
+    from pymatgen.io.core import InputSet
 
 __author__ = "Kiran Mathew, Brandon Wood, Zhi Deng, Manas Likhit, Guillaume Brunin (Matgenix)"
 __copyright__ = "Copyright 2018, The Materials Virtual Lab"

--- a/src/pymatgen/io/lammps/outputs.py
+++ b/src/pymatgen/io/lammps/outputs.py
@@ -14,6 +14,7 @@ import numpy as np
 import pandas as pd
 from monty.io import zopen
 from monty.json import MSONable
+
 from pymatgen.io.lammps.data import LammpsBox
 
 if TYPE_CHECKING:

--- a/src/pymatgen/io/lammps/sets.py
+++ b/src/pymatgen/io/lammps/sets.py
@@ -18,8 +18,9 @@ from pymatgen.io.lammps.data import CombinedData, LammpsData
 from pymatgen.io.lammps.inputs import LammpsInputFile
 
 if TYPE_CHECKING:
-    from pymatgen.util.typing import PathLike
     from typing_extensions import Self
+
+    from pymatgen.util.typing import PathLike
 
 __author__ = "Ryan Kingsbury, Guillaume Brunin (Matgenix)"
 __copyright__ = "Copyright 2021, The Materials Project"

--- a/src/pymatgen/io/lammps/utils.py
+++ b/src/pymatgen/io/lammps/utils.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 from monty.dev import deprecated
 from monty.tempfile import ScratchDir
+
 from pymatgen.core.operations import SymmOp
 from pymatgen.core.structure import Molecule
 from pymatgen.io.babel import BabelMolAdaptor

--- a/src/pymatgen/io/lmto.py
+++ b/src/pymatgen/io/lmto.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, no_type_check
 
 import numpy as np
 from monty.io import zopen
+
 from pymatgen.core.structure import Structure
 from pymatgen.core.units import Ry_to_eV, bohr_to_angstrom
 from pymatgen.electronic_structure.core import Spin

--- a/src/pymatgen/io/lobster/inputs.py
+++ b/src/pymatgen/io/lobster/inputs.py
@@ -22,6 +22,7 @@ import spglib
 from monty.io import zopen
 from monty.json import MSONable
 from monty.serialization import loadfn
+
 from pymatgen.core.structure import Structure
 from pymatgen.io.vasp import Vasprun
 from pymatgen.io.vasp.inputs import Incar, Kpoints, Potcar
@@ -31,9 +32,10 @@ from pymatgen.util.due import Doi, due
 if TYPE_CHECKING:
     from typing import Any, ClassVar, Literal
 
+    from typing_extensions import Self
+
     from pymatgen.core.composition import Composition
     from pymatgen.util.typing import PathLike, Tuple3Ints
-    from typing_extensions import Self
 
 MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
 

--- a/src/pymatgen/io/lobster/lobsterenv.py
+++ b/src/pymatgen/io/lobster/lobsterenv.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, NamedTuple
 
 import numpy as np
 from monty.dev import deprecated
+
 from pymatgen.analysis.bond_valence import BVAnalyzer
 from pymatgen.analysis.chemenv.coordination_environments.coordination_geometry_finder import LocalGeometryFinder
 from pymatgen.analysis.chemenv.coordination_environments.structure_environments import LightStructureEnvironments
@@ -31,9 +32,10 @@ from pymatgen.io.lobster import Charge, Icohplist
 from pymatgen.util.due import Doi, due
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from pymatgen.core import Structure
     from pymatgen.core.periodic_table import Element
-    from typing_extensions import Self
 
 __author__ = "Janine George"
 __copyright__ = "Copyright 2021, The Materials Project"

--- a/src/pymatgen/io/lobster/outputs.py
+++ b/src/pymatgen/io/lobster/outputs.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 from monty.io import zopen
 from monty.json import MSONable
+
 from pymatgen.core.structure import Structure
 from pymatgen.electronic_structure.bandstructure import LobsterBandStructureSymmLine
 from pymatgen.electronic_structure.core import Orbital, Spin

--- a/src/pymatgen/io/nwchem.py
+++ b/src/pymatgen/io/nwchem.py
@@ -29,6 +29,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 from monty.io import zopen
 from monty.json import MSONable
+
 from pymatgen.analysis.excitation import ExcitationSpectrum
 from pymatgen.core.structure import Molecule, Structure
 from pymatgen.core.units import Energy, FloatWithUnit

--- a/src/pymatgen/io/openff.py
+++ b/src/pymatgen/io/openff.py
@@ -6,6 +6,7 @@ import warnings
 from pathlib import Path
 
 import numpy as np
+
 import pymatgen
 from pymatgen.analysis.graphs import MoleculeGraph
 from pymatgen.analysis.local_env import OpenBabelNN, metal_edge_extender

--- a/src/pymatgen/io/packmol.py
+++ b/src/pymatgen/io/packmol.py
@@ -26,6 +26,7 @@ from shutil import which
 from typing import TYPE_CHECKING
 
 import numpy as np
+
 from pymatgen.core import Molecule
 from pymatgen.io.core import InputGenerator, InputSet
 

--- a/src/pymatgen/io/phonopy.py
+++ b/src/pymatgen/io/phonopy.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 import numpy as np
 from monty.dev import requires
 from monty.serialization import loadfn
+from scipy.interpolate import InterpolatedUnivariateSpline
+
 from pymatgen.core import Lattice, Structure
 from pymatgen.phonon.bandstructure import PhononBandStructure, PhononBandStructureSymmLine
 from pymatgen.phonon.dos import CompletePhononDos, PhononDos
 from pymatgen.phonon.gruneisen import GruneisenParameter, GruneisenPhononBandStructureSymmLine
 from pymatgen.phonon.thermal_displacements import ThermalDisplacementMatrices
 from pymatgen.symmetry.bandstructure import HighSymmKpath
-from scipy.interpolate import InterpolatedUnivariateSpline
 
 try:
     from phonopy import Phonopy

--- a/src/pymatgen/io/pwmat/inputs.py
+++ b/src/pymatgen/io/pwmat/inputs.py
@@ -8,12 +8,14 @@ from typing import TYPE_CHECKING
 import numpy as np
 from monty.io import zopen
 from monty.json import MSONable
+
 from pymatgen.core import Lattice, Structure
 from pymatgen.symmetry.kpath import KPathSeek
 
 if TYPE_CHECKING:
-    from pymatgen.util.typing import PathLike
     from typing_extensions import Self
+
+    from pymatgen.util.typing import PathLike
 
 __author__ = "Hanyu Liu"
 __email__ = "domainofbuaa@gmail.com"

--- a/src/pymatgen/io/pwmat/outputs.py
+++ b/src/pymatgen/io/pwmat/outputs.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 from monty.io import zopen
 from monty.json import MSONable
+
 from pymatgen.io.pwmat.inputs import ACstrExtractor, AtomConfig, LineLocator
 
 if TYPE_CHECKING:

--- a/src/pymatgen/io/pwscf.py
+++ b/src/pymatgen/io/pwscf.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 from monty.io import zopen
 from monty.re import regrep
+
 from pymatgen.core import Element, Lattice, Structure
 from pymatgen.util.io_utils import clean_lines
 

--- a/src/pymatgen/io/qchem/inputs.py
+++ b/src/pymatgen/io/qchem/inputs.py
@@ -7,6 +7,7 @@ import re
 from typing import TYPE_CHECKING
 
 from monty.io import zopen
+
 from pymatgen.core import Molecule
 from pymatgen.io.core import InputFile
 

--- a/src/pymatgen/io/qchem/outputs.py
+++ b/src/pymatgen/io/qchem/outputs.py
@@ -16,6 +16,7 @@ import numpy as np
 import pandas as pd
 from monty.io import zopen
 from monty.json import MSONable, jsanitize
+
 from pymatgen.analysis.graphs import MoleculeGraph
 from pymatgen.analysis.local_env import OpenBabelNN
 from pymatgen.core import Molecule

--- a/src/pymatgen/io/qchem/sets.py
+++ b/src/pymatgen/io/qchem/sets.py
@@ -8,6 +8,7 @@ import warnings
 from typing import TYPE_CHECKING
 
 from monty.io import zopen
+
 from pymatgen.io.qchem.inputs import QCInput
 from pymatgen.io.qchem.utils import lower_and_check_unique
 

--- a/src/pymatgen/io/res.py
+++ b/src/pymatgen/io/res.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING
 
 from monty.io import zopen
 from monty.json import MSONable
+
 from pymatgen.core import Element, Lattice, PeriodicSite, Structure
 from pymatgen.entries.computed_entries import ComputedStructureEntry
 from pymatgen.io.core import ParseError
@@ -27,8 +28,9 @@ if TYPE_CHECKING:
     from pathlib import Path
     from typing import Any, Callable, Literal
 
-    from pymatgen.util.typing import Tuple3Ints, Vector3D
     from typing_extensions import Self
+
+    from pymatgen.util.typing import Tuple3Ints, Vector3D
 
 
 @dataclass(frozen=True)

--- a/src/pymatgen/io/shengbte.py
+++ b/src/pymatgen/io/shengbte.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 from monty.dev import requires
 from monty.json import MSONable
+
 from pymatgen.core.structure import Structure
 from pymatgen.io.vasp import Kpoints
 

--- a/src/pymatgen/io/template.py
+++ b/src/pymatgen/io/template.py
@@ -9,6 +9,7 @@ from string import Template
 from typing import TYPE_CHECKING
 
 from monty.io import zopen
+
 from pymatgen.io.core import InputGenerator, InputSet
 
 if TYPE_CHECKING:

--- a/src/pymatgen/io/vasp/inputs.py
+++ b/src/pymatgen/io/vasp/inputs.py
@@ -31,21 +31,23 @@ from monty.json import MontyDecoder, MSONable
 from monty.os import cd
 from monty.os.path import zpath
 from monty.serialization import dumpfn, loadfn
+from tabulate import tabulate
+
 from pymatgen.core import SETTINGS, Element, Lattice, Structure, get_el_sp
 from pymatgen.electronic_structure.core import Magmom
 from pymatgen.util.io_utils import clean_lines
 from pymatgen.util.string import str_delimited
 from pymatgen.util.typing import Kpoint, Tuple3Floats, Tuple3Ints, Vector3D
-from tabulate import tabulate
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
     from typing import Any, ClassVar, Literal
 
     from numpy.typing import ArrayLike
+    from typing_extensions import Self
+
     from pymatgen.symmetry.bandstructure import HighSymmKpath
     from pymatgen.util.typing import PathLike
-    from typing_extensions import Self
 
 
 __author__ = "Shyue Ping Ong, Geoffroy Hautier, Rickard Armiento, Vincent L Chevrier, Stephen Dacek"

--- a/src/pymatgen/io/vasp/optics.py
+++ b/src/pymatgen/io/vasp/optics.py
@@ -10,14 +10,16 @@ import numpy as np
 import scipy.constants
 import scipy.special
 from monty.json import MSONable
+from tqdm import tqdm
+
 from pymatgen.electronic_structure.core import Spin
 from pymatgen.io.vasp.outputs import Vasprun, Waveder
-from tqdm import tqdm
 
 if TYPE_CHECKING:
     from numpy.typing import ArrayLike, NDArray
-    from pymatgen.util.typing import PathLike
     from typing_extensions import Self
+
+    from pymatgen.util.typing import PathLike
 
 __author__ = "Jimmy-Xuan Shen"
 __copyright__ = "Copyright 2022, The Materials Project"

--- a/src/pymatgen/io/vasp/outputs.py
+++ b/src/pymatgen/io/vasp/outputs.py
@@ -24,6 +24,7 @@ from monty.json import MSONable, jsanitize
 from monty.os.path import zpath
 from monty.re import regrep
 from numpy.testing import assert_allclose
+
 from pymatgen.core import Composition, Element, Lattice, Structure
 from pymatgen.core.trajectory import Trajectory
 from pymatgen.core.units import unitized
@@ -50,8 +51,9 @@ if TYPE_CHECKING:
     from xml.etree.ElementTree import Element as XML_Element
 
     from numpy.typing import NDArray
-    from pymatgen.util.typing import PathLike
     from typing_extensions import Self
+
+    from pymatgen.util.typing import PathLike
 
 logger = logging.getLogger(__name__)
 

--- a/src/pymatgen/io/vasp/sets.py
+++ b/src/pymatgen/io/vasp/sets.py
@@ -45,6 +45,7 @@ import numpy as np
 from monty.dev import deprecated
 from monty.json import MSONable
 from monty.serialization import loadfn
+
 from pymatgen.analysis.structure_matcher import StructureMatcher
 from pymatgen.core import Element, PeriodicSite, SiteCollection, Species, Structure
 from pymatgen.io.core import InputGenerator
@@ -58,8 +59,9 @@ from pymatgen.util.typing import Kpoint
 if TYPE_CHECKING:
     from typing import Callable, Literal, Union
 
-    from pymatgen.util.typing import PathLike, Tuple3Ints, Vector3D
     from typing_extensions import Self
+
+    from pymatgen.util.typing import PathLike, Tuple3Ints, Vector3D
 
     UserPotcarFunctional = Union[
         Literal["PBE", "PBE_52", "PBE_54", "LDA", "LDA_52", "LDA_54", "PW91", "LDA_US", "PW91_US"], None

--- a/src/pymatgen/io/xr.py
+++ b/src/pymatgen/io/xr.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from monty.io import zopen
+
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Structure
 

--- a/src/pymatgen/io/xtb/outputs.py
+++ b/src/pymatgen/io/xtb/outputs.py
@@ -7,6 +7,7 @@ import os
 import re
 
 from monty.json import MSONable
+
 from pymatgen.core import Molecule
 from pymatgen.io.xyz import XYZ
 

--- a/src/pymatgen/io/xyz.py
+++ b/src/pymatgen/io/xyz.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, cast
 
 import pandas as pd
 from monty.io import zopen
+
 from pymatgen.core import Molecule, Structure
 from pymatgen.core.structure import SiteCollection
 

--- a/src/pymatgen/io/zeopp.py
+++ b/src/pymatgen/io/zeopp.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING
 from monty.dev import requires
 from monty.io import zopen
 from monty.tempfile import ScratchDir
+
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Molecule, Structure
 from pymatgen.io.cssr import Cssr

--- a/src/pymatgen/phonon/bandstructure.py
+++ b/src/pymatgen/phonon/bandstructure.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from monty.json import MSONable
+
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Structure
 from pymatgen.electronic_structure.bandstructure import Kpoint
@@ -17,8 +18,9 @@ if TYPE_CHECKING:
     from typing import Any
 
     from numpy.typing import ArrayLike
-    from pymatgen.util.typing import Tuple3Ints
     from typing_extensions import Self
+
+    from pymatgen.util.typing import Tuple3Ints
 
 
 def get_reasonable_repetitions(n_atoms: int) -> Tuple3Ints:

--- a/src/pymatgen/phonon/dos.py
+++ b/src/pymatgen/phonon/dos.py
@@ -8,9 +8,10 @@ import numpy as np
 import scipy.constants as const
 from monty.functools import lazy_property
 from monty.json import MSONable
+from scipy.ndimage import gaussian_filter1d
+
 from pymatgen.core.structure import Structure
 from pymatgen.util.coord import get_linear_interpolated_value
-from scipy.ndimage import gaussian_filter1d
 
 if TYPE_CHECKING:
     from collections.abc import Sequence

--- a/src/pymatgen/phonon/gruneisen.py
+++ b/src/pymatgen/phonon/gruneisen.py
@@ -8,12 +8,13 @@ import numpy as np
 import scipy.constants as const
 from monty.dev import requires
 from monty.json import MSONable
+from scipy.interpolate import UnivariateSpline
+
 from pymatgen.core import Structure
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.units import amu_to_kg
 from pymatgen.phonon.bandstructure import PhononBandStructure, PhononBandStructureSymmLine
 from pymatgen.phonon.dos import PhononDos
-from scipy.interpolate import UnivariateSpline
 
 try:
     import phonopy

--- a/src/pymatgen/phonon/ir_spectra.py
+++ b/src/pymatgen/phonon/ir_spectra.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from monty.json import MSONable
+
 from pymatgen.core.spectrum import Spectrum
 from pymatgen.core.structure import Structure
 from pymatgen.util.plotting import add_fig_kwargs

--- a/src/pymatgen/phonon/plotter.py
+++ b/src/pymatgen/phonon/plotter.py
@@ -12,6 +12,7 @@ from matplotlib import colors
 from matplotlib.collections import LineCollection
 from matplotlib.colors import LinearSegmentedColormap
 from monty.json import jsanitize
+
 from pymatgen.electronic_structure.plotter import BSDOSPlotter, plot_brillouin_zone
 from pymatgen.phonon.bandstructure import PhononBandStructureSymmLine
 from pymatgen.phonon.gruneisen import GruneisenPhononBandStructureSymmLine
@@ -24,6 +25,7 @@ if TYPE_CHECKING:
 
     from matplotlib.axes import Axes
     from matplotlib.figure import Figure
+
     from pymatgen.core import Structure
     from pymatgen.phonon.dos import PhononDos
     from pymatgen.phonon.gruneisen import GruneisenParameter

--- a/src/pymatgen/phonon/thermal_displacements.py
+++ b/src/pymatgen/phonon/thermal_displacements.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from monty.json import MSONable
+
 from pymatgen.analysis.structure_matcher import StructureMatcher
 from pymatgen.core.structure import Structure
 from pymatgen.io.cif import CifFile, CifParser, CifWriter, str2float

--- a/src/pymatgen/symmetry/analyzer.py
+++ b/src/pymatgen/symmetry/analyzer.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import scipy.cluster
 import spglib
+
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.operations import SymmOp
 from pymatgen.core.structure import Molecule, PeriodicSite, Structure
@@ -36,11 +37,12 @@ if TYPE_CHECKING:
     from typing import Any, Literal
 
     from numpy.typing import NDArray
+    from spglib import SpglibDataset
+
     from pymatgen.core import Element, Species
     from pymatgen.core.sites import Site
     from pymatgen.symmetry.groups import CrystalSystem
     from pymatgen.util.typing import Kpoint
-    from spglib import SpglibDataset
 
     LatticeType = Literal["cubic", "hexagonal", "monoclinic", "orthorhombic", "rhombohedral", "tetragonal", "triclinic"]
 

--- a/src/pymatgen/symmetry/bandstructure.py
+++ b/src/pymatgen/symmetry/bandstructure.py
@@ -9,6 +9,7 @@ from warnings import warn
 
 import networkx as nx
 import numpy as np
+
 from pymatgen.electronic_structure.bandstructure import BandStructureSymmLine
 from pymatgen.electronic_structure.core import Spin
 from pymatgen.symmetry.analyzer import cite_conventional_cell_algo

--- a/src/pymatgen/symmetry/groups.py
+++ b/src/pymatgen/symmetry/groups.py
@@ -17,17 +17,19 @@ from typing import TYPE_CHECKING, overload
 import numpy as np
 from monty.design_patterns import cached_class
 from monty.serialization import loadfn
+
 from pymatgen.util.string import Stringify
 
 if TYPE_CHECKING:
     from typing import ClassVar, Literal
 
     from numpy.typing import ArrayLike
+    from typing_extensions import Self
+
     from pymatgen.core.lattice import Lattice
 
     # Don't import at runtime to avoid circular import
     from pymatgen.core.operations import SymmOp  # noqa: TCH004
-    from typing_extensions import Self
 
     CrystalSystem = Literal["cubic", "hexagonal", "monoclinic", "orthorhombic", "tetragonal", "triclinic", "trigonal"]
 

--- a/src/pymatgen/symmetry/kpath.py
+++ b/src/pymatgen/symmetry/kpath.py
@@ -12,6 +12,7 @@ import networkx as nx
 import numpy as np
 import spglib
 from monty.dev import requires
+
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.operations import MagSymmOp, SymmOp
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer, cite_conventional_cell_algo

--- a/src/pymatgen/symmetry/maggroups.py
+++ b/src/pymatgen/symmetry/maggroups.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from monty.design_patterns import cached_class
+
 from pymatgen.core.operations import MagSymmOp
 from pymatgen.electronic_structure.core import Magmom
 from pymatgen.symmetry.groups import SymmetryGroup, in_array_list
@@ -20,8 +21,9 @@ from pymatgen.util.string import transformation_to_string
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from pymatgen.core.lattice import Lattice
     from typing_extensions import Self
+
+    from pymatgen.core.lattice import Lattice
 
 __author__ = "Matthew Horton, Shyue Ping Ong"
 

--- a/src/pymatgen/symmetry/settings.py
+++ b/src/pymatgen/symmetry/settings.py
@@ -7,11 +7,12 @@ from fractions import Fraction
 from typing import TYPE_CHECKING
 
 import numpy as np
+from sympy import Matrix
+from sympy.parsing.sympy_parser import parse_expr
+
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.operations import MagSymmOp, SymmOp
 from pymatgen.util.string import transformation_to_string
-from sympy import Matrix
-from sympy.parsing.sympy_parser import parse_expr
 
 if TYPE_CHECKING:
     from typing_extensions import Self

--- a/src/pymatgen/symmetry/site_symmetries.py
+++ b/src/pymatgen/symmetry/site_symmetries.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import numpy as np
+
 from pymatgen.core.operations import SymmOp
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 

--- a/src/pymatgen/symmetry/structure.py
+++ b/src/pymatgen/symmetry/structure.py
@@ -5,14 +5,16 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import numpy as np
-from pymatgen.core.structure import PeriodicSite, Structure
 from tabulate import tabulate
+
+from pymatgen.core.structure import PeriodicSite, Structure
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from pymatgen.symmetry.analyzer import SpacegroupOperations
     from typing_extensions import Self
+
+    from pymatgen.symmetry.analyzer import SpacegroupOperations
 
 
 class SymmetrizedStructure(Structure):

--- a/src/pymatgen/transformations/advanced_transformations.py
+++ b/src/pymatgen/transformations/advanced_transformations.py
@@ -16,6 +16,7 @@ from joblib import Parallel, delayed
 from monty.dev import requires
 from monty.fractions import lcm
 from monty.json import MSONable
+
 from pymatgen.analysis.adsorption import AdsorbateSiteFinder
 from pymatgen.analysis.bond_valence import BVAnalyzer
 from pymatgen.analysis.energy_models import SymmetryModel

--- a/src/pymatgen/transformations/site_transformations.py
+++ b/src/pymatgen/transformations/site_transformations.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from monty.json import MSONable
+
 from pymatgen.analysis.ewald import EwaldMinimizer, EwaldSummation
 from pymatgen.analysis.local_env import MinimumDistanceNN
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer

--- a/src/pymatgen/transformations/standard_transformations.py
+++ b/src/pymatgen/transformations/standard_transformations.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from numpy import around
+
 from pymatgen.analysis.bond_valence import BVAnalyzer
 from pymatgen.analysis.elasticity.strain import Deformation
 from pymatgen.analysis.ewald import EwaldMinimizer, EwaldSummation
@@ -24,9 +25,10 @@ from pymatgen.transformations.site_transformations import PartialRemoveSitesTran
 from pymatgen.transformations.transformation_abc import AbstractTransformation
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from pymatgen.core.sites import PeriodicSite
     from pymatgen.util.typing import SpeciesLike
-    from typing_extensions import Self
 
 logger = logging.getLogger(__name__)
 

--- a/src/pymatgen/util/coord.py
+++ b/src/pymatgen/util/coord.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from monty.json import MSONable
+
 from pymatgen.util import coord_cython
 
 if TYPE_CHECKING:
@@ -18,6 +19,7 @@ if TYPE_CHECKING:
     from typing import Literal
 
     from numpy.typing import ArrayLike
+
     from pymatgen.util.typing import PbcLike
 
 

--- a/src/pymatgen/util/due.py
+++ b/src/pymatgen/util/due.py
@@ -5,7 +5,7 @@ Then use in your code as
 
     from .due import due, Doi, BibTeX, Text
 
-See  https://github.com/duecredit/duecredit/blob/master/README.md for examples.
+See https://github.com/duecredit/duecredit/blob/master/README.md for examples.
 
 Origin:     Originally a part of the duecredit
 Copyright:  2015-2021  DueCredit developers

--- a/src/pymatgen/util/plotting.py
+++ b/src/pymatgen/util/plotting.py
@@ -12,6 +12,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import palettable.colorbrewer.diverging
 from matplotlib import cm, colors
+
 from pymatgen.core import Element
 
 if TYPE_CHECKING:

--- a/src/pymatgen/util/provenance.py
+++ b/src/pymatgen/util/provenance.py
@@ -10,6 +10,7 @@ from io import StringIO
 from typing import TYPE_CHECKING, NamedTuple
 
 from monty.json import MontyDecoder, MontyEncoder
+
 from pymatgen.core.structure import Molecule, Structure
 
 try:

--- a/src/pymatgen/util/testing/__init__.py
+++ b/src/pymatgen/util/testing/__init__.py
@@ -17,6 +17,7 @@ from unittest import TestCase
 import pytest
 from monty.json import MontyDecoder, MontyEncoder, MSONable
 from monty.serialization import loadfn
+
 from pymatgen.core import ROOT, SETTINGS, Structure
 
 if TYPE_CHECKING:

--- a/src/pymatgen/util/testing/aims.py
+++ b/src/pymatgen/util/testing/aims.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import numpy as np
 from monty.io import zopen
+
 from pymatgen.core import Molecule, Structure
 
 

--- a/src/pymatgen/vis/plotters.py
+++ b/src/pymatgen/vis/plotters.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib
 
 import matplotlib.pyplot as plt
+
 from pymatgen.util.plotting import pretty_plot
 
 

--- a/src/pymatgen/vis/structure_chemview.py
+++ b/src/pymatgen/vis/structure_chemview.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import numpy as np
+
 from pymatgen.analysis.molecule_structure_comparator import CovalentRadius
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 

--- a/src/pymatgen/vis/structure_vtk.py
+++ b/src/pymatgen/vis/structure_vtk.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 from monty.dev import requires
 from monty.serialization import loadfn
+
 from pymatgen.core import PeriodicSite, Species, Structure
 from pymatgen.util.coord import in_coord_list
 

--- a/tasks.py
+++ b/tasks.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING
 import requests
 from invoke import task
 from monty.os import cd
+
 from pymatgen.core import __version__
 
 if TYPE_CHECKING:

--- a/tests/alchemy/test_filters.py
+++ b/tests/alchemy/test_filters.py
@@ -4,6 +4,7 @@ import json
 from unittest import TestCase
 
 from monty.json import MontyDecoder
+
 from pymatgen.alchemy.filters import (
     ContainsSpecieFilter,
     RemoveDuplicatesFilter,

--- a/tests/alchemy/test_materials.py
+++ b/tests/alchemy/test_materials.py
@@ -4,6 +4,7 @@ import json
 from copy import deepcopy
 
 import pytest
+
 from pymatgen.alchemy.filters import ContainsSpecieFilter
 from pymatgen.alchemy.materials import TransformedStructure
 from pymatgen.core import SETTINGS

--- a/tests/analysis/chemenv/connectivity/test_connected_components.py
+++ b/tests/analysis/chemenv/connectivity/test_connected_components.py
@@ -7,6 +7,7 @@ import networkx as nx
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
+
 from pymatgen.analysis.chemenv.connectivity.connected_components import ConnectedComponent
 from pymatgen.analysis.chemenv.connectivity.connectivity_finder import ConnectivityFinder
 from pymatgen.analysis.chemenv.connectivity.environment_nodes import EnvironmentNode

--- a/tests/analysis/chemenv/coordination_environments/test_chemenv_strategies.py
+++ b/tests/analysis/chemenv/coordination_environments/test_chemenv_strategies.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import pytest
+from pytest import approx
+
 from pymatgen.analysis.chemenv.coordination_environments.chemenv_strategies import (
     AdditionalConditionInt,
     AngleCutoffFloat,
@@ -9,7 +11,6 @@ from pymatgen.analysis.chemenv.coordination_environments.chemenv_strategies impo
     SimplestChemenvStrategy,
 )
 from pymatgen.util.testing import PymatgenTest
-from pytest import approx
 
 __author__ = "waroquiers"
 

--- a/tests/analysis/chemenv/coordination_environments/test_coordination_geometries.py
+++ b/tests/analysis/chemenv/coordination_environments/test_coordination_geometries.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
+from pytest import approx
+
 from pymatgen.analysis.chemenv.coordination_environments.coordination_geometries import (
     AllCoordinationGeometries,
     CoordinationGeometry,
@@ -10,7 +12,6 @@ from pymatgen.analysis.chemenv.coordination_environments.coordination_geometries
     SeparationPlane,
 )
 from pymatgen.util.testing import PymatgenTest
-from pytest import approx
 
 __author__ = "waroquiers"
 

--- a/tests/analysis/chemenv/coordination_environments/test_coordination_geometry_finder.py
+++ b/tests/analysis/chemenv/coordination_environments/test_coordination_geometry_finder.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
+from pytest import approx
+
 from pymatgen.analysis.chemenv.coordination_environments.coordination_geometries import AllCoordinationGeometries
 from pymatgen.analysis.chemenv.coordination_environments.coordination_geometry_finder import (
     AbstractGeometry,
@@ -11,7 +13,6 @@ from pymatgen.analysis.chemenv.coordination_environments.coordination_geometry_f
 )
 from pymatgen.core.structure import Lattice, Structure
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
 
 __author__ = "waroquiers"
 

--- a/tests/analysis/chemenv/coordination_environments/test_read_write.py
+++ b/tests/analysis/chemenv/coordination_environments/test_read_write.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 
 from numpy.testing import assert_allclose
+from pytest import approx
+
 from pymatgen.analysis.chemenv.coordination_environments.chemenv_strategies import (
     AngleNbSetWeight,
     CNBiasNbSetWeight,
@@ -21,7 +23,6 @@ from pymatgen.analysis.chemenv.coordination_environments.structure_environments 
 from pymatgen.analysis.chemenv.coordination_environments.voronoi import DetailedVoronoiContainer
 from pymatgen.core.structure import Structure
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
 
 __author__ = "waroquiers"
 

--- a/tests/analysis/chemenv/coordination_environments/test_structure_environments.py
+++ b/tests/analysis/chemenv/coordination_environments/test_structure_environments.py
@@ -5,6 +5,8 @@ import os
 
 import numpy as np
 from numpy.testing import assert_allclose
+from pytest import approx
+
 from pymatgen.analysis.chemenv.coordination_environments.chemenv_strategies import (
     MultiWeightsChemenvStrategy,
     SimplestChemenvStrategy,
@@ -16,7 +18,6 @@ from pymatgen.analysis.chemenv.coordination_environments.structure_environments 
 )
 from pymatgen.core import Species, Structure
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
 
 __author__ = "waroquiers"
 

--- a/tests/analysis/chemenv/coordination_environments/test_voronoi.py
+++ b/tests/analysis/chemenv/coordination_environments/test_voronoi.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import random
 
 import numpy as np
+
 from pymatgen.analysis.chemenv.coordination_environments.voronoi import DetailedVoronoiContainer
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Structure

--- a/tests/analysis/chemenv/coordination_environments/test_weights.py
+++ b/tests/analysis/chemenv/coordination_environments/test_weights.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 
 import pytest
+from pytest import approx
+
 from pymatgen.analysis.chemenv.coordination_environments.chemenv_strategies import (
     AngleNbSetWeight,
     CNBiasNbSetWeight,
@@ -15,7 +17,6 @@ from pymatgen.analysis.chemenv.coordination_environments.chemenv_strategies impo
 )
 from pymatgen.analysis.chemenv.coordination_environments.structure_environments import StructureEnvironments
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
 
 __author__ = "waroquiers"
 

--- a/tests/analysis/chemenv/utils/test_coordination_geometry_utils.py
+++ b/tests/analysis/chemenv/utils/test_coordination_geometry_utils.py
@@ -5,9 +5,10 @@ import random
 
 import numpy as np
 from numpy.testing import assert_allclose
+from pytest import approx
+
 from pymatgen.analysis.chemenv.utils.coordination_geometry_utils import Plane
 from pymatgen.util.testing import PymatgenTest
-from pytest import approx
 
 __author__ = "David Waroquiers"
 

--- a/tests/analysis/chemenv/utils/test_func_utils.py
+++ b/tests/analysis/chemenv/utils/test_func_utils.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
+from pytest import approx
+
 from pymatgen.analysis.chemenv.utils.func_utils import (
     CSMFiniteRatioFunction,
     CSMInfiniteRatioFunction,
     DeltaCSMRatioFunction,
 )
-from pytest import approx
 
 __author__ = "waroquiers"
 

--- a/tests/analysis/chemenv/utils/test_graph_utils.py
+++ b/tests/analysis/chemenv/utils/test_graph_utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 from numpy.testing import assert_allclose
+
 from pymatgen.analysis.chemenv.connectivity.environment_nodes import EnvironmentNode
 from pymatgen.analysis.chemenv.utils.graph_utils import MultiGraphCycle, SimpleGraphCycle, get_delta
 from pymatgen.util.testing import PymatgenTest

--- a/tests/analysis/chemenv/utils/test_math_utils.py
+++ b/tests/analysis/chemenv/utils/test_math_utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 from numpy.testing import assert_allclose
+
 from pymatgen.analysis.chemenv.utils.math_utils import (
     _cartesian_product,
     cosinus_step,

--- a/tests/analysis/diffraction/test_neutron.py
+++ b/tests/analysis/diffraction/test_neutron.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import pytest
+from pytest import approx
+
 from pymatgen.analysis.diffraction.neutron import NDCalculator
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Structure
 from pymatgen.util.testing import PymatgenTest
-from pytest import approx
 
 """
 These calculated values were verified with VESTA and FullProf.

--- a/tests/analysis/diffraction/test_tem.py
+++ b/tests/analysis/diffraction/test_tem.py
@@ -6,11 +6,12 @@ import numpy as np
 import pandas as pd
 import plotly.graph_objects as go
 from numpy.testing import assert_allclose
+from pytest import approx
+
 from pymatgen.analysis.diffraction.tem import TEMCalculator
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Structure
 from pymatgen.util.testing import PymatgenTest
-from pytest import approx
 
 __author__ = "Frank Wan, Jason Liang"
 __copyright__ = "Copyright 2019, The Materials Project"

--- a/tests/analysis/diffraction/test_xrd.py
+++ b/tests/analysis/diffraction/test_xrd.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import pytest
+from pytest import approx
+
 from pymatgen.analysis.diffraction.xrd import XRDCalculator
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Structure
 from pymatgen.util.testing import PymatgenTest
-from pytest import approx
 
 """
 TODO: Modify unittest doc.

--- a/tests/analysis/elasticity/test_elastic.py
+++ b/tests/analysis/elasticity/test_elastic.py
@@ -8,6 +8,9 @@ from copy import deepcopy
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
+from pytest import approx
+from scipy.misc import central_diff_weights
+
 from pymatgen.analysis.elasticity.elastic import (
     ComplianceTensor,
     ElasticTensor,
@@ -26,8 +29,6 @@ from pymatgen.core.structure import Structure
 from pymatgen.core.tensors import Tensor
 from pymatgen.core.units import FloatWithUnit
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
-from scipy.misc import central_diff_weights
 
 TEST_DIR = f"{TEST_FILES_DIR}/analysis/elasticity"
 

--- a/tests/analysis/elasticity/test_strain.py
+++ b/tests/analysis/elasticity/test_strain.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
+
 from pymatgen.analysis.elasticity.strain import Deformation, DeformedStructureSet, Strain, convert_strain_to_deformation
 from pymatgen.core.structure import Structure
 from pymatgen.core.tensors import Tensor

--- a/tests/analysis/elasticity/test_stress.py
+++ b/tests/analysis/elasticity/test_stress.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
+from pytest import approx
+
 from pymatgen.analysis.elasticity.strain import Deformation
 from pymatgen.analysis.elasticity.stress import Stress
 from pymatgen.util.testing import PymatgenTest
-from pytest import approx
 
 
 class TestStress(PymatgenTest):

--- a/tests/analysis/ferroelectricity/test_polarization.py
+++ b/tests/analysis/ferroelectricity/test_polarization.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import numpy as np
 from numpy.testing import assert_allclose
+from pytest import approx
+
 from pymatgen.analysis.ferroelectricity.polarization import (
     EnergyTrend,
     Polarization,
@@ -12,7 +14,6 @@ from pymatgen.core.structure import Structure
 from pymatgen.io.vasp.inputs import Potcar
 from pymatgen.io.vasp.outputs import Outcar
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
 
 TEST_DIR = f"{TEST_FILES_DIR}/io/vasp/fixtures/BTO_221_99_polarization"
 bto_folders = ["nonpolar_polarization"]

--- a/tests/analysis/interfaces/test_coherent_interface.py
+++ b/tests/analysis/interfaces/test_coherent_interface.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from numpy.testing import assert_allclose
+
 from pymatgen.analysis.interfaces.coherent_interfaces import (
     CoherentInterfaceBuilder,
     from_2d_to_3d,

--- a/tests/analysis/interfaces/test_substrate_analyzer.py
+++ b/tests/analysis/interfaces/test_substrate_analyzer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from numpy.testing import assert_allclose
+
 from pymatgen.analysis.elasticity.elastic import ElasticTensor
 from pymatgen.analysis.interfaces.substrate_analyzer import SubstrateAnalyzer
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer

--- a/tests/analysis/interfaces/test_zsl.py
+++ b/tests/analysis/interfaces/test_zsl.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import numpy as np
 from numpy.testing import assert_array_equal
+from pytest import approx
+
 from pymatgen.analysis.interfaces.zsl import (
     ZSLGenerator,
     fast_norm,
@@ -12,7 +14,6 @@ from pymatgen.analysis.interfaces.zsl import (
 )
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.util.testing import PymatgenTest
-from pytest import approx
 
 __author__ = "Shyam Dwaraknath"
 __copyright__ = "Copyright 2016, The Materials Project"

--- a/tests/analysis/magnetism/test_analyzer.py
+++ b/tests/analysis/magnetism/test_analyzer.py
@@ -6,6 +6,8 @@ from unittest import TestCase
 import pytest
 from monty.serialization import loadfn
 from numpy.testing import assert_allclose
+from pytest import approx
+
 from pymatgen.analysis.magnetism import (
     CollinearMagneticStructureAnalyzer,
     MagneticStructureEnumerator,
@@ -14,7 +16,6 @@ from pymatgen.analysis.magnetism import (
 )
 from pymatgen.core import Element, Lattice, Species, Structure
 from pymatgen.util.testing import TEST_FILES_DIR
-from pytest import approx
 
 TEST_DIR = f"{TEST_FILES_DIR}/analysis/magnetic_orderings"
 

--- a/tests/analysis/magnetism/test_heisenberg.py
+++ b/tests/analysis/magnetism/test_heisenberg.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from unittest import TestCase
 
 import pandas as pd
+
 from pymatgen.analysis.magnetism.heisenberg import HeisenbergMapper
 from pymatgen.core.structure import Structure
 from pymatgen.util.testing import TEST_FILES_DIR

--- a/tests/analysis/magnetism/test_jahnteller.py
+++ b/tests/analysis/magnetism/test_jahnteller.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 from unittest import TestCase
 
 import numpy as np
+from pytest import approx
+
 from pymatgen.analysis.magnetism.jahnteller import JahnTellerAnalyzer, Species
 from pymatgen.core import Structure
 from pymatgen.util.testing import TEST_FILES_DIR
-from pytest import approx
 
 
 class TestJahnTeller(TestCase):

--- a/tests/analysis/solar/test_slme.py
+++ b/tests/analysis/solar/test_slme.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+from pytest import approx
+
 from pymatgen.analysis.solar.slme import optics, slme
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
 
 TEST_DIR = f"{TEST_FILES_DIR}/analysis/solar"
 

--- a/tests/analysis/structure_prediction/test_dopant_predictor.py
+++ b/tests/analysis/structure_prediction/test_dopant_predictor.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 from unittest import TestCase
 
+from pytest import approx
+
 from pymatgen.analysis.local_env import CrystalNN
 from pymatgen.analysis.structure_prediction.dopant_predictor import (
     get_dopants_from_shannon_radii,
     get_dopants_from_substitution_probabilities,
 )
 from pymatgen.core import Species, Structure
-from pytest import approx
 
 
 class TestDopantPrediction(TestCase):

--- a/tests/analysis/structure_prediction/test_substitution_probability.py
+++ b/tests/analysis/structure_prediction/test_substitution_probability.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import json
 from unittest import TestCase
 
+from pytest import approx
+
 from pymatgen.analysis.structure_prediction.substitution_probability import (
     SubstitutionPredictor,
     SubstitutionProbability,
 )
 from pymatgen.core import Composition, Species
 from pymatgen.util.testing import TEST_FILES_DIR
-from pytest import approx
 
 TEST_DIR = f"{TEST_FILES_DIR}/analysis/struct_predictor"
 

--- a/tests/analysis/structure_prediction/test_volume_predictor.py
+++ b/tests/analysis/structure_prediction/test_volume_predictor.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import pytest
+from pytest import approx
+
 from pymatgen.analysis.structure_prediction.volume_predictor import DLSVolumePredictor, RLSVolumePredictor
 from pymatgen.core import Structure
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
 
 TEST_DIR = f"{TEST_FILES_DIR}/analysis/structure_prediction"
 

--- a/tests/analysis/test_adsorption.py
+++ b/tests/analysis/test_adsorption.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 from numpy.testing import assert_allclose
+
 from pymatgen.analysis.adsorption import AdsorbateSiteFinder, generate_all_slabs, get_rot, reorient_z
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Molecule, Structure

--- a/tests/analysis/test_bond_dissociation.py
+++ b/tests/analysis/test_bond_dissociation.py
@@ -4,6 +4,7 @@ from unittest import TestCase
 
 import pytest
 from monty.serialization import loadfn
+
 from pymatgen.analysis.bond_dissociation import BondDissociationEnergies
 from pymatgen.util.testing import TEST_FILES_DIR
 

--- a/tests/analysis/test_bond_valence.py
+++ b/tests/analysis/test_bond_valence.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import pytest
+from pytest import approx
+
 from pymatgen.analysis.bond_valence import BVAnalyzer, calculate_bv_sum, calculate_bv_sum_unordered
 from pymatgen.core import Composition, Species, Structure
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
 
 TEST_DIR = f"{TEST_FILES_DIR}/analysis/bond_valence"
 

--- a/tests/analysis/test_chempot_diagram.py
+++ b/tests/analysis/test_chempot_diagram.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import numpy as np
 from plotly.graph_objects import Figure
+from pytest import approx
+
 from pymatgen.analysis.chempot_diagram import (
     ChemicalPotentialDiagram,
     get_2d_orthonormal_vector,
@@ -11,7 +13,6 @@ from pymatgen.analysis.chempot_diagram import (
 from pymatgen.core.composition import Element
 from pymatgen.entries.entry_tools import EntrySet
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
 
 TEST_DIR = f"{TEST_FILES_DIR}/analysis"
 

--- a/tests/analysis/test_cost.py
+++ b/tests/analysis/test_cost.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from unittest import TestCase
 
+from pytest import approx
+
 from pymatgen.analysis.cost import CostAnalyzer, CostDBCSV, CostDBElements
 from pymatgen.util.testing import TEST_FILES_DIR
-from pytest import approx
 
 TEST_DIR = f"{TEST_FILES_DIR}/analysis/cost"
 

--- a/tests/analysis/test_dimensionality.py
+++ b/tests/analysis/test_dimensionality.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import networkx as nx
 import pytest
 from monty.serialization import loadfn
+
 from pymatgen.analysis.dimensionality import (
     calculate_dimensionality_of_site,
     get_dimensionality_cheon,

--- a/tests/analysis/test_disorder.py
+++ b/tests/analysis/test_disorder.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+from pytest import approx
+
 from pymatgen.analysis.disorder import get_warren_cowley_parameters
 from pymatgen.core import Element, Structure
 from pymatgen.util.testing import PymatgenTest
-from pytest import approx
 
 
 class TestOrderParameter(PymatgenTest):

--- a/tests/analysis/test_energy_models.py
+++ b/tests/analysis/test_energy_models.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+from pytest import approx
+
 from pymatgen.analysis.energy_models import EwaldElectrostaticModel, IsingModel, SymmetryModel
 from pymatgen.core import Species
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Structure
 from pymatgen.util.testing import TEST_FILES_DIR
-from pytest import approx
 
 
 class TestEwaldElectrostaticModel:

--- a/tests/analysis/test_eos.py
+++ b/tests/analysis/test_eos.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import numpy as np
 from numpy.testing import assert_allclose
+from pytest import approx
+
 from pymatgen.analysis.eos import EOS, NumericalEOS
 from pymatgen.util.testing import PymatgenTest
-from pytest import approx
 
 
 class TestEOS(PymatgenTest):

--- a/tests/analysis/test_ewald.py
+++ b/tests/analysis/test_ewald.py
@@ -4,10 +4,11 @@ from unittest import TestCase
 
 import numpy as np
 import pytest
+from pytest import approx
+
 from pymatgen.analysis.ewald import EwaldMinimizer, EwaldSummation
 from pymatgen.core.structure import Structure
 from pymatgen.util.testing import VASP_IN_DIR
-from pytest import approx
 
 
 class TestEwaldSummation(TestCase):

--- a/tests/analysis/test_fragmenter.py
+++ b/tests/analysis/test_fragmenter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+
 from pymatgen.analysis.fragmenter import Fragmenter
 from pymatgen.analysis.graphs import MoleculeGraph
 from pymatgen.analysis.local_env import OpenBabelNN

--- a/tests/analysis/test_functional_groups.py
+++ b/tests/analysis/test_functional_groups.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from unittest import TestCase
 
 import pytest
+
 from pymatgen.analysis.functional_groups import FunctionalGroupExtractor
 from pymatgen.analysis.graphs import MoleculeGraph
 from pymatgen.analysis.local_env import OpenBabelNN

--- a/tests/analysis/test_graphs.py
+++ b/tests/analysis/test_graphs.py
@@ -10,6 +10,8 @@ import networkx as nx
 import networkx.algorithms.isomorphism as iso
 import pytest
 from monty.serialization import loadfn
+from pytest import approx
+
 from pymatgen.analysis.graphs import MoleculeGraph, MolGraphSplitError, PeriodicSite, StructureGraph
 from pymatgen.analysis.local_env import (
     CovalentBondNN,
@@ -23,7 +25,6 @@ from pymatgen.command_line.critic2_caller import Critic2Analysis
 from pymatgen.core import Lattice, Molecule, Site, Structure
 from pymatgen.core.structure import FunctionalGroups
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
 
 try:
     from openbabel import openbabel

--- a/tests/analysis/test_hhi.py
+++ b/tests/analysis/test_hhi.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from pymatgen.analysis.hhi import HHIModel
 from pytest import approx
+
+from pymatgen.analysis.hhi import HHIModel
 
 
 class TestHHIModel:

--- a/tests/analysis/test_interface_reactions.py
+++ b/tests/analysis/test_interface_reactions.py
@@ -8,12 +8,13 @@ from matplotlib.figure import Figure as MplFigure
 from numpy.testing import assert_allclose
 from pandas import DataFrame
 from plotly.graph_objects import Figure
+from scipy.spatial import ConvexHull
+
 from pymatgen.analysis.interface_reactions import GrandPotentialInterfacialReactivity, InterfacialReactivity
 from pymatgen.analysis.phase_diagram import GrandPotentialPhaseDiagram, PhaseDiagram
 from pymatgen.analysis.reaction_calculator import Reaction
 from pymatgen.core.composition import Composition, Element
 from pymatgen.entries.computed_entries import ComputedEntry
-from scipy.spatial import ConvexHull
 
 
 class TestInterfaceReaction(TestCase):

--- a/tests/analysis/test_local_env.py
+++ b/tests/analysis/test_local_env.py
@@ -7,6 +7,8 @@ from typing import get_args
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
+from pytest import approx
+
 from pymatgen.analysis.graphs import MoleculeGraph, StructureGraph
 from pymatgen.analysis.local_env import (
     BrunnerNNReal,
@@ -36,7 +38,6 @@ from pymatgen.analysis.local_env import (
 )
 from pymatgen.core import Element, Lattice, Molecule, Structure
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
 
 TEST_DIR = f"{TEST_FILES_DIR}/analysis/local_env/fragmenter_files"
 

--- a/tests/analysis/test_molecule_matcher.py
+++ b/tests/analysis/test_molecule_matcher.py
@@ -4,6 +4,8 @@ from unittest import TestCase
 
 import numpy as np
 import pytest
+from pytest import approx
+
 from pymatgen.analysis.molecule_matcher import (
     BruteForceOrderMatcher,
     GeneticOrderMatcher,
@@ -17,7 +19,6 @@ from pymatgen.core.operations import SymmOp
 from pymatgen.core.structure import Lattice, Molecule, Structure
 from pymatgen.io.xyz import XYZ
 from pymatgen.util.testing import TEST_FILES_DIR
-from pytest import approx
 
 try:
     from openbabel import openbabel

--- a/tests/analysis/test_nmr.py
+++ b/tests/analysis/test_nmr.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
+from pytest import approx
+
 from pymatgen.analysis.nmr import ChemicalShielding, ElectricFieldGradient
 from pymatgen.util.testing import PymatgenTest
-from pytest import approx
 
 
 class TestChemicalShieldingNotation(PymatgenTest):

--- a/tests/analysis/test_phase_diagram.py
+++ b/tests/analysis/test_phase_diagram.py
@@ -13,6 +13,8 @@ import plotly.graph_objects as go
 import pytest
 from monty.serialization import dumpfn, loadfn
 from numpy.testing import assert_allclose
+from pytest import approx
+
 from pymatgen.analysis.phase_diagram import (
     CompoundPhaseDiagram,
     GrandPotentialPhaseDiagram,
@@ -31,7 +33,6 @@ from pymatgen.core import Composition, DummySpecies, Element
 from pymatgen.entries.computed_entries import ComputedEntry
 from pymatgen.entries.entry_tools import EntrySet
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
 
 TEST_DIR = f"{TEST_FILES_DIR}/analysis"
 

--- a/tests/analysis/test_piezo.py
+++ b/tests/analysis/test_piezo.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_array_equal
+
 from pymatgen.analysis.piezo import PiezoTensor
 from pymatgen.util.testing import PymatgenTest
 

--- a/tests/analysis/test_piezo_sensitivity.py
+++ b/tests/analysis/test_piezo_sensitivity.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import pickle
 
 import numpy as np
-import pymatgen
 import pytest
 from numpy.testing import assert_allclose
+
+import pymatgen
 from pymatgen.analysis.piezo_sensitivity import (
     BornEffectiveCharge,
     ForceConstantMatrix,

--- a/tests/analysis/test_pourbaix_diagram.py
+++ b/tests/analysis/test_pourbaix_diagram.py
@@ -7,12 +7,13 @@ from unittest import TestCase
 import matplotlib.pyplot as plt
 import numpy as np
 from monty.serialization import dumpfn, loadfn
+from pytest import approx
+
 from pymatgen.analysis.pourbaix_diagram import IonEntry, MultiEntry, PourbaixDiagram, PourbaixEntry, PourbaixPlotter
 from pymatgen.core.composition import Composition
 from pymatgen.core.ion import Ion
 from pymatgen.entries.computed_entries import ComputedEntry
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
 
 TEST_DIR = f"{TEST_FILES_DIR}/analysis/pourbaix_diagram"
 

--- a/tests/analysis/test_quasi_harmonic_debye_approx.py
+++ b/tests/analysis/test_quasi_harmonic_debye_approx.py
@@ -4,6 +4,7 @@ from unittest import TestCase
 
 import numpy as np
 from numpy.testing import assert_allclose
+
 from pymatgen.analysis.eos import EOS
 from pymatgen.analysis.quasiharmonic import QuasiHarmonicDebyeApprox
 from pymatgen.core.structure import Structure

--- a/tests/analysis/test_quasirrho.py
+++ b/tests/analysis/test_quasirrho.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from unittest import TestCase
 
 import pytest
+
 from pymatgen.analysis.quasirrho import QuasiRRHO, get_avg_mom_inertia
 from pymatgen.io.gaussian import GaussianOutput
 from pymatgen.io.qchem.outputs import QCOutput

--- a/tests/analysis/test_reaction_calculator.py
+++ b/tests/analysis/test_reaction_calculator.py
@@ -6,10 +6,11 @@ from unittest import TestCase
 
 import numpy as np
 import pytest
+from pytest import approx
+
 from pymatgen.analysis.reaction_calculator import BalancedReaction, ComputedReaction, Reaction, ReactionError
 from pymatgen.core.composition import Composition
 from pymatgen.entries.computed_entries import ComputedEntry
-from pytest import approx
 
 
 class TestReaction:

--- a/tests/analysis/test_structure_analyzer.py
+++ b/tests/analysis/test_structure_analyzer.py
@@ -4,6 +4,8 @@ from unittest import TestCase
 
 import numpy as np
 from numpy.testing import assert_allclose
+from pytest import approx
+
 from pymatgen.analysis.structure_analyzer import (
     RelaxationAnalyzer,
     VoronoiAnalyzer,
@@ -17,7 +19,6 @@ from pymatgen.analysis.structure_analyzer import (
 from pymatgen.core import Element, Lattice, Structure
 from pymatgen.io.vasp.outputs import Xdatcar
 from pymatgen.util.testing import VASP_IN_DIR, VASP_OUT_DIR, PymatgenTest
-from pytest import approx
 
 
 class TestVoronoiAnalyzer(PymatgenTest):

--- a/tests/analysis/test_structure_matcher.py
+++ b/tests/analysis/test_structure_matcher.py
@@ -6,6 +6,8 @@ import numpy as np
 import pytest
 from monty.json import MontyDecoder
 from numpy.testing import assert_allclose
+from pytest import approx
+
 from pymatgen.analysis.structure_matcher import (
     ElementComparator,
     FrameworkComparator,
@@ -16,7 +18,6 @@ from pymatgen.analysis.structure_matcher import (
 from pymatgen.core import Element, Lattice, Structure, SymmOp
 from pymatgen.util.coord import find_in_coord_list_pbc
 from pymatgen.util.testing import TEST_FILES_DIR, VASP_IN_DIR, PymatgenTest
-from pytest import approx
 
 TEST_DIR = f"{TEST_FILES_DIR}/analysis/structure_matcher"
 

--- a/tests/analysis/test_surface_analysis.py
+++ b/tests/analysis/test_surface_analysis.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import json
 
 from numpy.testing import assert_allclose
+from pytest import approx
+from sympy import Number, Symbol
+
 from pymatgen.analysis.surface_analysis import NanoscaleStability, SlabEntry, SurfaceEnergyPlotter, WorkFunctionAnalyzer
 from pymatgen.entries.computed_entries import ComputedStructureEntry
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
-from sympy import Number, Symbol
 
 __author__ = "Richard Tran"
 __copyright__ = "Copyright 2012, The Materials Project"

--- a/tests/analysis/test_transition_state.py
+++ b/tests/analysis/test_transition_state.py
@@ -4,6 +4,7 @@ import json
 
 from matplotlib import pyplot as plt
 from numpy.testing import assert_allclose
+
 from pymatgen.analysis.transition_state import NEBAnalysis, combine_neb_plots
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
 

--- a/tests/analysis/test_wulff.py
+++ b/tests/analysis/test_wulff.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 import json
 
+from pytest import approx
+
 from pymatgen.analysis.wulff import WulffShape
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.util.coord import in_coord_list
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
 
 __author__ = "Zihan Xu, Richard Tran, Balachandran Radhakrishnan"
 __copyright__ = "Copyright 2013, The Materials Virtual Lab"

--- a/tests/analysis/topological/test_spillage.py
+++ b/tests/analysis/topological/test_spillage.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+from pytest import approx
+
 from pymatgen.analysis.topological.spillage import SOCSpillage
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
 
 TEST_DIR = f"{TEST_FILES_DIR}/analysis/topological"
 

--- a/tests/analysis/xas/test_spectrum.py
+++ b/tests/analysis/xas/test_spectrum.py
@@ -6,10 +6,11 @@ import numpy as np
 import pytest
 from monty.json import MontyDecoder
 from numpy.testing import assert_allclose, assert_array_equal
+from pytest import approx
+
 from pymatgen.analysis.xas.spectrum import XAS, site_weighted_spectrum
 from pymatgen.core import Element
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
 
 TEST_DIR = f"{TEST_FILES_DIR}/analysis/spectrum_test"
 

--- a/tests/apps/battery/test_analyzer.py
+++ b/tests/apps/battery/test_analyzer.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import pytest
+from pytest import approx
+
 from pymatgen.apps.battery.analyzer import BatteryAnalyzer
 from pymatgen.core.structure import Structure
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
 
 
 class TestBatteryAnalyzer(PymatgenTest):

--- a/tests/apps/battery/test_conversion_battery.py
+++ b/tests/apps/battery/test_conversion_battery.py
@@ -4,10 +4,11 @@ import json
 from unittest import TestCase
 
 from monty.json import MontyDecoder
+from pytest import approx
+
 from pymatgen.apps.battery.conversion_battery import ConversionElectrode, ConversionVoltagePair
 from pymatgen.core.composition import Composition
 from pymatgen.util.testing import TEST_FILES_DIR
-from pytest import approx
 
 TEST_DIR = f"{TEST_FILES_DIR}/apps/battery"
 

--- a/tests/apps/battery/test_insertion_battery.py
+++ b/tests/apps/battery/test_insertion_battery.py
@@ -4,10 +4,11 @@ import json
 from unittest import TestCase
 
 from monty.json import MontyDecoder, MontyEncoder
+from pytest import approx
+
 from pymatgen.apps.battery.insertion_battery import InsertionElectrode, InsertionVoltagePair
 from pymatgen.entries.computed_entries import ComputedEntry
 from pymatgen.util.testing import TEST_FILES_DIR
-from pytest import approx
 
 TEST_DIR = f"{TEST_FILES_DIR}/apps/battery"
 

--- a/tests/apps/battery/test_plotter.py
+++ b/tests/apps/battery/test_plotter.py
@@ -4,6 +4,7 @@ import json
 from unittest import TestCase
 
 from monty.json import MontyDecoder
+
 from pymatgen.apps.battery.conversion_battery import ConversionElectrode
 from pymatgen.apps.battery.insertion_battery import InsertionElectrode
 from pymatgen.apps.battery.plotter import VoltageProfilePlotter

--- a/tests/apps/borg/test_hive.py
+++ b/tests/apps/borg/test_hive.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import os
 from unittest import TestCase
 
+from pytest import approx
+
 from pymatgen.apps.borg.hive import (
     GaussianToComputedEntryDrone,
     SimpleVaspToComputedEntryDrone,
@@ -10,7 +12,6 @@ from pymatgen.apps.borg.hive import (
 )
 from pymatgen.entries.computed_entries import ComputedStructureEntry
 from pymatgen.util.testing import TEST_FILES_DIR, VASP_OUT_DIR
-from pytest import approx
 
 TEST_DIR = f"{TEST_FILES_DIR}/apps/borg"
 

--- a/tests/apps/borg/test_queen.py
+++ b/tests/apps/borg/test_queen.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+from pytest import approx
+
 from pymatgen.apps.borg.hive import VaspToComputedEntryDrone
 from pymatgen.apps.borg.queen import BorgQueen
 from pymatgen.util.testing import TEST_FILES_DIR
-from pytest import approx
 
 __author__ = "Shyue Ping Ong"
 __copyright__ = "Copyright 2012, The Materials Project"

--- a/tests/command_line/test_bader_caller.py
+++ b/tests/command_line/test_bader_caller.py
@@ -8,9 +8,10 @@ import numpy as np
 import pytest
 from monty.shutil import copy_r
 from numpy.testing import assert_allclose
+from pytest import approx
+
 from pymatgen.command_line.bader_caller import BaderAnalysis, bader_analysis_from_path
 from pymatgen.util.testing import TEST_FILES_DIR, VASP_IN_DIR, VASP_OUT_DIR, PymatgenTest
-from pytest import approx
 
 TEST_DIR = f"{TEST_FILES_DIR}/command_line/bader"
 

--- a/tests/command_line/test_critic2_caller.py
+++ b/tests/command_line/test_critic2_caller.py
@@ -4,10 +4,11 @@ from shutil import which
 from unittest import TestCase
 
 import pytest
+from pytest import approx
+
 from pymatgen.command_line.critic2_caller import Critic2Analysis, Critic2Caller
 from pymatgen.core.structure import Structure
 from pymatgen.util.testing import TEST_FILES_DIR
-from pytest import approx
 
 __author__ = "Matthew Horton"
 __version__ = "0.1"

--- a/tests/command_line/test_enumlib_caller.py
+++ b/tests/command_line/test_enumlib_caller.py
@@ -5,13 +5,14 @@ from shutil import which
 
 import numpy as np
 import pytest
+from pytest import approx
+
 from pymatgen.command_line.enumlib_caller import EnumError, EnumlibAdaptor
 from pymatgen.core import Element, Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.transformations.site_transformations import RemoveSitesTransformation
 from pymatgen.transformations.standard_transformations import SubstitutionTransformation
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
 
 enum_cmd = which("enum.x") or which("multienum.x")
 makestr_cmd = which("makestr.x") or which("makeStr.x") or which("makeStr.py")

--- a/tests/command_line/test_gulp_caller.py
+++ b/tests/command_line/test_gulp_caller.py
@@ -14,6 +14,7 @@ from unittest import TestCase
 
 import numpy as np
 import pytest
+
 from pymatgen.analysis.bond_valence import BVAnalyzer
 from pymatgen.command_line.gulp_caller import (
     BuckinghamPotential,

--- a/tests/command_line/test_mcsqs_caller.py
+++ b/tests/command_line/test_mcsqs_caller.py
@@ -4,6 +4,7 @@ from shutil import which
 
 import pytest
 from monty.serialization import loadfn
+
 from pymatgen.command_line.mcsqs_caller import run_mcsqs
 from pymatgen.core.structure import Structure
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest

--- a/tests/command_line/test_vampire_caller.py
+++ b/tests/command_line/test_vampire_caller.py
@@ -4,10 +4,11 @@ from shutil import which
 
 import pandas as pd
 import pytest
+from pytest import approx
+
 from pymatgen.command_line.vampire_caller import VampireCaller
 from pymatgen.core.structure import Structure
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
 
 TEST_DIR = f"{TEST_FILES_DIR}/analysis/magnetic_orderings"
 

--- a/tests/core/test_bonds.py
+++ b/tests/core/test_bonds.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import pytest
+from pytest import approx
+
 from pymatgen.core import Element, Site
 from pymatgen.core.bonds import CovalentBond, get_bond_length, get_bond_order, obtain_all_bond_lengths
-from pytest import approx
 
 __author__ = "Shyue Ping Ong"
 __copyright__ = "Copyright 2012, The Materials Project"

--- a/tests/core/test_composition.py
+++ b/tests/core/test_composition.py
@@ -10,10 +10,11 @@ import random
 
 import pytest
 from numpy.testing import assert_allclose
+from pytest import approx
+
 from pymatgen.core import Composition, DummySpecies, Element, Species
 from pymatgen.core.composition import ChemicalPotential
 from pymatgen.util.testing import PymatgenTest
-from pytest import approx
 
 
 class TestComposition(PymatgenTest):

--- a/tests/core/test_interface.py
+++ b/tests/core/test_interface.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import numpy as np
 from numpy.testing import assert_allclose
+from pytest import approx
+
 from pymatgen.core.interface import GrainBoundary, GrainBoundaryGenerator, Interface
 from pymatgen.core.structure import Structure
 from pymatgen.core.surface import SlabGenerator
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
 
 TEST_DIR = f"{TEST_FILES_DIR}/core/grain_boundary"
 

--- a/tests/core/test_ion.py
+++ b/tests/core/test_ion.py
@@ -4,6 +4,7 @@ import random
 from unittest import TestCase
 
 import pytest
+
 from pymatgen.core import Composition, Element
 from pymatgen.core.ion import Ion
 

--- a/tests/core/test_lattice.py
+++ b/tests/core/test_lattice.py
@@ -5,10 +5,11 @@ import itertools
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_array_equal
+from pytest import approx
+
 from pymatgen.core.lattice import Lattice, get_points_in_spheres
 from pymatgen.core.operations import SymmOp
 from pymatgen.util.testing import PymatgenTest
-from pytest import approx
 
 
 class TestLattice(PymatgenTest):

--- a/tests/core/test_molecular_orbitals.py
+++ b/tests/core/test_molecular_orbitals.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+
 from pymatgen.core.molecular_orbitals import MolecularOrbitals
 from pymatgen.util.testing import PymatgenTest
 

--- a/tests/core/test_operations.py
+++ b/tests/core/test_operations.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 from numpy.testing import assert_allclose
+
 from pymatgen.core.operations import MagSymmOp, SymmOp
 from pymatgen.electronic_structure.core import Magmom
 from pymatgen.util.testing import PymatgenTest

--- a/tests/core/test_periodic_table.py
+++ b/tests/core/test_periodic_table.py
@@ -8,12 +8,13 @@ from enum import Enum
 
 import numpy as np
 import pytest
+from pytest import approx
+
 from pymatgen.core import DummySpecies, Element, Species, get_el_sp
 from pymatgen.core.periodic_table import ElementBase, ElementType
 from pymatgen.core.units import Ha_to_eV
 from pymatgen.io.core import ParseError
 from pymatgen.util.testing import PymatgenTest
-from pytest import approx
 
 
 class TestElement(PymatgenTest):

--- a/tests/core/test_sites.py
+++ b/tests/core/test_sites.py
@@ -5,10 +5,11 @@ import pickle
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
+from pytest import approx
+
 from pymatgen.core import Composition, Element, Lattice, PeriodicSite, Site, Species
 from pymatgen.electronic_structure.core import Magmom
 from pymatgen.util.testing import PymatgenTest
-from pytest import approx
 
 
 class TestSite(PymatgenTest):

--- a/tests/core/test_spectrum.py
+++ b/tests/core/test_spectrum.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import numpy as np
 from numpy.testing import assert_allclose
-from pymatgen.core.spectrum import Spectrum
-from pymatgen.util.testing import PymatgenTest
 from pytest import approx
 from scipy import stats
+
+from pymatgen.core.spectrum import Spectrum
+from pymatgen.util.testing import PymatgenTest
 
 
 class TestSpectrum(PymatgenTest):

--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -12,6 +12,8 @@ import numpy as np
 import pytest
 from monty.json import MontyDecoder, MontyEncoder
 from numpy.testing import assert_allclose, assert_array_equal
+from pytest import approx
+
 from pymatgen.core import SETTINGS, Composition, Element, Lattice, Species
 from pymatgen.core.operations import SymmOp
 from pymatgen.core.structure import (
@@ -28,7 +30,6 @@ from pymatgen.io.ase import AseAtomsAdaptor
 from pymatgen.io.cif import CifParser
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.util.testing import TEST_FILES_DIR, VASP_IN_DIR, PymatgenTest
-from pytest import approx
 
 try:
     from ase.atoms import Atoms

--- a/tests/core/test_surface.py
+++ b/tests/core/test_surface.py
@@ -6,8 +6,10 @@ import random
 import unittest
 
 import numpy as np
-import pymatgen
 from numpy.testing import assert_allclose
+from pytest import approx
+
+import pymatgen
 from pymatgen.analysis.structure_matcher import StructureMatcher
 from pymatgen.core import Lattice, Structure
 from pymatgen.core.surface import (
@@ -24,7 +26,6 @@ from pymatgen.core.surface import (
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.symmetry.groups import SpaceGroup
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
 
 
 class TestSlab(PymatgenTest):

--- a/tests/core/test_tensors.py
+++ b/tests/core/test_tensors.py
@@ -6,11 +6,12 @@ import numpy as np
 import pytest
 from monty.serialization import MontyDecoder, loadfn
 from numpy.testing import assert_allclose
+from pytest import approx
+
 from pymatgen.core.operations import SymmOp
 from pymatgen.core.tensors import SquareTensor, Tensor, TensorCollection, TensorMapping, itertools, symmetry_reduce
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
 
 
 class TestTensor(PymatgenTest):

--- a/tests/core/test_trajectory.py
+++ b/tests/core/test_trajectory.py
@@ -6,6 +6,7 @@ import re
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
+
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Molecule, Structure
 from pymatgen.core.trajectory import Trajectory

--- a/tests/core/test_units.py
+++ b/tests/core/test_units.py
@@ -4,6 +4,8 @@ import warnings
 
 import pytest
 from numpy.testing import assert_array_equal
+from pytest import approx
+
 from pymatgen.core.units import (
     ArrayWithUnit,
     Energy,
@@ -25,7 +27,6 @@ from pymatgen.core.units import (
     unitized,
 )
 from pymatgen.util.testing import PymatgenTest
-from pytest import approx
 
 
 def test_unit_conversions():

--- a/tests/core/test_xcfunc.py
+++ b/tests/core/test_xcfunc.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+
 from pymatgen.core.xcfunc import XcFunc
 from pymatgen.util.testing import PymatgenTest
 

--- a/tests/electronic_structure/test_bandstructure.py
+++ b/tests/electronic_structure/test_bandstructure.py
@@ -8,6 +8,8 @@ import numpy as np
 import pytest
 from monty.serialization import loadfn
 from numpy.testing import assert_allclose
+from pytest import approx
+
 from pymatgen.core.lattice import Lattice
 from pymatgen.electronic_structure.bandstructure import (
     BandStructureSymmLine,
@@ -19,7 +21,6 @@ from pymatgen.electronic_structure.core import Orbital, Spin
 from pymatgen.electronic_structure.plotter import BSPlotterProjected
 from pymatgen.io.vasp import BSVasprun
 from pymatgen.util.testing import TEST_FILES_DIR, VASP_IN_DIR, VASP_OUT_DIR, PymatgenTest
-from pytest import approx
 
 TEST_DIR = f"{TEST_FILES_DIR}/electronic_structure/bandstructure"
 

--- a/tests/electronic_structure/test_boltztrap.py
+++ b/tests/electronic_structure/test_boltztrap.py
@@ -6,11 +6,12 @@ from unittest import TestCase
 
 import pytest
 from monty.serialization import loadfn
+from pytest import approx
+
 from pymatgen.electronic_structure.bandstructure import BandStructure
 from pymatgen.electronic_structure.boltztrap import BoltztrapAnalyzer, BoltztrapRunner
 from pymatgen.electronic_structure.core import OrbitalType, Spin
 from pymatgen.util.testing import TEST_FILES_DIR
-from pytest import approx
 
 try:
     from ase.io.cube import read_cube

--- a/tests/electronic_structure/test_boltztrap2.py
+++ b/tests/electronic_structure/test_boltztrap2.py
@@ -5,10 +5,11 @@ from unittest import TestCase
 import numpy as np
 import pytest
 from monty.serialization import loadfn
+from pytest import approx
+
 from pymatgen.electronic_structure.core import OrbitalType, Spin
 from pymatgen.io.vasp import Vasprun
 from pymatgen.util.testing import TEST_FILES_DIR
-from pytest import approx
 
 try:
     from pymatgen.electronic_structure.boltztrap2 import (

--- a/tests/electronic_structure/test_cohp.py
+++ b/tests/electronic_structure/test_cohp.py
@@ -5,6 +5,8 @@ from unittest import TestCase
 
 import pytest
 from numpy.testing import assert_allclose, assert_array_equal
+from pytest import approx
+
 from pymatgen.electronic_structure.cohp import (
     Cohp,
     CompleteCohp,
@@ -14,7 +16,6 @@ from pymatgen.electronic_structure.cohp import (
 )
 from pymatgen.electronic_structure.core import Orbital, Spin
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
 
 TEST_DIR = f"{TEST_FILES_DIR}/electronic_structure/cohp"
 

--- a/tests/electronic_structure/test_core.py
+++ b/tests/electronic_structure/test_core.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
+
 from pymatgen.core import Lattice
 from pymatgen.electronic_structure.core import Magmom, Orbital, Spin
 

--- a/tests/electronic_structure/test_dos.py
+++ b/tests/electronic_structure/test_dos.py
@@ -8,11 +8,12 @@ import pytest
 from monty.io import zopen
 from monty.serialization import loadfn
 from numpy.testing import assert_allclose
+from pytest import approx
+
 from pymatgen.core import Element, Structure
 from pymatgen.electronic_structure.core import Orbital, OrbitalType, Spin
 from pymatgen.electronic_structure.dos import DOS, CompleteDos, FermiDos, LobsterCompleteDos
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
 
 TEST_DIR = f"{TEST_FILES_DIR}/electronic_structure/dos"
 

--- a/tests/electronic_structure/test_plotter.py
+++ b/tests/electronic_structure/test_plotter.py
@@ -10,6 +10,8 @@ import numpy as np
 import pytest
 from matplotlib import rc
 from numpy.testing import assert_allclose
+from pytest import approx
+
 from pymatgen.core.structure import Structure
 from pymatgen.electronic_structure.bandstructure import BandStructureSymmLine
 from pymatgen.electronic_structure.boltztrap import BoltztrapAnalyzer
@@ -29,7 +31,6 @@ from pymatgen.electronic_structure.plotter import (
 )
 from pymatgen.io.vasp import Vasprun
 from pymatgen.util.testing import TEST_FILES_DIR, VASP_IN_DIR, VASP_OUT_DIR, PymatgenTest
-from pytest import approx
 
 BAND_TEST_DIR = f"{TEST_FILES_DIR}/electronic_structure/bandstructure"
 

--- a/tests/entries/test_compatibility.py
+++ b/tests/entries/test_compatibility.py
@@ -9,9 +9,11 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest import TestCase
 
-import pymatgen
 import pytest
 from monty.json import MontyDecoder
+from pytest import approx
+
+import pymatgen
 from pymatgen.core import Element, Species
 from pymatgen.core.composition import Composition
 from pymatgen.core.lattice import Lattice
@@ -32,7 +34,6 @@ from pymatgen.entries.compatibility import (
 )
 from pymatgen.entries.computed_entries import ComputedEntry, ComputedStructureEntry, ConstantEnergyAdjustment
 from pymatgen.util.testing import TEST_FILES_DIR
-from pytest import approx
 
 if TYPE_CHECKING:
     from pymatgen.util.typing import CompositionLike

--- a/tests/entries/test_computed_entries.py
+++ b/tests/entries/test_computed_entries.py
@@ -7,6 +7,8 @@ from unittest import TestCase
 
 import pytest
 from monty.json import MontyDecoder
+from pytest import approx
+
 from pymatgen.analysis.phase_diagram import PhaseDiagram
 from pymatgen.entries.compatibility import MaterialsProject2020Compatibility
 from pymatgen.entries.computed_entries import (
@@ -21,7 +23,6 @@ from pymatgen.entries.computed_entries import (
 )
 from pymatgen.io.vasp.outputs import Vasprun
 from pymatgen.util.testing import TEST_FILES_DIR, VASP_OUT_DIR
-from pytest import approx
 
 TEST_DIR = f"{TEST_FILES_DIR}/entries"
 

--- a/tests/entries/test_correction_calculator.py
+++ b/tests/entries/test_correction_calculator.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from unittest import TestCase
 
 import pytest
+
 from pymatgen.entries.correction_calculator import CorrectionCalculator
 from pymatgen.util.testing import TEST_FILES_DIR
 

--- a/tests/entries/test_entry_tools.py
+++ b/tests/entries/test_entry_tools.py
@@ -4,6 +4,7 @@ from itertools import starmap
 
 import pytest
 from monty.serialization import dumpfn, loadfn
+
 from pymatgen.core import Element
 from pymatgen.entries.computed_entries import ComputedEntry
 from pymatgen.entries.entry_tools import EntrySet, group_entries_by_composition, group_entries_by_structure

--- a/tests/entries/test_exp_entries.py
+++ b/tests/entries/test_exp_entries.py
@@ -4,9 +4,10 @@ import json
 from unittest import TestCase
 
 from monty.json import MontyDecoder
+from pytest import approx
+
 from pymatgen.entries.exp_entries import ExpEntry
 from pymatgen.util.testing import TEST_FILES_DIR
-from pytest import approx
 
 
 class TestExpEntry(TestCase):

--- a/tests/entries/test_mixing_scheme.py
+++ b/tests/entries/test_mixing_scheme.py
@@ -108,6 +108,7 @@ import pandas as pd
 import pytest
 from monty.json import MontyDecoder
 from numpy.testing import assert_allclose
+
 from pymatgen.analysis.phase_diagram import PhaseDiagram
 from pymatgen.analysis.structure_matcher import StructureMatcher
 from pymatgen.core.lattice import Lattice

--- a/tests/ext/test_cod.py
+++ b/tests/ext/test_cod.py
@@ -6,6 +6,7 @@ from unittest import TestCase
 
 import pytest
 import requests
+
 from pymatgen.ext.cod import COD
 
 if "CI" in os.environ:  # test is slow and flaky, skip in CI. see

--- a/tests/ext/test_matproj.py
+++ b/tests/ext/test_matproj.py
@@ -7,6 +7,9 @@ from unittest.mock import patch
 import pytest
 import requests
 from numpy.testing import assert_allclose
+from pytest import approx
+from ruamel.yaml import YAML
+
 from pymatgen.analysis.phase_diagram import PhaseDiagram
 from pymatgen.analysis.pourbaix_diagram import PourbaixDiagram, PourbaixEntry
 from pymatgen.analysis.reaction_calculator import Reaction
@@ -21,8 +24,6 @@ from pymatgen.ext.matproj_legacy import MPRestError, TaskType, _MPResterLegacy
 from pymatgen.phonon.bandstructure import PhononBandStructureSymmLine
 from pymatgen.phonon.dos import CompletePhononDos
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
-from ruamel.yaml import YAML
 
 PMG_MAPI_KEY = SETTINGS.get("PMG_MAPI_KEY", "")
 if (10 < len(PMG_MAPI_KEY) <= 20) and "PMG_MAPI_KEY" in SETTINGS:

--- a/tests/ext/test_optimade.py
+++ b/tests/ext/test_optimade.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 import requests
+
 from pymatgen.ext.optimade import OptimadeRester
 from pymatgen.util.testing import PymatgenTest
 

--- a/tests/io/abinit/test_abiobjects.py
+++ b/tests/io/abinit/test_abiobjects.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_array_equal
+from pytest import approx
+
 from pymatgen.core.structure import Structure
 from pymatgen.core.units import Ha_to_eV, bohr_to_ang
 from pymatgen.io.abinit.abiobjects import (
@@ -18,7 +20,6 @@ from pymatgen.io.abinit.abiobjects import (
     structure_to_abivars,
 )
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
 
 
 class TestLatticeFromAbivars(PymatgenTest):

--- a/tests/io/abinit/test_inputs.py
+++ b/tests/io/abinit/test_inputs.py
@@ -6,6 +6,7 @@ import tempfile
 import numpy as np
 import pytest
 from numpy.testing import assert_array_equal
+
 from pymatgen.core.structure import Structure
 from pymatgen.io.abinit.inputs import (
     BasicAbinitInput,

--- a/tests/io/abinit/test_netcdf.py
+++ b/tests/io/abinit/test_netcdf.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 from monty.tempfile import ScratchDir
 from numpy.testing import assert_allclose, assert_array_equal
+
 from pymatgen.core.structure import Structure
 from pymatgen.io.abinit import EtsfReader
 from pymatgen.io.abinit.netcdf import AbinitHeader

--- a/tests/io/abinit/test_pseudos.py
+++ b/tests/io/abinit/test_pseudos.py
@@ -6,9 +6,10 @@ from collections import defaultdict
 
 import pytest
 from monty.tempfile import ScratchDir
+from pytest import approx
+
 from pymatgen.io.abinit.pseudos import Pseudo, PseudoTable
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
 
 TEST_DIR = f"{TEST_FILES_DIR}/io/abinit"
 

--- a/tests/io/aims/conftest.py
+++ b/tests/io/aims/conftest.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 
 import pytest
+
 from pymatgen.core import SETTINGS
 
 module_dir = os.path.dirname(__file__)

--- a/tests/io/aims/test_aims_inputs.py
+++ b/tests/io/aims/test_aims_inputs.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 from monty.json import MontyDecoder, MontyEncoder
 from numpy.testing import assert_allclose
+
 from pymatgen.core import SETTINGS
 from pymatgen.io.aims.inputs import (
     ALLOWED_AIMS_CUBE_TYPES,

--- a/tests/io/aims/test_aims_outputs.py
+++ b/tests/io/aims/test_aims_outputs.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from monty.json import MontyDecoder, MontyEncoder
 from numpy.testing import assert_allclose
+
 from pymatgen.core import Structure
 from pymatgen.io.aims.outputs import AimsOutput
 

--- a/tests/io/aims/test_aims_parsers.py
+++ b/tests/io/aims/test_aims_parsers.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
+
 from pymatgen.core.tensors import Tensor
 from pymatgen.io.aims.parsers import (
     EV_PER_A3_TO_KBAR,

--- a/tests/io/aims/test_sets/test_input_set.py
+++ b/tests/io/aims/test_sets/test_input_set.py
@@ -5,6 +5,7 @@ import json
 from pathlib import Path
 
 import pytest
+
 from pymatgen.core import Structure
 from pymatgen.io.aims.sets import AimsInputSet
 

--- a/tests/io/aims/test_sets/test_md_generator.py
+++ b/tests/io/aims/test_sets/test_md_generator.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+
 from pymatgen.io.aims.sets.core import MDSetGenerator
 from pymatgen.util.testing.aims import Si, compare_files
 

--- a/tests/io/cp2k/test_inputs.py
+++ b/tests/io/cp2k/test_inputs.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_array_equal
+from pytest import approx
+
 from pymatgen.core.structure import Molecule, Structure
 from pymatgen.io.cp2k.inputs import (
     BasisFile,
@@ -21,7 +23,6 @@ from pymatgen.io.cp2k.inputs import (
     SectionList,
 )
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
 
 TEST_DIR = f"{TEST_FILES_DIR}/io/cp2k"
 

--- a/tests/io/cp2k/test_outputs.py
+++ b/tests/io/cp2k/test_outputs.py
@@ -4,9 +4,10 @@ from unittest import TestCase
 
 import numpy as np
 from numpy.testing import assert_allclose
+from pytest import approx
+
 from pymatgen.io.cp2k.outputs import Cp2kOutput
 from pymatgen.util.testing import TEST_FILES_DIR
-from pytest import approx
 
 TEST_DIR = f"{TEST_FILES_DIR}/io/cp2k"
 

--- a/tests/io/cp2k/test_sets.py
+++ b/tests/io/cp2k/test_sets.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import pytest
+from pytest import approx
+
 from pymatgen.core.structure import Molecule, Structure
 from pymatgen.io.cp2k.sets import SETTINGS, Cp2kValidationError, DftSet, GaussianTypeOrbitalBasisSet, GthPotential
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
 
 TEST_DIR = f"{TEST_FILES_DIR}/io/cp2k"
 

--- a/tests/io/exciting/test_inputs.py
+++ b/tests/io/exciting/test_inputs.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from xml.etree import ElementTree
 
 from numpy.testing import assert_allclose
+
 from pymatgen.core import Lattice, Structure
 from pymatgen.io.exciting import ExcitingInput
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest

--- a/tests/io/feff/test_inputs.py
+++ b/tests/io/feff/test_inputs.py
@@ -4,10 +4,11 @@ import os
 from unittest import TestCase
 
 from numpy.testing import assert_allclose
+from pytest import approx
+
 from pymatgen.core import Molecule, Structure
 from pymatgen.io.feff.inputs import Atoms, Header, Paths, Potential, Tags
 from pymatgen.util.testing import TEST_FILES_DIR
-from pytest import approx
 
 FEFF_TEST_DIR = f"{TEST_FILES_DIR}/io/feff"
 

--- a/tests/io/feff/test_sets.py
+++ b/tests/io/feff/test_sets.py
@@ -5,6 +5,7 @@ import os
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
+
 from pymatgen.core.structure import Lattice, Molecule, Structure
 from pymatgen.io.feff.inputs import Atoms, Header, Potential, Tags
 from pymatgen.io.feff.sets import FEFFDictSet, MPELNESSet, MPEXAFSSet, MPXANESSet

--- a/tests/io/lammps/test_data.py
+++ b/tests/io/lammps/test_data.py
@@ -10,11 +10,12 @@ import pandas as pd
 import pytest
 from monty.json import MontyDecoder, MontyEncoder
 from numpy.testing import assert_allclose
+from pytest import approx
+from ruamel.yaml import YAML
+
 from pymatgen.core import Element, Lattice, Molecule, Structure
 from pymatgen.io.lammps.data import CombinedData, ForceField, LammpsBox, LammpsData, Topology, lattice_2_lmpbox
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
-from ruamel.yaml import YAML
 
 TEST_DIR = f"{TEST_FILES_DIR}/io/lammps"
 

--- a/tests/io/lammps/test_inputs.py
+++ b/tests/io/lammps/test_inputs.py
@@ -6,6 +6,7 @@ import re
 
 import pandas as pd
 import pytest
+
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Structure
 from pymatgen.io.lammps.data import LammpsData

--- a/tests/io/lammps/test_outputs.py
+++ b/tests/io/lammps/test_outputs.py
@@ -7,6 +7,7 @@ from unittest import TestCase
 import numpy as np
 import pandas as pd
 from numpy.testing import assert_allclose
+
 from pymatgen.io.lammps.outputs import LammpsDump, parse_lammps_dumps, parse_lammps_log
 from pymatgen.util.testing import TEST_FILES_DIR
 

--- a/tests/io/lobster/test_inputs.py
+++ b/tests/io/lobster/test_inputs.py
@@ -7,6 +7,8 @@ from unittest import TestCase
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_array_equal
+from pytest import approx
+
 from pymatgen.core.structure import Structure
 from pymatgen.electronic_structure.cohp import IcohpCollection
 from pymatgen.electronic_structure.core import Orbital, Spin
@@ -30,7 +32,6 @@ from pymatgen.io.lobster.inputs import get_all_possible_basis_combinations
 from pymatgen.io.vasp import Vasprun
 from pymatgen.io.vasp.inputs import Incar, Kpoints, Potcar
 from pymatgen.util.testing import FAKE_POTCAR_DIR, TEST_FILES_DIR, VASP_IN_DIR, VASP_OUT_DIR, PymatgenTest
-from pytest import approx
 
 TEST_DIR = f"{TEST_FILES_DIR}/electronic_structure/cohp"
 

--- a/tests/io/lobster/test_lobsterenv.py
+++ b/tests/io/lobster/test_lobsterenv.py
@@ -5,6 +5,8 @@ from unittest import TestCase
 
 import numpy as np
 import pytest
+from pytest import approx
+
 from pymatgen.analysis.graphs import StructureGraph
 from pymatgen.core import Element
 from pymatgen.core.structure import Structure
@@ -13,7 +15,6 @@ from pymatgen.electronic_structure.core import Spin
 from pymatgen.io.lobster import Charge, Icohplist
 from pymatgen.io.lobster.lobsterenv import LobsterNeighbors
 from pymatgen.util.testing import TEST_FILES_DIR
-from pytest import approx
 
 __author__ = "Janine George"
 __copyright__ = "Copyright 2021, The Materials Project"

--- a/tests/io/pwmat/test_inputs.py
+++ b/tests/io/pwmat/test_inputs.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 from monty.io import zopen
 from numpy.testing import assert_allclose
+
 from pymatgen.core import Composition, Structure
 from pymatgen.io.pwmat.inputs import (
     ACExtractor,

--- a/tests/io/qchem/test_inputs.py
+++ b/tests/io/qchem/test_inputs.py
@@ -5,6 +5,7 @@ import os
 
 import pytest
 from monty.serialization import loadfn
+
 from pymatgen.core.structure import Molecule
 from pymatgen.io.qchem.inputs import QCInput
 from pymatgen.io.qchem.sets import OptSet

--- a/tests/io/qchem/test_outputs.py
+++ b/tests/io/qchem/test_outputs.py
@@ -7,6 +7,8 @@ import numpy as np
 import pytest
 from monty.serialization import dumpfn, loadfn
 from numpy.testing import assert_allclose
+from pytest import approx
+
 from pymatgen.core.structure import Molecule
 from pymatgen.io.qchem.outputs import (
     QCOutput,
@@ -16,7 +18,6 @@ from pymatgen.io.qchem.outputs import (
     orbital_coeffs_parser,
 )
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
 
 try:
     from openbabel import openbabel

--- a/tests/io/qchem/test_sets.py
+++ b/tests/io/qchem/test_sets.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 
 import pytest
+
 from pymatgen.io.qchem.sets import (
     ForceSet,
     FreqSet,

--- a/tests/io/qchem/test_utils.py
+++ b/tests/io/qchem/test_utils.py
@@ -5,6 +5,7 @@ import struct
 
 import pytest
 from monty.io import zopen
+
 from pymatgen.io.qchem.utils import lower_and_check_unique, process_parsed_hess
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
 

--- a/tests/io/test_adf.py
+++ b/tests/io/test_adf.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+from pytest import approx
+
 from pymatgen.core.structure import Molecule
 from pymatgen.io.adf import AdfInput, AdfKey, AdfOutput, AdfTask
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
 
 __author__ = "Xin Chen, chenxin13@mails.tsinghua.edu.cn"
 

--- a/tests/io/test_ase.py
+++ b/tests/io/test_ase.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 from monty.json import MontyDecoder, jsanitize
+
 from pymatgen.core import Composition, Lattice, Molecule, Structure
 from pymatgen.core.structure import StructureError
 from pymatgen.io.ase import AseAtomsAdaptor, MSONAtoms

--- a/tests/io/test_atat.py
+++ b/tests/io/test_atat.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 from numpy.testing import assert_allclose
+from pytest import approx
+
 from pymatgen.core.structure import Structure
 from pymatgen.io.atat import Mcsqs
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
 
 TEST_DIR = f"{TEST_FILES_DIR}/io/atat/mcsqs"
 

--- a/tests/io/test_babel.py
+++ b/tests/io/test_babel.py
@@ -4,13 +4,14 @@ import copy
 from unittest import TestCase
 
 import pytest
+from pytest import approx
+
 from pymatgen.analysis.graphs import MoleculeGraph
 from pymatgen.analysis.molecule_matcher import MoleculeMatcher
 from pymatgen.core.structure import Molecule
 from pymatgen.io.babel import BabelMolAdaptor
 from pymatgen.io.xyz import XYZ
 from pymatgen.util.testing import TEST_FILES_DIR
-from pytest import approx
 
 pybel = pytest.importorskip("openbabel.pybel")
 

--- a/tests/io/test_cif.py
+++ b/tests/io/test_cif.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
+from pytest import approx
+
 from pymatgen.analysis.structure_matcher import StructureMatcher
 from pymatgen.core import Composition, DummySpecies, Element, Lattice, Species, Structure
 from pymatgen.electronic_structure.core import Magmom
 from pymatgen.io.cif import CifBlock, CifParser, CifWriter
 from pymatgen.symmetry.structure import SymmetrizedStructure
 from pymatgen.util.testing import TEST_FILES_DIR, VASP_IN_DIR, PymatgenTest
-from pytest import approx
 
 try:
     import pybtex

--- a/tests/io/test_core.py
+++ b/tests/io/test_core.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 from monty.serialization import MontyDecoder
+
 from pymatgen.core.structure import Structure
 from pymatgen.io.cif import CifParser, CifWriter
 from pymatgen.io.core import InputFile, InputSet

--- a/tests/io/test_gaussian.py
+++ b/tests/io/test_gaussian.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 from unittest import TestCase
 
 import pytest
+from pytest import approx
+
 from pymatgen.core.structure import Molecule
 from pymatgen.electronic_structure.core import Spin
 from pymatgen.io.gaussian import GaussianInput, GaussianOutput
 from pymatgen.util.testing import TEST_FILES_DIR
-from pytest import approx
 
 TEST_DIR = f"{TEST_FILES_DIR}/io/gaussian"
 

--- a/tests/io/test_jarvis.py
+++ b/tests/io/test_jarvis.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+
 from pymatgen.core import Structure
 from pymatgen.io.jarvis import Atoms, JarvisAtomsAdaptor
 from pymatgen.util.testing import VASP_IN_DIR

--- a/tests/io/test_lmto.py
+++ b/tests/io/test_lmto.py
@@ -4,6 +4,7 @@ import os
 
 import numpy as np
 from numpy.testing import assert_array_equal
+
 from pymatgen.core.structure import Structure
 from pymatgen.core.units import Ry_to_eV
 from pymatgen.electronic_structure.core import Spin

--- a/tests/io/test_multiwfn.py
+++ b/tests/io/test_multiwfn.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 
 import pytest
+
 from pymatgen.core.structure import Molecule
 from pymatgen.io.multiwfn import (
     QTAIM_CONDITIONALS,

--- a/tests/io/test_nwchem.py
+++ b/tests/io/test_nwchem.py
@@ -4,10 +4,11 @@ import json
 from unittest import TestCase
 
 import pytest
+from pytest import approx
+
 from pymatgen.core.structure import Molecule
 from pymatgen.io.nwchem import NwInput, NwInputError, NwOutput, NwTask
 from pymatgen.util.testing import TEST_FILES_DIR
-from pytest import approx
 
 TEST_DIR = f"{TEST_FILES_DIR}/io/nwchem"
 

--- a/tests/io/test_openff.py
+++ b/tests/io/test_openff.py
@@ -5,6 +5,7 @@ import networkx.algorithms.isomorphism as iso
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
+
 from pymatgen.analysis.graphs import MoleculeGraph
 from pymatgen.analysis.local_env import OpenBabelNN
 from pymatgen.core import Molecule

--- a/tests/io/test_packmol.py
+++ b/tests/io/test_packmol.py
@@ -6,6 +6,7 @@ from shutil import which
 from subprocess import TimeoutExpired
 
 import pytest
+
 from pymatgen.analysis.molecule_matcher import MoleculeMatcher
 from pymatgen.core import Molecule
 from pymatgen.io.packmol import PackmolBoxGen

--- a/tests/io/test_phonopy.py
+++ b/tests/io/test_phonopy.py
@@ -7,6 +7,8 @@ from unittest import TestCase
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_array_equal
+from pytest import approx
+
 from pymatgen.core import Element
 from pymatgen.io.phonopy import (
     CompletePhononDos,
@@ -27,7 +29,6 @@ from pymatgen.io.phonopy import (
     get_thermal_displacement_matrices,
 )
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
 
 try:
     from phonopy import Phonopy

--- a/tests/io/test_pwscf.py
+++ b/tests/io/test_pwscf.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
+from pytest import approx
+
 from pymatgen.io.pwscf import PWInput, PWInputError, PWOutput
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
 
 TEST_DIR = f"{TEST_FILES_DIR}/io/pwscf"
 

--- a/tests/io/test_res.py
+++ b/tests/io/test_res.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import pytest
+from pytest import approx
+
 from pymatgen.core import Structure
 from pymatgen.io.res import AirssProvider, ResParseError, ResWriter
 from pymatgen.util.testing import TEST_FILES_DIR
-from pytest import approx
 
 TEST_DIR = f"{TEST_FILES_DIR}/io/res"
 

--- a/tests/io/test_shengbte.py
+++ b/tests/io/test_shengbte.py
@@ -4,6 +4,7 @@ import os
 
 import pytest
 from numpy.testing import assert_array_equal
+
 from pymatgen.io.shengbte import Control
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
 

--- a/tests/io/test_template_input.py
+++ b/tests/io/test_template_input.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 
 import pytest
+
 from pymatgen.io.template import TemplateInputGen
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
 

--- a/tests/io/test_wannier90.py
+++ b/tests/io/test_wannier90.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
+from pytest import approx
+
 from pymatgen.io.wannier90 import Unk
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
 
 TEST_DIR = f"{TEST_FILES_DIR}/io/wannier90"
 

--- a/tests/io/test_xcrysden.py
+++ b/tests/io/test_xcrysden.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import numpy as np
+
 from pymatgen.core.structure import Structure
 from pymatgen.io.xcrysden import XSF
 from pymatgen.util.testing import PymatgenTest

--- a/tests/io/test_xyz.py
+++ b/tests/io/test_xyz.py
@@ -4,11 +4,12 @@ from unittest import TestCase
 
 import pandas as pd
 import pytest
+from pytest import approx
+
 from pymatgen.core import Structure
 from pymatgen.core.structure import Molecule
 from pymatgen.io.xyz import XYZ
 from pymatgen.util.testing import TEST_FILES_DIR, VASP_IN_DIR
-from pytest import approx
 
 
 class TestXYZ(TestCase):

--- a/tests/io/test_zeopp.py
+++ b/tests/io/test_zeopp.py
@@ -4,6 +4,8 @@ import unittest
 from unittest import TestCase
 
 import pytest
+from pytest import approx
+
 from pymatgen.analysis.bond_valence import BVAnalyzer
 from pymatgen.core import Molecule, Species, Structure
 from pymatgen.io.zeopp import (
@@ -14,7 +16,6 @@ from pymatgen.io.zeopp import (
     get_voronoi_nodes,
 )
 from pymatgen.util.testing import TEST_FILES_DIR, VASP_IN_DIR
-from pytest import approx
 
 try:
     import zeo

--- a/tests/io/vasp/test_inputs.py
+++ b/tests/io/vasp/test_inputs.py
@@ -15,6 +15,8 @@ import scipy.constants as const
 from monty.io import zopen
 from monty.serialization import loadfn
 from numpy.testing import assert_allclose
+from pytest import MonkeyPatch, approx
+
 from pymatgen.core import SETTINGS
 from pymatgen.core.composition import Composition
 from pymatgen.core.structure import Structure
@@ -34,7 +36,6 @@ from pymatgen.io.vasp.inputs import (
     _gen_potcar_summary_stats,
 )
 from pymatgen.util.testing import FAKE_POTCAR_DIR, TEST_FILES_DIR, VASP_IN_DIR, VASP_OUT_DIR, PymatgenTest
-from pytest import MonkeyPatch, approx
 
 # make sure _gen_potcar_summary_stats runs and works with all tests in this file
 _summ_stats = _gen_potcar_summary_stats(append=False, vasp_psp_dir=str(FAKE_POTCAR_DIR), summary_stats_filename=None)

--- a/tests/io/vasp/test_optics.py
+++ b/tests/io/vasp/test_optics.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 import scipy.special
 from numpy.testing import assert_allclose
+
 from pymatgen.io.vasp.optics import DielectricFunctionCalculator, delta_func, delta_methfessel_paxton, step_func
 from pymatgen.io.vasp.outputs import Vasprun
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest

--- a/tests/io/vasp/test_outputs.py
+++ b/tests/io/vasp/test_outputs.py
@@ -13,6 +13,8 @@ import numpy as np
 import pytest
 from monty.io import zopen
 from numpy.testing import assert_allclose
+from pytest import approx
+
 from pymatgen.core import Element
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Structure
@@ -40,7 +42,6 @@ from pymatgen.io.vasp.outputs import (
 )
 from pymatgen.io.wannier90 import Unk
 from pymatgen.util.testing import FAKE_POTCAR_DIR, TEST_FILES_DIR, VASP_IN_DIR, VASP_OUT_DIR, PymatgenTest
-from pytest import approx
 
 try:
     import h5py

--- a/tests/io/vasp/test_sets.py
+++ b/tests/io/vasp/test_sets.py
@@ -10,6 +10,8 @@ import pytest
 from monty.json import MontyDecoder
 from monty.serialization import loadfn
 from numpy.testing import assert_allclose
+from pytest import MonkeyPatch, approx, mark
+
 from pymatgen.analysis.structure_matcher import StructureMatcher
 from pymatgen.core import SETTINGS, Lattice, Species, Structure
 from pymatgen.core.composition import Composition
@@ -53,7 +55,6 @@ from pymatgen.io.vasp.sets import (
 )
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.util.testing import FAKE_POTCAR_DIR, TEST_FILES_DIR, VASP_IN_DIR, VASP_OUT_DIR, PymatgenTest
-from pytest import MonkeyPatch, approx, mark
 
 TEST_DIR = f"{TEST_FILES_DIR}/io/vasp"
 

--- a/tests/io/xtb/test_outputs.py
+++ b/tests/io/xtb/test_outputs.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import os
 
+from pytest import approx
+
 from pymatgen.core.structure import Molecule
 from pymatgen.io.qchem.outputs import check_for_structure_changes
 from pymatgen.io.xtb.outputs import CRESTOutput
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
 
 try:
     from openbabel import openbabel

--- a/tests/optimization/test_linear_assignment.py
+++ b/tests/optimization/test_linear_assignment.py
@@ -4,8 +4,9 @@ from unittest import TestCase
 
 import numpy as np
 import pytest
-from pymatgen.optimization.linear_assignment import LinearAssignment
 from pytest import approx
+
+from pymatgen.optimization.linear_assignment import LinearAssignment
 
 
 class TestLinearAssignment(TestCase):

--- a/tests/optimization/test_neighbors.py
+++ b/tests/optimization/test_neighbors.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import numpy as np
+
 from pymatgen.core.lattice import Lattice
 from pymatgen.optimization.neighbors import find_points_in_spheres
 from pymatgen.util.testing import PymatgenTest

--- a/tests/phonon/test_bandstructure.py
+++ b/tests/phonon/test_bandstructure.py
@@ -4,10 +4,11 @@ import copy
 import json
 
 from numpy.testing import assert_allclose, assert_array_equal
+from pytest import approx
+
 from pymatgen.electronic_structure.bandstructure import Kpoint
 from pymatgen.phonon.bandstructure import PhononBandStructureSymmLine
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
 
 TEST_DIR = f"{TEST_FILES_DIR}/electronic_structure/bandstructure"
 

--- a/tests/phonon/test_dos.py
+++ b/tests/phonon/test_dos.py
@@ -5,10 +5,11 @@ import re
 
 import numpy as np
 import pytest
+from pytest import approx
+
 from pymatgen.core import Element
 from pymatgen.phonon.dos import CompletePhononDos, PhononDos
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
 
 TEST_DIR = f"{TEST_FILES_DIR}/phonon/dos"
 

--- a/tests/phonon/test_gruneisen.py
+++ b/tests/phonon/test_gruneisen.py
@@ -4,11 +4,12 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 from matplotlib import colors
+from pytest import approx
+
 from pymatgen.io.phonopy import get_gruneisen_ph_bs_symm_line, get_gruneisenparameter
 from pymatgen.phonon.gruneisen import GruneisenParameter
 from pymatgen.phonon.plotter import GruneisenPhononBandStructureSymmLine, GruneisenPhononBSPlotter, GruneisenPlotter
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
 
 try:
     import phonopy

--- a/tests/phonon/test_ir_spectra.py
+++ b/tests/phonon/test_ir_spectra.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from monty.serialization import loadfn
+
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
 
 

--- a/tests/phonon/test_plotter.py
+++ b/tests/phonon/test_plotter.py
@@ -6,6 +6,7 @@ from unittest import TestCase
 import matplotlib.pyplot as plt
 import pytest
 from numpy.testing import assert_allclose
+
 from pymatgen.phonon import CompletePhononDos, PhononBandStructureSymmLine
 from pymatgen.phonon.plotter import PhononBSPlotter, PhononDosPlotter, ThermoPlotter
 from pymatgen.util.testing import TEST_FILES_DIR

--- a/tests/phonon/test_thermal_displacements.py
+++ b/tests/phonon/test_thermal_displacements.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import numpy as np
 from numpy.testing import assert_allclose
+from pytest import approx
+
 from pymatgen.core.structure import Structure
 from pymatgen.phonon.thermal_displacements import ThermalDisplacementMatrices
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
 
 TEST_DIR = f"{TEST_FILES_DIR}/phonon/thermal_displacement_matrices"
 

--- a/tests/symmetry/test_analyzer.py
+++ b/tests/symmetry/test_analyzer.py
@@ -6,6 +6,9 @@ from unittest import TestCase
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
+from pytest import approx, raises
+from spglib import SpglibDataset
+
 from pymatgen.core import Lattice, Molecule, PeriodicSite, Site, Species, Structure
 from pymatgen.io.vasp.outputs import Vasprun
 from pymatgen.symmetry.analyzer import (
@@ -17,8 +20,6 @@ from pymatgen.symmetry.analyzer import (
 )
 from pymatgen.symmetry.structure import SymmetrizedStructure
 from pymatgen.util.testing import TEST_FILES_DIR, VASP_IN_DIR, VASP_OUT_DIR, PymatgenTest
-from pytest import approx, raises
-from spglib import SpglibDataset
 
 TEST_DIR = f"{TEST_FILES_DIR}/symmetry/analyzer"
 

--- a/tests/symmetry/test_groups.py
+++ b/tests/symmetry/test_groups.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
+from pytest import approx
+
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.operations import SymmOp
 from pymatgen.symmetry.groups import SYMM_DATA, PointGroup, SpaceGroup
-from pytest import approx
 
 __author__ = "Shyue Ping Ong"
 __copyright__ = "Copyright 2012, The Materials Virtual Lab"

--- a/tests/symmetry/test_kpath_hin.py
+++ b/tests/symmetry/test_kpath_hin.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import pytest
+from pytest import approx
+
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Structure
 from pymatgen.symmetry.kpath import KPathSeek
 from pymatgen.util.testing import PymatgenTest
-from pytest import approx
 
 try:
     from seekpath import get_path

--- a/tests/symmetry/test_kpath_lm.py
+++ b/tests/symmetry/test_kpath_lm.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import numpy as np
+from pytest import approx
+
 from pymatgen.analysis.magnetism.analyzer import CollinearMagneticStructureAnalyzer
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.symmetry.kpath import KPathLatimerMunro
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
 
 
 class TestKPathLatimerMunro(PymatgenTest):

--- a/tests/symmetry/test_kpath_sc.py
+++ b/tests/symmetry/test_kpath_sc.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import numpy as np
+from pytest import approx
+
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Structure
 from pymatgen.symmetry.kpath import KPathSetyawanCurtarolo
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
-from pytest import approx
 
 TEST_DIR = f"{TEST_FILES_DIR}/symmetry/space_group_structs"
 

--- a/tests/symmetry/test_kpaths.py
+++ b/tests/symmetry/test_kpaths.py
@@ -4,6 +4,7 @@ import random
 
 import pytest
 from monty.serialization import loadfn
+
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Structure
 from pymatgen.symmetry.bandstructure import HighSymmKpath

--- a/tests/symmetry/test_maggroups.py
+++ b/tests/symmetry/test_maggroups.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 from numpy.testing import assert_allclose
+
 from pymatgen.core.lattice import Lattice
 from pymatgen.symmetry.groups import SpaceGroup
 from pymatgen.symmetry.maggroups import MagneticSpaceGroup

--- a/tests/symmetry/test_settings.py
+++ b/tests/symmetry/test_settings.py
@@ -4,6 +4,7 @@ from unittest import TestCase
 
 import numpy as np
 from numpy.testing import assert_allclose
+
 from pymatgen.symmetry.settings import JonesFaithfulTransformation, Lattice, SymmOp
 
 __author__ = "Matthew Horton"

--- a/tests/symmetry/test_site_symmetries.py
+++ b/tests/symmetry/test_site_symmetries.py
@@ -4,6 +4,7 @@ import gzip
 import json
 
 from monty.json import MontyDecoder
+
 from pymatgen.symmetry import site_symmetries as ss
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ import os
 from typing import TYPE_CHECKING
 
 import pytest
+
 from pymatgen.util.testing import TEST_FILES_DIR, VASP_IN_DIR
 
 if TYPE_CHECKING:

--- a/tests/transformations/test_advanced_transformations.py
+++ b/tests/transformations/test_advanced_transformations.py
@@ -7,6 +7,8 @@ import numpy as np
 import pytest
 from monty.serialization import loadfn
 from numpy.testing import assert_allclose, assert_array_equal
+from pytest import approx
+
 from pymatgen.analysis.energy_models import IsingModel, SymmetryModel
 from pymatgen.analysis.gb.grain import GrainBoundaryGenerator
 from pymatgen.core import Lattice, Molecule, Species, Structure
@@ -39,7 +41,6 @@ from pymatgen.transformations.standard_transformations import (
     SubstitutionTransformation,
 )
 from pymatgen.util.testing import TEST_FILES_DIR, VASP_IN_DIR, PymatgenTest
-from pytest import approx
 
 try:
     import hiphive

--- a/tests/transformations/test_site_transformations.py
+++ b/tests/transformations/test_site_transformations.py
@@ -6,6 +6,7 @@ from unittest import TestCase
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
+
 from pymatgen.core.structure import Molecule, Structure
 from pymatgen.transformations.site_transformations import (
     AddSitePropertyTransformation,

--- a/tests/transformations/test_standard_transformations.py
+++ b/tests/transformations/test_standard_transformations.py
@@ -9,6 +9,8 @@ from unittest import TestCase
 import numpy as np
 import pytest
 from monty.json import MontyDecoder
+from pytest import approx
+
 from pymatgen.core import Element, PeriodicSite
 from pymatgen.core.lattice import Lattice
 from pymatgen.symmetry.structure import SymmetrizedStructure
@@ -34,7 +36,6 @@ from pymatgen.transformations.standard_transformations import (
     SupercellTransformation,
 )
 from pymatgen.util.testing import TEST_FILES_DIR, VASP_IN_DIR
-from pytest import approx
 
 enumlib_present = which("enum.x") and which("makestr.x")
 

--- a/tests/util/test_coord.py
+++ b/tests/util/test_coord.py
@@ -6,9 +6,10 @@ from unittest import TestCase
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_array_equal
+from pytest import approx
+
 from pymatgen.core.lattice import Lattice
 from pymatgen.util import coord
-from pytest import approx
 
 
 class TestCoordUtils:

--- a/tests/util/test_num.py
+++ b/tests/util/test_num.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+
 from pymatgen.util.num import round_to_sigfigs
 
 

--- a/tests/util/test_plotting.py
+++ b/tests/util/test_plotting.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import matplotlib.pyplot as plt
+
 from pymatgen.util.plotting import periodic_table_heatmap, van_arkel_triangle
 from pymatgen.util.testing import PymatgenTest
 

--- a/tests/util/test_provenance.py
+++ b/tests/util/test_provenance.py
@@ -7,6 +7,7 @@ from unittest import TestCase
 
 import numpy as np
 import pytest
+
 from pymatgen.core.structure import Molecule, Structure
 from pymatgen.util.provenance import Author, HistoryNode, StructureNL
 

--- a/tests/util/test_string.py
+++ b/tests/util/test_string.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
+
 from pymatgen.core import Structure
 from pymatgen.util.string import (
     Stringify,

--- a/tests/util/test_typing.py
+++ b/tests/util/test_typing.py
@@ -10,6 +10,7 @@ from types import GenericAlias
 from typing import TYPE_CHECKING, get_args
 
 import pytest
+
 from pymatgen.core import Composition, DummySpecies, Element, Species
 from pymatgen.entries import Entry
 from pymatgen.util.typing import CompositionLike, EntryLike, PathLike, PbcLike, SpeciesLike

--- a/tests/vis/test_plotters.py
+++ b/tests/vis/test_plotters.py
@@ -6,6 +6,7 @@ import os
 import matplotlib.pyplot as plt
 import numpy as np
 from monty.json import MontyDecoder
+
 from pymatgen.analysis.xas.spectrum import XAS
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
 from pymatgen.vis.plotters import SpectrumPlotter


### PR DESCRIPTION
fix the import sorting issue [affecting many PRs](https://github.com/materialsproject/pymatgen/pull/3876#issuecomment-2248527074) after 9100860d7d didn't ensure [`pymatgen` is recognized as a first-party package](https://docs.astral.sh/ruff/settings/#lint_isort_known-first-party)