### PR TITLE
(Not) Use `setup-uv` in CI tests workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,10 +82,9 @@ jobs:
           # TODO1 (use uv over pip) uv install torch is flaky, track #3826
           # TODO2 (pin torch version): DGL library (matgl) doesn't support torch > 2.2.1,
           # see: https://discuss.dgl.ai/t/filenotfounderror-cannot-find-dgl-c-graphbolt-library/4302
-          # DEBUG: attach timestamp in ms
-          pip install torch==2.2.1 --verbose 2>&1 | while IFS= read -r line; do echo "$(date '+%Y-%m-%d %H:%M:%S.%3N') $line"; done
+          pip install torch==2.2.1
 
-          uv pip install --editable '.[${{ matrix.config.extras }}]' --resolution=${{ matrix.config.resolution }} --verbose 2>&1 | while IFS= read -r line; do echo "$(date '+%Y-%m-%d %H:%M:%S.%3N') $line"; done
+          uv pip install --editable '.[${{ matrix.config.extras }}]' --resolution=${{ matrix.config.resolution }}
 
       - name: Install optional Ubuntu dependencies
         if: matrix.config.os == 'ubuntu-latest'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,21 +68,12 @@ jobs:
         run: |
           micromamba create -n pmg python=${{ matrix.config.python }} --yes
 
-      # - name: Install uv
-      #   run: micromamba run -n pmg pip install uv
-
       - name: Install ubuntu-only conda dependencies
         if: matrix.config.os == 'ubuntu-latest'
         run: |
           micromamba install -n pmg -c conda-forge bader enumlib openff-toolkit packmol pygraphviz tblite --yes
 
-      # - name: Install the latest version of uv
-      #   uses: astral-sh/setup-uv@v2
-      #   with:
-      #     enable-cache: true
-      #     version: "latest"
-
-      - name: Install pymatgen and dependencies
+      - name: Install pymatgen and dependencies via uv
         run: |
           micromamba activate pmg
 
@@ -92,8 +83,6 @@ jobs:
           # TODO2 (pin torch version): DGL library (matgl) doesn't support torch > 2.2.1,
           # see: https://discuss.dgl.ai/t/filenotfounderror-cannot-find-dgl-c-graphbolt-library/4302
           pip install torch==2.2.1
