### PR TITLE
Increase warnings `stacklevel` to 2, un-ignore RUFF `B028`

### DIFF
--- a/dev_scripts/potcar_scrambler.py
+++ b/dev_scripts/potcar_scrambler.py
@@ -164,7 +164,7 @@ def generate_fake_potcar_libraries() -> None:
                 zpath(f"{func_dir}/{psp_name}/POTCAR"),
             ]
             if not any(map(os.path.isfile, paths_to_try)):
-                warnings.warn(f"Could not find {psp_name} in {paths_to_try}")
+                warnings.warn(f"Could not find {psp_name} in {paths_to_try}", stacklevel=2)
             for potcar_path in paths_to_try:
                 if os.path.isfile(potcar_path):
                     os.makedirs(rebase_dir, exist_ok=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,7 +193,6 @@ ignore = [
 
     # Single rules
     "B023",    # Function definition does not bind loop variable
-    "B028",    # No explicit stacklevel keyword argument found
     "B904",    # Within an except clause, raise exceptions with ...
     "C408",    # unnecessary-collection-call
     "D105",    # Missing docstring in magic method

--- a/src/pymatgen/alchemy/materials.py
+++ b/src/pymatgen/alchemy/materials.py
@@ -362,7 +362,7 @@ class TransformedStructure(MSONable):
             StructureNL: The generated StructureNL object.
         """
         if self.other_parameters:
-            warn("Data in TransformedStructure.other_parameters discarded during type conversion to SNL")
+            warn("Data in TransformedStructure.other_parameters discarded during type conversion to SNL", stacklevel=2)
         history = []
         for hist in self.history:
             snl_metadata = hist.pop("_snl", {})

--- a/src/pymatgen/analysis/bond_dissociation.py
+++ b/src/pymatgen/analysis/bond_dissociation.py
@@ -107,7 +107,8 @@ class BondDissociationEnergies(MSONable):
         if multibreak:
             warnings.warn(
                 "Breaking pairs of ring bonds. WARNING: Structure changes much more likely, meaning dissociation values"
-                " are less reliable! This is a bad idea!"
+                " are less reliable! This is a bad idea!",
+                stacklevel=2,
             )
             self.bond_pairs = []
             for ii, bond in enumerate(self.ring_bonds, start=1):
@@ -164,7 +165,8 @@ class BondDissociationEnergies(MSONable):
                         warnings.warn(
                             f"Missing ring opening fragment resulting from the breakage of {specie[bonds[0][0]]} "
                             f"{specie[bonds[0][1]]} bond {bonds[0][0]} {bonds[0][1]} which would yield a "
-                            f"molecule with this SMILES string: {smiles}"
+                            f"molecule with this SMILES string: {smiles}",
+                            stacklevel=2,
                         )
                     elif len(good_entries) == 1:
                         # If we have only one good entry, format it and add it to the list that will eventually return
@@ -212,14 +214,14 @@ class BondDissociationEnergies(MSONable):
                     smiles = pb_mol.write("smi").split()[0]
                     for charge in self.expected_charges:
                         if charge not in frag1_charges_found:
-                            warnings.warn(f"Missing {charge=} for fragment {smiles}")
+                            warnings.warn(f"Missing {charge=} for fragment {smiles}", stacklevel=2)
                 if len(frag2_charges_found) < len(self.expected_charges):
                     bb = BabelMolAdaptor(fragments[1].molecule)
                     pb_mol = bb.pybel_mol
                     smiles = pb_mol.write("smi").split()[0]
                     for charge in self.expected_charges:
                         if charge not in frag2_charges_found:
-                            warnings.warn(f"Missing {charge=} for fragment {smiles}")
+                            warnings.warn(f"Missing {charge=} for fragment {smiles}", stacklevel=2)
                 # Now we attempt to pair fragments with the right total charge, starting with only fragments with no
                 # structural change:
                 for frag1 in frag1_entries[0]:  # 0 -> no structural change

--- a/src/pymatgen/analysis/chemenv/coordination_environments/coordination_geometry_finder.py
+++ b/src/pymatgen/analysis/chemenv/coordination_environments/coordination_geometry_finder.py
@@ -2051,10 +2051,7 @@ class LocalGeometryFinder:
             The symmetry measures for the given coordination geometry for each permutation investigated.
         """
         if "NRANDOM" in kwargs:
-            warnings.warn(
-                "NRANDOM is deprecated, use n_random instead",
-                category=DeprecationWarning,
-            )
+            warnings.warn("NRANDOM is deprecated, use n_random instead", category=DeprecationWarning, stacklevel=2)
             n_random = kwargs.pop("NRANDOM")
         permutations_symmetry_measures = [None] * n_random
         permutations = []

--- a/src/pymatgen/analysis/chempot_diagram.py
+++ b/src/pymatgen/analysis/chempot_diagram.py
@@ -391,7 +391,7 @@ class ChemicalPotentialDiagram(MSONable):
         if formulas_to_draw:
             for formula in formulas_to_draw:
                 if formula not in domain_simplexes:
-                    warnings.warn(f"Specified formula to draw, {formula}, not found!")
+                    warnings.warn(f"Specified formula to draw, {formula}, not found!", stacklevel=2)
 
         if draw_formula_lines:
             data.extend(self._get_3d_formula_lines(draw_domains, formula_colors))

--- a/src/pymatgen/analysis/elasticity/elastic.py
+++ b/src/pymatgen/analysis/elasticity/elastic.py
@@ -63,7 +63,7 @@ class NthOrderElasticTensor(Tensor):
         if obj.rank % 2 != 0:
             raise ValueError("ElasticTensor must have even rank")
         if not obj.is_voigt_symmetric(tol):
-            warnings.warn("Input elastic tensor does not satisfy standard Voigt symmetries")
+            warnings.warn("Input elastic tensor does not satisfy standard Voigt symmetries", stacklevel=2)
         return obj.view(cls)
 
     @property
@@ -476,7 +476,8 @@ class ElasticTensor(NthOrderElasticTensor):
         # convert the stress/strain to Nx6 arrays of voigt notation
         warnings.warn(
             "Pseudo-inverse fitting of Strain/Stress lists may yield "
-            "questionable results from vasp data, use with caution."
+            "questionable results from vasp data, use with caution.",
+            stacklevel=2,
         )
         stresses = np.array([Stress(stress).voigt for stress in stresses])
         with warnings.catch_warnings():
@@ -505,7 +506,9 @@ class ElasticTensor(NthOrderElasticTensor):
         if not set(strain_states) <= set(ss_dict):
             raise ValueError(f"Missing independent strain states: {set(strain_states) - set(ss_dict)}")
         if len(set(ss_dict) - set(strain_states)) > 0:
-            warnings.warn("Extra strain states in strain-stress pairs are neglected in independent strain fitting")
+            warnings.warn(
+                "Extra strain states in strain-stress pairs are neglected in independent strain fitting", stacklevel=2
+            )
         c_ij = np.zeros((6, 6))
         for ii in range(6):
             strains = ss_dict[strain_states[ii]]["strains"]
@@ -916,7 +919,7 @@ def find_eq_stress(strains, stresses, tol: float = 1e-10):
             )
         eq_stress = eq_stress[0]
     else:
-        warnings.warn("No eq state found, returning zero voigt stress")
+        warnings.warn("No eq state found, returning zero voigt stress", stacklevel=2)
         eq_stress = Stress(np.zeros((3, 3)))
     return eq_stress
 

--- a/src/pymatgen/analysis/ewald.py
+++ b/src/pymatgen/analysis/ewald.py
@@ -288,7 +288,7 @@ class EwaldSummation(MSONable):
             self._initialized = True
 
         if self._charged:
-            warn("Per atom energies for charged structures not supported in EwaldSummation")
+            warn("Per atom energies for charged structures not supported in EwaldSummation", stacklevel=2)
         return np.sum(self._recip[:, site_index]) + np.sum(self._real[:, site_index]) + self._point[site_index]
 
     def _calc_ewald_terms(self):

--- a/src/pymatgen/analysis/gb/grain.py
+++ b/src/pymatgen/analysis/gb/grain.py
@@ -8,4 +8,5 @@ warnings.warn(
     "Grain boundary analysis has been moved to pymatgen.core.interface."
     "This stub is retained for backwards compatibility and will be removed Dec 31 2024.",
     DeprecationWarning,
+    stacklevel=2,
 )

--- a/src/pymatgen/analysis/graphs.py
+++ b/src/pymatgen/analysis/graphs.py
@@ -383,7 +383,7 @@ class StructureGraph(MSONable):
         # edges if appropriate
         if to_jimage is None:
             # assume we want the closest site
-            warnings.warn("Please specify to_jimage to be unambiguous, trying to automatically detect.")
+            warnings.warn("Please specify to_jimage to be unambiguous, trying to automatically detect.", stacklevel=2)
             dist, to_jimage = self.structure[from_index].distance_and_image(self.structure[to_index])
             if dist == 0:
                 # this will happen when from_index == to_index,
@@ -417,7 +417,7 @@ class StructureGraph(MSONable):
         # this is a convention to avoid duplicate hops
         if to_index == from_index:
             if to_jimage == (0, 0, 0):
-                warnings.warn("Tried to create a bond to itself, this doesn't make sense so was ignored.")
+                warnings.warn("Tried to create a bond to itself, this doesn't make sense so was ignored.", stacklevel=2)
                 return
 
             # ensure that the first non-zero jimage index is positive
@@ -439,7 +439,8 @@ class StructureGraph(MSONable):
                     if warn_duplicates:
                         warnings.warn(
                             "Trying to add an edge that already exists from "
-                            f"site {from_index} to site {to_index} in {to_jimage}."
+                            f"site {from_index} to site {to_index} in {to_jimage}.",
+                            stacklevel=2,
                         )
                     return
 
@@ -1826,7 +1827,9 @@ class MoleculeGraph(MSONable):
         # between two sites
         existing_edge_data = self.graph.get_edge_data(from_index, to_index)
         if existing_edge_data and warn_duplicates:
-            warnings.warn(f"Trying to add an edge that already exists from site {from_index} to site {to_index}.")
+            warnings.warn(
+                f"Trying to add an edge that already exists from site {from_index} to site {to_index}.", stacklevel=2
+            )
             return
 
         # generic container for additional edge properties,

--- a/src/pymatgen/analysis/interface_reactions.py
+++ b/src/pymatgen/analysis/interface_reactions.py
@@ -484,8 +484,10 @@ class InterfacialReactivity(MSONable):
 
         if not candidate:
             warnings.warn(
-                f"The reactant {composition.reduced_formula} has no matching entry with negative formation"
-                " energy, instead convex hull energy for this composition will be used for reaction energy calculation."
+                f"The reactant {composition.reduced_formula} has no matching entry "
+                "with negative formation energy, instead convex hull energy for "
+                "this composition will be used for reaction energy calculation.",
+                stacklevel=2,
             )
             return pd.get_hull_energy(composition)
         min_entry_energy = min(candidate)
@@ -545,8 +547,9 @@ class InterfacialReactivity(MSONable):
             The correction of chemical potential in eV/atom of the gas
             phase at given temperature and pressure.
         """
-        if element not in ["O", "N", "Cl", "F", "H"]:
-            warnings.warn(f"{element=} not one of valid options: ['O', 'N', 'Cl', 'F', 'H']")
+        valid_elements = {"O", "N", "Cl", "F", "H"}
+        if element not in valid_elements:
+            warnings.warn(f"{element=} not one of valid options: {valid_elements}", stacklevel=2)
             return 0
 
         std_temp = 298.15

--- a/src/pymatgen/analysis/local_env.py
+++ b/src/pymatgen/analysis/local_env.py
@@ -4025,7 +4025,8 @@ class CrystalNN(NearNeighbors):
                     warnings.warn(
                         "CrystalNN: cannot locate an appropriate radius, "
                         "covalent or atomic radii will be used, this can lead "
-                        "to non-optimal results."
+                        "to non-optimal results.",
+                        stacklevel=2,
                     )
                     diameter = _get_default_radius(structure[n]) + _get_default_radius(entry["site"])
 
@@ -4231,7 +4232,8 @@ def _get_radius(site):
     else:
         warnings.warn(
             "No oxidation states specified on sites! For better results, set "
-            "the site oxidation states in the structure."
+            "the site oxidation states in the structure.",
+            stacklevel=2,
         )
     return 0
 

--- a/src/pymatgen/analysis/magnetism/analyzer.py
+++ b/src/pymatgen/analysis/magnetism/analyzer.py
@@ -43,7 +43,7 @@ MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
 try:
     DEFAULT_MAGMOMS = loadfn(f"{MODULE_DIR}/default_magmoms.yaml")
 except (FileNotFoundError, MarkedYAMLError):
-    warnings.warn("Could not load default_magmoms.yaml, falling back to VASPIncarBase.yaml")
+    warnings.warn("Could not load default_magmoms.yaml, falling back to VASPIncarBase.yaml", stacklevel=2)
     DEFAULT_MAGMOMS = loadfn(f"{MODULE_DIR}/../../io/vasp/VASPIncarBase.yaml")["INCAR"]["MAGMOM"]
 
 
@@ -159,7 +159,7 @@ class CollinearMagneticStructureAnalyzer:
             try:
                 structure = trans.apply_transformation(structure)
             except ValueError:
-                warnings.warn(f"Could not assign valences for {structure.reduced_formula}")
+                warnings.warn(f"Could not assign valences for {structure.reduced_formula}", stacklevel=2)
 
         # Check if structure has magnetic moments
         # on site properties or species spin properties,
@@ -186,7 +186,8 @@ class CollinearMagneticStructureAnalyzer:
             if None in structure.site_properties["magmom"]:
                 warnings.warn(
                     "Be careful with mixing types in your magmom site properties. "
-                    "Any 'None' magmoms have been replaced with zero."
+                    "Any 'None' magmoms have been replaced with zero.",
+                    stacklevel=2,
                 )
             magmoms = [m or 0 for m in structure.site_properties["magmom"]]
         elif has_spin:
@@ -207,7 +208,8 @@ class CollinearMagneticStructureAnalyzer:
                 "This class is not designed to be used with "
                 "non-collinear structures. If your structure is "
                 "only slightly non-collinear (e.g. canted) may still "
-                "give useful results, but use with caution."
+                "give useful results, but use with caution.",
+                stacklevel=2,
             )
 
         # this is for collinear structures only, make sure magmoms are all floats
@@ -313,8 +315,8 @@ class CollinearMagneticStructureAnalyzer:
 
             except Exception as exc:
                 # TODO: typically a singular matrix warning, investigate this
-                warnings.warn("Failed to round magmoms intelligently, falling back to simple rounding.")
-                warnings.warn(str(exc))
+                warnings.warn("Failed to round magmoms intelligently, falling back to simple rounding.", stacklevel=2)
+                warnings.warn(str(exc), stacklevel=2)
 
             # and finally round roughly to the number of significant figures in our kde width
             n_decimals = len(str(round_magmoms_mode).split(".")[1]) + 1
@@ -483,7 +485,7 @@ class CollinearMagneticStructureAnalyzer:
                 (in which case a warning is issued).
         """
         if not self.is_collinear:
-            warnings.warn("Detecting ordering in non-collinear structures not yet implemented.")
+            warnings.warn("Detecting ordering in non-collinear structures not yet implemented.", stacklevel=2)
             return Ordering.Unknown
 
         if "magmom" not in self.structure.site_properties:

--- a/src/pymatgen/analysis/magnetism/jahnteller.py
+++ b/src/pymatgen/analysis/magnetism/jahnteller.py
@@ -286,7 +286,7 @@ class JahnTellerAnalyzer:
             )
             active = analysis["active"]
         except Exception as exc:
-            warnings.warn(f"Error analyzing {structure.reduced_formula}: {exc}")
+            warnings.warn(f"Error analyzing {structure.reduced_formula}: {exc}", stacklevel=2)
 
         return active
 
@@ -330,7 +330,7 @@ class JahnTellerAnalyzer:
                         structure.add_site_property("possible_jt_active", jt_sites)
             return structure
         except Exception as exc:
-            warnings.warn(f"Error analyzing {structure.reduced_formula}: {exc}")
+            warnings.warn(f"Error analyzing {structure.reduced_formula}: {exc}", stacklevel=2)
             return structure
 
     @staticmethod
@@ -380,7 +380,7 @@ class JahnTellerAnalyzer:
                 spin_config = self.spin_configs[motif][d_electrons][spin_state]
                 magnitude = JahnTellerAnalyzer.get_magnitude_of_effect_from_spin_config(motif, spin_config)
         else:
-            warnings.warn("No data for this species.")
+            warnings.warn("No data for this species.", stacklevel=2)
 
         return magnitude
 

--- a/src/pymatgen/analysis/phase_diagram.py
+++ b/src/pymatgen/analysis/phase_diagram.py
@@ -759,7 +759,7 @@ class PhaseDiagram(MSONable):
             if on_error == "raise":
                 raise ValueError(f"Unable to get decomposition for {entry}") from exc
             if on_error == "warn":
-                warnings.warn(f"Unable to get decomposition for {entry}, encountered {exc}")
+                warnings.warn(f"Unable to get decomposition for {entry}, encountered {exc}", stacklevel=2)
             return None, None
         e_above_hull = entry.energy_per_atom - hull_energy
 
@@ -770,7 +770,7 @@ class PhaseDiagram(MSONable):
         if on_error == "raise":
             raise ValueError(msg)
         if on_error == "warn":
-            warnings.warn(msg)
+            warnings.warn(msg, stacklevel=2)
         return None, None  # 'ignore' and 'warn' case
 
     def get_e_above_hull(self, entry: PDEntry, **kwargs: Any) -> float | None:
@@ -906,7 +906,8 @@ class PhaseDiagram(MSONable):
         if len(competing_entries) > space_limit and not stable_only:
             warnings.warn(
                 f"There are {len(competing_entries)} competing entries "
-                f"for {entry.composition} - Calculating inner hull to discard additional unstable entries"
+                f"for {entry.composition} - Calculating inner hull to discard additional unstable entries",
+                stacklevel=2,
             )
 
             reduced_space = competing_entries - {*self._get_stable_entries_in_space(entry_elems)} | {
@@ -922,7 +923,8 @@ class PhaseDiagram(MSONable):
         if len(competing_entries) > space_limit:
             warnings.warn(
                 f"There are {len(competing_entries)} competing entries "
-                f"for {entry.composition} - Using SLSQP to find decomposition likely to be slow"
+                f"for {entry.composition} - Using SLSQP to find decomposition likely to be slow",
+                stacklevel=2,
             )
 
         decomp = _get_slsqp_decomp(entry.composition, competing_entries, tols, maxiter)
@@ -1829,7 +1831,7 @@ class PatchedPhaseDiagram(PhaseDiagram):
             return pd.get_decomposition(comp)
         except ValueError as exc:
             # NOTE warn when stitching across pds is being used
-            warnings.warn(f"{exc} Using SLSQP to find decomposition")
+            warnings.warn(f"{exc} Using SLSQP to find decomposition", stacklevel=2)
             competing_entries = self._get_stable_entries_in_space(frozenset(comp.elements))
             return _get_slsqp_decomp(comp, competing_entries)
 

--- a/src/pymatgen/analysis/piezo.py
+++ b/src/pymatgen/analysis/piezo.py
@@ -39,7 +39,7 @@ class PiezoTensor(Tensor):
         """
         obj = super().__new__(cls, input_array, check_rank=3)
         if not np.allclose(obj, np.transpose(obj, (0, 2, 1)), atol=tol, rtol=0):
-            warnings.warn("Input piezo tensor does not satisfy standard symmetries")
+            warnings.warn("Input piezo tensor does not satisfy standard symmetries", stacklevel=2)
         return obj.view(cls)
 
     @classmethod

--- a/src/pymatgen/analysis/piezo_sensitivity.py
+++ b/src/pymatgen/analysis/piezo_sensitivity.py
@@ -49,7 +49,7 @@ class BornEffectiveCharge:
         self.pointops = pointops
         self.BEC_operations = None
         if np.sum(self.bec) >= tol:
-            warnings.warn("Input born effective charge tensor does not satisfy charge neutrality")
+            warnings.warn("Input born effective charge tensor does not satisfy charge neutrality", stacklevel=2)
 
     def get_BEC_operations(self, eigtol=1e-5, opstol=1e-3):
         """Get the symmetry operations which maps the tensors
@@ -182,7 +182,7 @@ class InternalStrainTensor:
 
         obj = self.ist
         if not np.allclose(obj, np.transpose(obj, (0, 1, 3, 2)), atol=tol, rtol=0):
-            warnings.warn("Input internal strain tensor does not satisfy standard symmetries")
+            warnings.warn("Input internal strain tensor does not satisfy standard symmetries", stacklevel=2)
 
     def get_IST_operations(self, opstol=1e-3) -> list[list[list]]:
         """Get the symmetry operations which maps the tensors

--- a/src/pymatgen/analysis/pourbaix_diagram.py
+++ b/src/pymatgen/analysis/pourbaix_diagram.py
@@ -664,7 +664,9 @@ class PourbaixDiagram(MSONable):
         processed_entries = []
         total = sum(comb(len(entries), idx + 1) for idx in range(n_elems))
         if total > 1e6:
-            warnings.warn(f"Your Pourbaix diagram includes {total} entries and may take a long time to generate.")
+            warnings.warn(
+                f"Your Pourbaix diagram includes {total} entries and may take a long time to generate.", stacklevel=2
+            )
 
         # Parallel processing of multi-entry generation
         if nproc is not None:

--- a/src/pymatgen/analysis/structure_analyzer.py
+++ b/src/pymatgen/analysis/structure_analyzer.py
@@ -296,7 +296,10 @@ class VoronoiConnectivity:
                 connectivity[atom_j, atom_i, image_i] = val
 
             if -10.101 in vts[v]:
-                warn("Found connectivity with infinite vertex. Cutoff is too low, and results may be incorrect")
+                warn(
+                    "Found connectivity with infinite vertex. Cutoff is too low, and results may be incorrect",
+                    stacklevel=2,
+                )
         return connectivity
 
     @property

--- a/src/pymatgen/analysis/structure_prediction/dopant_predictor.py
+++ b/src/pymatgen/analysis/structure_prediction/dopant_predictor.py
@@ -101,7 +101,9 @@ def get_dopants_from_shannon_radii(bonded_structure, num_dopants=5, match_oxi_si
         try:
             species_radius = species.get_shannon_radius(cn_roman)
         except KeyError:
-            warnings.warn(f"Shannon radius not found for {species} with coordination number {cn}.\nSkipping...")
+            warnings.warn(
+                f"Shannon radius not found for {species} with coordination number {cn}.\nSkipping...", stacklevel=2
+            )
             continue
 
         if cn not in cn_to_radii_map:

--- a/src/pymatgen/analysis/structure_prediction/volume_predictor.py
+++ b/src/pymatgen/analysis/structure_prediction/volume_predictor.py
@@ -92,7 +92,7 @@ class RLSVolumePredictor:
 
                 return ref_structure.volume * (numerator / denominator) ** 3
             except Exception:
-                warnings.warn("Exception occurred. Will attempt atomic radii.")
+                warnings.warn("Exception occurred. Will attempt atomic radii.", stacklevel=2)
                 # If error occurs during use of ionic radii scheme, pass
                 # and see if we can resolve it using atomic radii.
 
@@ -180,10 +180,10 @@ class DLSVolumePredictor:
             if sp.atomic_radius:
                 sub_sites.extend([site for site in structure if site.specie == sp])
             else:
-                warnings.warn(f"VolumePredictor: no atomic radius data for {sp}")
+                warnings.warn(f"VolumePredictor: no atomic radius data for {sp}", stacklevel=2)
 
             if sp.symbol not in bond_params:
-                warnings.warn(f"VolumePredictor: bond parameters not found, used atomic radii for {sp}")
+                warnings.warn(f"VolumePredictor: bond parameters not found, used atomic radii for {sp}", stacklevel=2)
             else:
                 r, k = bond_params[sp.symbol]["r"], bond_params[sp.symbol]["k"]
                 bp_dict[sp] = float(r) + float(k) * std_x

--- a/src/pymatgen/analysis/surface_analysis.py
+++ b/src/pymatgen/analysis/surface_analysis.py
@@ -193,7 +193,7 @@ class SlabEntry(ComputedStructureEntry):
         if slab_clean_comp.reduced_composition != ucell_entry.composition.reduced_composition:
             list_els = [next(iter(entry.composition.as_dict())) for entry in ref_entries]
             if not any(el in list_els for el in ucell_entry.composition.as_dict()):
-                warnings.warn("Elemental references missing for the non-dopant species.")
+                warnings.warn("Elemental references missing for the non-dopant species.", stacklevel=2)
 
         gamma = (Symbol("E_surf") - Symbol("Ebulk")) / (2 * Symbol("A"))
         ucell_comp = ucell_entry.composition
@@ -659,7 +659,7 @@ class SurfaceEnergyPlotter:
 
         solution = linsolve(all_eqns, all_parameters)
         if not solution:
-            warnings.warn("No solution")
+            warnings.warn("No solution", stacklevel=2)
             return solution
         return {param: next(iter(solution))[idx] for idx, param in enumerate(all_parameters)}
 

--- a/src/pymatgen/analysis/wulff.py
+++ b/src/pymatgen/analysis/wulff.py
@@ -140,7 +140,7 @@ class WulffShape:
             symprec (float): for reciprocal lattice operation, default is 1e-5.
         """
         if any(se < 0 for se in e_surf_list):
-            warnings.warn("Unphysical (negative) surface energy detected.")
+            warnings.warn("Unphysical (negative) surface energy detected.", stacklevel=2)
 
         self.color_ind = list(range(len(miller_list)))
 

--- a/src/pymatgen/analysis/xas/spectrum.py
+++ b/src/pymatgen/analysis/xas/spectrum.py
@@ -85,7 +85,6 @@ class XAS(Spectrum):
         if len(self.y[neg_intens_mask]) / len(self.y) > 0.05:
             warnings.warn(
                 "Double check the intensities. More than 5% of them are negative.",
-                UserWarning,
                 stacklevel=2,
             )
         self.zero_negative_intensity = zero_negative_intensity
@@ -216,7 +215,6 @@ class XAS(Spectrum):
             if abs(mu[idx] - mu[idx - 1]) / (mu[idx - 1]) > 0.1:
                 warnings.warn(
                     "There might exist a jump at the L2 and L3-edge junction.",
-                    UserWarning,
                     stacklevel=2,
                 )
 

--- a/src/pymatgen/analysis/xps.py
+++ b/src/pymatgen/analysis/xps.py
@@ -96,5 +96,5 @@ class XPS(Spectrum):
                 if weight is not None:
                     total += pdos.get_densities() * weight
                 else:
-                    warnings.warn(f"No cross-section for {el}{orb}")
+                    warnings.warn(f"No cross-section for {el}{orb}", stacklevel=2)
         return XPS(-dos.energies, total / np.max(total))

--- a/src/pymatgen/apps/borg/hive.py
+++ b/src/pymatgen/apps/borg/hive.py
@@ -139,7 +139,7 @@ class VaspToComputedEntryDrone(AbstractDrone):
                 # Since multiple files are ambiguous, we will always read
                 # the last one alphabetically.
                 filepath = max(vasprun_files)
-                warnings.warn(f"{len(vasprun_files)} vasprun.xml.* found. {filepath} is being parsed.")
+                warnings.warn(f"{len(vasprun_files)} vasprun.xml.* found. {filepath} is being parsed.", stacklevel=2)
 
         try:
             vasp_run = Vasprun(filepath)
@@ -252,7 +252,9 @@ class SimpleVaspToComputedEntryDrone(VaspToComputedEntryDrone):
                         # alphabetically for CONTCAR and OSZICAR.
 
                         files_to_parse[filename] = files[0] if filename == "POSCAR" else files[-1]
-                        warnings.warn(f"{len(files)} files found. {files_to_parse[filename]} is being parsed.")
+                        warnings.warn(
+                            f"{len(files)} files found. {files_to_parse[filename]} is being parsed.", stacklevel=2
+                        )
 
             if not set(files_to_parse).issuperset({"INCAR", "POTCAR", "CONTCAR", "OSZICAR", "POSCAR"}):
                 raise ValueError(

--- a/src/pymatgen/command_line/bader_caller.py
+++ b/src/pymatgen/command_line/bader_caller.py
@@ -192,7 +192,8 @@ class BaderAnalysis:
 
             if self.version < 1.0:
                 warnings.warn(
-                    "Your installed version of Bader is outdated, calculation of vacuum charge may be incorrect."
+                    "Your installed version of Bader is outdated, calculation of vacuum charge may be incorrect.",
+                    stacklevel=2,
                 )
 
             # Parse ACF.dat file
@@ -460,7 +461,7 @@ class BaderAnalysis:
                 # kwarg to avoid this!
                 paths.sort(reverse=True)
                 if len(paths) > 1:
-                    warnings.warn(f"Multiple files detected, using {paths[0]}")
+                    warnings.warn(f"Multiple files detected, using {paths[0]}", stacklevel=2)
                 filepath = paths[0]
             else:
                 msg = f"Could not find {filename!r}"
@@ -468,7 +469,7 @@ class BaderAnalysis:
                     msg += ", interpret Bader results with severe caution."
                 elif filename == "POTCAR":
                     msg += ", cannot calculate charge transfer."
-                warnings.warn(msg)
+                warnings.warn(msg, stacklevel=2)
             return filepath
 
         chgcar_filename = _get_filepath("CHGCAR")
@@ -515,7 +516,7 @@ def bader_analysis_from_path(path: str, suffix: str = "") -> dict[str, Any]:
     def _get_filepath(filename: str, msg: str = "") -> str | None:
         paths = glob(glob_pattern := f"{path}/{filename}{suffix}*")
         if len(paths) == 0:
-            warnings.warn(msg or f"no matches for {glob_pattern=}")
+            warnings.warn(msg or f"no matches for {glob_pattern=}", stacklevel=2)
             return None
         if len(paths) > 1:
             # using reverse=True because, if multiple files are present,
@@ -523,7 +524,7 @@ def bader_analysis_from_path(path: str, suffix: str = "") -> dict[str, Any]:
             # and this would give 'static' over 'relax2' over 'relax'
             # however, better to use 'suffix' kwarg to avoid this!
             paths.sort(reverse=True)
-            warnings.warn(f"Multiple files detected, using {os.path.basename(path)}")
+            warnings.warn(f"Multiple files detected, using {os.path.basename(path)}", stacklevel=2)
         return paths[0]
 
     chgcar_path = _get_filepath("CHGCAR", "Could not find CHGCAR!")
@@ -533,17 +534,17 @@ def bader_analysis_from_path(path: str, suffix: str = "") -> dict[str, Any]:
 
     aeccar0_path = _get_filepath("AECCAR0")
     if not aeccar0_path:
-        warnings.warn("Could not find AECCAR0, interpret Bader results with severe caution!")
+        warnings.warn("Could not find AECCAR0, interpret Bader results with severe caution!", stacklevel=2)
     aeccar0 = Chgcar.from_file(aeccar0_path) if aeccar0_path else None
 
     aeccar2_path = _get_filepath("AECCAR2")
     if not aeccar2_path:
-        warnings.warn("Could not find AECCAR2, interpret Bader results with severe caution!")
+        warnings.warn("Could not find AECCAR2, interpret Bader results with severe caution!", stacklevel=2)
     aeccar2 = Chgcar.from_file(aeccar2_path) if aeccar2_path else None
 
     potcar_path = _get_filepath("POTCAR")
     if not potcar_path:
-        warnings.warn("Could not find POTCAR, cannot calculate charge transfer.")
+        warnings.warn("Could not find POTCAR, cannot calculate charge transfer.", stacklevel=2)
     potcar = Potcar.from_file(potcar_path) if potcar_path else None
 
     return bader_analysis_from_objects(chgcar, potcar, aeccar0, aeccar2)

--- a/src/pymatgen/command_line/chargemol_caller.py
+++ b/src/pymatgen/command_line/chargemol_caller.py
@@ -126,12 +126,12 @@ class ChargemolAnalysis:
 
         else:
             self.chgcar = self.structure = self.natoms = None
-            warnings.warn("No CHGCAR found. Some properties may be unavailable.", UserWarning)
+            warnings.warn("No CHGCAR found. Some properties may be unavailable.", stacklevel=2)
 
         if self._potcar_path:
             self.potcar = Potcar.from_file(self._potcar_path)
         else:
-            warnings.warn("No POTCAR found. Some properties may be unavailable.", UserWarning)
+            warnings.warn("No POTCAR found. Some properties may be unavailable.", stacklevel=2)
 
         self.aeccar0 = Chgcar.from_file(self._aeccar0_path) if self._aeccar0_path else None
         self.aeccar2 = Chgcar.from_file(self._aeccar2_path) if self._aeccar2_path else None
@@ -164,7 +164,7 @@ class ChargemolAnalysis:
             # however, better to use 'suffix' kwarg to avoid this!
             paths.sort(reverse=True)
             if len(paths) > 1:
-                warnings.warn(f"Multiple files detected, using {os.path.basename(paths[0])}")
+                warnings.warn(f"Multiple files detected, using {os.path.basename(paths[0])}", stacklevel=2)
             fpath = paths[0]
         return fpath
 

--- a/src/pymatgen/command_line/critic2_caller.py
+++ b/src/pymatgen/command_line/critic2_caller.py
@@ -107,7 +107,7 @@ class Critic2Caller:
         stderr = ""
         if _stderr:
             stderr = _stderr.decode()
-            warnings.warn(stderr)
+            warnings.warn(stderr, stacklevel=2)
 
         if rs.returncode != 0:
             raise RuntimeError(f"critic2 exited with return code {rs.returncode}: {stdout}")
@@ -332,7 +332,7 @@ def get_filepath(filename, warning, path, suffix):
     """
     paths = glob(os.path.join(path, f"{filename}{suffix}*"))
     if not paths:
-        warnings.warn(warning)
+        warnings.warn(warning, stacklevel=2)
         return None
     if len(paths) > 1:
         # using reverse=True because, if multiple files are present,
@@ -340,7 +340,7 @@ def get_filepath(filename, warning, path, suffix):
         # and this would give 'static' over 'relax2' over 'relax'
         # however, better to use 'suffix' kwarg to avoid this!
         paths.sort(reverse=True)
-        warnings.warn(f"Multiple files detected, using {os.path.basename(path)}")
+        warnings.warn(f"Multiple files detected, using {os.path.basename(path)}", stacklevel=2)
     return paths[0]
 
 
@@ -550,7 +550,8 @@ class Critic2Analysis(MSONable):
                             "Duplicate edge detected, try re-running "
                             "critic2 with custom parameters to fix this. "
                             "Mostly harmless unless user is also "
-                            "interested in rings/cages."
+                            "interested in rings/cages.",
+                            stacklevel=2,
                         )
                         logger.debug(
                             f"Duplicate edge between points {idx} (unique point {self.nodes[idx]['unique_idx']})"
@@ -700,7 +701,8 @@ class Critic2Analysis(MSONable):
         if len(node_mapping) != len(self.structure):
             warnings.warn(
                 f"Check that all sites in input structure ({len(self.structure)}) have "
-                f"been detected by critic2 ({ len(node_mapping)})."
+                f"been detected by critic2 ({ len(node_mapping)}).",
+                stacklevel=2,
             )
 
         self.nodes = {node_mapping.get(idx, idx): node for idx, node in self.nodes.items()}
@@ -755,7 +757,7 @@ class Critic2Analysis(MSONable):
 
         if zpsp:
             if len(charge_transfer) != len(charges):
-                warnings.warn(f"Something went wrong calculating charge transfer: {charge_transfer}")
+                warnings.warn(f"Something went wrong calculating charge transfer: {charge_transfer}", stacklevel=2)
             else:
                 structure.add_site_property("bader_charge_transfer", charge_transfer)
 
@@ -764,7 +766,9 @@ class Critic2Analysis(MSONable):
     def _parse_stdout(self, stdout):
         warnings.warn(
             "Parsing critic2 standard output is deprecated and will not be maintained, "
-            "please use the native JSON output in future."
+            "please use the native JSON output in future.",
+            DeprecationWarning,
+            stacklevel=2,
         )
 
         stdout = stdout.split("\n")

--- a/src/pymatgen/core/__init__.py
+++ b/src/pymatgen/core/__init__.py
@@ -57,7 +57,9 @@ def _load_pmg_settings() -> dict[str, Any]:
         except Exception as exc:
             # If there are any errors, default to using environment variables
             # if present.
-            warnings.warn(f"Error loading {file_path}: {exc}.\nYou may need to reconfigure your YAML file.")
+            warnings.warn(
+                f"Error loading {file_path}: {exc}.\nYou may need to reconfigure your YAML file.", stacklevel=2
+            )
 
     # Override .pmgrc.yaml with env vars (if present)
     for key, val in os.environ.items():

--- a/src/pymatgen/core/bonds.py
+++ b/src/pymatgen/core/bonds.py
@@ -189,7 +189,7 @@ def get_bond_order(
     # Distance shorter than the shortest bond length stored,
     # check if the distance is too short
     if dist < lens[-1] * (1 - tol):  # too short
-        warnings.warn(f"{dist:.2f} angstrom distance is too short for {sp1} and {sp2}")
+        warnings.warn(f"{dist:.2f} angstrom distance is too short for {sp1} and {sp2}", stacklevel=2)
     # return the highest bond order
     return trial_bond_order - 1
 
@@ -226,6 +226,7 @@ def get_bond_length(
     except (ValueError, KeyError):
         warnings.warn(
             f"No order {bond_order} bond lengths between {sp1} and {sp2} found in "
-            "database. Returning sum of atomic radius."
+            "database. Returning sum of atomic radius.",
+            stacklevel=2,
         )
         return sp1.atomic_radius + sp2.atomic_radius  # type: ignore[operator]

--- a/src/pymatgen/core/composition.py
+++ b/src/pymatgen/core/composition.py
@@ -802,7 +802,8 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
         """
         warnings.warn(
             "Composition.charge is experimental and may produce incorrect results. Use with "
-            "caution and open a GitHub issue pinging @janosh to report bad behavior."
+            "caution and open a GitHub issue pinging @janosh to report bad behavior.",
+            stacklevel=2,
         )
         oxi_states = [getattr(specie, "oxi_state", None) for specie in self]
         if {*oxi_states} <= {0, None}:
@@ -818,7 +819,8 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
         """
         warnings.warn(
             "Composition.charge_balanced is experimental and may produce incorrect results. "
-            "Use with caution and open a GitHub issue pinging @janosh to report bad behavior."
+            "Use with caution and open a GitHub issue pinging @janosh to report bad behavior.",
+            stacklevel=2,
         )
         if self.charge is None:
             if {getattr(el, "oxi_state", None) for el in self} == {0}:
@@ -887,7 +889,8 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
         if invalid_elems:
             warnings.warn(
                 "Some elements to be substituted are not present in composition. Please check your input. "
-                f"Problematic element = {invalid_elems}; {self}"
+                f"Problematic element = {invalid_elems}; {self}",
+                stacklevel=2,
             )
         for elem in invalid_elems:
             elem_map.pop(elem)
@@ -917,7 +920,8 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
                 if el in self:
                     warnings.warn(
                         f"Same element ({el}) in both the keys and values of the substitution!"
-                        "This can be ambiguous, so be sure to check your result."
+                        "This can be ambiguous, so be sure to check your result.",
+                        stacklevel=2,
                     )
 
         return type(self)(new_comp)

--- a/src/pymatgen/core/interface.py
+++ b/src/pymatgen/core/interface.py
@@ -2072,7 +2072,8 @@ class GrainBoundaryGenerator:
             sigmas.sort()
             warnings.warn(
                 "This is not the possible sigma value according to the rotation axis!"
-                "The nearest neighbor sigma and its corresponding angle are returned"
+                "The nearest neighbor sigma and its corresponding angle are returned",
+                stacklevel=2,
             )
             rotation_angles = sigma_dict[sigmas[-1]]
         rotation_angles.sort()
@@ -2144,7 +2145,7 @@ class GrainBoundaryGenerator:
             t_matrix[1] = np.array(np.dot(scale_factor[1], csl))
             t_matrix[2] = csl[miller_nonzero[0]]
             if abs(np.linalg.det(t_matrix)) > 1000:
-                warnings.warn("Too large matrix. Suggest to use quick_gen=False")
+                warnings.warn("Too large matrix. Suggest to use quick_gen=False", stacklevel=2)
             return t_matrix
 
         c_index = 0
@@ -2235,7 +2236,7 @@ class GrainBoundaryGenerator:
             logger.info("Did not find the perpendicular c vector, increase max_j")
             while not normal_init:
                 if max_j == max_search:
-                    warnings.warn("Cannot find the perpendicular c vector, please increase max_search")
+                    warnings.warn("Cannot find the perpendicular c vector, please increase max_search", stacklevel=2)
                     break
                 max_j *= 3
                 max_j = min(max_j, max_search)
@@ -2298,7 +2299,7 @@ class GrainBoundaryGenerator:
             t_matrix *= -1
 
         if normal and abs(np.linalg.det(t_matrix)) > 1000:
-            warnings.warn("Too large matrix. Suggest to use Normal=False")
+            warnings.warn("Too large matrix. Suggest to use Normal=False", stacklevel=2)
         return t_matrix
 
     @staticmethod
@@ -2335,7 +2336,7 @@ class GrainBoundaryGenerator:
                 break
 
         if not reduced:
-            warnings.warn("Matrix reduction not performed, may lead to non-primitive GB cell.")
+            warnings.warn("Matrix reduction not performed, may lead to non-primitive GB cell.", stacklevel=2)
         return mat
 
     @staticmethod

--- a/src/pymatgen/core/lattice.py
+++ b/src/pymatgen/core/lattice.py
@@ -1792,7 +1792,7 @@ def get_integer_index(
     # Need to recalculate this after rounding as values may have changed
     int_miller_index = np.round(mi, 1).astype(int)
     if np.any(np.abs(mi - int_miller_index) > 1e-6) and verbose:
-        warnings.warn("Non-integer encountered in Miller index")
+        warnings.warn("Non-integer encountered in Miller index", stacklevel=2)
     else:
         mi = int_miller_index
 

--- a/src/pymatgen/core/operations.py
+++ b/src/pymatgen/core/operations.py
@@ -450,7 +450,7 @@ class SymmOp(MSONable):
         """
         # Check for invalid rotation matrix
         if not np.allclose(self.rotation_matrix, np.round(self.rotation_matrix)):
-            warnings.warn("Rotation matrix should be integer")
+            warnings.warn("Rotation matrix should be integer", stacklevel=2)
 
         return transformation_to_string(
             self.rotation_matrix,

--- a/src/pymatgen/core/periodic_table.py
+++ b/src/pymatgen/core/periodic_table.py
@@ -207,7 +207,7 @@ class ElementBase(Enum):
             key = item.capitalize().replace("_", " ")
             val = self._data.get(key)
             if val is None or str(val).startswith("no data"):
-                warnings.warn(f"No data available for {item} for {self.symbol}")
+                warnings.warn(f"No data available for {item} for {self.symbol}", stacklevel=2)
                 val = None
             elif isinstance(val, list | dict):
                 pass
@@ -246,7 +246,8 @@ class ElementBase(Enum):
                         and (match := re.findall(r"[\.\d]+", val))
                     ):
                         warnings.warn(
-                            f"Ambiguous values ({val}) for {item} of {self.symbol}. Returning first float value."
+                            f"Ambiguous values ({val}) for {item} of {self.symbol}. Returning first float value.",
+                            stacklevel=2,
                         )
                         return float(match[0])
             return val
@@ -293,7 +294,8 @@ class ElementBase(Enum):
             return X
         warnings.warn(
             f"No Pauling electronegativity for {self.symbol}. Setting to NaN. This has no physical meaning, "
-            "and is mainly done to avoid errors caused by the code expecting a float."
+            "and is mainly done to avoid errors caused by the code expecting a float.",
+            stacklevel=2,
         )
         return float("NaN")
 
@@ -342,7 +344,7 @@ class ElementBase(Enum):
     def ionization_energy(self) -> float | None:
         """First ionization energy of element."""
         if not self.ionization_energies:
-            warnings.warn(f"No data available for ionization_energy for {self.symbol}")
+            warnings.warn(f"No data available for ionization_energy for {self.symbol}", stacklevel=2)
             return None
         return self.ionization_energies[0]
 
@@ -1227,12 +1229,12 @@ class Species(MSONable, Stringify):
             oxi_str = str(int(self._oxi_state))
             warn_msg = f"No default ionic radius for {self}."
             if ion_rad := dct.get("Ionic radii hs", {}).get(oxi_str):
-                warnings.warn(f"{warn_msg} Using hs data.")
+                warnings.warn(f"{warn_msg} Using hs data.", stacklevel=2)
                 return ion_rad
             if ion_rad := dct.get("Ionic radii ls", {}).get(oxi_str):
-                warnings.warn(f"{warn_msg} Using ls data.")
+                warnings.warn(f"{warn_msg} Using ls data.", stacklevel=2)
                 return ion_rad
-        warnings.warn(f"No ionic radius for {self}!")
+        warnings.warn(f"No ionic radius for {self}!", stacklevel=2)
         return None
 
     @classmethod
@@ -1339,7 +1341,8 @@ class Species(MSONable, Stringify):
             if key != spin:
                 warnings.warn(
                     f"Specified {spin=} not consistent with database spin of {key}. "
-                    "Only one spin data available, and that value is returned."
+                    "Only one spin data available, and that value is returned.",
+                    stacklevel=2,
                 )
         else:
             data = radii[spin]

--- a/src/pymatgen/core/structure.py
+++ b/src/pymatgen/core/structure.py
@@ -605,7 +605,8 @@ class SiteCollection(collections.abc.Sequence, ABC):
         if not sp_in_structure >= sp_to_replace:
             warnings.warn(
                 "Some species to be substituted are not present in structure. Pls check your input. Species to be "
-                f"substituted = {sp_to_replace}; Species in structure = {sp_in_structure}"
+                f"substituted = {sp_to_replace}; Species in structure = {sp_in_structure}",
+                stacklevel=2,
             )
 
         for site in site_coll:
@@ -1260,7 +1261,7 @@ class IStructure(SiteCollection, MSONable):
                 props[key][idx] = val
         for key, val in props.items():
             if any(vv is None for vv in val):
-                warnings.warn(f"Not all sites have property {key}. Missing values are set to None.")
+                warnings.warn(f"Not all sites have property {key}. Missing values are set to None.", stacklevel=2)
         return cls(
             lattice,
             [site.species for site in sites],
@@ -1516,7 +1517,8 @@ class IStructure(SiteCollection, MSONable):
         if abs(formal_charge - self._charge) > 1e-8:
             warnings.warn(
                 f"Structure charge ({self._charge}) is set to be not equal to the sum of oxidation states"
-                f" ({formal_charge}). Use Structure.unset_charge() to reset the charge to None."
+                f" ({formal_charge}). Use Structure.unset_charge() to reset the charge to None.",
+                stacklevel=2,
             )
         return self._charge
 
@@ -4753,7 +4755,8 @@ class Structure(IStructure, collections.abc.MutableSequence):
                         else:
                             props[key] = None
                             warnings.warn(
-                                f"Sites with different site property {key} are merged. So property is set to none"
+                                f"Sites with different site property {key} are merged. So property is set to none",
+                                stacklevel=2,
                             )
             sites.append(PeriodicSite(species, coords, self.lattice, properties=props))
 

--- a/src/pymatgen/core/surface.py
+++ b/src/pymatgen/core/surface.py
@@ -537,7 +537,8 @@ class Slab(Structure):
                     "Odd number of sites to divide! Try changing "
                     "the tolerance to ensure even division of "
                     "sites or create supercells in a or b directions "
-                    "to allow for atoms to be moved!"
+                    "to allow for atoms to be moved!",
+                    stacklevel=2,
                 )
                 continue
             combinations = []
@@ -627,8 +628,7 @@ class Slab(Structure):
         # Check if deprecated argument is used
         if specie is not None:
             warnings.warn(
-                "The argument 'specie' is deprecated. Use 'species' instead.",
-                DeprecationWarning,
+                "The argument 'specie' is deprecated. Use 'species' instead.", DeprecationWarning, stacklevel=2
             )
             species = specie
 
@@ -660,8 +660,7 @@ class Slab(Structure):
         # Check if deprecated argument is used
         if specie is not None:
             warnings.warn(
-                "The argument 'specie' is deprecated. Use 'species' instead.",
-                DeprecationWarning,
+                "The argument 'specie' is deprecated. Use 'species' instead.", DeprecationWarning, stacklevel=2
             )
             species = specie
 
@@ -737,7 +736,7 @@ class Slab(Structure):
             self.remove_sites(equi_sites)
 
         else:
-            warnings.warn("Equivalent sites could not be found for some indices. Surface unchanged.")
+            warnings.warn("Equivalent sites could not be found for some indices. Surface unchanged.", stacklevel=2)
 
 
 def center_slab(slab: Structure) -> Structure:
@@ -1556,7 +1555,7 @@ class SlabGenerator:
                     slab.remove_sites([z_coords.index(min(z_coords))])
 
                 if len(slab) <= len(self.parent):
-                    warnings.warn("Too many sites removed, please use a larger slab.")
+                    warnings.warn("Too many sites removed, please use a larger slab.", stacklevel=2)
                     break
 
                 # Check if the new Slab is symmetric

--- a/src/pymatgen/core/tensors.py
+++ b/src/pymatgen/core/tensors.py
@@ -346,7 +346,7 @@ class Tensor(np.ndarray, MSONable):
         for ind, v in this_voigt_map.items():
             v_matrix[v] = self[ind]
         if not self.is_voigt_symmetric():
-            warnings.warn("Tensor is not symmetric, information may be lost in Voigt conversion.")
+            warnings.warn("Tensor is not symmetric, information may be lost in Voigt conversion.", stacklevel=2)
         return v_matrix * self._vscale
 
     def is_voigt_symmetric(self, tol: float = 1e-6) -> bool:
@@ -531,7 +531,7 @@ class Tensor(np.ndarray, MSONable):
         """
         sm = StructureMatcher()
         if not sm.fit(original_structure, new_structure):
-            warnings.warn("original and new structures do not match!")
+            warnings.warn("original and new structures do not match!", stacklevel=2)
         trans_1 = self.get_ieee_rotation(original_structure, refine_rotation)
         trans_2 = self.get_ieee_rotation(new_structure, refine_rotation)
         # Get the ieee format tensor
@@ -672,7 +672,7 @@ class Tensor(np.ndarray, MSONable):
                 print(f"Iteration {idx}: {np.max(diff)}")
         if not converged:
             max_diff = np.max(np.abs(self - test_new))
-            warnings.warn(f"Warning, populated tensor is not converged with max diff of {max_diff}")
+            warnings.warn(f"Warning, populated tensor is not converged with max diff of {max_diff}", stacklevel=2)
         return type(self)(test_new)
 
     def as_dict(self, voigt: bool = False) -> dict:

--- a/src/pymatgen/core/trajectory.py
+++ b/src/pymatgen/core/trajectory.py
@@ -147,7 +147,8 @@ class Trajectory(MSONable):
                 self.lattice = np.tile(lattice, (len(coords), 1, 1))
                 warnings.warn(
                     "Get constant_lattice=False, but only get a single lattice. "
-                    "Use this single lattice as the lattice for all frames."
+                    "Use this single lattice as the lattice for all frames.",
+                    stacklevel=2,
                 )
             else:
                 self.lattice = lattice
@@ -161,7 +162,8 @@ class Trajectory(MSONable):
             if base_positions is None:
                 warnings.warn(
                     "Without providing an array of starting positions, the positions "
-                    "for each time step will not be available."
+                    "for each time step will not be available.",
+                    stacklevel=2,
                 )
             self.base_positions = base_positions
         else:

--- a/src/pymatgen/electronic_structure/bandstructure.py
+++ b/src/pymatgen/electronic_structure/bandstructure.py
@@ -652,7 +652,8 @@ class BandStructure:
                 "Trying from_dict failed. Now we are trying the old "
                 "format. Please convert your BS dicts to the new "
                 "format. The old format will be retired in pymatgen "
-                "5.0."
+                "5.0.",
+                stacklevel=2,
             )
             return cls.from_old_dict(dct)
 
@@ -980,7 +981,8 @@ class LobsterBandStructureSymmLine(BandStructureSymmLine):
                 "Trying from_dict failed. Now we are trying the old "
                 "format. Please convert your BS dicts to the new "
                 "format. The old format will be retired in pymatgen "
-                "5.0."
+                "5.0.",
+                stacklevel=2,
             )
             return cls.from_old_dict(dct)
 

--- a/src/pymatgen/electronic_structure/boltztrap2.py
+++ b/src/pymatgen/electronic_structure/boltztrap2.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING
 
 import matplotlib.pyplot as plt
 import numpy as np
+from monty.dev import deprecated
 from monty.serialization import dumpfn, loadfn
 from tqdm import tqdm
 
@@ -182,6 +183,7 @@ class VasprunBSLoader:
         return accepted
 
 
+@deprecated(VasprunBSLoader, category=DeprecationWarning)
 class BandstructureLoader:
     """Loader for Bandstructure object."""
 
@@ -201,8 +203,6 @@ class BandstructureLoader:
             ne = vrun.parameters['NELECT']
             data = BandstructureLoader(bs,st,ne)
         """
-        warnings.warn("Deprecated Loader. Use VasprunBSLoader instead.")
-
         self.kpoints = np.array([kp.frac_coords for kp in bs_obj.kpoints])
 
         self.structure = bs_obj.structure if structure is None else structure
@@ -278,7 +278,8 @@ class BandstructureLoader:
         range in the spin up/down bands when calculating the DOS.
         """
         warnings.warn(
-            "This method does not work anymore in case of spin polarized case due to the concatenation of bands !"
+            "This method does not work anymore in case of spin polarized case due to the concatenation of bands !",
+            stacklevel=2,
         )
 
         lower_band = e_lower * np.ones((1, self.ebands.shape[1]))
@@ -301,13 +302,12 @@ class BandstructureLoader:
         return self.UCvol
 
 
+@deprecated(VasprunBSLoader, category=DeprecationWarning)
 class VasprunLoader:
     """Loader for Vasprun object."""
 
     def __init__(self, vrun_obj=None) -> None:
         """vrun_obj: Vasprun object."""
-        warnings.warn("Deprecated Loader. Use VasprunBSLoader instead.")
-
         if vrun_obj:
             self.kpoints = np.array(vrun_obj.actual_kpoints)
             self.structure = vrun_obj.final_structure
@@ -1199,7 +1199,10 @@ def merge_up_down_doses(dos_up, dos_dn):
     Returns:
         CompleteDos object
     """
-    warnings.warn("This function is not useful anymore. VasprunBSLoader deals with spin case.")
+    warnings.warn(
+        "This function is not useful anymore. VasprunBSLoader deals with spin case.", DeprecationWarning, stacklevel=2
+    )
+
     cdos = Dos(
         dos_up.efermi,
         dos_up.energies,

--- a/src/pymatgen/electronic_structure/cohp.py
+++ b/src/pymatgen/electronic_structure/cohp.py
@@ -1247,7 +1247,9 @@ class IcohpCollection(MSONable):
         for label in label_list:
             icohp = self._icohplist[label]
             if icohp.num_bonds != 1:
-                warnings.warn("One of the ICOHP values is an average over bonds. This is currently not considered.")
+                warnings.warn(
+                    "One of the ICOHP values is an average over bonds. This is currently not considered.", stacklevel=2
+                )
 
             if icohp._is_spin_polarized and summed_spin_channels:
                 sum_icohp += icohp.summed_icohp
@@ -1350,7 +1352,7 @@ class IcohpCollection(MSONable):
 
         if not self._is_spin_polarized:
             if spin == Spin.down:
-                warnings.warn("This spin channel does not exist. I am switching to Spin.up")
+                warnings.warn("This spin channel does not exist. I am switching to Spin.up", stacklevel=2)
             spin = Spin.up
 
         for value in self._icohplist.values():

--- a/src/pymatgen/electronic_structure/dos.py
+++ b/src/pymatgen/electronic_structure/dos.py
@@ -604,7 +604,7 @@ class FermiDos(Dos, MSONable):
             return self.get_fermi(concentration, temperature, **kwargs)
         except ValueError as exc:
             if warn:
-                warnings.warn(str(exc))
+                warnings.warn(str(exc), stacklevel=2)
 
             if abs(concentration) < c_ref:
                 if abs(concentration) < 1e-10:
@@ -1482,7 +1482,7 @@ class LobsterCompleteDos(CompleteDos):
         Returns:
             dict[Literal["e_g", "t2g"], Dos]: Summed e_g and t2g DOS for the site.
         """
-        warnings.warn("Are the orbitals correctly oriented? Are you sure?")
+        warnings.warn("Are the orbitals correctly oriented? Are you sure?", stacklevel=2)
 
         t2g_dos = []
         eg_dos = []

--- a/src/pymatgen/electronic_structure/plotter.py
+++ b/src/pymatgen/electronic_structure/plotter.py
@@ -570,9 +570,9 @@ class BSPlotter:
                 # reducing smooth_k when the number
                 # of points are fewer then k
                 smooth_k = len(dist) - 1
-                warnings.warn(warning_m_fewer_k)
+                warnings.warn(warning_m_fewer_k, stacklevel=2)
             elif len(dist) == 1:
-                warnings.warn("Skipping single point branch")
+                warnings.warn("Skipping single point branch", stacklevel=2)
                 continue
 
             int_distances.append(np.linspace(dist[0], dist[-1], smooth_np))
@@ -587,7 +587,7 @@ class BSPlotter:
             int_energies.append(np.vstack(br_en))
 
             if np.any(np.isnan(int_energies[-1])):
-                warnings.warn(warning_nan)
+                warnings.warn(warning_nan, stacklevel=2)
 
         return int_distances, int_energies
 
@@ -860,7 +860,7 @@ class BSPlotter:
         Returns:
             plt.Axes: matplotlib Axes object with both band structures
         """
-        warnings.warn("Deprecated method. Use BSPlotter([sbs1,sbs2,...]).get_plot() instead.")
+        warnings.warn("Deprecated method. Use BSPlotter([sbs1,sbs2,...]).get_plot() instead.", stacklevel=2)
 
         # TODO: add exception if the band structures are not compatible
         ax = self.get_plot()
@@ -928,7 +928,8 @@ class BSPlotterProjected(BSPlotter):
         if isinstance(bs, list):
             warnings.warn(
                 "Multiple band structures are not handled by BSPlotterProjected. "
-                "Only the first in the list will be considered"
+                "Only the first in the list will be considered",
+                stacklevel=2,
             )
             bs = bs[0]
 
@@ -2347,7 +2348,8 @@ class BSDOSPlotter:
             warnings.warn(
                 "Cannot get element projected data; either the projection data "
                 "doesn't exist, or you don't have a compound with exactly 2 "
-                "or 3 or 4 unique elements."
+                "or 3 or 4 unique elements.",
+                stacklevel=2,
             )
             bs_projection = None
 

--- a/src/pymatgen/entries/compatibility.py
+++ b/src/pymatgen/entries/compatibility.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, TypeAlias, cast
 import numpy as np
 from joblib import Parallel, delayed
 from monty.design_patterns import cached_class
+from monty.dev import deprecated
 from monty.json import MSONable
 from monty.serialization import loadfn
 from tqdm import tqdm
@@ -882,6 +883,11 @@ class CorrectionsList(Compatibility):
         print(f"The final energy after corrections is {dct['corrected_energy']:f}")
 
 
+@deprecated(
+    "MaterialsProject2020Compatibility",
+    "Materials Project formation energies use the newer MaterialsProject2020Compatibility scheme.",
+    category=DeprecationWarning,
+)
 class MaterialsProjectCompatibility(CorrectionsList):
     """This class implements the GGA/GGA+U mixing scheme, which allows mixing of
     entries. Note that this should only be used for VASP calculations using the
@@ -909,12 +915,6 @@ class MaterialsProjectCompatibility(CorrectionsList):
             check_potcar_hash (bool): Use potcar hash to verify potcars are correct.
             silence_deprecation (bool): Silence deprecation warning. Defaults to False.
         """
-        warnings.warn(  # added by @janosh on 2023-05-25
-            "MaterialsProjectCompatibility is deprecated, Materials Project formation energies "
-            "use the newer MaterialsProject2020Compatibility scheme.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         self.compat_type = compat_type
         self.correct_peroxide = correct_peroxide
         self.check_potcar_hash = check_potcar_hash

--- a/src/pymatgen/entries/compatibility.py
+++ b/src/pymatgen/entries/compatibility.py
@@ -296,7 +296,7 @@ class AnionCorrection(Correction):
             if entry.data.get("sulfide_type"):
                 sf_type = entry.data["sulfide_type"]
             elif hasattr(entry, "structure"):
-                warnings.warn(sf_type)
+                warnings.warn(sf_type, stacklevel=2)
                 sf_type = sulfide_type(entry.structure)
 
             # use the same correction for polysulfides and sulfides
@@ -329,7 +329,8 @@ class AnionCorrection(Correction):
                 else:
                     warnings.warn(
                         "No structure or oxide_type parameter present. Note that peroxide/superoxide corrections "
-                        "are not as reliable and relies only on detection of special formulas, e.g. Li2O2."
+                        "are not as reliable and relies only on detection of special formulas, e.g. Li2O2.",
+                        stacklevel=2,
                     )
                     rform = entry.reduced_formula
                     if rform in UCorrection.common_peroxides:
@@ -622,7 +623,7 @@ class Compatibility(MSONable, abc.ABC):
             if on_error == "raise":
                 raise
             if on_error == "warn":
-                warnings.warn(str(exc))
+                warnings.warn(str(exc), stacklevel=2)
             return None
 
         for e_adj in adjustments:
@@ -640,7 +641,8 @@ class Compatibility(MSONable, abc.ABC):
                 warnings.warn(
                     f"Entry {entry.entry_id} already has an energy adjustment called {e_adj.name}, but its "
                     f"value differs from the value of {e_adj.value:.3f} calculated here. This "
-                    "Entry will be discarded."
+                    "Entry will be discarded.",
+                    stacklevel=2,
                 )
 
             else:
@@ -911,6 +913,7 @@ class MaterialsProjectCompatibility(CorrectionsList):
             "MaterialsProjectCompatibility is deprecated, Materials Project formation energies "
             "use the newer MaterialsProject2020Compatibility scheme.",
             DeprecationWarning,
+            stacklevel=2,
         )
         self.compat_type = compat_type
         self.correct_peroxide = correct_peroxide
@@ -1130,7 +1133,8 @@ class MaterialsProject2020Compatibility(Compatibility):
                 else:
                     warnings.warn(
                         "No structure or oxide_type parameter present. Note that peroxide/superoxide corrections "
-                        "are not as reliable and relies only on detection of special formulas, e.g. Li2O2."
+                        "are not as reliable and relies only on detection of special formulas, e.g. Li2O2.",
+                        stacklevel=2,
                     )
 
                     common_peroxides = "Li2O2 Na2O2 K2O2 Cs2O2 Rb2O2 BeO2 MgO2 CaO2 SrO2 BaO2".split()
@@ -1180,7 +1184,8 @@ class MaterialsProject2020Compatibility(Compatibility):
             warnings.warn(
                 f"Failed to guess oxidation states for Entry {entry.entry_id} "
                 f"({entry.reduced_formula}). Assigning anion correction to "
-                "only the most electronegative atom."
+                "only the most electronegative atom.",
+                stacklevel=2,
             )
 
         for anion in ("Br", "I", "Se", "Si", "Sb", "Te", "H", "N", "F", "Cl"):
@@ -1418,7 +1423,8 @@ class MaterialsProjectAqueousCompatibility(Compatibility):
                 f"You did not provide the required O2 and H2O energies. {type(self).__name__} "
                 "needs these energies in order to compute the appropriate energy adjustments. It will try "
                 "to determine the values from ComputedEntry for O2 and H2O passed to process_entries, but "
-                "will fail if these entries are not provided."
+                "will fail if these entries are not provided.",
+                stacklevel=2,
             )
 
         # Standard state entropy of molecular-like compounds at 298K (-T delta S)
@@ -1604,7 +1610,8 @@ class MaterialsProjectAqueousCompatibility(Compatibility):
                 "being assigned the same energy. This should not cause problems "
                 "with Pourbaix diagram construction, but may be confusing. "
                 "Pass all entries to process_entries() at once in if you want to "
-                "preserve H2 polymorph energy differences."
+                "preserve H2 polymorph energy differences.",
+                stacklevel=2,
             )
 
         # extract the DFT energies of oxygen and water from the list of entries, if present

--- a/src/pymatgen/entries/computed_entries.py
+++ b/src/pymatgen/entries/computed_entries.py
@@ -661,7 +661,8 @@ class ComputedStructureEntry(ComputedEntry):
         warnings.warn(
             f"Normalization of a `{type(self).__name__}` makes "
             "`self.composition` and `self.structure.composition` inconsistent"
-            " - please use self.composition for all further calculations."
+            " - please use self.composition for all further calculations.",
+            stacklevel=2,
         )
         # TODO: find a better solution for creating copies instead of as/from dict
         factor = self._normalization_factor(mode)

--- a/src/pymatgen/entries/correction_calculator.py
+++ b/src/pymatgen/entries/correction_calculator.py
@@ -130,7 +130,10 @@ class CorrectionCalculator:
 
             compound = self.calc_compounds.get(name)
             if not compound:
-                warnings.warn(f"Compound {name} is not found in provided computed entries and is excluded from the fit")
+                warnings.warn(
+                    f"Compound {name} is not found in provided computed entries and is excluded from the fit",
+                    stacklevel=2,
+                )
                 continue
 
             # filter out compounds with large uncertainties
@@ -139,14 +142,17 @@ class CorrectionCalculator:
                 allow = False
                 warnings.warn(
                     f"Compound {name} is excluded from the fit due to high experimental "
-                    f"uncertainty ({relative_uncertainty:.1%})"
+                    f"uncertainty ({relative_uncertainty:.1%})",
+                    stacklevel=2,
                 )
 
             # filter out compounds containing certain polyanions
             for anion in self.exclude_polyanions:
                 if anion in name or anion in cmpd_info["formula"]:
                     allow = False
-                    warnings.warn(f"Compound {name} contains the poly{anion=} and is excluded from the fit")
+                    warnings.warn(
+                        f"Compound {name} contains the poly{anion=} and is excluded from the fit", stacklevel=2
+                    )
                     break
 
             # filter out compounds that are unstable
@@ -157,7 +163,9 @@ class CorrectionCalculator:
                     raise ValueError("Missing e above hull data")
                 if eah > self.allow_unstable:
                     allow = False
-                    warnings.warn(f"Compound {name} is unstable and excluded from the fit (e_above_hull = {eah})")
+                    warnings.warn(
+                        f"Compound {name} is unstable and excluded from the fit (e_above_hull = {eah})", stacklevel=2
+                    )
 
             if allow:
                 comp = Composition(name)

--- a/src/pymatgen/entries/mixing_scheme.py
+++ b/src/pymatgen/entries/mixing_scheme.py
@@ -156,7 +156,9 @@ class MaterialsProjectDFTMixingScheme(Compatibility):
 
         # We can't operate on single entries in this scheme
         if len(entries) == 1:
-            warnings.warn(f"{type(self).__name__} cannot process single entries. Supply a list of entries.")
+            warnings.warn(
+                f"{type(self).__name__} cannot process single entries. Supply a list of entries.", stacklevel=2
+            )
             return processed_entry_list
 
         # if inplace = False, process entries on a copy
@@ -210,7 +212,7 @@ class MaterialsProjectDFTMixingScheme(Compatibility):
                 adjustments = self.get_adjustments(entry, mixing_state_data)
             except CompatibilityError as exc:
                 if "WARNING!" in str(exc):
-                    warnings.warn(str(exc))
+                    warnings.warn(str(exc), stacklevel=2)
                 elif verbose:
                     print(f"  {exc}")
                 ignore_entry = True
@@ -228,7 +230,8 @@ class MaterialsProjectDFTMixingScheme(Compatibility):
                     warnings.warn(
                         f"Entry {entry.entry_id} already has an energy adjustment called {ea.name}, but its "
                         f"value differs from the value of {ea.value:.3f} calculated here. This "
-                        "Entry will be discarded."
+                        "Entry will be discarded.",
+                        stacklevel=2,
                     )
                 else:
                     # Add the correction to the energy_adjustments list
@@ -481,7 +484,8 @@ class MaterialsProjectDFTMixingScheme(Compatibility):
             if not isinstance(entry, ComputedStructureEntry):
                 warnings.warn(
                     f"Entry {entry.entry_id} is not a ComputedStructureEntry and will be ignored. "
-                    "The DFT mixing scheme requires structures for all entries"
+                    "The DFT mixing scheme requires structures for all entries",
+                    stacklevel=2,
                 )
                 continue
 
@@ -496,12 +500,12 @@ class MaterialsProjectDFTMixingScheme(Compatibility):
         try:
             pd_type_1 = PhaseDiagram(entries_type_1)
         except ValueError:
-            warnings.warn(f"{self.run_type_1} entries do not form a complete PhaseDiagram.")
+            warnings.warn(f"{self.run_type_1} entries do not form a complete PhaseDiagram.", stacklevel=2)
 
         try:
             pd_type_2 = PhaseDiagram(entries_type_2)
         except ValueError:
-            warnings.warn(f"{self.run_type_2} entries do not form a complete PhaseDiagram.")
+            warnings.warn(f"{self.run_type_2} entries do not form a complete PhaseDiagram.", stacklevel=2)
 
         # Objective: loop through all the entries, group them by structure matching (or fuzzy structure matching
         # where relevant). For each group, put a row in a pandas DataFrame with the composition of the run_type_1 entry,
@@ -582,7 +586,8 @@ class MaterialsProjectDFTMixingScheme(Compatibility):
             if not entry.parameters.get("run_type"):
                 warnings.warn(
                     f"Entry {entry_id} is missing parameters.run_type! This field"
-                    "is required. This entry will be ignored."
+                    "is required. This entry will be ignored.",
+                    stacklevel=2,
                 )
                 continue
 
@@ -590,7 +595,8 @@ class MaterialsProjectDFTMixingScheme(Compatibility):
             if run_type not in [*self.valid_rtypes_1, *self.valid_rtypes_2]:
                 warnings.warn(
                     f"Invalid {run_type=} for entry {entry_id}. Must be one of "
-                    f"{self.valid_rtypes_1 + self.valid_rtypes_2}. This entry will be ignored."
+                    f"{self.valid_rtypes_1 + self.valid_rtypes_2}. This entry will be ignored.",
+                    stacklevel=2,
                 )
                 continue
 
@@ -598,7 +604,8 @@ class MaterialsProjectDFTMixingScheme(Compatibility):
             if entry_id is None:
                 warnings.warn(
                     f"{entry_id=} for {formula=}. Unique entry_ids are required for every ComputedStructureEntry."
-                    " This entry will be ignored."
+                    " This entry will be ignored.",
+                    stacklevel=2,
                 )
                 continue
 
@@ -649,7 +656,8 @@ class MaterialsProjectDFTMixingScheme(Compatibility):
                 warnings.warn(
                     f"  {self.run_type_2} entries chemical system {entries_type_2.chemsys} is larger than "
                     f"{self.run_type_1} entries chemical system {entries_type_1.chemsys}. Entries outside the "
-                    f"{self.run_type_1} chemical system will be discarded"
+                    f"{self.run_type_1} chemical system will be discarded",
+                    stacklevel=2,
                 )
                 entries_type_2 = entries_type_2.get_subset_in_chemsys(chemsys)
         else:

--- a/src/pymatgen/ext/cod.py
+++ b/src/pymatgen/ext/cod.py
@@ -89,8 +89,7 @@ class COD:
         # TODO: remove timeout arg and use class level timeout after 2025-10-17
         if timeout is not None:
             warnings.warn(
-                "separate timeout arg is deprecated, please use class level timeout",
-                DeprecationWarning,
+                "separate timeout arg is deprecated, please use class level timeout", DeprecationWarning, stacklevel=2
             )
         timeout = timeout or self.timeout
 

--- a/src/pymatgen/ext/matproj_legacy.py
+++ b/src/pymatgen/ext/matproj_legacy.py
@@ -170,7 +170,7 @@ class _MPResterLegacy:
             "To access the latest data with the new MPRester, obtain a new API key from "
             "https://materialsproject.org/api and consult the docs at https://docs.materialsproject.org/ "
             "for more information.",
-            DeprecationWarning,
+            FutureWarning,
             stacklevel=2,
         )
         if api_key is not None:

