### PR TITLE
Add `Structure.get_symmetry_dataset` convenience method

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ dependencies = [
     # scipy<1.14.1 is incompatible with NumPy 2.0 on Windows
     # https://github.com/scipy/scipy/issues/21052
     "scipy>=1.14.1; platform_system == 'Windows'",
-    "spglib>=2.5.0",
+    "spglib>=2.5",
     "sympy>=1.3",  # PR #4116
     "tabulate>=0.9",
     "tqdm>=4.60",
@@ -110,6 +110,7 @@ optional = [
     "phonopy>=2.33.3",
     "seekpath>=2.0.1",
 ]
+symmetry = ["moyopy>=0.3", "spglib>=2.5"]
 # tblite only support Python 3.12+ through conda-forge
 # https://github.com/tblite/tblite/issues/175
 tblite = [ "tblite[ase]>=0.3.0; platform_system=='Linux' and python_version<'3.12'"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,8 @@ optional = [
     "phonopy>=2.33.3",
     "seekpath>=2.0.1",
 ]
-symmetry = ["moyopy>=0.3", "spglib>=2.5"]
+# moyopy[interface] includes ase
+symmetry = ["moyopy[interface]>=0.3", "spglib>=2.5"]
 # tblite only support Python 3.12+ through conda-forge
 # https://github.com/tblite/tblite/issues/175
 tblite = [ "tblite[ase]>=0.3.0; platform_system=='Linux' and python_version<'3.12'"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ Pypi = "https://pypi.org/project/pymatgen"
 [project.optional-dependencies]
 abinit = ["netcdf4>=1.7.2"]
 ase = ["ase>=3.23.0"]
-ci = ["pytest-cov>=4", "pytest-split>=0.8", "pytest>=8"]
+ci = ["pytest-cov>=4", "pytest-split>=0.8", "pytest>=8", "pymatgen[symmetry]"]
 docs = ["invoke", "sphinx", "sphinx_markdown_builder", "sphinx_rtd_theme"]
 electronic_structure = ["fdint>=2.0.2"]
 mlp = ["chgnet>=0.3.8", "matgl>=1.1.3"]

--- a/src/pymatgen/core/structure.py
+++ b/src/pymatgen/core/structure.py
@@ -23,8 +23,6 @@ from fnmatch import fnmatch
 from typing import TYPE_CHECKING, Literal, cast, get_args, overload
 
 import numpy as np
-from duecredit import due
-from duecredit.doi import Doi
 from monty.dev import deprecated
 from monty.io import zopen
 from monty.json import MSONable
@@ -45,6 +43,7 @@ from pymatgen.core.units import Length, Mass
 from pymatgen.electronic_structure.core import Magmom
 from pymatgen.symmetry.maggroups import MagneticSpaceGroup
 from pymatgen.util.coord import all_distances, get_angle, lattice_points_in_supercell
+from pymatgen.util.due import Doi, due
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Iterator, Sequence

--- a/src/pymatgen/core/structure.py
+++ b/src/pymatgen/core/structure.py
@@ -48,6 +48,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Iterator, Sequence
     from typing import Any, ClassVar, SupportsIndex, TypeAlias
 
+    import moyopy
     import pandas as pd
     from ase import Atoms
     from ase.calculators.calculator import Calculator
@@ -3337,6 +3338,29 @@ class IStructure(SiteCollection, MSONable):
             Structure: with the requested cell type.
         """
         return self.to_cell("conventional", **kwargs)
+
+    def get_moyo_dataset(self, **kwargs) -> moyopy.MoyoDataset:
+        """Get a MoyoDataset object from the structure.
+
+        Args:
+            **kwargs: Additional arguments passed to MoyoDataset constructor.
+
+        Returns:
+            moyopy.MoyoDataset: Object containing moyopy symmetry analysis for structure.
+
+        Raises:
+            ImportError: If moyopy is not installed.
+        """
+        try:
+            import moyopy
+        except ImportError:
+            raise ImportError("moyopy is not installed. Run pip install moyopy.")
+
+        import moyopy.interface
+
+        # Convert structure to MoyoDataset format
+        moyo_cell = moyopy.interface.MoyoAdapter.from_structure(self)
+        return moyopy.MoyoDataset(cell=moyo_cell, **kwargs)
 
 
 class IMolecule(SiteCollection, MSONable):

--- a/src/pymatgen/core/structure.py
+++ b/src/pymatgen/core/structure.py
@@ -23,6 +23,8 @@ from fnmatch import fnmatch
 from typing import TYPE_CHECKING, Literal, cast, get_args, overload
 
 import numpy as np
+from duecredit import due
+from duecredit.doi import Doi
 from monty.dev import deprecated
 from monty.io import zopen
 from monty.json import MSONable
@@ -3343,6 +3345,10 @@ class IStructure(SiteCollection, MSONable):
     @overload
     def get_symmetry_dataset(self, backend: Literal["moyopy"], **kwargs) -> moyopy.MoyoDataset: ...
 
+    @due.dcite(
+        Doi("10.1080/27660400.2024.2384822"),
+        description="Spglib: a software library for crystal symmetry search",
+    )
     @overload
     def get_symmetry_dataset(self, backend: Literal["spglib"], **kwargs) -> spglib.SpglibDataset: ...
 
@@ -3350,6 +3356,12 @@ class IStructure(SiteCollection, MSONable):
         self, backend: Literal["moyopy", "spglib"] = "spglib", **kwargs
     ) -> moyopy.MoyoDataset | spglib.SpglibDataset:
         """Get a symmetry dataset from the structure using either moyopy or spglib backend.
+
+        If using the spglib backend (default), please cite:
+
+        Togo, A., Shinohara, K., & Tanaka, I. (2024). Spglib: a software library for crystal
+        symmetry search. Science and Technology of Advanced Materials: Methods, 4(1), 2384822-2384836.
+        https://doi.org/10.1080/27660400.2024.2384822
 
         Args:
             backend ("moyopy" | "spglib"): Which symmetry analysis backend to use.

--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -6,6 +6,7 @@ import os
 from fractions import Fraction
 from pathlib import Path
 from shutil import which
+from unittest import mock
 
 import numpy as np
 import pytest
@@ -964,6 +965,26 @@ Direct
         new_sites = struct.sites[::-1]  # reverse order of sites
         struct.sites = new_sites
         assert struct.sites == new_sites
+
+    def test_get_moyo_dataset(self):
+        """Test getting MoyoDataset from structure."""
+        pytest.importorskip("moyopy")
+        import moyopy
+
+        dataset = self.struct.get_moyo_dataset()
+        assert isinstance(dataset, moyopy.MoyoDataset)
+        assert dataset.symprec == 0.0001
+        assert dataset.number == 227
+        assert dataset.wyckoffs == ["b", "b"]
+        assert dataset.std_cell.numbers == [14] * 8
+
+        # Test import error
+        import_err_msg = "moyopy is not installed. Run pip install moyopy."
+        with (
+            mock.patch.dict("sys.modules", {"moyopy": None}),
+            pytest.raises(ImportError, match=import_err_msg),
+        ):
+            self.struct.get_moyo_dataset()
 
 
 class TestStructure(PymatgenTest):


### PR DESCRIPTION
`moyopy` is a successor to `spglib` that's faster and written in Rust. in my usage so far for analyzing MLFF-relaxed WBM structures for https://matbench-discovery.materialsproject.org/tasks/geo-opt, it seems about 4x faster than `spglib` and gives identical results in nearly all 257k cases. a few exceptions were reported in https://github.com/CompRhys/aviary/pull/96 and resolution tracked in https://github.com/spglib/moyo/issues/54

this PR adds a convenience method for directly accessing `moyopy` symmetry analysis results on pymatgen `Structures`. it also defines a new optional dependency set `symmetry` in `pyproject.toml`

```
symmetry = ["moyopy>=0.3", "spglib>=2.5"]
```

pinging @lan496

related ASE issue: https://gitlab.com/ase/ase/-/issues/1612