### PR TITLE
Ion: bugfix for CO2(aq) reduced formula

### DIFF
--- a/src/pymatgen/core/ion.py
+++ b/src/pymatgen/core/ion.py
@@ -233,7 +233,7 @@ class Ion(Composition, MSONable, Stringify):
         elif formula == "HCOO":
             formula = "HCO2"
         # oxalate
-        elif formula == "CO2":
+        elif formula == "CO2" and self.charge == -2:
             formula = "C2O4"
             factor /= 2
         # diatomic gases

--- a/tests/core/test_ion.py
+++ b/tests/core/test_ion.py
@@ -39,6 +39,8 @@ class TestIon(TestCase):
         assert Ion.from_formula("Ca++").charge == 2
         assert Ion.from_formula("Ca[++]").charge == 2
         assert Ion.from_formula("Ca2+").charge == 1
+        assert Ion.from_formula("C2O4-2").charge == -2
+        assert Ion.from_formula("CO2").charge == 0
 
         assert Ion.from_formula("Cl-").charge == -1
         assert Ion.from_formula("Cl[-]").charge == -1
@@ -70,7 +72,9 @@ class TestIon(TestCase):
             ("CH3COOH", "CH3COOH(aq)"),
             ("CH3OH", "CH3OH(aq)"),
             ("H4CO", "CH3OH(aq)"),
-            ("CO2-", "C2O4[-2]"),
+            ("C2O4--", "C2O4[-2]"),
+            ("CO2", "CO2(aq)"),
+            ("CO3--", "CO3[-2]"),
             ("CH4", "CH4(aq)"),
             ("NH4+", "NH4[+1]"),
             ("NH3", "NH3(aq)"),


### PR DESCRIPTION
My recent changes to `Ion` in #3991 introduced a problem in which the `reduced_formula` of `CO2(aq)` would incorrectly be shown as `C2O4(aq)`. Other properties such as `composition` etc were not affected.

```
>>> from pymatgen.core.ion import Ion
>>> Ion.from_formula('CO2').composition
Composition('C1 O2')
>>> Ion.from_formula('CO2').formula
'C1 O2 (aq)'
>>> Ion.from_formula('CO2').reduced_formula
'C2O4(aq)'

>>> Ion.from_formula('C2O4[-2]').composition
Composition('C2 O4')
>>> Ion.from_formula('C2O4[-2]').formula
'C2 O4 -2'
>>> Ion.from_formula('C2O4[-2]').reduced_formula
'C2O4[-2]'
```

This PR fixes the CO2(aq) problem and adds tests.