### PR TITLE
Ensure `actual_kpoints_weights` is `list[float]` and add test

### DIFF
--- a/src/pymatgen/io/vasp/outputs.py
+++ b/src/pymatgen/io/vasp/outputs.py
@@ -1525,7 +1525,10 @@ class Vasprun(MSONable):
             if name == "kpointlist":
                 actual_kpoints = cast("list[Tuple3Floats]", list(map(tuple, _parse_vasp_array(va))))
             elif name == "weights":
-                weights = list(_parse_vasp_array(va))
+                weights_array = _parse_vasp_array(va)
+                if isinstance(weights_array, np.ndarray):
+                    weights_array = weights_array.flatten()
+                weights = list(weights_array)
         elem.clear()
 
         if kpoint.style == Kpoints.supported_modes.Reciprocal:

--- a/tests/io/vasp/test_outputs.py
+++ b/tests/io/vasp/test_outputs.py
@@ -301,6 +301,7 @@ class TestVasprun(PymatgenTest):
         assert isinstance(vasp_run.kpoints, Kpoints), f"{vasp_run.kpoints=}"
         assert isinstance(vasp_run.actual_kpoints, list), f"{vasp_run.actual_kpoints=}"
         assert isinstance(vasp_run.actual_kpoints_weights, list), f"{vasp_run.actual_kpoints_weights=}"
+        assert isinstance(vasp_run.actual_kpoints_weights[0], float), f"{vasp_run.actual_kpoints_weights[0]=}"
         for atom_doses in vasp_run.pdos:
             for orbital_dos in atom_doses:
                 assert isinstance(orbital_dos, Orbital), f"{orbital_dos=}"


### PR DESCRIPTION
Just a minor fix; after #4360 the format of `actual_kpoints_weights` was changed from `list[float]` to `list[np.ndarray[float]]` (where these were `np.ndarray[float]` with a single value). Minor thing but this changes the format back to what it was before, and adds a quick test for this.