### PR TITLE
Skip another failing `Phonopy` test in Windows after NumPy bumped to 2 in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,6 +90,9 @@ jobs:
           WHEEL_FILE=$(ls dist/pymatgen*.whl)
           uv pip install $WHEEL_FILE[${{matrix.config.extras}}] --resolution=${{matrix.config.resolution}}
 
+          # TODO: test monty fix for reverse readline
+          uv pip install git+https://github.com/materialsvirtuallab/monty.git@master
+
       - name: Install optional Ubuntu dependencies
         if: matrix.config.os == 'ubuntu-latest'
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,9 +90,6 @@ jobs:
           WHEEL_FILE=$(ls dist/pymatgen*.whl)
           uv pip install $WHEEL_FILE[${{matrix.config.extras}}] --resolution=${{matrix.config.resolution}}
 
-          # TODO: test monty fix for reverse readline
-          uv pip install git+https://github.com/materialsvirtuallab/monty.git@master
-
       - name: Install optional Ubuntu dependencies
         if: matrix.config.os == 'ubuntu-latest'
         run: |

--- a/tests/io/test_phonopy.py
+++ b/tests/io/test_phonopy.py
@@ -10,12 +10,11 @@ import pytest
 from numpy.testing import assert_allclose, assert_array_equal
 from pytest import approx
 
