### PR TITLE
Revert "Add `Structure.get_symmetry_dataset` convenience method (#4268)"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ dependencies = [
     # scipy<1.14.1 is incompatible with NumPy 2.0 on Windows
     # https://github.com/scipy/scipy/issues/21052
     "scipy>=1.14.1; platform_system == 'Windows'",
-    "spglib>=2.5",
+    "spglib>=2.5.0",
     "sympy>=1.3",  # PR #4116
     "tabulate>=0.9",
     "tqdm>=4.60",
@@ -89,7 +89,7 @@ Pypi = "https://pypi.org/project/pymatgen"
 [project.optional-dependencies]
 abinit = ["netcdf4>=1.7.2"]
 ase = ["ase>=3.23.0"]
-ci = ["pytest-cov>=4", "pytest-split>=0.8", "pytest>=8", "pymatgen[symmetry]"]
+ci = ["pytest-cov>=4", "pytest-split>=0.8", "pytest>=8"]
 docs = ["invoke", "sphinx", "sphinx_markdown_builder", "sphinx_rtd_theme"]
 electronic_structure = ["fdint>=2.0.2"]
 mlp = ["chgnet>=0.3.8", "matgl>=1.1.3"]
@@ -110,8 +110,6 @@ optional = [
     "phonopy>=2.33.3",
     "seekpath>=2.0.1",
 ]
-# moyopy[interface] includes ase
-symmetry = ["moyopy[interface]>=0.3", "spglib>=2.5"]
 # tblite only support Python 3.12+ through conda-forge
 # https://github.com/tblite/tblite/issues/175
 tblite = [ "tblite[ase]>=0.3.0; platform_system=='Linux' and python_version<'3.12'"]

--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -6,7 +6,6 @@ import os
 from fractions import Fraction
 from pathlib import Path
 from shutil import which
-from unittest import mock
 
 import numpy as np
 import pytest
@@ -965,32 +964,6 @@ Direct
         new_sites = struct.sites[::-1]  # reverse order of sites
         struct.sites = new_sites
         assert struct.sites == new_sites
-
-    def test_get_symmetry_dataset(self):
-        """Test getting symmetry dataset from structure using different backends."""
-        # Test spglib backend
-        dataset = self.struct.get_symmetry_dataset(backend="spglib")
-        assert dataset.number == 227  # Fd-3m space group
-        assert dataset.international == "Fd-3m"
-        assert len(dataset.rotations) > 0
-        assert len(dataset.translations) > 0
-
-        # Test moyopy backend if available
-        moyopy = pytest.importorskip("moyopy")
-        dataset = self.struct.get_symmetry_dataset(backend="moyopy")
-        assert isinstance(dataset, moyopy.MoyoDataset)
-        assert dataset.prim_std_cell.numbers == [14, 14]  # Si atomic number is 14
-
-        # Test import error
-        with (
-            mock.patch.dict("sys.modules", {"moyopy": None}),
-            pytest.raises(ImportError, match="moyopy is not installed. Run pip install moyopy."),
-        ):
-            self.struct.get_symmetry_dataset(backend="moyopy")
-
-        # Test invalid backend
-        with pytest.raises(ValueError, match="Invalid backend='42'"):
-            self.struct.get_symmetry_dataset(backend="42")
 
 
 class TestStructure(PymatgenTest):


### PR DESCRIPTION
This reverts commit 4375e342f31a10fc023c9b07df5db6f316c738d4.

## Summary

Major changes:

- feature 1: ...
- fix 1: ...

## Todos

If this is work in progress, what else needs to be done?

- feature 2: ...
- fix 2:

## Checklist

- [ ] Google format doc strings added. Check with `ruff`.
- [ ] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
