### PR TITLE
Moved NUPDOWN from int_keys to float_keys

### DIFF
--- a/src/pymatgen/io/vasp/inputs.py
+++ b/src/pymatgen/io/vasp/inputs.py
@@ -970,6 +970,7 @@ class Incar(UserDict, MSONable):
             "PARAM1",
             "PARAM2",
             "ENCUT",
+            "NUPDOWN",
         )
         int_keys = (
             "NSW",
@@ -987,7 +988,6 @@ class Incar(UserDict, MSONable):
             "LMAXMIX",
             "NSIM",
             "NKRED",
-            "NUPDOWN",
             "ISPIND",
             "LDAUTYPE",
             "IVDW",


### PR DESCRIPTION
## Summary
`NUPDOWN` key in Incar can be set to floating point values in VASP (see https://gitlab.com/ase/ase/-/merge_requests/2580). 
However, it is current treated as an int in `Incar.proc_val`. 

This PR treats `NUPDOWN` as a float instead.


- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [x] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

