### PR TITLE
Bump `phonopy` to apply fix for NumPy 2 in Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ optional = [
     "hiphive>=1.3.1",
     "jarvis-tools>=2020.7.14",
     "matplotlib>=3.8",
-    "phonopy @ git+https://github.com/phonopy/phonopy.git@develop",  # TODO: test fix
+    "phonopy>=2.33.3",
     "seekpath>=2.0.1",
 ]
 # tblite only support Python 3.12+ through conda-forge

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ optional = [
     "hiphive>=1.3.1",
     "jarvis-tools>=2020.7.14",
     "matplotlib>=3.8",
-    "phonopy>=2.23",
+    "phonopy @ git+https://github.com/phonopy/phonopy.git@develop",  # TODO: test fix
     "seekpath>=2.0.1",
 ]
 # tblite only support Python 3.12+ through conda-forge

--- a/tests/io/test_phonopy.py
+++ b/tests/io/test_phonopy.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import platform
 from pathlib import Path
 from unittest import TestCase
 
@@ -124,10 +123,6 @@ class TestStructureConversion(PymatgenTest):
         assert struct_pmg_round_trip.site_properties["magmom"] == struct_pmg.site_properties["magmom"]
 
 
-@pytest.mark.skipif(
-    platform.system() == "Windows" and int(np.__version__[0]) >= 2,
-    reason="cannot run NP2 on windows, see PR 4224",
-)
 @pytest.mark.skipif(Phonopy is None, reason="Phonopy not present")
 class TestGetDisplacedStructures(PymatgenTest):
     def test_get_displaced_structures(self):
@@ -160,10 +155,6 @@ class TestGetDisplacedStructures(PymatgenTest):
         assert os.path.isfile("test.yaml")
 
 
-@pytest.mark.skipif(
-    platform.system() == "Windows" and int(np.__version__[0]) >= 2,
-    reason="cannot run NP2 on windows, see PR 4224",
-)
 @pytest.mark.skipif(Phonopy is None, reason="Phonopy not present")
 class TestPhonopyFromForceConstants(TestCase):
     def setUp(self) -> None:

--- a/tests/util/test_typing.py
+++ b/tests/util/test_typing.py
@@ -2,12 +2,9 @@
 
 from __future__ import annotations
 
-import sys
 from pathlib import Path
 from types import GenericAlias
 from typing import TYPE_CHECKING, get_args
-
-import pytest
 
 from pymatgen.core import Composition, DummySpecies, Element, Species
 from pymatgen.entries import Entry
@@ -19,8 +16,6 @@ if TYPE_CHECKING:
 __author__ = "Janosh Riebesell"
 __date__ = "2022-10-20"
 __email__ = "janosh@lbl.gov"
-
-skip_below_py310 = pytest.mark.skipif(sys.version_info < (3, 10), reason="requires python 3.10 or higher")
 
 
 def _type_str(some_type: Any) -> str:
@@ -48,7 +43,6 @@ def test_entry_like():
     assert Entry.__name__ in str(EntryLike)
 
 
-@skip_below_py310
 def test_species_like():
     assert isinstance("H", SpeciesLike)
     assert isinstance(Element("H"), SpeciesLike)
@@ -56,7 +50,6 @@ def test_species_like():
     assert isinstance(DummySpecies("X"), SpeciesLike)
 
 
-@skip_below_py310
 def test_composition_like():
     assert isinstance("H", CompositionLike)
     assert isinstance(Element("H"), CompositionLike)
@@ -71,7 +64,6 @@ def test_pbc_like():
     assert get_args(PbcLike) == (bool, bool, bool)
 
 
-@skip_below_py310
 def test_pathlike():
     assert isinstance("path/to/file", PathLike)
     assert isinstance(Path("path/to/file"), PathLike)


### PR DESCRIPTION
- Bump `phonopy` to apply fix for NumPy 2 in Windows:
    - https://github.com/phonopy/phonopy/issues/476
- Drop Python < 3.10 check