### PR TITLE
Fix mypy errors for `io.cp2k`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -285,7 +285,7 @@ ignore_missing_imports = true
 namespace_packages = true
 explicit_package_bases = true
 no_implicit_optional = false
-disable_error_code = "annotation-unchecked"
+disable_error_code = ["annotation-unchecked", "override"]
 
 [[tool.mypy.overrides]]
 module = ["requests.*", "tabulate.*"]

--- a/src/pymatgen/analysis/local_env.py
+++ b/src/pymatgen/analysis/local_env.py
@@ -1490,7 +1490,7 @@ class OpenBabelNN(NearNeighbors):
 
         return siw
 
-    def get_bonded_structure(self, structure: Structure, decorate: bool = False) -> StructureGraph:  # type: ignore[override]
+    def get_bonded_structure(self, structure: Structure, decorate: bool = False) -> StructureGraph:
         """
         Obtain a MoleculeGraph object using this NearNeighbor
         class. Requires the optional dependency networkx
@@ -1637,7 +1637,7 @@ class CovalentBondNN(NearNeighbors):
 
         return siw
 
-    def get_bonded_structure(self, structure: Structure, decorate: bool = False) -> MoleculeGraph:  # type: ignore[override]
+    def get_bonded_structure(self, structure: Structure, decorate: bool = False) -> MoleculeGraph:
         """
         Obtain a MoleculeGraph object using this NearNeighbor class.
 
@@ -4000,7 +4000,7 @@ class CrystalNN(NearNeighbors):
 
         return self.transform_to_length(self.NNData(nn, cn_weights, cn_nninfo), length)
 
-    def get_cn(self, structure: Structure, n: int, **kwargs) -> float:  # type: ignore[override]
+    def get_cn(self, structure: Structure, n: int, **kwargs) -> float:
         """Get coordination number, CN, of site with index n in structure.
 
         Args:
@@ -4306,7 +4306,7 @@ class Critic2NN(NearNeighbors):
         """
         return True
 
-    def get_bonded_structure(self, structure: Structure, decorate: bool = False) -> StructureGraph:  # type: ignore[override]
+    def get_bonded_structure(self, structure: Structure, decorate: bool = False) -> StructureGraph:
         """
         Args:
             structure (Structure): Input structure

--- a/src/pymatgen/core/interface.py
+++ b/src/pymatgen/core/interface.py
@@ -166,7 +166,7 @@ class GrainBoundary(Structure):
             outs.append(f"{idx} {site.species_string} {' '.join(to_str(coord, 12) for coord in site.frac_coords)}")
         return "\n".join(outs)
 
-    def copy(self) -> Self:  # type: ignore[override]
+    def copy(self) -> Self:
         """Make a copy of the GrainBoundary."""
         return type(self)(
             self.lattice,
@@ -261,7 +261,7 @@ class GrainBoundary(Structure):
                 coincident_sites.append(self.sites[idx])
         return coincident_sites
 
-    def as_dict(self) -> dict:  # type: ignore[override]
+    def as_dict(self) -> dict:
         """
         Returns:
             Dictionary representation of GrainBoundary object.
@@ -281,7 +281,7 @@ class GrainBoundary(Structure):
         }
 
     @classmethod
-    def from_dict(cls, dct: dict) -> Self:  # type: ignore[override]
+    def from_dict(cls, dct: dict) -> Self:
         """Generate GrainBoundary from a dict created by as_dict().
 
         Args:
@@ -2580,7 +2580,7 @@ class Interface(Structure):
         """A Structure for just the film."""
         return Structure.from_sites(self.film_sites)
 
-    def copy(self) -> Self:  # type: ignore[override]
+    def copy(self) -> Self:
         """Make a copy of the Interface."""
         return type(self).from_dict(self.as_dict())
 
@@ -2689,7 +2689,7 @@ class Interface(Structure):
             site._lattice = new_lattice  # Update the lattice
             site.coords = c_coords  # Put back into original Cartesian space
 
-    def as_dict(self) -> dict:  # type: ignore[override]
+    def as_dict(self) -> dict:
         """MSONable dict."""
         return {
             **super().as_dict(),
@@ -2700,7 +2700,7 @@ class Interface(Structure):
         }
 
     @classmethod
-    def from_dict(cls, dct: dict) -> Self:  # type: ignore[override]
+    def from_dict(cls, dct: dict) -> Self:
         """
         Args:
             dct: dict.

