### PR TITLE
Ion: fix CO2- and I3- parsing errors; enhance tests

### DIFF
--- a/src/pymatgen/core/ion.py
+++ b/src/pymatgen/core/ion.py
@@ -226,7 +226,7 @@ class Ion(Composition, MSONable, Stringify):
         elif formula == "CSN":
             formula = "SCN"
         # triiodide, nitride, an phosphide
-        elif formula in ["I", "N", "P"] and self.charge == -1:
+        elif (formula in ["N", "P"] and self.charge == -1) or (formula == "I" and self.charge == 1 / 3):
             formula += "3"
             factor /= 3
         # formate # codespell:ignore
@@ -235,7 +235,7 @@ class Ion(Composition, MSONable, Stringify):
         # oxalate
         elif formula == "CO2":
             formula = "C2O4"
-            factor *= 2
+            factor /= 2
         # diatomic gases
         elif formula in {"O", "N", "F", "Cl", "H"} and factor % 2 == 0:
             formula += "2"

--- a/tests/core/test_ion.py
+++ b/tests/core/test_ion.py
@@ -56,6 +56,7 @@ class TestIon(TestCase):
             ("Cl-", "Cl[-1]"),
             ("H+", "H[+1]"),
             ("F-", "F[-1]"),
+            ("I-", "I[-1]"),
             ("F2", "F2(aq)"),
             ("H2", "H2(aq)"),
             ("O3", "O3(aq)"),
@@ -69,6 +70,7 @@ class TestIon(TestCase):
             ("CH3COOH", "CH3COOH(aq)"),
             ("CH3OH", "CH3OH(aq)"),
             ("H4CO", "CH3OH(aq)"),
+            ("CO2-", "C2O4[-2]"),
             ("CH4", "CH4(aq)"),
             ("NH4+", "NH4[+1]"),
             ("NH3", "NH3(aq)"),
@@ -81,7 +83,9 @@ class TestIon(TestCase):
             ("Zr(OH)4", "Zr(OH)4(aq)"),
         ]
         for tup in special_formulas:
-            assert Ion.from_formula(tup[0]).reduced_formula == tup[1]
+            assert (
+                Ion.from_formula(tup[0]).reduced_formula == tup[1]
+            ), f"Expected {tup[1]} but got {Ion.from_formula(tup[0]).reduced_formula}"
 
         assert Ion.from_formula("Fe(OH)4+").get_reduced_formula_and_factor(hydrates=True) == ("FeO2.2H2O", 1)
         assert Ion.from_formula("Zr(OH)4").get_reduced_formula_and_factor(hydrates=True) == ("ZrO2.2H2O", 1)


### PR DESCRIPTION
## Summary

My recent PR #3942 contained two bugs that were revealed by testing in downstream code (see [pyEQL PR](https://github.com/KingsburyLab/pyEQL/pull/169#issuecomment-2278396689)). This PR fixes those and expands the unit tests to catch them.

```
>>> Ion.from_formula('CO2-').reduced_formula
'C2O4[-0.5]'
>>> Ion.from_formula('CO2--').reduced_formula
'C2O4[-1]'
```
```
>>> Ion.from_formula('I3-').get_reduced_formula_and_factor()
('I3', 1.0)
>>> Ion.from_formula('I-').get_reduced_formula_and_factor()
('I3', 0.3333333333333333)
```

