### PR TITLE
Fix dict equality check with numpy array

### DIFF
--- a/src/pymatgen/core/sites.py
+++ b/src/pymatgen/core/sites.py
@@ -13,6 +13,7 @@ from pymatgen.core.composition import Composition
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.periodic_table import DummySpecies, Element, Species, get_el_sp
 from pymatgen.util.coord import pbc_diff
+from pymatgen.util.misc import is_np_dict_equal
 
 if TYPE_CHECKING:
     from typing import Any
@@ -96,18 +97,10 @@ class Site(collections.abc.Hashable, MSONable):
         if not isinstance(other, type(self)):
             return NotImplemented
 
-        # Some properties could be np.array, and in these cases
-        # using "==" for dict equality check would fail
-        try:
-            np.testing.assert_equal(self.properties, other.properties)
-            prop_equal = True
-        except AssertionError:
-            prop_equal = False
-
         return (
             self.species == other.species
             and np.allclose(self.coords, other.coords, atol=type(self).position_atol)
-            and prop_equal
+            and is_np_dict_equal(self.properties, other.properties)
         )
 
     def __hash__(self) -> int:
@@ -368,17 +361,11 @@ class PeriodicSite(Site, MSONable):
         if not isinstance(other, type(self)):
             return NotImplemented
 
-        try:
-            np.testing.assert_equal(self.properties, other.properties)
-            prop_equal = True
-        except AssertionError:
-            prop_equal = False
-
         return (
             self.species == other.species
             and self.lattice == other.lattice
             and np.allclose(self.coords, other.coords, atol=Site.position_atol)
-            and prop_equal
+            and is_np_dict_equal(self.properties, other.properties)
         )
 
     def __repr__(self) -> str:

--- a/src/pymatgen/core/sites.py
+++ b/src/pymatgen/core/sites.py
@@ -90,16 +90,24 @@ class Site(collections.abc.Hashable, MSONable):
 
     def __eq__(self, other: object) -> bool:
         """Site is equal to another site if the species and occupancies are the
-        same, and the coordinates are the same to some tolerance. `numpy.allclose`
+        same, and the coordinates are the same to some tolerance. `np.allclose`
         is used to determine if coordinates are close.
         """
         if not isinstance(other, type(self)):
             return NotImplemented
 
+        # Some properties could be np.array, and in these cases
+        # using "==" for dict equality check would fail
+        try:
+            np.testing.assert_equal(self.properties, other.properties)
+            prop_equal = True
+        except AssertionError:
+            prop_equal = False
+
         return (
             self.species == other.species
             and np.allclose(self.coords, other.coords, atol=type(self).position_atol)
-            and self.properties == other.properties
+            and prop_equal
         )
 
     def __hash__(self) -> int:
@@ -360,11 +368,17 @@ class PeriodicSite(Site, MSONable):
         if not isinstance(other, type(self)):
             return NotImplemented
 
+        try:
+            np.testing.assert_equal(self.properties, other.properties)
+            prop_equal = True
+        except AssertionError:
+            prop_equal = False
+
         return (
             self.species == other.species
             and self.lattice == other.lattice
             and np.allclose(self.coords, other.coords, atol=Site.position_atol)
-            and self.properties == other.properties
+            and prop_equal
         )
 
     def __repr__(self) -> str:

--- a/src/pymatgen/util/misc.py
+++ b/src/pymatgen/util/misc.py
@@ -1,0 +1,23 @@
+"""The util package implements various utilities that are commonly used by various
+packages.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def is_np_dict_equal(dict1, dict2, /) -> bool:
+    """Compare two dict whose value could be np arrays.
+
+    Args:
+        dict1 (dict): The first dict.
+        dict2 (dict): The second dict.
+
+    Returns:
+        bool: Whether these two dicts are equal.
+    """
+    if dict1.keys() != dict2.keys():
+        return False
+
+    return all(np.array_equal(dict1[key], dict2[key]) for key in dict1)

--- a/src/pymatgen/util/misc.py
+++ b/src/pymatgen/util/misc.py
@@ -1,6 +1,4 @@
-"""The util package implements various utilities that are commonly used by various
-packages.
-"""
+"""Other util functions."""
 
 from __future__ import annotations
 

--- a/tests/core/test_sites.py
+++ b/tests/core/test_sites.py
@@ -168,6 +168,20 @@ class TestPeriodicSite(PymatgenTest):
         assert self.labeled_site.label != site.label
         assert self.labeled_site == site
 
+    def test_equality_prop_with_np_array(self):
+        """Some property (e.g.g selective dynamics for POSCAR) could be numpy arrays,
+        use "==" for equality check might fail in these cases.
+        """
+        site_0 = PeriodicSite(
+            "Fe", [0.25, 0.35, 0.45], self.lattice, properties={"selective_dynamics": np.array([True, True, False])}
+        )
+        assert site_0 == site_0
+
+        site_1 = PeriodicSite(
+            "Fe", [0.25, 0.35, 0.45], self.lattice, properties={"selective_dynamics": np.array([True, False, False])}
+        )
+        assert site_0 != site_1
+
     def test_as_from_dict(self):
         dct = self.site2.as_dict()
         site = PeriodicSite.from_dict(dct)

--- a/tests/core/test_sites.py
+++ b/tests/core/test_sites.py
@@ -169,7 +169,7 @@ class TestPeriodicSite(PymatgenTest):
         assert self.labeled_site == site
 
     def test_equality_prop_with_np_array(self):
-        """Some property (e.g.g selective dynamics for POSCAR) could be numpy arrays,
+        """Some property (e.g. selective dynamics for POSCAR) could be numpy arrays,
         use "==" for equality check might fail in these cases.
         """
         site_0 = PeriodicSite(

--- a/tests/util/test_misc.py
+++ b/tests/util/test_misc.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import numpy as np
+
+from pymatgen.util.misc import is_np_dict_equal
+
+
+class TestIsNpDictEqual:
+    def test_different_keys(self):
+        """Test two dicts with different keys."""
+        dict1 = {"a": np.array([1, 2, 3])}
+        dict2 = {"a": np.array([1, 2, 3]), "b": "hello"}
+        assert not is_np_dict_equal(dict1, dict2)
+
+    def test_both_list(self):
+        """Test two dicts where both have lists as values."""
+        dict1 = {"a": [1, 2, 3]}
+        dict2 = {"a": [1, 2, 3]}
+        assert is_np_dict_equal(dict1, dict2)
+
+    def test_both_np_array(self):
+        """Test two dicts where both have NumPy arrays as values."""
+        dict1 = {"a": np.array([1, 2, 3])}
+        dict2 = {"a": np.array([1, 2, 3])}
+        assert is_np_dict_equal(dict1, dict2)
+
+    def test_one_np_one_list(self):
+        """Test two dicts where one has a NumPy array and the other has a list."""
+        dict1 = {"a": np.array([1, 2, 3])}
+        dict2 = {"a": [1, 2, 3]}
+        assert is_np_dict_equal(dict1, dict2)
+
+    def test_nested_arrays(self):
+        """Test two dicts with deeper nested arrays."""
+        dict1 = {"a": np.array([[1, 2], [3, 4]])}
+        dict2 = {"a": np.array([[1, 2], [3, 4]])}
+        assert is_np_dict_equal(dict1, dict2)
+
+        dict3 = {"a": np.array([[1, 2], [3, 5]])}
+        assert not is_np_dict_equal(dict1, dict3)

--- a/tests/util/test_misc.py
+++ b/tests/util/test_misc.py
@@ -10,7 +10,10 @@ class TestIsNpDictEqual:
         """Test two dicts with different keys."""
         dict1 = {"a": np.array([1, 2, 3])}
         dict2 = {"a": np.array([1, 2, 3]), "b": "hello"}
-        assert not is_np_dict_equal(dict1, dict2)
+        equal = is_np_dict_equal(dict1, dict2)
+        # make sure it's not a np.bool
+        assert isinstance(equal, bool)
+        assert not equal
 
     def test_both_list(self):
         """Test two dicts where both have lists as values."""


### PR DESCRIPTION
### Summary

- Fix dict equality check with numpy array, to fix #4085
- Added a helper function to compare two dicts because I have a feeling some other parts of the code might need it as well
- [x] Add unit tests
- [x] Add unit tests for new util function

### Efficiency 

Turns out  `np.testing.assert_equal` is much slower than `np.array_equal` for each value. See the following benchmark:

<details>

<summary>Script (by GPT)</summary>

```python
import numpy as np
import time

# 1. Comparison using `np.testing.assert_equal()`
def dicts_equal_np_test_assert(d1, d2):
    """Compare two dictionaries using np.testing.assert_equal."""
    try:
        np.testing.assert_equal(d1, d2)
        return True
    except AssertionError:
        return False

# 2. Comparison by using array_equal
def dicts_equal_array_equal(d1, d2):
    """Compare two dictionaries by using np.array_equal."""
    if d1.keys() != d2.keys():
        return False

    for key in d1:
        if not np.array_equal(d1[key], d2[key]):
            return False

    return True

# Helper function to average the time over 10 runs
def average_time(func, d1, d2, num_runs=10):
    total_time = 0
    for _ in range(num_runs):
        start = time.time()
        func(d1, d2)
        total_time += time.time() - start
    return total_time / num_runs

# 4. Running comparisons across array sizes
def run_comparisons(array_size):
    """Generate test dictionaries and run comparison methods."""
    # Create two identical dictionaries with numpy arrays
    arr1 = np.random.random(array_size)
    arr2 = np.copy(arr1)  # Create an identical array for comparison
    d1 = {"array": arr1}
    d2 = {"array": arr2}

    print(f"\nComparing dictionaries with array size: {array_size}")

    # 4.1. Using np.testing.assert_equal (averaged over 10 runs)
    avg_time_np_assert = average_time(dicts_equal_np_test_assert, d1, d2)
    print(f"np.testing.assert_equal: Average Time = {avg_time_np_assert * 1E6:.4f} microseconds")

    # 4.2. Using np.array_equal (averaged over 10 runs)
    avg_time_list_cast = average_time(dicts_equal_array_equal, d1, d2)
    print(f"np.array_equal: Average Time = {avg_time_list_cast * 1E6:.4f} microseconds")

if __name__ == "__main__":
    # Test with different array sizes
    for size in [1, 10, 100, 1000, 10_000]:
        run_comparisons(size)
```

</details>



```
Comparing dictionaries with array size: 1
np.testing.assert_equal: Average Time = 2419.4241 microseconds
np.array_equal: Average Time = 2.5749 microseconds

Comparing dictionaries with array size: 10
np.testing.assert_equal: Average Time = 19.1927 microseconds
np.array_equal: Average Time = 1.4067 microseconds

Comparing dictionaries with array size: 100
np.testing.assert_equal: Average Time = 19.1450 microseconds
np.array_equal: Average Time = 1.2159 microseconds

Comparing dictionaries with array size: 1000
np.testing.assert_equal: Average Time = 21.8868 microseconds
np.array_equal: Average Time = 1.5020 microseconds

Comparing dictionaries with array size: 10000
np.testing.assert_equal: Average Time = 43.8929 microseconds
np.array_equal: Average Time = 4.3869 microseconds
```
