### PR TITLE
Fix NumPy array indexing in 32-bit system in `analysis.chemenv.coordination_environments`

### DIFF
--- a/src/pymatgen/analysis/chemenv/coordination_environments/coordination_geometry_finder.py
+++ b/src/pymatgen/analysis/chemenv/coordination_environments/coordination_geometry_finder.py
@@ -218,7 +218,9 @@ class AbstractGeometry:
         """
         if permutation is None:
             return self._points_wcs_csc
-        return np.concatenate((self._points_wcs_csc[:1], self._points_wocs_csc.take(np.array(permutation, dtype=np.intp), axis=0)))
+        return np.concatenate(
+            (self._points_wcs_csc[:1], self._points_wocs_csc.take(np.array(permutation, dtype=np.intp), axis=0))
+        )
 
     def points_wocs_csc(self, permutation=None):
         """

--- a/src/pymatgen/analysis/chemenv/coordination_environments/coordination_geometry_finder.py
+++ b/src/pymatgen/analysis/chemenv/coordination_environments/coordination_geometry_finder.py
@@ -218,7 +218,7 @@ class AbstractGeometry:
         """
         if permutation is None:
             return self._points_wcs_csc
-        return np.concatenate((self._points_wcs_csc[:1], self._points_wocs_csc.take(permutation, axis=0)))
+        return np.concatenate((self._points_wcs_csc[:1], self._points_wocs_csc.take(np.array(permutation, dtype=np.intp), axis=0)))
 
     def points_wocs_csc(self, permutation=None):
         """
@@ -227,7 +227,7 @@ class AbstractGeometry:
         """
         if permutation is None:
             return self._points_wocs_csc
-        return self._points_wocs_csc.take(permutation, axis=0)
+        return self._points_wocs_csc.take(np.array(permutation, dtype=np.intp), axis=0)
 
     def points_wcs_ctwcc(self, permutation=None):
         """
@@ -239,7 +239,7 @@ class AbstractGeometry:
         return np.concatenate(
             (
                 self._points_wcs_ctwcc[:1],
-                self._points_wocs_ctwcc.take(permutation, axis=0),
+                self._points_wocs_ctwcc.take(np.array(permutation, dtype=np.intp), axis=0),
             )
         )
 
@@ -250,7 +250,7 @@ class AbstractGeometry:
         """
         if permutation is None:
             return self._points_wocs_ctwcc
-        return self._points_wocs_ctwcc.take(permutation, axis=0)
+        return self._points_wocs_ctwcc.take(np.array(permutation, dtype=np.intp), axis=0)
 
     def points_wcs_ctwocc(self, permutation=None):
         """
@@ -262,7 +262,7 @@ class AbstractGeometry:
         return np.concatenate(
             (
                 self._points_wcs_ctwocc[:1],
-                self._points_wocs_ctwocc.take(permutation, axis=0),
+                self._points_wocs_ctwocc.take(np.array(permutation, dtype=np.intp), axis=0),
             )
         )
 
