### PR TITLE
Fix usage of `strict=True` for `zip` in `cp2k.outputs`

### DIFF
--- a/src/pymatgen/io/cp2k/outputs.py
+++ b/src/pymatgen/io/cp2k/outputs.py
@@ -10,7 +10,6 @@ import re
 import warnings
 from glob import glob
 from itertools import chain
-from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -28,9 +27,6 @@ from pymatgen.io.cp2k.sets import Cp2kInput
 from pymatgen.io.cp2k.utils import natural_keys, postprocessor
 from pymatgen.io.xyz import XYZ
 
-if TYPE_CHECKING:
-    from pymatgen.util.typing import PathLike
-
 __author__ = "Nicholas Winner"
 __version__ = "2.0"
 __status__ = "Production"
@@ -42,20 +38,20 @@ class Cp2kOutput:
     but other parsing features may be called depending on the run type.
     """
 
-    def __init__(self, filename: PathLike, verbose: bool = False, auto_load: bool = False) -> None:
+    def __init__(self, filename, verbose=False, auto_load=False):
         """
         Initialize the Cp2kOutput object.
 
         Args:
-            filename (PathLike): The CP2K output file to parse.
-            verbose (bool): Whether or not to parse with verbosity (will parse lots of data that
-                may not be useful).
+            filename: (str) Name of the CP2K output file to parse
+            verbose: (bool) Whether or not to parse with verbosity (will parse lots of data that
+                may not be useful)
             auto_load (bool): Whether or not to automatically load basic info like energies
                 and structures.
         """
         # IO Info
-        self.filename = str(filename)
-        self.dir = os.path.dirname(self.filename)
+        self.filename = filename
+        self.dir = os.path.dirname(filename)
         self.filenames: dict = {}
         self.parse_files()
         self.data: dict = {}
@@ -106,17 +102,17 @@ class Cp2kOutput:
         return c
 
     @property
-    def num_warnings(self) -> int:
+    def num_warnings(self):
         """How many warnings showed up during the run."""
         return self.data.get("num_warnings", 0)
 
     @property
-    def run_type(self) -> str:
+    def run_type(self):
         """What type of run (Energy, MD, etc.) was performed."""
-        return self.data.get("global", {}).get("Run_type")
+        return self.data.get("global").get("Run_type")
 
     @property
-    def calculation_type(self) -> str:
+    def calculation_type(self):
         """The calculation type (what io.vasp.outputs calls run_type)."""
         LDA_TYPES = {"LDA", "PADE", "BECKE88", "BECKE88_LR", "BECKE88_LR_ADIABATIC", "BECKE97"}
 
@@ -162,7 +158,7 @@ class Cp2kOutput:
 
         if self.is_hubbard:
             rt += "+U"
-        if self.data.get("dft", {}).get("vdw"):
+        if self.data.get("dft").get("vdw"):
             rt += "+VDW"
 
         return rt
@@ -181,15 +177,11 @@ class Cp2kOutput:
     @property
     def charge(self) -> float:
         """Charge from the input file."""
-        if self.input is None:
-            raise RuntimeError("input attribute is None.")
         return self.input["FORCE_EVAL"]["DFT"].get("CHARGE", Keyword("", 0)).values[0]
 
     @property
     def multiplicity(self) -> int:
         """The spin multiplicity from input file."""
-        if self.input is None:
-            raise RuntimeError("input attribute is None.")
         return self.input["FORCE_EVAL"]["DFT"].get("Multiplicity", Keyword("")).values[0]
 
     @property
@@ -202,10 +194,8 @@ class Cp2kOutput:
 
     @property
     def is_metal(self) -> bool:
-        """Whether it is a metal by checking the band gap."""
-        if self.band_gap is None:
-            return True
-        return self.band_gap <= 0
+        """Was a band gap found? i.e. is it a metal."""
+        return True if self.band_gap is None else self.band_gap <= 0
 
     @property
     def is_hubbard(self) -> bool:
@@ -215,7 +205,7 @@ class Cp2kOutput:
                 return True
         return False
 
-    def parse_files(self) -> None:
+    def parse_files(self):
         """
         Identify files present in the directory with the CP2K output file. Looks for trajectories,
         dos, and cubes.
