### PR TITLE
Addition of "valences" property to ElementBase and Species for mixed-valence ions

### DIFF
--- a/src/pymatgen/core/periodic_table.py
+++ b/src/pymatgen/core/periodic_table.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 
     from pymatgen.util.typing import SpeciesLike
 
+
 # Load element data from JSON file
 with open(Path(__file__).absolute().parent / "periodic_table.json", encoding="utf-8") as ptable_json:
     _pt_data = json.load(ptable_json)
@@ -61,76 +62,71 @@ _madelung = [
 @functools.total_ordering
 @unique
 class ElementBase(Enum):
-    """Element class defined without any enum values so it can be subclassed."""
+    """Element class defined without any enum values so it can be subclassed.
+
+    This class is needed to get nested (as|from)_dict to work properly. All emmet classes that had
+    Element classes required custom construction whereas this definition behaves more like dataclasses
+    so serialization is less troublesome. There were many times where objects in as_dict serialized
+    only when they were top level. See https://github.com/materialsproject/pymatgen/issues/2999.
+    """
 
     def __init__(self, symbol: SpeciesLike) -> None:
-        """
-        This class provides a basic, immutable representation of an element, including
-        all relevant chemical and physical properties. It ensures that elements are
-        handled as singletons, reducing redundancy and improving efficiency. Missing
-        data is represented by `None` unless otherwise specified.
+        """Basic immutable element object with all relevant properties.
+
+        Only one instance of Element for each symbol is stored after creation,
+        ensuring that a particular element behaves like a singleton. For all
+        attributes, missing data (i.e., data for which is not available) is
+        represented by a None unless otherwise stated.
+
+        Args:
+            symbol (str): Element symbol, e.g. "H", "Fe"
 
         Attributes:
-            Z (int): Atomic number of the element.
-            symbol (str): Element symbol (e.g., "H", "Fe").
-            long_name (str): Full name of the element (e.g., "Hydrogen").
-            A (int, optional): Atomic mass number (sum of protons and neutrons).
-            atomic_radius_calculated (float, optional): Calculated atomic radius (Å).
-            van_der_waals_radius (float, optional): Van der Waals radius (Å).
-            mendeleev_no (int, optional): Mendeleev number based on crystal-structure maps.
-            electrical_resistivity (float, optional): Electrical resistivity (Ω·m).
-            velocity_of_sound (float, optional): Velocity of sound (m/s).
-            reflectivity (float, optional): Reflectivity (%).
-            refractive_index (float, optional): Refractive index.
-            poissons_ratio (float, optional): Poisson's ratio.
-            molar_volume (float, optional): Molar volume (cm³/mol).
-            electronic_structure (str): Electronic structure (e.g., "[Ar].3d6.4s2").
-            atomic_orbitals (dict): Orbital energies (Hartree units).
-            atomic_orbitals_eV (dict): Orbital energies in electron volts (eV).
-            thermal_conductivity (float, optional): Thermal conductivity (W/m·K).
-            boiling_point (float, optional): Boiling point (K).
-            melting_point (float, optional): Melting point (K).
-            critical_temperature (float, optional): Critical temperature (K).
-            superconduction_temperature (float, optional): Superconducting transition temperature (K).
-            liquid_range (float, optional): Temperature range for liquid phase (K).
-            bulk_modulus (float, optional): Bulk modulus (GPa).
-            youngs_modulus (float, optional): Young's modulus (GPa).
-            brinell_hardness (float, optional): Brinell hardness (MPa).
-            rigidity_modulus (float, optional): Rigidity modulus (GPa).
-            mineral_hardness (float, optional): Mohs hardness.
-            vickers_hardness (float, optional): Vickers hardness (MPa).
-            density_of_solid (float, optional): Density in solid phase (g/cm³).
-            coefficient_of_linear_thermal_expansion (float, optional): Thermal expansion coefficient (K⁻¹).
-            ground_level (float, optional): Ground energy level of the element.
-            ionization_energies (list[Optional[float]]): Ionization energies (kJ/mol), indexed from 0.
-
-        Examples:
-            Create an element instance and access its properties:
-                >>> hydrogen = Element("H")
-                >>> hydrogen.symbol
-                'H'
-                >>> hydrogen.Z
-                1
-                >>> hydrogen.electronic_structure
-                '1s1'
-
-            Access additional attributes such as atomic radius:
-                >>> hydrogen.atomic_radius_calculated
-                0.53
-
-        Notes:
-            - This class supports handling of isotopes by incorporating named isotopes
-            and their respective properties.
-            - Attributes are populated using a JSON file that stores data about all
-            known elements.
-            - Some attributes are calculated or derived based on predefined constants
-            and rules.
-
-        References:
-            - Atomic radius data: https://wikipedia.org/wiki/Atomic_radii_of_the_elements_(data_page)
-            - Van der Waals radius: CRC Handbook of Chemistry and Physics, 91st Ed.
-            - Mendeleev number: D. G. Pettifor, "A chemical scale for crystal-structure maps,"
-            Solid State Communications, 1984.
+            Z (int): Atomic number.
+            symbol (str): Element symbol.
+            long_name (str): Long name for element. e.g. "Hydrogen".
+            A (int) : Atomic mass number (number of protons plus neutrons).
+            atomic_radius_calculated (float): Calculated atomic radius for the element. This is the empirical value.
+                Data is obtained from https://wikipedia.org/wiki/Atomic_radii_of_the_elements_(data_page).
+            van_der_waals_radius (float): Van der Waals radius for the element. This is the empirical value determined
+                from critical reviews of X-ray diffraction, gas kinetic collision cross-section, and other experimental
+                data by Bondi and later workers. The uncertainty in these values is on the order of 0.1 Å.
+                Data are obtained from "Atomic Radii of the Elements" in CRC Handbook of Chemistry and Physics,
+                91st Ed.; Haynes, W.M., Ed.; CRC Press: Boca Raton, FL, 2010.
+            mendeleev_no (int): Mendeleev number from definition given by Pettifor, D. G. (1984). A chemical scale
+                for crystal-structure maps. Solid State Communications, 51 (1), 31-34.
+            electrical_resistivity (float): Electrical resistivity.
+            velocity_of_sound (float): Velocity of sound.
+            reflectivity (float): Reflectivity.
+            refractive_index (float): Refractive index.
+            poissons_ratio (float): Poisson's ratio.
+            molar_volume (float): Molar volume.
+            electronic_structure (str): Electronic structure. e.g. The electronic structure for Fe is represented
+                as [Ar].3d6.4s2.
+            atomic_orbitals (dict): Atomic Orbitals. Energy of the atomic orbitals as a dict. e.g. The orbitals
+                energies in Hartree are represented as {'1s': -1.0, '2s': -0.1}. Data is obtained from
+                https://www.nist.gov/pml/data/atomic-reference-data-electronic-structure-calculations.
+                The LDA values for neutral atoms are used.
+            atomic_orbitals_eV (dict): Atomic Orbitals. Same as `atomic_orbitals` but energies are in eV.
+            thermal_conductivity (float): Thermal conductivity.
+            boiling_point (float): Boiling point.
+            melting_point (float): Melting point.
+            critical_temperature (float): Critical temperature.
+            superconduction_temperature (float): Superconduction temperature.
+            liquid_range (float): Liquid range.
+            bulk_modulus (float): Bulk modulus.
+            youngs_modulus (float): Young's modulus.
+            brinell_hardness (float): Brinell hardness.
+            rigidity_modulus (float): Rigidity modulus.
+            mineral_hardness (float): Mineral hardness.
+            vickers_hardness (float): Vicker's hardness.
+            density_of_solid (float): Density of solid phase.
+            coefficient_of_linear_thermal_expansion (float): Coefficient of linear thermal expansion.
+            ground_level (float): Ground level for element.
+            ionization_energies (list[Optional[float]]): List of ionization energies. First value is the first
+                ionization energy, second is the second ionization energy, etc. Note that this is zero-based indexing!
+                So Element.ionization_energies[0] refer to the 1st ionization energy. Values are from the NIST Atomic
+                Spectra Database. Missing values are None.
         """
         self.symbol = str(symbol)
         data = _pt_data[symbol]
@@ -209,7 +205,8 @@ class ElementBase(Enum):
             if val is None or str(val).startswith("no data"):
                 warnings.warn(f"No data available for {item} for {self.symbol}")
                 val = None
-            elif isinstance(val, list | dict):
+            # elif isinstance(val, dict | list):
+            elif type(val) in [list, dict]:  # pre-commit fix
                 pass
             else:
                 try:
@@ -480,28 +477,35 @@ class ElementBase(Enum):
         return sum(t[-1] for t in self.full_electronic_structure)
 
     @property
-    def valence(self) -> tuple[int | np.nan, int]:
+    def valences(self) -> list[tuple[int | np.nan, int]]:
         """Valence subshell angular moment (L) and number of valence e- (v_e),
         obtained from full electron config, where L=0, 1, 2, or 3 for s, p, d,
         and f orbitals, respectively.
         """
         if self.group == 18:
-            return np.nan, 0  # The number of valence of noble gas is 0
+            return [(np.nan, 0)]  # The number of valence of noble gas is 0
 
         L_symbols = "SPDFGHIKLMNOQRTUVWXYZ"
-        valence: list[tuple[int, int]] = []
+        valences: list[tuple[int | np.nan, int]] = []
         full_electron_config = self.full_electronic_structure
         last_orbital = full_electron_config[-1]
         for n, l_symbol, ne in full_electron_config:
             idx = L_symbols.lower().index(l_symbol)
             if ne < (2 * idx + 1) * 2 or (
-                (n, l_symbol, ne) == last_orbital and ne == (2 * idx + 1) * 2 and len(valence) == 0
+                (n, l_symbol, ne) == last_orbital and ne == (2 * idx + 1) * 2 and len(valences) == 0
             ):  # check for full last shell (e.g. column 2)
-                valence.append((idx, ne))
-        if len(valence) > 1:
-            raise ValueError(f"{self} has ambiguous valence")
+                valences.append((idx, ne))
+        return valences
 
-        return valence[0]
+    @property
+    def valence(self) -> tuple[int | np.nan, int]:
+        """Valence subshell angular moment (L) and number of valence e- (v_e),
+        obtained from full electron config, where L=0, 1, 2, or 3 for s, p, d,
+        and f orbitals, respectively.
+        """
+        if len(self.valences) > 1:
+            raise ValueError(f"{self} has ambiguous valence")
+        return self.valences[0]
 
     @property
     def term_symbols(self) -> list[list[str]]:
@@ -528,7 +532,8 @@ class ElementBase(Enum):
         # Total ML = sum(ml1, ml2), Total MS = sum(ms1, ms2)
         TL = [sum(ml_ms[comb[e]][0] for e in range(v_e)) for comb in e_config_combs]
         TS = [sum(ml_ms[comb[e]][1] for e in range(v_e)) for comb in e_config_combs]
-        comb_counter = Counter(zip(TL, TS, strict=True))
+        # comb_counter: Counter = Counter(zip(TL, TS, strict=True))
+        comb_counter: Counter = Counter([(TL[i], TS[i]) for i in range(len(TL))])  # pre-commit edit
 
         term_symbols = []
         L_symbols = "SPDFGHIKLMNOQRTUVWXYZ"
@@ -1194,28 +1199,35 @@ class Species(MSONable, Stringify):
     # NOTE - copied exactly from Element. Refactoring / inheritance may improve
     # robustness
     @property
-    def valence(self) -> tuple[int | np.nan, int]:
-        """Valence subshell angular moment (L) and number of valence e- (v_e),
+    def valences(self) -> list[tuple[int | np.nan, int]]:
+        """List of valence subshell angular moment (L) and number of valence e- (v_e),
         obtained from full electron config, where L=0, 1, 2, or 3 for s, p, d,
         and f orbitals, respectively.
         """
         if self.group == 18:
-            return np.nan, 0  # The number of valence of noble gas is 0
+            return [(np.nan, 0)]  # The number of valence of noble gas is 0
 
         L_symbols = "SPDFGHIKLMNOQRTUVWXYZ"
-        valence: list[tuple[int, int]] = []
+        valences: list[tuple[int | np.nan, int]] = []
         full_electron_config = self.full_electronic_structure
         last_orbital = full_electron_config[-1]
         for n, l_symbol, ne in full_electron_config:
             idx = L_symbols.lower().index(l_symbol)
             if ne < (2 * idx + 1) * 2 or (
-                (n, l_symbol, ne) == last_orbital and ne == (2 * idx + 1) * 2 and len(valence) == 0
+                (n, l_symbol, ne) == last_orbital and ne == (2 * idx + 1) * 2 and len(valences) == 0
             ):  # check for full last shell (e.g. column 2)
-                valence.append((idx, ne))
-        if len(valence) > 1:
-            raise ValueError(f"{self} has ambiguous valence")
+                valences.append((idx, ne))
+        return valences
 
-        return valence[0]
+    @property
+    def valence(self) -> tuple[int | np.nan, int]:
+        """Valence subshell angular moment (L) and number of valence e- (v_e),
+        obtained from full electron config, where L=0, 1, 2, or 3 for s, p, d,
+        and f orbitals, respectively.
+        """
+        if len(self.valences) > 1:
+            raise ValueError(f"{self} has ambiguous valence")
+        return self.valences[0]
 
     @property
     def ionic_radius(self) -> float | None:
@@ -1644,9 +1656,18 @@ def get_el_sp(obj: int | SpeciesLike) -> Element | Species | DummySpecies:
             of properties that can be determined.
     """
     # If obj is already an Element or Species, return as is
-    if isinstance(obj, Element | Species | DummySpecies):
-        if getattr(obj, "_is_named_isotope", False):
-            return Element(obj.name) if isinstance(obj, Element) else Species(str(obj))
+    # TODO: Why do we need to check "_is_named_isotope"?
+    if isinstance(obj, Element):
+        if getattr(obj, "_is_named_isotope", None):
+            return Element(obj.name)
+        return obj
+    if isinstance(obj, Species):
+        if getattr(obj, "_is_named_isotope", None):
+            return Species(str(obj))
+        return obj
+    if isinstance(obj, Species):
+        if getattr(obj, "_is_named_isotope", None):
+            return Species(str(obj))
         return obj
 
     # If obj is an integer, return the Element with atomic number obj

--- a/src/pymatgen/core/periodic_table.py
+++ b/src/pymatgen/core/periodic_table.py
@@ -495,9 +495,11 @@ class ElementBase(Enum):
         last_orbital = full_electron_config[-1]
         for n, l_symbol, ne in full_electron_config:
             idx = L_symbols.lower().index(l_symbol)
-            if ne < (2 * idx + 1) * 2 or (
+            partially_filled_orbital = ne < (2 * idx + 1) * 2
+            filled_valence_orbital = (
                 (n, l_symbol, ne) == last_orbital and ne == (2 * idx + 1) * 2 and len(valences) == 0
-            ):  # check for full last shell (e.g. column 2)
+            )
+            if partially_filled_orbital or filled_valence_orbital:  # check for full last shell (e.g. column 2)
                 valences.append((idx, ne))
         return valences
 
@@ -1216,9 +1218,11 @@ class Species(MSONable, Stringify):
         last_orbital = full_electron_config[-1]
         for n, l_symbol, ne in full_electron_config:
             idx = L_symbols.lower().index(l_symbol)
-            if ne < (2 * idx + 1) * 2 or (
+            partially_filled_orbital = ne < (2 * idx + 1) * 2
+            filled_valence_orbital = (
                 (n, l_symbol, ne) == last_orbital and ne == (2 * idx + 1) * 2 and len(valences) == 0
-            ):  # check for full last shell (e.g. column 2)
+            )
+            if partially_filled_orbital or filled_valence_orbital:  # check for full last shell (e.g. column 2)
                 valences.append((idx, ne))
         return valences
 

--- a/src/pymatgen/core/periodic_table.py
+++ b/src/pymatgen/core/periodic_table.py
@@ -62,71 +62,76 @@ _madelung = [
 @functools.total_ordering
 @unique
 class ElementBase(Enum):
-    """Element class defined without any enum values so it can be subclassed.
-
-    This class is needed to get nested (as|from)_dict to work properly. All emmet classes that had
-    Element classes required custom construction whereas this definition behaves more like dataclasses
-    so serialization is less troublesome. There were many times where objects in as_dict serialized
-    only when they were top level. See https://github.com/materialsproject/pymatgen/issues/2999.
-    """
+    """Element class defined without any enum values so it can be subclassed."""
 
     def __init__(self, symbol: SpeciesLike) -> None:
-        """Basic immutable element object with all relevant properties.
-
-        Only one instance of Element for each symbol is stored after creation,
-        ensuring that a particular element behaves like a singleton. For all
-        attributes, missing data (i.e., data for which is not available) is
-        represented by a None unless otherwise stated.
-
-        Args:
-            symbol (str): Element symbol, e.g. "H", "Fe"
+        """
+        This class provides a basic, immutable representation of an element, including
+        all relevant chemical and physical properties. It ensures that elements are
+        handled as singletons, reducing redundancy and improving efficiency. Missing
+        data is represented by `None` unless otherwise specified.
 
         Attributes:
-            Z (int): Atomic number.
-            symbol (str): Element symbol.
-            long_name (str): Long name for element. e.g. "Hydrogen".
-            A (int) : Atomic mass number (number of protons plus neutrons).
-            atomic_radius_calculated (float): Calculated atomic radius for the element. This is the empirical value.
-                Data is obtained from https://wikipedia.org/wiki/Atomic_radii_of_the_elements_(data_page).
-            van_der_waals_radius (float): Van der Waals radius for the element. This is the empirical value determined
-                from critical reviews of X-ray diffraction, gas kinetic collision cross-section, and other experimental
-                data by Bondi and later workers. The uncertainty in these values is on the order of 0.1 Å.
-                Data are obtained from "Atomic Radii of the Elements" in CRC Handbook of Chemistry and Physics,
-                91st Ed.; Haynes, W.M., Ed.; CRC Press: Boca Raton, FL, 2010.
-            mendeleev_no (int): Mendeleev number from definition given by Pettifor, D. G. (1984). A chemical scale
-                for crystal-structure maps. Solid State Communications, 51 (1), 31-34.
-            electrical_resistivity (float): Electrical resistivity.
-            velocity_of_sound (float): Velocity of sound.
-            reflectivity (float): Reflectivity.
-            refractive_index (float): Refractive index.
-            poissons_ratio (float): Poisson's ratio.
-            molar_volume (float): Molar volume.
-            electronic_structure (str): Electronic structure. e.g. The electronic structure for Fe is represented
-                as [Ar].3d6.4s2.
-            atomic_orbitals (dict): Atomic Orbitals. Energy of the atomic orbitals as a dict. e.g. The orbitals
-                energies in Hartree are represented as {'1s': -1.0, '2s': -0.1}. Data is obtained from
-                https://www.nist.gov/pml/data/atomic-reference-data-electronic-structure-calculations.
-                The LDA values for neutral atoms are used.
-            atomic_orbitals_eV (dict): Atomic Orbitals. Same as `atomic_orbitals` but energies are in eV.
-            thermal_conductivity (float): Thermal conductivity.
-            boiling_point (float): Boiling point.
-            melting_point (float): Melting point.
-            critical_temperature (float): Critical temperature.
-            superconduction_temperature (float): Superconduction temperature.
-            liquid_range (float): Liquid range.
-            bulk_modulus (float): Bulk modulus.
-            youngs_modulus (float): Young's modulus.
-            brinell_hardness (float): Brinell hardness.
-            rigidity_modulus (float): Rigidity modulus.
-            mineral_hardness (float): Mineral hardness.
-            vickers_hardness (float): Vicker's hardness.
-            density_of_solid (float): Density of solid phase.
-            coefficient_of_linear_thermal_expansion (float): Coefficient of linear thermal expansion.
-            ground_level (float): Ground level for element.
-            ionization_energies (list[Optional[float]]): List of ionization energies. First value is the first
-                ionization energy, second is the second ionization energy, etc. Note that this is zero-based indexing!
-                So Element.ionization_energies[0] refer to the 1st ionization energy. Values are from the NIST Atomic
-                Spectra Database. Missing values are None.
+            Z (int): Atomic number of the element.
+            symbol (str): Element symbol (e.g., "H", "Fe").
+            long_name (str): Full name of the element (e.g., "Hydrogen").
+            A (int, optional): Atomic mass number (sum of protons and neutrons).
+            atomic_radius_calculated (float, optional): Calculated atomic radius (Å).
+            van_der_waals_radius (float, optional): Van der Waals radius (Å).
+            mendeleev_no (int, optional): Mendeleev number based on crystal-structure maps.
+            electrical_resistivity (float, optional): Electrical resistivity (Ω·m).
+            velocity_of_sound (float, optional): Velocity of sound (m/s).
+            reflectivity (float, optional): Reflectivity (%).
+            refractive_index (float, optional): Refractive index.
+            poissons_ratio (float, optional): Poisson's ratio.
+            molar_volume (float, optional): Molar volume (cm³/mol).
+            electronic_structure (str): Electronic structure (e.g., "[Ar].3d6.4s2").
+            atomic_orbitals (dict): Orbital energies (Hartree units).
+            atomic_orbitals_eV (dict): Orbital energies in electron volts (eV).
+            thermal_conductivity (float, optional): Thermal conductivity (W/m·K).
+            boiling_point (float, optional): Boiling point (K).
+            melting_point (float, optional): Melting point (K).
+            critical_temperature (float, optional): Critical temperature (K).
+            superconduction_temperature (float, optional): Superconducting transition temperature (K).
+            liquid_range (float, optional): Temperature range for liquid phase (K).
+            bulk_modulus (float, optional): Bulk modulus (GPa).
+            youngs_modulus (float, optional): Young's modulus (GPa).
+            brinell_hardness (float, optional): Brinell hardness (MPa).
+            rigidity_modulus (float, optional): Rigidity modulus (GPa).
+            mineral_hardness (float, optional): Mohs hardness.
+            vickers_hardness (float, optional): Vickers hardness (MPa).
+            density_of_solid (float, optional): Density in solid phase (g/cm³).
+            coefficient_of_linear_thermal_expansion (float, optional): Thermal expansion coefficient (K⁻¹).
+            ground_level (float, optional): Ground energy level of the element.
+            ionization_energies (list[Optional[float]]): Ionization energies (kJ/mol), indexed from 0.
+
+        Examples:
+            Create an element instance and access its properties:
+                >>> hydrogen = Element("H")
+                >>> hydrogen.symbol
+                'H'
+                >>> hydrogen.Z
+                1
+                >>> hydrogen.electronic_structure
+                '1s1'
+
+            Access additional attributes such as atomic radius:
+                >>> hydrogen.atomic_radius_calculated
+                0.53
+
+        Notes:
+            - This class supports handling of isotopes by incorporating named isotopes
+            and their respective properties.
+            - Attributes are populated using a JSON file that stores data about all
+            known elements.
+            - Some attributes are calculated or derived based on predefined constants
+            and rules.
+
+        References:
+            - Atomic radius data: https://wikipedia.org/wiki/Atomic_radii_of_the_elements_(data_page)
+            - Van der Waals radius: CRC Handbook of Chemistry and Physics, 91st Ed.
+            - Mendeleev number: D. G. Pettifor, "A chemical scale for crystal-structure maps,"
+            Solid State Communications, 1984.
         """
         self.symbol = str(symbol)
         data = _pt_data[symbol]
@@ -205,8 +210,7 @@ class ElementBase(Enum):
             if val is None or str(val).startswith("no data"):
                 warnings.warn(f"No data available for {item} for {self.symbol}")
                 val = None
-            # elif isinstance(val, dict | list):
-            elif type(val) in [list, dict]:  # pre-commit fix
+            elif isinstance(val, dict | list):
                 pass
             else:
                 try:
@@ -532,8 +536,7 @@ class ElementBase(Enum):
         # Total ML = sum(ml1, ml2), Total MS = sum(ms1, ms2)
         TL = [sum(ml_ms[comb[e]][0] for e in range(v_e)) for comb in e_config_combs]
         TS = [sum(ml_ms[comb[e]][1] for e in range(v_e)) for comb in e_config_combs]
-        # comb_counter: Counter = Counter(zip(TL, TS, strict=True))
-        comb_counter: Counter = Counter([(TL[i], TS[i]) for i in range(len(TL))])  # pre-commit edit
+        comb_counter: Counter = Counter(zip(TL, TS, strict=True))
 
         term_symbols = []
         L_symbols = "SPDFGHIKLMNOQRTUVWXYZ"
@@ -1656,18 +1659,9 @@ def get_el_sp(obj: int | SpeciesLike) -> Element | Species | DummySpecies:
             of properties that can be determined.
     """
     # If obj is already an Element or Species, return as is
-    # TODO: Why do we need to check "_is_named_isotope"?
-    if isinstance(obj, Element):
-        if getattr(obj, "_is_named_isotope", None):
-            return Element(obj.name)
-        return obj
-    if isinstance(obj, Species):
-        if getattr(obj, "_is_named_isotope", None):
-            return Species(str(obj))
-        return obj
-    if isinstance(obj, Species):
-        if getattr(obj, "_is_named_isotope", None):
-            return Species(str(obj))
+    if isinstance(obj, Element | Species | DummySpecies):
+        if getattr(obj, "_is_named_isotope", False):
+            return Element(obj.name) if isinstance(obj, Element) else Species(str(obj))
         return obj
 
     # If obj is an integer, return the Element with atomic number obj

--- a/tests/core/test_periodic_table.py
+++ b/tests/core/test_periodic_table.py
@@ -188,10 +188,11 @@ class TestElement(PymatgenTest):
         assert valence[1] == 0
 
     def test_valences(self):
-        cases = {"O": [(1, 4)], "Fe": [(2, 6)], "Cr": [(0, 1), (2, 5)], "Pt": [(0, 1), (2, 9)]}
+        cases = {"Fe": [(2, 6)], "Cr": [(0, 1), (2, 5)], "Pt": [(0, 1), (2, 9)]}
         for k, v in cases.items():
-            for i, vi in enumerate(Element(k).valences):
-                assert vi == v[i]
+            for ion_type in [Element, lambda sym: Species(sym, 0)]:
+                for i, vi in enumerate(ion_type(k).valences):
+                    assert vi == v[i]
 
     def test_term_symbols(self):
         cases = {

--- a/tests/core/test_periodic_table.py
+++ b/tests/core/test_periodic_table.py
@@ -187,6 +187,12 @@ class TestElement(PymatgenTest):
         assert np.isnan(valence[0])
         assert valence[1] == 0
 
+    def test_valences(self):
+        cases = {"O": [(1, 4)], "Fe": [(2, 6)], "Cr": [(0, 1), (2, 5)], "Pt": [(0, 1), (2, 9)]}
+        for k, v in cases.items():
+            for i, vi in enumerate(Element(k).valences):
+                assert vi == v[i]
+
     def test_term_symbols(self):
         cases = {
             "Li": [["2S0.5"]],  # s1


### PR DESCRIPTION
## Summary

Note: This code change is **no longer required for #4078** and the `valences` property does **not** return `(idx, ne)` for every valence subshell but only **every partially filled valence subshell** (unless all subshells are filled, which causes only the last subshell to be returned). I don't see a use for this criteria, so I will fix this to behave as intended. I am also okay with letting this PR be closed and abandoned since it is no longer needed for #4078. 

Major changes:

- feature 1: For both ElementBase and Species class, the code within the "valence" property was copy-pasted into a new "valences" property, with the error raised for ambiguous valence (more than one valence subshell) removed 
(`if len(valence) > 1:
            raise ValueError(f"{self} has ambiguous valence")`)
and return signature changed from `tuple[int | np.nan, int]` to `list[tuple[int | np.nan, int]]` (`return valence` instead of `return valence[0]`)
- fix 1: To remove redundancy, the "valence" property for `ElementBase` and `Species` was re-written to raise the ambiguous valence ValueError if `len(self.valences) > 1`, and otherwise return `self.valences[0]`

## TODO

- Loosen return criteria for `valences` to return all valence subshells while maintaining selectivity of `valence`
