### PR TITLE
Assign frame properties to molecule/structure when indexing trajectory

### DIFF
--- a/src/pymatgen/core/trajectory.py
+++ b/src/pymatgen/core/trajectory.py
@@ -219,6 +219,7 @@ class Trajectory(MSONable):
                     charge=charge,
                     spin_multiplicity=spin,
                     site_properties=self._get_site_props(frames),  # type: ignore[arg-type]
+                    properties=None if self.frame_properties is None else self.frame_properties[frames],
                 )
 
             lattice = self.lattice if self.constant_lattice else self.lattice[frames]
@@ -228,6 +229,7 @@ class Trajectory(MSONable):
                 self.species,
                 self.coords[frames],
                 site_properties=self._get_site_props(frames),  # type: ignore[arg-type]
+                properties=None if self.frame_properties is None else self.frame_properties[frames],
                 to_unit_cell=True,
             )
 

--- a/tests/core/test_trajectory.py
+++ b/tests/core/test_trajectory.py
@@ -219,6 +219,10 @@ class TestTrajectory(PymatgenTest):
         expected = props[1:]
         assert traj[1:].frame_properties == expected
 
+        # test that the frame properties are set correctly when indexing an individual structure/molecule
+        expected = props[0]
+        assert traj[0].properties == expected
+
     def test_extend(self):
         traj = copy.deepcopy(self.traj)
 


### PR DESCRIPTION
## Summary

When indexing a trajectory the site properties would be assigned to the structure/molecule but the frame properties would not be propagated down to the structure/molecule in question.

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))