--- a/src/pymatgen/core/ion.py
+++ b/src/pymatgen/core/ion.py
@@ -304,7 +304,7 @@ class Ion(Composition, MSONable, Stringify):
         """Composition of ion."""
         return Composition(self._data)
 
-    def oxi_state_guesses(  # type: ignore[override]
+    def oxi_state_guesses(
         self,
         oxi_states_override: dict | None = None,
         all_oxi_states: bool = False,

--- a/src/pymatgen/core/lattice.py
+++ b/src/pymatgen/core/lattice.py
@@ -443,7 +443,7 @@ class Lattice(MSONable):
         dct: dict,
         fmt: str | None = None,
         **kwargs,
-    ) -> Self:  # type: ignore[override]
+    ) -> Self:
         """Create a Lattice from a dictionary.
 
         If fmt is None, the dict should contain the a, b, c,

--- a/src/pymatgen/core/sites.py
+++ b/src/pymatgen/core/sites.py
@@ -84,7 +84,7 @@ class Site(collections.abc.Hashable, MSONable):
             return props[attr]
         raise AttributeError(f"{attr=} not found on {type(self).__name__}")
 
-    def __getitem__(self, el: Element) -> float:  # type: ignore[override]
+    def __getitem__(self, el: Element) -> float:
         """Get the occupancy for element."""
         return self.species[el]
 
@@ -102,7 +102,7 @@ class Site(collections.abc.Hashable, MSONable):
             and self.properties == other.properties
         )
 
-    def __hash__(self) -> int:  # type: ignore[override]
+    def __hash__(self) -> int:
         """Minimally effective hash function that just distinguishes between Sites
         with different elements.
         """

--- a/src/pymatgen/core/structure.py
+++ b/src/pymatgen/core/structure.py
@@ -104,7 +104,7 @@ class Neighbor(Site):
         """Make neighbor Tuple-like to retain backwards compatibility."""
         return 3
 
-    def __getitem__(self, idx: int) -> Self | float:  # type: ignore[override]
+    def __getitem__(self, idx: int) -> Self | float:
         """Make neighbor Tuple-like to retain backwards compatibility."""
         return (self, self.nn_distance, self.index)[idx]
 
@@ -170,7 +170,7 @@ class PeriodicNeighbor(PeriodicSite):
         """Make neighbor Tuple-like to retain backwards compatibility."""
         return 4
 
-    def __getitem__(self, idx: int | slice):  # type: ignore[override]
+    def __getitem__(self, idx: int | slice):
         """Make neighbor Tuple-like to retain backwards compatibility."""
         return (self, self.nn_distance, self.index, self.image)[idx]
 
@@ -179,12 +179,12 @@ class PeriodicNeighbor(PeriodicSite):
         """Cartesian coords."""
         return self._lattice.get_cartesian_coords(self._frac_coords)
 
-    def as_dict(self) -> dict:  # type: ignore[override]
+    def as_dict(self) -> dict:
         """Note that method calls the super of Site, which is MSONable itself."""
         return super(Site, self).as_dict()
 
     @classmethod
-    def from_dict(cls, dct: dict) -> Self:  # type: ignore[override]
+    def from_dict(cls, dct: dict) -> Self:
         """Get a PeriodicNeighbor from a dict.
 
         Args:
@@ -2960,7 +2960,7 @@ class IStructure(SiteCollection, MSONable):
         raise ValueError(f"Invalid source: {source}")
 
     @classmethod
