### PR TITLE
Clarify `util.string.formula_double_format` return type, fix using `int` to round to nearest int

### DIFF
--- a/src/pymatgen/util/string.py
+++ b/src/pymatgen/util/string.py
@@ -138,16 +138,16 @@ def formula_double_format(
     ignore_ones: bool = True,
     tol: float = 1e-8,
 ) -> float | str:
-    """Make pretty formulas by formatting the amounts.
+    """Format a float for pretty formulas.
     E.g. "Li1.0 Fe1.0 P1.0 O4.0" -> "LiFePO4".
 
     Args:
-        afloat (float): a float.
+        afloat (float): The float to be formatted.
         ignore_ones (bool): if true, floats of 1.0 are ignored.
-        tol (float): Absolute tolerance to round to nearest int. i.e. 2.0000000001 -> 2.
+        tol (float): Absolute tolerance to round to nearest int. i.e. (2 + 1E-9) -> 2.
 
     Returns:
-        str | float: A string representation of the float for formulas.
+        str | float: Formatted float for formulas.
     """
     if ignore_ones and math.isclose(afloat, 1, abs_tol=tol):
         return ""

--- a/src/pymatgen/util/string.py
+++ b/src/pymatgen/util/string.py
@@ -451,16 +451,16 @@ def disordered_formula(
     else:
         raise ValueError("Unsupported output format, choose from: LaTeX, HTML, plain")
 
-    disordered_formula = []
+    disordered_formulas = []
     for sp, occu in disordered_comp:
-        disordered_formula.append(sp)
+        disordered_formulas.append(sp)
         if occu:  # can be empty string if 1
             if fmt != "plain":
-                disordered_formula.append(sub_start)
-            disordered_formula.append(occu)
+                disordered_formulas.append(sub_start)
+            disordered_formulas.append(occu)
             if fmt != "plain":
-                disordered_formula.append(sub_end)
-    disordered_formula.append(" ")
-    disordered_formula += [f"{key}={formula_double_format(val)} " for key, val in variable_map.items()]
+                disordered_formulas.append(sub_end)
+    disordered_formulas.append(" ")
+    disordered_formulas += [f"{key}={formula_double_format(val)} " for key, val in variable_map.items()]
 
-    return "".join(map(str, disordered_formula))[:-1]
+    return "".join(map(str, disordered_formulas))[:-1]

--- a/src/pymatgen/util/string.py
+++ b/src/pymatgen/util/string.py
@@ -154,7 +154,7 @@ def formula_double_format(
     if ignore_ones and math.isclose(afloat, 1, abs_tol=tol):
         return ""
 
-    if math.isclose(afloat, round(afloat), abs_tol=tol):
+    if math.isclose(afloat, round(afloat), abs_tol=tol, rel_tol=0):
         return round(afloat)
     return round(afloat, 8)
 

--- a/src/pymatgen/util/string.py
+++ b/src/pymatgen/util/string.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
     from typing import Literal, TextIO
 
-    from pymatgen.core import IStructure
+    from pymatgen.core import Structure
     from pymatgen.util.typing import Vector3D
 
 SUBSCRIPT_UNICODE: dict[str, str] = {
@@ -365,7 +365,7 @@ def transformation_to_string(
 
 
 def disordered_formula(
-    disordered_struct: IStructure,  # TODO: double check type
+    disordered_struct: Structure,
     symbols: Sequence[str] = ("x", "y", "z"),
     fmt: Literal["plain", "HTML", "LaTex"] = "plain",
 ) -> str:
@@ -375,7 +375,7 @@ def disordered_formula(
     kind of disordered site at present.
 
     Args:
-        disordered_struct (IStructure): a disordered structure.
+        disordered_struct (Structure): a disordered structure.
         symbols (Sequence[str]): Characters to use for subscripts,
             by default this is ('x', 'y', 'z') but if you have more than three
             disordered species more symbols will need to be added.

--- a/src/pymatgen/util/string.py
+++ b/src/pymatgen/util/string.py
@@ -7,6 +7,7 @@ a community need.
 
 from __future__ import annotations
 
+import math
 import re
 from fractions import Fraction
 from typing import TYPE_CHECKING
@@ -143,17 +144,14 @@ def formula_double_format(
     Args:
         afloat (float): a float.
         ignore_ones (bool): if true, floats of 1.0 are ignored.
-        tol (float): Tolerance to round to nearest int. i.e. 2.0000000001 -> 2.
+        tol (float): Absolute tolerance to round to nearest int. i.e. 2.0000000001 -> 2.
 
     Returns:
         str | float: A string representation of the float for formulas.
-
-    Todo:
-        return signature doesn't agree with docstring (could return float/int).
     """
