### PR TITLE
Bugfix: Structure/ase.Atoms interconversion side effects

### DIFF
--- a/src/pymatgen/io/ase.py
+++ b/src/pymatgen/io/ase.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import warnings
 from importlib.metadata import PackageNotFoundError
 from typing import TYPE_CHECKING
+import copy
 
 import numpy as np
 from monty.json import MontyDecoder, MSONable, jsanitize
@@ -204,7 +205,7 @@ class AseAtomsAdaptor:
 
         # Atoms.info <---> Structure.properties
         if properties := structure.properties:
-            atoms.info = properties
+            atoms.info = copy.deepcopy(properties)
 
         # Regenerate Spacegroup object from `.todict()` representation
         if isinstance(atoms.info.get("spacegroup"), dict):
@@ -298,10 +299,11 @@ class AseAtomsAdaptor:
             sel_dyn = None
 
         # Atoms.info <---> Structure.properties
-        # But first make sure `spacegroup` is JSON serializable
-        if atoms.info.get("spacegroup") and isinstance(atoms.info["spacegroup"], Spacegroup):
-            atoms.info["spacegroup"] = atoms.info["spacegroup"].todict()
-        properties = getattr(atoms, "info", {})
+        properties = copy.deepcopy(getattr(atoms, "info", {}))
+        # If present, convert Spacegroup object to JSON-serializable dict
+        if properties.get("spacegroup") and isinstance(properties["spacegroup"], Spacegroup):
+            properties["spacegroup"] = properties["spacegroup"].todict()
+        
 
         # Return a Molecule object if that was specifically requested;
         # otherwise return a Structure object as expected

--- a/src/pymatgen/io/ase.py
+++ b/src/pymatgen/io/ase.py
@@ -5,8 +5,8 @@ Atoms object and pymatgen Structure objects.
 
 from __future__ import annotations
 
-from copy import deepcopy
 import warnings
+from copy import deepcopy
 from importlib.metadata import PackageNotFoundError
 from typing import TYPE_CHECKING
 

--- a/src/pymatgen/io/ase.py
+++ b/src/pymatgen/io/ase.py
@@ -5,10 +5,10 @@ Atoms object and pymatgen Structure objects.
 
 from __future__ import annotations
 
+import copy
 import warnings
 from importlib.metadata import PackageNotFoundError
 from typing import TYPE_CHECKING
-import copy
 
 import numpy as np
 from monty.json import MontyDecoder, MSONable, jsanitize
@@ -303,7 +303,6 @@ class AseAtomsAdaptor:
         # If present, convert Spacegroup object to JSON-serializable dict
         if properties.get("spacegroup") and isinstance(properties["spacegroup"], Spacegroup):
             properties["spacegroup"] = properties["spacegroup"].todict()
-        
 
         # Return a Molecule object if that was specifically requested;
         # otherwise return a Structure object as expected

--- a/src/pymatgen/io/ase.py
+++ b/src/pymatgen/io/ase.py
@@ -5,7 +5,7 @@ Atoms object and pymatgen Structure objects.
 
 from __future__ import annotations
 
-import copy
+from copy import deepcopy
 import warnings
 from importlib.metadata import PackageNotFoundError
 from typing import TYPE_CHECKING
@@ -205,7 +205,7 @@ class AseAtomsAdaptor:
 
         # Atoms.info <---> Structure.properties
         if properties := structure.properties:
-            atoms.info = copy.deepcopy(properties)
+            atoms.info = deepcopy(properties)
 
         # Regenerate Spacegroup object from `.todict()` representation
         if isinstance(atoms.info.get("spacegroup"), dict):
@@ -299,7 +299,7 @@ class AseAtomsAdaptor:
             sel_dyn = None
 
         # Atoms.info <---> Structure.properties
-        properties = copy.deepcopy(getattr(atoms, "info", {}))
+        properties = deepcopy(getattr(atoms, "info", {}))
         # If present, convert Spacegroup object to JSON-serializable dict
         if properties.get("spacegroup") and isinstance(properties["spacegroup"], Spacegroup):
             properties["spacegroup"] = properties["spacegroup"].todict()

--- a/tests/io/test_ase.py
+++ b/tests/io/test_ase.py
@@ -104,6 +104,7 @@ def test_get_atoms_from_structure_dyn():
         ase_mask = c.mask if isinstance(c, ase.constraints.FixCartesian) else [True, True, True]
         assert len(c.index) == len([mask for mask in sel_dyn if np.array_equal(mask, ~np.array(ase_mask))])
 
+
 def test_get_atoms_from_structure_spacegroup():
     # Get structure with space group dictionary in properties
     space_group_info = STRUCTURE.get_space_group_info()
@@ -117,7 +118,6 @@ def test_get_atoms_from_structure_spacegroup():
     # Check that space group matches
     assert atoms.info["spacegroup"].no == STRUCTURE.properties["spacegroup"]["number"]
     assert atoms.info["spacegroup"].setting == STRUCTURE.properties["spacegroup"]["setting"]