@@ -322,7 +312,7 @@ class Cp2kOutput:
                 self.structures = mols
             self.final_structure = self.structures[-1]
 
-    def parse_initial_structure(self) -> Structure | Molecule:
+    def parse_initial_structure(self):
         """Parse the initial structure from the main CP2K output file."""
         patterns = {"num_atoms": re.compile(r"- Atoms:\s+(\d+)")}
         self.read_pattern(
@@ -375,19 +365,13 @@ class Cp2kOutput:
                 charge=self.charge,
             )
 
-        if self.initial_structure is None:
-            raise RuntimeError("initial structure is not parsed.")
         self.composition = self.initial_structure.composition
         return self.initial_structure
 
-    def ran_successfully(self) -> None:
-        """Sanity checks that the program ran successfully.
-
-        Looks at the bottom of the CP2K output file for the "PROGRAM ENDED" line,
-        which is printed when successfully ran. Also grabs the number of warnings issued.
-
-        Raises:
-            ValueError: if CP2K job did not finish successfully.
+    def ran_successfully(self):
+        """Sanity checks that the program ran successfully. Looks at the bottom of the CP2K output
+        file for the "PROGRAM ENDED" line, which is printed when successfully ran. Also grabs
+        the number of warnings issued.
         """
         program_ended_at = re.compile(r"PROGRAM ENDED AT\s+(\w+)")
         num_warnings = re.compile(r"The number of warnings for this run is : (\d+)")
@@ -407,7 +391,7 @@ class Cp2kOutput:
         if not self.completed:
             raise ValueError("The provided CP2K job did not finish running! Cannot parse the file reliably.")
 
-    def convergence(self) -> None:
+    def convergence(self):
         """Check whether or not the SCF and geometry optimization cycles converged."""
         # SCF Loops
         unconverged_inner_loop = re.compile(r"(Leaving inner SCF loop)")
@@ -445,7 +429,7 @@ class Cp2kOutput:
         if any(self.data["geo_opt_not_converged"]):
             warnings.warn("Geometry optimization did not converge", UserWarning)
 
-    def parse_energies(self) -> None:
+    def parse_energies(self):
         """Get the total energy from a CP2K calculation. Presently, the energy reported in the
         trajectory (pos.xyz) file takes precedence over the energy reported in the main output
         file. This is because the trajectory file keeps track of energies in between restarts,