-    if ignore_ones and afloat == 1:  # TODO: this should use isclose with tol
+    if ignore_ones and math.isclose(afloat, 1, abs_tol=tol):
         return ""
-    if abs(afloat - int(afloat)) < tol:
+    if abs(afloat - int(afloat)) <= tol:
         return int(afloat)
     return round(afloat, 8)
 

--- a/src/pymatgen/util/string.py
+++ b/src/pymatgen/util/string.py
@@ -154,7 +154,7 @@ def formula_double_format(
     if ignore_ones and math.isclose(afloat, 1, abs_tol=tol):
         return ""
 
-    if abs(afloat - round(afloat)) <= tol:
+    if math.isclose(afloat, round(afloat), abs_tol=tol):
         return round(afloat)
     return round(afloat, 8)
 

--- a/src/pymatgen/util/string.py
+++ b/src/pymatgen/util/string.py
@@ -151,8 +151,9 @@ def formula_double_format(
     """
     if ignore_ones and math.isclose(afloat, 1, abs_tol=tol):
         return ""
-    if abs(afloat - int(afloat)) <= tol:
-        return int(afloat)
+
+    if abs(afloat - round(afloat)) <= tol:
+        return round(afloat)
     return round(afloat, 8)
 
 

--- a/src/pymatgen/util/string.py
+++ b/src/pymatgen/util/string.py
@@ -16,6 +16,8 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
     from typing import Any, Literal, TextIO
 
+    from numpy.typing import ArrayLike
+
     from pymatgen.core import Structure
     from pymatgen.util.typing import Vector3D
 
@@ -320,7 +322,7 @@ def stream_has_colors(stream: TextIO) -> bool:
 
 
 def transformation_to_string(
-    matrix,
+    matrix: ArrayLike,
     translation_vec: Vector3D = (0, 0, 0),
     components: tuple[str, str, str] = ("x", "y", "z"),
     c: str = "",
@@ -329,7 +331,7 @@ def transformation_to_string(
     """Convenience method. Given matrix returns string, e.g. x+2y+1/4.
 
     Args:
-        matrix: A 3x3 matrix.
+        matrix (ArrayLike): A 3x3 matrix.
         translation_vec (Vector3D): The translation vector. Defaults to (0, 0, 0).
         components(tuple[str, str, str]): The components. Either ('x', 'y', 'z') or ('a', 'b', 'c').
             Defaults to ('x', 'y', 'z').

--- a/tests/io/test_cif.py
+++ b/tests/io/test_cif.py
@@ -364,7 +364,7 @@ class TestCifIO(PymatgenTest):
         # Symbol in capital letters
         parser = CifParser(f"{TEST_FILES_DIR}/cif/Cod_2100513.cif")
         for struct in parser.parse_structures():
-            assert struct.formula == "Ca4 Nb2.0 Al2 O12"
+            assert struct.formula == "Ca4 Nb2 Al2 O12"
 
         # Label in capital letters
         parser = CifParser(f"{TEST_FILES_DIR}/cif/Cod_4115344.cif")

--- a/tests/util/test_string.py
+++ b/tests/util/test_string.py
@@ -70,10 +70,14 @@ class TestFunc:
 
     def test_formula_double_format(self):
         assert formula_double_format(1.00) == ""
+
         assert str(formula_double_format(2.00)) == "2"
-        assert str(formula_double_format(2.00 + 1e-8)) == "2"
         assert str(formula_double_format(2.10)) == "2.1"
-        assert str(formula_double_format(2.1 + 2e-9)) == "2.1"
+
+        # Test tolerance (default as 1E-8)
+        assert str(formula_double_format(2.00 + 1e-8)) == "2"
+        assert str(formula_double_format(2.00 + 2e-8)) == "2.00000002"
+        assert str(formula_double_format(2.1 + 1e-9)) == "2.1"
 
     def test_charge_string(self):
         assert charge_string(1) == "[+1]"

--- a/tests/util/test_string.py
+++ b/tests/util/test_string.py
@@ -70,9 +70,10 @@ class TestFunc:
 
     def test_formula_double_format(self):
         assert formula_double_format(1.00) == ""
-        assert formula_double_format(2.00) == 2
-        assert formula_double_format(2.10) == 2.1
-        assert formula_double_format(2.10000000002) == 2.1
+        assert str(formula_double_format(2.00)) == "2"
+        assert str(formula_double_format(2.00 + 1e-8)) == "2"
+        assert str(formula_double_format(2.10)) == "2.1"
+        assert str(formula_double_format(2.1 + 2e-9)) == "2.1"
 
     def test_charge_string(self):
         assert charge_string(1) == "[+1]"

--- a/tests/util/test_string.py
+++ b/tests/util/test_string.py
@@ -76,6 +76,7 @@ class TestFunc:
 
         # Test tolerance (default as 1E-8)
         assert str(formula_double_format(2.00 + 1e-8)) == "2"
+        assert str(formula_double_format(3.00 - 1e-9)) == "3"
         assert str(formula_double_format(2.00 + 2e-8)) == "2.00000002"
         assert str(formula_double_format(2.1 + 1e-9)) == "2.1"
 

--- a/tests/util/test_string.py
+++ b/tests/util/test_string.py
@@ -74,11 +74,14 @@ class TestFunc:
         assert str(formula_double_format(2.00)) == "2"
         assert str(formula_double_format(2.10)) == "2.1"
 
-        # Test tolerance (default as 1E-8)
+        # Test tolerance boundary
         assert str(formula_double_format(2.00 + 1e-8)) == "2"
-        assert str(formula_double_format(3.00 - 1e-9)) == "3"
-        assert str(formula_double_format(2.00 + 2e-8)) == "2.00000002"
+        assert str(formula_double_format(2.00 - 1e-8)) == "2"
+
+        # Test within tolerance
         assert str(formula_double_format(2.1 + 1e-9)) == "2.1"
+
+        assert str(formula_double_format(2.00 + 2e-8)) == "2.00000002"
 
     def test_charge_string(self):
         assert charge_string(1) == "[+1]"


### PR DESCRIPTION
### Summary

- [ ] Should `formula_double_format` return string instead of float?
- Clarify `util.string.formula_double_format` return type as `Literal[""] | float`
- Add types for `util.string`
- **Bug fix**: `int` would not round to nearest int (but truncate decimal part): https://github.com/materialsproject/pymatgen/blob/bd9fba9ec62437b5b62fbd0b2c2c723216cc5a2c/src/pymatgen/util/string.py#L136-L137
https://github.com/materialsproject/pymatgen/blob/bd9fba9ec62437b5b62fbd0b2c2c723216cc5a2c/src/pymatgen/util/string.py#L129
- **Two minor behavior changes** for `formula_double_format`:
    1. Use `isclose` to round float very close to `1`:
  ```diff
  - if ignore_ones and afloat == 1:
  + if ignore_ones and math.isclose(afloat, 1, abs_tol=tol):  
  ```
  2. `tol` now includes the boundary (unit test added):
  ```diff
  - if abs(afloat - int(afloat)) < tol:
  + if math.isclose(afloat, round(afloat), abs_tol=tol):
  ```
  
  ```python
  print(math.isclose(1, 1+1E-8, abs_tol=1E-8))  # True
  ```
