### PR TITLE
Fix `apply_operation(fractional=True)`

### DIFF
--- a/src/pymatgen/core/structure.py
+++ b/src/pymatgen/core/structure.py
@@ -4297,8 +4297,9 @@ class Structure(IStructure, collections.abc.MutableSequence):
             def operate_site(site):
                 return PeriodicSite(
                     site.species,
-                    symm_op.operate(site.frac_coords),
+                    site.lattice.get_cartesian_coords(symm_op.operate(site.frac_coords)),
                     self._lattice,
+                    coords_are_cartesian=True,
                     properties=site.properties,
                     skip_checks=True,
                     label=site.label,

--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -1237,6 +1237,7 @@ class TestStructure(PymatgenTest):
     def test_apply_operation(self):
         op = SymmOp.from_axis_angle_and_translation([0, 0, 1], 90)
         struct = self.struct.copy()
+        spg_info = struct.get_space_group_info()
         returned = struct.apply_operation(op)
         assert returned is struct
         assert_allclose(
@@ -1244,11 +1245,34 @@ class TestStructure(PymatgenTest):
             [[0, 3.840198, 0], [-3.325710, 1.920099, 0], [2.217138, -0, 3.135509]],
             atol=1e-6,
         )
+        assert returned.get_space_group_info() == spg_info
 
-        op = SymmOp([[1, 1, 0, 0.5], [1, 0, 0, 0.5], [0, 0, 1, 0.5], [0, 0, 0, 1]])
+        op = SymmOp([[1, 1, 0, 0.5], [1, 0, 0, 0.5], [0, 0, 1, 0.5], [0, 0, 0, 1]])  # not a SymmOp of this struct
         struct = self.struct.copy()
         struct.apply_operation(op, fractional=True)
         assert_allclose(struct.lattice.matrix, [[5.760297, 3.325710, 0], [3.840198, 0, 0], [0, -2.217138, 3.135509]], 5)
+
+        struct = self.struct.copy()
+        # actual SymmOp of this struct: (SpacegroupAnalyzer(struct).get_symmetry_operations()[-2])
+        op = SymmOp([[ 0.  ,  0.  , -1.  ,  0.75],
+        [-1.  , -1.  ,  1.  ,  0.5 ],
+        [ 0.  , -1.  ,  1.  ,  0.75],
+        [ 0.  ,  0.  ,  0.  ,  1.  ]])
+        struct.apply_operation(op, fractional=True)
+        assert struct.get_space_group_info() == spg_info
+
+        # same SymmOp in Cartesian coordinates:
+        op = SymmOp([[-0.5, -0.288675028, -0.816496280,
+          3.84019793],
+        [-0.866025723,  0.166666176,  0.471404694,
+          0],
+        [ 0, -0.942808868,  0.333333824,
+          2.35163180],
+        [ 0,  0,  0,
+          1.]])
+        struct = self.struct.copy()
+        struct.apply_operation(op, fractional=False)
+        assert struct.get_space_group_info() == spg_info
 
     def test_apply_strain(self):
         struct = self.struct

--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -1254,22 +1254,19 @@ class TestStructure(PymatgenTest):
 
         struct = self.struct.copy()
         # actual SymmOp of this struct: (SpacegroupAnalyzer(struct).get_symmetry_operations()[-2])
-        op = SymmOp([[ 0.  ,  0.  , -1.  ,  0.75],
-        [-1.  , -1.  ,  1.  ,  0.5 ],
-        [ 0.  , -1.  ,  1.  ,  0.75],
-        [ 0.  ,  0.  ,  0.  ,  1.  ]])
+        op = SymmOp([[0.0, 0.0, -1.0, 0.75], [-1.0, -1.0, 1.0, 0.5], [0.0, -1.0, 1.0, 0.75], [0.0, 0.0, 0.0, 1.0]])
         struct.apply_operation(op, fractional=True)
         assert struct.get_space_group_info() == spg_info
 
         # same SymmOp in Cartesian coordinates:
-        op = SymmOp([[-0.5, -0.288675028, -0.816496280,
-          3.84019793],
-        [-0.866025723,  0.166666176,  0.471404694,
-          0],
-        [ 0, -0.942808868,  0.333333824,
-          2.35163180],
-        [ 0,  0,  0,
-          1.]])
+        op = SymmOp(
+            [
+                [-0.5, -0.288675028, -0.816496280, 3.84019793],
+                [-0.866025723, 0.166666176, 0.471404694, 0],
+                [0, -0.942808868, 0.333333824, 2.35163180],
+                [0, 0, 0, 1.0],
+            ]
+        )
         struct = self.struct.copy()
         struct.apply_operation(op, fractional=False)
         assert struct.get_space_group_info() == spg_info


### PR DESCRIPTION
## Summary
`Structure.apply_operation()` fails when using the `fractional=True` operation.
The issue is that the ``SymmOp`` is applied to the site frac coords (in the original lattice), but then these new frac coords (in the old basis) are used directly with the new (transformed) lattice, giving a 'doubled' transformation and messing with the output.

Fix added here, matching the implementation in [`doped`](https://github.com/SMTG-Bham/doped/blob/develop/doped/utils/symmetry.py#L211) (which also has a couple more options and a cleaner implementation).

MWE:
<img width="728" alt="image" src="https://github.com/user-attachments/assets/96246dc4-1f92-4dc3-969d-cc36ce2c171a">
<img width="701" alt="image" src="https://github.com/user-attachments/assets/b5090429-09bf-4ea9-807b-d65da6ba0aa8">

(Notebook and structure being used attached too as always 😉 , with more examples)

[Pymatgen_SymmOp_Fix_PR.zip](https://github.com/user-attachments/files/16934325/Pymatgen_SymmOp_Fix_PR.zip)