### PR TITLE
Add warning and unit test for isotope conversion in `core.periodic_table.get_el_sp`

### DIFF
--- a/src/pymatgen/core/periodic_table.py
+++ b/src/pymatgen/core/periodic_table.py
@@ -1646,6 +1646,7 @@ def get_el_sp(obj: int | SpeciesLike) -> Element | Species | DummySpecies:
     # If obj is already an Element or Species, return as is
     if isinstance(obj, Element | Species | DummySpecies):
         if getattr(obj, "_is_named_isotope", False):
+            warnings.warn(f"Named isotope {obj.name} would be converted to {obj.symbol}", stacklevel=2)
             return Element(obj.name) if isinstance(obj, Element) else Species(str(obj))
         return obj
 

--- a/tests/core/test_periodic_table.py
+++ b/tests/core/test_periodic_table.py
@@ -705,12 +705,12 @@ class TestDummySpecies:
 class TestGetElSp:
     def test_regular(self):
         assert get_el_sp("Fe2+") == Species("Fe", 2)
-        assert get_el_sp("3") is Element.Li
-        assert get_el_sp(5) is Element.B
-        assert get_el_sp("3.0") is Element.Li
-        assert get_el_sp("+3.0") is Element.Li
-        assert get_el_sp(2.0) is Element.He
-        assert get_el_sp("U") is Element.U
+        assert get_el_sp("3") == Element.Li
+        assert get_el_sp(5) == Element.B
+        assert get_el_sp("3.0") == Element.Li
+        assert get_el_sp("+3.0") == Element.Li
+        assert get_el_sp(2.0) == Element.He
+        assert get_el_sp("U") == Element.U
         assert get_el_sp("X2+") == DummySpecies("X", 2)
         assert get_el_sp("Mn3+") == Species("Mn", 3)
         assert get_el_sp("X2+spin=5") == DummySpecies("X", 2, spin=5)

--- a/tests/core/test_periodic_table.py
+++ b/tests/core/test_periodic_table.py
@@ -702,20 +702,31 @@ class TestDummySpecies:
                 assert n_electron_el - n_electron_sp == ox, f"Failure for {el} {ox}"
 
 
-def test_get_el_sp():
-    assert get_el_sp("Fe2+") == Species("Fe", 2)
-    assert get_el_sp("3") == Element.Li
-    assert get_el_sp(5) == Element.B
-    assert get_el_sp("3.0") == Element.Li
-    assert get_el_sp("+3.0") == Element.Li
-    assert get_el_sp(2.0) == Element.He
-    assert get_el_sp("U") == Element.U
-    assert get_el_sp("X2+") == DummySpecies("X", 2)
-    assert get_el_sp("Mn3+") == Species("Mn", 3)
-    assert get_el_sp("X2+spin=5") == DummySpecies("X", 2, spin=5)
+class TestGetElSp:
+    def test_regular(self):
+        assert get_el_sp("Fe2+") == Species("Fe", 2)
+        assert get_el_sp("3") is Element.Li
+        assert get_el_sp(5) is Element.B
+        assert get_el_sp("3.0") is Element.Li
+        assert get_el_sp("+3.0") is Element.Li
+        assert get_el_sp(2.0) is Element.He
+        assert get_el_sp("U") is Element.U
+        assert get_el_sp("X2+") == DummySpecies("X", 2)
+        assert get_el_sp("Mn3+") == Species("Mn", 3)
+        assert get_el_sp("X2+spin=5") == DummySpecies("X", 2, spin=5)
 
-    with pytest.raises(ValueError, match="Can't parse Element or Species from None"):
-        get_el_sp(None)
+    def test_invalid_input(self):
+        with pytest.raises(ValueError, match="Can't parse Element or Species from None"):
+            get_el_sp(None)
+
+    def test_isotope_conversion_warning(self):
+        # Test Element
+        with pytest.warns(match="Named isotope D would be converted to H"):
+            get_el_sp(Element.D)
+
+        # Test Species
+        with pytest.warns(match="Named isotope D would be converted to H"):
+            get_el_sp(Species("D"))
 
 
 def test_element_type():


### PR DESCRIPTION
- Add warning for isotope conversion in `core.periodic_table.get_el_sp`, follow up original #3542
- [ ] Add unit test 