@@ -453,7 +437,7 @@ class Cp2kOutput:
         overwrites or appends it.
         """
         if self.filenames.get("trajectory"):
-            toten_pattern: str | re.Pattern = r".*E\s+\=\s+(-?\d+.\d+)"
+            toten_pattern = r".*E\s+\=\s+(-?\d+.\d+)"
             matches = regrep(
                 self.filenames["trajectory"][-1],
                 {"total_energy": toten_pattern},
@@ -475,7 +459,7 @@ class Cp2kOutput:
             )
         self.final_energy = self.data.get("total_energy", [])[-1]
 
-    def parse_forces(self) -> None:
+    def parse_forces(self):
         """Get the forces from the forces file, or from the main output file."""
         if len(self.filenames["forces"]) == 1:
             self.data["forces"] = [
@@ -495,7 +479,7 @@ class Cp2kOutput:
                 last_one_only=False,
             )
 
-    def parse_stresses(self) -> None:
+    def parse_stresses(self):
         """Get the stresses from stress file, or from the main output file."""
         if len(self.filenames["stress"]) == 1:
             dat = np.genfromtxt(self.filenames["stress"][0], skip_header=1)
@@ -525,7 +509,7 @@ class Cp2kOutput:
             if d:
                 self.data["stress_tensor"] = list(chunks(d[0], 3))
 
-    def parse_ionic_steps(self) -> list:
+    def parse_ionic_steps(self):
         """Parse the ionic step info. If already parsed, this will just assimilate."""
         if not self.structures:
             self.parse_structures()
@@ -536,7 +520,7 @@ class Cp2kOutput:
         if not self.data.get("stress_tensor"):
             self.parse_stresses()
 
-        for i, (structure, energy) in enumerate(zip(self.structures, self.data.get("total_energy", []), strict=False)):
+        for i, (structure, energy) in enumerate(zip(self.structures, self.data.get("total_energy"), strict=False)):
             self.ionic_steps.append(
                 {
                     "structure": structure,
@@ -548,7 +532,7 @@ class Cp2kOutput:
 
         return self.ionic_steps
 
-    def parse_cp2k_params(self) -> None:
+    def parse_cp2k_params(self):
         """Parse the CP2K general parameters from CP2K output file into a dictionary."""
         version = re.compile(r"\s+CP2K\|.+version\s+(.+)")
         input_file = re.compile(r"\s+CP2K\|\s+Input file name\s+(.+)$")
@@ -559,7 +543,7 @@ class Cp2kOutput:
             postprocess=str,
         )
 
-    def parse_plus_u_params(self) -> None:
+    def parse_plus_u_params(self):
         """Parse the DFT+U params."""
         method = re.compile(r"\s+DFT\+U\|\s+Method\s+()$")
         self.read_pattern(
@@ -569,7 +553,7 @@ class Cp2kOutput:
             postprocess=postprocessor,
         )
 
-    def parse_input(self) -> None:
+    def parse_input(self):
         """Load in the input set from the input file (if it can be found)."""
         if len(self.data["input_filename"]) == 0:
             return
@@ -580,7 +564,7 @@ class Cp2kOutput:
                 return
         warnings.warn("Original input file not found. Some info may be lost.")
 
-    def parse_global_params(self) -> None:
+    def parse_global_params(self):
         """Parse the GLOBAL section parameters from CP2K output file into a dictionary."""
         pat = re.compile(r"\s+GLOBAL\|\s+([\w+\s]*)\s+(\w+)")
         self.read_pattern({"global": pat}, terminate_on_match=False, reverse=False)
@@ -675,7 +659,7 @@ class Cp2kOutput:
                 i += 1
         self.data["QS"]["Multi_grid_cutoffs_[a.u.]"] = tmp
 
-    def parse_overlap_condition(self) -> None:
+    def parse_overlap_condition(self):
         """Retrieve the overlap condition number."""
         overlap_condition = re.compile(r"\|A\|\*\|A\^-1\|.+=\s+(-?\d+\.\d+E[+\-]?\d+)\s+Log")
         self.read_pattern(
@@ -1285,8 +1269,6 @@ class Cp2kOutput:
         bands_data = np.loadtxt(bandstructure_filename)
         nkpts = int(lines[0].split()[6])
         nbands = int(lines[0].split()[-2])
-        if self.final_structure is None:
-            raise RuntimeError("cannot parse bandstructure without final structure.")
         rec_lat = (
             self.final_structure.lattice.reciprocal_lattice
             if self.final_structure
@@ -1531,7 +1513,7 @@ class Cp2kOutput:
         last_one_only=True,
         strip=None,
     ):
-        r"""This method originated in pymatgen.io.vasp.outputs.Outcar.
+        r"""This function originated in pymatgen.io.vasp.outputs.Outcar.
 
         Parse table-like data. A table composes of three parts: header,
         main body, footer. All the data matches "row pattern" in the main body
@@ -1662,11 +1644,9 @@ def parse_energy_file(energy_file):
     return {c: df_energies[c].to_numpy() for c in columns}
 
 
+# TODO: The DOS file that CP2K outputs as of 2022.1 seems to have a lot of problems.
 def parse_dos(dos_file=None):
-    """Parse a dos file. This format is different from the pdos files.
-
-    TODO: The DOS file that CP2K outputs as of 2022.1 seems to have a lot of problems.
-    """
+    """Parse a dos file. This format is different from the pdos files."""
     data = np.loadtxt(dos_file)
     data[:, 0] *= Ha_to_eV
     energies = data[:, 0]

--- a/src/pymatgen/io/cp2k/outputs.py
+++ b/src/pymatgen/io/cp2k/outputs.py
@@ -297,7 +297,7 @@ class Cp2kOutput:
             self.structures = []
             gs = self.initial_structure.site_properties.get("ghost")
             if not self.is_molecule:
-                for mol, latt in zip(mols, lattices, strict=True):
+                for mol, latt in zip(mols, lattices, strict=False):
                     self.structures.append(
                         Structure(
                             lattice=latt,
@@ -520,7 +520,7 @@ class Cp2kOutput:
         if not self.data.get("stress_tensor"):
             self.parse_stresses()
 
-        for i, (structure, energy) in enumerate(zip(self.structures, self.data.get("total_energy"), strict=True)):
+        for i, (structure, energy) in enumerate(zip(self.structures, self.data.get("total_energy"), strict=False)):
             self.ionic_steps.append(
                 {
                     "structure": structure,
@@ -627,8 +627,8 @@ class Cp2kOutput:
             suffix = ""
             for ll in self.data.get("vdw"):
                 for _possible, _name in zip(
-                    ["RVV10", "LMKLL", "DRSLL", "DFT-D3", "DFT-D2"],
-                    ["RVV10", "LMKLL", "DRSLL", "D3", "D2"],
+                    ("RVV10", "LMKLL", "DRSLL", "DFT-D3", "DFT-D2"),
+                    ("RVV10", "LMKLL", "DRSLL", "D3", "D2"),
                     strict=True,
                 ):
                     if _possible in ll[0]:
@@ -1463,7 +1463,7 @@ class Cp2kOutput:
         dct = np.zeros(npts)
         e_s = np.linspace(min(energies), max(energies), npts)
 
-        for e, _pd in zip(energies, densities, strict=True):
+        for e, _pd in zip(energies, densities, strict=False):
             weight = np.exp(-(((e_s - e) / width) ** 2)) / (np.sqrt(np.pi) * width)
             dct += _pd * weight
 

--- a/tests/io/cp2k/test_inputs.py
+++ b/tests/io/cp2k/test_inputs.py
@@ -41,20 +41,7 @@ BASIS_FILE_STR = """
 """
 
 
-class TestBasisAndPotential(PymatgenTest):
-    all_hydrogen_str = """
-H ALLELECTRON ALL
-    1    0    0
-    0.20000000    0
-"""
-
-    pot_hydrogen_str = """
-H GTH-PBE-q1 GTH-PBE
-    1
-    0.20000000    2    -4.17890044     0.72446331
-    0
-"""
-
+class TestBasis(PymatgenTest):
     def test_basis_info(self):
         # Ensure basis metadata can be read from string
         basis_info = BasisInfo.from_str("cc-pc-DZVP-MOLOPT-q1-SCAN")
@@ -76,25 +63,13 @@ H GTH-PBE-q1 GTH-PBE
         assert basis_info3.polarization == 1
         assert basis_info3.contracted, True
 
-    def test_potential_info(self):
-        # Ensure potential metadata can be read from string
-        pot_info = PotentialInfo.from_str("GTH-PBE-q1-NLCC")
-        assert pot_info.potential_type == "GTH"
-        assert pot_info.xc == "PBE"
-        assert pot_info.nlcc
-
-        # Ensure one-way soft-matching works
-        pot_info2 = PotentialInfo.from_str("GTH-q1-NLCC")
-        assert pot_info2.softmatch(pot_info)
-        assert not pot_info.softmatch(pot_info2)
-
     def test_basis(self):
         # Ensure cp2k formatted string can be read for data correctly
         mol_opt = GaussianTypeOrbitalBasisSet.from_str(BASIS_FILE_STR)
         assert mol_opt.nexp == [7]
         # Basis file can read from strings
         bf = BasisFile.from_str(BASIS_FILE_STR)
-        for obj in [mol_opt, bf.objects[0]]:
+        for obj in (mol_opt, bf.objects[0]):
             assert_allclose(
                 obj.exponents[0],
                 [
@@ -115,6 +90,33 @@ H GTH-PBE-q1 GTH-PBE
         kw = mol_opt.get_keyword()
         assert_array_equal(kw.values, ["AUX_FIT", "SZV-MOLOPT-GTH"])
         mol_opt.info.admm = False
+
+
+class TestPotential(PymatgenTest):
+    all_hydrogen_str = """
+H ALLELECTRON ALL
+    1    0    0
+    0.20000000    0
+"""
+
+    pot_hydrogen_str = """
+H GTH-PBE-q1 GTH-PBE
+    1
+    0.20000000    2    -4.17890044     0.72446331
+    0
+"""
+
+    def test_potential_info(self):
+        # Ensure potential metadata can be read from string
+        pot_info = PotentialInfo.from_str("GTH-PBE-q1-NLCC")
+        assert pot_info.potential_type == "GTH"
+        assert pot_info.xc == "PBE"
+        assert pot_info.nlcc
+
+        # Ensure one-way soft-matching works
+        pot_info2 = PotentialInfo.from_str("GTH-q1-NLCC")
+        assert pot_info2.softmatch(pot_info)
+        assert not pot_info.softmatch(pot_info2)
 
     def test_potentials(self):
         # Ensure cp2k formatted string can be read for data correctly

--- a/tests/io/cp2k/test_inputs.py
+++ b/tests/io/cp2k/test_inputs.py
@@ -159,7 +159,7 @@ class TestBasisAndPotential(PymatgenTest):
         assert kw.values[0] == "ALL"
 
 
-class TestInput(PymatgenTest):
+class TestCp2kInput(PymatgenTest):
     def setUp(self):
         self.ci = Cp2kInput.from_file(f"{TEST_DIR}/cp2k.inp")
 

--- a/tests/io/cp2k/test_inputs.py
+++ b/tests/io/cp2k/test_inputs.py
@@ -26,19 +26,6 @@ from pymatgen.util.testing import TEST_FILES_DIR, PymatgenTest
 
 TEST_DIR = f"{TEST_FILES_DIR}/io/cp2k"
 
-si_struct = Structure(
-    lattice=[[0, 2.734364, 2.734364], [2.734364, 0, 2.734364], [2.734364, 2.734364, 0]],
-    species=["Si", "Si"],
-    coords=[[0, 0, 0], [0.25, 0.25, 0.25]],
-)
-
-nonsense_struct = Structure(
-    lattice=[[-1.0, -10.0, -100.0], [0.1, 0.01, 0.001], [7.0, 11.0, 21.0]],
-    species=["H"],
-    coords=[[-1, -1, -1]],
-)
-
-ch_mol = Molecule(species=["C", "H"], coords=[[0, 0, 0], [1, 1, 1]])
 
 BASIS_FILE_STR = """
  H  SZV-MOLOPT-GTH SZV-MOLOPT-GTH-q1
