### PR TITLE
Remove incorrect "Electrical resistivity" for Se as "high"

### DIFF
--- a/dev_scripts/periodic_table.yaml
+++ b/dev_scripts/periodic_table.yaml
@@ -4263,7 +4263,6 @@ Se:
   Common oxidation states: [-2, 2, 4, 6]
   Critical temperature: 1766 K
   Density of solid: 4819 kg m<sup>-3</sup>
-  Electrical resistivity: high 10<sup>-8</sup> &Omega; m
   Electronic structure: '[Ar].3d<sup>10</sup>.4s<sup>2</sup>.4p<sup>4</sup>'
   ICSD oxidation states: [-1, 4, -2, 6]
   Ionic radii: {'-2': 1.84, '4': 0.64, '6': 0.56}

--- a/src/pymatgen/core/periodic_table.json
+++ b/src/pymatgen/core/periodic_table.json
@@ -12618,7 +12618,6 @@
         ],
         "Critical temperature": "1766 K",
         "Density of solid": "4819 kg m<sup>-3</sup>",
-        "Electrical resistivity": "high 10<sup>-8</sup> &Omega; m",
         "Electronic structure": {
             "0": "[Ar].3d<sup>10</sup>.4s<sup>2</sup>.4p<sup>4</sup>",
             "-2": "[Ar].3d<sup>10</sup>.4s<sup>2</sup>.4p<sup>6</sup>",

--- a/src/pymatgen/core/periodic_table.py
+++ b/src/pymatgen/core/periodic_table.py
@@ -229,7 +229,7 @@ class ElementBase(Enum):
                             if "10<sup>" in tokens[1]:
                                 base_power = re.findall(r"([+-]?\d+)", tokens[1])
                                 factor = "e" + base_power[1]
-                                if tokens[0] in ["&gt;", "high"]:
+                                if tokens[0] == "&gt;":
                                     tokens[0] = "1"  # return the border value
                                 tokens[0] += factor
                                 if item == "electrical_resistivity":


### PR DESCRIPTION
### Summary
- Remove incorrect "Electrical resistivity" for Se as "high", to fix #4312

Current the data for Electrical resistivity of Se is "high" (with `10<sup>-8</sup> &Omega; m` as the unit), and our parser would interpret it to:

```python
from pymatgen.core import Element

print(Element.Se.electrical_resistivity)  # 1e-08 m ohm
```


This is the only data as "high" in `periodic_table.json` AFAIK.

After this, it would be None with a warning:
```
/Users/yang/developer/pymatgen/debug/test_elements.py:3: UserWarning: No data available for electrical_resistivity for Se
  print(Element.Se.electrical_resistivity)
None

```
