### PR TITLE
Fix incorrect attribute name in `Lobster.outputs.Cohpcar` docstring

### DIFF
--- a/src/pymatgen/io/lobster/outputs.py
+++ b/src/pymatgen/io/lobster/outputs.py
@@ -70,8 +70,8 @@ class Cohpcar:
         energies (Sequence[float]): Sequence of energies in eV. Note that LOBSTER
             shifts the energies so that the Fermi level is at zero.
         is_spin_polarized (bool): True if the calculation is spin polarized.
-        orb_cohp (dict[str, Dict[str, Dict[str, Any]]]): The orbital-resolved COHPs of the form:
-            orb_cohp[label] = {bond_data["orb_label"]: {
+        orb_res_cohp (dict[str, Dict[str, Dict[str, Any]]]): The orbital-resolved COHPs of the form:
+            orb_res_cohp[label] = {bond_data["orb_label"]: {
                 "COHP": {Spin.up: cohps, Spin.down:cohps},
                 "ICOHP": {Spin.up: icohps, Spin.down: icohps},
                 "orbitals": orbitals,


### PR DESCRIPTION
### Summary

- Fix incorrect attribute name in `Lobster.outputs.Cohpcar` docstring, `orb_cohp` -> `orb_res_cohp`
    https://github.com/materialsproject/pymatgen/blob/edcd4654cc5048d7f0f00417d82755d98b03b739/src/pymatgen/io/lobster/outputs.py#L261


```python
from pymatgen.io.lobster.outputs import Cohpcar


cohp = Cohpcar(filename="COHPCAR.lobster")

print(dir(cohp))
```


```['__class__', '__delattr__', '__dict__', '__dir__', '__doc__', '__eq__', '__format__', '__ge__', '__getattribute__', '__getstate__', '__gt__', '__hash__', '__init__', '__init_subclass__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__str__', '__subclasshook__', '__weakref__', '_get_bond_data', 'are_cobis', 'are_coops', 'are_multi_center_cobis', 'cohp_data', 'efermi', 'energies', 'is_spin_polarized', 'orb_res_cohp']```
