### PR TITLE
fix(MVLSlabSet): convert DIPOL vector to pure Python list before writing INCAR

### DIFF
--- a/src/pymatgen/io/vasp/sets.py
+++ b/src/pymatgen/io/vasp/sets.py
@@ -2447,7 +2447,7 @@ class MVLSlabSet(VaspInputSet):
                 updates |= {"AMIN": 0.01, "AMIX": 0.2, "BMIX": 0.001}
             if self.auto_dipole and self.structure is not None:
                 weights = [struct.species.weight for struct in self.structure]
-                center_of_mass = np.average(self.structure.frac_coords, weights=weights, axis=0)
+                center_of_mass = np.average(self.structure.frac_coords, weights=weights, axis=0).tolist()
                 updates |= {"IDIPOL": 3, "LDIPOL": True, "DIPOL": center_of_mass}
         return updates
 

--- a/tests/io/vasp/test_sets.py
+++ b/tests/io/vasp/test_sets.py
@@ -1483,6 +1483,10 @@ class TestMVLSlabSet(MatSciTest):
         assert dipole_incar["LDIPOL"]
         assert_allclose(dipole_incar["DIPOL"], [0.2323, 0.2323, 0.2165], atol=1e-4)
         assert dipole_incar["IDIPOL"] == 3
+        # DIPOL must be a plain Python list of floats
+        assert isinstance(dipole_incar["DIPOL"], list)
+        for comp in dipole_incar["DIPOL"]:
+            assert isinstance(comp, float)
 
     def test_kpoints(self):
         kpoints_slab = self.d_slab["KPOINTS"].kpts[0]


### PR DESCRIPTION
## Summary

When `auto_dipole=True`, `MVLSlabSet` was passing a NumPy array into the INCAR’s DIPOL tag, causing pymatgen to serialize it with brackets (e.g. `DIPOL = [0.1 0.2 0.3]`). VASP expects three space‑separated floats without any brackets: https://www.vasp.at/wiki/index.php/DIPOL. 
This PR converts the computed center‑of‑mass array into a plain Python `list[float]` (via `.tolist()`), ensuring the INCAR writes
`DIPOL = 0.1 0.2 0.3`
instead of
`DIPOL = [0.1 0.2 0.3]` 
which errors out with the recent VASP 6.4. 

Major changes:

- fix 1: In `MVLSlabSet.incar_updates`, replace `center_of_mass` (a NumPy array) with a pure python list = `com.tolist()` 

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [x] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