-    def from_str(  # type: ignore[override]
+    def from_str(
         cls,
         input_string: str,
         fmt: FileFormats,
@@ -3044,7 +3044,7 @@ class IStructure(SiteCollection, MSONable):
         return cls.from_sites(struct, properties=struct.properties)
 
     @classmethod
-    def from_file(  # type: ignore[override]
+    def from_file(
         cls,
         filename: PathLike,
         primitive: bool = False,
@@ -3774,7 +3774,7 @@ class IMolecule(SiteCollection, MSONable):
         return str(writer)
 
     @classmethod
-    def from_str(  # type: ignore[override]
+    def from_str(
         cls,
         input_string: str,
         fmt: Literal["xyz", "gjf", "g03", "g09", "com", "inp", "json", "yaml"],
@@ -3821,7 +3821,7 @@ class IMolecule(SiteCollection, MSONable):
         return cls.from_sites(mol, properties=mol.properties)
 
     @classmethod
-    def from_file(cls, filename: PathLike) -> Self | None:  # type: ignore[override]
+    def from_file(cls, filename: PathLike) -> Self | None:
         """Read a molecule from a file. Supported formats include xyz,
         gaussian input (gjf|g03|g09|com|inp), Gaussian output (.out|and
         pymatgen's JSON-serialized molecules. Using openbabel,
@@ -3933,7 +3933,7 @@ class Structure(IStructure, collections.abc.MutableSequence):
 
         self._sites: list[PeriodicSite] = list(self._sites)  # type: ignore[assignment]
 
-    def __setitem__(  # type: ignore[override]
+    def __setitem__(
         self,
         idx: int | slice | Sequence[int] | SpeciesLike,
         site: SpeciesLike | PeriodicSite | Sequence | dict[SpeciesLike, float],
@@ -4018,7 +4018,7 @@ class Structure(IStructure, collections.abc.MutableSequence):
         for site in self:
             site.lattice = lattice
 
-    def append(  # type: ignore[override]
+    def append(
         self,
         species: CompositionLike,
         coords: ArrayLike,
@@ -4049,7 +4049,7 @@ class Structure(IStructure, collections.abc.MutableSequence):
             properties=properties,
         )
 
-    def insert(  # type: ignore[override]
+    def insert(
         self,
         idx: int,
         species: CompositionLike,
@@ -4765,7 +4765,7 @@ class Molecule(IMolecule, collections.abc.MutableSequence):
         )
         self._sites: list[Site] = list(self._sites)
 
-    def __setitem__(  # type: ignore[override]
+    def __setitem__(
         self,
         idx: int | slice | Sequence[int] | SpeciesLike,
         site: SpeciesLike | Site | Sequence,
@@ -4810,7 +4810,7 @@ class Molecule(IMolecule, collections.abc.MutableSequence):
         """Deletes a site from the Structure."""
         self._sites.__delitem__(idx)
 
-    def append(  # type: ignore[override]
+    def append(
         self,
         species: CompositionLike,
         coords: ArrayLike,
@@ -4874,7 +4874,7 @@ class Molecule(IMolecule, collections.abc.MutableSequence):
 
         return self
 
-    def insert(  # type: ignore[override]
+    def insert(
         self,
         idx: int,
         species: CompositionLike,

--- a/src/pymatgen/core/surface.py
+++ b/src/pymatgen/core/surface.py
@@ -218,7 +218,7 @@ class Slab(Structure):
         return np.linalg.norm(np.cross(matrix[0], matrix[1]))
 
     @classmethod
-    def from_dict(cls, dct: dict[str, Any]) -> Self:  # type: ignore[override]
+    def from_dict(cls, dct: dict[str, Any]) -> Self:
         """
         Args:
             dct: dict.
@@ -242,7 +242,7 @@ class Slab(Structure):
             energy=dct["energy"],
         )
 
-    def as_dict(self, **kwargs) -> dict:  # type: ignore[override]
+    def as_dict(self, **kwargs) -> dict:
         """MSONable dict."""
         dct = super().as_dict(**kwargs)
         dct["@module"] = type(self).__module__
@@ -255,7 +255,7 @@ class Slab(Structure):
         dct["energy"] = self.energy
         return dct
 
-    def copy(self, site_properties: dict[str, Any] | None = None) -> Self:  # type: ignore[override]
+    def copy(self, site_properties: dict[str, Any] | None = None) -> Self:
         """Get a copy of the Slab, with options to update site properties.
 
         Args:

--- a/src/pymatgen/electronic_structure/bandstructure.py
+++ b/src/pymatgen/electronic_structure/bandstructure.py
@@ -1037,7 +1037,7 @@ class LobsterBandStructureSymmLine(BandStructureSymmLine):
 
     def get_projections_on_elements_and_orbitals(
         self,
-        el_orb_spec: dict[Element, list],  # type: ignore[override]
+        el_orb_spec: dict[Element, list],
     ) -> dict[Spin, list]:
         """Get projections on elements and specific orbitals.
 

--- a/src/pymatgen/electronic_structure/dos.py
+++ b/src/pymatgen/electronic_structure/dos.py
@@ -1397,7 +1397,7 @@ _lobster_orb_labs = (
 class LobsterCompleteDos(CompleteDos):
     """Extended CompleteDos for LOBSTER."""
 
-    def get_site_orbital_dos(self, site: PeriodicSite, orbital: str) -> Dos:  # type: ignore[override]
+    def get_site_orbital_dos(self, site: PeriodicSite, orbital: str) -> Dos:
         """Get the DOS for a particular orbital of a particular site.
 
         Args:
@@ -1448,7 +1448,7 @@ class LobsterCompleteDos(CompleteDos):
             "e_g": Dos(self.efermi, self.energies, functools.reduce(add_densities, eg_dos)),
         }
 
-    def get_spd_dos(self) -> dict[str, Dos]:  # type: ignore[override]
+    def get_spd_dos(self) -> dict[str, Dos]:
         """Get orbital projected DOS.
 
         For example, if 3s and 4s are included in the basis of some element,
@@ -1469,7 +1469,7 @@ class LobsterCompleteDos(CompleteDos):
 
         return {orb: Dos(self.efermi, self.energies, densities) for orb, densities in spd_dos.items()}  # type: ignore[misc]
 
-    def get_element_spd_dos(self, el: SpeciesLike) -> dict[str, Dos]:  # type: ignore[override]
+    def get_element_spd_dos(self, el: SpeciesLike) -> dict[str, Dos]:
         """Get element and s/p/d projected DOS.
 
         Args:

--- a/src/pymatgen/entries/compatibility.py
+++ b/src/pymatgen/entries/compatibility.py
@@ -837,7 +837,7 @@ class CorrectionsList(Compatibility):
         dct["corrections"] = corrections
         return dct
 
-    def explain(self, entry: ComputedEntry) -> None:  # type: ignore[override]
+    def explain(self, entry: ComputedEntry) -> None:
         """Print an explanation of the corrections that are being applied for a
         given compatibility scheme. Inspired by the "explain" methods in many
         database methodologies.

--- a/src/pymatgen/entries/mixing_scheme.py
+++ b/src/pymatgen/entries/mixing_scheme.py
@@ -114,7 +114,7 @@ class MaterialsProjectDFTMixingScheme(Compatibility):
             if hasattr(compat, "check_potcar"):
                 compat.check_potcar = check_potcar  # type: ignore[union-attr]
 
-    def process_entries(  # type: ignore[override]
+    def process_entries(
         self,
         entries: AnyComputedEntry | list[AnyComputedEntry],
         clean: bool = True,

--- a/src/pymatgen/io/cp2k/inputs.py
+++ b/src/pymatgen/io/cp2k/inputs.py
@@ -1998,7 +1998,7 @@ class Kpoints(Section):
         )
 
     @classmethod
-    def from_kpoints(cls, kpoints: VaspKpoints, structure=None) -> Self:
+    def from_kpoints(cls, kpoints: VaspKpoints, structure: Structure | None = None) -> Self:
         """
         Initialize the section from a Kpoints object (pymatgen.io.vasp.inputs). CP2K
         does not have an automatic gamma-point constructor, so this is generally used
@@ -2007,8 +2007,8 @@ class Kpoints(Section):
         so long as the grid is fine enough.
 
         Args:
-            kpoints: A pymatgen kpoints object.
-            structure: Pymatgen structure object. Required for automatically performing
+            kpoints (Kpoints): A pymatgen kpoints object.
+            structure (Structure): Required for automatically performing
                 symmetry analysis and reducing the kpoint grid.
             reduce: whether or not to reduce the grid using symmetry. CP2K itself cannot
                 do this automatically without spglib present at execution time.
@@ -2017,8 +2017,8 @@ class Kpoints(Section):
         weights = kpoints.kpts_weights
 
         if kpoints.style == KpointsSupportedModes.Monkhorst:
-            kpt: Kpoint = kpts[0]  # type: ignore[assignment]
-            x, y, z = (kpt, kpt, kpt) if isinstance(kpt, (int, float)) else kpt  # type: ignore[misc]
+            kpt: Kpoint = kpts[0]
+            x, y, z = (kpt, kpt, kpt) if isinstance(kpt, (int, float)) else kpt
             scheme = f"MONKHORST-PACK {x} {y} {z}"
             units = "B_VECTOR"
 
@@ -2042,7 +2042,7 @@ class Kpoints(Section):
                 scheme = "GAMMA"
             else:
                 sga = SpacegroupAnalyzer(structure)
-                _kpts, weights = zip(*sga.get_ir_reciprocal_mesh(mesh=kpts))  # type: ignore[assignment]
+                _kpts, weights = zip(*sga.get_ir_reciprocal_mesh(mesh=kpts))
                 kpts = tuple(itertools.chain.from_iterable(_kpts))
                 scheme = "GENERAL"
 
@@ -2771,7 +2771,7 @@ class BasisFile(DataFile):
     """Data file for basis sets only."""
 
     @classmethod
-    def from_str(cls, string: str) -> Self:  # type: ignore[override]
+    def from_str(cls, string: str) -> Self:
         """Initialize from a string representation."""
         basis_sets = [GaussianTypeOrbitalBasisSet.from_str(c) for c in chunk(string)]
         return cls(objects=basis_sets)
@@ -2782,7 +2782,7 @@ class PotentialFile(DataFile):
     """Data file for potentials only."""
 
     @classmethod
-    def from_str(cls, string: str) -> Self:  # type: ignore[override]
+    def from_str(cls, string: str) -> Self:
         """Initialize from a string representation."""
         basis_sets = [GthPotential.from_str(c) for c in chunk(string)]
         return cls(objects=basis_sets)

--- a/src/pymatgen/io/lammps/data.py
+++ b/src/pymatgen/io/lammps/data.py
@@ -1360,12 +1360,12 @@ class CombinedData(LammpsData):
 
     # NOTE (@janosh): The following two methods for override parent class LammpsData
     @classmethod
-    def from_ff_and_topologies(cls) -> None:  # type: ignore[override]
+    def from_ff_and_topologies(cls) -> None:
         """Unsupported constructor for CombinedData objects."""
         raise AttributeError("Unsupported constructor for CombinedData objects")
 
     @classmethod
-    def from_structure(cls) -> None:  # type: ignore[override]
+    def from_structure(cls) -> None:
         """Unsupported constructor for CombinedData objects."""
         raise AttributeError("Unsupported constructor for CombinedData objects")
 

--- a/src/pymatgen/io/lammps/inputs.py
+++ b/src/pymatgen/io/lammps/inputs.py
@@ -531,7 +531,7 @@ class LammpsInputFile(InputFile):
             file.write(self.get_str(ignore_comments=ignore_comments, keep_stages=keep_stages))
 
     @classmethod
-    def from_str(cls, contents: str, ignore_comments: bool = False, keep_stages: bool = False) -> Self:  # type: ignore[override]
+    def from_str(cls, contents: str, ignore_comments: bool = False, keep_stages: bool = False) -> Self:
         """
         Helper method to parse string representation of LammpsInputFile.
         If you created the input file by hand, there is no guarantee that the representation
@@ -609,7 +609,7 @@ class LammpsInputFile(InputFile):
         return lammps_in_file
 
     @classmethod
-    def from_file(cls, path: str | Path, ignore_comments: bool = False, keep_stages: bool = False) -> Self:  # type: ignore[override]
+    def from_file(cls, path: str | Path, ignore_comments: bool = False, keep_stages: bool = False) -> Self:
         """
         Creates an InputFile object from a file.
 
@@ -934,7 +934,7 @@ class LammpsTemplateGen(TemplateInputGen):
     See pymatgen.io.template.py for additional documentation of this method.
     """
 
-    def get_input_set(  # type: ignore[override]
+    def get_input_set(
         self,
         script_template: PathLike,
         settings: dict | None = None,

--- a/src/pymatgen/io/lammps/sets.py
+++ b/src/pymatgen/io/lammps/sets.py
@@ -75,7 +75,7 @@ class LammpsInputSet(InputSet):
         super().__init__(inputs={"in.lammps": self.inputfile, "system.data": self.data})
 
     @classmethod
-    def from_directory(cls, directory: PathLike, keep_stages: bool = False) -> Self:  # type: ignore[override]
+    def from_directory(cls, directory: PathLike, keep_stages: bool = False) -> Self:
         """Construct a LammpsInputSet from a directory of two or more files.
 
         TODO: accept directories with only the input file, that should include the structure as well.

--- a/src/pymatgen/io/lobster/inputs.py
+++ b/src/pymatgen/io/lobster/inputs.py
@@ -184,7 +184,7 @@ class Lobsterin(UserDict, MSONable):
         except KeyError as exc:
             raise KeyError(f"{key=} is not available") from exc
 
-    def __contains__(self, key: str) -> bool:  # type: ignore[override]
+    def __contains__(self, key: str) -> bool:
         """To avoid cases sensitivity problems."""
         return super().__contains__(key.lower().strip())
 

--- a/src/pymatgen/io/lobster/lobsterenv.py
+++ b/src/pymatgen/io/lobster/lobsterenv.py
@@ -253,7 +253,7 @@ class LobsterNeighbors(NearNeighbors):
     def get_anion_types(self):
         return self.anion_types
 
-    def get_nn_info(self, structure: Structure, n: int, use_weights: bool = False) -> dict:  # type: ignore[override]
+    def get_nn_info(self, structure: Structure, n: int, use_weights: bool = False) -> dict:
         """Get coordination number, CN, of site with index n in structure.
 
         Args:

--- a/src/pymatgen/io/qchem/inputs.py
+++ b/src/pymatgen/io/qchem/inputs.py
@@ -306,7 +306,7 @@ class QCInput(InputFile):
         return multi_job_string
 
     @classmethod
-    def from_str(cls, string: str) -> Self:  # type: ignore[override]
+    def from_str(cls, string: str) -> Self:
         """
         Read QcInput from string.
 
@@ -380,7 +380,7 @@ class QCInput(InputFile):
             file.write(QCInput.multi_job_string(job_list))
 
     @classmethod
-    def from_file(cls, filename: str | Path) -> Self:  # type: ignore[override]
+    def from_file(cls, filename: str | Path) -> Self:
         """
         Create QcInput from file.
 

--- a/src/pymatgen/symmetry/structure.py
+++ b/src/pymatgen/symmetry/structure.py
@@ -67,7 +67,7 @@ class SymmetrizedStructure(Structure):
         self.wyckoff_letters = wyckoff_letters
         self.wyckoff_symbols = [f"{len(symb)}{symb[0]}" for symb in wyckoff_symbols]
 
-    def copy(self) -> Self:  # type: ignore[override]
+    def copy(self) -> Self:
         """Make a copy of the SymmetrizedStructure."""
         return type(self)(
             self,
@@ -134,7 +134,7 @@ class SymmetrizedStructure(Structure):
         }
 
     @classmethod
-    def from_dict(cls, dct: dict) -> Self:  # type: ignore[override]
+    def from_dict(cls, dct: dict) -> Self:
         """
         Args:
             dct (dict): Dict representation.

--- a/tests/io/test_core.py
+++ b/tests/io/test_core.py
@@ -27,7 +27,7 @@ class StructInputFile(InputFile):
         return str(cw)
 
     @classmethod
-    def from_str(cls, contents: str) -> Self:  # type: ignore[override]
+    def from_str(cls, contents: str) -> Self:
         struct = Structure.from_str(contents, fmt="cif")
         return cls(structure=struct)
 


### PR DESCRIPTION
### Summary

- Fix mypy errors for `io.cp2k`
- `mypy` now ignore `override` error globally