### PR TITLE
`IStructure.to` default to JSON when `filename` not specified

### DIFF
--- a/src/pymatgen/core/structure.py
+++ b/src/pymatgen/core/structure.py
@@ -2918,7 +2918,7 @@ class IStructure(SiteCollection, MSONable):
         return cls.from_sites(sites, charge=charge, properties=dct.get("properties"))
 
     def to(self, filename: PathLike = "", fmt: FileFormats = "", **kwargs) -> str:
-        """Output the structure to a file or string.
+        """Output the structure to a string (and to a file when filename is given).
 
         Args:
             filename (PathLike): If provided, output will be written to a file. If

--- a/src/pymatgen/core/structure.py
+++ b/src/pymatgen/core/structure.py
@@ -2940,6 +2940,10 @@ class IStructure(SiteCollection, MSONable):
         """
         filename, fmt = str(filename), cast(FileFormats, fmt.lower())
 
+        # Default to JSON if filename not specified
+        if filename == "" and fmt == "":
+            fmt = "json"
+
         if fmt == "cif" or fnmatch(filename.lower(), "*.cif*"):
             from pymatgen.io.cif import CifWriter
 

--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -930,6 +930,9 @@ Direct
         with pytest.raises(ValueError, match="Invalid fmt='badformat'"):
             self.struct.to(fmt="badformat")
 
+        # Default as JSON (no exception expected)
+        self.struct.to()
+
         self.struct.to(filename=(gz_json_path := "POSCAR.testing.gz"))
         struct = Structure.from_file(gz_json_path)
         assert struct == self.struct

--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -931,7 +931,7 @@ Direct
             self.struct.to(fmt="badformat")
 
         # Default as JSON (no exception expected)
-        self.struct.to()
+        assert self.struct.to() == self.struct.to(fmt="json")
 
         self.struct.to(filename=(gz_json_path := "POSCAR.testing.gz"))
         struct = Structure.from_file(gz_json_path)


### PR DESCRIPTION
## Summay

- `IStructure.to` default to JSON when `filename` not specified, to close #4305 