-
 
 
 def test_get_atoms_from_molecule():
@@ -231,18 +231,17 @@ def test_get_structure_dyn(select_dyn):
 
     assert len(ase_atoms) == len(structure)
 
+
 def test_get_structure_spacegroup():
     # set up Atoms object with spacegroup information
     a = 4.05
-    atoms = ase.spacegroup.crystal(
-        "Al", [(0, 0, 0)], spacegroup=225, cellpar=[a, a, a, 90, 90, 90]
-    )
+    atoms = ase.spacegroup.crystal("Al", [(0, 0, 0)], spacegroup=225, cellpar=[a, a, a, 90, 90, 90])
     assert "spacegroup" in atoms.info
     assert isinstance(atoms.info["spacegroup"], ase.spacegroup.Spacegroup)
 
     # Test that get_structure does not mutate atoms
     structure = AseAtomsAdaptor.get_structure(atoms)
-    assert isinstance(atoms.info["spacegroup"], ase.spacegroup.Spacegroup) 
+    assert isinstance(atoms.info["spacegroup"], ase.spacegroup.Spacegroup)
     assert isinstance(structure.properties["spacegroup"], dict)
 
     # Test that spacegroup info matches

--- a/tests/io/test_ase.py
+++ b/tests/io/test_ase.py
@@ -104,6 +104,21 @@ def test_get_atoms_from_structure_dyn():
         ase_mask = c.mask if isinstance(c, ase.constraints.FixCartesian) else [True, True, True]
         assert len(c.index) == len([mask for mask in sel_dyn if np.array_equal(mask, ~np.array(ase_mask))])
 
+def test_get_atoms_from_structure_spacegroup():
+    # Get structure with space group dictionary in properties
+    space_group_info = STRUCTURE.get_space_group_info()
+    STRUCTURE.properties["spacegroup"] = {"number": space_group_info[1], "setting": 1}
+
+    # Convert to atoms and check that structure was not modified
+    atoms = AseAtomsAdaptor.get_atoms(STRUCTURE)
+    assert isinstance(STRUCTURE.properties["spacegroup"], dict)
+    assert isinstance(atoms.info["spacegroup"], ase.spacegroup.Spacegroup)
+
+    # Check that space group matches
+    assert atoms.info["spacegroup"].no == STRUCTURE.properties["spacegroup"]["number"]
+    assert atoms.info["spacegroup"].setting == STRUCTURE.properties["spacegroup"]["setting"]
+
+
 
 def test_get_atoms_from_molecule():
     mol = Molecule.from_file(XYZ_STRUCTURE)
@@ -215,6 +230,24 @@ def test_get_structure_dyn(select_dyn):
     ase_atoms = AseAtomsAdaptor.get_atoms(structure)
 
     assert len(ase_atoms) == len(structure)
+
+def test_get_structure_spacegroup():
+    # set up Atoms object with spacegroup information
+    a = 4.05
+    atoms = ase.spacegroup.crystal(
+        "Al", [(0, 0, 0)], spacegroup=225, cellpar=[a, a, a, 90, 90, 90]
+    )
+    assert "spacegroup" in atoms.info
+    assert isinstance(atoms.info["spacegroup"], ase.spacegroup.Spacegroup)
+
+    # Test that get_structure does not mutate atoms
+    structure = AseAtomsAdaptor.get_structure(atoms)
+    assert isinstance(atoms.info["spacegroup"], ase.spacegroup.Spacegroup) 
+    assert isinstance(structure.properties["spacegroup"], dict)
+
+    # Test that spacegroup info matches
+    assert atoms.info["spacegroup"].no == structure.properties["spacegroup"]["number"]
+    assert atoms.info["spacegroup"].setting == structure.properties["spacegroup"]["setting"]
 
 
 def test_get_molecule():


### PR DESCRIPTION
## Summary

This PR resolves #4289. There were bugs in `pymatgen.io.ase.AseAtomsAdaptor` in which `Structure` and `ase.Atoms` objects were modified when converted into one another. Specifically, `Atoms.info` and `Structure.properties` shared memory, leading to side effects. 

Minor changes:

- `AseAtomsAdaptor` now uses `deepcopy` when converting `Atoms.info` to `Structure.properties` and vice versa 3d477472f93b4ee4ad9cc47fe827a59b9e3d912f
- Added tests to check for side effects and check space group dictionary <-> `ase.spacegroup.Spacegroup` interconversion 1730f29eb617f15ce13a8977104d18c3dfb871bb

## Checklist

- [ ] Google format doc strings added. Check with `ruff`. 
- [ ] Type annotations included. Check with `mypy`. 
- [x] Tests added for new features/fixes.
- [x] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172)) **(N/A)**
