### PR TITLE
Add support for `use_structure_charge` keyword in FHI-aims input generator

### DIFF
--- a/src/pymatgen/io/aims/sets/base.py
+++ b/src/pymatgen/io/aims/sets/base.py
@@ -186,10 +186,14 @@ class AimsInputGenerator(InputGenerator):
             parameters for the FHI-aims calculator
         user_kpoints_settings (dict[str, Any]):  The settings
             used to create the k-grid parameters for FHI-aims
+        use_structure_charge (bool): If set to True, then the overall charge of the
+            structure (structure.charge) is used to set the `charge` variable in the
+            `control.in`. Default is False.
     """
 
     user_params: dict[str, Any] = field(default_factory=dict)
     user_kpoints_settings: dict[str, Any] = field(default_factory=dict)
+    use_structure_charge: bool = False
 
     def get_input_set(
         self,
@@ -321,6 +325,9 @@ class AimsInputGenerator(InputGenerator):
 
         parameter_updates = self.get_parameter_updates(structure, prev_parameters)
         params = recursive_update(params, parameter_updates)
+        # Add the structure charge (useful for defect workflows)
+        if self.use_structure_charge:
+            params["charge"] = structure.charge
 
         # Override default parameters with user_params
         params = recursive_update(params, self.user_params)

--- a/tests/io/aims/sets/test_static_generator.py
+++ b/tests/io/aims/sets/test_static_generator.py
@@ -16,6 +16,17 @@ def test_static_si(tmp_path):
     comp_system(Si, parameters, "static-si", tmp_path, REF_PATH, StaticSetGenerator)
 
 
+def test_static_o2_charge(tmp_path):
+    parameters = {
+        "species_dir": "light",
+        "k_grid": [2, 2, 2],
+    }
+    Si.set_charge(1)
+    generator = StaticSetGenerator(parameters, use_structure_charge=True)
+    input_set = generator.get_input_set(Si)
+    assert "charge                             1" in input_set.control_in
+
+
 def test_static_si_no_kgrid(tmp_path):
     parameters = {"species_dir": "light"}
     Si_supercell = Si.make_supercell([1, 2, 3], in_place=False)


### PR DESCRIPTION
## Summary

This PR adds support of `use_structure_charge` keyword to a base FHI-aims input generator to make it more consistent with VASP and `atomate2` common defect workflows.

Major changes:

- support of `use_structure_charge` keyword to a base FHI-aims input generator

## Checklist

- [X] Google format doc strings added. Check with `ruff`.
- [X] Type annotations included. Check with `mypy`.
- [X] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