@@ -52,26 +39,22 @@ BASIS_FILE_STR = """
       0.066918004004  0.037148121400
       0.021708243634 -0.001125195500
 """
-ALL_HYDROGEN_STR = """
-H ALLELECTRON ALL
-    1    0    0
-     0.20000000    0
-"""
-POT_HYDROGEN_STR = """
-H GTH-PBE-q1 GTH-PBE
-    1
-     0.20000000    2    -4.17890044     0.72446331
-    0
-"""
-CP2K_INPUT_STR = """
-&GLOBAL
-    RUN_TYPE ENERGY
-    PROJECT_NAME CP2K ! default name
-&END
-"""
 
 
 class TestBasisAndPotential(PymatgenTest):
+    all_hydrogen_str = """
+H ALLELECTRON ALL
+    1    0    0
+    0.20000000    0
+"""
+
+    pot_hydrogen_str = """
+H GTH-PBE-q1 GTH-PBE
+    1
+    0.20000000    2    -4.17890044     0.72446331
+    0
+"""
+
     def test_basis_info(self):
         # Ensure basis metadata can be read from string
         basis_info = BasisInfo.from_str("cc-pc-DZVP-MOLOPT-q1-SCAN")
@@ -135,20 +118,20 @@ class TestBasisAndPotential(PymatgenTest):
 
     def test_potentials(self):
         # Ensure cp2k formatted string can be read for data correctly
