### PR TITLE
Speed up `Vasprun` parsing some more

### DIFF
--- a/src/pymatgen/io/vasp/outputs.py
+++ b/src/pymatgen/io/vasp/outputs.py
@@ -138,8 +138,8 @@ def _parse_vasp_array(elem) -> list[list[float]] | NDArray[float]:
         return [[i == "T" for i in v.text.split()] for v in elem]
 
     try:
-        # numerical data, try parse with numpy fromstring for efficiency:
-        return np.loadtxt([e.text for e in elem])
+        # numerical data, try parse with numpy loadtxt for efficiency:
+        return np.loadtxt([e.text for e in elem], ndmin=2)
     except ValueError:  # unexpectedly couldn't re-shape to grid
         return [list(map(_vasprun_float, e.text.split())) for e in elem]
 

--- a/src/pymatgen/io/vasp/outputs.py
+++ b/src/pymatgen/io/vasp/outputs.py
@@ -139,12 +139,7 @@ def _parse_vasp_array(elem) -> list[list[float]] | NDArray[float]:
 
     try:
         # numerical data, try parse with numpy fromstring for efficiency:
-        lines = [e.text for e in elem]
-        float_array = np.fromstring("\n".join(lines), sep=" ")
-        # reshape into grid for efficient parsing
-        nrow = len(lines)
-        ncol = len(elem[0].text.split())
-        return float_array.reshape(nrow, ncol)
+        return np.loadtxt([e.text for e in elem])
     except ValueError:  # unexpectedly couldn't re-shape to grid
         return [list(map(_vasprun_float, e.text.split())) for e in elem]
 
@@ -1530,7 +1525,7 @@ class Vasprun(MSONable):
             if name == "kpointlist":
                 actual_kpoints = cast("list[Tuple3Floats]", list(map(tuple, _parse_vasp_array(va))))
             elif name == "weights":
-                weights = [i[0] for i in _parse_vasp_array(va)]
+                weights = list(_parse_vasp_array(va))
         elem.clear()
 
         if kpoint.style == Kpoints.supported_modes.Reciprocal:

--- a/src/pymatgen/io/vasp/outputs.py
+++ b/src/pymatgen/io/vasp/outputs.py
@@ -159,9 +159,7 @@ def _vasprun_float(flt: float | str) -> float:
         return float(flt)
 
     except ValueError:
-        flt = cast("str", flt)
-        _flt: str = flt.strip()
-        if _flt == "*" * len(_flt):
+        if "*" in str(flt):
             warnings.warn(
                 "Float overflow (*******) encountered in vasprun",
                 stacklevel=2,


### PR DESCRIPTION
Me again.
From further profiling and playing around, I found I could speed up `_parse_vasp_array` (one of the main bottlenecks when using `parse_dos = True` (default), `parse_eigen = True` (default) and/or `parse_projected_eigen = True` (False by default)), using `numpy`'s parse from string function.
e.g. parsing a SOC defect supercell vasprun via [`doped`](https://doped.readthedocs.io/en/latest/) with these updates (with `parse_projected_eigen=True` to get eigenvalues/magnetisation) decreases parsing time from ~8.5s to ~4.8s.

All changes here should be covered by tests already in the codebase.