### PR TITLE
fix phase diagram break from 41e6d99

### DIFF
--- a/src/pymatgen/analysis/phase_diagram.py
+++ b/src/pymatgen/analysis/phase_diagram.py
@@ -2972,7 +2972,7 @@ class PDPlotter:
                 for d in ["xref", "yref"]:
                     annotation.pop(d)  # Scatter3d cannot contain xref, yref
                     if self._dim == 3:
-                        annotation.update(x=x, y=y)
+                        annotation.update(x=y, y=x)
                         if entry.composition.is_element:
                             z = 0.9 * self._min_energy  # place label 10% above base
 


### PR DESCRIPTION
## Summary
This PR fixed the break of phase diagram plot caused by commit 41e6d99 which made changes not only to syntax but also plotting logic without careful review. This is a small fix but did require human hour to track down the issue, and caused downstream breakage on MP website and for pymatgen users who plot phase diagrams. 

![Screenshot 2024-09-16 at 4 25 56 PM](https://github.com/user-attachments/assets/6d2717b5-40e7-4681-b845-76d800c112fe)
