### PR TITLE
Change XAS behavior under negative frequencies

### DIFF
--- a/src/pymatgen/analysis/xas/spectrum.py
+++ b/src/pymatgen/analysis/xas/spectrum.py
@@ -10,11 +10,13 @@ import numpy as np
 from scipy.interpolate import interp1d
 
 from pymatgen.analysis.structure_matcher import StructureMatcher
+from pymatgen.core import Element
 from pymatgen.core.spectrum import Spectrum
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 
 if TYPE_CHECKING:
-    from typing import Literal, Sequence
+    from collections.abc import Sequence
+    from typing import Literal
 
     from pymatgen.core import Structure
 
@@ -44,7 +46,7 @@ class XAS(Spectrum):
     Attributes:
         x (Sequence[float]): The sequence of energies.
         y (Sequence[float]): The sequence of mu(E).
-        absorbing_element (str): The absorbing element of the spectrum.
+        absorbing_element (str or .Element): The absorbing element of the spectrum.
         edge (str): The edge of the spectrum.
         spectrum_type (str): The type of the spectrum (XANES or EXAFS).
         absorbing_index (int): The absorbing index of the spectrum.
@@ -56,19 +58,19 @@ class XAS(Spectrum):
 
     def __init__(
         self,
-        x : Sequence,
-        y : Sequence,
-        structure : Structure,
-        absorbing_element : str,
-        edge : str = "K",
-        spectrum_type : str = "XANES",
-        absorbing_index : int = None,
-        zero_negative_intensity : bool = False,
+        x: Sequence,
+        y: Sequence,
+        structure: Structure,
+        absorbing_element: str | Element,
+        edge: str = "K",
+        spectrum_type: str = "XANES",
+        absorbing_index: int | None = None,
+        zero_negative_intensity: bool = False,
     ):
         """Initialize a spectrum object."""
         super().__init__(x, y, structure, absorbing_element, edge)
         self.structure = structure
-        self.absorbing_element = absorbing_element
+        self.absorbing_element = Element(absorbing_element)
         self.edge = edge
         self.spectrum_type = spectrum_type
         self.e0 = self.x[np.argmax(np.gradient(self.y) / np.gradient(self.x))]
@@ -79,7 +81,7 @@ class XAS(Spectrum):
         ]
         self.absorbing_index = absorbing_index
         # check for empty spectra and negative intensities
-        neg_intens_mask = self.y < 0.
+        neg_intens_mask = self.y < 0.0
         if len(self.y[neg_intens_mask]) / len(self.y) > 0.05:
             warnings.warn(
                 "Double check the intensities. More than 5% of them are negative.",
@@ -88,7 +90,7 @@ class XAS(Spectrum):
             )
         self.zero_negative_intensity = zero_negative_intensity
         if self.zero_negative_intensity:
-            self.y[neg_intens_mask] = 0.
+            self.y[neg_intens_mask] = 0.0
 
     def __str__(self):
         return (

--- a/tests/analysis/xas/test_spectrum.py
+++ b/tests/analysis/xas/test_spectrum.py
@@ -67,10 +67,10 @@ class TestXAS(PymatgenTest):
         assert str(self.k_xanes) == "Co K Edge XANES for LiCoO2: <super: <class 'XAS'>, <XAS object>>"
 
     def test_validate(self):
-        y_zeros = np.zeros(len(self.k_xanes.x))
-        with pytest.raises(
-            ValueError,
-            match="Double check the intensities. Most of them are non-positive",
+        y_zeros = -np.ones(len(self.k_xanes.x))
+        with pytest.warns(
+            UserWarning,
+            match="Double check the intensities. More than 5% of them are negative.",
         ):
             XAS(
                 self.k_xanes.x,
@@ -78,6 +78,17 @@ class TestXAS(PymatgenTest):
                 self.k_xanes.structure,
                 self.k_xanes.absorbing_element,
             )
+
+    def test_zero_negative_intensity(self):
+        y_w_neg_intens = [(-1)**i * v for i, v in enumerate(self.k_xanes.y)]
+        spectrum = XAS(
+                self.k_xanes.x,
+                y_w_neg_intens,
+                self.k_xanes.structure,
+                self.k_xanes.absorbing_element,
+                zero_negative_intensity = True
+            )
+        assert all(v == 0. for i, v in enumerate(spectrum.y) if i % 2 == 1)
 
     def test_stitch_xafs(self):
         with pytest.raises(ValueError, match="Invalid mode. Only XAFS and L23 are supported"):

--- a/tests/analysis/xas/test_spectrum.py
+++ b/tests/analysis/xas/test_spectrum.py
@@ -80,15 +80,15 @@ class TestXAS(PymatgenTest):
             )
 
     def test_zero_negative_intensity(self):
-        y_w_neg_intens = [(-1)**i * v for i, v in enumerate(self.k_xanes.y)]
+        y_w_neg_intens = [(-1) ** i * v for i, v in enumerate(self.k_xanes.y)]
         spectrum = XAS(
-                self.k_xanes.x,
-                y_w_neg_intens,
-                self.k_xanes.structure,
-                self.k_xanes.absorbing_element,
-                zero_negative_intensity = True
-            )
-        assert all(v == 0. for i, v in enumerate(spectrum.y) if i % 2 == 1)
+            self.k_xanes.x,
+            y_w_neg_intens,
+            self.k_xanes.structure,
+            self.k_xanes.absorbing_element,
+            zero_negative_intensity=True,
+        )
+        assert all(v == 0.0 for i, v in enumerate(spectrum.y) if i % 2 == 1)
 
     def test_stitch_xafs(self):
         with pytest.raises(ValueError, match="Invalid mode. Only XAFS and L23 are supported"):


### PR DESCRIPTION
The XAS spectrum class used to not throw a `ValueError` when more than 5% of the user-input intensities are non-positive (cverified this was still the behavior as of v2020.4.29).  More, the warning that is thrown is misleading, as it suggests that the majority of intensities are non-positive.

This change in behavior has led to issues with MP's API users, see [here for an example](https://matsci.org/t/avoiding-value-error-double-check-the-intensities-most-of-them-are-nonpositive/58748/2)

Changed this to throw a warning only when more than 5% of the intensities are ***negative***. Zero intensity shouldn't be penalized since this is physical (there's no absorption in that range, e.g. if a transition is forbidden)

Also added an option to zero out negative intensities (false by default)