### PR TITLE
Update inequality in `get_linear_interpolated_value`

### DIFF
--- a/src/pymatgen/analysis/local_env.py
+++ b/src/pymatgen/analysis/local_env.py
@@ -3745,23 +3745,23 @@ class EconNN(NearNeighbors):
 
         if self.use_fictive_radius:
             # calculate fictive ionic radii
-            firs = [_get_fictive_ionic_radius(site, neighbor) for neighbor in neighbors]
+            fict_ionic_radii = [_get_fictive_ionic_radius(site, neighbor) for neighbor in neighbors]
         else:
             # just use the bond distance
-            firs = [neighbor.nn_distance for neighbor in neighbors]
+            fict_ionic_radii = [neighbor.nn_distance for neighbor in neighbors]
 
         # calculate mean fictive ionic radius
-        mefir = _get_mean_fictive_ionic_radius(firs)
+        mefir = _get_mean_fictive_ionic_radius(fict_ionic_radii)
 
         # iteratively solve MEFIR; follows equation 4 in Hoppe's EconN paper
         prev_mefir = float("inf")
         while abs(prev_mefir - mefir) > 1e-4:
             # this is guaranteed to converge
             prev_mefir = mefir
-            mefir = _get_mean_fictive_ionic_radius(firs, minimum_fir=mefir)
+            mefir = _get_mean_fictive_ionic_radius(fict_ionic_radii, minimum_fir=mefir)
 
         siw = []
-        for nn, fir in zip(neighbors, firs, strict=True):
+        for nn, fir in zip(neighbors, fict_ionic_radii, strict=True):
             if nn.nn_distance < self.cutoff:
                 w = math.exp(1 - (fir / mefir) ** 6)
                 if w > self.tol:

--- a/src/pymatgen/electronic_structure/dos.py
+++ b/src/pymatgen/electronic_structure/dos.py
@@ -107,6 +107,9 @@ class DOS(Spectrum):
         energies = self.x
         below_fermi = [i for i in range(len(energies)) if energies[i] < self.efermi and tdos[i] > tol]
         above_fermi = [i for i in range(len(energies)) if energies[i] > self.efermi and tdos[i] > tol]
+        if not below_fermi or not above_fermi:
+            return 0.0, self.efermi, self.efermi
+
         vbm_start = max(below_fermi)
         cbm_start = min(above_fermi)
         if vbm_start == cbm_start:

--- a/src/pymatgen/electronic_structure/dos.py
+++ b/src/pymatgen/electronic_structure/dos.py
@@ -112,7 +112,7 @@ class DOS(Spectrum):
 
         vbm_start = max(below_fermi)
         cbm_start = min(above_fermi)
-        if vbm_start == cbm_start:
+        if vbm_start in [cbm_start, cbm_start - 1]:
             return 0.0, self.efermi, self.efermi
 
         # Interpolate between adjacent values
@@ -314,7 +314,7 @@ class Dos(MSONable):
 
         vbm_start = max(below_fermi)
         cbm_start = min(above_fermi)
-        if vbm_start == cbm_start:
+        if vbm_start in [cbm_start, cbm_start - 1]:
             return 0.0, self.efermi, self.efermi
 
         # Interpolate between adjacent values

--- a/src/pymatgen/util/coord.py
+++ b/src/pymatgen/util/coord.py
@@ -135,7 +135,7 @@ def get_linear_interpolated_value(x_values: ArrayLike, y_values: ArrayLike, x: f
     """
     arr = np.array(sorted(zip(x_values, y_values, strict=True), key=lambda d: d[0]))
 
-    indices = np.where(arr[:, 0] >= x)[0]
+    indices = np.where(arr[:, 0] > x)[0]
 
     if len(indices) == 0 or indices[0] == 0:
         raise ValueError(f"{x=} is out of range of provided x_values ({min(x_values)}, {max(x_values)})")

--- a/tests/util/test_coord.py
+++ b/tests/util/test_coord.py
@@ -19,6 +19,11 @@ class TestCoordUtils:
         with pytest.raises(ValueError, match=r"x=6 is out of range of provided x_values \(0, 5\)"):
             coord.get_linear_interpolated_value(x_vals, y_vals, 6)
 
+        # test when x is equal to first value in x_vals (previously broke, fixed in #4299):
+        assert coord.get_linear_interpolated_value(x_vals, y_vals, 0) == approx(3)
+        with pytest.raises(ValueError, match=r"x=-0.5 is out of range of provided x_values \(0, 5\)"):
+            coord.get_linear_interpolated_value(x_vals, y_vals, -0.5)
+
     def test_in_coord_list(self):
         coords = [[0, 0, 0], [0.5, 0.5, 0.5]]
         test_coord = [0.1, 0.1, 0.1]


### PR DESCRIPTION
This is a small but important fix for the `get_linear_interpolated_value` function in `pymatgen.util.coord`, used in various places within the codebase. 

This function works by finding the first index in `x_values` that is greater than / equal to `x`, and then uses this index and the previous (`idx-1`) with `x_values` and `y_values` to interpolate:
https://github.com/materialsproject/pymatgen/blob/v2025.2.18/src/pymatgen/util/coord.py#L136-L147

The issue is that if the _first_ index in `x_values` is equal to `x`, this causes the ValueError to be thrown (as `indices[0]==0`); where it thinks that the input `x` to interpolate is outside the interpolable range. Changing the inequality to `>` rather than `>=` resolves this issue.

MWE:
```
from pymatgen.util.coord import get_linear_interpolated_value

get_linear_interpolated_value([0.0001, 0.0002], [1,2], 0.0001)
```
Current `pymatgen` `master`:
<img width="750" alt="image" src="https://github.com/user-attachments/assets/bf687cd5-58e0-4af9-8d78-dce680c8b5d0" />
Where we can see "`x=0.0001 is out of range of provided x_values (0.0001, 0.0002)`" does not make sense.

This branch:
<img width="514" alt="image" src="https://github.com/user-attachments/assets/13615bc3-4665-49ed-b58c-586b030a334b" />

And confirming the error is still correctly thrown with an `x` value that is actually outside the range:
<img width="747" alt="image" src="https://github.com/user-attachments/assets/7ed73f11-9d3c-4459-8481-ab160345fb27" />
