### PR TITLE
Fix PT013: incorrect import of `pytest`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,7 +216,6 @@ ignore = [
     "PLR1702", # Too many nested blocks
     "PLR2004", # Magic-value-comparison TODO: fix these
     "PLW2901", # Outer for loop variable overwritten by inner assignment target
-    "PT013",   # Incorrect import of pytest
     "S101",    # Use of "assert"  TODO: fix these
     "S110",    # Log for try-except-pass
     "S112",    # Log for try-except-continue

--- a/tests/io/abinit/test_abiobjects.py
+++ b/tests/io/abinit/test_abiobjects.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_array_equal
-from pytest import approx
 
 from pymatgen.core.structure import Structure
 from pymatgen.core.units import Ha_to_eV, bohr_to_ang
@@ -25,7 +24,7 @@ from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
 class TestLatticeFromAbivars(PymatgenTest):
     def test_rprim_acell(self):
         l1 = lattice_from_abivars(acell=3 * [10], rprim=np.eye(3))
-        assert l1.volume == approx(bohr_to_ang**3 * 1000)
+        assert l1.volume == pytest.approx(bohr_to_ang**3 * 1000)
         assert l1.angles == (90, 90, 90)
         l2 = lattice_from_abivars(acell=3 * [10], angdeg=(90, 90, 90))
         assert l1 == l2

--- a/tests/io/abinit/test_pseudos.py
+++ b/tests/io/abinit/test_pseudos.py
@@ -6,7 +6,6 @@ from collections import defaultdict
 
 import pytest
 from monty.tempfile import ScratchDir
-from pytest import approx
 
 from pymatgen.io.abinit.pseudos import Pseudo, PseudoTable
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
@@ -138,7 +137,7 @@ class TestPseudo(PymatgenTest):
         assert oxygen.xc.name == "PBE"
         assert oxygen.supports_soc
         assert oxygen.md5 is not None
-        assert oxygen.paw_radius == approx(1.4146523028)
+        assert oxygen.paw_radius == pytest.approx(1.4146523028)
 
         # Test pickle
         new_objs = self.serialize_with_pickle(oxygen)
@@ -150,7 +149,7 @@ class TestPseudo(PymatgenTest):
             assert obj.symbol == "O"
             assert (obj.Z, obj.core, obj.valence) == (8, 2, 6), obj.Z_val == 6
 
-            assert obj.paw_radius == approx(1.4146523028)
+            assert obj.paw_radius == pytest.approx(1.4146523028)
 
     def test_oncvpsp_pseudo_sr(self):
         """Test the ONCVPSP Ge pseudo (scalar relativistic version)."""

--- a/tests/io/cp2k/test_inputs.py
+++ b/tests/io/cp2k/test_inputs.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_array_equal
-from pytest import approx
 
 from pymatgen.core.structure import Molecule, Structure
 from pymatgen.io.cp2k.inputs import (
@@ -139,8 +138,8 @@ class TestBasisAndPotential(PymatgenTest):
         assert h_all_elec.potential == "All Electron"
         pot = GthPotential.from_str(POT_HYDROGEN_STR)
         assert pot.potential == "Pseudopotential"
-        assert pot.r_loc == approx(0.2)
-        assert pot.nexp_ppl == approx(2)
+        assert pot.r_loc == pytest.approx(0.2)
+        assert pot.nexp_ppl == pytest.approx(2)
         assert_allclose(pot.c_exp_ppl, [-4.17890044, 0.72446331])
 
         # Basis file can read from strings

--- a/tests/io/cp2k/test_outputs.py
+++ b/tests/io/cp2k/test_outputs.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from unittest import TestCase
 
 import numpy as np
+import pytest
 from numpy.testing import assert_allclose
-from pytest import approx
 
 from pymatgen.io.cp2k.outputs import Cp2kOutput
 from pymatgen.util.testing import TEST_FILES_DIR
@@ -49,17 +49,17 @@ class TestSet(TestCase):
 
     def test_dos(self):
         """Can parse dos files."""
-        assert self.out.data["pdos"]["Si_1"]["s"]["efermi"] == approx(-6.7370756409404455)
-        assert self.out.data["tdos"].energies[0] == approx(-6.781065751604123)
+        assert self.out.data["pdos"]["Si_1"]["s"]["efermi"] == pytest.approx(-6.7370756409404455)
+        assert self.out.data["tdos"].energies[0] == pytest.approx(-6.781065751604123)
 
     def test_chi(self):
         self.out.parse_chi_tensor()
         assert len(self.out.data["chi_total"]) == 1
-        assert self.out.data["PV1"][0] == approx(0.1587)
-        assert self.out.data["PV2"][0] == approx(0.4582)
-        assert self.out.data["PV3"][0] == approx(0.4582)
-        assert self.out.data["ISO"][0] == approx(0.3584)
-        assert self.out.data["ANISO"][0] == approx(0.1498)
+        assert self.out.data["PV1"][0] == pytest.approx(0.1587)
+        assert self.out.data["PV2"][0] == pytest.approx(0.4582)
+        assert self.out.data["PV3"][0] == pytest.approx(0.4582)
+        assert self.out.data["ISO"][0] == pytest.approx(0.3584)
+        assert self.out.data["ANISO"][0] == pytest.approx(0.1498)
         assert_allclose(
             self.out.data["chi_soft"][0],
             [[5.9508, -1.6579, -1.6579], [-1.6579, 5.9508, -1.6579], [-1.6579, -1.6579, 5.9508]],

--- a/tests/io/cp2k/test_sets.py
+++ b/tests/io/cp2k/test_sets.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import pytest
-from pytest import approx
 
 from pymatgen.core.structure import Molecule, Structure
 from pymatgen.io.cp2k.sets import SETTINGS, Cp2kValidationError, DftSet, GaussianTypeOrbitalBasisSet, GthPotential
@@ -66,7 +65,7 @@ class TestDftSet(PymatgenTest):
         }
         set_kwargs = dict.fromkeys(("print_pdos", "print_dos", "print_v_hartree", "print_e_density"), False)
         dft_set = DftSet(Si_structure, basis_and_potential=basis_and_potential, xc_functionals="PBE", **set_kwargs)
-        assert dft_set.cutoff == approx(150)
+        assert dft_set.cutoff == pytest.approx(150)
 
         # Test that printing will activate sections
         assert not dft_set.check("motion")

--- a/tests/io/feff/test_inputs.py
+++ b/tests/io/feff/test_inputs.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import os
 from unittest import TestCase
 
+import pytest
 from numpy.testing import assert_allclose
-from pytest import approx
 
 from pymatgen.core import Molecule, Structure
 from pymatgen.io.feff.inputs import Atoms, Header, Paths, Potential, Tags
@@ -84,17 +84,17 @@ class TestFeffAtoms(TestCase):
     def test_absorber_line(self):
         atoms_lines = self.atoms.get_lines()
         # x
-        assert float(atoms_lines[0][0]) == approx(0.0)
+        assert float(atoms_lines[0][0]) == pytest.approx(0.0)
         # y
-        assert float(atoms_lines[0][1]) == approx(0.0)
+        assert float(atoms_lines[0][1]) == pytest.approx(0.0)
         # z
-        assert float(atoms_lines[0][2]) == approx(0.0)
+        assert float(atoms_lines[0][2]) == pytest.approx(0.0)
         # ipot
         assert int(atoms_lines[0][3]) == 0
         # atom symbol
         assert atoms_lines[0][4] == "O"
         # distance
-        assert float(atoms_lines[0][5]) == approx(0.0)
+        assert float(atoms_lines[0][5]) == pytest.approx(0.0)
         # id
         assert int(atoms_lines[0][6]) == 0
 

--- a/tests/io/lammps/test_data.py
+++ b/tests/io/lammps/test_data.py
@@ -9,7 +9,6 @@ import pandas as pd
 import pytest
 from monty.json import MontyDecoder, MontyEncoder
 from numpy.testing import assert_allclose
-from pytest import approx
 from ruamel.yaml import YAML
 
 from pymatgen.core import Element, Lattice, Molecule, Structure
@@ -32,7 +31,7 @@ class TestLammpsBox(PymatgenTest):
         o_bounds = np.array(self.peptide.bounds)
         ov = np.prod(o_bounds[:, 1] - o_bounds[:, 0])
         assert self.peptide.volume == ov
-        assert self.quartz.volume == approx(113.007331)
+        assert self.quartz.volume == pytest.approx(113.007331)
 
     def test_get_str(self):
         peptide = self.peptide.get_str(5)
@@ -379,12 +378,12 @@ class TestLammpsData(PymatgenTest):
         assert pep.atoms.loc[29, "molecule-ID"] == 1
         assert pep.atoms.loc[29, "type"] == 7
         assert pep.atoms.loc[29, "q"] == -0.020
-        assert pep.atoms.loc[29, "x"] == approx(42.96709)
+        assert pep.atoms.loc[29, "x"] == pytest.approx(42.96709)
         assert pep.atoms.loc[1808, "molecule-ID"] == 576
         assert pep.atoms.loc[1808, "type"] == 14
-        assert pep.atoms.loc[1808, "y"] == approx(58.64352)
+        assert pep.atoms.loc[1808, "y"] == pytest.approx(58.64352)
         assert pep.atoms.loc[1808, "nx"] == -1
-        assert pep.velocities.loc[527, "vz"] == approx(-0.010889)
+        assert pep.velocities.loc[527, "vz"] == pytest.approx(-0.010889)
         assert topo["Bonds"].loc[47, "type"] == 8
         assert topo["Bonds"].loc[47, "atom2"] == 54
         assert topo["Bonds"].loc[953, "atom1"] == 1384
@@ -417,7 +416,7 @@ class TestLammpsData(PymatgenTest):
         quartz = self.quartz
         np.testing.assert_array_equal(quartz.box.tilt, [-2.456700, 0.0, 0.0])
         assert list(quartz.atoms.columns) == ["type", "x", "y", "z"]
-        assert quartz.atoms.loc[7, "x"] == approx(0.299963)
+        assert quartz.atoms.loc[7, "x"] == pytest.approx(0.299963)
         # PairIJ Coeffs section
         virus = self.virus
         pair_ij = virus.force_field["PairIJ Coeffs"]
@@ -480,8 +479,8 @@ class TestLammpsData(PymatgenTest):
         idx = rng.integers(0, 19)
         a = lattice.matrix[0]
         v_a = velocities[idx].dot(a) / np.linalg.norm(a)
-        assert v_a == approx(lammps_data.velocities.loc[idx + 1, "vx"])
-        assert velocities[idx, 1] == approx(lammps_data.velocities.loc[idx + 1, "vy"])
+        assert v_a == pytest.approx(lammps_data.velocities.loc[idx + 1, "vx"])
+        assert velocities[idx, 1] == pytest.approx(lammps_data.velocities.loc[idx + 1, "vy"])
         assert_allclose(lammps_data.masses["mass"], [22.989769, 190.23, 15.9994])
         np.testing.assert_array_equal(lammps_data.atoms["type"], [2] * 4 + [3] * 16)
 
@@ -854,10 +853,10 @@ class TestCombinedData(TestCase):
         assert ec_fec.atoms.loc[29, "molecule-ID"] == 3
         assert ec_fec.atoms.loc[29, "type"] == 5
         assert ec_fec.atoms.loc[29, "q"] == 0.0755
-        assert ec_fec.atoms.loc[29, "x"] == approx(14.442260)
+        assert ec_fec.atoms.loc[29, "x"] == pytest.approx(14.442260)
         assert ec_fec.atoms.loc[14958, "molecule-ID"] == 1496
         assert ec_fec.atoms.loc[14958, "type"] == 11
-        assert ec_fec.atoms.loc[14958, "y"] == approx(41.010962)
+        assert ec_fec.atoms.loc[14958, "y"] == pytest.approx(41.010962)
         assert topo["Bonds"].loc[47, "type"] == 5
         assert topo["Bonds"].loc[47, "atom2"] == 47
         assert topo["Bonds"].loc[953, "atom1"] == 951
@@ -905,10 +904,10 @@ class TestCombinedData(TestCase):
         assert ec_fec.atoms.loc[29, "molecule-ID"] == 3
         assert ec_fec.atoms.loc[29, "type"] == 5
         assert ec_fec.atoms.loc[29, "q"] == 0.0755
-        assert ec_fec.atoms.loc[29, "x"] == approx(14.442260)
+        assert ec_fec.atoms.loc[29, "x"] == pytest.approx(14.442260)
         assert ec_fec.atoms.loc[14958, "molecule-ID"] == 1496
         assert ec_fec.atoms.loc[14958, "type"] == 11
-        assert ec_fec.atoms.loc[14958, "y"] == approx(41.010962)
+        assert ec_fec.atoms.loc[14958, "y"] == pytest.approx(41.010962)
         assert topo["Bonds"].loc[47, "type"] == 5
         assert topo["Bonds"].loc[47, "atom2"] == 47
         assert topo["Bonds"].loc[953, "atom1"] == 951
@@ -1124,10 +1123,10 @@ class TestCombinedData(TestCase):
         assert ec_fec.atoms.loc[29, "molecule-ID"] == 3
         assert ec_fec.atoms.loc[29, "type"] == 5
         assert ec_fec.atoms.loc[29, "q"] == 0.0755
-        assert ec_fec.atoms.loc[29, "x"] == approx(14.442260)
+        assert ec_fec.atoms.loc[29, "x"] == pytest.approx(14.442260)
         assert ec_fec.atoms.loc[14958, "molecule-ID"] == 1496
         assert ec_fec.atoms.loc[14958, "type"] == 11
-        assert ec_fec.atoms.loc[14958, "y"] == approx(41.010962)
+        assert ec_fec.atoms.loc[14958, "y"] == pytest.approx(41.010962)
         assert topo["Bonds"].loc[47, "type"] == 5
         assert topo["Bonds"].loc[47, "atom2"] == 47
         assert topo["Bonds"].loc[953, "atom1"] == 951

--- a/tests/io/lobster/test_inputs.py
+++ b/tests/io/lobster/test_inputs.py
@@ -7,7 +7,6 @@ from unittest import TestCase
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_array_equal
-from pytest import approx
 
 from pymatgen.core.structure import Structure
 from pymatgen.electronic_structure.cohp import IcohpCollection
@@ -158,21 +157,21 @@ class TestCohpcar(PymatgenTest):
         assert self.cohp_KF.efermi == efermi_KF
         assert self.coop_KF.efermi == efermi_KF
 
-        assert self.cohp_bise.energies[0] + self.cohp_bise.efermi == approx(elim_bise[0], abs=1e-4)
-        assert self.cohp_bise.energies[-1] + self.cohp_bise.efermi == approx(elim_bise[1], abs=1e-4)
-        assert self.coop_bise.energies[0] + self.coop_bise.efermi == approx(elim_bise[0], abs=1e-4)
-        assert self.coop_bise.energies[-1] + self.coop_bise.efermi == approx(elim_bise[1], abs=1e-4)
+        assert self.cohp_bise.energies[0] + self.cohp_bise.efermi == pytest.approx(elim_bise[0], abs=1e-4)
+        assert self.cohp_bise.energies[-1] + self.cohp_bise.efermi == pytest.approx(elim_bise[1], abs=1e-4)
+        assert self.coop_bise.energies[0] + self.coop_bise.efermi == pytest.approx(elim_bise[0], abs=1e-4)
+        assert self.coop_bise.energies[-1] + self.coop_bise.efermi == pytest.approx(elim_bise[1], abs=1e-4)
 
-        assert self.cohp_fe.energies[0] + self.cohp_fe.efermi == approx(elim_fe[0], abs=1e-4)
-        assert self.cohp_fe.energies[-1] + self.cohp_fe.efermi == approx(elim_fe[1], abs=1e-4)
-        assert self.coop_fe.energies[0] + self.coop_fe.efermi == approx(elim_fe[0], abs=1e-4)
-        assert self.coop_fe.energies[-1] + self.coop_fe.efermi == approx(elim_fe[1], abs=1e-4)
+        assert self.cohp_fe.energies[0] + self.cohp_fe.efermi == pytest.approx(elim_fe[0], abs=1e-4)
+        assert self.cohp_fe.energies[-1] + self.cohp_fe.efermi == pytest.approx(elim_fe[1], abs=1e-4)
+        assert self.coop_fe.energies[0] + self.coop_fe.efermi == pytest.approx(elim_fe[0], abs=1e-4)
+        assert self.coop_fe.energies[-1] + self.coop_fe.efermi == pytest.approx(elim_fe[1], abs=1e-4)
 
         # Lobster 3.1
-        assert self.cohp_KF.energies[0] + self.cohp_KF.efermi == approx(elim_KF[0], abs=1e-4)
-        assert self.cohp_KF.energies[-1] + self.cohp_KF.efermi == approx(elim_KF[1], abs=1e-4)
-        assert self.coop_KF.energies[0] + self.coop_KF.efermi == approx(elim_KF[0], abs=1e-4)
-        assert self.coop_KF.energies[-1] + self.coop_KF.efermi == approx(elim_KF[1], abs=1e-4)
+        assert self.cohp_KF.energies[0] + self.cohp_KF.efermi == pytest.approx(elim_KF[0], abs=1e-4)
+        assert self.cohp_KF.energies[-1] + self.cohp_KF.efermi == pytest.approx(elim_KF[1], abs=1e-4)
+        assert self.coop_KF.energies[0] + self.coop_KF.efermi == pytest.approx(elim_KF[0], abs=1e-4)
+        assert self.coop_KF.energies[-1] + self.coop_KF.efermi == pytest.approx(elim_KF[1], abs=1e-4)
 
     def test_cohp_data(self):
         lengths_sites_bise = {
@@ -258,13 +257,13 @@ class TestCohpcar(PymatgenTest):
                         assert len(val["COHP"][Spin.up]) == 12
                         assert len(val["COHP"][Spin.down]) == 12
                         for cohp1, cohp2 in zip(val["COHP"][Spin.up], val["COHP"][Spin.down], strict=True):
-                            assert cohp1 == approx(cohp2, abs=1e-4)
+                            assert cohp1 == pytest.approx(cohp2, abs=1e-4)
                     else:
                         assert len(val["cells"]) == 2
                         assert len(val["COHP"][Spin.up]) == 12
                         assert len(val["COHP"][Spin.down]) == 12
                         for cohp1, cohp2 in zip(val["COHP"][Spin.up], val["COHP"][Spin.down], strict=True):
-                            assert cohp1 == approx(cohp2, abs=1e-3)
+                            assert cohp1 == pytest.approx(cohp2, abs=1e-3)
 
     def test_orbital_resolved_cohp(self):
         orbitals = [(Orbital(jj), Orbital(ii)) for ii in range(4) for jj in range(4)]
@@ -305,7 +304,7 @@ class TestCohpcar(PymatgenTest):
             assert orb_set[0][0] == ref_list1[iorb]
             assert str(orb_set[0][1]) == ref_list2[iorb]
 
-        # The sum of the orbital-resolved COHPs should be approximately
+        # The sum of the orbital-resolved COHPs should be pytest.approximately
         # the total COHP. Due to small deviations in the LOBSTER calculation,
         # the precision is not very high though.
         cohp = self.orb.cohp_data["1"]["COHP"][Spin.up]
@@ -618,12 +617,18 @@ class TestIcohplist(TestCase):
         assert self.icoop_fe.icohpcollection.extremum_icohpvalue() == -0.29919
         assert icooplist_bise == self.icoop_bise.icohplist
         assert self.icoop_bise.icohpcollection.extremum_icohpvalue() == 0.24714
-        assert self.icobi.icohplist["1"]["icohp"][Spin.up] == approx(0.58649)
-        assert self.icobi_orbitalwise.icohplist["2"]["icohp"][Spin.up] == approx(0.58649)
-        assert self.icobi_orbitalwise.icohplist["1"]["icohp"][Spin.up] == approx(0.58649)
-        assert self.icobi_orbitalwise_spinpolarized.icohplist["1"]["icohp"][Spin.up] == approx(0.58649 / 2, abs=1e-3)
-        assert self.icobi_orbitalwise_spinpolarized.icohplist["1"]["icohp"][Spin.down] == approx(0.58649 / 2, abs=1e-3)
-        assert self.icobi_orbitalwise_spinpolarized.icohplist["2"]["icohp"][Spin.down] == approx(0.58649 / 2, abs=1e-3)
+        assert self.icobi.icohplist["1"]["icohp"][Spin.up] == pytest.approx(0.58649)
+        assert self.icobi_orbitalwise.icohplist["2"]["icohp"][Spin.up] == pytest.approx(0.58649)
+        assert self.icobi_orbitalwise.icohplist["1"]["icohp"][Spin.up] == pytest.approx(0.58649)
+        assert self.icobi_orbitalwise_spinpolarized.icohplist["1"]["icohp"][Spin.up] == pytest.approx(
+            0.58649 / 2, abs=1e-3
+        )
+        assert self.icobi_orbitalwise_spinpolarized.icohplist["1"]["icohp"][Spin.down] == pytest.approx(
+            0.58649 / 2, abs=1e-3
+        )
+        assert self.icobi_orbitalwise_spinpolarized.icohplist["2"]["icohp"][Spin.down] == pytest.approx(
+            0.58649 / 2, abs=1e-3
+        )
         assert self.icobi.icohpcollection.extremum_icohpvalue() == 0.58649
         assert self.icobi_orbitalwise_spinpolarized.icohplist["2"]["orbitals"]["2s-6s"]["icohp"][Spin.up] == 0.0247
 
@@ -657,8 +662,8 @@ class TestNciCobiList(TestCase):
         assert not self.ncicobi_no_spin_wo.orbital_wise
         assert len(self.ncicobi.ncicobi_list) == 2
         assert self.ncicobi.ncicobi_list["2"]["number_of_atoms"] == 3
-        assert self.ncicobi.ncicobi_list["2"]["ncicobi"][Spin.up] == approx(0.00009)
-        assert self.ncicobi.ncicobi_list["2"]["ncicobi"][Spin.down] == approx(0.00009)
+        assert self.ncicobi.ncicobi_list["2"]["ncicobi"][Spin.up] == pytest.approx(0.00009)
+        assert self.ncicobi.ncicobi_list["2"]["ncicobi"][Spin.down] == pytest.approx(0.00009)
         assert self.ncicobi.ncicobi_list["2"]["interaction_type"] == "[X22[0,0,0]->Xs42[0,0,0]->X31[0,0,0]]"
         assert (
             self.ncicobi.ncicobi_list["2"]["ncicobi"][Spin.up] == self.ncicobi_wo.ncicobi_list["2"]["ncicobi"][Spin.up]
@@ -669,7 +674,7 @@ class TestNciCobiList(TestCase):
         assert (
             self.ncicobi.ncicobi_list["2"]["interaction_type"] == self.ncicobi_gz.ncicobi_list["2"]["interaction_type"]
         )
-        assert sum(self.ncicobi.ncicobi_list["2"]["ncicobi"].values()) == approx(
+        assert sum(self.ncicobi.ncicobi_list["2"]["ncicobi"].values()) == pytest.approx(
             self.ncicobi_no_spin.ncicobi_list["2"]["ncicobi"][Spin.up]
         )
 
@@ -717,7 +722,7 @@ class TestDoscar(TestCase):
         assert energies_spin == self.DOSCAR_spin_pol.completedos.energies.tolist()
         assert tdos_up == self.DOSCAR_spin_pol.completedos.densities[Spin.up].tolist()
         assert tdos_down == self.DOSCAR_spin_pol.completedos.densities[Spin.down].tolist()
-        assert fermi == approx(self.DOSCAR_spin_pol.completedos.efermi)
+        assert fermi == pytest.approx(self.DOSCAR_spin_pol.completedos.efermi)
 
         assert_allclose(
             self.DOSCAR_spin_pol.completedos.structure.frac_coords,
@@ -747,7 +752,7 @@ class TestDoscar(TestCase):
 
         assert tdos_nonspin == self.DOSCAR_nonspin_pol.completedos.densities[Spin.up].tolist()
 
-        assert fermi == approx(self.DOSCAR_nonspin_pol.completedos.efermi)
+        assert fermi == pytest.approx(self.DOSCAR_nonspin_pol.completedos.efermi)
 
         assert self.DOSCAR_nonspin_pol.completedos.structure == self.structure
 
@@ -798,7 +803,7 @@ class TestDoscar(TestCase):
         assert energies_spin == self.DOSCAR_spin_pol.tdos.energies.tolist()
         assert tdos_up == self.DOSCAR_spin_pol.tdos.densities[Spin.up].tolist()
         assert tdos_down == self.DOSCAR_spin_pol.tdos.densities[Spin.down].tolist()
-        assert fermi == approx(self.DOSCAR_spin_pol.tdos.efermi)
+        assert fermi == pytest.approx(self.DOSCAR_spin_pol.tdos.efermi)
 
         energies_nonspin = [-11.25000, -7.50000, -3.75000, 0.00000, 3.75000, 7.50000]
         tdos_nonspin = [0.00000, 1.60000, 0.00000, 1.60000, 0.00000, 0.02418]
@@ -806,7 +811,7 @@ class TestDoscar(TestCase):
 
         assert energies_nonspin == self.DOSCAR_nonspin_pol.tdos.energies.tolist()
         assert tdos_nonspin == self.DOSCAR_nonspin_pol.tdos.densities[Spin.up].tolist()
-        assert fermi == approx(self.DOSCAR_nonspin_pol.tdos.efermi)
+        assert fermi == pytest.approx(self.DOSCAR_nonspin_pol.tdos.efermi)
 
     def test_energies(self):
         # first for spin polarized version
@@ -963,7 +968,7 @@ class TestLobsterout(PymatgenTest):
             "user_time": {"h": "0", "min": "0", "s": "20", "ms": "330"},
             "sys_time": {"h": "0", "min": "0", "s": "0", "ms": "310"},
         }
-        assert self.lobsterout_normal.total_spilling[0] == approx([0.044000000000000004][0])
+        assert self.lobsterout_normal.total_spilling[0] == pytest.approx([0.044000000000000004][0])
         assert self.lobsterout_normal.warning_lines == [
             "3 of 147 k-points could not be orthonormalized with an accuracy of 1.0E-5.",
             "Generally, this is not a critical error. But to help you analyze it,",
@@ -1005,7 +1010,9 @@ class TestLobsterout(PymatgenTest):
             "user_time": {"h": "0", "min": "0", "s": "18", "ms": "280"},
             "sys_time": {"h": "0", "min": "0", "s": "0", "ms": "290"},
         }
-        assert self.lobsterout_fatband_grosspop_densityofenergies.total_spilling[0] == approx([0.044000000000000004][0])
+        assert self.lobsterout_fatband_grosspop_densityofenergies.total_spilling[0] == pytest.approx(
+            [0.044000000000000004][0]
+        )
         assert self.lobsterout_fatband_grosspop_densityofenergies.warning_lines == [
             "3 of 147 k-points could not be orthonormalized with an accuracy of 1.0E-5.",
             "Generally, this is not a critical error. But to help you analyze it,",
@@ -1047,7 +1054,7 @@ class TestLobsterout(PymatgenTest):
             "user_time": {"h": "0", "min": "0", "s": "18", "ms": "250"},
             "sys_time": {"h": "0", "min": "0", "s": "0", "ms": "320"},
         }
-        assert self.lobsterout_saveprojection.total_spilling[0] == approx([0.044000000000000004][0])
+        assert self.lobsterout_saveprojection.total_spilling[0] == pytest.approx([0.044000000000000004][0])
         assert self.lobsterout_saveprojection.warning_lines == [
             "3 of 147 k-points could not be orthonormalized with an accuracy of 1.0E-5.",
             "Generally, this is not a critical error. But to help you analyze it,",
@@ -1091,7 +1098,7 @@ class TestLobsterout(PymatgenTest):
             "user_time": {"h": "0", "min": "0", "s": "16", "ms": "79"},
             "sys_time": {"h": "0", "min": "0", "s": "0", "ms": "320"},
         }
-        assert self.lobsterout_skipping_all.total_spilling[0] == approx([0.044000000000000004][0])
+        assert self.lobsterout_skipping_all.total_spilling[0] == pytest.approx([0.044000000000000004][0])
         assert self.lobsterout_skipping_all.warning_lines == [
             "3 of 147 k-points could not be orthonormalized with an accuracy of 1.0E-5.",
             "Generally, this is not a critical error. But to help you analyze it,",
@@ -1114,8 +1121,8 @@ class TestLobsterout(PymatgenTest):
             ]
         ]
         assert self.lobsterout_twospins.basis_type == ["pbeVaspFit2015"]
-        assert self.lobsterout_twospins.charge_spilling[0] == approx(0.36619999999999997)
-        assert self.lobsterout_twospins.charge_spilling[1] == approx(0.36619999999999997)
+        assert self.lobsterout_twospins.charge_spilling[0] == pytest.approx(0.36619999999999997)
+        assert self.lobsterout_twospins.charge_spilling[1] == pytest.approx(0.36619999999999997)
         assert self.lobsterout_twospins.dft_program == "VASP"
         assert self.lobsterout_twospins.elements == ["Ti"]
         assert self.lobsterout_twospins.has_charge
@@ -1144,8 +1151,8 @@ class TestLobsterout(PymatgenTest):
             "user_time": {"h": "0", "min": "0", "s": "22", "ms": "660"},
             "sys_time": {"h": "0", "min": "0", "s": "0", "ms": "310"},
         }
-        assert self.lobsterout_twospins.total_spilling[0] == approx([0.2567][0])
-        assert self.lobsterout_twospins.total_spilling[1] == approx([0.2567][0])
+        assert self.lobsterout_twospins.total_spilling[0] == pytest.approx([0.2567][0])
+        assert self.lobsterout_twospins.total_spilling[1] == pytest.approx([0.2567][0])
         assert self.lobsterout_twospins.warning_lines == [
             "60 of 294 k-points could not be orthonormalized with an accuracy of 1.0E-5.",
             "Generally, this is not a critical error. But to help you analyze it,",
@@ -1156,7 +1163,7 @@ class TestLobsterout(PymatgenTest):
 
         assert self.lobsterout_from_projection.basis_functions == []
         assert self.lobsterout_from_projection.basis_type == []
-        assert self.lobsterout_from_projection.charge_spilling[0] == approx(0.0177)
+        assert self.lobsterout_from_projection.charge_spilling[0] == pytest.approx(0.0177)
         assert self.lobsterout_from_projection.dft_program is None
         assert self.lobsterout_from_projection.elements == []
         assert self.lobsterout_from_projection.has_charge
@@ -1179,7 +1186,7 @@ class TestLobsterout(PymatgenTest):
             "user_time": {"h": "0", "min": "15", "s": "10", "ms": "530"},
             "sys_time": {"h": "0", "min": "0", "s": "0", "ms": "400"},
         }
-        assert self.lobsterout_from_projection.total_spilling[0] == approx([0.1543][0])
+        assert self.lobsterout_from_projection.total_spilling[0] == pytest.approx([0.1543][0])
         assert self.lobsterout_from_projection.warning_lines == []
 
         assert self.lobsterout_GaAs.basis_functions == [
@@ -1197,7 +1204,7 @@ class TestLobsterout(PymatgenTest):
             ],
         ]
         assert self.lobsterout_GaAs.basis_type == ["Bunge", "Bunge"]
-        assert self.lobsterout_GaAs.charge_spilling[0] == approx(0.0089)
+        assert self.lobsterout_GaAs.charge_spilling[0] == pytest.approx(0.0089)
         assert self.lobsterout_GaAs.dft_program == "VASP"
         assert self.lobsterout_GaAs.elements == ["As", "Ga"]
         assert self.lobsterout_GaAs.has_charge
@@ -1224,7 +1231,7 @@ class TestLobsterout(PymatgenTest):
             "user_time": {"h": "0", "min": "0", "s": "12", "ms": "370"},
             "sys_time": {"h": "0", "min": "0", "s": "0", "ms": "180"},
         }
-        assert self.lobsterout_GaAs.total_spilling[0] == approx([0.0859][0])
+        assert self.lobsterout_GaAs.total_spilling[0] == pytest.approx([0.0859][0])
 
         assert self.lobsterout_onethread.number_of_threads == 1
         # Test lobsterout of lobster-4.1.0
@@ -1298,7 +1305,7 @@ class TestLobsterout(PymatgenTest):
                 elif isinstance(item, int):
                     assert ref_data[key] == item
                 elif key in ("charge_spilling", "total_spilling"):
-                    assert item[0] == approx(ref_data[key][0])
+                    assert item[0] == pytest.approx(ref_data[key][0])
                 elif isinstance(item, list | dict):
                     assert item == ref_data[key]
 
@@ -1364,53 +1371,53 @@ class TestFatband(PymatgenTest):
         self.bs_symmline_spin = self.vasprun_SiO2_p.get_band_structure(line_mode=True, force_hybrid_mode=True)
 
     def test_attributes(self):
-        assert list(self.fatband_SiO2_p_x.label_dict["M"]) == approx([0.5, 0.0, 0.0])
+        assert list(self.fatband_SiO2_p_x.label_dict["M"]) == pytest.approx([0.5, 0.0, 0.0])
         assert self.fatband_SiO2_p_x.efermi == self.vasprun_SiO2_p_x.efermi
         lattice1 = self.bs_symmline.lattice_rec.as_dict()
         lattice2 = self.fatband_SiO2_p_x.lattice.as_dict()
         for idx in range(3):
-            assert lattice1["matrix"][idx] == approx(lattice2["matrix"][idx])
+            assert lattice1["matrix"][idx] == pytest.approx(lattice2["matrix"][idx])
         assert self.fatband_SiO2_p_x.eigenvals[Spin.up][1][1] - self.fatband_SiO2_p_x.efermi == -18.245
         assert self.fatband_SiO2_p_x.is_spinpolarized is False
-        assert self.fatband_SiO2_p_x.kpoints_array[3] == approx([0.03409091, 0, 0])
+        assert self.fatband_SiO2_p_x.kpoints_array[3] == pytest.approx([0.03409091, 0, 0])
         assert self.fatband_SiO2_p_x.nbands == 36
         assert self.fatband_SiO2_p_x.p_eigenvals[Spin.up][2][1]["Si1"]["3p_x"] == 0.002
-        assert self.fatband_SiO2_p_x.structure[0].frac_coords == approx([0.0, 0.47634315, 0.666667])
+        assert self.fatband_SiO2_p_x.structure[0].frac_coords == pytest.approx([0.0, 0.47634315, 0.666667])
         assert self.fatband_SiO2_p_x.structure[0].species_string == "Si"
-        assert self.fatband_SiO2_p_x.structure[0].coords == approx([-1.19607309, 2.0716597, 3.67462144])
+        assert self.fatband_SiO2_p_x.structure[0].coords == pytest.approx([-1.19607309, 2.0716597, 3.67462144])
 
-        assert list(self.fatband_SiO2_p.label_dict["M"]) == approx([0.5, 0.0, 0.0])
+        assert list(self.fatband_SiO2_p.label_dict["M"]) == pytest.approx([0.5, 0.0, 0.0])
         assert self.fatband_SiO2_p.efermi == self.vasprun_SiO2_p.efermi
         lattice1 = self.bs_symmline2.lattice_rec.as_dict()
         lattice2 = self.fatband_SiO2_p.lattice.as_dict()
         for idx in range(3):
-            assert lattice1["matrix"][idx] == approx(lattice2["matrix"][idx])
+            assert lattice1["matrix"][idx] == pytest.approx(lattice2["matrix"][idx])
         assert self.fatband_SiO2_p.eigenvals[Spin.up][1][1] - self.fatband_SiO2_p.efermi == -18.245
         assert self.fatband_SiO2_p.is_spinpolarized is False
-        assert self.fatband_SiO2_p.kpoints_array[3] == approx([0.03409091, 0, 0])
+        assert self.fatband_SiO2_p.kpoints_array[3] == pytest.approx([0.03409091, 0, 0])
         assert self.fatband_SiO2_p.nbands == 36
         assert self.fatband_SiO2_p.p_eigenvals[Spin.up][2][1]["Si1"]["3p"] == 0.042
-        assert self.fatband_SiO2_p.structure[0].frac_coords == approx([0.0, 0.47634315, 0.666667])
+        assert self.fatband_SiO2_p.structure[0].frac_coords == pytest.approx([0.0, 0.47634315, 0.666667])
         assert self.fatband_SiO2_p.structure[0].species_string == "Si"
-        assert self.fatband_SiO2_p.structure[0].coords == approx([-1.19607309, 2.0716597, 3.67462144])
-        assert self.fatband_SiO2_p.efermi == approx(1.0647039)
+        assert self.fatband_SiO2_p.structure[0].coords == pytest.approx([-1.19607309, 2.0716597, 3.67462144])
+        assert self.fatband_SiO2_p.efermi == pytest.approx(1.0647039)
 
-        assert list(self.fatband_SiO2_spin.label_dict["M"]) == approx([0.5, 0.0, 0.0])
+        assert list(self.fatband_SiO2_spin.label_dict["M"]) == pytest.approx([0.5, 0.0, 0.0])
         assert self.fatband_SiO2_spin.efermi == self.vasprun_SiO2_spin.efermi
         lattice1 = self.bs_symmline_spin.lattice_rec.as_dict()
         lattice2 = self.fatband_SiO2_spin.lattice.as_dict()
         for idx in range(3):
-            assert lattice1["matrix"][idx] == approx(lattice2["matrix"][idx])
+            assert lattice1["matrix"][idx] == pytest.approx(lattice2["matrix"][idx])
         assert self.fatband_SiO2_spin.eigenvals[Spin.up][1][1] - self.fatband_SiO2_spin.efermi == -18.245
         assert self.fatband_SiO2_spin.eigenvals[Spin.down][1][1] - self.fatband_SiO2_spin.efermi == -18.245
         assert self.fatband_SiO2_spin.is_spinpolarized
-        assert self.fatband_SiO2_spin.kpoints_array[3] == approx([0.03409091, 0, 0])
+        assert self.fatband_SiO2_spin.kpoints_array[3] == pytest.approx([0.03409091, 0, 0])
         assert self.fatband_SiO2_spin.nbands == 36
 
         assert self.fatband_SiO2_spin.p_eigenvals[Spin.up][2][1]["Si1"]["3p"] == 0.042
-        assert self.fatband_SiO2_spin.structure[0].frac_coords == approx([0.0, 0.47634315, 0.666667])
+        assert self.fatband_SiO2_spin.structure[0].frac_coords == pytest.approx([0.0, 0.47634315, 0.666667])
         assert self.fatband_SiO2_spin.structure[0].species_string == "Si"
-        assert self.fatband_SiO2_spin.structure[0].coords == approx([-1.19607309, 2.0716597, 3.67462144])
+        assert self.fatband_SiO2_spin.structure[0].coords == pytest.approx([-1.19607309, 2.0716597, 3.67462144])
 
     def test_raises(self):
         with pytest.raises(ValueError, match="vasprun_file or efermi have to be provided"):
@@ -1470,12 +1477,12 @@ class TestFatband(PymatgenTest):
         bs_p = self.fatband_SiO2_p.get_bandstructure()
         atom1 = bs_p.structure[0]
         atom2 = self.bs_symmline2.structure[0]
-        assert atom1.frac_coords[0] == approx(atom2.frac_coords[0])
-        assert atom1.frac_coords[1] == approx(atom2.frac_coords[1])
-        assert atom1.frac_coords[2] == approx(atom2.frac_coords[2])
-        assert atom1.coords[0] == approx(atom2.coords[0])
-        assert atom1.coords[1] == approx(atom2.coords[1])
-        assert atom1.coords[2] == approx(atom2.coords[2])
+        assert atom1.frac_coords[0] == pytest.approx(atom2.frac_coords[0])
+        assert atom1.frac_coords[1] == pytest.approx(atom2.frac_coords[1])
+        assert atom1.frac_coords[2] == pytest.approx(atom2.frac_coords[2])
+        assert atom1.coords[0] == pytest.approx(atom2.coords[0])
+        assert atom1.coords[1] == pytest.approx(atom2.coords[1])
+        assert atom1.coords[2] == pytest.approx(atom2.coords[2])
         assert atom1.species_string == atom2.species_string
         assert bs_p.efermi == self.bs_symmline2.efermi
         branch1 = bs_p.branches[0]
@@ -1484,71 +1491,73 @@ class TestFatband(PymatgenTest):
         assert branch2["start_index"] == branch1["start_index"]
         assert branch2["end_index"] == branch1["end_index"]
 
-        assert bs_p.distance[30] == approx(self.bs_symmline2.distance[30])
+        assert bs_p.distance[30] == pytest.approx(self.bs_symmline2.distance[30])
         lattice1 = bs_p.lattice_rec.as_dict()
         lattice2 = self.bs_symmline2.lattice_rec.as_dict()
-        assert lattice1["matrix"][0] == approx(lattice2["matrix"][0])
-        assert lattice1["matrix"][1] == approx(lattice2["matrix"][1])
-        assert lattice1["matrix"][2] == approx(lattice2["matrix"][2])
+        assert lattice1["matrix"][0] == pytest.approx(lattice2["matrix"][0])
+        assert lattice1["matrix"][1] == pytest.approx(lattice2["matrix"][1])
+        assert lattice1["matrix"][2] == pytest.approx(lattice2["matrix"][2])
 
-        assert bs_p.kpoints[8].frac_coords[0] == approx(self.bs_symmline2.kpoints[8].frac_coords[0])
-        assert bs_p.kpoints[8].frac_coords[1] == approx(self.bs_symmline2.kpoints[8].frac_coords[1])
-        assert bs_p.kpoints[8].frac_coords[2] == approx(self.bs_symmline2.kpoints[8].frac_coords[2])
-        assert bs_p.kpoints[8].cart_coords[0] == approx(self.bs_symmline2.kpoints[8].cart_coords[0])
-        assert bs_p.kpoints[8].cart_coords[1] == approx(self.bs_symmline2.kpoints[8].cart_coords[1])
-        assert bs_p.kpoints[8].cart_coords[2] == approx(self.bs_symmline2.kpoints[8].cart_coords[2])
-        assert bs_p.kpoints[50].frac_coords[0] == approx(self.bs_symmline2.kpoints[50].frac_coords[0])
-        assert bs_p.kpoints[50].frac_coords[1] == approx(self.bs_symmline2.kpoints[50].frac_coords[1])
-        assert bs_p.kpoints[50].frac_coords[2] == approx(self.bs_symmline2.kpoints[50].frac_coords[2])
-        assert bs_p.kpoints[50].cart_coords[0] == approx(self.bs_symmline2.kpoints[50].cart_coords[0])
-        assert bs_p.kpoints[50].cart_coords[1] == approx(self.bs_symmline2.kpoints[50].cart_coords[1])
-        assert bs_p.kpoints[50].cart_coords[2] == approx(self.bs_symmline2.kpoints[50].cart_coords[2])
-        assert bs_p.get_band_gap()["energy"] == approx(self.bs_symmline2.get_band_gap()["energy"], abs=1e-2)
-        assert bs_p.get_projection_on_elements()[Spin.up][0][0]["Si"] == approx(3 * (0.001 + 0.064))
-        assert bs_p.get_projections_on_elements_and_orbitals({"Si": ["3p"]})[Spin.up][0][0]["Si"]["3p"] == approx(0.003)
-        assert bs_p.get_projections_on_elements_and_orbitals({"O": ["2p"]})[Spin.up][0][0]["O"]["2p"] == approx(
+        assert bs_p.kpoints[8].frac_coords[0] == pytest.approx(self.bs_symmline2.kpoints[8].frac_coords[0])
+        assert bs_p.kpoints[8].frac_coords[1] == pytest.approx(self.bs_symmline2.kpoints[8].frac_coords[1])
+        assert bs_p.kpoints[8].frac_coords[2] == pytest.approx(self.bs_symmline2.kpoints[8].frac_coords[2])
+        assert bs_p.kpoints[8].cart_coords[0] == pytest.approx(self.bs_symmline2.kpoints[8].cart_coords[0])
+        assert bs_p.kpoints[8].cart_coords[1] == pytest.approx(self.bs_symmline2.kpoints[8].cart_coords[1])
+        assert bs_p.kpoints[8].cart_coords[2] == pytest.approx(self.bs_symmline2.kpoints[8].cart_coords[2])
+        assert bs_p.kpoints[50].frac_coords[0] == pytest.approx(self.bs_symmline2.kpoints[50].frac_coords[0])
+        assert bs_p.kpoints[50].frac_coords[1] == pytest.approx(self.bs_symmline2.kpoints[50].frac_coords[1])
+        assert bs_p.kpoints[50].frac_coords[2] == pytest.approx(self.bs_symmline2.kpoints[50].frac_coords[2])
+        assert bs_p.kpoints[50].cart_coords[0] == pytest.approx(self.bs_symmline2.kpoints[50].cart_coords[0])
+        assert bs_p.kpoints[50].cart_coords[1] == pytest.approx(self.bs_symmline2.kpoints[50].cart_coords[1])
+        assert bs_p.kpoints[50].cart_coords[2] == pytest.approx(self.bs_symmline2.kpoints[50].cart_coords[2])
+        assert bs_p.get_band_gap()["energy"] == pytest.approx(self.bs_symmline2.get_band_gap()["energy"], abs=1e-2)
+        assert bs_p.get_projection_on_elements()[Spin.up][0][0]["Si"] == pytest.approx(3 * (0.001 + 0.064))
+        assert bs_p.get_projections_on_elements_and_orbitals({"Si": ["3p"]})[Spin.up][0][0]["Si"][
+            "3p"
+        ] == pytest.approx(0.003)
+        assert bs_p.get_projections_on_elements_and_orbitals({"O": ["2p"]})[Spin.up][0][0]["O"]["2p"] == pytest.approx(
             0.002 * 3 + 0.003 * 3
         )
         dict_here = bs_p.get_projections_on_elements_and_orbitals({"Si": ["3s", "3p"], "O": ["2s", "2p"]})[Spin.up][0][
             0
         ]
-        assert dict_here["Si"]["3s"] == approx(0.192)
-        assert dict_here["Si"]["3p"] == approx(0.003)
-        assert dict_here["O"]["2s"] == approx(0.792)
-        assert dict_here["O"]["2p"] == approx(0.015)
+        assert dict_here["Si"]["3s"] == pytest.approx(0.192)
+        assert dict_here["Si"]["3p"] == pytest.approx(0.003)
+        assert dict_here["O"]["2s"] == pytest.approx(0.792)
+        assert dict_here["O"]["2p"] == pytest.approx(0.015)
 
         bs_spin = self.fatband_SiO2_spin.get_bandstructure()
-        assert bs_spin.get_projection_on_elements()[Spin.up][0][0]["Si"] == approx(3 * (0.001 + 0.064))
-        assert bs_spin.get_projections_on_elements_and_orbitals({"Si": ["3p"]})[Spin.up][0][0]["Si"]["3p"] == approx(
-            0.003
-        )
-        assert bs_spin.get_projections_on_elements_and_orbitals({"O": ["2p"]})[Spin.up][0][0]["O"]["2p"] == approx(
-            0.002 * 3 + 0.003 * 3
-        )
+        assert bs_spin.get_projection_on_elements()[Spin.up][0][0]["Si"] == pytest.approx(3 * (0.001 + 0.064))
+        assert bs_spin.get_projections_on_elements_and_orbitals({"Si": ["3p"]})[Spin.up][0][0]["Si"][
+            "3p"
+        ] == pytest.approx(0.003)
+        assert bs_spin.get_projections_on_elements_and_orbitals({"O": ["2p"]})[Spin.up][0][0]["O"][
+            "2p"
+        ] == pytest.approx(0.002 * 3 + 0.003 * 3)
         dict_here = bs_spin.get_projections_on_elements_and_orbitals({"Si": ["3s", "3p"], "O": ["2s", "2p"]})[Spin.up][
             0
         ][0]
-        assert dict_here["Si"]["3s"] == approx(0.192)
-        assert dict_here["Si"]["3p"] == approx(0.003)
-        assert dict_here["O"]["2s"] == approx(0.792)
-        assert dict_here["O"]["2p"] == approx(0.015)
+        assert dict_here["Si"]["3s"] == pytest.approx(0.192)
+        assert dict_here["Si"]["3p"] == pytest.approx(0.003)
+        assert dict_here["O"]["2s"] == pytest.approx(0.792)
+        assert dict_here["O"]["2p"] == pytest.approx(0.015)
 
-        assert bs_spin.get_projection_on_elements()[Spin.up][0][0]["Si"] == approx(3 * (0.001 + 0.064))
-        assert bs_spin.get_projections_on_elements_and_orbitals({"Si": ["3p"]})[Spin.down][0][0]["Si"]["3p"] == approx(
-            0.003
-        )
-        assert bs_spin.get_projections_on_elements_and_orbitals({"O": ["2p"]})[Spin.down][0][0]["O"]["2p"] == approx(
-            0.002 * 3 + 0.003 * 3
-        )
+        assert bs_spin.get_projection_on_elements()[Spin.up][0][0]["Si"] == pytest.approx(3 * (0.001 + 0.064))
+        assert bs_spin.get_projections_on_elements_and_orbitals({"Si": ["3p"]})[Spin.down][0][0]["Si"][
+            "3p"
+        ] == pytest.approx(0.003)
+        assert bs_spin.get_projections_on_elements_and_orbitals({"O": ["2p"]})[Spin.down][0][0]["O"][
+            "2p"
+        ] == pytest.approx(0.002 * 3 + 0.003 * 3)
         dict_here = bs_spin.get_projections_on_elements_and_orbitals({"Si": ["3s", "3p"], "O": ["2s", "2p"]})[
             Spin.down
         ][0][0]
-        assert dict_here["Si"]["3s"] == approx(0.192)
-        assert dict_here["Si"]["3p"] == approx(0.003)
-        assert dict_here["O"]["2s"] == approx(0.792)
-        assert dict_here["O"]["2p"] == approx(0.015)
+        assert dict_here["Si"]["3s"] == pytest.approx(0.192)
+        assert dict_here["Si"]["3p"] == pytest.approx(0.003)
+        assert dict_here["O"]["2s"] == pytest.approx(0.792)
+        assert dict_here["O"]["2p"] == pytest.approx(0.015)
         bs_p_x = self.fatband_SiO2_p_x.get_bandstructure()
-        assert bs_p_x.get_projection_on_elements()[Spin.up][0][0]["Si"] == approx(3 * (0.001 + 0.064), abs=1e-2)
+        assert bs_p_x.get_projection_on_elements()[Spin.up][0][0]["Si"] == pytest.approx(3 * (0.001 + 0.064), abs=1e-2)
 
 
 class TestLobsterin(PymatgenTest):
@@ -1560,10 +1569,10 @@ class TestLobsterin(PymatgenTest):
 
     def test_from_file(self):
         # Test reading from file
-        assert self.Lobsterin["cohpstartenergy"] == approx(-15.0)
-        assert self.Lobsterin["cohpendenergy"] == approx(5.0)
+        assert self.Lobsterin["cohpstartenergy"] == pytest.approx(-15.0)
+        assert self.Lobsterin["cohpendenergy"] == pytest.approx(5.0)
         assert self.Lobsterin["basisset"] == "pbeVaspFit2015"
-        assert self.Lobsterin["gaussiansmearingwidth"] == approx(0.1)
+        assert self.Lobsterin["gaussiansmearingwidth"] == pytest.approx(0.1)
         assert self.Lobsterin["basisfunctions"][0] == "Fe 3d 4p 4s"
         assert self.Lobsterin["basisfunctions"][1] == "Co 3d 4p 4s"
         assert self.Lobsterin["skipdos"]
@@ -1603,7 +1612,7 @@ class TestLobsterin(PymatgenTest):
         should be case independent.
         """
         # Test __setitem__
-        assert self.Lobsterin["COHPSTARTENERGY"] == approx(-15.0)
+        assert self.Lobsterin["COHPSTARTENERGY"] == pytest.approx(-15.0)
 
         with pytest.raises(KeyError, match="Key hello is currently not available"):
             self.Lobsterin["HELLO"] = True
@@ -1638,10 +1647,10 @@ class TestLobsterin(PymatgenTest):
                 "skipgrosspopulation": True,
             }
         )
-        assert lobsterin["cohpstartenergy"] == approx(-15.0)
-        assert lobsterin["cohpendenergy"] == approx(5.0)
+        assert lobsterin["cohpstartenergy"] == pytest.approx(-15.0)
+        assert lobsterin["cohpendenergy"] == pytest.approx(5.0)
         assert lobsterin["basisset"] == "pbeVaspFit2015"
-        assert lobsterin["gaussiansmearingwidth"] == approx(0.1)
+        assert lobsterin["gaussiansmearingwidth"] == pytest.approx(0.1)
         assert lobsterin["basisfunctions"][0] == "Fe 3d 4p 4s"
         assert lobsterin["basisfunctions"][1] == "Co 3d 4p 4s"
         assert {*lobsterin} >= {"skipdos", "skipcohp", "skipcoop", "skippopulationanalysis", "skipgrosspopulation"}
@@ -1672,10 +1681,10 @@ class TestLobsterin(PymatgenTest):
                 f"{VASP_IN_DIR}/POTCAR_Fe3O4.gz",
                 option=option,
             )
-            assert lobsterin1["cohpstartenergy"] == approx(-35.0)
-            assert lobsterin1["cohpendenergy"] == approx(5.0)
+            assert lobsterin1["cohpstartenergy"] == pytest.approx(-35.0)
+            assert lobsterin1["cohpendenergy"] == pytest.approx(5.0)
             assert lobsterin1["basisset"] == "pbeVaspFit2015"
-            assert lobsterin1["gaussiansmearingwidth"] == approx(0.1)
+            assert lobsterin1["gaussiansmearingwidth"] == pytest.approx(0.1)
             assert lobsterin1["basisfunctions"][0] == "Fe 3d 4p 4s "
             assert lobsterin1["basisfunctions"][1] == "O 2p 2s "
 
@@ -1785,7 +1794,7 @@ class TestLobsterin(PymatgenTest):
     def test_diff(self):
         # test diff
         assert self.Lobsterin.diff(self.Lobsterin2)["Different"] == {}
-        assert self.Lobsterin.diff(self.Lobsterin2)["Same"]["cohpstartenergy"] == approx(-15.0)
+        assert self.Lobsterin.diff(self.Lobsterin2)["Same"]["cohpstartenergy"] == pytest.approx(-15.0)
 
         # test diff in both directions
         for entry in self.Lobsterin.diff(self.Lobsterin3)["Same"]:
@@ -1947,9 +1956,9 @@ class TestLobsterin(PymatgenTest):
         )
         kpoint = Kpoints.from_file(outfile_path)
         assert kpoint.num_kpts == 562
-        assert kpoint.kpts[-1][0] == approx(-0.5)
-        assert kpoint.kpts[-1][1] == approx(0.5)
-        assert kpoint.kpts[-1][2] == approx(0.5)
+        assert kpoint.kpts[-1][0] == pytest.approx(-0.5)
+        assert kpoint.kpts[-1][1] == pytest.approx(0.5)
+        assert kpoint.kpts[-1][2] == pytest.approx(0.5)
         assert kpoint.labels[-1] == "T"
         kpoint2 = Kpoints.from_file(f"{VASP_IN_DIR}/KPOINTS_band.lobster")
 
@@ -1984,9 +1993,9 @@ class TestLobsterin(PymatgenTest):
         kpoint2 = Kpoints.from_file(f"{VASP_OUT_DIR}/IBZKPT.lobster")
 
         for num_kpt, list_kpoint in enumerate(kpoint.kpts):
-            assert list_kpoint[0] == approx(kpoint2.kpts[num_kpt][0])
-            assert list_kpoint[1] == approx(kpoint2.kpts[num_kpt][1])
-            assert list_kpoint[2] == approx(kpoint2.kpts[num_kpt][2])
+            assert list_kpoint[0] == pytest.approx(kpoint2.kpts[num_kpt][0])
+            assert list_kpoint[1] == pytest.approx(kpoint2.kpts[num_kpt][1])
+            assert list_kpoint[2] == pytest.approx(kpoint2.kpts[num_kpt][2])
 
         assert kpoint.num_kpts == 108
 
@@ -2003,9 +2012,9 @@ class TestLobsterin(PymatgenTest):
         kpoint2 = Kpoints.from_file(f"{VASP_OUT_DIR}/IBZKPT.lobster")
 
         for num_kpt, list_kpoint in enumerate(kpoint.kpts):
-            assert list_kpoint[0] == approx(kpoint2.kpts[num_kpt][0])
-            assert list_kpoint[1] == approx(kpoint2.kpts[num_kpt][1])
-            assert list_kpoint[2] == approx(kpoint2.kpts[num_kpt][2])
+            assert list_kpoint[0] == pytest.approx(kpoint2.kpts[num_kpt][0])
+            assert list_kpoint[1] == pytest.approx(kpoint2.kpts[num_kpt][1])
+            assert list_kpoint[2] == pytest.approx(kpoint2.kpts[num_kpt][2])
 
         assert kpoint.num_kpts == 108
 
@@ -2101,28 +2110,30 @@ class TestBandoverlaps(TestCase):
     def test_attributes(self):
         # bandoverlapsdict
         bo_dict = self.band_overlaps1.bandoverlapsdict
-        assert bo_dict[Spin.up]["max_deviations"][0] == approx(0.000278953)
-        assert self.band_overlaps1_new.bandoverlapsdict[Spin.up]["max_deviations"][10] == approx(0.0640933)
-        assert bo_dict[Spin.up]["matrices"][0].item(-1, -1) == approx(0.0188058)
-        assert self.band_overlaps1_new.bandoverlapsdict[Spin.up]["matrices"][10].item(-1, -1) == approx(1.0)
-        assert bo_dict[Spin.up]["matrices"][0].item(0, 0) == approx(1)
-        assert self.band_overlaps1_new.bandoverlapsdict[Spin.up]["matrices"][10].item(0, 0) == approx(0.995849)
+        assert bo_dict[Spin.up]["max_deviations"][0] == pytest.approx(0.000278953)
+        assert self.band_overlaps1_new.bandoverlapsdict[Spin.up]["max_deviations"][10] == pytest.approx(0.0640933)
+        assert bo_dict[Spin.up]["matrices"][0].item(-1, -1) == pytest.approx(0.0188058)
+        assert self.band_overlaps1_new.bandoverlapsdict[Spin.up]["matrices"][10].item(-1, -1) == pytest.approx(1.0)
+        assert bo_dict[Spin.up]["matrices"][0].item(0, 0) == pytest.approx(1)
+        assert self.band_overlaps1_new.bandoverlapsdict[Spin.up]["matrices"][10].item(0, 0) == pytest.approx(0.995849)
 
-        assert bo_dict[Spin.down]["max_deviations"][-1] == approx(4.31567e-05)
-        assert self.band_overlaps1_new.bandoverlapsdict[Spin.down]["max_deviations"][9] == approx(0.064369)
-        assert bo_dict[Spin.down]["matrices"][-1].item(0, -1) == approx(4.0066e-07)
-        assert self.band_overlaps1_new.bandoverlapsdict[Spin.down]["matrices"][9].item(0, -1) == approx(1.37447e-09)
+        assert bo_dict[Spin.down]["max_deviations"][-1] == pytest.approx(4.31567e-05)
+        assert self.band_overlaps1_new.bandoverlapsdict[Spin.down]["max_deviations"][9] == pytest.approx(0.064369)
+        assert bo_dict[Spin.down]["matrices"][-1].item(0, -1) == pytest.approx(4.0066e-07)
+        assert self.band_overlaps1_new.bandoverlapsdict[Spin.down]["matrices"][9].item(0, -1) == pytest.approx(
+            1.37447e-09
+        )
 
         # maxDeviation
-        assert self.band_overlaps1.max_deviation[0] == approx(0.000278953)
-        assert self.band_overlaps1_new.max_deviation[0] == approx(0.39824)
-        assert self.band_overlaps1.max_deviation[-1] == approx(4.31567e-05)
-        assert self.band_overlaps1_new.max_deviation[-1] == approx(0.324898)
+        assert self.band_overlaps1.max_deviation[0] == pytest.approx(0.000278953)
+        assert self.band_overlaps1_new.max_deviation[0] == pytest.approx(0.39824)
+        assert self.band_overlaps1.max_deviation[-1] == pytest.approx(4.31567e-05)
+        assert self.band_overlaps1_new.max_deviation[-1] == pytest.approx(0.324898)
 
-        assert self.band_overlaps2.max_deviation[0] == approx(0.000473319)
-        assert self.band_overlaps2_new.max_deviation[0] == approx(0.403249)
-        assert self.band_overlaps2.max_deviation[-1] == approx(1.48451e-05)
-        assert self.band_overlaps2_new.max_deviation[-1] == approx(0.45154)
+        assert self.band_overlaps2.max_deviation[0] == pytest.approx(0.000473319)
+        assert self.band_overlaps2_new.max_deviation[0] == pytest.approx(0.403249)
+        assert self.band_overlaps2.max_deviation[-1] == pytest.approx(1.48451e-05)
+        assert self.band_overlaps2_new.max_deviation[-1] == pytest.approx(0.45154)
 
     def test_has_good_quality(self):
         assert not self.band_overlaps1.has_good_quality_maxDeviation(limit_maxDeviation=0.1)
@@ -2253,22 +2264,22 @@ class TestGrosspop(TestCase):
 
     def test_attributes(self):
         gross_pop_list = self.grosspop1.list_dict_grosspop
-        assert gross_pop_list[0]["Mulliken GP"]["3s"] == approx(0.52)
-        assert gross_pop_list[0]["Mulliken GP"]["3p_y"] == approx(0.38)
-        assert gross_pop_list[0]["Mulliken GP"]["3p_z"] == approx(0.37)
-        assert gross_pop_list[0]["Mulliken GP"]["3p_x"] == approx(0.37)
-        assert gross_pop_list[0]["Mulliken GP"]["total"] == approx(1.64)
+        assert gross_pop_list[0]["Mulliken GP"]["3s"] == pytest.approx(0.52)
+        assert gross_pop_list[0]["Mulliken GP"]["3p_y"] == pytest.approx(0.38)
+        assert gross_pop_list[0]["Mulliken GP"]["3p_z"] == pytest.approx(0.37)
+        assert gross_pop_list[0]["Mulliken GP"]["3p_x"] == pytest.approx(0.37)
+        assert gross_pop_list[0]["Mulliken GP"]["total"] == pytest.approx(1.64)
         assert gross_pop_list[0]["element"] == "Si"
-        assert gross_pop_list[0]["Loewdin GP"]["3s"] == approx(0.61)
-        assert gross_pop_list[0]["Loewdin GP"]["3p_y"] == approx(0.52)
-        assert gross_pop_list[0]["Loewdin GP"]["3p_z"] == approx(0.52)
-        assert gross_pop_list[0]["Loewdin GP"]["3p_x"] == approx(0.52)
-        assert gross_pop_list[0]["Loewdin GP"]["total"] == approx(2.16)
-        assert gross_pop_list[5]["Mulliken GP"]["2s"] == approx(1.80)
-        assert gross_pop_list[5]["Loewdin GP"]["2s"] == approx(1.60)
+        assert gross_pop_list[0]["Loewdin GP"]["3s"] == pytest.approx(0.61)
+        assert gross_pop_list[0]["Loewdin GP"]["3p_y"] == pytest.approx(0.52)
+        assert gross_pop_list[0]["Loewdin GP"]["3p_z"] == pytest.approx(0.52)
+        assert gross_pop_list[0]["Loewdin GP"]["3p_x"] == pytest.approx(0.52)
+        assert gross_pop_list[0]["Loewdin GP"]["total"] == pytest.approx(2.16)
+        assert gross_pop_list[5]["Mulliken GP"]["2s"] == pytest.approx(1.80)
+        assert gross_pop_list[5]["Loewdin GP"]["2s"] == pytest.approx(1.60)
         assert gross_pop_list[5]["element"] == "O"
-        assert gross_pop_list[8]["Mulliken GP"]["2s"] == approx(1.80)
-        assert gross_pop_list[8]["Loewdin GP"]["2s"] == approx(1.60)
+        assert gross_pop_list[8]["Mulliken GP"]["2s"] == pytest.approx(1.80)
+        assert gross_pop_list[8]["Loewdin GP"]["2s"] == pytest.approx(1.60)
         assert gross_pop_list[8]["element"] == "O"
 
     def test_structure_with_grosspop(self):
@@ -2433,15 +2444,15 @@ class TestWavefunction(PymatgenTest):
             f"{TEST_DIR}/LCAOWaveFunctionAfterLSO1PlotOfSpin1Kpoint1band1.gz"
         )
         assert_array_equal([41, 41, 41], grid)
-        assert points[4][0] == approx(0.0000)
-        assert points[4][1] == approx(0.0000)
-        assert points[4][2] == approx(0.4000)
-        assert real[8] == approx(1.38863e-01)
-        assert imaginary[8] == approx(2.89645e-01)
+        assert points[4][0] == pytest.approx(0.0000)
+        assert points[4][1] == pytest.approx(0.0000)
+        assert points[4][2] == pytest.approx(0.4000)
+        assert real[8] == pytest.approx(1.38863e-01)
+        assert imaginary[8] == pytest.approx(2.89645e-01)
         assert len(imaginary) == 41 * 41 * 41
         assert len(real) == 41 * 41 * 41
         assert len(points) == 41 * 41 * 41
-        assert distance[0] == approx(0.0000)
+        assert distance[0] == pytest.approx(0.0000)
 
     def test_set_volumetric_data(self):
         wave1 = Wavefunction(
@@ -2450,8 +2461,8 @@ class TestWavefunction(PymatgenTest):
         )
 
         wave1.set_volumetric_data(grid=wave1.grid, structure=wave1.structure)
-        assert wave1.volumetricdata_real.data["total"][0, 0, 0] == approx(-3.0966)
-        assert wave1.volumetricdata_imaginary.data["total"][0, 0, 0] == approx(-6.45895e00)
+        assert wave1.volumetricdata_real.data["total"][0, 0, 0] == pytest.approx(-3.0966)
+        assert wave1.volumetricdata_imaginary.data["total"][0, 0, 0] == pytest.approx(-6.45895e00)
 
     def test_get_volumetricdata_real(self):
         wave1 = Wavefunction(
@@ -2459,7 +2470,7 @@ class TestWavefunction(PymatgenTest):
             structure=Structure.from_file(f"{TEST_DIR}/POSCAR_O.gz"),
         )
         volumetricdata_real = wave1.get_volumetricdata_real()
-        assert volumetricdata_real.data["total"][0, 0, 0] == approx(-3.0966)
+        assert volumetricdata_real.data["total"][0, 0, 0] == pytest.approx(-3.0966)
 
     def test_get_volumetricdata_imaginary(self):
         wave1 = Wavefunction(
@@ -2467,7 +2478,7 @@ class TestWavefunction(PymatgenTest):
             structure=Structure.from_file(f"{TEST_DIR}/POSCAR_O.gz"),
         )
         volumetricdata_imaginary = wave1.get_volumetricdata_imaginary()
-        assert volumetricdata_imaginary.data["total"][0, 0, 0] == approx(-6.45895e00)
+        assert volumetricdata_imaginary.data["total"][0, 0, 0] == pytest.approx(-6.45895e00)
 
     def test_get_volumetricdata_density(self):
         wave1 = Wavefunction(
@@ -2475,7 +2486,9 @@ class TestWavefunction(PymatgenTest):
             structure=Structure.from_file(f"{TEST_DIR}/POSCAR_O.gz"),
         )
         volumetricdata_density = wave1.get_volumetricdata_density()
-        assert volumetricdata_density.data["total"][0, 0, 0] == approx((-3.0966 * -3.0966) + (-6.45895 * -6.45895))
+        assert volumetricdata_density.data["total"][0, 0, 0] == pytest.approx(
+            (-3.0966 * -3.0966) + (-6.45895 * -6.45895)
+        )
 
     def test_write_file(self):
         wave1 = Wavefunction(
@@ -2502,12 +2515,12 @@ class TestSitePotentials(PymatgenTest):
     def test_attributes(self):
         assert self.sitepotential.sitepotentials_Loewdin == [-8.77, -17.08, 9.57, 9.57, 8.45]
         assert self.sitepotential.sitepotentials_Mulliken == [-11.38, -19.62, 11.18, 11.18, 10.09]
-        assert self.sitepotential.madelungenergies_Loewdin == approx(-28.64)
-        assert self.sitepotential.madelungenergies_Mulliken == approx(-40.02)
+        assert self.sitepotential.madelungenergies_Loewdin == pytest.approx(-28.64)
+        assert self.sitepotential.madelungenergies_Mulliken == pytest.approx(-40.02)
         assert self.sitepotential.atomlist == ["La1", "Ta2", "N3", "N4", "O5"]
         assert self.sitepotential.types == ["La", "Ta", "N", "N", "O"]
         assert self.sitepotential.num_atoms == 5
-        assert self.sitepotential.ewald_splitting == approx(3.14)
+        assert self.sitepotential.ewald_splitting == pytest.approx(3.14)
 
     def test_get_structure(self):
         structure = self.sitepotential.get_structure_with_site_potentials(f"{TEST_DIR}/POSCAR.perovskite")
@@ -2527,9 +2540,9 @@ class TestMadelungEnergies(PymatgenTest):
         self.madelungenergies = MadelungEnergies(filename=f"{TEST_DIR}/MadelungEnergies.lobster.perovskite")
 
     def test_attributes(self):
-        assert self.madelungenergies.madelungenergies_Loewdin == approx(-28.64)
-        assert self.madelungenergies.madelungenergies_Mulliken == approx(-40.02)
-        assert self.madelungenergies.ewald_splitting == approx(3.14)
+        assert self.madelungenergies.madelungenergies_Loewdin == pytest.approx(-28.64)
+        assert self.madelungenergies.madelungenergies_Mulliken == pytest.approx(-40.02)
+        assert self.madelungenergies.ewald_splitting == pytest.approx(3.14)
 
     def test_msonable(self):
         dict_data = self.madelungenergies.as_dict()

--- a/tests/io/lobster/test_lobsterenv.py
+++ b/tests/io/lobster/test_lobsterenv.py
@@ -4,7 +4,6 @@ from unittest import TestCase
 
 import numpy as np
 import pytest
-from pytest import approx
 
 from pymatgen.analysis.graphs import StructureGraph
 from pymatgen.core import Element
@@ -650,9 +649,9 @@ class TestLobsterNeighbors(TestCase):
             edge_properties=True,
             weights=True,
         )
-        assert sg.graph.get_edge_data(0, 1)[0]["ICOHP"] == approx(-0.56541)
-        assert sg.graph.get_edge_data(0, 1)[0]["ICOBI"] == approx(0.08484)
-        assert sg.graph.get_edge_data(0, 1)[0]["ICOOP"] == approx(0.02826)
+        assert sg.graph.get_edge_data(0, 1)[0]["ICOHP"] == pytest.approx(-0.56541)
+        assert sg.graph.get_edge_data(0, 1)[0]["ICOBI"] == pytest.approx(0.08484)
+        assert sg.graph.get_edge_data(0, 1)[0]["ICOOP"] == pytest.approx(0.02826)
         assert sg.graph.get_edge_data(0, 1)[0]["bond_label"] == "21"
         assert sg.graph.get_edge_data(0, 1)[5]["bond_label"] == "30"
         assert isinstance(sg, StructureGraph)
@@ -676,7 +675,7 @@ class TestLobsterNeighbors(TestCase):
     def test_order_parameter(self):
         assert self.chem_env_lobster1_second.get_local_order_parameters(
             structure=Structure.from_file(f"{TEST_DIR}/POSCAR.mp_353.gz"), n=0
-        )["linear"] == approx(1.0)
+        )["linear"] == pytest.approx(1.0)
 
     def test_get_structure_environments(self):
         lse = self.chem_env_lobster1_second.get_light_structure_environment()
@@ -694,16 +693,16 @@ class TestLobsterNeighbors(TestCase):
 
     def test_get_info_icohps_neighbors(self):
         results = self.chem_env_lobster1.get_info_icohps_to_neighbors(isites=[0])
-        assert results[0] == approx(-33.26058)
+        assert results[0] == pytest.approx(-33.26058)
         for bond in results[1]:
-            assert bond == approx(-5.54345, abs=1e-3)
+            assert bond == pytest.approx(-5.54345, abs=1e-3)
         assert results[2] == 6
         assert results[3] == ["27", "30", "48", "49", "64", "73"]
 
         results2 = self.chem_env_lobster1.get_info_icohps_to_neighbors(isites=None)
-        assert results2[0] == approx(-33.26058)
+        assert results2[0] == pytest.approx(-33.26058)
         for bond in results2[1]:
-            assert bond == approx(-5.54345, abs=1e-3)
+            assert bond == pytest.approx(-5.54345, abs=1e-3)
         assert results2[2] == 6
         assert results2[3] == ["27", "30", "48", "49", "64", "73"]
         assert results2[4] == [
@@ -719,7 +718,7 @@ class TestLobsterNeighbors(TestCase):
         # will only look at icohps between cations or anions
         self.chem_env_lobster1.get_info_icohps_to_neighbors(isites=[1])
         assert self.chem_env_lobster1.get_info_icohps_between_neighbors(isites=[1])[2] == 1
-        assert self.chem_env_lobster1.get_info_icohps_between_neighbors(isites=[1])[0] == approx(-0.05507)
+        assert self.chem_env_lobster1.get_info_icohps_between_neighbors(isites=[1])[0] == pytest.approx(-0.05507)
         assert self.chem_env_lobster1.get_info_icohps_between_neighbors(isites=[0])[2] == 15
         # use an example where this is easier to test (e.g., linear environment?)
 
@@ -778,7 +777,7 @@ class TestLobsterNeighbors(TestCase):
             only_bonds_to=None,
             per_bond=False,
         )[1]
-        assert np.sum([coph_thing.icohp[Spin.up], coph_thing.icohp[Spin.down]], axis=0)[300] == approx(
+        assert np.sum([coph_thing.icohp[Spin.up], coph_thing.icohp[Spin.down]], axis=0)[300] == pytest.approx(
             chem_env_lobster1.get_info_icohps_to_neighbors(isites=[0])[0]
         )
 
@@ -790,7 +789,9 @@ class TestLobsterNeighbors(TestCase):
             per_bond=False,
             summed_spin_channels=True,
         )[1]
-        assert coph_thing.icohp[Spin.up][300] == approx(chem_env_lobster1.get_info_icohps_to_neighbors(isites=[0])[0])
+        assert coph_thing.icohp[Spin.up][300] == pytest.approx(
+            chem_env_lobster1.get_info_icohps_to_neighbors(isites=[0])[0]
+        )
 
         plot_label, summed_cohpcar_mp_190_Te = chem_env_lobster1.get_info_cohps_to_neighbors(
             path_to_cohpcar=cohpcar_lobster_mp_190,

--- a/tests/io/qchem/test_outputs.py
+++ b/tests/io/qchem/test_outputs.py
@@ -7,7 +7,6 @@ import numpy as np
 import pytest
 from monty.serialization import dumpfn, loadfn
 from numpy.testing import assert_allclose
-from pytest import approx
 
 from pymatgen.core.structure import Molecule
 from pymatgen.io.qchem.outputs import (
@@ -284,7 +283,7 @@ class TestQCOutput(PymatgenTest):
             except ValueError:
                 try:
                     if isinstance(out_data.get(key), dict):
-                        assert out_data.get(key) == approx(single_job_dict[filename].get(key))
+                        assert out_data.get(key) == pytest.approx(single_job_dict[filename].get(key))
                     else:
                         assert_allclose(out_data.get(key), single_job_dict[filename].get(key), atol=1e-6)
                 except AssertionError:
@@ -297,7 +296,7 @@ class TestQCOutput(PymatgenTest):
                     assert sub_output.data.get(key) == multi_job_dict[filename][idx].get(key)
                 except ValueError:
                     if isinstance(sub_output.data.get(key), dict):
-                        assert sub_output.data.get(key) == approx(multi_job_dict[filename][idx].get(key))
+                        assert sub_output.data.get(key) == pytest.approx(multi_job_dict[filename][idx].get(key))
                     else:
                         assert_allclose(sub_output.data.get(key), multi_job_dict[filename][idx].get(key), atol=1e-6)
 
@@ -423,7 +422,7 @@ class TestQCOutput(PymatgenTest):
         data = QCOutput(f"{TEST_DIR}/almo.out").data
         assert data["almo_coupling_states"] == [[[1, 2], [0, 1]], [[0, 1], [1, 2]]]
         assert data["almo_hamiltonian"][0][0] == -156.62929
-        assert data["almo_coupling_eV"] == approx(0.26895)
+        assert data["almo_coupling_eV"] == pytest.approx(0.26895)
 
     def test_pod_parsing(self):
         data = QCOutput(f"{TEST_DIR}/pod2_gs.out").data

--- a/tests/io/test_adf.py
+++ b/tests/io/test_adf.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pytest import approx
+import pytest
 
 from pymatgen.core.structure import Molecule
 from pymatgen.io.adf import AdfInput, AdfKey, AdfOutput, AdfTask
@@ -258,15 +258,15 @@ class TestAdfOutput:
     def test_analytical_freq(self):
         filename = f"{TEST_DIR}/analytical_freq/adf.out"
         adf_out = AdfOutput(filename)
-        assert adf_out.final_energy == approx(-0.54340325)
+        assert adf_out.final_energy == pytest.approx(-0.54340325)
         assert len(adf_out.energies) == 4
         assert len(adf_out.structures) == 4
-        assert adf_out.frequencies[0] == approx(1553.931)
-        assert adf_out.frequencies[2] == approx(3793.086)
-        assert adf_out.normal_modes[0][2] == approx(0.071)
-        assert adf_out.normal_modes[0][6] == approx(0.000)
-        assert adf_out.normal_modes[0][7] == approx(-0.426)
-        assert adf_out.normal_modes[0][8] == approx(-0.562)
+        assert adf_out.frequencies[0] == pytest.approx(1553.931)
+        assert adf_out.frequencies[2] == pytest.approx(3793.086)
+        assert adf_out.normal_modes[0][2] == pytest.approx(0.071)
+        assert adf_out.normal_modes[0][6] == pytest.approx(0.000)
+        assert adf_out.normal_modes[0][7] == pytest.approx(-0.426)
+        assert adf_out.normal_modes[0][8] == pytest.approx(-0.562)
 
     def test_numerical_freq(self):
         filename = f"{TEST_DIR}/numerical_freq/adf.out"
@@ -275,17 +275,17 @@ class TestAdfOutput:
         assert len(adf_out.final_structure) == 4
         assert len(adf_out.frequencies) == 6
         assert len(adf_out.normal_modes) == 6
-        assert adf_out.frequencies[0] == approx(938.21)
-        assert adf_out.frequencies[3] == approx(3426.64)
-        assert adf_out.frequencies[4] == approx(3559.35)
-        assert adf_out.frequencies[5] == approx(3559.35)
-        assert adf_out.normal_modes[1][0] == approx(0.067)
-        assert adf_out.normal_modes[1][3] == approx(-0.536)
-        assert adf_out.normal_modes[1][7] == approx(0.000)
-        assert adf_out.normal_modes[1][9] == approx(-0.536)
+        assert adf_out.frequencies[0] == pytest.approx(938.21)
+        assert adf_out.frequencies[3] == pytest.approx(3426.64)
+        assert adf_out.frequencies[4] == pytest.approx(3559.35)
+        assert adf_out.frequencies[5] == pytest.approx(3559.35)
+        assert adf_out.normal_modes[1][0] == pytest.approx(0.067)
+        assert adf_out.normal_modes[1][3] == pytest.approx(-0.536)
+        assert adf_out.normal_modes[1][7] == pytest.approx(0.000)
+        assert adf_out.normal_modes[1][9] == pytest.approx(-0.536)
 
     def test_single_point(self):
         filename = f"{TEST_DIR}/sp/adf.out"
         adf_out = AdfOutput(filename)
-        assert adf_out.final_energy == approx(-0.74399276)
+        assert adf_out.final_energy == pytest.approx(-0.74399276)
         assert len(adf_out.final_structure) == 4

--- a/tests/io/test_atat.py
+++ b/tests/io/test_atat.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+import pytest
 from numpy.testing import assert_allclose
-from pytest import approx
 
 from pymatgen.core.structure import Structure
 from pymatgen.io.atat import Mcsqs
@@ -63,9 +63,9 @@ class TestAtat(PymatgenTest):
         mcsqs = Mcsqs.structure_from_str(test_str)
 
         assert mcsqs.formula == "Sr3 Ca5 Mn7 Fe1 O24"
-        assert mcsqs.lattice.a == approx(2.2360679775)
-        assert mcsqs.lattice.b == approx(2.2360679775)
-        assert mcsqs.lattice.c == approx(1.73205080757)
+        assert mcsqs.lattice.a == pytest.approx(2.2360679775)
+        assert mcsqs.lattice.b == pytest.approx(2.2360679775)
+        assert mcsqs.lattice.c == pytest.approx(1.73205080757)
 
     def test_mcsqs_export(self):
         struct = self.get_structure("SrTiO3")

--- a/tests/io/test_babel.py
+++ b/tests/io/test_babel.py
@@ -4,7 +4,6 @@ import copy
 from unittest import TestCase
 
 import pytest
-from pytest import approx
 
 from pymatgen.analysis.graphs import MoleculeGraph
 from pymatgen.analysis.molecule_matcher import MoleculeMatcher
@@ -72,7 +71,7 @@ class TestBabelMolAdaptor(TestCase):
         adaptor.localopt()
         opt_mol = adaptor.pymatgen_mol
         for site in opt_mol[1:]:
-            assert site.distance(opt_mol[0]) == approx(1.09216, abs=1e-1)
+            assert site.distance(opt_mol[0]) == pytest.approx(1.09216, abs=1e-1)
 
     def test_make3d(self):
         mol_0d = pybel.readstring("smi", "CCCC").OBMol
@@ -95,7 +94,7 @@ class TestBabelMolAdaptor(TestCase):
         adaptor.rotor_conformer(*rotor_args, algo="WeightedRotorSearch")
         opt_mol = adaptor.pymatgen_mol
         for site in opt_mol[1:]:
-            assert site.distance(opt_mol[0]) == approx(1.09216, abs=1e-1)
+            assert site.distance(opt_mol[0]) == pytest.approx(1.09216, abs=1e-1)
 
     def test_rotor_search_srs(self):
         mol = copy.deepcopy(self.mol)
@@ -104,7 +103,7 @@ class TestBabelMolAdaptor(TestCase):
         adaptor.rotor_conformer(200, algo="SystematicRotorSearch")
         opt_mol = adaptor.pymatgen_mol
         for site in opt_mol[1:]:
-            assert site.distance(opt_mol[0]) == approx(1.09216, abs=1e-1)
+            assert site.distance(opt_mol[0]) == pytest.approx(1.09216, abs=1e-1)
 
     def test_rotor_search_rrs(self):
         mol = copy.deepcopy(self.mol)
@@ -113,7 +112,7 @@ class TestBabelMolAdaptor(TestCase):
         adaptor.rotor_conformer(250, 50, algo="RandomRotorSearch")
         opt_mol = adaptor.pymatgen_mol
         for site in opt_mol[1:]:
-            assert site.distance(opt_mol[0]) == approx(1.09216, abs=1e-1)
+            assert site.distance(opt_mol[0]) == pytest.approx(1.09216, abs=1e-1)
 
     def test_confab_conformers(self):
         mol = pybel.readstring("smi", "CCCC").OBMol
@@ -123,4 +122,4 @@ class TestBabelMolAdaptor(TestCase):
         assert adaptor.openbabel_mol.NumRotors() == 1
         assert len(conformers) >= 1
         if len(conformers) > 1:
-            assert MoleculeMatcher().get_rmsd(conformers[0], conformers[1]) != approx(0)
+            assert MoleculeMatcher().get_rmsd(conformers[0], conformers[1]) != pytest.approx(0)

--- a/tests/io/test_cif.py
+++ b/tests/io/test_cif.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
-from pytest import approx
 
 from pymatgen.analysis.structure_matcher import StructureMatcher
 from pymatgen.core import Composition, DummySpecies, Element, Lattice, Species, Structure
@@ -198,12 +197,12 @@ class TestCifIO(PymatgenTest):
         parser = CifParser.from_str(cif_str)
         struct = parser.parse_structures(primitive=False)[0]
         assert struct.formula == "Fe4 P4 O16"
-        assert struct.lattice.a == approx(10.4117668699)
-        assert struct.lattice.b == approx(6.06717187997)
-        assert struct.lattice.c == approx(4.75948953998)
-        assert struct.lattice.alpha == approx(91)
-        assert struct.lattice.beta == approx(92)
-        assert struct.lattice.gamma == approx(93)
+        assert struct.lattice.a == pytest.approx(10.4117668699)
+        assert struct.lattice.b == pytest.approx(6.06717187997)
+        assert struct.lattice.c == pytest.approx(4.75948953998)
+        assert struct.lattice.alpha == pytest.approx(91)
+        assert struct.lattice.beta == pytest.approx(92)
+        assert struct.lattice.gamma == pytest.approx(93)
 
         parser = CifParser(f"{TEST_FILES_DIR}/cif/srycoo.cif")
         assert parser.parse_structures()[0].formula == "Sr11.2 Y4.8 Co16 O42"
@@ -740,7 +739,7 @@ loop_
             parser.parse_structures(on_error="raise")
         parser = CifParser(filepath, occupancy_tolerance=2)
         struct = parser.parse_structures()[0]
-        assert struct[0].species["Al3+"] == approx(0.778)
+        assert struct[0].species["Al3+"] == pytest.approx(0.778)
 
     def test_not_check_occu(self):
         # Test large occupancy with check_occu turned off
@@ -1071,9 +1070,9 @@ Gd1 5.05 5.05 0.0"""
         s_ncl2 = self.mcif_ncl2.parse_structures()[0]
         list_magmoms = [list(m) for m in s_ncl2.site_properties["magmom"]]
         assert list_magmoms[0][0] == 0.0
-        assert list_magmoms[0][1] == approx(5.9160793408726366)
-        assert list_magmoms[1][0] == approx(-5.1234749999999991)
-        assert list_magmoms[1][1] == approx(2.9580396704363183)
+        assert list_magmoms[0][1] == pytest.approx(5.9160793408726366)
+        assert list_magmoms[1][0] == pytest.approx(-5.1234749999999991)
+        assert list_magmoms[1][1] == pytest.approx(2.9580396704363183)
 
         # test creating a structure without oxidation state doesn't raise errors
         s_manual = Structure(Lattice.cubic(4.2), ["Cs", "Cl"], [[0, 0, 0], [0.5, 0.5, 0.5]])

--- a/tests/io/test_gaussian.py
+++ b/tests/io/test_gaussian.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from unittest import TestCase
 
 import pytest
-from pytest import approx
 
 from pymatgen.core.structure import Molecule
 from pymatgen.electronic_structure.core import Spin
@@ -271,7 +270,7 @@ class TestGaussianOutput(TestCase):
     def test_props(self):
         gau = self.gau_out
         assert len(gau.energies) == 3
-        assert gau.energies[-1] == approx(-39.9768775602)
+        assert gau.energies[-1] == pytest.approx(-39.9768775602)
         assert len(gau.structures) == 4
         for mol in gau.structures:
             assert mol.formula == "H4 C1"
@@ -282,7 +281,7 @@ class TestGaussianOutput(TestCase):
         assert gau.num_basis_func == 17
         dct = gau.as_dict()
         assert dct["input"]["functional"] == "hf"
-        assert dct["output"]["final_energy"] == approx(-39.9768775602)
+        assert dct["output"]["final_energy"] == pytest.approx(-39.9768775602)
         assert len(gau.cart_forces) == 3
         assert gau.cart_forces[0][5] == 0.009791094
         assert gau.cart_forces[0][-1] == -0.003263698
@@ -389,18 +388,18 @@ class TestGaussianOutput(TestCase):
     def test_scan(self):
         gau = GaussianOutput(f"{TEST_DIR}/so2_scan.log")
         dct = gau.read_scan()
-        assert approx(dct["energies"][-1]) == -548.02102
+        assert pytest.approx(dct["energies"][-1]) == -548.02102
         assert len(dct["coords"]) == 1
         assert len(dct["energies"]) == len(gau.energies)
         assert len(dct["energies"]) == 21
         gau = GaussianOutput(f"{TEST_DIR}/so2_scan_opt.log")
         assert len(gau.opt_structures) == 21
         dct = gau.read_scan()
-        assert approx(dct["energies"][-1]) == -548.02336
+        assert pytest.approx(dct["energies"][-1]) == -548.02336
         assert len(dct["coords"]) == 2
         assert len(dct["energies"]) == 21
-        assert approx(dct["coords"]["DSO"][6]) == 1.60000
-        assert approx(dct["coords"]["ASO"][2]) == 124.01095
+        assert pytest.approx(dct["coords"]["DSO"][6]) == 1.60000
+        assert pytest.approx(dct["coords"]["ASO"][2]) == 124.01095
         gau = GaussianOutput(f"{TEST_DIR}/H2O_scan_G16.out")
         assert len(gau.opt_structures) == 21
         coords = [
@@ -410,16 +409,16 @@ class TestGaussianOutput(TestCase):
         ]
         assert gau.opt_structures[-1].cart_coords.tolist() == coords
         dct = gau.read_scan()
-        assert approx(dct["energies"][-1]) == -0.00523
+        assert pytest.approx(dct["energies"][-1]) == -0.00523
         assert len(dct["coords"]) == 3
         assert len(dct["energies"]) == 21
-        assert approx(dct["coords"]["R1"][6]) == 0.94710
-        assert approx(dct["coords"]["R2"][17]) == 0.94277
+        assert pytest.approx(dct["coords"]["R1"][6]) == 0.94710
+        assert pytest.approx(dct["coords"]["R2"][17]) == 0.94277
 
     def test_geo_opt(self):
         """Test an optimization where no "input orientation" is outputted."""
         gau = GaussianOutput(f"{TEST_DIR}/acene-n_gaussian09_opt.out")
-        assert approx(gau.energies[-1]) == -1812.58399675
+        assert pytest.approx(gau.energies[-1]) == -1812.58399675
         assert len(gau.structures) == 6
         # Test the first 3 atom coordinates
         coords = [
@@ -433,7 +432,7 @@ class TestGaussianOutput(TestCase):
         gau = GaussianOutput(f"{TEST_DIR}/so2_td.log")
         transitions = gau.read_excitation_energies()
         assert len(transitions) == 4
-        assert transitions[0] == approx((3.9281, 315.64, 0.0054))
+        assert transitions[0] == pytest.approx((3.9281, 315.64, 0.0054))
 
     def test_multiple_parameters(self):
         """Check that input files with multi-parameter keywords

--- a/tests/io/test_nwchem.py
+++ b/tests/io/test_nwchem.py
@@ -4,7 +4,6 @@ import json
 from unittest import TestCase
 
 import pytest
-from pytest import approx
 
 from pymatgen.core.structure import Molecule
 from pymatgen.io.nwchem import NwInput, NwInputError, NwOutput, NwTask
@@ -404,37 +403,37 @@ class TestNwOutput:
         assert nwo[0]["charge"] == 0
         assert nwo[-1]["charge"] == -1
         assert len(nwo) == 5
-        assert approx(nwo[0]["energies"][-1], abs=1e-2) == -1102.6224491715582
-        assert approx(nwo[2]["energies"][-1], abs=1e-3) == -1102.9986291578023
-        assert approx(nwo_cosmo[5]["energies"][0]["cosmo scf"], abs=1e-3) == -11156.354030653656
-        assert approx(nwo_cosmo[5]["energies"][0]["gas phase"], abs=1e-3) == -11153.374133394364
-        assert approx(nwo_cosmo[5]["energies"][0]["sol phase"], abs=1e-2) == -11156.353632962995
-        assert approx(nwo_cosmo[6]["energies"][0]["cosmo scf"], abs=1e-2) == -11168.818934311605
-        assert approx(nwo_cosmo[6]["energies"][0]["gas phase"], abs=1e-2) == -11166.3624424611462
-        assert approx(nwo_cosmo[6]["energies"][0]["sol phase"], abs=1e-2) == -11168.818934311605
-        assert approx(nwo_cosmo[7]["energies"][0]["cosmo scf"], abs=1e-2) == -11165.227959110889
-        assert approx(nwo_cosmo[7]["energies"][0]["gas phase"], abs=1e-2) == -11165.025443612385
-        assert approx(nwo_cosmo[7]["energies"][0]["sol phase"], abs=1e-2) == -11165.227959110154
+        assert pytest.approx(nwo[0]["energies"][-1], abs=1e-2) == -1102.6224491715582
+        assert pytest.approx(nwo[2]["energies"][-1], abs=1e-3) == -1102.9986291578023
+        assert pytest.approx(nwo_cosmo[5]["energies"][0]["cosmo scf"], abs=1e-3) == -11156.354030653656
+        assert pytest.approx(nwo_cosmo[5]["energies"][0]["gas phase"], abs=1e-3) == -11153.374133394364
+        assert pytest.approx(nwo_cosmo[5]["energies"][0]["sol phase"], abs=1e-2) == -11156.353632962995
+        assert pytest.approx(nwo_cosmo[6]["energies"][0]["cosmo scf"], abs=1e-2) == -11168.818934311605
+        assert pytest.approx(nwo_cosmo[6]["energies"][0]["gas phase"], abs=1e-2) == -11166.3624424611462
+        assert pytest.approx(nwo_cosmo[6]["energies"][0]["sol phase"], abs=1e-2) == -11168.818934311605
+        assert pytest.approx(nwo_cosmo[7]["energies"][0]["cosmo scf"], abs=1e-2) == -11165.227959110889
+        assert pytest.approx(nwo_cosmo[7]["energies"][0]["gas phase"], abs=1e-2) == -11165.025443612385
+        assert pytest.approx(nwo_cosmo[7]["energies"][0]["sol phase"], abs=1e-2) == -11165.227959110154
 
-        assert nwo[1]["hessian"][0][0] == approx(4.60187e01)
-        assert nwo[1]["hessian"][1][2] == approx(-1.14030e-08)
-        assert nwo[1]["hessian"][2][3] == approx(2.60819e01)
-        assert nwo[1]["hessian"][6][6] == approx(1.45055e02)
-        assert nwo[1]["hessian"][11][14] == approx(1.35078e01)
+        assert nwo[1]["hessian"][0][0] == pytest.approx(4.60187e01)
+        assert nwo[1]["hessian"][1][2] == pytest.approx(-1.14030e-08)
+        assert nwo[1]["hessian"][2][3] == pytest.approx(2.60819e01)
+        assert nwo[1]["hessian"][6][6] == pytest.approx(1.45055e02)
+        assert nwo[1]["hessian"][11][14] == pytest.approx(1.35078e01)
 
         # CH4.nwout, line 722
-        assert nwo[0]["forces"][0][3] == approx(-0.001991)
+        assert nwo[0]["forces"][0][3] == pytest.approx(-0.001991)
 
         # N2O4.nwout, line 1071
-        assert nwo_cosmo[0]["forces"][0][4] == approx(0.011948)
+        assert nwo_cosmo[0]["forces"][0][4] == pytest.approx(0.011948)
 
         # There should be four DFT gradients.
         assert len(nwo_cosmo[0]["forces"]) == 4
 
         ie = nwo[4]["energies"][-1] - nwo[2]["energies"][-1]
         ea = nwo[2]["energies"][-1] - nwo[3]["energies"][-1]
-        assert approx(ie) == 0.7575358648355177
-        assert approx(ea, abs=1e-3) == -14.997877958701338
+        assert pytest.approx(ie) == 0.7575358648355177
+        assert pytest.approx(ea, abs=1e-3) == -14.997877958701338
         assert nwo[4]["basis_set"]["C"]["description"] == "6-311++G**"
 
         nwo = NwOutput(f"{TEST_DIR}/H4C3O3_1.nwout")
@@ -465,14 +464,14 @@ class TestNwOutput:
         nwo = NwOutput(f"{TEST_DIR}/phen_tddft.log")
         roots = nwo.parse_tddft()
         assert len(roots["singlet"]) == 20
-        assert roots["singlet"][0]["energy"] == approx(3.9291)
-        assert roots["singlet"][0]["osc_strength"] == approx(0.0)
-        assert roots["singlet"][1]["osc_strength"] == approx(0.00177)
+        assert roots["singlet"][0]["energy"] == pytest.approx(3.9291)
+        assert roots["singlet"][0]["osc_strength"] == pytest.approx(0.0)
+        assert roots["singlet"][1]["osc_strength"] == pytest.approx(0.00177)
 
     def test_get_excitation_spectrum(self):
         nwo = NwOutput(f"{TEST_DIR}/phen_tddft.log")
         spectrum = nwo.get_excitation_spectrum()
         assert len(spectrum.x) == 2000
-        assert spectrum.x[0] == approx(1.9291)
-        assert spectrum.y[0] == approx(0.0)
-        assert spectrum.y[1000] == approx(0.0007423569947114812)
+        assert spectrum.x[0] == pytest.approx(1.9291)
+        assert spectrum.y[0] == pytest.approx(0.0)
+        assert spectrum.y[1000] == pytest.approx(0.0007423569947114812)

--- a/tests/io/test_phonopy.py
+++ b/tests/io/test_phonopy.py
@@ -8,7 +8,6 @@ from unittest import TestCase
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_array_equal
-from pytest import approx
 
 from pymatgen.core import Element
 from pymatgen.io.phonopy import (
@@ -46,8 +45,8 @@ class TestPhonopyParser(PymatgenTest):
     def test_get_ph_bs(self):
         ph_bs = get_ph_bs_symm_line(f"{TEST_DIR}/NaCl_band.yaml", has_nac=True)
 
-        assert ph_bs.bands[1][10] == approx(0.7753555184)
-        assert ph_bs.bands[5][100] == approx(5.2548379776)
+        assert ph_bs.bands[1][10] == pytest.approx(0.7753555184)
+        assert ph_bs.bands[5][100] == pytest.approx(5.2548379776)
         assert_array_equal(ph_bs.bands.shape, (6, 204))
         assert_array_equal(ph_bs.eigendisplacements.shape, (6, 204, 2, 3))
         assert_allclose(
@@ -56,7 +55,7 @@ class TestPhonopyParser(PymatgenTest):
         )
         assert ph_bs.has_eigendisplacements, True
         assert_array_equal(ph_bs.min_freq()[0].frac_coords, [0, 0, 0])
-        assert ph_bs.min_freq()[1] == approx(-0.03700895020)
+        assert ph_bs.min_freq()[1] == pytest.approx(-0.03700895020)
         assert ph_bs.has_imaginary_freq()
         assert not ph_bs.has_imaginary_freq(tol=0.5)
         assert_allclose(ph_bs.asr_breaking(), [-0.0370089502, -0.0370089502, -0.0221388897])
@@ -64,7 +63,7 @@ class TestPhonopyParser(PymatgenTest):
         assert ph_bs.nb_qpoints == 204
         assert_allclose(ph_bs.qpoints[1].frac_coords, [0.01, 0, 0])
         assert ph_bs.has_nac
-        assert ph_bs.get_nac_frequencies_along_dir([1, 1, 0])[3] == approx(4.6084532143)
+        assert ph_bs.get_nac_frequencies_along_dir([1, 1, 0])[3] == pytest.approx(4.6084532143)
         assert ph_bs.get_nac_frequencies_along_dir([1, 0, 1]) is None
         assert_allclose(
             ph_bs.get_nac_eigendisplacements_along_dir([1, 1, 0])[3][1],
@@ -75,9 +74,9 @@ class TestPhonopyParser(PymatgenTest):
     def test_get_ph_dos(self):
         dos = get_ph_dos(f"{TEST_DIR}/NaCl_total_dos.dat")
 
-        assert dos.densities[15] == approx(0.0001665998)
-        assert dos.frequencies[20] == approx(0.0894965119)
-        assert dos.get_interpolated_value(3.0) == approx(1.2915532670115628)
+        assert dos.densities[15] == pytest.approx(0.0001665998)
+        assert dos.frequencies[20] == pytest.approx(0.0894965119)
+        assert dos.get_interpolated_value(3.0) == pytest.approx(1.2915532670115628)
         assert len(dos.frequencies) == 201
         assert len(dos.densities) == 201
 
@@ -90,8 +89,8 @@ class TestPhonopyParser(PymatgenTest):
         site_Cl = cdos.structure[1]
 
         assert len(cdos.frequencies) == 201
-        assert cdos.pdos[site_Na][30] == approx(0.008058208)
-        assert cdos.pdos[site_Cl][30] == approx(0.0119040783)
+        assert cdos.pdos[site_Na][30] == pytest.approx(0.008058208)
+        assert cdos.pdos[site_Cl][30] == pytest.approx(0.0119040783)
 
         assert Element.Na in cdos.get_element_dos()
         assert Element.Cl in cdos.get_element_dos()
@@ -111,8 +110,8 @@ class TestStructureConversion(PymatgenTest):
         symbols_pmg = {*map(str, struct_pmg.composition)}
         symbols_pmg2 = {*map(str, struct_pmg_round_trip.composition)}
 
-        assert struct_ph.get_cell()[1, 1] == approx(struct_pmg.lattice._matrix[1, 1], abs=1e-7)
-        assert struct_pmg.lattice._matrix[1, 1] == approx(struct_pmg_round_trip.lattice._matrix[1, 1], abs=1e-7)
+        assert struct_ph.get_cell()[1, 1] == pytest.approx(struct_pmg.lattice._matrix[1, 1], abs=1e-7)
+        assert struct_pmg.lattice._matrix[1, 1] == pytest.approx(struct_pmg_round_trip.lattice._matrix[1, 1], abs=1e-7)
         assert symbols_pmg == set(struct_ph.symbols)
         assert symbols_pmg == symbols_pmg2
         assert_allclose(coords_ph[3], struct_pmg.frac_coords[3])
@@ -196,7 +195,7 @@ class TestPhonopyFromForceConstants(TestCase):
         assert bs, PhononBandStructure
         assert bs.nb_bands == 8
         assert bs.nb_qpoints == 8
-        assert bs.bands[2][10] == approx(3.887125285018674)
+        assert bs.bands[2][10] == pytest.approx(3.887125285018674)
 
     def test_get_phonon_band_structure_symm_line_from_fc(self):
         bs = get_phonon_band_structure_symm_line_from_fc(
@@ -209,7 +208,7 @@ class TestPhonopyFromForceConstants(TestCase):
         assert bs, PhononBandStructureSymmLine
         assert bs.nb_bands == 24
         assert bs.nb_qpoints == 48
-        assert bs.bands[2][10] == approx(2.869229797603161)
+        assert bs.bands[2][10] == pytest.approx(2.869229797603161)
 
 
 class TestGruneisen:
@@ -237,8 +236,8 @@ class TestGruneisen:
             structure_path=f"{PHONON_DIR}/gruneisen/eq/POSCAR_Si",
         )
 
-        assert self.gruneisenobject_Si.frequencies[0][0] == approx(0.2523831291)
-        assert self.gruneisenobject_Si.gruneisen[0][0] == approx(-0.1190736091)
+        assert self.gruneisenobject_Si.frequencies[0][0] == pytest.approx(0.2523831291)
+        assert self.gruneisenobject_Si.gruneisen[0][0] == pytest.approx(-0.1190736091)
 
         # catch the exception when no structure is present
         with pytest.raises(ValueError, match="Please provide a structure or structure path"):
@@ -274,5 +273,5 @@ class TestThermalDisplacementMatrices(PymatgenTest):
         # check if correct number of temperatures has been read
         assert len(list_matrices) == 31
 
-        assert list_matrices[-1].temperature == approx(300.0)
-        assert list_matrices[0].temperature == approx(0.0)
+        assert list_matrices[-1].temperature == pytest.approx(300.0)
+        assert list_matrices[0].temperature == pytest.approx(0.0)

--- a/tests/io/test_pwscf.py
+++ b/tests/io/test_pwscf.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
-from pytest import approx
 
 from pymatgen.io.pwscf import PWInput, PWInputError, PWOutput
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
@@ -521,9 +520,9 @@ class TestPWOutput(PymatgenTest):
         self.pw_out = PWOutput(f"{TEST_DIR}/Si.pwscf.out")
 
     def test_properties(self):
-        assert self.pw_out.final_energy == approx(-93.45259708)
+        assert self.pw_out.final_energy == pytest.approx(-93.45259708)
 
     def test_get_celldm(self):
-        assert self.pw_out.get_celldm(1) == approx(10.323)
+        assert self.pw_out.get_celldm(1) == pytest.approx(10.323)
         for i in range(2, 7):
-            assert self.pw_out.get_celldm(i) == approx(0)
+            assert self.pw_out.get_celldm(i) == pytest.approx(0)

--- a/tests/io/test_res.py
+++ b/tests/io/test_res.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import pytest
-from pytest import approx
 
 from pymatgen.core import Structure
 from pymatgen.io.res import AirssProvider, ResParseError, ResWriter
@@ -18,9 +17,9 @@ class TestAirssProvider:
         entry = provider.get_cut_grid_gmax_fsbc()
         assert entry is not None
         cut, gs, gm, fsbc = entry
-        assert cut == approx(326.5366)
-        assert gs == approx(1.75)
-        assert gm == approx(16.201)
+        assert cut == pytest.approx(326.5366)
+        assert gs == pytest.approx(1.75)
+        assert gm == pytest.approx(16.201)
         assert fsbc == "automatic"
 
     def test_moks(self, provider: AirssProvider):
@@ -39,14 +38,14 @@ class TestAirssProvider:
 
     def test_titl(self, provider: AirssProvider):
         assert provider.seed == "coc-115925-9326-14"
-        assert provider.energy == approx(-3.90427411e003)
+        assert provider.energy == pytest.approx(-3.90427411e003)
         assert provider.spacegroup_label == "R3"
-        assert provider.pressure == approx(15.0252)
-        assert provider.volume == approx(57.051984)
+        assert provider.pressure == pytest.approx(15.0252)
+        assert provider.volume == pytest.approx(57.051984)
 
     def test_lattice(self, provider: AirssProvider):
-        assert provider.lattice.lengths == approx((5.07144, 5.07144, 3.89024))
-        assert provider.lattice.angles == approx((49.32125, 49.32125, 60))
+        assert provider.lattice.lengths == pytest.approx((5.07144, 5.07144, 3.89024))
+        assert provider.lattice.angles == pytest.approx((49.32125, 49.32125, 60))
 
     def test_misc(self, provider: AirssProvider):
         rs_info = provider.get_run_start_info()
@@ -126,10 +125,10 @@ class TestAirssProvider:
             "volume",
         ]
         assert dct["seed"] == "coc-115925-9326-14"
-        assert dct["energy"] == approx(-3904.2741)
+        assert dct["energy"] == pytest.approx(-3904.2741)
         assert dct["spacegroup_label"] == "R3"
-        assert dct["pressure"] == approx(15.0252)
-        assert dct["volume"] == approx(57.051984)
+        assert dct["pressure"] == pytest.approx(15.0252)
+        assert dct["volume"] == pytest.approx(57.051984)
 
     def test_sfac_writer(self, provider: AirssProvider):
         """https://github.com/materialsproject/pymatgen/issues/3677"""
@@ -151,7 +150,7 @@ class TestSpin:
 
         for site in provider.structure:
             if site.properties["magmom"] is not None:
-                assert site.properties.get("magmom") == approx(-1.4)
+                assert site.properties.get("magmom") == pytest.approx(-1.4)
                 return
         pytest.fail("valid 'magmom' not found in any site properties")
 
@@ -171,4 +170,4 @@ class TestStructureModule:
     def test_structure_from_file(self):
         structure: Structure = Structure.from_file(res_coc)
         # just check that we read it
-        assert structure.lattice.angles == approx((49.32125, 49.32125, 60))
+        assert structure.lattice.angles == pytest.approx((49.32125, 49.32125, 60))

--- a/tests/io/test_wannier90.py
+++ b/tests/io/test_wannier90.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
-from pytest import approx
 
 from pymatgen.io.wannier90 import Unk
 from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
@@ -87,7 +86,7 @@ class TestUnk(PymatgenTest):
         assert unk.is_noncollinear
         assert_allclose(unk.data.shape, (5, 2, 6, 6, 8))
         assert unk.data[0, 0, 0, 0, 0].real != 0.0
-        assert unk.data[0, 1, 0, 0, 0].real == approx(0.0)
+        assert unk.data[0, 1, 0, 0, 0].real == pytest.approx(0.0)
 
     def test_write_file(self):
         self.unk_std.write_file("UNK00001.1")

--- a/tests/io/test_xyz.py
+++ b/tests/io/test_xyz.py
@@ -4,7 +4,6 @@ from unittest import TestCase
 
 import pandas as pd
 import pytest
-from pytest import approx
 
 from pymatgen.core import Structure
 from pymatgen.core.structure import Molecule
@@ -100,10 +99,10 @@ C  -4.440892098501D-01 -1.116307996198d+01  1.933502166311E+01
 """
         xyz = XYZ.from_str(mol_str)
         mol = xyz.molecule
-        assert mol[0].x == approx(0)
-        assert mol[1].y == approx(11.16307996198)
-        assert mol[2].x == approx(-0.4440892098501)
-        assert mol[2].y == approx(-11.16307996198)
+        assert mol[0].x == pytest.approx(0)
+        assert mol[1].y == pytest.approx(11.16307996198)
+        assert mol[2].x == pytest.approx(-0.4440892098501)
+        assert mol[2].y == pytest.approx(-11.16307996198)
         # assert abs(mol[1].z) < 1e-05
 
         mol_str = """    5
@@ -116,10 +115,10 @@ C32-C2-1
  """
         xyz = XYZ.from_str(mol_str)
         mol = xyz.molecule
-        assert mol[0].x == approx(2.70450)
-        assert mol[1].y == approx(1.72490)
-        assert mol[2].x == approx(2.34210)
-        assert mol[3].z == approx(-0.13790)
+        assert mol[0].x == pytest.approx(2.70450)
+        assert mol[1].y == pytest.approx(1.72490)
+        assert mol[2].x == pytest.approx(2.34210)
+        assert mol[3].z == pytest.approx(-0.13790)
 
     def test_from_file(self):
         filepath = f"{TEST_FILES_DIR}/io/xyz/multiple_frame.xyz"

--- a/tests/io/test_zeopp.py
+++ b/tests/io/test_zeopp.py
@@ -4,7 +4,6 @@ import unittest
 from unittest import TestCase
 
 import pytest
-from pytest import approx
 
 from pymatgen.analysis.bond_valence import BVAnalyzer
 from pymatgen.core import Molecule, Species, Structure
@@ -184,9 +183,9 @@ class TestGetFreeSphereParams(TestCase):
     def test_get_free_sphere_params(self):
         free_sph_params = get_free_sphere_params(self.structure, rad_dict=self.rad_dict)
         # Zeo results can change in future. Hence loose comparison
-        assert free_sph_params["inc_sph_max_dia"] == approx(2.58251, abs=1e-1)
-        assert free_sph_params["free_sph_max_dia"] == approx(1.29452, abs=1e-1)
-        assert free_sph_params["inc_sph_along_free_sph_path_max_dia"] == approx(2.58251, abs=1e-1)
+        assert free_sph_params["inc_sph_max_dia"] == pytest.approx(2.58251, abs=1e-1)
+        assert free_sph_params["free_sph_max_dia"] == pytest.approx(1.29452, abs=1e-1)
+        assert free_sph_params["inc_sph_along_free_sph_path_max_dia"] == pytest.approx(2.58251, abs=1e-1)
 
 
 @pytest.mark.skipif(zeo is None, reason="zeo not present")

--- a/tests/io/vasp/test_inputs.py
+++ b/tests/io/vasp/test_inputs.py
@@ -15,7 +15,6 @@ import scipy.constants as const
 from monty.io import zopen
 from monty.serialization import loadfn
 from numpy.testing import assert_allclose
-from pytest import MonkeyPatch, approx
 
 from pymatgen.core import SETTINGS
 from pymatgen.core.composition import Composition
@@ -42,7 +41,7 @@ _summ_stats = _gen_potcar_summary_stats(append=False, vasp_psp_dir=str(FAKE_POTC
 
 
 @pytest.fixture(autouse=True)
-def _mock_complete_potcar_summary_stats(monkeypatch: MonkeyPatch) -> None:
+def _mock_complete_potcar_summary_stats(monkeypatch: pytest.MonkeyPatch) -> None:
     # Override POTCAR library to use fake scrambled POTCARs
     monkeypatch.setitem(SETTINGS, "PMG_VASP_PSP_DIR", str(FAKE_POTCAR_DIR))
     monkeypatch.setattr(PotcarSingle, "_potcar_summary_stats", _summ_stats)
@@ -290,16 +289,16 @@ direct
     def test_from_md_run(self):
         # Parsing from an MD type run with velocities and predictor corrector data
         poscar = Poscar.from_file(f"{VASP_OUT_DIR}/CONTCAR.MD", check_for_potcar=False)
-        assert np.sum(poscar.velocities) == approx(0.0065417961324)
+        assert np.sum(poscar.velocities) == pytest.approx(0.0065417961324)
         assert poscar.predictor_corrector[0][0][0] == 0.33387820e00
         assert poscar.predictor_corrector[0][1][1] == -0.10583589e-02
         assert poscar.lattice_velocities is None
 
         # Parsing from an MD type run with velocities, predictor corrector data and lattice velocities
         poscar = Poscar.from_file(f"{VASP_OUT_DIR}/CONTCAR.MD.npt", check_for_potcar=False)
-        assert np.sum(poscar.velocities) == approx(-0.06193299494)
+        assert np.sum(poscar.velocities) == pytest.approx(-0.06193299494)
         assert poscar.predictor_corrector[0][0][0] == 0.63981833
-        assert poscar.lattice_velocities.sum() == approx(16.49411358474)
+        assert poscar.lattice_velocities.sum() == pytest.approx(16.49411358474)
 
     def test_write_md_poscar(self):
         # Parsing from an MD type run with velocities and predictor corrector data
@@ -396,18 +395,18 @@ direct
         v = np.array(poscar.velocities)
 
         for x in np.sum(v, axis=0):
-            assert x == approx(0, abs=1e-7)
+            assert x == pytest.approx(0, abs=1e-7)
 
         temperature = struct[0].specie.atomic_mass.to("kg") * np.sum(v**2) / (3 * const.k) * 1e10
-        assert temperature == approx(900, abs=1e-4), "Temperature instantiated incorrectly"
+        assert temperature == pytest.approx(900, abs=1e-4), "Temperature instantiated incorrectly"
 
         poscar.set_temperature(700)
         v = np.array(poscar.velocities)
         for x in np.sum(v, axis=0):
-            assert x == approx(0, abs=1e-7), "Velocities initialized with a net momentum"
+            assert x == pytest.approx(0, abs=1e-7), "Velocities initialized with a net momentum"
 
         temperature = struct[0].specie.atomic_mass.to("kg") * np.sum(v**2) / (3 * const.k) * 1e10
-        assert temperature == approx(700, abs=1e-4), "Temperature instantiated incorrectly"
+        assert temperature == pytest.approx(700, abs=1e-4), "Temperature instantiated incorrectly"
 
     def test_write(self):
         filepath = f"{VASP_IN_DIR}/POSCAR"
@@ -1447,7 +1446,7 @@ def test_potcar_summary_stats() -> None:
         assert actual == expected, f"{key=}, {expected=}, {actual=}"
 
 
-def test_gen_potcar_summary_stats(monkeypatch: MonkeyPatch) -> None:
+def test_gen_potcar_summary_stats(monkeypatch: pytest.MonkeyPatch) -> None:
     assert set(_summ_stats) == set(PotcarSingle.functional_dir)
 
     expected_funcs = [x for x in os.listdir(str(FAKE_POTCAR_DIR)) if x in PotcarSingle.functional_dir]

--- a/tests/io/vasp/test_outputs.py
+++ b/tests/io/vasp/test_outputs.py
@@ -13,7 +13,6 @@ import numpy as np
 import pytest
 from monty.io import zopen
 from numpy.testing import assert_allclose
-from pytest import approx
 
 from pymatgen.core import Element
 from pymatgen.core.lattice import Lattice
@@ -63,7 +62,7 @@ class TestVasprun(PymatgenTest):
             assert "structure" in frame
             assert "forces" in frame
             assert "energy" in frame
-        assert vasp_run.md_data[-1]["energy"]["total"] == approx(-491.51831988)
+        assert vasp_run.md_data[-1]["energy"]["total"] == pytest.approx(-491.51831988)
         assert vasp_run.md_n_steps == 100
         assert vasp_run.converged_ionic
 
@@ -72,7 +71,7 @@ class TestVasprun(PymatgenTest):
         # Does not generate the `md_data` attribute in Vasprun. Data based on `ionic_steps`
         vasp_run = Vasprun(f"{VASP_OUT_DIR}/vasprun.md.xml.gz")
         assert len(vasp_run.ionic_steps) == 10
-        assert vasp_run.final_energy == approx(-327.73014059)
+        assert vasp_run.final_energy == pytest.approx(-327.73014059)
         assert vasp_run.md_n_steps == 10
         assert vasp_run.converged_ionic
 
@@ -82,7 +81,7 @@ class TestVasprun(PymatgenTest):
         print(list(os.walk(VASP_OUT_DIR)))
         vasp_run = Vasprun(f"{VASP_OUT_DIR}/vasprun.ediffg_set_to_0.xml.gz")
         assert len(vasp_run.ionic_steps) == 3
-        assert vasp_run.final_energy == approx(-34.60164204)
+        assert vasp_run.final_energy == pytest.approx(-34.60164204)
         assert vasp_run.converged_ionic is True
         assert vasp_run.converged_electronic is True
         assert vasp_run.converged is True
@@ -132,7 +131,7 @@ class TestVasprun(PymatgenTest):
         ):
             vasp_run = Vasprun(f"{VASP_OUT_DIR}/vasprun.bad.xml.gz", exception_on_bad_xml=False)
         assert len(vasp_run.ionic_steps) == 1
-        assert vasp_run.final_energy == approx(-269.00551374)
+        assert vasp_run.final_energy == pytest.approx(-269.00551374)
 
     def test_runtype(self):
         vasp_run = Vasprun(f"{VASP_OUT_DIR}/vasprun.GW0.xml.gz")
@@ -174,24 +173,24 @@ class TestVasprun(PymatgenTest):
 
     def test_vdw(self):
         vasp_run = Vasprun(f"{VASP_OUT_DIR}/vasprun.vdw.xml.gz")
-        assert vasp_run.final_energy == approx(-9.78310677)
+        assert vasp_run.final_energy == pytest.approx(-9.78310677)
 
     def test_energies(self):
         # VASP 5.4.1
         vasp_run = Vasprun(f"{VASP_OUT_DIR}/vasprun.etest1.xml.gz")
-        assert vasp_run.final_energy == approx(-11.18981538)
+        assert vasp_run.final_energy == pytest.approx(-11.18981538)
 
         # VASP 6.2.1
         vasp_run = Vasprun(f"{VASP_OUT_DIR}/vasprun.etest2.xml.gz")
-        assert vasp_run.final_energy == approx(-11.18986774)
+        assert vasp_run.final_energy == pytest.approx(-11.18986774)
 
         # VASP 5.4.1
         vasp_run = Vasprun(f"{VASP_OUT_DIR}/vasprun.etest3.xml.gz")
-        assert vasp_run.final_energy == approx(-15.89355325)
+        assert vasp_run.final_energy == pytest.approx(-15.89355325)
 
         # VASP 6.2.1
         vasp_run = Vasprun(f"{VASP_OUT_DIR}/vasprun.etest4.xml.gz")
-        assert vasp_run.final_energy == approx(-15.89364691)
+        assert vasp_run.final_energy == pytest.approx(-15.89364691)
 
     def test_nonlmn(self):
         filepath = f"{VASP_OUT_DIR}/vasprun.nonlm.xml.gz"
@@ -211,35 +210,35 @@ class TestVasprun(PymatgenTest):
         assert Vasprun(f"{VASP_OUT_DIR}/vasprun.etest1.xml.gz").complete_dos.spin_polarization is None
 
         pdos0 = vasp_run.complete_dos.pdos[vasp_run.final_structure[0]]
-        assert pdos0[Orbital.s][Spin.up][16] == approx(0.0026)
-        assert pdos0[Orbital.pz][Spin.down][16] == approx(0.0012)
+        assert pdos0[Orbital.s][Spin.up][16] == pytest.approx(0.0026)
+        assert pdos0[Orbital.pz][Spin.down][16] == pytest.approx(0.0012)
         assert pdos0[Orbital.s][Spin.up].shape == (301,)
 
         pdos0_norm = vasp_run.complete_dos_normalized.pdos[vasp_run.final_structure[0]]
-        assert pdos0_norm[Orbital.s][Spin.up][16] == approx(0.0026)  # the site data should not change
+        assert pdos0_norm[Orbital.s][Spin.up][16] == pytest.approx(0.0026)  # the site data should not change
         assert pdos0_norm[Orbital.s][Spin.up].shape == (301,)
 
         cdos_norm, cdos = vasp_run.complete_dos_normalized, vasp_run.complete_dos
         ratio = np.nanmax(cdos.densities[Spin.up] / cdos_norm.densities[Spin.up])
-        assert ratio == approx(vasp_run.final_structure.volume)  # the site data should not change
+        assert ratio == pytest.approx(vasp_run.final_structure.volume)  # the site data should not change
 
         # check you can normalize an existing DOS
         cdos_norm2 = cdos.get_normalized()
         ratio = np.nanmax(cdos.densities[Spin.up] / cdos_norm2.densities[Spin.up])
-        assert ratio == approx(vasp_run.final_structure.volume)  # the site data should not change
+        assert ratio == pytest.approx(vasp_run.final_structure.volume)  # the site data should not change
 
         # but doing so twice should not change the data
         cdos_norm3 = cdos_norm2.get_normalized()
         ratio = np.nanmax(cdos.densities[Spin.up] / cdos_norm3.densities[Spin.up])
-        assert ratio == approx(vasp_run.final_structure.volume)  # the site data should not change
+        assert ratio == pytest.approx(vasp_run.final_structure.volume)  # the site data should not change
 
         pdos0_norm = vasp_run.complete_dos_normalized.pdos[vasp_run.final_structure[0]]
-        assert pdos0_norm[Orbital.s][Spin.up][16] == approx(0.0026)  # the site data should not change
+        assert pdos0_norm[Orbital.s][Spin.up][16] == pytest.approx(0.0026)  # the site data should not change
         assert pdos0_norm[Orbital.s][Spin.up].shape == (301,)
 
         cdos_norm, cdos = vasp_run.complete_dos_normalized, vasp_run.complete_dos
         ratio = np.nanmax(cdos.densities[Spin.up] / cdos_norm.densities[Spin.up])
-        assert ratio == approx(vasp_run.final_structure.volume)  # the site data should not change
+        assert ratio == pytest.approx(vasp_run.final_structure.volume)  # the site data should not change
 
         filepath2 = f"{VASP_OUT_DIR}/vasprun.lifepo4.xml.gz"
         vasprun_ggau = Vasprun(filepath2, parse_projected_eigen=True, parse_potcar_file=False)
@@ -266,10 +265,10 @@ class TestVasprun(PymatgenTest):
         assert isinstance(vasp_run.incar, Incar), f"{vasp_run.incar=}"
         assert isinstance(vasp_run.kpoints, Kpoints), f"{vasp_run.kpoints=}"
         assert isinstance(vasp_run.eigenvalues, dict), f"{vasp_run.eigenvalues=}"
-        assert vasp_run.final_energy == approx(-269.38319884, abs=1e-7)
-        assert vasp_run.tdos.get_gap() == approx(2.0589, abs=1e-4)
+        assert vasp_run.final_energy == pytest.approx(-269.38319884, abs=1e-7)
+        assert vasp_run.tdos.get_gap() == pytest.approx(2.0589, abs=1e-4)
         expected = (2.539, 4.0906, 1.5516, False)
-        assert vasp_run.eigenvalue_band_properties == approx(expected)
+        assert vasp_run.eigenvalue_band_properties == pytest.approx(expected)
         assert vasp_run.is_hubbard is False
         assert vasp_run.potcar_symbols == [
             "PAW_PBE Li 17Jan2003",
@@ -294,7 +293,7 @@ class TestVasprun(PymatgenTest):
         # Check that nionic_steps is preserved no matter what.
         assert vasprun_skip.nionic_steps == vasp_run.nionic_steps
 
-        assert vasprun_skip.final_energy != approx(vasp_run.final_energy)
+        assert vasprun_skip.final_energy != pytest.approx(vasp_run.final_energy)
 
         # Test with ionic_step_offset
         vasprun_offset = Vasprun(filepath, 3, 6, parse_potcar_file=False)
@@ -303,7 +302,7 @@ class TestVasprun(PymatgenTest):
 
         assert vasprun_ggau.is_hubbard
         assert vasprun_ggau.hubbards["Fe"] == 4.3
-        assert vasprun_ggau.projected_eigenvalues[Spin.up][0][0][96][0] == approx(0.0032)
+        assert vasprun_ggau.projected_eigenvalues[Spin.up][0][0][96][0] == pytest.approx(0.0032)
         dct = vasprun_ggau.as_dict()
         assert dct["elements"] == ["Fe", "Li", "O", "P"]
         assert dct["nelements"] == 4
@@ -327,24 +326,24 @@ class TestVasprun(PymatgenTest):
     def test_dfpt(self):
         filepath = f"{VASP_OUT_DIR}/vasprun.dfpt.xml.gz"
         vasprun_dfpt = Vasprun(filepath, parse_potcar_file=False)
-        assert vasprun_dfpt.epsilon_static[0][0] == approx(3.26105533)
-        assert vasprun_dfpt.epsilon_static[0][1] == approx(-0.00459066)
-        assert vasprun_dfpt.epsilon_static[2][2] == approx(3.24330517)
-        assert vasprun_dfpt.epsilon_static_wolfe[0][0] == approx(3.33402531)
-        assert vasprun_dfpt.epsilon_static_wolfe[0][1] == approx(-0.00559998)
-        assert vasprun_dfpt.epsilon_static_wolfe[2][2] == approx(3.31237357)
+        assert vasprun_dfpt.epsilon_static[0][0] == pytest.approx(3.26105533)
+        assert vasprun_dfpt.epsilon_static[0][1] == pytest.approx(-0.00459066)
+        assert vasprun_dfpt.epsilon_static[2][2] == pytest.approx(3.24330517)
+        assert vasprun_dfpt.epsilon_static_wolfe[0][0] == pytest.approx(3.33402531)
+        assert vasprun_dfpt.epsilon_static_wolfe[0][1] == pytest.approx(-0.00559998)
+        assert vasprun_dfpt.epsilon_static_wolfe[2][2] == pytest.approx(3.31237357)
         assert vasprun_dfpt.converged
 
         entry = vasprun_dfpt.get_computed_entry()
         entry = MaterialsProjectCompatibility(check_potcar_hash=False).process_entry(entry)
-        assert entry.uncorrected_energy + entry.correction == approx(entry.energy)
+        assert entry.uncorrected_energy + entry.correction == pytest.approx(entry.energy)
 
     def test_dfpt_ionic(self):
         filepath = f"{VASP_OUT_DIR}/vasprun.dfpt.ionic.xml.gz"
         vasprun_dfpt_ionic = Vasprun(filepath, parse_potcar_file=False)
-        assert vasprun_dfpt_ionic.epsilon_ionic[0][0] == approx(515.73485838)
-        assert vasprun_dfpt_ionic.epsilon_ionic[0][1] == approx(-0.00263523)
-        assert vasprun_dfpt_ionic.epsilon_ionic[2][2] == approx(19.02110169)
+        assert vasprun_dfpt_ionic.epsilon_ionic[0][0] == pytest.approx(515.73485838)
+        assert vasprun_dfpt_ionic.epsilon_ionic[0][1] == pytest.approx(-0.00263523)
+        assert vasprun_dfpt_ionic.epsilon_ionic[2][2] == pytest.approx(19.02110169)
 
     def test_dfpt_unconverged(self):
         filepath = f"{VASP_OUT_DIR}/vasprun.dfpt.unconverged.xml.gz"
@@ -369,52 +368,52 @@ class TestVasprun(PymatgenTest):
 
     def test_dielectric(self):
         vasprun_diel = Vasprun(f"{VASP_OUT_DIR}/vasprun.dielectric.xml.gz", parse_potcar_file=False)
-        assert approx(vasprun_diel.dielectric[0][10]) == 0.4294
-        assert approx(vasprun_diel.dielectric[1][51][0]) == 19.941
-        assert approx(vasprun_diel.dielectric[1][51][1]) == 19.941
-        assert approx(vasprun_diel.dielectric[1][51][2]) == 19.941
-        assert approx(vasprun_diel.dielectric[1][51][3]) == 0.0
-        assert approx(vasprun_diel.dielectric[2][85][0]) == 34.186
-        assert approx(vasprun_diel.dielectric[2][85][1]) == 34.186
-        assert approx(vasprun_diel.dielectric[2][85][2]) == 34.186
-        assert approx(vasprun_diel.dielectric[2][85][3]) == 0.0
+        assert pytest.approx(vasprun_diel.dielectric[0][10]) == 0.4294
+        assert pytest.approx(vasprun_diel.dielectric[1][51][0]) == 19.941
+        assert pytest.approx(vasprun_diel.dielectric[1][51][1]) == 19.941
+        assert pytest.approx(vasprun_diel.dielectric[1][51][2]) == 19.941
+        assert pytest.approx(vasprun_diel.dielectric[1][51][3]) == 0.0
+        assert pytest.approx(vasprun_diel.dielectric[2][85][0]) == 34.186
+        assert pytest.approx(vasprun_diel.dielectric[2][85][1]) == 34.186
+        assert pytest.approx(vasprun_diel.dielectric[2][85][2]) == 34.186
+        assert pytest.approx(vasprun_diel.dielectric[2][85][3]) == 0.0
 
     def test_dielectric_vasp608(self):
         # test reading dielectric constant in vasp 6.0.8
         vasp_xml_path = f"{VASP_OUT_DIR}/vasprun.dielectric_6.0.8.xml.gz"
         vasprun_diel = Vasprun(vasp_xml_path, parse_potcar_file=False)
-        assert approx(vasprun_diel.dielectric[0][10]) == 0.4338
-        assert approx(vasprun_diel.dielectric[1][51][0]) == 5.267
-        assert approx(vasprun_diel.dielectric_data["density"][0][10]) == 0.4338
-        assert approx(vasprun_diel.dielectric_data["density"][1][51][0]) == 5.267
-        assert approx(vasprun_diel.dielectric_data["velocity"][0][10]) == 0.4338
-        assert approx(vasprun_diel.dielectric_data["velocity"][1][51][0]) == 1.0741
+        assert pytest.approx(vasprun_diel.dielectric[0][10]) == 0.4338
+        assert pytest.approx(vasprun_diel.dielectric[1][51][0]) == 5.267
+        assert pytest.approx(vasprun_diel.dielectric_data["density"][0][10]) == 0.4338
+        assert pytest.approx(vasprun_diel.dielectric_data["density"][1][51][0]) == 5.267
+        assert pytest.approx(vasprun_diel.dielectric_data["velocity"][0][10]) == 0.4338
+        assert pytest.approx(vasprun_diel.dielectric_data["velocity"][1][51][0]) == 1.0741
         assert len(vasprun_diel.other_dielectric) == 0
 
     def test_indirect_vasprun(self):
         vasp_run = Vasprun(f"{VASP_OUT_DIR}/vasprun.indirect.xml.gz")
         gap, cbm, vbm, direct = vasp_run.eigenvalue_band_properties
-        assert gap == approx(0.6119)
-        assert cbm == approx(6.2231)
-        assert vbm == approx(5.6112)
+        assert gap == pytest.approx(0.6119)
+        assert cbm == pytest.approx(6.2231)
+        assert vbm == pytest.approx(5.6112)
         assert not direct
 
     def test_optical_vasprun(self):
         vasp_xml_path = f"{VASP_OUT_DIR}/vasprun.optical_transitions.xml.gz"
         vasprun_optical = Vasprun(vasp_xml_path, parse_potcar_file=False)
         optical_trans = vasprun_optical.optical_transition
-        assert approx(optical_trans[0][0]) == 3.084
-        assert approx(optical_trans[3][0]) == 3.087
-        assert approx(optical_trans[0][1]) == 0.001
-        assert approx(optical_trans[1][1]) == 0.001
-        assert approx(optical_trans[7][1]) == 0.001
-        assert approx(optical_trans[19][1]) == 0.001
-        assert approx(optical_trans[54][0]) == 3.3799999999
-        assert approx(optical_trans[55][0]) == 3.381
-        assert approx(optical_trans[56][0]) == 3.381
-        assert approx(optical_trans[54][1]) == 10554.9860
-        assert approx(optical_trans[55][1]) == 0.0
-        assert approx(optical_trans[56][1]) == 0.001
+        assert pytest.approx(optical_trans[0][0]) == 3.084
+        assert pytest.approx(optical_trans[3][0]) == 3.087
+        assert pytest.approx(optical_trans[0][1]) == 0.001
+        assert pytest.approx(optical_trans[1][1]) == 0.001
+        assert pytest.approx(optical_trans[7][1]) == 0.001
+        assert pytest.approx(optical_trans[19][1]) == 0.001
+        assert pytest.approx(optical_trans[54][0]) == 3.3799999999
+        assert pytest.approx(optical_trans[55][0]) == 3.381
+        assert pytest.approx(optical_trans[56][0]) == 3.381
+        assert pytest.approx(optical_trans[54][1]) == 10554.9860
+        assert pytest.approx(optical_trans[55][1]) == 0.0
+        assert pytest.approx(optical_trans[56][1]) == 0.001
 
     def test_force_constants(self):
         vasprun_fc = Vasprun(f"{VASP_OUT_DIR}/vasprun.dfpt.phonon.xml.gz", parse_potcar_file=False)
@@ -491,18 +490,18 @@ class TestVasprun(PymatgenTest):
         cbm = band_struct.get_cbm()
         vbm = band_struct.get_vbm()
         assert cbm["kpoint_index"] == [13], "wrong cbm kpoint index"
-        assert cbm["energy"] == approx(6.2301), "wrong cbm energy"
+        assert cbm["energy"] == pytest.approx(6.2301), "wrong cbm energy"
         assert cbm["band_index"] == {Spin.up: [4], Spin.down: [4]}, "wrong cbm bands"
         assert vbm["kpoint_index"] == [0, 63, 64]
-        assert vbm["energy"] == approx(5.6158), "wrong vbm energy"
+        assert vbm["energy"] == pytest.approx(5.6158), "wrong vbm energy"
         assert vbm["band_index"] == {Spin.up: [1, 2, 3], Spin.down: [1, 2, 3]}, "wrong vbm bands"
         assert vbm["kpoint"].label == "\\Gamma", "wrong vbm label"
         assert cbm["kpoint"].label is None, "wrong cbm label"
 
         projected = band_struct.get_projection_on_elements()
-        assert projected[Spin.up][0][0]["Si"] == approx(0.4238)
+        assert projected[Spin.up][0][0]["Si"] == pytest.approx(0.4238)
         projected = band_struct.get_projections_on_elements_and_orbitals({"Si": ["s"]})
-        assert projected[Spin.up][0][0]["Si"]["s"] == approx(0.4238)
+        assert projected[Spin.up][0][0]["Si"]["s"] == pytest.approx(0.4238)
 
         # Test compressed files case 1: compressed KPOINTS in current dir
         copyfile(f"{VASP_OUT_DIR}/vasprun_Si_bands.xml.gz", "vasprun.xml.gz")
@@ -540,10 +539,10 @@ class TestVasprun(PymatgenTest):
         cbm = band_struct.get_cbm()
         vbm = band_struct.get_vbm()
         assert cbm["kpoint_index"] == [0]
-        assert cbm["energy"] == approx(6.3676)
+        assert cbm["energy"] == pytest.approx(6.3676)
         assert cbm["kpoint"].label is None
         assert vbm["kpoint_index"] == [0]
-        assert vbm["energy"] == approx(2.8218)
+        assert vbm["energy"] == pytest.approx(2.8218)
         assert vbm["kpoint"].label is None
 
         # test self-consistent band structure calculation for non-hybrid functionals
@@ -561,7 +560,7 @@ class TestVasprun(PymatgenTest):
         dict_to_test = band_struct.get_band_gap()
 
         assert dict_to_test["direct"]
-        assert dict_to_test["energy"] == approx(6.007899999999999)
+        assert dict_to_test["energy"] == pytest.approx(6.007899999999999)
         assert dict_to_test["transition"] == "\\Gamma-\\Gamma"
         assert band_struct.get_branch(0)[0]["start_index"] == 0
         assert band_struct.get_branch(0)[0]["end_index"] == 0
@@ -571,39 +570,39 @@ class TestVasprun(PymatgenTest):
         vasp_run = Vasprun(filepath, parse_projected_eigen=True)
         assert vasp_run.projected_magnetisation is not None
         assert vasp_run.projected_magnetisation.shape == (76, 240, 4, 9, 3)
-        assert vasp_run.projected_magnetisation[0, 0, 0, 0, 0] == approx(-0.0712)
+        assert vasp_run.projected_magnetisation[0, 0, 0, 0, 0] == pytest.approx(-0.0712)
 
     def test_smart_efermi(self):
         # branch 1 - E_fermi does not cross a band
         vrun = Vasprun(f"{VASP_OUT_DIR}/vasprun.LiF.xml.gz")
         smart_fermi = vrun.calculate_efermi()
-        assert smart_fermi == approx(vrun.efermi, abs=1e-4)
+        assert smart_fermi == pytest.approx(vrun.efermi, abs=1e-4)
         eigen_gap = vrun.eigenvalue_band_properties[0]
         bs_gap = vrun.get_band_structure(efermi=smart_fermi).get_band_gap()["energy"]
-        assert bs_gap == approx(eigen_gap, abs=1e-3)
+        assert bs_gap == pytest.approx(eigen_gap, abs=1e-3)
 
         # branch 2 - E_fermi crosses a band but bandgap=0
         vrun = Vasprun(f"{VASP_OUT_DIR}/vasprun.Al.xml.gz")
         smart_fermi = vrun.calculate_efermi()
-        assert smart_fermi == approx(vrun.efermi, abs=1e-4)
+        assert smart_fermi == pytest.approx(vrun.efermi, abs=1e-4)
         eigen_gap = vrun.eigenvalue_band_properties[0]
         bs_gap = vrun.get_band_structure(efermi=smart_fermi).get_band_gap()["energy"]
-        assert bs_gap == approx(eigen_gap, abs=1e-3)
+        assert bs_gap == pytest.approx(eigen_gap, abs=1e-3)
 
         # branch 3 - E_fermi crosses a band in an insulator
         vrun = Vasprun(f"{VASP_OUT_DIR}/vasprun.LiH_bad_efermi.xml.gz")
         smart_fermi = vrun.calculate_efermi()
-        assert smart_fermi != approx(vrun.efermi, abs=1e-4)
+        assert smart_fermi != pytest.approx(vrun.efermi, abs=1e-4)
         eigen_gap = vrun.eigenvalue_band_properties[0]
         bs_gap = vrun.get_band_structure(efermi="smart").get_band_gap()["energy"]
-        assert bs_gap == approx(eigen_gap, abs=1e-3)
-        assert vrun.get_band_structure(efermi=None).get_band_gap()["energy"] != approx(eigen_gap, abs=1e-3)
+        assert bs_gap == pytest.approx(eigen_gap, abs=1e-3)
+        assert vrun.get_band_structure(efermi=None).get_band_gap()["energy"] != pytest.approx(eigen_gap, abs=1e-3)
         assert bs_gap != 0
 
         # branch 4 - E_fermi incorrectly placed inside a band
         vrun = Vasprun(f"{VASP_OUT_DIR}/vasprun.bad_fermi.xml.gz")
         smart_fermi = vrun.calculate_efermi()
-        assert smart_fermi == approx(6.0165)
+        assert smart_fermi == pytest.approx(6.0165)
 
     def test_float_overflow(self):
         # test we interpret VASP's *********** for overflowed values as NaNs
@@ -715,13 +714,13 @@ class TestVasprun(PymatgenTest):
         props = eig.eigenvalue_band_properties
         eig2 = Vasprun(f"{VASP_OUT_DIR}/vasprun_eig_separate_spins.xml.gz", separate_spins=False)
         props2 = eig2.eigenvalue_band_properties
-        assert props[0][0] == approx(2.8772, abs=1e-4)
-        assert props[0][1] == approx(1.2810, abs=1e-4)
-        assert props[1][0] == approx(3.6741, abs=1e-4)
-        assert props[1][1] == approx(1.6225, abs=1e-4)
-        assert props[2][0] == approx(0.7969, abs=1e-4)
-        assert props[2][1] == approx(0.3415, abs=1e-4)
-        assert props2[0] == approx(np.min(props[1]) - np.max(props[2]), abs=1e-4)
+        assert props[0][0] == pytest.approx(2.8772, abs=1e-4)
+        assert props[0][1] == pytest.approx(1.2810, abs=1e-4)
+        assert props[1][0] == pytest.approx(3.6741, abs=1e-4)
+        assert props[1][1] == pytest.approx(1.6225, abs=1e-4)
+        assert props[2][0] == pytest.approx(0.7969, abs=1e-4)
+        assert props[2][1] == pytest.approx(0.3415, abs=1e-4)
+        assert props2[0] == pytest.approx(np.min(props[1]) - np.max(props[2]), abs=1e-4)
         assert props[3][0]
         assert props[3][1]
 
@@ -737,20 +736,20 @@ class TestVasprun(PymatgenTest):
         # Check the eigenvalues were read correctly.
         assert vasp_run.eigenvalues[Spin.up].shape == (10, 24, 2)
         assert kpt_opt_props.eigenvalues[Spin.up].shape == (100, 24, 2)
-        assert vasp_run.eigenvalues[Spin.up][0, 0, 0] == approx(-6.1471)
-        assert kpt_opt_props.eigenvalues[Spin.up][0, 0, 0] == approx(-6.1536)
+        assert vasp_run.eigenvalues[Spin.up][0, 0, 0] == pytest.approx(-6.1471)
+        assert kpt_opt_props.eigenvalues[Spin.up][0, 0, 0] == pytest.approx(-6.1536)
         # Check the projected eigenvalues were read correctly
         assert vasp_run.projected_eigenvalues[Spin.up].shape == (10, 24, 8, 9)
         assert kpt_opt_props.projected_eigenvalues[Spin.up].shape == (100, 24, 8, 9)
-        assert vasp_run.projected_eigenvalues[Spin.up][0, 1, 0, 0] == approx(0.0492)
+        assert vasp_run.projected_eigenvalues[Spin.up][0, 1, 0, 0] == pytest.approx(0.0492)
         # I think these zeroes are a bug in VASP (maybe my VASP) transcribing from PROCAR_OPT to vasprun.xml
         # No matter. The point of the parser is to read what's in the file.
-        assert kpt_opt_props.projected_eigenvalues[Spin.up][0, 1, 0, 0] == approx(0.0000)
+        assert kpt_opt_props.projected_eigenvalues[Spin.up][0, 1, 0, 0] == pytest.approx(0.0000)
         # Test as_dict
         vasp_run_dct = vasp_run.as_dict()
         assert vasp_run_dct["input"]["nkpoints_opt"] == 100
         assert vasp_run_dct["input"]["nkpoints"] == 10
-        assert vasp_run_dct["output"]["eigenvalues_kpoints_opt"]["1"][0][0][0] == approx(-6.1536)
+        assert vasp_run_dct["output"]["eigenvalues_kpoints_opt"]["1"][0][0][0] == pytest.approx(-6.1536)
 
     def test_kpoints_opt_band_structure(self):
         vasp_run = Vasprun(kpts_opt_vrun_path, parse_potcar_file=False, parse_projected_eigen=True)
@@ -759,10 +758,10 @@ class TestVasprun(PymatgenTest):
         cbm = bs.get_cbm()
         vbm = bs.get_vbm()
         assert cbm["kpoint_index"] == [38], "wrong cbm kpoint index"
-        assert cbm["energy"] == approx(6.4394), "wrong cbm energy"
+        assert cbm["energy"] == pytest.approx(6.4394), "wrong cbm energy"
         assert cbm["band_index"] == {Spin.up: [16], Spin.down: [16]}, "wrong cbm bands"
         assert vbm["kpoint_index"] == [0, 39, 40]
-        assert vbm["energy"] == approx(5.7562), "wrong vbm energy"
+        assert vbm["energy"] == pytest.approx(5.7562), "wrong vbm energy"
         assert vbm["band_index"] == {Spin.down: [13, 14, 15], Spin.up: [13, 14, 15]}, "wrong vbm bands"
         vbm_kp_label = vbm["kpoint"].label
         assert vbm["kpoint"].label == "\\Gamma", f"Unpexpected {vbm_kp_label=}"
@@ -820,8 +819,8 @@ class TestOutcar(PymatgenTest):
             {"p": 3.365, "s": 1.582, "d": 0.0, "tot": 4.947},
         )
 
-        assert outcar.magnetization == approx(expected_mag, abs=1e-5), "Wrong magnetization read from Outcar"
-        assert outcar.charge == approx(expected_chg, abs=1e-5), "Wrong charge read from Outcar"
+        assert outcar.magnetization == pytest.approx(expected_mag, abs=1e-5), "Wrong magnetization read from Outcar"
+        assert outcar.charge == pytest.approx(expected_chg, abs=1e-5), "Wrong charge read from Outcar"
         assert not outcar.is_stopped
         assert outcar.run_stats == {
             "System time (sec)": 0.938,
@@ -832,9 +831,9 @@ class TestOutcar(PymatgenTest):
             "User time (sec)": 544.204,
             "cores": 8,
         }
-        assert outcar.efermi == approx(2.0112)
-        assert outcar.nelect == approx(44.9999991)
-        assert outcar.total_mag == approx(0.9999998)
+        assert outcar.efermi == pytest.approx(2.0112)
+        assert outcar.nelect == pytest.approx(44.9999991)
+        assert outcar.total_mag == pytest.approx(0.9999998)
 
         assert outcar.as_dict() is not None
 
@@ -843,7 +842,7 @@ class TestOutcar(PymatgenTest):
         toten = 0
         for k in outcar.final_energy_contribs:
             toten += outcar.final_energy_contribs[k]
-        assert toten == approx(outcar.final_energy, abs=1e-6)
+        assert toten == pytest.approx(outcar.final_energy, abs=1e-6)
 
     def test_stopped_old(self):
         filepath = f"{VASP_OUT_DIR}/OUTCAR.stopped.gz"
@@ -853,26 +852,26 @@ class TestOutcar(PymatgenTest):
         outcar = Outcar(f"{VASP_OUT_DIR}/OUTCAR.lepsilon_old_born.gz")
 
         assert outcar.lepsilon
-        assert outcar.dielectric_tensor[0][0] == approx(3.716432)
-        assert outcar.dielectric_tensor[0][1] == approx(-0.20464)
-        assert outcar.dielectric_tensor[1][2] == approx(-0.20464)
-        assert outcar.dielectric_ionic_tensor[0][0] == approx(0.001419)
-        assert outcar.dielectric_ionic_tensor[0][2] == approx(0.001419)
-        assert outcar.dielectric_ionic_tensor[2][2] == approx(0.001419)
-        assert outcar.piezo_tensor[0][0] == approx(0.52799)
-        assert outcar.piezo_tensor[1][3] == approx(0.35998)
-        assert outcar.piezo_tensor[2][5] == approx(0.35997)
-        assert outcar.piezo_ionic_tensor[0][0] == approx(0.05868)
-        assert outcar.piezo_ionic_tensor[1][3] == approx(0.06241)
-        assert outcar.piezo_ionic_tensor[2][5] == approx(0.06242)
-        assert outcar.born[0][1][2] == approx(-0.385)
-        assert outcar.born[1][2][0] == approx(0.36465)
-        assert outcar.internal_strain_tensor[0][0][0] == approx(-572.5437, abs=1e-4)
-        assert outcar.internal_strain_tensor[0][1][0] == approx(683.2985, abs=1e-4)
-        assert outcar.internal_strain_tensor[0][1][3] == approx(73.07059, abs=1e-4)
-        assert outcar.internal_strain_tensor[1][0][0] == approx(570.98927, abs=1e-4)
-        assert outcar.internal_strain_tensor[1][1][0] == approx(-683.68519, abs=1e-4)
-        assert outcar.internal_strain_tensor[1][2][2] == approx(570.98927, abs=1e-4)
+        assert outcar.dielectric_tensor[0][0] == pytest.approx(3.716432)
+        assert outcar.dielectric_tensor[0][1] == pytest.approx(-0.20464)
+        assert outcar.dielectric_tensor[1][2] == pytest.approx(-0.20464)
+        assert outcar.dielectric_ionic_tensor[0][0] == pytest.approx(0.001419)
+        assert outcar.dielectric_ionic_tensor[0][2] == pytest.approx(0.001419)
+        assert outcar.dielectric_ionic_tensor[2][2] == pytest.approx(0.001419)
+        assert outcar.piezo_tensor[0][0] == pytest.approx(0.52799)
+        assert outcar.piezo_tensor[1][3] == pytest.approx(0.35998)
+        assert outcar.piezo_tensor[2][5] == pytest.approx(0.35997)
+        assert outcar.piezo_ionic_tensor[0][0] == pytest.approx(0.05868)
+        assert outcar.piezo_ionic_tensor[1][3] == pytest.approx(0.06241)
+        assert outcar.piezo_ionic_tensor[2][5] == pytest.approx(0.06242)
+        assert outcar.born[0][1][2] == pytest.approx(-0.385)
+        assert outcar.born[1][2][0] == pytest.approx(0.36465)
+        assert outcar.internal_strain_tensor[0][0][0] == pytest.approx(-572.5437, abs=1e-4)
+        assert outcar.internal_strain_tensor[0][1][0] == pytest.approx(683.2985, abs=1e-4)
+        assert outcar.internal_strain_tensor[0][1][3] == pytest.approx(73.07059, abs=1e-4)
+        assert outcar.internal_strain_tensor[1][0][0] == pytest.approx(570.98927, abs=1e-4)
+        assert outcar.internal_strain_tensor[1][1][0] == pytest.approx(-683.68519, abs=1e-4)
+        assert outcar.internal_strain_tensor[1][2][2] == pytest.approx(570.98927, abs=1e-4)
 
     def test_stopped(self):
         filepath = f"{VASP_OUT_DIR}/OUTCAR.stopped.gz"
@@ -882,26 +881,26 @@ class TestOutcar(PymatgenTest):
         outcar = Outcar(f"{VASP_OUT_DIR}/OUTCAR.lepsilon.gz")
 
         assert outcar.lepsilon
-        assert outcar.dielectric_tensor[0][0] == approx(3.716432)
-        assert outcar.dielectric_tensor[0][1] == approx(-0.20464)
-        assert outcar.dielectric_tensor[1][2] == approx(-0.20464)
-        assert outcar.dielectric_ionic_tensor[0][0] == approx(0.001419)
-        assert outcar.dielectric_ionic_tensor[0][2] == approx(0.001419)
-        assert outcar.dielectric_ionic_tensor[2][2] == approx(0.001419)
-        assert outcar.piezo_tensor[0][0] == approx(0.52799)
-        assert outcar.piezo_tensor[1][3] == approx(0.35998)
-        assert outcar.piezo_tensor[2][5] == approx(0.35997)
-        assert outcar.piezo_ionic_tensor[0][0] == approx(0.05868)
-        assert outcar.piezo_ionic_tensor[1][3] == approx(0.06241)
-        assert outcar.piezo_ionic_tensor[2][5] == approx(0.06242)
-        assert outcar.born[0][1][2] == approx(-0.385)
-        assert outcar.born[1][2][0] == approx(0.36465)
-        assert outcar.internal_strain_tensor[0][0][0] == approx(-572.5437, abs=1e-4)
-        assert outcar.internal_strain_tensor[0][1][0] == approx(683.2985, abs=1e-4)
-        assert outcar.internal_strain_tensor[0][1][3] == approx(73.07059, abs=1e-4)
-        assert outcar.internal_strain_tensor[1][0][0] == approx(570.98927, abs=1e-4)
-        assert outcar.internal_strain_tensor[1][1][0] == approx(-683.68519, abs=1e-4)
-        assert outcar.internal_strain_tensor[1][2][2] == approx(570.98927, abs=1e-4)
+        assert outcar.dielectric_tensor[0][0] == pytest.approx(3.716432)
+        assert outcar.dielectric_tensor[0][1] == pytest.approx(-0.20464)
+        assert outcar.dielectric_tensor[1][2] == pytest.approx(-0.20464)
+        assert outcar.dielectric_ionic_tensor[0][0] == pytest.approx(0.001419)
+        assert outcar.dielectric_ionic_tensor[0][2] == pytest.approx(0.001419)
+        assert outcar.dielectric_ionic_tensor[2][2] == pytest.approx(0.001419)
+        assert outcar.piezo_tensor[0][0] == pytest.approx(0.52799)
+        assert outcar.piezo_tensor[1][3] == pytest.approx(0.35998)
+        assert outcar.piezo_tensor[2][5] == pytest.approx(0.35997)
+        assert outcar.piezo_ionic_tensor[0][0] == pytest.approx(0.05868)
+        assert outcar.piezo_ionic_tensor[1][3] == pytest.approx(0.06241)
+        assert outcar.piezo_ionic_tensor[2][5] == pytest.approx(0.06242)
+        assert outcar.born[0][1][2] == pytest.approx(-0.385)
+        assert outcar.born[1][2][0] == pytest.approx(0.36465)
+        assert outcar.internal_strain_tensor[0][0][0] == pytest.approx(-572.5437, abs=1e-4)
+        assert outcar.internal_strain_tensor[0][1][0] == pytest.approx(683.2985, abs=1e-4)
+        assert outcar.internal_strain_tensor[0][1][3] == pytest.approx(73.07059, abs=1e-4)
+        assert outcar.internal_strain_tensor[1][0][0] == pytest.approx(570.98927, abs=1e-4)
+        assert outcar.internal_strain_tensor[1][1][0] == pytest.approx(-683.68519, abs=1e-4)
+        assert outcar.internal_strain_tensor[1][2][2] == pytest.approx(570.98927, abs=1e-4)
 
     def test_soc(self):
         filepath = f"{VASP_OUT_DIR}/OUTCAR.NiO_SOC.gz"
@@ -941,8 +940,8 @@ class TestOutcar(PymatgenTest):
         outcar = Outcar(filepath)
         assert outcar.spin
         assert outcar.noncollinear is False
-        assert outcar.p_ion == approx([0.0, 0.0, -5.56684])
-        assert outcar.p_elec == approx([0.00024, 0.00019, 3.61674])
+        assert outcar.p_ion == pytest.approx([0.0, 0.0, -5.56684])
+        assert outcar.p_elec == pytest.approx([0.00024, 0.00019, 3.61674])
 
     def test_pseudo_zval(self):
         filepath = f"{VASP_OUT_DIR}/OUTCAR.BaTiO3.polar"
@@ -957,17 +956,17 @@ class TestOutcar(PymatgenTest):
         filepath = f"{VASP_OUT_DIR}/OUTCAR.dielectric"
         outcar = Outcar(filepath)
         outcar.read_corrections()
-        assert outcar.data["dipol_quadrupol_correction"] == approx(0.03565)
-        assert outcar.final_energy == approx(-797.46294064)
+        assert outcar.data["dipol_quadrupol_correction"] == pytest.approx(0.03565)
+        assert outcar.final_energy == pytest.approx(-797.46294064)
 
     def test_freq_dielectric(self):
         filepath = f"{VASP_OUT_DIR}/OUTCAR.LOPTICS"
         outcar = Outcar(filepath)
         outcar.read_freq_dielectric()
-        assert outcar.dielectric_energies[0] == approx(0)
-        assert outcar.dielectric_energies[-1] == approx(39.826101)
-        assert outcar.dielectric_tensor_function[0][0, 0] == approx(8.96938800)
-        assert outcar.dielectric_tensor_function[-1][0, 0] == approx(7.36167000e-01 + 1.53800000e-03j)
+        assert outcar.dielectric_energies[0] == pytest.approx(0)
+        assert outcar.dielectric_energies[-1] == pytest.approx(39.826101)
+        assert outcar.dielectric_tensor_function[0][0, 0] == pytest.approx(8.96938800)
+        assert outcar.dielectric_tensor_function[-1][0, 0] == pytest.approx(7.36167000e-01 + 1.53800000e-03j)
         assert len(outcar.dielectric_energies) == len(outcar.dielectric_tensor_function)
         np.testing.assert_array_equal(
             outcar.dielectric_tensor_function[0],
@@ -989,10 +988,10 @@ class TestOutcar(PymatgenTest):
         filepath = f"{VASP_OUT_DIR}/OUTCAR.LOPTICS.vasp544"
         outcar = Outcar(filepath)
         outcar.read_freq_dielectric()
-        assert outcar.dielectric_energies[0] == approx(0)
-        assert outcar.dielectric_energies[-1] == approx(39.63964)
-        assert outcar.dielectric_tensor_function[0][0, 0] == approx(12.769435 + 0j)
-        assert outcar.dielectric_tensor_function[-1][0, 0] == approx(0.828615 + 0.016594j)
+        assert outcar.dielectric_energies[0] == pytest.approx(0)
+        assert outcar.dielectric_energies[-1] == pytest.approx(39.63964)
+        assert outcar.dielectric_tensor_function[0][0, 0] == pytest.approx(12.769435 + 0j)
+        assert outcar.dielectric_tensor_function[-1][0, 0] == pytest.approx(0.828615 + 0.016594j)
         assert len(outcar.dielectric_energies) == len(outcar.dielectric_tensor_function)
         np.testing.assert_array_equal(
             outcar.dielectric_tensor_function[0],
@@ -1022,9 +1021,9 @@ class TestOutcar(PymatgenTest):
 
         outcar.read_elastic_tensor()
 
-        assert outcar.data["elastic_tensor"][0][0] == approx(1986.3391)
-        assert outcar.data["elastic_tensor"][0][1] == approx(187.8324)
-        assert outcar.data["elastic_tensor"][3][3] == approx(586.3034)
+        assert outcar.data["elastic_tensor"][0][0] == pytest.approx(1986.3391)
+        assert outcar.data["elastic_tensor"][0][1] == pytest.approx(187.8324)
+        assert outcar.data["elastic_tensor"][3][3] == pytest.approx(586.3034)
 
     def test_read_lcalcpol(self):
         # outcar with electrons Angst units
@@ -1039,10 +1038,10 @@ class TestOutcar(PymatgenTest):
         p_sp1 = [2.01124, 2.01124, -2.04426]
         p_sp2 = [2.01139, 2.01139, -2.04426]
 
-        assert outcar.p_ion == approx(p_ion)
-        assert outcar.p_elec == approx(p_elec)
-        assert outcar.p_sp1 == approx(p_sp1)
-        assert outcar.p_sp2 == approx(p_sp2)
+        assert outcar.p_ion == pytest.approx(p_ion)
+        assert outcar.p_elec == pytest.approx(p_elec)
+        assert outcar.p_sp1 == pytest.approx(p_sp1)
+        assert outcar.p_sp2 == pytest.approx(p_sp2)
 
         # outcar with |e| Angst units
         filepath = f"{VASP_OUT_DIR}/OUTCAR_vasp_6.3.gz"
@@ -1055,28 +1054,28 @@ class TestOutcar(PymatgenTest):
         p_sp1 = [4.50564, 0.0, 1.62154]
         p_sp2 = [4.50563e00, -1.00000e-05, 1.62154e00]
 
-        assert outcar.p_ion == approx(p_ion)
-        assert outcar.p_elec == approx(p_elec)
-        assert outcar.p_sp1 == approx(p_sp1)
-        assert outcar.p_sp2 == approx(p_sp2)
+        assert outcar.p_ion == pytest.approx(p_ion)
+        assert outcar.p_elec == pytest.approx(p_elec)
+        assert outcar.p_sp1 == pytest.approx(p_sp1)
+        assert outcar.p_sp2 == pytest.approx(p_sp2)
 
     def test_read_piezo_tensor(self):
         filepath = f"{VASP_OUT_DIR}/OUTCAR.lepsilon.gz"
         outcar = Outcar(filepath)
 
         outcar.read_piezo_tensor()
-        assert outcar.data["piezo_tensor"][0][0] == approx(0.52799)
-        assert outcar.data["piezo_tensor"][1][3] == approx(0.35998)
-        assert outcar.data["piezo_tensor"][2][5] == approx(0.35997)
+        assert outcar.data["piezo_tensor"][0][0] == pytest.approx(0.52799)
+        assert outcar.data["piezo_tensor"][1][3] == pytest.approx(0.35998)
+        assert outcar.data["piezo_tensor"][2][5] == pytest.approx(0.35997)
 
     def test_core_state_eigen(self):
         filepath = f"{VASP_OUT_DIR}/OUTCAR.CL.gz"
         cl = Outcar(filepath).read_core_state_eigen()
-        assert cl[6]["2s"][-1] == approx(-174.4779)
+        assert cl[6]["2s"][-1] == pytest.approx(-174.4779)
         filepath = f"{VASP_OUT_DIR}/OUTCAR.icorelevel"
         outcar = Outcar(filepath)
         cl = outcar.read_core_state_eigen()
-        assert cl[4]["3d"][-1] == approx(-31.4522)
+        assert cl[4]["3d"][-1] == pytest.approx(-31.4522)
 
         # test serialization
         outcar.as_dict()
@@ -1084,15 +1083,15 @@ class TestOutcar(PymatgenTest):
     def test_avg_core_poten(self):
         filepath = f"{VASP_OUT_DIR}/OUTCAR.lepsilon.gz"
         cp = Outcar(filepath).read_avg_core_poten()
-        assert cp[-1][1] == approx(-90.0487)
+        assert cp[-1][1] == pytest.approx(-90.0487)
 
         filepath = f"{VASP_OUT_DIR}/OUTCAR.gz"
         cp = Outcar(filepath).read_avg_core_poten()
-        assert cp[0][6] == approx(-73.1068)
+        assert cp[0][6] == pytest.approx(-73.1068)
 
         filepath = f"{VASP_OUT_DIR}/OUTCAR.bad_core_poten.gz"
         cp = Outcar(filepath).read_avg_core_poten()
-        assert cp[0][1] == approx(-101.5055)
+        assert cp[0][1] == pytest.approx(-101.5055)
 
     def test_single_atom(self):
         filepath = f"{VASP_OUT_DIR}/OUTCAR.Al"
@@ -1100,8 +1099,8 @@ class TestOutcar(PymatgenTest):
         expected_mag = ({"p": 0.0, "s": 0.0, "d": 0.0, "tot": 0.0},)
         expected_chg = ({"p": 0.343, "s": 0.425, "d": 0.0, "tot": 0.768},)
 
-        assert outcar.magnetization == approx(expected_mag)
-        assert outcar.charge == approx(expected_chg)
+        assert outcar.magnetization == pytest.approx(expected_mag)
+        assert outcar.charge == pytest.approx(expected_chg)
         assert not outcar.is_stopped
         assert outcar.run_stats == {
             "System time (sec)": 0.592,
@@ -1112,9 +1111,9 @@ class TestOutcar(PymatgenTest):
             "User time (sec)": 49.602,
             "cores": 32,
         }
-        assert outcar.efermi == approx(8.0942)
+        assert outcar.efermi == pytest.approx(8.0942)
         assert outcar.nelect == 3
-        assert outcar.total_mag == approx(8.2e-06)
+        assert outcar.total_mag == pytest.approx(8.2e-06)
 
         assert outcar.as_dict() is not None
 
@@ -1132,7 +1131,9 @@ class TestOutcar(PymatgenTest):
             [195.0788, 68.1733, 0.8337],
         ]
 
-        assert len(outcar.data["chemical_shielding"]["valence_only"][20:28]) == approx(len(expected_chemical_shielding))
+        assert len(outcar.data["chemical_shielding"]["valence_only"][20:28]) == pytest.approx(
+            len(expected_chemical_shielding)
+        )
 
         assert_allclose(
             outcar.data["chemical_shielding"]["valence_and_core"][20:28],
@@ -1144,9 +1145,9 @@ class TestOutcar(PymatgenTest):
         filename = f"{TEST_DIR}/fixtures/nmr/cs/core.diff/core.diff.chemical.shifts.OUTCAR"
         outcar = Outcar(filename)
         c_vo = outcar.data["chemical_shielding"]["valence_only"][7]
-        assert list(c_vo) == approx([198.7009, 73.7484, 1])
+        assert list(c_vo) == pytest.approx([198.7009, 73.7484, 1])
         c_vc = outcar.data["chemical_shielding"]["valence_and_core"][7]
-        assert list(c_vc) == approx([-1.9406, 73.7484, 1])
+        assert list(c_vc) == pytest.approx([-1.9406, 73.7484, 1])
 
     def test_cs_raw_tensors(self):
         filename = f"{TEST_DIR}/fixtures/nmr/cs/core.diff/core.diff.chemical.shifts.OUTCAR"
@@ -1195,7 +1196,7 @@ class TestOutcar(PymatgenTest):
         assert len(outcar.data["efg"][2:10]) == len(expected_efg)
         for e1, e2 in zip(outcar.data["efg"][2:10], expected_efg, strict=True):
             for k in e1:
-                assert e1[k] == approx(e2[k], abs=1e-5)
+                assert e1[k] == pytest.approx(e2[k], abs=1e-5)
 
         exepected_tensors = [
             [[11.11, 1.371, 2.652], [1.371, 3.635, -3.572], [2.652, -3.572, -14.746]],
@@ -1228,18 +1229,18 @@ class TestOutcar(PymatgenTest):
         filepath = f"{VASP_OUT_DIR}/OUTCAR_fc"
         outcar = Outcar(filepath)
         outcar.read_fermi_contact_shift()
-        assert outcar.data["fermi_contact_shift"]["fch"][0][0] == approx(-0.002)
-        assert outcar.data["fermi_contact_shift"]["th"][0][0] == approx(-0.052)
-        assert outcar.data["fermi_contact_shift"]["dh"][0][0] == approx(0.0)
+        assert outcar.data["fermi_contact_shift"]["fch"][0][0] == pytest.approx(-0.002)
+        assert outcar.data["fermi_contact_shift"]["th"][0][0] == pytest.approx(-0.052)
+        assert outcar.data["fermi_contact_shift"]["dh"][0][0] == pytest.approx(0.0)
 
     def test_drift(self):
         outcar = Outcar(f"{VASP_OUT_DIR}/OUTCAR.gz")
         assert len(outcar.drift) == 5
-        assert np.sum(outcar.drift) == approx(0)
+        assert np.sum(outcar.drift) == pytest.approx(0)
 
         outcar = Outcar(f"{VASP_OUT_DIR}/OUTCAR.CL.gz")
         assert len(outcar.drift) == 79
-        assert np.sum(outcar.drift) == approx(0.448010)
+        assert np.sum(outcar.drift) == pytest.approx(0.448010)
 
     def test_electrostatic_potential(self):
         outcar = Outcar(f"{VASP_OUT_DIR}/OUTCAR.gz")
@@ -1321,27 +1322,27 @@ class TestOutcar(PymatgenTest):
     def test_energies(self):
         # VASP 5.2.1
         outcar = Outcar(f"{VASP_OUT_DIR}/OUTCAR.etest1.gz")
-        assert outcar.final_energy == approx(-11.18981538)
-        assert outcar.final_energy_wo_entrp == approx(-11.13480014)
-        assert outcar.final_fr_energy == approx(-11.21732300)
+        assert outcar.final_energy == pytest.approx(-11.18981538)
+        assert outcar.final_energy_wo_entrp == pytest.approx(-11.13480014)
+        assert outcar.final_fr_energy == pytest.approx(-11.21732300)
 
         # VASP 6.2.1
         outcar = Outcar(f"{VASP_OUT_DIR}/OUTCAR.etest2.gz")
-        assert outcar.final_energy == approx(-11.18986774)
-        assert outcar.final_energy_wo_entrp == approx(-11.13485250)
-        assert outcar.final_fr_energy == approx(-11.21737536)
+        assert outcar.final_energy == pytest.approx(-11.18986774)
+        assert outcar.final_energy_wo_entrp == pytest.approx(-11.13485250)
+        assert outcar.final_fr_energy == pytest.approx(-11.21737536)
 
         # VASP 5.2.1
         outcar = Outcar(f"{VASP_OUT_DIR}/OUTCAR.etest3.gz")
-        assert outcar.final_energy == approx(-15.89355325)
-        assert outcar.final_energy_wo_entrp == approx(-15.83853800)
-        assert outcar.final_fr_energy == approx(-15.92106087)
+        assert outcar.final_energy == pytest.approx(-15.89355325)
+        assert outcar.final_energy_wo_entrp == pytest.approx(-15.83853800)
+        assert outcar.final_fr_energy == pytest.approx(-15.92106087)
 
         # VASP 6.2.1
         outcar = Outcar(f"{VASP_OUT_DIR}/OUTCAR.etest4.gz")
-        assert outcar.final_energy == approx(-15.89364691)
-        assert outcar.final_energy_wo_entrp == approx(-15.83863167)
-        assert outcar.final_fr_energy == approx(-15.92115453)
+        assert outcar.final_energy == pytest.approx(-15.89364691)
+        assert outcar.final_energy_wo_entrp == pytest.approx(-15.83863167)
+        assert outcar.final_fr_energy == pytest.approx(-15.92115453)
 
     def test_read_table_pattern(self):
         outcar = Outcar(f"{VASP_OUT_DIR}/OUTCAR.gz")
@@ -1380,10 +1381,10 @@ class TestBSVasprun(PymatgenTest):
         cbm = bs.get_cbm()
         vbm = bs.get_vbm()
         assert cbm["kpoint_index"] == [13], "wrong cbm kpoint index"
-        assert cbm["energy"] == approx(6.2301), "wrong cbm energy"
+        assert cbm["energy"] == pytest.approx(6.2301), "wrong cbm energy"
         assert cbm["band_index"] == {Spin.up: [4], Spin.down: [4]}, "wrong cbm bands"
         assert vbm["kpoint_index"] == [0, 63, 64]
-        assert vbm["energy"] == approx(5.6158), "wrong vbm energy"
+        assert vbm["energy"] == pytest.approx(5.6158), "wrong vbm energy"
         assert vbm["band_index"] == {Spin.up: [1, 2, 3], Spin.down: [1, 2, 3]}, "wrong vbm bands"
         assert vbm["kpoint"].label == "\\Gamma", "wrong vbm label"
         assert cbm["kpoint"].label is None, "wrong cbm label"
@@ -1397,13 +1398,13 @@ class TestBSVasprun(PymatgenTest):
         cbm = bs.get_cbm()
         vbm = bs.get_vbm()
         assert cbm["kpoint_index"] == [38], "wrong cbm kpoint index"
-        assert cbm["energy"] == approx(6.4394), "wrong cbm energy"
+        assert cbm["energy"] == pytest.approx(6.4394), "wrong cbm energy"
         assert cbm["band_index"] == {Spin.up: [16], Spin.down: [16]}, "wrong cbm bands"
         # Strangely, when I call with parse_projected_eigen, it gives empty Spin.down,
         # but without parse_projected_eigen it does not give it.
         # So at one point it called the empty key.
         assert vbm["kpoint_index"] == [0, 39, 40]
-        assert vbm["energy"] == approx(5.7562), "wrong vbm energy"
+        assert vbm["energy"] == pytest.approx(5.7562), "wrong vbm energy"
         assert vbm["band_index"] == {Spin.down: [13, 14, 15], Spin.up: [13, 14, 15]}, "wrong vbm bands"
         assert vbm["kpoint"].label == "\\Gamma", "wrong vbm label"
         assert cbm["kpoint"].label is None, "wrong cbm label"
@@ -1426,13 +1427,13 @@ class TestOszicar(PymatgenTest):
         oszicar = Oszicar(fpath)
         assert len(oszicar.electronic_steps) == len(oszicar.ionic_steps)
         assert len(oszicar.all_energies) == 60
-        assert oszicar.final_energy == approx(-526.63928)
+        assert oszicar.final_energy == pytest.approx(-526.63928)
         assert set(oszicar.ionic_steps[-1]) == set({"F", "E0", "dE", "mag"})
 
     def test_static(self):
         fpath = f"{TEST_DIR}/fixtures/static_silicon/OSZICAR"
         oszicar = Oszicar(fpath)
-        assert oszicar.final_energy == approx(-10.645278)
+        assert oszicar.final_energy == pytest.approx(-10.645278)
         assert set(oszicar.ionic_steps[-1]) == set({"F", "E0", "dE", "mag"})
 
 
@@ -1440,10 +1441,10 @@ class TestLocpot(PymatgenTest):
     def test_init(self):
         filepath = f"{VASP_OUT_DIR}/LOCPOT.gz"
         locpot = Locpot.from_file(filepath)
-        assert approx(sum(locpot.get_average_along_axis(0))) == -217.05226954
-        assert locpot.get_axis_grid(0)[-1] == approx(2.87629, abs=1e-2)
-        assert locpot.get_axis_grid(1)[-1] == approx(2.87629, abs=1e-2)
-        assert locpot.get_axis_grid(2)[-1] == approx(2.87629, abs=1e-2)
+        assert pytest.approx(sum(locpot.get_average_along_axis(0))) == -217.05226954
+        assert locpot.get_axis_grid(0)[-1] == pytest.approx(2.87629, abs=1e-2)
+        assert locpot.get_axis_grid(1)[-1] == pytest.approx(2.87629, abs=1e-2)
+        assert locpot.get_axis_grid(2)[-1] == pytest.approx(2.87629, abs=1e-2)
 
         # make sure locpot constructor works with data_aug=None
         poscar, data, _data_aug = Locpot.parse_file(filepath)
@@ -1467,14 +1468,14 @@ class TestChgcar(PymatgenTest):
         cls.chgcar_NiO_soc = Chgcar.from_file(filepath)
 
     def test_init(self):
-        assert self.chgcar_no_spin.get_integrated_diff(0, 2)[0, 1] == approx(0)
-        assert self.chgcar_spin.get_integrated_diff(0, 1)[0, 1] == approx(-0.0043896932237534022)
+        assert self.chgcar_no_spin.get_integrated_diff(0, 2)[0, 1] == pytest.approx(0)
+        assert self.chgcar_spin.get_integrated_diff(0, 1)[0, 1] == pytest.approx(-0.0043896932237534022)
         # test sum
         chgcar = self.chgcar_spin + self.chgcar_spin
-        assert chgcar.get_integrated_diff(0, 1)[0, 1] == approx(-0.0043896932237534022 * 2)
+        assert chgcar.get_integrated_diff(0, 1)[0, 1] == pytest.approx(-0.0043896932237534022 * 2)
 
         chgcar = self.chgcar_spin - self.chgcar_spin
-        assert chgcar.get_integrated_diff(0, 1)[0, 1] == approx(0)
+        assert chgcar.get_integrated_diff(0, 1)[0, 1] == pytest.approx(0)
 
         expected = [1.56472768, 3.25985108, 3.49205728, 3.66275028, 3.8045896, 5.10813352]
         actual = self.chgcar_fe3o4.get_integrated_diff(0, 3, 6)
@@ -1501,7 +1502,7 @@ class TestChgcar(PymatgenTest):
         # and that the net magnetization is about zero
         # note: we get ~ 0.08 here, seems a little high compared to
         # vasp output, but might be due to chgcar limitations?
-        assert self.chgcar_NiO_soc.net_magnetization == approx(0.0, abs=1e-0)
+        assert self.chgcar_NiO_soc.net_magnetization == pytest.approx(0.0, abs=1e-0)
 
         self.chgcar_NiO_soc.write_file(out_path := f"{self.tmp_path}/CHGCAR_pmg_soc")
         chg_from_file = Chgcar.from_file(out_path)
@@ -1579,8 +1580,8 @@ class TestAeccars(PymatgenTest):
 class TestElfcar(PymatgenTest):
     def test_init(self):
         elfcar = Elfcar.from_file(f"{VASP_OUT_DIR}/ELFCAR.gz")
-        assert approx(np.mean(elfcar.data["total"])) == 0.19076207645194002
-        assert approx(np.mean(elfcar.data["diff"])) == 0.19076046677910055
+        assert pytest.approx(np.mean(elfcar.data["total"])) == 0.19076207645194002
+        assert pytest.approx(np.mean(elfcar.data["diff"])) == 0.19076046677910055
         reconstituted = Elfcar.from_dict(elfcar.as_dict())
         assert elfcar.data == reconstituted.data
         assert elfcar.poscar.structure == reconstituted.poscar.structure
@@ -1588,11 +1589,11 @@ class TestElfcar(PymatgenTest):
     def test_alpha(self):
         elfcar = Elfcar.from_file(f"{VASP_OUT_DIR}/ELFCAR.gz")
         alpha = elfcar.get_alpha()
-        assert approx(np.median(alpha.data["total"])) == 2.936678808979031
+        assert pytest.approx(np.median(alpha.data["total"])) == 2.936678808979031
 
     def test_interpolation(self):
         elfcar = Elfcar.from_file(f"{VASP_OUT_DIR}/ELFCAR.gz")
-        assert approx(elfcar.value_at(0.4, 0.5, 0.6)) == 0.0918471
+        assert pytest.approx(elfcar.value_at(0.4, 0.5, 0.6)) == 0.0918471
         assert len(elfcar.linear_slice([0.0, 0.0, 0.0], [1.0, 1.0, 1.0])) == 100
 
 
@@ -1600,9 +1601,9 @@ class TestProcar(PymatgenTest):
     def test_init(self):
         filepath = f"{VASP_OUT_DIR}/PROCAR.simple"
         procar = Procar(filepath)
-        assert procar.get_occupation(0, "d")[Spin.up] == approx(0)
-        assert procar.get_occupation(0, "s")[Spin.up] == approx(0.35381249999999997)
-        assert procar.get_occupation(0, "p")[Spin.up] == approx(1.19540625)
+        assert procar.get_occupation(0, "d")[Spin.up] == pytest.approx(0)
+        assert procar.get_occupation(0, "s")[Spin.up] == pytest.approx(0.35381249999999997)
+        assert procar.get_occupation(0, "p")[Spin.up] == pytest.approx(1.19540625)
         with pytest.raises(ValueError, match="'m' is not in list"):
             procar.get_occupation(1, "m")
         assert procar.nbands == 10
@@ -1610,24 +1611,24 @@ class TestProcar(PymatgenTest):
         assert procar.nions == 3
         filepath = f"{VASP_OUT_DIR}/PROCAR.gz"
         procar = Procar(filepath)
-        assert procar.get_occupation(0, "dxy")[Spin.up] == approx(0.96214813853000025)
-        assert procar.get_occupation(0, "dxy")[Spin.down] == approx(0.85796295426000124)
+        assert procar.get_occupation(0, "dxy")[Spin.up] == pytest.approx(0.96214813853000025)
+        assert procar.get_occupation(0, "dxy")[Spin.down] == pytest.approx(0.85796295426000124)
 
     def test_phase_factors(self):
         filepath = f"{VASP_OUT_DIR}/PROCAR.phase.gz"
         procar = Procar(filepath)
-        assert procar.phase_factors[Spin.up][0, 0, 0, 0] == approx(-0.746 + 0.099j)
-        assert procar.phase_factors[Spin.down][0, 0, 0, 0] == approx(0.372 - 0.654j)
+        assert procar.phase_factors[Spin.up][0, 0, 0, 0] == pytest.approx(-0.746 + 0.099j)
+        assert procar.phase_factors[Spin.down][0, 0, 0, 0] == pytest.approx(0.372 - 0.654j)
 
         # Two Li should have same phase factor.
-        assert procar.phase_factors[Spin.up][0, 0, 0, 0] == approx(procar.phase_factors[Spin.up][0, 0, 1, 0])
-        assert procar.phase_factors[Spin.up][0, 0, 2, 0] == approx(-0.053 + 0.007j)
-        assert procar.phase_factors[Spin.down][0, 0, 2, 0] == approx(0.027 - 0.047j)
+        assert procar.phase_factors[Spin.up][0, 0, 0, 0] == pytest.approx(procar.phase_factors[Spin.up][0, 0, 1, 0])
+        assert procar.phase_factors[Spin.up][0, 0, 2, 0] == pytest.approx(-0.053 + 0.007j)
+        assert procar.phase_factors[Spin.down][0, 0, 2, 0] == pytest.approx(0.027 - 0.047j)
 
         # new style phase factors (VASP 5.4.4+)
         filepath = f"{VASP_OUT_DIR}/PROCAR.new_format_5.4.4.gz"
         procar = Procar(filepath)
-        assert procar.phase_factors[Spin.up][0, 0, 0, 0] == approx(-0.13 + 0.199j)
+        assert procar.phase_factors[Spin.up][0, 0, 0, 0] == pytest.approx(-0.13 + 0.199j)
 
     def test_get_projection_on_elements(self):
         filepath = f"{VASP_OUT_DIR}/PROCAR.simple"
@@ -1638,11 +1639,11 @@ class TestProcar(PymatgenTest):
             [[0.0, 0.0, 0.0], [0.25, 0.25, 0.25], [0.75, 0.75, 0.75]],
         )
         dct = procar.get_projection_on_elements(struct)
-        assert dct[Spin.up][2][2] == approx({"Na": 0.042, "K": 0.646, "Li": 0.042})
+        assert dct[Spin.up][2][2] == pytest.approx({"Na": 0.042, "K": 0.646, "Li": 0.042})
         # https://github.com/materialsproject/pymatgen/pull/3261
         struct.replace_species({"K": "Na"})
         d2 = procar.get_projection_on_elements(struct)
-        assert d2[Spin.up][2][2] == approx({"Na": 0.688, "Li": 0.042})
+        assert d2[Spin.up][2][2] == pytest.approx({"Na": 0.688, "Li": 0.042})
 
 
 class TestXdatcar:
@@ -1713,13 +1714,13 @@ class TestWavecar(PymatgenTest):
         b = 2 * np.pi * b / vol
 
         assert wavecar.filename == f"{VASP_OUT_DIR}/WAVECAR.N2"
-        assert wavecar.efermi == approx(-5.7232, abs=1e-4)
+        assert wavecar.efermi == pytest.approx(-5.7232, abs=1e-4)
         assert wavecar.encut == 25.0
         assert wavecar.nb == 9
         assert wavecar.nk == 1
         assert_allclose(wavecar.a, a)
         assert_allclose(wavecar.b, b)
-        assert wavecar.vol == approx(vol)
+        assert wavecar.vol == pytest.approx(vol)
         assert len(wavecar.kpoints) == wavecar.nk
         assert len(wavecar.coeffs) == wavecar.nk
         assert len(wavecar.coeffs[0]) == wavecar.nb
@@ -1758,13 +1759,13 @@ class TestWavecar(PymatgenTest):
     def test_n2_45210(self):
         wavecar = Wavecar(f"{VASP_OUT_DIR}/WAVECAR.N2.45210")
         assert wavecar.filename == f"{VASP_OUT_DIR}/WAVECAR.N2.45210"
-        assert wavecar.efermi == approx(-5.7232, abs=1e-4)
+        assert wavecar.efermi == pytest.approx(-5.7232, abs=1e-4)
         assert wavecar.encut == 25.0
         assert wavecar.nb == 9
         assert wavecar.nk == 1
         assert_allclose(wavecar.a, self.latt_mat)
         assert_allclose(wavecar.b, self.recip_latt_mat)
-        assert wavecar.vol == approx(self.vol)
+        assert wavecar.vol == pytest.approx(self.vol)
         assert len(wavecar.kpoints) == wavecar.nk
         assert len(wavecar.coeffs) == wavecar.nk
         assert len(wavecar.coeffs[0]) == wavecar.nb
@@ -1802,15 +1803,17 @@ class TestWavecar(PymatgenTest):
         self.wavecar.Gpoints.append(np.array([0, 0, 0]))
         self.wavecar.kpoints.append(np.array([0, 0, 0]))
         self.wavecar.coeffs.append([[1 + 1j]])
-        assert self.wavecar.evaluate_wavefunc(-1, -1, [0, 0, 0]) == approx((1 + 1j) / np.sqrt(self.vol), abs=1e-4)
-        assert self.wavecar.evaluate_wavefunc(0, 0, [0, 0, 0]) == approx(
+        assert self.wavecar.evaluate_wavefunc(-1, -1, [0, 0, 0]) == pytest.approx(
+            (1 + 1j) / np.sqrt(self.vol), abs=1e-4
+        )
+        assert self.wavecar.evaluate_wavefunc(0, 0, [0, 0, 0]) == pytest.approx(
             np.sum(self.wavecar.coeffs[0][0]) / np.sqrt(self.vol), abs=1e-4
         )
         w = Wavecar(f"{VASP_OUT_DIR}/WAVECAR.N2.spin")
         w.Gpoints.append(np.array([0, 0, 0]))
         w.kpoints.append(np.array([0, 0, 0]))
         w.coeffs[0].append([[1 + 1j]])
-        assert w.evaluate_wavefunc(-1, -1, [0, 0, 0]) == approx((1 + 1j) / np.sqrt(self.vol), abs=1e-4)
+        assert w.evaluate_wavefunc(-1, -1, [0, 0, 0]) == pytest.approx((1 + 1j) / np.sqrt(self.vol), abs=1e-4)
 
     def test_fft_mesh_basic(self):
         mesh = self.wavecar.fft_mesh(0, 5)
@@ -1857,20 +1860,22 @@ class TestWavecar(PymatgenTest):
         # check equality of FFT and slow FT for regular mesh (ratio, to account for normalization)
         v1 = self.wH2.evaluate_wavefunc(ik, ib, r1)
         v2 = self.wH2.evaluate_wavefunc(ik, ib, r2)
-        assert np.abs(mesh[p1]) / np.abs(mesh[p2]) == approx(np.abs(v1) / np.abs(v2), abs=1e-6)
+        assert np.abs(mesh[p1]) / np.abs(mesh[p2]) == pytest.approx(np.abs(v1) / np.abs(v2), abs=1e-6)
 
         # spot check one value that we happen to know from reference run
-        assert v1 == approx(-0.01947068011502887 + 0.23340228099620275j, abs=1e-8)
+        assert v1 == pytest.approx(-0.01947068011502887 + 0.23340228099620275j, abs=1e-8)
 
         # check equality of FFT and slow FT for gamma-only mesh (ratio again)
         v1_gamma = self.wH2_gamma.evaluate_wavefunc(ik, ib, r1)
         v2_gamma = self.wH2_gamma.evaluate_wavefunc(ik, ib, r2)
-        assert np.abs(mesh_gamma[p1]) / np.abs(mesh_gamma[p2]) == approx(np.abs(v1_gamma) / np.abs(v2_gamma), abs=1e-6)
+        assert np.abs(mesh_gamma[p1]) / np.abs(mesh_gamma[p2]) == pytest.approx(
+            np.abs(v1_gamma) / np.abs(v2_gamma), abs=1e-6
+        )
 
         # check equality of FFT and slow FT for ncl mesh (ratio again)
         v1_ncl = self.w_ncl.evaluate_wavefunc(ik, ib, r1)
         v2_ncl = self.w_ncl.evaluate_wavefunc(ik, ib, r2)
-        assert np.abs(mesh_ncl[p1]) / np.abs(mesh_ncl[p2]) == approx(np.abs(v1_ncl) / np.abs(v2_ncl), abs=1e-6)
+        assert np.abs(mesh_ncl[p1]) / np.abs(mesh_ncl[p2]) == pytest.approx(np.abs(v1_ncl) / np.abs(v2_ncl), abs=1e-6)
 
     def test_get_parchg(self):
         poscar = Poscar.from_file(f"{VASP_IN_DIR}/POSCAR")
@@ -1979,9 +1984,9 @@ class TestEigenval(PymatgenTest):
     def test_eigenvalue_band_properties(self):
         eig = Eigenval(f"{VASP_OUT_DIR}/EIGENVAL.gz")
         props = eig.eigenvalue_band_properties
-        assert props[0] == approx(6.4153, abs=1e-4)
-        assert props[1] == approx(7.5587, abs=1e-4)
-        assert props[2] == approx(1.1434, abs=1e-4)
+        assert props[0] == pytest.approx(6.4153, abs=1e-4)
+        assert props[1] == pytest.approx(7.5587, abs=1e-4)
+        assert props[2] == pytest.approx(1.1434, abs=1e-4)
         assert props[3] is False
 
     def test_eigenvalue_band_properties_separate_spins(self):
@@ -1990,8 +1995,8 @@ class TestEigenval(PymatgenTest):
         eig2 = Eigenval(f"{VASP_OUT_DIR}/EIGENVAL_separate_spins.gz", separate_spins=False)
         props2 = eig2.eigenvalue_band_properties
 
-        assert np.array(props)[:3, :2].flat == approx([2.8772, 1.2810, 3.6741, 1.6225, 0.7969, 0.3415], abs=1e-4)
-        assert props2[0] == approx(np.min(props[1]) - np.max(props[2]), abs=1e-4)
+        assert np.array(props)[:3, :2].flat == pytest.approx([2.8772, 1.2810, 3.6741, 1.6225, 0.7969, 0.3415], abs=1e-4)
+        assert props2[0] == pytest.approx(np.min(props[1]) - np.max(props[2]), abs=1e-4)
         assert props[3][0]
         assert props[3][1]
 
@@ -2007,7 +2012,7 @@ class TestWaveder(PymatgenTest):
         spin_index = 0
         cart_dir_index = 0
         cder = wder.get_orbital_derivative_between_states(band_i, band_j, kp_index, spin_index, cart_dir_index)
-        assert cder == approx(-1.33639226092e-103, abs=1e-114)
+        assert cder == pytest.approx(-1.33639226092e-103, abs=1e-114)
 
     def test_consistency(self):
         wder_ref = np.loadtxt(f"{VASP_OUT_DIR}/WAVEDERF.Si.gz", skiprows=1)
@@ -2017,15 +2022,15 @@ class TestWaveder(PymatgenTest):
                 first_line = [int(a) for a in file.readline().split()]
             assert wder.nkpoints == first_line[1]
             assert wder.nbands == first_line[2]
-            assert [wder.get_orbital_derivative_between_states(0, idx, 0, 0, 0).real for idx in range(10)] == approx(
-                wder_ref[:10, 6], abs=1e-10
-            )
-            assert wder.cder[0, :10, 0, 0, 0].real == approx(wder_ref[:10, 6], abs=1e-10)
-            assert wder.cder[0, :10, 0, 0, 0].imag == approx(wder_ref[:10, 7], abs=1e-10)
-            assert wder.cder[0, :10, 0, 0, 1].real == approx(wder_ref[:10, 8], abs=1e-10)
-            assert wder.cder[0, :10, 0, 0, 1].imag == approx(wder_ref[:10, 9], abs=1e-10)
-            assert wder.cder[0, :10, 0, 0, 2].real == approx(wder_ref[:10, 10], abs=1e-10)
-            assert wder.cder[0, :10, 0, 0, 2].imag == approx(wder_ref[:10, 11], abs=1e-10)
+            assert [
+                wder.get_orbital_derivative_between_states(0, idx, 0, 0, 0).real for idx in range(10)
+            ] == pytest.approx(wder_ref[:10, 6], abs=1e-10)
+            assert wder.cder[0, :10, 0, 0, 0].real == pytest.approx(wder_ref[:10, 6], abs=1e-10)
+            assert wder.cder[0, :10, 0, 0, 0].imag == pytest.approx(wder_ref[:10, 7], abs=1e-10)
+            assert wder.cder[0, :10, 0, 0, 1].real == pytest.approx(wder_ref[:10, 8], abs=1e-10)
+            assert wder.cder[0, :10, 0, 0, 1].imag == pytest.approx(wder_ref[:10, 9], abs=1e-10)
+            assert wder.cder[0, :10, 0, 0, 2].real == pytest.approx(wder_ref[:10, 10], abs=1e-10)
+            assert wder.cder[0, :10, 0, 0, 2].imag == pytest.approx(wder_ref[:10, 11], abs=1e-10)
 
         wder = Waveder.from_binary(f"{VASP_OUT_DIR}/WAVEDER.Si")
         _check(wder)

--- a/tests/io/xtb/test_outputs.py
+++ b/tests/io/xtb/test_outputs.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 
-from pytest import approx
+import pytest
 
 from pymatgen.core.structure import Molecule
 from pymatgen.io.qchem.outputs import check_for_structure_changes
@@ -46,7 +46,7 @@ class TestCRESTOutput(PymatgenTest):
             for j, r in enumerate(c):
                 if openbabel:
                     assert check_for_structure_changes(r[0], expected_sorted_structures[idx][j]) == "no_change"
-                assert float(r[1]) == approx(float(expected_energies[idx][j]), abs=1e-4)
+                assert float(r[1]) == pytest.approx(float(expected_energies[idx][j]), abs=1e-4)
 
         assert crest_out.properly_terminated
         if openbabel:

--- a/tests/optimization/test_linear_assignment.py
+++ b/tests/optimization/test_linear_assignment.py
@@ -4,7 +4,6 @@ from unittest import TestCase
 
 import numpy as np
 import pytest
-from pytest import approx
 
 from pymatgen.optimization.linear_assignment import LinearAssignment
 
@@ -228,7 +227,7 @@ class TestLinearAssignment(TestCase):
             ]
         )
         la = LinearAssignment(w1)
-        assert la.min_cost == approx(0)
+        assert la.min_cost == pytest.approx(0)
 
     def test_small_range(self):
         # can be tricky for the augment step
@@ -246,7 +245,7 @@ class TestLinearAssignment(TestCase):
                 [5, 6, 6, 6, 7, 6, 6, 5, 6, 7],
             ]
         )
-        assert LinearAssignment(x).min_cost == approx(48)
+        assert LinearAssignment(x).min_cost == pytest.approx(48)
 
     def test_boolean_inputs(self):
         ones = np.ones((135, 135), dtype=bool)

--- a/tests/phonon/test_bandstructure.py
+++ b/tests/phonon/test_bandstructure.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import copy
 import json
 
+import pytest
 from numpy.testing import assert_allclose, assert_array_equal
-from pytest import approx
 
 from pymatgen.electronic_structure.bandstructure import Kpoint
 from pymatgen.phonon.bandstructure import PhononBandStructureSymmLine
@@ -36,8 +36,8 @@ class TestPhononBandStructureSymmLine(PymatgenTest):
         assert self.bs != self.bs2
 
     def test_basic(self):
-        assert self.bs.bands[1][10] == approx(0.7753555184)
-        assert self.bs.bands[5][100] == approx(5.2548379776)
+        assert self.bs.bands[1][10] == pytest.approx(0.7753555184)
+        assert self.bs.bands[5][100] == pytest.approx(5.2548379776)
         assert_array_equal(self.bs.bands.shape, (6, 204))
         assert_array_equal(self.bs.eigendisplacements.shape, (6, 204, 2, 3))
         assert_allclose(
@@ -70,7 +70,7 @@ class TestPhononBandStructureSymmLine(PymatgenTest):
     def test_nac(self):
         assert self.bs.has_nac
         assert not self.bs2.has_nac
-        assert self.bs.get_nac_frequencies_along_dir([1, 1, 0])[3] == approx(4.6084532143)
+        assert self.bs.get_nac_frequencies_along_dir([1, 1, 0])[3] == pytest.approx(4.6084532143)
         assert self.bs.get_nac_frequencies_along_dir([0, 1, 1]) is None
         assert self.bs2.get_nac_frequencies_along_dir([0, 0, 1]) is None
         assert_allclose(
@@ -107,20 +107,20 @@ class TestPhononBandStructureSymmLine(PymatgenTest):
         min_qpoint, min_freq = self.bs.min_freq()
         assert isinstance(min_qpoint, Kpoint)
         assert list(min_qpoint.frac_coords) == [0, 0, 0]
-        assert min_freq == approx(-0.03700895020)
+        assert min_freq == pytest.approx(-0.03700895020)
 
         max_qpoint, max_freq = self.bs.max_freq()
         assert isinstance(max_qpoint, Kpoint)
         assert list(max_qpoint.frac_coords) == [0, 0, 0]
-        assert max_freq == approx(7.391425798)
+        assert max_freq == pytest.approx(7.391425798)
 
         min_qpoint2, min_freq2 = self.bs2.min_freq()
         assert list(min_qpoint2.frac_coords) == [0, 0, 0]
-        assert min_freq2 == approx(-0.0072257889)
+        assert min_freq2 == pytest.approx(-0.0072257889)
 
         max_qpoint2, max_freq2 = self.bs2.max_freq()
         assert list(max_qpoint2.frac_coords) == [0, 0, 0]
-        assert max_freq2 == approx(15.2873634264)
+        assert max_freq2 == pytest.approx(15.2873634264)
 
     def test_get_gamma_point(self):
         for bs in (self.bs, self.bs2):
@@ -130,8 +130,8 @@ class TestPhononBandStructureSymmLine(PymatgenTest):
             assert g_point.label in ("Gamma", "$\\Gamma$")
 
     def test_width(self):
-        assert self.bs.width() == approx(7.3227137833)
-        assert self.bs2.width() == approx(14.7108925878)
+        assert self.bs.width() == pytest.approx(7.3227137833)
+        assert self.bs2.width() == pytest.approx(14.7108925878)
 
-        assert self.bs.width(with_imaginary=True) == approx(7.4284347482)
-        assert self.bs2.width(with_imaginary=True) == approx(15.2945892153)
+        assert self.bs.width(with_imaginary=True) == pytest.approx(7.4284347482)
+        assert self.bs2.width(with_imaginary=True) == pytest.approx(15.2945892153)

--- a/tests/phonon/test_dos.py
+++ b/tests/phonon/test_dos.py
@@ -5,7 +5,6 @@ import re
 
 import numpy as np
 import pytest
-from pytest import approx
 
 from pymatgen.core import Element
 from pymatgen.phonon.dos import CompletePhononDos, PhononDos
@@ -30,17 +29,17 @@ class TestPhononDos(PymatgenTest):
         )
 
     def test_properties(self):
-        assert self.dos.densities[15] == approx(0.0001665998)
-        assert self.dos.frequencies[20] == approx(0.0894965119)
-        assert self.dos.get_interpolated_value(3.0) == approx(1.2915532670115628)
+        assert self.dos.densities[15] == pytest.approx(0.0001665998)
+        assert self.dos.frequencies[20] == pytest.approx(0.0894965119)
+        assert self.dos.get_interpolated_value(3.0) == pytest.approx(1.2915532670115628)
         assert len(self.dos.frequencies) == 201
         assert len(self.dos.densities) == 201
 
     def test_get_smeared_densities(self):
         smeared = self.dos.get_smeared_densities(0.01)
-        assert smeared[20] == approx(0.00084171007635058825)
+        assert smeared[20] == pytest.approx(0.00084171007635058825)
         dens = self.dos.densities
-        assert sum(dens) == approx(sum(smeared))
+        assert sum(dens) == pytest.approx(sum(smeared))
 
         # test 0 smearing returns original DOS
         assert self.dos.get_smeared_densities(0) is self.dos.densities
@@ -51,37 +50,39 @@ class TestPhononDos(PymatgenTest):
         self.assert_msonable(self.dos)
 
     def test_thermodynamic_functions(self):
-        assert self.dos.cv(300, structure=self.structure) == approx(48.049366665412485, abs=1e-4)
-        assert self.dos.internal_energy(300, structure=self.structure) == approx(15527.596956593827, abs=1e-4)
-        assert self.dos.helmholtz_free_energy(300, structure=self.structure) == approx(-6998.034212172695, abs=1e-4)
-        assert self.dos.entropy(300, structure=self.structure) == approx(75.08543723748751, abs=1e-4)
-        assert self.dos.zero_point_energy(structure=self.structure) == approx(4847.462485708741, abs=1e-4)
+        assert self.dos.cv(300, structure=self.structure) == pytest.approx(48.049366665412485, abs=1e-4)
+        assert self.dos.internal_energy(300, structure=self.structure) == pytest.approx(15527.596956593827, abs=1e-4)
+        assert self.dos.helmholtz_free_energy(300, structure=self.structure) == pytest.approx(
+            -6998.034212172695, abs=1e-4
+        )
+        assert self.dos.entropy(300, structure=self.structure) == pytest.approx(75.08543723748751, abs=1e-4)
+        assert self.dos.zero_point_energy(structure=self.structure) == pytest.approx(4847.462485708741, abs=1e-4)
 
     def test_add(self):
         dos_2x = self.dos + self.dos
-        assert dos_2x.frequencies == approx(self.dos.frequencies)
-        assert dos_2x.densities == approx(2 * self.dos.densities)
+        assert dos_2x.frequencies == pytest.approx(self.dos.frequencies)
+        assert dos_2x.densities == pytest.approx(2 * self.dos.densities)
 
         dos_3x = self.dos + dos_2x
-        assert dos_3x.frequencies == approx(self.dos.frequencies)
-        assert dos_3x.densities == approx(3 * self.dos.densities)
+        assert dos_3x.frequencies == pytest.approx(self.dos.frequencies)
+        assert dos_3x.densities == pytest.approx(3 * self.dos.densities)
 
         # test commutativity
         assert dos_2x + 42 == 42 + dos_2x
 
     def test_sub(self):
         dos_0 = self.dos - self.dos
-        assert dos_0.frequencies == approx(self.dos.frequencies)
-        assert dos_0.densities == approx(self.dos.densities * 0)
+        assert dos_0.frequencies == pytest.approx(self.dos.frequencies)
+        assert dos_0.densities == pytest.approx(self.dos.densities * 0)
 
         dos_1 = self.dos - dos_0
-        assert dos_1.frequencies == approx(self.dos.frequencies)
-        assert dos_1.densities == approx(self.dos.densities)
+        assert dos_1.frequencies == pytest.approx(self.dos.frequencies)
+        assert dos_1.densities == pytest.approx(self.dos.densities)
 
     def test_mul(self):
         dos_2x = self.dos * 2
-        assert dos_2x.frequencies == approx(self.dos.frequencies)
-        assert dos_2x.densities == approx(2 * self.dos.densities)
+        assert dos_2x.frequencies == pytest.approx(self.dos.frequencies)
+        assert dos_2x.densities == pytest.approx(2 * self.dos.densities)
 
         # test commutativity
         assert dos_2x * 1.234 == 1.234 * dos_2x
@@ -120,12 +121,12 @@ class TestPhononDos(PymatgenTest):
 
     def test_get_last_peak(self):
         peak_freq = self.dos.get_last_peak()
-        assert peak_freq == approx(5.9909763191)
-        assert self.dos.get_interpolated_value(peak_freq) == approx(1.1700016497)
+        assert peak_freq == pytest.approx(5.9909763191)
+        assert self.dos.get_interpolated_value(peak_freq) == pytest.approx(1.1700016497)
 
         # try different threshold
         peak_freq = self.dos.get_last_peak(threshold=0.5)
-        assert peak_freq == approx(4.9662820761)
+        assert peak_freq == pytest.approx(4.9662820761)
 
     def test_get_dos_fp(self):
         # normalize=True
@@ -134,12 +135,12 @@ class TestPhononDos(PymatgenTest):
         assert max(dos_fp.frequencies[0]) <= 5
         assert min(dos_fp.frequencies[0]) >= -1
         assert len(dos_fp.frequencies[0]) == 56
-        assert sum(dos_fp.densities * bin_width) == approx(1)
+        assert sum(dos_fp.densities * bin_width) == pytest.approx(1)
         # normalize=False
         dos_fp2 = self.dos.get_dos_fp(min_f=-1, max_f=5, n_bins=56, normalize=False)
         bin_width2 = np.diff(dos_fp2.frequencies)[0][0]
-        assert sum(dos_fp2.densities * bin_width2) == approx(13.722295798242834)
-        assert dos_fp2.bin_width == approx(bin_width2)
+        assert sum(dos_fp2.densities * bin_width2) == pytest.approx(13.722295798242834)
+        assert dos_fp2.bin_width == pytest.approx(bin_width2)
         # binning=False
         dos_fp = self.dos.get_dos_fp(min_f=None, max_f=None, n_bins=56, normalize=True, binning=False)
         assert dos_fp.n_bins == len(self.dos.frequencies)
@@ -149,18 +150,18 @@ class TestPhononDos(PymatgenTest):
         dos_fp = self.dos.get_dos_fp(min_f=-1, max_f=6, n_bins=56, normalize=True)
         dos_fp2 = self.dos.get_dos_fp(min_f=-1, max_f=6, n_bins=56, normalize=False)
         similarity_index = self.dos.get_dos_fp_similarity(dos_fp, dos_fp2, col=1, metric="tanimoto")
-        assert similarity_index == approx(0.0553088193)
+        assert similarity_index == pytest.approx(0.0553088193)
 
         dos_fp = self.dos.get_dos_fp(min_f=-1, max_f=6, n_bins=56, normalize=True)
         dos_fp2 = self.dos.get_dos_fp(min_f=-1, max_f=6, n_bins=56, normalize=True)
         similarity_index = self.dos.get_dos_fp_similarity(dos_fp, dos_fp2, col=1, metric="tanimoto")
-        assert similarity_index == approx(1)
+        assert similarity_index == pytest.approx(1)
 
         # Wasserstein
         dos_fp = self.dos.get_dos_fp(min_f=-1, max_f=6, n_bins=56, normalize=True)
         dos_fp2 = self.dos.get_dos_fp(min_f=-1, max_f=6, n_bins=56, normalize=True)
         similarity_index = self.dos.get_dos_fp_similarity(dos_fp, dos_fp2, col=1, metric="wasserstein")
-        assert similarity_index == approx(0)
+        assert similarity_index == pytest.approx(0)
 
     def test_dos_fp_exceptions(self):
         dos_fp = self.dos.get_dos_fp(min_f=-1, max_f=5, n_bins=56, normalize=True)
@@ -188,16 +189,16 @@ class TestCompletePhononDos(PymatgenTest):
         site_Cl = self.cdos.structure[1]
 
         assert len(self.cdos.frequencies) == 201
-        assert self.cdos.pdos[site_Na][30] == approx(0.008058208)
-        assert self.cdos.get_site_dos(site_Na).densities[30] == approx(0.008058208)
-        assert self.cdos.pdos[site_Cl][30] == approx(0.0119040783)
+        assert self.cdos.pdos[site_Na][30] == pytest.approx(0.008058208)
+        assert self.cdos.get_site_dos(site_Na).densities[30] == pytest.approx(0.008058208)
+        assert self.cdos.pdos[site_Cl][30] == pytest.approx(0.0119040783)
 
         assert Element.Na in self.cdos.get_element_dos()
         assert Element.Cl in self.cdos.get_element_dos()
 
         sum_dos = self.cdos.get_element_dos()[Element.Na] + self.cdos.get_element_dos()[Element.Cl]
-        assert sum_dos.frequencies == approx(self.cdos.frequencies)
-        assert sum_dos.densities == approx(self.cdos.densities)
+        assert sum_dos.frequencies == pytest.approx(self.cdos.frequencies)
+        assert sum_dos.densities == pytest.approx(self.cdos.densities)
 
     def test_dict_methods(self):
         json_str = json.dumps(self.cdos.as_dict())

--- a/tests/phonon/test_gruneisen.py
+++ b/tests/phonon/test_gruneisen.py
@@ -4,7 +4,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 from matplotlib import colors
-from pytest import approx
 
 from pymatgen.io.phonopy import get_gruneisen_ph_bs_symm_line, get_gruneisenparameter
 from pymatgen.phonon.gruneisen import GruneisenParameter
@@ -101,7 +100,7 @@ class TestGruneisenParameter(PymatgenTest):
         self.gruneisen_obj2 = GruneisenParameter.from_dict(new_dict)
 
     def test_frequencies(self):
-        assert self.gruneisen_obj_small.frequencies == approx(
+        assert self.gruneisen_obj_small.frequencies == pytest.approx(
             [0.12642146, 0.12642146, 0.25272004, 8.85202452, 8.85202452, 9.66016595]
         )
 
@@ -110,33 +109,33 @@ class TestGruneisenParameter(PymatgenTest):
         assert self.gruneisen_obj.multiplicities[0] == 2
 
     def test_gruneisen(self):
-        assert self.gruneisen_obj_small.gruneisen[0] == approx(-0.6176464482)
-        assert self.gruneisen_obj_small.gruneisen[5] == approx(1.7574050911)
+        assert self.gruneisen_obj_small.gruneisen[0] == pytest.approx(-0.6176464482)
+        assert self.gruneisen_obj_small.gruneisen[5] == pytest.approx(1.7574050911)
 
     def test_tdos(self):
         tdos = self.gruneisen_obj.tdos
         assert isinstance(tdos, phonopy.phonon.dos.TotalDos)
 
     def test_phdos(self):
-        assert self.gruneisen_obj.phdos.cv(298.15) == approx(45.17772584681599)
+        assert self.gruneisen_obj.phdos.cv(298.15) == pytest.approx(45.17772584681599)
 
     def test_average_gruneisen(self):
-        assert self.gruneisen_obj.average_gruneisen() == approx(1.164231026696211)
-        assert self.gruneisen_obj.average_gruneisen(squared=False) == approx(0.849759667411049)
-        assert self.gruneisen_obj.average_gruneisen(limit_frequencies="debye") == approx(0.848865124114612)
-        assert self.gruneisen_obj.average_gruneisen(limit_frequencies="acoustic") == approx(1.283180896570312)
-        assert self.gruneisen_obj_Si.average_gruneisen() == approx(1.1090815951892143)
+        assert self.gruneisen_obj.average_gruneisen() == pytest.approx(1.164231026696211)
+        assert self.gruneisen_obj.average_gruneisen(squared=False) == pytest.approx(0.849759667411049)
+        assert self.gruneisen_obj.average_gruneisen(limit_frequencies="debye") == pytest.approx(0.848865124114612)
+        assert self.gruneisen_obj.average_gruneisen(limit_frequencies="acoustic") == pytest.approx(1.283180896570312)
+        assert self.gruneisen_obj_Si.average_gruneisen() == pytest.approx(1.1090815951892143)
 
     def test_thermal_conductivity_slack(self):
-        assert self.gruneisen_obj.thermal_conductivity_slack() == approx(77.97582174520458)
-        assert self.gruneisen_obj.thermal_conductivity_slack(t=300) == approx(88.94562145031158)
-        assert self.gruneisen_obj_Si.thermal_conductivity_slack(t=300) == approx(127.69008331982265)
+        assert self.gruneisen_obj.thermal_conductivity_slack() == pytest.approx(77.97582174520458)
+        assert self.gruneisen_obj.thermal_conductivity_slack(t=300) == pytest.approx(88.94562145031158)
+        assert self.gruneisen_obj_Si.thermal_conductivity_slack(t=300) == pytest.approx(127.69008331982265)
 
     def test_debye_temp_phonopy(self):
         # This is the correct conversion when starting from THz in the debye_freq
-        assert self.gruneisen_obj_small.debye_temp_phonopy() == approx(473.31932718764284)
+        assert self.gruneisen_obj_small.debye_temp_phonopy() == pytest.approx(473.31932718764284)
 
     def test_acoustic_debye_temp(self):
-        assert self.gruneisen_obj_small.acoustic_debye_temp == approx(317.54811309631845)
-        assert self.gruneisen_obj.acoustic_debye_temp == approx(342.2046198151735)
-        assert self.gruneisen_obj_Si.acoustic_debye_temp == approx(526.0725636300882)
+        assert self.gruneisen_obj_small.acoustic_debye_temp == pytest.approx(317.54811309631845)
+        assert self.gruneisen_obj.acoustic_debye_temp == pytest.approx(342.2046198151735)
+        assert self.gruneisen_obj_Si.acoustic_debye_temp == pytest.approx(526.0725636300882)

--- a/tests/phonon/test_thermal_displacements.py
+++ b/tests/phonon/test_thermal_displacements.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 from numpy.testing import assert_allclose
-from pytest import approx
 
 from pymatgen.core.structure import Structure
 from pymatgen.phonon.thermal_displacements import ThermalDisplacementMatrices
@@ -98,7 +98,7 @@ class TestThermalDisplacement(PymatgenTest):
         )
 
     def test_ucart(self):
-        assert self.thermal.thermal_displacement_matrix_cart[0][0] == approx(0.00516)
+        assert self.thermal.thermal_displacement_matrix_cart[0][0] == pytest.approx(0.00516)
         # U11, U22, U33, U23, U13, U12
         assert_allclose(
             self.thermal.thermal_displacement_matrix_cart_matrixform[0],
@@ -112,7 +112,9 @@ class TestThermalDisplacement(PymatgenTest):
         )
 
     def test_u1_u2_u3(self):
-        assert self.thermal.U1U2U3[0].sort() == approx(np.array([2.893872e-03, 5.691239e-03, 6.854889e-03]).sort())
+        assert self.thermal.U1U2U3[0].sort() == pytest.approx(
+            np.array([2.893872e-03, 5.691239e-03, 6.854889e-03]).sort()
+        )
 
     def test_ustar(self):
         Ustar = self.thermal.Ustar
@@ -268,18 +270,18 @@ class TestThermalDisplacement(PymatgenTest):
             structure=Structure.from_file(f"{TEST_DIR}/POSCAR"),
             temperature=0.0,
         )
-        assert self.thermal.compute_directionality_quality_criterion(self.thermal)[0]["angle"] == approx(0.0)
+        assert self.thermal.compute_directionality_quality_criterion(self.thermal)[0]["angle"] == pytest.approx(0.0)
         assert_allclose(
             self.thermal.compute_directionality_quality_criterion(thermal)[0]["vector0"],
             self.thermal.compute_directionality_quality_criterion(thermal)[1]["vector1"],
         )
 
     def test_angle(self):
-        assert self.thermal._angle_dot([-1, -1, -1], [1, 1, 1]) == approx(180.0)
-        assert self.thermal._angle_dot([1, 1, 1], [1, 1, 1]) == approx(0.0)
+        assert self.thermal._angle_dot([-1, -1, -1], [1, 1, 1]) == pytest.approx(180.0)
+        assert self.thermal._angle_dot([1, 1, 1], [1, 1, 1]) == pytest.approx(0.0)
 
     def test_ratio_prolate(self):
-        assert self.thermal.ratio_prolate[0] == approx(6.854889e-03 / 2.893872e-03)
+        assert self.thermal.ratio_prolate[0] == pytest.approx(6.854889e-03 / 2.893872e-03)
 
     def test_to_structure_with_site_properties(self):
         # test creation of structure with site properties

--- a/tests/symmetry/test_analyzer.py
+++ b/tests/symmetry/test_analyzer.py
@@ -6,7 +6,6 @@ from unittest import TestCase
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
-from pytest import approx, raises
 from spglib import SpglibDataset
 
 from pymatgen.core import Lattice, Molecule, PeriodicSite, Site, Species, Structure
@@ -231,10 +230,10 @@ class TestSpacegroupAnalyzer(PymatgenTest):
         assert primitive_structure.formula == "Li2 O1"
         assert primitive_structure.site_properties.get("magmom") is None
         # This isn't what is expected. All the angles should be 60
-        assert primitive_structure.lattice.alpha == approx(60)
-        assert primitive_structure.lattice.beta == approx(60)
-        assert primitive_structure.lattice.gamma == approx(60)
-        assert primitive_structure.volume == approx(structure.volume / 4.0)
+        assert primitive_structure.lattice.alpha == pytest.approx(60)
+        assert primitive_structure.lattice.beta == pytest.approx(60)
+        assert primitive_structure.lattice.gamma == pytest.approx(60)
+        assert primitive_structure.volume == pytest.approx(structure.volume / 4.0)
 
         structure.add_site_property("magmom", [1.0] * len(structure))
         spga = SpacegroupAnalyzer(structure)
@@ -249,10 +248,10 @@ class TestSpacegroupAnalyzer(PymatgenTest):
     def test_get_ir_reciprocal_mesh(self):
         grid = self.sg.get_ir_reciprocal_mesh()
         assert len(grid) == 216
-        assert grid[1][0][0] == approx(0.1)
-        assert grid[1][0][1] == approx(0.0)
-        assert grid[1][0][2] == approx(0.0)
-        assert grid[1][1] == approx(2)
+        assert grid[1][0][0] == pytest.approx(0.1)
+        assert grid[1][0][1] == pytest.approx(0.0)
+        assert grid[1][0][2] == pytest.approx(0.0)
+        assert grid[1][1] == pytest.approx(2)
 
     def test_get_ir_reciprocal_mesh_map(self):
         mesh = (6, 6, 6)
@@ -260,69 +259,71 @@ class TestSpacegroupAnalyzer(PymatgenTest):
         full_grid, mapping = self.sg.get_ir_reciprocal_mesh_map(mesh=mesh)
         assert len(np.unique(mapping)) == len(grid)
         for _, idx in enumerate(np.unique(mapping)):
-            assert full_grid[idx][0] == approx(grid[_][0][0])
-            assert full_grid[idx][1] == approx(grid[_][0][1])
-            assert full_grid[idx][2] == approx(grid[_][0][2])
+            assert full_grid[idx][0] == pytest.approx(grid[_][0][0])
+            assert full_grid[idx][1] == pytest.approx(grid[_][0][1])
+            assert full_grid[idx][2] == pytest.approx(grid[_][0][2])
 
     def test_get_conventional_standard_structure(self):
         structure = Structure.from_file(f"{TEST_FILES_DIR}/cif/bcc_1927.cif")
         spga = SpacegroupAnalyzer(structure, symprec=1e-2)
         conventional = spga.get_conventional_standard_structure()
         assert conventional.lattice.angles == (90, 90, 90)
-        assert conventional.lattice.lengths == approx([9.1980270633769461] * 3)
+        assert conventional.lattice.lengths == pytest.approx([9.1980270633769461] * 3)
 
         structure = Structure.from_file(f"{TEST_FILES_DIR}/cif/btet_1915.cif")
         spga = SpacegroupAnalyzer(structure, symprec=1e-2)
         conventional = spga.get_conventional_standard_structure()
         assert conventional.lattice.angles == (90, 90, 90)
-        assert conventional.lattice.a == approx(5.0615106678044235)
-        assert conventional.lattice.b == approx(5.0615106678044235)
-        assert conventional.lattice.c == approx(4.2327080177761687)
+        assert conventional.lattice.a == pytest.approx(5.0615106678044235)
+        assert conventional.lattice.b == pytest.approx(5.0615106678044235)
+        assert conventional.lattice.c == pytest.approx(4.2327080177761687)
 
         structure = Structure.from_file(f"{TEST_FILES_DIR}/cif/orci_1010.cif")
         spga = SpacegroupAnalyzer(structure, symprec=1e-2)
         conventional = spga.get_conventional_standard_structure()
         assert conventional.lattice.angles == (90, 90, 90)
-        assert conventional.lattice.a == approx(2.9542233922299999)
-        assert conventional.lattice.b == approx(4.6330325651443296)
-        assert conventional.lattice.c == approx(5.373703587040775)
+        assert conventional.lattice.a == pytest.approx(2.9542233922299999)
+        assert conventional.lattice.b == pytest.approx(4.6330325651443296)
+        assert conventional.lattice.c == pytest.approx(5.373703587040775)
 
         structure = Structure.from_file(f"{TEST_FILES_DIR}/cif/orcc_1003.cif")
         spga = SpacegroupAnalyzer(structure, symprec=1e-2)
         conventional = spga.get_conventional_standard_structure()
         assert conventional.lattice.angles == (90, 90, 90)
-        assert conventional.lattice.a == approx(4.1430033493799998)
-        assert conventional.lattice.b == approx(31.437979757624728)
-        assert conventional.lattice.c == approx(3.99648651)
+        assert conventional.lattice.a == pytest.approx(4.1430033493799998)
+        assert conventional.lattice.b == pytest.approx(31.437979757624728)
+        assert conventional.lattice.c == pytest.approx(3.99648651)
 
         structure = Structure.from_file(f"{TEST_FILES_DIR}/cif/orac_632475.cif")
         spga = SpacegroupAnalyzer(structure, symprec=1e-2)
         conventional = spga.get_conventional_standard_structure()
         assert conventional.lattice.angles == (90, 90, 90)
-        assert conventional.lattice.lengths == approx([3.1790663399999999, 9.9032878699999998, 3.5372412099999999])
+        assert conventional.lattice.lengths == pytest.approx(
+            [3.1790663399999999, 9.9032878699999998, 3.5372412099999999]
+        )
 
         structure = Structure.from_file(f"{TEST_FILES_DIR}/cif/monoc_1028.cif")
         spga = SpacegroupAnalyzer(structure, symprec=1e-2)
         conventional = spga.get_conventional_standard_structure()
-        assert conventional.lattice.angles == approx([90, 117.53832420192903, 90])
-        assert conventional.lattice.lengths == approx([14.033435583000625, 3.96052850731, 6.8743926325200002])
+        assert conventional.lattice.angles == pytest.approx([90, 117.53832420192903, 90])
+        assert conventional.lattice.lengths == pytest.approx([14.033435583000625, 3.96052850731, 6.8743926325200002])
         structure = Structure.from_file(f"{TEST_FILES_DIR}/cif/hex_1170.cif")
         spga = SpacegroupAnalyzer(structure, symprec=1e-2)
         conventional = spga.get_conventional_standard_structure()
-        assert conventional.lattice.angles == approx([90, 90, 120])
-        assert conventional.lattice.lengths == approx([3.699919902005897, 3.699919902005897, 6.9779585500000003])
+        assert conventional.lattice.angles == pytest.approx([90, 90, 120])
+        assert conventional.lattice.lengths == pytest.approx([3.699919902005897, 3.699919902005897, 6.9779585500000003])
 
         STRUCTURE = f"{TEST_FILES_DIR}/symmetry/analyzer/tric_684654.json"
 
         structure = Structure.from_file(STRUCTURE)
         spga = SpacegroupAnalyzer(structure, symprec=1e-2)
         conventional = spga.get_conventional_standard_structure()
-        assert conventional.lattice.alpha == approx(74.09581916308757)
-        assert conventional.lattice.beta == approx(75.72817279281173)
-        assert conventional.lattice.gamma == approx(63.63234318667333)
-        assert conventional.lattice.a == approx(3.741372924048738)
-        assert conventional.lattice.b == approx(3.9883228679270686)
-        assert conventional.lattice.c == approx(7.288495840048958)
+        assert conventional.lattice.alpha == pytest.approx(74.09581916308757)
+        assert conventional.lattice.beta == pytest.approx(75.72817279281173)
+        assert conventional.lattice.gamma == pytest.approx(63.63234318667333)
+        assert conventional.lattice.a == pytest.approx(3.741372924048738)
+        assert conventional.lattice.b == pytest.approx(3.9883228679270686)
+        assert conventional.lattice.c == pytest.approx(7.288495840048958)
 
         structure = Structure.from_file(STRUCTURE)
         structure.add_site_property("magmom", [1.0] * len(structure))
@@ -350,8 +351,8 @@ class TestSpacegroupAnalyzer(PymatgenTest):
             structure = Structure.from_file(f"{TEST_FILES_DIR}/cif/{file_name}")
             spga = SpacegroupAnalyzer(structure, symprec=1e-2)
             prim = spga.get_primitive_standard_structure()
-            assert prim.lattice.angles == approx(expected_angles)
-            assert prim.lattice.abc == approx(expected_abc)
+            assert prim.lattice.angles == pytest.approx(expected_angles)
+            assert prim.lattice.abc == pytest.approx(expected_abc)
 
         structure = Structure.from_file(f"{TEST_FILES_DIR}/cif/rhomb_3478_conv.cif")
         structure.add_site_property("magmom", [1.0] * len(structure))
@@ -378,7 +379,7 @@ class TestSpacegroupAnalyzer(PymatgenTest):
 
     def test_bad_structure(self):
         struct = Structure(Lattice.cubic(5), ["H", "H"], [[0.0, 0.0, 0.0], [0.001, 0.0, 0.0]])
-        with raises(SymmetryUndetermined):
+        with pytest.raises(SymmetryUndetermined):
             SpacegroupAnalyzer(struct, 0.1)
 
 
@@ -611,7 +612,7 @@ class TestPointGroupAnalyzer(PymatgenTest):
             weights = [i[1] for i in ir_mesh]
             weights = np.array(weights) / sum(weights)
             for expected, weight in zip(weights, spga.get_kpoint_weights([i[0] for i in ir_mesh]), strict=True):
-                assert weight == approx(expected)
+                assert weight == pytest.approx(expected)
 
         for name in ("SrTiO3", "LiFePO4", "Graphite"):
             struct = PymatgenTest.get_structure(name)
@@ -620,14 +621,14 @@ class TestPointGroupAnalyzer(PymatgenTest):
             weights = [i[1] for i in ir_mesh]
             weights = np.array(weights) / sum(weights)
             for expected, weight in zip(weights, spga.get_kpoint_weights([i[0] for i in ir_mesh]), strict=True):
-                assert weight == approx(expected)
+                assert weight == pytest.approx(expected)
 
         vasp_run = Vasprun(f"{VASP_OUT_DIR}/vasprun.xml.gz")
         spga = SpacegroupAnalyzer(vasp_run.final_structure)
         wts = spga.get_kpoint_weights(vasp_run.actual_kpoints)
 
         for w1, w2 in zip(vasp_run.actual_kpoints_weights, wts, strict=True):
-            assert w1 == approx(w2)
+            assert w1 == pytest.approx(w2)
 
         kpts = [[0, 0, 0], [0.15, 0.15, 0.15], [0.2, 0.2, 0.2]]
         with pytest.raises(

--- a/tests/symmetry/test_groups.py
+++ b/tests/symmetry/test_groups.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
-from pytest import approx
 
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.operations import SymmOp
@@ -130,9 +129,9 @@ class TestSpaceGroup:
         orbit, generators = sg.get_orbit_and_generators(rand_percent)
         assert len(orbit) <= sg.order
         pp = generators[0].operate(orbit[0])
-        assert rand_percent[0] == approx(pp[0])
-        assert rand_percent[1] == approx(pp[1])
-        assert rand_percent[2] == approx(pp[2])
+        assert rand_percent[0] == pytest.approx(pp[0])
+        assert rand_percent[1] == pytest.approx(pp[1])
+        assert rand_percent[2] == pytest.approx(pp[2])
 
     def test_is_compatible(self):
         cubic = Lattice.cubic(1)

--- a/tests/symmetry/test_kpath_hin.py
+++ b/tests/symmetry/test_kpath_hin.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import pytest
-from pytest import approx
 
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Structure
@@ -63,32 +62,32 @@ class TestKPathSeek(PymatgenTest):
             ["B_0", "B_2", "DELTA_0", "F_0", "GAMMA", "G_0", "G_2", "R", "R_2", "S", "T", "T_2", "Y", "Z", "Z_2"]
         )
 
-        assert kpoints["GAMMA"] == approx([0.0, 0.0, 0.0])
+        assert kpoints["GAMMA"] == pytest.approx([0.0, 0.0, 0.0])
 
-        assert kpoints["Y"] == approx([0.5, 0.5, 0.0])
+        assert kpoints["Y"] == pytest.approx([0.5, 0.5, 0.0])
 
-        assert kpoints["T"] == approx([0.5, 0.5, 0.5])
+        assert kpoints["T"] == pytest.approx([0.5, 0.5, 0.5])
 
-        assert kpoints["T_2"] == approx([0.5, 0.5, -0.5])
+        assert kpoints["T_2"] == pytest.approx([0.5, 0.5, -0.5])
 
-        assert kpoints["Z"] == approx([0.0, 0.0, 0.5])
+        assert kpoints["Z"] == pytest.approx([0.0, 0.0, 0.5])
 
-        assert kpoints["Z_2"] == approx([0.0, 0.0, -0.5])
+        assert kpoints["Z_2"] == pytest.approx([0.0, 0.0, -0.5])
 
-        assert kpoints["S"] == approx([0.0, 0.5, 0.0])
+        assert kpoints["S"] == pytest.approx([0.0, 0.5, 0.0])
 
-        assert kpoints["R"] == approx([0.0, 0.5, 0.5])
+        assert kpoints["R"] == pytest.approx([0.0, 0.5, 0.5])
 
-        assert kpoints["R_2"] == approx([0.0, 0.5, -0.5])
+        assert kpoints["R_2"] == pytest.approx([0.0, 0.5, -0.5])
 
-        assert kpoints["DELTA_0"] == approx([-0.25308641975308643, 0.25308641975308643, 0.0])
+        assert kpoints["DELTA_0"] == pytest.approx([-0.25308641975308643, 0.25308641975308643, 0.0])
 
-        assert kpoints["F_0"] == approx([0.25308641975308643, 0.7469135802469136, 0.0])
+        assert kpoints["F_0"] == pytest.approx([0.25308641975308643, 0.7469135802469136, 0.0])
 
-        assert kpoints["B_0"] == approx([-0.25308641975308643, 0.25308641975308643, 0.5])
+        assert kpoints["B_0"] == pytest.approx([-0.25308641975308643, 0.25308641975308643, 0.5])
 
-        assert kpoints["B_2"] == approx([-0.25308641975308643, 0.25308641975308643, -0.5])
+        assert kpoints["B_2"] == pytest.approx([-0.25308641975308643, 0.25308641975308643, -0.5])
 
-        assert kpoints["G_0"] == approx([0.25308641975308643, 0.7469135802469136, 0.5])
+        assert kpoints["G_0"] == pytest.approx([0.25308641975308643, 0.7469135802469136, 0.5])
 
-        assert kpoints["G_2"] == approx([0.25308641975308643, 0.7469135802469136, -0.5])
+        assert kpoints["G_2"] == pytest.approx([0.25308641975308643, 0.7469135802469136, -0.5])

--- a/tests/symmetry/test_kpath_lm.py
+++ b/tests/symmetry/test_kpath_lm.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import numpy as np
-from pytest import approx
+import pytest
 
 from pymatgen.analysis.magnetism.analyzer import CollinearMagneticStructureAnalyzer
 from pymatgen.core.lattice import Lattice
@@ -62,25 +62,25 @@ class TestKPathLatimerMunro(PymatgenTest):
 
         assert sorted(labels) == sorted(["a", "b", "c", "d", "d_{1}", "e", "f", "q", "q_{1}", "Γ"])
 
-        assert kpoints["a"] == approx([0.0, 0.5, 0.0])
+        assert kpoints["a"] == pytest.approx([0.0, 0.5, 0.0])
 
-        assert kpoints["f"] == approx([-0.5, 0.5, 0.5])
+        assert kpoints["f"] == pytest.approx([-0.5, 0.5, 0.5])
 
-        assert kpoints["c"] == approx([0.0, 0.0, 0.5])
+        assert kpoints["c"] == pytest.approx([0.0, 0.0, 0.5])
 
-        assert kpoints["b"] == approx([-0.5, 0.5, 0.0])
+        assert kpoints["b"] == pytest.approx([-0.5, 0.5, 0.0])
 
-        assert kpoints["Γ"] == approx([0, 0, 0])
+        assert kpoints["Γ"] == pytest.approx([0, 0, 0])
 
-        assert kpoints["e"] == approx([0.0, 0.5, 0.5])
+        assert kpoints["e"] == pytest.approx([0.0, 0.5, 0.5])
 
-        assert kpoints["d_{1}"] == approx([0.2530864197530836, 0.25308641975308915, 0.0]) or kpoints["d"] == approx(
-            [0.2530864197530836, 0.25308641975308915, 0.0]
-        )
+        assert kpoints["d_{1}"] == pytest.approx([0.2530864197530836, 0.25308641975308915, 0.0]) or kpoints[
+            "d"
+        ] == pytest.approx([0.2530864197530836, 0.25308641975308915, 0.0])
 
-        assert kpoints["q_{1}"] == approx([0.2530864197530836, 0.25308641975308915, 0.5]) or kpoints["q"] == approx(
-            [0.2530864197530836, 0.25308641975308915, 0.5]
-        )
+        assert kpoints["q_{1}"] == pytest.approx([0.2530864197530836, 0.25308641975308915, 0.5]) or kpoints[
+            "q"
+        ] == pytest.approx([0.2530864197530836, 0.25308641975308915, 0.5])
 
     def test_magnetic_kpath_generation(self):
         struct_file_path = f"{TEST_FILES_DIR}/io/cif/mcif/LaMnO3_magnetic.mcif"
@@ -105,20 +105,20 @@ class TestKPathLatimerMunro(PymatgenTest):
         kpoints = kpath._kpath["kpoints"]
         assert sorted(kpoints) == sorted(["a", "b", "c", "d", "d_{1}", "e", "f", "g", "g_{1}", "Γ"])
 
-        assert kpoints["e"] == approx([-0.5, 0.0, 0.5])
+        assert kpoints["e"] == pytest.approx([-0.5, 0.0, 0.5])
 
-        assert kpoints["g"] == approx([-0.5, -0.5, 0.5])
+        assert kpoints["g"] == pytest.approx([-0.5, -0.5, 0.5])
 
-        assert kpoints["a"] == approx([-0.5, 0.0, 0.0])
+        assert kpoints["a"] == pytest.approx([-0.5, 0.0, 0.0])
 
-        assert kpoints["g_{1}"] == approx([0.5, -0.5, 0.5])
+        assert kpoints["g_{1}"] == pytest.approx([0.5, -0.5, 0.5])
 
-        assert kpoints["f"] == approx([0.0, -0.5, 0.5])
+        assert kpoints["f"] == pytest.approx([0.0, -0.5, 0.5])
 
-        assert kpoints["c"] == approx([0.0, 0.0, 0.5])
+        assert kpoints["c"] == pytest.approx([0.0, 0.0, 0.5])
 
-        assert kpoints["b"] == approx([0.0, -0.5, 0.0])
+        assert kpoints["b"] == pytest.approx([0.0, -0.5, 0.0])
 
-        assert kpoints["Γ"] == approx([0, 0, 0])
+        assert kpoints["Γ"] == pytest.approx([0, 0, 0])
 
-        assert kpoints["d_{1}"] == approx([-0.5, -0.5, 0.0]) or kpoints["d"] == approx([-0.5, -0.5, 0.0])
+        assert kpoints["d_{1}"] == pytest.approx([-0.5, -0.5, 0.0]) or kpoints["d"] == pytest.approx([-0.5, -0.5, 0.0])

--- a/tests/symmetry/test_kpath_sc.py
+++ b/tests/symmetry/test_kpath_sc.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import numpy as np
-from pytest import approx
+import pytest
 
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Structure
@@ -62,20 +62,20 @@ class TestBandStructureSC(PymatgenTest):
 
         assert list(kpoints["\\Gamma"]) == [0, 0, 0]
 
-        assert kpoints["A"] == approx([0.25308642, 0.25308642, 0.5])
+        assert kpoints["A"] == pytest.approx([0.25308642, 0.25308642, 0.5])
 
-        assert kpoints["A_1"] == approx([-0.25308642, 0.74691358, 0.5])
+        assert kpoints["A_1"] == pytest.approx([-0.25308642, 0.74691358, 0.5])
 
-        assert kpoints["R"] == approx([0, 0.5, 0.5])
+        assert kpoints["R"] == pytest.approx([0, 0.5, 0.5])
 
-        assert kpoints["S"] == approx([0, 0.5, 0])
+        assert kpoints["S"] == pytest.approx([0, 0.5, 0])
 
-        assert kpoints["T"] == approx([-0.5, 0.5, 0.5])
+        assert kpoints["T"] == pytest.approx([-0.5, 0.5, 0.5])
 
-        assert kpoints["X"] == approx([0.25308642, 0.25308642, 0])
+        assert kpoints["X"] == pytest.approx([0.25308642, 0.25308642, 0])
 
-        assert kpoints["X_1"] == approx([-0.25308642, 0.74691358, 0])
+        assert kpoints["X_1"] == pytest.approx([-0.25308642, 0.74691358, 0])
 
-        assert kpoints["Y"] == approx([-0.5, 0.5, 0])
+        assert kpoints["Y"] == pytest.approx([-0.5, 0.5, 0])
 
-        assert kpoints["Z"] == approx([0, 0, 0.5])
+        assert kpoints["Z"] == pytest.approx([0, 0, 0.5])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,11 +11,9 @@ from pymatgen.util.testing import TEST_FILES_DIR, VASP_IN_DIR
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from pytest import MonkeyPatch
-
 
 @pytest.fixture
-def cd_tmp_path(tmp_path: Path, monkeypatch: MonkeyPatch):
+def cd_tmp_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.chdir(tmp_path)
     return tmp_path
 

--- a/tests/transformations/test_advanced_transformations.py
+++ b/tests/transformations/test_advanced_transformations.py
@@ -7,7 +7,6 @@ import numpy as np
 import pytest
 from monty.serialization import loadfn
 from numpy.testing import assert_allclose, assert_array_equal
-from pytest import approx
 
 from pymatgen.analysis.energy_models import IsingModel, SymmetryModel
 from pymatgen.analysis.gb.grain import GrainBoundaryGenerator
@@ -152,7 +151,7 @@ class TestChargeBalanceTransformation:
         struct = Structure(lattice, ["Li+", "Li+", "Li+", "Li+", "Li+", "Li+", "O2-", "O2-"], coords)
         struct_trafo = trafo.apply_transformation(struct)
 
-        assert struct_trafo.charge == approx(0, abs=1e-5)
+        assert struct_trafo.charge == pytest.approx(0, abs=1e-5)
 
 
 @pytest.mark.skipif(not enumlib_present, reason="enum_lib not present.")

--- a/tests/transformations/test_standard_transformations.py
+++ b/tests/transformations/test_standard_transformations.py
@@ -9,7 +9,6 @@ from unittest import TestCase
 import numpy as np
 import pytest
 from monty.json import MontyDecoder
-from pytest import approx
 
 from pymatgen.core import Element, PeriodicSite
 from pymatgen.core.lattice import Lattice
@@ -240,7 +239,9 @@ class TestPartialRemoveSpecieTransformation:
         fast_opt_s = trafo.apply_transformation(struct)
         trafo = PartialRemoveSpecieTransformation("Li+", 0.5, PartialRemoveSpecieTransformation.ALGO_COMPLETE)
         slow_opt_s = trafo.apply_transformation(struct)
-        assert EwaldSummation(fast_opt_s).total_energy == approx(EwaldSummation(slow_opt_s).total_energy, abs=1e-4)
+        assert EwaldSummation(fast_opt_s).total_energy == pytest.approx(
+            EwaldSummation(slow_opt_s).total_energy, abs=1e-4
+        )
         assert fast_opt_s == slow_opt_s
 
     def test_apply_transformations_complete_ranking(self):
@@ -355,7 +356,7 @@ class TestOrderDisorderedStructureTransformation:
             coords,
         )
         output = trafo.apply_transformation(struct, return_ranked_list=3)
-        assert output[0]["energy"] == approx(-234.57813667648315, abs=1e-4)
+        assert output[0]["energy"] == pytest.approx(-234.57813667648315, abs=1e-4)
 
 
 class TestPrimitiveCellTransformation:
@@ -426,7 +427,7 @@ class TestPerturbStructureTransformation:
         struct = Structure(lattice, ["Li+", "Li+", "Li+", "Li+", "O2-", "O2-", "O2-", "O2-"], coords)
         transformed_struct = trafo.apply_transformation(struct)
         for idx, site in enumerate(transformed_struct):
-            assert site.distance(struct[idx]) == approx(0.05)
+            assert site.distance(struct[idx]) == pytest.approx(0.05)
 
         dct = trafo.as_dict()
         assert isinstance(PerturbStructureTransformation.from_dict(dct), PerturbStructureTransformation)
@@ -462,9 +463,9 @@ class TestDeformStructureTransformation:
         ]
         struct = Structure(lattice, ["Li+", "Li+", "Li+", "Li+", "O2-", "O2-", "O2-", "O2-"], coords)
         transformed_s = trafo.apply_transformation(struct)
-        assert transformed_s.lattice.a == approx(3.84019793)
-        assert transformed_s.lattice.b == approx(3.84379750)
-        assert transformed_s.lattice.c == approx(3.75022981)
+        assert transformed_s.lattice.a == pytest.approx(3.84019793)
+        assert transformed_s.lattice.b == pytest.approx(3.84379750)
+        assert transformed_s.lattice.c == pytest.approx(3.75022981)
 
         dct = json.loads(json.dumps(trafo.as_dict()))
         assert isinstance(DeformStructureTransformation.from_dict(dct), DeformStructureTransformation)
@@ -527,7 +528,7 @@ class TestScaleToRelaxedTransformation:
         slab_scaling = ScaleToRelaxedTransformation(Cu_init, Cu_fin)
         Au_init = Structure.from_file(f"{surf_dir}/Au_slab_init.cif")
         Au_fin = slab_scaling.apply_transformation(Au_init)
-        assert Au_fin.volume == approx(Au_init.volume)
+        assert Au_fin.volume == pytest.approx(Au_init.volume)
 
         # Test on gb relaxation
         gb_dir = f"{TEST_FILES_DIR}/core/grain_boundary"

--- a/tests/util/test_coord.py
+++ b/tests/util/test_coord.py
@@ -5,7 +5,6 @@ from unittest import TestCase
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_array_equal
-from pytest import approx
 
 from pymatgen.core.lattice import Lattice
 from pymatgen.util import coord
@@ -155,13 +154,13 @@ class TestCoordUtils:
     def test_lattice_points_in_supercell(self):
         supercell = np.array([[1, 3, 5], [-3, 2, 3], [-5, 3, 1]])
         points = coord.lattice_points_in_supercell(supercell)
-        assert len(points) == approx(abs(np.linalg.det(supercell)))
+        assert len(points) == pytest.approx(abs(np.linalg.det(supercell)))
         assert np.min(points) >= -1e-10
         assert np.max(points) <= 1 - 1e-10
 
         supercell = np.array([[-5, -5, -3], [0, -4, -2], [0, -5, -2]])
         points = coord.lattice_points_in_supercell(supercell)
-        assert len(points) == approx(abs(np.linalg.det(supercell)))
+        assert len(points) == pytest.approx(abs(np.linalg.det(supercell)))
         assert np.min(points) >= -1e-10
         assert np.max(points) <= 1 - 1e-10
 
@@ -231,8 +230,8 @@ class TestCoordUtils:
     def test_get_angle(self):
         v1 = (1, 0, 0)
         v2 = (1, 1, 1)
-        assert coord.get_angle(v1, v2) == approx(54.7356103172)
-        assert coord.get_angle(v1, v2, units="radians") == approx(0.9553166181245092)
+        assert coord.get_angle(v1, v2) == pytest.approx(54.7356103172)
+        assert coord.get_angle(v1, v2, units="radians") == pytest.approx(0.9553166181245092)
 
 
 class TestSimplex(TestCase):
@@ -266,7 +265,7 @@ class TestSimplex(TestCase):
 
     def test_volume(self):
         # Should be value of a right tetrahedron.
-        assert self.simplex.volume == approx(1 / 6)
+        assert self.simplex.volume == pytest.approx(1 / 6)
 
     def test_str(self):
         assert str(self.simplex).startswith("3-simplex in 4D space")


### PR DESCRIPTION
### Summary

- Fix [PT013: incorrect import of `pytest`](https://docs.astral.sh/ruff/rules/pytest-incorrect-pytest-import/)
> For consistency, pytest should be imported as import pytest and its members should be accessed in the form of pytest.xxx.yyy for consistency


Admittedly, `approx` is less verbose than `pytest.approx` (sad we cannot set an exception for `approx`), not sure if we want to fix this