### PR TITLE
`Composition` support formula strings with curly brackets

### DIFF
--- a/src/pymatgen/core/composition.py
+++ b/src/pymatgen/core/composition.py
@@ -619,6 +619,7 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
         # Square brackets are used in formulas to denote coordination complexes (gh-3583)
         formula = formula.replace("[", "(")
         formula = formula.replace("]", ")")
+        # next 2 lines covered by test_curly_bracket_deeply_nested_formulas
         formula = formula.replace("{", "(")
         formula = formula.replace("}", ")")
 

--- a/src/pymatgen/core/composition.py
+++ b/src/pymatgen/core/composition.py
@@ -619,6 +619,8 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
         # Square brackets are used in formulas to denote coordination complexes (gh-3583)
         formula = formula.replace("[", "(")
         formula = formula.replace("]", ")")
+        formula = formula.replace("{", "(")
+        formula = formula.replace("}", ")")
 
         def get_sym_dict(form: str, factor: float) -> dict[str, float]:
             sym_dict: dict[str, float] = defaultdict(float)

--- a/src/pymatgen/io/vasp/outputs.py
+++ b/src/pymatgen/io/vasp/outputs.py
@@ -4719,9 +4719,9 @@ class Xdatcar:
                         preamble.append(line)
                 elif line == "" or "Direct configuration=" in line:
                     poscar = Poscar.from_str("\n".join([*preamble, "Direct", *coords_str]))
-                    if (
-                        ionicstep_end is None and ionicstep_cnt >= ionicstep_start
-                    ) or ionicstep_start <= ionicstep_cnt < ionicstep_end:
+                    if (ionicstep_end is None and ionicstep_cnt >= ionicstep_start) or (
+                        ionicstep_end is not None and ionicstep_start <= ionicstep_cnt < ionicstep_end
+                    ):
                         structures.append(poscar.structure)
                     ionicstep_cnt += 1
                     coords_str = []

--- a/tests/core/test_composition.py
+++ b/tests/core/test_composition.py
@@ -860,7 +860,9 @@ class TestComposition(PymatgenTest):
         assert "Deuterium" in [elem.long_name for elem in composition.elements]
 
     def test_curly_bracket_deeply_nested_formulas(self):
-        """Test parsing of bulk metallic glass formulas with complex nested brackets."""
+        """Test parsing of bulk metallic glass formulas with complex nested brackets collected in
+        Ward et al. (2018) https://doi.org/10.1016/j.actamat.2018.08.002.
+        """
         for formula, expected in {
             "{[(Fe0.6Co0.4)0.75B0.2Si0.05]0.96Nb0.04}100": "Nb4 Fe43.2 Co28.8 Si4.8 B19.2",
             "{[(Fe0.6Co0.4)0.75B0.2Si0.05]0.96Nb0.04}99Cr1": "Nb3.96 Cr1 Fe42.768 Co28.512 Si4.752 B19.008",

--- a/tests/core/test_composition.py
+++ b/tests/core/test_composition.py
@@ -859,6 +859,17 @@ class TestComposition(PymatgenTest):
         assert composition.elements[0].oxi_state == 1
         assert "Deuterium" in [elem.long_name for elem in composition.elements]
 
+    def test_curly_bracket_deeply_nested_formulas(self):
+        """Test parsing of bulk metallic glass formulas with complex nested brackets."""
+        for formula, expected in {
+            "{[(Fe0.6Co0.4)0.75B0.2Si0.05]0.96Nb0.04}100": "Nb4 Fe43.2 Co28.8 Si4.8 B19.2",
+            "{[(Fe0.6Co0.4)0.75B0.2Si0.05]0.96Nb0.04}99Cr1": "Nb3.96 Cr1 Fe42.768 Co28.512 Si4.752 B19.008",
+            "{[(Fe0.6Co0.4)0.75B0.2Si0.05]0.96Nb0.04}98Cr2": "Nb3.92 Cr2 Fe42.336 Co28.224 Si4.704 B18.816",
+            "{[(Fe0.6Co0.4)0.75B0.2Si0.05]0.96Nb0.04}97Cr3": "Nb3.88 Cr3 Fe41.904 Co27.936 Si4.656 B18.624",
+            "{[(Fe0.6Co0.4)0.75B0.2Si0.05]0.96Nb0.04}96Cr4": "Nb3.84 Cr4 Fe41.472 Co27.648 Si4.608 B18.432",
+        }.items():
+            assert Composition(formula).formula == expected
+
 
 def test_reduce_formula():
     assert reduce_formula({"Li": 2, "Mn": 4, "O": 8}) == ("LiMn2O4", 2)


### PR DESCRIPTION
This PR extends the existing bracket normalization for square brackets `[...]` to curly brackets `{...}`. Important e.g. for a few of the 8k+ metallic glass compositions reported in Ward et al. (2018) https://doi.org/10.1016/j.actamat.2018.08.002. previously, some of those formulas raised

```py
ValueError: Invalid formula: {[(Fe0.6Co0.4)0.75B0.2Si0.05]0.96Nb0.04}100
```

i added 5 unit tests to ensure they now parse correctly