### PR TITLE
Support to aims format from Structure instance

### DIFF
--- a/src/pymatgen/core/structure.py
+++ b/src/pymatgen/core/structure.py
@@ -62,7 +62,7 @@ if TYPE_CHECKING:
 
     from pymatgen.util.typing import CompositionLike, MillerIndex, PathLike, PbcLike, SpeciesLike
 
-FileFormats = Literal["cif", "poscar", "cssr", "json", "yaml", "yml", "xsf", "mcsqs", "res", "pwmat", ""]
+FileFormats = Literal["cif", "poscar", "cssr", "json", "yaml", "yml", "xsf", "mcsqs", "res", "pwmat", "aims", ""]
 StructureSources = Literal["Materials Project", "COD"]
 
 
@@ -2847,7 +2847,8 @@ class IStructure(SiteCollection, MSONable):
             fmt (str): Format to output to. Defaults to JSON unless filename
                 is provided. If fmt is specifies, it overrides whatever the
                 filename is. Options include "cif", "poscar", "cssr", "json",
-                "xsf", "mcsqs", "prismatic", "yaml", "yml", "fleur-inpgen", "pwmat".
+                "xsf", "mcsqs", "prismatic", "yaml", "yml", "fleur-inpgen", "pwmat",
+                "aims".
                 Non-case sensitive.
             **kwargs: Kwargs passthru to relevant methods. e.g. This allows
                 the passing of parameters like symprec to the
@@ -2915,6 +2916,16 @@ class IStructure(SiteCollection, MSONable):
                 with zopen(filename, mode="wt") as file:
                     file.write(yaml_str)
             return yaml_str
+        elif fmt == "aims" or fnmatch(filename, "geometry.in"):
+            from pymatgen.io.aims.inputs import AimsGeometryIn
+
+            geom_in = AimsGeometryIn.from_structure(self)
+            if filename:
+                with zopen(filename, mode="w") as file:
+                    file.write(geom_in.get_header(filename))
+                    file.write(geom_in.content)
+                    file.write("\n")
+            return geom_in.content
         # fleur support implemented in external namespace pkg https://github.com/JuDFTteam/pymatgen-io-fleur
         elif fmt == "fleur-inpgen" or fnmatch(filename, "*.in*"):
             from pymatgen.io.fleur import FleurInput
@@ -3021,6 +3032,10 @@ class IStructure(SiteCollection, MSONable):
             from pymatgen.io.atat import Mcsqs
 
             struct = Mcsqs.structure_from_str(input_string, **kwargs)
+        elif fmt == "aims":
+            from pymatgen.io.aims.inputs import AimsGeometryIn
+
+            struct = AimsGeometryIn.from_str(input_string)
         # fleur support implemented in external namespace pkg https://github.com/JuDFTteam/pymatgen-io-fleur
         elif fmt == "fleur-inpgen":
             from pymatgen.io.fleur import FleurInput
@@ -3117,6 +3132,8 @@ class IStructure(SiteCollection, MSONable):
             from pymatgen.io.lmto import LMTOCtrl
 
             return LMTOCtrl.from_file(filename=filename, **kwargs).structure
+        elif fnmatch(fname, "geometry.in*"):
+            return cls.from_str(contents, fmt="aims", primitive=primitive, sort=sort, merge_tol=merge_tol, **kwargs)
         elif fnmatch(fname, "inp*.xml") or fnmatch(fname, "*.in*") or fnmatch(fname, "inp_*"):
             from pymatgen.io.fleur import FleurInput
 

--- a/src/pymatgen/core/structure.py
+++ b/src/pymatgen/core/structure.py
@@ -3035,7 +3035,7 @@ class IStructure(SiteCollection, MSONable):
         elif fmt == "aims":
             from pymatgen.io.aims.inputs import AimsGeometryIn
 
