### PR TITLE
Compositions from weight str

### DIFF
--- a/src/pymatgen/core/composition.py
+++ b/src/pymatgen/core/composition.py
@@ -670,7 +670,13 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
             **kwargs: Additional kwargs supported by the dict() constructor.
 
         Returns:
-            Composition
+            Composition in molar fractions.
+
+        Examples:
+            >>> Composition.from_weights("Fe50Ti50")
+            Composition('Fe0.461538 Ti0.538462')
+            >>> Composition.from_weights({"Fe": 0.5, "Ni": 0.5})
+            Composition('Fe0.512434 Ni0.487566')
         """
         if len(args) == 1 and isinstance(args[0], str):
             elem_map: dict[str, float] = cls._parse_formula(args[0])

--- a/src/pymatgen/core/composition.py
+++ b/src/pymatgen/core/composition.py
@@ -652,7 +652,13 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
             **kwargs: Additional kwargs supported by the dict() constructor.
 
         Returns:
-            Composition
+            Composition in molar fractions.
+
+        Examples:
+            >>> Composition.from_weights({"Fe": 0.5, "Ni": 0.5})
+            Composition('Fe0.512434 Ni0.487566')
+            >>> Composition.from_weights({"Ti": 60, "Ni": 40})
+            Composition('Ti0.647796 Ni0.352204')
         """
         weight_sum = sum(val / Element(el).atomic_mass for el, val in weight_dict.items())
         comp_dict = {el: val / Element(el).atomic_mass / weight_sum for el, val in weight_dict.items()}

--- a/tests/core/test_composition.py
+++ b/tests/core/test_composition.py
@@ -903,9 +903,3 @@ class TestChemicalPotential:
         # test nested brackets with charge
         comp = Composition("[N[Fe]2]2")
         assert str(comp) == "N2 Fe4"
-
-
-if __name__ == "__main__":
-    import pytest
-
-    pytest.main([__file__])

--- a/tests/core/test_composition.py
+++ b/tests/core/test_composition.py
@@ -426,6 +426,42 @@ class TestComposition(PymatgenTest):
             c2 = Composition().from_weight_dict(comp.to_weight_dict)
             comp.almost_equals(c2)
 
+    def test_composition_from_weights(self):
+        ref_comp = Composition({"Fe": 0.5, "Ni": 0.5})
+
+        # Test basic weight-based composition
+        comp = Composition.from_weights({"Fe": ref_comp.get_wt_fraction("Fe"), "Ni": ref_comp.get_wt_fraction("Ni")})
+        assert comp["Fe"] == approx(ref_comp.get_atomic_fraction("Fe"))
+        assert comp["Ni"] == approx(ref_comp.get_atomic_fraction("Ni"))
+
+        # Test with another Composition instance
+        comp = Composition({"Fe": ref_comp.get_wt_fraction("Fe"), "Ni": ref_comp.get_wt_fraction("Ni")})
+        comp = Composition.from_weights(comp)
+        assert comp["Fe"] == approx(ref_comp.get_atomic_fraction("Fe"))
+        assert comp["Ni"] == approx(ref_comp.get_atomic_fraction("Ni"))
+
+        # Test with string input
+        comp = Composition.from_weights(f"Fe{ref_comp.get_wt_fraction('Fe')}Ni{ref_comp.get_wt_fraction('Ni')}")
+        assert comp["Fe"] == approx(ref_comp.get_atomic_fraction("Fe"))
+        assert comp["Ni"] == approx(ref_comp.get_atomic_fraction("Ni"))
+
+        # Test with kwargs
+        comp = Composition.from_weights(Fe=ref_comp.get_wt_fraction("Fe"), Ni=ref_comp.get_wt_fraction("Ni"))
+        assert comp["Fe"] == approx(ref_comp.get_atomic_fraction("Fe"))
+        assert comp["Ni"] == approx(ref_comp.get_atomic_fraction("Ni"))
+
+        # Test strict mode
+        with pytest.raises(ValueError, match="'Xx' is not a valid Element"):
+            Composition.from_weights({"Xx": 10}, strict=True)
+
+        # Test allow_negative
+        with pytest.raises(ValueError, match="Weights in Composition cannot be negative!"):
+            Composition.from_weights({"Fe": -55.845})
+
+        # Test NaN handling
+        with pytest.raises(ValueError, match=r"float\('NaN'\) is not a valid Composition"):
+            Composition.from_weights(float("nan"))
+
     def test_as_dict(self):
         comp = Composition.from_dict({"Fe": 4, "O": 6})
         dct = comp.as_dict()
@@ -867,3 +903,9 @@ class TestChemicalPotential:
         # test nested brackets with charge
         comp = Composition("[N[Fe]2]2")
         assert str(comp) == "N2 Fe4"
+
+
+if __name__ == "__main__":
+    import pytest
+
+    pytest.main([__file__])


### PR DESCRIPTION
Often in alloy literature we get composition strings given in weight rather than molar quantities. This PR extends upon the `from_weight_dict` method to give a more general `from_weights` method that will take strings as well as CompositionLike