--- a/src/pymatgen/ext/matproj_legacy.py
+++ b/src/pymatgen/ext/matproj_legacy.py
@@ -169,19 +169,22 @@ class _MPResterLegacy:
             "You are using the legacy MPRester. This version of the MPRester will no longer be updated. "
             "To access the latest data with the new MPRester, obtain a new API key from "
             "https://materialsproject.org/api and consult the docs at https://docs.materialsproject.org/ "
-            "for more information."
+            "for more information.",
+            DeprecationWarning,
+            stacklevel=2,
         )
         if api_key is not None:
             self.api_key = api_key
         else:
             self.api_key = SETTINGS.get("PMG_MAPI_KEY", "")
+
         if endpoint is not None:
             self.preamble = endpoint
         else:
             self.preamble = SETTINGS.get("PMG_MAPI_ENDPOINT", "https://legacy.materialsproject.org/rest/v2")
 
         if self.preamble != "https://legacy.materialsproject.org/rest/v2":
-            warnings.warn(f"Non-default endpoint used: {self.preamble}")
+            warnings.warn(f"Non-default endpoint used: {self.preamble}", stacklevel=2)
 
         self.session = requests.Session()
         self.session.headers = {"x-api-key": self.api_key}
@@ -219,12 +222,13 @@ class _MPResterLegacy:
             else:
                 dct["MAPI_DB_VERSION"]["LOG"][db_version] += 1
 
