### PR TITLE
Fix bug with species defaults

### DIFF
--- a/src/pymatgen/io/aims/inputs.py
+++ b/src/pymatgen/io/aims/inputs.py
@@ -584,7 +584,9 @@ class AimsControlIn(MSONable):
                 content += cube.control_block
 
         content += f"{lim}\n\n"
-        species_defaults = self._parameters.get("species_dir", "")
+        species_defaults = self._parameters.get(
+            "species_dir", SETTINGS.get("AIMS_SPECIES_DIR", "")
+        )
         if not species_defaults:
             raise KeyError("Species' defaults not specified in the parameters")
 


### PR DESCRIPTION
Need to specify the default value properly

## Summary

Major changes:

- fix 1: Species Defaults need to be read from SETTINGS object

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
