### PR TITLE
Drop duplicate `iupac_ordering` entries in `core.periodic_table.json`

### DIFF
--- a/src/pymatgen/core/periodic_table.json
+++ b/src/pymatgen/core/periodic_table.json
@@ -71,7 +71,6 @@
         "X": 1.1,
         "Youngs modulus": "no data GPa",
         "Metallic radius": 1.878,
-        "iupac_ordering": 32,
         "IUPAC ordering": 32,
         "Ground level": "2D3/2",
         "Ionization energies": [
@@ -305,7 +304,6 @@
         "X": 1.93,
         "Youngs modulus": "83 GPa",
         "Metallic radius": 1.445,
-        "iupac_ordering": 72,
         "IUPAC ordering": 72,
         "Ground level": "2S1/2",
         "Ionization energies": [
@@ -438,7 +436,6 @@
             "Al-27": 146.6
         },
         "Metallic radius": 1.43,
-        "iupac_ordering": 80,
         "IUPAC ordering": 80,
         "Ground level": "2P°1/2",
         "Ionization energies": [
@@ -558,7 +555,6 @@
         "X": 1.3,
         "Youngs modulus": "no data GPa",
         "Metallic radius": 1.73,
-        "iupac_ordering": 26,
         "IUPAC ordering": 26,
         "Ground level": "8S°7/2",
         "Ionization energies": [
@@ -701,7 +697,6 @@
         "Vickers hardness": "no data MN m<sup>-2</sup>",
         "Youngs modulus": "no data GPa",
         "Metallic radius": "no data",
-        "iupac_ordering": 3,
         "IUPAC ordering": 3,
         "Ground level": "1S0",
         "Ionization energies": [
@@ -819,7 +814,6 @@
         "X": 2.18,
         "Youngs modulus": "8 GPa",
         "Metallic radius": "no data",
-        "iupac_ordering": 89,
         "IUPAC ordering": 89,
         "Ground level": "4S°3/2",
         "Ionization energies": [
@@ -934,7 +928,6 @@
         "X": 2.2,
         "Youngs modulus": "no data GPa",
         "Metallic radius": "no data",
-        "iupac_ordering": 98,
         "IUPAC ordering": 98,
         "Ground level": "2P°3/2",
         "Ionization energies": [
@@ -1123,7 +1116,6 @@
         "X": 2.54,
         "Youngs modulus": "78 GPa",
         "Metallic radius": 1.442,
-        "iupac_ordering": 71,
         "IUPAC ordering": 71,
         "Ground level": "2S1/2",
         "Ionization energies": [
@@ -1289,7 +1281,6 @@
             "B-11": 40.59
         },
         "Metallic radius": "no data",
-        "iupac_ordering": 81,
         "IUPAC ordering": 81,
         "Ground level": "2P°1/2",
         "Ionization energies": [
@@ -1407,7 +1398,6 @@
         "X": 0.89,
         "Youngs modulus": "13 GPa",
         "Metallic radius": 2.236,
-        "iupac_ordering": 13,
         "IUPAC ordering": 13,
         "Ground level": "1S0",
         "Ionization energies": [
@@ -1545,7 +1535,6 @@
             "Be-9": 52.88
         },
         "Metallic radius": 1.12,
-        "iupac_ordering": 17,
         "IUPAC ordering": 17,
         "Ground level": "1S0",
         "Ionization energies": [
@@ -1655,7 +1644,6 @@
         "X": 2.02,
         "Youngs modulus": "32 GPa",
         "Metallic radius": 1.82,
-        "iupac_ordering": 87,
         "IUPAC ordering": 87,
         "Ground level": "4S°3/2",
         "Ionization energies": [
@@ -1815,7 +1803,6 @@
         "X": 1.3,
         "Youngs modulus": "no data GPa",
         "Metallic radius": 1.703,
-        "iupac_ordering": 24,
         "IUPAC ordering": 24,
         "Ground level": "6H°15/2",
         "Ionization energies": [
@@ -2032,7 +2019,6 @@
         "X": 2.96,
         "Youngs modulus": "no data GPa",
         "Metallic radius": 1.14,
-        "iupac_ordering": 100,
         "IUPAC ordering": 100,
         "Ground level": "2P°3/2",
         "Ionization energies": [
@@ -2164,7 +2150,6 @@
             "C-11": 33.27
         },
         "Metallic radius": "no data",
-        "iupac_ordering": 86,
         "IUPAC ordering": 86,
         "Ground level": "3P0",
         "Ionization energies": [
@@ -2275,7 +2260,6 @@
             "Ca-43": -40.8
         },
         "Metallic radius": 1.976,
-        "iupac_ordering": 15,
         "IUPAC ordering": 15,
         "Ground level": "1S0",
         "Ionization energies": [
@@ -2401,7 +2385,6 @@
         "X": 1.69,
         "Youngs modulus": "50 GPa",
         "Metallic radius": 1.51,
-        "iupac_ordering": 75,
         "IUPAC ordering": 75,
         "Ground level": "1S0",
         "Ionization energies": [
@@ -2590,7 +2573,6 @@
         "X": 1.12,
         "Youngs modulus": "34 GPa",
         "Metallic radius": 1.707,
-        "iupac_ordering": 46,
         "IUPAC ordering": 46,
         "Ground level": "1G°4",
         "Ionization energies": [
@@ -2726,7 +2708,6 @@
         "X": 1.3,
         "Youngs modulus": "no data GPa",
         "Metallic radius": 1.86,
-        "iupac_ordering": 23,
         "IUPAC ordering": 23,
         "Ground level": "5I8",
         "Ionization energies": [
@@ -2937,7 +2918,6 @@
             "Cl-37": -64.35
         },
         "Metallic radius": "no data",
-        "iupac_ordering": 101,
         "IUPAC ordering": 101,
         "Ground level": "2P°3/2",
         "Ionization energies": [
@@ -3031,7 +3011,6 @@
         "X": 1.3,
         "Youngs modulus": "no data GPa",
         "Metallic radius": 1.743,
-        "iupac_ordering": 25,
         "IUPAC ordering": 25,
         "Ground level": "9D°2",
         "Ionization energies": [
@@ -3271,7 +3250,6 @@
             "Co-59": 420.3
         },
         "Metallic radius": 1.25,
-        "iupac_ordering": 67,
         "IUPAC ordering": 67,
         "Ground level": "4F9/2",
         "Ionization energies": [
@@ -3457,7 +3435,6 @@
             "Cr-53": -150.5
         },
         "Metallic radius": 1.285,
-        "iupac_ordering": 58,
         "IUPAC ordering": 58,
         "Ground level": "7S3",
         "Ionization energies": [
@@ -3588,7 +3565,6 @@
         "X": 0.79,
         "Youngs modulus": "1.7 GPa",
         "Metallic radius": 2.719,
-        "iupac_ordering": 7,
         "IUPAC ordering": 7,
         "Ground level": "2S1/2",
         "Ionization energies": [
@@ -3774,7 +3750,6 @@
             "Cu-65": -204.14
         },
         "Metallic radius": 1.278,
-        "iupac_ordering": 73,
         "IUPAC ordering": 73,
         "Ground level": "2S1/2",
         "Ionization energies": [
@@ -3921,7 +3896,6 @@
         "X": 1.22,
         "Youngs modulus": "61 GPa",
         "Metallic radius": 1.773,
-        "iupac_ordering": 38,
         "IUPAC ordering": 38,
         "Ground level": "5I8",
         "Ionization energies": [
@@ -4083,7 +4057,6 @@
         "X": 1.24,
         "Youngs modulus": "70 GPa",
         "Metallic radius": 1.756,
-        "iupac_ordering": 36,
         "IUPAC ordering": 36,
         "Ground level": "3H6",
         "Ionization energies": [
@@ -4200,7 +4173,6 @@
         "X": 1.3,
         "Youngs modulus": "no data GPa",
         "Metallic radius": 1.86,
-        "iupac_ordering": 22,
         "IUPAC ordering": 22,
         "Ground level": "4I°15/2",
         "Ionization energies": [
@@ -4432,7 +4404,6 @@
         "X": 1.2,
         "Youngs modulus": "18 GPa",
         "Metallic radius": 2.041,
-        "iupac_ordering": 41,
         "IUPAC ordering": 41,
         "Ground level": "8S°7/2",
         "Ionization energies": [
@@ -4593,7 +4564,6 @@
             "F-19": -94.2
         },
         "Metallic radius": "no data",
-        "iupac_ordering": 102,
         "IUPAC ordering": 102,
         "Ground level": "2P°3/2",
         "Ionization energies": [
@@ -4766,7 +4736,6 @@
             "Fe-57": 160
         },
         "Metallic radius": 1.277,
-        "iupac_ordering": 64,
         "IUPAC ordering": 64,
         "Ground level": "5D4",
         "Ionization energies": [
@@ -4841,7 +4810,6 @@
         "X": 1.3,
         "Youngs modulus": "no data GPa",
         "Metallic radius": "no data",
-        "iupac_ordering": 21,
         "IUPAC ordering": 21,
         "Ground level": "3H6",
         "Ionization energies": [
@@ -5019,7 +4987,6 @@
         "X": 0.7,
         "Youngs modulus": "no data GPa",
         "Metallic radius": "no data",
-        "iupac_ordering": 6,
         "IUPAC ordering": 6,
         "Ground level": "2S1/2",
         "Ionization energies": [
@@ -5194,7 +5161,6 @@
         "X": 1.81,
         "Youngs modulus": "no data GPa",
         "Metallic radius": 1.35,
-        "iupac_ordering": 79,
         "IUPAC ordering": 79,
         "Ground level": "2P°1/2",
         "Ionization energies": [
@@ -5324,7 +5290,6 @@
         "X": 1.2,
         "Youngs modulus": "55 GPa",
         "Metallic radius": 1.802,
-        "iupac_ordering": 40,
         "IUPAC ordering": 40,
         "Ground level": "9D°2",
         "Ionization energies": [
@@ -5486,7 +5451,6 @@
         "X": 2.01,
         "Youngs modulus": "no data GPa",
         "Metallic radius": 1.39,
-        "iupac_ordering": 84,
         "IUPAC ordering": 84,
         "Ground level": "3P0",
         "Ionization energies": [
@@ -5596,7 +5560,6 @@
             "H-2": 2.86
         },
         "Metallic radius": "no data",
-        "iupac_ordering": 92,
         "IUPAC ordering": 92,
         "Ground level": "2S1/2",
         "Ionization energies": [
@@ -5641,7 +5604,6 @@
         "Vickers hardness": "no data MN m<sup>-2</sup>",
         "Youngs modulus": "no data GPa",
         "Metallic radius": "no data",
-        "iupac_ordering": 5,
         "IUPAC ordering": 5,
         "Ground level": "1S0",
         "Ionization energies": [
@@ -5742,7 +5704,6 @@
         "X": 1.3,
         "Youngs modulus": "78 GPa",
         "Metallic radius": 1.58,
-        "iupac_ordering": 50,
         "IUPAC ordering": 50,
         "Ground level": "3F2",
         "Ionization energies": [
@@ -5934,7 +5895,6 @@
             "Hg-201": 387.6
         },
         "Metallic radius": 1.51,
-        "iupac_ordering": 74,
         "IUPAC ordering": 74,
         "Ground level": "1S0",
         "Ionization energies": [
@@ -6110,7 +6070,6 @@
         "X": 1.23,
         "Youngs modulus": "65 GPa",
         "Metallic radius": 1.765,
-        "iupac_ordering": 37,
         "IUPAC ordering": 37,
         "Ground level": "4I°15/2",
         "Ionization energies": [
@@ -6300,7 +6259,6 @@
             "I-129": -604.1
         },
         "Metallic radius": "no data",
-        "iupac_ordering": 99,
         "IUPAC ordering": 99,
         "Ground level": "2P°3/2",
         "Ionization energies": [
@@ -6449,7 +6407,6 @@
             "In-115": 770.8
         },
         "Metallic radius": 1.67,
-        "iupac_ordering": 78,
         "IUPAC ordering": 78,
         "Ground level": "2P°1/2",
         "Ionization energies": [
@@ -6606,7 +6563,6 @@
         "X": 2.2,
         "Youngs modulus": "528 GPa",
         "Metallic radius": 1.357,
-        "iupac_ordering": 65,
         "IUPAC ordering": 65,
         "Ground level": "4F9/2",
         "Ionization energies": [
@@ -6796,7 +6752,6 @@
             "K-41": 71.1
         },
         "Metallic radius": 2.381,
-        "iupac_ordering": 9,
         "IUPAC ordering": 9,
         "Ground level": "2S1/2",
         "Ionization energies": [
@@ -6867,7 +6822,6 @@
         "X": 3,
         "Youngs modulus": "no data GPa",
         "Metallic radius": "no data",
-        "iupac_ordering": 2,
         "IUPAC ordering": 2,
         "Ground level": "1S0",
         "Ionization energies": [
@@ -7016,7 +6970,6 @@
             "La-139": 200.6
         },
         "Metallic radius": 1.877,
-        "iupac_ordering": 47,
         "IUPAC ordering": 47,
         "Ground level": "2D3/2",
         "Ionization energies": [
@@ -7156,7 +7109,6 @@
             "Li-7": -40.1
         },
         "Metallic radius": 1.52,
-        "iupac_ordering": 11,
         "IUPAC ordering": 11,
         "Ground level": "2S1/2",
         "Ionization energies": [
@@ -7207,7 +7159,6 @@
         "X": 1.3,
         "Youngs modulus": "no data GPa",
         "Metallic radius": "no data",
-        "iupac_ordering": 18,
         "IUPAC ordering": 18,
         "Ground level": "2P°1/2",
         "Ionization energies": [
@@ -7401,7 +7352,6 @@
         "X": 1.27,
         "Youngs modulus": "69 GPa",
         "Metallic radius": 1.735,
-        "iupac_ordering": 33,
         "IUPAC ordering": 33,
         "Ground level": "2D3/2",
         "Ionization energies": [
@@ -7521,7 +7471,6 @@
         "X": 1.3,
         "Youngs modulus": "no data GPa",
         "Metallic radius": "no data",
-        "iupac_ordering": 20,
         "IUPAC ordering": 20,
         "Ground level": "2F°7/2",
         "Ionization energies": [
@@ -7713,7 +7662,6 @@
             "Mg-25": 199.4
         },
         "Metallic radius": 1.6,
-        "iupac_ordering": 16,
         "IUPAC ordering": 16,
         "Ground level": "1S0",
         "Ionization energies": [
@@ -7924,7 +7872,6 @@
             "Mn-55": 330.1
         },
         "Metallic radius": 1.292,
-        "iupac_ordering": 61,
         "IUPAC ordering": 61,
         "Ground level": "6S5/2",
         "Ionization energies": [
@@ -8089,7 +8036,6 @@
         "X": 2.16,
         "Youngs modulus": "329 GPa",
         "Metallic radius": 1.402,
-        "iupac_ordering": 57,
         "IUPAC ordering": 57,
         "Ground level": "7S3",
         "Ionization energies": [
@@ -8242,7 +8188,6 @@
             "N-14": 20.44
         },
         "Metallic radius": "no data",
-        "iupac_ordering": 91,
         "IUPAC ordering": 91,
         "Ground level": "4S°3/2",
         "Ionization energies": [
@@ -8358,7 +8303,6 @@
             "Na-23": 104.1
         },
         "Metallic radius": 1.86,
-        "iupac_ordering": 10,
         "IUPAC ordering": 10,
         "Ground level": "2S1/2",
         "Ionization energies": [
@@ -8493,7 +8437,6 @@
         "X": 1.6,
         "Youngs modulus": "105 GPa",
         "Metallic radius": 1.473,
-        "iupac_ordering": 54,
         "IUPAC ordering": 54,
         "Ground level": "6D1/2",
         "Ionization energies": [
@@ -8647,7 +8590,6 @@
         "X": 1.14,
         "Youngs modulus": "41 GPa",
         "Metallic radius": 1.821,
-        "iupac_ordering": 44,
         "IUPAC ordering": 44,
         "Ground level": "5I4",
         "Ionization energies": [
@@ -8756,7 +8698,6 @@
             "Ne-21": 101.55
         },
         "Metallic radius": "no data",
-        "iupac_ordering": 4,
         "IUPAC ordering": 4,
         "Ground level": "1S0",
         "Ionization energies": [
@@ -8895,7 +8836,6 @@
             "Ni-61": 162.15
         },
         "Metallic radius": 1.246,
-        "iupac_ordering": 70,
         "IUPAC ordering": 70,
         "Ground level": "3F4",
         "Ionization energies": [
@@ -8982,7 +8922,6 @@
         "X": 1.3,
         "Youngs modulus": "no data GPa",
         "Metallic radius": "no data",
-        "iupac_ordering": 19,
         "IUPAC ordering": 19,
         "Ground level": "1S0",
         "Ionization energies": [
@@ -9200,7 +9139,6 @@
         "X": 1.36,
         "Youngs modulus": "no data GPa",
         "Metallic radius": 1.503,
-        "iupac_ordering": 28,
         "IUPAC ordering": 28,
         "Ground level": "6L11/2",
         "Ionization energies": [
@@ -9391,7 +9329,6 @@
             "O-17": -25.58
         },
         "Metallic radius": "no data",
-        "iupac_ordering": 97,
         "IUPAC ordering": 97,
         "Ground level": "3P2",
         "Ionization energies": [
@@ -9526,7 +9463,6 @@
         "X": 2.2,
         "Youngs modulus": "no data GPa",
         "Metallic radius": 1.352,
-        "iupac_ordering": 62,
         "IUPAC ordering": 62,
         "Ground level": "5D4",
         "Ionization energies": [
@@ -9709,7 +9645,6 @@
         "X": 2.19,
         "Youngs modulus": "no data GPa",
         "Metallic radius": "no data",
-        "iupac_ordering": 90,
         "IUPAC ordering": 90,
         "Ground level": "4S°3/2",
         "Ionization energies": [
@@ -9842,7 +9777,6 @@
         "X": 1.5,
         "Youngs modulus": "no data GPa",
         "Metallic radius": 1.642,
-        "iupac_ordering": 30,
         "IUPAC ordering": 30,
         "Ground level": "4K11/2",
         "Ionization energies": [
@@ -10087,7 +10021,6 @@
         "X": 2.33,
         "Youngs modulus": "16 GPa",
         "Metallic radius": 1.75,
-        "iupac_ordering": 82,
         "IUPAC ordering": 82,
         "Ground level": "1/2,1/2)0",
         "Ionization energies": [
@@ -10280,7 +10213,6 @@
         "X": 2.2,
         "Youngs modulus": "121 GPa",
         "Metallic radius": 1.376,
-        "iupac_ordering": 69,
         "IUPAC ordering": 69,
         "Ground level": "1S0",
         "Ionization energies": [
@@ -10413,7 +10345,6 @@
         "X": 1.13,
         "Youngs modulus": "46 GPa",
         "Metallic radius": 1.811,
-        "iupac_ordering": 43,
         "IUPAC ordering": 43,
         "Ground level": "6H°5/2",
         "Ionization energies": [
@@ -10573,7 +10504,6 @@
         "X": 2,
         "Youngs modulus": "no data GPa",
         "Metallic radius": 1.53,
-        "iupac_ordering": 93,
         "IUPAC ordering": 93,
         "Ground level": "3P2",
         "Ionization energies": [
@@ -10765,7 +10695,6 @@
         "X": 1.13,
         "Youngs modulus": "37 GPa",
         "Metallic radius": 1.828,
-        "iupac_ordering": 45,
         "IUPAC ordering": 45,
         "Ground level": "4I°9/2",
         "Ionization energies": [
@@ -10930,7 +10859,6 @@
         "X": 2.28,
         "Youngs modulus": "168 GPa",
         "Metallic radius": 1.387,
-        "iupac_ordering": 68,
         "IUPAC ordering": 68,
         "Ground level": "3D3",
         "Ionization energies": [
@@ -11106,7 +11034,6 @@
         "X": 1.28,
         "Youngs modulus": "96 GPa",
         "Metallic radius": 1.523,
-        "iupac_ordering": 27,
         "IUPAC ordering": 27,
         "Ground level": "7F0",
         "Ionization energies": [
@@ -11287,7 +11214,6 @@
             "Ra-223": 1210.3
         },
         "Metallic radius": 2.293,
-        "iupac_ordering": 12,
         "IUPAC ordering": 12,
         "Ground level": "1S0",
         "Ionization energies": [
@@ -11491,7 +11417,6 @@
         "X": 0.82,
         "Youngs modulus": "2.4 GPa",
         "Metallic radius": 2.537,
-        "iupac_ordering": 8,
         "IUPAC ordering": 8,
         "Ground level": "2S1/2",
         "Ionization energies": [
@@ -11652,7 +11577,6 @@
         "X": 1.9,
         "Youngs modulus": "463 GPa",
         "Metallic radius": 1.375,
-        "iupac_ordering": 59,
         "IUPAC ordering": 59,
         "Ground level": "6S5/2",
         "Ionization energies": [
@@ -11827,7 +11751,6 @@
         "X": 2.28,
         "Youngs modulus": "275 GPa",
         "Metallic radius": 1.345,
-        "iupac_ordering": 66,
         "IUPAC ordering": 66,
         "Ground level": "4F9/2",
         "Ionization energies": [
@@ -11931,7 +11854,6 @@
         "X": 2.2,
         "Youngs modulus": "no data GPa",
         "Metallic radius": "no data",
-        "iupac_ordering": 0,
         "IUPAC ordering": 0,
         "Ground level": "1S0",
         "Ionization energies": [
@@ -12142,7 +12064,6 @@
         "X": 2.2,
         "Youngs modulus": "447 GPa",
         "Metallic radius": 1.339,
-        "iupac_ordering": 63,
         "IUPAC ordering": 63,
         "Ground level": "5F5",
         "Ionization energies": [
@@ -12301,7 +12222,6 @@
             "S-35": 47.1
         },
         "Metallic radius": "no data",
-        "iupac_ordering": 96,
         "IUPAC ordering": 96,
         "Ground level": "3P2",
         "Ionization energies": [
@@ -12428,7 +12348,6 @@
             "Sb-123": -692.14
         },
         "Metallic radius": 1.61,
-        "iupac_ordering": 88,
         "IUPAC ordering": 88,
         "Ground level": "4S°3/2",
         "Ionization energies": [
@@ -12563,7 +12482,6 @@
             "Sc-45": -220.2
         },
         "Metallic radius": 1.641,
-        "iupac_ordering": 49,
         "IUPAC ordering": 49,
         "Ground level": "2D3/2",
         "Ionization energies": [
@@ -12693,7 +12611,6 @@
         "X": 2.55,
         "Youngs modulus": "10 GPa",
         "Metallic radius": "no data",
-        "iupac_ordering": 95,
         "IUPAC ordering": 95,
         "Ground level": "3P2",
         "Ionization energies": [
@@ -12813,7 +12730,6 @@
         "X": 1.9,
         "Youngs modulus": "47 GPa",
         "Metallic radius": "no data",
-        "iupac_ordering": 85,
         "IUPAC ordering": 85,
         "Ground level": "3P0",
         "Ionization energies": [
@@ -12952,7 +12868,6 @@
         "X": 1.17,
         "Youngs modulus": "50 GPa",
         "Metallic radius": 1.804,
-        "iupac_ordering": 42,
         "IUPAC ordering": 42,
         "Ground level": "7F0",
         "Ionization energies": [
@@ -13125,7 +13040,6 @@
             "Sn-119": -132.1
         },
         "Metallic radius": 1.58,
-        "iupac_ordering": 83,
         "IUPAC ordering": 83,
         "Ground level": "3P0",
         "Ionization energies": [
@@ -13282,7 +13196,6 @@
             "Sr-87": 305.2
         },
         "Metallic radius": 2.151,
-        "iupac_ordering": 14,
         "IUPAC ordering": 14,
         "Ground level": "1S0",
         "Ionization energies": [
@@ -13435,7 +13348,6 @@
         "X": 1.5,
         "Youngs modulus": "186 GPa",
         "Metallic radius": 1.47,
-        "iupac_ordering": 53,
         "IUPAC ordering": 53,
         "Ground level": "4F3/2",
         "Ionization energies": [
@@ -13622,7 +13534,6 @@
         "X": 1.1,
         "Youngs modulus": "56 GPa",
         "Metallic radius": 1.781,
-        "iupac_ordering": 39,
         "IUPAC ordering": 39,
         "Ground level": "6H°15/2",
         "Ionization energies": [
@@ -13793,7 +13704,6 @@
         "X": 1.9,
         "Youngs modulus": "no data GPa",
         "Metallic radius": 1.363,
-        "iupac_ordering": 60,
         "IUPAC ordering": 60,
         "Ground level": "6S5/2",
         "Ionization energies": [
@@ -13961,7 +13871,6 @@
         "X": 2.1,
         "Youngs modulus": "43 GPa",
         "Metallic radius": "no data",
-        "iupac_ordering": 94,
         "IUPAC ordering": 94,
         "Ground level": "3P2",
         "Ionization energies": [
@@ -14127,7 +14036,6 @@
         "X": 1.3,
         "Youngs modulus": "79 GPa",
         "Metallic radius": 1.798,
-        "iupac_ordering": 31,
         "IUPAC ordering": 31,
         "Ground level": "3F2",
         "Ionization energies": [
@@ -14334,7 +14242,6 @@
             "Ti-49": 247.11
         },
         "Metallic radius": 1.462,
-        "iupac_ordering": 52,
         "IUPAC ordering": 52,
         "Ground level": "3F2",
         "Ionization energies": [
@@ -14473,7 +14380,6 @@
         "X": 1.62,
         "Youngs modulus": "8 GPa",
         "Metallic radius": 1.7,
-        "iupac_ordering": 77,
         "IUPAC ordering": 77,
         "Ground level": "2P°1/2",
         "Ionization energies": [
@@ -14660,7 +14566,6 @@
         "X": 1.25,
         "Youngs modulus": "74 GPa",
         "Metallic radius": 1.747,
-        "iupac_ordering": 35,
         "IUPAC ordering": 35,
         "Ground level": "2F°7/2",
         "Ionization energies": [
@@ -14899,7 +14804,6 @@
         "X": 1.38,
         "Youngs modulus": "208 GPa",
         "Metallic radius": 1.542,
-        "iupac_ordering": 29,
         "IUPAC ordering": 29,
         "Ground level": "5L°6",
         "Ionization energies": [
@@ -15129,7 +15033,6 @@
             "V-51": -52.1
         },
         "Metallic radius": 1.347,
-        "iupac_ordering": 55,
         "IUPAC ordering": 55,
         "Ground level": "4F3/2",
         "Ionization energies": [
@@ -15274,7 +15177,6 @@
         "X": 2.36,
         "Youngs modulus": "411 GPa",
         "Metallic radius": 1.41,
-        "iupac_ordering": 56,
         "IUPAC ordering": 56,
         "Ground level": "5D0",
         "Ionization energies": [
@@ -15422,7 +15324,6 @@
         "X": 2.6,
         "Youngs modulus": "no data GPa",
         "Metallic radius": "no data",
-        "iupac_ordering": 1,
         "IUPAC ordering": 1,
         "Ground level": "1S0",
         "Ionization energies": [
@@ -15571,7 +15472,6 @@
         "X": 1.22,
         "Youngs modulus": "64 GPa",
         "Metallic radius": 1.8,
-        "iupac_ordering": 48,
         "IUPAC ordering": 48,
         "Ground level": "2D3/2",
         "Ionization energies": [
@@ -15729,7 +15629,6 @@
         "X": 1.1,
         "Youngs modulus": "24 GPa",
         "Metallic radius": 1.94,
-        "iupac_ordering": 34,
         "IUPAC ordering": 34,
         "Ground level": "1S0",
         "Ionization energies": [
@@ -15893,7 +15792,6 @@
             "Zn-67": 150.15
         },
         "Metallic radius": 1.34,
-        "iupac_ordering": 76,
         "IUPAC ordering": 76,
         "Ground level": "1S0",
         "Ionization energies": [
@@ -16033,7 +15931,6 @@
         "X": 1.33,
         "Youngs modulus": "68 GPa",
         "Metallic radius": 1.602,
-        "iupac_ordering": 51,
         "IUPAC ordering": 51,
         "Ground level": "3F2",
         "Ionization energies": [


### PR DESCRIPTION
## Summary

- Drop duplicate `iupac_ordering` entries in `core.periodic_table.json`

If I understand correctly, the `Element.iupac_ordering` should access the other "IUPAC ordering" instead:

https://github.com/materialsproject/pymatgen/blob/4c7892f5c9dcc51a1389b3ad2ada77632989a13e/src/pymatgen/core/periodic_table.py#L843-L850
