### PR TITLE
Add additional metadata to default CIF comment string

### DIFF
--- a/src/pymatgen/io/cif.py
+++ b/src/pymatgen/io/cif.py
@@ -19,8 +19,9 @@ import numpy as np
 from monty.dev import deprecated
 from monty.io import zopen
 from monty.serialization import loadfn
+from spglib import __version__ as __spglib_version__
 
-from pymatgen.core import Composition, DummySpecies, Element, Lattice, PeriodicSite, Species, Structure, get_el_sp
+from pymatgen.core import Composition, DummySpecies, Element, Lattice, PeriodicSite, Species, Structure, get_el_sp, __version__
 from pymatgen.core.operations import MagSymmOp, SymmOp
 from pymatgen.electronic_structure.core import Magmom
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer, SpacegroupOperations
@@ -254,7 +255,7 @@ class CifFile:
         """
         self.data = data
         self.orig_string = orig_string
-        self.comment: str = comment or "# generated using pymatgen"
+        self.comment: str = comment or f"# generated using pymatgen {__version__} (spglib {__spglib_version__})"
 
     def __str__(self) -> str:
         out = "\n".join(map(str, self.data.values()))


### PR DESCRIPTION
Should a bug be found in either pymatgen's CIFWriter or spglib, a key package depended upon by pymatgen, this updated comment string will make it easier to find affected CIF files.

## Summary

Major changes:

- feature 1: ...
- fix 1: ...

## Todos

If this is work in progress, what else needs to be done?

- feature 2: ...
- fix 2:

## Checklist

- [ ] Google format doc strings added. Check with `ruff`.
- [ ] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
