### PR TITLE
Drop Python 3.9 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,14 +28,14 @@ jobs:
         # maximize CI coverage of different platforms and python versions while minimizing the
         # total number of jobs. We run all pytest splits with the oldest supported python
         # version (currently 3.10) on windows (seems most likely to surface errors) and with
-        # newest version (currently 3.13) on ubuntu (to get complete coverage on unix).
+        # newest version (currently 3.12) on ubuntu (to get complete coverage on unix).
         config:
           - os: windows-latest
             python: "3.10"
             resolution: highest
             extras: ci,optional
           - os: ubuntu-latest
-            python: "3.13.0rc1"
+            python: ">3.10"
             resolution: lowest-direct
             extras: ci,optional
           - os: macos-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
             resolution: highest
             extras: ci,optional
           - os: ubuntu-latest
-            python: "3.13"
+            python: "3.13.0rc1"
             resolution: lowest-direct
             extras: ci,optional
           - os: macos-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
             resolution: highest
             extras: ci,optional
           - os: ubuntu-latest
-            python: ">3.10"
+            python: "3.13"
             resolution: lowest-direct
             extras: ci,optional
           - os: macos-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,19 +27,19 @@ jobs:
       matrix:
         # maximize CI coverage of different platforms and python versions while minimizing the
         # total number of jobs. We run all pytest splits with the oldest supported python
-        # version (currently 3.9) on windows (seems most likely to surface errors) and with
-        # newest version (currently 3.12) on ubuntu (to get complete coverage on unix).
+        # version (currently 3.10) on windows (seems most likely to surface errors) and with
+        # newest version (currently 3.13) on ubuntu (to get complete coverage on unix).
         config:
           - os: windows-latest
-            python: "3.9"
+            python: "3.10"
             resolution: highest
             extras: ci,optional
           - os: ubuntu-latest
-            python: ">3.9"
+            python: ">3.10"
             resolution: lowest-direct
             extras: ci,optional
           - os: macos-latest
-            python: "3.10"
+            python: "3.11"
             resolution: lowest-direct
             extras: ci # test with only required dependencies installed
 

--- a/dev_scripts/update_pt_data.py
+++ b/dev_scripts/update_pt_data.py
@@ -218,7 +218,9 @@ def gen_iupac_ordering():
     ]  # At -> F
 
     order = sum((list(product(x, y)) for x, y in order), [])  # noqa: RUF017
-    iupac_ordering_dict = dict(zip([Element.from_row_and_group(row, group) for group, row in order], range(len(order))))
+    iupac_ordering_dict = dict(
+        zip([Element.from_row_and_group(row, group) for group, row in order], range(len(order)), strict=False)
+    )
 
     # first clean periodic table of any IUPAC ordering
     for el in periodic_table:

--- a/dev_scripts/update_pt_data.py
+++ b/dev_scripts/update_pt_data.py
@@ -3,9 +3,7 @@ Created on 2011-11-15."""
 
 from __future__ import annotations
 
-import functools
 import json
-import operator
 import re
 from collections import defaultdict
 from itertools import product
@@ -219,7 +217,7 @@ def gen_iupac_ordering():
         ([17], range(6, 1, -1)),
     ]  # At -> F
 
-    order = functools.reduce(operator.iadd, (list(product(x, y)) for x, y in order), [])
+    order = sum((list(product(x, y)) for x, y in order), [])  # noqa: RUF017
     iupac_ordering_dict = dict(
         zip([Element.from_row_and_group(row, group) for group, row in order], range(len(order)), strict=False)
     )

--- a/dev_scripts/update_pt_data.py
+++ b/dev_scripts/update_pt_data.py
@@ -3,7 +3,9 @@ Created on 2011-11-15."""
 
 from __future__ import annotations
 
+import functools
 import json
+import operator
 import re
 from collections import defaultdict
 from itertools import product
@@ -217,7 +219,7 @@ def gen_iupac_ordering():
         ([17], range(6, 1, -1)),
     ]  # At -> F
 
-    order = sum((list(product(x, y)) for x, y in order), [])  # noqa: RUF017
+    order = functools.reduce(operator.iadd, (list(product(x, y)) for x, y in order), [])
     iupac_ordering_dict = dict(
         zip([Element.from_row_and_group(row, group) for group, row in order], range(len(order)), strict=False)
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,7 +170,7 @@ before-all = "ln -s /usr/lib64/libgfortran.so.5 /usr/lib64/libgfortran.so.3"
 repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel} --ignore-missing-dependencies"
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py310"
 line-length = 120
 output-format = "concise"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,8 +106,7 @@ optional = [
     "h5py>=3.11.0",
     "jarvis-tools>=2020.7.14",
     "matgl>=1.1.1",
-    # TODO: track https://github.com/matplotlib/matplotlib/issues/28551
-    "matplotlib>=3.8,!=3.9.1",
+    "matplotlib>=3.8",
     "netCDF4>=1.6.5",
     "phonopy>=2.23",
     "seekpath>=2.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "Cython>=0.29.23",
     # Building against NPY2 will support both NPY1 and NPY2
     # https://numpy.org/devdocs/dev/depending_on_numpy.html#build-time-dependency
-    "numpy>=2.0.1",
+    "numpy>=2.1.0",
     "setuptools>=65.0.0",
 ]
 build-backend = "setuptools.build_meta"
