### PR TITLE
VaspInputSet.write_input: Improve error message

### DIFF
--- a/src/pymatgen/io/vasp/inputs.py
+++ b/src/pymatgen/io/vasp/inputs.py
@@ -1733,6 +1733,11 @@ VASP_POTCAR_HASHES = loadfn(f"{module_dir}/vasp_potcar_file_hashes.json")
 POTCAR_STATS_PATH: str = os.path.join(module_dir, "potcar-summary-stats.json.bz2")
 
 
+class PMG_VASP_PSP_DIR_Error(ValueError):
+    """Error thrown when PMG_VASP_PSP_DIR is not configured, but POTCAR is requested."""
+    pass
+
+
 class PotcarSingle:
     """
     Object for a **single** POTCAR. The builder assumes the POTCAR contains
@@ -2278,7 +2283,7 @@ class PotcarSingle:
         functional_subdir = SETTINGS.get("PMG_VASP_PSP_SUB_DIRS", {}).get(functional, cls.functional_dir[functional])
         PMG_VASP_PSP_DIR = SETTINGS.get("PMG_VASP_PSP_DIR")
         if PMG_VASP_PSP_DIR is None:
-            raise ValueError(
+            raise PMG_VASP_PSP_DIR_Error(
                 f"No POTCAR for {symbol} with {functional=} found. Please set the PMG_VASP_PSP_DIR in .pmgrc.yaml."
             )
         if not os.path.isdir(PMG_VASP_PSP_DIR):

--- a/src/pymatgen/io/vasp/inputs.py
+++ b/src/pymatgen/io/vasp/inputs.py
@@ -1735,7 +1735,6 @@ POTCAR_STATS_PATH: str = os.path.join(module_dir, "potcar-summary-stats.json.bz2
 
 class PMG_VASP_PSP_DIR_Error(ValueError):
     """Error thrown when PMG_VASP_PSP_DIR is not configured, but POTCAR is requested."""
-    pass
 
 
 class PotcarSingle:

--- a/src/pymatgen/io/vasp/sets.py
+++ b/src/pymatgen/io/vasp/sets.py
@@ -49,7 +49,7 @@ from monty.serialization import loadfn
 from pymatgen.analysis.structure_matcher import StructureMatcher
 from pymatgen.core import Element, PeriodicSite, SiteCollection, Species, Structure
 from pymatgen.io.core import InputGenerator
-from pymatgen.io.vasp.inputs import Incar, Kpoints, Poscar, Potcar, VaspInput
+from pymatgen.io.vasp.inputs import Incar, Kpoints, PMG_VASP_PSP_DIR_Error, Poscar, Potcar, VaspInput
 from pymatgen.io.vasp.outputs import Outcar, Vasprun
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.symmetry.bandstructure import HighSymmKpath
@@ -341,7 +341,15 @@ class VaspInputSet(InputGenerator, abc.ABC):
             zip_output (bool): If True, output will be zipped into a file with the
                 same name as the InputSet (e.g., MPStaticSet.zip).
         """
-        vasp_input = self.get_input_set(potcar_spec=potcar_spec)
+        try:
+            vasp_input = self.get_input_set(potcar_spec=potcar_spec)
+        except PMG_VASP_PSP_DIR_Error:
+            assert potcar_spec is False
+            raise ValueError(
+                "PMG_VASP_PSP_DIR is not set."
+                "  Please set the PMG_VASP_PSP_DIR in .pmgrc.yaml"
+                " or use potcar_spec=True argument."
+            )
 
         cif_name = None
         if include_cif:


### PR DESCRIPTION
## Summary

This is a small patch improving error message when writing VASP input without VASP installation.
The original message thrown by Potcar constructor is very generic and sounds like VASP _must_ be installed:

    pymatgen.io.vasp.inputs.PMG_VASP_PSP_DIR_Error: No POTCAR for H with functional='PBE' found. Please set the PMG_VASP_PSP_DIR in .pmgrc.yaml.

The new message highlights the existance of `potcar_spec` argument:

    ValueError: PMG_VASP_PSP_DIR is not set.  Please set the PMG_VASP_PSP_DIR in .pmgrc.yaml or use potcar_spec=True argument.

## Checklist
(used pre-commit hook)
- [X] Google format doc strings added. Check with `ruff`.
- [X] Type annotations included. Check with `mypy`.
- [X] Tests added for new features/fixes.
- [X] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

