### PR TITLE
Pascal-case `PMG_VASP_PSP_DIR_Error`

### DIFF
--- a/src/pymatgen/io/vasp/inputs.py
+++ b/src/pymatgen/io/vasp/inputs.py
@@ -1728,7 +1728,7 @@ VASP_POTCAR_HASHES = loadfn(f"{MODULE_DIR}/vasp_potcar_file_hashes.json")
 POTCAR_STATS_PATH: str = os.path.join(MODULE_DIR, "potcar-summary-stats.json.bz2")
 
 
-class PMG_VASP_PSP_DIR_Error(ValueError):
+class PmgVaspPspDirError(ValueError):
     """Error thrown when PMG_VASP_PSP_DIR is not configured, but POTCAR is requested."""
 
 
@@ -2277,7 +2277,7 @@ class PotcarSingle:
         functional_subdir = SETTINGS.get("PMG_VASP_PSP_SUB_DIRS", {}).get(functional, cls.functional_dir[functional])
         PMG_VASP_PSP_DIR = SETTINGS.get("PMG_VASP_PSP_DIR")
         if PMG_VASP_PSP_DIR is None:
-            raise PMG_VASP_PSP_DIR_Error(
+            raise PmgVaspPspDirError(
                 f"No POTCAR for {symbol} with {functional=} found. Please set the PMG_VASP_PSP_DIR in .pmgrc.yaml."
             )
         if not os.path.isdir(PMG_VASP_PSP_DIR):

--- a/src/pymatgen/io/vasp/sets.py
+++ b/src/pymatgen/io/vasp/sets.py
@@ -49,7 +49,7 @@ from monty.serialization import loadfn
 from pymatgen.analysis.structure_matcher import StructureMatcher
 from pymatgen.core import Element, PeriodicSite, SiteCollection, Species, Structure
 from pymatgen.io.core import InputGenerator
-from pymatgen.io.vasp.inputs import Incar, Kpoints, PMG_VASP_PSP_DIR_Error, Poscar, Potcar, VaspInput
+from pymatgen.io.vasp.inputs import Incar, Kpoints, PmgVaspPspDirError, Poscar, Potcar, VaspInput
 from pymatgen.io.vasp.outputs import Outcar, Vasprun
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.symmetry.bandstructure import HighSymmKpath
@@ -345,13 +345,12 @@ class VaspInputSet(InputGenerator, abc.ABC):
         vasp_input = None
         try:
             vasp_input = self.get_input_set(potcar_spec=potcar_spec)
-        except PMG_VASP_PSP_DIR_Error as exc:
+        except PmgVaspPspDirError:
             if not potcar_spec:
-                raise ValueError(
-                    "PMG_VASP_PSP_DIR is not set."
-                    "  Please set the PMG_VASP_PSP_DIR in .pmgrc.yaml"
-                    " or use potcar_spec=True argument."
-                ) from exc
+                raise PmgVaspPspDirError(
+                    "PMG_VASP_PSP_DIR is not set. Please set PMG_VASP_PSP_DIR"
+                    " in .pmgrc.yaml or use potcar_spec=True argument."
+                ) from None
 
         if vasp_input is None:
             raise ValueError("vasp_input is None")


### PR DESCRIPTION
`PMG_VASP_PSP_DIR_Error` is a class and hence should use PascalCase.

no downstream effects expected from this (strictly speaking) breaking change. 

`PMG_VASP_PSP_DIR_Error` was only added 3 weeks ago in https://github.com/materialsproject/pymatgen/pull/3999 and [the last release](https://github.com/materialsproject/pymatgen/releases/tag/v2024.8.9) was a month ago.