### PR TITLE
Remove the skip mark for test_delta_func

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ dependencies = [
     "requests>=2.32",
     "ruamel.yaml>=0.17.0",
     "scipy>=1.13.0",
+    "scipy>=1.14.1; platform_system == 'Windows'",
     "spglib>=2.5.0",
     "sympy>=1.2",
     "tabulate>=0.9",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,8 @@ dependencies = [
     "requests>=2.32",
     "ruamel.yaml>=0.17.0",
     "scipy>=1.13.0",
+    # scipy<1.14.1 is incompatible with NumPy 2.0 on Windows 
+    # https://github.com/scipy/scipy/issues/21052
     "scipy>=1.14.1; platform_system == 'Windows'",
     "spglib>=2.5.0",
     "sympy>=1.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ dependencies = [
     "requests>=2.32",
     "ruamel.yaml>=0.17.0",
     "scipy>=1.13.0",
-    # scipy<1.14.1 is incompatible with NumPy 2.0 on Windows 
+    # scipy<1.14.1 is incompatible with NumPy 2.0 on Windows
     # https://github.com/scipy/scipy/issues/21052
     "scipy>=1.14.1; platform_system == 'Windows'",
     "spglib>=2.5.0",

--- a/tests/io/vasp/test_optics.py
+++ b/tests/io/vasp/test_optics.py
@@ -53,10 +53,6 @@ class TestVasprun(PymatgenTest):
         assert len(x_val) == len(y_val) == len(text)
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32" and int(np.__version__[0]) >= 2,
-    reason="Fails on Windows with numpy > 2.0.0, awaiting https://github.com/scipy/scipy/issues/21052 resolution",
-)
 def test_delta_func():
     x = np.array([0, 1, 2, 3, 4, 5])
 

--- a/tests/io/vasp/test_optics.py
+++ b/tests/io/vasp/test_optics.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import sys
-
 import numpy as np
 import pytest
 import scipy.special


### PR DESCRIPTION
## Summary

https://github.com/scipy/scipy/issues/21052 has been fixed and released in scipy 1.14.1. This PR removes the skip mark.

## Todos

If this is work in progress, what else needs to be done?

- feature 2: ...
- fix 2:

## Checklist

- [ ] Google format doc strings added. Check with `ruff`.
- [ ] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