-        h_all_elec = GthPotential.from_str(ALL_HYDROGEN_STR)
+        h_all_elec = GthPotential.from_str(self.all_hydrogen_str)
         assert h_all_elec.potential == "All Electron"
-        pot = GthPotential.from_str(POT_HYDROGEN_STR)
+        pot = GthPotential.from_str(self.pot_hydrogen_str)
         assert pot.potential == "Pseudopotential"
         assert pot.r_loc == approx(0.2)
         assert pot.nexp_ppl == approx(2)
         assert_allclose(pot.c_exp_ppl, [-4.17890044, 0.72446331])
 
         # Basis file can read from strings
-        pot_file = PotentialFile.from_str(POT_HYDROGEN_STR)
+        pot_file = PotentialFile.from_str(self.pot_hydrogen_str)
         assert pot_file.objects[0] == pot
 
         pot_file_path = self.tmp_path / "potential-file"
-        pot_file_path.write_text(POT_HYDROGEN_STR)
+        pot_file_path.write_text(self.pot_hydrogen_str)
         pot_from_file = PotentialFile.from_file(pot_file_path)
         assert pot_file != pot_from_file  # unequal because pot_from_file has filename != None
 
@@ -160,11 +143,32 @@ class TestBasisAndPotential(PymatgenTest):
 
 
 class TestCp2kInput(PymatgenTest):
