### PR TITLE
added ramannoodle external package to addons.md

### DIFF
--- a/docs/addons.md
+++ b/docs/addons.md
@@ -44,3 +44,4 @@ look at [pymatgen dependents](https://github.com/materialsproject/pymatgen/netwo
 * [matgl](https://github.com/materialsvirtuallab/matgl): Graph deep learning library for materials. Implements M3GNet and MEGNet in DGL and Pytorch with more to come.
 * [chgnet](https://github.com/CederGroupHub/chgnet): Pretrained universal neural network potential for charge-informed atomistic modeling.
 * [DebyeCalculator](https://github.com/FrederikLizakJohansen/DebyeCalculator): A vectorised implementation of the Debye Scattering Equation on CPU and GPU.
+* [ramannoodle](https://github.com/wolearyc/ramannoodle): Efficiently compute off-resonance Raman spectra from first principles calculations (e.g. VASP) using polynomial and ML models. 


### PR DESCRIPTION
## Summary

I'm the maintainer of [ramannoodle](https://github.com/wolearyc/ramannoodle), an new API for calculating off-resonance Raman spectra from first principles calculations. The API includes an interface with pymatgen, and I wish to add it to pymatgen's list of external packages. 

Cheers,
Willis