-from pymatgen.core import Element
+from pymatgen.core import Element, Structure
 from pymatgen.io.phonopy import (
     CompletePhononDos,
     PhononBandStructure,
     PhononBandStructureSymmLine,
-    Structure,
     get_complete_ph_dos,
     get_displaced_structures,
     get_gruneisen_ph_bs_symm_line,

--- a/tests/io/test_phonopy.py
+++ b/tests/io/test_phonopy.py
@@ -125,6 +125,10 @@ class TestStructureConversion(PymatgenTest):
         assert struct_pmg_round_trip.site_properties["magmom"] == struct_pmg.site_properties["magmom"]
 
 
+@pytest.mark.skipif(
+    platform.system() == "Windows" and int(np.__version__[0]) >= 2,
+    reason="See https://github.com/conda-forge/phonopy-feedstock/pull/158#issuecomment-2227506701",
+)
 @pytest.mark.skipif(Phonopy is None, reason="Phonopy not present")
 class TestGetDisplacedStructures(PymatgenTest):
     def test_get_displaced_structures(self):
@@ -157,11 +161,11 @@ class TestGetDisplacedStructures(PymatgenTest):
         assert os.path.isfile("test.yaml")
 
 
-@pytest.mark.skipif(Phonopy is None, reason="Phonopy not present")
 @pytest.mark.skipif(
     platform.system() == "Windows" and int(np.__version__[0]) >= 2,
     reason="See https://github.com/conda-forge/phonopy-feedstock/pull/158#issuecomment-2227506701",
 )
+@pytest.mark.skipif(Phonopy is None, reason="Phonopy not present")
 class TestPhonopyFromForceConstants(TestCase):
     def setUp(self) -> None:
         test_path = Path(TEST_DIR)

--- a/tests/io/test_phonopy.py
+++ b/tests/io/test_phonopy.py
@@ -126,7 +126,7 @@ class TestStructureConversion(PymatgenTest):
 
 @pytest.mark.skipif(
     platform.system() == "Windows" and int(np.__version__[0]) >= 2,
-    reason="See https://github.com/conda-forge/phonopy-feedstock/pull/158#issuecomment-2227506701",
+    reason="cannot run NP2 on windows, see PR 4224",
 )
 @pytest.mark.skipif(Phonopy is None, reason="Phonopy not present")
 class TestGetDisplacedStructures(PymatgenTest):
@@ -162,7 +162,7 @@ class TestGetDisplacedStructures(PymatgenTest):
 
 @pytest.mark.skipif(
     platform.system() == "Windows" and int(np.__version__[0]) >= 2,
-    reason="See https://github.com/conda-forge/phonopy-feedstock/pull/158#issuecomment-2227506701",
+    reason="cannot run NP2 on windows, see PR 4224",
 )
 @pytest.mark.skipif(Phonopy is None, reason="Phonopy not present")
 class TestPhonopyFromForceConstants(TestCase):


### PR DESCRIPTION
Skip another failing `phonopy` test in Windows after NumPy bumped to 2 in CI
- https://github.com/phonopy/phonopy/issues/476

I could recreate this in my Windows PC, all four tests failing for the same reason:

```
Python 3.10.0

phonopy==2.33.0
numpy==2.0.2
```

```
$ pytest tests/io/test_phonopy.py 
....FFFF...                                                                                                                                                       [100%]
=============================================================================== FAILURES ===============================================================================
_______________________________________________________ TestGetDisplacedStructures.test_get_displaced_structures _______________________________________________________

self = <tests.io.test_phonopy.TestGetDisplacedStructures testMethod=test_get_displaced_structures>

    def test_get_displaced_structures(self):
        pmg_s = Structure.from_file(f"{TEST_DIR}/POSCAR-unitcell", primitive=False)
        supercell_matrix = np.diag((2, 1, 2))
>       structures = get_displaced_structures(pmg_structure=pmg_s, atom_disp=0.01, supercell_matrix=supercell_matrix)

D:\pymatgen\tests\io\test_phonopy.py:134:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _  
C:\Users\Yang\anaconda3\envs\py310\lib\site-packages\monty\dev.py:216: in decorated
    return _callable(*args, **kwargs)
D:\pymatgen\src\pymatgen\io\phonopy.py:260: in get_displaced_structures
    phonon = Phonopy(unitcell=ph_structure, supercell_matrix=supercell_matrix)
C:\Users\Yang\anaconda3\envs\py310\lib\site-packages\phonopy\api_phonopy.py:293: in __init__
    self._build_primitive_cell()
C:\Users\Yang\anaconda3\envs\py310\lib\site-packages\phonopy\api_phonopy.py:4146: in _build_primitive_cell
    self._primitive = get_primitive(
C:\Users\Yang\anaconda3\envs\py310\lib\site-packages\phonopy\structure\cells.py:886: in get_primitive
    return Primitive(
C:\Users\Yang\anaconda3\envs\py310\lib\site-packages\phonopy\structure\cells.py:386: in __init__
    self._run(supercell, positions_to_reorder=positions_to_reorder)
C:\Users\Yang\anaconda3\envs\py310\lib\site-packages\phonopy\structure\cells.py:554: in _run
    (self._smallest_vectors, self._multiplicity) = self._get_smallest_vectors(
C:\Users\Yang\anaconda3\envs\py310\lib\site-packages\phonopy\structure\cells.py:650: in _get_smallest_vectors
    svecs, multi = get_smallest_vectors(
C:\Users\Yang\anaconda3\envs\py310\lib\site-packages\phonopy\structure\cells.py:1098: in get_smallest_vectors
    spairs = ShortestPairs(
C:\Users\Yang\anaconda3\envs\py310\lib\site-packages\phonopy\structure\cells.py:1165: in __init__
    svecs, multi = self._run_dense()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _  

self = <phonopy.structure.cells.ShortestPairs object at 0x0000027AFBAD2B60>

    def _run_dense(self):
        """Find shortest atomic pair vectors.

        Returns
        -------
        shortest_vectors : ndarray
            Shortest vectors in supercell coordinates.
            shape=(sum(multiplicities[:, :, 0], 3), dtype='double'
        multiplicities : ndarray
            Number of equidistance shortest vectors. The last dimension
            indicates [0] multipliticy at the pair of atoms in the supercell
            and primitive cell, and [1] integral of multiplicities to
            this pair, i.e., which indicates address used in
            `shortest_vectors`.
            shape=(size_super, size_prim, 2), dtype='int_'

        """
        (
            lattice_points,
            supercell_fracs,
            primitive_fracs,
            trans_mat_inv,
            reduced_bases,
        ) = self._transform_cell_basis("int_")

        # Phase1 : Set multiplicity.
        # shortest_vectors is a dummy array.
        shortest_vectors = np.zeros((1, 3), dtype="double", order="C")
        multiplicity = np.zeros(
            (len(supercell_fracs), len(primitive_fracs), 2), dtype="int_", order="C"
        )
        import phonopy._phonopy as phonoc

        phonoc.gsv_set_smallest_vectors_dense(
            shortest_vectors,
            multiplicity,
            supercell_fracs,
            primitive_fracs,
            lattice_points,
            np.array(reduced_bases.T, dtype="double", order="C"),
            np.array(trans_mat_inv.T, dtype="int_", order="C"),
            1,
            self._symprec,
        )

        # Phase 2 : Set shortest_vectors.
>       shortest_vectors = np.zeros(
            (np.sum(multiplicity[:, :, 0]), 3), dtype="double", order="C"
        )
E       numpy._core._exceptions._ArrayMemoryError: Unable to allocate 2.14 EiB for an array with shape (102803044411911591, 3) and data type float64

C:\Users\Yang\anaconda3\envs\py310\lib\site-packages\phonopy\structure\cells.py:1239: MemoryError
_________________________________________________ TestPhonopyFromForceConstants.test_get_phonon_band_structure_from_fc _________________________________________________ 

self = <tests.io.test_phonopy.TestPhonopyFromForceConstants testMethod=test_get_phonon_band_structure_from_fc>

    def test_get_phonon_band_structure_from_fc(self):
>       bs = get_phonon_band_structure_from_fc(
            self.structure,
            self.supercell_matrix,
            self.force_constants,
            mesh_density=10.0,
        )

tests\io\test_phonopy.py:187:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _  
C:\Users\Yang\anaconda3\envs\py310\lib\site-packages\monty\dev.py:216: in decorated
    return _callable(*args, **kwargs)
src\pymatgen\io\phonopy.py:362: in get_phonon_band_structure_from_fc
    phonon = Phonopy(structure_phonopy, supercell_matrix=supercell_matrix, **kwargs)
C:\Users\Yang\anaconda3\envs\py310\lib\site-packages\phonopy\api_phonopy.py:293: in __init__
    self._build_primitive_cell()
C:\Users\Yang\anaconda3\envs\py310\lib\site-packages\phonopy\api_phonopy.py:4146: in _build_primitive_cell
    self._primitive = get_primitive(
C:\Users\Yang\anaconda3\envs\py310\lib\site-packages\phonopy\structure\cells.py:886: in get_primitive
    return Primitive(
C:\Users\Yang\anaconda3\envs\py310\lib\site-packages\phonopy\structure\cells.py:386: in __init__
    self._run(supercell, positions_to_reorder=positions_to_reorder)
C:\Users\Yang\anaconda3\envs\py310\lib\site-packages\phonopy\structure\cells.py:554: in _run
    (self._smallest_vectors, self._multiplicity) = self._get_smallest_vectors(
C:\Users\Yang\anaconda3\envs\py310\lib\site-packages\phonopy\structure\cells.py:650: in _get_smallest_vectors
    svecs, multi = get_smallest_vectors(
C:\Users\Yang\anaconda3\envs\py310\lib\site-packages\phonopy\structure\cells.py:1098: in get_smallest_vectors
    spairs = ShortestPairs(
C:\Users\Yang\anaconda3\envs\py310\lib\site-packages\phonopy\structure\cells.py:1165: in __init__
    svecs, multi = self._run_dense()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _  

self = <phonopy.structure.cells.ShortestPairs object at 0x0000027AFC82BB20>

    def _run_dense(self):
        """Find shortest atomic pair vectors.

        Returns
        -------
        shortest_vectors : ndarray
            Shortest vectors in supercell coordinates.
            shape=(sum(multiplicities[:, :, 0], 3), dtype='double'
        multiplicities : ndarray
            Number of equidistance shortest vectors. The last dimension
            indicates [0] multipliticy at the pair of atoms in the supercell
            and primitive cell, and [1] integral of multiplicities to
            this pair, i.e., which indicates address used in
            `shortest_vectors`.
            shape=(size_super, size_prim, 2), dtype='int_'

        """
        (
            lattice_points,
            supercell_fracs,
            primitive_fracs,
            trans_mat_inv,
            reduced_bases,
        ) = self._transform_cell_basis("int_")

        # Phase1 : Set multiplicity.
        # shortest_vectors is a dummy array.
        shortest_vectors = np.zeros((1, 3), dtype="double", order="C")
        multiplicity = np.zeros(
            (len(supercell_fracs), len(primitive_fracs), 2), dtype="int_", order="C"
        )
        import phonopy._phonopy as phonoc

        phonoc.gsv_set_smallest_vectors_dense(
            shortest_vectors,
            multiplicity,
            supercell_fracs,
            primitive_fracs,
            lattice_points,
            np.array(reduced_bases.T, dtype="double", order="C"),
            np.array(trans_mat_inv.T, dtype="int_", order="C"),
            1,
            self._symprec,
        )

        # Phase 2 : Set shortest_vectors.
>       shortest_vectors = np.zeros(
            (np.sum(multiplicity[:, :, 0]), 3), dtype="double", order="C"
        )
E       numpy._core._exceptions._ArrayMemoryError: Unable to allocate 45.7 PiB for an array with shape (2143661127108530, 3) and data type float64

C:\Users\Yang\anaconda3\envs\py310\lib\site-packages\phonopy\structure\cells.py:1239: MemoryError
____________________________________________ TestPhonopyFromForceConstants.test_get_phonon_band_structure_symm_line_from_fc ____________________________________________ 

self = <tests.io.test_phonopy.TestPhonopyFromForceConstants testMethod=test_get_phonon_band_structure_symm_line_from_fc>

    def test_get_phonon_band_structure_symm_line_from_fc(self):
>       bs = get_phonon_band_structure_symm_line_from_fc(
            self.structure,
            self.supercell_matrix,
            self.force_constants,
            line_density=5.0,
        )

tests\io\test_phonopy.py:200:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _  
C:\Users\Yang\anaconda3\envs\py310\lib\site-packages\monty\dev.py:216: in decorated
    return _callable(*args, **kwargs)
src\pymatgen\io\phonopy.py:396: in get_phonon_band_structure_symm_line_from_fc
    phonon = Phonopy(structure_phonopy, supercell_matrix=supercell_matrix, symprec=symprec, **kwargs)
C:\Users\Yang\anaconda3\envs\py310\lib\site-packages\phonopy\api_phonopy.py:293: in __init__
    self._build_primitive_cell()
C:\Users\Yang\anaconda3\envs\py310\lib\site-packages\phonopy\api_phonopy.py:4146: in _build_primitive_cell
    self._primitive = get_primitive(
C:\Users\Yang\anaconda3\envs\py310\lib\site-packages\phonopy\structure\cells.py:886: in get_primitive
    return Primitive(
C:\Users\Yang\anaconda3\envs\py310\lib\site-packages\phonopy\structure\cells.py:386: in __init__
    self._run(supercell, positions_to_reorder=positions_to_reorder)
C:\Users\Yang\anaconda3\envs\py310\lib\site-packages\phonopy\structure\cells.py:554: in _run
    (self._smallest_vectors, self._multiplicity) = self._get_smallest_vectors(
C:\Users\Yang\anaconda3\envs\py310\lib\site-packages\phonopy\structure\cells.py:650: in _get_smallest_vectors
    svecs, multi = get_smallest_vectors(
C:\Users\Yang\anaconda3\envs\py310\lib\site-packages\phonopy\structure\cells.py:1098: in get_smallest_vectors
    spairs = ShortestPairs(
C:\Users\Yang\anaconda3\envs\py310\lib\site-packages\phonopy\structure\cells.py:1165: in __init__
    svecs, multi = self._run_dense()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _  

self = <phonopy.structure.cells.ShortestPairs object at 0x0000027AFA9AF4C0>

    def _run_dense(self):
        """Find shortest atomic pair vectors.

        Returns
        -------
        shortest_vectors : ndarray
            Shortest vectors in supercell coordinates.
            shape=(sum(multiplicities[:, :, 0], 3), dtype='double'
        multiplicities : ndarray
            Number of equidistance shortest vectors. The last dimension
            indicates [0] multipliticy at the pair of atoms in the supercell
            and primitive cell, and [1] integral of multiplicities to
            this pair, i.e., which indicates address used in
            `shortest_vectors`.
            shape=(size_super, size_prim, 2), dtype='int_'

        """
        (
            lattice_points,
            supercell_fracs,
            primitive_fracs,
            trans_mat_inv,
            reduced_bases,
        ) = self._transform_cell_basis("int_")

        # Phase1 : Set multiplicity.
        # shortest_vectors is a dummy array.
        shortest_vectors = np.zeros((1, 3), dtype="double", order="C")
        multiplicity = np.zeros(
            (len(supercell_fracs), len(primitive_fracs), 2), dtype="int_", order="C"
        )
        import phonopy._phonopy as phonoc

        phonoc.gsv_set_smallest_vectors_dense(
            shortest_vectors,
            multiplicity,
            supercell_fracs,
            primitive_fracs,
            lattice_points,
            np.array(reduced_bases.T, dtype="double", order="C"),
            np.array(trans_mat_inv.T, dtype="int_", order="C"),
            1,
            self._symprec,
        )

        # Phase 2 : Set shortest_vectors.
>       shortest_vectors = np.zeros(
            (np.sum(multiplicity[:, :, 0]), 3), dtype="double", order="C"
        )
E       numpy._core._exceptions._ArrayMemoryError: Unable to allocate 45.7 PiB for an array with shape (2143661127108530, 3) and data type float64

C:\Users\Yang\anaconda3\envs\py310\lib\site-packages\phonopy\structure\cells.py:1239: MemoryError
______________________________________________________ TestPhonopyFromForceConstants.test_get_phonon_dos_from_fc _______________________________________________________ 

self = <tests.io.test_phonopy.TestPhonopyFromForceConstants testMethod=test_get_phonon_dos_from_fc>

    def test_get_phonon_dos_from_fc(self):
>       dos = get_phonon_dos_from_fc(
            self.structure,
            self.supercell_matrix,
            self.force_constants,
            mesh_density=10.0,
        )

tests\io\test_phonopy.py:174:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _  
C:\Users\Yang\anaconda3\envs\py310\lib\site-packages\monty\dev.py:216: in decorated
    return _callable(*args, **kwargs)
src\pymatgen\io\phonopy.py:315: in get_phonon_dos_from_fc
    phonon = Phonopy(structure_phonopy, supercell_matrix=supercell_matrix, **kwargs)
C:\Users\Yang\anaconda3\envs\py310\lib\site-packages\phonopy\api_phonopy.py:293: in __init__
    self._build_primitive_cell()
C:\Users\Yang\anaconda3\envs\py310\lib\site-packages\phonopy\api_phonopy.py:4146: in _build_primitive_cell
    self._primitive = get_primitive(
C:\Users\Yang\anaconda3\envs\py310\lib\site-packages\phonopy\structure\cells.py:886: in get_primitive
    return Primitive(
C:\Users\Yang\anaconda3\envs\py310\lib\site-packages\phonopy\structure\cells.py:386: in __init__
    self._run(supercell, positions_to_reorder=positions_to_reorder)
C:\Users\Yang\anaconda3\envs\py310\lib\site-packages\phonopy\structure\cells.py:554: in _run
    (self._smallest_vectors, self._multiplicity) = self._get_smallest_vectors(
C:\Users\Yang\anaconda3\envs\py310\lib\site-packages\phonopy\structure\cells.py:650: in _get_smallest_vectors
    svecs, multi = get_smallest_vectors(
C:\Users\Yang\anaconda3\envs\py310\lib\site-packages\phonopy\structure\cells.py:1098: in get_smallest_vectors
    spairs = ShortestPairs(
C:\Users\Yang\anaconda3\envs\py310\lib\site-packages\phonopy\structure\cells.py:1165: in __init__
    svecs, multi = self._run_dense()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _  

self = <phonopy.structure.cells.ShortestPairs object at 0x0000027AFBAD02E0>

    def _run_dense(self):
        """Find shortest atomic pair vectors.

        Returns
        -------
        shortest_vectors : ndarray
            Shortest vectors in supercell coordinates.
            shape=(sum(multiplicities[:, :, 0], 3), dtype='double'
        multiplicities : ndarray
            Number of equidistance shortest vectors. The last dimension
            indicates [0] multipliticy at the pair of atoms in the supercell
            and primitive cell, and [1] integral of multiplicities to
            this pair, i.e., which indicates address used in
            `shortest_vectors`.
            shape=(size_super, size_prim, 2), dtype='int_'

        """
        (
            lattice_points,
            supercell_fracs,
            primitive_fracs,
            trans_mat_inv,
            reduced_bases,
        ) = self._transform_cell_basis("int_")

        # Phase1 : Set multiplicity.
        # shortest_vectors is a dummy array.
        shortest_vectors = np.zeros((1, 3), dtype="double", order="C")
        multiplicity = np.zeros(
            (len(supercell_fracs), len(primitive_fracs), 2), dtype="int_", order="C"
        )
        import phonopy._phonopy as phonoc

        phonoc.gsv_set_smallest_vectors_dense(
            shortest_vectors,
            multiplicity,
            supercell_fracs,
            primitive_fracs,
            lattice_points,
            np.array(reduced_bases.T, dtype="double", order="C"),
            np.array(trans_mat_inv.T, dtype="int_", order="C"),
            1,
            self._symprec,
        )

        # Phase 2 : Set shortest_vectors.
>       shortest_vectors = np.zeros(
            (np.sum(multiplicity[:, :, 0]), 3), dtype="double", order="C"
        )
E       numpy._core._exceptions._ArrayMemoryError: Unable to allocate 45.7 PiB for an array with shape (2143661127108530, 3) and data type float64

C:\Users\Yang\anaconda3\envs\py310\lib\site-packages\phonopy\structure\cells.py:1239: MemoryError
========================================================================= slowest 30 durations ========================================================================= 
24.93s call     tests/io/test_phonopy.py::TestGruneisen::test_gruneisen_parameter
8.58s call     tests/io/test_phonopy.py::TestGruneisen::test_ph_bs_symm_line
4.29s call     tests/io/test_phonopy.py::TestPhonopyParser::test_get_ph_bs
1.11s call     tests/io/test_phonopy.py::TestThermalDisplacementMatrices::test_get_thermal_displacement_matrix
0.51s call     tests/io/test_phonopy.py::TestGetDisplacedStructures::test_get_displaced_structures
0.12s call     tests/io/test_phonopy.py::TestPhonopyParser::test_get_complete_dos
0.03s call     tests/io/test_phonopy.py::TestPhonopyFromForceConstants::test_get_phonon_dos_from_fc
0.03s call     tests/io/test_phonopy.py::TestPhonopyFromForceConstants::test_get_phonon_band_structure_symm_line_from_fc
0.03s call     tests/io/test_phonopy.py::TestPhonopyFromForceConstants::test_get_phonon_band_structure_from_fc
0.01s call     tests/io/test_phonopy.py::TestStructureConversion::test_structure_conversion
0.01s setup    tests/io/test_phonopy.py::TestPhonopyParser::test_get_ph_bs

(19 durations < 0.005s hidden.  Use -vv to show these durations.)
4 failed, 7 passed in 42.69s
```