### PR TITLE
Avoid repeated `Incar.get()` calls which slow down vasprun parsing by ~20-50%

### DIFF
--- a/src/pymatgen/io/vasp/outputs.py
+++ b/src/pymatgen/io/vasp/outputs.py
@@ -393,6 +393,7 @@ class Vasprun(MSONable):
         md_data: list[dict] = []
         parsed_header: bool = False
         in_kpoints_opt: bool = False
+        ml_run: bool = False
         try:
             # When parsing XML, start tags tell us when we have entered a block
             # while end tags are when we have actually read the data.
@@ -421,6 +422,7 @@ class Vasprun(MSONable):
                             self.generator = self._parse_params(elem)
                         elif tag == "incar":
                             self.incar = self._parse_params(elem)
+                            ml_run = self.incar.get("ML_LMLFF")
                         elif tag == "kpoints":
                             if not hasattr(self, "kpoints"):
                                 (
@@ -542,7 +544,7 @@ class Vasprun(MSONable):
                         self.normalmode_eigenvals = np.array(eigenvalues)
                         self.normalmode_eigenvecs = np.array(phonon_eigenvectors)
 
-                    elif self.incar.get("ML_LMLFF"):
+                    elif ml_run:
                         if tag == "structure" and elem.attrib.get("name") is None:
                             md_data.append({})
                             md_data[-1]["structure"] = self._parse_structure(elem)


### PR DESCRIPTION
From profiling my `Vasprun` initialisations, I found that one of the main contributions to runtime was repeated `Incar.get()` calls:
https://github.com/materialsproject/pymatgen/blob/31aa2148f85fcd3f01461e269a06b0186f82a22b/src/pymatgen/io/vasp/inputs.py#L847

This can be slow when called many times because of the `UserDict.get()` implementation from `collections.abc` and formatting code. Because `incar.get("ML_LMFF")` was being used in the `Vasprun` parsing loop, this method was called e.g. 1e4 - 1e6+ times in my vasprun parsing. Changing this so that `incar.get("ML_LMFF")` is only called once to determine if the vasp run is an ML run, means `incar.get` only gets called ~20 times and reduces the vasprun parsing time by ~20-50% (depending on choices of `parse_dos` and `parse_projected_eigen`).