-            # alert user if db version changed
+            # alert user if DB version changed
             last_accessed = dct["MAPI_DB_VERSION"]["LAST_ACCESSED"]
             if last_accessed and last_accessed != db_version:
-                print(
+                warnings.warn(
                     f"This database version has changed from the database last accessed ({last_accessed}).\n"
-                    f"Please see release notes on materialsproject.org for information about what has changed."
+                    f"Please see release notes on materialsproject.org for information about what has changed.",
+                    stacklevel=2,
                 )
             dct["MAPI_DB_VERSION"]["LAST_ACCESSED"] = db_version
 
@@ -263,7 +267,7 @@ class _MPResterLegacy:
                 data = json.loads(response.text, cls=MontyDecoder) if mp_decode else json.loads(response.text)
                 if data["valid_response"]:
                     if data.get("warning"):
-                        warnings.warn(data["warning"])
+                        warnings.warn(data["warning"], stacklevel=2)
                     return data["response"]
                 raise MPRestError(data["error"])
 
@@ -693,7 +697,8 @@ class _MPResterLegacy:
                         f"so structure for {new_material_id} returned. This is not an error, see "
                         f"documentation. If original task data for {material_id} is required, use "
                         "get_task_data(). To find the canonical mp-id from a task id use "
-                        "get_materials_id_from_task_id()."
+                        "get_materials_id_from_task_id().",
+                        stacklevel=2,
                     )
                 return self.get_structure_by_material_id(new_material_id)
             except MPRestError:
@@ -1106,7 +1111,7 @@ class _MPResterLegacy:
             response = json.loads(response.text, cls=MontyDecoder)
             if response["valid_response"]:
                 if response.get("warning"):
-                    warnings.warn(response["warning"])
+                    warnings.warn(response["warning"], stacklevel=2)
                 return response["inserted_ids"]
             raise MPRestError(response["error"])
 
@@ -1132,7 +1137,7 @@ class _MPResterLegacy:
             response = json.loads(response.text, cls=MontyDecoder)
             if response["valid_response"]:
                 if response.get("warning"):
-                    warnings.warn(response["warning"])
+                    warnings.warn(response["warning"], stacklevel=2)
                 return response
             raise MPRestError(response["error"])
 
@@ -1160,7 +1165,7 @@ class _MPResterLegacy:
             response = json.loads(response.text)
             if response["valid_response"]:
                 if response.get("warning"):
-                    warnings.warn(response["warning"])
+                    warnings.warn(response["warning"], stacklevel=2)
                 return response["response"]
             raise MPRestError(response["error"])
 
@@ -1258,7 +1263,7 @@ class _MPResterLegacy:
             response = json.loads(response.text, cls=MontyDecoder)
             if response["valid_response"]:
                 if response.get("warning"):
-                    warnings.warn(response["warning"])
+                    warnings.warn(response["warning"], stacklevel=2)
                 return response["response"]
             raise MPRestError(response["error"])
         raise MPRestError(f"REST error with status code {response.status_code} and error {response.text}")
@@ -1556,7 +1561,8 @@ class _MPResterLegacy:
         warnings.warn(
             f"For {file_patterns=}] and {task_types=}, \n"
             f"the following ids are not found on NOMAD [{list(non_exist_ids)}]. \n"
-            f"If you need to upload them, please contact Patrick Huck at phuck@lbl.gov"
+            f"If you need to upload them, please contact Patrick Huck at phuck@lbl.gov",
+            stacklevel=2,
         )
 
     def _check_get_download_info_url_by_task_id(self, prefix, task_ids) -> list[str]:

--- a/src/pymatgen/io/abinit/netcdf.py
+++ b/src/pymatgen/io/abinit/netcdf.py
@@ -25,7 +25,10 @@ try:
     import netCDF4
 except ImportError:
     netCDF4 = None
-    warnings.warn("Can't import netCDF4. Some features will be disabled unless you pip install netCDF4.")
+    warnings.warn(
+        "Can't import netCDF4. Some features will be disabled unless you pip install netCDF4.",
+        stacklevel=2,
+    )
 
 
 logger = logging.getLogger(__name__)

--- a/src/pymatgen/io/aims/inputs.py
+++ b/src/pymatgen/io/aims/inputs.py
@@ -566,6 +566,7 @@ class AimsControlIn(MSONable):
             warn(
                 "Removing spin from parameters since no spin information is in the structure",
                 RuntimeWarning,
+                stacklevel=2,
             )
             parameters.pop("spin")
 

--- a/src/pymatgen/io/aims/parsers.py
+++ b/src/pymatgen/io/aims/parsers.py
@@ -500,8 +500,7 @@ class AimsOutCalcChunk(AimsOutChunk):
         ) < 1e-3:
             warnings.warn(
                 "Total magnetic moment and sum of Mulliken spins are not consistent",
-                UserWarning,
-                stacklevel=1,
+                stacklevel=2,
             )
 
         if lattice is not None:

--- a/src/pymatgen/io/aims/sets/base.py
+++ b/src/pymatgen/io/aims/sets/base.py
@@ -343,14 +343,14 @@ class AimsInputGenerator(InputGenerator):
             warn(
                 "WARNING: the k_grid is set in user_params and in the kpt_settings,"
                 " using the one passed in user_params.",
-                stacklevel=1,
+                stacklevel=2,
             )
         elif isinstance(structure, Structure) and ("k_grid" not in params):
             density = kpt_settings.get("density", 5.0)
             even = kpt_settings.get("even", True)
             params["k_grid"] = self.d2k(structure, density, even)
         elif isinstance(structure, Molecule) and "k_grid" in params:
-            warn("WARNING: removing unnecessary k_grid information", stacklevel=1)
+            warn("WARNING: removing unnecessary k_grid information", stacklevel=2)
             del params["k_grid"]
 
         return params

--- a/src/pymatgen/io/ase.py
+++ b/src/pymatgen/io/ase.py
@@ -266,8 +266,7 @@ class AseAtomsAdaptor:
                     unsupported_constraint_type = True
             if unsupported_constraint_type:
                 warnings.warn(
-                    "Only FixAtoms is supported by Pymatgen. Other constraints will not be set.",
-                    UserWarning,
+                    "Only FixAtoms is supported by Pymatgen. Other constraints will not be set.", stacklevel=2
                 )
             sel_dyn = [[False] * 3 if atom.index in constraint_indices else [True] * 3 for atom in atoms]
         else:

--- a/src/pymatgen/io/babel.py
+++ b/src/pymatgen/io/babel.py
@@ -186,7 +186,8 @@ class BabelMolAdaptor:
             warnings.warn(
                 f"This input {forcefield=} is not supported "
                 "in openbabel. The forcefield will be reset as "
-                "default 'mmff94' for now."
+                "default 'mmff94' for now.",
+                stacklevel=2,
             )
             ff = openbabel.OBForceField.FindType("mmff94")
 
@@ -199,7 +200,8 @@ class BabelMolAdaptor:
                 "'SystematicRotorSearch', 'RandomRotorSearch' "
                 "and 'WeightedRotorSearch'. "
                 "The algorithm will be reset as default "
-                "'WeightedRotorSearch' for now."
+                "'WeightedRotorSearch' for now.",
+                stacklevel=2,
             )
             rotor_search = ff.WeightedRotorSearch
         rotor_search(*rotor_args)

--- a/src/pymatgen/io/cif.py
+++ b/src/pymatgen/io/cif.py
@@ -233,7 +233,7 @@ class CifBlock:
                     data[k].append(v.strip())
 
             elif issue := "".join(_str).strip():
-                warnings.warn(f"Possible issue in CIF file at line: {issue}")
+                warnings.warn(f"Possible issue in CIF file at line: {issue}", stacklevel=2)
 
         return cls(data, loops, header)
 
@@ -684,7 +684,7 @@ class CifParser:
                         return self.get_lattice(data, lengths, angles, lattice_type=lattice_type)
                     except AttributeError as exc:
                         self.warnings.append(str(exc))
-                        warnings.warn(str(exc))
+                        warnings.warn(str(exc), stacklevel=2)
 
                 else:
                     return None
@@ -734,7 +734,7 @@ class CifParser:
 
                 if isinstance(xyz, str):
                     msg = "A 1-line symmetry op P1 CIF is detected!"
-                    warnings.warn(msg)
+                    warnings.warn(msg, stacklevel=2)
                     self.warnings.append(msg)
                     xyz = [xyz]
                 try:
@@ -772,7 +772,7 @@ class CifParser:
                         if spg := space_groups.get(sg):
                             sym_ops = list(SpaceGroup(spg).symmetry_ops)
                             msg = msg_template.format(symmetry_label)
-                            warnings.warn(msg)
+                            warnings.warn(msg, stacklevel=2)
                             self.warnings.append(msg)
                             break
                     except ValueError:
@@ -791,7 +791,7 @@ class CifParser:
                                 xyz = _data["symops"]
                                 sym_ops = [SymmOp.from_xyz_str(s) for s in xyz]
                                 msg = msg_template.format(symmetry_label)
-                                warnings.warn(msg)
+                                warnings.warn(msg, stacklevel=2)
                                 self.warnings.append(msg)
                                 break
                     except Exception:
@@ -818,7 +818,7 @@ class CifParser:
 
         if not sym_ops:
             msg = "No _symmetry_equiv_pos_as_xyz type key found. Defaulting to P1."
-            warnings.warn(msg)
+            warnings.warn(msg, stacklevel=2)
             self.warnings.append(msg)
             sym_ops = [SymmOp.from_xyz_str(s) for s in ("x", "y", "z")]
 
@@ -880,7 +880,7 @@ class CifParser:
 
         if not mag_symm_ops:
             msg = "No magnetic symmetry detected, using primitive symmetry."
-            warnings.warn(msg)
+            warnings.warn(msg, stacklevel=2)
             self.warnings.append(msg)
             mag_symm_ops = [MagSymmOp.from_xyzt_str("x, y, z, 1")]
 
@@ -958,7 +958,7 @@ class CifParser:
 
         if parsed_sym is not None and (m_sp or not re.match(rf"{parsed_sym}\d*", sym)):
             msg = f"{sym} parsed as {parsed_sym}"
-            warnings.warn(msg)
+            warnings.warn(msg, stacklevel=2)
             self.warnings.append(msg)
 
         return parsed_sym
@@ -1111,7 +1111,7 @@ class CifParser:
                 "the occupancy_tolerance, they will be rescaled. "
                 f"The current occupancy_tolerance is set to: {self._occupancy_tolerance}"
             )
-            warnings.warn(msg)
+            warnings.warn(msg, stacklevel=2)
             self.warnings.append(msg)
 
         # Collect info for building Structure
@@ -1255,7 +1255,7 @@ class CifParser:
             if self.check_cif:
                 cif_failure_reason = self.check(struct)
                 if cif_failure_reason is not None:
-                    warnings.warn(cif_failure_reason)
+                    warnings.warn(cif_failure_reason, stacklevel=2)
 
             return struct
         return None
@@ -1317,11 +1317,11 @@ class CifParser:
                 if on_error == "raise":
                     raise ValueError(msg) from exc
                 if on_error == "warn":
-                    warnings.warn(msg)
+                    warnings.warn(msg, stacklevel=2)
                 self.warnings.append(msg)
 
         if self.warnings and on_error == "warn":
-            warnings.warn("Issues encountered while parsing CIF: " + "\n".join(self.warnings))
+            warnings.warn("Issues encountered while parsing CIF: " + "\n".join(self.warnings), stacklevel=2)
 
         if not structures:
             raise ValueError("Invalid CIF file with no structures!")
@@ -1560,7 +1560,10 @@ class CifWriter:
                 to the CIF as _atom_site_{property name}. Defaults to False.
         """
         if write_magmoms and symprec is not None:
-            warnings.warn("Magnetic symmetry cannot currently be detected by pymatgen, disabling symmetry detection.")
+            warnings.warn(
+                "Magnetic symmetry cannot currently be detected by pymatgen, disabling symmetry detection.",
+                stacklevel=2,
+            )
             symprec = None
 
         blocks: dict[str, Any] = {}

--- a/src/pymatgen/io/cif.py
+++ b/src/pymatgen/io/cif.py
@@ -1297,7 +1297,7 @@ class CifParser:
                 "The default value of primitive was changed from True to False in "
                 "https://github.com/materialsproject/pymatgen/pull/3419. CifParser now returns the cell "
                 "in the CIF file as is. If you want the primitive cell, please set primitive=True explicitly.",
-                UserWarning,
+                stacklevel=2,
             )
 
         if primitive and symmetrized:
@@ -1705,7 +1705,7 @@ class CifWriter:
                 "Site labels are not unique, which is not compliant with the CIF spec "
                 "(https://www.iucr.org/__data/iucr/cifdic_html/1/cif_core.dic/Iatom_site_label.html):"
                 f"`{atom_site_label}`.",
-                UserWarning,
+                stacklevel=2,
             )
 
         blocks["_atom_site_type_symbol"] = atom_site_type_symbol

--- a/src/pymatgen/io/common.py
+++ b/src/pymatgen/io/common.py
@@ -152,7 +152,10 @@ class VolumetricData(MSONable):
             VolumetricData corresponding to self + scale_factor * other.
         """
         if self.structure != other.structure:
-            warnings.warn("Structures are different. Make sure you know what you are doing...")
+            warnings.warn(
+                "Structures are different. Make sure you know what you are doing...",
+                stacklevel=2,
+            )
         if list(self.data) != list(other.data):
             raise ValueError("Data have different keys! Maybe one is spin-polarized and the other is not?")
 

--- a/src/pymatgen/io/common.py
+++ b/src/pymatgen/io/common.py
@@ -524,7 +524,7 @@ class PMGDir(collections.abc.Mapping):
 
         warnings.warn(
             f"No parser defined for {item}. Contents are returned as a string.",
-            UserWarning,
+            stacklevel=2,
         )
         with zopen(fpath, "rt") as f:
             return f.read()

--- a/src/pymatgen/io/cp2k/outputs.py
+++ b/src/pymatgen/io/cp2k/outputs.py
@@ -428,10 +428,10 @@ class Cp2kOutput:
         if not all(self.data["scf_converged"]):
             warnings.warn(
                 "There is at least one unconverged SCF cycle in the provided CP2K calculation",
-                UserWarning,
+                stacklevel=2,
             )
         if any(self.data["geo_opt_not_converged"]):
-            warnings.warn("Geometry optimization did not converge", UserWarning)
+            warnings.warn("Geometry optimization did not converge")
 
     def parse_energies(self):
         """Get the total energy from a CP2K calculation. Presently, the energy reported in the

--- a/src/pymatgen/io/cp2k/outputs.py
+++ b/src/pymatgen/io/cp2k/outputs.py
@@ -431,7 +431,7 @@ class Cp2kOutput:
                 stacklevel=2,
             )
         if any(self.data["geo_opt_not_converged"]):
-            warnings.warn("Geometry optimization did not converge")
+            warnings.warn("Geometry optimization did not converge", stacklevel=2)
 
     def parse_energies(self):
         """Get the total energy from a CP2K calculation. Presently, the energy reported in the
@@ -566,7 +566,7 @@ class Cp2kOutput:
             if os.path.isfile(os.path.join(self.dir, input_filename + ext)):
                 self.input = Cp2kInput.from_file(os.path.join(self.dir, input_filename + ext))
                 return
-        warnings.warn("Original input file not found. Some info may be lost.")
+        warnings.warn("Original input file not found. Some info may be lost.", stacklevel=2)
 
     def parse_global_params(self):
         """Parse the GLOBAL section parameters from CP2K output file into a dictionary."""
@@ -711,7 +711,8 @@ class Cp2kOutput:
             ]
 
         warnings.warn(
-            "Input file lost. Reading cell params from summary at top of output. Precision errors may result."
+            "Input file lost. Reading cell params from summary at top of output. Precision errors may result.",
+            stacklevel=2,
         )
         cell_volume = re.compile(r"\s+CELL\|\sVolume.*\s(\d+\.\d+)")
         vectors = re.compile(r"\s+CELL\| Vector.*\s(-?\d+\.\d+)\s+(-?\d+\.\d+)\s+(-?\d+\.\d+)")
@@ -1046,7 +1047,8 @@ class Cp2kOutput:
                         while True:
                             if "WARNING : did not converge" in line:
                                 warnings.warn(
-                                    "Convergence of eigenvalues for unoccupied subspace spin 1 did NOT converge"
+                                    "Convergence of eigenvalues for unoccupied subspace spin 1 did NOT converge",
+                                    stacklevel=2,
                                 )
                                 next(lines)
                                 next(lines)
@@ -1073,7 +1075,8 @@ class Cp2kOutput:
                             while True:
                                 if "WARNING : did not converge" in line:
                                     warnings.warn(
-                                        "Convergence of eigenvalues for unoccupied subspace spin 2 did NOT converge"
+                                        "Convergence of eigenvalues for unoccupied subspace spin 2 did NOT converge",
+                                        stacklevel=2,
                                     )
                                     next(lines)
                                     next(lines)
@@ -1105,7 +1108,7 @@ class Cp2kOutput:
                             "unoccupied": {Spin.up: None, Spin.down: None},
                         }
                     ]
-                    warnings.warn("Convergence of eigenvalues for one or more subspaces did NOT converge")
+                    warnings.warn("Convergence of eigenvalues for one or more subspaces did NOT converge", stacklevel=2)
 
         self.data["eigenvalues"] = eigenvalues
 

--- a/src/pymatgen/io/cp2k/sets.py
+++ b/src/pymatgen/io/cp2k/sets.py
@@ -238,7 +238,10 @@ class DftSet(Cp2kInput):
             ):
                 self.kpoints = None
             if ot and self.kpoints:
-                warnings.warn("As of 2022.1, kpoints not supported with OT. Defaulting to diagonalization")
+                warnings.warn(
+                    "As of 2022.1, kpoints not supported with OT. Defaulting to diagonalization",
+                    stacklevel=2,
+                )
                 ot = False
 
         # Build the global section
@@ -547,19 +550,24 @@ class DftSet(Cp2kInput):
             if basis is None:
                 if not basis_and_potential.get(el, {}).get("basis"):
                     raise ValueError(f"No explicit basis found for {el} and matching has failed.")
-                warnings.warn(f"Unable to validate basis for {el}. Exact name provided will be put in input file.")
+                warnings.warn(
+                    f"Unable to validate basis for {el}. Exact name provided will be put in input file.",
+                    stacklevel=2,
+                )
                 basis = basis_and_potential[el].get("basis")
 
             if aux_basis is None and basis_and_potential.get(el, {}).get("aux_basis"):
                 warnings.warn(
-                    f"Unable to validate auxiliary basis for {el}. Exact name provided will be put in input file."
+                    f"Unable to validate auxiliary basis for {el}. Exact name provided will be put in input file.",
+                    stacklevel=2,
                 )
                 aux_basis = basis_and_potential[el].get("aux_basis")
 
             if potential is None:
                 if basis_and_potential.get(el, {}).get("potential"):
                     warnings.warn(
-                        f"Unable to validate potential for {el}. Exact name provided will be put in input file."
+                        f"Unable to validate potential for {el}. Exact name provided will be put in input file.",
+                        stacklevel=2,
                     )
                     potential = basis_and_potential.get(el, {}).get("potential")
                 else:
@@ -873,7 +881,8 @@ class DftSet(Cp2kInput):
             if max_cutoff_radius < cutoff_radius:
                 warnings.warn(
                     "Provided cutoff radius exceeds half the minimum"
-                    " distance between atoms. I hope you know what you're doing."
+                    " distance between atoms. I hope you know what you're doing.",
+                    stacklevel=2,
                 )
 
         ip_keywords: dict[str, Keyword] = {}
@@ -962,7 +971,8 @@ class DftSet(Cp2kInput):
         else:
             warnings.warn(
                 "Unknown hybrid functional. Using PBE base functional and overriding all "
-                "settings manually. Proceed with caution."
+                "settings manually. Proceed with caution.",
+                stacklevel=2,
             )
             pbe = PBE("ORIG", scale_c=gga_c_fraction, scale_x=gga_x_fraction)
             xc_functional = XCFunctional(functionals=[], subsections={"PBE": pbe})
@@ -1224,7 +1234,8 @@ class DftSet(Cp2kInput):
             warnings.warn(
                 "Reference functional will not be checked for validity. "
                 "Calculation will fail if the reference functional "
-                "does not exist in the dftd3 reference data"
+                "does not exist in the dftd3 reference data",
+                stacklevel=2,
             )
             keywords["PARAMETER_FILE_NAME"] = Keyword("PARAMETER_FILE_NAME", "dftd3.dat")
             keywords["REFERENCE_FUNCTIONAL"] = Keyword("REFERENCE_FUNCTIONAL", reference_functional)

--- a/src/pymatgen/io/feff/inputs.py
+++ b/src/pymatgen/io/feff/inputs.py
@@ -554,7 +554,10 @@ class Tags(dict):
             value: value associated with key in dictionary
         """
         if key.strip().upper() not in VALID_FEFF_TAGS:
-            warnings.warn(f"{key.strip()} not in VALID_FEFF_TAGS list")
+            warnings.warn(
+                f"{key.strip()} not in VALID_FEFF_TAGS list",
+                stacklevel=2,
+            )
         super().__setitem__(
             key.strip(),
             Tags.proc_val(key.strip(), val.strip()) if isinstance(val, str) else val,

--- a/src/pymatgen/io/feff/sets.py
+++ b/src/pymatgen/io/feff/sets.py
@@ -191,7 +191,7 @@ class FEFFDictSet(AbstractFeffInputSet):
                         "For Molecule objects with a net charge it is recommended to set one or more"
                         " ION tags in the input file by modifying user_tag_settings."
                         " Consult the FEFFDictSet docstring and the FEFF10 User Guide for more information.",
-                        UserWarning,
+                        stacklevel=2,
                     )
             else:
                 raise ValueError("'structure' argument must be a Structure or Molecule!")

--- a/src/pymatgen/io/gaussian.py
+++ b/src/pymatgen/io/gaussian.py
@@ -790,7 +790,10 @@ class GaussianOutput:
                                     "Density Matrix:" in line or mo_coeff_patt.search(line)
                                 ):
                                     end_mo = True
-                                    warnings.warn("POP=regular case, matrix coefficients not complete")
+                                    warnings.warn(
+                                        "POP=regular case, matrix coefficients not complete",
+                                        stacklevel=2,
+                                    )
                             file.readline()
 
                         self.eigenvectors = mat_mo
@@ -926,7 +929,8 @@ class GaussianOutput:
                         line = file.readline()
                         if " -- Stationary point found." not in line:
                             warnings.warn(
-                                f"\n{self.filename}: Optimization complete but this is not a stationary point"
+                                f"\n{self.filename}: Optimization complete but this is not a stationary point",
+                                stacklevel=2,
                             )
                         if standard_orientation:
                             opt_structures.append(std_structures[-1])
@@ -989,7 +993,10 @@ class GaussianOutput:
         self.opt_structures = opt_structures
 
         if not terminated:
-            warnings.warn(f"\n{self.filename}: Termination error or bad Gaussian output file !")
+            warnings.warn(
+                f"\n{self.filename}: Termination error or bad Gaussian output file !",
+                stacklevel=2,
+            )
 
     def _parse_hessian(self, file, structure):
         """Parse the hessian matrix in the output file.

--- a/src/pymatgen/io/icet.py
+++ b/src/pymatgen/io/icet.py
@@ -120,7 +120,10 @@ class IcetSQS:
 
         unrecognized_kwargs = {key for key in self.sqs_kwargs if key not in self.sqs_kwarg_names[sqs_method]}
         if len(unrecognized_kwargs) > 0:
-            warnings.warn(f"Ignoring unrecognized icet {sqs_method} kwargs: {', '.join(unrecognized_kwargs)}")
+            warnings.warn(
+                f"Ignoring unrecognized icet {sqs_method} kwargs: {', '.join(unrecognized_kwargs)}",
+                stacklevel=2,
+            )
 
         self.sqs_kwargs = {
             key: value for key, value in self.sqs_kwargs.items() if key in self.sqs_kwarg_names[sqs_method]

--- a/src/pymatgen/io/lammps/data.py
+++ b/src/pymatgen/io/lammps/data.py
@@ -833,7 +833,10 @@ class LammpsData(MSONable):
             df_topology = pd.DataFrame(np.concatenate(topo_collector[key]), columns=SECTION_HEADERS[key][1:])
             df_topology["type"] = list(map(ff.maps[key].get, topo_labels[key]))
             if any(pd.isna(df_topology["type"])):  # Throw away undefined topologies
-                warnings.warn(f"Undefined {key.lower()} detected and removed")
+                warnings.warn(
+                    f"Undefined {key.lower()} detected and removed",
+                    stacklevel=2,
+                )
                 df_topology = df_topology.dropna(subset=["type"])
                 df_topology = df_topology.reset_index(drop=True)
             df_topology.index += 1

--- a/src/pymatgen/io/lammps/inputs.py
+++ b/src/pymatgen/io/lammps/inputs.py
@@ -273,7 +273,8 @@ class LammpsInputFile(InputFile):
             if commands or stage_name:
                 warnings.warn(
                     "A stage has been passed together with commands and stage_name. This is incompatible. "
-                    "Only the stage will be used."
+                    "Only the stage will be used.",
+                    stacklevel=2,
                 )
 
             # Make sure the given stage has the correct format
@@ -467,7 +468,10 @@ class LammpsInputFile(InputFile):
         self.stages = new_list_of_stages
 
         if n_removed == 0:
-            warnings.warn(f"{command} not found in the LammpsInputFile.")
+            warnings.warn(
+                f"{command} not found in the LammpsInputFile.",
+                stacklevel=2,
+            )
 
     def append(self, lmp_input_file: LammpsInputFile) -> None:
         """
@@ -1105,4 +1109,7 @@ def write_lammps_inputs(
         elif isinstance(data, str) and os.path.isfile(data):
             shutil.copyfile(data, os.path.join(output_dir, data_filename))
         else:
-            warnings.warn(f"No data file supplied. Skip writing {data_filename}.")
+            warnings.warn(
+                f"No data file supplied. Skip writing {data_filename}.",
+                stacklevel=2,
+            )

--- a/src/pymatgen/io/lobster/inputs.py
+++ b/src/pymatgen/io/lobster/inputs.py
@@ -337,7 +337,10 @@ class Lobsterin(UserDict, MSONable):
         """
         # Read INCAR from file, which will be modified
         incar = Incar.from_file(incar_input)
-        warnings.warn("Please check your incar_input before using it. This method only changes three settings!")
+        warnings.warn(
+            "Please check your incar_input before using it. This method only changes three settings!",
+            stacklevel=2,
+        )
         if isym in {-1, 0}:
             incar["ISYM"] = isym
         else:
@@ -654,7 +657,8 @@ class Lobsterin(UserDict, MSONable):
                 "Lobster up to version 4.1.0."
                 "\n The keywords SHA256 and COPYR "
                 "cannot be handled by Lobster"
-                " \n and will lead to wrong results."
+                " \n and will lead to wrong results.",
+                stacklevel=2,
             )
 
         if potcar.functional != "PBE":
@@ -697,7 +701,8 @@ class Lobsterin(UserDict, MSONable):
             Lobsterin with standard settings
         """
         warnings.warn(
-            "Always check and test the provided basis functions. The spilling of your Lobster calculation might help"
+            "Always check and test the provided basis functions. The spilling of your Lobster calculation might help",
+            stacklevel=2,
         )
 
         if option not in {

--- a/src/pymatgen/io/lobster/outputs.py
+++ b/src/pymatgen/io/lobster/outputs.py
@@ -418,7 +418,10 @@ class Icohplist(MSONable):
                 version = "5.1.0"
             elif len(lines[0].split()) == 6:
                 version = "2.2.1"
-                warnings.warn("Please consider using a newer LOBSTER version. See www.cohp.de.")
+                warnings.warn(
+                    "Please consider using a newer LOBSTER version. See www.cohp.de.",
+                    stacklevel=2,
+                )
             else:
                 raise ValueError("Unsupported LOBSTER version.")
 
@@ -640,7 +643,8 @@ class NciCobiList:
                 self.orbital_wise = True
                 warnings.warn(
                     "This is an orbitalwise NcICOBILIST.lobster file. "
-                    "Currently, the orbitalwise information is not read!"
+                    "Currently, the orbitalwise information is not read!",
+                    stacklevel=2,
                 )
                 break  # condition has only to be met once
 
@@ -1392,8 +1396,14 @@ class Fatband:
             structure (Structure): Structure object.
             efermi (float): Fermi level in eV.
         """
-        warnings.warn("Make sure all relevant FATBAND files were generated and read in!")
-        warnings.warn("Use Lobster 3.2.0 or newer for fatband calculations!")
+        warnings.warn(
+            "Make sure all relevant FATBAND files were generated and read in!",
+            stacklevel=2,
+        )
+        warnings.warn(
+            "Use Lobster 3.2.0 or newer for fatband calculations!",
+            stacklevel=2,
+        )
 
         if structure is None:
             raise ValueError("A structure object has to be provided")

