### PR TITLE
Show `FutureWarning` and `DeprecationWarning` for `pytest`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -252,7 +252,12 @@ docstring-code-format = true
 "dev_scripts/*" = ["D"]
 
 [tool.pytest.ini_options]
-addopts = "--durations=30 --quiet -r xXs --color=yes -p no:warnings --import-mode=importlib"
+addopts = "--durations=30 --quiet -r xXs --color=yes --import-mode=importlib"
+filterwarnings = [
+    "ignore::Warning",  # Ignore all warnings
+    "default::FutureWarning",  # Show FutureWarnings
+    "default::DeprecationWarning"  # Show DeprecationWarnings
+]
 
 [tool.coverage.run]
 parallel = true


### PR DESCRIPTION
### Summary

- Show `FutureWarning` and `DeprecationWarning` for `pytest`
- [ ] Fix #4112