### PR TITLE
fix chempot_diagram

### DIFF
--- a/src/pymatgen/analysis/chempot_diagram.py
+++ b/src/pymatgen/analysis/chempot_diagram.py
@@ -646,7 +646,7 @@ def simple_pca(data: np.ndarray, k: int = 2) -> tuple[np.ndarray, np.ndarray, np
     Returns:
         tuple: projected data, eigenvalues, eigenvectors
     """
-    data -= np.mean(data.T, axis=1)  # centering the data
+    data = data - np.mean(data.T, axis=1)  # centering the data
     cov = np.cov(data.T)  # calculating covariance matrix
     v, w = np.linalg.eig(cov)  # performing eigendecomposition
     idx = v.argsort()[::-1]  # sorting the components


### PR DESCRIPTION
## Summary
A strange behavior was caught for chemical potential diagram where the planes were crossed. 
Using the in-place [assignment expression](https://github.com/materialsproject/pymatgen/blob/150f816c55be80dd146cb20ebbf5f930633c8aeb/src/pymatgen/analysis/chempot_diagram.py#L649), the plot shows below: 

<img width="817" alt="Screenshot 2024-09-17 at 2 38 07 PM" src="https://github.com/user-attachments/assets/5dc7a153-e968-42ab-9dd9-8e08d74343dd">

It it not obvious how it could cause the breakage. I spent sometime debugging but with no luck, it could be something much deeper. For now I suggest we revert it to the original form till we have a real solution. Would much appreciate a quick release due to breakage for MP... 