--- a/src/pymatgen/io/multiwfn.py
+++ b/src/pymatgen/io/multiwfn.py
@@ -401,7 +401,10 @@ def add_atoms(
             sorted_atoms = sort_cps_by_distance(np.array(cp_desc["pos_ang"]), atom_info)
 
             if sorted_atoms[1][0] > dist_threshold_bond:
-                warnings.warn("Warning: bond CP is far from bonding atoms")
+                warnings.warn(
+                    "Warning: bond CP is far from bonding atoms",
+                    stacklevel=2,
+                )
 
             # Assume only two atoms involved in bond
             modified_organized_cps["bond"][cp_name]["atom_inds"] = sorted([ca[1] for ca in sorted_atoms[:2]])
@@ -428,7 +431,10 @@ def add_atoms(
                 sorted_atoms = sort_cps_by_distance(np.array(cp_desc["pos_ang"]), atom_info)
 
                 if sorted_atoms[1][0] > dist_threshold_bond:
-                    warnings.warn("Warning: bond CP is far from bonding atoms")
+                    warnings.warn(
+                        "Warning: bond CP is far from bonding atoms",
+                        stacklevel=2,
+                    )
 
                 bond_atoms_list = sorted([ca[1] for ca in sorted_atoms[:2]])
 
@@ -439,7 +445,10 @@ def add_atoms(
         max_close_dist = sorted_bonds[2][0]
 
         if max_close_dist > dist_threshold_ring_cage:
-            warnings.warn("Warning: ring CP is far from closest bond CPs.")
+            warnings.warn(
+                "Warning: ring CP is far from closest bond CPs.",
+                stacklevel=2,
+            )
 
         # Assume that the three closest bonds are all part of the ring
         bond_names = [bcp[1] for bcp in sorted_bonds[:3]]
@@ -466,7 +475,10 @@ def add_atoms(
 
         # Warn if the three closest bonds are further than the max distance
         if max_close_dist > dist_threshold_ring_cage:
-            warnings.warn("Warning: cage CP is far from closest ring CPs.")
+            warnings.warn(
+                "Warning: cage CP is far from closest ring CPs.",
+                stacklevel=2,
+            )
 
         # Assume that the three closest rings are all part of the cage
         ring_names = [rcp[1] for rcp in sorted_rings[:3]]
@@ -536,7 +548,10 @@ def process_multiwfn_qtaim(
     remapped_atoms, missing_atoms = map_atoms_cps(molecule, qtaim_descriptors["atom"], max_distance=max_distance_atom)
 
     if len(missing_atoms) > 0:
-        warnings.warn(f"Some atoms not mapped to atom CPs! Indices: {missing_atoms}")
+        warnings.warn(
+            f"Some atoms not mapped to atom CPs! Indices: {missing_atoms}",
+            stacklevel=2,
+        )
 
     qtaim_descriptors["atom"] = remapped_atoms
 

--- a/src/pymatgen/io/nwchem.py
+++ b/src/pymatgen/io/nwchem.py
@@ -139,7 +139,10 @@ class NwTask(MSONable):
         if NWCHEM_BASIS_LIBRARY is not None:
             for b in set(self.basis_set.values()):
                 if re.sub(r"\*", "s", b.lower()) not in NWCHEM_BASIS_LIBRARY:
-                    warnings.warn(f"Basis set {b} not in NWCHEM_BASIS_LIBRARY")
+                    warnings.warn(
+                        f"Basis set {b} not in NWCHEM_BASIS_LIBRARY",
+                        stacklevel=2,
+                    )
 
         self.basis_set_option = basis_set_option
 

--- a/src/pymatgen/io/openff.py
+++ b/src/pymatgen/io/openff.py
@@ -20,7 +20,8 @@ except ImportError:
     unit = None
     warnings.warn(
         "To use the pymatgen.io.openff module install openff-toolkit and openff-units"
-        "with `conda install -c conda-forge openff-toolkit openff-units`."
+        "with `conda install -c conda-forge openff-toolkit openff-units`.",
+        stacklevel=2,
     )
 
 

--- a/src/pymatgen/io/qchem/outputs.py
+++ b/src/pymatgen/io/qchem/outputs.py
@@ -2308,7 +2308,8 @@ def check_for_structure_changes(mol1: Molecule, mol2: Molecule) -> str:
         if site.specie.symbol != mol2[ii].specie.symbol:
             warnings.warn(
                 "Comparing molecules with different atom ordering! "
-                "Turning off special treatment for coordinating metals."
+                "Turning off special treatment for coordinating metals.",
+                stacklevel=2,
             )
             special_elements = []
 

--- a/src/pymatgen/io/qchem/sets.py
+++ b/src/pymatgen/io/qchem/sets.py
@@ -555,7 +555,7 @@ class QChemDictSet(QCInput):
                     if rem["solvent_method"] != "pcm":
                         warnings.warn(
                             "The solvent section will be ignored unless solvent_method=pcm!",
-                            UserWarning,
+                            stacklevel=2,
                         )
                 if sec == "smx":
                     smx |= lower_and_check_unique(sec_dict)
@@ -589,17 +589,17 @@ class QChemDictSet(QCInput):
                             if self.cmirs_solvent is not None and v == "0":
                                 warnings.warn(
                                     "Setting IDEFESR=0 will disable the CMIRS calculation you requested!",
-                                    UserWarning,
+                                    stacklevel=2,
                                 )
                             if self.cmirs_solvent is None and v == "1":
                                 warnings.warn(
                                     "Setting IDEFESR=1 will have no effect unless you specify a cmirs_solvent!",
-                                    UserWarning,
+                                    stacklevel=2,
                                 )
                         if k == "dielst" and rem["solvent_method"] != "isosvp":
                             warnings.warn(
                                 "Setting DIELST will have no effect unless you specify a solvent_method=isosvp!",
-                                UserWarning,
+                                stacklevel=2,
                             )
 
                         svp[k] = v

--- a/src/pymatgen/io/shengbte.py
+++ b/src/pymatgen/io/shengbte.py
@@ -180,7 +180,10 @@ class Control(MSONable, dict):
         """
         for param in self.required_params:
             if param not in self.as_dict():
-                warnings.warn(f"Required parameter {param!r} not specified!")
+                warnings.warn(
+                    f"Required parameter {param!r} not specified!",
+                    stacklevel=2,
+                )
 
         alloc_dict = _get_subdict(self, self.allocations_keys)
         alloc_nml = f90nml.Namelist({"allocations": alloc_dict})

--- a/src/pymatgen/io/vasp/inputs.py
+++ b/src/pymatgen/io/vasp/inputs.py
@@ -264,6 +264,7 @@ class Poscar(MSONable):
             warnings.warn(
                 "check_for_POTCAR is deprecated. Use check_for_potcar instead.",
                 DeprecationWarning,
+                stacklevel=2,
             )
             check_for_potcar = cast(bool, kwargs.pop("check_for_POTCAR"))
 
@@ -468,6 +469,7 @@ class Poscar(MSONable):
                 warnings.warn(
                     f"Elements in POSCAR cannot be determined. Defaulting to false names {atomic_symbols}.",
                     BadPoscarWarning,
+                    stacklevel=2,
                 )
 
         # Read the atomic coordinates
@@ -483,6 +485,7 @@ class Poscar(MSONable):
                     warnings.warn(
                         "Selective dynamics values must be either 'T' or 'F'.",
                         BadPoscarWarning,
+                        stacklevel=2,
                     )
 
                 # Warn when elements contains Fluorine (F) (#3539)
@@ -493,6 +496,7 @@ class Poscar(MSONable):
                             "Make sure the 4th-6th entry each position line is selective dynamics info."
                         ),
                         BadPoscarWarning,
+                        stacklevel=2,
                     )
 
                 selective_dynamics.append([value == "T" for value in tokens[3:6]])
@@ -502,6 +506,7 @@ class Poscar(MSONable):
             warnings.warn(
                 "Ignoring selective dynamics tag, as no ionic degrees of freedom were fixed.",
                 BadPoscarWarning,
+                stacklevel=2,
             )
 
         struct = Structure(
@@ -625,7 +630,11 @@ class Poscar(MSONable):
                     # VASP is strict about the format when reading this quantity
                     lines.append(" ".join(f" {val: .7E}" for val in velo))
             except Exception:
-                warnings.warn("Lattice velocities are missing or corrupted.", BadPoscarWarning)
+                warnings.warn(
+                    "Lattice velocities are missing or corrupted.",
+                    BadPoscarWarning,
+                    stacklevel=2,
+                )
 
         if self.velocities:
             try:
@@ -633,7 +642,11 @@ class Poscar(MSONable):
                 for velo in self.velocities:
                     lines.append(" ".join(format_str.format(val) for val in velo))
             except Exception:
-                warnings.warn("Velocities are missing or corrupted.", BadPoscarWarning)
+                warnings.warn(
+                    "Velocities are missing or corrupted.",
+                    BadPoscarWarning,
+                    stacklevel=2,
+                )
 
         if self.predictor_corrector:
             lines.append("")
@@ -647,6 +660,7 @@ class Poscar(MSONable):
                 warnings.warn(
                     "Preamble information missing or corrupt. Writing Poscar with no predictor corrector data.",
                     BadPoscarWarning,
+                    stacklevel=2,
                 )
 
         return "\n".join(lines) + "\n"
@@ -2007,7 +2021,10 @@ class PotcarSingle:
             try:
                 keywords[key] = self.parse_functions[key](val)  # type: ignore[operator]
             except KeyError:
-                warnings.warn(f"Ignoring unknown variable type {key}")
+                warnings.warn(
+                    f"Ignoring unknown variable type {key}",
+                    stacklevel=2,
+                )
 
         PSCTR: dict[str, Any] = {}
 
@@ -2081,6 +2098,7 @@ class PotcarSingle:
                 f"POTCAR data with symbol {self.symbol} is not known to pymatgen. Your "
                 "POTCAR may be corrupted or pymatgen's POTCAR database is incomplete.",
                 UnknownPotcarWarning,
+                stacklevel=2,
             )
 
     def __eq__(self, other: object) -> bool:
@@ -2112,7 +2130,10 @@ class PotcarSingle:
     def electron_configuration(self) -> list[tuple[int, str, int]] | None:
         """Electronic configuration of the PotcarSingle."""
         if not self.nelectrons.is_integer():
-            warnings.warn("POTCAR has non-integer charge, electron configuration not well-defined.")
+            warnings.warn(
+                "POTCAR has non-integer charge, electron configuration not well-defined.",
+                stacklevel=2,
+            )
             return None
 
         el = Element.from_Z(self.atomic_no)
@@ -2421,7 +2442,10 @@ class PotcarSingle:
                 return cls(file.read(), symbol=symbol or None)
 
         except UnicodeDecodeError:
-            warnings.warn("POTCAR contains invalid unicode errors. We will attempt to read it by ignoring errors.")
+            warnings.warn(
+                "POTCAR contains invalid unicode errors. We will attempt to read it by ignoring errors.",
+                stacklevel=2,
+            )
 
             with codecs.open(str(filename), "r", encoding="utf-8", errors="ignore") as file:
                 return cls(file.read(), symbol=symbol or None)
@@ -2706,7 +2730,10 @@ def _gen_potcar_summary_stats(
         if os.path.isdir(cpsp_dir):
             func_dir_exist[func] = func_dir
         else:
-            warnings.warn(f"missing {func_dir} POTCAR directory")
+            warnings.warn(
+                f"missing {func_dir} POTCAR directory",
+                stacklevel=2,
+            )
 
     # Use append = True if a new POTCAR library is released to add new summary stats
     # without completely regenerating the dict of summary stats

--- a/src/pymatgen/io/vasp/outputs.py
+++ b/src/pymatgen/io/vasp/outputs.py
@@ -157,7 +157,10 @@ def _vasprun_float(flt: float | str) -> float:
         flt = cast(str, flt)
         _flt: str = flt.strip()
         if _flt == "*" * len(_flt):
-            warnings.warn("Float overflow (*******) encountered in vasprun")
+            warnings.warn(
+                "Float overflow (*******) encountered in vasprun",
+                stacklevel=2,
+            )
             return np.nan
         raise
 
@@ -349,7 +352,11 @@ class Vasprun(MSONable):
             msg = f"{filename} is an unconverged VASP run.\n"
             msg += f"Electronic convergence reached: {self.converged_electronic}.\n"
             msg += f"Ionic convergence reached: {self.converged_ionic}."
-            warnings.warn(msg, UnconvergedVASPWarning)
+            warnings.warn(
+                msg,
+                UnconvergedVASPWarning,
+                stacklevel=2,
+            )
 
     def _parse(
         self,
@@ -688,7 +695,8 @@ class Vasprun(MSONable):
             warnings.warn(
                 "Calculation does not have a total energy. "
                 "Possibly a GW or similar kind of run. "
-                "Infinity is returned."
+                "Infinity is returned.",
+                stacklevel=2,
             )
             return float("inf")
 
@@ -800,7 +808,10 @@ class Vasprun(MSONable):
             run_type = "LDA"
         else:
             run_type = "unknown"
-            warnings.warn("Unknown run type!")
+            warnings.warn(
+                "Unknown run type!",
+                stacklevel=2,
+            )
 
         if self.is_hubbard or self.parameters.get("LDAU", True):
             run_type += "+U"
@@ -1215,7 +1226,10 @@ class Vasprun(MSONable):
             except Exception:
                 continue
 
-        warnings.warn("No POTCAR file with matching TITEL fields was found in\n" + "\n  ".join(potcar_paths))
+        warnings.warn(
+            "No POTCAR file with matching TITEL fields was found in\n" + "\n  ".join(potcar_paths),
+            stacklevel=2,
+        )
 
         return None
 
@@ -4440,7 +4454,10 @@ def get_band_structure_from_vasp_multiple_branches(
                 branches.append(run.get_band_structure(efermi=efermi))
             else:
                 # TODO: It might be better to throw an exception
-                warnings.warn(f"Skipping {dname}. Unable to find {xml_file}")
+                warnings.warn(
+                    f"Skipping {dname}. Unable to find {xml_file}",
+                    stacklevel=2,
+                )
 
         return get_reconstructed_band_structure(branches, efermi)
 
@@ -5273,7 +5290,10 @@ class Wavecar:
             A Chgcar object.
         """
         if phase and not np.all(self.kpoints[kpoint] == 0.0):
-            warnings.warn("phase is True should only be used for the Gamma kpoint! I hope you know what you're doing!")
+            warnings.warn(
+                "phase is True should only be used for the Gamma kpoint! I hope you know what you're doing!",
+                stacklevel=2,
+            )
 
         # Scaling of ng for the fft grid, need to restore value at the end
         temp_ng = self.ng
@@ -5607,7 +5627,8 @@ class Waveder(MSONable):
         if self.cder_real.shape[0] != self.cder_real.shape[1]:  # pragma: no cover
             warnings.warn(
                 "Not all band pairs are present in the WAVEDER file."
-                "If you want to get all the matrix elements set LVEL=.True. in the INCAR."
+                "If you want to get all the matrix elements set LVEL=.True. in the INCAR.",
+                stacklevel=2,
             )
         return self.cder_real + 1j * self.cder_imag
 

--- a/src/pymatgen/io/vasp/outputs.py
+++ b/src/pymatgen/io/vasp/outputs.py
@@ -484,7 +484,7 @@ class Vasprun(MSONable):
                             else:
                                 warnings.warn(
                                     "Additional unlabelled dielectric data in vasprun.xml are stored as unlabelled.",
-                                    UserWarning,
+                                    stacklevel=2,
                                 )
                                 label = "unlabelled"
                         # VASP 6+ has labels for the density and current
@@ -537,7 +537,6 @@ class Vasprun(MSONable):
                 raise
             warnings.warn(
                 "XML is malformed. Parsing has stopped but partial data is available.",
-                UserWarning,
                 stacklevel=2,
             )
 

--- a/src/pymatgen/io/vasp/sets.py
+++ b/src/pymatgen/io/vasp/sets.py
@@ -268,6 +268,7 @@ class VaspInputSet(InputGenerator, abc.ABC):
                 "will generate a KPOINTS file and ignore KSPACING."
                 "Remove the `user_kpoints_settings` argument to enable KSPACING.",
                 BadInputSetWarning,
+                stacklevel=2,
             )
 
         if self.vdw:
@@ -293,6 +294,7 @@ class VaspInputSet(InputGenerator, abc.ABC):
                 "the configuration file may not be available in the selected "
                 "functional.",
                 BadInputSetWarning,
+                stacklevel=2,
             )
 
         if self.user_potcar_settings:
@@ -304,6 +306,7 @@ class VaspInputSet(InputGenerator, abc.ABC):
                 "subclass of a desired input set and override the POTCAR in "
                 "the subclass to be explicit on the differences.",
                 BadInputSetWarning,
+                stacklevel=2,
             )
             for key, val in self.user_potcar_settings.items():
                 self._config_dict["POTCAR"][key] = val
@@ -431,6 +434,7 @@ class VaspInputSet(InputGenerator, abc.ABC):
                     "Yb_2 is known to often give bad results since Yb has oxidation state 3+ in most compounds.\n"
                     "See https://github.com/materialsproject/pymatgen/issues/2968 for details.",
                     BadInputSetWarning,
+                    stacklevel=2,
                 )
             if self.standardize and self.sym_prec:
                 structure = standardize_structure(
@@ -580,7 +584,8 @@ class VaspInputSet(InputGenerator, abc.ABC):
                             warnings.warn(
                                 "Co without an oxidation state is initialized as low spin by default in Pymatgen. "
                                 "If this default behavior is not desired, please set the spin on the magmom on the "
-                                "site directly to ensure correct initialization."
+                                "site directly to ensure correct initialization.",
+                                stacklevel=2,
                             )
                         mag.append(setting.get(str(site.specie)))
                     else:
@@ -588,7 +593,8 @@ class VaspInputSet(InputGenerator, abc.ABC):
                             warnings.warn(
                                 "Co without an oxidation state is initialized as low spin by default in Pymatgen. "
                                 "If this default behavior is not desired, please set the spin on the magmom on the "
-                                "site directly to ensure correct initialization."
+                                "site directly to ensure correct initialization.",
+                                stacklevel=2,
                             )
                         mag.append(setting.get(site.specie.symbol, 0.6))
                 incar[key] = mag
@@ -652,6 +658,7 @@ class VaspInputSet(InputGenerator, abc.ABC):
             warnings.warn(
                 "LASPH = True should be set for +U, meta-GGAs, hybrids, and vdW-DFT",
                 BadInputSetWarning,
+                stacklevel=2,
             )
 
         # Apply previous INCAR settings, be careful not to override user_incar_settings
@@ -686,6 +693,7 @@ class VaspInputSet(InputGenerator, abc.ABC):
             warnings.warn(
                 "Hybrid functionals only support Algo = All, Damped, or Normal.",
                 BadInputSetWarning,
+                stacklevel=2,
             )
 
         if self.auto_ismear:
@@ -739,6 +747,7 @@ class VaspInputSet(InputGenerator, abc.ABC):
                 "generates an adequate number of KPOINTS, lower KSPACING, or "
                 "set ISMEAR = 0",
                 BadInputSetWarning,
+                stacklevel=2,
             )
 
         ismear = incar.get("ISMEAR", 1)
@@ -963,6 +972,7 @@ class VaspInputSet(InputGenerator, abc.ABC):
                     f"is known to correspond with functionals {p_single.identify_potcar(mode='data')[0]}. "
                     "Please verify that you are using the right POTCARs!",
                     BadInputSetWarning,
+                    stacklevel=2,
                 )
 
         return potcar
