### PR TITLE
`core.Lattice` cast `pbc` to `bool` (possibly `np.bool_`)

### DIFF
--- a/src/pymatgen/core/lattice.py
+++ b/src/pymatgen/core/lattice.py
@@ -11,7 +11,7 @@ import warnings
 from collections import defaultdict
 from fractions import Fraction
 from functools import reduce
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 import numpy as np
 from monty.dev import deprecated
@@ -183,7 +183,7 @@ class Lattice(MSONable):
         if len(pbc) != 3 or any(item not in {True, False} for item in pbc):
             raise ValueError(f"pbc must be a tuple of three True/False values, got {pbc}")
 
-        self._pbc = cast("tuple[bool, bool, bool]", tuple(pbc))
+        self._pbc = tuple(bool(item) for item in pbc)
 
     @property
     def is_3d_periodic(self) -> bool:

--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -964,7 +964,11 @@ Direct
         assert isinstance(atoms, Atoms)
         assert len(atoms) == len(self.struct)
 
-        assert AseAtomsAdaptor.get_structure(atoms) == self.struct
+        structure = AseAtomsAdaptor.get_structure(atoms)
+        assert structure == self.struct
+
+        # Ensure PBC is `bool` type (not `np.bool_`) and JSON serializable
+        assert "pymatgen.core.structure" in structure.to(fmt="json")
 
         assert IStructure.from_ase_atoms(atoms) == self.struct
         assert type(IStructure.from_ase_atoms(atoms)) is IStructure


### PR DESCRIPTION
### Summary

- `core.Lattice` cast `pbc` to `bool` (possibly `np.bool_`), to close #4339