### PR TITLE
Formatting customization for `PWInput`

### DIFF
--- a/src/pymatgen/util/io_utils.py
+++ b/src/pymatgen/util/io_utils.py
@@ -20,23 +20,30 @@ __status__ = "Production"
 __date__ = "Sep 23, 2011"
 
 
-def clean_lines(string_list, remove_empty_lines=True) -> Generator[str, None, None]:
+def clean_lines(
+    string_list,
+    remove_empty_lines=True,
+    rstrip_only=False,
+) -> Generator[str, None, None]:
     """Strips whitespace, carriage returns and empty lines from a list of strings.
 
     Args:
         string_list: List of strings
         remove_empty_lines: Set to True to skip lines which are empty after
             stripping.
+        rstrip_only: Set to True to strip trailing whitespaces only (i.e.,
+            to retain leading whitespaces). Defaults to False.
 
     Yields:
-        list: clean strings with no whitespaces.
+        list: clean strings with no whitespaces. If rstrip_only == True,
+            clean strings with no trailing whitespaces.
     """
     for s in string_list:
         clean_s = s
         if "#" in s:
             ind = s.index("#")
             clean_s = s[:ind]
-        clean_s = clean_s.strip()
+        clean_s = clean_s.rstrip() if rstrip_only else clean_s.strip()
         if (not remove_empty_lines) or clean_s != "":
             yield clean_s
 

--- a/tests/io/test_pwscf.py
+++ b/tests/io/test_pwscf.py
@@ -500,6 +500,21 @@ CELL_PARAMETERS angstrom
 """
         assert str(pw).strip() == expected.strip()
 
+    def test_custom_decimal_precision_write_and_read_str(self):
+        struct = self.get_structure("Li2O")
+        pw = PWInput(
+            struct,
+            control={"calculation": "scf", "pseudo_dir": "./"},
+            pseudo={
+                "Li+": "Li.pbe-n-kjpaw_psl.0.1.UPF",
+                "O2-": "O.pbe-n-kjpaw_psl.0.1.UPF",
+            },
+            system={"ecutwfc": 50},
+            format_options={"coord_decimals": 9},
+        )
+        pw_str = str(pw)
+        assert pw_str.strip() == str(PWInput.from_str(pw_str)).strip()
+
 
 class TestPWOutput(PymatgenTest):
     def setUp(self):

--- a/tests/io/test_pwscf.py
+++ b/tests/io/test_pwscf.py
@@ -402,6 +402,104 @@ CELL_PARAMETERS angstrom
         pw_str = str(pw)
         assert pw_str.strip() == str(PWInput.from_str(pw_str)).strip()
 
+    def test_custom_decimal_precision(self):
+        struct = self.get_structure("Li2O")
+        pw = PWInput(
+            struct,
+            control={"calculation": "scf", "pseudo_dir": "./"},
+            pseudo={
+                "Li+": "Li.pbe-n-kjpaw_psl.0.1.UPF",
+                "O2-": "O.pbe-n-kjpaw_psl.0.1.UPF",
+            },
+            system={"ecutwfc": 50},
+            format_options={"coord_decimals": 9, "indent": 0},
+        )
+        expected = """&CONTROL
+calculation = 'scf',
+pseudo_dir = './',
+/
+&SYSTEM
+ecutwfc = 50,
+ibrav = 0,
+nat = 3,
+ntyp = 2,
+/
+&ELECTRONS
+/
+&IONS
+/
+&CELL
+/
+ATOMIC_SPECIES
+Li+  6.9410 Li.pbe-n-kjpaw_psl.0.1.UPF
+O2-  15.9994 O.pbe-n-kjpaw_psl.0.1.UPF
+ATOMIC_POSITIONS crystal
+O2- 0.000000000 0.000000000 0.000000000
+Li+ 0.750178290 0.750178290 0.750178290
+Li+ 0.249821710 0.249821710 0.249821710
+K_POINTS automatic
+1 1 1 0 0 0
+CELL_PARAMETERS angstrom
+2.917388570 0.097894370 1.520004660
+0.964634060 2.755035610 1.520004660
+0.133206350 0.097894430 3.286917710
+"""
+        assert str(pw).strip() == expected.strip()
+
+    def test_custom_decimal_precision_kpoint_grid_crystal_b(self):
+        struct = self.get_structure("Li2O")
+        struct.remove_oxidation_states()
+        kpoints = [[0.0, 0.0, 0.0], [0.0, 0.5, 0.5], [0.5, 0.0, 0.0], [0.0, 0.0, 0.5], [0.5, 0.5, 0.5]]
+        pw = PWInput(
+            struct,
+            control={"calculation": "scf", "pseudo_dir": "./"},
+            pseudo={
+                "Li": "Li.pbe-n-kjpaw_psl.0.1.UPF",
+                "O": "O.pbe-n-kjpaw_psl.0.1.UPF",
+            },
+            system={"ecutwfc": 50},
+            kpoints_mode="crystal_b",
+            kpoints_grid=kpoints,
+            format_options={"kpoints_crystal_b_indent": 2},
+        )
+        expected = """
+&CONTROL
+  calculation = 'scf',
+  pseudo_dir = './',
+/
+&SYSTEM
+  ecutwfc = 50,
+  ibrav = 0,
+  nat = 3,
+  ntyp = 2,
+/
+&ELECTRONS
+/
+&IONS
+/
+&CELL
+/
+ATOMIC_SPECIES
+  Li  6.9410 Li.pbe-n-kjpaw_psl.0.1.UPF
+  O  15.9994 O.pbe-n-kjpaw_psl.0.1.UPF
+ATOMIC_POSITIONS crystal
+  O 0.000000 0.000000 0.000000
+  Li 0.750178 0.750178 0.750178
+  Li 0.249822 0.249822 0.249822
+K_POINTS crystal_b
+  5
+  0.0000 0.0000 0.0000
+  0.0000 0.5000 0.5000
+  0.5000 0.0000 0.0000
+  0.0000 0.0000 0.5000
+  0.5000 0.5000 0.5000
+CELL_PARAMETERS angstrom
+  2.917389 0.097894 1.520005
+  0.964634 2.755036 1.520005
+  0.133206 0.097894 3.286918
+"""
+        assert str(pw).strip() == expected.strip()
+
 
 class TestPWOutput(PymatgenTest):
     def setUp(self):


### PR DESCRIPTION
## Summary

Add optional keyword argument `format_options` of type `dict`, which specifies

- `indent`: # of spaces for indentation (defaults to 2)
- `kpoints_crystal_b_indent` # of spaces for indentation in `K_POINTS` card with `crystal_b` option (defaults to 1)
- `coord_decimals`: # of decimal digits for structure information (atomic position coordinates, lattice vector coordinates; defaults to 6)
- `atomic_mass_decimals`: # of decimal digits for atomic mass under `ATOMIC_SPECIES` card (defaults to 4)
- `kpoints_grid_decimals`: # of decimal digits for k-point reciprocal lattice coordinate values in `K_POINTS` card with `crystal_b` option (defaults to 4)

as keys. The default values are chosen to maintain the same output format as before the change.

This PR aims to close #4000 