-            struct = AimsGeometryIn.from_str(input_string)
+            struct = AimsGeometryIn.from_str(input_string).structure
         # fleur support implemented in external namespace pkg https://github.com/JuDFTteam/pymatgen-io-fleur
         elif fmt == "fleur-inpgen":
             from pymatgen.io.fleur import FleurInput

--- a/src/pymatgen/io/aims/inputs.py
+++ b/src/pymatgen/io/aims/inputs.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import os
 import re
+import textwrap
 import time
 from copy import deepcopy
 from dataclasses import dataclass, field
@@ -183,6 +184,20 @@ class AimsGeometryIn(MSONable):
         """Access the contents of the file."""
         return self._content
 
+    def get_header(self, filename: str) -> str:
+        """A header of geometry.in file
+
+        Args:
+            filename (str): A name of the file for the header
+        """
+        return textwrap.dedent(f"""\
+        #{'=' * 72}
+        # FHI-aims geometry file: {filename}
+        # File generated from pymatgen
+        # {time.asctime()}
+        #{'=' * 72}
+        """)
+
     def write_file(self, directory: str | Path | None = None, overwrite: bool = False) -> None:
         """Write the geometry.in file.
 
@@ -191,16 +206,13 @@ class AimsGeometryIn(MSONable):
             overwrite (bool): If True allow to overwrite existing files
         """
         directory = directory or Path.cwd()
+        file_name = Path(directory) / "geometry.in"
 
-        if not overwrite and (Path(directory) / "geometry.in").exists():
+        if not overwrite and file_name.exists():
             raise ValueError(f"geometry.in file exists in {directory}")
 
         with open(f"{directory}/geometry.in", mode="w") as file:
-            file.write(f"#{'=' * 72}\n")
-            file.write(f"# FHI-aims geometry file: {directory}/geometry.in\n")
-            file.write("# File generated from pymatgen\n")
-            file.write(f"# {time.asctime()}\n")
-            file.write(f"#{'=' * 72}\n")
+            file.write(self.get_header(file_name.as_posix()))
             file.write(self.content)
             file.write("\n")
 

--- a/tests/io/aims/test_inputs.py
+++ b/tests/io/aims/test_inputs.py
@@ -51,6 +51,9 @@ def test_read_write_si_in(tmp_path: Path):
     si.structure.to(tmp_path / "si.in", fmt="aims")
     compare_files(TEST_DIR / "geometry.in.si.ref", f"{tmp_path}/si.in")
 
+    si_from_file = Structure.from_file(f"{tmp_path}/geometry.in")
+    assert all(sp.symbol == "Si" for sp in si_from_file.species)
+
     with gzip.open(f"{TEST_DIR}/si_ref.json.gz", mode="rt") as si_ref_json:
         si_from_dct = json.load(si_ref_json, cls=MontyDecoder)
 

--- a/tests/io/aims/test_inputs.py
+++ b/tests/io/aims/test_inputs.py
@@ -48,6 +48,9 @@ def test_read_write_si_in(tmp_path: Path):
 
     compare_files(TEST_DIR / "geometry.in.si.ref", f"{tmp_path}/geometry.in")
 
+    si.structure.to(tmp_path / "si.in", fmt="aims")
+    compare_files(TEST_DIR / "geometry.in.si.ref", f"{tmp_path}/si.in")
+
     with gzip.open(f"{TEST_DIR}/si_ref.json.gz", mode="rt") as si_ref_json:
         si_from_dct = json.load(si_ref_json, cls=MontyDecoder)
 


### PR DESCRIPTION
## Summary
This pull request adds support for reading and writing files in FHI-aims `geometry.in` format to the `Structure` objects.

Major changes:

- Support for reading `geometry.in` file in `Structure.from_file` and `Structure.from_str` methods
- Support for writing FHI-aims formatted file in `Structure.to` method

## Checklist

- [X] Google format doc strings added. Check with `ruff`.
- [X] Type annotations included. Check with `mypy`.
- [X] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
