### PR TITLE
Fix `Composition` for mixed species & element compositions

### DIFF
--- a/src/pymatgen/core/composition.py
+++ b/src/pymatgen/core/composition.py
@@ -203,6 +203,7 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
         return iter(self._data)
 
     def items(self) -> ItemsView[Species | Element | DummySpecies, float]:
+        """Returns Dict.items() for the Composition dict."""
         return self._data.items()
 
     def __contains__(self, key) -> bool:

--- a/src/pymatgen/core/composition.py
+++ b/src/pymatgen/core/composition.py
@@ -24,8 +24,8 @@ from pymatgen.core.units import Mass
 from pymatgen.util.string import Stringify, formula_double_format
 
 if TYPE_CHECKING:
-    from collections.abc import Generator, Iterator
-    from typing import Any, ClassVar, Literal, ItemsView
+    from collections.abc import Generator, ItemsView, Iterator
+    from typing import Any, ClassVar, Literal
 
     from typing_extensions import Self
 

--- a/src/pymatgen/core/composition.py
+++ b/src/pymatgen/core/composition.py
@@ -173,7 +173,7 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
         else:
             elem_map = dict(*args, **kwargs)  # type: ignore[assignment]
         elem_amt = {}
-        self._n_atoms = 0
+        self._n_atoms: int | float = 0
         for key, val in elem_map.items():
             if val < -type(self).amount_tolerance and not self.allow_negative:
                 raise ValueError("Amounts in Composition cannot be negative!")
@@ -184,7 +184,7 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
         if strict and not self.valid:
             raise ValueError(f"Composition is not valid, contains: {', '.join(map(str, self.elements))}")
 
-    def __getitem__(self, key: SpeciesLike) -> float:
+    def __getitem__(self, key: SpeciesLike) -> int | float:
         try:
             sp = get_el_sp(key)
             if isinstance(sp, Species):
@@ -202,7 +202,7 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
     def __iter__(self) -> Iterator[Species | Element | DummySpecies]:
         return iter(self._data)
 
-    def items(self) -> ItemsView[Species | Element | DummySpecies, float]:
+    def items(self) -> ItemsView[Species | Element | DummySpecies, int | float]:
         """Returns Dict.items() for the Composition dict."""
         return self._data.items()
 

--- a/src/pymatgen/core/composition.py
+++ b/src/pymatgen/core/composition.py
@@ -25,7 +25,7 @@ from pymatgen.util.string import Stringify, formula_double_format
 
 if TYPE_CHECKING:
     from collections.abc import Generator, Iterator
-    from typing import Any, ClassVar, Literal
+    from typing import Any, ClassVar, Literal, ItemsView
 
     from typing_extensions import Self
 
@@ -201,6 +201,9 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
 
     def __iter__(self) -> Iterator[Species | Element | DummySpecies]:
         return iter(self._data)
+
+    def items(self) -> ItemsView[Species | Element | DummySpecies, float]:
+        return self._data.items()
 
     def __contains__(self, key) -> bool:
         try:

--- a/tests/core/test_composition.py
+++ b/tests/core/test_composition.py
@@ -625,8 +625,8 @@ class TestComposition(PymatgenTest):
         # test species
         c1 = Composition({"Mg": 1, "Mg2+": -1}, allow_negative=True)
         assert c1.num_atoms == 2
-        assert c1.element_composition == Composition("Mg-1", allow_negative=True)
-        assert c1.average_electroneg == 0.655
+        assert c1.get_el_amt_dict() == {"Mg": 0}
+        assert c1.average_electroneg == 1.31  # correct Mg electronegativity
 
     def test_special_formulas(self):
         special_formulas = {

--- a/tests/core/test_composition.py
+++ b/tests/core/test_composition.py
@@ -144,6 +144,10 @@ class TestComposition(PymatgenTest):
             with pytest.raises(TypeError, match=f"{type(val).__name__!r} object is not iterable"):
                 Composition(val)
 
+    def test_init_mixed_valence(self):
+        assert Composition({"Fe3+": 2, "Fe2+": 2, "Li": 4, "O": 16, "P": 4}).formula == "Li4 Fe4 P4 O16"
+        assert Composition({"Fe3+": 2, "Fe": 2, "Li": 4, "O": 16, "P": 4}).formula == "Li4 Fe4 P4 O16"
+
     def test_str_and_repr(self):
         test_cases = [
             (


### PR DESCRIPTION
`Composition` objects initialised as e.g. `Composition({"Cd2+": 1, "Cd": 1, "Te2-": 2})` do not behave as expected, giving e.g. `Composition.formula = "Cd3 Te2"` instead of `Cd2 Te2`. This is due to `Composition.__getitem__()` matching all species and elements/non-species of a given input string; so that `Composition["Cd"]` here would return `2` (as desired), but than `Composition.items()` (which is use for `get_el_amt_dict`, `formula` and more) gives `("Cd2+", 1), ("Cd", 2), ("Te", 2)` which is incorrect.
In the end, it's an easy fix to just define the `items()` method to avoid the `Composition.__getitem__()` (which is only needed when the user does `Composition[...]`).

Test added, which failed with previous code and passes now.

Context: Took a while to find what was going on here. Was originally flagged by this `ValueError` with `ComputedStructureEntry`: https://github.com/materialsproject/pymatgen/blob/master/src/pymatgen/entries/computed_entries.py#L588

With original `pymatgen` code:
![image](https://github.com/user-attachments/assets/82469cb3-4ada-45bb-8cfe-55b6676004b4)

![image](https://github.com/user-attachments/assets/d333b290-96d3-495e-98ce-4a62274db5bd)

With fixed code:
![image](https://github.com/user-attachments/assets/b8a89a9a-69d2-4539-9d60-05c8cd5685a1)

![image](https://github.com/user-attachments/assets/26e3b2d9-8dc7-4f75-8691-d0ba8afe69b2)


Flagged by tests in [ShakeNBreak](https://shakenbreak.readthedocs.io/), because defect generation in `pymatgen-analysis-defects` mixes species with just element symbols; e.g. converting to just element symbol with `get_element` here: https://github.com/materialsproject/pymatgen-analysis-defects/blob/main/pymatgen/analysis/defects/core.py#L566-L576
