### PR TITLE
return `bool` instead of `np.bool_`

### DIFF
--- a/src/pymatgen/analysis/chemenv/utils/coordination_geometry_utils.py
+++ b/src/pymatgen/analysis/chemenv/utils/coordination_geometry_utils.py
@@ -724,7 +724,7 @@ class Plane:
         Returns:
             bool: True if pp is in the plane.
         """
-        return np.abs(np.dot(self.normal_vector, pp) + self._coefficients[3]) <= dist_tolerance
+        return abs(np.abs(np.dot(self.normal_vector, pp) + self._coefficients[3]) <= dist_tolerance)
 
     def is_same_plane_as(self, plane) -> bool:
         """

--- a/src/pymatgen/analysis/chemenv/utils/coordination_geometry_utils.py
+++ b/src/pymatgen/analysis/chemenv/utils/coordination_geometry_utils.py
@@ -724,7 +724,7 @@ class Plane:
         Returns:
             bool: True if pp is in the plane.
         """
-        return abs(np.abs(np.dot(self.normal_vector, pp) + self._coefficients[3]) <= dist_tolerance)
+        return bool(np.abs(np.dot(self.normal_vector, pp) + self._coefficients[3]) <= dist_tolerance)
 
     def is_same_plane_as(self, plane) -> bool:
         """

--- a/src/pymatgen/analysis/ewald.py
+++ b/src/pymatgen/analysis/ewald.py
@@ -615,7 +615,7 @@ class EwaldMinimizer:
                 1 - speedup_parameter
             )
 
-        return np.sum(matrix) + np.inner(sums[::-1], fractions - 1) + interaction_correction
+        return float(np.sum(matrix) + np.inner(sums[::-1], fractions - 1) + interaction_correction)
 
     @classmethod
     def get_next_index(cls, matrix, manipulation, indices_left):

--- a/src/pymatgen/analysis/ewald.py
+++ b/src/pymatgen/analysis/ewald.py
@@ -615,7 +615,7 @@ class EwaldMinimizer:
                 1 - speedup_parameter
             )
 
-        return float(np.sum(matrix) + np.inner(sums[::-1], fractions - 1) + interaction_correction)
+        return np.sum(matrix) + np.inner(sums[::-1], fractions - 1) + interaction_correction
 
     @classmethod
     def get_next_index(cls, matrix, manipulation, indices_left):

--- a/src/pymatgen/analysis/structure_matcher.py
+++ b/src/pymatgen/analysis/structure_matcher.py
@@ -633,7 +633,7 @@ class StructureMatcher(MSONable):
         if match1 is None or match2 is None:
             return False
 
-        return max(match1[0], match2[0]) <= self.stol
+        return bool(max(match1[0], match2[0]) <= self.stol)
 
     def get_rms_dist(self, struct1, struct2):
         """

--- a/src/pymatgen/core/structure.py
+++ b/src/pymatgen/core/structure.py
@@ -500,7 +500,7 @@ class SiteCollection(collections.abc.Sequence, ABC):
         if len(self) == 1:
             return True
         all_dists = self.distance_matrix[np.triu_indices(len(self), 1)]
-        return np.min(all_dists) > tol
+        return bool(np.min(all_dists) > tol)
 
     @abstractmethod
     def to(self, filename: str = "", fmt: FileFormats = "") -> str | None:

--- a/src/pymatgen/core/surface.py
+++ b/src/pymatgen/core/surface.py
@@ -299,7 +299,7 @@ class Slab(Structure):
         # to surface (b) along the [hkl]-axis, surfaces are symmetric. Or because the
         # two surfaces of our slabs are always parallel to the (hkl) plane,
         # any operation where there's an (hkl) mirror plane has surface symmetry
-        return (
+        return bool(
             spg_analyzer.is_laue()
             or any(op.translation_vector[2] != 0 for op in symm_ops)
             or any(np.all(op.rotation_matrix[2] == np.array([0, 0, -1])) for op in symm_ops)
@@ -318,7 +318,7 @@ class Slab(Structure):
                 considered polar.
         """
         dip_per_unit_area = self.dipole / self.surface_area
-        return np.linalg.norm(dip_per_unit_area) > tol_dipole_per_unit_area
+        return bool(np.linalg.norm(dip_per_unit_area) > tol_dipole_per_unit_area)
 
     def get_surface_sites(self, tag: bool = False) -> dict[str, list]:
         """Get the surface sites and their indices in a dictionary.

--- a/src/pymatgen/core/tensors.py
+++ b/src/pymatgen/core/tensors.py
@@ -331,7 +331,7 @@ class Tensor(np.ndarray, MSONable):
             structure (Structure): structure to be fit to
             tol (float): tolerance for symmetry testing
         """
-        return (self - self.fit_to_structure(structure) < tol).all()
+        return bool((self - self.fit_to_structure(structure) < tol).all())
 
     @property
     def voigt(self) -> NDArray:
@@ -968,7 +968,7 @@ class SquareTensor(Tensor):
         det = np.abs(np.linalg.det(self))
         if include_improper:
             det = np.abs(det)
-        return (np.abs(self.inv - self.trans) < tol).all() and (np.abs(det - 1.0) < tol)
+        return bool((np.abs(self.inv - self.trans) < tol).all() and (np.abs(det - 1.0) < tol))
 
     def refine_rotation(self) -> Self:
         """Helper method for refining rotation matrix by ensuring

--- a/src/pymatgen/phonon/bandstructure.py
+++ b/src/pymatgen/phonon/bandstructure.py
@@ -182,7 +182,7 @@ class PhononBandStructure(MSONable):
         Args:
             tol: Tolerance for determining if a frequency is imaginary. Defaults to 0.01.
         """
-        return self.min_freq()[1] + tol < 0
+        return bool(self.min_freq()[1] + tol < 0)
 
     def has_imaginary_gamma_freq(self, tol: float = 0.01) -> bool:
         """Check if there are imaginary modes at the gamma point and all close points.


### PR DESCRIPTION
## Summary

The return signature of this function is currently `np.bool_` which can cause serialization problems with older atomate1 workflows.

Changed to `bool` instead.