### PR TITLE
Support Pymatgen Species object in aims

### DIFF
--- a/src/pymatgen/io/aims/inputs.py
+++ b/src/pymatgen/io/aims/inputs.py
@@ -20,7 +20,7 @@ from monty.io import zopen
 from monty.json import MontyDecoder, MSONable
 from monty.os.path import zpath
 
-from pymatgen.core import SETTINGS, Element, Lattice, Molecule, Species, Structure
+from pymatgen.core import SETTINGS, Element, Lattice, Molecule, Structure
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -865,15 +865,12 @@ class SpeciesDefaults(list, MSONable):
         """Initialize species defaults from a structure."""
         labels = []
         elements = {}
-        for label, el in sorted(zip(struct.labels, struct.species, strict=True)):
-            if isinstance(el, Species):
-                el = el.element
-            if (label is None) or (el is None):
-                raise ValueError("Something is terribly wrong with the structure")
-            if label not in labels:
-                labels.append(label)
-                elements[label] = el.name
-        return SpeciesDefaults(labels, basis_set, species_dir=species_dir, elements=elements)
+        for site in struct:
+            el = site.specie
+            if site.species_string not in labels:
+                labels.append(site.species_string)
+                elements[site.species_string] = el.name
+        return SpeciesDefaults(sorted(labels), basis_set, species_dir=species_dir, elements=elements)
 
     def to_dict(self):
         """Dictionary representation of the species' defaults"""

--- a/src/pymatgen/io/aims/inputs.py
+++ b/src/pymatgen/io/aims/inputs.py
@@ -164,7 +164,7 @@ class AimsGeometryIn(MSONable):
                 content_lines.append(f"     initial_charge {charge:.12e}")
             if (spin is not None) and (spin != 0):
                 content_lines.append(f"     initial_moment {spin:.12e}")
-            if any(v_i != 0.0 for v_i in v):
+            if (v is not None) and any(v_i != 0.0 for v_i in v):
                 content_lines.append(f"     velocity   {'  '.join([f'{v_i:.12e}' for v_i in v])}")
 
         return cls(_content="\n".join(content_lines), _structure=structure)

--- a/tests/io/aims/test_inputs.py
+++ b/tests/io/aims/test_inputs.py
@@ -9,7 +9,7 @@ import pytest
 from monty.json import MontyDecoder, MontyEncoder
 from numpy.testing import assert_allclose
 
-from pymatgen.core import SETTINGS, Lattice, Species, Structure
+from pymatgen.core import SETTINGS, Composition, Lattice, Species, Structure
 from pymatgen.io.aims.inputs import (
     ALLOWED_AIMS_CUBE_TYPES,
     ALLOWED_AIMS_CUBE_TYPES_STATE,
@@ -297,9 +297,9 @@ def test_species_defaults(monkeypatch: pytest.MonkeyPatch):
     ]
     assert species_defaults.elements == {"Si": "Si"}
 
-    si.relabel_sites()
+    si[0].species = Composition({"Si0+": 1}, strict=True)
     species_defaults = SpeciesDefaults.from_structure(si, "light")
-    assert species_defaults.labels == ["Si_1", "Si_2"]
-    assert species_defaults.elements == {"Si_1": "Si", "Si_2": "Si"}
-    assert "Si_1" in str(species_defaults)
-    assert "Si_2" in str(species_defaults)
+    assert species_defaults.labels == ["Si", "Si0+"]
+    assert species_defaults.elements == {"Si": "Si", "Si0+": "Si"}
+    assert "Si0+" in str(species_defaults)
+    assert "Si" in str(species_defaults)


### PR DESCRIPTION
## Summary

As of now, the basis set for the site in FHI-aims input files got chosen according to the site element. This PR enables the support of Species object when present in the structure, which should make setting up heterogeneous calculations with FHI-aims and Pymatgen easier.     

Major changes:

- Support for `species_string` in `SpeciesDefaults` class added
- Simplified creating string representation for `geometry.in` file, adding support for `species_string` there as well 
