### PR TITLE
doc: make the test procedure explicit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,14 @@ For developers interested in expanding `pymatgen` for their own purposes, we rec
 Given that `pymatgen` is intended to be a long-term code base, we adopt very strict quality control and coding guidelines for all contributions to `pymatgen`. The following must be satisfied for your contributions to be accepted into `pymatgen`.
 
 1. **Unit tests** are required for all new modules and methods. The only way to minimize code regression is to ensure that all code is well-tested. Untested contributions will not be accepted.
+   To run the testsuite in you repository follow these steps
+
+   ```sh
+   cd path/to/repo
+   pip install -e .  # install the package in your environment as "editable" == dev package
+   PMG_TEST_FILES_DIR=$(pwd)/tests/files pytest tests  # run the test suite providing the path for the datafiles
+   ```
+
 1. **Python PEP 8** [code style](https://python.org/dev/peps/pep-0008). We allow a few exceptions when they are well-justified (e.g., Element's atomic number is given a variable name of capital Z, in line with accepted scientific convention), but generally, PEP 8 must be observed. Code style will be automatically checked for all PRs and must pass before any PR is merged. To aid you, you can install and run the same set of formatters and linters that will run in CI using
 
    ```sh


### PR DESCRIPTION
The most common usual workflow with `pytest` is just `pip install . && pytest`, but this doesn't apply to pymatgen because of the test files.
Since I had to dig (just a bit) in the sources to get `pytest` to run I figured I could help the next contributor by making it clear how to point to the files using an environment variable.