### PR TITLE
`matplotlib` test use non-interactive `agg` backend 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
 
     env:
       PMG_MAPI_KEY: ${{ secrets.PMG_MAPI_KEY }}
-      PMG_VASP_PSP_DIR: ${{ github.workspace }}/tests/files
+      MPLBACKEND: Agg  # non-interactive backend for matplotlib
 
     steps:
       - name: Check out repo
@@ -101,8 +101,6 @@ jobs:
           echo "$(realpath vampire-5.0/)" >> $GITHUB_PATH
 
       - name: pytest split ${{ matrix.split }}
-        env:
-          MPLBACKEND: Agg
         run: |
           micromamba activate pmg
           pytest --splits 10 --group ${{ matrix.split }} --durations-path tests/files/.pytest-split-durations tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,6 +101,8 @@ jobs:
           echo "$(realpath vampire-5.0/)" >> $GITHUB_PATH
 
       - name: pytest split ${{ matrix.split }}
+        env:
+          MPLBACKEND: Agg
         run: |
           micromamba activate pmg
           pytest --splits 10 --group ${{ matrix.split }} --durations-path tests/files/.pytest-split-durations tests


### PR DESCRIPTION
### Summary

- I don't think we need `PMG_VASP_PSP_DIR` in editable mode
- [`matplotlib` test use non-interactive `agg` backend](https://matplotlib.org/stable/users/explain/figure/backends.html), as the [tk install for github windows runner seems pretty flaky](https://github.com/matplotlib/matplotlib/issues/29119#issuecomment-2469406065)
> The last, Agg, is a non-interactive backend that can only write to files. It is used on Linux, if Matplotlib cannot connect to either an X display or a Wayland display.

> The names of builtin backends are case-insensitive; e.g., 'QtAgg' and 'qtagg' are equivalent.


The tk backend might [emit intermittent failures](https://github.com/materialsproject/pymatgen/actions/runs/11771540044/job/32785607964?pr=4159) like:
```
>       self.tk = _tkinter.create(screenName, baseName, className, interactive, wantobjects, useTk, sync, use)
E       _tkinter.TclError: invalid command name "tcl_findLibrary"
```

[Or](https://github.com/materialsproject/pymatgen/actions/runs/11793603996/job/32849482132?pr=4164):
```
>       self.tk = _tkinter.create(screenName, baseName, className, interactive, wantobjects, useTk, sync, use)
E       _tkinter.TclError: Can't find a usable init.tcl in the following directories: 
E           C:/Users/runneradmin/micromamba/envs/pmg/Library/lib/tcl8.6 C:/Users/runneradmin/micromamba/envs/lib/tcl8.6 C:/Users/runneradmin/micromamba/lib/tcl8.6 C:/Users/runneradmin/micromamba/envs/library C:/Users/runneradmin/micromamba/library C:/Users/runneradmin/micromamba/tcl8.6.13/library C:/Users/runneradmin/tcl8.6.13/library
E       
E       C:/Users/runneradmin/micromamba/envs/pmg/Library/lib/tcl8.6/init.tcl: couldn't read file "C:/Users/runneradmin/micromamba/envs/pmg/Library/lib/tcl8.6/init.tcl": No error
E       couldn't read file "C:/Users/runneradmin/micromamba/envs/pmg/Library/lib/tcl8.6/init.tcl": No error
E           while executing
E       "source C:/Users/runneradmin/micromamba/envs/pmg/Library/lib/tcl8.6/init.tcl"
E           ("uplevel" body line 1)
E           invoked from within
E       "uplevel #0 [list source $tclfile]"
E       
E       
E       This probably means that Tcl wasn't installed properly.
```