### PR TITLE
Fix `uv pip install` from binary distribution (wheels) usage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,12 +61,12 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v4
 
-      - name: Set up micromamba
-        uses: mamba-org/setup-micromamba@main
-
       - name: Create mamba environment
-        run: |
-          micromamba create -n pmg python=${{ matrix.config.python }} --yes
+        uses: mamba-org/setup-micromamba@main
+        with:
+          environment-name: pmg
+          create-args: >-
+            python=${{ matrix.config.python }}
 
       - name: Install ubuntu-only conda dependencies
         if: matrix.config.os == 'ubuntu-latest'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,7 +87,7 @@ jobs:
 
           # Install from wheels to test the content
           uv build --wheel
-          uv pip install dist/*.whl pymatgen[${{ matrix.config.extras }}] --resolution=${{ matrix.config.resolution }}
+          uv pip install dist/*.whl 'pymatgen[${{ matrix.config.extras }}]' --resolution=${{ matrix.config.resolution }}
 
       - name: Install optional Ubuntu dependencies
         if: matrix.config.os == 'ubuntu-latest'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,9 +86,7 @@ jobs:
           pip install torch==2.2.1
 
           # Install from wheels to test the content
-          uv pip install build
-          python -m build --wheel
-
+          uv build --wheel
           uv pip install dist/*.whl pymatgen[${{ matrix.config.extras }}] --resolution=${{ matrix.config.resolution }}
 
       - name: Install optional Ubuntu dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
           pip install torch==2.2.1
 
           # Install from wheels to test the content
-          uv build --wheel --quiet
+          uv build --wheel --no-build-logs
           WHEEL_FILE=$(ls dist/pymatgen*.whl)
           uv pip install $WHEEL_FILE[${{matrix.config.extras}}] --resolution=${{matrix.config.resolution}}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,8 +89,7 @@ jobs:
           uv pip install build
           python -m build --wheel
 
-          uv pip install dist/*.whl
-          uv pip install pymatgen[${{ matrix.config.extras }}] --resolution=${{ matrix.config.resolution }}
+          uv pip install dist/*.whl pymatgen[${{ matrix.config.extras }}] --resolution=${{ matrix.config.resolution }}
 
       - name: Install optional Ubuntu dependencies
         if: matrix.config.os == 'ubuntu-latest'


### PR DESCRIPTION
### Summary

- Fix `uv pip install` from binary distribution (wheels) usage, https://github.com/astral-sh/uv/issues/8155#issuecomment-2506014815
- Use `uv` to build wheel, https://docs.astral.sh/uv/guides/integration/github/
- [**REVERTED**] Test `mcsqs` install in 3f63f4b341674e31d597506de4e6a64de4ed5ea3, it's way too slow ~90 s

