### PR TITLE
Remove redundant `total_ordering` decorator usage

### DIFF
--- a/src/pymatgen/core/composition.py
+++ b/src/pymatgen/core/composition.py
@@ -25,7 +25,7 @@ from pymatgen.util.string import Stringify, formula_double_format
 
 if TYPE_CHECKING:
     from collections.abc import Generator, Iterator
-    from typing import Any, ClassVar
+    from typing import Any, ClassVar, Literal
 
     from typing_extensions import Self
 
@@ -774,17 +774,25 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
     def to_weight_dict(self) -> dict[str, float]:
         """
         Returns:
-            dict[str, float] with weight fraction of each component {"Ti": 0.90, "V": 0.06, "Al": 0.04}.
+            dict[str, float]: weight fractions of each component, e.g. {"Ti": 0.90, "V": 0.06, "Al": 0.04}.
         """
         return {str(el): self.get_wt_fraction(el) for el in self.elements}
 
     @property
-    def to_data_dict(self) -> dict[str, Any]:
+    def to_data_dict(
+        self,
+    ) -> dict[
+        Literal["reduced_cell_composition", "unit_cell_composition", "reduced_cell_formula", "elements", "nelements"],
+        Any,
+    ]:
         """
         Returns:
-            A dict with many keys and values relating to Composition/Formula,
-            including reduced_cell_composition, unit_cell_composition,
-            reduced_cell_formula, elements and nelements.
+            dict with the following keys:
+                - reduced_cell_composition
+                - unit_cell_composition
+                - reduced_cell_formula
+                - elements
+                - nelements.
         """
         return {
             "reduced_cell_composition": self.reduced_composition,

--- a/src/pymatgen/core/periodic_table.py
+++ b/src/pymatgen/core/periodic_table.py
@@ -876,7 +876,6 @@ class ElementBase(Enum):
             print(" ".join(row_str))
 
 
-@functools.total_ordering
 class Element(ElementBase):
     """Enum representing an element in the periodic table."""
 
@@ -1597,14 +1596,12 @@ class DummySpecies(Species):
         return cls(dct["element"], dct["oxidation_state"], spin=dct.get("spin"))
 
 
-@functools.total_ordering
 class Specie(Species):
     """This maps the historical grammatically inaccurate Specie to Species
     to maintain backwards compatibility.
     """
 
 
-@functools.total_ordering
 class DummySpecie(DummySpecies):
     """This maps the historical grammatically inaccurate DummySpecie to DummySpecies
     to maintain backwards compatibility.

--- a/src/pymatgen/core/structure.py
+++ b/src/pymatgen/core/structure.py
@@ -1097,21 +1097,22 @@ class IStructure(SiteCollection, MSONable):
 
     def __eq__(self, other: object) -> bool:
         """Define equality by comparing all three attributes: lattice, sites, properties."""
-        if not (hasattr(other, "lattice") and hasattr(other, "sites") and hasattr(other, "properties")):
+        needed_attrs = ("lattice", "sites", "properties")
+        if not all(hasattr(other, attr) for attr in needed_attrs):
             return NotImplemented
+
+        # TODO (DanielYang59): fix below type
+        other = cast(Structure, other)  # make mypy happy
 
         if other is self:
             return True
 
-        if isinstance(other, collections.abc.Sized) and len(self) != len(other):
+        if len(self) != len(other):
             return False
 
         if self.lattice != other.lattice:
             return False
         if self.properties != other.properties:
-            return False
-
-        if not isinstance(other, collections.abc.Container):
             return False
         return all(site in other for site in self)
 

--- a/src/pymatgen/core/structure.py
+++ b/src/pymatgen/core/structure.py
@@ -6,7 +6,6 @@ IMolecule and IStructure.
 from __future__ import annotations
 
 import collections
-import collections.abc
 import contextlib
 import functools
 import inspect
@@ -20,9 +19,7 @@ import sys
 import warnings
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from collections.abc import MutableSequence
 from fnmatch import fnmatch
-from io import StringIO
 from typing import TYPE_CHECKING, Literal, cast, get_args
 
 import numpy as np
@@ -246,7 +243,7 @@ class SiteCollection(collections.abc.Sequence, ABC):
     def sites(self, sites: Sequence[PeriodicSite]) -> None:
         """Set the sites in the Structure."""
         # If self is mutable Structure or Molecule, set _sites as list
-        is_mutable = isinstance(self._sites, MutableSequence)
+        is_mutable = isinstance(self._sites, collections.abc.MutableSequence)
         self._sites: list[PeriodicSite] | tuple[PeriodicSite, ...] = list(sites) if is_mutable else tuple(sites)
 
     @abstractmethod
@@ -2985,7 +2982,7 @@ class IStructure(SiteCollection, MSONable):
             return Prismatic(self).to_str()
         elif fmt in ("yaml", "yml") or fnmatch(filename, "*.yaml*") or fnmatch(filename, "*.yml*"):
             yaml = YAML()
-            str_io = StringIO()
+            str_io = io.StringIO()
             yaml.dump(self.as_dict(), str_io)
             yaml_str = str_io.getvalue()
             if filename:
@@ -3926,7 +3923,7 @@ class IMolecule(SiteCollection, MSONable):
             return json_str
         elif fmt in {"yaml", "yml"} or fnmatch(filename, "*.yaml*") or fnmatch(filename, "*.yml*"):
             yaml = YAML()
-            str_io = StringIO()
+            str_io = io.StringIO()
             yaml.dump(self.as_dict(), str_io)
             yaml_str = str_io.getvalue()
             if filename:

--- a/src/pymatgen/core/structure.py
+++ b/src/pymatgen/core/structure.py
@@ -1097,9 +1097,7 @@ class IStructure(SiteCollection, MSONable):
 
     def __eq__(self, other: object) -> bool:
         """Define equality by comparing all three attributes: lattice, sites, properties."""
-        needed_attrs = ("lattice", "sites", "properties")
-
-        if not all(hasattr(other, attr) for attr in needed_attrs):
+        if not (hasattr(other, "lattice") and hasattr(other, "sites") and hasattr(other, "properties")):
             return NotImplemented
 
         if other is self:
@@ -1108,12 +1106,12 @@ class IStructure(SiteCollection, MSONable):
         if hasattr(other, "__len__") and len(self) != len(other):
             return False
 
-        if hasattr(other, "lattice") and self.lattice != other.lattice:
+        if self.lattice != other.lattice:
             return False
-        if hasattr(other, "properties") and self.properties != other.properties:
+        if self.properties != other.properties:
             return False
 
-        if not hasattr(other, "__contains__"):
+        if not isinstance(other, collections.abc.Container):
             return False
         return all(site in other for site in self)
 

--- a/src/pymatgen/core/structure.py
+++ b/src/pymatgen/core/structure.py
@@ -1103,7 +1103,7 @@ class IStructure(SiteCollection, MSONable):
         if other is self:
             return True
 
-        if hasattr(other, "__len__") and len(self) != len(other):
+        if isinstance(other, collections.abc.Sized) and len(self) != len(other):
             return False
 
         if self.lattice != other.lattice:

--- a/src/pymatgen/core/structure.py
+++ b/src/pymatgen/core/structure.py
@@ -1100,7 +1100,6 @@ class IStructure(SiteCollection, MSONable):
     def __eq__(self, other: object) -> bool:
         needed_attrs = ("lattice", "sites", "properties")
 
-        # Return NotImplemented as in https://docs.python.org/3/library/functools.html#functools.total_ordering
         if not all(hasattr(other, attr) for attr in needed_attrs):
             return NotImplemented
 

--- a/src/pymatgen/core/structure.py
+++ b/src/pymatgen/core/structure.py
@@ -6,6 +6,7 @@ IMolecule and IStructure.
 from __future__ import annotations
 
 import collections
+import collections.abc
 import contextlib
 import functools
 import inspect
@@ -1104,16 +1105,18 @@ class IStructure(SiteCollection, MSONable):
         if not all(hasattr(other, attr) for attr in needed_attrs):
             return NotImplemented
 
-        # TODO (DanielYang59): fix below type
-        other = cast(Structure, other)  # make mypy happy
-
         if other is self:
             return True
-        if len(self) != len(other):
+
+        if hasattr(other, "__len__") and len(self) != len(other):
             return False
-        if self.lattice != other.lattice:
+
+        if hasattr(other, "lattice") and self.lattice != other.lattice:
             return False
-        if self.properties != other.properties:
+        if hasattr(other, "properties") and self.properties != other.properties:
+            return False
+
+        if not hasattr(other, "__contains__"):
             return False
         return all(site in other for site in self)
 

--- a/src/pymatgen/core/structure.py
+++ b/src/pymatgen/core/structure.py
@@ -1098,6 +1098,7 @@ class IStructure(SiteCollection, MSONable):
         self._properties = properties or {}
 
     def __eq__(self, other: object) -> bool:
+        """Define equality by comparing all three attributes: lattice, sites, properties."""
         needed_attrs = ("lattice", "sites", "properties")
 
         if not all(hasattr(other, attr) for attr in needed_attrs):


### PR DESCRIPTION
### Summary

- Remove redundant `total_ordering` decorator usage, as `total_ordering` is already applied on superclasses and child classes did not redefine any rich comparison operations.
- Clean up comment of  equality definition of `core.IStructure`
- Minor import clean up (avoid `from io import StringIO` when it's used only twice as `io` is already imported)
- Minor docstring clean up