### PR TITLE
Bugfix: Preserve PBC info in `AseAtomsAdaptor`

### DIFF
--- a/src/pymatgen/io/ase.py
+++ b/src/pymatgen/io/ase.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 from monty.json import MontyDecoder, MSONable, jsanitize
 
-from pymatgen.core.structure import Molecule, Structure
+from pymatgen.core.structure import Lattice, Molecule, Structure
 
 try:
     from ase.atoms import Atoms
@@ -103,7 +103,7 @@ class AseAtomsAdaptor:
         symbols = [str(site.specie.symbol) for site in structure]
         positions = [site.coords for site in structure]
         if hasattr(structure, "lattice"):
-            pbc = True
+            pbc = getattr(structure.lattice, "pbc", True)
             cell = structure.lattice.matrix
         else:  # Molecule without lattice
             pbc = False
@@ -284,7 +284,7 @@ class AseAtomsAdaptor:
             structure = cls(symbols, positions, properties=properties, **cls_kwargs)
         else:
             structure = cls(
-                lattice,
+                Lattice(lattice, pbc=atoms.pbc),
                 symbols,
                 positions,
                 coords_are_cartesian=True,

--- a/tests/io/test_ase.py
+++ b/tests/io/test_ase.py
@@ -318,6 +318,20 @@ def test_back_forth_v4():
 
 
 @skip_if_no_ase
+def test_back_forth_v5():
+    # Structure --> Atoms --> Structure --> Atoms
+    structure = Structure.from_file(f"{VASP_IN_DIR}/POSCAR")
+    # 2D structure; test if PBC is preserved in all conversions
+    structure.lattice.pbc = (True, True, False)
+    atoms = AseAtomsAdaptor.get_atoms(structure)
+    structure_back = AseAtomsAdaptor.get_structure(atoms)
+    atoms_back = AseAtomsAdaptor.get_atoms(structure_back)
+    assert structure_back == structure
+    for key, val in atoms.todict().items():
+        assert str(atoms_back.todict()[key]) == str(val)
+
+
+@skip_if_no_ase
 def test_msonable_atoms():
     structure = Structure.from_file(f"{VASP_IN_DIR}/POSCAR")
 


### PR DESCRIPTION
## Summary

The `get_atoms()` and `get_structure()` methods of the `pymatgen.io.ase.AseAtomsAdaptor` class now preserve PBC value of their input.

Intended to close #4120 