### PR TITLE
Correctly compute rotational symmetry number for D*h point group

### DIFF
--- a/src/pymatgen/symmetry/analyzer.py
+++ b/src/pymatgen/symmetry/analyzer.py
@@ -1329,6 +1329,11 @@ class PointGroupAnalyzer:
         return generate_full_symmops(self.symmops, self.tol)
 
     def get_rotational_symmetry_number(self) -> int:
+
+        if self.sch_symbol == "D*h":
+            # Special case. H2 for example has rotational symmetry number 2
+            return 2
+
         """Get the rotational symmetry number."""
         symm_ops = self.get_symmetry_operations()
         symm_number = 0

--- a/src/pymatgen/symmetry/analyzer.py
+++ b/src/pymatgen/symmetry/analyzer.py
@@ -1334,7 +1334,6 @@ class PointGroupAnalyzer:
         Returns:
             int: Rotational symmetry number.
         """
-
         if self.sch_symbol == "D*h":
             # Special case. H2 for example has rotational symmetry number 2
             return 2

--- a/src/pymatgen/symmetry/analyzer.py
+++ b/src/pymatgen/symmetry/analyzer.py
@@ -1329,7 +1329,6 @@ class PointGroupAnalyzer:
         return generate_full_symmops(self.symmops, self.tol)
 
     def get_rotational_symmetry_number(self) -> int:
-
         if self.sch_symbol == "D*h":
             # Special case. H2 for example has rotational symmetry number 2
             return 2

--- a/src/pymatgen/symmetry/analyzer.py
+++ b/src/pymatgen/symmetry/analyzer.py
@@ -1329,6 +1329,12 @@ class PointGroupAnalyzer:
         return generate_full_symmops(self.symmops, self.tol)
 
     def get_rotational_symmetry_number(self) -> int:
+        """Get rotational symmetry number.
+
+        Returns:
+            int: Rotational symmetry number.
+        """
+
         if self.sch_symbol == "D*h":
             # Special case. H2 for example has rotational symmetry number 2
             return 2

--- a/tests/symmetry/test_analyzer.py
+++ b/tests/symmetry/test_analyzer.py
@@ -510,6 +510,7 @@ class TestPointGroupAnalyzer(PymatgenTest):
         mol = Molecule.from_file(f"{TEST_DIR}/dh.xyz")
         pg_analyzer = PointGroupAnalyzer(mol, 0.1)
         assert pg_analyzer.sch_symbol == "D*h"
+        assert pg_analyzer.get_rotational_symmetry_number() == 2
 
     def test_linear(self):
         coords = [
@@ -520,9 +521,12 @@ class TestPointGroupAnalyzer(PymatgenTest):
         mol = Molecule(["C", "H", "H"], coords)
         pg_analyzer = PointGroupAnalyzer(mol)
         assert pg_analyzer.sch_symbol == "D*h"
+        assert pg_analyzer.get_rotational_symmetry_number() == 2
+
         mol = Molecule(["C", "H", "N"], coords)
         pg_analyzer = PointGroupAnalyzer(mol)
         assert pg_analyzer.sch_symbol == "C*v"
+        assert pg_analyzer.get_rotational_symmetry_number() == 1
 
     def test_asym_top(self):
         coords = [


### PR DESCRIPTION
Correct value is 2.

Example is H2. Also see See, for example, Table 10.1 and Appendix B of C. Cramer “Essentials of Computational Chemistry”, 2nd Ed.