### PR TITLE
Remove legacy MPRester method tests from `TestMPResterNewBasic`

### DIFF
--- a/src/pymatgen/ext/matproj.py
+++ b/src/pymatgen/ext/matproj.py
@@ -265,7 +265,7 @@ class _MPResterBasic:
         conventional_unit_cell=False,
         sort_by_e_above_hull=False,
     ):
-        """Get  a list of ComputedEntries or ComputedStructureEntries corresponding
+        """Get a list of ComputedEntries or ComputedStructureEntries corresponding
         to a chemical system, formula, or materials_id or full criteria.
 
         Args:

--- a/tests/ext/test_matproj.py
+++ b/tests/ext/test_matproj.py
@@ -313,18 +313,6 @@ class TestMPResterOld(PymatgenTest):
         entry = self.rester.get_exp_entry("Fe2O3")
         assert entry.energy == approx(-825.5)
 
-    @pytest.mark.skip("TODO: Need someone to fix this")
-    def test_submit_query_delete_snl(self):
-        struct = Structure(np.eye(3) * 5, ["Fe"], [[0, 0, 0]])
-        submission_ids = self.rester.submit_snl([struct, struct])
-        assert len(submission_ids) == 2
-        data = self.rester.query_snl({"about.remarks": "unittest"})
-        assert len(data) == 2
-        snl_ids = [d["_id"] for d in data]
-        self.rester.delete_snl(snl_ids)
-        data = self.rester.query_snl({"about.remarks": "unittest"})
-        assert len(data) == 0
-
     def test_get_stability(self):
         entries = self.rester.get_entries_in_chemsys(["Fe", "O"])
         modified_entries = [
@@ -546,23 +534,11 @@ class TestMPResterNewBasic(PymatgenTest):
         assert doc[0]["energy_above_hull"] >= 0
         assert doc[1]["energy_above_hull"] >= 0
 
-        # dos = self.rester.get_dos_by_material_id(mid)
-        #
-        # assert isinstance(dos, CompleteDos)
-
     def test_get_all_materials_ids_doc(self):
         mids = self.rester.get_material_ids("Al2O3")
         np.random.default_rng().shuffle(mids)
         doc = self.rester.get_doc(mids.pop(0))
         assert doc["formula_pretty"] == "Al2O3"
-
-    @pytest.mark.skip("TODO: need someone to fix this")
-    def test_get_xas_data(self):
-        # Test getting XAS data
-        data = self.rester.get_xas_data("mp-19017", "Li")
-        assert data["mid_and_el"] == "mp-19017,Li"
-        assert data["spectrum"]["x"][0] == approx(55.178)
-        assert data["spectrum"]["y"][0] == approx(0.0164634)
 
     @pytest.mark.skip("TODO: need someone to fix this")
     def test_get_data(self):
@@ -625,16 +601,6 @@ class TestMPResterNewBasic(PymatgenTest):
         with pytest.raises(MPRestError, match="REST query returned with error status code 404"):
             self.rester.get_data("Fe2O3", "badmethod")
 
-    @pytest.mark.skip("TODO: need someone to fix this")
-    def test_get_materials_id_from_task_id(self):
-        assert self.rester.get_materials_id_from_task_id("mp-540081") == "mp-19017"
-
-    @pytest.mark.skip("TODO: need someone to fix this")
-    def test_get_materials_id_references(self):
-        mpr = _MPResterLegacy()
-        data = mpr.get_materials_id_references("mp-123")
-        assert len(data) > 1000
-
     def test_get_entries_and_in_chemsys(self):
         # One large system test.
         syms = ["Li", "Fe", "O", "P", "Mn"]
@@ -681,34 +647,11 @@ class TestMPResterNewBasic(PymatgenTest):
         assert len(data) >= 52
         assert "Li2O" in (d["pretty_formula"] for d in data)
 
-    @pytest.mark.skip("TODO: need someone to fix this")
-    def test_get_exp_thermo_data(self):
-        data = self.rester.get_exp_thermo_data("Fe2O3")
-        assert len(data) > 0
-        for d in data:
-            assert d.formula == "Fe2O3"
-
-    @pytest.mark.skip("TODO: need someone to fix this")
-    def test_get_dos_by_id(self):
-        dos = self.rester.get_dos_by_material_id("mp-2254")
-        assert isinstance(dos, CompleteDos)
-
-    @pytest.mark.skip("TODO: need someone to fix this")
-    def test_get_bandstructure_by_material_id(self):
-        bs = self.rester.get_bandstructure_by_material_id("mp-2254")
-        assert isinstance(bs, BandStructureSymmLine)
-        bs_unif = self.rester.get_bandstructure_by_material_id("mp-2254", line_mode=False)
-        assert isinstance(bs_unif, BandStructure)
-        assert not isinstance(bs_unif, BandStructureSymmLine)
-
     def test_get_phonon_data_by_material_id(self):
         bs = self.rester.get_phonon_bandstructure_by_material_id("mp-661")
         assert isinstance(bs, PhononBandStructureSymmLine)
         dos = self.rester.get_phonon_dos_by_material_id("mp-661")
         assert isinstance(dos, CompletePhononDos)
-
-    #     ddb_str = self.rester.get_phonon_ddb_by_material_id("mp-661")
-    #     assert isinstance(ddb_str, str)
 
     def test_get_structures(self):
         structs = self.rester.get_structures("Mn3O4")
@@ -771,11 +714,6 @@ class TestMPResterNewBasic(PymatgenTest):
         assert Fe_entries[0].data["e_above_hull"] == 0
 
     @pytest.mark.skip("TODO: need someone to fix this")
-    def test_get_exp_entry(self):
-        entry = self.rester.get_exp_entry("Fe2O3")
-        assert entry.energy == approx(-825.5)
-
-    @pytest.mark.skip("TODO: need someone to fix this")
     def test_get_stability(self):
         entries = self.rester.get_entries_in_chemsys(["Fe", "O"])
         modified_entries = [
@@ -800,106 +738,6 @@ class TestMPResterNewBasic(PymatgenTest):
                         data = dct
                         break
                 assert pd.get_e_above_hull(entry) == approx(data["e_above_hull"])
-
-    @pytest.mark.skip("TODO: need someone to fix this")
-    def test_get_reaction(self):
-        rxn = self.rester.get_reaction(["Li", "O"], ["Li2O"])
-        assert "Li2O" in rxn["Experimental_references"]
-
-    @pytest.mark.skip("TODO: need someone to fix this")
-    def test_get_substrates(self):
-        substrate_data = self.rester.get_substrates("mp-123", 5, [1, 0, 0])
-        substrates = [sub_dict["sub_id"] for sub_dict in substrate_data]
-        assert "mp-2534" in substrates
-
-    @pytest.mark.skip("TODO: need someone to fix this")
-    def test_get_surface_data(self):
-        data = self.rester.get_surface_data("mp-126")  # Pt
-        one_surf = self.rester.get_surface_data("mp-129", miller_index=[-2, -3, 1])
-        assert one_surf["surface_energy"] == approx(2.99156963)
-        assert_allclose(one_surf["miller_index"], [3, 2, 1])
-        assert "surfaces" in data
-        surfaces = data["surfaces"]
-        assert len(surfaces) > 0
-        surface = surfaces.pop()
-        assert "miller_index" in surface
-        assert "surface_energy" in surface
-        assert "is_reconstructed" in surface
-        data_inc = self.rester.get_surface_data("mp-126", inc_structures=True)
-        assert "structure" in data_inc["surfaces"][0]
-
-    @pytest.mark.skip("TODO: need someone to fix this")
-    def test_get_wulff_shape(self):
-        ws = self.rester.get_wulff_shape("mp-126")
-        assert isinstance(ws, WulffShape)
-
-    @pytest.mark.skip("TODO: need someone to fix this")
-    def test_get_cohesive_energy(self):
-        ecoh = self.rester.get_cohesive_energy("mp-13")
-        assert ecoh, 5.04543279
-
-    @pytest.mark.skip("TODO: need someone to fix this")
-    def test_get_gb_data(self):
-        mo_gbs = self.rester.get_gb_data(chemsys="Mo")
-        assert len(mo_gbs) == 10
-        mo_gbs_s5 = self.rester.get_gb_data(pretty_formula="Mo", sigma=5)
-        assert len(mo_gbs_s5) == 3
-        mo_s3_112 = self.rester.get_gb_data(
-            material_id="mp-129",
-            sigma=3,
-            gb_plane=[1, -1, -2],
-            include_work_of_separation=True,
-        )
-        assert len(mo_s3_112) == 1
-        gb_f = mo_s3_112[0]["final_structure"]
-        assert_allclose(gb_f.rotation_axis, [1, 1, 0])
-        assert gb_f.rotation_angle == approx(109.47122)
-        assert mo_s3_112[0]["gb_energy"] == approx(0.47965, rel=1e-4)
-        assert mo_s3_112[0]["work_of_separation"] == approx(6.318144)
-        assert "Mo24" in gb_f.formula
-        hcp_s7 = self.rester.get_gb_data(material_id="mp-87", gb_plane=[0, 0, 0, 1], include_work_of_separation=True)
-        assert hcp_s7[0]["gb_energy"] == approx(1.1206, rel=1e-4)
-        assert hcp_s7[0]["work_of_separation"] == approx(2.4706, rel=1e-4)
-
-    @pytest.mark.skip("TODO: need someone to fix this")
-    def test_get_interface_reactions(self):
-        kinks = self.rester.get_interface_reactions("LiCoO2", "Li3PS4")
-        assert len(kinks) > 0
-        kink = kinks[0]
-        assert "energy" in kink
-        assert "ratio_atomic" in kink
-        assert "rxn" in kink
-        assert isinstance(kink["rxn"], Reaction)
-        kinks_open_O = self.rester.get_interface_reactions("LiCoO2", "Li3PS4", open_el="O", relative_mu=-1)
-        assert len(kinks_open_O) > 0
-        with pytest.warns(
-            UserWarning,
-            match="The reactant MnO9 has no matching entry with negative formation energy, "
-            "instead convex hull energy for this composition will be used for reaction energy calculation.",
-        ):
-            self.rester.get_interface_reactions("LiCoO2", "MnO9")
-
-    @pytest.mark.skip("TODO: need someone to fix this")
-    def test_pourbaix_heavy(self):
-        entries = self.rester.get_pourbaix_entries(["Na", "Ca", "Nd", "Y", "Ho", "F"])
-        _ = PourbaixDiagram(entries, nproc=4, filter_solids=False)
-
-    @pytest.mark.skip("TODO: need someone to fix this")
-    def test_pourbaix_mpr_pipeline(self):
-        data = self.rester.get_pourbaix_entries(["Zn"])
-        pbx = PourbaixDiagram(data, filter_solids=True, conc_dict={"Zn": 1e-8})
-        pbx.find_stable_entry(10, 0)
-
-        data = self.rester.get_pourbaix_entries(["Ag", "Te"])
-        pbx = PourbaixDiagram(data, filter_solids=True, conc_dict={"Ag": 1e-8, "Te": 1e-8})
-        assert len(pbx.stable_entries) == 30
-        test_entry = pbx.find_stable_entry(8, 2)
-        assert sorted(test_entry.entry_id) == ["ion-10", "mp-996958"]
-
-        # Test against ion sets with multiple equivalent ions (Bi-V regression)
-        entries = self.rester.get_pourbaix_entries(["Bi", "V"])
-        pbx = PourbaixDiagram(entries, filter_solids=True, conc_dict={"Bi": 1e-8, "V": 1e-8})
-        assert all("Bi" in entry.composition and "V" in entry.composition for entry in pbx.all_entries)
 
     def test_parity_with_mp_api(self):
         try:

--- a/tests/ext/test_matproj.py
+++ b/tests/ext/test_matproj.py
@@ -540,67 +540,6 @@ class TestMPResterNewBasic(PymatgenTest):
         doc = self.rester.get_doc(mids.pop(0))
         assert doc["formula_pretty"] == "Al2O3"
 
-    @pytest.mark.skip("TODO: need someone to fix this")
-    def test_get_data(self):
-        props = {
-            "energy",
-            "energy_per_atom",
-            "formation_energy_per_atom",
-            "nsites",
-            "unit_cell_formula",
-            "pretty_formula",
-            "is_hubbard",
-            "elements",
-            "nelements",
-            "e_above_hull",
-            "hubbards",
-            "is_compatible",
-            "task_ids",
-            "density",
-            "icsd_ids",
-            "total_magnetization",
-        }
-        mp_id = "mp-1143"
-        vals = requests.get(f"https://legacy.materialsproject.org/materials/{mp_id}/json/", timeout=60)
-        expected_vals = vals.json()
-
-        for prop in props:
-            if prop not in [
-                "hubbards",
-                "unit_cell_formula",
-                "elements",
-                "icsd_ids",
-                "task_ids",
-            ]:
-                val = self.rester.get_data(mp_id, prop=prop)[0][prop]
-                if prop in ["energy", "energy_per_atom"]:
-                    prop = "final_" + prop
-                assert expected_vals[prop] == approx(val), f"Failed with property {prop}"
-            elif prop in ["elements", "icsd_ids", "task_ids"]:
-                upstream_vals = set(self.rester.get_data(mp_id, prop=prop)[0][prop])
-                assert set(expected_vals[prop]) <= upstream_vals
-            else:
-                assert expected_vals[prop] == self.rester.get_data(mp_id, prop=prop)[0][prop]
-
-        props = ["structure", "initial_structure", "final_structure", "entry"]
-        for prop in props:
-            obj = self.rester.get_data(mp_id, prop=prop)[0][prop]
-            if prop.endswith("structure"):
-                assert isinstance(obj, Structure)
-            elif prop == "entry":
-                obj = self.rester.get_data(mp_id, prop=prop)[0][prop]
-                assert isinstance(obj, ComputedEntry)
-
-        # Test chemsys search
-        data = self.rester.get_data("Fe-Li-O", prop="unit_cell_formula")
-        assert len(data) > 1
-        elements = {Element("Li"), Element("Fe"), Element("O")}
-        for d in data:
-            assert set(Composition(d["unit_cell_formula"]).elements).issubset(elements)
-
-        with pytest.raises(MPRestError, match="REST query returned with error status code 404"):
-            self.rester.get_data("Fe2O3", "badmethod")
-
     def test_get_entries_and_in_chemsys(self):
         # One large system test.
         syms = ["Li", "Fe", "O", "P", "Mn"]

--- a/tests/ext/test_matproj.py
+++ b/tests/ext/test_matproj.py
@@ -624,32 +624,6 @@ class TestMPResterNewBasic(PymatgenTest):
         assert Ni.lattice.beta == approx(90)
         assert Ni.lattice.gamma == approx(90)
 
-    @pytest.mark.skip("TODO: need someone to fix this")
-    def test_get_stability(self):
-        entries = self.rester.get_entries_in_chemsys(["Fe", "O"])
-        modified_entries = [
-            ComputedEntry(
-                entry.composition,
-                entry.uncorrected_energy + 0.01,
-                parameters=entry.parameters,
-                entry_id=f"mod_{entry.entry_id}",
-            )
-            for entry in entries
-            if entry.reduced_formula == "Fe2O3"
-        ]
-        rester_ehulls = self.rester.get_stability(modified_entries)
-        all_entries = entries + modified_entries
-        compat = MaterialsProject2020Compatibility()
-        all_entries = compat.process_entries(all_entries)
-        pd = PhaseDiagram(all_entries)
-        for entry in all_entries:
-            if str(entry.entry_id).startswith("mod"):
-                for dct in rester_ehulls:
-                    if dct["entry_id"] == entry.entry_id:
-                        data = dct
-                        break
-                assert pd.get_e_above_hull(entry) == approx(data["e_above_hull"])
-
     def test_parity_with_mp_api(self):
         try:
             from mp_api.client import MPRester as MpApi

--- a/tests/ext/test_matproj.py
+++ b/tests/ext/test_matproj.py
@@ -637,16 +637,6 @@ class TestMPResterNewBasic(PymatgenTest):
         with pytest.raises(IndexError, match="list index out of range"):
             self.rester.get_entry_by_material_id("mp-2022")  # "mp-2022" does not exist
 
-    @pytest.mark.skip("TODO: need someone to fix this")
-    def test_query(self):
-        criteria = {"elements": {"$in": ["Li", "Na", "K"], "$all": ["O"]}}
-        props = ["pretty_formula", "energy"]
-        data = self.rester.query(criteria=criteria, properties=props, chunk_size=0)
-        assert len(data) > 6
-        data = self.rester.query(criteria="*2O", properties=props, chunk_size=0)
-        assert len(data) >= 52
-        assert "Li2O" in (d["pretty_formula"] for d in data)
-
     def test_get_phonon_data_by_material_id(self):
         bs = self.rester.get_phonon_bandstructure_by_material_id("mp-661")
         assert isinstance(bs, PhononBandStructureSymmLine)

--- a/tests/ext/test_matproj.py
+++ b/tests/ext/test_matproj.py
@@ -586,7 +586,6 @@ class TestMPResterNewBasic(PymatgenTest):
         structs = self.rester.get_structures("Mn3O4")
         assert len(structs) > 0
 
-    @pytest.mark.skip("TODO: need someone to fix this")
     def test_get_entries(self):
         entries = self.rester.get_entries("TiO2")
         assert len(entries) > 1
@@ -601,8 +600,6 @@ class TestMPResterNewBasic(PymatgenTest):
         all_entries = self.rester.get_entries("Fe", compatible_only=False)
         entries = self.rester.get_entries("Fe", compatible_only=True)
         assert len(entries) < len(all_entries)
-        entries = self.rester.get_entries("Fe", compatible_only=True, property_data=["cif"])
-        assert "cif" in entries[0].data
 
         for entry in self.rester.get_entries("CdO2", inc_structure=False):
             assert entry.data["oxide_type"] is not None
@@ -612,9 +609,9 @@ class TestMPResterNewBasic(PymatgenTest):
         Ni = entry.structure
         assert Ni.lattice.a == Ni.lattice.b
         assert Ni.lattice.a == Ni.lattice.c
-        assert Ni.lattice.alpha == 90
-        assert Ni.lattice.beta == 90
-        assert Ni.lattice.gamma == 90
+        assert Ni.lattice.alpha == approx(60)
+        assert Ni.lattice.beta == approx(60)
+        assert Ni.lattice.gamma == approx(60)
 
         # Ensure energy per atom is same
         primNi = self.rester.get_entry_by_material_id("mp-23", inc_structure=True, conventional_unit_cell=False)
@@ -623,24 +620,9 @@ class TestMPResterNewBasic(PymatgenTest):
         Ni = self.rester.get_structure_by_material_id("mp-23", conventional_unit_cell=True)
         assert Ni.lattice.a == Ni.lattice.b
         assert Ni.lattice.a == Ni.lattice.c
-        assert Ni.lattice.alpha == 90
-        assert Ni.lattice.beta == 90
-        assert Ni.lattice.gamma == 90
-
-        # Test case where convs are different from initial and final
-        th = self.rester.get_structure_by_material_id("mp-37", conventional_unit_cell=True)
-        th_entry = self.rester.get_entry_by_material_id("mp-37", inc_structure=True, conventional_unit_cell=True)
-        th_entry_initial = self.rester.get_entry_by_material_id(
-            "mp-37", inc_structure="initial", conventional_unit_cell=True
-        )
-        assert th == th_entry.structure
-        assert len(th_entry.structure) == 4
-        assert len(th_entry_initial.structure) == 2
-
-        # Test if the polymorphs of Fe are properly sorted
-        # by e_above_hull when sort_by_e_above_hull=True
-        Fe_entries = self.rester.get_entries("Fe", sort_by_e_above_hull=True)
-        assert Fe_entries[0].data["e_above_hull"] == 0
+        assert Ni.lattice.alpha == approx(90)
+        assert Ni.lattice.beta == approx(90)
+        assert Ni.lattice.gamma == approx(90)
 
     @pytest.mark.skip("TODO: need someone to fix this")
     def test_get_stability(self):

--- a/tests/ext/test_matproj.py
+++ b/tests/ext/test_matproj.py
@@ -742,8 +742,9 @@ class TestMPResterNewBasic(PymatgenTest):
     def test_parity_with_mp_api(self):
         try:
             from mp_api.client import MPRester as MpApi
-        except Exception:
+        except ModuleNotFoundError:
             pytest.skip("mp_api.client.MPRester cannot be imported for this test.")
+
         mpr_mp_api = MpApi(PMG_MAPI_KEY)
         # Test summary
         mp_data = mpr_mp_api.materials.search(formula="Al2O3")


### PR DESCRIPTION
### Summary

Remove legacy MPRester tests from `TestMPResterNewBasic`, I believe some test methods (commented out previously, and recovered in #4027) are testing methods from the legacy MPRester (while being inside `TestMPResterNewBasic`), maybe we should remove them altogether?

ping @ml-evs for review?