-
-          uv pip install cython setuptools wheel
 
           uv pip install --editable '.[${{ matrix.config.extras }}]' --resolution=${{ matrix.config.resolution }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,8 @@ jobs:
       # - name: Install uv
       #   run: micromamba run -n pmg pip install uv
 
+      # Try let uv cache work
+
       - name: Install ubuntu-only conda dependencies
         if: matrix.config.os == 'ubuntu-latest'
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,19 +68,19 @@ jobs:
         run: |
           micromamba create -n pmg python=${{ matrix.config.python }} --yes
 
-      - name: Install uv
-        run: micromamba run -n pmg pip install uv
+      # - name: Install uv
+      #   run: micromamba run -n pmg pip install uv
 
       - name: Install ubuntu-only conda dependencies
         if: matrix.config.os == 'ubuntu-latest'
         run: |
           micromamba install -n pmg -c conda-forge bader enumlib openff-toolkit packmol pygraphviz tblite --yes
 
-      # - name: Install the latest version of uv
-      #   uses: astral-sh/setup-uv@v2
-      #   with:
-      #     enable-cache: true
-      #     version: "latest"
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v2
+        with:
+          enable-cache: true
+          version: "latest"
 
       - name: Install pymatgen and dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,22 +71,22 @@ jobs:
       # - name: Install uv
       #   run: micromamba run -n pmg pip install uv
 
-      # Try let uv cache work
-
       - name: Install ubuntu-only conda dependencies
         if: matrix.config.os == 'ubuntu-latest'
         run: |
           micromamba install -n pmg -c conda-forge bader enumlib openff-toolkit packmol pygraphviz tblite --yes
 
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v2
-        with:
-          enable-cache: true
-          version: "latest"
+      # - name: Install the latest version of uv
+      #   uses: astral-sh/setup-uv@v2
+      #   with:
+      #     enable-cache: true
+      #     version: "latest"
 
       - name: Install pymatgen and dependencies
         run: |
           micromamba activate pmg
+
+          pip install uv
 
           # TODO1 (use uv over pip) uv install torch is flaky, track #3826
           # TODO2 (pin torch version): DGL library (matgl) doesn't support torch > 2.2.1,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,6 +76,12 @@ jobs:
         run: |
           micromamba install -n pmg -c conda-forge bader enumlib openff-toolkit packmol pygraphviz tblite --yes
 
+      # - name: Install the latest version of uv
+      #   uses: astral-sh/setup-uv@v2
+      #   with:
+      #     enable-cache: true
+      #     version: "latest"
+
       - name: Install pymatgen and dependencies
         run: |
           micromamba activate pmg

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,9 +82,10 @@ jobs:
           # TODO1 (use uv over pip) uv install torch is flaky, track #3826
           # TODO2 (pin torch version): DGL library (matgl) doesn't support torch > 2.2.1,
           # see: https://discuss.dgl.ai/t/filenotfounderror-cannot-find-dgl-c-graphbolt-library/4302
-          pip install torch==2.2.1
+          # DEBUG: attach timestamp in ms
+          pip install torch==2.2.1 --verbose 2>&1 | while IFS= read -r line; do echo "$(date '+%Y-%m-%d %H:%M:%S.%3N') $line"; done
 
-          uv pip install --editable '.[${{ matrix.config.extras }}]' --resolution=${{ matrix.config.resolution }}
+          uv pip install --editable '.[${{ matrix.config.extras }}]' --resolution=${{ matrix.config.resolution }} --verbose 2>&1 | while IFS= read -r line; do echo "$(date '+%Y-%m-%d %H:%M:%S.%3N') $line"; done
 
       - name: Install optional Ubuntu dependencies
         if: matrix.config.os == 'ubuntu-latest'


### PR DESCRIPTION
### Summary

- [Use `setup-uv` in CI tests workflow](https://docs.astral.sh/uv/guides/integration/github/), to close #4044

## Performance benchmark

The following word "native" refers to package installed by native github action setups: `setup-Python/micromamba/uv`

**NOTE**: `setup-uv` installer might provide caching function, so the run time might be slower for the first run

### Dependency installation time

Time (in seconds)  is reported on the `Install pymatgen and dependencies` stage for "split 1", excluding conda and optional Ubuntu dependencies 

|                           | Ubuntu 22.04 | Windows 11 | MacOS |
|---------------------------|--------------|------------|-------|
| native mamba + pip        |        88      |      235      |   26    |
| native mamba + uv         |         85     |      150      |    28   |
| native mamba + native uv (first run)  |        93      |     254       |    24   |
| native mamba + native uv  (second run) |   97   |   141    |   23  |

**Conclusion**: not much difference between `setup-uv` and `pip install uv`, and [the M1 MacOS runner](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners) is just another level.

### Pytest running time

Time (in seconds) is reported for "split 1"

|                           | Ubuntu 22.04 | Windows 11 | MacOS |
|---------------------------|--------------|------------|-------|
| native mamba + pip        |       187       |       262     |    101   |
| native mamba + uv         |      181  |     249       |    114   |
| native mamba + native uv (first run)  |    183          |       258     |   100     |
| native mamba + native uv  (second run) |  186    |  249 |   100 |

**Conclusion**: Actual test running time is largely not influenced (as expected).

### Link to above workflow runs

|                           | Link |
|---------------------------|------|
| native mamba + pip     |   https://github.com/materialsproject/pymatgen/actions/runs/10824932738   |
| native mamba + uv         |   https://github.com/materialsproject/pymatgen/actions/runs/10824062208   |
| native mamba + native uv  (first run) |  https://github.com/materialsproject/pymatgen/actions/runs/10824811886    |
| native mamba + native uv  (second run) |   https://github.com/materialsproject/pymatgen/actions/runs/10824892797   |