@@ -22,7 +22,7 @@ Python Materials Genomics is a robust materials analysis code that defines core 
 and molecules with support for many electronic structure codes. It is currently the core analysis code powering the
 Materials Project (https://materialsproject.org)."""
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 keywords = [
     "ABINIT",
     "VASP",
@@ -49,7 +49,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Chemistry",
     "Topic :: Scientific/Engineering :: Information Analysis",
     "Topic :: Scientific/Engineering :: Physics",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Chemistry",
     "Topic :: Scientific/Engineering :: Information Analysis",
     "Topic :: Scientific/Engineering :: Physics",

--- a/src/pymatgen/alchemy/filters.py
+++ b/src/pymatgen/alchemy/filters.py
@@ -177,7 +177,7 @@ class RemoveDuplicatesFilter(AbstractStructureFilter):
         """
         self.symprec = symprec
         self.structure_list: dict[str, list[Structure]] = defaultdict(list)
-        if not isinstance(structure_matcher, (dict, StructureMatcher, type(None))):
+        if not isinstance(structure_matcher, dict | StructureMatcher | type(None)):
             raise TypeError(f"{structure_matcher=} must be a dict, StructureMatcher or None")
         if isinstance(structure_matcher, dict):
             self.structure_matcher = StructureMatcher.from_dict(structure_matcher)

--- a/src/pymatgen/alchemy/transmuters.py
+++ b/src/pymatgen/alchemy/transmuters.py
@@ -18,8 +18,7 @@ from pymatgen.alchemy.materials import TransformedStructure
 from pymatgen.io.vasp.sets import MPRelaxSet, VaspInputSet
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
-    from typing import Callable
+    from collections.abc import Callable, Sequence
 
     from typing_extensions import Self
 

--- a/src/pymatgen/analysis/adsorption.py
+++ b/src/pymatgen/analysis/adsorption.py
@@ -4,7 +4,9 @@ adsorption sites on slabs.
 
 from __future__ import annotations
 
+import functools
 import itertools
+import operator
 import os
 from typing import TYPE_CHECKING
 
@@ -300,7 +302,7 @@ class AdsorbateSiteFinder:
             sites = [site + distance * np.asarray(self.mvec) for site in sites]
 
             ads_sites[key] = sites
-        ads_sites["all"] = sum(ads_sites.values(), [])  # noqa: RUF017
+        ads_sites["all"] = functools.reduce(operator.iadd, ads_sites.values(), [])
         return ads_sites
 
     def symm_reduce(self, coords_set, threshold=1e-6):

--- a/src/pymatgen/analysis/adsorption.py
+++ b/src/pymatgen/analysis/adsorption.py
@@ -178,7 +178,7 @@ class AdsorbateSiteFinder:
         surf_sites = [slab.sites[n] for n in np.where(mask)[0]]
         if xy_tol:
             # sort surface sites by height
-            surf_sites = [s for (h, s) in zip(m_projs[mask], surf_sites)]
+            surf_sites = [s for (h, s) in zip(m_projs[mask], surf_sites, strict=False)]
             surf_sites.reverse()
             unique_sites: list = []
             unique_perp_fracs: list = []
@@ -268,7 +268,7 @@ class AdsorbateSiteFinder:
             for v in dt.simplices:
                 if -1 not in v:
                     dots = []
-                    for i_corner, i_opp in zip(range(3), ((1, 2), (0, 2), (0, 1))):
+                    for i_corner, i_opp in zip(range(3), ((1, 2), (0, 2), (0, 1)), strict=False):
                         corner, opp = v[i_corner], [v[o] for o in i_opp]
                         vecs = [mesh[d].coords - mesh[corner].coords for d in opp]
                         vecs = [vec / np.linalg.norm(vec) for vec in vecs]
@@ -701,7 +701,7 @@ def plot_slab(
         ads_sites = asf.find_adsorption_sites()["all"]
         symm_op = get_rot(orig_slab)
         ads_sites = [symm_op.operate(ads_site)[:2].tolist() for ads_site in ads_sites]
-        ax.plot(*zip(*ads_sites), color="k", marker="x", markersize=10, mew=1, linestyle="", zorder=10000)
+        ax.plot(*zip(*ads_sites, strict=False), color="k", marker="x", markersize=10, mew=1, linestyle="", zorder=10000)
     # Draw unit cell
     if draw_unit_cell:
         vertices = np.insert(vertices, 1, lattice_sum, axis=0).tolist()

--- a/src/pymatgen/analysis/adsorption.py
+++ b/src/pymatgen/analysis/adsorption.py
@@ -4,9 +4,7 @@ adsorption sites on slabs.
 
 from __future__ import annotations
 
-import functools
 import itertools
-import operator
 import os
 from typing import TYPE_CHECKING
 
@@ -302,7 +300,7 @@ class AdsorbateSiteFinder:
             sites = [site + distance * np.asarray(self.mvec) for site in sites]
 
             ads_sites[key] = sites
-        ads_sites["all"] = functools.reduce(operator.iadd, ads_sites.values(), [])
+        ads_sites["all"] = sum(ads_sites.values(), [])  # noqa: RUF017
         return ads_sites
 
     def symm_reduce(self, coords_set, threshold=1e-6):

--- a/src/pymatgen/analysis/bond_valence.py
+++ b/src/pymatgen/analysis/bond_valence.py
@@ -403,7 +403,7 @@ class BVAnalyzer:
         if self._best_vset:
             if structure.is_ordered:
                 assigned = {}
-                for val, sites in zip(self._best_vset, equi_sites):
+                for val, sites in zip(self._best_vset, equi_sites, strict=False):
                     for site in sites:
                         assigned[site] = val
 
@@ -414,7 +414,7 @@ class BVAnalyzer:
                 new_best_vset.append([])
             for ival, val in enumerate(self._best_vset):
                 new_best_vset[attrib[ival]].append(val)
-            for val, sites in zip(new_best_vset, equi_sites):
+            for val, sites in zip(new_best_vset, equi_sites, strict=False):
                 for site in sites:
                     assigned[site] = val
 

--- a/src/pymatgen/analysis/chemenv/utils/coordination_geometry_utils.py
+++ b/src/pymatgen/analysis/chemenv/utils/coordination_geometry_utils.py
@@ -14,7 +14,7 @@ from scipy.spatial import ConvexHull
 from pymatgen.analysis.chemenv.utils.chemenv_errors import SolidAngleError
 
 if TYPE_CHECKING:
-    from typing import Callable
+    from collections.abc import Callable
 
     from numpy.typing import ArrayLike
     from typing_extensions import Self

--- a/src/pymatgen/analysis/chemenv/utils/graph_utils.py
+++ b/src/pymatgen/analysis/chemenv/utils/graph_utils.py
@@ -180,7 +180,7 @@ class SimpleGraphCycle(MSONable):
                 if "'<' not supported between instances of" in msg:
                     return False, "The nodes are not sortable."
                 raise
-            res = all(i < j for i, j in zip(sorted_nodes, sorted_nodes[1:], strict=False))
+            res = all(i < j for i, j in itertools.pairwise(sorted_nodes))
             if not res:
                 return False, "The list of nodes in the cycle cannot be strictly ordered."
         return True, ""
@@ -266,10 +266,7 @@ class SimpleGraphCycle(MSONable):
         """
         if edges_are_ordered:
             nodes = [edge[0] for edge in edges]
-            if (
-                not all(e1e2[0][1] == e1e2[1][0] for e1e2 in zip(edges, edges[1:], strict=False))
-                or edges[-1][1] != edges[0][0]
-            ):
+            if any(e1e2[0][1] != e1e2[1][0] for e1e2 in itertools.pairwise(edges)) or edges[-1][1] != edges[0][0]:
                 raise ValueError("Could not construct a cycle from edges.")
         else:
             remaining_edges = list(edges)
@@ -371,7 +368,7 @@ class MultiGraphCycle(MSONable):
                 if "'<' not supported between instances of" in msg:
                     return False, "The nodes are not sortable."
                 raise
-            is_ordered = all(node1 < node2 for node1, node2 in zip(sorted_nodes, sorted_nodes[1:], strict=False))
+            is_ordered = all(node1 < node2 for node1, node2 in itertools.pairwise(sorted_nodes))
             if not is_ordered:
                 return False, "The list of nodes in the cycle cannot be strictly ordered."
         return True, ""

--- a/src/pymatgen/analysis/chemenv/utils/graph_utils.py
+++ b/src/pymatgen/analysis/chemenv/utils/graph_utils.py
@@ -157,7 +157,7 @@ class SimpleGraphCycle(MSONable):
     def _is_valid(self, check_strict_ordering=False):
         """Check if a SimpleGraphCycle is valid.
 
-        This method checks :
+        This method checks:
         - that there are no duplicate nodes,
         - that there are either 1 or more than 2 nodes
 
@@ -180,7 +180,7 @@ class SimpleGraphCycle(MSONable):
                 if "'<' not supported between instances of" in msg:
                     return False, "The nodes are not sortable."
                 raise
-            res = all(i < j for i, j in zip(sorted_nodes, sorted_nodes[1:]))
+            res = all(i < j for i, j in zip(sorted_nodes, sorted_nodes[1:], strict=False))
             if not res:
                 return False, "The list of nodes in the cycle cannot be strictly ordered."
         return True, ""
@@ -266,7 +266,10 @@ class SimpleGraphCycle(MSONable):
         """
         if edges_are_ordered:
             nodes = [edge[0] for edge in edges]
-            if not all(e1e2[0][1] == e1e2[1][0] for e1e2 in zip(edges, edges[1:])) or edges[-1][1] != edges[0][0]:
+            if (
+                not all(e1e2[0][1] == e1e2[1][0] for e1e2 in zip(edges, edges[1:], strict=False))
+                or edges[-1][1] != edges[0][0]
+            ):
                 raise ValueError("Could not construct a cycle from edges.")
         else:
             remaining_edges = list(edges)
@@ -368,7 +371,7 @@ class MultiGraphCycle(MSONable):
                 if "'<' not supported between instances of" in msg:
                     return False, "The nodes are not sortable."
                 raise
-            is_ordered = all(node1 < node2 for node1, node2 in zip(sorted_nodes, sorted_nodes[1:]))
+            is_ordered = all(node1 < node2 for node1, node2 in zip(sorted_nodes, sorted_nodes[1:], strict=False))
             if not is_ordered:
                 return False, "The list of nodes in the cycle cannot be strictly ordered."
         return True, ""

--- a/src/pymatgen/analysis/chempot_diagram.py
+++ b/src/pymatgen/analysis/chempot_diagram.py
@@ -213,7 +213,7 @@ class ChemicalPotentialDiagram(MSONable):
 
         domains: dict[str, list] = {entry.reduced_formula: [] for entry in entries}
 
-        for intersection, facet in zip(hs_int.intersections, hs_int.dual_facets):
+        for intersection, facet in zip(hs_int.intersections, hs_int.dual_facets, strict=False):
             for v in facet:
                 if v < len(entries):
                     this_entry = entries[v]
@@ -578,7 +578,7 @@ class ChemicalPotentialDiagram(MSONable):
             return f"<br> μ<sub>{element}</sub> - μ<sub>{element}</sub><sup>o</sup> (eV)"
 
         axes_layout = {}
-        for ax, el in zip(axes, elements):
+        for ax, el in zip(axes, elements, strict=False):
             layout = plotly_layouts[layout_name].copy()
             layout["title"] = get_chempot_axis_title(el)
             axes_layout[ax] = layout

--- a/src/pymatgen/analysis/diffraction/core.py
+++ b/src/pymatgen/analysis/diffraction/core.py
@@ -105,7 +105,7 @@ class AbstractDiffractionPatternCalculator(abc.ABC):
         xrd = self.get_pattern(structure, two_theta_range=two_theta_range)
         imax = max(xrd.y)
 
-        for two_theta, i, hkls in zip(xrd.x, xrd.y, xrd.hkls):
+        for two_theta, i, hkls in zip(xrd.x, xrd.y, xrd.hkls, strict=False):
             if two_theta_range[0] <= two_theta <= two_theta_range[1]:
                 hkl_tuples = [hkl["hkl"] for hkl in hkls]
                 label = ", ".join(map(str, hkl_tuples))  # 'full' label
@@ -188,7 +188,7 @@ class AbstractDiffractionPatternCalculator(abc.ABC):
         n_rows = len(structures)
         fig, axes = plt.subplots(nrows=n_rows, ncols=1, sharex=True, squeeze=False)
 
-        for i, (ax, structure) in enumerate(zip(axes.ravel(), structures)):
+        for i, (ax, structure) in enumerate(zip(axes.ravel(), structures, strict=False)):
             self.get_plot(structure, fontsize=fontsize, ax=ax, with_labels=i == n_rows - 1, **kwargs)
             spg_symbol, spg_number = structure.get_space_group_info()
             ax.set_title(f"{structure.formula} {spg_symbol} ({spg_number}) ")

--- a/src/pymatgen/analysis/diffraction/tem.py
+++ b/src/pymatgen/analysis/diffraction/tem.py
@@ -139,7 +139,7 @@ class TEMCalculator(AbstractDiffractionPatternCalculator):
         if (0, 0, 0) in points_filtered:
             points_filtered.remove((0, 0, 0))
         interplanar_spacings_val = np.array([structure.lattice.d_hkl(x) for x in points_filtered])
-        return dict(zip(points_filtered, interplanar_spacings_val))
+        return dict(zip(points_filtered, interplanar_spacings_val, strict=False))
 
     def bragg_angles(self, interplanar_spacings: dict[Tuple3Ints, float]) -> dict[Tuple3Ints, float]:
         """Get the Bragg angles for every hkl point passed in (where n = 1).
@@ -153,7 +153,7 @@ class TEMCalculator(AbstractDiffractionPatternCalculator):
         plane = list(interplanar_spacings)
         interplanar_spacings_val = np.array(list(interplanar_spacings.values()))
         bragg_angles_val = np.arcsin(self.wavelength_rel() / (2 * interplanar_spacings_val))
-        return dict(zip(plane, bragg_angles_val))
+        return dict(zip(plane, bragg_angles_val, strict=False))
 
     def get_s2(self, bragg_angles: dict[Tuple3Ints, float]) -> dict[Tuple3Ints, float]:
         """
@@ -169,7 +169,7 @@ class TEMCalculator(AbstractDiffractionPatternCalculator):
         plane = list(bragg_angles)
         bragg_angles_val = np.array(list(bragg_angles.values()))
         s2_val = (np.sin(bragg_angles_val) / self.wavelength_rel()) ** 2
-        return dict(zip(plane, s2_val))
+        return dict(zip(plane, s2_val, strict=False))
 
     def x_ray_factors(
         self, structure: Structure, bragg_angles: dict[Tuple3Ints, float]
@@ -269,7 +269,7 @@ class TEMCalculator(AbstractDiffractionPatternCalculator):
         csf = self.cell_scattering_factors(structure, bragg_angles)
         csf_val = np.array(list(csf.values()))
         cell_intensity_val = (csf_val * csf_val.conjugate()).real
-        return dict(zip(bragg_angles, cell_intensity_val))
+        return dict(zip(bragg_angles, cell_intensity_val, strict=False))
 
     def get_pattern(
         self,

--- a/src/pymatgen/analysis/diffraction/xrd.py
+++ b/src/pymatgen/analysis/diffraction/xrd.py
@@ -114,7 +114,7 @@ class XRDCalculator(AbstractDiffractionPatternCalculator):
                 specification of Debye-Waller factors. Note that these
                 factors are temperature dependent.
         """
-        if isinstance(wavelength, (float, int)):
+        if isinstance(wavelength, float | int):
             self.wavelength = wavelength
         elif isinstance(wavelength, str):
             self.radiation = wavelength

--- a/src/pymatgen/analysis/elasticity/elastic.py
+++ b/src/pymatgen/analysis/elasticity/elastic.py
@@ -619,7 +619,7 @@ class ElasticTensorExpansion(TensorCollection):
         points = quad["points"]
         weights = quad["weights"]
         num, denom, c = np.zeros((3, 3)), 0, 1
-        for p, w in zip(points, weights):
+        for p, w in zip(points, weights, strict=False):
             gk = ElasticTensor(self[0]).green_kristoffel(p)
             _rho_wsquareds, us = np.linalg.eigh(gk)
             us = [u / np.linalg.norm(u) for u in np.transpose(us)]
@@ -882,7 +882,7 @@ def diff_fit(strains, stresses, eq_stress=None, order=2, tol: float = 1e-10):
     for _ord in range(1, order):
         cvec, carr = get_symbol_list(_ord + 1)
         svec = np.ravel(dei_dsi[_ord - 1].T)
-        cmap = dict(zip(cvec, np.dot(m[_ord - 1], svec)))
+        cmap = dict(zip(cvec, np.dot(m[_ord - 1], svec), strict=False))
         c_list.append(v_subs(carr, cmap))
     return [Tensor.from_voigt(c) for c in c_list]
 

--- a/src/pymatgen/analysis/elasticity/strain.py
+++ b/src/pymatgen/analysis/elasticity/strain.py
@@ -60,7 +60,7 @@ class Deformation(SquareTensor):
         """Get indices of perturbed elements of the deformation gradient,
         i. e. those that differ from the identity.
         """
-        return list(zip(*np.where(abs(self - np.eye(3)) > tol)))
+        return list(zip(*np.where(abs(self - np.eye(3)) > tol), strict=False))
 
     @property
     def green_lagrange_strain(self):

--- a/src/pymatgen/analysis/eos.py
+++ b/src/pymatgen/analysis/eos.py
@@ -431,7 +431,7 @@ class NumericalEOS(PolynomialEOS):
             return np.sqrt(np.sum((np.array(x) - np.array(y)) ** 2) / len(x))
 
         # list of (energy, volume) tuples
-        e_v = list(zip(self.energies, self.volumes))
+        e_v = list(zip(self.energies, self.volumes, strict=False))
         n_data = len(e_v)
         # minimum number of data points used for fitting
         n_data_min = max(n_data - 2 * min_ndata_factor, min_poly_order + 1)

--- a/src/pymatgen/analysis/ewald.py
+++ b/src/pymatgen/analysis/ewald.py
@@ -332,7 +332,7 @@ class EwaldSummation(MSONable):
         s_reals = np.sum(oxi_states[None, :] * np.cos(grs), 1)
         s_imags = np.sum(oxi_states[None, :] * np.sin(grs), 1)
 
-        for g, g2, gr, exp_val, s_real, s_imag in zip(gs, g2s, grs, exp_vals, s_reals, s_imags):
+        for g, g2, gr, exp_val, s_real, s_imag in zip(gs, g2s, grs, exp_vals, s_reals, s_imags, strict=False):
             # Uses the identity sin(x)+cos(x) = 2**0.5 sin(x + pi/4)
             m = np.sin((gr[None, :] + math.pi / 4) - gr[:, None])
             m *= exp_val / g2

--- a/src/pymatgen/analysis/ferroelectricity/polarization.py
+++ b/src/pymatgen/analysis/ferroelectricity/polarization.py
@@ -307,7 +307,7 @@ class Polarization:
             sites.append(new_site[0])
 
         adjust_pol = []
-        for site, struct in zip(sites, d_structs):
+        for site, struct in zip(sites, d_structs, strict=False):
             adjust_pol.append(np.multiply(site.frac_coords, np.array(struct.lattice.lengths)).ravel())
         return np.array(adjust_pol)
 

--- a/src/pymatgen/analysis/graphs.py
+++ b/src/pymatgen/analysis/graphs.py
@@ -34,8 +34,8 @@ except ImportError:
     igraph = None
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
-    from typing import Any, Callable
+    from collections.abc import Callable, Sequence
+    from typing import Any
 
     from igraph import Graph
     from numpy.typing import ArrayLike

--- a/src/pymatgen/analysis/interface_reactions.py
+++ b/src/pymatgen/analysis/interface_reactions.py
@@ -186,7 +186,7 @@ class InterfacialReactivity(MSONable):
 
         index_kink = range(1, len(critical_comp) + 1)
 
-        return list(zip(index_kink, x_kink, energy_kink, react_kink, energy_per_rxt_formula))
+        return list(zip(index_kink, x_kink, energy_kink, react_kink, energy_per_rxt_formula, strict=False))
 
     def plot(self, backend: Literal["plotly", "matplotlib"] = "plotly") -> Figure | plt.Figure:
         """
@@ -326,7 +326,7 @@ class InterfacialReactivity(MSONable):
 
     def _get_plotly_figure(self) -> Figure:
         """Get a Plotly figure of reaction kinks diagram."""
-        kinks = map(list, zip(*self.get_kinks()))
+        kinks = map(list, zip(*self.get_kinks(), strict=False))
         _, x, energy, reactions, _ = kinks
 
         lines = Scatter(
@@ -347,7 +347,8 @@ class InterfacialReactivity(MSONable):
         rxn_min = reactions.pop(min_idx)
 
         labels = [
-            f"{htmlify(str(r))} <br>\u0394E<sub>rxn</sub> = {round(e, 3)} eV/atom" for r, e in zip(reactions, energy)
+            f"{htmlify(str(r))} <br>\u0394E<sub>rxn</sub> = {round(e, 3)} eV/atom"
+            for r, e in zip(reactions, energy, strict=False)
         ]
 
         markers = Scatter(
@@ -391,13 +392,13 @@ class InterfacialReactivity(MSONable):
         ax = pretty_plot(8, 5)
         plt.xlim([-0.05, 1.05])  # plot boundary is 5% wider on each side
 
-        kinks = list(zip(*self.get_kinks()))
+        kinks = list(zip(*self.get_kinks(), strict=False))
         _, x, energy, reactions, _ = kinks
 
         plt.plot(x, energy, "o-", markersize=8, c="navy", zorder=1)
         plt.scatter(self.minimum[0], self.minimum[1], marker="*", c="red", s=400, zorder=2)
 
-        for x_coord, y_coord, rxn in zip(x, energy, reactions):
+        for x_coord, y_coord, rxn in zip(x, energy, reactions, strict=False):
             products = ", ".join(
                 [latexify(p.reduced_formula) for p in rxn.products if not np.isclose(rxn.get_coeff(p), 0)]
             )
@@ -437,7 +438,7 @@ class InterfacialReactivity(MSONable):
     def _get_plotly_annotations(x: list[float], y: list[float], reactions: list[Reaction]):
         """Get dictionary of annotations for the Plotly figure layout."""
         annotations = []
-        for x_coord, y_coord, rxn in zip(x, y, reactions):
+        for x_coord, y_coord, rxn in zip(x, y, reactions, strict=False):
             products = ", ".join(
                 [htmlify(p.reduced_formula) for p in rxn.products if not np.isclose(rxn.get_coeff(p), 0)]
             )

--- a/src/pymatgen/analysis/interfaces/coherent_interfaces.py
+++ b/src/pymatgen/analysis/interfaces/coherent_interfaces.py
@@ -143,7 +143,7 @@ class CoherentInterfaceBuilder:
         self._terminations = {
             (film_label, sub_label): (film_shift, sub_shift)
             for (film_label, film_shift), (sub_label, sub_shift) in product(
-                zip(film_terminations, film_shifts), zip(sub_terminations, sub_shifts)
+                zip(film_terminations, film_shifts, strict=False), zip(sub_terminations, sub_shifts, strict=False)
             )
         }
         self.terminations = list(self._terminations)

--- a/src/pymatgen/analysis/interfaces/zsl.py
+++ b/src/pymatgen/analysis/interfaces/zsl.py
@@ -172,6 +172,7 @@ class ZSLGenerator(MSONable):
             for (f_trans, s_trans), (f, s) in zip(
                 product(film_transformations, substrate_transformations),
                 product(films, substrates),
+                strict=False,
             ):
                 if is_same_vectors(
                     f,

--- a/src/pymatgen/analysis/local_env.py
+++ b/src/pymatgen/analysis/local_env.py
@@ -82,13 +82,13 @@ class ValenceIonicRadiusEvaluator:
     def radii(self):
         """List of ionic radii of elements in the order of sites."""
         elems = [site.species_string for site in self._structure]
-        return dict(zip(elems, self._ionic_radii))
+        return dict(zip(elems, self._ionic_radii, strict=False))
 
     @property
     def valences(self):
         """List of oxidation states of elements in the order of sites."""
         el = [site.species_string for site in self._structure]
-        return dict(zip(el, self._valences))
+        return dict(zip(el, self._valences, strict=False))
 
     @property
     def structure(self):
@@ -521,7 +521,7 @@ class NearNeighbors:
         #  And, different first steps might results in the same neighbor
         #  Now, we condense those neighbors into a single entry per neighbor
         all_sites = {}
-        for first_site, term_sites in zip(allowed_steps, terminal_neighbors):
+        for first_site, term_sites in zip(allowed_steps, terminal_neighbors, strict=False):
             for term_site in term_sites:
                 key = (term_site["site_index"], tuple(term_site["image"]))
 
@@ -572,7 +572,7 @@ class NearNeighbors:
             return site.index
 
         for idx, struc_site in enumerate(structure):
-            if isinstance(structure, (IStructure, Structure)):
+            if isinstance(structure, IStructure | Structure):
                 if site.is_periodic_image(struc_site):
                     return idx
             elif site == struc_site:
@@ -895,7 +895,7 @@ class VoronoiNN(NearNeighbors):
                 # qvoronoi returns vertices in CCW order, so I can break
                 # the face up in to segments (0,1,2), (0,2,3), ... to compute
                 # its area where each number is a vertex size
-                for j, k in zip(vind[1:], vind[2:]):
+                for j, k in zip(vind[1:], vind[2:], strict=False):
                     volume += vol_tetra(
                         center_coords,
                         all_vertices[vind[0]],
@@ -1364,7 +1364,7 @@ class MinimumDistanceNN(NearNeighbors):
         """
         site = structure[n]
         neighs_dists = structure.get_neighbors(site, self.cutoff)
-        is_periodic = isinstance(structure, (Structure, IStructure))
+        is_periodic = isinstance(structure, Structure | IStructure)
         siw = []
         if self.get_all_sites:
             for nn in neighs_dists:
@@ -2397,8 +2397,12 @@ class LocalStructOrderParams:
         self._cos_n_p[1] = [math.cos(float(p)) for p in phis]
 
         for idx in range(2, self._max_trig_order + 1):
-            self._pow_sin_t[idx] = [e[0] * e[1] for e in zip(self._pow_sin_t[idx - 1], self._pow_sin_t[1])]
-            self._pow_cos_t[idx] = [e[0] * e[1] for e in zip(self._pow_cos_t[idx - 1], self._pow_cos_t[1])]
+            self._pow_sin_t[idx] = [
+                e[0] * e[1] for e in zip(self._pow_sin_t[idx - 1], self._pow_sin_t[1], strict=False)
+            ]
+            self._pow_cos_t[idx] = [
+                e[0] * e[1] for e in zip(self._pow_cos_t[idx - 1], self._pow_cos_t[1], strict=False)
+            ]
             self._sin_n_p[idx] = [math.sin(float(idx) * float(p)) for p in phis]
             self._cos_n_p[idx] = [math.cos(float(idx) * float(p)) for p in phis]
 
@@ -2427,7 +2431,9 @@ class LocalStructOrderParams:
         sqrt_5_pi = math.sqrt(5 / math.pi)
 
         pre_y_2_2 = [0.25 * sqrt_15_2pi * val for val in self._pow_sin_t[2]]
-        pre_y_2_1 = [0.5 * sqrt_15_2pi * val[0] * val[1] for val in zip(self._pow_sin_t[1], self._pow_cos_t[1])]
+        pre_y_2_1 = [
+            0.5 * sqrt_15_2pi * val[0] * val[1] for val in zip(self._pow_sin_t[1], self._pow_cos_t[1], strict=False)
+        ]
 
         acc = 0.0
 
@@ -2498,13 +2504,16 @@ class LocalStructOrderParams:
         sqrt_1_pi = math.sqrt(1 / math.pi)
 
         pre_y_4_4 = [i16_3 * sqrt_35_2pi * val for val in self._pow_sin_t[4]]
-        pre_y_4_3 = [i8_3 * sqrt_35_pi * val[0] * val[1] for val in zip(self._pow_sin_t[3], self._pow_cos_t[1])]
+        pre_y_4_3 = [
+            i8_3 * sqrt_35_pi * val[0] * val[1] for val in zip(self._pow_sin_t[3], self._pow_cos_t[1], strict=False)
+        ]
         pre_y_4_2 = [
-            i8_3 * sqrt_5_2pi * val[0] * (7 * val[1] - 1.0) for val in zip(self._pow_sin_t[2], self._pow_cos_t[2])
+            i8_3 * sqrt_5_2pi * val[0] * (7 * val[1] - 1.0)
+            for val in zip(self._pow_sin_t[2], self._pow_cos_t[2], strict=False)
         ]
         pre_y_4_1 = [
             i8_3 * sqrt_5_pi * val[0] * (7 * val[1] - 3 * val[2])
-            for val in zip(self._pow_sin_t[1], self._pow_cos_t[3], self._pow_cos_t[1])
+            for val in zip(self._pow_sin_t[1], self._pow_cos_t[3], self._pow_cos_t[1], strict=False)
         ]
 
         acc = 0.0
@@ -2607,17 +2616,20 @@ class LocalStructOrderParams:
         sqrt_13_pi = math.sqrt(13 / math.pi)
 
         pre_y_6_6 = [i64 * sqrt_3003_pi * val for val in self._pow_sin_t[6]]
-        pre_y_6_5 = [i32_3 * sqrt_1001_pi * val[0] * val[1] for val in zip(self._pow_sin_t[5], self._pow_cos_t[1])]
+        pre_y_6_5 = [
+            i32_3 * sqrt_1001_pi * val[0] * val[1] for val in zip(self._pow_sin_t[5], self._pow_cos_t[1], strict=False)
+        ]
         pre_y_6_4 = [
-            i32_3 * sqrt_91_2pi * val[0] * (11 * val[1] - 1.0) for val in zip(self._pow_sin_t[4], self._pow_cos_t[2])
+            i32_3 * sqrt_91_2pi * val[0] * (11 * val[1] - 1.0)
+            for val in zip(self._pow_sin_t[4], self._pow_cos_t[2], strict=False)
         ]
         pre_y_6_3 = [
             i32 * sqrt_1365_pi * val[0] * (11 * val[1] - 3 * val[2])
-            for val in zip(self._pow_sin_t[3], self._pow_cos_t[3], self._pow_cos_t[1])
+            for val in zip(self._pow_sin_t[3], self._pow_cos_t[3], self._pow_cos_t[1], strict=False)
         ]
         pre_y_6_2 = [
             i64 * sqrt_1365_pi * val[0] * (33 * val[1] - 18 * val[2] + 1.0)
-            for val in zip(self._pow_sin_t[2], self._pow_cos_t[4], self._pow_cos_t[2])
+            for val in zip(self._pow_sin_t[2], self._pow_cos_t[4], self._pow_cos_t[2], strict=False)
         ]
         pre_y_6_1 = [
             i16 * sqrt_273_2pi * val[0] * (33 * val[1] - 30 * val[2] + 5 * val[3])
@@ -2626,6 +2638,7 @@ class LocalStructOrderParams:
                 self._pow_cos_t[5],
                 self._pow_cos_t[3],
                 self._pow_cos_t[1],
+                strict=False,
             )
         ]
 
@@ -3680,7 +3693,7 @@ class EconNN(NearNeighbors):
             mefir = _get_mean_fictive_ionic_radius(firs, minimum_fir=mefir)
 
         siw = []
-        for nn, fir in zip(neighbors, firs):
+        for nn, fir in zip(neighbors, firs, strict=False):
             if nn.nn_distance < self.cutoff:
                 w = math.exp(1 - (fir / mefir) ** 6)
                 if w > self.tol:

--- a/src/pymatgen/analysis/local_env.py
+++ b/src/pymatgen/analysis/local_env.py
@@ -14,6 +14,7 @@ from bisect import bisect_left
 from collections import defaultdict
 from copy import deepcopy
 from functools import lru_cache
+from itertools import pairwise
 from typing import TYPE_CHECKING, Literal, NamedTuple, get_args
 
 import numpy as np
@@ -895,7 +896,7 @@ class VoronoiNN(NearNeighbors):
                 # qvoronoi returns vertices in CCW order, so I can break
                 # the face up in to segments (0,1,2), (0,2,3), ... to compute
                 # its area where each number is a vertex size
-                for j, k in zip(vind[1:], vind[2:], strict=False):
+                for j, k in pairwise(vind[1:]):
                     volume += vol_tetra(
                         center_coords,
                         all_vertices[vind[0]],

--- a/src/pymatgen/analysis/magnetism/analyzer.py
+++ b/src/pymatgen/analysis/magnetism/analyzer.py
@@ -226,7 +226,7 @@ class CollinearMagneticStructureAnalyzer:
             else magmom
             if abs(magmom) > threshold_nonmag and site.species_string not in self.default_magmoms
             else 0
-            for magmom, site in zip(magmoms, structure)
+            for magmom, site in zip(magmoms, structure, strict=False)
         ]
 
         # overwrite existing magmoms with default_magmoms
@@ -791,14 +791,15 @@ class MagneticStructureEnumerator:
         sga = SpacegroupAnalyzer(structure)
         structure_sym = sga.get_symmetrized_structure()
         wyckoff = ["n/a"] * len(structure)
-        for indices, symbol in zip(structure_sym.equivalent_indices, structure_sym.wyckoff_symbols):
+        for indices, symbol in zip(structure_sym.equivalent_indices, structure_sym.wyckoff_symbols, strict=False):
             for index in indices:
                 wyckoff[index] = symbol
         is_magnetic_sites = [site.specie in types_mag_species for site in structure]
         # we're not interested in sites that we don't think are magnetic,
         # set these symbols to None to filter them out later
         wyckoff = [
-            symbol if is_magnetic_site else "n/a" for symbol, is_magnetic_site in zip(wyckoff, is_magnetic_sites)
+            symbol if is_magnetic_site else "n/a"
+            for symbol, is_magnetic_site in zip(wyckoff, is_magnetic_sites, strict=False)
         ]
         structure.add_site_property("wyckoff", wyckoff)
         wyckoff_symbols = set(wyckoff) - {"n/a"}

--- a/src/pymatgen/analysis/magnetism/heisenberg.py
+++ b/src/pymatgen/analysis/magnetism/heisenberg.py
@@ -148,7 +148,7 @@ class HeisenbergMapper:
         unique_site_ids = {}
         wyckoff_ids = {}
 
-        for idx, (indices, symbol) in enumerate(zip(equivalent_indices, wyckoff_symbols)):
+        for idx, (indices, symbol) in enumerate(zip(equivalent_indices, wyckoff_symbols, strict=False)):
             unique_site_ids[tuple(indices)] = idx
             wyckoff_ids[idx] = symbol
             for index in indices:
@@ -195,7 +195,7 @@ class HeisenbergMapper:
 
         all_dists = all_dists[:3]
         labels = ("nn", "nnn", "nnnn")
-        dists = dict(zip(labels, all_dists))
+        dists = dict(zip(labels, all_dists, strict=False))
 
         # Get dictionary keys for interactions
         for k in unique_site_ids:
@@ -376,7 +376,7 @@ class HeisenbergMapper:
         # Convert J_ij to meV
         j_ij[1:] *= 1000  # J_ij in meV
         j_ij = j_ij.tolist()
-        ex_params = {j_name: j[0] for j_name, j in zip(j_names, j_ij)}
+        ex_params = {j_name: j[0] for j_name, j in zip(j_names, j_ij, strict=False)}
 
         self.ex_params = ex_params
 
@@ -401,7 +401,7 @@ class HeisenbergMapper:
 
         # epas = [e / len(s) for (e, s) in zip(self.energies, self.ordered_structures)]
 
-        for s, e in zip(self.ordered_structures, self.energies):
+        for s, e in zip(self.ordered_structures, self.energies, strict=False):
             ordering = CollinearMagneticStructureAnalyzer(s, threshold=0, make_primitive=False).ordering
             magmoms = s.site_properties["magmom"]
 
@@ -420,7 +420,7 @@ class HeisenbergMapper:
 
         # Brute force search for closest thing to FM and AFM
         if not fm_struct or not afm_struct:
-            for s, e in zip(self.ordered_structures, self.energies):
+            for s, e in zip(self.ordered_structures, self.energies, strict=False):
                 magmoms = s.site_properties["magmom"]
 
                 if abs(sum(magmoms)) > mag_max:  # FM ground state
@@ -723,7 +723,7 @@ class HeisenbergScreener:
         ]
 
         # Convert to energies / magnetic ion
-        energies = [e / len(s) for (e, s) in zip(energies, ordered_structures)]
+        energies = [e / len(s) for (e, s) in zip(energies, ordered_structures, strict=False)]
 
         # Check for duplicate / degenerate states (sometimes different initial
         # configs relax to the same state)
@@ -751,7 +751,7 @@ class HeisenbergScreener:
             energies = [energy for idx, energy in enumerate(energies) if idx not in remove_list]
 
         # Sort by energy if not already sorted
-        ordered_structures = [s for _, s in sorted(zip(energies, ordered_structures), reverse=False)]
+        ordered_structures = [s for _, s in sorted(zip(energies, ordered_structures, strict=False), reverse=False)]
         ordered_energies = sorted(energies, reverse=False)
 
         return ordered_structures, ordered_energies

--- a/src/pymatgen/analysis/molecule_matcher.py
+++ b/src/pymatgen/analysis/molecule_matcher.py
@@ -403,7 +403,7 @@ class InchiMolAtomMapper(AbstractMolAtomMapper):
                 canon_label2[c2 - 1] = canon_idx
                 candidates1.remove(canon_idx)
 
-        canon_inchi_orig_map2 = list(zip(canon_label2, list(range(1, n_heavy + 1)), ilabel2))
+        canon_inchi_orig_map2 = list(zip(canon_label2, list(range(1, n_heavy + 1)), ilabel2, strict=False))
         canon_inchi_orig_map2.sort(key=lambda m: m[0])
         return tuple(x[2] for x in canon_inchi_orig_map2)
 
@@ -464,7 +464,7 @@ class InchiMolAtomMapper(AbstractMolAtomMapper):
             hydrogen_label1.remove(idx)
 
         hydrogen_orig_idx2 = label2[len(heavy_indices2) :]
-        hydrogen_canon_orig_map2 = list(zip(hydrogen_label2, hydrogen_orig_idx2))
+        hydrogen_canon_orig_map2 = list(zip(hydrogen_label2, hydrogen_orig_idx2, strict=False))
         hydrogen_canon_orig_map2.sort(key=lambda m: m[0])
         hydrogen_canon_indices2 = [x[1] for x in hydrogen_canon_orig_map2]
 
@@ -1100,7 +1100,7 @@ class HungarianOrderMatcher(KabschMatcher):
         """
         Ixx = Iyy = Izz = Ixy = Ixz = Iyz = 0.0
 
-        for (x, y, z), wt in zip(coords, weights):
+        for (x, y, z), wt in zip(coords, weights, strict=False):
             Ixx += wt * (y * y + z * z)
             Iyy += wt * (x * x + z * z)
             Izz += wt * (x * x + y * y)

--- a/src/pymatgen/analysis/molecule_structure_comparator.py
+++ b/src/pymatgen/analysis/molecule_structure_comparator.py
@@ -253,7 +253,7 @@ class MoleculeStructureComparator(MSONable):
             for p in all_pairs
         ]
 
-        return [bond for bond, dist, cap in zip(all_pairs, pair_dists, max_length) if dist <= cap]
+        return [bond for bond, dist, cap in zip(all_pairs, pair_dists, max_length, strict=False) if dist <= cap]
 
     def as_dict(self):
         """Get MSONable dict."""

--- a/src/pymatgen/analysis/phase_diagram.py
+++ b/src/pymatgen/analysis/phase_diagram.py
@@ -527,7 +527,7 @@ class PhaseDiagram(MSONable):
         Returns:
             list[Entry]: stable entries in the space.
         """
-        return [e for e, s in zip(self._stable_entries, self._stable_spaces) if space.issuperset(s)]
+        return [e for e, s in zip(self._stable_entries, self._stable_spaces, strict=False) if space.issuperset(s)]
 
     def get_reference_energy(self, comp: Composition) -> float:
         """Sum of elemental reference energies over all elements in a composition.
@@ -594,7 +594,7 @@ class PhaseDiagram(MSONable):
             comp (Composition): A composition
         """
         coord = self.pd_coords(comp)
-        for facet, simplex in zip(self.facets, self.simplexes):
+        for facet, simplex in zip(self.facets, self.simplexes, strict=False):
             if simplex.in_simplex(coord, PhaseDiagram.numerical_tol / 10):
                 return facet, simplex
 
@@ -610,7 +610,7 @@ class PhaseDiagram(MSONable):
 
         all_facets = [
             facet
-            for facet, simplex in zip(self.facets, self.simplexes)
+            for facet, simplex in zip(self.facets, self.simplexes, strict=False)
             if simplex.in_simplex(coords, PhaseDiagram.numerical_tol / 10)
         ]
 
@@ -634,7 +634,7 @@ class PhaseDiagram(MSONable):
         atom_frac_mat = [[c.get_atomic_fraction(e) for e in self.elements] for c in comp_list]
         chempots = np.linalg.solve(atom_frac_mat, energy_list)
 
-        return dict(zip(self.elements, chempots))
+        return dict(zip(self.elements, chempots, strict=False))
 
     def _get_simplex_intersections(self, c1, c2):
         """Get coordinates of the intersection of the tie line between two compositions
@@ -668,7 +668,9 @@ class PhaseDiagram(MSONable):
         facet, simplex = self._get_facet_and_simplex(comp)
         decomp_amts = simplex.bary_coords(self.pd_coords(comp))
         return {
-            self.qhull_entries[f]: amt for f, amt in zip(facet, decomp_amts) if abs(amt) > PhaseDiagram.numerical_tol
+            self.qhull_entries[f]: amt
+            for f, amt in zip(facet, decomp_amts, strict=False)
+            if abs(amt) > PhaseDiagram.numerical_tol
         }
 
     def get_decomp_and_hull_energy_per_atom(self, comp: Composition) -> tuple[dict[PDEntry, float], float]:
@@ -868,7 +870,9 @@ class PhaseDiagram(MSONable):
         if stable_only:
             compare_entries = self._get_stable_entries_in_space(entry_elems)
         else:
-            compare_entries = [e for e, s in zip(self.qhull_entries, self._qhull_spaces) if entry_elems.issuperset(s)]
+            compare_entries = [
+                e for e, s in zip(self.qhull_entries, self._qhull_spaces, strict=False) if entry_elems.issuperset(s)
+            ]
 
         # get memory ids of entries with the same composition.
         same_comp_mem_ids = [
@@ -1065,7 +1069,7 @@ class PhaseDiagram(MSONable):
         num_atoms = n1 + (n2 - n1) * x_unnormalized
         cs *= num_atoms[:, None]
 
-        return [Composition((elem, val) for elem, val in zip(pd_els, m)) for m in cs]
+        return [Composition((elem, val) for elem, val in zip(pd_els, m, strict=False)) for m in cs]
 
     def get_element_profile(self, element, comp, comp_tol=1e-5):
         """
@@ -1818,7 +1822,7 @@ class PatchedPhaseDiagram(PhaseDiagram):
         Returns:
             space, PhaseDiagram for the given chemical space
         """
-        space_entries = [e for e, s in zip(self.qhull_entries, self._qhull_spaces) if space.issuperset(s)]
+        space_entries = [e for e, s in zip(self.qhull_entries, self._qhull_spaces, strict=False) if space.issuperset(s)]
 
         return space, PhaseDiagram(space_entries)
 
@@ -1962,7 +1966,7 @@ class ReactionDiagram:
 
                         energy = -(x * entry1.energy_per_atom + (1 - x) * entry2.energy_per_atom)
 
-                        for c, entry in zip(coeffs[:-1], face_entries):
+                        for c, entry in zip(coeffs[:-1], face_entries, strict=False):
                             if c > tol:
                                 redu_comp = entry.composition.reduced_composition
                                 products.append(f"{fmt(c / redu_comp.num_atoms * factor)} {redu_comp.reduced_formula}")
@@ -1972,7 +1976,7 @@ class ReactionDiagram:
                         rxn_str += " + ".join(products)
                         comp = x * comp_vec1 + (1 - x) * comp_vec2
                         entry = PDEntry(
-                            Composition(dict(zip(elements, comp))),
+                            Composition(dict(zip(elements, comp, strict=False))),
                             energy=energy,
                             attribute=rxn_str,
                         )
@@ -2114,7 +2118,7 @@ def _get_slsqp_decomp(
             decomp_amts = solution.x
             return {
                 c: amt  # NOTE this is the amount of the fractional composition.
-                for c, amt in zip(competing_entries, decomp_amts)
+                for c, amt in zip(competing_entries, decomp_amts, strict=False)
                 if amt > PhaseDiagram.numerical_tol
             }
 
@@ -2555,7 +2559,7 @@ class PDPlotter:
             else:
                 coord = tet_coord(data[line, 0:3])
             lines.append(coord)
-            labelcoord = list(zip(*coord))
+            labelcoord = list(zip(*coord, strict=False))
             stable_entries[labelcoord[0]] = entry1
             stable_entries[labelcoord[1]] = entry2
 
@@ -2574,7 +2578,7 @@ class PDPlotter:
                     coord = triangular_coord([all_data[idx, 0:2], all_data[idx, 0:2]])
                 else:
                     coord = tet_coord([all_data[idx, 0:3], all_data[idx, 0:3], all_data[idx, 0:3]])
-                labelcoord = list(zip(*coord))
+                labelcoord = list(zip(*coord, strict=False))
                 unstable_entries[entry] = labelcoord[0]
 
         return lines, stable_entries, unstable_entries
@@ -2604,7 +2608,7 @@ class PDPlotter:
             layout["annotations"] = annotations
         elif self._dim == 3 and self.ternary_style == "2d":
             layout = plotly_layouts["default_ternary_2d_layout"].copy()
-            for el, axis in zip(self._pd.elements, ["a", "b", "c"]):
+            for el, axis in zip(self._pd.elements, ["a", "b", "c"], strict=False):
                 el_ref = self._pd.el_refs[el]
                 clean_formula = str(el_ref.elements[0])
                 if hasattr(el_ref, "original_entry"):  # for grand potential PDs, etc.
@@ -2661,14 +2665,14 @@ class PDPlotter:
                 if self._dim == 3:
                     form_enes = [
                         self._pd.get_form_energy_per_atom(self.pd_plot_data[1][coord])
-                        for coord in zip(line[0], line[1])
+                        for coord in zip(line[0], line[1], strict=False)
                     ]
                     z += [*form_enes, None]
 
                 elif self._dim == 4:
                     form_enes = [
                         self._pd.get_form_energy_per_atom(self.pd_plot_data[1][coord])
-                        for coord in zip(line[0], line[1], line[2])
+                        for coord in zip(line[0], line[1], line[2], strict=False)
                     ]
                     energies += [*form_enes, None]
                     z += [*line[2], None]
@@ -2737,7 +2741,10 @@ class PDPlotter:
         elif self._dim == 3 and self.ternary_style == "3d":
             facets = np.array(self._pd.facets)
             coords = np.array(
-                [triangular_coord(c) for c in zip(self._pd.qhull_data[:-1, 0], self._pd.qhull_data[:-1, 1])]
+                [
+                    triangular_coord(c)
+                    for c in zip(self._pd.qhull_data[:-1, 0], self._pd.qhull_data[:-1, 1], strict=False)
+                ]
             )
             energies = np.array([self._pd.get_form_energy_per_atom(entry) for entry in self._pd.qhull_entries])
 
@@ -2992,7 +2999,7 @@ class PDPlotter:
             x, y, z, texts, energies, uncertainties = [], [], [], [], [], []
 
             is_stable = [entry in self._pd.stable_entries for entry in entries]
-            for coord, entry, stable in zip(coords, entries, is_stable):
+            for coord, entry, stable in zip(coords, entries, is_stable, strict=False):
                 energy = round(self._pd.get_form_energy_per_atom(entry), 3)
 
                 entry_id = getattr(entry, "entry_id", "no ID")
@@ -3023,8 +3030,10 @@ class PDPlotter:
 
                 if self._dim == 3 and self.ternary_style == "2d":
                     label += "<br>"
-                    total_sum_el = sum(entry.composition[el] for el, _axis in zip(self._pd.elements, range(self._dim)))
-                    for el, axis in zip(self._pd.elements, range(self._dim)):
+                    total_sum_el = sum(
+                        entry.composition[el] for el, _axis in zip(self._pd.elements, range(self._dim), strict=False)
+                    )
+                    for el, axis in zip(self._pd.elements, range(self._dim), strict=False):
                         _cartesian_positions = [x, y, z]
                         _cartesian_positions[axis].append(entry.composition[el])
                         label += f"<br> {el}: {round(entry.composition[el]/total_sum_el, 6)}"
@@ -3034,8 +3043,10 @@ class PDPlotter:
                     z.append(energy)
 
                     label += "<br>"
-                    total_sum_el = sum(entry.composition[el] for el, _axis in zip(self._pd.elements, range(self._dim)))
-                    for el, _axis in zip(self._pd.elements, range(self._dim)):
+                    total_sum_el = sum(
+                        entry.composition[el] for el, _axis in zip(self._pd.elements, range(self._dim), strict=False)
+                    )
+                    for el, _axis in zip(self._pd.elements, range(self._dim), strict=False):
                         label += f"<br> {el}: {round(entry.composition[el]/total_sum_el, 6)}"
                 elif self._dim == 4:
                     x.append(coord[0])
@@ -3043,8 +3054,10 @@ class PDPlotter:
                     z.append(coord[2])
 
                     label += "<br>"
-                    total_sum_el = sum(entry.composition[el] for el, _axis in zip(self._pd.elements, range(self._dim)))
-                    for el, _axis in zip(self._pd.elements, range(self._dim)):
+                    total_sum_el = sum(
+                        entry.composition[el] for el, _axis in zip(self._pd.elements, range(self._dim), strict=False)
+                    )
+                    for el, _axis in zip(self._pd.elements, range(self._dim), strict=False):
                         label += f"<br> {el}: {round(entry.composition[el]/total_sum_el, 6)}"
                 else:
                     x.append(coord[0])
@@ -3061,7 +3074,7 @@ class PDPlotter:
         unstable_coords, unstable_entries = [], []
         highlight_coords, highlight_ents = [], []
 
-        for coord, entry in zip(self.pd_plot_data[1], self.pd_plot_data[1].values()):
+        for coord, entry in zip(self.pd_plot_data[1], self.pd_plot_data[1].values(), strict=False):
             if entry in highlight_entries:
                 highlight_coords.append(coord)
                 highlight_ents.append(entry)
@@ -3069,7 +3082,7 @@ class PDPlotter:
                 stable_coords.append(coord)
                 stable_entries.append(entry)
 
-        for coord, entry in zip(self.pd_plot_data[2].values(), self.pd_plot_data[2]):
+        for coord, entry in zip(self.pd_plot_data[2].values(), self.pd_plot_data[2], strict=False):
             if entry in highlight_entries:
                 highlight_coords.append(coord)
                 highlight_ents.append(entry)

--- a/src/pymatgen/analysis/pourbaix_diagram.py
+++ b/src/pymatgen/analysis/pourbaix_diagram.py
@@ -275,7 +275,9 @@ class MultiEntry(PourbaixEntry):
         if attr in ["energy", "npH", "nH2O", "nPhi", "conc_term", "composition", "uncorrected_energy", "elements"]:
             # TODO: Composition could be changed for compat with sum
             start = Composition() if attr == "composition" else 0
-            weighted_values = (getattr(entry, attr) * weight for entry, weight in zip(self.entry_list, self.weights))
+            weighted_values = (
+                getattr(entry, attr) * weight for entry, weight in zip(self.entry_list, self.weights, strict=False)
+            )
             return sum(weighted_values, start)
 
         # Attributes that are just lists of entry attributes
@@ -744,7 +746,7 @@ class PourbaixDiagram(MSONable):
 
         # organize the boundary points by entry
         pourbaix_domains = {entry: [] for entry in pourbaix_entries}
-        for intersection, facet in zip(hs_int.intersections, hs_int.dual_facets):
+        for intersection, facet in zip(hs_int.intersections, hs_int.dual_facets, strict=False):
             for v in facet:
                 if v < len(pourbaix_entries):
                     this_entry = pourbaix_entries[v]

--- a/src/pymatgen/analysis/quasiharmonic.py
+++ b/src/pymatgen/analysis/quasiharmonic.py
@@ -350,7 +350,7 @@ class QuasiHarmonicDebyeApprox:
         dct["gibbs_free_energy"] = self.gibbs_free_energy
         dct["temperatures"] = self.temperatures
         dct["optimum_volumes"] = self.optimum_volumes
-        for v, t in zip(self.optimum_volumes, self.temperatures):
+        for v, t in zip(self.optimum_volumes, self.temperatures, strict=False):
             dct["debye_temperature"].append(self.debye_temperature(v))
             dct["gruneisen_parameter"].append(self.gruneisen_parameter(t, v))
             dct["thermal_conductivity"].append(self.thermal_conductivity(t, v))

--- a/src/pymatgen/analysis/reaction_calculator.py
+++ b/src/pymatgen/analysis/reaction_calculator.py
@@ -113,7 +113,7 @@ class BalancedReaction(MSONable):
         Returns:
             reaction energy as a float.
         """
-        return sum(amt * energies[c] for amt, c in zip(self._coeffs, self._all_comp))
+        return sum(amt * energies[c] for amt, c in zip(self._coeffs, self._all_comp, strict=False))
 
     def normalize_to(self, comp: Composition, factor: float = 1) -> None:
         """
@@ -203,7 +203,7 @@ class BalancedReaction(MSONable):
     def _str_from_formulas(cls, coeffs, formulas) -> str:
         reactant_str = []
         product_str = []
-        for amt, formula in zip(coeffs, formulas):
+        for amt, formula in zip(coeffs, formulas, strict=False):
             if abs(amt + 1) < cls.TOLERANCE:
                 reactant_str.append(formula)
             elif abs(amt - 1) < cls.TOLERANCE:
@@ -219,7 +219,7 @@ class BalancedReaction(MSONable):
     def _str_from_comp(cls, coeffs, compositions, reduce=False) -> tuple[str, float]:
         r_coeffs = np.zeros(len(coeffs))
         r_formulas = []
-        for idx, (amt, comp) in enumerate(zip(coeffs, compositions)):
+        for idx, (amt, comp) in enumerate(zip(coeffs, compositions, strict=False)):
             formula, factor = comp.get_reduced_formula_and_factor()
             r_coeffs[idx] = amt * factor
             r_formulas.append(formula)
@@ -232,7 +232,7 @@ class BalancedReaction(MSONable):
 
     def as_entry(self, energies) -> ComputedEntry:
         """Get a ComputedEntry representation of the reaction."""
-        relevant_comp = [comp * abs(coeff) for coeff, comp in zip(self._coeffs, self._all_comp)]
+        relevant_comp = [comp * abs(coeff) for coeff, comp in zip(self._coeffs, self._all_comp, strict=False)]
         comp: Composition = sum(relevant_comp, Composition())  # type: ignore[assignment]
 
         entry = ComputedEntry(0.5 * comp, self.calculate_energy(energies))

--- a/src/pymatgen/analysis/structure_analyzer.py
+++ b/src/pymatgen/analysis/structure_analyzer.py
@@ -154,7 +154,7 @@ class VoronoiAnalyzer:
         Returns:
             plt.Axes: Matplotlib Axes object with the plotted Voronoi analysis.
         """
-        labels, val = zip(*voronoi_ensemble)
+        labels, val = zip(*voronoi_ensemble, strict=False)
         arr = np.array(val, dtype=float)
         arr /= np.sum(arr)
         pos = np.arange(len(arr)) + 0.5  # the bar centers on the y axis

--- a/src/pymatgen/analysis/structure_matcher.py
+++ b/src/pymatgen/analysis/structure_matcher.py
@@ -913,7 +913,7 @@ class StructureMatcher(MSONable):
         s2_comp = struct2.composition
         matches = []
         for perm in itertools.permutations(sp2):
-            sp_mapping = dict(zip(sp1, perm))
+            sp_mapping = dict(zip(sp1, perm, strict=False))
 
             # do quick check that compositions are compatible
             mapped_comp = Composition({sp_mapping[k]: v for k, v in s1_comp.items()})

--- a/src/pymatgen/analysis/structure_prediction/substitution_probability.py
+++ b/src/pymatgen/analysis/structure_prediction/substitution_probability.py
@@ -152,7 +152,7 @@ class SubstitutionProbability:
         """
         assert len(l1) == len(l2)
         p = 1
-        for s1, s2 in zip(l1, l2):
+        for s1, s2 in zip(l1, l2, strict=False):
             p *= self.cond_prob(s1, s2)
         return p
 
@@ -231,9 +231,9 @@ class SubstitutionPredictor:
                 if len(output_species) == len(species):
                     odict = {"probability": functools.reduce(mul, best_case_prob)}
                     if to_this_composition:
-                        odict["substitutions"] = dict(zip(output_species, species))
+                        odict["substitutions"] = dict(zip(output_species, species, strict=False))
                     else:
-                        odict["substitutions"] = dict(zip(species, output_species))
+                        odict["substitutions"] = dict(zip(species, output_species, strict=False))
                     if len(output_species) == len(set(output_species)):
                         output.append(odict)
                     return

--- a/src/pymatgen/analysis/structure_prediction/substitutor.py
+++ b/src/pymatgen/analysis/structure_prediction/substitutor.py
@@ -207,7 +207,7 @@ class Substitutor(MSONable):
             if functools.reduce(mul, best_case_prob) > self._threshold:
                 if len(output_species) == len(species_list):
                     odict = {
-                        "substitutions": dict(zip(species_list, output_species)),
+                        "substitutions": dict(zip(species_list, output_species, strict=False)),
                         "probability": functools.reduce(mul, best_case_prob),
                     }
                     output.append(odict)

--- a/src/pymatgen/analysis/surface_analysis.py
+++ b/src/pymatgen/analysis/surface_analysis.py
@@ -780,7 +780,7 @@ class SurfaceEnergyPlotter:
 
         # sort the chempot ranges for each facet
         for entry, v in stable_urange_dict.items():
-            se_dict[entry] = [se for idx, se in sorted(zip(v, se_dict[entry]))]
+            se_dict[entry] = [se for idx, se in sorted(zip(v, se_dict[entry], strict=False))]
             stable_urange_dict[entry] = sorted(v)
 
         if return_se_dict:
@@ -1033,7 +1033,7 @@ class SurfaceEnergyPlotter:
             # sort the binding energies and monolayers
             # in order to properly draw a line plot
             vals = sorted(ml_be_dict.items())
-            monolayers, BEs = zip(*vals)
+            monolayers, BEs = zip(*vals, strict=False)
             ax.plot(monolayers, BEs, "-o", c=self.color_dict[clean_entry], label=hkl)
 
         adsorbates = tuple(ads_entry.ads_entries_dict)
@@ -1447,7 +1447,7 @@ class WorkFunctionAnalyzer:
             else:
                 yg.append(pot)
                 xg.append(self.along_c[idx])
-        xg, yg = zip(*sorted(zip(xg, yg)))
+        xg, yg = zip(*sorted(zip(xg, yg, strict=False)), strict=False)
         plt.plot(xg, yg, "r", linewidth=2.5, zorder=-1)
 
         # make it look nice

--- a/src/pymatgen/analysis/transition_state.py
+++ b/src/pymatgen/analysis/transition_state.py
@@ -109,7 +109,7 @@ class NEBAnalysis(MSONable):
         rms_dist = [0]
         prev = structures[0]
         for st in structures[1:]:
-            dists = np.array([s2.distance(s1) for s1, s2 in zip(prev, st)])
+            dists = np.array([s2.distance(s1) for s1, s2 in zip(prev, st, strict=False)])
             rms_dist.append(np.sqrt(np.sum(dists**2)))
             prev = st
         rms_dist = np.cumsum(rms_dist)
@@ -173,7 +173,7 @@ class NEBAnalysis(MSONable):
         ax.set_ylabel("Energy (meV)")
         ax.set_ylim((np.min(ys) - 10, np.max(ys) * 1.02 + 20))
         if label_barrier:
-            data = zip(xs * scale, ys)
+            data = zip(xs * scale, ys, strict=False)
             barrier = max(data, key=lambda d: d[1])
             ax.plot([0, barrier[0]], [barrier[1], barrier[1]], "k--", linewidth=0.5)
             ax.annotate(

--- a/src/pymatgen/analysis/wulff.py
+++ b/src/pymatgen/analysis/wulff.py
@@ -202,7 +202,7 @@ class WulffShape:
         recp = self.structure.lattice.reciprocal_lattice_crystallographic
         recp_symm_ops = self.lattice.get_recp_symmetry_operation(self.symprec)
 
-        for i, (hkl, energy) in enumerate(zip(self.hkl_list, self.e_surf_list)):
+        for i, (hkl, energy) in enumerate(zip(self.hkl_list, self.e_surf_list, strict=False)):
             for op in recp_symm_ops:
                 miller = tuple(int(x) for x in op.operate(hkl))
                 if miller not in all_hkl:
@@ -625,12 +625,12 @@ class WulffShape:
     @property
     def miller_area_dict(self) -> dict[tuple, float]:
         """{hkl: area_hkl on wulff}."""
-        return dict(zip(self.miller_list, self.color_area))
+        return dict(zip(self.miller_list, self.color_area, strict=False))
 
     @property
     def miller_energy_dict(self) -> dict[tuple, float]:
         """{hkl: surface energy_hkl}."""
-        return dict(zip(self.miller_list, self.e_surf_list))
+        return dict(zip(self.miller_list, self.e_surf_list, strict=False))
 
     @property
     def surface_area(self) -> float:

--- a/src/pymatgen/analysis/xas/spectrum.py
+++ b/src/pymatgen/analysis/xas/spectrum.py
@@ -194,7 +194,7 @@ class XAS(Spectrum):
             )
             l3_f = interp1d(l3_xanes.x, l3_xanes.y, bounds_error=True, fill_value=0, kind="cubic")
             energy = list(np.linspace(min(l3_xanes.x), max(l3_xanes.x), num=num_samples))
-            mu = [i + j for i, j in zip([max(i, 0) for i in l2_f(energy)], l3_f(energy))]
+            mu = [i + j for i, j in zip([max(i, 0) for i in l2_f(energy)], l3_f(energy), strict=False)]
             # check for jumps at the onset of L2-edge XANES
             idx = energy.index(min(energy, key=lambda x: (abs(x - l2_xanes.x[0]))))
             if abs(mu[idx] - mu[idx - 1]) / (mu[idx - 1]) > 0.1:

--- a/src/pymatgen/apps/borg/hive.py
+++ b/src/pymatgen/apps/borg/hive.py
@@ -253,7 +253,7 @@ class SimpleVaspToComputedEntryDrone(VaspToComputedEntryDrone):
 
             param = {"hubbards": {}}
             if "LDAUU" in incar:
-                param["hubbards"] = dict(zip(poscar.site_symbols, incar["LDAUU"]))
+                param["hubbards"] = dict(zip(poscar.site_symbols, incar["LDAUU"], strict=False))
             param["is_hubbard"] = incar.get("LDAU", True) and sum(param["hubbards"].values()) > 0
             param["run_type"] = None
             param["potcar_spec"] = potcar.spec

--- a/src/pymatgen/cli/pmg.py
+++ b/src/pymatgen/cli/pmg.py
@@ -47,7 +47,7 @@ def diff_incar(args):
     incar2 = Incar.from_file(filepath2)
 
     def format_lists(v):
-        if isinstance(v, (tuple, list)):
+        if isinstance(v, tuple | list):
             return " ".join(f"{len(tuple(group))}*{i:.2f}" for (i, group) in itertools.groupby(v))
         return v
 

--- a/src/pymatgen/cli/pmg_config.py
+++ b/src/pymatgen/cli/pmg_config.py
@@ -272,7 +272,7 @@ def add_config_var(tokens: list[str], backup_suffix: str) -> None:
             print(f"Existing {rc_path} backed up to {rc_path}{backup_suffix}")
         dct = loadfn(rc_path)
     special_vals = {"true": True, "false": False, "none": None, "null": None}
-    for key, val in zip(tokens[::2], tokens[1::2]):
+    for key, val in zip(tokens[::2], tokens[1::2], strict=False):
         dct[key] = special_vals.get(val.lower(), val)
     dumpfn(dct, rc_path)
     print(f"New {rc_path} written!")

--- a/src/pymatgen/cli/pmg_structure.py
+++ b/src/pymatgen/cli/pmg_structure.py
@@ -37,13 +37,13 @@ def analyze_symmetry(args):
         args (dict): Args from argparse.
     """
     tolerance = args.symmetry
-    t = []
+    table_rows = []
     for filename in args.filenames:
         struct = Structure.from_file(filename, primitive=False)
         finder = SpacegroupAnalyzer(struct, tolerance)
         dataset = finder.get_symmetry_dataset()
-        t.append([filename, dataset["international"], dataset["number"], dataset["hall"]])
-    print(tabulate(t, headers=["Filename", "Int Symbol", "Int number", "Hall"]))
+        table_rows.append([filename, dataset.international, dataset.number, dataset.hall])
+    print(tabulate(table_rows, headers=["Filename", "Int Symbol", "Int number", "Hall"]))
 
 
 def analyze_localenv(args):

--- a/src/pymatgen/command_line/bader_caller.py
+++ b/src/pymatgen/command_line/bader_caller.py
@@ -218,7 +218,7 @@ class BaderAnalysis:
             if line.startswith("-"):
                 break
             vals = map(float, line.split()[1:])
-            data.append(dict(zip(headers, vals)))
+            data.append(dict(zip(headers, vals, strict=False)))
 
         for line in lines:
             tokens = line.strip().split(":")
@@ -277,6 +277,7 @@ class BaderAnalysis:
             self.chgcar.structure,
             self.chgcar.structure.frac_coords,
             atom_chgcars,
+            strict=False,
         ):
             # Find the index of the atom in the charge density atom
             index = np.round(np.multiply(loc, chg.dim))

--- a/src/pymatgen/command_line/gulp_caller.py
+++ b/src/pymatgen/command_line/gulp_caller.py
@@ -408,12 +408,12 @@ class GulpIO:
                 # If structure is oxidation state decorated, use that first.
                 el = [site.specie.symbol for site in structure]
                 valences = [site.specie.oxi_state for site in structure]
-                val_dict = dict(zip(el, valences))
+                val_dict = dict(zip(el, valences, strict=False))
             except AttributeError:
                 bv = BVAnalyzer()
                 el = [site.specie.symbol for site in structure]
                 valences = bv.get_valences(structure)
-                val_dict = dict(zip(el, valences))
+                val_dict = dict(zip(el, valences, strict=False))
 
         # Try bush library first
         bpb = BuckinghamPotential("bush")
@@ -490,7 +490,7 @@ class GulpIO:
         bv = BVAnalyzer()
         el = [site.specie.symbol for site in structure]
         valences = bv.get_valences(structure)
-        el_val_dict = dict(zip(el, valences))
+        el_val_dict = dict(zip(el, valences, strict=False))
 
         gin = "species \n"
         qerf_str = "qerfc\n"

--- a/src/pymatgen/command_line/mcsqs_caller.py
+++ b/src/pymatgen/command_line/mcsqs_caller.py
@@ -87,7 +87,7 @@ def run_mcsqs(
     directory = directory or tempfile.mkdtemp()
     os.chdir(directory)
 
-    if isinstance(scaling, (int, float)):
+    if isinstance(scaling, int | float):
         if scaling % 1 != 0:
             raise ValueError(f"{scaling=} should be an integer")
         mcsqs_find_sqs_cmd = ["mcsqs", f"-n {scaling * n_atoms}"]

--- a/src/pymatgen/core/composition.py
+++ b/src/pymatgen/core/composition.py
@@ -206,7 +206,6 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
         for el in sorted(set(self.elements + other.elements)):
             if other[el] - self[el] >= type(self).amount_tolerance:
                 return False
-            # TODO @janosh 2024-04-29: is this a bug? why would we return True early?
             if self[el] - other[el] >= type(self).amount_tolerance:
                 return True
         return True

--- a/src/pymatgen/core/interface.py
+++ b/src/pymatgen/core/interface.py
@@ -10,7 +10,7 @@ import warnings
 from fractions import Fraction
 from functools import reduce
 from itertools import chain, combinations, product
-from typing import TYPE_CHECKING, Literal, Union, cast
+from typing import TYPE_CHECKING, Literal, cast
 
 import numpy as np
 from monty.fractions import lcm
@@ -27,8 +27,8 @@ from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.util.typing import Tuple3Ints
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
-    from typing import Any, Callable
+    from collections.abc import Callable, Sequence
+    from typing import Any
 
     from numpy.typing import ArrayLike, NDArray
     from typing_extensions import Self
@@ -966,7 +966,7 @@ class GrainBoundaryGenerator:
         # Make sure gcd(r_axis) == 1
         if reduce(math.gcd, r_axis) != 1:
             r_axis = cast(
-                Union[Tuple3Ints, Tuple4Ints],
+                Tuple3Ints | Tuple4Ints,
                 tuple(round(x / reduce(math.gcd, r_axis)) for x in r_axis),
             )
 
@@ -1014,11 +1014,11 @@ class GrainBoundaryGenerator:
                 surface = np.matmul(r_axis, metric)
                 fractions = [Fraction(x).limit_denominator() for x in surface]
                 least_mul = reduce(lcm, [fraction.denominator for fraction in fractions])
-                surface = cast(Union[Tuple3Ints, Tuple4Ints], tuple(round(x * least_mul) for x in surface))
+                surface = cast(Tuple3Ints | Tuple4Ints, tuple(round(x * least_mul) for x in surface))
 
         if reduce(math.gcd, surface) != 1:
             index = reduce(math.gcd, surface)
-            surface = cast(Union[Tuple3Ints, Tuple4Ints], tuple(round(x / index) for x in surface))
+            surface = cast(Tuple3Ints | Tuple4Ints, tuple(round(x / index) for x in surface))
 
         lam = None
         if lat_type == "h":
@@ -1431,7 +1431,7 @@ class GrainBoundaryGenerator:
         # Make sure math.gcd(r_axis) == 1
         if reduce(math.gcd, r_axis) != 1:
             r_axis = cast(
-                Union[Tuple3Ints, Tuple4Ints],
+                Tuple3Ints | Tuple4Ints,
                 tuple(round(x / reduce(math.gcd, r_axis)) for x in r_axis),
             )
 
@@ -2558,7 +2558,9 @@ class Interface(Structure):
     @property
     def substrate_sites(self) -> list[Site]:
         """The site objects in the substrate."""
-        return [site for site, tag in zip(self, self.site_properties["interface_label"]) if "substrate" in tag]
+        return [
+            site for site, tag in zip(self, self.site_properties["interface_label"], strict=False) if "substrate" in tag
+        ]
 
     @property
     def substrate(self) -> Structure:
@@ -2573,7 +2575,7 @@ class Interface(Structure):
     @property
     def film_sites(self) -> list[Site]:
         """The film sites of the interface."""
-        return [site for site, tag in zip(self, self.site_properties["interface_label"]) if "film" in tag]
+        return [site for site, tag in zip(self, self.site_properties["interface_label"], strict=False) if "film" in tag]
 
     @property
     def film(self) -> Structure:
@@ -2685,7 +2687,7 @@ class Interface(Structure):
         new_lattice = Lattice(new_latt_matrix)
         self._lattice = new_lattice
 
-        for site, c_coords in zip(self, self.cart_coords):
+        for site, c_coords in zip(self, self.cart_coords, strict=False):
             site._lattice = new_lattice  # Update the lattice
             site.coords = c_coords  # Put back into original Cartesian space
 

--- a/src/pymatgen/core/operations.py
+++ b/src/pymatgen/core/operations.py
@@ -159,7 +159,7 @@ class SymmOp(MSONable):
         # Build einstein sum string
         lc = string.ascii_lowercase
         indices = lc[:rank], lc[rank : 2 * rank]
-        einsum_string = ",".join(a + i for a, i in zip(*indices))
+        einsum_string = ",".join(a + i for a, i in zip(*indices, strict=False))
         einsum_string += f",{indices[::-1][0]}->{indices[::-1][1]}"
         einsum_args = [self.rotation_matrix] * rank + [tensor]
 
@@ -262,7 +262,7 @@ class SymmOp(MSONable):
         Returns:
             SymmOp for a rotation about given axis and translation.
         """
-        if isinstance(axis, (tuple, list)):
+        if isinstance(axis, tuple | list):
             axis = np.array(axis)
 
         vec = np.array(translation_vec)

--- a/src/pymatgen/core/periodic_table.py
+++ b/src/pymatgen/core/periodic_table.py
@@ -23,7 +23,8 @@ from pymatgen.io.core import ParseError
 from pymatgen.util.string import Stringify, formula_double_format
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Literal
+    from collections.abc import Callable
+    from typing import Any, Literal
 
     from typing_extensions import Self
 
@@ -204,7 +205,7 @@ class ElementBase(Enum):
             if val is None or str(val).startswith("no data"):
                 warnings.warn(f"No data available for {item} for {self.symbol}")
                 val = None
-            elif isinstance(val, (list, dict)):
+            elif isinstance(val, list | dict):
                 pass
             else:
                 try:
@@ -523,7 +524,7 @@ class ElementBase(Enum):
         # Total ML = sum(ml1, ml2), Total MS = sum(ms1, ms2)
         TL = [sum(ml_ms[comb[e]][0] for e in range(v_e)) for comb in e_config_combs]
         TS = [sum(ml_ms[comb[e]][1] for e in range(v_e)) for comb in e_config_combs]
-        comb_counter = Counter(zip(TL, TS))
+        comb_counter = Counter(zip(TL, TS, strict=False))
 
         term_symbols = []
         L_symbols = "SPDFGHIKLMNOQRTUVWXYZ"
@@ -1626,7 +1627,7 @@ def get_el_sp(obj: int | SpeciesLike) -> Element | Species | DummySpecies:
             of properties that can be determined.
     """
     # If obj is already an Element or Species, return as is
-    if isinstance(obj, (Element, Species, DummySpecies)):
+    if isinstance(obj, Element | Species | DummySpecies):
         if getattr(obj, "_is_named_isotope", None):
             return Element(obj.name) if isinstance(obj, Element) else Species(str(obj))
         return obj

--- a/src/pymatgen/core/sites.py
+++ b/src/pymatgen/core/sites.py
@@ -329,7 +329,7 @@ class PeriodicSite(Site, MSONable):
         frac_coords = lattice.get_fractional_coords(coords) if coords_are_cartesian else coords
 
         if to_unit_cell:
-            frac_coords = np.array([np.mod(f, 1) if p else f for p, f in zip(lattice.pbc, frac_coords)])
+            frac_coords = np.array([np.mod(f, 1) if p else f for p, f in zip(lattice.pbc, frac_coords, strict=False)])
 
         if not skip_checks:
             frac_coords = np.array(frac_coords)
@@ -475,7 +475,7 @@ class PeriodicSite(Site, MSONable):
 
     def to_unit_cell(self, in_place: bool = False) -> Self | None:
         """Move frac coords to within the unit cell."""
-        frac_coords = [np.mod(f, 1) if p else f for p, f in zip(self.lattice.pbc, self.frac_coords)]
+        frac_coords = [np.mod(f, 1) if p else f for p, f in zip(self.lattice.pbc, self.frac_coords, strict=False)]
         if in_place:
             self.frac_coords = np.array(frac_coords)
             return None

--- a/src/pymatgen/core/spectrum.py
+++ b/src/pymatgen/core/spectrum.py
@@ -14,7 +14,8 @@ from scipy.ndimage import convolve1d
 from pymatgen.util.coord import get_linear_interpolated_value
 
 if TYPE_CHECKING:
-    from typing import Callable, Literal
+    from collections.abc import Callable
+    from typing import Literal
 
     from numpy.typing import NDArray
     from typing_extensions import Self

--- a/src/pymatgen/core/structure.py
+++ b/src/pymatgen/core/structure.py
@@ -22,7 +22,7 @@ from collections import defaultdict
 from collections.abc import MutableSequence
 from fnmatch import fnmatch
 from io import StringIO
-from typing import TYPE_CHECKING, Literal, Union, cast, get_args
+from typing import TYPE_CHECKING, Literal, cast, get_args
 
 import numpy as np
 from monty.dev import deprecated
@@ -48,8 +48,8 @@ from pymatgen.symmetry.maggroups import MagneticSpaceGroup
 from pymatgen.util.coord import all_distances, get_angle, lattice_points_in_supercell
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Iterator, Sequence
-    from typing import Any, Callable, SupportsIndex
+    from collections.abc import Callable, Iterable, Iterator, Sequence
+    from typing import Any, SupportsIndex
 
     import pandas as pd
     from ase import Atoms
@@ -304,7 +304,7 @@ class SiteCollection(collections.abc.Sequence, ABC):
                     types.append(sp)
 
         # Cannot use set since we want a deterministic algorithm
-        return cast(tuple[Union[Element, Species, DummySpecies], ...], tuple(sorted(set(types))))
+        return cast(tuple[Element | Species | DummySpecies, ...], tuple(sorted(set(types))))
 
     @property
     def types_of_specie(self) -> tuple[Element | Species | DummySpecies, ...]:
@@ -547,7 +547,7 @@ class SiteCollection(collections.abc.Sequence, ABC):
         """
         if len(values) != len(self):
             raise ValueError(f"{len(values)=} must equal sites in structure={len(self)}")
-        for site, val in zip(self, values):
+        for site, val in zip(self, values, strict=False):
             site.properties[property_name] = val
 
         return self
@@ -651,7 +651,7 @@ class SiteCollection(collections.abc.Sequence, ABC):
                 f"Oxidation states of all sites must be specified, expected {len(self)} values, "
                 f"got {len(oxidation_states)}"
             )
-        for site, ox in zip(self, oxidation_states):
+        for site, ox in zip(self, oxidation_states, strict=False):
             new_sp = {}
             for el, occu in site.species.items():
                 sym = el.symbol
@@ -712,7 +712,7 @@ class SiteCollection(collections.abc.Sequence, ABC):
         if len(spins) != len(self):
             raise ValueError(f"Spins for all sites must be specified, expected {len(self)} spins, got {len(spins)}")
 
-        for site, spin in zip(self.sites, spins):
+        for site, spin in zip(self.sites, spins, strict=False):
             new_species = {}
             for sp, occu in site.species.items():
                 sym = sp.symbol
@@ -1321,7 +1321,7 @@ class IStructure(SiteCollection, MSONable):
         all_coords: list[list[float]] = []
         all_site_properties: dict[str, list] = defaultdict(list)
         all_labels: list[str | None] = []
-        for idx, (sp, c) in enumerate(zip(species, frac_coords)):
+        for idx, (sp, c) in enumerate(zip(species, frac_coords, strict=False)):
             cc = spg.get_orbit(c, tol=tol)
             all_sp.extend([sp] * len(cc))
             all_coords.extend(cc)
@@ -1427,7 +1427,7 @@ class IStructure(SiteCollection, MSONable):
         all_magmoms: list[float] = []
         all_site_properties: dict[str, list] = defaultdict(list)
         all_labels: list[str | None] = []
-        for idx, (spec, f_coord, magmom) in enumerate(zip(species, frac_coords, magmoms)):
+        for idx, (spec, f_coord, magmom) in enumerate(zip(species, frac_coords, magmoms, strict=False)):
             cc, mm = msg.get_orbit(f_coord, magmom, tol=tol)
             all_sp.extend([spec] * len(cc))
             all_coords.extend(cc)
@@ -1864,10 +1864,10 @@ class IStructure(SiteCollection, MSONable):
             # Compare all neighbors pairwise to find the pairs that connect the same
             # two sites, but with an inverted vector (R=-R) that connects the two and add
             # one of each pair to the redundant list.
-            for idx, (i, j, R, d) in enumerate(zip(*bonds)):
+            for idx, (i, j, R, d) in enumerate(zip(*bonds, strict=False)):
                 if idx in redundant:
                     continue
-                for jdx, (i2, j2, R2, d2) in enumerate(zip(*bonds)):
+                for jdx, (i2, j2, R2, d2) in enumerate(zip(*bonds, strict=False)):
                     bool1 = i == j2
                     bool2 = j == i2
                     bool3 = (-R2 == R).all()
@@ -2004,7 +2004,9 @@ class IStructure(SiteCollection, MSONable):
         lattice = self.lattice
         atol = Site.position_atol
         all_sites = self.sites
-        for cindex, pindex, image, f_coord, d in zip(center_indices, points_indices, images, f_coords, distances):
+        for cindex, pindex, image, f_coord, d in zip(
+            center_indices, points_indices, images, f_coords, distances, strict=False
+        ):
             psite = all_sites[pindex]
             csite = sites[cindex]
             if (
@@ -2091,7 +2093,7 @@ class IStructure(SiteCollection, MSONable):
             lattice=self.lattice,
         )
         neighbors: list[list[PeriodicNeighbor]] = []
-        for point_neighbor, site in zip(point_neighbors, sites):
+        for point_neighbor, site in zip(point_neighbors, sites, strict=False):
             nns: list[PeriodicNeighbor] = []
             if len(point_neighbor) < 1:
                 neighbors.append([])
@@ -2155,7 +2157,7 @@ class IStructure(SiteCollection, MSONable):
         nmin = np.floor(np.min(self.frac_coords, axis=0)) - maxr
         nmax = np.ceil(np.max(self.frac_coords, axis=0)) + maxr
 
-        all_ranges = list(itertools.starmap(np.arange, zip(nmin, nmax)))
+        all_ranges = list(itertools.starmap(np.arange, zip(nmin, nmax, strict=False)))
         lattice = self._lattice
         matrix = lattice.matrix
         neighbors: list[list] = [[] for _ in range(len(self))]
@@ -2170,7 +2172,7 @@ class IStructure(SiteCollection, MSONable):
             all_dists = all_distances(coords, site_coords)
             all_within_r = np.bitwise_and(all_dists <= r, all_dists > 1e-8)
 
-            for j, d, within_r in zip(indices, all_dists, all_within_r):
+            for j, d, within_r in zip(indices, all_dists, all_within_r, strict=False):
                 if include_site:
                     nnsite = PeriodicSite(
                         self[j].species,
@@ -2602,7 +2604,7 @@ class IStructure(SiteCollection, MSONable):
             any_close = np.any(is_close, axis=-1)
             inds = np.all(any_close, axis=-1)
 
-            for inv_m, latt_mat in zip(inv_ms[inds], ms[inds]):
+            for inv_m, latt_mat in zip(inv_ms[inds], ms[inds], strict=False):
                 new_m = np.dot(inv_m, self.lattice.matrix)
                 ftol = np.divide(tolerance, np.sqrt(np.sum(new_m**2, axis=1)))
 
@@ -2611,7 +2613,9 @@ class IStructure(SiteCollection, MSONable):
                 new_sp = []
                 new_props = defaultdict(list)
                 new_labels = []
-                for gsites, gf_coords, non_nbrs in zip(grouped_sites, grouped_frac_coords, grouped_non_nbrs):
+                for gsites, gf_coords, non_nbrs in zip(
+                    grouped_sites, grouped_frac_coords, grouped_non_nbrs, strict=False
+                ):
                     all_frac = np.dot(gf_coords, latt_mat)
 
                     # Calculate grouping of equivalent sites, represented by
@@ -3275,7 +3279,7 @@ class IMolecule(SiteCollection, MSONable):
         if not all(hasattr(other, attr) for attr in needed_attrs):
             return NotImplemented
 
-        other = cast(Union[IMolecule, Molecule], other)
+        other = cast(IMolecule | Molecule, other)
 
         if len(self) != len(other):
             return False
@@ -3974,7 +3978,7 @@ class Structure(IStructure, collections.abc.MutableSequence):
         """
         if isinstance(idx, int):
             indices = [idx]
-        elif isinstance(idx, (str, Element, Species)):
+        elif isinstance(idx, str | Element | Species):
             self.replace_species({idx: site})  # type: ignore[dict-item]
             return
         elif isinstance(idx, slice):
@@ -4391,7 +4395,7 @@ class Structure(IStructure, collections.abc.MutableSequence):
             else:
                 f_coords = self._lattice.get_fractional_coords(site.coords + vector)
             if to_unit_cell:
-                f_coords = [np.mod(f, 1) if p else f for p, f in zip(self.lattice.pbc, f_coords)]
+                f_coords = [np.mod(f, 1) if p else f for p, f in zip(self.lattice.pbc, f_coords, strict=False)]
             self[idx].frac_coords = f_coords
 
         return self
@@ -4471,7 +4475,7 @@ class Structure(IStructure, collections.abc.MutableSequence):
             vector = rng.standard_normal(3)
             vnorm = np.linalg.norm(vector)
             dist = distance
-            if isinstance(min_distance, (float, int)):
+            if isinstance(min_distance, float | int):
                 dist = rng.uniform(min_distance, dist)
             return vector / vnorm * dist if vnorm != 0 else get_rand_vec()
 
@@ -4783,7 +4787,7 @@ class Molecule(IMolecule, collections.abc.MutableSequence):
         if isinstance(idx, int):
             indices = [idx]
 
-        elif isinstance(idx, (str, Element, Species)):
+        elif isinstance(idx, str | Element | Species):
             self.replace_species({idx: site})  # type: ignore[dict-item]
             return
 

--- a/src/pymatgen/core/surface.py
+++ b/src/pymatgen/core/surface.py
@@ -557,7 +557,7 @@ class Slab(Structure):
                         frac_coords.append(struct_matcher.frac_coords + [0, 0, shift])  # noqa: RUF005
 
                 # sort by species to put all similar species together.
-                sp_fcoord = sorted(zip(species, frac_coords), key=lambda x: x[0])
+                sp_fcoord = sorted(zip(species, frac_coords, strict=False), key=lambda x: x[0])
                 species = [x[0] for x in sp_fcoord]
                 frac_coords = [x[1] for x in sp_fcoord]
                 slab = type(self)(
@@ -1691,7 +1691,7 @@ def get_d(slab: Slab) -> float:
     sorted_sites = sorted(slab, key=lambda site: site.frac_coords[2])
 
     distance = None
-    for site, next_site in zip(sorted_sites, sorted_sites[1:]):
+    for site, next_site in zip(sorted_sites, sorted_sites[1:], strict=False):
         if not isclose(site.frac_coords[2], next_site.frac_coords[2], abs_tol=1e-6):
             distance = next_site.frac_coords[2] - site.frac_coords[2]
             break

--- a/src/pymatgen/core/surface.py
+++ b/src/pymatgen/core/surface.py
@@ -1691,7 +1691,7 @@ def get_d(slab: Slab) -> float:
     sorted_sites = sorted(slab, key=lambda site: site.frac_coords[2])
 
     distance = None
-    for site, next_site in zip(sorted_sites, sorted_sites[1:], strict=False):
+    for site, next_site in itertools.pairwise(sorted_sites):
         if not isclose(site.frac_coords[2], next_site.frac_coords[2], abs_tol=1e-6):
             distance = next_site.frac_coords[2] - site.frac_coords[2]
             break

--- a/src/pymatgen/core/tensors.py
+++ b/src/pymatgen/core/tensors.py
@@ -181,7 +181,7 @@ class Tensor(np.ndarray, MSONable):
         """
         quad = quad or DEFAULT_QUAD
         weights, points = quad["weights"], quad["points"]
-        return sum(w * self.project(n) for w, n in zip(weights, points))
+        return sum(w * self.project(n) for w, n in zip(weights, points, strict=False))
 
     def get_grouped_indices(self, voigt: bool = False, **kwargs) -> list[list]:
         """Get index sets for equivalent tensor values.
@@ -208,11 +208,11 @@ class Tensor(np.ndarray, MSONable):
         indices = list(itertools.product(*(range(n) for n in array.shape)))
         remaining = indices.copy()
         # Start with everything near zero
-        grouped = [list(zip(*np.where(np.isclose(array, 0, **kwargs))))]
+        grouped = [list(zip(*np.where(np.isclose(array, 0, **kwargs)), strict=False))]
         remaining = [i for i in remaining if i not in grouped[0]]
         # Iteratively run through remaining indices
         while remaining:
-            new = list(zip(*np.where(np.isclose(array, array[remaining[0]], **kwargs))))
+            new = list(zip(*np.where(np.isclose(array, array[remaining[0]], **kwargs)), strict=False))
             grouped.append(new)
             remaining = [i for i in remaining if i not in new]
         # Don't return any empty lists
@@ -430,14 +430,16 @@ class Tensor(np.ndarray, MSONable):
 
         # IEEE rules: a=b in length; c,a || x3, x1
         elif xtal_sys == "tetragonal":
-            rotation = np.array([vec / mag for (mag, vec) in sorted(zip(lengths, vecs), key=lambda x: x[0])])
+            rotation = np.array(
+                [vec / mag for (mag, vec) in sorted(zip(lengths, vecs, strict=False), key=lambda x: x[0])]
+            )
             if abs(lengths[2] - lengths[1]) < abs(lengths[1] - lengths[0]):
                 rotation[0], rotation[2] = rotation[2], rotation[0].copy()
             rotation[1] = get_uvec(np.cross(rotation[2], rotation[0]))
 
         # IEEE rules: c<a<b; c,a || x3,x1
         elif xtal_sys == "orthorhombic":
-            rotation = [vec / mag for (mag, vec) in sorted(zip(lengths, vecs))]
+            rotation = [vec / mag for (mag, vec) in sorted(zip(lengths, vecs, strict=False))]
             rotation = np.roll(rotation, 2, axis=0)
 
         # IEEE rules: c,a || x3,x1, c is threefold axis
@@ -457,13 +459,13 @@ class Tensor(np.ndarray, MSONable):
             n_umask = np.logical_not(angles == angles[u_index])
             rotation[1] = get_uvec(vecs[u_index])
             # Shorter of remaining lattice vectors for c axis
-            c = next(vec / mag for (mag, vec) in sorted(zip(lengths[n_umask], vecs[n_umask])))
+            c = next(vec / mag for (mag, vec) in sorted(zip(lengths[n_umask], vecs[n_umask], strict=False)))
             rotation[2] = np.array(c)
             rotation[0] = np.cross(rotation[1], rotation[2])
 
         # IEEE rules: c || x3, x2 normal to ac plane
         elif xtal_sys == "triclinic":
-            rotation = [vec / mag for (mag, vec) in sorted(zip(lengths, vecs))]
+            rotation = [vec / mag for (mag, vec) in sorted(zip(lengths, vecs, strict=False))]
             rotation[1] = get_uvec(np.cross(rotation[2], rotation[0]))
             rotation[0] = np.cross(rotation[1], rotation[2])
 
@@ -570,7 +572,7 @@ class Tensor(np.ndarray, MSONable):
             shape = np.ceil(np.max(indices + 1, axis=0) / 3.0) * 3
 
         base = np.zeros(shape.astype(int))
-        for v, idx in zip(values, indices):
+        for v, idx in zip(values, indices, strict=False):
             base[tuple(idx)] = v
         obj = cls.from_voigt(base) if 6 in shape else cls(base)
 
@@ -1118,7 +1120,7 @@ class TensorMapping(collections.abc.MutableMapping):
 
     def items(self):
         """Items in mapping."""
-        return zip(self._tensor_list, self._value_list)
+        return zip(self._tensor_list, self._value_list, strict=False)
 
     def _get_item_index(self, item):
         if len(self._tensor_list) == 0:

--- a/src/pymatgen/core/trajectory.py
+++ b/src/pymatgen/core/trajectory.py
@@ -234,7 +234,7 @@ class Trajectory(MSONable):
             )
 
         # For slice input, return a trajectory
-        if isinstance(frames, (slice, list, np.ndarray)):
+        if isinstance(frames, slice | list | np.ndarray):
             if isinstance(frames, slice):
                 start, stop, step = frames.indices(len(self))
                 selected = list(range(start, stop, step))
@@ -460,7 +460,7 @@ class Trajectory(MSONable):
 
             lines.append(f"Direct configuration=     {idx + 1}")
 
-            for coord, specie in zip(coords, self.species):
+            for coord, specie in zip(coords, self.species, strict=False):
                 line = f'{" ".join(format_str.format(c) for c in coord)} {specie}'
                 lines.append(line)
 
@@ -642,8 +642,8 @@ class Trajectory(MSONable):
             return prop1
 
         # General case
-        assert prop1 is None or isinstance(prop1, (list, dict))
-        assert prop2 is None or isinstance(prop2, (list, dict))
+        assert prop1 is None or isinstance(prop1, list | dict)
+        assert prop2 is None or isinstance(prop2, list | dict)
 
         p1_candidates: dict[str, Any] = {
             "NoneType": [None] * len1,

--- a/src/pymatgen/core/trajectory.py
+++ b/src/pymatgen/core/trajectory.py
@@ -278,7 +278,7 @@ class Trajectory(MSONable):
                 base_positions=self.base_positions,
             )
 
-        raise TypeError(f"bad index={frames!r}, expected one of [{ValidIndex!s}]")
+        raise TypeError(f"bad index={frames!r}, expected one of [{", ".join(str(ValidIndex).split(" | "))}]")
 
     def get_structure(self, idx: int) -> Structure:
         """Get structure at specified index.

--- a/src/pymatgen/core/trajectory.py
+++ b/src/pymatgen/core/trajectory.py
@@ -278,8 +278,7 @@ class Trajectory(MSONable):
                 base_positions=self.base_positions,
             )
 
-        avail_indexes: list[str] = str(ValidIndex).split(" | ")
-        raise TypeError(f"bad index={frames!r}, expected one of [{", ".join(avail_indexes)}]")
+        raise TypeError(f"bad index={frames!r}, expected one of [{', '.join(str(ValidIndex).split(' | '))}]")
 
     def get_structure(self, idx: int) -> Structure:
         """Get structure at specified index.

--- a/src/pymatgen/core/trajectory.py
+++ b/src/pymatgen/core/trajectory.py
@@ -8,7 +8,7 @@ import itertools
 import warnings
 from fnmatch import fnmatch
 from pathlib import Path
-from typing import TYPE_CHECKING, Union, cast
+from typing import TYPE_CHECKING, TypeAlias, cast
 
 import numpy as np
 from monty.io import zopen
@@ -30,7 +30,7 @@ __author__ = "Eric Sivonxay, Shyam Dwaraknath, Mingjian Wen, Evan Spotte-Smith"
 __version__ = "0.1"
 __date__ = "Jun 29, 2022"
 
-ValidIndex = Union[int, slice, list[int], np.ndarray]
+ValidIndex: TypeAlias = int | slice | list[int] | np.ndarray
 
 
 class Trajectory(MSONable):
@@ -278,7 +278,7 @@ class Trajectory(MSONable):
                 base_positions=self.base_positions,
             )
 
-        raise TypeError(f"bad index={frames!r}, expected one of {str(ValidIndex).split('Union')[1]}")
+        raise TypeError(f"bad index={frames!r}, expected one of [{ValidIndex!s}]")
 
     def get_structure(self, idx: int) -> Structure:
         """Get structure at specified index.

--- a/src/pymatgen/core/trajectory.py
+++ b/src/pymatgen/core/trajectory.py
@@ -278,7 +278,8 @@ class Trajectory(MSONable):
                 base_positions=self.base_positions,
             )
 
-        raise TypeError(f"bad index={frames!r}, expected one of [{", ".join(str(ValidIndex).split(" | "))}]")
+        avail_indexes: list[str] = str(ValidIndex).split(" | ")
+        raise TypeError(f"bad index={frames!r}, expected one of [{", ".join(avail_indexes)}]")
 
     def get_structure(self, idx: int) -> Structure:
         """Get structure at specified index.

--- a/src/pymatgen/core/units.py
+++ b/src/pymatgen/core/units.py
@@ -267,7 +267,7 @@ class Unit(collections.abc.Mapping):
         units_old = sorted(old_base.items(), key=lambda d: _UNAME2UTYPE[d[0]])
         factor: float = old_factor / new_factor
 
-        for old, new in zip(units_old, units_new):
+        for old, new in zip(units_old, units_new, strict=False):
             if old[1] != new[1]:
                 raise UnitError(f"Units {old} and {new} are not compatible!")
             c = ALL_UNITS[_UNAME2UTYPE[old[0]]]
@@ -819,7 +819,7 @@ def unitized(unit):
             val = func(*args, **kwargs)
             unit_type = _UNAME2UTYPE[unit]
 
-            if isinstance(val, (FloatWithUnit, ArrayWithUnit)):
+            if isinstance(val, FloatWithUnit | ArrayWithUnit):
                 return val.to(unit)
 
             if isinstance(val, collections.abc.Sequence):

--- a/src/pymatgen/core/xcfunc.py
+++ b/src/pymatgen/core/xcfunc.py
@@ -144,7 +144,7 @@ class XcFunc(MSONable):
         return hash(self.name)
 
     def __eq__(self, other: object) -> bool:
-        if not isinstance(other, (str, type(self))):
+        if not isinstance(other, str | type(self)):
             return NotImplemented
         if isinstance(other, type(self)):
             return self.name == other.name

--- a/src/pymatgen/electronic_structure/bandstructure.py
+++ b/src/pymatgen/electronic_structure/bandstructure.py
@@ -332,7 +332,7 @@ class BandStructure:
         max_tmp = -float("inf")
         index = kpoint_vbm = None
         for value in self.bands.values():
-            for idx, j in zip(*np.where(value < self.efermi)):
+            for idx, j in zip(*np.where(value < self.efermi), strict=False):
                 if value[idx, j] > max_tmp:
                     max_tmp = float(value[idx, j])
                     index = j
@@ -398,7 +398,7 @@ class BandStructure:
         max_tmp = float("inf")
         index = kpoint_cbm = None
         for value in self.bands.values():
-            for idx, j in zip(*np.where(value >= self.efermi)):
+            for idx, j in zip(*np.where(value >= self.efermi), strict=False):
                 if value[idx, j] < max_tmp:
                     max_tmp = float(value[idx, j])
                     index = j

--- a/src/pymatgen/electronic_structure/boltztrap.py
+++ b/src/pymatgen/electronic_structure/boltztrap.py
@@ -851,7 +851,9 @@ class BoltztrapAnalyzer:
                     for kpt in kpath.get_kpoints(coords_are_cartesian=False)[0]
                 ]
                 labels_dict = {
-                    label: key for key, label in zip(*kpath.get_kpoints(coords_are_cartesian=False)) if label
+                    label: key
+                    for key, label in zip(*kpath.get_kpoints(coords_are_cartesian=False), strict=False)
+                    if label
                 }
                 kpt_line = [kp.frac_coords for kp in kpt_line]
             elif isinstance(kpt_line[0], Kpoint):
@@ -1386,7 +1388,7 @@ class BoltztrapAnalyzer:
                 cond_mass = self.get_average_eff_mass(output=output, doping_levels=True)[dt][temp]
 
                 if output == "average":
-                    cmplx_fact[dt] = [(m_s / abs(m_c)) ** 1.5 for m_s, m_c in zip(sbk_mass, cond_mass)]
+                    cmplx_fact[dt] = [(m_s / abs(m_c)) ** 1.5 for m_s, m_c in zip(sbk_mass, cond_mass, strict=False)]
 
                 else:
                     cmplx_fact[dt] = []
@@ -1401,7 +1403,7 @@ class BoltztrapAnalyzer:
         cond_mass = self.get_average_eff_mass(output=output, doping_levels=False)[temp]
 
         if output == "average":
-            return [(m_s / abs(m_c)) ** 1.5 for m_s, m_c in zip(sbk_mass, cond_mass)]
+            return [(m_s / abs(m_c)) ** 1.5 for m_s, m_c in zip(sbk_mass, cond_mass, strict=False)]
 
         cmplx_fact_list: list = []
         for i, sm in enumerate(sbk_mass):

--- a/src/pymatgen/electronic_structure/boltztrap2.py
+++ b/src/pymatgen/electronic_structure/boltztrap2.py
@@ -554,7 +554,7 @@ class BztInterpolator:
             spins = [Spin.up]
 
         energies = []
-        for spin, eb, vvb in zip(spins, eband_ud, vvband_ud):
+        for spin, eb, vvb in zip(spins, eband_ud, vvband_ud, strict=False):
             energies, densities, _vvdos, _cdos = BL.BTPDOS(eb, vvb, npts=npts_mu, erange=enr)
 
             if T:
@@ -589,7 +589,7 @@ class BztInterpolator:
         else:
             bar = None
 
-        for spin, eb in zip(spins, eband_ud):
+        for spin, eb in zip(spins, eband_ud, strict=False):
             for idx, site in enumerate(self.data.structure):
                 if site not in pdoss:
                     pdoss[site] = {}

--- a/src/pymatgen/electronic_structure/cohp.py
+++ b/src/pymatgen/electronic_structure/cohp.py
@@ -552,7 +552,7 @@ class CompleteCohp(Cohp):
         if self.orb_res_cohp is None:
             return None
 
-        if isinstance(orbitals, (list, tuple)):
+        if isinstance(orbitals, list | tuple):
             cohp_orbs = [val["orbitals"] for val in self.orb_res_cohp[label].values()]
             orbs = []
             for orbital in orbitals:
@@ -1062,7 +1062,7 @@ class IcohpValue(MSONable):
         if not self.is_spin_polarized and spin == Spin.down:
             raise ValueError("The calculation was not performed with spin polarization")
 
-        if isinstance(orbitals, (tuple, list)):
+        if isinstance(orbitals, tuple | list):
             orbitals = f"{orbitals[0]}-{orbitals[1]}"
 
         assert self._orbitals is not None
@@ -1202,7 +1202,7 @@ class IcohpCollection(MSONable):
         if orbitals is None:
             return icohp.summed_icohp if summed_spin_channels else icohp.icohpvalue(spin)
 
-        if isinstance(orbitals, (tuple, list)):
+        if isinstance(orbitals, tuple | list):
             orbitals = f"{orbitals[0]}-{orbitals[1]}"
 
         if summed_spin_channels:

--- a/src/pymatgen/electronic_structure/dos.py
+++ b/src/pymatgen/electronic_structure/dos.py
@@ -1268,7 +1268,7 @@ class CompleteDos(Dos):
 
             dos_rebin = np.zeros(ener.shape)
 
-            for ii, e1, e2 in zip(range(len(ener)), ener_bounds[:-1], ener_bounds[1:]):
+            for ii, e1, e2 in zip(range(len(ener)), ener_bounds[:-1], ener_bounds[1:], strict=False):
                 inds = np.where((energies >= e1) & (energies < e2))
                 dos_rebin[ii] = np.sum(densities[inds])
 

--- a/src/pymatgen/electronic_structure/dos.py
+++ b/src/pymatgen/electronic_structure/dos.py
@@ -1326,11 +1326,9 @@ class CompleteDos(Dos):
         Returns:
             float: Similarity index given by the dot product.
         """
-        if metric not in ["tanimoto", "wasserstein", "cosine-sim"]:
-            raise ValueError(
-                "Requested metric not implemented. Currently implemented metrics are tanimoto, "
-                "wasserstien and cosine-sim."
-            )
+        valid_metrics = ("tanimoto", "wasserstein", "cosine-sim")
+        if metric not in valid_metrics:
+            raise ValueError(f"Invalid {metric=}, choose from {valid_metrics}.")
 
         fp1_dict = CompleteDos.fp_to_dict(fp1) if not isinstance(fp1, dict) else fp1
         fp2_dict = CompleteDos.fp_to_dict(fp2) if not isinstance(fp2, dict) else fp2

--- a/src/pymatgen/electronic_structure/plotter.py
+++ b/src/pymatgen/electronic_structure/plotter.py
@@ -197,7 +197,7 @@ class DosPlotter:
                     else:
                         x = energy
                         y = densities
-                    all_pts.extend(list(zip(x, y)))
+                    all_pts.extend(list(zip(x, y, strict=False)))
                     if self.stack:
                         ax.fill(x, y, color=colors[idx % n_colors], label=str(key))
                     elif spin == Spin.down and beta_dashed:
@@ -237,7 +237,7 @@ class DosPlotter:
 
         # Remove duplicate labels with a dictionary
         handles, labels = ax.get_legend_handles_labels()
-        label_dict = dict(zip(labels, handles))
+        label_dict = dict(zip(labels, handles, strict=False))
         ax.legend(label_dict.values(), label_dict)
         legend_text = ax.get_legend().get_texts()  # all the text.Text instance in the legend
         plt.setp(legend_text, fontsize=30)
@@ -336,7 +336,7 @@ class BSPlotter:
         # Sanitize only plot the uniq values
         uniq_d = []
         uniq_l = []
-        temp_ticks = list(zip(ticks["distance"], ticks["label"]))
+        temp_ticks = list(zip(ticks["distance"], ticks["label"], strict=False))
         for idx, t in enumerate(temp_ticks):
             if idx == 0:
                 uniq_d.append(t[0])
@@ -349,7 +349,7 @@ class BSPlotter:
                 uniq_d.append(t[0])
                 uniq_l.append(t[1])
 
-        logger.debug(f"Unique labels are {list(zip(uniq_d, uniq_l))}")
+        logger.debug(f"Unique labels are {list(zip(uniq_d, uniq_l, strict=False))}")
         ax.set_xticks(uniq_d)
         ax.set_xticklabels(uniq_l)
 
@@ -371,7 +371,7 @@ class BSPlotter:
     def _get_branch_steps(branches):
         """Find discontinuous branches."""
         steps = [0]
-        for b1, b2 in zip(branches[:-1], branches[1:]):
+        for b1, b2 in zip(branches[:-1], branches[1:], strict=False):
             if b2["name"].split("-")[0] != b1["name"].split("-")[-1]:
                 steps.append(b2["start_index"])
         steps.append(branches[-1]["end_index"] + 1)
@@ -385,7 +385,7 @@ class BSPlotter:
         """
         scaled_distances = []
 
-        for br, br2 in zip(bs_ref.branches, bs.branches):
+        for br, br2 in zip(bs_ref.branches, bs.branches, strict=False):
             start = br["start_index"]
             end = br["end_index"]
             max_d = bs_ref.distance[end]
@@ -531,7 +531,7 @@ class BSPlotter:
         int_energies, int_distances = [], []
         smooth_k_orig = smooth_k
 
-        for dist, ene in zip(distances, energies):
+        for dist, ene in zip(distances, energies, strict=False):
             br_en = []
             warning_nan = (
                 f"WARNING! Distance / branch, band cannot be "
@@ -662,7 +662,7 @@ class BSPlotter:
                     distances = np.split(distances, steps)
                     energies = np.hsplit(energies, steps)
 
-                for dist, ene in zip(distances, energies):
+                for dist, ene in zip(distances, energies, strict=False):
                     ax.plot(dist, ene.T, c=colors[ibs], ls=ls)
 
             # plot markers for vbm and cbm
@@ -2196,7 +2196,7 @@ class BSPlotterProjected(BSPlotter):
 
         uniq_d = []
         uniq_l = []
-        temp_ticks = list(zip(f_distance, f_label))
+        temp_ticks = list(zip(f_distance, f_label, strict=False))
         for idx, tick in enumerate(temp_ticks):
             if idx == 0:
                 uniq_d.append(tick[0])
@@ -2209,7 +2209,7 @@ class BSPlotterProjected(BSPlotter):
                 uniq_d.append(tick[0])
                 uniq_l.append(tick[1])
 
-        logger.debug(f"Unique labels are {list(zip(uniq_d, uniq_l))}")
+        logger.debug(f"Unique labels are {list(zip(uniq_d, uniq_l, strict=False))}")
         ax.set_xticks(uniq_d)
         ax.set_xticklabels(uniq_l)
 
@@ -2583,7 +2583,9 @@ class BSDOSPlotter:
         green = [0.5 * (green[i] + green[i + 1]) for i in range(n_seg)]
         blue = [0.5 * (blue[i] + blue[i + 1]) for i in range(n_seg)]
         alpha = np.ones(n_seg, float) * alpha
-        lc = LineCollection(seg, colors=list(zip(red, green, blue, alpha)), linewidth=2, linestyles=linestyles)
+        lc = LineCollection(
+            seg, colors=list(zip(red, green, blue, alpha, strict=False)), linewidth=2, linestyles=linestyles
+        )
         ax.add_collection(lc)
 
     @staticmethod
@@ -3134,7 +3136,7 @@ class BoltztrapPlotter:
                     for xyz in range(3):
                         ax.plot(
                             temperatures,
-                            list(zip(*sbk_temp))[xyz],
+                            list(zip(*sbk_temp, strict=False))[xyz],
                             marker="s",
                             label=f"{xyz} {dop} $cm^{{-3}}$",
                         )
@@ -3188,7 +3190,7 @@ class BoltztrapPlotter:
                     for xyz in range(3):
                         ax.plot(
                             temperatures,
-                            list(zip(*cond_temp))[xyz],
+                            list(zip(*cond_temp, strict=False))[xyz],
                             marker="s",
                             label=f"{xyz} {dop} $cm^{{-3}}$",
                         )
@@ -3243,7 +3245,7 @@ class BoltztrapPlotter:
                     for xyz in range(3):
                         ax.plot(
                             temperatures,
-                            list(zip(*pf_temp))[xyz],
+                            list(zip(*pf_temp, strict=False))[xyz],
                             marker="s",
                             label=f"{xyz} {dop} $cm^{{-3}}$",
                         )
@@ -3297,7 +3299,7 @@ class BoltztrapPlotter:
                     for xyz in range(3):
                         ax.plot(
                             temperatures,
-                            list(zip(*zt_temp))[xyz],
+                            list(zip(*zt_temp, strict=False))[xyz],
                             marker="s",
                             label=f"{xyz} {dop} $cm^{{-3}}$",
                         )
@@ -3344,7 +3346,12 @@ class BoltztrapPlotter:
                     ax.plot(temperatures, em_temp, marker="s", label=f"{dop} $cm^{{-3}}$")
                 elif output == "eigs":
                     for xyz in range(3):
-                        ax.plot(temperatures, list(zip(*em_temp))[xyz], marker="s", label=f"{xyz} {dop} $cm^{{-3}}$")
+                        ax.plot(
+                            temperatures,
+                            list(zip(*em_temp, strict=False))[xyz],
+                            marker="s",
+                            label=f"{xyz} {dop} $cm^{{-3}}$",
+                        )
             ax.set_title(f"{dop_type}-type", fontsize=20)
             if idx == 0:
                 ax.set_ylabel("Effective mass (m$_e$)", fontsize=30.0)
@@ -3380,7 +3387,7 @@ class BoltztrapPlotter:
                     for xyz in range(3):
                         ax.semilogx(
                             self._bz.doping[dop_type],
-                            list(zip(*sbk[dop_type][temp]))[xyz],
+                            list(zip(*sbk[dop_type][temp], strict=False))[xyz],
                             marker="s",
                             label=f"{xyz} {temp} K",
                         )
@@ -3429,7 +3436,7 @@ class BoltztrapPlotter:
                     for xyz in range(3):
                         ax.semilogx(
                             self._bz.doping[dop_type],
-                            list(zip(*cond[dop_type][temp]))[xyz],
+                            list(zip(*cond[dop_type][temp], strict=False))[xyz],
                             marker="s",
                             label=f"{xyz} {temp} K",
                         )
@@ -3481,7 +3488,7 @@ class BoltztrapPlotter:
                     for xyz in range(3):
                         ax.semilogx(
                             self._bz.doping[dop_type],
-                            list(zip(*pow_factor[dop_type][temp]))[xyz],
+                            list(zip(*pow_factor[dop_type][temp], strict=False))[xyz],
                             marker="s",
                             label=f"{xyz} {temp} K",
                         )
@@ -3530,7 +3537,7 @@ class BoltztrapPlotter:
                     for xyz in range(3):
                         ax.semilogx(
                             self._bz.doping[dop_type],
-                            list(zip(*zt[dop_type][temp]))[xyz],
+                            list(zip(*zt[dop_type][temp], strict=False))[xyz],
                             marker="s",
                             label=f"{xyz} {temp} K",
                         )
@@ -3584,7 +3591,7 @@ class BoltztrapPlotter:
                     for xyz in range(3):
                         ax.semilogx(
                             self._bz.doping[dop_type],
-                            list(zip(*em[dop_type][temp]))[xyz],
+                            list(zip(*em[dop_type][temp], strict=False))[xyz],
                             marker="s",
                             label=f"{xyz} {temp} K",
                         )
@@ -3802,7 +3809,7 @@ class CohpPlotter:
                     else:
                         x = energies
                         y = -populations[spin] if plot_negative else populations[spin]
-                    allpts.extend(list(zip(x, y)))
+                    allpts.extend(list(zip(x, y, strict=False)))
                     if spin == Spin.up:
                         ax.plot(
                             x,
@@ -3997,7 +4004,7 @@ def plot_fermi_surface(
                         and any(np.all(line[1] == x) for x in bz[jface])
                     ):
                         mlab.plot3d(
-                            *zip(line[0], line[1]),
+                            *zip(line[0], line[1], strict=False),
                             color=(0, 0, 0),
                             tube_radius=None,
                             figure=fig,
@@ -4033,7 +4040,7 @@ def plot_fermi_surface(
                             and any(np.all(line[1] == x) for x in bz[jface])
                         ):
                             mlab.plot3d(
-                                *zip(line[0], line[1]),
+                                *zip(line[0], line[1], strict=False),
                                 color=(0, 0, 0),
                                 tube_radius=None,
                                 figure=fig,
@@ -4108,7 +4115,7 @@ def plot_wigner_seitz(lattice, ax: plt.Axes = None, **kwargs):
                     and any(np.all(line[0] == x) for x in bz[jface])
                     and any(np.all(line[1] == x) for x in bz[jface])
                 ):
-                    ax.plot(*zip(line[0], line[1]), **kwargs)
+                    ax.plot(*zip(line[0], line[1], strict=False), **kwargs)
 
     return fig, ax
 
@@ -4134,11 +4141,11 @@ def plot_lattice_vectors(lattice, ax: plt.Axes = None, **kwargs):
 
     vertex1 = lattice.get_cartesian_coords([0.0, 0.0, 0.0])
     vertex2 = lattice.get_cartesian_coords([1.0, 0.0, 0.0])
-    ax.plot(*zip(vertex1, vertex2), **kwargs)
+    ax.plot(*zip(vertex1, vertex2, strict=False), **kwargs)
     vertex2 = lattice.get_cartesian_coords([0.0, 1.0, 0.0])
-    ax.plot(*zip(vertex1, vertex2), **kwargs)
+    ax.plot(*zip(vertex1, vertex2, strict=False), **kwargs)
     vertex2 = lattice.get_cartesian_coords([0.0, 0.0, 1.0])
-    ax.plot(*zip(vertex1, vertex2), **kwargs)
+    ax.plot(*zip(vertex1, vertex2, strict=False), **kwargs)
 
     return fig, ax
 
@@ -4174,7 +4181,7 @@ def plot_path(line, lattice=None, coords_are_cartesian=False, ax: plt.Axes = Non
                 raise ValueError("coords_are_cartesian False requires the lattice")
             vertex1 = lattice.get_cartesian_coords(vertex1)
             vertex2 = lattice.get_cartesian_coords(vertex2)
-        ax.plot(*zip(vertex1, vertex2), **kwargs)
+        ax.plot(*zip(vertex1, vertex2, strict=False), **kwargs)
 
     return fig, ax
 

--- a/src/pymatgen/electronic_structure/plotter.py
+++ b/src/pymatgen/electronic_structure/plotter.py
@@ -371,7 +371,7 @@ class BSPlotter:
     def _get_branch_steps(branches):
         """Find discontinuous branches."""
         steps = [0]
-        for b1, b2 in zip(branches[:-1], branches[1:], strict=False):
+        for b1, b2 in itertools.pairwise(branches):
             if b2["name"].split("-")[0] != b1["name"].split("-")[-1]:
                 steps.append(b2["start_index"])
         steps.append(branches[-1]["end_index"] + 1)

--- a/src/pymatgen/entries/compatibility.py
+++ b/src/pymatgen/entries/compatibility.py
@@ -9,7 +9,7 @@ import copy
 import os
 import warnings
 from collections import defaultdict
-from typing import TYPE_CHECKING, Union, cast
+from typing import TYPE_CHECKING, TypeAlias, cast
 
 import numpy as np
 from joblib import Parallel, delayed
@@ -73,7 +73,7 @@ assert (  # ping @janosh @rkingsbury on GitHub if this fails
     == MP2020_COMPAT_CONFIG["Corrections"]["GGAUMixingCorrections"]["F"]
 ), "MP2020Compatibility.yaml expected to have the same Hubbard U corrections for O and F"
 
-AnyComputedEntry = Union[ComputedEntry, ComputedStructureEntry]
+AnyComputedEntry: TypeAlias = ComputedEntry | ComputedStructureEntry
 
 
 class CompatibilityError(Exception):

--- a/src/pymatgen/entries/correction_calculator.py
+++ b/src/pymatgen/entries/correction_calculator.py
@@ -266,7 +266,9 @@ class CorrectionCalculator:
 
         abs_errors = [abs(i) for i in self.diffs - np.dot(self.coeff_mat, self.corrections)]
         labels_graph = self.names.copy()
-        abs_errors, labels_graph = (list(t) for t in zip(*sorted(zip(abs_errors, labels_graph))))  # sort by error
+        abs_errors, labels_graph = (
+            list(t) for t in zip(*sorted(zip(abs_errors, labels_graph, strict=False)), strict=False)
+        )  # sort by error
 
         n_err = len(abs_errors)
         fig = go.Figure(
@@ -331,7 +333,7 @@ class CorrectionCalculator:
                     del abs_errors[n_species - idx - 1]
                     del diffs_cpy[n_species - idx - 1]
         abs_errors, labels_species = (
-            list(tup) for tup in zip(*sorted(zip(abs_errors, labels_species)))
+            list(tup) for tup in zip(*sorted(zip(abs_errors, labels_species, strict=False)), strict=False)
         )  # sort by error
 
         n_err = len(abs_errors)

--- a/src/pymatgen/entries/entry_tools.py
+++ b/src/pymatgen/entries/entry_tools.py
@@ -46,7 +46,7 @@ def _perform_grouping(args):
 
     entries = json.loads(entries_json, cls=MontyDecoder)
     hosts = json.loads(hosts_json, cls=MontyDecoder)
-    unmatched = list(zip(entries, hosts))
+    unmatched = list(zip(entries, hosts, strict=False))
     while len(unmatched) > 0:
         ref_host = unmatched[0][1]
         logger.info(f"Reference tid = {unmatched[0][0].entry_id}, formula = {ref_host.formula}")

--- a/src/pymatgen/ext/matproj.py
+++ b/src/pymatgen/ext/matproj.py
@@ -26,7 +26,7 @@ from pymatgen.core import __version__ as PMG_VERSION
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 
 if TYPE_CHECKING:
-    from typing import Callable
+    from collections.abc import Callable
 
     from mp_api.client import MPRester as _MPResterNew
     from typing_extensions import Self

--- a/src/pymatgen/ext/matproj_legacy.py
+++ b/src/pymatgen/ext/matproj_legacy.py
@@ -1393,7 +1393,7 @@ class _MPResterLegacy:
             # Prefer reconstructed surfaces, which have lower surface energies.
             if (miller not in miller_energy_map) or surf["is_reconstructed"]:
                 miller_energy_map[miller] = surf["surface_energy"]
-        millers, energies = zip(*miller_energy_map.items())
+        millers, energies = zip(*miller_energy_map.items(), strict=False)
         return WulffShape(lattice, millers, energies)
 
     def get_gb_data(

--- a/src/pymatgen/ext/optimade.py
+++ b/src/pymatgen/ext/optimade.py
@@ -201,13 +201,13 @@ class OptimadeRester:
             filters.append(f"(elements HAS ALL {elements_str})")
 
         if nsites:
-            if isinstance(nsites, (list, tuple)):
+            if isinstance(nsites, list | tuple):
                 filters.append(f"(nsites>={min(nsites)} AND nsites<={max(nsites)})")
             else:
                 filters.append(f"({nsites=})")
 
         if nelements:
-            if isinstance(nelements, (list, tuple)):
+            if isinstance(nelements, list | tuple):
                 filters.append(f"(nelements>={min(nelements)} AND nelements<={max(nelements)})")
             else:
                 filters.append(f"({nelements=})")
@@ -379,7 +379,7 @@ class OptimadeRester:
         def _get_comp(sp_dict):
             return {
                 _sanitize_symbol(symbol): conc
-                for symbol, conc in zip(sp_dict["chemical_symbols"], sp_dict["concentration"])
+                for symbol, conc in zip(sp_dict["chemical_symbols"], sp_dict["concentration"], strict=False)
             }
 
         for data in json["data"]:

--- a/src/pymatgen/io/abinit/abitimer.py
+++ b/src/pymatgen/io/abinit/abitimer.py
@@ -28,7 +28,7 @@ def alternate(*iterables):
     [1, 2, 3, 4, 5, 6].
     """
     items = []
-    for tup in zip(*iterables):
+    for tup in zip(*iterables, strict=False):
         items.extend(tup)
     return items
 
@@ -266,8 +266,12 @@ class AbinitTimerParser(collections.abc.Iterable):
 
         # Compute the parallel efficiency (total and section efficiency)
         peff = {}
-        ctime_peff = [(min_ncpus * ref_t.wall_time) / (t.wall_time * ncp) for (t, ncp) in zip(timers, ncpus)]
-        wtime_peff = [(min_ncpus * ref_t.cpu_time) / (t.cpu_time * ncp) for (t, ncp) in zip(timers, ncpus)]
+        ctime_peff = [
+            (min_ncpus * ref_t.wall_time) / (t.wall_time * ncp) for (t, ncp) in zip(timers, ncpus, strict=False)
+        ]
+        wtime_peff = [
+            (min_ncpus * ref_t.cpu_time) / (t.cpu_time * ncp) for (t, ncp) in zip(timers, ncpus, strict=False)
+        ]
         n = len(timers)
 
         peff["total"] = {}
@@ -280,8 +284,13 @@ class AbinitTimerParser(collections.abc.Iterable):
             ref_sect = ref_t.get_section(sect_name)
             sects = [timer.get_section(sect_name) for timer in timers]
             try:
-                ctime_peff = [(min_ncpus * ref_sect.cpu_time) / (s.cpu_time * ncp) for (s, ncp) in zip(sects, ncpus)]
-                wtime_peff = [(min_ncpus * ref_sect.wall_time) / (s.wall_time * ncp) for (s, ncp) in zip(sects, ncpus)]
+                ctime_peff = [
+                    (min_ncpus * ref_sect.cpu_time) / (s.cpu_time * ncp) for (s, ncp) in zip(sects, ncpus, strict=False)
+                ]
+                wtime_peff = [
+                    (min_ncpus * ref_sect.wall_time) / (s.wall_time * ncp)
+                    for (s, ncp) in zip(sects, ncpus, strict=False)
+                ]
             except ZeroDivisionError:
                 ctime_peff = n * [-1]
                 wtime_peff = n * [-1]
@@ -729,7 +738,7 @@ class AbinitTimer:
         if minval is not None:
             assert minfract is None
 
-            for name, val in zip(names, values):
+            for name, val in zip(names, values, strict=False):
                 if val >= minval:
                     new_names.append(name)
                     new_values.append(val)
@@ -744,7 +753,7 @@ class AbinitTimer:
 
             total = self.sum_sections(key)
 
-            for name, val in zip(names, values):
+            for name, val in zip(names, values, strict=False):
                 if val / total >= minfract:
                     new_names.append(name)
                     new_values.append(val)
@@ -760,7 +769,7 @@ class AbinitTimer:
 
         if sorted:
             # Sort new_values and rearrange new_names.
-            nandv = list(zip(new_names, new_values))
+            nandv = list(zip(new_names, new_values, strict=False))
             nandv.sort(key=lambda t: t[1])
             new_names, new_values = [n[0] for n in nandv], [n[1] for n in nandv]
 

--- a/src/pymatgen/io/abinit/inputs.py
+++ b/src/pymatgen/io/abinit/inputs.py
@@ -345,7 +345,7 @@ def ebands_input(
     """
     structure = as_structure(structure)
 
-    if dos_kppa is not None and not isinstance(dos_kppa, (list, tuple)):
+    if dos_kppa is not None and not isinstance(dos_kppa, list | tuple):
         dos_kppa = [dos_kppa]
 
     multi = BasicMultiDataset(structure, pseudos, ndtset=2 if dos_kppa is None else 2 + len(dos_kppa))
@@ -1068,7 +1068,7 @@ class BasicMultiDataset:
         if ndtset <= 0:
             raise ValueError(f"{ndtset=} cannot be <=0")
 
-        if not isinstance(structure, (list, tuple)):
+        if not isinstance(structure, list | tuple):
             self._inputs = [BasicAbinitInput(structure=structure, pseudos=pseudos) for i in range(ndtset)]
         else:
             assert len(structure) == ndtset
@@ -1078,7 +1078,7 @@ class BasicMultiDataset:
     def from_inputs(cls, inputs: list[BasicAbinitInput]) -> Self:
         """Construct a multidataset from a list of BasicAbinitInputs."""
         for inp in inputs:
-            if any(p1 != p2 for p1, p2 in zip(inputs[0].pseudos, inp.pseudos)):
+            if any(p1 != p2 for p1, p2 in zip(inputs[0].pseudos, inp.pseudos, strict=False)):
                 raise ValueError("Pseudos must be consistent when from_inputs is invoked.")
 
         # Build BasicMultiDataset from input structures and pseudos and add inputs.
@@ -1089,7 +1089,7 @@ class BasicMultiDataset:
         )
 
         # Add variables
-        for inp, new_inp in zip(inputs, multi):
+        for inp, new_inp in zip(inputs, multi, strict=False):
             new_inp.set_vars(**inp)
 
         return multi
@@ -1184,7 +1184,7 @@ class BasicMultiDataset:
     def append(self, abinit_input):
         """Add a BasicAbinitInput to the list."""
         assert isinstance(abinit_input, BasicAbinitInput)
-        if any(p1 != p2 for p1, p2 in zip(abinit_input.pseudos, abinit_input.pseudos)):
+        if any(p1 != p2 for p1, p2 in zip(abinit_input.pseudos, abinit_input.pseudos, strict=False)):
             raise ValueError("Pseudos must be consistent when from_inputs is invoked.")
         self._inputs.append(abinit_input)
 
@@ -1192,7 +1192,7 @@ class BasicMultiDataset:
         """Extends self with a list of BasicAbinitInputs."""
         assert all(isinstance(inp, BasicAbinitInput) for inp in abinit_inputs)
         for inp in abinit_inputs:
-            if any(p1 != p2 for p1, p2 in zip(self[0].pseudos, inp.pseudos)):
+            if any(p1 != p2 for p1, p2 in zip(self[0].pseudos, inp.pseudos, strict=False)):
                 raise ValueError("Pseudos must be consistent when from_inputs is invoked.")
         self._inputs.extend(abinit_inputs)
 

--- a/src/pymatgen/io/abinit/pseudos.py
+++ b/src/pymatgen/io/abinit/pseudos.py
@@ -623,7 +623,7 @@ def _dict_from_lines(lines, key_nums, sep=None) -> dict:
         if len(values) != len(keys):
             raise ValueError(f"{line=}\n {len(keys)=} must equal {len(values)=}")
 
-        kwargs.update(zip(keys, values))
+        kwargs.update(zip(keys, values, strict=False))
 
     return kwargs
 
@@ -1829,7 +1829,7 @@ class PseudoTable(collections.abc.Sequence, MSONable):
         """Get new class:`PseudoTable` object with pseudos in the given rows of the periodic table.
         rows can be either a int or a list of integers.
         """
-        if not isinstance(rows, (list, tuple)):
+        if not isinstance(rows, list | tuple):
             rows = [rows]
         return type(self)([p for p in self if p.element.row in rows])
 

--- a/src/pymatgen/io/abinit/variable.py
+++ b/src/pymatgen/io/abinit/variable.py
@@ -94,9 +94,9 @@ class InputVariable:
             value = list(value.flatten())
 
         # values in lists
-        if isinstance(value, (list, tuple)):
+        if isinstance(value, list | tuple):
             # Reshape a list of lists into a single list
-            if all(isinstance(v, (list, tuple)) for v in value):
+            if all(isinstance(v, list | tuple) for v in value):
                 line += self.format_list2d(value, float_decimal)
 
             else:

--- a/src/pymatgen/io/adf.py
+++ b/src/pymatgen/io/adf.py
@@ -96,7 +96,7 @@ class AdfKey(MSONable):
                     raise TypeError("Not all subkeys are ``AdfKey`` objects!")
         self._sized_op = None
         if len(self.options) > 0:
-            self._sized_op = isinstance(self.options[0], (list, tuple))
+            self._sized_op = isinstance(self.options[0], list | tuple)
 
     def _options_string(self):
         """Return the option string."""
@@ -213,7 +213,7 @@ class AdfKey(MSONable):
         if len(self.options) == 0:
             self.options.append(option)
         else:
-            sized_op = isinstance(option, (list, tuple))
+            sized_op = isinstance(option, list | tuple)
             if self._sized_op != sized_op:
                 raise TypeError("Option type is mismatched!")
             self.options.append(option)

--- a/src/pymatgen/io/aims/inputs.py
+++ b/src/pymatgen/io/aims/inputs.py
@@ -150,7 +150,7 @@ class AimsGeometryIn(MSONable):
         magmoms = structure.site_properties.get("magmom", np.zeros(len(structure.species)))
         velocities = structure.site_properties.get("velocity", [None for _ in structure.species])
         for species, coord, charge, magmom, v in zip(
-            structure.species, structure.cart_coords, charges, magmoms, velocities
+            structure.species, structure.cart_coords, charges, magmoms, velocities, strict=False
         ):
             content_lines.append(f"atom {coord[0]: .12e} {coord[1]: .12e} {coord[2]: .12e} {species}")
             if charge != 0:
@@ -546,7 +546,7 @@ class AimsControlIn(MSONable):
                 content += self.get_aims_control_parameter_str(key, "", "%s")
             elif isinstance(value, bool):
                 content += self.get_aims_control_parameter_str(key, str(value).lower(), ".%s.")
-            elif isinstance(value, (tuple, list)):
+            elif isinstance(value, tuple | list):
                 content += self.get_aims_control_parameter_str(key, " ".join(map(str, value)), "%s")
             elif isinstance(value, str):
                 content += self.get_aims_control_parameter_str(key, value, "%s")
@@ -799,7 +799,7 @@ class SpeciesDefaults(list, MSONable):
         """Initialize species defaults from a structure."""
         labels = []
         elements = {}
-        for label, el in sorted(zip(struct.labels, struct.species)):
+        for label, el in sorted(zip(struct.labels, struct.species, strict=False)):
             if not isinstance(el, Element):
                 raise TypeError("FHI-aims does not support fractional compositions")
             if (label is None) or (el is None):

--- a/src/pymatgen/io/aims/sets/bs.py
+++ b/src/pymatgen/io/aims/sets/bs.py
@@ -31,7 +31,7 @@ def prepare_band_input(structure: Structure, density: float = 20):
     points, labels = bp.get_kpoints(line_density=density, coords_are_cartesian=False)
     lines_and_labels: list[_SegmentDict] = []
     current_segment: _SegmentDict | None = None
-    for label_, coords in zip(labels, points):
+    for label_, coords in zip(labels, points, strict=False):
         # rename the Gamma point label
         label = "G" if label_ in ("GAMMA", "\\Gamma", "Γ") else label_
         if label:

--- a/src/pymatgen/io/cif.py
+++ b/src/pymatgen/io/cif.py
@@ -105,7 +105,7 @@ class CifBlock:
         for line in loop:
             out += "\n " + line
 
-        for fields in zip(*(self.data[k] for k in loop)):
+        for fields in zip(*(self.data[k] for k in loop), strict=False):
             line = "\n"
             for val in map(self._format_field, fields):
                 if val[0] == ";":
@@ -228,7 +228,7 @@ class CifBlock:
                 n = len(items) // len(columns)
                 assert len(items) % n == 0
                 loops.append(columns)
-                for k, v in zip(columns * n, items):
+                for k, v in zip(columns * n, items, strict=False):
                     data[k].append(v.strip())
 
             elif issue := "".join(_str).strip():
@@ -373,7 +373,7 @@ class CifParser:
         self._frac_tolerance = frac_tolerance
 
         # Read CIF file
-        if isinstance(filename, (str, Path)):
+        if isinstance(filename, str | Path):
             self._cif = CifFile.from_file(filename)
         elif isinstance(filename, StringIO):
             self._cif = CifFile.from_str(filename.read())
@@ -610,7 +610,7 @@ class CifParser:
                 raise ValueError("Length of magmoms and coords don't match.")
 
             magmoms_out: list[Magmom] = []
-            for tmp_coord, tmp_magmom in zip(coords, magmoms):
+            for tmp_coord, tmp_magmom in zip(coords, magmoms, strict=False):
                 for op in self.symmetry_operations:
                     coord = op.operate(tmp_coord)
                     coord = np.array([i - math.floor(i) for i in coord])

--- a/src/pymatgen/io/cp2k/outputs.py
+++ b/src/pymatgen/io/cp2k/outputs.py
@@ -297,7 +297,7 @@ class Cp2kOutput:
             self.structures = []
             gs = self.initial_structure.site_properties.get("ghost")
             if not self.is_molecule:
-                for mol, latt in zip(mols, lattices):
+                for mol, latt in zip(mols, lattices, strict=False):
                     self.structures.append(
                         Structure(
                             lattice=latt,
@@ -520,7 +520,7 @@ class Cp2kOutput:
         if not self.data.get("stress_tensor"):
             self.parse_stresses()
 
-        for i, (structure, energy) in enumerate(zip(self.structures, self.data.get("total_energy"))):
+        for i, (structure, energy) in enumerate(zip(self.structures, self.data.get("total_energy"), strict=False)):
             self.ionic_steps.append(
                 {
                     "structure": structure,
@@ -629,6 +629,7 @@ class Cp2kOutput:
                 for _possible, _name in zip(
                     ["RVV10", "LMKLL", "DRSLL", "DFT-D3", "DFT-D2"],
                     ["RVV10", "LMKLL", "DRSLL", "D3", "D2"],
+                    strict=False,
                 ):
                     if _possible in ll[0]:
                         found = _name
@@ -714,7 +715,7 @@ class Cp2kOutput:
             reverse=False,
         )
         i = iter(self.data["lattice"])
-        lattices = list(zip(i, i, i))
+        lattices = list(zip(i, i, i, strict=False))
         return lattices[0]
 
     def parse_atomic_kind_info(self):
@@ -1462,7 +1463,7 @@ class Cp2kOutput:
         dct = np.zeros(npts)
         e_s = np.linspace(min(energies), max(energies), npts)
 
-        for e, _pd in zip(energies, densities):
+        for e, _pd in zip(energies, densities, strict=False):
             weight = np.exp(-(((e_s - e) / width) ** 2)) / (np.sqrt(np.pi) * width)
             dct += _pd * weight
 

--- a/src/pymatgen/io/cp2k/sets.py
+++ b/src/pymatgen/io/cp2k/sets.py
@@ -1075,7 +1075,7 @@ class DftSet(Cp2kInput):
                                 "LIST": Keyword("LIST", f"{t[0]}..{t[1]}"),
                             },
                         )
-                        for t, c in zip(tuples, components)
+                        for t, c in zip(tuples, components, strict=False)
                         if c
                     ]
                 )

--- a/src/pymatgen/io/feff/inputs.py
+++ b/src/pymatgen/io/feff/inputs.py
@@ -677,7 +677,7 @@ class Tags(dict):
             else:
                 eels_keys = ["BEAM_ENERGY", "ANGLES", "MESH", "POSITION"]
             eels_dict = {"ENERGY": Tags._stringify_val(eels_params[0].split()[1:])}
-            for k, v in zip(eels_keys, eels_params[1:]):
+            for k, v in zip(eels_keys, eels_params[1:], strict=False):
                 eels_dict[k] = str(v)
             params[str(eels_params[0].split()[0])] = eels_dict
 

--- a/src/pymatgen/io/gaussian.py
+++ b/src/pymatgen/io/gaussian.py
@@ -836,23 +836,23 @@ class GaussianOutput:
                             while "Atom  AN" not in line:
                                 if "Frequencies --" in line:
                                     freqs = map(float, float_patt.findall(line))
-                                    for ifreq, freq in zip(ifreqs, freqs):
+                                    for ifreq, freq in zip(ifreqs, freqs, strict=False):
                                         frequencies[ifreq]["frequency"] = freq
                                 elif "Red. masses --" in line:
                                     r_masses = map(float, float_patt.findall(line))
-                                    for ifreq, r_mass in zip(ifreqs, r_masses):
+                                    for ifreq, r_mass in zip(ifreqs, r_masses, strict=False):
                                         frequencies[ifreq]["r_mass"] = r_mass
                                 elif "Frc consts  --" in line:
                                     f_consts = map(float, float_patt.findall(line))
-                                    for ifreq, f_const in zip(ifreqs, f_consts):
+                                    for ifreq, f_const in zip(ifreqs, f_consts, strict=False):
                                         frequencies[ifreq]["f_constant"] = f_const
                                 elif "IR Inten    --" in line:
                                     IR_intens = map(float, float_patt.findall(line))
-                                    for ifreq, intens in zip(ifreqs, IR_intens):
+                                    for ifreq, intens in zip(ifreqs, IR_intens, strict=False):
                                         frequencies[ifreq]["IR_intensity"] = intens
                                 else:
                                     syms = line.split()[:3]
-                                    for ifreq, sym in zip(ifreqs, syms):
+                                    for ifreq, sym in zip(ifreqs, syms, strict=False):
                                         frequencies[ifreq]["symmetry"] = sym
                                 line = file.readline()
 
@@ -860,7 +860,7 @@ class GaussianOutput:
                             line = file.readline()
                             while normal_mode_patt.search(line):
                                 values = list(map(float, float_patt.findall(line)))
-                                for idx, ifreq in zip(range(0, len(values), 3), ifreqs):
+                                for idx, ifreq in zip(range(0, len(values), 3), ifreqs, strict=False):
                                     frequencies[ifreq]["mode"].extend(values[idx : idx + 3])
                                 line = file.readline()
 

--- a/src/pymatgen/io/lammps/outputs.py
+++ b/src/pymatgen/io/lammps/outputs.py
@@ -184,6 +184,6 @@ def parse_lammps_log(filename: str = "log.lammps") -> list[pd.DataFrame]:
         return df
 
     runs = []
-    for b, e in zip(begins, ends):
+    for b, e in zip(begins, ends, strict=False):
         runs.append(_parse_thermo(lines[b + 1 : e]))
     return runs

--- a/src/pymatgen/io/lobster/lobsterenv.py
+++ b/src/pymatgen/io/lobster/lobsterenv.py
@@ -243,7 +243,7 @@ class LobsterNeighbors(NearNeighbors):
             raise ValueError("No cations and anions defined")
 
         anion_species = []
-        for site, val in zip(self.structure, self.valences):
+        for site, val in zip(self.structure, self.valences, strict=False):
             if val < 0.0:
                 anion_species.append(site.specie)
 
@@ -413,7 +413,7 @@ class LobsterNeighbors(NearNeighbors):
         final_isites = []
         for ival, _site in enumerate(self.structure):
             if ival in isites:
-                for keys, icohpsum in zip(self.list_keys[ival], self.list_icohps[ival]):
+                for keys, icohpsum in zip(self.list_keys[ival], self.list_icohps[ival], strict=False):
                     summed_icohps += icohpsum
                     list_icohps.append(icohpsum)
                     labels.append(keys)
@@ -559,7 +559,7 @@ class LobsterNeighbors(NearNeighbors):
             # iterate through labels and atoms and check which bonds can be included
             new_labels = []
             new_atoms = []
-            for key, atompair, isite in zip(labels, atoms, final_isites):
+            for key, atompair, isite in zip(labels, atoms, final_isites, strict=False):
                 present = False
                 for atomtype in only_bonds_to:
                     # This is necessary to identify also bonds between the same elements correctly!

--- a/src/pymatgen/io/lobster/outputs.py
+++ b/src/pymatgen/io/lobster/outputs.py
@@ -2115,7 +2115,7 @@ class LobsterMatrices:
         matrix_real = []
         matrix_imag = []
         for start_inx_real, end_inx_real, start_inx_imag, end_inx_imag in zip(
-            start_inxs_real, end_inxs_real, start_inxs_imag, end_inxs_imag
+            start_inxs_real, end_inxs_real, start_inxs_imag, end_inxs_imag, strict=False
         ):
             # matrix with text headers
             matrix_real = file_data[start_inx_real:end_inx_real]
@@ -2147,6 +2147,8 @@ class LobsterMatrices:
         average_matrix_diagonal_values = np.array(matrix_diagonal_values, dtype=float).mean(axis=0)
 
         # get a dict with basis functions as keys and average values as values
-        average_average_matrix_diag_dict = dict(zip(elements_basis_functions, average_matrix_diagonal_values))
+        average_average_matrix_diag_dict = dict(
+            zip(elements_basis_functions, average_matrix_diagonal_values, strict=False)
+        )
 
         return matrix_diagonal_values, average_average_matrix_diag_dict, complex_matrices

--- a/src/pymatgen/io/nwchem.py
+++ b/src/pymatgen/io/nwchem.py
@@ -767,7 +767,7 @@ class NwOutput:
                 else:
                     vibs = [float(vib) for vib in line.strip().split()[1:]]
                     n_vibs = len(vibs)
-                    for mode, dis in zip(normal_frequencies[-n_vibs:], vibs):
+                    for mode, dis in zip(normal_frequencies[-n_vibs:], vibs, strict=False):
                         mode[1].append(dis)
 
             elif parse_projected_freq:
@@ -778,7 +778,7 @@ class NwOutput:
                 else:
                     vibs = [float(vib) for vib in line.strip().split()[1:]]
                     n_vibs = len(vibs)
-                    for mode, dis in zip(frequencies[-n_vibs:], vibs):
+                    for mode, dis in zip(frequencies[-n_vibs:], vibs, strict=False):
                         mode[1].append(dis)
 
             elif parse_bset:
@@ -787,7 +787,7 @@ class NwOutput:
                 else:
                     tokens = line.split()
                     if tokens[0] != "Tag" and not re.match(r"-+", tokens[0]):
-                        basis_set[tokens[0]] = dict(zip(bset_header[1:], tokens[1:]))
+                        basis_set[tokens[0]] = dict(zip(bset_header[1:], tokens[1:], strict=False))
                     elif tokens[0] == "Tag":
                         bset_header = tokens
                         bset_header.pop(4)
@@ -895,10 +895,10 @@ class NwOutput:
 
         if frequencies:
             for _freq, mode in frequencies:
-                mode[:] = zip(*[iter(mode)] * 3)
+                mode[:] = zip(*[iter(mode)] * 3, strict=False)
         if normal_frequencies:
             for _freq, mode in normal_frequencies:
-                mode[:] = zip(*[iter(mode)] * 3)
+                mode[:] = zip(*[iter(mode)] * 3, strict=False)
         if hessian:
             len_hess = len(hessian)
             for ii in range(len_hess):

--- a/src/pymatgen/io/openff.py
+++ b/src/pymatgen/io/openff.py
@@ -286,7 +286,7 @@ def create_openff_mol(
     Returns:
         tk.Molecule: The created OpenFF Molecule.
     """
-    if isinstance(geometry, (str, Path)):
+    if isinstance(geometry, str | Path):
         geometry = pymatgen.core.Molecule.from_file(str(geometry))
 
     if partial_charges is not None:

--- a/src/pymatgen/io/optimade.py
+++ b/src/pymatgen/io/optimade.py
@@ -56,7 +56,7 @@ def _pymatgen_species(
             chemical_symbols.append(symbol)
             concentration.append(current_species["concentration"][index])
 
-        pymatgen_species.append(dict(zip(chemical_symbols, concentration)))
+        pymatgen_species.append(dict(zip(chemical_symbols, concentration, strict=False)))
 
     return pymatgen_species
 
@@ -95,12 +95,12 @@ def _optimade_reduce_or_anonymize_formula(formula: str, alphabetize: bool = True
 
     if anonymize:
         numbers = sorted(numbers, reverse=True)
-        species = [s for _, s in zip(numbers, _optimade_anonymous_element_generator())]
+        species = [s for _, s in zip(numbers, _optimade_anonymous_element_generator(), strict=False)]
 
     elif alphabetize:
-        species, numbers = zip(*sorted(zip(species, numbers)))  # type: ignore[assignment]
+        species, numbers = zip(*sorted(zip(species, numbers, strict=False)), strict=False)  # type: ignore[assignment]
 
-    return "".join(f"{s}{n if n != 1 else ''}" for n, s in zip(numbers, species))
+    return "".join(f"{s}{n if n != 1 else ''}" for n, s in zip(numbers, species, strict=False))
 
 
 class OptimadeStructureAdapter:

--- a/src/pymatgen/io/packmol.py
+++ b/src/pymatgen/io/packmol.py
@@ -205,7 +205,7 @@ class PackmolBoxGen(InputGenerator):
             box_list = f"0.0 0.0 0.0 {box_length:.1f} {box_length:.1f} {box_length:.1f}"
 
         for dct in molecules:
-            if isinstance(dct["coords"], (str, Path)):
+            if isinstance(dct["coords"], str | Path):
                 mol = Molecule.from_file(dct["coords"])
             elif isinstance(dct["coords"], Molecule):
                 mol = dct["coords"]

--- a/src/pymatgen/io/phonopy.py
+++ b/src/pymatgen/io/phonopy.py
@@ -224,7 +224,7 @@ def get_complete_ph_dos(partial_dos_path, phonopy_yaml_path):
     total_dos = PhononDos(arr[0], arr[1:].sum(axis=0))
 
     partial_doses = {}
-    for site, p_dos in zip(structure, arr[1:]):
+    for site, p_dos in zip(structure, arr[1:], strict=False):
         partial_doses[site] = p_dos.tolist()
 
     return CompletePhononDos(structure, total_dos, partial_doses)
@@ -330,7 +330,7 @@ def get_phonon_dos_from_fc(
     phonon.run_projected_dos(freq_min=freq_min, freq_max=freq_max, freq_pitch=freq_pitch)
 
     dos_raw = phonon.projected_dos.get_partial_dos()
-    p_doses = dict(zip(structure, dos_raw[1]))
+    p_doses = dict(zip(structure, dos_raw[1], strict=False))
 
     total_dos = PhononDos(dos_raw[0], dos_raw[1].sum(axis=0))
     return CompletePhononDos(structure, total_dos, p_doses)
@@ -403,7 +403,7 @@ def get_phonon_band_structure_symm_line_from_fc(
     phonon.run_qpoints(kpoints)
     frequencies = phonon.qpoints.get_frequencies().T
 
-    labels_dict = {a: k for a, k in zip(labels, kpoints) if a != ""}
+    labels_dict = {a: k for a, k in zip(labels, kpoints, strict=False) if a != ""}
 
     return PhononBandStructureSymmLine(kpoints, frequencies, structure.lattice, labels_dict=labels_dict)
 

--- a/src/pymatgen/io/qchem/inputs.py
+++ b/src/pymatgen/io/qchem/inputs.py
@@ -690,7 +690,11 @@ class QCInput(InputFile):
                         raise ValueError("Invalid CDFT constraint type!")
 
                 for coef, first, last, type_string in zip(
-                    constraint["coefficients"], constraint["first_atoms"], constraint["last_atoms"], type_strings
+                    constraint["coefficients"],
+                    constraint["first_atoms"],
+                    constraint["last_atoms"],
+                    type_strings,
+                    strict=False,
                 ):
                     if type_string != "":
                         cdft_list.append(f"   {coef} {first} {last} {type_string}")
@@ -844,7 +848,7 @@ class QCInput(InputFile):
         matches = read_pattern(string, patterns)
 
         mol_table = read_table_pattern(string, header_pattern=header, row_pattern=row, footer_pattern=footer)
-        for match, table in zip(matches.get("charge_spin"), mol_table):
+        for match, table in zip(matches.get("charge_spin"), mol_table, strict=False):
             charge = int(match[0])
             spin = int(match[1])
             species = [val[0] for val in table]

--- a/src/pymatgen/io/qchem/outputs.py
+++ b/src/pymatgen/io/qchem/outputs.py
@@ -1905,7 +1905,7 @@ class QCOutput(MSONable):
         )
 
         self.data["cdft_constraints_multipliers"] = []
-        for const, multip in zip(temp_dict.get("constraint", []), temp_dict.get("multiplier", [])):
+        for const, multip in zip(temp_dict.get("constraint", []), temp_dict.get("multiplier", []), strict=False):
             entry = {"index": int(const[0]), "constraint": float(const[1]), "multiplier": float(multip[0])}
             self.data["cdft_constraints_multipliers"].append(entry)
 
@@ -1979,8 +1979,8 @@ class QCOutput(MSONable):
             spins_2 = [int(r.strip()) for r in temp_dict["states"][0][3].strip().split("\n")]
 
             self.data["almo_coupling_states"] = [
-                [[i, j] for i, j in zip(charges_1, spins_1)],
-                [[i, j] for i, j in zip(charges_2, spins_2)],
+                [[i, j] for i, j in zip(charges_1, spins_1, strict=False)],
+                [[i, j] for i, j in zip(charges_2, spins_2, strict=False)],
             ]
 
         # State energies

--- a/src/pymatgen/io/qchem/utils.py
+++ b/src/pymatgen/io/qchem/utils.py
@@ -146,7 +146,7 @@ def lower_and_check_unique(dict_to_check):
 
         if isinstance(val, str):
             val = val.lower()
-        elif isinstance(val, (int, float)):
+        elif isinstance(val, int | float):
             # convert all numeric keys to str
             val = str(val)
         else:

--- a/src/pymatgen/io/res.py
+++ b/src/pymatgen/io/res.py
@@ -23,9 +23,9 @@ from pymatgen.entries.computed_entries import ComputedStructureEntry
 from pymatgen.io.core import ParseError
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Callable, Iterator
     from pathlib import Path
-    from typing import Any, Callable, Literal
+    from typing import Any, Literal
 
     from typing_extensions import Self
 

--- a/src/pymatgen/io/shengbte.py
+++ b/src/pymatgen/io/shengbte.py
@@ -111,7 +111,7 @@ class Control(MSONable, dict):
 
         self["ngrid"] = ngrid
 
-        if isinstance(temperature, (int, float)):
+        if isinstance(temperature, int | float):
             self["t"] = temperature
 
         elif isinstance(temperature, dict):
@@ -213,7 +213,7 @@ class Control(MSONable, dict):
         elements = list(map(str, structure.elements))
 
         unique_nums = np.unique(structure.atomic_numbers)
-        types_dict = dict(zip(unique_nums, range(len(unique_nums))))
+        types_dict = dict(zip(unique_nums, range(len(unique_nums)), strict=False))
         types = [types_dict[i] + 1 for i in structure.atomic_numbers]
 
         control_dict = {
@@ -250,7 +250,7 @@ class Control(MSONable, dict):
 
         unique_elements = self["elements"]
         n_unique_elements = len(unique_elements)
-        element_map = dict(zip(range(1, n_unique_elements + 1), unique_elements))
+        element_map = dict(zip(range(1, n_unique_elements + 1), unique_elements, strict=False))
         species = [element_map[i] for i in self["types"]]
 
         cell = np.array(self["lattvec"])

--- a/src/pymatgen/io/vasp/incar_parameters.json
+++ b/src/pymatgen/io/vasp/incar_parameters.json
@@ -650,7 +650,7 @@
     "type": "bool"
  },
  "LREAL": {
-   "type": "(bool, str)",
+   "type": "bool | str",
    "values": [
       false,
       true,

--- a/src/pymatgen/io/vasp/inputs.py
+++ b/src/pymatgen/io/vasp/inputs.py
@@ -715,7 +715,7 @@ class Incar(dict, MSONable):
         if params is not None:
             # If INCAR contains vector-like MAGMOMS given as a list
             # of floats, convert to a list of lists
-            if (params.get("MAGMOM") and isinstance(params["MAGMOM"][0], (int, float))) and (
+            if (params.get("MAGMOM") and isinstance(params["MAGMOM"][0], int | float)) and (
                 params.get("LSORBIT") or params.get("LNONCOLLINEAR")
             ):
                 val = []
@@ -790,7 +790,7 @@ class Incar(dict, MSONable):
             if key == "MAGMOM" and isinstance(self[key], list):
                 value = []
 
-                if isinstance(self[key][0], (list, Magmom)) and (self.get("LSORBIT") or self.get("LNONCOLLINEAR")):
+                if isinstance(self[key][0], list | Magmom) and (self.get("LSORBIT") or self.get("LNONCOLLINEAR")):
                     value.append(" ".join(str(i) for j in self[key] for i in j))
                 elif self.get("LSORBIT") or self.get("LNONCOLLINEAR"):
                     for _key, group in itertools.groupby(self[key]):
@@ -1182,10 +1182,10 @@ class Kpoints(MSONable):
     @property
     def kpts(self) -> list[Kpoint]:
         """A sequence of Kpoints, where each Kpoint is a tuple of 3 or 1."""
-        if all(isinstance(kpt, (list, tuple, np.ndarray)) and len(kpt) in {1, 3} for kpt in self._kpts):
+        if all(isinstance(kpt, list | tuple | np.ndarray) and len(kpt) in {1, 3} for kpt in self._kpts):
             return list(map(tuple, self._kpts))  # type: ignore[arg-type]
 
-        if all(isinstance(point, (int, float)) for point in self._kpts) and len(self._kpts) == 3:
+        if all(isinstance(point, int | float) for point in self._kpts) and len(self._kpts) == 3:
             return [cast(Kpoint, tuple(self._kpts))]
 
         raise ValueError(f"Invalid Kpoint {self._kpts}.")
@@ -2043,17 +2043,17 @@ class PotcarSingle:
             if k in {"nentries", "Orbitals", "SHA256", "COPYR"}:
                 continue
             hash_str += f"{k}"
-            if isinstance(v, (bool, int)):
+            if isinstance(v, bool | int):
                 hash_str += f"{v}"
             elif isinstance(v, float):
                 hash_str += f"{v:.3f}"
-            elif isinstance(v, (tuple, list)):
+            elif isinstance(v, tuple | list):
                 for item in v:
                     if isinstance(item, float):
                         hash_str += f"{item:.3f}"
-                    elif isinstance(item, (Orbital, OrbitalDescription)):
+                    elif isinstance(item, Orbital | OrbitalDescription):
                         for item_v in item:
-                            if isinstance(item_v, (int, str)):
+                            if isinstance(item_v, int | str):
                                 hash_str += f"{item_v}"
                             elif isinstance(item_v, float):
                                 hash_str += f"{item_v:.3f}"
@@ -2158,7 +2158,7 @@ class PotcarSingle:
                 parsed_val = parse_fortran_style_str(raw_val)
                 if isinstance(parsed_val, str):
                     tmp_str += parsed_val.strip()
-                elif isinstance(parsed_val, (float, int)):
+                elif isinstance(parsed_val, float | int):
                     psp_vals.append(parsed_val)
             if len(tmp_str) > 0:
                 psp_keys.append(tmp_str.lower())
@@ -2169,10 +2169,10 @@ class PotcarSingle:
             if isinstance(val, bool):
                 # has to come first since bools are also ints
                 keyword_vals.append(1.0 if val else 0.0)
-            elif isinstance(val, (float, int)):
+            elif isinstance(val, float | int):
                 keyword_vals.append(val)
             elif hasattr(val, "__len__"):
-                keyword_vals += [num for num in val if isinstance(num, (float, int))]
+                keyword_vals += [num for num in val if isinstance(num, float | int)]
 
         def data_stats(data_list: Sequence) -> dict:
             """Used for hash-less and therefore less brittle POTCAR validity checking."""

--- a/src/pymatgen/io/vasp/sets.py
+++ b/src/pymatgen/io/vasp/sets.py
@@ -57,7 +57,8 @@ from pymatgen.util.due import Doi, due
 from pymatgen.util.typing import Kpoint
 
 if TYPE_CHECKING:
-    from typing import Callable, Literal, Union
+    from collections.abc import Callable
+    from typing import Literal, Union
 
     from typing_extensions import Self
 
@@ -300,10 +301,10 @@ class VaspInputSet(InputGenerator, abc.ABC):
         else:
             self.structure = self.structure
 
-        if isinstance(self.prev_incar, (Path, str)):
+        if isinstance(self.prev_incar, Path | str):
             self.prev_incar = Incar.from_file(self.prev_incar)
 
-        if isinstance(self.prev_kpoints, (Path, str)):
+        if isinstance(self.prev_kpoints, Path | str):
             self.prev_kpoints = Kpoints.from_file(self.prev_kpoints)
 
         self.prev_vasprun: Vasprun | None = None
@@ -518,7 +519,7 @@ class VaspInputSet(InputGenerator, abc.ABC):
         prev_incar: dict[str, Any] = {}
         if self.inherit_incar is True and self.prev_incar:
             prev_incar = cast(dict[str, Any], self.prev_incar)
-        elif isinstance(self.inherit_incar, (list, tuple)) and self.prev_incar:
+        elif isinstance(self.inherit_incar, list | tuple) and self.prev_incar:
             prev_incar = {
                 k: cast(dict[str, Any], self.prev_incar)[k] for k in self.inherit_incar if k in self.prev_incar
             }
@@ -584,7 +585,7 @@ class VaspInputSet(InputGenerator, abc.ABC):
                         # Else, use fallback LDAU value if it exists
                     else:
                         incar[key] = [
-                            setting.get(sym, 0) if isinstance(setting.get(sym, 0), (float, int)) else 0
+                            setting.get(sym, 0) if isinstance(setting.get(sym, 0), float | int) else 0
                             for sym in poscar.site_symbols
                         ]
 
@@ -2960,7 +2961,7 @@ def get_valid_magmom_struct(
         for site in structure:
             if "magmom" not in site.properties or site.properties["magmom"] is None:
                 pass
-            elif isinstance(site.properties["magmom"], (float, int)):
+            elif isinstance(site.properties["magmom"], float | int):
                 if mode == "v":
                     raise TypeError("Magmom type conflict")
                 mode = "s"

--- a/src/pymatgen/io/vasp/sets.py
+++ b/src/pymatgen/io/vasp/sets.py
@@ -58,15 +58,15 @@ from pymatgen.util.typing import Kpoint
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-    from typing import Literal, Union
+    from typing import Literal
 
     from typing_extensions import Self
 
     from pymatgen.util.typing import PathLike, Tuple3Ints, Vector3D
 
-    UserPotcarFunctional = Union[
-        Literal["PBE", "PBE_52", "PBE_54", "PBE_64", "LDA", "LDA_52", "LDA_54", "PW91", "LDA_US", "PW91_US"], None
-    ]
+    UserPotcarFunctional = (
+        Literal["PBE", "PBE_52", "PBE_54", "PBE_64", "LDA", "LDA_52", "LDA_54", "PW91", "LDA_US", "PW91_US"] | None
+    )
 
 MODULE_DIR = os.path.dirname(__file__)
 

--- a/src/pymatgen/io/xcrysden.py
+++ b/src/pymatgen/io/xcrysden.py
@@ -42,7 +42,7 @@ class XSF:
         cart_coords = self.structure.cart_coords
         lines.extend(("# Cartesian coordinates in Angstrom.", "PRIMCOORD", f" {len(cart_coords)} 1"))
 
-        for site, coord in zip(self.structure, cart_coords):
+        for site, coord in zip(self.structure, cart_coords, strict=False):
             sp = site.specie.symbol if atom_symbol else f"{site.specie.Z}"
             x, y, z = coord
             lines.append(f"{sp} {x:20.14f} {y:20.14f} {z:20.14f}")

--- a/src/pymatgen/phonon/dos.py
+++ b/src/pymatgen/phonon/dos.py
@@ -509,17 +509,15 @@ class PhononDos(MSONable):
             metric (Literal): Metric used to compute similarity default is "tanimoto".
 
         Raises:
-            ValueError: If metric other than tanimoto, wasserstein and "cosine-sim" is requested.
+            ValueError: If metric other than "tanimoto", "wasserstein" and "cosine-sim" is requested.
             ValueError: If normalize is set to True along with the metric.
 
         Returns:
             float: Similarity index given by the dot product
         """
-        if metric not in ["tanimoto", "wasserstein", "cosine-sim"]:
-            raise ValueError(
-                "Requested metric not implemented. Currently implemented metrics are tanimoto, "
-                "wasserstien and cosine-sim."
-            )
+        valid_metrics = ("tanimoto", "wasserstein", "cosine-sim")
+        if metric not in valid_metrics:
+            raise ValueError(f"Invalid {metric=}, choose from {valid_metrics}.")
 
         fp1_dict = CompletePhononDos.fp_to_dict(fp1) if not isinstance(fp1, dict) else fp1
 

--- a/src/pymatgen/phonon/dos.py
+++ b/src/pymatgen/phonon/dos.py
@@ -63,7 +63,7 @@ class PhononDos(MSONable):
         Returns:
             Sum of the two DOSs.
         """
-        if isinstance(other, (int, float)):
+        if isinstance(other, int | float):
             return PhononDos(self.frequencies, self.densities + other)
         if not all(np.equal(self.frequencies, other.frequencies)):
             raise ValueError("Frequencies of both DOS are not compatible!")
@@ -462,7 +462,7 @@ class PhononDos(MSONable):
 
         dos_rebin = np.zeros(freq.shape)
 
-        for ii, e1, e2 in zip(range(len(freq)), freq_bounds[:-1], freq_bounds[1:]):
+        for ii, e1, e2 in zip(range(len(freq)), freq_bounds[:-1], freq_bounds[1:], strict=False):
             inds = np.where((frequencies >= e1) & (frequencies < e2))
             dos_rebin[ii] = np.sum(densities[inds])
         if normalize:  # scale DOS bins to make area under histogram equal 1
@@ -621,7 +621,7 @@ class CompletePhononDos(PhononDos):
         """Get CompleteDos object from dict representation."""
         total_dos = PhononDos.from_dict(dct)
         struct = Structure.from_dict(dct["structure"])
-        ph_doses = dict(zip(struct, dct["pdos"]))
+        ph_doses = dict(zip(struct, dct["pdos"], strict=False))
 
         return cls(struct, total_dos, ph_doses)
 

--- a/src/pymatgen/phonon/plotter.py
+++ b/src/pymatgen/phonon/plotter.py
@@ -19,9 +19,9 @@ from pymatgen.phonon.gruneisen import GruneisenPhononBandStructureSymmLine
 from pymatgen.util.plotting import add_fig_kwargs, get_ax_fig, pretty_plot
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Callable, Sequence
     from os import PathLike
-    from typing import Any, Callable, Literal
+    from typing import Any, Literal
 
     from matplotlib.axes import Axes
     from matplotlib.figure import Figure
@@ -189,7 +189,7 @@ class PhononDosPlotter:
         all_frequencies.reverse()
         all_pts = []
         colors = ("blue", "red", "green", "orange", "purple", "brown", "pink", "gray", "olive")
-        for idx, (key, frequencies, densities) in enumerate(zip(keys, all_frequencies, all_densities)):
+        for idx, (key, frequencies, densities) in enumerate(zip(keys, all_frequencies, all_densities, strict=False)):
             color = self._doses[key].get("color", colors[idx % n_colors])
             linewidth = self._doses[key].get("linewidth", 3)
             kwargs = {
@@ -197,7 +197,7 @@ class PhononDosPlotter:
                 for key, val in self._doses[key].items()
                 if key not in ["frequencies", "densities", "color", "linewidth"]
             }
-            all_pts.extend(list(zip(frequencies, densities)))
+            all_pts.extend(list(zip(frequencies, densities, strict=False)))
             if invert_axes:
                 xs, ys = densities, frequencies
             else:
@@ -313,7 +313,7 @@ class PhononBSPlotter:
         ticks = self.get_ticks()
 
         # zip to sanitize, only plot the uniq values
-        if ticks_labels := list(zip(*zip(ticks["distance"], ticks["label"]))):
+        if ticks_labels := list(zip(*zip(ticks["distance"], ticks["label"], strict=False), strict=False)):
             ax.set_xticks(ticks_labels[0])
             ax.set_xticklabels(ticks_labels[1])
 
@@ -374,7 +374,7 @@ class PhononBSPlotter:
 
         data = self.bs_plot_data()
         kwargs.setdefault("color", "blue")
-        for dists, freqs in zip(data["distances"], data["frequency"]):
+        for dists, freqs in zip(data["distances"], data["frequency"], strict=False):
             for idx in range(self.n_bands):
                 ys = [freqs[idx][j] * u.factor for j in range(len(dists))]
                 ax.plot(dists, ys, **kwargs)
@@ -699,7 +699,7 @@ class PhononBSPlotter:
         color_self = ax.lines[0].get_color()
         ax.plot([], [], label=self._label or self_label, linewidth=2 * line_width, color=color_self)
         linestyle = other_kwargs.get("linestyle", "-")
-        for color_other, label_other in zip(colors_other, other_plotter):
+        for color_other, label_other in zip(colors_other, other_plotter, strict=False):
             ax.plot([], [], label=label_other, linewidth=2 * line_width, color=color_other, linestyle=linestyle)
             ax.legend(**legend_kwargs)
 
@@ -964,7 +964,7 @@ class GruneisenPlotter:
         ax.set_ylabel(r"$\mathrm{Grüneisen\ parameter}$")
 
         n_points = len(ys) - 1
-        for idx, (xi, yi) in enumerate(zip(xs, ys)):
+        for idx, (xi, yi) in enumerate(zip(xs, ys, strict=False)):
             color = (1.0 / n_points * idx, 0, 1.0 / n_points * (n_points - idx))
 
             ax.plot(xi, yi, marker, color=color, markersize=markersize)
@@ -1090,7 +1090,9 @@ class GruneisenPhononBSPlotter(PhononBSPlotter):
         )
 
         sc = None
-        for (dists_inx, dists), (_, freqs) in zip(enumerate(data["distances"]), enumerate(data["frequency"])):
+        for (dists_inx, dists), (_, freqs) in zip(
+            enumerate(data["distances"]), enumerate(data["frequency"]), strict=False
+        ):
             for band_idx in range(self.n_bands):
                 if plot_ph_bs_with_gruneisen:
                     ys = [freqs[band_idx][j] * u.factor for j in range(len(dists))]

--- a/src/pymatgen/phonon/thermal_displacements.py
+++ b/src/pymatgen/phonon/thermal_displacements.py
@@ -229,7 +229,7 @@ class ThermalDisplacementMatrices(MSONable):
             file.write("_atom_site_aniso_U_12\n")
             file.write(f"# Additional Data for U_Aniso: {self.temperature}\n")
 
-            for idx, (site, matrix) in enumerate(zip(self.structure, self.Ucif)):
+            for idx, (site, matrix) in enumerate(zip(self.structure, self.Ucif, strict=False)):
                 file.write(
                     f"{site.specie.symbol}{idx} {matrix[0][0]} {matrix[1][1]} {matrix[2][2]}"
                     f" {matrix[1][2]} {matrix[0][2]} {matrix[0][1]}\n"
@@ -267,7 +267,7 @@ class ThermalDisplacementMatrices(MSONable):
               Vectors are given in Cartesian coordinates
         """
         # compare the atoms string at least
-        for spec1, spec2 in zip(self.structure.species, other.structure.species):
+        for spec1, spec2 in zip(self.structure.species, other.structure.species, strict=False):
             if spec1 != spec2:
                 raise ValueError(
                     "Species in both structures are not the same! "
@@ -280,7 +280,9 @@ class ThermalDisplacementMatrices(MSONable):
 
         results = []
         for self_Ucart, other_Ucart in zip(
-            self.thermal_displacement_matrix_cart_matrixform, other.thermal_displacement_matrix_cart_matrixform
+            self.thermal_displacement_matrix_cart_matrixform,
+            other.thermal_displacement_matrix_cart_matrixform,
+            strict=False,
         ):
             result_dict = {}
 
@@ -361,7 +363,7 @@ class ThermalDisplacementMatrices(MSONable):
             # print all U11s (make sure they are in the correct order)
             counter = 1
             # VESTA order: _U_12    _U_13    _atom_site_aniso_U_23
-            for atom_therm, site in zip(matrix_cif, structure):
+            for atom_therm, site in zip(matrix_cif, structure, strict=False):
                 file.write(
                     f"{counter} {site.species_string}{counter} {atom_therm[0]} "
                     f"{atom_therm[1]} {atom_therm[2]} {atom_therm[5]} {atom_therm[4]} {atom_therm[3]}\n"

--- a/src/pymatgen/symmetry/analyzer.py
+++ b/src/pymatgen/symmetry/analyzer.py
@@ -296,7 +296,7 @@ class SpacegroupAnalyzer:
         sym_ops = []
         mat = self._structure.lattice.matrix.T
         inv_mat = np.linalg.inv(mat)
-        for rot, trans in zip(rotation, translation):
+        for rot, trans in zip(rotation, translation, strict=False):
             if cartesian:
                 rot = np.dot(mat, np.dot(rot, inv_mat))
                 trans = np.dot(trans, self._structure.lattice.matrix)
@@ -429,7 +429,7 @@ class SpacegroupAnalyzer:
         mapping, grid = spglib.get_ir_reciprocal_mesh(np.array(mesh), self._cell, is_shift=shift, symprec=self._symprec)
 
         results = []
-        for idx, count in zip(*np.unique(mapping, return_counts=True)):
+        for idx, count in zip(*np.unique(mapping, return_counts=True), strict=False):
             results.append(((grid[idx] + shift * (0.5, 0.5, 0.5)) / mesh, count))
         return results
 
@@ -1380,7 +1380,7 @@ class PointGroupAnalyzer:
 
         for index in get_clustered_indices():
             sites = self.centered_mol.cart_coords[index]
-            for i, reference in zip(index, sites):
+            for i, reference in zip(index, sites, strict=False):
                 for op in symm_ops:
                     rotated = np.dot(op, sites.T).T
                     matched_indices = find_in_coord_list(rotated, reference, self.tol)

--- a/src/pymatgen/symmetry/groups.py
+++ b/src/pymatgen/symmetry/groups.py
@@ -468,7 +468,7 @@ class SpaceGroup(SymmetryGroup):
         crys_system = self.crystal_system
 
         def check(param, ref, tolerance):
-            return all(abs(i - j) < tolerance for i, j in zip(param, ref) if j is not None)
+            return all(abs(i - j) < tolerance for i, j in zip(param, ref, strict=False) if j is not None)
 
         if crys_system == "cubic":
             a = abc[0]

--- a/src/pymatgen/symmetry/kpath.py
+++ b/src/pymatgen/symmetry/kpath.py
@@ -894,7 +894,7 @@ class KPathSeek(KPathBase):
 
         if not system_is_tri:
             warn("Non-zero 'magmom' data will be used to define unique atoms in the cell.")
-            site_data = zip(species, [tuple(vec) for vec in sp["magmom"]])  # type: ignore[assignment]
+            site_data = zip(species, [tuple(vec) for vec in sp["magmom"]], strict=False)  # type: ignore[assignment]
 
         unique_species: list[SpeciesLike] = []
         numbers = []
@@ -1437,7 +1437,7 @@ class KPathLatimerMunro(KPathBase):
         return key_points, bz_as_key_point_inds, face_center_inds
 
     def _get_key_point_orbits(self, key_points):
-        key_points_copy = dict(zip(range(len(key_points) - 1), key_points[0 : len(key_points) - 1]))
+        key_points_copy = dict(zip(range(len(key_points) - 1), key_points[0 : len(key_points) - 1], strict=False))
         # gamma not equivalent to any in BZ and is last point added to
         # key_points
         key_points_inds_orbits = []
@@ -1507,7 +1507,7 @@ class KPathLatimerMunro(KPathBase):
         return key_lines
 
     def _get_key_line_orbits(self, key_points, key_lines, key_points_inds_orbits):
-        key_lines_copy = dict(zip(range(len(key_lines)), key_lines))
+        key_lines_copy = dict(zip(range(len(key_lines)), key_lines, strict=False))
         key_lines_inds_orbits = []
 
         i = 0

--- a/src/pymatgen/symmetry/maggroups.py
+++ b/src/pymatgen/symmetry/maggroups.py
@@ -403,7 +403,7 @@ class MagneticSpaceGroup(SymmetryGroup):
         crys_system = self.crystal_system
 
         def check(param, ref, tolerance):
-            return all(abs(i - j) < tolerance for i, j in zip(param, ref) if j is not None)
+            return all(abs(i - j) < tolerance for i, j in zip(param, ref, strict=False) if j is not None)
 
         if crys_system == "cubic":
             a = abc[0]

--- a/src/pymatgen/transformations/advanced_transformations.py
+++ b/src/pymatgen/transformations/advanced_transformations.py
@@ -46,8 +46,8 @@ except ImportError:
     hiphive = None
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Sequence
-    from typing import Any, Callable, Literal
+    from collections.abc import Callable, Iterable, Sequence
+    from typing import Any, Literal
 
 
 __author__ = "Shyue Ping Ong, Stephen Dacek, Anubhav Jain, Matthew Horton, Alex Ganose"
@@ -721,7 +721,7 @@ class MagOrderingTransformation(AbstractTransformation):
                 DummySpecies(symbol, spin=Spin.up): constraint.order_parameter,
                 DummySpecies(symbol, spin=Spin.down): 1 - constraint.order_parameter,
             }
-            for symbol, constraint in zip(dummy_species_symbols, order_parameters)
+            for symbol, constraint in zip(dummy_species_symbols, order_parameters, strict=False)
         ]
 
         for site in dummy_struct:

--- a/src/pymatgen/transformations/site_transformations.py
+++ b/src/pymatgen/transformations/site_transformations.py
@@ -378,7 +378,7 @@ class PartialRemoveSitesTransformation(AbstractTransformation):
     def _enumerate_ordering(self, structure: Structure):
         # Generate the disordered structure first.
         struct = structure.copy()
-        for indices, fraction in zip(self.indices, self.fractions):
+        for indices, fraction in zip(self.indices, self.fractions, strict=False):
             for ind in indices:
                 new_sp = {sp: occu * fraction for sp, occu in structure[ind].species.items()}
                 struct[ind] = new_sp
@@ -409,7 +409,7 @@ class PartialRemoveSitesTransformation(AbstractTransformation):
         """
         num_remove_dict = {}
         total_combos = 0
-        for idx, frac in zip(self.indices, self.fractions):
+        for idx, frac in zip(self.indices, self.fractions, strict=False):
             n_to_remove = len(idx) * frac
             if abs(n_to_remove - int(round(n_to_remove))) > 1e-3:
                 raise ValueError("Fraction to remove must be consistent with integer amounts in structure.")

--- a/src/pymatgen/transformations/standard_transformations.py
+++ b/src/pymatgen/transformations/standard_transformations.py
@@ -277,7 +277,7 @@ class SubstitutionTransformation(AbstractTransformation):
         self.species_map = species_map
         self._species_map = dict(species_map)
         for key, val in self._species_map.items():
-            if isinstance(val, (tuple, list)):
+            if isinstance(val, tuple | list):
                 self._species_map[key] = dict(val)  # type: ignore[assignment]
 
     def apply_transformation(self, structure: Structure) -> Structure:

--- a/src/pymatgen/util/coord.py
+++ b/src/pymatgen/util/coord.py
@@ -133,7 +133,7 @@ def get_linear_interpolated_value(x_values: ArrayLike, y_values: ArrayLike, x: f
     Returns:
         Value at x.
     """
-    arr = np.array(sorted(zip(x_values, y_values), key=lambda d: d[0]))
+    arr = np.array(sorted(zip(x_values, y_values, strict=False), key=lambda d: d[0]))
 
     indices = np.where(arr[:, 0] >= x)[0]
 

--- a/src/pymatgen/util/plotting.py
+++ b/src/pymatgen/util/plotting.py
@@ -676,7 +676,7 @@ def add_fig_kwargs(func):
             tags = ascii_letters
             if len(fig.axes) > len(tags):
                 tags = (1 + len(ascii_letters) // len(fig.axes)) * ascii_letters
-            for ax, tag in zip(fig.axes, tags):
+            for ax, tag in zip(fig.axes, tags, strict=False):
                 ax.annotate(f"({tag})", xy=(0.05, 0.95), xycoords="axes fraction")
 
         if tight_layout:

--- a/src/pymatgen/util/testing/__init__.py
+++ b/src/pymatgen/util/testing/__init__.py
@@ -88,7 +88,7 @@ class PymatgenTest(TestCase):
         """
         # Build a list even when we receive a single object.
         got_single_object = False
-        if not isinstance(objects, (list, tuple)):
+        if not isinstance(objects, list | tuple):
             got_single_object = True
             objects = [objects]
 
@@ -117,7 +117,7 @@ class PymatgenTest(TestCase):
 
             # Test for equality
             if test_eq:
-                for orig, unpickled in zip(objects, unpickled_objs):
+                for orig, unpickled in zip(objects, unpickled_objs, strict=False):
                     assert (
                         orig == unpickled
                     ), f"Unpickled and original objects are unequal for {protocol=}\n{orig=}\n{unpickled=}"

--- a/src/pymatgen/util/testing/aims.py
+++ b/src/pymatgen/util/testing/aims.py
@@ -48,7 +48,7 @@ def compare_files(test_name: str, work_dir: Path, ref_dir: Path) -> None:
         with gzip.open(f"{ref_dir / test_name / Path(file).name}.gz", "rt") as ref_file:
             ref_lines = [line.strip() for line in ref_file.readlines() if len(line.strip()) > 0 and line[0] != "#"]
 
-        for test_line, ref_line in zip(test_lines, ref_lines):
+        for test_line, ref_line in zip(test_lines, ref_lines, strict=False):
             if "output" in test_line and "band" in test_line:
                 assert check_band(test_line, ref_line)
             else:
@@ -68,7 +68,7 @@ def compare_files(test_name: str, work_dir: Path, ref_dir: Path) -> None:
     assert ref == check
 
     if check_output:
-        for ref_out, check_out in zip(ref_output, check_output):
+        for ref_out, check_out in zip(ref_output, check_output, strict=False):
             if "band" in check_out:
                 assert check_band(check_out, ref_out)
             else:
@@ -138,7 +138,7 @@ def compare_single_files(ref_file: str | Path, test_file: str | Path) -> None:
     with zopen(f"{ref_file}.gz", mode="rt") as rf:
         ref_lines = rf.readlines()[5:]
 
-    for test_line, ref_line in zip(test_lines, ref_lines):
+    for test_line, ref_line in zip(test_lines, ref_lines, strict=False):
         if "species_dir" in ref_line:
             continue
         if test_line.strip() != ref_line.strip():

--- a/src/pymatgen/util/typing.py
+++ b/src/pymatgen/util/typing.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from os import PathLike as OsPathLike
-from typing import TYPE_CHECKING, Any, Literal, Union
+from typing import TYPE_CHECKING, Any, Literal, TypeAlias, Union
 
 from numpy.typing import NDArray
 
@@ -22,26 +22,26 @@ if TYPE_CHECKING:  # needed to avoid circular imports
     from pymatgen.entries.exp_entries import ExpEntry
 
 # Commonly used composite types
-Tuple3Ints = tuple[int, int, int]
-Tuple3Floats = tuple[float, float, float]
+Tuple3Ints: TypeAlias = tuple[int, int, int]
+Tuple3Floats: TypeAlias = tuple[float, float, float]
 
-PathLike = str | OsPathLike
-PbcLike = tuple[bool, bool, bool]
+PathLike: TypeAlias = str | OsPathLike
+PbcLike: TypeAlias = tuple[bool, bool, bool]
 
 # Things that can be cast to a Spin
-SpinLike = Spin | Literal[-1, 1, "up", "down"]
+SpinLike: TypeAlias = Spin | Literal[-1, 1, "up", "down"]
 
 # Things that can be cast to a magnetic moment
-MagMomentLike = float | Sequence[float] | NDArray | Magmom
+MagMomentLike: TypeAlias = float | Sequence[float] | NDArray | Magmom
 
 # Things that can be cast to a Species-like object using get_el_sp
-SpeciesLike = str | Element | Species | DummySpecies
+SpeciesLike: TypeAlias = str | Element | Species | DummySpecies
 
 # Things that can be cast to a Composition
-CompositionLike = str | Element | Species | DummySpecies | dict | Composition
+CompositionLike: TypeAlias = str | Element | Species | DummySpecies | dict | Composition
 
 # Entry or any of its subclasses or dicts that can be unpacked into any of them
-EntryLike = Union[
+EntryLike: TypeAlias = Union[
     dict[str, Any],
     "Entry",
     "PDEntry",
@@ -54,16 +54,18 @@ EntryLike = Union[
     "GibbsComputedStructureEntry",
 ]
 
-Vector3D = Tuple3Floats
-Matrix3D = tuple[Vector3D, Vector3D, Vector3D]
+Vector3D: TypeAlias = Tuple3Floats
+Matrix3D: TypeAlias = tuple[Vector3D, Vector3D, Vector3D]
 
-SitePropsType = list[dict[Any, Sequence[Any]]] | dict[Any, Sequence[Any]]
+SitePropsType: TypeAlias = list[dict[Any, Sequence[Any]]] | dict[Any, Sequence[Any]]
 
 # Types specific to io.vasp
-Kpoint = (
-    Tuple3Ints | tuple[int] | Vector3D
-)  # tuple[int]: Automatic k-point mesh, Vector3D: Line-mode and explicit k-point mesh
+Kpoint: TypeAlias = (
+    Tuple3Ints
+    | tuple[int]  # Automatic k-point mesh
+    | Vector3D  # Line-mode and explicit k-point mesh
+)
 
 
 # Miller index
-MillerIndex = Tuple3Ints
+MillerIndex: TypeAlias = Tuple3Ints

--- a/src/pymatgen/util/typing.py
+++ b/src/pymatgen/util/typing.py
@@ -25,20 +25,20 @@ if TYPE_CHECKING:  # needed to avoid circular imports
 Tuple3Ints = tuple[int, int, int]
 Tuple3Floats = tuple[float, float, float]
 
-PathLike = Union[str, OsPathLike]
+PathLike = str | OsPathLike
 PbcLike = tuple[bool, bool, bool]
 
 # Things that can be cast to a Spin
-SpinLike = Union[Spin, Literal[-1, 1, "up", "down"]]
+SpinLike = Spin | Literal[-1, 1, "up", "down"]
 
 # Things that can be cast to a magnetic moment
-MagMomentLike = Union[float, Sequence[float], NDArray, Magmom]
+MagMomentLike = float | Sequence[float] | NDArray | Magmom
 
 # Things that can be cast to a Species-like object using get_el_sp
-SpeciesLike = Union[str, Element, Species, DummySpecies]
+SpeciesLike = str | Element | Species | DummySpecies
 
 # Things that can be cast to a Composition
-CompositionLike = Union[str, Element, Species, DummySpecies, dict, Composition]
+CompositionLike = str | Element | Species | DummySpecies | dict | Composition
 
 # Entry or any of its subclasses or dicts that can be unpacked into any of them
 EntryLike = Union[
@@ -57,14 +57,13 @@ EntryLike = Union[
 Vector3D = Tuple3Floats
 Matrix3D = tuple[Vector3D, Vector3D, Vector3D]
 
-SitePropsType = Union[list[dict[Any, Sequence[Any]]], dict[Any, Sequence[Any]]]
+SitePropsType = list[dict[Any, Sequence[Any]]] | dict[Any, Sequence[Any]]
 
 # Types specific to io.vasp
-Kpoint = Union[
-    Tuple3Ints,
-    tuple[int,],  # Automatic k-point mesh
-    Vector3D,  # Line-mode and explicit k-point mesh
-]
+Kpoint = (
+    Tuple3Ints | tuple[int] | Vector3D
+)  # tuple[int]: Automatic k-point mesh, Vector3D: Line-mode and explicit k-point mesh
+
 
 # Miller index
 MillerIndex = Tuple3Ints

--- a/tests/analysis/chemenv/coordination_environments/test_coordination_geometries.py
+++ b/tests/analysis/chemenv/coordination_environments/test_coordination_geometries.py
@@ -63,7 +63,7 @@ class TestCoordinationGeometries(PymatgenTest):
         cg_oct2 = CoordinationGeometry.from_dict(cg_oct.as_dict())
 
         assert cg_oct.central_site == approx(cg_oct2.central_site)
-        for p1, p2 in zip(cg_oct.points, cg_oct2.points):
+        for p1, p2 in zip(cg_oct.points, cg_oct2.points, strict=False):
             assert p1 == approx(p2)
         assert (
             str(cg_oct) == "Coordination geometry type : Octahedron (IUPAC: OC-6 || IUCr: [6o])\n"

--- a/tests/analysis/diffraction/test_xrd.py
+++ b/tests/analysis/diffraction/test_xrd.py
@@ -8,10 +8,6 @@ from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Structure
 from pymatgen.util.testing import PymatgenTest
 
-"""
-TODO: Modify unittest doc.
-"""
-
 __author__ = "Shyue Ping Ong"
 __copyright__ = "Copyright 2012, The Materials Project"
 __version__ = "0.1"

--- a/tests/analysis/elasticity/test_elastic.py
+++ b/tests/analysis/elasticity/test_elastic.py
@@ -422,7 +422,7 @@ class TestDiffFit(PymatgenTest):
         all_strains = [Strain.from_voigt(v).zeroed() for vec in vecs.values() for v in vec]
         rng.shuffle(all_strains)
         all_stresses = [Stress.from_voigt(rng.random(6)).zeroed() for _ in all_strains]
-        strain_dict = {k.tobytes(): v for k, v in zip(all_strains, all_stresses)}
+        strain_dict = {k.tobytes(): v for k, v in zip(all_strains, all_stresses, strict=False)}
         ss_dict = get_strain_state_dict(all_strains, all_stresses, add_eq=False)
         # Check length of ss_dict
         assert len(strain_inds) == len(ss_dict)
@@ -430,7 +430,7 @@ class TestDiffFit(PymatgenTest):
         assert set(strain_states) == set(ss_dict)
         for data in ss_dict.values():
             # Check correspondence of strains/stresses
-            for strain, stress in zip(data["strains"], data["stresses"]):
+            for strain, stress in zip(data["strains"], data["stresses"], strict=False):
                 assert_allclose(
                     Stress.from_voigt(stress),
                     strain_dict[Strain.from_voigt(strain).tobytes()],
@@ -472,9 +472,13 @@ class TestDiffFit(PymatgenTest):
 
     def test_fit(self):
         diff_fit(self.strains, self.pk_stresses, self.data_dict["eq_stress"])
-        reduced = [(e, pk) for e, pk in zip(self.strains, self.pk_stresses) if not (abs(abs(e) - 0.05) < 1e-10).any()]
+        reduced = [
+            (e, pk)
+            for e, pk in zip(self.strains, self.pk_stresses, strict=False)
+            if not (abs(abs(e) - 0.05) < 1e-10).any()
+        ]
         # Get reduced dataset
-        r_strains, r_pk_stresses = zip(*reduced)
+        r_strains, r_pk_stresses = zip(*reduced, strict=False)
         c2 = diff_fit(r_strains, r_pk_stresses, self.data_dict["eq_stress"], order=2)
         c2, c3, _c4 = diff_fit(r_strains, r_pk_stresses, self.data_dict["eq_stress"], order=4)
         c2, c3 = diff_fit(self.strains, self.pk_stresses, self.data_dict["eq_stress"], order=3)

--- a/tests/analysis/elasticity/test_strain.py
+++ b/tests/analysis/elasticity/test_strain.py
@@ -61,10 +61,10 @@ class TestDeformation(PymatgenTest):
         assert_allclose(strained_non.sites[1].coords, [3.8872306, 1.224e-6, 2.3516318], atol=1e-7)
 
         # Check convention for applying transformation
-        for vec, defo_vec in zip(self.structure.lattice.matrix, strained_non.lattice.matrix):
+        for vec, defo_vec in zip(self.structure.lattice.matrix, strained_non.lattice.matrix, strict=False):
             new_vec = np.dot(self.non_ind_defo, np.transpose(vec))
             assert_allclose(new_vec, defo_vec)
-        for coord, defo_coord in zip(self.structure.cart_coords, strained_non.cart_coords):
+        for coord, defo_coord in zip(self.structure.cart_coords, strained_non.cart_coords, strict=False):
             new_coord = np.dot(self.non_ind_defo, np.transpose(coord))
             assert_allclose(new_coord, defo_coord)
 

--- a/tests/analysis/magnetism/test_heisenberg.py
+++ b/tests/analysis/magnetism/test_heisenberg.py
@@ -26,7 +26,7 @@ class TestHeisenbergMapper(TestCase):
             ordered_structures = list(c["structure"])
             ordered_structures = [Structure.from_dict(d) for d in ordered_structures]
             epa = list(c["energy_per_atom"])
-            energies = [e * len(s) for (e, s) in zip(epa, ordered_structures)]
+            energies = [e * len(s) for (e, s) in zip(epa, ordered_structures, strict=False)]
 
             hm = HeisenbergMapper(ordered_structures, energies, cutoff=5.0, tol=0.02)
             cls.hms.append(hm)

--- a/tests/analysis/test_chempot_diagram.py
+++ b/tests/analysis/test_chempot_diagram.py
@@ -38,7 +38,7 @@ class TestChemicalPotentialDiagram(PymatgenTest):
 
         elems = [Element("Li"), Element("Fe"), Element("O")]
         energies = [-1.91301487, -6.5961471, -25.54966885]
-        correct_el_refs = dict(zip(elems, energies))
+        correct_el_refs = dict(zip(elems, energies, strict=False))
 
         assert el_refs == approx(correct_el_refs)
 
@@ -46,7 +46,7 @@ class TestChemicalPotentialDiagram(PymatgenTest):
         el_refs = {elem: entry.energy for elem, entry in self.cpd_ternary_formal.el_refs.items()}
         elems = [Element("Li"), Element("Fe"), Element("O")]
         energies = [0, 0, 0]
-        correct_el_refs = dict(zip(elems, energies))
+        correct_el_refs = dict(zip(elems, energies, strict=False))
         assert el_refs == approx(correct_el_refs)
 
     def test_border_hyperplanes(self):

--- a/tests/analysis/test_eos.py
+++ b/tests/analysis/test_eos.py
@@ -405,9 +405,8 @@ class TestEOS(PymatgenTest):
         assert_allclose(self.num_eos_fit.e0, -10.84749, atol=1e-3)
         assert_allclose(self.num_eos_fit.v0, 40.857201, atol=1e-1)
         assert_allclose(self.num_eos_fit.b0, 0.55, atol=1e-2)
-        # TODO: why were these tests commented out?
-        # assert_allclose(self.num_eos_fit.b0_GPa, 89.0370727, atol=1e-1)
-        # assert_allclose(self.num_eos_fit.b1, 4.344039, atol=1e-2)
+        assert_allclose(self.num_eos_fit.b0_GPa, 89.0370727, atol=1e-1)
+        assert_allclose(self.num_eos_fit.b1, 4.344039, atol=1e-2)
 
     def test_eos_func(self):
         # list vs np.array arguments

--- a/tests/analysis/test_interface_reactions.py
+++ b/tests/analysis/test_interface_reactions.py
@@ -335,7 +335,7 @@ class TestInterfaceReaction(TestCase):
             lst = list(ir.get_kinks())
             x_kink = [i[1] for i in lst]
             energy_kink = [i[2] for i in lst]
-            points = list(zip(x_kink, energy_kink))
+            points = list(zip(x_kink, energy_kink, strict=False))
             if len(points) >= 3:
                 # To test convexity of the plot, construct convex hull from
                 # the kinks and make sure
@@ -343,7 +343,7 @@ class TestInterfaceReaction(TestCase):
                 # 2. all points are on the convex hull.
                 relative_vectors_1 = [(x - x_kink[0], e - energy_kink[0]) for x, e in points]
                 relative_vectors_2 = [(x - x_kink[-1], e - energy_kink[-1]) for x, e in points]
-                relative_vectors = zip(relative_vectors_1, relative_vectors_2)
+                relative_vectors = zip(relative_vectors_1, relative_vectors_2, strict=False)
                 positions = [np.cross(v1, v2) for v1, v2 in relative_vectors]
                 assert np.all(np.array(positions) <= 0)
 
@@ -419,7 +419,7 @@ class TestInterfaceReaction(TestCase):
             (0.3333333, -3.333333),
             (0.3333333, -4.0),
         ]
-        for inter_react, expected in zip(self.irs, answer):
+        for inter_react, expected in zip(self.irs, answer, strict=False):
             assert_allclose(inter_react.minimum, expected, atol=1e-7)
 
     def test_get_no_mixing_energy(self):
@@ -438,7 +438,7 @@ class TestInterfaceReaction(TestCase):
             return lst[0][1], lst[1][1]
 
         result_info = [ir.get_no_mixing_energy() for ir in self.irs if ir.grand]
-        for ii, jj in zip(result_info, answer):
+        for ii, jj in zip(result_info, answer, strict=False):
             err_msg = f"get_no_mixing_energy: names get error, {name_lst(jj)} expected but gets {name_lst(ii)}"
             assert name_lst(ii) == name_lst(jj), err_msg
             assert_allclose(

--- a/tests/analysis/test_molecule_matcher.py
+++ b/tests/analysis/test_molecule_matcher.py
@@ -55,7 +55,7 @@ def perturb(mol, scale, seed):
     rng = np.random.default_rng(seed=seed)
 
     dV = rng.normal(scale=scale, size=(len(mol), 3))
-    for site, dv in zip(mol, dV):
+    for site, dv in zip(mol, dV, strict=False):
         site.coords += dv
 
 

--- a/tests/analysis/test_phase_diagram.py
+++ b/tests/analysis/test_phase_diagram.py
@@ -447,7 +447,7 @@ class TestPhaseDiagram(PymatgenTest):
             {"evolution": -1.0, "chempot": -10.48758201, "reaction": "Li2O -> 2 Li + 0.5 O2"},
         ]
         result = self.pd.get_element_profile(Element("O"), Composition("Li2O"))
-        for d1, d2 in zip(expected, result):
+        for d1, d2 in zip(expected, result, strict=False):
             assert d1["evolution"] == approx(d2["evolution"])
             assert d1["chempot"] == approx(d2["chempot"])
             assert d1["reaction"] == str(d2["reaction"])
@@ -505,7 +505,7 @@ class TestPhaseDiagram(PymatgenTest):
             Composition("Li0.3243244Fe0.1621621O0.51351349"),
             Composition("Li3FeO4").fractional_composition,
         ]
-        for crit, exp in zip(comps, expected):
+        for crit, exp in zip(comps, expected, strict=False):
             assert crit.almost_equals(exp, rtol=0, atol=1e-5)
 
         comps = self.pd.get_critical_compositions(c1, c3)
@@ -515,7 +515,7 @@ class TestPhaseDiagram(PymatgenTest):
             Composition("Li5FeO4").fractional_composition,
             Composition("Li2O").fractional_composition,
         ]
-        for crit, exp in zip(comps, expected):
+        for crit, exp in zip(comps, expected, strict=False):
             assert crit.almost_equals(exp, rtol=0, atol=1e-5)
 
     def test_get_critical_compositions(self):
@@ -529,7 +529,7 @@ class TestPhaseDiagram(PymatgenTest):
             Composition("Li0.3243244Fe0.1621621O0.51351349") * 7.4,
             Composition("Li3FeO4"),
         ]
-        for crit, exp in zip(comps, expected):
+        for crit, exp in zip(comps, expected, strict=False):
             assert crit.almost_equals(exp, rtol=0, atol=1e-5)
 
         comps = self.pd.get_critical_compositions(c1, c3)
@@ -539,7 +539,7 @@ class TestPhaseDiagram(PymatgenTest):
             Composition("Li5FeO4") / 3,
             Composition("Li2O"),
         ]
-        for crit, exp in zip(comps, expected):
+        for crit, exp in zip(comps, expected, strict=False):
             assert crit.almost_equals(exp, rtol=0, atol=1e-5)
 
         # Don't fail silently if input compositions aren't in phase diagram
@@ -560,7 +560,7 @@ class TestPhaseDiagram(PymatgenTest):
             Composition("Li0.3243244Fe0.1621621O0.51351349") * 7.4,
             Composition("Li3FeO4"),
         ]
-        for crit, exp in zip(comps, expected):
+        for crit, exp in zip(comps, expected, strict=False):
             assert crit.almost_equals(exp, rtol=0, atol=1e-5)
 
         # case where the endpoints are identical

--- a/tests/analysis/test_reaction_calculator.py
+++ b/tests/analysis/test_reaction_calculator.py
@@ -519,7 +519,7 @@ class TestComputedReaction(TestCase):
         assert str(new_rxn) == "2 Li + O2 -> Li2O2"
 
     def test_all_entries(self):
-        for coeff, entry in zip(self.rxn.coeffs, self.rxn.all_entries):
+        for coeff, entry in zip(self.rxn.coeffs, self.rxn.all_entries, strict=False):
             if coeff > 0:
                 assert entry.reduced_formula == "Li2O2"
                 assert entry.energy == approx(-959.64693323)

--- a/tests/analysis/test_structure_matcher.py
+++ b/tests/analysis/test_structure_matcher.py
@@ -465,7 +465,7 @@ class TestStructureMatcher(PymatgenTest):
 
         # test when s1 is exact supercell of s2
         result = sm.get_s2_like_s1(s1, s2)
-        for a, b in zip(s1, result):
+        for a, b in zip(s1, result, strict=False):
             assert a.distance(b) < 0.08
             assert a.species == b.species
 
@@ -483,7 +483,7 @@ class TestStructureMatcher(PymatgenTest):
         del subset_supercell[0]
         result = sm.get_s2_like_s1(subset_supercell, s2)
         assert len(result) == 6
-        for a, b in zip(subset_supercell, result):
+        for a, b in zip(subset_supercell, result, strict=False):
             assert a.distance(b) < 0.08
             assert a.species == b.species
 
@@ -500,7 +500,7 @@ class TestStructureMatcher(PymatgenTest):
         s2_missing_site = s2.copy()
         del s2_missing_site[1]
         result = sm.get_s2_like_s1(s1, s2_missing_site)
-        for a, b in zip((s1[i] for i in (0, 2, 4, 5)), result):
+        for a, b in zip((s1[i] for i in (0, 2, 4, 5)), result, strict=False):
             assert a.distance(b) < 0.08
             assert a.species == b.species
 
@@ -534,7 +534,7 @@ class TestStructureMatcher(PymatgenTest):
 
         result = sm.get_s2_like_s1(s1, s2)
 
-        for x, y in zip(s1, result):
+        for x, y in zip(s1, result, strict=False):
             assert x.distance(y) < 0.08
 
     def test_get_mapping(self):

--- a/tests/command_line/test_bader_caller.py
+++ b/tests/command_line/test_bader_caller.py
@@ -76,7 +76,7 @@ class TestBaderAnalysis(PymatgenTest):
 
         for key, val_from_path in analysis_from_path.summary.items():
             val = analysis.summary[key]
-            if isinstance(val_from_path, (bool, str)):
+            if isinstance(val_from_path, bool | str):
                 assert val == val_from_path, f"{key=}"
             elif key == "charge":
                 assert_allclose(val, val_from_path, atol=1e-5)

--- a/tests/command_line/test_gulp_caller.py
+++ b/tests/command_line/test_gulp_caller.py
@@ -280,7 +280,7 @@ class TestGlobalFunctions(TestCase):
         bv = BVAnalyzer()
         val = bv.get_valences(self.mgo_uc)
         el = [site.species_string for site in self.mgo_uc]
-        self.val_dict = dict(zip(el, val))
+        self.val_dict = dict(zip(el, val, strict=False))
 
     def test_get_energy_tersoff(self):
         structure = Structure.from_file(f"{VASP_IN_DIR}/POSCAR_Al12O18")

--- a/tests/command_line/test_vampire_caller.py
+++ b/tests/command_line/test_vampire_caller.py
@@ -27,13 +27,13 @@ class TestVampireCaller(PymatgenTest):
             ordered_structures = list(c["structure"])
             ordered_structures = [Structure.from_dict(d) for d in ordered_structures]
             epa = list(c["energy_per_atom"])
-            energies = [e * len(s) for (e, s) in zip(epa, ordered_structures)]
+            energies = [e * len(s) for (e, s) in zip(epa, ordered_structures, strict=False)]
 
             cls.structure_inputs.append(ordered_structures)
             cls.energy_inputs.append(energies)
 
     def test_vampire(self):
-        for structs, energies in zip(self.structure_inputs, self.energy_inputs):
+        for structs, energies in zip(self.structure_inputs, self.energy_inputs, strict=False):
             settings = {"start_t": 0, "end_t": 500, "temp_increment": 50}
             vc = VampireCaller(
                 structs,

--- a/tests/core/test_composition.py
+++ b/tests/core/test_composition.py
@@ -173,7 +173,7 @@ class TestComposition(PymatgenTest):
             1.21,
             2.43,
         )
-        for elem, val in zip(self.comps, electro_negs):
+        for elem, val in zip(self.comps, electro_negs, strict=False):
             assert elem.average_electroneg == approx(val)
 
     def test_total_electrons(self):
@@ -406,7 +406,7 @@ class TestComposition(PymatgenTest):
         ]
         formula_list = ["Ti87.6 V5.5 Al6.9", "Ti44.98 Ni55.02", "H2O"]
 
-        for weight_dict, formula in zip(weight_dict_list, formula_list):
+        for weight_dict, formula in zip(weight_dict_list, formula_list, strict=False):
             c1 = Composition(formula).fractional_composition
             c2 = Composition.from_weight_dict(weight_dict).fractional_composition
             assert set(c1.elements) == set(c2.elements)

--- a/tests/core/test_operations.py
+++ b/tests/core/test_operations.py
@@ -259,7 +259,7 @@ class TestMagSymmOp(PymatgenTest):
 
         transformed_magmoms = [[1, 2, 3], [-1, -2, -3], [1, -2, 3], [1, 2, -3]]
 
-        for xyzt_string, transformed_magmom in zip(xyzt_strings, transformed_magmoms):
+        for xyzt_string, transformed_magmom in zip(xyzt_strings, transformed_magmoms, strict=False):
             for magmom in magmoms:
                 op = MagSymmOp.from_xyzt_str(xyzt_string)
                 assert_allclose(transformed_magmom, op.operate_magmom(magmom).global_moment)

--- a/tests/core/test_operations.py
+++ b/tests/core/test_operations.py
@@ -216,9 +216,7 @@ class TestSymmOp(PymatgenTest):
         assert op4 == op5
         assert op3 == op5
 
-        # TODO: assertWarns not in Python 2.x unittest
-        # update PymatgenTest for unittest2?
-        # self.assertWarns(UserWarning, self.op.as_xyz_str)
+        self.assertWarns(UserWarning, self.op.as_xyz_str)
 
         symm_op = SymmOp.from_xyz_str("0.5+x, 0.25+y, 0.75+z")
         assert_allclose(symm_op.translation_vector, [0.5, 0.25, 0.75])

--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -622,7 +622,7 @@ class TestIStructure(PymatgenTest):
             assert len(all_nn[idx][0]) == 4
             assert len(all_nn[idx]) == len(struct.get_neighbors(site, rand_radius))
 
-        for site, nns in zip(struct, all_nn):
+        for site, nns in zip(struct, all_nn, strict=False):
             for nn in nns:
                 assert nn[0].is_periodic_image(struct[nn[2]])
                 dist = sum((site.coords - nn[0].coords) ** 2) ** 0.5
@@ -785,7 +785,7 @@ Direct
             [[3.1] * 3, [0.11] * 3, [-1.91] * 3, [0.5] * 3],
         )
         all_nn = struct.get_all_neighbors(0.2, include_index=True)
-        for site, nns in zip(struct, all_nn):
+        for site, nns in zip(struct, all_nn, strict=False):
             for nn in nns:
                 assert nn[0].is_periodic_image(struct[nn[2]])
                 d = sum((site.coords - nn[0].coords) ** 2) ** 0.5

--- a/tests/core/test_tensors.py
+++ b/tests/core/test_tensors.py
@@ -271,7 +271,7 @@ class TestTensor(PymatgenTest):
         reduced = symmetry_reduce(tbs, self.get_structure("Sn"))
         tkey = Tensor.from_values_indices([0.01], [(0, 0)])
         tval = reduced[tkey]
-        for tens_1, tens_2 in zip(tval, reduced[tbs[0]]):
+        for tens_1, tens_2 in zip(tval, reduced[tbs[0]], strict=False):
             assert approx(tens_1) == tens_2
         # Test set
         reduced[tkey] = "test_val"
@@ -304,7 +304,7 @@ class TestTensor(PymatgenTest):
         vtens = np.zeros([6] * 3)
         indices = [(0, 0, 0), (0, 0, 1), (0, 1, 2), (0, 3, 3), (0, 5, 5), (3, 4, 5)]
         values = [-1271.0, -814.0, -50.0, -3.0, -780.0, -95.0]
-        for v, idx in zip(values, indices):
+        for v, idx in zip(values, indices, strict=False):
             vtens[idx] = v
         toec = Tensor.from_voigt(vtens)
         toec = toec.populate(sn, prec=1e-3, verbose=True)
@@ -382,7 +382,7 @@ class TestTensorCollection(PymatgenTest):
         tc_mod = getattr(tc_orig, attribute)
         if callable(tc_mod):
             tc_mod = tc_mod(*args, **kwargs)
-        for t_orig, t_mod in zip(tc_orig, tc_mod):
+        for t_orig, t_mod in zip(tc_orig, tc_mod, strict=False):
             this_mod = getattr(t_orig, attribute)
             if callable(this_mod):
                 this_mod = this_mod(*args, **kwargs)
@@ -440,20 +440,20 @@ class TestTensorCollection(PymatgenTest):
         # from_voigt
         tc_input = list(np.random.default_rng().random((3, 6, 6)))
         tc = TensorCollection.from_voigt(tc_input)
-        for t_input, tensor in zip(tc_input, tc):
+        for t_input, tensor in zip(tc_input, tc, strict=False):
             assert_allclose(Tensor.from_voigt(t_input), tensor)
 
     def test_serialization(self):
         # Test base serialize-deserialize
         dct = self.seq_tc.as_dict()
         new = TensorCollection.from_dict(dct)
-        for t, t_new in zip(self.seq_tc, new):
+        for t, t_new in zip(self.seq_tc, new, strict=False):
             assert_allclose(t, t_new)
 
         voigt_symmetrized = self.rand_tc.voigt_symmetrized
         dct = voigt_symmetrized.as_dict(voigt=True)
         new_vsym = TensorCollection.from_dict(dct)
-        for t, t_new in zip(voigt_symmetrized, new_vsym):
+        for t, t_new in zip(voigt_symmetrized, new_vsym, strict=False):
             assert_allclose(t, t_new)
 
 

--- a/tests/core/test_trajectory.py
+++ b/tests/core/test_trajectory.py
@@ -49,7 +49,7 @@ class TestTrajectory(PymatgenTest):
         if traj_1.species != traj_2.species:
             return False
 
-        return all(frame1 == frame2 for frame1, frame2 in zip(self.traj, traj_2))
+        return all(frame1 == frame2 for frame1, frame2 in zip(self.traj, traj_2, strict=False))
 
     def _get_lattice_species_and_coords(self):
         lattice = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
@@ -390,7 +390,7 @@ class TestTrajectory(PymatgenTest):
         traj_1 = Trajectory(lattice=lattice, species=species, coords=coords, frame_properties=props_1)
 
         # energy and pressure properties
-        props_2 = [{"energy": e, "pressure": p} for e, p in zip(energy_2, pressure_2)]
+        props_2 = [{"energy": e, "pressure": p} for e, p in zip(energy_2, pressure_2, strict=False)]
         traj_2 = Trajectory(lattice=lattice, species=species, coords=coords, frame_properties=props_2)
 
         # no properties

--- a/tests/electronic_structure/test_boltztrap.py
+++ b/tests/electronic_structure/test_boltztrap.py
@@ -204,7 +204,9 @@ class TestBoltztrapAnalyzer(TestCase):
         sbs = loadfn(f"{TEST_DIR}/dft_bs_sym_line.json")
         kpoints = [kp.frac_coords for kp in sbs.kpoints]
         labels_dict = {k: sbs.labels_dict[k].frac_coords for k in sbs.labels_dict}
-        for kpt_line, label_dict in zip([None, sbs.kpoints, kpoints], [None, sbs.labels_dict, labels_dict]):
+        for kpt_line, label_dict in zip(
+            [None, sbs.kpoints, kpoints], [None, sbs.labels_dict, labels_dict], strict=False
+        ):
             sbs_bzt = self.bz_bands.get_symm_bands(structure, -5.25204548, kpt_line=kpt_line, labels_dict=label_dict)
             assert len(sbs_bzt.bands[Spin.up]) == approx(20)
             assert len(sbs_bzt.bands[Spin.up][1]) == approx(143)

--- a/tests/electronic_structure/test_cohp.py
+++ b/tests/electronic_structure/test_cohp.py
@@ -900,6 +900,7 @@ class TestCompleteCohp(PymatgenTest):
         for cohp1, cohp2 in zip(
             self.cobi_multi_B2H6.get_cohp_by_label("average").cohp[Spin.up],
             self.cobi_multi_B2H6_average2.get_cohp_by_label("average").cohp[Spin.up],
+            strict=False,
         ):
             print(cohp1)
             print(cohp2)
@@ -908,18 +909,21 @@ class TestCompleteCohp(PymatgenTest):
         for cohp1, cohp2 in zip(
             self.cobi_multi_B2H6.get_cohp_by_label("average").cohp[Spin.down],
             self.cobi_multi_B2H6_average2.get_cohp_by_label("average").cohp[Spin.down],
+            strict=False,
         ):
             assert cohp1 == approx(cohp2, abs=1e-4)
 
         for icohp1, icohp2 in zip(
             self.cobi_multi_B2H6.get_cohp_by_label("average").icohp[Spin.up],
             self.cobi_multi_B2H6_average2.get_cohp_by_label("average").icohp[Spin.up],
+            strict=False,
         ):
             assert icohp1 == approx(icohp2, abs=1e-4)
 
         for icohp1, icohp2 in zip(
             self.cobi_multi_B2H6.get_cohp_by_label("average").icohp[Spin.down],
             self.cobi_multi_B2H6_average2.get_cohp_by_label("average").icohp[Spin.down],
+            strict=False,
         ):
             assert icohp1 == approx(icohp2, abs=1e-4)
 

--- a/tests/electronic_structure/test_dos.py
+++ b/tests/electronic_structure/test_dos.py
@@ -311,7 +311,7 @@ class TestDOS(PymatgenTest):
     def setUp(self):
         with open(f"{TEST_DIR}/complete_dos.json") as file:
             dct = json.load(file)
-            ys = list(zip(dct["densities"]["1"], dct["densities"]["-1"]))
+            ys = list(zip(dct["densities"]["1"], dct["densities"]["-1"], strict=False))
             self.dos = DOS(dct["energies"], ys, dct["efermi"])
 
     def test_get_gap(self):

--- a/tests/electronic_structure/test_dos.py
+++ b/tests/electronic_structure/test_dos.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from unittest import TestCase
 
 import numpy as np
@@ -299,12 +300,11 @@ class TestCompleteDos(TestCase):
             "projections unavailable in input DOS or there's a typo in type.",
         ):
             self.dos.get_dos_fp(fp_type="k", min_e=-10, max_e=0, n_bins=56, normalize=True)
-        with pytest.raises(
-            ValueError,
-            match="Requested metric not implemented. Currently implemented metrics are "
-            "tanimoto, wasserstien and cosine-sim.",
-        ):
-            self.dos.get_dos_fp_similarity(dos_fp, dos_fp2, col=1, metric="Dot", normalize=False)
+
+        valid_metrics = ("tanimoto", "wasserstein", "cosine-sim")
+        metric = "Dot"
+        with pytest.raises(ValueError, match=re.escape(f"Invalid {metric=}, choose from {valid_metrics}.")):
+            self.dos.get_dos_fp_similarity(dos_fp, dos_fp2, col=1, metric=metric, normalize=False)
 
 
 class TestDOS(PymatgenTest):

--- a/tests/entries/test_compatibility.py
+++ b/tests/entries/test_compatibility.py
@@ -1018,7 +1018,7 @@ class TestMaterialsProjectCompatibility2020(TestCase):
         # check whether the compatibility scheme can keep input entries unchanged
         entries_copy = copy.deepcopy(entries)
         self.compat.process_entries(entries, inplace=False)
-        assert all(e.correction == e_copy.correction for e, e_copy in zip(entries, entries_copy))
+        assert all(e.correction == e_copy.correction for e, e_copy in zip(entries, entries_copy, strict=False))
 
     def test_check_potcar(self):
         MaterialsProject2020Compatibility(check_potcar=False).process_entries(self.entry1)
@@ -1891,7 +1891,7 @@ class TestMaterialsProjectAqueousCompatibility:
         entries = [h2o_entry, o2_entry]
         entries_copy = copy.deepcopy(entries)
         MaterialsProjectAqueousCompatibility().process_entries(entries, inplace=False)
-        assert all(e.correction == e_copy.correction for e, e_copy in zip(entries, entries_copy))
+        assert all(e.correction == e_copy.correction for e, e_copy in zip(entries, entries_copy, strict=False))
 
     def test_parallel_process_entries(self):
         hydrate_entry = ComputedEntry(Composition("FeH4O2"), -10)  # nH2O = 2

--- a/tests/entries/test_mixing_scheme.py
+++ b/tests/entries/test_mixing_scheme.py
@@ -756,7 +756,7 @@ def test_data_ms_complete(ms_complete):
     ComputedStructureEntry match (or don't match) as intended.
     """
     sm = StructureMatcher()
-    for g, s in zip(ms_complete.gga_entries, ms_complete.scan_entries):
+    for g, s in zip(ms_complete.gga_entries, ms_complete.scan_entries, strict=False):
         if g.entry_id == "gga-3":
             assert not sm.fit(g.structure, s.structure)
         else:
@@ -1226,7 +1226,7 @@ class TestMaterialsProjectDFTMixingSchemeArgs:
         # check whether the compatibility scheme can keep input entries unchanged
         entries_copy = copy.deepcopy(entries)
         MaterialsProjectDFTMixingScheme().process_entries(entries, inplace=False)
-        assert all(e.correction == e_copy.correction for e, e_copy in zip(entries, entries_copy))
+        assert all(e.correction == e_copy.correction for e, e_copy in zip(entries, entries_copy, strict=False))
 
     def test_check_potcar(self, ms_complete):
         """Entries with invalid or missing POTCAR raise error by default but should be ignored if

--- a/tests/io/abinit/test_abiobjects.py
+++ b/tests/io/abinit/test_abiobjects.py
@@ -101,7 +101,7 @@ class TestLatticeFromAbivars(PymatgenTest):
 
         assert [s.symbol for s in species_by_znucl(gan)] == ["Ga", "N"]
 
-        for itype1, itype2 in zip(def_typat, enforce_typat):
+        for itype1, itype2 in zip(def_typat, enforce_typat, strict=False):
             assert def_znucl[itype1 - 1] == enforce_znucl[itype2 - 1]
 
         with pytest.raises(ValueError, match="Both enforce_znucl and enforce_typat are required"):

--- a/tests/io/abinit/test_inputs.py
+++ b/tests/io/abinit/test_inputs.py
@@ -235,7 +235,7 @@ class TestMultiDataset(PymatgenTest):
         assert new_multi.ndtset == multi.ndtset
         assert new_multi.structure == multi.structure
 
-        for old_inp, new_inp in zip(multi, new_multi):
+        for old_inp, new_inp in zip(multi, new_multi, strict=False):
             assert old_inp is not new_inp
             assert old_inp.as_dict() == new_inp.as_dict()
 

--- a/tests/io/aims/test_aims_inputs.py
+++ b/tests/io/aims/test_aims_inputs.py
@@ -58,7 +58,7 @@ def test_read_h2o_in(tmp_path: Path):
         [0, -0.763239, -0.477047],
     ]
 
-    assert all(sp.symbol == symb for sp, symb in zip(h2o.structure.species, ["O", "H", "H"]))
+    assert all(sp.symbol == symb for sp, symb in zip(h2o.structure.species, ["O", "H", "H"], strict=False))
     assert_allclose(h2o.structure.cart_coords, in_coords)
 
     h2o_test_from_struct = AimsGeometryIn.from_structure(h2o.structure)

--- a/tests/io/cp2k/test_inputs.py
+++ b/tests/io/cp2k/test_inputs.py
@@ -193,7 +193,7 @@ class TestInput(PymatgenTest):
         for struct in [nonsense_struct, si_struct, ch_mol]:
             coords = Coord(struct)
             for val in coords.keywords.values():
-                assert isinstance(val, (Keyword, KeywordList))
+                assert isinstance(val, Keyword | KeywordList)
 
     def test_kind(self):
         for struct in [nonsense_struct, si_struct, ch_mol]:

--- a/tests/io/exciting/test_inputs.py
+++ b/tests/io/exciting/test_inputs.py
@@ -70,7 +70,7 @@ class TestExcitingInput(PymatgenTest):
             ],
         )
         exc_in = ExcitingInput(structure)
-        for l1, l2 in zip(input_string.split("\n"), exc_in.write_string("unchanged").split("\n")):
+        for l1, l2 in zip(input_string.split("\n"), exc_in.write_string("unchanged").split("\n"), strict=False):
             if not l1.strip().startswith("<crystal scale"):
                 assert l1.strip() == l2.strip()
 

--- a/tests/io/lobster/test_inputs.py
+++ b/tests/io/lobster/test_inputs.py
@@ -257,13 +257,13 @@ class TestCohpcar(PymatgenTest):
                         assert len(val["cells"]) == 3
                         assert len(val["COHP"][Spin.up]) == 12
                         assert len(val["COHP"][Spin.down]) == 12
-                        for cohp1, cohp2 in zip(val["COHP"][Spin.up], val["COHP"][Spin.down]):
+                        for cohp1, cohp2 in zip(val["COHP"][Spin.up], val["COHP"][Spin.down], strict=False):
                             assert cohp1 == approx(cohp2, abs=1e-4)
                     else:
                         assert len(val["cells"]) == 2
                         assert len(val["COHP"][Spin.up]) == 12
                         assert len(val["COHP"][Spin.down]) == 12
-                        for cohp1, cohp2 in zip(val["COHP"][Spin.up], val["COHP"][Spin.down]):
+                        for cohp1, cohp2 in zip(val["COHP"][Spin.up], val["COHP"][Spin.down], strict=False):
                             assert cohp1 == approx(cohp2, abs=1e-3)
 
     def test_orbital_resolved_cohp(self):
@@ -1299,7 +1299,7 @@ class TestLobsterout(PymatgenTest):
                     assert ref_data[key] == item
                 elif key in ("charge_spilling", "total_spilling"):
                     assert item[0] == approx(ref_data[key][0])
-                elif isinstance(item, (list, dict)):
+                elif isinstance(item, list | dict):
                     assert item == ref_data[key]
 
     def test_msonable(self):

--- a/tests/io/qchem/test_inputs.py
+++ b/tests/io/qchem/test_inputs.py
@@ -1176,7 +1176,7 @@ $end"""
         ref_path = f"{TEST_DIR}/test_ref.qin"
 
         with open(ref_path) as ref_file, open(test_path) as test_file:
-            for l_test, l_ref in zip(test_file, ref_file):
+            for l_test, l_ref in zip(test_file, ref_file, strict=False):
                 # By default, if this statement fails the offending line will be printed
                 assert l_test == l_ref
 
@@ -1191,7 +1191,7 @@ $end"""
         ref_path = f"{TEST_DIR}/test_ref_vdw.qin"
 
         with open(ref_path) as ref_file, open(test_path) as test_file:
-            for l_test, l_ref in zip(test_file, ref_file):
+            for l_test, l_ref in zip(test_file, ref_file, strict=False):
                 # By default, if this statement fails the offending line will be printed
                 assert l_test == l_ref
 
@@ -1204,7 +1204,7 @@ $end"""
         qcinp.write_file(test_path)
 
         with open(test_path) as ref_file, open(ref_path) as test_file:
-            for l_test, l_ref in zip(test_file, ref_file):
+            for l_test, l_ref in zip(test_file, ref_file, strict=False):
                 # By default, if this statement fails the offending line will be printed
                 assert l_test == l_ref
 
@@ -1217,7 +1217,7 @@ $end"""
         ref_path = f"{TEST_DIR}/test_e2pert.qin"
 
         with open(ref_path) as ref_file, open(test_path) as test_file:
-            for l_test, l_ref in zip(test_file, ref_file):
+            for l_test, l_ref in zip(test_file, ref_file, strict=False):
                 assert l_test == l_ref
 
         os.remove(f"{TEST_DIR}/test_e2pert.qin")
@@ -1229,7 +1229,7 @@ $end"""
         ref_path = f"{TEST_DIR}/test_custom_smd.qin"
 
         with open(ref_path) as ref_file, open(test_path) as test_file:
-            for l_test, l_ref in zip(test_file, ref_file):
+            for l_test, l_ref in zip(test_file, ref_file, strict=False):
                 assert l_test == l_ref
 
         os.remove(f"{TEST_DIR}/test_custom_smd.qin")

--- a/tests/io/test_cif.py
+++ b/tests/io/test_cif.py
@@ -104,7 +104,7 @@ loop_
  _atom_site_attached_hydrogens
   C1  C0+  2  b  0  0  0.25  .  1.  0
   C2  C0+  2  c  0.3333  0.6667  0.25  .  1.  0"""
-        for l1, l2, l3 in zip(str(cif_block).split("\n"), cif_str.split("\n"), cif_str_2.split("\n")):
+        for l1, l2, l3 in zip(str(cif_block).split("\n"), cif_str.split("\n"), cif_str_2.split("\n"), strict=False):
             assert l1.strip() == l2.strip()
             assert l2.strip() == l3.strip()
 
@@ -257,7 +257,7 @@ class TestCifIO(PymatgenTest):
         assert {*struct.labels} == expected_site_names
 
         # check label of each site
-        for site, label in zip(struct, struct.labels):
+        for site, label in zip(struct, struct.labels, strict=False):
             assert site.label == label
             # Ensure the site label starts with the site species name
             assert site.label.startswith(site.specie.name)
@@ -463,7 +463,7 @@ loop_
   O  O2  8  0.16570974  0.04607233  0.28538394  1
   O  O3  4  0.04337231  0.75000000  0.70713767  1
   O  O4  4  0.09664244  0.25000000  0.74132035  1"""
-        for l1, l2 in zip(str(writer).split("\n"), answer.split("\n")):
+        for l1, l2 in zip(str(writer).split("\n"), answer.split("\n"), strict=False):
             assert l1.strip() == l2.strip()
 
     def test_symmetrized(self):
@@ -542,7 +542,7 @@ loop_
   Si  Si1  1  0.75000000  0.50000000  0.75000000  0.5
   N  N2  1  0.75000000  0.50000000  0.75000000  0.5"""
 
-        for l1, l2 in zip(str(writer).split("\n"), answer.split("\n")):
+        for l1, l2 in zip(str(writer).split("\n"), answer.split("\n"), strict=False):
             assert l1.strip() == l2.strip()
 
     def test_cif_writer_without_refinement(self):
@@ -604,7 +604,7 @@ loop_
   Si3+  Si2  1  0.75000000  0.50000000  0.75000000  0.5
   Si4+  Si3  1  0.00000000  0.00000000  0.00000000  1
 """
-        for l1, l2 in zip(str(writer).split("\n"), answer.split("\n")):
+        for l1, l2 in zip(str(writer).split("\n"), answer.split("\n"), strict=False):
             assert l1.strip() == l2.strip()
 
         # test that mixed valence works properly

--- a/tests/io/test_core.py
+++ b/tests/io/test_core.py
@@ -82,7 +82,7 @@ class TestInputSet(PymatgenTest):
             _ = inp_set.kwarg3
         expected = [("cif1", sif1), ("cif2", sif2), ("cif3", sif3)]
 
-        for (fname, contents), (exp_fname, exp_contents) in zip(inp_set.items(), expected):
+        for (fname, contents), (exp_fname, exp_contents) in zip(inp_set.items(), expected, strict=False):
             assert fname == exp_fname
             assert contents is exp_contents
 
@@ -100,7 +100,7 @@ class TestInputSet(PymatgenTest):
 
         assert len(inp_set) == 2
         expected = [("cif1", sif1), ("cif3", sif3)]
-        for (fname, contents), (exp_fname, exp_contents) in zip(inp_set.items(), expected):
+        for (fname, contents), (exp_fname, exp_contents) in zip(inp_set.items(), expected, strict=False):
             assert fname == exp_fname
             assert contents is exp_contents
 
@@ -133,7 +133,7 @@ class TestInputSet(PymatgenTest):
         assert temp_inp_set.kwarg1 == 1
         assert temp_inp_set.kwarg2 == "hello"
         assert temp_inp_set._kwargs == inp_set._kwargs
-        for (fname, contents), (fname2, contents2) in zip(temp_inp_set.items(), inp_set.items()):
+        for (fname, contents), (fname2, contents2) in zip(temp_inp_set.items(), inp_set.items(), strict=False):
             assert fname == fname2
             assert contents.structure == contents2.structure
 

--- a/tests/io/test_shengbte.py
+++ b/tests/io/test_shengbte.py
@@ -46,11 +46,11 @@ class TestShengBTE(PymatgenTest):
         assert io["lattvec"][0] == [0.0, 2.734363999, 2.734363999]
         assert io["lattvec"][1] == [2.734363999, 0.0, 2.734363999]
         assert io["lattvec"][2] == [2.734363999, 2.734363999, 0.0]
-        assert isinstance(io["elements"], (list, str))
+        assert isinstance(io["elements"], list | str)
         if isinstance(io["elements"], list):
             all_strings = all(isinstance(item, str) for item in io["elements"])
             assert all_strings
-        assert isinstance(io["types"], (list, int))
+        assert isinstance(io["types"], list | int)
         if isinstance(io["types"], list):
             all_ints = all(isinstance(item, int) for item in io["types"])
             assert all_ints

--- a/tests/io/test_zeopp.py
+++ b/tests/io/test_zeopp.py
@@ -158,7 +158,7 @@ class TestGetVoronoiNodes(TestCase):
         bv = BVAnalyzer()
         valences = bv.get_valences(self.structure)
         el = [site.species_string for site in self.structure]
-        valence_dict = dict(zip(el, valences))
+        valence_dict = dict(zip(el, valences, strict=False))
         self.rad_dict = {}
         for key, val in valence_dict.items():
             self.rad_dict[key] = float(Species(key, val).ionic_radius)
@@ -197,7 +197,7 @@ class TestGetHighAccuracyVoronoiNodes(TestCase):
         bv = BVAnalyzer()
         valences = bv.get_valences(self.structure)
         el = [site.species_string for site in self.structure]
-        valence_dict = dict(zip(el, valences))
+        valence_dict = dict(zip(el, valences, strict=False))
         self.rad_dict = {}
         for key, val in valence_dict.items():
             self.rad_dict[key] = float(Species(key, val).ionic_radius)
@@ -223,7 +223,7 @@ class TestGetVoronoiNodesMultiOxi(TestCase):
             radius = Species(el, valence).ionic_radius
             radii.append(radius)
         el = [site.species_string for site in self.structure]
-        self.rad_dict = dict(zip(el, radii))
+        self.rad_dict = dict(zip(el, radii, strict=False))
 
     def test_get_voronoi_nodes(self):
         vor_node_struct, vor_edge_center_struct, vor_face_center_struct = get_voronoi_nodes(

--- a/tests/io/vasp/test_inputs.py
+++ b/tests/io/vasp/test_inputs.py
@@ -1306,7 +1306,7 @@ class TestPotcar(PymatgenTest):
         assert len(ref_potcar) == len(new_potcar), f"wrong POTCAR line count: {len(ref_potcar)} != {len(new_potcar)}"
 
         # check line by line
-        for line1, line2 in zip(ref_potcar, new_potcar):
+        for line1, line2 in zip(ref_potcar, new_potcar, strict=False):
             assert line1.strip() == line2.strip(), f"wrong POTCAR line: {line1} != {line2}"
 
     def test_set_symbol(self):

--- a/tests/io/vasp/test_outputs.py
+++ b/tests/io/vasp/test_outputs.py
@@ -1193,7 +1193,7 @@ class TestOutcar(PymatgenTest):
             {"eta": 0.42, "nuclear_quadrupole_moment": 146.6, "cq": -5.58},
         ]
         assert len(outcar.data["efg"][2:10]) == len(expected_efg)
-        for e1, e2 in zip(outcar.data["efg"][2:10], expected_efg):
+        for e1, e2 in zip(outcar.data["efg"][2:10], expected_efg, strict=False):
             for k in e1:
                 assert e1[k] == approx(e2[k], abs=1e-5)
 
@@ -1221,7 +1221,7 @@ class TestOutcar(PymatgenTest):
         ]
 
         assert len(outcar.data["unsym_efg_tensor"][2:10]) == len(exepected_tensors)
-        for e1, e2 in zip(outcar.data["unsym_efg_tensor"][2:10], exepected_tensors):
+        for e1, e2 in zip(outcar.data["unsym_efg_tensor"][2:10], exepected_tensors, strict=False):
             assert_allclose(e1, e2)
 
     def test_read_fermi_contact_shift(self):
@@ -2043,7 +2043,7 @@ class TestWSWQ(PymatgenTest):
         assert self.wswq.nspin == 2
         assert self.wswq.me_real.shape == (2, 20, 18, 18)
         assert self.wswq.me_imag.shape == (2, 20, 18, 18)
-        for itr, (r, i) in enumerate(zip(self.wswq.me_real[0][0][4], self.wswq.me_imag[0][0][4])):
+        for itr, (r, i) in enumerate(zip(self.wswq.me_real[0][0][4], self.wswq.me_imag[0][0][4], strict=False)):
             if itr == 4:
                 assert np.linalg.norm([r, i]) > 0.999
             else:

--- a/tests/phonon/test_dos.py
+++ b/tests/phonon/test_dos.py
@@ -171,12 +171,11 @@ class TestPhononDos(PymatgenTest):
             match="Cannot compute similarity index. When normalize=True, then please set metric=cosine-sim",
         ):
             self.dos.get_dos_fp_similarity(dos_fp, dos_fp2, col=1, metric="tanimoto", normalize=True)
-        with pytest.raises(
-            ValueError,
-            match="Requested metric not implemented. Currently implemented metrics are "
-            "tanimoto, wasserstien and cosine-sim.",
-        ):
-            self.dos.get_dos_fp_similarity(dos_fp, dos_fp2, col=1, metric="Dot", normalize=False)
+
+        valid_metrics = ("tanimoto", "wasserstein", "cosine-sim")
+        metric = "Dot"
+        with pytest.raises(ValueError, match=re.escape(f"Invalid {metric=}, choose from {valid_metrics}.")):
+            self.dos.get_dos_fp_similarity(dos_fp, dos_fp2, col=1, metric=metric, normalize=False)
 
 
 class TestCompletePhononDos(PymatgenTest):

--- a/tests/symmetry/test_analyzer.py
+++ b/tests/symmetry/test_analyzer.py
@@ -93,7 +93,7 @@ class TestSpacegroupAnalyzer(PymatgenTest):
             pg_ops = sg.get_point_group_operations()
             frac_symm_ops = sg.get_symmetry_operations()
             symm_ops = sg.get_symmetry_operations(cartesian=True)
-            for fop, op, pgop in zip(frac_symm_ops, symm_ops, pg_ops):
+            for fop, op, pgop in zip(frac_symm_ops, symm_ops, pg_ops, strict=False):
                 # translation vector values should all be 0 or 0.5
                 t = fop.translation_vector * 2
                 assert_allclose(t - np.round(t), 0)
@@ -610,7 +610,7 @@ class TestPointGroupAnalyzer(PymatgenTest):
             ir_mesh = spga.get_ir_reciprocal_mesh((4, 4, 4))
             weights = [i[1] for i in ir_mesh]
             weights = np.array(weights) / sum(weights)
-            for expected, weight in zip(weights, spga.get_kpoint_weights([i[0] for i in ir_mesh])):
+            for expected, weight in zip(weights, spga.get_kpoint_weights([i[0] for i in ir_mesh]), strict=False):
                 assert weight == approx(expected)
 
         for name in ("SrTiO3", "LiFePO4", "Graphite"):
@@ -619,14 +619,14 @@ class TestPointGroupAnalyzer(PymatgenTest):
             ir_mesh = spga.get_ir_reciprocal_mesh((1, 2, 3))
             weights = [i[1] for i in ir_mesh]
             weights = np.array(weights) / sum(weights)
-            for expected, weight in zip(weights, spga.get_kpoint_weights([i[0] for i in ir_mesh])):
+            for expected, weight in zip(weights, spga.get_kpoint_weights([i[0] for i in ir_mesh]), strict=False):
                 assert weight == approx(expected)
 
         vasp_run = Vasprun(f"{VASP_OUT_DIR}/vasprun.xml.gz")
         spga = SpacegroupAnalyzer(vasp_run.final_structure)
         wts = spga.get_kpoint_weights(vasp_run.actual_kpoints)
 
-        for w1, w2 in zip(vasp_run.actual_kpoints_weights, wts):
+        for w1, w2 in zip(vasp_run.actual_kpoints_weights, wts, strict=False):
             assert w1 == approx(w2)
 
         kpts = [[0, 0, 0], [0.15, 0.15, 0.15], [0.2, 0.2, 0.2]]

--- a/tests/symmetry/test_settings.py
+++ b/tests/symmetry/test_settings.py
@@ -32,7 +32,7 @@ class TestJonesFaithfulTransformation(TestCase):
         ]
 
     def test_init(self):
-        for test_str, test_Pp in zip(self.test_strings, self.test_Pps):
+        for test_str, test_Pp in zip(self.test_strings, self.test_Pps, strict=False):
             jft = JonesFaithfulTransformation.from_transformation_str(test_str)
             jft2 = JonesFaithfulTransformation(test_Pp[0], test_Pp[1])
             assert_allclose(jft.P, jft2.P)
@@ -56,7 +56,7 @@ class TestJonesFaithfulTransformation(TestCase):
             [[5.0, 0.0, 0.0], [0.0, 5.0, 0.0], [0.0, 0.0, 5.0]],
         ]
 
-        for ref_lattice, (P, p) in zip(all_ref_lattices, self.test_Pps):
+        for ref_lattice, (P, p) in zip(all_ref_lattices, self.test_Pps, strict=False):
             jft = JonesFaithfulTransformation(P, p)
             assert_allclose(jft.transform_lattice(lattice).matrix, ref_lattice)
 
@@ -70,10 +70,10 @@ class TestJonesFaithfulTransformation(TestCase):
             [[-0.25, -0.5, -0.75], [0.25, 0.0, -0.25]],
         ]
 
-        for ref_coords, (P, p) in zip(all_ref_coords, self.test_Pps):
+        for ref_coords, (P, p) in zip(all_ref_coords, self.test_Pps, strict=False):
             jft = JonesFaithfulTransformation(P, p)
             transformed_coords = jft.transform_coords(coords)
-            for coord, ref_coord in zip(transformed_coords, ref_coords):
+            for coord, ref_coord in zip(transformed_coords, ref_coords, strict=False):
                 assert_allclose(coord, ref_coord)
 
     def test_transform_symmops(self):
@@ -187,5 +187,5 @@ y,-x,-z+1/2
 
         transformed_symm_ops = [jft.transform_symmop(op) for op in input_symm_ops]
 
-        for transformed_op, ref_transformed_op in zip(transformed_symm_ops, ref_transformed_symm_ops):
+        for transformed_op, ref_transformed_op in zip(transformed_symm_ops, ref_transformed_symm_ops, strict=False):
             assert transformed_op == ref_transformed_op

--- a/tests/transformations/test_site_transformations.py
+++ b/tests/transformations/test_site_transformations.py
@@ -326,7 +326,7 @@ class TestRadialSiteDistortionTransformation(PymatgenTest):
 
         trafo = RadialSiteDistortionTransformation(0, 1, nn_only=True)
         struct = trafo.apply_transformation(self.structure)
-        for c1, c2 in zip(self.structure[1:7], struct[1:7]):
+        for c1, c2 in zip(self.structure[1:7], struct[1:7], strict=False):
             assert c1.distance(c2) == 1.0
 
         assert np.array_equal(struct[0].coords, [0, 0, 0])
@@ -340,5 +340,5 @@ class TestRadialSiteDistortionTransformation(PymatgenTest):
     def test_second_nn(self):
         trafo = RadialSiteDistortionTransformation(0, 1, nn_only=False)
         struct = trafo.apply_transformation(self.molecule)
-        for c1, c2 in zip(self.molecule[7:], struct[7:]):
+        for c1, c2 in zip(self.molecule[7:], struct[7:], strict=False):
             assert abs(round(sum(c2.coords - c1.coords), 2)) == 0.33


### PR DESCRIPTION
### Summary

- Drop Python 3.9 support, following NumPy https://github.com/numpy/numpy/issues/24932
- Remove a few outdated TODOs


### TODOs
- [x] Implement https://github.com/materialsproject/pymatgen/pull/3958#issuecomment-2259644593

### Future PR

- Looks like Python 3.13 rc1 is not supported by micromamba (perhaps I did it incorrectly), let's wait until [the stable release Oct 2024](https://peps.python.org/pep-0719/#schedule)?
- Fix ignore of `RUF017` rules