+    si_struct = Structure(
+        lattice=[[0, 2.734364, 2.734364], [2.734364, 0, 2.734364], [2.734364, 2.734364, 0]],
+        species=["Si", "Si"],
+        coords=[[0, 0, 0], [0.25, 0.25, 0.25]],
+    )
+
+    invalid_struct = Structure(
+        lattice=[[-1.0, -10.0, -100.0], [0.1, 0.01, 0.001], [7.0, 11.0, 21.0]],
+        species=["H"],
+        coords=[[-1, -1, -1]],
+    )
+
+    ch_mol = Molecule(species=["C", "H"], coords=[[0, 0, 0], [1, 1, 1]])
+
+    cp2k_input_str = """
+&GLOBAL
+    RUN_TYPE ENERGY
+    PROJECT_NAME CP2K ! default name
+&END
+"""
+
     def setUp(self):
         self.ci = Cp2kInput.from_file(f"{TEST_DIR}/cp2k.inp")
 
     def test_basic_sections(self):
-        cp2k_input = Cp2kInput.from_str(CP2K_INPUT_STR)
+        cp2k_input = Cp2kInput.from_str(self.cp2k_input_str)
         assert cp2k_input["GLOBAL"]["RUN_TYPE"] == Keyword("RUN_TYPE", "energy")
         assert cp2k_input["GLOBAL"]["PROJECT_NAME"].description == "default name"
         self.assert_msonable(cp2k_input)
@@ -190,13 +194,13 @@ class TestCp2kInput(PymatgenTest):
         assert "[Ha]" in kwd.get_str()
 
     def test_coords(self):
-        for struct in [nonsense_struct, si_struct, ch_mol]:
+        for struct in (self.invalid_struct, self.si_struct, self.ch_mol):
             coords = Coord(struct)
             for val in coords.keywords.values():
                 assert isinstance(val, Keyword | KeywordList)
 
     def test_kind(self):
-        for struct in [nonsense_struct, si_struct, ch_mol]:
+        for struct in (self.invalid_struct, self.si_struct, self.ch_mol):
             for spec in struct.species:
                 assert spec == Kind(spec).specie
 
@@ -246,7 +250,7 @@ class TestCp2kInput(PymatgenTest):
         assert self.ci["FORCE_EVAL"]["DFT"]["SCF"]["MAX_SCF"] == Keyword("MAX_SCF", 1)
 
     def test_mongo(self):
-        cp2k_input = Cp2kInput.from_str(CP2K_INPUT_STR)
+        cp2k_input = Cp2kInput.from_str(self.cp2k_input_str)
         cp2k_input.inc({"GLOBAL": {"TEST": 1}})
         assert cp2k_input["global"]["test"] == Keyword("TEST", 1)
 

--- a/tests/io/cp2k/test_outputs.py
+++ b/tests/io/cp2k/test_outputs.py
@@ -12,7 +12,7 @@ from pymatgen.util.testing import TEST_FILES_DIR
 TEST_DIR = f"{TEST_FILES_DIR}/io/cp2k"
 
 
-class TestSet(TestCase):
+class TestCp2kOutput(TestCase):
     def setUp(self):
         self.out = Cp2kOutput(f"{TEST_DIR}/cp2k.out", auto_load=True)
 


### PR DESCRIPTION
### Summary

- Fix usage of `strict=True` during `zip` in `cp2k.outputs`, to fix #4079
- [ ]  Add unit tests? (**need input**)
- Rename and clean up some tests 


I have to revert to `strict=False` for now, but **it's better if we could know the reason for such mismatch**. Anyone experienced with CP2K please feel free to comment.