@@ -273,7 +273,7 @@ class AbstractGeometry:
         """
         if permutation is None:
             return self._points_wocs_ctwocc
-        return self._points_wocs_ctwocc.take(permutation, axis=0)
+        return self._points_wocs_ctwocc.take(np.array(permutation, dtype=np.intp), axis=0)
 
     @property
     def cn(self):
@@ -1976,6 +1976,7 @@ class LocalGeometryFinder:
         stop_search = False
         # TODO: do not do that several times ... also keep in memory
         if sepplane.ordered_plane:
+            separation_indices = [arr.astype(np.intp) for arr in separation_indices]
             inp = self.local_geometry.coords.take(separation_indices[1], axis=0)
             if sepplane.ordered_point_groups[0]:
                 pp_s0 = self.local_geometry.coords.take(separation_indices[0], axis=0)


### PR DESCRIPTION
### Summary

- Fix NumPy array indexing in 32-bit system, to close #4161
    > https://numpy.org/doc/1.21/reference/arrays.scalars.html

I may use `intp` instead of `uintp` as I'm not 100% sure if the indexes could be negative or not in the code design.


### Run unit tests locally as GitHub doesn't provide 32-bit runner

Test platform: 
- `Linux debian32bit 6.1.0-27-686-pae #1 SMP PREEMPT_DYNAMIC Debian 6.1.115-1 (2024-11-01) i686 GNU/Linux`
- Python 3.11.2


#### Numpy 1.26.4 

I don't think those three test failures are related to this PR.

```
.....................................ss...................................................................................................... [  4%]
.................................s.............................sss.......................................F........sssss.....s..s............. [  9%]
.....s..............................................ss.......................s.....ssssssss.................................................. [ 14%]
.......s...............................................................................................................ss.................... [ 19%]
.................................F....................................................sss....s.s............................................. [ 24%]
....................sssss..ss..sssssssssssssssssssssssssssssssssssssss....................................................................... [ 29%]
...................................................F......................................................................................... [ 33%]
...................................................s.......s..................................sss....s...............sssssss..........s...... [ 38%]
............................ss.....sss....s..........................s....................................................................... [ 43%]
.s.................................ssssssssssssssss...................................................................................sssssss [ 48%]
ssssssssssss................................................................................................................................. [ 53%]
..................................................s...................ss..................................................................... [ 58%]
............................................................................................................................................. [ 62%]
............................................................................................................................................. [ 67%]
.............ssss................................................s..................s........................................................ [ 72%]
...................................................................................ss............................sssss..s.................... [ 77%]
...........................................................................................................s................................. [ 82%]
............................................................................................................................................. [ 87%]
...............................................s.......................................................................sssssssssss........... [ 91%]
..............................................................................s................s..sssss..ssssssss...ssssss....s...........s.. [ 96%]
.................ssss..........................................................................                                               [100%]
===================================================================== FAILURES ======================================================================
_________________________________________________________ TestEOS.test_numerical_eos_values _________________________________________________________

self = <analysis.test_eos.TestEOS testMethod=test_numerical_eos_values>

    def test_numerical_eos_values(self):
        assert_allclose(self.num_eos_fit.e0, -10.84749, atol=1e-3)
        assert_allclose(self.num_eos_fit.v0, 40.857201, atol=1e-1)
        assert_allclose(self.num_eos_fit.b0, 0.55, atol=1e-2)
>       assert_allclose(self.num_eos_fit.b0_GPa, 89.0370727, atol=1e-1)

/home/yang/pymatgen/tests/analysis/test_eos.py:429: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

args = (<function assert_allclose.<locals>.compare at 0x9a968d48>, array(88.86413), array(89.0370727))
kwds = {'equal_nan': True, 'err_msg': '', 'header': 'Not equal to tolerance rtol=1e-07, atol=0.1', 'verbose': True}

    @wraps(func)
    def inner(*args, **kwds):
        with self._recreate_cm():
>           return func(*args, **kwds)
E           AssertionError: 
E           Not equal to tolerance rtol=1e-07, atol=0.1
E           
E           Mismatched elements: 1 / 1 (100%)
E           Max absolute difference: 0.1729427
E           Max relative difference: 0.00194237
E            x: array(88.86413)
E            y: array(89.037073)

/usr/lib/python3.11/contextlib.py:81: AssertionError
__________________________________________________________ TestBalancedReaction.test_hash ___________________________________________________________

self = <analysis.test_reaction_calculator.TestBalancedReaction testMethod=test_hash>

    def test_hash(self):
>       assert hash(self.rxn) == 4774511606373046513
E       assert 221359835 == 4774511606373046513
E        +  where 221359835 = hash(24 Li + Na2S + 3 K2SO4 -> 2 KNaS + 2 K2S + 12 Li2O)
E        +    where 24 Li + Na2S + 3 K2SO4 -> 2 KNaS + 2 K2S + 12 Li2O = <analysis.test_reaction_calculator.TestBalancedReaction testMethod=test_hash>.rxn

tests/analysis/test_reaction_calculator.py:334: AssertionError
_______________________________________________________________ TestLattice.test_init _______________________________________________________________

self = <core.test_lattice.TestLattice testMethod=test_init>

    def test_init(self):
        len_a = 9.026
        lattice = Lattice.cubic(len_a)
        assert lattice is not None, "Initialization from new_cubic failed"
        assert_array_equal(lattice.pbc, (True, True, True))
>       assert hash(lattice) == -6887896986157825384
E       assert 50099439 == -6887896986157825384
E        +  where 50099439 = hash(Lattice\n    abc : 9.026 9.026 9.026\n angles : 90.0 90.0 90.0\n volume : 735.336269576\n      A : 9.026 0.0 0.0\n      B : 0.0 9.026 0.0\n      C : 0.0 0.0 9.026\n    pbc : True True True)

/home/yang/pymatgen/tests/core/test_lattice.py:43: AssertionError

3 failed, 2719 passed, 205 skipped, 54 warnings in 1223.52s (0:20:23)
```

#### NumPy 2

Cannot install:
```
ERROR: Cannot install monty==2024.10.21, pymatgen and pymatgen==2024.11.13 because these package versions have conflicting dependencies.

The conflict is caused by:
    pymatgen 2024.11.13 depends on numpy<3 and >=2.0.0
    matplotlib 3.9.0 depends on numpy>=1.23
    monty 2024.10.21 depends on numpy<2.0.0
```
