### PR TITLE
Fix circular import of `SymmOp`

### DIFF
--- a/src/pymatgen/symmetry/groups.py
+++ b/src/pymatgen/symmetry/groups.py
@@ -18,7 +18,6 @@ import numpy as np
 from monty.design_patterns import cached_class
 from monty.serialization import loadfn
 
-from pymatgen.core.operations import SymmOp
 from pymatgen.util.string import Stringify
 
 if TYPE_CHECKING:

--- a/tests/symmetry/test_groups.py
+++ b/tests/symmetry/test_groups.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import subprocess
+import sys
+
 import numpy as np
 import pytest
 from pytest import approx
@@ -285,3 +288,7 @@ class TestSpaceGroup:
                 match=f"International number must be between 1 and 230, got {num}",
             ):
                 SpaceGroup.from_int_number(num)
+
+    def test_import(self):
+        # Ensure no circular import
+        subprocess.run([sys.executable, "-c", "from pymatgen.symmetry.groups import SpaceGroup"], check=True)


### PR DESCRIPTION

- Fix circular import of `SymmOp`, to close #4309

Looks like the import of `SymmOp` was added in #4177, @tpurcell90 do we have a reason to import `SymmOp` at runtime? https://github.com/materialsproject/pymatgen/blob/482ffd01312e7607c58bdd3ed285bf8a45e405bf/src/pymatgen/symmetry/groups.py#L24-L33