### PR TITLE
Add informative error message to `SymmetryUndeterminedError`

### DIFF
--- a/src/pymatgen/symmetry/analyzer.py
+++ b/src/pymatgen/symmetry/analyzer.py
@@ -77,7 +77,7 @@ def _get_symmetry_dataset(cell, symprec, angle_tolerance):
     """
     dataset = spglib.get_symmetry_dataset(cell, symprec=symprec, angle_tolerance=angle_tolerance)
     if dataset is None:
-        raise SymmetryUndeterminedError
+        raise SymmetryUndeterminedError(spglib.get_error_message())
     return dataset
 
 


### PR DESCRIPTION
After pulling my hair out for a little while, trying to figure out why I was getting `SymmetryUndeterminedError`s when trying to initialise `SpacegroupAnalyzer` with a particular structure (which currently don't come with any message), I realised that `spglib.get_error_message()` can be called to get an error message for why no result was obtained. 
This is a small update to include the `spglib.get_error_message()` message in `SymmetryUndeterminedError`, so the user has some idea why it failed.

In action:
<img width="711" alt="image" src="https://github.com/user-attachments/assets/17ebbe2e-1571-4624-9d2a-3375eed9ff75">

<img width="741" alt="image" src="https://github.com/user-attachments/assets/f250b804-cd25-4bcb-8ab6-7d4540432a69">
