### PR TITLE
test_graph: add filename only to pdf list

### DIFF
--- a/tests/analysis/test_graphs.py
+++ b/tests/analysis/test_graphs.py
@@ -373,7 +373,7 @@ from    to  to_image
         bc_square_sg_r.draw_graph_to_file(f"{self.tmp_path}/bc_square_r.pdf", algo="neato", image_labels=False)
 
         # ensure PDF files were created
-        pdfs = {path.split("/") for path in glob(f"{self.tmp_path}/*.pdf")}
+        pdfs = {path.split("/")[-1] for path in glob(f"{self.tmp_path}/*.pdf")}
         expected_pdfs = {
             "bc_square_r_single.pdf",
             "bc_square_r.pdf",


### PR DESCRIPTION
The pdfs list must be constructed from filenames only without other path components, i.e. use last entry from split()

## Summary

Major changes:

- fix: fix list of pdf files in test_draw (test_graph)

## Checklist

- [ ] Google format doc strings added. Check with `ruff`.
- [ ] Type annotations included. Check with `mypy`.
- [x ] Tests added for new features/fixes (test already present).

Closes: #3969 