### PR TITLE
Added new Flag for `AutoOxiStateDecorationTransformation`

### DIFF
--- a/src/pymatgen/transformations/standard_transformations.py
+++ b/src/pymatgen/transformations/standard_transformations.py
@@ -107,6 +107,7 @@ class AutoOxiStateDecorationTransformation(AbstractTransformation):
         max_radius=4,
         max_permutations=100000,
         distance_scale_factor=1.015,
+        zeros_on_fail=False,
     ):
         """
         Args:
@@ -121,12 +122,16 @@ class AutoOxiStateDecorationTransformation(AbstractTransformation):
                 calculation-relaxed structures, which may tend to under (GGA) or
                 over bind (LDA). The default of 1.015 works for GGA. For
                 experimental structure, set this to 1.
+            zeros_on_fail (bool): If True and the BVAnalyzer fails to come up
+                with a guess for the oxidation states, we will set the all the
+                oxidation states to zero.
         """
         self.symm_tol = symm_tol
         self.max_radius = max_radius
         self.max_permutations = max_permutations
         self.distance_scale_factor = distance_scale_factor
         self.analyzer = BVAnalyzer(symm_tol, max_radius, max_permutations, distance_scale_factor)
+        self.zeros_on_fail = zeros_on_fail
 
     def apply_transformation(self, structure):
         """Apply the transformation.
@@ -137,7 +142,14 @@ class AutoOxiStateDecorationTransformation(AbstractTransformation):
         Returns:
             Oxidation state decorated Structure.
         """
-        return self.analyzer.get_oxi_state_decorated_structure(structure)
+        try:
+            return self.analyzer.get_oxi_state_decorated_structure(structure)
+        except ValueError as er:
+            if self.zeros_on_fail:
+                struct_ = structure.copy()
+                struct_.add_oxidation_state_by_site([0] * len(struct_))
+                return struct_
+            raise ValueError(f"BVAnalyzer failed with error: {er}")
 
 
 class OxidationStateRemovalTransformation(AbstractTransformation):

--- a/tests/transformations/test_standard_transformations.py
+++ b/tests/transformations/test_standard_transformations.py
@@ -200,6 +200,15 @@ class TestAutoOxiStateDecorationTransformation:
         trafo = AutoOxiStateDecorationTransformation.from_dict(dct)
         assert trafo.analyzer.dist_scale_factor == 1.015
 
+    def test_failure(self):
+        trafo_fail = AutoOxiStateDecorationTransformation()
+        trafo_no_fail = AutoOxiStateDecorationTransformation(zeros_on_fail=True)
+        struct_metal = Structure.from_spacegroup("Fm-3m", Lattice.cubic(3.677), ["Cu"], [[0, 0, 0]])
+        with pytest.raises(ValueError, match="BVAnalyzer failed with error"):
+            trafo_fail.apply_transformation(struct_metal)
+        zero_oxi_struct = trafo_no_fail.apply_transformation(struct_metal)
+        assert all(site.specie.oxi_state == 0 for site in zero_oxi_struct)
+
 
 class TestOxidationStateRemovalTransformation:
     def test_apply_transformation(self):


### PR DESCRIPTION
# New flag for `AutoOxiStateDecorationTransformation`

The situation we have in mind is `AutoOxiStateDecorationTransformation` -> `OrderDisorderedStructureTransformation` pipeline.

The `OrderDisorderedStructureTransformation` expects oxidation numbers to help rank the structure guesses.  However, if you have metallic systems, the sequences of transformation breaks.  In those cases it's not super clear how the ordered structures should be ranked anyways unless you start invoking more sqs-type logic.  For the simple case I think we can allow the users to come up with some quick and dirty guess for ordered structures so they can start computing stuff before they might move on to more fine-grained structure selection.

Added a new `zeros_on_fail` flag.
If True and and  the `BVAnalyzer` fails to come up with a guess for the oxidation guess, we will set the all the oxidation states to zero.

