### PR TITLE
Remove deprecated memory units from `core`

### DIFF
--- a/src/pymatgen/core/units.py
+++ b/src/pymatgen/core/units.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import collections
 import re
-import warnings
 from collections import defaultdict
 from functools import partial
 from numbers import Number
@@ -310,25 +309,6 @@ class FloatWithUnit(float):
             unit (str | Unit): A unit. e.g. "C".
             unit_type (str): A type of unit. e.g. "charge"
         """
-        # Check deprecated memory unit
-        # TODO: remove after 2025-01-01
-        if unit_type == "memory" and str(unit) in {
-            "Kb",
-            "kb",
-            "Mb",
-            "mb",
-            "Gb",
-            "gb",
-            "Tb",
-            "tb",
-        }:
-            warnings.warn(
-                f"Unit {unit!s} is deprecated, please use {str(unit).upper()} instead",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            unit = str(unit).upper()
-
         if unit_type is not None and str(unit) not in ALL_UNITS[unit_type]:
             raise UnitError(f"{unit} is not a supported unit for {unit_type}")
 

--- a/tests/core/test_units.py
+++ b/tests/core/test_units.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import warnings
-
 import pytest
 from numpy.testing import assert_array_equal
 from pytest import approx
@@ -108,17 +106,6 @@ class TestFloatWithUnit(PymatgenTest):
 
         mega_3 = Memory.from_str("+1.0 MB")
         assert mega_0 == mega_1 == mega_2 == mega_3
-
-    def test_deprecated_memory(self):
-        # TODO: remove after 2025-01-01
-        for unit in ("Kb", "kb", "Mb", "mb", "Gb", "gb", "Tb", "tb"):
-            with pytest.warns(DeprecationWarning, match=f"Unit {unit} is deprecated"):
-                Memory(1, unit)
-
-        with warnings.catch_warnings():
-            warnings.simplefilter("error")
-            for unit in ("KB", "MB", "GB", "TB"):
-                Memory(1, unit)
 
     def test_unitized(self):
         @unitized("eV")


### PR DESCRIPTION
### Summary

- Remove deprecated memory units from `core`