### PR TITLE
Fixed execution of packmol in relative path.

### DIFF
--- a/tests/io/test_packmol.py
+++ b/tests/io/test_packmol.py
@@ -91,10 +91,21 @@ class TestPackmolSet(PymatgenTest):
                 {"name": "LiTFSi", "number": 20, "coords": p2},
             ],
         )
-        pw.write_input(self.tmp_path)
-        pw.run(self.tmp_path)
+        # PymatgenTest makes each test change to a temporary directory
+        # Check here we can run in the current directory
+        pw.write_input(".")
+        pw.run(".")
         assert os.path.isfile(f"{self.tmp_path}/packmol_out.xyz")
+        assert os.path.isfile(f"{self.tmp_path}/packmol.stdout")
         out = Molecule.from_file(f"{self.tmp_path}/packmol_out.xyz")
+        assert out.composition.num_atoms == 10 * 15 + 20 * 16
+        # PymatgenTest makes each test change to a temporary directory
+        # Check here we can run in a relative directory
+        pw.write_input("somedir")
+        pw.run("somedir")
+        assert os.path.isfile(f"{self.tmp_path}/somedir/packmol_out.xyz")
+        out = Molecule.from_file(f"{self.tmp_path}/somedir/packmol_out.xyz")
+        assert os.path.isfile(f"{self.tmp_path}/somedir/packmol.stdout")
         assert out.composition.num_atoms == 10 * 15 + 20 * 16
 
     def test_control_params(self):


### PR DESCRIPTION
## Summary

Major changes:

- fix 1: One could not do packmol_input_set.run("randomdirectory"). Code would fail.

This PR fixes this small issue. Added (actually adapted) a unit test to make sure it continues to work.