@@ -1035,7 +1045,8 @@ class VaspInputSet(InputGenerator, abc.ABC):
                 "Use of standardize=True with from_prev_run is not "
                 "recommended as there is no guarantee the copied "
                 "files will be appropriate for the standardized "
-                "structure."
+                "structure.",
+                stacklevel=2,
             )
 
         files_to_transfer = {}
@@ -1354,7 +1365,10 @@ class MPScanRelaxSet(VaspInputSet):
     def __post_init__(self) -> None:
         super().__post_init__()
         if self.vdw and self.vdw != "rvv10":
-            warnings.warn("Use of van der waals functionals other than rVV10 with SCAN is not supported at this time. ")
+            warnings.warn(
+                "Use of van der waals functionals other than rVV10 with SCAN is not supported at this time. ",
+                stacklevel=2,
+            )
             # Delete any vdw parameters that may have been added to the INCAR
             vdw_par = loadfn(f"{MODULE_DIR}/vdW_parameters.yaml")
             for k in vdw_par[self.vdw]:
@@ -1788,14 +1802,18 @@ class MPNonSCFSet(VaspInputSet):
             )
 
         if (mode != "uniform" or self.nedos < 2000) and self.optics:
-            warnings.warn("It is recommended to use Uniform mode with a high NEDOS for optics calculations.")
+            warnings.warn(
+                "It is recommended to use Uniform mode with a high NEDOS for optics calculations.",
+                stacklevel=2,
+            )
 
         if self.standardize:
             warnings.warn(
                 "Use of standardize=True with from_prev_run is not "
                 "recommended as there is no guarantee the copied "
                 "files will be appropriate for the standardized"
-                " structure. copy_chgcar is enforced to be false."
+                " structure. copy_chgcar is enforced to be false.",
+                stacklevel=2,
             )
             self.copy_chgcar = False
 
@@ -2803,7 +2821,10 @@ class LobsterSet(VaspInputSet):
 
     def __post_init__(self) -> None:
         super().__post_init__()
-        warnings.warn("Make sure that all parameters are okay! This is a brand new implementation.")
+        warnings.warn(
+            "Make sure that all parameters are okay! This is a brand new implementation.",
+            stacklevel=2,
+        )
 
         if self.user_potcar_functional in ["PBE_52", "PBE_64"]:
             warnings.warn(
@@ -2811,6 +2832,7 @@ class LobsterSet(VaspInputSet):
                 "Basis functions for elements with obsoleted, updated or newly added POTCARs in "
                 f"{self.user_potcar_functional} will not be available and may cause errors or inaccuracies.",
                 BadInputSetWarning,
+                stacklevel=2,
             )
         if self.isym not in {-1, 0}:
             raise ValueError("Lobster cannot digest WAVEFUNCTIONS with symmetry. isym must be -1 or 0")

--- a/src/pymatgen/io/vasp/sets.py
+++ b/src/pymatgen/io/vasp/sets.py
@@ -670,7 +670,6 @@ class VaspInputSet(InputGenerator, abc.ABC):
                     "multiplet and should typically be an integer. You are likely "
                     "better off changing the values of MAGMOM or simply setting "
                     "NUPDOWN directly in your INCAR settings.",
-                    UserWarning,
                     stacklevel=2,
                 )
             auto_updates["NUPDOWN"] = nupdown
@@ -1554,7 +1553,7 @@ class MatPESStaticSet(VaspInputSet):
         if self.user_potcar_functional.upper() != default_potcars:
             warnings.warn(
                 f"{self.user_potcar_functional=} is inconsistent with the recommended {default_potcars}.",
-                UserWarning,
+                stacklevel=2,
             )
 
         if self.xc_functional.upper() == "R2SCAN":

--- a/src/pymatgen/io/vasp/sets.py
+++ b/src/pymatgen/io/vasp/sets.py
@@ -756,7 +756,7 @@ class VaspInputSet(InputGenerator, abc.ABC):
             warnings.warn(
                 f"{msg} See VASP recommendations on ISMEAR for metals (https://www.vasp.at/wiki/index.php/ISMEAR).",
                 BadInputSetWarning,
-                stacklevel=1,
+                stacklevel=2,
             )
 
         return incar

--- a/src/pymatgen/symmetry/analyzer.py
+++ b/src/pymatgen/symmetry/analyzer.py
@@ -275,7 +275,7 @@ class SpacegroupAnalyzer:
             vectors in scaled positions.
         """
         with warnings.catch_warnings():
-            # TODO: DeprecationWarning: Use get_magnetic_symmetry() for cell with magnetic moments.
+            # TODO: get DeprecationWarning: Use get_magnetic_symmetry() for cell with magnetic moments.
             warnings.filterwarnings("ignore", message="Use get_magnetic_symmetry", category=DeprecationWarning)
             dct = spglib.get_symmetry(self._cell, symprec=self._symprec, angle_tolerance=self._angle_tol)
 

--- a/src/pymatgen/symmetry/analyzer.py
+++ b/src/pymatgen/symmetry/analyzer.py
@@ -1674,7 +1674,8 @@ def generate_full_symmops(
             if len(full) > 1000:
                 warnings.warn(
                     f"{len(full)} matrices have been generated. The tol may be too small. Please terminate"
-                    " and rerun with a different tolerance."
+                    " and rerun with a different tolerance.",
+                    stacklevel=2,
                 )
 
     d = np.abs(full - identity) < tol

--- a/src/pymatgen/symmetry/bandstructure.py
+++ b/src/pymatgen/symmetry/bandstructure.py
@@ -204,7 +204,8 @@ class HighSymmKpath(KPathBase):
 
         warn(
             "K-path from the Hinuma et al. convention has been transformed to the basis of the reciprocal lattice"
-            "of the input structure. Use `KPathSeek` for the path in the original author-intended basis."
+            "of the input structure. Use `KPathSeek` for the path in the original author-intended basis.",
+            stacklevel=2,
         )
 
         return bs

--- a/src/pymatgen/symmetry/groups.py
+++ b/src/pymatgen/symmetry/groups.py
@@ -106,7 +106,8 @@ class SymmetryGroup(Sequence, Stringify, ABC):
         """
         warnings.warn(
             "This is not fully functional. Only trivial subsets are tested right now. "
-            "This will not work if the crystallographic directions of the two groups are different."
+            "This will not work if the crystallographic directions of the two groups are different.",
+            stacklevel=2,
         )
         return set(self.symmetry_ops).issubset(supergroup.symmetry_ops)
 
@@ -121,7 +122,8 @@ class SymmetryGroup(Sequence, Stringify, ABC):
         """
         warnings.warn(
             "This is not fully functional. Only trivial subsets are tested right now. "
-            "This will not work if the crystallographic directions of the two groups are different."
+            "This will not work if the crystallographic directions of the two groups are different.",
+            stacklevel=2,
         )
         return set(subgroup.symmetry_ops).issubset(self.symmetry_ops)
 
@@ -229,7 +231,8 @@ class PointGroup(SymmetryGroup):
             raise NotImplementedError
         warnings.warn(
             "This is not fully functional. Only trivial subsets are tested right now. "
-            "This will not work if the crystallographic directions of the two groups are different."
+            "This will not work if the crystallographic directions of the two groups are different.",
+            stacklevel=2,
         )
         return set(self.symmetry_ops).issubset(supergroup.symmetry_ops)
 
@@ -376,7 +379,8 @@ class SpaceGroup(SymmetryGroup):
                     self.full_symbol = spg["hermann_mauguin_u"]
                     warnings.warn(
                         f"Full symbol not available, falling back to short Hermann Mauguin symbol "
-                        f"{self.symbol} instead"
+                        f"{self.symbol} instead",
+                        stacklevel=2,
                     )
                     self.point_group = spg["point_group"]
                 self.int_number = spg["number"]

--- a/src/pymatgen/symmetry/kpath.py
+++ b/src/pymatgen/symmetry/kpath.py
@@ -152,7 +152,11 @@ class KPathSetyawanCurtarolo(KPathBase):
         """
         if "magmom" in structure.site_properties:
             warn(
-                "'magmom' entry found in site properties but will be ignored for the Setyawan and Curtarolo convention."
+                (
+                    "'magmom' entry found in site properties but will be ignored "
+                    "for the Setyawan and Curtarolo convention."
+                ),
+                stacklevel=2,
             )
 
         super().__init__(structure, symprec=symprec, angle_tolerance=angle_tolerance, atol=atol)
@@ -168,7 +172,8 @@ class KPathSetyawanCurtarolo(KPathBase):
         if not np.allclose(self._structure.lattice.matrix, self._prim.lattice.matrix, atol=atol):
             warn(
                 "The input structure does not match the expected standard primitive! "
-                "The path may be incorrect. Use at your own risk."
+                "The path may be incorrect. Use at your own risk.",
+                stacklevel=2,
             )
 
         lattice_type = self._sym.get_lattice_type()
@@ -182,7 +187,7 @@ class KPathSetyawanCurtarolo(KPathBase):
             elif "I" in spg_symbol:
                 self._kpath = self.bcc()
             else:
-                warn(f"Unexpected value for {spg_symbol=}")
+                warn(f"Unexpected value for {spg_symbol=}", stacklevel=2)
 
         elif lattice_type == "tetragonal":
             if "P" in spg_symbol:
@@ -195,7 +200,7 @@ class KPathSetyawanCurtarolo(KPathBase):
                 else:
                     self._kpath = self.bctet2(c, a)
             else:
-                warn(f"Unexpected value for {spg_symbol=}")
+                warn(f"Unexpected value for {spg_symbol=}", stacklevel=2)
 
         elif lattice_type == "orthorhombic":
             a = self._conv.lattice.abc[0]
@@ -219,7 +224,7 @@ class KPathSetyawanCurtarolo(KPathBase):
             elif "C" in spg_symbol or "A" in spg_symbol:
                 self._kpath = self.orcc(a, b, c)
             else:
-                warn(f"Unexpected value for {spg_symbol=}")
+                warn(f"Unexpected value for {spg_symbol=}", stacklevel=2)
 
         elif lattice_type == "hexagonal":
             self._kpath = self.hex()
@@ -253,7 +258,7 @@ class KPathSetyawanCurtarolo(KPathBase):
                     if b * cos(alpha * pi / 180) / c + b**2 * sin(alpha * pi / 180) ** 2 / a**2 > 1:
                         self._kpath = self.mclc5(a, b, c, alpha * pi / 180)
             else:
-                warn(f"Unexpected value for {spg_symbol=}")
+                warn(f"Unexpected value for {spg_symbol=}", stacklevel=2)
 
         elif lattice_type == "triclinic":
             kalpha = self._rec_lattice.parameters[3]
@@ -269,7 +274,7 @@ class KPathSetyawanCurtarolo(KPathBase):
                 self._kpath = self.trib()
 
         else:
-            warn(f"Unknown lattice type {lattice_type}")
+            warn(f"Unknown lattice type {lattice_type}", stacklevel=2)
 
     @property
     def conventional(self):
@@ -909,7 +914,7 @@ class KPathSeek(KPathBase):
         site_data: list[Composition] = species
 
         if not system_is_tri:
-            warn("Non-zero 'magmom' data will be used to define unique atoms in the cell.")
+            warn("Non-zero 'magmom' data will be used to define unique atoms in the cell.", stacklevel=2)
             site_data = zip(species, [tuple(vec) for vec in sp["magmom"]], strict=True)  # type: ignore[assignment]
 
         unique_species: list[SpeciesLike] = []
@@ -1069,7 +1074,8 @@ class KPathLatimerMunro(KPathBase):
             print("reducible")
             warn(
                 "The unit cell of the input structure is not fully reduced!"
-                "The path may be incorrect. Use at your own risk."
+                "The path may be incorrect. Use at your own risk.",
+                stacklevel=2,
             )
 
         if magmom_axis is None:
@@ -1153,7 +1159,8 @@ class KPathLatimerMunro(KPathBase):
             if "magmom" in self._structure.site_properties:
                 warn(
                     "The parameter has_magmoms is False, but site_properties contains the key magmom."
-                    "This property will be removed and could result in different symmetry operations."
+                    "This property will be removed and could result in different symmetry operations.",
+                    stacklevel=2,
                 )
                 self._structure.remove_site_property("magmom")
             sga = SpacegroupAnalyzer(self._structure)
@@ -1634,7 +1641,8 @@ class KPathLatimerMunro(KPathBase):
         if "magmom" not in struct.site_properties:
             warn(
                 "The 'magmom' property is not set in the structure's site properties."
-                "All magnetic moments are being set to zero."
+                "All magnetic moments are being set to zero.",
+                stacklevel=2,
             )
             struct.add_site_property("magmom", [np.array([0, 0, 0]) for _ in range(len(struct))])
 
@@ -1654,7 +1662,10 @@ class KPathLatimerMunro(KPathBase):
                 new_magmoms.append(magmom * magmom_axis)
 
         if found_scalar and not axis_specified:
-            warn("At least one magmom had a scalar value and magmom_axis was not specified. Defaulted to z+ spinor.")
+            warn(
+                "At least one magmom had a scalar value and magmom_axis was not specified. Defaulted to z+ spinor.",
+                stacklevel=2,
+            )
 
         struct.remove_site_property("magmom")
         struct.add_site_property("magmom", new_magmoms)

--- a/src/pymatgen/transformations/advanced_transformations.py
+++ b/src/pymatgen/transformations/advanced_transformations.py
@@ -360,7 +360,8 @@ class EnumerateStructureTransformation(AbstractTransformation):
 
         if structure.is_ordered:
             warnings.warn(
-                f"Enumeration skipped for structure with composition {structure.composition} because it is ordered"
+                f"Enumeration skipped for structure with composition {structure.composition} because it is ordered",
+                stacklevel=2,
             )
             structures = [structure.copy()]
 
@@ -392,7 +393,7 @@ class EnumerateStructureTransformation(AbstractTransformation):
                 if structures:
                     break
             except EnumError:
-                warnings.warn(f"Unable to enumerate for {max_cell_size = }")
+                warnings.warn(f"Unable to enumerate for {max_cell_size = }", stacklevel=2)
 
         if structures is None:
             raise ValueError("Unable to enumerate")
@@ -580,7 +581,8 @@ class MagOrderParameterConstraint(MSONable):
             warnings.warn(
                 "Use care when using a non-standard order parameter, "
                 "though it can be useful in some cases it can also "
-                "lead to unintended behavior. Consult documentation."
+                "lead to unintended behavior. Consult documentation.",
+                stacklevel=2,
             )
 
         self.order_parameter = order_parameter
@@ -846,7 +848,8 @@ class MagOrderingTransformation(AbstractTransformation):
                     f"Specified max cell size ({enum_kwargs['max_cell_size']}) is "
                     "smaller than the minimum enumerable cell size "
                     f"({enum_kwargs['min_cell_size']}), changing max cell size to "
-                    f"{enum_kwargs['min_cell_size']}"
+                    f"{enum_kwargs['min_cell_size']}",
+                    stacklevel=2,
                 )
                 enum_kwargs["max_cell_size"] = enum_kwargs["min_cell_size"]
         else:

--- a/tests/entries/test_compatibility.py
+++ b/tests/entries/test_compatibility.py
@@ -594,7 +594,7 @@ class TestMaterialsProjectCompatibility(TestCase):
         assert len(entries) == 2
 
     def test_parallel_process_entries(self):
-        # TODO: DeprecationWarning: This process (pid=xxxx) is multi-threaded,
+        # TODO: get DeprecationWarning: This process (pid=xxxx) is multi-threaded,
         # use of fork() may lead to deadlocks in the child.
         # pid = os.fork()
         with pytest.raises(


### PR DESCRIPTION
### Summary
- Increase warnings `stacklevel` to 2, to point to the caller instead of `warnings.warn`
- [x] Un-ignore [RUFF B028](https://docs.astral.sh/ruff/rules/no-explicit-stacklevel/#no-explicit-stacklevel-b028): Checks for warnings.warn calls without an explicit stacklevel keyword argument
- [x] Replace explicit `stacklevel=1`, people might have misunderstood this. It's not "default stacklevel" that is bad, but "default stacklevel as 1" that is not informative
- [x] Remove unnecessary [explicit `UserWarning` as it's default](https://docs.python.org/3/library/warnings.html#warnings.warn):
    > The category argument, if given, must be a [warning category class](https://docs.python.org/3/library/warnings.html#warning-categories); it defaults to [UserWarning](https://docs.python.org/3/library/exceptions.html#UserWarning).
- Change `_MPResterLegacy` from default `UserWarning` to `FutureWarning`
    > https://github.com/materialsproject/pymatgen/blob/31f1e1fb8cc1bb517d59ea8e484965bb641c42a0/src/pymatgen/ext/matproj_legacy.py#L169

---

### Example
https://github.com/materialsproject/pymatgen/blob/31f1e1fb8cc1bb517d59ea8e484965bb641c42a0/src/pymatgen/ext/matproj_legacy.py#L184

**Stacklevel 1**:
```
UserWarning: Non-default endpoint used:xxxx
warnings.warn(f"Non-default endpoint used: {self.preamble}", stacklevel=1)
```

**vs** 

**Stacklevel 2**:
```
UserWarning: Non-default endpoint used: xxxx
  mpr = _MPResterLegacy(MP_API_KEY)
```
