### PR TITLE
Use distinct names for artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
           python-version: "3.12"
 
       - name: Get build artifacts
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4
         with:
           pattern: dist-*
           merge-multiple: true


### PR DESCRIPTION
## Summary

Major changes:

- `upload-artifacts` was recently bumped to `v4` (see #4037). I think that this breaks the release workflow because from `v4` upwards they are not allowed to have the same name anymore  (see https://github.com/actions/upload-artifact/issues/478). This PR should fix it, according to [this suggestion](https://github.com/actions/upload-artifact/issues/478#issuecomment-1885470013)

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [x] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))